### PR TITLE
feat(marketplace-api): add /internal/active-domains endpoint

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1935,6 +1935,10 @@ func main() {
 		// 301 to the merchant's verified custom domain.
 		internalsvc.NewStoreActiveDomainHandler(conn).
 			Register(r.Group("/internal"), cfg.AuditIngestSecret)
+		// OpenPanel CORS reconciler reads this — no wildcard covers a
+		// merchant's own domain, so the list has to be enumerated.
+		internalsvc.NewActiveDomainsHandler(conn).
+			Register(r.Group("/internal"), cfg.AuditIngestSecret)
 		// Tenant hard-delete — platform-api's outbox drainer POSTs here to
 		// run the destructive purge of a tenant's marketplace-api domain
 		// data (see internal/tenantpurge). Purge is idempotent, so replay
@@ -2017,6 +2021,10 @@ func main() {
 			// Custom-domain takeover — wired on both engines so admin
 			// + storefront middlewares can hit whichever pod is local.
 			internalsvc.NewStoreActiveDomainHandler(conn).
+				Register(engine.Group("/internal"), cfg.AuditIngestSecret)
+			// OpenPanel CORS reconciler reads this — admin-only, matching
+			// the other cross-tenant enumerations above.
+			internalsvc.NewActiveDomainsHandler(conn).
 				Register(engine.Group("/internal"), cfg.AuditIngestSecret)
 			// Tenant hard-delete — platform-api's outbox drainer POSTs here
 			// to run the destructive purge of a tenant's marketplace-api

--- a/services/marketplace-api/internal/handlers/admin/setupprogress.go
+++ b/services/marketplace-api/internal/handlers/admin/setupprogress.go
@@ -168,7 +168,7 @@ func (h *SetupProgressHandler) Stream(c *gin.Context) {
 		if err != nil {
 			return false
 		}
-		if _, err := fmt.Fprintf(c.Writer, "event: progress\ndata: %s\n\n", data); err != nil {
+		if _, err := fmt.Fprintf(c.Writer, "event: progress\ndata: %s\n\n", data); err != nil { //nolint:logging-smoke // SSE frame to the client, not a log
 			return false
 		}
 		c.Writer.Flush()
@@ -199,7 +199,7 @@ func (h *SetupProgressHandler) Stream(c *gin.Context) {
 		case <-deadline.C:
 			return // client reconnects with a fresh stream
 		case <-heartbeat.C:
-			if _, err := fmt.Fprint(c.Writer, ": ping\n\n"); err != nil {
+			if _, err := fmt.Fprint(c.Writer, ": ping\n\n"); err != nil { //nolint:logging-smoke // SSE keep-alive to the client, not a log
 				return
 			}
 			c.Writer.Flush()

--- a/services/marketplace-api/internal/handlers/internalsvc/active_domains.go
+++ b/services/marketplace-api/internal/handlers/internalsvc/active_domains.go
@@ -1,0 +1,58 @@
+package internalsvc
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// ActiveDomainsResponse is the wire shape returned by /internal/active-domains.
+type ActiveDomainsResponse struct {
+	Domains []string `json:"domains"`
+}
+
+// ActiveDomainsHandler answers GET /internal/active-domains with every verified
+// merchant custom domain.
+//
+// Exists for the OpenPanel CORS reconciler: OpenPanel rejects an event whose
+// Origin is absent from the project's cors list, and no wildcard can cover a
+// merchant's own domain, so the list has to be enumerated periodically.
+type ActiveDomainsHandler struct {
+	db *gorm.DB
+}
+
+// NewActiveDomainsHandler constructs a handler bound to the marketplace-api DB.
+func NewActiveDomainsHandler(db *gorm.DB) *ActiveDomainsHandler {
+	return &ActiveDomainsHandler{db: db}
+}
+
+// Get is the Gin handler. Path: /internal/active-domains.
+func (h *ActiveDomainsHandler) Get(c *gin.Context) {
+	var domains []string
+	// Only 'active' — a verifying row has no working TLS yet, so allowing its
+	// origin would just widen the CORS list to a host nobody can reach.
+	err := h.db.WithContext(c.Request.Context()).Raw(`
+		SELECT domain
+		  FROM custom_domains
+		 WHERE status = 'active' AND domain <> ''
+		 ORDER BY domain
+	`).Scan(&domains).Error
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "lookup_failed"})
+		return
+	}
+
+	if domains == nil {
+		domains = []string{}
+	}
+	c.JSON(http.StatusOK, ActiveDomainsResponse{Domains: domains})
+}
+
+// Register mounts the endpoint onto the supplied /internal route group.
+//
+// Gated by X-Internal-Auth: a single slug→domain lookup is publicly observable,
+// but the full enumeration of onboarded merchants is not.
+func (h *ActiveDomainsHandler) Register(group *gin.RouterGroup, internalSecret string) {
+	group.GET("/active-domains", RequireInternalAuth(internalSecret), h.Get)
+}

--- a/services/marketplace-api/internal/handlers/internalsvc/active_domains_test.go
+++ b/services/marketplace-api/internal/handlers/internalsvc/active_domains_test.go
@@ -1,0 +1,32 @@
+package internalsvc_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/internalsvc"
+)
+
+// Unlike the sibling per-slug endpoints, this one enumerates every merchant's
+// custom domain, so the shared secret is not optional. Both cases abort before
+// the DB is touched, hence the nil handle.
+func TestActiveDomainsRequiresInternalAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	internalsvc.NewActiveDomainsHandler(nil).Register(r.Group("/internal"), "s3cret")
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/internal/active-domains", nil))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/internal/active-domains", nil)
+	req.Header.Set("X-Internal-Auth", "wrong")
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}


### PR DESCRIPTION
Enumerates verified merchant custom domains so the OpenPanel CORS reconciler can keep them in the storefront project's `cors` list.

OpenPanel rejects an event whose `Origin` is not listed (`401 Ingestion: Invalid cors or secret`, verified against prod). `https://*.mark8ly.com` covers every platform subdomain, but nothing can cover a merchant's own domain — and once a custom domain is verified the storefront 301s the platform URL to it, so that merchant would collect nothing.

Gated by `X-Internal-Auth` (AuditIngestSecret, the existing CronJob-caller secret): a single slug→domain lookup is publicly observable, a full enumeration of onboarded merchants is not. Mounted on the admin engine, matching the other cross-tenant enumerations.

Consumer: `openpanel-cors-sync` CronJob in tesserix-k8s.