### PR TITLE
feat(marketplace-api): mount the CSM migration fast-path review route and audit its decisions (#281)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -456,6 +456,11 @@ func main() {
 	// brandingSeeder is non-nil only when MARKETPLACE_API_ENABLE_TEST_ROUTES=true.
 	// Declared at func scope so the later route-mount block can see it.
 	var brandingSeeder *testroutes.BrandingSeeder
+	// migrationHandler is constructed in the admin wiring branch but its
+	// CSM-review route is mounted on the /internal group inside both
+	// engine-switch cases below, so declare it at outer scope (same
+	// reason as brandingSeeder above).
+	var migrationHandler *migration.Handler
 	// downgradeCron is non-nil only when STRIPE_BILLING_SECRET_KEY is set.
 	// Declared at func scope so the cron-start block below the admin-mode
 	// block can reference it.
@@ -940,7 +945,7 @@ func main() {
 
 		// P5 — Migration fast-path submit handler.
 		migrationRepo := migration.NewRepository(conn)
-		migrationHandler := migration.NewHandler(migrationRepo, migration.NoOpValidator{}, log)
+		migrationHandler = migration.NewHandler(migrationRepo, migration.NoOpValidator{}, log).WithAudit(auditEmitter)
 
 		// P8 — Arbitrage appeal handler (§18.8.1).
 		arbitrageAppealSvc := arbitrage.NewAppealService(conn, arbitrage.NoOpPublisher{}, arbitrage.NopPIILogger{})
@@ -1970,6 +1975,13 @@ func main() {
 		// handed off to a human. Same /internal namespace + same shared
 		// secret; the slm-router pod carries it via SLM_ROUTER_INTERNAL_AUTH.
 		ticketInternalHandler.RegisterRoutes(r.Group("/internal"))
+		// CSM fast-path review action — POST /internal/csm/migration-fast-path/
+		// :id/review. Was implemented and tested but never mounted (#281);
+		// mounted here and on the mode.Admin engine below via the same
+		// RegisterInternalRoutes method so the two engines can't drift (#323).
+		if migrationHandler != nil {
+			migrationHandler.RegisterInternalRoutes(r.Group("/internal"), cfg.InternalAuthSecret)
+		}
 		// Cross-service audit ingest — auth-bff posts login/logout,
 		// platform-api posts staff invite/accept/revoke. Mounted on the
 		// existing /internal namespace gated by X-Internal-Auth.
@@ -2077,6 +2089,13 @@ func main() {
 			// service 404'd it — register on the admin engine (the
 			// dashboard that owns tickets).
 			ticketInternalHandler.RegisterRoutes(engine.Group("/internal"))
+			// CSM fast-path review action — mirrors the mode.Both mount
+			// above via the same RegisterInternalRoutes method, so
+			// MODE=admin (production) and local mode.Both dev never drift
+			// on this route (#281, #323).
+			if migrationHandler != nil {
+				migrationHandler.RegisterInternalRoutes(engine.Group("/internal"), cfg.InternalAuthSecret)
+			}
 			// Audit ingest is admin-only because the audit_logs read
 			// endpoint also lives on the admin engine — keeping write
 			// + read on the same pod simplifies ops and keeps the

--- a/services/marketplace-api/internal/billing/migration/handler.go
+++ b/services/marketplace-api/internal/billing/migration/handler.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/auth"
 )
 
 // PriorPlatformValidator is the WHOIS-age check interface. P7 will ship a
@@ -31,8 +34,8 @@ func (NoOpValidator) ValidateWhoisAge(context.Context, string, int) error { retu
 // substitute a fake without importing gorm.
 type reviewStore interface {
 	CreatePending(ctx context.Context, in CreatePendingInput) (*Review, error)
-	Approve(ctx context.Context, id, reviewerID uuid.UUID, notes string) error
-	Reject(ctx context.Context, id, reviewerID uuid.UUID, notes string) error
+	Approve(ctx context.Context, id, reviewerID uuid.UUID, notes string) (*Review, error)
+	Reject(ctx context.Context, id, reviewerID uuid.UUID, notes string) (*Review, error)
 }
 
 // Handler exposes the fast-path submit and CSM review endpoints.
@@ -40,6 +43,7 @@ type Handler struct {
 	repo      reviewStore
 	validator PriorPlatformValidator
 	logger    *slog.Logger
+	audit     *audit.Emitter // optional — nil-safe, see WithAudit
 }
 
 // NewHandler constructs a Handler. If v is nil the NoOpValidator is used.
@@ -52,6 +56,24 @@ func NewHandler(repo reviewStore, v PriorPlatformValidator, logger *slog.Logger)
 		logger = slog.Default()
 	}
 	return &Handler{repo: repo, validator: v, logger: logger}
+}
+
+// WithAudit attaches an audit emitter so approve/reject decisions are
+// recorded in the audit log. Omitting this call leaves h.audit nil, which
+// audit.Emitter.Emit tolerates (nil-receiver no-op) — safe for tests and
+// opted-out wiring.
+func (h *Handler) WithAudit(e *audit.Emitter) *Handler {
+	h.audit = e
+	return h
+}
+
+// RegisterInternalRoutes mounts the CSM review route behind
+// auth.HeaderTrustAuth on the supplied /internal group, so the full path is
+// POST /internal/csm/migration-fast-path/:id/review. Call this once per
+// engine (mode.Both and mode.Admin both mount an /internal group) so the
+// route is never present on one engine and missing on the other (#323).
+func (h *Handler) RegisterInternalRoutes(g *gin.RouterGroup, internalSecret string) {
+	g.POST("/csm/migration-fast-path/:id/review", auth.HeaderTrustAuth(internalSecret), h.Review)
 }
 
 type submitRequest struct {
@@ -122,7 +144,7 @@ type reviewRequest struct {
 // Review handles POST /internal/csm/migration-fast-path/:id/review. The route
 // is mounted behind auth.HeaderTrustAuth so only internal callers (CSM tooling)
 // reach it. The CSM's user_id is set on the gin context by that middleware via
-// the X-User-Id trust header. Route wiring is deferred to Task 15.
+// the X-User-Id trust header. Mounted via RegisterInternalRoutes.
 func (h *Handler) Review(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
@@ -141,12 +163,15 @@ func (h *Handler) Review(c *gin.Context) {
 		return
 	}
 
-	var repoErr error
+	var (
+		review  *Review
+		repoErr error
+	)
 	switch req.Decision {
 	case "approve":
-		repoErr = h.repo.Approve(c.Request.Context(), id, reviewerID, req.Notes)
+		review, repoErr = h.repo.Approve(c.Request.Context(), id, reviewerID, req.Notes)
 	case "reject":
-		repoErr = h.repo.Reject(c.Request.Context(), id, reviewerID, req.Notes)
+		review, repoErr = h.repo.Reject(c.Request.Context(), id, reviewerID, req.Notes)
 	}
 
 	switch {
@@ -161,6 +186,29 @@ func (h *Handler) Review(c *gin.Context) {
 		return
 	}
 
+	statusMap := map[string]string{
+		"approve": "approved",
+		"reject":  "rejected",
+	}
+
+	// The CSM caller addresses the review by id alone and need not send a
+	// tenant header — audit.Emit's gin-context fallback for TenantID/StoreID
+	// cannot be relied on here (#310: an event with no tenant is silently
+	// dropped, not written with a NULL tenant). Set both explicitly from the
+	// review row the repository just handed back.
+	h.audit.Emit(c, audit.Event{
+		Action:       "migration_fast_path.review_" + statusMap[req.Decision],
+		ResourceType: "migration_fast_path_review",
+		ResourceID:   id.String(),
+		TenantID:     review.TenantID,
+		StoreID:      review.StoreID,
+		Metadata: map[string]any{
+			"decision":    req.Decision,
+			"reviewer_id": reviewerID.String(),
+			"notes":       req.Notes,
+		},
+	})
+
 	// TODO: migration fast-path approval/rejection emails land when the email
 	// package and StoreSubscription.email column exist (deferred from P5 scope).
 	h.logger.Info("migration fast-path decided; email deferred",
@@ -168,9 +216,5 @@ func (h *Handler) Review(c *gin.Context) {
 		"decision", req.Decision,
 		"reviewer_id", reviewerID.String())
 
-	statusMap := map[string]string{
-		"approve": "approved",
-		"reject":  "rejected",
-	}
 	c.JSON(http.StatusOK, gin.H{"status": statusMap[req.Decision]})
 }

--- a/services/marketplace-api/internal/billing/migration/handler_test.go
+++ b/services/marketplace-api/internal/billing/migration/handler_test.go
@@ -4,15 +4,20 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
+	"github.com/mark8ly/marketplace-api/internal/audit"
 	"github.com/mark8ly/marketplace-api/internal/billing/migration"
 )
 
@@ -22,22 +27,36 @@ import (
 
 // fakeReviewStore is a test double for the reviewStore interface.
 type fakeReviewStore struct {
-	createResult *migration.Review
-	createErr    error
-	approveErr   error
-	rejectErr    error
+	createResult  *migration.Review
+	createErr     error
+	approveResult *migration.Review
+	approveErr    error
+	rejectResult  *migration.Review
+	rejectErr     error
 }
 
 func (f *fakeReviewStore) CreatePending(_ context.Context, _ migration.CreatePendingInput) (*migration.Review, error) {
 	return f.createResult, f.createErr
 }
 
-func (f *fakeReviewStore) Approve(_ context.Context, _, _ uuid.UUID, _ string) error {
-	return f.approveErr
+func (f *fakeReviewStore) Approve(_ context.Context, id, _ uuid.UUID, _ string) (*migration.Review, error) {
+	if f.approveErr != nil {
+		return nil, f.approveErr
+	}
+	if f.approveResult != nil {
+		return f.approveResult, nil
+	}
+	return &migration.Review{ID: id, TenantID: uuid.MustParse(validTenantID), StoreID: uuid.MustParse(validStoreID)}, nil
 }
 
-func (f *fakeReviewStore) Reject(_ context.Context, _, _ uuid.UUID, _ string) error {
-	return f.rejectErr
+func (f *fakeReviewStore) Reject(_ context.Context, id, _ uuid.UUID, _ string) (*migration.Review, error) {
+	if f.rejectErr != nil {
+		return nil, f.rejectErr
+	}
+	if f.rejectResult != nil {
+		return f.rejectResult, nil
+	}
+	return &migration.Review{ID: id, TenantID: uuid.MustParse(validTenantID), StoreID: uuid.MustParse(validStoreID)}, nil
 }
 
 // fakeValidator is a test double for PriorPlatformValidator.
@@ -265,4 +284,302 @@ func TestReview_MissingReviewer_Returns401(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 	resp := parseJSON(t, w)
 	assert.Equal(t, "missing_reviewer", resp["error"])
+}
+
+// ---------------------------------------------------------------------------
+// RegisterInternalRoutes tests (#281 — the route was implemented but never
+// mounted; these pin the mount itself, not just the handler in isolation).
+// ---------------------------------------------------------------------------
+
+const internalSecret = "test-internal-secret"
+
+// recordingAuditRepo is a stub audit.Repository that records every entry
+// handed to Create, so tests can prove an event was (or was not) enqueued
+// without a database. Guarded by a mutex — the emitter writes from a worker
+// goroutine.
+type recordingAuditRepo struct {
+	mu      sync.Mutex
+	created []audit.Entry
+}
+
+func (r *recordingAuditRepo) Create(_ context.Context, _ *gorm.DB, e *audit.Entry) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.created = append(r.created, *e)
+	return nil
+}
+
+func (r *recordingAuditRepo) List(context.Context, *gorm.DB, audit.ListFilter) (audit.ListResult, error) {
+	return audit.ListResult{}, nil
+}
+
+func (r *recordingAuditRepo) Stream(context.Context, *gorm.DB, audit.ListFilter, func(*audit.Entry) error) error {
+	return nil
+}
+
+func (r *recordingAuditRepo) ListPlatform(context.Context, *gorm.DB, audit.PlatformListFilter) (audit.ListResult, error) {
+	return audit.ListResult{}, nil
+}
+
+func (r *recordingAuditRepo) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.created)
+}
+
+func (r *recordingAuditRepo) first() audit.Entry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.created[0]
+}
+
+func newTestEmitter(t *testing.T, repo audit.Repository) *audit.Emitter {
+	t.Helper()
+	em := audit.NewEmitter(audit.EmitterConfig{
+		Repo:   repo,
+		Logger: slog.New(slog.NewTextHandler(httptest.NewRecorder().Body, nil)),
+	})
+	t.Cleanup(func() { em.Stop(context.Background()) })
+	return em
+}
+
+// waitForAuditWrite polls the recording repo briefly — Emit is async
+// fire-and-forget, so the write may land a beat after the HTTP response.
+func waitForAuditWrite(t *testing.T, repo *recordingAuditRepo, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if repo.count() >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.GreaterOrEqual(t, repo.count(), want, "audit event was not written in time")
+}
+
+// newInternalRouter builds a router with the route mounted exactly as
+// production does — via RegisterInternalRoutes, behind auth.HeaderTrustAuth
+// — rather than binding Review directly. This is what proves the route is
+// actually reachable end to end, not just that the handler method works in
+// isolation.
+func newInternalRouter(store *fakeReviewStore, em *audit.Emitter) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h := migration.NewHandler(store, nil, nil)
+	if em != nil {
+		h.WithAudit(em)
+	}
+	h.RegisterInternalRoutes(r.Group("/internal"), internalSecret)
+	return r
+}
+
+func doInternalPost(t *testing.T, r *gin.Engine, path string, body any, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func validInternalHeaders() map[string]string {
+	return map[string]string{
+		"X-Internal-Auth": internalSecret,
+		"X-User-Id":       validUserID,
+		"X-Tenant-Id":     validTenantID, // HeaderTrustAuth requires this present; CSM doesn't need it to be the review's real tenant.
+	}
+}
+
+// TestRegisterInternalRoutes_MountsExpectedPath pins requirement 1: the
+// route is registered at POST /internal/csm/migration-fast-path/:id/review
+// by RegisterInternalRoutes, not hand-wired at each call site.
+func TestRegisterInternalRoutes_MountsExpectedPath(t *testing.T) {
+	store := &fakeReviewStore{}
+	r := newInternalRouter(store, nil)
+	w := doInternalPost(t, r, "/internal/csm/migration-fast-path/"+validReviewID+"/review", map[string]any{
+		"decision": "approve",
+		"notes":    "Verified via RegisterInternalRoutes mount.",
+	}, validInternalHeaders())
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	resp := parseJSON(t, w)
+	assert.Equal(t, "approved", resp["status"])
+}
+
+// TestRegisterInternalRoutes_NoInternalAuthHeader_Returns401BeforeHandler
+// proves HeaderTrustAuth actually gates the route: an otherwise-valid
+// request missing X-Internal-Auth never reaches Review — the fake store's
+// Approve is never called by construction (a 401 from the middleware means
+// c.Next() was never called).
+func TestRegisterInternalRoutes_NoInternalAuthHeader_Returns401BeforeHandler(t *testing.T) {
+	store := &fakeReviewStore{}
+	r := newInternalRouter(store, nil)
+	headers := validInternalHeaders()
+	delete(headers, "X-Internal-Auth")
+	w := doInternalPost(t, r, "/internal/csm/migration-fast-path/"+validReviewID+"/review", map[string]any{
+		"decision": "approve",
+		"notes":    "Should never reach the handler.",
+	}, headers)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestRegisterInternalRoutes_MissingUserID_Returns401MissingReviewer proves
+// the mounted route (not just the bare handler) surfaces missing_reviewer
+// when X-User-Id is absent, even though HeaderTrustAuth itself requires
+// X-User-Id to be non-empty to pass at all — so this exercises the same
+// contract requirement 3 of the task calls out.
+func TestRegisterInternalRoutes_MissingUserID_Returns401MissingReviewer(t *testing.T) {
+	store := &fakeReviewStore{}
+	r := newInternalRouter(store, nil)
+	headers := validInternalHeaders()
+	delete(headers, "X-User-Id")
+	w := doInternalPost(t, r, "/internal/csm/migration-fast-path/"+validReviewID+"/review", map[string]any{
+		"decision": "approve",
+		"notes":    "Missing user id entirely.",
+	}, headers)
+
+	// HeaderTrustAuth itself rejects a request with no X-User-Id before the
+	// handler runs, so this also comes back 401 — but via the middleware's
+	// generic "unauthorized", not the handler's "missing_reviewer". Both are
+	// 401s the caller cannot get past without a real trust header.
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestRegisterInternalRoutes_NonUUIDUserID_Returns401MissingReviewer covers
+// the case HeaderTrustAuth itself does not: a syntactically present but
+// non-UUID X-User-Id passes the middleware (it only checks non-empty) and
+// must be rejected by the handler's own uuid.Parse check.
+func TestRegisterInternalRoutes_NonUUIDUserID_Returns401MissingReviewer(t *testing.T) {
+	store := &fakeReviewStore{}
+	r := newInternalRouter(store, nil)
+	headers := validInternalHeaders()
+	headers["X-User-Id"] = "not-a-uuid"
+	w := doInternalPost(t, r, "/internal/csm/migration-fast-path/"+validReviewID+"/review", map[string]any{
+		"decision": "approve",
+		"notes":    "Non-UUID reviewer id.",
+	}, headers)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	resp := parseJSON(t, w)
+	assert.Equal(t, "missing_reviewer", resp["error"])
+}
+
+// ---------------------------------------------------------------------------
+// Audit emission tests (requirement 2 — #310: an event with no tenant is
+// silently dropped, so the tenant id must be asserted explicitly, not just
+// "an event was written").
+// ---------------------------------------------------------------------------
+
+func TestReview_Approve_EmitsAuditEvent_WithReviewerDecisionAndTenant(t *testing.T) {
+	reviewTenantID := uuid.MustParse(validTenantID)
+	reviewStoreID := uuid.MustParse(validStoreID)
+	reviewID := uuid.MustParse(validReviewID)
+	reviewerID := uuid.MustParse(validUserID)
+
+	repo := &recordingAuditRepo{}
+	em := newTestEmitter(t, repo)
+
+	store := &fakeReviewStore{
+		approveResult: &migration.Review{
+			ID:       reviewID,
+			TenantID: reviewTenantID,
+			StoreID:  reviewStoreID,
+			Status:   "approved",
+		},
+	}
+	r := newInternalRouter(store, em)
+
+	// Deliberately send a different tenant on the header than the review's
+	// real tenant, mirroring the task's point that a CSM caller addresses
+	// the review by id and the header tenant must not be trusted as the
+	// review's tenant.
+	headers := validInternalHeaders()
+	headers["X-Tenant-Id"] = "99999999-9999-9999-9999-999999999999"
+
+	w := doInternalPost(t, r, "/internal/csm/migration-fast-path/"+validReviewID+"/review", map[string]any{
+		"decision": "approve",
+		"notes":    "Verified Shopify export CSV.",
+	}, headers)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	waitForAuditWrite(t, repo, 1)
+	entry := repo.first()
+
+	assert.Equal(t, reviewTenantID, entry.TenantID, "audit event must carry the REVIEW's tenant, not the request header's")
+	require.NotNil(t, entry.StoreID)
+	assert.Equal(t, reviewStoreID, *entry.StoreID)
+	require.NotNil(t, entry.ActorUserID)
+	assert.Equal(t, reviewerID, *entry.ActorUserID)
+	assert.Contains(t, entry.Action, "approve")
+	require.NotNil(t, entry.ResourceID)
+	assert.Equal(t, reviewID.String(), *entry.ResourceID)
+	assert.Equal(t, "Verified Shopify export CSV.", entry.Metadata["notes"])
+	assert.Equal(t, "approve", entry.Metadata["decision"])
+}
+
+func TestReview_Reject_EmitsAuditEvent_WithReviewerDecisionAndTenant(t *testing.T) {
+	// The review's real tenant deliberately differs from the header tenant
+	// sent below (same reasoning as the approve test) — this is what makes
+	// the assertion actually prove the explicit-TenantID wiring rather than
+	// just happening to match the context fallback.
+	reviewTenantID := uuid.MustParse(validTenantID)
+	reviewStoreID := uuid.MustParse(validStoreID)
+	reviewID := uuid.MustParse(validReviewID)
+	reviewerID := uuid.MustParse(validUserID)
+
+	repo := &recordingAuditRepo{}
+	em := newTestEmitter(t, repo)
+
+	store := &fakeReviewStore{
+		rejectResult: &migration.Review{
+			ID:       reviewID,
+			TenantID: reviewTenantID,
+			StoreID:  reviewStoreID,
+			Status:   "rejected",
+		},
+	}
+	r := newInternalRouter(store, em)
+
+	headers := validInternalHeaders()
+	headers["X-Tenant-Id"] = "88888888-8888-8888-8888-888888888888"
+
+	w := doInternalPost(t, r, "/internal/csm/migration-fast-path/"+validReviewID+"/review", map[string]any{
+		"decision": "reject",
+		"notes":    "Evidence URL is a broken link.",
+	}, headers)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	waitForAuditWrite(t, repo, 1)
+	entry := repo.first()
+
+	assert.Equal(t, reviewTenantID, entry.TenantID, "audit event must carry the REVIEW's tenant, not the request header's")
+	require.NotNil(t, entry.StoreID)
+	assert.Equal(t, reviewStoreID, *entry.StoreID)
+	require.NotNil(t, entry.ActorUserID)
+	assert.Equal(t, reviewerID, *entry.ActorUserID)
+	assert.Contains(t, entry.Action, "reject")
+	assert.Equal(t, "reject", entry.Metadata["decision"])
+	assert.Equal(t, "Evidence URL is a broken link.", entry.Metadata["notes"])
+}
+
+// TestReview_NilAuditEmitter_DoesNotPanic pins the nil-safety requirement:
+// a Handler constructed without WithAudit (h.audit stays nil) must not
+// panic on approve/reject, matching audit.Emitter.Emit's own nil-receiver
+// tolerance.
+func TestReview_NilAuditEmitter_DoesNotPanic(t *testing.T) {
+	store := &fakeReviewStore{}
+	r := newInternalRouter(store, nil) // em == nil, WithAudit never called
+	assert.NotPanics(t, func() {
+		w := doInternalPost(t, r, "/internal/csm/migration-fast-path/"+validReviewID+"/review", map[string]any{
+			"decision": "approve",
+			"notes":    "No emitter wired.",
+		}, validInternalHeaders())
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
 }

--- a/services/marketplace-api/internal/billing/migration/repository.go
+++ b/services/marketplace-api/internal/billing/migration/repository.go
@@ -97,9 +97,13 @@ func (r *Repository) Get(ctx context.Context, id uuid.UUID) (*Review, error) {
 // Approve marks the review approved and shortens the tax-ID window to 48h
 // (from the 14d default) by stamping store_subscriptions.tax_id_window_shortened_at.
 // Does NOT waive tax-ID validation — P7 still runs the registry lookup.
-func (r *Repository) Approve(ctx context.Context, id, reviewerID uuid.UUID, notes string) error {
-	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var review Review
+//
+// Returns the post-update review row so callers (the Review handler) can
+// attribute an audit event to the review's tenant/store without a second
+// lookup — the row is already in hand from inside this transaction.
+func (r *Repository) Approve(ctx context.Context, id, reviewerID uuid.UUID, notes string) (*Review, error) {
+	var review Review
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.First(&review, "id = ? AND status = ?", id, "pending").Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return ErrNotFound
@@ -120,6 +124,11 @@ func (r *Repository) Approve(ctx context.Context, id, reviewerID uuid.UUID, note
 		if res.RowsAffected == 0 {
 			return ErrNotFound
 		}
+		review.Status = "approved"
+		review.ReviewerID = &reviewerID
+		trimmed := strings.TrimSpace(notes)
+		review.ReviewerNotes = trimmed
+		review.ReviewedAt = &now
 
 		// Stamp tax_id_window_shortened_at — only if not already set (idempotent).
 		return tx.Exec(`
@@ -129,23 +138,48 @@ func (r *Repository) Approve(ctx context.Context, id, reviewerID uuid.UUID, note
 			now, review.StoreID,
 		).Error
 	})
+	if err != nil {
+		return nil, err
+	}
+	return &review, nil
 }
 
 // Reject marks the review rejected. No side effect on store_subscriptions.
-func (r *Repository) Reject(ctx context.Context, id, reviewerID uuid.UUID, notes string) error {
-	res := r.db.WithContext(ctx).Exec(`
-		UPDATE migration_fast_path_reviews
-		SET status = 'rejected', reviewer_id = ?, reviewer_notes = ?, reviewed_at = now()
-		WHERE id = ? AND status = 'pending'`,
-		reviewerID, strings.TrimSpace(notes), id,
-	)
-	if res.Error != nil {
-		return res.Error
+//
+// Returns the post-update review row for the same reason Approve does.
+func (r *Repository) Reject(ctx context.Context, id, reviewerID uuid.UUID, notes string) (*Review, error) {
+	var review Review
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.First(&review, "id = ? AND status = ?", id, "pending").Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+
+		now := time.Now().UTC()
+		res := tx.Exec(`
+			UPDATE migration_fast_path_reviews
+			SET status = 'rejected', reviewer_id = ?, reviewer_notes = ?, reviewed_at = ?
+			WHERE id = ? AND status = 'pending'`,
+			reviewerID, strings.TrimSpace(notes), now, id,
+		)
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return ErrNotFound
+		}
+		review.Status = "rejected"
+		review.ReviewerID = &reviewerID
+		review.ReviewerNotes = strings.TrimSpace(notes)
+		review.ReviewedAt = &now
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	if res.RowsAffected == 0 {
-		return ErrNotFound
-	}
-	return nil
+	return &review, nil
 }
 
 // isUniquePendingViolation detects the EXCLUDE-constraint violation produced by

--- a/services/marketplace-api/internal/billing/migration/repository_integration_test.go
+++ b/services/marketplace-api/internal/billing/migration/repository_integration_test.go
@@ -4,6 +4,7 @@ package migration_test
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"testing"
 	"time"
@@ -15,21 +16,51 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/billing/migration"
+	"github.com/mark8ly/marketplace-api/internal/stores"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 )
 
-// openIntegrationDB connects to the database specified by TEST_DB_DSN.
+// openIntegrationDB connects to the database specified by TEST_DATABASE_URL —
+// the same env var every other integration test in this repo reads (see
+// pkg/testdb.NewDB). This file previously gated on the nonstandard
+// TEST_DB_DSN, which meant these tests silently skipped under the variable
+// everyone else sets (#317's env-var-split family of traps).
 // Tests that call this are skipped when the env var is absent.
 func openIntegrationDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	dsn, ok := os.LookupEnv("TEST_DB_DSN")
+	dsn, ok := os.LookupEnv("TEST_DATABASE_URL")
 	if !ok || dsn == "" {
-		t.Skip("TEST_DB_DSN not set; skipping integration test")
+		t.Skip("TEST_DATABASE_URL not set; skipping integration test")
 	}
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	require.NoError(t, err, "open integration DB")
 	t.Cleanup(func() { sqlDB, _ := db.DB(); _ = sqlDB.Close() })
 	return db
+}
+
+// seedStoreForReview inserts the parent stores row that
+// store_subscriptions.store_id (and, transitively, migration_fast_path_reviews
+// via the app's tenant/store scoping convention) requires via foreign key.
+// CountryCode/CurrencyCode/Timezone must be values already present in the
+// countries/currencies/timezones reference tables the stores table FKs to —
+// GB/GBP/Europe/London are seeded by the base migrations; IE/Europe/Dublin
+// are NOT and will fail with a FK violation.
+func seedStoreForReview(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
+	t.Helper()
+	s := &stores.Store{
+		ID:           storeID.String(),
+		TenantID:     tenantID.String(),
+		Slug:         "migration-fastpath-" + storeID.String()[:8],
+		Name:         "Migration Fast-Path Test Store",
+		CountryCode:  "GB",
+		CurrencyCode: "GBP",
+		Timezone:     "Europe/London",
+		Status:       stores.StatusActive,
+	}
+	require.NoError(t, db.Create(s).Error)
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM stores WHERE id = ?", storeID.String())
+	})
 }
 
 // seedReview inserts a migration_fast_path_reviews row and registers cleanup.
@@ -50,10 +81,13 @@ func seedReview(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) *migrati
 	return row
 }
 
-// seedSubscriptionForStore inserts a minimal store_subscriptions row for
-// the given store_id so the Approve path can stamp tax_id_window_shortened_at.
+// seedSubscriptionForStore inserts the parent stores row (required by the
+// store_subscriptions.store_id foreign key) and a minimal store_subscriptions
+// row for the given store_id so the Approve path can stamp
+// tax_id_window_shortened_at.
 func seedSubscriptionForStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
 	t.Helper()
+	seedStoreForReview(t, db, tenantID, storeID)
 	sub := subscription.StoreSubscription{
 		ID:                 uuid.New(),
 		TenantID:           tenantID,
@@ -136,10 +170,15 @@ func TestRepo_Approve_ShortensTaxWindow(t *testing.T) {
 
 	// Verify tax_id_window_shortened_at was stamped via raw query (the Go model
 	// doesn't have this column yet — it was added in migration 053).
-	var shortenedAt *time.Time
+	// sql.NullTime, not *time.Time: GORM's Raw().Scan() into a bare *time.Time
+	// destination errors ("unsupported Scan ... storing driver.Value type
+	// <nil>") the moment the column is actually NULL — this only surfaces
+	// once a test exercises the NULL branch, which TestRepo_Reject_NoSideEffect
+	// below is the first to do.
+	var shortenedAt sql.NullTime
 	db.Raw("SELECT tax_id_window_shortened_at FROM store_subscriptions WHERE store_id = ?", storeID).
 		Scan(&shortenedAt)
-	assert.NotNil(t, shortenedAt, "tax_id_window_shortened_at should be non-NULL after approval")
+	assert.True(t, shortenedAt.Valid, "tax_id_window_shortened_at should be non-NULL after approval")
 
 	// Verify review row is now approved.
 	approved, err := repo.Get(context.Background(), row.ID)
@@ -166,10 +205,10 @@ func TestRepo_Reject_NoSideEffect(t *testing.T) {
 	assert.Equal(t, storeID, updated.StoreID, "returned row must carry the review's real store id")
 
 	// tax_id_window_shortened_at must remain NULL — reject has no side effect.
-	var shortenedAt *time.Time
+	var shortenedAt sql.NullTime
 	db.Raw("SELECT tax_id_window_shortened_at FROM store_subscriptions WHERE store_id = ?", storeID).
 		Scan(&shortenedAt)
-	assert.Nil(t, shortenedAt, "tax_id_window_shortened_at should remain NULL after rejection")
+	assert.False(t, shortenedAt.Valid, "tax_id_window_shortened_at should remain NULL after rejection")
 
 	// Verify review row is now rejected.
 	rejected, err := repo.Get(context.Background(), row.ID)

--- a/services/marketplace-api/internal/billing/migration/repository_integration_test.go
+++ b/services/marketplace-api/internal/billing/migration/repository_integration_test.go
@@ -39,12 +39,16 @@ func openIntegrationDB(t *testing.T) *gorm.DB {
 }
 
 // seedStoreForReview inserts the parent stores row that
-// store_subscriptions.store_id (and, transitively, migration_fast_path_reviews
-// via the app's tenant/store scoping convention) requires via foreign key.
-// CountryCode/CurrencyCode/Timezone must be values already present in the
-// countries/currencies/timezones reference tables the stores table FKs to —
-// GB/GBP/Europe/London are seeded by the base migrations; IE/Europe/Dublin
-// are NOT and will fail with a FK violation.
+// store_subscriptions.store_id requires via foreign key (see
+// seedSubscriptionForStore below). marketplace-api's stores table is a local
+// projection of platform-api's (migrations/000001_products_initial.up.sql) —
+// plain country_code/currency_code/timezone columns with no reference-data
+// foreign keys, only stores_slug_unique and the stores_status_valid CHECK
+// (status IN ('active','suspended','archived')). So the country/currency/
+// timezone values here need only be plausible strings; GB/GBP/Europe/London
+// are used for consistency with other fixtures in this repo (e.g.
+// seedStoreForCSV in internal/handlers/platformadmin/health_checks_integration_test.go),
+// not because any FK or seeded reference row requires them.
 func seedStoreForReview(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
 	t.Helper()
 	s := &stores.Store{

--- a/services/marketplace-api/internal/billing/migration/repository_integration_test.go
+++ b/services/marketplace-api/internal/billing/migration/repository_integration_test.go
@@ -128,8 +128,11 @@ func TestRepo_Approve_ShortensTaxWindow(t *testing.T) {
 
 	reviewerID := uuid.New()
 	repo := migration.NewRepository(db)
-	err := repo.Approve(context.Background(), row.ID, reviewerID, "Shopify export verified.")
+	updated, err := repo.Approve(context.Background(), row.ID, reviewerID, "Shopify export verified.")
 	require.NoError(t, err)
+	require.NotNil(t, updated, "Approve must return the updated review row")
+	assert.Equal(t, tenantID, updated.TenantID, "returned row must carry the review's real tenant id")
+	assert.Equal(t, storeID, updated.StoreID, "returned row must carry the review's real store id")
 
 	// Verify tax_id_window_shortened_at was stamped via raw query (the Go model
 	// doesn't have this column yet — it was added in migration 053).
@@ -156,8 +159,11 @@ func TestRepo_Reject_NoSideEffect(t *testing.T) {
 
 	reviewerID := uuid.New()
 	repo := migration.NewRepository(db)
-	err := repo.Reject(context.Background(), row.ID, reviewerID, "Cannot verify evidence URL.")
+	updated, err := repo.Reject(context.Background(), row.ID, reviewerID, "Cannot verify evidence URL.")
 	require.NoError(t, err)
+	require.NotNil(t, updated, "Reject must return the updated review row")
+	assert.Equal(t, tenantID, updated.TenantID, "returned row must carry the review's real tenant id")
+	assert.Equal(t, storeID, updated.StoreID, "returned row must carry the review's real store id")
 
 	// tax_id_window_shortened_at must remain NULL — reject has no side effect.
 	var shortenedAt *time.Time

--- a/services/marketplace-api/internal/handlers/admin/routes.go
+++ b/services/marketplace-api/internal/handlers/admin/routes.go
@@ -784,8 +784,9 @@ func RegisterAdmin(router *gin.RouterGroup, deps Deps) {
 		}
 
 		// Migration fast-path — P5 merchant-initiated platform migration submit.
-		// TODO: /internal/csm/migration-fast-path/:id/review wiring deferred —
-		// the /internal/ group and HeaderTrustAuth chain are not mounted here.
+		// The CSM review counterpart (POST /internal/csm/migration-fast-path/
+		// :id/review) is mounted on the /internal group via
+		// migration.Handler.RegisterInternalRoutes — see main.go.
 		if deps.MigrationFastPathHandler != nil {
 			storeRoute.POST("/migration-fast-path/submit",
 				deps.AuthzMiddleware.RequireTenantRelation(authz.SubscriptionEditRole),


### PR DESCRIPTION
Part of #281 — **does not close it** (see "What this does not do" below). Follows #335.

## The gap

`internal/billing/migration/handler.go` has a working, tested `Review` handler for `POST /internal/csm/migration-fast-path/:id/review`. **It was never mounted.** `internal/handlers/admin/routes.go` carried a TODO saying the wiring was deferred, so the CSM fast-path review step — a live business process, with a handler, a repository, tests, and a table — had no door. No caller could reach it.

Two gaps, not one: it also emitted **no audit row**. `grep` for audit/Emit in the handler and repository returned zero, so #281's "the decision is attributed to that operator in mark8ly's audit log" was entirely unimplemented rather than merely unmounted.

## What this does

- **`Handler.RegisterInternalRoutes(g, internalSecret)`** mounts `POST /csm/migration-fast-path/:id/review` behind `auth.HeaderTrustAuth`, the chain the handler's own doc comment always named.
- **Called at both `main.go` wiring sites** — the `mode.Both` engine and the `mode.Admin` engine — through one registration method rather than two hand-written mounts. `/internal` is registered twice in `main.go`, so a route added to one site only would leave production (`MODE=admin`) silently different from local dev. That is #323's failure mode, in a second place.
- **Audit emission on approve and reject**, carrying the reviewer, the decision, the notes, and the review id. `Approve`/`Reject` now return the loaded `*Review` so the handler can set `TenantID` and `StoreID` **explicitly from the review row**. That matters: a CSM caller addresses a review by id and need not send a tenant header, and `audit.Emit` with no tenant silently writes **no row** (#310). `platformadmin.EmitOperatorAction` is deliberately not used — wrong surface, wrong dependency.
- **The stale TODO is gone.**

## What this does not do

Console-facing access over `/api/v1/platform` is **out of scope**, and #281 stays open.

`Review` requires `c.GetString("user_id")` to parse as a **UUID**; the platform admin surface sets `platform_operator_id` as an opaque bounded **string**. So mounting this on the console's surface would 401 `missing_reviewer` on every call until reviewer identity is reworked — `reviewer_id` is `UUID NULL` in migration 000051. #281's part (a) additionally needs the inbox from #280, which is blocked.

So this makes the process reachable for internal/CSM callers and gives it attribution. The console-facing half is a separate decision about reviewer identity.

## Three things found along the way

1. **The signature change broke a build-tagged test that no default run compiles.** `repository_integration_test.go` is `//go:build integration`, so `go build`, `go vet` and `go test` without `-tags=integration` never touch it — it kept using the old single-return form and nothing complained. Caught in review, fixed, and a service-wide `go vet -tags=integration ./...` sweep now confirms nothing else on this branch is hiding the same way.

2. **Those two integration tests had never actually run.** They failed at the merge base with `store_subscriptions_store_id_fkey` — verified by checking out `e11d89af` in a throwaway worktree and running them there — because `seedSubscriptionForStore` never created the parent `stores` row. So the assertions added in the fix could not execute, which proves nothing. The fixture now seeds the store, and the assertions are **mutation-proved live**: making `Approve` return a zero-valued `&Review{}` fails them with `uuid.Nil` against the real database.

3. **`repository_integration_test.go` gated on `TEST_DB_DSN`** while the rest of the repo uses `TEST_DATABASE_URL` — the env-var split #317 documents. Under the variable everyone else sets, these tests **skipped silently**, and a skip is indistinguishable from a pass in a summary line. That is how two never-passing tests sat there looking healthy. The gate now matches the repo. The rest of #317 is untouched.

## Test plan

- [x] `go build ./...`, `go vet ./...`, and **`go vet -tags=integration ./...`** (whole service) clean
- [x] `go test ./internal/billing/migration/ ./internal/handlers/admin/ ./cmd/marketplace-api/` pass
- [x] Route mount, missing-trust-header rejection, non-UUID reviewer 401, and audit emission for both approve and reject covered by unit tests
- [x] Audit tenant mutation-proved: removing the explicit `TenantID` makes both audit tests fail (they send a header tenant deliberately *different* from the review's, so a context fallback picks up the wrong tenant and is caught). A first draft of the reject test was a false positive — its header tenant coincidentally matched — and was fixed.
- [x] All five `TestRepo_*` integration tests confirmed **RUN and PASS** (`-count=1`, verbose) against Postgres with `-p 1` — not skipped
- [ ] Post-deploy: exercise one approve and one reject through internal tooling and confirm an audit row appears for each with the reviewer and the review's tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
