### PR TITLE
feat(platformadmin): GET /admin/conversions for the platform CRM (#279)

### DIFF
--- a/docs/superpowers/2026-08-23-platform-integration-handoff.md
+++ b/docs/superpowers/2026-08-23-platform-integration-handoff.md
@@ -1,0 +1,170 @@
+# Takeover prompt — Platform integration v1
+
+Paste everything below into a new session.
+
+---
+
+You are taking over the **Platform integration v1** milestone in `tesserix/mark8ly`
+(repo root `/Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly`, a multi-service
+Go + Next.js workspace).
+
+## What this milestone is
+
+The Tesserix platform console (`console.tesserix.app`) is moving off **direct
+cross-database reads** of mark8ly's data onto mark8ly's own HTTP surface. Umbrella
+issue: **#260**. Each endpoint is its own issue.
+
+**Delivered and live in production:** #274 (front door), #275 (auth), #276
+(`/admin/audit-logs`), #277 (`/admin/entities/tenants`).
+
+**Open in the milestone:** #278–#290, plus #319 (OpenBao credentials, a different
+concern grouped in).
+
+## Read these first
+
+- `docs/superpowers/specs/2026-08-22-platform-admin-surface-design.md` — the foundation
+- `docs/superpowers/specs/2026-08-23-tenant-directory-design.md` — the most recent endpoint
+- The umbrella comment on **#260** — what every new endpoint inherits
+- `services/marketplace-api/internal/handlers/platformadmin/routes.go` — the doc comment there explains the mount decision
+
+**Treat specs as hypotheses, not authority.** Across two specs in this milestone,
+nine separate claims turned out to be contradicted by the code — a CHECK constraint,
+a prune cron, a nonce sweep, a lock claim, a gateway policy, a route path, a
+registration group, a query strategy, and a test that was claimed to exist and did
+not. Every one was caught by someone reading the code instead of the document.
+Verify before you build on a spec sentence.
+
+## Where the surface lives
+
+**Base URL: `https://api.mark8ly.com/api/v1/platform`** — so contract path
+`/admin/foo` resolves to `/api/v1/platform/admin/foo`.
+
+New endpoints go in `services/marketplace-api/internal/handlers/platformadmin/`,
+mounted on the group in `routes.go`. Routing needs **no infra change** —
+`tesserix-k8s` has one prefix rule for `/api/v1/platform/` covering the whole series.
+
+Mount a handler on that group and you inherit: HMAC signature verification, replay
+defence (±300s window + single-use Postgres nonce), the enforcement matrix (writes
+require operator identity *and* capability; reads do not), fail-closed behaviour
+(`503 not_configured` when the secret is unset), and operator attribution into audit
+rows.
+
+## Conventions — follow, do not re-derive
+
+- Envelope is exactly `{"data": [...], "pagination": {"page","limit","total"}}`
+- Empty results are `200` + `[]`. Allocate with `make([]T, 0, n)` — a nil slice
+  marshals to `{}` and defeats the caller's `?? []`
+- `pagination.limit` reports the **effective** (clamped) limit, so `total / limit`
+  is a correct page count
+- Oversized `limit` clamps (500); a missing parameter takes the default, never errors
+- Money: integer minor units + explicit currency. Never a bare number
+- Timestamps RFC3339 UTC with offset
+- Ids **bare** — the platform API namespaces `<slug>:<id>` on arrival
+- Never send `source` — the platform API stamps it and overwrites the body
+- **Add a golden fixture per endpoint** and prove by mutation that it catches a field
+  *rename* AND a field *addition*. A fixture that only catches omissions is theatre
+- **Project, do not pass through.** Map upstream structs field by field.
+  platform-api's tenant record carries `owner_user_id` (a GIP UID); it never reaches
+  the console because `tenantRow` is a projection. A passthrough leaks every field
+  added upstream, silently
+
+## Five traps that each cost real time
+
+1. **`/api/v1/admin/*` is JWT-gated at the mesh.** An Istio `AuthorizationPolicy`
+   (`require-customer-auth`, namespace `istio-ingress`, repo `tesserix-k8s`) denies
+   any request without a JWT to a path list including `/api/v1/admin/*`,
+   `/api/v1/staff/*`, `/api/v1/analytics/*`, `/api/v1/reports/*`. This surface
+   authenticates by HMAC, not JWT. That is why it lives under `/api/v1/platform/`.
+   Invisible locally and in CI. Documented in `docs/architecture.md`.
+2. **#287 can panic the service at startup.** `/admin/tenants/{id}/suspend` collides
+   with the merchant `/admin/tenants/:tenantId/sso` — two different wildcard names in
+   one path position makes gin panic at *router build time*. Safe only while the new
+   route is registered on the `platformadmin` group, never the merchant one.
+3. **A missing tenant drops the audit event.** Nothing on this surface sets
+   `tenant_id` on the gin context. Use
+   `platformadmin.EmitOperatorAction(c, emitter, tenantID, ev)` — the tenant is a
+   required parameter so it cannot be forgotten. Calling `audit.Emit` directly on a
+   write path will silently write no row (#310 built the helper; the trap remains for
+   anyone not using it).
+4. **Two services, two sets of reference data.** `platform-api`'s `stores` FKs to
+   `countries`, `currencies`, `timezones` and its seed ships a specific set —
+   `GB`/`GBP`/`Europe/London` are safe, `IE`/`Europe/Dublin` are not. Copying fixture
+   values from marketplace-api produces tests that pass only on the machine where
+   someone hand-inserted the rows.
+5. **`-p 1` on integration runs.** The packages share one local Postgres; parallel
+   execution exhausts its connection limit (`FATAL: sorry, too many clients already`)
+   and presents as data pollution. It is not.
+
+## Environment
+
+- **Use the LAN IP, not `localhost`** — a native Postgres squats on 127.0.0.1:
+  - marketplace: `postgres://dev:dev@192.168.1.110:5432/marketplace_db`
+  - platform: `postgres://dev:dev@192.168.1.110:5432/platform_api`
+  The committed Makefile says `localhost`, correct everywhere else — do not change it.
+- `make dev` is broken (migrate containers fail with `exec: "up": executable file not found`).
+  Apply migrations with `cd services/<svc> && DATABASE_URL=... go run ./cmd/migrate up`.
+- **Deployment is Kargo-gated**, not direct ArgoCD: CI → ghcr → Kargo Warehouse →
+  Freight → Promotion to the `prod` stage → ArgoCD sync. Expect ~10–20 min, and check
+  `kubectl get stages,promotions -n kargo-mark8ly` rather than assuming a stall.
+- Only ONE GKE cluster exists and it is **production** (`tesseract-prod-in-gke`).
+  Never run tests against it.
+- Test package conventions differ by service: `platform-api` integration tests use the
+  **internal** package (`package tenant`), marketplace-api uses **external**
+  (`package foo_test`). Both use `//go:build integration`.
+
+## Process that worked
+
+For each endpoint: `superpowers:brainstorming` → spec in `docs/superpowers/specs/` →
+`superpowers:writing-plans` → `superpowers:subagent-driven-development` (fresh
+subagent per task, review between, final whole-branch review).
+
+The reviews earn their cost when they **mutate rather than read**: rewrite the query
+as a JOIN and confirm the dedup test fails; remove a guard and confirm its test fails;
+rename a JSON tag and confirm the golden test fails. A review that only reads the diff
+has repeatedly missed things a two-minute mutation caught.
+
+Two failure modes seen more than once:
+- A reviewer finding a real problem and **rating it Minor because "the plan mandated
+  it"**. A plan is not authority. Rule on those yourself.
+- A test passing **for the wrong reason** — asserting a stub's behaviour, or decoding
+  JSON so `[]` and `null` become indistinguishable. Check what the assertion actually
+  proves.
+
+## Blocked — do not start these
+
+- **#278** (user directory) — its constraint "no customer rows under any filter" is
+  unenforceable: `user_profiles` has no role/type/origin, and the staff/customer split
+  lives in GIP tenant pools, not Postgres. Needs a console-side decision. Full analysis
+  on the issue.
+- **#313** — `metadata` object-vs-string for `/admin/audit-logs`. Field ships omitted
+  until answered.
+- **#290** — blocked on the console publishing `@tesserix/admin-conformance`.
+- **#280** as written — its stated rationale (the SEA manual-review queue) is void:
+  **SEA countries are not supported and the integrations are untested**, so that queue
+  is inert. If you build the inbox, rebuild its justification from what is actually
+  live: erasure requests (#259, accumulating with a statutory clock), the migration
+  fast-path (#281, handler exists but was never mounted), and arbitrage appeals.
+
+## Suggested order
+
+Reads before writes; **#288 (purge) last** — it is irreversible.
+
+Good next candidates: **#283** (onboarding funnel — needs the same `tenantdirectory`
+client shape, scoped so extending is additive) or **#279** (conversions — smallest,
+and its `404`-means-nothing semantics are already specified precisely on the issue).
+
+**#284** carries an open design question the issue itself flags: subscriptions are
+per-store and plans are Go descriptors rather than DB rows, so a cross-tenant view may
+need a projection. Say so on the issue if it does, rather than guessing.
+
+## Known follow-ups outside the milestone
+
+#311 (store-less audit rows unprunable — decided: never pruned, needs the guard made
+deliberate), #312 (gateway policy documentation), #316/#317 (integration fixture drift
+across 17+ packages), #318 (`audit.NewEmitter` accepts a nil `Repo` and panics a
+worker goroutine).
+
+---
+
+Start by reading #260's latest comment, then pick an endpoint and run the
+brainstorming → spec → plan → subagent-driven flow. Ask me before merging anything.

