### PR TITLE
ci: listen for the base-image-refresh dispatch event

### DIFF
--- a/.github/workflows/base-image-refresh.yml
+++ b/.github/workflows/base-image-refresh.yml
@@ -13,7 +13,9 @@ env:
 
 on:
   repository_dispatch:
-    types: [tesserix-base-images-updated]
+    # base-docker-images sends `base-image-refresh`; the older name is kept
+    # so an in-flight dispatch from a not-yet-updated sender still lands.
+    types: [base-image-refresh, tesserix-base-images-updated]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
base-docker-images sends event_type=base-image-refresh, so the weekly rebuild never reached this repo. Accept both names.