### PR TITLE
fix(marketplace-api): scope storefront order reads/writes to the customer

### DIFF
--- a/services/marketplace-api/internal/handlers/storefront/order_detail.go
+++ b/services/marketplace-api/internal/handlers/storefront/order_detail.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -163,6 +164,38 @@ type storefrontAddressResponse struct {
 }
 
 // GetOrder handles GET /storefront/stores/:storeSlug/orders/:id.
+// resolveCallerCustomer identifies which customer a storefront order request is
+// acting for, so reads/writes can be scoped to that customer. It prefers a
+// logged-in session profile (CustomerProfileKey, set by the optional
+// customer-auth middleware); failing that, a trusted backend caller — the Otto
+// support assistant, already authenticated by the storefront key — may act for a
+// verified customer via the X-Customer-Email header (the conversation's
+// OTP/session-verified email). ok=false means no customer is identifiable (e.g.
+// the post-checkout confirmation view), which stays store-scoped only.
+func resolveCallerCustomer(c *gin.Context) (profileID, email string, ok bool) {
+	if pv, exists := c.Get(CustomerProfileKey); exists {
+		if p, _ := pv.(*customer.CustomerProfile); p != nil {
+			return p.ID.String(), "", true
+		}
+	}
+	if e := strings.TrimSpace(c.GetHeader("X-Customer-Email")); e != "" {
+		return "", e, true
+	}
+	return "", "", false
+}
+
+// orderMatchesCaller reports whether order o belongs to the resolved caller —
+// by customer profile id (logged-in) or by email (trusted assistant call).
+func orderMatchesCaller(o *order.Order, profileID, email string) bool {
+	if profileID != "" {
+		return o.CustomerID != nil && o.CustomerID.String() == profileID
+	}
+	if email != "" {
+		return strings.EqualFold(strings.TrimSpace(o.CustomerEmail), email)
+	}
+	return false
+}
+
 func (h *OrderDetailHandler) GetOrder(c *gin.Context) {
 	storeVal, _ := c.Get("store")
 	store, _ := storeVal.(*stores.Store)
@@ -192,6 +225,18 @@ func (h *OrderDetailHandler) GetOrder(c *gin.Context) {
 
 	// Verify order belongs to this store.
 	if o.StoreID.String() != store.ID {
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
+			"error": "not_found", "message": "order not found",
+		})
+		return
+	}
+
+	// Scope to the requesting customer: a logged-in customer or the Otto
+	// assistant (acting for a verified customer via X-Customer-Email) may only
+	// read THEIR own order. Anonymous storefront-key reads (the post-checkout
+	// confirmation view) stay store-scoped. Same not_found on a mismatch so an
+	// order id can't be probed for existence.
+	if pid, email, ok := resolveCallerCustomer(c); ok && !orderMatchesCaller(o, pid, email) {
 		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
 			"error": "not_found", "message": "order not found",
 		})

--- a/services/marketplace-api/internal/handlers/storefront/order_returns.go
+++ b/services/marketplace-api/internal/handlers/storefront/order_returns.go
@@ -80,13 +80,14 @@ func (h *OrderDetailHandler) RequestReturn(c *gin.Context) {
 		return
 	}
 
-	profileVal, exists := c.Get(CustomerProfileKey)
-	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized", "message": "Sign in to request a return."})
-		return
-	}
-	profile, ok := profileVal.(*customer.CustomerProfile)
-	if !ok || profile == nil {
+	// Identify the customer: a logged-in session profile, or the Otto assistant
+	// acting for a verified customer (X-Customer-Email, gated by the storefront
+	// key). profile may be nil on the assistant path — it's only used for the
+	// notification display name below.
+	profileVal, _ := c.Get(CustomerProfileKey)
+	profile, _ := profileVal.(*customer.CustomerProfile)
+	pid, email, identified := resolveCallerCustomer(c)
+	if !identified {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized", "message": "Sign in to request a return."})
 		return
 	}
@@ -105,7 +106,7 @@ func (h *OrderDetailHandler) RequestReturn(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "not_found", "message": "order not found"})
 		return
 	}
