### PR TITLE
fix(mobile-admin): repair tenant_id GIP claim + stop the login bounce loop

### DIFF
--- a/services/marketplace-api/internal/auth/gip_verifier.go
+++ b/services/marketplace-api/internal/auth/gip_verifier.go
@@ -29,10 +29,17 @@ func (v *GIPVerifier) Verify(ctx context.Context, idToken string) (*TokenClaims,
 		return nil, ErrInvalidToken
 	}
 
+	// A missing tenant_id claim is NOT an authentication failure — the
+	// token is validly signed and the user is who they say they are.
+	// They simply have no store bound to this identity yet.
+	//
+	// Returning an error here made GIPBearerAuth abort with 401, which
+	// the mobile client reads as "session is dead" and responds to by
+	// calling signOut() — bouncing the user back to /login with no
+	// explanation, in a loop. Instead, pass through with an empty
+	// TenantID and let authz.RequireTenantRelation answer 404, which
+	// the app already renders as its "No store yet" screen.
 	tenantID := tenantIDFromClaims(token.Claims)
-	if tenantID == "" {
-		return nil, fmt.Errorf("token missing tenant_id claim")
-	}
 
 	return &TokenClaims{
 		UserID:   userID,

--- a/services/marketplace-api/internal/auth/gip_verifier_test.go
+++ b/services/marketplace-api/internal/auth/gip_verifier_test.go
@@ -1,6 +1,14 @@
 package auth
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
 
 // tenant-service writes tenant_id as a multi-value array (its
 // UpdateUserAttributes appends into []interface{}), so the array form is what
@@ -74,5 +82,76 @@ func TestTenantIDFromClaims(t *testing.T) {
 				t.Errorf("tenantIDFromClaims() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// stubVerifier lets us exercise GIPBearerAuth's status-code contract
+// without a real Firebase client.
+type stubVerifier struct {
+	claims *TokenClaims
+	err    error
+}
+
+func (s stubVerifier) Verify(_ context.Context, _ string) (*TokenClaims, error) {
+	return s.claims, s.err
+}
+
+// TestGIPBearerAuth_NoTenantClaimIsNot401 is the regression test for the
+// mobile-admin login bounce.
+//
+// A validly-signed token whose user simply has no store must NOT be
+// rejected as an authentication failure. It previously returned 401
+// "invalid or expired token", which the mobile client interprets as a
+// dead session — it calls signOut() and the router redirects to /login,
+// producing an endless oscillation with no error shown. Every tenant
+// onboarded through the wizard hit this, because nothing ever set the
+// tenant_id custom claim.
+//
+// Correct behaviour: authenticate fine with an empty tenant_id, and let
+// authz.RequireTenantRelation answer 404, which the app renders as its
+// existing "No store yet" screen.
+func TestGIPBearerAuth_NoTenantClaimIsNot401(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(GIPBearerAuth(stubVerifier{claims: &TokenClaims{UserID: "uid-no-store", TenantID: ""}}))
+	r.GET("/probe", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"user_id":   c.GetString("user_id"),
+			"tenant_id": c.GetString("tenant_id"),
+		})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	req.Header.Set("Authorization", "Bearer any-validly-signed-token")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code == http.StatusUnauthorized {
+		t.Fatalf("missing tenant_id returned 401 — the mobile client will signOut() and bounce to /login")
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (auth succeeds; authorization is decided downstream)", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "uid-no-store") {
+		t.Errorf("user_id not propagated to context: %s", w.Body.String())
+	}
+}
+
+// A genuinely bad token must still be 401.
+func TestGIPBearerAuth_InvalidTokenIsStill401(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(GIPBearerAuth(stubVerifier{err: ErrInvalidToken}))
+	r.GET("/probe", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	req.Header.Set("Authorization", "Bearer garbage")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 for an invalid token", w.Code)
 	}
 }

--- a/services/marketplace-api/internal/auth/require_tenant_claim.go
+++ b/services/marketplace-api/internal/auth/require_tenant_claim.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RequireTenantClaim aborts with 404 unless the authenticated caller has a
+// tenant bound to their identity.
+//
+// This is the companion to GIPBearerAuth's deliberate decision to NOT reject
+// a token that lacks a tenant_id claim. That change fixed a login bounce
+// loop (a 401 made the mobile client tear down a perfectly valid session and
+// redirect to /login), but on its own it would fail OPEN: routes that read
+// tenant_id without an authorization guard would suddenly be reachable by an
+// authenticated user with no tenant at all, carrying an empty tenant scope.
+//
+// Most mobile admin routes are already covered by
+// authz.RequireTenantRelation, which performs the real FGA check. This guard
+// exists for the groups that are not — platform-support (not store-scoped)
+// and push-tokens — and is mounted alongside bearerAuth at group level so
+// that any route added later is protected by default rather than by
+// remembering to add a check.
+//
+// 404 rather than 403 matches authz.RequireTenantRelation's existing
+// convention of not leaking existence, and critically it is NOT 401 — the
+// mobile client only signs the user out on 401, which is the behaviour this
+// whole change set is removing.
+func RequireTenantClaim() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.GetString("tenant_id") == "" {
+			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
+				"error":   "not_found",
+				"message": "no store is linked to this account",
+			})
+			return
+		}
+		c.Next()
+	}
+}

