### PR TITLE
fix(security): tenant-scope store refresh, gate SSO writes, fail closed on prod secrets

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -13,7 +13,6 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -1977,10 +1976,7 @@ func main() {
 		if stripeBillingWebhookHandler != nil {
 			r.POST("/webhooks/stripe-billing", stripeBillingWebhookHandler)
 		}
-		srv = &http.Server{
-			Addr:    fmt.Sprintf(":%d", cfg.HTTPPort),
-			Handler: r,
-		}
+		srv = newHTTPServer(cfg.HTTPPort, r)
 	case mode.Admin, mode.Storefront:
 		e := httpserver.New(cfg.Env, m, log)
 		engine := e.Admin
@@ -2087,10 +2083,7 @@ func main() {
 			internalsvc.NewStoreActiveDomainHandler(conn).
 				Register(engine.Group("/internal"), cfg.AuditIngestSecret)
 		}
-		srv = &http.Server{
-			Addr:    fmt.Sprintf(":%d", cfg.HTTPPort),
-			Handler: engine,
-		}
+		srv = newHTTPServer(cfg.HTTPPort, engine)
 	}
 
 	// Start the server in a goroutine so we can signal-handle on the main.

--- a/services/marketplace-api/cmd/marketplace-api/server.go
+++ b/services/marketplace-api/cmd/marketplace-api/server.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// newHTTPServer builds the listener with the timeouts a bare &http.Server
+// leaves at zero. ReadTimeout and WriteTimeout stay unset on purpose:
+// media uploads and CSV exports legitimately run long, and a blanket cap
+// would truncate them.
+func newHTTPServer(port int, h http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              fmt.Sprintf(":%d", port),
+		Handler:           h,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+}

--- a/services/marketplace-api/cmd/marketplace-api/server_test.go
+++ b/services/marketplace-api/cmd/marketplace-api/server_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// A server with no ReadHeaderTimeout lets a client hold a connection open
+// indefinitely mid-header (Slowloris); IdleTimeout bounds kept-alive
+// connections that go silent.
+func TestNewHTTPServer_SetsTimeouts(t *testing.T) {
+	srv := newHTTPServer(8080, http.NotFoundHandler())
+
+	if srv.Addr != ":8080" {
+		t.Fatalf("Addr = %q, want \":8080\"", srv.Addr)
+	}
+	if srv.ReadHeaderTimeout != 10*time.Second {
+		t.Fatalf("ReadHeaderTimeout = %v, want 10s", srv.ReadHeaderTimeout)
+	}
+	if srv.IdleTimeout != 120*time.Second {
+		t.Fatalf("IdleTimeout = %v, want 120s", srv.IdleTimeout)
+	}
+}

--- a/services/marketplace-api/internal/domainvalidate/validate.go
+++ b/services/marketplace-api/internal/domainvalidate/validate.go
@@ -63,10 +63,32 @@ func Check(ctx context.Context, raw string, resolver Resolver) (canonical string
 	if resolver == nil {
 		resolver = net.DefaultResolver
 	}
+	if err := checkNotReserved(canonical); err != nil {
+		return "", err
+	}
 	if err := checkExistence(dnsCtx, canonical, resolver); err != nil {
 		return "", err
 	}
 	return canonical, nil
+}
+
+// reservedZones are the apexes the platform itself serves. Ownership is
+// proved by pointing DNS at edge.mark8ly.com, and every name under these
+// zones already resolves to our own ingress — so a merchant could
+// "verify" admin.mark8ly.com or another tenant's storefront without ever
+// controlling it. Claiming one also burns the UNIQUE(domain) slot, which
+// would deny the real owner their name.
+var reservedZones = []string{"mark8ly.com", "mark8ly.dev"}
+
+// checkNotReserved rejects the platform's own zones and anything beneath
+// them. Suffix matching is label-aware so notmark8ly.com stays valid.
+func checkNotReserved(canonical string) error {
+	for _, zone := range reservedZones {
+		if canonical == zone || strings.HasSuffix(canonical, "."+zone) {
+			return fmt.Errorf("%w: %s is reserved by the platform and cannot be added as a custom domain", ErrInvalidDomain, canonical)
+		}
+	}
+	return nil
 }
 
 // checkSyntax normalises and validates the domain shape. Returns the

