### PR TITLE
feat(admin): enable Otto Live chat inbox in support nav

### DIFF
--- a/apps/admin/components/shell/AdminShell.tsx
+++ b/apps/admin/components/shell/AdminShell.tsx
@@ -161,12 +161,11 @@ const navigation: NavSection[] = [
     label: "Support",
     icon: HelpCircle,
     children: [
-      // Otto Live chat + Audit log are temporarily hidden from the
-      // nav until product launch. The routes + components remain in
-      // the tree so re-enabling is a matter of uncommenting these
-      // entries. See docs/otto-disabled.md for the full checklist.
-      // { label: "Live chat", href: "/support/live-chat" },
-      // { label: "Audit log", href: "/support/audit-log" },
+      // Otto real-time support: the staff inbox for customer live chats
+      // (and its audit trail). Routes + components live under
+      // app/(admin)/support/{live-chat,audit-log}.
+      { label: "Live chat", href: "/support/live-chat" },
+      { label: "Audit log", href: "/support/audit-log" },
       { label: "Tickets", href: "/support/tickets" },
       { label: "Help Center", href: "/support/help" },
       { label: "Platform support", href: "/support/platform" },


### PR DESCRIPTION
Re-enables the Otto **Live chat** (staff inbox for customer live chats) + **Audit log** nav entries — they were commented out, so merchants couldn't see/answer the storefront chat widget's conversations (only the email Tickets view). Pages/components already exist under `app/(admin)/support/`.