### PR TITLE
fix(admin): send X-Internal-Auth on marketplace-api read/delete calls

### DIFF
--- a/apps/admin/lib/api/marketplace-api.ts
+++ b/apps/admin/lib/api/marketplace-api.ts
@@ -320,11 +320,7 @@ export async function getProduct(
     `${MARKETPLACE_API_URL}/api/v1/admin/stores/${storeId}/products/${productId}`,
     {
       cache: "no-store",
-      headers: {
-        "X-User-Id": session.userId,
-        "X-Tenant-Id": session.tenantId,
-        Accept: "application/json",
-      },
+      headers: readHeaders(session),
     },
   );
   if (res.status === 401 || res.status === 403 || res.status === 404) {
@@ -387,10 +383,7 @@ export async function deleteProduct(
     {
       method: "DELETE",
       cache: "no-store",
-      headers: {
-        "X-User-Id": session.userId,
-        "X-Tenant-Id": session.tenantId,
-      },
+      headers: readHeaders(session),
     },
   );
   if (res.status === 204 || res.ok) {
@@ -407,11 +400,7 @@ export async function listCategories(
     `${MARKETPLACE_API_URL}/api/v1/admin/stores/${storeId}/categories`,
     {
       cache: "no-store",
-      headers: {
-        "X-User-Id": session.userId,
-        "X-Tenant-Id": session.tenantId,
-        Accept: "application/json",
-      },
+      headers: readHeaders(session),
     },
   );
   if (res.status === 401 || res.status === 403 || res.status === 404) {
@@ -573,10 +562,7 @@ export async function deleteMedia(
     {
       method: "DELETE",
       cache: "no-store",
-      headers: {
-        "X-User-Id": session.userId,
-        "X-Tenant-Id": session.tenantId,
-      },
+      headers: readHeaders(session),
     },
   );
   if (res.status === 204 || res.ok) {


### PR DESCRIPTION
## Summary
- `listCategories`, `getProduct`, `deleteProduct`, and `deleteMedia` in `apps/admin/lib/api/marketplace-api.ts` built their headers inline and skipped `X-Internal-Auth`.
- With `MARKETPLACE_INTERNAL_AUTH` enforced upstream, this caused the server-side render of `/products/new` to throw on `await listCategories(...)`, which the products error boundary surfaced as **"Couldn't load your products"** (HTTP 500 on the page POST).
- Switched the four call sites to the existing `readHeaders(session)` helper so the auth header is always included.

## Test plan
- [ ] Open `/products/new` on the test admin host — page renders the product form with the categories picker populated, no 500.
- [ ] Edit an existing product (`getProduct`) and delete a product / media — both succeed.