--- a/docs/superpowers/plans/2026-08-23-admin-conversions.md
+++ b/docs/superpowers/plans/2026-08-23-admin-conversions.md
@@ -1,0 +1,307 @@
+# Admin Conversions Implementation Plan (#279)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Answer, for one lead email, whether that lead has become a mark8ly tenant — so the platform CRM's conversion column stops resolving to `unknown` for every row.
+
+**Architecture:** `platform-api` gains one internal endpoint that owns the lookup — an exact, case-insensitive match on `tenants.owner_email`, hitting the `tenants_owner_email_unique` index from migration 0014. `marketplace-api` calls it through the existing `tenantdirectory` client and reshapes the answer onto the `platformadmin` surface, which already carries signature verification, replay defence and the pinned envelope.
+
+**Tech Stack:** Go 1.26, Gin 1.12, GORM, PostgreSQL 15, testify.
+
+**Issue:** #279. Design approved in-session (bounded change; no separate spec file). The response-semantics table on the issue is the binding contract.
+
+## The contract — this is the whole point of the endpoint
+
+`404` **cannot** mean "not converted", because `404` is also what a framework returns for a route that does not exist. The two are indistinguishable on the wire, so the console can never trust `404` to carry a definite answer.
+
+| case | marketplace-api response |
+|---|---|
+| owner email matches a tenant | `200 {"state":"converted","ref":"<bare tenant id>","label":"<tenant name>","observed_at":"<created_at, RFC3339 UTC>"}` |
+| no tenant owns that email | `200 {"state":"none"}` — the **only** honest way to assert this |
+| `email` missing or blank | `400 {"error":"validation_error","message":...}` — a caller bug, not an answer |
+| upstream unreachable or 5xx | `503 {"error":"upstream_unavailable",...}` — never `{"state":"none"}` |
+
+The `404` from platform-api is swallowed **in the marketplace-api handler** and converted to `200 {"state":"none"}`. That is the single most important line in this plan.
+
+## Global Constraints
+
+- **`observed_at` is the tenant's `created_at`** — when the conversion happened. Never `time.Now()`.
+- Ids go out **bare** — no `mark8ly:` prefix. The platform API namespaces `<slug>:<id>` on arrival; prefixing here yields `mark8ly:mark8ly:...`.
+- Never send a `source` field. The platform API stamps it and overwrites the body.
+- Timestamps are RFC3339, UTC, with offset.
+- **Conversion means owning a tenant.** `tenants.owner_email` only. A lead later invited as staff on someone else's tenant reads as `none`. Staff membership lives in OpenFGA, not queryably in Postgres, and only `owner_email` has a unique index behind it.
+- **Project, do not pass through.** The marketplace-api response is built field by field. `owner_user_id` is a GIP UID and must never reach the console.
+- This endpoint returns a single object, not a page. It has **no** `pagination` key. Do not add one.
+- Commit messages: single line, conventional-commit prefix, no signature, no `Co-Authored-By` trailer.
+
+## Verified facts — do not re-derive, do not doubt
+
+- **Migration 0014** puts `CREATE UNIQUE INDEX tenants_owner_email_unique ON tenants (lower(owner_email))`. An email owns **at most one** tenant. There is no "which one wins" case to handle, and no `ErrMultiple` to invent.
+- `repository.OwnerEmailExists` (`internal/tenant/repository.go:109`) already normalises with `strings.ToLower(strings.TrimSpace(email))` and queries `WHERE lower(owner_email) = ?`. **Copy that normalisation exactly** — a different one would miss the index or disagree with onboarding's duplicate check.
+- **Gin 1.12 accepts `/internal/tenants/by-owner-email` as a static sibling of `:id`.** Verified in this session against the real two-group shape from `cmd/server/main.go` (strict directory group + permissive internal group, directory registered first): no panic at router build time, the static route wins over `:id`, and `/tenants/:id`, `/:id/detail`, `/:id/members` all still resolve to their own handlers under their own middleware. This is the one place trap #2 (the #287 gin panic) could have bitten; it does not.
+- `RegisterDirectory` is already mounted in `cmd/server/main.go:348` behind `middleware.RequireInternalAuthStrict`. Adding a route inside it needs **no** `main.go` change.
+- `platformadmin.Deps.TenantDirectory` is already wired at **two** sites in `cmd/marketplace-api/main.go` (~1917 and ~2003). Extending the existing `TenantDirectory` interface means the conversions handler reuses that dependency and needs **no** `main.go` change either. Do not add a third Deps field.
+- `require.JSONEq` compares both directions, so a golden fixture asserted with it catches a field **rename** and a field **addition**, not only an omission. Prove it by mutation anyway (see Task 4).
+
+## Two conventions that differ between the services
+
+- **`platform-api` integration tests use the INTERNAL package** — `package tenant`, not `tenant_test`. See `internal/tenant/repository_integration_test.go`. They import `github.com/mark8ly/platform-api/pkg/testdb`.
+- **`marketplace-api` tests use the EXTERNAL package** — `package platformadmin_test`, `package tenantdirectory_test`.
+
+Both use `//go:build integration` and the `*_integration_test.go` suffix for DB-backed tests.
+
+## Environment
+
+- Local docker Postgres is running. **Use the LAN IP, not localhost** — a native Postgres squats on 127.0.0.1 on this machine, so `localhost` reaches the wrong server and reports `role "dev" does not exist`:
+  - marketplace-api: `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'`
+  - platform-api: `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/platform_api?sslmode=disable'`
+  The committed Makefile says `localhost`, which is correct everywhere else — **do not change it**.
+- Integration runs need `-p 1`. These packages share one local Postgres and parallel package execution exhausts its connection limit (`FATAL: sorry, too many clients already`), which looks like data pollution and is not.
+- **`platform-api` seeds its own reference data.** `stores` FKs to `countries`, `currencies`, `timezones`. `GB`/`GBP`/`Europe/London` are in the seed; `IE`/`Europe/Dublin` are not. Do not copy fixture values from marketplace-api. This task touches only `tenants`, so it should not need a store at all — if you find yourself inserting one, stop and ask whether the test needs it.
+- Do NOT run `make dev` — the migrate containers are broken on this machine.
+- Never run anything against a remote or GKE database. The only cluster that exists is production.
+
+## File Structure
+
+**`platform-api`**
+
+| File | Responsibility |
+|---|---|
+| `internal/tenant/directory.go` (modify) | `GetByOwnerEmail` repository query |
+| `internal/tenant/repository.go` (modify) | `GetByOwnerEmail` on the `Repository` interface |
+| `internal/tenant/service.go` (modify) | `GetByOwnerEmail` service passthrough |
+| `internal/tenant/directory_integration_test.go` (modify) | Exact-match, case/whitespace, substring-is-not-a-match, miss |
+| `internal/tenant/handler.go` (modify) | `GET /tenants/by-owner-email` on `RegisterDirectory` |
+| `internal/tenant/directory_handler_test.go` (modify) | Route wiring, missing-email, hit and miss shapes |
+
+**`marketplace-api`**
+
+| File | Responsibility |
+|---|---|
+| `internal/tenantdirectory/client.go` (modify) | `FindByOwnerEmail` |
+| `internal/tenantdirectory/client_test.go` (modify) | Auth header, query encoding, 404→`ErrNotFound`, 5xx→`ErrUnavailable` |
+| `internal/handlers/platformadmin/conversions.go` (create) | The handler and the wire shape |
+| `internal/handlers/platformadmin/conversions_test.go` (create) | All four contract rows plus the golden fixture |
+| `internal/handlers/platformadmin/testdata/conversions_converted.json` (create) | Golden fixture |
+| `internal/handlers/platformadmin/entities_tenants.go` (modify) | Extend the `TenantDirectory` interface |
+| `internal/handlers/platformadmin/routes.go` (modify) | Mount the handler |
+
+---
+
+### Task 1: platform-api — the owner-email lookup query
+
+**Files:** `internal/tenant/directory.go`, `internal/tenant/repository.go`, `internal/tenant/service.go`, `internal/tenant/directory_integration_test.go`
+
+Add to the `Repository` interface in `repository.go`, beside `GetWithStores`:
+
+```go
+	// GetByOwnerEmail returns the tenant owned by the given email, or
+	// apperrors.NotFound when no tenant is. Comparison is case-insensitive
+	// and trims surrounding whitespace, matching OwnerEmailExists and the
+	// tenants_owner_email_unique index (migration 0014) — which is also why
+	// this returns at most one row rather than a slice.
+	GetByOwnerEmail(ctx context.Context, email string) (*Tenant, error)
+```
+
+Implement in `directory.go` (it belongs with the directory reads, not with the onboarding-facing queries in `repository.go`):
+
+```go
+func (r *gormRepository) GetByOwnerEmail(ctx context.Context, email string) (*Tenant, error) {
+	// Same normalisation as OwnerEmailExists: the unique index is on
+	// lower(owner_email), so anything else silently misses it.
+	normalized := strings.ToLower(strings.TrimSpace(email))
+	if normalized == "" {
+		return nil, apperrors.NotFound("tenant_not_found", "no tenant owns that email")
+	}
+
+	var t Tenant
+	err := r.db.WithContext(ctx).
+		Where("lower(owner_email) = ?", normalized).
+		First(&t).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, apperrors.NotFound("tenant_not_found", "no tenant owns that email")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("tenant: get by owner email: %w", err)
+	}
+	return &t, nil
+}
+```
+
+Check the exact `apperrors.NotFound` signature and the error-code string used by the neighbouring `GetByID` before writing this — match it rather than inventing a new code.
+
+Add the service passthrough in `service.go`, beside `GetWithStores`:
+
+```go
+// GetByOwnerEmail returns the tenant owned by the given email (#279).
+func (s *Service) GetByOwnerEmail(ctx context.Context, email string) (*Tenant, error) {
+	return s.repo.GetByOwnerEmail(ctx, email)
+}
+```
+
+**Tests** (`directory_integration_test.go`, `package tenant`, `//go:build integration`). Write these first and watch them fail:
+
+- [ ] Exact match returns the tenant: seed `founder@acme.example`, look it up, assert the id and name.
+- [ ] **Case-insensitive:** seeding `founder@acme.example` and querying `Founder@ACME.example` returns the same tenant.
+- [ ] **Whitespace-trimmed:** querying `"  founder@acme.example  "` returns the same tenant.
+- [ ] **A substring is NOT a match:** seed `bob@acme.example`, query `ob@acme.example`, assert `apperrors` not-found. This is the regression guard against anyone later "simplifying" this into the directory's `ILIKE '%q%'` search.
+- [ ] An unseeded email returns not-found, not an empty `Tenant` and not a nil error.
+- [ ] Empty string and whitespace-only both return not-found without touching the DB.
+
+Seed with the package's existing tenant helper if one exists; this test needs no store, no country and no currency.
+
+**Verify:**
+
+```
+cd services/platform-api && TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/platform_api?sslmode=disable' go test -tags=integration -p 1 -run 'OwnerEmail' ./internal/tenant/...
+```
+
+**Commit:** `feat(tenant): look up a tenant by owner email (#279)`
+
+---
+
+### Task 2: platform-api — the internal endpoint
+
+**Files:** `internal/tenant/handler.go`, `internal/tenant/directory_handler_test.go`
+
+Add the route inside `RegisterDirectory`, next to the existing two:
+
+```go
+		// Static sibling of :id. Verified against gin 1.12 with main.go's
+		// real two-group shape: no router-build panic, and /tenants/:id,
+		// /:id/detail and /:id/members all still resolve to their own
+		// handlers. Path chosen over a filter on the directory list because
+		// that list matches with ILIKE '%q%' — a substring match would
+		// report the wrong lead converted.
+		t.GET("/by-owner-email", h.getTenantByOwnerEmail)
+```
+
+The handler:
+
+```go
+func (h *Handler) getTenantByOwnerEmail(c *gin.Context) {
+	t, err := h.svc.GetByOwnerEmail(c.Request.Context(), c.Query("email"))
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": t})
+}
+```
+
+A missing `email` reaches the repository as `""` and comes back not-found, so it answers `404` — which is correct on **this** hop. The `400` in the contract belongs to marketplace-api, which knows it is serving a console caller.
+
+**Tests** (`directory_handler_test.go`, existing package and style):
+
+- [ ] A hit returns `200` with `data.id` and `data.owner_email` matching the seeded tenant.
+- [ ] A miss returns `404`.
+- [ ] A missing `email` parameter returns `404`, not `500` and not a panic.
+- [ ] The route is reachable at exactly `/internal/tenants/by-owner-email` when mounted the way `main.go` mounts it, and registering it does **not** break `/internal/tenants/:id/detail`. Assert both in the same test so a future route change cannot silently shadow one.
+
+**Verify:** the package's unit tests, plus `go build ./...`.
+
+**Commit:** `feat(tenant): internal by-owner-email lookup endpoint (#279)`
+
+---
+
+### Task 3: marketplace-api — the client method
+
+**Files:** `internal/tenantdirectory/client.go`, `internal/tenantdirectory/client_test.go`
+
+Add, following the shape of the existing `Get`:
+
+```go
+// FindByOwnerEmail returns the tenant owned by the given email.
+//
+// ErrNotFound means no tenant owns it — a definite answer, and the caller
+// MUST turn it into a 200 "none" rather than propagating a 404. See #279:
+// a 404 on the wire is indistinguishable from a route that does not exist,
+// so it can never carry "not converted".
+func (c *Client) FindByOwnerEmail(ctx context.Context, email string) (*Tenant, error) {
+	var envelope struct {
+		Data Tenant `json:"data"`
+	}
+	q := url.Values{}
+	q.Set("email", email)
+	if err := c.do(ctx, "/internal/tenants/by-owner-email?"+q.Encode(), &envelope); err != nil {
+		return nil, err
+	}
+	return &envelope.Data, nil
+}
+```
+
+**Tests** (`client_test.go`, `package tenantdirectory_test`):
+
+- [ ] Sends `X-Internal-Auth` and requests path `/internal/tenants/by-owner-email` with `email` correctly URL-encoded — use an address containing `+` (`founder+tag@acme.example`) so a naive string concatenation fails this test.
+- [ ] Parses the envelope into a `Tenant`, including `created_at`.
+- [ ] Upstream `404` → `ErrNotFound`.
+- [ ] Upstream `5xx` → `ErrUnavailable`.
+- [ ] A closed server (transport failure) → `ErrUnavailable`.
+
+**Verify:** `cd services/marketplace-api && go test ./internal/tenantdirectory/...`
+
+**Commit:** `feat(tenantdirectory): find a tenant by owner email (#279)`
+
+---
+
+### Task 4: marketplace-api — the conversions endpoint
+
+**Files:** `internal/handlers/platformadmin/conversions.go` (create), `conversions_test.go` (create), `testdata/conversions_converted.json` (create), `entities_tenants.go` (modify), `routes.go` (modify)
+
+Extend the existing interface in `entities_tenants.go` — do **not** declare a second one, and do **not** add a new `Deps` field. The client already satisfies it, so both `main.go` wiring sites keep working untouched:
+
+```go
+	FindByOwnerEmail(ctx context.Context, email string) (*tenantdirectory.Tenant, error)
+```
+
+Any existing test stub implementing `TenantDirectory` needs the new method too.
+
+`conversions.go` — the wire shape, projected field by field:
+
+```go
+// conversionResponse is the CRM's answer for one lead email.
+//
+// The zero-value response is {"state":"none"} — every other field is
+// omitempty, so a miss cannot leak an empty ref the console would render.
+type conversionResponse struct {
+	State      string `json:"state"`
+	Ref        string `json:"ref,omitempty"`
+	Label      string `json:"label,omitempty"`
+	ObservedAt string `json:"observed_at,omitempty"`
+}
+```
+
+Register `GET /admin/conversions`. The handler:
+
+- [ ] Trims `email`; blank → `400 validation_error`.
+- [ ] Calls `FindByOwnerEmail`.
+- [ ] `ErrNotFound` → `200 {"state":"none"}`. **Comment this line** with why a 404 must not be propagated.
+- [ ] `ErrUnavailable` → `503 upstream_unavailable`, logged. Never `{"state":"none"}` — "we could not ask" is not "not converted", and the console renders the two differently.
+- [ ] Anything else → `500 internal_error`, matching `respondErr`'s existing reasoning about a wrong shared secret. Reuse `respondErr` for the 503/500 branches if it fits without contortion; if reusing it would force the 404-to-200 conversion into the shared function, write a local switch instead — the shared helper must keep mapping `ErrNotFound` to `404` for the tenants routes.
+- [ ] Success → `converted`, with `Ref` the **bare** id, `Label` the tenant name, `ObservedAt` the tenant's `CreatedAt` as RFC3339 UTC.
+
+Mount it in `routes.go` inside the existing `if deps.TenantDirectory != nil` block.
+
+**Tests** (`conversions_test.go`, `package platformadmin_test`):
+
+- [ ] Converted: golden fixture via `require.JSONEq` against `testdata/conversions_converted.json`.
+- [ ] **Prove the fixture by mutation.** Temporarily rename a JSON tag (`ref` → `reference`) and confirm the test fails; temporarily add a field to the struct and confirm it fails again. Revert both. Record both results in your report — a fixture that only catches omissions is theatre.
+- [ ] Miss: body is exactly `{"state":"none"}` — assert on the decoded raw JSON, so an extra `"ref":""` would fail. Assert the status is `200` and **explicitly assert it is not 404**.
+- [ ] Missing `email`, and `email=` blank, and `email=%20%20`: all `400`.
+- [ ] `ErrUnavailable` → `503`, and assert the body does **not** contain `"state"`. A 503 that also says `none` would be read as a definite answer by a caller that only checks the body.
+- [ ] An unexpected error → `500`.
+- [ ] The email reaches the client verbatim after trimming — assert the stub received exactly what you expect, so a future normalisation change here cannot silently diverge from platform-api's.
+
+**Verify:** `cd services/marketplace-api && go test ./internal/handlers/platformadmin/... && go build ./...`
+
+**Commit:** `feat(platformadmin): GET /admin/conversions for the CRM (#279)`
+
+---
+
+## After the plan
+
+- [ ] `go build ./...` clean in both services.
+- [ ] Full unit suites green in both touched packages.
+- [ ] Integration suite green in `platform-api/internal/tenant` with `-p 1`.
+- [ ] Confirm no `main.go` in either service was modified — if one was, that is a signal the interface extension was done wrong.
+- [ ] Comment on #279 with the delivered shape and the owner-email-only scoping decision, so the console side can object before it ships.

