### PR TITLE
feat(platformadmin): GET /admin/billing/subscriptions, and carry the catalog amount on trials (#284, #328)

### DIFF
--- a/docs/superpowers/plans/2026-08-24-admin-billing-subscriptions.md
+++ b/docs/superpowers/plans/2026-08-24-admin-billing-subscriptions.md
@@ -1,0 +1,257 @@
+# Admin Billing Subscriptions Implementation Plan (#284, #328)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A cross-tenant view of every subscription on the platform, with plan, status and price — and, in the same change, add the price to `/admin/billing/trials`, which shipped without one on a mistaken conclusion.
+
+**Architecture:** One money resolver, shared by both billing endpoints, reading `internal/billing/pricing`'s catalog. A cross-tenant list query in `internal/subscription`. Tenant names via the `ids` batch filter built in #285.
+
+**Tech Stack:** Go 1.26, Gin 1.12, GORM, PostgreSQL 15, testify.
+
+**Spec:** `docs/superpowers/specs/2026-08-24-admin-billing-subscriptions-design.md` — the binding authority. Read its "The correction this folds in" and "The money resolver" sections before writing any code.
+
+## Global Constraints
+
+- **Never call `pricing.MustGet`.** It **panics** on a miss (`panic("pricing: no amount for plan=…")`). A console read must not panic on a plan/currency combination the catalog lacks. Use `pricing.DevelopedCurrencyOptions` then `pricing.LookupPPPOption` — the pair `MustGet` wraps, minus the panic.
+- **Omit, never fake.** No `billing_currency`, or no catalog entry, means **no `amount` key** — not `null`, not `0`, not a guessed currency.
+- **Catalog keys are lowercase ISO 4217** (`"gbp"`); `billing_currency` is `char(3)`; the wire contract is **uppercase** (`"GBP"`). Both conversions explicit.
+- **All eight `SubscriptionStatus` values** are valid filters and returned values: `signup`, `trialing`, `active`, `past_due`, `payment_action_required`, `cancel_scheduled`, `expired`, `store_closed`. Do not truncate to the four the issue names.
+- An unrecognised `status` or `plan` filter is **`400 validation_error`** naming the parameter — an empty list must mean "none match", never "I did not understand you".
+- Empty result is `200` with `[]`, **never `501`**. mark8ly has a billing concept.
+- `TaxBehavior` is **not** carried on the wire (decided in the spec).
+- Ids bare, timestamps RFC3339 UTC, no `source` field. `pagination.limit` reports the **effective** clamped value.
+- Commit messages: single line, conventional-commit prefix, no signature, no `Co-Authored-By` trailer.
+
+## Two facts that shape the work
+
+**1. The catalog has no price for `trial` or `marketplace` plans.** `internal/billing/pricing/catalog.go` says so explicitly: *"PlanTrial and PlanMarketplace have no Price objects — excluded."*
+
+Subscriptions reach `plan='trial'` by one path (`internal/subscription/service.go:124`) and a merchant-chosen `starter`/`studio`/`pro` by another (`internal/billing/trial/subscribe.go:140`). So a row with `plan='trial'` correctly carries **no amount** — there is no price for it, and that is by design rather than a gap.
+
+This makes #328's value **partial and honest**: `/admin/billing/trials` gains an amount for rows on a real plan, and correctly omits one for `plan='trial'` rows. Production's current golden fixture uses `plan: "trial"`, so its rows will keep carrying no amount. Do not "fix" that by inventing a trial price.
+
+**2. `store_subscriptions` is empty in production.** Verified read-only against the replica: 4 tenants and 4 stores exist, but subscriptions require an explicit merchant-initiated call with a Stripe customer, and none has been made. The new endpoint will correctly serve `[]` until the first merchant subscribes — so it will not be exercised by production data on day one, and the tests are the only evidence its row-shaping is right.
+
+## Conventions that will bite you
+
+- **`subscription.Repository` is STATELESS.** `NewRepository()` takes no arguments; every method takes `db *gorm.DB` as a parameter; receivers are value receivers on `gormRepository`. `NewRepository(conn)` will not compile.
+- That interface **warns against tenant-agnostic lookups** (see `GetByStripeCustomerID`). The new cross-tenant list is deliberately unscoped and must carry its own warning comment in the same style, as `CountExpiring` does.
+- Tests: `marketplace-api` uses the EXTERNAL package (`package foo_test`); `//go:build integration` for DB-backed ones.
+- **`internal/subscription` has pre-existing `store_subscriptions_store_id_fkey` failures** tracked as **#317**. Scope runs with `-run` and do not try to fix them. Seed a `stores` row before a `store_subscriptions` row, as `internal/billing/trial`'s tests do.
+
+## Environment
+
+- **Use the LAN IP, not localhost**: `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'`, with `-p 1 -count=1`. The committed Makefile says `localhost`, correct everywhere else — do not change it.
+- Never run anything against a remote or GKE database. Do not run `make dev`.
+- Ignore `go.work requires go >= 1.26.6 (running go 1.26.5)` — pre-existing drift.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `internal/handlers/platformadmin/money.go` (create) | The shared resolver and the `money` wire type |
+| `internal/handlers/platformadmin/money_test.go` (create) | Tier selection, omission rules, case handling |
+| `internal/subscription/repository.go` (modify) | `ListAllSubscriptions` cross-tenant query |
+| `internal/subscription/repository_crosstenant_integration_test.go` (create) | Filters, ordering, pagination |
+| `internal/handlers/platformadmin/billing_subscriptions.go` (create) | Handler and wire shape |
+| `internal/handlers/platformadmin/billing_subscriptions_test.go` (create) | Contract, filters, golden |
+| `internal/handlers/platformadmin/testdata/billing_subscriptions_response.json` (create) | Golden fixture |
+| `internal/handlers/platformadmin/billing_trials.go` (modify) | Add `amount` via the shared resolver (#328) |
+| `internal/handlers/platformadmin/billing_trials_test.go` (modify) | Amount cases + cross-endpoint agreement |
+| `internal/handlers/platformadmin/testdata/billing_trials_response.json` (modify only if values change) | |
+| `internal/handlers/platformadmin/routes.go` (modify) | New `Deps` field, mount |
+| `cmd/marketplace-api/main.go` (modify) | Wire at BOTH sites |
+
+---
+
+### Task 1: the shared money resolver
+
+**Files:** `internal/handlers/platformadmin/money.go` (create), `money_test.go` (create)
+
+**Interfaces:**
+- Produces: `type money struct { Amount int64 \`json:"amount"\`; Currency string \`json:"currency"\` }` and `func resolveMoney(plan, period string, billingCurrency *string, tier subscription.PriceTier) (money, bool)`.
+
+Read `internal/billing/pricing/catalog.go` first — particularly `MustGet`, so you can see exactly what you must not call and why.
+
+```go
+// resolveMoney returns the catalog price for a subscription's plan, period
+// and currency, or ok=false when no price can be determined.
+//
+// ok=false is a normal outcome, not an error:
+//   - billing_currency is NULL (the merchant never chose one), or
+//   - the plan has no price at all — the catalog excludes `trial` and
+//     `marketplace` by design ("no Price objects"), or
+//   - the catalog has no entry for that plan/period/currency combination.
+//
+// Callers OMIT the amount key entirely in that case. Never null, never 0,
+// never a guessed currency: a number the system cannot determine must not
+// be reported as a number.
+//
+// Deliberately does NOT use pricing.MustGet, which panics on a miss. A
+// console read must not panic on an unpriced combination. This calls the
+// same two lookups MustGet wraps, minus the panic.
+func resolveMoney(plan, period string, billingCurrency *string, tier subscription.PriceTier) (money, bool) {
+	if billingCurrency == nil || strings.TrimSpace(*billingCurrency) == "" {
+		return money{}, false
+	}
+	// Catalog keys are lowercase ISO 4217; the column is char(3) of
+	// unspecified case; the wire contract is uppercase.
+	cur := strings.ToLower(strings.TrimSpace(*billingCurrency))
+
+	p, per := pricing.Plan(plan), pricing.Period(period)
+
+	if tier == subscription.PriceTierPPP {
+		if amt, ok := pricing.LookupPPPOption(p, per, cur); ok {
+			return money{Amount: amt.UnitAmountMinor, Currency: strings.ToUpper(amt.Currency)}, true
+		}
+		return money{}, false
+	}
+
+	if opts, ok := pricing.DevelopedCurrencyOptions(p, per); ok {
+		if amt, present := opts[cur]; present {
+			return money{Amount: amt.UnitAmountMinor, Currency: strings.ToUpper(amt.Currency)}, true
+		}
+	}
+	return money{}, false
+}
+```
+
+Check the exact `subscription.PriceTier` constant names before writing this (`PriceTierDeveloped`, `PriceTierPPP` at `internal/subscription/models.go:59-60`) and the `pricing` function signatures — do not trust the snippet over the source.
+
+**Tests** (`package platformadmin`, internal — this is an unexported function; check whether the package's existing tests are external and, if so, put these in a `package platformadmin` file alongside, noting it in your report):
+
+- [ ] A developed-tier row (`plan=starter`, `period=monthly`, `currency=gbp`, `tier=developed`) resolves to `{1500, "GBP"}`. **Assert the uppercase currency** — a lowercase `"gbp"` on the wire is a contract break.
+- [ ] A PPP-tier row resolves from the PPP table, not the developed one. Pick a plan/currency present in `pppAmounts` and assert the value differs from the developed price for the same plan, so a tier mix-up is visible.
+- [ ] **`plan="trial"` resolves `ok=false`** — the catalog has no trial price by design.
+- [ ] `plan="marketplace"` resolves `ok=false`.
+- [ ] A nil `billingCurrency` resolves `ok=false`.
+- [ ] An empty-string and whitespace-only `billingCurrency` both resolve `ok=false`.
+- [ ] An **uppercase** input currency (`"GBP"`) resolves the same as lowercase — proving the lookup lowercases rather than missing.
+- [ ] An unknown currency (`"zzz"`) resolves `ok=false` and **does not panic**. Assert non-panic explicitly with `require.NotPanics`.
+- [ ] An unknown plan (`"nonexistent"`) resolves `ok=false` and does not panic.
+
+**Verify:** `cd services/marketplace-api && go test ./internal/handlers/platformadmin/...`
+
+**Commit:** `feat(platformadmin): shared catalog-backed money resolver (#284)`
+
+---
+
+### Task 2: the cross-tenant subscription query
+
+**Files:** `internal/subscription/repository.go`, `internal/subscription/repository_crosstenant_integration_test.go` (create)
+
+**Interfaces:**
+- Produces: `Repository.ListAllSubscriptions(ctx context.Context, db *gorm.DB, f CrossTenantFilter) ([]StoreSubscription, int64, error)` and `type CrossTenantFilter struct { Status, Plan string; Page, Limit int }`.
+
+Add to the `Repository` interface with a warning comment in the same style as `GetByStripeCustomerID`'s:
+
+```go
+	// ListAllSubscriptions returns a page of subscriptions across EVERY
+	// tenant, plus the unpaginated total.
+	//
+	// ESTATE-WIDE, deliberately unscoped by tenant: this serves the platform
+	// console's cross-tenant billing view, which is HMAC-gated on the
+	// platformadmin surface and has no tenant context at all. DO NOT call it
+	// from any tenant-facing handler — those must stay tenant-scoped like
+	// GetByStoreID.
+	ListAllSubscriptions(ctx context.Context, db *gorm.DB, f CrossTenantFilter) ([]StoreSubscription, int64, error)
+```
+
+Implementation notes:
+- Value receiver `(gormRepository)`, `db` from the parameter — the repository is stateless.
+- Build the filter once and use it for **both** the count and the page query, so the two cannot drift. `applyDirectoryFilter` in `platform-api/internal/tenant/directory.go` is the established shape.
+- An empty `Status` or `Plan` adds **no** clause. Guard each with `if f.Status != ""`, not a bare `Where`.
+- Order `created_at DESC`.
+- Default limit 50, clamp 500.
+- Allocate with `make([]StoreSubscription, 0, limit)` before `Find`.
+
+**Tests** (`package subscription_test`, `//go:build integration`). Seed a `stores` row before each `store_subscriptions` row — the FK is enforced (#317):
+
+- [ ] Returns subscriptions across **two different tenants** — asserted explicitly, since this is the estate-wide behaviour.
+- [ ] `Status` filter narrows correctly; an empty `Status` returns everything (the guard).
+- [ ] `Plan` filter narrows correctly; an empty `Plan` returns everything.
+- [ ] Both filters combine (AND), rather than one replacing the other.
+- [ ] Ordering is `created_at DESC` — seed three rows in a different order from their timestamps.
+- [ ] Pagination: `Limit: 1` returns one row with `total` equal to the full match count.
+- [ ] `Limit: 9999` clamps to 500 and reports the clamped value through the caller's page size.
+- [ ] An empty table returns an **allocated empty slice** and `total=0`, not nil and not an error.
+
+**Verify:** `cd services/marketplace-api && TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' go test -tags=integration -p 1 -count=1 -run CrossTenant ./internal/subscription/...`
+
+**Commit:** `feat(subscription): cross-tenant subscription listing for the platform console (#284)`
+
+---
+
+### Task 3: the subscriptions endpoint
+
+**Files:** `internal/handlers/platformadmin/billing_subscriptions.go` (create), `billing_subscriptions_test.go` (create), `testdata/billing_subscriptions_response.json` (create), `routes.go`, `cmd/marketplace-api/main.go`
+
+**Interfaces:**
+- Consumes: `resolveMoney` (Task 1), `ListAllSubscriptions` + `CrossTenantFilter` (Task 2), `tenantdirectory` `List` with `IDs` (built in #285).
+
+Wire shape exactly as the spec's JSON block:
+
+```json
+{ "tenant_id": "<bare>", "tenant_name": "Acme Trading", "store_id": "<bare>",
+  "plan": "studio", "period": "monthly", "status": "active",
+  "amount": {"amount": 1500, "currency": "GBP"},
+  "current_period_end": "2026-09-24T00:00:00Z", "cancel_at_period_end": false }
+```
+
+- [ ] Validate `status` against the **eight** `subscription.Status*` constants; validate `plan` against the five `subscription.Plan*` constants. An unrecognised value is `400 validation_error` naming the parameter.
+- [ ] `amount` **omitted** when `resolveMoney` returns `ok=false`. Use `*money` with `omitempty`, or build the response with a map — whichever your golden test can assert cleanly. Never `null`.
+- [ ] `current_period_end` omitted when NULL.
+- [ ] One batch `tenantdirectory.List` call per page with **distinct** ids; a tenant missing from the response omits `tenant_name` and the row still appears.
+- [ ] `tenantdirectory.ErrUnavailable` → `503 upstream_unavailable`; anything else → `500 internal_error`. Never a partial result.
+- [ ] Mount in `routes.go` behind a nil guard on both the new dependency and `TenantDirectory`. Wire at **BOTH** `main.go` sites — production runs two deployments from this binary.
+
+**Tests** (`package platformadmin_test`):
+
+- [ ] Golden fixture via `require.JSONEq`, **proven by mutation**: rename a JSON key and confirm failure; add a field to the response struct and confirm failure. Revert both; report both results.
+- [ ] A row whose plan has no catalog price (`plan="trial"`) has **no `amount` key at all** — assert on the raw body, not a decoded struct.
+- [ ] A row with a priced plan carries `amount` with an **uppercase** currency.
+- [ ] Empty result is `200` with `data` exactly `[]`.
+- [ ] Each of the **eight** statuses is accepted as a filter — table-driven over the constants, so a new status added to `models.go` without handler support fails the test.
+- [ ] `status=nonsense` and `plan=nonsense` each return `400` naming the parameter, not an empty `200`.
+- [ ] One deduplicated tenant lookup per page; no lookup for an empty page.
+- [ ] `ErrUnavailable` → `503` with no `data` key on the raw body.
+
+**Verify:** `cd services/marketplace-api && go test ./internal/handlers/platformadmin/... && go build ./...`
+
+**Commit:** `feat(platformadmin): GET /admin/billing/subscriptions cross-tenant (#284)`
+
+---
+
+### Task 4: add the amount to `/admin/billing/trials` (#328)
+
+**Files:** `internal/handlers/platformadmin/billing_trials.go`, `billing_trials_test.go`, `testdata/billing_trials_response.json` (only if values change)
+
+**Interfaces:**
+- Consumes: `resolveMoney` (Task 1).
+
+`/admin/billing/trials` shipped with no `amount` because a previous conclusion held that mark8ly has no prices. It does — see the spec's correction section. This task closes that.
+
+- [ ] `trial.ExpiringRow` already carries `Plan`, `Period` and `BillingCurrency`. It does **not** carry `PriceTier`. Check whether it needs to: `resolveMoney` takes a tier, and a PPP-tier trial would otherwise resolve against the developed table. If the tier is absent from `ExpiringRow`, add it to the row struct and the query's SELECT in `internal/billing/trial/expiring.go`, and extend that package's mapping test to assert it — the same test that pins the other five fields. **Report which you found.**
+- [ ] Add `amount` to the trial row wire shape via `resolveMoney`, omitted on `ok=false`.
+- [ ] Update the golden fixture **only if its values change**. Its current rows use `plan: "trial"`, which has no catalog price, so they should keep carrying no amount. If the fixture changes, say why in your report — an unexpected change means the resolver is pricing something it should not.
+
+**Tests:**
+
+- [ ] A trial row on a **priced** plan (`starter`/`studio`/`pro`) carries `amount` with an uppercase currency.
+- [ ] A trial row with `plan="trial"` carries **no `amount` key** — assert on the raw body.
+- [ ] **Cross-endpoint agreement:** the same plan/period/currency resolves to the same amount on `/admin/billing/trials` and `/admin/billing/subscriptions`. **Drive both handlers in one test over one fixture** — two separate assertions against the same catalog would pass even if the handlers resolved differently, which is the failure mode that let a structurally-zero counter ship in this codebase.
+
+**Verify:** `cd services/marketplace-api && go test ./internal/handlers/platformadmin/... ./internal/billing/trial/... && go build ./...` plus the trial integration suite if `expiring.go` changed.
+
+**Commit:** `feat(platformadmin): carry the catalog amount on billing trials rows (#328)`
+
+---
+
+## After the plan
+
+- [ ] `go build ./...` clean.
+- [ ] Unit suites green; the cross-tenant and trial integration suites green with `-p 1`.
+- [ ] `grep` confirms `pricing.MustGet` is not called anywhere under `internal/handlers/`.
+- [ ] Confirm both `main.go` sites are wired.
+- [ ] Comment on #284 with the delivered shape and the confirmed no-projection answer.
+- [ ] Comment on #328 recording that the amount is now carried, and that `plan="trial"` rows correctly have none.

--- a/docs/superpowers/specs/2026-08-24-admin-billing-subscriptions-design.md
+++ b/docs/superpowers/specs/2026-08-24-admin-billing-subscriptions-design.md
@@ -1,0 +1,115 @@
+# Admin Billing Subscriptions — Design
+
+**Issue:** #284, folding in #328. Part of the platform console integration series (#260), after #274, #275, #276, #277, #279, #282, #283, #285.
+
+**Goal:** A cross-tenant view of every subscription on the platform, with plan, status and price — and, in the same change, add the price to `/admin/billing/trials`, which shipped without one on a conclusion that turned out to be wrong.
+
+## The issue's flagged risk resolves: no projection is needed
+
+#284 warns that this "may need a **projection** rather than a query", because mark8ly's subscription surface is per-store and plans are Go descriptors rather than DB rows. It asks that the answer be recorded here rather than guessed at.
+
+**It is a query.** `store_subscriptions` carries everything the view needs as ordinary columns: `tenant_id`, `store_id`, `plan`, `status`, `subscription_period`, `billing_currency`, `price_tier`, `current_period_end`, `cancel_at_period_end`, `created_at`.
+
+Plans being Go descriptors affects only **prices**, and `internal/billing/pricing/catalog.go` supplies those, keyed by plan / period / currency with `price_tier` selecting the tier. So the endpoint is a plain paginated query, a per-row catalog lookup, and one batch tenant-name call — the same shape as #285.
+
+No slip. The console can plan on that.
+
+## The correction this folds in (#328)
+
+#285's spec states that mark8ly holds no prices, citing `PriceIDFor` returning a Stripe price ID, and `/admin/billing/trials` therefore ships with **no `amount`**, recording the issue's money criterion as unsatisfiable.
+
+That was wrong. `internal/billing/pricing/catalog.go` holds prices **in minor units**:
+
+```go
+type Amount struct {
+    Currency        string // lowercase ISO 4217
+    UnitAmountMinor int64  // cents, paise, sen, satang…
+    TaxBehavior     string
+}
+```
+
+with `LookupBaseline`, `LookupPPPOption`, `DevelopedCurrencyOptions` and `MustGet`. The earlier conclusion came from finding one plausible location and stopping, rather than searching for the authority — the same mistake that produced #282's broken counter, in a different direction: **concluding that something does not exist also requires a search, not a single lookup.**
+
+Nothing wrong shipped — no fabricated figure — but a trial row carries `plan`, `period` and `billing_currency`, so the conversion price was computable all along.
+
+**One resolver serves both endpoints**, so they cannot disagree about what a plan costs.
+
+## The money resolver
+
+```go
+// Resolve returns the catalog price for a subscription's plan, period and
+// currency, or ok=false when no price can be determined.
+func Resolve(plan, period, currency string, tier PriceTier) (Money, bool)
+```
+
+Three rules, each load-bearing:
+
+1. **Never call `pricing.MustGet`.** It panics on a miss (`panic("pricing: no amount for plan=…")`). A console read must not panic on a subscription whose plan/currency combination is absent from the catalog. Use `DevelopedCurrencyOptions` then `LookupPPPOption` — the same pair `MustGet` wraps, minus the panic.
+2. **Lowercase to look up, uppercase to serve.** Catalog keys are lowercase ISO 4217; `billing_currency` is `char(3)`; the surface's money contract is uppercase (`"GBP"`). Both conversions are explicit.
+3. **Omit, never fake.** When `billing_currency` is NULL, or the catalog has no entry, the row carries **no `amount` key** — not `null`, not `0`, not a guessed currency. This is the same discipline as #282's `501` for GMV and #285's absent amount: a number the system cannot determine is not reported as a number.
+
+`TaxBehavior` (`exclusive` for `aud`) is **not** carried. The console renders a price, not a tax-inclusive total, and shipping a field whose meaning changes the number without the console using it invites misreading. Recorded here so the omission is a decision rather than an oversight.
+
+## `GET /admin/billing/subscriptions`
+
+Query: `status`, `plan`, `page`, `limit` (default 50, clamp 500). Standard envelope; empty is `200` with `[]`. Ordered `created_at DESC`.
+
+```json
+{ "data": [
+    { "tenant_id": "<bare uuid>",
+      "tenant_name": "Acme Trading",
+      "store_id": "<bare uuid>",
+      "plan": "studio",
+      "period": "monthly",
+      "status": "active",
+      "amount": { "amount": 1500, "currency": "GBP" },
+      "current_period_end": "2026-09-24T00:00:00Z",
+      "cancel_at_period_end": false }
+  ],
+  "pagination": {"page": 1, "limit": 50, "total": 1} }
+```
+
+### All eight statuses, not four
+
+The issue names `trialing`, `active`, `past_due`, `expired` and says **do not invent a second vocabulary**. `internal/subscription/models.go` defines **eight**: those four plus `signup`, `payment_action_required`, `cancel_scheduled`, `store_closed`.
+
+Filtering to the issue's four would be inventing a second vocabulary — a truncated one — and would hide from the console exactly the subscriptions most needing an operator, `payment_action_required` among them. All eight are accepted as filters and returned as values.
+
+An unrecognised `status` or `plan` value is a `400 validation_error` naming the parameter, not a silently empty list. An empty list must mean "none match", never "you asked for something I did not understand".
+
+### Empty is `[]`, never `501`
+
+The issue is explicit: a product with **no billing concept** returns `501`; an empty list means "no subscriptions", which is a different and real answer. mark8ly has a billing concept, so this endpoint never returns `501`.
+
+Worth knowing: `store_subscriptions` is **empty in production today** (verified read-only against the replica — 4 tenants and 4 stores exist, but subscriptions are created by an explicit merchant-initiated call requiring a Stripe customer, and no merchant has entered that flow). So this endpoint will correctly serve `[]` until the first merchant subscribes. That is the real answer, and it is why `501` would be wrong.
+
+### Tenant names
+
+One batch call through `tenantdirectory`'s `IDs` filter, built in #285 — distinct ids per page, not per row. Unreachable platform-api yields `503`, consistent with the rest of the surface.
+
+## Architecture
+
+| Layer | Responsibility |
+|---|---|
+| `marketplace-api/internal/billing/pricing` | Already owns the catalog. Gains nothing. |
+| `marketplace-api/internal/subscription` | A cross-tenant list query. Estate-wide and unscoped by tenant, so it carries the same warning comment as `CountExpiring` — the platformadmin surface is HMAC-gated with no tenant context, and tenant-facing handlers must not call it. |
+| `marketplace-api/internal/handlers/platformadmin` | The money resolver (shared), both handlers' wire shapes. |
+
+The resolver lives beside the handlers rather than in `pricing`, because it encodes a *wire* decision (omit on miss, uppercase on the wire) rather than a pricing fact. `pricing` stays the catalog's owner.
+
+## Testing
+
+- Amount resolved correctly for a **developed**-tier row and a **PPP**-tier row.
+- Amount **omitted** when `billing_currency` is NULL, and when the catalog has no entry for the combination — proving `MustGet`'s panic path is unreachable from a request.
+- Lowercase lookup / uppercase wire asserted explicitly, with a currency where the difference is visible.
+- All eight statuses filterable; an unknown status is `400`, not an empty `200`.
+- Empty result is `200` with `[]`.
+- One deduplicated tenant lookup per page; no lookup at all for an empty page.
+- **Both endpoints agree on the amount** for the same plan/period/currency, asserted by driving both handlers in one test over one fixture — the pattern that caught the KPI/listing divergence in #285.
+- Golden fixture per endpoint, each proven by mutation against a field rename and a field addition.
+
+## Out of scope
+
+- Changing what `/admin/billing/trials` already ships beyond adding `amount`.
+- `TaxBehavior` on the wire (decided above).
+- Any change to the pricing catalog's contents. This design reads it.

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1927,6 +1927,7 @@ func main() {
 			estateCountsClient = estatecounts.NewClient(
 				cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 		}
+		platformSubscriptionRepo := subscription.NewRepository()
 		platformadmin.Register(r.Group("/api/v1/platform"), platformadmin.Deps{
 			DB:               conn,
 			Repo:             auditRepo,
@@ -1937,6 +1938,7 @@ func main() {
 			EstateCounts:     estateCountsClient,
 			Subscriptions:    platformadmin.SubscriptionsFunc(trial.CountExpiring),
 			Trials:           platformadmin.TrialListerFunc(trial.ListExpiring),
+			AllSubscriptions: platformadmin.SubscriptionListerFunc(platformSubscriptionRepo.ListAllSubscriptions),
 		})
 		storefront.RegisterStorefront(r.Group("/api/v1"), storefrontDeps)
 		storefront.RegisterMobileStorefrontSupport(r.Group("/api/v1"), storefrontSupportHandler, storefrontDeps.SlugCache, storefrontCustomerVerifier)
@@ -2023,6 +2025,7 @@ func main() {
 				estateCountsClient = estatecounts.NewClient(
 					cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 			}
+			platformSubscriptionRepo := subscription.NewRepository()
 			platformadmin.Register(engine.Group("/api/v1/platform"), platformadmin.Deps{
 				DB:               conn,
 				Repo:             auditRepo,
@@ -2033,6 +2036,7 @@ func main() {
 				EstateCounts:     estateCountsClient,
 				Subscriptions:    platformadmin.SubscriptionsFunc(trial.CountExpiring),
 				Trials:           platformadmin.TrialListerFunc(trial.ListExpiring),
+				AllSubscriptions: platformadmin.SubscriptionListerFunc(platformSubscriptionRepo.ListAllSubscriptions),
 			})
 			// Public Delhivery webhook receiver. Mounted on the admin
 			// engine because the merchant-configured URL points at the

--- a/services/marketplace-api/internal/billing/trial/expiring.go
+++ b/services/marketplace-api/internal/billing/trial/expiring.go
@@ -28,6 +28,7 @@ type ExpiringRow struct {
 	Plan             string
 	Period           string
 	BillingCurrency  *string
+	PriceTier        subscription.PriceTier
 	HasPaymentMethod bool
 	Status           string
 }
@@ -105,6 +106,7 @@ func ListExpiring(ctx context.Context, db *gorm.DB, asOf time.Time, window time.
 			Plan:             string(r.Plan),
 			Period:           string(r.SubscriptionPeriod),
 			BillingCurrency:  r.BillingCurrency,
+			PriceTier:        r.PriceTier,
 			HasPaymentMethod: r.HasDefaultPaymentMethod,
 			Status:           string(r.Status),
 		})

--- a/services/marketplace-api/internal/billing/trial/expiring_integration_test.go
+++ b/services/marketplace-api/internal/billing/trial/expiring_integration_test.go
@@ -253,6 +253,7 @@ func TestListExpiring_MapsAllFields(t *testing.T) {
 		r.Plan = subscription.PlanStudio
 		r.SubscriptionPeriod = subscription.PeriodAnnual
 		r.BillingCurrency = &currency
+		r.PriceTier = subscription.PriceTierPPP
 		r.HasDefaultPaymentMethod = true
 	})
 
@@ -284,6 +285,7 @@ func TestListExpiring_MapsAllFields(t *testing.T) {
 	assert.Equal(t, string(subscription.PeriodAnnual), row.Period)
 	require.NotNil(t, row.BillingCurrency)
 	assert.Equal(t, "GBP", *row.BillingCurrency)
+	assert.Equal(t, subscription.PriceTierPPP, row.PriceTier)
 	assert.True(t, row.HasPaymentMethod)
 	assert.Equal(t, string(subscription.StatusTrialing), row.Status)
 

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions.go
@@ -1,0 +1,267 @@
+package platformadmin
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
+)
+
+// SubscriptionLister is the subset of subscription.Repository this handler
+// needs, declared as an interface so the handler can be tested with a stub —
+// the same pattern TrialLister uses in billing_trials.go for
+// trial.ListExpiring.
+type SubscriptionLister interface {
+	ListAllSubscriptions(ctx context.Context, db *gorm.DB, f subscription.CrossTenantFilter) ([]subscription.StoreSubscription, int64, error)
+}
+
+// SubscriptionListerFunc adapts a bare function — such as a
+// subscription.Repository's ListAllSubscriptions method value — to the
+// SubscriptionLister interface.
+type SubscriptionListerFunc func(ctx context.Context, db *gorm.DB, f subscription.CrossTenantFilter) ([]subscription.StoreSubscription, int64, error)
+
+// ListAllSubscriptions implements SubscriptionLister by delegating to the
+// wrapped func.
+func (f SubscriptionListerFunc) ListAllSubscriptions(ctx context.Context, db *gorm.DB, filter subscription.CrossTenantFilter) ([]subscription.StoreSubscription, int64, error) {
+	return f(ctx, db, filter)
+}
+
+// defaultBillingSubscriptionsLimit and maxBillingSubscriptionsLimit mirror
+// subscription.DefaultCrossTenantPageSize/MaxCrossTenantPageSize so the
+// handler reports the SAME effective limit it sends downstream — the
+// repository clamps independently, but a stub in tests does not, so the
+// handler must clamp itself before the pagination envelope is built.
+const (
+	defaultBillingSubscriptionsLimit = subscription.DefaultCrossTenantPageSize
+	maxBillingSubscriptionsLimit     = subscription.MaxCrossTenantPageSize
+)
+
+// validSubscriptionStatuses is the exact eight subscription.Status* values
+// this surface accepts as a `status` filter. Deliberately NOT every
+// SubscriptionStatus constant: StatusPendingHardDelete and StatusHardDeleted
+// are internal-only lifecycle states the platform console does not filter
+// on. See billing_subscriptions_test.go's table-driven status test, which
+// loops over these same eight constants so a ninth accepted value added
+// here without a corresponding constant (or vice versa) fails loudly.
+var validSubscriptionStatuses = map[string]bool{
+	string(subscription.StatusSignup):                true,
+	string(subscription.StatusTrialing):              true,
+	string(subscription.StatusActive):                true,
+	string(subscription.StatusPastDue):               true,
+	string(subscription.StatusPaymentActionRequired): true,
+	string(subscription.StatusCancelScheduled):       true,
+	string(subscription.StatusExpired):               true,
+	string(subscription.StatusStoreClosed):           true,
+}
+
+// validSubscriptionPlans is the five subscription.Plan* values this surface
+// accepts as a `plan` filter — including trial and marketplace, which have
+// no catalog price but are still valid rows/filters.
+var validSubscriptionPlans = map[string]bool{
+	string(subscription.PlanTrial):       true,
+	string(subscription.PlanStarter):     true,
+	string(subscription.PlanStudio):      true,
+	string(subscription.PlanPro):         true,
+	string(subscription.PlanMarketplace): true,
+}
+
+// BillingSubscriptionsHandler serves the platform console's GET
+// /admin/billing/subscriptions (#284): a cross-tenant, filterable,
+// paginated view of every store's subscription.
+type BillingSubscriptionsHandler struct {
+	subs   SubscriptionLister
+	dir    TenantDirectory
+	db     *gorm.DB
+	logger *slog.Logger
+}
+
+// NewBillingSubscriptionsHandler constructs the handler. logger may be nil.
+func NewBillingSubscriptionsHandler(subs SubscriptionLister, dir TenantDirectory, db *gorm.DB, logger *slog.Logger) *BillingSubscriptionsHandler {
+	return &BillingSubscriptionsHandler{subs: subs, dir: dir, db: db, logger: logger}
+}
+
+// Register mounts the route on the supplied group.
+func (h *BillingSubscriptionsHandler) Register(g *gin.RouterGroup) {
+	g.GET("/admin/billing/subscriptions", h.list)
+}
+
+// subscriptionRow is the wire shape for one cross-tenant subscription.
+//
+// TenantName is omitempty: a tenant missing from the directory response gets
+// its name omitted rather than a blank string, matching trialRow above.
+// Amount is a *money with omitempty: resolveMoney returning ok=false (no
+// billing_currency, or a plan/period/currency the catalog has no price for —
+// trial and marketplace by design) means the row carries NO amount key at
+// all, never null and never a guessed 0. CurrentPeriodEnd is likewise
+// omitempty for a NULL column.
+type subscriptionRow struct {
+	TenantID          string `json:"tenant_id"`
+	TenantName        string `json:"tenant_name,omitempty"`
+	StoreID           string `json:"store_id"`
+	Plan              string `json:"plan"`
+	Period            string `json:"period"`
+	Status            string `json:"status"`
+	Amount            *money `json:"amount,omitempty"`
+	CurrentPeriodEnd  string `json:"current_period_end,omitempty"`
+	CancelAtPeriodEnd bool   `json:"cancel_at_period_end"`
+}
+
+type billingSubscriptionsResponse struct {
+	Data       []subscriptionRow `json:"data"`
+	Pagination pagination        `json:"pagination"`
+}
+
+func (h *BillingSubscriptionsHandler) list(c *gin.Context) {
+	status := strings.TrimSpace(c.Query("status"))
+	if status != "" && !validSubscriptionStatuses[status] {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "validation_error", "message": "status is invalid",
+		})
+		return
+	}
+
+	plan := strings.TrimSpace(c.Query("plan"))
+	if plan != "" && !validSubscriptionPlans[plan] {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "validation_error", "message": "plan is invalid",
+		})
+		return
+	}
+
+	page := parsePositiveIntDefault(c.Query("page"), 1)
+	limit := parsePositiveIntDefault(c.Query("limit"), defaultBillingSubscriptionsLimit)
+	if limit > maxBillingSubscriptionsLimit {
+		limit = maxBillingSubscriptionsLimit
+	}
+
+	ctx := c.Request.Context()
+	filter := subscription.CrossTenantFilter{Status: status, Plan: plan, Page: page, Limit: limit}
+
+	rows, total, err := h.subs.ListAllSubscriptions(ctx, h.db, filter)
+	if err != nil {
+		h.respondErr(c, err)
+		return
+	}
+
+	names, err := h.lookupTenantNames(ctx, rows)
+	if err != nil {
+		h.respondErr(c, err)
+		return
+	}
+
+	// Allocate before appending: a nil slice marshals to {}, which defeats a
+	// caller's `?? []`.
+	out := make([]subscriptionRow, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, toSubscriptionRow(r, names))
+	}
+
+	c.JSON(http.StatusOK, billingSubscriptionsResponse{
+		Data: out,
+		Pagination: pagination{
+			Page:  page,
+			Limit: limit,
+			Total: total,
+		},
+	})
+}
+
+// lookupTenantNames collects the DISTINCT tenant ids on the page and makes
+// exactly one tenantdirectory.List call for all of them, never one call per
+// row. A page with zero rows makes no call at all: an empty IDs slice would
+// otherwise match "no id filter" on the wire and pull back the whole
+// directory instead of nothing. Mirrors BillingTrialsHandler.lookupTenantNames.
+func (h *BillingSubscriptionsHandler) lookupTenantNames(ctx context.Context, rows []subscription.StoreSubscription) (map[string]string, error) {
+	names := map[string]string{}
+	if len(rows) == 0 {
+		return names, nil
+	}
+
+	seen := make(map[string]bool, len(rows))
+	ids := make([]string, 0, len(rows))
+	for _, r := range rows {
+		id := r.TenantID.String()
+		if !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+	}
+
+	res, err := h.dir.List(ctx, tenantdirectory.ListParams{IDs: ids, Limit: len(ids)})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, t := range res.Tenants {
+		names[t.ID] = t.Name
+	}
+
+	// A tenant id present on a subscription row but absent from the
+	// directory response means the two services disagree about which
+	// tenants exist. The row still appears (its name is simply omitted) but
+	// this is worth a log line, not silence.
+	for _, id := range ids {
+		if _, ok := names[id]; !ok && h.logger != nil {
+			h.logger.Warn("billing subscriptions: tenant missing from directory", "tenant_id", id)
+		}
+	}
+
+	return names, nil
+}
+
+func toSubscriptionRow(r subscription.StoreSubscription, names map[string]string) subscriptionRow {
+	tenantID := r.TenantID.String()
+	row := subscriptionRow{
+		TenantID:          tenantID,
+		TenantName:        names[tenantID],
+		StoreID:           r.StoreID.String(),
+		Plan:              string(r.Plan),
+		Period:            string(r.SubscriptionPeriod),
+		Status:            string(r.Status),
+		CancelAtPeriodEnd: r.CancelAtPeriodEnd,
+	}
+
+	if m, ok := resolveMoney(string(r.Plan), string(r.SubscriptionPeriod), r.BillingCurrency, r.PriceTier); ok {
+		row.Amount = &m
+	}
+
+	if r.CurrentPeriodEnd != nil {
+		row.CurrentPeriodEnd = r.CurrentPeriodEnd.UTC().Format(time.RFC3339)
+	}
+
+	return row
+}
+
+// respondErr maps a gather-stage error to the surface's stable codes,
+// mirroring respondErr in billing_trials.go and entities_tenants.go so this
+// surface stays internally consistent.
+//
+// tenantdirectory.ErrUnavailable (platform-api unreachable or 5xx) becomes
+// 503 upstream_unavailable. Any other error — including a bare
+// ListAllSubscriptions (DB) error, which wraps neither sentinel — becomes
+// 500 internal_error. Neither path ever returns a partial page.
+func (h *BillingSubscriptionsHandler) respondErr(c *gin.Context, err error) {
+	if errors.Is(err, tenantdirectory.ErrUnavailable) {
+		if h.logger != nil {
+			h.logger.Error("billing subscriptions upstream unavailable", "err", err)
+		}
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "upstream_unavailable", "message": "tenant directory is unavailable",
+		})
+		return
+	}
+	if h.logger != nil {
+		h.logger.Error("billing subscriptions", "err", err)
+	}
+	c.JSON(http.StatusInternalServerError, gin.H{
+		"error": "internal_error", "message": "could not list subscriptions",
+	})
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions.go
@@ -49,7 +49,7 @@ const (
 // meaning.
 //
 // This is an explicit DENY list rather than a hand-written allow list: a new
-// SubscriptionStatus added to models.go becomes filterable automatically,
+// SubscriptionStatus added to AllStatuses() becomes filterable automatically,
 // and hiding one requires editing this set deliberately. The reverse — a
 // hand-written allow list — silently leaves new states unfilterable, which
 // is how a console loses sight of a state nobody remembered to add.

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions.go
@@ -62,8 +62,14 @@ var consoleHiddenStatuses = map[subscription.SubscriptionStatus]bool{
 // minus consoleHiddenStatuses — every status this surface accepts as a
 // `status` filter. See billing_subscriptions_test.go's table-driven status
 // test, which loops over subscription.AllStatuses() so a status added to
-// models.go without a corresponding entry in consoleHiddenStatuses is
+// AllStatuses() without a corresponding entry in consoleHiddenStatuses is
 // accepted automatically, and hiding one is a deliberate, tested edit.
+// AllStatuses() itself is verified against the store_subscriptions.status
+// database CHECK constraint by
+// subscription.TestAllStatuses_MatchesDatabaseCheckConstraint, which is
+// what makes it trustworthy as "every status" in the first place — see that
+// test's doc comment for why the schema, not this package, is the
+// authority.
 var validSubscriptionStatuses = func() map[string]bool {
 	m := make(map[string]bool)
 	for _, status := range subscription.AllStatuses() {

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions.go
@@ -44,23 +44,35 @@ const (
 	maxBillingSubscriptionsLimit     = subscription.MaxCrossTenantPageSize
 )
 
-// validSubscriptionStatuses is the exact eight subscription.Status* values
-// this surface accepts as a `status` filter. Deliberately NOT every
-// SubscriptionStatus constant: StatusPendingHardDelete and StatusHardDeleted
-// are internal-only lifecycle states the platform console does not filter
-// on. See billing_subscriptions_test.go's table-driven status test, which
-// loops over these same eight constants so a ninth accepted value added
-// here without a corresponding constant (or vice versa) fails loudly.
-var validSubscriptionStatuses = map[string]bool{
-	string(subscription.StatusSignup):                true,
-	string(subscription.StatusTrialing):              true,
-	string(subscription.StatusActive):                true,
-	string(subscription.StatusPastDue):               true,
-	string(subscription.StatusPaymentActionRequired): true,
-	string(subscription.StatusCancelScheduled):       true,
-	string(subscription.StatusExpired):               true,
-	string(subscription.StatusStoreClosed):           true,
+// consoleHiddenStatuses are the lifecycle states the platform console does
+// not filter on. Both are internal-only teardown states with no operator
+// meaning.
+//
+// This is an explicit DENY list rather than a hand-written allow list: a new
+// SubscriptionStatus added to models.go becomes filterable automatically,
+// and hiding one requires editing this set deliberately. The reverse — a
+// hand-written allow list — silently leaves new states unfilterable, which
+// is how a console loses sight of a state nobody remembered to add.
+var consoleHiddenStatuses = map[subscription.SubscriptionStatus]bool{
+	subscription.StatusPendingHardDelete: true,
+	subscription.StatusHardDeleted:       true,
 }
+
+// validSubscriptionStatuses is derived from subscription.AllStatuses()
+// minus consoleHiddenStatuses — every status this surface accepts as a
+// `status` filter. See billing_subscriptions_test.go's table-driven status
+// test, which loops over subscription.AllStatuses() so a status added to
+// models.go without a corresponding entry in consoleHiddenStatuses is
+// accepted automatically, and hiding one is a deliberate, tested edit.
+var validSubscriptionStatuses = func() map[string]bool {
+	m := make(map[string]bool)
+	for _, status := range subscription.AllStatuses() {
+		if !consoleHiddenStatuses[status] {
+			m[string(status)] = true
+		}
+	}
+	return m
+}()
 
 // validSubscriptionPlans is the five subscription.Plan* values this surface
 // accepts as a `plan` filter — including trial and marketplace, which have

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions_hidden_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions_hidden_test.go
@@ -1,0 +1,19 @@
+package platformadmin
+
+import (
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConsoleHiddenStatusesIsExactlyTheTwoTeardownStates makes any change
+// to consoleHiddenStatuses a deliberate, visible edit: adding a status to
+// the deny list without updating this test fails it, and so does removing
+// one of the two teardown states from the deny list.
+func TestConsoleHiddenStatusesIsExactlyTheTwoTeardownStates(t *testing.T) {
+	require.Equal(t, map[subscription.SubscriptionStatus]bool{
+		subscription.StatusPendingHardDelete: true,
+		subscription.StatusHardDeleted:       true,
+	}, consoleHiddenStatuses)
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions_test.go
@@ -1,0 +1,425 @@
+package platformadmin_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
+)
+
+// stubSubscriptionLister records the params ListAllSubscriptions was called
+// with and returns canned rows/total, mirroring stubTrialLister in
+// billing_trials_test.go.
+type stubSubscriptionLister struct {
+	rows  []subscription.StoreSubscription
+	total int64
+	err   error
+
+	gotFilter subscription.CrossTenantFilter
+	calls     int
+}
+
+func (s *stubSubscriptionLister) ListAllSubscriptions(_ context.Context, _ *gorm.DB, f subscription.CrossTenantFilter) ([]subscription.StoreSubscription, int64, error) {
+	s.calls++
+	s.gotFilter = f
+	if s.err != nil {
+		return nil, 0, s.err
+	}
+	return s.rows, s.total, nil
+}
+
+// billingSubscriptionsRouter builds a router around the handler under test.
+func billingSubscriptionsRouter(t *testing.T, subs platformadmin.SubscriptionLister, dir platformadmin.TenantDirectory) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	platformadmin.NewBillingSubscriptionsHandler(subs, dir, nil, nil).Register(r.Group(""))
+	return r
+}
+
+var (
+	subsFixtureTenantA = uuid.MustParse("3f2504e0-4f89-11d3-9a0c-0305e82c3301")
+	subsFixtureStoreA  = uuid.MustParse("aaaaaaaa-4f89-11d3-9a0c-0305e82c3301")
+	subsFixtureTenantB = uuid.MustParse("3f2504e0-4f89-11d3-9a0c-0305e82c3302")
+	subsFixtureStoreB  = uuid.MustParse("bbbbbbbb-4f89-11d3-9a0c-0305e82c3302")
+)
+
+// billingSubscriptionsFixtureRows backs the golden fixture. Row A is a
+// priced, active subscription with a current_period_end. Row B is a `trial`
+// plan — the catalog has no trial price by design — with a NULL
+// current_period_end and a tenant absent from the directory stub, covering
+// every omission rule in one fixture.
+func billingSubscriptionsFixtureRows() []subscription.StoreSubscription {
+	gbp := "gbp"
+	periodEnd := time.Date(2026, 9, 24, 0, 0, 0, 0, time.UTC)
+	return []subscription.StoreSubscription{
+		{
+			TenantID:           subsFixtureTenantA,
+			StoreID:            subsFixtureStoreA,
+			Plan:               subscription.PlanStarter,
+			Status:             subscription.StatusActive,
+			SubscriptionPeriod: subscription.PeriodMonthly,
+			BillingCurrency:    &gbp,
+			PriceTier:          subscription.PriceTierDeveloped,
+			CurrentPeriodEnd:   &periodEnd,
+			CancelAtPeriodEnd:  false,
+		},
+		{
+			TenantID:           subsFixtureTenantB,
+			StoreID:            subsFixtureStoreB,
+			Plan:               subscription.PlanTrial,
+			Status:             subscription.StatusTrialing,
+			SubscriptionPeriod: subscription.PeriodMonthly,
+			BillingCurrency:    nil,
+			PriceTier:          subscription.PriceTierDeveloped,
+			CurrentPeriodEnd:   nil,
+			CancelAtPeriodEnd:  false,
+		},
+	}
+}
+
+// THE test. Real handler output compared to the committed contract.
+func TestBillingSubscriptionsMatchesContract(t *testing.T) {
+	rows := billingSubscriptionsFixtureRows()
+	subs := &stubSubscriptionLister{rows: rows, total: int64(len(rows))}
+	dir := &stubBillingDirectory{names: map[string]string{
+		subsFixtureTenantA.String(): "Acme Trading",
+		// subsFixtureTenantB deliberately absent from the directory.
+	}}
+
+	rec := httptest.NewRecorder()
+	billingSubscriptionsRouter(t, subs, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/subscriptions", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	want, err := os.ReadFile("testdata/billing_subscriptions_response.json")
+	require.NoError(t, err)
+	require.JSONEq(t, string(want), rec.Body.String())
+}
+
+// A row whose plan has no catalog price (plan="trial") must have no
+// `amount` key at all — asserted on the raw body, not a decoded struct,
+// since a decoded *money field would silently read back as nil either way.
+func TestBillingSubscriptionsUnpricedPlanOmitsAmountKey(t *testing.T) {
+	rows := []subscription.StoreSubscription{
+		{
+			TenantID:           subsFixtureTenantB,
+			StoreID:            subsFixtureStoreB,
+			Plan:               subscription.PlanTrial,
+			Status:             subscription.StatusTrialing,
+			SubscriptionPeriod: subscription.PeriodMonthly,
+			PriceTier:          subscription.PriceTierDeveloped,
+		},
+	}
+	subs := &stubSubscriptionLister{rows: rows, total: 1}
+	dir := &stubBillingDirectory{}
+
+	rec := httptest.NewRecorder()
+	billingSubscriptionsRouter(t, subs, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/subscriptions", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data []map[string]json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Data, 1)
+	_, hasAmount := body.Data[0]["amount"]
+	require.False(t, hasAmount, "a plan with no catalog price must carry no amount key at all")
+}
+
+// A row with a priced plan carries `amount` with an uppercase currency.
+func TestBillingSubscriptionsPricedPlanCarriesUppercaseCurrency(t *testing.T) {
+	gbp := "gbp"
+	rows := []subscription.StoreSubscription{
+		{
+			TenantID:           subsFixtureTenantA,
+			StoreID:            subsFixtureStoreA,
+			Plan:               subscription.PlanStarter,
+			Status:             subscription.StatusActive,
+			SubscriptionPeriod: subscription.PeriodMonthly,
+			BillingCurrency:    &gbp,
+			PriceTier:          subscription.PriceTierDeveloped,
+		},
+	}
+	subs := &stubSubscriptionLister{rows: rows, total: 1}
+	dir := &stubBillingDirectory{}
+
+	rec := httptest.NewRecorder()
+	billingSubscriptionsRouter(t, subs, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/subscriptions", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data []struct {
+			Amount *struct {
+				Amount   int64  `json:"amount"`
+				Currency string `json:"currency"`
+			} `json:"amount"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Data, 1)
+	require.NotNil(t, body.Data[0].Amount)
+	require.Equal(t, int64(1500), body.Data[0].Amount.Amount)
+	require.Equal(t, "GBP", body.Data[0].Amount.Currency)
+}
+
+func TestBillingSubscriptionsEmptyIsArray(t *testing.T) {
+	subs := &stubSubscriptionLister{rows: nil, total: 0}
+	dir := &stubBillingDirectory{}
+
+	rec := httptest.NewRecorder()
+	billingSubscriptionsRouter(t, subs, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/subscriptions", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"data":[],"pagination":{"page":1,"limit":50,"total":0}}`, rec.Body.String())
+
+	// A page with no rows must not call the directory at all.
+	require.Equal(t, 0, dir.calls, "empty page must not call tenantdirectory.List")
+}
+
+// Each of the eight subscription.Status* constants must be accepted as a
+// `status` filter. Table-driven over the constants themselves (not a
+// hand-copied list of strings) so a ninth status added to models.go without
+// handler support fails this test rather than being silently unsupported.
+func TestBillingSubscriptionsAcceptsAllEightStatuses(t *testing.T) {
+	statuses := []subscription.SubscriptionStatus{
+		subscription.StatusSignup,
+		subscription.StatusTrialing,
+		subscription.StatusActive,
+		subscription.StatusPastDue,
+		subscription.StatusPaymentActionRequired,
+		subscription.StatusCancelScheduled,
+		subscription.StatusExpired,
+		subscription.StatusStoreClosed,
+	}
+	require.Len(t, statuses, 8, "this test must cover exactly the eight platform-console-facing statuses")
+
+	for _, status := range statuses {
+		t.Run(string(status), func(t *testing.T) {
+			subs := &stubSubscriptionLister{}
+			dir := &stubBillingDirectory{}
+
+			rec := httptest.NewRecorder()
+			billingSubscriptionsRouter(t, subs, dir).ServeHTTP(rec, httptest.NewRequest(
+				http.MethodGet, "/admin/billing/subscriptions?status="+string(status), nil))
+
+			require.Equal(t, http.StatusOK, rec.Code, "status=%s must be accepted", status)
+			require.Equal(t, string(status), subs.gotFilter.Status)
+		})
+	}
+}
+
+// Each of the five subscription.Plan* constants must be accepted as a
+// `plan` filter.
+func TestBillingSubscriptionsAcceptsAllFivePlans(t *testing.T) {
+	plans := []subscription.SubscriptionPlan{
+		subscription.PlanTrial,
+		subscription.PlanStarter,
+		subscription.PlanStudio,
+		subscription.PlanPro,
+		subscription.PlanMarketplace,
+	}
+	require.Len(t, plans, 5)
+
+	for _, plan := range plans {
+		t.Run(string(plan), func(t *testing.T) {
+			subs := &stubSubscriptionLister{}
+			dir := &stubBillingDirectory{}
+
+			rec := httptest.NewRecorder()
+			billingSubscriptionsRouter(t, subs, dir).ServeHTTP(rec, httptest.NewRequest(
+				http.MethodGet, "/admin/billing/subscriptions?plan="+string(plan), nil))
+
+			require.Equal(t, http.StatusOK, rec.Code, "plan=%s must be accepted", plan)
+			require.Equal(t, string(plan), subs.gotFilter.Plan)
+		})
+	}
+}
+
+// An unrecognised status must be 400 validation_error, never an empty 200 —
+// an empty list must mean "none match", never "I did not understand you".
+func TestBillingSubscriptionsUnknownStatusIs400(t *testing.T) {
+	subs := &stubSubscriptionLister{}
+	dir := &stubBillingDirectory{}
+
+	rec := httptest.NewRecorder()
+	billingSubscriptionsRouter(t, subs, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/subscriptions?status=nonsense", nil))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "validation_error", errorCode(t, rec))
+	require.Equal(t, 0, subs.calls, "an unrecognised status must never reach the repository")
+}
+
+// An unrecognised plan must be 400 validation_error, likewise never an
+// empty 200.
+func TestBillingSubscriptionsUnknownPlanIs400(t *testing.T) {
+	subs := &stubSubscriptionLister{}
+	dir := &stubBillingDirectory{}
+
+	rec := httptest.NewRecorder()
+	billingSubscriptionsRouter(t, subs, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/subscriptions?plan=nonsense", nil))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "validation_error", errorCode(t, rec))
+	require.Equal(t, 0, subs.calls, "an unrecognised plan must never reach the repository")
+}
+
+// limit=9999 must clamp to 500 both on the value sent to the repository AND
+// on pagination.limit in the response — Task 2's repository test only
+// caught a clamp removal incidentally via slice capacity; here it is cheap
+// to assert both properly.
+func TestBillingSubscriptionsLimitClampsAndReportsEffectiveValue(t *testing.T) {
+	subs := &stubSubscriptionLister{}
+	dir := &stubBillingDirectory{}
+
+	rec := httptest.NewRecorder()
+	billingSubscriptionsRouter(t, subs, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/subscriptions?limit=9999", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, 500, subs.gotFilter.Limit, "limit must clamp to 500 before reaching the stub")
+
+	var body struct {
+		Pagination struct {
+			Limit int `json:"limit"`
+		} `json:"pagination"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, 500, body.Pagination.Limit, "pagination.limit must report the clamped, effective value")
+}
+
+// One tenant lookup for a page with several rows sharing a tenant — the
+// stub must be called exactly once and receive DEDUPLICATED ids, not one
+// call per row.
+func TestBillingSubscriptionsOneTenantLookupPerPageDeduplicated(t *testing.T) {
+	shared := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	other := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	rows := []subscription.StoreSubscription{
+		{TenantID: shared, StoreID: uuid.New(), Plan: subscription.PlanTrial, Status: subscription.StatusTrialing, SubscriptionPeriod: subscription.PeriodMonthly},
+		{TenantID: shared, StoreID: uuid.New(), Plan: subscription.PlanTrial, Status: subscription.StatusTrialing, SubscriptionPeriod: subscription.PeriodMonthly},
+		{TenantID: other, StoreID: uuid.New(), Plan: subscription.PlanTrial, Status: subscription.StatusTrialing, SubscriptionPeriod: subscription.PeriodMonthly},
+		{TenantID: shared, StoreID: uuid.New(), Plan: subscription.PlanTrial, Status: subscription.StatusTrialing, SubscriptionPeriod: subscription.PeriodMonthly},
+	}
+	subs := &stubSubscriptionLister{rows: rows, total: 4}
+	dir := &stubBillingDirectory{names: map[string]string{
+		shared.String(): "Shared Co", other.String(): "Other Co",
+	}}
+
+	rec := httptest.NewRecorder()
+	billingSubscriptionsRouter(t, subs, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/subscriptions", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, 1, dir.calls, "must make exactly one tenantdirectory.List call per page")
+	require.ElementsMatch(t, []string{shared.String(), other.String()}, dir.gotIDs, "ids sent upstream must be deduplicated")
+}
+
+// A tenant absent from the directory response omits tenant_name; the row
+// still appears.
+func TestBillingSubscriptionsMissingTenantOmitsName(t *testing.T) {
+	ghost := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	rows := []subscription.StoreSubscription{
+		{TenantID: ghost, StoreID: uuid.New(), Plan: subscription.PlanTrial, Status: subscription.StatusTrialing, SubscriptionPeriod: subscription.PeriodMonthly},
+	}
+	subs := &stubSubscriptionLister{rows: rows, total: 1}
+	dir := &stubBillingDirectory{names: map[string]string{}} // directory knows nothing
+
+	rec := httptest.NewRecorder()
+	billingSubscriptionsRouter(t, subs, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/subscriptions", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotContains(t, rec.Body.String(), "tenant_name", "a tenant missing from the directory must omit tenant_name entirely")
+
+	var body struct {
+		Data []struct {
+			TenantID string `json:"tenant_id"`
+			StoreID  string `json:"store_id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Data, 1, "the row must still appear even without a name")
+	require.Equal(t, ghost.String(), body.Data[0].TenantID)
+}
+
+func TestBillingSubscriptionsUpstreamUnavailableIs503NoDataKey(t *testing.T) {
+	rows := []subscription.StoreSubscription{
+		{TenantID: uuid.New(), StoreID: uuid.New(), Plan: subscription.PlanTrial, Status: subscription.StatusTrialing, SubscriptionPeriod: subscription.PeriodMonthly},
+	}
+	subs := &stubSubscriptionLister{rows: rows, total: 1}
+	dir := &stubBillingDirectory{err: tenantdirectory.ErrUnavailable}
+
+	rec := httptest.NewRecorder()
+	billingSubscriptionsRouter(t, subs, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/subscriptions", nil))
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "upstream_unavailable", errorCode(t, rec))
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	_, hasData := raw["data"]
+	require.False(t, hasData, "a 503 must never carry a data key — no partial result")
+}
+
+func TestBillingSubscriptionsListErrorIs500(t *testing.T) {
+	subs := &stubSubscriptionLister{err: errBoom}
+	dir := &stubBillingDirectory{}
+
+	rec := httptest.NewRecorder()
+	billingSubscriptionsRouter(t, subs, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/subscriptions", nil))
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Equal(t, "internal_error", errorCode(t, rec))
+}
+
+// Rows come back from ListAllSubscriptions already ordered (created_at
+// DESC, per the repository). The handler must preserve that order, not
+// resort it.
+func TestBillingSubscriptionsPreservesOrder(t *testing.T) {
+	rows := []subscription.StoreSubscription{
+		{TenantID: uuid.New(), StoreID: uuid.MustParse("00000000-0000-0000-0000-000000000001"), Plan: subscription.PlanTrial, Status: subscription.StatusTrialing, SubscriptionPeriod: subscription.PeriodMonthly},
+		{TenantID: uuid.New(), StoreID: uuid.MustParse("00000000-0000-0000-0000-000000000002"), Plan: subscription.PlanTrial, Status: subscription.StatusTrialing, SubscriptionPeriod: subscription.PeriodMonthly},
+		{TenantID: uuid.New(), StoreID: uuid.MustParse("00000000-0000-0000-0000-000000000003"), Plan: subscription.PlanTrial, Status: subscription.StatusTrialing, SubscriptionPeriod: subscription.PeriodMonthly},
+	}
+	subs := &stubSubscriptionLister{rows: rows, total: 3}
+	dir := &stubBillingDirectory{}
+
+	rec := httptest.NewRecorder()
+	billingSubscriptionsRouter(t, subs, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/subscriptions", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data []struct {
+			StoreID string `json:"store_id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Data, 3)
+	require.Equal(t, rows[0].StoreID.String(), body.Data[0].StoreID)
+	require.Equal(t, rows[1].StoreID.String(), body.Data[1].StoreID)
+	require.Equal(t, rows[2].StoreID.String(), body.Data[2].StoreID)
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions_test.go
@@ -195,24 +195,28 @@ func TestBillingSubscriptionsEmptyIsArray(t *testing.T) {
 	require.Equal(t, 0, dir.calls, "empty page must not call tenantdirectory.List")
 }
 
-// Each of the eight subscription.Status* constants must be accepted as a
-// `status` filter. Table-driven over the constants themselves (not a
-// hand-copied list of strings) so a ninth status added to models.go without
-// handler support fails this test rather than being silently unsupported.
-func TestBillingSubscriptionsAcceptsAllEightStatuses(t *testing.T) {
-	statuses := []subscription.SubscriptionStatus{
-		subscription.StatusSignup,
-		subscription.StatusTrialing,
-		subscription.StatusActive,
-		subscription.StatusPastDue,
-		subscription.StatusPaymentActionRequired,
-		subscription.StatusCancelScheduled,
-		subscription.StatusExpired,
-		subscription.StatusStoreClosed,
-	}
-	require.Len(t, statuses, 8, "this test must cover exactly the eight platform-console-facing statuses")
+// hiddenSubscriptionStatuses mirrors platformadmin's consoleHiddenStatuses
+// deny list for this black-box test. billing_subscriptions_hidden_test.go
+// (in-package) separately asserts the real consoleHiddenStatuses var
+// contains exactly these two, so this list cannot drift silently from the
+// handler's.
+var hiddenSubscriptionStatuses = map[subscription.SubscriptionStatus]bool{
+	subscription.StatusPendingHardDelete: true,
+	subscription.StatusHardDeleted:       true,
+}
+
+// Every subscription.AllStatuses() value must be accepted as a `status`
+// filter UNLESS it is in hiddenSubscriptionStatuses, in which case it must
+// be rejected with 400. Table-driven over the full enum (not a hand-copied
+// list of strings) so a new status added to models.go is automatically
+// exercised in both directions — accepted by default, or 400 only if
+// deliberately hidden.
+func TestBillingSubscriptionsStatusFilter(t *testing.T) {
+	statuses := subscription.AllStatuses()
+	require.NotEmpty(t, statuses, "this test must cover every SubscriptionStatus constant")
 
 	for _, status := range statuses {
+		status := status
 		t.Run(string(status), func(t *testing.T) {
 			subs := &stubSubscriptionLister{}
 			dir := &stubBillingDirectory{}
@@ -220,6 +224,12 @@ func TestBillingSubscriptionsAcceptsAllEightStatuses(t *testing.T) {
 			rec := httptest.NewRecorder()
 			billingSubscriptionsRouter(t, subs, dir).ServeHTTP(rec, httptest.NewRequest(
 				http.MethodGet, "/admin/billing/subscriptions?status="+string(status), nil))
+
+			if hiddenSubscriptionStatuses[status] {
+				require.Equal(t, http.StatusBadRequest, rec.Code, "status=%s must be rejected", status)
+				require.Equal(t, 0, subs.calls, "a hidden status must never reach the repository")
+				return
+			}
 
 			require.Equal(t, http.StatusOK, rec.Code, "status=%s must be accepted", status)
 			require.Equal(t, string(status), subs.gotFilter.Status)

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_trials.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_trials.go
@@ -45,13 +45,17 @@ const (
 // BillingTrialsHandler serves the platform console's GET
 // /admin/billing/trials (#285): trials about to expire, page by page.
 //
-// mark8ly holds no prices anywhere in this workspace — PriceIDFor returns a
-// Stripe price ID, not an amount — so the row deliberately carries no
-// `amount` key. And a trial cannot be in dunning: the dunning ladder selects
-// status IN (past_due, expired, store_closed), status is single-valued, and
-// a trialing row's status is 'trialing'. So no `dunning_state` key either.
-// Both are structural absences, not nulled-out fields — see billing_trials_
-// test.go for the raw-body assertions that pin this.
+// amount is resolved via the same resolveMoney helper
+// /admin/billing/subscriptions uses, so the two surfaces cannot disagree
+// about what a plan costs (#328). It is omitted, never null or zero, when
+// resolveMoney reports ok=false — which is the normal outcome for every row
+// on plan="trial": the catalog holds no Price objects for `trial` or
+// `marketplace` by design. A trial cannot be in dunning either: the dunning
+// ladder selects status IN (past_due, expired, store_closed), status is
+// single-valued, and a trialing row's status is 'trialing'. So no
+// `dunning_state` key. All three are structural absences, not nulled-out
+// fields — see billing_trials_test.go for the raw-body assertions that pin
+// this.
 type BillingTrialsHandler struct {
 	trials TrialLister
 	dir    TenantDirectory
@@ -88,7 +92,11 @@ func (h *BillingTrialsHandler) Register(g *gin.RouterGroup) {
 // gets its name omitted rather than a blank string — see list() for why
 // that disagreement is also logged. BillingCurrency is omitempty for the
 // same reason trial.ExpiringRow carries it as a pointer: a store that has
-// never taken a currency has none to report, not an empty one.
+// never taken a currency has none to report, not an empty one. Amount is a
+// *money with omitempty, mirroring subscriptionRow: resolveMoney returning
+// ok=false (no billing_currency, or a plan/period/currency the catalog has
+// no price for — trial and marketplace by design) means the row carries NO
+// amount key at all, never null and never a guessed 0.
 type trialRow struct {
 	TenantID            string  `json:"tenant_id"`
 	TenantName          string  `json:"tenant_name,omitempty"`
@@ -98,6 +106,7 @@ type trialRow struct {
 	Plan                string  `json:"plan"`
 	Period              string  `json:"period"`
 	BillingCurrency     *string `json:"billing_currency,omitempty"`
+	Amount              *money  `json:"amount,omitempty"`
 	PaymentMethodOnFile bool    `json:"payment_method_on_file"`
 	Status              string  `json:"status"`
 }
@@ -191,7 +200,7 @@ func (h *BillingTrialsHandler) lookupTenantNames(ctx context.Context, rows []tri
 }
 
 func toTrialRow(r trial.ExpiringRow, names map[string]string, asOf time.Time) trialRow {
-	return trialRow{
+	row := trialRow{
 		TenantID:      r.TenantID,
 		TenantName:    names[r.TenantID],
 		StoreID:       r.StoreID,
@@ -206,6 +215,12 @@ func toTrialRow(r trial.ExpiringRow, names map[string]string, asOf time.Time) tr
 		PaymentMethodOnFile: r.HasPaymentMethod,
 		Status:              r.Status,
 	}
+
+	if m, ok := resolveMoney(r.Plan, r.Period, r.BillingCurrency, r.PriceTier); ok {
+		row.Amount = &m
+	}
+
+	return row
 }
 
 // daysRemaining is computed from asOf — the SAME instant the query itself

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_trials_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_trials_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/estatecounts"
 	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
 	"github.com/mark8ly/marketplace-api/internal/onboardingfunnel"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
 	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
 )
 
@@ -321,10 +323,14 @@ func TestBillingTrialsListExpiringErrorIs500(t *testing.T) {
 	require.Equal(t, "internal_error", errorCode(t, rec))
 }
 
-// mark8ly holds no prices and a trial cannot be in dunning: no `amount` key,
-// no `dunning_state` key, ever — asserted on the raw body across every shape
-// this handler can produce (happy path, empty, and error).
-func TestBillingTrialsNeverCarriesAmountOrDunningState(t *testing.T) {
+// A trial cannot be in dunning: the dunning ladder never selects status
+// 'trialing', so no row ever carries a `dunning_state` key. amount is
+// asserted absent too, but only because billingTrialsFixtureRows uses
+// plan="trial" throughout, which the catalog excludes by design (#328) — see
+// TestBillingTrialsPricedPlanCarriesAmount and
+// TestBillingTrialsTrialPlanOmitsAmount below for the cases that pin amount
+// as conditional rather than categorically absent.
+func TestBillingTrialsNeverCarriesDunningState(t *testing.T) {
 	asOf := billingTrialsFixtureAsOf
 	rows := billingTrialsFixtureRows(asOf)
 
@@ -353,10 +359,222 @@ func TestBillingTrialsNeverCarriesAmountOrDunningState(t *testing.T) {
 			rec := httptest.NewRecorder()
 			billingTrialsRouter(t, tc.trials, tc.dir).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tc.request, nil))
 			body := rec.Body.String()
-			require.False(t, strings.Contains(body, "\"amount\""), "no amount key: mark8ly holds no prices")
+			require.False(t, strings.Contains(body, "\"amount\""), "fixture rows are all plan=trial, which the catalog excludes: no amount key")
 			require.False(t, strings.Contains(body, "\"dunning_state\""), "no dunning_state key: a trial cannot be in dunning")
 		})
 	}
+}
+
+// TestBillingTrialsPricedPlanCarriesAmount proves a trial row on a merchant-
+// chosen, PRICED plan (starter/studio/pro — reachable via
+// internal/subscription/service.go's other creation path) carries `amount`
+// with an uppercase currency, resolved through the same resolveMoney helper
+// /admin/billing/subscriptions uses (#328).
+func TestBillingTrialsPricedPlanCarriesAmount(t *testing.T) {
+	asOf := billingTrialsFixtureAsOf
+	gbp := "gbp"
+	rows := []trial.ExpiringRow{
+		{
+			TenantID:         "t-priced",
+			StoreID:          "s-priced",
+			TrialEndsAt:      asOf.Add(3 * 24 * time.Hour),
+			Plan:             "starter",
+			Period:           "monthly",
+			BillingCurrency:  &gbp,
+			PriceTier:        subscription.PriceTierDeveloped,
+			HasPaymentMethod: false,
+			Status:           "trialing",
+		},
+	}
+	trials := &stubTrialLister{rows: rows, total: 1}
+	dir := &stubBillingDirectory{}
+
+	rec := httptest.NewRecorder()
+	billingTrialsRouter(t, trials, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/trials", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data []struct {
+			Amount *struct {
+				Amount   int64  `json:"amount"`
+				Currency string `json:"currency"`
+			} `json:"amount"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Data, 1)
+	require.NotNil(t, body.Data[0].Amount, "a priced plan must carry an amount")
+	require.Equal(t, int64(1500), body.Data[0].Amount.Amount)
+	require.Equal(t, "GBP", body.Data[0].Amount.Currency, "currency on the wire must be uppercase")
+}
+
+// TestBillingTrialsTrialPlanOmitsAmount proves a row with plan="trial"
+// carries NO `amount` key at all — asserted on the raw JSON body, not a
+// decoded struct, so a null or a zeroed amount would also fail this. The
+// catalog has no Price objects for plan="trial" by design (#328's
+// correction): subscriptions reach plan="trial" by
+// internal/subscription/service.go:124, a path distinct from a merchant
+// choosing starter/studio/pro.
+func TestBillingTrialsTrialPlanOmitsAmount(t *testing.T) {
+	asOf := billingTrialsFixtureAsOf
+	gbp := "gbp"
+	rows := []trial.ExpiringRow{
+		{
+			TenantID:         "t-trial",
+			StoreID:          "s-trial",
+			TrialEndsAt:      asOf.Add(3 * 24 * time.Hour),
+			Plan:             "trial",
+			Period:           "monthly",
+			BillingCurrency:  &gbp,
+			PriceTier:        subscription.PriceTierDeveloped,
+			HasPaymentMethod: false,
+			Status:           "trialing",
+		},
+	}
+	trials := &stubTrialLister{rows: rows, total: 1}
+	dir := &stubBillingDirectory{}
+
+	rec := httptest.NewRecorder()
+	billingTrialsRouter(t, trials, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/trials", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotContains(t, rec.Body.String(), "\"amount\"",
+		"plan=trial has no catalog price; the row must omit the amount key entirely, not null it out")
+}
+
+// TestBillingTrialsPPPTierResolvesFromPPPTable proves a PPP-tier trial row
+// resolves from the PPP price table, not the developed one — the exact
+// failure mode #328 called out: guessing the tier wrong produces a
+// wrong-but-plausible number, the worst outcome available here.
+func TestBillingTrialsPPPTierResolvesFromPPPTable(t *testing.T) {
+	asOf := billingTrialsFixtureAsOf
+	inr := "inr"
+	rows := []trial.ExpiringRow{
+		{
+			TenantID:         "t-ppp",
+			StoreID:          "s-ppp",
+			TrialEndsAt:      asOf.Add(3 * 24 * time.Hour),
+			Plan:             "starter",
+			Period:           "monthly",
+			BillingCurrency:  &inr,
+			PriceTier:        subscription.PriceTierPPP,
+			HasPaymentMethod: false,
+			Status:           "trialing",
+		},
+	}
+	trials := &stubTrialLister{rows: rows, total: 1}
+	dir := &stubBillingDirectory{}
+
+	rec := httptest.NewRecorder()
+	billingTrialsRouter(t, trials, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/trials", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data []struct {
+			Amount *struct {
+				Amount   int64  `json:"amount"`
+				Currency string `json:"currency"`
+			} `json:"amount"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Data, 1)
+	require.NotNil(t, body.Data[0].Amount)
+	require.Equal(t, int64(99900), body.Data[0].Amount.Amount,
+		"PPP tier must resolve from the PPP table (99900), not the developed table")
+	require.Equal(t, "INR", body.Data[0].Amount.Currency)
+}
+
+// TestCrossEndpointAmountAgreement is the cross-endpoint invariant #328
+// exists to guarantee: the same plan/period/currency/tier resolves to the
+// SAME amount whether it is read through /admin/billing/trials or
+// /admin/billing/subscriptions. Both handlers are driven against ONE shared
+// row in this single test — two separate assertions against the same
+// catalog, each configured independently, would still pass even if the two
+// handlers resolved money differently, which is the failure mode that let a
+// structurally-zero counter ship in this codebase (#282) and the reasoning
+// #328 explicitly calls out for why one resolver must serve both endpoints.
+func TestCrossEndpointAmountAgreement(t *testing.T) {
+	asOf := billingTrialsFixtureAsOf
+	gbp := "gbp"
+	tenantID := uuid.MustParse("3f2504e0-4f89-11d3-9a0c-0305e82c3301")
+	storeID := uuid.MustParse("aaaaaaaa-4f89-11d3-9a0c-0305e82c3301")
+
+	// --- drive /admin/billing/trials ---
+	trialsRows := []trial.ExpiringRow{
+		{
+			TenantID:         tenantID.String(),
+			StoreID:          storeID.String(),
+			TrialEndsAt:      asOf.Add(3 * 24 * time.Hour),
+			Plan:             "starter",
+			Period:           "monthly",
+			BillingCurrency:  &gbp,
+			PriceTier:        subscription.PriceTierDeveloped,
+			HasPaymentMethod: false,
+			Status:           "trialing",
+		},
+	}
+	trials := &stubTrialLister{rows: trialsRows, total: 1}
+	trialsDir := &stubBillingDirectory{}
+	trialsRec := httptest.NewRecorder()
+	billingTrialsRouter(t, trials, trialsDir).ServeHTTP(trialsRec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/trials", nil))
+	require.Equal(t, http.StatusOK, trialsRec.Code)
+
+	var trialsBody struct {
+		Data []struct {
+			Amount *struct {
+				Amount   int64  `json:"amount"`
+				Currency string `json:"currency"`
+			} `json:"amount"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(trialsRec.Body.Bytes(), &trialsBody))
+	require.Len(t, trialsBody.Data, 1)
+	require.NotNil(t, trialsBody.Data[0].Amount)
+
+	// --- drive /admin/billing/subscriptions over the SAME plan/period/
+	// currency/tier ---
+	subsRows := []subscription.StoreSubscription{
+		{
+			TenantID:           tenantID,
+			StoreID:            storeID,
+			Plan:               subscription.PlanStarter,
+			Status:             subscription.StatusTrialing,
+			SubscriptionPeriod: subscription.PeriodMonthly,
+			BillingCurrency:    &gbp,
+			PriceTier:          subscription.PriceTierDeveloped,
+			CancelAtPeriodEnd:  false,
+		},
+	}
+	subs := &stubSubscriptionLister{rows: subsRows, total: 1}
+	subsDir := &stubBillingDirectory{}
+	subsRec := httptest.NewRecorder()
+	billingSubscriptionsRouter(t, subs, subsDir).ServeHTTP(subsRec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/subscriptions", nil))
+	require.Equal(t, http.StatusOK, subsRec.Code)
+
+	var subsBody struct {
+		Data []struct {
+			Amount *struct {
+				Amount   int64  `json:"amount"`
+				Currency string `json:"currency"`
+			} `json:"amount"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(subsRec.Body.Bytes(), &subsBody))
+	require.Len(t, subsBody.Data, 1)
+	require.NotNil(t, subsBody.Data[0].Amount)
+
+	require.Equal(t, subsBody.Data[0].Amount.Amount, trialsBody.Data[0].Amount.Amount,
+		"trials and subscriptions must agree on the resolved amount for the same plan/period/currency/tier")
+	require.Equal(t, subsBody.Data[0].Amount.Currency, trialsBody.Data[0].Amount.Currency,
+		"trials and subscriptions must agree on the resolved currency")
 }
 
 // The cross-endpoint invariant (#282's original defect): /admin/kpis's

--- a/services/marketplace-api/internal/handlers/platformadmin/money.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/money.go
@@ -1,0 +1,56 @@
+package platformadmin
+
+import (
+	"strings"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// money is the wire representation of a resolved subscription price.
+// Currency is always uppercase ISO 4217 on the wire.
+type money struct {
+	Amount   int64  `json:"amount"`
+	Currency string `json:"currency"`
+}
+
+// resolveMoney returns the catalog price for a subscription's plan, period
+// and currency, or ok=false when no price can be determined.
+//
+// ok=false is a normal outcome, not an error:
+//   - billing_currency is NULL (the merchant never chose one), or
+//   - the plan has no price at all — the catalog excludes `trial` and
+//     `marketplace` by design ("no Price objects"), or
+//   - the catalog has no entry for that plan/period/currency combination.
+//
+// Callers OMIT the amount key entirely in that case. Never null, never 0,
+// never a guessed currency: a number the system cannot determine must not
+// be reported as a number.
+//
+// Deliberately does NOT use pricing.MustGet, which panics on a miss. A
+// console read must not panic on an unpriced combination. This calls the
+// same two lookups MustGet wraps, minus the panic.
+func resolveMoney(plan, period string, billingCurrency *string, tier subscription.PriceTier) (money, bool) {
+	if billingCurrency == nil || strings.TrimSpace(*billingCurrency) == "" {
+		return money{}, false
+	}
+	// Catalog keys are lowercase ISO 4217; the column is char(3) of
+	// unspecified case; the wire contract is uppercase.
+	cur := strings.ToLower(strings.TrimSpace(*billingCurrency))
+
+	p, per := pricing.Plan(plan), pricing.Period(period)
+
+	if tier == subscription.PriceTierPPP {
+		if amt, ok := pricing.LookupPPPOption(p, per, cur); ok {
+			return money{Amount: amt.UnitAmountMinor, Currency: strings.ToUpper(amt.Currency)}, true
+		}
+		return money{}, false
+	}
+
+	if opts, ok := pricing.DevelopedCurrencyOptions(p, per); ok {
+		if amt, present := opts[cur]; present {
+			return money{Amount: amt.UnitAmountMinor, Currency: strings.ToUpper(amt.Currency)}, true
+		}
+	}
+	return money{}, false
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/money.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/money.go
@@ -48,7 +48,13 @@ func resolveMoney(plan, period string, billingCurrency *string, tier subscriptio
 	}
 
 	if opts, ok := pricing.DevelopedCurrencyOptions(p, per); ok {
-		if amt, present := opts[cur]; present {
+		// DevelopedCurrencyOptions' Options map is pre-populated with a
+		// zero-value Amount for every developed currency, even one the
+		// catalog has no price for (see catalog.go's init: opts[c] =
+		// byPeriod[c]). Map presence alone is not proof of a real price —
+		// require a non-empty Currency too, or a catalog gap silently
+		// resolves as amount=0.
+		if amt, present := opts[cur]; present && amt.Currency != "" {
 			return money{Amount: amt.UnitAmountMinor, Currency: strings.ToUpper(amt.Currency)}, true
 		}
 	}

--- a/services/marketplace-api/internal/handlers/platformadmin/money_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/money_test.go
@@ -1,0 +1,82 @@
+package platformadmin
+
+import (
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/stretchr/testify/require"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestResolveMoney_DevelopedTier(t *testing.T) {
+	m, ok := resolveMoney("starter", "monthly", strPtr("gbp"), subscription.PriceTierDeveloped)
+	require.True(t, ok)
+	require.Equal(t, money{Amount: 1500, Currency: "GBP"}, m)
+}
+
+func TestResolveMoney_PPPTier_DiffersFromDeveloped(t *testing.T) {
+	pppMoney, ok := resolveMoney("starter", "monthly", strPtr("inr"), subscription.PriceTierPPP)
+	require.True(t, ok)
+	require.Equal(t, money{Amount: 99900, Currency: "INR"}, pppMoney)
+
+	// inr is not a developed-tier currency, so use a developed price for the
+	// same plan/period to prove the PPP lookup didn't fall through to the
+	// developed table.
+	developedMoney, ok := resolveMoney("starter", "monthly", strPtr("usd"), subscription.PriceTierDeveloped)
+	require.True(t, ok)
+	require.NotEqual(t, pppMoney.Amount, developedMoney.Amount)
+}
+
+func TestResolveMoney_TrialPlanHasNoPrice(t *testing.T) {
+	_, ok := resolveMoney("trial", "monthly", strPtr("usd"), subscription.PriceTierDeveloped)
+	require.False(t, ok)
+}
+
+func TestResolveMoney_MarketplacePlanHasNoPrice(t *testing.T) {
+	_, ok := resolveMoney("marketplace", "monthly", strPtr("usd"), subscription.PriceTierDeveloped)
+	require.False(t, ok)
+}
+
+func TestResolveMoney_NilBillingCurrency(t *testing.T) {
+	_, ok := resolveMoney("starter", "monthly", nil, subscription.PriceTierDeveloped)
+	require.False(t, ok)
+}
+
+func TestResolveMoney_EmptyAndWhitespaceBillingCurrency(t *testing.T) {
+	_, ok := resolveMoney("starter", "monthly", strPtr(""), subscription.PriceTierDeveloped)
+	require.False(t, ok)
+
+	_, ok = resolveMoney("starter", "monthly", strPtr("   "), subscription.PriceTierDeveloped)
+	require.False(t, ok)
+}
+
+func TestResolveMoney_UppercaseCurrencyInputResolvesSameAsLowercase(t *testing.T) {
+	upper, ok := resolveMoney("starter", "monthly", strPtr("GBP"), subscription.PriceTierDeveloped)
+	require.True(t, ok)
+
+	lower, ok := resolveMoney("starter", "monthly", strPtr("gbp"), subscription.PriceTierDeveloped)
+	require.True(t, ok)
+
+	require.Equal(t, lower, upper)
+}
+
+func TestResolveMoney_UnknownCurrencyDoesNotPanic(t *testing.T) {
+	var m money
+	var ok bool
+	require.NotPanics(t, func() {
+		m, ok = resolveMoney("starter", "monthly", strPtr("zzz"), subscription.PriceTierDeveloped)
+	})
+	require.False(t, ok)
+	require.Equal(t, money{}, m)
+}
+
+func TestResolveMoney_UnknownPlanDoesNotPanic(t *testing.T) {
+	var m money
+	var ok bool
+	require.NotPanics(t, func() {
+		m, ok = resolveMoney("nonexistent", "monthly", strPtr("usd"), subscription.PriceTierDeveloped)
+	})
+	require.False(t, ok)
+	require.Equal(t, money{}, m)
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/money_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/money_test.go
@@ -3,6 +3,7 @@ package platformadmin
 import (
 	"testing"
 
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 	"github.com/stretchr/testify/require"
 )
@@ -69,6 +70,51 @@ func TestResolveMoney_UnknownCurrencyDoesNotPanic(t *testing.T) {
 	})
 	require.False(t, ok)
 	require.Equal(t, money{}, m)
+}
+
+// TestResolveMoney_ZeroValueCatalogEntryGuard pins the guard added to the
+// developed-tier branch of resolveMoney: `pricing.DevelopedCurrencyOptions`
+// pre-populates its Options map with a zero-value pricing.Amount for every
+// developed currency, even one the catalog has no price for (catalog.go's
+// init does `opts[c] = byPeriod[c]` unconditionally over all 7 currencies).
+// A plain `present` check on that map therefore cannot distinguish "no
+// price" from "zero-value placeholder present" — resolveMoney must also
+// require amt.Currency != "".
+//
+// Today every (plan, period) in developedAmounts populates all 7
+// currencies, so this gap is unreachable through resolveMoney itself
+// without editing the catalog (which this task explicitly forbids). This
+// test instead pins the guard's condition directly against the same
+// pricing.Amount zero value the real map would produce, so a regression
+// that drops the `amt.Currency != ""` check is caught without depending on
+// catalog contents.
+func TestResolveMoney_ZeroValueCatalogEntryGuard(t *testing.T) {
+	// isResolvable mirrors the exact condition in resolveMoney's
+	// developed-tier branch: `present && amt.Currency != ""`.
+	isResolvable := func(opts map[string]pricing.Amount, cur string) bool {
+		amt, present := opts[cur]
+		return present && amt.Currency != ""
+	}
+
+	// A catalog-populated entry (mirrors byPeriod[c] with a real price).
+	populated := map[string]pricing.Amount{
+		"gbp": {Currency: "gbp", UnitAmountMinor: 1500},
+	}
+	require.True(t, isResolvable(populated, "gbp"))
+
+	// A zero-value entry, exactly what `opts[c] = byPeriod[c]` produces
+	// when byPeriod has no key c: map lookup succeeds (present == true)
+	// but the Amount is the zero value.
+	withZeroValueEntry := map[string]pricing.Amount{
+		"nzd": {},
+	}
+	amt, present := withZeroValueEntry["nzd"]
+	require.True(t, present, "map lookup must report present for a zero-value entry, proving present alone is not sufficient")
+	require.Equal(t, pricing.Amount{}, amt)
+	require.False(t, isResolvable(withZeroValueEntry, "nzd"), "a zero-value catalog entry must not be treated as resolvable")
+
+	// A genuinely absent key must also be unresolvable.
+	require.False(t, isResolvable(populated, "nzd"))
 }
 
 func TestResolveMoney_UnknownPlanDoesNotPanic(t *testing.T) {

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -44,6 +44,11 @@ type Deps struct {
 	// to mount, matching the EstateCounts/Subscriptions/OnboardingFunnel
 	// pattern above.
 	Trials TrialLister
+
+	// AllSubscriptions serves /admin/billing/subscriptions (#284), alongside
+	// TenantDirectory above for the tenant-name lookup. Both must be
+	// non-nil for that route to mount, matching the Trials pattern above.
+	AllSubscriptions SubscriptionLister
 }
 
 // Register mounts the platform console's /admin/* surface behind
@@ -102,5 +107,9 @@ func Register(g *gin.RouterGroup, deps Deps) {
 
 	if deps.Trials != nil && deps.TenantDirectory != nil {
 		NewBillingTrialsHandler(deps.Trials, deps.TenantDirectory, deps.DB, nil, deps.Logger).Register(group)
+	}
+
+	if deps.AllSubscriptions != nil && deps.TenantDirectory != nil {
+		NewBillingSubscriptionsHandler(deps.AllSubscriptions, deps.TenantDirectory, deps.DB, deps.Logger).Register(group)
 	}
 }

--- a/services/marketplace-api/internal/handlers/platformadmin/testdata/billing_subscriptions_response.json
+++ b/services/marketplace-api/internal/handlers/platformadmin/testdata/billing_subscriptions_response.json
@@ -1,0 +1,24 @@
+{
+  "data": [
+    {
+      "tenant_id": "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+      "tenant_name": "Acme Trading",
+      "store_id": "aaaaaaaa-4f89-11d3-9a0c-0305e82c3301",
+      "plan": "starter",
+      "period": "monthly",
+      "status": "active",
+      "amount": {"amount": 1500, "currency": "GBP"},
+      "current_period_end": "2026-09-24T00:00:00Z",
+      "cancel_at_period_end": false
+    },
+    {
+      "tenant_id": "3f2504e0-4f89-11d3-9a0c-0305e82c3302",
+      "store_id": "bbbbbbbb-4f89-11d3-9a0c-0305e82c3302",
+      "plan": "trial",
+      "period": "monthly",
+      "status": "trialing",
+      "cancel_at_period_end": false
+    }
+  ],
+  "pagination": {"page": 1, "limit": 50, "total": 2}
+}

--- a/services/marketplace-api/internal/subscription/models.go
+++ b/services/marketplace-api/internal/subscription/models.go
@@ -29,8 +29,18 @@ func AllPublicPlans() []SubscriptionPlan {
 //
 // Single source for callers that must reason about the complete set. The
 // platform console's billing filter derives its accepted values from this
-// minus an explicit hidden set, so a new state added here becomes filterable
+// minus an explicit hidden set, so a status listed here becomes filterable
 // by default and hiding one is a deliberate act.
+//
+// Go cannot enumerate the constants of the SubscriptionStatus type, so this
+// slice is hand-maintained and does NOT automatically track new consts
+// added to the block below. What keeps it honest is
+// TestAllStatuses_MatchesDatabaseCheckConstraint
+// (status_check_constraint_integration_test.go), which verifies this list
+// against the store_subscriptions.status CHECK constraint — the one
+// mechanically-enforced "every valid status" set in the system. Add a new
+// status here (and to the const block) only alongside a migration that
+// updates that constraint, or the integration test fails.
 func AllStatuses() []SubscriptionStatus {
 	return []SubscriptionStatus{
 		StatusSignup,

--- a/services/marketplace-api/internal/subscription/models.go
+++ b/services/marketplace-api/internal/subscription/models.go
@@ -25,6 +25,27 @@ func AllPublicPlans() []SubscriptionPlan {
 	return []SubscriptionPlan{PlanTrial, PlanStarter, PlanStudio, PlanPro}
 }
 
+// AllStatuses returns every subscription lifecycle state.
+//
+// Single source for callers that must reason about the complete set. The
+// platform console's billing filter derives its accepted values from this
+// minus an explicit hidden set, so a new state added here becomes filterable
+// by default and hiding one is a deliberate act.
+func AllStatuses() []SubscriptionStatus {
+	return []SubscriptionStatus{
+		StatusSignup,
+		StatusTrialing,
+		StatusActive,
+		StatusPastDue,
+		StatusPaymentActionRequired,
+		StatusCancelScheduled,
+		StatusExpired,
+		StatusStoreClosed,
+		StatusPendingHardDelete,
+		StatusHardDeleted,
+	}
+}
+
 // SubscriptionStatus enumerates subscription lifecycle states (v2.3).
 // The state machine that gates transitions between these values lives in
 // P2 — this package only defines the enum itself.

--- a/services/marketplace-api/internal/subscription/planchange/cron_test.go
+++ b/services/marketplace-api/internal/subscription/planchange/cron_test.go
@@ -71,6 +71,9 @@ func (r *cronFakeSubRepo) FindPendingDowngradesReady(_ context.Context, _ *gorm.
 func (r *cronFakeSubRepo) CountStoresForPlanSlot(_ context.Context, _ *gorm.DB, _ uuid.UUID) (int, error) {
 	return 0, nil
 }
+func (r *cronFakeSubRepo) ListAllSubscriptions(_ context.Context, _ *gorm.DB, _ subscription.CrossTenantFilter) ([]subscription.StoreSubscription, int64, error) {
+	return nil, 0, nil
+}
 
 // recordingStripe wraps fakeStripe and records UpdateSubscription call params.
 type recordingStripe struct {

--- a/services/marketplace-api/internal/subscription/planchange/planchange_test.go
+++ b/services/marketplace-api/internal/subscription/planchange/planchange_test.go
@@ -72,6 +72,9 @@ func (r *fakeSubRepo) FindPendingDowngradesReady(_ context.Context, _ *gorm.DB, 
 func (r *fakeSubRepo) CountStoresForPlanSlot(_ context.Context, _ *gorm.DB, _ uuid.UUID) (int, error) {
 	return 0, nil
 }
+func (r *fakeSubRepo) ListAllSubscriptions(_ context.Context, _ *gorm.DB, _ subscription.CrossTenantFilter) ([]subscription.StoreSubscription, int64, error) {
+	return nil, 0, nil
+}
 
 // fixedClock returns a constant time for deterministic tests.
 type fixedClock struct{ t time.Time }

--- a/services/marketplace-api/internal/subscription/repository.go
+++ b/services/marketplace-api/internal/subscription/repository.go
@@ -74,7 +74,34 @@ type Repository interface {
 	// Caller scopes to tenant only — plan slots are tenant-wide. Soft-deleted
 	// stores within the 60-day restorable grace window also count toward the slot.
 	CountStoresForPlanSlot(ctx context.Context, db *gorm.DB, tenantID uuid.UUID) (int, error)
+
+	// ListAllSubscriptions returns a page of subscriptions across EVERY
+	// tenant, plus the unpaginated total.
+	//
+	// ESTATE-WIDE, deliberately unscoped by tenant: this serves the platform
+	// console's cross-tenant billing view, which is HMAC-gated on the
+	// platformadmin surface and has no tenant context at all. DO NOT call it
+	// from any tenant-facing handler — those must stay tenant-scoped like
+	// GetByStoreID.
+	ListAllSubscriptions(ctx context.Context, db *gorm.DB, f CrossTenantFilter) ([]StoreSubscription, int64, error)
 }
+
+// CrossTenantFilter narrows the estate-wide subscription listing served by
+// ListAllSubscriptions. Every field is optional — this is the platform
+// operator's view, not a tenant-scoped one.
+type CrossTenantFilter struct {
+	Status string
+	Plan   string
+	Page   int
+	Limit  int
+}
+
+// DefaultCrossTenantPageSize applies when the caller sends no limit.
+const DefaultCrossTenantPageSize = 50
+
+// MaxCrossTenantPageSize caps a page, mirroring the ceiling applied by the
+// platform-api tenant directory (see applyDirectoryFilter).
+const MaxCrossTenantPageSize = 500
 
 type gormRepository struct{}
 
@@ -247,4 +274,51 @@ func (gormRepository) CountStoresForPlanSlot(ctx context.Context, db *gorm.DB, t
 		return 0, fmt.Errorf("subscription: count stores for plan slot: %w", err)
 	}
 	return int(count), nil
+}
+
+// applyCrossTenantFilter builds the WHERE clause shared by the count and the
+// page query in ListAllSubscriptions, so the two can never drift apart.
+func applyCrossTenantFilter(q *gorm.DB, f CrossTenantFilter) *gorm.DB {
+	if f.Status != "" {
+		q = q.Where("status = ?", f.Status)
+	}
+	if f.Plan != "" {
+		q = q.Where("plan = ?", f.Plan)
+	}
+	return q
+}
+
+func (gormRepository) ListAllSubscriptions(ctx context.Context, db *gorm.DB, f CrossTenantFilter) ([]StoreSubscription, int64, error) {
+	var total int64
+	countQ := applyCrossTenantFilter(db.WithContext(ctx).Model(&StoreSubscription{}), f)
+	if err := countQ.Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("subscription: list all count: %w", err)
+	}
+
+	page := f.Page
+	if page <= 0 {
+		page = 1
+	}
+	limit := f.Limit
+	switch {
+	case limit <= 0:
+		limit = DefaultCrossTenantPageSize
+	case limit > MaxCrossTenantPageSize:
+		limit = MaxCrossTenantPageSize
+	}
+
+	// Allocate before Find: a nil slice marshals to {} downstream, which
+	// defeats a caller's `?? []`.
+	rows := make([]StoreSubscription, 0, limit)
+
+	pageQ := applyCrossTenantFilter(db.WithContext(ctx).Model(&StoreSubscription{}), f)
+	if err := pageQ.
+		Order("created_at DESC").
+		Offset((page - 1) * limit).
+		Limit(limit).
+		Find(&rows).Error; err != nil {
+		return nil, 0, fmt.Errorf("subscription: list all: %w", err)
+	}
+
+	return rows, total, nil
 }

--- a/services/marketplace-api/internal/subscription/repository_crosstenant_integration_test.go
+++ b/services/marketplace-api/internal/subscription/repository_crosstenant_integration_test.go
@@ -1,0 +1,244 @@
+//go:build integration
+
+package subscription_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedCrossTenantStore inserts a minimal stores row so a store_subscriptions
+// row referencing storeID satisfies store_subscriptions_store_id_fkey.
+// Mirrors internal/billing/trial/expiring_integration_test.go's helper.
+func seedCrossTenantStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
+	t.Helper()
+
+	slug := "xt-" + strings.ReplaceAll(storeID.String(), "-", "")[:20]
+
+	err := db.Exec(
+		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, encode(gen_random_bytes(32), 'hex'))`,
+		storeID, tenantID, slug, "Cross Tenant Store", "IE", "EUR", "Europe/Dublin", "active",
+	).Error
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM stores WHERE id = ?", storeID)
+	})
+}
+
+// seedCrossTenantRow seeds a stores row plus a store_subscriptions row that
+// references it, and registers cleanup for the subscription row.
+func seedCrossTenantRow(t *testing.T, db *gorm.DB, row subscription.StoreSubscription) subscription.StoreSubscription {
+	t.Helper()
+
+	if row.ID == uuid.Nil {
+		row.ID = uuid.New()
+	}
+	if row.TenantID == uuid.Nil {
+		row.TenantID = uuid.New()
+	}
+	if row.StoreID == uuid.Nil {
+		row.StoreID = uuid.New()
+	}
+	if row.StripeCustomerID == "" {
+		row.StripeCustomerID = "cus_xt_" + row.ID.String()
+	}
+	if row.Plan == "" {
+		row.Plan = subscription.PlanStarter
+	}
+	if row.Status == "" {
+		row.Status = subscription.StatusActive
+	}
+
+	seedCrossTenantStore(t, db, row.TenantID, row.StoreID)
+
+	require.NoError(t, db.Create(&row).Error)
+	t.Cleanup(func() {
+		db.Unscoped().Delete(&subscription.StoreSubscription{}, "id = ?", row.ID)
+	})
+	return row
+}
+
+// TestListAllSubscriptions_CrossesTenants proves the estate-wide behaviour
+// this method exists for: two rows belonging to two different tenants both
+// come back from a single unscoped call.
+func TestCrossTenantListAllSubscriptions_CrossesTenants(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	rowA := seedCrossTenantRow(t, db, subscription.StoreSubscription{})
+	rowB := seedCrossTenantRow(t, db, subscription.StoreSubscription{})
+	require.NotEqual(t, rowA.TenantID, rowB.TenantID, "rows must belong to two different tenants")
+
+	rows, total, err := repo.ListAllSubscriptions(context.Background(), db, subscription.CrossTenantFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), total)
+	require.Len(t, rows, 2)
+
+	tenants := map[uuid.UUID]bool{}
+	for _, r := range rows {
+		tenants[r.TenantID] = true
+	}
+	assert.True(t, tenants[rowA.TenantID], "expected rowA's tenant present")
+	assert.True(t, tenants[rowB.TenantID], "expected rowB's tenant present")
+}
+
+// TestListAllSubscriptions_StatusFilterNarrows proves Status narrows the
+// result set, and that an empty Status returns everything (the guard).
+func TestCrossTenantListAllSubscriptions_StatusFilterNarrows(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	seedCrossTenantRow(t, db, subscription.StoreSubscription{Status: subscription.StatusActive})
+	seedCrossTenantRow(t, db, subscription.StoreSubscription{Status: subscription.StatusTrialing})
+
+	rows, total, err := repo.ListAllSubscriptions(context.Background(), db, subscription.CrossTenantFilter{
+		Status: string(subscription.StatusActive),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	require.Len(t, rows, 1)
+	assert.Equal(t, subscription.StatusActive, rows[0].Status)
+
+	rows, total, err = repo.ListAllSubscriptions(context.Background(), db, subscription.CrossTenantFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), total)
+	assert.Len(t, rows, 2)
+}
+
+// TestListAllSubscriptions_PlanFilterNarrows proves Plan narrows the result
+// set, and that an empty Plan returns everything (the guard).
+func TestCrossTenantListAllSubscriptions_PlanFilterNarrows(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	seedCrossTenantRow(t, db, subscription.StoreSubscription{Plan: subscription.PlanStarter})
+	seedCrossTenantRow(t, db, subscription.StoreSubscription{Plan: subscription.PlanStudio})
+
+	rows, total, err := repo.ListAllSubscriptions(context.Background(), db, subscription.CrossTenantFilter{
+		Plan: string(subscription.PlanStudio),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	require.Len(t, rows, 1)
+	assert.Equal(t, subscription.PlanStudio, rows[0].Plan)
+
+	rows, total, err = repo.ListAllSubscriptions(context.Background(), db, subscription.CrossTenantFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), total)
+	assert.Len(t, rows, 2)
+}
+
+// TestListAllSubscriptions_FiltersCombineWithAND proves Status and Plan
+// combine as AND, rather than one replacing the other.
+func TestCrossTenantListAllSubscriptions_FiltersCombineWithAND(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	// Matches both.
+	match := seedCrossTenantRow(t, db, subscription.StoreSubscription{
+		Status: subscription.StatusActive,
+		Plan:   subscription.PlanStudio,
+	})
+	// Matches status only.
+	seedCrossTenantRow(t, db, subscription.StoreSubscription{
+		Status: subscription.StatusActive,
+		Plan:   subscription.PlanStarter,
+	})
+	// Matches plan only.
+	seedCrossTenantRow(t, db, subscription.StoreSubscription{
+		Status: subscription.StatusTrialing,
+		Plan:   subscription.PlanStudio,
+	})
+
+	rows, total, err := repo.ListAllSubscriptions(context.Background(), db, subscription.CrossTenantFilter{
+		Status: string(subscription.StatusActive),
+		Plan:   string(subscription.PlanStudio),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	require.Len(t, rows, 1)
+	assert.Equal(t, match.ID, rows[0].ID)
+}
+
+// TestListAllSubscriptions_OrderedCreatedAtDesc seeds three rows in an
+// insertion order that differs from their created_at ordering, and asserts
+// the listing comes back newest-first.
+func TestCrossTenantListAllSubscriptions_OrderedCreatedAtDesc(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rowOldest := seedCrossTenantRow(t, db, subscription.StoreSubscription{CreatedAt: base})
+	rowNewest := seedCrossTenantRow(t, db, subscription.StoreSubscription{CreatedAt: base.Add(48 * time.Hour)})
+	rowMiddle := seedCrossTenantRow(t, db, subscription.StoreSubscription{CreatedAt: base.Add(24 * time.Hour)})
+
+	rows, total, err := repo.ListAllSubscriptions(context.Background(), db, subscription.CrossTenantFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), total)
+	require.Len(t, rows, 3)
+
+	assert.Equal(t, rowNewest.ID, rows[0].ID)
+	assert.Equal(t, rowMiddle.ID, rows[1].ID)
+	assert.Equal(t, rowOldest.ID, rows[2].ID)
+}
+
+// TestListAllSubscriptions_Pagination proves Limit: 1 returns one row with
+// total equal to the full match count.
+func TestCrossTenantListAllSubscriptions_Pagination(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	seedCrossTenantRow(t, db, subscription.StoreSubscription{})
+	seedCrossTenantRow(t, db, subscription.StoreSubscription{})
+	seedCrossTenantRow(t, db, subscription.StoreSubscription{})
+
+	rows, total, err := repo.ListAllSubscriptions(context.Background(), db, subscription.CrossTenantFilter{
+		Page:  1,
+		Limit: 1,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), total)
+	assert.Len(t, rows, 1)
+}
+
+// TestListAllSubscriptions_LimitClampsTo500 proves a Limit above the ceiling
+// clamps to 500 and that the clamped value governs the returned page size.
+func TestCrossTenantListAllSubscriptions_LimitClampsTo500(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	seedCrossTenantRow(t, db, subscription.StoreSubscription{})
+
+	rows, total, err := repo.ListAllSubscriptions(context.Background(), db, subscription.CrossTenantFilter{
+		Limit: 9999,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	require.Len(t, rows, 1)
+	assert.LessOrEqual(t, cap(rows), 500)
+}
+
+// TestListAllSubscriptions_EmptyTableReturnsAllocatedEmptySlice proves an
+// empty table returns an allocated empty slice (not nil) and total=0.
+func TestCrossTenantListAllSubscriptions_EmptyTableReturnsAllocatedEmptySlice(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	repo := subscription.NewRepository()
+
+	rows, total, err := repo.ListAllSubscriptions(context.Background(), db, subscription.CrossTenantFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), total)
+	assert.NotNil(t, rows)
+	assert.Empty(t, rows)
+}

--- a/services/marketplace-api/internal/subscription/status_check_constraint_integration_test.go
+++ b/services/marketplace-api/internal/subscription/status_check_constraint_integration_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+
+package subscription_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// quotedLiteralRE matches single-quoted string literals inside a
+// pg_get_constraintdef() rendering of a CHECK ((status)::text = ANY
+// (ARRAY['a', 'b', ...]::text[])) constraint, e.g. 'past_due'.
+var quotedLiteralRE = regexp.MustCompile(`'([^']*)'`)
+
+// TestAllStatuses_MatchesDatabaseCheckConstraint is the test that makes
+// subscription.AllStatuses() trustworthy.
+//
+// Go cannot enumerate the constants of a type at runtime, so nothing in the
+// language can mechanically verify that AllStatuses() — a hand-written slice
+// — actually lists every SubscriptionStatus declared in the const block
+// above it. A twelfth status added to the const block alone compiles clean,
+// every existing test still passes, and the value is silently unfilterable
+// anywhere that derives from AllStatuses() (see
+// platformadmin/billing_subscriptions.go's validSubscriptionStatuses).
+//
+// The one thing in this system that DOES mechanically enumerate "every
+// valid status" is the database: store_subscriptions.status carries a CHECK
+// constraint listing the complete accepted set, enforced by Postgres on
+// every write. That constraint is the authoritative source of truth this
+// test verifies AllStatuses() against, in both directions — a value the
+// database accepts but Go doesn't know about, or a value Go claims but the
+// database would reject, both fail this test.
+func TestAllStatuses_MatchesDatabaseCheckConstraint(t *testing.T) {
+	db := testdb.NewTx(t)
+
+	var def string
+	err := db.Raw(`
+		SELECT pg_get_constraintdef(oid)
+		FROM pg_constraint
+		WHERE conrelid = 'store_subscriptions'::regclass
+		  AND contype = 'c'
+		  AND pg_get_constraintdef(oid) LIKE '%status%'
+	`).Scan(&def).Error
+	require.NoError(t, err)
+	require.NotEmpty(t, def, "expected a CHECK constraint on store_subscriptions mentioning status")
+
+	matches := quotedLiteralRE.FindAllStringSubmatch(def, -1)
+	require.NotEmpty(t, matches, "could not parse any quoted values out of constraint definition: %s", def)
+
+	dbStatuses := make([]string, 0, len(matches))
+	for _, m := range matches {
+		dbStatuses = append(dbStatuses, m[1])
+	}
+
+	goStatuses := make([]string, 0, len(subscription.AllStatuses()))
+	for _, s := range subscription.AllStatuses() {
+		goStatuses = append(goStatuses, string(s))
+	}
+
+	require.ElementsMatch(t, dbStatuses, goStatuses,
+		"subscription.AllStatuses() must match the store_subscriptions.status CHECK constraint exactly; "+
+			"constraint def was: %s", def)
+}


### PR DESCRIPTION
Closes #284 and #328. Part of the platform console integration series (#260).

**Two things, and the second was found while building the first.**

## 1. `GET /admin/billing/subscriptions`

Cross-tenant, filterable on status and plan, ordered newest-first.

```json
{ "tenant_id": "<bare>", "tenant_name": "Acme Trading", "store_id": "<bare>",
  "plan": "studio", "period": "monthly", "status": "active",
  "amount": {"amount": 1500, "currency": "GBP"},
  "current_period_end": "2026-09-24T00:00:00Z", "cancel_at_period_end": false }
```

**The issue's flagged risk resolves: it is a query, not a projection.** #284 warned this "may need a projection" because the subscription surface is per-store and plans are Go descriptors. Everything the view needs is an ordinary column on `store_subscriptions`; plans being descriptors affects only prices, which the catalog supplies. No slip — recorded on the issue as it asked.

## 2. The correction (#328) — `/admin/billing/trials` had no `amount`

#285's spec claimed mark8ly holds no prices, citing `PriceIDFor` returning a *Stripe price ID*. **It does hold them** — `internal/billing/pricing/catalog.go`, in minor units, keyed by plan/period/currency with developed and PPP tiers.

That claim came from finding one plausible location and stopping rather than searching. Nothing wrong shipped — no fabricated figure — but the conversion price was computable all along.

**One resolver now serves both endpoints**, so they cannot disagree about what a plan costs, and a test drives both handlers over one fixture to prove it.

## Decisions worth reviewing

**All eight console-facing statuses, via a deny list.** The issue named four; `models.go` defines **ten** — the eight plus two internal-only teardown states. The handler accepts `AllStatuses()` minus an explicit `consoleHiddenStatuses` set. A new status becomes filterable **automatically**; hiding one requires a deliberate, tested edit. A hand-written allow list would leave a new state silently unfilterable, which is how a console loses sight of something nobody remembered to add.

**`AllStatuses()` is verified against the database.** Go cannot enumerate a type's constants, so the `store_subscriptions.status` CHECK constraint — which Postgres enforces on every write — is the authority. An integration test asserts the two match in both directions. Stated limitation, in the code: this catches Go-vs-schema drift, not const-block-vs-slice drift in isolation.

**`amount` omitted, never faked.** No `billing_currency`, or no catalog entry, means no key — not `null`, not `0`. `plan="trial"` rows correctly carry none: the catalog excludes trial and marketplace by design. The resolver never calls `pricing.MustGet`, which **panics** on a miss.

**`400` on an unknown `status`/`plan` filter**, never an empty `200`. An empty list must mean "none match".

## Test plan

- [x] Money resolver: developed and PPP tiers; omission on NULL currency, unpriced plan, and unknown combination; `require.NotPanics` guarding against a future `MustGet` "simplification"
- [x] Uppercase currency on the wire, lowercase for lookup — asserted with a currency where the difference shows
- [x] Cross-tenant listing proven by mutation: tenant-scoping the query fails all seven cross-tenant tests
- [x] Filter guards proven: removing either empty-value guard fails tests; diverging the count filter from the page filter fails tests
- [x] Deny-set proven in both directions: an eleventh status is filterable automatically; adding it to the hidden set fails the exactly-two test
- [x] `AllStatuses()` vs the live CHECK constraint, bidirectional
- [x] Both endpoints agree on price, driven through both handlers in one test
- [x] Golden fixture per endpoint, each proven against a rename and a field addition
- [x] `limit=9999` clamps, asserted on **`pagination.limit`** and on the value reaching the repository
- [ ] Verify against production after deploy — note `store_subscriptions` is **empty**, so this will correctly serve `[]`

## Known, tracked, not addressed here

- **#323** — no test covers `main.go` wiring. For this endpoint a single-line deletion happens to fail compilation via an unused variable; a two-line deletion silently unmounts. Five instances now recorded there.
- **#317** — `store_subscriptions_store_id_fkey` fixture drift, plus an env-var split hiding failures behind a skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)