### PR TITLE
feat(admin): add Sign in with Apple to the web login, gated on config

### DIFF
--- a/apps/admin/components/auth/SignInForm.tsx
+++ b/apps/admin/components/auth/SignInForm.tsx
@@ -19,9 +19,12 @@ import { z } from "zod";
 import { Input } from "@tesserix/web";
 import { Field } from "@repo/ui/field";
 import { GoogleMark } from "@repo/ui/google-mark";
+import { AppleMark } from "@repo/ui/apple-mark";
 
-import { signInWithPassword, signInWithGoogle, GIPError } from "@/lib/gip/signup";
+import { signInWithPassword, signInWithGoogle, signInWithApple, GIPError } from "@/lib/gip/signup";
 import { getGoogleCredential } from "@/lib/gip/google-gsi";
+import { getAppleCredential } from "@/lib/gip/apple-js";
+import { appleSignInEnabled } from "@/lib/config";
 import { linkGoogleToInternalPassword } from "@/lib/gip/link";
 import { signIn, confirmMFALogin } from "@/app/login/actions";
 import { prepareCrossDomainNavigation } from "@/lib/auth/cross-domain-handoff";
@@ -78,6 +81,7 @@ export function SignInForm({ returnUrl }: SignInFormProps = {}) {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
   const [googlePending, setGooglePending] = useState(false);
+  const [applePending, setApplePending] = useState(false);
   const [needConfirmation, setNeedConfirmation] = useState<{
     email: string;
     pendingIdpCredential: string;
@@ -106,7 +110,7 @@ export function SignInForm({ returnUrl }: SignInFormProps = {}) {
     defaultValues: { email: "", password: "" },
   });
 
-  const disabled = pending || googlePending;
+  const disabled = pending || googlePending || applePending;
 
   function onValid(values: FormValues) {
     setSubmitError(null);
@@ -169,6 +173,35 @@ export function SignInForm({ returnUrl }: SignInFormProps = {}) {
       return;
     }
     await goToDestination(r.data.multipleTenants ? "/pick-tenant" : "/dashboard");
+  }
+
+  async function handleApple() {
+    setSubmitError(null);
+    setApplePending(true);
+    try {
+      const { idToken: appleToken, nonce } = await getAppleCredential();
+      const result = await signInWithApple(appleToken, nonce);
+      if (result.kind === "needConfirmation") {
+        // Same linking prompt as Google: GIP already has this email under
+        // another provider and wants proof before joining them.
+        setNeedConfirmation({
+          email: result.email,
+          pendingIdpCredential: result.pendingIdpCredential,
+        });
+        return;
+      }
+      await completeSignIn(result.idToken, result.uid);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "";
+      // Closing Apple's popup is a normal user action, not an error worth
+      // shouting about.
+      if (msg.includes("popup_closed") || msg.includes("user_cancelled")) {
+        return;
+      }
+      setSubmitError(msg ? `Apple sign-in failed: ${msg}` : "Apple sign-in failed");
+    } finally {
+      setApplePending(false);
+    }
   }
 
   async function handleGoogle() {
@@ -388,6 +421,21 @@ export function SignInForm({ returnUrl }: SignInFormProps = {}) {
           <GoogleMark />
           {googlePending ? "Opening Google…" : "Continue with Google"}
         </button>
+
+        {/* Rendered only when a Services ID is configured. Apple treats web
+            as a separate client from the iOS app, so until that exists the
+            button would fail at Apple rather than in our code. */}
+        {appleSignInEnabled && (
+          <button
+            type="button"
+            onClick={handleApple}
+            disabled={disabled}
+            className="mt-3 inline-flex h-11 w-full items-center justify-center gap-3 rounded-md border border-border bg-background-elevated px-6 text-sm font-medium text-foreground hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <AppleMark />
+            {applePending ? "Opening Apple…" : "Continue with Apple"}
+          </button>
+        )}
 
         <p className="text-center text-xs text-foreground-tertiary">
           Don&apos;t have a store yet?{" "}

--- a/apps/admin/lib/config.ts
+++ b/apps/admin/lib/config.ts
@@ -14,4 +14,15 @@ export const publicConfig = {
   gipTenantId: process.env.NEXT_PUBLIC_GIP_TENANT_ID ?? "",
   gipApiKey: process.env.NEXT_PUBLIC_GIP_API_KEY ?? "",
   googleClientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ?? "",
+  // Apple *Services ID* (e.g. "com.mark8ly.admin.web") — NOT the iOS bundle
+  // ID. Apple treats native and web as separate clients: the native app uses
+  // a bundle ID, the web flow needs a Services ID registered with a return
+  // URL. Empty until that Services ID exists in the Apple Developer account
+  // AND its client secret is configured on the GIP apple.com provider; the
+  // sign-in button stays hidden until then, because a button that 400s at
+  // Apple is worse than no button.
+  appleServicesId: process.env.NEXT_PUBLIC_APPLE_SERVICES_ID ?? "",
 } as const;
+
+/** True when web Sign in with Apple is fully configured. */
+export const appleSignInEnabled = Boolean(publicConfig.appleServicesId);

--- a/apps/admin/lib/gip/apple-js.ts
+++ b/apps/admin/lib/gip/apple-js.ts
@@ -1,0 +1,140 @@
+// Browser-only wrapper around "Sign in with Apple JS".
+//
+// Mirrors google-gsi.ts: lazily load Apple's SDK, run the popup, and resolve
+// with the Apple identity token. The caller exchanges that token via
+// signInWithApple (Identity Toolkit signInWithIdp) for a GIP id_token in our
+// tenant pool.
+//
+// Why a separate SDK rather than reusing the Google path: Apple does not
+// expose a one-tap credential API, and GIP cannot mint an Apple credential
+// on its own — the browser must complete Apple's own OAuth dance first.
+//
+// Prerequisites that live OUTSIDE this repo (see docs/apple-web-signin.md):
+//   1. An Apple *Services ID* — the web client_id. The iOS bundle ID does
+//      not work here; Apple treats native and web as different clients.
+//   2. That Services ID configured with a return URL pointing at GIP's
+//      handler, and its domain verified with Apple.
+//   3. A .p8 key turned into a client secret on the GIP apple.com provider.
+//      Apple caps that secret at 6 months — it must be rotated or web Apple
+//      sign-in breaks with no warning.
+
+import { publicConfig } from "@/lib/config";
+
+const SCRIPT_URL =
+  "https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js";
+
+// GIP's hosted OAuth handler. Apple redirects here, not to our own domain,
+// which is what keeps per-tenant admin subdomains ({slug}-admin.mark8ly.com)
+// out of Apple's domain allow-list — Apple has no wildcard support, so
+// registering each tenant subdomain would not scale.
+const gipRedirectURI = () =>
+  `https://${publicConfig.gipProjectId}.firebaseapp.com/__/auth/handler`;
+
+interface AppleAuthResponse {
+  authorization: { id_token: string; code: string; state?: string };
+  // Only present on the FIRST authorization, and omitted entirely when the
+  // user picks "Hide My Email".
+  user?: { name?: { firstName?: string; lastName?: string }; email?: string };
+}
+
+interface AppleIDAuth {
+  init(opts: {
+    clientId: string;
+    scope: string;
+    redirectURI: string;
+    state?: string;
+    nonce?: string;
+    usePopup: boolean;
+  }): void;
+  signIn(): Promise<AppleAuthResponse>;
+}
+
+declare global {
+  interface Window {
+    AppleID?: { auth: AppleIDAuth };
+  }
+}
+
+let scriptPromise: Promise<void> | null = null;
+
+function loadScript(): Promise<void> {
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("apple sign-in only available in the browser"));
+  }
+  if (window.AppleID?.auth) return Promise.resolve();
+  if (scriptPromise) return scriptPromise;
+
+  scriptPromise = new Promise((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src="${SCRIPT_URL}"]`,
+    );
+    if (existing) {
+      existing.addEventListener("load", () => resolve());
+      existing.addEventListener("error", () => reject(new Error("apple sdk load failed")));
+      return;
+    }
+    const s = document.createElement("script");
+    s.src = SCRIPT_URL;
+    s.async = true;
+    s.defer = true;
+    s.onload = () => resolve();
+    s.onerror = () => {
+      // Reset so a later attempt can retry rather than reusing a rejected
+      // promise for the lifetime of the page.
+      scriptPromise = null;
+      reject(new Error("apple sdk load failed"));
+    };
+    document.head.appendChild(s);
+  });
+  return scriptPromise;
+}
+
+/** Cryptographically random nonce, hex-encoded. */
+function randomNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Runs Apple's popup and returns the identity token plus the nonce it was
+ * bound to.
+ *
+ * The nonce is generated per attempt and passed to signInWithIdp so Apple's
+ * token cannot be replayed. The mobile client currently hardcodes an empty
+ * nonce (apps/mobile-admin/lib/social-auth.ts) — do not copy that here.
+ */
+export async function getAppleCredential(): Promise<{
+  idToken: string;
+  nonce: string;
+}> {
+  if (!publicConfig.appleServicesId) {
+    throw new Error(
+      "Apple sign-in is not configured (NEXT_PUBLIC_APPLE_SERVICES_ID missing)",
+    );
+  }
+  if (!publicConfig.gipProjectId) {
+    throw new Error("Apple sign-in is not configured (NEXT_PUBLIC_GIP_PROJECT_ID missing)");
+  }
+
+  await loadScript();
+  if (!window.AppleID?.auth) {
+    throw new Error("apple sdk unavailable after load");
+  }
+
+  const nonce = randomNonce();
+  window.AppleID.auth.init({
+    clientId: publicConfig.appleServicesId,
+    scope: "name email",
+    redirectURI: gipRedirectURI(),
+    nonce,
+    usePopup: true,
+  });
+
+  const res = await window.AppleID.auth.signIn();
+  const idToken = res?.authorization?.id_token;
+  if (!idToken) {
+    throw new Error("apple returned no identity token");
+  }
+  return { idToken, nonce };
+}

--- a/apps/admin/lib/gip/signup.ts
+++ b/apps/admin/lib/gip/signup.ts
@@ -278,3 +278,90 @@ export async function signUp(
     expiresIn: parseInt(signupBody.expiresIn, 10),
   };
 }
+
+/**
+ * Exchanges an Apple identity token for a GIP id_token in our tenant pool.
+ *
+ * Same shape as signInWithGoogle — including the needConfirmation branch,
+ * which fires when GIP has an existing account with this email under a
+ * different provider and the caller must re-authenticate to link.
+ *
+ * The nonce must be the one getAppleCredential() bound into Apple's token;
+ * GIP verifies the pair, which is what stops the token being replayed.
+ *
+ * Caveat worth knowing: if the user picks Apple's "Hide My Email", Apple
+ * reports a @privaterelay.appleid.com address rather than their real one.
+ * GIP therefore sees a different email, no conflict is raised, and a
+ * SEPARATE account is created. Email-based linking cannot fix that — the
+ * user must link Apple from account settings while already signed in.
+ */
+export async function signInWithApple(
+  appleIdToken: string,
+  nonce: string,
+): Promise<GoogleSignInResult> {
+  if (!publicConfig.gipApiKey) {
+    throw new GIPError("config_missing", "GIP Web API key is not configured");
+  }
+  if (!publicConfig.gipTenantId) {
+    throw new GIPError("config_missing", "GIP tenant id is not configured");
+  }
+
+  const url = `https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=${publicConfig.gipApiKey}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      tenantId: publicConfig.gipTenantId,
+      requestUri:
+        typeof window !== "undefined" ? window.location.origin : "https://admin.mark8ly.com",
+      postBody: `id_token=${encodeURIComponent(appleIdToken)}&providerId=apple.com&nonce=${encodeURIComponent(nonce)}`,
+      returnSecureToken: true,
+      returnIdpCredential: true,
+    }),
+  });
+
+  if (!res.ok) {
+    let body: { error?: { message?: string } } = {};
+    try {
+      body = await res.json();
+    } catch {
+      // ignore
+    }
+    throw new GIPError(
+      "apple_signin_failed",
+      body.error?.message ?? `HTTP ${res.status}`,
+    );
+  }
+
+  const data = (await res.json()) as {
+    localId?: string;
+    idToken?: string;
+    refreshToken?: string;
+    expiresIn?: string;
+    needConfirmation?: boolean;
+    email?: string;
+    oauthIdToken?: string;
+    verifiedProvider?: string[];
+  };
+
+  if (data.needConfirmation && data.email && data.oauthIdToken) {
+    return {
+      kind: "needConfirmation",
+      email: data.email,
+      pendingIdpCredential: data.oauthIdToken,
+      verifiedProvider: data.verifiedProvider ?? [],
+    };
+  }
+
+  if (!data.localId || !data.idToken || !data.refreshToken || !data.expiresIn) {
+    throw new GIPError("malformed_response", "GIP response missing required fields");
+  }
+
+  return {
+    kind: "ok",
+    uid: data.localId,
+    idToken: data.idToken,
+    refreshToken: data.refreshToken,
+    expiresIn: parseInt(data.expiresIn, 10),
+  };
+}

