### PR TITLE
feat(notifications): customer-targeted notifications + storefront bell API

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1094,6 +1094,7 @@ func main() {
 		customerRepo := customer.NewRepository(conn)
 		customerSvc := customer.NewService(conn, customerRepo, log).WithAudit(auditEmitter)
 		customerAccountHandler := storefront.NewCustomerAccountHandler(conn, customerRepo, customerSvc, log)
+		customerNotificationsHandler := storefront.NewCustomerNotificationsHandler(notificationSvc)
 
 		// C3 — Reviews.
 		reviewRepoSF := review.NewRepository(conn)
@@ -1212,8 +1213,9 @@ func main() {
 			StorefrontKey:          cfg.StorefrontKey,
 			CountryHandler:         countryHandler,
 			// C1 customer auth.
-			CustomerAccountHandler: customerAccountHandler,
-			CustomerService:        customerSvc,
+			CustomerAccountHandler:       customerAccountHandler,
+			CustomerNotificationsHandler: customerNotificationsHandler,
+			CustomerService:              customerSvc,
 			CustomerSessionSecret:  cfg.CustomerSessionSecret,
 			// C3 reviews.
 			ReviewsHandler: sfReviewsHandler,

--- a/services/marketplace-api/internal/handlers/storefront/customer_notifications.go
+++ b/services/marketplace-api/internal/handlers/storefront/customer_notifications.go
@@ -1,0 +1,160 @@
+// Package storefront — customer_notifications.go: the storefront customer
+// notification bell. Lists / counts / marks-read a logged-in customer's
+// notifications (recipient_user_id = customer profile id). All routes require
+// RequireCustomerAuth + StoreContext.
+package storefront
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/customer"
+	"github.com/mark8ly/marketplace-api/internal/notification"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+)
+
+// CustomerNotificationsHandler serves the storefront /account/notifications routes.
+type CustomerNotificationsHandler struct {
+	svc *notification.Service
+}
+
+// NewCustomerNotificationsHandler constructs the handler. svc may be nil
+// (notifications disabled) — handlers degrade to empty results.
+func NewCustomerNotificationsHandler(svc *notification.Service) *CustomerNotificationsHandler {
+	return &CustomerNotificationsHandler{svc: svc}
+}
+
+type notificationResponse struct {
+	ID           string  `json:"id"`
+	Type         string  `json:"type"`
+	Title        string  `json:"title"`
+	Message      *string `json:"message"`
+	IsRead       bool    `json:"is_read"`
+	CreatedAt    string  `json:"created_at"`
+	ResourceType *string `json:"resource_type"`
+	ResourceID   *string `json:"resource_id"`
+}
+
+func toResponse(n notification.Notification) notificationResponse {
+	r := notificationResponse{
+		ID:           n.ID.String(),
+		Type:         string(n.Type),
+		Title:        n.Title,
+		Message:      n.Message,
+		IsRead:       n.IsRead,
+		CreatedAt:    n.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		ResourceType: n.ResourceType,
+	}
+	if n.ResourceID != nil {
+		s := n.ResourceID.String()
+		r.ResourceID = &s
+	}
+	return r
+}
+
+// resolve returns (storeID, customerProfileID, ok). On failure it writes the
+// response and returns ok=false.
+func (h *CustomerNotificationsHandler) resolve(c *gin.Context) (uuid.UUID, string, bool) {
+	storeVal, _ := c.Get("store")
+	store, ok := storeVal.(*stores.Store)
+	if !ok || store == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "store_not_resolved"})
+		return uuid.Nil, "", false
+	}
+	storeID, err := uuid.Parse(store.ID)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "store_not_resolved"})
+		return uuid.Nil, "", false
+	}
+	val, exists := c.Get(CustomerProfileKey)
+	profile, pok := val.(*customer.CustomerProfile)
+	if !exists || !pok || profile == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return uuid.Nil, "", false
+	}
+	return storeID, profile.ID.String(), true
+}
+
+// List handles GET /account/notifications.
+func (h *CustomerNotificationsHandler) List(c *gin.Context) {
+	storeID, recipient, ok := h.resolve(c)
+	if !ok {
+		return
+	}
+	if h.svc == nil {
+		c.JSON(http.StatusOK, gin.H{"notifications": []notificationResponse{}})
+		return
+	}
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	perPage, _ := strconv.Atoi(c.DefaultQuery("per_page", "20"))
+	res, err := h.svc.ListForCustomer(c.Request.Context(), storeID, recipient, page, perPage)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "list_failed"})
+		return
+	}
+	out := make([]notificationResponse, 0, len(res.Notifications))
+	for _, n := range res.Notifications {
+		out = append(out, toResponse(n))
+	}
+	c.JSON(http.StatusOK, gin.H{"notifications": out, "total": res.Total})
+}
+
+// UnreadCount handles GET /account/notifications/unread-count.
+func (h *CustomerNotificationsHandler) UnreadCount(c *gin.Context) {
+	storeID, recipient, ok := h.resolve(c)
+	if !ok {
+		return
+	}
+	if h.svc == nil {
+		c.JSON(http.StatusOK, gin.H{"unread_count": 0})
+		return
+	}
+	count, err := h.svc.GetUnreadCountForCustomer(c.Request.Context(), storeID, recipient)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "count_failed"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"unread_count": count})
+}
+
+// MarkRead handles PATCH /account/notifications/:id/read.
+func (h *CustomerNotificationsHandler) MarkRead(c *gin.Context) {
+	storeID, recipient, ok := h.resolve(c)
+	if !ok {
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "bad_id"})
+		return
+	}
+	if h.svc == nil {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+		return
+	}
+	if err := h.svc.MarkReadForCustomer(c.Request.Context(), storeID, recipient, id); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true})
+}
+
+// MarkAllRead handles PATCH /account/notifications/read-all.
+func (h *CustomerNotificationsHandler) MarkAllRead(c *gin.Context) {
+	storeID, recipient, ok := h.resolve(c)
+	if !ok {
+		return
+	}
+	if h.svc == nil {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+		return
+	}
+	if err := h.svc.MarkAllReadForCustomer(c.Request.Context(), storeID, recipient); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "mark_all_failed"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true})
+}

