### PR TITLE
feat(platformadmin): GET /admin/kpis with an explicit not-instrumented contract (#282)

### DIFF
--- a/docs/superpowers/plans/2026-08-23-admin-kpis.md
+++ b/docs/superpowers/plans/2026-08-23-admin-kpis.md
@@ -1,0 +1,327 @@
+# Admin KPIs Implementation Plan (#282)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the platform console's product tile headline counters for mark8ly, and a way to say "not instrumented" that cannot be mistaken for zero.
+
+**Architecture:** A key registry in `marketplace-api` drives both the `200` payload and the `501` responses. The handler composes three sources: a new `estatecounts` client to platform-api, the existing `onboardingfunnel` client from #283, and marketplace-api's own subscription repository.
+
+**Tech Stack:** Go 1.26, Gin 1.12, GORM, PostgreSQL 15, testify.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-admin-kpis-design.md` — the binding authority. Read its "The failure this endpoint exists to prevent" and "The key registry" sections before writing any code.
+
+## Global Constraints
+
+- **No key is ever omitted to mean "unavailable", and no unavailable value is ever rendered as `0`.** This is the entire point of the endpoint. The console has rendered em-dashes-that-look-like-zeroes for a year because an existing route falls through to `{}`.
+- Three states must stay distinguishable: instrumented (`200` + value), known-but-uninstrumented (`501`), unknown key (`501`). The last two share a status deliberately; they differ only in message.
+- Every `501` body carries a machine-readable `key` field so the console can mark one tile rather than the whole panel.
+- **`onboarding_in_flight` reuses #283's funnel** — do not recompute it. One definition, one implementation.
+- **`trials_expiring` horizon is a single exported constant.** #285 will reuse it. A second literal `7` anywhere is a defect.
+- **Partial results are forbidden.** If any upstream fails, the whole endpoint returns `503`. Never return the subset that succeeded.
+- Money keys are declared and uninstrumented. Do NOT implement GMV — there is no FX source and currency is per-store and per-order.
+- Envelope is `{"data": {...}}`. Values are integers, never floats or strings.
+- Ids bare, timestamps RFC3339 UTC, no `source` field.
+- Commit messages: single line, conventional-commit prefix, no signature, no `Co-Authored-By` trailer.
+
+## Conventions that differ, and will bite you
+
+- **marketplace-api's `subscription.Repository` is STATELESS.** `NewRepository()` takes no arguments and every method takes `db *gorm.DB` as its first real parameter (see `internal/subscription/repository.go:82`). platform-api's repositories hold their own `db`. Writing `subscription.NewRepository(conn)` will not compile.
+- **`platform-api` tests use the INTERNAL package** (`package tenant`, `package store`). **`marketplace-api` tests use EXTERNAL** (`package foo_test`). Both use `//go:build integration` for DB-backed tests.
+- The subscription `Repository` interface carries an explicit warning that tenant-agnostic lookups must not be exposed through tenant-facing APIs. The new count in Task 3 **is** deliberately estate-wide. It is justified because the platformadmin surface is HMAC-gated and has no tenant context at all — but it must carry its own warning comment saying so, in the same style as `GetByStripeCustomerID`'s. Do not quietly add an unscoped query to that interface without the comment.
+
+## Environment
+
+- **Use the LAN IP, not localhost** — a native Postgres squats on 127.0.0.1:
+  - platform: `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/platform_api?sslmode=disable'`
+  - marketplace: `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'`
+  The committed Makefile says `localhost`, correct everywhere else — **do not change it**.
+- Integration runs need `-p 1 -count=1`. The packages share one local Postgres; parallel execution exhausts its connection limit (`FATAL: sorry, too many clients already`) and looks like data pollution.
+- **platform-api seeds its own reference data.** `stores` FKs to `countries`, `currencies`, `timezones`; `GB`/`GBP`/`Europe/London` are in the seed, `IE`/`Europe/Dublin` are not. Do not copy fixture values from marketplace-api.
+- Do NOT run `make dev` — the migrate containers are broken here.
+- Never run anything against a remote or GKE database. The only cluster that exists is production.
+- Ignore `go.work requires go >= 1.26.6 (running go 1.26.5)` from vet/LSP — pre-existing drift.
+- `TestIntegration_Complete_TenantAndOutboxCommitAtomically` in platform-api's onboarding package fails with a nil-storeRepo panic. Pre-existing and unrelated; scope runs with `-run` to avoid it.
+
+## File Structure
+
+**`platform-api`**
+
+| File | Responsibility |
+|---|---|
+| `internal/estate/counts.go` (create) | `Counts` type and the two count queries |
+| `internal/estate/handler.go` (create) | `GET /internal/estate/counts` |
+| `internal/estate/counts_integration_test.go` (create) | Status filtering, empty estate |
+| `internal/estate/handler_test.go` (create) | Envelope, error mapping |
+| `cmd/server/main.go` (modify) | Mount on the strict group |
+
+**`marketplace-api`**
+
+| File | Responsibility |
+|---|---|
+| `internal/estatecounts/client.go` (create) | Client + `ErrUnavailable` |
+| `internal/estatecounts/client_test.go` (create) | Parsing, 5xx, transport failure |
+| `internal/subscription/repository.go` (modify) | `CountTrialsExpiring` + the horizon constant |
+| `internal/subscription/repository_kpi_integration_test.go` (create) | Horizon boundary, status filtering |
+| `internal/handlers/platformadmin/kpis.go` (create) | Registry, handler, wire shape |
+| `internal/handlers/platformadmin/kpis_test.go` (create) | Registry-driven tests, 501s, 503 |
+| `internal/handlers/platformadmin/testdata/kpis_response.json` (create) | Golden fixture |
+| `internal/handlers/platformadmin/routes.go` (modify) | Two new `Deps` fields, mount |
+| `cmd/marketplace-api/main.go` (modify) | Wire at BOTH sites |
+
+---
+
+### Task 1: platform-api — estate counts
+
+**Files:** `internal/estate/counts.go`, `internal/estate/handler.go`, `internal/estate/counts_integration_test.go`, `internal/estate/handler_test.go`, `cmd/server/main.go`
+
+**Interfaces:**
+- Produces: `estate.Counts{TenantsActive int64; StoresActive int64}`, `estate.NewRepository(db *gorm.DB) Repository` with `Get(ctx) (*Counts, error)`, `estate.NewHandler(repo Repository) *Handler` with `Register(g *gin.RouterGroup)` mounting `GET /estate/counts`.
+
+A new small package rather than bolting onto `tenant` or `store`: it spans both, and neither owns it.
+
+```go
+// Package estate serves platform-wide counts for the Tesserix console's
+// product tile (#282). It reads across tenants and stores, which is why it
+// is its own package rather than living in either.
+package estate
+
+// Counts is the estate-wide headline count set.
+type Counts struct {
+	TenantsActive int64 `json:"tenants_active"`
+	StoresActive  int64 `json:"stores_active"`
+}
+```
+
+The repository runs two counts:
+
+```go
+func (r *gormRepository) Get(ctx context.Context) (*Counts, error) {
+	var c Counts
+	if err := r.db.WithContext(ctx).Table("tenants").
+		Where("status = ?", tenant.StatusActive).
+		Count(&c.TenantsActive).Error; err != nil {
+		return nil, fmt.Errorf("estate: count active tenants: %w", err)
+	}
+	if err := r.db.WithContext(ctx).Table("stores").
+		Where("status = ?", store.StatusActive).
+		Count(&c.StoresActive).Error; err != nil {
+		return nil, fmt.Errorf("estate: count active stores: %w", err)
+	}
+	return &c, nil
+}
+```
+
+Use the existing `tenant.StatusActive` and `store.StatusActive` constants — do not write `"active"` as a literal. Check both exist and are exported before writing this (they are, at `internal/tenant/models.go` and `internal/store/models.go`).
+
+Handler:
+
+```go
+func (h *Handler) Register(g *gin.RouterGroup) {
+	g.GET("/estate/counts", h.get)
+}
+
+func (h *Handler) get(c *gin.Context) {
+	counts, err := h.repo.Get(c.Request.Context())
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": counts})
+}
+```
+
+`respondError` is package-local here — check how `internal/tenant/handler.go` maps errors and mirror it rather than inventing a second convention. If that helper is not exported from a shared place, write a minimal local equivalent.
+
+In `cmd/server/main.go`, mount on the **strict** group (the `strictInternal` variable that #283 renamed), alongside the tenant directory and onboarding analytics. Extend the comment above that group to mention estate counts. These are estate-wide reads: an unconfigured deploy must refuse, not serve them.
+
+**Tests** (`counts_integration_test.go`, `package estate`, `//go:build integration`):
+
+- [ ] Counts only `active` tenants: seed one `active` and one `suspended`, assert `TenantsActive == 1`.
+- [ ] Counts only `active` stores: same shape.
+- [ ] An empty estate returns zeros and **no error** — zero is a real answer here, distinct from the endpoint being unavailable.
+- [ ] Tenants and stores are counted independently: a tenant with two stores yields `TenantsActive=1, StoresActive=2`.
+
+Seed stores with `GB`/`GBP`/`Europe/London` — those are in platform-api's reference seed. `IE`/`Europe/Dublin` are not and will fail the FK.
+
+**Tests** (`handler_test.go`): envelope is `{"data":{...}}` with both keys present; a repository error maps to the package's error convention, not a bare 500 string.
+
+**Verify:** `cd services/platform-api && TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/platform_api?sslmode=disable' go test -tags=integration -p 1 -count=1 ./internal/estate/... && go build ./...`
+
+**Commit:** `feat(estate): platform-wide tenant and store counts (#282)`
+
+---
+
+### Task 2: marketplace-api — the estate counts client
+
+**Files:** `internal/estatecounts/client.go`, `internal/estatecounts/client_test.go`
+
+**Interfaces:**
+- Consumes: platform-api `GET /internal/estate/counts` → `{"data":{"tenants_active":N,"stores_active":N}}`.
+- Produces: `estatecounts.NewClient(baseURL, secret string, httpClient *http.Client) *Client` with `Get(ctx) (*Counts, error)`; `estatecounts.Counts{TenantsActive, StoresActive int64}`; `estatecounts.ErrUnavailable`.
+
+Model this on `internal/tenantdirectory/client.go` — read it first. Same `do` helper shape, same `maxBody` cap, same `X-Internal-Auth` header, same `ErrUnavailable` doc-comment reasoning.
+
+No `ErrNotFound`: this endpoint does not 404. Do not add a sentinel for an impossible case.
+
+**Tests** (`package estatecounts_test`):
+
+- [ ] Sends `X-Internal-Auth` and requests exactly `/internal/estate/counts` — assert on `r.URL.Path`, not merely that a request arrived.
+- [ ] Parses the envelope into `Counts`.
+- [ ] Upstream 5xx → `ErrUnavailable`.
+- [ ] Transport failure (closed server) → `ErrUnavailable`.
+- [ ] A `200` with `{"data":{}}` yields zeros and no error — an empty estate is a real answer.
+
+**Verify:** `cd services/marketplace-api && go test ./internal/estatecounts/...`
+
+**Commit:** `feat(estatecounts): client for platform-wide estate counts (#282)`
+
+---
+
+### Task 3: marketplace-api — the expiring-trials count
+
+**Files:** `internal/subscription/repository.go`, `internal/subscription/repository_kpi_integration_test.go`
+
+**Interfaces:**
+- Produces: `subscription.TrialExpiryHorizon` (a `time.Duration` constant) and `Repository.CountTrialsExpiring(ctx context.Context, db *gorm.DB, asOf time.Time) (int64, error)`.
+
+Add the constant near the status constants:
+
+```go
+// TrialExpiryHorizon is how far ahead a trial counts as "expiring" for the
+// platform console's KPI tile (#282).
+//
+// SHARED, deliberately: #285 (GET /admin/billing/trials) needs the same
+// notion of "expiring". If it declares its own, the console shows two
+// different numbers for the same word on two screens. Reuse this constant.
+const TrialExpiryHorizon = 7 * 24 * time.Hour
+```
+
+Add to the `Repository` interface, with a warning comment in the same style as `GetByStripeCustomerID`'s:
+
+```go
+	// CountTrialsExpiring counts trialing subscriptions whose current period
+	// ends within TrialExpiryHorizon of asOf.
+	//
+	// ESTATE-WIDE, deliberately unscoped by tenant: this serves the platform
+	// console's KPI tile, which is HMAC-gated on the platformadmin surface and
+	// has no tenant context at all. DO NOT call it from any tenant-facing
+	// handler — those must stay tenant-scoped like GetByStoreID.
+	//
+	// asOf is a parameter rather than now() so a test can pin the window
+	// boundary exactly; production passes time.Now().
+	CountTrialsExpiring(ctx context.Context, db *gorm.DB, asOf time.Time) (int64, error)
+```
+
+Implementation — note the receiver style is `(gormRepository)`, matching its neighbours, and the repository is **stateless**, so `db` comes from the parameter:
+
+```go
+func (gormRepository) CountTrialsExpiring(ctx context.Context, db *gorm.DB, asOf time.Time) (int64, error) {
+	var n int64
+	err := db.WithContext(ctx).Model(&StoreSubscription{}).
+		Where("status = ?", StatusTrialing).
+		Where("current_period_end IS NOT NULL").
+		Where("current_period_end > ?", asOf).
+		Where("current_period_end <= ?", asOf.Add(TrialExpiryHorizon)).
+		Count(&n).Error
+	if err != nil {
+		return 0, fmt.Errorf("subscription: count trials expiring: %w", err)
+	}
+	return n, nil
+}
+```
+
+The window is half-open on the left (`> asOf`) so an **already-expired** trial does not count as "expiring", and inclusive on the right so a trial ending exactly at the horizon does. State that in the doc comment; a reviewer will otherwise have to guess which side is which.
+
+**Tests** (`repository_kpi_integration_test.go`, `package subscription_test`, `//go:build integration`). Seed relative to a fixed `asOf`:
+
+- [ ] A trial ending in 3 days counts.
+- [ ] A trial ending in 10 days does **not** count (outside the horizon).
+- [ ] A trial ending exactly at `asOf + TrialExpiryHorizon` **does** count (inclusive right edge).
+- [ ] A trial that already ended (`current_period_end` before `asOf`) does **not** count.
+- [ ] A subscription with `status = 'active'` ending in 3 days does **not** count — only `trialing`.
+- [ ] A trialing subscription with `current_period_end IS NULL` does not count and does not error.
+- [ ] Counts across tenants: two trialing subscriptions under different `tenant_id`s both count. This is the estate-wide behaviour, asserted rather than assumed.
+
+**Verify:** `cd services/marketplace-api && TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' go test -tags=integration -p 1 -count=1 ./internal/subscription/...`
+
+**Commit:** `feat(subscription): count expiring trials for the KPI tile (#282)`
+
+---
+
+### Task 4: marketplace-api — the registry and the endpoint
+
+**Files:** `internal/handlers/platformadmin/kpis.go`, `kpis_test.go`, `testdata/kpis_response.json`, `routes.go`, `cmd/marketplace-api/main.go`
+
+**Interfaces:**
+- Consumes: `estatecounts.Client.Get`, `onboardingfunnel.Client.GetFunnel` (existing, from #283 — its `FunnelStats.InFlight` is the value), `subscription.Repository.CountTrialsExpiring`.
+
+The registry is the heart of this task:
+
+```go
+// kpiKey is one metric the console may ask for.
+type kpiKey struct {
+	Name         string
+	Instrumented bool
+}
+
+// kpiRegistry declares EVERY key mark8ly knows. Both the 200 payload and the
+// 501 responses are driven from here rather than from conditionals in the
+// handler, so a key cannot be silently dropped.
+//
+// An uninstrumented key is NOT omitted and NOT zero — the console has
+// rendered em-dashes that look like zeroes for a year because a sibling
+// route falls through to {}. See the spec.
+var kpiRegistry = []kpiKey{
+	{Name: "tenants_active", Instrumented: true},
+	{Name: "stores_active", Instrumented: true},
+	{Name: "onboarding_in_flight", Instrumented: true},
+	{Name: "trials_expiring", Instrumented: true},
+	// GMV is genuinely not computable: currency is per store and per order,
+	// and there is no FX source anywhere in the workspace. 501 is the honest
+	// answer; 0 would be a lie and omitting it would be ambiguous.
+	{Name: "gmv_today", Instrumented: false},
+	{Name: "gmv_month", Instrumented: false},
+}
+```
+
+Handler behaviour:
+
+- [ ] Parse `?keys=` as a comma-separated list, trimming each. Empty or absent means "all instrumented keys".
+- [ ] For each requested key, resolve it against the registry and respond `501` immediately — do not accumulate partial results first. The two cases share the status and the `key` field but differ in `message`, because the console cannot act differently on them while a human reading logs can:
+  - **in the registry, `Instrumented: false`** → `{"error":"not_implemented","message":"kpi \"<key>\" is known but not instrumented","key":"<key>"}`
+  - **not in the registry at all** → `{"error":"not_implemented","message":"kpi \"<key>\" is not a recognised key","key":"<key>"}`
+- [ ] Otherwise gather values from the three sources.
+- [ ] **Any** upstream error → `503 upstream_unavailable`. Never a partial object. `ErrUnavailable` from either client, and any repository error, all take this path.
+- [ ] Respond `200 {"data": {...}}` with integer values.
+
+Add **two** fields to `platformadmin.Deps` (`EstateCounts` and `Subscriptions`) plus reuse of the existing `OnboardingFunnel` field from #283. Mount only when all three are non-nil, mirroring the existing nil-guard pattern.
+
+Wire in `cmd/marketplace-api/main.go` at **BOTH** sites (~1917 and ~2003), guarded by `cfg.PlatformAPIURL != ""` exactly as the existing clients are. There are two because production runs two deployments from this binary (`marketplace-api-admin` and `marketplace-api-storefront`); missing one makes the endpoint 404 depending on which served the request.
+
+**Tests** (`package platformadmin_test`):
+
+- [ ] **Registry-driven completeness:** iterate `kpiRegistry`; every instrumented key appears in the `200` payload, and every uninstrumented key returns `501` when requested by name. Written as a loop over the registry, so adding a key without handling it fails the test.
+- [ ] An unknown key (`?keys=not_a_real_kpi`) returns `501`, the body's `key` field names it, and the message says **not a recognised key**.
+- [ ] A known-uninstrumented key (`?keys=gmv_today`) returns `501`, names it, and the message says **known but not instrumented**. Assert the two messages differ — they are the only thing distinguishing the cases.
+- [ ] `?keys=tenants_active,gmv_today` returns `501` — **not** a partial `200` with just `tenants_active`. Assert the body has no `data` key at all.
+- [ ] **Anti-drift:** `onboarding_in_flight` equals the `InFlight` the funnel stub reports. Use one stub value and assert both, so a future handler that recomputes rather than reuses fails.
+- [ ] An `ErrUnavailable` from the estate client → `503`, and assert the raw body contains **none** of the counter key names. A partial object is the failure mode this asserts against.
+- [ ] The same for an `ErrUnavailable` from the funnel client, and for a subscription repository error.
+- [ ] Every value in the `200` payload decodes as an integer — assert on raw JSON so a float `4.0` or a string `"4"` fails.
+- [ ] Golden fixture via `require.JSONEq` against `testdata/kpis_response.json`. **Prove it by mutation:** rename a JSON key and confirm failure; add a field to the response struct and confirm failure. Revert both and report both results.
+
+**Verify:** `cd services/marketplace-api && go test ./internal/handlers/platformadmin/... ./internal/estatecounts/... && go build ./...`
+
+**Commit:** `feat(platformadmin): GET /admin/kpis with an explicit not-instrumented contract (#282)`
+
+---
+
+## After the plan
+
+- [ ] `go build ./...` clean in both services.
+- [ ] Full unit suites green in every touched package.
+- [ ] Integration suites green in `platform-api/internal/estate` and `marketplace-api/internal/subscription` with `-p 1`.
+- [ ] Confirm `TrialExpiryHorizon` is the only place `7` appears for this purpose — `grep` for a stray literal.
+- [ ] Confirm no code path can return a partial KPI object: every error branch ends in `501` or `503`.
+- [ ] Comment on #282 with the delivered keys, the `501` contract, and the reason GMV ships uninstrumented — so the console can wire its registry against the real shape.
+- [ ] Note on #285 that `TrialExpiryHorizon` exists and must be reused rather than redeclared.

--- a/docs/superpowers/specs/2026-08-23-admin-kpis-design.md
+++ b/docs/superpowers/specs/2026-08-23-admin-kpis-design.md
@@ -1,0 +1,131 @@
+# Admin KPIs — Design
+
+**Issue:** #282. Part of the platform console integration series (#260), after #274, #275, #276, #277, #279, #283.
+
+**Goal:** Give the console's product tile a set of headline counters for mark8ly, and — just as importantly — a way to say "this metric is not instrumented" that cannot be mistaken for zero.
+
+## The failure this endpoint exists to prevent
+
+The console's existing KPI route falls through to an empty object for products it does not recognise. One product has therefore rendered four em-dashes since launch: **dashes that look like zeroes**.
+
+"Not instrumented" and "zero" are different answers. A tile showing `0` active tenants is an emergency; a tile showing "not instrumented" is a backlog item. Collapsing them costs someone an afternoon.
+
+So: **no key is ever omitted to mean "unavailable", and no unavailable value is ever rendered as `0`.**
+
+## The key registry
+
+Every key mark8ly knows is declared in one place, each marked instrumented or not. Both the `200` payload and the `501` responses are driven by that declaration rather than by conditionals scattered through a handler.
+
+This makes three states distinguishable, which is the whole point:
+
+| state | response |
+|---|---|
+| known and instrumented | `200`, the value |
+| known, not instrumented | `501 not_implemented`, naming the key |
+| not a key mark8ly knows | `501 not_implemented`, naming the key |
+
+The last two share a status deliberately — the console cannot act differently on them, and distinguishing them would leak our roadmap into an error code. They differ in the message, which is for a human reading logs.
+
+## v1 keys
+
+All counters. Money keys are declared but uninstrumented (see below).
+
+```json
+{ "data": {
+    "tenants_active": 4,
+    "stores_active": 5,
+    "onboarding_in_flight": 0,
+    "trials_expiring": 2
+} }
+```
+
+| key | definition | source |
+|---|---|---|
+| `tenants_active` | `tenants.status = 'active'` | platform-api |
+| `stores_active` | `stores.status = 'active'` | platform-api |
+| `onboarding_in_flight` | not completed, idle **less than 24h** — #283's exact definition | platform-api onboarding funnel |
+| `trials_expiring` | `subscriptions.status = 'trialing'` and `current_period_end` within **7 days** | marketplace-api |
+
+**`onboarding_in_flight` reuses #283's funnel rather than recomputing.** One definition, one implementation — otherwise the KPI tile and the funnel screen can show different numbers for the same word, which is the same class of bug as counters disagreeing with rows inside #283.
+
+**`trials_expiring` is per store, not per tenant.** `subscriptions.store_id` is unique; a tenant with three stores can have three trials. The key counts subscriptions, and its name says `trials`, not `tenants_on_trial`.
+
+### The 7-day horizon is shared, not local
+
+**#285** (`GET /admin/billing/trials — expiring, with dunning state`) will need its own notion of "expiring". If it picks a different horizon, the console shows two different numbers for the same word on two screens.
+
+The horizon lives in one exported constant in the subscription package. #285 must reuse it rather than declare its own.
+
+## Money: pinned now, instrumented later
+
+`gmv_today` and `gmv_month` are **declared in the registry and marked uninstrumented**. Requesting either returns `501`.
+
+That is not a placeholder — it is the honest answer. GMV across the estate is not computable today:
+
+- Currency is per store (`stores.currency_code`) and per order (`orders.currency_code`), so a cross-tenant sum spans however many currencies the estate uses.
+- **There is no FX rate source anywhere in the workspace.** Summing INR and GBP into one number would be arithmetic on incompatible units.
+
+Returning `0`, or omitting the key, would both be worse than `501` — the first is a lie and the second is ambiguous.
+
+**The money contract is still pinned here**, so the first implementation cannot invent a third convention:
+
+```json
+{ "gmv_today": { "amount": 984200, "currency": "INR" } }
+```
+
+Integer **minor units**, explicit currency, never a bare number.
+
+Note for whoever instruments it: `orders.grand_total` is `numeric(12,2)` — **major** units. Conversion is required, and multiplying by 100 is correct only for 2-decimal currencies. Read the currency's exponent rather than assuming.
+
+## API
+
+`GET /admin/kpis` — all instrumented keys.
+
+`GET /admin/kpis?keys=tenants_active,gmv_today` — the named subset. If **any** named key is uninstrumented or unknown, the response is `501` naming that key. A caller asking a definite question gets a definite answer rather than a quietly shorter object.
+
+```json
+{ "error": "not_implemented",
+  "message": "kpi \"gmv_today\" is not instrumented",
+  "key": "gmv_today" }
+```
+
+The `key` field is machine-readable so the console can mark exactly one tile rather than the whole panel.
+
+With no `keys` parameter, uninstrumented keys are simply absent — the console's registry knows what it expected, and `?keys=` is how it turns absence into a definite answer. This is the one place absence is acceptable, because the caller did not ask about a specific key.
+
+## Failure is not zero
+
+If platform-api is unreachable, `GET /admin/kpis` returns **`503`** for the whole request. It does **not** return the subset it managed to reach.
+
+A partial object is indistinguishable from a complete one, so a missing counter would read as absent-therefore-uninstrumented, or worse be rendered as `0`. That is precisely the em-dashes failure. One unreachable dependency makes the whole answer untrustworthy, and the endpoint says so.
+
+A non-404 4xx from platform-api becomes `500` — that means our configuration is broken, and retrying never helps.
+
+## Architecture
+
+Same path as the three endpoints before it.
+
+| Layer | Responsibility |
+|---|---|
+| `platform-api` repository + internal endpoint | `GET /internal/estate/counts` → `{tenants_active, stores_active}`, on the **strict** auth group (estate-wide data, so an unconfigured deploy must refuse) |
+| `marketplace-api` client | A new `estatecounts` client, modelled on `tenantdirectory` |
+| `marketplace-api` subscription repository | The `trials_expiring` count |
+| `marketplace-api` handler | The registry, the composition, the wire shape |
+
+The handler composes three sources: the new estate-counts client, the existing `onboardingfunnel` client (for `in_flight`), and its own subscription repository.
+
+## Testing
+
+- Registry-driven: every key in the registry either returns a value or `501`; no key can be silently dropped by adding one to the registry and forgetting the handler.
+- An unknown key and a known-uninstrumented key both `501`, and the response names the key.
+- `?keys=` with a mix of instrumented and uninstrumented returns `501`, not a partial `200`.
+- **`onboarding_in_flight` equals what the funnel endpoint reports** for the same instant — the anti-drift assertion.
+- An unreachable platform-api yields `503` and **never** a partial object. Assert on the raw body that no counter keys are present.
+- Every instrumented value is an integer, never a float or a string.
+- Golden fixture proven by mutation against a field rename and a field addition.
+
+## Out of scope
+
+- Instrumenting GMV. Needs a reporting currency or an FX source; neither exists. The registry entry and the money contract are the deliverable here.
+- Caching. The counters are cheap and the tile is not hot. Adding a cache would introduce a staleness question nobody has asked.
+- Per-tenant KPIs. This is the estate-wide product tile.

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -67,6 +67,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/domain"
 	"github.com/mark8ly/marketplace-api/internal/email"
 	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+	"github.com/mark8ly/marketplace-api/internal/estatecounts"
 	"github.com/mark8ly/marketplace-api/internal/giftcard"
 	"github.com/mark8ly/marketplace-api/internal/gipkey"
 	"github.com/mark8ly/marketplace-api/internal/gipuser"
@@ -1917,10 +1918,13 @@ func main() {
 		admin.RegisterAdminMobile(r.Group("/api/v1"), mobileDeps)
 		var tenantDirectoryClient platformadmin.TenantDirectory
 		var onboardingFunnelClient platformadmin.OnboardingFunnel
+		var estateCountsClient platformadmin.EstateCounts
 		if cfg.PlatformAPIURL != "" {
 			tenantDirectoryClient = tenantdirectory.NewClient(
 				cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 			onboardingFunnelClient = onboardingfunnel.NewClient(
+				cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
+			estateCountsClient = estatecounts.NewClient(
 				cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 		}
 		platformadmin.Register(r.Group("/api/v1/platform"), platformadmin.Deps{
@@ -1930,6 +1934,8 @@ func main() {
 			Secret:           cfg.PlatformAdminSecret,
 			TenantDirectory:  tenantDirectoryClient,
 			OnboardingFunnel: onboardingFunnelClient,
+			EstateCounts:     estateCountsClient,
+			Subscriptions:    subscription.NewRepository(),
 		})
 		storefront.RegisterStorefront(r.Group("/api/v1"), storefrontDeps)
 		storefront.RegisterMobileStorefrontSupport(r.Group("/api/v1"), storefrontSupportHandler, storefrontDeps.SlugCache, storefrontCustomerVerifier)
@@ -2007,10 +2013,13 @@ func main() {
 			admin.RegisterAdminMobile(engine.Group("/api/v1"), mobileDeps)
 			var tenantDirectoryClient platformadmin.TenantDirectory
 			var onboardingFunnelClient platformadmin.OnboardingFunnel
+			var estateCountsClient platformadmin.EstateCounts
 			if cfg.PlatformAPIURL != "" {
 				tenantDirectoryClient = tenantdirectory.NewClient(
 					cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 				onboardingFunnelClient = onboardingfunnel.NewClient(
+					cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
+				estateCountsClient = estatecounts.NewClient(
 					cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 			}
 			platformadmin.Register(engine.Group("/api/v1/platform"), platformadmin.Deps{
@@ -2020,6 +2029,8 @@ func main() {
 				Secret:           cfg.PlatformAdminSecret,
 				TenantDirectory:  tenantDirectoryClient,
 				OnboardingFunnel: onboardingFunnelClient,
+				EstateCounts:     estateCountsClient,
+				Subscriptions:    subscription.NewRepository(),
 			})
 			// Public Delhivery webhook receiver. Mounted on the admin
 			// engine because the merchant-configured URL points at the

--- a/services/marketplace-api/internal/estatecounts/client.go
+++ b/services/marketplace-api/internal/estatecounts/client.go
@@ -1,0 +1,88 @@
+// Package estatecounts is a marketplace-api client for platform-api's
+// internal platform-wide estate counts endpoint (#282).
+package estatecounts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ErrUnavailable signals platform-api could not be reached, or answered 5xx.
+// Callers MUST NOT treat this as an empty result: an empty estate and an
+// unreachable one are different answers, and conflating them shows a console
+// operator "0 active tenants" when the truth is "we could not ask" — a KPI
+// tile must never render an outage as if it were an emergency.
+var ErrUnavailable = errors.New("estatecounts: platform-api unavailable")
+
+// maxBody caps what we will read from platform-api.
+const maxBody = 4 << 20
+
+// Counts is the platform-wide estate rollup.
+type Counts struct {
+	TenantsActive int64 `json:"tenants_active"`
+	StoresActive  int64 `json:"stores_active"`
+}
+
+// Client calls platform-api's internal estate-counts endpoint.
+type Client struct {
+	baseURL string
+	secret  string
+	http    *http.Client
+}
+
+// NewClient constructs a Client. httpClient may be nil (defaults to a
+// 5-second timeout). The secret is sent as X-Internal-Auth when non-empty.
+func NewClient(baseURL, secret string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 5 * time.Second}
+	}
+	return &Client{baseURL: baseURL, secret: secret, http: httpClient}
+}
+
+func (c *Client) do(ctx context.Context, path string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("estatecounts: build request: %w", err)
+	}
+	if c.secret != "" {
+		req.Header.Set("X-Internal-Auth", c.secret)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrUnavailable, err)
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode >= 500:
+		return fmt.Errorf("%w: upstream %d", ErrUnavailable, resp.StatusCode)
+	case resp.StatusCode != http.StatusOK:
+		return fmt.Errorf("estatecounts: platform-api %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBody))
+	if err != nil {
+		return fmt.Errorf("%w: read body: %v", ErrUnavailable, err)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("estatecounts: decode: %w", err)
+	}
+	return nil
+}
+
+// Get fetches the platform-wide estate counts.
+func (c *Client) Get(ctx context.Context) (*Counts, error) {
+	var envelope struct {
+		Data Counts `json:"data"`
+	}
+	if err := c.do(ctx, "/internal/estate/counts", &envelope); err != nil {
+		return nil, err
+	}
+	return &envelope.Data, nil
+}

--- a/services/marketplace-api/internal/estatecounts/client_test.go
+++ b/services/marketplace-api/internal/estatecounts/client_test.go
@@ -1,0 +1,100 @@
+package estatecounts_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/estatecounts"
+)
+
+func TestGet_SendsAuthHeaderAndPath(t *testing.T) {
+	var gotPath, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("X-Internal-Auth")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"tenants_active":4,"stores_active":5}}`))
+	}))
+	defer srv.Close()
+
+	c := estatecounts.NewClient(srv.URL, "secret-token", nil)
+	_, err := c.Get(t.Context())
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	if gotPath != "/internal/estate/counts" {
+		t.Errorf("path = %q, want %q", gotPath, "/internal/estate/counts")
+	}
+	if gotAuth != "secret-token" {
+		t.Errorf("X-Internal-Auth = %q, want %q", gotAuth, "secret-token")
+	}
+}
+
+func TestGet_ParsesEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"tenants_active":4,"stores_active":5}}`))
+	}))
+	defer srv.Close()
+
+	c := estatecounts.NewClient(srv.URL, "secret", nil)
+	got, err := c.Get(t.Context())
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	want := &estatecounts.Counts{TenantsActive: 4, StoresActive: 5}
+	if *got != *want {
+		t.Errorf("Get() = %+v, want %+v", got, want)
+	}
+}
+
+func TestGet_UpstreamServerError_ReturnsErrUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := estatecounts.NewClient(srv.URL, "secret", nil)
+	got, err := c.Get(t.Context())
+	if !errors.Is(err, estatecounts.ErrUnavailable) {
+		t.Fatalf("Get() error = %v, want ErrUnavailable", err)
+	}
+	if got != nil {
+		t.Errorf("Get() result = %+v, want nil on error", got)
+	}
+}
+
+func TestGet_TransportFailure_ReturnsErrUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	baseURL := srv.URL
+	srv.Close() // closed server: connection refused
+
+	c := estatecounts.NewClient(baseURL, "secret", nil)
+	got, err := c.Get(t.Context())
+	if !errors.Is(err, estatecounts.ErrUnavailable) {
+		t.Fatalf("Get() error = %v, want ErrUnavailable", err)
+	}
+	if got != nil {
+		t.Errorf("Get() result = %+v, want nil on error", got)
+	}
+}
+
+func TestGet_EmptyEstate_YieldsZerosNoError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+
+	c := estatecounts.NewClient(srv.URL, "secret", nil)
+	got, err := c.Get(t.Context())
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	want := &estatecounts.Counts{TenantsActive: 0, StoresActive: 0}
+	if *got != *want {
+		t.Errorf("Get() = %+v, want %+v", got, want)
+	}
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/kpis.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/kpis.go
@@ -2,6 +2,7 @@ package platformadmin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -74,7 +75,12 @@ func defaultKPIKeys() []string {
 }
 
 // parseKPIKeys parses ?keys= as a comma-separated list, trimming each.
-// Empty or absent means "all instrumented keys".
+// Empty or absent means "all instrumented keys". Empty segments produced by
+// stray commas (e.g. "?keys=,," or "?keys=a,,b") are dropped rather than
+// looked up — an empty string is never a valid registry key, so keeping it
+// would only ever 501 with a useless empty key name. If dropping empty
+// segments leaves nothing (e.g. "?keys=,,"), that is treated the same as an
+// absent or empty "keys" param: "all instrumented keys".
 func parseKPIKeys(raw string) []string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -149,19 +155,19 @@ func (h *KPIsHandler) kpis(c *gin.Context) {
 
 	counts, err := h.estate.Get(ctx)
 	if err != nil {
-		h.respondUnavailable(c, "estatecounts", err)
+		h.respondErr(c, "estatecounts", err)
 		return
 	}
 
 	funnelStats, err := h.funnel.GetFunnel(ctx, onboardingfunnel.FunnelParams{})
 	if err != nil {
-		h.respondUnavailable(c, "onboardingfunnel", err)
+		h.respondErr(c, "onboardingfunnel", err)
 		return
 	}
 
 	trialsExpiring, err := h.subs.CountTrialsExpiring(ctx, h.db, h.now())
 	if err != nil {
-		h.respondUnavailable(c, "subscription", err)
+		h.respondErr(c, "subscription", err)
 		return
 	}
 
@@ -174,22 +180,61 @@ func (h *KPIsHandler) kpis(c *gin.Context) {
 
 	data := gin.H{}
 	for _, name := range keys {
-		data[name] = values[name]
+		v, ok := values[name]
+		if !ok {
+			// This means the registry lists `name` as Instrumented but the
+			// gather stage above never populated a value for it — a
+			// programming error (a handler left unwired after a registry
+			// change), not a runtime condition like an unreachable
+			// upstream. Silently falling back to Go's zero value here is
+			// exactly the fabricated-KPI failure mode this endpoint exists
+			// to prevent, so we fail loudly instead of emitting a lying 0.
+			if h.logger != nil {
+				h.logger.Error("kpis registry/values mismatch: instrumented key has no gathered value", "key", name)
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error":   "internal_error",
+				"message": fmt.Sprintf("kpi %q is registered as instrumented but has no gathered value", name),
+				"key":     name,
+			})
+			return
+		}
+		data[name] = v
 	}
 
 	c.JSON(http.StatusOK, gin.H{"data": data})
 }
 
-// respondUnavailable answers 503 upstream_unavailable. This is the ONLY
-// error path for the gather stage: an estatecounts/onboardingfunnel
-// ErrUnavailable and a bare subscription-repository error are all treated
-// identically, because a partial KPI object is indistinguishable from a
-// complete one — the very failure mode this endpoint exists to close.
-func (h *KPIsHandler) respondUnavailable(c *gin.Context, source string, err error) {
-	if h.logger != nil {
-		h.logger.Error("kpis upstream unavailable", "source", source, "err", err)
+// respondErr maps a gather-stage error to the surface's stable codes,
+// mirroring respondErr in entities_tenants.go so this surface stays
+// internally consistent.
+//
+// estatecounts.ErrUnavailable / onboardingfunnel.ErrUnavailable (transport
+// failure or a 5xx from platform-api) becomes 503 upstream_unavailable:
+// retrying may help once the dependency recovers.
+//
+// Any other error — including a non-404 4xx from platform-api, and a bare
+// subscription-repository (DB) error, neither of which wraps either
+// sentinel — becomes 500 internal_error. A 4xx from platform-api means
+// mark8ly's own configuration is broken (e.g. a wrong shared secret); a DB
+// error means our own service is broken. Neither is something retrying
+// fixes, so 503 would be misleading here. In both outcomes a partial KPI
+// object is never returned — a partial object is indistinguishable from a
+// complete one, the very failure mode this endpoint exists to close.
+func (h *KPIsHandler) respondErr(c *gin.Context, source string, err error) {
+	if errors.Is(err, estatecounts.ErrUnavailable) || errors.Is(err, onboardingfunnel.ErrUnavailable) {
+		if h.logger != nil {
+			h.logger.Error("kpis upstream unavailable", "source", source, "err", err)
+		}
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "upstream_unavailable", "message": "one or more kpi sources is unavailable",
+		})
+		return
 	}
-	c.JSON(http.StatusServiceUnavailable, gin.H{
-		"error": "upstream_unavailable", "message": "one or more kpi sources is unavailable",
+	if h.logger != nil {
+		h.logger.Error("kpis source error", "source", source, "err", err)
+	}
+	c.JSON(http.StatusInternalServerError, gin.H{
+		"error": "internal_error", "message": "could not gather one or more kpi sources",
 	})
 }

--- a/services/marketplace-api/internal/handlers/platformadmin/kpis.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/kpis.go
@@ -1,0 +1,195 @@
+package platformadmin
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/estatecounts"
+	"github.com/mark8ly/marketplace-api/internal/onboardingfunnel"
+)
+
+// EstateCounts is the subset of estatecounts.Client this handler needs.
+// Declared here (rather than importing the concrete client type directly
+// into Deps) so the handler can be tested with a stub, mirroring
+// OnboardingFunnel in onboarding.go.
+type EstateCounts interface {
+	Get(ctx context.Context) (*estatecounts.Counts, error)
+}
+
+// Subscriptions is the subset of subscription.Repository this handler
+// needs. Narrowed to one method for the same reason as EstateCounts above.
+type Subscriptions interface {
+	CountTrialsExpiring(ctx context.Context, db *gorm.DB, asOf time.Time) (int64, error)
+}
+
+// kpiKey is one metric the console may ask for.
+type kpiKey struct {
+	Name         string
+	Instrumented bool
+}
+
+// KPIRegistry declares EVERY key mark8ly knows. Both the 200 payload and
+// the 501 responses are driven from here rather than from conditionals in
+// the handler, so a key cannot be silently dropped.
+//
+// An uninstrumented key is NOT omitted and NOT zero — the console has
+// rendered em-dashes that look like zeroes for a year because a sibling
+// route falls through to {}. See docs/ops for the incident writeup.
+var KPIRegistry = []kpiKey{
+	{Name: "tenants_active", Instrumented: true},
+	{Name: "stores_active", Instrumented: true},
+	{Name: "onboarding_in_flight", Instrumented: true},
+	{Name: "trials_expiring", Instrumented: true},
+	// GMV is genuinely not computable: currency is per store and per order,
+	// and there is no FX source anywhere in the workspace. 501 is the
+	// honest answer; 0 would be a lie and omitting it would be ambiguous.
+	{Name: "gmv_today", Instrumented: false},
+	{Name: "gmv_month", Instrumented: false},
+}
+
+func lookupKPI(name string) (kpiKey, bool) {
+	for _, k := range KPIRegistry {
+		if k.Name == name {
+			return k, true
+		}
+	}
+	return kpiKey{}, false
+}
+
+func defaultKPIKeys() []string {
+	keys := make([]string, 0, len(KPIRegistry))
+	for _, k := range KPIRegistry {
+		if k.Instrumented {
+			keys = append(keys, k.Name)
+		}
+	}
+	return keys
+}
+
+// parseKPIKeys parses ?keys= as a comma-separated list, trimming each.
+// Empty or absent means "all instrumented keys".
+func parseKPIKeys(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultKPIKeys()
+	}
+	parts := strings.Split(raw, ",")
+	keys := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			keys = append(keys, p)
+		}
+	}
+	if len(keys) == 0 {
+		return defaultKPIKeys()
+	}
+	return keys
+}
+
+// KPIsHandler serves the platform console's GET /admin/kpis (#282). It
+// gathers values from three independent upstreams — estatecounts,
+// onboardingfunnel, and the subscription repository — and only ever
+// answers with the complete set or a 503; see kpis() for why.
+type KPIsHandler struct {
+	estate EstateCounts
+	funnel OnboardingFunnel
+	subs   Subscriptions
+	db     *gorm.DB
+	logger *slog.Logger
+	// now is overridable in tests; production uses time.Now.
+	now func() time.Time
+}
+
+// NewKPIsHandler constructs the handler. logger may be nil.
+func NewKPIsHandler(estate EstateCounts, funnel OnboardingFunnel, subs Subscriptions, db *gorm.DB, logger *slog.Logger) *KPIsHandler {
+	return &KPIsHandler{estate: estate, funnel: funnel, subs: subs, db: db, logger: logger, now: time.Now}
+}
+
+// Register mounts the route on the supplied group.
+func (h *KPIsHandler) Register(g *gin.RouterGroup) {
+	g.GET("/admin/kpis", h.kpis)
+}
+
+func (h *KPIsHandler) kpis(c *gin.Context) {
+	keys := parseKPIKeys(c.Query("keys"))
+
+	// Resolve every requested key against the registry BEFORE touching any
+	// upstream. The two 501 cases share a status but differ in message —
+	// see the spec — and either one aborts the whole request; there is no
+	// partial success to accumulate first.
+	for _, name := range keys {
+		key, known := lookupKPI(name)
+		switch {
+		case !known:
+			c.JSON(http.StatusNotImplemented, gin.H{
+				"error":   "not_implemented",
+				"message": fmt.Sprintf("kpi %q is not a recognised key", name),
+				"key":     name,
+			})
+			return
+		case !key.Instrumented:
+			c.JSON(http.StatusNotImplemented, gin.H{
+				"error":   "not_implemented",
+				"message": fmt.Sprintf("kpi %q is known but not instrumented", name),
+				"key":     name,
+			})
+			return
+		}
+	}
+
+	ctx := c.Request.Context()
+
+	counts, err := h.estate.Get(ctx)
+	if err != nil {
+		h.respondUnavailable(c, "estatecounts", err)
+		return
+	}
+
+	funnelStats, err := h.funnel.GetFunnel(ctx, onboardingfunnel.FunnelParams{})
+	if err != nil {
+		h.respondUnavailable(c, "onboardingfunnel", err)
+		return
+	}
+
+	trialsExpiring, err := h.subs.CountTrialsExpiring(ctx, h.db, h.now())
+	if err != nil {
+		h.respondUnavailable(c, "subscription", err)
+		return
+	}
+
+	values := map[string]int64{
+		"tenants_active":       counts.TenantsActive,
+		"stores_active":        counts.StoresActive,
+		"onboarding_in_flight": funnelStats.InFlight,
+		"trials_expiring":      trialsExpiring,
+	}
+
+	data := gin.H{}
+	for _, name := range keys {
+		data[name] = values[name]
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": data})
+}
+
+// respondUnavailable answers 503 upstream_unavailable. This is the ONLY
+// error path for the gather stage: an estatecounts/onboardingfunnel
+// ErrUnavailable and a bare subscription-repository error are all treated
+// identically, because a partial KPI object is indistinguishable from a
+// complete one — the very failure mode this endpoint exists to close.
+func (h *KPIsHandler) respondUnavailable(c *gin.Context, source string, err error) {
+	if h.logger != nil {
+		h.logger.Error("kpis upstream unavailable", "source", source, "err", err)
+	}
+	c.JSON(http.StatusServiceUnavailable, gin.H{
+		"error": "upstream_unavailable", "message": "one or more kpi sources is unavailable",
+	})
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/kpis_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/kpis_test.go
@@ -170,6 +170,26 @@ func TestKPIsKnownUninstrumentedKeyIs501KnownButNotInstrumented(t *testing.T) {
 	require.Contains(t, kpiErrorMessage(t, rec), "known but not instrumented")
 }
 
+// The 501 for an uninstrumented key must not depend on upstream health: the
+// registry check runs before any gather, so this must stay 501 even when
+// every upstream is down (which would otherwise produce a 503). If the
+// check ever moved after the gather, this test would catch it turning into
+// a 503.
+func TestKPIsKnownUninstrumentedKeyIs501EvenWhenAllUpstreamsFail(t *testing.T) {
+	estate := &stubEstateCounts{err: estatecounts.ErrUnavailable}
+	funnel := &stubFunnelClient{err: onboardingfunnel.ErrUnavailable}
+	subs := &stubSubscriptions{err: errors.New("db exploded")}
+
+	rec := httptest.NewRecorder()
+	kpisRouter(t, estate, funnel, subs).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/kpis?keys=gmv_today", nil))
+
+	require.Equal(t, http.StatusNotImplemented, rec.Code)
+	require.Equal(t, "not_implemented", errorCode(t, rec))
+	require.Equal(t, "gmv_today", kpiErrorKey(t, rec))
+	require.Contains(t, kpiErrorMessage(t, rec), "known but not instrumented")
+}
+
 // The two 501 messages are the only thing distinguishing the cases for a
 // human reading logs. Comparing the two raw messages for inequality does
 // NOT prove that: both messages interpolate their own key name

--- a/services/marketplace-api/internal/handlers/platformadmin/kpis_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/kpis_test.go
@@ -1,0 +1,294 @@
+package platformadmin_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/estatecounts"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/internal/onboardingfunnel"
+)
+
+// stubEstateCounts is a canned estatecounts.Client stand-in.
+type stubEstateCounts struct {
+	counts *estatecounts.Counts
+	err    error
+}
+
+func (s *stubEstateCounts) Get(_ context.Context) (*estatecounts.Counts, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.counts == nil {
+		s.counts = &estatecounts.Counts{}
+	}
+	return s.counts, nil
+}
+
+// stubSubscriptions is a canned subscription.Repository stand-in, narrowed
+// to the one method the kpis handler calls.
+type stubSubscriptions struct {
+	count   int64
+	err     error
+	gotAsOf time.Time
+}
+
+func (s *stubSubscriptions) CountTrialsExpiring(_ context.Context, _ *gorm.DB, asOf time.Time) (int64, error) {
+	s.gotAsOf = asOf
+	if s.err != nil {
+		return 0, s.err
+	}
+	return s.count, nil
+}
+
+// kpisFixture builds one consistent set of stubs used across the happy-path
+// tests, so the golden fixture and the anti-drift test agree on values.
+func kpisFixture() (*stubEstateCounts, *stubFunnelClient, *stubSubscriptions) {
+	estate := &stubEstateCounts{counts: &estatecounts.Counts{TenantsActive: 42, StoresActive: 57}}
+	funnel := &stubFunnelClient{funnel: &onboardingfunnel.FunnelStats{
+		FunnelCounts: onboardingfunnel.FunnelCounts{InFlight: 34},
+	}}
+	subs := &stubSubscriptions{count: 9}
+	return estate, funnel, subs
+}
+
+func kpisRouter(t *testing.T, estate platformadmin.EstateCounts, funnel platformadmin.OnboardingFunnel, subs platformadmin.Subscriptions) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	platformadmin.NewKPIsHandler(estate, funnel, subs, nil, nil).Register(r.Group(""))
+	return r
+}
+
+func kpiErrorKey(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	var body struct {
+		Key string `json:"key"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	return body.Key
+}
+
+func kpiErrorMessage(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	var body struct {
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	return body.Message
+}
+
+// Registry-driven completeness: iterate KPIRegistry so a future key added
+// there without handler support fails this test. Every instrumented key
+// must appear in the 200 payload when requested alone; every uninstrumented
+// key must 501 when requested by name.
+func TestKPIsRegistryDrivenCompleteness(t *testing.T) {
+	for _, key := range platformadmin.KPIRegistry {
+		t.Run(key.Name, func(t *testing.T) {
+			estate, funnel, subs := kpisFixture()
+
+			rec := httptest.NewRecorder()
+			kpisRouter(t, estate, funnel, subs).ServeHTTP(rec, httptest.NewRequest(
+				http.MethodGet, "/admin/kpis?keys="+key.Name, nil))
+
+			if key.Instrumented {
+				require.Equal(t, http.StatusOK, rec.Code)
+				var body struct {
+					Data map[string]json.RawMessage `json:"data"`
+				}
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+				_, ok := body.Data[key.Name]
+				require.True(t, ok, "instrumented key %q missing from 200 payload", key.Name)
+			} else {
+				require.Equal(t, http.StatusNotImplemented, rec.Code)
+				require.Equal(t, key.Name, kpiErrorKey(t, rec))
+			}
+		})
+	}
+}
+
+func TestKPIsUnknownKeyIs501NotARecognisedKey(t *testing.T) {
+	estate, funnel, subs := kpisFixture()
+
+	rec := httptest.NewRecorder()
+	kpisRouter(t, estate, funnel, subs).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/kpis?keys=not_a_real_kpi", nil))
+
+	require.Equal(t, http.StatusNotImplemented, rec.Code)
+	require.Equal(t, "not_implemented", errorCode(t, rec))
+	require.Equal(t, "not_a_real_kpi", kpiErrorKey(t, rec))
+	require.Contains(t, kpiErrorMessage(t, rec), "not a recognised key")
+}
+
+func TestKPIsKnownUninstrumentedKeyIs501KnownButNotInstrumented(t *testing.T) {
+	estate, funnel, subs := kpisFixture()
+
+	rec := httptest.NewRecorder()
+	kpisRouter(t, estate, funnel, subs).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/kpis?keys=gmv_today", nil))
+
+	require.Equal(t, http.StatusNotImplemented, rec.Code)
+	require.Equal(t, "not_implemented", errorCode(t, rec))
+	require.Equal(t, "gmv_today", kpiErrorKey(t, rec))
+	require.Contains(t, kpiErrorMessage(t, rec), "known but not instrumented")
+}
+
+// The two 501 messages are the only thing distinguishing the cases for a
+// human reading logs — assert they actually differ.
+func TestKPIs501MessagesDifferBetweenUnknownAndUninstrumented(t *testing.T) {
+	estate, funnel, subs := kpisFixture()
+	router := kpisRouter(t, estate, funnel, subs)
+
+	unknownRec := httptest.NewRecorder()
+	router.ServeHTTP(unknownRec, httptest.NewRequest(http.MethodGet, "/admin/kpis?keys=not_a_real_kpi", nil))
+
+	uninstrumentedRec := httptest.NewRecorder()
+	router.ServeHTTP(uninstrumentedRec, httptest.NewRequest(http.MethodGet, "/admin/kpis?keys=gmv_today", nil))
+
+	require.NotEqual(t, kpiErrorMessage(t, unknownRec), kpiErrorMessage(t, uninstrumentedRec))
+}
+
+// A mixed request with one good key and one uninstrumented key must 501 as
+// a whole — never a partial 200 with just the good key.
+func TestKPIsMixedRequestWithUninstrumentedKeyIs501NotPartial200(t *testing.T) {
+	estate, funnel, subs := kpisFixture()
+
+	rec := httptest.NewRecorder()
+	kpisRouter(t, estate, funnel, subs).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/kpis?keys=tenants_active,gmv_today", nil))
+
+	require.Equal(t, http.StatusNotImplemented, rec.Code)
+	require.NotContains(t, rec.Body.String(), `"data"`)
+}
+
+// Anti-drift: onboarding_in_flight must equal the InFlight the funnel stub
+// reports, from the SAME stub value used to build the stub — so a future
+// handler that recomputes rather than reuses fails this test.
+func TestKPIsOnboardingInFlightMatchesFunnelStubExactly(t *testing.T) {
+	const wantInFlight = int64(77)
+	estate := &stubEstateCounts{counts: &estatecounts.Counts{TenantsActive: 1, StoresActive: 1}}
+	funnel := &stubFunnelClient{funnel: &onboardingfunnel.FunnelStats{
+		FunnelCounts: onboardingfunnel.FunnelCounts{InFlight: wantInFlight},
+	}}
+	subs := &stubSubscriptions{count: 1}
+
+	rec := httptest.NewRecorder()
+	kpisRouter(t, estate, funnel, subs).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/kpis", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data struct {
+			OnboardingInFlight int64 `json:"onboarding_in_flight"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, wantInFlight, body.Data.OnboardingInFlight)
+	require.Equal(t, funnel.funnel.InFlight, body.Data.OnboardingInFlight)
+}
+
+// counterKeyNames lists every JSON key that could carry a real counter
+// value in the 200 payload. Used to assert a 503 body carries NONE of
+// them — a partial object is the failure mode these tests exist to catch.
+var counterKeyNames = []string{"tenants_active", "stores_active", "onboarding_in_flight", "trials_expiring"}
+
+func assertNoCounterKeys(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	for _, name := range counterKeyNames {
+		require.NotContains(t, rec.Body.String(), name)
+	}
+}
+
+func TestKPIsEstateUnavailableIs503WithNoPartialBody(t *testing.T) {
+	estate := &stubEstateCounts{err: estatecounts.ErrUnavailable}
+	funnel := &stubFunnelClient{funnel: &onboardingfunnel.FunnelStats{}}
+	subs := &stubSubscriptions{count: 1}
+
+	rec := httptest.NewRecorder()
+	kpisRouter(t, estate, funnel, subs).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/kpis", nil))
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "upstream_unavailable", errorCode(t, rec))
+	assertNoCounterKeys(t, rec)
+}
+
+func TestKPIsFunnelUnavailableIs503WithNoPartialBody(t *testing.T) {
+	estate := &stubEstateCounts{counts: &estatecounts.Counts{TenantsActive: 1, StoresActive: 1}}
+	funnel := &stubFunnelClient{err: onboardingfunnel.ErrUnavailable}
+	subs := &stubSubscriptions{count: 1}
+
+	rec := httptest.NewRecorder()
+	kpisRouter(t, estate, funnel, subs).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/kpis", nil))
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "upstream_unavailable", errorCode(t, rec))
+	assertNoCounterKeys(t, rec)
+}
+
+func TestKPIsSubscriptionRepositoryErrorIs503WithNoPartialBody(t *testing.T) {
+	estate := &stubEstateCounts{counts: &estatecounts.Counts{TenantsActive: 1, StoresActive: 1}}
+	funnel := &stubFunnelClient{funnel: &onboardingfunnel.FunnelStats{}}
+	subs := &stubSubscriptions{err: errors.New("db exploded")}
+
+	rec := httptest.NewRecorder()
+	kpisRouter(t, estate, funnel, subs).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/kpis", nil))
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "upstream_unavailable", errorCode(t, rec))
+	assertNoCounterKeys(t, rec)
+}
+
+// Every value in the 200 payload must decode as a bare JSON integer — a
+// float 4.0 or a string "4" must fail. Asserted on the RAW JSON: decoding
+// into an int would hide both cases.
+var rawIntegerPattern = regexp.MustCompile(`^-?[0-9]+$`)
+
+func TestKPIsValuesAreRawIntegersNotFloatsOrStrings(t *testing.T) {
+	estate, funnel, subs := kpisFixture()
+
+	rec := httptest.NewRecorder()
+	kpisRouter(t, estate, funnel, subs).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/kpis", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data map[string]json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.NotEmpty(t, body.Data)
+	for name, raw := range body.Data {
+		require.Truef(t, rawIntegerPattern.MatchString(string(raw)),
+			"kpi %q raw value %q is not a bare JSON integer", name, string(raw))
+	}
+}
+
+// THE test. Real handler output compared to the committed contract.
+func TestKPIsMatchesContract(t *testing.T) {
+	estate, funnel, subs := kpisFixture()
+
+	rec := httptest.NewRecorder()
+	kpisRouter(t, estate, funnel, subs).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/kpis", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	want, err := os.ReadFile("testdata/kpis_response.json")
+	require.NoError(t, err)
+	require.JSONEq(t, string(want), rec.Body.String())
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/kpis_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/kpis_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -89,10 +90,30 @@ func kpiErrorMessage(t *testing.T, rec *httptest.ResponseRecorder) string {
 	return body.Message
 }
 
+// wantKPIValue maps a fixture key to the distinct, non-zero value
+// kpisFixture() reports for it, so the assertion below can check the exact
+// value carried through the payload rather than merely the key's presence.
+// A missing entry here for a key that IS instrumented is itself a test bug
+// (see the require.Contains fallthrough below), which is intentional: this
+// map must be kept in lockstep with kpisFixture.
+var wantKPIValue = map[string]int64{
+	"tenants_active":       42,
+	"stores_active":        57,
+	"onboarding_in_flight": 34,
+	"trials_expiring":      9,
+}
+
 // Registry-driven completeness: iterate KPIRegistry so a future key added
 // there without handler support fails this test. Every instrumented key
-// must appear in the 200 payload when requested alone; every uninstrumented
-// key must 501 when requested by name.
+// must appear in the 200 payload, WITH THE EXACT VALUE the stub reports for
+// it, when requested alone; every uninstrumented key must 501 when
+// requested by name.
+//
+// Asserting only presence (as this test used to) lets a registry key with
+// no handler support through: Go's zero value for an unpopulated map entry
+// is 0, and 0 satisfies "key is present" every time. Asserting the exact,
+// distinct, non-zero fixture value closes that gap — a fabricated 0 now
+// fails on the value.
 func TestKPIsRegistryDrivenCompleteness(t *testing.T) {
 	for _, key := range platformadmin.KPIRegistry {
 		t.Run(key.Name, func(t *testing.T) {
@@ -108,8 +129,13 @@ func TestKPIsRegistryDrivenCompleteness(t *testing.T) {
 					Data map[string]json.RawMessage `json:"data"`
 				}
 				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
-				_, ok := body.Data[key.Name]
+				raw, ok := body.Data[key.Name]
 				require.True(t, ok, "instrumented key %q missing from 200 payload", key.Name)
+
+				want, known := wantKPIValue[key.Name]
+				require.True(t, known, "test bug: wantKPIValue has no entry for instrumented key %q — add one alongside kpisFixture", key.Name)
+				require.JSONEq(t, fmt.Sprintf("%d", want), string(raw),
+					"kpi %q carried the wrong value — a fabricated zero would also pass a presence-only check", key.Name)
 			} else {
 				require.Equal(t, http.StatusNotImplemented, rec.Code)
 				require.Equal(t, key.Name, kpiErrorKey(t, rec))
@@ -145,7 +171,14 @@ func TestKPIsKnownUninstrumentedKeyIs501KnownButNotInstrumented(t *testing.T) {
 }
 
 // The two 501 messages are the only thing distinguishing the cases for a
-// human reading logs — assert they actually differ.
+// human reading logs. Comparing the two raw messages for inequality does
+// NOT prove that: both messages interpolate their own key name
+// ("not_a_real_kpi" vs "gmv_today"), so they differ no matter what the
+// surrounding template text says — even if a reviewer made both templates
+// byte-for-byte identical, the strings would still differ on the key alone
+// and this test would still pass. Assert each message's distinguishing
+// phrase directly instead, so deleting either phrase from its template
+// fails this test.
 func TestKPIs501MessagesDifferBetweenUnknownAndUninstrumented(t *testing.T) {
 	estate, funnel, subs := kpisFixture()
 	router := kpisRouter(t, estate, funnel, subs)
@@ -156,7 +189,14 @@ func TestKPIs501MessagesDifferBetweenUnknownAndUninstrumented(t *testing.T) {
 	uninstrumentedRec := httptest.NewRecorder()
 	router.ServeHTTP(uninstrumentedRec, httptest.NewRequest(http.MethodGet, "/admin/kpis?keys=gmv_today", nil))
 
-	require.NotEqual(t, kpiErrorMessage(t, unknownRec), kpiErrorMessage(t, uninstrumentedRec))
+	unknownMsg := kpiErrorMessage(t, unknownRec)
+	uninstrumentedMsg := kpiErrorMessage(t, uninstrumentedRec)
+
+	require.Contains(t, unknownMsg, "not a recognised key")
+	require.NotContains(t, unknownMsg, "known but not instrumented")
+
+	require.Contains(t, uninstrumentedMsg, "known but not instrumented")
+	require.NotContains(t, uninstrumentedMsg, "not a recognised key")
 }
 
 // A mixed request with one good key and one uninstrumented key must 501 as
@@ -239,7 +279,11 @@ func TestKPIsFunnelUnavailableIs503WithNoPartialBody(t *testing.T) {
 	assertNoCounterKeys(t, rec)
 }
 
-func TestKPIsSubscriptionRepositoryErrorIs503WithNoPartialBody(t *testing.T) {
+// A bare subscription-repository (DB) error wraps neither ErrUnavailable
+// sentinel, so per the spec (binding over the brief, which said 503 for
+// every error) it becomes 500 internal_error, not 503: a DB error means our
+// own service is broken, and 503 would misleadingly suggest retrying helps.
+func TestKPIsSubscriptionRepositoryErrorIs500WithNoPartialBody(t *testing.T) {
 	estate := &stubEstateCounts{counts: &estatecounts.Counts{TenantsActive: 1, StoresActive: 1}}
 	funnel := &stubFunnelClient{funnel: &onboardingfunnel.FunnelStats{}}
 	subs := &stubSubscriptions{err: errors.New("db exploded")}
@@ -248,8 +292,42 @@ func TestKPIsSubscriptionRepositoryErrorIs503WithNoPartialBody(t *testing.T) {
 	kpisRouter(t, estate, funnel, subs).ServeHTTP(rec, httptest.NewRequest(
 		http.MethodGet, "/admin/kpis", nil))
 
-	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
-	require.Equal(t, "upstream_unavailable", errorCode(t, rec))
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Equal(t, "internal_error", errorCode(t, rec))
+	assertNoCounterKeys(t, rec)
+}
+
+// A non-404 4xx from platform-api (e.g. a wrong shared secret returning
+// 401/403) wraps neither ErrUnavailable sentinel either, so it takes the
+// same 500 branch: our own configuration is broken, and retrying a wrong
+// secret never helps.
+func TestKPIsEstateNon5xxErrorIs500NotServiceUnavailable(t *testing.T) {
+	estate := &stubEstateCounts{err: errors.New("estatecounts: platform-api 401")}
+	funnel := &stubFunnelClient{funnel: &onboardingfunnel.FunnelStats{}}
+	subs := &stubSubscriptions{count: 1}
+
+	rec := httptest.NewRecorder()
+	kpisRouter(t, estate, funnel, subs).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/kpis", nil))
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Equal(t, "internal_error", errorCode(t, rec))
+	assertNoCounterKeys(t, rec)
+}
+
+// The funnel client's equivalent non-5xx case takes the same 500 branch,
+// covering both upstreams that can produce a non-404 4xx.
+func TestKPIsFunnelNon5xxErrorIs500NotServiceUnavailable(t *testing.T) {
+	estate := &stubEstateCounts{counts: &estatecounts.Counts{TenantsActive: 1, StoresActive: 1}}
+	funnel := &stubFunnelClient{err: errors.New("onboardingfunnel: platform-api 403")}
+	subs := &stubSubscriptions{count: 1}
+
+	rec := httptest.NewRecorder()
+	kpisRouter(t, estate, funnel, subs).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/kpis", nil))
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Equal(t, "internal_error", errorCode(t, rec))
 	assertNoCounterKeys(t, rec)
 }
 
@@ -275,6 +353,29 @@ func TestKPIsValuesAreRawIntegersNotFloatsOrStrings(t *testing.T) {
 	for name, raw := range body.Data {
 		require.Truef(t, rawIntegerPattern.MatchString(string(raw)),
 			"kpi %q raw value %q is not a bare JSON integer", name, string(raw))
+	}
+}
+
+// A ?keys= value made only of empty/comma segments (e.g. "?keys=,,") must
+// behave exactly like an absent "keys" param: all instrumented keys, not a
+// 501 for an empty-string key and not an empty payload. See the comment on
+// parseKPIKeys for the documented contract this proves.
+func TestKPIsKeysOnlyEmptySegmentsFallsBackToAllInstrumented(t *testing.T) {
+	estate, funnel, subs := kpisFixture()
+
+	rec := httptest.NewRecorder()
+	kpisRouter(t, estate, funnel, subs).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/kpis?keys=,,", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data map[string]json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	for name := range wantKPIValue {
+		_, ok := body.Data[name]
+		require.True(t, ok, "instrumented key %q missing when keys=,, falls back to all instrumented keys", name)
 	}
 }
 

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -32,6 +32,12 @@ type Deps struct {
 	// Nil leaves those routes unmounted, matching the nil-safe pattern used
 	// for TenantDirectory above.
 	OnboardingFunnel OnboardingFunnel
+
+	// EstateCounts and Subscriptions, together with OnboardingFunnel above,
+	// serve /admin/kpis (#282). All three must be non-nil for that route to
+	// mount — a partial KPI handler is worse than no handler at all.
+	EstateCounts  EstateCounts
+	Subscriptions Subscriptions
 }
 
 // Register mounts the platform console's /admin/* surface behind
@@ -82,5 +88,9 @@ func Register(g *gin.RouterGroup, deps Deps) {
 
 	if deps.OnboardingFunnel != nil {
 		NewOnboardingFunnelHandler(deps.OnboardingFunnel, deps.Logger).Register(group)
+	}
+
+	if deps.EstateCounts != nil && deps.OnboardingFunnel != nil && deps.Subscriptions != nil {
+		NewKPIsHandler(deps.EstateCounts, deps.OnboardingFunnel, deps.Subscriptions, deps.DB, deps.Logger).Register(group)
 	}
 }

--- a/services/marketplace-api/internal/handlers/platformadmin/routes_kpis_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes_kpis_test.go
@@ -1,0 +1,64 @@
+package platformadmin_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+)
+
+// Any one of the three KPI dependencies missing must leave /admin/kpis
+// unmounted rather than panic at request time — a partial handler is worse
+// than no handler, so the mount itself must not happen.
+func TestRegisterKPIsIsNilSafeWhenAnyDepMissing(t *testing.T) {
+	estate, funnel, subs := kpisFixture()
+
+	cases := map[string]platformadmin.Deps{
+		"all missing": {Repo: &stubRepo{}},
+		"estate only": {Repo: &stubRepo{}, EstateCounts: estate},
+		"funnel only": {Repo: &stubRepo{}, OnboardingFunnel: funnel},
+		"subs only":   {Repo: &stubRepo{}, Subscriptions: subs},
+		"missing subs": {
+			Repo: &stubRepo{}, EstateCounts: estate, OnboardingFunnel: funnel,
+		},
+	}
+
+	for name, deps := range cases {
+		t.Run(name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			r := gin.New()
+			platformadmin.Register(r.Group("/api/v1/platform"), deps)
+
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+				"/api/v1/platform/admin/kpis", nil))
+			require.Equal(t, http.StatusNotFound, rec.Code)
+		})
+	}
+}
+
+// Mounted but with no secret: 503 not_configured, same as every other
+// route on this surface.
+func TestKPIsFailsClosedWithoutSecret(t *testing.T) {
+	estate, funnel, subs := kpisFixture()
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	platformadmin.Register(r.Group("/api/v1/platform"), platformadmin.Deps{
+		Repo:             &stubRepo{},
+		EstateCounts:     estate,
+		OnboardingFunnel: funnel,
+		Subscriptions:    subs,
+		Secret:           "",
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/api/v1/platform/admin/kpis", nil))
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "not_configured", errorCode(t, rec))
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/testdata/kpis_response.json
+++ b/services/marketplace-api/internal/handlers/platformadmin/testdata/kpis_response.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "tenants_active": 42,
+    "stores_active": 57,
+    "onboarding_in_flight": 34,
+    "trials_expiring": 9
+  }
+}

--- a/services/marketplace-api/internal/subscription/models.go
+++ b/services/marketplace-api/internal/subscription/models.go
@@ -43,6 +43,14 @@ const (
 	StatusHardDeleted           SubscriptionStatus = "hard_deleted"
 )
 
+// TrialExpiryHorizon is how far ahead a trial counts as "expiring" for the
+// platform console's KPI tile (#282).
+//
+// SHARED, deliberately: #285 (GET /admin/billing/trials) needs the same
+// notion of "expiring". If it declares its own, the console shows two
+// different numbers for the same word on two screens. Reuse this constant.
+const TrialExpiryHorizon = 7 * 24 * time.Hour
+
 // PriceTier encodes whether the merchant is billed at the developed-market
 // list price or a purchasing-power-parity (PPP) discounted tier.
 type PriceTier string

--- a/services/marketplace-api/internal/subscription/planchange/cron_test.go
+++ b/services/marketplace-api/internal/subscription/planchange/cron_test.go
@@ -71,6 +71,9 @@ func (r *cronFakeSubRepo) FindPendingDowngradesReady(_ context.Context, _ *gorm.
 func (r *cronFakeSubRepo) CountStoresForPlanSlot(_ context.Context, _ *gorm.DB, _ uuid.UUID) (int, error) {
 	return 0, nil
 }
+func (r *cronFakeSubRepo) CountTrialsExpiring(_ context.Context, _ *gorm.DB, _ time.Time) (int64, error) {
+	return 0, nil
+}
 
 // recordingStripe wraps fakeStripe and records UpdateSubscription call params.
 type recordingStripe struct {

--- a/services/marketplace-api/internal/subscription/planchange/planchange_test.go
+++ b/services/marketplace-api/internal/subscription/planchange/planchange_test.go
@@ -72,6 +72,9 @@ func (r *fakeSubRepo) FindPendingDowngradesReady(_ context.Context, _ *gorm.DB, 
 func (r *fakeSubRepo) CountStoresForPlanSlot(_ context.Context, _ *gorm.DB, _ uuid.UUID) (int, error) {
 	return 0, nil
 }
+func (r *fakeSubRepo) CountTrialsExpiring(_ context.Context, _ *gorm.DB, _ time.Time) (int64, error) {
+	return 0, nil
+}
 
 // fixedClock returns a constant time for deterministic tests.
 type fixedClock struct{ t time.Time }

--- a/services/marketplace-api/internal/subscription/repository.go
+++ b/services/marketplace-api/internal/subscription/repository.go
@@ -74,6 +74,18 @@ type Repository interface {
 	// Caller scopes to tenant only — plan slots are tenant-wide. Soft-deleted
 	// stores within the 60-day restorable grace window also count toward the slot.
 	CountStoresForPlanSlot(ctx context.Context, db *gorm.DB, tenantID uuid.UUID) (int, error)
+
+	// CountTrialsExpiring counts trialing subscriptions whose current period
+	// ends within TrialExpiryHorizon of asOf.
+	//
+	// ESTATE-WIDE, deliberately unscoped by tenant: this serves the platform
+	// console's KPI tile, which is HMAC-gated on the platformadmin surface and
+	// has no tenant context at all. DO NOT call it from any tenant-facing
+	// handler — those must stay tenant-scoped like GetByStoreID.
+	//
+	// asOf is a parameter rather than now() so a test can pin the window
+	// boundary exactly; production passes time.Now().
+	CountTrialsExpiring(ctx context.Context, db *gorm.DB, asOf time.Time) (int64, error)
 }
 
 type gormRepository struct{}
@@ -247,4 +259,22 @@ func (gormRepository) CountStoresForPlanSlot(ctx context.Context, db *gorm.DB, t
 		return 0, fmt.Errorf("subscription: count stores for plan slot: %w", err)
 	}
 	return int(count), nil
+}
+
+// CountTrialsExpiring counts trialing subscriptions whose current period end
+// falls within the window (asOf, asOf+TrialExpiryHorizon] — half-open on the
+// left so an already-expired trial does not count as "expiring", inclusive
+// on the right so a trial ending exactly at the horizon does count.
+func (gormRepository) CountTrialsExpiring(ctx context.Context, db *gorm.DB, asOf time.Time) (int64, error) {
+	var n int64
+	err := db.WithContext(ctx).Model(&StoreSubscription{}).
+		Where("status = ?", StatusTrialing).
+		Where("current_period_end IS NOT NULL").
+		Where("current_period_end > ?", asOf).
+		Where("current_period_end <= ?", asOf.Add(TrialExpiryHorizon)).
+		Count(&n).Error
+	if err != nil {
+		return 0, fmt.Errorf("subscription: count trials expiring: %w", err)
+	}
+	return n, nil
 }

--- a/services/marketplace-api/internal/subscription/repository_kpi_integration_test.go
+++ b/services/marketplace-api/internal/subscription/repository_kpi_integration_test.go
@@ -114,6 +114,22 @@ func TestRepository_CountTrialsExpiring_AlreadyExpiredExcluded(t *testing.T) {
 	require.Equal(t, int64(0), got)
 }
 
+// TestRepository_CountTrialsExpiring_LeftEdgeExclusive proves the left edge
+// is strictly exclusive: a trial whose period ends exactly at asOf has
+// already expired and is not "expiring". A fixture an hour away from the
+// boundary (see AlreadyExpiredExcluded above) can't distinguish `>` from
+// `>=`; only current_period_end == asOf can.
+func TestRepository_CountTrialsExpiring_LeftEdgeExclusive(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	seedSubscription(t, db, uuid.New(), subscription.StatusTrialing, at(0))
+
+	got, err := repo.CountTrialsExpiring(context.Background(), db, kpiTestAsOf)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got)
+}
+
 // TestRepository_CountTrialsExpiring_OnlyTrialingStatus proves an active
 // subscription ending within the window is not counted — only trialing.
 func TestRepository_CountTrialsExpiring_OnlyTrialingStatus(t *testing.T) {

--- a/services/marketplace-api/internal/subscription/repository_kpi_integration_test.go
+++ b/services/marketplace-api/internal/subscription/repository_kpi_integration_test.go
@@ -1,0 +1,155 @@
+//go:build integration
+
+package subscription_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// asOf is fixed (not time.Now()) so the window-boundary assertions below stay
+// stable forever instead of drifting with the calendar.
+var kpiTestAsOf = time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+
+// seedStore inserts a minimal stores row for (tenantID, storeID) so that a
+// store_subscriptions row referencing storeID satisfies
+// store_subscriptions_store_id_fkey. Mirrors the equivalent helper in
+// internal/subscription/dunning.
+func seedStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
+	t.Helper()
+
+	slug := "tst-" + strings.ReplaceAll(storeID.String(), "-", "")[:20]
+
+	err := db.Exec(
+		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, encode(gen_random_bytes(32), 'hex'))`,
+		storeID, tenantID, slug, "Test Store", "IE", "EUR", "Europe/Dublin", "active",
+	).Error
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM stores WHERE id = ?", storeID)
+	})
+}
+
+func seedSubscription(t *testing.T, db *gorm.DB, tenantID uuid.UUID, status subscription.SubscriptionStatus, periodEnd *time.Time) {
+	t.Helper()
+	storeID := uuid.New()
+	seedStore(t, db, tenantID, storeID)
+
+	s := subscription.StoreSubscription{
+		TenantID:         tenantID,
+		StoreID:          storeID,
+		StripeCustomerID: "cus_" + uuid.New().String(),
+		Plan:             subscription.PlanTrial,
+		Status:           status,
+		CurrentPeriodEnd: periodEnd,
+	}
+	require.NoError(t, db.Create(&s).Error)
+}
+
+func at(d time.Duration) *time.Time {
+	tm := kpiTestAsOf.Add(d)
+	return &tm
+}
+
+// TestRepository_CountTrialsExpiring_WithinHorizon proves a trialing
+// subscription ending inside the window is counted.
+func TestRepository_CountTrialsExpiring_WithinHorizon(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	seedSubscription(t, db, uuid.New(), subscription.StatusTrialing, at(3*24*time.Hour))
+
+	got, err := repo.CountTrialsExpiring(context.Background(), db, kpiTestAsOf)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), got)
+}
+
+// TestRepository_CountTrialsExpiring_OutsideHorizon proves a trial ending
+// past the horizon (10 days out, horizon is 7) is not counted.
+func TestRepository_CountTrialsExpiring_OutsideHorizon(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	seedSubscription(t, db, uuid.New(), subscription.StatusTrialing, at(10*24*time.Hour))
+
+	got, err := repo.CountTrialsExpiring(context.Background(), db, kpiTestAsOf)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got)
+}
+
+// TestRepository_CountTrialsExpiring_RightEdgeInclusive proves a trial
+// ending exactly at asOf+TrialExpiryHorizon counts (inclusive right edge).
+func TestRepository_CountTrialsExpiring_RightEdgeInclusive(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	seedSubscription(t, db, uuid.New(), subscription.StatusTrialing, at(subscription.TrialExpiryHorizon))
+
+	got, err := repo.CountTrialsExpiring(context.Background(), db, kpiTestAsOf)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), got)
+}
+
+// TestRepository_CountTrialsExpiring_AlreadyExpiredExcluded proves the left
+// edge is half-open: a trial whose period already ended is not "expiring".
+func TestRepository_CountTrialsExpiring_AlreadyExpiredExcluded(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	seedSubscription(t, db, uuid.New(), subscription.StatusTrialing, at(-1*time.Hour))
+
+	got, err := repo.CountTrialsExpiring(context.Background(), db, kpiTestAsOf)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got)
+}
+
+// TestRepository_CountTrialsExpiring_OnlyTrialingStatus proves an active
+// subscription ending within the window is not counted — only trialing.
+func TestRepository_CountTrialsExpiring_OnlyTrialingStatus(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	seedSubscription(t, db, uuid.New(), subscription.StatusActive, at(3*24*time.Hour))
+
+	got, err := repo.CountTrialsExpiring(context.Background(), db, kpiTestAsOf)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got)
+}
+
+// TestRepository_CountTrialsExpiring_NilPeriodEndExcluded proves a trialing
+// row with a NULL current_period_end is skipped without error.
+func TestRepository_CountTrialsExpiring_NilPeriodEndExcluded(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	seedSubscription(t, db, uuid.New(), subscription.StatusTrialing, nil)
+
+	got, err := repo.CountTrialsExpiring(context.Background(), db, kpiTestAsOf)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got)
+}
+
+// TestRepository_CountTrialsExpiring_CountsAcrossTenants proves the count is
+// estate-wide: two trialing subscriptions under different tenants both count.
+func TestRepository_CountTrialsExpiring_CountsAcrossTenants(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	seedSubscription(t, db, uuid.New(), subscription.StatusTrialing, at(2*24*time.Hour))
+	seedSubscription(t, db, uuid.New(), subscription.StatusTrialing, at(5*24*time.Hour))
+
+	got, err := repo.CountTrialsExpiring(context.Background(), db, kpiTestAsOf)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), got)
+}

--- a/services/platform-api/cmd/server/main.go
+++ b/services/platform-api/cmd/server/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/mark8ly/platform-api/internal/audit"
 	"github.com/mark8ly/platform-api/internal/auth"
 	"github.com/mark8ly/platform-api/internal/authz"
+	"github.com/mark8ly/platform-api/internal/estate"
 	"github.com/mark8ly/platform-api/internal/gipadmin"
 	"github.com/mark8ly/platform-api/internal/invitation"
 	"github.com/mark8ly/platform-api/internal/location"
@@ -345,10 +346,14 @@ func main() {
 	// Deliberately a different group with different middleware — see
 	// middleware.RequireInternalAuthStrict. The onboarding funnel/sessions
 	// analytics routes (#283) share this guard for the same reason: both
-	// are estate-wide reads with no tenant scoping.
+	// are estate-wide reads with no tenant scoping. The estate counts
+	// endpoint (#282) joins them here too — GET /estate/counts reads
+	// across every tenant and store on the platform, same fail-closed
+	// requirement.
 	strictInternal := r.Group("/internal", middleware.RequireInternalAuthStrict(cfg.InternalAuthSecret))
 	tenantHandler.RegisterDirectory(strictInternal)
 	onboardingHandler.RegisterAnalytics(strictInternal)
+	estate.NewHandler(estate.NewRepository(conn)).Register(strictInternal)
 
 	locationHandler.Register(v1)
 	tenantHandler.Register(v1, internal)

--- a/services/platform-api/internal/estate/counts.go
+++ b/services/platform-api/internal/estate/counts.go
@@ -1,0 +1,53 @@
+// Package estate serves platform-wide counts for the Tesserix console's
+// product tile (#282). It reads across tenants and stores, which is why it
+// is its own package rather than living in either.
+package estate
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/platform-api/internal/store"
+	"github.com/mark8ly/platform-api/internal/tenant"
+)
+
+// Counts is the estate-wide headline count set.
+type Counts struct {
+	TenantsActive int64 `json:"tenants_active"`
+	StoresActive  int64 `json:"stores_active"`
+}
+
+// Repository is the data-access interface for estate-wide counts.
+type Repository interface {
+	Get(ctx context.Context) (*Counts, error)
+}
+
+type gormRepository struct {
+	db *gorm.DB
+}
+
+// NewRepository constructs a Repository backed by the given *gorm.DB.
+func NewRepository(db *gorm.DB) Repository {
+	return &gormRepository{db: db}
+}
+
+// Get runs the two independent counts that make up the estate headline:
+// active tenants and active stores. An empty estate is a real answer —
+// zero counts with a nil error — not distinguished from any other count;
+// only a query failure returns an error.
+func (r *gormRepository) Get(ctx context.Context) (*Counts, error) {
+	var c Counts
+	if err := r.db.WithContext(ctx).Table("tenants").
+		Where("status = ?", tenant.StatusActive).
+		Count(&c.TenantsActive).Error; err != nil {
+		return nil, fmt.Errorf("estate: count active tenants: %w", err)
+	}
+	if err := r.db.WithContext(ctx).Table("stores").
+		Where("status = ?", store.StatusActive).
+		Count(&c.StoresActive).Error; err != nil {
+		return nil, fmt.Errorf("estate: count active stores: %w", err)
+	}
+	return &c, nil
+}

--- a/services/platform-api/internal/estate/counts_integration_test.go
+++ b/services/platform-api/internal/estate/counts_integration_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+package estate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/platform-api/internal/store"
+	"github.com/mark8ly/platform-api/internal/tenant"
+	"github.com/mark8ly/platform-api/pkg/testdb"
+)
+
+// seedTenant inserts a tenant row with the given status and returns its id.
+func seedTenant(t *testing.T, db *gorm.DB, status string) string {
+	t.Helper()
+	id := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO tenants (id, name, owner_user_id, owner_email, status)
+		 VALUES (?, ?, ?, ?, ?)`,
+		id, "Estate Co "+id[:8], "uid-"+id[:8], id[:8]+"@example.com", status,
+	).Error)
+	return id
+}
+
+// seedStore inserts a store row under tenantID with the given status. Uses
+// GB/GBP/Europe/London — the reference rows actually present in
+// platform-api's seed (IE/Europe/Dublin are NOT seeded and would fail the FK).
+func seedStore(t *testing.T, db *gorm.DB, tenantID, status string) string {
+	t.Helper()
+	id := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, tenantID, "store-"+id[:8], "Estate Store", "GB", "GBP", "Europe/London", status,
+	).Error)
+	return id
+}
+
+func TestGet_CountsOnlyActiveTenants(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := NewRepository(db)
+
+	seedTenant(t, db, tenant.StatusActive)
+	seedTenant(t, db, tenant.StatusSuspended)
+
+	got, err := repo.Get(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), got.TenantsActive)
+}
+
+func TestGet_CountsOnlyActiveStores(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := NewRepository(db)
+
+	tenantID := seedTenant(t, db, tenant.StatusActive)
+	seedStore(t, db, tenantID, store.StatusActive)
+	seedStore(t, db, tenantID, "suspended")
+
+	got, err := repo.Get(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), got.StoresActive)
+}
+
+// An empty estate is a real answer — zero, not an error. Zero counts and
+// "we could not count" must stay distinguishable.
+func TestGet_EmptyEstateReturnsZerosNoError(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := NewRepository(db)
+
+	got, err := repo.Get(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got.TenantsActive)
+	require.Equal(t, int64(0), got.StoresActive)
+}
+
+// Tenants and stores are counted independently: one tenant with two active
+// stores yields TenantsActive=1, StoresActive=2.
+func TestGet_CountsTenantsAndStoresIndependently(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := NewRepository(db)
+
+	tenantID := seedTenant(t, db, tenant.StatusActive)
+	seedStore(t, db, tenantID, store.StatusActive)
+	seedStore(t, db, tenantID, store.StatusActive)
+
+	got, err := repo.Get(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), got.TenantsActive)
+	require.Equal(t, int64(2), got.StoresActive)
+}

