### PR TITLE
fix(ci+test): pin Go 1.26.5 (GO-2026-5856) + repair marketplace-api test drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
           cache-dependency-path: services/${{ matrix.service }}/go.sum
       - name: vet
         working-directory: services/${{ matrix.service }}

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
           cache-dependency-path: services/${{ matrix.service }}/go.sum
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/services/marketplace-api/internal/handlers/admin/refund_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/refund_integration_test.go
@@ -147,5 +147,5 @@ func TestRefund_OutsideCoolingOff(t *testing.T) {
 
 // refundURL builds the §8 cooling-off subscription refund endpoint path.
 func refundURL(storeID string) string {
-	return "/admin/stores/" + storeID + "/subscription/refund"
+	return "/api/v1/admin/stores/" + storeID + "/subscription/refund"
 }

--- a/services/marketplace-api/internal/handlers/admin/shipments_tracking_sync_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments_tracking_sync_test.go
@@ -278,8 +278,8 @@ func seedStoreRowForSync(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID)
 	// evolved. Field list chosen to satisfy NOT NULL columns in
 	// migrations/000002_orders_initial.up.sql.
 	err := db.Exec(`
-		INSERT INTO stores (id, tenant_id, name, slug, country_code, currency_code, created_at, updated_at)
-		VALUES (?, ?, 'Test', ?, 'IN', 'INR', now(), now())
+		INSERT INTO stores (id, tenant_id, name, slug, country_code, currency_code, created_at, updated_at, storefront_customer_portal_secret)
+		VALUES (?, ?, 'Test', ?, 'IN', 'INR', now(), now(), encode(gen_random_bytes(32), 'hex'))
 		ON CONFLICT (id) DO NOTHING`,
 		storeID, tenantID, "test-"+storeID.String()[:8]).Error
 	if err != nil {

--- a/services/marketplace-api/internal/handlers/storefront/storefront_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/storefront_integration_test.go
@@ -100,8 +100,8 @@ func seedStorefrontStore(t *testing.T, db *gorm.DB, slug, currency string) (stor
 	storeID = uuid.NewString()
 	tenantID = uuid.NewString()
 	if err := db.Exec(`
-		INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, synced_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, now())`,
+		INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, synced_at, storefront_customer_portal_secret)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, now(), encode(gen_random_bytes(32), 'hex'))`,
 		storeID, tenantID, slug, "Storefront Test Store", "US", currency, "UTC", stores.StatusActive).Error; err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
@@ -113,8 +113,8 @@ func seedSuspendedStore(t *testing.T, db *gorm.DB, slug string) string {
 	storeID := uuid.NewString()
 	tenantID := uuid.NewString()
 	if err := db.Exec(`
-		INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, synced_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, now())`,
+		INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, synced_at, storefront_customer_portal_secret)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, now(), encode(gen_random_bytes(32), 'hex'))`,
 		storeID, tenantID, slug, "Suspended Store", "US", "USD", "UTC", stores.StatusSuspended).Error; err != nil {
 		t.Fatalf("seed suspended store: %v", err)
 	}


### PR DESCRIPTION
Closes #167, part of #168.

- **#167** — govulncheck GO-2026-5856 (`crypto/tls`, Fixed in go1.26.5): bump `go-version` `"1.26"`→`"1.26.5"` in `ci.yml` + `reusable-security.yml`. (No pinned `golang:` Docker base images or `toolchain` lines exist to bump.)
- **#168** — repair marketplace-api integration-test drift:
  - `stores` seed helpers in storefront/admin test packages missing `storefront_customer_portal_secret` (NOT NULL) → add `encode(gen_random_bytes(32),'hex')`.
  - `TestRefund_OutsideCoolingOff` 404 root cause was `refundURL()` missing the `/api/v1` prefix every sibling helper uses (not a RefundHandler wiring gap) → fixed.

`go build ./...` clean. Local integration re-run was blocked by a wedged dev Postgres backend; CI on this PR exercises them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6RADP76F9LHU3zsvLvQU9