### PR TITLE
docs(platformadmin): correct two false claims in the /admin/health comments

### DIFF
--- a/services/marketplace-api/internal/handlers/platformadmin/health_checks.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/health_checks.go
@@ -101,9 +101,21 @@ func (s *dbHealthSource) StripeWebhooks(ctx context.Context, asOf time.Time) (St
 		return StripeWebhooksHealth{}, errNoDB
 	}
 	var out StripeWebhooksHealth
-	// All three metrics share `processed_at IS NULL`, so it is a WHERE:
-	// the table is never pruned, and the WHERE lets the partial indexes
-	// (swe_orphan_idx, swe_manual_review_idx, migration 000043) apply.
+	// All three metrics share `processed_at IS NULL`, so it is a WHERE
+	// rather than three FILTERs.
+	//
+	// It is NOT an index optimisation, despite the table never being
+	// pruned. Neither partial index on this table can serve this query:
+	// swe_orphan_idx is partial on `processed_at IS NULL AND store_id IS
+	// NULL AND manual_review_required = false` and swe_manual_review_idx on
+	// `manual_review_required = true` (migration 000043). A partial index is
+	// usable only when the query predicate IMPLIES the index predicate, and
+	// this predicate is strictly weaker than both, so Postgres still scans.
+	// If this ever needs to be cheap, it needs its own index on
+	// (received_at) WHERE processed_at IS NULL.
+	//
+	// Contrast the outbox query above, where outbox_unpublished_idx IS
+	// partial on exactly `published_at IS NULL` and does apply.
 	//
 	// Scoping manual_review_required to unprocessed rows also stops it
 	// being a one-way latch. Nothing ever sets the column back to false,

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -95,11 +95,13 @@ func Register(g *gin.RouterGroup, deps Deps) {
 	// Health needs only the DB, so it mounts alongside the surface itself
 	// rather than behind a nil-dependency guard like the client-backed
 	// routes below. The source's nil-DB guard (errNoDB -> `unknown`) is
-	// defensive only and is NOT reachable through Register: a nil DB also
-	// leaves NonceStore nil, so RequirePlatformAuth answers 503
-	// not_configured before any handler runs. The guard stays because the
-	// source is constructible directly, and a nil *gorm.DB would otherwise
-	// panic on WithContext.
+	// defensive: it is not reachable in the main.go wiring, because neither
+	// call site sets NonceStore, so a nil DB leaves it nil and
+	// RequirePlatformAuth answers 503 not_configured before any handler
+	// runs. It IS reachable by a caller that supplies its own NonceStore
+	// alongside a nil DB — Deps.NonceStore is exported and documented
+	// optional — and by anyone constructing the source directly, where a
+	// nil *gorm.DB would otherwise panic on WithContext.
 	NewHealthHandler(NewDBHealthSource(deps.DB), deps.Logger).Register(group)
 
 	if deps.TenantDirectory != nil {


### PR DESCRIPTION
Follow-up to #335. Comment-only — no behaviour changes, no test changes. Both were flagged in that PR's description as known issues left for review.

## 1. `health_checks.go` — a false index claim

The stripe comment said the `WHERE processed_at IS NULL` "lets the partial indexes (swe_orphan_idx, swe_manual_review_idx) apply". It does not. Per migration 000043 those indexes are partial on:

- `swe_orphan_idx`: `processed_at IS NULL AND store_id IS NULL AND manual_review_required = false`
- `swe_manual_review_idx`: `manual_review_required = true`

A partial index is usable only when the query predicate **implies** the index predicate. Ours (`processed_at IS NULL` alone) is strictly weaker than both, so Postgres still sequentially scans. The `WHERE` stays regardless — scoping `manual_review_required` to unprocessed rows is what stops it being a one-way latch — but the stated justification was wrong.

The comment now says what is true, and names the index this query would actually need: `(received_at) WHERE processed_at IS NULL`.

Worth noting why this one mattered: the **outbox** comment makes the same claim and is **accurate** (`outbox_unpublished_idx` is partial on exactly `published_at IS NULL`). A false claim sitting beside a true one is more credible, not less — which is precisely how a confident comment redirects the next reader away from looking.

## 2. `routes.go` — an overstated unreachability claim

Said the nil-DB guard is "NOT reachable through `Register`". True only because neither production call site sets `Deps.NonceStore` — and that field is exported and documented optional, so a caller supplying its own NonceStore alongside a nil DB *does* reach the guard.

Now scoped to "not reachable in the main.go wiring", and states the two paths that do reach it.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/handlers/platformadmin/` clean
- [x] `go test ./internal/handlers/platformadmin/` — ok
- [x] No non-comment lines changed (`git diff` is comment hunks only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)