### PR TITLE
fix(marketplace-api): stop CSV poll loop querying with an empty store uuid

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1364,19 +1364,36 @@ func main() {
 			defer close(done)
 			ticker := time.NewTicker(5 * time.Second)
 			defer ticker.Stop()
+			// Only log when the pending count or the error state changes —
+			// a 5s tick would otherwise flood the log with identical lines.
+			lastPending := -1
+			var lastErr string
 			for {
 				select {
 				case <-workerCtx.Done():
 					return
 				case <-ticker.C:
-					jobs, _, err := csvRepo.ListByStore(workerCtx, "", 1, 1)
-					_ = jobs
+					jobs, err := csvRepo.FindQueuedJobs(workerCtx, 10)
 					if err != nil {
-						log.Error("csvjob: poll error", "err", err)
+						if workerCtx.Err() != nil {
+							return
+						}
+						if err.Error() != lastErr {
+							lastErr = err.Error()
+							log.Error("csvjob: poll error", "err", err)
+						}
+						continue
 					}
-					// Full worker dispatch is wired when handlers submit
-					// jobs — the polling loop here ensures queued jobs from
-					// crash recovery are eventually picked up.
+					lastErr = ""
+					if len(jobs) != lastPending {
+						lastPending = len(jobs)
+						if lastPending > 0 {
+							log.Info("csvjob: queued jobs awaiting dispatch", "count", lastPending)
+						}
+					}
+					// Dispatch is driven by the submit handler once the CSV
+					// upload writes to GCS; this loop reports the backlog of
+					// jobs recovered from a crash so it is visible in logs.
 				}
 			}
 		}()

--- a/services/marketplace-api/internal/csvjob/repository.go
+++ b/services/marketplace-api/internal/csvjob/repository.go
@@ -20,6 +20,7 @@ type Repository interface {
 	UpdateProgress(ctx context.Context, id string, lastRow, successCount, errorCount int) error
 	UpdateHeartbeat(ctx context.Context, id string) error
 	FindOrphanedJobs(ctx context.Context, staleDuration time.Duration) ([]CsvImportJob, error)
+	FindQueuedJobs(ctx context.Context, limit int) ([]CsvImportJob, error)
 	FindByContentHash(ctx context.Context, storeID, contentHash string) (*CsvImportJob, error)
 	SetStatusFields(ctx context.Context, id string, fields map[string]any) error
 }
@@ -56,6 +57,12 @@ func (r *gormRepository) ListByStore(ctx context.Context, storeID string, page, 
 	}
 	if pageSize <= 0 {
 		pageSize = 20
+	}
+
+	// store_id is a uuid column — an empty string makes Postgres reject the
+	// whole statement with SQLSTATE 22P02, so reject it before it hits SQL.
+	if storeID == "" {
+		return nil, 0, apperrors.ValidationFailed("store_id", "store id is required")
 	}
 
 	base := r.db.WithContext(ctx).Model(&CsvImportJob{}).Where("store_id = ?", storeID)
@@ -127,6 +134,26 @@ func (r *gormRepository) FindOrphanedJobs(ctx context.Context, staleDuration tim
 		Scan(&jobs).Error
 	if err != nil {
 		return nil, fmt.Errorf("csvjob: find orphaned: %w", err)
+	}
+	return jobs, nil
+}
+
+// FindQueuedJobs returns up to limit jobs sitting in the queued state,
+// across all stores, oldest first. This is the store-agnostic query the
+// polling loop needs: jobs left behind by a crash (re-queued by
+// RecoverOrphanedJobs or resumed by a merchant) belong to arbitrary stores.
+func (r *gormRepository) FindQueuedJobs(ctx context.Context, limit int) ([]CsvImportJob, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	var jobs []CsvImportJob
+	err := r.db.WithContext(ctx).
+		Where("status = ?", StatusQueued).
+		Order("created_at ASC").
+		Limit(limit).
+		Find(&jobs).Error
+	if err != nil {
+		return nil, fmt.Errorf("csvjob: find queued: %w", err)
 	}
 	return jobs, nil
 }

--- a/services/marketplace-api/internal/csvjob/repository_test.go
+++ b/services/marketplace-api/internal/csvjob/repository_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/csvjob"
 	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
@@ -160,4 +161,51 @@ func TestRepository_ListByStore(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(3), total)
 	require.Len(t, jobs, 2)
