### PR TITLE
feat(refund): wire order refunds to payment gateway (idempotent saga + retry sweeper)

### DIFF
--- a/docs/superpowers/plans/2026-07-09-order-refund-gateway-wiring.md
+++ b/docs/superpowers/plans/2026-07-09-order-refund-gateway-wiring.md
@@ -1,0 +1,1261 @@
+# Order Refund → Payment Gateway Wiring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every order-refund path (admin refund, return refund, paid self-cancel) actually move money through the customer's original payment gateway, with provider idempotency and a retry sweeper so a refund is never lost and never doubled.
+
+**Architecture:** A single `RefundCoordinator` (`internal/orderrefund/`) that all triggers call. It resolves the order's gateway from `payment_transactions.provider` + `payment_gateway_configs`, runs a ledger-first / idempotency-keyed saga (reserve pending `refund_transactions` row → call gateway → finalize row + `order.RecordRefund` atomically), and is backstopped by a standalone Cloud Run Job sweeper that re-runs stuck `pending` refunds with the same idempotency key.
+
+**Tech Stack:** Go 1.26, Gin, GORM, PostgreSQL, golang-migrate, shopspring/decimal, existing `payment.Gateway` (Stripe/Razorpay/PayPal), robfig/cron (existing standalone-job pattern).
+
+## Global Constraints
+
+- Go 1.26; no stack changes; no new heavy dependencies (reuse existing gateways + repos).
+- Service: `services/marketplace-api`. All paths below are relative to it.
+- Immutable style: return new values, do not mutate shared structs.
+- Error envelope: `{"error": code, "message": human}`; handlers use `RespondErr` / `apperrors`.
+- Conventional commits, single-line messages, no signatures. Commit directly to `main`.
+- **Prod service: no task is complete until its tests are written and green.** Target ≥80% coverage on new/changed packages. Run `go test -race` on touched packages.
+- Feature flag `REFUND_GATEWAY_ENABLED` (env, default `false`) gates every real gateway call and the auto-cancel-refund. Off ⇒ current behavior.
+- Migrations: golang-migrate, `migrations/NNNNNN_<name>.{up,down}.sql`, next number `000092`.
+- Money never moves inside a DB transaction. Gateway call sits between two DB txns.
+
+---
+
+### Task 1: Migration — extend `refund_transactions` for the saga
+
+**Files:**
+- Create: `migrations/000092_refund_transactions_saga.up.sql`
+- Create: `migrations/000092_refund_transactions_saga.down.sql`
+- Modify: `internal/payment/repository.go` (RefundTransaction struct: add `OrderID`, keep `Status`, add `IdempotencyKey`)
+
+**Interfaces:**
+- Produces: `refund_transactions` columns `order_id uuid`, `status varchar(30)`, `idempotency_key varchar(255)` with `UNIQUE(idempotency_key)` and index `(status, created_at)`. Struct field `RefundTransaction.OrderID string`, `.IdempotencyKey string`.
+
+- [ ] **Step 1: Write the up migration (defensive — nullable then tighten)**
+
+`migrations/000092_refund_transactions_saga.up.sql`:
+```sql
+-- Extend refund_transactions to be the saga ledger (spec §5).
+-- Columns added nullable first so the migration is safe even if rows exist,
+-- then tightened. No real gateway refunds have moved money yet, so backfill
+-- of order_id is best-effort (left NULL for any legacy rows).
+ALTER TABLE refund_transactions
+    ADD COLUMN IF NOT EXISTS order_id        uuid,
+    ADD COLUMN IF NOT EXISTS idempotency_key varchar(255);
+
+-- status already referenced by the webhook handler; ensure it exists + default.
+ALTER TABLE refund_transactions
+    ALTER COLUMN status SET DEFAULT 'pending';
+
+-- Backfill legacy rows to a stable synthetic key so the UNIQUE index can be
+-- created without collisions.
+UPDATE refund_transactions
+   SET idempotency_key = 'legacy:' || id::text
+ WHERE idempotency_key IS NULL;
+
+ALTER TABLE refund_transactions
+    ALTER COLUMN idempotency_key SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_refund_transactions_idempotency_key
+    ON refund_transactions (idempotency_key);
+
+CREATE INDEX IF NOT EXISTS ix_refund_transactions_status_created
+    ON refund_transactions (status, created_at);
+
+CREATE INDEX IF NOT EXISTS ix_refund_transactions_order_id
+    ON refund_transactions (order_id);
+```
+
+- [ ] **Step 2: Write the down migration**
+
+`migrations/000092_refund_transactions_saga.down.sql`:
+```sql
+DROP INDEX IF EXISTS ix_refund_transactions_order_id;
+DROP INDEX IF EXISTS ix_refund_transactions_status_created;
+DROP INDEX IF EXISTS ux_refund_transactions_idempotency_key;
+ALTER TABLE refund_transactions ALTER COLUMN status DROP DEFAULT;
+ALTER TABLE refund_transactions
+    DROP COLUMN IF EXISTS idempotency_key,
+    DROP COLUMN IF EXISTS order_id;
+```
+
+- [ ] **Step 3: Update the GORM model**
+
+In `internal/payment/repository.go`, add to `RefundTransaction` (after `StoreID`):
+```go
+	OrderID           string          `gorm:"column:order_id;type:uuid;index"                json:"order_id"`
+	IdempotencyKey    string          `gorm:"column:idempotency_key;type:varchar(255);uniqueIndex" json:"idempotency_key"`
+```
+(`Status` already exists.)
+
+- [ ] **Step 4: Run the migration up + down locally to verify**
+
+Run: `make migrate-up && make migrate-down && make migrate-up` (see `Makefile`; falls back to `migrate -path migrations -database "$DATABASE_URL" up`)
+Expected: no errors; `\d refund_transactions` shows the three columns + indexes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add migrations/000092_refund_transactions_saga.up.sql migrations/000092_refund_transactions_saga.down.sql internal/payment/repository.go
+git commit -m "feat(refund): extend refund_transactions with order_id, status, idempotency_key"
+```
+
+---
+
+### Task 2: Add `refund_unavailable` app error
+
+**Files:**
+- Modify: `pkg/apperrors/errors.go`
+- Modify: `pkg/apperrors/codes.go` (or wherever `Code*` consts live — grep `CodeRefundExceedsTotal`)
+- Test: `pkg/apperrors/errors_test.go`
+
+**Interfaces:**
+- Produces: `apperrors.ErrRefundUnavailable` (sentinel, `errors.Is`-comparable), `apperrors.RefundUnavailable(reason string) *Error`, HTTP 422.
+
+- [ ] **Step 1: Write the failing test**
+
+`pkg/apperrors/errors_test.go` (add):
+```go
+func TestRefundUnavailable(t *testing.T) {
+	err := apperrors.RefundUnavailable("no captured payment")
+	if !errors.Is(err, apperrors.ErrRefundUnavailable) {
+		t.Fatalf("want ErrRefundUnavailable, got %v", err)
+	}
+	if got := apperrors.HTTPStatus(err); got != 422 {
+		t.Fatalf("want 422, got %d", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/apperrors/ -run TestRefundUnavailable -v`
+Expected: FAIL — `undefined: apperrors.RefundUnavailable`.
+
+- [ ] **Step 3: Implement**
+
+In `codes.go` add const near `CodeRefundExceedsTotal`:
+```go
+	CodeRefundUnavailable = "refund_unavailable"
+```
+In `errors.go` add sentinel near `ErrRefundExceedsTotal`:
+```go
+	ErrRefundUnavailable = &Error{Code: CodeRefundUnavailable}
+```
+Add constructor (mirror existing constructors like `ValidationFailed`):
+```go
+// RefundUnavailable is returned when an order cannot be refunded through the
+// gateway (no captured payment transaction — COD/manual/authorized-only).
+func RefundUnavailable(reason string) *Error {
+	return &Error{Code: CodeRefundUnavailable, Message: reason}
+}
+```
+Ensure the code→HTTP map returns 422 for `CodeRefundUnavailable` (mirror `CodeRefundExceedsTotal`'s mapping — grep it and add the same entry).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pkg/apperrors/ -run TestRefundUnavailable -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/apperrors/
+git commit -m "feat(refund): add refund_unavailable (422) app error"
+```
+
+---
+
+### Task 3: Add `IdempotencyKey` to `RefundInput` + Stripe header
+
+**Files:**
+- Modify: `internal/payment/gateway.go` (RefundInput struct)
+- Modify: `internal/payment/stripe.go:RefundPayment`
+- Test: `internal/payment/stripe_test.go`
+
+**Interfaces:**
+- Produces: `payment.RefundInput.IdempotencyKey string`. Stripe sends `Idempotency-Key: <key>` header when non-empty.
+
+- [ ] **Step 1: Add the field**
+
+In `internal/payment/gateway.go`, `RefundInput`:
+```go
+type RefundInput struct {
+	ProviderPaymentID string
+	Amount            decimal.Decimal
+	CurrencyCode      string
+	Reason            string
+	IdempotencyKey    string // provider idempotency key; retries with the same key never double-refund
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+`internal/payment/stripe_test.go` (add):
+```go
+func TestStripeRefund_SendsIdempotencyKey(t *testing.T) {
+	var gotKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("Idempotency-Key")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"re_1","status":"succeeded","amount":5000}`))
+	}))
+	defer srv.Close()
+
+	gw := payment.NewStripeGatewayWithBaseURL("sk_test", "", "test", srv.URL) // see Step 3
+	_, err := gw.RefundPayment(context.Background(), payment.RefundInput{
+		ProviderPaymentID: "pi_1", Amount: decimal.NewFromInt(50), CurrencyCode: "usd",
+		IdempotencyKey: "refund:order-123:cancel",
+	})
+	if err != nil {
+		t.Fatalf("refund: %v", err)
+	}
+	if gotKey != "refund:order-123:cancel" {
+		t.Fatalf("Idempotency-Key = %q, want the key", gotKey)
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails, then implement**
+
+Run: `go test ./internal/payment/ -run TestStripeRefund_SendsIdempotencyKey -v`
+Expected: FAIL (`NewStripeGatewayWithBaseURL` undefined and/or header empty).
+
+Implement:
+1. If a base-URL test seam does not already exist, add one in `stripe.go` mirroring the existing constructor:
+```go
+// NewStripeGatewayWithBaseURL is the test seam for pointing at an httptest server.
+func NewStripeGatewayWithBaseURL(apiKey, secretKey, mode, baseURL string) *StripeGateway {
+	g := NewStripeGateway(apiKey, secretKey, mode)
+	g.baseURL = baseURL
+	return g
+}
+```
+(If a seam already exists — grep `baseURL` in `stripe.go` — reuse it.)
+
+2. In `StripeGateway.RefundPayment`, after building `req` and before `s.client.Do(req)`:
+```go
+	if in.IdempotencyKey != "" {
+		req.Header.Set("Idempotency-Key", in.IdempotencyKey)
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/payment/ -run TestStripeRefund_SendsIdempotencyKey -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/payment/gateway.go internal/payment/stripe.go internal/payment/stripe_test.go
+git commit -m "feat(refund): Stripe refund sends Idempotency-Key header"
+```
+
+---
+
+### Task 4: Razorpay refund idempotency + notes
+
+**Files:**
+- Modify: `internal/payment/razorpay.go:RefundPayment`
+- Test: `internal/payment/razorpay_test.go`
+
+**Interfaces:**
+- Consumes: `RefundInput.IdempotencyKey` (Task 3).
+- Produces: Razorpay refund sends header `X-Razorpay-Idempotency: <key>` and `notes[order_reason]=<reason>` (mirrors Home-Chef `RefundRequest.Notes`).
+
+- [ ] **Step 1: Write the failing test**
+
+`internal/payment/razorpay_test.go` (add):
+```go
+func TestRazorpayRefund_SendsIdempotencyHeaderAndNotes(t *testing.T) {
+	var gotKey string
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("X-Razorpay-Idempotency")
+		body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"rfnd_1","status":"processed","amount":5000}`))
+	}))
+	defer srv.Close()
+
+	gw := payment.NewRazorpayGatewayWithBaseURL("key", "secret", "test", srv.URL)
+	_, err := gw.RefundPayment(context.Background(), payment.RefundInput{
+		ProviderPaymentID: "pay_1", Amount: decimal.NewFromInt(50), CurrencyCode: "INR",
+		Reason: "cancelled", IdempotencyKey: "refund:order-9:cancel",
+	})
+	if err != nil {
+		t.Fatalf("refund: %v", err)
+	}
+	if gotKey != "refund:order-9:cancel" {
+		t.Fatalf("idempotency header = %q", gotKey)
+	}
+	if !strings.Contains(string(body), "cancelled") {
+		t.Fatalf("reason not in notes: %s", body)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/payment/ -run TestRazorpayRefund_SendsIdempotencyHeaderAndNotes -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Add `NewRazorpayGatewayWithBaseURL` seam (mirror Task 3 Step 3 if not present). In `RefundPayment`, include notes in the JSON body and set the header before `Do`:
+```go
+	if in.IdempotencyKey != "" {
+		req.Header.Set("X-Razorpay-Idempotency", in.IdempotencyKey)
+	}
+```
+When constructing the refund request body, add:
+```go
+	"notes": map[string]string{"order_reason": in.Reason},
+```
+(match the existing body-building style in this method — it may use `url.Values` or JSON; keep it consistent).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./internal/payment/ -run TestRazorpayRefund_SendsIdempotencyHeaderAndNotes -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/payment/razorpay.go internal/payment/razorpay_test.go
+git commit -m "feat(refund): Razorpay refund sends idempotency header + notes"
+```
+
+---
+
+### Task 5: PayPal refund idempotency (`PayPal-Request-Id`)
+
+**Files:**
+- Modify: `internal/payment/paypal.go:RefundPayment`
+- Test: `internal/payment/paypal_test.go`
+
+**Interfaces:**
+- Consumes: `RefundInput.IdempotencyKey`.
+- Produces: PayPal refund sends header `PayPal-Request-Id: <key>`.
+
+- [ ] **Step 1: Write the failing test**
+
+`internal/payment/paypal_test.go` (add):
+```go
+func TestPayPalRefund_SendsRequestId(t *testing.T) {
+	var gotKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/oauth2/token") {
+			_, _ = w.Write([]byte(`{"access_token":"t","expires_in":3600}`))
+			return
+		}
+		gotKey = r.Header.Get("PayPal-Request-Id")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"RF-1","status":"COMPLETED"}`))
+	}))
+	defer srv.Close()
+
+	gw := payment.NewPayPalGatewayWithBaseURL("id", "secret", "test", srv.URL)
+	_, err := gw.RefundPayment(context.Background(), payment.RefundInput{
+		ProviderPaymentID: "CAP-1", Amount: decimal.NewFromInt(50), CurrencyCode: "USD",
+		IdempotencyKey: "refund:order-7:ret-2",
+	})
+	if err != nil {
+		t.Fatalf("refund: %v", err)
+	}
+	if gotKey != "refund:order-7:ret-2" {
+		t.Fatalf("PayPal-Request-Id = %q", gotKey)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/payment/ -run TestPayPalRefund_SendsRequestId -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Add `NewPayPalGatewayWithBaseURL` seam (mirror; PayPal has both token + api base — set both to `baseURL` for the test). In `RefundPayment`, before `Do`:
+```go
+	if in.IdempotencyKey != "" {
+		req.Header.Set("PayPal-Request-Id", in.IdempotencyKey)
+	}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./internal/payment/ -run TestPayPalRefund_SendsRequestId -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/payment/paypal.go internal/payment/paypal_test.go
+git commit -m "feat(refund): PayPal refund sends PayPal-Request-Id header"
+```
+
+---
+
+### Task 6: Payment saga primitives (reserve / execute / finalize)
+
+**Files:**
+- Modify: `internal/payment/repository.go` (tx-aware ledger methods)
+- Modify: `internal/payment/service.go` (saga methods)
+- Test: `internal/payment/service_test.go`
+
+**Interfaces:**
+- Consumes: `RefundInput.IdempotencyKey`, `Gateway.RefundPayment`.
+- Produces:
+  - `payment.Service.ReserveRefund(ctx, tx *gorm.DB, in ReserveRefundInput) (*RefundTransaction, bool, error)` — inserts a `pending` row `ON CONFLICT (idempotency_key) DO NOTHING`; bool `created`=false when the key already existed (returns the existing row).
+  - `payment.Service.ExecuteGatewayRefund(ctx, gw Gateway, in RefundInput) (*Refund, error)` — pure gateway call, no DB.
+  - `payment.Service.FinalizeRefund(ctx, tx *gorm.DB, ledgerID, providerRefundID, status string) error`.
+  - `ReserveRefundInput{TenantID, StoreID, OrderID, Provider, ProviderPaymentID, Amount, CurrencyCode, Reason, IdempotencyKey}`.
+
+- [ ] **Step 1: Add tx-aware repo methods**
+
+In `internal/payment/repository.go`, add to the `Repository` interface and `gormRepository`:
+```go
+	// InsertRefundPending inserts a pending refund row inside tx. Returns
+	// (row, created). created=false ⇒ a row with this idempotency_key already
+	// existed (returned instead) — the saga re-entry guard.
+	InsertRefundPending(tx *gorm.DB, r *RefundTransaction) (*RefundTransaction, bool, error)
+	// UpdateRefundOutcome sets status + provider_refund_id on a ledger row.
+	UpdateRefundOutcome(tx *gorm.DB, ledgerID, providerRefundID, status string) error
+	// GetRefundByIdempotencyKey reads a ledger row by its unique key.
+	GetRefundByIdempotencyKey(ctx context.Context, key string) (*RefundTransaction, error)
+```
+Implementation:
+```go
+func (r *gormRepository) InsertRefundPending(tx *gorm.DB, row *RefundTransaction) (*RefundTransaction, bool, error) {
+	if row.Status == "" {
+		row.Status = "pending"
+	}
+	res := tx.Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "idempotency_key"}}, DoNothing: true}).Create(row)
+	if res.Error != nil {
+		return nil, false, res.Error
+	}
+	if res.RowsAffected == 1 {
+		return row, true, nil
+	}
+	var existing RefundTransaction
+	if err := tx.Where("idempotency_key = ?", row.IdempotencyKey).First(&existing).Error; err != nil {
+		return nil, false, err
+	}
+	return &existing, false, nil
+}
+
+func (r *gormRepository) UpdateRefundOutcome(tx *gorm.DB, ledgerID, providerRefundID, status string) error {
+	return tx.Model(&RefundTransaction{}).Where("id = ?", ledgerID).
+		Updates(map[string]any{"provider_refund_id": providerRefundID, "status": status, "updated_at": gorm.Expr("now()")}).Error
+}
+
+func (r *gormRepository) GetRefundByIdempotencyKey(ctx context.Context, key string) (*RefundTransaction, error) {
+	var row RefundTransaction
+	if err := r.db.WithContext(ctx).Where("idempotency_key = ?", key).First(&row).Error; err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+```
+Add `import "gorm.io/gorm/clause"`.
+
+- [ ] **Step 2: Write the failing service test**
+
+`internal/payment/service_test.go` (add; uses the package's existing fake `Repository` + fake `Gateway` — mirror existing tests in this file):
+```go
+func TestReserveRefund_Idempotent(t *testing.T) {
+	// second reserve with same key returns created=false + same row
+	// (exercised against the fake repo; see existing fakes in this file)
+}
+
+func TestExecuteGatewayRefund_PassesIdempotencyKey(t *testing.T) {
+	fg := &fakeGateway{refund: &payment.Refund{ProviderRefundID: "re_9", Status: "succeeded"}}
+	svc := payment.NewService(&fakeRepo{})
+	_, err := svc.ExecuteGatewayRefund(context.Background(), fg, payment.RefundInput{
+		ProviderPaymentID: "pi_1", Amount: decimal.NewFromInt(10), IdempotencyKey: "k1",
+	})
+	if err != nil { t.Fatal(err) }
+	if fg.lastIn.IdempotencyKey != "k1" {
+		t.Fatalf("gateway got key %q", fg.lastIn.IdempotencyKey)
+	}
+}
+```
+(Extend the file's existing `fakeGateway` to record `lastIn RefundInput`; if no fake exists yet, add one implementing `payment.Gateway` with the four other methods returning zero values.)
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `go test ./internal/payment/ -run 'TestReserveRefund_Idempotent|TestExecuteGatewayRefund' -v`
+Expected: FAIL — methods undefined.
+
+- [ ] **Step 4: Implement the service methods**
+
+In `internal/payment/service.go`:
+```go
+type ReserveRefundInput struct {
+	TenantID, StoreID, OrderID  string
+	Provider, ProviderPaymentID string
+	Amount                      decimal.Decimal
+	CurrencyCode, Reason        string
+	IdempotencyKey              string
+}
+
+func (s *Service) ReserveRefund(ctx context.Context, tx *gorm.DB, in ReserveRefundInput) (*RefundTransaction, bool, error) {
+	return s.repo.InsertRefundPending(tx, &RefundTransaction{
+		TenantID: in.TenantID, StoreID: in.StoreID, OrderID: in.OrderID,
+		Provider: in.Provider, ProviderPaymentID: in.ProviderPaymentID,
+		Amount: in.Amount, Reason: in.Reason, Status: "pending",
+		IdempotencyKey: in.IdempotencyKey,
+	})
+}
+
+func (s *Service) ExecuteGatewayRefund(ctx context.Context, gw Gateway, in RefundInput) (*Refund, error) {
+	r, err := gw.RefundPayment(ctx, in)
+	if err != nil {
+		return nil, fmt.Errorf("payment service: gateway refund: %w", err)
+	}
+	return r, nil
+}
+
+func (s *Service) FinalizeRefund(ctx context.Context, tx *gorm.DB, ledgerID, providerRefundID, status string) error {
+	return s.repo.UpdateRefundOutcome(tx, ledgerID, providerRefundID, status)
+}
+```
+Add `import "gorm.io/gorm"` to service.go. Leave the legacy `RefundPayment` in place (now unused by handlers) or mark deprecated.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `go test ./internal/payment/ -race -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/payment/repository.go internal/payment/service.go internal/payment/service_test.go
+git commit -m "feat(refund): payment saga primitives (reserve/execute/finalize)"
+```
+
+---
+
+### Task 7: Gateway + payment-txn resolver for orders
+
+**Files:**
+- Create: `internal/orderrefund/resolver.go`
+- Test: `internal/orderrefund/resolver_test.go`
+
+**Interfaces:**
+- Produces:
+  - `PaymentContext{Provider, ProviderPaymentID string; CapturedTotal decimal.Decimal; Found bool}`.
+  - `Resolver.PaymentContextForOrder(ctx, orderID uuid.UUID) (PaymentContext, error)` — reads `payment_transactions`; `Found=false` when no captured txn.
+  - `Resolver.GatewayFor(ctx, storeID uuid.UUID, provider string) (payment.Gateway, error)` — reads `payment_gateway_configs`, calls `payment.NewGateway`.
+
+- [ ] **Step 1: Write the failing test**
+
+`internal/orderrefund/resolver_test.go` (integration-style against a test DB helper — reuse the pattern in `internal/order/testhelpers_integration_test.go`):
+```go
+//go:build integration
+func TestPaymentContextForOrder_CapturedTotal(t *testing.T) {
+	db := testDB(t) // shared helper
+	orderID := uuid.New()
+	seedPaymentTxn(t, db, orderID, "stripe", "pi_1", "100.00", "captured")
+	r := orderrefund.NewResolver(db)
+	pc, err := r.PaymentContextForOrder(context.Background(), orderID)
+	if err != nil { t.Fatal(err) }
+	if !pc.Found || pc.Provider != "stripe" || !pc.CapturedTotal.Equal(decimal.RequireFromString("100.00")) {
+		t.Fatalf("unexpected: %+v", pc)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test -tags integration ./internal/orderrefund/ -run TestPaymentContextForOrder_CapturedTotal -v`
+Expected: FAIL — package/functions undefined.
+
+- [ ] **Step 3: Implement**
+
+`internal/orderrefund/resolver.go`:
+```go
+package orderrefund
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/payment"
+)
+
+type PaymentContext struct {
+	Provider          string
+	ProviderPaymentID string
+	CapturedTotal     decimal.Decimal
+	Found             bool
+}
+
+type Resolver struct{ db *gorm.DB }
+
+func NewResolver(db *gorm.DB) *Resolver { return &Resolver{db: db} }
+
+// PaymentContextForOrder returns the captured payment for an order. Only rows
+// in a captured/paid state count toward CapturedTotal so authorized-only
+// orders are treated as non-refundable (Found=false).
+func (r *Resolver) PaymentContextForOrder(ctx context.Context, orderID uuid.UUID) (PaymentContext, error) {
+	type row struct {
+		Provider          string
+		ProviderIntentID  string
+		Amount            decimal.Decimal
+	}
+	var rows []row
+	if err := r.db.WithContext(ctx).
+		Table("payment_transactions").
+		Select("provider", "provider_intent_id", "amount").
+		Where("order_id = ? AND status IN ('captured','paid','succeeded')", orderID).
+		Order("created_at ASC").
+		Scan(&rows).Error; err != nil {
+		return PaymentContext{}, err
+	}
+	if len(rows) == 0 {
+		return PaymentContext{Found: false}, nil
+	}
+	total := decimal.Zero
+	for _, x := range rows {
+		total = total.Add(x.Amount)
+	}
+	return PaymentContext{
+		Provider:          rows[0].Provider,
+		ProviderPaymentID: rows[0].ProviderIntentID,
+		CapturedTotal:     total,
+		Found:             true,
+	}, nil
+}
+
+type gatewayConfigRow struct {
+	Provider  string `gorm:"column:provider"`
+	APIKey    string `gorm:"column:api_key_encrypted"`
+	SecretKey string `gorm:"column:secret_key_encrypted"`
+	Mode      string `gorm:"column:mode"`
+}
+
+func (gatewayConfigRow) TableName() string { return "payment_gateway_configs" }
+
+func (r *Resolver) GatewayFor(ctx context.Context, storeID uuid.UUID, provider string) (payment.Gateway, error) {
+	var cfg gatewayConfigRow
+	if err := r.db.WithContext(ctx).
+		Where("store_id = ? AND provider = ? AND is_active = true", storeID, provider).
+		First(&cfg).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("orderrefund: no active %q gateway config for store %s", provider, storeID)
+		}
+		return nil, err
+	}
+	return payment.NewGateway(provider, cfg.APIKey, cfg.SecretKey, cfg.Mode)
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test -tags integration ./internal/orderrefund/ -run TestPaymentContextForOrder_CapturedTotal -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/orderrefund/resolver.go internal/orderrefund/resolver_test.go
+git commit -m "feat(refund): order payment-context + gateway resolver"
+```
+
+---
+
+### Task 8: RefundCoordinator core (amount/status derivation + saga)
+
+**Files:**
+- Create: `internal/orderrefund/coordinator.go`
+- Test: `internal/orderrefund/coordinator_test.go`
+
+**Interfaces:**
+- Consumes: `Resolver` (Task 7), `payment.Service` saga methods (Task 6), `order.Service.RecordRefund` (existing), `order.Repository.GetByID` (existing).
+- Produces:
+  - `RefundCommand{OrderID uuid.UUID; Amount *decimal.Decimal; Reason string; Actor string; ScopeID string}` — `Amount==nil` ⇒ full remaining; `ScopeID` sets the idempotency scope (`return_id`, `"cancel:"+orderID`, or a refund-request UUID).
+  - `RefundResult{ProviderRefundID string; Amount decimal.Decimal; PaymentStatus order.PaymentStatus; AlreadyDone bool}`.
+  - `Coordinator.Refund(ctx, cmd RefundCommand) (RefundResult, error)` — returns `apperrors.ErrRefundUnavailable` when no captured txn; `apperrors.ErrRefundExceedsTotal` when over cap.
+  - `NewCoordinator(db *gorm.DB, res *Resolver, pay *payment.Service, orders *order.Service, orderRepo order.Repository, enabled bool) *Coordinator`.
+
+- [ ] **Step 1: Write the failing unit tests (fakes, no DB)**
+
+`internal/orderrefund/coordinator_test.go`:
+```go
+func TestDeriveStatus(t *testing.T) {
+	gt := decimal.RequireFromString("120.00")
+	cases := []struct{ refunded, amount string; want order.PaymentStatus }{
+		{"0", "50.00", order.PaymentStatusPartiallyRefunded},
+		{"0", "120.00", order.PaymentStatusRefunded},
+		{"60.00", "60.00", order.PaymentStatusRefunded},
+		{"60.00", "30.00", order.PaymentStatusPartiallyRefunded},
+	}
+	for _, c := range cases {
+		got := orderrefund.DeriveStatus(decimal.RequireFromString(c.refunded), decimal.RequireFromString(c.amount), gt)
+		if got != c.want {
+			t.Fatalf("refunded=%s amount=%s => %s, want %s", c.refunded, c.amount, got, c.want)
+		}
+	}
+}
+```
+Plus (with fake resolver/payment/order via small interfaces — see Step 3 for the interface seams):
+- `TestRefund_NoCapturedTxn_Unavailable` → `errors.Is(err, apperrors.ErrRefundUnavailable)`, gateway never called.
+- `TestRefund_OverCap_Rejected` → `errors.Is(err, apperrors.ErrRefundExceedsTotal)`, gateway never called.
+- `TestRefund_FullNilAmount_RefundsRemaining` → amount == grand_total − refunded.
+- `TestRefund_GatewayError_LeavesPending` → coordinator returns error, no `RecordRefund` call.
+- `TestRefund_Disabled_SkipsGateway` → `enabled=false` ⇒ returns a clear error (does NOT silently bookkeep).
+- `TestRefund_IdempotencyKeyStable` → same `(OrderID, ScopeID)` ⇒ identical key string.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `go test ./internal/orderrefund/ -run TestRefund -v`
+Expected: FAIL — undefined.
+
+- [ ] **Step 3: Implement**
+
+`internal/orderrefund/coordinator.go`:
+```go
+package orderrefund
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/internal/payment"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+)
+
+type RefundCommand struct {
+	OrderID uuid.UUID
+	Amount  *decimal.Decimal // nil ⇒ full remaining
+	Reason  string
+	Actor   string
+	ScopeID string // idempotency scope: return_id | "cancel:"+orderID | refund_request_id
+}
+
+type RefundResult struct {
+	ProviderRefundID string
+	Amount           decimal.Decimal
+	PaymentStatus    order.PaymentStatus
+	AlreadyDone      bool
+}
+
+type Coordinator struct {
+	db        *gorm.DB
+	res       *Resolver
+	pay       *payment.Service
+	orders    *order.Service
+	orderRepo order.Repository
+	enabled   bool
+}
+
+func NewCoordinator(db *gorm.DB, res *Resolver, pay *payment.Service, orders *order.Service, orderRepo order.Repository, enabled bool) *Coordinator {
+	return &Coordinator{db: db, res: res, pay: pay, orders: orders, orderRepo: orderRepo, enabled: enabled}
+}
+
+// DeriveStatus picks partially_refunded vs refunded from the post-refund total.
+func DeriveStatus(refunded, amount, grandTotal decimal.Decimal) order.PaymentStatus {
+	if refunded.Add(amount).GreaterThanOrEqual(grandTotal) {
+		return order.PaymentStatusRefunded
+	}
+	return order.PaymentStatusPartiallyRefunded
+}
+
+func idempotencyKey(orderID uuid.UUID, scopeID string) string {
+	return "refund:" + orderID.String() + ":" + scopeID
+}
+
+func (c *Coordinator) Refund(ctx context.Context, cmd RefundCommand) (RefundResult, error) {
+	if !c.enabled {
+		return RefundResult{}, fmt.Errorf("orderrefund: gateway refunds disabled (REFUND_GATEWAY_ENABLED=false)")
+	}
+	o, _, _, err := c.orderRepo.GetByID(ctx, c.db, cmd.OrderID)
+	if err != nil || o == nil {
+		return RefundResult{}, apperrors.NotFound("order")
+	}
+	pc, err := c.res.PaymentContextForOrder(ctx, cmd.OrderID)
+	if err != nil {
+		return RefundResult{}, err
+	}
+	if !pc.Found {
+		return RefundResult{}, apperrors.RefundUnavailable("no captured payment for this order")
+	}
+
+	remaining := o.GrandTotal.Sub(o.RefundedAmount)
+	amount := remaining
+	if cmd.Amount != nil {
+		amount = *cmd.Amount
+	}
+	if amount.LessThanOrEqual(decimal.Zero) {
+		return RefundResult{}, apperrors.ValidationFailed("amount", "refund amount must be positive")
+	}
+	cap := decimal.Min(o.GrandTotal, pc.CapturedTotal)
+	if o.RefundedAmount.Add(amount).GreaterThan(cap) {
+		return RefundResult{}, apperrors.ErrRefundExceedsTotal
+	}
+	target := DeriveStatus(o.RefundedAmount, amount, o.GrandTotal)
+	key := idempotencyKey(cmd.OrderID, cmd.ScopeID)
+
+	gw, err := c.res.GatewayFor(ctx, o.StoreID, pc.Provider)
+	if err != nil {
+		return RefundResult{}, err
+	}
+
+	// tx #1 — reserve pending ledger row (idempotent).
+	var ledger *payment.RefundTransaction
+	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		row, _, rErr := c.pay.ReserveRefund(ctx, tx, payment.ReserveRefundInput{
+			TenantID: o.TenantID.String(), StoreID: o.StoreID.String(), OrderID: cmd.OrderID.String(),
+			Provider: pc.Provider, ProviderPaymentID: pc.ProviderPaymentID,
+			Amount: amount, CurrencyCode: o.CurrencyCode, Reason: cmd.Reason, IdempotencyKey: key,
+		})
+		ledger = row
+		return rErr
+	}); err != nil {
+		return RefundResult{}, err
+	}
+	if ledger.Status == "succeeded" {
+		return RefundResult{ProviderRefundID: ledger.ProviderRefundID, Amount: amount, PaymentStatus: target, AlreadyDone: true}, nil
+	}
+
+	// gateway call — real money, retry-safe via key.
+	ref, err := c.pay.ExecuteGatewayRefund(ctx, gw, payment.RefundInput{
+		ProviderPaymentID: pc.ProviderPaymentID, Amount: amount,
+		CurrencyCode: o.CurrencyCode, Reason: cmd.Reason, IdempotencyKey: key,
+	})
+	if err != nil {
+		return RefundResult{}, err // ledger stays pending → sweeper retries
+	}
+
+	// tx #2 — finalize ledger + bookkeeping, atomic.
+	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := c.pay.FinalizeRefund(ctx, tx, ledger.ID, ref.ProviderRefundID, "succeeded"); err != nil {
+			return err
+		}
+		return c.orders.RecordRefund(ctx, tx, cmd.OrderID, amount, target, cmd.Reason)
+	}); err != nil {
+		return RefundResult{}, err
+	}
+	return RefundResult{ProviderRefundID: ref.ProviderRefundID, Amount: amount, PaymentStatus: target}, nil
+}
+```
+Note the unit tests in Step 1 need small interface seams. Refactor `res`, `pay`, `orders` dependencies behind narrow interfaces defined in this package (e.g. `paymentContexter`, `gatewayResolver`, `refundLedger`, `bookkeeper`) so the fakes can be injected. Define those interfaces and have `NewCoordinator` accept them; the concrete `*Resolver`/`*payment.Service`/`*order.Service` satisfy them. (This keeps `DeriveStatus`, cap, and unavailable logic unit-testable without a DB.)
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `go test ./internal/orderrefund/ -race -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/orderrefund/coordinator.go internal/orderrefund/coordinator_test.go
+git commit -m "feat(refund): RefundCoordinator core saga + amount/status derivation"
+```
+
+---
+
+### Task 9: Wire admin order refund handler → coordinator
+
+**Files:**
+- Modify: `internal/handlers/admin/orders.go:Refund` (~line 467)
+- Modify: `internal/handlers/admin/orders_dto.go` (RefundOrderRequest: add `RefundRequestID`, deprecate `PaymentStatus`)
+- Modify: `internal/handlers/admin/routes.go` (inject coordinator into OrdersHandler)
+- Test: `internal/handlers/admin/orders_refund_integration_test.go`
+
+**Interfaces:**
+- Consumes: `orderrefund.Coordinator.Refund`.
+- Produces: admin `POST /admin/stores/:storeId/orders/:id/refund` now moves money; response includes `provider_refund_id` + derived `payment_status`.
+
+- [ ] **Step 1: Update the request DTO**
+
+In `orders_dto.go`:
+```go
+type RefundOrderRequest struct {
+	Amount          *decimal.Decimal `json:"amount"`                       // omit ⇒ full remaining
+	RefundRequestID string           `json:"refund_request_id,omitempty"`  // idempotency scope; server generates if empty
+	Reason          string           `json:"reason"`
+	// Deprecated: server derives partial/full from amount. Ignored.
+	PaymentStatus string `json:"payment_status,omitempty"`
+}
+```
+
+- [ ] **Step 2: Write the failing integration test**
+
+`internal/handlers/admin/orders_refund_integration_test.go` (build tag `integration`; reuse the admin test harness — grep an existing `*_integration_test.go` in this package for setup). Seed a paid order with a captured stripe `payment_transactions` row and an active `payment_gateway_configs` row; point the gateway at an httptest Stripe stub. Assert:
+```go
+// POST refund amount=50 on a 120 order
+// → 200, body.provider_refund_id != "", body.payment_status == "partially_refunded"
+// → refund_transactions row status='succeeded', order_id set, unique key
+// → orders.refunded_amount == 50.00
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `go test -tags integration ./internal/handlers/admin/ -run Refund -v`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement the handler change**
+
+Replace the body of `Refund` that calls `h.svc.RecordRefund(...)` with:
+```go
+	scope := req.RefundRequestID
+	if scope == "" {
+		scope = uuid.NewString()
+	}
+	res, rerr := h.refunds.Refund(c.Request.Context(), orderrefund.RefundCommand{
+		OrderID: id, Amount: req.Amount, Reason: req.Reason,
+		Actor: "user:" + c.GetString("user_id"), ScopeID: scope,
+	})
+	if rerr != nil {
+		RespondErr(c, rerr, h.logger) // maps ErrRefundUnavailable→422, ErrRefundExceedsTotal→422, ErrInvalidTransition→409
+		return
+	}
+```
+Keep the existing audit emit + `dispatchRefundEmail`, but source the amount/total from `res` and a fresh `GetByID`. Add `h.refunds *orderrefund.Coordinator` to `OrdersHandler` + its constructor; wire it in `routes.go` and `main.go` (deps struct).
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `go test -tags integration ./internal/handlers/admin/ -run Refund -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/handlers/admin/orders.go internal/handlers/admin/orders_dto.go internal/handlers/admin/routes.go internal/handlers/admin/orders_refund_integration_test.go
+git commit -m "feat(refund): admin order refund moves money via coordinator"
+```
+
+---
+
+### Task 10: Wire return refund → coordinator
+
+**Files:**
+- Modify: `internal/order/return_service.go:MarkRefunded`
+- Modify: `internal/handlers/admin/returns.go:MarkRefunded` (pass through; unchanged surface) + its constructor/deps if the coordinator is injected at handler level
+- Test: `internal/order/return_refund_integration_test.go`
+
+**Interfaces:**
+- Consumes: `orderrefund.Coordinator.Refund`.
+- Produces: return happy path (`requested→approved→received→refunded`) moves money and stamps the return, atomically consistent.
+
+**Design note:** to avoid an import cycle (`order` importing `orderrefund` which imports `order`), the coordinator call stays in the **handler** layer, not inside `order.ReturnService`. Change `ReturnsHandler.MarkRefunded` to: (1) call `coordinator.Refund` with `ScopeID = return_id`, then (2) call a slimmed `ReturnService.MarkRefunded` that only stamps the return state + writes the return event (the `RecordRefund` money-bookkeeping now happens inside the coordinator's tx #2). Alternatively pass the return-stamp as a hook. Simpler: coordinator does money + `RecordRefund`; `ReturnService.StampRefundedOnly(ctx, returnID, amount)` stamps `returns` and appends the `return_refunded` event.
+
+- [ ] **Step 1: Add `ReturnService.StampRefundedOnly`**
+
+In `return_service.go`, add a method that does what `MarkRefunded` did **minus** the `orderSvc.RecordRefund` call (that moves to the coordinator):
+```go
+// StampRefundedOnly transitions received→refunded and stamps the return, WITHOUT
+// touching orders.refunded_amount (the coordinator's tx already did that). Used
+// by the handler after orderrefund.Coordinator.Refund succeeds.
+func (s *ReturnService) StampRefundedOnly(ctx context.Context, returnID uuid.UUID, amount decimal.Decimal, reason string) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		r, _, err := s.repo.GetByID(ctx, tx, returnID)
+		if err != nil {
+			return err
+		}
+		if !ReturnStatus(r.Status).CanTransitionTo(ReturnStatusRefunded) {
+			return apperrors.InvalidTransition("return", r.Status, string(ReturnStatusRefunded))
+		}
+		if err := s.repo.UpdateStatus(tx, returnID, ReturnStatusRefunded); err != nil {
+			return err
+		}
+		if err := s.repo.StampRefunded(tx, returnID, amount); err != nil {
+			return err
+		}
+		return s.orderSvc.RecordReturnEvent(ctx, tx, r.OrderID, EventKindReturnRefunded, outbox.EventReturnRefunded, ReturnEventPayload{
+			ReturnID: r.ID.String(), ReturnNumber: r.ReturnNumber, Amount: amount.String(), Reason: reason,
+		})
+	})
+}
+```
+Keep the old `MarkRefunded` for now but stop calling it from the handler.
+
+- [ ] **Step 2: Write the failing integration test**
+
+`internal/order/return_refund_integration_test.go` (tag `integration`): drive request→approve→received, then simulate the handler flow (`coordinator.Refund(ScopeID=returnID)` with a fake gateway + seeded captured txn, then `StampRefundedOnly`). Assert `refund_transactions.succeeded` + `orders.refunded_amount` bumped once + `returns.status='refunded'` + `returns.refund_amount` set.
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `go test -tags integration ./internal/order/ -run ReturnRefund -v`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement handler change**
+
+In `internal/handlers/admin/returns.go:MarkRefunded`, replace the single `h.svc.MarkRefunded(...)` call with: load the return to get `order_id` + amount, call `h.refunds.Refund(ctx, RefundCommand{OrderID, Amount:&req.Amount, ScopeID:returnID.String(), Reason:req.Reason})`, then `h.svc.StampRefundedOnly(ctx, id, req.Amount, req.Reason)`. Map coordinator errors via `RespondErr`. Inject `h.refunds` into `ReturnsHandler`.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `go test -tags integration ./internal/order/ ./internal/handlers/admin/ -run 'ReturnRefund|Refunded' -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/order/return_service.go internal/handlers/admin/returns.go internal/order/return_refund_integration_test.go
+git commit -m "feat(refund): return refund moves money via coordinator"
+```
+
+---
+
+### Task 11: Paid self-cancel auto-refund
+
+**Files:**
+- Modify: `internal/handlers/storefront/order_detail.go:Cancel` (~line 584)
+- Modify: `internal/handlers/admin/orders.go:Cancel` (~line 435) — same hook
+- Test: `internal/handlers/storefront/cancel_autorefund_integration_test.go`
+
+**Interfaces:**
+- Consumes: `orderrefund.Coordinator.Refund` with `Amount=nil` (full), `ScopeID="cancel:"+orderID`.
+- Produces: paid, un-shipped self-cancel → order cancelled + full gateway refund + `payment_status=refunded`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+`internal/handlers/storefront/cancel_autorefund_integration_test.go` (tag `integration`): seed a paid, unshipped order for a signed-in customer + captured stripe txn + active config + httptest stub. POST `/cancel`. Assert: order `status=cancelled`, a `refund_transactions.succeeded` full-amount row, `orders.payment_status=refunded`, `orders.refunded_amount == grand_total`. Also add a case: **unpaid** order → cancelled, **no** refund row.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test -tags integration ./internal/handlers/storefront/ -run CancelAutoRefund -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `storefront/order_detail.go:Cancel`, after the successful `h.orderSvc.Cancel(...)` and before the email dispatch, add:
+```go
+	// Auto-refund a paid order on cancellation (spec §4). Best-effort: a
+	// gateway blip leaves the order cancelled + a pending ledger row for the
+	// sweeper, so the customer is never blocked.
+	if h.refunds != nil && o.PaymentStatus == string(order.PaymentStatusPaid) {
+		if _, rerr := h.refunds.Refund(c.Request.Context(), orderrefund.RefundCommand{
+			OrderID: orderID, Amount: nil, Reason: "order cancelled",
+			Actor: "customer", ScopeID: "cancel:" + orderID.String(),
+		}); rerr != nil {
+			h.logger.Warn("cancel auto-refund deferred to sweeper", "order_id", orderID, "err", rerr)
+		}
+	}
+```
+Add `refunds *orderrefund.Coordinator` to `OrderDetailHandler` (+ a `WithRefunds` setter, nil-safe like `WithReturns`). Mirror the same block in `admin/orders.go:Cancel` after its cancel succeeds (Actor = `"user:"+userID`). Wire in `main.go`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test -tags integration ./internal/handlers/storefront/ -run CancelAutoRefund -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/handlers/storefront/order_detail.go internal/handlers/admin/orders.go internal/handlers/storefront/cancel_autorefund_integration_test.go
+git commit -m "feat(refund): auto-refund paid orders on cancellation"
+```
+
+---
+
+### Task 12: Retry sweeper (`cmd/refund-sweep-cron`)
+
+**Files:**
+- Create: `cmd/refund-sweep-cron/main.go`
+- Modify: `internal/orderrefund/coordinator.go` (add `ResumePending`)
+- Test: `internal/orderrefund/sweeper_integration_test.go`
+
+**Interfaces:**
+- Consumes: `Coordinator` + `payment.Service.GetRefundByIdempotencyKey`.
+- Produces: `Coordinator.ResumePending(ctx, olderThan time.Duration, limit int) (resumed int, err error)` — re-runs `pending` ledger rows with the same key (provider no-op if already refunded), then finalizes.
+
+- [ ] **Step 1: Write the failing integration test**
+
+`internal/orderrefund/sweeper_integration_test.go` (tag `integration`): insert a `pending` `refund_transactions` row (as if tx #2 never ran) with a known key + seeded order/txn/config + httptest stub that records how many times `/v1/refunds` is hit. Call `ResumePending`. Assert: the fake gateway received the **same idempotency key**, the ledger flips to `succeeded`, `orders.refunded_amount` is bumped exactly once.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test -tags integration ./internal/orderrefund/ -run Sweeper -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `ResumePending`**
+
+In `coordinator.go`:
+```go
+// ResumePending re-drives refund ledger rows stuck in 'pending' — the never-lost
+// guarantee. Safe to run repeatedly: the same idempotency_key means the gateway
+// call is a no-op if the money already moved.
+func (c *Coordinator) ResumePending(ctx context.Context, olderThan time.Duration, limit int) (int, error) {
+	var rows []payment.RefundTransaction
+	if err := c.db.WithContext(ctx).
+		Where("status = 'pending' AND created_at < now() - (? || ' seconds')::interval", int(olderThan.Seconds())).
+		Order("created_at ASC").Limit(limit).Find(&rows).Error; err != nil {
+		return 0, err
+	}
+	resumed := 0
+	for i := range rows {
+		row := rows[i]
+		oid, err := uuid.Parse(row.OrderID)
+		if err != nil {
+			continue
+		}
+		o, _, _, err := c.orderRepo.GetByID(ctx, c.db, oid)
+		if err != nil || o == nil {
+			continue
+		}
+		gw, err := c.res.GatewayFor(ctx, o.StoreID, row.Provider)
+		if err != nil {
+			continue
+		}
+		ref, err := c.pay.ExecuteGatewayRefund(ctx, gw, payment.RefundInput{
+			ProviderPaymentID: row.ProviderPaymentID, Amount: row.Amount,
+			CurrencyCode: o.CurrencyCode, Reason: row.Reason, IdempotencyKey: row.IdempotencyKey,
+		})
+		if err != nil {
+			continue // try again next sweep
+		}
+		target := DeriveStatus(o.RefundedAmount, row.Amount, o.GrandTotal)
+		if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			if err := c.pay.FinalizeRefund(ctx, tx, row.ID, ref.ProviderRefundID, "succeeded"); err != nil {
+				return err
+			}
+			return c.orders.RecordRefund(ctx, tx, oid, row.Amount, target, row.Reason)
+		}); err != nil {
+			continue
+		}
+		resumed++
+	}
+	return resumed, nil
+}
+```
+Add `import "time"`.
+
+**Guard against double-bookkeeping:** `order.Service.RecordRefund` re-adds to `refunded_amount`. Since tx #2 either fully committed (row=`succeeded`, not selected here) or fully rolled back (row=`pending`, `refunded_amount` untouched), a `pending` row always means bookkeeping did NOT happen — so re-adding is correct. Add an assertion comment and a test case where tx #2 partially… (not possible — it's one tx). Document this invariant inline.
+
+- [ ] **Step 4: Write the cron entrypoint**
+
+`cmd/refund-sweep-cron/main.go` (mirror `cmd/reconciliation-cron/main.go` structure — DB open from `DATABASE_URL`, build repos, construct `Coordinator` with `enabled=true`, run once, exit):
+```go
+package main
+
+// Command refund-sweep-cron re-drives stuck 'pending' refund_transactions rows.
+// Runs as a Cloud Run Job on a Cloud Scheduler trigger (every 5 min).
+
+import (
+	"context"
+	"os"
+	"time"
+	// ... same imports/log setup as reconciliation-cron ...
+)
+
+func main() {
+	log := newLogger()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		log.Error("refund-sweep-cron: DATABASE_URL not set")
+		os.Exit(1)
+	}
+	db := mustOpen(dsn) // same helper shape as reconciliation-cron
+	res := orderrefund.NewResolver(db)
+	pay := payment.NewService(payment.NewRepository(db))
+	orders := order.NewService(db, order.NewRepository(), outbox.NewRepository())
+	coord := orderrefund.NewCoordinator(db, res, pay, orders, order.NewRepository(), true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	n, err := coord.ResumePending(ctx, 5*time.Minute, 200)
+	if err != nil {
+		log.Error("refund-sweep-cron: run failed", "err", err)
+		os.Exit(1)
+	}
+	log.Info("refund-sweep-cron: done", "resumed", n)
+}
+```
+(Match the exact logger/db helpers used by `reconciliation-cron`; do not invent new ones.)
+
+- [ ] **Step 5: Run to verify it passes + build the cmd**
+
+Run: `go test -tags integration ./internal/orderrefund/ -run Sweeper -v && go build ./cmd/refund-sweep-cron/`
+Expected: PASS + clean build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/orderrefund/coordinator.go cmd/refund-sweep-cron/main.go internal/orderrefund/sweeper_integration_test.go
+git commit -m "feat(refund): retry sweeper for stuck pending refunds"
+```
+
+---
+
+### Task 13: Feature flag + main wiring + full regression
+
+**Files:**
+- Modify: `cmd/marketplace-api/main.go` (read `REFUND_GATEWAY_ENABLED`, construct `Coordinator`, inject into admin OrdersHandler, ReturnsHandler, storefront OrderDetailHandler)
+- Modify: infra deploy config for the new Cloud Run Job + Scheduler (note-only; see spec §10)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: a single `*orderrefund.Coordinator` shared by all handlers, gated by the env flag.
+
+- [ ] **Step 1: Construct the coordinator in main.go**
+
+Near the payment service construction in `main.go`:
+```go
+	refundEnabled := os.Getenv("REFUND_GATEWAY_ENABLED") == "true"
+	refundResolver := orderrefund.NewResolver(db)
+	refundCoordinator := orderrefund.NewCoordinator(db, refundResolver, paymentService, orderService, orderRepo, refundEnabled)
+	log.Info("refund coordinator wired", "gateway_enabled", refundEnabled)
+```
+Inject `refundCoordinator` into the three handlers (admin OrdersHandler, admin ReturnsHandler, storefront OrderDetailHandler via `WithRefunds`). Grep their existing construction sites in `main.go` / `routes.go`.
+
+- [ ] **Step 2: Manual flag-off safety check (test)**
+
+Add `internal/orderrefund/coordinator_test.go` case (already in Task 8): `enabled=false` ⇒ `Refund` returns the disabled error and never calls the gateway. Confirm the storefront cancel path treats that error as non-fatal (order still cancelled) — covered by a `enabled=false` variant of the Task 11 test.
+
+- [ ] **Step 3: Full regression**
+
+Run:
+```bash
+go build ./...
+go test ./... 2>&1 | tail -30
+go test -tags integration ./internal/orderrefund/ ./internal/order/ ./internal/payment/ ./internal/handlers/... -race
+```
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/marketplace-api/main.go
+git commit -m "feat(refund): wire RefundCoordinator behind REFUND_GATEWAY_ENABLED flag"
+```
+
+- [ ] **Step 5: Infra note (separate follow-up, not code)**
+
+Document in the PR/deploy notes: add `cmd/refund-sweep-cron` as a Cloud Run Job + Cloud Scheduler (every 5 min) in `tesserix-k8s` / infra, and set `REFUND_GATEWAY_ENABLED` per environment (dark in prod until the integration suite passes against test-mode keys).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 problem (orphaned gateway) → Tasks 8–11. ✅
+- §3 decision 1 auto-refund paid cancel → Task 11. ✅
+- §3 decision 2 no-gateway blocked (422) → Task 8 (`RefundUnavailable`) + Task 2. ✅
+- §3 decision 3 derive status → Task 8 `DeriveStatus`. ✅
+- §3 decision 4 idempotency + ledger + sweeper → Tasks 6, 8, 12. ✅
+- §3 decision 5 standalone Job → Task 12. ✅
+- §3 decision 6 feature flag → Tasks 8, 13. ✅
+- §4.1 coordinator → Task 8. §4.2 saga → Tasks 6, 8. §4.3 sweeper → Task 12. §4.4 triggers → Tasks 9–11. ✅
+- §5 schema → Task 1. §6 API (refund_request_id, refund_unavailable) → Tasks 2, 9. §7 gateway idempotency → Tasks 3–5. §8 validation → Task 8. §9 tests → every task + Task 13 regression. §10 rollout → Tasks 12–13. ✅
+
+**Placeholder scan:** No TBD/TODO left; each code step shows real code. Test bodies for integration tasks reference the existing package harness (grep-to-find) rather than reinventing — acceptable since the harness exists; the assertions are concrete.
+
+**Type consistency:** `RefundCommand{OrderID, Amount *decimal.Decimal, Reason, Actor, ScopeID}`, `RefundResult{ProviderRefundID, Amount, PaymentStatus, AlreadyDone}`, `ReserveRefundInput`, `PaymentContext`, `DeriveStatus(refunded, amount, grandTotal)`, `Coordinator.Refund/ResumePending`, `payment.Service.ReserveRefund/ExecuteGatewayRefund/FinalizeRefund`, `RefundInput.IdempotencyKey` — used consistently across Tasks 3–13. `order.Service.RecordRefund(ctx, tx, orderID, amount, target, reason)` matches the real signature (`service.go:335`).
+
+**Known risk to flag at execution:** Task 8's unit tests require narrow interface seams for the coordinator's deps (so fakes inject without a DB). If introducing those interfaces balloons scope, fall back to DB-backed integration tests for the coordinator and keep only `DeriveStatus` + idempotency-key as pure unit tests.

--- a/docs/superpowers/plans/2026-07-09-order-refund-gateway-wiring.md
+++ b/docs/superpowers/plans/2026-07-09-order-refund-gateway-wiring.md
@@ -263,7 +263,7 @@ git commit -m "feat(refund): Stripe refund sends Idempotency-Key header"
 
 **Interfaces:**
 - Consumes: `RefundInput.IdempotencyKey` (Task 3).
-- Produces: Razorpay refund sends header `X-Razorpay-Idempotency: <key>` and `notes[order_reason]=<reason>` (mirrors Home-Chef `RefundRequest.Notes`).
+- Produces: Razorpay refund sends header `X-Refund-Idempotency: <key>` and `notes[order_reason]=<reason>` (mirrors Home-Chef `RefundRequest.Notes`).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -273,7 +273,7 @@ func TestRazorpayRefund_SendsIdempotencyHeaderAndNotes(t *testing.T) {
 	var gotKey string
 	var body []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotKey = r.Header.Get("X-Razorpay-Idempotency")
+		gotKey = r.Header.Get("X-Refund-Idempotency")
 		body, _ = io.ReadAll(r.Body)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"id":"rfnd_1","status":"processed","amount":5000}`))
@@ -307,7 +307,7 @@ Expected: FAIL.
 Add `NewRazorpayGatewayWithBaseURL` seam (mirror Task 3 Step 3 if not present). In `RefundPayment`, include notes in the JSON body and set the header before `Do`:
 ```go
 	if in.IdempotencyKey != "" {
-		req.Header.Set("X-Razorpay-Idempotency", in.IdempotencyKey)
+		req.Header.Set("X-Refund-Idempotency", in.IdempotencyKey)
 	}
 ```
 When constructing the refund request body, add:
@@ -682,7 +682,7 @@ git commit -m "feat(refund): order payment-context + gateway resolver"
 **Interfaces:**
 - Consumes: `Resolver` (Task 7), `payment.Service` saga methods (Task 6), `order.Service.RecordRefund` (existing), `order.Repository.GetByID` (existing).
 - Produces:
-  - `RefundCommand{OrderID uuid.UUID; Amount *decimal.Decimal; Reason string; Actor string; ScopeID string}` — `Amount==nil` ⇒ full remaining; `ScopeID` sets the idempotency scope (`return_id`, `"cancel:"+orderID`, or a refund-request UUID).
+  - `RefundCommand{OrderID uuid.UUID; Amount *decimal.Decimal; Reason string; Actor string; ScopeID string}` — `Amount==nil` ⇒ full remaining; `ScopeID` sets the idempotency scope (`return_id`, the constant `"cancel"`, or a refund-request UUID). Must be `[A-Za-z0-9_-]` only (no colons — Razorpay).
   - `RefundResult{ProviderRefundID string; Amount decimal.Decimal; PaymentStatus order.PaymentStatus; AlreadyDone bool}`.
   - `Coordinator.Refund(ctx, cmd RefundCommand) (RefundResult, error)` — returns `apperrors.ErrRefundUnavailable` when no captured txn; `apperrors.ErrRefundExceedsTotal` when over cap.
   - `NewCoordinator(db *gorm.DB, res *Resolver, pay *payment.Service, orders *order.Service, orderRepo order.Repository, enabled bool) *Coordinator`.
@@ -744,7 +744,7 @@ type RefundCommand struct {
 	Amount  *decimal.Decimal // nil ⇒ full remaining
 	Reason  string
 	Actor   string
-	ScopeID string // idempotency scope: return_id | "cancel:"+orderID | refund_request_id
+	ScopeID string // idempotency scope: return_id | "cancel" | refund_request_id ([A-Za-z0-9_-] only)
 }
 
 type RefundResult struct {
@@ -775,8 +775,11 @@ func DeriveStatus(refunded, amount, grandTotal decimal.Decimal) order.PaymentSta
 	return order.PaymentStatusPartiallyRefunded
 }
 
+// idempotencyKey builds a provider-safe key. Charset is restricted to
+// [A-Za-z0-9_-] (Razorpay's X-Refund-Idempotency requires this and min 10
+// chars; Stripe/PayPal accept it). NO colons — Razorpay rejects them.
 func idempotencyKey(orderID uuid.UUID, scopeID string) string {
-	return "refund:" + orderID.String() + ":" + scopeID
+	return "refund_" + orderID.String() + "_" + scopeID
 }
 
 func (c *Coordinator) Refund(ctx context.Context, cmd RefundCommand) (RefundResult, error) {
@@ -1020,7 +1023,7 @@ git commit -m "feat(refund): return refund moves money via coordinator"
 - Test: `internal/handlers/storefront/cancel_autorefund_integration_test.go`
 
 **Interfaces:**
-- Consumes: `orderrefund.Coordinator.Refund` with `Amount=nil` (full), `ScopeID="cancel:"+orderID`.
+- Consumes: `orderrefund.Coordinator.Refund` with `Amount=nil` (full), `ScopeID="cancel"`.
 - Produces: paid, un-shipped self-cancel → order cancelled + full gateway refund + `payment_status=refunded`.
 
 - [ ] **Step 1: Write the failing integration test**
@@ -1042,7 +1045,7 @@ In `storefront/order_detail.go:Cancel`, after the successful `h.orderSvc.Cancel(
 	if h.refunds != nil && o.PaymentStatus == string(order.PaymentStatusPaid) {
 		if _, rerr := h.refunds.Refund(c.Request.Context(), orderrefund.RefundCommand{
 			OrderID: orderID, Amount: nil, Reason: "order cancelled",
-			Actor: "customer", ScopeID: "cancel:" + orderID.String(),
+			Actor: "customer", ScopeID: "cancel",
 		}); rerr != nil {
 			h.logger.Warn("cancel auto-refund deferred to sweeper", "order_id", orderID, "err", rerr)
 		}

--- a/docs/superpowers/plans/2026-07-09-order-refund-gateway-wiring.md
+++ b/docs/superpowers/plans/2026-07-09-order-refund-gateway-wiring.md
@@ -544,11 +544,27 @@ git commit -m "feat(refund): payment saga primitives (reserve/execute/finalize)"
 **Files:**
 - Create: `internal/orderrefund/resolver.go`
 - Test: `internal/orderrefund/resolver_test.go`
+- Modify: `internal/handlers/storefront/webhooks.go` (`handlePaymentSucceeded`) — persist the captured provider payment id (see Step 0 below).
+
+**Pre-existing gap this task must close (multi-gateway correctness):**
+`handlePaymentSucceeded` currently writes `status='captured', payment_method=?` but **never persists `provider_payment_id`**. Only `provider_intent_id` (set at intent creation) is stored. That works for Stripe (its refund target IS the payment_intent) but breaks Razorpay/PayPal refunds, whose refund target is the captured payment/capture id carried in `evt.ProviderPaymentID` and currently discarded. Both the webhook path and the Razorpay client-verify path (`payment_verify.go`) route through `handlePaymentSucceeded`, so one fix covers both.
+
+- [ ] **Step 0: Persist the captured payment id.** In `handlePaymentSucceeded` (`internal/handlers/storefront/webhooks.go`), change the UPDATE to also set `provider_payment_id`, preserving any existing value when the event lacks one:
+```go
+`UPDATE payment_transactions
+    SET status = 'captured',
+        payment_method = ?,
+        provider_payment_id = COALESCE(NULLIF(?, ''), provider_payment_id),
+        updated_at = now()
+  WHERE order_id = ?::uuid AND provider = ?`,
+evt.PaymentMethod, evt.ProviderPaymentID, evt.OrderID, provider,
+```
+Add/adjust an assertion in the existing webhook test (or a focused integration test) that after a `payment.succeeded` event carrying a `ProviderPaymentID`, the row's `provider_payment_id` is populated.
 
 **Interfaces:**
 - Produces:
-  - `PaymentContext{Provider, ProviderPaymentID string; CapturedTotal decimal.Decimal; Found bool}`.
-  - `Resolver.PaymentContextForOrder(ctx, orderID uuid.UUID) (PaymentContext, error)` — reads `payment_transactions`; `Found=false` when no captured txn.
+  - `PaymentContext{Provider, ProviderPaymentID string; CapturedTotal decimal.Decimal; Found bool}` — `ProviderPaymentID` is the captured refund target (prefers `provider_payment_id`, falls back to `provider_intent_id`).
+  - `Resolver.PaymentContextForOrder(ctx, orderID uuid.UUID) (PaymentContext, error)` — reads `payment_transactions` where `status='captured'`; `Found=false` when none.
   - `Resolver.GatewayFor(ctx, storeID uuid.UUID, provider string) (payment.Gateway, error)` — reads `payment_gateway_configs`, calls `payment.NewGateway`.
 
 - [ ] **Step 1: Write the failing test**
@@ -604,19 +620,27 @@ type Resolver struct{ db *gorm.DB }
 func NewResolver(db *gorm.DB) *Resolver { return &Resolver{db: db} }
 
 // PaymentContextForOrder returns the captured payment for an order. Only rows
-// in a captured/paid state count toward CapturedTotal so authorized-only
-// orders are treated as non-refundable (Found=false).
+// with status='captured' count (that is what the capture webhook / client-verify
+// writes; authorized-only or pending orders are non-refundable → Found=false).
+//
+// ProviderPaymentID is the id we refund against. It must be the CAPTURED payment
+// id — Stripe refunds the payment_intent, Razorpay the payment id (pay_...),
+// PayPal the capture id. That id lives in provider_payment_id (persisted at
+// capture — see the capture-handler fix in this task). We prefer
+// provider_payment_id and fall back to provider_intent_id for legacy rows
+// captured before that fix (Stripe rows, where intent == the refund target).
 func (r *Resolver) PaymentContextForOrder(ctx context.Context, orderID uuid.UUID) (PaymentContext, error) {
 	type row struct {
 		Provider          string
+		ProviderPaymentID string
 		ProviderIntentID  string
 		Amount            decimal.Decimal
 	}
 	var rows []row
 	if err := r.db.WithContext(ctx).
 		Table("payment_transactions").
-		Select("provider", "provider_intent_id", "amount").
-		Where("order_id = ? AND status IN ('captured','paid','succeeded')", orderID).
+		Select("provider", "provider_payment_id", "provider_intent_id", "amount").
+		Where("order_id = ? AND status = 'captured'", orderID).
 		Order("created_at ASC").
 		Scan(&rows).Error; err != nil {
 		return PaymentContext{}, err
@@ -628,9 +652,13 @@ func (r *Resolver) PaymentContextForOrder(ctx context.Context, orderID uuid.UUID
 	for _, x := range rows {
 		total = total.Add(x.Amount)
 	}
+	refundTarget := rows[0].ProviderPaymentID
+	if refundTarget == "" {
+		refundTarget = rows[0].ProviderIntentID
+	}
 	return PaymentContext{
 		Provider:          rows[0].Provider,
-		ProviderPaymentID: rows[0].ProviderIntentID,
+		ProviderPaymentID: refundTarget,
 		CapturedTotal:     total,
 		Found:             true,
 	}, nil

--- a/docs/superpowers/specs/2026-07-09-order-refund-gateway-wiring-design.md
+++ b/docs/superpowers/specs/2026-07-09-order-refund-gateway-wiring-design.md
@@ -1,0 +1,266 @@
+# Order Refund → Payment Gateway Wiring
+
+**Date:** 2026-07-09
+**Status:** Approved (design), pending spec review
+**Service:** `services/marketplace-api`
+**Author:** Mahesh + Claude
+
+---
+
+## 1. Problem
+
+Every order-refund path in `marketplace-api` mutates database bookkeeping only — it
+never moves money. Concretely:
+
+- Admin order refund (`internal/handlers/admin/orders.go:Refund`) → `order.Service.RecordRefund`
+- Return refund (`internal/order/return_service.go:MarkRefunded`) → `order.Service.RecordRefund`
+
+`order.Service.RecordRefund` (`internal/order/service.go:335`) does an atomic
+`UPDATE orders SET refunded_amount=…, payment_status='refunded'`, writes
+`order_events` + `outbox_events`, and **triggers a refund email** — but never calls
+`payment.Service.RefundPayment`, the only code that hits Stripe/Razorpay/PayPal
+`/refunds`. `payment.Service.RefundPayment` (`internal/payment/service.go:108`) has
+**zero non-test callers** — it is orphaned.
+
+Net effect in production: the customer is emailed "you've been refunded", the merchant
+sees `refunded_amount` rise, and the card is **never credited**. There is no
+`refund_transactions` ledger row on the order path, so no reconciliation and no
+protection against double-refunds.
+
+Secondary defects folded into this work:
+
+- **Paid cancellation strands money.** `order.Service.Cancel` never touches
+  `payment_status` and never refunds. A customer who paid then self-cancels lands at
+  `status=cancelled / payment_status=paid / refunded_amount=0` with no money back.
+- **Amount/status mismatch.** `RefundOrderRequest` accepts both `amount` and a
+  `payment_status` target from the client; they can disagree (full amount tagged
+  `partially_refunded`, or vice-versa) and the server accepts it.
+- **Refund cap is against `grand_total`, not captured amount.** The
+  `authorized → refunded` transition is legal, so money that was only authorized
+  (never captured) can be "refunded" in bookkeeping.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- All three refund triggers move real money through the customer's original gateway,
+  via the existing `payment.Gateway` interface (Stripe, Razorpay, PayPal — provider
+  resolved per order, not hardcoded).
+- A refund is **never lost** (retry sweeper) and **never doubled** (provider
+  idempotency key).
+- Paid, un-shipped self-cancellation issues an automatic full refund.
+- Server-side correctness for amount, status, and cap.
+- **No change ships without comprehensive automated tests** (see §9). This service is
+  in production.
+
+**Non-goals**
+- Refund to store credit / gift-card / wallet (future).
+- Split-payout / escrow reversal (not present in this marketplace flow).
+- COD / manual / offline refunds — explicitly **blocked** with `422 refund_unavailable`.
+
+## 3. Locked decisions
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Paid self-cancel behavior | **Auto-refund to original method** (full) |
+| 2 | Orders with no gateway transaction (COD/manual) | **Block** → `422 refund_unavailable` |
+| 3 | Partial vs full status | **Derive server-side** from amount vs grand_total |
+| 4 | Reliability model | **Idempotency key + ledger-first saga + retry sweeper** |
+| 5 | Sweeper hosting | **Standalone Cloud Run Job** (`cmd/refund-sweep-cron`, mirrors `cmd/reconciliation-cron`) |
+| 6 | Rollout | **Feature flag** `REFUND_GATEWAY_ENABLED` (ship dark, enable per env) |
+
+## 4. Architecture
+
+### 4.1 New component — `RefundCoordinator` (`internal/orderrefund/`)
+
+A single domain service that all refund triggers call, so money-movement logic lives
+in exactly one place. Depends only on well-defined interfaces (all fakeable in tests):
+
+- `order.Service` — existing `RecordRefund`, `Cancel`, `loadForUpdate`
+- `payment.Service` — gateway call + ledger persistence
+- `PaymentTxnLookup` — `payment_transactions` by `order_id` (provider + intent + captured amount)
+- `GatewayConfigResolver` — `payment_gateway_configs` by (store, provider, active) → `payment.NewGateway` (reuse the pattern in `internal/giftcard/gateway_resolver.go`)
+
+```
+RefundCoordinator.Refund(ctx, RefundCommand{OrderID, Amount*, Reason, Actor}) (RefundResult, error)
+  1. loadForUpdate(order)                              // row lock
+  2. txn = PaymentTxnLookup(order_id)
+        └─ none OR not captured → ErrRefundUnavailable // COD/manual/authorized-only
+  3. capturedTotal = Σ captured payment_transactions
+     amount = Amount or (grand_total - refunded_amount) // nil ⇒ full remaining
+     validate: 0 < amount ≤ min(grand_total, capturedTotal) - refunded_amount
+  4. targetStatus = derive(refunded_amount + amount, grand_total)
+        → partially_refunded | refunded
+  5. gateway = GatewayConfigResolver(store, txn.provider)
+  6. runIdempotentSaga(...)                            // §4.2
+```
+
+`Amount` is a pointer: `nil` ⇒ full remaining refund (used by auto-cancel and
+"refund everything" return path).
+
+### 4.2 Idempotent refund saga
+
+A gateway refund is a non-rollback-able side effect, so it cannot sit inside a DB
+transaction. Ledger-first + idempotency-key saga:
+
+```
+key = deterministic(order_id, refund_scope_id)   // stable across retries
+
+// refund_scope_id identifies ONE logical refund so retries share a key but
+// distinct refunds don't collide:
+//   - return path : return_id
+//   - cancel path : "cancel:" + order_id            (one auto-refund per order)
+//   - admin path  : caller-supplied refund_request_id (client generates a UUID;
+//                   required so two intentional partials get distinct keys while
+//                   a double-submit of the same partial is deduped)
+
+DB tx #1: INSERT refund_transactions
+            (order_id, provider, provider_payment_id, amount, status='pending',
+             idempotency_key=key, reason)
+          ON CONFLICT (idempotency_key) DO NOTHING   // safe re-entry
+
+gateway.RefundPayment(RefundInput{..., IdempotencyKey: key})   // real money
+
+DB tx #2 (atomic):
+   UPDATE refund_transactions SET status='succeeded', provider_refund_id=…
+   order.Service.RecordRefund(order_id, amount, targetStatus, reason)  // refunded_amount, events, outbox
+   (return path only) return.repo.StampRefunded + UpdateStatus(refunded)
+```
+
+- **Idempotency-Key** is added to `payment.RefundInput` and sent by every gateway
+  (Stripe `Idempotency-Key` header; Razorpay/PayPal request-id equivalents). Re-issuing
+  with the same key never double-refunds at the provider. This is the concrete
+  improvement over the Home-Chef `cancellation_execute.go` original-method path, which
+  lacks a provider idempotency key and can double-refund in the crash window.
+- If tx #2 fails after the gateway succeeds, the ledger row stays `pending` and the
+  sweeper (§4.3) re-runs the gateway call with the **same key** (a no-op at the
+  provider) then completes tx #2.
+
+### 4.3 Retry sweeper — `cmd/refund-sweep-cron`
+
+Standalone Cloud Run Job (Cloud Scheduler trigger), modeled on `cmd/reconciliation-cron`.
+
+```
+every N minutes:
+  SELECT * FROM refund_transactions
+   WHERE status='pending' AND created_at < now() - interval '5 minutes'
+   LIMIT 200
+  for each: RefundCoordinator.resumeSaga(row)  // same idem key → provider no-op if already done
+```
+
+The existing `refund.succeeded` webhook (`internal/handlers/storefront/webhooks.go:711`)
+already flips ledger rows to `succeeded`; it doubles as async confirmation and reduces
+sweeper work.
+
+### 4.4 Trigger wiring
+
+| Trigger | File | Change |
+|---------|------|--------|
+| Admin order refund | `internal/handlers/admin/orders.go:Refund` | call `RefundCoordinator.Refund` instead of `svc.RecordRefund` |
+| Return refund | `internal/order/return_service.go:MarkRefunded` | call coordinator inside its tx-orchestration; keep return-state stamping atomic with `RecordRefund` in tx #2 |
+| Admin return refund handler | `internal/handlers/admin/returns.go:MarkRefunded` | unchanged surface; downstream now moves money |
+| Paid self-cancel | `internal/handlers/storefront/order_detail.go:Cancel` | after cancel, if `payment_status==paid` → `RefundCoordinator.Refund(nil)` (full) |
+| Admin cancel | `internal/handlers/admin/orders.go:Cancel` | same paid-order auto-refund hook (behind flag) |
+
+Cancellation and refund are **separate steps**: a gateway blip leaves the order
+cancelled + a `pending` ledger row for the sweeper; the customer is never blocked.
+
+## 5. Data model changes
+
+`refund_transactions` (add columns; migration via golang-migrate):
+
+| Column | Type | Note |
+|--------|------|------|
+| `order_id` | `uuid NOT NULL` | today absent — needed for sweeper + reconciliation |
+| `status` | `varchar(30) NOT NULL` | `pending` \| `succeeded` \| `failed` (already partially used by webhook) |
+| `idempotency_key` | `varchar(255) NOT NULL` | **UNIQUE** — the saga re-entry guard |
+
+Backfill: none required (no real refunds have moved money yet). New unique index on
+`idempotency_key`; index on `(status, created_at)` for the sweeper query.
+
+## 6. API / wire changes
+
+- `RefundOrderRequest.payment_status` → **optional / ignored**; server derives it.
+  `amount` optional (omit ⇒ full remaining). Keep the field for backward compat but
+  document as deprecated.
+- `RefundOrderRequest` gains optional `refund_request_id` (UUID). When present it is the
+  idempotency scope (see §4.2) so a double-submit of the same partial is deduped; when
+  absent the server generates one (single-shot, no client retry-safety).
+- New error code `refund_unavailable` (422) when no captured gateway transaction exists.
+- Response includes `provider_refund_id` and final `payment_status`.
+
+## 7. Payment gateway interface changes
+
+- `payment.RefundInput` gains `IdempotencyKey string`.
+- `StripeGateway.RefundPayment` sends `Idempotency-Key` header.
+- `RazorpayGateway.RefundPayment` sends its request-id / idempotency header and
+  `notes{order_id,reason,scope}` (mirrors Home-Chef `RefundRequest.Notes`).
+- `PayPalGateway.RefundPayment` sends `PayPal-Request-Id`.
+- `payment.Service.RefundPayment` persists the ledger row within the coordinator's tx
+  boundary rather than owning its own connection (moves ledger write into tx #1/#2).
+
+## 8. Correctness / validation rules
+
+- `amount > 0`.
+- `refunded_amount + amount ≤ min(grand_total, capturedTotal)`.
+- `targetStatus` derived, never client-trusted.
+- Only orders with a **captured** payment transaction are refundable via gateway;
+  `authorized`-only orders → `refund_unavailable`.
+- All attempts (success + failure) emit an audit event (extend the existing admin-path
+  audit to the cancel + return paths).
+
+## 9. Testing strategy (blocking — prod service)
+
+No task in the implementation plan is "done" until its tests are written and green.
+Target ≥ 80% coverage on all new/changed packages.
+
+### 9.1 Unit — `internal/orderrefund` (fake `Gateway`, fake repos)
+- Partial refund → `partially_refunded`, correct `refunded_amount`.
+- Full refund (explicit amount == remaining) → `refunded`.
+- Full refund (`amount=nil`) → refunds `grand_total - refunded_amount`.
+- Over-cap (`refunded_amount + amount > grand_total`) → rejected, no gateway call.
+- No `payment_transactions` row → `ErrRefundUnavailable`, no gateway call.
+- Authorized-but-not-captured → `ErrRefundUnavailable`.
+- Status derivation table test (amounts around the grand_total boundary).
+- Idempotency key is **stable** for the same (order, scope) across calls.
+- Gateway returns error → ledger row stays `pending`, no `refunded_amount` change,
+  error surfaced.
+
+### 9.2 Gateway unit tests (httptest server per provider)
+- Stripe/Razorpay/PayPal `RefundPayment` sends the idempotency header.
+- Re-call with same key is treated as safe (assert header present + request shape).
+- Non-200 provider response → wrapped error, no ledger mutation.
+
+### 9.3 Integration (real DB, fake gateway) — `*_integration_test.go`
+- **Return happy path**: request → approve → receive → refund asserts a
+  `refund_transactions` row (`succeeded`, correct `order_id`, `idempotency_key`) **and**
+  `orders.refunded_amount` bump **and** `order_events`/`outbox_events` rows, all
+  consistent in one logical operation.
+- **Paid-cancel auto-refund**: paid + un-shipped order → customer cancel → order
+  cancelled, full refund ledger row, `payment_status=refunded`, refund email dispatched.
+- **Un-paid cancel**: pending/COD order → cancelled, **no** refund row.
+- **Shipment guard**: label cut → self-cancel still `409`, no refund.
+- **Sweeper**: a `pending` row older than threshold is resumed and completes **without
+  a second provider charge** (assert the fake gateway received the same idempotency key
+  and short-circuited).
+- **Double-submit**: two concurrent admin refunds for the same order/scope →
+  exactly one gateway call, one ledger row (unique key), correct final amount.
+- **Over-cap via two partials**: 60 + 60 on a 100 order → second rejected.
+
+### 9.4 Regression
+- Existing `order` / `return` / `payment` suites stay green.
+- `go test -race ./...` on touched packages.
+
+## 10. Rollout & safety
+
+- `REFUND_GATEWAY_ENABLED` flag gates the gateway call + auto-cancel-refund. Off ⇒
+  current behavior (bookkeeping only) so the deploy is inert until flipped, per the
+  escrow-flag pattern.
+- Ship the migration + code dark, enable in a non-prod env, run the integration suite
+  against a Stripe/Razorpay **test-mode** key, then enable in prod.
+- Sweeper Job deployed but scheduled conservatively (e.g. every 5 min) after the flag is on.
+- Audit + structured logs on every refund attempt for observability.
+
+## 11. Open questions
+
+_None blocking. Store-credit refund destination and a merchant "manual refund recorded"
+path (for COD) are noted as future follow-ups._

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -634,7 +634,8 @@ func main() {
 
 		ordersHandler := admin.NewOrdersHandler(conn, orderSvc, orderRepo, orderDocSvc, log).
 			WithRefunds(refundCoordinator)
-		returnsHandler := admin.NewReturnsHandler(conn, returnSvc, returnRepo, orderRepo, orderSvc, log)
+		returnsHandler := admin.NewReturnsHandler(conn, returnSvc, returnRepo, orderRepo, orderSvc, log).
+			WithRefunds(refundCoordinator)
 		abandonedCartsHandler := admin.NewAbandonedCartsHandler(abandonedCartSvc, log)
 
 		storesHandler := admin.NewStoresHandler(storesRepo, log)

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -86,9 +86,11 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/observability"
 	"github.com/mark8ly/marketplace-api/internal/order"
 	"github.com/mark8ly/marketplace-api/internal/orderdoc"
+	"github.com/mark8ly/marketplace-api/internal/orderrefund"
 	"github.com/mark8ly/marketplace-api/internal/ottoclient"
 	"github.com/mark8ly/marketplace-api/internal/outbox"
 	"github.com/mark8ly/marketplace-api/internal/page"
+	"github.com/mark8ly/marketplace-api/internal/payment"
 	"github.com/mark8ly/marketplace-api/internal/plangate"
 	"github.com/mark8ly/marketplace-api/internal/product"
 	"github.com/mark8ly/marketplace-api/internal/promo"
@@ -601,6 +603,16 @@ func main() {
 		orderSvc := order.NewService(conn, orderRepo, outboxRepo)
 		returnSvc := order.NewReturnService(conn, returnRepo, orderRepo, orderSvc, outboxRepo)
 		abandonedCartSvc := order.NewAbandonedCartService(conn, abandonedCartRepo, outboxRepo)
+		// Refund coordinator — the single place that moves real money via
+		// the payment gateway. Gated by REFUND_GATEWAY_ENABLED so refunds
+		// stay a hard error (not a silent no-op) until the gateway wiring
+		// is verified in an environment; Task 13 documents the flag and
+		// reuses refundCoordinator for the other refund-triggering flows
+		// (returns, paid cancels).
+		refundGatewayEnabled := os.Getenv("REFUND_GATEWAY_ENABLED") == "true"
+		paymentSvc := payment.NewService(payment.NewRepository(conn))
+		refundResolver := orderrefund.NewResolver(conn)
+		refundCoordinator := orderrefund.NewCoordinator(conn, refundResolver, paymentSvc, orderSvc, orderRepo, refundGatewayEnabled)
 		// Order document mailer — invoice on accept, receipt on delivery.
 		// Built up here because both OrdersHandler and ShipmentsHandler need
 		// it. Provider selection (SendGrid → Resend → log-only) already
@@ -620,7 +632,8 @@ func main() {
 		orderDocSvc := orderdoc.NewService(conn, orderDocMailer, orderRepo, orderDocBrandingSvc, cfg.StorefrontBaseURLTemplate).
 			WithLogger(log)
 
-		ordersHandler := admin.NewOrdersHandler(conn, orderSvc, orderRepo, orderDocSvc, log)
+		ordersHandler := admin.NewOrdersHandler(conn, orderSvc, orderRepo, orderDocSvc, log).
+			WithRefunds(refundCoordinator)
 		returnsHandler := admin.NewReturnsHandler(conn, returnSvc, returnRepo, orderRepo, orderSvc, log)
 		abandonedCartsHandler := admin.NewAbandonedCartsHandler(abandonedCartSvc, log)
 

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -613,6 +613,7 @@ func main() {
 		paymentSvc := payment.NewService(payment.NewRepository(conn))
 		refundResolver := orderrefund.NewResolver(conn)
 		refundCoordinator := orderrefund.NewCoordinator(conn, refundResolver, paymentSvc, orderSvc, orderRepo, refundGatewayEnabled)
+		log.Info("refund coordinator wired (admin)", "gateway_enabled", refundGatewayEnabled)
 		// Order document mailer — invoice on accept, receipt on delivery.
 		// Built up here because both OrdersHandler and ShipmentsHandler need
 		// it. Provider selection (SendGrid → Resend → log-only) already
@@ -1186,6 +1187,7 @@ func main() {
 		paymentSvcSF := payment.NewService(payment.NewRepository(conn))
 		refundResolverSF := orderrefund.NewResolver(conn)
 		refundCoordinatorSF := orderrefund.NewCoordinator(conn, refundResolverSF, paymentSvcSF, orderSvcSF, orderRepoSF, refundGatewayEnabledSF)
+		log.Info("refund coordinator wired (storefront)", "gateway_enabled", refundGatewayEnabledSF)
 
 		orderDetailHandler := storefront.NewOrderDetailHandler(conn, orderRepoSF, orderSvcSF, orderDocSvcSF, log).
 			WithReturns(returnSvcSF, returnRepoSF).

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1178,9 +1178,19 @@ func main() {
 		// SendGrid blip never re-queues the webhook.
 		webhookHandler.WithDocMailer(orderDocSvcSF)
 
+		// Refund coordinator for the storefront's own self-cancel auto-refund
+		// (spec §4). Built independently from the admin block's
+		// refundCoordinator — that one is scoped inside the mode.Admin
+		// block and out of reach here in a mode.Storefront-only process.
+		refundGatewayEnabledSF := os.Getenv("REFUND_GATEWAY_ENABLED") == "true"
+		paymentSvcSF := payment.NewService(payment.NewRepository(conn))
+		refundResolverSF := orderrefund.NewResolver(conn)
+		refundCoordinatorSF := orderrefund.NewCoordinator(conn, refundResolverSF, paymentSvcSF, orderSvcSF, orderRepoSF, refundGatewayEnabledSF)
+
 		orderDetailHandler := storefront.NewOrderDetailHandler(conn, orderRepoSF, orderSvcSF, orderDocSvcSF, log).
 			WithReturns(returnSvcSF, returnRepoSF).
-			WithNotifier(notificationSvc)
+			WithNotifier(notificationSvc).
+			WithRefunds(refundCoordinatorSF)
 
 		// Support tickets — public contact form endpoint. Shares the
 		// ticketSvc with admin so created rows surface on the admin

--- a/services/marketplace-api/cmd/refund-sweep-cron/README.md
+++ b/services/marketplace-api/cmd/refund-sweep-cron/README.md
@@ -1,0 +1,42 @@
+# refund-sweep-cron
+
+Re-drives `refund_transactions` rows stuck in `pending` — the never-lost
+guarantee for refunds. A row goes stuck when the gateway call succeeded but
+the process crashed (or the DB blipped) before the finalize transaction
+committed. The sweeper re-calls the gateway with the **same idempotency
+key** (a provider no-op if the money already moved) and completes the DB
+finalize + bookkeeping via `orderrefund.Coordinator.ResumePending`.
+
+## Deployment
+
+Run as a **Cloud Run Job** (mirroring `reconciliation-cron`) triggered by
+**Cloud Scheduler every ~5 minutes**. Not a long-lived service — each
+invocation processes the current backlog of stuck rows and exits.
+
+- K8s alternative: a `CronJob` on the same `*/5 * * * *` schedule if the
+  environment isn't Cloud Run-based.
+- Timeout: the job self-bounds to 2 minutes per run; schedule accordingly
+  so overlapping runs stay rare (idempotency keys make overlap safe either
+  way).
+
+## Configuration
+
+- `DATABASE_URL` (required) — same Cloud SQL instance as `marketplace-api`.
+- The job always constructs its `Coordinator` with `enabled=true`: the
+  sweep IS the recovery path for the `REFUND_GATEWAY_ENABLED` kill switch,
+  so it must re-drive pending rows regardless of the main API's flag state.
+
+## Exit behavior
+
+Exits non-zero **only** on infrastructure failure (missing `DATABASE_URL`,
+DB connection failure, or an unexpected error from `ResumePending`). A run
+that resumes zero rows is a normal, successful exit — do not alert on
+"nothing to do."
+
+## Relationship to REFUND_GATEWAY_ENABLED
+
+`REFUND_GATEWAY_ENABLED` gates the main API's `orderrefund.Coordinator`
+(admin + storefront). Refunds only flow end-to-end when it is `true` on
+`marketplace-api`. The sweeper is deploy-independent of that flag — it
+should always be running so any refund that got stuck while the flag was
+on (or during a flip) gets recovered.

--- a/services/marketplace-api/cmd/refund-sweep-cron/main.go
+++ b/services/marketplace-api/cmd/refund-sweep-cron/main.go
@@ -1,0 +1,59 @@
+// Command refund-sweep-cron re-drives refund_transactions rows stuck in
+// 'pending' — the never-lost guarantee for refunds. A row is stuck when the
+// gateway call succeeded but the process crashed (or the DB blipped) before
+// the finalize transaction committed. The sweeper re-calls the gateway with
+// the SAME idempotency key (a provider no-op if the money already moved)
+// and completes the DB finalize + bookkeeping.
+//
+// Designed to run as a Cloud Run Job on a Cloud Scheduler trigger (every 5
+// min). Exits non-zero only on infrastructure failures (DB connection,
+// etc.) — a sweep that resumes zero rows is a normal, successful run.
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/internal/orderrefund"
+	"github.com/mark8ly/marketplace-api/internal/outbox"
+	"github.com/mark8ly/marketplace-api/internal/payment"
+	"github.com/mark8ly/marketplace-api/pkg/db"
+)
+
+func main() {
+	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		log.Error("refund-sweep-cron: DATABASE_URL not set")
+		os.Exit(1)
+	}
+
+	conn, err := db.Open(databaseURL)
+	if err != nil {
+		log.Error("refund-sweep-cron: db open failed", "err", err)
+		os.Exit(1)
+	}
+
+	res := orderrefund.NewResolver(conn)
+	pay := payment.NewService(payment.NewRepository(conn))
+	orders := order.NewService(conn, order.NewRepository(), outbox.NewRepository(conn))
+	// enabled=true: the sweep is itself the recovery path for the
+	// REFUND_GATEWAY_ENABLED kill switch — a stuck pending row must still be
+	// re-driven so a later flip back to enabled doesn't leave it orphaned.
+	coord := orderrefund.NewCoordinator(conn, res, pay, orders, order.NewRepository(), true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	n, err := coord.ResumePending(ctx, 5*time.Minute, 200)
+	if err != nil {
+		log.Error("refund-sweep-cron: run failed", "err", err)
+		os.Exit(1)
+	}
+
+	log.Info("refund-sweep-cron: done", "resumed", n)
+}

--- a/services/marketplace-api/internal/handlers/admin/errors.go
+++ b/services/marketplace-api/internal/handlers/admin/errors.go
@@ -36,6 +36,7 @@ var codeStatus = map[apperrors.Code]int{
 	// Orders slice 1.
 	apperrors.CodeInvalidTransition:        http.StatusConflict,
 	apperrors.CodeRefundExceedsTotal:       http.StatusUnprocessableEntity,
+	apperrors.CodeRefundUnavailable:        http.StatusUnprocessableEntity,
 	apperrors.CodeIdempotencyConflict:      http.StatusConflict,
 	apperrors.CodeReturnItemsExceedOrdered: http.StatusUnprocessableEntity,
 	apperrors.CodeRecoveryTooRecent:        http.StatusTooManyRequests,

--- a/services/marketplace-api/internal/handlers/admin/errors_test.go
+++ b/services/marketplace-api/internal/handlers/admin/errors_test.go
@@ -109,3 +109,10 @@ func TestCodeStatus_CoversAllCodes(t *testing.T) {
 		}
 	}
 }
+
+func TestRespondErr_RefundUnavailable_Returns422(t *testing.T) {
+	w, _ := runRespondErr(t, apperrors.RefundUnavailable("no captured payment"))
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", w.Code)
+	}
+}

--- a/services/marketplace-api/internal/handlers/admin/orders.go
+++ b/services/marketplace-api/internal/handlers/admin/orders.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/notification"
 	"github.com/mark8ly/marketplace-api/internal/order"
 	"github.com/mark8ly/marketplace-api/internal/orderdoc"
+	"github.com/mark8ly/marketplace-api/internal/orderrefund"
 	"github.com/mark8ly/marketplace-api/internal/stores"
 	"github.com/mark8ly/marketplace-api/internal/tax"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
@@ -30,9 +31,10 @@ type OrdersHandler struct {
 	db        *gorm.DB
 	svc       *order.Service
 	repo      order.Repository
-	docMailer *orderdoc.Service     // optional — nil disables auto-emails
-	audit     *audit.Emitter        // optional — nil-safe; Emit is no-op when nil
-	notify    *notification.Service // optional — nil-safe; notification.Emit skips when nil
+	docMailer *orderdoc.Service        // optional — nil disables auto-emails
+	audit     *audit.Emitter           // optional — nil-safe; Emit is no-op when nil
+	notify    *notification.Service    // optional — nil-safe; notification.Emit skips when nil
+	refunds   *orderrefund.Coordinator // optional — nil disables the refund endpoint (503)
 	logger    *slog.Logger
 }
 
@@ -56,6 +58,16 @@ func (h *OrdersHandler) WithAudit(e *audit.Emitter) *OrdersHandler {
 // Nil-safe — notification.Emit is a no-op without a service.
 func (h *OrdersHandler) WithNotifier(n *notification.Service) *OrdersHandler {
 	h.notify = n
+	return h
+}
+
+// WithRefunds attaches the refund coordinator that moves real money.
+// Nil-safe by omission — without it, Refund returns 503 rather than
+// silently no-opping, since a refund request that appears to succeed
+// without touching the gateway would be a correctness bug, not a
+// degraded-mode fallback.
+func (h *OrdersHandler) WithRefunds(c *orderrefund.Coordinator) *OrdersHandler {
+	h.refunds = c
 	return h
 }
 
@@ -461,9 +473,11 @@ func (h *OrdersHandler) Cancel(c *gin.Context) {
 
 func stringPtr(s string) *string { return &s }
 
-// Refund handles POST /admin/stores/:storeId/orders/:id/refund. The
-// payment_status target is required because the service layer needs to
-// know whether this is a partial or full refund (transition is enforced).
+// Refund handles POST /admin/stores/:storeId/orders/:id/refund. This now
+// moves real money — the request goes through orderrefund.Coordinator,
+// which resolves the captured payment, calls the gateway, and derives
+// whether the result is a partial or full refund from the amount. The
+// caller-supplied payment_status field is ignored (see RefundOrderRequest).
 func (h *OrdersHandler) Refund(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
@@ -479,11 +493,26 @@ func (h *OrdersHandler) Refund(c *gin.Context) {
 		RespondErr(c, apperrors.ValidationFailed("body", err.Error()), h.logger)
 		return
 	}
-	if err := h.svc.RecordRefund(
-		c.Request.Context(), nil, id,
-		req.Amount, order.PaymentStatus(req.PaymentStatus), req.Reason,
-	); err != nil {
-		RespondErr(c, err, h.logger)
+	if h.refunds == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error":   "service_unavailable",
+			"message": "Refunds are not configured.",
+		})
+		return
+	}
+	scope := req.RefundRequestID
+	if scope == "" {
+		scope = uuid.NewString()
+	}
+	res, rerr := h.refunds.Refund(c.Request.Context(), orderrefund.RefundCommand{
+		OrderID: id,
+		Amount:  req.Amount,
+		Reason:  req.Reason,
+		Actor:   "user:" + c.GetString("user_id"),
+		ScopeID: scope,
+	})
+	if rerr != nil {
+		RespondErr(c, rerr, h.logger)
 		return
 	}
 	o, items, addrs, err := h.repo.GetByID(c.Request.Context(), h.db, id)
@@ -497,16 +526,17 @@ func (h *OrdersHandler) Refund(c *gin.Context) {
 		ResourceID:   id.String(),
 		Severity:     audit.SeverityWarning,
 		Metadata: map[string]any{
-			"refund_amount":    req.Amount,
-			"refunded_total":   o.RefundedAmount,
-			"payment_status":   req.PaymentStatus,
-			"reason":           req.Reason,
+			"refund_amount":      res.Amount,
+			"refunded_total":     o.RefundedAmount,
+			"payment_status":     res.PaymentStatus,
+			"provider_refund_id": res.ProviderRefundID,
+			"reason":             req.Reason,
 		},
 	})
 	// Refund recorded — fire the customer email with this refund's
 	// amount + the running total. The post-refund order row already
 	// reflects the new refunded_amount.
-	h.dispatchRefundEmail(id, req.Amount, o.RefundedAmount)
+	h.dispatchRefundEmail(id, res.Amount, o.RefundedAmount)
 	c.JSON(http.StatusOK, ToAdminOrderResponse(o, items, addrs))
 }
 
@@ -704,4 +734,3 @@ func (h *OrdersHandler) verifyOrderOwnership(c *gin.Context, orderID uuid.UUID) 
 	}
 	return nil
 }
-

--- a/services/marketplace-api/internal/handlers/admin/orders.go
+++ b/services/marketplace-api/internal/handlers/admin/orders.go
@@ -511,16 +511,16 @@ func (h *OrdersHandler) Refund(c *gin.Context) {
 		})
 		return
 	}
-	scope := req.RefundRequestID
-	if scope == "" {
-		scope = uuid.NewString()
+	if req.RefundRequestID == "" {
+		RespondErr(c, apperrors.ValidationFailed("refund_request_id", "refund_request_id is required (stable idempotency key per refund attempt)"), h.logger)
+		return
 	}
 	res, rerr := h.refunds.Refund(c.Request.Context(), orderrefund.RefundCommand{
 		OrderID: id,
 		Amount:  req.Amount,
 		Reason:  req.Reason,
 		Actor:   "user:" + c.GetString("user_id"),
-		ScopeID: scope,
+		ScopeID: req.RefundRequestID,
 	})
 	if rerr != nil {
 		RespondErr(c, rerr, h.logger)

--- a/services/marketplace-api/internal/handlers/admin/orders.go
+++ b/services/marketplace-api/internal/handlers/admin/orders.go
@@ -537,7 +537,11 @@ func (h *OrdersHandler) Refund(c *gin.Context) {
 	// amount + the running total. The post-refund order row already
 	// reflects the new refunded_amount.
 	h.dispatchRefundEmail(id, res.Amount, o.RefundedAmount)
-	c.JSON(http.StatusOK, ToAdminOrderResponse(o, items, addrs))
+	c.JSON(http.StatusOK, RefundOrderResponse{
+		AdminOrderResponse: ToAdminOrderResponse(o, items, addrs),
+		ProviderRefundID:   res.ProviderRefundID,
+		AlreadyDone:        res.AlreadyDone,
+	})
 }
 
 // EmailInvoice handles POST /admin/stores/:storeId/orders/:id/invoice/email

--- a/services/marketplace-api/internal/handlers/admin/orders.go
+++ b/services/marketplace-api/internal/handlers/admin/orders.go
@@ -458,6 +458,17 @@ func (h *OrdersHandler) Cancel(c *gin.Context) {
 		RespondErr(c, err, h.logger)
 		return
 	}
+	// Auto-refund a paid order on cancellation (spec §4). Best-effort: a
+	// gateway blip leaves the order cancelled + a pending ledger row for the
+	// sweeper, so the merchant is never blocked on the cancel response.
+	if h.refunds != nil && o.PaymentStatus == string(order.PaymentStatusPaid) {
+		if _, rerr := h.refunds.Refund(c.Request.Context(), orderrefund.RefundCommand{
+			OrderID: id, Amount: nil, Reason: "order cancelled",
+			Actor: "user:" + c.GetString("user_id"), ScopeID: "cancel",
+		}); rerr != nil {
+			h.logger.Warn("cancel auto-refund deferred", "order_id", id, "err", rerr)
+		}
+	}
 	cancelMsg := "Order " + o.OrderNumber + " was cancelled."
 	notification.Emit(c.Request.Context(), h.notify, h.logger, notification.Notification{
 		TenantID:     o.TenantID,

--- a/services/marketplace-api/internal/handlers/admin/orders_dto.go
+++ b/services/marketplace-api/internal/handlers/admin/orders_dto.go
@@ -301,9 +301,12 @@ type RejectReturnRequest struct {
 }
 
 // MarkRefundedRequest is the wire body for the cross-module refund step.
+// PaymentStatus is accepted for backward compatibility but ignored — the
+// orderrefund.Coordinator derives partial vs full payment_status itself
+// from the amount and the order's running refunded_amount.
 type MarkRefundedRequest struct {
-	Amount        decimal.Decimal `json:"amount"         binding:"required"`
-	PaymentStatus string          `json:"payment_status" binding:"required"`
+	Amount        decimal.Decimal `json:"amount" binding:"required"`
+	PaymentStatus string          `json:"payment_status"`
 	Reason        string          `json:"reason"`
 }
 

--- a/services/marketplace-api/internal/handlers/admin/orders_dto.go
+++ b/services/marketplace-api/internal/handlers/admin/orders_dto.go
@@ -100,9 +100,17 @@ type CancelOrderRequest struct {
 // the resulting payment_status from the amount rather than trusting the
 // caller — see OrdersHandler.Refund.
 type RefundOrderRequest struct {
-	Amount          *decimal.Decimal `json:"amount"`                      // omit ⇒ full remaining balance
-	RefundRequestID string           `json:"refund_request_id,omitempty"` // idempotency scope; server generates one if empty
-	Reason          string           `json:"reason"`
+	Amount *decimal.Decimal `json:"amount"` // omit ⇒ full remaining balance
+	// RefundRequestID is REQUIRED. It is the idempotency scope passed
+	// straight through to orderrefund.Coordinator as ScopeID: a stable
+	// UUID the admin UI generates once per refund attempt (charset
+	// [A-Za-z0-9_-]) and reuses verbatim on retry, so a client that times
+	// out and resubmits the same logical refund lands on the coordinator's
+	// AlreadyDone path instead of triggering a second real gateway refund.
+	// There is deliberately no server-generated fallback — a fresh UUID
+	// per request would defeat retry-safety.
+	RefundRequestID string `json:"refund_request_id"`
+	Reason          string `json:"reason"`
 	// PaymentStatus is deprecated: the coordinator derives partial vs full
 	// from the amount. Retained on the wire so older clients don't fail
 	// binding; the value is ignored.

--- a/services/marketplace-api/internal/handlers/admin/orders_dto.go
+++ b/services/marketplace-api/internal/handlers/admin/orders_dto.go
@@ -187,6 +187,17 @@ type AdminOrderTaxLineResponse struct {
 	Jurisdiction string          `json:"jurisdiction,omitempty"`
 }
 
+// RefundOrderResponse is the wire shape for a successful refund. It
+// anonymously embeds AdminOrderResponse so the response still serializes
+// every existing order field inline (callers unmarshalling into a plain
+// AdminOrderResponse keep working) while also surfacing the gateway's
+// provider_refund_id for reconciliation.
+type RefundOrderResponse struct {
+	AdminOrderResponse
+	ProviderRefundID string `json:"provider_refund_id"`
+	AlreadyDone      bool   `json:"already_refunded,omitempty"`
+}
+
 // ToAdminOrderResponse renders the persistence types into the wire shape.
 func ToAdminOrderResponse(o *order.Order, items []order.OrderItem, addrs []order.OrderAddress) AdminOrderResponse {
 	out := AdminOrderResponse{

--- a/services/marketplace-api/internal/handlers/admin/orders_dto.go
+++ b/services/marketplace-api/internal/handlers/admin/orders_dto.go
@@ -20,9 +20,9 @@ type ListOrdersQuery struct {
 	// customer_email. ILIKE match inside the repo layer so partial typed
 	// input (first chars of an order number, a customer domain, etc.)
 	// produces useful matches without pressing Enter.
-	Search        string `form:"search"`
-	Page          int    `form:"page"`
-	PageSize      int    `form:"page_size"`
+	Search   string `form:"search"`
+	Page     int    `form:"page"`
+	PageSize int    `form:"page_size"`
 }
 
 // Defaults sets sensible page / page_size defaults.
@@ -96,10 +96,17 @@ type CancelOrderRequest struct {
 }
 
 // RefundOrderRequest is the wire body for POST /admin/stores/:storeId/orders/:id/refund.
+// Money movement now goes through orderrefund.Coordinator, which derives
+// the resulting payment_status from the amount rather than trusting the
+// caller — see OrdersHandler.Refund.
 type RefundOrderRequest struct {
-	Amount        decimal.Decimal `json:"amount"         binding:"required"`
-	PaymentStatus string          `json:"payment_status" binding:"required"` // partially_refunded | refunded
-	Reason        string          `json:"reason"`
+	Amount          *decimal.Decimal `json:"amount"`                      // omit ⇒ full remaining balance
+	RefundRequestID string           `json:"refund_request_id,omitempty"` // idempotency scope; server generates one if empty
+	Reason          string           `json:"reason"`
+	// PaymentStatus is deprecated: the coordinator derives partial vs full
+	// from the amount. Retained on the wire so older clients don't fail
+	// binding; the value is ignored.
+	PaymentStatus string `json:"payment_status,omitempty"`
 }
 
 // -----------------------------------------------------------------------------
@@ -135,40 +142,40 @@ type AdminAddressResponse struct {
 
 // AdminOrderResponse is the canonical wire shape for a single order.
 type AdminOrderResponse struct {
-	ID                string                   `json:"id"`
-	TenantID          string                   `json:"tenant_id"`
-	StoreID           string                   `json:"store_id"`
-	OrderNumber       string                   `json:"order_number"`
-	IdempotencyKey    string                   `json:"idempotency_key"`
-	CustomerEmail     string                   `json:"customer_email"`
-	CustomerName      *string                  `json:"customer_name,omitempty"`
-	Status            string                   `json:"status"`
-	PaymentStatus     string                   `json:"payment_status"`
-	FulfillmentStatus string                   `json:"fulfillment_status"`
-	Subtotal          decimal.Decimal          `json:"subtotal"`
-	ShippingTotal     decimal.Decimal          `json:"shipping_total"`
-	TaxTotal          decimal.Decimal          `json:"tax_total"`
+	ID                string          `json:"id"`
+	TenantID          string          `json:"tenant_id"`
+	StoreID           string          `json:"store_id"`
+	OrderNumber       string          `json:"order_number"`
+	IdempotencyKey    string          `json:"idempotency_key"`
+	CustomerEmail     string          `json:"customer_email"`
+	CustomerName      *string         `json:"customer_name,omitempty"`
+	Status            string          `json:"status"`
+	PaymentStatus     string          `json:"payment_status"`
+	FulfillmentStatus string          `json:"fulfillment_status"`
+	Subtotal          decimal.Decimal `json:"subtotal"`
+	ShippingTotal     decimal.Decimal `json:"shipping_total"`
+	TaxTotal          decimal.Decimal `json:"tax_total"`
 	// TaxLines is the per-jurisdiction breakdown (CGST/SGST/IGST for
 	// India, VAT for flat-rate countries, state+county+city for TaxJar).
 	// Populated by single-order Get handler; List leaves it nil to keep
 	// the page payload tight.
-	TaxLines          []AdminOrderTaxLineResponse `json:"tax_lines,omitempty"`
-	DiscountTotal     decimal.Decimal          `json:"discount_total"`
-	GrandTotal        decimal.Decimal          `json:"grand_total"`
-	RefundedAmount    decimal.Decimal          `json:"refunded_amount"`
-	CurrencyCode      string                   `json:"currency_code"`
+	TaxLines       []AdminOrderTaxLineResponse `json:"tax_lines,omitempty"`
+	DiscountTotal  decimal.Decimal             `json:"discount_total"`
+	GrandTotal     decimal.Decimal             `json:"grand_total"`
+	RefundedAmount decimal.Decimal             `json:"refunded_amount"`
+	CurrencyCode   string                      `json:"currency_code"`
 	// ShippingService / ShippingCarrier are the customer's checkout choice
 	// — captured so the admin "Approve & generate label" panel can default
 	// to what the buyer paid for. Empty for orders pre-dating migration 82.
-	ShippingService   *string                  `json:"shipping_service,omitempty"`
-	ShippingCarrier   *string                  `json:"shipping_carrier,omitempty"`
-	Items             []AdminOrderItemResponse `json:"items"`
-	Addresses         []AdminAddressResponse   `json:"addresses"`
-	PlacedAt          time.Time                `json:"placed_at"`
-	CancelledAt       *time.Time               `json:"cancelled_at,omitempty"`
-	FulfilledAt       *time.Time               `json:"fulfilled_at,omitempty"`
-	CreatedAt         time.Time                `json:"created_at"`
-	UpdatedAt         time.Time                `json:"updated_at"`
+	ShippingService *string                  `json:"shipping_service,omitempty"`
+	ShippingCarrier *string                  `json:"shipping_carrier,omitempty"`
+	Items           []AdminOrderItemResponse `json:"items"`
+	Addresses       []AdminAddressResponse   `json:"addresses"`
+	PlacedAt        time.Time                `json:"placed_at"`
+	CancelledAt     *time.Time               `json:"cancelled_at,omitempty"`
+	FulfilledAt     *time.Time               `json:"fulfilled_at,omitempty"`
+	CreatedAt       time.Time                `json:"created_at"`
+	UpdatedAt       time.Time                `json:"updated_at"`
 }
 
 // AdminOrderTaxLineResponse is one row from order_tax_lines in the

--- a/services/marketplace-api/internal/handlers/admin/orders_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/orders_integration_test.go
@@ -30,6 +30,9 @@ var ordersTables = []string{
 	"order_items",
 	"return_items",
 	"returns",
+	"refund_transactions",
+	"payment_transactions",
+	"payment_gateway_configs",
 	"orders",
 	"abandoned_carts",
 	"outbox_events",
@@ -68,7 +71,14 @@ func setupOrdersRouter(t *testing.T) *ordersTestEnv {
 	})
 	authzMW := authz.NewMiddleware(fga, nil)
 
-	ordersHandler := admin.NewOrdersHandler(db, orderSvc, orderRepo, nil, nil)
+	// Refund coordinator wired against a fake gateway so refund tests never
+	// hit real Stripe. fakeGateway/fakeRefundResolver live in
+	// orders_refund_integration_test.go (same package/build tag).
+	gw := &fakeGateway{}
+	refundCoordinator := newTestRefundCoordinator(db, gw)
+
+	ordersHandler := admin.NewOrdersHandler(db, orderSvc, orderRepo, nil, nil).
+		WithRefunds(refundCoordinator)
 	returnsHandler := admin.NewReturnsHandler(db, returnSvc, returnRepo, orderRepo, orderSvc, nil)
 	abandonedCartsHandler := admin.NewAbandonedCartsHandler(abandonedCartSvc, nil)
 
@@ -181,10 +191,14 @@ func TestAPI_OrdersHappyPath(t *testing.T) {
 	}
 
 	// --- Partial refund (50 of 100) ---
+	// Refunds now move real money through the coordinator, which requires
+	// a captured gateway transaction + an active gateway config to resolve
+	// the payment context and provider — seed both before hitting /refund.
+	seedCapturedPaymentTxn(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID), uuid.MustParse(orderID), "100.00")
+	seedActiveGatewayConfig(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID))
 	refundBody := map[string]any{
-		"amount":         "50.00",
-		"payment_status": "partially_refunded",
-		"reason":         "customer-credit",
+		"amount": "50.00",
+		"reason": "customer-credit",
 	}
 	w = request(t, env.router, http.MethodPost, base+"/"+orderID+"/refund", refundBody, headers)
 	if w.Code != http.StatusOK {

--- a/services/marketplace-api/internal/handlers/admin/orders_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/orders_integration_test.go
@@ -198,8 +198,9 @@ func TestAPI_OrdersHappyPath(t *testing.T) {
 	seedCapturedPaymentTxn(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID), uuid.MustParse(orderID), "100.00")
 	seedActiveGatewayConfig(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID))
 	refundBody := map[string]any{
-		"amount": "50.00",
-		"reason": "customer-credit",
+		"amount":            "50.00",
+		"reason":            "customer-credit",
+		"refund_request_id": uuid.NewString(),
 	}
 	w = request(t, env.router, http.MethodPost, base+"/"+orderID+"/refund", refundBody, headers)
 	if w.Code != http.StatusOK {

--- a/services/marketplace-api/internal/handlers/admin/orders_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/orders_integration_test.go
@@ -212,6 +212,16 @@ func TestAPI_OrdersHappyPath(t *testing.T) {
 	if refunded.RefundedAmount.String() != "50" && refunded.RefundedAmount.String() != "50.00" {
 		t.Fatalf("refund: refunded_amount = %q, want 50", refunded.RefundedAmount.String())
 	}
+	// RefundOrderResponse anonymously embeds AdminOrderResponse and adds
+	// provider_refund_id — unmarshal separately into a narrow struct to
+	// assert the gateway's fakeGateway-supplied id round-trips.
+	var refundMeta struct {
+		ProviderRefundID string `json:"provider_refund_id"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &refundMeta)
+	if refundMeta.ProviderRefundID != "re_test" {
+		t.Fatalf("refund: provider_refund_id = %q, want re_test", refundMeta.ProviderRefundID)
+	}
 
 	// --- Get returns the same final state ---
 	w = request(t, env.router, http.MethodGet, base+"/"+orderID, nil, headers)

--- a/services/marketplace-api/internal/handlers/admin/orders_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/orders_integration_test.go
@@ -79,7 +79,8 @@ func setupOrdersRouter(t *testing.T) *ordersTestEnv {
 
 	ordersHandler := admin.NewOrdersHandler(db, orderSvc, orderRepo, nil, nil).
 		WithRefunds(refundCoordinator)
-	returnsHandler := admin.NewReturnsHandler(db, returnSvc, returnRepo, orderRepo, orderSvc, nil)
+	returnsHandler := admin.NewReturnsHandler(db, returnSvc, returnRepo, orderRepo, orderSvc, nil).
+		WithRefunds(refundCoordinator)
 	abandonedCartsHandler := admin.NewAbandonedCartsHandler(abandonedCartSvc, nil)
 
 	r := gin.New()

--- a/services/marketplace-api/internal/handlers/admin/orders_refund_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/orders_refund_integration_test.go
@@ -162,7 +162,7 @@ func TestAPI_OrdersRefund_NoCapturedPayment_Unavailable(t *testing.T) {
 	orderID := createAndConfirmOrder(t, env, base, headers, "100.00")
 	// Deliberately do NOT seed payment_transactions or payment_gateway_configs.
 
-	refundBody := map[string]any{"amount": "50.00", "reason": "customer-credit"}
+	refundBody := map[string]any{"amount": "50.00", "reason": "customer-credit", "refund_request_id": uuid.NewString()}
 	w := request(t, env.router, http.MethodPost, base+"/"+orderID+"/refund", refundBody, headers)
 	if w.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("refund: status %d, want 422 (body=%s)", w.Code, w.Body.String())
@@ -192,7 +192,7 @@ func TestAPI_OrdersRefund_OverCap_Rejected(t *testing.T) {
 	seedCapturedPaymentTxn(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID), uuid.MustParse(orderID), "100.00")
 	seedActiveGatewayConfig(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID))
 
-	refundBody := map[string]any{"amount": "999.00", "reason": "customer-credit"}
+	refundBody := map[string]any{"amount": "999.00", "reason": "customer-credit", "refund_request_id": uuid.NewString()}
 	w := request(t, env.router, http.MethodPost, base+"/"+orderID+"/refund", refundBody, headers)
 	if w.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("refund: status %d, want 422 (body=%s)", w.Code, w.Body.String())
@@ -249,5 +249,101 @@ func TestAPI_OrdersCancel_Paid_AutoRefunds(t *testing.T) {
 	}
 	if refundCount != 1 {
 		t.Fatalf("refund_transactions succeeded rows = %d, want 1", refundCount)
+	}
+}
+
+// TestAPI_OrdersRefund_MissingRequestID_400 asserts that refund_request_id
+// is required: a request omitting it never reaches the coordinator (no
+// server-generated fallback), and is rejected with 400 validation_failed.
+func TestAPI_OrdersRefund_MissingRequestID_400(t *testing.T) {
+	env := setupOrdersRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleAdmin, tenantID)
+	headers := authHeaders(userID, tenantID)
+	base := "/api/v1/admin/stores/" + storeID + "/orders"
+
+	orderID := createAndConfirmOrder(t, env, base, headers, "100.00")
+	seedCapturedPaymentTxn(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID), uuid.MustParse(orderID), "100.00")
+	seedActiveGatewayConfig(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID))
+
+	refundBody := map[string]any{"amount": "50.00", "reason": "customer-credit"}
+	w := request(t, env.router, http.MethodPost, base+"/"+orderID+"/refund", refundBody, headers)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("refund: status %d, want 400 (body=%s)", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("refund: unmarshal: %v", err)
+	}
+	if body["error"] != "validation_failed" {
+		t.Fatalf("refund: error = %v, want validation_failed", body["error"])
+	}
+}
+
+// TestAPI_OrdersRefund_SameRequestID_Idempotent proves retry-safety: POSTing
+// the same amount + refund_request_id twice must not double-refund. The
+// second call hits the coordinator's AlreadyDone path (same ScopeID), so
+// refunded_amount reflects the amount exactly once.
+func TestAPI_OrdersRefund_SameRequestID_Idempotent(t *testing.T) {
+	env := setupOrdersRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleAdmin, tenantID)
+	headers := authHeaders(userID, tenantID)
+	base := "/api/v1/admin/stores/" + storeID + "/orders"
+
+	orderID := createAndConfirmOrder(t, env, base, headers, "100.00")
+	seedCapturedPaymentTxn(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID), uuid.MustParse(orderID), "100.00")
+	seedActiveGatewayConfig(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID))
+
+	requestID := uuid.NewString()
+	refundBody := map[string]any{"amount": "50.00", "reason": "customer-credit", "refund_request_id": requestID}
+
+	w := request(t, env.router, http.MethodPost, base+"/"+orderID+"/refund", refundBody, headers)
+	if w.Code != http.StatusOK {
+		t.Fatalf("refund #1: status %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+	var first admin.AdminOrderResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &first); err != nil {
+		t.Fatalf("refund #1: unmarshal: %v", err)
+	}
+	if first.RefundedAmount.String() != "50" && first.RefundedAmount.String() != "50.00" {
+		t.Fatalf("refund #1: refunded_amount = %q, want 50", first.RefundedAmount.String())
+	}
+
+	// Retry with the SAME body (same amount + same refund_request_id) —
+	// simulates a client that timed out and resubmitted the identical
+	// logical refund. Must not trigger a second real gateway refund.
+	w = request(t, env.router, http.MethodPost, base+"/"+orderID+"/refund", refundBody, headers)
+	if w.Code != http.StatusOK {
+		t.Fatalf("refund #2 (retry): status %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+	var second admin.AdminOrderResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &second); err != nil {
+		t.Fatalf("refund #2: unmarshal: %v", err)
+	}
+	if second.RefundedAmount.String() != "50" && second.RefundedAmount.String() != "50.00" {
+		t.Fatalf("refund #2 (retry): refunded_amount = %q, want 50 (not doubled — idempotency broken)", second.RefundedAmount.String())
+	}
+
+	var refundMeta struct {
+		AlreadyDone bool `json:"already_refunded"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &refundMeta); err != nil {
+		t.Fatalf("refund #2: unmarshal meta: %v", err)
+	}
+	if !refundMeta.AlreadyDone {
+		t.Fatalf("refund #2 (retry): already_refunded = false, want true (coordinator should have short-circuited on the reused scope)")
+	}
+
+	// Double-check against the DB directly — refunded_amount must not be
+	// 100 (which would mean the cap didn't stop a second real refund).
+	var reloaded order.Order
+	if err := env.db.Table("orders").First(&reloaded, "id = ?", orderID).Error; err != nil {
+		t.Fatalf("reload order: %v", err)
+	}
+	if reloaded.RefundedAmount.String() != "50" && reloaded.RefundedAmount.String() != "50.00" {
+		t.Fatalf("reloaded order refunded_amount = %q, want 50 (not doubled)", reloaded.RefundedAmount.String())
 	}
 }

--- a/services/marketplace-api/internal/handlers/admin/orders_refund_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/orders_refund_integration_test.go
@@ -1,0 +1,207 @@
+//go:build integration
+
+// Package admin_test — refund-specific fixtures for the admin orders
+// integration suite. Task 9 wired OrdersHandler.Refund to
+// orderrefund.Coordinator, which moves real money through a payment.Gateway.
+// The fakeGateway/fakeRefundResolver here mirror the pattern used in
+// internal/orderrefund's own integration tests (coordinator_integration_test.go)
+// so the admin HTTP surface can be exercised end-to-end without ever
+// touching a real Stripe/Razorpay account. setupOrdersRouter (in
+// orders_integration_test.go, same package) wires every OrdersHandler in
+// this suite with a Coordinator built from newTestRefundCoordinator.
+package admin_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/authz"
+	"github.com/mark8ly/marketplace-api/internal/handlers/admin"
+	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/internal/orderrefund"
+	"github.com/mark8ly/marketplace-api/internal/outbox"
+	"github.com/mark8ly/marketplace-api/internal/payment"
+)
+
+// fakeGateway implements payment.Gateway with a canned successful
+// RefundPayment — refund tests must never dial out to a real provider.
+type fakeGateway struct{}
+
+func (f *fakeGateway) CreateIntent(ctx context.Context, in payment.CreateIntentInput) (*payment.Intent, error) {
+	return nil, errors.New("fakeGateway: CreateIntent not implemented")
+}
+
+func (f *fakeGateway) CapturePayment(ctx context.Context, captureID string) (*payment.Capture, error) {
+	return nil, errors.New("fakeGateway: CapturePayment not implemented")
+}
+
+func (f *fakeGateway) RefundPayment(ctx context.Context, in payment.RefundInput) (*payment.Refund, error) {
+	return &payment.Refund{ProviderRefundID: "re_test", Status: "succeeded", Amount: in.Amount}, nil
+}
+
+func (f *fakeGateway) VerifyWebhook(ctx context.Context, payload []byte, signature string) (*payment.WebhookEvent, error) {
+	return nil, errors.New("fakeGateway: VerifyWebhook not implemented")
+}
+
+func (f *fakeGateway) ProviderName() string { return "stripe" }
+
+func (f *fakeGateway) SupportedCountries() []string { return []string{"US"} }
+
+// fakeRefundResolver embeds the real *orderrefund.Resolver so
+// PaymentContextForOrder reads seeded rows for real, but overrides
+// GatewayFor to hand back the fakeGateway instead of constructing a real
+// provider client from decrypted API keys.
+type fakeRefundResolver struct {
+	*orderrefund.Resolver
+	gw payment.Gateway
+}
+
+func (f *fakeRefundResolver) GatewayFor(ctx context.Context, storeID uuid.UUID, provider string) (payment.Gateway, error) {
+	return f.gw, nil
+}
+
+// newTestRefundCoordinator wires a Coordinator against real payment/order
+// services and a fakeRefundResolver, always enabled so the admin refund
+// endpoint actually runs the saga in tests.
+func newTestRefundCoordinator(db *gorm.DB, gw payment.Gateway) *orderrefund.Coordinator {
+	res := &fakeRefundResolver{Resolver: orderrefund.NewResolver(db), gw: gw}
+	pay := payment.NewService(payment.NewRepository(db))
+	orders := order.NewService(db, order.NewRepository(), outbox.NewRepository(db))
+	return orderrefund.NewCoordinator(db, res, pay, orders, order.NewRepository(), true)
+}
+
+// seedCapturedPaymentTxn inserts a captured payment_transactions row so
+// orderrefund.Resolver.PaymentContextForOrder resolves a refund target for
+// orderID. Required before Coordinator.Refund will do anything but 422.
+func seedCapturedPaymentTxn(t *testing.T, db *gorm.DB, tenantID, storeID, orderID uuid.UUID, amount string) {
+	t.Helper()
+	err := db.Exec(
+		`INSERT INTO payment_transactions
+			(id, tenant_id, store_id, order_id, provider, provider_intent_id, provider_payment_id, amount, currency_code, status, metadata, created_at, updated_at)
+		 VALUES (gen_random_uuid(), ?, ?, ?, 'stripe', 'pi_test', 'pi_test', ?, 'USD', 'captured', '{}'::jsonb, now(), now())`,
+		tenantID, storeID, orderID, amount,
+	).Error
+	if err != nil {
+		t.Fatalf("seedCapturedPaymentTxn: %v", err)
+	}
+}
+
+// seedActiveGatewayConfig inserts an active stripe payment_gateway_configs
+// row so orderrefund.Resolver.GatewayFor resolves — the fake gateway
+// injected via fakeRefundResolver.GatewayFor never reads these column
+// values, but the row must exist and be active for resolution to succeed
+// in the real (non-fake) codepath this mirrors.
+func seedActiveGatewayConfig(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
+	t.Helper()
+	err := db.Exec(
+		`INSERT INTO payment_gateway_configs (id, tenant_id, store_id, provider, api_key_encrypted, secret_key_encrypted, mode, is_active)
+		 VALUES (gen_random_uuid(), ?, ?, 'stripe', 'sk', 'sk_secret', 'test', true)`,
+		tenantID, storeID,
+	).Error
+	if err != nil {
+		t.Fatalf("seedActiveGatewayConfig: %v", err)
+	}
+}
+
+// createAndConfirmOrder drives create → confirm(paid) over HTTP so the
+// order reaches payment_status=paid the same way a real merchant would,
+// and returns its id. grandTotal is used as both subtotal and grand_total
+// (no shipping/tax) to keep the refund-cap math simple in callers.
+func createAndConfirmOrder(t *testing.T, env *ordersTestEnv, base string, headers map[string]string, grandTotal string) string {
+	t.Helper()
+	createBody := map[string]any{
+		"idempotency_key": "refund-fixture-" + uuid.NewString(),
+		"customer_email":  "refund-fixture@example.com",
+		"items": []map[string]any{{
+			"title_snapshot": "Widget", "sku_snapshot": "WID-" + uuid.NewString()[:8],
+			"unit_price": grandTotal, "quantity": 1, "line_total": grandTotal,
+			"currency_code": "USD",
+		}},
+		"shipping":      map[string]any{"name": "A", "line1": "1 Main St", "city": "Dublin", "country_code": "IE"},
+		"billing":       map[string]any{"name": "A", "line1": "1 Main St", "city": "Dublin", "country_code": "IE"},
+		"subtotal":      grandTotal,
+		"grand_total":   grandTotal,
+		"currency_code": "USD",
+	}
+	w := request(t, env.router, http.MethodPost, base, createBody, headers)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: status %d body=%s", w.Code, w.Body.String())
+	}
+	var created admin.AdminOrderResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("create: unmarshal: %v", err)
+	}
+
+	confirmBody := map[string]any{"payment_status": "paid", "reason": "stripe-auth"}
+	w = request(t, env.router, http.MethodPost, base+"/"+created.ID+"/confirm", confirmBody, headers)
+	if w.Code != http.StatusOK {
+		t.Fatalf("confirm: status %d body=%s", w.Code, w.Body.String())
+	}
+	return created.ID
+}
+
+// TestAPI_OrdersRefund_NoCapturedPayment_Unavailable asserts that refunding
+// an order with no captured payment_transactions row is rejected before
+// the gateway or the order's payment_status is ever touched — the
+// coordinator returns apperrors.RefundUnavailable, which RespondErr maps
+// to 422 with error code "refund_unavailable".
+func TestAPI_OrdersRefund_NoCapturedPayment_Unavailable(t *testing.T) {
+	env := setupOrdersRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleAdmin, tenantID)
+	headers := authHeaders(userID, tenantID)
+	base := "/api/v1/admin/stores/" + storeID + "/orders"
+
+	orderID := createAndConfirmOrder(t, env, base, headers, "100.00")
+	// Deliberately do NOT seed payment_transactions or payment_gateway_configs.
+
+	refundBody := map[string]any{"amount": "50.00", "reason": "customer-credit"}
+	w := request(t, env.router, http.MethodPost, base+"/"+orderID+"/refund", refundBody, headers)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("refund: status %d, want 422 (body=%s)", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("refund: unmarshal: %v", err)
+	}
+	if body["error"] != "refund_unavailable" {
+		t.Fatalf("refund: error = %v, want refund_unavailable", body["error"])
+	}
+}
+
+// TestAPI_OrdersRefund_OverCap_Rejected asserts that a refund request
+// exceeding the captured total (min(grand_total, capturedTotal)) is
+// rejected with apperrors.ErrRefundExceedsTotal (422,
+// "refund_exceeds_total") and never reaches the gateway.
+func TestAPI_OrdersRefund_OverCap_Rejected(t *testing.T) {
+	env := setupOrdersRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleAdmin, tenantID)
+	headers := authHeaders(userID, tenantID)
+	base := "/api/v1/admin/stores/" + storeID + "/orders"
+
+	orderID := createAndConfirmOrder(t, env, base, headers, "100.00")
+	seedCapturedPaymentTxn(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID), uuid.MustParse(orderID), "100.00")
+	seedActiveGatewayConfig(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID))
+
+	refundBody := map[string]any{"amount": "999.00", "reason": "customer-credit"}
+	w := request(t, env.router, http.MethodPost, base+"/"+orderID+"/refund", refundBody, headers)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("refund: status %d, want 422 (body=%s)", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("refund: unmarshal: %v", err)
+	}
+	if body["error"] != "refund_exceeds_total" {
+		t.Fatalf("refund: error = %v, want refund_exceeds_total", body["error"])
+	}
+}

--- a/services/marketplace-api/internal/handlers/admin/orders_refund_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/orders_refund_integration_test.go
@@ -205,3 +205,49 @@ func TestAPI_OrdersRefund_OverCap_Rejected(t *testing.T) {
 		t.Fatalf("refund: error = %v, want refund_exceeds_total", body["error"])
 	}
 }
+
+// TestAPI_OrdersCancel_Paid_AutoRefunds asserts Task 11's admin-side hook:
+// cancelling a paid order with a captured payment auto-refunds the full
+// remaining balance through the same orderrefund.Coordinator saga the
+// Refund endpoint uses. Best-effort — the cancel response is 200 either
+// way — so this asserts on the resulting DB state (order + ledger row)
+// rather than the response body.
+func TestAPI_OrdersCancel_Paid_AutoRefunds(t *testing.T) {
+	env := setupOrdersRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleAdmin, tenantID)
+	headers := authHeaders(userID, tenantID)
+	base := "/api/v1/admin/stores/" + storeID + "/orders"
+
+	orderID := createAndConfirmOrder(t, env, base, headers, "75.00")
+	seedCapturedPaymentTxn(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID), uuid.MustParse(orderID), "75.00")
+	seedActiveGatewayConfig(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID))
+
+	cancelBody := map[string]any{"reason": "merchant cancelled — out of stock"}
+	w := request(t, env.router, http.MethodPost, base+"/"+orderID+"/cancel", cancelBody, headers)
+	if w.Code != http.StatusOK {
+		t.Fatalf("cancel: status %d, body=%s", w.Code, w.Body.String())
+	}
+
+	var reloaded order.Order
+	if err := env.db.Table("orders").First(&reloaded, "id = ?", orderID).Error; err != nil {
+		t.Fatalf("reload order: %v", err)
+	}
+	if reloaded.Status != string(order.OrderStatusCancelled) {
+		t.Fatalf("order status = %q, want cancelled", reloaded.Status)
+	}
+	if reloaded.PaymentStatus != string(order.PaymentStatusRefunded) {
+		t.Fatalf("order payment_status = %q, want refunded", reloaded.PaymentStatus)
+	}
+
+	var refundCount int64
+	if err := env.db.Table("refund_transactions").
+		Where("order_id = ? AND status = 'succeeded' AND idempotency_key = ?", orderID, "refund_"+orderID+"_cancel").
+		Count(&refundCount).Error; err != nil {
+		t.Fatalf("count refund_transactions: %v", err)
+	}
+	if refundCount != 1 {
+		t.Fatalf("refund_transactions succeeded rows = %d, want 1", refundCount)
+	}
+}

--- a/services/marketplace-api/internal/handlers/admin/refund_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/refund_integration_test.go
@@ -144,3 +144,8 @@ func TestRefund_OutsideCoolingOff(t *testing.T) {
 		t.Errorf("expected error=refund_outside_cooling_off, got %v", resp["error"])
 	}
 }
+
+// refundURL builds the §8 cooling-off subscription refund endpoint path.
+func refundURL(storeID string) string {
+	return "/admin/stores/" + storeID + "/subscription/refund"
+}

--- a/services/marketplace-api/internal/handlers/admin/returns.go
+++ b/services/marketplace-api/internal/handlers/admin/returns.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/notification"
 	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/internal/orderrefund"
 	"github.com/mark8ly/marketplace-api/internal/stores"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 )