--- a/services/marketplace-api/internal/domainvalidate/validate_test.go
+++ b/services/marketplace-api/internal/domainvalidate/validate_test.go
@@ -109,3 +109,41 @@ func TestCheck_Happy(t *testing.T) {
 		t.Fatalf("canonical: %s", got)
 	}
 }
+
+// A merchant must not be able to claim a platform-owned hostname as a
+// custom domain. Verification accepts an A-record overlap with
+// edge.mark8ly.com, and every *.mark8ly.com name resolves to our own
+// ingress — so without this gate the ownership proof is self-satisfying.
+func TestCheck_RejectsPlatformDomains(t *testing.T) {
+	r := stubResolver{ns: []*net.NS{{Host: "ns1.example.com."}}}
+
+	for _, name := range []string{
+		"mark8ly.com",
+		"MARK8LY.COM",
+		"admin.mark8ly.com",
+		"edge.mark8ly.com",
+		"victim-store.mark8ly.com",
+		"victim-store-admin.mark8ly.com",
+		"api.mark8ly.dev",
+		"deep.nested.mark8ly.com.",
+	} {
+		if _, err := Check(context.Background(), name, r); err == nil {
+			t.Errorf("Check(%q) = nil error, want rejection", name)
+		}
+	}
+}
+
+// Names that merely contain the platform label are ordinary domains.
+func TestCheck_AllowsLookalikeDomains(t *testing.T) {
+	r := stubResolver{ns: []*net.NS{{Host: "ns1.example.com."}}}
+
+	for _, name := range []string{
+		"mark8ly.com.evil.io",
+		"notmark8ly.com",
+		"mark8ly.co",
+	} {
+		if _, err := Check(context.Background(), name, r); err != nil {
+			t.Errorf("Check(%q) = %v, want nil", name, err)
+		}
+	}
+}