--- a/services/marketplace-api/internal/handlers/platformadmin/conversions.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/conversions.go
@@ -1,0 +1,93 @@
+package platformadmin
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
+)
+
+// ConversionsHandler answers the CRM's question "has this lead email
+// converted to a tenant?" for the platform console (#279). It owns only the
+// wire shape; platform-api owns the owner-email lookup and its
+// normalisation.
+type ConversionsHandler struct {
+	dir    TenantDirectory
+	logger *slog.Logger
+}
+
+// NewConversionsHandler constructs the handler. logger may be nil.
+func NewConversionsHandler(dir TenantDirectory, logger *slog.Logger) *ConversionsHandler {
+	return &ConversionsHandler{dir: dir, logger: logger}
+}
+
+// Register mounts the route on the supplied group.
+func (h *ConversionsHandler) Register(g *gin.RouterGroup) {
+	g.GET("/admin/conversions", h.get)
+}
+
+// conversionResponse is the CRM's answer for one lead email.
+//
+// The zero-value response is {"state":"none"} — every other field is
+// omitempty, so a miss cannot leak an empty ref the console would render.
+type conversionResponse struct {
+	State      string `json:"state"`
+	Ref        string `json:"ref,omitempty"`
+	Label      string `json:"label,omitempty"`
+	ObservedAt string `json:"observed_at,omitempty"`
+}
+
+func (h *ConversionsHandler) get(c *gin.Context) {
+	email := strings.TrimSpace(c.Query("email"))
+	if email == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "validation_error", "message": "email is required",
+		})
+		return
+	}
+
+	// Deliberately not lowercased here: platform-api's repository owns the
+	// normalisation that backs its unique index. A second normalisation
+	// here could drift from that one and silently change matching.
+	t, err := h.dir.FindByOwnerEmail(c.Request.Context(), email)
+	if err != nil {
+		switch {
+		case errors.Is(err, tenantdirectory.ErrNotFound):
+			// A miss is a definite, positive answer ("this email has not
+			// converted"), not the absence of a route. Reporting it as 404
+			// would be indistinguishable on the wire from a route that
+			// doesn't exist, so it must come back 200 with an explicit
+			// state instead.
+			c.JSON(http.StatusOK, conversionResponse{State: "none"})
+		case errors.Is(err, tenantdirectory.ErrUnavailable):
+			if h.logger != nil {
+				h.logger.Error("tenant directory upstream unavailable", "err", err)
+			}
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"error": "upstream_unavailable", "message": "tenant directory is unavailable",
+			})
+		default:
+			if h.logger != nil {
+				h.logger.Error("tenant directory", "err", err)
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "internal_error", "message": "could not check conversion status",
+			})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, conversionResponse{
+		State: "converted",
+		// Bare id. The platform API namespaces as <slug>:<id> on arrival;
+		// prefixing here yields "mark8ly:mark8ly:...".
+		Ref:        t.ID,
+		Label:      t.Name,
+		ObservedAt: t.CreatedAt.UTC().Format(time.RFC3339),
+	})
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/conversions_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/conversions_test.go
@@ -1,0 +1,123 @@
+package platformadmin_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
+)
+
+func conversionsRouter(t *testing.T, dir platformadmin.TenantDirectory) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	platformadmin.NewConversionsHandler(dir, nil).Register(r.Group(""))
+	return r
+}
+
+func conversionsRequest(email string) *http.Request {
+	return httptest.NewRequest(http.MethodGet, "/admin/conversions?email="+url.QueryEscape(email), nil)
+}
+
+// THE test. Real handler output compared to the committed contract.
+func TestConversionsMatchesContract(t *testing.T) {
+	dir := &stubDirectory{conversion: &tenantdirectory.Tenant{
+		ID: "3f2504e0-4f89-11d3-9a0c-0305e82c3301", Name: "Acme Trading",
+		OwnerEmail: "founder@acme.example", Status: "active",
+		CreatedAt: time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC),
+	}}
+
+	rec := httptest.NewRecorder()
+	conversionsRouter(t, dir).ServeHTTP(rec, conversionsRequest("founder@acme.example"))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	want, err := os.ReadFile("testdata/conversions_converted.json")
+	require.NoError(t, err)
+	require.JSONEq(t, string(want), rec.Body.String())
+}
+
+// A miss is a definite, positive answer, never a 404 — a 404 on the wire is
+// indistinguishable from a route that does not exist, so it can never carry
+// the answer "not converted".
+func TestConversionsMissIsExactlyStateNone(t *testing.T) {
+	dir := &stubDirectory{err: tenantdirectory.ErrNotFound}
+
+	rec := httptest.NewRecorder()
+	conversionsRouter(t, dir).ServeHTTP(rec, conversionsRequest("nobody@example.com"))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotEqual(t, http.StatusNotFound, rec.Code)
+	require.JSONEq(t, `{"state":"none"}`, rec.Body.String())
+}
+
+func TestConversionsMissingEmailIs400(t *testing.T) {
+	rec := httptest.NewRecorder()
+	conversionsRouter(t, &stubDirectory{}).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/conversions", nil))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "validation_error", errorCode(t, rec))
+}
+
+func TestConversionsBlankEmailIs400(t *testing.T) {
+	rec := httptest.NewRecorder()
+	conversionsRouter(t, &stubDirectory{}).ServeHTTP(rec, conversionsRequest(""))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "validation_error", errorCode(t, rec))
+}
+
+func TestConversionsWhitespaceEmailIs400(t *testing.T) {
+	rec := httptest.NewRecorder()
+	conversionsRouter(t, &stubDirectory{}).ServeHTTP(rec, conversionsRequest("  "))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "validation_error", errorCode(t, rec))
+}
+
+// "We could not ask" is not "not converted", and the console renders the two
+// differently. A 503 body must never also carry a definite state.
+func TestConversionsUpstreamDownIs503(t *testing.T) {
+	dir := &stubDirectory{err: tenantdirectory.ErrUnavailable}
+
+	rec := httptest.NewRecorder()
+	conversionsRouter(t, dir).ServeHTTP(rec, conversionsRequest("a@example.com"))
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "upstream_unavailable", errorCode(t, rec))
+	require.NotContains(t, rec.Body.String(), `"state"`)
+}
+
+func TestConversionsUnexpectedErrorIs500(t *testing.T) {
+	dir := &stubDirectory{err: errUnexpected}
+
+	rec := httptest.NewRecorder()
+	conversionsRouter(t, dir).ServeHTTP(rec, conversionsRequest("a@example.com"))
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Equal(t, "internal_error", errorCode(t, rec))
+}
+
+// The email reaches the client verbatim after trimming, so a future
+// normalisation change here cannot silently diverge from platform-api's.
+func TestConversionsTrimsEmailBeforeCallingClient(t *testing.T) {
+	dir := &stubDirectory{err: tenantdirectory.ErrNotFound}
+
+	rec := httptest.NewRecorder()
+	conversionsRouter(t, dir).ServeHTTP(rec, conversionsRequest("  Founder@Acme.example  "))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "Founder@Acme.example", dir.gotEmail)
+}
+
+var errUnexpected = errors.New("boom")