--- a/services/platform-api/internal/estate/counts_integration_test.go
+++ b/services/platform-api/internal/estate/counts_integration_test.go
@@ -47,6 +47,7 @@ func TestGet_CountsOnlyActiveTenants(t *testing.T) {
 
 	seedTenant(t, db, tenant.StatusActive)
 	seedTenant(t, db, tenant.StatusSuspended)
+	seedTenant(t, db, tenant.StatusArchived)
 
 	got, err := repo.Get(context.Background())
 	require.NoError(t, err)
@@ -60,6 +61,7 @@ func TestGet_CountsOnlyActiveStores(t *testing.T) {
 	tenantID := seedTenant(t, db, tenant.StatusActive)
 	seedStore(t, db, tenantID, store.StatusActive)
 	seedStore(t, db, tenantID, "suspended")
+	seedStore(t, db, tenantID, store.StatusArchived)
 
 	got, err := repo.Get(context.Background())
 	require.NoError(t, err)

--- a/services/platform-api/internal/estate/handler.go
+++ b/services/platform-api/internal/estate/handler.go
@@ -1,0 +1,52 @@
+package estate
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	apperrors "github.com/mark8ly/platform-api/pkg/errors"
+)
+
+// Handler is the HTTP layer for estate-wide counts.
+type Handler struct {
+	repo Repository
+}
+
+// NewHandler constructs a Handler.
+func NewHandler(repo Repository) *Handler {
+	return &Handler{repo: repo}
+}
+
+// Register mounts GET /estate/counts onto the given gin.RouterGroup. The
+// CALLER is responsible for gating it — main.go wraps it in the strict
+// internal group (middleware.RequireInternalAuthStrict), because these
+// counts are estate-wide reads and must not be reachable on an
+// unconfigured deploy.
+func (h *Handler) Register(g *gin.RouterGroup) {
+	g.GET("/estate/counts", h.get)
+}
+
+func (h *Handler) get(c *gin.Context) {
+	counts, err := h.repo.Get(c.Request.Context())
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": counts})
+}
+
+// respondError mirrors internal/tenant/handler.go's error-mapping
+// convention: a typed apperrors.AppError maps to its own status/code/
+// message, everything else collapses to a generic 500 so internals never
+// leak into the response.
+func respondError(c *gin.Context, err error) {
+	if ae, ok := apperrors.As(err); ok {
+		c.JSON(ae.Status, gin.H{"error": ae.Code, "message": ae.Message})
+		return
+	}
+	c.JSON(http.StatusInternalServerError, gin.H{
+		"error":   "internal_error",
+		"message": "an unexpected error occurred",
+	})
+}

--- a/services/platform-api/internal/estate/handler_test.go
+++ b/services/platform-api/internal/estate/handler_test.go
@@ -1,0 +1,94 @@
+package estate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	apperrors "github.com/mark8ly/platform-api/pkg/errors"
+)
+
+// stubRepo returns a canned result or error for Get.
+type stubRepo struct {
+	counts *Counts
+	err    error
+}
+
+func (s *stubRepo) Get(_ context.Context) (*Counts, error) {
+	return s.counts, s.err
+}
+
+func router(repo Repository) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	NewHandler(repo).Register(r.Group(""))
+	return r
+}
+
+func TestGet_EnvelopeHasDataWithBothKeys(t *testing.T) {
+	repo := &stubRepo{counts: &Counts{TenantsActive: 3, StoresActive: 5}}
+	rec := httptest.NewRecorder()
+	router(repo).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/estate/counts", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data Counts `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, int64(3), body.Data.TenantsActive)
+	require.Equal(t, int64(5), body.Data.StoresActive)
+}
+
+func TestGet_ZeroCountsStillPresentInEnvelope(t *testing.T) {
+	repo := &stubRepo{counts: &Counts{TenantsActive: 0, StoresActive: 0}}
+	rec := httptest.NewRecorder()
+	router(repo).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/estate/counts", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Contains(t, string(body["data"]), `"tenants_active":0`)
+	require.Contains(t, string(body["data"]), `"stores_active":0`)
+}
+
+// A repository error must map through the package's error convention
+// (apperrors -> respondError), not come back as a bare 500 string.
+func TestGet_RepositoryErrorMapsThroughAppErrors(t *testing.T) {
+	repo := &stubRepo{err: apperrors.Internal("estate_count_failed", "could not count the estate")}
+	rec := httptest.NewRecorder()
+	router(repo).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/estate/counts", nil))
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	var body struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "estate_count_failed", body.Error)
+	require.Equal(t, "could not count the estate", body.Message)
+}
+
+// An unwrapped/unknown error still maps to a safe generic 500 body, not a
+// leaked error string.
+func TestGet_UnknownErrorMapsToGenericInternalError(t *testing.T) {
+	repo := &stubRepo{err: context.DeadlineExceeded}
+	rec := httptest.NewRecorder()
+	router(repo).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/estate/counts", nil))
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	var body struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "internal_error", body.Error)
+}


