### PR TITLE
feat(platformadmin): onboarding funnel and sessions for the platform console (#283)

### DIFF
--- a/docs/superpowers/plans/2026-08-23-onboarding-funnel.md
+++ b/docs/superpowers/plans/2026-08-23-onboarding-funnel.md
@@ -1,0 +1,247 @@
+# Onboarding Funnel Implementation Plan (#283)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose mark8ly's onboarding funnel to the Tesserix platform console — estate-wide counters plus the session rows behind them, agreeing with each other by construction.
+
+**Architecture:** `platform-api` owns both queries, including one shared SQL predicate for "abandoned" that the counters and the rows both use. `marketplace-api` calls them through a new `onboardingfunnel` client and reshapes onto the `platformadmin` surface.
+
+**Tech Stack:** Go 1.26, Gin 1.12, GORM, PostgreSQL 15, testify.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-onboarding-funnel-design.md` — the binding authority. Read its "Definitions" and "The finding that shapes this design" sections before writing any query.
+
+## The finding you must not re-derive
+
+`StatusAbandoned` and `StatusExpired` exist as constants and in migration 0004's CHECK constraint, and the package doc claims sessions transition to them. **Nothing writes either value.** There is no gc. Every production session is `in_progress`, `verifying` or `completed`.
+
+So **`abandoned` is derived from idle time, never read from `status`**. Filed as #322. Do not "fix" this by querying `status = 'abandoned'` — that returns zero forever and looks like a data problem.
+
+## Global Constraints
+
+- **Abandoned** = not completed AND `last_activity_at <= now() - 24 hours`. **In flight** = not completed AND `last_activity_at > now() - 24 hours`. Exactly 24h idle is **abandoned**.
+- `24 * time.Hour` lives in ONE exported named constant. No literal `24` in a query.
+- **One shared SQL predicate** for abandoned, used by both the funnel aggregate and the sessions list — the way `applyDirectoryFilter` is shared by the directory's count and page queries. Two copies is how the two endpoints come to disagree.
+- **Partition invariant:** `completed + in_flight + abandoned == started`, exactly, for any window. Assert it in a test.
+- `email_verified` is a **subset counter that cuts across** the partition, not a stage. Do not include it in the sum.
+- `median_completion_seconds` is `null` with zero completions. Never `0`.
+- `last_24h` is always `now()-24h … now()` and **ignores the window**.
+- The funnel returns a single object with **no `pagination` key**. `sessions` uses the standard envelope; empty is `200` with `[]`, allocated via `make([]T, 0, n)`.
+- `pagination.limit` reports the **effective** (clamped) limit. Clamp at 500. A missing parameter takes the default and never errors.
+- Ids **bare**. Timestamps RFC3339 UTC with offset. Never send a `source` field.
+- **`draft` must never reach the console.** It is a JSONB blob of merchant-entered wizard data. Project field by field and assert its absence in a test.
+- Commit messages: single line, conventional-commit prefix, no signature, no `Co-Authored-By` trailer.
+
+## Two conventions that differ between the services
+
+- **`platform-api` tests use the INTERNAL package** — `package onboarding`, not `onboarding_test`. See `internal/onboarding/completion_integration_test.go`.
+- **`marketplace-api` tests use the EXTERNAL package** — `package platformadmin_test`, `package onboardingfunnel_test`.
+
+Both use `//go:build integration` and the `*_integration_test.go` suffix for DB-backed tests.
+
+## Environment
+
+- **Use the LAN IP, not localhost** — a native Postgres squats on 127.0.0.1 on this machine, so `localhost` reports `role "dev" does not exist`:
+  - platform: `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/platform_api?sslmode=disable'`
+  - marketplace: `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'`
+  The committed Makefile says `localhost`, correct everywhere else — **do not change it**.
+- Integration runs need `-p 1`. The packages share one local Postgres; parallel execution exhausts its connection limit (`FATAL: sorry, too many clients already`) and presents as data pollution. It is not.
+- Do NOT run `make dev` — the migrate containers are broken here.
+- Never run anything against a remote or GKE database. The only cluster that exists is production.
+- Ignore `go.work requires go >= 1.26.6 (running go 1.26.5)` from vet/LSP — pre-existing drift.
+
+## Time-dependent tests: seed relative to `now()`
+
+Every one of these queries compares against `now()`. Seed fixtures as offsets from the current time (`now - 25h`, `now - 23h`, `now - 24h`), never as absolute timestamps — an absolute fixture passes today and fails tomorrow. Insert `last_activity_at` explicitly rather than letting the column default fire.
+
+## File Structure
+
+**`platform-api`**
+
+| File | Responsibility |
+|---|---|
+| `internal/onboarding/funnel.go` (create) | The constant, the shared predicate, `FunnelStats`, `SessionRow`, both queries |
+| `internal/onboarding/repository.go` (modify) | Two methods on the `Repository` interface |
+| `internal/onboarding/service.go` (modify) | Two passthroughs |
+| `internal/onboarding/funnel_integration_test.go` (create) | Boundary, partition, median, window, cross-endpoint agreement |
+| `internal/onboarding/handler.go` (modify) | `RegisterAnalytics(g *gin.RouterGroup)` plus two handlers |
+| `internal/onboarding/funnel_handler_test.go` (create) | Query parsing, clamping, envelope, null median |
+| `cmd/server/main.go` (modify) | Mount on the strict group |
+
+**`marketplace-api`**
+
+| File | Responsibility |
+|---|---|
+| `internal/onboardingfunnel/client.go` (create) | Client, `ErrUnavailable`, both calls |
+| `internal/onboardingfunnel/client_test.go` (create) | Envelope parsing, null median, 5xx, transport failure |
+| `internal/handlers/platformadmin/onboarding.go` (create) | Both handlers and the wire shapes |
+| `internal/handlers/platformadmin/onboarding_test.go` (create) | Golden fixtures, draft-absence, empty-is-array |
+| `internal/handlers/platformadmin/testdata/onboarding_funnel.json` (create) | Golden fixture |
+| `internal/handlers/platformadmin/testdata/onboarding_sessions.json` (create) | Golden fixture |
+| `internal/handlers/platformadmin/routes.go` (modify) | New `Deps` field, mount both |
+| `cmd/marketplace-api/main.go` (modify) | Wire the client at BOTH sites |
+
+---
+
+### Task 1: platform-api — the queries
+
+**Files:** `internal/onboarding/funnel.go` (create), `repository.go`, `service.go`, `funnel_integration_test.go` (create)
+
+Create `funnel.go` with:
+
+```go
+// AbandonedAfter is how long a non-completed session may sit idle before the
+// funnel counts it abandoned.
+//
+// Derived, not stored: StatusAbandoned exists as a constant and in migration
+// 0004's CHECK constraint, but nothing ever writes it and there is no gc
+// (#322). Querying status = 'abandoned' returns zero forever.
+//
+// 24h because onboarding is normally one sitting; the only legitimate long
+// pause is waiting on the verification email, which is minutes to hours.
+const AbandonedAfter = 24 * time.Hour
+```
+
+The shared predicate — **one definition, used by both queries**:
+
+```go
+// abandonedExpr is the SQL for "not completed and idle past the cutoff".
+// Shared by the funnel aggregate and the sessions list so the two cannot
+// disagree about which sessions are abandoned. Exactly AbandonedAfter idle
+// counts as abandoned, hence <=.
+func abandonedExpr() string {
+	return "(onboarding_sessions.status <> 'completed' AND onboarding_sessions.last_activity_at <= now() - INTERVAL '24 hours')"
+}
+```
+
+Derive the interval from `AbandonedAfter` rather than hardcoding `'24 hours'` twice — e.g. build it with `fmt.Sprintf("%d hours", int(AbandonedAfter.Hours()))` as a bound parameter, or use `now() - make_interval(hours => ?)`. Pick one and make the constant genuinely load-bearing: a test must be able to prove that changing `AbandonedAfter` changes the query's behaviour.
+
+`FunnelStats` and `SessionRow` types, plus a `FunnelFilter` carrying `CreatedFrom`, `CreatedTo`, `Status`, `Abandoned *bool`, `Page`, `Limit`.
+
+**`GetFunnel`** — ONE query with `FILTER (WHERE …)` aggregates. Five separate counts could observe five different database states and break the partition for reasons unrelated to the data:
+
+```sql
+SELECT
+  COUNT(*)                                        AS started,
+  COUNT(*) FILTER (WHERE email_verified_at IS NOT NULL) AS email_verified,
+  COUNT(*) FILTER (WHERE status = 'completed')    AS completed,
+  COUNT(*) FILTER (WHERE <abandoned>)             AS abandoned,
+  COUNT(*) FILTER (WHERE status <> 'completed' AND NOT (<abandoned>)) AS in_flight,
+  percentile_cont(0.5) WITH IN GROUP (ORDER BY EXTRACT(EPOCH FROM completed_at - created_at))
+    FILTER (WHERE status = 'completed')           AS median_completion_seconds
+FROM onboarding_sessions WHERE <window>
+```
+
+Note the exact syntax is `percentile_cont(0.5) WITHIN GROUP (ORDER BY …)` — check it compiles rather than copying the line above verbatim.
+
+Scan `median_completion_seconds` into a `*float64` so SQL `NULL` survives as Go `nil`. Scanning into `float64` silently turns "nothing completed" into `0`.
+
+`last_24h` is a second, tiny query over `created_at > now() - INTERVAL '24 hours'` — **not** filtered by the window.
+
+**`ListSessions`** — page + unpaginated total, sharing the same filter builder, ordered `created_at DESC`. Allocate before `Find`. Clamp limit at 500, default 50 (mirror `DefaultDirectoryPageSize`/`MaxDirectoryPageSize` in the tenant package).
+
+**Tests** (`funnel_integration_test.go`, `package onboarding`, `//go:build integration`). Seed relative to `now()`:
+
+- [ ] **Boundary:** sessions at `now-23h` (in flight), `now-25h` (abandoned) and **exactly `now-24h` (abandoned)**. This pins the rule rather than leaving it to whichever operator was typed.
+- [ ] **Partition:** over a mixed fixture, `completed + in_flight + abandoned == started`, exactly.
+- [ ] **Cross-endpoint agreement:** the funnel's `abandoned` count equals the number of rows `ListSessions` flags abandoned over the same window. This is what proves the predicate is genuinely shared.
+- [ ] **Median, odd count:** three completions of 10s, 20s, 60s → 20.
+- [ ] **Median, even count:** two completions of 10s and 20s → 15. The even case is where a wrong percentile implementation shows up.
+- [ ] **Median, zero completions:** `nil`, not `0`.
+- [ ] **Window:** a session created outside `[from, to]` appears in neither the counters nor the rows.
+- [ ] **`last_24h` ignores the window:** with a window entirely in the past, `last_24h.started` still counts a session created minutes ago.
+- [ ] **A completed session is never abandoned**, however old and idle.
+
+**Verify:** `cd services/platform-api && TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/platform_api?sslmode=disable' go test -tags=integration -p 1 -count=1 ./internal/onboarding/...`
+
+**Commit:** `feat(onboarding): funnel counters and session rows (#283)`
+
+---
+
+### Task 2: platform-api — the internal endpoints
+
+**Files:** `internal/onboarding/handler.go`, `internal/onboarding/funnel_handler_test.go` (create), `cmd/server/main.go`
+
+Add `RegisterAnalytics(g *gin.RouterGroup)` to the onboarding `Handler`, mounting `GET /onboarding/funnel` and `GET /onboarding/sessions`. Keep it **separate from `Register`**, whose routes are public wizard routes on `/api/v1` — mirroring how `tenant.RegisterDirectory` is separate from `tenant.Register`, and for the same reason.
+
+In `cmd/server/main.go`, mount it on the **strict** group (the one already built at line ~347 for the tenant directory). Both endpoints return estate-wide data, so an unconfigured deploy must refuse rather than serve the lot.
+
+**Rename that group's variable** from `tenantDirectory` to something like `strictInternal`, since it now carries two features. Update the one existing use. Keep the explanatory comment above it and extend it to say the onboarding analytics routes share the guard for the same reason.
+
+Unlike #279, **this task does change `main.go`** — the onboarding handler has no existing mount on the strict group. That is expected here.
+
+**Tests** (`funnel_handler_test.go`):
+
+- [ ] Funnel returns `200` with the counters under `data`, and **no `pagination` key**.
+- [ ] `median_completion_seconds` serialises as JSON `null` when nil — assert on raw JSON, not a decoded struct, since decoding makes `null` and `0` hard to tell apart.
+- [ ] Sessions returns the standard envelope; empty is `[]`, not `null`.
+- [ ] `limit=9999` clamps to 500 and `pagination.limit` reports **500**.
+- [ ] A missing parameter takes the default and does not error.
+- [ ] Both routes are reachable under the strict group's prefix and do not collide with the existing `/onboarding/sessions/:id` public route. **Assert both in one test** — `/onboarding/sessions` (static, analytics) and `/onboarding/sessions/:id` (public wizard) live at the same path position, and a future edit could shadow one. This is the #287 class of bug.
+
+**Verify:** package tests plus `go build ./...`.
+
+**Commit:** `feat(onboarding): internal funnel and sessions endpoints (#283)`
+
+---
+
+### Task 3: marketplace-api — the client
+
+**Files:** `internal/onboardingfunnel/client.go` (create), `client_test.go` (create)
+
+A new package modelled on `internal/tenantdirectory` — same `do` helper shape, same `ErrUnavailable` sentinel and reasoning. Separate package on purpose: a funnel read is a different concern from a directory read and the two will diverge.
+
+No `ErrNotFound` is needed: neither endpoint 404s.
+
+`FunnelStats` must carry `MedianCompletionSeconds *float64` so upstream `null` survives as `nil` rather than becoming `0`.
+
+**Tests:**
+
+- [ ] Sends `X-Internal-Auth`; requests the right paths.
+- [ ] Parses the funnel envelope including nested `last_24h` and `window`.
+- [ ] **`"median_completion_seconds": null` parses to `nil`, not `0`.**
+- [ ] Parses the sessions envelope; `"data": []` yields an allocated empty slice, and `"data": null` also yields an allocated empty slice.
+- [ ] Upstream 5xx → `ErrUnavailable`. Transport failure → `ErrUnavailable`.
+- [ ] Window parameters are URL-encoded correctly (RFC3339 contains `+` in offsets — use an offset timestamp so a naive concatenation fails this test).
+
+**Verify:** `cd services/marketplace-api && go test ./internal/onboardingfunnel/...`
+
+**Commit:** `feat(onboardingfunnel): client for the platform onboarding funnel (#283)`
+
+---
+
+### Task 4: marketplace-api — the platformadmin endpoints
+
+**Files:** `internal/handlers/platformadmin/onboarding.go` (create), `onboarding_test.go` (create), two fixtures under `testdata/`, `routes.go`, `cmd/marketplace-api/main.go`
+
+Declare an `OnboardingFunnel` interface in `onboarding.go` (the subset the handler needs), add an `OnboardingFunnel` field to `platformadmin.Deps`, and mount both routes when it is non-nil — mirroring the existing `TenantDirectory` treatment.
+
+Unlike #279, **this task does add a `Deps` field and does change `main.go`**, because the client is a new type. Wire it at **both** sites (~1917 and ~2003), guarded by `cfg.PlatformAPIURL != ""` exactly as `tenantDirectoryClient` is. Missing one site means the endpoint works in one server mode and 404s in the other.
+
+Wire shapes exactly as the spec's two JSON blocks. `median_completion_seconds` is `*float64` with **no `omitempty`** — the console must receive an explicit `null`, not a missing key.
+
+Session rows are projected field by field. **`draft` must not appear.**
+
+Errors: `ErrUnavailable` → `503 upstream_unavailable`; anything else → `500 internal_error`. Never an empty funnel on failure.
+
+**Tests:**
+
+- [ ] Golden fixture per endpoint, each **proven by mutation**: rename a JSON tag and confirm the test fails; add a field to the response struct and confirm it fails again. Revert both and report both results.
+- [ ] **`draft` absent** from a session row even when the stub supplies a populated `draft`. Assert on the raw JSON body, not a decoded struct.
+- [ ] Empty sessions is `200` with `[]` — assert the raw `data` is exactly `[]`.
+- [ ] `median_completion_seconds` serialises as `null` when nil, and is **present** (not omitted).
+- [ ] Upstream unavailable → `503` on both endpoints, and the body carries no counters.
+- [ ] `pagination.limit` reflects what the client reported, not what was requested.
+
+**Verify:** `cd services/marketplace-api && go test ./internal/handlers/platformadmin/... ./internal/onboardingfunnel/... && go build ./...`
+
+**Commit:** `feat(platformadmin): onboarding funnel and sessions (#283)`
+
+---
+
+## After the plan
+
+- [ ] `go build ./...` clean in both services.
+- [ ] Full unit suites green in every touched package.
+- [ ] Integration suite green in `platform-api/internal/onboarding` with `-p 1`.
+- [ ] Confirm the `AbandonedAfter` constant is load-bearing: changing it changes query behaviour, proven by a test rather than by inspection.
+- [ ] Comment on #283 with the delivered shape, the 24h cutoff, and the derived-not-stored explanation, linking #322.

--- a/docs/superpowers/specs/2026-08-23-onboarding-funnel-design.md
+++ b/docs/superpowers/specs/2026-08-23-onboarding-funnel-design.md
@@ -1,0 +1,131 @@
+# Onboarding Funnel — Design
+
+**Issue:** #283. Part of the platform console integration series (#260), after #274, #275, #276, #277, #279.
+
+**Goal:** Expose mark8ly's onboarding funnel to the Tesserix platform console, so the estate-wide view of *lead → onboarding session → tenant* stops being split across three places with no endpoint over the middle one.
+
+## The finding that shapes this design
+
+`internal/onboarding/models.go` declares `StatusAbandoned` and `StatusExpired`, migration 0004 CHECK-constrains both, and the package doc comment states that a session "may transition to `status="abandoned"` (browser close) or `"expired"` (gc)".
+
+**Neither value is ever written.** The repository exposes `Create`, `GetByID`, `UpdateDraft`, `MarkEmailVerified` and `CompleteInTx` — no status transition to either. There is no gc, cron, sweep or reaper for onboarding sessions anywhere in the workspace (verified by searching all Go, TypeScript and SQL outside tests). In production, every session is `in_progress`, `verifying` or `completed`.
+
+Two consequences, and they are the whole reason this document exists:
+
+1. **`abandoned` cannot be read from the status column.** It is derived from idle time.
+2. **The package doc is wrong** and will mislead the next reader. Recorded as a follow-up issue rather than fixed here, to keep this change read-only.
+
+`last_activity_at` is genuinely maintained — `UpdateDraft`, `MarkEmailVerified` and `CompleteInTx` all set it — and migration 0004 indexes it (`idx_onboarding_sessions_last_activity`). So deriving from it is both honest and cheap.
+
+## Definitions
+
+Fixed for this endpoint. The console must not be able to reach two different numbers for the same word.
+
+- **Started** — a session row exists. Every session counts, whatever its status.
+- **Email verified** — `email_verified_at IS NOT NULL`. A **subset counter that cuts across the others**, not a funnel stage: a verified session may be completed, in flight or abandoned. This is the single most misreadable field on the response and the spec says so out loud.
+- **Completed** — `status = 'completed'`. `completed_at` is the timestamp.
+- **Abandoned** — not completed, and `last_activity_at <= now() - 24 hours`.
+- **In flight** — not completed, and `last_activity_at > now() - 24 hours`.
+
+**The 24-hour cutoff is a product decision**, chosen because onboarding is normally one sitting and the only legitimate long pause is waiting on the verification email, which is minutes to hours. It is a named constant, not a literal scattered through queries.
+
+**Boundary rule: exactly 24 hours idle is abandoned**, not in flight. Arbitrary, but stated, and pinned by a test — otherwise it is decided accidentally by whichever comparison operator someone typed.
+
+### The partition invariant
+
+    completed + in_flight + abandoned == started
+
+Exact, for any window. This is acceptance criterion "counters and rows agree with each other for the same window" made checkable, and it is asserted directly by a test. `email_verified` is deliberately outside it.
+
+## `GET /admin/onboarding/funnel`
+
+```json
+{"data": {
+  "started": 412,
+  "email_verified": 301,
+  "completed": 188,
+  "in_flight": 34,
+  "abandoned": 190,
+  "median_completion_seconds": 743,
+  "last_24h": {"started": 12, "completed": 5},
+  "window": {"from": "2026-08-01T00:00:00Z", "to": "2026-08-23T00:00:00Z"}
+}}
+```
+
+- Single object. **No `pagination` key.**
+- `median_completion_seconds` is `percentile_cont(0.5)` over `completed_at - created_at` for sessions completed in the window. **`null` when nothing completed** — never `0`, which reads as "instant".
+- `last_24h` is always `now()-24h … now()` and **ignores the window**. It is a live pulse for the console header. Intersecting it with the window would return `0` for any historical window, which looks like a data problem rather than a definition.
+- `window` echoes the effective window back, including the defaults, so the console can render what it actually got rather than what it thinks it asked for.
+- Computed in **one query** with `FILTER (WHERE …)` aggregates. Five separate counts could observe five different database states and break the partition invariant for reasons unrelated to the data.
+
+## `GET /admin/onboarding/sessions`
+
+Standard envelope: `{"data": [...], "pagination": {"page","limit","total"}}`. Empty is `200` with `[]`.
+
+Row shape:
+
+```json
+{
+  "id": "<bare uuid>",
+  "email": "founder@acme.example",
+  "status": "in_progress",
+  "created_at": "2026-08-22T10:00:00Z",
+  "last_activity_at": "2026-08-22T10:14:00Z",
+  "idle_hours": 31.4,
+  "abandoned": true,
+  "completed_at": null,
+  "tenant_id": null
+}
+```
+
+- `status` is the **stored** status, unmodified. `abandoned` is the **derived** flag. Keeping them as separate fields rather than overwriting `status` with a synthetic `"abandoned"` means the console can see that the stored status is `in_progress` while the flag says abandoned — which is the truth, and which is what makes the dead-status problem visible rather than hidden.
+- `idle_hours` is a float, computed as `EXTRACT(EPOCH FROM now() - last_activity_at) / 3600`, so a caller can apply its own threshold without a second round trip.
+- `tenant_id` is **bare** and `null` until completion.
+- Ids bare, timestamps RFC3339 UTC with offset, no `source` field.
+
+## Shared window and the anti-drift rule
+
+Both endpoints accept `created_from` and `created_to` (RFC3339), matching the tenant directory's parameter names. `sessions` additionally accepts `status` and `abandoned=true|false`.
+
+**The abandoned predicate is defined once in SQL and shared by both queries**, the way `applyDirectoryFilter` is shared by the directory's count and page queries. Two hand-written copies is exactly how the funnel's `abandoned` count and the rows' `abandoned` flags come to disagree — the failure the acceptance criterion is written to prevent.
+
+Defaults follow the directory: missing parameter takes the default and never errors, `limit` clamps at 500, `pagination.limit` reports the **effective** (clamped) limit so `total / limit` is a correct page count.
+
+## Architecture
+
+Unchanged from #277/#279 — this is the third endpoint through the same path, and it should not invent a fourth shape.
+
+| Layer | Responsibility |
+|---|---|
+| `platform-api` repository | Both queries. Owns the SQL, the shared predicate and the constant. |
+| `platform-api` internal endpoints | `GET /internal/onboarding/funnel` and `/internal/onboarding/sessions`, on the **strict** auth group — both return estate-wide data, so an unconfigured deploy must refuse rather than serve the lot. |
+| `marketplace-api` client | A new `onboardingfunnel` package, modelled on `tenantdirectory`. Separate package: a funnel read is a different concern from a tenant directory read and the two will diverge. |
+| `marketplace-api` handler | Owns the wire shape. Projects field by field. |
+
+**Projection, not passthrough.** The session row upstream carries `draft` — a JSONB blob of whatever the wizard has collected, which may hold business details and is not the console's business. It must never reach the console. The projection is what guarantees that, and a test asserts `draft` is absent from the response.
+
+**Error semantics** inherit #279's: upstream unreachable or 5xx is `503 upstream_unavailable`, never an empty result, because "we could not ask" and "nothing there" are different answers. A non-404 4xx becomes `500` — that means our own configuration is broken and retrying never helps.
+
+## Testing
+
+Integration tests (platform-api, internal `package onboarding`, `//go:build integration`):
+
+- Sessions seeded either side of the 24h boundary, **including one at exactly 24h idle**, pinning the boundary rule.
+- The partition invariant asserted over a mixed fixture: completed + in flight + abandoned equals started, exactly.
+- Median with an **even** and an **odd** number of completions (the even case is where a wrong percentile implementation shows up), and `null` with zero completions.
+- The funnel's `abandoned` count equals the number of rows the sessions endpoint flags abandoned over the same window — the two must be computed from the shared predicate and this test is what proves they are.
+- Window filtering: a session outside the window appears in neither.
+- `last_24h` unaffected by a historical window.
+
+Handler tests (marketplace-api, external `package platformadmin_test`):
+
+- Golden fixture per endpoint, each proven by mutation against a field **rename** and a field **addition**.
+- `draft` absent from a session row even when the stub supplies it.
+- Empty result is `200` with `[]`, not `null` or `{}`.
+- `median_completion_seconds` serialises as `null`, not omitted and not `0`.
+- Upstream unavailable is `503`, not an empty funnel.
+
+## Out of scope
+
+- **Writing** `abandoned`/`expired` statuses, or adding the gc the package doc imagines. This change is read-only. Follow-up issue filed.
+- Verifications and invitations. The issue mentions them as nearby data; the funnel it specifies is sessions-only. Adding them later is additive.

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -86,6 +86,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/mode"
 	"github.com/mark8ly/marketplace-api/internal/notification"
 	"github.com/mark8ly/marketplace-api/internal/observability"
+	"github.com/mark8ly/marketplace-api/internal/onboardingfunnel"
 	"github.com/mark8ly/marketplace-api/internal/order"
 	"github.com/mark8ly/marketplace-api/internal/orderdoc"
 	"github.com/mark8ly/marketplace-api/internal/orderrefund"
@@ -1915,16 +1916,20 @@ func main() {
 		admin.RegisterAdmin(r.Group("/api/v1"), adminDeps)
 		admin.RegisterAdminMobile(r.Group("/api/v1"), mobileDeps)
 		var tenantDirectoryClient platformadmin.TenantDirectory
+		var onboardingFunnelClient platformadmin.OnboardingFunnel
 		if cfg.PlatformAPIURL != "" {
 			tenantDirectoryClient = tenantdirectory.NewClient(
 				cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
+			onboardingFunnelClient = onboardingfunnel.NewClient(
+				cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 		}
 		platformadmin.Register(r.Group("/api/v1/platform"), platformadmin.Deps{
-			DB:              conn,
-			Repo:            auditRepo,
-			Logger:          log,
-			Secret:          cfg.PlatformAdminSecret,
-			TenantDirectory: tenantDirectoryClient,
+			DB:               conn,
+			Repo:             auditRepo,
+			Logger:           log,
+			Secret:           cfg.PlatformAdminSecret,
+			TenantDirectory:  tenantDirectoryClient,
+			OnboardingFunnel: onboardingFunnelClient,
 		})
 		storefront.RegisterStorefront(r.Group("/api/v1"), storefrontDeps)
 		storefront.RegisterMobileStorefrontSupport(r.Group("/api/v1"), storefrontSupportHandler, storefrontDeps.SlugCache, storefrontCustomerVerifier)
@@ -2001,16 +2006,20 @@ func main() {
 			admin.RegisterAdmin(engine.Group("/api/v1"), adminDeps)
 			admin.RegisterAdminMobile(engine.Group("/api/v1"), mobileDeps)
 			var tenantDirectoryClient platformadmin.TenantDirectory
+			var onboardingFunnelClient platformadmin.OnboardingFunnel
 			if cfg.PlatformAPIURL != "" {
 				tenantDirectoryClient = tenantdirectory.NewClient(
 					cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
+				onboardingFunnelClient = onboardingfunnel.NewClient(
+					cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 			}
 			platformadmin.Register(engine.Group("/api/v1/platform"), platformadmin.Deps{
-				DB:              conn,
-				Repo:            auditRepo,
-				Logger:          log,
-				Secret:          cfg.PlatformAdminSecret,
-				TenantDirectory: tenantDirectoryClient,
+				DB:               conn,
+				Repo:             auditRepo,
+				Logger:           log,
+				Secret:           cfg.PlatformAdminSecret,
+				TenantDirectory:  tenantDirectoryClient,
+				OnboardingFunnel: onboardingFunnelClient,
 			})
 			// Public Delhivery webhook receiver. Mounted on the admin
 			// engine because the merchant-configured URL points at the

--- a/services/marketplace-api/internal/handlers/platformadmin/onboarding.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/onboarding.go
@@ -29,19 +29,11 @@ type OnboardingFunnel interface {
 type OnboardingFunnelHandler struct {
 	client OnboardingFunnel
 	logger *slog.Logger
-	// now is injectable for tests, defaulting to time.Now. It backs
-	// idle_hours, which is computed here rather than upstream because
-	// onboardingfunnel.Session does not carry it.
-	now func() time.Time
 }
 
-// NewOnboardingFunnelHandler constructs the handler. logger may be nil; now
-// may be nil (defaults to time.Now).
-func NewOnboardingFunnelHandler(client OnboardingFunnel, logger *slog.Logger, now func() time.Time) *OnboardingFunnelHandler {
-	if now == nil {
-		now = time.Now
-	}
-	return &OnboardingFunnelHandler{client: client, logger: logger, now: now}
+// NewOnboardingFunnelHandler constructs the handler. logger may be nil.
+func NewOnboardingFunnelHandler(client OnboardingFunnel, logger *slog.Logger) *OnboardingFunnelHandler {
+	return &OnboardingFunnelHandler{client: client, logger: logger}
 }
 
 // Register mounts both routes on the supplied group.
@@ -182,7 +174,7 @@ func (h *OnboardingFunnelHandler) toSessionRow(s onboardingfunnel.Session) sessi
 		Status:         s.Status,
 		CreatedAt:      s.CreatedAt.UTC().Format(time.RFC3339),
 		LastActivityAt: s.LastActivityAt.UTC().Format(time.RFC3339),
-		IdleHours:      h.now().Sub(s.LastActivityAt).Hours(),
+		IdleHours:      s.IdleHours,
 		Abandoned:      s.Abandoned,
 	}
 	if s.CompletedAt != nil {

--- a/services/marketplace-api/internal/handlers/platformadmin/onboarding.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/onboarding.go
@@ -1,0 +1,253 @@
+package platformadmin
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/marketplace-api/internal/onboardingfunnel"
+)
+
+// OnboardingFunnel is the subset of onboardingfunnel.Client this handler
+// needs. Declared here so the handler can be tested with a stub and so the
+// transport package stays swappable.
+type OnboardingFunnel interface {
+	GetFunnel(ctx context.Context, p onboardingfunnel.FunnelParams) (*onboardingfunnel.FunnelStats, error)
+	ListSessions(ctx context.Context, p onboardingfunnel.SessionsParams) (*onboardingfunnel.SessionsResult, error)
+}
+
+// OnboardingFunnelHandler serves the platform console's onboarding funnel
+// and session list (#283). It owns the wire shape and nothing else — the
+// counters, the shared abandoned predicate and the 24h cutoff all live in
+// platform-api, which owns the data.
+type OnboardingFunnelHandler struct {
+	client OnboardingFunnel
+	logger *slog.Logger
+	// now is injectable for tests, defaulting to time.Now. It backs
+	// idle_hours, which is computed here rather than upstream because
+	// onboardingfunnel.Session does not carry it.
+	now func() time.Time
+}
+
+// NewOnboardingFunnelHandler constructs the handler. logger may be nil; now
+// may be nil (defaults to time.Now).
+func NewOnboardingFunnelHandler(client OnboardingFunnel, logger *slog.Logger, now func() time.Time) *OnboardingFunnelHandler {
+	if now == nil {
+		now = time.Now
+	}
+	return &OnboardingFunnelHandler{client: client, logger: logger, now: now}
+}
+
+// Register mounts both routes on the supplied group.
+func (h *OnboardingFunnelHandler) Register(g *gin.RouterGroup) {
+	g.GET("/admin/onboarding/funnel", h.funnel)
+	g.GET("/admin/onboarding/sessions", h.sessions)
+}
+
+// funnelCountsRow is the top-level counters shape, shared by the funnel
+// response's root and (narrowed, see last24hRow) its last_24h field.
+type funnelCountsRow struct {
+	Started       int64 `json:"started"`
+	EmailVerified int64 `json:"email_verified"`
+	Completed     int64 `json:"completed"`
+	InFlight      int64 `json:"in_flight"`
+	Abandoned     int64 `json:"abandoned"`
+}
+
+// last24hRow is deliberately narrower than funnelCountsRow — the contract
+// pins only started/completed for the live pulse, not the full counter set.
+type last24hRow struct {
+	Started   int64 `json:"started"`
+	Completed int64 `json:"completed"`
+}
+
+type funnelWindowRow struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// funnelRow is the funnel wire shape. MedianCompletionSeconds has NO
+// omitempty: the console must receive an explicit JSON null when nothing
+// completed in the window, never a missing key and never 0 (which reads as
+// "instant completion").
+type funnelRow struct {
+	funnelCountsRow
+	MedianCompletionSeconds *float64        `json:"median_completion_seconds"`
+	Last24h                 last24hRow      `json:"last_24h"`
+	Window                  funnelWindowRow `json:"window"`
+}
+
+func (h *OnboardingFunnelHandler) funnel(c *gin.Context) {
+	p := onboardingfunnel.FunnelParams{}
+	if t, ok := parseTime(c.Query("created_from")); ok {
+		p.CreatedFrom = t
+	}
+	if t, ok := parseTime(c.Query("created_to")); ok {
+		p.CreatedTo = t
+	}
+
+	stats, err := h.client.GetFunnel(c.Request.Context(), p)
+	if err != nil {
+		h.respondErr(c, err)
+		return
+	}
+
+	// Single object, no pagination key — deliberately not reusing
+	// listResponse/pagination here.
+	c.JSON(http.StatusOK, gin.H{"data": toFunnelRow(stats)})
+}
+
+func toFunnelRow(s *onboardingfunnel.FunnelStats) funnelRow {
+	return funnelRow{
+		funnelCountsRow: funnelCountsRow{
+			Started:       s.Started,
+			EmailVerified: s.EmailVerified,
+			Completed:     s.Completed,
+			InFlight:      s.InFlight,
+			Abandoned:     s.Abandoned,
+		},
+		MedianCompletionSeconds: s.MedianCompletionSeconds,
+		Last24h: last24hRow{
+			Started:   s.Last24h.Started,
+			Completed: s.Last24h.Completed,
+		},
+		Window: funnelWindowRow{From: s.Window.From, To: s.Window.To},
+	}
+}
+
+// sessionRow is the sessions wire shape. Projected field by field from
+// onboardingfunnel.Session: the upstream row also carries `draft`, a JSONB
+// blob of merchant-entered wizard data that must never reach the console.
+// Naming every field here — rather than embedding or passing the client
+// type through — is what makes that structurally impossible.
+//
+// CompletedAt and TenantID have NO omitempty: the contract pins them as
+// explicit null until completion, not an omitted key.
+type sessionRow struct {
+	ID             string  `json:"id"`
+	Email          string  `json:"email"`
+	Status         string  `json:"status"`
+	CreatedAt      string  `json:"created_at"`
+	LastActivityAt string  `json:"last_activity_at"`
+	IdleHours      float64 `json:"idle_hours"`
+	Abandoned      bool    `json:"abandoned"`
+	CompletedAt    *string `json:"completed_at"`
+	TenantID       *string `json:"tenant_id"`
+}
+
+type sessionsListResponse struct {
+	Data       []sessionRow `json:"data"`
+	Pagination pagination   `json:"pagination"`
+}
+
+func (h *OnboardingFunnelHandler) sessions(c *gin.Context) {
+	p := parseSessionsParams(c)
+
+	res, err := h.client.ListSessions(c.Request.Context(), p)
+	if err != nil {
+		h.respondErr(c, err)
+		return
+	}
+
+	// Allocate before appending: a nil slice marshals to {}, which defeats a
+	// caller's `?? []` and crashes their page precisely when there is no data.
+	rows := make([]sessionRow, 0, len(res.Sessions))
+	for _, s := range res.Sessions {
+		rows = append(rows, h.toSessionRow(s))
+	}
+
+	c.JSON(http.StatusOK, sessionsListResponse{
+		Data: rows,
+		Pagination: pagination{
+			// pagination.limit/page mirror what the client reported (the
+			// clamped, effective values), never the raw request — see
+			// parseSessionsParams.
+			Page:  max(res.Page, 1),
+			Limit: res.Limit,
+			Total: res.Total,
+		},
+	})
+}
+
+func (h *OnboardingFunnelHandler) toSessionRow(s onboardingfunnel.Session) sessionRow {
+	row := sessionRow{
+		ID:             s.ID,
+		Email:          s.Email,
+		Status:         s.Status,
+		CreatedAt:      s.CreatedAt.UTC().Format(time.RFC3339),
+		LastActivityAt: s.LastActivityAt.UTC().Format(time.RFC3339),
+		IdleHours:      h.now().Sub(s.LastActivityAt).Hours(),
+		Abandoned:      s.Abandoned,
+	}
+	if s.CompletedAt != nil {
+		v := s.CompletedAt.UTC().Format(time.RFC3339)
+		row.CompletedAt = &v
+	}
+	if s.TenantID != nil {
+		// Bare id, no copy-of-pointer aliasing into the client's struct.
+		v := *s.TenantID
+		row.TenantID = &v
+	}
+	return row
+}
+
+// parseSessionsParams never errors. A missing parameter takes platform-api's
+// default; an oversized limit is clamped there.
+func parseSessionsParams(c *gin.Context) onboardingfunnel.SessionsParams {
+	p := onboardingfunnel.SessionsParams{
+		Status: strings.TrimSpace(c.Query("status")),
+	}
+	if t, ok := parseTime(c.Query("created_from")); ok {
+		p.CreatedFrom = t
+	}
+	if t, ok := parseTime(c.Query("created_to")); ok {
+		p.CreatedTo = t
+	}
+	if v := strings.TrimSpace(c.Query("abandoned")); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			p.Abandoned = &b
+		}
+	}
+	if v := strings.TrimSpace(c.Query("page")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			p.Page = n
+		}
+	}
+	if v := strings.TrimSpace(c.Query("limit")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			p.Limit = n
+		}
+	}
+	return p
+}
+
+// respondErr maps client errors to the surface's stable codes.
+//
+// ErrUnavailable becomes 503, never an empty 200: an empty funnel/session
+// list and an unreachable upstream are different answers, and a console
+// operator shown "no activity" would believe the first. There is no
+// ErrNotFound case — neither endpoint 404s.
+func (h *OnboardingFunnelHandler) respondErr(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, onboardingfunnel.ErrUnavailable):
+		if h.logger != nil {
+			h.logger.Error("onboarding funnel upstream unavailable", "err", err)
+		}
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "upstream_unavailable", "message": "onboarding funnel is unavailable",
+		})
+	default:
+		if h.logger != nil {
+			h.logger.Error("onboarding funnel", "err", err)
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "internal_error", "message": "could not read the onboarding funnel",
+		})
+	}
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/onboarding_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/onboarding_test.go
@@ -1,0 +1,315 @@
+package platformadmin_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/internal/onboardingfunnel"
+)
+
+// errBoom is a generic non-sentinel error used to prove the handler's
+// default branch (-> 500 internal_error) rather than the ErrUnavailable
+// branch (-> 503).
+var errBoom = errors.New("boom")
+
+// stubFunnelClient records params and returns canned results.
+type stubFunnelClient struct {
+	gotFunnelParams   onboardingfunnel.FunnelParams
+	gotSessionsParams onboardingfunnel.SessionsParams
+	funnel            *onboardingfunnel.FunnelStats
+	sessions          *onboardingfunnel.SessionsResult
+	err               error
+}
+
+func (s *stubFunnelClient) GetFunnel(_ context.Context, p onboardingfunnel.FunnelParams) (*onboardingfunnel.FunnelStats, error) {
+	s.gotFunnelParams = p
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.funnel == nil {
+		s.funnel = &onboardingfunnel.FunnelStats{}
+	}
+	return s.funnel, nil
+}
+
+func (s *stubFunnelClient) ListSessions(_ context.Context, p onboardingfunnel.SessionsParams) (*onboardingfunnel.SessionsResult, error) {
+	s.gotSessionsParams = p
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.sessions == nil {
+		s.sessions = &onboardingfunnel.SessionsResult{Sessions: []onboardingfunnel.Session{}}
+	}
+	return s.sessions, nil
+}
+
+func funnelRouter(t *testing.T, client platformadmin.OnboardingFunnel, now func() time.Time) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	platformadmin.NewOnboardingFunnelHandler(client, nil, now).Register(r.Group(""))
+	return r
+}
+
+func ptrFloat64(v float64) *float64 { return &v }
+
+func mustParseTime(t *testing.T, v string) time.Time {
+	t.Helper()
+	tm, err := time.Parse(time.RFC3339, v)
+	require.NoError(t, err)
+	return tm
+}
+
+// THE test. Real handler output compared to the committed contract.
+func TestOnboardingFunnelMatchesContract(t *testing.T) {
+	client := &stubFunnelClient{funnel: &onboardingfunnel.FunnelStats{
+		FunnelCounts: onboardingfunnel.FunnelCounts{
+			Started: 412, EmailVerified: 301, Completed: 188, InFlight: 34, Abandoned: 190,
+		},
+		MedianCompletionSeconds: ptrFloat64(743),
+		Last24h: onboardingfunnel.FunnelCounts{
+			Started: 12, Completed: 5,
+		},
+		Window: onboardingfunnel.FunnelWindow{
+			From: "2026-08-01T00:00:00Z", To: "2026-08-23T00:00:00Z",
+		},
+	}}
+
+	rec := httptest.NewRecorder()
+	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/onboarding/funnel", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	want, err := os.ReadFile("testdata/onboarding_funnel_response.json")
+	require.NoError(t, err)
+	require.JSONEq(t, string(want), rec.Body.String())
+}
+
+// median_completion_seconds must serialise as JSON null, not omitted and not
+// 0. Asserted against the raw body: decoding null and 0 into a *float64
+// collapses the very distinction this test exists to catch.
+func TestOnboardingFunnelMedianNullWhenNoCompletions(t *testing.T) {
+	client := &stubFunnelClient{funnel: &onboardingfunnel.FunnelStats{
+		MedianCompletionSeconds: nil,
+		Window:                  onboardingfunnel.FunnelWindow{From: "2026-08-01T00:00:00Z", To: "2026-08-23T00:00:00Z"},
+	}}
+
+	rec := httptest.NewRecorder()
+	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/onboarding/funnel", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data map[string]json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	raw, ok := body.Data["median_completion_seconds"]
+	require.True(t, ok, "median_completion_seconds key must be present")
+	require.Equal(t, "null", string(raw))
+}
+
+// The funnel response is a single object with no pagination key.
+func TestOnboardingFunnelHasNoPaginationKey(t *testing.T) {
+	client := &stubFunnelClient{funnel: &onboardingfunnel.FunnelStats{}}
+
+	rec := httptest.NewRecorder()
+	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/onboarding/funnel", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotContains(t, rec.Body.String(), "pagination")
+}
+
+func TestOnboardingFunnelPassesWindowParams(t *testing.T) {
+	client := &stubFunnelClient{funnel: &onboardingfunnel.FunnelStats{}}
+
+	rec := httptest.NewRecorder()
+	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/onboarding/funnel?created_from=2026-08-01T00:00:00Z&created_to=2026-08-23T00:00:00Z", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, client.gotFunnelParams.CreatedFrom.Equal(mustParseTime(t, "2026-08-01T00:00:00Z")))
+	require.True(t, client.gotFunnelParams.CreatedTo.Equal(mustParseTime(t, "2026-08-23T00:00:00Z")))
+}
+
+// An unreachable upstream must NOT look like an empty funnel — that would
+// tell a console operator "no activity" when the truth is "we could not
+// ask". The body must carry no counters at all.
+func TestOnboardingFunnelUpstreamDownIs503(t *testing.T) {
+	client := &stubFunnelClient{err: onboardingfunnel.ErrUnavailable}
+
+	rec := httptest.NewRecorder()
+	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/onboarding/funnel", nil))
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "upstream_unavailable", errorCode(t, rec))
+	require.NotContains(t, rec.Body.String(), "started")
+	require.NotContains(t, rec.Body.String(), "median_completion_seconds")
+}
+
+func TestOnboardingFunnelOtherErrorIs500(t *testing.T) {
+	client := &stubFunnelClient{err: errBoom}
+
+	rec := httptest.NewRecorder()
+	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/onboarding/funnel", nil))
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Equal(t, "internal_error", errorCode(t, rec))
+}
+
+// THE test for sessions. Real handler output compared to the committed
+// contract. The clock is fixed so idle_hours is deterministic.
+func TestOnboardingSessionsMatchesContract(t *testing.T) {
+	completedAt := mustParseTime(t, "2026-08-21T03:00:00Z")
+	tenantID := "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+
+	client := &stubFunnelClient{sessions: &onboardingfunnel.SessionsResult{
+		Total: 2, Page: 1, Limit: 50,
+		Sessions: []onboardingfunnel.Session{
+			{
+				ID:             "9f2504e0-4f89-11d3-9a0c-0305e82c9901",
+				Email:          "founder@acme.example",
+				Status:         "in_progress",
+				CreatedAt:      mustParseTime(t, "2026-08-20T09:00:00Z"),
+				LastActivityAt: mustParseTime(t, "2026-08-21T02:00:00Z"),
+				Abandoned:      true,
+			},
+			{
+				ID:             "9f2504e0-4f89-11d3-9a0c-0305e82c9902",
+				Email:          "owner@beta.example",
+				Status:         "completed",
+				CreatedAt:      mustParseTime(t, "2026-08-19T08:00:00Z"),
+				LastActivityAt: mustParseTime(t, "2026-08-19T09:00:00Z"),
+				CompletedAt:    &completedAt,
+				TenantID:       &tenantID,
+				Abandoned:      false,
+			},
+		},
+	}}
+
+	fixedNow := func() time.Time { return mustParseTime(t, "2026-08-22T10:00:00Z") }
+
+	rec := httptest.NewRecorder()
+	funnelRouter(t, client, fixedNow).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/onboarding/sessions", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	want, err := os.ReadFile("testdata/onboarding_sessions_response.json")
+	require.NoError(t, err)
+	require.JSONEq(t, string(want), rec.Body.String())
+}
+
+// draft must never reach the console. onboardingfunnel.Session carries no
+// Draft field at all — Task 3's client already refuses to decode it — so
+// this is a permanent regression guard: it fails only if a future edit
+// either adds Draft back to Session and passes it through by embedding, or
+// stops projecting sessions field by field.
+func TestOnboardingSessionsDraftAbsentFromRawBody(t *testing.T) {
+	client := &stubFunnelClient{sessions: &onboardingfunnel.SessionsResult{
+		Sessions: []onboardingfunnel.Session{
+			{
+				ID:             "9f2504e0-4f89-11d3-9a0c-0305e82c9901",
+				Email:          "founder@acme.example",
+				Status:         "in_progress",
+				CreatedAt:      mustParseTime(t, "2026-08-20T09:00:00Z"),
+				LastActivityAt: mustParseTime(t, "2026-08-21T02:00:00Z"),
+				Abandoned:      true,
+			},
+		},
+		Total: 1, Page: 1, Limit: 50,
+	}}
+
+	rec := httptest.NewRecorder()
+	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/onboarding/sessions", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.False(t, strings.Contains(strings.ToLower(rec.Body.String()), "draft"),
+		"raw response body must never contain a draft key")
+}
+
+func TestOnboardingSessionsEmptyIsArray(t *testing.T) {
+	rec := httptest.NewRecorder()
+	funnelRouter(t, &stubFunnelClient{}, nil).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/onboarding/sessions", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "[]", string(body.Data))
+}
+
+func TestOnboardingSessionsPassesFilters(t *testing.T) {
+	client := &stubFunnelClient{}
+	rec := httptest.NewRecorder()
+	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/onboarding/sessions?status=in_progress&abandoned=true&limit=25&page=2", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "in_progress", client.gotSessionsParams.Status)
+	require.NotNil(t, client.gotSessionsParams.Abandoned)
+	require.True(t, *client.gotSessionsParams.Abandoned)
+	require.Equal(t, 25, client.gotSessionsParams.Limit)
+	require.Equal(t, 2, client.gotSessionsParams.Page)
+}
+
+// pagination.limit must reflect what the client reported (the clamped,
+// effective limit), not what the caller requested.
+func TestOnboardingSessionsPaginationReflectsClientNotRequest(t *testing.T) {
+	client := &stubFunnelClient{sessions: &onboardingfunnel.SessionsResult{
+		Sessions: []onboardingfunnel.Session{}, Total: 0, Page: 1, Limit: 500,
+	}}
+
+	rec := httptest.NewRecorder()
+	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/onboarding/sessions?limit=9999", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Pagination struct {
+			Limit int `json:"limit"`
+		} `json:"pagination"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, 500, body.Pagination.Limit)
+}
+
+// An unreachable upstream must NOT look like an empty session list.
+func TestOnboardingSessionsUpstreamDownIs503(t *testing.T) {
+	rec := httptest.NewRecorder()
+	funnelRouter(t, &stubFunnelClient{err: onboardingfunnel.ErrUnavailable}, nil).
+		ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/onboarding/sessions", nil))
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "upstream_unavailable", errorCode(t, rec))
+}
+
+func TestOnboardingSessionsOtherErrorIs500(t *testing.T) {
+	rec := httptest.NewRecorder()
+	funnelRouter(t, &stubFunnelClient{err: errBoom}, nil).
+		ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/onboarding/sessions", nil))
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Equal(t, "internal_error", errorCode(t, rec))
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/onboarding_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/onboarding_test.go
@@ -54,11 +54,11 @@ func (s *stubFunnelClient) ListSessions(_ context.Context, p onboardingfunnel.Se
 	return s.sessions, nil
 }
 
-func funnelRouter(t *testing.T, client platformadmin.OnboardingFunnel, now func() time.Time) *gin.Engine {
+func funnelRouter(t *testing.T, client platformadmin.OnboardingFunnel) *gin.Engine {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	platformadmin.NewOnboardingFunnelHandler(client, nil, now).Register(r.Group(""))
+	platformadmin.NewOnboardingFunnelHandler(client, nil).Register(r.Group(""))
 	return r
 }
 
@@ -87,7 +87,7 @@ func TestOnboardingFunnelMatchesContract(t *testing.T) {
 	}}
 
 	rec := httptest.NewRecorder()
-	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+	funnelRouter(t, client).ServeHTTP(rec, httptest.NewRequest(
 		http.MethodGet, "/admin/onboarding/funnel", nil))
 
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -107,7 +107,7 @@ func TestOnboardingFunnelMedianNullWhenNoCompletions(t *testing.T) {
 	}}
 
 	rec := httptest.NewRecorder()
-	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+	funnelRouter(t, client).ServeHTTP(rec, httptest.NewRequest(
 		http.MethodGet, "/admin/onboarding/funnel", nil))
 
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -127,7 +127,7 @@ func TestOnboardingFunnelHasNoPaginationKey(t *testing.T) {
 	client := &stubFunnelClient{funnel: &onboardingfunnel.FunnelStats{}}
 
 	rec := httptest.NewRecorder()
-	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+	funnelRouter(t, client).ServeHTTP(rec, httptest.NewRequest(
 		http.MethodGet, "/admin/onboarding/funnel", nil))
 
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -138,7 +138,7 @@ func TestOnboardingFunnelPassesWindowParams(t *testing.T) {
 	client := &stubFunnelClient{funnel: &onboardingfunnel.FunnelStats{}}
 
 	rec := httptest.NewRecorder()
-	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+	funnelRouter(t, client).ServeHTTP(rec, httptest.NewRequest(
 		http.MethodGet, "/admin/onboarding/funnel?created_from=2026-08-01T00:00:00Z&created_to=2026-08-23T00:00:00Z", nil))
 
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -153,7 +153,7 @@ func TestOnboardingFunnelUpstreamDownIs503(t *testing.T) {
 	client := &stubFunnelClient{err: onboardingfunnel.ErrUnavailable}
 
 	rec := httptest.NewRecorder()
-	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+	funnelRouter(t, client).ServeHTTP(rec, httptest.NewRequest(
 		http.MethodGet, "/admin/onboarding/funnel", nil))
 
 	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
@@ -166,7 +166,7 @@ func TestOnboardingFunnelOtherErrorIs500(t *testing.T) {
 	client := &stubFunnelClient{err: errBoom}
 
 	rec := httptest.NewRecorder()
-	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+	funnelRouter(t, client).ServeHTTP(rec, httptest.NewRequest(
 		http.MethodGet, "/admin/onboarding/funnel", nil))
 
 	require.Equal(t, http.StatusInternalServerError, rec.Code)
@@ -174,7 +174,9 @@ func TestOnboardingFunnelOtherErrorIs500(t *testing.T) {
 }
 
 // THE test for sessions. Real handler output compared to the committed
-// contract. The clock is fixed so idle_hours is deterministic.
+// contract. idle_hours comes straight from the upstream Session field —
+// the handler no longer computes it against its own clock — so the stub
+// sets it directly, deterministically.
 func TestOnboardingSessionsMatchesContract(t *testing.T) {
 	completedAt := mustParseTime(t, "2026-08-21T03:00:00Z")
 	tenantID := "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
@@ -189,6 +191,7 @@ func TestOnboardingSessionsMatchesContract(t *testing.T) {
 				CreatedAt:      mustParseTime(t, "2026-08-20T09:00:00Z"),
 				LastActivityAt: mustParseTime(t, "2026-08-21T02:00:00Z"),
 				Abandoned:      true,
+				IdleHours:      32,
 			},
 			{
 				ID:             "9f2504e0-4f89-11d3-9a0c-0305e82c9902",
@@ -199,14 +202,13 @@ func TestOnboardingSessionsMatchesContract(t *testing.T) {
 				CompletedAt:    &completedAt,
 				TenantID:       &tenantID,
 				Abandoned:      false,
+				IdleHours:      73,
 			},
 		},
 	}}
 
-	fixedNow := func() time.Time { return mustParseTime(t, "2026-08-22T10:00:00Z") }
-
 	rec := httptest.NewRecorder()
-	funnelRouter(t, client, fixedNow).ServeHTTP(rec, httptest.NewRequest(
+	funnelRouter(t, client).ServeHTTP(rec, httptest.NewRequest(
 		http.MethodGet, "/admin/onboarding/sessions", nil))
 
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -237,7 +239,7 @@ func TestOnboardingSessionsDraftAbsentFromRawBody(t *testing.T) {
 	}}
 
 	rec := httptest.NewRecorder()
-	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+	funnelRouter(t, client).ServeHTTP(rec, httptest.NewRequest(
 		http.MethodGet, "/admin/onboarding/sessions", nil))
 
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -247,7 +249,7 @@ func TestOnboardingSessionsDraftAbsentFromRawBody(t *testing.T) {
 
 func TestOnboardingSessionsEmptyIsArray(t *testing.T) {
 	rec := httptest.NewRecorder()
-	funnelRouter(t, &stubFunnelClient{}, nil).ServeHTTP(rec, httptest.NewRequest(
+	funnelRouter(t, &stubFunnelClient{}).ServeHTTP(rec, httptest.NewRequest(
 		http.MethodGet, "/admin/onboarding/sessions", nil))
 
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -262,7 +264,7 @@ func TestOnboardingSessionsEmptyIsArray(t *testing.T) {
 func TestOnboardingSessionsPassesFilters(t *testing.T) {
 	client := &stubFunnelClient{}
 	rec := httptest.NewRecorder()
-	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+	funnelRouter(t, client).ServeHTTP(rec, httptest.NewRequest(
 		http.MethodGet, "/admin/onboarding/sessions?status=in_progress&abandoned=true&limit=25&page=2", nil))
 
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -281,7 +283,7 @@ func TestOnboardingSessionsPaginationReflectsClientNotRequest(t *testing.T) {
 	}}
 
 	rec := httptest.NewRecorder()
-	funnelRouter(t, client, nil).ServeHTTP(rec, httptest.NewRequest(
+	funnelRouter(t, client).ServeHTTP(rec, httptest.NewRequest(
 		http.MethodGet, "/admin/onboarding/sessions?limit=9999", nil))
 
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -298,7 +300,7 @@ func TestOnboardingSessionsPaginationReflectsClientNotRequest(t *testing.T) {
 // An unreachable upstream must NOT look like an empty session list.
 func TestOnboardingSessionsUpstreamDownIs503(t *testing.T) {
 	rec := httptest.NewRecorder()
-	funnelRouter(t, &stubFunnelClient{err: onboardingfunnel.ErrUnavailable}, nil).
+	funnelRouter(t, &stubFunnelClient{err: onboardingfunnel.ErrUnavailable}).
 		ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/onboarding/sessions", nil))
 
 	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
@@ -307,7 +309,7 @@ func TestOnboardingSessionsUpstreamDownIs503(t *testing.T) {
 
 func TestOnboardingSessionsOtherErrorIs500(t *testing.T) {
 	rec := httptest.NewRecorder()
-	funnelRouter(t, &stubFunnelClient{err: errBoom}, nil).
+	funnelRouter(t, &stubFunnelClient{err: errBoom}).
 		ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/onboarding/sessions", nil))
 
 	require.Equal(t, http.StatusInternalServerError, rec.Code)

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -81,6 +81,6 @@ func Register(g *gin.RouterGroup, deps Deps) {
 	}
 
 	if deps.OnboardingFunnel != nil {
-		NewOnboardingFunnelHandler(deps.OnboardingFunnel, deps.Logger, nil).Register(group)
+		NewOnboardingFunnelHandler(deps.OnboardingFunnel, deps.Logger).Register(group)
 	}
 }

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -27,6 +27,11 @@ type Deps struct {
 	// TenantDirectory serves /admin/entities/tenants (#277). Nil leaves those
 	// routes unmounted, matching the nil-safe pattern used for Repo above.
 	TenantDirectory TenantDirectory
+
+	// OnboardingFunnel serves /admin/onboarding/funnel and /sessions (#283).
+	// Nil leaves those routes unmounted, matching the nil-safe pattern used
+	// for TenantDirectory above.
+	OnboardingFunnel OnboardingFunnel
 }
 
 // Register mounts the platform console's /admin/* surface behind
@@ -73,5 +78,9 @@ func Register(g *gin.RouterGroup, deps Deps) {
 	if deps.TenantDirectory != nil {
 		NewEntitiesTenantsHandler(deps.TenantDirectory, deps.Logger).Register(group)
 		NewConversionsHandler(deps.TenantDirectory, deps.Logger).Register(group)
+	}
+
+	if deps.OnboardingFunnel != nil {
+		NewOnboardingFunnelHandler(deps.OnboardingFunnel, deps.Logger, nil).Register(group)
 	}
 }

--- a/services/marketplace-api/internal/handlers/platformadmin/routes_onboarding_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes_onboarding_test.go
@@ -1,0 +1,45 @@
+package platformadmin_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+)
+
+// A nil OnboardingFunnel must leave the routes unmounted rather than panic
+// at request time — matching the nil-safe pattern for TenantDirectory.
+func TestRegisterOnboardingFunnelIsNilSafe(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	platformadmin.Register(r.Group("/api/v1/platform"), platformadmin.Deps{
+		Repo: &stubRepo{},
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/api/v1/platform/admin/onboarding/funnel", nil))
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// Mounted but with no secret: 503 not_configured, same as every other route
+// on this surface.
+func TestOnboardingFunnelFailsClosedWithoutSecret(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	platformadmin.Register(r.Group("/api/v1/platform"), platformadmin.Deps{
+		Repo:             &stubRepo{},
+		OnboardingFunnel: &stubFunnelClient{},
+		Secret:           "",
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/api/v1/platform/admin/onboarding/funnel", nil))
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "not_configured", errorCode(t, rec))
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/testdata/onboarding_funnel_response.json
+++ b/services/marketplace-api/internal/handlers/platformadmin/testdata/onboarding_funnel_response.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "started": 412,
+    "email_verified": 301,
+    "completed": 188,
+    "in_flight": 34,
+    "abandoned": 190,
+    "median_completion_seconds": 743,
+    "last_24h": {
+      "started": 12,
+      "completed": 5
+    },
+    "window": {
+      "from": "2026-08-01T00:00:00Z",
+      "to": "2026-08-23T00:00:00Z"
+    }
+  }
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/testdata/onboarding_sessions_response.json
+++ b/services/marketplace-api/internal/handlers/platformadmin/testdata/onboarding_sessions_response.json
@@ -1,0 +1,31 @@
+{
+  "data": [
+    {
+      "id": "9f2504e0-4f89-11d3-9a0c-0305e82c9901",
+      "email": "founder@acme.example",
+      "status": "in_progress",
+      "created_at": "2026-08-20T09:00:00Z",
+      "last_activity_at": "2026-08-21T02:00:00Z",
+      "idle_hours": 32,
+      "abandoned": true,
+      "completed_at": null,
+      "tenant_id": null
+    },
+    {
+      "id": "9f2504e0-4f89-11d3-9a0c-0305e82c9902",
+      "email": "owner@beta.example",
+      "status": "completed",
+      "created_at": "2026-08-19T08:00:00Z",
+      "last_activity_at": "2026-08-19T09:00:00Z",
+      "idle_hours": 73,
+      "abandoned": false,
+      "completed_at": "2026-08-21T03:00:00Z",
+      "tenant_id": "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "limit": 50,
+    "total": 2
+  }
+}

--- a/services/marketplace-api/internal/onboardingfunnel/client.go
+++ b/services/marketplace-api/internal/onboardingfunnel/client.go
@@ -35,7 +35,7 @@ type FunnelCounts struct {
 	Abandoned     int64 `json:"abandoned"`
 }
 
-// FunnelWindow is the effective [from, to) window the stats were computed
+// FunnelWindow is the effective [from, to] window the stats were computed
 // over, as returned by platform-api.
 type FunnelWindow struct {
 	From string `json:"from"`

--- a/services/marketplace-api/internal/onboardingfunnel/client.go
+++ b/services/marketplace-api/internal/onboardingfunnel/client.go
@@ -64,6 +64,7 @@ type Session struct {
 	LastActivityAt  time.Time  `json:"last_activity_at"`
 	CreatedAt       time.Time  `json:"created_at"`
 	Abandoned       bool       `json:"abandoned"`
+	IdleHours       float64    `json:"idle_hours"`
 }
 
 // SessionsResult is a page of sessions plus the unpaginated total.

--- a/services/marketplace-api/internal/onboardingfunnel/client.go
+++ b/services/marketplace-api/internal/onboardingfunnel/client.go
@@ -1,0 +1,219 @@
+// Package onboardingfunnel is a marketplace-api client for platform-api's
+// internal onboarding-funnel endpoints (#283).
+//
+// Separate from internal/tenantdirectory on purpose: a funnel read is a
+// different concern from a tenant directory read, and the two will diverge.
+package onboardingfunnel
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// ErrUnavailable signals platform-api could not be reached, or answered 5xx.
+// Callers MUST NOT treat this as an empty result: an empty funnel and an
+// unreachable one are different answers, and conflating them shows a console
+// operator "no activity" when the truth is "we could not ask".
+var ErrUnavailable = errors.New("onboardingfunnel: platform-api unavailable")
+
+// maxBody caps what we will read from platform-api.
+const maxBody = 4 << 20
+
+// FunnelCounts is one window's worth of funnel aggregates.
+type FunnelCounts struct {
+	Started       int64 `json:"started"`
+	EmailVerified int64 `json:"email_verified"`
+	Completed     int64 `json:"completed"`
+	InFlight      int64 `json:"in_flight"`
+	Abandoned     int64 `json:"abandoned"`
+}
+
+// FunnelWindow is the effective [from, to) window the stats were computed
+// over, as returned by platform-api.
+type FunnelWindow struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// FunnelStats is the full funnel response.
+type FunnelStats struct {
+	FunnelCounts
+	// MedianCompletionSeconds is nil when no session in the window
+	// completed — upstream NULL must survive as Go nil, not silently
+	// become 0 ("instant completion").
+	MedianCompletionSeconds *float64     `json:"median_completion_seconds"`
+	Last24h                 FunnelCounts `json:"last_24h"`
+	Window                  FunnelWindow `json:"window"`
+}
+
+// Session is one row of the onboarding sessions list.
+type Session struct {
+	ID              string     `json:"id"`
+	Email           string     `json:"email"`
+	Status          string     `json:"status"`
+	EmailVerifiedAt *time.Time `json:"email_verified_at,omitempty"`
+	TenantID        *string    `json:"tenant_id,omitempty"`
+	CompletedAt     *time.Time `json:"completed_at,omitempty"`
+	LastActivityAt  time.Time  `json:"last_activity_at"`
+	CreatedAt       time.Time  `json:"created_at"`
+	Abandoned       bool       `json:"abandoned"`
+}
+
+// SessionsResult is a page of sessions plus the unpaginated total.
+type SessionsResult struct {
+	Sessions []Session
+	Total    int64
+	Page     int
+	Limit    int
+}
+
+// FunnelParams narrows a funnel query to a window. Zero values are omitted.
+type FunnelParams struct {
+	CreatedFrom time.Time
+	CreatedTo   time.Time
+}
+
+// SessionsParams narrows a sessions query. Zero values are omitted.
+type SessionsParams struct {
+	CreatedFrom time.Time
+	CreatedTo   time.Time
+	Status      string
+	Abandoned   *bool
+	Page        int
+	Limit       int
+}
+
+// Client calls platform-api's internal onboarding-funnel endpoints.
+type Client struct {
+	baseURL string
+	secret  string
+	http    *http.Client
+}
+
+// NewClient constructs a Client. httpClient may be nil (defaults to a
+// 5-second timeout). The secret is sent as X-Internal-Auth when non-empty.
+func NewClient(baseURL, secret string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 5 * time.Second}
+	}
+	return &Client{baseURL: baseURL, secret: secret, http: httpClient}
+}
+
+func (c *Client) do(ctx context.Context, path string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("onboardingfunnel: build request: %w", err)
+	}
+	if c.secret != "" {
+		req.Header.Set("X-Internal-Auth", c.secret)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrUnavailable, err)
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode >= 500:
+		return fmt.Errorf("%w: upstream %d", ErrUnavailable, resp.StatusCode)
+	case resp.StatusCode != http.StatusOK:
+		return fmt.Errorf("onboardingfunnel: platform-api %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBody))
+	if err != nil {
+		return fmt.Errorf("%w: read body: %v", ErrUnavailable, err)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("onboardingfunnel: decode: %w", err)
+	}
+	return nil
+}
+
+// windowValues encodes created_from/created_to as RFC3339 via url.Values, so
+// the "+" in a non-UTC offset is percent-encoded rather than corrupted by a
+// naive string concatenation.
+func windowValues(from, to time.Time) url.Values {
+	q := url.Values{}
+	if !from.IsZero() {
+		q.Set("created_from", from.Format(time.RFC3339))
+	}
+	if !to.IsZero() {
+		q.Set("created_to", to.Format(time.RFC3339))
+	}
+	return q
+}
+
+// GetFunnel fetches the onboarding funnel stats for the given window.
+func (c *Client) GetFunnel(ctx context.Context, p FunnelParams) (*FunnelStats, error) {
+	q := windowValues(p.CreatedFrom, p.CreatedTo)
+
+	path := "/internal/onboarding/funnel"
+	if encoded := q.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+
+	var envelope struct {
+		Data FunnelStats `json:"data"`
+	}
+	if err := c.do(ctx, path, &envelope); err != nil {
+		return nil, err
+	}
+	return &envelope.Data, nil
+}
+
+// ListSessions fetches a page of onboarding sessions.
+func (c *Client) ListSessions(ctx context.Context, p SessionsParams) (*SessionsResult, error) {
+	q := windowValues(p.CreatedFrom, p.CreatedTo)
+	if p.Status != "" {
+		q.Set("status", p.Status)
+	}
+	if p.Abandoned != nil {
+		q.Set("abandoned", strconv.FormatBool(*p.Abandoned))
+	}
+	if p.Page > 0 {
+		q.Set("page", strconv.Itoa(p.Page))
+	}
+	if p.Limit > 0 {
+		q.Set("limit", strconv.Itoa(p.Limit))
+	}
+
+	path := "/internal/onboarding/sessions"
+	if encoded := q.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+
+	var envelope struct {
+		Data       []Session `json:"data"`
+		Pagination struct {
+			Page  int   `json:"page"`
+			Limit int   `json:"limit"`
+			Total int64 `json:"total"`
+		} `json:"pagination"`
+	}
+	if err := c.do(ctx, path, &envelope); err != nil {
+		return nil, err
+	}
+
+	// Allocate: upstream `"data": null` would otherwise become a nil slice
+	// that the handler marshals as {} instead of [].
+	sessions := envelope.Data
+	if sessions == nil {
+		sessions = []Session{}
+	}
+
+	return &SessionsResult{
+		Sessions: sessions,
+		Total:    envelope.Pagination.Total,
+		Page:     envelope.Pagination.Page,
+		Limit:    envelope.Pagination.Limit,
+	}, nil
+}

--- a/services/marketplace-api/internal/onboardingfunnel/client_test.go
+++ b/services/marketplace-api/internal/onboardingfunnel/client_test.go
@@ -1,0 +1,190 @@
+package onboardingfunnel_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/onboardingfunnel"
+)
+
+func TestGetFunnelSendsAuthAndParsesEnvelope(t *testing.T) {
+	var gotAuth, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("X-Internal-Auth")
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{
+			"started":10,
+			"email_verified":8,
+			"completed":5,
+			"in_flight":3,
+			"abandoned":2,
+			"median_completion_seconds":123.5,
+			"last_24h":{"started":4,"email_verified":3,"completed":2,"in_flight":1,"abandoned":1},
+			"window":{"from":"2026-08-01T00:00:00Z","to":"2026-08-23T00:00:00Z"}
+		}}`))
+	}))
+	defer srv.Close()
+
+	c := onboardingfunnel.NewClient(srv.URL, "s3cret", srv.Client())
+	got, err := c.GetFunnel(context.Background(), onboardingfunnel.FunnelParams{})
+	require.NoError(t, err)
+
+	require.Equal(t, "s3cret", gotAuth)
+	require.Equal(t, "/internal/onboarding/funnel", gotPath)
+	require.Equal(t, int64(10), got.Started)
+	require.Equal(t, int64(8), got.EmailVerified)
+	require.Equal(t, int64(5), got.Completed)
+	require.Equal(t, int64(3), got.InFlight)
+	require.Equal(t, int64(2), got.Abandoned)
+	require.NotNil(t, got.MedianCompletionSeconds)
+	require.Equal(t, 123.5, *got.MedianCompletionSeconds)
+	require.Equal(t, int64(4), got.Last24h.Started)
+	require.Equal(t, int64(2), got.Last24h.Completed)
+	require.Equal(t, "2026-08-01T00:00:00Z", got.Window.From)
+	require.Equal(t, "2026-08-23T00:00:00Z", got.Window.To)
+}
+
+// null must survive as Go nil, not become 0 ("instant completion").
+func TestGetFunnelMedianCompletionSecondsNull(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{
+			"started":0,
+			"email_verified":0,
+			"completed":0,
+			"in_flight":0,
+			"abandoned":0,
+			"median_completion_seconds":null,
+			"last_24h":{"started":0,"email_verified":0,"completed":0,"in_flight":0,"abandoned":0},
+			"window":{"from":"2026-08-01T00:00:00Z","to":"2026-08-23T00:00:00Z"}
+		}}`))
+	}))
+	defer srv.Close()
+
+	c := onboardingfunnel.NewClient(srv.URL, "s", srv.Client())
+	got, err := c.GetFunnel(context.Background(), onboardingfunnel.FunnelParams{})
+	require.NoError(t, err)
+	require.Nil(t, got.MedianCompletionSeconds)
+}
+
+func TestListSessionsParsesEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"s1","email":"a@example.com","status":"completed","last_activity_at":"2026-08-22T10:00:00Z","created_at":"2026-08-22T09:00:00Z","abandoned":false}],"pagination":{"page":1,"limit":50,"total":1}}`))
+	}))
+	defer srv.Close()
+
+	c := onboardingfunnel.NewClient(srv.URL, "s", srv.Client())
+	got, err := c.ListSessions(context.Background(), onboardingfunnel.SessionsParams{})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), got.Total)
+	require.Len(t, got.Sessions, 1)
+	require.Equal(t, "s1", got.Sessions[0].ID)
+}
+
+func TestListSessionsEmptyIsAllocated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[],"pagination":{"page":1,"limit":50,"total":0}}`))
+	}))
+	defer srv.Close()
+
+	got, err := onboardingfunnel.NewClient(srv.URL, "s", srv.Client()).
+		ListSessions(context.Background(), onboardingfunnel.SessionsParams{})
+	require.NoError(t, err)
+	require.NotNil(t, got.Sessions)
+	require.Empty(t, got.Sessions)
+}
+
+func TestListSessionsNullDataIsAllocated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":null,"pagination":{"page":1,"limit":50,"total":0}}`))
+	}))
+	defer srv.Close()
+
+	got, err := onboardingfunnel.NewClient(srv.URL, "s", srv.Client()).
+		ListSessions(context.Background(), onboardingfunnel.SessionsParams{})
+	require.NoError(t, err)
+	require.NotNil(t, got.Sessions)
+	require.Empty(t, got.Sessions)
+}
+
+func TestGetFunnelUpstream5xxIsUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	_, err := onboardingfunnel.NewClient(srv.URL, "s", srv.Client()).
+		GetFunnel(context.Background(), onboardingfunnel.FunnelParams{})
+	require.ErrorIs(t, err, onboardingfunnel.ErrUnavailable)
+}
+
+func TestGetFunnelTransportFailureIsUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close() // closed: connection refused
+
+	_, err := onboardingfunnel.NewClient(srv.URL, "s", srv.Client()).
+		GetFunnel(context.Background(), onboardingfunnel.FunnelParams{})
+	require.ErrorIs(t, err, onboardingfunnel.ErrUnavailable)
+}
+
+func TestListSessionsUpstream5xxIsUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	_, err := onboardingfunnel.NewClient(srv.URL, "s", srv.Client()).
+		ListSessions(context.Background(), onboardingfunnel.SessionsParams{})
+	require.ErrorIs(t, err, onboardingfunnel.ErrUnavailable)
+}
+
+func TestListSessionsTransportFailureIsUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close() // closed: connection refused
+
+	_, err := onboardingfunnel.NewClient(srv.URL, "s", srv.Client()).
+		ListSessions(context.Background(), onboardingfunnel.SessionsParams{})
+	require.ErrorIs(t, err, onboardingfunnel.ErrUnavailable)
+}
+
+// RFC3339 offsets contain "+" (e.g. +05:30). A naive string concatenation of
+// the window params corrupts it into a space; only proper URL encoding via
+// url.Values survives the round trip.
+func TestWindowParamsAreURLEncoded(t *testing.T) {
+	loc := time.FixedZone("IST", 5*60*60+30*60)
+	from := time.Date(2026, 8, 1, 9, 30, 0, 0, loc)
+	to := time.Date(2026, 8, 23, 18, 0, 0, 0, loc)
+
+	var gotFrom, gotTo string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotFrom = r.URL.Query().Get("created_from")
+		gotTo = r.URL.Query().Get("created_to")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{
+			"started":0,"email_verified":0,"completed":0,"in_flight":0,"abandoned":0,
+			"median_completion_seconds":null,
+			"last_24h":{"started":0,"email_verified":0,"completed":0,"in_flight":0,"abandoned":0},
+			"window":{"from":"2026-08-01T00:00:00Z","to":"2026-08-23T00:00:00Z"}
+		}}`))
+	}))
+	defer srv.Close()
+
+	c := onboardingfunnel.NewClient(srv.URL, "s", srv.Client())
+	_, err := c.GetFunnel(context.Background(), onboardingfunnel.FunnelParams{
+		CreatedFrom: from,
+		CreatedTo:   to,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, from.Format(time.RFC3339), gotFrom)
+	require.Equal(t, to.Format(time.RFC3339), gotTo)
+	require.Contains(t, gotFrom, "+05:30")
+	require.Contains(t, gotTo, "+05:30")
+}

--- a/services/platform-api/cmd/server/main.go
+++ b/services/platform-api/cmd/server/main.go
@@ -343,9 +343,12 @@ func main() {
 	// unscoped, so it gets the fail-closed guard rather than the permissive
 	// one above: an unconfigured deploy must refuse, not serve the lot.
 	// Deliberately a different group with different middleware — see
-	// middleware.RequireInternalAuthStrict.
-	tenantDirectory := r.Group("/internal", middleware.RequireInternalAuthStrict(cfg.InternalAuthSecret))
-	tenantHandler.RegisterDirectory(tenantDirectory)
+	// middleware.RequireInternalAuthStrict. The onboarding funnel/sessions
+	// analytics routes (#283) share this guard for the same reason: both
+	// are estate-wide reads with no tenant scoping.
+	strictInternal := r.Group("/internal", middleware.RequireInternalAuthStrict(cfg.InternalAuthSecret))
+	tenantHandler.RegisterDirectory(strictInternal)
+	onboardingHandler.RegisterAnalytics(strictInternal)
 
 	locationHandler.Register(v1)
 	tenantHandler.Register(v1, internal)

--- a/services/platform-api/internal/onboarding/funnel.go
+++ b/services/platform-api/internal/onboarding/funnel.go
@@ -27,11 +27,32 @@ const AbandonedAfter = 24 * time.Hour
 // The interval is built from AbandonedAfter (via make_interval, in hours)
 // rather than hardcoded as a second literal — a test changing the constant
 // changes the query, since there is only one place the cutoff is written.
-func abandonedExpr() string {
+//
+// asOfExpr is the SQL expression to evaluate "now" against — normally the
+// literal "now()", but a test can pass a bound parameter placeholder (see
+// FunnelFilter.AsOf) to pin the evaluation instant exactly.
+func abandonedExpr(asOfExpr string) string {
 	return fmt.Sprintf(
-		"(onboarding_sessions.status <> 'completed' AND onboarding_sessions.last_activity_at <= now() - make_interval(hours => %d))",
+		"(onboarding_sessions.status <> 'completed' AND onboarding_sessions.last_activity_at <= %s - make_interval(hours => %d))",
+		asOfExpr,
 		int(AbandonedAfter.Hours()),
 	)
+}
+
+// asOfExpr renders the SQL expression the funnel queries use in place of
+// now(). When f.AsOf is the zero value it returns the literal "now()", so
+// production behaviour is unchanged. When AsOf is set, it renders a
+// timestamptz literal instead, so a test can pin the evaluation instant
+// exactly and place a fixture precisely on the abandoned-cutoff boundary.
+//
+// AsOf is formatted from a Go time.Time via RFC3339Nano, never from
+// unsanitized external input, so building the literal by fmt.Sprintf here
+// carries no injection risk.
+func asOfExpr(f FunnelFilter) string {
+	if f.AsOf.IsZero() {
+		return "now()"
+	}
+	return fmt.Sprintf("'%s'::timestamptz", f.AsOf.UTC().Format(time.RFC3339Nano))
 }
 
 // DefaultFunnelPageSize applies when the caller sends no limit.
@@ -53,6 +74,16 @@ type FunnelFilter struct {
 	Abandoned *bool
 	Page      int
 	Limit     int
+	// AsOf pins the instant the abandoned/in-flight predicates and the
+	// last_24h window evaluate "now" against. Zero value (the default)
+	// means "use the database's now() exactly as before" — production
+	// behaviour is unchanged.
+	//
+	// Internal only. This field exists so tests can freeze time and place
+	// a fixture precisely on the AbandonedAfter boundary; it must NEVER be
+	// exposed as an HTTP query parameter by Task 2's handlers — a console
+	// caller able to set it could time-travel the funnel.
+	AsOf time.Time
 }
 
 // FunnelCounts is one window's worth of funnel aggregates. Completed +
@@ -117,10 +148,11 @@ func applySessionFilter(q *gorm.DB, f FunnelFilter) *gorm.DB {
 		q = q.Where("onboarding_sessions.status = ?", f.Status)
 	}
 	if f.Abandoned != nil {
+		abandoned := abandonedExpr(asOfExpr(f))
 		if *f.Abandoned {
-			q = q.Where(abandonedExpr())
+			q = q.Where(abandoned)
 		} else {
-			q = q.Where("NOT " + abandonedExpr())
+			q = q.Where("NOT " + abandoned)
 		}
 	}
 	return q
@@ -146,7 +178,8 @@ type funnelAggregateRow struct {
 // query that always covers the trailing 24 hours regardless of the
 // requested window).
 func (r *gormRepository) GetFunnel(ctx context.Context, f FunnelFilter) (*FunnelStats, error) {
-	abandoned := abandonedExpr()
+	asOf := asOfExpr(f)
+	abandoned := abandonedExpr(asOf)
 
 	var row funnelAggregateRow
 	q := applyFunnelWindow(r.db.WithContext(ctx).Table("onboarding_sessions"), f)
@@ -164,7 +197,7 @@ func (r *gormRepository) GetFunnel(ctx context.Context, f FunnelFilter) (*Funnel
 
 	var last24h funnelAggregateRow
 	err = r.db.WithContext(ctx).Table("onboarding_sessions").
-		Where("created_at > now() - INTERVAL '24 hours'").
+		Where(fmt.Sprintf("created_at > %s - INTERVAL '24 hours'", asOf)).
 		Select(
 			"COUNT(*) AS started",
 			"COUNT(*) FILTER (WHERE email_verified_at IS NOT NULL) AS email_verified",
@@ -213,7 +246,7 @@ type sessionRowScan struct {
 // with GetFunnel so the two queries can never drift apart on which sessions
 // are in scope or which are abandoned.
 func (r *gormRepository) ListSessions(ctx context.Context, f FunnelFilter) ([]SessionRow, int64, error) {
-	abandoned := abandonedExpr()
+	abandoned := abandonedExpr(asOfExpr(f))
 
 	countQ := applySessionFilter(r.db.WithContext(ctx).Table("onboarding_sessions"), f)
 	var total int64

--- a/services/platform-api/internal/onboarding/funnel.go
+++ b/services/platform-api/internal/onboarding/funnel.go
@@ -55,6 +55,16 @@ func asOfExpr(f FunnelFilter) string {
 	return fmt.Sprintf("'%s'::timestamptz", f.AsOf.UTC().Format(time.RFC3339Nano))
 }
 
+// idleHoursExpr is the SQL for the number of hours a session has been idle,
+// evaluated against the same asOfExpr the abandoned predicate uses so the
+// two can never disagree about which instant "now" is.
+func idleHoursExpr(asOfExpr string) string {
+	return fmt.Sprintf(
+		"EXTRACT(EPOCH FROM %s - onboarding_sessions.last_activity_at) / 3600",
+		asOfExpr,
+	)
+}
+
 // DefaultFunnelPageSize applies when the caller sends no limit.
 const DefaultFunnelPageSize = 50
 
@@ -124,6 +134,10 @@ type SessionRow struct {
 	LastActivityAt  time.Time  `json:"last_activity_at"`
 	CreatedAt       time.Time  `json:"created_at"`
 	Abandoned       bool       `json:"abandoned"`
+	// IdleHours is computed in SQL from the same asOfExpr the abandoned
+	// predicate uses, so the two fields can never disagree about which
+	// instant "now" is.
+	IdleHours float64 `json:"idle_hours"`
 }
 
 // applyFunnelWindow scopes a query to onboarding_sessions.created_at within
@@ -239,6 +253,7 @@ type sessionRowScan struct {
 	LastActivityAt  time.Time
 	CreatedAt       time.Time
 	Abandoned       bool
+	IdleHours       float64
 }
 
 // ListSessions returns a page of onboarding sessions plus the unpaginated
@@ -246,7 +261,9 @@ type sessionRowScan struct {
 // with GetFunnel so the two queries can never drift apart on which sessions
 // are in scope or which are abandoned.
 func (r *gormRepository) ListSessions(ctx context.Context, f FunnelFilter) ([]SessionRow, int64, error) {
-	abandoned := abandonedExpr(asOfExpr(f))
+	asOf := asOfExpr(f)
+	abandoned := abandonedExpr(asOf)
+	idleHours := idleHoursExpr(asOf)
 
 	countQ := applySessionFilter(r.db.WithContext(ctx).Table("onboarding_sessions"), f)
 	var total int64
@@ -273,6 +290,7 @@ func (r *gormRepository) ListSessions(ctx context.Context, f FunnelFilter) ([]Se
 			"id", "email", "status", "email_verified_at", "tenant_id",
 			"completed_at", "last_activity_at", "created_at",
 			fmt.Sprintf("(%s) AS abandoned", abandoned),
+			fmt.Sprintf("(%s) AS idle_hours", idleHours),
 		).
 		Order("created_at DESC").
 		Offset((page - 1) * limit).
@@ -294,6 +312,7 @@ func (r *gormRepository) ListSessions(ctx context.Context, f FunnelFilter) ([]Se
 			LastActivityAt:  raw.LastActivityAt,
 			CreatedAt:       raw.CreatedAt,
 			Abandoned:       raw.Abandoned,
+			IdleHours:       raw.IdleHours,
 		})
 	}
 	return rows, total, nil

--- a/services/platform-api/internal/onboarding/funnel.go
+++ b/services/platform-api/internal/onboarding/funnel.go
@@ -1,0 +1,267 @@
+package onboarding
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// AbandonedAfter is how long a non-completed session may sit idle before the
+// funnel counts it abandoned.
+//
+// Derived, not stored: StatusAbandoned exists as a constant and in migration
+// 0004's CHECK constraint, but nothing ever writes it and there is no gc
+// (#322). Querying status = 'abandoned' returns zero forever.
+//
+// 24h because onboarding is normally one sitting; the only legitimate long
+// pause is waiting on the verification email, which is minutes to hours.
+const AbandonedAfter = 24 * time.Hour
+
+// abandonedExpr is the SQL for "not completed and idle past the cutoff".
+// Shared by the funnel aggregate and the sessions list so the two cannot
+// disagree about which sessions are abandoned. Exactly AbandonedAfter idle
+// counts as abandoned, hence <=.
+//
+// The interval is built from AbandonedAfter (via make_interval, in hours)
+// rather than hardcoded as a second literal — a test changing the constant
+// changes the query, since there is only one place the cutoff is written.
+func abandonedExpr() string {
+	return fmt.Sprintf(
+		"(onboarding_sessions.status <> 'completed' AND onboarding_sessions.last_activity_at <= now() - make_interval(hours => %d))",
+		int(AbandonedAfter.Hours()),
+	)
+}
+
+// DefaultFunnelPageSize applies when the caller sends no limit.
+const DefaultFunnelPageSize = 50
+
+// MaxFunnelPageSize caps a page, mirroring the tenant directory's ceiling.
+const MaxFunnelPageSize = 500
+
+// FunnelFilter narrows the onboarding funnel to a window and, for
+// ListSessions, a page. CreatedFrom/CreatedTo bound onboarding_sessions
+// created_at; Status and Abandoned further narrow ListSessions only.
+type FunnelFilter struct {
+	CreatedFrom time.Time
+	CreatedTo   time.Time
+	Status      string
+	// Abandoned, when non-nil, filters ListSessions rows to only
+	// abandoned (true) or only non-abandoned (false) sessions. GetFunnel
+	// ignores this field — it always returns all three buckets.
+	Abandoned *bool
+	Page      int
+	Limit     int
+}
+
+// FunnelCounts is one window's worth of funnel aggregates. Completed +
+// InFlight + Abandoned == Started, exactly, for any window — that
+// invariant is the whole point of computing all four in one query.
+// EmailVerified is a subset counter cutting across the other three, not a
+// fourth bucket to add into the sum.
+type FunnelCounts struct {
+	Started       int64 `json:"started"`
+	EmailVerified int64 `json:"email_verified"`
+	Completed     int64 `json:"completed"`
+	InFlight      int64 `json:"in_flight"`
+	Abandoned     int64 `json:"abandoned"`
+}
+
+// FunnelStats is the full funnel response: the windowed counts, the
+// median completion time within that window, and a Last24h count that
+// always covers the trailing 24 hours regardless of the requested window.
+type FunnelStats struct {
+	FunnelCounts
+	// MedianCompletionSeconds is nil when no session in the window
+	// completed — NULL must survive the SQL round trip as Go nil, not
+	// silently become 0 ("instant completion").
+	MedianCompletionSeconds *float64     `json:"median_completion_seconds"`
+	Last24h                 FunnelCounts `json:"last_24h"`
+}
+
+// SessionRow is one row of the onboarding sessions list, with Abandoned
+// computed by the same predicate GetFunnel uses so the two endpoints can
+// never disagree about which sessions are abandoned.
+type SessionRow struct {
+	ID              string     `json:"id"`
+	Email           string     `json:"email"`
+	Status          string     `json:"status"`
+	EmailVerifiedAt *time.Time `json:"email_verified_at,omitempty"`
+	TenantID        *string    `json:"tenant_id,omitempty"`
+	CompletedAt     *time.Time `json:"completed_at,omitempty"`
+	LastActivityAt  time.Time  `json:"last_activity_at"`
+	CreatedAt       time.Time  `json:"created_at"`
+	Abandoned       bool       `json:"abandoned"`
+}
+
+// applyFunnelWindow scopes a query to onboarding_sessions.created_at within
+// [CreatedFrom, CreatedTo]. Shared by GetFunnel's windowed aggregate and
+// ListSessions, so a session outside the window can never appear in one
+// but not the other.
+func applyFunnelWindow(q *gorm.DB, f FunnelFilter) *gorm.DB {
+	if !f.CreatedFrom.IsZero() {
+		q = q.Where("onboarding_sessions.created_at >= ?", f.CreatedFrom)
+	}
+	if !f.CreatedTo.IsZero() {
+		q = q.Where("onboarding_sessions.created_at <= ?", f.CreatedTo)
+	}
+	return q
+}
+
+// applySessionFilter narrows ListSessions further, on top of the window:
+// by status, and by the shared abandoned predicate.
+func applySessionFilter(q *gorm.DB, f FunnelFilter) *gorm.DB {
+	q = applyFunnelWindow(q, f)
+	if f.Status != "" {
+		q = q.Where("onboarding_sessions.status = ?", f.Status)
+	}
+	if f.Abandoned != nil {
+		if *f.Abandoned {
+			q = q.Where(abandonedExpr())
+		} else {
+			q = q.Where("NOT " + abandonedExpr())
+		}
+	}
+	return q
+}
+
+// funnelAggregateRow is the raw scan target for GetFunnel's single
+// aggregate query. MedianCompletionSeconds is a *float64 so SQL NULL
+// (no completions in the window) survives as Go nil rather than silently
+// becoming 0.
+type funnelAggregateRow struct {
+	Started                 int64
+	EmailVerified           int64
+	Completed               int64
+	Abandoned               int64
+	InFlight                int64
+	MedianCompletionSeconds *float64
+}
+
+// GetFunnel returns the funnel counters for the given window: started,
+// email_verified, completed, in_flight, abandoned (all from ONE query with
+// FILTER (WHERE …) aggregates, so every count observes the same database
+// state), the median completion time, and last_24h (a second, independent
+// query that always covers the trailing 24 hours regardless of the
+// requested window).
+func (r *gormRepository) GetFunnel(ctx context.Context, f FunnelFilter) (*FunnelStats, error) {
+	abandoned := abandonedExpr()
+
+	var row funnelAggregateRow
+	q := applyFunnelWindow(r.db.WithContext(ctx).Table("onboarding_sessions"), f)
+	err := q.Select(
+		"COUNT(*) AS started",
+		"COUNT(*) FILTER (WHERE email_verified_at IS NOT NULL) AS email_verified",
+		"COUNT(*) FILTER (WHERE status = 'completed') AS completed",
+		fmt.Sprintf("COUNT(*) FILTER (WHERE %s) AS abandoned", abandoned),
+		fmt.Sprintf("COUNT(*) FILTER (WHERE status <> 'completed' AND NOT (%s)) AS in_flight", abandoned),
+		"percentile_cont(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM completed_at - created_at)) FILTER (WHERE status = 'completed') AS median_completion_seconds",
+	).Scan(&row).Error
+	if err != nil {
+		return nil, fmt.Errorf("onboarding: get funnel: %w", err)
+	}
+
+	var last24h funnelAggregateRow
+	err = r.db.WithContext(ctx).Table("onboarding_sessions").
+		Where("created_at > now() - INTERVAL '24 hours'").
+		Select(
+			"COUNT(*) AS started",
+			"COUNT(*) FILTER (WHERE email_verified_at IS NOT NULL) AS email_verified",
+			"COUNT(*) FILTER (WHERE status = 'completed') AS completed",
+			fmt.Sprintf("COUNT(*) FILTER (WHERE %s) AS abandoned", abandoned),
+			fmt.Sprintf("COUNT(*) FILTER (WHERE status <> 'completed' AND NOT (%s)) AS in_flight", abandoned),
+		).Scan(&last24h).Error
+	if err != nil {
+		return nil, fmt.Errorf("onboarding: get funnel last_24h: %w", err)
+	}
+
+	return &FunnelStats{
+		FunnelCounts: FunnelCounts{
+			Started:       row.Started,
+			EmailVerified: row.EmailVerified,
+			Completed:     row.Completed,
+			InFlight:      row.InFlight,
+			Abandoned:     row.Abandoned,
+		},
+		MedianCompletionSeconds: row.MedianCompletionSeconds,
+		Last24h: FunnelCounts{
+			Started:       last24h.Started,
+			EmailVerified: last24h.EmailVerified,
+			Completed:     last24h.Completed,
+			InFlight:      last24h.InFlight,
+			Abandoned:     last24h.Abandoned,
+		},
+	}, nil
+}
+
+// sessionRowScan is the raw scan target for one ListSessions row.
+type sessionRowScan struct {
+	ID              string
+	Email           string
+	Status          string
+	EmailVerifiedAt *time.Time
+	TenantID        *string
+	CompletedAt     *time.Time
+	LastActivityAt  time.Time
+	CreatedAt       time.Time
+	Abandoned       bool
+}
+
+// ListSessions returns a page of onboarding sessions plus the unpaginated
+// total, ordered created_at DESC, sharing applyFunnelWindow/applySessionFilter
+// with GetFunnel so the two queries can never drift apart on which sessions
+// are in scope or which are abandoned.
+func (r *gormRepository) ListSessions(ctx context.Context, f FunnelFilter) ([]SessionRow, int64, error) {
+	abandoned := abandonedExpr()
+
+	countQ := applySessionFilter(r.db.WithContext(ctx).Table("onboarding_sessions"), f)
+	var total int64
+	if err := countQ.Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("onboarding: list sessions count: %w", err)
+	}
+
+	page := max(f.Page, 1)
+	limit := f.Limit
+	switch {
+	case limit <= 0:
+		limit = DefaultFunnelPageSize
+	case limit > MaxFunnelPageSize:
+		limit = MaxFunnelPageSize
+	}
+
+	// Allocate before Scan: a nil slice marshals to {} downstream, which
+	// defeats a caller's `?? []`.
+	rawRows := make([]sessionRowScan, 0, limit)
+
+	pageQ := applySessionFilter(r.db.WithContext(ctx).Table("onboarding_sessions"), f)
+	err := pageQ.
+		Select(
+			"id", "email", "status", "email_verified_at", "tenant_id",
+			"completed_at", "last_activity_at", "created_at",
+			fmt.Sprintf("(%s) AS abandoned", abandoned),
+		).
+		Order("created_at DESC").
+		Offset((page - 1) * limit).
+		Limit(limit).
+		Scan(&rawRows).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("onboarding: list sessions: %w", err)
+	}
+
+	rows := make([]SessionRow, 0, len(rawRows))
+	for _, raw := range rawRows {
+		rows = append(rows, SessionRow{
+			ID:              raw.ID,
+			Email:           raw.Email,
+			Status:          raw.Status,
+			EmailVerifiedAt: raw.EmailVerifiedAt,
+			TenantID:        raw.TenantID,
+			CompletedAt:     raw.CompletedAt,
+			LastActivityAt:  raw.LastActivityAt,
+			CreatedAt:       raw.CreatedAt,
+			Abandoned:       raw.Abandoned,
+		})
+	}
+	return rows, total, nil
+}

--- a/services/platform-api/internal/onboarding/funnel.go
+++ b/services/platform-api/internal/onboarding/funnel.go
@@ -29,8 +29,8 @@ const AbandonedAfter = 24 * time.Hour
 // changes the query, since there is only one place the cutoff is written.
 //
 // asOfExpr is the SQL expression to evaluate "now" against — normally the
-// literal "now()", but a test can pass a bound parameter placeholder (see
-// FunnelFilter.AsOf) to pin the evaluation instant exactly.
+// literal "now()", but a test can pin the evaluation instant exactly (see
+// FunnelFilter.AsOf) by rendering an inline timestamptz literal instead.
 func abandonedExpr(asOfExpr string) string {
 	return fmt.Sprintf(
 		"(onboarding_sessions.status <> 'completed' AND onboarding_sessions.last_activity_at <= %s - make_interval(hours => %d))",
@@ -109,9 +109,31 @@ type FunnelCounts struct {
 	Abandoned     int64 `json:"abandoned"`
 }
 
+// FunnelWindow is the effective [from, to] window GetFunnel computed the
+// counters over, echoed back so the console can render what it actually
+// got rather than what it thinks it asked for.
+type FunnelWindow struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// formatWindowBound renders one FunnelFilter window bound the way
+// GetFunnel actually treats it: a zero time.Time means the caller supplied
+// no bound and applyFunnelWindow adds no constraint on that side, so the
+// effective bound is "unbounded" — rendered here as "", not a computed
+// default timestamp. A non-zero bound is exactly the value GetFunnel
+// filtered on, RFC3339 in UTC.
+func formatWindowBound(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
 // FunnelStats is the full funnel response: the windowed counts, the
-// median completion time within that window, and a Last24h count that
-// always covers the trailing 24 hours regardless of the requested window.
+// median completion time within that window, a Last24h count that always
+// covers the trailing 24 hours regardless of the requested window, and the
+// effective Window those counts were computed over.
 type FunnelStats struct {
 	FunnelCounts
 	// MedianCompletionSeconds is nil when no session in the window
@@ -119,6 +141,7 @@ type FunnelStats struct {
 	// silently become 0 ("instant completion").
 	MedianCompletionSeconds *float64     `json:"median_completion_seconds"`
 	Last24h                 FunnelCounts `json:"last_24h"`
+	Window                  FunnelWindow `json:"window"`
 }
 
 // SessionRow is one row of the onboarding sessions list, with Abandoned
@@ -211,7 +234,7 @@ func (r *gormRepository) GetFunnel(ctx context.Context, f FunnelFilter) (*Funnel
 
 	var last24h funnelAggregateRow
 	err = r.db.WithContext(ctx).Table("onboarding_sessions").
-		Where(fmt.Sprintf("created_at > %s - INTERVAL '24 hours'", asOf)).
+		Where(fmt.Sprintf("created_at > %s - INTERVAL '24 hours' AND created_at <= %s", asOf, asOf)).
 		Select(
 			"COUNT(*) AS started",
 			"COUNT(*) FILTER (WHERE email_verified_at IS NOT NULL) AS email_verified",
@@ -238,6 +261,10 @@ func (r *gormRepository) GetFunnel(ctx context.Context, f FunnelFilter) (*Funnel
 			Completed:     last24h.Completed,
 			InFlight:      last24h.InFlight,
 			Abandoned:     last24h.Abandoned,
+		},
+		Window: FunnelWindow{
+			From: formatWindowBound(f.CreatedFrom),
+			To:   formatWindowBound(f.CreatedTo),
 		},
 	}, nil
 }

--- a/services/platform-api/internal/onboarding/funnel_handler_test.go
+++ b/services/platform-api/internal/onboarding/funnel_handler_test.go
@@ -1,0 +1,232 @@
+package onboarding
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// stubFunnelRepo records the filter it received and returns canned results.
+// Embeds Repository so it only needs to implement the two methods the
+// analytics handlers actually call.
+type stubFunnelRepo struct {
+	Repository
+	gotFunnelFilter  FunnelFilter
+	funnelStats      *FunnelStats
+	funnelErr        error
+	gotSessionFilter FunnelFilter
+	sessionRows      []SessionRow
+	sessionTotal     int64
+	sessionErr       error
+}
+
+func (s *stubFunnelRepo) GetFunnel(_ context.Context, f FunnelFilter) (*FunnelStats, error) {
+	s.gotFunnelFilter = f
+	return s.funnelStats, s.funnelErr
+}
+
+func (s *stubFunnelRepo) ListSessions(_ context.Context, f FunnelFilter) ([]SessionRow, int64, error) {
+	s.gotSessionFilter = f
+	return s.sessionRows, s.sessionTotal, s.sessionErr
+}
+
+// analyticsRouter mounts only RegisterAnalytics, for tests that don't care
+// about route collisions with the public wizard routes.
+func analyticsRouter(t *testing.T, repo Repository) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h := NewHandler(NewService(Config{Repo: repo}), nil)
+	h.RegisterAnalytics(r.Group(""))
+	return r
+}
+
+func TestFunnel_ReturnsCountersNoPaginationKey(t *testing.T) {
+	repo := &stubFunnelRepo{funnelStats: &FunnelStats{
+		FunnelCounts: FunnelCounts{Started: 10, EmailVerified: 8, Completed: 5, InFlight: 3, Abandoned: 2},
+	}}
+	rec := httptest.NewRecorder()
+	analyticsRouter(t, repo).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/onboarding/funnel", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	_, hasData := body["data"]
+	require.True(t, hasData)
+	_, hasPagination := body["pagination"]
+	require.False(t, hasPagination, "funnel response must not have a pagination key")
+
+	var data FunnelCounts
+	require.NoError(t, json.Unmarshal(body["data"], &data))
+	require.Equal(t, int64(10), data.Started)
+}
+
+// TestFunnel_MedianNullSerializesJSONNull asserts on the raw JSON body,
+// not a decoded struct — decoding makes null and 0 hard to tell apart,
+// and that distinction is the whole point (#283).
+func TestFunnel_MedianNullSerializesJSONNull(t *testing.T) {
+	repo := &stubFunnelRepo{funnelStats: &FunnelStats{
+		MedianCompletionSeconds: nil,
+	}}
+	rec := httptest.NewRecorder()
+	analyticsRouter(t, repo).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/onboarding/funnel", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"median_completion_seconds":null`)
+}
+
+func TestFunnel_AsOfIsNeverSetFromQueryParams(t *testing.T) {
+	repo := &stubFunnelRepo{funnelStats: &FunnelStats{}}
+	rec := httptest.NewRecorder()
+	analyticsRouter(t, repo).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/onboarding/funnel?as_of=2020-01-01T00:00:00Z", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, repo.gotFunnelFilter.AsOf.IsZero(), "AsOf must never be settable from a query param")
+}
+
+func TestSessions_EmptyIsArrayNotNull(t *testing.T) {
+	repo := &stubFunnelRepo{sessionRows: nil, sessionTotal: 0}
+	rec := httptest.NewRecorder()
+	analyticsRouter(t, repo).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/onboarding/sessions", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "[]", string(body.Data))
+}
+
+func TestSessions_LimitClamps500(t *testing.T) {
+	repo := &stubFunnelRepo{sessionRows: []SessionRow{}, sessionTotal: 0}
+	rec := httptest.NewRecorder()
+	analyticsRouter(t, repo).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/onboarding/sessions?limit=9999", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, MaxFunnelPageSize, repo.gotSessionFilter.Limit)
+
+	var body struct {
+		Pagination struct {
+			Limit int `json:"limit"`
+		} `json:"pagination"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, 500, body.Pagination.Limit)
+}
+
+func TestSessions_MissingParamsTakeDefaults(t *testing.T) {
+	repo := &stubFunnelRepo{sessionRows: []SessionRow{}, sessionTotal: 0}
+	rec := httptest.NewRecorder()
+	analyticsRouter(t, repo).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/onboarding/sessions", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, DefaultFunnelPageSize, repo.gotSessionFilter.Limit)
+	require.Equal(t, 1, max(repo.gotSessionFilter.Page, 1))
+
+	var body struct {
+		Pagination struct {
+			Page  int   `json:"page"`
+			Limit int   `json:"limit"`
+			Total int64 `json:"total"`
+		} `json:"pagination"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, DefaultFunnelPageSize, body.Pagination.Limit)
+}
+
+func TestSessions_GarbageParamsDoNotError(t *testing.T) {
+	repo := &stubFunnelRepo{sessionRows: []SessionRow{}, sessionTotal: 0}
+	rec := httptest.NewRecorder()
+	analyticsRouter(t, repo).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/onboarding/sessions?limit=abc&page=-4", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, DefaultFunnelPageSize, repo.gotSessionFilter.Limit)
+}
+
+// fullRouter mounts the onboarding handler exactly the way cmd/server/
+// main.go does: Register on the public /api/v1 group, RegisterAnalytics on
+// a SEPARATE strict internal group. This is the real two-group shape —
+// verified not to panic at router-build time and not to shadow either
+// sibling route, the #287 class of bug: /onboarding/sessions (static,
+// analytics) and /onboarding/sessions/:id (public wizard) sit at the same
+// path position.
+func fullRouter(t *testing.T, repo Repository) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h := NewHandler(NewService(Config{Repo: repo}), nil)
+
+	public := r.Group("/api/v1")
+	h.Register(public)
+
+	strictInternal := r.Group("/internal")
+	h.RegisterAnalytics(strictInternal)
+
+	return r
+}
+
+func TestRoute_SessionsStaticSiblingDoesNotShadowPublicWildcard(t *testing.T) {
+	repo := &stubFunnelRepo{
+		sessionRows:  []SessionRow{{ID: "row-1"}},
+		sessionTotal: 1,
+		funnelStats:  &FunnelStats{},
+	}
+
+	require.NotPanics(t, func() {
+		fullRouter(t, repo)
+	})
+
+	r := fullRouter(t, repo)
+
+	// New static analytics route resolves to its own handler.
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/internal/onboarding/sessions", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var listBody struct {
+		Data []SessionRow `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &listBody))
+	require.Len(t, listBody.Data, 1)
+	require.Equal(t, "row-1", listBody.Data[0].ID)
+
+	// Public wizard's GET /api/v1/onboarding/sessions/:id (wildcard) still
+	// resolves to its own handler, not the static analytics route.
+	sessRepo := &sessionByIDStub{sess: &Session{ID: "sess-abc"}}
+	sessRouter := gin.New()
+	gin.SetMode(gin.TestMode)
+	sh := NewHandler(NewService(Config{Repo: sessRepo}), nil)
+	pub := sessRouter.Group("/api/v1")
+	sh.Register(pub)
+	strict := sessRouter.Group("/internal")
+	sh.RegisterAnalytics(strict)
+
+	rec2 := httptest.NewRecorder()
+	sessRouter.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/api/v1/onboarding/sessions/sess-abc", nil))
+	require.Equal(t, http.StatusOK, rec2.Code)
+	var getBody struct {
+		Data Session `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &getBody))
+	require.Equal(t, "sess-abc", getBody.Data.ID)
+}
+
+// sessionByIDStub satisfies Repository just enough for GetByID, used to
+// prove the public /:id wildcard still resolves after RegisterAnalytics
+// adds the static sibling.
+type sessionByIDStub struct {
+	Repository
+	sess *Session
+}
+
+func (s *sessionByIDStub) GetByID(_ context.Context, _ string) (*Session, error) {
+	return s.sess, nil
+}