--- a/services/marketplace-api/internal/handlers/platformadmin/entities_tenants.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/entities_tenants.go
@@ -20,6 +20,7 @@ import (
 type TenantDirectory interface {
 	List(ctx context.Context, p tenantdirectory.ListParams) (*tenantdirectory.ListResult, error)
 	Get(ctx context.Context, id string) (*tenantdirectory.TenantDetail, error)
+	FindByOwnerEmail(ctx context.Context, email string) (*tenantdirectory.Tenant, error)
 }
 
 // EntitiesTenantsHandler serves the platform console's tenant directory

--- a/services/marketplace-api/internal/handlers/platformadmin/entities_tenants_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/entities_tenants_test.go
@@ -22,6 +22,10 @@ type stubDirectory struct {
 	list      *tenantdirectory.ListResult
 	detail    *tenantdirectory.TenantDetail
 	err       error
+
+	// gotEmail and conversion back FindByOwnerEmail (#279).
+	gotEmail   string
+	conversion *tenantdirectory.Tenant
 }
 
 func (s *stubDirectory) List(_ context.Context, p tenantdirectory.ListParams) (*tenantdirectory.ListResult, error) {
@@ -40,6 +44,14 @@ func (s *stubDirectory) Get(_ context.Context, _ string) (*tenantdirectory.Tenan
 		return nil, s.err
 	}
 	return s.detail, nil
+}
+
+func (s *stubDirectory) FindByOwnerEmail(_ context.Context, email string) (*tenantdirectory.Tenant, error) {
+	s.gotEmail = email
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.conversion, nil
 }
 
 func tenantsRouter(t *testing.T, dir platformadmin.TenantDirectory) *gin.Engine {

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -72,5 +72,6 @@ func Register(g *gin.RouterGroup, deps Deps) {
 
 	if deps.TenantDirectory != nil {
 		NewEntitiesTenantsHandler(deps.TenantDirectory, deps.Logger).Register(group)
+		NewConversionsHandler(deps.TenantDirectory, deps.Logger).Register(group)
 	}
 }

--- a/services/marketplace-api/internal/handlers/platformadmin/testdata/conversions_converted.json
+++ b/services/marketplace-api/internal/handlers/platformadmin/testdata/conversions_converted.json
@@ -1,0 +1,6 @@
+{
+  "state": "converted",
+  "ref": "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+  "label": "Acme Trading",
+  "observed_at": "2026-08-22T10:00:00Z"
+}

--- a/services/marketplace-api/internal/tenantdirectory/client.go
+++ b/services/marketplace-api/internal/tenantdirectory/client.go
@@ -188,3 +188,21 @@ func (c *Client) Get(ctx context.Context, id string) (*TenantDetail, error) {
 	}
 	return &envelope.Data, nil
 }
+
+// FindByOwnerEmail returns the tenant owned by the given email.
+//
+// ErrNotFound means no tenant owns it — a definite answer, and the caller
+// MUST turn it into a 200 "none" rather than propagating a 404. See #279:
+// a 404 on the wire is indistinguishable from a route that does not exist,
+// so it can never carry "not converted".
+func (c *Client) FindByOwnerEmail(ctx context.Context, email string) (*Tenant, error) {
+	var envelope struct {
+		Data Tenant `json:"data"`
+	}
+	q := url.Values{}
+	q.Set("email", email)
+	if err := c.do(ctx, "/internal/tenants/by-owner-email?"+q.Encode(), &envelope); err != nil {
+		return nil, err
+	}
+	return &envelope.Data, nil
+}

--- a/services/marketplace-api/internal/tenantdirectory/client_test.go
+++ b/services/marketplace-api/internal/tenantdirectory/client_test.go
@@ -92,3 +92,72 @@ func TestTransportFailureIsUnavailable(t *testing.T) {
 		List(context.Background(), tenantdirectory.ListParams{})
 	require.ErrorIs(t, err, tenantdirectory.ErrUnavailable)
 }
+
+// The email is URL-encoded via url.Values, not string-concatenated, so a
+// "+" in a legitimate address survives the round trip intact.
+func TestFindByOwnerEmailSendsAuthAndEncodesQuery(t *testing.T) {
+	var gotAuth, gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("X-Internal-Auth")
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query().Get("email")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":"t1","name":"Acme","owner_email":"founder+tag@acme.example","status":"active","created_at":"2026-08-22T10:00:00Z"}}`))
+	}))
+	defer srv.Close()
+
+	c := tenantdirectory.NewClient(srv.URL, "s3cret", srv.Client())
+	got, err := c.FindByOwnerEmail(context.Background(), "founder+tag@acme.example")
+	require.NoError(t, err)
+
+	require.Equal(t, "s3cret", gotAuth)
+	require.Equal(t, "/internal/tenants/by-owner-email", gotPath)
+	require.Equal(t, "founder+tag@acme.example", gotQuery)
+	require.Equal(t, "Acme", got.Name)
+}
+
+func TestFindByOwnerEmailParsesEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"id":"t1","name":"Acme","owner_email":"a@example.com","status":"active","created_at":"2026-08-22T10:00:00Z"}}`))
+	}))
+	defer srv.Close()
+
+	got, err := tenantdirectory.NewClient(srv.URL, "s", srv.Client()).
+		FindByOwnerEmail(context.Background(), "a@example.com")
+	require.NoError(t, err)
+	require.Equal(t, "t1", got.ID)
+	require.Equal(t, "a@example.com", got.OwnerEmail)
+	require.Equal(t, 2026, got.CreatedAt.Year())
+}
+
+func TestFindByOwnerEmailNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not_found","message":"no such tenant"}`))
+	}))
+	defer srv.Close()
+
+	_, err := tenantdirectory.NewClient(srv.URL, "s", srv.Client()).
+		FindByOwnerEmail(context.Background(), "missing@example.com")
+	require.ErrorIs(t, err, tenantdirectory.ErrNotFound)
+}
+
+func TestFindByOwnerEmailUpstream5xxIsUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	_, err := tenantdirectory.NewClient(srv.URL, "s", srv.Client()).
+		FindByOwnerEmail(context.Background(), "a@example.com")
+	require.ErrorIs(t, err, tenantdirectory.ErrUnavailable)
+}
+
+func TestFindByOwnerEmailTransportFailureIsUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close() // closed: connection refused
+
+	_, err := tenantdirectory.NewClient(srv.URL, "s", srv.Client()).
+		FindByOwnerEmail(context.Background(), "a@example.com")
+	require.ErrorIs(t, err, tenantdirectory.ErrUnavailable)
+}

