### PR TITLE
docs(superpowers): mark M4/M5a/M5b/M6 plans complete

### DIFF
--- a/docs/superpowers/plans/2026-04-09-products-m4-openfga-authz.md
+++ b/docs/superpowers/plans/2026-04-09-products-m4-openfga-authz.md
@@ -12,7 +12,7 @@
 
 ## Status
 
-> **Pending.** All tasks open.
+**Status: ✅ COMPLETE** — all tasks merged to main.
 
 ---
 
@@ -122,7 +122,7 @@ The integration test against real FGA introduces a new opt-in env var, NOT a new
 
 **Scope:** Read-only Client interface (`Check`, `CheckMembership`, `GetRole`), real impl backed by `github.com/openfga/go-sdk`, `Config`, `New(cfg)`, `DiscoverStoreID(ctx, apiURL, name)`. Mirror platform-api's shape but trim out every Write* method.
 
-- [ ] **Step 1: Add the dependency**
+- [x] **Step 1: Add the dependency**
 
 ```
 cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go get github.com/openfga/go-sdk && go mod tidy
@@ -134,7 +134,7 @@ grep "openfga/go-sdk" services/platform-api/go.mod
 ```
 If platform-api pins a version, use the same: `go get github.com/openfga/go-sdk@<version>`.
 
-- [ ] **Step 2: Write the failing unit test**
+- [x] **Step 2: Write the failing unit test**
 
 `services/marketplace-api/internal/authz/client_test.go`:
 
@@ -169,13 +169,13 @@ func TestRole_Priority(t *testing.T) {
 }
 ```
 
-- [ ] **Step 3: Run test, expect compile failure**
+- [x] **Step 3: Run test, expect compile failure**
 
 ```
 go test ./internal/authz/... -v
 ```
 
-- [ ] **Step 4: Implement `client.go`**
+- [x] **Step 4: Implement `client.go`**
 
 ```go
 // Package authz is marketplace-api's read-only OpenFGA client for tenant-
@@ -341,20 +341,20 @@ func (c *fgaClient) GetRole(ctx context.Context, userID, tenantID string) (Role,
 }
 ```
 
-- [ ] **Step 5: Run tests and confirm pass**
+- [x] **Step 5: Run tests and confirm pass**
 
 ```
 cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go build ./... && go vet ./internal/authz/... && go test ./internal/authz/... -v
 ```
 
-- [ ] **Step 6: Confirm `go.work` untouched**
+- [x] **Step 6: Confirm `go.work` untouched**
 
 ```
 cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly && git diff go.work
 ```
 Empty.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```
 git add services/marketplace-api/internal/authz services/marketplace-api/go.mod services/marketplace-api/go.sum
@@ -373,7 +373,7 @@ git commit -m "feat(marketplace-api): add read-only authz Client interface + rea
 
 Key semantic: `CheckMembership` (i.e. `Check(..., "member", ...)`) must return true if the user has ANY role on the tenant — mirroring the FGA model's derived `member` relation. `Check("admin", ...)` must return true for users granted `owner` (since `admin` is `[user] or owner` in the model). The fake implements these implications explicitly.
 
-- [ ] **Step 1: Write the failing tests** (`fake_test.go`):
+- [x] **Step 1: Write the failing tests** (`fake_test.go`):
 
 Cases:
 1. Grant owner → Check(owner) true, Check(admin) true (implied), Check(staff) true (implied), CheckMembership true.
@@ -384,7 +384,7 @@ Cases:
 6. GetRole returns the highest granted role (grant staff + admin → returns admin).
 7. Revoke removes the grant and subsequent Check returns false.
 
-- [ ] **Step 2: Implement `fake.go`**
+- [x] **Step 2: Implement `fake.go`**
 
 ```go
 package authz
@@ -471,13 +471,13 @@ func (f *FakeClient) GetRole(_ context.Context, userID, tenantID string) (Role, 
 }
 ```
 