--- a/services/marketplace-api/internal/handlers/storefront/routes.go
+++ b/services/marketplace-api/internal/handlers/storefront/routes.go
@@ -35,6 +35,8 @@ type Deps struct {
 	CustomerAccountHandler *CustomerAccountHandler
 	CustomerService        *customer.Service
 	CustomerSessionSecret  string
+	// Customer notification bell.
+	CustomerNotificationsHandler *CustomerNotificationsHandler
 	// C3 reviews.
 	ReviewsHandler *ReviewsHandler
 	// C4 wishlists.
@@ -249,6 +251,14 @@ func RegisterStorefront(router *gin.RouterGroup, deps Deps) {
 			// Order history — list orders for authenticated customer.
 			if deps.OrderDetailHandler != nil {
 				account.GET("/orders", deps.OrderDetailHandler.ListOrders)
+			}
+
+			// Customer notification bell.
+			if deps.CustomerNotificationsHandler != nil {
+				account.GET("/notifications", deps.CustomerNotificationsHandler.List)
+				account.GET("/notifications/unread-count", deps.CustomerNotificationsHandler.UnreadCount)
+				account.PATCH("/notifications/read-all", deps.CustomerNotificationsHandler.MarkAllRead)
+				account.PATCH("/notifications/:id/read", deps.CustomerNotificationsHandler.MarkRead)
 			}
 
 			// C3 — Reviews (authenticated: submit + react + comment).

--- a/services/marketplace-api/internal/handlers/storefront/webhooks.go
+++ b/services/marketplace-api/internal/handlers/storefront/webhooks.go
@@ -618,13 +618,14 @@ func (h *WebhookHandler) emitPaymentReceived(ctx context.Context, orderID uuid.U
 		return
 	}
 	var row struct {
-		TenantID    uuid.UUID `gorm:"column:tenant_id"`
-		StoreID     uuid.UUID `gorm:"column:store_id"`
-		OrderNumber string    `gorm:"column:order_number"`
+		TenantID    uuid.UUID  `gorm:"column:tenant_id"`
+		StoreID     uuid.UUID  `gorm:"column:store_id"`
+		CustomerID  *uuid.UUID `gorm:"column:customer_id"`
+		OrderNumber string     `gorm:"column:order_number"`
 	}
 	if err := h.db.WithContext(ctx).
 		Table("orders").
-		Select("tenant_id, store_id, order_number").
+		Select("tenant_id, store_id, customer_id, order_number").
 		Where("id = ?", orderID).
 		Take(&row).Error; err != nil {
 		h.logError("webhook: order lookup for notification failed",
@@ -642,6 +643,23 @@ func (h *WebhookHandler) emitPaymentReceived(ctx context.Context, orderID uuid.U
 		ResourceType: &resourceType,
 		ResourceID:   &orderID,
 	})
+
+	// Also notify the customer's own bell when the order belongs to a
+	// logged-in customer profile (recipient_user_id = customer profile id).
+	if row.CustomerID != nil {
+		custMsg := "Your payment for order " + row.OrderNumber + " was received — your order is confirmed."
+		recipient := row.CustomerID.String()
+		notification.EmitToCustomer(ctx, h.notify, h.logger, notification.Notification{
+			TenantID:        row.TenantID,
+			StoreID:         row.StoreID,
+			RecipientUserID: &recipient,
+			Type:            notification.TypeOrderPlaced,
+			Title:           "Order confirmed",
+			Message:         &custMsg,
+			ResourceType:    &resourceType,
+			ResourceID:      &orderID,
+		})
+	}
 }
 
 // awardLoyaltyPoints looks up the order and credits points on the

--- a/services/marketplace-api/internal/notification/models.go
+++ b/services/marketplace-api/internal/notification/models.go
@@ -21,6 +21,13 @@ const (
 	TypeOrderCancelled  NotificationType = "order_cancelled"
 	TypeOrderFulfilled  NotificationType = "order_fulfilled"
 	TypeSystemAlert     NotificationType = "system_alert"
+
+	// Customer-facing types (recipient_user_id set) — power the storefront
+	// customer notification bell.
+	TypeOrderPlaced     NotificationType = "order_placed"
+	TypeOrderShipped    NotificationType = "order_shipped"
+	TypeOrderDelivered  NotificationType = "order_delivered"
+	TypeRefundProcessed NotificationType = "refund_processed"
 )
 
 // Notification is the GORM model for the notifications table.
@@ -28,6 +35,9 @@ type Notification struct {
 	ID           uuid.UUID        `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()"`
 	TenantID     uuid.UUID        `gorm:"column:tenant_id;type:uuid;not null"`
 	StoreID      uuid.UUID        `gorm:"column:store_id;type:uuid;not null"`
+	// RecipientUserID, when set, targets a storefront customer (GIP string id)
+	// for the customer notification bell. NULL = store/staff notification.
+	RecipientUserID *string        `gorm:"column:recipient_user_id;type:varchar(255)"`
 	Type         NotificationType `gorm:"column:type;type:varchar(40);not null"`
 	Title        string           `gorm:"column:title;type:varchar(200);not null"`
 	Message      *string          `gorm:"column:message;type:text"`

--- a/services/marketplace-api/internal/notification/repository.go
+++ b/services/marketplace-api/internal/notification/repository.go
@@ -40,6 +40,20 @@ type Repository interface {
 	// MarkAllRead marks all unread notifications as read for a store.
 	MarkAllRead(ctx context.Context, db *gorm.DB, storeID uuid.UUID) error
 
+	// --- Customer-scoped (recipient_user_id) — storefront notification bell ---
+
+	// ListByCustomer returns a paginated list of a customer's notifications in a store.
+	ListByCustomer(ctx context.Context, db *gorm.DB, storeID uuid.UUID, recipientUserID string, page, perPage int) (ListResult, error)
+
+	// GetUnreadCountByCustomer returns a customer's unread count in a store.
+	GetUnreadCountByCustomer(ctx context.Context, db *gorm.DB, storeID uuid.UUID, recipientUserID string) (int64, error)
+
+	// MarkReadByCustomer marks one of a customer's notifications as read.
+	MarkReadByCustomer(ctx context.Context, db *gorm.DB, storeID uuid.UUID, recipientUserID string, id uuid.UUID) error
+
+	// MarkAllReadByCustomer marks all of a customer's unread notifications as read.
+	MarkAllReadByCustomer(ctx context.Context, db *gorm.DB, storeID uuid.UUID, recipientUserID string) error
+
 	// Create inserts a new notification row.
 	Create(ctx context.Context, db *gorm.DB, n *Notification) error
 
@@ -107,6 +121,58 @@ func (gormRepository) MarkAllRead(ctx context.Context, db *gorm.DB, storeID uuid
 		Where("store_id = ? AND is_read = false", storeID).
 		Update("is_read", true).Error; err != nil {
 		return fmt.Errorf("notification mark all read: %w", err)
+	}
+	return nil
+}
+
+func (gormRepository) ListByCustomer(ctx context.Context, db *gorm.DB, storeID uuid.UUID, recipientUserID string, page, perPage int) (ListResult, error) {
+	var result ListResult
+	q := db.WithContext(ctx).Model(&Notification{}).
+		Where("store_id = ? AND recipient_user_id = ?", storeID, recipientUserID)
+	if err := q.Count(&result.Total).Error; err != nil {
+		return result, fmt.Errorf("notification customer list count: %w", err)
+	}
+	if page < 1 {
+		page = 1
+	}
+	if perPage < 1 || perPage > 100 {
+		perPage = 20
+	}
+	offset := (page - 1) * perPage
+	if err := q.Order("created_at DESC").Offset(offset).Limit(perPage).Find(&result.Notifications).Error; err != nil {
+		return result, fmt.Errorf("notification customer list: %w", err)
+	}
+	return result, nil
+}
+
+func (gormRepository) GetUnreadCountByCustomer(ctx context.Context, db *gorm.DB, storeID uuid.UUID, recipientUserID string) (int64, error) {
+	var count int64
+	if err := db.WithContext(ctx).Model(&Notification{}).
+		Where("store_id = ? AND recipient_user_id = ? AND is_read = false", storeID, recipientUserID).
+		Count(&count).Error; err != nil {
+		return 0, fmt.Errorf("notification customer unread count: %w", err)
+	}
+	return count, nil
+}
+
+func (gormRepository) MarkReadByCustomer(ctx context.Context, db *gorm.DB, storeID uuid.UUID, recipientUserID string, id uuid.UUID) error {
+	res := db.WithContext(ctx).Model(&Notification{}).
+		Where("store_id = ? AND recipient_user_id = ? AND id = ?", storeID, recipientUserID, id).
+		Update("is_read", true)
+	if res.Error != nil {
+		return fmt.Errorf("notification customer mark read: %w", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return apperrors.NotFound("notification")
+	}
+	return nil
+}
+
+func (gormRepository) MarkAllReadByCustomer(ctx context.Context, db *gorm.DB, storeID uuid.UUID, recipientUserID string) error {
+	if err := db.WithContext(ctx).Model(&Notification{}).
+		Where("store_id = ? AND recipient_user_id = ? AND is_read = false", storeID, recipientUserID).
+		Update("is_read", true).Error; err != nil {
+		return fmt.Errorf("notification customer mark all read: %w", err)
 	}
 	return nil
 }

--- a/services/marketplace-api/internal/notification/service.go
+++ b/services/marketplace-api/internal/notification/service.go
@@ -52,6 +52,28 @@ func (s *Service) MarkAllRead(ctx context.Context, storeID uuid.UUID) error {
 	return s.repo.MarkAllRead(ctx, s.db, storeID)
 }
 
+// --- Customer-scoped (storefront notification bell) ---
+
+// ListForCustomer returns a customer's notifications in a store.
+func (s *Service) ListForCustomer(ctx context.Context, storeID uuid.UUID, recipientUserID string, page, perPage int) (ListResult, error) {
+	return s.repo.ListByCustomer(ctx, s.db, storeID, recipientUserID, page, perPage)
+}
+
+// GetUnreadCountForCustomer returns a customer's unread count in a store.
+func (s *Service) GetUnreadCountForCustomer(ctx context.Context, storeID uuid.UUID, recipientUserID string) (int64, error) {
+	return s.repo.GetUnreadCountByCustomer(ctx, s.db, storeID, recipientUserID)
+}
+
+// MarkReadForCustomer marks one of a customer's notifications as read.
+func (s *Service) MarkReadForCustomer(ctx context.Context, storeID uuid.UUID, recipientUserID string, id uuid.UUID) error {
+	return s.repo.MarkReadByCustomer(ctx, s.db, storeID, recipientUserID, id)
+}
+
+// MarkAllReadForCustomer marks all of a customer's notifications as read.
+func (s *Service) MarkAllReadForCustomer(ctx context.Context, storeID uuid.UUID, recipientUserID string) error {
+	return s.repo.MarkAllReadByCustomer(ctx, s.db, storeID, recipientUserID)
+}
+
 // Create inserts a new notification, bypassing preference checks. Reserved
 // for non-toggleable types like system_alert. Feature code should prefer
 // CreateIfEnabled so merchant preferences are honored.
@@ -99,6 +121,22 @@ func Emit(ctx context.Context, svc *Service, logger *slog.Logger, n Notification
 		logger.Warn("notification emit failed",
 			"type", string(n.Type),
 			"store_id", n.StoreID.String(),
+			"err", err.Error())
+	}
+}
+
+// EmitToCustomer is a fire-and-forget helper for customer-facing notifications
+// (recipient_user_id set). Customer notifications are not gated by merchant
+// preferences, so it inserts directly. Nil-safe on svc + no-op without a
+// recipient.
+func EmitToCustomer(ctx context.Context, svc *Service, logger *slog.Logger, n Notification) {
+	if svc == nil || n.RecipientUserID == nil || *n.RecipientUserID == "" {
+		return
+	}
+	if err := svc.Create(ctx, &n); err != nil && logger != nil {
+		logger.Warn("customer notification emit failed",
+			"type", string(n.Type),
+			"recipient", *n.RecipientUserID,
 			"err", err.Error())
 	}
 }

--- a/services/marketplace-api/migrations/000091_notifications_recipient_user_id.down.sql
+++ b/services/marketplace-api/migrations/000091_notifications_recipient_user_id.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS notif_recipient_unread_idx;
+ALTER TABLE notifications DROP COLUMN IF EXISTS recipient_user_id;

--- a/services/marketplace-api/migrations/000091_notifications_recipient_user_id.up.sql
+++ b/services/marketplace-api/migrations/000091_notifications_recipient_user_id.up.sql
@@ -1,0 +1,11 @@
+-- Customer-targeted notifications. When recipient_user_id is set, the
+-- notification belongs to a storefront customer (GIP string user id) and
+-- powers the customer notification bell; when NULL it is the existing
+-- store/staff notification. Nullable so existing rows are unaffected.
+ALTER TABLE notifications ADD COLUMN IF NOT EXISTS recipient_user_id VARCHAR(255);
+
+-- Partial index for the customer bell queries (list + unread count), scoped
+-- to a store + recipient. Only indexes customer rows to keep it small.
+CREATE INDEX IF NOT EXISTS notif_recipient_unread_idx
+    ON notifications (store_id, recipient_user_id, is_read, created_at DESC)
+    WHERE recipient_user_id IS NOT NULL;


### PR DESCRIPTION
recipient_user_id on notifications (migration 000091); storefront /account/notifications endpoints; payment webhook emits a customer 'Order confirmed' notification. Backend for the storefront customer bell (UI follows).