--- a/services/platform-api/internal/tenant/directory.go
+++ b/services/platform-api/internal/tenant/directory.go
@@ -2,10 +2,14 @@ package tenant
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
+
+	apperrors "github.com/mark8ly/platform-api/pkg/errors"
 )
 
 // DefaultDirectoryPageSize applies when the caller sends no limit. The
@@ -128,4 +132,26 @@ func (r *gormRepository) GetWithStores(ctx context.Context, id string) (*TenantW
 		return nil, fmt.Errorf("tenant store rollup: %w", err)
 	}
 	return out, nil
+}
+
+// GetByOwnerEmail returns the tenant owned by the given email (#279).
+func (r *gormRepository) GetByOwnerEmail(ctx context.Context, email string) (*Tenant, error) {
+	// Same normalisation as OwnerEmailExists: the unique index is on
+	// lower(owner_email), so anything else silently misses it.
+	normalized := strings.ToLower(strings.TrimSpace(email))
+	if normalized == "" {
+		return nil, apperrors.NotFound("tenant_not_found", "no tenant owns that email")
+	}
+
+	var t Tenant
+	err := r.db.WithContext(ctx).
+		Where("lower(owner_email) = ?", normalized).
+		First(&t).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, apperrors.NotFound("tenant_not_found", "no tenant owns that email")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("tenant: get by owner email: %w", err)
+	}
+	return &t, nil
 }