--- a/docs/apple-web-signin.md
+++ b/docs/apple-web-signin.md
@@ -1,0 +1,109 @@
+# Sign in with Apple — web admin
+
+The web sign-in code is complete and merged. The button is **hidden until
+configured**, because Apple treats web as a separate client from the iOS app
+and a button without a Services ID fails at Apple rather than in our code.
+
+Native (mobile-admin) already works — it uses the bundle ID
+`com.mark8ly.admin`. Web needs its own client. That is the only gap.
+
+## Current state
+
+```
+apple.com    enabled:      true
+             bundleIds:    ["com.mark8ly.admin"]   # native, working
+             clientId:     EMPTY                   # web Services ID — missing
+             clientSecret: EMPTY                   # derived from a .p8 key — missing
+```
+
+## Setup (Apple Developer account required)
+
+Nobody outside the Apple Developer account can do these steps.
+
+### 1. Create a Services ID
+
+Certificates, IDs & Profiles → Identifiers → **+** → **Services IDs**
+
+- Description: `Mark8ly Admin Web`
+- Identifier: `com.mark8ly.admin.web` (this becomes the web `clientId`)
+
+### 2. Configure it for Sign in with Apple
+
+Enable **Sign in with Apple** on the Services ID → **Configure**:
+
+- Primary App ID: the existing `com.mark8ly.admin`
+- Domains and Subdomains: `tesseracthub-480811.firebaseapp.com`
+- Return URLs: `https://tesseracthub-480811.firebaseapp.com/__/auth/handler`
+
+> The return URL points at **GIP's** handler, not at our own domain. That is
+> deliberate and load-bearing: Apple does **not** support wildcard domains,
+> so if the return URL lived on `{slug}-admin.mark8ly.com` every tenant
+> subdomain would need registering by hand. Routing through GIP's fixed
+> handler means one domain covers every tenant.
+
+### 3. Create a signing key
+
+Certificates, IDs & Profiles → Keys → **+**
+
+- Enable **Sign in with Apple**, bind it to the primary App ID
+- Download the `.p8` — **Apple allows this exactly once**
+- Record the **Key ID** and your **Team ID**
+
+### 4. Configure GIP
+
+Identity Platform → Providers → Apple, on tenant `MP-Internal-e986p`:
+
+- Services ID → `clientId`
+- Team ID, Key ID, and the `.p8` contents → used to mint the client secret
+
+### 5. Set the app env var
+
+```
+NEXT_PUBLIC_APPLE_SERVICES_ID=com.mark8ly.admin.web
+```
+
+Set it on the `mark8ly-admin` chart in `tesserix-k8s`. The button appears
+once this is present (`appleSignInEnabled` in `apps/admin/lib/config.ts`).
+
+## ⚠️ The client secret expires every 6 months
+
+Apple caps the Sign in with Apple client secret at **6 months**. When it
+lapses, web Apple sign-in breaks with no warning and no deploy to correlate
+it with — it simply stops working.
+
+**Assign an owner and a calendar reminder now.** This is the single most
+common way Sign in with Apple breaks in production. Native is unaffected;
+only the web flow uses this secret.
+
+## "Hide My Email" is not solved by any of the above
+
+If a user picks **Hide My Email**, Apple reports
+`something@privaterelay.appleid.com` instead of their real address. GIP sees
+a different email, so no conflict is raised and a **separate account** is
+created — one that owns no tenant, and therefore no store.
+
+This is Apple's design, not a configuration mistake, and **email-based
+account linking cannot fix it**: there is no shared email to match on.
+
+The supported path is explicit linking while already signed in:
+**Settings → Security → Link Apple**, which binds the Apple identity
+(relay address and all) to the existing account's UID.
+
+The durable fix would be supporting multiple identities per owner rather
+than the single `owner_user_id` the schema has today. That is a schema
+change and is not planned yet.
+
+## Implementation map
+
+| Piece | File |
+|---|---|
+| Apple JS SDK loader, popup, nonce | `apps/admin/lib/gip/apple-js.ts` |
+| GIP token exchange | `apps/admin/lib/gip/signup.ts` (`signInWithApple`) |
+| Button + handler | `apps/admin/components/auth/SignInForm.tsx` |
+| Config flag | `apps/admin/lib/config.ts` (`appleSignInEnabled`) |
+| Logo | `packages/ui/src/apple-mark.tsx` |
+
+The web flow generates a **random nonce per attempt** and binds it into the
+Apple token, so the token cannot be replayed. Note that mobile currently
+hardcodes an empty nonce (`apps/mobile-admin/lib/social-auth.ts`) — that is
+a known gap, tracked separately; do not copy it.

