### PR TITLE
feat(support): SSE fallback transport (WS → SSE → polling)

### DIFF
--- a/packages/mobile-shared/support/__tests__/sse.test.ts
+++ b/packages/mobile-shared/support/__tests__/sse.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { createSSEParser } from "../sse";
+
+function collect(chunks: string[]): string[] {
+  const out: string[] = [];
+  const parser = createSSEParser((d) => out.push(d));
+  for (const c of chunks) parser.push(c);
+  return out;
+}
+
+describe("createSSEParser", () => {
+  it("parses a single complete event", () => {
+    expect(collect(['data: {"type":"x"}\n\n'])).toEqual(['{"type":"x"}']);
+  });
+
+  it("handles an event split across chunks", () => {
+    expect(collect(['data: {"ty', 'pe":"x"}', "\n\n"])).toEqual(['{"type":"x"}']);
+  });
+
+  it("parses multiple events in one chunk", () => {
+    expect(collect(["data: a\n\ndata: b\n\n"])).toEqual(["a", "b"]);
+  });
+
+  it("ignores comment heartbeats", () => {
+    expect(collect([": ping\n\n", "data: real\n\n"])).toEqual(["real"]);
+  });
+
+  it("joins multi-line data fields", () => {
+    expect(collect(["data: line1\ndata: line2\n\n"])).toEqual(["line1\nline2"]);
+  });
+
+  it("strips only one leading space after data:", () => {
+    expect(collect(["data:  two-spaces\n\n"])).toEqual([" two-spaces"]);
+  });
+
+  it("normalises CRLF framing", () => {
+    expect(collect(['data: {"a":1}\r\n\r\n'])).toEqual(['{"a":1}']);
+  });
+
+  it("buffers an incomplete event until its terminator arrives", () => {
+    const out: string[] = [];
+    const p = createSSEParser((d) => out.push(d));
+    p.push("data: partial\n");
+    expect(out).toEqual([]);
+    p.push("\n");
+    expect(out).toEqual(["partial"]);
+  });
+});

--- a/packages/mobile-shared/support/client.ts
+++ b/packages/mobile-shared/support/client.ts
@@ -195,6 +195,16 @@ export function createSupportClient(config: SupportClientConfig) {
     buildWsUrl: (ticket: WsTicket): string =>
       `${ticket.ws_url}?ticket=${encodeURIComponent(ticket.ticket)}`,
 
+    /** Builds the SSE URL from the same ticket — otto serves /sse next to
+     *  /ws and a ticket is transport-agnostic. */
+    buildSseUrl: (ticket: WsTicket): string => {
+      const base = ticket.ws_url
+        .replace(/\/ws$/, "/sse")
+        .replace(/^wss:/, "https:")
+        .replace(/^ws:/, "http:");
+      return `${base}?ticket=${encodeURIComponent(ticket.ticket)}`;
+    },
+
     /** The currently held otto session token, if any. */
     currentSessionToken: (): string | null => sessionToken,
   };

--- a/packages/mobile-shared/support/index.ts
+++ b/packages/mobile-shared/support/index.ts
@@ -2,6 +2,7 @@
 export * from "./types";
 export * from "./events";
 export * from "./outbox";
+export * from "./sse";
 export * from "./client";
 export * from "./useSupportChat";
 export * from "./SupportChatView";

