### PR TITLE
fix(platform-api): enforce admin email uniqueness across tenants

### DIFF
--- a/services/platform-api/internal/onboarding/completion_integration_test.go
+++ b/services/platform-api/internal/onboarding/completion_integration_test.go
@@ -305,8 +305,21 @@ func TestIntegration_Complete_DuplicateSlugRollsBackEverything(t *testing.T) {
 // ─── fakeVendorClient ────────────────────────────────────────────────────────
 
 type fakeVendorClient struct {
-	calls []struct{ tenantID, name, slug string }
-	err   error
+	calls      []struct{ tenantID, name, slug string }
+	storeCalls []marketplaceapi.Store
+	err        error
+}
+
+// EnsureSelfStore mirrors the platform-api store row into marketplace-api.
+// Added to the VendorEnsurer interface in Phase Q; recorded here so tests
+// can assert on it.
+func (f *fakeVendorClient) EnsureSelfStore(_ context.Context, s marketplaceapi.Store) (*marketplaceapi.Store, error) {
+	f.storeCalls = append(f.storeCalls, s)
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := s
+	return &out, nil
 }
 
 func (f *fakeVendorClient) EnsureSelfVendor(_ context.Context, tenantID, name, slug string) (*marketplaceapi.Vendor, error) {

--- a/services/platform-api/internal/onboarding/owner_email_uniqueness_integration_test.go
+++ b/services/platform-api/internal/onboarding/owner_email_uniqueness_integration_test.go
@@ -1,0 +1,179 @@
+//go:build integration
+
+package onboarding
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark8ly/platform-api/internal/notification"
+	"github.com/mark8ly/platform-api/internal/store"
+	"github.com/mark8ly/platform-api/internal/tenant"
+	apperrors "github.com/mark8ly/platform-api/pkg/errors"
+	"github.com/mark8ly/platform-api/pkg/testdb"
+)
+
+// newUniquenessSvc builds the onboarding service stack against a real DB
+// with the tables the owner-email guard touches.
+func newUniquenessSvc(t *testing.T) (*Service, Repository, tenant.Repository) {
+	t.Helper()
+	db := testdb.NewDB(t,
+		"outbox_events",
+		"verification_tokens",
+		"onboarding_sessions",
+		"stores",
+		"tenants",
+	)
+	tenantRepo := tenant.NewRepository(db)
+	onboardingRepo := NewRepository(db)
+	svc := NewService(Config{
+		DB:           db,
+		Repo:         onboardingRepo,
+		TenantRepo:   tenantRepo,
+		StoreRepo:    store.NewRepository(db),
+		Sender:       notification.NoopSender{},
+		EmailFrom:    "noreply@test.local",
+		SupportEmail: "help@test.local",
+	})
+	return svc, onboardingRepo, tenantRepo
+}
+
+// seedVerifiedSession creates an onboarding session already past email
+// verification, which is the precondition Complete enforces.
+func seedVerifiedSession(t *testing.T, repo Repository, email string) *Session {
+	t.Helper()
+	now := time.Now()
+	sess := &Session{
+		Email:           email,
+		Draft:           json.RawMessage(`{}`),
+		Status:          StatusInProgress,
+		EmailVerifiedAt: &now,
+	}
+	if err := repo.Create(context.Background(), sess); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	return sess
+}
+
+// completeFor runs a full onboarding for the given email/slug.
+func completeFor(t *testing.T, svc *Service, repo Repository, email, slug, uid string) error {
+	t.Helper()
+	sess := seedVerifiedSession(t, repo, email)
+	_, err := svc.Complete(context.Background(), CompleteRequest{
+		SessionID:    sess.ID,
+		BusinessName: "Store " + slug,
+		Slug:         slug,
+		OwnerUserID:  uid,
+		OwnerEmail:   email,
+		CountryCode:  "US",
+		CurrencyCode: "USD",
+		Timezone:     "America/New_York",
+	})
+	return err
+}
+
+// TestIntegration_Create_RejectsEmailOwningAnotherTenant is the
+// regression test for the prod bug: onboarding let a merchant walk the
+// entire wizard with an email that already administered another store,
+// only failing at the very end (or at GIP's EMAIL_EXISTS, which reads
+// as an auth error). The guard must fire at step 1.
+func TestIntegration_Create_RejectsEmailOwningAnotherTenant(t *testing.T) {
+	svc, repo, _ := newUniquenessSvc(t)
+	ctx := context.Background()
+
+	if err := completeFor(t, svc, repo, "founder@dupe-test.local", "first-store", "gip-uid-1"); err != nil {
+		t.Fatalf("first onboarding should succeed: %v", err)
+	}
+
+	_, err := svc.Create(ctx, CreateRequest{Email: "founder@dupe-test.local"})
+	if err == nil {
+		t.Fatal("Create accepted an email that already owns a tenant; want conflict")
+	}
+	assertOwnerEmailConflict(t, err)
+}
+
+// The guard must be case-insensitive — Founder@ and founder@ are the
+// same human, and the unique index compares on lower(owner_email).
+func TestIntegration_Create_EmailComparisonIsCaseInsensitive(t *testing.T) {
+	svc, repo, _ := newUniquenessSvc(t)
+	ctx := context.Background()
+
+	if err := completeFor(t, svc, repo, "founder@case-test.local", "case-first", "gip-uid-2"); err != nil {
+		t.Fatalf("first onboarding should succeed: %v", err)
+	}
+
+	for _, variant := range []string{
+		"Founder@case-test.local",
+		"FOUNDER@CASE-TEST.LOCAL",
+		"  founder@case-test.local  ",
+	} {
+		if _, err := svc.Create(ctx, CreateRequest{Email: variant}); err == nil {
+			t.Errorf("Create(%q) accepted a case/whitespace variant of a taken email", variant)
+		}
+	}
+}
+
+// TestIntegration_Complete_RejectsEmailOwningAnotherTenant covers the
+// bypass path: the old guard lived only in the Next.js server action, so
+// calling POST /onboarding/sessions/:id/complete directly could mint an
+// unlimited number of tenants under one owner email. Complete must
+// enforce it server-side, independent of Create.
+func TestIntegration_Complete_RejectsEmailOwningAnotherTenant(t *testing.T) {
+	svc, repo, tenantRepo := newUniquenessSvc(t)
+	ctx := context.Background()
+
+	if err := completeFor(t, svc, repo, "founder@bypass-test.local", "bypass-first", "gip-uid-3"); err != nil {
+		t.Fatalf("first onboarding should succeed: %v", err)
+	}
+
+	// Seed a verified session directly, skipping Create entirely — this
+	// is exactly what a direct API call to :id/complete looks like.
+	err := completeFor(t, svc, repo, "founder@bypass-test.local", "bypass-second", "gip-uid-4")
+	if err == nil {
+		t.Fatal("Complete minted a second tenant for an email that already owns one")
+	}
+	assertOwnerEmailConflict(t, err)
+
+	// And the original tenant is still intact.
+	exists, qErr := tenantRepo.OwnerEmailExists(ctx, "founder@bypass-test.local")
+	if qErr != nil {
+		t.Fatalf("OwnerEmailExists: %v", qErr)
+	}
+	if !exists {
+		t.Fatal("first tenant vanished")
+	}
+}
+
+// A fresh, unused email must still sail through — the guard should not
+// be so blunt that it blocks legitimate signups.
+func TestIntegration_Create_AllowsUnusedEmail(t *testing.T) {
+	svc, repo, _ := newUniquenessSvc(t)
+	ctx := context.Background()
+
+	if err := completeFor(t, svc, repo, "taken@fresh-test.local", "fresh-first", "gip-uid-5"); err != nil {
+		t.Fatalf("first onboarding should succeed: %v", err)
+	}
+
+	if _, err := svc.Create(ctx, CreateRequest{Email: "brand-new@fresh-test.local"}); err != nil {
+		t.Fatalf("Create rejected an unused email: %v", err)
+	}
+}
+
+func assertOwnerEmailConflict(t *testing.T, err error) {
+	t.Helper()
+	appErr, ok := apperrors.As(err)
+	if !ok {
+		t.Fatalf("error %v (%T) is not an *apperrors.AppError", err, err)
+	}
+	if appErr.Code != "owner_email_already_in_use" {
+		t.Errorf("Code = %q, want owner_email_already_in_use", appErr.Code)
+	}
+	// The message is user-facing — it must actually tell the merchant
+	// what to do, not just that something conflicted.
+	if !strings.Contains(strings.ToLower(appErr.Message), "different email") {
+		t.Errorf("Message = %q, want it to tell the user to use a different email", appErr.Message)
+	}
+}

--- a/services/platform-api/internal/onboarding/service.go
+++ b/services/platform-api/internal/onboarding/service.go
@@ -114,6 +114,15 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (*Session, erro
 		return nil, apperrors.BadRequest("invalid_email", "valid email is required")
 	}
 
+	// An admin email is globally unique across tenants. Reject here, at
+	// step 1 of the wizard, rather than letting the merchant fill in the
+	// whole form and hit the failure at the final insert (or worse, at
+	// GIP's EMAIL_EXISTS on the set-password screen, which reads as an
+	// auth error rather than "pick a different email").
+	if err := s.ensureOwnerEmailAvailable(ctx, email); err != nil {
+		return nil, err
+	}
+
 	sess := &Session{
 		Email:  email,
 		Draft:  json.RawMessage(`{}`),
@@ -123,6 +132,35 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (*Session, erro
 		return nil, err
 	}
 	return sess, nil
+}
+
+// ensureOwnerEmailAvailable rejects an email that already owns a tenant.
+//
+// This is the authoritative cross-tenant admin-email guard. It runs on
+// BOTH Create (fail fast at step 1) and Complete (non-bypassable — a
+// client calling POST /onboarding/sessions/:id/complete directly still
+// hits it). The frontend check in apps/onboarding/app/onboarding/
+// actions.ts is a UX affordance only; this is the enforcement point.
+//
+// The DB-level backstop is the tenants_owner_email_unique index
+// (migration 0014), which closes the TOCTOU window between this check
+// and the insert — two concurrent onboardings for the same email make
+// one of them fail at CreateInTx with a 23505 rather than both landing.
+func (s *Service) ensureOwnerEmailAvailable(ctx context.Context, email string) error {
+	if s.tenantRepo == nil {
+		return nil
+	}
+	exists, err := s.tenantRepo.OwnerEmailExists(ctx, email)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return apperrors.Conflict(
+			"owner_email_already_in_use",
+			"This email is already an admin of another store. Please use a different email address — an admin email must be unique across stores.",
+		)
+	}
+	return nil
 }
 
 // Get returns a session by ID.
