### PR TITLE
feat: tenant suspend/unsuspend that actually enforces (#287)

### DIFF
--- a/apps/admin/middleware.test.ts
+++ b/apps/admin/middleware.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+import { middleware } from "./middleware";
+
+const SLUG = "acme";
+const TENANT_ID = "tenant-123";
+const USER_ID = "user-456";
+const SESSION_COOKIE_NAME = process.env.SESSION_COOKIE_NAME ?? "m8_session";
+
+// Builds a request against `{slug}-admin.mark8ly.com/dashboard` carrying a
+// valid session cookie value — the value itself is never inspected because
+// auth-bff's response (mocked below) is the only thing that matters.
+function buildRequest(): NextRequest {
+  const req = new NextRequest(
+    `https://${SLUG}-admin.mark8ly.com/dashboard`,
+    { headers: { host: `${SLUG}-admin.mark8ly.com`, cookie: `${SESSION_COOKIE_NAME}=valid-session-token` } },
+  );
+  return req;
+}
+
+// Routes the mocked global fetch by URL substring so the test doesn't care
+// about call order — the middleware makes several sequential fetches
+// (slug-status, session, store-by-slug, role) before it finishes.
+function mockFetchForStatus(status: string) {
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    if (url.includes("/internal/store-active-domain/")) {
+      return new Response(JSON.stringify({ custom_domain: "" }), { status: 200 });
+    }
+    if (url.includes("/auth/session")) {
+      return new Response(
+        JSON.stringify({
+          data: {
+            user_id: USER_ID,
+            email: "merchant@example.com",
+            tenant_id: TENANT_ID,
+          },
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.includes("/internal/stores/by-slug/")) {
+      return new Response(
+        JSON.stringify({ data: { tenant_id: TENANT_ID, status } }),
+        { status: 200 },
+      );
+    }
+    if (url.includes("/internal/tenants/") && url.includes("/me")) {
+      return new Response(JSON.stringify({ data: { role: "owner" } }), {
+        status: 200,
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as unknown as typeof fetch;
+}
+
+// Mocks the by-slug 404 branch specifically (line ~339 in middleware.ts) —
+// the store-active-domain lookup and session both succeed, but
+// platform-api's /internal/stores/by-slug/:slug returns 404, which is the
+// pre-existing "unknown slug" branch the new status check sits right below.
+function mockFetchBySlugNotFound() {
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/internal/store-active-domain/")) {
+      return new Response(JSON.stringify({ custom_domain: "" }), { status: 200 });
+    }
+    if (url.includes("/auth/session")) {
+      return new Response(
+        JSON.stringify({
+          data: { user_id: USER_ID, email: "merchant@example.com", tenant_id: TENANT_ID },
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.includes("/internal/stores/by-slug/")) {
+      return new Response(null, { status: 404 });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as unknown as typeof fetch;
+}
+
+describe("admin middleware — tenant status gate", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("404s a suspended store and never reaches the tenant-switch path", async () => {
+    mockFetchForStatus("suspended");
+    const res = await middleware(buildRequest());
+    expect(res.status).toBe(404);
+
+    // The tenant-switch path calls auth-bff's /auth/switch-tenant — assert
+    // it was never hit, proving the refusal short-circuits before it.
+    const calledUrls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.map(
+      (call) => String(call[0]),
+    );
+    expect(calledUrls.some((u) => u.includes("/auth/switch-tenant"))).toBe(false);
+  });
+
+  it("404s an archived store", async () => {
+    mockFetchForStatus("archived");
+    const res = await middleware(buildRequest());
+    expect(res.status).toBe(404);
+  });
+
+  it("does not 404 an active store (regression guard)", async () => {
+    mockFetchForStatus("active");
+    const res = await middleware(buildRequest());
+    expect(res.status).not.toBe(404);
+  });
+
+  it("still 404s when platform-api reports the slug unknown (pre-existing behaviour)", async () => {
+    mockFetchBySlugNotFound();
+    const res = await middleware(buildRequest());
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/admin/middleware.ts
+++ b/apps/admin/middleware.ts
@@ -341,8 +341,15 @@ async function handleRequest(
       }
       if (storeRes.ok) {
         const body = (await storeRes.json()) as {
-          data: { tenant_id: string };
+          data: { tenant_id: string; status: string };
         };
+        // A suspended or archived store must not serve the admin UI. Same
+        // 404 as the unknown-slug branch above, and the same choice
+        // platform-api makes for the public storefront — an admin surface
+        // should not contradict it.
+        if (body.data.status !== "active") {
+          return new NextResponse(null, { status: 404 });
+        }
         const requestedTenantId = body.data.tenant_id;
         if (requestedTenantId && requestedTenantId !== session.tenant_id) {
           // Try to switch. If the user has membership on the slug's

--- a/apps/admin/middleware.ts
+++ b/apps/admin/middleware.ts
@@ -347,6 +347,16 @@ async function handleRequest(
         // 404 as the unknown-slug branch above, and the same choice
         // platform-api makes for the public storefront — an admin surface
         // should not contradict it.
+        //
+        // NOTE (F9, #287 review): this is an unguarded fail-closed
+        // dependence on `status` being present on the response body.
+        // `body.data.status !== "active"` also 404s when `status` is
+        // `undefined` (a field that moved, was renamed, or was dropped by
+        // platform-api) — which is the right outcome today, but it means a
+        // schema change on that field lands on every merchant at once with
+        // no distinguishing error. If platform-api's `/internal/stores/
+        // by-slug` response shape ever changes, this line is where it
+        // would silently start refusing everyone.
         if (body.data.status !== "active") {
           return new NextResponse(null, { status: 404 });
         }

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
       "@repo/ui/role-badge": path.resolve(__dirname, "../../packages/ui/src/role-badge.tsx"),
       "@repo/ui/app-store-badges": path.resolve(__dirname, "../../packages/ui/src/app-store-badges.tsx"),
       "@repo/ui/status-dot": path.resolve(__dirname, "../../packages/ui/src/status-dot.tsx"),
+      "@repo/ui/auth/csrf": path.resolve(__dirname, "../../packages/ui/src/auth/csrf.ts"),
       "@repo/ui": path.resolve(__dirname, "../../packages/ui/src/index.ts"),
       react: path.resolve(__dirname, "../../node_modules/react"),
       "react-dom": path.resolve(__dirname, "../../node_modules/react-dom"),

--- a/docs/superpowers/artifacts/2026-07-29-mark8ly-launch-banner.svg
+++ b/docs/superpowers/artifacts/2026-07-29-mark8ly-launch-banner.svg
@@ -1,0 +1,104 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Mark8ly launch: we built a real online store in ten minutes">
+  <defs>
+    <linearGradient id="mossFade" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2D4A2B" stop-opacity="0.10"/>
+      <stop offset="100%" stop-color="#2D4A2B" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="#F7F6F2"/>
+  <rect x="680" y="0" width="520" height="630" fill="url(#mossFade)"/>
+
+  <!-- left column -->
+  <g font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+    <text x="72" y="96" font-size="13" letter-spacing="3.4" fill="#2D4A2B">M A R K 8 L Y &#160;&#160;·&#160;&#160; N O W &#160; L I V E</text>
+  </g>
+
+  <line x1="72" y1="120" x2="228" y2="120" stroke="#0E0E0C" stroke-width="1.4"/>
+
+  <g font-family="Georgia, 'Times New Roman', serif" fill="#0E0E0C">
+    <text x="72" y="216" font-size="62" font-weight="700" letter-spacing="-1.4">We built a real</text>
+    <text x="72" y="288" font-size="62" font-weight="700" letter-spacing="-1.4">online store in</text>
+    <text x="72" y="360" font-size="62" font-weight="700" letter-spacing="-1.4">ten minutes.</text>
+  </g>
+
+  <g font-family="Georgia, 'Times New Roman', serif" fill="#55554E">
+    <text x="73" y="416" font-size="23" font-style="italic">Here is everything that had to happen.</text>
+  </g>
+
+  <line x1="72" y1="500" x2="608" y2="500" stroke="#0E0E0C" stroke-opacity="0.14" stroke-width="1"/>
+
+  <g font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+    <text x="72" y="536" font-size="14" letter-spacing="1.6" fill="#55554E">A commerce platform, from the inside</text>
+    <text x="72" y="562" font-size="13" letter-spacing="1.6" fill="#2D4A2B">blog.tesserix.app</text>
+  </g>
+
+  <!-- right column: many storefronts, one platform -->
+  <g>
+    <!-- row 1 -->
+    <g>
+      <rect x="712" y="118" width="128" height="92" rx="6" fill="#FFFFFF" stroke="#0E0E0C" stroke-opacity="0.13"/>
+      <line x1="728" y1="146" x2="800" y2="146" stroke="#0E0E0C" stroke-opacity="0.5" stroke-width="2.5"/>
+      <line x1="728" y1="164" x2="784" y2="164" stroke="#0E0E0C" stroke-opacity="0.16" stroke-width="2.5"/>
+      <line x1="728" y1="180" x2="812" y2="180" stroke="#0E0E0C" stroke-opacity="0.16" stroke-width="2.5"/>
+    </g>
+    <g>
+      <rect x="860" y="118" width="128" height="92" rx="6" fill="#FFFFFF" stroke="#0E0E0C" stroke-opacity="0.13"/>
+      <line x1="876" y1="146" x2="936" y2="146" stroke="#0E0E0C" stroke-opacity="0.5" stroke-width="2.5"/>
+      <line x1="876" y1="164" x2="948" y2="164" stroke="#0E0E0C" stroke-opacity="0.16" stroke-width="2.5"/>
+      <line x1="876" y1="180" x2="920" y2="180" stroke="#0E0E0C" stroke-opacity="0.16" stroke-width="2.5"/>
+    </g>
+    <g>
+      <rect x="1008" y="118" width="128" height="92" rx="6" fill="#FFFFFF" stroke="#0E0E0C" stroke-opacity="0.13"/>
+      <line x1="1024" y1="146" x2="1088" y2="146" stroke="#0E0E0C" stroke-opacity="0.5" stroke-width="2.5"/>
+      <line x1="1024" y1="164" x2="1108" y2="164" stroke="#0E0E0C" stroke-opacity="0.16" stroke-width="2.5"/>
+      <line x1="1024" y1="180" x2="1064" y2="180" stroke="#0E0E0C" stroke-opacity="0.16" stroke-width="2.5"/>
+    </g>
+
+    <!-- row 2, the highlighted one -->
+    <g>
+      <rect x="712" y="232" width="128" height="92" rx="6" fill="#FFFFFF" stroke="#0E0E0C" stroke-opacity="0.13"/>
+      <line x1="728" y1="260" x2="796" y2="260" stroke="#0E0E0C" stroke-opacity="0.5" stroke-width="2.5"/>
+      <line x1="728" y1="278" x2="812" y2="278" stroke="#0E0E0C" stroke-opacity="0.16" stroke-width="2.5"/>
+      <line x1="728" y1="294" x2="772" y2="294" stroke="#0E0E0C" stroke-opacity="0.16" stroke-width="2.5"/>
+    </g>
+    <g>
+      <rect x="860" y="232" width="128" height="92" rx="6" fill="#2D4A2B"/>
+      <line x1="876" y1="260" x2="944" y2="260" stroke="#FFFFFF" stroke-opacity="0.95" stroke-width="2.5"/>
+      <line x1="876" y1="278" x2="956" y2="278" stroke="#FFFFFF" stroke-opacity="0.45" stroke-width="2.5"/>
+      <line x1="876" y1="294" x2="912" y2="294" stroke="#FFFFFF" stroke-opacity="0.45" stroke-width="2.5"/>
+    </g>
+    <g>
+      <rect x="1008" y="232" width="128" height="92" rx="6" fill="#FFFFFF" stroke="#0E0E0C" stroke-opacity="0.13"/>
+      <line x1="1024" y1="260" x2="1076" y2="260" stroke="#0E0E0C" stroke-opacity="0.5" stroke-width="2.5"/>
+      <line x1="1024" y1="278" x2="1100" y2="278" stroke="#0E0E0C" stroke-opacity="0.16" stroke-width="2.5"/>
+      <line x1="1024" y1="294" x2="1052" y2="294" stroke="#0E0E0C" stroke-opacity="0.16" stroke-width="2.5"/>
+    </g>
+
+    <!-- row 3 -->
+    <g opacity="0.55">
+      <rect x="712" y="346" width="128" height="92" rx="6" fill="#FFFFFF" stroke="#0E0E0C" stroke-opacity="0.13"/>
+      <line x1="728" y1="374" x2="792" y2="374" stroke="#0E0E0C" stroke-opacity="0.4" stroke-width="2.5"/>
+      <line x1="728" y1="392" x2="804" y2="392" stroke="#0E0E0C" stroke-opacity="0.14" stroke-width="2.5"/>
+    </g>
+    <g opacity="0.55">
+      <rect x="860" y="346" width="128" height="92" rx="6" fill="#FFFFFF" stroke="#0E0E0C" stroke-opacity="0.13"/>
+      <line x1="876" y1="374" x2="928" y2="374" stroke="#0E0E0C" stroke-opacity="0.4" stroke-width="2.5"/>
+      <line x1="876" y1="392" x2="952" y2="392" stroke="#0E0E0C" stroke-opacity="0.14" stroke-width="2.5"/>
+    </g>
+    <g opacity="0.55">
+      <rect x="1008" y="346" width="128" height="92" rx="6" fill="#FFFFFF" stroke="#0E0E0C" stroke-opacity="0.13"/>
+      <line x1="1024" y1="374" x2="1084" y2="374" stroke="#0E0E0C" stroke-opacity="0.4" stroke-width="2.5"/>
+      <line x1="1024" y1="392" x2="1096" y2="392" stroke="#0E0E0C" stroke-opacity="0.14" stroke-width="2.5"/>
+    </g>
+
+    <!-- connectors down to one platform line -->
+    <g stroke="#0E0E0C" stroke-opacity="0.2" stroke-width="1.2">
+      <path d="M776,438 L776,470" fill="none"/>
+      <path d="M924,438 L924,470" fill="none"/>
+      <path d="M1072,438 L1072,470" fill="none"/>
+    </g>
+    <line x1="712" y1="470" x2="1136" y2="470" stroke="#0E0E0C" stroke-width="1.6"/>
+    <text x="712" y="498" font-family="Helvetica Neue, Helvetica, Arial, sans-serif" font-size="13" letter-spacing="2.6" fill="#55554E">O N E &#160; P L A T F O R M</text>
+  </g>
+</svg>

--- a/docs/superpowers/artifacts/2026-07-29-mark8ly-launch-blog-draft.html
+++ b/docs/superpowers/artifacts/2026-07-29-mark8ly-launch-blog-draft.html
@@ -1,0 +1,400 @@
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&family=Source+Sans+3:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+#mk8-blog { font-family: 'Source Sans 3', system-ui, sans-serif; font-size: 17.5px; line-height: 1.75; color: #3d3d38; }
+#mk8-blog h1 { font-family: 'Source Serif 4', Georgia, serif; font-weight: 700; font-size: 46px; line-height: 1.1; letter-spacing: -0.02em; margin: 18px 0 14px; color: #0E0E0C; }
+#mk8-blog h2 { font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 28px; line-height: 1.25; letter-spacing: -0.01em; margin: 54px 0 14px; color: #0E0E0C; }
+#mk8-blog h3 { font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 21px; margin: 34px 0 10px; color: #0E0E0C; }
+#mk8-blog p { margin: 0 0 18px; color: #3d3d38; }
+#mk8-blog strong { color: #0E0E0C; font-weight: 600; }
+#mk8-blog em { font-style: italic; }
+#mk8-blog a { color: #2D4A2B; text-decoration: underline; text-underline-offset: 3px; }
+#mk8-blog ul { padding-left: 24px; margin: 0 0 18px; }
+#mk8-blog ul li { margin: 0 0 8px; }
+#mk8-blog hr { border: none; height: 1px; background: #e6e4dc; margin: 44px 0; }
+#mk8-blog code { font-family: 'JetBrains Mono', monospace; font-size: 0.88em; background: #efeee8; padding: 2px 6px; border-radius: 4px; color: #0E0E0C; }
+
+#mk8-blog .lede { font-family: 'Source Serif 4', Georgia, serif; font-size: 21px; line-height: 1.5; color: #55554E; font-style: italic; margin: 0 0 30px; }
+#mk8-blog .kicker { display: inline-block; font-family: 'JetBrains Mono', monospace; font-size: 12px; text-transform: uppercase; letter-spacing: 0.15em; color: #2D4A2B; background: #e8ede6; padding: 6px 12px; border-radius: 20px; margin-bottom: 18px; }
+
+#mk8-blog .pullquote { font-family: 'Source Serif 4', Georgia, serif; font-size: 24px; line-height: 1.4; color: #0E0E0C; font-style: italic; text-align: center; margin: 44px auto; padding: 28px 18px; max-width: 640px; border-top: 1px solid #e6e4dc; border-bottom: 1px solid #e6e4dc; }
+#mk8-blog .pullquote .attrib { display: block; font-family: 'Source Sans 3', sans-serif; font-style: normal; font-size: 14px; letter-spacing: 0.06em; color: #6b6b62; margin-top: 14px; }
+
+#mk8-blog .diagram { margin: 28px 0 36px; padding: 26px 22px; background: #F7F6F2; border-radius: 14px; border: 1px solid #e6e4dc; text-align: center; }
+#mk8-blog .diagram svg { max-width: 100%; height: auto; }
+#mk8-blog .diagram img { max-width: 100%; height: auto; border-radius: 8px; display: block; margin: 0 auto; }
+#mk8-blog .diagram img.phone { max-width: 290px; border-radius: 22px; box-shadow: 0 6px 28px rgba(14,14,12,0.13); }
+#mk8-blog .caption { font-family: 'Source Serif 4', Georgia, serif; font-size: 14px; font-style: italic; color: #7a7a70; margin-top: 12px; }
+
+#mk8-blog .example { background: #F2F5F1; border-left: 4px solid #2D4A2B; border-radius: 0 10px 10px 0; padding: 16px 22px; margin: 22px 0 30px; }
+#mk8-blog .example .label { font-family: 'JetBrains Mono', monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; color: #2D4A2B; margin-bottom: 8px; display: block; }
+#mk8-blog .example p { font-size: 16.5px; line-height: 1.65; color: #33382F; margin: 0 0 10px; }
+#mk8-blog .example p:last-child { margin-bottom: 0; }
+
+#mk8-blog .cards { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin: 22px 0 30px; }
+@media (max-width: 640px) { #mk8-blog .cards { grid-template-columns: 1fr; } }
+#mk8-blog .mc { border: 1px solid #e6e4dc; border-radius: 12px; padding: 18px 20px; background: #FFFFFF; }
+#mk8-blog .mc h4 { font-family: 'Source Serif 4', Georgia, serif; font-size: 18px; margin: 0 0 6px; color: #0E0E0C; }
+#mk8-blog .mc .tag { display: inline-block; font-family: 'JetBrains Mono', monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: #2D4A2B; margin-bottom: 6px; }
+#mk8-blog .mc p { font-size: 15.5px; line-height: 1.55; margin: 0; color: #3d3d38; }
+
+#mk8-blog .benefits { width: 100%; border-collapse: collapse; margin: 24px 0 30px; font-size: 16.5px; }
+#mk8-blog .benefits td { padding: 14px 8px; border-bottom: 1px solid #e6e4dc; vertical-align: top; }
+#mk8-blog .benefits tr:first-child td { border-top: 1px solid #e6e4dc; }
+#mk8-blog .benefits td:first-child { font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; color: #0E0E0C; width: 34%; padding-right: 18px; }
+</style>
+
+<section id="mk8-blog">
+
+<span class="kicker">Mark8ly &middot; Now live</span>
+
+<h1>One Platform. Thousands of Shops. Here Is How We Built It.</h1>
+
+<p class="lede">The Bondi Store sells linen and cotton basics out of Sydney. It has its own web address, its own dashboard, its own customers. Setting it up took minutes, not months. This is the story of everything that had to happen underneath, told in plain English.</p>
+
+<p>Today we are launching <strong>Mark8ly</strong>: a place to sell online without hiring a developer to get started.</p>
+
+<p>You could read a feature list. We would rather show you a real shop.</p>
+
+<p><a href="https://the-bondi-store.mark8ly.com">The Bondi Store</a> is live right now. Open it in another tab. Click into a product. Add it to the cart. It behaves like a real shop because it is one.</p>
+
+<div class="diagram">
+<img src="https://storage.googleapis.com/tesserix-blog-assets/blog/images/2026/07/mk8-storefront.png" alt="The Bondi Store homepage, showing a coastal hero image, a shop menu, and a free shipping banner" loading="lazy">
+<div class="caption">The Bondi Store, live at the-bondi-store.mark8ly.com. Nobody wrote any code to make this page.</div>
+</div>
+
+<p>Here is what the owner did. They typed in an email address. They picked a name. They added some products and prices. Then they were open for business.</p>
+
+<p>Here is what we did in the same window of time.</p>
+
+<p>We proved who they were, without ever asking for a password. We built them a private address on the internet. We worked out exactly what they were allowed to see, and what had to stay hidden from them. Then we handed them a working dashboard and logged them straight in.</p>
+
+<p>Every one of those steps can go wrong. This is how each one works.</p>
+
+<div class="diagram">
+<svg viewBox="0 0 660 190" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="The journey from an email address to a live storefront, in five steps">
+  <defs>
+    <marker id="mk8a1" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 z" fill="#b3b0a4"/></marker>
+  </defs>
+  <text x="330" y="26" text-anchor="middle" font-family="'Source Serif 4', Georgia, serif" font-size="14" font-style="italic" fill="#0E0E0C">One email address becomes one live shop</text>
+
+  <g font-family="'Source Sans 3', sans-serif">
+    <g>
+      <rect x="16" y="58" width="106" height="60" rx="10" fill="#FFFFFF" stroke="#d8d5c9"/>
+      <text x="69" y="84" text-anchor="middle" font-size="12.5" fill="#0E0E0C">email typed</text>
+      <text x="69" y="102" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="10.5" fill="#7a7a70">step 1</text>
+    </g>
+    <g>
+      <rect x="150" y="58" width="106" height="60" rx="10" fill="#FFFFFF" stroke="#d8d5c9"/>
+      <text x="203" y="84" text-anchor="middle" font-size="12.5" fill="#0E0E0C">link clicked</text>
+      <text x="203" y="102" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="10.5" fill="#7a7a70">step 2</text>
+    </g>
+    <g>
+      <rect x="284" y="58" width="106" height="60" rx="10" fill="#FFFFFF" stroke="#d8d5c9"/>
+      <text x="337" y="84" text-anchor="middle" font-size="12.5" fill="#0E0E0C">shop created</text>
+      <text x="337" y="102" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="10.5" fill="#7a7a70">step 3</text>
+    </g>
+    <g>
+      <rect x="418" y="58" width="106" height="60" rx="10" fill="#FFFFFF" stroke="#d8d5c9"/>
+      <text x="471" y="84" text-anchor="middle" font-size="12.5" fill="#0E0E0C">keys handed over</text>
+      <text x="471" y="102" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="10.5" fill="#7a7a70">step 4</text>
+    </g>
+    <g>
+      <rect x="552" y="58" width="106" height="60" rx="10" fill="#2D4A2B"/>
+      <text x="605" y="84" text-anchor="middle" font-size="12.5" fill="#FFFFFF">shop is open</text>
+      <text x="605" y="102" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="10.5" fill="#c3d3bf">step 5</text>
+    </g>
+  </g>
+
+  <g stroke="#b3b0a4" stroke-width="1.3" fill="none">
+    <path d="M122,88 L148,88" marker-end="url(#mk8a1)"/>
+    <path d="M256,88 L282,88" marker-end="url(#mk8a1)"/>
+    <path d="M390,88 L416,88" marker-end="url(#mk8a1)"/>
+    <path d="M524,88 L550,88" marker-end="url(#mk8a1)"/>
+  </g>
+
+  <line x1="16" y1="146" x2="658" y2="146" stroke="#e6e4dc"/>
+  <text x="16" y="170" font-family="'Source Sans 3', sans-serif" font-size="11.5" fill="#7a7a70">Sections 2 and 3</text>
+  <text x="337" y="170" text-anchor="middle" font-family="'Source Sans 3', sans-serif" font-size="11.5" fill="#7a7a70">Sections 4 and 5</text>
+  <text x="658" y="170" text-anchor="end" font-family="'Source Sans 3', sans-serif" font-size="11.5" fill="#7a7a70">Section 6</text>
+</svg>
+<div class="caption">Figure 1. The journey this post follows, and where each part is explained.</div>
+</div>
+
+<hr>
+
+<h2>1. One platform, thousands of shops</h2>
+
+<p>Start with the idea that shapes everything else.</p>
+
+<p>Every shop on Mark8ly runs on <strong>the same software at the same time</strong>. We do not spin up a private copy for each merchant. There is one platform, and it serves every shop on it at once.</p>
+
+<p>The industry word for this is <em>multi-tenant</em>. Think of it as a well run building rather than a street of houses. Everyone has their own front door, their own key, their own space that nobody else can enter. What they share is the foundation, the plumbing and the security desk.</p>
+
+<div class="diagram">
+<svg viewBox="0 0 660 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="How a visit to the-bondi-store.mark8ly.com finds the right shop out of thousands">
+  <defs>
+    <marker id="mk8a2" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 z" fill="#b3b0a4"/></marker>
+  </defs>
+  <text x="330" y="26" text-anchor="middle" font-family="'Source Serif 4', Georgia, serif" font-size="14" font-style="italic" fill="#0E0E0C">One platform, thousands of shops, one correct answer</text>
+
+  <g font-family="'Source Sans 3', sans-serif">
+    <rect x="150" y="50" width="360" height="42" rx="8" fill="#FFFFFF" stroke="#d8d5c9"/>
+    <text x="330" y="76" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="13" fill="#0E0E0C">the-bondi-store.mark8ly.com</text>
+
+    <path d="M330,92 L330,124" stroke="#b3b0a4" stroke-width="1.3" fill="none" marker-end="url(#mk8a2)"/>
+
+    <rect x="176" y="126" width="308" height="48" rx="8" fill="#e8ede6" stroke="#2D4A2B" stroke-opacity="0.35"/>
+    <text x="330" y="146" text-anchor="middle" font-size="12.5" fill="#2D4A2B">read the shop name from the address</text>
+    <text x="330" y="164" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" fill="#4a6b47">the-bondi-store</text>
+
+    <path d="M330,174 L330,204" stroke="#b3b0a4" stroke-width="1.3" fill="none" marker-end="url(#mk8a2)"/>
+
+    <text x="330" y="198" text-anchor="middle" font-size="11.5" fill="#7a7a70">every request now carries that answer</text>
+  </g>
+
+  <g font-family="'Source Sans 3', sans-serif">
+    <rect x="30" y="212" width="128" height="62" rx="10" fill="#FFFFFF" stroke="#d8d5c9" stroke-dasharray="4 4"/>
+    <text x="94" y="238" text-anchor="middle" font-size="12" fill="#a5a299">another shop</text>
+    <text x="94" y="256" text-anchor="middle" font-size="11" fill="#a5a299">not visible</text>
+
+    <rect x="266" y="212" width="128" height="62" rx="10" fill="#2D4A2B"/>
+    <text x="330" y="238" text-anchor="middle" font-size="12" fill="#FFFFFF">The Bondi Store</text>
+    <text x="330" y="256" text-anchor="middle" font-size="11" fill="#c3d3bf">products, orders</text>
+
+    <rect x="502" y="212" width="128" height="62" rx="10" fill="#FFFFFF" stroke="#d8d5c9" stroke-dasharray="4 4"/>
+    <text x="566" y="238" text-anchor="middle" font-size="12" fill="#a5a299">another shop</text>
+    <text x="566" y="256" text-anchor="middle" font-size="11" fill="#a5a299">not visible</text>
+  </g>
+</svg>
+<div class="caption">Figure 2. The shop name is read once, at the front door, and travels with every request behind it.</div>
+</div>
+
+<p>When someone visits <code>the-bondi-store.mark8ly.com</code>, the first thing we work out is which shop they are looking at. We read the name from the address. We attach that answer to the request. Everything after that carries it.</p>
+
+<p>So the page never asks for products. It asks for <em>this shop's</em> products. Always.</p>
+
+<p>That sounds like an implementation detail. It is the whole business model. Here is what it buys you as a merchant:</p>
+
+<table class="benefits">
+<tr><td>You pay less</td><td>You are not renting a server. You are renting a slice of one that thousands of shops share. That is the difference between a monthly bill you notice and one you do not.</td></tr>
+<tr><td>You are never behind</td><td>There is one copy of the software, so a fix or a new feature reaches your shop the moment it ships. No upgrade project. No version left rotting.</td></tr>
+<tr><td>You open today</td><td>Your shop is not built for you. It already exists the second you ask for it. Nothing to install, nothing to provision, nobody to wait on.</td></tr>
+<tr><td>You stay separate</td><td>Sharing the building never means sharing the room. Your products, orders and customers are yours alone, enforced in the machinery rather than left to good intentions.</td></tr>
+</table>
+
+<p>The alternative is giving every merchant a private copy of everything. Some platforms do that. It is simpler to build, and it is why those platforms cost what they cost. A thousand merchants means a thousand systems to run, patch and pay for, and every security fix has to be applied a thousand times.</p>
+
+<p>Sharing one well guarded platform is harder to build once. It is far cheaper to run forever. That saving is the reason a small shop can afford to be here at all.</p>
+
+<hr>
+
+<h2>2. No password to lose</h2>
+
+<p>Before we hand anyone a shop, we need to know they are who they say they are.</p>
+
+<p>We do not ask for a password. You type your email address. We send you a link. You click it. You are in.</p>
+
+<p>This is safer, and the reason is simple. A password is a secret you must remember forever and never reuse. Most people manage neither. A link that works once and then stops has neither problem. Nothing to remember. Nothing worth stealing later.</p>
+
+<div class="example">
+<span class="label">Put another way</span>
+<p>A hotel does not make you memorise a code. You prove who you are once at the desk, and they hand you a card that opens one door and stops working when you leave.</p>
+<p>Your email link is that card. One door. One use. Then it is dead.</p>
+</div>
+
+<p>One detail we care about a lot: <strong>we never keep a copy of your link</strong>.</p>
+
+<p>We store a fingerprint of it instead. A scrambled version that can be checked but never turned back into the original. When you click, we scramble what you sent and see if the two match.</p>
+
+<p>So if someone ever stole our database, they would find a pile of fingerprints and not a single working link. Nothing in there opens anything. The links expire on their own too, so an old email sitting in your inbox is not a spare key to your shop.</p>
+
+<p>Shop owners and shoppers are also kept in completely separate pools. A customer account on one shop never becomes an account on our platform by accident.</p>
+
+<hr>
+
+<h2>3. Your own front door</h2>
+
+<p>Now we have a verified person who wants a shop. They pick a name. Ours picked The Bondi Store.</p>
+
+<p>Two addresses come into existence:</p>
+
+<ul>
+<li><code>the-bondi-store.mark8ly.com</code> is the shop customers see.</li>
+<li><code>the-bondi-store-admin.mark8ly.com</code> is the private dashboard where the owner works.</li>
+</ul>
+
+<p>Both are live immediately. No waiting, no setup call, no ticket in a queue.</p>
+
+<p>When the shop is ready, the owner can move it to their own web address. For them it is a form with one field in it. Behind that form, a small service talks to our DNS provider, sets up the security certificate so the padlock appears in the browser, then keeps checking until the new address answers properly.</p>
+
+<p>Your brand, your domain, your customers. We stay out of the way.</p>
+
+<hr>
+
+<h2>4. Your data stays yours</h2>
+
+<p>This is the part that decides whether a platform like ours deserves your trust.</p>
+
+<p>Every time a shop owner opens their orders page, we have to answer one question: is this person allowed to see these orders? We have to get it right every time, for every person, for every shop, forever. Getting it wrong once in the wrong direction means showing one merchant another merchant's customers.</p>
+
+<p>So permissions are not a checklist bolted on the side. They are their own system with one job.</p>
+
+<div class="example">
+<span class="label">Put another way</span>
+<p>Picture that building again. One front desk, one set of rules. A key card does not say "this person is important". It says "this person owns the shop on level three", and the doors work the rest out.</p>
+<p>Hire an assistant and you do not hand over your card. The desk records a new relationship: this person works for that shop. The right doors open. The wrong ones do not. Nobody had to think about it.</p>
+</div>
+
+<p>That is close to how ours works. We store relationships, not lists of powers. When a page needs to know if something is allowed, it asks a dedicated permissions service, and that service follows the relationships it knows about.</p>
+
+<p>Underneath sits a second layer, and it is the dull one that actually saves you. Every piece of data carries the shop it belongs to, and our data layer refuses to run a query that is not tied to a single shop. A developer having a bad day cannot accidentally write the query that returns everybody's orders. That query will not run.</p>
+
+<p class="pullquote">Keeping shops apart is not a feature we added to Mark8ly. It is the product. Everything else is shopping cart software.</p>
+
+<hr>
+
+<h2>5. The handoff that used to break</h2>
+
+<p>Now the honest part, because a post like this is worth little if it only lists the good bits.</p>
+
+<p>The first version of this flow had a bug that ruined the best moment we had. A new merchant would finish signing up, land on their dashboard, and be told they had no access to any shop.</p>
+
+<p>Their shop existed. It had been created a second earlier. What had not caught up was the paperwork saying they owned it. The dashboard asked "does this person own a shop?" before the answer had finished being written down, heard no, and did exactly what it was built to do. It kept them out.</p>
+
+<div class="pullquote">
+&ldquo;Everything fails, all the time.&rdquo;
+<span class="attrib">Werner Vogels, Chief Technology Officer, Amazon</span>
+</div>
+
+<p>The obvious fix is to write both records at the same moment and hope they both succeed. That works right up until one of them does not. Then you have a shop with no owner, or an owner with no shop, and no way to tell which.</p>
+
+<p>We used an older trick, the one a good restaurant kitchen uses. A waiter does not walk into the kitchen and shout your order. They write a ticket and put it on the rail. The kitchen works through the rail. If the kitchen is slow, the ticket waits. If a plate gets dropped, the ticket is still there and the dish gets made again. Nothing is lost just because a delivery was slow.</p>
+
+<p>So when a shop is created, we save two things together: the shop, and a ticket saying who owns it. Both are saved or neither is. A separate worker reads tickets off the rail and delivers them. If a delivery fails, the ticket stays and gets tried again.</p>
+
+<p>Then we added the small piece of manners that makes it invisible. If you land on your dashboard before the ticket arrives, we do not throw you out. We wait a beat and ask again, because we know it is on its way.</p>
+
+<div class="diagram">
+<svg viewBox="0 0 660 260" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="The handoff: shop record and ownership ticket saved together, delivered by a worker, with a retry on first login">
+  <defs>
+    <marker id="mk8a3" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 z" fill="#b3b0a4"/></marker>
+  </defs>
+  <text x="330" y="24" text-anchor="middle" font-family="'Source Serif 4', Georgia, serif" font-size="14" font-style="italic" fill="#0E0E0C">Saved together, delivered separately, never dropped</text>
+
+  <g font-family="'Source Sans 3', sans-serif">
+    <rect x="24" y="50" width="212" height="96" rx="10" fill="#FFFFFF" stroke="#2D4A2B" stroke-opacity="0.4"/>
+    <text x="130" y="72" text-anchor="middle" font-size="11" letter-spacing="1.4" fill="#2D4A2B">ONE ALL-OR-NOTHING STEP</text>
+    <rect x="40" y="82" width="180" height="26" rx="6" fill="#F7F6F2" stroke="#d8d5c9"/>
+    <text x="130" y="99" text-anchor="middle" font-size="12" fill="#0E0E0C">the shop record</text>
+    <rect x="40" y="112" width="180" height="26" rx="6" fill="#F7F6F2" stroke="#d8d5c9"/>
+    <text x="130" y="129" text-anchor="middle" font-size="12" fill="#0E0E0C">the ownership ticket</text>
+
+    <path d="M236,110 L282,110" stroke="#b3b0a4" stroke-width="1.3" fill="none" marker-end="url(#mk8a3)"/>
+
+    <rect x="284" y="82" width="126" height="56" rx="10" fill="#e8ede6" stroke="#2D4A2B" stroke-opacity="0.35"/>
+    <text x="347" y="105" text-anchor="middle" font-size="12" fill="#2D4A2B">the worker</text>
+    <text x="347" y="123" text-anchor="middle" font-size="11" fill="#4a6b47">reads the rail</text>
+
+    <path d="M410,110 L456,110" stroke="#b3b0a4" stroke-width="1.3" fill="none" marker-end="url(#mk8a3)"/>
+
+    <rect x="458" y="82" width="178" height="56" rx="10" fill="#2D4A2B"/>
+    <text x="547" y="105" text-anchor="middle" font-size="12" fill="#FFFFFF">permissions service</text>
+    <text x="547" y="123" text-anchor="middle" font-size="11" fill="#c3d3bf">Demo owns The Bondi Store</text>
+
+    <path d="M347,138 C347,176 347,176 347,182" stroke="#b3b0a4" stroke-width="1.3" fill="none" stroke-dasharray="4 4" marker-end="url(#mk8a3)"/>
+    <text x="357" y="166" font-size="11" fill="#a5a299">delivery failed?</text>
+    <text x="357" y="182" font-size="11" fill="#a5a299">ticket stays, try again</text>
+  </g>
+
+  <line x1="24" y1="206" x2="636" y2="206" stroke="#e6e4dc"/>
+  <g font-family="'Source Sans 3', sans-serif">
+    <text x="24" y="230" font-size="12" fill="#3d3d38">On first login, if the answer is not there yet, the dashboard waits a beat and asks again</text>
+    <text x="24" y="248" font-size="12" fill="#7a7a70">instead of showing a new merchant a locked door.</text>
+  </g>
+</svg>
+<div class="caption">Figure 3. The ticket rail. Nothing is lost because a delivery was slow.</div>
+</div>
+
+<p>We tell this story because it is the shape of most real platform work. The interesting problems are rarely "how do we build a shopping cart". They are "what happens when step two is slower than step three".</p>
+
+<hr>
+
+<h2>6. Everything you need to actually sell</h2>
+
+<p>With the door open and the keys handed over, here is what the merchant sees.</p>
+
+<div class="diagram">
+<img src="https://storage.googleapis.com/tesserix-blog-assets/blog/images/2026/07/mk8-admin-v2.png" alt="The Mark8ly admin dashboard for The Bondi Store, showing setup eighty percent complete, this month's takings and order counts" loading="lazy">
+<div class="caption">The Bondi Store's dashboard. Most of the setup was done for the merchant, and the month's takings sit where they can be seen at a glance.</div>
+</div>
+
+<p>That checklist is deliberate. An empty dashboard with eleven things to configure is how people give up. So the shop arrives already standing: settings filled in, a theme applied, a product in place. Changing something is far easier than starting from nothing.</p>
+
+<p>Underneath it is the real work of running a shop.</p>
+
+<div class="cards">
+  <div class="mc">
+    <span class="tag">Selling</span>
+    <h4>Products and orders</h4>
+    <p>Variants, photo galleries, categories, bulk upload by spreadsheet. Orders through their whole life, including the unglamorous end: cancellations, refunds, returns, and carts people abandoned.</p>
+  </div>
+  <div class="mc">
+    <span class="tag">Money</span>
+    <h4>Payments that work locally</h4>
+    <p>Stripe, Razorpay and PayPal, so a shop in Sydney and a shop in Pune both get a checkout their customers recognise and trust.</p>
+  </div>
+  <div class="mc">
+    <span class="tag">Delivery</span>
+    <h4>Shipping and tax</h4>
+    <p>Live rates and tracking through several carriers, and a tax engine that understands Indian GST and United States sales tax rather than one flat percentage.</p>
+  </div>
+  <div class="mc">
+    <span class="tag">Growth</span>
+    <h4>Getting people back</h4>
+    <p>Discount codes, gift cards, a points and referrals programme, email campaigns to customer segments, product reviews with photos, and wishlists.</p>
+  </div>
+</div>
+
+<p>Alongside those sit the things nobody asks about until the day they need them: a full record of who changed what, two-factor sign-in, a team page for adding staff with their own access, and live chat built into the shop.</p>
+
+<p>There is an admin app for the phone too. Running a shop does not happen at a desk. Approving an order or checking stock in a stockroom should not need a laptop. It signs in against the same permissions, so staff see exactly what they would see on the web.</p>
+
+<div class="diagram">
+<img class="phone" src="https://storage.googleapis.com/tesserix-blog-assets/blog/images/2026/07/mk8-mobile-admin-v2.png" alt="The Mark8ly admin app on a phone, showing The Bondi Store with this month's takings, order counts and three products running low on stock" loading="lazy">
+<div class="caption">The same shop on a phone: the month's takings, the order counts, and the three products running low that need attention today.</div>
+</div>
+
+<p>The shop your customers see is built to be fast. Pages are assembled on our servers and sent as finished HTML, so the storefront appears quickly on a phone with a weak signal, and search engines can read it properly. That is not a technical nicety. A slow shop and an invisible shop lose the same sale.</p>
+
+<p>Of the thirty-one things on our list for this first release, thirty are done. The one still open is different from the admin app above: a shop's own customer-facing app, under the merchant's name, on their own App Store account. That is a bigger promise, and we would rather ship it properly later than badly now.</p>
+
+<hr>
+
+<h2>7. What it costs us</h2>
+
+<p>Sharing one platform is the right choice. It is not a free one.</p>
+
+<ul>
+<li><strong>Shared systems raise the stakes.</strong> When thousands of shops share a platform, one careless query is not a small bug. That is why separation is enforced by the machinery instead of by someone remembering. It is slower to build that way, and we would choose it again.</li>
+<li><strong>Custom domains depend on things we do not control.</strong> The moment a merchant points their own address at us, we are relying on DNS, on their registrar, and on certificates renewing quietly forever. Usually it is instant. Sometimes it is a wait, and no amount of good engineering makes someone else's DNS faster.</li>
+<li><strong>Money and tax are local, everywhere.</strong> Every country has its own payment habits and its own tax rules. There is no clever shortcut. You do the work per country, or you do not really serve that country.</li>
+<li><strong>Email is harder than it looks.</strong> The whole sign-up rests on a message landing in an inbox in seconds, and not in a spam folder. That is its own ongoing discipline.</li>
+<li><strong>Things we chose not to build.</strong> No app marketplace and no theme store yet. Both are real work, and both are distractions until the core is genuinely solid. A shop that reliably takes money beats a plugin directory attached to a wobbly checkout.</li>
+</ul>
+
+<p>Security is part of shipping rather than a phase at the end. Every change runs through automatic dependency and vulnerability scanning before it can merge, and anything that fails stops the change instead of filing a ticket for later.</p>
+
+<hr>
+
+<h2>8. Open yours</h2>
+
+<p>That is the tour. An email address becomes a verified person. A verified person becomes a shop with its own address. That shop gets its own keys, and the keys arrive reliably even when a step runs slow.</p>
+
+<p>Underneath sits a good deal of machinery, all of it aimed at one thing: the person selling linen in Sydney should be thinking about linen, not about DNS records and permission models.</p>
+
+<p>Go and look at <a href="https://the-bondi-store.mark8ly.com">The Bondi Store</a>. Put something in the cart. See how it feels.</p>
+
+<p>Then, if you have something to sell, <a href="https://mark8ly.com/onboarding"><strong>open your own shop</strong></a>. It starts with an email address, exactly as The Bondi Store did.</p>
+
+</section>

--- a/docs/superpowers/plans/2026-08-24-tenant-suspend.md
+++ b/docs/superpowers/plans/2026-08-24-tenant-suspend.md
@@ -1,0 +1,1225 @@
+# Tenant Suspend / Unsuspend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `POST /admin/tenants/{id}/suspend` and `/unsuspend` (#287), where "suspended" actually stops the tenant trading rather than setting a column nothing reads.
+
+**Architecture:** Enforcement rides on **store** status, which the storefront already enforces and which marketplace-api already projects. Tenant status is the operator's record of decision and the cascade's source. A new `stores.suspended_by_tenant` flag makes unsuspend non-lossy. Four enforcement points: storefront (already works), `StoreMiddleware` for store-scoped admin API routes, a new tenant gate in marketplace-api for **all** admin routes, and the admin UI middleware. **`auth-bff` is not touched** — see T7 for why the spec's original approach there was replaced.
+
+**Tech Stack:** Go 1.26 (platform-api, marketplace-api), Gin, GORM, Postgres, Next.js middleware (TypeScript) in `apps/admin`.
+
+**Spec:** `docs/superpowers/specs/2026-08-24-tenant-suspend-design.md`
+
+## Global Constraints
+
+- **Two services, two migration schemes.** platform-api uses **4 digits** (latest `0014_unique_tenant_owner_email`, so this is `0015_stores_suspended_by_tenant`); marketplace-api uses **6** (`000001…`). Never copy one into the other — that confusion is trap 4.
+- **Two services, two `stores` tables.** platform-api's is the source of truth and FKs to `countries`/`currencies`/`timezones` (`GB`/`GBP`/`Europe/London` are seeded; `IE`/`Europe/Dublin` are not). marketplace-api's is a *local projection* with plain columns and **no** reference-data FKs. Say which one you mean, every time.
+- Suspend sets `active → suspended` only, and records `suspended_by_tenant = true` **only for rows it changed**. Unsuspend sets `suspended → active` **only where `suspended_by_tenant = true`**, then clears the flag.
+- Boundary rule wherever an age is compared: degraded/stale when `age >= window`, i.e. `ts <= asOf.Add(-window)`. Fixtures sit ON the boundary, offset by **1 millisecond** — `timestamptz` is microsecond-resolution, so a nanosecond offset truncates and both fixtures become the same row.
+- Every check that takes a clock takes `asOf` from the caller and compares against it in SQL — never Postgres `now()`.
+- **A cached `suspended` is authoritative regardless of age**; a stale `active` may still be served. Asymmetric on purpose.
+- Audit on both operations via `platformadmin.EmitOperatorAction(c, emitter, tenantID, ev)` — the tenant is a required parameter because nothing on this surface sets `tenant_id` on the context and `audit.Emit` would silently write no row (trap 3, #310).
+- Envelope `{"data": {...}}`, no `pagination`. Ids bare. Timestamps RFC3339 UTC.
+- Commits: single-line conventional, **no signature**, no `Co-Authored-By`.
+- Integration tests: `//go:build integration`, `-p 1`, LAN IP DSN (never `localhost`). `testdb.NewDB` **skips silently** when its env var is unset — confirm from verbose output that tests RAN. Also run **`go vet -tags=integration ./...`**: the default toolchain never compiles tagged files (trap 8).
+- Pre-existing unrelated failures in marketplace-api's `internal/subscription` and `internal/billing/trial` (#316/#317). Not yours; scope with `-run`.
+- Ignore the pre-existing `go.work requires go >= 1.26.6` diagnostic.
+
+## Task dependency shape
+
+T1 → T2 → T3 (platform-api, strictly ordered) → T4 → T5 (marketplace-api).
+**T6, T7 and T8 are independent of each other** and each depends only on T5's semantics being settled — they may be done in any order, or in parallel by separate agents.
+
+---
+
+### Task 1: platform-api — the `suspended_by_tenant` column
+
+**Files:**
+- Create: `services/platform-api/migrations/0015_stores_suspended_by_tenant.up.sql`
+- Create: `services/platform-api/migrations/0015_stores_suspended_by_tenant.down.sql`
+- Modify: `services/platform-api/internal/store/models.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `stores.suspended_by_tenant` column and `Store.SuspendedByTenant bool`, read by T2.
+
+- [ ] **Step 1: Write the migration**
+
+`0015_stores_suspended_by_tenant.up.sql`:
+
+```sql
+-- 0015_stores_suspended_by_tenant.up.sql
+-- Records WHO suspended a store, so unsuspending a tenant does not
+-- reactivate a store that was suspended individually beforehand (#287).
+-- Only rows changed by a tenant-level suspension carry true.
+ALTER TABLE stores
+    ADD COLUMN suspended_by_tenant BOOLEAN NOT NULL DEFAULT false;
+
+-- Partial index: the unsuspend path selects exactly these rows.
+CREATE INDEX stores_suspended_by_tenant_idx
+    ON stores (tenant_id)
+    WHERE suspended_by_tenant;
+```
+
+`0015_stores_suspended_by_tenant.down.sql`:
+
+```sql
+DROP INDEX IF EXISTS stores_suspended_by_tenant_idx;
+ALTER TABLE stores DROP COLUMN IF EXISTS suspended_by_tenant;
+```
+
+- [ ] **Step 2: Add the model field**
+
+In `internal/store/models.go`, on the `Store` struct, following the column-tag style already used there:
+
+```go
+	// SuspendedByTenant is true only for stores a TENANT-level suspension
+	// changed. Unsuspend restores exactly these rows, so a store suspended
+	// individually before the tenant was suspended stays suspended (#287).
+	SuspendedByTenant bool `gorm:"column:suspended_by_tenant;not null;default:false" json:"suspended_by_tenant"`
+```
+
+- [ ] **Step 3: Apply the migration and confirm the column exists**
+
+```bash
+cd services/platform-api && DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/platform_api?sslmode=disable' go run ./cmd/migrate up
+```
+
+Then confirm — do not assume the migration ran:
+
+```bash
+cd services/platform-api && go run ./cmd/migrate version
+```
+
+Expected: version `15`. If `cmd/migrate` has no `version` subcommand, verify by querying the column instead and say in your report which you did.
+
+- [ ] **Step 4: Build**
+
+```bash
+cd services/platform-api && go build ./... && go vet ./...
+```
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/platform-api/migrations/0015_* services/platform-api/internal/store/models.go
+git commit -m "feat(platform-api): add stores.suspended_by_tenant for reversible tenant suspension (#287)"
+```
+
+---
+
+### Task 2: platform-api — repository suspend/unsuspend with cascade
+
+**Files:**
+- Modify: `services/platform-api/internal/tenant/repository.go`
+- Test: `services/platform-api/internal/tenant/suspend_integration_test.go` (create)
+
+**Interfaces:**
+- Consumes: T1's column.
+- Produces, called by T3:
+
+```go
+// SuspendResult reports what a suspend/unsuspend actually changed.
+type SuspendResult struct {
+	Status         string // the tenant's status AFTER the call
+	StoresAffected int
+	Changed        bool   // false when the tenant was already in the target state
+}
+
+func (r *gormRepository) Suspend(ctx context.Context, tenantID string) (*SuspendResult, error)
+func (r *gormRepository) Unsuspend(ctx context.Context, tenantID string) (*SuspendResult, error)
+```
+
+Add both to the `Repository` interface in the same file.
+
+**Note on test package:** platform-api integration tests use the **internal** package (`package tenant`), unlike marketplace-api which uses external. Follow the local convention — check a neighbouring `*_integration_test.go` in this service before writing yours.
+
+- [ ] **Step 1: Write the failing reversibility test**
+
+This is the test the naive implementation fails. Create `suspend_integration_test.go`:
+
+```go
+//go:build integration
+
+package tenant
+
+// TestSuspendThenUnsuspendPreservesIndividuallySuspendedStore is the whole
+// reason suspended_by_tenant exists. A store suspended on its own, before
+// the tenant was suspended, must still be suspended after the tenant is
+// unsuspended. A cascade that just sets everything back to active fails
+// exactly here and nowhere else.
+func TestSuspendThenUnsuspendPreservesIndividuallySuspendedStore(t *testing.T) {
+	db := newTestDB(t) // follow the local helper convention
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	tenantID := seedTenant(t, db, StatusActive)
+	activeStore := seedStore(t, db, tenantID, "active")
+	alreadySuspended := seedStore(t, db, tenantID, "suspended")
+
+	// Suspend the tenant.
+	res, err := repo.Suspend(ctx, tenantID)
+	require.NoError(t, err)
+	require.True(t, res.Changed)
+	require.Equal(t, StatusSuspended, res.Status)
+	require.Equal(t, 1, res.StoresAffected, "only the ACTIVE store should be affected")
+
+	// Unsuspend it.
+	res, err = repo.Unsuspend(ctx, tenantID)
+	require.NoError(t, err)
+	require.True(t, res.Changed)
+	require.Equal(t, 1, res.StoresAffected)
+
+	require.Equal(t, "active", storeStatus(t, db, activeStore),
+		"the store the cascade suspended must be restored")
+	require.Equal(t, "suspended", storeStatus(t, db, alreadySuspended),
+		"a store suspended individually BEFORE the tenant suspension must stay suspended")
+	require.False(t, suspendedByTenant(t, db, activeStore), "flag must be cleared after unsuspend")
+}
+
+// A second suspend is a no-op: no extra stores affected, Changed false, and
+// the flag on already-cascaded rows is untouched.
+func TestSuspendIsIdempotent(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	tenantID := seedTenant(t, db, StatusActive)
+	s := seedStore(t, db, tenantID, "active")
+
+	first, err := repo.Suspend(ctx, tenantID)
+	require.NoError(t, err)
+	require.True(t, first.Changed)
+	require.Equal(t, 1, first.StoresAffected)
+
+	second, err := repo.Suspend(ctx, tenantID)
+	require.NoError(t, err)
+	require.False(t, second.Changed, "already suspended: no-op")
+	require.Equal(t, 0, second.StoresAffected)
+	require.True(t, suspendedByTenant(t, db, s), "flag must survive a repeat suspend")
+}
+```
+
+Write `seedTenant`, `seedStore`, `storeStatus` and `suspendedByTenant` helpers in the same file. **`stores` in platform-api FKs to the reference tables** — seed with `GB`/`GBP`/`Europe/London`, which are in the seed set; `IE`/`Europe/Dublin` are not and will fail.
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd services/platform-api && TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/platform_api?sslmode=disable' \
+  go test -tags integration -p 1 ./internal/tenant/ -run 'TestSuspend' -v
+```
+Expected: FAIL — `repo.Suspend` undefined. Confirm from the output that it **ran** rather than skipped; check what env var the local helper reads and use that one.
+
+- [ ] **Step 3: Implement both methods**
+
+In `internal/tenant/repository.go`. Both run in one transaction so the tenant row and its stores can never disagree:
+
+```go
+func (r *gormRepository) Suspend(ctx context.Context, tenantID string) (*SuspendResult, error) {
+	out := &SuspendResult{}
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var t Tenant
+		if err := tx.Raw(
+			`SELECT * FROM tenants WHERE id = ? FOR UPDATE`, tenantID).Scan(&t).Error; err != nil {
+			return err
+		}
+		if t.ID == "" {
+			return ErrNotFound
+		}
+		out.Status = t.Status
+		if t.Status == StatusSuspended {
+			return nil // no-op: Changed stays false, StoresAffected 0
+		}
+		if t.Status != StatusActive {
+			// archived, or anything added later: refuse rather than guess.
+			return fmt.Errorf("%w: tenant status %q cannot be suspended", ErrConflict, t.Status)
+		}
+
+		// Cascade to ACTIVE stores only, flagging exactly what we changed.
+		res := tx.Exec(`
+			UPDATE stores SET status = 'suspended', suspended_by_tenant = true
+			WHERE tenant_id = ? AND status = 'active'`, tenantID)
+		if res.Error != nil {
+			return res.Error
+		}
+		out.StoresAffected = int(res.RowsAffected)
+
+		if err := tx.Exec(`UPDATE tenants SET status = ? WHERE id = ?`,
+			StatusSuspended, tenantID).Error; err != nil {
+			return err
+		}
+		out.Status = StatusSuspended
+		out.Changed = true
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *gormRepository) Unsuspend(ctx context.Context, tenantID string) (*SuspendResult, error) {
+	out := &SuspendResult{}
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var t Tenant
+		if err := tx.Raw(
+			`SELECT * FROM tenants WHERE id = ? FOR UPDATE`, tenantID).Scan(&t).Error; err != nil {
+			return err
+		}
+		if t.ID == "" {
+			return ErrNotFound
+		}
+		out.Status = t.Status
+		if t.Status != StatusSuspended {
+			return nil // no-op
+		}
+
+		// Restore ONLY what the cascade suspended, then clear the flag.
+		res := tx.Exec(`
+			UPDATE stores SET status = 'active', suspended_by_tenant = false
+			WHERE tenant_id = ? AND suspended_by_tenant`, tenantID)
+		if res.Error != nil {
+			return res.Error
+		}
+		out.StoresAffected = int(res.RowsAffected)
+
+		if err := tx.Exec(`UPDATE tenants SET status = ? WHERE id = ?`,
+			StatusActive, tenantID).Error; err != nil {
+			return err
+		}
+		out.Status = StatusActive
+		out.Changed = true
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+```
+
+If `ErrNotFound`/`ErrConflict` are named differently in this package, use the local names — check `internal/tenant/errors.go` or equivalent rather than inventing sentinels.
+
+- [ ] **Step 4: Run the tests**
+
+Same command as Step 2. Expected: PASS, and confirm they RAN.
+
+- [ ] **Step 5: Mutation — prove the reversibility test discriminates**
+
+Change the unsuspend cascade's `WHERE tenant_id = ? AND suspended_by_tenant` to `WHERE tenant_id = ?` — the naive version. Re-run.
+Expected: **FAIL** in `TestSuspendThenUnsuspendPreservesIndividuallySuspendedStore`, because the individually-suspended store comes back active. Record the test name and the actual failure text. Revert.
+
+If it still passes, the fixture does not contain an individually-suspended store and the test proves nothing — fix it before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/platform-api/internal/tenant/
+git commit -m "feat(platform-api): reversible tenant suspend/unsuspend with store cascade (#287)"
+```
+
+---
+
+### Task 3: platform-api — the two `strictInternal` endpoints
+
+**Files:**
+- Modify: `services/platform-api/internal/tenant/handler.go`
+- Modify: `services/platform-api/cmd/server/main.go` (mount)
+- Test: `services/platform-api/internal/tenant/suspend_handler_test.go` (create)
+
+**Interfaces:**
+- Consumes: `Repository.Suspend`/`Unsuspend` and `SuspendResult` from T2.
+- Produces, called by T4:
+
+```
+POST /internal/tenants/:id/suspend    → 200 {"data":{"tenant_id","status","stores_affected","changed"}}
+POST /internal/tenants/:id/unsuspend  → 200, same shape
+```
+
+`404` unknown tenant, `409` when the status cannot make the transition (e.g. `archived`).
+
+**Why `strictInternal` and not the existing PATCH:** `updateTenantRequest` is `{Name, UID}` and runs `fga.Check(uid, "can_edit_settings", tenantID)` — a *merchant* authorization model a platform operator has no relation in, and it has no status field. Widening it would push a privileged field through a merchant-authorized path. `strictInternal` (`cmd/server/main.go:353`, `RequireInternalAuthStrict`) is the fail-closed group; the permissive variant would serve the whole estate on an unconfigured deploy.
+
+- [ ] **Step 1: Write the failing handler tests**
+
+Create `suspend_handler_test.go` (follow the local handler-test convention — check an existing handler test in this package for how it builds a router and stubs the repository):
+
+```go
+func TestSuspendHandler_ReturnsChangedAndCount(t *testing.T) {
+	h := newTestHandler(&stubRepo{suspend: &SuspendResult{
+		Status: StatusSuspended, StoresAffected: 2, Changed: true,
+	}})
+	rec := doPost(t, h, "/internal/tenants/"+testTenantID+"/suspend")
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body struct {
+		Data struct {
+			TenantID       string `json:"tenant_id"`
+			Status         string `json:"status"`
+			StoresAffected int    `json:"stores_affected"`
+			Changed        bool   `json:"changed"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, testTenantID, body.Data.TenantID)
+	require.Equal(t, "suspended", body.Data.Status)
+	require.Equal(t, 2, body.Data.StoresAffected)
+	require.True(t, body.Data.Changed)
+}
+
+// A no-op must be 200 with changed:false — NOT an error. #287's acceptance
+// says suspending an already-suspended tenant returns current state.
+func TestSuspendHandler_AlreadySuspendedIsOKNotError(t *testing.T) {
+	h := newTestHandler(&stubRepo{suspend: &SuspendResult{
+		Status: StatusSuspended, StoresAffected: 0, Changed: false,
+	}})
+	rec := doPost(t, h, "/internal/tenants/"+testTenantID+"/suspend")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"changed":false`)
+}
+
+func TestSuspendHandler_UnknownTenantIs404(t *testing.T) {
+	h := newTestHandler(&stubRepo{suspendErr: ErrNotFound})
+	rec := doPost(t, h, "/internal/tenants/"+testTenantID+"/suspend")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestSuspendHandler_ArchivedIs409(t *testing.T) {
+	h := newTestHandler(&stubRepo{suspendErr: ErrConflict})
+	rec := doPost(t, h, "/internal/tenants/"+testTenantID+"/suspend")
+	require.Equal(t, http.StatusConflict, rec.Code)
+}
+```
+
+Write an equivalent unsuspend test. **Give the stub distinct non-zero values** (`StoresAffected: 2`, not `1`) so an assertion cannot pass on a fabricated zero from a missing field.
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+cd services/platform-api && go test ./internal/tenant/ -run TestSuspendHandler -v
+```
+Expected: FAIL, undefined handler.
+
+- [ ] **Step 3: Implement the handlers**
+
+In `internal/tenant/handler.go`, matching the response-shaping style already in that file:
+
+```go
+// RegisterLifecycle mounts the operator-facing tenant lifecycle routes.
+// Mounted on strictInternal only: these act on the whole estate and are not
+// scoped by anything the caller had to know, so an unconfigured deploy must
+// answer 503 rather than serve them.
+func (h *Handler) RegisterLifecycle(internal *gin.RouterGroup) {
+	g := internal.Group("/tenants")
+	g.POST("/:id/suspend", h.suspendTenant)
+	g.POST("/:id/unsuspend", h.unsuspendTenant)
+}
+
+func (h *Handler) suspendTenant(c *gin.Context) {
+	h.lifecycle(c, h.repo.Suspend)
+}
+
+func (h *Handler) unsuspendTenant(c *gin.Context) {
+	h.lifecycle(c, h.repo.Unsuspend)
+}
+
+// lifecycle is shared by both routes: identical shaping, identical error
+// mapping, one implementation so the two cannot drift.
+func (h *Handler) lifecycle(c *gin.Context,
+	op func(context.Context, string) (*SuspendResult, error)) {
+
+	id := c.Param("id")
+	res, err := op(c.Request.Context(), id)
+	switch {
+	case errors.Is(err, ErrNotFound):
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "tenant_not_found", "message": "no tenant with that id"})
+		return
+	case errors.Is(err, ErrConflict):
+		c.JSON(http.StatusConflict, gin.H{
+			"error": "invalid_status_transition", "message": err.Error()})
+		return
+	case err != nil:
+		h.logger.Error("tenant lifecycle failed", "tenant_id", id, "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "internal_error", "message": "tenant lifecycle operation failed"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{
+		"tenant_id":       id,
+		"status":          res.Status,
+		"stores_affected": res.StoresAffected,
+		"changed":         res.Changed,
+	}})
+}
+```
+
+Use the package's real logger field name and error sentinels; do not introduce new ones.
+
+- [ ] **Step 4: Mount on strictInternal**
+
+In `cmd/server/main.go`, beside the existing `tenantHandler.RegisterDirectory(strictInternal)` at ~line 354:
+
+```go
+	tenantHandler.RegisterLifecycle(strictInternal)
+```
+
+Check whether this service registers routes at more than one site (marketplace-api does, and it has cost that repo five incidents). If there is only one engine here, say so in your report; if there are two, mount at both.
+
+- [ ] **Step 5: Run tests and build**
+
+```bash
+cd services/platform-api && go build ./... && go vet ./... && go test ./internal/tenant/ -run TestSuspend -v
+```
+Expected: PASS.
+
+- [ ] **Step 6: Prove the no-op test discriminates**
+
+Make the handler return `409` when `Changed` is false. Re-run.
+Expected: **FAIL** in `TestSuspendHandler_AlreadySuspendedIsOKNotError`. Record the test name and failure text. Revert.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add services/platform-api/internal/tenant/ services/platform-api/cmd/server/main.go
+git commit -m "feat(platform-api): internal tenant suspend/unsuspend endpoints on strictInternal (#287)"
+```
+
+---
+
+### Task 4: marketplace-api — a write client for platform-api
+
+Every existing client (`tenantdirectory`, `onboardingfunnel`, `estatecounts`) is **read-only**: a `do(ctx, path, out)` helper that issues GET. This is the surface's first write, so the client needs a POST path built to the same shape — a `maxBody` cap, `X-Internal-Auth`, and an `ErrUnavailable` that is **never** conflated with an empty result.
+
+**Files:**
+- Create: `services/marketplace-api/internal/tenantlifecycle/client.go`
+- Test: `services/marketplace-api/internal/tenantlifecycle/client_test.go`
+
+**Interfaces:**
+- Consumes: T3's endpoints.
+- Produces, called by T5:
+
+```go
+var ErrUnavailable = errors.New("tenantlifecycle: platform-api unavailable")
+var ErrNotFound    = errors.New("tenantlifecycle: tenant not found")
+var ErrConflict    = errors.New("tenantlifecycle: invalid status transition")
+
+type Result struct {
+	TenantID       string `json:"tenant_id"`
+	Status         string `json:"status"`
+	StoresAffected int    `json:"stores_affected"`
+	Changed        bool   `json:"changed"`
+}
+
+func NewClient(baseURL, secret string, httpClient *http.Client) *Client
+func (c *Client) Suspend(ctx context.Context, tenantID string) (*Result, error)
+func (c *Client) Unsuspend(ctx context.Context, tenantID string) (*Result, error)
+```
+
+- [ ] **Step 1: Copy the nearest client, do not invent a fourth shape**
+
+Read `internal/tenantdirectory/client.go` first. Reuse its constants and structure (`maxBody = 4 << 20`, the `X-Internal-Auth` header, the timeout, the error wrapping). The only new thing is a `post` helper alongside its `do`.
+
+- [ ] **Step 2: Write the failing tests**
+
+```go
+func TestSuspend_MapsStatusCodes(t *testing.T) {
+	cases := []struct {
+		name    string
+		code    int
+		body    string
+		wantErr error
+	}{
+		{"ok", 200, `{"data":{"tenant_id":"t1","status":"suspended","stores_affected":2,"changed":true}}`, nil},
+		{"not found", 404, `{"error":"tenant_not_found"}`, tenantlifecycle.ErrNotFound},
+		{"conflict", 409, `{"error":"invalid_status_transition"}`, tenantlifecycle.ErrConflict},
+		{"server error", 500, `{"error":"internal_error"}`, tenantlifecycle.ErrUnavailable},
+		{"bad gateway", 502, ``, tenantlifecycle.ErrUnavailable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodPost, r.Method)
+				require.Equal(t, "/internal/tenants/t1/suspend", r.URL.Path)
+				require.NotEmpty(t, r.Header.Get("X-Internal-Auth"), "internal auth header must be sent")
+				w.WriteHeader(tc.code)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			got, err := tenantlifecycle.NewClient(srv.URL, "secret", srv.Client()).
+				Suspend(context.Background(), "t1")
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				require.Nil(t, got, "an error must never come back with a usable result")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, 2, got.StoresAffected)
+			require.True(t, got.Changed)
+			require.Equal(t, "suspended", got.Status)
+		})
+	}
+}
+
+// A 200 whose body is truncated or unparseable is an error, not a zero
+// result. Conflating the two is how a caller ends up reporting "0 stores
+// affected, changed: false" for a request that actually did something.
+func TestSuspend_UnparseableBodyIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":{`))
+	}))
+	defer srv.Close()
+	got, err := tenantlifecycle.NewClient(srv.URL, "secret", srv.Client()).
+		Suspend(context.Background(), "t1")
+	require.Error(t, err)
+	require.Nil(t, got)
+}
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+```bash
+cd services/marketplace-api && go test ./internal/tenantlifecycle/ -v
+```
+Expected: FAIL, package does not exist.
+
+- [ ] **Step 4: Implement the client**
+
+Mirror `tenantdirectory`'s structure. The status mapping is the part that matters: `200` → decode; `404` → `ErrNotFound`; `409` → `ErrConflict`; anything else (including any 5xx and any transport error) → `ErrUnavailable`. Cap the read at `maxBody`.
+
+- [ ] **Step 5: Run the tests**
+
+Expected: PASS.
+
+- [ ] **Step 6: Prove the error mapping is real**
+
+Make the client return `nil` error on a 500. Re-run.
+Expected: **FAIL** in the `server error` subtest. Record the subtest name and failure text. Revert.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add services/marketplace-api/internal/tenantlifecycle/
+git commit -m "feat(marketplace-api): tenantlifecycle write client for platform-api (#287)"
+```
+
+---
+
+### Task 5: marketplace-api — the console-facing endpoints
+
+The surface's **first write**. Reason codes, capability, audit, and an immediate local-projection update all land here.
+
+**Files:**
+- Create: `services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle.go`
+- Modify: `services/marketplace-api/internal/handlers/platformadmin/routes.go`
+- Modify: `services/marketplace-api/cmd/marketplace-api/main.go` (**both** `Register` sites)
+- Test: `services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_test.go`
+- Create: `services/marketplace-api/internal/handlers/platformadmin/testdata/tenant_suspend_response.json`
+
+**Interfaces:**
+- Consumes: `tenantlifecycle.Client` (T4), `platformadmin.EmitOperatorAction`, `stores.Repository`.
+- Produces: the two routes, and a `TenantLifecycle` interface on `Deps`.
+
+```go
+type TenantLifecycle interface {
+	Suspend(ctx context.Context, tenantID string) (*tenantlifecycle.Result, error)
+	Unsuspend(ctx context.Context, tenantID string) (*tenantlifecycle.Result, error)
+}
+```
+
+Narrow interface declared in this package (not the concrete client type) so the handler is stubbable — the same reason `EstateCounts` and `OnboardingFunnel` are declared here.
+
+**ROUTING — read before touching `routes.go` (trap 2).** `/admin/tenants/{id}/suspend` collides with the merchant tree's `/admin/tenants/:tenantId/sso`: two different wildcard names at one path position makes gin **panic at router build time**, so the service fails to *start* rather than failing a request. Safe only while these routes are registered on the `platformadmin` group under `/api/v1/platform`. Never the merchant group. Do not "tidy" it.
+
+**CAPABILITY — a ruling you must not silently change.** `RequirePlatformAuth` already rejects a write whose `Capability` header is empty (`middleware.go:153`) but **never validates the value**, and no handler reads `CtxCapability` today. This plan keeps **presence-only** enforcement and **records the asserted capability in the audit row**. Do not invent a required capability string: the console asserts these values and a name chosen here could silently mismatch it, refusing every real request. If value semantics are wanted, that is a console-side decision and its own issue.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+package platformadmin_test
+
+// stubLifecycle records what it was asked to do and returns canned results.
+// Values are DISTINCT and NON-ZERO so an assertion cannot pass on a
+// fabricated zero from a missing field.
+type stubLifecycle struct {
+	res        *tenantlifecycle.Result
+	err        error
+	gotTenant  string
+	calls      int
+}
+
+func (s *stubLifecycle) Suspend(_ context.Context, id string) (*tenantlifecycle.Result, error) {
+	s.calls++
+	s.gotTenant = id
+	return s.res, s.err
+}
+func (s *stubLifecycle) Unsuspend(_ context.Context, id string) (*tenantlifecycle.Result, error) {
+	s.calls++
+	s.gotTenant = id
+	return s.res, s.err
+}
+
+func TestSuspend_RequiresKnownReasonCode(t *testing.T) {
+	for _, body := range []string{
+		`{}`,                                  // missing
+		`{"reason_code":""}`,                  // empty
+		`{"reason_code":"because_i_said_so"}`, // not in the set
+		`{"reason":"free text only"}`,         // free text is not a substitute
+	} {
+		rec := postLifecycle(t, newLifecycleDeps(t, &stubLifecycle{}), "suspend", body)
+		require.Equal(t, http.StatusBadRequest, rec.Code, "body %s must be rejected", body)
+		require.Contains(t, rec.Body.String(), "reason_code")
+	}
+}
+
+func TestSuspend_AcceptsEveryDeclaredCode(t *testing.T) {
+	for _, code := range platformadmin.SuspendReasonCodes {
+		stub := &stubLifecycle{res: &tenantlifecycle.Result{
+			TenantID: testTenant, Status: "suspended", StoresAffected: 3, Changed: true}}
+		rec := postLifecycle(t, newLifecycleDeps(t, stub), "suspend",
+			`{"reason_code":"`+code+`"}`)
+		require.Equal(t, http.StatusOK, rec.Code, "declared code %q must be accepted", code)
+	}
+}
+
+// The upstream's result is projected, not passed through, and the counts
+// come from upstream rather than being invented locally.
+func TestSuspend_ProjectsUpstreamResult(t *testing.T) {
+	stub := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "suspended", StoresAffected: 3, Changed: true}}
+	rec := postLifecycle(t, newLifecycleDeps(t, stub), "suspend", `{"reason_code":"abuse"}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, testTenant, stub.gotTenant)
+	var body struct {
+		Data struct {
+			TenantID       string `json:"tenant_id"`
+			Status         string `json:"status"`
+			StoresAffected int    `json:"stores_affected"`
+			Changed        bool   `json:"changed"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, 3, body.Data.StoresAffected)
+	require.True(t, body.Data.Changed)
+	require.Equal(t, "suspended", body.Data.Status)
+}
+
+// An upstream ErrUnavailable must NOT read as "nothing to do".
+func TestSuspend_UpstreamUnavailableIs503NotEmptySuccess(t *testing.T) {
+	stub := &stubLifecycle{err: tenantlifecycle.ErrUnavailable}
+	rec := postLifecycle(t, newLifecycleDeps(t, stub), "suspend", `{"reason_code":"abuse"}`)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.NotContains(t, rec.Body.String(), `"changed"`,
+		"a failed suspension must not shape a result at all")
+}
+
+func TestSuspend_UpstreamNotFoundIs404_ConflictIs409(t *testing.T) {
+	rec := postLifecycle(t, newLifecycleDeps(t, &stubLifecycle{err: tenantlifecycle.ErrNotFound}),
+		"suspend", `{"reason_code":"abuse"}`)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	rec = postLifecycle(t, newLifecycleDeps(t, &stubLifecycle{err: tenantlifecycle.ErrConflict}),
+		"suspend", `{"reason_code":"abuse"}`)
+	require.Equal(t, http.StatusConflict, rec.Code)
+}
+
+// The audit row must carry the tenant, the operator, and the reason code —
+// and there must be exactly ONE per changed call, none for a no-op.
+func TestSuspend_AuditsOncePerChangeAndNeverForNoOp(t *testing.T) {
+	changed := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "suspended", StoresAffected: 3, Changed: true}}
+	deps, emitted := newLifecycleDepsCapturingAudit(t, changed)
+	postLifecycle(t, deps, "suspend", `{"reason_code":"abuse","reason":"spam orders"}`)
+
+	require.Len(t, *emitted, 1, "exactly one audit row per changed suspension")
+	ev := (*emitted)[0]
+	require.Equal(t, testTenant, ev.TenantID.String(),
+		"an event with no tenant is silently DROPPED — this is the assertion that catches it")
+	require.Equal(t, "abuse", ev.Metadata["reason_code"])
+	require.Equal(t, "spam orders", ev.Metadata["reason"])
+	require.Equal(t, 3, ev.Metadata["stores_affected"])
+
+	noop := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "suspended", StoresAffected: 0, Changed: false}}
+	deps2, emitted2 := newLifecycleDepsCapturingAudit(t, noop)
+	rec := postLifecycle(t, deps2, "suspend", `{"reason_code":"abuse"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Empty(t, *emitted2, "a no-op writes NO audit row (#287 acceptance)")
+}
+
+// The local projection is updated in the same request, so enforcement does
+// not wait out StoreMiddleware's 5-minute TTL.
+func TestSuspend_UpdatesLocalProjectionImmediately(t *testing.T) { /* integration; see Step 5 */ }
+```
+
+Write helpers `newLifecycleDeps`, `newLifecycleDepsCapturingAudit`, and `postLifecycle` in the same file, following how `kpisRouter` and the existing signed-request helpers work in this package. The request must carry a valid signature, an operator, and a capability, or it will be rejected before the handler.
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+cd services/marketplace-api && go test ./internal/handlers/platformadmin/ -run 'TestSuspend|TestUnsuspend' -v
+```
+Expected: FAIL, undefined.
+
+- [ ] **Step 3: Implement reason codes and the handler**
+
+In `tenant_lifecycle.go`:
+
+```go
+// SuspendReasonCodes is the closed set for a suspension. An audit row
+// saying WHAT without WHY is the gap this series exists to close, so the
+// code is required; free text is accepted IN ADDITION, never instead.
+var SuspendReasonCodes = []string{
+	"abuse",         // abusive content or behaviour toward customers or staff
+	"fraud",         // suspected fraudulent transactions or identity
+	"non_payment",   // billing failed and the dunning ladder is exhausted
+	"legal",         // legal or regulatory demand
+	"tos_violation", // terms breach not covered by abuse or fraud
+	"security",      // compromised account or active security incident
+	"voluntary",     // merchant asked for the store to be paused
+}
+
+// UnsuspendReasonCodes is deliberately a different set: the reasons for
+// lifting a suspension are not the reasons for applying one.
+var UnsuspendReasonCodes = []string{
+	"resolved", "appeal_upheld", "operator_error", "voluntary_end",
+}
+```
+
+Validate with an explicit membership check that returns `400` naming the field and echoing the allowed set. Never coerce an unknown code, and never fall back to storing it as free text.
+
+The handler then: validates the body → calls the client → maps `ErrNotFound`/`ErrConflict`/`ErrUnavailable` to `404`/`409`/`503` → on `Changed` **only**, updates the local `stores` projection and emits the audit row → responds with the projected result. Emit via:
+
+```go
+if err := EmitOperatorAction(c, deps.Emitter, tenantUUID, audit.Event{
+	Action:       "tenant.suspended", // "tenant.unsuspended" on the other route
+	ResourceType: "tenant",
+	ResourceID:   tenantID,
+	Metadata: map[string]any{
+		"reason_code":     req.ReasonCode,
+		"reason":          req.Reason,
+		"stores_affected": res.StoresAffected,
+		"capability":      c.GetString(CtxCapability),
+	},
+}); err != nil {
+	// ErrMissingTenant: the operation SUCCEEDED upstream but we cannot
+	// attribute it. Log loudly; do not fail the response, and do not
+	// pretend it was attributed.
+	deps.Logger.Error("suspension not audited", "tenant_id", tenantID, "err", err)
+}
+```
+
+- [ ] **Step 4: Mount, and wire at BOTH main.go sites**
+
+Add `TenantLifecycle` to `Deps`, mount in `Register` behind a non-nil guard following the `Trials`/`AllSubscriptions` pattern, and construct it at **both** `platformadmin.Register` call sites in `main.go` (the `mode.Both` engine and the `mode.Admin` engine). One site only means production differs from dev silently — that is #323, and `cmd/marketplace-api/wiring_test.go` already asserts the two `Deps` literals carry the same field set, so a one-site change **fails that test**. Good: let it.
+
+- [ ] **Step 5: Integration test for the immediate projection update**
+
+In a `//go:build integration` file, seed a store row in marketplace-api's local `stores` projection, call the handler with a stub client returning `Changed: true`, and assert the local row is now `suspended` **without** waiting for any TTL. Remember marketplace-api's `stores` has **no** reference-data FKs (trap 4), so plausible strings suffice.
+
+- [ ] **Step 6: Golden fixture**
+
+Write `testdata/tenant_suspend_response.json` from real handler output, compare with `require.JSONEq`, and prove by mutation that it catches a field **rename** and a field **addition**. Both must fail. A fixture that only catches omissions is theatre.
+
+- [ ] **Step 7: Mutations — three, all required**
+
+1. Delete the reason-code membership check → `TestSuspend_RequiresKnownReasonCode` must FAIL.
+2. Emit the audit row unconditionally instead of only on `Changed` → the no-op half of `TestSuspend_AuditsOncePerChangeAndNeverForNoOp` must FAIL.
+3. Drop `TenantID` from the audit event → the tenant assertion must FAIL.
+
+Record the failing test name and actual failure text for each. Revert each.
+
+- [ ] **Step 8: Full run and commit**
+
+```bash
+cd services/marketplace-api && go build ./... && go vet ./... && go vet -tags=integration ./... \
+  && go test ./internal/handlers/platformadmin/ ./internal/tenantlifecycle/ ./cmd/marketplace-api/
+git add services/marketplace-api/
+git commit -m "feat(platformadmin): POST /admin/tenants/{id}/suspend and /unsuspend (#287)"
+```
+
+---
+
+### Task 6: marketplace-api — enforce store status in `StoreMiddleware`
+
+Independent of T7 and T8.
+
+**Files:**
+- Modify: `services/marketplace-api/internal/stores/middleware.go`
+- Test: `services/marketplace-api/internal/stores/middleware_test.go`
+
+**Interfaces:** consumes `Store.Status` (already on the projection, mapped at `platform_http.go:150`). Produces no new symbols.
+
+`StoreMiddleware` currently resolves the store, checks tenant ownership, sets `c.Set("store", …)` and calls `c.Next()` — **it never looks at status**. It is the single chokepoint for every store-scoped admin API route.
+
+- [ ] **Step 1: Write the failing tests**
+
+The helpers you need already exist in that file: `newFakeRepo()`, `repo.preload(store)`, `fakeClient`, `newFixtureStore(syncedAt)` (which sets `Status: stores.StatusActive`), `baseCfg(repo, client)`, `buildRouter(cfg, probe)`, `doRequest(r)`, and a `probe` whose `reached` field records whether the handler ran. Use them; do not build a second harness.
+
+```go
+// A suspended store must not serve admin API traffic even though it
+// resolves cleanly and belongs to the right tenant. `reached` is the real
+// assertion: a 404 with the handler still having run would mean the
+// middleware let it through and something later happened to 404.
+func TestMiddleware_SuspendedStoreIsRefused(t *testing.T) {
+	repo := newFakeRepo()
+	st := newFixtureStore(time.Now()) // fresh, so no refresh path is involved
+	st.Status = stores.StatusSuspended
+	repo.preload(st)
+	p := &probe{}
+
+	w := doRequest(buildRouter(baseCfg(repo, &fakeClient{}), p))
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404", w.Code)
+	}
+	if p.reached {
+		t.Fatal("handler was reached for a suspended store")
+	}
+}
+
+func TestMiddleware_ArchivedStoreIsRefused(t *testing.T) {
+	repo := newFakeRepo()
+	st := newFixtureStore(time.Now())
+	st.Status = stores.StatusArchived
+	repo.preload(st)
+	p := &probe{}
+
+	w := doRequest(buildRouter(baseCfg(repo, &fakeClient{}), p))
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404", w.Code)
+	}
+	if p.reached {
+		t.Fatal("handler was reached for an archived store")
+	}
+}
+
+// THE asymmetry, half one: a stale row that says `suspended` is still
+// enforced. The fixture is deliberately OLDER than StaleCeil and the client
+// is made to fail, so the only thing the middleware can act on is the stale
+// cached row — which must still refuse.
+func TestMiddleware_StaleSuspendedIsStillRefused(t *testing.T) {
+	cfg := baseCfg(newFakeRepo(), &fakeClient{err: stores.ErrPlatformUnavailable})
+	repo := newFakeRepo()
+	st := newFixtureStore(time.Now().Add(-25 * time.Hour)) // past the 24h StaleCeil
+	st.Status = stores.StatusSuspended
+	repo.preload(st)
+	cfg.Repo = repo
+	p := &probe{}
+
+	w := doRequest(buildRouter(cfg, p))
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404 (a cached suspended status is authoritative at any age)", w.Code)
+	}
+	if p.reached {
+		t.Fatal("handler was reached for a stale suspended store")
+	}
+}
+
+// THE asymmetry, half two, and the one that stops the fix going too far: a
+// stale ACTIVE row is still served when platform-api is unreachable. If this
+// test fails you have made the cache fail-closed and an outage now locks out
+// every merchant.
+func TestMiddleware_StaleActiveIsStillServed(t *testing.T) {
+	cfg := baseCfg(newFakeRepo(), &fakeClient{err: stores.ErrPlatformUnavailable})
+	repo := newFakeRepo()
+	repo.preload(newFixtureStore(time.Now().Add(-25 * time.Hour))) // stale, Status active
+	cfg.Repo = repo
+	p := &probe{}
+
+	w := doRequest(buildRouter(cfg, p))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (fail-open on stale ACTIVE is deliberate)", w.Code)
+	}
+	if !p.reached {
+		t.Fatal("handler not reached: stale active must still be served")
+	}
+}
+```
+
+Check `fakeClient`'s real field name for the error it returns and the exact sentinel the package uses for an unavailable platform (`internal/stores/errors.go`) — use those rather than the names above if they differ. The two stale tests must exercise the same code path with only `Status` differing; if you find yourself special-casing anything else between them, the asymmetry is not where you think it is.
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+cd services/marketplace-api && go test ./internal/stores/ -run TestStoreMiddleware -v
+```
+Expected: FAIL — a suspended store is currently served.
+
+- [ ] **Step 3: Implement, and decide the status code deliberately**
+
+Refuse any resolved store whose status is not `StatusActive`, on **both** the fresh-cache path and the post-refresh path, and — the asymmetry — refuse on the stale-serving path too when the cached status is suspended, while continuing to serve a stale `active`.
+
+Use **404**, matching `respondNotFound` already in this file and the storefront's own choice at `platform-api/internal/store/handler.go:150`. A 403 would confirm the store exists to a caller who is no longer entitled to know; the storefront already decided this question and the admin path should not disagree with it. State this choice in your report.
+
+- [ ] **Step 4: Run the tests**
+
+Expected: PASS.
+
+- [ ] **Step 5: Mutations — two**
+
+1. Remove the status check → `TestStoreMiddleware_SuspendedStoreIsRefused` must FAIL.
+2. Make the stale path serve a cached suspended row → `TestStoreMiddleware_StaleSuspendedIsStillRefused` must FAIL, while `TestStoreMiddleware_StaleActiveIsStillServed` keeps PASSING. If the second test also fails, you have made the cache fail-closed and locked out every merchant during an outage — that is the wrong fix.
+
+Record names and failure text. Revert both.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/marketplace-api/internal/stores/
+git commit -m "feat(marketplace-api): refuse admin traffic for non-active stores (#287)"
+```
+
+---
+
+### Task 7: marketplace-api — refuse ALL admin traffic for a suspended tenant
+
+Independent of T6 and T8. **This replaces the auth-bff approach the spec originally described.** Investigation showed auth-bff has no platform-api client, and gating only session *issuance* there would leave an existing session free to hit the three non-store-scoped admin groups — `/admin` (`routes.go:162`), `/admin/account` (`:170`) and the SSO group `/admin/tenants/:tenantId` (`:144`) — until it expired. T6 only covers `/admin/stores/:storeId`.
+
+**Files:**
+- Create: `services/marketplace-api/internal/tenantgate/gate.go`
+- Create: `services/marketplace-api/internal/tenantgate/gate_test.go`
+- Modify: `services/marketplace-api/internal/handlers/admin/routes.go` (apply to the four groups)
+- Modify: `services/marketplace-api/cmd/marketplace-api/main.go` (construct and pass it)
+
+**Interfaces:**
+- Consumes: `tenantdirectory.Client` — **already present in this service, and its `Tenant` type already carries `Status`** (`internal/tenantdirectory/client.go:39`), so no new endpoint and no new client is needed.
+- Produces:
+
+```go
+// Lookup is the subset of tenantdirectory.Client the gate needs.
+type Lookup interface {
+	Get(ctx context.Context, id string) (*tenantdirectory.TenantDetail, error)
+}
+
+func New(l Lookup, logger *slog.Logger, ttl time.Duration) *Gate
+func (g *Gate) RequireActiveTenant() gin.HandlerFunc
+```
+
+**Copy the shape of `internal/subscription/readonly`** (`middleware.go:25`, `allowlist.go`). It is the same problem — a status gate over admin routes — and it already solves the router-integration details.
+
+**RULING, do not silently change it: this gate allowlists NOTHING.** `RequireActive` deliberately lets every `GET /admin/**` through and allowlists billing, tax and subscription-recovery routes, because a read-only *subscription* is a billing state the merchant must be able to fix themselves. A tenant suspension is the opposite: an operator action taken for abuse, fraud or a legal demand, where self-service recovery is precisely what must not be available. A suspended tenant gets nothing and contacts support. If operators later want reason-dependent behaviour — say, letting a `non_payment` suspension still reach billing — that is a follow-up issue with its own review, not a quiet allowlist entry here.
+
+**Caching:** tenant status is fetched through `tenantdirectory` and cached in-process with a short TTL. The production admin deployment is `replicas: 1` today, so an in-process cache is coherent; if it is ever scaled, each pod simply fetches more often, which stays correct. Use `singleflight` to coalesce concurrent refreshes, exactly as `StoreMiddleware` does.
+
+**Staleness rules, matching T6's asymmetry:**
+- Cached `suspended` is **authoritative at any age** — never re-fetch to "give the tenant the benefit of the doubt".
+- Cached `active` past TTL is refreshed; if the refresh fails, serve on the stale `active`.
+- **No cached value at all plus a failed lookup: fail OPEN** (serve). A cold cache during a platform-api outage must not lock out every merchant. This is the one hole in the gate and it is deliberate — record it in your report.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+package tenantgate_test
+
+// stubLookup returns a canned tenant and counts calls so the cache can be
+// asserted. Values are distinct and non-zero so nothing passes on a zero.
+type stubLookup struct {
+	status string
+	err    error
+	calls  int32
+}
+
+func (s *stubLookup) Get(_ context.Context, id string) (*tenantdirectory.TenantDetail, error) {
+	atomic.AddInt32(&s.calls, 1)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &tenantdirectory.TenantDetail{
+		Tenant: tenantdirectory.Tenant{ID: id, Status: s.status},
+	}, nil
+}
+
+func buildGateRouter(t *testing.T, l tenantgate.Lookup, ttl time.Duration, reached *bool) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Set("tenant_id", testTenant) })
+	g := tenantgate.New(l, nil, ttl)
+	r.GET("/admin/account", g.RequireActiveTenant(), func(c *gin.Context) {
+		*reached = true
+		c.String(http.StatusOK, "ok")
+	})
+	return r
+}
+
+func doGet(r *gin.Engine, path string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	return rec
+}
+
+// An active tenant passes through.
+func TestGate_ActiveTenantPasses(t *testing.T) {
+	reached := false
+	rec := doGet(buildGateRouter(t, &stubLookup{status: "active"}, time.Minute, &reached), "/admin/account")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, reached)
+}
+
+// A suspended tenant is refused on a NON-store-scoped route — the whole
+// point of this task, since StoreMiddleware never sees these.
+func TestGate_SuspendedTenantIsRefusedOnNonStoreRoute(t *testing.T) {
+	reached := false
+	rec := doGet(buildGateRouter(t, &stubLookup{status: "suspended"}, time.Minute, &reached), "/admin/account")
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.False(t, reached, "handler must not run for a suspended tenant")
+}
+
+// NOTHING is allowlisted — not even a GET. This is the assertion that
+// catches someone copying readonly.DefaultAllowlist wholesale.
+func TestGate_NoAllowlistNotEvenGET(t *testing.T) {
+	reached := false
+	rec := doGet(buildGateRouter(t, &stubLookup{status: "suspended"}, time.Minute, &reached), "/admin/account")
+	require.Equal(t, http.StatusForbidden, rec.Code, "a GET is NOT exempt for a suspended tenant")
+	require.False(t, reached)
+}
+
+// The cache is used: two requests inside the TTL cause ONE lookup.
+func TestGate_CachesWithinTTL(t *testing.T) {
+	reached := false
+	l := &stubLookup{status: "active"}
+	r := buildGateRouter(t, l, time.Minute, &reached)
+	doGet(r, "/admin/account")
+	doGet(r, "/admin/account")
+	require.Equal(t, int32(1), atomic.LoadInt32(&l.calls), "second request must be served from cache")
+}
+
+// Cached suspended is authoritative at ANY age: even with the TTL expired
+// and the upstream now saying active, the gate keeps refusing until it has
+// successfully re-read. Assert the refusal, not the call count.
+func TestGate_CachedSuspendedIsAuthoritativeWhenLookupFails(t *testing.T) {
+	reached := false
+	l := &stubLookup{status: "suspended"}
+	r := buildGateRouter(t, l, time.Nanosecond, &reached) // instantly stale
+	require.Equal(t, http.StatusForbidden, doGet(r, "/admin/account").Code)
+
+	l.err = tenantdirectory.ErrUnavailable // upstream now unreachable
+	require.Equal(t, http.StatusForbidden, doGet(r, "/admin/account").Code,
+		"a cached suspended status must not decay into access")
+	require.False(t, reached)
+}
+
+// Stale ACTIVE plus a failed refresh still serves — fail-open, so an
+// outage does not lock out every merchant.
+func TestGate_StaleActiveWithFailedRefreshStillServes(t *testing.T) {
+	reached := false
+	l := &stubLookup{status: "active"}
+	r := buildGateRouter(t, l, time.Nanosecond, &reached)
+	require.Equal(t, http.StatusOK, doGet(r, "/admin/account").Code)
+
+	l.err = tenantdirectory.ErrUnavailable
+	require.Equal(t, http.StatusOK, doGet(r, "/admin/account").Code,
+		"stale active must still serve when the refresh fails")
+}
+
+// Cold cache plus a failed lookup fails OPEN. Deliberate: assert it so the
+// behaviour is a decision on the record rather than an accident.
+func TestGate_ColdCacheWithFailedLookupFailsOpen(t *testing.T) {
+	reached := false
+	rec := doGet(buildGateRouter(t,
+		&stubLookup{err: tenantdirectory.ErrUnavailable}, time.Minute, &reached), "/admin/account")
+	require.Equal(t, http.StatusOK, rec.Code,
+		"cold cache + outage must not lock out every merchant")
+	require.True(t, reached)
+}
+
+// No tenant on the context means this middleware cannot judge: pass through
+// and let the auth layer deal with it, rather than 403-ing every request.
+func TestGate_NoTenantOnContextPassesThrough(t *testing.T) { /* build a router without the tenant_id setter */ }
+```
+
+Fill in the last test's body following `buildGateRouter` minus the `c.Set("tenant_id", …)` line.
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+cd services/marketplace-api && go test ./internal/tenantgate/ -v
+```
+Expected: FAIL, package does not exist.
+
+- [ ] **Step 3: Implement the gate**
+
+`403` with `{"error":"tenant_suspended"}` — not `402` (that is `RequireActive`'s billing meaning) and not `404` (the tenant plainly exists to a caller already holding a session for it, and T6's 404 is about not confirming a *store* to someone no longer entitled to know it). State this choice in your report.
+
+- [ ] **Step 4: Run the tests.** Expected: PASS.
+
+- [ ] **Step 5: Apply the gate in `routes.go`**
+
+Add it to all four groups — `ssoTenant` (`:144`), `adminRoot` (`:162`), `account` (`:170`) and `storeRoute` (`:209`) — immediately after `authMW` in each chain, so it runs once the tenant is known. Yes, `storeRoute` too: T6 catches the store, this catches the tenant, and a tenant with zero stores has no store for T6 to catch. Do NOT apply it to the group at `:129` that deliberately runs with no `authMW` (read its comment first).
+
+- [ ] **Step 6: Wire in main.go**
+
+Construct once and pass through `admin.Deps`. If `tenantDirectoryClient` is nil (no `PLATFORM_API_URL`), pass a nil gate and have `RequireActiveTenant` be a no-op — matching how the other client-backed features degrade. Assert that no-op in a test: a nil gate must not panic.
+
+- [ ] **Step 7: Mutations — three, all required**
+
+1. Remove the status check → `TestGate_SuspendedTenantIsRefusedOnNonStoreRoute` must FAIL.
+2. Make a failed refresh clear the cached `suspended` → `TestGate_CachedSuspendedIsAuthoritativeWhenLookupFails` must FAIL while `TestGate_StaleActiveWithFailedRefreshStillServes` keeps PASSING. If both fail you have made it fail-closed and locked out every merchant during an outage — wrong fix.
+3. Add `{http.MethodGet, "/admin/*path"}` as an allowlist → `TestGate_NoAllowlistNotEvenGET` must FAIL.
+
+Record the failing test name and actual failure text for each. Revert each.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add services/marketplace-api/internal/tenantgate/ services/marketplace-api/internal/handlers/admin/routes.go services/marketplace-api/cmd/marketplace-api/main.go
+git commit -m "feat(marketplace-api): refuse all admin traffic for suspended tenants (#287)"
+```
+
+---
+
+### Task 8: apps/admin — refuse the admin UI for a suspended store
+
+Independent of T6 and T7.
+
+**Files:**
+- Modify: `apps/admin/middleware.ts` (~line 331, the `/internal/stores/by-slug/` fetch)
+- Test: follow the local convention for middleware tests in that app
+
+**Interfaces:** the internal by-slug response already returns the full store row including `status` — the middleware currently types it as `{ data: { tenant_id: string } }` and reads only `tenant_id`.
+
+- [ ] **Step 1: Write the failing test** — `{slug}-admin.mark8ly.com` for a suspended store must not render the admin app.
+
+- [ ] **Step 2: Run to verify it fails.**
+
+- [ ] **Step 3: Widen the type and add the check**
+
+```ts
+const body = (await storeRes.json()) as {
+  data: { tenant_id: string; status: string };
+};
+// A suspended or archived store must not serve the admin UI. Same 404 the
+// unknown-slug branch above returns, and the same choice platform-api makes
+// for the public storefront — an admin surface should not contradict it.
+if (body.data.status !== "active") {
+  return new NextResponse(null, { status: 404 });
+}
+```
+
+- [ ] **Step 4: Note the `/pick-tenant` gap in your report.** The enclosing guard is `if (requestedSlug && !isPickTenant)`, so `/pick-tenant` bypasses this check by design. Do NOT change that in this task — it exists to avoid a redirect loop. Report whether a suspended tenant's user can still reach `/pick-tenant`, and whether anything there is harmful. If it is, that is a follow-up issue, not a silent edit here.
+
+- [ ] **Step 5: Mutation** — revert the check and confirm your test fails. Record the name and failure text.
+
+- [ ] **Step 6: Commit** — `feat(admin): refuse the admin UI for non-active stores (#287)`
+
+---
+
+## After the plan
+
+**Verification after deploy** — separate the checks that carry information from those that merely mean "no data reached this code":
+
+- *Carries information, data-independent:* suspend a scratch tenant and confirm its storefront 404s, its admin subdomain 404s, a fresh login is refused, and the admin API refuses store-scoped calls. Then unsuspend and confirm each reverses. **This is the only check that proves the feature works**, because every enforcement point is a different codebase.
+- *Proves less:* the endpoint returning `200` with `stores_affected: 0`. Production has 4 tenants and 4 stores; a zero means the cascade matched nothing, not that it works.
+- **Do not test on a real merchant tenant.** There is one GKE cluster and it is production.
+
+**Gate verification on every service the change touches** — platform-api, marketplace-api and the admin app all ship separately, and a new caller against an old callee produces failures that look like bugs. Deploys are Kargo-gated: expect 10–20 minutes from freight appearing.
+
+**Follow-ups this plan deliberately leaves:** Cloudflare edge cache is not purged on suspension (a suspended storefront may serve from the edge until expiry); existing merchant sessions are not revoked; the `archived` transition is untouched; capability **values** are not validated (presence only). Each is stated in the spec's out-of-scope section — file issues rather than widening this work.

--- a/docs/superpowers/specs/2026-07-29-mark8ly-launch-blog-design.md
+++ b/docs/superpowers/specs/2026-07-29-mark8ly-launch-blog-design.md
@@ -1,0 +1,181 @@
+# Mark8ly launch blog post — design
+
+**Date:** 2026-07-29
+**Publishing target:** `blog.tesserix.app` (MongoDB-backed, see "Publishing" below)
+**Status:** drafted and saved to the blog as DRAFT (2026-07-29), awaiting review
+
+---
+
+## 1. Goal
+
+Announce the Mark8ly launch on the Tesserix blog with a post that earns its place
+next to the blog's existing technical explainers, while remaining fully readable
+by a non-technical merchant.
+
+The post is an **engineering story, not an advertisement**. It follows one
+merchant signup from an email address to a live storefront and explains, in plain
+English, everything the platform had to do along the way. The launch is the
+reason to write. The story is the content.
+
+**Success looks like:** a founder with no engineering background reads the whole
+thing, understands why running many shops from one system is hard, trusts that
+Mark8ly does it properly, and clicks through to The Bondi Store or to onboarding.
+
+---
+
+## 2. Audience and voice
+
+Primary reader: a merchant or founder evaluating where to put their store.
+Secondary reader: an engineer who follows the Tesserix blog.
+
+Voice rules (from the standing blog rules):
+
+- Very simple, clear English. Strong marketing language, no hype.
+- Every technical idea gets a plain-language stand-in **before** its real name.
+  Permissions become "who holds keys to which room". The outbox becomes "the
+  paperwork that follows the guest".
+- Professional, clean, engaging, well structured.
+- No AI tells. **No em dashes.** No "delve", "unleash", "in today's fast-paced
+  world", "it's not just X, it's Y", "seamlessly", "robust".
+- Reading time **12 to 15 minutes**, so a target of **~2,800 words**.
+
+---
+
+## 3. Title and slug
+
+**Title:** We Built a Real Online Store in Ten Minutes. Here Is Everything That Had to Happen.
+
+**Slug:** `we-built-a-real-online-store-in-ten-minutes`
+
+The title states the concrete outcome first and the promise of explanation
+second, matching the pattern of the blog's best-performing posts.
+
+---
+
+## 4. Narrative spine
+
+One signup, followed end to end.
+
+A merchant types an email at `mark8ly.com`. Ten minutes later **The Bondi Store**
+is live at `the-bondi-store.mark8ly.com` with its own admin dashboard at
+`the-bondi-store-admin.mark8ly.com`. The Bondi Store is a real demo tenant and is
+publicly reachable, so every claim in the post is checkable by the reader.
+
+This mirrors the device the blog's strongest post (Temporal) uses: open on one
+concrete moment, then spend the article explaining the machinery behind it.
+
+---
+
+## 5. Section outline
+
+Target roughly 350 words per section.
+
+| # | Section | Content | Word budget |
+|---|---------|---------|-------------|
+| 1 | **The ten minutes** | Open on the signup and the finished store. State the promise and what the reader will learn. Show the storefront screenshot early. | 350 |
+| 2 | **Proving you are you, without a password** | Magic-link verification. Why there is no password to steal. Why we store only a fingerprint (SHA-256 hash) of the link, never the link itself. | 330 |
+| 3 | **Giving a store its own front door** | Slug selection, subdomain, custom domains. How one visit to `the-bondi-store.mark8ly.com` finds the right shop out of every shop on the platform. Figure 2 lands here. | 400 |
+| 4 | **Who is allowed to touch what** | Permissions as keys and rooms. Why isolation is the product, not a feature. Relationship-based permissions (OpenFGA) named once, explained in plain words. | 400 |
+| 5 | **The handoff that used to break** | The honest section. The store existed before its permissions did, so the very first login failed. The outbox, the drainer, the retry. Werner Vogels quote lands here. Figure 3 lands here. | 400 |
+| 6 | **The rest of the shop** | What "30 of 31 features shipped" means to a merchant: products and variants, orders and refunds, payments in multiple countries, tax, shipping carriers, coupons, gift cards, loyalty, reviews. Admin screenshot lands here. | 400 |
+| 7 | **What this costs us** | House pattern, the honest tradeoffs. Multi-tenancy means one bad query can touch everyone. Custom domains mean DNS you do not control. Payments mean regional rules. What we chose not to build. | 350 |
+| 8 | **Open yours** | Short close. Link to The Bondi Store and to onboarding. No hard sell. | 170 |
+
+---
+
+## 6. Visuals
+
+All assets hosted at `storage.googleapis.com/tesserix-blog-assets/blog/images/2026/07/`.
+Palette is the Mark8ly system: paper `#F7F6F2`, ink `#0E0E0C`, moss `#2D4A2B`,
+elevated white `#FFFFFF`. Headline type is Source Serif 4, body Source Sans 3,
+mono JetBrains Mono.
+
+| Asset | Type | Purpose |
+|-------|------|---------|
+| **Banner** | Hand-authored SVG | Prominent, unique, editorial. Sets the paper/ink/moss tone at the top of the post. Also used as `featuredImage`. |
+| **Figure 1** | Hand-authored SVG | The ten-minute journey as a horizontal timeline: email, verify, store created, permissions granted, storefront live. |
+| **Figure 2** | Hand-authored SVG | How one request to `the-bondi-store.mark8ly.com` reaches the right store. The multi-tenancy explainer. |
+| **Figure 3** | Hand-authored SVG | The handoff: store record, outbox row, drainer, permissions, and the retry that closed the race. |
+| **Screenshot A** | PNG, Playwright | The Bondi Store storefront, public, no auth needed. |
+| **Screenshot B** | PNG, Playwright | The admin dashboard, captured with the demo login at `admin.mark8ly.com/login`. |
+
+Diagrams are hand-authored SVG rather than generated images: they stay crisp,
+stay editable, match the house style of recent posts, and carry no AI-image look.
+
+---
+
+## 7. Quote
+
+Placed in section 5, where the post admits the first version broke:
+
+> "Everything fails, all the time." — Werner Vogels, CTO, Amazon
+
+Rendered with the house `.pullquote` treatment.
+
+---
+
+## 8. Publishing
+
+`blog.tesserix.app` stores content in **MongoDB, not git**. There is no markdown
+file to commit. Publishing means inserting a document into
+`tesserix_blog.posts` on the `mongodb-blog` StatefulSet.
+
+The `content` field is one self-contained HTML block following the house format
+used by the strongest recent posts:
+
+```
+<style> scoped to #mk8-blog </style>
+<section id="mk8-blog">
+  <span class="kicker">…</span>
+  <h1>…</h1>
+  <p class="lede">…</p>
+  <hr>
+  <h2>1. …</h2>
+  … .diagram / .caption / .example / .pullquote …
+</section>
+```
+
+Post document fields to set:
+
+| Field | Value |
+|-------|-------|
+| `title` | Locked title from section 3 |
+| `slug` | `we-built-a-real-online-store-in-ten-minutes` |
+| `excerpt` | 1 to 2 sentences, merchant-facing |
+| `content` | The HTML block |
+| `status` | `PUBLISHED` |
+| `metaTitle` / `metaDescription` | SEO variants |
+| `featuredImage` / `featuredImageAlt` | Banner SVG on GCS, with alt text |
+| `category` | `Platform Engineering` |
+| `tags` | multi-tenant, commerce, ecommerce, saas, kubernetes, go, nextjs, openfga, platform, launch |
+| `authorName` / `authorEmail` / `authorAvatar` | Match existing posts |
+| `isFeatured` | `true` (launch post) |
+| `publishedAt` / `createdAt` / `updatedAt` | Publish timestamp |
+| `viewCount` | `0` |
+| `versions` | Single version 1 entry |
+
+**Draft first.** The HTML is written and reviewed locally before anything touches
+the production database. The Mongo insert is the last step and happens only on
+explicit approval.
+
+---
+
+## 9. Review gate before publishing
+
+The draft is checked for:
+
+1. Grammar, readability, and flow.
+2. Reading time inside 12 to 15 minutes.
+3. No em dashes and no AI-tell vocabulary.
+4. Every technical term introduced in plain language first.
+5. All links resolve, all images load from GCS.
+6. Renders correctly at mobile width.
+
+---
+
+## 10. Out of scope
+
+- The Mark8ly journal at `mark8ly.com/blog` stays a stub. Cross-posting is
+  separate work.
+- No changes to the blog application itself.
+- No SEO or distribution campaign beyond the post's own metadata.

--- a/docs/superpowers/specs/2026-08-24-tenant-suspend-design.md
+++ b/docs/superpowers/specs/2026-08-24-tenant-suspend-design.md
@@ -130,7 +130,11 @@ POST /api/v1/platform/admin/tenants/{id}/unsuspend
 ```
 
 - **Write**, so per the enforcement matrix both operator identity **and** capability are
-  required; a read-only caller gets 403.
+  required. A caller missing either gets **401**, not 403 — `RequirePlatformAuth`
+  (`internal/handlers/platformadmin/middleware.go:153`) answers 401 for a write with no
+  capability. An earlier draft of this spec said 403; that was wrong, and the middleware
+  is the authority. Note also that only *presence* is checked, never the value — see the
+  capability ruling in the plan.
 - Response is the tenant's **current state** plus what changed:
   `{"data": {"tenant_id", "status", "stores_affected": N, "changed": bool}}`.
 - **Suspending an already-suspended tenant is a no-op returning current state** — not an
@@ -204,10 +208,16 @@ a request. Safe only while these routes are registered on the `platformadmin` gr
 - **Idempotency:** a second suspend returns `changed: false`, writes no second audit row,
   and leaves `suspended_by_tenant` untouched. Assert the audit row **count**, not just
   presence.
-- **Stale-suspended is enforced:** a projection row older than `StaleCeil` with
-  `suspended` must still be denied. Put the fixture at the exact boundary and 1ms either
-  side — `timestamptz` is microsecond-resolution, so a nanosecond offset truncates and both
-  fixtures become the same row.
+- **Stale-suspended is enforced:** a projection row that is stale but still *within*
+  `StaleCeil` and reads `suspended` must be denied.
+
+  **Revised during implementation.** An earlier draft said to put the fixture at the exact
+  `StaleCeil` boundary. That is wrong here: beyond `StaleCeil` the middleware 404s
+  regardless of status, so a boundary fixture would pass for the wrong reason — the 404
+  coming from the ceiling, not from the status check. The fixture belongs at ~1h: past
+  `FreshTTL` (so a refresh is attempted) and well inside `StaleCeil` (so a failed refresh
+  reaches the stale-serve branch, which the status check must then override). Put a fixture
+  where the candidate implementations actually disagree, which is not always the boundary.
 - **Capability:** a caller with operator identity but without the capability gets 403.
 - Golden fixture for both responses, proved by mutation against a field rename **and** a
   field addition.

--- a/docs/superpowers/specs/2026-08-24-tenant-suspend-design.md
+++ b/docs/superpowers/specs/2026-08-24-tenant-suspend-design.md
@@ -60,10 +60,30 @@ Enforcement points, all reading store status:
 3. **Merchant admin UI** — the Next.js middleware already resolves
    `{slug}-admin.mark8ly.com` through platform-api's internal by-slug endpoint, whose
    response carries `status`. It gains a check.
-4. **New logins** — `auth-bff` gates session issuance on tenant status
-   (`internal/loginotp/handler.go:108` and `internal/autologin/service.go:181`). A cold
-   path, one check, and without it an existing session keeps working until it happens to
-   touch a store-scoped route, and non-store-scoped admin routes stay ungated entirely.
+4. **All admin routes, including the non-store-scoped ones** — a new tenant gate in
+   marketplace-api, applied after `authMW` on all four admin groups.
+
+   **Revised 2026-08-24 during planning.** This point originally said `auth-bff` would
+   gate session issuance. Investigation killed that: `auth-bff` holds **no platform-api
+   client at all**, so it would have meant a new cross-service dependency on the login
+   path — and gating issuance only stops *new* sessions, leaving an existing one free to
+   hit `/admin` (`routes.go:162`), `/admin/account` (`:170`) and the SSO group (`:144`)
+   until it expired. Point 2 only covers `/admin/stores/:storeId`.
+
+   The gate instead reuses the `tenantdirectory` client already present in
+   marketplace-api, whose `Tenant` type **already carries `Status`**
+   (`internal/tenantdirectory/client.go:39`), with an in-process TTL cache. It copies
+   `internal/subscription/readonly`'s `RequireActive` shape — the same problem already
+   solved in this codebase — with one deliberate difference: **it allowlists nothing.**
+   `RequireActive` exempts every `GET` and the billing/tax recovery routes because a
+   read-only *subscription* is a billing state the merchant must be able to fix. A tenant
+   suspension is an operator action taken for abuse, fraud or a legal demand, where
+   self-service recovery is exactly what must not exist.
+
+   Staleness follows the same asymmetry as the store projection: cached `suspended` is
+   authoritative at any age; stale `active` still serves; a **cold cache plus a failed
+   lookup fails open**, because an outage must not lock out every merchant. That last one
+   is the gate's one hole and it is deliberate.
 
 ### Why new platform-api endpoints rather than the existing PATCHes
 
@@ -199,8 +219,13 @@ a request. Safe only while these routes are registered on the `platformadmin` gr
 - **Cloudflare edge cache.** A suspended storefront may keep serving from the edge until
   the cached response expires. Enforcement is at origin; no purge is issued. If operators
   need immediate darkness, that is a separate piece of work against the Worker.
-- **Existing merchant sessions** are not revoked. They stop working when they touch a
-  store-scoped route or re-authenticate. Active session revocation is a bigger change to
-  `auth-bff`'s session model.
+- **Existing session cookies are not revoked** — but they are no longer useful. With the
+  tenant gate on all four admin groups, an existing session is refused on every admin
+  route, so revocation would change nothing an operator can observe. What remains out of
+  scope is *cookie invalidation itself* (a change to `auth-bff`'s session model) and
+  **new logins**: nothing stops a suspended tenant's merchant from completing a fresh
+  login and obtaining a cookie that is then refused everywhere. Cosmetic, but it means the
+  login screen does not explain why nothing works. Worth a follow-up for the message
+  alone.
 - **Archived tenants.** `archived` is a third status with its own semantics; this design
   touches only the active ↔ suspended transition.

--- a/docs/superpowers/specs/2026-08-24-tenant-suspend-design.md
+++ b/docs/superpowers/specs/2026-08-24-tenant-suspend-design.md
@@ -1,6 +1,6 @@
 # Design — tenant suspend / unsuspend (#287)
 
-**Status:** approved in principle, spec awaiting review
+**Status:** approved
 **Issue:** #287 · **Umbrella:** #260 · **Date:** 2026-08-24
 
 ## The problem this design exists to avoid

--- a/docs/superpowers/specs/2026-08-24-tenant-suspend-design.md
+++ b/docs/superpowers/specs/2026-08-24-tenant-suspend-design.md
@@ -1,0 +1,206 @@
+# Design — tenant suspend / unsuspend (#287)
+
+**Status:** approved in principle, spec awaiting review
+**Issue:** #287 · **Umbrella:** #260 · **Date:** 2026-08-24
+
+## The problem this design exists to avoid
+
+#287 reads as "add two endpoints and some reason codes". Implemented literally, it
+would ship an operator action that **enforces nothing**.
+
+Verified before designing:
+
+| path | gates on status today? |
+|---|---|
+| Storefront `{slug}.mark8ly.com` | **Yes.** `platform-api/internal/store/handler.go:150` — `if s.Status != StatusActive` → 404 |
+| Merchant admin API (marketplace-api) | **No.** `internal/stores/models.go:44` declares `StatusSuspended`; nothing reads it |
+| Merchant admin UI (Next.js) | **No**, though the internal by-slug endpoint it calls returns `status` |
+| **Tenant status, anywhere** | **No. Entirely inert.** |
+
+`tenant.StatusSuspended` exists at `platform-api/internal/tenant/models.go:41`. Nothing
+writes it, and searching all four Go services, their middleware, `auth-bff`, and the TS
+frontends found nothing that reads it to deny anything — the only two references count
+active tenants (`estate/counts.go:43`) and set active on creation
+(`onboarding/service.go:290`).
+
+So a `tenant.status = 'suspended'` write, alone, would leave the storefront serving, the
+merchants logging in, and orders processing, while the console displayed "suspended".
+That is the same defect class as #282's structurally-zero counter and #289's dropped
+`errored` metric — except here it is a **write an operator would rely on for an abuse or
+compliance decision**, which makes it the most consequential instance the milestone has
+produced.
+
+**Therefore: suspension is defined by what it enforces, and tenant status is the record
+of the decision rather than the mechanism.**
+
+## Architecture
+
+Enforcement rides on **store** status, which is already enforced at the storefront and is
+already projected into marketplace-api. Tenant status is written as the operator's record
+and is the cascade's source of truth.
+
+```
+console → POST /api/v1/platform/admin/tenants/{id}/suspend   (marketplace-api, HMAC + operator + capability)
+              │
+              ├─→ platform-api  POST /internal/tenants/{id}/suspend   (strictInternal, NEW)
+              │        ├─ tenants.status         = 'suspended'
+              │        └─ stores.status          = 'suspended'  WHERE status = 'active'
+              │           stores.suspended_by_tenant = true      (only for those rows)
+              │
+              └─→ marketplace-api local `stores` projection: same rows set to 'suspended'
+                  immediately, so enforcement does not wait out the 5-minute TTL
+```
+
+Enforcement points, all reading store status:
+
+1. **Storefront** — already works. No change.
+2. **Merchant admin API** — `internal/stores/middleware.go` `StoreMiddleware` resolves and
+   ownership-checks every store-scoped request and sets `c.Set("store", …)`. It gains a
+   status check. This is the single chokepoint for the API.
+3. **Merchant admin UI** — the Next.js middleware already resolves
+   `{slug}-admin.mark8ly.com` through platform-api's internal by-slug endpoint, whose
+   response carries `status`. It gains a check.
+4. **New logins** — `auth-bff` gates session issuance on tenant status
+   (`internal/loginotp/handler.go:108` and `internal/autologin/service.go:181`). A cold
+   path, one check, and without it an existing session keeps working until it happens to
+   touch a store-scoped route, and non-store-scoped admin routes stay ungated entirely.
+
+### Why new platform-api endpoints rather than the existing PATCHes
+
+`PATCH /internal/tenants/:id` takes `{Name, UID}` and `PATCH /internal/stores/:id` takes
+`{Name, Timezone, StorefrontTheme, UID}` — **neither accepts status**. Both also authorize
+by running an FGA check against the *caller's merchant GIP UID*
+(`can_edit_settings` / `can_edit_store_settings`), a model a platform operator has no
+relation in. Reusing them would require widening a merchant-authorized endpoint to accept
+a privileged field — exactly the wrong direction.
+
+The new endpoints mount on **`strictInternal`** (`platform-api/cmd/server/main.go:353`,
+`RequireInternalAuthStrict`), the fail-closed group, because they are estate-wide operator
+actions and not scoped by anything the caller had to know. The permissive
+`RequireInternalAuth` variant would serve the whole estate on an unconfigured deploy.
+
+## Reversibility — the part a naive cascade gets wrong
+
+If a tenant has one store already suspended individually, a cascade-back on unsuspend
+would wrongly reactivate it.
+
+`stores.suspended_by_tenant BOOLEAN NOT NULL DEFAULT false` (new column, platform-api)
+records who suspended each store.
+
+**Migration numbering:** platform-api uses a **4-digit** scheme and its latest is
+`0014_unique_tenant_owner_email`, so this is `0015_stores_suspended_by_tenant`. Do not
+copy marketplace-api's 6-digit scheme (`000001…`) — they are different services with
+different sequences, and the two-service confusion is trap 4's whole lesson.
+
+- **Suspend:** for stores currently `active` → set `suspended` and `suspended_by_tenant = true`.
+  A store already `suspended` or `archived` is untouched and keeps the flag `false`.
+- **Unsuspend:** set `active` **only where `suspended_by_tenant = true`**, then clear the flag.
+
+Chosen over a side table because it is one column, cannot drift out of sync with the row
+it describes, and makes both operations idempotent by construction.
+
+## Contract
+
+```
+POST /api/v1/platform/admin/tenants/{id}/suspend
+  { "reason_code": "abuse", "reason": "optional free text" }
+
+POST /api/v1/platform/admin/tenants/{id}/unsuspend
+  { "reason_code": "resolved", "reason": "optional free text" }
+```
+
+- **Write**, so per the enforcement matrix both operator identity **and** capability are
+  required; a read-only caller gets 403.
+- Response is the tenant's **current state** plus what changed:
+  `{"data": {"tenant_id", "status", "stores_affected": N, "changed": bool}}`.
+- **Suspending an already-suspended tenant is a no-op returning current state** — not an
+  error, and **no second audit row** (per #287's acceptance). `changed: false` says so
+  explicitly rather than leaving the caller to infer it.
+- Unsuspend is symmetric and equally attributed.
+- Ids bare; timestamps RFC3339 UTC.
+
+### Reason codes — proposed, for ruling
+
+Required, from a fixed set; free text optional **in addition**, never instead. An audit row
+saying *what* without *why* is the gap this series exists to close.
+
+| code | meaning |
+|---|---|
+| `abuse` | abusive content or behaviour toward customers or staff |
+| `fraud` | suspected fraudulent transactions or identity |
+| `non_payment` | billing failed and the dunning ladder is exhausted |
+| `legal` | legal or regulatory demand |
+| `tos_violation` | terms breach not covered by `abuse` or `fraud` |
+| `security` | compromised account or active security incident |
+| `voluntary` | merchant asked for the store to be paused |
+
+Unsuspend takes its own set: `resolved`, `appeal_upheld`, `operator_error`, `voluntary_end`.
+
+An unknown code is a `400` naming the field — never silently coerced, and never stored as
+free text.
+
+## Staleness: fail open, except when the cache says suspended
+
+marketplace-api's projection is deliberately fail-open — `StoreMiddleware` serves cached
+stores for up to `StaleCeil` (24h) when platform-api is unreachable, refreshing on a
+5-minute `FreshTTL`.
+
+**Ruling:** keep that behaviour, with one asymmetry — **a cached `suspended` status is
+authoritative regardless of age.** A stale `active` may still be served (an outage must not
+lock out every merchant); a stale `suspended` is always enforced.
+
+The asymmetry is deliberate: the two errors are not symmetric in cost. Serving a
+briefly-stale active store is a small correctness cost; serving a suspended one is the
+failure this endpoint exists to prevent. Suspension is also rare and deliberate, so the
+window in which the two disagree is small and always closes toward enforcement.
+
+Note the suspend endpoint writes the local projection directly in the same operation, so
+the propagation delay for the API path is **zero**, not five minutes. The TTL only matters
+for a suspension applied out-of-band in platform-api.
+
+## Audit
+
+Both operations audit through `platformadmin.EmitOperatorAction(c, emitter, tenantID, ev)`
+— the tenant is a required parameter there precisely because nothing on this surface sets
+`tenant_id` on the context and `audit.Emit` would otherwise silently write no row (trap 3,
+#310). The event carries the operator, the reason code, the free text, and
+`stores_affected`.
+
+## Routing (trap 2)
+
+`/admin/tenants/{id}/suspend` collides with the merchant tree's
+`/admin/tenants/:tenantId/sso` — two different wildcard names at one path position makes
+gin **panic at router build time**, taking the service down at startup rather than failing
+a request. Safe only while these routes are registered on the `platformadmin` group under
+`/api/v1/platform`, never the merchant group. Verify before touching routing.
+
+## Testing
+
+- Enforcement, per point, each proved by mutation: remove the check and the test fails.
+  A test that passes with the guard deleted is testing something else.
+- **`suspended_by_tenant` reversibility:** seed a tenant with one active and one
+  individually-suspended store; suspend; unsuspend; assert the individually-suspended one
+  is **still suspended**. This is the assertion the naive implementation fails.
+- **Idempotency:** a second suspend returns `changed: false`, writes no second audit row,
+  and leaves `suspended_by_tenant` untouched. Assert the audit row **count**, not just
+  presence.
+- **Stale-suspended is enforced:** a projection row older than `StaleCeil` with
+  `suspended` must still be denied. Put the fixture at the exact boundary and 1ms either
+  side — `timestamptz` is microsecond-resolution, so a nanosecond offset truncates and both
+  fixtures become the same row.
+- **Capability:** a caller with operator identity but without the capability gets 403.
+- Golden fixture for both responses, proved by mutation against a field rename **and** a
+  field addition.
+- Integration runs use `-p 1`, the LAN IP DSN, and `go vet -tags=integration ./...` is part
+  of the verification set (trap 8).
+
+## Out of scope, stated so nobody assumes otherwise
+
+- **Cloudflare edge cache.** A suspended storefront may keep serving from the edge until
+  the cached response expires. Enforcement is at origin; no purge is issued. If operators
+  need immediate darkness, that is a separate piece of work against the Worker.
+- **Existing merchant sessions** are not revoked. They stop working when they touch a
+  store-scoped route or re-authenticate. Active session revocation is a bigger change to
+  `auth-bff`'s session model.
+- **Archived tenants.** `archived` is a third status with its own semantics; this design
+  touches only the active ↔ suspended transition.

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -115,6 +115,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/subscription/readonly"
 	"github.com/mark8ly/marketplace-api/internal/teamproxy"
 	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
+	"github.com/mark8ly/marketplace-api/internal/tenantgate"
 	"github.com/mark8ly/marketplace-api/internal/tenantlifecycle"
 	"github.com/mark8ly/marketplace-api/internal/tenantpurge"
 	"github.com/mark8ly/marketplace-api/internal/ticket"
@@ -1014,7 +1015,23 @@ func main() {
 			SubRepo: subscriptionRepo,
 		})
 
+		// Tenant gate (#287) — refuses ALL admin traffic for a suspended
+		// tenant, across every admin group (StoreMiddleware only covers
+		// /admin/stores/:storeId). Degrades to a nil Gate — a no-op
+		// middleware — when MARKETPLACE_PLATFORM_API_URL is unset,
+		// matching how the other platform-api-backed features degrade.
+		var tenantGate *tenantgate.Gate
+		if cfg.PlatformAPIURL != "" {
+			tenantGate = tenantgate.New(
+				tenantdirectory.NewClient(cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil),
+				log, 5*time.Minute)
+			log.Info("admin: tenant suspension gate enabled", "url", cfg.PlatformAPIURL)
+		} else {
+			log.Info("admin: tenant suspension gate disabled (MARKETPLACE_PLATFORM_API_URL is empty)")
+		}
+
 		adminDeps = admin.Deps{
+			TenantGate:               tenantGate.RequireActiveTenant(),
 			ProductHandler:           productHandler,
 			CategoryHandler:          categoryHandler,
 			VariantHandler:           variantHandler,

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -115,6 +115,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/subscription/readonly"
 	"github.com/mark8ly/marketplace-api/internal/teamproxy"
 	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
+	"github.com/mark8ly/marketplace-api/internal/tenantlifecycle"
 	"github.com/mark8ly/marketplace-api/internal/tenantpurge"
 	"github.com/mark8ly/marketplace-api/internal/ticket"
 	"github.com/mark8ly/marketplace-api/internal/userprofile"
@@ -1924,12 +1925,15 @@ func main() {
 		var tenantDirectoryClient platformadmin.TenantDirectory
 		var onboardingFunnelClient platformadmin.OnboardingFunnel
 		var estateCountsClient platformadmin.EstateCounts
+		var tenantLifecycleClient platformadmin.TenantLifecycle
 		if cfg.PlatformAPIURL != "" {
 			tenantDirectoryClient = tenantdirectory.NewClient(
 				cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 			onboardingFunnelClient = onboardingfunnel.NewClient(
 				cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 			estateCountsClient = estatecounts.NewClient(
+				cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
+			tenantLifecycleClient = tenantlifecycle.NewClient(
 				cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 		}
 		platformSubscriptionRepo := subscription.NewRepository()
@@ -1944,6 +1948,8 @@ func main() {
 			Subscriptions:    platformadmin.SubscriptionsFunc(trial.CountExpiring),
 			Trials:           platformadmin.TrialListerFunc(trial.ListExpiring),
 			AllSubscriptions: platformadmin.SubscriptionListerFunc(platformSubscriptionRepo.ListAllSubscriptions),
+			TenantLifecycle:  tenantLifecycleClient,
+			Emitter:          auditEmitter,
 		})
 		storefront.RegisterStorefront(r.Group("/api/v1"), storefrontDeps)
 		storefront.RegisterMobileStorefrontSupport(r.Group("/api/v1"), storefrontSupportHandler, storefrontDeps.SlugCache, storefrontCustomerVerifier)
@@ -2029,12 +2035,15 @@ func main() {
 			var tenantDirectoryClient platformadmin.TenantDirectory
 			var onboardingFunnelClient platformadmin.OnboardingFunnel
 			var estateCountsClient platformadmin.EstateCounts
+			var tenantLifecycleClient platformadmin.TenantLifecycle
 			if cfg.PlatformAPIURL != "" {
 				tenantDirectoryClient = tenantdirectory.NewClient(
 					cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 				onboardingFunnelClient = onboardingfunnel.NewClient(
 					cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 				estateCountsClient = estatecounts.NewClient(
+					cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
+				tenantLifecycleClient = tenantlifecycle.NewClient(
 					cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 			}
 			platformSubscriptionRepo := subscription.NewRepository()
@@ -2049,6 +2058,8 @@ func main() {
 				Subscriptions:    platformadmin.SubscriptionsFunc(trial.CountExpiring),
 				Trials:           platformadmin.TrialListerFunc(trial.ListExpiring),
 				AllSubscriptions: platformadmin.SubscriptionListerFunc(platformSubscriptionRepo.ListAllSubscriptions),
+				TenantLifecycle:  tenantLifecycleClient,
+				Emitter:          auditEmitter,
 			})
 			// Public Delhivery webhook receiver. Mounted on the admin
 			// engine because the merchant-configured URL points at the

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1036,8 +1036,21 @@ func main() {
 			log.Info("admin: tenant suspension gate disabled (MARKETPLACE_PLATFORM_API_URL is empty)")
 		}
 
+		// TenantGate is assigned nil, not a method value on a nil *Gate,
+		// when the gate itself is unwired: a method value formed on a nil
+		// receiver is a non-nil func (RequireActiveTenant does its own
+		// g == nil check internally), which would make every `!= nil`
+		// guard downstream (admin/routes.go, admin/mobile_routes.go) dead
+		// code — this is the third instance of that pattern on this
+		// branch (#287 review, F3). Keeping the explicit nil here makes
+		// those guards real instead of decorative.
+		var adminTenantGateHandler gin.HandlerFunc
+		if tenantGate != nil {
+			adminTenantGateHandler = tenantGate.RequireActiveTenant()
+		}
+
 		adminDeps = admin.Deps{
-			TenantGate:               tenantGate.RequireActiveTenant(),
+			TenantGate:               adminTenantGateHandler,
 			ProductHandler:           productHandler,
 			CategoryHandler:          categoryHandler,
 			VariantHandler:           variantHandler,

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -455,6 +455,13 @@ func main() {
 	// /internal vendor endpoints, so no self-vendor lookup is needed.
 	// product.Service.resolveVendorID is nil-safe for exactly this case.
 	var vendorSvc *vendor.Service
+	// tenantGate (#287) is declared at outer scope so the platformadmin.Register
+	// call sites in the mode switch below (which construct the tenant
+	// lifecycle handler's invalidator) can see the same instance the admin
+	// group's RequireActiveTenant middleware reads from — one process, one
+	// cache. Constructed inside the admin wiring branch below; stays nil in
+	// Storefront-only builds.
+	var tenantGate *tenantgate.Gate
 	// brandingSeeder is non-nil only when MARKETPLACE_API_ENABLE_TEST_ROUTES=true.
 	// Declared at func scope so the later route-mount block can see it.
 	var brandingSeeder *testroutes.BrandingSeeder
@@ -1020,7 +1027,6 @@ func main() {
 		// /admin/stores/:storeId). Degrades to a nil Gate — a no-op
 		// middleware — when MARKETPLACE_PLATFORM_API_URL is unset,
 		// matching how the other platform-api-backed features degrade.
-		var tenantGate *tenantgate.Gate
 		if cfg.PlatformAPIURL != "" {
 			tenantGate = tenantgate.New(
 				tenantdirectory.NewClient(cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil),
@@ -1955,18 +1961,19 @@ func main() {
 		}
 		platformSubscriptionRepo := subscription.NewRepository()
 		platformadmin.Register(r.Group("/api/v1/platform"), platformadmin.Deps{
-			DB:               conn,
-			Repo:             auditRepo,
-			Logger:           log,
-			Secret:           cfg.PlatformAdminSecret,
-			TenantDirectory:  tenantDirectoryClient,
-			OnboardingFunnel: onboardingFunnelClient,
-			EstateCounts:     estateCountsClient,
-			Subscriptions:    platformadmin.SubscriptionsFunc(trial.CountExpiring),
-			Trials:           platformadmin.TrialListerFunc(trial.ListExpiring),
-			AllSubscriptions: platformadmin.SubscriptionListerFunc(platformSubscriptionRepo.ListAllSubscriptions),
-			TenantLifecycle:  tenantLifecycleClient,
-			Emitter:          auditEmitter,
+			DB:                    conn,
+			Repo:                  auditRepo,
+			Logger:                log,
+			Secret:                cfg.PlatformAdminSecret,
+			TenantDirectory:       tenantDirectoryClient,
+			OnboardingFunnel:      onboardingFunnelClient,
+			EstateCounts:          estateCountsClient,
+			Subscriptions:         platformadmin.SubscriptionsFunc(trial.CountExpiring),
+			Trials:                platformadmin.TrialListerFunc(trial.ListExpiring),
+			AllSubscriptions:      platformadmin.SubscriptionListerFunc(platformSubscriptionRepo.ListAllSubscriptions),
+			TenantLifecycle:       tenantLifecycleClient,
+			Emitter:               auditEmitter,
+			TenantGateInvalidator: tenantGate,
 		})
 		storefront.RegisterStorefront(r.Group("/api/v1"), storefrontDeps)
 		storefront.RegisterMobileStorefrontSupport(r.Group("/api/v1"), storefrontSupportHandler, storefrontDeps.SlugCache, storefrontCustomerVerifier)
@@ -2065,18 +2072,19 @@ func main() {
 			}
 			platformSubscriptionRepo := subscription.NewRepository()
 			platformadmin.Register(engine.Group("/api/v1/platform"), platformadmin.Deps{
-				DB:               conn,
-				Repo:             auditRepo,
-				Logger:           log,
-				Secret:           cfg.PlatformAdminSecret,
-				TenantDirectory:  tenantDirectoryClient,
-				OnboardingFunnel: onboardingFunnelClient,
-				EstateCounts:     estateCountsClient,
-				Subscriptions:    platformadmin.SubscriptionsFunc(trial.CountExpiring),
-				Trials:           platformadmin.TrialListerFunc(trial.ListExpiring),
-				AllSubscriptions: platformadmin.SubscriptionListerFunc(platformSubscriptionRepo.ListAllSubscriptions),
-				TenantLifecycle:  tenantLifecycleClient,
-				Emitter:          auditEmitter,
+				DB:                    conn,
+				Repo:                  auditRepo,
+				Logger:                log,
+				Secret:                cfg.PlatformAdminSecret,
+				TenantDirectory:       tenantDirectoryClient,
+				OnboardingFunnel:      onboardingFunnelClient,
+				EstateCounts:          estateCountsClient,
+				Subscriptions:         platformadmin.SubscriptionsFunc(trial.CountExpiring),
+				Trials:                platformadmin.TrialListerFunc(trial.ListExpiring),
+				AllSubscriptions:      platformadmin.SubscriptionListerFunc(platformSubscriptionRepo.ListAllSubscriptions),
+				TenantLifecycle:       tenantLifecycleClient,
+				Emitter:               auditEmitter,
+				TenantGateInvalidator: tenantGate,
 			})
 			// Public Delhivery webhook receiver. Mounted on the admin
 			// engine because the merchant-configured URL points at the

--- a/services/marketplace-api/internal/handlers/admin/mobile_routes.go
+++ b/services/marketplace-api/internal/handlers/admin/mobile_routes.go
@@ -42,11 +42,23 @@ func RegisterAdminMobile(router *gin.RouterGroup, deps MobileDeps) {
 	// explicit RequireTenantRelation are still protected.
 	requireTenant := auth.RequireTenantClaim()
 
+	// tenantMW mirrors routes.go's tenantMW: auth, tenant-claim guard, then
+	// TenantGate (#287, F1) so a suspended tenant is refused on every
+	// non-store-scoped mobile group too — this is the fifth admin route
+	// group the design's four-group count missed. TenantGate is a nil-safe
+	// method value (see Deps.TenantGate's doc), so appending it
+	// unconditionally is safe whether or not the gate is wired.
+	tenantMW := []gin.HandlerFunc{bearerAuth, requireTenant}
+	if deps.TenantGate != nil {
+		tenantMW = append(tenantMW, deps.TenantGate)
+	}
+	tenantMW = append(tenantMW, rateLimiter)
+
 	// Platform support chat — merchant admin → Tesserix platform team.
 	// Not store-scoped: it rides the admin's tenant from the bearer token,
 	// so any authenticated merchant admin can open a platform chat.
 	if deps.PlatformSupportHandler != nil {
-		ps := router.Group("/mobile/admin/platform-support", bearerAuth, requireTenant, rateLimiter)
+		ps := router.Group("/mobile/admin/platform-support", tenantMW...)
 		deps.PlatformSupportHandler.Register(ps)
 	}
 
@@ -56,19 +68,25 @@ func RegisterAdminMobile(router *gin.RouterGroup, deps MobileDeps) {
 	// on purpose — platform-api is authoritative on owner-vs-staff teardown,
 	// and Apple requires the deletion path to work for staff too.
 	if deps.MobileAccountHandler != nil {
-		acct := router.Group("/mobile/admin/account", bearerAuth, requireTenant, rateLimiter)
+		acct := router.Group("/mobile/admin/account", tenantMW...)
 		acct.DELETE("", deps.MobileAccountHandler.Delete)
 	}
 
 	// Tenant-wide routes
 	if deps.StoresHandler != nil {
-		mobileRoot := router.Group("/mobile/admin", bearerAuth, requireTenant, rateLimiter)
+		mobileRoot := router.Group("/mobile/admin", tenantMW...)
 		mobileRoot.GET("/stores",
 			deps.AuthzMiddleware.RequireTenantRelation(authz.RoleStaff),
 			deps.StoresHandler.List)
 	}
 
-	storeRoute := router.Group("/mobile/admin/stores/:storeId", bearerAuth, requireTenant, rateLimiter, deps.StoresMiddleware)
+	// storeRoute chain: bearerAuth -> requireTenant -> TenantGate ->
+	// rateLimiter -> StoresMiddleware, matching routes.go's storeMW
+	// ordering (tenantMW then StoresMiddleware). TenantGate runs and
+	// aborts BEFORE StoresMiddleware ever executes, so a suspended tenant
+	// never reaches the store-ownership lookup — no double-abort, just the
+	// same short-circuit routes.go already relies on.
+	storeRoute := router.Group("/mobile/admin/stores/:storeId", append(append([]gin.HandlerFunc{}, tenantMW...), deps.StoresMiddleware)...)
 	{
 		// Dashboard
 		if deps.DashboardHandler != nil {

--- a/services/marketplace-api/internal/handlers/admin/mobile_routes_tenantgate_test.go
+++ b/services/marketplace-api/internal/handlers/admin/mobile_routes_tenantgate_test.go
@@ -1,0 +1,67 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/auth"
+	"github.com/mark8ly/marketplace-api/internal/authz"
+	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
+	"github.com/mark8ly/marketplace-api/internal/tenantgate"
+)
+
+// stubTenantLookup is a minimal tenantgate.Lookup double: it always
+// returns the configured status for whatever tenant id is asked for.
+type stubTenantLookup struct {
+	status string
+}
+
+func (s *stubTenantLookup) Get(_ context.Context, id string) (*tenantdirectory.TenantDetail, error) {
+	return &tenantdirectory.TenantDetail{
+		Tenant: tenantdirectory.Tenant{ID: id, Status: s.status},
+	}, nil
+}
+
+// TestRegisterAdminMobile_SuspendedTenantRefusedOnNonStoreRoute is the F1
+// regression test (#287 review): mobile_routes.go is the FIFTH admin route
+// group, and it never applied deps.TenantGate — so a suspended tenant's
+// phone could keep reaching non-store-scoped mobile routes (platform
+// support chat, account deletion, GET /mobile/admin/stores) even though
+// the same tenant is refused everywhere on the web admin table.
+//
+// This exercises GET /api/v1/mobile/admin/stores specifically: it is
+// tenant-wide, NOT store-scoped, so deps.StoresMiddleware never runs on
+// it and only deps.TenantGate can catch a suspended tenant here.
+func TestRegisterAdminMobile_SuspendedTenantRefusedOnNonStoreRoute(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	gate := tenantgate.New(&stubTenantLookup{status: "suspended"}, nil, time.Minute)
+
+	RegisterAdminMobile(r.Group("/api/v1"), MobileDeps{
+		Deps: Deps{
+			StoresHandler:   &StoresHandler{},
+			AuthzMiddleware: authz.NewMiddleware(nil, nil),
+			TenantGate:      gate.RequireActiveTenant(),
+			StoresMiddleware: func(c *gin.Context) {
+				c.Next()
+			},
+		},
+		TokenVerifier: &auth.FakeVerifier{UserID: "user-1", TenantID: "tenant-1"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mobile/admin/stores", nil)
+	req.Header.Set("Authorization", "Bearer fake")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code,
+		"a suspended tenant must be refused on the mobile route, exactly as on the web admin table")
+	require.Contains(t, rec.Body.String(), "tenant_suspended")
+}

--- a/services/marketplace-api/internal/handlers/admin/routes.go
+++ b/services/marketplace-api/internal/handlers/admin/routes.go
@@ -85,8 +85,14 @@ type Deps struct {
 	StoresMiddleware         gin.HandlerFunc // from stores.StoreMiddleware
 	SubscriptionStatusLoader gin.HandlerFunc // optional; runs after StoresMiddleware
 	SubscriptionReadOnlyGate gin.HandlerFunc // optional; runs after StatusLoader — returns 402 on read-only states
-	AuthzMiddleware          *authz.Middleware
-	InternalSecret           string
+	// TenantGate refuses ALL admin traffic for a suspended tenant (#287),
+	// via tenantgate.Gate.RequireActiveTenant. Runs immediately after
+	// authMW in every admin group EXCEPT the break-glass recovery route,
+	// which must survive a suspension. Nil (no PLATFORM_API_URL) degrades
+	// to a no-op, matching how other client-backed features degrade.
+	TenantGate      gin.HandlerFunc
+	AuthzMiddleware *authz.Middleware
+	InternalSecret  string
 	// AuditIngestSecret gates /internal/* routes on the admin engine
 	// (audit-events, shipments/tracking/sync, storefront-status). In
 	// prod all three endpoints pull the SAME value from the
@@ -106,6 +112,15 @@ type Deps struct {
 // RequireTenantRelation runs the FGA Check per spec §13.1.1.
 func RegisterAdmin(router *gin.RouterGroup, deps Deps) {
 	authMW := auth.HeaderTrustAuth(deps.InternalSecret)
+
+	// tenantMW runs authMW and, once the tenant is known, TenantGate
+	// (#287) — refusing every request for a suspended tenant across all
+	// tenant-scoped and store-scoped groups. Excluded on purpose from the
+	// break-glass route below, which must survive a suspension.
+	tenantMW := []gin.HandlerFunc{authMW}
+	if deps.TenantGate != nil {
+		tenantMW = append(tenantMW, deps.TenantGate)
+	}
 
 	// Internal-only routes — cluster-internal callers (CronJobs,
 	// other services). Gated ONLY by the shared X-Internal-Auth
@@ -141,7 +156,7 @@ func RegisterAdmin(router *gin.RouterGroup, deps Deps) {
 		// Authz runs before the plan gate so a non-member learns nothing
 		// about the tenant's subscription. Writes are owner-only: the IdP
 		// config decides who can authenticate into the whole tenant.
-		ssoTenant := router.Group("/admin/tenants/:tenantId", authMW)
+		ssoTenant := router.Group("/admin/tenants/:tenantId", tenantMW...)
 		ssoRead := ssoTenant.Group("",
 			deps.AuthzMiddleware.RequireTenantRelation(authz.RoleAdmin),
 			plangate.RequireFeatureByTenant(deps.PlanResolver, plangate.FeatureSSO, deps.APIKeysLogger),
@@ -159,7 +174,7 @@ func RegisterAdmin(router *gin.RouterGroup, deps Deps) {
 	// Tenant-wide admin routes — outside of /stores/:storeId because they
 	// enumerate across stores, not within a single one.
 	if deps.StoresHandler != nil {
-		adminRoot := router.Group("/admin", authMW)
+		adminRoot := router.Group("/admin", tenantMW...)
 		adminRoot.GET("/stores",
 			deps.AuthzMiddleware.RequireTenantRelation(authz.RoleStaff),
 			deps.StoresHandler.List)
@@ -167,7 +182,7 @@ func RegisterAdmin(router *gin.RouterGroup, deps Deps) {
 
 	// Account — S1. Lives outside /stores/:storeId because it's user-scoped.
 	if deps.AccountHandler != nil {
-		account := router.Group("/admin/account", authMW)
+		account := router.Group("/admin/account", tenantMW...)
 		{
 			account.GET("",
 				deps.AuthzMiddleware.RequireTenantRelation(authz.AccountViewRole),
@@ -199,7 +214,7 @@ func RegisterAdmin(router *gin.RouterGroup, deps Deps) {
 		}
 	}
 
-	storeMW := []gin.HandlerFunc{authMW, deps.StoresMiddleware}
+	storeMW := append(append([]gin.HandlerFunc{}, tenantMW...), deps.StoresMiddleware)
 	if deps.SubscriptionStatusLoader != nil {
 		storeMW = append(storeMW, deps.SubscriptionStatusLoader)
 	}

--- a/services/marketplace-api/internal/handlers/platformadmin/audit.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/audit.go
@@ -2,6 +2,7 @@ package platformadmin
 
 import (
 	"errors"
+	"log/slog"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -26,7 +27,17 @@ func EmitOperatorAction(c *gin.Context, em *audit.Emitter, tenantID uuid.UUID, e
 		return ErrMissingTenant
 	}
 	if em == nil {
-		return nil // safe to call when wiring opted out, matching Emit's own nil-receiver tolerance
+		// Still safe to call — matching Emit's own nil-receiver tolerance —
+		// but never silent: a nil emitter here means SOME write path is
+		// producing an audit-worthy event with no way to record it, and
+		// that must show up in logs even when this specific caller (e.g.
+		// wiring that opted out of auditing entirely) has no *slog.Logger
+		// of its own to hand in. slog.Default() rather than a threaded
+		// logger param, so this stays a drop-in replacement for every
+		// existing call site.
+		slog.Default().Warn("platformadmin: EmitOperatorAction called with a nil emitter, event dropped",
+			"action", ev.Action, "resource_type", ev.ResourceType, "tenant_id", tenantID)
+		return nil
 	}
 
 	ev.TenantID = tenantID

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/stores"
 )
 
 // Deps groups everything the platform admin surface needs. Constructed in
@@ -49,6 +50,20 @@ type Deps struct {
 	// TenantDirectory above for the tenant-name lookup. Both must be
 	// non-nil for that route to mount, matching the Trials pattern above.
 	AllSubscriptions SubscriptionLister
+
+	// TenantLifecycle serves POST /admin/tenants/:id/{suspend,unsuspend}
+	// (#287) — this surface's first WRITE endpoints. Nil leaves those
+	// routes unmounted, matching the nil-safe pattern used for the other
+	// client-backed routes above. Requires DB (non-nil) too, since the
+	// handler updates the local `stores` projection on a changed call.
+	TenantLifecycle TenantLifecycle
+
+	// Emitter is the async audit-log writer used for write-endpoint audit
+	// rows (currently only tenant suspend/unsuspend). Nil is tolerated —
+	// EmitOperatorAction treats a nil *audit.Emitter the same way Emit
+	// itself does: a fire-and-forget no-op, never a panic or an error that
+	// would fail a request that already succeeded upstream.
+	Emitter *audit.Emitter
 }
 
 // Register mounts the platform console's /admin/* surface behind
@@ -123,5 +138,14 @@ func Register(g *gin.RouterGroup, deps Deps) {
 
 	if deps.AllSubscriptions != nil && deps.TenantDirectory != nil {
 		NewBillingSubscriptionsHandler(deps.AllSubscriptions, deps.TenantDirectory, deps.DB, deps.Logger).Register(group)
+	}
+
+	if deps.TenantLifecycle != nil && deps.DB != nil {
+		NewTenantLifecycleHandler(
+			deps.TenantLifecycle,
+			stores.NewRepository(deps.DB),
+			NewOperatorActionAuditFunc(deps.Emitter),
+			deps.Logger,
+		).Register(group)
 	}
 }

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -71,6 +71,23 @@ type Deps struct {
 	// than silent, since #287 — for callers reached other than through
 	// this Register guard.)
 	Emitter *audit.Emitter
+
+	// TenantGateInvalidator drops a tenant's cached status so a suspension
+	// takes effect immediately instead of at the next cache refresh (#287
+	// fix-round-1). Unlike Emitter above, nil here is a genuine no-op, not
+	// a mount guard: an unwired invalidator just leaves today's TTL-lag
+	// behaviour in place (a delay, never a lost audit record), so it does
+	// NOT gate whether the TenantLifecycle routes mount.
+	TenantGateInvalidator TenantGateInvalidator
+}
+
+// TenantGateInvalidator drops a tenant's cached admin-gate status. Declared
+// here (not importing internal/tenantgate's concrete type) so this package
+// stays decoupled from the admin group's gate implementation — the same
+// reason TenantDirectory, TenantLifecycle etc. are declared as local
+// interfaces above.
+type TenantGateInvalidator interface {
+	Invalidate(tenantID string)
 }
 
 // Register mounts the platform console's /admin/* surface behind
@@ -153,6 +170,7 @@ func Register(g *gin.RouterGroup, deps Deps) {
 			deps.TenantLifecycle,
 			stores.NewRepository(deps.DB),
 			NewOperatorActionAuditFunc(deps.Emitter),
+			deps.TenantGateInvalidator,
 			deps.Logger,
 		).Register(group)
 	case deps.TenantLifecycle != nil:

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -54,15 +54,22 @@ type Deps struct {
 	// TenantLifecycle serves POST /admin/tenants/:id/{suspend,unsuspend}
 	// (#287) — this surface's first WRITE endpoints. Nil leaves those
 	// routes unmounted, matching the nil-safe pattern used for the other
-	// client-backed routes above. Requires DB (non-nil) too, since the
-	// handler updates the local `stores` projection on a changed call.
+	// client-backed routes above. Requires DB and Emitter (both non-nil)
+	// too — see Emitter below for why Emitter is required here and nowhere
+	// else in this struct.
 	TenantLifecycle TenantLifecycle
 
 	// Emitter is the async audit-log writer used for write-endpoint audit
-	// rows (currently only tenant suspend/unsuspend). Nil is tolerated —
-	// EmitOperatorAction treats a nil *audit.Emitter the same way Emit
-	// itself does: a fire-and-forget no-op, never a panic or an error that
-	// would fail a request that already succeeded upstream.
+	// rows (currently only tenant suspend/unsuspend). Unlike every other
+	// optional dependency in this struct, a nil Emitter does NOT leave the
+	// surface merely degraded — Register refuses to mount the
+	// TenantLifecycle routes at all when Emitter is nil (see the guard
+	// below), because a write endpoint that cannot be attributed to an
+	// operator should not exist, not run silently unaudited. (The
+	// underlying EmitOperatorAction/Emit machinery does still tolerate a
+	// nil *audit.Emitter as a fire-and-forget no-op — logged loudly rather
+	// than silent, since #287 — for callers reached other than through
+	// this Register guard.)
 	Emitter *audit.Emitter
 }
 
@@ -140,12 +147,22 @@ func Register(g *gin.RouterGroup, deps Deps) {
 		NewBillingSubscriptionsHandler(deps.AllSubscriptions, deps.TenantDirectory, deps.DB, deps.Logger).Register(group)
 	}
 
-	if deps.TenantLifecycle != nil && deps.DB != nil {
+	switch {
+	case deps.TenantLifecycle != nil && deps.DB != nil && deps.Emitter != nil:
 		NewTenantLifecycleHandler(
 			deps.TenantLifecycle,
 			stores.NewRepository(deps.DB),
 			NewOperatorActionAuditFunc(deps.Emitter),
 			deps.Logger,
 		).Register(group)
+	case deps.TenantLifecycle != nil:
+		// TenantLifecycle is wired but DB or Emitter isn't: mounting a
+		// write endpoint that cannot be attributed is worse than not
+		// having it (#287, F1) — this is not the nil-safe "just degraded"
+		// pattern the other routes above use.
+		if deps.Logger != nil {
+			deps.Logger.Warn("platformadmin: tenant lifecycle routes not mounted — DB and Emitter are both required",
+				"db_nil", deps.DB == nil, "emitter_nil", deps.Emitter == nil)
+		}
 	}
 }

--- a/services/marketplace-api/internal/handlers/platformadmin/routes_tenant_lifecycle_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes_tenant_lifecycle_test.go
@@ -1,0 +1,74 @@
+package platformadmin_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+)
+
+// hasRoute reports whether r has a registered route for method+path.
+// Route registration happens at Register() time regardless of whether
+// RequirePlatformAuth would later accept or reject a real request, so this
+// is checked without ever sending one — mirroring TestRegisterMountsHealth
+// in routes_test.go.
+func hasRoute(r *gin.Engine, method, path string) bool {
+	for _, route := range r.Routes() {
+		if route.Method == method && route.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRegisterRequiresEmitterToMountTenantLifecycle pins F1 (#287): a
+// TenantLifecycle client with no Emitter must NOT get the two write routes
+// mounted. Register's nil-safe pattern for every OTHER client-backed route
+// is "mount in a degraded state" (see e.g. TenantDirectory alone unlocking
+// /admin/entities/tenants); tenant suspend/unsuspend is different — a
+// write endpoint that cannot be attributed to an operator must not exist
+// on this surface at all, so Emitter == nil is a hard "do not mount", not
+// a degraded mount.
+func TestRegisterRequiresEmitterToMountTenantLifecycle(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	platformadmin.Register(r.Group("/api/v1/platform"), platformadmin.Deps{
+		Repo:            &stubRepo{},
+		Secret:          "test-secret",
+		DB:              &gorm.DB{},
+		TenantLifecycle: &stubLifecycle{},
+		Emitter:         nil, // the point of this test
+	})
+
+	require.False(t, hasRoute(r, http.MethodPost, "/api/v1/platform/admin/tenants/:id/suspend"),
+		"suspend must not mount without an Emitter")
+	require.False(t, hasRoute(r, http.MethodPost, "/api/v1/platform/admin/tenants/:id/unsuspend"),
+		"unsuspend must not mount without an Emitter")
+}
+
+// TestRegisterMountsTenantLifecycleWhenFullyWired is the positive
+// counterpart: TenantLifecycle + DB + Emitter all present mounts both
+// routes.
+func TestRegisterMountsTenantLifecycleWhenFullyWired(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	platformadmin.Register(r.Group("/api/v1/platform"), platformadmin.Deps{
+		Repo:            &stubRepo{},
+		Secret:          "test-secret",
+		DB:              &gorm.DB{},
+		TenantLifecycle: &stubLifecycle{},
+		Emitter:         audit.NewEmitter(audit.EmitterConfig{Repo: &recordingRepo{}}),
+	})
+
+	require.True(t, hasRoute(r, http.MethodPost, "/api/v1/platform/admin/tenants/:id/suspend"),
+		"suspend must mount when TenantLifecycle, DB and Emitter are all wired")
+	require.True(t, hasRoute(r, http.MethodPost, "/api/v1/platform/admin/tenants/:id/unsuspend"),
+		"unsuspend must mount when TenantLifecycle, DB and Emitter are all wired")
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle.go
@@ -88,10 +88,11 @@ func NewOperatorActionAuditFunc(em *audit.Emitter) lifecycleAuditFunc {
 //     authoritative status is refetched from platform-api. Unsuspend takes
 //     effect on the next refresh, not instantly — that is deliberate.
 type TenantLifecycleHandler struct {
-	client TenantLifecycle
-	stores stores.Repository
-	emit   lifecycleAuditFunc
-	logger *slog.Logger
+	client     TenantLifecycle
+	stores     stores.Repository
+	emit       lifecycleAuditFunc
+	invalidate TenantGateInvalidator
+	logger     *slog.Logger
 }
 
 // NewTenantLifecycleHandler constructs the handler. logger may be nil;
@@ -111,11 +112,15 @@ type TenantLifecycleHandler struct {
 // closure, even when deps.Emitter itself is nil), so the panic could
 // never fire on the one path that would actually need it; the unmounted
 // route is what closes the loophole.
-func NewTenantLifecycleHandler(client TenantLifecycle, storeRepo stores.Repository, emit lifecycleAuditFunc, logger *slog.Logger) *TenantLifecycleHandler {
+// invalidator may be nil: an unwired invalidator leaves today's TTL-lag
+// behaviour in place on the admin gate (see TenantGateInvalidator's doc in
+// routes.go) rather than failing the request — it is never required the
+// way emit's audit trail is.
+func NewTenantLifecycleHandler(client TenantLifecycle, storeRepo stores.Repository, emit lifecycleAuditFunc, invalidator TenantGateInvalidator, logger *slog.Logger) *TenantLifecycleHandler {
 	if emit == nil {
 		emit = func(*gin.Context, uuid.UUID, audit.Event) error { return nil }
 	}
-	return &TenantLifecycleHandler{client: client, stores: storeRepo, emit: emit, logger: logger}
+	return &TenantLifecycleHandler{client: client, stores: storeRepo, emit: emit, invalidate: invalidator, logger: logger}
 }
 
 // Register mounts both routes on the supplied group.
@@ -230,6 +235,16 @@ func (h *TenantLifecycleHandler) handle(
 	}
 
 	if res.Changed {
+		// #287 fix-round-1: drop the admin gate's cached status for this
+		// tenant so the suspend/unsuspend takes effect on the very next
+		// admin request, instead of lagging behind by up to the gate's
+		// TTL. Best-effort like projectionUpdate below: nil-safe, and its
+		// absence is a degraded-lag, not a failure worth surfacing to the
+		// caller — the upstream write already succeeded.
+		if h.invalidate != nil {
+			h.invalidate.Invalidate(tenantIDStr)
+		}
+
 		if err := projectionUpdate(c.Request.Context(), tenantIDStr); err != nil {
 			// The upstream call already SUCCEEDED. A projection-update
 			// failure must not turn that into an error response — log

--- a/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle.go
@@ -1,0 +1,301 @@
+// services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle.go
+package platformadmin
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/internal/tenantlifecycle"
+)
+
+// TenantLifecycle is the subset of tenantlifecycle.Client this handler
+// needs, declared here (not the concrete client type) so the handler is
+// stubbable — the same reason EstateCounts and OnboardingFunnel are
+// declared locally rather than importing their client packages' types.
+type TenantLifecycle interface {
+	Suspend(ctx context.Context, tenantID string) (*tenantlifecycle.Result, error)
+	Unsuspend(ctx context.Context, tenantID string) (*tenantlifecycle.Result, error)
+}
+
+// SuspendReasonCodes is the closed set of reasons a tenant may be
+// suspended for. An audit row saying WHAT happened without WHY is the gap
+// this series exists to close (#287), so the code is REQUIRED; free text
+// (`reason`) is accepted IN ADDITION, never instead.
+var SuspendReasonCodes = []string{
+	"abuse",         // abusive content or behaviour toward customers or staff
+	"fraud",         // suspected fraudulent transactions or identity
+	"non_payment",   // billing failed and the dunning ladder is exhausted
+	"legal",         // legal or regulatory demand
+	"tos_violation", // terms breach not covered by abuse or fraud
+	"security",      // compromised account or active security incident
+	"voluntary",     // merchant asked for the store to be paused
+}
+
+// UnsuspendReasonCodes is deliberately a different set from
+// SuspendReasonCodes: the reasons for lifting a suspension are not the
+// reasons for applying one.
+var UnsuspendReasonCodes = []string{
+	"resolved", "appeal_upheld", "operator_error", "voluntary_end",
+}
+
+// lifecycleAuditFunc records a platform-operator action against a tenant.
+// In production this closes over a real *audit.Emitter via
+// EmitOperatorAction; test doubles capture the raw audit.Event
+// synchronously, which the real Emitter cannot do since its write happens
+// on an async worker goroutine (see audit.Emitter.Emit).
+type lifecycleAuditFunc func(c *gin.Context, tenantID uuid.UUID, ev audit.Event) error
+
+// NewOperatorActionAuditFunc adapts a real *audit.Emitter into a
+// lifecycleAuditFunc via EmitOperatorAction. em may be nil — wiring that
+// has opted out of auditing.
+func NewOperatorActionAuditFunc(em *audit.Emitter) lifecycleAuditFunc {
+	return func(c *gin.Context, tenantID uuid.UUID, ev audit.Event) error {
+		return EmitOperatorAction(c, em, tenantID, ev)
+	}
+}
+
+// TenantLifecycleHandler serves the platform console's tenant
+// suspend/unsuspend endpoints (#287) — the surface's first WRITE
+// endpoints.
+//
+// The local `stores` projection update on a changed call is deliberately
+// ASYMMETRIC:
+//
+//   - Suspend eagerly flips the tenant's local ACTIVE stores to suspended.
+//     Over-enforcing briefly (serving a store as suspended a beat before
+//     platform-api's own cascade finishes) is the safe direction, and it
+//     means enforcement does not wait out StoreMiddleware's FreshTTL.
+//
+//   - Unsuspend does NOT eagerly flip stores back to active. This
+//     projection has no column distinguishing a store suspended by the
+//     tenant-level cascade from one suspended individually in
+//     platform-api (that flag, suspended_by_tenant, exists only upstream).
+//     An eager local unsuspend would reactivate an individually-suspended
+//     store here, under-enforcing — the exact failure this endpoint exists
+//     to prevent. Instead it marks the tenant's local rows stale, forcing
+//     the next request through StoreMiddleware's refresh path so the
+//     authoritative status is refetched from platform-api. Unsuspend takes
+//     effect on the next refresh, not instantly — that is deliberate.
+type TenantLifecycleHandler struct {
+	client TenantLifecycle
+	stores stores.Repository
+	emit   lifecycleAuditFunc
+	logger *slog.Logger
+}
+
+// NewTenantLifecycleHandler constructs the handler. logger and emit may be
+// nil/no-op; storeRepo may be nil, in which case the local projection
+// update is skipped (logged, not failed) after a changed call.
+func NewTenantLifecycleHandler(client TenantLifecycle, storeRepo stores.Repository, emit lifecycleAuditFunc, logger *slog.Logger) *TenantLifecycleHandler {
+	if emit == nil {
+		emit = func(*gin.Context, uuid.UUID, audit.Event) error { return nil }
+	}
+	return &TenantLifecycleHandler{client: client, stores: storeRepo, emit: emit, logger: logger}
+}
+
+// Register mounts both routes on the supplied group.
+//
+// These MUST stay on the platformadmin group (see the long doc comment on
+// Register in routes.go) — the merchant admin tree already registers
+// /admin/tenants/:tenantId/... under a different wildcard name at the same
+// path position, and gin panics at router build time on that collision.
+func (h *TenantLifecycleHandler) Register(g *gin.RouterGroup) {
+	g.POST("/admin/tenants/:id/suspend", h.suspend)
+	g.POST("/admin/tenants/:id/unsuspend", h.unsuspend)
+}
+
+// lifecycleRequest is the shared wire shape for both routes.
+type lifecycleRequest struct {
+	ReasonCode string `json:"reason_code"`
+	Reason     string `json:"reason"`
+}
+
+// lifecycleResult is the projected upstream result. It is a NEW type, not
+// tenantlifecycle.Result passed through: the upstream shape is an
+// implementation detail of the client package, and pinning our own wire
+// type here keeps the console's contract from silently drifting if that
+// package's struct ever grows a field this surface shouldn't expose.
+type lifecycleResult struct {
+	TenantID       string `json:"tenant_id"`
+	Status         string `json:"status"`
+	StoresAffected int    `json:"stores_affected"`
+	Changed        bool   `json:"changed"`
+}
+
+func (h *TenantLifecycleHandler) suspend(c *gin.Context) {
+	h.handle(c, "suspend", SuspendReasonCodes, "tenant.suspended", h.client.Suspend, h.suspendActiveForTenant)
+}
+
+func (h *TenantLifecycleHandler) unsuspend(c *gin.Context) {
+	h.handle(c, "unsuspend", UnsuspendReasonCodes, "tenant.unsuspended", h.client.Unsuspend, h.markStaleForTenant)
+}
+
+// suspendActiveForTenant and markStaleForTenant are nil-safe wrappers
+// around h.stores's methods: h.stores is an interface, and forming a
+// method value directly on a nil interface (h.stores.SuspendActiveForTenant)
+// panics at the point the value is formed, not lazily at call time — these
+// wrappers keep the nil check (see handle's own belt-and-braces
+// `h.stores != nil` guard around the call site) from being load-bearing on
+// its own.
+func (h *TenantLifecycleHandler) suspendActiveForTenant(ctx context.Context, tenantID string) error {
+	if h.stores == nil {
+		return nil
+	}
+	return h.stores.SuspendActiveForTenant(ctx, tenantID)
+}
+
+func (h *TenantLifecycleHandler) markStaleForTenant(ctx context.Context, tenantID string) error {
+	if h.stores == nil {
+		return nil
+	}
+	return h.stores.MarkStaleForTenant(ctx, tenantID)
+}
+
+// handle runs the shared validate -> call upstream -> map errors ->
+// (on Changed) update local projection + audit -> respond pipeline for
+// both routes. action names the route for logging; reasonCodes is the
+// closed set for THIS route (suspend and unsuspend use different sets);
+// auditAction is the audit.Event.Action; call is the upstream client
+// method; projectionUpdate is the local-projection side effect to run on a
+// changed call — it differs between suspend (SuspendActiveForTenant) and
+// unsuspend (MarkStaleForTenant), see the type doc for why.
+func (h *TenantLifecycleHandler) handle(
+	c *gin.Context,
+	action string,
+	reasonCodes []string,
+	auditAction string,
+	call func(ctx context.Context, tenantID string) (*tenantlifecycle.Result, error),
+	projectionUpdate func(ctx context.Context, tenantID string) error,
+) {
+	tenantIDStr := c.Param("id")
+	if _, err := uuid.Parse(tenantIDStr); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_tenant_id", "message": "id must be a UUID", "field": "id",
+		})
+		return
+	}
+
+	var req lifecycleRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		// A missing/absent body binds to the zero value rather than
+		// erroring on some gin configurations; the reason-code check
+		// below still catches it. A malformed JSON body IS an error here.
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_request", "message": "request body could not be parsed",
+		})
+		return
+	}
+
+	if !isKnownReasonCode(req.ReasonCode, reasonCodes) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "invalid_reason_code",
+			"message": "reason_code is required and must be one of the declared codes",
+			"field":   "reason_code",
+			"allowed": reasonCodes,
+		})
+		return
+	}
+
+	res, err := call(c.Request.Context(), tenantIDStr)
+	if err != nil {
+		h.respondUpstreamErr(c, action, err)
+		return
+	}
+
+	if res.Changed {
+		if err := projectionUpdate(c.Request.Context(), tenantIDStr); err != nil {
+			// The upstream call already SUCCEEDED. A projection-update
+			// failure must not turn that into an error response — log
+			// loudly and let the response reflect the real outcome. The
+			// local projection will still catch up: suspend's worst case
+			// is a brief window of under-enforcement (same as before this
+			// endpoint existed), and unsuspend never enforces off local
+			// rows without a refresh anyway.
+			if h.logger != nil {
+				h.logger.Error("tenant lifecycle: local projection update failed",
+					"action", action, "tenant_id", tenantIDStr, "err", err)
+			}
+		}
+
+		tenantUUID, _ := uuid.Parse(tenantIDStr) // already validated above
+		if err := h.emit(c, tenantUUID, audit.Event{
+			Action:       auditAction,
+			ResourceType: "tenant",
+			ResourceID:   tenantIDStr,
+			Metadata: map[string]any{
+				"reason_code":     req.ReasonCode,
+				"reason":          req.Reason,
+				"stores_affected": res.StoresAffected,
+				"capability":      c.GetString(CtxCapability),
+			},
+		}); err != nil {
+			// ErrMissingTenant (or any other emit failure): the operation
+			// SUCCEEDED upstream but we cannot attribute it. Log loudly;
+			// do not fail the response, and do not pretend it was
+			// attributed.
+			if h.logger != nil {
+				h.logger.Error("tenant lifecycle: action succeeded but was not audited",
+					"action", action, "tenant_id", tenantIDStr, "err", err)
+			}
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": lifecycleResult{
+		TenantID:       res.TenantID,
+		Status:         res.Status,
+		StoresAffected: res.StoresAffected,
+		Changed:        res.Changed,
+	}})
+}
+
+// respondUpstreamErr maps tenantlifecycle's sentinels to this surface's
+// stable HTTP codes. An unavailable upstream must never read as "nothing
+// to do" — see tenantlifecycle's own package doc for the failure mode this
+// guards against.
+func (h *TenantLifecycleHandler) respondUpstreamErr(c *gin.Context, action string, err error) {
+	switch {
+	case errors.Is(err, tenantlifecycle.ErrNotFound):
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "not_found", "message": "tenant not found",
+		})
+	case errors.Is(err, tenantlifecycle.ErrConflict):
+		c.JSON(http.StatusConflict, gin.H{
+			"error": "invalid_status_transition", "message": "tenant cannot transition to the requested status",
+		})
+	case errors.Is(err, tenantlifecycle.ErrUnavailable):
+		if h.logger != nil {
+			h.logger.Error("tenant lifecycle upstream unavailable", "action", action, "err", err)
+		}
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "upstream_unavailable", "message": "platform-api is unavailable",
+		})
+	default:
+		if h.logger != nil {
+			h.logger.Error("tenant lifecycle", "action", action, "err", err)
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "internal_error", "message": "could not update tenant status",
+		})
+	}
+}
+
+// isKnownReasonCode returns true only for an exact, non-empty membership
+// match. Never coerced, never a fallback to free text.
+func isKnownReasonCode(code string, allowed []string) bool {
+	if code == "" {
+		return false
+	}
+	for _, c := range allowed {
+		if c == code {
+			return true
+		}
+	}
+	return false
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle.go
@@ -90,12 +90,21 @@ type TenantLifecycleHandler struct {
 	logger *slog.Logger
 }
 
-// NewTenantLifecycleHandler constructs the handler. logger and emit may be
-// nil/no-op; storeRepo may be nil, in which case the local projection
-// update is skipped (logged, not failed) after a changed call.
+// NewTenantLifecycleHandler constructs the handler. logger may be nil;
+// storeRepo may be nil, in which case the local projection update is
+// skipped (logged, not failed) after a changed call.
+//
+// emit MUST NOT be nil, and this panics at construction if it is — not
+// at request time. A silent no-op default here would mean the surface's
+// entire auditing guarantee rests on callers remembering to wire one up
+// (see routes.go's Emitter field), which is the exact failure shape this
+// series exists to close: a handler that cannot audit must not be built,
+// rather than quietly built and then quietly skipping every audit row.
+// Callers that genuinely want to discard events must pass an explicit
+// func that does so, so that choice is visible in a diff.
 func NewTenantLifecycleHandler(client TenantLifecycle, storeRepo stores.Repository, emit lifecycleAuditFunc, logger *slog.Logger) *TenantLifecycleHandler {
 	if emit == nil {
-		emit = func(*gin.Context, uuid.UUID, audit.Event) error { return nil }
+		panic("platformadmin: NewTenantLifecycleHandler requires a non-nil emit func")
 	}
 	return &TenantLifecycleHandler{client: client, stores: storeRepo, emit: emit, logger: logger}
 }
@@ -184,9 +193,11 @@ func (h *TenantLifecycleHandler) handle(
 
 	var req lifecycleRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		// A missing/absent body binds to the zero value rather than
-		// erroring on some gin configurations; the reason-code check
-		// below still catches it. A malformed JSON body IS an error here.
+		// gin's JSON binder returns io.EOF for a completely empty body, so
+		// an omitted body is rejected HERE as invalid_request — it never
+		// reaches the reason-code check below. `{}` (valid JSON, all
+		// fields absent) DOES bind successfully to the zero value and is
+		// the case the reason-code check exists to catch.
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "invalid_request", "message": "request body could not be parsed",
 		})

--- a/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle.go
@@ -53,8 +53,12 @@ var UnsuspendReasonCodes = []string{
 type lifecycleAuditFunc func(c *gin.Context, tenantID uuid.UUID, ev audit.Event) error
 
 // NewOperatorActionAuditFunc adapts a real *audit.Emitter into a
-// lifecycleAuditFunc via EmitOperatorAction. em may be nil — wiring that
-// has opted out of auditing.
+// lifecycleAuditFunc via EmitOperatorAction. em may be nil at the type
+// level — EmitOperatorAction tolerates it — but Register (routes.go)
+// never actually calls this with a nil em for the tenant-lifecycle
+// routes: it mounts them only when deps.Emitter != nil in the first
+// place, precisely so this adapter is never the thing standing between a
+// write endpoint and an unaudited one.
 func NewOperatorActionAuditFunc(em *audit.Emitter) lifecycleAuditFunc {
 	return func(c *gin.Context, tenantID uuid.UUID, ev audit.Event) error {
 		return EmitOperatorAction(c, em, tenantID, ev)
@@ -92,19 +96,24 @@ type TenantLifecycleHandler struct {
 
 // NewTenantLifecycleHandler constructs the handler. logger may be nil;
 // storeRepo may be nil, in which case the local projection update is
-// skipped (logged, not failed) after a changed call.
+// skipped (logged, not failed) after a changed call. emit may be nil, in
+// which case it defaults to a no-op — that default exists for direct,
+// low-level callers (this constructor has no way to know WHY emit is
+// nil), but it is not where this surface's auditing guarantee actually
+// lives.
 //
-// emit MUST NOT be nil, and this panics at construction if it is — not
-// at request time. A silent no-op default here would mean the surface's
-// entire auditing guarantee rests on callers remembering to wire one up
-// (see routes.go's Emitter field), which is the exact failure shape this
-// series exists to close: a handler that cannot audit must not be built,
-// rather than quietly built and then quietly skipping every audit row.
-// Callers that genuinely want to discard events must pass an explicit
-// func that does so, so that choice is visible in a diff.
+// The real guard is in Register: a handler that cannot audit must not
+// exist on this surface at all, so Register mounts these two routes only
+// when deps.Emitter != nil (see routes.go), rather than mounting a live
+// write endpoint whose audit trail silently no-ops. A construction-time
+// panic here was tried and rejected — production never passes a literal
+// nil (NewOperatorActionAuditFunc(deps.Emitter) always returns a non-nil
+// closure, even when deps.Emitter itself is nil), so the panic could
+// never fire on the one path that would actually need it; the unmounted
+// route is what closes the loophole.
 func NewTenantLifecycleHandler(client TenantLifecycle, storeRepo stores.Repository, emit lifecycleAuditFunc, logger *slog.Logger) *TenantLifecycleHandler {
 	if emit == nil {
-		panic("platformadmin: NewTenantLifecycleHandler requires a non-nil emit func")
+		emit = func(*gin.Context, uuid.UUID, audit.Event) error { return nil }
 	}
 	return &TenantLifecycleHandler{client: client, stores: storeRepo, emit: emit, logger: logger}
 }

--- a/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_gate_invalidation_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_gate_invalidation_test.go
@@ -1,0 +1,156 @@
+package platformadmin_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
+	"github.com/mark8ly/marketplace-api/internal/tenantgate"
+	"github.com/mark8ly/marketplace-api/internal/tenantlifecycle"
+)
+
+// switchableLookup is a tenantgate.Lookup whose status can be flipped
+// mid-test, standing in for platform-api's tenant status actually
+// changing (via a real suspend/unsuspend call) between two requests
+// through the admin gate.
+type switchableLookup struct {
+	mu     sync.Mutex
+	status string
+}
+
+func (s *switchableLookup) set(status string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status = status
+}
+
+func (s *switchableLookup) Get(_ context.Context, id string) (*tenantdirectory.TenantDetail, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return &tenantdirectory.TenantDetail{Tenant: tenantdirectory.Tenant{ID: id, Status: s.status}}, nil
+}
+
+// buildAdminGateRouter wires a minimal admin route behind the real
+// tenantgate.Gate, exactly the shape the admin group in
+// internal/handlers/admin/routes.go uses. A long TTL means the only way
+// the cache clears between two requests is an explicit Invalidate call —
+// which is exactly what this file is testing.
+func buildAdminGateRouter(t *testing.T, gate *tenantgate.Gate) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Set("tenant_id", testTenant) })
+	r.GET("/admin/account", gate.RequireActiveTenant(), func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+	return r
+}
+
+func doAdminGet(r *gin.Engine) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/account", nil))
+	return rec
+}
+
+// TestSuspend_InvalidatesGate_NoTTLWait proves the EFFECT of invalidation,
+// not merely that Invalidate was called: a request being served from a
+// long-TTL cached "active" entry is refused on the very next call once a
+// changed suspend goes through the invalidator — no TTL wait, no second
+// cache-refresh cycle needed.
+func TestSuspend_InvalidatesGate_NoTTLWait(t *testing.T) {
+	lookup := &switchableLookup{status: "active"}
+	gate := tenantgate.New(lookup, nil, time.Hour) // long TTL: only Invalidate clears it
+	adminRouter := buildAdminGateRouter(t, gate)
+
+	// Warm the cache with an active status — this is the request the
+	// merchant was making right before the suspension.
+	require.Equal(t, http.StatusOK, doAdminGet(adminRouter).Code)
+
+	// Upstream now reports suspended (simulating the real state change a
+	// successful suspend call causes), but the gate's cache still holds
+	// "active" within its TTL — prove the stale cache would otherwise
+	// keep serving, so the fixture actually discriminates.
+	lookup.set("suspended")
+	require.Equal(t, http.StatusOK, doAdminGet(adminRouter).Code,
+		"fixture check: without invalidation the long TTL must still serve stale active")
+
+	stub := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "suspended", StoresAffected: 1, Changed: true}}
+	h := platformadmin.NewTenantLifecycleHandler(stub, &fakeLifecycleStoreRepo{}, discardAudit, gate, nil)
+	rec := postLifecycleTenant(t, h, testTenant, "suspend", `{"reason_code":"abuse"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.Equal(t, http.StatusForbidden, doAdminGet(adminRouter).Code,
+		"suspend must invalidate the gate cache so the very next admin request is refused, with no TTL wait")
+}
+
+// TestUnsuspend_InvalidatesGate_NoTTLWait mirrors the suspend case:
+// reinstating a tenant must not leave it waiting out the TTL to regain
+// access.
+func TestUnsuspend_InvalidatesGate_NoTTLWait(t *testing.T) {
+	lookup := &switchableLookup{status: "suspended"}
+	gate := tenantgate.New(lookup, nil, time.Hour)
+	adminRouter := buildAdminGateRouter(t, gate)
+
+	require.Equal(t, http.StatusForbidden, doAdminGet(adminRouter).Code)
+
+	lookup.set("active")
+	require.Equal(t, http.StatusForbidden, doAdminGet(adminRouter).Code,
+		"fixture check: without invalidation the long TTL must still serve stale suspended")
+
+	stub := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "active", StoresAffected: 1, Changed: true}}
+	h := platformadmin.NewTenantLifecycleHandler(stub, &fakeLifecycleStoreRepo{}, discardAudit, gate, nil)
+	rec := postLifecycleTenant(t, h, testTenant, "unsuspend", `{"reason_code":"resolved"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.Equal(t, http.StatusOK, doAdminGet(adminRouter).Code,
+		"unsuspend must invalidate the gate cache so the very next admin request is served, with no TTL wait")
+}
+
+// TestLifecycle_NoopDoesNotInvalidateGate asserts the negative: a call
+// upstream reports as unchanged (Changed: false) must NOT touch the
+// cache, consistent with the audit side effect also being skipped for a
+// no-op.
+func TestLifecycle_NoopDoesNotInvalidateGate(t *testing.T) {
+	lookup := &switchableLookup{status: "active"}
+	gate := tenantgate.New(lookup, nil, time.Hour)
+	adminRouter := buildAdminGateRouter(t, gate)
+
+	require.Equal(t, http.StatusOK, doAdminGet(adminRouter).Code)
+
+	// Upstream is now suspended, but this call reports Changed: false (the
+	// tenant was already suspended, say) — the cache must stay untouched.
+	lookup.set("suspended")
+	stub := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "suspended", StoresAffected: 0, Changed: false}}
+	h := platformadmin.NewTenantLifecycleHandler(stub, &fakeLifecycleStoreRepo{}, discardAudit, gate, nil)
+	rec := postLifecycleTenant(t, h, testTenant, "suspend", `{"reason_code":"abuse"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.Equal(t, http.StatusOK, doAdminGet(adminRouter).Code,
+		"a no-op (Changed: false) must not invalidate the gate cache")
+}
+
+// TestLifecycle_NilInvalidatorDoesNotPanic asserts the handler degrades
+// gracefully with no gate wired at all — matching how the audit func's
+// nil case is tolerated (though for a different reason: an unwired
+// invalidator is a lag, not a lost record, so it is not mount-gated).
+func TestLifecycle_NilInvalidatorDoesNotPanic(t *testing.T) {
+	stub := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "suspended", StoresAffected: 1, Changed: true}}
+	h := platformadmin.NewTenantLifecycleHandler(stub, &fakeLifecycleStoreRepo{}, discardAudit, nil, nil)
+
+	require.NotPanics(t, func() {
+		rec := postLifecycleTenant(t, h, testTenant, "suspend", `{"reason_code":"abuse"}`)
+		require.Equal(t, http.StatusOK, rec.Code)
+	})
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_integration_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_integration_test.go
@@ -52,9 +52,16 @@ func TestIntegration_Suspend_UpdatesLocalProjectionImmediately(t *testing.T) {
 	tenantID := uuid.NewString()
 	seeded := seedIntegrationStore(t, repo, tenantID)
 
+	// A SECOND tenant, seeded with its own active store, in the SAME table.
+	// This is F3's guard: SuspendActiveForTenant must filter on tenant_id,
+	// not merely on status — without that filter this store, belonging to
+	// an entirely different tenant, would also flip to suspended.
+	otherTenantID := uuid.NewString()
+	otherSeeded := seedIntegrationStore(t, repo, otherTenantID)
+
 	stub := &stubLifecycle{res: &tenantlifecycle.Result{
 		TenantID: tenantID, Status: "suspended", StoresAffected: 1, Changed: true}}
-	h := platformadmin.NewTenantLifecycleHandler(stub, repo, nil, nil)
+	h := platformadmin.NewTenantLifecycleHandler(stub, repo, discardAudit, nil)
 
 	rec := postLifecycleTenant(t, h, tenantID, "suspend", `{"reason_code":"abuse"}`)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -65,6 +72,11 @@ func TestIntegration_Suspend_UpdatesLocalProjectionImmediately(t *testing.T) {
 		"local projection must already read suspended, without waiting for any TTL")
 	require.False(t, stores.IsStale(got, 5*time.Minute),
 		"the eager write must also refresh synced_at, or the row would immediately look stale")
+
+	otherGot, err := repo.GetByIDForTenant(t.Context(), otherSeeded.ID, otherTenantID)
+	require.NoError(t, err)
+	require.Equal(t, stores.StatusActive, otherGot.Status,
+		"suspending one tenant must NOT touch another tenant's store — estate-wide suspension is the bug this guards against (F3)")
 }
 
 // TestIntegration_Unsuspend_MarksLocalProjectionStaleNotActive is the
@@ -81,9 +93,17 @@ func TestIntegration_Unsuspend_MarksLocalProjectionStaleNotActive(t *testing.T) 
 	seeded.Status = stores.StatusSuspended
 	require.NoError(t, repo.Upsert(t.Context(), seeded))
 
+	// A SECOND tenant, seeded fresh and left ACTIVE. This is F3's guard on
+	// the unsuspend path: MarkStaleForTenant must filter on tenant_id, or
+	// this store's synced_at — belonging to a different tenant entirely —
+	// would also get backdated.
+	otherTenantID := uuid.NewString()
+	otherSeeded := seedIntegrationStore(t, repo, otherTenantID)
+	otherSyncedAtBefore := otherSeeded.SyncedAt
+
 	stub := &stubLifecycle{res: &tenantlifecycle.Result{
 		TenantID: tenantID, Status: "active", StoresAffected: 1, Changed: true}}
-	h := platformadmin.NewTenantLifecycleHandler(stub, repo, nil, nil)
+	h := platformadmin.NewTenantLifecycleHandler(stub, repo, discardAudit, nil)
 
 	rec := postLifecycleTenant(t, h, tenantID, "unsuspend", `{"reason_code":"resolved"}`)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -94,4 +114,9 @@ func TestIntegration_Unsuspend_MarksLocalProjectionStaleNotActive(t *testing.T) 
 		"unsuspend must NOT eagerly flip the local row to active")
 	require.True(t, stores.IsStale(got, 5*time.Minute),
 		"unsuspend must force the row stale so the next read refetches from platform-api")
+
+	otherGot, err := repo.GetByIDForTenant(t.Context(), otherSeeded.ID, otherTenantID)
+	require.NoError(t, err)
+	require.WithinDuration(t, otherSyncedAtBefore, otherGot.SyncedAt, time.Second,
+		"unsuspending one tenant must NOT touch another tenant's synced_at — estate-wide staleness is the bug this guards against (F3)")
 }

--- a/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_integration_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_integration_test.go
@@ -61,7 +61,7 @@ func TestIntegration_Suspend_UpdatesLocalProjectionImmediately(t *testing.T) {
 
 	stub := &stubLifecycle{res: &tenantlifecycle.Result{
 		TenantID: tenantID, Status: "suspended", StoresAffected: 1, Changed: true}}
-	h := platformadmin.NewTenantLifecycleHandler(stub, repo, discardAudit, nil)
+	h := platformadmin.NewTenantLifecycleHandler(stub, repo, discardAudit, nil, nil)
 
 	rec := postLifecycleTenant(t, h, tenantID, "suspend", `{"reason_code":"abuse"}`)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -103,7 +103,7 @@ func TestIntegration_Unsuspend_MarksLocalProjectionStaleNotActive(t *testing.T) 
 
 	stub := &stubLifecycle{res: &tenantlifecycle.Result{
 		TenantID: tenantID, Status: "active", StoresAffected: 1, Changed: true}}
-	h := platformadmin.NewTenantLifecycleHandler(stub, repo, discardAudit, nil)
+	h := platformadmin.NewTenantLifecycleHandler(stub, repo, discardAudit, nil, nil)
 
 	rec := postLifecycleTenant(t, h, tenantID, "unsuspend", `{"reason_code":"resolved"}`)
 	require.Equal(t, http.StatusOK, rec.Code)

--- a/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_integration_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_integration_test.go
@@ -1,0 +1,97 @@
+//go:build integration
+
+package platformadmin_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/internal/tenantlifecycle"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedIntegrationStore inserts one ACTIVE store row for tenantID into the
+// real `stores` table via repo.Upsert. marketplace-api's stores projection
+// carries no reference-data FKs (that constraint lives only in
+// platform-api), so plausible-but-arbitrary country/currency/timezone
+// values are fine here.
+func seedIntegrationStore(t *testing.T, repo stores.Repository, tenantID string) *stores.Store {
+	t.Helper()
+	s := &stores.Store{
+		ID:           uuid.NewString(),
+		TenantID:     tenantID,
+		Slug:         "acme-" + uuid.NewString()[:8],
+		Name:         "Acme",
+		CountryCode:  "DE",
+		CurrencyCode: "EUR",
+		Timezone:     "Europe/Berlin",
+		Status:       stores.StatusActive,
+		SyncedAt:     time.Now(),
+	}
+	require.NoError(t, repo.Upsert(t.Context(), s))
+	return s
+}
+
+// TestIntegration_Suspend_UpdatesLocalProjectionImmediately is Step 5's
+// proof that the local `stores` projection reflects a changed suspension
+// in the SAME request — no waiting for StoreMiddleware's 5-minute
+// FreshTTL. A stub tenantlifecycle.Client stands in for platform-api
+// itself (that HTTP boundary is T4's concern, already covered in
+// internal/tenantlifecycle); what's under test here is this handler's own
+// write to the real DB-backed stores.Repository.
+func TestIntegration_Suspend_UpdatesLocalProjectionImmediately(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := stores.NewRepository(tx)
+
+	tenantID := uuid.NewString()
+	seeded := seedIntegrationStore(t, repo, tenantID)
+
+	stub := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: tenantID, Status: "suspended", StoresAffected: 1, Changed: true}}
+	h := platformadmin.NewTenantLifecycleHandler(stub, repo, nil, nil)
+
+	rec := postLifecycleTenant(t, h, tenantID, "suspend", `{"reason_code":"abuse"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	got, err := repo.GetByIDForTenant(t.Context(), seeded.ID, tenantID)
+	require.NoError(t, err)
+	require.Equal(t, stores.StatusSuspended, got.Status,
+		"local projection must already read suspended, without waiting for any TTL")
+	require.False(t, stores.IsStale(got, 5*time.Minute),
+		"the eager write must also refresh synced_at, or the row would immediately look stale")
+}
+
+// TestIntegration_Unsuspend_MarksLocalProjectionStaleNotActive is the
+// asymmetric half: an unsuspend must NOT flip the local row back to
+// active (this projection cannot tell a cascade-suspended store from an
+// individually-suspended one), it must force a refetch by marking the row
+// stale.
+func TestIntegration_Unsuspend_MarksLocalProjectionStaleNotActive(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := stores.NewRepository(tx)
+
+	tenantID := uuid.NewString()
+	seeded := seedIntegrationStore(t, repo, tenantID)
+	seeded.Status = stores.StatusSuspended
+	require.NoError(t, repo.Upsert(t.Context(), seeded))
+
+	stub := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: tenantID, Status: "active", StoresAffected: 1, Changed: true}}
+	h := platformadmin.NewTenantLifecycleHandler(stub, repo, nil, nil)
+
+	rec := postLifecycleTenant(t, h, tenantID, "unsuspend", `{"reason_code":"resolved"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	got, err := repo.GetByIDForTenant(t.Context(), seeded.ID, tenantID)
+	require.NoError(t, err)
+	require.Equal(t, stores.StatusSuspended, got.Status,
+		"unsuspend must NOT eagerly flip the local row to active")
+	require.True(t, stores.IsStale(got, 5*time.Minute),
+		"unsuspend must force the row stale so the next read refetches from platform-api")
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_test.go
@@ -1,0 +1,313 @@
+package platformadmin_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/internal/tenantlifecycle"
+)
+
+// testTenant is a fixed, valid UUID used across this file's fixtures, so
+// the golden fixture and the assertions cannot drift apart.
+const testTenant = "44444444-4444-4444-4444-444444444444"
+
+// stubLifecycle records what it was asked to do and returns canned results.
+// Values are DISTINCT and NON-ZERO so an assertion cannot pass on a
+// fabricated zero from a missing field.
+type stubLifecycle struct {
+	res       *tenantlifecycle.Result
+	err       error
+	gotTenant string
+	calls     int
+}
+
+func (s *stubLifecycle) Suspend(_ context.Context, id string) (*tenantlifecycle.Result, error) {
+	s.calls++
+	s.gotTenant = id
+	return s.res, s.err
+}
+func (s *stubLifecycle) Unsuspend(_ context.Context, id string) (*tenantlifecycle.Result, error) {
+	s.calls++
+	s.gotTenant = id
+	return s.res, s.err
+}
+
+// fakeLifecycleStoreRepo implements stores.Repository for this file's unit
+// tests. Only the two methods this handler calls (SuspendActiveForTenant,
+// MarkStaleForTenant) record anything; the rest are inert stubs, mirroring
+// fakeStoreRepo in internal/subscription/planchange/preflight_test.go.
+type fakeLifecycleStoreRepo struct {
+	mu               sync.Mutex
+	suspendedTenants []string
+	staleTenants     []string
+}
+
+func (r *fakeLifecycleStoreRepo) GetByIDForTenant(_ context.Context, _, _ string) (*stores.Store, error) {
+	return nil, stores.ErrNotFound
+}
+func (r *fakeLifecycleStoreRepo) GetBySlug(_ context.Context, _ string) (*stores.Store, error) {
+	return nil, stores.ErrNotFound
+}
+func (r *fakeLifecycleStoreRepo) ListForTenant(_ context.Context, _ string) ([]stores.Store, error) {
+	return nil, nil
+}
+func (r *fakeLifecycleStoreRepo) Upsert(_ context.Context, _ *stores.Store) error { return nil }
+func (r *fakeLifecycleStoreRepo) GetProductsWatermark(_ context.Context, _ string) (time.Time, error) {
+	return time.Time{}, nil
+}
+func (r *fakeLifecycleStoreRepo) CountActiveOrSoftDeletedRestorable(_ context.Context, _ uuid.UUID) (int, error) {
+	return 0, nil
+}
+func (r *fakeLifecycleStoreRepo) CountActiveOrSoftDeletedRestorableTx(_ context.Context, _ *gorm.DB, _ uuid.UUID) (int, error) {
+	return 0, nil
+}
+func (r *fakeLifecycleStoreRepo) ListActiveOrSoftDeletedRestorable(_ context.Context, _ uuid.UUID) ([]stores.Store, error) {
+	return nil, nil
+}
+func (r *fakeLifecycleStoreRepo) InFlightOrderCount(_ context.Context, _ uuid.UUID) (int, error) {
+	return 0, nil
+}
+func (r *fakeLifecycleStoreRepo) SuspendActiveForTenant(_ context.Context, tenantID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.suspendedTenants = append(r.suspendedTenants, tenantID)
+	return nil
+}
+func (r *fakeLifecycleStoreRepo) MarkStaleForTenant(_ context.Context, tenantID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.staleTenants = append(r.staleTenants, tenantID)
+	return nil
+}
+
+// newLifecycleDeps builds a handler wired to client, an inert local
+// store repo, and an audit func that discards every event. Used by tests
+// that don't care about the audit side effect.
+func newLifecycleDeps(t *testing.T, client platformadmin.TenantLifecycle) *platformadmin.TenantLifecycleHandler {
+	t.Helper()
+	return platformadmin.NewTenantLifecycleHandler(
+		client,
+		&fakeLifecycleStoreRepo{},
+		nil, // NewTenantLifecycleHandler treats nil as a no-op emit func
+		nil,
+	)
+}
+
+// newLifecycleDepsCapturingAudit builds a handler whose audit emission is
+// captured synchronously into the returned slice, rather than routed
+// through the real *audit.Emitter's async worker goroutine — the raw
+// audit.Event is available at the call boundary itself, so no wait is
+// needed for the assertion that follows.
+func newLifecycleDepsCapturingAudit(t *testing.T, client platformadmin.TenantLifecycle) (*platformadmin.TenantLifecycleHandler, *[]audit.Event) {
+	t.Helper()
+	emitted := &[]audit.Event{}
+	var mu sync.Mutex
+	h := platformadmin.NewTenantLifecycleHandler(
+		client,
+		&fakeLifecycleStoreRepo{},
+		func(_ *gin.Context, tenantID uuid.UUID, ev audit.Event) error {
+			mu.Lock()
+			defer mu.Unlock()
+			ev.TenantID = tenantID
+			*emitted = append(*emitted, ev)
+			return nil
+		},
+		nil,
+	)
+	return h, emitted
+}
+
+// postLifecycle signs and sends a POST to /admin/tenants/{testTenant}/{action}
+// through RequirePlatformAuth, mirroring newRouter/signedRequest in
+// middleware_test.go. The request must carry a valid signature, an
+// operator, and a capability, or it is rejected before the handler runs.
+func postLifecycle(t *testing.T, h *platformadmin.TenantLifecycleHandler, action, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	return postLifecycleTenant(t, h, testTenant, action, body)
+}
+
+// postLifecycleTenant is postLifecycle parameterised on the tenant id, for
+// the integration tests (Step 5), which need a real, per-test tenant id
+// rather than the shared fixture constant.
+func postLifecycleTenant(t *testing.T, h *platformadmin.TenantLifecycleHandler, tenantID, action, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(platformadmin.RequirePlatformAuth(platformadmin.AuthConfig{
+		Secret:     testSecret,
+		NonceStore: newMemNonces(),
+		Now:        func() time.Time { return fixedNow },
+	}))
+	h.Register(r.Group(""))
+
+	target := "/admin/tenants/" + tenantID + "/" + action
+	req := signedRequest(t, http.MethodPost, target, []byte(body))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestSuspend_RequiresKnownReasonCode(t *testing.T) {
+	for _, body := range []string{
+		`{}`,                                  // missing
+		`{"reason_code":""}`,                  // empty
+		`{"reason_code":"because_i_said_so"}`, // not in the set
+		`{"reason":"free text only"}`,         // free text is not a substitute
+	} {
+		rec := postLifecycle(t, newLifecycleDeps(t, &stubLifecycle{}), "suspend", body)
+		require.Equal(t, http.StatusBadRequest, rec.Code, "body %s must be rejected", body)
+		require.Contains(t, rec.Body.String(), "reason_code")
+	}
+}
+
+func TestSuspend_AcceptsEveryDeclaredCode(t *testing.T) {
+	for _, code := range platformadmin.SuspendReasonCodes {
+		stub := &stubLifecycle{res: &tenantlifecycle.Result{
+			TenantID: testTenant, Status: "suspended", StoresAffected: 3, Changed: true}}
+		rec := postLifecycle(t, newLifecycleDeps(t, stub), "suspend",
+			`{"reason_code":"`+code+`"}`)
+		require.Equal(t, http.StatusOK, rec.Code, "declared code %q must be accepted", code)
+	}
+}
+
+// The upstream's result is projected, not passed through, and the counts
+// come from upstream rather than being invented locally.
+func TestSuspend_ProjectsUpstreamResult(t *testing.T) {
+	stub := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "suspended", StoresAffected: 3, Changed: true}}
+	rec := postLifecycle(t, newLifecycleDeps(t, stub), "suspend", `{"reason_code":"abuse"}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, testTenant, stub.gotTenant)
+	var body struct {
+		Data struct {
+			TenantID       string `json:"tenant_id"`
+			Status         string `json:"status"`
+			StoresAffected int    `json:"stores_affected"`
+			Changed        bool   `json:"changed"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, 3, body.Data.StoresAffected)
+	require.True(t, body.Data.Changed)
+	require.Equal(t, "suspended", body.Data.Status)
+}
+
+// An upstream ErrUnavailable must NOT read as "nothing to do".
+func TestSuspend_UpstreamUnavailableIs503NotEmptySuccess(t *testing.T) {
+	stub := &stubLifecycle{err: tenantlifecycle.ErrUnavailable}
+	rec := postLifecycle(t, newLifecycleDeps(t, stub), "suspend", `{"reason_code":"abuse"}`)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.NotContains(t, rec.Body.String(), `"changed"`,
+		"a failed suspension must not shape a result at all")
+}
+
+func TestSuspend_UpstreamNotFoundIs404_ConflictIs409(t *testing.T) {
+	rec := postLifecycle(t, newLifecycleDeps(t, &stubLifecycle{err: tenantlifecycle.ErrNotFound}),
+		"suspend", `{"reason_code":"abuse"}`)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	rec = postLifecycle(t, newLifecycleDeps(t, &stubLifecycle{err: tenantlifecycle.ErrConflict}),
+		"suspend", `{"reason_code":"abuse"}`)
+	require.Equal(t, http.StatusConflict, rec.Code)
+}
+
+// The audit row must carry the tenant, the operator, and the reason code —
+// and there must be exactly ONE per changed call, none for a no-op.
+func TestSuspend_AuditsOncePerChangeAndNeverForNoOp(t *testing.T) {
+	changed := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "suspended", StoresAffected: 3, Changed: true}}
+	deps, emitted := newLifecycleDepsCapturingAudit(t, changed)
+	postLifecycle(t, deps, "suspend", `{"reason_code":"abuse","reason":"spam orders"}`)
+
+	require.Len(t, *emitted, 1, "exactly one audit row per changed suspension")
+	ev := (*emitted)[0]
+	require.Equal(t, testTenant, ev.TenantID.String(),
+		"an event with no tenant is silently DROPPED — this is the assertion that catches it")
+	require.Equal(t, "abuse", ev.Metadata["reason_code"])
+	require.Equal(t, "spam orders", ev.Metadata["reason"])
+	require.Equal(t, 3, ev.Metadata["stores_affected"])
+
+	noop := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "suspended", StoresAffected: 0, Changed: false}}
+	deps2, emitted2 := newLifecycleDepsCapturingAudit(t, noop)
+	rec := postLifecycle(t, deps2, "suspend", `{"reason_code":"abuse"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Empty(t, *emitted2, "a no-op writes NO audit row (#287 acceptance)")
+}
+
+// The local projection is updated in the same request, so enforcement does
+// not wait out StoreMiddleware's 5-minute TTL. The unit-level slice of
+// this — that the handler calls SuspendActiveForTenant on a changed
+// suspend and MarkStaleForTenant on a changed unsuspend, never the
+// reverse — is covered here; the DB-backed proof that a real row's status
+// actually changes lives in the integration test (Step 5).
+func TestSuspend_UpdatesLocalProjectionImmediately(t *testing.T) {
+	repo := &fakeLifecycleStoreRepo{}
+	stub := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "suspended", StoresAffected: 3, Changed: true}}
+	h := platformadmin.NewTenantLifecycleHandler(stub, repo, nil, nil)
+	rec := postLifecycle(t, h, "suspend", `{"reason_code":"abuse"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, []string{testTenant}, repo.suspendedTenants,
+		"suspend must eagerly flip the local projection to suspended")
+	require.Empty(t, repo.staleTenants, "suspend must never mark rows stale")
+}
+
+// Unsuspend takes effect on the next refresh, not instantly — see the type
+// doc on TenantLifecycleHandler for why an eager local flip back to
+// active would under-enforce.
+func TestUnsuspend_MarksLocalProjectionStaleNotActive(t *testing.T) {
+	repo := &fakeLifecycleStoreRepo{}
+	stub := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "active", StoresAffected: 3, Changed: true}}
+	h := platformadmin.NewTenantLifecycleHandler(stub, repo, nil, nil)
+	rec := postLifecycle(t, h, "unsuspend", `{"reason_code":"resolved"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, []string{testTenant}, repo.staleTenants,
+		"unsuspend must mark the local projection stale so it is refetched")
+	require.Empty(t, repo.suspendedTenants, "unsuspend must never call the suspend-projection path")
+}
+
+func TestUnsuspend_RequiresKnownReasonCode(t *testing.T) {
+	rec := postLifecycle(t, newLifecycleDeps(t, &stubLifecycle{}), "unsuspend", `{"reason_code":"abuse"}`)
+	require.Equal(t, http.StatusBadRequest, rec.Code,
+		"a suspend-only code must not be accepted on unsuspend — the two closed sets are different")
+	require.Contains(t, rec.Body.String(), "reason_code")
+}
+
+func TestUnsuspend_AcceptsEveryDeclaredCode(t *testing.T) {
+	for _, code := range platformadmin.UnsuspendReasonCodes {
+		stub := &stubLifecycle{res: &tenantlifecycle.Result{
+			TenantID: testTenant, Status: "active", StoresAffected: 2, Changed: true}}
+		rec := postLifecycle(t, newLifecycleDeps(t, stub), "unsuspend",
+			`{"reason_code":"`+code+`"}`)
+		require.Equal(t, http.StatusOK, rec.Code, "declared code %q must be accepted", code)
+	}
+}
+
+// THE test. Real handler output compared to the committed contract.
+func TestSuspend_MatchesGoldenFixture(t *testing.T) {
+	stub := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "suspended", StoresAffected: 3, Changed: true}}
+	rec := postLifecycle(t, newLifecycleDeps(t, stub), "suspend", `{"reason_code":"abuse","reason":"spam orders"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	want, err := os.ReadFile("testdata/tenant_suspend_response.json")
+	require.NoError(t, err)
+	require.JSONEq(t, string(want), rec.Body.String())
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_test.go
@@ -94,6 +94,11 @@ func (r *fakeLifecycleStoreRepo) MarkStaleForTenant(_ context.Context, tenantID 
 	return nil
 }
 
+// discardAudit is an explicit, visible "throw the event away" choice —
+// NewTenantLifecycleHandler panics on a nil emit func (F1, #287) precisely
+// so that choice can never be made silently by omission.
+func discardAudit(*gin.Context, uuid.UUID, audit.Event) error { return nil }
+
 // newLifecycleDeps builds a handler wired to client, an inert local
 // store repo, and an audit func that discards every event. Used by tests
 // that don't care about the audit side effect.
@@ -102,7 +107,7 @@ func newLifecycleDeps(t *testing.T, client platformadmin.TenantLifecycle) *platf
 	return platformadmin.NewTenantLifecycleHandler(
 		client,
 		&fakeLifecycleStoreRepo{},
-		nil, // NewTenantLifecycleHandler treats nil as a no-op emit func
+		discardAudit,
 		nil,
 	)
 }
@@ -241,6 +246,8 @@ func TestSuspend_AuditsOncePerChangeAndNeverForNoOp(t *testing.T) {
 	require.Equal(t, "abuse", ev.Metadata["reason_code"])
 	require.Equal(t, "spam orders", ev.Metadata["reason"])
 	require.Equal(t, 3, ev.Metadata["stores_affected"])
+	require.Equal(t, "audit.read", ev.Metadata["capability"],
+		"the asserted capability header must be recorded on the audit row (F5, #287)")
 
 	noop := &stubLifecycle{res: &tenantlifecycle.Result{
 		TenantID: testTenant, Status: "suspended", StoresAffected: 0, Changed: false}}
@@ -260,7 +267,7 @@ func TestSuspend_UpdatesLocalProjectionImmediately(t *testing.T) {
 	repo := &fakeLifecycleStoreRepo{}
 	stub := &stubLifecycle{res: &tenantlifecycle.Result{
 		TenantID: testTenant, Status: "suspended", StoresAffected: 3, Changed: true}}
-	h := platformadmin.NewTenantLifecycleHandler(stub, repo, nil, nil)
+	h := platformadmin.NewTenantLifecycleHandler(stub, repo, discardAudit, nil)
 	rec := postLifecycle(t, h, "suspend", `{"reason_code":"abuse"}`)
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, []string{testTenant}, repo.suspendedTenants,
@@ -275,7 +282,7 @@ func TestUnsuspend_MarksLocalProjectionStaleNotActive(t *testing.T) {
 	repo := &fakeLifecycleStoreRepo{}
 	stub := &stubLifecycle{res: &tenantlifecycle.Result{
 		TenantID: testTenant, Status: "active", StoresAffected: 3, Changed: true}}
-	h := platformadmin.NewTenantLifecycleHandler(stub, repo, nil, nil)
+	h := platformadmin.NewTenantLifecycleHandler(stub, repo, discardAudit, nil)
 	rec := postLifecycle(t, h, "unsuspend", `{"reason_code":"resolved"}`)
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, []string{testTenant}, repo.staleTenants,

--- a/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_test.go
@@ -94,9 +94,13 @@ func (r *fakeLifecycleStoreRepo) MarkStaleForTenant(_ context.Context, tenantID 
 	return nil
 }
 
-// discardAudit is an explicit, visible "throw the event away" choice —
-// NewTenantLifecycleHandler panics on a nil emit func (F1, #287) precisely
-// so that choice can never be made silently by omission.
+// discardAudit is an explicit, visible "throw the event away" choice, used
+// by tests that don't care about the audit side effect. The real guard
+// against a silently-unaudited write endpoint (F1, #287) is NOT here —
+// NewTenantLifecycleHandler tolerates a nil emit func too — it's in
+// Register (routes.go), which refuses to mount these routes at all when
+// Deps.Emitter is nil. See TestRegisterRequiresEmitterToMountTenantLifecycle
+// in routes_tenant_lifecycle_test.go for that guard's own test.
 func discardAudit(*gin.Context, uuid.UUID, audit.Event) error { return nil }
 
 // newLifecycleDeps builds a handler wired to client, an inert local

--- a/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_test.go
@@ -113,6 +113,7 @@ func newLifecycleDeps(t *testing.T, client platformadmin.TenantLifecycle) *platf
 		&fakeLifecycleStoreRepo{},
 		discardAudit,
 		nil,
+		nil,
 	)
 }
 
@@ -135,6 +136,7 @@ func newLifecycleDepsCapturingAudit(t *testing.T, client platformadmin.TenantLif
 			*emitted = append(*emitted, ev)
 			return nil
 		},
+		nil,
 		nil,
 	)
 	return h, emitted
@@ -271,7 +273,7 @@ func TestSuspend_UpdatesLocalProjectionImmediately(t *testing.T) {
 	repo := &fakeLifecycleStoreRepo{}
 	stub := &stubLifecycle{res: &tenantlifecycle.Result{
 		TenantID: testTenant, Status: "suspended", StoresAffected: 3, Changed: true}}
-	h := platformadmin.NewTenantLifecycleHandler(stub, repo, discardAudit, nil)
+	h := platformadmin.NewTenantLifecycleHandler(stub, repo, discardAudit, nil, nil)
 	rec := postLifecycle(t, h, "suspend", `{"reason_code":"abuse"}`)
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, []string{testTenant}, repo.suspendedTenants,
@@ -286,7 +288,7 @@ func TestUnsuspend_MarksLocalProjectionStaleNotActive(t *testing.T) {
 	repo := &fakeLifecycleStoreRepo{}
 	stub := &stubLifecycle{res: &tenantlifecycle.Result{
 		TenantID: testTenant, Status: "active", StoresAffected: 3, Changed: true}}
-	h := platformadmin.NewTenantLifecycleHandler(stub, repo, discardAudit, nil)
+	h := platformadmin.NewTenantLifecycleHandler(stub, repo, discardAudit, nil, nil)
 	rec := postLifecycle(t, h, "unsuspend", `{"reason_code":"resolved"}`)
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, []string{testTenant}, repo.staleTenants,

--- a/services/marketplace-api/internal/handlers/platformadmin/testdata/tenant_suspend_response.json
+++ b/services/marketplace-api/internal/handlers/platformadmin/testdata/tenant_suspend_response.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "tenant_id": "44444444-4444-4444-4444-444444444444",
+    "status": "suspended",
+    "stores_affected": 3,
+    "changed": true
+  }
+}

--- a/services/marketplace-api/internal/stores/middleware.go
+++ b/services/marketplace-api/internal/stores/middleware.go
@@ -49,6 +49,10 @@ func StoreMiddleware(cfg MiddlewareConfig) gin.HandlerFunc {
 		cached, cacheErr := cfg.Repo.GetByIDForTenant(c.Request.Context(), storeID, tid)
 		fresh := cacheErr == nil && !IsStale(cached, cfg.FreshTTL)
 		if fresh {
+			if cached.Status != StatusActive {
+				respondNotFound(c)
+				return
+			}
 			c.Set("store", cached)
 			c.Next()
 			return
@@ -62,8 +66,18 @@ func StoreMiddleware(cfg MiddlewareConfig) gin.HandlerFunc {
 
 		switch {
 		case refreshErr == nil && result != nil:
-			c.Set("store", result.(*Store))
+			refreshed := result.(*Store)
+			if refreshed.Status != StatusActive {
+				respondNotFound(c)
+				return
+			}
+			c.Set("store", refreshed)
 			c.Next()
+		case cacheErr == nil && cached != nil && cached.Status != StatusActive:
+			// A cached suspended (or otherwise non-active) status is
+			// authoritative at any age — never fail-open on it, even
+			// within the stale ceiling.
+			respondNotFound(c)
 		case cacheErr == nil && cached != nil && time.Since(cached.SyncedAt) < cfg.StaleCeil:
 			if cfg.Logger != nil {
 				cfg.Logger.Warn("serving stale store projection",

--- a/services/marketplace-api/internal/stores/middleware_test.go
+++ b/services/marketplace-api/internal/stores/middleware_test.go
@@ -459,6 +459,99 @@ func buildRouterForTenant(cfg stores.MiddlewareConfig, p *probe, tenantID string
 
 // A concurrent request from another tenant must not piggyback on the
 // singleflight refresh of the owning tenant and receive its store.
+// A suspended store must not serve admin API traffic even though it
+// resolves cleanly and belongs to the right tenant. `reached` is the real
+// assertion: a 404 with the handler still having run would mean the
+// middleware let it through and something later happened to 404.
+func TestMiddleware_SuspendedStoreIsRefused(t *testing.T) {
+	repo := newFakeRepo()
+	st := newFixtureStore(time.Now()) // fresh, so no refresh path is involved
+	st.Status = stores.StatusSuspended
+	repo.preload(st)
+	p := &probe{}
+
+	w := doRequest(buildRouter(baseCfg(repo, &fakeClient{}), p))
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404", w.Code)
+	}
+	if p.reached {
+		t.Fatal("handler was reached for a suspended store")
+	}
+}
+
+func TestMiddleware_ArchivedStoreIsRefused(t *testing.T) {
+	repo := newFakeRepo()
+	st := newFixtureStore(time.Now())
+	st.Status = stores.StatusArchived
+	repo.preload(st)
+	p := &probe{}
+
+	w := doRequest(buildRouter(baseCfg(repo, &fakeClient{}), p))
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404", w.Code)
+	}
+	if p.reached {
+		t.Fatal("handler was reached for an archived store")
+	}
+}
+
+// THE asymmetry, half one: a stale row that says `suspended` is still
+// enforced. The fixture is deliberately OLDER than StaleCeil and the client
+// is made to fail, so the only thing the middleware can act on is the stale
+// cached row — which must still refuse.
+func TestMiddleware_StaleSuspendedIsStillRefused(t *testing.T) {
+	cfg := baseCfg(newFakeRepo(), &fakeClient{err: stores.ErrPlatformUnavailable})
+	repo := newFakeRepo()
+	// Stale past FreshTTL but WITHIN the 24h StaleCeil (see NOTE on
+	// TestMiddleware_StaleActiveIsStillServed): if this fixture were beyond
+	// the ceiling instead, the pre-existing ceiling default would already
+	// 404 it regardless of status, and the test would not actually exercise
+	// the suspended-is-authoritative-while-stale asymmetry it is meant to pin.
+	st := newFixtureStore(time.Now().Add(-1 * time.Hour))
+	st.Status = stores.StatusSuspended
+	repo.preload(st)
+	cfg.Repo = repo
+	p := &probe{}
+
+	w := doRequest(buildRouter(cfg, p))
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404 (a cached suspended status is authoritative at any age)", w.Code)
+	}
+	if p.reached {
+		t.Fatal("handler was reached for a stale suspended store")
+	}
+}
+
+// THE asymmetry, half two, and the one that stops the fix going too far: a
+// stale ACTIVE row is still served when platform-api is unreachable. If this
+// test fails you have made the cache fail-closed and an outage now locks out
+// every merchant.
+func TestMiddleware_StaleActiveIsStillServed(t *testing.T) {
+	cfg := baseCfg(newFakeRepo(), &fakeClient{err: stores.ErrPlatformUnavailable})
+	repo := newFakeRepo()
+	// Stale past FreshTTL but within StaleCeil, Status active. NOTE: deliberately
+	// NOT -25h (beyond the 24h StaleCeil) — that exact input is already pinned to
+	// 404 by TestMiddleware_StaleCache_BeyondCeiling_404 regardless of status, so
+	// reusing it here would contradict that pre-existing, deliberate ceiling. The
+	// "served at any age" guarantee in the design applies to suspended being
+	// refused, not to active bypassing the ceiling.
+	repo.preload(newFixtureStore(time.Now().Add(-1 * time.Hour)))
+	cfg.Repo = repo
+	p := &probe{}
+
+	w := doRequest(buildRouter(cfg, p))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (fail-open on stale ACTIVE is deliberate)", w.Code)
+	}
+	if !p.reached {
+		t.Fatal("handler not reached: stale active must still be served")
+	}
+}
+
 func TestStoreMiddleware_ConcurrentRefreshIsTenantScoped(t *testing.T) {
 	const otherTenantID = "33333333-3333-3333-3333-333333333333"
 

--- a/services/marketplace-api/internal/stores/middleware_test.go
+++ b/services/marketplace-api/internal/stores/middleware_test.go
@@ -101,6 +101,32 @@ func (r *fakeRepo) InFlightOrderCount(_ context.Context, _ uuid.UUID) (int, erro
 	return 0, nil
 }
 
+func (r *fakeRepo) SuspendActiveForTenant(_ context.Context, tenantID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for k, s := range r.byKey {
+		if s.TenantID == tenantID && s.Status == stores.StatusActive {
+			cp := *s
+			cp.Status = stores.StatusSuspended
+			r.byKey[k] = &cp
+		}
+	}
+	return nil
+}
+
+func (r *fakeRepo) MarkStaleForTenant(_ context.Context, tenantID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for k, s := range r.byKey {
+		if s.TenantID == tenantID {
+			cp := *s
+			cp.SyncedAt = time.Unix(0, 0)
+			r.byKey[k] = &cp
+		}
+	}
+	return nil
+}
+
 func (r *fakeRepo) preload(s *stores.Store) {
 	_ = r.Upsert(context.Background(), s)
 	r.mu.Lock()

--- a/services/marketplace-api/internal/stores/middleware_test.go
+++ b/services/marketplace-api/internal/stores/middleware_test.go
@@ -351,14 +351,25 @@ func TestMiddleware_StaleCache_BeyondCeiling_404(t *testing.T) {
 	}
 }
 
-// TestMiddleware_MarkStaleForTenant_PlatformOutage_ServesStale pins the
-// fail-open requirement (F2, #287): MarkStaleForTenant backdates synced_at
+// TestMiddleware_ForceRefreshAgeBackdateStaysWithinStaleCeiling pins a
+// property of the forceRefreshAge CONSTANT (F2, #287 review), not of
+// MarkStaleForTenant's real caller: MarkStaleForTenant backdates synced_at
 // enough to trip IsStale and force a refresh attempt, but NOT so far back
-// that a failed refresh (platform-api unreachable) falls outside StaleCeil.
-// If MarkStaleForTenant instead wrote the epoch, this request would 404 —
-// locking every merchant out of every store during an outage that follows
-// an unsuspend, which is exactly the failure mode this design forbids.
-func TestMiddleware_MarkStaleForTenant_PlatformOutage_ServesStale(t *testing.T) {
+// that the row falls outside StaleCeil. This matters for any caller that
+// marks an ACTIVE row stale (a failed refresh on such a row then serves
+// stale instead of 404ing) — it is a general-safety property of the
+// helper, exercised here directly against an active fixture.
+//
+// It is NOT a claim about MarkStaleForTenant's actual production caller:
+// unsuspend is the only caller, and every row it touches is status=
+// suspended at the time this runs, which 404s on a failed refresh
+// regardless of forceRefreshAge's value (StoreMiddleware's suspended check
+// runs before its StaleCeil check — see TestMiddleware_StaleSuspendedIsStillRefused
+// for that path, and forceRefreshAge's doc comment in repository.go for
+// the full reasoning). This test was previously named as if it covered
+// that path; it does not, and never could, since it seeds an active
+// fixture MarkStaleForTenant's caller can never produce.
+func TestMiddleware_ForceRefreshAgeBackdateStaysWithinStaleCeiling(t *testing.T) {
 	repo := newFakeRepo()
 	repo.preload(newFixtureStore(time.Now())) // fresh to start
 	if err := repo.MarkStaleForTenant(context.Background(), testTenantID); err != nil {

--- a/services/marketplace-api/internal/stores/middleware_test.go
+++ b/services/marketplace-api/internal/stores/middleware_test.go
@@ -120,7 +120,11 @@ func (r *fakeRepo) MarkStaleForTenant(_ context.Context, tenantID string) error 
 	for k, s := range r.byKey {
 		if s.TenantID == tenantID {
 			cp := *s
-			cp.SyncedAt = time.Unix(0, 0)
+			// Mirrors the real repository's forceRefreshAge: stale enough
+			// to fail IsStale against the default 5-minute FreshTTL, but
+			// nowhere near the 24h StaleCeil, so a failed refresh still
+			// falls into the fail-open stale-serve branch instead of 404ing.
+			cp.SyncedAt = time.Now().Add(-10 * time.Minute)
 			r.byKey[k] = &cp
 		}
 	}
@@ -344,6 +348,36 @@ func TestMiddleware_StaleCache_BeyondCeiling_404(t *testing.T) {
 	}
 	if p.reached {
 		t.Fatal("handler should not be reached")
+	}
+}
+
+// TestMiddleware_MarkStaleForTenant_PlatformOutage_ServesStale pins the
+// fail-open requirement (F2, #287): MarkStaleForTenant backdates synced_at
+// enough to trip IsStale and force a refresh attempt, but NOT so far back
+// that a failed refresh (platform-api unreachable) falls outside StaleCeil.
+// If MarkStaleForTenant instead wrote the epoch, this request would 404 —
+// locking every merchant out of every store during an outage that follows
+// an unsuspend, which is exactly the failure mode this design forbids.
+func TestMiddleware_MarkStaleForTenant_PlatformOutage_ServesStale(t *testing.T) {
+	repo := newFakeRepo()
+	repo.preload(newFixtureStore(time.Now())) // fresh to start
+	if err := repo.MarkStaleForTenant(context.Background(), testTenantID); err != nil {
+		t.Fatalf("MarkStaleForTenant: %v", err)
+	}
+
+	client := &fakeClient{err: stores.ErrPlatformUnavailable}
+	p := &probe{}
+	r := buildRouter(baseCfg(repo, client), p)
+
+	w := doRequest(r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (fail-open on a stale-but-recent row)", w.Code)
+	}
+	if !p.reached {
+		t.Fatal("handler not reached")
+	}
+	if !p.storeStale {
+		t.Fatal("expected store_stale=true")
 	}
 }
 

--- a/services/marketplace-api/internal/stores/repository.go
+++ b/services/marketplace-api/internal/stores/repository.go
@@ -221,22 +221,28 @@ func (r *gormRepository) InFlightOrderCount(ctx context.Context, storeID uuid.UU
 }
 
 // forceRefreshAge is how far in the past MarkStaleForTenant backdates
-// synced_at. It is DELIBERATELY NOT the epoch: StoreMiddleware and
-// SlugCache both fail OPEN on a refresh error, serving a cached row
-// whose age is under their StaleCeil (24h) rather than 404ing every
-// merchant during a platform-api outage (see StoreMiddleware's
-// cacheErr == nil && cached != nil && time.Since(cached.SyncedAt) <
-// cfg.StaleCeil branch, and SlugCache.Get's matching fallback). Backdating
-// to the epoch would put every row past that 24h ceiling, so a failed
-// refresh right after an unsuspend would 404 instead of serving the
-// (still-accurate-enough) cached row — fail-closed where the design
-// requires fail-open.
+// synced_at. It sits just past the 5-minute FreshTTL default (so IsStale
+// reports true and the very next read is forced through the refresh path)
+// while staying far inside the 24h StaleCeil default, which keeps the row
+// inside StoreMiddleware's / SlugCache's fail-open stale-serve window as a
+// general-safety property of this helper — useful for ANY caller that
+// marks ACTIVE rows stale, since a failed refresh on those would then be
+// served rather than 404ed.
 //
-// forceRefreshAge sits just past the 5-minute FreshTTL default (so
-// IsStale reports true and the very next read is forced through the
-// refresh path) but stays far inside the 24h StaleCeil default (so a
-// refresh that fails — platform-api down — still falls into the
-// stale-serve branch instead of 404ing).
+// That said: on this helper's only current caller, MarkStaleForTenant is
+// invoked exclusively from unsuspend (see tenant_lifecycle.go), at which
+// point every row it touches is still status=suspended (suspend flips them
+// there; unsuspend only backdates synced_at, it does not eagerly flip
+// status back — see MarkStaleForTenant's doc). StoreMiddleware's switch
+// checks `cached.Status != StatusActive` BEFORE it ever reaches the
+// StaleCeil branch, so those rows 404 on a failed refresh regardless of
+// forceRefreshAge's value — backdating by 10 minutes vs. to the epoch is
+// observationally identical on that path. That is correct: fail-closed on
+// a suspended tenant is exactly what the spec requires. Do not read this
+// constant's value as evidence that a failed refresh "still falls into the
+// stale-serve branch instead of 404ing" for MarkStaleForTenant's actual
+// caller — it does not; the general-safety property above is the reason
+// this constant is what it is, not a behavioral guarantee for unsuspend.
 const forceRefreshAge = 10 * time.Minute
 
 // SuspendActiveForTenant flips active -> suspended for every local store
@@ -255,13 +261,14 @@ func (r *gormRepository) SuspendActiveForTenant(ctx context.Context, tenantID st
 // MarkStaleForTenant backdates synced_at by forceRefreshAge (NOT to the
 // epoch) for every local store row belonging to tenantID, so the next
 // read is forced through the refresh path instead of serving a cached
-// status. Backdating by forceRefreshAge rather than to the epoch keeps
-// the row's age inside StaleCeil, so a refresh that then fails (e.g.
-// platform-api unreachable) still falls into StoreMiddleware's /
-// SlugCache's fail-open stale-serve branch instead of 404ing every
-// merchant during the outage — see forceRefreshAge's doc for the full
-// reasoning. See Repository interface doc for why unsuspend uses this
-// instead of an eager flip back to active.
+// status. See forceRefreshAge's doc for what backdating by that amount
+// does and does not guarantee: on this method's only caller (unsuspend),
+// every affected row is still status=suspended, and StoreMiddleware
+// refuses a cached suspended row before it ever consults StaleCeil — so a
+// failed refresh 404s here regardless of how far back synced_at was
+// pushed. That is intentional fail-closed behavior, not a bug. See
+// Repository interface doc for why unsuspend uses this instead of an
+// eager flip back to active.
 func (r *gormRepository) MarkStaleForTenant(ctx context.Context, tenantID string) error {
 	if err := r.db.WithContext(ctx).
 		Model(&Store{}).

--- a/services/marketplace-api/internal/stores/repository.go
+++ b/services/marketplace-api/internal/stores/repository.go
@@ -61,15 +61,17 @@ type Repository interface {
 	SuspendActiveForTenant(ctx context.Context, tenantID string) error
 
 	// MarkStaleForTenant forces every local store row for a tenant to be
-	// treated as stale on the next read, by resetting synced_at to the
-	// epoch. Used by the platform console's tenant-unsuspend endpoint
-	// (#287) instead of eagerly flipping status back to active: this
-	// projection has no column distinguishing a store suspended by the
-	// tenant-level cascade from one suspended individually in
-	// platform-api, so a local unsuspend cannot tell them apart. Forcing a
-	// refetch is the only way to get an authoritative status without
-	// risking that a distinction. See tenant_lifecycle.go for the full
-	// rationale.
+	// treated as stale on the next read, by backdating synced_at by
+	// forceRefreshAge — NOT to the epoch, so the row stays inside
+	// StaleCeil and a failed refresh still fails open (see
+	// forceRefreshAge's doc). Used by the platform console's
+	// tenant-unsuspend endpoint (#287) instead of eagerly flipping status
+	// back to active: this projection has no column distinguishing a
+	// store suspended by the tenant-level cascade from one suspended
+	// individually in platform-api, so a local unsuspend cannot tell them
+	// apart. Forcing a refetch is the only way to get an authoritative
+	// status without risking that a distinction. See tenant_lifecycle.go
+	// for the full rationale.
 	MarkStaleForTenant(ctx context.Context, tenantID string) error
 }
 
@@ -250,11 +252,16 @@ func (r *gormRepository) SuspendActiveForTenant(ctx context.Context, tenantID st
 	return nil
 }
 
-// MarkStaleForTenant resets synced_at to the epoch for every local store
-// row belonging to tenantID, so the next read is forced through the
-// refresh path instead of serving a cached status. See Repository
-// interface doc for why unsuspend uses this instead of an eager flip back
-// to active.
+// MarkStaleForTenant backdates synced_at by forceRefreshAge (NOT to the
+// epoch) for every local store row belonging to tenantID, so the next
+// read is forced through the refresh path instead of serving a cached
+// status. Backdating by forceRefreshAge rather than to the epoch keeps
+// the row's age inside StaleCeil, so a refresh that then fails (e.g.
+// platform-api unreachable) still falls into StoreMiddleware's /
+// SlugCache's fail-open stale-serve branch instead of 404ing every
+// merchant during the outage — see forceRefreshAge's doc for the full
+// reasoning. See Repository interface doc for why unsuspend uses this
+// instead of an eager flip back to active.
 func (r *gormRepository) MarkStaleForTenant(ctx context.Context, tenantID string) error {
 	if err := r.db.WithContext(ctx).
 		Model(&Store{}).

--- a/services/marketplace-api/internal/stores/repository.go
+++ b/services/marketplace-api/internal/stores/repository.go
@@ -218,11 +218,24 @@ func (r *gormRepository) InFlightOrderCount(ctx context.Context, storeID uuid.UU
 	return int(n), nil
 }
 
-// staleEpoch is written to synced_at by MarkStaleForTenant. It is always
-// older than any FreshTTL StoreMiddleware or slugCache is configured with,
-// so IsStale reports true unconditionally on the next read regardless of
-// how that TTL is tuned.
-var staleEpoch = time.Unix(0, 0)
+// forceRefreshAge is how far in the past MarkStaleForTenant backdates
+// synced_at. It is DELIBERATELY NOT the epoch: StoreMiddleware and
+// SlugCache both fail OPEN on a refresh error, serving a cached row
+// whose age is under their StaleCeil (24h) rather than 404ing every
+// merchant during a platform-api outage (see StoreMiddleware's
+// cacheErr == nil && cached != nil && time.Since(cached.SyncedAt) <
+// cfg.StaleCeil branch, and SlugCache.Get's matching fallback). Backdating
+// to the epoch would put every row past that 24h ceiling, so a failed
+// refresh right after an unsuspend would 404 instead of serving the
+// (still-accurate-enough) cached row — fail-closed where the design
+// requires fail-open.
+//
+// forceRefreshAge sits just past the 5-minute FreshTTL default (so
+// IsStale reports true and the very next read is forced through the
+// refresh path) but stays far inside the 24h StaleCeil default (so a
+// refresh that fails — platform-api down — still falls into the
+// stale-serve branch instead of 404ing).
+const forceRefreshAge = 10 * time.Minute
 
 // SuspendActiveForTenant flips active -> suspended for every local store
 // row belonging to tenantID. See Repository interface doc for why this is
@@ -246,7 +259,7 @@ func (r *gormRepository) MarkStaleForTenant(ctx context.Context, tenantID string
 	if err := r.db.WithContext(ctx).
 		Model(&Store{}).
 		Where("tenant_id = ?", tenantID).
-		Update("synced_at", staleEpoch).Error; err != nil {
+		Update("synced_at", time.Now().Add(-forceRefreshAge)).Error; err != nil {
 		return fmt.Errorf("stores: mark stale for tenant: %w", err)
 	}
 	return nil

--- a/services/marketplace-api/internal/stores/repository.go
+++ b/services/marketplace-api/internal/stores/repository.go
@@ -51,6 +51,26 @@ type Repository interface {
 	// downgrading. Update the terminal set here if a new terminal status is added
 	// to order.OrderStatus.
 	InFlightOrderCount(ctx context.Context, storeID uuid.UUID) (int, error)
+
+	// SuspendActiveForTenant flips every ACTIVE local store row for a
+	// tenant to suspended, immediately — used by the platform console's
+	// tenant-suspend endpoint (#287) so enforcement does not wait out
+	// StoreMiddleware's FreshTTL. Over-enforcing (a store that was already
+	// suspended stays suspended) is the safe direction here, so this is a
+	// plain bulk UPDATE with no read-modify-write.
+	SuspendActiveForTenant(ctx context.Context, tenantID string) error
+
+	// MarkStaleForTenant forces every local store row for a tenant to be
+	// treated as stale on the next read, by resetting synced_at to the
+	// epoch. Used by the platform console's tenant-unsuspend endpoint
+	// (#287) instead of eagerly flipping status back to active: this
+	// projection has no column distinguishing a store suspended by the
+	// tenant-level cascade from one suspended individually in
+	// platform-api, so a local unsuspend cannot tell them apart. Forcing a
+	// refetch is the only way to get an authoritative status without
+	// risking that a distinction. See tenant_lifecycle.go for the full
+	// rationale.
+	MarkStaleForTenant(ctx context.Context, tenantID string) error
 }
 
 // WatermarkReader is the narrow read-only contract consumed by the M6
@@ -196,6 +216,40 @@ func (r *gormRepository) InFlightOrderCount(ctx context.Context, storeID uuid.UU
 		return 0, fmt.Errorf("stores: in-flight order count: %w", err)
 	}
 	return int(n), nil
+}
+
+// staleEpoch is written to synced_at by MarkStaleForTenant. It is always
+// older than any FreshTTL StoreMiddleware or slugCache is configured with,
+// so IsStale reports true unconditionally on the next read regardless of
+// how that TTL is tuned.
+var staleEpoch = time.Unix(0, 0)
+
+// SuspendActiveForTenant flips active -> suspended for every local store
+// row belonging to tenantID. See Repository interface doc for why this is
+// safe to over-apply (it only ever adds suspension, never removes it).
+func (r *gormRepository) SuspendActiveForTenant(ctx context.Context, tenantID string) error {
+	if err := r.db.WithContext(ctx).
+		Model(&Store{}).
+		Where("tenant_id = ? AND status = ?", tenantID, StatusActive).
+		Updates(map[string]any{"status": StatusSuspended, "synced_at": time.Now()}).Error; err != nil {
+		return fmt.Errorf("stores: suspend active for tenant: %w", err)
+	}
+	return nil
+}
+
+// MarkStaleForTenant resets synced_at to the epoch for every local store
+// row belonging to tenantID, so the next read is forced through the
+// refresh path instead of serving a cached status. See Repository
+// interface doc for why unsuspend uses this instead of an eager flip back
+// to active.
+func (r *gormRepository) MarkStaleForTenant(ctx context.Context, tenantID string) error {
+	if err := r.db.WithContext(ctx).
+		Model(&Store{}).
+		Where("tenant_id = ?", tenantID).
+		Update("synced_at", staleEpoch).Error; err != nil {
+		return fmt.Errorf("stores: mark stale for tenant: %w", err)
+	}
+	return nil
 }
 
 // countStoresByTenant is the shared implementation for both count methods.

--- a/services/marketplace-api/internal/subscription/planchange/preflight_test.go
+++ b/services/marketplace-api/internal/subscription/planchange/preflight_test.go
@@ -54,6 +54,8 @@ func (r *fakeStoreRepo) ListActiveOrSoftDeletedRestorable(_ context.Context, _ u
 func (r *fakeStoreRepo) InFlightOrderCount(_ context.Context, _ uuid.UUID) (int, error) {
 	return r.orderCount, nil
 }
+func (r *fakeStoreRepo) SuspendActiveForTenant(_ context.Context, _ string) error { return nil }
+func (r *fakeStoreRepo) MarkStaleForTenant(_ context.Context, _ string) error     { return nil }
 
 // activeSubscription builds a minimal StoreSubscription in Active status on
 // the given plan/period with a billing currency and period-end 30 days out.

--- a/services/marketplace-api/internal/tenantgate/gate.go
+++ b/services/marketplace-api/internal/tenantgate/gate.go
@@ -2,13 +2,17 @@
 // refuses ALL admin traffic for a suspended tenant (#287).
 //
 // StoreMiddleware (internal/stores) already refuses a suspended tenant on
-// /admin/stores/:storeId, but that group is one of four admin route groups.
-// The other three — /admin, /admin/account and the SSO group
-// /admin/tenants/:tenantId — are tenant-scoped, not store-scoped, so
-// StoreMiddleware never runs on them. A suspended tenant with an existing
-// session (or a tenant with zero stores) would otherwise keep full access
-// to those groups until the session expired. This package closes that gap
-// at the tenant level, independent of any specific store.
+// /admin/stores/:storeId, but that group is one of FIVE admin route groups
+// (four web + the mobile group, internal/handlers/admin/mobile_routes.go,
+// which was missed in the original design and fixed under F1/#287). The
+// other four — /admin, /admin/account, the SSO group
+// /admin/tenants/:tenantId, and the mobile group's non-store-scoped routes
+// (platform-support, account, /mobile/admin/stores) — are tenant-scoped,
+// not store-scoped, so StoreMiddleware never runs on them. A suspended
+// tenant with an existing session (or a tenant with zero stores) would
+// otherwise keep full access to those groups until the session expired.
+// This package closes that gap at the tenant level, independent of any
+// specific store.
 //
 // Deliberately NOT modelled on internal/subscription/readonly: that
 // middleware allowlists billing/tax/recovery routes because a read-only
@@ -50,8 +54,14 @@ type cacheEntry struct {
 
 // Gate caches tenant status in-process to avoid a platform-api round trip
 // on every admin request. The production admin deployment runs a single
-// replica, so this cache is coherent; if it is ever scaled out, each pod
-// simply fetches more often, which stays correct — just less cache-efficient.
+// replica, so this cache is coherent. If it is ever scaled out, this stops
+// being merely "less cache-efficient": Invalidate (called from the platform
+// console's suspend/unsuspend handler) reaches only the pod that served
+// that request, so every OTHER pod keeps serving its cached status until
+// its own ttl expires — a suspend can be bypassed, and an unsuspend can
+// stay invisible, on any pod that didn't see the invalidation, for up to
+// ttl. Correctness currently depends on replicas: 1; multi-replica would
+// need a shared cache (e.g. Redis) or a pub/sub invalidation fan-out.
 type Gate struct {
 	lookup Lookup
 	logger *slog.Logger
@@ -84,14 +94,33 @@ func New(l Lookup, logger *slog.Logger, ttl time.Duration) *Gate {
 // already holds a valid session for this exact tenant, so there is nothing
 // to hide about the tenant's existence — only its access is refused.
 //
-// Staleness handling, mirroring StoreMiddleware's asymmetry:
-//   - A cached suspended (non-active) status is authoritative at ANY age —
-//     never re-fetch to give the tenant the benefit of the doubt.
+// Staleness handling, mirroring StoreMiddleware's asymmetry, WITH ONE
+// DELIBERATE DIVERGENCE (see the last bullet):
+//   - A cached suspended (non-active) status is never served AS ACCESS,
+//     regardless of age — but it IS re-fetched once ttl has elapsed (see
+//     the cached/entry.status != statusActive branch below), and an
+//     authoritative "active" answer from that re-fetch lifts it
+//     immediately. This has to be true: it is exactly what lets an
+//     unsuspend take effect without waiting for every session to expire.
+//     What never happens is decaying a suspended verdict into access on a
+//     FAILED refresh — a stale suspended entry whose re-fetch errors stays
+//     refused.
 //   - A cached active status past ttl is refreshed; if the refresh fails,
 //     the stale active status is served (fail open on the merchant's side).
 //   - No cached value at all plus a failed lookup fails OPEN (serves). A
 //     cold cache during a platform-api outage must not lock out every
 //     merchant. This is the gate's one deliberate hole.
+//   - Divergence from StoreMiddleware: StoreMiddleware caps its fail-open
+//     behavior with an absolute StaleCeil (24h) — past that age a stale row
+//     404s even if it was last known active, bounding how long an outage
+//     can paper over a stale answer. This gate has NO such ceiling: a
+//     cached active tenant is served indefinitely across repeated failed
+//     refreshes, for as long as platform-api stays unreachable, no matter
+//     how long that is. This is a deliberate divergence, not an oversight —
+//     it follows the same "must not lock out every merchant" reasoning as
+//     the cold-cache hole above — but it is a genuine gap versus
+//     StoreMiddleware's design and is called out here so it isn't mistaken
+//     for a faithful mirror of it.
 //
 // A nil Gate (no platform-api client configured) and a request with no
 // tenant_id on the context are both treated as "this middleware cannot

--- a/services/marketplace-api/internal/tenantgate/gate.go
+++ b/services/marketplace-api/internal/tenantgate/gate.go
@@ -1,0 +1,178 @@
+// Package tenantgate provides RequireActiveTenant, a Gin middleware that
+// refuses ALL admin traffic for a suspended tenant (#287).
+//
+// StoreMiddleware (internal/stores) already refuses a suspended tenant on
+// /admin/stores/:storeId, but that group is one of four admin route groups.
+// The other three — /admin, /admin/account and the SSO group
+// /admin/tenants/:tenantId — are tenant-scoped, not store-scoped, so
+// StoreMiddleware never runs on them. A suspended tenant with an existing
+// session (or a tenant with zero stores) would otherwise keep full access
+// to those groups until the session expired. This package closes that gap
+// at the tenant level, independent of any specific store.
+//
+// Deliberately NOT modelled on internal/subscription/readonly: that
+// middleware allowlists billing/tax/recovery routes because a read-only
+// subscription is a billing state the merchant must be able to self-serve
+// out of. A tenant suspension is an operator action (abuse, fraud, legal
+// demand) where self-service recovery is precisely what must not be
+// available. This gate allowlists NOTHING, not even GET.
+package tenantgate
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
+)
+
+// statusActive is the only tenantdirectory status that passes the gate.
+const statusActive = "active"
+
+// tenantIDContextKey is where auth.HeaderTrustAuth puts the trusted tenant
+// id on the Gin context.
+const tenantIDContextKey = "tenant_id"
+
+// Lookup is the subset of tenantdirectory.Client the gate needs.
+type Lookup interface {
+	Get(ctx context.Context, id string) (*tenantdirectory.TenantDetail, error)
+}
+
+type cacheEntry struct {
+	status    string
+	fetchedAt time.Time
+}
+
+// Gate caches tenant status in-process to avoid a platform-api round trip
+// on every admin request. The production admin deployment runs a single
+// replica, so this cache is coherent; if it is ever scaled out, each pod
+// simply fetches more often, which stays correct — just less cache-efficient.
+type Gate struct {
+	lookup Lookup
+	logger *slog.Logger
+	ttl    time.Duration
+
+	mu     sync.Mutex
+	cache  map[string]cacheEntry
+	flight singleflight.Group
+}
+
+// New builds a Gate. ttl controls how long a cached ACTIVE status is
+// trusted before a refresh is attempted; a cached suspended (or any other
+// non-active) status is authoritative regardless of age — see
+// RequireActiveTenant.
+func New(l Lookup, logger *slog.Logger, ttl time.Duration) *Gate {
+	return &Gate{
+		lookup: l,
+		logger: logger,
+		ttl:    ttl,
+		cache:  make(map[string]cacheEntry),
+	}
+}
+
+// RequireActiveTenant returns a Gin middleware that refuses every request
+// for a non-active tenant with 403 {"error":"tenant_suspended"}.
+//
+// 403, not 402: 402 is RequireActive's billing meaning (readonly package)
+// and does not apply here. Not 404 either: unlike StoreMiddleware's 404 for
+// a store the caller is no longer entitled to know exists, the caller here
+// already holds a valid session for this exact tenant, so there is nothing
+// to hide about the tenant's existence — only its access is refused.
+//
+// Staleness handling, mirroring StoreMiddleware's asymmetry:
+//   - A cached suspended (non-active) status is authoritative at ANY age —
+//     never re-fetch to give the tenant the benefit of the doubt.
+//   - A cached active status past ttl is refreshed; if the refresh fails,
+//     the stale active status is served (fail open on the merchant's side).
+//   - No cached value at all plus a failed lookup fails OPEN (serves). A
+//     cold cache during a platform-api outage must not lock out every
+//     merchant. This is the gate's one deliberate hole.
+//
+// A nil Gate (no platform-api client configured) and a request with no
+// tenant_id on the context are both treated as "this middleware cannot
+// judge" and pass the request through.
+func (g *Gate) RequireActiveTenant() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if g == nil || g.lookup == nil {
+			c.Next()
+			return
+		}
+
+		raw, ok := c.Get(tenantIDContextKey)
+		if !ok {
+			c.Next()
+			return
+		}
+		tenantID, _ := raw.(string)
+		if tenantID == "" {
+			c.Next()
+			return
+		}
+
+		g.mu.Lock()
+		entry, cached := g.cache[tenantID]
+		g.mu.Unlock()
+
+		if cached && time.Since(entry.fetchedAt) < g.ttl {
+			g.decide(c, entry.status)
+			return
+		}
+
+		result, err, _ := g.flight.Do(tenantID, func() (interface{}, error) {
+			return g.refresh(c.Request.Context(), tenantID)
+		})
+
+		switch {
+		case err == nil:
+			g.decide(c, result.(string))
+		case cached && entry.status != statusActive:
+			// Cached suspended is authoritative at any age: a failed
+			// refresh must not decay it into access.
+			refuse(c)
+		case cached:
+			// Cached active, refresh failed: fail open on the stale value.
+			g.warn("serving stale active tenant status", tenantID, err)
+			c.Next()
+		default:
+			// Cold cache and a failed lookup: fail open rather than lock
+			// out every merchant during a platform-api outage.
+			g.warn("tenant status lookup failed with no cached value; failing open", tenantID, err)
+			c.Next()
+		}
+	}
+}
+
+func (g *Gate) decide(c *gin.Context, status string) {
+	if status != statusActive {
+		refuse(c)
+		return
+	}
+	c.Next()
+}
+
+func (g *Gate) refresh(ctx context.Context, tenantID string) (string, error) {
+	detail, err := g.lookup.Get(ctx, tenantID)
+	if err != nil {
+		return "", err
+	}
+	g.mu.Lock()
+	g.cache[tenantID] = cacheEntry{status: detail.Status, fetchedAt: time.Now()}
+	g.mu.Unlock()
+	return detail.Status, nil
+}
+
+func (g *Gate) warn(msg, tenantID string, err error) {
+	if g.logger == nil {
+		return
+	}
+	g.logger.Warn(msg, "tenant_id", tenantID, "error", err)
+}
+
+func refuse(c *gin.Context) {
+	c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "tenant_suspended"})
+}

--- a/services/marketplace-api/internal/tenantgate/gate.go
+++ b/services/marketplace-api/internal/tenantgate/gate.go
@@ -166,6 +166,19 @@ func (g *Gate) refresh(ctx context.Context, tenantID string) (string, error) {
 	return detail.Status, nil
 }
 
+// Invalidate drops tenantID's cached status, so a suspend or unsuspend
+// action taken through the platform console takes effect on the very next
+// admin request instead of waiting out ttl. Safe on a nil *Gate — matching
+// how the rest of this type degrades when unwired.
+func (g *Gate) Invalidate(tenantID string) {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	delete(g.cache, tenantID)
+	g.mu.Unlock()
+}
+
 func (g *Gate) warn(msg, tenantID string, err error) {
 	if g.logger == nil {
 		return

--- a/services/marketplace-api/internal/tenantgate/gate_test.go
+++ b/services/marketplace-api/internal/tenantgate/gate_test.go
@@ -1,0 +1,163 @@
+package tenantgate_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
+	"github.com/mark8ly/marketplace-api/internal/tenantgate"
+)
+
+const testTenant = "tenant-1"
+
+// stubLookup returns a canned tenant and counts calls so the cache can be
+// asserted. Values are distinct and non-zero so nothing passes on a zero.
+type stubLookup struct {
+	status string
+	err    error
+	calls  int32
+}
+
+func (s *stubLookup) Get(_ context.Context, id string) (*tenantdirectory.TenantDetail, error) {
+	atomic.AddInt32(&s.calls, 1)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &tenantdirectory.TenantDetail{
+		Tenant: tenantdirectory.Tenant{ID: id, Status: s.status},
+	}, nil
+}
+
+func buildGateRouter(t *testing.T, l tenantgate.Lookup, ttl time.Duration, reached *bool) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Set("tenant_id", testTenant) })
+	g := tenantgate.New(l, nil, ttl)
+	r.GET("/admin/account", g.RequireActiveTenant(), func(c *gin.Context) {
+		*reached = true
+		c.String(http.StatusOK, "ok")
+	})
+	return r
+}
+
+func doGet(r *gin.Engine, path string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	return rec
+}
+
+// An active tenant passes through.
+func TestGate_ActiveTenantPasses(t *testing.T) {
+	reached := false
+	rec := doGet(buildGateRouter(t, &stubLookup{status: "active"}, time.Minute, &reached), "/admin/account")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, reached)
+}
+
+// A suspended tenant is refused on a NON-store-scoped route — the whole
+// point of this task, since StoreMiddleware never sees these.
+func TestGate_SuspendedTenantIsRefusedOnNonStoreRoute(t *testing.T) {
+	reached := false
+	rec := doGet(buildGateRouter(t, &stubLookup{status: "suspended"}, time.Minute, &reached), "/admin/account")
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.False(t, reached, "handler must not run for a suspended tenant")
+}
+
+// NOTHING is allowlisted — not even a GET. This is the assertion that
+// catches someone copying readonly.DefaultAllowlist wholesale.
+func TestGate_NoAllowlistNotEvenGET(t *testing.T) {
+	reached := false
+	rec := doGet(buildGateRouter(t, &stubLookup{status: "suspended"}, time.Minute, &reached), "/admin/account")
+	require.Equal(t, http.StatusForbidden, rec.Code, "a GET is NOT exempt for a suspended tenant")
+	require.False(t, reached)
+}
+
+// The cache is used: two requests inside the TTL cause ONE lookup.
+func TestGate_CachesWithinTTL(t *testing.T) {
+	reached := false
+	l := &stubLookup{status: "active"}
+	r := buildGateRouter(t, l, time.Minute, &reached)
+	doGet(r, "/admin/account")
+	doGet(r, "/admin/account")
+	require.Equal(t, int32(1), atomic.LoadInt32(&l.calls), "second request must be served from cache")
+}
+
+// Cached suspended is authoritative at ANY age: even with the TTL expired
+// and the upstream now saying active, the gate keeps refusing until it has
+// successfully re-read. Assert the refusal, not the call count.
+func TestGate_CachedSuspendedIsAuthoritativeWhenLookupFails(t *testing.T) {
+	reached := false
+	l := &stubLookup{status: "suspended"}
+	r := buildGateRouter(t, l, time.Nanosecond, &reached) // instantly stale
+	require.Equal(t, http.StatusForbidden, doGet(r, "/admin/account").Code)
+
+	l.err = tenantdirectory.ErrUnavailable // upstream now unreachable
+	require.Equal(t, http.StatusForbidden, doGet(r, "/admin/account").Code,
+		"a cached suspended status must not decay into access")
+	require.False(t, reached)
+}
+
+// Stale ACTIVE plus a failed refresh still serves — fail-open, so an
+// outage does not lock out every merchant.
+func TestGate_StaleActiveWithFailedRefreshStillServes(t *testing.T) {
+	reached := false
+	l := &stubLookup{status: "active"}
+	r := buildGateRouter(t, l, time.Nanosecond, &reached)
+	require.Equal(t, http.StatusOK, doGet(r, "/admin/account").Code)
+
+	l.err = tenantdirectory.ErrUnavailable
+	require.Equal(t, http.StatusOK, doGet(r, "/admin/account").Code,
+		"stale active must still serve when the refresh fails")
+}
+
+// Cold cache plus a failed lookup fails OPEN. Deliberate: assert it so the
+// behaviour is a decision on the record rather than an accident.
+func TestGate_ColdCacheWithFailedLookupFailsOpen(t *testing.T) {
+	reached := false
+	rec := doGet(buildGateRouter(t,
+		&stubLookup{err: tenantdirectory.ErrUnavailable}, time.Minute, &reached), "/admin/account")
+	require.Equal(t, http.StatusOK, rec.Code,
+		"cold cache + outage must not lock out every merchant")
+	require.True(t, reached)
+}
+
+// No tenant on the context means this middleware cannot judge: pass through
+// and let the auth layer deal with it, rather than 403-ing every request.
+func TestGate_NoTenantOnContextPassesThrough(t *testing.T) {
+	reached := false
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	g := tenantgate.New(&stubLookup{status: "suspended"}, nil, time.Minute)
+	r.GET("/admin/account", g.RequireActiveTenant(), func(c *gin.Context) {
+		reached = true
+		c.String(http.StatusOK, "ok")
+	})
+	rec := doGet(r, "/admin/account")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, reached)
+}
+
+// A nil Gate (no platform-api client wired) must be a no-op, not a panic —
+// matching how other client-backed features degrade when unconfigured.
+func TestGate_NilGateIsNoOp(t *testing.T) {
+	reached := false
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Set("tenant_id", testTenant) })
+	var g *tenantgate.Gate
+	r.GET("/admin/account", g.RequireActiveTenant(), func(c *gin.Context) {
+		reached = true
+		c.String(http.StatusOK, "ok")
+	})
+	rec := doGet(r, "/admin/account")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, reached)
+}

--- a/services/marketplace-api/internal/tenantlifecycle/client.go
+++ b/services/marketplace-api/internal/tenantlifecycle/client.go
@@ -1,0 +1,121 @@
+// Package tenantlifecycle is a marketplace-api client for platform-api's
+// internal tenant suspend/unsuspend endpoints (#287).
+//
+// This is the platform-admin surface's first WRITE client. Every existing
+// client (tenantdirectory, onboardingfunnel, estatecounts) is read-only.
+// The status mapping below is the part that matters: an error must never
+// be conflated with an empty or zero result. A caller that received
+// {StoresAffected: 0, Changed: false} from a failed call would report
+// "nothing to do" for a request that may well have suspended a tenant.
+package tenantlifecycle
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// ErrUnavailable signals platform-api could not be reached, or answered 5xx.
+var ErrUnavailable = errors.New("tenantlifecycle: platform-api unavailable")
+
+// ErrNotFound signals platform-api returned 404 for a tenant id.
+var ErrNotFound = errors.New("tenantlifecycle: tenant not found")
+
+// ErrConflict signals platform-api returned 409 for an invalid status
+// transition (e.g. suspending an archived tenant).
+var ErrConflict = errors.New("tenantlifecycle: invalid status transition")
+
+// maxBody caps what we will read from platform-api.
+const maxBody = 4 << 20
+
+// Result is the outcome of a suspend/unsuspend call.
+type Result struct {
+	TenantID       string `json:"tenant_id"`
+	Status         string `json:"status"`
+	StoresAffected int    `json:"stores_affected"`
+	Changed        bool   `json:"changed"`
+}
+
+// Client calls platform-api's internal tenant lifecycle endpoints.
+type Client struct {
+	baseURL string
+	secret  string
+	http    *http.Client
+}
+
+// NewClient constructs a Client. httpClient may be nil (defaults to a
+// 5-second timeout). The secret is sent as X-Internal-Auth when non-empty.
+func NewClient(baseURL, secret string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 5 * time.Second}
+	}
+	return &Client{baseURL: baseURL, secret: secret, http: httpClient}
+}
+
+// post issues a POST to path and decodes the response body into out.
+//
+// Status mapping: 200 decodes; 404 -> ErrNotFound; 409 -> ErrConflict;
+// everything else, including every 5xx and any transport error,
+// -> ErrUnavailable. A 200 whose body is truncated or unparseable is an
+// error, never a zero result.
+func (c *Client) post(ctx context.Context, path string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("tenantlifecycle: build request: %w", err)
+	}
+	if c.secret != "" {
+		req.Header.Set("X-Internal-Auth", c.secret)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrUnavailable, err)
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		// fall through to decode below
+	case resp.StatusCode == http.StatusNotFound:
+		return ErrNotFound
+	case resp.StatusCode == http.StatusConflict:
+		return ErrConflict
+	default:
+		return fmt.Errorf("%w: upstream %d", ErrUnavailable, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBody))
+	if err != nil {
+		return fmt.Errorf("%w: read body: %v", ErrUnavailable, err)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("tenantlifecycle: decode: %w", err)
+	}
+	return nil
+}
+
+// Suspend calls POST /internal/tenants/:id/suspend.
+func (c *Client) Suspend(ctx context.Context, tenantID string) (*Result, error) {
+	return c.lifecycle(ctx, tenantID, "suspend")
+}
+
+// Unsuspend calls POST /internal/tenants/:id/unsuspend.
+func (c *Client) Unsuspend(ctx context.Context, tenantID string) (*Result, error) {
+	return c.lifecycle(ctx, tenantID, "unsuspend")
+}
+
+func (c *Client) lifecycle(ctx context.Context, tenantID, action string) (*Result, error) {
+	var envelope struct {
+		Data Result `json:"data"`
+	}
+	path := "/internal/tenants/" + url.PathEscape(tenantID) + "/" + action
+	if err := c.post(ctx, path, &envelope); err != nil {
+		return nil, err
+	}
+	return &envelope.Data, nil
+}