@@ -24,7 +25,8 @@ type ReturnsHandler struct {
 	repo      order.ReturnRepository
 	orderRepo order.Repository
 	orderSvc  *order.Service
-	notify    *notification.Service // optional — nil-safe
+	refunds   *orderrefund.Coordinator // optional — nil disables the refunded endpoint (503)
+	notify    *notification.Service    // optional — nil-safe
 	logger    *slog.Logger
 }
 
@@ -37,6 +39,14 @@ func NewReturnsHandler(db *gorm.DB, svc *order.ReturnService, repo order.ReturnR
 // in-app notifications. Nil-safe.
 func (h *ReturnsHandler) WithNotifier(n *notification.Service) *ReturnsHandler {
 	h.notify = n
+	return h
+}
+
+// WithRefunds attaches the refund coordinator that moves real money for
+// return refunds. Nil-safe — leaving it unset makes MarkRefunded respond
+// 503 rather than silently skipping the gateway.
+func (h *ReturnsHandler) WithRefunds(c *orderrefund.Coordinator) *ReturnsHandler {
+	h.refunds = c
 	return h
 }
 
@@ -284,7 +294,20 @@ func (h *ReturnsHandler) MarkReceived(c *gin.Context) {
 }
 
 // MarkRefunded handles POST /admin/stores/:storeId/returns/:id/refunded.
-// Drives the cross-module atomic refund through the service layer.
+// This now moves real money — the request goes through
+// orderrefund.Coordinator (ScopeID = the return id, giving each return its
+// own idempotency key namespace), which resolves the order's captured
+// payment, calls the gateway, and derives partial vs full payment_status
+// from the amount. The caller-supplied payment_status field is ignored
+// (server-derived). Once the coordinator succeeds, ReturnService.StampRefundedOnly
+// stamps the return as refunded — the coordinator's own tx already bumped
+// orders.refunded_amount, so this second step only owns the return
+// aggregate's state.
+//
+// Self-heal: Coordinator.Refund is idempotent on ScopeID, so if
+// StampRefundedOnly fails after the money moved, retrying this endpoint
+// re-runs Coordinator.Refund as a no-op (AlreadyDone=true) and completes
+// the stamp on retry.
 func (h *ReturnsHandler) MarkRefunded(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
@@ -296,17 +319,41 @@ func (h *ReturnsHandler) MarkRefunded(c *gin.Context) {
 		RespondErr(c, apperrors.ValidationFailed("body", err.Error()), h.logger)
 		return
 	}
-	if err := h.svc.MarkRefunded(
-		c.Request.Context(), id,
-		req.Amount, order.PaymentStatus(req.PaymentStatus), req.Reason,
-	); err != nil {
-		RespondErr(c, err, h.logger)
+	if h.refunds == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error":   "service_unavailable",
+			"message": "Refunds are not configured.",
+		})
 		return
 	}
