### PR TITLE
feat(refund): admin UI sends refund_request_id + 503 for disabled refunds

### DIFF
--- a/apps/admin/app/(admin)/orders/[id]/actions.ts
+++ b/apps/admin/app/(admin)/orders/[id]/actions.ts
@@ -159,6 +159,7 @@ export interface RefundOrderActionInput {
   amount: string;
   paymentStatus: PaymentStatus;
   reason?: string;
+  refundRequestId: string;
 }
 
 export async function refundOrderAction(
@@ -194,6 +195,16 @@ export async function refundOrderAction(
       },
     };
   }
+  if (!input.refundRequestId) {
+    return {
+      ok: false,
+      error: {
+        code: "validation_failed",
+        message: "Refund request id is required.",
+        field: "refund_request_id",
+      },
+    };
+  }
 
   const result = await refundOrder(
     ctx.storeId,
@@ -202,6 +213,7 @@ export async function refundOrderAction(
       amount: input.amount,
       payment_status: input.paymentStatus,
       reason: input.reason ?? "",
+      refund_request_id: input.refundRequestId,
     },
     { userId: ctx.userId, tenantId: ctx.tenantId },
   );

--- a/apps/admin/components/orders/OrderActionsBar.tsx
+++ b/apps/admin/components/orders/OrderActionsBar.tsx
@@ -442,6 +442,10 @@ function RefundForm({
   );
   const [reason, setReason] = useState("");
   const [step, setStep] = useState<"form" | "review">("form");
+  // Stable per-mount id: same value across re-renders and submit retries
+  // within this open form, but a new id if the form is closed and reopened
+  // (a new refund attempt). This is the idempotency semantics we want.
+  const [refundRequestId] = useState(() => crypto.randomUUID());
 
   const remaining = (
     Number.parseFloat(grandTotal) - Number.parseFloat(refundedAmount)
@@ -454,6 +458,7 @@ function RefundForm({
         amount,
         paymentStatus,
         reason,
+        refundRequestId,
       });
       if (!r.ok) {
         setError(r.error);

--- a/apps/admin/lib/api/marketplace-api.ts
+++ b/apps/admin/lib/api/marketplace-api.ts
@@ -1240,6 +1240,8 @@ export interface RefundOrderInput {
   /** Target payment_status: "partially_refunded" or "refunded". */
   payment_status: PaymentStatus;
   reason?: string;
+  /** Stable idempotency key per refund attempt. */
+  refund_request_id: string;
 }
 
 export async function refundOrder(

--- a/services/marketplace-api/internal/handlers/admin/errors.go
+++ b/services/marketplace-api/internal/handlers/admin/errors.go
@@ -40,6 +40,7 @@ var codeStatus = map[apperrors.Code]int{
 	apperrors.CodeIdempotencyConflict:      http.StatusConflict,
 	apperrors.CodeReturnItemsExceedOrdered: http.StatusUnprocessableEntity,
 	apperrors.CodeRecoveryTooRecent:        http.StatusTooManyRequests,
+	apperrors.CodeRefundsDisabled:          http.StatusServiceUnavailable,
 
 	// Coupons M1.
 	apperrors.CodeCouponNotFound:          http.StatusNotFound,

--- a/services/marketplace-api/internal/orderrefund/coordinator.go
+++ b/services/marketplace-api/internal/orderrefund/coordinator.go
@@ -101,7 +101,7 @@ func idempotencyKey(orderID uuid.UUID, scopeID string) string {
 // database when the coordinator is disabled.
 func (c *Coordinator) Refund(ctx context.Context, cmd RefundCommand) (RefundResult, error) {
 	if !c.enabled {
-		return RefundResult{}, fmt.Errorf("orderrefund: gateway refunds disabled (REFUND_GATEWAY_ENABLED=false)")
+		return RefundResult{}, apperrors.ErrRefundsDisabled
 	}
 	if !scopeIDPattern.MatchString(cmd.ScopeID) {
 		return RefundResult{}, apperrors.ValidationFailed("refund_request_id", "must match [A-Za-z0-9_-]")

--- a/services/marketplace-api/internal/orderrefund/coordinator_integration_test.go
+++ b/services/marketplace-api/internal/orderrefund/coordinator_integration_test.go
@@ -305,8 +305,8 @@ func TestRefund_Disabled_SkipsGateway(t *testing.T) {
 	_, err := c.Refund(context.Background(), orderrefund.RefundCommand{
 		OrderID: orderID, Amount: &amount, Reason: "customer request", Actor: "admin", ScopeID: "rr1",
 	})
-	if err == nil {
-		t.Fatal("Refund: err = nil, want non-nil (coordinator disabled)")
+	if !errors.Is(err, apperrors.ErrRefundsDisabled) {
+		t.Fatalf("Refund: err = %v, want apperrors.ErrRefundsDisabled", err)
 	}
 	if gw.callCount() != 0 {
 		t.Fatalf("gateway call count = %d, want 0", gw.callCount())

--- a/services/marketplace-api/pkg/apperrors/errors.go
+++ b/services/marketplace-api/pkg/apperrors/errors.go
@@ -41,6 +41,7 @@ const (
 	CodeIdempotencyConflict      Code = "idempotency_conflict"
 	CodeReturnItemsExceedOrdered Code = "return_items_exceed_ordered"
 	CodeRecoveryTooRecent        Code = "recovery_too_recent"
+	CodeRefundsDisabled          Code = "refunds_disabled"
 
 	// Coupons M1.
 	CodeCouponNotFound          Code = "coupon_not_found"
@@ -116,6 +117,7 @@ var (
 	ErrIdempotencyConflict      = &Error{Code: CodeIdempotencyConflict}
 	ErrReturnItemsExceedOrdered = &Error{Code: CodeReturnItemsExceedOrdered}
 	ErrRecoveryTooRecent        = &Error{Code: CodeRecoveryTooRecent}
+	ErrRefundsDisabled          = &Error{Code: CodeRefundsDisabled}
 
 	// Coupons M1 sentinels.
 	ErrCouponNotFound          = &Error{Code: CodeCouponNotFound}
@@ -166,7 +168,7 @@ func IsKnownCode(s string) bool {
 		CodePayloadTooLarge, CodeUnsupportedMediaType, CodeRateLimited,
 		CodeCurrencyChangeForbidden, CodeOptionValueInUse,
 		CodeInvalidTransition, CodeRefundExceedsTotal, CodeRefundUnavailable, CodeIdempotencyConflict,
-		CodeReturnItemsExceedOrdered, CodeRecoveryTooRecent,
+		CodeReturnItemsExceedOrdered, CodeRecoveryTooRecent, CodeRefundsDisabled,
 		CodeCouponNotFound, CodeCouponExpired, CodeCouponUsageLimitReached,
 		CodeCouponInvalid, CodeCouponMinPurchaseNotMet,
 		CodeInsufficientGiftCardBalance, CodeGiftCardExpired, CodeGiftCardNotFound,
@@ -321,6 +323,12 @@ func RefundExceedsTotal(grandTotal, requested, alreadyRefunded string) *Error {
 // gateway (no captured payment transaction — COD/manual/authorized-only).
 func RefundUnavailable(reason string) *Error {
 	return &Error{Code: CodeRefundUnavailable, Message: reason}
+}
+
+// RefundsDisabled is returned when the refund coordinator's feature flag is
+// off, so callers get a clear 503 instead of a generic 500.
+func RefundsDisabled() *Error {
+	return &Error{Code: CodeRefundsDisabled, Message: "refunds are temporarily disabled"}
 }
 
 // IdempotencyConflict is returned when a Create call reuses an existing


### PR DESCRIPTION
## Summary
Follow-ups to PR #164 (refund gateway wiring):

- **Admin UI now sends `refund_request_id`.** The admin refund endpoint requires a stable idempotency key per refund attempt (added in #164); without it, admin refunds returned 400. `RefundForm` now mints one stable UUID per form mount (`useState(() => crypto.randomUUID())`) — retries of the same open form reuse it; closing/reopening starts a fresh attempt — and threads it through the server action → API call.
- **Disabled-flag refunds return a typed 503** (`refunds_disabled`) instead of a generic 500. When `REFUND_GATEWAY_ENABLED` is off (the dark window), admin/return refund requests now get a clear `503 refunds_disabled`; the cancel auto-refund path still logs non-fatally and the cancel succeeds.

## Files
- `apps/admin/lib/api/marketplace-api.ts`, `apps/admin/app/(admin)/orders/[id]/actions.ts`, `apps/admin/components/orders/OrderActionsBar.tsx` — thread `refund_request_id`.
- `services/marketplace-api/pkg/apperrors/errors.go`, `internal/handlers/admin/errors.go`, `internal/orderrefund/coordinator.go` — `refunds_disabled` (503) typed error.

## Test plan
- [x] `go build ./...`, `go test ./pkg/apperrors ./internal/orderrefund ./internal/handlers/admin` — pass (incl. `TestRefund_Disabled_SkipsGateway` asserting the typed error).
- [x] `apps/admin` `tsc --noEmit` — clean.
- [x] Pre-existing unrelated failures (`TestRefund_OutsideCoolingOff` route bug, local test-DB seed drift) confirmed on `main` too — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6RADP76F9LHU3zsvLvQU9
