### PR TITLE
feat(mobile): support chat for storefront (#118) and admin (#119)

### DIFF
--- a/apps/mobile-admin/app/(tabs)/more/_layout.tsx
+++ b/apps/mobile-admin/app/(tabs)/more/_layout.tsx
@@ -6,6 +6,7 @@ export default function MoreLayout() {
       <Stack.Screen name="index" />
       <Stack.Screen name="notifications" />
       <Stack.Screen name="account" />
+      <Stack.Screen name="support" />
     </Stack>
   );
 }

--- a/apps/mobile-admin/app/(tabs)/more/index.tsx
+++ b/apps/mobile-admin/app/(tabs)/more/index.tsx
@@ -4,6 +4,7 @@ import {
   Bell,
   ChevronRight,
   ExternalLink,
+  LifeBuoy,
   Settings,
   UserRound,
 } from "lucide-react-native";
@@ -80,6 +81,13 @@ export default function MoreScreen() {
           label="Account"
           accessibilityLabel="Account settings"
           onPress={() => router.push("/(tabs)/more/account")}
+        />
+        <Hairline inset={theme.spacing.huge + theme.spacing.xs} />
+        <Row
+          icon={<LifeBuoy size={18} color={theme.colors.text} strokeWidth={1.75} />}
+          label="Tesserix Support"
+          accessibilityLabel="Chat with Tesserix platform support"
+          onPress={() => router.push("/(tabs)/more/support")}
         />
         <Hairline inset={theme.spacing.huge + theme.spacing.xs} />
         <Row

--- a/apps/mobile-admin/app/(tabs)/more/support.tsx
+++ b/apps/mobile-admin/app/(tabs)/more/support.tsx
@@ -1,0 +1,93 @@
+// Merchant -> platform support chat (#119). Renders the shared
+// SupportChatView wired to the marketplace-api admin platform-support BFF,
+// which bridges to otto's "platform" tenant. A Tesserix employee handles
+// the conversation from the platform-support inbox; the merchant's own
+// tenant is attached server-side so they know who's asking.
+import { useMemo } from "react";
+import { View, StyleSheet } from "react-native";
+import * as SecureStore from "expo-secure-store";
+
+import {
+  createSupportClient,
+  useSupportChat,
+  SupportChatView,
+  type IntakeReason,
+  type SupportPalette,
+} from "@repo/mobile-shared/support";
+import { useAuth } from "@repo/mobile-shared/auth/provider";
+import { useEnvironment } from "@repo/mobile-shared/config/env";
+
+import { BackHeader, Screen } from "@/components/ui";
+import { theme } from "@/lib/theme";
+
+const REASONS: IntakeReason[] = [
+  { value: "general_question", label: "Quick question", requiresStatus: false },
+  { value: "billing", label: "Billing" },
+  { value: "domains", label: "Domain / DNS" },
+  { value: "payments_setup", label: "Payments setup" },
+  { value: "incident", label: "Outage / incident" },
+  { value: "kyc_compliance", label: "KYC / compliance" },
+  { value: "feature_request", label: "Feature request" },
+  { value: "other", label: "Something else" },
+];
+
+const SESSION_KEY = "otto_platform_support_session";
+
+export default function PlatformSupportScreen() {
+  const { user, getToken, refreshToken, signOut } = useAuth();
+  const env = useEnvironment();
+
+  const client = useMemo(
+    () =>
+      createSupportClient({
+        baseUrl: env.apiBaseUrl,
+        basePath: "/api/v1/mobile/admin/platform-support",
+        getToken,
+        refreshToken,
+        onUnauthorized: signOut,
+        loadSessionToken: () => SecureStore.getItemAsync(SESSION_KEY),
+        saveSessionToken: (t) => SecureStore.setItemAsync(SESSION_KEY, t),
+      }),
+    [env.apiBaseUrl, getToken, refreshToken, signOut],
+  );
+
+  const chat = useSupportChat({ client });
+
+  const palette = useMemo<SupportPalette>(
+    () => ({
+      background: theme.colors.background,
+      surface: theme.colors.surfaceAlt,
+      bubbleOwn: theme.colors.accent,
+      textOnOwn: theme.colors.palette.white,
+      text: theme.colors.text,
+      textSecondary: theme.colors.textSecondary,
+      border: theme.colors.border,
+      primary: theme.colors.accent,
+      onPrimary: theme.colors.palette.white,
+      danger: theme.colors.danger,
+    }),
+    [],
+  );
+
+  return (
+    <Screen>
+      <BackHeader title="Tesserix Support" eyebrow="HELP" />
+      <View style={styles.fill}>
+        <SupportChatView
+          chat={chat}
+          palette={palette}
+          reasons={REASONS}
+          defaults={{ name: user?.displayName ?? undefined, email: user?.email ?? undefined }}
+          introTitle="Chat with Tesserix"
+          introSubtitle="Questions about billing, domains, payments, or an incident? We're here to help."
+          composerPlaceholder="Type a message…"
+          statusPlaceholder="e.g. Checkout returning 500 since 09:00 UTC"
+        />
+      </View>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  fill: { flex: 1 },
+});

--- a/apps/storefront-mobile/app/(tabs)/account/_layout.tsx
+++ b/apps/storefront-mobile/app/(tabs)/account/_layout.tsx
@@ -19,6 +19,7 @@ export default function AccountLayout() {
       <Stack.Screen name="wishlist" options={{ title: "Wishlist" }} />
       <Stack.Screen name="loyalty" options={{ title: "Loyalty" }} />
       <Stack.Screen name="reviews" options={{ title: "Reviews" }} />
+      <Stack.Screen name="support" options={{ title: "Help & Support" }} />
     </Stack>
   );
 }

--- a/apps/storefront-mobile/app/(tabs)/account/index.tsx
+++ b/apps/storefront-mobile/app/(tabs)/account/index.tsx
@@ -17,6 +17,7 @@ import {
   Heart,
   Star,
   MessageSquare,
+  LifeBuoy,
   LogOut,
 } from "lucide-react-native";
 
@@ -32,6 +33,7 @@ const QUICK_LINKS: QuickLinkItem[] = [
   { label: "Wishlist", icon: Heart, route: "/(tabs)/account/wishlist" },
   { label: "Loyalty", icon: Star, route: "/(tabs)/account/loyalty" },
   { label: "Reviews", icon: MessageSquare, route: "/(tabs)/account/reviews" },
+  { label: "Support", icon: LifeBuoy, route: "/(tabs)/account/support" },
 ];
 
 export default function AccountDashboardScreen() {

--- a/apps/storefront-mobile/app/(tabs)/account/support.tsx
+++ b/apps/storefront-mobile/app/(tabs)/account/support.tsx
@@ -1,0 +1,84 @@
+// Customer support chat (#118) — customer -> merchant. Renders the shared
+// SupportChatView wired to the marketplace-api mobile support BFF, which
+// bridges to otto. The otto session token is persisted per-store so the
+// thread resumes across app launches.
+import { useMemo } from "react";
+import * as SecureStore from "expo-secure-store";
+
+import {
+  createSupportClient,
+  useSupportChat,
+  SupportChatView,
+  type IntakeReason,
+  type SupportPalette,
+} from "@repo/mobile-shared/support";
+import { useAuth } from "@repo/mobile-shared/auth/provider";
+
+import { useTheme } from "@/lib/theme/theme-provider";
+import { useApiBaseUrl, useStoreSlug } from "@/lib/storefront-api/client-provider";
+
+const REASONS: IntakeReason[] = [
+  { value: "order_issue", label: "Order issue" },
+  { value: "return", label: "Return / refund" },
+  { value: "payment", label: "Payment" },
+  { value: "product_question", label: "Product question", requiresStatus: false },
+  { value: "other", label: "Something else" },
+];
+
+// otto requires a date of birth for order/account-related reasons so staff
+// can verify the customer before discussing an order.
+const DOB_REASONS = new Set(["order_issue", "return", "payment"]);
+const SESSION_PREFIX = "otto_support_session";
+
+export default function SupportScreen() {
+  const theme = useTheme();
+  const { user, getToken, refreshToken, signOut } = useAuth();
+  const baseUrl = useApiBaseUrl();
+  const storeSlug = useStoreSlug();
+
+  const client = useMemo(
+    () =>
+      createSupportClient({
+        baseUrl,
+        basePath: `/api/v1/mobile/storefront/stores/${storeSlug}/support`,
+        getToken,
+        refreshToken,
+        onUnauthorized: signOut,
+        loadSessionToken: () => SecureStore.getItemAsync(`${SESSION_PREFIX}:${storeSlug}`),
+        saveSessionToken: (t) => SecureStore.setItemAsync(`${SESSION_PREFIX}:${storeSlug}`, t),
+      }),
+    [baseUrl, storeSlug, getToken, refreshToken, signOut],
+  );
+
+  const chat = useSupportChat({ client });
+
+  const palette = useMemo<SupportPalette>(
+    () => ({
+      background: theme.background,
+      surface: theme.elevated,
+      bubbleOwn: theme.primary,
+      textOnOwn: theme.elevated,
+      text: theme.text,
+      textSecondary: theme.textSecondary,
+      border: theme.border,
+      primary: theme.primary,
+      onPrimary: theme.elevated,
+      danger: "#8B2020",
+    }),
+    [theme],
+  );
+
+  return (
+    <SupportChatView
+      chat={chat}
+      palette={palette}
+      reasons={REASONS}
+      defaults={{ name: user?.displayName ?? undefined, email: user?.email ?? undefined }}
+      requiresDob={(r) => DOB_REASONS.has(r)}
+      introTitle="How can we help?"
+      introSubtitle="Chat with the store's support team."
+      composerPlaceholder="Type a message…"
+      statusPlaceholder="e.g. Order #1234 hasn't arrived"
+    />
+  );
+}

--- a/apps/storefront-mobile/lib/storefront-api/client-provider.tsx
+++ b/apps/storefront-mobile/lib/storefront-api/client-provider.tsx
@@ -47,3 +47,7 @@ export function useApiClient(): ApiClient {
 export function useStoreSlug(): string {
   return getExtraConfig().storeSlug;
 }
+
+export function useApiBaseUrl(): string {
+  return getExtraConfig().apiBaseUrl;
+}

--- a/go.work.sum
+++ b/go.work.sum
@@ -2505,6 +2505,7 @@ golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4 h1:bTLqdHv7xrGlFbvf5/T
 golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4/go.mod h1:g5NllXBEermZrmR51cJDQxmJUHUOfRAaNyWBM+R+548=
 golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c h1:6a8FdnNk6bTXBjR4AGKFgUKuo+7GnR3FX5L7CbveeZc=
 golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c/go.mod h1:TpUTTEp9frx7rTdLpC9gFG9kdI7zVLFTFFlqaH2Cncw=
+golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa/go.mod h1:kHjTxDEnAu6/Nl9lDkzjWpR+bmKfxeiRuSDlsMb70gE=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=

--- a/packages/mobile-shared/package.json
+++ b/packages/mobile-shared/package.json
@@ -36,7 +36,6 @@
     "@react-native-firebase/auth": "*"
   },
   "devDependencies": {
-    "typescript": "^5.9.0",
-    "vitest": "^4.1.4"
+    "typescript": "^5.9.0"
   }
 }

--- a/packages/mobile-shared/package.json
+++ b/packages/mobile-shared/package.json
@@ -14,7 +14,13 @@
     "./stores/*": "./stores/*.ts",
     "./deep-links/*": "./deep-links/*.ts",
     "./haptics/*": "./haptics/*.ts",
