### PR TITLE
fix(platformadmin): close the audit-drop and retention gaps, document the gateway JWT gate

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -274,6 +274,32 @@ than provider branching:
 - `OrderStatusGateway` — has no client-side signature, so confirmation
   polls the provider instead (Cashfree).
 
+## Gateway JWT gate (istio-ingress)
+
+The cluster's Istio ingress carries an `AuthorizationPolicy` named
+`require-customer-auth` (namespace `istio-ingress`, repo `tesserix-k8s`) that
+denies any request without a valid JWT to a fixed list of path prefixes,
+including `/api/v1/admin/*`, `/api/v1/staff/*`, `/api/v1/analytics/*`,
+`/api/v1/reports/*`, `/api/v1/orders/*`, `/api/v1/cart/*`,
+`/api/v1/payments/*`, and others. This runs at the mesh, before any
+`marketplace-api` handler sees the request.
+
+Any surface that authenticates by something other than a JWT — e.g.
+`marketplace-api`'s platform-console admin surface
+(`internal/handlers/platformadmin/`), which is HMAC-signed — must be mounted
+outside those prefixes, or the mesh rejects it with `403` and body
+`RBAC: access denied` before the app-level auth even runs. This is why that
+surface is mounted at `/api/v1/platform/...` rather than `/api/v1/admin/...`
+(see `internal/handlers/platformadmin/routes.go`).
+
+The failure only reproduces against the deployed cluster — Istio isn't part
+of local dev or CI, so a caller signing correctly against a JWT-gated prefix
+sees a `403` that looks like an auth bug on their end. If you hit a `403`
+with `RBAC: access denied` from `marketplace-api`, check whether the route
+is inside one of `require-customer-auth`'s prefixes before debugging the
+request signature — the policy itself lives in `tesserix-k8s`, not this
+repo.
+
 ## What's deliberately NOT here (yet)
 
 This slice ends at the welcome page. Everything below is next-phase

--- a/services/marketplace-api/internal/audit/prune_cron.go
+++ b/services/marketplace-api/internal/audit/prune_cron.go
@@ -162,6 +162,24 @@ func (c *PruneCron) pruneBucket(ctx context.Context, plans []subscription.Subscr
 		default:
 		}
 