-	r, items, err := h.repo.GetByID(c.Request.Context(), h.db, id)
+
+	r, _, err := h.repo.GetByID(c.Request.Context(), h.db, id)
 	if err != nil {
 		RespondErr(c, err, h.logger)
 		return
 	}
-	c.JSON(http.StatusOK, ToAdminReturnResponse(r, items))
+
+	amount := req.Amount
+	if _, rerr := h.refunds.Refund(c.Request.Context(), orderrefund.RefundCommand{
+		OrderID: r.OrderID,
+		Amount:  &amount,
+		Reason:  req.Reason,
+		Actor:   "user:" + c.GetString("user_id"),
+		ScopeID: id.String(),
+	}); rerr != nil {
+		RespondErr(c, rerr, h.logger)
+		return
+	}
+
+	if err := h.svc.StampRefundedOnly(c.Request.Context(), id, req.Amount, req.Reason); err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+
+	full, items, err := h.repo.GetByID(c.Request.Context(), h.db, id)
+	if err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+	c.JSON(http.StatusOK, ToAdminReturnResponse(full, items))
 }

--- a/services/marketplace-api/internal/handlers/admin/returns_refund_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/returns_refund_integration_test.go
@@ -1,0 +1,201 @@
+//go:build integration
+
+// Package admin_test — Task 10 wired ReturnsHandler.MarkRefunded to
+// orderrefund.Coordinator so return refunds move real money, mirroring the
+// order-level refund wired in Task 9 (orders_refund_integration_test.go).
+// This file drives the full return lifecycle (request → approve →
+// received → refunded) over HTTP against setupOrdersRouter, which already
+// wires returnsHandler with a Coordinator built from a fakeGateway.
+package admin_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/mark8ly/marketplace-api/internal/authz"
+	"github.com/mark8ly/marketplace-api/internal/handlers/admin"
+	"github.com/mark8ly/marketplace-api/internal/payment"
+)
+
+// driveReturnToReceived creates an order item-scoped return, approves it,
+// and marks it received, returning the return id and the order item id it
+// covers. base is the /admin/stores/:storeId/orders path prefix.
+func driveReturnToReceived(t *testing.T, env *ordersTestEnv, base, orderID, orderItemID string, headers map[string]string) string {
+	t.Helper()
+
+	createBody := map[string]any{
+		"currency_code": "USD",
+		"items": []map[string]any{
+			{"order_item_id": orderItemID, "quantity": 1, "reason": "damaged"},
+		},
+	}
+	w := request(t, env.router, http.MethodPost, base+"/"+orderID+"/returns", createBody, headers)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("return request: status %d body=%s", w.Code, w.Body.String())
+	}
+	var created admin.AdminReturnResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("return request: unmarshal: %v", err)
+	}
+
+	returnsBase := "/api/v1/admin/stores/" + envStoreIDFromBase(base) + "/returns"
+
+	w = request(t, env.router, http.MethodPost, returnsBase+"/"+created.ID+"/approve", map[string]any{}, headers)
+	if w.Code != http.StatusOK {
+		t.Fatalf("return approve: status %d body=%s", w.Code, w.Body.String())
+	}
+
+	w = request(t, env.router, http.MethodPost, returnsBase+"/"+created.ID+"/received", map[string]any{}, headers)
+	if w.Code != http.StatusOK {
+		t.Fatalf("return received: status %d body=%s", w.Code, w.Body.String())
+	}
+
+	return created.ID
+}
+
+// envStoreIDFromBase extracts the storeId path segment from an
+// /admin/stores/:storeId/orders base path.
+func envStoreIDFromBase(base string) string {
+	const prefix = "/api/v1/admin/stores/"
+	rest := base[len(prefix):]
+	end := 0
+	for end < len(rest) && rest[end] != '/' {
+		end++
+	}
+	return rest[:end]
+}
+
+// TestAPI_ReturnRefund_MovesMoney drives request→approve→received→refunded
+// over HTTP and asserts the refund actually moved money through the
+// coordinator: a succeeded refund_transactions row keyed off the return id,
+// orders.refunded_amount bumped, and the return stamped refunded.
+func TestAPI_ReturnRefund_MovesMoney(t *testing.T) {
+	env := setupOrdersRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleAdmin, tenantID)
+	headers := authHeaders(userID, tenantID)
+	base := "/api/v1/admin/stores/" + storeID + "/orders"
+
+	// Seed a PAID order with a captured payment_transaction + active
+	// gateway config so the coordinator can resolve a refund target.
+	orderID := createAndConfirmOrder(t, env, base, headers, "120.00")
+	seedCapturedPaymentTxn(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID), uuid.MustParse(orderID), "120.00")
+	seedActiveGatewayConfig(t, env.db, uuid.MustParse(tenantID), uuid.MustParse(storeID))
+
+	// Fetch the order to grab its single item's id for the return request.
+	w := request(t, env.router, http.MethodGet, base+"/"+orderID, nil, headers)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get order: status %d body=%s", w.Code, w.Body.String())
+	}
+	var got admin.AdminOrderResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("get order: unmarshal: %v", err)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("expected 1 order item, got %d", len(got.Items))
+	}
+	orderItemID := got.Items[0].ID
+
+	returnID := driveReturnToReceived(t, env, base, orderID, orderItemID, headers)
+
+	refundedBody := map[string]any{"amount": "50.00", "reason": "item returned"}
+	w = request(t, env.router, http.MethodPost, "/api/v1/admin/stores/"+storeID+"/returns/"+returnID+"/refunded", refundedBody, headers)
+	if w.Code != http.StatusOK {
+		t.Fatalf("mark refunded: status %d body=%s", w.Code, w.Body.String())
+	}
+	var refunded admin.AdminReturnResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &refunded); err != nil {
+		t.Fatalf("mark refunded: unmarshal: %v", err)
+	}
+	if refunded.Status != "refunded" {
+		t.Fatalf("return status = %q, want refunded", refunded.Status)
+	}
+	if refunded.RefundAmount == nil || !refunded.RefundAmount.Equal(decimal.NewFromInt(50)) {
+		t.Fatalf("return refund_amount = %v, want 50", refunded.RefundAmount)
+	}
+
+	// --- refund_transactions row ---
+	wantKey := "refund_" + orderID + "_" + returnID
+	var txn payment.RefundTransaction
+	if err := env.db.Where("idempotency_key = ?", wantKey).First(&txn).Error; err != nil {
+		t.Fatalf("refund_transactions lookup: %v", err)
+	}
+	if txn.Status != "succeeded" {
+		t.Fatalf("refund_transactions.status = %q, want succeeded", txn.Status)
+	}
+	if txn.OrderID != orderID {
+		t.Fatalf("refund_transactions.order_id = %q, want %q", txn.OrderID, orderID)
+	}
+
+	// --- orders.refunded_amount ---
+	w = request(t, env.router, http.MethodGet, base+"/"+orderID, nil, headers)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get order (post-refund): status %d body=%s", w.Code, w.Body.String())
+	}
+	var postRefundOrder admin.AdminOrderResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &postRefundOrder); err != nil {
+		t.Fatalf("get order (post-refund): unmarshal: %v", err)
+	}
+	if !postRefundOrder.RefundedAmount.Equal(decimal.NewFromInt(50)) {
+		t.Fatalf("orders.refunded_amount = %s, want 50", postRefundOrder.RefundedAmount.String())
+	}
+}
+
+// TestAPI_ReturnRefund_NoCapturedPayment_Unavailable asserts that refunding
+// a received return whose order has no captured payment_transactions row
+// is rejected (422 refund_unavailable) BEFORE the return is ever stamped
+// refunded — the return must stay in 'received'.
+func TestAPI_ReturnRefund_NoCapturedPayment_Unavailable(t *testing.T) {
+	env := setupOrdersRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleAdmin, tenantID)
+	headers := authHeaders(userID, tenantID)
+	base := "/api/v1/admin/stores/" + storeID + "/orders"
+
+	orderID := createAndConfirmOrder(t, env, base, headers, "120.00")
+	// Deliberately do NOT seed payment_transactions or payment_gateway_configs.
+
+	w := request(t, env.router, http.MethodGet, base+"/"+orderID, nil, headers)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get order: status %d body=%s", w.Code, w.Body.String())
+	}
+	var got admin.AdminOrderResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("get order: unmarshal: %v", err)
+	}
+	orderItemID := got.Items[0].ID
+
+	returnID := driveReturnToReceived(t, env, base, orderID, orderItemID, headers)
+
+	refundedBody := map[string]any{"amount": "50.00", "reason": "item returned"}
+	w = request(t, env.router, http.MethodPost, "/api/v1/admin/stores/"+storeID+"/returns/"+returnID+"/refunded", refundedBody, headers)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("mark refunded: status %d, want 422 (body=%s)", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("mark refunded: unmarshal: %v", err)
+	}
+	if body["error"] != "refund_unavailable" {
+		t.Fatalf("mark refunded: error = %v, want refund_unavailable", body["error"])
+	}
+
+	// The return must NOT have been stamped refunded.
+	w = request(t, env.router, http.MethodGet, "/api/v1/admin/stores/"+storeID+"/returns/"+returnID, nil, headers)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get return: status %d body=%s", w.Code, w.Body.String())
+	}
+	var r admin.AdminReturnResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &r); err != nil {
+		t.Fatalf("get return: unmarshal: %v", err)
+	}
+	if r.Status != "received" {
+		t.Fatalf("return status = %q, want received (unchanged)", r.Status)
+	}
+}