@@ -216,6 +254,13 @@ func (s *Service) Complete(ctx context.Context, req CompleteRequest) (*CompleteR
 		return nil, apperrors.BadRequest("email_not_verified", "email must be verified before completion")
 	}
 
+	// Re-check at completion. Create already rejected a duplicate, but a
+	// tenant may have claimed this email while the wizard was open, and
+	// a direct API call skips Create's check entirely.
+	if err := s.ensureOwnerEmailAvailable(ctx, req.OwnerEmail); err != nil {
+		return nil, err
+	}
+
 	// Phase Q: onboarding creates BOTH a tenant (the company) and a
 	// default store (the first storefront) in the same transaction.
 	// The merchant's "business name" becomes both the tenant.name
@@ -226,8 +271,10 @@ func (s *Service) Complete(ctx context.Context, req CompleteRequest) (*CompleteR
 	t := &tenant.Tenant{
 		Name:        req.BusinessName,
 		OwnerUserID: req.OwnerUserID,
-		OwnerEmail:  req.OwnerEmail,
-		Status:      tenant.StatusActive,
+		// Store normalized so the row matches what the case-insensitive
+		// uniqueness check and the lower(owner_email) index compare on.
+		OwnerEmail: strings.ToLower(strings.TrimSpace(req.OwnerEmail)),
+		Status:     tenant.StatusActive,
 	}
 	st := &store.Store{
 		Slug:            req.Slug,

--- a/services/platform-api/internal/tenant/repository.go
+++ b/services/platform-api/internal/tenant/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"gorm.io/gorm"
@@ -23,6 +24,15 @@ type Repository interface {
 	// GIP identity back to a Mark8ly tenant before calling auth-bff
 	// /auth/auto-login. v1 assumption: a UID owns at most one tenant.
 	GetByOwnerUserID(ctx context.Context, uid string) (*Tenant, error)
+	// OwnerEmailExists reports whether any tenant is already owned by the
+	// given email. Comparison is case-insensitive to match the
+	// tenants_owner_email_unique index (migration 0014), so
+	// Founder@example.com and founder@example.com collide.
+	//
+	// An admin email is globally unique across tenants: one email owns at
+	// most one tenant. Callers use this to reject a duplicate at the START
+	// of onboarding rather than letting it fail at the final insert.
+	OwnerEmailExists(ctx context.Context, email string) (bool, error)
 	UpdateEditable(ctx context.Context, id string, patch map[string]any) (*Tenant, error)
 	// ListByIDs returns tenant rows for each id in the given slice.
 	// Used by Phase P multi-tenant membership lookups.
@@ -71,6 +81,21 @@ func (r *gormRepository) GetByOwnerUserID(ctx context.Context, uid string) (*Ten
 		return nil, fmt.Errorf("tenant: get by owner uid %q: %w", uid, err)
 	}
 	return &t, nil
+}
+
+func (r *gormRepository) OwnerEmailExists(ctx context.Context, email string) (bool, error) {
+	normalized := strings.ToLower(strings.TrimSpace(email))
+	if normalized == "" {
+		return false, nil
+	}
+	var count int64
+	err := r.db.WithContext(ctx).Model(&Tenant{}).
+		Where("lower(owner_email) = ?", normalized).
+		Count(&count).Error
+	if err != nil {
+		return false, fmt.Errorf("tenant: owner email exists %q: %w", normalized, err)
+	}
+	return count > 0, nil
 }
 
 func (r *gormRepository) ListByIDs(ctx context.Context, ids []string) ([]Tenant, error) {

--- a/services/platform-api/internal/tenant/repository_integration_test.go
+++ b/services/platform-api/internal/tenant/repository_integration_test.go
@@ -10,131 +10,154 @@ import (
 	"github.com/mark8ly/platform-api/pkg/testdb"
 )
 
-// TestIntegration_CreateInTx_HappyPath inserts a tenant via the real
+// This file was rewritten for Phase Q: slug, country, currency and
+// timezone moved from Tenant onto Store, and GetBySlug/SlugExists moved
+// to the store package. The previous slug-based tests here referenced
+// fields and methods that no longer exist and had stopped compiling.
+
+func newTenant(name, uid, email string) *Tenant {
+	return &Tenant{
+		Name:        name,
+		OwnerUserID: uid,
+		OwnerEmail:  email,
+		Status:      StatusActive,
+	}
+}
+
+// TestIntegration_CreateInTx_HappyPath writes a tenant through the
 // transaction path and reads it back through GetByID. Uses tx-rollback so
 // nothing leaks between tests.
 func TestIntegration_CreateInTx_HappyPath(t *testing.T) {
 	tx := testdb.NewTx(t)
 	repo := NewRepository(tx)
+	ctx := context.Background()
 
-	tenant := &Tenant{
-		Slug:         "acme-test",
-		Name:         "Acme Test Co",
-		OwnerUserID:  "uid-test-1",
-		OwnerEmail:   "founder@test.local",
-		CountryCode:  "US",
-		CurrencyCode: "USD",
-		Timezone:     "America/New_York",
-		Status:       StatusActive,
-	}
-	if err := repo.CreateInTx(context.Background(), tx, tenant); err != nil {
+	seed := newTenant("Acme Test Co", "uid-test-1", "founder@test.local")
+	if err := repo.CreateInTx(ctx, tx, seed); err != nil {
 		t.Fatalf("CreateInTx: %v", err)
 	}
-	if tenant.ID == "" {
+	if seed.ID == "" {
 		t.Error("ID should be populated by gen_random_uuid()")
 	}
 
-	got, err := repo.GetByID(context.Background(), tenant.ID)
+	got, err := repo.GetByID(ctx, seed.ID)
 	if err != nil {
 		t.Fatalf("GetByID: %v", err)
 	}
-	if got.Slug != "acme-test" {
-		t.Errorf("Slug = %q, want acme-test", got.Slug)
+	if got.Name != "Acme Test Co" {
+		t.Errorf("Name = %q, want Acme Test Co", got.Name)
+	}
+	if got.OwnerEmail != "founder@test.local" {
+		t.Errorf("OwnerEmail = %q, want founder@test.local", got.OwnerEmail)
 	}
 }
 
-// TestIntegration_CreateInTx_TranslatesUniqueViolation is the regression
-// test for the conflict-mapping path: a duplicate slug must surface as a
-// 409 conflict (slug_taken), NOT a generic 500.
+// TestIntegration_CreateInTx_TranslatesUniqueViolation is the
+// conflict-mapping regression test. Since Phase Q the only unique
+// constraint on tenants is tenants_owner_email_unique (migration 0014) —
+// a second tenant claiming an owner_email must surface as a 409 conflict,
+// NOT a generic 500.
 func TestIntegration_CreateInTx_TranslatesUniqueViolation(t *testing.T) {
 	tx := testdb.NewTx(t)
 	repo := NewRepository(tx)
+	ctx := context.Background()
 
-	first := &Tenant{
-		Slug: "duplicate-slug", Name: "First", OwnerUserID: "uid-1",
-		OwnerEmail: "a@test.local", CountryCode: "US", CurrencyCode: "USD",
-		Timezone: "America/New_York", Status: StatusActive,
-	}
-	if err := repo.CreateInTx(context.Background(), tx, first); err != nil {
+	first := newTenant("First", "uid-1", "duplicate@test.local")
+	if err := repo.CreateInTx(ctx, tx, first); err != nil {
 		t.Fatalf("first insert: %v", err)
 	}
 
-	second := &Tenant{
-		Slug: "duplicate-slug", Name: "Second", OwnerUserID: "uid-2",
-		OwnerEmail: "b@test.local", CountryCode: "US", CurrencyCode: "USD",
-		Timezone: "America/New_York", Status: StatusActive,
-	}
-	err := repo.CreateInTx(context.Background(), tx, second)
+	second := newTenant("Second", "uid-2", "duplicate@test.local")
+	err := repo.CreateInTx(ctx, tx, second)
 
 	ae, ok := apperrors.As(err)
 	if !ok {
-		t.Fatalf("expected AppError on duplicate slug, got %v", err)
-	}
-	if ae.Code != "slug_taken" {
-		t.Errorf("Code = %q, want slug_taken", ae.Code)
+		t.Fatalf("expected AppError on duplicate owner_email, got %v", err)
 	}
 	if ae.Status != 409 {
 		t.Errorf("Status = %d, want 409", ae.Status)
 	}
 }
 
-// TestIntegration_GetBySlug_FoundAndNotFound exercises the read path.
-func TestIntegration_GetBySlug_FoundAndNotFound(t *testing.T) {
+// The unique index is on lower(owner_email), so a case variant must
+// collide too — otherwise the DB backstop would not actually match what
+// onboarding.Service checks in application code.
+func TestIntegration_CreateInTx_OwnerEmailUniqueIsCaseInsensitive(t *testing.T) {
 	tx := testdb.NewTx(t)
 	repo := NewRepository(tx)
+	ctx := context.Background()
 
-	seed := &Tenant{
-		Slug: "lookup-test", Name: "Lookup", OwnerUserID: "uid-3",
-		OwnerEmail: "c@test.local", CountryCode: "US", CurrencyCode: "USD",
-		Timezone: "America/New_York", Status: StatusActive,
+	if err := repo.CreateInTx(ctx, tx, newTenant("First", "uid-1", "founder@case.local")); err != nil {
+		t.Fatalf("first insert: %v", err)
 	}
-	if err := repo.CreateInTx(context.Background(), tx, seed); err != nil {
+
+	err := repo.CreateInTx(ctx, tx, newTenant("Second", "uid-2", "Founder@Case.local"))
+	if err == nil {
+		t.Fatal("a case variant of an existing owner_email was accepted; want unique violation")
+	}
+	if ae, ok := apperrors.As(err); ok && ae.Status != 409 {
+		t.Errorf("Status = %d, want 409", ae.Status)
+	}
+}
+
+// TestIntegration_OwnerEmailExists_TrueAndFalse exercises the existence
+// check that onboarding uses to reject a duplicate admin email at step 1.
+func TestIntegration_OwnerEmailExists_TrueAndFalse(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := NewRepository(tx)
+	ctx := context.Background()
+
+	seed := newTenant("X", "uid-4", "taken@test.local")
+	if err := repo.CreateInTx(ctx, tx, seed); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := repo.GetBySlug(context.Background(), "lookup-test")
+	for _, probe := range []string{
+		"taken@test.local",
+		"Taken@Test.local",
+		"  taken@test.local  ",
+	} {
+		exists, err := repo.OwnerEmailExists(ctx, probe)
+		if err != nil {
+			t.Fatalf("OwnerEmailExists(%q): %v", probe, err)
+		}
+		if !exists {
+			t.Errorf("OwnerEmailExists(%q) = false, want true", probe)
+		}
+	}
+
+	exists, err := repo.OwnerEmailExists(ctx, "definitely-not-here@test.local")
 	if err != nil {
-		t.Fatalf("GetBySlug: %v", err)
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("OwnerEmailExists for unused email = true, want false")
+	}
+}
+
+// TestIntegration_GetByOwnerUserID_FoundAndNotFound exercises the
+// returning-user sign-in read path.
+func TestIntegration_GetByOwnerUserID_FoundAndNotFound(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := NewRepository(tx)
+	ctx := context.Background()
+
+	seed := newTenant("Lookup", "uid-3", "lookup@test.local")
+	if err := repo.CreateInTx(ctx, tx, seed); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.GetByOwnerUserID(ctx, "uid-3")
+	if err != nil {
+		t.Fatalf("GetByOwnerUserID: %v", err)
 	}
 	if got.ID != seed.ID {
 		t.Errorf("ID mismatch: got %q, want %q", got.ID, seed.ID)
 	}
 
-	_, err = repo.GetBySlug(context.Background(), "nope-not-here")
+	_, err = repo.GetByOwnerUserID(ctx, "uid-does-not-exist")
 	ae, ok := apperrors.As(err)
 	if !ok || ae.Code != "tenant_not_found" {
 		t.Errorf("expected tenant_not_found, got %v", err)
-	}
-}
-
-// TestIntegration_SlugExists_TrueAndFalse exercises the existence check
-// used by IsSlugAvailable.
-func TestIntegration_SlugExists_TrueAndFalse(t *testing.T) {
-	tx := testdb.NewTx(t)
-	repo := NewRepository(tx)
-
-	seed := &Tenant{
-		Slug: "exists-test", Name: "X", OwnerUserID: "uid-4",
-		OwnerEmail: "d@test.local", CountryCode: "US", CurrencyCode: "USD",
-		Timezone: "America/New_York", Status: StatusActive,
-	}
-	if err := repo.CreateInTx(context.Background(), tx, seed); err != nil {
-		t.Fatal(err)
-	}
-
-	exists, err := repo.SlugExists(context.Background(), "exists-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !exists {
-		t.Error("SlugExists(\"exists-test\") = false, want true")
-	}
-
-	notExists, err := repo.SlugExists(context.Background(), "definitely-not-here")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if notExists {
-		t.Error("SlugExists for unused slug = true, want false")
 	}
 }

--- a/services/platform-api/internal/tenant/service_test.go
+++ b/services/platform-api/internal/tenant/service_test.go
@@ -2,6 +2,7 @@ package tenant
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 
@@ -52,6 +53,18 @@ func (f *fakeRepo) GetByOwnerUserID(ctx context.Context, uid string) (*Tenant, e
 		}
 	}
 	return nil, apperrors.NotFound("tenant_not_found", "no")
+}
+
+func (f *fakeRepo) OwnerEmailExists(ctx context.Context, email string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	normalized := strings.ToLower(strings.TrimSpace(email))
+	for _, t := range f.byID {
+		if strings.ToLower(strings.TrimSpace(t.OwnerEmail)) == normalized {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (f *fakeRepo) ListByIDs(ctx context.Context, ids []string) ([]Tenant, error) {

--- a/services/platform-api/migrations/0014_unique_tenant_owner_email.down.sql
+++ b/services/platform-api/migrations/0014_unique_tenant_owner_email.down.sql
@@ -1,0 +1,8 @@
+-- Restore the plain non-unique index from migration 0003.
+-- The lower-casing of existing owner_email values is intentionally NOT
+-- reverted: the original casing is not recoverable, and lower-cased
+-- emails remain valid and deliverable.
+
+CREATE INDEX IF NOT EXISTS idx_tenants_owner_email ON tenants (owner_email);
+
+DROP INDEX IF EXISTS tenants_owner_email_unique;

--- a/services/platform-api/migrations/0014_unique_tenant_owner_email.up.sql
+++ b/services/platform-api/migrations/0014_unique_tenant_owner_email.up.sql
@@ -1,0 +1,38 @@
+-- Enforces that an admin email owns at most one tenant.
+--
+-- Before this, `idx_tenants_owner_email` (migration 0003) was a plain,
+-- non-unique index and the only cross-tenant admin-email guard lived in
+-- the onboarding frontend (apps/onboarding/app/onboarding/actions.ts) —
+-- which keyed on GIP UID rather than email and was bypassed entirely by
+-- calling POST /onboarding/sessions/:id/complete directly. Two tenants
+-- could therefore share an owner_email.
+--
+-- The application-level check in onboarding.Service (Create + Complete)
+-- produces the friendly "use a different email" error. This index is the
+-- backstop that closes the TOCTOU window between that check and the
+-- INSERT: two concurrent onboardings for the same email now make one
+-- fail with 23505 instead of both committing.
+--
+-- Case-insensitive on purpose: Founder@example.com and
+-- founder@example.com are the same admin. onboarding.Service writes
+-- owner_email already lower-cased, so new rows match the index directly.
+
+-- Normalize existing rows first, otherwise the index below would treat
+-- mixed-case duplicates as distinct and let them survive.
+UPDATE tenants
+   SET owner_email = lower(trim(owner_email))
+ WHERE owner_email <> lower(trim(owner_email));
+
+-- Verified against prod (mark8ly_platform_api) before writing this
+-- migration: zero duplicate lower(owner_email) groups across all
+-- tenants, so this index builds without a data cleanup step. If it ever
+-- fails on another environment, that environment has genuine duplicates
+-- that need a product decision (which tenant keeps the email) rather
+-- than an automatic fix — hence no DELETE/merge here.
+CREATE UNIQUE INDEX IF NOT EXISTS tenants_owner_email_unique
+  ON tenants (lower(owner_email));
+
+-- The old non-unique index is now redundant: the unique index above
+-- serves the same lookup. Dropping it saves a write on every tenant
+-- insert/update.
+DROP INDEX IF EXISTS idx_tenants_owner_email;


### PR DESCRIPTION
## Problem

An admin email could own more than one tenant.

The only cross-tenant guard lived in the onboarding **frontend** (`apps/onboarding/app/onboarding/actions.ts:206`), keyed on **GIP UID rather than email**, and was bypassed entirely by calling `POST /onboarding/sessions/:id/complete` directly. Server-side validation was just `strings.Contains(email, "@")`, and `idx_tenants_owner_email` was a plain non-unique index — so two tenants sharing an `owner_email` were both representable in the schema and reachable via the API.

In practice merchants hit this at the *end* of the wizard, as GIP's `EMAIL_EXISTS` on the set-password screen, which reads as an auth failure rather than "pick a different email".

## Fix

Enforced at three layers:

| Layer | Where | Behaviour |
|---|---|---|
| Step 1 of wizard | `onboarding/service.go` `Create` | Rejects a taken email immediately |
| Completion | `onboarding/service.go` `Complete` | Non-bypassable; also catches an email claimed mid-wizard |
| DB backstop | `migrations/0014` | Unique index on `lower(owner_email)`, closes the TOCTOU window |

Case-insensitive throughout; `owner_email` is now stored normalized. Migration also normalizes existing rows and drops the redundant non-unique index.

Error message: *"This email is already an admin of another store. Please use a different email address — an admin email must be unique across stores."* No frontend change needed — `routeServerError` already routes anything matching `/email/` to the email field, so it renders inline.

## Verification

- `go build`, `go vet` (incl. `-tags=integration`), gofmt-clean, **all unit tests pass**
- Verified **zero** duplicate `lower(owner_email)` groups in prod before writing the migration, so the index builds without a cleanup step

> [!WARNING]
> **The 4 new integration tests compile and vet clean but were NOT executed** — no local Docker daemon, so `TEST_DATABASE_URL` was unset and they skipped. They are unproven until CI or a local `make dev && make test-int` runs them. Please don't read the green unit-test run as covering them.

## Note for reviewers

The first commit is **scope beyond the bug**. The integration suite did not compile *before* this change (confirmed by stashing) — stale since Phase Q: `tenant/repository_integration_test.go` exercised `GetBySlug`/`SlugExists` and `Tenant.Slug`, none of which still exist on that interface, and `fakeVendorClient` lacked `EnsureSelfStore`. I rewrote the former and added the latter, because otherwise the new regression tests could not compile, let alone run. Kept as a separate commit so it can be reviewed independently.

Migration placement follows the existing in-repo `services/platform-api/migrations/` pattern (0014 of 14, run by CI via Cloud SQL Proxy), which conflicts with the `CLAUDE.md` rule that schema lives in `tesserix-k8s`. Flagged rather than silently resolved — happy to move it.