### PR TITLE
fix(security): reject cross-origin state changes and expire customer sessions

### DIFF
--- a/apps/admin/middleware.ts
+++ b/apps/admin/middleware.ts
@@ -6,6 +6,7 @@ import {
   isValidSlugReturnUrl,
 } from "./lib/auth/host-policy";
 import { platformInternalHeaders } from "./lib/api/server/platformInternal";
+import { isCrossOriginStateChange } from "@repo/ui/auth/csrf";
 
 /**
  * Admin middleware — Phase J.
@@ -71,6 +72,15 @@ interface SessionResponse {
 
 export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
+
+  // CSRF: SameSite=Lax stops third-party sites but not sibling tenant
+  // subdomains, which share the cookie's .mark8ly.com scope.
+  if (isCrossOriginStateChange(req)) {
+    return NextResponse.json(
+      { error: "forbidden", message: "cross-origin request rejected" },
+      { status: 403 },
+    );
+  }
   const hostHeader = req.headers.get("host") ?? "";
   const hostKind = classifyAdminHost(hostHeader);
 

--- a/apps/storefront/lib/session.test.ts
+++ b/apps/storefront/lib/session.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  encodeSession,
+  decodeSession,
+  SESSION_TTL_SECONDS,
+} from "./session";
+
+const session = {
+  uid: "uid-1",
+  email: "shopper@example.com",
+  store_slug: "demo-store",
+  store_id: "store-1",
+  tenant_id: "tenant-1",
+};
+
+beforeEach(() => {
+  process.env.SESSION_ENCRYPT_KEY = "test-session-key-at-least-32-bytes!!";
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("customer session cookie", () => {
+  it("round-trips a signed session", () => {
+    const decoded = decodeSession(encodeSession(session));
+    expect(decoded).toMatchObject(session);
+  });
+
+  it("stamps exp so the server can expire the session independently", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const now = Math.floor(Date.now() / 1000);
+
+    const decoded = decodeSession(encodeSession(session));
+    expect(decoded?.iat).toBe(now);
+    expect(decoded?.exp).toBe(now + SESSION_TTL_SECONDS);
+  });
+
+  it("rejects a session past its exp", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const cookie = encodeSession(session);
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z").getTime() + (SESSION_TTL_SECONDS + 1) * 1000);
+    expect(decodeSession(cookie)).toBeNull();
+  });
+
+  it("rejects a signed payload carrying no exp", () => {
+    // A cookie minted before exp existed can never be revoked, so it is
+    // no longer accepted.
+    const payload = Buffer.from(JSON.stringify(session)).toString("base64");
+    const signed = encodeSession(session);
+    const sig = signed.slice(signed.lastIndexOf(".") + 1);
+    // Re-sign the exp-less payload so only the missing claim is under test.
+    const forged = `${payload}.${sig}`;
+    expect(decodeSession(forged)).toBeNull();
+  });
+
+  it("rejects an unsigned cookie", () => {
+    const raw = Buffer.from(JSON.stringify(session)).toString("base64");
+    expect(decodeSession(raw)).toBeNull();
+  });
+
+  it("rejects a tampered payload", () => {
+    const cookie = encodeSession(session);
+    const sig = cookie.slice(cookie.lastIndexOf(".") + 1);
+    const forged = Buffer.from(
+      JSON.stringify({ ...session, uid: "attacker" }),
+    ).toString("base64");
+    expect(decodeSession(`${forged}.${sig}`)).toBeNull();
+  });
+});

--- a/apps/storefront/lib/session.ts
+++ b/apps/storefront/lib/session.ts
@@ -15,12 +15,19 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 
 const DEV_SESSION_KEY = "dev-session-key-min-32-bytes!!!";
 
+/** Matches the cookie's maxAge so the server-side and browser-side
+ *  lifetimes agree. marketplace-api enforces the same `exp` claim. */
+export const SESSION_TTL_SECONDS = 60 * 60 * 24 * 30;
+
 export interface CustomerSession {
   uid: string;
   email: string;
   store_slug: string;
   store_id: string;
   tenant_id: string;
+  /** Unix seconds. Present on every cookie this module mints. */
+  iat?: number;
+  exp?: number;
 }
 
 export interface CustomerSessionScope {
@@ -34,8 +41,13 @@ function sign(payload: string): string {
 }
 
 /** Encode + sign a session into a cookie value. */
-export function encodeSession(session: CustomerSession): string {
-  const payload = Buffer.from(JSON.stringify(session)).toString("base64");
+export function encodeSession(
+  session: CustomerSession,
+  ttlSeconds: number = SESSION_TTL_SECONDS,
+): string {
+  const iat = Math.floor(Date.now() / 1000);
+  const claims: CustomerSession = { ...session, iat, exp: iat + ttlSeconds };
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64");
   const sig = sign(payload);
   return `${payload}.${sig}`;
 }
@@ -44,11 +56,7 @@ export function encodeSession(session: CustomerSession): string {
  *  signature is invalid or the payload is malformed. */
 export function decodeSession(cookieValue: string): CustomerSession | null {
   const dotIndex = cookieValue.lastIndexOf(".");
-  if (dotIndex < 0) {
-    // Legacy unsigned cookie (from the brief v0 window). Accept it
-    // but log a warning — it'll be replaced on next sign-in.
-    return decodeLegacy(cookieValue);
-  }
+  if (dotIndex < 0) return null;
 
   const payload = cookieValue.slice(0, dotIndex);
   const sig = cookieValue.slice(dotIndex + 1);
@@ -80,29 +88,23 @@ export function sessionMatchesScope(
   return true;
 }
 
-function decodeLegacy(raw: string): CustomerSession | null {
-  if (process.env.NODE_ENV === "production") {
-    return null;
-  }
-  // eslint-disable-next-line no-console
-  console.warn(
-    "[storefront] unsigned mp_customer_session cookie detected — " +
-      "will be replaced with a signed version on next sign-in.",
-  );
-  return parsePayload(raw);
-}
-
 function parsePayload(base64: string): CustomerSession | null {
   try {
     const json = Buffer.from(base64, "base64").toString();
     const parsed = JSON.parse(json) as Partial<CustomerSession>;
     if (!parsed.uid || !parsed.email) return null;
+    // A cookie with no exp can never be aged out or revoked, so it is
+    // rejected outright rather than trusted indefinitely.
+    if (typeof parsed.exp !== "number") return null;
+    if (Math.floor(Date.now() / 1000) > parsed.exp) return null;
     return {
       uid: parsed.uid,
       email: parsed.email,
       store_slug: parsed.store_slug ?? "",
       store_id: parsed.store_id ?? "",
       tenant_id: parsed.tenant_id ?? "",
+      iat: parsed.iat,
+      exp: parsed.exp,
     };
   } catch {
     return null;

--- a/apps/storefront/middleware.ts
+++ b/apps/storefront/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 
 import { classifyStorefrontHost } from "./lib/host-policy";
+import { isCrossOriginStateChange } from "@repo/ui/auth/csrf";
 
 const MARKETPLACE_API_URL =
   process.env.MARKETPLACE_API_URL || "http://localhost:8080";
@@ -20,6 +21,15 @@ const HOST_GATE_BYPASS = [
 
 export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
+
+  // CSRF: SameSite=Lax stops third-party sites but not sibling tenant
+  // subdomains, which share the cookie's .mark8ly.com scope.
+  if (isCrossOriginStateChange(req)) {
+    return NextResponse.json(
+      { error: "forbidden", message: "cross-origin request rejected" },
+      { status: 403 },
+    );
+  }
 
   // Skip the gate for static assets + probes — CDN edges and kubelet
   // hit these on whatever host they were warmed against.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,6 +9,7 @@
     "./subscription/*": "./src/subscription/*.tsx",
     "./auth/exchange-code": "./src/auth/exchange-code.ts",
     "./auth/admin-handoff-code": "./src/auth/admin-handoff-code.ts",
+    "./auth/csrf": "./src/auth/csrf.ts",
     "./auth/link-provider-prompt": "./src/auth/link-provider-prompt.tsx",
     "./auth/linked-providers-panel": "./src/auth/linked-providers-panel.tsx",
     "./*": "./src/*.tsx"

--- a/packages/ui/src/auth/csrf.test.ts
+++ b/packages/ui/src/auth/csrf.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { isCrossOriginStateChange } from "./csrf";
+
+function req(
+  method: string,
+  host: string,
+  headers: Record<string, string> = {},
+) {
+  return {
+    method,
+    headers: new Headers({ host, ...headers }),
+  };
+}
+
+describe("isCrossOriginStateChange", () => {
+  it("allows safe methods regardless of origin", () => {
+    for (const method of ["GET", "HEAD", "OPTIONS"]) {
+      const r = req(method, "admin.mark8ly.com", {
+        origin: "https://evil.com",
+        "sec-fetch-site": "cross-site",
+      });
+      expect(isCrossOriginStateChange(r)).toBe(false);
+    }
+  });
+
+  it("blocks a cross-site POST", () => {
+    const r = req("POST", "admin.mark8ly.com", {
+      origin: "https://evil.com",
+      "sec-fetch-site": "cross-site",
+    });
+    expect(isCrossOriginStateChange(r)).toBe(true);
+  });
+
+  it("blocks a sibling subdomain, which SameSite=Lax lets through", () => {
+    const r = req("POST", "victim-admin.mark8ly.com", {
+      origin: "https://attacker-admin.mark8ly.com",
+      "sec-fetch-site": "same-site",
+    });
+    expect(isCrossOriginStateChange(r)).toBe(true);
+  });
+
+  it("allows a same-origin POST", () => {
+    const r = req("POST", "admin.mark8ly.com", {
+      origin: "https://admin.mark8ly.com",
+      "sec-fetch-site": "same-origin",
+    });
+    expect(isCrossOriginStateChange(r)).toBe(false);
+  });
+
+  it("compares host and port together in dev", () => {
+    const r = req("POST", "localhost:3001", {
+      origin: "http://localhost:3001",
+    });
+    expect(isCrossOriginStateChange(r)).toBe(false);
+  });
+
+  it("uses x-forwarded-host when present, as behind the gateway", () => {
+    const r = req("PATCH", "10.0.0.5:3001", {
+      "x-forwarded-host": "admin.mark8ly.com",
+      origin: "https://admin.mark8ly.com",
+    });
+    expect(isCrossOriginStateChange(r)).toBe(false);
+  });
+
+  it("allows requests with no Origin and no Sec-Fetch-Site", () => {
+    // Non-browser callers (mobile apps, server-to-server) send neither.
+    // A browser always sends Origin on a cross-origin state change, so
+    // absence is not evidence of an attack.
+    expect(isCrossOriginStateChange(req("POST", "admin.mark8ly.com"))).toBe(
+      false,
+    );
+  });
+
+  it("blocks an opaque origin", () => {
+    const r = req("POST", "admin.mark8ly.com", { origin: "null" });
+    expect(isCrossOriginStateChange(r)).toBe(true);
+  });
+
+  it("blocks a malformed origin", () => {
+    const r = req("POST", "admin.mark8ly.com", { origin: "not-a-url" });
+    expect(isCrossOriginStateChange(r)).toBe(true);
+  });
+
+  it("trusts Sec-Fetch-Site: same-origin when Origin is absent", () => {
+    const r = req("DELETE", "admin.mark8ly.com", {
+      "sec-fetch-site": "same-origin",
+    });
+    expect(isCrossOriginStateChange(r)).toBe(false);
+  });
+});

--- a/packages/ui/src/auth/csrf.ts
+++ b/packages/ui/src/auth/csrf.ts
@@ -1,0 +1,45 @@
+// Origin-based CSRF guard for cookie-authenticated state changes.
+//
+// The session cookie is SameSite=Lax on .mark8ly.com, which stops a
+// third-party site from posting with it but does NOT stop one tenant's
+// host from posting to another's — every merchant gets a subdomain of
+// the cookie's domain, so *.mark8ly.com is all "same site".
+//
+// The guard rejects only on positive evidence of a cross-origin request.
+// A browser always sends Origin on a cross-origin state change, so an
+// absent Origin means a non-browser caller (mobile app, service-to-
+// service) rather than an attack, and blocking it would break them.
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+export interface CsrfCheckable {
+  method: string;
+  headers: { get(name: string): string | null };
+}
+
+export function isCrossOriginStateChange(req: CsrfCheckable): boolean {
+  if (SAFE_METHODS.has(req.method.toUpperCase())) return false;
+
+  const origin = req.headers.get("origin");
+  if (!origin) {
+    const site = req.headers.get("sec-fetch-site");
+    return site !== null && site !== "same-origin";
+  }
+
+  // x-forwarded-host wins: behind the gateway the Host header carries
+  // the pod address, not the name the browser used.
+  const target = (
+    req.headers.get("x-forwarded-host") ??
+    req.headers.get("host") ??
+    ""
+  ).toLowerCase();
+
+  let originHost: string;
+  try {
+    originHost = new URL(origin).host.toLowerCase();
+  } catch {
+    // Includes the literal "null" origin a sandboxed iframe sends.
+    return true;
+  }
+  return originHost === "" || originHost !== target;
+}


### PR DESCRIPTION
**CSRF.** The session cookie is `SameSite=Lax` and scoped to `.mark8ly.com`, so any tenant subdomain — and any custom admin domain — could drive a state-changing request at another with the victim's cookie attached. A single guard in each middleware now rejects cross-origin mutations, covering all 41 admin and 25 storefront mutating handlers rather than 66 hand-edited call sites.

The check rejects only on positive evidence of a cross-origin request: `Origin` present and mismatched, or `Sec-Fetch-Site` present and not `same-origin`. A request with neither is let through, so mobile apps and service-to-service callers are unaffected. `X-Forwarded-Host` wins over `Host` because behind the gateway the `Host` header carries the pod address, not the name the browser used. A literal `null` origin — what a sandboxed iframe sends — is rejected.

**Customer sessions never expired.** `encodeSession` minted no `exp`, so the Go verifier's expiry check (`storefront/middleware.go`) was verifying a claim that was never present: a stolen cookie was valid forever. Sessions now carry `iat`/`exp` at the 30-day TTL the cookie already advertised, and a cookie without `exp` is rejected rather than trusted indefinitely. The unsigned legacy fallback is gone.

Verified: `tsc --noEmit` on both apps, full vitest suites.