-- [ ] **Step 3: Run tests, confirm pass**
+- [x] **Step 3: Run tests, confirm pass**
 
 ```
 cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go test ./internal/authz/... -race -v
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```
 git add services/marketplace-api/internal/authz/fake.go services/marketplace-api/internal/authz/fake_test.go
@@ -502,7 +502,7 @@ Behavior:
 5. On `false` → respond 404 (no existence leak).
 6. On `true` → `c.Next()`.
 
-- [ ] **Step 1: Write the failing test** (`middleware_test.go`):
+- [x] **Step 1: Write the failing test** (`middleware_test.go`):
 
 Cases (all using FakeClient + httptest):
 
@@ -514,7 +514,7 @@ Cases (all using FakeClient + httptest):
 6. `TestMiddleware_RequireRoleAdmin_GrantedStaff_Returns404` — fake grants staff, middleware requires admin → 404.
 7. `TestMiddleware_RequireRoleStaff_GrantedAdmin_Allowed` — fake grants admin, middleware requires staff → allowed (because admin implies staff via the fake's role-implication semantics).
 
-- [ ] **Step 2: Implement `middleware.go`**
+- [x] **Step 2: Implement `middleware.go`**
 
 ```go
 package authz
@@ -594,13 +594,13 @@ func respondInternal(c *gin.Context) {
 var _ = context.Background
 ```
 
-- [ ] **Step 3: Run tests, confirm all 7 cases pass**
+- [x] **Step 3: Run tests, confirm all 7 cases pass**
 
 ```
 cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go test ./internal/authz/... -race -v
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```
 git add services/marketplace-api/internal/authz/middleware.go services/marketplace-api/internal/authz/middleware_test.go
@@ -628,9 +628,9 @@ The test does:
 
 Document the test's preconditions in a comment at the top of the file: "This test requires a running OpenFGA at TEST_FGA_API_URL with a store named mark8ly-platform whose authorization model includes the marketplace-api role definitions. Local devs without that infra get a clean skip."
 
-- [ ] **Step 1: Implement** (single file, ~150 lines)
-- [ ] **Step 2: Run** `cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go test -tags integration ./internal/authz/... -v` — expect skip.
-- [ ] **Step 3: Commit**
+- [x] **Step 1: Implement** (single file, ~150 lines)
+- [x] **Step 2: Run** `cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go test -tags integration ./internal/authz/... -v` — expect skip.
+- [x] **Step 3: Commit**
 
 ```
 git add services/marketplace-api/internal/authz/client_integration_test.go
@@ -647,11 +647,11 @@ git commit -m "test(marketplace-api): real-FGA integration test gated by TEST_FG
 
 **Scope:** Add a single string field to the existing `Config` struct loaded by envconfig.
 
-- [ ] **Step 1: Read the existing config.go** to see the field naming convention (envconfig uses tags like `envconfig:"MARKETPLACE_HTTP_PORT"` or similar — match the existing prefix).
-- [ ] **Step 2: Add the field** `FGAAPIURL string `envconfig:"MARKETPLACE_FGA_API_URL" required:"true"``. Make it required so misconfiguration fails fast at startup.
-- [ ] **Step 3: Update config_test.go** — set the env var in the existing test setup so the existing tests still pass.
-- [ ] **Step 4: Verify** `go test ./pkg/config/... -v`.
-- [ ] **Step 5: Commit**
+- [x] **Step 1: Read the existing config.go** to see the field naming convention (envconfig uses tags like `envconfig:"MARKETPLACE_HTTP_PORT"` or similar — match the existing prefix).
+- [x] **Step 2: Add the field** `FGAAPIURL string `envconfig:"MARKETPLACE_FGA_API_URL" required:"true"``. Make it required so misconfiguration fails fast at startup.
+- [x] **Step 3: Update config_test.go** — set the env var in the existing test setup so the existing tests still pass.
+- [x] **Step 4: Verify** `go test ./pkg/config/... -v`.
+- [x] **Step 5: Commit**
 
 ```
 git add services/marketplace-api/pkg/config
@@ -669,9 +669,9 @@ git commit -m "feat(marketplace-api): add MARKETPLACE_FGA_API_URL config var (M4
 
 For M4 there are no routes to attach the middleware to. Just construct and log. Add a comment: `// M5 will pass authzMW to the admin route registrar`.
 
-- [ ] **Step 1: Read main.go** (already familiar from M3 Task 13).
-- [ ] **Step 2: Add imports**: `"github.com/mark8ly/marketplace-api/internal/authz"`.
-- [ ] **Step 3: After `conn, err := db.Open(...)`** insert:
+- [x] **Step 1: Read main.go** (already familiar from M3 Task 13).
+- [x] **Step 2: Add imports**: `"github.com/mark8ly/marketplace-api/internal/authz"`.
+- [x] **Step 3: After `conn, err := db.Open(...)`** insert:
 
 ```go
 // OpenFGA client — read-only per spec §13.1.1.
@@ -697,8 +697,8 @@ authzMW := authz.NewMiddleware(fgaClient, log)
 _ = authzMW // M5 will pass this to the admin route registrar
 ```
 
-- [ ] **Step 4: Build + vet** `cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go build ./... && go vet ./...`.
-- [ ] **Step 5: Commit**
+- [x] **Step 4: Build + vet** `cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go build ./... && go vet ./...`.
+- [x] **Step 5: Commit**
 
 ```
 git add services/marketplace-api/cmd/marketplace-api/main.go
@@ -709,7 +709,7 @@ git commit -m "feat(marketplace-api): bootstrap FGA client + middleware in main 
 
 ### Task 7: M4 verification + PR
 
-- [ ] **Step 1: Full test run**
+- [x] **Step 1: Full test run**
 
 ```
 cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go vet ./... && go vet -tags=integration ./... && go build ./... && go test ./... -race && go test -tags integration ./... -race
@@ -717,13 +717,13 @@ cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
 
 All clean. Integration tests skip without `TEST_FGA_API_URL`.
 
-- [ ] **Step 2: Push the branch**
+- [x] **Step 2: Push the branch**
 
 ```
 git push -u origin feat/products-m4-openfga-authz
 ```
 
-- [ ] **Step 3: Open PR**
+- [x] **Step 3: Open PR**
 
 ```
 gh pr create --base main --head feat/products-m4-openfga-authz --title "feat(marketplace-api): products M4 — OpenFGA tenant-relation authz middleware" --body "$(cat <<'EOF'
@@ -755,22 +755,22 @@ EOF
 )"
 ```
 
-- [ ] **Step 4: Wait for CI, merge.**
+- [x] **Step 4: Wait for CI, merge.**
 
 ---
 
 ## Exit criteria
 
-- [ ] `go test ./internal/authz/... -race` green
-- [ ] `go vet -tags=integration ./internal/authz/...` clean
-- [ ] FakeClient implies derived roles correctly (owner→admin→staff→member)
-- [ ] Middleware returns 404 (not 403) on every deny path
-- [ ] Middleware logs at ERROR level on FGA outage and returns 500
-- [ ] `cmd/marketplace-api/main.go` discovers the store at startup and exits 1 on failure
-- [ ] `MARKETPLACE_FGA_API_URL` is a required config var (start fails without it)
-- [ ] `Client` interface exposes NO Write methods (compile-time guarantee against tuple writes from marketplace-api)
-- [ ] No changes to migrations, Helm chart, CI workflows, or `go.work`
-- [ ] PR is open and CI is green
+- [x] `go test ./internal/authz/... -race` green
+- [x] `go vet -tags=integration ./internal/authz/...` clean
+- [x] FakeClient implies derived roles correctly (owner→admin→staff→member)
+- [x] Middleware returns 404 (not 403) on every deny path
+- [x] Middleware logs at ERROR level on FGA outage and returns 500
+- [x] `cmd/marketplace-api/main.go` discovers the store at startup and exits 1 on failure
+- [x] `MARKETPLACE_FGA_API_URL` is a required config var (start fails without it)
+- [x] `Client` interface exposes NO Write methods (compile-time guarantee against tuple writes from marketplace-api)
+- [x] No changes to migrations, Helm chart, CI workflows, or `go.work`
+- [x] PR is open and CI is green
 
 ---
 

--- a/docs/superpowers/plans/2026-04-09-products-m5a-admin-products-http.md
+++ b/docs/superpowers/plans/2026-04-09-products-m5a-admin-products-http.md
@@ -12,7 +12,7 @@
 
 ## Status
 
-> **Pending.** All tasks open.
+**Status: ✅ COMPLETE** — all tasks merged to main.
 
 ---
 
@@ -195,11 +195,11 @@ Tests use `gin.New() + httptest.NewRequest + httptest.NewRecorder + router.Serve
 
 **Steps:**
 
-- [ ] **Step 1:** Write all 6 failing tests
-- [ ] **Step 2:** `cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go test ./internal/auth/...` — confirm compile failure
-- [ ] **Step 3:** Implement `middleware.go` verbatim
-- [ ] **Step 4:** Run tests `go test ./internal/auth/... -race -v` — 6 PASS
-- [ ] **Step 5:** `git add services/marketplace-api/internal/auth && git commit -m "feat(marketplace-api): add header-trust auth middleware (M5a)"`
+- [x] **Step 1:** Write all 6 failing tests
+- [x] **Step 2:** `cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go test ./internal/auth/...` — confirm compile failure
+- [x] **Step 3:** Implement `middleware.go` verbatim
+- [x] **Step 4:** Run tests `go test ./internal/auth/... -race -v` — 6 PASS
+- [x] **Step 5:** `git add services/marketplace-api/internal/auth && git commit -m "feat(marketplace-api): add header-trust auth middleware (M5a)"`
 
 ---
 
@@ -866,10 +866,10 @@ Document in service.go why these wrappers exist (handler-facing convenience).
 
 **Steps:**
 
-- [ ] **Step 1:** Add `Service.List` + `Service.Get` to `internal/product/service.go`
-- [ ] **Step 2:** Implement `products.go`
-- [ ] **Step 3:** `cd .../services/marketplace-api && go build ./... && go vet ./internal/handlers/admin/...`
-- [ ] **Step 4:** Commit: `feat(marketplace-api): add admin product handler with 6 routes (M5a)`
+- [x] **Step 1:** Add `Service.List` + `Service.Get` to `internal/product/service.go`
+- [x] **Step 2:** Implement `products.go`
+- [x] **Step 3:** `cd .../services/marketplace-api && go build ./... && go vet ./internal/handlers/admin/...`
+- [x] **Step 4:** Commit: `feat(marketplace-api): add admin product handler with 6 routes (M5a)`
 
 ---
 
@@ -1066,7 +1066,7 @@ Each test follows the seed → request → assert pattern. Use `httptest.NewReco
 
 ### Task 9: M5a verification + PR
 
-- [ ] **Step 1:** Full test run
+- [x] **Step 1:** Full test run
 
 ```
 cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go vet ./... && go vet -tags=integration ./... && go build ./... && go test ./... -race && go test -tags integration ./... -race
@@ -1074,13 +1074,13 @@ cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
 
 All clean. API tests skip cleanly without `TEST_DATABASE_URL`.
 
-- [ ] **Step 2:** Push the branch
+- [x] **Step 2:** Push the branch
 
 ```
 git push -u origin feat/products-m5a-admin-products-http
 ```
 
-- [ ] **Step 3:** Open PR
+- [x] **Step 3:** Open PR
 
 ```
 gh pr create --base main --head feat/products-m5a-admin-products-http --title "feat(marketplace-api): products M5a — admin HTTP surface (products lifecycle)" --body "$(cat <<'EOF'
@@ -1114,21 +1114,21 @@ EOF
 )"
 ```
 
-- [ ] **Step 4:** Wait for CI, merge.
+- [x] **Step 4:** Wait for CI, merge.
 
 ---
 
 ## Exit criteria
 
-- [ ] Every product lifecycle endpoint (List, Get, Create, Patch, Delete, Copy) responds correctly to a `curl` from the test harness
-- [ ] Header-trust auth blocks requests with missing claim headers (401)
-- [ ] FGA middleware blocks requests with insufficient role (404, no leak)
-- [ ] StoreMiddleware blocks cross-tenant store access (404, no leak)
-- [ ] Error envelope matches §13.4/§14.13 for every typed error code reachable through the HTTP layer
-- [ ] DTO mapper does not leak any forbidden fields (compile-time guarantee + unit test on field names)
-- [ ] All 18+ API integration tests green against real Postgres
-- [ ] No changes to migrations, Helm chart, CI workflows, or `go.work`
-- [ ] PR is open and CI is green
+- [x] Every product lifecycle endpoint (List, Get, Create, Patch, Delete, Copy) responds correctly to a `curl` from the test harness
+- [x] Header-trust auth blocks requests with missing claim headers (401)
+- [x] FGA middleware blocks requests with insufficient role (404, no leak)
+- [x] StoreMiddleware blocks cross-tenant store access (404, no leak)
+- [x] Error envelope matches §13.4/§14.13 for every typed error code reachable through the HTTP layer
+- [x] DTO mapper does not leak any forbidden fields (compile-time guarantee + unit test on field names)
+- [x] All 18+ API integration tests green against real Postgres
+- [x] No changes to migrations, Helm chart, CI workflows, or `go.work`
+- [x] PR is open and CI is green
 
 ---
 

--- a/docs/superpowers/plans/2026-04-09-products-m5b-categories-media-gcs.md
+++ b/docs/superpowers/plans/2026-04-09-products-m5b-categories-media-gcs.md
@@ -12,7 +12,7 @@
 
 ## Status
 
-> **Pending.** All tasks open.
+**Status: ✅ COMPLETE** — all tasks merged to main.
 
 ---
 
@@ -378,12 +378,12 @@ func (u *GCSUploader) SignedUploadURL(ctx context.Context, key, contentType stri
 
 **Steps:**
 
-- [ ] **Step 1: Add dep** `cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go get cloud.google.com/go/storage && go mod tidy`. Expect new direct require line for `cloud.google.com/go/storage` and new transitive deps. **Any downgrade of existing direct deps → stop.**
-- [ ] **Step 2: Write failing tests**
-- [ ] **Step 3: Implement `gcs.go`**
-- [ ] **Step 4: Run tests** `go build ./... && go vet ./internal/media/... && go test ./internal/media/... -race -v`. All 6 unit tests pass (+ optional 7th skips).
-- [ ] **Step 5: Verify `git diff go.work` empty**
-- [ ] **Step 6: Commit** `feat(marketplace-api): add GCS uploader with signed URL support (M5b)`
+- [x] **Step 1: Add dep** `cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go get cloud.google.com/go/storage && go mod tidy`. Expect new direct require line for `cloud.google.com/go/storage` and new transitive deps. **Any downgrade of existing direct deps → stop.**
+- [x] **Step 2: Write failing tests**
+- [x] **Step 3: Implement `gcs.go`**
+- [x] **Step 4: Run tests** `go build ./... && go vet ./internal/media/... && go test ./internal/media/... -race -v`. All 6 unit tests pass (+ optional 7th skips).
+- [x] **Step 5: Verify `git diff go.work` empty**
+- [x] **Step 6: Commit** `feat(marketplace-api): add GCS uploader with signed URL support (M5b)`
 
 ---
 
@@ -861,23 +861,23 @@ Read `internal/category/service.go` for the exact `category.Config` field names 
 
 ### Task 9: M5b verification + PR
 
-- [ ] **Step 1: Full check**
+- [x] **Step 1: Full check**
 ```
 cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go vet ./... && go vet -tags=integration ./... && go build ./... && go test ./... -race && go test -tags integration ./... -race
 ```
 
-- [ ] **Step 2: Branch scope check**
+- [x] **Step 2: Branch scope check**
 ```
 cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly && git diff --stat main..feat/products-m5b-categories-media-gcs
 ```
 Only files under `services/marketplace-api/{internal/{auth,media,stores,product,handlers/admin},cmd/marketplace-api,pkg/config,go.mod,go.sum}` plus the M5b plan doc. No migrations, no Helm chart, no docs outside `docs/superpowers/plans/`.
 
-- [ ] **Step 3: Push**
+- [x] **Step 3: Push**
 ```
 git push -u origin feat/products-m5b-categories-media-gcs
 ```
 
-- [ ] **Step 4: Open PR** with a body that documents the new env vars for the ops team:
+- [x] **Step 4: Open PR** with a body that documents the new env vars for the ops team:
 
 ```
 gh pr create --base main --head feat/products-m5b-categories-media-gcs --title "feat(marketplace-api): products M5b — categories, media, variant PATCH, real GCS, real platform client" --body "$(cat <<'EOF'
