### PR TITLE
fix(dunning): repair the integration suite and the billing bug it was hiding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,14 +51,27 @@ test-int: ## Run integration tests against the running `make dev` stack
 	  TEST_DATABASE_URL='postgres://dev:dev@localhost:5432/auth_bff?sslmode=disable' \
 	  go test -tags=integration ./...
 	@echo "▶ marketplace-api integration"
-	@# Scoped to ./internal/audit/... and ./internal/handlers/platformadmin/...
-	@# (not ./...): internal/subscription/dunning has 16 integration tests that
-	@# fail on a pre-existing missing "stores" seed row gap in the local stack
-	@# (unrelated to this task — parked/escalated separately). Once that seed
-	@# gap is closed, widen this target to ./...
+	@# -p 1: these share one local Postgres, and parallel package execution
+	@# exhausts its connection limit ("sorry, too many clients already").
+	@#
+	@# Scoped to the packages whose fixtures are currently correct, NOT ./... —
+	@# the rest fail on schema drift: migrations added NOT NULL columns and FKs
+	@# without updating test fixtures (products.vendor_id, store_subscriptions'
+	@# store FK, stores.storefront_customer_portal_secret, an apikeys varchar(60)
+	@# overflow, orderrefund cleanup deadlocks, and a nil-Repo panic in
+	@# whitelabel/lifecycle). Tracked separately.
+	@#
+	@# Widen this one package at a time as each cluster is fixed. A permanently
+	@# red target is worse than a narrow green one: this suite was dark long
+	@# enough to hide a production dunning bug (see the sql.NullTime fix in
+	@# internal/subscription/dunning/ladder.go).
 	@cd services/marketplace-api && \
 	  TEST_DATABASE_URL='postgres://dev:dev@localhost:5432/marketplace_db?sslmode=disable' \
-	  go test -tags=integration ./internal/audit/... ./internal/handlers/platformadmin/...
+	  go test -tags=integration -p 1 \
+	    ./internal/audit/... \
+	    ./internal/handlers/platformadmin/... \
+	    ./internal/tenantpurge/... \
+	    ./internal/subscription/dunning/...
 
 cover: ## Coverage report for both Go services
 	@cd services/platform-api && go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out | tail -5

