### PR TITLE
fix(platform-api): point marketplace-api self-vendor call at :8080 + bundle backfill-vendors CLI

### DIFF
--- a/services/platform-api/Dockerfile
+++ b/services/platform-api/Dockerfile
@@ -1,5 +1,5 @@
-# Multi-stage Dockerfile producing three targets: server, migrate, seed.
-# Same source, same embedded migrations, no version skew.
+# Multi-stage Dockerfile producing four targets: server, migrate, seed,
+# backfill-vendors. Same source, same embedded migrations, no version skew.
 # Builds on tesserix company-owned base images.
 
 FROM ghcr.io/tesserix/base-go-builder:latest AS build
@@ -8,16 +8,20 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go build -trimpath -ldflags="-s -w" -o /out/server  ./cmd/server \
- && go build -trimpath -ldflags="-s -w" -o /out/migrate ./cmd/migrate \
- && go build -trimpath -ldflags="-s -w" -o /out/seed    ./cmd/seed
+RUN go build -trimpath -ldflags="-s -w" -o /out/server           ./cmd/server \
+ && go build -trimpath -ldflags="-s -w" -o /out/migrate          ./cmd/migrate \
+ && go build -trimpath -ldflags="-s -w" -o /out/seed             ./cmd/seed \
+ && go build -trimpath -ldflags="-s -w" -o /out/backfill-vendors ./cmd/backfill-vendors
 
-# Single runtime stage carries all three binaries so the K8s init+seed
-# pattern can override ENTRYPOINT without pulling a second image.
+# Single runtime stage carries all four binaries so K8s init/seed/Job
+# overrides can pick the right entrypoint without pulling a second image.
+# /backfill-vendors is the CLI surfaced by the marketplace-api error
+# "tenant has no self-vendor; run platform-api's backfill-vendors CLI".
 FROM ghcr.io/tesserix/base-alpine-runtime:latest AS server
-COPY --from=build --chown=10001:10001 /out/server  /server
-COPY --from=build --chown=10001:10001 /out/migrate /migrate
-COPY --from=build --chown=10001:10001 /out/seed    /seed
+COPY --from=build --chown=10001:10001 /out/server           /server
+COPY --from=build --chown=10001:10001 /out/migrate          /migrate
+COPY --from=build --chown=10001:10001 /out/seed             /seed
+COPY --from=build --chown=10001:10001 /out/backfill-vendors /backfill-vendors
 EXPOSE 8086
 # base-alpine-runtime's ENTRYPOINT is already `tini --`.
 CMD ["/server"]

--- a/services/platform-api/internal/marketplaceapi/vendor_client.go
+++ b/services/platform-api/internal/marketplaceapi/vendor_client.go
@@ -33,7 +33,7 @@ type VendorClient struct {
 }
 
 // NewVendorClient constructs a client pointed at the given base URL
-// (e.g. "http://mark8ly-marketplace-api-admin.mark8ly.svc.cluster.local:8086").
+// (e.g. "http://mark8ly-marketplace-api-admin.mark8ly.svc.cluster.local:8080").
 // A 10-second default timeout is applied; the caller can swap the client
 // by assigning to the embedded field if a different policy is needed.
 func NewVendorClient(baseURL string) *VendorClient {

--- a/services/platform-api/pkg/config/config.go
+++ b/services/platform-api/pkg/config/config.go
@@ -53,7 +53,7 @@ type Config struct {
 	// onboarding to create a tenant's self-vendor. Phase 1 of the
 	// tenant/vendor/store refactor. Default targets the in-cluster
 	// Knative admin revision; override with an env var for local dev.
-	MarketplaceAPIURL string `envconfig:"MARKETPLACE_API_URL" default:"http://mark8ly-marketplace-api-admin.mark8ly.svc.cluster.local:8086"`
+	MarketplaceAPIURL string `envconfig:"MARKETPLACE_API_URL" default:"http://mark8ly-marketplace-api-admin.mark8ly.svc.cluster.local:8080"`
 
 	// MarketplaceInternalAuthSecret is the shared secret used to sign
 	// service-to-service calls to marketplace-api's HeaderTrustAuth


### PR DESCRIPTION
## Why
Onboarding for `australia-store` (first new tenant since 2026-04-14) failed to create a self-vendor row in marketplace-api. Product creation then errored with `tenant has no self-vendor; run platform-api's backfill-vendors CLI`.

Root cause: platform-api was calling `http://mark8ly-marketplace-api-admin.mark8ly.svc:8086/...` but the K8s Service exposes port **8080**. The wrong port was the in-code default in `pkg/config/config.go`. The deployment had no env override (a comment claimed the default was sensible).

The call is best-effort, so onboarding silently swallowed the timeout. No new tenant was created between 04-14 and 04-25, so the bug shipped unnoticed.

## What
- `pkg/config/config.go`: default `MARKETPLACE_API_URL` `:8086` -> `:8080`.
- `internal/marketplaceapi/vendor_client.go`: example URL in doc comment now matches.
- `Dockerfile`: bundle the `backfill-vendors` CLI binary into the runtime image so the error message's instruction is actually executable in-cluster (`kubectl exec ... /backfill-vendors`). Previously only `server`/`migrate`/`seed` were shipped.

## Companion chart change
`tesserix-k8s` PR pins `MARKETPLACE_API_URL` explicitly in the platform-api Helm chart so a future code-default drift can't re-introduce this. Both PRs should land together.

## Verified
- go build clean.
- Australia-store unblocked manually in prod via curl POST `:8080/internal/tenants/<id>/ensure-self-vendor`. Vendor row `b0bea47d-...` created.

## Test plan
- [ ] CI green
- [ ] Bump-k8s job opens companion PR on tesserix-k8s with new image tag
- [ ] After both deploy, smoke-test by onboarding a fresh tenant and verifying the vendors row appears within seconds (no manual backfill)