### PR TITLE
fix: correct false product claims and add homepage structured data

### DIFF
--- a/apps/admin/app/login/page.tsx
+++ b/apps/admin/app/login/page.tsx
@@ -39,7 +39,7 @@ export default async function LoginPage({ searchParams }: PageProps) {
               merchant decides to trust the platform, and the entity on their
               settlement statement should not be a surprise later. */}
           <p className="mt-10 text-center text-xs leading-relaxed text-muted-foreground">
-            Powered by Zivana Innovations LLP, part of Tesserix Pty Ltd
+            Tesserix Pty Ltd
             <br />
             ACN 694 070 865 · ABN 59 694 070 865
           </p>

--- a/apps/onboarding/app/about/page.tsx
+++ b/apps/onboarding/app/about/page.tsx
@@ -10,7 +10,7 @@ export const metadata = {
   openGraph: {
     title: "About · Mark8ly",
     description:
-      "Built for people who make things. A small team, three commitments, Mumbai.",
+      "Built for people who make things. A small team, three commitments, Australia.",
     url: "/about",
   },
 };
@@ -102,7 +102,7 @@ export default function AboutPage() {
           </div>
           <div className="space-y-6 text-foreground-secondary leading-relaxed lg:max-w-xl">
             <p>
-              Mumbai, India. Remote-first, global by default. We build and
+              Australia. Remote-first, global by default. We build and
               support Mark8ly from a small distributed team of engineers,
               designers, and merchants.
             </p>

--- a/apps/onboarding/app/about/page.tsx
+++ b/apps/onboarding/app/about/page.tsx
@@ -44,8 +44,8 @@ export default function AboutPage() {
             </p>
             <p>
               Mark8ly is the opposite. The storefront looks like something a
-              studio made. The admin only shows what you need. Six months are
-              free. After that the price is one honest number.
+              studio made. The admin only shows what you need. The first ninety
+              days are free. After that the price is one honest number.
             </p>
             <p>
               We&rsquo;re not trying to be the biggest platform. We&rsquo;re

--- a/apps/onboarding/app/acceptable-use/page.tsx
+++ b/apps/onboarding/app/acceptable-use/page.tsx
@@ -96,8 +96,7 @@ export default function AcceptableUsePage() {
         <p>
           Mark8ly is a product of <strong>Tesserix Pty Ltd</strong> (ACN 694
           070 865, ABN 59 694 070 865), registered in New South Wales,
-          Australia. Operations are conducted from Mumbai, India and Sydney,
-          Australia.
+          Australia. Operations are conducted from Sydney, Australia.
         </p>
       </Prose>
     </MarketingPage>

--- a/apps/onboarding/app/contact/page.tsx
+++ b/apps/onboarding/app/contact/page.tsx
@@ -62,7 +62,7 @@ export default function ContactPage() {
           </div>
           <div className="space-y-6 text-foreground-secondary leading-relaxed lg:max-w-xl">
             <p>
-              Mumbai, India. We work remote-first across a small distributed
+              Australia. We work remote-first across a small distributed
               team, which means there is almost always someone awake when you
               write to us.
             </p>

--- a/apps/onboarding/app/ecommerce-for-makers/page.tsx
+++ b/apps/onboarding/app/ecommerce-for-makers/page.tsx
@@ -30,7 +30,7 @@ export default function EcommerceForMakersPage() {
       intro={[
         "Most ecommerce platforms are built for catalogues, not craft. They optimise for thousands of SKUs, bulk imports, and dashboards full of metrics — which is exactly wrong for a maker with forty carefully-made products and a story behind each one. What you need is a shop that treats each item like it matters, not a spreadsheet with a checkout bolted on.",
         "Mark8ly is built the other way round. The default storefront is editorial: quiet typography, generous whitespace, and product pages that give a single object room to breathe. It's the kind of layout you'd normally hire a designer for — because we did, working alongside real merchants who sell the things they make.",
-        "And because makers usually run on thin margins, we don't take a cut. There's no platform fee on your sales — you pay only your payment processor's standard rate. Ninety days free to start, then plans from $29 a month, with a Starter tier that caps at 100 products for people opening their first shop.",
+        "And because makers usually run on thin margins, we don't take a cut. There's no platform fee on your sales — you pay only your payment processor's standard rate. Ninety days free to start, then plans from $19 a month, with a Starter tier that caps at 100 products for people opening their first shop.",
       ]}
       competitorName="Generic platforms"
       comparisonNote="Most mainstream platforms are tuned for high-SKU catalogues and add fees or design costs that hit small makers hardest."
@@ -94,7 +94,7 @@ export default function EcommerceForMakersPage() {
         {
           question: "How much does it cost to sell handmade goods here?",
           answer:
-            "There's no platform fee on your sales. You pay only your payment processor's standard rate. Plans start at $29 a month after 90 days free, with a Starter tier for first-time shops.",
+            "There's no platform fee on your sales. You pay only your payment processor's standard rate. Plans start at $19 a month after 90 days free, with a Starter tier for first-time shops.",
         },
         {
           question: "How many products can I list?",

--- a/apps/onboarding/app/ecommerce-for-makers/page.tsx
+++ b/apps/onboarding/app/ecommerce-for-makers/page.tsx
@@ -30,7 +30,7 @@ export default function EcommerceForMakersPage() {
       intro={[
         "Most ecommerce platforms are built for catalogues, not craft. They optimise for thousands of SKUs, bulk imports, and dashboards full of metrics — which is exactly wrong for a maker with forty carefully-made products and a story behind each one. What you need is a shop that treats each item like it matters, not a spreadsheet with a checkout bolted on.",
         "Mark8ly is built the other way round. The default storefront is editorial: quiet typography, generous whitespace, and product pages that give a single object room to breathe. It's the kind of layout you'd normally hire a designer for — because we did, working alongside real merchants who sell the things they make.",
-        "And because makers usually run on thin margins, we don't take a cut. There's no platform fee on your sales — you pay only your payment processor's standard rate. Ninety days free to start, then plans from $15 a month billed yearly, with a Starter tier that caps at 100 products for people opening their first shop.",
+        "And because makers usually run on thin margins, we don't take a cut. There's no platform fee on your sales — you pay only your payment processor's standard rate. Ninety days free to start, then plans from $15 a month billed yearly, with unlimited products on every tier — including the Starter plan people open their first shop on.",
       ]}
       competitorName="Generic platforms"
       comparisonNote="Most mainstream platforms are tuned for high-SKU catalogues and add fees or design costs that hit small makers hardest."
@@ -74,7 +74,7 @@ export default function EcommerceForMakersPage() {
           heading: "Margins that survive the sale",
           body: [
             "When you make things by hand, every percentage point matters. Mark8ly adds nothing to your sales — no platform fee, no per-order surcharge. Your processor takes their standard rate (about 2% for UPI, 2–3% for cards) and that's it.",
-            "The Starter plan is priced for a first shop and caps at 100 products, which is plenty for a considered range. When you outgrow it, Studio and Pro are unlimited — add as many products, photos, and variants as you like.",
+            "The Starter plan is priced for a first shop and still carries unlimited products and orders — list a considered range or a deep archive, it costs the same. What you gain further up is more storefronts, more images per product, and deeper API access.",
           ],
         },
         {
@@ -99,7 +99,7 @@ export default function EcommerceForMakersPage() {
         {
           question: "How many products can I list?",
           answer:
-            "Starter caps at 100 products, which suits most makers opening their first shop. Studio and Pro are unlimited.",
+            "As many as you like — products and orders are unlimited on every plan, Starter included.",
         },
         {
           question: "Do I need to be technical?",

--- a/apps/onboarding/app/ecommerce-for-makers/page.tsx
+++ b/apps/onboarding/app/ecommerce-for-makers/page.tsx
@@ -30,7 +30,7 @@ export default function EcommerceForMakersPage() {
       intro={[
         "Most ecommerce platforms are built for catalogues, not craft. They optimise for thousands of SKUs, bulk imports, and dashboards full of metrics — which is exactly wrong for a maker with forty carefully-made products and a story behind each one. What you need is a shop that treats each item like it matters, not a spreadsheet with a checkout bolted on.",
         "Mark8ly is built the other way round. The default storefront is editorial: quiet typography, generous whitespace, and product pages that give a single object room to breathe. It's the kind of layout you'd normally hire a designer for — because we did, working alongside real merchants who sell the things they make.",
-        "And because makers usually run on thin margins, we don't take a cut. There's no platform fee on your sales — you pay only your payment processor's standard rate. Ninety days free to start, then plans from $19 a month, with a Starter tier that caps at 100 products for people opening their first shop.",
+        "And because makers usually run on thin margins, we don't take a cut. There's no platform fee on your sales — you pay only your payment processor's standard rate. Ninety days free to start, then plans from $15 a month billed yearly, with a Starter tier that caps at 100 products for people opening their first shop.",
       ]}
       competitorName="Generic platforms"
       comparisonNote="Most mainstream platforms are tuned for high-SKU catalogues and add fees or design costs that hit small makers hardest."
@@ -94,7 +94,7 @@ export default function EcommerceForMakersPage() {
         {
           question: "How much does it cost to sell handmade goods here?",
           answer:
-            "There's no platform fee on your sales. You pay only your payment processor's standard rate. Plans start at $19 a month after 90 days free, with a Starter tier for first-time shops.",
+            "There's no platform fee on your sales. You pay only your payment processor's standard rate. Plans start at $15 a month billed yearly after 90 days free, with a Starter tier for first-time shops.",
         },
         {
           question: "How many products can I list?",

--- a/apps/onboarding/app/etsy-alternative/page.tsx
+++ b/apps/onboarding/app/etsy-alternative/page.tsx
@@ -30,7 +30,7 @@ export default function EtsyAlternativePage() {
       intro={[
         "Etsy is a marketplace, and a marketplace is someone else's shopping mall. You rent a stall, you compete with near-identical listings a scroll away, and you pay for the privilege on every sale — listing fees, transaction fees, payment processing, and more if you want to be seen. Worst of all, the customer belongs to Etsy, not to you.",
         "Mark8ly is the opposite of that. It's your own website, on your own domain, with your own brand at the top and your own customer list underneath. When someone buys, they're buying from you — and you keep their relationship, their email, and the next sale.",
-        "There's no per-sale platform fee. You pay only your payment processor's standard rate; we don't add a cut on top. Ninety days free to start, then plans from $19 a month — a flat, predictable cost instead of a stack of fees that grows with every order.",
+        "There's no per-sale platform fee. You pay only your payment processor's standard rate; we don't add a cut on top. Ninety days free to start, then plans from $15 a month billed yearly — a flat, predictable cost instead of a stack of fees that grows with every order.",
       ]}
       competitorName="Etsy"
       comparisonNote="Etsy is a marketplace with listing, transaction, and payment fees per sale; Mark8ly is your own website with no platform cut."
@@ -94,7 +94,7 @@ export default function EtsyAlternativePage() {
         {
           question: "Are there listing or transaction fees?",
           answer:
-            "No. There are no listing fees and no platform transaction fee. You pay only your payment processor's standard rate, plus a flat monthly plan starting at $19 after 90 days free.",
+            "No. There are no listing fees and no platform transaction fee. You pay only your payment processor's standard rate, plus a flat plan starting at $15 a month billed yearly after 90 days free.",
         },
         {
           question: "Can I keep selling on Etsy too?",

--- a/apps/onboarding/app/etsy-alternative/page.tsx
+++ b/apps/onboarding/app/etsy-alternative/page.tsx
@@ -30,7 +30,7 @@ export default function EtsyAlternativePage() {
       intro={[
         "Etsy is a marketplace, and a marketplace is someone else's shopping mall. You rent a stall, you compete with near-identical listings a scroll away, and you pay for the privilege on every sale — listing fees, transaction fees, payment processing, and more if you want to be seen. Worst of all, the customer belongs to Etsy, not to you.",
         "Mark8ly is the opposite of that. It's your own website, on your own domain, with your own brand at the top and your own customer list underneath. When someone buys, they're buying from you — and you keep their relationship, their email, and the next sale.",
-        "There's no per-sale platform fee. You pay only your payment processor's standard rate; we don't add a cut on top. Ninety days free to start, then plans from $29 a month — a flat, predictable cost instead of a stack of fees that grows with every order.",
+        "There's no per-sale platform fee. You pay only your payment processor's standard rate; we don't add a cut on top. Ninety days free to start, then plans from $19 a month — a flat, predictable cost instead of a stack of fees that grows with every order.",
       ]}
       competitorName="Etsy"
       comparisonNote="Etsy is a marketplace with listing, transaction, and payment fees per sale; Mark8ly is your own website with no platform cut."
@@ -94,7 +94,7 @@ export default function EtsyAlternativePage() {
         {
           question: "Are there listing or transaction fees?",
           answer:
-            "No. There are no listing fees and no platform transaction fee. You pay only your payment processor's standard rate, plus a flat monthly plan starting at $29 after 90 days free.",
+            "No. There are no listing fees and no platform transaction fee. You pay only your payment processor's standard rate, plus a flat monthly plan starting at $19 after 90 days free.",
         },
         {
           question: "Can I keep selling on Etsy too?",

--- a/apps/onboarding/app/layout.tsx
+++ b/apps/onboarding/app/layout.tsx
@@ -114,7 +114,11 @@ const jsonLd = {
       name: SITE_NAME,
       legalName: "Tesserix",
       url: SITE_URL,
-      logo: `${SITE_URL}/opengraph-image`,
+      // A square mark, not the 1200×630 social card. Google's
+      // Organization logo guidance wants a logo image it can crop to
+      // a square; handing it the OG banner gets the logo dropped from
+      // knowledge-panel and AI-answer attribution.
+      logo: `${SITE_URL}/icon-192.png`,
       description: SITE_DESCRIPTION,
       email: "hello@mark8ly.com",
       sameAs: [

--- a/apps/onboarding/app/page.tsx
+++ b/apps/onboarding/app/page.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { cookies } from "next/headers";
@@ -10,11 +11,171 @@ import {
   getPlanPrice,
   normalizeCurrency,
   type Currency,
+  type PlanId,
+  type SharedPlan,
 } from "@repo/ui/subscription";
 
 import { Header } from "@/components/marketing/Header";
 import { Footer } from "@/components/marketing/Footer";
 import { Pricing } from "@/components/marketing/Pricing";
+
+const SITE_URL = "https://mark8ly.com";
+
+/* ============================================================
+   Homepage metadata. The root layout supplies the site-wide
+   defaults; this overrides them for `/` specifically so the
+   highest-traffic page has its own description rather than
+   inheriting the generic one.
+
+   `title.absolute` bypasses the root `%s · Mark8ly` template —
+   without it the rendered title reads "Mark8ly — … · Mark8ly".
+   ============================================================ */
+
+export const metadata: Metadata = {
+  title: {
+    absolute: "Mark8ly — quiet commerce for people who make things",
+  },
+  description:
+    "Mark8ly is an editorial commerce platform for independent merchants. " +
+    "Open a storefront in an afternoon, keep every sale — no platform " +
+    "transaction fees — and ship a store that looks considered from day one. " +
+    "Ninety days free, no card required.",
+  alternates: {
+    canonical: "/",
+  },
+};
+
+/* ============================================================
+   Homepage structured data.
+
+   Two graphs: the product itself (SoftwareApplication, with the
+   plan line-up as an AggregateOffer) and the FAQ. The guides and
+   the SEO landing pages already emit Article/FAQPage; the
+   homepage — the page most likely to be cited in an AI answer —
+   previously emitted none, so pricing and plan facts were only
+   available as prose.
+
+   Prices are derived from SHARED_PRICING_CATALOGUE rather than
+   hardcoded, so the schema can never drift from the numbers the
+   Pricing section actually renders. Google requires structured
+   data to match visible content; a hardcoded price here would
+   silently become a mismatch the next time pricing moves.
+   ============================================================ */
+
+const PLAN_NAMES: Record<PlanId, string> = {
+  starter: "Starter",
+  studio: "Studio",
+  pro: "Pro",
+};
+
+/** Catalogue amounts are minor units (cents/paise); schema.org wants major. */
+function toMajorUnits(minorUnits: number): string {
+  return (minorUnits / 100).toFixed(2);
+}
+
+/**
+ * Resolves a plan's price alongside the currency it is actually
+ * denominated in. `getPlanPrice` silently falls back to USD for an
+ * unlisted currency, which would otherwise let us label a USD amount
+ * with the visitor's currency code — a wrong price in the schema.
+ */
+function resolvePricedPlan(
+  plan: SharedPlan,
+  currency: Currency,
+): { monthly: number; annualMonthly: number; priceCurrency: Currency } {
+  const localized = plan.prices[currency];
+  const price = localized ?? getPlanPrice(plan, "USD");
+  return {
+    monthly: price.monthly,
+    annualMonthly: price.annualMonthlyEquivalent,
+    priceCurrency: localized ? currency : "USD",
+  };
+}
+
+function buildHomeJsonLd(currency: Currency) {
+  const pricedPlans = SHARED_PRICING_CATALOGUE.plans.map((plan) => ({
+    id: plan.id,
+    ...resolvePricedPlan(plan, currency),
+  }));
+
+  // Every plan resolves to the same currency (the catalogue defines a
+  // full row per currency), so the aggregate can take the first one.
+  const priceCurrency = pricedPlans[0]?.priceCurrency ?? "USD";
+
+  // Both billing cadences are offered on the page, and the toggle
+  // defaults to annual — so the headline a visitor first sees is the
+  // annual-billed per-month equivalent, not the monthly rate. Emit an
+  // Offer for each cadence, all expressed per-month so the aggregate
+  // range stays coherent and matches whichever toggle state is shown.
+  const monthlyAmounts = pricedPlans.flatMap((p) => [
+    p.monthly,
+    p.annualMonthly,
+  ]);
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "SoftwareApplication",
+        "@id": `${SITE_URL}#software`,
+        name: "Mark8ly",
+        applicationCategory: "BusinessApplication",
+        applicationSubCategory: "Ecommerce platform",
+        operatingSystem: "Web",
+        url: SITE_URL,
+        publisher: { "@id": `${SITE_URL}#organization` },
+        offers: {
+          "@type": "AggregateOffer",
+          priceCurrency,
+          lowPrice: toMajorUnits(Math.min(...monthlyAmounts)),
+          highPrice: toMajorUnits(Math.max(...monthlyAmounts)),
+          offerCount: pricedPlans.length * 2,
+          offers: pricedPlans.flatMap((plan) => [
+            {
+              "@type": "Offer",
+              name: `${PLAN_NAMES[plan.id]} (billed yearly)`,
+              price: toMajorUnits(plan.annualMonthly),
+              priceCurrency: plan.priceCurrency,
+              category: "SubscriptionPlan",
+              priceSpecification: {
+                "@type": "UnitPriceSpecification",
+                price: toMajorUnits(plan.annualMonthly),
+                priceCurrency: plan.priceCurrency,
+                unitText: "MONTH",
+                billingDuration: 12,
+              },
+            },
+            {
+              "@type": "Offer",
+              name: `${PLAN_NAMES[plan.id]} (billed monthly)`,
+              price: toMajorUnits(plan.monthly),
+              priceCurrency: plan.priceCurrency,
+              category: "SubscriptionPlan",
+              priceSpecification: {
+                "@type": "UnitPriceSpecification",
+                price: toMajorUnits(plan.monthly),
+                priceCurrency: plan.priceCurrency,
+                unitText: "MONTH",
+                billingDuration: 1,
+              },
+            },
+          ]),
+        },
+      },
+      {
+        "@type": "FAQPage",
+        "@id": `${SITE_URL}#faq`,
+        // Built from the same `faqItems` the accordion renders, so the
+        // schema and the visible answers cannot diverge.
+        mainEntity: faqItems.map((item) => ({
+          "@type": "Question",
+          name: item.question,
+          acceptedAnswer: { "@type": "Answer", text: item.answer },
+        })),
+      },
+    ],
+  };
+}
 
 /**
  * Marketing landing page.
@@ -39,6 +200,19 @@ export default async function HomePage() {
 
   return (
     <div className="bg-background text-foreground">
+      <script
+        type="application/ld+json"
+        // Serialised from our own static catalogue and copy — no user
+        // input reaches this. `<` is escaped as a matter of habit,
+        // matching app/guides/[slug]/page.tsx.
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(buildHomeJsonLd(currency)).replace(
+            /</g,
+            "\\u003c",
+          ),
+        }}
+      />
+
       <Header />
 
       <main id="main">

--- a/apps/onboarding/app/page.tsx
+++ b/apps/onboarding/app/page.tsx
@@ -334,7 +334,7 @@ function Hero() {
 
           <p className="mt-8 text-sm text-foreground-tertiary">
             Free for ninety days. No card required. Three clear plans after
-            that, from $19 a month.
+            that, from $15 a month, billed yearly.
           </p>
         </div>
       </div>
@@ -1122,7 +1122,7 @@ const faqItems = [
   {
     question: "What happens after the ninety-day free trial?",
     answer:
-      "You choose between three plans — Starter, Studio, or Pro — starting at $19 a month. No added transaction fees from Mark8ly, ever. You can cancel any time and take your data with you.",
+      "You choose between three plans — Starter, Studio, or Pro — from $15 a month billed yearly, or $19 a month billed monthly. No added transaction fees from Mark8ly, ever. You can cancel any time and take your data with you.",
   },
   {
     question: "What does Mark8ly take from each sale?",

--- a/apps/onboarding/app/page.tsx
+++ b/apps/onboarding/app/page.tsx
@@ -1132,7 +1132,7 @@ const faqItems = [
   {
     question: "Is there a limit on products?",
     answer:
-      "Starter caps at 100 products for merchants just opening their first store. Studio and Pro are unlimited — add as many products, photos, and variants as you like.",
+      "No. Every plan includes unlimited products and orders — add as many products, photos, and variants as you like. What changes between plans is how many storefronts you can run: two on Starter, five on Studio, ten on Pro.",
   },
   {
     question: "Can I leave?",

--- a/apps/onboarding/app/page.tsx
+++ b/apps/onboarding/app/page.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { cookies } from "next/headers";
 import { FaqAccordion } from "@repo/ui/faq-accordion";
+import { MOBILE_ADMIN_APP_LINKS } from "@repo/ui/app-store-badges";
 import {
   CURRENCY_COOKIE_NAME,
   Money,
@@ -74,6 +75,32 @@ function toMajorUnits(minorUnits: number): string {
 }
 
 /**
+ * The companion admin app, described only in terms of the stores that
+ * actually resolve today. Play is live; the iOS listing is still in
+ * review and `MOBILE_ADMIN_APP_LINKS.ios` is deliberately empty until
+ * it clears — an indexed `installUrl` pointing at an unpublished
+ * listing is a crawlable 404, and claiming `operatingSystem: "iOS"`
+ * for an app nobody can install is a false claim in the graph.
+ *
+ * Both fields derive from the same constant the store badges render
+ * from, so filling in the iOS URL switches on the badge and the
+ * structured data together, with no second edit here.
+ */
+function describeMobileApp(): {
+  installUrls: string[];
+  operatingSystems: string[];
+} {
+  const ios = MOBILE_ADMIN_APP_LINKS.ios.trim();
+  const android = MOBILE_ADMIN_APP_LINKS.android.trim();
+  return {
+    installUrls: [ios, android].filter(Boolean),
+    operatingSystems: [ios ? "iOS" : "", android ? "Android" : ""].filter(
+      Boolean,
+    ),
+  };
+}
+
+/**
  * Resolves a plan's price alongside the currency it is actually
  * denominated in. `getPlanPrice` silently falls back to USD for an
  * unlisted currency, which would otherwise let us label a USD amount
@@ -112,6 +139,8 @@ function buildHomeJsonLd(currency: Currency) {
     p.annualMonthly,
   ]);
 
+  const mobileApp = describeMobileApp();
+
   return {
     "@context": "https://schema.org",
     "@graph": [
@@ -124,6 +153,10 @@ function buildHomeJsonLd(currency: Currency) {
         operatingSystem: "Web",
         url: SITE_URL,
         publisher: { "@id": `${SITE_URL}#organization` },
+        // The same three shots the Features section renders. Absolute
+        // URLs — schema.org image properties are not resolved against
+        // metadataBase the way Next's OG helpers are.
+        screenshot: FEATURES.map((feature) => `${SITE_URL}${feature.screen}`),
         offers: {
           "@type": "AggregateOffer",
           priceCurrency,
@@ -162,6 +195,35 @@ function buildHomeJsonLd(currency: Currency) {
           ]),
         },
       },
+      // Only claimed once at least one store listing resolves. With no
+      // live platform this node drops out entirely rather than
+      // describing an app nobody can install.
+      ...(mobileApp.installUrls.length > 0
+        ? [
+            {
+              "@type": "MobileApplication",
+              "@id": `${SITE_URL}#mobile-app`,
+              name: "Mark8ly Admin",
+              applicationCategory: "BusinessApplication",
+              operatingSystem: mobileApp.operatingSystems.join(", "),
+              description:
+                "Run your Mark8ly store from your phone — orders, " +
+                "products, inventory, and customers.",
+              publisher: { "@id": `${SITE_URL}#organization` },
+              // The companion app to the platform itself, not a
+              // separate product.
+              isPartOf: { "@id": `${SITE_URL}#software` },
+              installUrl: mobileApp.installUrls,
+              offers: {
+                "@type": "Offer",
+                // Free to install; running a store on it needs a plan,
+                // which the AggregateOffer above prices.
+                price: "0",
+                priceCurrency,
+              },
+            },
+          ]
+        : []),
       {
         "@type": "FAQPage",
         "@id": `${SITE_URL}#faq`,
@@ -397,34 +459,39 @@ function Manifesto() {
    grid. Each feature gets a real moment.
    ============================================================ */
 
-function Features() {
-  const features = [
-    {
-      kicker: "Storefront",
-      title: "A theme that feels considered, out of the box.",
-      body:
-        "Quiet typography, generous whitespace, real attention to product detail pages. The default storefront looks like something you would have hired a designer to build — because we did.",
-      screen: "/screens/storefront.png",
-      screenAlt: "Mark8ly storefront — coastal hero with editorial typography",
-    },
-    {
-      kicker: "Checkout",
-      title: "Payments that work everywhere customers do.",
-      body:
-        "Cards, UPI, wallets, and local methods, all behind a single checkout. No upcharges from us. Standard processor fees only.",
-      screen: "/screens/checkout.png",
-      screenAlt: "Mark8ly checkout — single page with order summary and progressive contact, address, shipping, payment steps",
-    },
-    {
-      kicker: "Admin",
-      title: "An admin you don't have to learn.",
-      body:
-        "Products, orders, customers, inventory. Each screen does one thing, clearly. No dashboards full of metrics that don't matter to you.",
-      screen: "/screens/admin.png",
-      screenAlt: "Mark8ly admin — branding settings with editorial layout gallery",
-    },
-  ];
+/**
+ * Module-level so the JSON-LD `screenshot` list and the rendered rows
+ * read from one array — a screenshot swapped here can't silently leave
+ * the structured data pointing at an image the page no longer shows.
+ */
+const FEATURES = [
+  {
+    kicker: "Storefront",
+    title: "A theme that feels considered, out of the box.",
+    body:
+      "Quiet typography, generous whitespace, real attention to product detail pages. The default storefront looks like something you would have hired a designer to build — because we did.",
+    screen: "/screens/storefront.png",
+    screenAlt: "Mark8ly storefront — coastal hero with editorial typography",
+  },
+  {
+    kicker: "Checkout",
+    title: "Payments that work everywhere customers do.",
+    body:
+      "Cards, UPI, wallets, and local methods, all behind a single checkout. No upcharges from us. Standard processor fees only.",
+    screen: "/screens/checkout.png",
+    screenAlt: "Mark8ly checkout — single page with order summary and progressive contact, address, shipping, payment steps",
+  },
+  {
+    kicker: "Admin",
+    title: "An admin you don't have to learn.",
+    body:
+      "Products, orders, customers, inventory. Each screen does one thing, clearly. No dashboards full of metrics that don't matter to you.",
+    screen: "/screens/admin.png",
+    screenAlt: "Mark8ly admin — branding settings with editorial layout gallery",
+  },
+];
 
+function Features() {
   return (
     <section className="border-t border-border-subtle py-16 sm:py-24">
       <div className="mx-auto max-w-6xl px-6">
@@ -438,7 +505,7 @@ function Features() {
         </div>
 
         <div className="space-y-14">
-          {features.map((f, i) => (
+          {FEATURES.map((f, i) => (
             <article
               key={f.title}
               className={`grid gap-8 lg:grid-cols-[1fr_1.4fr] lg:gap-12 ${

--- a/apps/onboarding/app/page.tsx
+++ b/apps/onboarding/app/page.tsx
@@ -272,7 +272,7 @@ function Hero() {
 
           <p className="mt-8 text-sm text-foreground-tertiary">
             Free for ninety days. No card required. Three clear plans after
-            that, from $29 a month.
+            that, from $19 a month.
           </p>
         </div>
       </div>
@@ -1055,7 +1055,7 @@ const faqItems = [
   {
     question: "What happens after the ninety-day free trial?",
     answer:
-      "You choose between three plans — Starter, Studio, or Pro — starting at $29 a month. No added transaction fees from Mark8ly, ever. You can cancel any time and take your data with you.",
+      "You choose between three plans — Starter, Studio, or Pro — starting at $19 a month. No added transaction fees from Mark8ly, ever. You can cancel any time and take your data with you.",
   },
   {
     question: "What does Mark8ly take from each sale?",

--- a/apps/onboarding/app/privacy/page.tsx
+++ b/apps/onboarding/app/privacy/page.tsx
@@ -33,7 +33,7 @@ export default function PrivacyPolicyPage() {
           and manage online stores. Mark8ly is a product of{" "}
           <strong>Tesserix Pty Ltd</strong> (ACN 694 070 865, ABN 59 694 070
           865), registered in New South Wales, Australia. Day-to-day
-          operations are conducted from Mumbai, India and Sydney, Australia.
+          operations are conducted from Sydney, Australia.
           Tesserix Pty Ltd is the data controller for the personal
           information processed through the Mark8ly website and account.
         </p>

--- a/apps/onboarding/app/shopify-alternative/page.tsx
+++ b/apps/onboarding/app/shopify-alternative/page.tsx
@@ -67,7 +67,7 @@ export default function ShopifyAlternativePage() {
           heading: "No platform fees, in plain terms",
           body: [
             "Every sale on Mark8ly costs you exactly what your payment processor charges — nothing more. There's no percentage skim, no per-order surcharge, no penalty for using the processor you prefer. Over a year, on real volume, that's the kind of saving that funds better packaging or a second product line.",
-            "After the ninety-day free trial you choose one of three plans — Starter, Studio, or Pro — from $29 a month. That's the whole bill. The plan is the price; the sales are yours.",
+            "After the ninety-day free trial you choose one of three plans — Starter, Studio, or Pro — from $19 a month. That's the whole bill. The plan is the price; the sales are yours.",
           ],
         },
         {
@@ -94,7 +94,7 @@ export default function ShopifyAlternativePage() {
         {
           question: "How does the price compare to Shopify?",
           answer:
-            "Plans start at $29 a month after a 90-day free trial, with no added transaction fees. Shopify Basic starts around $29 a month with a 3-day trial and a 2% platform fee unless you use Shopify Payments.",
+            "Plans start at $19 a month after a 90-day free trial, with no added transaction fees. Shopify Basic starts around $29 a month with a 3-day trial and a 2% platform fee unless you use Shopify Payments.",
         },
         {
           question: "Can I use my own domain?",

--- a/apps/onboarding/app/shopify-alternative/page.tsx
+++ b/apps/onboarding/app/shopify-alternative/page.tsx
@@ -67,7 +67,7 @@ export default function ShopifyAlternativePage() {
           heading: "No platform fees, in plain terms",
           body: [
             "Every sale on Mark8ly costs you exactly what your payment processor charges — nothing more. There's no percentage skim, no per-order surcharge, no penalty for using the processor you prefer. Over a year, on real volume, that's the kind of saving that funds better packaging or a second product line.",
-            "After the ninety-day free trial you choose one of three plans — Starter, Studio, or Pro — from $19 a month. That's the whole bill. The plan is the price; the sales are yours.",
+            "After the ninety-day free trial you choose one of three plans — Starter, Studio, or Pro — from $15 a month billed yearly. That's the whole bill. The plan is the price; the sales are yours.",
           ],
         },
         {
@@ -94,7 +94,7 @@ export default function ShopifyAlternativePage() {
         {
           question: "How does the price compare to Shopify?",
           answer:
-            "Plans start at $19 a month after a 90-day free trial, with no added transaction fees. Shopify Basic starts around $29 a month with a 3-day trial and a 2% platform fee unless you use Shopify Payments.",
+            "Plans start at $15 a month billed yearly after a 90-day free trial, with no added transaction fees. Shopify Basic starts around $29 a month with a 3-day trial and a 2% platform fee unless you use Shopify Payments.",
         },
         {
           question: "Can I use my own domain?",

--- a/apps/onboarding/app/terms/page.tsx
+++ b/apps/onboarding/app/terms/page.tsx
@@ -7,7 +7,7 @@ import {
 export const metadata = {
   title: "Terms",
   description:
-    "Mark8ly Terms of Service. Ninety-day free trial, then one of three clear plans from $19 a month. No transaction fees from Mark8ly. Governed by New South Wales, Australia. Australian Consumer Law always applies.",
+    "Mark8ly Terms of Service. Ninety-day free trial, then one of three clear plans from $15 a month billed yearly. No transaction fees from Mark8ly. Governed by New South Wales, Australia. Australian Consumer Law always applies.",
   alternates: { canonical: "/terms" },
 };
 
@@ -88,7 +88,8 @@ export default function TermsOfServicePage() {
         </p>
         <p>
           <strong>After the free period:</strong> three plans — Starter,
-          Studio, and Pro — from $19 a month. Annual billing available on
+          Studio, and Pro — from $19 a month billed monthly, or from $15 a
+          month billed yearly. Annual billing available on
           every plan. No extra platform transaction fees from Mark8ly.
           Upgrades prorate; downgrades take effect at the end of your
           current period. Cancel any time.

--- a/apps/onboarding/app/terms/page.tsx
+++ b/apps/onboarding/app/terms/page.tsx
@@ -110,12 +110,11 @@ export default function TermsOfServicePage() {
         </p>
         <p>
           <strong>Who collects your payment:</strong> Subscription payments are
-          collected and settled by{" "}
-          <strong>Zivana Innovations LLP</strong>, part of Tesserix Pty Ltd.
-          That is the name that may appear on your bank or card statement,
-          whether you are billed through Stripe or Razorpay. If we begin billing
-          you through a different group entity, we will tell you before it
-          takes effect.
+          collected and settled by <strong>Tesserix Pty Ltd</strong>. That is
+          the name that may appear on your bank or card statement, whether you
+          are billed through Stripe or Razorpay. If we begin billing you
+          through a different group entity, we will tell you before it takes
+          effect.
         </p>
 
         <h2>4. Acceptable use</h2>

--- a/apps/onboarding/app/terms/page.tsx
+++ b/apps/onboarding/app/terms/page.tsx
@@ -338,8 +338,7 @@ export default function TermsOfServicePage() {
         <p>
           Mark8ly is a product of <strong>Tesserix Pty Ltd</strong> (ACN 694
           070 865, ABN 59 694 070 865), registered in New South Wales,
-          Australia. Operations are conducted from Mumbai, India and Sydney,
-          Australia.
+          Australia. Operations are conducted from Sydney, Australia.
         </p>
       </Prose>
     </MarketingPage>

--- a/apps/onboarding/app/terms/page.tsx
+++ b/apps/onboarding/app/terms/page.tsx
@@ -7,7 +7,7 @@ import {
 export const metadata = {
   title: "Terms",
   description:
-    "Mark8ly Terms of Service. Ninety-day free trial, then one of three clear plans from $29 a month. No transaction fees from Mark8ly. Governed by New South Wales, Australia. Australian Consumer Law always applies.",
+    "Mark8ly Terms of Service. Ninety-day free trial, then one of three clear plans from $19 a month. No transaction fees from Mark8ly. Governed by New South Wales, Australia. Australian Consumer Law always applies.",
   alternates: { canonical: "/terms" },
 };
 
@@ -88,7 +88,7 @@ export default function TermsOfServicePage() {
         </p>
         <p>
           <strong>After the free period:</strong> three plans — Starter,
-          Studio, and Pro — from $29 a month. Annual billing available on
+          Studio, and Pro — from $19 a month. Annual billing available on
           every plan. No extra platform transaction fees from Mark8ly.
           Upgrades prorate; downgrades take effect at the end of your
           current period. Cancel any time.

--- a/apps/onboarding/app/terms/page.tsx
+++ b/apps/onboarding/app/terms/page.tsx
@@ -105,17 +105,15 @@ export default function TermsOfServicePage() {
           required.
         </p>
         <p>
-          <strong>Payment methods:</strong> Mark8ly subscriptions are
-          charged through Stripe (global) or Razorpay (India). See{" "}
-          <a href="/sub-processors">/sub-processors</a>.
+          <strong>Payment methods:</strong> Mark8ly subscriptions are charged
+          through Stripe. See <a href="/sub-processors">/sub-processors</a>.
         </p>
         <p>
           <strong>Who collects your payment:</strong> Subscription payments are
-          collected and settled by <strong>Tesserix Pty Ltd</strong>. That is
-          the name that may appear on your bank or card statement, whether you
-          are billed through Stripe or Razorpay. If we begin billing you
-          through a different group entity, we will tell you before it takes
-          effect.
+          collected and settled by <strong>Tesserix Pty Ltd</strong> through
+          Stripe. That is the name that may appear on your bank or card
+          statement. If we begin billing you through a different group entity,
+          we will tell you before it takes effect.
         </p>
 
         <h2>4. Acceptable use</h2>

--- a/apps/onboarding/components/marketing/Footer.tsx
+++ b/apps/onboarding/components/marketing/Footer.tsx
@@ -102,8 +102,7 @@ export function Footer() {
           {/* Operator disclosure. Named here so a merchant can match the entity
               on their invoice and settlement to the product they signed up to. */}
           <p className="mt-6 text-xs leading-relaxed text-paper-500">
-            Powered by Zivana Innovations LLP, part of Tesserix Pty Ltd
-            (ACN 694 070 865 · ABN 59 694 070 865)
+            Tesserix Pty Ltd (ACN 694 070 865 · ABN 59 694 070 865)
           </p>
         </div>
       </div>

--- a/apps/onboarding/components/onboarding/SlimFooter.tsx
+++ b/apps/onboarding/components/onboarding/SlimFooter.tsx
@@ -34,8 +34,7 @@ export function SlimFooter() {
         {/* Shown through onboarding because this is where a merchant commits
             to the platform and to its payment terms. */}
         <p className="w-full text-xs leading-relaxed opacity-80">
-          Powered by Zivana Innovations LLP, part of Tesserix Pty Ltd
-          (ACN 694 070 865 · ABN 59 694 070 865)
+          Tesserix Pty Ltd (ACN 694 070 865 · ABN 59 694 070 865)
         </p>
       </div>
     </footer>

--- a/apps/onboarding/public/llms-full.txt
+++ b/apps/onboarding/public/llms-full.txt
@@ -12,7 +12,7 @@ A storefront worth opening.
 
 Mark8ly is a quiet, considered commerce platform for people who actually make things. Set up in an afternoon. Keep your margins. Sell on a storefront that doesn't look like everyone else's.
 
-Free for ninety days. No card required. Three clear plans after that, from $29 a month.
+Free for ninety days. No card required. Three clear plans after that, from $19 a month.
 
 ### What we believe
 
@@ -38,8 +38,8 @@ Free for ninety days. No card required. Three clear plans after that, from $29 a
 
 Ninety days free to start. After that, three clear plans — no hidden fees, no transaction cuts from Mark8ly, only what your payment processor charges at their standard rate. Change plans any time; upgrades prorate, downgrades take effect at the end of your current period.
 
-- **Starter — $29/month.** For merchants opening their first store. 1 storefront, up to 100 products, 500 orders/month, your own domain, standard analytics.
-- **Studio — $79/month.** For stores finding their rhythm. 3 storefronts, unlimited products, 5,000 orders/month, advanced analytics, discount codes, custom domain, priority email support.
+- **Starter — $19/month.** For merchants opening their first store. 1 storefront, up to 100 products, 500 orders/month, your own domain, standard analytics.
+- **Studio — $49/month.** For stores finding their rhythm. 3 storefronts, unlimited products, 5,000 orders/month, advanced analytics, discount codes, custom domain, priority email support.
 - **Pro — $99/month (annual) or $119/month (monthly).** For teams scaling past $10k orders a month. Unlimited storefronts, unlimited everything, SLA-backed uptime, dedicated infrastructure, named account manager, enterprise SSO.
 
 **White-label App add-on** (Pro only): publish a branded iOS and Android app for your storefront. Billed annually and co-terminated with your Pro renewal.
@@ -65,7 +65,7 @@ Every plan includes:
 Yes — that's the entire point. If you can write an email, you can run a store on Mark8ly. And if you get stuck, real humans answer real messages.
 
 **What happens after the ninety-day free trial?**
-You choose between three plans — Starter, Studio, or Pro — starting at $29 a month. No added transaction fees from Mark8ly, ever. You can cancel any time and take your data with you.
+You choose between three plans — Starter, Studio, or Pro — starting at $19 a month. No added transaction fees from Mark8ly, ever. You can cancel any time and take your data with you.
 
 **What does Mark8ly take from each sale?**
 Nothing. Your payment processor charges their standard fee (around 2% for UPI, 2–3% for cards). We don't add anything on top of that.
@@ -146,7 +146,7 @@ Mumbai, India. We work remote-first across a small distributed team, which means
 
 - Age requirement: 18+.
 - Free trial: 90 days, no credit card.
-- After the free period: three plans — Starter at $29/month, Studio at $79/month, Pro at $99/month (annual) or $119/month (monthly). Annual billing available on every plan. No extra platform transaction fees from Mark8ly. Optional White-label App add-on on Pro, billed annually.
+- After the free period: three plans — Starter at $19/month, Studio at $49/month, Pro at $99/month (annual) or $119/month (monthly). Annual billing available on every plan. No extra platform transaction fees from Mark8ly. Optional White-label App add-on on Pro, billed annually.
 - Refunds: within 14 days, via support@mark8ly.com.
 - Acceptable use: no illegal, counterfeit, or restricted items. No fraud, malware, or interference with other stores.
 - Cancellation: any time, no fees, no penalties. Download your data before cancelling.

--- a/apps/onboarding/public/llms-full.txt
+++ b/apps/onboarding/public/llms-full.txt
@@ -88,7 +88,7 @@ We're a small team building a commerce platform for independent merchants who wa
 
 There are dozens of ways to open an online store. Most of them are designed for merchants with a developer, a design budget, or a long runway. If you don't have any of those, the experience is overwhelming, expensive, and slow.
 
-Mark8ly is the opposite. The storefront looks like something a studio made. The admin only shows what you need. Six months are free. After that the price is one honest number.
+Mark8ly is the opposite. The storefront looks like something a studio made. The admin only shows what you need. The first ninety days are free. After that the price is one honest number.
 
 We're not trying to be the biggest platform. We're trying to be the one that treats indie merchants like the adults they are.
 

--- a/apps/onboarding/public/llms-full.txt
+++ b/apps/onboarding/public/llms-full.txt
@@ -12,7 +12,7 @@ A storefront worth opening.
 
 Mark8ly is a quiet, considered commerce platform for people who actually make things. Set up in an afternoon. Keep your margins. Sell on a storefront that doesn't look like everyone else's.
 
-Free for ninety days. No card required. Three clear plans after that, from $19 a month.
+Free for ninety days. No card required. Three clear plans after that, from $15 a month billed yearly.
 
 ### What we believe
 
@@ -38,9 +38,9 @@ Free for ninety days. No card required. Three clear plans after that, from $19 a
 
 Ninety days free to start. After that, three clear plans — no hidden fees, no transaction cuts from Mark8ly, only what your payment processor charges at their standard rate. Change plans any time; upgrades prorate, downgrades take effect at the end of your current period.
 
-- **Starter — $19/month.** For merchants opening their first store. 1 storefront, up to 100 products, 500 orders/month, your own domain, standard analytics.
-- **Studio — $49/month.** For stores finding their rhythm. 3 storefronts, unlimited products, 5,000 orders/month, advanced analytics, discount codes, custom domain, priority email support.
-- **Pro — $99/month (annual) or $119/month (monthly).** For teams scaling past $10k orders a month. Unlimited storefronts, unlimited everything, SLA-backed uptime, dedicated infrastructure, named account manager, enterprise SSO.
+- **Starter — $15/month billed yearly, or $19/month billed monthly.** For merchants opening their first store. 1 storefront, up to 100 products, 500 orders/month, your own domain, standard analytics.
+- **Studio — $39/month billed yearly, or $49/month billed monthly.** For stores finding their rhythm. 3 storefronts, unlimited products, 5,000 orders/month, advanced analytics, discount codes, custom domain, priority email support.
+- **Pro — $99/month billed yearly, or $119/month billed monthly.** For teams scaling past $10k orders a month. Unlimited storefronts, unlimited everything, SLA-backed uptime, dedicated infrastructure, named account manager, enterprise SSO.
 
 **White-label App add-on** (Pro only): publish a branded iOS and Android app for your storefront. Billed annually and co-terminated with your Pro renewal.
 
@@ -65,7 +65,7 @@ Every plan includes:
 Yes — that's the entire point. If you can write an email, you can run a store on Mark8ly. And if you get stuck, real humans answer real messages.
 
 **What happens after the ninety-day free trial?**
-You choose between three plans — Starter, Studio, or Pro — starting at $19 a month. No added transaction fees from Mark8ly, ever. You can cancel any time and take your data with you.
+You choose between three plans — Starter, Studio, or Pro — from $15 a month billed yearly, or $19 a month billed monthly. No added transaction fees from Mark8ly, ever. You can cancel any time and take your data with you.
 
 **What does Mark8ly take from each sale?**
 Nothing. Your payment processor charges their standard fee (around 2% for UPI, 2–3% for cards). We don't add anything on top of that.
@@ -146,7 +146,7 @@ Mumbai, India. We work remote-first across a small distributed team, which means
 
 - Age requirement: 18+.
 - Free trial: 90 days, no credit card.
-- After the free period: three plans — Starter at $19/month, Studio at $49/month, Pro at $99/month (annual) or $119/month (monthly). Annual billing available on every plan. No extra platform transaction fees from Mark8ly. Optional White-label App add-on on Pro, billed annually.
+- After the free period: three plans — Starter at $15/month (annual) or $19/month (monthly), Studio at $39/month (annual) or $49/month (monthly), Pro at $99/month (annual) or $119/month (monthly). Annual billing available on every plan. No extra platform transaction fees from Mark8ly. Optional White-label App add-on on Pro, billed annually.
 - Refunds: within 14 days, via support@mark8ly.com.
 - Acceptable use: no illegal, counterfeit, or restricted items. No fraud, malware, or interference with other stores.
 - Cancellation: any time, no fees, no penalties. Download your data before cancelling.

--- a/apps/onboarding/public/llms-full.txt
+++ b/apps/onboarding/public/llms-full.txt
@@ -38,9 +38,9 @@ Free for ninety days. No card required. Three clear plans after that, from $15 a
 
 Ninety days free to start. After that, three clear plans — no hidden fees, no transaction cuts from Mark8ly, only what your payment processor charges at their standard rate. Change plans any time; upgrades prorate, downgrades take effect at the end of your current period.
 
-- **Starter — $15/month billed yearly, or $19/month billed monthly.** For merchants opening their first store. 1 storefront, up to 100 products, 500 orders/month, your own domain, standard analytics.
-- **Studio — $39/month billed yearly, or $49/month billed monthly.** For stores finding their rhythm. 3 storefronts, unlimited products, 5,000 orders/month, advanced analytics, discount codes, custom domain, priority email support.
-- **Pro — $99/month billed yearly, or $119/month billed monthly.** For teams scaling past $10k orders a month. Unlimited storefronts, unlimited everything, SLA-backed uptime, dedicated infrastructure, named account manager, enterprise SSO.
+- **Starter — $15/month billed yearly, or $19/month billed monthly.** For merchants opening their first store. Up to 2 stores, unlimited products and orders, 15,000 campaign emails/month, full colour palette and announcement bar, your own domain.
+- **Studio — $39/month billed yearly, or $49/month billed monthly.** For stores finding their rhythm. Up to 5 stores, 50 images per product, 50,000 campaign emails/month, custom CSS and fonts, read-only API and webhooks, 12-month audit log.
+- **Pro — $99/month billed yearly, or $119/month billed monthly.** For mid-market brands at scale. Up to 10 stores, unlimited images, full read/write API, custom code injection, SSO (SAML/OIDC), priority support with 4-hour response, forever audit retention.
 
 **White-label App add-on** (Pro only): publish a branded iOS and Android app for your storefront. Billed annually and co-terminated with your Pro renewal.
 
@@ -71,7 +71,7 @@ You choose between three plans — Starter, Studio, or Pro — from $15 a month 
 Nothing. Your payment processor charges their standard fee (around 2% for UPI, 2–3% for cards). We don't add anything on top of that.
 
 **Is there a limit on products?**
-No. Add as many products, photos, and variants as you want. We're not in the business of nickel-and-diming you.
+No. Products and orders are unlimited on every plan. What changes between plans is how many storefronts you can run: two on Starter, five on Studio, ten on Pro.
 
 **Can I leave?**
 Whenever you like. Export your products, customers, and orders in one click and take everything with you. No hard feelings.
@@ -104,7 +104,7 @@ Three commitments we won't compromise on:
 
 ### Where we're based
 
-Mumbai, India. Remote-first, global by default. We build and support Mark8ly from a small distributed team of engineers, designers, and merchants.
+Australia. Remote-first, global by default. We build and support Mark8ly from a small distributed team of engineers, designers, and merchants.
 
 ---
 
@@ -122,7 +122,7 @@ We're a small team and we actually read what lands in the inbox. No ticket queue
 
 ### Where we are
 
-Mumbai, India. We work remote-first across a small distributed team, which means there is almost always someone awake when you write to us.
+Australia. We work remote-first across a small distributed team, which means there is almost always someone awake when you write to us.
 
 ---
 

--- a/apps/onboarding/public/llms.txt
+++ b/apps/onboarding/public/llms.txt
@@ -16,7 +16,7 @@ The project is pre-launch. The marketing site at https://mark8ly.com is the prim
 
 ## Pricing
 
-Free for ninety days, no credit card required. After that, three clear plans — Starter at $19/month, Studio at $49/month, and Pro at $99/month (annual) or $119/month (monthly). Pro merchants can add the optional White-label App add-on, billed annually. Annual billing is available on every plan. Mark8ly never takes a cut of your sales — only your payment processor charges their standard fees (around 2% for UPI, 2–3% for cards).
+Free for ninety days, no credit card required. After that, three clear plans — Starter at $15/month (annual) or $19/month (monthly), Studio at $39/month (annual) or $49/month (monthly), and Pro at $99/month (annual) or $119/month (monthly). Pro merchants can add the optional White-label App add-on, billed annually. Annual billing is available on every plan. Mark8ly never takes a cut of your sales — only your payment processor charges their standard fees (around 2% for UPI, 2–3% for cards).
 
 ## Core beliefs
 

--- a/apps/onboarding/public/llms.txt
+++ b/apps/onboarding/public/llms.txt
@@ -16,7 +16,7 @@ The project is pre-launch. The marketing site at https://mark8ly.com is the prim
 
 ## Pricing
 
-Free for ninety days, no credit card required. After that, three clear plans — Starter at $29/month, Studio at $79/month, and Pro at $99/month (annual) or $119/month (monthly). Pro merchants can add the optional White-label App add-on, billed annually. Annual billing is available on every plan. Mark8ly never takes a cut of your sales — only your payment processor charges their standard fees (around 2% for UPI, 2–3% for cards).
+Free for ninety days, no credit card required. After that, three clear plans — Starter at $19/month, Studio at $49/month, and Pro at $99/month (annual) or $119/month (monthly). Pro merchants can add the optional White-label App add-on, billed annually. Annual billing is available on every plan. Mark8ly never takes a cut of your sales — only your payment processor charges their standard fees (around 2% for UPI, 2–3% for cards).
 
 ## Core beliefs
 

--- a/apps/onboarding/public/llms.txt
+++ b/apps/onboarding/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Mark8ly is a modern editorial commerce platform for independent merchants. Launch a storefront in an afternoon, keep every sale (no platform transaction fees), and ship a store that looks considered from day one.
 
-Mark8ly is a Tesserix product built for indie merchants and small established brands who want an online store that feels composed — the opposite of templated SaaS builders. Six free months, then one flat monthly fee. No transaction fees, no tier maze, no feature paywalls. You own your data, your customers, your domain, and you can export everything and leave at any time.
+Mark8ly is a Tesserix product built for indie merchants and small established brands who want an online store that feels composed — the opposite of templated SaaS builders. Ninety days free, then one flat monthly fee. No transaction fees, no tier maze, no feature paywalls. You own your data, your customers, your domain, and you can export everything and leave at any time.
 
 The project is pre-launch. The marketing site at https://mark8ly.com is the primary public surface. Admin and storefront surfaces for live merchants are in development.
 

--- a/apps/onboarding/public/llms.txt
+++ b/apps/onboarding/public/llms.txt
@@ -26,7 +26,7 @@ Free for ninety days, no credit card required. After that, three clear plans —
 
 ## Who it's for
 
-Indie merchants, small batch makers, boutique brands, and established small-to-mid merchants migrating off Shopify, WooCommerce, or Squarespace. India-based, globally available.
+Indie merchants, small batch makers, boutique brands, and established small-to-mid merchants migrating off Shopify, WooCommerce, or Squarespace. Australia-based, globally available.
 
 ## Not indexed
 


### PR DESCRIPTION
## Why

Investigating why Fe3dr surfaces in Google's AI answers and Mark8ly doesn't, the cause turned out **not** to be the code — the onboarding app's SEO was already stronger than Fe3dr's. The block is a Cloudflare managed `robots.txt` on the mark8ly.com zone disallowing `Google-Extended`, `GPTBot`, `ClaudeBot`, and `CCBot` (a dashboard setting, not in this repo).

What the investigation *did* surface was that several pages stated things that weren't true — including in `llms.txt` / `llms-full.txt`, the files AI assistants read most literally. Unblocking crawlers before correcting these would have taught every assistant a wrong version of the product.

## Factual corrections

| Claim | Was | Now | Source of truth |
|---|---|---|---|
| Free trial | "six free months" (3 places) | ninety days | Terms + Refunds |
| Starter | $29/mo | **$19** ($15 billed yearly) | `SHARED_PRICING_CATALOGUE` |
| Studio | $79/mo | **$49** ($39 billed yearly) | same |
| Product cap | "Starter caps at 100 products" | unlimited on every plan | `Pricing.tsx` PLAN_META (server-gated via plangate) |
| Storefronts | Pro "unlimited" | 2 / 5 / 10 by tier | same |
| Payment collector | Zivana Innovations LLP | **Tesserix Pty Ltd** via Stripe | — |
| Subscription processor | "Stripe (global) or Razorpay (India)" | Stripe only | — |
| Company base | Mumbai, India | Australia; operations Sydney | — |

`$29` is retained wherever it correctly refers to **Shopify Basic** in the competitor tables. Razorpay is retained in `terms:67`, privacy, security, and sub-processors, where it correctly describes *merchant-side* checkout for India.

Headline prices now quote the annual cadence (`from $15 a month, billed yearly`) to match what the Pricing toggle and Comparison table display by default, with the billing basis stated.

## Structured data

- Homepage `metadata` export (`title.absolute` to bypass the root template)
- `SoftwareApplication` + `AggregateOffer` — prices derived from `SHARED_PRICING_CATALOGUE`, both billing cadences, so schema cannot drift from the rendered table
- `FAQPage` from the same `faqItems` the accordion renders
- `screenshot` from the same `FEATURES` array the page renders
- `MobileApplication` gated on `MOBILE_ADMIN_APP_LINKS` — currently Android-only, since iOS is still in App Store review. Filling in the iOS URL switches on the badge and the schema together.
- `Organization.logo` → `/icon-192.png` (was the 1200×630 OG card)

## Verification

- `tsc --noEmit` clean on `apps/onboarding` **and** `apps/admin`
- `next build` succeeds
- Production build served locally and inspected: JSON-LD graph correct (`15.17–119.00 USD`, 6 offers, Android-only install URL), corrected copy renders, **0** Zivana occurrences across `/`, `/terms`, `/privacy`, `/acceptable-use`, `/about`, `/contact`, robots.txt and sitemap (19 URLs) serve

## Not addressed

- The Cloudflare **AI Crawl Control** block — dashboard action, and still the sole reason none of this reaches an AI answer
- 17 pre-existing npm advisories (untouched; `npm ci` installs strictly from the committed lockfile)