@@ -925,22 +925,22 @@ EOF
 )"
 ```
 
-- [ ] **Step 5: Wait for CI, merge.**
+- [x] **Step 5: Wait for CI, merge.**
 
 ---
 
 ## Exit criteria
 
-- [ ] Every route in spec §6.1 is live: 6 product + 4 category + 1 variant + 4 media = 15 admin routes (M5a's 6 + M5b's 9)
-- [ ] FakeUploader → real GCS switch is config-gated and defaults to fake
-- [ ] stubPlatformClient → real HTTP client switch is config-gated and defaults to stub
-- [ ] New service methods (`AddMedia`, `UpdateMedia`, `DeleteMedia`, `UpdateVariantBasics`) enqueue outbox events and are covered by integration tests
-- [ ] Signed upload URL endpoint returns 501 with the fake and 200 with the real GCS uploader
-- [ ] Variant PATCH's inventory path writes to `variant_stock` (trigger test)
-- [ ] Variant PATCH rejects currency changes with `currency_change_forbidden`
-- [ ] Platform HTTP client enforces tenant scoping at the client boundary (no leak)
-- [ ] `go.mod` diff touches only `cloud.google.com/go/storage` and its transitives (no cascade to gin/gorm/etc)
-- [ ] PR is open, CI is green, Helm chart follow-up is flagged in the PR description
+- [x] Every route in spec §6.1 is live: 6 product + 4 category + 1 variant + 4 media = 15 admin routes (M5a's 6 + M5b's 9)
+- [x] FakeUploader → real GCS switch is config-gated and defaults to fake
+- [x] stubPlatformClient → real HTTP client switch is config-gated and defaults to stub
+- [x] New service methods (`AddMedia`, `UpdateMedia`, `DeleteMedia`, `UpdateVariantBasics`) enqueue outbox events and are covered by integration tests
+- [x] Signed upload URL endpoint returns 501 with the fake and 200 with the real GCS uploader
+- [x] Variant PATCH's inventory path writes to `variant_stock` (trigger test)
+- [x] Variant PATCH rejects currency changes with `currency_change_forbidden`
+- [x] Platform HTTP client enforces tenant scoping at the client boundary (no leak)
+- [x] `go.mod` diff touches only `cloud.google.com/go/storage` and its transitives (no cascade to gin/gorm/etc)
+- [x] PR is open, CI is green, Helm chart follow-up is flagged in the PR description
 
 ---
 

--- a/docs/superpowers/plans/2026-04-09-products-m6-storefront-routes.md
+++ b/docs/superpowers/plans/2026-04-09-products-m6-storefront-routes.md
@@ -12,7 +12,7 @@
 
 ## Status
 
-> **Pending.** All tasks open.
+**Status: ✅ COMPLETE** — all tasks merged to main.
 
 ---
 
@@ -958,7 +958,7 @@ This task could be merged into Task 1's commit (where the interface method is ad
 
 ### Task 10: Verification + PR
 
-- [ ] **Step 1: Full run**
+- [x] **Step 1: Full run**
 
 ```
 cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api && go vet ./... && go vet -tags=integration ./... && go build ./... && go test ./... -race && go test -tags integration ./... -race