--- a/services/marketplace-api/internal/handlers/storefront/cancel_autorefund_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/cancel_autorefund_integration_test.go
@@ -1,0 +1,380 @@
+//go:build integration
+
+// Package storefront_test — Task 11: auto-refund a PAID order when the
+// customer self-cancels it (spec §4). Mirrors the fakeGateway/
+// fakeRefundResolver pattern used by the admin refund integration suite
+// (internal/handlers/admin/orders_refund_integration_test.go) so this test
+// exercises the real orderrefund.Coordinator saga — reserve pending ledger
+// row, "call" the gateway, finalize — without ever dialing out to Stripe.
+package storefront_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/customer"
+	"github.com/mark8ly/marketplace-api/internal/handlers/storefront"
+	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/internal/orderrefund"
+	"github.com/mark8ly/marketplace-api/internal/outbox"
+	"github.com/mark8ly/marketplace-api/internal/payment"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// cancelAutoRefundTables is the dependency-ordered truncate list for this
+// suite. CASCADE handles cross-table cleanup.
+var cancelAutoRefundTables = []string{
+	"order_events",
+	"order_addresses",
+	"order_items",
+	"shipments",
+	"refund_transactions",
+	"payment_transactions",
+	"payment_gateway_configs",
+	"orders",
+	"customer_profiles",
+	"outbox_events",
+	"store_watermarks",
+	"stores",
+}
+
+// carFakeGateway implements payment.Gateway with a canned successful
+// RefundPayment — this suite must never dial out to a real provider.
+// Named distinctly from admin_test's fakeGateway since these live in
+// different packages but the same binary during `go vet ./...`.
+type carFakeGateway struct{}
+
+func (f *carFakeGateway) CreateIntent(ctx context.Context, in payment.CreateIntentInput) (*payment.Intent, error) {
+	return nil, errors.New("carFakeGateway: CreateIntent not implemented")
+}
+
+func (f *carFakeGateway) CapturePayment(ctx context.Context, captureID string) (*payment.Capture, error) {
+	return nil, errors.New("carFakeGateway: CapturePayment not implemented")
+}
+
+func (f *carFakeGateway) RefundPayment(ctx context.Context, in payment.RefundInput) (*payment.Refund, error) {
+	return &payment.Refund{ProviderRefundID: "re_test_cancel", Status: "succeeded", Amount: in.Amount}, nil
+}
+
+func (f *carFakeGateway) VerifyWebhook(ctx context.Context, payload []byte, signature string) (*payment.WebhookEvent, error) {
+	return nil, errors.New("carFakeGateway: VerifyWebhook not implemented")
+}
+
+func (f *carFakeGateway) ProviderName() string { return "stripe" }
+
+func (f *carFakeGateway) SupportedCountries() []string { return []string{"US"} }
+
+// carFakeRefundResolver embeds the real *orderrefund.Resolver so
+// PaymentContextForOrder reads seeded rows for real, but overrides
+// GatewayFor to hand back the fake gateway instead of constructing a real
+// provider client from decrypted API keys.
+type carFakeRefundResolver struct {
+	*orderrefund.Resolver
+	gw payment.Gateway
+}
+
+func (f *carFakeRefundResolver) GatewayFor(ctx context.Context, storeID uuid.UUID, provider string) (payment.Gateway, error) {
+	return f.gw, nil
+}
+
+// cancelAutoRefundEnv bundles the router, db, and seeded store for this suite.
+type cancelAutoRefundEnv struct {
+	db      *gorm.DB
+	handler *storefront.OrderDetailHandler
+	store   *stores.Store
+}
+
+// setupCancelAutoRefundEnv wires an OrderDetailHandler with orderSvc + a
+// refund Coordinator backed by the fake gateway above, always enabled so
+// the auto-refund path actually runs the saga in tests.
+func setupCancelAutoRefundEnv(t *testing.T) *cancelAutoRefundEnv {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	db := testdb.NewDB(t, cancelAutoRefundTables...)
+
+	store := seedCancelAutoRefundStore(t, db)
+
+	orderRepo := order.NewRepository()
+	outboxRepo := outbox.NewRepository(db)
+	orderSvc := order.NewService(db, orderRepo, outboxRepo)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	gw := &carFakeGateway{}
+	res := &carFakeRefundResolver{Resolver: orderrefund.NewResolver(db), gw: gw}
+	paySvc := payment.NewService(payment.NewRepository(db))
+	refundCoordinator := orderrefund.NewCoordinator(db, res, paySvc, orderSvc, orderRepo, true)
+
+	handler := storefront.NewOrderDetailHandler(db, orderRepo, orderSvc, nil, logger).
+		WithRefunds(refundCoordinator)
+
+	return &cancelAutoRefundEnv{db: db, handler: handler, store: store}
+}
+
+// buildCancelRouter mounts a minimal router exercising only Cancel, with a
+// tiny middleware that sets "store" and storefront.CustomerProfileKey on
+// the gin context — mimicking what StoreContext + OptionalCustomerAuth do
+// in production, without the overhead of real signed session cookies.
+func buildCancelRouter(handler *storefront.OrderDetailHandler, store *stores.Store, profile *customer.CustomerProfile) *gin.Engine {
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("store", store)
+		if profile != nil {
+			c.Set(storefront.CustomerProfileKey, profile)
+		}
+		c.Next()
+	})
+	r.POST("/storefront/stores/:storeSlug/orders/:id/cancel", handler.Cancel)
+	return r
+}
+
+func seedCancelAutoRefundStore(t *testing.T, db *gorm.DB) *stores.Store {
+	t.Helper()
+	storeID := uuid.NewString()
+	tenantID := uuid.NewString()
+	s := &stores.Store{
+		ID:           storeID,
+		TenantID:     tenantID,
+		Slug:         "car-" + storeID[:8],
+		Name:         "Cancel Auto-Refund Test Store",
+		CountryCode:  "US",
+		CurrencyCode: "USD",
+		Timezone:     "UTC",
+		Status:       stores.StatusActive,
+		SyncedAt:     time.Now(),
+	}
+	if err := db.Create(s).Error; err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	return s
+}
+
+func seedCancelAutoRefundCustomer(t *testing.T, db *gorm.DB, store *stores.Store) *customer.CustomerProfile {
+	t.Helper()
+	p := &customer.CustomerProfile{
+		TenantID: uuid.MustParse(store.TenantID),
+		StoreID:  uuid.MustParse(store.ID),
+		Email:    "cancel-autorefund-" + uuid.NewString()[:8] + "@example.com",
+	}
+	if err := db.Create(p).Error; err != nil {
+		t.Fatalf("seed customer profile: %v", err)
+	}
+	return p
+}
+
+// cancelAutoRefundOrderOpts controls the seeded order's payment state.
+type cancelAutoRefundOrderOpts struct {
+	PaymentStatus string // defaults to order.PaymentStatusPaid
+	GrandTotal    string // defaults to "120.00"
+}
+
+func seedCancelAutoRefundOrder(t *testing.T, db *gorm.DB, store *stores.Store, cust *customer.CustomerProfile, opts cancelAutoRefundOrderOpts) *order.Order {
+	t.Helper()
+	if opts.PaymentStatus == "" {
+		opts.PaymentStatus = string(order.PaymentStatusPaid)
+	}
+	if opts.GrandTotal == "" {
+		opts.GrandTotal = "120.00"
+	}
+	grandTotal, err := decimal.NewFromString(opts.GrandTotal)
+	if err != nil {
+		t.Fatalf("parse grand total: %v", err)
+	}
+	custID := cust.ID
+	o := &order.Order{
+		TenantID:       uuid.MustParse(store.TenantID),
+		StoreID:        uuid.MustParse(store.ID),
+		OrderNumber:    "M-" + uuid.NewString()[:8],
+		IdempotencyKey: "cancel-autorefund-" + uuid.NewString(),
+		CustomerID:     &custID,
+		CustomerEmail:  cust.Email,
+		Status:         string(order.OrderStatusConfirmed),
+		PaymentStatus:  opts.PaymentStatus,
+		Subtotal:       grandTotal,
+		GrandTotal:     grandTotal,
+		CurrencyCode:   "USD",
+	}
+	if err := db.Create(o).Error; err != nil {
+		t.Fatalf("seed order: %v", err)
+	}
+	return o
+}
+
+// seedCancelAutoRefundCapturedTxn inserts a captured payment_transactions
+// row so orderrefund.Resolver.PaymentContextForOrder resolves a refund
+// target for orderID.
+func seedCancelAutoRefundCapturedTxn(t *testing.T, db *gorm.DB, store *stores.Store, orderID uuid.UUID, amount string) {
+	t.Helper()
+	err := db.Exec(
+		`INSERT INTO payment_transactions
+			(id, tenant_id, store_id, order_id, provider, provider_intent_id, provider_payment_id, amount, currency_code, status, metadata, created_at, updated_at)
+		 VALUES (gen_random_uuid(), ?, ?, ?, 'stripe', 'pi_x', 'pi_x', ?, 'USD', 'captured', '{}'::jsonb, now(), now())`,
+		store.TenantID, store.ID, orderID, amount,
+	).Error
+	if err != nil {
+		t.Fatalf("seed captured payment txn: %v", err)
+	}
+}
+
+func seedCancelAutoRefundGatewayConfig(t *testing.T, db *gorm.DB, store *stores.Store) {
+	t.Helper()
+	err := db.Exec(
+		`INSERT INTO payment_gateway_configs (id, tenant_id, store_id, provider, api_key_encrypted, secret_key_encrypted, mode, is_active)
+		 VALUES (gen_random_uuid(), ?, ?, 'stripe', 'sk', 'sk_secret', 'test', true)`,
+		store.TenantID, store.ID,
+	).Error
+	if err != nil {
+		t.Fatalf("seed gateway config: %v", err)
+	}
+}
+
+func seedCancelAutoRefundShipment(t *testing.T, db *gorm.DB, store *stores.Store, orderID uuid.UUID) {
+	t.Helper()
+	err := db.Exec(
+		`INSERT INTO shipments (id, tenant_id, store_id, order_id, carrier, status, ship_from, ship_to, currency_code, created_at, updated_at)
+		 VALUES (gen_random_uuid(), ?, ?, ?, 'usps', 'pending', '{}'::jsonb, '{}'::jsonb, 'USD', now(), now())`,
+		store.TenantID, store.ID, orderID,
+	).Error
+	if err != nil {
+		t.Fatalf("seed shipment: %v", err)
+	}
+}
+
+func cancelAutoRefundRequest(r http.Handler, storeSlug, orderID string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/storefront/stores/"+storeSlug+"/orders/"+orderID+"/cancel", nil)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// TestCancelAutoRefund_Paid_TriggersFullRefund asserts that self-cancelling
+// a paid, unshipped order (1) cancels the order and (2) auto-refunds the
+// full grand_total through the (fake) gateway: a succeeded ledger row with
+// the deterministic idempotency key, refunded_amount == grand_total, and
+// payment_status flipped to refunded.
+func TestCancelAutoRefund_Paid_TriggersFullRefund(t *testing.T) {
+	env := setupCancelAutoRefundEnv(t)
+	cust := seedCancelAutoRefundCustomer(t, env.db, env.store)
+	o := seedCancelAutoRefundOrder(t, env.db, env.store, cust, cancelAutoRefundOrderOpts{GrandTotal: "120.00"})
+	seedCancelAutoRefundCapturedTxn(t, env.db, env.store, o.ID, "120.00")
+	seedCancelAutoRefundGatewayConfig(t, env.db, env.store)
+
+	r := buildCancelRouter(env.handler, env.store, cust)
+	w := cancelAutoRefundRequest(r, env.store.Slug, o.ID.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("cancel: status %d, body=%s", w.Code, w.Body.String())
+	}
+
+	var reloaded order.Order
+	if err := env.db.Table("orders").First(&reloaded, "id = ?", o.ID).Error; err != nil {
+		t.Fatalf("reload order: %v", err)
+	}
+	if reloaded.Status != string(order.OrderStatusCancelled) {
+		t.Fatalf("order status = %q, want cancelled", reloaded.Status)
+	}
+	if reloaded.PaymentStatus != string(order.PaymentStatusRefunded) {
+		t.Fatalf("order payment_status = %q, want refunded", reloaded.PaymentStatus)
+	}
+	if !reloaded.RefundedAmount.Equal(decimal.RequireFromString("120.00")) {
+		t.Fatalf("order refunded_amount = %s, want 120.00", reloaded.RefundedAmount.String())
+	}
+
+	var refundCount int64
+	if err := env.db.Table("refund_transactions").
+		Where("order_id = ? AND status = 'succeeded' AND idempotency_key = ?", o.ID, "refund_"+o.ID.String()+"_cancel").
+		Count(&refundCount).Error; err != nil {
+		t.Fatalf("count refund_transactions: %v", err)
+	}
+	if refundCount != 1 {
+		t.Fatalf("refund_transactions succeeded rows = %d, want 1", refundCount)
+	}
+}
+
+// TestCancelAutoRefund_Unpaid_NoRefund asserts that self-cancelling a
+// not-yet-paid order cancels it without ever attempting a refund — no
+// refund_transactions row should appear.
+func TestCancelAutoRefund_Unpaid_NoRefund(t *testing.T) {
+	env := setupCancelAutoRefundEnv(t)
+	cust := seedCancelAutoRefundCustomer(t, env.db, env.store)
+	o := seedCancelAutoRefundOrder(t, env.db, env.store, cust, cancelAutoRefundOrderOpts{
+		PaymentStatus: string(order.PaymentStatusPending),
+		GrandTotal:    "80.00",
+	})
+	// Deliberately do NOT seed payment_transactions or payment_gateway_configs.
+
+	r := buildCancelRouter(env.handler, env.store, cust)
+	w := cancelAutoRefundRequest(r, env.store.Slug, o.ID.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("cancel: status %d, body=%s", w.Code, w.Body.String())
+	}
+
+	var reloaded order.Order
+	if err := env.db.Table("orders").First(&reloaded, "id = ?", o.ID).Error; err != nil {
+		t.Fatalf("reload order: %v", err)
+	}
+	if reloaded.Status != string(order.OrderStatusCancelled) {
+		t.Fatalf("order status = %q, want cancelled", reloaded.Status)
+	}
+
+	var refundCount int64
+	if err := env.db.Table("refund_transactions").Where("order_id = ?", o.ID).Count(&refundCount).Error; err != nil {
+		t.Fatalf("count refund_transactions: %v", err)
+	}
+	if refundCount != 0 {
+		t.Fatalf("refund_transactions rows = %d, want 0 for an unpaid order", refundCount)
+	}
+}
+
+// TestCancelAutoRefund_ShipmentGuardWins asserts that the pre-existing
+// shipment-in-flight guard still bounces self-cancel with 409 before any
+// refund is attempted, even for a paid order.
+func TestCancelAutoRefund_ShipmentGuardWins(t *testing.T) {
+	env := setupCancelAutoRefundEnv(t)
+	cust := seedCancelAutoRefundCustomer(t, env.db, env.store)
+	o := seedCancelAutoRefundOrder(t, env.db, env.store, cust, cancelAutoRefundOrderOpts{GrandTotal: "50.00"})
+	seedCancelAutoRefundCapturedTxn(t, env.db, env.store, o.ID, "50.00")
+	seedCancelAutoRefundGatewayConfig(t, env.db, env.store)
+	seedCancelAutoRefundShipment(t, env.db, env.store, o.ID)
+
+	r := buildCancelRouter(env.handler, env.store, cust)
+	w := cancelAutoRefundRequest(r, env.store.Slug, o.ID.String())
+	if w.Code != http.StatusConflict {
+		t.Fatalf("cancel: status %d, want 409, body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["error"] != "shipment_in_flight" {
+		t.Fatalf("error = %v, want shipment_in_flight", body["error"])
+	}
+
+	var reloaded order.Order
+	if err := env.db.Table("orders").First(&reloaded, "id = ?", o.ID).Error; err != nil {
+		t.Fatalf("reload order: %v", err)
+	}
+	if reloaded.Status == string(order.OrderStatusCancelled) {
+		t.Fatalf("order should NOT be cancelled when the shipment guard fires")
+	}
+
+	var refundCount int64
+	if err := env.db.Table("refund_transactions").Where("order_id = ?", o.ID).Count(&refundCount).Error; err != nil {
+		t.Fatalf("count refund_transactions: %v", err)
+	}
+	if refundCount != 0 {
+		t.Fatalf("refund_transactions rows = %d, want 0 when the shipment guard blocks cancel", refundCount)
+	}
+}

--- a/services/marketplace-api/internal/handlers/storefront/order_detail.go
+++ b/services/marketplace-api/internal/handlers/storefront/order_detail.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/notification"
 	"github.com/mark8ly/marketplace-api/internal/order"
 	"github.com/mark8ly/marketplace-api/internal/orderdoc"
+	"github.com/mark8ly/marketplace-api/internal/orderrefund"
 	"github.com/mark8ly/marketplace-api/internal/stores"
 	"github.com/mark8ly/marketplace-api/internal/tax"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
@@ -39,6 +40,11 @@ type OrderDetailHandler struct {
 	// initiated return requests emit notification.TypeReturnRequested so
 	// admins see them in their bell just like admin-initiated ones.
 	notify     *notification.Service
+	// refunds is an optional refund coordinator. When set, a paid order
+	// is auto-refunded on customer self-cancel (spec §4). Nil-safe —
+	// without it, self-cancel simply skips the refund step (pre-existing
+	// behavior).
+	refunds    *orderrefund.Coordinator
 	logger     *slog.Logger
 }
 
@@ -62,6 +68,14 @@ func (h *OrderDetailHandler) WithReturns(svc *order.ReturnService, repo order.Re
 // Nil-safe; passing nil simply suppresses notifications on this path.
 func (h *OrderDetailHandler) WithNotifier(n *notification.Service) *OrderDetailHandler {
 	h.notify = n
+	return h
+}
+
+// WithRefunds attaches the refund coordinator so a paid order is
+// auto-refunded when the customer self-cancels it (spec §4). Nil-safe —
+// passing nil (or never calling this) simply skips the refund step.
+func (h *OrderDetailHandler) WithRefunds(c *orderrefund.Coordinator) *OrderDetailHandler {
+	h.refunds = c
 	return h
 }
 
@@ -594,6 +608,17 @@ func (h *OrderDetailHandler) Cancel(c *gin.Context) {
 		h.logger.Error("storefront cancel: service error", "err", err, "order_id", orderID)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal", "message": "Could not cancel the order. Please try again."})
 		return
+	}
+
+	// Auto-refund a paid order on cancellation (spec §4). Best-effort: a
+	// gateway blip leaves the order cancelled + a pending ledger row for the
+	// sweeper, so the customer is never blocked on the cancel response.
+	if h.refunds != nil && o.PaymentStatus == string(order.PaymentStatusPaid) {
+		if _, rerr := h.refunds.Refund(c.Request.Context(), orderrefund.RefundCommand{
+			OrderID: orderID, Amount: nil, Reason: "order cancelled", Actor: "customer", ScopeID: "cancel",
+		}); rerr != nil {
+			h.logger.Warn("cancel auto-refund deferred", "order_id", orderID, "err", rerr)
+		}
 	}
 
 	// Fire the cancellation email on a detached context — same fire-and-

--- a/services/marketplace-api/internal/handlers/storefront/webhooks.go
+++ b/services/marketplace-api/internal/handlers/storefront/webhooks.go
@@ -545,11 +545,21 @@ func (h *WebhookHandler) handleGiftCardEvent(ctx context.Context, evt *payment.W
 
 // handlePaymentSucceeded updates the payment transaction and confirms the order.
 func (h *WebhookHandler) handlePaymentSucceeded(ctx context.Context, provider string, evt *payment.WebhookEvent) {
-	// Update payment_transaction status to "captured".
+	// Update payment_transaction status to "captured". provider_payment_id
+	// is the captured refund target — Stripe's refund target is the intent
+	// (already persisted at intent creation), but Razorpay/PayPal refund
+	// against the captured payment/capture id carried on the event, which
+	// was previously discarded here. COALESCE(NULLIF(?, ''), ...) preserves
+	// any existing value when the event doesn't carry one (e.g. a retried
+	// webhook), instead of clobbering it with empty string.
 	if err := h.db.WithContext(ctx).Exec(
-		`UPDATE payment_transactions SET status = 'captured', payment_method = ?, updated_at = now()
-		 WHERE order_id = ?::uuid AND provider = ?`,
-		evt.PaymentMethod, evt.OrderID, provider,
+		`UPDATE payment_transactions
+		    SET status = 'captured',
+		        payment_method = ?,
+		        provider_payment_id = COALESCE(NULLIF(?, ''), provider_payment_id),
+		        updated_at = now()
+		  WHERE order_id = ?::uuid AND provider = ?`,
+		evt.PaymentMethod, evt.ProviderPaymentID, evt.OrderID, provider,
 	).Error; err != nil {
 		h.logError("webhook: failed to update payment transaction",
 			"order_id", evt.OrderID,

--- a/services/marketplace-api/internal/handlers/storefront/webhooks_capture_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/webhooks_capture_integration_test.go
@@ -1,0 +1,184 @@
+//go:build integration
+
+// White-box (in-package) test for handlePaymentSucceeded's persistence of
+// provider_payment_id. This must live in package storefront (not
+// storefront_test) because handlePaymentSucceeded is unexported.
+//
+// The WebhookHandler is constructed directly with orderSvc left nil, which
+// is safe: handlePaymentSucceeded only invokes the order-confirm path when
+// both h.orderSvc != nil AND evt.OrderID != "". Leaving orderSvc nil lets
+// this test exercise the payment_transactions UPDATE in isolation without
+// standing up the full order.Service + notification/loyalty/docmailer
+// dependency graph exercised by webhooks.go's other collaborators.
+package storefront
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/payment"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+var captureTestTruncateTables = []string{
+	"payment_transactions",
+	"orders",
+	"stores",
+}
+
+func seedCaptureTestStore(t *testing.T, db *gorm.DB, storeID, tenantID uuid.UUID) {
+	t.Helper()
+	err := db.Exec(
+		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, encode(gen_random_bytes(32), 'hex'))`,
+		storeID, tenantID, "wh-"+storeID.String()[:8], "Webhook Capture Test Store", "IE", "EUR", "Europe/Dublin", "active",
+	).Error
+	if err != nil {
+		t.Fatalf("seedCaptureTestStore: %v", err)
+	}
+}
+
+func seedCaptureTestOrder(t *testing.T, db *gorm.DB, orderID, storeID, tenantID uuid.UUID) {
+	t.Helper()
+	err := db.Exec(
+		`INSERT INTO orders (id, tenant_id, store_id, order_number, idempotency_key, customer_email,
+			status, payment_status, fulfillment_status,
+			subtotal, tax_total, shipping_total, grand_total, refunded_amount,
+			currency_code, placed_at, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, 'test@example.com',
+			'pending', 'pending', 'unfulfilled',
+			'100.00', '0', '0', '100.00', '0',
+			'EUR', now(), now(), now())`,
+		orderID, tenantID, storeID, "WH-"+orderID.String()[:8], "idem-"+orderID.String(),
+	).Error
+	if err != nil {
+		t.Fatalf("seedCaptureTestOrder: %v", err)
+	}
+}
+
+func seedCaptureTestPaymentTxn(t *testing.T, db *gorm.DB, tenantID, storeID, orderID uuid.UUID, provider string) {
+	t.Helper()
+	err := db.Exec(
+		`INSERT INTO payment_transactions
+			(id, tenant_id, store_id, order_id, provider, provider_intent_id, amount, currency_code, status, metadata)
+		 VALUES (gen_random_uuid(), ?, ?, ?, ?, ?, '100.00', 'EUR', 'pending', '{}'::jsonb)`,
+		tenantID, storeID, orderID, provider, "intent_"+orderID.String(),
+	).Error
+	if err != nil {
+		t.Fatalf("seedCaptureTestPaymentTxn: %v", err)
+	}
+}
+
+func fetchCaptureTestRow(t *testing.T, db *gorm.DB, orderID uuid.UUID) (status, providerPaymentID string) {
+	t.Helper()
+	var row struct {
+		Status            string `gorm:"column:status"`
+		ProviderPaymentID string `gorm:"column:provider_payment_id"`
+	}
+	if err := db.Table("payment_transactions").
+		Select("status, provider_payment_id").
+		Where("order_id = ?", orderID).
+		Take(&row).Error; err != nil {
+		t.Fatalf("fetchCaptureTestRow: %v", err)
+	}
+	return row.Status, row.ProviderPaymentID
+}
+
+// TestHandlePaymentSucceeded_PersistsProviderPaymentID is the Step 0
+// regression test: Razorpay/PayPal refund targets live in
+// provider_payment_id, which was previously discarded by
+// handlePaymentSucceeded. This exercises the exact SQL path both the
+// webhook route and the Razorpay client-verify route
+// (payment_verify.go) funnel through.
+func TestHandlePaymentSucceeded_PersistsProviderPaymentID(t *testing.T) {
+	db := testdb.NewDB(t, captureTestTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedCaptureTestStore(t, db, storeID, tenantID)
+	seedCaptureTestOrder(t, db, orderID, storeID, tenantID)
+	seedCaptureTestPaymentTxn(t, db, tenantID, storeID, orderID, "razorpay")
+
+	h := &WebhookHandler{db: db}
+	evt := &payment.WebhookEvent{
+		OrderID:           orderID.String(),
+		PaymentMethod:     "card",
+		ProviderPaymentID: "pay_ABC123",
+	}
+	h.handlePaymentSucceeded(context.Background(), "razorpay", evt)
+
+	status, providerPaymentID := fetchCaptureTestRow(t, db, orderID)
+	if status != "captured" {
+		t.Fatalf("status = %q, want captured", status)
+	}
+	if providerPaymentID != "pay_ABC123" {
+		t.Fatalf("provider_payment_id = %q, want pay_ABC123", providerPaymentID)
+	}
+}
+
+// TestHandlePaymentSucceeded_PreservesExistingProviderPaymentIDWhenEventLacksOne
+// covers the COALESCE(NULLIF(?, ''), provider_payment_id) branch: an event
+// with an empty ProviderPaymentID (e.g. a retried/duplicate webhook, or a
+// provider that doesn't carry one on every event) must not clobber a value
+// already persisted from an earlier capture.
+func TestHandlePaymentSucceeded_PreservesExistingProviderPaymentIDWhenEventLacksOne(t *testing.T) {
+	db := testdb.NewDB(t, captureTestTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedCaptureTestStore(t, db, storeID, tenantID)
+	seedCaptureTestOrder(t, db, orderID, storeID, tenantID)
+	seedCaptureTestPaymentTxn(t, db, tenantID, storeID, orderID, "razorpay")
+
+	h := &WebhookHandler{db: db}
+
+	// First event carries the captured payment id.
+	h.handlePaymentSucceeded(context.Background(), "razorpay", &payment.WebhookEvent{
+		OrderID:           orderID.String(),
+		PaymentMethod:     "card",
+		ProviderPaymentID: "pay_first",
+	})
+	_, providerPaymentID := fetchCaptureTestRow(t, db, orderID)
+	if providerPaymentID != "pay_first" {
+		t.Fatalf("after first event: provider_payment_id = %q, want pay_first", providerPaymentID)
+	}
+
+	// Second event (e.g. a retry) carries no ProviderPaymentID — must
+	// preserve the value already persisted, not overwrite it with empty.
+	h.handlePaymentSucceeded(context.Background(), "razorpay", &payment.WebhookEvent{
+		OrderID:           orderID.String(),
+		PaymentMethod:     "card",
+		ProviderPaymentID: "",
+	})
+	_, providerPaymentID = fetchCaptureTestRow(t, db, orderID)
+	if providerPaymentID != "pay_first" {
+		t.Fatalf("after empty-id event: provider_payment_id = %q, want preserved pay_first", providerPaymentID)
+	}
+}
+
+// TestHandlePaymentSucceeded_NilOrderServiceSkipsConfirm is a sanity check
+// that the test harness pattern used above (orderSvc left nil) is itself
+// safe — handlePaymentSucceeded must not panic when orderSvc is nil even
+// though evt.OrderID is set.
+func TestHandlePaymentSucceeded_NilOrderServiceSkipsConfirm(t *testing.T) {
+	db := testdb.NewDB(t, captureTestTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedCaptureTestStore(t, db, storeID, tenantID)
+	seedCaptureTestOrder(t, db, orderID, storeID, tenantID)
+	seedCaptureTestPaymentTxn(t, db, tenantID, storeID, orderID, "stripe")
+
+	h := &WebhookHandler{db: db}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	h.handlePaymentSucceeded(ctx, "stripe", &payment.WebhookEvent{
+		OrderID:           orderID.String(),
+		PaymentMethod:     "card",
+		ProviderPaymentID: "pi_stripe123",
+	})
+
+	status, providerPaymentID := fetchCaptureTestRow(t, db, orderID)
+	if status != "captured" || providerPaymentID != "pi_stripe123" {
+		t.Fatalf("status=%q provider_payment_id=%q, want captured/pi_stripe123", status, providerPaymentID)
+	}
+}

--- a/services/marketplace-api/internal/order/lifecycle_integration_test.go
+++ b/services/marketplace-api/internal/order/lifecycle_integration_test.go
@@ -138,7 +138,7 @@ func TestOrderLifecycle_FullJourney(t *testing.T) {
 	require.NoError(t, err)
 	returnID := returnRow.ID
 
-	require.NoError(t, returnSvc.Approve(ctx, returnID))
+	require.NoError(t, returnSvc.Approve(ctx, returnID, ""))
 	require.NoError(t, returnSvc.MarkReceived(ctx, returnID))
 	// Refund 50 EUR (one of two items) — partial refund.
 	require.NoError(t, returnSvc.MarkRefunded(ctx, returnID,
@@ -277,8 +277,8 @@ func seedStoreWithTenant(t *testing.T, db *gorm.DB, storeID, tenantID uuid.UUID)
 	t.Helper()
 	slug := "lc-" + storeID.String()[:18]
 	err := db.Exec(
-		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, encode(gen_random_bytes(32), 'hex'))`,
 		storeID, tenantID, slug, "Lifecycle Store", "IE", "EUR", "Europe/Dublin", "active",
 	).Error
 	require.NoError(t, err)

--- a/services/marketplace-api/internal/order/return_service.go
+++ b/services/marketplace-api/internal/order/return_service.go
@@ -312,6 +312,15 @@ func (s *ReturnService) MarkReceived(ctx context.Context, returnID uuid.UUID) er
 //
 // paymentStatusTarget is whichever PaymentStatus the caller wants the
 // underlying order to land on (PartiallyRefunded for partial, Refunded for full).
+//
+// Bookkeeping-only (no gateway); retained for state-machine tests
+// (internal/order/lifecycle_integration_test.go exercises the full
+// request→approve→received→refunded happy path against this method). The
+// HTTP path (ReturnsHandler.MarkRefunded) does NOT call this — it goes
+// through orderrefund.Coordinator (which moves real money and calls
+// order.Service.RecordRefund itself) followed by StampRefundedOnly. Both
+// methods coexist intentionally: this one for bookkeeping-only tests, the
+// coordinator + StampRefundedOnly pair for the real gateway-backed flow.
 func (s *ReturnService) MarkRefunded(ctx context.Context, returnID uuid.UUID, amount decimal.Decimal, paymentStatusTarget PaymentStatus, reason string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		r, _, err := s.repo.GetByID(ctx, tx, returnID)
@@ -329,6 +338,41 @@ func (s *ReturnService) MarkRefunded(ctx context.Context, returnID uuid.UUID, am
 		}
 		// Cross-module atomic refund.
 		if err := s.orderSvc.RecordRefund(ctx, tx, r.OrderID, amount, paymentStatusTarget, reason); err != nil {
+			return err
+		}
+		return s.orderSvc.RecordReturnEvent(ctx, tx, r.OrderID, EventKindReturnRefunded, outbox.EventReturnRefunded, ReturnEventPayload{
+			ReturnID:     r.ID.String(),
+			ReturnNumber: r.ReturnNumber,
+			Amount:       amount.String(),
+			Reason:       reason,
+		})
+	})
+}
+
+// StampRefundedOnly transitions received→refunded and stamps the return,
+// WITHOUT touching orders.refunded_amount — the orderrefund.Coordinator's
+// tx #2 already bumped that atomically alongside finalizing the gateway
+// refund ledger row. Used by ReturnsHandler.MarkRefunded after
+// orderrefund.Coordinator.Refund succeeds.
+//
+// Self-heal property: Coordinator.Refund is idempotent on ScopeID (the
+// return id), so if this call fails after the money already moved, an
+// admin retry of the HTTP endpoint re-runs Coordinator.Refund (which
+// no-ops with AlreadyDone=true since the ledger row is already
+// "succeeded") and then successfully completes the stamp here.
+func (s *ReturnService) StampRefundedOnly(ctx context.Context, returnID uuid.UUID, amount decimal.Decimal, reason string) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		r, _, err := s.repo.GetByID(ctx, tx, returnID)
+		if err != nil {
+			return err
+		}
+		if !ReturnStatus(r.Status).CanTransitionTo(ReturnStatusRefunded) {
+			return apperrors.InvalidTransition("return", r.Status, string(ReturnStatusRefunded))
+		}
+		if err := s.repo.UpdateStatus(tx, returnID, ReturnStatusRefunded); err != nil {
+			return err
+		}
+		if err := s.repo.StampRefunded(tx, returnID, amount); err != nil {
 			return err
 		}
 		return s.orderSvc.RecordReturnEvent(ctx, tx, r.OrderID, EventKindReturnRefunded, outbox.EventReturnRefunded, ReturnEventPayload{

--- a/services/marketplace-api/internal/order/testhelpers_integration_test.go
+++ b/services/marketplace-api/internal/order/testhelpers_integration_test.go
@@ -27,8 +27,8 @@ func seedStore(t *testing.T, db *gorm.DB, storeID uuid.UUID) {
 	tenantID := uuid.New()
 
 	err := db.Exec(
-		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, encode(gen_random_bytes(32), 'hex'))`,
 		storeID, tenantID, slug, "Test Store", "IE", "EUR", "Europe/Dublin", "active",
 	).Error
 	if err != nil {

--- a/services/marketplace-api/internal/orderrefund/coordinator.go
+++ b/services/marketplace-api/internal/orderrefund/coordinator.go
@@ -3,6 +3,7 @@ package orderrefund
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
@@ -12,6 +13,13 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/payment"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 )
+
+// scopeIDPattern restricts RefundCommand.ScopeID to the charset gateways
+// accept in idempotency keys (Razorpay's X-Refund-Idempotency requires
+// [A-Za-z0-9_-]). Return IDs (uuids) and the "cancel" constant already
+// satisfy this; the only untrusted value is admin's client-supplied
+// refund_request_id, but validating centrally protects every caller.
+var scopeIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
 // Refund ledger row statuses used by the saga.
 const (
@@ -92,6 +100,9 @@ func idempotencyKey(orderID uuid.UUID, scopeID string) string {
 func (c *Coordinator) Refund(ctx context.Context, cmd RefundCommand) (RefundResult, error) {
 	if !c.enabled {
 		return RefundResult{}, fmt.Errorf("orderrefund: gateway refunds disabled (REFUND_GATEWAY_ENABLED=false)")
+	}
+	if !scopeIDPattern.MatchString(cmd.ScopeID) {
+		return RefundResult{}, apperrors.ValidationFailed("refund_request_id", "must match [A-Za-z0-9_-]")
 	}
 
 	o, _, _, err := c.orderRepo.GetByID(ctx, c.db, cmd.OrderID)

--- a/services/marketplace-api/internal/orderrefund/coordinator.go
+++ b/services/marketplace-api/internal/orderrefund/coordinator.go
@@ -13,6 +13,12 @@ import (
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 )
 
+// Refund ledger row statuses used by the saga.
+const (
+	refundStatusPending   = "pending"
+	refundStatusSucceeded = "succeeded"
+)
+
 // RefundCommand is a request to refund all or part of an order's captured
 // payment. Amount==nil means "refund the full remaining balance"
 // (grand_total - refunded_amount).
@@ -125,8 +131,9 @@ func (c *Coordinator) Refund(ctx context.Context, cmd RefundCommand) (RefundResu
 
 	// tx #1 — reserve pending ledger row (idempotent re-entry guard).
 	var ledger *payment.RefundTransaction
+	var created bool
 	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		row, _, rErr := c.pay.ReserveRefund(ctx, tx, payment.ReserveRefundInput{
+		row, wasCreated, rErr := c.pay.ReserveRefund(ctx, tx, payment.ReserveRefundInput{
 			TenantID:          o.TenantID.String(),
 			StoreID:           o.StoreID.String(),
 			OrderID:           cmd.OrderID.String(),
@@ -138,17 +145,26 @@ func (c *Coordinator) Refund(ctx context.Context, cmd RefundCommand) (RefundResu
 			IdempotencyKey:    key,
 		})
 		ledger = row
+		created = wasCreated
 		return rErr
 	}); err != nil {
 		return RefundResult{}, err
 	}
-	if ledger.Status == "succeeded" {
-		return RefundResult{
-			ProviderRefundID: ledger.ProviderRefundID,
-			Amount:           amount,
-			PaymentStatus:    target,
-			AlreadyDone:      true,
-		}, nil
+	if !created {
+		if ledger.Status == refundStatusSucceeded {
+			return RefundResult{
+				ProviderRefundID: ledger.ProviderRefundID,
+				Amount:           amount,
+				PaymentStatus:    target,
+				AlreadyDone:      true,
+			}, nil
+		}
+		// An in-flight or crashed prior attempt reserved this key and never
+		// reached "succeeded". Do NOT re-run the gateway/bump refunded_amount
+		// here — that risks a double bump under RecordRefund's cap-only
+		// guard. Crash-recovery of stuck pending rows is handled by the
+		// sweeper, not by re-running Refund.
+		return RefundResult{}, apperrors.ErrIdempotencyConflict
 	}
 
 	// gateway call — real money, retry-safe via key. Deliberately outside
@@ -168,7 +184,7 @@ func (c *Coordinator) Refund(ctx context.Context, cmd RefundCommand) (RefundResu
 
 	// tx #2 — finalize ledger + bookkeeping, atomic.
 	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := c.pay.FinalizeRefund(ctx, tx, ledger.ID, ref.ProviderRefundID, "succeeded"); err != nil {
+		if err := c.pay.FinalizeRefund(ctx, tx, ledger.ID, ref.ProviderRefundID, refundStatusSucceeded); err != nil {
 			return err
 		}
 		return c.orders.RecordRefund(ctx, tx, cmd.OrderID, amount, target, cmd.Reason)

--- a/services/marketplace-api/internal/orderrefund/coordinator.go
+++ b/services/marketplace-api/internal/orderrefund/coordinator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/mark8ly/marketplace-api/internal/order"
 	"github.com/mark8ly/marketplace-api/internal/payment"
@@ -217,16 +218,44 @@ func (c *Coordinator) Refund(ctx context.Context, cmd RefundCommand) (RefundResu
 // so orders.refunded_amount was NOT bumped for it — re-running RecordRefund bumps
 // it exactly once.
 func (c *Coordinator) ResumePending(ctx context.Context, olderThan time.Duration, limit int) (int, error) {
-	var rows []payment.RefundTransaction
 	// The interval literal is built in Go (rather than concatenated in SQL
 	// via `? || ' seconds'`) because pgx cannot infer a text type for a bare
 	// numeric placeholder feeding string concatenation.
 	cutoff := fmt.Sprintf("%d seconds", int(olderThan.Seconds()))
-	if err := c.db.WithContext(ctx).
-		Where("status = 'pending' AND created_at < now() - (?)::interval", cutoff).
-		Order("created_at ASC").Limit(limit).Find(&rows).Error; err != nil {
+
+	// Claim a batch of pending row IDs with FOR UPDATE SKIP LOCKED so
+	// overlapping sweep runs (Cloud Scheduler retry, manual re-trigger, a
+	// prior run still mid-flight) don't even pick the same rows. This is a
+	// best-effort reduction of duplicate gateway calls, not the correctness
+	// guarantee — the row lock is released as soon as this short
+	// transaction commits, well before the gateway call and finalize below.
+	// The status-guarded UPDATE in the per-row loop is what makes
+	// double-finalization impossible even if two sweeps do end up
+	// processing the same row.
+	var ids []string
+	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return tx.Model(&payment.RefundTransaction{}).
+			Select("id").
+			Where("status = 'pending' AND created_at < now() - (?)::interval", cutoff).
+			Order("created_at ASC").
+			Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
+			Limit(limit).
+			Pluck("id", &ids).Error
+	}); err != nil {
 		return 0, err
 	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+
+	var rows []payment.RefundTransaction
+	if err := c.db.WithContext(ctx).
+		Where("id IN ?", ids).
+		Order("created_at ASC").
+		Find(&rows).Error; err != nil {
+		return 0, err
+	}
+
 	resumed := 0
 	for i := range rows {
 		row := rows[i]
@@ -250,15 +279,38 @@ func (c *Coordinator) ResumePending(ctx context.Context, olderThan time.Duration
 			continue // try again next sweep
 		}
 		target := DeriveStatus(o.RefundedAmount, row.Amount, o.GrandTotal)
+
+		// Status-guarded finalize: the UPDATE only flips rows still
+		// 'pending'. If a concurrent sweep run already finalized this row
+		// (RowsAffected == 0), skip RecordRefund entirely — otherwise
+		// orders.refunded_amount would be double-bumped for one real
+		// refund, since RecordRefund's only guard is the grand_total cap,
+		// not idempotency. Deliberately inlined here (rather than reusing
+		// payment.Service.FinalizeRefund) to make the guard explicit and
+		// keep the shared method's Task-6 contract untouched.
+		finalized := false
 		if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-			if err := c.pay.FinalizeRefund(ctx, tx, row.ID, ref.ProviderRefundID, refundStatusSucceeded); err != nil {
-				return err
+			res := tx.Exec(
+				`UPDATE refund_transactions SET status = 'succeeded', provider_refund_id = ?, updated_at = now()
+				  WHERE id = ? AND status = 'pending'`,
+				ref.ProviderRefundID, row.ID,
+			)
+			if res.Error != nil {
+				return res.Error
 			}
+			if res.RowsAffected == 0 {
+				// Another sweep run already finalized this row — do NOT
+				// bump refunded_amount again.
+				return nil
+			}
+			finalized = true
 			return c.orders.RecordRefund(ctx, tx, oid, row.Amount, target, row.Reason)
 		}); err != nil {
 			continue
 		}
-		resumed++
+		if finalized {
+			resumed++
+		}
 	}
 	return resumed, nil
 }

--- a/services/marketplace-api/internal/orderrefund/coordinator.go
+++ b/services/marketplace-api/internal/orderrefund/coordinator.go
@@ -1,0 +1,184 @@
+package orderrefund
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/internal/payment"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+)
+
+// RefundCommand is a request to refund all or part of an order's captured
+// payment. Amount==nil means "refund the full remaining balance"
+// (grand_total - refunded_amount).
+type RefundCommand struct {
+	OrderID uuid.UUID
+	Amount  *decimal.Decimal // nil ⇒ full remaining
+	Reason  string
+	Actor   string
+	ScopeID string // idempotency scope: return_id | "cancel" | refund_request_id ([A-Za-z0-9_-] only)
+}
+
+// RefundResult is what a successful (or already-completed) Refund call
+// reports back to the caller.
+type RefundResult struct {
+	ProviderRefundID string
+	Amount           decimal.Decimal
+	PaymentStatus    order.PaymentStatus
+	AlreadyDone      bool
+}
+
+// resolver is the narrow surface Coordinator needs from *Resolver — reading
+// an order's captured payment context and constructing the matching
+// payment.Gateway. Defined as an interface (rather than depending on
+// *Resolver concretely) so integration tests can inject a fake gateway
+// while still exercising the real PaymentContextForOrder DB read.
+type resolver interface {
+	PaymentContextForOrder(ctx context.Context, orderID uuid.UUID) (PaymentContext, error)
+	GatewayFor(ctx context.Context, storeID uuid.UUID, provider string) (payment.Gateway, error)
+}
+
+// Coordinator runs the refund saga: reserve a pending ledger row, call the
+// gateway, then atomically finalize the ledger and bookkeep the order. Every
+// trigger that can produce a refund (admin refund, return refund, paid
+// cancel) calls Coordinator.Refund — this is the single place gateway money
+// movement happens.
+type Coordinator struct {
+	db        *gorm.DB
+	res       resolver
+	pay       *payment.Service
+	orders    *order.Service
+	orderRepo order.Repository
+	enabled   bool
+}
+
+// NewCoordinator constructs a Coordinator. enabled gates whether Refund is
+// allowed to touch the gateway/DB at all — see the REFUND_GATEWAY_ENABLED
+// kill switch.
+func NewCoordinator(db *gorm.DB, res resolver, pay *payment.Service, orders *order.Service, orderRepo order.Repository, enabled bool) *Coordinator {
+	return &Coordinator{db: db, res: res, pay: pay, orders: orders, orderRepo: orderRepo, enabled: enabled}
+}
+
+// DeriveStatus picks partially_refunded vs refunded from the post-refund
+// total: refunded so far plus the amount about to be refunded, compared
+// against the order's grand total.
+func DeriveStatus(refunded, amount, grandTotal decimal.Decimal) order.PaymentStatus {
+	if refunded.Add(amount).GreaterThanOrEqual(grandTotal) {
+		return order.PaymentStatusRefunded
+	}
+	return order.PaymentStatusPartiallyRefunded
+}
+
+// idempotencyKey builds a provider-safe key. Charset is restricted to
+// [A-Za-z0-9_-] (Razorpay's X-Refund-Idempotency requires this and min 10
+// chars; Stripe/PayPal accept it). NO colons — Razorpay rejects them.
+func idempotencyKey(orderID uuid.UUID, scopeID string) string {
+	return "refund_" + orderID.String() + "_" + scopeID
+}
+
+// Refund runs the full saga for cmd. It never touches the gateway or the
+// database when the coordinator is disabled.
+func (c *Coordinator) Refund(ctx context.Context, cmd RefundCommand) (RefundResult, error) {
+	if !c.enabled {
+		return RefundResult{}, fmt.Errorf("orderrefund: gateway refunds disabled (REFUND_GATEWAY_ENABLED=false)")
+	}
+
+	o, _, _, err := c.orderRepo.GetByID(ctx, c.db, cmd.OrderID)
+	if err != nil {
+		return RefundResult{}, err
+	}
+
+	pc, err := c.res.PaymentContextForOrder(ctx, cmd.OrderID)
+	if err != nil {
+		return RefundResult{}, err
+	}
+	if !pc.Found {
+		return RefundResult{}, apperrors.RefundUnavailable("no captured payment for this order")
+	}
+
+	remaining := o.GrandTotal.Sub(o.RefundedAmount)
+	amount := remaining
+	if cmd.Amount != nil {
+		amount = *cmd.Amount
+	}
+	if amount.LessThanOrEqual(decimal.Zero) {
+		return RefundResult{}, apperrors.ValidationFailed("amount", "refund amount must be positive")
+	}
+
+	refundCap := decimal.Min(o.GrandTotal, pc.CapturedTotal)
+	if o.RefundedAmount.Add(amount).GreaterThan(refundCap) {
+		return RefundResult{}, apperrors.ErrRefundExceedsTotal
+	}
+
+	target := DeriveStatus(o.RefundedAmount, amount, o.GrandTotal)
+	key := idempotencyKey(cmd.OrderID, cmd.ScopeID)
+
+	gw, err := c.res.GatewayFor(ctx, o.StoreID, pc.Provider)
+	if err != nil {
+		return RefundResult{}, err
+	}
+
+	// tx #1 — reserve pending ledger row (idempotent re-entry guard).
+	var ledger *payment.RefundTransaction
+	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		row, _, rErr := c.pay.ReserveRefund(ctx, tx, payment.ReserveRefundInput{
+			TenantID:          o.TenantID.String(),
+			StoreID:           o.StoreID.String(),
+			OrderID:           cmd.OrderID.String(),
+			Provider:          pc.Provider,
+			ProviderPaymentID: pc.ProviderPaymentID,
+			Amount:            amount,
+			CurrencyCode:      o.CurrencyCode,
+			Reason:            cmd.Reason,
+			IdempotencyKey:    key,
+		})
+		ledger = row
+		return rErr
+	}); err != nil {
+		return RefundResult{}, err
+	}
+	if ledger.Status == "succeeded" {
+		return RefundResult{
+			ProviderRefundID: ledger.ProviderRefundID,
+			Amount:           amount,
+			PaymentStatus:    target,
+			AlreadyDone:      true,
+		}, nil
+	}
+
+	// gateway call — real money, retry-safe via key. Deliberately outside
+	// any transaction: if this fails or the process dies, the ledger row
+	// stays pending and a sweeper (or the next retry with the same
+	// ScopeID) picks it back up.
+	ref, err := c.pay.ExecuteGatewayRefund(ctx, gw, payment.RefundInput{
+		ProviderPaymentID: pc.ProviderPaymentID,
+		Amount:            amount,
+		CurrencyCode:      o.CurrencyCode,
+		Reason:            cmd.Reason,
+		IdempotencyKey:    key,
+	})
+	if err != nil {
+		return RefundResult{}, err // ledger stays pending → sweeper retries
+	}
+
+	// tx #2 — finalize ledger + bookkeeping, atomic.
+	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := c.pay.FinalizeRefund(ctx, tx, ledger.ID, ref.ProviderRefundID, "succeeded"); err != nil {
+			return err
+		}
+		return c.orders.RecordRefund(ctx, tx, cmd.OrderID, amount, target, cmd.Reason)
+	}); err != nil {
+		return RefundResult{}, err
+	}
+
+	return RefundResult{
+		ProviderRefundID: ref.ProviderRefundID,
+		Amount:           amount,
+		PaymentStatus:    target,
+	}, nil
+}

--- a/services/marketplace-api/internal/orderrefund/coordinator.go
+++ b/services/marketplace-api/internal/orderrefund/coordinator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
@@ -208,4 +209,56 @@ func (c *Coordinator) Refund(ctx context.Context, cmd RefundCommand) (RefundResu
 		Amount:           amount,
 		PaymentStatus:    target,
 	}, nil
+}
+
+// ResumePending re-drives refund ledger rows stuck in 'pending' — the never-lost
+// guarantee. Safe to run repeatedly: the same idempotency_key makes the gateway
+// call a no-op if money already moved. A 'pending' row means tx#2 never committed,
+// so orders.refunded_amount was NOT bumped for it — re-running RecordRefund bumps
+// it exactly once.
+func (c *Coordinator) ResumePending(ctx context.Context, olderThan time.Duration, limit int) (int, error) {
+	var rows []payment.RefundTransaction
+	// The interval literal is built in Go (rather than concatenated in SQL
+	// via `? || ' seconds'`) because pgx cannot infer a text type for a bare
+	// numeric placeholder feeding string concatenation.
+	cutoff := fmt.Sprintf("%d seconds", int(olderThan.Seconds()))
+	if err := c.db.WithContext(ctx).
+		Where("status = 'pending' AND created_at < now() - (?)::interval", cutoff).
+		Order("created_at ASC").Limit(limit).Find(&rows).Error; err != nil {
+		return 0, err
+	}
+	resumed := 0
+	for i := range rows {
+		row := rows[i]
+		oid, err := uuid.Parse(row.OrderID)
+		if err != nil {
+			continue
+		}
+		o, _, _, err := c.orderRepo.GetByID(ctx, c.db, oid)
+		if err != nil || o == nil {
+			continue
+		}
+		gw, err := c.res.GatewayFor(ctx, o.StoreID, row.Provider)
+		if err != nil {
+			continue
+		}
+		ref, err := c.pay.ExecuteGatewayRefund(ctx, gw, payment.RefundInput{
+			ProviderPaymentID: row.ProviderPaymentID, Amount: row.Amount,
+			CurrencyCode: o.CurrencyCode, Reason: row.Reason, IdempotencyKey: row.IdempotencyKey,
+		})
+		if err != nil {
+			continue // try again next sweep
+		}
+		target := DeriveStatus(o.RefundedAmount, row.Amount, o.GrandTotal)
+		if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			if err := c.pay.FinalizeRefund(ctx, tx, row.ID, ref.ProviderRefundID, refundStatusSucceeded); err != nil {
+				return err
+			}
+			return c.orders.RecordRefund(ctx, tx, oid, row.Amount, target, row.Reason)
+		}); err != nil {
+			continue
+		}
+		resumed++
+	}
+	return resumed, nil
 }

--- a/services/marketplace-api/internal/orderrefund/coordinator_integration_test.go
+++ b/services/marketplace-api/internal/orderrefund/coordinator_integration_test.go
@@ -56,10 +56,13 @@ func seedPaidOrder(t *testing.T, db *gorm.DB, orderID, storeID, tenantID uuid.UU
 
 // fakeGateway implements payment.Gateway. Only RefundPayment does anything
 // interesting for these tests; it records every call so tests can assert
-// the gateway was (or was not) invoked.
+// the gateway was (or was not) invoked. If refundErr is set, RefundPayment
+// returns it instead of a successful refund (used to exercise the
+// gateway-failure path).
 type fakeGateway struct {
-	mu    sync.Mutex
-	calls []payment.RefundInput
+	mu        sync.Mutex
+	calls     []payment.RefundInput
+	refundErr error
 }
 
 func (f *fakeGateway) callCount() int {
@@ -85,7 +88,11 @@ func (f *fakeGateway) CapturePayment(ctx context.Context, captureID string) (*pa
 func (f *fakeGateway) RefundPayment(ctx context.Context, in payment.RefundInput) (*payment.Refund, error) {
 	f.mu.Lock()
 	f.calls = append(f.calls, in)
+	err := f.refundErr
 	f.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
 	return &payment.Refund{ProviderRefundID: "re_test", Status: "succeeded", Amount: in.Amount}, nil
 }
 
@@ -361,5 +368,104 @@ func TestRefund_IdempotentReplay(t *testing.T) {
 	o := getOrder(t, db, orderID)
 	if !o.RefundedAmount.Equal(decimal.RequireFromString("50.00")) {
 		t.Fatalf("refunded_amount = %s, want 50.00 (bumped once, not twice)", o.RefundedAmount)
+	}
+}
+
+// (g) Gateway error: the gateway rejects the refund call. The ledger row
+// reserved in tx #1 must stay pending (not succeeded) and refunded_amount
+// must not be bumped — tx #2 never runs.
+func TestRefund_GatewayError_LeavesPending(t *testing.T) {
+	db := testdb.NewDB(t, coordinatorTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedPaidOrder(t, db, orderID, storeID, tenantID, "120.00", "0")
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider: "stripe", ProviderPaymentID: "pi_x", Amount: "120.00", Status: "captured",
+	})
+
+	gw := &fakeGateway{refundErr: errors.New("gateway: card declined")}
+	c := newCoordinator(db, gw, true)
+
+	amount := decimal.RequireFromString("50.00")
+	_, err := c.Refund(context.Background(), orderrefund.RefundCommand{
+		OrderID: orderID, Amount: &amount, Reason: "customer request", Actor: "admin", ScopeID: "rr1",
+	})
+	if err == nil {
+		t.Fatal("Refund: err = nil, want non-nil (gateway error)")
+	}
+
+	o := getOrder(t, db, orderID)
+	if !o.RefundedAmount.IsZero() {
+		t.Fatalf("refunded_amount = %s, want 0 (gateway failed, must not bookkeep)", o.RefundedAmount)
+	}
+
+	wantKey := "refund_" + orderID.String() + "_rr1"
+	row := getRefundTxn(t, db, wantKey)
+	if row.Status != "pending" {
+		t.Fatalf("ledger status = %q, want pending (gateway failed, stays pending for sweeper/retry)", row.Status)
+	}
+
+	if gw.callCount() != 1 {
+		t.Fatalf("gateway call count = %d, want 1", gw.callCount())
+	}
+}
+
+// (h) Pending replay: a ledger row already exists for this idempotency key
+// (e.g. a concurrent in-flight call or a crashed prior attempt) but never
+// reached "succeeded". Refund must reject with ErrIdempotencyConflict
+// without calling the gateway or bumping refunded_amount — re-running the
+// saga against a stuck pending row risks a double bump under RecordRefund's
+// cap-only guard. Crash-recovery of stuck rows is the sweeper's job, not
+// Refund's.
+func TestRefund_PendingReplay_ConflictWithoutGatewayCall(t *testing.T) {
+	db := testdb.NewDB(t, coordinatorTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedPaidOrder(t, db, orderID, storeID, tenantID, "120.00", "0")
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider: "stripe", ProviderPaymentID: "pi_x", Amount: "120.00", Status: "captured",
+	})
+
+	wantKey := "refund_" + orderID.String() + "_rr1"
+
+	// Pre-reserve a pending ledger row for this scope directly via the
+	// payment repo/service, simulating a concurrent duplicate request or a
+	// crash between tx #1 and the gateway call.
+	pay := payment.NewService(payment.NewRepository(db))
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		_, created, rErr := pay.ReserveRefund(context.Background(), tx, payment.ReserveRefundInput{
+			TenantID: tenantID.String(), StoreID: storeID.String(), OrderID: orderID.String(),
+			Provider: "stripe", ProviderPaymentID: "pi_x",
+			Amount: decimal.RequireFromString("50.00"), CurrencyCode: "EUR",
+			Reason: "prior attempt", IdempotencyKey: wantKey,
+		})
+		if !created {
+			t.Fatal("pre-reserve: created = false, want true")
+		}
+		return rErr
+	}); err != nil {
+		t.Fatalf("pre-reserve: %v", err)
+	}
+
+	gw := &fakeGateway{}
+	c := newCoordinator(db, gw, true)
+
+	amount := decimal.RequireFromString("50.00")
+	_, err := c.Refund(context.Background(), orderrefund.RefundCommand{
+		OrderID: orderID, Amount: &amount, Reason: "customer request", Actor: "admin", ScopeID: "rr1",
+	})
+	if !errors.Is(err, apperrors.ErrIdempotencyConflict) {
+		t.Fatalf("err = %v, want ErrIdempotencyConflict", err)
+	}
+	if gw.callCount() != 0 {
+		t.Fatalf("gateway call count = %d, want 0 (must not re-run gateway against stuck pending row)", gw.callCount())
+	}
+
+	o := getOrder(t, db, orderID)
+	if !o.RefundedAmount.IsZero() {
+		t.Fatalf("refunded_amount = %s, want 0 (must not bump against a pending, non-succeeded ledger row)", o.RefundedAmount)
+	}
+	if n := countRefundTxns(t, db, orderID); n != 1 {
+		t.Fatalf("refund_transactions rows = %d, want 1 (no duplicate ledger row)", n)
 	}
 }

--- a/services/marketplace-api/internal/orderrefund/coordinator_integration_test.go
+++ b/services/marketplace-api/internal/orderrefund/coordinator_integration_test.go
@@ -1,0 +1,365 @@
+//go:build integration
+
+package orderrefund_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/internal/orderrefund"
+	"github.com/mark8ly/marketplace-api/internal/outbox"
+	"github.com/mark8ly/marketplace-api/internal/payment"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// coordinatorTruncateTables is the dependency-ordered truncate list for the
+// Coordinator integration tests. Children (refund_transactions,
+// payment_transactions, payment_gateway_configs) are listed before parents
+// (orders, stores); order_events/outbox_events cascade automatically.
+var coordinatorTruncateTables = []string{
+	"refund_transactions",
+	"payment_transactions",
+	"payment_gateway_configs",
+	"orders",
+	"stores",
+}
+
+// seedPaidOrder inserts an orders row with payment_status='paid' so
+// order.Service.RecordRefund's transition guard (paid -> refunded |
+// partially_refunded) is satisfied.
+func seedPaidOrder(t *testing.T, db *gorm.DB, orderID, storeID, tenantID uuid.UUID, grandTotal, refundedAmount string) {
+	t.Helper()
+	err := db.Exec(
+		`INSERT INTO orders (id, tenant_id, store_id, order_number, idempotency_key, customer_email,
+			status, payment_status, fulfillment_status,
+			subtotal, tax_total, shipping_total, grand_total, refunded_amount,
+			currency_code, placed_at, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, 'test@example.com',
+			'confirmed', 'paid', 'unfulfilled',
+			?, '0', '0', ?, ?,
+			'EUR', now(), now(), now())`,
+		orderID, tenantID, storeID, "RO-"+orderID.String()[:8], "idem-"+orderID.String(),
+		grandTotal, grandTotal, refundedAmount,
+	).Error
+	if err != nil {
+		t.Fatalf("seedPaidOrder: %v", err)
+	}
+}
+
+// fakeGateway implements payment.Gateway. Only RefundPayment does anything
+// interesting for these tests; it records every call so tests can assert
+// the gateway was (or was not) invoked.
+type fakeGateway struct {
+	mu    sync.Mutex
+	calls []payment.RefundInput
+}
+
+func (f *fakeGateway) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+func (f *fakeGateway) lastCall() payment.RefundInput {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[len(f.calls)-1]
+}
+
+func (f *fakeGateway) CreateIntent(ctx context.Context, in payment.CreateIntentInput) (*payment.Intent, error) {
+	return nil, errors.New("fakeGateway: CreateIntent not implemented")
+}
+
+func (f *fakeGateway) CapturePayment(ctx context.Context, captureID string) (*payment.Capture, error) {
+	return nil, errors.New("fakeGateway: CapturePayment not implemented")
+}
+
+func (f *fakeGateway) RefundPayment(ctx context.Context, in payment.RefundInput) (*payment.Refund, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, in)
+	f.mu.Unlock()
+	return &payment.Refund{ProviderRefundID: "re_test", Status: "succeeded", Amount: in.Amount}, nil
+}
+
+func (f *fakeGateway) VerifyWebhook(ctx context.Context, payload []byte, signature string) (*payment.WebhookEvent, error) {
+	return nil, errors.New("fakeGateway: VerifyWebhook not implemented")
+}
+
+func (f *fakeGateway) ProviderName() string { return "stripe" }
+
+func (f *fakeGateway) SupportedCountries() []string { return []string{"IE"} }
+
+// fakeResolver embeds the real *orderrefund.Resolver (so PaymentContextForOrder
+// reads seeded rows for real) but overrides GatewayFor to hand back a
+// fakeGateway instead of constructing a real provider client.
+type fakeResolver struct {
+	*orderrefund.Resolver
+	gw payment.Gateway
+}
+
+func (f *fakeResolver) GatewayFor(ctx context.Context, storeID uuid.UUID, provider string) (payment.Gateway, error) {
+	return f.gw, nil
+}
+
+// newCoordinator wires a Coordinator against real payment/order services and
+// a fakeResolver, for the given db and enabled flag.
+func newCoordinator(db *gorm.DB, gw *fakeGateway, enabled bool) *orderrefund.Coordinator {
+	res := &fakeResolver{Resolver: orderrefund.NewResolver(db), gw: gw}
+	pay := payment.NewService(payment.NewRepository(db))
+	orders := order.NewService(db, order.NewRepository(), outbox.NewRepository(db))
+	return orderrefund.NewCoordinator(db, res, pay, orders, order.NewRepository(), enabled)
+}
+
+func getOrder(t *testing.T, db *gorm.DB, orderID uuid.UUID) order.Order {
+	t.Helper()
+	var o order.Order
+	if err := db.Where("id = ?", orderID).First(&o).Error; err != nil {
+		t.Fatalf("getOrder: %v", err)
+	}
+	return o
+}
+
+func getRefundTxn(t *testing.T, db *gorm.DB, idempotencyKey string) payment.RefundTransaction {
+	t.Helper()
+	var row payment.RefundTransaction
+	if err := db.Where("idempotency_key = ?", idempotencyKey).First(&row).Error; err != nil {
+		t.Fatalf("getRefundTxn: %v", err)
+	}
+	return row
+}
+
+func countRefundTxns(t *testing.T, db *gorm.DB, orderID uuid.UUID) int64 {
+	t.Helper()
+	var n int64
+	if err := db.Model(&payment.RefundTransaction{}).Where("order_id = ?", orderID).Count(&n).Error; err != nil {
+		t.Fatalf("countRefundTxns: %v", err)
+	}
+	return n
+}
+
+// (a) Partial refund: Amount=50 on a 120 order captures a partially_refunded
+// order, a succeeded ledger row keyed correctly, and the gateway sees the
+// same idempotency key.
+func TestRefund_Partial(t *testing.T) {
+	db := testdb.NewDB(t, coordinatorTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedPaidOrder(t, db, orderID, storeID, tenantID, "120.00", "0")
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider: "stripe", ProviderPaymentID: "pi_x", Amount: "120.00", Status: "captured",
+	})
+
+	gw := &fakeGateway{}
+	c := newCoordinator(db, gw, true)
+
+	amount := decimal.RequireFromString("50.00")
+	result, err := c.Refund(context.Background(), orderrefund.RefundCommand{
+		OrderID: orderID, Amount: &amount, Reason: "customer request", Actor: "admin", ScopeID: "rr1",
+	})
+	if err != nil {
+		t.Fatalf("Refund: %v", err)
+	}
+	if result.PaymentStatus != order.PaymentStatusPartiallyRefunded {
+		t.Fatalf("PaymentStatus = %q, want partially_refunded", result.PaymentStatus)
+	}
+	if result.AlreadyDone {
+		t.Fatalf("AlreadyDone = true, want false")
+	}
+
+	wantKey := "refund_" + orderID.String() + "_rr1"
+	row := getRefundTxn(t, db, wantKey)
+	if row.Status != "succeeded" {
+		t.Fatalf("ledger status = %q, want succeeded", row.Status)
+	}
+
+	o := getOrder(t, db, orderID)
+	if !o.RefundedAmount.Equal(decimal.RequireFromString("50.00")) {
+		t.Fatalf("refunded_amount = %s, want 50.00", o.RefundedAmount)
+	}
+
+	if gw.callCount() != 1 {
+		t.Fatalf("gateway call count = %d, want 1", gw.callCount())
+	}
+	if gw.lastCall().IdempotencyKey != wantKey {
+		t.Fatalf("gateway saw IdempotencyKey = %q, want %q", gw.lastCall().IdempotencyKey, wantKey)
+	}
+}
+
+// (b) Full refund via nil Amount refunds the entire remaining balance.
+func TestRefund_FullNilAmount(t *testing.T) {
+	db := testdb.NewDB(t, coordinatorTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedPaidOrder(t, db, orderID, storeID, tenantID, "120.00", "0")
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider: "stripe", ProviderPaymentID: "pi_x", Amount: "120.00", Status: "captured",
+	})
+
+	gw := &fakeGateway{}
+	c := newCoordinator(db, gw, true)
+
+	result, err := c.Refund(context.Background(), orderrefund.RefundCommand{
+		OrderID: orderID, Amount: nil, Reason: "cancel", Actor: "admin", ScopeID: "cancel",
+	})
+	if err != nil {
+		t.Fatalf("Refund: %v", err)
+	}
+	if result.PaymentStatus != order.PaymentStatusRefunded {
+		t.Fatalf("PaymentStatus = %q, want refunded", result.PaymentStatus)
+	}
+	if !result.Amount.Equal(decimal.RequireFromString("120.00")) {
+		t.Fatalf("Amount = %s, want 120.00", result.Amount)
+	}
+
+	o := getOrder(t, db, orderID)
+	if !o.RefundedAmount.Equal(decimal.RequireFromString("120.00")) {
+		t.Fatalf("refunded_amount = %s, want 120.00", o.RefundedAmount)
+	}
+}
+
+// (c) Over cap: requesting more than the captured total is rejected before
+// the gateway is ever called.
+func TestRefund_OverCap_Rejected(t *testing.T) {
+	db := testdb.NewDB(t, coordinatorTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedPaidOrder(t, db, orderID, storeID, tenantID, "120.00", "0")
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider: "stripe", ProviderPaymentID: "pi_x", Amount: "120.00", Status: "captured",
+	})
+
+	gw := &fakeGateway{}
+	c := newCoordinator(db, gw, true)
+
+	amount := decimal.RequireFromString("200.00")
+	_, err := c.Refund(context.Background(), orderrefund.RefundCommand{
+		OrderID: orderID, Amount: &amount, Reason: "customer request", Actor: "admin", ScopeID: "rr1",
+	})
+	if !errors.Is(err, apperrors.ErrRefundExceedsTotal) {
+		t.Fatalf("err = %v, want ErrRefundExceedsTotal", err)
+	}
+	if gw.callCount() != 0 {
+		t.Fatalf("gateway call count = %d, want 0", gw.callCount())
+	}
+	if n := countRefundTxns(t, db, orderID); n != 0 {
+		t.Fatalf("refund_transactions rows = %d, want 0", n)
+	}
+}
+
+// (d) No captured transaction (only a pending row) → RefundUnavailable,
+// gateway never called.
+func TestRefund_NoCapturedTxn_Unavailable(t *testing.T) {
+	db := testdb.NewDB(t, coordinatorTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedPaidOrder(t, db, orderID, storeID, tenantID, "120.00", "0")
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider: "stripe", ProviderPaymentID: "pi_x", Amount: "120.00", Status: "pending",
+	})
+
+	gw := &fakeGateway{}
+	c := newCoordinator(db, gw, true)
+
+	amount := decimal.RequireFromString("50.00")
+	_, err := c.Refund(context.Background(), orderrefund.RefundCommand{
+		OrderID: orderID, Amount: &amount, Reason: "customer request", Actor: "admin", ScopeID: "rr1",
+	})
+	if !errors.Is(err, apperrors.ErrRefundUnavailable) {
+		t.Fatalf("err = %v, want ErrRefundUnavailable", err)
+	}
+	if gw.callCount() != 0 {
+		t.Fatalf("gateway call count = %d, want 0", gw.callCount())
+	}
+}
+
+// (e) Disabled coordinator returns an error and never touches the gateway
+// or the ledger.
+func TestRefund_Disabled_SkipsGateway(t *testing.T) {
+	db := testdb.NewDB(t, coordinatorTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedPaidOrder(t, db, orderID, storeID, tenantID, "120.00", "0")
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider: "stripe", ProviderPaymentID: "pi_x", Amount: "120.00", Status: "captured",
+	})
+
+	gw := &fakeGateway{}
+	c := newCoordinator(db, gw, false)
+
+	amount := decimal.RequireFromString("50.00")
+	_, err := c.Refund(context.Background(), orderrefund.RefundCommand{
+		OrderID: orderID, Amount: &amount, Reason: "customer request", Actor: "admin", ScopeID: "rr1",
+	})
+	if err == nil {
+		t.Fatal("Refund: err = nil, want non-nil (coordinator disabled)")
+	}
+	if gw.callCount() != 0 {
+		t.Fatalf("gateway call count = %d, want 0", gw.callCount())
+	}
+	if n := countRefundTxns(t, db, orderID); n != 0 {
+		t.Fatalf("refund_transactions rows = %d, want 0", n)
+	}
+
+	o := getOrder(t, db, orderID)
+	if !o.RefundedAmount.IsZero() {
+		t.Fatalf("refunded_amount = %s, want 0 (disabled path must not bookkeep)", o.RefundedAmount)
+	}
+}
+
+// (f) Idempotent replay: calling Refund twice with the same ScopeID must
+// not double-charge — the second call sees the already-succeeded ledger row
+// and returns AlreadyDone without calling the gateway or bumping
+// refunded_amount again.
+func TestRefund_IdempotentReplay(t *testing.T) {
+	db := testdb.NewDB(t, coordinatorTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedPaidOrder(t, db, orderID, storeID, tenantID, "120.00", "0")
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider: "stripe", ProviderPaymentID: "pi_x", Amount: "120.00", Status: "captured",
+	})
+
+	gw := &fakeGateway{}
+	c := newCoordinator(db, gw, true)
+
+	amount := decimal.RequireFromString("50.00")
+	cmd := orderrefund.RefundCommand{
+		OrderID: orderID, Amount: &amount, Reason: "customer request", Actor: "admin", ScopeID: "rr1",
+	}
+
+	first, err := c.Refund(context.Background(), cmd)
+	if err != nil {
+		t.Fatalf("first Refund: %v", err)
+	}
+	if first.AlreadyDone {
+		t.Fatalf("first Refund: AlreadyDone = true, want false")
+	}
+
+	second, err := c.Refund(context.Background(), cmd)
+	if err != nil {
+		t.Fatalf("second Refund: %v", err)
+	}
+	if !second.AlreadyDone {
+		t.Fatalf("second Refund: AlreadyDone = false, want true (idempotent replay)")
+	}
+
+	if gw.callCount() != 1 {
+		t.Fatalf("gateway call count = %d, want 1 (second call must not re-charge)", gw.callCount())
+	}
+	if n := countRefundTxns(t, db, orderID); n != 1 {
+		t.Fatalf("refund_transactions rows = %d, want 1 (no duplicate ledger row)", n)
+	}
+
+	o := getOrder(t, db, orderID)
+	if !o.RefundedAmount.Equal(decimal.RequireFromString("50.00")) {
+		t.Fatalf("refunded_amount = %s, want 50.00 (bumped once, not twice)", o.RefundedAmount)
+	}
+}

--- a/services/marketplace-api/internal/orderrefund/coordinator_test.go
+++ b/services/marketplace-api/internal/orderrefund/coordinator_test.go
@@ -1,6 +1,8 @@
 package orderrefund
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -8,6 +10,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 )
 
 // TestDeriveStatus proves the partial-vs-full status derivation: a refund
@@ -56,5 +59,24 @@ func TestIdempotencyKey_StableAndColonFree(t *testing.T) {
 	}
 	if idempotencyKey(orderID, "rr2") == first {
 		t.Fatalf("idempotency key collided across different scope IDs")
+	}
+}
+
+// TestRefund_InvalidScopeID_Rejected proves the ScopeID charset guard runs
+// immediately after the enabled check and before any DB access — a
+// coordinator with nil db/resolver/pay/orders/orderRepo must still reject a
+// bad ScopeID rather than panicking on a nil dependency.
+func TestRefund_InvalidScopeID_Rejected(t *testing.T) {
+	c := &Coordinator{enabled: true}
+
+	_, err := c.Refund(context.Background(), RefundCommand{
+		OrderID: uuid.New(),
+		ScopeID: "a:b",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid ScopeID, got nil")
+	}
+	if !errors.Is(err, apperrors.ErrValidationFailed) {
+		t.Fatalf("expected apperrors.ErrValidationFailed, got %v", err)
 	}
 }

--- a/services/marketplace-api/internal/orderrefund/coordinator_test.go
+++ b/services/marketplace-api/internal/orderrefund/coordinator_test.go
@@ -1,0 +1,60 @@
+package orderrefund
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/mark8ly/marketplace-api/internal/order"
+)
+
+// TestDeriveStatus proves the partial-vs-full status derivation: a refund
+// (existing refunded_amount + this amount) that meets or exceeds grand_total
+// flips the order to refunded; anything less stays partially_refunded.
+func TestDeriveStatus(t *testing.T) {
+	gt := decimal.RequireFromString("120.00")
+	cases := []struct {
+		refunded, amount string
+		want             order.PaymentStatus
+	}{
+		{"0", "50.00", order.PaymentStatusPartiallyRefunded},
+		{"0", "120.00", order.PaymentStatusRefunded},
+		{"60.00", "60.00", order.PaymentStatusRefunded},
+		{"60.00", "30.00", order.PaymentStatusPartiallyRefunded},
+	}
+	for _, c := range cases {
+		got := DeriveStatus(decimal.RequireFromString(c.refunded), decimal.RequireFromString(c.amount), gt)
+		if got != c.want {
+			t.Fatalf("refunded=%s amount=%s => %s, want %s", c.refunded, c.amount, got, c.want)
+		}
+	}
+}
+
+// TestIdempotencyKey_StableAndColonFree proves idempotencyKey is
+// deterministic for a given (OrderID, ScopeID) pair — required so saga
+// retries reserve the same ledger row instead of creating duplicates — and
+// that it never contains a colon, since Razorpay's X-Refund-Idempotency
+// header rejects that charset.
+func TestIdempotencyKey_StableAndColonFree(t *testing.T) {
+	orderID := uuid.New()
+	scopeID := "rr1"
+
+	first := idempotencyKey(orderID, scopeID)
+	second := idempotencyKey(orderID, scopeID)
+	if first != second {
+		t.Fatalf("idempotency key not stable: %q != %q", first, second)
+	}
+	if strings.Contains(first, ":") {
+		t.Fatalf("idempotency key contains a colon: %q", first)
+	}
+
+	// Different order or scope must produce a different key.
+	if idempotencyKey(uuid.New(), scopeID) == first {
+		t.Fatalf("idempotency key collided across different order IDs")
+	}
+	if idempotencyKey(orderID, "rr2") == first {
+		t.Fatalf("idempotency key collided across different scope IDs")
+	}
+}

--- a/services/marketplace-api/internal/orderrefund/resolver.go
+++ b/services/marketplace-api/internal/orderrefund/resolver.go
@@ -1,0 +1,107 @@
+// Package orderrefund resolves the payment context (provider + refund
+// target id + captured total) and payment gateway for an order, so refund
+// flows can act on an order without callers hand-rolling the underlying
+// payment_transactions / payment_gateway_configs lookups.
+package orderrefund
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/payment"
+)
+
+// PaymentContext is what a refund flow needs to know about an order's
+// captured payment: which provider processed it, the id to refund against,
+// and the total amount actually captured (across possibly multiple
+// captured payment_transactions rows for the order).
+type PaymentContext struct {
+	Provider          string
+	ProviderPaymentID string
+	CapturedTotal     decimal.Decimal
+	Found             bool
+}
+
+// Resolver reads payment_transactions and payment_gateway_configs to
+// answer "what did this order pay with, and how do we talk to that
+// gateway."
+type Resolver struct{ db *gorm.DB }
+
+// NewResolver constructs a Resolver bound to db.
+func NewResolver(db *gorm.DB) *Resolver { return &Resolver{db: db} }
+
+// PaymentContextForOrder returns the captured payment for an order. Only rows
+// with status='captured' count (that is what the capture webhook / client-verify
+// writes; authorized-only or pending orders are non-refundable → Found=false).
+//
+// ProviderPaymentID is the id we refund against. It must be the CAPTURED payment
+// id — Stripe refunds the payment_intent, Razorpay the payment id (pay_...),
+// PayPal the capture id. That id lives in provider_payment_id (persisted at
+// capture — see the capture-handler fix in this task). We prefer
+// provider_payment_id and fall back to provider_intent_id for legacy rows
+// captured before that fix (Stripe rows, where intent == the refund target).
+func (r *Resolver) PaymentContextForOrder(ctx context.Context, orderID uuid.UUID) (PaymentContext, error) {
+	type row struct {
+		Provider          string
+		ProviderPaymentID string
+		ProviderIntentID  string
+		Amount            decimal.Decimal
+	}
+	var rows []row
+	if err := r.db.WithContext(ctx).
+		Table("payment_transactions").
+		Select("provider", "provider_payment_id", "provider_intent_id", "amount").
+		Where("order_id = ? AND status = 'captured'", orderID).
+		Order("created_at ASC").
+		Scan(&rows).Error; err != nil {
+		return PaymentContext{}, err
+	}
+	if len(rows) == 0 {
+		return PaymentContext{Found: false}, nil
+	}
+	total := decimal.Zero
+	for _, x := range rows {
+		total = total.Add(x.Amount)
+	}
+	refundTarget := rows[0].ProviderPaymentID
+	if refundTarget == "" {
+		refundTarget = rows[0].ProviderIntentID
+	}
+	return PaymentContext{
+		Provider:          rows[0].Provider,
+		ProviderPaymentID: refundTarget,
+		CapturedTotal:     total,
+		Found:             true,
+	}, nil
+}
+
+// gatewayConfigRow is a read-only projection of payment_gateway_configs
+// used to instantiate the correct payment.Gateway for a store+provider.
+type gatewayConfigRow struct {
+	Provider  string `gorm:"column:provider"`
+	APIKey    string `gorm:"column:api_key_encrypted"`
+	SecretKey string `gorm:"column:secret_key_encrypted"`
+	Mode      string `gorm:"column:mode"`
+}
+
+func (gatewayConfigRow) TableName() string { return "payment_gateway_configs" }
+
+// GatewayFor looks up the active payment_gateway_configs row for
+// (storeID, provider) and constructs the matching payment.Gateway.
+func (r *Resolver) GatewayFor(ctx context.Context, storeID uuid.UUID, provider string) (payment.Gateway, error) {
+	var cfg gatewayConfigRow
+	if err := r.db.WithContext(ctx).
+		Where("store_id = ? AND provider = ? AND is_active = true", storeID, provider).
+		First(&cfg).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("orderrefund: no active %q gateway config for store %s", provider, storeID)
+		}
+		return nil, err
+	}
+	return payment.NewGateway(provider, cfg.APIKey, cfg.SecretKey, cfg.Mode)
+}

--- a/services/marketplace-api/internal/orderrefund/resolver_integration_test.go
+++ b/services/marketplace-api/internal/orderrefund/resolver_integration_test.go
@@ -1,0 +1,270 @@
+//go:build integration
+
+package orderrefund_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/orderrefund"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// resolverTruncateTables is the dependency-ordered truncate list for the
+// orderrefund resolver tests. payment_transactions FKs to orders, and
+// payment_gateway_configs FKs to stores, so children are listed before
+// parents; TRUNCATE ... CASCADE (see pkg/testdb) handles anything missed.
+var resolverTruncateTables = []string{
+	"payment_transactions",
+	"payment_gateway_configs",
+	"orders",
+	"stores",
+}
+
+// seedStore inserts a minimal stores row satisfying all NOT NULL columns,
+// including storefront_customer_portal_secret which has no default
+// (migration 000058 drops the default after backfilling existing rows).
+func seedStore(t *testing.T, db *gorm.DB, storeID, tenantID uuid.UUID) {
+	t.Helper()
+	err := db.Exec(
+		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, encode(gen_random_bytes(32), 'hex'))`,
+		storeID, tenantID, "rs-"+storeID.String()[:8], "Resolver Test Store", "IE", "EUR", "Europe/Dublin", "active",
+	).Error
+	if err != nil {
+		t.Fatalf("seedStore: %v", err)
+	}
+}
+
+// seedOrder inserts a minimal orders row so payment_transactions rows (which
+// FK to orders.id ON DELETE RESTRICT) can be seeded against it.
+func seedOrder(t *testing.T, db *gorm.DB, orderID, storeID, tenantID uuid.UUID) {
+	t.Helper()
+	err := db.Exec(
+		`INSERT INTO orders (id, tenant_id, store_id, order_number, idempotency_key, customer_email,
+			status, payment_status, fulfillment_status,
+			subtotal, tax_total, shipping_total, grand_total, refunded_amount,
+			currency_code, placed_at, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, 'test@example.com',
+			'pending', 'pending', 'unfulfilled',
+			'100.00', '0', '0', '100.00', '0',
+			'EUR', now(), now(), now())`,
+		orderID, tenantID, storeID, "RO-"+orderID.String()[:8], "idem-"+orderID.String(),
+	).Error
+	if err != nil {
+		t.Fatalf("seedOrder: %v", err)
+	}
+}
+
+// seedPaymentTxnOpts controls the optional fields of a seeded
+// payment_transactions row so tests can exercise each resolver branch.
+type seedPaymentTxnOpts struct {
+	Provider          string
+	ProviderPaymentID string // may be "" to leave the column NULL
+	ProviderIntentID  string // may be "" to leave the column NULL
+	Amount            string
+	Status            string
+	CreatedAt         time.Time
+}
+
+func seedPaymentTxn(t *testing.T, db *gorm.DB, tenantID, storeID, orderID uuid.UUID, opts seedPaymentTxnOpts) {
+	t.Helper()
+	var providerPaymentID, providerIntentID any
+	if opts.ProviderPaymentID != "" {
+		providerPaymentID = opts.ProviderPaymentID
+	}
+	if opts.ProviderIntentID != "" {
+		providerIntentID = opts.ProviderIntentID
+	}
+	err := db.Exec(
+		`INSERT INTO payment_transactions
+			(id, tenant_id, store_id, order_id, provider, provider_intent_id, provider_payment_id, amount, currency_code, status, metadata, created_at, updated_at)
+		 VALUES (gen_random_uuid(), ?, ?, ?, ?, ?, ?, ?, 'EUR', ?, '{}'::jsonb, ?, ?)`,
+		tenantID, storeID, orderID, opts.Provider, providerIntentID, providerPaymentID, opts.Amount, opts.Status, opts.CreatedAt, opts.CreatedAt,
+	).Error
+	if err != nil {
+		t.Fatalf("seedPaymentTxn: %v", err)
+	}
+}
+
+func seedGatewayConfig(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID, provider string, isActive bool) {
+	t.Helper()
+	err := db.Exec(
+		`INSERT INTO payment_gateway_configs (id, tenant_id, store_id, provider, api_key_encrypted, secret_key_encrypted, mode, is_active)
+		 VALUES (gen_random_uuid(), ?, ?, ?, 'test-api-key', 'test-secret-key', 'test', ?)`,
+		tenantID, storeID, provider, isActive,
+	).Error
+	if err != nil {
+		t.Fatalf("seedGatewayConfig: %v", err)
+	}
+}
+
+func TestPaymentContextForOrder_CapturedTotal(t *testing.T) {
+	db := testdb.NewDB(t, resolverTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedOrder(t, db, orderID, storeID, tenantID)
+
+	base := time.Now().Add(-1 * time.Hour)
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider:          "stripe",
+		ProviderPaymentID: "pi_earliest",
+		Amount:            "60.00",
+		Status:            "captured",
+		CreatedAt:         base,
+	})
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider:          "stripe",
+		ProviderPaymentID: "pi_second",
+		Amount:            "40.00",
+		Status:            "captured",
+		CreatedAt:         base.Add(1 * time.Minute),
+	})
+
+	r := orderrefund.NewResolver(db)
+	pc, err := r.PaymentContextForOrder(context.Background(), orderID)
+	if err != nil {
+		t.Fatalf("PaymentContextForOrder: %v", err)
+	}
+	if !pc.Found {
+		t.Fatalf("Found = false, want true")
+	}
+	if pc.Provider != "stripe" {
+		t.Fatalf("Provider = %q, want stripe", pc.Provider)
+	}
+	if pc.ProviderPaymentID != "pi_earliest" {
+		t.Fatalf("ProviderPaymentID = %q, want pi_earliest (earliest row)", pc.ProviderPaymentID)
+	}
+	if !pc.CapturedTotal.Equal(decimal.RequireFromString("100.00")) {
+		t.Fatalf("CapturedTotal = %s, want 100.00", pc.CapturedTotal)
+	}
+}
+
+func TestPaymentContextForOrder_PrefersProviderPaymentIDOverIntentID(t *testing.T) {
+	db := testdb.NewDB(t, resolverTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedOrder(t, db, orderID, storeID, tenantID)
+
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider:          "razorpay",
+		ProviderPaymentID: "pay_captured123",
+		ProviderIntentID:  "order_intent456",
+		Amount:            "75.00",
+		Status:            "captured",
+		CreatedAt:         time.Now(),
+	})
+
+	r := orderrefund.NewResolver(db)
+	pc, err := r.PaymentContextForOrder(context.Background(), orderID)
+	if err != nil {
+		t.Fatalf("PaymentContextForOrder: %v", err)
+	}
+	if !pc.Found {
+		t.Fatalf("Found = false, want true")
+	}
+	if pc.ProviderPaymentID != "pay_captured123" {
+		t.Fatalf("ProviderPaymentID = %q, want pay_captured123 (must prefer provider_payment_id)", pc.ProviderPaymentID)
+	}
+}
+
+func TestPaymentContextForOrder_FallsBackToProviderIntentID(t *testing.T) {
+	db := testdb.NewDB(t, resolverTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedOrder(t, db, orderID, storeID, tenantID)
+
+	// Legacy row captured before the Step 0 fix: only provider_intent_id was
+	// ever persisted. Stripe's intent IS the refund target, so this must
+	// still resolve to a usable ProviderPaymentID.
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider:         "stripe",
+		ProviderIntentID: "pi_legacy_only",
+		Amount:           "30.00",
+		Status:           "captured",
+		CreatedAt:        time.Now(),
+	})
+
+	r := orderrefund.NewResolver(db)
+	pc, err := r.PaymentContextForOrder(context.Background(), orderID)
+	if err != nil {
+		t.Fatalf("PaymentContextForOrder: %v", err)
+	}
+	if !pc.Found {
+		t.Fatalf("Found = false, want true")
+	}
+	if pc.ProviderPaymentID != "pi_legacy_only" {
+		t.Fatalf("ProviderPaymentID = %q, want pi_legacy_only (fallback to provider_intent_id)", pc.ProviderPaymentID)
+	}
+}
+
+func TestPaymentContextForOrder_NotCaptured(t *testing.T) {
+	db := testdb.NewDB(t, resolverTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedOrder(t, db, orderID, storeID, tenantID)
+
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider:          "stripe",
+		ProviderPaymentID: "pi_pending",
+		Amount:            "50.00",
+		Status:            "pending",
+		CreatedAt:         time.Now(),
+	})
+
+	r := orderrefund.NewResolver(db)
+	pc, err := r.PaymentContextForOrder(context.Background(), orderID)
+	if err != nil {
+		t.Fatalf("PaymentContextForOrder: %v", err)
+	}
+	if pc.Found {
+		t.Fatalf("Found = true, want false (no captured rows)")
+	}
+}
+
+func TestGatewayFor_ActiveConfig(t *testing.T) {
+	db := testdb.NewDB(t, resolverTruncateTables...)
+	tenantID, storeID := uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedGatewayConfig(t, db, tenantID, storeID, "stripe", true)
+
+	r := orderrefund.NewResolver(db)
+	gw, err := r.GatewayFor(context.Background(), storeID, "stripe")
+	if err != nil {
+		t.Fatalf("GatewayFor: %v", err)
+	}
+	if gw == nil {
+		t.Fatalf("gateway is nil")
+	}
+	if gw.ProviderName() != "stripe" {
+		t.Fatalf("ProviderName() = %q, want stripe", gw.ProviderName())
+	}
+}
+
+func TestGatewayFor_InactiveConfig(t *testing.T) {
+	db := testdb.NewDB(t, resolverTruncateTables...)
+	tenantID, storeID := uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedGatewayConfig(t, db, tenantID, storeID, "stripe", false)
+
+	r := orderrefund.NewResolver(db)
+	if _, err := r.GatewayFor(context.Background(), storeID, "stripe"); err == nil {
+		t.Fatalf("expected error for inactive gateway config, got nil")
+	}
+}
+
+func TestGatewayFor_MissingConfig(t *testing.T) {
+	db := testdb.NewDB(t, resolverTruncateTables...)
+	tenantID, storeID := uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+
+	r := orderrefund.NewResolver(db)
+	if _, err := r.GatewayFor(context.Background(), storeID, "stripe"); err == nil {
+		t.Fatalf("expected error for missing gateway config, got nil")
+	}
+}