--- a/services/marketplace-api/internal/handlers/admin/routes.go
+++ b/services/marketplace-api/internal/handlers/admin/routes.go
@@ -138,14 +138,22 @@ func RegisterAdmin(router *gin.RouterGroup, deps Deps) {
 	// RequireFeatureByTenant resolves the plan from the tenant's highest active
 	// store subscription rather than a specific store.
 	if deps.SSOConfigHandler != nil {
-		ssoTenant := router.Group("/admin/tenants/:tenantId",
-			authMW,
+		// Authz runs before the plan gate so a non-member learns nothing
+		// about the tenant's subscription. Writes are owner-only: the IdP
+		// config decides who can authenticate into the whole tenant.
+		ssoTenant := router.Group("/admin/tenants/:tenantId", authMW)
+		ssoRead := ssoTenant.Group("",
+			deps.AuthzMiddleware.RequireTenantRelation(authz.RoleAdmin),
 			plangate.RequireFeatureByTenant(deps.PlanResolver, plangate.FeatureSSO, deps.APIKeysLogger),
 		)
-		ssoTenant.POST("/sso/config", deps.SSOConfigHandler.Upsert)
-		ssoTenant.GET("/sso/config", deps.SSOConfigHandler.Get)
-		ssoTenant.DELETE("/sso/config", deps.SSOConfigHandler.Delete)
-		ssoTenant.POST("/sso/test", deps.SSOConfigHandler.Test)
+		ssoWrite := ssoTenant.Group("",
+			deps.AuthzMiddleware.RequireTenantRelation(authz.RoleOwner),
+			plangate.RequireFeatureByTenant(deps.PlanResolver, plangate.FeatureSSO, deps.APIKeysLogger),
+		)
+		ssoRead.GET("/sso/config", deps.SSOConfigHandler.Get)
+		ssoWrite.POST("/sso/config", deps.SSOConfigHandler.Upsert)
+		ssoWrite.DELETE("/sso/config", deps.SSOConfigHandler.Delete)
+		ssoWrite.POST("/sso/test", deps.SSOConfigHandler.Test)
 	}
 
 	// Tenant-wide admin routes — outside of /stores/:storeId because they

--- a/services/marketplace-api/internal/handlers/admin/sso_routes_test.go
+++ b/services/marketplace-api/internal/handlers/admin/sso_routes_test.go
@@ -1,0 +1,88 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/authz"
+)
+
+// ssoRouterForRole mounts the real admin routes with an FGA fake that grants
+// the caller exactly role on the tenant, so the assertions exercise the
+// production middleware chain rather than a hand-rolled copy of it.
+func ssoRouterForRole(t *testing.T, role authz.Role, userID, tenantID string) *gin.Engine {
+	t.Helper()
+	fga := authz.NewFakeClient()
+	fga.Grant(userID, role, tenantID)
+	r := gin.New()
+	RegisterAdmin(r.Group("/"), Deps{
+		SSOConfigHandler: NewSSOConfigHandler(nil, nil, nil, nil),
+		AuthzMiddleware:  authz.NewMiddleware(fga, nil),
+	})
+	return r
+}
+
+func ssoRoutePaths() [][2]string {
+	return [][2]string{
+		{http.MethodGet, "/sso/config"},
+		{http.MethodPost, "/sso/config"},
+		{http.MethodDelete, "/sso/config"},
+		{http.MethodPost, "/sso/test"},
+	}
+}
+
+// Every SSO route must be registered — otherwise the 404 assertions below
+// would pass against a router that simply has no such routes.
+func TestSSORoutes_AreRegistered(t *testing.T) {
+	r := ssoRouterForRole(t, authz.RoleOwner, uuid.NewString(), uuid.NewString())
+	registered := map[string]bool{}
+	for _, rt := range r.Routes() {
+		registered[rt.Method+" "+rt.Path] = true
+	}
+	for _, p := range ssoRoutePaths() {
+		key := p[0] + " /admin/tenants/:tenantId" + p[1]
+		require.True(t, registered[key], "route not registered: %s", key)
+	}
+}
+
+// A tenant member with only viewer rights must not read or overwrite the
+// tenant's identity-provider configuration.
+func TestSSORoutes_ViewerDenied(t *testing.T) {
+	userID, tenantID := uuid.NewString(), uuid.NewString()
+	r := ssoRouterForRole(t, authz.RoleViewer, userID, tenantID)
+
+	for _, p := range ssoRoutePaths() {
+		req := httptest.NewRequest(p[0], "/admin/tenants/"+tenantID+p[1], nil)
+		req.Header.Set("X-User-Id", userID)
+		req.Header.Set("X-Tenant-Id", tenantID)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusNotFound, w.Code, "%s %s", p[0], p[1])
+	}
+}
+
+// Staff and admin may not rewrite the IdP config either — changing it
+// redirects the whole tenant's authentication.
+func TestSSORoutes_MutationsRequireOwner(t *testing.T) {
+	for _, role := range []authz.Role{authz.RoleStaff, authz.RoleAdmin} {
+		userID, tenantID := uuid.NewString(), uuid.NewString()
+		r := ssoRouterForRole(t, role, userID, tenantID)
+
+		for _, p := range ssoRoutePaths() {
+			if p[0] == http.MethodGet {
+				continue
+			}
+			req := httptest.NewRequest(p[0], "/admin/tenants/"+tenantID+p[1], nil)
+			req.Header.Set("X-User-Id", userID)
+			req.Header.Set("X-Tenant-Id", tenantID)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			require.Equal(t, http.StatusNotFound, w.Code, "%s %s as %s", p[0], p[1], role)
+		}
+	}
+}

--- a/services/marketplace-api/internal/stores/middleware.go
+++ b/services/marketplace-api/internal/stores/middleware.go
@@ -54,7 +54,9 @@ func StoreMiddleware(cfg MiddlewareConfig) gin.HandlerFunc {
 			return
 		}
 
