### PR TITLE
feat(onboarding): funnel UX — step indicator, head-start progress, form polish

### DIFF
--- a/apps/onboarding/app/onboarding/check-inbox/page.tsx
+++ b/apps/onboarding/app/onboarding/check-inbox/page.tsx
@@ -10,6 +10,7 @@ export const metadata = {
 export default function CheckInboxPage() {
   return (
     <PostSubmitShell
+      step={2}
       eyebrow="Email confirmation"
       title="Your store is one click away."
       description="We sent your verification link. Open it on this device and we’ll carry you straight into the last setup step."

--- a/apps/onboarding/app/onboarding/page.tsx
+++ b/apps/onboarding/app/onboarding/page.tsx
@@ -43,7 +43,10 @@ export default async function OnboardingPage() {
         </div>
       </header>
 
-      <main id="main" className="flex-1">
+      <main
+        id="main"
+        className="flex-1 motion-safe:animate-[fadeInUp_0.35s_ease-out_both]"
+      >
         <div className="mx-auto grid max-w-6xl gap-12 px-6 pb-20 pt-16 sm:pt-20 lg:grid-cols-[1fr_1.2fr] lg:gap-16">
           <section>
             <p className="eyebrow mb-5">Open your store</p>

--- a/apps/onboarding/app/onboarding/set-password/page.tsx
+++ b/apps/onboarding/app/onboarding/set-password/page.tsx
@@ -45,6 +45,7 @@ export default async function SetPasswordPage({ searchParams }: PageProps) {
 
   return (
     <PostSubmitShell
+      step={3}
       eyebrow="Final step"
       title="Finish creating your account."
       description="Your email is verified. Add a password or continue with Google so we can open your admin dashboard."

--- a/apps/onboarding/app/onboarding/verify/page.tsx
+++ b/apps/onboarding/app/onboarding/verify/page.tsx
@@ -15,6 +15,7 @@ export const metadata = {
 export default function VerifyPage() {
   return (
     <PostSubmitShell
+      step={2}
       eyebrow="Verification in progress"
       title="We’re preparing your workspace."
       description="We&apos;re confirming your email and moving your session forward. This usually takes a moment."

--- a/apps/onboarding/app/welcome/page.tsx
+++ b/apps/onboarding/app/welcome/page.tsx
@@ -22,6 +22,24 @@ export default function WelcomePage() {
       description="You&rsquo;re signed in. Step into the admin dashboard to add your first product, shape your storefront, and confirm your settings."
     >
       <div className="border-t border-border-subtle pt-10">
+        {/* Head start — same 20% the admin checklist opens with, so the
+            momentum promise carries across apps without a reset to zero. */}
+        <div className="mb-10 max-w-md">
+          <div className="flex items-baseline justify-between">
+            <p className="eyebrow">Store setup</p>
+            <p className="font-serif text-xl font-medium text-moss-700 tabular-nums">
+              20%
+            </p>
+          </div>
+          <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-ink-900/10">
+            <div className="h-full w-1/5 rounded-full bg-moss-700 motion-safe:animate-[fadeInUp_0.6s_ease-out_both]" />
+          </div>
+          <p className="mt-3 text-sm text-foreground-secondary">
+            Creating your store already completed the first steps. Finish the
+            checklist in your admin to go live.
+          </p>
+        </div>
+
         <WelcomeCta />
 
         <dl className="mt-16 grid gap-10 border-t border-border-subtle pt-10 sm:grid-cols-2">

--- a/apps/onboarding/components/onboarding/OnboardingForm.tsx
+++ b/apps/onboarding/components/onboarding/OnboardingForm.tsx
@@ -242,13 +242,18 @@ export function OnboardingForm({ countries, currencies, timezones }: Props) {
     }
   }
 
-  const canSubmit = slugAvailability.state === "available" && !pending && !screenshotUploading;
+  // Only disable while genuinely busy. Gating the button on slug
+  // availability left a mystery-disabled submit on first load (NN/g:
+  // disabled buttons must explain themselves) — instead, submitting
+  // with an unavailable slug surfaces the error and focuses the field.
+  const canSubmit = !pending && !screenshotUploading;
 
   function onValid(values: FormValues) {
     setSubmitError(null);
 
     if (slugAvailability.state !== "available") {
       setSubmitError("Please pick an available store URL.");
+      document.getElementById("slug")?.focus();
       return;
     }
 
@@ -498,9 +503,18 @@ export function OnboardingForm({ countries, currencies, timezones }: Props) {
             </span>
           </label>
 
-          {isMigrating && (
+          {/* Always mounted; grid-rows 0fr→1fr glides the evidence panel
+              open instead of jump-cutting it into the layout. */}
+          <div
+            className={`grid transition-[grid-template-rows] duration-300 ease-out ${
+              isMigrating ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+            }`}
+            inert={!isMigrating || undefined}
+            aria-hidden={!isMigrating}
+          >
+            <div className="overflow-hidden">
             <div
-              className="mt-3 space-y-4 border-l-2 border-moss-200 pl-4"
+              className="mt-3 space-y-4 border-l-2 border-moss-200 pl-4 pb-1"
               data-testid="migration-evidence-panel"
             >
               {/* WHOIS URL */}
@@ -578,7 +592,8 @@ export function OnboardingForm({ countries, currencies, timezones }: Props) {
                 </p>
               )}
             </div>
-          )}
+            </div>
+          </div>
         </fieldset>
 
         {/* Server-level submit error */}

--- a/apps/onboarding/components/onboarding/PostSubmitShell.tsx
+++ b/apps/onboarding/components/onboarding/PostSubmitShell.tsx
@@ -7,8 +7,18 @@ interface PostSubmitShellProps {
   eyebrow: string;
   title: string;
   description: string;
+  /**
+   * Position in the 3-step funnel (1 = signup form, 2 = verify email,
+   * 3 = set password). When set, a quiet "Step N of 3" indicator with
+   * progress dots renders above the eyebrow so the user always knows
+   * where they are and how much is left (NN/g heuristic #1 — visibility
+   * of system status). Omit on terminal pages like /welcome.
+   */
+  step?: 1 | 2 | 3;
   children: ReactNode;
 }
+
+const TOTAL_STEPS = 3;
 
 /**
  * PostSubmitShell — wrapper used by every page after the
@@ -24,6 +34,7 @@ export function PostSubmitShell({
   eyebrow,
   title,
   description,
+  step,
   children,
 }: PostSubmitShellProps) {
   return (
@@ -43,8 +54,30 @@ export function PostSubmitShell({
         </div>
       </header>
 
-      <main id="main" className="flex-1">
+      <main
+        id="main"
+        className="flex-1 motion-safe:animate-[fadeInUp_0.35s_ease-out_both]"
+      >
         <section className="mx-auto max-w-3xl px-6 pb-16 pt-16 sm:pb-20 sm:pt-24">
+          {step && (
+            <div className="mb-6 flex items-center gap-3">
+              <div className="flex items-center gap-1.5" aria-hidden="true">
+                {Array.from({ length: TOTAL_STEPS }, (_, i) => (
+                  <span
+                    key={i}
+                    className={`h-1.5 rounded-full transition-all duration-300 ${
+                      i < step
+                        ? "w-6 bg-moss-700"
+                        : "w-1.5 bg-border-subtle"
+                    }`}
+                  />
+                ))}
+              </div>
+              <p className="text-xs font-medium uppercase tracking-[0.14em] text-foreground-tertiary">
+                Step {step} of {TOTAL_STEPS}
+              </p>
+            </div>
+          )}
           <p className="eyebrow mb-5">{eyebrow}</p>
           <h1 className="font-serif text-4xl font-medium leading-[1.05] tracking-[-0.02em] text-foreground">
             {title}


### PR DESCRIPTION
Applies the UX baseline (NN/g heuristic #1 visibility of status, forms research, motion baseline) to the mark8ly.com signup funnel:

- **Step indicator**: post-submit pages now show 'Step N of 3' with animated progress dots (check-inbox/verify = 2, set-password = 3) — the funnel previously never said where you were.
- **Head-start continuity**: the welcome page shows the same 20% setup progress the admin checklist opens with, so momentum carries across apps instead of resetting at the door.
- **No mystery-disabled submit**: the button was disabled until the slug check resolved with no explanation; it now submits, surfaces the store-URL error, and focuses the field. Disabled only while genuinely busy.
- **Migration panel glides**: evidence panel animates open via grid-rows (inert/aria-hidden when closed) instead of jump-cutting.
- **Entrance motion**: funnel pages get the same motion-safe fade-rise as the admin.

Verified with tsc --noEmit.