@@ -966,7 +966,7 @@ cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
 
 All clean. Integration tests skip cleanly without TEST_DATABASE_URL.
 
-- [ ] **Step 2: Verify branch scope**
+- [x] **Step 2: Verify branch scope**
 
 ```
 cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly && git diff --stat main..feat/products-m6-storefront-routes
@@ -974,13 +974,13 @@ cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly && git diff --stat main.
 
 Only files under `services/marketplace-api/{internal/{stores,category,product,handlers/storefront,handlers/admin},cmd/marketplace-api,pkg/config}`, `services/marketplace-api/go.mod` (untouched — no new deps), and the M6 plan doc.
 
-- [ ] **Step 3: Push**
+- [x] **Step 3: Push**
 
 ```
 git push -u origin feat/products-m6-storefront-routes
 ```
 
-- [ ] **Step 4: Open PR**
+- [x] **Step 4: Open PR**
 
 Title: `feat(marketplace-api): products M6 — storefront read routes with leak regression`
 
@@ -990,27 +990,27 @@ Body covers:
 - What's NOT in this PR: admin routes (already shipped in M5), signed ETag variants, CDN purging hooks.
 - Test plan: leak assertions list (cost_price, inventory_quantity, tenant_id, deleted_at absent); cache header assertions; 304 flow verified.
 
-- [ ] **Step 5: Merge.**
+- [x] **Step 5: Merge.**
 
 ---
 
 ## Exit criteria
 
-- [ ] 4 storefront routes live under `/api/v1/storefront/stores/:storeSlug/...`
-- [ ] Separate Gin engine mounts them (storefront mode); admin mode NEVER mounts them
-- [ ] `Cache-Control: public, s-maxage=60, stale-while-revalidate=300` on every 200
-- [ ] Weak ETag derived from `store_watermarks.products_updated_at` + store id
-- [ ] `If-None-Match` matching current ETag returns 304
-- [ ] Storefront DTO family contains zero leak fields (reflect-based regression test)
-- [ ] Draft / archived / soft-deleted / unpublished products NEVER appear in any storefront response
-- [ ] Handle lookup (`GetPublishedByHandle`) cannot return a non-published product
-- [ ] Category lookup returns only `is_active=true AND deleted_at IS NULL`
-- [ ] Unknown store slug → 404 (no existence leak)
-- [ ] Suspended store → 404
-- [ ] `X-Storefront-Key` check blocks wrong/missing keys with 404 (not 401 — no leak)
-- [ ] `go.mod` untouched
-- [ ] `go.work` untouched
-- [ ] PR is open and CI is green
+- [x] 4 storefront routes live under `/api/v1/storefront/stores/:storeSlug/...`
+- [x] Separate Gin engine mounts them (storefront mode); admin mode NEVER mounts them
+- [x] `Cache-Control: public, s-maxage=60, stale-while-revalidate=300` on every 200
+- [x] Weak ETag derived from `store_watermarks.products_updated_at` + store id
+- [x] `If-None-Match` matching current ETag returns 304
+- [x] Storefront DTO family contains zero leak fields (reflect-based regression test)
+- [x] Draft / archived / soft-deleted / unpublished products NEVER appear in any storefront response
+- [x] Handle lookup (`GetPublishedByHandle`) cannot return a non-published product
+- [x] Category lookup returns only `is_active=true AND deleted_at IS NULL`
+- [x] Unknown store slug → 404 (no existence leak)
+- [x] Suspended store → 404
+- [x] `X-Storefront-Key` check blocks wrong/missing keys with 404 (not 401 — no leak)
+- [x] `go.mod` untouched
+- [x] `go.work` untouched
+- [x] PR is open and CI is green
 
 ---
 


### PR DESCRIPTION
Flips all task checkboxes to checked and updates the status marker on the four plan docs whose work landed across PRs #9, #10, #11, and #12. Doc-only; no code changes.