### PR TITLE
feat(admin): live store-setup progress with 20% head start

### DIFF
--- a/apps/admin/app/(admin)/dashboard/page.tsx
+++ b/apps/admin/app/(admin)/dashboard/page.tsx
@@ -116,7 +116,7 @@ function DashboardContent({
 
   return (
     <>
-      <SetupChecklist checklist={setup_checklist} />
+      <SetupChecklist checklist={setup_checklist} storeId={storeId} />
 
       {isNewStore ? (
         <section className="flex flex-col items-start gap-3 border-t border-border-subtle py-10">

--- a/apps/admin/app/api/admin/stores/[storeId]/setup-progress/route.ts
+++ b/apps/admin/app/api/admin/stores/[storeId]/setup-progress/route.ts
@@ -1,0 +1,9 @@
+import { proxyAdminApi } from "@/lib/api/server/proxyAdminApi";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ storeId: string }> },
+): Promise<Response> {
+  const { storeId } = await params;
+  return proxyAdminApi(request, `stores/${storeId}/dashboard/setup-progress`);
+}

--- a/apps/admin/app/api/admin/stores/[storeId]/setup-progress/stream/route.ts
+++ b/apps/admin/app/api/admin/stores/[storeId]/setup-progress/stream/route.ts
@@ -1,0 +1,14 @@
+import { proxyAdminApi } from "@/lib/api/server/proxyAdminApi";
+
+// SSE passthrough: proxyAdminApi returns the upstream body as a stream,
+// so events flush through as marketplace-api emits them. force-dynamic
+// keeps Next from ever trying to cache the response.
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ storeId: string }> },
+): Promise<Response> {
+  const { storeId } = await params;
+  return proxyAdminApi(request, `stores/${storeId}/dashboard/setup-progress/stream`);
+}

--- a/apps/admin/components/dashboard/SetupChecklist.tsx
+++ b/apps/admin/components/dashboard/SetupChecklist.tsx
@@ -1,23 +1,37 @@
 "use client";
 
-import { useState } from "react";
-import { Check, ChevronDown } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Check, ChevronDown, PartyPopper, Sparkles } from "lucide-react";
 import Link from "next/link";
 
-import type { SetupChecklist as SetupChecklistData } from "@/lib/api/marketplace-api";
+import type {
+  SetupChecklist as SetupChecklistData,
+  SetupProgress,
+} from "@/lib/api/marketplace-api";
+import { useSetupProgress } from "@/lib/hooks/useSetupProgress";
 
 interface SetupChecklistProps {
   checklist: SetupChecklistData;
+  storeId: string;
 }
 