+}
+
+func TestRepository_ListByStore_RejectsEmptyStoreID(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := csvjob.NewRepository(tx)
+
+	_, _, err := repo.ListByStore(context.Background(), "", 1, 1)
+	require.Error(t, err)
+	require.ErrorIs(t, err, apperrors.ErrValidationFailed)
+}
+
+func TestRepository_FindQueuedJobs(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := csvjob.NewRepository(tx)
+	ctx := context.Background()
+
+	storeA := seedStoreForCSV(t, tx)
+	storeB := seedStoreForCSV(t, tx)
+
+	for _, tc := range []struct {
+		storeID string
+		status  string
+	}{
+		{storeA, csvjob.StatusQueued},
+		{storeB, csvjob.StatusQueued},
+		{storeA, csvjob.StatusCompleted},
+	} {
+		require.NoError(t, repo.Create(ctx, &csvjob.CsvImportJob{
+			ID:          uuid.NewString(),
+			StoreID:     tc.storeID,
+			UserID:      "user-1",
+			GCSPath:     "csv-imports/queued.csv",
+			ContentHash: uuid.NewString(),
+			Status:      tc.status,
+		}))
+	}
+
+	jobs, err := repo.FindQueuedJobs(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, jobs, 2)
+	for _, j := range jobs {
+		require.Equal(t, csvjob.StatusQueued, j.Status)
+	}
+
+	limited, err := repo.FindQueuedJobs(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
 }

--- a/services/marketplace-api/internal/csvjob/service_test.go
+++ b/services/marketplace-api/internal/csvjob/service_test.go
@@ -88,6 +88,22 @@ func (f *fakeRepo) FindOrphanedJobs(_ context.Context, staleDuration time.Durati
 	return out, nil
 }
 
+func (f *fakeRepo) FindQueuedJobs(_ context.Context, limit int) ([]csvjob.CsvImportJob, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	var out []csvjob.CsvImportJob
+	for _, j := range f.jobs {
+		if len(out) == limit {
+			break
+		}
+		if j.Status == csvjob.StatusQueued {
+			out = append(out, *j)
+		}
+	}
+	return out, nil
+}
+
 func (f *fakeRepo) FindByContentHash(_ context.Context, storeID, contentHash string) (*csvjob.CsvImportJob, error) {
 	for _, j := range f.jobs {
 		if j.StoreID == storeID && j.ContentHash == contentHash &&

--- a/services/marketplace-api/internal/handlers/admin/csv_imports_test.go
+++ b/services/marketplace-api/internal/handlers/admin/csv_imports_test.go
@@ -75,6 +75,10 @@ func (r *memRepo) FindOrphanedJobs(_ context.Context, _ time.Duration) ([]csvjob
 	return nil, nil
 }
 
+func (r *memRepo) FindQueuedJobs(_ context.Context, _ int) ([]csvjob.CsvImportJob, error) {
+	return nil, nil
+}
+
 func (r *memRepo) FindByContentHash(_ context.Context, storeID, hash string) (*csvjob.CsvImportJob, error) {
 	for _, j := range r.jobs {
 		if j.StoreID == storeID && j.ContentHash == hash &&


### PR DESCRIPTION
Fixes the P1 in #196.

## Cause

The CSV import polling goroutine in `cmd/marketplace-api/main.go` was a placeholder that called `csvRepo.ListByStore(ctx, "", 1, 1)` on every 5s tick. `csv_import_jobs.store_id` is a `uuid` column, so Postgres rejected the statement with `SQLSTATE 22P02 — invalid input syntax for type uuid: ""`, producing ~720 ERROR lines/hour per admin pod while doing no useful work.

## Fix

- New `Repository.FindQueuedJobs(ctx, limit)` — the store-agnostic query the loop actually needs, since jobs recovered from a crash belong to arbitrary stores.
- Poll loop uses it and only logs when the pending count or the error string changes, so a 5s tick can never flood the log again. It also exits quietly when the worker context is cancelled during shutdown.
- `ListByStore` now rejects an empty store id with a validation error before the malformed query reaches SQL.

Worker dispatch stays where it was — the submit handler still does not upload the CSV to GCS, so there is no `CSVReader` implementation to dispatch against. The loop now reports the queued backlog instead of pretending to drain it; wiring real dispatch is a separate piece of work.

## Verification

- `go build ./...`, `go vet ./...`, `go vet -tags integration ./internal/csvjob/` — clean
- `go test ./internal/csvjob/... ./internal/handlers/admin/...` — pass
- New integration tests `TestRepository_FindQueuedJobs` and `TestRepository_ListByStore_RejectsEmptyStoreID` (require `TEST_DATABASE_URL`; skipped locally, run in CI)