### PR TITLE
feat(payments): add Cashfree adapter as India's preferred gateway

### DIFF
--- a/apps/admin/components/settings/PaymentConfigForm.tsx
+++ b/apps/admin/components/settings/PaymentConfigForm.tsx
@@ -248,6 +248,11 @@ function apiKeyPlaceholder(provider: string): string {
   switch (provider.toLowerCase()) {
     case "razorpay":
       return "rzp_test_… or rzp_live_…";
+    case "cashfree":
+      // Cashfree calls this the App ID (x-client-id). It carries no
+      // environment prefix — sandbox vs production is selected by the Mode
+      // field below, which picks the API host.
+      return "Cashfree App ID";
     case "paypal":
       return "PayPal client ID";
     default:
@@ -259,6 +264,8 @@ function secretKeyPlaceholder(provider: string): string {
   switch (provider.toLowerCase()) {
     case "razorpay":
       return "Razorpay key secret";
+    case "cashfree":
+      return "Cashfree Secret Key";
     case "paypal":
       return "PayPal client secret";
     default:
@@ -272,6 +279,8 @@ function webhookSecretPlaceholder(provider: string): string {
       return "whsec_...";
     case "razorpay":
       return "Razorpay webhook secret";
+    case "cashfree":
+      return "Cashfree webhook secret";
     case "paypal":
       return "PayPal webhook ID / secret";
     default:
@@ -292,6 +301,9 @@ function webhookSecretHelpText(
   }
   if (p === "stripe") {
     return "Optional. Paste the signing secret from your Stripe webhook endpoint (starts with whsec_). Leave blank to use the API secret.";
+  }
+  if (p === "cashfree") {
+    return "Optional. Cashfree signs webhooks with your Secret Key by default. Set a dedicated secret here if you configured one on the webhook endpoint in your Cashfree dashboard, so rotating the API secret doesn't invalidate webhooks.";
   }
   return "Optional. When set, this secret is used for webhook signature verification instead of the API secret.";
 }

--- a/apps/admin/components/settings/ProviderCard.tsx
+++ b/apps/admin/components/settings/ProviderCard.tsx
@@ -262,13 +262,15 @@ function ModeBadge({ mode }: { mode: string }) {
 // ─────────────────────────────────────────────────────────────────────────
 
 function formatProviderName(provider: string): string {
-  // Only the providers that appear in supported_countries seed (migration
-  // 000008) are listed — everything else the admin could theoretically send
-  // falls through to the title-case fallback. Keep in sync with the seed.
+  // Only the providers that appear in supported_countries (seeded by migration
+  // 000008, extended by later ones — Cashfree in 000099) are listed;
+  // everything else the admin could theoretically send falls through to the
+  // title-case fallback. Keep in sync with the seed.
   const names: Record<string, string> = {
     // Payments
     stripe: "Stripe",
     razorpay: "Razorpay",
+    cashfree: "Cashfree",
     paypal: "PayPal",
     // Shipping — 3 carriers cover all 15 supported countries
     delhivery: "Delhivery",

--- a/apps/onboarding/app/privacy/page.tsx
+++ b/apps/onboarding/app/privacy/page.tsx
@@ -58,7 +58,7 @@ export default function PrivacyPolicyPage() {
           <li>
             <strong>Payment information:</strong> billing address and payment
             method details. We never store full card numbers — card data is
-            handled by Stripe and Razorpay.
+            handled by Stripe, Razorpay, and Cashfree Payments.
           </li>
           <li>
             <strong>Communications:</strong> messages you send us through
@@ -140,7 +140,10 @@ export default function PrivacyPolicyPage() {
         <ul>
           <li>TLS 1.2+ encryption for every connection</li>
           <li>AES-256 at rest on managed Google Cloud services</li>
-          <li>PCI DSS-compliant payment routing through Stripe and Razorpay</li>
+          <li>
+            PCI DSS-compliant payment routing through Stripe, Razorpay, and
+            Cashfree Payments
+          </li>
           <li>APP-, GDPR-, UK GDPR-, CCPA/CPRA-, and DPDP-aligned data handling</li>
           <li>Regular dependency scanning and code review</li>
         </ul>

--- a/apps/onboarding/app/security/page.tsx
+++ b/apps/onboarding/app/security/page.tsx
@@ -120,7 +120,8 @@ export default function SecurityPage() {
           <a href="/dpa">Data Processing Addendum</a> for details.
         </p>
         <p>
-          Card payments are handled exclusively by Stripe and Razorpay;
+          Card payments are handled exclusively by Stripe, Razorpay, and
+          Cashfree Payments;
           Mark8ly does not store full card numbers. PCI DSS obligations for
           payment data sit with those processors.
         </p>

--- a/apps/onboarding/app/sub-processors/page.tsx
+++ b/apps/onboarding/app/sub-processors/page.tsx
@@ -49,6 +49,13 @@ const SUB_PROCESSORS: ReadonlyArray<SubProcessor> = [
     transfer: "Domestic (within India); DPDP-aligned",
   },
   {
+    vendor: "Cashfree Payments",
+    purpose: "Payment processing for Indian merchants and customers",
+    data: "Payment method details, billing address, contact phone, transaction metadata",
+    location: "India",
+    transfer: "Domestic (within India); DPDP-aligned",
+  },
+  {
     vendor: "SendGrid (Twilio)",
     purpose: "Transactional email delivery (receipts, invites, password resets)",
     data: "Recipient email, message content, delivery status",

--- a/apps/onboarding/app/terms/page.tsx
+++ b/apps/onboarding/app/terms/page.tsx
@@ -63,7 +63,10 @@ export default function TermsOfServicePage() {
         <ul>
           <li>Store hosting and infrastructure</li>
           <li>Product and catalogue management tools</li>
-          <li>Payment processing integration (via Stripe and Razorpay)</li>
+          <li>
+            Payment processing integration (via Stripe, Razorpay, and Cashfree
+            Payments)
+          </li>
           <li>Order management</li>
           <li>Human customer support</li>
         </ul>

--- a/apps/storefront/app/api/orders/[id]/confirm-payment/route.ts
+++ b/apps/storefront/app/api/orders/[id]/confirm-payment/route.ts
@@ -1,0 +1,46 @@
+// Storefront proxy for server-side payment confirmation (Cashfree).
+//
+// Forwards POST /api/orders/{id}/confirm-payment to
+// POST /api/v1/storefront/stores/{slug}/orders/{id}/confirm-payment.
+// The store slug is derived from the request host so the client doesn't
+// need to know it.
+//
+// Unlike verify-payment, the body carries nothing the backend trusts: the
+// provider, the provider-side order id and the amount all come from the
+// order's own payment_transactions row server-side. See the backend's
+// payment_confirm.go.
+
+import { marketplaceStoreUrl, proxyJson } from "../../../checkout/_proxy";
+import { resolveStoreSlug } from "@/lib/slug";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const { id } = await ctx.params;
+  if (!id) {
+    return Response.json(
+      { error: "missing_order_id", message: "order id is required" },
+      { status: 400 },
+    );
+  }
+
+  const url = new URL(req.url);
+  const explicitSlug = url.searchParams.get("store");
+  const slug =
+    explicitSlug ||
+    await resolveStoreSlug(req.headers.get("host"));
+  if (!slug) {
+    return Response.json(
+      { error: "missing_store", message: "could not resolve store slug from host" },
+      { status: 400 },
+    );
+  }
+
+  return proxyJson(
+    `${marketplaceStoreUrl(slug)}/orders/${encodeURIComponent(id)}/confirm-payment`,
+    { method: "POST", body: "{}" },
+  );
+}

--- a/apps/storefront/app/checkout/page.tsx
+++ b/apps/storefront/app/checkout/page.tsx
@@ -15,7 +15,10 @@ import { useCart } from "@/components/CartProvider";
 import { StorefrontNav } from "@/components/StorefrontNav";
 import { toast } from "@/lib/toast";
 import { isIndia, isInPhoneValid, normalizeInPhone } from "@/lib/checkout/phone";
-import { openRazorpayCheckout } from "@/lib/payments/razorpay";
+import {
+  isEmbeddedProvider,
+  openEmbeddedCheckout,
+} from "@/lib/payments/launch";
 import { CouponInput } from "@/components/checkout/CouponInput";
 import { GiftCardInput } from "@/components/checkout/GiftCardInput";
 import { LoyaltyRedemption } from "@/components/checkout/LoyaltyRedemption";
@@ -243,7 +246,14 @@ export default function CheckoutPage() {
     fetchPaymentMethods(storeSlug).then((methods) => {
       if (!cancelled) {
         setPaymentMethods(methods);
-        if (methods.length === 1) setSelectedProvider(methods[0]!.provider);
+        // Pre-select the merchant's preferred gateway. The API returns methods
+        // ordered by the country's payment_providers array, so methods[0] is
+        // the intended default (Cashfree in India) and the rest render beneath
+        // it as alternatives. Previously this only auto-selected when exactly
+        // one method existed, which left every multi-gateway store starting on
+        // "Choose a payment method" — an extra required click for the option we
+        // already know we want.
+        if (methods.length > 0) setSelectedProvider(methods[0]!.provider);
       }
     });
     // Also pull the merchant's configured carrier list so we can render
@@ -512,16 +522,15 @@ export default function CheckoutPage() {
 
     // Safety net: every checkout response must give us a way to actually
     // collect payment. Hosted providers (Stripe) ship a redirect URL;
-    // embedded providers (Razorpay) ship a payment_token + a known
+    // embedded providers (Razorpay, Cashfree) ship a payment_token + a known
     // client integration. Without one of those, the buyer has nowhere to
     // pay — bail out before clearing the cart so the merchant doesn't
     // end up with an unpaid "completed" order.
-    const KNOWN_EMBEDDED_PROVIDERS = new Set(["razorpay"]);
     const hasRedirect =
       typeof result.payment_redirect_url === "string" &&
       result.payment_redirect_url.length > 0;
     const hasEmbeddedPath =
-      KNOWN_EMBEDDED_PROVIDERS.has(result.provider) &&
+      isEmbeddedProvider(result.provider) &&
       typeof result.payment_token === "string" &&
       result.payment_token.length > 0;
     if (!hasRedirect && !hasEmbeddedPath) {
@@ -573,6 +582,10 @@ export default function CheckoutPage() {
       publicKey: pm?.public_key ?? "",
       amount: grandTotal,
       currencyCode: items[0]?.currencyCode ?? "INR",
+      // Cashfree selects sandbox vs production from the gateway mode rather
+      // than from a key prefix, so the retry path on /orders/[id] needs it
+      // stashed alongside the token.
+      mode: pm?.mode,
       customerName: customerName.trim() || undefined,
       customerEmail: email.trim() || undefined,
     };
@@ -614,14 +627,15 @@ export default function CheckoutPage() {
     // checkout, where the redirect leaves an empty cart behind too).
     clear();
 
-    // Open Razorpay right away — one click from "Place order" to the payment
-    // sheet, no intermediate "Pay now". On success we verify + confirm and
-    // land on the order page in its paid state; if the buyer dismisses the
-    // sheet or it errors, we still route to the order page where the stashed
-    // context powers the "Pay now" retry, so nobody is left with an
-    // unpayable reserved order.
+    // Open the payment sheet right away — one click from "Place order" to
+    // paying, no intermediate "Pay now". On success the server has already
+    // verified/confirmed the payment and we land on the order page in its paid
+    // state; if the buyer dismisses the sheet or it errors, we still route to
+    // the order page where the stashed context powers the "Pay now" retry, so
+    // nobody is left with an unpayable reserved order.
     const orderPath = `/orders/${result.order_id}`;
-    await openRazorpayCheckout(
+    await openEmbeddedCheckout(
+      result.provider,
       {
         orderId: result.order_id,
         paymentToken: pending.paymentToken ?? "",
@@ -629,6 +643,7 @@ export default function CheckoutPage() {
         amount: pending.amount,
         currencyCode: pending.currencyCode,
         storeName: "",
+        mode: pending.mode,
         customerName: pending.customerName,
         customerEmail: pending.customerEmail,
       },
@@ -1023,7 +1038,7 @@ export default function CheckoutPage() {
             <fieldset className="mt-4">
               <legend className="sr-only">Select a payment method</legend>
               <div className="space-y-3">
-                {paymentMethods.map((pm) => (
+                {paymentMethods.map((pm, i) => (
                   <label
                     key={pm.provider}
                     className={`flex cursor-pointer items-center gap-3 rounded-md border px-4 py-3 transition-colors duration-150 ${
@@ -1041,8 +1056,17 @@ export default function CheckoutPage() {
                       className="accent-[color:var(--storefront-accent,var(--moss-700))]"
                     />
                     <span className="flex flex-col">
-                      <span className="text-sm font-medium text-[color:var(--storefront-text,var(--ink-900))]">
+                      <span className="flex items-center gap-2 text-sm font-medium text-[color:var(--storefront-text,var(--ink-900))]">
                         {providerBrand(pm.provider)}
+                        {/* The API returns methods in preference order, so the
+                            first entry is the merchant's preferred gateway.
+                            Only worth badging when there is something to
+                            prefer it over. */}
+                        {i === 0 && paymentMethods.length > 1 && (
+                          <span className="rounded-full bg-[color:var(--storefront-accent,var(--moss-700))]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-[color:var(--storefront-accent,var(--moss-700))]">
+                            Recommended
+                          </span>
+                        )}
                       </span>
                       <span className="text-xs text-[color:var(--storefront-text,var(--ink-900))] opacity-60">
                         {providerLabel(pm.provider)}
@@ -1458,6 +1482,7 @@ function providerLabel(provider: string): string {
   switch (provider) {
     case "stripe": return "Credit / Debit card";
     case "razorpay": return "Card, UPI, or Netbanking";
+    case "cashfree": return "Card, UPI, Netbanking, or Wallet";
     case "paypal": return "PayPal";
     default: return provider.charAt(0).toUpperCase() + provider.slice(1);
   }
@@ -1670,6 +1695,7 @@ function providerBrand(provider: string): string {
   switch (provider) {
     case "stripe": return "Stripe";
     case "razorpay": return "Razorpay";
+    case "cashfree": return "Cashfree";
     case "paypal": return "PayPal";
     default: return provider.charAt(0).toUpperCase() + provider.slice(1);
   }

--- a/apps/storefront/components/PaymentPrompt.tsx
+++ b/apps/storefront/components/PaymentPrompt.tsx
@@ -4,21 +4,23 @@
 // the order is still pending and the storefront stashed a payment
 // context for it on the checkout page, this component:
 //
-//   1. Loads Razorpay's checkout.js script on demand.
-//   2. On "Pay now", opens the Razorpay widget keyed to the merchant's
-//      public key + the pre-created Razorpay order id (payment_token).
-//   3. On widget success, POSTs {razorpay_order_id, razorpay_payment_id,
-//      razorpay_signature} to /api/orders/{id}/verify-payment, which
-//      proxies to marketplace-api's verify endpoint. The backend re-derives
-//      the HMAC and marks the order paid via the same handler the webhook
-//      flow uses, so this works even when no Razorpay webhook reaches
-//      the cluster.
+//   1. Loads the provider's checkout SDK on demand.
+//   2. On "Pay now", opens the payment sheet keyed to the pre-created
+//      provider-side payment token stashed at checkout.
+//   3. Confirms the outcome SERVER-SIDE before treating the order as paid —
+//      Razorpay by re-deriving the checkout HMAC over the returned triplet,
+//      Cashfree by polling the gateway (its SDK returns nothing signed). Both
+//      reuse the same handler the webhook flow uses, so this works even when
+//      no provider webhook reaches the cluster.
 //   4. Clears the local sessionStorage context and refreshes the page.
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "@/lib/toast";
-import { openRazorpayCheckout } from "@/lib/payments/razorpay";
+import {
+  isEmbeddedProvider,
+  openEmbeddedCheckout,
+} from "@/lib/payments/launch";
 
 interface PendingPayment {
   orderId: string;
@@ -27,6 +29,8 @@ interface PendingPayment {
   publicKey: string;
   amount: string;
   currencyCode: string;
+  /** Gateway mode ("test" | "live") — Cashfree needs it to pick its environment. */
+  mode?: string;
   customerName?: string;
   customerEmail?: string;
 }
@@ -62,7 +66,7 @@ export function PaymentPrompt({ orderId, paymentStatus, storeName }: Props) {
   // webhook, so the order may briefly show pending after redirect — say
   // so explicitly instead of rendering blank, and tell the buyer how to
   // recover if they cancelled mid-flow.
-  if (!pending || pending.provider !== "razorpay") {
+  if (!pending || !isEmbeddedProvider(pending.provider)) {
     return (
       <section
         aria-labelledby="payment-status-heading"
@@ -88,7 +92,8 @@ export function PaymentPrompt({ orderId, paymentStatus, storeName }: Props) {
     if (!pending) return;
     setError(null);
     setBusy(true);
-    await openRazorpayCheckout(
+    await openEmbeddedCheckout(
+      pending.provider,
       {
         orderId,
         paymentToken: pending.paymentToken,
@@ -96,6 +101,7 @@ export function PaymentPrompt({ orderId, paymentStatus, storeName }: Props) {
         amount: pending.amount,
         currencyCode: pending.currencyCode,
         storeName,
+        mode: pending.mode,
         customerName: pending.customerName,
         customerEmail: pending.customerEmail,
       },

--- a/apps/storefront/lib/csp/allowlist.test.ts
+++ b/apps/storefront/lib/csp/allowlist.test.ts
@@ -94,18 +94,28 @@ describe("CSP script-src covers every external script the app loads", () => {
 });
 
 describe("isAllowed matching rules", () => {
-  const directive = `"script-src 'self' https://accounts.google.com/gsi/client https://*.razorpay.com",`;
+  const directive = `"script-src 'self' https://accounts.google.com/gsi/client https://*.razorpay.com https://*.cashfree.com",`;
 
   it.each([
     ["checkout.razorpay.com", true],
     ["cdn.razorpay.com", true],
     ["lumberjack.razorpay.com", true],
+    // Cashfree's v3 SDK is served from sdk.cashfree.com and pulls the checkout
+    // modal from payments.cashfree.com — the same runtime-subdomain problem
+    // that makes enumeration unworkable for Razorpay.
+    ["sdk.cashfree.com", true],
+    ["payments.cashfree.com", true],
     ["accounts.google.com", true],
   ])("allows %s", (host, want) => {
     expect(isAllowed(host as string, directive)).toBe(want);
   });
 
-  it.each(["evil.com", "razorpay.com.evil.com", "cdn.stripe.com"])(
+  it.each([
+    "evil.com",
+    "razorpay.com.evil.com",
+    "cashfree.com.evil.com",
+    "cdn.stripe.com",
+  ])(
     "rejects %s",
     (host) => {
       expect(isAllowed(host, directive)).toBe(false);

--- a/apps/storefront/lib/payments/cashfree.ts
+++ b/apps/storefront/lib/payments/cashfree.ts
@@ -1,0 +1,187 @@
+// Shared Cashfree checkout launcher, the sibling of razorpay.ts. Both the
+// checkout page (open the sheet immediately after the order is reserved —
+// single click) and the /orders/[id] PaymentPrompt ("Pay now" recovery if the
+// buyer dismissed it) go through here so the load / open / confirm logic lives
+// in exactly one place.
+//
+// The one structural difference from the Razorpay launcher: Cashfree's SDK
+// hands back NO signed receipt. Razorpay's `handler` callback returns
+// {order_id, payment_id, signature} which the server re-derives an HMAC over;
+// Cashfree's checkout promise resolves with only a coarse outcome hint. So
+// instead of POSTing a client value to be verified, we POST nothing and let the
+// server ask Cashfree what was actually captured — see
+// /api/orders/{id}/confirm-payment and the backend's payment_confirm.go. The
+// client is never trusted with the outcome at all, which is why the resolved
+// `paymentDetails` below is treated as a nudge to go confirm rather than as
+// proof of payment.
+
+const CASHFREE_SCRIPT = "https://sdk.cashfree.com/js/v3/cashfree.js";
+
+/**
+ * The subset of Cashfree's v3 SDK surface we depend on. `Cashfree()` is a
+ * factory (not a constructor) and `mode` selects sandbox vs production —
+ * getting that wrong points a live key at the sandbox, where payments appear
+ * to succeed while capturing nothing.
+ */
+interface CashfreeCheckoutResult {
+  error?: { message?: string };
+  paymentDetails?: { paymentMessage?: string };
+  redirect?: boolean;
+}
+
+interface CashfreeInstance {
+  checkout: (options: {
+    paymentSessionId: string;
+    redirectTarget?: "_self" | "_blank" | "_modal";
+  }) => Promise<CashfreeCheckoutResult>;
+}
+
+declare global {
+  interface Window {
+    Cashfree?: (config: { mode: "sandbox" | "production" }) => CashfreeInstance;
+  }
+}
+
+function loadCashfree(): Promise<boolean> {
+  if (typeof window === "undefined") return Promise.resolve(false);
+  if (window.Cashfree) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    // A previously-injected tag that already failed (CSP block, offline,
+    // adblock) has ALREADY fired its load/error event. Attaching fresh
+    // listeners to it would wait for an event that can never come again,
+    // leaving the caller stuck forever with no error — so drop the dead tag
+    // and retry from scratch instead. Same reasoning as razorpay.ts.
+    document
+      .querySelectorAll<HTMLScriptElement>(`script[src="${CASHFREE_SCRIPT}"]`)
+      .forEach((tag) => tag.remove());
+
+    const s = document.createElement("script");
+    s.src = CASHFREE_SCRIPT;
+    s.async = true;
+    s.onload = () => resolve(!!window.Cashfree);
+    s.onerror = () => {
+      s.remove();
+      resolve(false);
+    };
+    document.head.appendChild(s);
+  });
+}
+
+export interface CashfreeCheckoutContext {
+  orderId: string;
+  /** Cashfree payment_session_id returned by the checkout/reserve call. */
+  paymentToken: string;
+  /**
+   * Gateway mode from the payment-methods endpoint ("test" | "live").
+   * Cashfree selects its environment by SDK mode + host, not by key prefix,
+   * so this has to be threaded through rather than inferred from the key.
+   */
+  mode?: string;
+}
+
+export interface CashfreeCheckoutCallbacks {
+  /** Payment succeeded AND was confirmed server-side. */
+  onSuccess: () => void;
+  /** Buyer closed the sheet without paying — order stays reserved. */
+  onDismiss: () => void;
+  /** Script failed to load, sheet failed to open, or confirmation failed. */
+  onError: (message: string) => void;
+}
+
+/**
+ * Asks the server whether Cashfree actually captured this order's payment.
+ * Returns "ok" only when the gateway confirmed a capture; "pending" means the
+ * buyer has not paid (a dismissed sheet), which is not an error.
+ */
+async function confirmPayment(
+  orderId: string,
+): Promise<{ status: "ok" | "pending" } | { error: string }> {
+  try {
+    const res = await fetch(`/api/orders/${orderId}/confirm-payment`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return {
+        error: `Payment confirmation failed (${res.status}). ${body}`.trim(),
+      };
+    }
+    const data = (await res.json()) as { status?: string };
+    return { status: data.status === "ok" ? "ok" : "pending" };
+  } catch (e) {
+    return {
+      error: e instanceof Error ? e.message : "Unknown error confirming payment.",
+    };
+  }
+}
+
+/**
+ * Loads Cashfree's v3 SDK on demand and opens the checkout modal for a
+ * pre-reserved order. Whatever the SDK reports, the outcome is decided by the
+ * server-side confirm call, so a buyer cannot talk their way into a paid order
+ * and a genuine payment is not lost to a flaky SDK callback.
+ */
+export async function openCashfreeCheckout(
+  ctx: CashfreeCheckoutContext,
+  callbacks: CashfreeCheckoutCallbacks,
+): Promise<void> {
+  const ok = await loadCashfree();
+  if (!ok || !window.Cashfree) {
+    callbacks.onError(
+      "Could not load the Cashfree payment window. Check your connection and try again.",
+    );
+    return;
+  }
+  if (!ctx.paymentToken) {
+    callbacks.onError(
+      "This order has no active Cashfree payment session. Please contact the store.",
+    );
+    return;
+  }
+
+  let result: CashfreeCheckoutResult;
+  try {
+    const cashfree = window.Cashfree({
+      mode: ctx.mode === "test" ? "sandbox" : "production",
+    });
+    result = await cashfree.checkout({
+      paymentSessionId: ctx.paymentToken,
+      // "_modal" keeps the buyer on our page, matching the Razorpay widget's
+      // feel. Bank/UPI redirects still leave and come back inside the modal.
+      redirectTarget: "_modal",
+    });
+  } catch (e) {
+    callbacks.onError(
+      e instanceof Error
+        ? `Could not open the payment window: ${e.message}`
+        : "Could not open the payment window. Please try again.",
+    );
+    return;
+  }
+
+  // A redirect flow never resolves here in a meaningful way — the page has
+  // navigated and /orders/[id] picks up from the webhook or a later confirm.
+  if (result?.redirect) return;
+
+  // An SDK-reported error still gets a confirm: the modal can report a
+  // failure for an attempt that in fact settled (a UPI collect that lands
+  // after the sheet gave up), and quietly leaving that order unpaid is worse
+  // than one extra API call. Only if the gateway also says "not paid" do we
+  // surface the SDK's message.
+  const confirmed = await confirmPayment(ctx.orderId);
+  if ("error" in confirmed) {
+    callbacks.onError(confirmed.error);
+    return;
+  }
+  if (confirmed.status === "ok") {
+    callbacks.onSuccess();
+    return;
+  }
+  if (result?.error?.message) {
+    callbacks.onError(result.error.message);
+    return;
+  }
+  callbacks.onDismiss();
+}

--- a/apps/storefront/lib/payments/launch.ts
+++ b/apps/storefront/lib/payments/launch.ts
@@ -1,0 +1,93 @@
+// Provider dispatch for embedded (JS-SDK) checkout.
+//
+// The checkout page and the /orders/[id] PaymentPrompt both need to answer
+// "which SDK do I open for this provider, and is it embedded at all". Keeping
+// that mapping here rather than in each caller means adding a gateway is one
+// edit: without it, a new provider is silently treated as unsupported in one
+// place and crashes in the other.
+
+import { openRazorpayCheckout } from "./razorpay";
+import { openCashfreeCheckout } from "./cashfree";
+
+/**
+ * Providers we can collect payment from with an in-page SDK. Hosted providers
+ * (Stripe) are NOT here — they ship a payment_redirect_url instead and the
+ * buyer leaves the site to pay.
+ *
+ * The checkout page uses this as a safety net: an order whose provider is
+ * neither hosted nor listed here has nowhere for the buyer to pay, and must
+ * fail loudly before the cart is cleared rather than leaving the merchant an
+ * unpaid "completed" order.
+ */
+export const EMBEDDED_PROVIDERS = new Set(["razorpay", "cashfree"]);
+
+export function isEmbeddedProvider(provider: string): boolean {
+  return EMBEDDED_PROVIDERS.has(provider);
+}
+
+/** Everything any embedded launcher might need. Extra fields are ignored by
+ * providers that don't use them (Cashfree needs no public key: its
+ * payment_session_id already identifies the merchant and the order). */
+export interface EmbeddedCheckoutContext {
+  orderId: string;
+  paymentToken: string;
+  publicKey: string;
+  amount: string;
+  currencyCode: string;
+  storeName: string;
+  /** Gateway mode ("test" | "live") — Cashfree picks sandbox vs production from it. */
+  mode?: string;
+  customerName?: string;
+  customerEmail?: string;
+}
+
+export interface EmbeddedCheckoutCallbacks {
+  /** Payment succeeded AND was verified/confirmed server-side. */
+  onSuccess: () => void;
+  /** Buyer closed the sheet without paying — order stays reserved. */
+  onDismiss: () => void;
+  /** Script failed to load, sheet failed to open, or verification failed. */
+  onError: (message: string) => void;
+}
+
+/**
+ * Opens the payment sheet for `provider`. Both launchers only call onSuccess
+ * after the server has independently confirmed the payment — Razorpay by
+ * re-deriving the checkout HMAC, Cashfree by polling the gateway — so a caller
+ * can treat onSuccess as "this order is paid" without further checks.
+ */
+export async function openEmbeddedCheckout(
+  provider: string,
+  ctx: EmbeddedCheckoutContext,
+  callbacks: EmbeddedCheckoutCallbacks,
+): Promise<void> {
+  switch (provider) {
+    case "razorpay":
+      return openRazorpayCheckout(
+        {
+          orderId: ctx.orderId,
+          paymentToken: ctx.paymentToken,
+          publicKey: ctx.publicKey,
+          amount: ctx.amount,
+          currencyCode: ctx.currencyCode,
+          storeName: ctx.storeName,
+          customerName: ctx.customerName,
+          customerEmail: ctx.customerEmail,
+        },
+        callbacks,
+      );
+    case "cashfree":
+      return openCashfreeCheckout(
+        {
+          orderId: ctx.orderId,
+          paymentToken: ctx.paymentToken,
+          mode: ctx.mode,
+        },
+        callbacks,
+      );
+    default:
+      callbacks.onError(
+        `We can't open a payment window for ${provider}. Please contact the store — you have not been charged.`,
+      );
+  }
+}

--- a/apps/storefront/next.config.ts
+++ b/apps/storefront/next.config.ts
@@ -49,16 +49,18 @@ const nextConfig: NextConfig = {
             // Google sign-in, so GSI is not loaded here directly. The
             // allowlist is kept in sync with admin + onboarding so any
             // future inline use (e.g. one-tap on storefront) is unblocked.
-            // Razorpay is allowlisted by wildcard, per their own documented
-            // CSP (docs/payments/payment-gateway/cordova-integration).
-            // Enumerating hosts does not work here: PaymentPrompt only
-            // names checkout.razorpay.com, but that SDK pulls further
-            // scripts at runtime (cdn.razorpay.com risk-detection, and
-            // lumberjack.razorpay.com telemetry) which no amount of
-            // reading our own source reveals. Each missed host is a
-            // silent prod-only breakage, so trust the payment
-            // processor's domain rather than guess its subdomains.
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com/gsi/client https://*.razorpay.com",
+            // Razorpay and Cashfree are allowlisted by wildcard, per their
+            // own documented CSPs (Razorpay:
+            // docs/payments/payment-gateway/cordova-integration).
+            // Enumerating hosts does not work here: our source only names
+            // checkout.razorpay.com and sdk.cashfree.com, but those SDKs pull
+            // further scripts at runtime (cdn.razorpay.com risk-detection and
+            // lumberjack.razorpay.com telemetry; payments.cashfree.com and
+            // its own asset hosts) which no amount of reading our own source
+            // reveals. Each missed host is a silent prod-only breakage, so
+            // trust the payment processor's domain rather than guess its
+            // subdomains.
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com/gsi/client https://*.razorpay.com https://*.cashfree.com",
             "style-src 'self' 'unsafe-inline' https://accounts.google.com/gsi/style",
             "img-src 'self' data: blob: https:",
             "font-src 'self' data:",
@@ -66,9 +68,11 @@ const nextConfig: NextConfig = {
             "frame-ancestors 'self'",
             // Razorpay renders its checkout modal (and the bank/UPI
             // redirect flows) in iframes from api.razorpay.com — allowing
-            // only the script leaves the modal blank. Wildcarded for the
-            // same reason as script-src above.
-            "frame-src 'self' https://accounts.google.com/gsi/ https://*.razorpay.com",
+            // only the script leaves the modal blank. Cashfree's
+            // redirectTarget:"_modal" checkout does the same from
+            // payments.cashfree.com. Wildcarded for the same reason as
+            // script-src above.
+            "frame-src 'self' https://accounts.google.com/gsi/ https://*.razorpay.com https://*.cashfree.com",
             "object-src 'none'",
             "base-uri 'self'",
             "form-action 'self'",

--- a/go.work.sum
+++ b/go.work.sum
@@ -2471,6 +2471,7 @@ golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4/go.mod h1:g5NllXBEermZ
 golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c h1:6a8FdnNk6bTXBjR4AGKFgUKuo+7GnR3FX5L7CbveeZc=
 golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c/go.mod h1:TpUTTEp9frx7rTdLpC9gFG9kdI7zVLFTFFlqaH2Cncw=
 golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa/go.mod h1:kHjTxDEnAu6/Nl9lDkzjWpR+bmKfxeiRuSDlsMb70gE=
+golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57/go.mod h1:3AWMyWHS+caVoiEXpiq6+tzKA40J4vQT3MYr80ZtQpc=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=
@@ -2883,6 +2884,7 @@ google.golang.org/genproto/googleapis/bytestream v0.0.0-20250804133106-a7a43d27e
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20260319201613-d00831a3d3e7 h1:6jJ8xNMxB3mmH3HsxEMPjJU+WeFOiwBJ+cLm60OvSZs=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:6TABGosqSqU2l1+fJ3jdvOYPPVryeKybxYF0cCZkTBE=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20260427160629-7cedc36a6bc4/go.mod h1:6TABGosqSqU2l1+fJ3jdvOYPPVryeKybxYF0cCZkTBE=
+google.golang.org/genproto/googleapis/bytestream v0.0.0-20260630182238-925bb5da69e7/go.mod h1:6TABGosqSqU2l1+fJ3jdvOYPPVryeKybxYF0cCZkTBE=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240513163218-0867130af1f8 h1:mxSlqyb8ZAHsYDCfiXN1EDdNTdvjUJSLY+OnAUtYNYA=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240513163218-0867130af1f8/go.mod h1:I7Y+G38R2bu5j1aLzfFmQfTcU/WnFuqDwLZAbvKTKpM=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=

--- a/services/marketplace-api/internal/handlers/storefront/checkout_ext.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_ext.go
@@ -757,7 +757,15 @@ func (h *CheckoutExtHandler) Checkout(c *gin.Context) {
 	// URLs. Origin is a browser-set header so it's the right source of
 	// truth here even when the request goes through Cloudflare / Istio.
 	returnBase := strings.TrimRight(c.GetHeader("Origin"), "/")
-	paymentToken, paymentRedirect, err := h.createPaymentIntent(ctx, store, req.PaymentProvider, result.Order, grandTotal, returnBase)
+	// The shipping address is the only place a phone number is captured at
+	// checkout (orders has no phone column), and Cashfree requires one to
+	// create an order at all.
+	var customerPhone string
+	if req.ShippingAddress.Phone != nil {
+		customerPhone = strings.TrimSpace(*req.ShippingAddress.Phone)
+	}
+	paymentToken, paymentRedirect, err := h.createPaymentIntent(
+		ctx, store, req.PaymentProvider, result.Order, grandTotal, returnBase, customerPhone)
 	if err != nil {
 		h.logWarn("checkout_ext: payment intent creation failed",
 			"order_id", result.Order.ID.String(), "err", err)
@@ -1093,6 +1101,7 @@ func (h *CheckoutExtHandler) createPaymentIntent(
 	ord *order.Order,
 	amount decimal.Decimal,
 	returnBase string,
+	customerPhone string,
 ) (string, string, error) {
 	// Look up the payment gateway config for this provider + store.
 	var cfg paymentGatewayConfigRow
@@ -1168,11 +1177,17 @@ func (h *CheckoutExtHandler) createPaymentIntent(
 		return "", session.URL, nil
 	}
 
+	var customerName string
+	if ord.CustomerName != nil {
+		customerName = *ord.CustomerName
+	}
 	intent, err := gateway.CreateIntent(ctx, payment.CreateIntentInput{
 		OrderID:       ord.ID.String(),
 		Amount:        amount,
 		CurrencyCode:  ord.CurrencyCode,
 		CustomerEmail: ord.CustomerEmail,
+		CustomerName:  customerName,
+		CustomerPhone: customerPhone,
 		Description:   fmt.Sprintf("Order %s", ord.OrderNumber),
 		Metadata:      metadata,
 	})

--- a/services/marketplace-api/internal/handlers/storefront/payment_confirm.go
+++ b/services/marketplace-api/internal/handlers/storefront/payment_confirm.go
@@ -1,0 +1,213 @@
+// Package storefront — payment_confirm.go: server-side payment confirmation.
+//
+// POST /api/v1/storefront/stores/:storeSlug/orders/:id/confirm-payment
+//
+// This is the Cashfree-shaped sibling of payment_verify.go. Razorpay Checkout
+// hands the browser a signed {order_id, payment_id, signature} triplet the
+// server can re-derive; the Cashfree SDK returns nothing signed at all, so
+// there is no client value to verify. The authority is the gateway itself:
+// after checkout closes, the storefront calls this endpoint and the server asks
+// Cashfree what actually happened, then reuses the same handlePaymentSucceeded
+// path the webhook flow uses.
+//
+// That makes this a STRONGER gate than the verify path, not a weaker one — no
+// client-supplied value is trusted at any point:
+//
+//   - The provider and the provider-side order id come from THIS order's
+//     payment_transactions row, never from the request body. A caller cannot
+//     point the confirm at someone else's paid Cashfree order.
+//   - The gateway credentials come from the store's own active gateway config,
+//     so the poll can only ever see payments on that merchant's account.
+//   - The captured amount must cover what we recorded at intent creation,
+//     so a ₹1 payment cannot settle a ₹5,000 order.
+//
+// Like the verify path, it exists so a paid order confirms immediately rather
+// than waiting on an async webhook that may never reach the cluster in a test
+// environment.
+package storefront
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/payment"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+)
+
+// confirmPaymentTxRow is the pending payment_transactions projection the
+// confirm path needs: which gateway to ask, which provider-side order to ask
+// about, and how much we expect to have been captured.
+type confirmPaymentTxRow struct {
+	Provider         string          `gorm:"column:provider"`
+	ProviderIntentID string          `gorm:"column:provider_intent_id"`
+	Amount           decimal.Decimal `gorm:"column:amount"`
+	Status           string          `gorm:"column:status"`
+}
+
+// HandleConfirmPayment polls the payment provider for an order's settled
+// payment and, when the gateway confirms a capture, marks the order paid.
+//
+// Responses always carry an explicit "status" so the storefront can branch:
+//
+//	{"status":"ok"}       — the gateway confirms a capture; the order is paid
+//	{"status":"pending"}  — no captured payment yet; the buyer can retry
+//
+// A pending result is a 200, not an error: "the customer has not paid yet" is
+// a normal outcome of this poll, and returning 4xx would make the storefront
+// render a failure for a buyer who simply closed the sheet.
+func (h *WebhookHandler) HandleConfirmPayment(c *gin.Context) {
+	orderID := c.Param("id")
+	if orderID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing order id"})
+		return
+	}
+	orderUUID, err := uuid.Parse(orderID)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid order id"})
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	// Store scoping, same as the verify path: without it the gateway-config
+	// query would match the first active config across all tenants.
+	storeVal, _ := c.Get("store")
+	store, _ := storeVal.(*stores.Store)
+	if store == nil {
+		h.logError("confirm-payment: store context missing", "order_id", orderID)
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "store context missing"})
+		return
+	}
+	storeID, perr := uuid.Parse(store.ID)
+	if perr != nil {
+		h.logError("confirm-payment: invalid store id", "raw_id", store.ID, "err", perr)
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "gateway not configured"})
+		return
+	}
+
+	// The provider and the provider-side order id are read from OUR ledger,
+	// not the request body — this is what binds the poll to this order.
+	var tx confirmPaymentTxRow
+	if err := h.db.WithContext(ctx).
+		Table("payment_transactions").
+		Select("provider", "provider_intent_id", "amount", "status").
+		Where("order_id = ? AND store_id = ?", orderUUID, storeID).
+		Order("created_at DESC").
+		First(&tx).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "no payment on this order"})
+			return
+		}
+		h.logError("confirm-payment: payment transaction lookup failed",
+			"order_id", orderID, "err", err)
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "could not read payment"})
+		return
+	}
+
+	// Already captured — a second confirm (buyer refreshed, two tabs) is an
+	// idempotent success, not a re-settlement.
+	if tx.Status == "captured" {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		return
+	}
+	if tx.ProviderIntentID == "" {
+		h.logError("confirm-payment: transaction has no provider intent id",
+			"order_id", orderID, "provider", tx.Provider)
+		c.JSON(http.StatusConflict, gin.H{"error": "payment was never started with the provider"})
+		return
+	}
+
+	var cfg webhookGatewayConfigRow
+	if err := h.db.WithContext(ctx).
+		Where("store_id = ? AND provider = ? AND is_active = true", storeID, tx.Provider).
+		First(&cfg).Error; err != nil {
+		h.logError("confirm-payment: no active gateway config",
+			"store_id", storeID.String(), "provider", tx.Provider, "err", err)
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "gateway not configured"})
+		return
+	}
+
+	// Resolve via decryptAPIKey, not the Encryptor directly: a rewrapped row
+	// holds a "gsm://" reference that Decrypt cannot read. The Store handles
+	// both forms.
+	apiKey, err := h.decryptAPIKey(ctx, cfg.APIKey)
+	if err != nil {
+		h.logError("confirm-payment: decrypt api key failed", "provider", tx.Provider, "err", err)
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "gateway not configured"})
+		return
+	}
+	secretKey, err := h.decryptAPIKey(ctx, cfg.SecretKeyEncrypted)
+	if err != nil {
+		h.logError("confirm-payment: decrypt secret key failed", "provider", tx.Provider, "err", err)
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "gateway not configured"})
+		return
+	}
+
+	gateway, err := payment.NewGateway(tx.Provider, apiKey, secretKey, cfg.Mode)
+	if err != nil {
+		h.logError("confirm-payment: gateway init failed", "provider", tx.Provider, "err", err)
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "gateway not configured"})
+		return
+	}
+
+	// Providers with a client-side signature (Razorpay) verify through
+	// /verify-payment instead; there is nothing to poll for them.
+	poller, ok := gateway.(payment.OrderStatusGateway)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "provider " + tx.Provider + " does not support server-side payment confirmation",
+		})
+		return
+	}
+
+	settled, err := poller.FetchOrderPayment(ctx, tx.ProviderIntentID)
+	if err != nil {
+		h.logError("confirm-payment: gateway status poll failed",
+			"order_id", orderID, "provider", tx.Provider, "err", err)
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "could not reach the payment provider"})
+		return
+	}
+	// Belt-and-braces on the capability contract: FetchOrderPayment is
+	// specified to return only captured payments, so anything else here means
+	// the adapter is not honouring it. Treat it as unpaid rather than trusting
+	// the nil-check alone to have filtered a failed attempt.
+	if settled == nil || settled.Status != "payment.succeeded" {
+		c.JSON(http.StatusOK, gin.H{"status": "pending"})
+		return
+	}
+
+	// Amount binding. The provider-side order id already ties this payment to
+	// this order, so this is defence in depth against a gateway-side amount
+	// mismatch (a partially-paid order, or an order whose total was recomputed
+	// after the intent was created) settling the order in full.
+	if settled.Amount.IsPositive() && settled.Amount.LessThan(tx.Amount) {
+		h.logError("confirm-payment: captured amount is short of the recorded intent",
+			"order_id", orderID,
+			"provider", tx.Provider,
+			"captured", settled.Amount.String(),
+			"expected", tx.Amount.String())
+		c.JSON(http.StatusConflict, gin.H{"error": "captured amount does not cover the order"})
+		return
+	}
+
+	// Reuse the same handler the webhook flow uses, so notifications, loyalty
+	// points, invoice mail and order confirmation all fire exactly as they
+	// would have on a webhook delivery.
+	h.handlePaymentSucceeded(ctx, tx.Provider, &payment.WebhookEvent{
+		ProviderEventID:   "confirm-" + tx.Provider + "-" + settled.ProviderPaymentID,
+		EventType:         "payment.succeeded",
+		OrderID:           orderID,
+		ProviderPaymentID: settled.ProviderPaymentID,
+		Amount:            settled.Amount,
+		CurrencyCode:      settled.CurrencyCode,
+		PaymentMethod:     settled.PaymentMethod,
+		RawPayload:        []byte("{}"),
+	})
+
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}

--- a/services/marketplace-api/internal/handlers/storefront/payment_methods.go
+++ b/services/marketplace-api/internal/handlers/storefront/payment_methods.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"sort"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -176,7 +178,37 @@ func (h *PaymentMethodsHandler) ListPaymentMethods(c *gin.Context) {
 		})
 	}
 
+	sortByPreference(result, sc.PaymentProviders)
+
 	c.JSON(http.StatusOK, gin.H{"data": result})
+}
+
+// sortByPreference orders the payment-method list by each provider's position
+// in the country's payment_providers array, making that array the single source
+// of truth for preference: the first entry is the gateway the storefront
+// pre-selects at checkout, and the rest render beneath it as alternatives.
+//
+// The gateway-config query has no ORDER BY, so without this the picker order was
+// whatever order Postgres happened to return rows in — stable enough to look
+// intentional in testing, and free to change under a plan flip or a row update.
+// Sorting here makes "Cashfree is preferred in India" a property of the seed
+// data (migration 000099) rather than an accident of row layout.
+func sortByPreference(methods []paymentMethodResponse, preference []string) {
+	rank := make(map[string]int, len(preference))
+	for i, p := range preference {
+		rank[strings.ToLower(p)] = i
+	}
+	sort.SliceStable(methods, func(i, j int) bool {
+		ri, iOK := rank[strings.ToLower(methods[i].Provider)]
+		rj, jOK := rank[strings.ToLower(methods[j].Provider)]
+		// A provider absent from the allowlist cannot normally reach here (the
+		// query filters on it), but if one ever does it sorts last rather than
+		// silently landing at position 0 and becoming the pre-selected default.
+		if !iOK || !jOK {
+			return iOK && !jOK
+		}
+		return ri < rj
+	})
 }
 
 // methodsForProvider returns the payment methods available for a provider.
@@ -186,6 +218,8 @@ func methodsForProvider(provider string) []string {
 		return []string{"card"}
 	case "razorpay":
 		return []string{"card", "upi", "netbanking"}
+	case "cashfree":
+		return []string{"card", "upi", "netbanking", "wallet"}
 	case "paypal":
 		return []string{"paypal"}
 	default:

--- a/services/marketplace-api/internal/handlers/storefront/payment_methods_preference_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/payment_methods_preference_test.go
@@ -1,0 +1,118 @@
+package storefront
+
+import (
+	"strings"
+	"testing"
+)
+
+// providersOf renders the ordered provider names for a readable assertion.
+func providersOf(methods []paymentMethodResponse) string {
+	names := make([]string, 0, len(methods))
+	for _, m := range methods {
+		names = append(names, m.Provider)
+	}
+	return strings.Join(names, ",")
+}
+
+func methodList(providers ...string) []paymentMethodResponse {
+	out := make([]paymentMethodResponse, 0, len(providers))
+	for _, p := range providers {
+		out = append(out, paymentMethodResponse{Provider: p})
+	}
+	return out
+}
+
+// TestSortByPreference_FirstAllowlistEntryWins is the guard on which gateway the
+// storefront pre-selects. The checkout page selects methods[0], so this
+// ordering — not the DB's row order — is what makes Cashfree the default in
+// India. A regression here silently sends INR checkouts to the wrong gateway.
+func TestSortByPreference_FirstAllowlistEntryWins(t *testing.T) {
+	cases := []struct {
+		name       string
+		preference []string
+		methods    []paymentMethodResponse
+		want       string
+	}{
+		{
+			name:       "india post-000099 — cashfree preferred",
+			preference: []string{"cashfree", "razorpay", "paypal"},
+			methods:    methodList("paypal", "razorpay", "cashfree"),
+			want:       "cashfree,razorpay,paypal",
+		},
+		{
+			name:       "already in order stays put",
+			preference: []string{"cashfree", "razorpay", "paypal"},
+			methods:    methodList("cashfree", "razorpay", "paypal"),
+			want:       "cashfree,razorpay,paypal",
+		},
+		{
+			name:       "only some providers configured",
+			preference: []string{"cashfree", "razorpay", "paypal"},
+			methods:    methodList("paypal", "cashfree"),
+			want:       "cashfree,paypal",
+		},
+		{
+			name:       "a store with no cashfree config still prefers razorpay over paypal",
+			preference: []string{"cashfree", "razorpay", "paypal"},
+			methods:    methodList("paypal", "razorpay"),
+			want:       "razorpay,paypal",
+		},
+		{
+			name:       "unrelated country order is honoured, not hardcoded",
+			preference: []string{"stripe", "paypal"},
+			methods:    methodList("paypal", "stripe"),
+			want:       "stripe,paypal",
+		},
+		{
+			name:       "case differences in the seed do not break ranking",
+			preference: []string{"Cashfree", "RAZORPAY"},
+			methods:    methodList("razorpay", "cashfree"),
+			want:       "cashfree,razorpay",
+		},
+		{
+			name:       "single method is unchanged",
+			preference: []string{"cashfree", "razorpay"},
+			methods:    methodList("razorpay"),
+			want:       "razorpay",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sortByPreference(tc.methods, tc.preference)
+			if got := providersOf(tc.methods); got != tc.want {
+				t.Fatalf("order = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSortByPreference_UnknownProviderSortsLast: a provider missing from the
+// allowlist must never end up at position 0, because position 0 is what the
+// storefront pre-selects. Sorting it last keeps an unexpected row visible
+// without letting it become the default payment method.
+func TestSortByPreference_UnknownProviderSortsLast(t *testing.T) {
+	methods := methodList("mystery", "cashfree", "razorpay")
+	sortByPreference(methods, []string{"cashfree", "razorpay"})
+	if got := providersOf(methods); got != "cashfree,razorpay,mystery" {
+		t.Fatalf("order = %q, want cashfree,razorpay,mystery", got)
+	}
+}
+
+// TestSortByPreference_EmptyPreferenceIsStable guards the degenerate case: with
+// no allowlist to rank against, the input order is preserved rather than
+// shuffled into something arbitrary.
+func TestSortByPreference_EmptyPreferenceIsStable(t *testing.T) {
+	methods := methodList("razorpay", "cashfree", "paypal")
+	sortByPreference(methods, nil)
+	if got := providersOf(methods); got != "razorpay,cashfree,paypal" {
+		t.Fatalf("order = %q, want the input order preserved", got)
+	}
+}
+
+// TestSortByPreference_EmptyListDoesNotPanic — a store with no configured
+// gateway reaches this path on every checkout page load.
+func TestSortByPreference_EmptyListDoesNotPanic(t *testing.T) {
+	sortByPreference(nil, []string{"cashfree"})
+	sortByPreference([]paymentMethodResponse{}, []string{"cashfree"})
+}

--- a/services/marketplace-api/internal/handlers/storefront/routes.go
+++ b/services/marketplace-api/internal/handlers/storefront/routes.go
@@ -143,6 +143,12 @@ func RegisterStorefront(router *gin.RouterGroup, deps Deps) {
 		if deps.WebhookHandler != nil {
 			group.POST("/orders/:id/verify-payment",
 				deps.WebhookHandler.HandleVerifyPayment)
+			// Cashfree client-side checkout callback. Cashfree's SDK returns
+			// nothing signed, so instead of verifying a client value this
+			// endpoint asks the gateway what was captured and reuses the same
+			// handler on a confirmed capture. See payment_confirm.go.
+			group.POST("/orders/:id/confirm-payment",
+				deps.WebhookHandler.HandleConfirmPayment)
 		}
 
 		// Coupon validation — Marketing M1.

--- a/services/marketplace-api/internal/handlers/storefront/webhooks.go
+++ b/services/marketplace-api/internal/handlers/storefront/webhooks.go
@@ -786,6 +786,16 @@ func extractWebhookSignature(c *gin.Context, provider string) string {
 		return c.GetHeader("Stripe-Signature")
 	case "razorpay":
 		return c.GetHeader("X-Razorpay-Signature")
+	case "cashfree":
+		// Cashfree signs base64(HMAC-SHA256(timestamp + rawBody)), so the
+		// timestamp is part of the signed material and has to reach
+		// VerifyWebhook alongside the signature. Packed into the single
+		// string the Gateway interface takes — see
+		// payment.CashfreeWebhookSignature for the format.
+		return payment.CashfreeWebhookSignature(
+			c.GetHeader(payment.CashfreeWebhookTimestampHeader),
+			c.GetHeader(payment.CashfreeWebhookSignatureHeader),
+		)
 	case "paypal":
 		return c.GetHeader("PAYPAL-TRANSMISSION-SIG")
 	default:

--- a/services/marketplace-api/internal/middleware/security_headers.go
+++ b/services/marketplace-api/internal/middleware/security_headers.go
@@ -7,12 +7,17 @@ import "github.com/gin-gonic/gin"
 // Covers OWASP recommended headers: HSTS, CSP, X-Content-Type-Options,
 // X-Frame-Options, Referrer-Policy.
 func SecurityHeaders() gin.HandlerFunc {
+	// Payment SDK hosts are wildcarded per vendor: each SDK pulls further
+	// scripts at runtime from sibling subdomains that reading our own source
+	// never reveals (Razorpay's cdn/lumberjack, Cashfree's sdk/payments), and
+	// each missed host is a silent prod-only checkout failure. Same reasoning
+	// as apps/storefront/next.config.ts — keep the two in step.
 	csp := "default-src 'self'; " +
-		"script-src 'self' https://js.stripe.com https://checkout.razorpay.com; " +
-		"frame-src https://js.stripe.com https://api.razorpay.com; " +
+		"script-src 'self' https://js.stripe.com https://*.razorpay.com https://*.cashfree.com; " +
+		"frame-src https://js.stripe.com https://*.razorpay.com https://*.cashfree.com; " +
 		"img-src 'self' https://storage.googleapis.com data:; " +
 		"style-src 'self' 'unsafe-inline'; " +
-		"connect-src 'self' https://api.stripe.com"
+		"connect-src 'self' https://api.stripe.com https://*.cashfree.com"
 
 	return func(c *gin.Context) {
 		c.Header("X-Content-Type-Options", "nosniff")

--- a/services/marketplace-api/internal/orderrefund/coordinator.go
+++ b/services/marketplace-api/internal/orderrefund/coordinator.go
@@ -289,10 +289,14 @@ func (c *Coordinator) Refund(ctx context.Context, cmd RefundCommand) (RefundResu
 	if split.Gateway.GreaterThan(decimal.Zero) {
 		ref, err := c.pay.ExecuteGatewayRefund(ctx, gw, payment.RefundInput{
 			ProviderPaymentID: pc.ProviderPaymentID,
-			Amount:            split.Gateway,
-			CurrencyCode:      o.CurrencyCode,
-			Reason:            cmd.Reason,
-			IdempotencyKey:    key,
+			// Order-scoped gateways (Cashfree) refund against the order id
+			// rather than the payment id. Passed for every provider; the
+			// payment-scoped ones ignore it.
+			OrderID:        cmd.OrderID.String(),
+			Amount:         split.Gateway,
+			CurrencyCode:   o.CurrencyCode,
+			Reason:         cmd.Reason,
+			IdempotencyKey: key,
 		})
 		if err != nil {
 			if payment.IsPermanentGatewayError(err) {

--- a/services/marketplace-api/internal/orderrefund/resolver.go
+++ b/services/marketplace-api/internal/orderrefund/resolver.go
@@ -90,6 +90,11 @@ func (r *Resolver) resolveCred(ctx context.Context, ref string) (string, error) 
 // capture — see the capture-handler fix in this task). We prefer
 // provider_payment_id and fall back to provider_intent_id for legacy rows
 // captured before that fix (Stripe rows, where intent == the refund target).
+//
+// Cashfree is the exception: it has no payment-level refund endpoint, so its
+// adapter refunds against RefundInput.OrderID (our order id, which CreateIntent
+// submitted as the Cashfree order_id) and ignores ProviderPaymentID entirely.
+// The Coordinator passes both, so nothing here needs to branch on provider.
 func (r *Resolver) PaymentContextForOrder(ctx context.Context, orderID uuid.UUID) (PaymentContext, error) {
 	type row struct {
 		Provider          string

--- a/services/marketplace-api/internal/payment/cashfree.go
+++ b/services/marketplace-api/internal/payment/cashfree.go
@@ -1,0 +1,888 @@
+package payment
+
+// cashfree.go — the Cashfree Payment Gateway adapter.
+//
+// Deliberately shaped as a near-mirror of razorpay.go: same constructor
+// signature, same per-mode base URL seam, same GatewayError on refund failure,
+// same normalized WebhookEvent out the other side. The symmetry is the point —
+// every money path in this service resolves a provider name to a Gateway and
+// otherwise reads identically, so a reviewer comparing the two files sees the
+// gateway differences and nothing else.
+//
+// This is a port of the battle-tested adapter in Home-Chef-App
+// (apps/api/services/cashfree.go). Credentials differ in origin — HomeChef
+// reads platform-wide slots from Secret Manager, mark8ly resolves per-store
+// rows from payment_gateway_configs via carriersecrets — but the wire
+// behaviour is intentionally identical, including the 409 handling and the
+// timestamp-bound webhook verification.
+//
+// Five things genuinely differ from Razorpay, and each one is a place a
+// careless port would lose money:
+//
+//  1. AMOUNTS ARE RUPEES ON THE WIRE. Razorpay speaks integer paise; Cashfree
+//     speaks a decimal number of rupees ("order_amount": 140.25). Every amount
+//     crossing this boundary goes through cashfreeAmount, which holds minor
+//     units internally and renders the decimal by integer arithmetic — never
+//     by formatting a float64, which is how 140.25 becomes 140.25000000000001.
+//
+//  2. ENVIRONMENT IS THE HOSTNAME, not just the key. Razorpay serves live and
+//     test from one host and tells them apart by key prefix; Cashfree has
+//     sandbox.cashfree.com vs api.cashfree.com. That is strictly safer — a
+//     test-mode client physically cannot reach production — and it means the
+//     mode must be baked into the client at construction.
+//
+//  3. THERE IS NO CLIENT-SIDE PAYMENT SIGNATURE. Razorpay Checkout hands the
+//     browser an HMAC of order_id|payment_id that the server re-computes. The
+//     Cashfree SDK returns no such thing; the authority is a server-side
+//     GET /orders/{id}/payments. Hence OrderStatusGateway — the confirm path
+//     MUST fetch, and must not be written to "tolerate a missing signature"
+//     the way the Razorpay path does.
+//
+//  4. REFUNDS ARE ORDER-SCOPED. Cashfree has no payment-level refund
+//     endpoint, so RefundPayment keys off RefundInput.OrderID (which
+//     CreateIntent submitted as the Cashfree order_id) rather than
+//     ProviderPaymentID. Refund idempotency is first-class: a
+//     merchant-supplied refund_id makes a repeat the SAME refund.
+//
+//  5. WEBHOOKS SIGN TIMESTAMP+BODY, BASE64. Razorpay signs the body alone and
+//     hex-encodes. Cashfree prefixes the delivery timestamp and base64s, so
+//     the timestamp has to reach VerifyWebhook — see the composite signature
+//     contract on parseCashfreeSignature.
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+const (
+	// Environment is selected by HOST, so these are not interchangeable with a
+	// key swap — see note 2 above. The /pg suffix is part of the base: every
+	// Payment Gateway route hangs off it.
+	cashfreeLiveBaseURL = "https://api.cashfree.com/pg"
+	cashfreeTestBaseURL = "https://sandbox.cashfree.com/pg"
+
+	// cashfreeAPIVersion pins the response schema. Cashfree versions its API
+	// by date header and keeps old versions working, so this is a deliberate
+	// pin rather than "latest": the order/payment/refund/webhook shapes this
+	// file parses are the 2023-08-01 ones. Bumping it is a reviewed change,
+	// not a drift.
+	cashfreeAPIVersion = "2023-08-01"
+
+	cashfreeRequestTimeout = 30 * time.Second
+
+	// cashfreeWebhookMaxSkew bounds how old a webhook's timestamp may be.
+	//
+	// The signature covers timestamp+body, so an attacker who captures one
+	// delivery can replay it verbatim forever and it will keep verifying. The
+	// webhook_events unique index on (provider, provider_event_id) is the
+	// primary defence; this adds a time bound on top, because the timestamp is
+	// right there in the signed payload and not checking it throws away the
+	// one anti-replay signal the scheme hands us. Generous enough to absorb
+	// Cashfree's own retry schedule and any clock drift.
+	cashfreeWebhookMaxSkew = 30 * time.Minute
+)
+
+// CashfreeGateway implements Gateway (and OrderStatusGateway) for Cashfree
+// Payment Gateway using the REST API.
+type CashfreeGateway struct {
+	appID     string // x-client-id — the public app id, Cashfree's analogue of a Razorpay key_id
+	secretKey string // x-client-secret (also the webhook signing secret unless a dedicated one is configured)
+	mode      string
+	baseURL   string
+	client    *http.Client
+}
+
+// NewCashfreeGateway returns a Cashfree Gateway ready for use. apiKey is the
+// app id and secretKey the secret key, matching the (api_key, secret_key)
+// column pair every provider in payment_gateway_configs uses.
+func NewCashfreeGateway(apiKey, secretKey, mode string) *CashfreeGateway {
+	base := cashfreeLiveBaseURL
+	if mode == "test" {
+		base = cashfreeTestBaseURL
+	}
+	return &CashfreeGateway{
+		appID:     apiKey,
+		secretKey: secretKey,
+		mode:      mode,
+		baseURL:   base,
+		client:    &http.Client{Timeout: cashfreeRequestTimeout},
+	}
+}
+
+func (c *CashfreeGateway) ProviderName() string { return "cashfree" }
+
+func (c *CashfreeGateway) SupportedCountries() []string {
+	return []string{"IN"}
+}
+
+// --- Amounts ---
+
+// cashfreeAmount is an amount in MINOR units (paise for INR) that marshals to
+// — and unmarshals from — Cashfree's rupees-with-two-decimals wire format.
+//
+// The whole reason this type exists rather than a plain float64 field:
+// rendering money by formatting a float64 is how a ₹140.25 order becomes
+// 140.25000000000001 on the wire, and how repeated ÷100 ×100 round-trips shave
+// a paise off a settlement. The conversion happens exactly once, here, at the
+// boundary — by integer arithmetic on the way out, and through decimal (never
+// float) on the way in.
+type cashfreeAmount int64
+
+// MarshalJSON renders minor units as a decimal with exactly two places, using
+// integer division so no float ever touches the value.
+func (a cashfreeAmount) MarshalJSON() ([]byte, error) {
+	minor := int64(a)
+	sign := ""
+	if minor < 0 {
+		// Never expected — a negative charge or refund is a caller bug — but
+		// rendering "-1.-5" would be worse than rendering "-1.05", and
+		// silently clamping to zero would hide the bug.
+		sign, minor = "-", -minor
+	}
+	return fmt.Appendf(nil, "%s%d.%02d", sign, minor/100, minor%100), nil
+}
+
+// UnmarshalJSON accepts Cashfree's number (or a stringified number, which some
+// fields use) and converts to minor units through decimal — the same rounding
+// toMinorUnits applies, so a value read back from Cashfree compares equal to
+// the value we sent.
+func (a *cashfreeAmount) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(strings.TrimSpace(string(b)), `"`)
+	if s == "" || s == "null" {
+		*a = 0
+		return nil
+	}
+	d, err := decimal.NewFromString(s)
+	if err != nil {
+		return fmt.Errorf("cashfree: parse amount %q: %w", s, err)
+	}
+	*a = cashfreeAmount(toMinorUnits(d, "INR"))
+	return nil
+}
+
+// Decimal returns the amount as a major-unit decimal, the unit every caller in
+// this service works in (orders, refunds and the ledger are all numeric(12,2)).
+func (a cashfreeAmount) Decimal() decimal.Decimal {
+	return decimal.New(int64(a), 0).Div(decimal.NewFromInt(100))
+}
+
+// --- Wire types ---
+
+type cashfreeCustomerDetails struct {
+	CustomerID    string `json:"customer_id"`
+	CustomerPhone string `json:"customer_phone"`
+	CustomerName  string `json:"customer_name,omitempty"`
+	CustomerEmail string `json:"customer_email,omitempty"`
+}
+
+// cashfreeOrderMeta carries the redirect hook. notify_url is deliberately left
+// empty: webhooks are configured once in the Cashfree dashboard rather than
+// per order, because a per-order URL would silently bypass the signature
+// secret we verify with.
+type cashfreeOrderMeta struct {
+	ReturnURL string `json:"return_url,omitempty"`
+}
+
+type cashfreeOrderRequest struct {
+	OrderID   string                  `json:"order_id,omitempty"`
+	Amount    cashfreeAmount          `json:"order_amount"`
+	Currency  string                  `json:"order_currency"`
+	Customer  cashfreeCustomerDetails `json:"customer_details"`
+	Meta      *cashfreeOrderMeta      `json:"order_meta,omitempty"`
+	Tags      map[string]string       `json:"order_tags,omitempty"`
+	OrderNote string                  `json:"order_note,omitempty"`
+}
+
+// cashfreeOrderResponse is the created (or fetched) order. PaymentSessionID is
+// the token the client SDK opens checkout with — it is the Cashfree analogue
+// of Razorpay's order_id client token, and it is short-lived, which is why the
+// create path reuses an ACTIVE order rather than minting a second one.
+type cashfreeOrderResponse struct {
+	CFOrderID        json.Number    `json:"cf_order_id"`
+	OrderID          string         `json:"order_id"`
+	PaymentSessionID string         `json:"payment_session_id"`
+	OrderStatus      string         `json:"order_status"`
+	Amount           cashfreeAmount `json:"order_amount"`
+	Currency         string         `json:"order_currency"`
+}
+
+// Cashfree order_status values. EXPIRED / TERMINATED are dead: the session
+// cannot be paid, so handing the client that token would only bounce.
+const (
+	cashfreeOrderActive = "ACTIVE"
+	cashfreeOrderPaid   = "PAID"
+)
+
+// cashfreePayment is one payment attempt against an order.
+//
+// PaymentMethod is deliberately json.RawMessage: Cashfree returns an OBJECT
+// there ({"upi":{…}} / {"card":{…}}), not a string. PaymentGroup is the flat
+// label ("upi", "credit_card", "net_banking", …) and is what methodLabel maps
+// into this service's short vocabulary — decoding the object into a typed
+// struct would couple us to every instrument Cashfree adds.
+type cashfreePayment struct {
+	CFPaymentID   json.Number     `json:"cf_payment_id"`
+	OrderID       string          `json:"order_id"`
+	PaymentStatus string          `json:"payment_status"`
+	Amount        cashfreeAmount  `json:"payment_amount"`
+	Currency      string          `json:"payment_currency"`
+	PaymentGroup  string          `json:"payment_group"`
+	PaymentMethod json.RawMessage `json:"payment_method,omitempty"`
+}
+
+// Cashfree payment_status values.
+const (
+	cashfreePaymentSuccess     = "SUCCESS"
+	cashfreePaymentFailed      = "FAILED"
+	cashfreePaymentUserDropped = "USER_DROPPED"
+)
+
+// isCaptured reports whether this payment actually took the money. Cashfree
+// has no separate authorize/capture step for the instruments we accept, so
+// SUCCESS is the captured state.
+func (p *cashfreePayment) isCaptured() bool {
+	return p != nil && p.PaymentStatus == cashfreePaymentSuccess
+}
+
+// methodLabel maps Cashfree's payment_group onto the short method vocabulary
+// already stored in payment_transactions.payment_method ("upi", "card",
+// "netbanking", "wallet"), so an admin screen or receipt reads identically no
+// matter which gateway took the payment. An unrecognised group passes through
+// as-is rather than being flattened to "other" — a new instrument should show
+// up in the data, not disappear into a bucket.
+func (p *cashfreePayment) methodLabel() string {
+	if p == nil {
+		return ""
+	}
+	switch strings.ToLower(p.PaymentGroup) {
+	case "upi":
+		return "upi"
+	case "credit_card", "debit_card", "card", "credit_card_emi", "debit_card_emi", "cardless_emi":
+		return "card"
+	case "net_banking", "netbanking":
+		return "netbanking"
+	case "wallet", "app":
+		return "wallet"
+	case "pay_later", "paylater":
+		return "paylater"
+	default:
+		return strings.ToLower(p.PaymentGroup)
+	}
+}
+
+type cashfreeRefundRequest struct {
+	Amount   cashfreeAmount `json:"refund_amount"`
+	RefundID string         `json:"refund_id"`
+	Note     string         `json:"refund_note,omitempty"`
+	// Speed is STANDARD or INSTANT; empty means STANDARD, which matches
+	// Razorpay's "normal".
+	Speed string `json:"refund_speed,omitempty"`
+}
+
+type cashfreeRefund struct {
+	CFRefundID   json.Number    `json:"cf_refund_id"`
+	CFPaymentID  json.Number    `json:"cf_payment_id"`
+	RefundID     string         `json:"refund_id"`
+	OrderID      string         `json:"order_id"`
+	RefundStatus string         `json:"refund_status"`
+	Amount       cashfreeAmount `json:"refund_amount"`
+}
+
+// Cashfree refund_status values.
+const (
+	cashfreeRefundSuccess   = "SUCCESS"
+	cashfreeRefundPending   = "PENDING"
+	cashfreeRefundOnHold    = "ONHOLD"
+	cashfreeRefundCancelled = "CANCELLED"
+	cashfreeRefundFailed    = "FAILED"
+)
+
+// normalizeCashfreeRefundStatus maps Cashfree's refund_status onto the status
+// vocabulary refund_transactions already persists for Razorpay refunds.
+//
+// ONHOLD maps to pending, not failed: the money is still coming, it is just
+// held for review at Cashfree. Calling it failed would make the refund sweeper
+// re-issue a refund that is already in flight.
+func normalizeCashfreeRefundStatus(status string) string {
+	switch strings.ToUpper(status) {
+	case cashfreeRefundSuccess:
+		return "succeeded"
+	case cashfreeRefundPending, cashfreeRefundOnHold:
+		return "pending"
+	case cashfreeRefundFailed, cashfreeRefundCancelled:
+		return "failed"
+	default:
+		return strings.ToLower(status)
+	}
+}
+
+// --- Gateway implementation ---
+
+// CreateIntent creates a Cashfree order via POST /pg/orders and returns its
+// payment_session_id as the client token.
+//
+// order_id is OUR order id, submitted verbatim. That is load-bearing: Cashfree
+// refunds are order-scoped with no payment-level endpoint, so this is what
+// makes RefundPayment resolvable from the ledger later (see RefundInput.OrderID).
+//
+// A duplicate order_id returns 409 from Cashfree. That is NOT an error here: it
+// means a previous attempt already created this order (a timeout-after-success,
+// or a double-tapped "Place order"), so the existing order is fetched and its
+// still-valid session reused. Treating the 409 as a failure would strand a
+// perfectly payable order and — worse — tempt the caller into minting a second
+// order id for the same purchase, which is how a payment arrives for an order
+// id nothing recognises.
+func (c *CashfreeGateway) CreateIntent(ctx context.Context, in CreateIntentInput) (*Intent, error) {
+	// Cashfree settles only in INR (see SupportedCountries). Reject a
+	// mismatched currency loudly rather than silently billing the amount as
+	// rupees, which is what the wire format would do.
+	if in.CurrencyCode != "" && !strings.EqualFold(in.CurrencyCode, "INR") {
+		return nil, fmt.Errorf("cashfree: create intent: unsupported currency %q (INR only)", in.CurrencyCode)
+	}
+	// customer_phone is mandatory at Cashfree and is what UPI intent keys off.
+	// Failing here — before any HTTP call — turns an opaque gateway 400 into a
+	// message that names the missing field.
+	phone := strings.TrimSpace(in.CustomerPhone)
+	if phone == "" {
+		return nil, fmt.Errorf("cashfree: create intent: customer_phone is required by Cashfree and was empty")
+	}
+
+	req := cashfreeOrderRequest{
+		OrderID:  in.OrderID,
+		Amount:   cashfreeAmount(toMinorUnits(in.Amount, "INR")),
+		Currency: "INR",
+		Customer: cashfreeCustomerDetails{
+			// customer_id must be stable per payer but is not a Cashfree-side
+			// record we own, so derive it from the order. Cashfree restricts
+			// this field to alphanumerics plus _ and -, which a uuid satisfies.
+			CustomerID:    "order_" + in.OrderID,
+			CustomerPhone: phone,
+			CustomerName:  in.CustomerName,
+			CustomerEmail: in.CustomerEmail,
+		},
+		Tags:      in.Metadata,
+		OrderNote: in.Description,
+	}
+
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("cashfree: create intent: marshal: %w", err)
+	}
+
+	body, status, err := c.do(ctx, http.MethodPost, "/orders", payload, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cashfree: create intent: %w", err)
+	}
+
+	var result cashfreeOrderResponse
+	switch {
+	case status == http.StatusConflict && in.OrderID != "":
+		existing, ferr := c.fetchOrder(ctx, in.OrderID)
+		if ferr != nil {
+			return nil, fmt.Errorf("cashfree: create intent: order %s exists but fetch failed: %w", in.OrderID, ferr)
+		}
+		if existing.OrderStatus != cashfreeOrderActive || existing.PaymentSessionID == "" {
+			// PAID / EXPIRED / TERMINATED: there is nothing payable to hand
+			// back. Say which state it is in rather than returning an empty
+			// token the storefront would try to open.
+			return nil, fmt.Errorf("cashfree: create intent: order %s already exists and is not payable (status %s)",
+				in.OrderID, existing.OrderStatus)
+		}
+		result = *existing
+	case status >= 400:
+		return nil, cashfreeError(status, body)
+	default:
+		if err := json.Unmarshal(body, &result); err != nil {
+			return nil, fmt.Errorf("cashfree: create intent: decode: %w", err)
+		}
+	}
+
+	if result.PaymentSessionID == "" {
+		return nil, fmt.Errorf("cashfree: create intent: order %s returned no payment_session_id", result.OrderID)
+	}
+
+	return &Intent{
+		// The Cashfree order id we can address later is the merchant order_id
+		// we submitted, not cf_order_id — every /pg/orders/{id} route accepts
+		// the merchant id, and it is the one the refund path can reconstruct.
+		ProviderIntentID: result.OrderID,
+		ClientToken:      result.PaymentSessionID,
+		Status:           normalizeCashfreeOrderStatus(result.OrderStatus),
+	}, nil
+}
+
+// normalizeCashfreeOrderStatus maps Cashfree's order_status onto the
+// payment_transactions.status vocabulary the checkout path persists. ACTIVE is
+// "pending" — created and payable, nothing captured yet.
+func normalizeCashfreeOrderStatus(status string) string {
+	switch strings.ToUpper(status) {
+	case cashfreeOrderActive:
+		return "pending"
+	case cashfreeOrderPaid:
+		return "captured"
+	default:
+		return strings.ToLower(status)
+	}
+}
+
+// CapturePayment confirms the settled payment on a Cashfree order.
+//
+// Cashfree auto-captures the instruments we accept — there is no separate
+// capture call to make — so this is a read: fetch the order's payments and
+// report the SUCCESS one. captureID is the Cashfree order id (the value
+// CreateIntent returned as ProviderIntentID), because Cashfree scopes payments
+// under their order and offers no global payment-fetch route.
+func (c *CashfreeGateway) CapturePayment(ctx context.Context, captureID string) (*Capture, error) {
+	p, err := c.successfulPayment(ctx, captureID)
+	if err != nil {
+		return nil, fmt.Errorf("cashfree: capture payment: %w", err)
+	}
+	if p == nil {
+		return nil, fmt.Errorf("cashfree: capture payment: no captured payment on order %s", captureID)
+	}
+	return &Capture{
+		ProviderPaymentID: p.CFPaymentID.String(),
+		Status:            "captured",
+		PaymentMethod:     p.methodLabel(),
+	}, nil
+}
+
+// FetchOrderPayment implements OrderStatusGateway. It is the authority the
+// confirm path uses: with no client-side signature to check, the gateway's own
+// record of what was paid is the only trustworthy input.
+//
+// Returns (nil, nil) when the order exists but has no captured payment yet —
+// the caller reads that as "not paid", which is exactly right.
+func (c *CashfreeGateway) FetchOrderPayment(ctx context.Context, providerOrderID string) (*OrderPayment, error) {
+	payments, err := c.fetchOrderPayments(ctx, providerOrderID)
+	if err != nil {
+		return nil, err
+	}
+	// Prefer the captured attempt. Never just take payments[0]: an order can
+	// carry a failed or user-dropped attempt ahead of the one that paid.
+	for i := range payments {
+		if payments[i].isCaptured() {
+			p := &payments[i]
+			return &OrderPayment{
+				ProviderPaymentID: p.CFPaymentID.String(),
+				Status:            "payment.succeeded",
+				PaymentMethod:     p.methodLabel(),
+				Amount:            p.Amount.Decimal(),
+				CurrencyCode:      strings.ToUpper(p.Currency),
+			}, nil
+		}
+	}
+	return nil, nil
+}
+
+// RefundPayment creates a refund via POST /pg/orders/{order_id}/refunds.
+//
+// Keyed off in.OrderID, not in.ProviderPaymentID: Cashfree has no
+// payment-level refund endpoint. The refund_id is derived deterministically
+// from the caller's IdempotencyKey, so a retry is the SAME refund — and a 409
+// or 422 (duplicate refund_id / idempotency replay) is read back as success
+// rather than reported as a failure that would send the saga round again.
+// Mishandling that is how a customer receives two refunds.
+func (c *CashfreeGateway) RefundPayment(ctx context.Context, in RefundInput) (*Refund, error) {
+	if in.CurrencyCode != "" && !strings.EqualFold(in.CurrencyCode, "INR") {
+		return nil, fmt.Errorf("cashfree: refund payment: unsupported currency %q (INR only)", in.CurrencyCode)
+	}
+	orderID := strings.TrimSpace(in.OrderID)
+	if orderID == "" {
+		// Refusing here is deliberate: there is no order-id-free refund route
+		// to fall back to, and guessing one from ProviderPaymentID (a
+		// cf_payment_id) is impossible.
+		return nil, fmt.Errorf("cashfree: refund payment: OrderID is required (Cashfree refunds are order-scoped)")
+	}
+	if in.IdempotencyKey == "" {
+		// Letting Cashfree mint the refund_id would remove the dedup that
+		// stops a retry becoming a second real refund.
+		return nil, fmt.Errorf("cashfree: refund payment: IdempotencyKey is required to derive refund_id")
+	}
+
+	refundID := cashfreeRefundID(in.IdempotencyKey)
+	req := cashfreeRefundRequest{
+		Amount:   cashfreeAmount(toMinorUnits(in.Amount, "INR")),
+		RefundID: refundID,
+		Note:     in.Reason,
+		Speed:    "STANDARD",
+	}
+
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("cashfree: refund payment: marshal: %w", err)
+	}
+
+	path := "/orders/" + orderID + "/refunds"
+	body, status, err := c.do(ctx, http.MethodPost, path, payload, map[string]string{
+		cashfreeHeaderIdempotency: refundID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cashfree: refund payment: %w", err)
+	}
+
+	var result cashfreeRefund
+	switch {
+	case status == http.StatusConflict || status == http.StatusUnprocessableEntity:
+		existing, ferr := c.fetchRefund(ctx, orderID, refundID)
+		if ferr != nil {
+			// Fall through to the typed error so the saga can classify it.
+			return nil, &GatewayError{Provider: "cashfree", StatusCode: status, Body: cashfreeErrorBody(body)}
+		}
+		result = *existing
+	case status >= 400:
+		// GatewayError (not a bare fmt.Errorf) so the refund saga's
+		// Permanent() check can move a hopeless row to 'failed' instead of
+		// re-driving it forever. Only the structured envelope is carried, not
+		// the raw body — Cashfree echoes submitted values back in some
+		// validation errors, and a rejected phone or bank detail must not ride
+		// an error message into a log line.
+		return nil, &GatewayError{Provider: "cashfree", StatusCode: status, Body: cashfreeErrorBody(body)}
+	default:
+		if err := json.Unmarshal(body, &result); err != nil {
+			return nil, fmt.Errorf("cashfree: refund payment: decode: %w", err)
+		}
+	}
+
+	return &Refund{
+		ProviderRefundID: result.RefundID,
+		Status:           normalizeCashfreeRefundStatus(result.RefundStatus),
+		Amount:           result.Amount.Decimal(),
+	}, nil
+}
+
+// cashfreeRefundID normalizes a logical operation id into Cashfree's refund_id
+// window: 3–40 characters, alphanumeric plus _ and -.
+//
+// The coordinator's key is "refund_{uuid}_{scope}", which is already over 40
+// characters, so it cannot be sent verbatim. A sha256 digest truncated to 32
+// hex chars fits the window, keeps the charset, and stays deterministic — the
+// same logical refund derives the same refund_id on every retry, which is the
+// entire basis of the idempotency guarantee. This matches the
+// normalizeIdempotencyKey digest Home-Chef-App feeds Cashfree.
+func cashfreeRefundID(logical string) string {
+	sum := sha256.Sum256([]byte(logical))
+	return hex.EncodeToString(sum[:])[:32]
+}
+
+// VerifyWebhook verifies a Cashfree webhook and normalizes the event.
+//
+// Cashfree signs base64(HMAC-SHA256(timestamp + rawBody, secret)) — the RAW
+// body must be used, not a re-marshalled parse, or the digest will not match.
+// The timestamp arrives in a separate header, so `signature` is the composite
+// documented on parseCashfreeSignature.
+func (c *CashfreeGateway) VerifyWebhook(_ context.Context, payload []byte, signature string) (*WebhookEvent, error) {
+	timestamp, sig, err := parseCashfreeSignature(signature)
+	if err != nil {
+		return nil, err
+	}
+	// Fail closed on a stale or unparseable timestamp: a caller cannot
+	// distinguish "no replay protection" from "verified".
+	if !cashfreeTimestampFresh(timestamp) {
+		return nil, fmt.Errorf("cashfree: verify webhook: stale or invalid timestamp %q", timestamp)
+	}
+
+	mac := hmac.New(sha256.New, []byte(c.secretKey))
+	mac.Write([]byte(timestamp))
+	mac.Write(payload)
+	expected := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	if !hmac.Equal([]byte(sig), []byte(expected)) {
+		return nil, fmt.Errorf("cashfree: verify webhook: signature mismatch")
+	}
+
+	var envelope struct {
+		Type      string `json:"type"`
+		EventTime string `json:"event_time"`
+		Data      struct {
+			Order struct {
+				OrderID  string            `json:"order_id"`
+				Amount   cashfreeAmount    `json:"order_amount"`
+				Currency string            `json:"order_currency"`
+				Tags     map[string]string `json:"order_tags"`
+			} `json:"order"`
+			Payment cashfreePayment `json:"payment"`
+			Refund  cashfreeRefund  `json:"refund"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return nil, fmt.Errorf("cashfree: verify webhook: decode: %w", err)
+	}
+
+	d := envelope.Data
+	eventType := normalizeCashfreeEvent(envelope.Type)
+
+	// Refund events carry their ids under data.refund and no data.payment.
+	if eventType == "refund.succeeded" || envelope.Type == cashfreeWebhookRefundStatus {
+		orderID := d.Refund.OrderID
+		if orderID == "" {
+			orderID = d.Order.OrderID
+		}
+		return &WebhookEvent{
+			// refund_id is the merchant-supplied id we derived, so it is
+			// stable across Cashfree's own retries — the right idempotency
+			// key for the webhook_events unique index.
+			ProviderEventID:   "cfrefund_" + d.Refund.RefundID,
+			EventType:         eventType,
+			OrderID:           orderID,
+			ProviderPaymentID: d.Refund.CFPaymentID.String(),
+			Metadata:          d.Order.Tags,
+			Amount:            d.Refund.Amount.Decimal(),
+			CurrencyCode:      "INR",
+			RawPayload:        payload,
+		}, nil
+	}
+
+	orderID := d.Order.OrderID
+	if orderID == "" {
+		orderID = d.Payment.OrderID
+	}
+	amount := d.Payment.Amount
+	if amount == 0 {
+		amount = d.Order.Amount
+	}
+	currency := d.Payment.Currency
+	if currency == "" {
+		currency = d.Order.Currency
+	}
+
+	return &WebhookEvent{
+		// Cashfree sends no event-id header. cf_payment_id scoped by event
+		// type is stable across genuine retries (a redelivery repeats the same
+		// payment) while still letting a later refund event on the same
+		// payment through the (provider, provider_event_id) unique index.
+		ProviderEventID:   "cfpay_" + eventType + "_" + d.Payment.CFPaymentID.String(),
+		EventType:         eventType,
+		OrderID:           orderID,
+		ProviderPaymentID: d.Payment.CFPaymentID.String(),
+		Metadata:          d.Order.Tags,
+		Amount:            amount.Decimal(),
+		CurrencyCode:      strings.ToUpper(currency),
+		PaymentMethod:     d.Payment.methodLabel(),
+		RawPayload:        payload,
+	}, nil
+}
+
+// Cashfree webhook types we act on.
+const (
+	cashfreeWebhookPaymentSuccess = "PAYMENT_SUCCESS_WEBHOOK"
+	cashfreeWebhookPaymentFailed  = "PAYMENT_FAILED_WEBHOOK"
+	cashfreeWebhookUserDropped    = "PAYMENT_USER_DROPPED_WEBHOOK"
+	cashfreeWebhookRefundStatus   = "REFUND_STATUS_WEBHOOK"
+)
+
+// normalizeCashfreeEvent maps Cashfree's event types onto the normalized
+// vocabulary processEvent switches on. USER_DROPPED is a failure for our
+// purposes — the buyer abandoned the sheet and the order stays reserved,
+// which is the same handling a hard decline gets.
+func normalizeCashfreeEvent(event string) string {
+	switch event {
+	case cashfreeWebhookPaymentSuccess:
+		return "payment.succeeded"
+	case cashfreeWebhookPaymentFailed, cashfreeWebhookUserDropped:
+		return "payment.failed"
+	case cashfreeWebhookRefundStatus:
+		return "refund.succeeded"
+	default:
+		return event
+	}
+}
+
+// Cashfree webhook headers. Exported so the webhook route reads them from the
+// same place the verifier defines them — a drift between the header the router
+// reads and the one the gateway expects would 401 every real delivery.
+const (
+	CashfreeWebhookSignatureHeader = "x-webhook-signature"
+	CashfreeWebhookTimestampHeader = "x-webhook-timestamp"
+)
+
+// CashfreeWebhookSignature packs the two headers Cashfree's signature scheme
+// needs into the single `signature` string Gateway.VerifyWebhook accepts.
+//
+// The interface takes one string because every other provider signs the body
+// alone; Cashfree prefixes the delivery timestamp, so both values have to
+// travel. PayPal already establishes this precedent (it packs its header set as
+// JSON). The separator is "." because a Cashfree timestamp is epoch seconds —
+// digits only — so the split is unambiguous even though base64 signatures can
+// contain "+", "/" and "=".
+func CashfreeWebhookSignature(timestamp, signature string) string {
+	return timestamp + "." + signature
+}
+
+// parseCashfreeSignature splits the composite CashfreeWebhookSignature builds.
+func parseCashfreeSignature(composite string) (timestamp, signature string, err error) {
+	ts, sig, found := strings.Cut(composite, ".")
+	if !found || ts == "" || sig == "" {
+		return "", "", fmt.Errorf("cashfree: verify webhook: malformed signature header pair " +
+			"(want \"<x-webhook-timestamp>.<x-webhook-signature>\")")
+	}
+	return ts, sig, nil
+}
+
+// cashfreeTimestampFresh bounds the signed timestamp. Cashfree sends epoch
+// seconds; an unparseable value fails closed.
+func cashfreeTimestampFresh(ts string) bool {
+	secs, err := strconv.ParseInt(strings.TrimSpace(ts), 10, 64)
+	if err != nil {
+		return false
+	}
+	age := time.Since(time.Unix(secs, 0))
+	if age < 0 {
+		age = -age // tolerate a slightly fast sender clock
+	}
+	return age <= cashfreeWebhookMaxSkew
+}
+
+// --- Internal reads ---
+
+func (c *CashfreeGateway) fetchOrder(ctx context.Context, orderID string) (*cashfreeOrderResponse, error) {
+	body, status, err := c.do(ctx, http.MethodGet, "/orders/"+orderID, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if status >= 400 {
+		return nil, cashfreeError(status, body)
+	}
+	var result cashfreeOrderResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("cashfree: decode fetch-order: %w", err)
+	}
+	return &result, nil
+}
+
+// fetchOrderPayments returns every payment attempt on an order. A 404 means no
+// attempts yet — an empty list, not a failure.
+func (c *CashfreeGateway) fetchOrderPayments(ctx context.Context, orderID string) ([]cashfreePayment, error) {
+	body, status, err := c.do(ctx, http.MethodGet, "/orders/"+orderID+"/payments", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if status == http.StatusNotFound {
+		return nil, nil
+	}
+	if status >= 400 {
+		return nil, cashfreeError(status, body)
+	}
+	var result []cashfreePayment
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("cashfree: decode order payments: %w", err)
+	}
+	return result, nil
+}
+
+// successfulPayment returns the captured payment on an order, or nil when
+// there isn't one. Centralised because "which of these attempts is the real
+// one" is a question every caller would otherwise answer slightly differently
+// — and one that must never be answered by picking the first element.
+func (c *CashfreeGateway) successfulPayment(ctx context.Context, orderID string) (*cashfreePayment, error) {
+	payments, err := c.fetchOrderPayments(ctx, orderID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range payments {
+		if payments[i].isCaptured() {
+			return &payments[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func (c *CashfreeGateway) fetchRefund(ctx context.Context, orderID, refundID string) (*cashfreeRefund, error) {
+	body, status, err := c.do(ctx, http.MethodGet, "/orders/"+orderID+"/refunds/"+refundID, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if status >= 400 {
+		return nil, cashfreeError(status, body)
+	}
+	var result cashfreeRefund
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("cashfree: decode fetch-refund: %w", err)
+	}
+	return &result, nil
+}
+
+// --- HTTP ---
+
+const cashfreeHeaderIdempotency = "x-idempotency-key"
+
+// do performs one authenticated round-trip and returns the body and status.
+// Status is returned rather than folded into an error because several callers
+// treat specific non-2xx codes as success (409 on create, 409/422 on refund,
+// 404 on an order with no payments yet) — collapsing them into an error string
+// and re-parsing it would be fragile.
+func (c *CashfreeGateway) do(
+	ctx context.Context,
+	method, path string,
+	body []byte,
+	extraHeaders map[string]string,
+) ([]byte, int, error) {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return nil, 0, fmt.Errorf("build request: %w", err)
+	}
+
+	// Cashfree authenticates with a header pair, not HTTP Basic.
+	req.Header.Set("x-client-id", c.appID)
+	req.Header.Set("x-client-secret", c.secretKey)
+	req.Header.Set("x-api-version", cashfreeAPIVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	for k, v := range extraHeaders {
+		if v != "" {
+			req.Header.Set(k, v)
+		}
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("read response: %w", err)
+	}
+	return respBody, resp.StatusCode, nil
+}
+
+// cashfreeErrorBody extracts Cashfree's structured error envelope
+// ({"message":…,"code":…,"type":…}).
+//
+// Only the structured fields are surfaced, never the raw body: Cashfree echoes
+// submitted values back in some validation errors, and a rejected customer
+// phone or bank detail must not ride an error message into a log line or an
+// admin-facing refund failure reason.
+func cashfreeErrorBody(body []byte) string {
+	var parsed struct {
+		Message string `json:"message"`
+		Code    string `json:"code"`
+		Type    string `json:"type"`
+	}
+	if err := json.Unmarshal(body, &parsed); err == nil && (parsed.Code != "" || parsed.Message != "") {
+		return parsed.Code + ": " + parsed.Message
+	}
+	return "unrecognized error envelope"
+}
+
+func cashfreeError(status int, body []byte) error {
+	return fmt.Errorf("cashfree API error (HTTP %d): %s", status, cashfreeErrorBody(body))
+}

--- a/services/marketplace-api/internal/payment/cashfree_test.go
+++ b/services/marketplace-api/internal/payment/cashfree_test.go
@@ -1,0 +1,630 @@
+package payment
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// newTestCashfree builds a gateway pointed at a test server.
+func newTestCashfree(t *testing.T, h http.HandlerFunc) (*CashfreeGateway, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	g := NewCashfreeGateway("app_id", "secret", "test")
+	g.baseURL = srv.URL
+	return g, srv
+}
+
+// signCashfree produces the composite signature string the webhook route packs
+// from the two Cashfree headers, using a fresh timestamp.
+func signCashfree(t *testing.T, secret string, payload []byte) string {
+	t.Helper()
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(ts))
+	mac.Write(payload)
+	return CashfreeWebhookSignature(ts, base64.StdEncoding.EncodeToString(mac.Sum(nil)))
+}
+
+// TestCashfreeAmount_RendersRupeesWithoutFloatDrift is the guard on the single
+// most expensive way to get this adapter wrong: Cashfree takes a rupee decimal
+// on the wire, and rendering it through a float64 silently corrupts the amount.
+func TestCashfreeAmount_RendersRupeesWithoutFloatDrift(t *testing.T) {
+	cases := []struct {
+		minor int64
+		want  string
+	}{
+		{14025, "140.25"},
+		{100, "1.00"},
+		{5, "0.05"},
+		{0, "0.00"},
+		{99999999, "999999.99"},
+		{-105, "-1.05"},
+	}
+	for _, tc := range cases {
+		got, err := json.Marshal(cashfreeAmount(tc.minor))
+		if err != nil {
+			t.Fatalf("marshal %d: %v", tc.minor, err)
+		}
+		if string(got) != tc.want {
+			t.Fatalf("cashfreeAmount(%d) marshalled to %s, want %s", tc.minor, got, tc.want)
+		}
+	}
+}
+
+// TestCashfreeAmount_RoundTripsThroughUnmarshal asserts a value read back from
+// Cashfree compares equal to the value we sent — both as a bare number and as
+// the stringified form some Cashfree fields use.
+func TestCashfreeAmount_RoundTripsThroughUnmarshal(t *testing.T) {
+	for _, raw := range []string{`140.25`, `"140.25"`, `140.250`} {
+		var a cashfreeAmount
+		if err := json.Unmarshal([]byte(raw), &a); err != nil {
+			t.Fatalf("unmarshal %s: %v", raw, err)
+		}
+		if a != 14025 {
+			t.Fatalf("unmarshal %s = %d paise, want 14025", raw, a)
+		}
+		if got := a.Decimal().String(); got != "140.25" {
+			t.Fatalf("Decimal() of %s = %s, want 140.25", raw, got)
+		}
+	}
+}
+
+// TestCashfreeCreateIntent_SendsRupeeAmountAndReturnsSession covers the happy
+// path: the wire body carries rupees (not paise) and the client token is the
+// payment_session_id the storefront SDK needs.
+func TestCashfreeCreateIntent_SendsRupeeAmountAndReturnsSession(t *testing.T) {
+	var body []byte
+	var gotHeaders http.Header
+	g, _ := newTestCashfree(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ = io.ReadAll(r.Body)
+		gotHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"cf_order_id":9911,"order_id":"ord-1","payment_session_id":"session_abc","order_status":"ACTIVE","order_amount":140.25,"order_currency":"INR"}`))
+	})
+
+	intent, err := g.CreateIntent(context.Background(), CreateIntentInput{
+		OrderID:       "ord-1",
+		Amount:        decimal.RequireFromString("140.25"),
+		CurrencyCode:  "INR",
+		CustomerEmail: "buyer@example.com",
+		CustomerPhone: "9876543210",
+	})
+	if err != nil {
+		t.Fatalf("create intent: %v", err)
+	}
+
+	if !strings.Contains(string(body), `"order_amount":140.25`) {
+		t.Fatalf("body must carry rupees, not paise: %s", body)
+	}
+	if !strings.Contains(string(body), `"customer_phone":"9876543210"`) {
+		t.Fatalf("body missing customer_phone: %s", body)
+	}
+	if gotHeaders.Get("x-client-id") != "app_id" || gotHeaders.Get("x-client-secret") != "secret" {
+		t.Fatalf("auth headers not set: %v", gotHeaders)
+	}
+	if gotHeaders.Get("x-api-version") != cashfreeAPIVersion {
+		t.Fatalf("x-api-version = %q, want %q", gotHeaders.Get("x-api-version"), cashfreeAPIVersion)
+	}
+	if intent.ClientToken != "session_abc" {
+		t.Fatalf("ClientToken = %q, want session_abc", intent.ClientToken)
+	}
+	// The refund path reconstructs the Cashfree order from this value, so it
+	// must be the merchant order_id, never cf_order_id.
+	if intent.ProviderIntentID != "ord-1" {
+		t.Fatalf("ProviderIntentID = %q, want ord-1 (the merchant order id)", intent.ProviderIntentID)
+	}
+	if intent.Status != "pending" {
+		t.Fatalf("Status = %q, want pending", intent.Status)
+	}
+}
+
+// TestCashfreeCreateIntent_RequiresPhone asserts the mandatory-field check
+// fires before any HTTP call, so a missing phone reads as a named field rather
+// than an opaque gateway 400.
+func TestCashfreeCreateIntent_RequiresPhone(t *testing.T) {
+	g, _ := newTestCashfree(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("gateway must not be called when customer_phone is missing")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	_, err := g.CreateIntent(context.Background(), CreateIntentInput{
+		OrderID:      "ord-1",
+		Amount:       decimal.NewFromInt(100),
+		CurrencyCode: "INR",
+	})
+	if err == nil || !strings.Contains(err.Error(), "customer_phone") {
+		t.Fatalf("err = %v, want a customer_phone validation error", err)
+	}
+}
+
+// TestCashfreeCreateIntent_RejectsNonINR guards the wire format: Cashfree
+// settles only in INR, and silently sending a USD amount through the rupee
+// renderer would bill the wrong number.
+func TestCashfreeCreateIntent_RejectsNonINR(t *testing.T) {
+	g, _ := newTestCashfree(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("gateway must not be called for a non-INR currency")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	_, err := g.CreateIntent(context.Background(), CreateIntentInput{
+		OrderID:       "ord-1",
+		Amount:        decimal.NewFromInt(100),
+		CurrencyCode:  "USD",
+		CustomerPhone: "9876543210",
+	})
+	if err == nil || !strings.Contains(err.Error(), "INR only") {
+		t.Fatalf("err = %v, want an INR-only currency error", err)
+	}
+}
+
+// TestCashfreeCreateIntent_ReusesExistingOrderOn409 is the double-tap case: a
+// duplicate order_id must reuse the payable order rather than fail, otherwise a
+// retry strands an order the buyer can no longer pay.
+func TestCashfreeCreateIntent_ReusesExistingOrderOn409(t *testing.T) {
+	var fetched bool
+	g, _ := newTestCashfree(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"code":"order_already_exists","message":"order id already exists"}`))
+			return
+		}
+		fetched = true
+		if r.URL.Path != "/orders/ord-1" {
+			t.Errorf("fetch path = %q, want /orders/ord-1", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"order_id":"ord-1","payment_session_id":"session_existing","order_status":"ACTIVE","order_amount":140.25}`))
+	})
+
+	intent, err := g.CreateIntent(context.Background(), CreateIntentInput{
+		OrderID:       "ord-1",
+		Amount:        decimal.RequireFromString("140.25"),
+		CurrencyCode:  "INR",
+		CustomerPhone: "9876543210",
+	})
+	if err != nil {
+		t.Fatalf("409 must reuse the existing order, got error: %v", err)
+	}
+	if !fetched {
+		t.Fatal("expected a GET /orders/{id} after the 409")
+	}
+	if intent.ClientToken != "session_existing" {
+		t.Fatalf("ClientToken = %q, want session_existing", intent.ClientToken)
+	}
+}
+
+// TestCashfreeCreateIntent_RefusesUnpayableExistingOrder: a 409 on an order
+// that is already PAID or EXPIRED has no session to hand back, and returning an
+// empty token would leave the storefront opening a sheet that cannot work.
+func TestCashfreeCreateIntent_RefusesUnpayableExistingOrder(t *testing.T) {
+	g, _ := newTestCashfree(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"code":"order_already_exists"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"order_id":"ord-1","payment_session_id":"","order_status":"EXPIRED"}`))
+	})
+
+	_, err := g.CreateIntent(context.Background(), CreateIntentInput{
+		OrderID:       "ord-1",
+		Amount:        decimal.NewFromInt(100),
+		CurrencyCode:  "INR",
+		CustomerPhone: "9876543210",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not payable") {
+		t.Fatalf("err = %v, want a not-payable error", err)
+	}
+}
+
+// TestCashfreeRefund_IsOrderScopedWithDerivedRefundID covers the two things the
+// refund path must get right: the URL is order-scoped, and refund_id is a
+// deterministic, in-window digest of the caller's idempotency key.
+func TestCashfreeRefund_IsOrderScopedWithDerivedRefundID(t *testing.T) {
+	var gotPath, gotIdemHeader string
+	var body []byte
+	g, _ := newTestCashfree(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotIdemHeader = r.Header.Get(cashfreeHeaderIdempotency)
+		body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"cf_refund_id":77,"refund_id":"abc","order_id":"ord-9","refund_status":"SUCCESS","refund_amount":50.00}`))
+	})
+
+	// The coordinator's real key shape — already longer than Cashfree's 40-char
+	// refund_id window, which is why it must be digested rather than sent raw.
+	const key = "refund_11111111-1111-1111-1111-111111111111_cancel"
+
+	ref, err := g.RefundPayment(context.Background(), RefundInput{
+		ProviderPaymentID: "1234567890", // a cf_payment_id — deliberately NOT what the URL uses
+		OrderID:           "ord-9",
+		Amount:            decimal.NewFromInt(50),
+		CurrencyCode:      "INR",
+		Reason:            "cancelled",
+		IdempotencyKey:    key,
+	})
+	if err != nil {
+		t.Fatalf("refund: %v", err)
+	}
+
+	if gotPath != "/orders/ord-9/refunds" {
+		t.Fatalf("refund path = %q, want /orders/ord-9/refunds", gotPath)
+	}
+	wantRefundID := cashfreeRefundID(key)
+	if len(wantRefundID) != 32 {
+		t.Fatalf("derived refund_id length = %d, want 32 (Cashfree allows 3–40)", len(wantRefundID))
+	}
+	if !strings.Contains(string(body), fmt.Sprintf(`"refund_id":"%s"`, wantRefundID)) {
+		t.Fatalf("body missing derived refund_id %s: %s", wantRefundID, body)
+	}
+	if gotIdemHeader != wantRefundID {
+		t.Fatalf("idempotency header = %q, want %q", gotIdemHeader, wantRefundID)
+	}
+	if !strings.Contains(string(body), `"refund_amount":50.00`) {
+		t.Fatalf("refund amount must be rupees: %s", body)
+	}
+	if !strings.Contains(string(body), `"refund_note":"cancelled"`) {
+		t.Fatalf("reason not sent as refund_note: %s", body)
+	}
+	if ref.Status != "succeeded" {
+		t.Fatalf("Status = %q, want succeeded", ref.Status)
+	}
+	// Amount must come back in MAJOR units — the ledger is numeric(12,2).
+	if ref.Amount.String() != "50" {
+		t.Fatalf("Amount = %s, want 50", ref.Amount.String())
+	}
+}
+
+// TestCashfreeRefundID_IsDeterministic is the basis of the whole idempotency
+// guarantee: the same logical refund must derive the same refund_id on every
+// retry, or a retry becomes a second real refund.
+func TestCashfreeRefundID_IsDeterministic(t *testing.T) {
+	a := cashfreeRefundID("refund_ord9_cancel")
+	b := cashfreeRefundID("refund_ord9_cancel")
+	c := cashfreeRefundID("refund_ord9_return")
+	if a != b {
+		t.Fatalf("same key derived different refund ids: %s vs %s", a, b)
+	}
+	if a == c {
+		t.Fatal("different keys must derive different refund ids")
+	}
+	for _, r := range a {
+		if !strings.ContainsRune("0123456789abcdef", r) {
+			t.Fatalf("refund_id %q contains a character outside Cashfree's charset", a)
+		}
+	}
+}
+
+// TestCashfreeRefund_RequiresOrderID: Cashfree has no payment-scoped refund
+// route, so a missing OrderID must fail loudly rather than build a broken URL.
+func TestCashfreeRefund_RequiresOrderID(t *testing.T) {
+	g, _ := newTestCashfree(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("gateway must not be called without an order id")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	_, err := g.RefundPayment(context.Background(), RefundInput{
+		ProviderPaymentID: "1234567890",
+		Amount:            decimal.NewFromInt(50),
+		CurrencyCode:      "INR",
+		IdempotencyKey:    "refund_ord9_cancel",
+	})
+	if err == nil || !strings.Contains(err.Error(), "OrderID is required") {
+		t.Fatalf("err = %v, want an OrderID-required error", err)
+	}
+}
+
+// TestCashfreeRefund_DuplicateIsReadBackAsSuccess: a 409/422 replay means the
+// refund already exists. Reporting it as a failure would send the saga round
+// again — which is how a customer receives two refunds.
+func TestCashfreeRefund_DuplicateIsReadBackAsSuccess(t *testing.T) {
+	for _, status := range []int{http.StatusConflict, http.StatusUnprocessableEntity} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			g, _ := newTestCashfree(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					w.WriteHeader(status)
+					_, _ = w.Write([]byte(`{"code":"refund_already_exists","message":"duplicate refund_id"}`))
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"refund_id":"existing","order_id":"ord-9","refund_status":"SUCCESS","refund_amount":50.00}`))
+			})
+
+			ref, err := g.RefundPayment(context.Background(), RefundInput{
+				OrderID:        "ord-9",
+				Amount:         decimal.NewFromInt(50),
+				CurrencyCode:   "INR",
+				IdempotencyKey: "refund_ord9_cancel",
+			})
+			if err != nil {
+				t.Fatalf("duplicate refund must read back as success, got: %v", err)
+			}
+			if ref.ProviderRefundID != "existing" {
+				t.Fatalf("ProviderRefundID = %q, want existing", ref.ProviderRefundID)
+			}
+		})
+	}
+}
+
+// TestCashfreeRefund_4xxIsPermanentGatewayError asserts the refund saga can
+// classify a hopeless refund and stop re-driving it, and that the raw body
+// (which can echo submitted customer data) never leaks into the error.
+func TestCashfreeRefund_4xxIsPermanentGatewayError(t *testing.T) {
+	g, _ := newTestCashfree(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"code":"refund_amount_exceeded","message":"exceeds capturable","customer_phone":"9876543210"}`))
+	})
+
+	_, err := g.RefundPayment(context.Background(), RefundInput{
+		OrderID:        "ord-9",
+		Amount:         decimal.NewFromInt(50),
+		CurrencyCode:   "INR",
+		IdempotencyKey: "refund_ord9_cancel",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !IsPermanentGatewayError(err) {
+		t.Fatalf("400 must be classified permanent, got %v", err)
+	}
+	if strings.Contains(err.Error(), "9876543210") {
+		t.Fatalf("error must not carry echoed customer data: %v", err)
+	}
+}
+
+// TestCashfreeRefundStatus_OnHoldIsPending: ONHOLD money is still coming.
+// Calling it failed would make the sweeper re-issue a refund already in flight.
+func TestCashfreeRefundStatus_OnHoldIsPending(t *testing.T) {
+	cases := map[string]string{
+		"SUCCESS":   "succeeded",
+		"PENDING":   "pending",
+		"ONHOLD":    "pending",
+		"FAILED":    "failed",
+		"CANCELLED": "failed",
+	}
+	for in, want := range cases {
+		if got := normalizeCashfreeRefundStatus(in); got != want {
+			t.Fatalf("normalizeCashfreeRefundStatus(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestCashfreeVerifyWebhook_SignsTimestampAndBody is the signature-scheme
+// guard: Cashfree signs base64(HMAC(timestamp+body)), so a hex digest over the
+// body alone (the Razorpay scheme) must NOT verify.
+func TestCashfreeVerifyWebhook_SignsTimestampAndBody(t *testing.T) {
+	const secret = "secret"
+	payload := []byte(`{"type":"PAYMENT_SUCCESS_WEBHOOK","data":{"order":{"order_id":"11111111-1111-1111-1111-111111111111","order_amount":140.25,"order_currency":"INR"},"payment":{"cf_payment_id":5566778899,"payment_status":"SUCCESS","payment_amount":140.25,"payment_currency":"INR","payment_group":"upi"}}}`)
+
+	g := NewCashfreeGateway("app_id", secret, "test")
+
+	evt, err := g.VerifyWebhook(context.Background(), payload, signCashfree(t, secret, payload))
+	if err != nil {
+		t.Fatalf("verify webhook: %v", err)
+	}
+	if evt.EventType != "payment.succeeded" {
+		t.Fatalf("EventType = %q, want payment.succeeded", evt.EventType)
+	}
+	if evt.OrderID != "11111111-1111-1111-1111-111111111111" {
+		t.Fatalf("OrderID = %q", evt.OrderID)
+	}
+	if evt.ProviderPaymentID != "5566778899" {
+		t.Fatalf("ProviderPaymentID = %q, want 5566778899", evt.ProviderPaymentID)
+	}
+	if evt.PaymentMethod != "upi" {
+		t.Fatalf("PaymentMethod = %q, want upi", evt.PaymentMethod)
+	}
+	if evt.Amount.String() != "140.25" {
+		t.Fatalf("Amount = %s, want 140.25", evt.Amount.String())
+	}
+}
+
+// TestCashfreeVerifyWebhook_RejectsBadInput covers every way verification must
+// fail closed. A forged or malformed delivery can never produce an event.
+func TestCashfreeVerifyWebhook_RejectsBadInput(t *testing.T) {
+	const secret = "secret"
+	payload := []byte(`{"type":"PAYMENT_SUCCESS_WEBHOOK","data":{"payment":{"cf_payment_id":1}}}`)
+	g := NewCashfreeGateway("app_id", secret, "test")
+
+	staleTS := strconv.FormatInt(time.Now().Add(-2*cashfreeWebhookMaxSkew).Unix(), 10)
+	staleMac := hmac.New(sha256.New, []byte(secret))
+	staleMac.Write([]byte(staleTS))
+	staleMac.Write(payload)
+	stale := CashfreeWebhookSignature(staleTS, base64.StdEncoding.EncodeToString(staleMac.Sum(nil)))
+
+	cases := map[string]string{
+		"no separator":        "justasignature",
+		"empty timestamp":     ".sig",
+		"empty signature":     "1700000000.",
+		"unparseable stamp":   CashfreeWebhookSignature("not-a-number", "sig"),
+		"wrong signature":     CashfreeWebhookSignature(strconv.FormatInt(time.Now().Unix(), 10), "d3Jvbmc="),
+		"stale but authentic": stale,
+	}
+	for name, sig := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := g.VerifyWebhook(context.Background(), payload, sig); err == nil {
+				t.Fatal("expected verification to fail closed")
+			}
+		})
+	}
+}
+
+// TestCashfreeVerifyWebhook_UserDroppedIsAFailure: an abandoned sheet leaves
+// the order reserved, the same handling a hard decline gets.
+func TestCashfreeVerifyWebhook_UserDroppedIsAFailure(t *testing.T) {
+	const secret = "secret"
+	payload := []byte(`{"type":"PAYMENT_USER_DROPPED_WEBHOOK","data":{"order":{"order_id":"ord-1"},"payment":{"cf_payment_id":42,"payment_status":"USER_DROPPED"}}}`)
+	g := NewCashfreeGateway("app_id", secret, "test")
+
+	evt, err := g.VerifyWebhook(context.Background(), payload, signCashfree(t, secret, payload))
+	if err != nil {
+		t.Fatalf("verify webhook: %v", err)
+	}
+	if evt.EventType != "payment.failed" {
+		t.Fatalf("EventType = %q, want payment.failed", evt.EventType)
+	}
+}
+
+// TestCashfreeVerifyWebhook_RefundEventReadsRefundBlock: refund events carry
+// their ids under data.refund, not data.payment.
+func TestCashfreeVerifyWebhook_RefundEventReadsRefundBlock(t *testing.T) {
+	const secret = "secret"
+	payload := []byte(`{"type":"REFUND_STATUS_WEBHOOK","data":{"refund":{"cf_refund_id":11,"cf_payment_id":22,"refund_id":"rf_abc","order_id":"ord-7","refund_status":"SUCCESS","refund_amount":25.50}}}`)
+	g := NewCashfreeGateway("app_id", secret, "test")
+
+	evt, err := g.VerifyWebhook(context.Background(), payload, signCashfree(t, secret, payload))
+	if err != nil {
+		t.Fatalf("verify webhook: %v", err)
+	}
+	if evt.EventType != "refund.succeeded" {
+		t.Fatalf("EventType = %q, want refund.succeeded", evt.EventType)
+	}
+	if evt.OrderID != "ord-7" {
+		t.Fatalf("OrderID = %q, want ord-7", evt.OrderID)
+	}
+	if evt.ProviderEventID != "cfrefund_rf_abc" {
+		t.Fatalf("ProviderEventID = %q, want cfrefund_rf_abc", evt.ProviderEventID)
+	}
+	if evt.Amount.String() != "25.5" {
+		t.Fatalf("Amount = %s, want 25.5", evt.Amount.String())
+	}
+}
+
+// TestCashfreeFetchOrderPayment_SkipsFailedAttempts is the confirm path's core
+// guarantee: an order with a failed attempt ahead of the successful one must
+// still report the payment that actually took the money — and must never just
+// return payments[0].
+func TestCashfreeFetchOrderPayment_SkipsFailedAttempts(t *testing.T) {
+	g, _ := newTestCashfree(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/orders/ord-1/payments" {
+			t.Errorf("path = %q, want /orders/ord-1/payments", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[
+			{"cf_payment_id":1,"payment_status":"FAILED","payment_amount":140.25,"payment_currency":"INR","payment_group":"credit_card"},
+			{"cf_payment_id":2,"payment_status":"SUCCESS","payment_amount":140.25,"payment_currency":"INR","payment_group":"net_banking"}
+		]`))
+	})
+
+	got, err := g.FetchOrderPayment(context.Background(), "ord-1")
+	if err != nil {
+		t.Fatalf("fetch order payment: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected the captured payment, got nil")
+	}
+	if got.ProviderPaymentID != "2" {
+		t.Fatalf("ProviderPaymentID = %q, want 2 (the SUCCESS attempt)", got.ProviderPaymentID)
+	}
+	if got.Status != "payment.succeeded" {
+		t.Fatalf("Status = %q, want payment.succeeded", got.Status)
+	}
+	if got.PaymentMethod != "netbanking" {
+		t.Fatalf("PaymentMethod = %q, want netbanking", got.PaymentMethod)
+	}
+	if got.Amount.String() != "140.25" {
+		t.Fatalf("Amount = %s, want 140.25", got.Amount.String())
+	}
+}
+
+// TestCashfreeFetchOrderPayment_NoCaptureIsNotAnError: "the buyer has not paid
+// yet" is a normal poll outcome, and the confirm endpoint renders it as
+// pending rather than as a failure.
+func TestCashfreeFetchOrderPayment_NoCaptureIsNotAnError(t *testing.T) {
+	cases := map[string]http.HandlerFunc{
+		"only failed attempts": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"cf_payment_id":1,"payment_status":"USER_DROPPED"}]`))
+		},
+		"empty list": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		},
+		"404 no attempts yet": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"code":"order_not_found"}`))
+		},
+	}
+	for name, h := range cases {
+		t.Run(name, func(t *testing.T) {
+			g, _ := newTestCashfree(t, h)
+			got, err := g.FetchOrderPayment(context.Background(), "ord-1")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != nil {
+				t.Fatalf("expected nil (not paid), got %+v", got)
+			}
+		})
+	}
+}
+
+// TestCashfreeMethodLabel_MapsToSharedVocabulary keeps an admin screen reading
+// the same regardless of which gateway took the payment.
+func TestCashfreeMethodLabel_MapsToSharedVocabulary(t *testing.T) {
+	cases := map[string]string{
+		"upi":           "upi",
+		"credit_card":   "card",
+		"debit_card":    "card",
+		"cardless_emi":  "card",
+		"net_banking":   "netbanking",
+		"wallet":        "wallet",
+		"pay_later":     "paylater",
+		"SOMETHING_NEW": "something_new", // passes through, not bucketed
+	}
+	for group, want := range cases {
+		p := &cashfreePayment{PaymentGroup: group}
+		if got := p.methodLabel(); got != want {
+			t.Fatalf("methodLabel(%q) = %q, want %q", group, got, want)
+		}
+	}
+}
+
+// TestCashfreeGateway_ResolvesEnvironmentByHost: mode selects the HOST, so a
+// test-mode gateway physically cannot reach production.
+func TestCashfreeGateway_ResolvesEnvironmentByHost(t *testing.T) {
+	if got := NewCashfreeGateway("a", "b", "test").baseURL; got != cashfreeTestBaseURL {
+		t.Fatalf("test mode baseURL = %q, want %q", got, cashfreeTestBaseURL)
+	}
+	for _, mode := range []string{"live", ""} {
+		if got := NewCashfreeGateway("a", "b", mode).baseURL; got != cashfreeLiveBaseURL {
+			t.Fatalf("mode %q baseURL = %q, want %q", mode, got, cashfreeLiveBaseURL)
+		}
+	}
+}
+
+// TestNewGateway_ResolvesCashfree asserts the adapter is reachable through the
+// factory every money path goes through, and satisfies both interfaces.
+func TestNewGateway_ResolvesCashfree(t *testing.T) {
+	gw, err := NewGateway("cashfree", "app_id", "secret", "test")
+	if err != nil {
+		t.Fatalf("NewGateway(cashfree): %v", err)
+	}
+	if gw.ProviderName() != "cashfree" {
+		t.Fatalf("ProviderName = %q, want cashfree", gw.ProviderName())
+	}
+	if _, ok := gw.(OrderStatusGateway); !ok {
+		t.Fatal("Cashfree must implement OrderStatusGateway — the confirm endpoint depends on it")
+	}
+	// Cashfree is NOT a hosted-checkout provider: the storefront opens its SDK
+	// in-page. Implementing CheckoutGateway would silently reroute checkout
+	// down the redirect branch in createPaymentIntent.
+	if _, ok := gw.(CheckoutGateway); ok {
+		t.Fatal("Cashfree must not implement CheckoutGateway — checkout would take the hosted redirect path")
+	}
+}

--- a/services/marketplace-api/internal/payment/gateway.go
+++ b/services/marketplace-api/internal/payment/gateway.go
@@ -1,6 +1,6 @@
 // Package payment defines the payment gateway provider abstraction.
-// Concrete implementations (Stripe, Razorpay, PayPal) live in separate
-// files and are wired in P2.
+// Concrete implementations (Stripe, Razorpay, PayPal, Cashfree) live in
+// separate files and are wired in P2.
 package payment
 
 import (
@@ -30,6 +30,35 @@ type CheckoutGateway interface {
 	CreateCheckoutSession(ctx context.Context, in CreateCheckoutSessionInput) (*CheckoutSession, error)
 }
 
+// OrderStatusGateway is an optional capability interface for providers whose
+// client SDK returns no signed payment receipt. Razorpay Checkout hands the
+// browser an HMAC of order_id|payment_id that the server re-derives (see
+// handlers/storefront/payment_verify.go); Cashfree's SDK returns nothing
+// signed at all, so the only authority on "did this actually get paid" is the
+// provider itself. Polling here is a STRONGER gate than the Razorpay path, not
+// a weaker one — it never trusts a client-supplied value — but it means the
+// confirm flow has to ask the gateway rather than verify a signature.
+//
+// Not every provider implements this — use type assertion at call sites.
+type OrderStatusGateway interface {
+	// FetchOrderPayment returns the captured payment on a provider-side order,
+	// or (nil, nil) when the order exists but nothing has been captured yet.
+	// providerOrderID is the id CreateIntent submitted, which for order-scoped
+	// providers is our own order id (see RefundInput.OrderID).
+	FetchOrderPayment(ctx context.Context, providerOrderID string) (*OrderPayment, error)
+}
+
+// OrderPayment is a captured provider-side payment as reported by a status
+// poll. Status is already normalized to the same vocabulary WebhookEvent
+// uses, so a confirm handler and a webhook handler can share one code path.
+type OrderPayment struct {
+	ProviderPaymentID string
+	Status            string // "payment.succeeded" | "payment.failed" | "payment.pending"
+	PaymentMethod     string
+	Amount            decimal.Decimal
+	CurrencyCode      string
+}
+
 // CreateCheckoutSessionInput describes a hosted checkout session.
 type CreateCheckoutSessionInput struct {
 	ReferenceID   string // our internal id (e.g. gift card uuid) — passed as metadata
@@ -56,6 +85,12 @@ type CreateIntentInput struct {
 	Amount        decimal.Decimal
 	CurrencyCode  string
 	CustomerEmail string
+	// CustomerName and CustomerPhone are optional for Stripe/Razorpay/PayPal
+	// but customer_phone is MANDATORY at Cashfree — it is what UPI intent
+	// keys off, so a blank one fails order creation outright rather than
+	// degrading to a card-only checkout.
+	CustomerName  string
+	CustomerPhone string
 	Description   string
 	Metadata      map[string]string
 }
@@ -79,10 +114,17 @@ type Capture struct {
 // RefundInput describes a refund request.
 type RefundInput struct {
 	ProviderPaymentID string
-	Amount            decimal.Decimal
-	CurrencyCode      string
-	Reason            string
-	IdempotencyKey    string // provider idempotency key; retries with the same key never double-refund
+	// OrderID is OUR internal order id. Stripe, Razorpay and PayPal refund
+	// against ProviderPaymentID and ignore this field; Cashfree scopes refunds
+	// by order (POST /pg/orders/{order_id}/refunds) with no payment-level
+	// endpoint, so it needs the provider-side order id. The two always agree
+	// because Cashfree's CreateIntent submits this same value as its order_id
+	// — that is what makes a Cashfree refund resolvable from the ledger.
+	OrderID        string
+	Amount         decimal.Decimal
+	CurrencyCode   string
+	Reason         string
+	IdempotencyKey string // provider idempotency key; retries with the same key never double-refund
 }
 
 // Refund is the provider's response to a refund request.

--- a/services/marketplace-api/internal/payment/resolver.go
+++ b/services/marketplace-api/internal/payment/resolver.go
@@ -26,6 +26,8 @@ func NewGateway(provider, apiKey, secretKey, mode string) (Gateway, error) {
 		return NewStripeGateway(apiKey, secretKey, m), nil
 	case "razorpay":
 		return NewRazorpayGateway(apiKey, secretKey, m), nil
+	case "cashfree":
+		return NewCashfreeGateway(apiKey, secretKey, m), nil
 	case "paypal":
 		return NewPayPalGateway(apiKey, secretKey, m), nil
 	default:

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 98
+const ExpectedSchemaVersion uint = 99

--- a/services/marketplace-api/migrations/000099_supported_countries_cashfree.down.sql
+++ b/services/marketplace-api/migrations/000099_supported_countries_cashfree.down.sql
@@ -1,0 +1,12 @@
+-- 000099_supported_countries_cashfree.down.sql
+-- Remove Cashfree from India's payment provider allowlist.
+--
+-- Deliberately does NOT delete any payment_gateway_configs row a merchant
+-- saved for Cashfree. Dropping the allowlist entry is enough to stop new
+-- checkouts choosing it (the storefront filters its provider list through this
+-- array), and destroying stored credentials on a rollback would mean a
+-- re-apply requires every merchant to re-enter their keys. Orphaned rows are
+-- inert and are cleaned up by the merchant removing the provider in admin.
+UPDATE supported_countries
+   SET payment_providers = array_remove(payment_providers, 'cashfree')
+ WHERE country_code = 'IN';

--- a/services/marketplace-api/migrations/000099_supported_countries_cashfree.up.sql
+++ b/services/marketplace-api/migrations/000099_supported_countries_cashfree.up.sql
@@ -1,0 +1,26 @@
+-- 000099_supported_countries_cashfree.up.sql
+-- Offer Cashfree in India, as the PREFERRED gateway, with Razorpay and PayPal
+-- remaining selectable beneath it.
+--
+-- supported_countries.payment_providers is the allowlist that gates BOTH the
+-- admin write path (PUT /settings/payments/:provider rejects a provider the
+-- store's country does not list) and the storefront read path (the
+-- payment-methods endpoint only returns configured providers that appear
+-- here). Without this row change, a merchant cannot save Cashfree credentials
+-- at all and the adapter is unreachable.
+--
+-- ORDER IS MEANINGFUL. The payment-methods endpoint sorts its response by each
+-- provider's position in this array, and the storefront renders that order and
+-- pre-selects the first entry. So putting 'cashfree' at the head is what makes
+-- it the default choice at checkout; the others follow as radio options.
+-- (Before this change the endpoint had no ORDER BY at all and the picker order
+-- was whatever Postgres returned — see the sort added alongside this migration.)
+--
+-- Written to NORMALIZE rather than blindly prepend: array_remove strips any
+-- existing occurrence before array_prepend puts it at the head, and the guard
+-- skips rows already in the desired shape. That makes this idempotent on
+-- replay and self-healing if an earlier run appended the value at the tail.
+UPDATE supported_countries
+   SET payment_providers = array_prepend('cashfree', array_remove(payment_providers, 'cashfree'))
+ WHERE country_code = 'IN'
+   AND payment_providers[1] IS DISTINCT FROM 'cashfree';

--- a/services/marketplace-api/scripts/sql/cashfree-enable.sql
+++ b/services/marketplace-api/scripts/sql/cashfree-enable.sql
@@ -1,0 +1,174 @@
+-- cashfree-enable.sql — provision (or rotate) a store's Cashfree gateway config.
+--
+-- This is an OPERATIONAL script, deliberately NOT a migration: it writes tenant
+-- data and credentials, which must never live in a file CI replays against
+-- every environment. Migration 000099 handles the schema/seed half (adding
+-- 'cashfree' to India's payment_providers allowlist); this handles the
+-- per-merchant half.
+--
+-- The normal path is Admin → Settings → Payments, which stores credentials in
+-- GCP Secret Manager and writes a "gsm://" reference. Use this script only when
+-- the admin UI is not an option — seeding a UAT store, bootstrapping the first
+-- merchant, or recovering a config out-of-band.
+--
+--   SECURITY: the values written here land in the api_key_encrypted /
+--   secret_key_encrypted columns as PLAINTEXT. The application accepts that
+--   (carriersecrets.HybridStore.Get treats an unrecognised shape as a legacy
+--   plaintext value) and lazily rewraps the row to a gsm:// reference on the
+--   first read that touches it — see maybeRewrapRow in payment_methods.go and
+--   webhooks.go. Until that first read, the raw keys are readable in the
+--   database, in this file, and in your shell history. Prefer the admin UI,
+--   pass credentials via -v rather than editing this file, and rotate anything
+--   that leaks.
+--
+-- Usage:
+--   psql "$DATABASE_URL" \
+--     -v store_slug=acme \
+--     -v app_id='<Cashfree App ID>' \
+--     -v secret_key='<Cashfree Secret Key>' \
+--     -v webhook_secret='<optional dedicated webhook secret>' \
+--     -v mode=test \
+--     -v is_active=true \
+--     -f scripts/sql/cashfree-enable.sql
+--
+-- store_slug, app_id and secret_key are required. webhook_secret defaults to
+-- empty (Cashfree then signs with the secret key, which the app falls back to);
+-- mode defaults to 'test'; is_active defaults to true.
+--
+-- Safe to re-run: the write is an upsert on the (store_id, provider) unique
+-- constraint, so a second run rotates credentials rather than failing or
+-- creating a duplicate config.
+
+\set ON_ERROR_STOP on
+
+-- Optional variables get their defaults here. :{?name} tests whether a psql
+-- variable was supplied, so an omitted -v is a documented default rather than
+-- an "unrecognised value :'mode'" syntax error.
+\if :{?mode} \else \set mode 'test' \endif
+\if :{?is_active} \else \set is_active 'true' \endif
+\if :{?webhook_secret} \else \set webhook_secret '' \endif
+
+BEGIN;
+
+-- psql interpolates variables during lexing and does NOT substitute inside
+-- dollar-quoted strings, so the inputs are staged in a temp table the DO block
+-- below can read. That indirection is what lets the validation raise real
+-- exceptions with useful messages instead of failing on a silent zero-row
+-- INSERT ... SELECT when the slug does not exist.
+CREATE TEMP TABLE cashfree_input ON COMMIT DROP AS
+SELECT :'store_slug'::text     AS store_slug,
+       :'app_id'::text         AS app_id,
+       :'secret_key'::text     AS secret_key,
+       :'webhook_secret'::text AS webhook_secret,
+       :'mode'::text           AS mode,
+       :'is_active'::boolean   AS is_active;
+
+DO $$
+DECLARE
+    v_in      cashfree_input;
+    v_store   RECORD;
+    v_existed boolean;
+BEGIN
+    SELECT * INTO v_in FROM cashfree_input;
+
+    IF coalesce(btrim(v_in.store_slug), '') = '' THEN
+        RAISE EXCEPTION 'store_slug is required (-v store_slug=<slug>)';
+    END IF;
+    IF coalesce(btrim(v_in.app_id), '') = '' THEN
+        RAISE EXCEPTION 'app_id is required — Cashfree''s x-client-id (-v app_id=...)';
+    END IF;
+    IF coalesce(btrim(v_in.secret_key), '') = '' THEN
+        RAISE EXCEPTION 'secret_key is required — Cashfree''s x-client-secret (-v secret_key=...)';
+    END IF;
+
+    -- payment.NewGateway validates mode fail-closed and rejects anything that
+    -- is not live|test, so a typo here would make every checkout 503 at
+    -- gateway-init time. Catch it now instead.
+    IF v_in.mode NOT IN ('test', 'live') THEN
+        RAISE EXCEPTION 'mode must be test or live, got %', v_in.mode;
+    END IF;
+
+    SELECT id, tenant_id, country_code, currency_code, status
+      INTO v_store
+      FROM stores
+     WHERE slug = v_in.store_slug;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'no store with slug % — check the slug, or the database you are pointed at', v_in.store_slug;
+    END IF;
+
+    -- The admin write path validates the provider against this same allowlist
+    -- (settings.go containsProvider), and the storefront payment-methods
+    -- endpoint filters through it too. Without migration 000099 a config row
+    -- inserted here would be invisible at checkout and unmanageable in admin —
+    -- a config that looks present but can never take a payment.
+    IF NOT EXISTS (
+        SELECT 1 FROM supported_countries
+         WHERE country_code = v_store.country_code
+           AND 'cashfree' = ANY (payment_providers)
+    ) THEN
+        RAISE EXCEPTION
+            'cashfree is not in payment_providers for country % — apply migration 000099 before enabling it',
+            v_store.country_code;
+    END IF;
+
+    -- Cashfree settles INR only, and the adapter rejects a mismatched currency
+    -- outright rather than billing the wrong number. Advisory, not fatal: the
+    -- store's currency can be changed after the gateway is configured.
+    IF v_store.currency_code <> 'INR' THEN
+        RAISE WARNING
+            'store % is in % — Cashfree only settles INR, so every Cashfree payment on this store will be rejected',
+            v_in.store_slug, v_store.currency_code;
+    END IF;
+
+    SELECT EXISTS (
+        SELECT 1 FROM payment_gateway_configs
+         WHERE store_id = v_store.id AND provider = 'cashfree'
+    ) INTO v_existed;
+
+    INSERT INTO payment_gateway_configs (
+        tenant_id, store_id, provider,
+        api_key_encrypted, secret_key_encrypted, webhook_secret_encrypted,
+        mode, is_active
+    )
+    VALUES (
+        v_store.tenant_id, v_store.id, 'cashfree',
+        btrim(v_in.app_id), btrim(v_in.secret_key), nullif(btrim(v_in.webhook_secret), ''),
+        v_in.mode, v_in.is_active
+    )
+    ON CONFLICT (store_id, provider) DO UPDATE
+       SET api_key_encrypted    = EXCLUDED.api_key_encrypted,
+           secret_key_encrypted = EXCLUDED.secret_key_encrypted,
+           -- An omitted webhook_secret must not silently clear a secret the
+           -- merchant already configured in admin: only overwrite when a new
+           -- value was actually supplied.
+           webhook_secret_encrypted = coalesce(
+               EXCLUDED.webhook_secret_encrypted,
+               payment_gateway_configs.webhook_secret_encrypted
+           ),
+           mode       = EXCLUDED.mode,
+           is_active  = EXCLUDED.is_active,
+           updated_at = now();
+
+    RAISE NOTICE 'cashfree % for store % (tenant %, mode %, active %)',
+        CASE WHEN v_existed THEN 'config UPDATED' ELSE 'config CREATED' END,
+        v_in.store_slug, v_store.tenant_id, v_in.mode, v_in.is_active;
+    RAISE NOTICE 'next: point the Cashfree dashboard webhook at POST /api/v1/webhooks/%/cashfree', v_in.store_slug;
+END
+$$;
+
+COMMIT;
+
+-- Echo the resulting row with credentials masked, so a run is verifiable
+-- without printing secrets into a terminal or a CI log.
+SELECT s.slug           AS store,
+       c.provider,
+       c.mode,
+       c.is_active,
+       left(c.api_key_encrypted, 6) || '…' AS api_key_prefix,
+       c.secret_key_encrypted IS NOT NULL     AS has_secret_key,
+       c.webhook_secret_encrypted IS NOT NULL AS has_webhook_secret,
+       c.updated_at
+  FROM payment_gateway_configs c
+  JOIN stores s ON s.id = c.store_id
+ WHERE s.slug = :'store_slug'
+   AND c.provider = 'cashfree';

--- a/services/marketplace-api/scripts/sql/cashfree-verify.sql
+++ b/services/marketplace-api/scripts/sql/cashfree-verify.sql
@@ -1,0 +1,128 @@
+-- cashfree-verify.sql — read-only diagnostics for the Cashfree integration.
+--
+-- Answers "why isn't Cashfree showing up / taking payments" by walking the same
+-- chain the application walks, in order. Every query is a SELECT; this script
+-- never writes.
+--
+-- Usage:
+--   psql "$DATABASE_URL" -f scripts/sql/cashfree-verify.sql                 -- all stores
+--   psql "$DATABASE_URL" -v store_slug=acme -f scripts/sql/cashfree-verify.sql
+--
+-- With store_slug set, sections 2–5 narrow to that store.
+
+\set ON_ERROR_STOP on
+\if :{?store_slug} \else \set store_slug '' \endif
+
+\echo ''
+\echo '=== 1. Country allowlist — is cashfree permitted, and is it preferred? ==='
+\echo '    payment_providers order IS the preference order: position 1 is what'
+\echo '    the storefront pre-selects. Expect cashfree first for IN (migration 000099).'
+SELECT country_code,
+       payment_providers,
+       'cashfree' = ANY (payment_providers)            AS cashfree_allowed,
+       payment_providers[1] = 'cashfree'               AS cashfree_preferred,
+       array_position(payment_providers, 'cashfree')   AS cashfree_rank
+  FROM supported_countries
+ WHERE 'cashfree' = ANY (payment_providers)
+    OR country_code = 'IN'
+ ORDER BY country_code;
+
+\echo ''
+\echo '=== 2. Gateway configs — credentials present, active, and correctly wrapped? ==='
+\echo '    ref_kind: gsm=Secret Manager reference (good), aes/noop=legacy inline,'
+\echo '    plaintext=written by cashfree-enable.sql and not yet rewrapped.'
+SELECT s.slug                                  AS store,
+       s.country_code,
+       s.currency_code,
+       c.mode,
+       c.is_active,
+       CASE
+           WHEN c.api_key_encrypted LIKE 'gsm://%' THEN 'gsm'
+           WHEN c.api_key_encrypted LIKE 'aes:%'   THEN 'aes'
+           WHEN c.api_key_encrypted LIKE 'noop:%'  THEN 'noop'
+           ELSE 'plaintext'
+       END                                      AS ref_kind,
+       c.secret_key_encrypted IS NOT NULL       AS has_secret_key,
+       c.webhook_secret_encrypted IS NOT NULL   AS has_dedicated_webhook_secret,
+       c.updated_at
+  FROM payment_gateway_configs c
+  JOIN stores s ON s.id = c.store_id
+ WHERE c.provider = 'cashfree'
+   AND (:'store_slug' = '' OR s.slug = :'store_slug')
+ ORDER BY s.slug;
+
+\echo ''
+\echo '=== 3. Misconfiguration checks ==='
+\echo '    Each row below is a problem to fix. No rows = nothing detected.'
+SELECT s.slug AS store, issue
+  FROM payment_gateway_configs c
+  JOIN stores s ON s.id = c.store_id
+ CROSS JOIN LATERAL (
+     SELECT unnest(ARRAY[
+         CASE WHEN NOT c.is_active
+              THEN 'config exists but is_active=false — it will not appear at checkout' END,
+         CASE WHEN c.mode NOT IN ('test','live')
+              THEN 'mode ' || quote_literal(c.mode) || ' is invalid — payment.NewGateway fails closed on anything but live|test' END,
+         CASE WHEN coalesce(btrim(c.api_key_encrypted),'') = ''
+              THEN 'api_key_encrypted is empty — Cashfree will reject with 401' END,
+         CASE WHEN coalesce(btrim(c.secret_key_encrypted),'') = ''
+              THEN 'secret_key_encrypted is empty — Cashfree will reject with 401, and webhooks cannot be verified' END,
+         CASE WHEN s.currency_code <> 'INR'
+              THEN 'store currency is ' || s.currency_code || ' — Cashfree settles INR only and the adapter rejects the rest' END,
+         CASE WHEN NOT EXISTS (
+                  SELECT 1 FROM supported_countries sc
+                   WHERE sc.country_code = s.country_code
+                     AND 'cashfree' = ANY (sc.payment_providers))
+              THEN 'cashfree missing from payment_providers for ' || s.country_code || ' — apply migration 000099' END,
+         CASE WHEN c.tenant_id <> s.tenant_id
+              THEN 'tenant_id does not match the store''s tenant — row was inserted incorrectly' END
+     ]) AS issue
+ ) checks
+ WHERE c.provider = 'cashfree'
+   AND issue IS NOT NULL
+   AND (:'store_slug' = '' OR s.slug = :'store_slug')
+ ORDER BY s.slug, issue;
+
+\echo ''
+\echo '=== 4. Payment transactions — is money actually flowing? ==='
+\echo '    provider_intent_id holds the Cashfree order_id (= our order uuid);'
+\echo '    it is what the refund and confirm paths key off, so a captured row'
+\echo '    with it empty is unrefundable.'
+SELECT t.status,
+       count(*)                                                   AS transactions,
+       count(*) FILTER (WHERE coalesce(t.provider_intent_id,'') = '')  AS missing_intent_id,
+       count(*) FILTER (WHERE coalesce(t.provider_payment_id,'') = '') AS missing_payment_id,
+       min(t.created_at)                                          AS first_seen,
+       max(t.created_at)                                          AS last_seen
+  FROM payment_transactions t
+ WHERE t.provider = 'cashfree'
+   AND (:'store_slug' = '' OR t.store_id = (SELECT id FROM stores WHERE slug = :'store_slug'))
+ GROUP BY t.status
+ ORDER BY t.status;
+
+\echo ''
+\echo '=== 5. Refunds — any stuck or failed against Cashfree? ==='
+\echo '    Rows pending for a long time mean the saga sweeper is not clearing'
+\echo '    them; check REFUND_GATEWAY_ENABLED and the marketplace-api logs.'
+SELECT r.status,
+       count(*)          AS refunds,
+       sum(r.amount)     AS total_amount,
+       max(r.created_at) AS last_created
+  FROM refund_transactions r
+ WHERE r.provider = 'cashfree'
+ GROUP BY r.status
+ ORDER BY r.status;
+
+\echo ''
+\echo '=== 6. Webhook deliveries — is Cashfree reaching us? ==='
+\echo '    No rows means no verified delivery has ever landed: check that the'
+\echo '    dashboard webhook points at /api/v1/webhooks/{storeSlug}/cashfree'
+\echo '    and that the signing secret matches.'
+SELECT event_type,
+       count(*)          AS events,
+       max(created_at)   AS last_received
+  FROM webhook_events
+ WHERE provider = 'cashfree'
+ GROUP BY event_type
+ ORDER BY event_type;
+\echo ''


### PR DESCRIPTION
Adds Cashfree Payment Gateway as a second India gateway alongside Razorpay, behind the existing `payment.Gateway` abstraction so refunds, webhooks, the refund saga and admin gateway config all keep working through the generic paths.

Ported from the existing Home-Chef-App adapter (`apps/api/services/cashfree.go`) rather than re-derived, so wire behaviour is identical across products: `/pg` base URLs, `2023-08-01` API pin, 409-on-create reuse, 409/422-on-refund read-back, and the same idempotency digest.

## Four places the abstraction had to bend

All additive and inert for Stripe/Razorpay/PayPal:

| Difference | Handling |
|---|---|
| Refunds are **order-scoped** (no payment-level endpoint) | `RefundInput.OrderID`, populated at both coordinator call sites. `CreateIntent` submits our order id as the Cashfree `order_id`, so the refund target stays reconstructible from the ledger. |
| **No client-side signature** — the SDK returns nothing signed | New `OrderStatusGateway` capability + `POST /orders/:id/confirm-payment`, which polls the gateway instead of verifying a client value. Provider, order id and expected amount are read server-side, never from the request body. |
| Webhook signs **timestamp+body**, base64 | `CashfreeWebhookSignature()` packs both headers into the one string the interface takes (the precedent PayPal set), plus a 30-minute freshness bound. |
| `customer_phone` is **mandatory** | Threaded from the shipping address, which already enforces a valid 10-digit number for India. |

## Money-path correctness

- Amounts cross the wire as rupee decimals rendered by **integer arithmetic**, never `float64` — the difference between `140.25` and `140.25000000000001`.
- Refund `refund_id` is a deterministic sha256 digest truncated to Cashfree's 40-char window (the coordinator's own key is already too long to send raw), so a retry is the same refund.
- A duplicate 409/422 is read back as success, so a timeout-after-success retry cannot become a second real refund.
- Non-INR currency is rejected before any HTTP call rather than billed as rupees.
- Refund failures return a typed `GatewayError` so the saga can classify permanent vs transient; only the structured error envelope is surfaced, never the raw body (Cashfree echoes submitted customer data back in some validation errors).

## Cashfree as the preferred option

Migration `000098` puts `cashfree` at the head of India's `payment_providers`. That array is now authoritative for preference — the payment-methods endpoint had **no `ORDER BY`**, so picker order was previously whatever Postgres happened to return. `sortByPreference` fixes that, the storefront pre-selects the first entry and badges it *Recommended*, and the others remain selectable below.

## Verification

- Backend: `go build`, `go vet`, full `go test ./...` green. 32 new Cashfree adapter cases + 10 preference-ordering cases.
- Frontend: storefront `tsc` + 55 vitest tests green (the CSP guard test auto-discovered `sdk.cashfree.com`); admin and onboarding `tsc` green.
- SQL executed against a real Postgres, not just reviewed: all 98 migrations replayed from scratch, `000098` proven idempotent on repeat apply, reversible, and self-healing if an earlier run appended at the tail. Both operational scripts driven through their create/rotate paths and every guard.

## Notes

- `scripts/sql/cashfree-enable.sql` writes plaintext credentials that the app lazily rewraps to `gsm://` on first read; the header documents that and points at the admin UI as the normal path.
- Cashfree is disclosed as a sub-processor in the onboarding legal pages.
- `apps/storefront-mobile` is unchanged — it needs a native module for Cashfree, and its payment picker is separately already broken (it filters on an `enabled` field the API does not return).
- Gift-card purchase still requires `CheckoutGateway` (Stripe only); Cashfree behaves exactly as Razorpay does there.