### PR TITLE
fix(admin): dashboard stat-row UX — sparkline ownership, currency, orders subtitle

### DIFF
--- a/apps/admin/app/(admin)/dashboard/page.tsx
+++ b/apps/admin/app/(admin)/dashboard/page.tsx
@@ -136,12 +136,25 @@ function DashboardContent({
               label="Revenue today"
               value={formatCurrency(stats.revenue_today, currencyCode)}
               changePercent={stats.revenue_change_pct}
-              sparkline={<RevenueSparkline data={stats.revenue_trend} />}
+              sparkline={
+                <RevenueSparkline
+                  data={stats.revenue_trend}
+                  currencyCode={currencyCode}
+                />
+              }
             />
+            {/* Subtitle shows the actionable all-time backlog, not a
+                today-scoped breakdown — "2 pending / 1 fulfilled" under a
+                "6 today" headline read as contradictory arithmetic. */}
             <StatCard
               label="Orders today"
               value={String(stats.orders_today)}
-              subtitle={`${stats.orders_pending} pending / ${stats.orders_fulfilled} fulfilled`}
+              subtitle={
+                stats.orders_pending > 0
+                  ? `${stats.orders_pending} awaiting fulfillment`
+                  : undefined
+              }
+              href="/orders?status=pending"
             />
             <StatCard
               label="Total customers"

--- a/apps/admin/components/dashboard/RevenueSparkline.tsx
+++ b/apps/admin/components/dashboard/RevenueSparkline.tsx
@@ -4,12 +4,15 @@ import { Line, LineChart, ResponsiveContainer, Tooltip } from "recharts";
 
 interface RevenueSparklineProps {
   data: number[];
+  /** ISO 4217 code of the store's currency — the tooltip must match the
+      headline value, not assume USD. */
+  currencyCode: string;
 }
 
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat("en-US", {
+function formatCurrency(value: number, currencyCode: string): string {
+  return new Intl.NumberFormat(undefined, {
     style: "currency",
-    currency: "USD",
+    currency: currencyCode,
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   }).format(value);
@@ -18,26 +21,28 @@ function formatCurrency(value: number): string {
 function SparklineTooltip({
   active,
   payload,
+  currencyCode,
 }: {
   active?: boolean;
   payload?: Array<{ payload: { day: string; value: number } }>;
+  currencyCode: string;
 }) {
   if (!active || !payload?.[0]) return null;
   const { day, value } = payload[0].payload;
   return (
     <div className="rounded bg-foreground px-2 py-1 text-xs text-background shadow">
       <p>{day}</p>
-      <p className="font-medium">{formatCurrency(value)}</p>
+      <p className="font-medium">{formatCurrency(value, currencyCode)}</p>
     </div>
   );
 }
 
-export function RevenueSparkline({ data }: RevenueSparklineProps) {
+export function RevenueSparkline({ data, currencyCode }: RevenueSparklineProps) {
   const allZero = data.every((v) => v === 0);
 
   if (allZero) {
     return (
-      <div className="flex h-[50px] w-[100px] items-end justify-center">
+      <div className="relative flex h-10 w-full items-end justify-center">
         <div className="mb-2 w-full border-t border-dashed border-foreground-tertiary/40" />
         <p className="absolute text-[10px] text-foreground-tertiary">
           No sales yet
@@ -57,18 +62,19 @@ export function RevenueSparkline({ data }: RevenueSparklineProps) {
   });
 
   return (
-    <div className="h-[50px] w-[100px]">
+    <div className="h-10 w-full">
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={chartData}>
           <Tooltip
-            content={<SparklineTooltip />}
+            content={<SparklineTooltip currencyCode={currencyCode} />}
             cursor={false}
           />
           <Line
             type="monotone"
             dataKey="value"
             stroke="var(--moss-700)"
-            strokeWidth={2}
+            strokeWidth={1.5}
+            strokeOpacity={0.7}
             strokeLinecap="round"
             dot={false}
             activeDot={{ r: 3, fill: "var(--moss-700)" }}

--- a/apps/admin/components/dashboard/StatCard.tsx
+++ b/apps/admin/components/dashboard/StatCard.tsx
@@ -25,33 +25,38 @@ export function StatCard({
       <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-foreground-tertiary">
         {label}
       </p>
-      <div className="mt-3 flex items-end justify-between gap-4">
-        <div className="space-y-1">
-          <p className="font-serif text-4xl font-medium tabular-nums text-foreground">
-            {value}
-          </p>
-          <div className="flex items-center gap-2">
-            {changePercent !== undefined && changePercent !== 0 && (
-              <span
-                className={`text-xs font-medium ${
-                  changePercent > 0
-                    ? "text-[color:var(--moss-700)]"
-                    : "text-[color:var(--signal)]"
-                }`}
-              >
-                {changePercent > 0 ? "+" : ""}
-                {changePercent.toFixed(1)}%
-              </span>
-            )}
-            {subtitle && (
-              <span className="text-xs text-foreground-secondary">
-                {subtitle}
-              </span>
-            )}
-          </div>
+      <div className="mt-3 space-y-1">
+        <p className="font-serif text-4xl font-medium tabular-nums text-foreground">
+          {value}
+        </p>
+        <div className="flex items-center gap-2">
+          {changePercent !== undefined && changePercent !== 0 && (
+            <span
+              className={`text-xs font-medium ${
+                changePercent > 0
+                  ? "text-[color:var(--moss-700)]"
+                  : "text-[color:var(--signal)]"
+              }`}
+            >
+              {changePercent > 0 ? "+" : ""}
+              {changePercent.toFixed(1)}%
+            </span>
+          )}
+          {subtitle && (
+            <span className="text-xs text-foreground-secondary">
+              {subtitle}
+            </span>
+          )}
         </div>
-        {sparkline && <div className="shrink-0">{sparkline}</div>}
       </div>
+      {/* Full-width under the value so the trend line reads as part of
+          THIS stat — right-aligned next to the cell edge it visually
+          attached to the neighbouring card's number. */}
+      {sparkline && (
+        <div className="mt-3" aria-hidden="true">
+          {sparkline}
+        </div>
+      )}
     </>
   );
 


### PR DESCRIPTION
Fixes three issues on the dashboard stat row, judged against the UX baseline (NN/g heuristics #1/#2/#4):

- **Sparkline misread as an artifact**: the revenue trend line sat right-aligned at the cell edge, visually attaching to the neighbouring card's number (screenshot showed it as a strikethrough under 'Orders today: 6'). Now renders full-width beneath the revenue value — unambiguous ownership.
- **Wrong currency in tooltip**: sparkline tooltip hardcoded USD; now formats with the store's currency (INR stores were showing dollar values). Also fixes the all-zero state's missing relative parent.
- **Contradictory arithmetic**: '6 orders today' subtitled '2 pending / 1 fulfilled' mixed all-time status counts into a today-scoped headline. Subtitle is now the actionable '2 awaiting fulfillment' and the card links to /orders?status=pending.

Verified with tsc --noEmit.