--- a/services/marketplace-api/internal/auth/require_tenant_claim_test.go
+++ b/services/marketplace-api/internal/auth/require_tenant_claim_test.go
@@ -1,0 +1,71 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestRequireTenantClaim_BlocksEmptyTenant is the fail-closed half of the
+// login-bounce fix. GIPBearerAuth deliberately admits a validly-signed token
+// with no tenant_id; without this guard, routes that lack an explicit
+// RequireTenantRelation (platform-support, push-tokens) would become
+// reachable by a user with no tenant, carrying an empty tenant scope.
+func TestRequireTenantClaim_BlocksEmptyTenant(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	reached := false
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Set("tenant_id", ""); c.Next() })
+	r.Use(RequireTenantClaim())
+	r.GET("/probe", func(c *gin.Context) { reached = true; c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/probe", nil))
+
+	if reached {
+		t.Fatal("handler ran with an empty tenant scope — fail-open")
+	}
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+	// 401 would make the mobile client signOut() and bounce to /login —
+	// the exact loop this change set removes.
+	if w.Code == http.StatusUnauthorized {
+		t.Error("guard returned 401; must not trigger client-side sign-out")
+	}
+}
+
+func TestRequireTenantClaim_AllowsBoundTenant(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Set("tenant_id", "tenant-1"); c.Next() })
+	r.Use(RequireTenantClaim())
+	r.GET("/probe", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/probe", nil))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 for a caller with a tenant", w.Code)
+	}
+}
+
+// A completely absent key must behave like an empty one.
+func TestRequireTenantClaim_BlocksMissingKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(RequireTenantClaim())
+	r.GET("/probe", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/probe", nil))
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 when tenant_id was never set", w.Code)
+	}
+}