--- a/services/platform-api/internal/tenant/directory_handler_test.go
+++ b/services/platform-api/internal/tenant/directory_handler_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
+
+	apperrors "github.com/mark8ly/platform-api/pkg/errors"
 )
 
 // stubDirRepo records the filter it received and returns a canned result.
@@ -18,6 +20,12 @@ type stubDirRepo struct {
 	result DirectoryResult
 	detail *TenantWithStores
 	err    error
+
+	byID          *Tenant
+	byIDErr       error
+	byOwnerEmail  *Tenant
+	byOwnerErr    error
+	gotOwnerEmail string
 }
 
 func (s *stubDirRepo) ListDirectory(_ context.Context, f DirectoryFilter) (DirectoryResult, error) {
@@ -27,6 +35,15 @@ func (s *stubDirRepo) ListDirectory(_ context.Context, f DirectoryFilter) (Direc
 
 func (s *stubDirRepo) GetWithStores(_ context.Context, _ string) (*TenantWithStores, error) {
 	return s.detail, s.err
+}
+
+func (s *stubDirRepo) GetByID(_ context.Context, _ string) (*Tenant, error) {
+	return s.byID, s.byIDErr
+}
+
+func (s *stubDirRepo) GetByOwnerEmail(_ context.Context, email string) (*Tenant, error) {
+	s.gotOwnerEmail = email
+	return s.byOwnerEmail, s.byOwnerErr
 }
 
 func dirRouter(t *testing.T, repo Repository) *gin.Engine {
@@ -87,4 +104,121 @@ func TestDirectoryList_EmptyIsArrayNotNull(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	require.Equal(t, "[]", string(body.Data))
+}
+
+// TestGetTenantByOwnerEmail_Hit covers the happy path (#279): a seeded
+// tenant's owner email resolves to a 200 with the matching tenant.
+func TestGetTenantByOwnerEmail_Hit(t *testing.T) {
+	repo := &stubDirRepo{byOwnerEmail: &Tenant{ID: "tenant-123", OwnerEmail: "founder@acme.example"}}
+	rec := httptest.NewRecorder()
+	dirRouter(t, repo).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/tenants/by-owner-email?email=founder@acme.example", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "founder@acme.example", repo.gotOwnerEmail)
+
+	var body struct {
+		Data Tenant `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "tenant-123", body.Data.ID)
+	require.Equal(t, "founder@acme.example", body.Data.OwnerEmail)
+}
+
+// TestGetTenantByOwnerEmail_Miss covers no tenant owning the given email:
+// the repository's apperrors.NotFound must map to a 404 via respondError.
+func TestGetTenantByOwnerEmail_Miss(t *testing.T) {
+	repo := &stubDirRepo{byOwnerErr: apperrors.NotFound("tenant_not_found", "no tenant owns that email")}
+	rec := httptest.NewRecorder()
+	dirRouter(t, repo).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/tenants/by-owner-email?email=nobody@nowhere.example", nil))
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestGetTenantByOwnerEmail_MissingEmail asserts an absent email query
+// param reaches the repository as "" and comes back 404, not a 500 or a
+// panic. The 400-for-console-callers contract belongs to marketplace-api,
+// not this hop.
+func TestGetTenantByOwnerEmail_MissingEmail(t *testing.T) {
+	repo := &stubDirRepo{byOwnerErr: apperrors.NotFound("tenant_not_found", "no tenant owns that email")}
+	rec := httptest.NewRecorder()
+	dirRouter(t, repo).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/tenants/by-owner-email", nil))
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Equal(t, "", repo.gotOwnerEmail)
+}
+
+// fullRouter mounts the tenant handler exactly the way cmd/server/main.go
+// does: Register on a permissive /internal group and RegisterDirectory on
+// a SEPARATE strict /internal group with the same base path. This is the
+// real two-group shape from main.go:340-348 (gin 1.12) — verified not to
+// panic at router-build time and not to shadow sibling routes. That
+// verification is load-bearing (see issue #287, a router-panic-at-startup
+// class of bug), so it is asserted here rather than only in prose.
+func fullRouter(t *testing.T, repo Repository) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h := NewHandler(NewService(repo, nil), nil)
+
+	public := r.Group("")
+	internal := r.Group("/internal")
+	h.Register(public, internal)
+
+	tenantDirectory := r.Group("/internal")
+	h.RegisterDirectory(tenantDirectory)
+
+	return r
+}
+
+// TestRoute_ByOwnerEmailIsStaticSiblingAndDoesNotShadow locks in that
+// adding the static /by-owner-email route next to Register's /:id and
+// RegisterDirectory's /:id/detail does not panic the router and does not
+// shadow either sibling. A future route edit that reintroduces a
+// conflicting wildcard/static pair at this path would fail this test
+// before it could panic the service at startup.
+func TestRoute_ByOwnerEmailIsStaticSiblingAndDoesNotShadow(t *testing.T) {
+	repo := &stubDirRepo{
+		byID:         &Tenant{ID: "id-tenant", OwnerEmail: "id@acme.example"},
+		detail:       &TenantWithStores{Tenant: Tenant{ID: "detail-tenant"}},
+		byOwnerEmail: &Tenant{ID: "email-tenant", OwnerEmail: "owner@acme.example"},
+	}
+
+	require.NotPanics(t, func() {
+		fullRouter(t, repo)
+	})
+
+	r := fullRouter(t, repo)
+
+	// New static route resolves to its own handler, not the :id wildcard.
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/internal/tenants/by-owner-email?email=owner@acme.example", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var byEmail struct {
+		Data Tenant `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &byEmail))
+	require.Equal(t, "email-tenant", byEmail.Data.ID)
+
+	// /internal/tenants/:id (from Register's permissive group) still resolves.
+	rec2 := httptest.NewRecorder()
+	r.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/internal/tenants/some-id", nil))
+	require.Equal(t, http.StatusOK, rec2.Code)
+	var byID struct {
+		Data Tenant `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &byID))
+	require.Equal(t, "id-tenant", byID.Data.ID)
+
+	// /internal/tenants/:id/detail (from RegisterDirectory's strict group)
+	// still resolves and is not shadowed by the new static route.
+	rec3 := httptest.NewRecorder()
+	r.ServeHTTP(rec3, httptest.NewRequest(http.MethodGet, "/internal/tenants/some-id/detail", nil))
+	require.Equal(t, http.StatusOK, rec3.Code)
+	var detail struct {
+		Data TenantWithStores `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec3.Body.Bytes(), &detail))
+	require.Equal(t, "detail-tenant", detail.Data.ID)
 }

--- a/services/platform-api/internal/tenant/directory_integration_test.go
+++ b/services/platform-api/internal/tenant/directory_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
+	apperrors "github.com/mark8ly/platform-api/pkg/errors"
 	"github.com/mark8ly/platform-api/pkg/testdb"
 )
 
