### PR TITLE
ci: fix three workflows that never ran, and clear the actionlint backlog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,10 @@ jobs:
           FP=$(printf '%s' "$KEY" | sha256sum | cut -c1-12)
           # sha256("") — means the repo secret is unset or empty.
           if [ "$FP" = "e3b0c44298fc" ]; then
+            # shellcheck disable=SC2028  # the \n is literal text in the remedy
+            # command we are telling the operator to run, so echo NOT expanding
+            # it is the desired behaviour — printf here would emit a real
+            # newline and corrupt the instruction.
             echo "::error::NEXT_SERVER_ACTIONS_ENCRYPTION_KEY is empty or unset. Set it with: openssl rand -base64 32 | tr -d '\n' | gh secret set NEXT_SERVER_ACTIONS_ENCRYPTION_KEY --repo tesserix/mark8ly"
             exit 1
           fi

--- a/.github/workflows/dashboard-validation.yml
+++ b/.github/workflows/dashboard-validation.yml
@@ -24,6 +24,11 @@ on:
 
 permissions:
   contents: read
+  # Required by reusable-security.yml, which declares `packages: read` for its
+  # @tesserix/* install. A caller cannot grant a reusable workflow more than it
+  # holds itself, so omitting this fails the whole run at STARTUP — before any
+  # job executes and with no log to read.
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,6 +41,10 @@ jobs:
   # workflow-specific path filter skipped the main CI build.
   security:
     uses: ./.github/workflows/reusable-security.yml
+    # Reusable workflows need explicit secret forwarding — GITHUB_TOKEN passes
+    # automatically but org PATs like GHCR_PAT do not, and npm-audit's install
+    # authenticates to GitHub Packages with it.
+    secrets: inherit
 
   validate:
     name: Validate dashboards

--- a/.github/workflows/logging-smoke.yml
+++ b/.github/workflows/logging-smoke.yml
@@ -20,6 +20,12 @@ on:
 
 permissions:
   contents: read
+  # Required by reusable-security.yml, which declares `packages: read` for its
+  # @tesserix/* install. A caller cannot grant a reusable workflow more than it
+  # holds itself, so omitting this fails the whole run at STARTUP — before any
+  # job executes and with no log to read. That is why this guard silently never
+  # ran despite appearing in the checks list.
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,6 +38,10 @@ jobs:
   # workflow-specific path filter skipped the main CI build.
   security:
     uses: ./.github/workflows/reusable-security.yml
+    # Reusable workflows need explicit secret forwarding — GITHUB_TOKEN passes
+    # automatically but org PATs like GHCR_PAT do not, and npm-audit's install
+    # authenticates to GitHub Packages with it.
+    secrets: inherit
 
   logging-smoke:
     name: Log-shipping smoke guard

--- a/.github/workflows/pii-leak-guard.yml
+++ b/.github/workflows/pii-leak-guard.yml
@@ -15,6 +15,12 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  # Required by reusable-security.yml, which declares `packages: read` for its
+  # @tesserix/* install. A caller cannot grant a reusable workflow more than it
+  # holds itself, so omitting this fails the whole run at STARTUP — before any
+  # job executes and with no log to read. That is why this guard silently never
+  # ran despite appearing in the checks list.
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,6 +33,10 @@ jobs:
   # workflow-specific path filter skipped the main CI build.
   security:
     uses: ./.github/workflows/reusable-security.yml
+    # Reusable workflows need explicit secret forwarding — GITHUB_TOKEN passes
+    # automatically but org PATs like GHCR_PAT do not, and npm-audit's install
+    # authenticates to GitHub Packages with it.
+    secrets: inherit
 
   pii-grep:
     name: Grep added log lines for PII fields


### PR DESCRIPTION
`logging-smoke`, `pii-leak-guard` and `dashboard-validation` have been failing at **startup** on every trigger — the first two on every push and PR, `dashboard-validation` since 17 July.

Because the failure happens before any job is created, they produce **no logs** while still appearing in the checks list. Three guards have looked green-ish while enforcing nothing; the PII guard in particular has been decorative on every PR it was meant to gate.

## Cause

Each calls `reusable-security.yml`, which declares `packages: read` for its `@tesserix/*` install. A caller cannot grant a reusable workflow more permission than it holds itself, so any caller whose `permissions:` block omits `packages` fails the entire run immediately.

`ci.yml` is the only caller that already declared `packages` (`write`, for image push) — which is exactly why it alone works.

| Workflow | calls reusable-security | had `packages` | result |
|---|---|---|---|
| `ci.yml` | yes | **yes** (write) | ✅ runs |
| `logging-smoke.yml` | yes | no | ❌ startup_failure |
| `pii-leak-guard.yml` | yes | no | ❌ startup_failure |
| `dashboard-validation.yml` | yes | no | ❌ startup_failure |
| `mobile-admin-build.yml` | no | — | not affected |
| `base-image-refresh.yml` | no | — | not affected |

3/3 of the failing workflows fit; both non-callers don't. 

Each also gains `secrets: inherit`, matching `ci.yml` — without it `npm-audit`'s install cannot authenticate `GHCR_PAT` to GitHub Packages, so the fix would have traded a startup failure for a runtime one.

## actionlint

Also silences the single remaining finding (SC2028 in `ci.yml`) with a disable **and a reason**, not a rewrite: the `\n` is literal text inside the remedy command printed for the operator, so `echo` not expanding it is the correct behaviour — `printf` would emit a real newline and corrupt the instruction. `actionlint` is now clean across all eight workflows, so the next genuine finding won't be buried.

## Deliberately not "fixed"

- **`mobile-admin-build`** failed on *"recent account payments have failed or your spending limit needs to be increased"* — a GitHub billing condition, not a workflow defect.
- **`base-image-refresh`** has never run because it is `repository_dispatch`/`workflow_dispatch` only. Expected.

## Verification

This PR edits `.github/workflows/dashboard-validation.yml`, which is in that workflow's own `pull_request` path filter — so it triggers here and gives a live proof the startup failure is gone.