### PR TITLE
fix(ci): pin dependabot/fetch-metadata to a commit SHA

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
A tag is mutable, and this step runs in a workflow that holds a write token.

Every other third-party action moved into the org's central reusable workflows since this was written, so this is the only one left in the repo. The `actions/*` steps stay on tags — first-party GitHub — and so does `tesserix-workflows`, where the versioned tag is the point of having it.

`github-actions` is already a Dependabot ecosystem here, so the pin gets update PRs rather than going stale.