### PR DESCRIPTION
Closes #282. Part of the platform console integration series (#260), after #274, #275, #276, #277, #279, #283.

## What this is really about

The console's existing KPI route falls through to an empty object for products it does not recognise, so one product has rendered four em-dashes since launch — **dashes that look like zeroes**. A tile showing `0` active tenants is an emergency; a tile showing "not instrumented" is a backlog item. Every decision here descends from keeping those apart.

## The contract

| state | response |
|---|---|
| known and instrumented | `200`, integer value |
| known, not instrumented | `501`, message says **known but not instrumented**, `key` names it |
| not a recognised key | `501`, message says **not a recognised key**, `key` names it |
| upstream unreachable | `503` — and never a partial object |
| upstream misconfigured (non-sentinel error) | `500` — retrying never fixes a wrong secret |

Both `501`s share a status because the console cannot act differently on them; they differ in message because a human reading logs can. The `key` field lets the console mark one tile rather than the whole panel.

```json
{ "data": { "tenants_active": 4, "stores_active": 5,
            "onboarding_in_flight": 0, "trials_expiring": 2 } }
```

`GET /admin/kpis?keys=a,b` returns `501` if **any** named key is uninstrumented or unknown — a caller asking a definite question gets a definite answer rather than a quietly shorter object.