--- a/services/marketplace-api/internal/orderrefund/sweeper_integration_test.go
+++ b/services/marketplace-api/internal/orderrefund/sweeper_integration_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+package orderrefund_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedPendingRefundTxn inserts a refund_transactions row directly in status
+// 'pending', as if the gateway call in Coordinator.Refund succeeded but the
+// process crashed (or the DB blipped) before tx #2 committed. createdAt is
+// set explicitly so tests can control whether ResumePending's
+// olderThan window selects the row.
+func seedPendingRefundTxn(t *testing.T, db *gorm.DB, tenantID, storeID, orderID uuid.UUID, idempotencyKey, providerPaymentID, provider, amount string, createdAt time.Time) {
+	t.Helper()
+	err := db.Exec(
+		`INSERT INTO refund_transactions
+			(id, tenant_id, store_id, order_id, idempotency_key, provider_payment_id, provider_refund_id, provider, amount, reason, status, created_at, updated_at)
+		 VALUES (gen_random_uuid(), ?, ?, ?, ?, ?, '', ?, ?, 'cancel', 'pending', ?, ?)`,
+		tenantID, storeID, orderID, idempotencyKey, providerPaymentID, provider, amount, createdAt, createdAt,
+	).Error
+	if err != nil {
+		t.Fatalf("seedPendingRefundTxn: %v", err)
+	}
+}
+
+// TestResumePending_CompletesStuckRefund seeds a pending ledger row (as if
+// tx #2 crashed after the gateway call succeeded) and asserts ResumePending
+// re-drives it to completion exactly once: same idempotency key hits the
+// gateway, the ledger flips to succeeded, and refunded_amount is bumped by
+// exactly the ledger row's amount (never double-bumped).
+func TestResumePending_CompletesStuckRefund(t *testing.T) {
+	db := testdb.NewDB(t, coordinatorTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedPaidOrder(t, db, orderID, storeID, tenantID, "100.00", "0")
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider: "stripe", ProviderPaymentID: "pi_x", Amount: "100.00", Status: "captured",
+	})
+	seedGatewayConfig(t, db, tenantID, storeID, "stripe", true)
+
+	wantKey := "refund_" + orderID.String() + "_cancel"
+	seedPendingRefundTxn(t, db, tenantID, storeID, orderID, wantKey, "pi_x", "stripe", "100.00", time.Now().Add(-1*time.Hour))
+
+	gw := &fakeGateway{}
+	c := newCoordinator(db, gw, true)
+
+	n, err := c.ResumePending(context.Background(), 0, 200)
+	if err != nil {
+		t.Fatalf("ResumePending: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("ResumePending resumed = %d, want 1", n)
+	}
+
+	if gw.callCount() != 1 {
+		t.Fatalf("gateway call count = %d, want 1", gw.callCount())
+	}
+	if gw.lastCall().IdempotencyKey != wantKey {
+		t.Fatalf("gateway saw IdempotencyKey = %q, want %q", gw.lastCall().IdempotencyKey, wantKey)
+	}
+
+	row := getRefundTxn(t, db, wantKey)
+	if row.Status != "succeeded" {
+		t.Fatalf("ledger status = %q, want succeeded", row.Status)
+	}
+
+	o := getOrder(t, db, orderID)
+	if !o.RefundedAmount.Equal(decimal.RequireFromString("100.00")) {
+		t.Fatalf("refunded_amount = %s, want 100.00 (bumped exactly once)", o.RefundedAmount)
+	}
+	if o.PaymentStatus != string(order.PaymentStatusRefunded) {
+		t.Fatalf("payment_status = %q, want refunded", o.PaymentStatus)
+	}
+}
+
+// TestResumePending_NoPendingRows asserts that a sweep with nothing stuck is
+// a normal, successful no-op: zero resumed, gateway never touched.
+func TestResumePending_NoPendingRows(t *testing.T) {
+	db := testdb.NewDB(t, coordinatorTruncateTables...)
+	gw := &fakeGateway{}
+	c := newCoordinator(db, gw, true)
+
+	n, err := c.ResumePending(context.Background(), 0, 200)
+	if err != nil {
+		t.Fatalf("ResumePending: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("ResumePending resumed = %d, want 0", n)
+	}
+	if gw.callCount() != 0 {
+		t.Fatalf("gateway call count = %d, want 0", gw.callCount())
+	}
+}
+
+// TestResumePending_GatewayStillFailing asserts that when the gateway is
+// still erroring, ResumePending leaves the row pending (not succeeded),
+// does not bump refunded_amount, and reports 0 resumed — so the next sweep
+// tries again rather than silently losing the row.
+func TestResumePending_GatewayStillFailing(t *testing.T) {
+	db := testdb.NewDB(t, coordinatorTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedPaidOrder(t, db, orderID, storeID, tenantID, "100.00", "0")
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider: "stripe", ProviderPaymentID: "pi_x", Amount: "100.00", Status: "captured",
+	})
+	seedGatewayConfig(t, db, tenantID, storeID, "stripe", true)
+
+	wantKey := "refund_" + orderID.String() + "_cancel"
+	seedPendingRefundTxn(t, db, tenantID, storeID, orderID, wantKey, "pi_x", "stripe", "100.00", time.Now().Add(-1*time.Hour))
+
+	gw := &fakeGateway{refundErr: errors.New("gateway: still down")}
+	c := newCoordinator(db, gw, true)
+
+	n, err := c.ResumePending(context.Background(), 0, 200)
+	if err != nil {
+		t.Fatalf("ResumePending: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("ResumePending resumed = %d, want 0", n)
+	}
+
+	row := getRefundTxn(t, db, wantKey)
+	if row.Status != "pending" {
+		t.Fatalf("ledger status = %q, want pending (gateway still failing, retry next sweep)", row.Status)
+	}
+
+	o := getOrder(t, db, orderID)
+	if !o.RefundedAmount.IsZero() {
+		t.Fatalf("refunded_amount = %s, want 0 (gateway failed, must not bookkeep)", o.RefundedAmount)
+	}
+}

--- a/services/marketplace-api/internal/orderrefund/sweeper_integration_test.go
+++ b/services/marketplace-api/internal/orderrefund/sweeper_integration_test.go
@@ -141,3 +141,54 @@ func TestResumePending_GatewayStillFailing(t *testing.T) {
 		t.Fatalf("refunded_amount = %s, want 0 (gateway failed, must not bookkeep)", o.RefundedAmount)
 	}
 }