-	if o.StoreID.String() != store.ID || o.CustomerID == nil || o.CustomerID.String() != profile.ID.String() {
+	if o.StoreID.String() != store.ID || !orderMatchesCaller(o, pid, email) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "not_found", "message": "order not found"})
 		return
 	}
@@ -242,9 +243,11 @@ func (h *OrderDetailHandler) ListReturnsForOrder(c *gin.Context) {
 		return
 	}
 
-	profileVal, _ := c.Get(CustomerProfileKey)
-	profile, _ := profileVal.(*customer.CustomerProfile)
-	if profile == nil {
+	// Identify the customer: a logged-in session profile, or the Otto assistant
+	// acting for a verified customer (X-Customer-Email, gated by the storefront
+	// key). No identifiable customer → empty list (never leak others' returns).
+	pid, email, identified := resolveCallerCustomer(c)
+	if !identified {
 		c.JSON(http.StatusOK, gin.H{"returns": []any{}})
 		return
 	}
@@ -259,7 +262,7 @@ func (h *OrderDetailHandler) ListReturnsForOrder(c *gin.Context) {
 	o, _, _, err := h.orderRepo.GetByID(c.Request.Context(), h.db, orderID)
 	if err != nil || o == nil ||
 		o.StoreID.String() != store.ID ||
-		o.CustomerID == nil || o.CustomerID.String() != profile.ID.String() {
+		!orderMatchesCaller(o, pid, email) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
 		return
 	}

--- a/services/marketplace-api/internal/handlers/storefront/order_scope_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/order_scope_test.go
@@ -1,0 +1,60 @@
+package storefront
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/order"
+)
+
+func TestOrderMatchesCaller(t *testing.T) {
+	cid := uuid.New()
+	o := &order.Order{CustomerID: &cid, CustomerEmail: "Jane@Example.com"}
+
+	if !orderMatchesCaller(o, cid.String(), "") {
+		t.Error("matching profile id should match")
+	}
+	if orderMatchesCaller(o, uuid.New().String(), "") {
+		t.Error("a different profile id must NOT match")
+	}
+	if !orderMatchesCaller(o, "", "jane@example.com") {
+		t.Error("email should match case-insensitively")
+	}
+	if orderMatchesCaller(o, "", "someone.else@example.com") {
+		t.Error("a different email must NOT match")
+	}
+	if orderMatchesCaller(o, "", "") {
+		t.Error("no identity must NOT match (fail closed)")
+	}
+
+	// Order with no owning customer id can only be matched by email.
+	noCust := &order.Order{CustomerEmail: "guest@example.com"}
+	if orderMatchesCaller(noCust, uuid.New().String(), "") {
+		t.Error("nil CustomerID must not match a profile id")
+	}
+	if !orderMatchesCaller(noCust, "", "guest@example.com") {
+		t.Error("guest order should match by email")
+	}
+}
+
+func TestResolveCallerCustomer(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Trusted backend caller (Otto MCP) via X-Customer-Email header.
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("GET", "/", nil)
+	c.Request.Header.Set("X-Customer-Email", "  a@b.com  ")
+	if pid, email, ok := resolveCallerCustomer(c); !ok || email != "a@b.com" || pid != "" {
+		t.Errorf("header path: got pid=%q email=%q ok=%v", pid, email, ok)
+	}
+
+	// No session, no header → not identified (fail closed; callers store-scope).
+	c2, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c2.Request = httptest.NewRequest("GET", "/", nil)
+	if _, _, ok := resolveCallerCustomer(c2); ok {
+		t.Error("no identity should resolve ok=false")
+	}
+}


### PR DESCRIPTION
Closes an IDOR: GET /orders/:id was store-scoped only. Now scoped to the requesting customer (session profile or trusted X-Customer-Email from Otto). Applied to GetOrder, ListReturnsForOrder, RequestReturn. Unit-tested.