## Why GMV ships uninstrumented

`gmv_today` and `gmv_month` are declared in the registry with `Instrumented: false`, and that is the honest answer rather than a placeholder. Currency is per-store (`stores.currency_code`) and per-order (`orders.currency_code`), so a cross-tenant sum spans however many currencies the estate uses, and **there is no FX rate source anywhere in the workspace**. Returning `0` would be a lie; omitting the key would be ambiguous.

The money contract is pinned in the spec anyway, so the first implementation cannot invent a third convention: integer **minor units** plus an explicit currency. Note for whoever instruments it — `orders.grand_total` is `numeric(12,2)`, i.e. major units, and multiplying by 100 is correct only for 2-decimal currencies.

## Design points worth a look

- **The registry drives everything.** One declaration produces both the `200` payload and the `501`s. The completeness test loops over it, so a key added without handler support fails a test rather than silently vanishing from the tile.
- **`onboarding_in_flight` reuses #283's funnel value** rather than recomputing it, so the KPI tile and the funnel screen cannot disagree. Pinned by a test that fails if it is ever recomputed.
- **`subscription.TrialExpiryHorizon`** is the single source of the 7-day window, with a doc comment telling #285 to reuse it. If #285 declares its own, the console shows two different numbers for the same word on two screens.
- **`CountTrialsExpiring` is deliberately estate-wide**, and carries a warning comment in the style of `GetByStripeCustomerID` explaining why that is justified here (HMAC-gated surface, no tenant context) and that tenant-facing handlers must not call it.