--- a/services/marketplace-api/internal/subscription/dunning/criterion_38_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/criterion_38_integration_test.go
@@ -28,6 +28,7 @@ func TestCriterion38_DunningLeavesPaymentActionRequiredAlone(t *testing.T) {
 
 	storeID := uuid.New()
 	tenantID := uuid.New()
+	seedStore(t, db, tenantID, storeID)
 	hostedURL := "https://stripe.example/i/criterion38"
 
 	// FirstChargeAt 30 days ago simulates an established sub — well outside the

--- a/services/marketplace-api/internal/subscription/dunning/dunning_emails_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/dunning_emails_integration_test.go
@@ -55,6 +55,7 @@ func TestSendDunningEmails_SendsOnDay5AndDay7(t *testing.T) {
 	// Sub A: entered past_due 5 days ago.
 	storeA := uuid.New()
 	tenantA := uuid.New()
+	seedStore(t, db, tenantA, storeA)
 	subA := subscription.StoreSubscription{
 		ID:               uuid.New(),
 		TenantID:         tenantA,
@@ -85,6 +86,7 @@ func TestSendDunningEmails_SendsOnDay5AndDay7(t *testing.T) {
 	// Sub B: entered past_due 7 days ago.
 	storeB := uuid.New()
 	tenantB := uuid.New()
+	seedStore(t, db, tenantB, storeB)
 	subB := subscription.StoreSubscription{
 		ID:               uuid.New(),
 		TenantID:         tenantB,
@@ -133,6 +135,7 @@ func TestSendDunningEmails_NoEmailIfSubNoLongerPastDue(t *testing.T) {
 
 	storeID := uuid.New()
 	tenantID := uuid.New()
+	seedStore(t, db, tenantID, storeID)
 	sub := subscription.StoreSubscription{
 		ID:               uuid.New(),
 		TenantID:         tenantID,

--- a/services/marketplace-api/internal/subscription/dunning/ladder.go
+++ b/services/marketplace-api/internal/subscription/dunning/ladder.go
@@ -2,6 +2,7 @@ package dunning
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -193,7 +194,12 @@ func (s *StepDailyLadder) transition(ctx context.Context, tx *gorm.DB, fresh *su
 // Note: the audit emitter stores "to_status" (not "to_state") per
 // audit.EmitStateTransition's metadata keys.
 func statusEnteredAt(ctx context.Context, tx *gorm.DB, storeID any, status subscription.SubscriptionStatus, fallback time.Time) (time.Time, error) {
-	var enteredAt *time.Time
+	// sql.NullTime, not *time.Time: MAX() over zero matching rows returns a
+	// single NULL row rather than no rows, and a plain *time.Time (a
+	// **time.Time destination once you take its address) cannot Scan a SQL
+	// NULL — the driver errors instead of leaving it nil. NullTime is the
+	// only way to let the "no audit row yet" case reach the fallback below.
+	var enteredAt sql.NullTime
 	err := tx.WithContext(ctx).
 		Raw(`
 			SELECT MAX(created_at)
@@ -206,8 +212,8 @@ func statusEnteredAt(ctx context.Context, tx *gorm.DB, storeID any, status subsc
 	if err != nil {
 		return fallback, err
 	}
-	if enteredAt == nil {
+	if !enteredAt.Valid {
 		return fallback, nil
 	}
-	return *enteredAt, nil
+	return enteredAt.Time, nil
 }

--- a/services/marketplace-api/internal/subscription/dunning/ladder_e2e_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/ladder_e2e_integration_test.go
@@ -73,13 +73,17 @@ func TestE2E_FullLadder_PastDueToPendingDelete(t *testing.T) {
 	// --- Step 1: transition active → past_due, backdate to 9 days ago ---
 	nineDaysAgo := time.Now().UTC().Add(-9 * 24 * time.Hour)
 
-	if err := db.Exec(`
+	res := db.Exec(`
 		UPDATE store_subscriptions
 		SET status = ?, updated_at = ?
 		WHERE store_id = ?`,
 		string(subscription.StatusPastDue), nineDaysAgo, storeID,
-	).Error; err != nil {
-		t.Fatalf("set past_due: %v", err)
+	)
+	if res.Error != nil {
+		t.Fatalf("set past_due: %v", res.Error)
+	}
+	if res.RowsAffected != 1 {
+		t.Fatalf("set past_due: expected 1 row updated, got %d — the seeded sub is missing", res.RowsAffected)
 	}
 
 	auditPastDue := audit.Entry{
@@ -113,17 +117,26 @@ func TestE2E_FullLadder_PastDueToPendingDelete(t *testing.T) {
 		t.Fatalf("step 1: expected expired, got %q", afterStep1.Status)
 	}
 
-	// --- Step 3: backdate the expired audit row to 15 days ago, run ladder → store_closed ---
+	// --- Step 3: seed a backdated "entered expired" audit row (15 days ago), run ladder → store_closed ---
+	// The ladder itself never writes this row (nil emitter, see below), so —
+	// same as step 1 — the test seeds it directly rather than mutating a row
+	// that doesn't exist. db.Exec-ing an UPDATE that matches zero rows does
+	// not error, which is exactly what silently broke this step before.
 	fifteenDaysAgo := now.Add(-15 * 24 * time.Hour)
-	if err := db.Exec(`
-		UPDATE audit_logs
-		SET created_at = ?
-		WHERE store_id = ?
-		  AND action = 'subscription.state_transition'
-		  AND metadata->>'to_status' = 'expired'`,
-		fifteenDaysAgo, storeID,
-	).Error; err != nil {
-		t.Fatalf("backdate expired audit: %v", err)
+	auditExpired := audit.Entry{
+		ID:           uuid.New(),
+		TenantID:     tenantID,
+		StoreID:      &storeID,
+		ActorType:    audit.ActorSystem,
+		Action:       "subscription.state_transition",
+		ResourceType: "subscription",
+		Status:       audit.StatusSuccess,
+		Severity:     audit.SeverityWarning,
+		Metadata:     audit.Metadata{"from_status": "past_due", "to_status": "expired"},
+		CreatedAt:    fifteenDaysAgo,
+	}
+	if err := db.Create(&auditExpired).Error; err != nil {
+		t.Fatalf("seed audit expired: %v", err)
 	}
 
 	ladder2 := dunning.NewStepDailyLadder(db, nil, slog.Default(), nil, fixedClock(now))
@@ -139,17 +152,22 @@ func TestE2E_FullLadder_PastDueToPendingDelete(t *testing.T) {
 		t.Fatalf("step 2: expected store_closed, got %q", afterStep2.Status)
 	}
 
-	// --- Step 4: backdate the store_closed audit row to 91 days ago, run ladder → pending_hard_delete ---
+	// --- Step 4: seed a backdated "entered store_closed" audit row (91 days ago), run ladder → pending_hard_delete ---
 	ninetyOneDaysAgo := now.Add(-91 * 24 * time.Hour)
-	if err := db.Exec(`
-		UPDATE audit_logs
-		SET created_at = ?
-		WHERE store_id = ?
-		  AND action = 'subscription.state_transition'
-		  AND metadata->>'to_status' = 'store_closed'`,
-		ninetyOneDaysAgo, storeID,
-	).Error; err != nil {
-		t.Fatalf("backdate store_closed audit: %v", err)
+	auditStoreClosed := audit.Entry{
+		ID:           uuid.New(),
+		TenantID:     tenantID,
+		StoreID:      &storeID,
+		ActorType:    audit.ActorSystem,
+		Action:       "subscription.state_transition",
+		ResourceType: "subscription",
+		Status:       audit.StatusSuccess,
+		Severity:     audit.SeverityWarning,
+		Metadata:     audit.Metadata{"from_status": "expired", "to_status": "store_closed"},
+		CreatedAt:    ninetyOneDaysAgo,
+	}
+	if err := db.Create(&auditStoreClosed).Error; err != nil {
+		t.Fatalf("seed audit store_closed: %v", err)
 	}
 
 	ladder3 := dunning.NewStepDailyLadder(db, nil, slog.Default(), nil, fixedClock(now))

--- a/services/marketplace-api/internal/subscription/dunning/ladder_e2e_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/ladder_e2e_integration_test.go
@@ -55,6 +55,7 @@ func TestE2E_FullLadder_PastDueToPendingDelete(t *testing.T) {
 
 	storeID := uuid.New()
 	tenantID := uuid.New()
+	seedStore(t, db, tenantID, storeID)
 
 	// Seed the subscription as active.
 	sub := subscription.StoreSubscription{
@@ -192,6 +193,7 @@ func TestE2E_RefundWindow_BlocksPastDueToExpired(t *testing.T) {
 
 	storeID := uuid.New()
 	tenantID := uuid.New()
+	seedStore(t, db, tenantID, storeID)
 
 	// FirstChargeAt is 3 days ago — within the 14-day refund window.
 	threeDaysAgo := time.Now().UTC().Add(-3 * 24 * time.Hour)

--- a/services/marketplace-api/internal/subscription/dunning/ladder_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/ladder_integration_test.go
@@ -22,6 +22,7 @@ func TestLadder_PastDue_TransitionsToExpired(t *testing.T) {
 
 	storeID := uuid.New()
 	tenantID := uuid.New()
+	seedStore(t, db, tenantID, storeID)
 	eighteenDaysAgo := time.Now().UTC().Add(-18 * 24 * time.Hour)
 
 	sub := subscription.StoreSubscription{
@@ -62,6 +63,7 @@ func TestLadder_PastDue_InRefundWindow_NotAdvanced(t *testing.T) {
 
 	storeID := uuid.New()
 	tenantID := uuid.New()
+	seedStore(t, db, tenantID, storeID)
 	thirtyDaysAgo := time.Now().UTC().Add(-30 * 24 * time.Hour)
 	sevenDaysAgo := time.Now().UTC().Add(-7 * 24 * time.Hour)
 

--- a/services/marketplace-api/internal/subscription/dunning/payment_action_reminders_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/payment_action_reminders_integration_test.go
@@ -39,6 +39,7 @@ func TestSCAReminders_SendsAtT14T7T1(t *testing.T) {
 	for _, o := range offsets {
 		storeID := uuid.New()
 		tenantID := uuid.New()
+		seedStore(t, db, tenantID, storeID)
 		sub := subscription.StoreSubscription{
 			ID:               uuid.New(),
 			TenantID:         tenantID,
@@ -89,6 +90,7 @@ func TestSCAReminders_Idempotent_OnConflict(t *testing.T) {
 	hostedURL := "https://invoice.stripe.com/i/idempotency-test"
 	storeID := uuid.New()
 	tenantID := uuid.New()
+	seedStore(t, db, tenantID, storeID)
 	fourteenDaysAgo := now.AddDate(0, 0, -14)
 
 	sub := subscription.StoreSubscription{
@@ -148,6 +150,7 @@ func TestSCAReminders_SkipsSubsWithoutHostedInvoiceURL(t *testing.T) {
 	now := time.Now().UTC()
 	storeID := uuid.New()
 	tenantID := uuid.New()
+	seedStore(t, db, tenantID, storeID)
 	fourteenDaysAgo := now.AddDate(0, 0, -14)
 
 	sub := subscription.StoreSubscription{

--- a/services/marketplace-api/internal/subscription/dunning/sca_recovery_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/sca_recovery_integration_test.go
@@ -35,6 +35,7 @@ func TestSCARecovery_WebhookPaymentActionRequired_SCAReminders_InvoicePaidClears
 
 	storeID := uuid.New()
 	tenantID := uuid.New()
+	seedStore(t, db, tenantID, storeID)
 	stripeCustomerID := "cus_sca_recovery_" + storeID.String()[:8]
 	hostedURL := "https://stripe.example/i/test"
 

--- a/services/marketplace-api/internal/subscription/dunning/testhelpers_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/testhelpers_integration_test.go
@@ -1,0 +1,47 @@
+//go:build integration
+
+package dunning_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// seedStore inserts a minimal stores row for (tenantID, storeID) so that a
+// store_subscriptions row referencing storeID satisfies
+// store_subscriptions_store_id_fkey.
+//
+// Unlike internal/order's seedStore helper, tenantID is supplied by the
+// caller rather than generated here: dunning tests already mint their own
+// tenantID for the subscription/audit rows they seed, and the store must
+// carry that same tenant — otherwise the subscription and its store
+// disagree about tenancy and any tenant-scoped assertion becomes
+// meaningless.
+//
+// Registers a t.Cleanup that deletes the store row so consecutive test runs
+// start from a clean state. No per-store sequences are dropped here (unlike
+// internal/order's helper) — dunning doesn't touch order/return numbering.
+func seedStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
+	t.Helper()
+
+	// Slug is derived from the store id to dodge the stores_slug_unique
+	// constraint when multiple tests (or multiple stores within one test)
+	// run in the same package.
+	slug := "tst-" + strings.ReplaceAll(storeID.String(), "-", "")[:20]
+
+	err := db.Exec(
+		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, encode(gen_random_bytes(32), 'hex'))`,
+		storeID, tenantID, slug, "Test Store", "IE", "EUR", "Europe/Dublin", "active",
+	).Error
+	if err != nil {
+		t.Fatalf("seedStore: insert stores row: %v", err)
+	}
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM stores WHERE id = ?", storeID)
+	})
+}

--- a/services/marketplace-api/internal/subscription/dunning/trial_reminders_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/trial_reminders_integration_test.go
@@ -48,10 +48,13 @@ func TestTrialReminders_SendsAtAllNoPMOffsets(t *testing.T) {
 		// when "now" is itself near midnight UTC.
 		created := time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, time.UTC).
 			AddDate(0, 0, -c.daysSinceSignup)
+		tenantID := uuid.New()
+		storeID := uuid.New()
+		seedStore(t, db, tenantID, storeID)
 		sub := subscription.StoreSubscription{
 			ID:                      uuid.New(),
-			TenantID:                uuid.New(),
-			StoreID:                 uuid.New(),
+			TenantID:                tenantID,
+			StoreID:                 storeID,
 			StripeCustomerID:        "cus_" + c.desc,
 			Plan:                    subscription.PlanTrial,
 			Status:                  subscription.StatusTrialing,
@@ -95,10 +98,13 @@ func TestTrialReminders_HasPMSendsOnlyT1(t *testing.T) {
 	// Sub created 89 days ago with PM on file → only 'has_pm_t_minus_1' fires.
 	created := time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, time.UTC).
 		AddDate(0, 0, -(trial.TrialDays - 1))
+	tenantID := uuid.New()
+	storeID := uuid.New()
+	seedStore(t, db, tenantID, storeID)
 	sub := subscription.StoreSubscription{
 		ID:                      uuid.New(),
-		TenantID:                uuid.New(),
-		StoreID:                 uuid.New(),
+		TenantID:                tenantID,
+		StoreID:                 storeID,
 		StripeCustomerID:        "cus_haspm",
 		Plan:                    subscription.PlanStarter,
 		Status:                  subscription.StatusTrialing,
@@ -133,10 +139,13 @@ func TestTrialReminders_Idempotent(t *testing.T) {
 
 	created := time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, time.UTC).
 		AddDate(0, 0, -(trial.TrialDays - 7))
+	tenantID := uuid.New()
+	storeID := uuid.New()
+	seedStore(t, db, tenantID, storeID)
 	sub := subscription.StoreSubscription{
 		ID:                      uuid.New(),
-		TenantID:                uuid.New(),
-		StoreID:                 uuid.New(),
+		TenantID:                tenantID,
+		StoreID:                 storeID,
 		StripeCustomerID:        "cus_idem",
 		Plan:                    subscription.PlanTrial,
 		Status:                  subscription.StatusTrialing,
@@ -179,10 +188,13 @@ func TestTrialReminders_TenantIsolation(t *testing.T) {
 		AddDate(0, 0, -(trial.TrialDays - 3))
 
 	for _, suffix := range []string{"a", "b"} {
+		tenantID := uuid.New()
+		storeID := uuid.New()
+		seedStore(t, db, tenantID, storeID)
 		sub := subscription.StoreSubscription{
 			ID:                      uuid.New(),
-			TenantID:                uuid.New(),
-			StoreID:                 uuid.New(),
+			TenantID:                tenantID,
+			StoreID:                 storeID,
 			StripeCustomerID:        "cus_iso_" + suffix,
 			Plan:                    subscription.PlanTrial,
 			Status:                  subscription.StatusTrialing,
@@ -216,10 +228,13 @@ func TestTrialReminders_ExpiredSubsAreSkipped(t *testing.T) {
 
 	created := time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, time.UTC).
 		AddDate(0, 0, -(trial.TrialDays - 1))
+	tenantID := uuid.New()
+	storeID := uuid.New()
+	seedStore(t, db, tenantID, storeID)
 	sub := subscription.StoreSubscription{
 		ID:                      uuid.New(),
-		TenantID:                uuid.New(),
-		StoreID:                 uuid.New(),
+		TenantID:                tenantID,
+		StoreID:                 storeID,
 		StripeCustomerID:        "cus_expired",
 		Plan:                    subscription.PlanTrial,
 		Status:                  subscription.StatusExpired,

--- a/services/marketplace-api/internal/tenantpurge/purge_integration_test.go
+++ b/services/marketplace-api/internal/tenantpurge/purge_integration_test.go
@@ -76,8 +76,8 @@ func seedTenant(t *testing.T, db *gorm.DB, tenantID string) seededTenant {
 	}
 
 	// stores (group 6 root)
-	exec(`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status)
-	      VALUES (?, ?, ?, 'Seed Store', 'US', 'USD', 'UTC', 'active')`,
+	exec(`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
+	      VALUES (?, ?, ?, 'Seed Store', 'US', 'USD', 'UTC', 'active', encode(gen_random_bytes(32), 'hex'))`,
 		s.storeID, s.tenantID, "seed-store-"+s.storeID[:8])
 
 	// group 6 — CASCADE-swept config table (proves stores CASCADE reaches it)
@@ -162,7 +162,13 @@ func TestIntegration_Purge_DeletesTenantLeavesGlobalAndOtherTenantIntact(t *test
 
 	// Ensure at least one row exists in a global table so we can assert it
 	// survives the purge untouched.
-	if err := db.Exec(`INSERT INTO fx_rates (currency, usd_mid_rate, source) VALUES ('SEED', 1.0, 'test') ON CONFLICT (currency) DO NOTHING`).Error; err != nil {
+	//
+	// XTS is the ISO 4217 code officially reserved for testing purposes
+	// (no real currency will ever use it), and fx_rates.currency is
+	// character(3), so it must stay exactly 3 characters — do not swap
+	// this for 'USD' or any other real code, that would risk colliding
+	// with a currency another test cares about.
+	if err := db.Exec(`INSERT INTO fx_rates (currency, usd_mid_rate, source) VALUES ('XTS', 1.0, 'test') ON CONFLICT (currency) DO NOTHING`).Error; err != nil {
 		t.Fatalf("seed fx_rates: %v", err)
 	}
 
@@ -187,7 +193,7 @@ func TestIntegration_Purge_DeletesTenantLeavesGlobalAndOtherTenantIntact(t *test
 
 	// global table untouched.
 	var fxCount int64
-	if err := db.Raw(`SELECT count(*) FROM fx_rates WHERE currency = 'SEED'`).Scan(&fxCount).Error; err != nil {
+	if err := db.Raw(`SELECT count(*) FROM fx_rates WHERE currency = 'XTS'`).Scan(&fxCount).Error; err != nil {
 		t.Fatalf("count fx_rates: %v", err)
 	}
 	if fxCount != 1 {


### PR DESCRIPTION
Repairs the marketplace-api integration suite, which has been dark long enough to hide a production bug.

## The production bug this uncovered

`internal/subscription/dunning/ladder.go`'s `statusEnteredAt` scanned `MAX(created_at)` into `**time.Time`. GORM has a fast path for `*time.Time` that bypasses `database/sql`'s generic pointer handling, so a SQL NULL **errors** instead of yielding nil:

```
gorm .Raw().Scan(**time.Time) -> ERROR: unsupported Scan, storing driver.Value type <nil> into type *time.Time
gorm .Row().Scan(**time.Time) -> ok, nil=true
gorm .Raw().Scan(**string)    -> ok
gorm .Raw().Scan(**int64)     -> ok
```

So the function's own documented fallback — `if enteredAt == nil { return fallback, nil }` — was **unreachable**, and the caller turns that error into a hard failure of the whole dunning step (`ladder.go:150-152`).

**Effect in production:** any subscription that entered its current status without a `subscription.state_transition` audit row never advances through the dunning ladder. That is precisely the legacy case the doc comment says the fallback exists for. Past-due subscriptions that should progress to expired stall indefinitely, and it presents as a transient DB error rather than a logic bug.

Fixed with `sql.NullTime`. The hazard is exactly that one combination — verified against the live DB, not assumed — so no other call site needed changing.

**This was invisible because all 16 tests in the package died at the seed step before reaching ladder logic.** The broken tests were not just noise; they were concealing a defect.

## The test fixes

**`tenantpurge`** — inserted `'SEED'` (4 chars) into `fx_rates.currency`, a `character(3)`. Now `'XTS'`, the ISO 4217 code reserved for testing, so it cannot collide with a real currency. Also completed a `stores` insert missing `storefront_customer_portal_secret`, a NOT NULL column added by a later migration.

**`dunning`** — created `store_subscriptions` rows for a random `storeID` with no `stores` row to satisfy the FK. There is no seed binary for this service and `stores` is empty locally, so nothing else was going to provide it. Added a `seedStore` helper following the established pattern in `internal/order/testhelpers_integration_test.go`, with one deliberate difference: the caller supplies the tenant, so the store and its subscription agree about tenancy — otherwise every tenant-scoped assertion in those tests would be vacuous.

**`TestE2E_FullLadder_PastDueToPendingDelete`** — its doc comment says it uses "backdated audit_logs rows to simulate elapsed time at each step". Step 1 INSERTs one; steps 3 and 4 UPDATEd a row they assumed the ladder had written. With a nil emitter that row never exists, the UPDATE matched **zero rows**, and `db.Exec` does not error on zero rows — so it failed silently and misleadingly. Steps 3 and 4 now INSERT their own backdated rows, matching step 1.

Result: dunning **0/16 → 34/34** (16 target + 18 pre-existing unit tests), verified across 18 consecutive runs.

## `make test-int` — widened, but deliberately not to `./...`

Two changes:

**`-p 1`.** These packages share one local Postgres and parallel package execution exhausts its connection limit (`FATAL: sorry, too many clients already`). That was initially misread as cross-test pollution; it was disproved by pairwise bisection and 18 clean isolated runs, then reproduced deliberately under concurrent multi-package load.

**Scoped to the packages whose fixtures are correct** — `audit`, `handlers/platformadmin`, `tenantpurge`, `subscription/dunning`. Running the full `./...` integration suite surfaces failures across 23 packages, all schema drift: migrations added NOT NULL columns and FKs without updating test fixtures.

Leaving the target at `./...` would make it permanently red, which recreates the exact condition that hid the dunning bug. Widen one package at a time as each cluster is fixed. The reasoning is in the Makefile comment so the next person does not have to rediscover it.

## Backlog surfaced, filed separately

`products.vendor_id` NOT NULL (54 tests), the `store_subscriptions` store FK (13 packages), `stores.storefront_customer_portal_secret` (4 packages), an `apikeys` `varchar(60)` overflow, `orderrefund` cleanup deadlocks, and a nil-`Repo` panic in `audit.NewEmitter` that kills the `whitelabel/lifecycle` test binary.

## Test plan

- [x] dunning 34/34, twice consecutively and across 18 total runs
- [x] tenantpurge, audit, platformadmin pass
- [x] `go build ./...`, `go vet ./...`, `go test ./... -count=1` clean
- [x] The scoped `make test-int` target passes end to end
- [x] The `sql.NullTime` hazard characterised empirically against the live DB, not inferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCy84rLD5XVchzo6eBRuba
