### PR TITLE
ci: allow CI to be triggered manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Rebuild on demand. Images are published as main-<short-sha>, and GHCR's
+  # retention deletes anything not rebuilt recently — so an image a chart still
+  # pins can disappear while the code has not changed at all. Without a manual
+  # trigger the only way to republish is a no-op commit to main.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Images publish as `main-<short-sha>`, and GHCR retention deletes anything not rebuilt recently — so an image a chart still pins can vanish while the code hasn't changed at all.

That's what took `tesserix-auth-bff` down today. It's pinned to `main-3a47f1d` (13 May), which no longer exists in the registry, so it couldn't restart when GKE recycled its spot node this morning. It's been `ImagePullBackOff` for ~6h.

Without `workflow_dispatch` the only way to republish an unchanged image is a no-op commit to main. This adds the trigger — no inputs, so nothing untrusted reaches a run step.

Merging this is itself a push to main, which republishes every image including `mark8ly-auth-bff`. I'll then repin `charts/apps/tesserix-auth-bff/values.yaml` in tesserix-k8s to the new tag.

Related: tesserix-k8s#124 stops the cleanup deleting images that charts still pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)