--- a/packages/mobile-shared/support/sse.ts
+++ b/packages/mobile-shared/support/sse.ts
@@ -1,0 +1,105 @@
+// Minimal Server-Sent Events client for React Native. RN has no native
+// EventSource, and fetch streaming is unreliable across engines, so this
+// reads an XMLHttpRequest's incrementally-growing responseText (the same
+// approach react-native-sse uses) — no native dependency. The wire parser is
+// pure and unit-tested; openSSE is the thin RN-bound transport.
+//
+// Used as the support chat's middle fallback: WebSocket → SSE → polling.
+
+/** Pure SSE frame parser. Feed raw text deltas; emits each event's `data`. */
+export function createSSEParser(onData: (data: string) => void) {
+  let buffer = "";
+  return {
+    push(chunk: string): void {
+      // Normalise CRLF so framing is consistent across servers/proxies.
+      buffer += chunk.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+      let sep: number;
+      while ((sep = buffer.indexOf("\n\n")) !== -1) {
+        const rawEvent = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        const dataLines: string[] = [];
+        for (const line of rawEvent.split("\n")) {
+          if (line.startsWith("data:")) {
+            // Strip "data:" and an optional single leading space.
+            dataLines.push(line.slice(5).replace(/^ /, ""));
+          }
+          // Lines starting with ":" are comments (heartbeats) — ignored.
+        }
+        if (dataLines.length > 0) onData(dataLines.join("\n"));
+      }
+    },
+  };
+}
+
+export interface SSEHandle {
+  close(): void;
+}
+
+export interface SSEHandlers {
+  onOpen?: () => void;
+  onMessage: (data: string) => void;
+  onError?: () => void;
+}
+
+/**
+ * Opens an SSE stream over XMLHttpRequest. Returns a handle whose close()
+ * aborts the request. onError fires on transport failure or stream end so
+ * the caller can reconnect.
+ */
+export function openSSE(url: string, h: SSEHandlers): SSEHandle {
+  const xhr = new XMLHttpRequest();
+  const parser = createSSEParser(h.onMessage);
+  let lastIndex = 0;
+  let errored = false;
+
+  const fail = () => {
+    if (errored) return;
+    errored = true;
+    h.onError?.();
+  };
+
+  xhr.open("GET", url, true);
+  xhr.setRequestHeader("Accept", "text/event-stream");
+  xhr.onreadystatechange = () => {
+    // HEADERS_RECEIVED — confirm a 200 stream before declaring open.
+    if (xhr.readyState === 2) {
+      if (xhr.status === 200) {
+        h.onOpen?.();
+      } else {
+        fail();
+      }
+    }
+    // LOADING / DONE — drain whatever new text has arrived.
+    if (xhr.readyState === 3 || xhr.readyState === 4) {
+      const text = xhr.responseText ?? "";
+      if (text.length > lastIndex) {
+        const delta = text.slice(lastIndex);
+        lastIndex = text.length;
+        parser.push(delta);
+      }
+    }
+    if (xhr.readyState === 4) {
+      // Stream ended (server closed or network dropped) — always a
+      // disconnect, so signal the caller to reconnect.
+      fail();
+    }
+  };
+  xhr.onerror = fail;
+  xhr.ontimeout = fail;
+  try {
+    xhr.send();
+  } catch {
+    fail();
+  }
+
+  return {
+    close() {
+      errored = true; // suppress onError from the abort
+      try {
+        xhr.abort();
+      } catch {
+        /* noop */
+      }
+    },
+  };
+}

--- a/packages/mobile-shared/support/useSupportChat.ts
+++ b/packages/mobile-shared/support/useSupportChat.ts
@@ -15,6 +15,7 @@ import { AppState, type AppStateStatus } from "react-native";
 
 import { SupportError, type SupportClient } from "./client";
 import { mergeMessage, mergeMessages, parseOttoEvent } from "./events";