-		result, refreshErr, _ := cfg.Flight.Do("store:"+storeID, func() (interface{}, error) {
+		// Key by tenant too: a shared key lets a concurrent request from
+		// another tenant piggyback on this refresh and receive its store.
+		result, refreshErr, _ := cfg.Flight.Do("store:"+tid+":"+storeID, func() (interface{}, error) {
 			return refresh(c.Request.Context(), cfg, storeID, tid)
 		})
 

--- a/services/marketplace-api/internal/stores/middleware_test.go
+++ b/services/marketplace-api/internal/stores/middleware_test.go
@@ -351,3 +351,104 @@ func TestMiddleware_SingleflightCoalescing(t *testing.T) {
 		t.Fatalf("singleflight: client calls got %d want 1", got)
 	}
 }
+
+// tenantScopedClient always returns a store owned by ownerTenant, whatever
+// tenant asks for it, and blocks inside GetStore until release is closed so a
+// second request has a window to join the singleflight.
+type tenantScopedClient struct {
+	ownerTenant string
+	entered     chan struct{}
+	release     chan struct{}
+	calls       atomic.Int64
+	once        sync.Once
+}
+
+func (c *tenantScopedClient) GetStore(_ context.Context, _, storeID string) (*stores.Store, error) {
+	c.calls.Add(1)
+	c.once.Do(func() {
+		close(c.entered)
+		<-c.release
+	})
+	s := newFixtureStore(time.Now())
+	s.ID = storeID
+	s.TenantID = c.ownerTenant
+	return s, nil
+}
+
+func (c *tenantScopedClient) GetStoreBySlug(_ context.Context, _ string) (*stores.Store, error) {
+	return nil, stores.ErrPlatformUnavailable
+}
+
+func buildRouterForTenant(cfg stores.MiddlewareConfig, p *probe, tenantID string, onEntry func()) *gin.Engine {
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("tenant_id", tenantID)
+		if onEntry != nil {
+			onEntry()
+		}
+	})
+	r.GET("/stores/:storeId", stores.StoreMiddleware(cfg), func(c *gin.Context) {
+		p.reached = true
+		if v, ok := c.Get("store"); ok {
+			p.store, _ = v.(*stores.Store)
+		}
+		c.String(http.StatusOK, "ok")
+	})
+	return r
+}
+
+// A concurrent request from another tenant must not piggyback on the
+// singleflight refresh of the owning tenant and receive its store.
+func TestStoreMiddleware_ConcurrentRefreshIsTenantScoped(t *testing.T) {
+	const otherTenantID = "33333333-3333-3333-3333-333333333333"
+
+	client := &tenantScopedClient{
+		ownerTenant: testTenantID,
+		entered:     make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+	flight := &singleflight.Group{}
+
+	ownerProbe := &probe{}
+	ownerCfg := baseCfg(newFakeRepo(), client)
+	ownerCfg.Flight = flight
+	ownerRouter := buildRouterForTenant(ownerCfg, ownerProbe, testTenantID, nil)
+
+	otherProbe := &probe{}
+	otherCfg := baseCfg(newFakeRepo(), client)
+	otherCfg.Flight = flight
+	otherEntered := make(chan struct{})
+	otherRouter := buildRouterForTenant(otherCfg, otherProbe, otherTenantID, func() {
+		close(otherEntered)
+	})
+
+	ownerDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() { ownerDone <- doRequest(ownerRouter) }()
+
+	<-client.entered
+
+	otherDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() { otherDone <- doRequest(otherRouter) }()
+
+	<-otherEntered
+	// Give the second request time to reach Flight.Do before the first
+	// refresh completes; without it the singleflight window never opens.
+	time.Sleep(50 * time.Millisecond)
+	close(client.release)
+
+	ownerRes := <-ownerDone
+	otherRes := <-otherDone
+
+	if ownerRes.Code != http.StatusOK {
+		t.Fatalf("owning tenant: got %d, want 200", ownerRes.Code)
+	}
+	if otherRes.Code != http.StatusNotFound {
+		t.Fatalf("foreign tenant: got %d, want 404", otherRes.Code)
+	}
+	if otherProbe.reached {
+		t.Fatal("foreign tenant reached the handler")
+	}
+	if got := client.calls.Load(); got != 2 {
+		t.Fatalf("platform client calls = %d, want 2 (one per tenant)", got)
+	}
+}

--- a/services/marketplace-api/pkg/config/config.go
+++ b/services/marketplace-api/pkg/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"errors"
 	"strings"
 	"time"
 
@@ -239,6 +240,19 @@ type Config struct {
 	PushOIDCServiceAccount string `envconfig:"PUSH_OIDC_SERVICE_ACCOUNT" default:""`
 }
 
+// Fail-closed boot errors. Each names a setting whose empty value disables a
+// control rather than breaking a feature, so an unset var must stop the boot.
+var (
+	ErrInternalAuthSecretRequired = errors.New(
+		"marketplace config: MARKETPLACE_INTERNAL_AUTH_SECRET must be set when ENV != \"dev\" (HeaderTrustAuth gates the whole admin surface)")
+	ErrCustomerSessionSecretRequired = errors.New(
+		"marketplace config: CUSTOMER_SESSION_SECRET must be set when ENV != \"dev\" (HMAC key for storefront customer sessions)")
+	ErrEncryptionModeRequired = errors.New(
+		"marketplace config: ENCRYPTION_MODE must be \"aes\" when ENV != \"dev\" (noop stores merchant provider secrets as base64)")
+	ErrEncryptionKeyRequired = errors.New(
+		"marketplace config: ENCRYPTION_KEY must be set when ENCRYPTION_MODE=aes")
+)
+
 // Load reads .env (if present) and binds environment variables into Config.
 func Load() (*Config, error) {
 	_ = godotenv.Load() // .env is optional
@@ -267,6 +281,36 @@ func Load() (*Config, error) {
 	// with "invalid header field value".
 	cfg.SendGridAPIKey = strings.TrimSpace(cfg.SendGridAPIKey)
 	cfg.ResendAPIKey = strings.TrimSpace(cfg.ResendAPIKey)
+	cfg.CustomerSessionSecret = strings.TrimSpace(cfg.CustomerSessionSecret)
+	cfg.EncryptionKey = strings.TrimSpace(cfg.EncryptionKey)
+	cfg.EncryptionMode = strings.ToLower(strings.TrimSpace(cfg.EncryptionMode))
+
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
 
 	return &cfg, nil
+}
+
+// Validate refuses to boot outside dev when a security-critical setting is
+// missing. Every one of these silently degrades to "no protection" when
+// empty, so an unset env var would ship an open service rather than a
+// broken one — the failure mode we can least afford to discover in prod.
+func (c *Config) Validate() error {
+	if c.Env == "dev" {
+		return nil
+	}
+	if c.InternalAuthSecret == "" {
+		return ErrInternalAuthSecretRequired
+	}
+	if c.CustomerSessionSecret == "" {
+		return ErrCustomerSessionSecretRequired
+	}
+	if c.EncryptionMode != "aes" {
+		return ErrEncryptionModeRequired
+	}
+	if c.EncryptionKey == "" {
+		return ErrEncryptionKeyRequired
+	}
+	return nil
 }

--- a/services/marketplace-api/pkg/config/config_test.go
+++ b/services/marketplace-api/pkg/config/config_test.go
@@ -86,3 +86,71 @@ func TestLoad_LoadsShippingCarrierCredentials(t *testing.T) {
 		t.Errorf("NinjaVanVNClientSecret = %q, want nv-vn-secret", cfg.NinjaVanVNClientSecret)
 	}
 }
+
+// prodEnv sets the minimum env for a non-dev Load, then lets the caller
+// override individual vars to assert each fail-closed check in isolation.
+func prodEnv(t *testing.T) {
+	t.Helper()
+	for k, v := range map[string]string{
+		"DATABASE_URL":                     "postgres://x/y",
+		"MARKETPLACE_FGA_API_URL":          "http://openfga:8080",
+		"ENV":                              "prod",
+		"MARKETPLACE_INTERNAL_AUTH_SECRET": "internal-secret",
+		"CUSTOMER_SESSION_SECRET":          "customer-secret",
+		"ENCRYPTION_MODE":                  "aes",
+		"ENCRYPTION_KEY":                   "0123456789abcdef0123456789abcdef",
+	} {
+		t.Setenv(k, v)
+	}
+}
+
+func TestLoad_ProdRequiresInternalAuthSecret(t *testing.T) {
+	prodEnv(t)
+	t.Setenv("MARKETPLACE_INTERNAL_AUTH_SECRET", "")
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() with empty MARKETPLACE_INTERNAL_AUTH_SECRET in prod = nil, want error")
+	}
+}
+
+func TestLoad_ProdRequiresCustomerSessionSecret(t *testing.T) {
+	prodEnv(t)
+	t.Setenv("CUSTOMER_SESSION_SECRET", "")
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() with empty CUSTOMER_SESSION_SECRET in prod = nil, want error")
+	}
+}
+
+func TestLoad_ProdRejectsNoopEncryption(t *testing.T) {
+	prodEnv(t)
+	t.Setenv("ENCRYPTION_MODE", "noop")
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() with ENCRYPTION_MODE=noop in prod = nil, want error")
+	}
+}
+
+func TestLoad_ProdRequiresEncryptionKeyForAES(t *testing.T) {
+	prodEnv(t)
+	t.Setenv("ENCRYPTION_KEY", "")
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() with ENCRYPTION_MODE=aes and empty ENCRYPTION_KEY = nil, want error")
+	}
+}
+
+func TestLoad_ProdSucceedsWhenFullyConfigured(t *testing.T) {
+	prodEnv(t)
+	if _, err := Load(); err != nil {
+		t.Fatalf("Load() with a complete prod config: %v", err)
+	}
+}
+
+func TestLoad_DevToleratesEmptySecrets(t *testing.T) {
+	prodEnv(t)
+	t.Setenv("ENV", "dev")
+	t.Setenv("MARKETPLACE_INTERNAL_AUTH_SECRET", "")
+	t.Setenv("CUSTOMER_SESSION_SECRET", "")
+	t.Setenv("ENCRYPTION_MODE", "noop")
+	t.Setenv("ENCRYPTION_KEY", "")
+	if _, err := Load(); err != nil {
+		t.Fatalf("Load() in dev with empty secrets: %v", err)
+	}
+}


