### PR TITLE
fix(platform-api): bump ExpectedSchemaVersion to 14 and guard it in a unit test

### DIFF
--- a/services/platform-api/migrations.go
+++ b/services/platform-api/migrations.go
@@ -11,4 +11,4 @@ var MigrationsFS embed.FS
 // ExpectedSchemaVersion is the version cmd/server requires on startup.
 // Bump this when you add a new migration. cmd/server refuses to start if the
 // DB is at any other version.
-const ExpectedSchemaVersion uint = 13
+const ExpectedSchemaVersion uint = 14

--- a/services/platform-api/migrations_test.go
+++ b/services/platform-api/migrations_test.go
@@ -1,0 +1,99 @@
+package platformapi
+
+import (
+	"io/fs"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestExpectedSchemaVersionMatchesHighestMigration guards the failure mode
+// where a migration is added but ExpectedSchemaVersion is not bumped.
+//
+// cmd/server calls AssertVersion, which requires EXACT equality, while the
+// deployment's initContainer runs `migrate up` on every pod start. So a
+// forgotten bump does not fail at build or review time — it fails in prod,
+// as a crashloop: the initContainer advances the DB to the new version and
+// the server then refuses to boot against it.
+//
+// pkg/migrate's integration test already covers this, but it needs
+// TEST_DATABASE_URL and is therefore SKIPPED in CI — which is exactly how a
+// missing bump reached main once. This test needs no database, so it runs
+// on every `go test ./...`.
+func TestExpectedSchemaVersionMatchesHighestMigration(t *testing.T) {
+	entries, err := fs.ReadDir(MigrationsFS, "migrations")
+	if err != nil {
+		t.Fatalf("read migrations dir: %v", err)
+	}
+
+	var highest uint
+	seen := map[uint]bool{}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".up.sql") {
+			continue
+		}
+		prefix, _, ok := strings.Cut(name, "_")
+		if !ok {
+			t.Errorf("migration %q does not match NNNN_name.up.sql", name)
+			continue
+		}
+		n, err := strconv.ParseUint(prefix, 10, 64)
+		if err != nil {
+			t.Errorf("migration %q has a non-numeric version prefix %q", name, prefix)
+			continue
+		}
+		v := uint(n)
+		if seen[v] {
+			t.Errorf("duplicate migration version %d", v)
+		}
+		seen[v] = true
+		if v > highest {
+			highest = v
+		}
+	}
+
+	if highest == 0 {
+		t.Fatal("no .up.sql migrations found — embed or path is wrong")
+	}
+	if ExpectedSchemaVersion != highest {
+		t.Errorf("ExpectedSchemaVersion = %d, but the highest migration is %d.\n"+
+			"Bump ExpectedSchemaVersion in migrations.go to %d — otherwise the "+
+			"migrate initContainer advances the DB past what cmd/server accepts "+
+			"and platform-api crashloops on rollout.",
+			ExpectedSchemaVersion, highest, highest)
+	}
+
+	// Every up must have a matching down, or a rollback strands the schema.
+	for v := uint(1); v <= highest; v++ {
+		if !seen[v] {
+			t.Errorf("migration version %d is missing — versions must be contiguous", v)
+		}
+	}
+}
+
+// Each .up.sql must have a sibling .down.sql.
+func TestEveryMigrationHasADownFile(t *testing.T) {
+	entries, err := fs.ReadDir(MigrationsFS, "migrations")
+	if err != nil {
+		t.Fatalf("read migrations dir: %v", err)
+	}
+
+	downs := map[string]bool{}
+	var ups []string
+	for _, e := range entries {
+		name := e.Name()
+		switch {
+		case strings.HasSuffix(name, ".down.sql"):
+			downs[strings.TrimSuffix(name, ".down.sql")] = true
+		case strings.HasSuffix(name, ".up.sql"):
+			ups = append(ups, strings.TrimSuffix(name, ".up.sql"))
+		}
+	}
+
+	for _, u := range ups {
+		if !downs[u] {
+			t.Errorf("migration %q has no matching %s.down.sql", u+".up.sql", u)
+		}
+	}
+}


### PR DESCRIPTION
## Urgent — follow-up to #183

Migration `0014` shipped in #183 **without** bumping `ExpectedSchemaVersion` (still 13).

`cmd/server` calls `AssertVersion`, which requires **exact** equality (`v != expected` → panic), and the deployment runs `/migrate up` in an **initContainer on every pod start**. So on the next rollout:

1. initContainer applies `0014` → DB advances to **14**
2. server asserts **13**, finds **14** → panic → **crashloop**

**Caught before Kargo promoted the image.** Prod is still on `main-f629b93` at schema 13, so there was no impact — but this would have taken platform-api down on the next rollout.

## Why CI didn't catch it

`pkg/migrate/migrate_integration_test.go` already asserts this exact invariant (`Up()` then `AssertVersion(ExpectedSchemaVersion)`) — but it requires `TEST_DATABASE_URL`, which is unset in CI, so it **skips**. That is precisely how #183 went green on a change that would crashloop prod.

So this PR adds a **DB-free unit test** that runs on every `go test ./...`: it derives the highest migration number from the embedded FS and compares it against `ExpectedSchemaVersion`, failing with the exact remediation. It also checks version contiguity and that every `.up.sql` has a matching `.down.sql`.

Verified it fails with the constant at 13 and passes at 14:

```
--- FAIL: TestExpectedSchemaVersionMatchesHighestMigration
    Bump ExpectedSchemaVersion in migrations.go to 14 — otherwise the migrate
    initContainer advances the DB past what cmd/server accepts and platform-api
    crashloops on rollout.
```

## Rollout order

Once merged, the image contains migration 0014 **and** `ExpectedSchemaVersion = 14` together, so the initContainer and server agree — the schema advances atomically with the rollout. No manual DDL needed.