## A bug worth calling out, caught mid-branch

The handler built its payload with `data[name] = values[name]` over a `map[string]int64`. A registry key with no handler support therefore yielded Go's zero value — so adding a key returned `"key": 0`. That is the em-dashes bug exactly, reproduced inside the endpoint built to prevent it, and reachable from our own registry. The completeness test passed because it asserted key *presence*, which a fabricated zero satisfies.

Now a guarded lookup that fails loudly, and the test asserts **values**, not presence.

## Test plan

- [x] `platform-api` estate integration suite green with `-p 1`
- [x] `marketplace-api` platformadmin + estatecounts packages green
- [x] `CountTrialsExpiring` integration tests green
- [x] `go build ./...` clean in both services
- [x] Trial window edges pinned: half-open left (a fixture at **exactly** `asOf` proves `>` not `>=`), inclusive right
- [x] Archived rows proven excluded from both headline counts (a third enum value the fixtures previously lacked)
- [x] `503` guard verified independently on all three sources
- [x] `501`-before-gather ordering pinned: an uninstrumented key returns `501` even with every upstream down
- [x] Golden fixture proven by mutation against a field rename and a field addition
- [ ] Verify against production after deploy (Kargo-gated; expect 10-20 min)

## Known gap, not introduced here

Neither `main.go` wiring site is verified by any test — deleting one builds clean and passes everything. This now applies to all three features in this series; recorded on #323, where the fix (extracting the wiring into a testable function) belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)