### PR TITLE
fix(analytics): read OpenPanel config at runtime, not build time

### DIFF
--- a/apps/admin/app/analytics.tsx
+++ b/apps/admin/app/analytics.tsx
@@ -2,11 +2,16 @@
 
 import { OpenPanelComponent } from "@openpanel/nextjs";
 
-// Self-hosted OpenPanel at analytics.tesserix.app. Renders nothing without a
-// client ID so local and preview builds stay out of the production dataset.
-export function Analytics() {
-  const clientId = process.env.NEXT_PUBLIC_OPENPANEL_CLIENT_ID;
+interface AnalyticsProps {
+  clientId?: string;
+  apiUrl?: string;
+  scriptUrl?: string;
+}
 
+// Self-hosted OpenPanel at analytics.tesserix.app. Config arrives as props from
+// the server layout: NEXT_PUBLIC_* would be inlined at build time, but the Helm
+// chart supplies these at runtime. No client ID means no-op.
+export function Analytics({ clientId, apiUrl, scriptUrl }: AnalyticsProps) {
   if (!clientId) {
     return null;
   }
@@ -14,8 +19,8 @@ export function Analytics() {
   return (
     <OpenPanelComponent
       clientId={clientId}
-      apiUrl={process.env.NEXT_PUBLIC_OPENPANEL_API_URL}
-      scriptUrl={process.env.NEXT_PUBLIC_OPENPANEL_SCRIPT_URL}
+      apiUrl={apiUrl}
+      scriptUrl={scriptUrl}
       trackScreenViews
       trackOutgoingLinks
       trackAttributes

--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -55,7 +55,11 @@ export default function RootLayout({ children }: RootLayoutProps) {
       <body>
         <SkipLink />
         <QueryProvider>{children}</QueryProvider>
-        <Analytics />
+        <Analytics
+          clientId={process.env.OPENPANEL_CLIENT_ID}
+          apiUrl={process.env.OPENPANEL_API_URL}
+          scriptUrl={process.env.OPENPANEL_SCRIPT_URL}
+        />
       </body>
     </html>
   );

--- a/apps/onboarding/app/analytics.tsx
+++ b/apps/onboarding/app/analytics.tsx
@@ -2,11 +2,16 @@
 
 import { OpenPanelComponent } from "@openpanel/nextjs";
 
-// Self-hosted OpenPanel at analytics.tesserix.app. Renders nothing without a
-// client ID so local and preview builds stay out of the production dataset.
-export function Analytics() {
-  const clientId = process.env.NEXT_PUBLIC_OPENPANEL_CLIENT_ID;
+interface AnalyticsProps {
+  clientId?: string;
+  apiUrl?: string;
+  scriptUrl?: string;
+}
 
+// Self-hosted OpenPanel at analytics.tesserix.app. Config arrives as props from
+// the server layout: NEXT_PUBLIC_* would be inlined at build time, but the Helm
+// chart supplies these at runtime. No client ID means no-op.
+export function Analytics({ clientId, apiUrl, scriptUrl }: AnalyticsProps) {
   if (!clientId) {
     return null;
   }
@@ -14,8 +19,8 @@ export function Analytics() {
   return (
     <OpenPanelComponent
       clientId={clientId}
-      apiUrl={process.env.NEXT_PUBLIC_OPENPANEL_API_URL}
-      scriptUrl={process.env.NEXT_PUBLIC_OPENPANEL_SCRIPT_URL}
+      apiUrl={apiUrl}
+      scriptUrl={scriptUrl}
       trackScreenViews
       trackOutgoingLinks
       trackAttributes

--- a/apps/onboarding/app/layout.tsx
+++ b/apps/onboarding/app/layout.tsx
@@ -167,7 +167,11 @@ export default function RootLayout({ children }: RootLayoutProps) {
       <body>
         <SkipLink />
         {children}
-        <Analytics />
+        <Analytics
+          clientId={process.env.OPENPANEL_CLIENT_ID}
+          apiUrl={process.env.OPENPANEL_API_URL}
+          scriptUrl={process.env.OPENPANEL_SCRIPT_URL}
+        />
       </body>
     </html>
   );

--- a/apps/storefront/app/analytics.tsx
+++ b/apps/storefront/app/analytics.tsx
@@ -2,11 +2,16 @@
 
 import { OpenPanelComponent } from "@openpanel/nextjs";
 
-// Self-hosted OpenPanel at analytics.tesserix.app. Renders nothing without a
-// client ID so local and preview builds stay out of the production dataset.
-export function Analytics() {
-  const clientId = process.env.NEXT_PUBLIC_OPENPANEL_CLIENT_ID;
+interface AnalyticsProps {
+  clientId?: string;
+  apiUrl?: string;
+  scriptUrl?: string;
+}
 
+// Self-hosted OpenPanel at analytics.tesserix.app. Config arrives as props from
+// the server layout: NEXT_PUBLIC_* would be inlined at build time, but the Helm
+// chart supplies these at runtime. No client ID means no-op.
+export function Analytics({ clientId, apiUrl, scriptUrl }: AnalyticsProps) {
   if (!clientId) {
     return null;
   }
@@ -14,8 +19,8 @@ export function Analytics() {
   return (
     <OpenPanelComponent
       clientId={clientId}
-      apiUrl={process.env.NEXT_PUBLIC_OPENPANEL_API_URL}
-      scriptUrl={process.env.NEXT_PUBLIC_OPENPANEL_SCRIPT_URL}
+      apiUrl={apiUrl}
+      scriptUrl={scriptUrl}
       trackScreenViews
       trackOutgoingLinks
       trackAttributes

--- a/apps/storefront/app/layout.tsx
+++ b/apps/storefront/app/layout.tsx
@@ -257,7 +257,11 @@ export default async function RootLayout({ children }: RootLayoutProps) {
         </CustomerAuthProvider>
         <Toaster />
         <MerchantCSS css={brandingData?.branding?.custom_css} />
-        <Analytics />
+        <Analytics
+          clientId={process.env.OPENPANEL_CLIENT_ID}
+          apiUrl={process.env.OPENPANEL_API_URL}
+          scriptUrl={process.env.OPENPANEL_SCRIPT_URL}
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
Follow-up to #235. `NEXT_PUBLIC_*` is inlined by `next build`, so the client ID supplied by the Helm chart at runtime would never have reached the bundle — analytics would have silently stayed off.

The server layout now reads `OPENPANEL_CLIENT_ID` / `OPENPANEL_API_URL` and passes them to the client component as props.