### PR TITLE
ci: build images on workflow_dispatch too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,9 @@ jobs:
   # them to GHCR. Skipped on PRs (only main pushes ship images).
   images:
     name: Build & push (${{ matrix.image.name }})
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # workflow_dispatch is how the base-image refresh fans out; without it the
+    # refresh runs CI, skips this job and reports success having built nothing.
+    if: contains(fromJSON('["push","workflow_dispatch"]'), github.event_name) && github.ref == 'refs/heads/main'
     needs: [go, node, security]
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
The Base Image Refresh workflow fans out by dispatching this workflow, but the image job was gated on `github.event_name == 'push'`. CI ran, the build job skipped, and the refresh reported success having rebuilt nothing — so base-image security patches never reached any mark8ly image.