### PR TITLE
fix(payments): keep Razorpay the default in India, Cashfree secondary

### DIFF
--- a/apps/storefront/app/checkout/page.tsx
+++ b/apps/storefront/app/checkout/page.tsx
@@ -248,11 +248,13 @@ export default function CheckoutPage() {
         setPaymentMethods(methods);
         // Pre-select the merchant's preferred gateway. The API returns methods
         // ordered by the country's payment_providers array, so methods[0] is
-        // the intended default (Cashfree in India) and the rest render beneath
-        // it as alternatives. Previously this only auto-selected when exactly
-        // one method existed, which left every multi-gateway store starting on
-        // "Choose a payment method" — an extra required click for the option we
-        // already know we want.
+        // the intended default (Razorpay in India) and the rest — Cashfree
+        // included — render beneath it as options the buyer can pick instead.
+        // Previously this only auto-selected when exactly one method existed,
+        // which left every multi-gateway store starting on "Choose a payment
+        // method" — an extra required click for the option we already know we
+        // want. Deliberately reads position rather than naming a provider, so
+        // changing the default stays a migration and not a deploy.
         if (methods.length > 0) setSelectedProvider(methods[0]!.provider);
       }
     });

--- a/docs/cashfree-webhook.md
+++ b/docs/cashfree-webhook.md
@@ -135,14 +135,21 @@ whose header documents the plaintext-until-first-read caveat.
 ### Prerequisite: the country allowlist
 
 `supported_countries.payment_providers` gates both the admin write path and the
-storefront read path. Migration `000099_supported_countries_cashfree` puts
-`cashfree` at the head of India's list. Without it, admin rejects the provider
-outright and the storefront never offers it — so a webhook configured first
-would arrive for a store that has no Cashfree config and be dropped.
+storefront read path. Migration `000099_supported_countries_cashfree` adds
+`cashfree` to India's list. Without it, admin rejects the provider outright and
+the storefront never offers it — so a webhook configured first would arrive for
+a store that has no Cashfree config and be dropped.
 
 Array **order is preference**: the payment-methods endpoint sorts its response
 by position (`sortByPreference`), and the storefront pre-selects the first entry
-and badges it *Recommended*. `cashfree` first is what makes it the default.
+and badges it *Recommended*.
+
+**Razorpay is the default in India, not Cashfree.** 000099 originally promoted
+Cashfree to the head; `000100_razorpay_preferred_in_india` reversed that, so the
+live order is `{razorpay,paypal,cashfree}` — Cashfree is fully configured and
+selectable, it is simply not pre-selected. Buyers reach it by choosing it at
+checkout. Because the ordering is read from data rather than named in code,
+flipping the default back is a one-row migration, not a deploy.
 
 ## Signature verification
 

--- a/docs/testing-payments.md
+++ b/docs/testing-payments.md
@@ -86,8 +86,15 @@ block test-mode work.
 
 ### What to expect at checkout
 
-Cashfree is first in India's `payment_providers`, so on an IN store it is
-**pre-selected and badged "Recommended"**, with Razorpay and PayPal below it.
+**Razorpay is the default**, so on an IN store it is pre-selected and badged
+"Recommended", with PayPal and Cashfree below it as options. Cashfree is a
+deliberate choice the buyer makes — to test it you must **select the Cashfree
+radio** before placing the order. Forgetting that step is the likeliest reason a
+"Cashfree test" ends up going through Razorpay.
+
+If Cashfree does not appear in the list at all, it has no active gateway config
+for that store (see section 2 of `cashfree-verify.sql`) — the storefront only
+lists providers that are both allowlisted for the country and configured.
 
 The order confirms via a server-side status poll, not a client signature:
 Cashfree's SDK returns no signed receipt, so after the sheet closes the