+import { openSSE, type SSEHandle } from "./sse";
 import {
   addItem,
   backoffMs,
@@ -61,6 +62,8 @@ export interface UseSupportChat {
 
 const MAX_BACKOFF_MS = 15_000;
 const DEFAULT_POLL_MS = 5_000;
+// Consecutive WebSocket connect failures before falling back to SSE.
+const WS_FALLBACK_THRESHOLD = 3;
 
 function newClientMsgId(): string {
   return `cmid-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
@@ -89,6 +92,9 @@ export function useSupportChat({
   const [error, setError] = useState<string | null>(null);
 
   const socketRef = useRef<WebSocket | null>(null);
+  const sseRef = useRef<SSEHandle | null>(null);
+  const preferSSERef = useRef(false);
+  const wsFailuresRef = useRef(0);
   const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const retryRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const attemptsRef = useRef(0);
@@ -177,7 +183,7 @@ export function useSupportChat({
     void drainOutbox();
   }, [persistOutbox, drainOutbox]);
 
-  // ── WebSocket ─────────────────────────────────────────────────────
+  // ── Realtime (WebSocket → SSE → polling) ──────────────────────────
   const clearReconnect = () => {
     if (reconnectRef.current) {
       clearTimeout(reconnectRef.current);
@@ -185,6 +191,8 @@ export function useSupportChat({
     }
   };
 
+  // teardownSocket tears down whichever realtime transport is active
+  // (WebSocket or SSE) and stops reconnects.
   const teardownSocket = useCallback(() => {
     closedByUsRef.current = true;
     clearReconnect();
@@ -192,58 +200,91 @@ export function useSupportChat({
       socketRef.current.close();
       socketRef.current = null;
     }
+    if (sseRef.current) {
+      sseRef.current.close();
+      sseRef.current = null;
+    }
     setConnectedBoth(false);
   }, []);
 
   const connect = useCallback(
     async (conversationId: string) => {
       closedByUsRef.current = false;
-      try {
-        const ticket = await client.getWsTicket(conversationId);
-        if (closedByUsRef.current) return;
-        const ws = new WebSocket(client.buildWsUrl(ticket));
-        socketRef.current = ws;
 
-        ws.onopen = () => {
-          attemptsRef.current = 0;
-          setConnectedBoth(true);
-          setStatus("ready");
-          // Reconcile anything missed while we were offline, and flush the
-          // outbox now that connectivity is confirmed.
-          void refresh();
-          void drainOutbox();
-        };
-        ws.onmessage = (ev) => {
-          const data = (ev as { data?: unknown }).data;
-          const event = parseOttoEvent(typeof data === "string" ? data : "");
-          if (event.kind === "message") {
-            setServerMessages((prev) => mergeMessage(prev, event.message));
-          } else if (event.kind === "conversation_closed") {
-            setStatus("closed");
-            setConversation((prev) => (prev ? { ...prev, status: "closed" } : prev));
-            teardownSocket();
-          }
-        };
-        ws.onerror = () => setConnectedBoth(false);
-        ws.onclose = () => {
-          setConnectedBoth(false);
-          socketRef.current = null;
-          if (closedByUsRef.current) return;
-          const attempt = (attemptsRef.current += 1);
-          const delay = Math.min(MAX_BACKOFF_MS, 1000 * 2 ** (attempt - 1));
-          clearReconnect();
-          reconnectRef.current = setTimeout(() => {
-            if (convIdRef.current) void connect(convIdRef.current);
-          }, delay);
-        };
-      } catch {
+      const reconnect = () => {
         const attempt = (attemptsRef.current += 1);
         const delay = Math.min(MAX_BACKOFF_MS, 1000 * 2 ** (attempt - 1));
         clearReconnect();
         reconnectRef.current = setTimeout(() => {
           if (convIdRef.current) void connect(convIdRef.current);
         }, delay);
+      };
+      const onOpen = () => {
+        attemptsRef.current = 0;
+        setConnectedBoth(true);
+        setStatus("ready");
+        // Reconcile anything missed while offline + flush the outbox.
+        void refresh();
+        void drainOutbox();
+      };
+      const onFrame = (raw: string) => {
+        const event = parseOttoEvent(raw);
+        if (event.kind === "message") {
+          setServerMessages((prev) => mergeMessage(prev, event.message));
+        } else if (event.kind === "conversation_closed") {
+          setStatus("closed");
+          setConversation((prev) => (prev ? { ...prev, status: "closed" } : prev));
+          teardownSocket();
+        }
+      };
+
+      let ticket;
+      try {
+        ticket = await client.getWsTicket(conversationId);
+      } catch {
+        reconnect();
+        return;
       }
+      if (closedByUsRef.current) return;
+
+      // After repeated WS failures (blocked upgrades / hostile proxies) fall
+      // back to SSE. Polling remains the final safety net in both modes.
+      if (preferSSERef.current) {
+        const handle = openSSE(client.buildSseUrl(ticket), {
+          onOpen,
+          onMessage: onFrame,
+          onError: () => {
+            setConnectedBoth(false);
+            sseRef.current = null;
+            if (closedByUsRef.current) return;
+            reconnect();
+          },
+        });
+        sseRef.current = handle;
+        return;
+      }
+
+      const ws = new WebSocket(client.buildWsUrl(ticket));
+      socketRef.current = ws;
+      ws.onopen = () => {
+        wsFailuresRef.current = 0;
+        onOpen();
+      };
+      ws.onmessage = (ev) => {
+        const data = (ev as { data?: unknown }).data;
+        onFrame(typeof data === "string" ? data : "");
+      };
+      ws.onerror = () => setConnectedBoth(false);
+      ws.onclose = () => {
+        setConnectedBoth(false);
+        socketRef.current = null;
+        if (closedByUsRef.current) return;
+        wsFailuresRef.current += 1;
+        if (wsFailuresRef.current >= WS_FALLBACK_THRESHOLD) {
+          preferSSERef.current = true; // switch transports on next attempt
+        }
+        reconnect();
+      };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [client, teardownSocket, drainOutbox],


### PR DESCRIPTION
Adds a Server-Sent Events fallback so the mobile chat keeps a live push channel even where WebSocket upgrades are blocked, before degrading to the REST polling net (pairs with the otto `/sse` endpoint in slm-support-platform#1).

- `sse.ts`: pure SSE frame parser (CRLF-normalised, multi-line data, comment heartbeats) + an XHR-based RN client (no native dependency).
- `client.buildSseUrl`: derives `/sse` from the ws-ticket (a ticket is transport-agnostic).
- `useSupportChat`: after repeated WS connect failures it switches to SSE; both feed the same frame handler; polling stays the final safety net.

41 vitest cases (8 new SSE parser cases), tsc clean. Mobile-only — ships via EAS.