@@ -200,4 +201,130 @@ func TestGetWithStores_NotFound(t *testing.T) {
 
 	_, err := repo.GetWithStores(context.Background(), uuid.NewString())
 	require.Error(t, err)
+}
+
+// TestIntegration_GetByOwnerEmail_ExactMatch exercises the happy path for
+// the #279 admin-conversions lookup: an exact owner_email match returns
+// the tenant that owns it.
+func TestIntegration_GetByOwnerEmail_ExactMatch(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := NewRepository(tx)
+	ctx := context.Background()
+
+	seed := newTenant("Acme Co", "uid-owner-1", "founder@acme.example")
+	if err := repo.CreateInTx(ctx, tx, seed); err != nil {
+		t.Fatalf("CreateInTx: %v", err)
+	}
+
+	got, err := repo.GetByOwnerEmail(ctx, "founder@acme.example")
+	if err != nil {
+		t.Fatalf("GetByOwnerEmail: %v", err)
+	}
+	if got.ID != seed.ID {
+		t.Errorf("ID = %q, want %q", got.ID, seed.ID)
+	}
+	if got.Name != "Acme Co" {
+		t.Errorf("Name = %q, want Acme Co", got.Name)
+	}
+}
+
+// TestIntegration_GetByOwnerEmail_CaseInsensitive mirrors the unique index
+// on lower(owner_email) (migration 0014): a differently-cased query must
+// still find the tenant.
+func TestIntegration_GetByOwnerEmail_CaseInsensitive(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := NewRepository(tx)
+	ctx := context.Background()
+
+	seed := newTenant("Acme Co", "uid-owner-2", "founder@acme.example")
+	if err := repo.CreateInTx(ctx, tx, seed); err != nil {
+		t.Fatalf("CreateInTx: %v", err)
+	}
+
+	got, err := repo.GetByOwnerEmail(ctx, "Founder@ACME.example")
+	if err != nil {
+		t.Fatalf("GetByOwnerEmail: %v", err)
+	}
+	if got.ID != seed.ID {
+		t.Errorf("ID = %q, want %q", got.ID, seed.ID)
+	}
+}
+
+// TestIntegration_GetByOwnerEmail_WhitespaceTrimmed asserts surrounding
+// whitespace on the query does not defeat the match.
+func TestIntegration_GetByOwnerEmail_WhitespaceTrimmed(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := NewRepository(tx)
+	ctx := context.Background()
+
+	seed := newTenant("Acme Co", "uid-owner-3", "founder@acme.example")
+	if err := repo.CreateInTx(ctx, tx, seed); err != nil {
+		t.Fatalf("CreateInTx: %v", err)
+	}
+
+	got, err := repo.GetByOwnerEmail(ctx, "  founder@acme.example  ")
+	if err != nil {
+		t.Fatalf("GetByOwnerEmail: %v", err)
+	}
+	if got.ID != seed.ID {
+		t.Errorf("ID = %q, want %q", got.ID, seed.ID)
+	}
+}
+
+// TestIntegration_GetByOwnerEmail_SubstringIsNotAMatch is the regression
+// guard against anyone later "simplifying" this into the directory's
+// ILIKE '%q%' search: a substring of a real owner_email must NOT match.
+func TestIntegration_GetByOwnerEmail_SubstringIsNotAMatch(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := NewRepository(tx)
+	ctx := context.Background()
+
+	seed := newTenant("Bob's Shop", "uid-owner-4", "bob@acme.example")
+	if err := repo.CreateInTx(ctx, tx, seed); err != nil {
+		t.Fatalf("CreateInTx: %v", err)
+	}
+
+	_, err := repo.GetByOwnerEmail(ctx, "ob@acme.example")
+	ae, ok := apperrors.As(err)
+	if !ok || ae.Code != "tenant_not_found" {
+		t.Errorf("expected tenant_not_found for substring query, got %v", err)
+	}
+}
+
+// TestIntegration_GetByOwnerEmail_UnseededEmailNotFound asserts an email
+// nothing owns returns a typed not-found rather than a zero-value Tenant
+// with a nil error.
+func TestIntegration_GetByOwnerEmail_UnseededEmailNotFound(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := NewRepository(tx)
+	ctx := context.Background()
+
+	got, err := repo.GetByOwnerEmail(ctx, "nobody@nowhere.example")
+	if got != nil {
+		t.Errorf("expected nil tenant, got %+v", got)
+	}
+	ae, ok := apperrors.As(err)
+	if !ok || ae.Code != "tenant_not_found" {
+		t.Errorf("expected tenant_not_found, got %v", err)
+	}
+}
+
+// TestIntegration_GetByOwnerEmail_EmptyAndWhitespaceOnly asserts both an
+// empty string and a whitespace-only string short-circuit to not-found
+// without touching the DB.
+func TestIntegration_GetByOwnerEmail_EmptyAndWhitespaceOnly(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := NewRepository(tx)
+	ctx := context.Background()
+
+	for _, probe := range []string{"", "   "} {
+		got, err := repo.GetByOwnerEmail(ctx, probe)
+		if got != nil {
+			t.Errorf("GetByOwnerEmail(%q): expected nil tenant, got %+v", probe, got)
+		}
+		ae, ok := apperrors.As(err)
+		if !ok || ae.Code != "tenant_not_found" {
+			t.Errorf("GetByOwnerEmail(%q): expected tenant_not_found, got %v", probe, err)
+		}
+	}
 }