--- a/services/platform-api/internal/onboarding/funnel_integration_test.go
+++ b/services/platform-api/internal/onboarding/funnel_integration_test.go
@@ -245,6 +245,17 @@ func TestIntegration_Funnel_Partition(t *testing.T) {
 // TestIntegration_Funnel_CrossEndpointAgreement proves the funnel's
 // abandoned count and ListSessions' abandoned-flagged row count agree over
 // the same window — the point of sharing one predicate.
+//
+// The fixture deliberately includes a session idle ~24.5h — squarely in
+// the 24-25h band. Without a row in that band, GetFunnel's abandoned
+// predicate (built from AbandonedAfter == 24h) and a hand-copied 25h
+// predicate in ListSessions would classify every fixture identically and
+// this test would pass even with the two predicates drifted apart, which
+// is exactly what happened once: a reviewer hand-copied a 25h interval
+// into ListSessions while GetFunnel kept 24h, and this test still passed
+// because the old fixtures idled at 5h/40h/30h/completed — nowhere near
+// the 24-25h band the drift moves. See task-4-report.md for the mutation
+// that proves this row closes the gap.
 func TestIntegration_Funnel_CrossEndpointAgreement(t *testing.T) {
 	repo, db := setupFunnelTest(t)
 	ctx := context.Background()
@@ -253,6 +264,7 @@ func TestIntegration_Funnel_CrossEndpointAgreement(t *testing.T) {
 	seedInFlightOrAbandoned(t, repo, "x-inflight@cross.local", StatusInProgress, now.Add(-5*time.Hour), now.Add(-5*time.Hour))
 	seedInFlightOrAbandoned(t, repo, "x-abandoned-1@cross.local", StatusInProgress, now.Add(-40*time.Hour), now.Add(-40*time.Hour))
 	seedInFlightOrAbandoned(t, repo, "x-abandoned-2@cross.local", StatusVerifying, now.Add(-90*time.Hour), now.Add(-30*time.Hour))
+	seedInFlightOrAbandoned(t, repo, "x-abandoned-3-band@cross.local", StatusInProgress, now.Add(-24*time.Hour-30*time.Minute), now.Add(-24*time.Hour-30*time.Minute))
 	seedCompletedSession(t, repo, db, "x-completed@cross.local", now.Add(-6*time.Hour), 15)
 
 	filter := FunnelFilter{
@@ -400,6 +412,58 @@ func TestIntegration_Funnel_WindowExcludesOutsideSessions(t *testing.T) {
 	}
 }
 
+// TestIntegration_Funnel_WindowKeyReflectsEffectiveBounds proves GetFunnel
+// populates the "window" field with the effective bounds it actually
+// filtered on, RFC3339 in UTC — the field platform-api's real upstream
+// response was missing entirely (marketplace-api's client, wire type and
+// golden fixture all assumed it existed, but nothing populated it, so the
+// console would always have received {"from":"","to":""} in production).
+//
+// Also pins the no-bounds case: when the caller supplies neither
+// CreatedFrom nor CreatedTo, GetFunnel applies no window constraint at
+// all (applyFunnelWindow adds nothing), so the effective bound on that
+// side is "unbounded" and Window renders "" for it — not a computed
+// default timestamp. That is the existing behaviour, described here
+// truthfully rather than inventing new defaulting.
+func TestIntegration_Funnel_WindowKeyReflectsEffectiveBounds(t *testing.T) {
+	repo, _ := setupFunnelTest(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	seedInFlightOrAbandoned(t, repo, "window-key@window.local", StatusInProgress, now.Add(-1*time.Hour), now.Add(-1*time.Hour))
+
+	from := now.Add(-48 * time.Hour)
+	to := now.Add(time.Hour)
+
+	stats, err := repo.GetFunnel(ctx, FunnelFilter{
+		CreatedFrom: from,
+		CreatedTo:   to,
+	})
+	if err != nil {
+		t.Fatalf("GetFunnel: %v", err)
+	}
+	if got, want := stats.Window.From, from.UTC().Format(time.RFC3339); got != want {
+		t.Errorf("Window.From = %q, want %q", got, want)
+	}
+	if got, want := stats.Window.To, to.UTC().Format(time.RFC3339); got != want {
+		t.Errorf("Window.To = %q, want %q", got, want)
+	}
+
+	// No bounds supplied at all: the effective window is unbounded on
+	// both sides, and the field must say so rather than fabricate a
+	// default.
+	unboundedStats, err := repo.GetFunnel(ctx, FunnelFilter{})
+	if err != nil {
+		t.Fatalf("GetFunnel (unbounded): %v", err)
+	}
+	if unboundedStats.Window.From != "" {
+		t.Errorf("Window.From = %q with no CreatedFrom supplied, want \"\"", unboundedStats.Window.From)
+	}
+	if unboundedStats.Window.To != "" {
+		t.Errorf("Window.To = %q with no CreatedTo supplied, want \"\"", unboundedStats.Window.To)
+	}
+}
+
 // TestIntegration_Funnel_Last24hIgnoresWindow verifies last_24h is always
 // computed over the trailing 24h regardless of the requested window — with
 // a window entirely in the past, last_24h.started still counts a session
@@ -428,6 +492,61 @@ func TestIntegration_Funnel_Last24hIgnoresWindow(t *testing.T) {
 	}
 	if stats.Last24h.Started < 1 {
 		t.Errorf("Last24h.Started = %d, want >= 1 (the session created 5 minutes ago)", stats.Last24h.Started)
+	}
+}
+
+// TestIntegration_Funnel_Last24hPinnedToAsOf proves last_24h is computed
+// relative to FunnelFilter.AsOf, not an independently-evaluated now() —
+// the same defect class fc8b4198 fixed for idle_hours, in the last_24h
+// clock instead. Before this test, replacing the shared asOf - INTERVAL
+// '24 hours' expression with a literal now() in GetFunnel's last_24h query
+// survived the entire suite, because every other last_24h assertion used
+// real wall-clock fixtures where a leaked now() looks identical to the
+// pinned AsOf.
+//
+// AsOf is pinned 10 days in the past — clearly historical, and far enough
+// from real time.Now() that every fixture below sits nowhere near a real
+// trailing-24h window. That distance is deliberate: it is what makes the
+// primary assertion (Last24h.Started == 1) actually discriminate against a
+// mutated, independently-evaluated now() rather than passing by
+// coincidence. A 6h-in-the-past AsOf was tried first and rejected — a
+// fixture placed just after such a near AsOf can still land inside the
+// real last-24-real-hours window, so a now()-mutation would count it too
+// and the test would pass either way.
+//
+// Also pins the upper bound: last_24h had no created_at <= asOf clause,
+// so with AsOf pinned in the past a session created between AsOf and the
+// real now() (i.e. "in the future" relative to AsOf) would still be
+// counted. That session must NOT appear in Last24h.Started.
+func TestIntegration_Funnel_Last24hPinnedToAsOf(t *testing.T) {
+	repo, _ := setupFunnelTest(t)
+	ctx := context.Background()
+	asOf := time.Now().Add(-10 * 24 * time.Hour)
+
+	// Within the trailing 24h of asOf: must count. Correct impl: yes
+	// (asOf-23h is within (asOf-24h, asOf]). Mutated impl (real now()):
+	// no — asOf-23h is ~10 days before real now(), nowhere near it.
+	seedInFlightOrAbandoned(t, repo, "within-24h-of-asof@last24hpin.local", StatusInProgress,
+		asOf.Add(-23*time.Hour), asOf.Add(-23*time.Hour))
+	// More than 24h before asOf: must not count under either impl.
+	seedInFlightOrAbandoned(t, repo, "before-24h-of-asof@last24hpin.local", StatusInProgress,
+		asOf.Add(-25*time.Hour), asOf.Add(-25*time.Hour))
+	// Created after asOf (but ~10 days before real now()): must not count
+	// under either impl — this pins the missing-upper-bound nit
+	// independently of the now()-mutation this test is primarily for.
+	seedInFlightOrAbandoned(t, repo, "after-asof@last24hpin.local", StatusInProgress,
+		asOf.Add(1*time.Hour), asOf.Add(1*time.Hour))
+
+	stats, err := repo.GetFunnel(ctx, FunnelFilter{
+		CreatedFrom: asOf.Add(-72 * time.Hour),
+		CreatedTo:   asOf.Add(72 * time.Hour),
+		AsOf:        asOf,
+	})
+	if err != nil {
+		t.Fatalf("GetFunnel: %v", err)
+	}
+	if stats.Last24h.Started != 1 {
+		t.Errorf("Last24h.Started = %d, want 1 (only the session within 24h before AsOf)", stats.Last24h.Started)
 	}
 }
 

--- a/services/platform-api/internal/onboarding/funnel_integration_test.go
+++ b/services/platform-api/internal/onboarding/funnel_integration_test.go
@@ -161,7 +161,11 @@ func TestIntegration_Funnel_BoundaryAbandonment(t *testing.T) {
 func TestIntegration_Funnel_IdleHoursAgreesWithAbandoned(t *testing.T) {
 	repo, _ := setupFunnelTest(t)
 	ctx := context.Background()
-	asOf := time.Now()
+	// asOf is pinned to a clearly historical instant (not time.Now()) so
+	// that a mutation using an independent now() for idle_hours can't hide
+	// behind the sub-second gap between Go's clock and Postgres's own now()
+	// at query time.
+	asOf := time.Now().Add(-6 * time.Hour)
 
 	justUnderCutoff := asOf.Add(-AbandonedAfter + time.Minute)
 	atCutoff := asOf.Add(-AbandonedAfter)

--- a/services/platform-api/internal/onboarding/funnel_integration_test.go
+++ b/services/platform-api/internal/onboarding/funnel_integration_test.go
@@ -147,6 +147,65 @@ func TestIntegration_Funnel_BoundaryAbandonment(t *testing.T) {
 	}
 }
 
+// TestIntegration_Funnel_IdleHoursAgreesWithAbandoned proves idle_hours and
+// abandoned can never contradict each other on the same row, because both
+// are computed upstream from the same asOfExpr(f) — never from a caller's
+// own clock. A session idle by exactly AbandonedAfter relative to a fixed
+// AsOf must show abandoned == true AND idle_hours == 24 (within a tiny
+// float epsilon); one idle by AbandonedAfter minus a small delta must show
+// abandoned == false AND idle_hours just under 24.
+//
+// This assertion was impossible before this fix: idle_hours did not exist
+// on SessionRow at all, so there was nothing to freeze against AsOf or
+// compare against abandoned.
+func TestIntegration_Funnel_IdleHoursAgreesWithAbandoned(t *testing.T) {
+	repo, _ := setupFunnelTest(t)
+	ctx := context.Background()
+	asOf := time.Now()
+
+	justUnderCutoff := asOf.Add(-AbandonedAfter + time.Minute)
+	atCutoff := asOf.Add(-AbandonedAfter)
+
+	seedInFlightOrAbandoned(t, repo, "idle-just-under@idlehours.local", StatusInProgress, justUnderCutoff, justUnderCutoff)
+	seedInFlightOrAbandoned(t, repo, "idle-at-cutoff@idlehours.local", StatusInProgress, atCutoff, atCutoff)
+
+	rows, _, err := repo.ListSessions(ctx, FunnelFilter{
+		CreatedFrom: asOf.Add(-48 * time.Hour),
+		CreatedTo:   asOf.Add(time.Hour),
+		AsOf:        asOf,
+		Limit:       10,
+	})
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+
+	const epsilon = 0.001
+	found := 0
+	for _, r := range rows {
+		switch r.Email {
+		case "idle-at-cutoff@idlehours.local":
+			found++
+			if !r.Abandoned {
+				t.Errorf("session idle exactly AbandonedAfter must be abandoned")
+			}
+			if diff := r.IdleHours - 24; diff < -epsilon || diff > epsilon {
+				t.Errorf("idle_hours = %v, want 24 (within epsilon)", r.IdleHours)
+			}
+		case "idle-just-under@idlehours.local":
+			found++
+			if r.Abandoned {
+				t.Errorf("session idle just under AbandonedAfter must NOT be abandoned")
+			}
+			if r.IdleHours >= 24 {
+				t.Errorf("idle_hours = %v, want just under 24", r.IdleHours)
+			}
+		}
+	}
+	if found != 2 {
+		t.Fatalf("expected to find both fixtures in ListSessions rows, found %d", found)
+	}
+}
+
 // TestIntegration_Funnel_Partition proves completed + in_flight + abandoned
 // == started exactly, over a mixed fixture. email_verified is a subset
 // counter and must never be added into this sum.

--- a/services/platform-api/internal/onboarding/funnel_integration_test.go
+++ b/services/platform-api/internal/onboarding/funnel_integration_test.go
@@ -1,0 +1,426 @@
+//go:build integration
+
+package onboarding
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/platform-api/internal/tenant"
+	"github.com/mark8ly/platform-api/pkg/testdb"
+)
+
+// seedInFlightOrAbandoned inserts a non-completed session with an explicit
+// created_at / last_activity_at. Fixtures are always relative to now() (via
+// the caller) rather than absolute clock times, and last_activity_at is
+// always set explicitly rather than left to the column default — the whole
+// point of these tests is pinning behaviour around that column.
+func seedInFlightOrAbandoned(t *testing.T, repo Repository, email, status string, createdAt, lastActivityAt time.Time) *Session {
+	t.Helper()
+	sess := &Session{
+		Email:          email,
+		Status:         status,
+		CreatedAt:      createdAt,
+		LastActivityAt: lastActivityAt,
+	}
+	if err := repo.Create(context.Background(), sess); err != nil {
+		t.Fatalf("seed session %s: %v", email, err)
+	}
+	return sess
+}
+
+// seedCompletedSession creates a tenant row (required by the FK and the
+// completed_consistency CHECK on onboarding_sessions) plus a completed
+// session that took completionSeconds to finish from createdAt.
+func seedCompletedSession(t *testing.T, repo Repository, db *gorm.DB, email string, createdAt time.Time, completionSeconds float64) *Session {
+	t.Helper()
+	ctx := context.Background()
+
+	tn := &tenant.Tenant{
+		Name:        "Funnel Test Co " + email,
+		OwnerUserID: "owner-" + email,
+		OwnerEmail:  email,
+		Status:      tenant.StatusActive,
+	}
+	if err := db.WithContext(ctx).Create(tn).Error; err != nil {
+		t.Fatalf("seed tenant for %s: %v", email, err)
+	}
+
+	completedAt := createdAt.Add(time.Duration(completionSeconds * float64(time.Second)))
+	sess := &Session{
+		Email:          email,
+		Status:         StatusCompleted,
+		CreatedAt:      createdAt,
+		LastActivityAt: completedAt,
+		TenantID:       &tn.ID,
+		CompletedAt:    &completedAt,
+	}
+	if err := repo.Create(ctx, sess); err != nil {
+		t.Fatalf("seed completed session %s: %v", email, err)
+	}
+	return sess
+}
+
+func setupFunnelTest(t *testing.T) (Repository, *gorm.DB) {
+	t.Helper()
+	db := testdb.NewDB(t,
+		"outbox_events",
+		"verification_tokens",
+		"onboarding_sessions",
+		"stores",
+		"tenants",
+	)
+	return NewRepository(db), db
+}
+
+// TestIntegration_Funnel_BoundaryAbandonment pins the exactly-24h-idle rule:
+// a session idle for 23h is in flight, one idle for exactly 24h or more is
+// abandoned. This is arbitrary but decided, and must not silently drift.
+func TestIntegration_Funnel_BoundaryAbandonment(t *testing.T) {
+	repo, _ := setupFunnelTest(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	seedInFlightOrAbandoned(t, repo, "in-flight-23h@boundary.local", StatusInProgress, now.Add(-23*time.Hour), now.Add(-23*time.Hour))
+	seedInFlightOrAbandoned(t, repo, "abandoned-24h@boundary.local", StatusInProgress, now.Add(-24*time.Hour), now.Add(-24*time.Hour))
+	seedInFlightOrAbandoned(t, repo, "abandoned-25h@boundary.local", StatusInProgress, now.Add(-25*time.Hour), now.Add(-25*time.Hour))
+
+	stats, err := repo.GetFunnel(ctx, FunnelFilter{
+		CreatedFrom: now.Add(-48 * time.Hour),
+		CreatedTo:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetFunnel: %v", err)
+	}
+	if stats.Started != 3 {
+		t.Fatalf("Started = %d, want 3", stats.Started)
+	}
+	if stats.InFlight != 1 {
+		t.Errorf("InFlight = %d, want 1 (the 23h session)", stats.InFlight)
+	}
+	if stats.Abandoned != 2 {
+		t.Errorf("Abandoned = %d, want 2 (the 24h and 25h sessions)", stats.Abandoned)
+	}
+
+	rows, _, err := repo.ListSessions(ctx, FunnelFilter{
+		CreatedFrom: now.Add(-48 * time.Hour),
+		CreatedTo:   now.Add(time.Hour),
+		Limit:       10,
+	})
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	abandonedCount := 0
+	for _, r := range rows {
+		if r.Email == "abandoned-24h@boundary.local" && !r.Abandoned {
+			t.Errorf("session idle exactly 24h must be flagged abandoned")
+		}
+		if r.Email == "in-flight-23h@boundary.local" && r.Abandoned {
+			t.Errorf("session idle 23h must NOT be flagged abandoned")
+		}
+		if r.Abandoned {
+			abandonedCount++
+		}
+	}
+	if abandonedCount != 2 {
+		t.Errorf("ListSessions abandoned rows = %d, want 2", abandonedCount)
+	}
+}
+
+// TestIntegration_Funnel_Partition proves completed + in_flight + abandoned
+// == started exactly, over a mixed fixture. email_verified is a subset
+// counter and must never be added into this sum.
+func TestIntegration_Funnel_Partition(t *testing.T) {
+	repo, db := setupFunnelTest(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	seedInFlightOrAbandoned(t, repo, "p-inflight-1@partition.local", StatusInProgress, now.Add(-2*time.Hour), now.Add(-2*time.Hour))
+	seedInFlightOrAbandoned(t, repo, "p-inflight-2@partition.local", StatusVerifying, now.Add(-1*time.Hour), now.Add(-1*time.Hour))
+	seedInFlightOrAbandoned(t, repo, "p-abandoned-1@partition.local", StatusInProgress, now.Add(-30*time.Hour), now.Add(-30*time.Hour))
+	seedInFlightOrAbandoned(t, repo, "p-abandoned-2@partition.local", StatusVerifying, now.Add(-48*time.Hour), now.Add(-26*time.Hour))
+	seedCompletedSession(t, repo, db, "p-completed-1@partition.local", now.Add(-3*time.Hour), 10)
+	seedCompletedSession(t, repo, db, "p-completed-2@partition.local", now.Add(-4*time.Hour), 20)
+
+	stats, err := repo.GetFunnel(ctx, FunnelFilter{
+		CreatedFrom: now.Add(-72 * time.Hour),
+		CreatedTo:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetFunnel: %v", err)
+	}
+	if stats.Started != 6 {
+		t.Fatalf("Started = %d, want 6", stats.Started)
+	}
+	sum := stats.Completed + stats.InFlight + stats.Abandoned
+	if sum != stats.Started {
+		t.Errorf("completed(%d) + in_flight(%d) + abandoned(%d) = %d, want started(%d)",
+			stats.Completed, stats.InFlight, stats.Abandoned, sum, stats.Started)
+	}
+}
+
+// TestIntegration_Funnel_CrossEndpointAgreement proves the funnel's
+// abandoned count and ListSessions' abandoned-flagged row count agree over
+// the same window — the point of sharing one predicate.
+func TestIntegration_Funnel_CrossEndpointAgreement(t *testing.T) {
+	repo, db := setupFunnelTest(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	seedInFlightOrAbandoned(t, repo, "x-inflight@cross.local", StatusInProgress, now.Add(-5*time.Hour), now.Add(-5*time.Hour))
+	seedInFlightOrAbandoned(t, repo, "x-abandoned-1@cross.local", StatusInProgress, now.Add(-40*time.Hour), now.Add(-40*time.Hour))
+	seedInFlightOrAbandoned(t, repo, "x-abandoned-2@cross.local", StatusVerifying, now.Add(-90*time.Hour), now.Add(-30*time.Hour))
+	seedCompletedSession(t, repo, db, "x-completed@cross.local", now.Add(-6*time.Hour), 15)
+
+	filter := FunnelFilter{
+		CreatedFrom: now.Add(-100 * time.Hour),
+		CreatedTo:   now.Add(time.Hour),
+		Limit:       500,
+	}
+
+	stats, err := repo.GetFunnel(ctx, filter)
+	if err != nil {
+		t.Fatalf("GetFunnel: %v", err)
+	}
+
+	rows, total, err := repo.ListSessions(ctx, filter)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if total != stats.Started {
+		t.Fatalf("ListSessions total = %d, GetFunnel started = %d, want equal", total, stats.Started)
+	}
+
+	rowAbandoned := int64(0)
+	for _, r := range rows {
+		if r.Abandoned {
+			rowAbandoned++
+		}
+	}
+	if rowAbandoned != stats.Abandoned {
+		t.Errorf("ListSessions abandoned rows = %d, GetFunnel.Abandoned = %d, want equal", rowAbandoned, stats.Abandoned)
+	}
+}
+
+// TestIntegration_Funnel_MedianOddCount verifies percentile_cont(0.5) picks
+// the middle value for an odd number of completions: 10s, 20s, 60s -> 20.
+func TestIntegration_Funnel_MedianOddCount(t *testing.T) {
+	repo, db := setupFunnelTest(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	seedCompletedSession(t, repo, db, "median-odd-1@median.local", now.Add(-1*time.Hour), 10)
+	seedCompletedSession(t, repo, db, "median-odd-2@median.local", now.Add(-1*time.Hour), 20)
+	seedCompletedSession(t, repo, db, "median-odd-3@median.local", now.Add(-1*time.Hour), 60)
+
+	stats, err := repo.GetFunnel(ctx, FunnelFilter{
+		CreatedFrom: now.Add(-24 * time.Hour),
+		CreatedTo:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetFunnel: %v", err)
+	}
+	if stats.MedianCompletionSeconds == nil {
+		t.Fatal("MedianCompletionSeconds is nil, want 20")
+	}
+	if got := *stats.MedianCompletionSeconds; got < 19.9 || got > 20.1 {
+		t.Errorf("MedianCompletionSeconds = %v, want ~20", got)
+	}
+}
+
+// TestIntegration_Funnel_MedianEvenCount verifies the even-count case, where
+// a wrong percentile implementation (e.g. plain MEDIAN via a naive middle
+// row pick) tends to show up: 10s and 20s -> 15.
+func TestIntegration_Funnel_MedianEvenCount(t *testing.T) {
+	repo, db := setupFunnelTest(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	seedCompletedSession(t, repo, db, "median-even-1@median.local", now.Add(-1*time.Hour), 10)
+	seedCompletedSession(t, repo, db, "median-even-2@median.local", now.Add(-1*time.Hour), 20)
+
+	stats, err := repo.GetFunnel(ctx, FunnelFilter{
+		CreatedFrom: now.Add(-24 * time.Hour),
+		CreatedTo:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetFunnel: %v", err)
+	}
+	if stats.MedianCompletionSeconds == nil {
+		t.Fatal("MedianCompletionSeconds is nil, want 15")
+	}
+	if got := *stats.MedianCompletionSeconds; got < 14.9 || got > 15.1 {
+		t.Errorf("MedianCompletionSeconds = %v, want ~15", got)
+	}
+}
+
+// TestIntegration_Funnel_MedianZeroCompletions verifies that with no
+// completions in the window the median scans as nil, not 0 — scanning into
+// a plain float64 would silently turn "nothing completed" into "instant
+// completion".
+func TestIntegration_Funnel_MedianZeroCompletions(t *testing.T) {
+	repo, _ := setupFunnelTest(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	seedInFlightOrAbandoned(t, repo, "no-completions@median.local", StatusInProgress, now.Add(-1*time.Hour), now.Add(-1*time.Hour))
+
+	stats, err := repo.GetFunnel(ctx, FunnelFilter{
+		CreatedFrom: now.Add(-24 * time.Hour),
+		CreatedTo:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetFunnel: %v", err)
+	}
+	if stats.MedianCompletionSeconds != nil {
+		t.Errorf("MedianCompletionSeconds = %v, want nil", *stats.MedianCompletionSeconds)
+	}
+}
+
+// TestIntegration_Funnel_WindowExcludesOutsideSessions verifies a session
+// created outside [from, to] appears in neither the counters nor the rows.
+func TestIntegration_Funnel_WindowExcludesOutsideSessions(t *testing.T) {
+	repo, _ := setupFunnelTest(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Inside the window.
+	seedInFlightOrAbandoned(t, repo, "inside-window@window.local", StatusInProgress, now.Add(-10*time.Hour), now.Add(-10*time.Hour))
+	// Outside the window (created well before `from`).
+	seedInFlightOrAbandoned(t, repo, "outside-window@window.local", StatusInProgress, now.Add(-200*time.Hour), now.Add(-200*time.Hour))
+
+	filter := FunnelFilter{
+		CreatedFrom: now.Add(-48 * time.Hour),
+		CreatedTo:   now.Add(time.Hour),
+		Limit:       500,
+	}
+
+	stats, err := repo.GetFunnel(ctx, filter)
+	if err != nil {
+		t.Fatalf("GetFunnel: %v", err)
+	}
+	if stats.Started != 1 {
+		t.Fatalf("Started = %d, want 1 (only the in-window session)", stats.Started)
+	}
+
+	rows, total, err := repo.ListSessions(ctx, filter)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if total != 1 {
+		t.Fatalf("ListSessions total = %d, want 1", total)
+	}
+	for _, r := range rows {
+		if r.Email == "outside-window@window.local" {
+			t.Error("ListSessions returned a session created outside the window")
+		}
+	}
+}
+
+// TestIntegration_Funnel_Last24hIgnoresWindow verifies last_24h is always
+// computed over the trailing 24h regardless of the requested window — with
+// a window entirely in the past, last_24h.started still counts a session
+// created minutes ago.
+func TestIntegration_Funnel_Last24hIgnoresWindow(t *testing.T) {
+	repo, _ := setupFunnelTest(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Created just now — outside a window that's entirely in the past.
+	seedInFlightOrAbandoned(t, repo, "recent@last24h.local", StatusInProgress, now.Add(-5*time.Minute), now.Add(-5*time.Minute))
+	// Also seed a session inside the requested (past) window, to make sure
+	// the two aggregates are actually independent rather than one just
+	// echoing the other.
+	seedInFlightOrAbandoned(t, repo, "in-past-window@last24h.local", StatusInProgress, now.Add(-200*time.Hour), now.Add(-200*time.Hour))
+
+	stats, err := repo.GetFunnel(ctx, FunnelFilter{
+		CreatedFrom: now.Add(-300 * time.Hour),
+		CreatedTo:   now.Add(-100 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetFunnel: %v", err)
+	}
+	if stats.Started != 1 {
+		t.Fatalf("windowed Started = %d, want 1 (only the session inside the requested window)", stats.Started)
+	}
+	if stats.Last24h.Started < 1 {
+		t.Errorf("Last24h.Started = %d, want >= 1 (the session created 5 minutes ago)", stats.Last24h.Started)
+	}
+}
+
+// TestIntegration_Funnel_CompletedNeverAbandoned verifies a completed
+// session is never flagged abandoned, however old and idle its
+// last_activity_at is.
+func TestIntegration_Funnel_CompletedNeverAbandoned(t *testing.T) {
+	repo, db := setupFunnelTest(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	// completed session whose last_activity_at (== completed_at here) is
+	// far in the past — would be "abandoned" by the raw idle check if the
+	// completed-status exclusion weren't applied.
+	seedCompletedSession(t, repo, db, "old-completed@never-abandoned.local", now.Add(-500*time.Hour), 30)
+
+	stats, err := repo.GetFunnel(ctx, FunnelFilter{
+		CreatedFrom: now.Add(-600 * time.Hour),
+		CreatedTo:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetFunnel: %v", err)
+	}
+	if stats.Abandoned != 0 {
+		t.Errorf("Abandoned = %d, want 0 (the only session is completed)", stats.Abandoned)
+	}
+	if stats.Completed != 1 {
+		t.Errorf("Completed = %d, want 1", stats.Completed)
+	}
+
+	rows, _, err := repo.ListSessions(ctx, FunnelFilter{
+		CreatedFrom: now.Add(-600 * time.Hour),
+		CreatedTo:   now.Add(time.Hour),
+		Limit:       10,
+	})
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	for _, r := range rows {
+		if r.Email == "old-completed@never-abandoned.local" && r.Abandoned {
+			t.Error("completed session was flagged abandoned")
+		}
+	}
+}
+
+// TestIntegration_Funnel_AbandonedAfterConstantDrivesQuery proves the SQL
+// predicate is built from the AbandonedAfter constant rather than a second,
+// independently hardcoded interval: a session idle for exactly
+// AbandonedAfter is abandoned, one idle for AbandonedAfter minus a minute
+// is not. If the query hardcoded a different interval than the Go
+// constant, this test would catch the drift without needing to touch the
+// constant itself.
+func TestIntegration_Funnel_AbandonedAfterConstantDrivesQuery(t *testing.T) {
+	repo, _ := setupFunnelTest(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	seedInFlightOrAbandoned(t, repo, "just-under-cutoff@constant.local", StatusInProgress,
+		now.Add(-AbandonedAfter+time.Minute), now.Add(-AbandonedAfter+time.Minute))
+	seedInFlightOrAbandoned(t, repo, "at-cutoff@constant.local", StatusInProgress,
+		now.Add(-AbandonedAfter), now.Add(-AbandonedAfter))
+
+	stats, err := repo.GetFunnel(ctx, FunnelFilter{
+		CreatedFrom: now.Add(-2 * AbandonedAfter),
+		CreatedTo:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetFunnel: %v", err)
+	}
+	if stats.InFlight != 1 {
+		t.Errorf("InFlight = %d, want 1 (just under the AbandonedAfter cutoff)", stats.InFlight)
+	}
+	if stats.Abandoned != 1 {
+		t.Errorf("Abandoned = %d, want 1 (exactly at the AbandonedAfter cutoff)", stats.Abandoned)
+	}
+}

--- a/services/platform-api/internal/onboarding/funnel_integration_test.go
+++ b/services/platform-api/internal/onboarding/funnel_integration_test.go
@@ -77,37 +77,54 @@ func setupFunnelTest(t *testing.T) (Repository, *gorm.DB) {
 }
 
 // TestIntegration_Funnel_BoundaryAbandonment pins the exactly-24h-idle rule:
-// a session idle for 23h is in flight, one idle for exactly 24h or more is
-// abandoned. This is arbitrary but decided, and must not silently drift.
+// a session idle for AbandonedAfter minus a small delta is in flight, one
+// idle for exactly AbandonedAfter is abandoned. This is arbitrary but
+// decided, and must not silently drift.
+//
+// This pins the rule genuinely, not just apparently: FunnelFilter.AsOf
+// freezes the instant the query evaluates "now" against, so the fixture at
+// exactly asOf-AbandonedAfter lands on the true knife-edge in DB time
+// rather than drifting past it during the query round trip (as it would if
+// the fixture were built from Go's now() and the query used Postgres's
+// independently-evaluated now()).
+//
+// Verified by mutation: changing abandonedExpr's <= to < makes this test
+// fail (the at-cutoff session flips to in-flight) — see task-1-report.md.
 func TestIntegration_Funnel_BoundaryAbandonment(t *testing.T) {
 	repo, _ := setupFunnelTest(t)
 	ctx := context.Background()
-	now := time.Now()
+	asOf := time.Now()
 
-	seedInFlightOrAbandoned(t, repo, "in-flight-23h@boundary.local", StatusInProgress, now.Add(-23*time.Hour), now.Add(-23*time.Hour))
-	seedInFlightOrAbandoned(t, repo, "abandoned-24h@boundary.local", StatusInProgress, now.Add(-24*time.Hour), now.Add(-24*time.Hour))
-	seedInFlightOrAbandoned(t, repo, "abandoned-25h@boundary.local", StatusInProgress, now.Add(-25*time.Hour), now.Add(-25*time.Hour))
+	justUnderCutoff := asOf.Add(-AbandonedAfter + time.Minute)
+	atCutoff := asOf.Add(-AbandonedAfter)
 
-	stats, err := repo.GetFunnel(ctx, FunnelFilter{
-		CreatedFrom: now.Add(-48 * time.Hour),
-		CreatedTo:   now.Add(time.Hour),
-	})
+	seedInFlightOrAbandoned(t, repo, "in-flight-just-under@boundary.local", StatusInProgress, justUnderCutoff, justUnderCutoff)
+	seedInFlightOrAbandoned(t, repo, "abandoned-at-cutoff@boundary.local", StatusInProgress, atCutoff, atCutoff)
+
+	filter := FunnelFilter{
+		CreatedFrom: asOf.Add(-48 * time.Hour),
+		CreatedTo:   asOf.Add(time.Hour),
+		AsOf:        asOf,
+	}
+
+	stats, err := repo.GetFunnel(ctx, filter)
 	if err != nil {
 		t.Fatalf("GetFunnel: %v", err)
 	}
-	if stats.Started != 3 {
-		t.Fatalf("Started = %d, want 3", stats.Started)
+	if stats.Started != 2 {
+		t.Fatalf("Started = %d, want 2", stats.Started)
 	}
 	if stats.InFlight != 1 {
-		t.Errorf("InFlight = %d, want 1 (the 23h session)", stats.InFlight)
+		t.Errorf("InFlight = %d, want 1 (idle AbandonedAfter minus a minute)", stats.InFlight)
 	}
-	if stats.Abandoned != 2 {
-		t.Errorf("Abandoned = %d, want 2 (the 24h and 25h sessions)", stats.Abandoned)
+	if stats.Abandoned != 1 {
+		t.Errorf("Abandoned = %d, want 1 (idle exactly AbandonedAfter)", stats.Abandoned)
 	}
 
 	rows, _, err := repo.ListSessions(ctx, FunnelFilter{
-		CreatedFrom: now.Add(-48 * time.Hour),
-		CreatedTo:   now.Add(time.Hour),
+		CreatedFrom: filter.CreatedFrom,
+		CreatedTo:   filter.CreatedTo,
+		AsOf:        asOf,
 		Limit:       10,
 	})
 	if err != nil {
@@ -115,18 +132,18 @@ func TestIntegration_Funnel_BoundaryAbandonment(t *testing.T) {
 	}
 	abandonedCount := 0
 	for _, r := range rows {
-		if r.Email == "abandoned-24h@boundary.local" && !r.Abandoned {
-			t.Errorf("session idle exactly 24h must be flagged abandoned")
+		if r.Email == "abandoned-at-cutoff@boundary.local" && !r.Abandoned {
+			t.Errorf("session idle exactly AbandonedAfter must be flagged abandoned")
 		}
-		if r.Email == "in-flight-23h@boundary.local" && r.Abandoned {
-			t.Errorf("session idle 23h must NOT be flagged abandoned")
+		if r.Email == "in-flight-just-under@boundary.local" && r.Abandoned {
+			t.Errorf("session idle just under AbandonedAfter must NOT be flagged abandoned")
 		}
 		if r.Abandoned {
 			abandonedCount++
 		}
 	}
-	if abandonedCount != 2 {
-		t.Errorf("ListSessions abandoned rows = %d, want 2", abandonedCount)
+	if abandonedCount != 1 {
+		t.Errorf("ListSessions abandoned rows = %d, want 1", abandonedCount)
 	}
 }
 
@@ -400,19 +417,26 @@ func TestIntegration_Funnel_CompletedNeverAbandoned(t *testing.T) {
 // is not. If the query hardcoded a different interval than the Go
 // constant, this test would catch the drift without needing to touch the
 // constant itself.
+//
+// Uses a fixed AsOf for the same reason TestIntegration_Funnel_
+// BoundaryAbandonment does: without pinning the evaluation instant, the
+// "exactly AbandonedAfter" fixture is evaluated against Postgres's own
+// now(), which has already moved past the fixture's timestamp by the time
+// the query runs, so the boundary is never actually exercised.
 func TestIntegration_Funnel_AbandonedAfterConstantDrivesQuery(t *testing.T) {
 	repo, _ := setupFunnelTest(t)
 	ctx := context.Background()
-	now := time.Now()
+	asOf := time.Now()
 
 	seedInFlightOrAbandoned(t, repo, "just-under-cutoff@constant.local", StatusInProgress,
-		now.Add(-AbandonedAfter+time.Minute), now.Add(-AbandonedAfter+time.Minute))
+		asOf.Add(-AbandonedAfter+time.Minute), asOf.Add(-AbandonedAfter+time.Minute))
 	seedInFlightOrAbandoned(t, repo, "at-cutoff@constant.local", StatusInProgress,
-		now.Add(-AbandonedAfter), now.Add(-AbandonedAfter))
+		asOf.Add(-AbandonedAfter), asOf.Add(-AbandonedAfter))
 
 	stats, err := repo.GetFunnel(ctx, FunnelFilter{
-		CreatedFrom: now.Add(-2 * AbandonedAfter),
-		CreatedTo:   now.Add(time.Hour),
+		CreatedFrom: asOf.Add(-2 * AbandonedAfter),
+		CreatedTo:   asOf.Add(time.Hour),
+		AsOf:        asOf,
 	})
 	if err != nil {
 		t.Fatalf("GetFunnel: %v", err)

--- a/services/platform-api/internal/onboarding/handler.go
+++ b/services/platform-api/internal/onboarding/handler.go
@@ -3,6 +3,9 @@ package onboarding
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -141,6 +144,119 @@ func (h *Handler) completeSession(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"data": res})
+}
+
+// RegisterAnalytics mounts the onboarding funnel and sessions analytics
+// routes (#283) onto the supplied group. The CALLER is responsible for
+// gating it — main.go wraps it in middleware.RequireInternalAuthStrict,
+// the same strict guard the tenant directory (#277) uses: both return
+// estate-wide data, so an unconfigured deploy must refuse rather than
+// serve the lot.
+//
+// Deliberately separate from Register: those routes are the public wizard
+// routes on /api/v1 and keep the permissive/no auth branch — mirroring how
+// tenant.RegisterDirectory is kept separate from tenant.Register.
+func (h *Handler) RegisterAnalytics(g *gin.RouterGroup) {
+	o := g.Group("/onboarding")
+	{
+		o.GET("/funnel", h.getFunnel)
+		// Static sibling of Register's /sessions/:id. Verified against
+		// gin 1.12 with the real two-group router shape main.go builds:
+		// no router-build panic, and both routes resolve to their own
+		// handlers (the #287 class of bug — see funnel_handler_test.go).
+		o.GET("/sessions", h.listFunnelSessions)
+	}
+}
+
+// getFunnel serves GET /internal/onboarding/funnel.
+//
+// Response is a single object under "data" — no "pagination" key, since
+// the funnel has no page concept. median_completion_seconds serialises as
+// JSON null (not 0, not omitted) when no session in the window completed;
+// FunnelStats' field has no omitempty for exactly this reason.
+func (h *Handler) getFunnel(c *gin.Context) {
+	f := parseFunnelFilter(c)
+	stats, err := h.svc.GetFunnel(c.Request.Context(), f)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": stats})
+}
+
+// listFunnelSessions serves GET /internal/onboarding/sessions.
+//
+// Standard envelope: data + pagination. Empty result is 200 with data: [],
+// never null. pagination.limit reports the EFFECTIVE (clamped) limit, so
+// total / limit is a correct page count.
+func (h *Handler) listFunnelSessions(c *gin.Context) {
+	f := parseFunnelFilter(c)
+	rows, total, err := h.svc.ListSessions(c.Request.Context(), f)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	if rows == nil {
+		rows = []SessionRow{}
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"data": rows,
+		"pagination": gin.H{
+			"page":  max(f.Page, 1),
+			"limit": f.Limit,
+			"total": total,
+		},
+	})
+}
+
+// parseFunnelFilter never returns an error. A missing or malformed
+// parameter takes the default; an oversized limit clamps here so
+// pagination.limit in the response reflects the effective value used.
+//
+// AsOf is deliberately never parsed from a query parameter — see
+// FunnelFilter.AsOf's doc comment. A console caller able to set it could
+// time-travel the funnel. It is left at its zero value on every path
+// through this function.
+func parseFunnelFilter(c *gin.Context) FunnelFilter {
+	f := FunnelFilter{
+		Status: strings.TrimSpace(c.Query("status")),
+		Page:   1,
+		Limit:  DefaultFunnelPageSize,
+	}
+	if v := strings.TrimSpace(c.Query("page")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			f.Page = n
+		}
+	}
+	if v := strings.TrimSpace(c.Query("limit")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			f.Limit = min(n, MaxFunnelPageSize)
+		}
+	}
+	if t, ok := parseFunnelRFC3339(c.Query("created_from")); ok {
+		f.CreatedFrom = t
+	}
+	if t, ok := parseFunnelRFC3339(c.Query("created_to")); ok {
+		f.CreatedTo = t
+	}
+	if v := strings.TrimSpace(c.Query("abandoned")); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			f.Abandoned = &b
+		}
+	}
+	return f
+}
+
+func parseFunnelRFC3339(v string) (time.Time, bool) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, v)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
 }
 
 func respondError(c *gin.Context, err error) {

--- a/services/platform-api/internal/onboarding/repository.go
+++ b/services/platform-api/internal/onboarding/repository.go
@@ -21,6 +21,12 @@ type Repository interface {
 	// CompleteInTx marks the session completed and links it to a tenant.
 	// Called inside the onboarding completion transaction.
 	CompleteInTx(ctx context.Context, tx *gorm.DB, id, tenantID string) error
+	// GetFunnel returns the onboarding funnel counters for the given
+	// window (see funnel.go).
+	GetFunnel(ctx context.Context, f FunnelFilter) (*FunnelStats, error)
+	// ListSessions returns a page of onboarding sessions for the given
+	// window/filter, plus the unpaginated total (see funnel.go).
+	ListSessions(ctx context.Context, f FunnelFilter) ([]SessionRow, int64, error)
 }
 
 type gormRepository struct {

--- a/services/platform-api/internal/onboarding/service.go
+++ b/services/platform-api/internal/onboarding/service.go
@@ -168,6 +168,19 @@ func (s *Service) Get(ctx context.Context, id string) (*Session, error) {
 	return s.repo.GetByID(ctx, id)
 }
 
+// GetFunnel returns the onboarding funnel counters for the given window
+// (#283). AsOf is deliberately not settable from outside this package —
+// see FunnelFilter's doc comment.
+func (s *Service) GetFunnel(ctx context.Context, f FunnelFilter) (*FunnelStats, error) {
+	return s.repo.GetFunnel(ctx, f)
+}
+
+// ListSessions returns a page of onboarding sessions for the given
+// window/filter, plus the unpaginated total (#283).
+func (s *Service) ListSessions(ctx context.Context, f FunnelFilter) ([]SessionRow, int64, error) {
+	return s.repo.ListSessions(ctx, f)
+}
+
 // SaveDraft replaces the session's draft JSON. The draft is opaque to the
 // backend — the wizard's frontend owns the schema. We only validate that
 // it parses as JSON.


### PR DESCRIPTION
Closes #283. Part of the platform console integration series (#260), after #274, #275, #276, #277, #279.

Unblocks the console's estate-wide onboarding funnel, which sits beside the platform CRM because *lead → onboarding session → tenant* is one pipeline currently split across three places with no endpoint over the middle one.

## The finding that shaped the design

`StatusAbandoned` and `StatusExpired` exist as Go constants and in migration 0004's CHECK constraint, and the onboarding package doc claims sessions transition to them on browser close or via a gc.

**Neither value is ever written, and there is no gc.** In production every session is `in_progress`, `verifying` or `completed`. Querying `status = 'abandoned'` would return zero forever and look like a data problem rather than a code one.

So **abandoned is derived from idle time**: not completed, and `last_activity_at <= now() - 24h`. Filed separately as #322.

The stored `status` and the derived `abandoned` flag ship as **separate fields** rather than overwriting `status` with a synthetic value — so the console can see a row whose stored status is `in_progress` while the flag says abandoned. That keeps the discrepancy visible instead of hiding it.

## Endpoints

`GET /admin/onboarding/funnel` — a single object, no `pagination` key:

```json
{"data": {"started": 412, "email_verified": 301, "completed": 188,
          "in_flight": 34, "abandoned": 190,
          "median_completion_seconds": 743,
          "last_24h": {"started": 12, "completed": 5},
          "window": {"from": "...", "to": "..."}}}
```

`GET /admin/onboarding/sessions` — standard envelope, `[]` when empty, rows carrying status, `idle_hours`, and the `abandoned` flag.

## Invariants, and how they are enforced

- **`completed + in_flight + abandoned == started`**, exactly, for any window. `email_verified` is deliberately *outside* that partition — it is a subset counter cutting across all three, since a verified session may be in any of them.
- **One shared SQL predicate** for abandoned, used by both the aggregate and the row list. Two copies is how counters and rows come to disagree.
- **One instant per row.** `abandoned` and `idle_hours` derive from the same evaluation instant. An earlier revision computed `idle_hours` in marketplace-api's clock while `abandoned` came from Postgres — so a row could contradict itself (`abandoned: true` beside `idle_hours: 23.98`). Fixed by computing it upstream from the same expression.
- **`median_completion_seconds` is `null`** when nothing completed — never `0`, which reads as "instant". Preserved as `*float64` across all three layers.
- **`draft` never reaches the console.** Rows are projected field by field; the client type has no `Draft` field at all.
- **`AsOf` is internal-only** — it exists so tests can pin the evaluation instant, and is not parsable from a query parameter at any layer. A caller able to set it could time-travel the funnel.

## Test plan

- [x] `platform-api` funnel integration suite green with `-p 1` (13 tests)
- [x] `marketplace-api` `platformadmin` + `onboardingfunnel` packages green
- [x] `go build ./...` clean in both services
- [x] Boundary pinned: exactly 24h idle is abandoned, proven by mutation (`<=` → `<` fails the test)
- [x] Shared predicate proven: desyncing the two intervals fails the cross-endpoint agreement test
- [x] `idle_hours`/`abandoned` agreement proven under a fixed `AsOf`
- [x] `last_24h` proven pinned to the shared instant
- [x] Golden fixtures proven two-sided — each fails on a field **rename** and on a field **addition**
- [x] `window` verified by driving the real upstream handler, bounded and unbounded
- [ ] Verify against production after deploy (Kargo-gated; expect 10-20 min)

## Known gap, not introduced here

Neither service's `main.go` wiring is verified by any test — deleting a wiring site breaks nothing. It applies equally to the already-shipped tenant directory, and the honest fix is extracting the wiring into a testable function, which touches shipped code. Filed as #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)