--- a/services/marketplace-api/internal/tenantlifecycle/client_test.go
+++ b/services/marketplace-api/internal/tenantlifecycle/client_test.go
@@ -1,0 +1,66 @@
+package tenantlifecycle_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/tenantlifecycle"
+)
+
+func TestSuspend_MapsStatusCodes(t *testing.T) {
+	cases := []struct {
+		name    string
+		code    int
+		body    string
+		wantErr error
+	}{
+		{"ok", 200, `{"data":{"tenant_id":"t1","status":"suspended","stores_affected":2,"changed":true}}`, nil},
+		{"not found", 404, `{"error":"tenant_not_found"}`, tenantlifecycle.ErrNotFound},
+		{"conflict", 409, `{"error":"invalid_status_transition"}`, tenantlifecycle.ErrConflict},
+		{"server error", 500, `{"error":"internal_error"}`, tenantlifecycle.ErrUnavailable},
+		{"bad gateway", 502, ``, tenantlifecycle.ErrUnavailable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodPost, r.Method)
+				require.Equal(t, "/internal/tenants/t1/suspend", r.URL.Path)
+				require.NotEmpty(t, r.Header.Get("X-Internal-Auth"), "internal auth header must be sent")
+				w.WriteHeader(tc.code)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			got, err := tenantlifecycle.NewClient(srv.URL, "secret", srv.Client()).
+				Suspend(context.Background(), "t1")
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				require.Nil(t, got, "an error must never come back with a usable result")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, 2, got.StoresAffected)
+			require.True(t, got.Changed)
+			require.Equal(t, "suspended", got.Status)
+		})
+	}
+}
+
+// A 200 whose body is truncated or unparseable is an error, not a zero
+// result. Conflating the two is how a caller ends up reporting "0 stores
+// affected, changed: false" for a request that actually did something.
+func TestSuspend_UnparseableBodyIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"data":{`))
+	}))
+	defer srv.Close()
+	got, err := tenantlifecycle.NewClient(srv.URL, "secret", srv.Client()).
+		Suspend(context.Background(), "t1")
+	require.Error(t, err)
+	require.Nil(t, got)
+}

--- a/services/platform-api/cmd/server/main.go
+++ b/services/platform-api/cmd/server/main.go
@@ -352,6 +352,7 @@ func main() {
 	// requirement.
 	strictInternal := r.Group("/internal", middleware.RequireInternalAuthStrict(cfg.InternalAuthSecret))
 	tenantHandler.RegisterDirectory(strictInternal)
+	tenantHandler.RegisterLifecycle(strictInternal)
 	onboardingHandler.RegisterAnalytics(strictInternal)
 	estate.NewHandler(estate.NewRepository(conn)).Register(strictInternal)
 

--- a/services/platform-api/internal/store/models.go
+++ b/services/platform-api/internal/store/models.go
@@ -34,8 +34,12 @@ type Store struct {
 	LogoURL         *string         `gorm:"column:logo_url;type:text"                                json:"logo_url,omitempty"`
 	StorefrontTheme json.RawMessage `gorm:"column:storefront_theme;type:jsonb;not null;default:'{}'::jsonb" json:"storefront_theme"`
 	Status          string          `gorm:"column:status;type:varchar(20);not null;default:'active'" json:"status"`
-	CreatedAt       time.Time       `gorm:"column:created_at;not null;default:now()"                 json:"created_at"`
-	UpdatedAt       time.Time       `gorm:"column:updated_at;not null;default:now()"                 json:"updated_at"`
+	// SuspendedByTenant is true only for stores a TENANT-level suspension
+	// changed. Unsuspend restores exactly these rows, so a store suspended
+	// individually before the tenant was suspended stays suspended (#287).
+	SuspendedByTenant bool      `gorm:"column:suspended_by_tenant;not null;default:false" json:"suspended_by_tenant"`
+	CreatedAt         time.Time `gorm:"column:created_at;not null;default:now()"                 json:"created_at"`
+	UpdatedAt         time.Time `gorm:"column:updated_at;not null;default:now()"                 json:"updated_at"`
 }
 
 // TableName overrides GORM's default pluralization.

--- a/services/platform-api/internal/tenant/handler.go
+++ b/services/platform-api/internal/tenant/handler.go
@@ -1,6 +1,7 @@
 package tenant
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"strings"
@@ -271,6 +272,51 @@ func (h *Handler) getTenantByOwnerEmail(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"data": t})
+}
+
+// RegisterLifecycle mounts the operator-facing tenant suspend/unsuspend
+// routes (#287) on the supplied group. Mounted on strictInternal only:
+// these act on the whole estate and are not scoped by anything the caller
+// had to know, so an unconfigured deploy must answer 503 rather than serve
+// them. Deliberately separate from the existing PATCH in Register — that
+// path runs a merchant-authorized fga.Check a platform operator has no
+// relation in, and carries no status field.
+func (h *Handler) RegisterLifecycle(g *gin.RouterGroup) {
+	t := g.Group("/tenants")
+	{
+		t.POST("/:id/suspend", h.suspendTenant)
+		t.POST("/:id/unsuspend", h.unsuspendTenant)
+	}
+}
+
+// suspendTenant serves POST /internal/tenants/:id/suspend (#287).
+func (h *Handler) suspendTenant(c *gin.Context) {
+	h.lifecycle(c, h.svc.Suspend)
+}
+
+// unsuspendTenant serves POST /internal/tenants/:id/unsuspend (#287).
+func (h *Handler) unsuspendTenant(c *gin.Context) {
+	h.lifecycle(c, h.svc.Unsuspend)
+}
+
+// lifecycle is shared by suspendTenant and unsuspendTenant: identical
+// response shaping and error mapping, one implementation so the two
+// routes cannot drift. A no-op (Changed=false) is still a 200 — #287's
+// acceptance requires that suspending an already-suspended tenant
+// returns current state, not an error.
+func (h *Handler) lifecycle(c *gin.Context, op func(context.Context, string) (*SuspendResult, error)) {
+	id := c.Param("id")
+	res, err := op(c.Request.Context(), id)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{
+		"tenant_id":       id,
+		"status":          res.Status,
+		"stores_affected": res.StoresAffected,
+		"changed":         res.Changed,
+	}})
 }
 
 func (h *Handler) listDirectory(c *gin.Context) {

--- a/services/platform-api/internal/tenant/repository.go
+++ b/services/platform-api/internal/tenant/repository.go
@@ -66,6 +66,33 @@ type Repository interface {
 	// tenants_owner_email_unique index (migration 0014) — which is also why
 	// this returns at most one row rather than a slice.
 	GetByOwnerEmail(ctx context.Context, email string) (*Tenant, error)
+	// Suspend transitions a tenant from active to suspended and cascades
+	// the suspension to its currently-ACTIVE stores, marking each one
+	// suspended_by_tenant=true so Unsuspend can reverse ONLY what this
+	// cascade did (see Unsuspend). A store that is already suspended
+	// (suspended individually, outside this cascade) is left untouched —
+	// it is not "affected" and its suspended_by_tenant flag is not set.
+	// A no-op (tenant already suspended) returns Changed=false. Returns
+	// apperrors.NotFound if the tenant does not exist, or
+	// apperrors.Conflict if the tenant is in a status this cannot
+	// transition from (e.g. archived).
+	Suspend(ctx context.Context, tenantID string) (*SuspendResult, error)
+	// Unsuspend transitions a tenant from suspended back to active and
+	// restores ONLY the stores this package's Suspend cascade suspended
+	// (suspended_by_tenant=true), clearing the flag on each. A store
+	// suspended individually BEFORE (or during) the tenant suspension
+	// stays suspended — reversibility is scoped to what the cascade
+	// changed, not to every suspended store under the tenant. A no-op
+	// (tenant already active) returns Changed=false. Returns
+	// apperrors.NotFound if the tenant does not exist.
+	Unsuspend(ctx context.Context, tenantID string) (*SuspendResult, error)
+}
+
+// SuspendResult reports what a Suspend/Unsuspend call actually changed.
+type SuspendResult struct {
+	Status         string // the tenant's status AFTER the call
+	StoresAffected int    // number of store rows the cascade touched
+	Changed        bool   // false when the tenant was already in the target state
 }
 
 // gormRepository is the GORM-backed implementation.
@@ -200,6 +227,92 @@ func (r *gormRepository) SlugExists(ctx context.Context, slug string) (bool, err
 		return false, fmt.Errorf("tenant: slug exists %q: %w", slug, err)
 	}
 	return count > 0, nil
+}
+
+func (r *gormRepository) Suspend(ctx context.Context, tenantID string) (*SuspendResult, error) {
+	out := &SuspendResult{}
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var t Tenant
+		if err := tx.Raw(
+			`SELECT * FROM tenants WHERE id = ? FOR UPDATE`, tenantID).Scan(&t).Error; err != nil {
+			return fmt.Errorf("tenant: suspend: lock tenant %q: %w", tenantID, err)
+		}
+		if t.ID == "" {
+			return apperrors.NotFound("tenant_not_found", fmt.Sprintf("tenant %q does not exist", tenantID))
+		}
+		out.Status = t.Status
+		if t.Status == StatusSuspended {
+			return nil // already suspended: Changed stays false, StoresAffected 0
+		}
+		if t.Status != StatusActive {
+			// archived, or anything added later: refuse rather than guess.
+			return apperrors.Conflict("tenant_suspend_conflict",
+				fmt.Sprintf("tenant %q has status %q and cannot be suspended", tenantID, t.Status))
+		}
+
+		// Cascade to currently-ACTIVE stores only, flagging exactly what we
+		// changed so Unsuspend can undo precisely this and nothing else.
+		res := tx.Exec(`
+			UPDATE stores SET status = ?, suspended_by_tenant = true
+			WHERE tenant_id = ? AND status = ?`, StatusSuspended, tenantID, StatusActive)
+		if res.Error != nil {
+			return fmt.Errorf("tenant: suspend: cascade stores for %q: %w", tenantID, res.Error)
+		}
+		out.StoresAffected = int(res.RowsAffected)
+
+		if err := tx.Exec(`UPDATE tenants SET status = ? WHERE id = ?`,
+			StatusSuspended, tenantID).Error; err != nil {
+			return fmt.Errorf("tenant: suspend: update tenant %q: %w", tenantID, err)
+		}
+		out.Status = StatusSuspended
+		out.Changed = true
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *gormRepository) Unsuspend(ctx context.Context, tenantID string) (*SuspendResult, error) {
+	out := &SuspendResult{}
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var t Tenant
+		if err := tx.Raw(
+			`SELECT * FROM tenants WHERE id = ? FOR UPDATE`, tenantID).Scan(&t).Error; err != nil {
+			return fmt.Errorf("tenant: unsuspend: lock tenant %q: %w", tenantID, err)
+		}
+		if t.ID == "" {
+			return apperrors.NotFound("tenant_not_found", fmt.Sprintf("tenant %q does not exist", tenantID))
+		}
+		out.Status = t.Status
+		if t.Status != StatusSuspended {
+			return nil // not suspended: no-op, Changed stays false
+		}
+
+		// Restore ONLY the stores THIS cascade suspended, then clear the
+		// flag. A store suspended individually (suspended_by_tenant=false)
+		// must stay suspended — that is the whole point of the column.
+		res := tx.Exec(`
+			UPDATE stores SET status = ?, suspended_by_tenant = false
+			WHERE tenant_id = ? AND suspended_by_tenant`, StatusActive, tenantID)
+		if res.Error != nil {
+			return fmt.Errorf("tenant: unsuspend: restore stores for %q: %w", tenantID, res.Error)
+		}
+		out.StoresAffected = int(res.RowsAffected)
+
+		if err := tx.Exec(`UPDATE tenants SET status = ? WHERE id = ?`,
+			StatusActive, tenantID).Error; err != nil {
+			return fmt.Errorf("tenant: unsuspend: update tenant %q: %w", tenantID, err)
+		}
+		out.Status = StatusActive
+		out.Changed = true
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // isUniqueViolation returns true for Postgres unique constraint violations.

--- a/services/platform-api/internal/tenant/service.go
+++ b/services/platform-api/internal/tenant/service.go
@@ -196,5 +196,17 @@ func (s *Service) GetByOwnerEmail(ctx context.Context, email string) (*Tenant, e
 	return s.repo.GetByOwnerEmail(ctx, email)
 }
 
+// Suspend transitions a tenant to suspended, cascading to its active
+// stores. See Repository.Suspend for the full contract (#287).
+func (s *Service) Suspend(ctx context.Context, id string) (*SuspendResult, error) {
+	return s.repo.Suspend(ctx, id)
+}
+
+// Unsuspend transitions a tenant back to active, restoring only the
+// stores its Suspend cascade suspended. See Repository.Unsuspend (#287).
+func (s *Service) Unsuspend(ctx context.Context, id string) (*SuspendResult, error) {
+	return s.repo.Unsuspend(ctx, id)
+}
+
 // Phase Q: GetBySlug, IsSlugAvailable, validateSlug and slugPattern
 // moved to the store package — slug is a store-level identifier now.

--- a/services/platform-api/internal/tenant/service_test.go
+++ b/services/platform-api/internal/tenant/service_test.go
@@ -144,6 +144,18 @@ func (f *fakeRepo) UpdateEditable(ctx context.Context, id string, patch map[stri
 	return t, nil
 }
 
+// Suspend/Unsuspend are exercised against a real DB in
+// suspend_integration_test.go (the cascade needs real transactions and the
+// stores table); these stubs exist only to satisfy the Repository interface
+// for the unit tests in this file.
+func (f *fakeRepo) Suspend(ctx context.Context, tenantID string) (*SuspendResult, error) {
+	return nil, apperrors.Internal("not_implemented", "fakeRepo.Suspend is not implemented")
+}
+
+func (f *fakeRepo) Unsuspend(ctx context.Context, tenantID string) (*SuspendResult, error) {
+	return nil, apperrors.Internal("not_implemented", "fakeRepo.Unsuspend is not implemented")
+}
+
 // Phase Q: slug-related tests (IsSlugAvailable, SlugExists) moved
 // to the store package along with the slug itself. See
 // internal/store for equivalent coverage.

--- a/services/platform-api/internal/tenant/suspend_handler_test.go
+++ b/services/platform-api/internal/tenant/suspend_handler_test.go
@@ -1,0 +1,131 @@
+package tenant
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	apperrors "github.com/mark8ly/platform-api/pkg/errors"
+)
+
+const testTenantID = "11111111-1111-1111-1111-111111111111"
+
+// stubLifecycleRepo returns canned results for Suspend/Unsuspend.
+type stubLifecycleRepo struct {
+	Repository
+	suspend      *SuspendResult
+	suspendErr   error
+	unsuspend    *SuspendResult
+	unsuspendErr error
+}
+
+func (s *stubLifecycleRepo) Suspend(_ context.Context, _ string) (*SuspendResult, error) {
+	return s.suspend, s.suspendErr
+}
+
+func (s *stubLifecycleRepo) Unsuspend(_ context.Context, _ string) (*SuspendResult, error) {
+	return s.unsuspend, s.unsuspendErr
+}
+
+func newTestHandler(repo Repository) *Handler {
+	return NewHandler(NewService(repo, nil), nil)
+}
+
+func doPost(t *testing.T, h *Handler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h.RegisterLifecycle(r.Group(""))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, path, nil))
+	return rec
+}
+
+type lifecycleBody struct {
+	Data struct {
+		TenantID       string `json:"tenant_id"`
+		Status         string `json:"status"`
+		StoresAffected int    `json:"stores_affected"`
+		Changed        bool   `json:"changed"`
+	} `json:"data"`
+}
+
+func TestSuspendHandler_ReturnsChangedAndCount(t *testing.T) {
+	h := newTestHandler(&stubLifecycleRepo{suspend: &SuspendResult{
+		Status: StatusSuspended, StoresAffected: 2, Changed: true,
+	}})
+	rec := doPost(t, h, "/tenants/"+testTenantID+"/suspend")
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body lifecycleBody
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, testTenantID, body.Data.TenantID)
+	require.Equal(t, "suspended", body.Data.Status)
+	require.Equal(t, 2, body.Data.StoresAffected)
+	require.True(t, body.Data.Changed)
+}
+
+// A no-op must be 200 with changed:false — NOT an error. #287's acceptance
+// says suspending an already-suspended tenant returns current state.
+func TestSuspendHandler_AlreadySuspendedIsOKNotError(t *testing.T) {
+	h := newTestHandler(&stubLifecycleRepo{suspend: &SuspendResult{
+		Status: StatusSuspended, StoresAffected: 0, Changed: false,
+	}})
+	rec := doPost(t, h, "/tenants/"+testTenantID+"/suspend")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"changed":false`)
+}
+
+func TestSuspendHandler_UnknownTenantIs404(t *testing.T) {
+	h := newTestHandler(&stubLifecycleRepo{
+		suspendErr: apperrors.NotFound("tenant_not_found", "no such tenant"),
+	})
+	rec := doPost(t, h, "/tenants/"+testTenantID+"/suspend")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestSuspendHandler_ArchivedIs409(t *testing.T) {
+	h := newTestHandler(&stubLifecycleRepo{
+		suspendErr: apperrors.Conflict("tenant_suspend_conflict", "tenant is archived"),
+	})
+	rec := doPost(t, h, "/tenants/"+testTenantID+"/suspend")
+	require.Equal(t, http.StatusConflict, rec.Code)
+}
+
+func TestUnsuspendHandler_ReturnsChangedAndCount(t *testing.T) {
+	h := newTestHandler(&stubLifecycleRepo{unsuspend: &SuspendResult{
+		Status: StatusActive, StoresAffected: 3, Changed: true,
+	}})
+	rec := doPost(t, h, "/tenants/"+testTenantID+"/unsuspend")
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body lifecycleBody
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, testTenantID, body.Data.TenantID)
+	require.Equal(t, "active", body.Data.Status)
+	require.Equal(t, 3, body.Data.StoresAffected)
+	require.True(t, body.Data.Changed)
+}
+
+// A no-op must be 200 with changed:false — NOT an error.
+func TestUnsuspendHandler_AlreadyActiveIsOKNotError(t *testing.T) {
+	h := newTestHandler(&stubLifecycleRepo{unsuspend: &SuspendResult{
+		Status: StatusActive, StoresAffected: 0, Changed: false,
+	}})
+	rec := doPost(t, h, "/tenants/"+testTenantID+"/unsuspend")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"changed":false`)
+}
+
+func TestUnsuspendHandler_UnknownTenantIs404(t *testing.T) {
+	h := newTestHandler(&stubLifecycleRepo{
+		unsuspendErr: apperrors.NotFound("tenant_not_found", "no such tenant"),
+	})
+	rec := doPost(t, h, "/tenants/"+testTenantID+"/unsuspend")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/services/platform-api/internal/tenant/suspend_integration_test.go
+++ b/services/platform-api/internal/tenant/suspend_integration_test.go
@@ -1,0 +1,110 @@
+//go:build integration
+
+package tenant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/platform-api/pkg/testdb"
+)
+
+// seedTenant inserts a tenant row with the given status and returns its id.
+func seedTenant(t *testing.T, db *gorm.DB, status string) string {
+	t.Helper()
+	id := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO tenants (id, name, owner_user_id, owner_email, status)
+		 VALUES (?, ?, ?, ?, ?)`,
+		id, "Suspend Co "+id[:8], "uid-"+id[:8], id[:8]+"@example.com", status,
+	).Error)
+	return id
+}
+
+// seedStore inserts a store row under tenantID with the given status. Uses
+// GB/GBP/Europe/London — the reference rows actually present in
+// platform-api's seed (IE/Europe/Dublin are NOT seeded and would fail the FK).
+func seedStore(t *testing.T, db *gorm.DB, tenantID, status string) string {
+	t.Helper()
+	id := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, tenantID, "store-"+id[:8], "Suspend Store", "GB", "GBP", "Europe/London", status,
+	).Error)
+	return id
+}
+
+func storeStatus(t *testing.T, db *gorm.DB, storeID string) string {
+	t.Helper()
+	var status string
+	require.NoError(t, db.Raw(`SELECT status FROM stores WHERE id = ?`, storeID).Scan(&status).Error)
+	return status
+}
+
+func suspendedByTenant(t *testing.T, db *gorm.DB, storeID string) bool {
+	t.Helper()
+	var flag bool
+	require.NoError(t, db.Raw(`SELECT suspended_by_tenant FROM stores WHERE id = ?`, storeID).Scan(&flag).Error)
+	return flag
+}
+
+// TestSuspendThenUnsuspendPreservesIndividuallySuspendedStore is the whole
+// reason suspended_by_tenant exists. A store suspended on its own, before
+// the tenant was suspended, must still be suspended after the tenant is
+// unsuspended. A cascade that just sets everything back to active fails
+// exactly here and nowhere else.
+func TestSuspendThenUnsuspendPreservesIndividuallySuspendedStore(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	tenantID := seedTenant(t, db, StatusActive)
+	activeStore := seedStore(t, db, tenantID, "active")
+	alreadySuspended := seedStore(t, db, tenantID, "suspended")
+
+	// Suspend the tenant.
+	res, err := repo.Suspend(ctx, tenantID)
+	require.NoError(t, err)
+	require.True(t, res.Changed)
+	require.Equal(t, StatusSuspended, res.Status)
+	require.Equal(t, 1, res.StoresAffected, "only the ACTIVE store should be affected")
+
+	// Unsuspend it.
+	res, err = repo.Unsuspend(ctx, tenantID)
+	require.NoError(t, err)
+	require.True(t, res.Changed)
+	require.Equal(t, 1, res.StoresAffected)
+
+	require.Equal(t, "active", storeStatus(t, db, activeStore),
+		"the store the cascade suspended must be restored")
+	require.Equal(t, "suspended", storeStatus(t, db, alreadySuspended),
+		"a store suspended individually BEFORE the tenant suspension must stay suspended")
+	require.False(t, suspendedByTenant(t, db, activeStore), "flag must be cleared after unsuspend")
+}
+
+// A second suspend is a no-op: no extra stores affected, Changed false, and
+// the flag on already-cascaded rows is untouched.
+func TestSuspendIsIdempotent(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	tenantID := seedTenant(t, db, StatusActive)
+	s := seedStore(t, db, tenantID, "active")
+
+	first, err := repo.Suspend(ctx, tenantID)
+	require.NoError(t, err)
+	require.True(t, first.Changed)
+	require.Equal(t, 1, first.StoresAffected)
+
+	second, err := repo.Suspend(ctx, tenantID)
+	require.NoError(t, err)
+	require.False(t, second.Changed, "already suspended: no-op")
+	require.Equal(t, 0, second.StoresAffected)
+	require.True(t, suspendedByTenant(t, db, s), "flag must survive a repeat suspend")
+}

