### PR TITLE
fix(marketplace-api): bump ExpectedSchemaVersion to 91

### DIFF
--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 90
+const ExpectedSchemaVersion uint = 91


### PR DESCRIPTION
Migration 000091 made the schema-version guard test fail; bump the constant to 91. Unblocks the customer-notification builds (#142/#143).