### PR TITLE
feat(admin): motion polish — page entrance, checklist glide, fix dead fadeInUp

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -122,6 +122,24 @@
   }
 }
 
+/* ============================================================
+   Motion keyframes — shared entrance animation. error.tsx and
+   AdminPage reference fadeInUp via Tailwind arbitrary animation
+   values; the keyframes must exist globally or those classes
+   silently no-op.
+   ============================================================ */
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;

--- a/apps/admin/components/dashboard/SetupChecklist.tsx
+++ b/apps/admin/components/dashboard/SetupChecklist.tsx
@@ -181,8 +181,18 @@ export function SetupChecklist({ checklist, storeId }: SetupChecklistProps) {
         />
       </div>
 
-      {!collapsed && (
-        <div className="mt-6 space-y-6">
+      {/* Always mounted; grid-rows 0fr→1fr animates the height so
+          expand/collapse glides instead of jump-cutting. inert + hidden
+          keep the collapsed content out of tab order and the a11y tree. */}
+      <div
+        className={`grid transition-[grid-template-rows] duration-300 ease-out ${
+          collapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]"
+        }`}
+        inert={collapsed || undefined}
+        aria-hidden={collapsed}
+      >
+        <div className="overflow-hidden">
+          <div className="mt-6 space-y-6 pb-1">
           {phases.map((phase) => {
             const phaseItems = items.filter((item) => item.phase === phase);
             return (
@@ -235,8 +245,9 @@ export function SetupChecklist({ checklist, storeId }: SetupChecklistProps) {
               </div>
             );
           })}
+          </div>
         </div>
-      )}
+      </div>
     </section>
   );
 }

--- a/apps/admin/components/layout/AdminPage.tsx
+++ b/apps/admin/components/layout/AdminPage.tsx
@@ -61,8 +61,12 @@ export function AdminPage({
   // Width is owned by the (admin) layout's <main> wrapper (max-w-5xl).
   // AdminPage only handles the inner header + rhythm — no container
   // wrapper of its own, so pages don't double-nest max-widths.
+  //
+  // The entrance animation smooths the skeleton→content swap on route
+  // changes (M3 "emphasized decelerate" feel via ease-out-expo). Guarded
+  // by motion-safe; prefers-reduced-motion users get an instant swap.
   return (
-    <div className="space-y-10">
+    <div className="space-y-10 motion-safe:animate-[fadeInUp_0.35s_var(--ease-out)_both]">
       <header className="space-y-4">
         <div className="flex flex-wrap items-end justify-between gap-x-6 gap-y-4">
           <div className="min-w-0 flex-1 space-y-3">


### PR DESCRIPTION
Smoothness pass on the admin, applying the motion baseline added to the UX reference issue (single ease-out-expo curve, 150/220/350ms tiers, motion-safe guards):

- **Define the missing `fadeInUp` keyframes** — error.tsx referenced them via an arbitrary animation class but no @keyframes existed anywhere, so it silently no-opped.
- **Page entrance** — AdminPage content fades/rises 6px on mount (350ms, `var(--ease-out)`, `motion-safe:` only), smoothing the skeleton→content swap on every route change.
- **Checklist glide** — Store-setup expand/collapse now animates via `grid-template-rows` 0fr→1fr (300ms) with `inert`/`aria-hidden` while collapsed, replacing the instant mount/unmount jump-cut.

All guarded for prefers-reduced-motion (global override + motion-safe). Verified with tsc --noEmit.