--- a/services/platform-api/internal/tenant/handler.go
+++ b/services/platform-api/internal/tenant/handler.go
@@ -246,7 +246,31 @@ func (h *Handler) RegisterDirectory(g *gin.RouterGroup) {
 		// /detail, not /:id — the internal group already serves GET
 		// /tenants/:id with a different shape, and the admin BFF calls it.
 		t.GET("/:id/detail", h.getTenantDetail)
+		// Static sibling of :id. Verified against gin 1.12 with main.go's
+		// real two-group shape: no router-build panic, and /tenants/:id,
+		// /:id/detail and /:id/members all still resolve to their own
+		// handlers. Path chosen over a filter on the directory list because
+		// that list matches with ILIKE '%q%' — a substring match would
+		// report the wrong lead converted.
+		t.GET("/by-owner-email", h.getTenantByOwnerEmail)
 	}
+}
+
+// getTenantByOwnerEmail serves GET /internal/tenants/by-owner-email?email=...
+// (#279). Used by the marketplace-api console lookup that maps a lead's
+// email to the tenant it converted into. A missing or unowned email comes
+// back 404 — the repository already normalises (trim + lowercase) and
+// reports apperrors.NotFound, which respondError maps here. The 400 the
+// console contract expects for a missing email belongs to marketplace-api,
+// which knows it's serving a console caller; this hop only knows "found"
+// or "not found".
+func (h *Handler) getTenantByOwnerEmail(c *gin.Context) {
+	t, err := h.svc.GetByOwnerEmail(c.Request.Context(), c.Query("email"))
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": t})
 }
 
 func (h *Handler) listDirectory(c *gin.Context) {

--- a/services/platform-api/internal/tenant/repository.go
+++ b/services/platform-api/internal/tenant/repository.go
@@ -60,6 +60,12 @@ type Repository interface {
 	ListDirectory(ctx context.Context, f DirectoryFilter) (DirectoryResult, error)
 	// GetWithStores returns a tenant plus its store rollup in one query.
 	GetWithStores(ctx context.Context, id string) (*TenantWithStores, error)
+	// GetByOwnerEmail returns the tenant owned by the given email, or
+	// apperrors.NotFound when no tenant is. Comparison is case-insensitive
+	// and trims surrounding whitespace, matching OwnerEmailExists and the
+	// tenants_owner_email_unique index (migration 0014) — which is also why
+	// this returns at most one row rather than a slice.
+	GetByOwnerEmail(ctx context.Context, email string) (*Tenant, error)
 }
 
 // gormRepository is the GORM-backed implementation.

--- a/services/platform-api/internal/tenant/service.go
+++ b/services/platform-api/internal/tenant/service.go
@@ -191,5 +191,10 @@ func (s *Service) GetWithStores(ctx context.Context, id string) (*TenantWithStor
 	return s.repo.GetWithStores(ctx, id)
 }
 
+// GetByOwnerEmail returns the tenant owned by the given email (#279).
+func (s *Service) GetByOwnerEmail(ctx context.Context, email string) (*Tenant, error) {
+	return s.repo.GetByOwnerEmail(ctx, email)
+}
+
 // Phase Q: GetBySlug, IsSlugAvailable, validateSlug and slugPattern
 // moved to the store package — slug is a store-level identifier now.

--- a/services/platform-api/internal/tenant/service_test.go
+++ b/services/platform-api/internal/tenant/service_test.go
@@ -116,6 +116,21 @@ func (f *fakeRepo) GetWithStores(ctx context.Context, id string) (*TenantWithSto
 	return &TenantWithStores{Tenant: *t, Stores: []StoreSummary{}}, nil
 }
 
+// GetByOwnerEmail is likewise not exercised by these service-level unit
+// tests (covered by directory_integration_test.go against a real DB);
+// this stub exists only to satisfy the Repository interface.
+func (f *fakeRepo) GetByOwnerEmail(ctx context.Context, email string) (*Tenant, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, t := range f.byID {
+		if strings.EqualFold(strings.TrimSpace(t.OwnerEmail), strings.TrimSpace(email)) {
+			cp := *t
+			return &cp, nil
+		}
+	}
+	return nil, apperrors.NotFound("tenant_not_found", "no tenant owns that email")
+}
+
 func (f *fakeRepo) UpdateEditable(ctx context.Context, id string, patch map[string]any) (*Tenant, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()


### PR DESCRIPTION
Closes #279. Part of the platform console integration series (#260).

Unblocks the platform CRM's conversion column, which is blank today for every product because the `conversion-status` route has never been implemented.

## The contract

`404` **cannot** mean "not converted" — it is also what a framework returns for a route that does not exist, and the two are indistinguishable on the wire. So a miss is an explicit `200`:

| case | response |
|---|---|
| owner email matches | `200 {"state":"converted","ref":"<bare tenant id>","label":"<name>","observed_at":"<created_at>"}` |
| no tenant owns it | `200 {"state":"none"}` |
| `email` missing or blank | `400 validation_error` |
| upstream unreachable / 5xx | `503 upstream_unavailable` — never `none`, because "could not ask" is not "not converted" |

## How it works

Four layers, one per commit:

1. `platform-api` — `Repository.GetByOwnerEmail`, an exact case-insensitive match on `lower(owner_email)` that hits the `tenants_owner_email_unique` index from migration 0014.
2. `platform-api` — `GET /internal/tenants/by-owner-email`, mounted inside the existing `RegisterDirectory` behind `RequireInternalAuthStrict`.
3. `marketplace-api` — `tenantdirectory.Client.FindByOwnerEmail`, reusing the existing `do` helper's status mapping.
4. `marketplace-api` — the `platformadmin` handler that owns the wire shape.

**Deliberately exact, not the directory's search.** `ListDirectory` matches with `ILIKE '%q%'`; reusing it here would report `bob@x.com` converted because `rob@x.com` owns a tenant. A dedicated exact lookup avoids that.

**Migration 0014 removed a design question.** The unique index on `lower(owner_email)` means an email owns at most one tenant, so there is no tie-break and no multi-match error type.

**No `main.go` change in either service.** Extending the existing `TenantDirectory` interface rather than adding a `Deps` field means both existing wiring sites compile untouched.

## Scoping decision worth objecting to before it ships

Conversion means **owning** a tenant — `tenants.owner_email` only. A lead later invited as staff on someone else's tenant reads as `none`. That matches "has this lead become a tenant", and it is the only signal with a unique index behind it; staff membership lives in OpenFGA rather than queryably in Postgres. Raised on #279 for the console side.

## Test plan

- [x] `platform-api` integration suite green with `-p 1` (the packages share one local Postgres)
- [x] `marketplace-api` `platformadmin` + `tenantdirectory` packages green
- [x] `go build ./...` clean in both services
- [x] Exact-match behaviour proven by mutation: swapping the query for `ILIKE` breaks `SubstringIsNotAMatch`; dropping `ToLower`/`TrimSpace` each breaks its own test
- [x] Contract proven by mutation: returning 404 on a miss, or `none` on an upstream failure, each break a test
- [x] Golden fixture proven two-sided — it fails on a field **rename** and on a field **addition**, not only an omission
- [x] Three-hop chain exercised end to end: upstream `owner_user_id` (a GIP UID) never reaches the console, and a `+05:30` timestamp is genuinely converted to UTC
- [ ] Verify against production after deploy (Kargo-gated; expect 10-20 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)