+
+// TestResumePending_DoubleRun_BumpsOnce simulates two overlapping sweep runs
+// racing the same pending ledger row (Cloud Scheduler retry, manual
+// re-trigger, or a slow gateway call outliving the sweep cadence). Both
+// calls hit the same pending row's idempotency key, so the gateway is a
+// no-op either way — but before the concurrency fix, both calls would also
+// run the finalize tx and double-bump orders.refunded_amount. This asserts
+// the status-guarded finalize makes the second call a true no-op: it
+// reports 0 resumed and refunded_amount is bumped exactly once.
+func TestResumePending_DoubleRun_BumpsOnce(t *testing.T) {
+	db := testdb.NewDB(t, coordinatorTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedPaidOrder(t, db, orderID, storeID, tenantID, "100.00", "0")
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider: "stripe", ProviderPaymentID: "pi_x", Amount: "100.00", Status: "captured",
+	})
+	seedGatewayConfig(t, db, tenantID, storeID, "stripe", true)
+
+	wantKey := "refund_" + orderID.String() + "_cancel"
+	seedPendingRefundTxn(t, db, tenantID, storeID, orderID, wantKey, "pi_x", "stripe", "100.00", time.Now().Add(-1*time.Hour))
+
+	gw := &fakeGateway{}
+	c := newCoordinator(db, gw, true)
+
+	n1, err := c.ResumePending(context.Background(), 0, 200)
+	if err != nil {
+		t.Fatalf("ResumePending (run 1): %v", err)
+	}
+	if n1 != 1 {
+		t.Fatalf("ResumePending (run 1) resumed = %d, want 1", n1)
+	}
+
+	n2, err := c.ResumePending(context.Background(), 0, 200)
+	if err != nil {
+		t.Fatalf("ResumePending (run 2): %v", err)
+	}
+	if n2 != 0 {
+		t.Fatalf("ResumePending (run 2) resumed = %d, want 0 (row already succeeded, must not re-finalize)", n2)
+	}
+
+	row := getRefundTxn(t, db, wantKey)
+	if row.Status != "succeeded" {
+		t.Fatalf("ledger status = %q, want succeeded", row.Status)
+	}
+
+	o := getOrder(t, db, orderID)
+	if !o.RefundedAmount.Equal(decimal.RequireFromString("100.00")) {
+		t.Fatalf("refunded_amount = %s, want 100.00 (must not be double-bumped by the second run)", o.RefundedAmount)
+	}
+}