--- a/services/marketplace-api/internal/handlers/admin/mobile_routes.go
+++ b/services/marketplace-api/internal/handlers/admin/mobile_routes.go
@@ -30,24 +30,31 @@ func RegisterAdminMobile(router *gin.RouterGroup, deps MobileDeps) {
 
 	bearerAuth := auth.GIPBearerAuth(deps.TokenVerifier)
 	rateLimiter := auth.NewPerUserRateLimiter(60, 10) // 60 req/min, burst 10
+	// Fails closed for callers with no tenant bound to their identity.
+	// GIPBearerAuth intentionally lets a claimless-but-validly-signed token
+	// through (a 401 there made the mobile client sign the user out and
+	// bounce to /login), so this guard supplies the authorization half —
+	// as 404, never 401. Mounted at group level so routes without an
+	// explicit RequireTenantRelation are still protected.
+	requireTenant := auth.RequireTenantClaim()
 
 	// Platform support chat — merchant admin → Tesserix platform team.
 	// Not store-scoped: it rides the admin's tenant from the bearer token,
 	// so any authenticated merchant admin can open a platform chat.
 	if deps.PlatformSupportHandler != nil {
-		ps := router.Group("/mobile/admin/platform-support", bearerAuth, rateLimiter)
+		ps := router.Group("/mobile/admin/platform-support", bearerAuth, requireTenant, rateLimiter)
 		deps.PlatformSupportHandler.Register(ps)
 	}
 
 	// Tenant-wide routes
 	if deps.StoresHandler != nil {
-		mobileRoot := router.Group("/mobile/admin", bearerAuth, rateLimiter)
+		mobileRoot := router.Group("/mobile/admin", bearerAuth, requireTenant, rateLimiter)
 		mobileRoot.GET("/stores",
 			deps.AuthzMiddleware.RequireTenantRelation(authz.RoleStaff),
 			deps.StoresHandler.List)
 	}
 
-	storeRoute := router.Group("/mobile/admin/stores/:storeId", bearerAuth, rateLimiter, deps.StoresMiddleware)
+	storeRoute := router.Group("/mobile/admin/stores/:storeId", bearerAuth, requireTenant, rateLimiter, deps.StoresMiddleware)
 	{
 		// Dashboard
 		if deps.DashboardHandler != nil {

--- a/services/platform-api/cmd/backfill-gip-claims/main.go
+++ b/services/platform-api/cmd/backfill-gip-claims/main.go
@@ -1,0 +1,104 @@
+// Command backfill-gip-claims stamps the tenant_id GIP custom claim onto
+// every existing tenant owner who is missing it.
+//
+// Why: marketplace-api's mobile bearer auth resolves a caller's tenant
+// solely from the tenant_id custom claim on the GIP ID token
+// (services/marketplace-api/internal/auth/gip_verifier.go). Nothing ever
+// wrote that claim, so owners created through the onboarding wizard could
+// authenticate but had every mobile API call refused — surfacing as an
+// endless bounce back to the login screen. The web admin was unaffected
+// because it resolves the tenant from the database.
+//
+// Onboarding now enqueues this write via the outbox for NEW tenants; this
+// command repairs the ones created before that fix.
+//
+// Idempotent: EnsureTenantClaim merges into existing claims and skips
+// accounts that already carry the tenant. Safe to re-run.
+//
+// Usage:
+//
+//	DATABASE_URL=... GIP_PROJECT_ID=... GIP_TENANT_ID=... GIP_WEB_API_KEY=... \
+//	  go run ./cmd/backfill-gip-claims [-dry-run]
+//
+// Exits 0 on complete success; 1 if any owner failed (each failure is
+// logged and the run continues).
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"time"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/platform-api/internal/gipadmin"
+	"github.com/mark8ly/platform-api/internal/tenant"
+)
+
+func main() {
+	dryRun := flag.Bool("dry-run", false, "list what would change without writing")
+	flag.Parse()
+
+	dbURL := mustEnv("DATABASE_URL")
+	cfg := gipadmin.Config{
+		ProjectID: mustEnv("GIP_PROJECT_ID"),
+		TenantID:  mustEnv("GIP_TENANT_ID"),
+		WebAPIKey: mustEnv("GIP_WEB_API_KEY"),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	db, err := gorm.Open(postgres.Open(dbURL), &gorm.Config{})
+	if err != nil {
+		log.Fatalf("open db: %v", err)
+	}
+
+	admin, err := gipadmin.New(ctx, cfg)
+	if err != nil {
+		log.Fatalf("gipadmin init: %v", err)
+	}
+
+	var tenants []tenant.Tenant
+	if err := db.WithContext(ctx).Find(&tenants).Error; err != nil {
+		log.Fatalf("list tenants: %v", err)
+	}
+	log.Printf("found %d tenant(s)", len(tenants))
+
+	var failed int
+	for _, t := range tenants {
+		if t.OwnerUserID == "" {
+			log.Printf("SKIP  %-24s (%s) — no owner_user_id", t.Name, t.ID)
+			continue
+		}
+		if *dryRun {
+			log.Printf("DRY   %-24s owner=%s tenant=%s", t.Name, t.OwnerUserID, t.ID)
+			continue
+		}
+		if err := admin.EnsureTenantClaim(ctx, t.OwnerUserID, t.ID); err != nil {
+			// Keep going: one broken account must not block the rest.
+			log.Printf("FAIL  %-24s owner=%s: %v", t.Name, t.OwnerUserID, err)
+			failed++
+			continue
+		}
+		log.Printf("OK    %-24s owner=%s tenant=%s", t.Name, t.OwnerUserID, t.ID)
+	}
+
+	if failed > 0 {
+		log.Printf("completed with %d failure(s)", failed)
+		os.Exit(1)
+	}
+	log.Print("all tenant owners have their tenant_id claim")
+	log.Print("NOTE: owners must sign out and back in — claims only refresh on a new ID token")
+}
+
+func mustEnv(k string) string {
+	v := os.Getenv(k)
+	if v == "" {
+		log.Fatalf("%s is required", k)
+	}
+	return v
+}

--- a/services/platform-api/cmd/server/main.go
+++ b/services/platform-api/cmd/server/main.go
@@ -246,6 +246,9 @@ func main() {
 	// dev machines without real GIP credentials fall through to GIP's
 	// default behaviour via auth-bff.
 	var authHandler *auth.Handler
+	// Hoisted: the outbox drainer also needs this client, to stamp the
+	// owner's tenant_id GIP custom claim after onboarding completes.
+	var gipAdmin *gipadmin.AdminClient
 	if cfg.GIPProjectID != "" && cfg.GIPTenantID != "" && cfg.GIPWebAPIKey != "" {
 		admin, adminErr := gipadmin.New(context.Background(), gipadmin.Config{
 			ProjectID: cfg.GIPProjectID,
@@ -256,6 +259,7 @@ func main() {
 			log.Error("gipadmin: init", "err", adminErr)
 			log.Warn("auth: password reset disabled — gipadmin init failed")
 		} else {
+			gipAdmin = admin
 			authSvc := auth.NewService(auth.Config{
 				Admin:             admin,
 				Sender:            sender,
@@ -279,6 +283,14 @@ func main() {
 	drainer := outbox.NewDrainer(conn, log, outbox.Config{})
 	if fga != nil {
 		drainer.Register(onboarding.FGAOutboxKind, onboarding.NewFGAOutboxHandler(fga))
+	}
+	if gipAdmin != nil {
+		drainer.Register(onboarding.GIPClaimOutboxKind, onboarding.NewGIPClaimOutboxHandler(gipAdmin))
+	} else {
+		// Unregistered kinds stay pending rather than erroring, so the
+		// rows drain once GIP credentials are configured. Loud, because
+		// mobile-admin login is broken for every new tenant until then.
+		log.Warn("outbox: gip tenant-claim handler NOT registered — mobile admin login will fail for new tenants")
 	}
 
 	// ─── HTTP routes ───────────────────────────────────────────────────

--- a/services/platform-api/internal/gipadmin/claims.go
+++ b/services/platform-api/internal/gipadmin/claims.go
@@ -1,0 +1,180 @@
+package gipadmin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// tenantClaimKey is the custom-claim key marketplace-api reads out of the
+// GIP ID token to decide which tenant a mobile caller belongs to
+// (services/marketplace-api/internal/auth/gip_verifier.go).
+const tenantClaimKey = "tenant_id"
+
+// EnsureTenantClaim adds tenantID to the user's `tenant_id` custom claim,
+// preserving every other claim already on the account.
+//
+// Why this exists: marketplace-api's mobile bearer auth reads `tenant_id`
+// from the ID token, but until now nothing in the codebase ever WROTE it.
+// Every tenant created through the onboarding wizard therefore had an owner
+// who could sign in to GIP but was rejected by the mobile API — the app read
+// that rejection as a dead session and bounced back to the login screen.
+//
+// The claim is written as an ARRAY, which is the shape the verifier's
+// tenantIDFromClaims prefers, so a user can own more than one tenant later
+// without a migration.
+//
+// Merge, don't clobber: accounts are known to carry unrelated claims (e.g.
+// {"admin": true}). We read the current attributes, add to them, and write
+// the union back. GIP has no partial-update for customAttributes — the field
+// is replaced wholesale — so read-modify-write is the only correct approach.
+//
+// Idempotent: if tenantID is already present the call is a no-op and no
+// write is issued, so retries from the outbox drainer are safe.
+func (c *AdminClient) EnsureTenantClaim(ctx context.Context, uid, tenantID string) error {
+	if uid == "" || tenantID == "" {
+		return fmt.Errorf("gipadmin: uid and tenantID are required")
+	}
+
+	attrs, err := c.lookupCustomAttributes(ctx, uid)
+	if err != nil {
+		return err
+	}
+
+	tenants := existingTenantIDs(attrs[tenantClaimKey])
+	for _, t := range tenants {
+		if t == tenantID {
+			return nil // already present — nothing to do
+		}
+	}
+	attrs[tenantClaimKey] = append(tenants, tenantID)
+
+	encoded, err := json.Marshal(attrs)
+	if err != nil {
+		return fmt.Errorf("gipadmin: marshal custom attributes: %w", err)
+	}
+
+	// customAttributes is a JSON *string* field, not a nested object.
+	return c.postAdmin(ctx, "accounts:update", map[string]any{
+		"localId":          uid,
+		"customAttributes": string(encoded),
+	})
+}
+
+// existingTenantIDs normalises whatever shape the claim is currently in.
+// Accepts the array form we write, plus the scalar form the verifier also
+// tolerates, so an account written by any other tool still merges cleanly.
+func existingTenantIDs(v any) []string {
+	switch t := v.(type) {
+	case string:
+		if t == "" {
+			return nil
+		}
+		return []string{t}
+	case []any:
+		// The shape after a JSON round-trip.
+		out := make([]string, 0, len(t))
+		for _, item := range t {
+			if s, ok := item.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		// The shape while still in memory, before marshalling. Omitting
+		// this silently dropped previously-held tenants on a second
+		// append. Mirrors tenantIDFromClaims in marketplace-api, which
+		// accepts the same three shapes.
+		out := make([]string, 0, len(t))
+		for _, s := range t {
+			if s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// lookupCustomAttributes returns the account's current custom claims as a
+// map. An account with no claims yields an empty (non-nil) map.
+func (c *AdminClient) lookupCustomAttributes(ctx context.Context, uid string) (map[string]any, error) {
+	raw, err := c.doAdmin(ctx, "accounts:lookup", map[string]any{
+		"localId": []string{uid},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed struct {
+		Users []struct {
+			CustomAttributes string `json:"customAttributes"`
+		} `json:"users"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("gipadmin: decode lookup response: %w", err)
+	}
+	if len(parsed.Users) == 0 {
+		return nil, ErrUserNotFound
+	}
+
+	attrs := map[string]any{}
+	if s := parsed.Users[0].CustomAttributes; s != "" {
+		if err := json.Unmarshal([]byte(s), &attrs); err != nil {
+			// Corrupt claims would otherwise be silently replaced,
+			// destroying whatever was there. Fail loudly instead.
+			return nil, fmt.Errorf("gipadmin: existing customAttributes is not valid JSON: %w", err)
+		}
+	}
+	return attrs, nil
+}
+
+// postAdmin issues a tenant-scoped admin call and discards the body.
+func (c *AdminClient) postAdmin(ctx context.Context, method string, body map[string]any) error {
+	_, err := c.doAdmin(ctx, method, body)
+	return err
+}
+
+// doAdmin issues an OAuth-authenticated call against the tenant-scoped
+// Identity Toolkit admin API and returns the raw response body.
+func (c *AdminClient) doAdmin(ctx context.Context, method string, body map[string]any) ([]byte, error) {
+	url := fmt.Sprintf(
+		"https://identitytoolkit.googleapis.com/v1/projects/%s/tenants/%s/%s",
+		c.cfg.ProjectID, c.cfg.TenantID, method,
+	)
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("gipadmin: marshal %s request: %w", method, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("gipadmin: build %s request: %w", method, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	tok, err := c.tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrUnauthenticated, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrUnavailable, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return respBody, nil
+	}
+
+	errMsg := parseIdentityToolkitError(respBody)
+	if errMsg == "USER_NOT_FOUND" {
+		return nil, ErrUserNotFound
+	}
+	return nil, fmt.Errorf("gipadmin: %s %d: %s", method, resp.StatusCode, errMsg)
+}

--- a/services/platform-api/internal/gipadmin/claims_test.go
+++ b/services/platform-api/internal/gipadmin/claims_test.go
@@ -1,0 +1,89 @@
+package gipadmin
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestExistingTenantIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want []string
+	}{
+		{"array form (what we write)", []any{"t1", "t2"}, []string{"t1", "t2"}},
+		{"scalar form (tolerated)", "t1", []string{"t1"}},
+		{"empty scalar", "", nil},
+		{"absent", nil, nil},
+		{"empty array", []any{}, []string{}},
+		{"non-string entries skipped", []any{"t1", 42, ""}, []string{"t1"}},
+		{"unexpected type", map[string]any{"x": 1}, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := existingTenantIDs(tc.in)
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("existingTenantIDs(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// The merge must preserve unrelated claims. A real production account
+// carries {"admin": true}; clobbering customAttributes would silently strip
+// that and demote the user. GIP replaces the field wholesale, so this is a
+// genuine hazard rather than a theoretical one.
+func TestMergePreservesUnrelatedClaims(t *testing.T) {
+	attrs := map[string]any{"admin": true, "region": "in"}
+
+	tenants := existingTenantIDs(attrs[tenantClaimKey])
+	attrs[tenantClaimKey] = append(tenants, "tenant-new")
+
+	encoded, err := json.Marshal(attrs)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round map[string]any
+	if err := json.Unmarshal(encoded, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if round["admin"] != true {
+		t.Error("admin claim was lost — merge clobbered unrelated claims")
+	}
+	if round["region"] != "in" {
+		t.Error("region claim was lost")
+	}
+	got := existingTenantIDs(round[tenantClaimKey])
+	if !reflect.DeepEqual(got, []string{"tenant-new"}) {
+		t.Errorf("tenant_id = %v, want [tenant-new]", got)
+	}
+}
+
+// Appending a second tenant must keep the first — owners may hold more
+// than one store.
+func TestMergeAppendsAdditionalTenant(t *testing.T) {
+	attrs := map[string]any{tenantClaimKey: []any{"tenant-a"}}
+
+	tenants := existingTenantIDs(attrs[tenantClaimKey])
+	attrs[tenantClaimKey] = append(tenants, "tenant-b")
+
+	got := existingTenantIDs(attrs[tenantClaimKey])
+	if !reflect.DeepEqual(got, []string{"tenant-a", "tenant-b"}) {
+		t.Errorf("tenant_id = %v, want [tenant-a tenant-b]", got)
+	}
+}
+
+func TestEnsureTenantClaimRejectsEmptyArgs(t *testing.T) {
+	c := &AdminClient{}
+	if err := c.EnsureTenantClaim(t.Context(), "", "tenant"); err == nil {
+		t.Error("empty uid should error")
+	}
+	if err := c.EnsureTenantClaim(t.Context(), "uid", ""); err == nil {
+		t.Error("empty tenantID should error")
+	}
+}

--- a/services/platform-api/internal/onboarding/gip_claim_handler.go
+++ b/services/platform-api/internal/onboarding/gip_claim_handler.go
@@ -1,0 +1,62 @@
+package onboarding
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark8ly/platform-api/internal/outbox"
+)
+
+// GIPClaimOutboxKind is the outbox kind for writing the owner's tenant_id
+// custom claim into Google Identity Platform.
+const GIPClaimOutboxKind = "gip.set_tenant_claim"
+
+// gipClaimPayload is the outbox payload for GIPClaimOutboxKind.
+type gipClaimPayload struct {
+	UserID   string `json:"user_id"`
+	TenantID string `json:"tenant_id"`
+}
+
+// TenantClaimSetter writes the tenant_id custom claim onto a GIP user.
+// gipadmin.AdminClient satisfies this. Kept as an interface so onboarding
+// does not depend on the concrete client and can be tested with a fake.
+type TenantClaimSetter interface {
+	EnsureTenantClaim(ctx context.Context, uid, tenantID string) error
+}
+
+// NewGIPClaimOutboxHandler returns the outbox handler that stamps the
+// owner's tenant_id custom claim onto their GIP account.
+//
+// Why this must exist, and why it goes through the outbox:
+//
+// marketplace-api's mobile bearer auth resolves a caller's tenant purely
+// from the tenant_id custom claim on the GIP ID token
+// (services/marketplace-api/internal/auth/gip_verifier.go). Nothing in the
+// codebase ever wrote that claim, so every tenant created through the
+// onboarding wizard had an owner who could authenticate but was refused by
+// the mobile API — which the app surfaced as an endless bounce back to the
+// login screen. The web admin was unaffected because it resolves the tenant
+// from the database instead.
+//
+// It rides the outbox rather than a best-effort post-commit call (as
+// EnsureSelfVendor does) precisely because a silent failure here locks the
+// owner out of the mobile app entirely. The drainer retries with backoff, so
+// a transient Identity Toolkit outage self-heals instead of stranding them.
+//
+// EnsureTenantClaim is idempotent, so redelivery is safe.
+func NewGIPClaimOutboxHandler(claims TenantClaimSetter) outbox.Handler {
+	return func(ctx context.Context, payload json.RawMessage) error {
+		var p gipClaimPayload
+		if err := json.Unmarshal(payload, &p); err != nil {
+			return fmt.Errorf("gip claim outbox: parse payload: %w", err)
+		}
+		if p.UserID == "" || p.TenantID == "" {
+			return fmt.Errorf("gip claim outbox: missing user_id or tenant_id")
+		}
+		if err := claims.EnsureTenantClaim(ctx, p.UserID, p.TenantID); err != nil {
+			return fmt.Errorf("gip claim outbox: set tenant claim for %s: %w", p.UserID, err)
+		}
+		return nil
+	}
+}

--- a/services/platform-api/internal/onboarding/gip_claim_handler_test.go
+++ b/services/platform-api/internal/onboarding/gip_claim_handler_test.go
@@ -1,0 +1,64 @@
+package onboarding
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+type fakeClaimSetter struct {
+	calls []struct{ uid, tenantID string }
+	err   error
+}
+
+func (f *fakeClaimSetter) EnsureTenantClaim(_ context.Context, uid, tenantID string) error {
+	f.calls = append(f.calls, struct{ uid, tenantID string }{uid, tenantID})
+	return f.err
+}
+
+func TestGIPClaimOutboxHandler_WritesClaim(t *testing.T) {
+	fake := &fakeClaimSetter{}
+	h := NewGIPClaimOutboxHandler(fake)
+
+	payload, _ := json.Marshal(gipClaimPayload{UserID: "uid-1", TenantID: "tenant-1"})
+	if err := h(t.Context(), payload); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+
+	if len(fake.calls) != 1 {
+		t.Fatalf("EnsureTenantClaim called %d times, want 1", len(fake.calls))
+	}
+	if fake.calls[0].uid != "uid-1" || fake.calls[0].tenantID != "tenant-1" {
+		t.Errorf("called with %+v, want {uid-1 tenant-1}", fake.calls[0])
+	}
+}
+
+// A failure must be returned so the drainer retries. Swallowing it would
+// leave the owner permanently locked out of the mobile app — the exact
+// failure mode this handler exists to prevent.
+func TestGIPClaimOutboxHandler_PropagatesErrorForRetry(t *testing.T) {
+	fake := &fakeClaimSetter{err: errors.New("identity toolkit unavailable")}
+	h := NewGIPClaimOutboxHandler(fake)
+
+	payload, _ := json.Marshal(gipClaimPayload{UserID: "uid-1", TenantID: "tenant-1"})
+	if err := h(t.Context(), payload); err == nil {
+		t.Fatal("handler swallowed the error; the drainer would mark it complete and never retry")
+	}
+}
+
+func TestGIPClaimOutboxHandler_RejectsIncompletePayload(t *testing.T) {
+	h := NewGIPClaimOutboxHandler(&fakeClaimSetter{})
+
+	for _, tc := range []struct{ name, body string }{
+		{"missing user_id", `{"tenant_id":"t1"}`},
+		{"missing tenant_id", `{"user_id":"u1"}`},
+		{"not json", `{`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := h(t.Context(), json.RawMessage(tc.body)); err == nil {
+				t.Errorf("payload %q accepted, want error", tc.body)
+			}
+		})
+	}
+}

--- a/services/platform-api/internal/onboarding/service.go
+++ b/services/platform-api/internal/onboarding/service.go
@@ -310,6 +310,18 @@ func (s *Service) Complete(ctx context.Context, req CompleteRequest) (*CompleteR
 		}); err != nil {
 			return err
 		}
+		// Stamp the owner's tenant_id GIP custom claim. marketplace-api's
+		// mobile auth resolves the caller's tenant from this claim alone,
+		// so without it the owner authenticates but every mobile API call
+		// is refused — which the app renders as a login bounce loop. Rides
+		// the same transaction/outbox as the FGA tuple so it is retried
+		// until it lands rather than silently locking the owner out.
+		if err := outbox.Enqueue(tx, GIPClaimOutboxKind, gipClaimPayload{
+			UserID:   req.OwnerUserID,
+			TenantID: t.ID,
+		}); err != nil {
+			return err
+		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
## Problem

Mobile admin login bounced endlessly back to the sign-in screen — for **every tenant created through the onboarding wizard**, on **every provider** (password, Google, Apple). Web was unaffected.

Two independent defects compounded:

**1. Nothing ever wrote the `tenant_id` custom claim.**
`marketplace-api` resolves a mobile caller's tenant *solely* from the `tenant_id` claim on the GIP ID token (`gip_verifier.go:34`). But there is **not a single `SetCustomUserClaims` call anywhere in the repo** — `gipadmin` only did password resets. Onboarding created the tenant, store, and FGA tuples, and never touched GIP claims.

Production state when diagnosed — **4 of 5 tenants locked out**:

| Tenant | claim |
|---|---|
| The Bondi Store | `{"tenant_id":["8c302556…"]}` (set by hand) |
| The Facade Factory | none |
| My God | `{"admin":true}` — no tenant_id |
| Apple Store | none |
| Phone Store | none |

**2. A missing claim was reported as 401.**
`gip_verifier` returned an error → `GIPBearerAuth` → `401 invalid or expired token` → mobile client reads a 401 surviving refresh as a dead session → `signOut()` → router redirects to `/login`. An oscillation with no error shown.

Web is unaffected because it resolves the tenant from the **database**, never the claim.

## Fix

**`marketplace-api`** — "no store" is an *authorization* fact, not an authentication failure. Pass through with an empty `tenant_id` and let `authz.RequireTenantRelation` answer 404, which `TenantGate` already renders as **"No store yet"**. That empty state existed all along and could never render, because the 401 tore the session down first. Invalid tokens still 401.

**`platform-api`**
- `gipadmin.EnsureTenantClaim` — writes `tenant_id` as an array; **merges** rather than clobbers. GIP replaces `customAttributes` wholesale and a real account carries `{"admin":true}`, so a naive write would silently strip it. Idempotent → outbox redelivery is safe.
- Enqueued **in the same transaction as the FGA tuple**, via the outbox — deliberately *not* best-effort like `EnsureSelfVendor`, because a silent failure locks the owner out of mobile entirely. Retries with backoff.
- `cmd/backfill-gip-claims` — repairs pre-existing owners. Idempotent, `-dry-run`, continues past individual failures.

## Tests

New unit tests for: 401-vs-404 contract (both directions), claim merge preserving unrelated claims, multi-tenant append, outbox handler error propagation (so the drainer retries), payload validation.

A test caught a real bug during development: `existingTenantIDs` handled `string` and `[]any` but not `[]string`, so appending a **second** tenant silently dropped the first. Fixed.

> [!WARNING]
> Integration tests compile and vet clean but were **not executed** — no local Docker, and CI skips them without `TEST_DATABASE_URL`. Coverage here is unit tests plus direct verification against prod GIP/DB state.

## Post-merge steps (required)

1. Run `cmd/backfill-gip-claims` against prod for the 4 affected owners
2. **Owners must sign out and back in** — claims only refresh on a new ID token

## Out of scope

- **Web "Sign in with Apple"** cannot be added yet: the Apple provider is configured native-only (`bundleIds: ["com.mark8ly.admin"]`, `clientId`/`clientSecret` empty). Web needs an Apple **Services ID**, a `.p8`-signed client secret (**expires every 6 months**), a registered return URL, and domain verification — all Apple Developer Portal actions.
- **Apple "Hide My Email"** still forks a separate account by design; the existing Settings → Security link flow is the supported path.

## Design note

The claim is a **snapshot** — it goes stale if membership changes and only refreshes on a new ID token. Resolving tenancy server-side from the DB (as web does) would be more robust. This PR makes the existing claim-based path correct rather than replacing it.