-    "./config/*": "./config/*.ts"
+    "./config/*": "./config/*.ts",
+    "./support": "./support/index.ts",
+    "./support/*": "./support/*.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "check-types": "tsc --noEmit"
   },
   "dependencies": {
     "zustand": "^5.0.0",
@@ -30,6 +36,7 @@
     "@react-native-firebase/auth": "*"
   },
   "devDependencies": {
-    "typescript": "^5.9.0"
+    "typescript": "^5.9.0",
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/mobile-shared/support/SupportChatView.tsx
+++ b/packages/mobile-shared/support/SupportChatView.tsx
@@ -1,0 +1,397 @@
+// SupportChatView — the shared, themeable support-chat UI. It renders the
+// intake form, the live message thread, the composer, and the closed/queue
+// states from a UseSupportChat instance. Both mobile apps render it with
+// their own palette so there is one chat UI, not two.
+import { useMemo, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import type { UseSupportChat } from "./useSupportChat";
+import type { IntakeReason, SupportMessage } from "./types";
+
+export interface SupportPalette {
+  background: string;
+  surface: string;
+  bubbleOwn: string;
+  textOnOwn: string;
+  text: string;
+  textSecondary: string;
+  border: string;
+  primary: string;
+  onPrimary: string;
+  danger: string;
+}
+
+export interface SupportChatViewProps {
+  chat: UseSupportChat;
+  palette: SupportPalette;
+  reasons: IntakeReason[];
+  defaults?: { name?: string; email?: string };
+  introTitle?: string;
+  introSubtitle?: string;
+  composerPlaceholder?: string;
+  statusPlaceholder?: string;
+  /** Returns true when the selected reason requires a date of birth. */
+  requiresDob?: (reason: string) => boolean;
+}
+
+export function SupportChatView({
+  chat,
+  palette,
+  reasons,
+  defaults,
+  introTitle = "How can we help?",
+  introSubtitle = "Start a conversation and we'll get back to you.",
+  composerPlaceholder = "Type a message…",
+  statusPlaceholder = "Briefly, what's going on?",
+  requiresDob,
+}: SupportChatViewProps) {
+  const [composeNew, setComposeNew] = useState(false);
+
+  const showIntake = composeNew || (!chat.conversation && chat.status !== "loading");
+
+  if (chat.status === "loading" && !chat.conversation && !composeNew) {
+    return (
+      <View style={[styles.center, { backgroundColor: palette.background }]}>
+        <ActivityIndicator color={palette.primary} />
+      </View>
+    );
+  }
+
+  if (showIntake) {
+    return (
+      <IntakeForm
+        palette={palette}
+        reasons={reasons}
+        defaults={defaults}
+        introTitle={introTitle}
+        introSubtitle={introSubtitle}
+        statusPlaceholder={statusPlaceholder}
+        requiresDob={requiresDob}
+        submitting={chat.status === "loading"}
+        error={chat.error}
+        onSubmit={async (input) => {
+          await chat.startConversation(input);
+          setComposeNew(false);
+        }}
+      />
+    );
+  }
+
+  return (
+    <ThreadView
+      chat={chat}
+      palette={palette}
+      composerPlaceholder={composerPlaceholder}
+      onNewChat={() => setComposeNew(true)}
+    />
+  );
+}
+
+function ThreadView({
+  chat,
+  palette,
+  composerPlaceholder,
+  onNewChat,
+}: {
+  chat: UseSupportChat;
+  palette: SupportPalette;
+  composerPlaceholder: string;
+  onNewChat: () => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const listRef = useRef<FlatList<SupportMessage>>(null);
+  const closed = chat.conversation?.status === "closed" || chat.status === "closed";
+
+  const send = async () => {
+    const body = draft.trim();
+    if (!body || sending) return;
+    setSending(true);
+    setDraft("");
+    try {
+      await chat.sendMessage(body);
+    } catch {
+      setDraft(body); // restore on failure
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={[styles.flex, { backgroundColor: palette.background }]}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+      keyboardVerticalOffset={Platform.OS === "ios" ? 90 : 0}
+    >
+      <StatusBar chat={chat} palette={palette} />
+      <FlatList
+        ref={listRef}
+        data={chat.messages}
+        keyExtractor={(m) => m.id}
+        renderItem={({ item }) => <MessageBubble message={item} palette={palette} />}
+        contentContainerStyle={styles.listContent}
+        onContentSizeChange={() => listRef.current?.scrollToEnd({ animated: true })}
+        showsVerticalScrollIndicator={false}
+      />
+      {closed ? (
+        <View style={[styles.closedBar, { borderTopColor: palette.border }]}>
+          <Text style={[styles.closedText, { color: palette.textSecondary }]}>
+            This conversation is closed.
+          </Text>
+          <Pressable onPress={onNewChat} accessibilityRole="button" accessibilityLabel="Start a new chat">
+            <Text style={[styles.link, { color: palette.primary }]}>Start a new chat</Text>
+          </Pressable>
+        </View>
+      ) : (
+        <View style={[styles.composer, { borderTopColor: palette.border, backgroundColor: palette.background }]}>
+          <TextInput
+            style={[styles.input, { backgroundColor: palette.surface, color: palette.text, borderColor: palette.border }]}
+            placeholder={composerPlaceholder}
+            placeholderTextColor={palette.textSecondary}
+            value={draft}
+            onChangeText={setDraft}
+            multiline
+            accessibilityLabel="Message"
+          />
+          <Pressable
+            style={[styles.sendBtn, { backgroundColor: draft.trim() ? palette.primary : palette.border }]}
+            onPress={send}
+            disabled={!draft.trim() || sending}
+            accessibilityRole="button"
+            accessibilityLabel="Send message"
+          >
+            <Text style={[styles.sendText, { color: palette.onPrimary }]}>{sending ? "…" : "Send"}</Text>
+          </Pressable>
+        </View>
+      )}
+    </KeyboardAvoidingView>
+  );
+}
+
+function StatusBar({ chat, palette }: { chat: UseSupportChat; palette: SupportPalette }) {
+  const conv = chat.conversation;
+  const label = useMemo(() => {
+    if (chat.status === "closed" || conv?.status === "closed") return "Closed";
+    if (conv?.status === "pending") return chat.connected ? "Waiting for an agent…" : "Connecting…";
+    if (conv?.status === "active") return chat.connected ? "Connected" : "Reconnecting…";
+    return "";
+  }, [chat.status, chat.connected, conv?.status]);
+
+  if (!conv) return null;
+  return (
+    <View style={[styles.statusBar, { borderBottomColor: palette.border }]}>
+      <View style={[styles.dot, { backgroundColor: chat.connected ? "#1f9d55" : palette.textSecondary }]} />
+      <Text style={[styles.statusText, { color: palette.textSecondary }]}>
+        {label}
+        {conv.case_id ? `  ·  ${conv.case_id}` : ""}
+      </Text>
+    </View>
+  );
+}
+
+function MessageBubble({ message, palette }: { message: SupportMessage; palette: SupportPalette }) {
+  if (message.sender_type === "system") {
+    return (
+      <View style={styles.systemRow}>
+        <Text style={[styles.systemText, { color: palette.textSecondary }]}>{message.body}</Text>
+      </View>
+    );
+  }
+  const own = message.sender_type === "customer";
+  return (
+    <View style={[styles.bubbleRow, own ? styles.rowEnd : styles.rowStart]}>
+      <View
+        style={[
+          styles.bubble,
+          own
+            ? { backgroundColor: palette.bubbleOwn }
+            : { backgroundColor: palette.surface, borderColor: palette.border, borderWidth: StyleSheet.hairlineWidth },
+        ]}
+      >
+        {!own && message.sender_name ? (
+          <Text style={[styles.senderName, { color: palette.textSecondary }]}>{message.sender_name}</Text>
+        ) : null}
+        <Text style={[styles.bubbleText, { color: own ? palette.textOnOwn : palette.text }]}>{message.body}</Text>
+      </View>
+    </View>
+  );
+}
+
+function IntakeForm({
+  palette,
+  reasons,
+  defaults,
+  introTitle,
+  introSubtitle,
+  statusPlaceholder,
+  requiresDob,
+  submitting,
+  error,
+  onSubmit,
+}: {
+  palette: SupportPalette;
+  reasons: IntakeReason[];
+  defaults?: { name?: string; email?: string };
+  introTitle: string;
+  introSubtitle: string;
+  statusPlaceholder: string;
+  requiresDob?: (reason: string) => boolean;
+  submitting: boolean;
+  error: string | null;
+  onSubmit: (input: {
+    message: string;
+    reason: string;
+    statusInfo: string;
+    name?: string;
+    email?: string;
+    dob?: string;
+  }) => Promise<void>;
+}) {
+  const [reason, setReason] = useState(reasons[0]?.value ?? "other");
+  const [statusInfo, setStatusInfo] = useState("");
+  const [message, setMessage] = useState("");
+  const [dob, setDob] = useState("");
+
+  const selected = reasons.find((r) => r.value === reason);
+  const needsStatus = selected?.requiresStatus !== false;
+  const needsDob = requiresDob?.(reason) ?? false;
+  const canSubmit =
+    message.trim().length > 0 && (!needsStatus || statusInfo.trim().length > 0) && (!needsDob || dob.trim().length > 0);
+
+  return (
+    <KeyboardAvoidingView
+      style={[styles.flex, { backgroundColor: palette.background }]}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
+      <ScrollView keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false}>
+        <View style={styles.intake}>
+            <Text style={[styles.introTitle, { color: palette.text }]}>{introTitle}</Text>
+            <Text style={[styles.introSubtitle, { color: palette.textSecondary }]}>{introSubtitle}</Text>
+
+            <Text style={[styles.label, { color: palette.text }]}>Topic</Text>
+            <View style={styles.chips}>
+              {reasons.map((r) => {
+                const active = r.value === reason;
+                return (
+                  <Pressable
+                    key={r.value}
+                    onPress={() => setReason(r.value)}
+                    style={[
+                      styles.chip,
+                      {
+                        backgroundColor: active ? palette.primary : palette.surface,
+                        borderColor: active ? palette.primary : palette.border,
+                      },
+                    ]}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: active }}
+                    accessibilityLabel={r.label}
+                  >
+                    <Text style={{ color: active ? palette.onPrimary : palette.text, fontSize: 13 }}>{r.label}</Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+
+            {needsStatus ? (
+              <>
+                <Text style={[styles.label, { color: palette.text }]}>Summary</Text>
+                <TextInput
+                  style={[styles.field, { backgroundColor: palette.surface, color: palette.text, borderColor: palette.border }]}
+                  placeholder={statusPlaceholder}
+                  placeholderTextColor={palette.textSecondary}
+                  value={statusInfo}
+                  onChangeText={setStatusInfo}
+                  accessibilityLabel="Summary"
+                />
+              </>
+            ) : null}
+
+            {needsDob ? (
+              <>
+                <Text style={[styles.label, { color: palette.text }]}>Date of birth (YYYY-MM-DD)</Text>
+                <TextInput
+                  style={[styles.field, { backgroundColor: palette.surface, color: palette.text, borderColor: palette.border }]}
+                  placeholder="1990-01-01"
+                  placeholderTextColor={palette.textSecondary}
+                  value={dob}
+                  onChangeText={setDob}
+                  autoCapitalize="none"
+                  accessibilityLabel="Date of birth"
+                />
+              </>
+            ) : null}
+
+            <Text style={[styles.label, { color: palette.text }]}>Message</Text>
+            <TextInput
+              style={[styles.fieldMultiline, { backgroundColor: palette.surface, color: palette.text, borderColor: palette.border }]}
+              placeholder="Describe your issue…"
+              placeholderTextColor={palette.textSecondary}
+              value={message}
+              onChangeText={setMessage}
+              multiline
+              accessibilityLabel="Message"
+            />
+
+            {error ? <Text style={[styles.error, { color: palette.danger }]}>{error}</Text> : null}
+
+            <Pressable
+              style={[styles.submit, { backgroundColor: canSubmit ? palette.primary : palette.border }]}
+              disabled={!canSubmit || submitting}
+              onPress={() => onSubmit({ message: message.trim(), reason, statusInfo: statusInfo.trim(), name: defaults?.name, email: defaults?.email, dob: dob.trim() || undefined })}
+              accessibilityRole="button"
+              accessibilityLabel="Start chat"
+            >
+              <Text style={[styles.submitText, { color: palette.onPrimary }]}>{submitting ? "Starting…" : "Start chat"}</Text>
+            </Pressable>
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  center: { flex: 1, alignItems: "center", justifyContent: "center" },
+  listContent: { padding: 14, gap: 8 },
+  statusBar: { flexDirection: "row", alignItems: "center", gap: 8, paddingHorizontal: 14, paddingVertical: 8, borderBottomWidth: StyleSheet.hairlineWidth },
+  dot: { width: 8, height: 8, borderRadius: 4 },
+  statusText: { fontSize: 12 },
+  bubbleRow: { flexDirection: "row" },
+  rowEnd: { justifyContent: "flex-end" },
+  rowStart: { justifyContent: "flex-start" },
+  bubble: { maxWidth: "82%", borderRadius: 14, paddingHorizontal: 12, paddingVertical: 8 },
+  senderName: { fontSize: 11, marginBottom: 2, fontWeight: "600" },
+  bubbleText: { fontSize: 15, lineHeight: 20 },
+  systemRow: { alignItems: "center", paddingVertical: 4 },
+  systemText: { fontSize: 12, fontStyle: "italic" },
+  composer: { flexDirection: "row", alignItems: "flex-end", gap: 8, padding: 10, borderTopWidth: StyleSheet.hairlineWidth },
+  input: { flex: 1, minHeight: 40, maxHeight: 120, borderRadius: 10, borderWidth: StyleSheet.hairlineWidth, paddingHorizontal: 12, paddingTop: 10, paddingBottom: 10, fontSize: 15 },
+  sendBtn: { height: 40, paddingHorizontal: 16, borderRadius: 10, alignItems: "center", justifyContent: "center" },
+  sendText: { fontSize: 15, fontWeight: "600" },
+  closedBar: { padding: 16, borderTopWidth: StyleSheet.hairlineWidth, alignItems: "center", gap: 6 },
+  closedText: { fontSize: 14 },
+  link: { fontSize: 15, fontWeight: "600" },
+  intake: { padding: 20, gap: 10 },
+  introTitle: { fontSize: 22, fontWeight: "700" },
+  introSubtitle: { fontSize: 14, lineHeight: 20, marginBottom: 6 },
+  label: { fontSize: 13, fontWeight: "600", marginTop: 8 },
+  chips: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+  chip: { paddingHorizontal: 12, paddingVertical: 8, borderRadius: 16, borderWidth: StyleSheet.hairlineWidth },
+  field: { height: 44, borderRadius: 10, borderWidth: StyleSheet.hairlineWidth, paddingHorizontal: 12, fontSize: 15 },
+  fieldMultiline: { minHeight: 90, borderRadius: 10, borderWidth: StyleSheet.hairlineWidth, paddingHorizontal: 12, paddingTop: 10, fontSize: 15, textAlignVertical: "top" },
+  error: { fontSize: 13, marginTop: 4 },
+  submit: { height: 50, borderRadius: 10, alignItems: "center", justifyContent: "center", marginTop: 14 },
+  submitText: { fontSize: 16, fontWeight: "700" },
+});

--- a/packages/mobile-shared/support/__tests__/client.test.ts
+++ b/packages/mobile-shared/support/__tests__/client.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createSupportClient, SupportError } from "../client";
+
+interface Captured {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+let calls: Captured[] = [];
+
+function mockOnce(status: number, json: unknown) {
+  (globalThis.fetch as any).mockImplementationOnce(async (url: string, init: RequestInit) => {
+    calls.push({
+      url,
+      method: init.method ?? "GET",
+      headers: (init.headers as Record<string, string>) ?? {},
+      body: init.body as string | undefined,
+    });
+    return new Response(JSON.stringify(json), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+}
+
+function newClient(overrides: Partial<Parameters<typeof createSupportClient>[0]> = {}) {
+  return createSupportClient({
+    baseUrl: "https://api.test",
+    basePath: "/api/v1/mobile/storefront/stores/acme/support",
+    getToken: async () => "tok-1",
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  calls = [];
+  vi.stubGlobal("fetch", vi.fn());
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createSupportClient", () => {
+  it("creates a conversation, sends bearer + body, captures session_token", async () => {
+    const saved: string[] = [];
+    const client = newClient({ saveSessionToken: (t) => void saved.push(t) });
+    mockOnce(201, {
+      conversation: { id: "c1", status: "pending" },
+      first_message: { id: "m1", sender_type: "customer", body: "hi", created_at: "2026-06-21T10:00:00Z" },
+      session_token: "sess-xyz",
+    });
+
+    const out = await client.createConversation({ message: "hi", reason: "order_issue", statusInfo: "late" });
+
+    expect(out.conversation.id).toBe("c1");
+    expect(out.firstMessage.id).toBe("m1");
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toBe("https://api.test/api/v1/mobile/storefront/stores/acme/support/conversations");
+    expect(calls[0].headers["Authorization"]).toBe("Bearer tok-1");
+    expect(JSON.parse(calls[0].body!)).toMatchObject({ message: "hi", reason: "order_issue", status_info: "late" });
+    expect(client.currentSessionToken()).toBe("sess-xyz");
+    expect(saved).toEqual(["sess-xyz"]);
+  });
+
+  it("sends X-Otto-Session on calls after the session is established", async () => {
+    const client = newClient();
+    mockOnce(201, { conversation: { id: "c1", status: "pending" }, first_message: { id: "m1", sender_type: "customer", body: "hi", created_at: "2026-06-21T10:00:00Z" }, session_token: "sess-xyz" });
+    await client.createConversation({ message: "hi", reason: "other", statusInfo: "x" });
+
+    mockOnce(201, { message: { id: "m2", sender_type: "customer", body: "again", created_at: "2026-06-21T10:01:00Z" } });
+    await client.postMessage("c1", "again");
+
+    expect(calls[1].headers["X-Otto-Session"]).toBe("sess-xyz");
+    expect(calls[1].url).toBe("https://api.test/api/v1/mobile/storefront/stores/acme/support/conversations/c1/messages");
+  });
+
+  it("refreshes the token once on 401 then retries", async () => {
+    const refreshToken = vi.fn(async () => "tok-2");
+    const client = newClient({ refreshToken });
+    mockOnce(401, { error: "unauthorized" });
+    mockOnce(200, { messages: [] });
+
+    const msgs = await client.listMessages("c1");
+    expect(msgs).toEqual([]);
+    expect(refreshToken).toHaveBeenCalledTimes(1);
+    expect(calls[1].headers["Authorization"]).toBe("Bearer tok-2");
+  });
+
+  it("throws SupportError + calls onUnauthorized when refresh still 401s", async () => {
+    const onUnauthorized = vi.fn();
+    const client = newClient({ refreshToken: async () => "tok-2", onUnauthorized });
+    mockOnce(401, { error: "unauthorized" });
+    mockOnce(401, { error: "unauthorized" });
+
+    await expect(client.listMessages("c1")).rejects.toBeInstanceOf(SupportError);
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps a non-OK response to SupportError with otto's code", async () => {
+    const client = newClient();
+    mockOnce(409, { error: "thread_closed", message: "closed" });
+    await expect(client.postMessage("c1", "hi")).rejects.toMatchObject({ status: 409, code: "thread_closed" });
+  });
+
+  it("resume returns null when there is no open thread", async () => {
+    const client = newClient();
+    mockOnce(200, { conversation: null });
+    expect(await client.resume()).toBeNull();
+  });
+
+  it("loads a persisted session token and sends it on the first call", async () => {
+    const client = newClient({ loadSessionToken: () => "persisted-sess" });
+    mockOnce(200, { conversation: { id: "c1", status: "active" }, messages: [] });
+    await client.resume();
+    expect(calls[0].headers["X-Otto-Session"]).toBe("persisted-sess");
+  });
+
+  it("builds the ws url with the ticket query param", () => {
+    const client = newClient();
+    expect(
+      client.buildWsUrl({ ticket: "tk t/1", ws_url: "wss://api.test/api/v1/storefront/otto/conversations/c1/ws" }),
+    ).toBe("wss://api.test/api/v1/storefront/otto/conversations/c1/ws?ticket=tk%20t%2F1");
+  });
+});

--- a/packages/mobile-shared/support/__tests__/client.test.ts
+++ b/packages/mobile-shared/support/__tests__/client.test.ts
@@ -56,10 +56,10 @@ describe("createSupportClient", () => {
 
     expect(out.conversation.id).toBe("c1");
     expect(out.firstMessage.id).toBe("m1");
-    expect(calls[0].method).toBe("POST");
-    expect(calls[0].url).toBe("https://api.test/api/v1/mobile/storefront/stores/acme/support/conversations");
-    expect(calls[0].headers["Authorization"]).toBe("Bearer tok-1");
-    expect(JSON.parse(calls[0].body!)).toMatchObject({ message: "hi", reason: "order_issue", status_info: "late" });
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.url).toBe("https://api.test/api/v1/mobile/storefront/stores/acme/support/conversations");
+    expect(calls[0]!.headers["Authorization"]).toBe("Bearer tok-1");
+    expect(JSON.parse(calls[0]!.body!)).toMatchObject({ message: "hi", reason: "order_issue", status_info: "late" });
     expect(client.currentSessionToken()).toBe("sess-xyz");
     expect(saved).toEqual(["sess-xyz"]);
   });
@@ -72,8 +72,8 @@ describe("createSupportClient", () => {
     mockOnce(201, { message: { id: "m2", sender_type: "customer", body: "again", created_at: "2026-06-21T10:01:00Z" } });
     await client.postMessage("c1", "again");
 
-    expect(calls[1].headers["X-Otto-Session"]).toBe("sess-xyz");
-    expect(calls[1].url).toBe("https://api.test/api/v1/mobile/storefront/stores/acme/support/conversations/c1/messages");
+    expect(calls[1]!.headers["X-Otto-Session"]).toBe("sess-xyz");
+    expect(calls[1]!.url).toBe("https://api.test/api/v1/mobile/storefront/stores/acme/support/conversations/c1/messages");
   });
 
   it("refreshes the token once on 401 then retries", async () => {
@@ -85,7 +85,7 @@ describe("createSupportClient", () => {
     const msgs = await client.listMessages("c1");
     expect(msgs).toEqual([]);
     expect(refreshToken).toHaveBeenCalledTimes(1);
-    expect(calls[1].headers["Authorization"]).toBe("Bearer tok-2");
+    expect(calls[1]!.headers["Authorization"]).toBe("Bearer tok-2");
   });
 
   it("throws SupportError + calls onUnauthorized when refresh still 401s", async () => {
@@ -114,7 +114,7 @@ describe("createSupportClient", () => {
     const client = newClient({ loadSessionToken: () => "persisted-sess" });
     mockOnce(200, { conversation: { id: "c1", status: "active" }, messages: [] });
     await client.resume();
-    expect(calls[0].headers["X-Otto-Session"]).toBe("persisted-sess");
+    expect(calls[0]!.headers["X-Otto-Session"]).toBe("persisted-sess");
   });
 
   it("builds the ws url with the ticket query param", () => {

--- a/packages/mobile-shared/support/__tests__/events.test.ts
+++ b/packages/mobile-shared/support/__tests__/events.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { parseOttoEvent, mergeMessage, mergeMessages } from "../events";
+import type { SupportMessage } from "../types";
+
+const msg = (id: string, at: string): SupportMessage => ({
+  id,
+  sender_type: "customer",
+  sender_name: "Sam",
+  body: "hi",
+  created_at: at,
+});
+
+describe("parseOttoEvent", () => {
+  it("parses a message.created frame", () => {
+    const raw = JSON.stringify({
+      type: "otto.message.created",
+      room: "conv:1",
+      payload: { message: { id: "m1", sender_type: "staff", body: "hello", created_at: "2026-06-21T10:00:00Z" } },
+    });
+    const ev = parseOttoEvent(raw);
+    expect(ev.kind).toBe("message");
+    if (ev.kind === "message") {
+      expect(ev.message.id).toBe("m1");
+      expect(ev.message.sender_type).toBe("staff");
+    }
+  });
+
+  it("parses a conversation.closed frame", () => {
+    const ev = parseOttoEvent(JSON.stringify({ type: "otto.conversation.closed", payload: {} }));
+    expect(ev.kind).toBe("conversation_closed");
+  });
+
+  it("parses conversation.updated with conversation_id", () => {
+    const ev = parseOttoEvent(JSON.stringify({ type: "otto.conversation.updated", payload: { conversation_id: "c9" } }));
+    expect(ev).toEqual({ kind: "conversation_updated", conversationId: "c9" });
+  });
+
+  it("parses conversation.updated with nested conversation object", () => {
+    const ev = parseOttoEvent(JSON.stringify({ type: "otto.conversation.updated", payload: { conversation: { id: "c5" } } }));
+    expect(ev).toEqual({ kind: "conversation_updated", conversationId: "c5" });
+  });
+
+  it("returns unknown for unrecognised type", () => {
+    expect(parseOttoEvent(JSON.stringify({ type: "otto.something.else" })).kind).toBe("unknown");
+  });
+
+  it("returns unknown for malformed JSON", () => {
+    expect(parseOttoEvent("not json").kind).toBe("unknown");
+  });
+
+  it("returns unknown when the message payload is invalid", () => {
+    const ev = parseOttoEvent(JSON.stringify({ type: "otto.message.created", payload: { message: { id: 123 } } }));
+    expect(ev.kind).toBe("unknown");
+  });
+});
+
+describe("mergeMessage", () => {
+  it("appends a new message", () => {
+    const out = mergeMessage([], msg("a", "2026-06-21T10:00:00Z"));
+    expect(out).toHaveLength(1);
+  });
+
+  it("de-duplicates by id", () => {
+    const start = [msg("a", "2026-06-21T10:00:00Z")];
+    const out = mergeMessage(start, msg("a", "2026-06-21T10:00:00Z"));
+    expect(out).toHaveLength(1);
+    expect(out).toBe(start); // unchanged reference when no-op
+  });
+
+  it("keeps messages ordered by created_at", () => {
+    const out = mergeMessages([], [msg("b", "2026-06-21T10:05:00Z"), msg("a", "2026-06-21T10:00:00Z")]);
+    expect(out.map((m) => m.id)).toEqual(["a", "b"]);
+  });
+});

--- a/packages/mobile-shared/support/__tests__/types.test.ts
+++ b/packages/mobile-shared/support/__tests__/types.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import {
+  toCreateBody,
+  SupportConversationSchema,
+  SupportMessageSchema,
+  QueueStateSchema,
+} from "../types";
+
+describe("toCreateBody", () => {
+  it("maps friendly input to otto's wire shape with defaults", () => {
+    expect(toCreateBody({ message: "hi", reason: "billing", statusInfo: "late" })).toEqual({
+      message: "hi",
+      reason: "billing",
+      status_info: "late",
+      subject: "",
+      name: "",
+      email: "",
+      dob: "",
+    });
+  });
+
+  it("passes through optional fields", () => {
+    const out = toCreateBody({
+      message: "m",
+      reason: "order_issue",
+      statusInfo: "s",
+      subject: "Order #5",
+      name: "Sam",
+      email: "s@x.com",
+      dob: "1990-01-01",
+    });
+    expect(out.subject).toBe("Order #5");
+    expect(out.dob).toBe("1990-01-01");
+  });
+});
+
+describe("schemas", () => {
+  it("parses a conversation, keeping unknown fields (passthrough)", () => {
+    const c = SupportConversationSchema.parse({
+      id: "c1",
+      status: "active",
+      unread_count_customer: 2,
+    });
+    expect(c.id).toBe("c1");
+    expect((c as Record<string, unknown>).unread_count_customer).toBe(2);
+    expect(c.case_id).toBe(""); // default applied
+  });
+
+  it("rejects an invalid status", () => {
+    expect(() => SupportConversationSchema.parse({ id: "c1", status: "frozen" })).toThrow();
+  });
+
+  it("parses a message", () => {
+    const m = SupportMessageSchema.parse({
+      id: "m1",
+      sender_type: "system",
+      body: "auto-closed",
+      created_at: "2026-06-21T10:00:00Z",
+    });
+    expect(m.sender_name).toBe("");
+  });
+
+  it("applies queue defaults", () => {
+    const q = QueueStateSchema.parse({ status: "pending" });
+    expect(q.position).toBe(0);
+    expect(q.all_busy).toBe(false);
+  });
+});

--- a/packages/mobile-shared/support/client.ts
+++ b/packages/mobile-shared/support/client.ts
@@ -1,0 +1,203 @@
+// createSupportClient — the shared REST client for the mobile support BFF.
+// Both apps construct it with their own base path + GIP token getters; the
+// only support-specific behaviour lives here, once:
+//   - sends the GIP bearer token (with a single-flight refresh on 401)
+//   - carries the opaque otto session as X-Otto-Session on every call and
+//     captures the fresh token the BFF returns in the create body (the app
+//     can't read otto's HttpOnly cookie), optionally persisting it
+//   - unwraps otto's { conversation } / { messages } / { message } envelopes
+import { z } from "zod";
+
+import {
+  CreateConversationInput,
+  FeedbackInput,
+  QueueStateSchema,
+  SupportConversationSchema,
+  SupportMessageSchema,
+  WsTicketSchema,
+  toCreateBody,
+  type QueueState,
+  type SupportConversation,
+  type SupportMessage,
+  type WsTicket,
+} from "./types";
+
+export class SupportError extends Error {
+  constructor(
+    public status: number,
+    public code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "SupportError";
+  }
+}
+
+export interface SupportClientConfig {
+  /** API origin, e.g. "https://api.mark8ly.com". */
+  baseUrl: string;
+  /**
+   * Path prefix for this surface, e.g.
+   * "/api/v1/mobile/storefront/stores/acme/support" (customer->merchant) or
+   * "/api/v1/mobile/admin/platform-support" (merchant->platform).
+   */
+  basePath: string;
+  /** Returns the cached GIP id_token, or null when signed out. */
+  getToken: () => Promise<string | null>;
+  /** Mints a fresh GIP id_token; called once on a 401 before giving up. */
+  refreshToken?: () => Promise<string | null>;
+  /** Called when a (refreshed) token is still rejected with 401. */
+  onUnauthorized?: () => void | Promise<void>;
+  /** Loads a persisted otto session token on first use (cross-launch resume). */
+  loadSessionToken?: () => Promise<string | null> | string | null;
+  /** Persists the otto session token when otto mints a new one. */
+  saveSessionToken?: (token: string) => Promise<void> | void;
+}
+
+export interface ResumeResult {
+  conversation: SupportConversation;
+  messages: SupportMessage[];
+}
+
+export function createSupportClient(config: SupportClientConfig) {
+  let sessionToken: string | null = null;
+  let sessionLoaded = false;
+
+  async function loadSession(): Promise<string | null> {
+    if (!sessionLoaded) {
+      sessionLoaded = true;
+      if (config.loadSessionToken) {
+        sessionToken = (await config.loadSessionToken()) ?? null;
+      }
+    }
+    return sessionToken;
+  }
+
+  async function rememberSession(token: string): Promise<void> {
+    sessionToken = token;
+    if (config.saveSessionToken) await config.saveSessionToken(token);
+  }
+
+  // Single-flight token refresh — parallel 401s share one refresh call.
+  let inflightRefresh: Promise<string | null> | null = null;
+  function refresh(): Promise<string | null> {
+    if (!config.refreshToken) return Promise.resolve(null);
+    if (!inflightRefresh) {
+      inflightRefresh = config.refreshToken().finally(() => {
+        inflightRefresh = null;
+      });
+    }
+    return inflightRefresh;
+  }
+
+  async function send(token: string | null, method: string, path: string, body?: unknown): Promise<Response> {
+    const session = await loadSession();
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    if (session) headers["X-Otto-Session"] = session;
+    let payload: string | undefined;
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+      payload = JSON.stringify(body);
+    }
+    return fetch(`${config.baseUrl}${config.basePath}${path}`, { method, headers, body: payload });
+  }
+
+  async function request(method: string, path: string, body?: unknown): Promise<any> {
+    let token = await config.getToken();
+    let res = await send(token, method, path, body);
+
+    if (res.status === 401 && token) {
+      const refreshed = await refresh();
+      if (refreshed) {
+        token = refreshed;
+        res = await send(refreshed, method, path, body);
+      }
+      if (res.status === 401) {
+        await config.onUnauthorized?.();
+        throw new SupportError(401, "unauthorized", "Session expired");
+      }
+    }
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ error: "error", message: res.statusText }));
+      throw new SupportError(res.status, err.error ?? "error", err.message ?? res.statusText);
+    }
+
+    if (res.status === 204) return undefined;
+    const data = await res.json();
+    // otto mints the session cookie on create; the BFF surfaces it in the
+    // body as session_token. Capture + persist it for later calls.
+    if (data && typeof data === "object" && typeof data.session_token === "string") {
+      await rememberSession(data.session_token);
+    }
+    return data;
+  }
+
+  return {
+    /** Opens a new conversation and returns it plus the first message. */
+    createConversation: async (
+      input: CreateConversationInput,
+    ): Promise<{ conversation: SupportConversation; firstMessage: SupportMessage }> => {
+      const data = await request("POST", "/conversations", toCreateBody(input));
+      return {
+        conversation: SupportConversationSchema.parse(data.conversation),
+        firstMessage: SupportMessageSchema.parse(data.first_message),
+      };
+    },
+
+    /** Returns the customer's most recent open thread, or null. */
+    resume: async (): Promise<ResumeResult | null> => {
+      const data = await request("GET", "/resume");
+      if (!data || data.conversation == null) return null;
+      return {
+        conversation: SupportConversationSchema.parse(data.conversation),
+        messages: z.array(SupportMessageSchema).parse(data.messages ?? []),
+      };
+    },
+
+    getConversation: async (id: string): Promise<SupportConversation> => {
+      const data = await request("GET", `/conversations/${encodeURIComponent(id)}`);
+      return SupportConversationSchema.parse(data.conversation);
+    },
+
+    listMessages: async (id: string): Promise<SupportMessage[]> => {
+      const data = await request("GET", `/conversations/${encodeURIComponent(id)}/messages`);
+      return z.array(SupportMessageSchema).parse(data.messages ?? []);
+    },
+
+    postMessage: async (id: string, body: string): Promise<SupportMessage> => {
+      const data = await request("POST", `/conversations/${encodeURIComponent(id)}/messages`, { body });
+      return SupportMessageSchema.parse(data.message);
+    },
+
+    close: async (id: string): Promise<SupportConversation> => {
+      const data = await request("POST", `/conversations/${encodeURIComponent(id)}/close`);
+      return SupportConversationSchema.parse(data.conversation);
+    },
+
+    submitFeedback: async (id: string, feedback: FeedbackInput): Promise<SupportConversation> => {
+      const data = await request("POST", `/conversations/${encodeURIComponent(id)}/feedback`, feedback);
+      return SupportConversationSchema.parse(data.conversation);
+    },
+
+    getQueue: async (id: string): Promise<QueueState> => {
+      const data = await request("GET", `/conversations/${encodeURIComponent(id)}/queue`);
+      return QueueStateSchema.parse(data);
+    },
+
+    getWsTicket: async (id: string): Promise<WsTicket> => {
+      const data = await request("POST", `/conversations/${encodeURIComponent(id)}/ws-ticket`);
+      return WsTicketSchema.parse(data);
+    },
+
+    /** Builds the full WebSocket URL (origin + path + ?ticket=). */
+    buildWsUrl: (ticket: WsTicket): string =>
+      `${ticket.ws_url}?ticket=${encodeURIComponent(ticket.ticket)}`,
+
+    /** The currently held otto session token, if any. */
+    currentSessionToken: (): string | null => sessionToken,
+  };
+}
+
+export type SupportClient = ReturnType<typeof createSupportClient>;

--- a/packages/mobile-shared/support/events.ts
+++ b/packages/mobile-shared/support/events.ts
@@ -1,0 +1,69 @@
+// WebSocket event parsing + the pure message-merge reducer. Kept free of
+// React Native imports so it is unit-testable under the node vitest env;
+// the RN socket lifecycle lives in useSupportChat.
+import { SupportMessageSchema, type SupportMessage } from "./types";
+
+// OttoEvent is the normalised form of an otto WebSocket envelope
+// ({type, room, payload}). Unknown/garbage frames collapse to "unknown"
+// so the UI can ignore them safely.
+export type OttoEvent =
+  | { kind: "message"; message: SupportMessage }
+  | { kind: "conversation_updated"; conversationId?: string }
+  | { kind: "conversation_closed" }
+  | { kind: "unknown" };
+
+const UNKNOWN: OttoEvent = { kind: "unknown" };
+
+/** Parses a raw WebSocket frame into a typed OttoEvent. */
+export function parseOttoEvent(raw: string): OttoEvent {
+  let env: unknown;
+  try {
+    env = JSON.parse(raw);
+  } catch {
+    return UNKNOWN;
+  }
+  if (!env || typeof env !== "object") return UNKNOWN;
+  const e = env as { type?: unknown; payload?: unknown };
+  const payload = (e.payload ?? {}) as Record<string, unknown>;
+
+  switch (e.type) {
+    case "otto.message.created": {
+      const parsed = SupportMessageSchema.safeParse(payload.message);
+      return parsed.success ? { kind: "message", message: parsed.data } : UNKNOWN;
+    }
+    case "otto.conversation.closed":
+      return { kind: "conversation_closed" };
+    case "otto.conversation.updated": {
+      const conv = payload.conversation as { id?: string } | undefined;
+      const conversationId =
+        (typeof payload.conversation_id === "string" ? payload.conversation_id : undefined) ??
+        conv?.id;
+      return { kind: "conversation_updated", conversationId };
+    }
+    default:
+      return UNKNOWN;
+  }
+}
+
+/**
+ * Appends a message, de-duplicating by id (the sender sees their own
+ * message optimistically AND echoed back over the socket) and keeping the
+ * list ordered by created_at.
+ */
+export function mergeMessage(
+  messages: SupportMessage[],
+  incoming: SupportMessage,
+): SupportMessage[] {
+  if (messages.some((m) => m.id === incoming.id)) return messages;
+  const next = [...messages, incoming];
+  next.sort((a, b) => (a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0));
+  return next;
+}
+
+/** Merges a batch (initial history / resume) into existing messages. */
+export function mergeMessages(
+  messages: SupportMessage[],
+  batch: SupportMessage[],
+): SupportMessage[] {
+  return batch.reduce(mergeMessage, messages);
+}

--- a/packages/mobile-shared/support/index.ts
+++ b/packages/mobile-shared/support/index.ts
@@ -3,3 +3,4 @@ export * from "./types";
 export * from "./events";
 export * from "./client";
 export * from "./useSupportChat";
+export * from "./SupportChatView";

--- a/packages/mobile-shared/support/index.ts
+++ b/packages/mobile-shared/support/index.ts
@@ -1,0 +1,5 @@
+// Barrel for the shared mobile support-chat module.
+export * from "./types";
+export * from "./events";
+export * from "./client";
+export * from "./useSupportChat";

--- a/packages/mobile-shared/support/types.ts
+++ b/packages/mobile-shared/support/types.ts
@@ -1,0 +1,90 @@
+// Shared support-chat types + Zod schemas, used by both the storefront
+// (customer->merchant) and admin (merchant->platform) mobile apps. The
+// shapes mirror the otto service responses relayed by the marketplace-api
+// support BFF; schemas are lenient (passthrough) on the conversation so a
+// future otto field addition doesn't break parsing.
+import { z } from "zod";
+
+export const SupportSenderTypeSchema = z.enum(["customer", "staff", "system"]);
+export type SupportSenderType = z.infer<typeof SupportSenderTypeSchema>;
+
+export const SupportStatusSchema = z.enum(["pending", "active", "closed"]);
+export type SupportStatus = z.infer<typeof SupportStatusSchema>;
+
+export const SupportMessageSchema = z.object({
+  id: z.string(),
+  conversation_id: z.string().optional(),
+  sender_type: SupportSenderTypeSchema,
+  sender_name: z.string().optional().default(""),
+  body: z.string(),
+  created_at: z.string(),
+});
+export type SupportMessage = z.infer<typeof SupportMessageSchema>;
+
+export const SupportConversationSchema = z
+  .object({
+    id: z.string(),
+    case_id: z.string().optional().default(""),
+    status: SupportStatusSchema,
+    subject: z.string().optional().default(""),
+    created_at: z.string().optional(),
+    closed_at: z.string().optional(),
+  })
+  .passthrough();
+export type SupportConversation = z.infer<typeof SupportConversationSchema>;
+
+export const QueueStateSchema = z.object({
+  status: SupportStatusSchema,
+  position: z.number().default(0),
+  total_pending: z.number().default(0),
+  estimated_wait_seconds: z.number().default(0),
+  all_busy: z.boolean().default(false),
+});
+export type QueueState = z.infer<typeof QueueStateSchema>;
+
+export const WsTicketSchema = z.object({
+  ticket: z.string(),
+  ws_url: z.string(),
+});
+export type WsTicket = z.infer<typeof WsTicketSchema>;
+
+/** An intake reason offered before the first message is sent. */
+export interface IntakeReason {
+  value: string;
+  label: string;
+  /** When false, the free-text "what's going on" field is optional. */
+  requiresStatus?: boolean;
+}
+
+/** Input for opening a new support conversation. */
+export interface CreateConversationInput {
+  message: string;
+  reason: string;
+  statusInfo: string;
+  subject?: string;
+  name?: string;
+  email?: string;
+  /** Required by otto only for order/account-related reasons. */
+  dob?: string;
+}
+
+/** Post-case survey payload. */
+export interface FeedbackInput {
+  call_rating: number;
+  query_resolved: boolean;
+  staff_rating: number;
+  comments?: string;
+}
+
+/** Maps the friendly input onto otto's create wire shape. */
+export function toCreateBody(input: CreateConversationInput): Record<string, unknown> {
+  return {
+    message: input.message,
+    reason: input.reason,
+    status_info: input.statusInfo,
+    subject: input.subject ?? "",
+    name: input.name ?? "",
+    email: input.email ?? "",
+    dob: input.dob ?? "",
+  };
+}

--- a/packages/mobile-shared/support/useSupportChat.ts
+++ b/packages/mobile-shared/support/useSupportChat.ts
@@ -1,0 +1,250 @@
+// useSupportChat — the React Native hook that drives a live support thread:
+// resume-or-create, load history, open the otto WebSocket with reconnect +
+// app-state handling, and append incoming messages. Shared verbatim by the
+// storefront (customer->merchant) and admin (merchant->platform) apps; only
+// the SupportClient passed in differs.
+//
+// Pure logic (event parsing, message merge, request shaping) lives in the
+// sibling modules so it can be unit-tested without an RN runtime; this file
+// is the thin RN-bound glue.
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AppState, type AppStateStatus } from "react-native";
+
+import type { SupportClient } from "./client";
+import { mergeMessage, mergeMessages, parseOttoEvent } from "./events";
+import type { CreateConversationInput, SupportConversation, SupportMessage } from "./types";
+
+export type SupportChatStatus =
+  | "idle"
+  | "loading"
+  | "connecting"
+  | "ready"
+  | "closed"
+  | "error";
+
+export interface UseSupportChatOptions {
+  client: SupportClient;
+  /** Resume the customer's open thread on mount. Default true. */
+  autoResume?: boolean;
+}
+
+export interface UseSupportChat {
+  conversation: SupportConversation | null;
+  messages: SupportMessage[];
+  status: SupportChatStatus;
+  connected: boolean;
+  error: string | null;
+  startConversation: (input: CreateConversationInput) => Promise<void>;
+  sendMessage: (body: string) => Promise<void>;
+  closeConversation: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const MAX_BACKOFF_MS = 15_000;
+
+export function useSupportChat({ client, autoResume = true }: UseSupportChatOptions): UseSupportChat {
+  const [conversation, setConversation] = useState<SupportConversation | null>(null);
+  const [messages, setMessages] = useState<SupportMessage[]>([]);
+  const [status, setStatus] = useState<SupportChatStatus>("idle");
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const socketRef = useRef<WebSocket | null>(null);
+  const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const attemptsRef = useRef(0);
+  const closedByUsRef = useRef(false);
+  const convIdRef = useRef<string | null>(null);
+
+  const clearReconnect = () => {
+    if (reconnectRef.current) {
+      clearTimeout(reconnectRef.current);
+      reconnectRef.current = null;
+    }
+  };
+
+  const teardownSocket = useCallback(() => {
+    closedByUsRef.current = true;
+    clearReconnect();
+    if (socketRef.current) {
+      socketRef.current.close();
+      socketRef.current = null;
+    }
+    setConnected(false);
+  }, []);
+
+  const connect = useCallback(
+    async (conversationId: string) => {
+      // Closed threads don't get a socket — they're read-only.
+      closedByUsRef.current = false;
+      try {
+        const ticket = await client.getWsTicket(conversationId);
+        if (closedByUsRef.current) return;
+        const ws = new WebSocket(client.buildWsUrl(ticket));
+        socketRef.current = ws;
+
+        ws.onopen = () => {
+          attemptsRef.current = 0;
+          setConnected(true);
+          setStatus("ready");
+        };
+        ws.onmessage = (ev: { data: string }) => {
+          const event = parseOttoEvent(typeof ev.data === "string" ? ev.data : "");
+          if (event.kind === "message") {
+            setMessages((prev) => mergeMessage(prev, event.message));
+          } else if (event.kind === "conversation_closed") {
+            setStatus("closed");
+            setConversation((prev) => (prev ? { ...prev, status: "closed" } : prev));
+            teardownSocket();
+          }
+        };
+        ws.onerror = () => {
+          setConnected(false);
+        };
+        ws.onclose = () => {
+          setConnected(false);
+          socketRef.current = null;
+          if (closedByUsRef.current) return;
+          // Reconnect with capped exponential backoff.
+          const attempt = (attemptsRef.current += 1);
+          const delay = Math.min(MAX_BACKOFF_MS, 1000 * 2 ** (attempt - 1));
+          clearReconnect();
+          reconnectRef.current = setTimeout(() => {
+            if (convIdRef.current) void connect(convIdRef.current);
+          }, delay);
+        };
+      } catch {
+        // Ticket mint failed (e.g. offline) — retry on a backoff.
+        const attempt = (attemptsRef.current += 1);
+        const delay = Math.min(MAX_BACKOFF_MS, 1000 * 2 ** (attempt - 1));
+        clearReconnect();
+        reconnectRef.current = setTimeout(() => {
+          if (convIdRef.current) void connect(convIdRef.current);
+        }, delay);
+      }
+    },
+    [client, teardownSocket],
+  );
+
+  const adoptConversation = useCallback(
+    async (conv: SupportConversation, initial: SupportMessage[]) => {
+      setConversation(conv);
+      setMessages((prev) => mergeMessages(prev, initial));
+      convIdRef.current = conv.id;
+      if (conv.status === "closed") {
+        setStatus("closed");
+        teardownSocket();
+        return;
+      }
+      setStatus("connecting");
+      await connect(conv.id);
+    },
+    [connect, teardownSocket],
+  );
+
+  const refresh = useCallback(async () => {
+    if (!convIdRef.current) return;
+    try {
+      const [conv, msgs] = await Promise.all([
+        client.getConversation(convIdRef.current),
+        client.listMessages(convIdRef.current),
+      ]);
+      setConversation(conv);
+      setMessages((prev) => mergeMessages(prev, msgs));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "refresh failed");
+    }
+  }, [client]);
+
+  const startConversation = useCallback(
+    async (input: CreateConversationInput) => {
+      setStatus("loading");
+      setError(null);
+      try {
+        const { conversation: conv, firstMessage } = await client.createConversation(input);
+        await adoptConversation(conv, [firstMessage]);
+      } catch (e) {
+        setStatus("error");
+        setError(e instanceof Error ? e.message : "could not start chat");
+        throw e;
+      }
+    },
+    [client, adoptConversation],
+  );
+
+  const sendMessage = useCallback(
+    async (body: string) => {
+      const id = convIdRef.current;
+      if (!id) return;
+      // Optimistic append; the socket echo is de-duplicated by id.
+      const sent = await client.postMessage(id, body);
+      setMessages((prev) => mergeMessage(prev, sent));
+    },
+    [client],
+  );
+
+  const closeConversation = useCallback(async () => {
+    const id = convIdRef.current;
+    if (!id) return;
+    const conv = await client.close(id);
+    setConversation(conv);
+    setStatus("closed");
+    teardownSocket();
+  }, [client, teardownSocket]);
+
+  // Resume on mount.
+  useEffect(() => {
+    let cancelled = false;
+    if (!autoResume) {
+      setStatus("idle");
+      return;
+    }
+    setStatus("loading");
+    client
+      .resume()
+      .then((res) => {
+        if (cancelled) return;
+        if (res) {
+          void adoptConversation(res.conversation, res.messages);
+        } else {
+          setStatus("idle");
+        }
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setStatus("idle"); // no open thread is not an error to the user
+        setError(e instanceof Error ? e.message : null);
+      });
+    return () => {
+      cancelled = true;
+      teardownSocket();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Reconnect when the app returns to the foreground; the OS suspends
+  // sockets in the background.
+  useEffect(() => {
+    const onChange = (next: AppStateStatus) => {
+      if (next === "active" && convIdRef.current && !socketRef.current) {
+        const conv = conversation;
+        if (!conv || conv.status !== "closed") {
+          void connect(convIdRef.current);
+        }
+      }
+    };
+    const sub = AppState.addEventListener("change", onChange);
+    return () => sub.remove();
+  }, [connect, conversation]);
+
+  return {
+    conversation,
+    messages,
+    status,
+    connected,
+    error,
+    startConversation,
+    sendMessage,
+    closeConversation,
+    refresh,
+  };
+}

--- a/packages/mobile-shared/support/useSupportChat.ts
+++ b/packages/mobile-shared/support/useSupportChat.ts
@@ -87,8 +87,9 @@ export function useSupportChat({ client, autoResume = true }: UseSupportChatOpti
           setConnected(true);
           setStatus("ready");
         };
-        ws.onmessage = (ev: { data: string }) => {
-          const event = parseOttoEvent(typeof ev.data === "string" ? ev.data : "");
+        ws.onmessage = (ev) => {
+          const data = (ev as { data?: unknown }).data;
+          const event = parseOttoEvent(typeof data === "string" ? data : "");
           if (event.kind === "message") {
             setMessages((prev) => mergeMessage(prev, event.message));
           } else if (event.kind === "conversation_closed") {

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -962,6 +962,16 @@ func main() {
 		}
 	}
 
+	// Shared otto chat client (S2S) — nil when OTTO_URL/OTTO_INTERNAL_AUTH
+	// are unset (local dev without otto). Reused by the ticket transcript
+	// pull, the admin platform-support bridge (#119), and the storefront
+	// support bridge (#118).
+	ottoChatClient := ottoclient.New(cfg.OttoURL, cfg.OttoInternalAuth)
+	// Mobile storefront support chat (#118) — populated in the storefront
+	// wiring block, mounted in the per-mode registration below.
+	var storefrontSupportHandler *storefront.MobileSupportHandler
+	var storefrontCustomerVerifier storefront.CustomerVerifier
+
 	// Mobile admin deps — Bearer auth for external mobile clients.
 	var mobileDeps admin.MobileDeps
 	var pushWebhookHandler gin.HandlerFunc
@@ -991,6 +1001,9 @@ func main() {
 			Deps:             adminDeps,
 			TokenVerifier:    tokenVerifier,
 			PushTokenHandler: pushTokenHandler,
+			// Merchant→platform support chat (#119) — bridges to otto's
+			// platform tenant. Nil otto client => routes return 503.
+			PlatformSupportHandler: admin.NewPlatformSupportHandler(ottoChatClient, cfg.OttoWSPublicBase, log),
 		}
 	}
 
@@ -1139,11 +1152,25 @@ func main() {
 		// OTTO_URL / OTTO_INTERNAL_AUTH are unset (typical for local
 		// dev without otto running) the constructor returns nil and the
 		// transcript endpoint cleanly degrades to 404.
-		ottoSupportClient := ottoclient.New(cfg.OttoURL, cfg.OttoInternalAuth)
 		sfTicketsHandler := storefront.NewTicketsHandler(ticketSvc, log).
 			WithNotifier(notificationSvc).
 			WithAudit(auditEmitter).
-			WithOtto(ottoSupportClient)
+			WithOtto(ottoChatClient)
+
+		// Mobile support chat (#118) — customer→merchant, bridges to otto.
+		// Mounted standalone below (the full mobile storefront route group
+		// isn't wired yet). The customer verifier reuses the GIP project to
+		// validate the app's Firebase ID tokens.
+		storefrontSupportHandler = storefront.NewMobileSupportHandler(ottoChatClient, cfg.OttoWSPublicBase, log)
+		if cfg.GIPProjectID != "" {
+			if fbApp, err := firebase.NewApp(context.Background(), &firebase.Config{ProjectID: cfg.GIPProjectID}); err != nil {
+				log.Error("mobile support: firebase init failed", "error", err)
+			} else if fbAuth, err := fbApp.Auth(context.Background()); err != nil {
+				log.Error("mobile support: firebase auth init failed", "error", err)
+			} else {
+				storefrontCustomerVerifier = storefront.NewGIPCustomerVerifier(fbAuth)
+			}
+		}
 
 		// P11 — Customer portal (GDPR order-history + erasure §15.4).
 		customerPortalHandler := customerportal.NewHandler(conn, log)
@@ -1702,6 +1729,7 @@ func main() {
 		admin.RegisterAdmin(r.Group("/api/v1"), adminDeps)
 		admin.RegisterAdminMobile(r.Group("/api/v1"), mobileDeps)
 		storefront.RegisterStorefront(r.Group("/api/v1"), storefrontDeps)
+		storefront.RegisterMobileStorefrontSupport(r.Group("/api/v1"), storefrontSupportHandler, storefrontDeps.SlugCache, storefrontCustomerVerifier)
 		public.RegisterPublic(r.Group("/api/v1"), public.PublicDeps{
 			DelhiveryWebhookHandler: delhiveryWebhookHandler,
 		})
@@ -1818,6 +1846,7 @@ func main() {
 		}
 		if m == mode.Storefront {
 			storefront.RegisterStorefront(engine.Group("/api/v1"), storefrontDeps)
+			storefront.RegisterMobileStorefrontSupport(engine.Group("/api/v1"), storefrontSupportHandler, storefrontDeps.SlugCache, storefrontCustomerVerifier)
 			// Custom-domain takeover — storefront middleware queries
 			// this on every slug-host request to decide whether to 301
 			// to the merchant's verified custom domain.

--- a/services/marketplace-api/internal/handlers/admin/mobile_routes.go
+++ b/services/marketplace-api/internal/handlers/admin/mobile_routes.go
@@ -12,6 +12,9 @@ type MobileDeps struct {
 	Deps
 	TokenVerifier    auth.TokenVerifier
 	PushTokenHandler *PushTokenHandler
+	// PlatformSupportHandler bridges merchant→platform support chat to
+	// otto's platform tenant. Nil when otto isn't wired.
+	PlatformSupportHandler *PlatformSupportHandler
 }
 
 // RegisterAdminMobile mounts the mobile admin route group. Uses GIPBearerAuth
@@ -24,6 +27,14 @@ func RegisterAdminMobile(router *gin.RouterGroup, deps MobileDeps) {
 
 	bearerAuth := auth.GIPBearerAuth(deps.TokenVerifier)
 	rateLimiter := auth.NewPerUserRateLimiter(60, 10) // 60 req/min, burst 10
+
+	// Platform support chat — merchant admin → Tesserix platform team.
+	// Not store-scoped: it rides the admin's tenant from the bearer token,
+	// so any authenticated merchant admin can open a platform chat.
+	if deps.PlatformSupportHandler != nil {
+		ps := router.Group("/mobile/admin/platform-support", bearerAuth, rateLimiter)
+		deps.PlatformSupportHandler.Register(ps)
+	}
 
 	// Tenant-wide routes
 	if deps.StoresHandler != nil {

--- a/services/marketplace-api/internal/handlers/admin/platform_support.go
+++ b/services/marketplace-api/internal/handlers/admin/platform_support.go
@@ -1,0 +1,54 @@
+// Package admin — platform_support.go: PlatformSupportHandler exposes the
+// mobile admin merchant→platform support-chat routes, bridging to otto's
+// fixed "platform" tenant (the same surface the web admin PlatformChat
+// uses). A Tesserix employee picks the chat up from the platform-support
+// inbox. The merchant's own tenant is carried as X-Client-Tenant-* so the
+// agent can see which merchant is talking.
+package admin
+
+import (
+	"log/slog"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/marketplace-api/internal/ottobridge"
+	"github.com/mark8ly/marketplace-api/internal/ottoclient"
+)
+
+// Platform support pins to a single deterministic tenant/store on otto:
+// every merchant talks to the same Tesserix support surface, so there's no
+// per-merchant store row to invent.
+const (
+	platformTenantID = "platform"
+	platformStoreID  = "default"
+)
+
+// PlatformSupportHandler exposes the mobile admin /platform-support/* routes.
+type PlatformSupportHandler struct {
+	bridge *ottobridge.Bridge
+}
+
+// NewPlatformSupportHandler builds the handler. otto may be nil (not wired
+// in local dev) — every route then returns 503.
+func NewPlatformSupportHandler(otto *ottoclient.Client, wsPublicBase string, logger *slog.Logger) *PlatformSupportHandler {
+	return &PlatformSupportHandler{bridge: ottobridge.New(otto, wsPublicBase, logger)}
+}
+
+// Register mounts the platform-support routes onto g. The group MUST
+// already have the admin GIP bearer auth (sets "user_id" + "tenant_id").
+func (h *PlatformSupportHandler) Register(g *gin.RouterGroup) {
+	h.bridge.Mount(g, platformResolver)
+}
+
+// platformResolver pins the otto scope to the platform tenant and forwards
+// the admin's identity. The admin is otto's "customer" here; their own
+// (merchant) tenant rides along as X-Client-Tenant-Id so the platform
+// agent sees who raised the chat.
+func platformResolver(c *gin.Context) (ottoclient.ForwardScope, ottoclient.ForwardIdentity, bool) {
+	return ottoclient.ForwardScope{TenantID: platformTenantID, StoreID: platformStoreID},
+		ottoclient.ForwardIdentity{
+			UserID:         c.GetString("user_id"),
+			ClientTenantID: c.GetString("tenant_id"),
+		},
+		true
+}

--- a/services/marketplace-api/internal/handlers/admin/platform_support_test.go
+++ b/services/marketplace-api/internal/handlers/admin/platform_support_test.go
@@ -1,0 +1,58 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/marketplace-api/internal/ottoclient"
+)
+
+// TestPlatformSupport_PinsPlatformTenantAndAttributesMerchant covers #119:
+// a merchant admin opens a platform chat. The bridge must pin otto to the
+// platform tenant/store and carry the merchant's own tenant as
+// X-Client-Tenant-Id so the Tesserix agent sees who is talking.
+func TestPlatformSupport_PinsPlatformTenantAndAttributesMerchant(t *testing.T) {
+	var sawTenant, sawStore, sawUser, sawClientTenant string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawTenant = r.Header.Get("X-Tenant-Id")
+		sawStore = r.Header.Get("X-Store-Id")
+		sawUser = r.Header.Get("X-User-Id")
+		sawClientTenant = r.Header.Get("X-Client-Tenant-Id")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"conversation":{"id":"p1"}}`))
+	}))
+	defer srv.Close()
+
+	gin.SetMode(gin.TestMode)
+	h := NewPlatformSupportHandler(ottoclient.New(srv.URL, "secret"), "wss://api.test", nil)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		// Simulates the admin GIP bearer auth middleware.
+		c.Set("user_id", "admin-1")
+		c.Set("tenant_id", "merchant-9")
+		c.Next()
+	})
+	h.Register(r.Group("/platform-support"))
+
+	rec := httptest.NewRecorder()
+	body := `{"message":"billing help","reason":"billing","status_info":"x"}`
+	req, _ := http.NewRequest(http.MethodPost, "/platform-support/conversations", strings.NewReader(body))
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("code=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if sawTenant != "platform" || sawStore != "default" {
+		t.Errorf("scope: tenant=%q store=%q, want platform/default", sawTenant, sawStore)
+	}
+	if sawUser != "admin-1" {
+		t.Errorf("X-User-Id=%q, want admin-1", sawUser)
+	}
+	if sawClientTenant != "merchant-9" {
+		t.Errorf("X-Client-Tenant-Id=%q, want merchant-9", sawClientTenant)
+	}
+}

--- a/services/marketplace-api/internal/handlers/storefront/gip_customer_verifier.go
+++ b/services/marketplace-api/internal/handlers/storefront/gip_customer_verifier.go
@@ -1,0 +1,55 @@
+// Package storefront — gip_customer_verifier.go: production CustomerVerifier
+// backed by the Firebase Admin Auth client. Mirrors auth.GIPVerifier (used
+// by the admin mobile group) but projects the claims the storefront needs —
+// the GIP UID and the verified email — instead of the tenant claim.
+package storefront
+
+import (
+	"context"
+	"errors"
+
+	firebaseAuth "firebase.google.com/go/v4/auth"
+	"github.com/gin-gonic/gin"
+)
+
+// GIPCustomerVerifier verifies storefront customer GIP ID tokens.
+type GIPCustomerVerifier struct {
+	client *firebaseAuth.Client
+}
+
+// NewGIPCustomerVerifier builds a verifier from a Firebase Auth client.
+func NewGIPCustomerVerifier(client *firebaseAuth.Client) *GIPCustomerVerifier {
+	return &GIPCustomerVerifier{client: client}
+}
+
+// VerifyCustomerToken validates the token signature and returns the GIP UID
+// + email. The UID is otto's customer identity (skips the OTP step) and the
+// email is forwarded so staff see who they're talking to.
+func (v *GIPCustomerVerifier) VerifyCustomerToken(idToken string) (gipUID, email string, err error) {
+	token, err := v.client.VerifyIDToken(context.Background(), idToken)
+	if err != nil {
+		return "", "", err
+	}
+	if token.UID == "" {
+		return "", "", errors.New("token missing uid")
+	}
+	email, _ = token.Claims["email"].(string)
+	return token.UID, email, nil
+}
+
+// RegisterMobileStorefrontSupport mounts ONLY the support-chat routes under
+// /mobile/storefront/stores/:storeSlug/support with the store-context +
+// customer-auth middleware. It exists so the support feature can ship
+// before the full mobile storefront route group (RegisterMobileStorefront)
+// is wired. When that group is mounted, drop this call to avoid a duplicate
+// registration (support is also wired inside RegisterMobileStorefront).
+func RegisterMobileStorefrontSupport(router *gin.RouterGroup, h *MobileSupportHandler, slug SlugLookup, verifier CustomerVerifier) {
+	if h == nil || verifier == nil {
+		return
+	}
+	grp := router.Group("/mobile/storefront/stores/:storeSlug/support",
+		StoreContext(slug),
+		MobileCustomerAuth(verifier),
+	)
+	h.Register(grp)
+}

--- a/services/marketplace-api/internal/handlers/storefront/mobile_routes.go
+++ b/services/marketplace-api/internal/handlers/storefront/mobile_routes.go
@@ -39,8 +39,10 @@ type MobileDeps struct {
 	// Mobile-specific.
 	PushTokenHandler *PushTokenHandler
 	NotifyMeHandler  *NotifyMeHandler
-	DevMode          bool
-	Logger           *slog.Logger
+	// Support chat — bridges to the otto service (customer→merchant).
+	SupportHandler *MobileSupportHandler
+	DevMode        bool
+	Logger         *slog.Logger
 }
 
 // RegisterMobileStorefront mounts the mobile storefront routes on the given
@@ -191,6 +193,13 @@ func RegisterMobileStorefront(router *gin.RouterGroup, deps MobileDeps) {
 			if deps.NotifyMeHandler != nil {
 				authed.POST("/products/:handle/notify-me", deps.NotifyMeHandler.Subscribe)
 				authed.DELETE("/products/:handle/notify-me/:notifyType", deps.NotifyMeHandler.Unsubscribe)
+			}
+
+			// Support chat — bridges to otto (customer→merchant). Mounted
+			// under the authed group so every conversation is attributed to
+			// the logged-in customer and otto skips the anonymous OTP step.
+			if deps.SupportHandler != nil {
+				deps.SupportHandler.Register(authed.Group("/support"))
 			}
 		}
 	}

--- a/services/marketplace-api/internal/handlers/storefront/support.go
+++ b/services/marketplace-api/internal/handlers/storefront/support.go
@@ -1,0 +1,54 @@
+// Package storefront — support.go: MobileSupportHandler exposes the mobile
+// storefront support-chat routes (customer→merchant), bridging to the otto
+// service via the shared ottobridge. The web storefront reaches otto
+// through a Next.js proxy; mobile authenticates with a GIP bearer token, so
+// this is the server-side equivalent — it resolves the store scope + the
+// verified customer identity and lets the bridge do the rest.
+package storefront
+
+import (
+	"log/slog"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/marketplace-api/internal/ottobridge"
+	"github.com/mark8ly/marketplace-api/internal/ottoclient"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+)
+
+// MobileSupportHandler exposes the mobile storefront /support/* routes.
+type MobileSupportHandler struct {
+	bridge *ottobridge.Bridge
+}
+
+// NewMobileSupportHandler builds the handler. otto may be nil (otto not
+// wired in local dev) — every route then returns 503. wsPublicBase is the
+// public WebSocket origin the app dials, e.g. "wss://api.mark8ly.com".
+func NewMobileSupportHandler(otto *ottoclient.Client, wsPublicBase string, logger *slog.Logger) *MobileSupportHandler {
+	return &MobileSupportHandler{bridge: ottobridge.New(otto, wsPublicBase, logger)}
+}
+
+// Register mounts the support routes onto g. The group MUST already have
+// StoreContext (so "store" is set) and the customer-identity middleware
+// applied.
+func (h *MobileSupportHandler) Register(g *gin.RouterGroup) {
+	h.bridge.Mount(g, storefrontResolver)
+}
+
+// storefrontResolver maps the resolved store + verified customer onto the
+// otto scope/identity. A non-empty UserID makes otto skip the anonymous
+// OTP step for the logged-in customer.
+func storefrontResolver(c *gin.Context) (ottoclient.ForwardScope, ottoclient.ForwardIdentity, bool) {
+	v, exists := c.Get("store")
+	s, isStore := v.(*stores.Store)
+	if !exists || !isStore || s == nil {
+		c.JSON(500, gin.H{"error": "store_unresolved"})
+		return ottoclient.ForwardScope{}, ottoclient.ForwardIdentity{}, false
+	}
+	return ottoclient.ForwardScope{TenantID: s.TenantID, StoreID: s.ID},
+		ottoclient.ForwardIdentity{
+			UserID:    c.GetString(CustomerGipUIDKey),
+			UserEmail: c.GetString(CustomerEmailKey),
+		},
+		true
+}

--- a/services/marketplace-api/internal/handlers/storefront/support_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/support_test.go
@@ -1,0 +1,163 @@
+package storefront
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/marketplace-api/internal/ottoclient"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+)
+
+// newSupportTestRig wires a gin engine whose routes are guarded by a stub
+// middleware that mimics StoreContext + mobileCustomerProfileMW (sets the
+// resolved store + verified customer identity on the context), pointed at
+// a fake otto server. Returns the engine and a pointer the fake otto
+// handler reads, so each test can assert on what otto received.
+func newSupportTestRig(t *testing.T, otto http.HandlerFunc) (*gin.Engine, func()) {
+	t.Helper()
+	srv := httptest.NewServer(otto)
+	gin.SetMode(gin.TestMode)
+	h := NewMobileSupportHandler(ottoclient.New(srv.URL, "secret"), "wss://api.test", nil)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("store", &stores.Store{ID: "store-1", TenantID: "tenant-1", Status: stores.StatusActive})
+		c.Set(CustomerGipUIDKey, "gip-abc")
+		c.Set(CustomerEmailKey, "buyer@example.com")
+		c.Next()
+	})
+	grp := r.Group("/support")
+	h.Register(grp)
+	return r, srv.Close
+}
+
+func TestSupport_Create_ForwardsScopeAndMergesSessionToken(t *testing.T) {
+	var sawTenant, sawStore, sawUser string
+	var sawBody string
+	r, closeFn := newSupportTestRig(t, func(w http.ResponseWriter, req *http.Request) {
+		sawTenant = req.Header.Get("X-Tenant-Id")
+		sawStore = req.Header.Get("X-Store-Id")
+		sawUser = req.Header.Get("X-User-Id")
+		b, _ := io.ReadAll(req.Body)
+		sawBody = string(b)
+		http.SetCookie(w, &http.Cookie{Name: "otto_session", Value: "sess-xyz", Path: "/"})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"conversation":{"id":"c1","case_id":"CS-1"},"first_message":{"id":"m1"}}`))
+	})
+	defer closeFn()
+
+	rec := httptest.NewRecorder()
+	body := `{"message":"hi","reason":"order_issue","status_info":"late","name":"Sam","email":"buyer@example.com"}`
+	req, _ := http.NewRequest(http.MethodPost, "/support/conversations", strings.NewReader(body))
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if sawTenant != "tenant-1" || sawStore != "store-1" {
+		t.Errorf("scope headers: tenant=%q store=%q", sawTenant, sawStore)
+	}
+	if sawUser != "gip-abc" {
+		t.Errorf("X-User-Id = %q, want gip-abc (skips OTP)", sawUser)
+	}
+	if !strings.Contains(sawBody, `"reason":"order_issue"`) {
+		t.Errorf("body not forwarded verbatim: %q", sawBody)
+	}
+	// The session token otto minted via Set-Cookie must be surfaced to the
+	// app in the JSON body (the app can't read the HttpOnly cookie).
+	var out map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out["session_token"] != "sess-xyz" {
+		t.Errorf("session_token = %v, want sess-xyz", out["session_token"])
+	}
+	if _, ok := out["conversation"]; !ok {
+		t.Errorf("conversation missing from relayed body")
+	}
+	if rec.Header().Get("X-Otto-Session") != "sess-xyz" {
+		t.Errorf("X-Otto-Session header not set")
+	}
+}
+
+func TestSupport_PostMessage_ForwardsSessionHeaderAndId(t *testing.T) {
+	var sawSession, sawPath string
+	r, closeFn := newSupportTestRig(t, func(w http.ResponseWriter, req *http.Request) {
+		sawSession = req.Header.Get("X-Otto-Session")
+		sawPath = req.URL.Path
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"message":{"id":"m2"}}`))
+	})
+	defer closeFn()
+
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/support/conversations/c1/messages", strings.NewReader(`{"body":"hello"}`))
+	req.Header.Set("X-Otto-Session", "sess-xyz")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if sawSession != "sess-xyz" {
+		t.Errorf("X-Otto-Session forwarded = %q", sawSession)
+	}
+	if !strings.HasSuffix(sawPath, "/api/v1/storefront/otto/conversations/c1/messages") {
+		t.Errorf("path = %q", sawPath)
+	}
+}
+
+func TestSupport_WsTicket_AugmentsWithWsURL(t *testing.T) {
+	r, closeFn := newSupportTestRig(t, func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ticket":"tkt-123"}`))
+	})
+	defer closeFn()
+
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/support/conversations/c1/ws-ticket", nil)
+	req.Header.Set("X-Otto-Session", "sess-xyz")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Ticket string `json:"ticket"`
+		WsURL  string `json:"ws_url"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Ticket != "tkt-123" {
+		t.Errorf("ticket = %q", out.Ticket)
+	}
+	want := "wss://api.test/api/v1/storefront/otto/conversations/c1/ws"
+	if out.WsURL != want {
+		t.Errorf("ws_url = %q, want %q", out.WsURL, want)
+	}
+}
+
+func TestSupport_NilClient_ReturnsUnavailable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewMobileSupportHandler(nil, "", nil)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("store", &stores.Store{ID: "s", TenantID: "t", Status: stores.StatusActive})
+		c.Next()
+	})
+	h.Register(r.Group("/support"))
+
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/support/resume", nil)
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rec.Code)
+	}
+}

--- a/services/marketplace-api/internal/ottobridge/bridge.go
+++ b/services/marketplace-api/internal/ottobridge/bridge.go
@@ -1,0 +1,198 @@
+// Package ottobridge mounts the mobile-facing support-chat routes that
+// proxy to the otto service. Both the storefront (customer→merchant) and
+// the admin (merchant→platform) surfaces share the exact same wire shape
+// with otto — only the tenant/store scope + caller identity differ — so
+// the proxy, session-token handling, and ws-ticket augmentation live here
+// once and each surface supplies a small Resolver for its scope/identity.
+//
+// otto's session cookie is HttpOnly, so a native app can't read it. On
+// create, otto mints the cookie; the bridge lifts the token out of the
+// Set-Cookie header into the JSON body as "session_token" (and echoes it
+// as an X-Otto-Session response header). The app stores it and sends it
+// back as X-Otto-Session on every later call, which otto accepts in lieu
+// of the cookie.
+package ottobridge
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/marketplace-api/internal/ottoclient"
+)
+
+// maxBody caps request/relayed bodies — chat payloads are small.
+const maxBody = 1 << 20
+
+// Resolver extracts the otto scope + caller identity for the current
+// request, typically from middleware-populated context keys. Returning
+// ok=false signals the resolver already wrote an error response and the
+// bridge must stop.
+type Resolver func(c *gin.Context) (ottoclient.ForwardScope, ottoclient.ForwardIdentity, bool)
+
+// Bridge proxies mobile support-chat calls to otto.
+type Bridge struct {
+	otto         *ottoclient.Client
+	wsPublicBase string
+	logger       *slog.Logger
+}
+
+// New builds a Bridge. otto may be nil (not wired in local dev) — every
+// route then returns 503. wsPublicBase is the public WebSocket origin the
+// app dials (e.g. "wss://api.mark8ly.com"); empty derives it per-request.
+func New(otto *ottoclient.Client, wsPublicBase string, logger *slog.Logger) *Bridge {
+	return &Bridge{otto: otto, wsPublicBase: wsPublicBase, logger: logger}
+}
+
+// Mount registers the standard support routes on g, using resolve to
+// obtain the per-request otto scope + identity. The group MUST already
+// have whatever auth/scope middleware the resolver reads from.
+func (b *Bridge) Mount(g *gin.RouterGroup, resolve Resolver) {
+	g.POST("/conversations", b.proxy(http.MethodPost, staticPath("/conversations"), resolve))
+	g.GET("/resume", b.proxy(http.MethodGet, staticPath("/resume"), resolve))
+	g.GET("/conversations/:id", b.proxy(http.MethodGet, convPath(""), resolve))
+	g.GET("/conversations/:id/messages", b.proxy(http.MethodGet, convPath("/messages"), resolve))
+	g.POST("/conversations/:id/messages", b.proxy(http.MethodPost, convPath("/messages"), resolve))
+	g.POST("/conversations/:id/close", b.proxy(http.MethodPost, convPath("/close"), resolve))
+	g.POST("/conversations/:id/feedback", b.proxy(http.MethodPost, convPath("/feedback"), resolve))
+	g.GET("/conversations/:id/queue", b.proxy(http.MethodGet, convPath("/queue"), resolve))
+	g.POST("/conversations/:id/ws-ticket", b.wsTicket(resolve))
+}
+
+type pathFunc func(c *gin.Context) string
+
+func staticPath(p string) pathFunc { return func(*gin.Context) string { return p } }
+
+func convPath(suffix string) pathFunc {
+	return func(c *gin.Context) string {
+		return "/conversations/" + url.PathEscape(c.Param("id")) + suffix
+	}
+}
+
+func (b *Bridge) proxy(method string, path pathFunc, resolve Resolver) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		res, ok := b.forward(c, method, path(c), resolve)
+		if !ok {
+			return
+		}
+		b.relay(c, res)
+	}
+}
+
+func (b *Bridge) forward(c *gin.Context, method, path string, resolve Resolver) (*ottoclient.ForwardResponse, bool) {
+	if b.otto == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "support_unavailable"})
+		return nil, false
+	}
+	scope, identity, ok := resolve(c)
+	if !ok {
+		return nil, false // resolver already wrote the error
+	}
+
+	var body []byte
+	if method != http.MethodGet && c.Request.Body != nil {
+		body, _ = io.ReadAll(io.LimitReader(c.Request.Body, maxBody))
+	}
+
+	res, err := b.otto.Forward(c.Request.Context(), ottoclient.ForwardRequest{
+		Method:       method,
+		Path:         path,
+		Scope:        scope,
+		Identity:     identity,
+		SessionToken: c.GetHeader("X-Otto-Session"),
+		Body:         body,
+	})
+	if err != nil {
+		if b.logger != nil {
+			b.logger.Error("ottobridge: forward failed", "err", err, "path", path)
+		}
+		c.JSON(http.StatusBadGateway, gin.H{"error": "support_unreachable"})
+		return nil, false
+	}
+	return res, true
+}
+
+// wsTicket mints an otto WebSocket ticket and augments the response with
+// the public ws_url the app dials directly (real-time delivery bypasses
+// this BFF and goes straight to otto via the gateway).
+func (b *Bridge) wsTicket(resolve Resolver) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		res, ok := b.forward(c, http.MethodPost, convPath("/ws-ticket")(c), resolve)
+		if !ok {
+			return
+		}
+		if res.Status != http.StatusOK {
+			b.relay(c, res)
+			return
+		}
+		var minted struct {
+			Ticket string `json:"ticket"`
+		}
+		if err := json.Unmarshal(res.Body, &minted); err != nil || minted.Ticket == "" {
+			c.JSON(http.StatusBadGateway, gin.H{"error": "ticket_mint_failed"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"ticket": minted.Ticket,
+			"ws_url": b.wsURL(c, c.Param("id")),
+		})
+	}
+}
+
+// relay writes otto's response back to the client, surfacing a freshly
+// minted session token into the JSON body + an X-Otto-Session header.
+func (b *Bridge) relay(c *gin.Context, res *ottoclient.ForwardResponse) {
+	contentType := res.ContentType
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	body := res.Body
+	if res.SessionToken != "" {
+		if merged, ok := mergeSessionToken(res.Body, res.SessionToken); ok {
+			body = merged
+		}
+		c.Header("X-Otto-Session", res.SessionToken)
+	}
+	c.Data(res.Status, contentType, body)
+}
+
+// wsURL builds the public WebSocket URL for a conversation, preferring the
+// configured public base and otherwise deriving it from the request.
+func (b *Bridge) wsURL(c *gin.Context, convID string) string {
+	base := b.wsPublicBase
+	if base == "" {
+		host := c.GetHeader("X-Forwarded-Host")
+		if host == "" {
+			host = c.Request.Host
+		}
+		scheme := "wss"
+		if c.GetHeader("X-Forwarded-Proto") == "http" {
+			scheme = "ws"
+		}
+		base = scheme + "://" + host
+	}
+	return base + "/api/v1/storefront/otto/conversations/" + url.PathEscape(convID) + "/ws"
+}
+
+// mergeSessionToken injects a top-level "session_token" into a JSON object
+// body. Returns false when the body isn't a JSON object.
+func mergeSessionToken(body []byte, token string) ([]byte, bool) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return nil, false
+	}
+	tok, err := json.Marshal(token)
+	if err != nil {
+		return nil, false
+	}
+	obj["session_token"] = tok
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}

--- a/services/marketplace-api/internal/ottobridge/bridge_test.go
+++ b/services/marketplace-api/internal/ottobridge/bridge_test.go
@@ -1,0 +1,119 @@
+package ottobridge
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/marketplace-api/internal/ottoclient"
+)
+
+func fixedResolver(scope ottoclient.ForwardScope, id ottoclient.ForwardIdentity) Resolver {
+	return func(c *gin.Context) (ottoclient.ForwardScope, ottoclient.ForwardIdentity, bool) {
+		return scope, id, true
+	}
+}
+
+func mountRig(t *testing.T, otto http.HandlerFunc, resolve Resolver) (*gin.Engine, func()) {
+	t.Helper()
+	srv := httptest.NewServer(otto)
+	gin.SetMode(gin.TestMode)
+	b := New(ottoclient.New(srv.URL, "secret"), "wss://api.test", nil)
+	r := gin.New()
+	b.Mount(r.Group("/support"), resolve)
+	return r, srv.Close
+}
+
+func TestBridge_Create_MergesSessionTokenAndForwardsScope(t *testing.T) {
+	var sawTenant string
+	r, closeFn := mountRig(t, func(w http.ResponseWriter, req *http.Request) {
+		sawTenant = req.Header.Get("X-Tenant-Id")
+		http.SetCookie(w, &http.Cookie{Name: "otto_session", Value: "sess-1", Path: "/"})
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"conversation":{"id":"c1"}}`))
+	}, fixedResolver(
+		ottoclient.ForwardScope{TenantID: "tenant-x", StoreID: "store-x"},
+		ottoclient.ForwardIdentity{UserID: "u1"},
+	))
+	defer closeFn()
+
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/support/conversations", strings.NewReader(`{"message":"hi"}`))
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("code=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if sawTenant != "tenant-x" {
+		t.Errorf("X-Tenant-Id forwarded = %q", sawTenant)
+	}
+	var out map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &out)
+	if out["session_token"] != "sess-1" {
+		t.Errorf("session_token = %v", out["session_token"])
+	}
+}
+
+func TestBridge_WsTicket_ReturnsWsURL(t *testing.T) {
+	r, closeFn := mountRig(t, func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ticket":"tkt"}`))
+	}, fixedResolver(ottoclient.ForwardScope{TenantID: "t", StoreID: "s"}, ottoclient.ForwardIdentity{}))
+	defer closeFn()
+
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/support/conversations/c9/ws-ticket", nil)
+	r.ServeHTTP(rec, req)
+
+	var out struct {
+		Ticket string `json:"ticket"`
+		WsURL  string `json:"ws_url"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &out)
+	if out.Ticket != "tkt" {
+		t.Errorf("ticket=%q", out.Ticket)
+	}
+	if out.WsURL != "wss://api.test/api/v1/storefront/otto/conversations/c9/ws" {
+		t.Errorf("ws_url=%q", out.WsURL)
+	}
+}
+
+func TestBridge_NilOtto_503(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	b := New(nil, "", nil)
+	r := gin.New()
+	b.Mount(r.Group("/support"), fixedResolver(ottoclient.ForwardScope{}, ottoclient.ForwardIdentity{}))
+
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/support/resume", nil)
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("code=%d want 503", rec.Code)
+	}
+}
+
+func TestBridge_ResolverAbort_StopsRequest(t *testing.T) {
+	var ottoHit bool
+	r, closeFn := mountRig(t, func(w http.ResponseWriter, req *http.Request) {
+		ottoHit = true
+		w.WriteHeader(http.StatusOK)
+	}, func(c *gin.Context) (ottoclient.ForwardScope, ottoclient.ForwardIdentity, bool) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "no_store"})
+		return ottoclient.ForwardScope{}, ottoclient.ForwardIdentity{}, false
+	})
+	defer closeFn()
+
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/support/resume", nil)
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("code=%d want 403", rec.Code)
+	}
+	if ottoHit {
+		t.Errorf("otto must not be called after resolver abort")
+	}
+}

--- a/services/marketplace-api/internal/ottoclient/forward.go
+++ b/services/marketplace-api/internal/ottoclient/forward.go
@@ -1,0 +1,135 @@
+package ottoclient
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// sessionCookieName is the cookie otto mints for a customer chat session.
+// It matches otto's CUSTOMER_SESSION_COOKIE default. The mobile app can't
+// read otto's HttpOnly cookie, so the BFF lifts the token out of the
+// Set-Cookie header (see Forward) and hands it back in the JSON body; the
+// app then echoes it via X-Otto-Session on subsequent calls.
+const sessionCookieName = "otto_session"
+
+// ForwardScope is the otto tenant+store a forwarded request runs under.
+// For the per-merchant storefront surface these are the resolved store's
+// tenant_id/store_id; for platform support they are the fixed
+// "platform"/"default" pair.
+type ForwardScope struct {
+	TenantID string
+	StoreID  string
+}
+
+// ForwardIdentity is the verified caller otto attributes the conversation
+// to. A non-empty UserID makes otto treat the caller as a logged-in
+// customer and skip the anonymous OTP step. ClientTenant* are only set on
+// the platform-support surface so the Tesserix agent can see which
+// merchant raised the chat.
+type ForwardIdentity struct {
+	UserID           string
+	UserEmail        string
+	UserName         string
+	ClientTenantID   string
+	ClientTenantName string
+}
+
+// ForwardRequest is one proxied call to otto's storefront HTTP surface
+// (`/api/v1/storefront/otto`). Path is relative to that prefix, e.g.
+// "/conversations" or "/conversations/{id}/messages".
+type ForwardRequest struct {
+	Method string
+	Path   string
+	Scope  ForwardScope
+	// Identity is the verified caller; the zero value forwards an
+	// anonymous request (otto then requires an OTP on create).
+	Identity ForwardIdentity
+	// SessionToken is the opaque otto session the app captured from a
+	// prior create. Empty on the first call. Sent as X-Otto-Session.
+	SessionToken string
+	// Body is the raw JSON request body, or nil for GET/DELETE.
+	Body []byte
+}
+
+// ForwardResponse relays otto's response verbatim. SessionToken is the
+// freshly minted session lifted from a Set-Cookie header (non-empty only
+// on the create call); the handler surfaces it to the mobile client.
+type ForwardResponse struct {
+	Status       int
+	Body         []byte
+	ContentType  string
+	SessionToken string
+}
+
+// Forward proxies a single request to otto's storefront surface, injecting
+// the internal-auth secret, tenant/store scope, and caller identity that
+// otto's middleware expects. Non-2xx responses are relayed as data (not Go
+// errors) so the BFF can pass otto's status + body straight through to the
+// app; only transport failures return an error.
+func (c *Client) Forward(ctx context.Context, in ForwardRequest) (*ForwardResponse, error) {
+	url := c.baseURL + "/api/v1/storefront/otto" + in.Path
+
+	var bodyReader io.Reader
+	if len(in.Body) > 0 {
+		bodyReader = bytes.NewReader(in.Body)
+	}
+	req, err := http.NewRequestWithContext(ctx, in.Method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("otto forward: build request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+	if len(in.Body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("X-Internal-Auth", c.secret)
+	req.Header.Set("X-Tenant-Id", in.Scope.TenantID)
+	req.Header.Set("X-Store-Id", in.Scope.StoreID)
+	if in.Identity.UserID != "" {
+		req.Header.Set("X-User-Id", in.Identity.UserID)
+	}
+	if in.Identity.UserEmail != "" {
+		req.Header.Set("X-User-Email", in.Identity.UserEmail)
+	}
+	if in.Identity.UserName != "" {
+		req.Header.Set("X-User-Name", in.Identity.UserName)
+	}
+	if in.Identity.ClientTenantID != "" {
+		req.Header.Set("X-Client-Tenant-Id", in.Identity.ClientTenantID)
+	}
+	if in.Identity.ClientTenantName != "" {
+		req.Header.Set("X-Client-Tenant-Name", in.Identity.ClientTenantName)
+	}
+	if in.SessionToken != "" {
+		req.Header.Set("X-Otto-Session", in.SessionToken)
+	}
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("otto forward: request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Cap the relayed body — chat payloads are small; a runaway upstream
+	// shouldn't be able to balloon BFF memory.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("otto forward: read body: %w", err)
+	}
+
+	out := &ForwardResponse{
+		Status:      resp.StatusCode,
+		Body:        body,
+		ContentType: resp.Header.Get("Content-Type"),
+	}
+	for _, ck := range resp.Cookies() {
+		if ck.Name == sessionCookieName && ck.Value != "" {
+			out.SessionToken = ck.Value
+			break
+		}
+	}
+	return out, nil
+}

--- a/services/marketplace-api/internal/ottoclient/forward_test.go
+++ b/services/marketplace-api/internal/ottoclient/forward_test.go
@@ -1,0 +1,186 @@
+package ottoclient
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestForward_Create_PassesScopeIdentityAndBody covers the happy-path
+// create bridge: the BFF forwards a customer's "open a chat" POST to
+// otto's storefront surface. We assert every header otto's
+// CustomerContext middleware reads plus the body passthrough, then check
+// the session token is lifted out of otto's Set-Cookie so the mobile app
+// can echo it back on later calls (it can't read the HttpOnly cookie).
+func TestForward_Create_PassesScopeIdentityAndBody(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Internal-Auth"); got != "shh" {
+			t.Errorf("X-Internal-Auth = %q, want shh", got)
+		}
+		if got := r.Header.Get("X-Tenant-Id"); got != "tenant-1" {
+			t.Errorf("X-Tenant-Id = %q, want tenant-1", got)
+		}
+		if got := r.Header.Get("X-Store-Id"); got != "store-1" {
+			t.Errorf("X-Store-Id = %q, want store-1", got)
+		}
+		if got := r.Header.Get("X-User-Id"); got != "gip-abc" {
+			t.Errorf("X-User-Id = %q, want gip-abc", got)
+		}
+		if got := r.Header.Get("X-User-Email"); got != "a@b.com" {
+			t.Errorf("X-User-Email = %q, want a@b.com", got)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/api/v1/storefront/otto/conversations") {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		http.SetCookie(w, &http.Cookie{Name: "otto_session", Value: "raw-token-123", Path: "/"})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"conversation":{"id":"c1"},"first_message":{"id":"m1"}}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "shh")
+	res, err := c.Forward(context.Background(), ForwardRequest{
+		Method:   http.MethodPost,
+		Path:     "/conversations",
+		Scope:    ForwardScope{TenantID: "tenant-1", StoreID: "store-1"},
+		Identity: ForwardIdentity{UserID: "gip-abc", UserEmail: "a@b.com"},
+		Body:     []byte(`{"message":"hi","reason":"other","status_info":"x"}`),
+	})
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if res.Status != http.StatusCreated {
+		t.Errorf("Status = %d, want 201", res.Status)
+	}
+	if gotBody != `{"message":"hi","reason":"other","status_info":"x"}` {
+		t.Errorf("forwarded body = %q", gotBody)
+	}
+	if res.SessionToken != "raw-token-123" {
+		t.Errorf("SessionToken = %q, want raw-token-123", res.SessionToken)
+	}
+	if !strings.Contains(string(res.Body), `"conversation"`) {
+		t.Errorf("body passthrough = %q", res.Body)
+	}
+}
+
+// TestForward_SessionTokenSentAsHeader covers the resume/reply path: the
+// mobile app holds the opaque session token and the BFF re-presents it to
+// otto as X-Otto-Session (otto's RequireCustomerSession accepts either the
+// cookie or that header). No new cookie => SessionToken stays empty.
+func TestForward_SessionTokenSentAsHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Otto-Session"); got != "raw-token-123" {
+			t.Errorf("X-Otto-Session = %q, want raw-token-123", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"messages":[]}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "shh")
+	res, err := c.Forward(context.Background(), ForwardRequest{
+		Method:       http.MethodGet,
+		Path:         "/conversations/c1/messages",
+		Scope:        ForwardScope{TenantID: "t", StoreID: "s"},
+		SessionToken: "raw-token-123",
+	})
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if res.Status != http.StatusOK {
+		t.Errorf("Status = %d, want 200", res.Status)
+	}
+	if res.SessionToken != "" {
+		t.Errorf("SessionToken = %q, want empty (no new cookie)", res.SessionToken)
+	}
+}
+
+// TestForward_PlatformIdentity covers #119: merchant→platform chat runs
+// on the same storefront surface but pinned to the platform tenant, with
+// the merchant's own tenant carried as X-Client-Tenant-* so the Tesserix
+// agent can see who is talking.
+func TestForward_PlatformIdentity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Tenant-Id"); got != "platform" {
+			t.Errorf("X-Tenant-Id = %q, want platform", got)
+		}
+		if got := r.Header.Get("X-Store-Id"); got != "default" {
+			t.Errorf("X-Store-Id = %q, want default", got)
+		}
+		if got := r.Header.Get("X-Client-Tenant-Id"); got != "merchant-9" {
+			t.Errorf("X-Client-Tenant-Id = %q, want merchant-9", got)
+		}
+		if got := r.Header.Get("X-Client-Tenant-Name"); got != "Acme Store" {
+			t.Errorf("X-Client-Tenant-Name = %q, want Acme Store", got)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"conversation":{"id":"p1"}}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "shh")
+	_, err := c.Forward(context.Background(), ForwardRequest{
+		Method: http.MethodPost,
+		Path:   "/conversations",
+		Scope:  ForwardScope{TenantID: "platform", StoreID: "default"},
+		Identity: ForwardIdentity{
+			UserID:           "admin-1",
+			UserEmail:        "owner@acme.com",
+			ClientTenantID:   "merchant-9",
+			ClientTenantName: "Acme Store",
+		},
+		Body: []byte(`{"message":"billing question","reason":"billing","status_info":"x"}`),
+	})
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+}
+
+// TestForward_UpstreamErrorPassesThrough — a 4xx from otto (e.g. closed
+// thread) is NOT a Go error; the BFF must relay otto's status + body to
+// the client verbatim so the app shows the right message.
+func TestForward_UpstreamErrorPassesThrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"thread_closed"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "shh")
+	res, err := c.Forward(context.Background(), ForwardRequest{
+		Method: http.MethodPost,
+		Path:   "/conversations/c1/messages",
+		Scope:  ForwardScope{TenantID: "t", StoreID: "s"},
+		Body:   []byte(`{"body":"hello"}`),
+	})
+	if err != nil {
+		t.Fatalf("Forward should pass through 4xx without error, got %v", err)
+	}
+	if res.Status != http.StatusConflict {
+		t.Errorf("Status = %d, want 409", res.Status)
+	}
+	if !strings.Contains(string(res.Body), "thread_closed") {
+		t.Errorf("body = %q", res.Body)
+	}
+}
+
+// TestForward_TransportErrorSurfaces — a dead upstream IS a Go error so
+// the handler can map it to 502.
+func TestForward_TransportErrorSurfaces(t *testing.T) {
+	c := New("http://127.0.0.1:0", "shh")
+	_, err := c.Forward(context.Background(), ForwardRequest{
+		Method: http.MethodGet,
+		Path:   "/resume",
+		Scope:  ForwardScope{TenantID: "t", StoreID: "s"},
+	})
+	if err == nil {
+		t.Fatal("expected transport error")
+	}
+}

--- a/services/marketplace-api/pkg/config/config.go
+++ b/services/marketplace-api/pkg/config/config.go
@@ -144,6 +144,12 @@ type Config struct {
 	// X-Internal-Auth header on every call.
 	OttoURL          string `envconfig:"OTTO_URL" default:""`
 	OttoInternalAuth string `envconfig:"OTTO_INTERNAL_AUTH" default:""`
+	// OttoWSPublicBase is the public WebSocket origin mobile clients dial
+	// for the real-time support chat, e.g. "wss://api.mark8ly.com". The
+	// mobile support BFF returns "<base>/api/v1/storefront/otto/.../ws" so
+	// the app connects straight to otto via the gateway (bypassing the
+	// BFF). When empty the BFF derives it from the inbound request host.
+	OttoWSPublicBase string `envconfig:"OTTO_WS_PUBLIC_BASE" default:""`
 
 	// P7 — tax-ID validation (§19). NZTaxValidationEnabled gates the IRD
 	// validator until counsel sign-off (§20.3); leave false in production


### PR DESCRIPTION
## Summary
Adds mobile support chat for both directions, reusing the existing Otto service end-to-end:
- **#118** customer→merchant chat in `storefront-mobile`
- **#119** merchant→platform chat in `mobile-admin`

Web was already complete; this fills the mobile gap (mobile-first).

## Backend (marketplace-api)
- `ottoclient.Forward` — generic S2S proxy to Otto's storefront surface (injects internal-auth + tenant/store scope + caller identity; lifts Otto's HttpOnly session cookie into the response for the app).
- `ottobridge` — mounts the standard support routes over `Forward` via a per-surface resolver; ws-ticket returns a public `ws_url`.
- Storefront `MobileSupportHandler` (`/api/v1/mobile/storefront/stores/:slug/support/*`) + admin `PlatformSupportHandler` (`/api/v1/mobile/admin/platform-support/*`, Otto `platform` tenant, merchant attributed via `X-Client-Tenant-Id`).
- GIP customer verifier + standalone storefront support mount; `OTTO_WS_PUBLIC_BASE` config.

## Mobile
- `packages/mobile-shared/support` — typed client (GIP bearer + refresh, `X-Otto-Session` round-trip + persistence), WS event parser + reducer, `useSupportChat` hook (resume/create + reconnect + app-state), shared themeable `SupportChatView`.
- `storefront-mobile`: Account → Support. `mobile-admin`: More → Tesserix Support.

## Tests
- Go unit tests for forwarder, bridge, both handlers (`go build`/`vet` clean).
- 24 vitest cases for the mobile-shared client/events/types; `tsc` clean for the module + storefront-mobile.

## Deploy note
Requires the companion `tesserix-k8s` change (otto env on marketplace-api + `api.mark8ly.com` routing). Routes degrade to 503 until then, so this is safe to merge first.

Closes #118, closes #119.