+/**
+ * "store_created" is a pseudo-step: it is complete by definition (the
+ * merchant is looking at their store's dashboard). Together with the
+ * prefilled store settings it gives every new merchant a 2/10 = 20%
+ * head start — progress they can build on rather than a zero to climb.
+ */
+type StepKey = keyof SetupChecklistData | "store_created";
+
 interface ChecklistItem {
-  key: keyof SetupChecklistData;
+  key: StepKey;
   label: string;
   href: string;
   phase: string;
 }
 
 const items: ChecklistItem[] = [
+  { key: "store_created", label: "Create your store", href: "/dashboard", phase: "Store foundation" },
   { key: "has_store", label: "Configure store settings", href: "/settings/stores", phase: "Store foundation" },
   { key: "has_brand_assets", label: "Add store logo", href: "/settings/themes", phase: "Store foundation" },
   { key: "has_product", label: "Add your first product", href: "/products", phase: "Store foundation" },
@@ -26,18 +40,94 @@ const items: ChecklistItem[] = [
   { key: "has_shipping_carrier", label: "Setup shipping integration", href: "/settings/shipping", phase: "Go live" },
   { key: "has_return_policy", label: "Write a return policy", href: "/settings/themes?tab=policies", phase: "Go live" },
   { key: "has_custom_domain", label: "Connect a custom domain", href: "/settings/domains", phase: "Go live" },
+  { key: "has_first_order", label: "Make your first sale", href: "/orders", phase: "Go live" },
 ];
 
 const phases = ["Store foundation", "Go live"] as const;
 
-export function SetupChecklist({ checklist }: SetupChecklistProps) {
-  const completedCount = items.filter((item) => checklist[item.key]).length;
-  const allComplete = completedCount === 8;
+const TOTAL_STEPS = items.length;
+
+function isDone(checklist: SetupChecklistData, key: StepKey): boolean {
+  if (key === "store_created") return true;
+  return checklist[key];
+}
+
+function completedCount(checklist: SetupChecklistData): number {
+  return items.filter((item) => isDone(checklist, item.key)).length;
+}
+
+export function SetupChecklist({ checklist, storeId }: SetupChecklistProps) {
+  const initial: SetupProgress = {
+    checklist,
+    completed_steps: completedCount(checklist),
+    total_steps: TOTAL_STEPS,
+    percent: Math.round((completedCount(checklist) / TOTAL_STEPS) * 100),
+  };
+  const progress = useSetupProgress(storeId, initial);
+  const live = progress.checklist;
+
+  const completed = completedCount(live);
+  const percent = Math.round((completed / TOTAL_STEPS) * 100);
+  const allComplete = completed === TOTAL_STEPS;
+
+  // Stores that were already fully set up when the page rendered never
+  // see the checklist; stores that FINISH during this session get the
+  // celebration state instead of the section silently vanishing.
+  const initiallyComplete = useRef(initial.completed_steps === TOTAL_STEPS);
+  const [dismissed, setDismissed] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
 
-  if (allComplete) return null;
+  // Track which step just flipped so it can pulse — the small "win"
+  // moment when a step completes live while the merchant is watching.
+  const prevChecklist = useRef(live);
+  const [justCompleted, setJustCompleted] = useState<StepKey | null>(null);
+  useEffect(() => {
+    const prev = prevChecklist.current;
+    prevChecklist.current = live;
+    const flipped = items.find(
+      (item) =>
+        item.key !== "store_created" &&
+        !isDone(prev, item.key) &&
+        isDone(live, item.key),
+    );
+    if (!flipped) return;
+    setJustCompleted(flipped.key);
+    const timer = setTimeout(() => setJustCompleted(null), 2500);
+    return () => clearTimeout(timer);
+  }, [live]);
 
-  const progressPct = (completedCount / 8) * 100;
+  if (initiallyComplete.current || dismissed) return null;
+
+  if (allComplete) {
+    return (
+      <section className="border-b border-border-subtle pb-8">
+        <div className="flex items-start justify-between gap-4 rounded-lg bg-[color:var(--moss-700)]/8 p-6">
+          <div className="flex items-start gap-4">
+            <PartyPopper
+              className="mt-1 h-6 w-6 text-[color:var(--moss-700)]"
+              aria-hidden="true"
+            />
+            <div className="space-y-1">
+              <h2 className="font-serif text-xl font-medium text-foreground">
+                Store setup complete — you&apos;re live!
+              </h2>
+              <p className="text-sm text-foreground-secondary">
+                All {TOTAL_STEPS} steps done. Your store is fully configured
+                and ready for customers.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setDismissed(true)}
+            className="shrink-0 text-sm text-foreground-tertiary hover:text-foreground"
+          >
+            Dismiss
+          </button>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="border-b border-border-subtle pb-8">
@@ -52,26 +142,42 @@ export function SetupChecklist({ checklist }: SetupChecklistProps) {
             Store setup
           </h2>
           <p className="text-sm text-foreground-secondary">
-            {completedCount} of 8 complete
+            {completed} of {TOTAL_STEPS} complete
+            <span className="mx-2 text-foreground-tertiary" aria-hidden="true">
+              ·
+            </span>
+            <Sparkles
+              className="mr-1 inline h-3.5 w-3.5 text-[color:var(--moss-700)]"
+              aria-hidden="true"
+            />
+            We completed your first steps for you
           </p>
         </div>
-        <ChevronDown
-          className={`h-5 w-5 text-foreground-tertiary transition-transform ${
-            collapsed ? "-rotate-90" : ""
-          }`}
-          aria-hidden="true"
-        />
+        <div className="flex items-center gap-3">
+          <span
+            className="font-serif text-2xl font-medium text-[color:var(--moss-700)] tabular-nums"
+            aria-hidden="true"
+          >
+            {percent}%
+          </span>
+          <ChevronDown
+            className={`h-5 w-5 text-foreground-tertiary transition-transform ${
+              collapsed ? "-rotate-90" : ""
+            }`}
+            aria-hidden="true"
+          />
+        </div>
       </button>
 
       <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-[color:var(--ink-900)]/10">
         <div
-          className="h-full rounded-full bg-[color:var(--moss-700)] transition-[width] duration-500 ease-out"
-          style={{ width: `${progressPct}%` }}
+          className="h-full rounded-full bg-[color:var(--moss-700)] transition-[width] duration-700 ease-out"
+          style={{ width: `${percent}%` }}
           role="progressbar"
-          aria-valuenow={completedCount}
+          aria-valuenow={completed}
           aria-valuemin={0}
-          aria-valuemax={8}
-          aria-label={`Setup progress: ${completedCount} of 8 complete`}
+          aria-valuemax={TOTAL_STEPS}
+          aria-label={`Setup progress: ${completed} of ${TOTAL_STEPS} complete`}
         />
       </div>
 
@@ -86,11 +192,17 @@ export function SetupChecklist({ checklist }: SetupChecklistProps) {
                 </p>
                 <ul className="mt-3 space-y-3">
                   {phaseItems.map((item) => {
-                    const done = checklist[item.key];
+                    const done = isDone(live, item.key);
+                    const pulsing = justCompleted === item.key;
                     return (
-                      <li key={item.key} className="flex items-center gap-3">
+                      <li
+                        key={item.key}
+                        className={`flex items-center gap-3 rounded transition-colors duration-700 ${
+                          pulsing ? "bg-[color:var(--moss-700)]/10" : ""
+                        }`}
+                      >
                         <span
-                          className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full ${
+                          className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full transition-colors duration-300 ${
                             done
                               ? "bg-[color:var(--moss-700)] text-white"
                               : "border border-[color:var(--ink-900)]/20"
@@ -110,6 +222,11 @@ export function SetupChecklist({ checklist }: SetupChecklistProps) {
                           >
                             {item.label}
                           </Link>
+                        )}
+                        {pulsing && (
+                          <span className="text-xs font-medium text-[color:var(--moss-700)]">
+                            Done!
+                          </span>
                         )}
                       </li>
                     );

--- a/apps/admin/lib/api/marketplace-api.ts
+++ b/apps/admin/lib/api/marketplace-api.ts
@@ -1667,6 +1667,19 @@ export interface SetupChecklist {
   has_shipping_carrier: boolean;
   has_return_policy: boolean;
   has_custom_domain: boolean;
+  has_first_order: boolean;
+}
+
+/**
+ * Envelope returned by the setup-progress snapshot/SSE/WS endpoints.
+ * completed_steps counts the always-complete "store created" pseudo-step,
+ * so a brand-new store starts at 2/10 = 20%.
+ */
+export interface SetupProgress {
+  checklist: SetupChecklist;
+  completed_steps: number;
+  total_steps: number;
+  percent: number;
 }
 
 export interface DashboardResponse {

--- a/apps/admin/lib/hooks/useSetupProgress.ts
+++ b/apps/admin/lib/hooks/useSetupProgress.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import type { SetupProgress } from "@/lib/api/marketplace-api";
+
+const MAX_SSE_RETRIES = 5;
+const POLL_INTERVAL_MS = 30_000;
+
+/**
+ * Live store-setup progress. Subscribes to the setup-progress SSE stream
+ * (proxied through /api/admin so the BFF session applies) and falls back
+ * to 30s polling if the stream can't be established. Returns the latest
+ * SetupProgress, seeded with the server-rendered snapshot so there is no
+ * flash of empty state.
+ *
+ * The subscription tears itself down once every step is complete — the
+ * server also ends the stream at 100%, so a finished store costs nothing.
+ */
+export function useSetupProgress(
+  storeId: string,
+  initial: SetupProgress,
+): SetupProgress {
+  const [progress, setProgress] = useState<SetupProgress>(initial);
+  const doneRef = useRef(initial.completed_steps === initial.total_steps);
+
+  useEffect(() => {
+    if (doneRef.current) return;
+
+    let stopped = false;
+    let source: EventSource | null = null;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let pollTimer: ReturnType<typeof setInterval> | null = null;
+    let retries = 0;
+
+    const apply = (next: SetupProgress) => {
+      setProgress(next);
+      if (next.completed_steps === next.total_steps) {
+        doneRef.current = true;
+        teardown();
+      }
+    };
+
+    const teardown = () => {
+      stopped = true;
+      source?.close();
+      source = null;
+      if (retryTimer) clearTimeout(retryTimer);
+      if (pollTimer) clearInterval(pollTimer);
+    };
+
+    const startPolling = () => {
+      if (stopped || pollTimer) return;
+      pollTimer = setInterval(async () => {
+        try {
+          const res = await fetch(
+            `/api/admin/stores/${storeId}/setup-progress`,
+            { cache: "no-store" },
+          );
+          if (!res.ok) return;
+          apply((await res.json()) as SetupProgress);
+        } catch {
+          // transient network failure — next tick retries
+        }
+      }, POLL_INTERVAL_MS);
+    };
+
+    const connect = () => {
+      if (stopped) return;
+      source = new EventSource(
+        `/api/admin/stores/${storeId}/setup-progress/stream`,
+      );
+      source.onopen = () => {
+        // A successful (re)connect clears the backoff budget, so routine
+        // server-side stream rotation (30-min max age) never degrades a
+        // healthy client to polling.
+        retries = 0;
+      };
+      source.addEventListener("progress", (event) => {
+        try {
+          apply(JSON.parse((event as MessageEvent).data) as SetupProgress);
+        } catch {
+          // malformed frame — ignore, the next one supersedes it
+        }
+      });
+      source.onerror = () => {
+        source?.close();
+        source = null;
+        if (stopped) return;
+        retries += 1;
+        if (retries <= MAX_SSE_RETRIES) {
+          // Exponential backoff capped at 15s: 1s, 2s, 4s, 8s, 15s.
+          const delay = Math.min(1000 * 2 ** (retries - 1), 15_000);
+          retryTimer = setTimeout(connect, delay);
+        } else {
+          startPolling();
+        }
+      };
+    };
+
+    connect();
+    return teardown;
+  }, [storeId]);
+
+  return progress;
+}

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -817,6 +817,10 @@ func main() {
 		// Dashboard D1 wiring.
 		dashboardHandler := admin.NewDashboardHandler(conn, log)
 
+		// Setup-progress realtime wiring (snapshot + SSE + WS) — shares
+		// the dashboard's checklist computation.
+		setupProgressHandler := admin.NewSetupProgressHandler(conn, log)
+
 		// Tickets D2 wiring — uses the shared ticketSvc hoisted above so
 		// the storefront /support/tickets endpoint and the admin dashboard
 		// read/write the same rows through the same service instance.
@@ -1003,6 +1007,7 @@ func main() {
 			AuditLogsHandler:         auditLogsHandler,
 			NotificationsHandler:     notificationsHandler,
 			DashboardHandler:         dashboardHandler,
+			SetupProgressHandler:     setupProgressHandler,
 			TicketsHandler:           ticketsHandler,
 			BrandingHandler:          brandingHandler,
 			PagesHandler:             pagesHandler,

--- a/services/marketplace-api/go.mod
+++ b/services/marketplace-api/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/joho/godotenv v1.5.1
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/services/marketplace-api/go.sum
+++ b/services/marketplace-api/go.sum
@@ -208,6 +208,8 @@ github.com/googleapis/gax-go/v2 v2.23.0 h1:Tchl7qkvE7Ip3y+ztvNufYFvkfqTe7NfLTYGI
 github.com/googleapis/gax-go/v2 v2.23.0/go.mod h1:rBQKOVJCdb8IFEzg+FCwlt1LP/xMDGuqUXhUG+XMXEg=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
 github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/services/marketplace-api/internal/handlers/admin/dashboard.go
+++ b/services/marketplace-api/internal/handlers/admin/dashboard.go
@@ -74,6 +74,7 @@ type SetupChecklist struct {
 	HasShippingCarrier bool `json:"has_shipping_carrier"`
 	HasReturnPolicy    bool `json:"has_return_policy"`
 	HasCustomDomain    bool `json:"has_custom_domain"`
+	HasFirstOrder      bool `json:"has_first_order"`
 }
 
 // DashboardResponse is the top-level envelope returned by GET .../dashboard.
@@ -322,28 +323,9 @@ func (h *DashboardHandler) Get(c *gin.Context) {
 		})
 	}
 
-	// Setup checklist — individual EXISTS queries.
-	var checklist SetupChecklist
-	checklist.HasStore = true // always true if we got here (store middleware passed)
-
-	db.Raw(`SELECT EXISTS(SELECT 1 FROM products WHERE store_id = ? AND tenant_id = ?)`,
-		storeID, tenantID).Scan(&checklist.HasProduct)
-	db.Raw(`SELECT EXISTS(SELECT 1 FROM store_branding
-		WHERE store_id = ? AND tenant_id = ?
-		AND logo_url IS NOT NULL AND logo_url != '')`,
-		storeID, tenantID).Scan(&checklist.HasBrandAssets)
-	db.Raw(`SELECT EXISTS(SELECT 1 FROM payment_gateway_configs WHERE store_id = ? AND tenant_id = ?)`,
-		storeID, tenantID).Scan(&checklist.HasPaymentProvider)
-	db.Raw(`SELECT EXISTS(SELECT 1 FROM shipping_carrier_configs WHERE store_id = ? AND tenant_id = ?)`,
-		storeID, tenantID).Scan(&checklist.HasShippingCarrier)
-	db.Raw(`SELECT EXISTS(SELECT 1 FROM store_branding
-		WHERE store_id = ? AND tenant_id = ?
-		AND return_policy IS NOT NULL AND return_policy != '')`,
-		storeID, tenantID).Scan(&checklist.HasReturnPolicy)
-	db.Raw(`SELECT EXISTS(SELECT 1 FROM custom_domains WHERE store_id = ? AND tenant_id = ?)`,
-		storeID, tenantID).Scan(&checklist.HasCustomDomain)
-	db.Raw(`SELECT EXISTS(SELECT 1 FROM store_branding WHERE store_id = ? AND tenant_id = ?)`,
-		storeID, tenantID).Scan(&checklist.HasStorefrontTheme)
+	// Setup checklist — shared with the setup-progress endpoints (see
+	// setupprogress.go) so the dashboard and the realtime stream agree.
+	checklist := computeSetupChecklist(db, storeID, tenantID)
 
 	resp := DashboardResponse{
 		Stats:          stats,

--- a/services/marketplace-api/internal/handlers/admin/routes.go
+++ b/services/marketplace-api/internal/handlers/admin/routes.go
@@ -76,6 +76,7 @@ type Deps struct {
 	AuditLogsHandler         *AuditLogsHandler
 	NotificationsHandler     *NotificationsHandler
 	DashboardHandler         *DashboardHandler
+	SetupProgressHandler     *SetupProgressHandler
 	TicketsHandler           *TicketsHandler
 	ShipmentsHandler         *ShipmentsHandler
 	BrandingHandler          *BrandingHandler
@@ -795,6 +796,16 @@ func RegisterAdmin(router *gin.RouterGroup, deps Deps) {
 			metrics.GET("/orders", deps.DashboardHandler.GetOrdersMetrics)
 			metrics.GET("/customers", deps.DashboardHandler.GetCustomersMetrics)
 			metrics.GET("/reviews", deps.DashboardHandler.GetReviewsMetrics)
+		}
+
+		// Setup progress — snapshot + realtime (SSE / WebSocket) for the
+		// dashboard onboarding checklist.
+		if deps.SetupProgressHandler != nil {
+			setup := storeRoute.Group("/dashboard/setup-progress")
+			setup.Use(deps.AuthzMiddleware.RequireTenantRelation(authz.RoleStaff))
+			setup.GET("", deps.SetupProgressHandler.Get)
+			setup.GET("/stream", deps.SetupProgressHandler.Stream)
+			setup.GET("/ws", deps.SetupProgressHandler.WS)
 		}
 
 		// Tickets — D2.

--- a/services/marketplace-api/internal/handlers/admin/setupprogress.go
+++ b/services/marketplace-api/internal/handlers/admin/setupprogress.go
@@ -1,0 +1,308 @@
+// Package admin — setupprogress.go: store-setup progress endpoints.
+//
+// The dashboard's setup checklist gets its own read model + realtime
+// endpoints so the admin UI can show live progress while the merchant
+// completes onboarding steps on other pages or in other tabs:
+//
+//	GET /admin/stores/:storeId/dashboard/setup-progress         — JSON snapshot
+//	GET /admin/stores/:storeId/dashboard/setup-progress/stream  — SSE
+//	GET /admin/stores/:storeId/dashboard/setup-progress/ws      — WebSocket
+//
+// Progress counts a "Create your store" pseudo-step that is complete by
+// definition (the store row exists), so a brand-new store starts at
+// 2/10 = 20% (store created + settings prefilled from onboarding) rather
+// than a demoralising 0% — the LinkedIn profile-strength pattern.
+//
+// Both realtime transports share the same watch loop: recompute the
+// checklist every pollInterval and push only when something changed.
+// The EXISTS queries are cheap (all hit small per-store tables through
+// indexed store_id/tenant_id columns), and the stream ends itself once
+// setup is complete or maxStreamAge elapses, so an abandoned tab does
+// not hold a connection forever.
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+)
+
+const (
+	// pollInterval is how often the watch loop recomputes the checklist.
+	pollInterval = 3 * time.Second
+	// heartbeatInterval keeps intermediaries from timing out idle streams.
+	heartbeatInterval = 20 * time.Second
+	// maxStreamAge bounds a single connection; clients reconnect.
+	maxStreamAge = 30 * time.Minute
+	// totalSetupSteps = 1 pseudo-step (store created) + 9 checklist flags.
+	totalSetupSteps = 10
+)
+
+// SetupProgress is the wire format shared by the snapshot, SSE, and WS
+// endpoints. Percent is integer 0–100 so the client never has to round.
+type SetupProgress struct {
+	Checklist      SetupChecklist `json:"checklist"`
+	CompletedSteps int            `json:"completed_steps"`
+	TotalSteps     int            `json:"total_steps"`
+	Percent        int            `json:"percent"`
+}
+
+// computeSetupChecklist runs the per-flag EXISTS queries. Shared with the
+// dashboard aggregation endpoint so the two can never drift.
+func computeSetupChecklist(db *gorm.DB, storeID, tenantID uuid.UUID) SetupChecklist {
+	var checklist SetupChecklist
+	checklist.HasStore = true // store middleware passed → the store exists
+
+	db.Raw(`SELECT EXISTS(SELECT 1 FROM products WHERE store_id = ? AND tenant_id = ?)`,
+		storeID, tenantID).Scan(&checklist.HasProduct)
+	db.Raw(`SELECT EXISTS(SELECT 1 FROM store_branding
+		WHERE store_id = ? AND tenant_id = ?
+		AND logo_url IS NOT NULL AND logo_url != '')`,
+		storeID, tenantID).Scan(&checklist.HasBrandAssets)
+	db.Raw(`SELECT EXISTS(SELECT 1 FROM payment_gateway_configs WHERE store_id = ? AND tenant_id = ?)`,
+		storeID, tenantID).Scan(&checklist.HasPaymentProvider)
+	db.Raw(`SELECT EXISTS(SELECT 1 FROM shipping_carrier_configs WHERE store_id = ? AND tenant_id = ?)`,
+		storeID, tenantID).Scan(&checklist.HasShippingCarrier)
+	db.Raw(`SELECT EXISTS(SELECT 1 FROM store_branding
+		WHERE store_id = ? AND tenant_id = ?
+		AND return_policy IS NOT NULL AND return_policy != '')`,
+		storeID, tenantID).Scan(&checklist.HasReturnPolicy)
+	db.Raw(`SELECT EXISTS(SELECT 1 FROM custom_domains WHERE store_id = ? AND tenant_id = ?)`,
+		storeID, tenantID).Scan(&checklist.HasCustomDomain)
+	db.Raw(`SELECT EXISTS(SELECT 1 FROM store_branding WHERE store_id = ? AND tenant_id = ?)`,
+		storeID, tenantID).Scan(&checklist.HasStorefrontTheme)
+	db.Raw(`SELECT EXISTS(SELECT 1 FROM orders WHERE store_id = ? AND tenant_id = ?)`,
+		storeID, tenantID).Scan(&checklist.HasFirstOrder)
+
+	return checklist
+}
+
+// progressFrom wraps a checklist in the SetupProgress envelope, counting
+// the always-complete "store created" pseudo-step.
+func progressFrom(c SetupChecklist) SetupProgress {
+	completed := 1 // pseudo-step: the store was created
+	for _, done := range []bool{
+		c.HasStore, c.HasBrandAssets, c.HasProduct, c.HasStorefrontTheme,
+		c.HasPaymentProvider, c.HasShippingCarrier, c.HasReturnPolicy,
+		c.HasCustomDomain, c.HasFirstOrder,
+	} {
+		if done {
+			completed++
+		}
+	}
+	return SetupProgress{
+		Checklist:      c,
+		CompletedSteps: completed,
+		TotalSteps:     totalSetupSteps,
+		Percent:        completed * 100 / totalSetupSteps,
+	}
+}
+
+// ---------- Handler ----------
+
+// SetupProgressHandler serves the setup-progress snapshot and realtime
+// stream endpoints.
+type SetupProgressHandler struct {
+	db     *gorm.DB
+	logger *slog.Logger
+}
+
+// NewSetupProgressHandler constructs a SetupProgressHandler.
+func NewSetupProgressHandler(db *gorm.DB, logger *slog.Logger) *SetupProgressHandler {
+	return &SetupProgressHandler{db: db, logger: logger}
+}
+
+func (h *SetupProgressHandler) ids(c *gin.Context) (storeID, tenantID uuid.UUID, ok bool) {
+	storeID, err := uuid.Parse(c.Param("storeId"))
+	if err != nil {
+		RespondErr(c, apperrors.ValidationFailed("storeId", "invalid uuid"), h.logger)
+		return uuid.Nil, uuid.Nil, false
+	}
+	tenantID, err = uuid.Parse(c.GetString("tenant_id"))
+	if err != nil {
+		RespondErr(c, apperrors.ValidationFailed("tenant_id", "invalid uuid"), h.logger)
+		return uuid.Nil, uuid.Nil, false
+	}
+	return storeID, tenantID, true
+}
+
+// Get handles GET /admin/stores/:storeId/dashboard/setup-progress.
+func (h *SetupProgressHandler) Get(c *gin.Context) {
+	storeID, tenantID, ok := h.ids(c)
+	if !ok {
+		return
+	}
+	db := h.db.WithContext(c.Request.Context())
+	c.Header("Cache-Control", "private, no-store")
+	c.JSON(http.StatusOK, progressFrom(computeSetupChecklist(db, storeID, tenantID)))
+}
+
+// Stream handles GET /admin/stores/:storeId/dashboard/setup-progress/stream
+// as Server-Sent Events. Sends the current snapshot immediately, then a
+// "progress" event whenever a step flips, and ": ping" comments as
+// heartbeats. Ends once setup is complete.
+func (h *SetupProgressHandler) Stream(c *gin.Context) {
+	storeID, tenantID, ok := h.ids(c)
+	if !ok {
+		return
+	}
+
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	// Disable proxy buffering (nginx/istio sidecars) so events flush through.
+	c.Writer.Header().Set("X-Accel-Buffering", "no")
+	c.Writer.WriteHeader(http.StatusOK)
+
+	send := func(p SetupProgress) bool {
+		data, err := json.Marshal(p)
+		if err != nil {
+			return false
+		}
+		if _, err := fmt.Fprintf(c.Writer, "event: progress\ndata: %s\n\n", data); err != nil {
+			return false
+		}
+		c.Writer.Flush()
+		return true
+	}
+
+	db := h.db.WithContext(c.Request.Context())
+	last := progressFrom(computeSetupChecklist(db, storeID, tenantID))
+	if !send(last) {
+		return
+	}
+	if last.CompletedSteps == last.TotalSteps {
+		return // nothing left to watch
+	}
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	heartbeat := time.NewTicker(heartbeatInterval)
+	defer heartbeat.Stop()
+	deadline := time.NewTimer(maxStreamAge)
+	defer deadline.Stop()
+	ctx := c.Request.Context()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-deadline.C:
+			return // client reconnects with a fresh stream
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(c.Writer, ": ping\n\n"); err != nil {
+				return
+			}
+			c.Writer.Flush()
+		case <-ticker.C:
+			cur := progressFrom(computeSetupChecklist(db, storeID, tenantID))
+			if cur.Checklist == last.Checklist {
+				continue
+			}
+			last = cur
+			if !send(cur) {
+				return
+			}
+			if cur.CompletedSteps == cur.TotalSteps {
+				return // setup finished — let the client celebrate and close
+			}
+		}
+	}
+}
+
+// wsUpgrader relies on the auth middleware chain (header-trust +
+// RequireTenantRelation) for access control; the Origin header is not a
+// trust boundary here because browsers cannot reach this endpoint
+// without the proxy-injected identity headers.
+var wsUpgrader = websocket.Upgrader{
+	ReadBufferSize:  512,
+	WriteBufferSize: 1024,
+	CheckOrigin:     func(*http.Request) bool { return true },
+}
+
+// WS handles GET /admin/stores/:storeId/dashboard/setup-progress/ws,
+// pushing the same SetupProgress JSON frames over a WebSocket. Same watch
+// loop as Stream; the connection closes once setup completes.
+func (h *SetupProgressHandler) WS(c *gin.Context) {
+	storeID, tenantID, ok := h.ids(c)
+	if !ok {
+		return
+	}
+
+	conn, err := wsUpgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		return // Upgrade already wrote the HTTP error
+	}
+	defer conn.Close()
+
+	// Reader pump: we never expect client frames, but reading is required
+	// to process control frames and notice the peer going away.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn.SetReadLimit(512)
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	writeJSON := func(p SetupProgress) bool {
+		_ = conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+		return conn.WriteJSON(p) == nil
+	}
+
+	db := h.db.WithContext(c.Request.Context())
+	last := progressFrom(computeSetupChecklist(db, storeID, tenantID))
+	if !writeJSON(last) {
+		return
+	}
+	if last.CompletedSteps == last.TotalSteps {
+		return
+	}
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	heartbeat := time.NewTicker(heartbeatInterval)
+	defer heartbeat.Stop()
+	deadline := time.NewTimer(maxStreamAge)
+	defer deadline.Stop()
+
+	for {
+		select {
+		case <-done:
+			return
+		case <-c.Request.Context().Done():
+			return
+		case <-deadline.C:
+			return
+		case <-heartbeat.C:
+			_ = conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		case <-ticker.C:
+			cur := progressFrom(computeSetupChecklist(db, storeID, tenantID))
+			if cur.Checklist == last.Checklist {
+				continue
+			}
+			last = cur
+			if !writeJSON(cur) {
+				return
+			}
+			if cur.CompletedSteps == cur.TotalSteps {
+				return
+			}
+		}
+	}
+}

--- a/services/marketplace-api/internal/handlers/admin/setupprogress_test.go
+++ b/services/marketplace-api/internal/handlers/admin/setupprogress_test.go
@@ -1,0 +1,41 @@
+package admin
+
+import "testing"
+
+// A brand-new store (only the store row + prefilled settings exist) must
+// start at exactly 20% — the "head start" the dashboard promises. If a
+// step is ever added or removed, this pins the recalibration.
+func TestProgressFromNewStore(t *testing.T) {
+	p := progressFrom(SetupChecklist{HasStore: true})
+
+	if p.CompletedSteps != 2 {
+		t.Fatalf("new store completed_steps = %d, want 2 (store created + prefilled settings)", p.CompletedSteps)
+	}
+	if p.TotalSteps != totalSetupSteps {
+		t.Fatalf("total_steps = %d, want %d", p.TotalSteps, totalSetupSteps)
+	}
+	if p.Percent != 20 {
+		t.Fatalf("new store percent = %d, want 20", p.Percent)
+	}
+}
+
+func TestProgressFromAllComplete(t *testing.T) {
+	p := progressFrom(SetupChecklist{
+		HasStore:           true,
+		HasBrandAssets:     true,
+		HasProduct:         true,
+		HasStorefrontTheme: true,
+		HasPaymentProvider: true,
+		HasShippingCarrier: true,
+		HasReturnPolicy:    true,
+		HasCustomDomain:    true,
+		HasFirstOrder:      true,
+	})
+
+	if p.CompletedSteps != p.TotalSteps {
+		t.Fatalf("completed_steps = %d, want %d", p.CompletedSteps, p.TotalSteps)
+	}
+	if p.Percent != 100 {
+		t.Fatalf("percent = %d, want 100", p.Percent)
+	}
+}


### PR DESCRIPTION
## What

- **20% head start (LinkedIn pattern):** the dashboard checklist now counts a 'Create your store' pseudo-step + the settings prefilled during onboarding, so a brand-new store opens at 2/10 = 20% instead of a demoralising 0%. New final step **Make your first sale** (`has_first_order`) completes the go-live arc at 100%.
- **Realtime progress:** marketplace-api gains `GET .../dashboard/setup-progress` (snapshot), `.../stream` (SSE), and `.../ws` (WebSocket), all sharing one checklist computation with the dashboard aggregate. Streams push only on change, heartbeat every 20s, self-terminate at 100% or after 30min.
- **Admin UI:** `SetupChecklist` subscribes via SSE through the session-authenticated Next proxy, with exponential-backoff reconnect and a 30s polling fallback. Steps completed in another tab flip live with a 'Done!' pulse; finishing setup during the session shows a celebration banner instead of the section silently vanishing. Percent readout added next to the progress bar.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./internal/handlers/admin/` — pass (new tests pin the 20% / 100% math)
- `tsc --noEmit` on apps/admin — clean