+		// #311: tenant-scoped platform operator audit rows (store_id IS
+		// NULL — suspend/unsuspend/purge/trial-extend, possible since
+		// migration 000101) are never pruned on this timer. They're rare,
+		// individually consequential integrity records of privileged
+		// actions against a customer's tenant ("who suspended this tenant,
+		// and why"), unlike the high-volume, low-consequence merchant
+		// activity this retention policy targets. The INNER JOIN below
+		// already excludes them (it can't match a NULL store_id), but that
+		// exclusion is incidental — the explicit `a.store_id IS NOT NULL`
+		// makes it the policy. DO NOT remove this condition, and DO NOT
+		// change the JOIN to a LEFT JOIN without preserving it, or this
+		// prune will start deleting operator audit history with nothing to
+		// catch it.
+		//
+		// "Never pruned" means never pruned on this timer, not immune to
+		// deletion: internal/tenantpurge/purge.go:238 deletes audit_logs by
+		// tenant_id and still reaches these rows, so GDPR erasure and
+		// tenant deletion are unaffected by this guard.
 		res := c.db.WithContext(ctx).Exec(`
 			DELETE FROM audit_logs
 			WHERE id IN (
@@ -170,6 +188,7 @@ func (c *PruneCron) pruneBucket(ctx context.Context, plans []subscription.Subscr
 				JOIN store_subscriptions s ON s.store_id = a.store_id
 				WHERE s.plan IN ?
 				  AND a.created_at < ?
+				  AND a.store_id IS NOT NULL
 				LIMIT ?
 			)`,
 			planStrings, cutoff, c.batchSize,

--- a/services/marketplace-api/internal/audit/prune_cron_storeless_integration_test.go
+++ b/services/marketplace-api/internal/audit/prune_cron_storeless_integration_test.go
@@ -1,0 +1,83 @@
+//go:build integration
+
+package audit_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// TestPruneCronSkipsStoreLessRows proves #311's decision holds at the SQL
+// level, not just in a comment: a tenant-scoped platform operator audit row
+// (store_id IS NULL) survives a prune run, while an ordinary store-scoped
+// row on the same plan and well past its retention cutoff is deleted.
+//
+// The control row is the point of this test. Without it, an assertion that
+// only checks "the store-less row is still there" would pass even if the
+// prune silently no-oped — which is exactly the kind of regression the
+// `a.store_id IS NOT NULL` guard in pruneBucket exists to prevent someone
+// from introducing unnoticed (e.g. by changing the JOIN to a LEFT JOIN).
+func TestPruneCronSkipsStoreLessRows(t *testing.T) {
+	db := testdb.NewDB(t, "audit_logs", "store_subscriptions", "stores")
+	ctx := context.Background()
+
+	tenantID := uuid.New()
+	storeID := uuid.New()
+
+	// A real store + a starter-plan subscription, so the control row is
+	// eligible under the trial+starter 90-day bucket.
+	require.NoError(t, db.Exec(
+		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, synced_at, storefront_customer_portal_secret)
+		 VALUES (?, ?, ?, 'Test Store', 'US', 'USD', 'UTC', 'active', now(), ?)`,
+		storeID, tenantID, "prune-test-"+uuid.NewString()[:8], strings.Repeat("a", 64),
+	).Error)
+	require.NoError(t, db.Exec(
+		`INSERT INTO store_subscriptions (id, tenant_id, store_id, stripe_customer_id, plan, status, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, 'active', now(), now())`,
+		uuid.New(), tenantID, storeID, "cus_prune_test", string(subscription.PlanStarter),
+	).Error)
+
+	longAgo := time.Now().UTC().AddDate(0, 0, -200) // well past the 90-day starter cutoff
+
+	// Control row: ordinary store-scoped audit row, eligible for pruning.
+	// Its deletion is what proves the prune actually ran.
+	controlID := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO audit_logs (id, tenant_id, store_id, actor_type, action, resource_type, status, severity, created_at)
+		 VALUES (?, ?, ?, 'user', 'product.updated', 'product', 'success', 'info', ?)`,
+		controlID, tenantID, storeID, longAgo,
+	).Error)
+
+	// Store-less row: a platform operator action against the tenant, with
+	// no store. Created even further back so it would definitely have been
+	// eligible were it not for the store_id IS NOT NULL guard.
+	storelessID := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO audit_logs (id, tenant_id, store_id, actor_type, action, resource_type, status, severity, created_at)
+		 VALUES (?, ?, NULL, 'operator', 'tenant.suspended', 'tenant', 'success', 'warning', ?)`,
+		storelessID, tenantID, longAgo.AddDate(0, 0, -800),
+	).Error)
+
+	cron := audit.NewPruneCron(db, nil, nil, 0)
+	stats, err := cron.Run(ctx)
+	require.NoError(t, err)
+	require.Empty(t, stats.ErrorsByPlan, "prune bucket errors: %+v", stats.ErrorsByPlan)
+	require.GreaterOrEqual(t, stats.RowsDeleted, int64(1), "prune must have deleted at least the control row")
+
+	var controlCount int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM audit_logs WHERE id = ?`, controlID).Scan(&controlCount).Error)
+	require.Equal(t, int64(0), controlCount, "control row (store-scoped, past cutoff) must be deleted by the prune")
+
+	var storelessCount int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM audit_logs WHERE id = ?`, storelessID).Scan(&storelessCount).Error)
+	require.Equal(t, int64(1), storelessCount, "store-less operator audit row must survive the prune (#311)")
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/audit.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/audit.go
@@ -1,0 +1,35 @@
+package platformadmin
+
+import (
+	"errors"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+)
+
+// ErrMissingTenant is returned by EmitOperatorAction when the caller passes
+// uuid.Nil for tenantID.
+var ErrMissingTenant = errors.New("platformadmin: EmitOperatorAction requires a non-nil tenant ID")
+
+// EmitOperatorAction records a platform-operator action against a tenant.
+//
+// The tenant is a REQUIRED parameter rather than something pulled from the
+// gin context, because nothing on this surface sets `tenant_id` — see #310.
+// audit.Emit would otherwise silently drop the event.
+//
+// Returns an error when the tenant is missing, so a caller cannot ignore
+// the failure the way it can ignore a dropped Emit.
+func EmitOperatorAction(c *gin.Context, em *audit.Emitter, tenantID uuid.UUID, ev audit.Event) error {
+	if tenantID == uuid.Nil {
+		return ErrMissingTenant
+	}
+	if em == nil {
+		return nil // safe to call when wiring opted out, matching Emit's own nil-receiver tolerance
+	}
+
+	ev.TenantID = tenantID
+	em.Emit(c, ev)
+	return nil
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/audit_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/audit_test.go
@@ -1,0 +1,172 @@
+package platformadmin_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+)
+
+// recordingRepo is a stub audit.Repository that records every entry handed
+// to Create, so tests can prove an event was (or was not) enqueued without
+// a database. Access is guarded by a mutex because the emitter writes from
+// a worker goroutine.
+type recordingRepo struct {
+	mu      sync.Mutex
+	created []audit.Entry
+}
+
+func (r *recordingRepo) Create(_ context.Context, _ *gorm.DB, e *audit.Entry) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.created = append(r.created, *e)
+	return nil
+}
+
+func (r *recordingRepo) List(context.Context, *gorm.DB, audit.ListFilter) (audit.ListResult, error) {
+	return audit.ListResult{}, nil
+}
+
+func (r *recordingRepo) Stream(context.Context, *gorm.DB, audit.ListFilter, func(*audit.Entry) error) error {
+	return nil
+}
+
+func (r *recordingRepo) ListPlatform(context.Context, *gorm.DB, audit.PlatformListFilter) (audit.ListResult, error) {
+	return audit.ListResult{}, nil
+}
+
+func (r *recordingRepo) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.created)
+}
+
+func (r *recordingRepo) first() audit.Entry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.created[0]
+}
+
+func newTestEmitter(t *testing.T, repo audit.Repository) *audit.Emitter {
+	t.Helper()
+	em := audit.NewEmitter(audit.EmitterConfig{
+		Repo:   repo,
+		Logger: slog.New(slog.NewTextHandler(httptest.NewRecorder().Body, nil)),
+	})
+	t.Cleanup(func() { em.Stop(context.Background()) })
+	return em
+}
+
+// TestEmitOperatorAction_NilTenant_RejectsAndEmitsNothing pins #310's
+// compile-time-safety requirement: a caller that forgets to supply a
+// tenant gets an error back, and — proven via a recording repository,
+// not merely the error return — nothing is ever enqueued for write.
+func TestEmitOperatorAction_NilTenant_RejectsAndEmitsNothing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &recordingRepo{}
+	em := newTestEmitter(t, repo)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest(http.MethodPost, "/", nil)
+
+	err := platformadmin.EmitOperatorAction(c, em, uuid.Nil, audit.Event{
+		Action:       "tenant.suspended",
+		ResourceType: "tenant",
+	})
+
+	require.ErrorIs(t, err, platformadmin.ErrMissingTenant)
+
+	// Give the (nonexistent) async write every chance to happen before
+	// asserting it didn't: if EmitOperatorAction had called em.Emit
+	// despite the nil tenant, the worker would have written it well
+	// within this window.
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, 0, repo.count(), "no audit row should ever be enqueued for a nil tenant")
+}
+
+// TestEmitOperatorAction_ValidTenant_EnqueuesWithTenantID proves the
+// happy path populates Event.TenantID before delegating to Emit, so the
+// gin-context lookup (which nothing sets on this surface) is never relied
+// on.
+func TestEmitOperatorAction_ValidTenant_EnqueuesWithTenantID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &recordingRepo{}
+	em := newTestEmitter(t, repo)
+
+	tenantID := uuid.New()
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest(http.MethodPost, "/", nil)
+
+	err := platformadmin.EmitOperatorAction(c, em, tenantID, audit.Event{
+		Action:       "tenant.suspended",
+		ResourceType: "tenant",
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool { return repo.count() == 1 }, time.Second, 5*time.Millisecond,
+		"expected exactly one audit row to be written")
+	entry := repo.first()
+	require.Equal(t, tenantID, entry.TenantID)
+	require.Equal(t, "tenant.suspended", entry.Action)
+}
+
+// TestEmitOperatorAction_NilEmitter_NoPanicNoError matches Emit's own
+// nil-receiver tolerance: wiring that opts out of auditing (em == nil)
+// must not panic or surface an error.
+func TestEmitOperatorAction_NilEmitter_NoPanicNoError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest(http.MethodPost, "/", nil)
+
+	var em *audit.Emitter
+	require.NotPanics(t, func() {
+		err := platformadmin.EmitOperatorAction(c, em, uuid.New(), audit.Event{
+			Action:       "tenant.suspended",
+			ResourceType: "tenant",
+		})
+		require.NoError(t, err)
+	})
+}
+
+// TestEmitOperatorAction_OperatorContextFlowsThrough proves the operator
+// and capability context keys set by platform middleware still reach the
+// written entry through EmitOperatorAction — i.e. it doesn't bypass
+// buildEntry's context-derived attribution, it only forces TenantID.
+func TestEmitOperatorAction_OperatorContextFlowsThrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &recordingRepo{}
+	em := newTestEmitter(t, repo)
+
+	tenantID := uuid.New()
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest(http.MethodPost, "/", nil)
+	c.Set(platformadmin.CtxOperatorID, "op_7f3a")
+	c.Set(platformadmin.CtxCapability, "tenant.suspend")
+
+	err := platformadmin.EmitOperatorAction(c, em, tenantID, audit.Event{
+		Action:       "tenant.suspended",
+		ResourceType: "tenant",
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool { return repo.count() == 1 }, time.Second, 5*time.Millisecond,
+		"expected exactly one audit row to be written")
+	entry := repo.first()
+	require.Equal(t, tenantID, entry.TenantID)
+	require.Equal(t, audit.ActorOperator, entry.ActorType)
+	require.NotNil(t, entry.ActorOperatorID)
+	require.Equal(t, "op_7f3a", *entry.ActorOperatorID)
+	require.NotNil(t, entry.Capability)
+	require.Equal(t, "tenant.suspend", *entry.Capability)
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -28,6 +28,26 @@ type Deps struct {
 // Register mounts the platform console's /admin/* surface behind
 // RequirePlatformAuth. A nil Repo leaves everything unmounted, matching the
 // nil-safe pattern used for optional handlers in internal/handlers/admin.
+//
+// Callers always mount this under /api/v1/platform (see cmd/marketplace-api/
+// main.go) — never under /api/v1/admin, deliberately, for two reasons:
+//
+//  1. The mesh. An Istio AuthorizationPolicy in the cluster,
+//     `require-customer-auth` (namespace istio-ingress, repo tesserix-k8s),
+//     denies any request without a valid JWT to a fixed list of prefixes
+//     that includes /api/v1/admin/*. This surface authenticates by HMAC
+//     signature, not JWT, so mounting it under /api/v1/admin/* gets every
+//     request rejected with 403 "RBAC: access denied" at the mesh — before
+//     it ever reaches this package. See docs/architecture.md, "Gateway JWT
+//     gate (istio-ingress)", for the full writeup. This is invisible
+//     locally and in CI since Istio isn't part of either.
+//  2. The router. The merchant admin tree already registers
+//     /admin/tenants/:tenantId/... under a wildcard name that a later
+//     platform endpoint would collide with under a different wildcard name
+//     at the same path position — gin panics at router build time when
+//     that happens.
+//
+// Do not "tidy" this back onto /api/v1/admin.
 func Register(g *gin.RouterGroup, deps Deps) {
 	if deps.Repo == nil {
 		return


### PR DESCRIPTION
Closes #310. Closes #311. Closes #312.

Three follow-ups from the platform console admin surface (#292, #302). Two are safety work on failure modes that are currently *latent* — nothing is broken today, and that is precisely why they are cheap to fix now and expensive to fix after the write endpoints land.

## #310 — platform writes could silently drop their audit row

`audit.Emit` is fire-and-forget by design and must never gate a business request. When no tenant resolves, `buildEntry` returns nil and the event is dropped — logged since #292, but dropped.

That is a live trap on this surface specifically: **`RequirePlatformAuth` is the only middleware mounted on it, and nothing sets `tenant_id` on the gin context.** The merchant surface gets it from `HeaderTrustAuth`; the platform surface has no equivalent. So every write endpoint (#281, #286, #287, #288) would have to *remember* to set `Event.TenantID`, and a handler that forgot would succeed while writing no audit row — the exact silent-attribution loss #275 exists to eliminate, reintroduced through a different door.

Rather than document the convention, `EmitOperatorAction` makes the tenant a **required parameter**:

```go
func EmitOperatorAction(c *gin.Context, em *audit.Emitter, tenantID uuid.UUID, ev audit.Event) error
```

A handler cannot forget it — it will not compile. `uuid.Nil` returns `ErrMissingTenant` and emits nothing, so the failure is returned rather than swallowed. The nil-tenant check runs *before* the nil-emitter check, so the programming error surfaces even where auditing is wired out.

`audit.Emit` itself is unchanged; other callers are unaffected.

The test proves the negative with a recording repository: on a nil tenant, **nothing is enqueued** — not merely that an error came back.

## #311 — store-less audit rows are never pruned, now deliberately

Decision recorded on the issue: tenant-scoped operator actions are retained indefinitely. They are rare, individually consequential integrity records of privileged actions, unlike the high-volume merchant activity the per-plan retention model exists to bound.

**This was already the behaviour — by accident.** `pruneBucket`'s inner join on `store_subscriptions` cannot match `store_id IS NULL`. So the change is not a behaviour fix; it is making the exclusion durable:

- An explicit `AND a.store_id IS NOT NULL`, redundant against the join *on purpose*
- A comment recording the decision and warning against removing it
- A test asserting a store-less row survives

Without that, someone "fixing" the join to a `LEFT JOIN` — a reasonable-looking change — would quietly start deleting operator actions with nothing to catch it.

**"Never pruned" means never pruned on a timer, not immune to deletion.** `internal/tenantpurge/purge.go:238` deletes by `tenant_id` and still reaches these rows, so GDPR erasure and tenant deletion are unaffected. Accepted cost: unbounded growth on a shared `db-f1-micro`, bounded in practice because these accrue at human speed.

The test uses a **control row that does get deleted** alongside the store-less one that survives. Asserting only "the row is still there" would pass if the prune silently no-opped — which would hide exactly the regression the test exists to catch. Verified: `rows_deleted=1` for the control, while a 1000-day-old operator row survived.

## #312 — the gateway JWT policy is now documented

An Istio `AuthorizationPolicy` (`require-customer-auth`, namespace `istio-ingress`) denies any request without a valid JWT to a path list including `/api/v1/admin/*`, `/api/v1/staff/*`, `/api/v1/analytics/*`, `/api/v1/reports/*`.

The platform admin surface authenticates by HMAC signature, not JWT, so mounting it under `/api/v1/admin/` produced `403 RBAC: access denied` **before the application saw the request** — invisible locally and in CI, and indistinguishable from a caller-side signing bug. It cost real debugging time and was found only by probing the deployed cluster. Nothing in this repo mentioned the policy existed.

Now documented in two places aimed at whoever hits it next: a comment block in `platformadmin/routes.go` (where someone adding an endpoint reads), and a section in `docs/architecture.md`.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./... -count=1` — 0 failures
- [x] Integration suites (`internal/audit/...`, `internal/handlers/platformadmin/...`) clean
- [x] `TestPruneCronSkipsStoreLessRows` — control row deleted, store-less row survived
- [x] Nil-tenant emits nothing, proven via a recording repository
- [x] `scripts/ci/verify-logging-smoke.sh` passes

## Two pre-existing issues noticed, not fixed

Both are local-stack seed-data problems, unrelated to this branch and left untouched:

- `internal/subscription/dunning` — 16 integration tests fail on a missing `stores` seed row (already known)
- `internal/tenantpurge` — integration test fails on an `fx_rates` seed (`value too long for type character(3)`). Same class, different table. Found while seeding this branch's control row.

Also worth a separate cleanup: `docs/architecture.md` scopes itself to the older "onboarding slice" and its closing section still says `marketplace-api` is "deliberately NOT here (yet)", which is long out of date. The new section was added anyway since it is the only `architecture.md` in the repo; the stale claim was left alone as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCy84rLD5XVchzo6eBRuba