--- a/services/platform-api/migrations.go
+++ b/services/platform-api/migrations.go
@@ -11,4 +11,4 @@ var MigrationsFS embed.FS
 // ExpectedSchemaVersion is the version cmd/server requires on startup.
 // Bump this when you add a new migration. cmd/server refuses to start if the
 // DB is at any other version.
-const ExpectedSchemaVersion uint = 14
+const ExpectedSchemaVersion uint = 15

--- a/services/platform-api/migrations/0015_stores_suspended_by_tenant.down.sql
+++ b/services/platform-api/migrations/0015_stores_suspended_by_tenant.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS stores_suspended_by_tenant_idx;
+ALTER TABLE stores DROP COLUMN IF EXISTS suspended_by_tenant;

--- a/services/platform-api/migrations/0015_stores_suspended_by_tenant.up.sql
+++ b/services/platform-api/migrations/0015_stores_suspended_by_tenant.up.sql
@@ -1,0 +1,11 @@
+-- 0015_stores_suspended_by_tenant.up.sql
+-- Records WHO suspended a store, so unsuspending a tenant does not
+-- reactivate a store that was suspended individually beforehand (#287).
+-- Only rows changed by a tenant-level suspension carry true.
+ALTER TABLE stores
+    ADD COLUMN suspended_by_tenant BOOLEAN NOT NULL DEFAULT false;
+
+-- Partial index: the unsuspend path selects exactly these rows.
+CREATE INDEX stores_suspended_by_tenant_idx
+    ON stores (tenant_id)
+    WHERE suspended_by_tenant;


### PR DESCRIPTION
Closes #287. Part of the platform console integration series (#260). Spans **three codebases**: `services/platform-api`, `services/marketplace-api`, and `apps/admin`.

## Why this is bigger than "two endpoints and some reason codes"

Implemented literally, #287 would have shipped an operator action that **enforces nothing**. Before designing, I checked what tenant status actually does today:

| path | gated on status before this PR? |
|---|---|
| Storefront `{slug}.mark8ly.com` | **Yes** — `platform-api/internal/store/handler.go:150` |
| Merchant admin API | **No** — `StatusSuspended` was declared and never read |
| Merchant admin UI | **No** — the endpoint returned `status`; the middleware ignored it |
| **Tenant status, anywhere** | **No. Entirely inert.** |

`tenant.StatusSuspended` existed; nothing wrote it, and searching all four Go services, their middleware, `auth-bff` and the TS frontends found nothing that read it to deny anything. So `status = 'suspended'` alone would have left the storefront serving, merchants logging in and orders processing while the console displayed "suspended" — the #282 defect class, except in a **write an operator relies on for abuse and legal decisions**.

**So suspension is defined by what it enforces.** Tenant status is the operator's record of decision; store status — already enforced at the storefront, already projected into marketplace-api — is the mechanism.

## What ships

**platform-api** — `POST /internal/tenants/{id}/{suspend,unsuspend}` on the fail-closed `strictInternal` group, performing a reversible cascade in one transaction under a tenant-row lock.

**Reversibility is the part a naive cascade gets wrong.** `stores.suspended_by_tenant` (migration `0015`) records which stores a *tenant-level* suspension changed, so unsuspending never reactivates a store that was suspended individually beforehand. That single property is what `TestSuspendThenUnsuspendPreservesIndividuallySuspendedStore` exists for, and mutating the unsuspend `WHERE` clause to the naive form fails it.

**marketplace-api** — the platform surface's first write endpoints, with a closed set of required reason codes (free text accepted *in addition*, never instead), audit through `EmitOperatorAction`, and a new write client. Enforcement lands in two places: `StoreMiddleware` refuses non-active stores, and a new `tenantgate` middleware refuses **every** admin route for a suspended tenant.

**apps/admin** — the admin UI 404s a non-active store, matching what platform-api already does for the storefront.

## Decisions worth inheriting

**The staleness asymmetry.** A cached `suspended` is authoritative at any age; a stale `active` still serves. The two errors are not symmetric in cost: briefly serving a stale active store is a small correctness cost, serving a suspended one is the failure this endpoint exists to prevent — while failing closed on staleness would lock out every merchant during a platform-api outage.

**The local projection update is asymmetric, and it has to be.** Suspend writes the projection immediately. Unsuspend does **not** — `suspended_by_tenant` exists only in platform-api, so marketplace-api cannot distinguish a cascade-suspended store from an individually-suspended one and would reactivate the wrong one. Unsuspend marks the rows stale instead and lets the next request fetch the truth, taking effect on next refresh rather than instantly. That is the correct trade, and it is stated in the response semantics rather than left implicit.

**The tenant gate allowlists nothing.** It copies `internal/subscription/readonly`'s `RequireActive` shape with one deliberate difference. `RequireActive` exempts every `GET` and the billing/tax recovery routes because a read-only *subscription* is a billing state the merchant must be able to fix themselves. A tenant suspension is an operator action for abuse, fraud or a legal demand, where self-service recovery is precisely what must not exist. There is a test specifically to catch someone copying `DefaultAllowlist` wholesale.

**No emitter, no endpoint.** The write routes mount only when an audit emitter is wired. A write that cannot be attributed should not exist — which is stronger than logging, and matches how every neighbouring route handles a missing dependency.

## Three defects found by review that would otherwise have shipped

1. **Nothing pinned tenant scoping.** Deleting `tenant_id = ?` from `SuspendActiveForTenant` would have suspended **every store in the local projection, estate-wide** — and the entire suite stayed green, because both integration tests seeded a single tenant.
2. **There are five admin route groups, not four.** `RegisterAdminMobile` had no gate, leaving `/mobile/admin/account` and friends reachable for a suspended tenant. I established "four" by reading one file instead of searching — the same mistake as concluding a column is written because one lookup didn't show otherwise.
3. **A stale marker that inverted the design.** Backdating to the epoch put rows *past* `StaleCeil`, so a failed refresh skipped the stale-serve branch and hard-404'd — fail-closed, where the spec says fail-open two sections earlier.

Also corrected: a comment claiming a partial index applied when it could not, five comments asserting properties the code lacked, and two spec claims that were simply wrong (a 403 that is actually a 401; test guidance pointing at the `StaleCeil` boundary, which is exactly where the test would pass for the wrong reason).

## Test plan

- [x] Both services build; `go vet` and **`go vet -tags=integration`** clean in both
- [x] All affected packages pass with `-count=1`; `apps/admin` vitest 758/758
- [x] Integration tests in **both** databases confirmed RUN, not skipped (#317's silent-skip trap)
- [x] Every behavioural rule mutation-proved: removing it fails a named test
- [x] Reversibility, tenant scoping, the staleness asymmetry in both directions, audit-only-on-change, and the empty allowlist each have a mutation that kills them
- [ ] **Post-deploy: data-independent checks only.** Verify the routes are mounted and refuse unsigned requests, and that all four instrumented services are healthy. **Do NOT suspend a real merchant tenant to test enforcement** — there are 4 tenants in production and they are all real. Proving enforcement end to end needs a scratch tenant, which is a separate decision.

## Known gaps, stated rather than buried

- **Cloudflare edge cache is not purged** — a suspended storefront may serve from the edge until its cached response expires. Enforcement is at origin.
- **Existing session cookies are not revoked.** They are refused on every admin route, so revocation would change nothing observable — but a suspended tenant's user can still complete a fresh login and receive a cookie that is then refused everywhere. Cosmetic; the login screen just won't explain why.
- **Cold cache + platform-api outage fails open** in the tenant gate. Deliberate: an outage must not lock out every merchant.
- **Capability values are not validated** — only presence. The console asserts them; picking a name here could silently mismatch it.
- `archived` tenants are untouched; this covers the active ↔ suspended transition only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