--- a/packages/ui/src/apple-mark.tsx
+++ b/packages/ui/src/apple-mark.tsx
@@ -1,0 +1,28 @@
+interface AppleMarkProps {
+  size?: number;
+}
+
+/**
+ * AppleMark — the Apple logo used in "Continue with Apple" buttons.
+ * Lives in @repo/ui alongside GoogleMark so every app shares one mark.
+ *
+ * Uses currentColor rather than a fixed black: Apple's Human Interface
+ * Guidelines require the logo to stay legible against its background, and
+ * the admin renders these buttons in both light and dark themes.
+ *
+ * Keep aria-hidden — the button's text label ("Continue with Apple") is
+ * the accessible name.
+ */
+export function AppleMark({ size = 18 }: AppleMarkProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 814 1000"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57-155.5-127C46.7 790.7 0 663 0 541.8c0-194.4 126.4-297.5 250.8-297.5 66.1 0 121.2 43.4 162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zM554 159.4c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Problem

The web admin offered only password and Google. Apple was **enabled** on the GIP tenant but configured **native-only**:

```
apple.com    enabled:      true
             bundleIds:    ["com.mark8ly.admin"]   ← native, working
             clientId:     EMPTY                   ← web Services ID, missing
             clientSecret: EMPTY
```

Apple treats web as a **separate client** from the iOS app. It needs its own Services ID, so there was nothing to hook a button up to.

## What this adds

| Piece | File |
|---|---|
| Apple JS SDK loader + popup + nonce | `apps/admin/lib/gip/apple-js.ts` |
| GIP token exchange | `apps/admin/lib/gip/signup.ts` → `signInWithApple` |
| Button + handler | `apps/admin/components/auth/SignInForm.tsx` |
| Config gate | `apps/admin/lib/config.ts` → `appleSignInEnabled` |
| Logo | `packages/ui/src/apple-mark.tsx` |
| Setup runbook | `docs/apple-web-signin.md` |

Mirrors the existing Google path, including the `needConfirmation` branch so an existing email under another provider still routes to the linking prompt.

## Ships dark — nothing changes until configured

The button renders **only** when `NEXT_PUBLIC_APPLE_SERVICES_ID` is set. Prod does not set it (verified: 0 matches on the `mark8ly-admin` deployment), so this is a no-op on merge.

That gate is deliberate: without a Services ID the request fails **at Apple**, not in our code, so a visible button would be worse than no button.

## Two decisions worth reviewing

**Return URL points at GIP's hosted handler, not our own domain.** This is load-bearing: Apple does **not** support wildcard domains. A return URL on `{slug}-admin.mark8ly.com` would require registering every tenant subdomain by hand. Routing through GIP's fixed handler covers all tenants with one registration.

**A random nonce is generated per attempt** and bound into Apple's token, so it cannot be replayed. Note `apps/mobile-admin/lib/social-auth.ts` currently hardcodes an empty nonce — a real gap, tracked separately, deliberately not copied here.

## Verification

- `tsc --noEmit` clean
- `next build` succeeds
- Button gating verified against the live prod deployment env

`next lint` is a stub in this app (removed in Next 16), so `tsc` is the real gate.

## Still requires Apple Developer setup — I cannot do this

Steps are in `docs/apple-web-signin.md`: create a Services ID, configure it with GIP's return URL, create a `.p8` key, wire it into GIP, then set the env var.

> [!WARNING]
> The Apple client secret **expires every 6 months**. When it lapses, web Apple sign-in breaks with no warning and no deploy to correlate against. Assign an owner and a calendar reminder — this is the most common way Sign in with Apple breaks in production. Native is unaffected.

## Not solved

**Apple "Hide My Email"** reports a `@privaterelay.appleid.com` address, so GIP sees a different email, raises no conflict, and creates a **separate account** owning no store. Email-based linking cannot fix this — there is no shared email to match on. The signed-in **Settings → Security → Link Apple** flow remains the supported path.

The durable fix is supporting multiple identities per owner instead of the single `owner_user_id`; that is a schema change and not planned here.