--- a/services/marketplace-api/internal/payment/gateway.go
+++ b/services/marketplace-api/internal/payment/gateway.go
@@ -82,6 +82,7 @@ type RefundInput struct {
 	Amount            decimal.Decimal
 	CurrencyCode      string
 	Reason            string
+	IdempotencyKey    string // provider idempotency key; retries with the same key never double-refund
 }
 
 // Refund is the provider's response to a refund request.

--- a/services/marketplace-api/internal/payment/paypal.go
+++ b/services/marketplace-api/internal/payment/paypal.go
@@ -222,6 +222,9 @@ func (p *PayPalGateway) RefundPayment(ctx context.Context, in RefundInput) (*Ref
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+token)
+	if in.IdempotencyKey != "" {
+		req.Header.Set("PayPal-Request-Id", in.IdempotencyKey)
+	}
 
 	resp, err := p.client.Do(req)
 	if err != nil {

--- a/services/marketplace-api/internal/payment/paypal.go
+++ b/services/marketplace-api/internal/payment/paypal.go
@@ -272,9 +272,9 @@ func (p *PayPalGateway) VerifyWebhook(ctx context.Context, payload []byte, signa
 
 	// Parse the raw event first to extract the webhook_id.
 	var rawEvent struct {
-		ID           string `json:"id"`
-		EventType    string `json:"event_type"`
-		Resource     json.RawMessage `json:"resource"`
+		ID        string          `json:"id"`
+		EventType string          `json:"event_type"`
+		Resource  json.RawMessage `json:"resource"`
 	}
 	if err := json.Unmarshal(payload, &rawEvent); err != nil {
 		return nil, fmt.Errorf("paypal: verify webhook: decode event: %w", err)
@@ -341,7 +341,7 @@ func (p *PayPalGateway) VerifyWebhook(ctx context.Context, payload []byte, signa
 
 	// Extract resource details.
 	var resource struct {
-		ID            string `json:"id"`
+		ID            string        `json:"id"`
 		Amount        *paypalAmount `json:"amount"`
 		PurchaseUnits []struct {
 			ReferenceID string       `json:"reference_id"`
@@ -356,6 +356,8 @@ func (p *PayPalGateway) VerifyWebhook(ctx context.Context, payload []byte, signa
 		PaymentMethod:   "paypal",
 		RawPayload:      payload,
 	}
+
+	evt.ProviderPaymentID = resource.ID
 
 	if len(resource.PurchaseUnits) > 0 {
 		pu := resource.PurchaseUnits[0]
@@ -439,14 +441,14 @@ func normalizePayPalEvent(eventType string) string {
 // PayPal request/response types.
 
 type paypalOrderRequest struct {
-	Intent        string                `json:"intent"`
-	PurchaseUnits []paypalPurchaseUnit  `json:"purchase_units"`
-	Payer         *paypalPayer          `json:"payer,omitempty"`
+	Intent        string               `json:"intent"`
+	PurchaseUnits []paypalPurchaseUnit `json:"purchase_units"`
+	Payer         *paypalPayer         `json:"payer,omitempty"`
 }
 
 type paypalPurchaseUnit struct {
-	ReferenceID string      `json:"reference_id"`
-	Description string      `json:"description"`
+	ReferenceID string       `json:"reference_id"`
+	Description string       `json:"description"`
 	Amount      paypalAmount `json:"amount"`
 }
 

--- a/services/marketplace-api/internal/payment/paypal_test.go
+++ b/services/marketplace-api/internal/payment/paypal_test.go
@@ -39,3 +39,31 @@ func TestPayPalRefund_SendsRequestIdHeader(t *testing.T) {
 		t.Fatalf("PayPal-Request-Id header = %q, want %q", gotKey, "refund_ord7_ret-2")
 	}
 }
+
+func TestPayPalVerifyWebhook_SetsProviderPaymentID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/oauth2/token"):
+			_, _ = w.Write([]byte(`{"access_token":"t","expires_in":3600}`))
+		case strings.Contains(r.URL.Path, "/verify-webhook-signature"):
+			_, _ = w.Write([]byte(`{"verification_status":"SUCCESS"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	g := NewPayPalGateway("id", "secret", "test")
+	g.baseURL = srv.URL
+
+	payload := []byte(`{"id":"WH-1","event_type":"PAYMENT.CAPTURE.COMPLETED","resource":{"id":"CAP-77","amount":{"currency_code":"USD","value":"50.00"}}}`)
+	signature := `{"transmission_id":"tx-1","transmission_time":"2026-07-09T00:00:00Z","cert_url":"https://example.com/cert","auth_algo":"SHA256withRSA","transmission_sig":"sig","webhook_id":"WH-ID-1"}`
+
+	evt, err := g.VerifyWebhook(context.Background(), payload, signature)
+	if err != nil {
+		t.Fatalf("verify webhook: %v", err)
+	}
+	if evt.ProviderPaymentID != "CAP-77" {
+		t.Fatalf("ProviderPaymentID = %q, want %q", evt.ProviderPaymentID, "CAP-77")
+	}
+}

--- a/services/marketplace-api/internal/payment/paypal_test.go
+++ b/services/marketplace-api/internal/payment/paypal_test.go
@@ -1,0 +1,41 @@
+package payment
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestPayPalRefund_SendsRequestIdHeader(t *testing.T) {
+	var gotKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/oauth2/token") {
+			_, _ = w.Write([]byte(`{"access_token":"t","expires_in":3600}`))
+			return
+		}
+		gotKey = r.Header.Get("PayPal-Request-Id")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"RF-1","status":"COMPLETED","amount":{"value":"50.00"}}`))
+	}))
+	defer srv.Close()
+
+	g := NewPayPalGateway("id", "secret", "test")
+	g.baseURL = srv.URL
+
+	_, err := g.RefundPayment(context.Background(), RefundInput{
+		ProviderPaymentID: "CAP-1",
+		Amount:            decimal.NewFromInt(50),
+		CurrencyCode:      "USD",
+		IdempotencyKey:    "refund_ord7_ret-2",
+	})
+	if err != nil {
+		t.Fatalf("refund: %v", err)
+	}
+	if gotKey != "refund_ord7_ret-2" {
+		t.Fatalf("PayPal-Request-Id header = %q, want %q", gotKey, "refund_ord7_ret-2")
+	}
+}

--- a/services/marketplace-api/internal/payment/razorpay.go
+++ b/services/marketplace-api/internal/payment/razorpay.go
@@ -261,13 +261,14 @@ func (r *RazorpayGateway) VerifyWebhook(_ context.Context, payload []byte, signa
 	}
 
 	return &WebhookEvent{
-		ProviderEventID: entity.ID,
-		EventType:       normalizeRazorpayEvent(raw.Event),
-		OrderID:         orderID,
-		Amount:          decimal.NewFromInt(entity.Amount),
-		CurrencyCode:    strings.ToUpper(entity.Currency),
-		PaymentMethod:   entity.Method,
-		RawPayload:      payload,
+		ProviderEventID:   entity.ID,
+		ProviderPaymentID: entity.ID,
+		EventType:         normalizeRazorpayEvent(raw.Event),
+		OrderID:           orderID,
+		Amount:            decimal.NewFromInt(entity.Amount),
+		CurrencyCode:      strings.ToUpper(entity.Currency),
+		PaymentMethod:     entity.Method,
+		RawPayload:        payload,
 	}, nil
 }
 

--- a/services/marketplace-api/internal/payment/razorpay.go
+++ b/services/marketplace-api/internal/payment/razorpay.go
@@ -188,6 +188,9 @@ func (r *RazorpayGateway) RefundPayment(ctx context.Context, in RefundInput) (*R
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.SetBasicAuth(r.apiKey, r.secretKey)
+	if in.IdempotencyKey != "" {
+		req.Header.Set("X-Refund-Idempotency", in.IdempotencyKey)
+	}
 
 	resp, err := r.client.Do(req)
 	if err != nil {

--- a/services/marketplace-api/internal/payment/razorpay_test.go
+++ b/services/marketplace-api/internal/payment/razorpay_test.go
@@ -1,0 +1,44 @@
+package payment
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestRazorpayRefund_SendsIdempotencyHeaderAndNotes(t *testing.T) {
+	var gotKey string
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("X-Refund-Idempotency")
+		body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"rfnd_1","status":"processed","amount":5000}`))
+	}))
+	defer srv.Close()
+
+	g := NewRazorpayGateway("key", "secret", "test")
+	g.baseURL = srv.URL
+
+	_, err := g.RefundPayment(context.Background(), RefundInput{
+		ProviderPaymentID: "pay_1",
+		Amount:            decimal.NewFromInt(50),
+		CurrencyCode:      "INR",
+		Reason:            "cancelled",
+		IdempotencyKey:    "refund_ord9_cancel",
+	})
+	if err != nil {
+		t.Fatalf("refund: %v", err)
+	}
+	if gotKey != "refund_ord9_cancel" {
+		t.Fatalf("X-Refund-Idempotency header = %q, want %q", gotKey, "refund_ord9_cancel")
+	}
+	if !strings.Contains(string(body), `"reason":"cancelled"`) {
+		t.Fatalf("reason not in notes: %s", body)
+	}
+}

--- a/services/marketplace-api/internal/payment/razorpay_test.go
+++ b/services/marketplace-api/internal/payment/razorpay_test.go
@@ -2,6 +2,9 @@ package payment
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -40,5 +43,24 @@ func TestRazorpayRefund_SendsIdempotencyHeaderAndNotes(t *testing.T) {
 	}
 	if !strings.Contains(string(body), `"reason":"cancelled"`) {
 		t.Fatalf("reason not in notes: %s", body)
+	}
+}
+
+func TestRazorpayVerifyWebhook_SetsProviderPaymentID(t *testing.T) {
+	secret := "secret"
+	payload := []byte(`{"event":"payment.captured","payload":{"payment":{"entity":{"id":"pay_123","order_id":"order_9","amount":5000,"currency":"INR","method":"upi","notes":{"order_id":"11111111-1111-1111-1111-111111111111"}}}}}`)
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	signature := hex.EncodeToString(mac.Sum(nil))
+
+	g := NewRazorpayGateway("key", secret, "test")
+
+	evt, err := g.VerifyWebhook(context.Background(), payload, signature)
+	if err != nil {
+		t.Fatalf("verify webhook: %v", err)
+	}
+	if evt.ProviderPaymentID != "pay_123" {
+		t.Fatalf("ProviderPaymentID = %q, want %q", evt.ProviderPaymentID, "pay_123")
 	}
 }

--- a/services/marketplace-api/internal/payment/repository.go
+++ b/services/marketplace-api/internal/payment/repository.go
@@ -43,6 +43,8 @@ type RefundTransaction struct {
 	ID                string          `gorm:"column:id;type:uuid;primaryKey"                json:"id"`
 	TenantID          string          `gorm:"column:tenant_id;type:uuid;not null;index"      json:"tenant_id"`
 	StoreID           string          `gorm:"column:store_id;type:uuid;not null;index"       json:"store_id"`
+	OrderID           string          `gorm:"column:order_id;type:uuid;index"                json:"order_id"`
+	IdempotencyKey    string          `gorm:"column:idempotency_key;type:varchar(255);uniqueIndex" json:"idempotency_key"`
 	ProviderPaymentID string          `gorm:"column:provider_payment_id;type:varchar(255);not null" json:"provider_payment_id"`
 	ProviderRefundID  string          `gorm:"column:provider_refund_id;type:varchar(255);not null"  json:"provider_refund_id"`
 	Provider          string          `gorm:"column:provider;type:varchar(20);not null"       json:"provider"`

--- a/services/marketplace-api/internal/payment/repository.go
+++ b/services/marketplace-api/internal/payment/repository.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // ---------------------------------------------------------------------------
@@ -99,6 +100,15 @@ type Repository interface {
 	CreateRefundTransaction(ctx context.Context, refund *RefundTransaction) error
 	ListRefundsByPaymentID(ctx context.Context, providerPaymentID string) ([]RefundTransaction, error)
 
+	// InsertRefundPending inserts a pending refund row inside tx. Returns
+	// (row, created). created=false ⇒ a row with this idempotency_key already
+	// existed (returned instead) — the saga re-entry guard.
+	InsertRefundPending(tx *gorm.DB, r *RefundTransaction) (*RefundTransaction, bool, error)
+	// UpdateRefundOutcome sets status + provider_refund_id on a ledger row.
+	UpdateRefundOutcome(tx *gorm.DB, ledgerID, providerRefundID, status string) error
+	// GetRefundByIdempotencyKey reads a ledger row by its unique key.
+	GetRefundByIdempotencyKey(ctx context.Context, key string) (*RefundTransaction, error)
+
 	CreateWebhookEvent(ctx context.Context, evt *WebhookEventRecord) error
 	GetWebhookEventByProviderID(ctx context.Context, providerEventID string) (*WebhookEventRecord, error)
 }
@@ -150,6 +160,51 @@ func (r *gormRepository) ListRefundsByPaymentID(ctx context.Context, providerPay
 		Order("created_at DESC").
 		Find(&rows).Error
 	return rows, err
+}
+
+// InsertRefundPending inserts a pending refund row inside tx, guarding
+// against duplicate saga re-entry via a unique idempotency_key. If a row
+// with the same key already exists, ON CONFLICT DO NOTHING skips the
+// insert and the existing row is re-selected and returned with created=false.
+func (r *gormRepository) InsertRefundPending(tx *gorm.DB, row *RefundTransaction) (*RefundTransaction, bool, error) {
+	if row.Status == "" {
+		row.Status = "pending"
+	}
+	res := tx.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "idempotency_key"}},
+		DoNothing: true,
+	}).Create(row)
+	if res.Error != nil {
+		return nil, false, res.Error
+	}
+	if res.RowsAffected == 1 {
+		return row, true, nil
+	}
+	var existing RefundTransaction
+	if err := tx.Where("idempotency_key = ?", row.IdempotencyKey).First(&existing).Error; err != nil {
+		return nil, false, err
+	}
+	return &existing, false, nil
+}
+
+// UpdateRefundOutcome sets status + provider_refund_id on a ledger row.
+func (r *gormRepository) UpdateRefundOutcome(tx *gorm.DB, ledgerID, providerRefundID, status string) error {
+	return tx.Model(&RefundTransaction{}).
+		Where("id = ?", ledgerID).
+		Updates(map[string]any{
+			"provider_refund_id": providerRefundID,
+			"status":             status,
+			"updated_at":         gorm.Expr("now()"),
+		}).Error
+}
+
+// GetRefundByIdempotencyKey reads a ledger row by its unique key.
+func (r *gormRepository) GetRefundByIdempotencyKey(ctx context.Context, key string) (*RefundTransaction, error) {
+	var row RefundTransaction
+	if err := r.db.WithContext(ctx).Where("idempotency_key = ?", key).First(&row).Error; err != nil {
+		return nil, err
+	}
+	return &row, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/services/marketplace-api/internal/payment/repository.go
+++ b/services/marketplace-api/internal/payment/repository.go
@@ -2,6 +2,7 @@ package payment
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -180,6 +181,10 @@ func (r *gormRepository) InsertRefundPending(tx *gorm.DB, row *RefundTransaction
 	if res.RowsAffected == 1 {
 		return row, true, nil
 	}
+	// Losing transaction: the winner's row isn't visible in our own
+	// snapshot yet, so re-select it. This relies on READ COMMITTED (the
+	// default isolation level) so that once the winning tx commits, our
+	// next statement in this tx sees its committed row.
 	var existing RefundTransaction
 	if err := tx.Where("idempotency_key = ?", row.IdempotencyKey).First(&existing).Error; err != nil {
 		return nil, false, err
@@ -189,13 +194,20 @@ func (r *gormRepository) InsertRefundPending(tx *gorm.DB, row *RefundTransaction
 
 // UpdateRefundOutcome sets status + provider_refund_id on a ledger row.
 func (r *gormRepository) UpdateRefundOutcome(tx *gorm.DB, ledgerID, providerRefundID, status string) error {
-	return tx.Model(&RefundTransaction{}).
+	res := tx.Model(&RefundTransaction{}).
 		Where("id = ?", ledgerID).
 		Updates(map[string]any{
 			"provider_refund_id": providerRefundID,
 			"status":             status,
 			"updated_at":         gorm.Expr("now()"),
-		}).Error
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("payment: UpdateRefundOutcome: no refund_transactions row with id %s", ledgerID)
+	}
+	return nil
 }
 
 // GetRefundByIdempotencyKey reads a ledger row by its unique key.

--- a/services/marketplace-api/internal/payment/service.go
+++ b/services/marketplace-api/internal/payment/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
 )
 
 // Service orchestrates payment intent creation, webhook processing, and
@@ -138,6 +139,60 @@ func (s *Service) RefundPayment(
 	}
 
 	return refund, nil
+}
+
+// ReserveRefundInput describes a refund reservation — the first step of the
+// refund saga (ledger row inserted before any provider call is made). It
+// carries CurrencyCode for later gateway use; refund_transactions has no
+// currency column, so it is not persisted on the row.
+type ReserveRefundInput struct {
+	TenantID, StoreID, OrderID  string
+	Provider, ProviderPaymentID string
+	Amount                      decimal.Decimal
+	CurrencyCode, Reason        string
+	IdempotencyKey              string
+}
+
+// ReserveRefund inserts a pending refund ledger row inside tx, keyed by
+// IdempotencyKey. This is the saga re-entry guard: replaying the same
+// reservation (e.g. after a crash mid-saga) returns the original row with
+// created=false instead of inserting a duplicate.
+func (s *Service) ReserveRefund(ctx context.Context, tx *gorm.DB, in ReserveRefundInput) (*RefundTransaction, bool, error) {
+	row, created, err := s.repo.InsertRefundPending(tx, &RefundTransaction{
+		TenantID:          in.TenantID,
+		StoreID:           in.StoreID,
+		OrderID:           in.OrderID,
+		Provider:          in.Provider,
+		ProviderPaymentID: in.ProviderPaymentID,
+		Amount:            in.Amount,
+		Reason:            in.Reason,
+		Status:            "pending",
+		IdempotencyKey:    in.IdempotencyKey,
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("payment service: reserve refund: %w", err)
+	}
+	return row, created, nil
+}
+
+// ExecuteGatewayRefund issues the refund against the provider. It is a pure
+// gateway call — no DB access — so the saga orchestrator can call it outside
+// any transaction and retry independently of ledger state.
+func (s *Service) ExecuteGatewayRefund(ctx context.Context, gw Gateway, in RefundInput) (*Refund, error) {
+	r, err := gw.RefundPayment(ctx, in)
+	if err != nil {
+		return nil, fmt.Errorf("payment service: gateway refund: %w", err)
+	}
+	return r, nil
+}
+
+// FinalizeRefund records the gateway outcome on the ledger row, completing
+// the saga.
+func (s *Service) FinalizeRefund(ctx context.Context, tx *gorm.DB, ledgerID, providerRefundID, status string) error {
+	if err := s.repo.UpdateRefundOutcome(tx, ledgerID, providerRefundID, status); err != nil {
+		return fmt.Errorf("payment service: finalize refund: %w", err)
+	}
+	return nil
 }
 
 func webhookEventToStatus(eventType string) string {

--- a/services/marketplace-api/internal/payment/service_integration_test.go
+++ b/services/marketplace-api/internal/payment/service_integration_test.go
@@ -110,3 +110,18 @@ func TestFinalizeRefund_UpdatesStatusAndProviderRefundID(t *testing.T) {
 		t.Fatalf("ProviderRefundID = %q, want re_789", updated.ProviderRefundID)
 	}
 }
+
+// TestFinalizeRefund_UnknownLedgerID_Errors proves FinalizeRefund cannot
+// silently no-op: a ledgerID that matches zero refund_transactions rows must
+// return an error rather than nil, otherwise the saga would falsely report
+// success while the ledger row never reflects the gateway's outcome.
+func TestFinalizeRefund_UnknownLedgerID_Errors(t *testing.T) {
+	db := testdb.NewDB(t, "refund_transactions")
+	svc := NewService(NewRepository(db))
+	ctx := context.Background()
+
+	err := svc.FinalizeRefund(ctx, db, uuid.New().String(), "re_x", "succeeded")
+	if err == nil {
+		t.Fatal("FinalizeRefund: err = nil, want non-nil for unknown ledger ID")
+	}
+}

--- a/services/marketplace-api/internal/payment/service_integration_test.go
+++ b/services/marketplace-api/internal/payment/service_integration_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+
+package payment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// TestReserveRefund_Idempotent proves the ON CONFLICT (idempotency_key) DO
+// NOTHING semantics: a second ReserveRefund call with the same idempotency
+// key must not insert a second row — it must return the original row with
+// created=false. This is the saga re-entry guard the RefundCoordinator
+// (Task 8) relies on to make retries safe.
+func TestReserveRefund_Idempotent(t *testing.T) {
+	db := testdb.NewDB(t, "refund_transactions")
+	svc := NewService(NewRepository(db))
+	ctx := context.Background()
+
+	in := ReserveRefundInput{
+		TenantID:          uuid.New().String(),
+		StoreID:           uuid.New().String(),
+		OrderID:           uuid.New().String(),
+		Provider:          "stripe",
+		ProviderPaymentID: "pi_123",
+		Amount:            decimal.NewFromInt(50),
+		CurrencyCode:      "usd",
+		Reason:            "customer requested",
+		IdempotencyKey:    "refund:" + uuid.New().String(),
+	}
+
+	first, created, err := svc.ReserveRefund(ctx, db, in)
+	if err != nil {
+		t.Fatalf("first ReserveRefund: %v", err)
+	}
+	if !created {
+		t.Fatalf("first ReserveRefund: created = false, want true")
+	}
+	if first.ID == "" {
+		t.Fatal("first ReserveRefund: row has no ID")
+	}
+	if first.Status != "pending" {
+		t.Fatalf("first ReserveRefund: status = %q, want pending", first.Status)
+	}
+
+	second, created, err := svc.ReserveRefund(ctx, db, in)
+	if err != nil {
+		t.Fatalf("second ReserveRefund: %v", err)
+	}
+	if created {
+		t.Fatal("second ReserveRefund: created = true, want false (idempotency guard)")
+	}
+	if second.ID != first.ID {
+		t.Fatalf("second ReserveRefund: ID = %q, want same as first %q", second.ID, first.ID)
+	}
+
+	rows, err := NewRepository(db).ListRefundsByPaymentID(ctx, "pi_123")
+	if err != nil {
+		t.Fatalf("ListRefundsByPaymentID: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("refund_transactions has %d rows for pi_123, want 1 (no duplicate insert)", len(rows))
+	}
+}
+
+// TestFinalizeRefund_UpdatesStatusAndProviderRefundID confirms FinalizeRefund
+// flips a pending row to a terminal status and stamps the provider refund id.
+func TestFinalizeRefund_UpdatesStatusAndProviderRefundID(t *testing.T) {
+	db := testdb.NewDB(t, "refund_transactions")
+	svc := NewService(NewRepository(db))
+	ctx := context.Background()
+
+	in := ReserveRefundInput{
+		TenantID:          uuid.New().String(),
+		StoreID:           uuid.New().String(),
+		OrderID:           uuid.New().String(),
+		Provider:          "stripe",
+		ProviderPaymentID: "pi_456",
+		Amount:            decimal.NewFromInt(75),
+		CurrencyCode:      "usd",
+		Reason:            "defective item",
+		IdempotencyKey:    "refund:" + uuid.New().String(),
+	}
+
+	row, created, err := svc.ReserveRefund(ctx, db, in)
+	if err != nil {
+		t.Fatalf("ReserveRefund: %v", err)
+	}
+	if !created {
+		t.Fatal("ReserveRefund: created = false, want true")
+	}
+
+	if err := svc.FinalizeRefund(ctx, db, row.ID, "re_789", "succeeded"); err != nil {
+		t.Fatalf("FinalizeRefund: %v", err)
+	}
+
+	updated, err := NewRepository(db).GetRefundByIdempotencyKey(ctx, in.IdempotencyKey)
+	if err != nil {
+		t.Fatalf("GetRefundByIdempotencyKey: %v", err)
+	}
+	if updated.Status != "succeeded" {
+		t.Fatalf("Status = %q, want succeeded", updated.Status)
+	}
+	if updated.ProviderRefundID != "re_789" {
+		t.Fatalf("ProviderRefundID = %q, want re_789", updated.ProviderRefundID)
+	}
+}

--- a/services/marketplace-api/internal/payment/service_test.go
+++ b/services/marketplace-api/internal/payment/service_test.go
@@ -1,0 +1,161 @@
+package payment
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+// ---------------------------------------------------------------------------
+// fakeGateway — implements the full Gateway interface for unit tests. Only
+// RefundPayment is exercised; the rest return zero values.
+// ---------------------------------------------------------------------------
+
+type fakeGateway struct {
+	refund    *Refund
+	refundErr error
+	lastIn    RefundInput
+}
+
+func (f *fakeGateway) CreateIntent(ctx context.Context, in CreateIntentInput) (*Intent, error) {
+	return nil, nil
+}
+
+func (f *fakeGateway) CapturePayment(ctx context.Context, captureID string) (*Capture, error) {
+	return nil, nil
+}
+
+func (f *fakeGateway) RefundPayment(ctx context.Context, in RefundInput) (*Refund, error) {
+	f.lastIn = in
+	if f.refundErr != nil {
+		return nil, f.refundErr
+	}
+	return f.refund, nil
+}
+
+func (f *fakeGateway) VerifyWebhook(ctx context.Context, payload []byte, signature string) (*WebhookEvent, error) {
+	return nil, nil
+}
+
+func (f *fakeGateway) ProviderName() string { return "fake" }
+
+func (f *fakeGateway) SupportedCountries() []string { return nil }
+
+// ---------------------------------------------------------------------------
+// fakeRepo — implements the full Repository interface for unit tests.
+// Refund-ledger methods are backed by an in-memory map keyed by idempotency
+// key so ReserveRefund's conflict-detection behavior can be exercised
+// without a real database.
+// ---------------------------------------------------------------------------
+
+type fakeRepo struct {
+	byIdempotencyKey map[string]*RefundTransaction
+	nextID           int
+}
+
+func newFakeRepo() *fakeRepo {
+	return &fakeRepo{byIdempotencyKey: make(map[string]*RefundTransaction)}
+}
+
+func (f *fakeRepo) CreateTransaction(ctx context.Context, tx *PaymentTransaction) error {
+	return nil
+}
+
+func (f *fakeRepo) GetTransactionByOrderID(ctx context.Context, orderID string) (*PaymentTransaction, error) {
+	return nil, nil
+}
+
+func (f *fakeRepo) UpdateTransactionStatus(ctx context.Context, orderID, status string) error {
+	return nil
+}
+
+func (f *fakeRepo) CreateRefundTransaction(ctx context.Context, refund *RefundTransaction) error {
+	return nil
+}
+
+func (f *fakeRepo) ListRefundsByPaymentID(ctx context.Context, providerPaymentID string) ([]RefundTransaction, error) {
+	return nil, nil
+}
+
+func (f *fakeRepo) CreateWebhookEvent(ctx context.Context, evt *WebhookEventRecord) error {
+	return nil
+}
+
+func (f *fakeRepo) GetWebhookEventByProviderID(ctx context.Context, providerEventID string) (*WebhookEventRecord, error) {
+	return nil, nil
+}
+
+func (f *fakeRepo) InsertRefundPending(tx *gorm.DB, row *RefundTransaction) (*RefundTransaction, bool, error) {
+	// Not used directly by unit tests below — repository-level fake logic
+	// isn't exercised because ReserveRefund's idempotency guarantee is
+	// verified against a real database in service_integration_test.go
+	// (the ON CONFLICT DO NOTHING semantics require real Postgres).
+	if row.Status == "" {
+		row.Status = "pending"
+	}
+	if existing, ok := f.byIdempotencyKey[row.IdempotencyKey]; ok {
+		return existing, false, nil
+	}
+	f.nextID++
+	row.ID = row.IdempotencyKey // deterministic fake id for equality checks
+	f.byIdempotencyKey[row.IdempotencyKey] = row
+	return row, true, nil
+}
+
+func (f *fakeRepo) UpdateRefundOutcome(tx *gorm.DB, ledgerID, providerRefundID, status string) error {
+	return nil
+}
+
+func (f *fakeRepo) GetRefundByIdempotencyKey(ctx context.Context, key string) (*RefundTransaction, error) {
+	if row, ok := f.byIdempotencyKey[key]; ok {
+		return row, nil
+	}
+	return nil, errors.New("not found")
+}
+
+// ---------------------------------------------------------------------------
+// ExecuteGatewayRefund — pure gateway call, no DB.
+// ---------------------------------------------------------------------------
+
+func TestExecuteGatewayRefund_PassesIdempotencyKey(t *testing.T) {
+	fg := &fakeGateway{refund: &Refund{ProviderRefundID: "re_9", Status: "succeeded"}}
+	svc := NewService(newFakeRepo())
+
+	refund, err := svc.ExecuteGatewayRefund(context.Background(), fg, RefundInput{
+		ProviderPaymentID: "pi_1",
+		Amount:            decimal.NewFromInt(10),
+		IdempotencyKey:    "k1",
+	})
+	if err != nil {
+		t.Fatalf("ExecuteGatewayRefund: unexpected error: %v", err)
+	}
+	if fg.lastIn.IdempotencyKey != "k1" {
+		t.Fatalf("gateway got IdempotencyKey %q, want %q", fg.lastIn.IdempotencyKey, "k1")
+	}
+	if refund == nil || refund.ProviderRefundID != "re_9" {
+		t.Fatalf("ExecuteGatewayRefund returned %+v, want ProviderRefundID re_9", refund)
+	}
+}
+
+func TestExecuteGatewayRefund_WrapsGatewayError(t *testing.T) {
+	fg := &fakeGateway{refundErr: errors.New("gateway down")}
+	svc := NewService(newFakeRepo())
+
+	refund, err := svc.ExecuteGatewayRefund(context.Background(), fg, RefundInput{
+		ProviderPaymentID: "pi_1",
+		Amount:            decimal.NewFromInt(10),
+		IdempotencyKey:    "k1",
+	})
+	if err == nil {
+		t.Fatal("ExecuteGatewayRefund: expected error, got nil")
+	}
+	if refund != nil {
+		t.Fatalf("ExecuteGatewayRefund: expected nil refund on error, got %+v", refund)
+	}
+	if !errors.Is(err, fg.refundErr) {
+		t.Fatalf("ExecuteGatewayRefund: error %v does not wrap gateway error %v", err, fg.refundErr)
+	}
+}

--- a/services/marketplace-api/internal/payment/stripe.go
+++ b/services/marketplace-api/internal/payment/stripe.go
@@ -231,6 +231,9 @@ func (s *StripeGateway) RefundPayment(ctx context.Context, in RefundInput) (*Ref
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetBasicAuth(s.apiKey, "")
+	if in.IdempotencyKey != "" {
+		req.Header.Set("Idempotency-Key", in.IdempotencyKey)
+	}
 
 	resp, err := s.client.Do(req)
 	if err != nil {

--- a/services/marketplace-api/internal/payment/stripe_test.go
+++ b/services/marketplace-api/internal/payment/stripe_test.go
@@ -1,0 +1,36 @@
+package payment
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestStripeRefund_SendsIdempotencyKey(t *testing.T) {
+	var gotKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("Idempotency-Key")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"re_1","status":"succeeded","amount":5000}`))
+	}))
+	defer srv.Close()
+
+	g := NewStripeGateway("sk_test", "", "test")
+	g.baseURL = srv.URL
+
+	_, err := g.RefundPayment(context.Background(), RefundInput{
+		ProviderPaymentID: "pi_1",
+		Amount:            decimal.NewFromInt(50),
+		CurrencyCode:      "usd",
+		IdempotencyKey:    "refund:order-123:cancel",
+	})
+	if err != nil {
+		t.Fatalf("refund: %v", err)
+	}
+	if gotKey != "refund:order-123:cancel" {
+		t.Fatalf("Idempotency-Key = %q, want %q", gotKey, "refund:order-123:cancel")
+	}
+}

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 91
+const ExpectedSchemaVersion uint = 93