--- a/services/marketplace-api/internal/handlers/storefront/payment_methods.go
+++ b/services/marketplace-api/internal/handlers/storefront/payment_methods.go
@@ -191,8 +191,10 @@ func (h *PaymentMethodsHandler) ListPaymentMethods(c *gin.Context) {
 // The gateway-config query has no ORDER BY, so without this the picker order was
 // whatever order Postgres happened to return rows in — stable enough to look
 // intentional in testing, and free to change under a plan flip or a row update.
-// Sorting here makes "Cashfree is preferred in India" a property of the seed
-// data (migration 000099) rather than an accident of row layout.
+// Sorting here makes "which gateway is the default in India" a property of the
+// seed data rather than an accident of row layout, which is what lets the
+// decision be reversed by a one-row migration: 000099 promoted Cashfree, 000100
+// put Razorpay back in front with Cashfree kept as a selectable option.
 func sortByPreference(methods []paymentMethodResponse, preference []string) {
 	rank := make(map[string]int, len(preference))
 	for i, p := range preference {

--- a/services/marketplace-api/internal/handlers/storefront/payment_methods_preference_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/payment_methods_preference_test.go
@@ -24,8 +24,8 @@ func methodList(providers ...string) []paymentMethodResponse {
 
 // TestSortByPreference_FirstAllowlistEntryWins is the guard on which gateway the
 // storefront pre-selects. The checkout page selects methods[0], so this
-// ordering — not the DB's row order — is what makes Cashfree the default in
-// India. A regression here silently sends INR checkouts to the wrong gateway.
+// ordering — not the DB's row order — is what decides the default gateway in
+// India. A regression here silently sends INR checkouts to the wrong one.
 func TestSortByPreference_FirstAllowlistEntryWins(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -34,28 +34,39 @@ func TestSortByPreference_FirstAllowlistEntryWins(t *testing.T) {
 		want       string
 	}{
 		{
-			name:       "india post-000099 — cashfree preferred",
+			// India's live seed after 000100: Razorpay is the default and
+			// Cashfree is a selectable secondary option.
+			name:       "india post-000100 — razorpay preferred, cashfree selectable",
+			preference: []string{"razorpay", "paypal", "cashfree"},
+			methods:    methodList("cashfree", "paypal", "razorpay"),
+			want:       "razorpay,paypal,cashfree",
+		},
+		{
+			// The same function must honour the OPPOSITE seed (000099's order)
+			// with no code change. This is what makes the "which gateway is
+			// default" decision a one-row migration rather than a deploy.
+			name:       "a cashfree-first seed is honoured too — order is data, not code",
 			preference: []string{"cashfree", "razorpay", "paypal"},
 			methods:    methodList("paypal", "razorpay", "cashfree"),
 			want:       "cashfree,razorpay,paypal",
 		},
 		{
 			name:       "already in order stays put",
-			preference: []string{"cashfree", "razorpay", "paypal"},
-			methods:    methodList("cashfree", "razorpay", "paypal"),
-			want:       "cashfree,razorpay,paypal",
+			preference: []string{"razorpay", "paypal", "cashfree"},
+			methods:    methodList("razorpay", "paypal", "cashfree"),
+			want:       "razorpay,paypal,cashfree",
 		},
 		{
 			name:       "only some providers configured",
-			preference: []string{"cashfree", "razorpay", "paypal"},
-			methods:    methodList("paypal", "cashfree"),
-			want:       "cashfree,paypal",
+			preference: []string{"razorpay", "paypal", "cashfree"},
+			methods:    methodList("cashfree", "razorpay"),
+			want:       "razorpay,cashfree",
 		},
 		{
-			name:       "a store with no cashfree config still prefers razorpay over paypal",
-			preference: []string{"cashfree", "razorpay", "paypal"},
-			methods:    methodList("paypal", "razorpay"),
-			want:       "razorpay,paypal",
+			name:       "a store with no razorpay config falls to paypal, not cashfree",
+			preference: []string{"razorpay", "paypal", "cashfree"},
+			methods:    methodList("cashfree", "paypal"),
+			want:       "paypal,cashfree",
 		},
 		{
 			name:       "unrelated country order is honoured, not hardcoded",

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 99
+const ExpectedSchemaVersion uint = 100

--- a/services/marketplace-api/migrations/000100_razorpay_preferred_in_india.down.sql
+++ b/services/marketplace-api/migrations/000100_razorpay_preferred_in_india.down.sql
@@ -1,0 +1,14 @@
+-- 000100_razorpay_preferred_in_india.down.sql
+-- Restore migration 000099's ordering: Cashfree back at the head of India's
+-- payment_providers, making it the default at checkout again.
+--
+-- Rolling back to 99 must land in 99's state, not in 98's — so this promotes
+-- Cashfree rather than removing it. Removing it here would leave the database
+-- at "99 applied" while the row looks like 98, and a subsequent re-apply of
+-- 000100 would then silently produce a different result.
+--
+-- Same remove-then-prepend normalization as the up migration, so it is
+-- idempotent and independent of the current position.
+UPDATE supported_countries
+   SET payment_providers = array_prepend('cashfree', array_remove(payment_providers, 'cashfree'))
+ WHERE country_code = 'IN';

--- a/services/marketplace-api/migrations/000100_razorpay_preferred_in_india.up.sql
+++ b/services/marketplace-api/migrations/000100_razorpay_preferred_in_india.up.sql
@@ -1,0 +1,33 @@
+-- 000100_razorpay_preferred_in_india.up.sql
+-- Make Razorpay the preferred India gateway again, with Cashfree kept as a
+-- selectable secondary option.
+--
+-- Migration 000099 put 'cashfree' at the head of India's payment_providers,
+-- which made it the default at checkout. That is being reversed as a business
+-- decision: existing kitchens settle through Razorpay, so it stays the default
+-- and Cashfree becomes an option the buyer picks deliberately.
+--
+-- This is a NEW migration rather than an edit to 000099 because 000099 has
+-- already been applied in production. `migrate up` only runs versions the
+-- database has not seen, so editing it in place would change nothing on any
+-- environment that is already at 99 — and would silently diverge a fresh
+-- environment from a migrated one.
+--
+-- ORDER IS MEANINGFUL. The payment-methods endpoint sorts its response by each
+-- provider's position in this array (sortByPreference), and the storefront
+-- pre-selects the first entry and badges it "Recommended". So position 1 is the
+-- whole mechanism: Cashfree stays fully configured and selectable, it just
+-- stops being the default.
+--
+-- Written to NORMALIZE rather than assume a starting shape: strip 'cashfree'
+-- wherever it currently sits, then re-append it. remove-then-append is
+-- idempotent by construction, so no ordering guard is needed — and a guard on
+-- "is razorpay already first" would be actively wrong, because it would accept
+-- {razorpay,cashfree,paypal} and leave PayPal demoted below Cashfree.
+--
+-- Correct from any starting state: 99's {cashfree,razorpay,paypal}, a
+-- rolled-back 98's {razorpay,paypal} (Cashfree is re-added, which is what this
+-- migration wants), or an already-correct row.
+UPDATE supported_countries
+   SET payment_providers = array_append(array_remove(payment_providers, 'cashfree'), 'cashfree')
+ WHERE country_code = 'IN';

--- a/services/marketplace-api/scripts/sql/cashfree-verify.sql
+++ b/services/marketplace-api/scripts/sql/cashfree-verify.sql
@@ -14,14 +14,15 @@
 \if :{?store_slug} \else \set store_slug '' \endif
 
 \echo ''
-\echo '=== 1. Country allowlist — is cashfree permitted, and is it preferred? ==='
+\echo '=== 1. Country allowlist — is cashfree permitted, and where does it rank? ==='
 \echo '    payment_providers order IS the preference order: position 1 is what'
-\echo '    the storefront pre-selects. Expect cashfree first for IN (migration 000099).'
+\echo '    the storefront pre-selects. For IN expect razorpay first and cashfree'
+\echo '    present as a selectable secondary option (migration 000100).'
 SELECT country_code,
        payment_providers,
-       'cashfree' = ANY (payment_providers)            AS cashfree_allowed,
-       payment_providers[1] = 'cashfree'               AS cashfree_preferred,
-       array_position(payment_providers, 'cashfree')   AS cashfree_rank
+       'cashfree' = ANY (payment_providers)          AS cashfree_allowed,
+       payment_providers[1]                          AS default_provider,
+       array_position(payment_providers, 'cashfree') AS cashfree_rank
   FROM supported_countries
  WHERE 'cashfree' = ANY (payment_providers)
     OR country_code = 'IN'


### PR DESCRIPTION
Reverses the preference `000099` introduced. Existing kitchens settle through Razorpay, so it stays pre-selected at checkout and Cashfree becomes an option the buyer picks deliberately.

Cashfree remains **fully wired** — allowlisted, configurable in admin, listed in the picker, and able to take payments and refunds. It is simply no longer the default.

## Why a new migration

`000099` is already applied in production. `migrate up` only runs versions the database has not seen, so editing it in place would change nothing on a migrated environment while silently diverging a fresh one.

`000100` normalizes rather than assuming a starting shape — remove `cashfree` wherever it sits, then re-append. That is idempotent by construction and needs no ordering guard. A guard on "is razorpay already first" would actually be **wrong**: it would accept `{razorpay,cashfree,paypal}` and leave PayPal demoted below Cashfree.

Verified against a real Postgres from every reachable state:

| State | Result |
|---|---|
| 99 upgrade path `{cashfree,razorpay,paypal}` | → `{razorpay,paypal,cashfree}` |
| Replayed 3× | unchanged |
| `down` | → `{cashfree,razorpay,paypal}` — 99's state, not 98's, so re-apply is deterministic |
| `down` 2× | unchanged |
| Rolled back to 98 `{razorpay,paypal}` | → correct (Cashfree re-added) |
| Cashfree stranded mid-array | → normalized correctly |

Also replayed all 100 migrations from scratch: 0 failures, `{razorpay,paypal,cashfree}`.

## No behavioural code changed

Ordering is read from `supported_countries.payment_providers`, which is what makes flipping the default a one-row migration rather than a deploy. `sortByPreference` and the storefront's `methods[0]` pre-select both read position and name no provider.

The preference tests now assert India's live order, plus a case proving the *opposite* seed is honoured by the same code — so this stays reversible either way.

Docs updated to state Razorpay is the default, and that testing Cashfree means selecting its radio first. Forgetting that is the likeliest way a "Cashfree test" silently goes through Razorpay.