### PR DESCRIPTION
Four backend fixes found in a security pass over the app.

**Cross-tenant store leak.** The store-projection middleware keyed its `singleflight` group on `storeId` alone. A concurrent request from tenant B naming tenant A's `storeId` piggybacked on A's in-flight refresh and received A's store — the tenant check only ran for the flight winner. The key now includes the tenant.

**SSO config was writable by any tenant member.** The routes carried the auth middleware and a plan gate but no role gate, so a viewer could overwrite or delete the tenant's IdP config — the thing that decides who can authenticate into the whole tenant. Reads now require admin, writes require owner, and authz runs before the plan gate so a non-member learns nothing about the tenant's subscription.

**Prod started with empty secrets.** `INTERNAL_AUTH_SECRET`, `CUSTOMER_SESSION_SECRET`, and the encryption mode/key are now required when `ENV != dev`, matching the pattern already used elsewhere. `AUDIT_INGEST_SECRET` and `MARKETPLACE_STOREFRONT_KEY` are deliberately left optional — they are `optional: true` in the chart and enforcing them would brick the deploy.

**Platform hostnames could be claimed as custom domains.** Nothing stopped a merchant registering `admin.mark8ly.com` or another store's `victim-store.mark8ly.com`. Reserved zones are now rejected, and lookalikes like `mark8ly.com.evil.io` still pass.

Also sets read/write/idle timeouts on the HTTP server.

Verified: `go build ./...`, `go vet ./...`, `go test ./...` all clean.