--- a/services/marketplace-api/migrations/000092_refund_transactions_saga.down.sql
+++ b/services/marketplace-api/migrations/000092_refund_transactions_saga.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS ix_refund_transactions_order_id;
+DROP INDEX IF EXISTS ix_refund_transactions_status_created;
+DROP INDEX IF EXISTS ux_refund_transactions_idempotency_key;
+ALTER TABLE refund_transactions ALTER COLUMN status DROP DEFAULT;
+ALTER TABLE refund_transactions
+    DROP COLUMN IF EXISTS idempotency_key,
+    DROP COLUMN IF EXISTS order_id;

--- a/services/marketplace-api/migrations/000092_refund_transactions_saga.up.sql
+++ b/services/marketplace-api/migrations/000092_refund_transactions_saga.up.sql
@@ -1,0 +1,29 @@
+-- Extend refund_transactions to be the saga ledger (spec §5).
+-- Columns added nullable first so the migration is safe even if rows exist,
+-- then tightened. No real gateway refunds have moved money yet, so backfill
+-- of order_id is best-effort (left NULL for any legacy rows).
+ALTER TABLE refund_transactions
+    ADD COLUMN IF NOT EXISTS order_id        uuid,
+    ADD COLUMN IF NOT EXISTS idempotency_key varchar(255);
+
+-- status already referenced by the webhook handler; ensure it exists + default.
+ALTER TABLE refund_transactions
+    ALTER COLUMN status SET DEFAULT 'pending';
+
+-- Backfill legacy rows to a stable synthetic key so the UNIQUE index can be
+-- created without collisions.
+UPDATE refund_transactions
+   SET idempotency_key = 'legacy:' || id::text
+ WHERE idempotency_key IS NULL;
+
+ALTER TABLE refund_transactions
+    ALTER COLUMN idempotency_key SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_refund_transactions_idempotency_key
+    ON refund_transactions (idempotency_key);
+
+CREATE INDEX IF NOT EXISTS ix_refund_transactions_status_created
+    ON refund_transactions (status, created_at);
+
+CREATE INDEX IF NOT EXISTS ix_refund_transactions_order_id
+    ON refund_transactions (order_id);

--- a/services/marketplace-api/migrations/000093_refund_transactions_saga_columns.down.sql
+++ b/services/marketplace-api/migrations/000093_refund_transactions_saga_columns.down.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS ix_refund_transactions_store_id;
+
+ALTER TABLE refund_transactions
+    ALTER COLUMN payment_transaction_id SET NOT NULL,
+    ALTER COLUMN currency_code SET NOT NULL;
+
+ALTER TABLE refund_transactions
+    DROP COLUMN IF EXISTS store_id,
+    DROP COLUMN IF EXISTS provider,
+    DROP COLUMN IF EXISTS provider_payment_id;

--- a/services/marketplace-api/migrations/000093_refund_transactions_saga_columns.down.sql
+++ b/services/marketplace-api/migrations/000093_refund_transactions_saga_columns.down.sql
@@ -1,9 +1,12 @@
 DROP INDEX IF EXISTS ix_refund_transactions_store_id;
 
-ALTER TABLE refund_transactions
-    ALTER COLUMN payment_transaction_id SET NOT NULL,
-    ALTER COLUMN currency_code SET NOT NULL;
-
+-- Intentionally NOT restoring NOT NULL on payment_transaction_id /
+-- currency_code: the relaxation in the up migration is deliberately
+-- one-way. Those columns are legacy/orphaned (no code path sets them) and
+-- the saga primitives (ReserveRefund/FinalizeRefund) insert real rows that
+-- never populate them. Restoring the constraint here would make `migrate
+-- down` fail with a not-null violation on any environment where the saga
+-- has already run, leaving golang-migrate in a dirty state.
 ALTER TABLE refund_transactions
     DROP COLUMN IF EXISTS store_id,
     DROP COLUMN IF EXISTS provider,

--- a/services/marketplace-api/migrations/000093_refund_transactions_saga_columns.up.sql
+++ b/services/marketplace-api/migrations/000093_refund_transactions_saga_columns.up.sql
@@ -1,0 +1,22 @@
+-- refund_transactions was already extended with order_id/idempotency_key in
+-- 000092, but the payment.RefundTransaction GORM model (introduced in the
+-- P2/P3/P4 payment provider work) reads/writes store_id, provider, and
+-- provider_payment_id — columns that were never actually migrated in. This
+-- backfills the gap so the Task 6 saga primitives (ReserveRefund /
+-- FinalizeRefund) can persist rows.
+--
+-- payment_transaction_id and currency_code are legacy columns no longer set
+-- by any code path (the model has no matching fields); relax their NOT NULL
+-- constraints so inserts that don't populate them still succeed. No real
+-- gateway refunds have moved money yet, so there is no data to backfill.
+ALTER TABLE refund_transactions
+    ADD COLUMN IF NOT EXISTS store_id            uuid,
+    ADD COLUMN IF NOT EXISTS provider             varchar(20),
+    ADD COLUMN IF NOT EXISTS provider_payment_id  varchar(255);
+
+ALTER TABLE refund_transactions
+    ALTER COLUMN payment_transaction_id DROP NOT NULL,
+    ALTER COLUMN currency_code DROP NOT NULL;
+
+CREATE INDEX IF NOT EXISTS ix_refund_transactions_store_id
+    ON refund_transactions (store_id);

--- a/services/marketplace-api/pkg/apperrors/errors.go
+++ b/services/marketplace-api/pkg/apperrors/errors.go
@@ -35,11 +35,12 @@ const (
 	CodeOptionValueInUse        Code = "option_value_in_use"
 
 	// Orders slice 1 — added in Orders M2.
-	CodeInvalidTransition       Code = "invalid_transition"
-	CodeRefundExceedsTotal      Code = "refund_exceeds_total"
-	CodeIdempotencyConflict     Code = "idempotency_conflict"
+	CodeInvalidTransition        Code = "invalid_transition"
+	CodeRefundExceedsTotal       Code = "refund_exceeds_total"
+	CodeRefundUnavailable        Code = "refund_unavailable"
+	CodeIdempotencyConflict      Code = "idempotency_conflict"
 	CodeReturnItemsExceedOrdered Code = "return_items_exceed_ordered"
-	CodeRecoveryTooRecent       Code = "recovery_too_recent"
+	CodeRecoveryTooRecent        Code = "recovery_too_recent"
 
 	// Coupons M1.
 	CodeCouponNotFound          Code = "coupon_not_found"
@@ -111,6 +112,7 @@ var (
 	// Orders slice 1 sentinels.
 	ErrInvalidTransition        = &Error{Code: CodeInvalidTransition}
 	ErrRefundExceedsTotal       = &Error{Code: CodeRefundExceedsTotal}
+	ErrRefundUnavailable        = &Error{Code: CodeRefundUnavailable}
 	ErrIdempotencyConflict      = &Error{Code: CodeIdempotencyConflict}
 	ErrReturnItemsExceedOrdered = &Error{Code: CodeReturnItemsExceedOrdered}
 	ErrRecoveryTooRecent        = &Error{Code: CodeRecoveryTooRecent}
@@ -163,7 +165,7 @@ func IsKnownCode(s string) bool {
 		CodeTargetStoreInvalid, CodeUploadNotFound, CodeForbidden, CodeNotFound,
 		CodePayloadTooLarge, CodeUnsupportedMediaType, CodeRateLimited,
 		CodeCurrencyChangeForbidden, CodeOptionValueInUse,
-		CodeInvalidTransition, CodeRefundExceedsTotal, CodeIdempotencyConflict,
+		CodeInvalidTransition, CodeRefundExceedsTotal, CodeRefundUnavailable, CodeIdempotencyConflict,
 		CodeReturnItemsExceedOrdered, CodeRecoveryTooRecent,
 		CodeCouponNotFound, CodeCouponExpired, CodeCouponUsageLimitReached,
 		CodeCouponInvalid, CodeCouponMinPurchaseNotMet,
@@ -309,10 +311,16 @@ func RefundExceedsTotal(grandTotal, requested, alreadyRefunded string) *Error {
 	return &Error{Code: CodeRefundExceedsTotal,
 		Message: "refund amount would exceed the order grand total",
 		Details: map[string]any{
-			"grand_total":       grandTotal,
-			"requested":         requested,
-			"already_refunded":  alreadyRefunded,
+			"grand_total":      grandTotal,
+			"requested":        requested,
+			"already_refunded": alreadyRefunded,
 		}}
+}
+
+// RefundUnavailable is returned when an order cannot be refunded through the
+// gateway (no captured payment transaction — COD/manual/authorized-only).
+func RefundUnavailable(reason string) *Error {
+	return &Error{Code: CodeRefundUnavailable, Message: reason}
 }
 
 // IdempotencyConflict is returned when a Create call reuses an existing

--- a/services/marketplace-api/pkg/apperrors/errors_test.go
+++ b/services/marketplace-api/pkg/apperrors/errors_test.go
@@ -95,3 +95,13 @@ func TestCouponMinPurchaseNotMetConstructor(t *testing.T) {
 		t.Errorf("expected code %q, got %q", apperrors.CodeCouponMinPurchaseNotMet, err.Code)
 	}
 }
+
+func TestRefundUnavailable(t *testing.T) {
+	err := apperrors.RefundUnavailable("no captured payment")
+	if !errors.Is(err, apperrors.ErrRefundUnavailable) {
+		t.Fatalf("want ErrRefundUnavailable, got %v", err)
+	}
+	if err.Code != apperrors.CodeRefundUnavailable {
+		t.Fatalf("code: got %q want %q", err.Code, apperrors.CodeRefundUnavailable)
+	}
+}


### PR DESCRIPTION
## Summary

Wires **all order-refund paths to actually move money** through the customer's original payment gateway. Previously every refund path (admin refund, return refund) only mutated bookkeeping — `orders.refunded_amount` rose and a "refunded" email was sent, but the card was never credited (`payment.Service.RefundPayment` had zero callers). Paid cancellations stranded funds entirely.

Three triggers now converge on a single `RefundCoordinator`:
- **Admin order refund** — `POST /admin/stores/:storeId/orders/:id/refund`
- **Return refund** — `POST /admin/stores/:storeId/returns/:id/refunded`
- **Paid self-cancellation** — customer/admin cancel of a paid, un-shipped order → automatic full refund

### How it works
- **All gateways** (Stripe / Razorpay / PayPal) via the `payment.Gateway` interface — provider resolved per order from `payment_transactions`, each sending its native idempotency header (`Idempotency-Key`, `X-Refund-Idempotency`, `PayPal-Request-Id`).
- **Ledger-first idempotent saga**: reserve a `pending` `refund_transactions` row (unique `idempotency_key`) → call gateway **outside** any DB tx → atomic tx { finalize row `succeeded` + `order.RecordRefund` bumps `refunded_amount` }. Never double-refunds, never loses one.
- **Retry sweeper** (`cmd/refund-sweep-cron` → `Coordinator.ResumePending`) re-drives stuck `pending` rows with the same idempotency key, using `FOR UPDATE SKIP LOCKED` + a status-guarded finalize so overlapping runs can't double-bump.
- **Correctness**: server derives partial vs full status from amount; caps against the *captured* amount; COD/no-gateway orders → `422 refund_unavailable`; captured provider payment id is persisted at webhook capture so Razorpay/PayPal have a valid refund target.
- **Ships dark** behind `REFUND_GATEWAY_ENABLED` (default off).

### Schema
- `000092` — `refund_transactions` gains `order_id`, `status`, unique `idempotency_key` (+ indexes).
- `000093` — adds `store_id`/`provider`/`provider_payment_id` (pre-existing model/schema drift that would have broken inserts) and relaxes orphaned NOT NULLs. `ExpectedSchemaVersion` → 93.

## Before enabling the flag
- The admin refund endpoint now **requires `refund_request_id`** (stable UUID per refund attempt) for retry-safe idempotency. **marketplace-admin UI must generate + persist it** and reuse on retry, or admin refunds will 400.
- Deploy `cmd/refund-sweep-cron` as a Cloud Run Job / CronJob (~5 min) — see its README.

## Test plan
- [x] Unit: coordinator status derivation, idempotency-key stability/charset, per-gateway idempotency headers.
- [x] Integration (real Postgres): admin refund (partial/full/over-cap/no-captured-txn/missing-id/same-id-idempotent), return refund happy path, paid-cancel auto-refund (paid/unpaid/shipment-guard), sweeper (completes-stuck / no-pending / gateway-still-failing / double-run-bumps-once), payment saga primitives, resolver, capture-id persistence.
- [x] `go build ./...`, `go vet`, `-race` on feature packages — clean.
- [x] No regressions in feature packages; pre-existing unrelated integration-test drift documented, not introduced here.

## Follow-ups (non-blocking)
- Disabled-flag path returns 500 (prefer 503) during the dark window.
- marketplace-admin: generate/persist `refund_request_id`.
- Separate cleanup ticket for pre-existing storefront/admin integration-test seed drift.

Spec: `docs/superpowers/specs/2026-07-09-order-refund-gateway-wiring-design.md`
Plan: `docs/superpowers/plans/2026-07-09-order-refund-gateway-wiring.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6RADP76F9LHU3zsvLvQU9
