### PR TITLE
fix(otto): make post-close feedback survey scrollable

### DIFF
--- a/apps/admin/components/support/PlatformChat.tsx
+++ b/apps/admin/components/support/PlatformChat.tsx
@@ -3,6 +3,9 @@
 import { OttoWidget } from "@tesserix/otto-widget";
 
 import "@tesserix/otto-widget/styles/otto.css";
+// Local override (loaded after the widget CSS): makes the post-close
+// feedback survey scrollable so the Submit button is always reachable.
+import "./otto-widget-overrides.css";
 
 /**
  * PlatformChat is the admin-side chat surface to the Tesserix

--- a/apps/admin/components/support/otto-widget-overrides.css
+++ b/apps/admin/components/support/otto-widget-overrides.css
@@ -1,0 +1,14 @@
+/* Otto support widget — post-close feedback survey scroll fix.
+ *
+ * @tesserix/otto-widget@0.5.1 renders the feedback survey in the panel's
+ * fixed-height (560px) slot, but unlike .otto-widget__messages the
+ * .otto-widget__feedback view has no flex/scroll. On short viewports its
+ * lower fields and the Submit button get clipped and become unreachable.
+ * Give it the same scroll behaviour as the messages view. Loaded after
+ * the widget stylesheet; !important guards against bundle-order changes.
+ * Remove once the upstream widget package ships the fix. */
+.otto-widget__feedback {
+  flex: 1 1 auto !important;
+  min-height: 0 !important;
+  overflow-y: auto !important;
+}

--- a/apps/storefront/components/OttoSupportChat.tsx
+++ b/apps/storefront/components/OttoSupportChat.tsx
@@ -3,6 +3,9 @@
 import { OttoWidget } from "@tesserix/otto-widget";
 
 import "@tesserix/otto-widget/styles/otto.css";
+// Local override (loaded after the widget CSS): makes the post-close
+// feedback survey scrollable so the Submit button is always reachable.
+import "./otto-widget-overrides.css";
 
 import { useCustomerAuth } from "@/components/CustomerAuthProvider";
 

--- a/apps/storefront/components/otto-widget-overrides.css
+++ b/apps/storefront/components/otto-widget-overrides.css
@@ -1,0 +1,14 @@
+/* Otto support widget — post-close feedback survey scroll fix.
+ *
+ * @tesserix/otto-widget@0.5.1 renders the feedback survey in the panel's
+ * fixed-height (560px) slot, but unlike .otto-widget__messages the
+ * .otto-widget__feedback view has no flex/scroll. On short viewports its
+ * lower fields and the Submit button get clipped and become unreachable.
+ * Give it the same scroll behaviour as the messages view. Loaded after
+ * the widget stylesheet; !important guards against bundle-order changes.
+ * Remove once the upstream widget package ships the fix. */
+.otto-widget__feedback {
+  flex: 1 1 auto !important;
+  min-height: 0 !important;
+  overflow-y: auto !important;
+}


### PR DESCRIPTION
The widget's close-out feedback survey renders in the panel's fixed-height slot without scroll, so on short viewports the lower fields + Submit button are clipped/unreachable. Adds a local CSS override (loaded after the widget stylesheet) giving the survey the same scroll behaviour as the messages view — on the storefront widget + admin platform chat.