### PR TITLE
fix(analytics): read OpenPanel config at runtime

### DIFF
--- a/apps/admin/app/analytics.tsx
+++ b/apps/admin/app/analytics.tsx
@@ -1,26 +1,42 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { OpenPanelComponent } from "@openpanel/nextjs";
 
-interface AnalyticsProps {
-  clientId?: string;
-  apiUrl?: string;
-  scriptUrl?: string;
+interface AnalyticsConfig {
+  clientId: string | null;
+  apiUrl: string | null;
+  scriptUrl: string | null;
 }
 
-// Self-hosted OpenPanel at analytics.tesserix.app. Config arrives as props from
-// the server layout: NEXT_PUBLIC_* would be inlined at build time, but the Helm
-// chart supplies these at runtime. No client ID means no-op.
-export function Analytics({ clientId, apiUrl, scriptUrl }: AnalyticsProps) {
-  if (!clientId) {
+// Self-hosted OpenPanel at analytics.tesserix.app. Pages are prerendered at
+// build time, so the config the Helm chart injects into the pod has to be read
+// from the route handler at runtime. No client ID means no-op.
+export function Analytics() {
+  const [config, setConfig] = useState<AnalyticsConfig | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/analytics-config")
+      .then((response) => (response.ok ? response.json() : null))
+      .then((loaded) => {
+        if (!cancelled) setConfig(loaded);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!config?.clientId) {
     return null;
   }
 
   return (
     <OpenPanelComponent
-      clientId={clientId}
-      apiUrl={apiUrl}
-      scriptUrl={scriptUrl}
+      clientId={config.clientId}
+      apiUrl={config.apiUrl ?? undefined}
+      scriptUrl={config.scriptUrl ?? undefined}
       trackScreenViews
       trackOutgoingLinks
       trackAttributes

--- a/apps/admin/app/api/analytics-config/route.test.ts
+++ b/apps/admin/app/api/analytics-config/route.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.unstubAllEnvs();
+});
+
+describe("analytics config route", () => {
+  it("is never prerendered, so it can read the pod env", async () => {
+    const route = await import("./route");
+    expect(route.dynamic).toBe("force-dynamic");
+  });
+
+  it("serves the OpenPanel config supplied at runtime", async () => {
+    vi.stubEnv("OPENPANEL_CLIENT_ID", "a-client-id");
+    vi.stubEnv("OPENPANEL_API_URL", "https://analytics.tesserix.app/api");
+    vi.stubEnv("OPENPANEL_SCRIPT_URL", "https://analytics.tesserix.app/op1.js");
+
+    const { GET } = await import("./route");
+    await expect(GET().json()).resolves.toEqual({
+      clientId: "a-client-id",
+      apiUrl: "https://analytics.tesserix.app/api",
+      scriptUrl: "https://analytics.tesserix.app/op1.js",
+    });
+  });
+
+  it("reports a null client id when analytics is not configured", async () => {
+    vi.stubEnv("OPENPANEL_CLIENT_ID", "");
+
+    const { GET } = await import("./route");
+    await expect(GET().json()).resolves.toMatchObject({ clientId: null });
+  });
+
+  it("is never cached, so a redeploy takes effect immediately", async () => {
+    const { GET } = await import("./route");
+    expect(GET().headers.get("cache-control")).toContain("no-store");
+  });
+});

--- a/apps/admin/app/api/analytics-config/route.ts
+++ b/apps/admin/app/api/analytics-config/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+// Pages are prerendered at build time, so the OpenPanel client id the Helm
+// chart supplies at runtime can never be baked into their HTML. The browser
+// reads it from here instead.
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json(
+    {
+      clientId: process.env.OPENPANEL_CLIENT_ID || null,
+      apiUrl: process.env.OPENPANEL_API_URL || null,
+      scriptUrl: process.env.OPENPANEL_SCRIPT_URL || null,
+    },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -55,11 +55,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
       <body>
         <SkipLink />
         <QueryProvider>{children}</QueryProvider>
-        <Analytics
-          clientId={process.env.OPENPANEL_CLIENT_ID}
-          apiUrl={process.env.OPENPANEL_API_URL}
-          scriptUrl={process.env.OPENPANEL_SCRIPT_URL}
-        />
+        <Analytics />
       </body>
     </html>
   );

--- a/apps/admin/middleware.ts
+++ b/apps/admin/middleware.ts
@@ -54,6 +54,7 @@ const PUBLIC_PREFIXES = [
   "/auth/handoff", // cross-TLD admin handoff — mints a session for this host, so it MUST render before the cookie exists
   "/webhooks", // external provider callbacks (Stripe, etc.) — never gated
   "/api/health", // kubelet probe target; must not 30x to /login
+  "/api/analytics-config", // non-secret client id, read before sign-in
   "/_next",
   "/favicon",
   "/icon-",

--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -40,7 +40,7 @@ const nextConfig: NextConfig = {
             // (SignInForm → getAppleCredential, lib/gip/apple-js.ts) — without
             // it the script tag is blocked and Apple sign-in fails with
             // "apple sdk load failed".
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com/gsi/client https://appleid.cdn-apple.com",
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com/gsi/client https://appleid.cdn-apple.com https://analytics.tesserix.app",
             "style-src 'self' 'unsafe-inline' https://accounts.google.com/gsi/style",
             "img-src 'self' data: blob: https:",
             "font-src 'self' data:",

--- a/apps/onboarding/app/analytics.tsx
+++ b/apps/onboarding/app/analytics.tsx
@@ -1,26 +1,42 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { OpenPanelComponent } from "@openpanel/nextjs";
 
-interface AnalyticsProps {
-  clientId?: string;
-  apiUrl?: string;
-  scriptUrl?: string;
+interface AnalyticsConfig {
+  clientId: string | null;
+  apiUrl: string | null;
+  scriptUrl: string | null;
 }
 
-// Self-hosted OpenPanel at analytics.tesserix.app. Config arrives as props from
-// the server layout: NEXT_PUBLIC_* would be inlined at build time, but the Helm
-// chart supplies these at runtime. No client ID means no-op.
-export function Analytics({ clientId, apiUrl, scriptUrl }: AnalyticsProps) {
-  if (!clientId) {
+// Self-hosted OpenPanel at analytics.tesserix.app. Pages are prerendered at
+// build time, so the config the Helm chart injects into the pod has to be read
+// from the route handler at runtime. No client ID means no-op.
+export function Analytics() {
+  const [config, setConfig] = useState<AnalyticsConfig | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/analytics-config")
+      .then((response) => (response.ok ? response.json() : null))
+      .then((loaded) => {
+        if (!cancelled) setConfig(loaded);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!config?.clientId) {
     return null;
   }
 
   return (
     <OpenPanelComponent
-      clientId={clientId}
-      apiUrl={apiUrl}
-      scriptUrl={scriptUrl}
+      clientId={config.clientId}
+      apiUrl={config.apiUrl ?? undefined}
+      scriptUrl={config.scriptUrl ?? undefined}
       trackScreenViews
       trackOutgoingLinks
       trackAttributes

--- a/apps/onboarding/app/api/analytics-config/route.ts
+++ b/apps/onboarding/app/api/analytics-config/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+// Pages are prerendered at build time, so the OpenPanel client id the Helm
+// chart supplies at runtime can never be baked into their HTML. The browser
+// reads it from here instead.
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json(
+    {
+      clientId: process.env.OPENPANEL_CLIENT_ID || null,
+      apiUrl: process.env.OPENPANEL_API_URL || null,
+      scriptUrl: process.env.OPENPANEL_SCRIPT_URL || null,
+    },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/apps/onboarding/app/layout.tsx
+++ b/apps/onboarding/app/layout.tsx
@@ -167,11 +167,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
       <body>
         <SkipLink />
         {children}
-        <Analytics
-          clientId={process.env.OPENPANEL_CLIENT_ID}
-          apiUrl={process.env.OPENPANEL_API_URL}
-          scriptUrl={process.env.OPENPANEL_SCRIPT_URL}
-        />
+        <Analytics />
       </body>
     </html>
   );

--- a/apps/onboarding/next.config.ts
+++ b/apps/onboarding/next.config.ts
@@ -28,7 +28,7 @@ const nextConfig: NextConfig = {
               "default-src 'self'",
               // accounts.google.com hosts the GSI client script used by
               // /auth/google (customer Google sign-in trampoline).
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com/gsi/client",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com/gsi/client https://analytics.tesserix.app",
               "style-src 'self' 'unsafe-inline' https://accounts.google.com/gsi/style",
               "img-src 'self' data: blob: https:",
               "font-src 'self' data:",

--- a/apps/storefront/app/analytics.tsx
+++ b/apps/storefront/app/analytics.tsx
@@ -1,26 +1,42 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { OpenPanelComponent } from "@openpanel/nextjs";
 
-interface AnalyticsProps {
-  clientId?: string;
-  apiUrl?: string;
-  scriptUrl?: string;
+interface AnalyticsConfig {
+  clientId: string | null;
+  apiUrl: string | null;
+  scriptUrl: string | null;
 }
 
-// Self-hosted OpenPanel at analytics.tesserix.app. Config arrives as props from
-// the server layout: NEXT_PUBLIC_* would be inlined at build time, but the Helm
-// chart supplies these at runtime. No client ID means no-op.
-export function Analytics({ clientId, apiUrl, scriptUrl }: AnalyticsProps) {
-  if (!clientId) {
+// Self-hosted OpenPanel at analytics.tesserix.app. Pages are prerendered at
+// build time, so the config the Helm chart injects into the pod has to be read
+// from the route handler at runtime. No client ID means no-op.
+export function Analytics() {
+  const [config, setConfig] = useState<AnalyticsConfig | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/analytics-config")
+      .then((response) => (response.ok ? response.json() : null))
+      .then((loaded) => {
+        if (!cancelled) setConfig(loaded);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!config?.clientId) {
     return null;
   }
 
   return (
     <OpenPanelComponent
-      clientId={clientId}
-      apiUrl={apiUrl}
-      scriptUrl={scriptUrl}
+      clientId={config.clientId}
+      apiUrl={config.apiUrl ?? undefined}
+      scriptUrl={config.scriptUrl ?? undefined}
       trackScreenViews
       trackOutgoingLinks
       trackAttributes

--- a/apps/storefront/app/api/analytics-config/route.test.ts
+++ b/apps/storefront/app/api/analytics-config/route.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.unstubAllEnvs();
+});
+
+describe("analytics config route", () => {
+  it("is never prerendered, so it can read the pod env", async () => {
+    const route = await import("./route");
+    expect(route.dynamic).toBe("force-dynamic");
+  });
+
+  it("serves the OpenPanel config supplied at runtime", async () => {
+    vi.stubEnv("OPENPANEL_CLIENT_ID", "a-client-id");
+    vi.stubEnv("OPENPANEL_API_URL", "https://analytics.tesserix.app/api");
+    vi.stubEnv("OPENPANEL_SCRIPT_URL", "https://analytics.tesserix.app/op1.js");
+
+    const { GET } = await import("./route");
+    await expect(GET().json()).resolves.toEqual({
+      clientId: "a-client-id",
+      apiUrl: "https://analytics.tesserix.app/api",
+      scriptUrl: "https://analytics.tesserix.app/op1.js",
+    });
+  });
+
+  it("reports a null client id when analytics is not configured", async () => {
+    vi.stubEnv("OPENPANEL_CLIENT_ID", "");
+
+    const { GET } = await import("./route");
+    await expect(GET().json()).resolves.toMatchObject({ clientId: null });
+  });
+
+  it("is never cached, so a redeploy takes effect immediately", async () => {
+    const { GET } = await import("./route");
+    expect(GET().headers.get("cache-control")).toContain("no-store");
+  });
+});

--- a/apps/storefront/app/api/analytics-config/route.ts
+++ b/apps/storefront/app/api/analytics-config/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+// Pages are prerendered at build time, so the OpenPanel client id the Helm
+// chart supplies at runtime can never be baked into their HTML. The browser
+// reads it from here instead.
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json(
+    {
+      clientId: process.env.OPENPANEL_CLIENT_ID || null,
+      apiUrl: process.env.OPENPANEL_API_URL || null,
+      scriptUrl: process.env.OPENPANEL_SCRIPT_URL || null,
+    },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/apps/storefront/app/layout.tsx
+++ b/apps/storefront/app/layout.tsx
@@ -257,11 +257,7 @@ export default async function RootLayout({ children }: RootLayoutProps) {
         </CustomerAuthProvider>
         <Toaster />
         <MerchantCSS css={brandingData?.branding?.custom_css} />
-        <Analytics
-          clientId={process.env.OPENPANEL_CLIENT_ID}
-          apiUrl={process.env.OPENPANEL_API_URL}
-          scriptUrl={process.env.OPENPANEL_SCRIPT_URL}
-        />
+        <Analytics />
       </body>
     </html>
   );

--- a/apps/storefront/middleware.ts
+++ b/apps/storefront/middleware.ts
@@ -13,6 +13,7 @@ const HOST_GATE_BYPASS = [
   "/favicon",
   "/icon-",
   "/api/health",
+  "/api/analytics-config",
   "/robots.txt",
   "/sitemap",
 ];

--- a/apps/storefront/next.config.ts
+++ b/apps/storefront/next.config.ts
@@ -60,7 +60,7 @@ const nextConfig: NextConfig = {
             // reveals. Each missed host is a silent prod-only breakage, so
             // trust the payment processor's domain rather than guess its
             // subdomains.
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com/gsi/client https://*.razorpay.com https://*.cashfree.com",
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com/gsi/client https://*.razorpay.com https://*.cashfree.com https://analytics.tesserix.app",
             "style-src 'self' 'unsafe-inline' https://accounts.google.com/gsi/style",
             "img-src 'self' data: blob: https:",
             "font-src 'self' data:",

--- a/apps/storefront/vitest.config.ts
+++ b/apps/storefront/vitest.config.ts
@@ -5,7 +5,10 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: false,
-    include: ["lib/**/*.{test,spec}.{ts,tsx}"],
+    include: [
+      "lib/**/*.{test,spec}.{ts,tsx}",
+      "app/api/**/*.{test,spec}.{ts,tsx}",
+    ],
     exclude: ["**/node_modules/**", "**/tests/e2e/**", "**/.next/**"],
   },
   resolve: {


### PR DESCRIPTION
Admin, Storefront and Tenant Onboarding all reported 0 events in OpenPanel. `process.env.OPENPANEL_*` was read in each root layout, which resolves at `next build` where the Helm-injected values do not exist, so prerendered pages shipped an undefined client id. Each app's CSP also omitted `analytics.tesserix.app` from `script-src`, so the tracking script was refused.

A `force-dynamic` route handler now serves the pod env and the client fetches it on mount; `/api/analytics-config` is allow-listed in the admin and storefront middleware gates.

Verified in a headless browser against production builds of storefront and onboarding: config fetch, op1.js load and `POST /api/track` all succeed with no CSP violations.