### PR TITLE
docs: #332 delivered; traps 10 and 11; the migrate initContainer asymmetry

### DIFF
--- a/docs/superpowers/2026-08-23-platform-integration-handoff.md
+++ b/docs/superpowers/2026-08-23-platform-integration-handoff.md
@@ -19,7 +19,8 @@ issue: **#260**. Each endpoint is its own issue.
 #282 (`/admin/kpis`), #283 (`/admin/onboarding/funnel` + `/sessions`), #284
 (`/admin/billing/subscriptions`), #285 (`/admin/billing/trials`), #289
 (`/admin/health`), **#287** (`/admin/tenants/{id}/suspend` + `/unsuspend`, #340),
-**#329** (`/admin/tickets`, #346), and **#281 part (b) only** — the CSM migration
+**#329** (`/admin/tickets`, #346), **#332** (`/admin/notifications`, #351), and
+**#281 part (b) only** — the CSM migration
 fast-path review route, mounted and audited (#338); #281 stays OPEN for part (a).
 
 **The map changed on 2026-08-24 — this doc's "everything remaining is a write" is
@@ -30,7 +31,7 @@ no longer true.** Five issues joined the milestone: #329 (`/admin/tickets`), #33
 **Effort ordering, re-derived 2026-08-24 (session 3 close)** — reads-before-writes no
 longer sorts this queue:
 
-**#332 → #333 → #286 → #288 (purge, last) → #319.**
+**#332 → #333 → #286 → #288 (purge, last) → #319.** — **#332 is now DELIVERED; start at #333.**
 
 #287 and #329 are now DELIVERED. **#333 is blocked on a decision, not on work:** its
 acceptance requires gating on the operator holding the `rotate-credentials` **capability**,
@@ -280,6 +281,39 @@ rows.
    changes arrive as **image tags**. A check that cannot observe its subject is
    indistinguishable from a subject that is not moving.
 
+10. **Running the search is not the same as reading it.** Trap 9 says a negative needs a
+   search rather than a lookup. #332 obeyed that and still shipped a false negative,
+   because the disconfirming evidence **was in the grep output and was read past**.
+
+   The claim was "no sent-mail log exists anywhere in the estate", written after grepping
+   all four services. The output contained
+   `migrations/000086_shipments_dispatched_email_sent_at.up.sql` — a per-email record,
+   named in the filename. A second record, `campaign_recipients`, was *analysed in detail
+   in the same document* that declared nothing existed. Neither is a delivery outcome,
+   which is the true and narrower claim; but "nothing exists" reached a spec, two Go doc
+   comments, and two issue bodies before the final whole-branch review caught it.
+
+   The corollary that costs the least to apply: **a negative you are about to write down
+   should name what you found that was closest to disconfirming it.** "No delivery-outcome
+   record exists; the two partial handoff records are X and Y" is checkable. "No record
+   exists" is not, and a reader who trusts it stops looking.
+
+   Same round, same shape, second instance: `notifications.recipient_user_id` was
+   documented as a GIP UID by migration `000091` and `models.go:38`. It holds
+   `customers.id`. The spec repeated the comment instead of reading the writer
+   (`storefront/webhooks.go:713` sets `row.CustomerID.String()`) and the reader
+   (`customer_notifications.go:58-73` resolves a `*customer.CustomerProfile`). Filed as
+   #350. **A pre-existing comment is not evidence — it is a claim of the same kind you are
+   being warned about, written by someone with the same incentives.**
+
+11. **`CREATE INDEX` without `IF NOT EXISTS` can crashloop the estate.** Caught in review on
+   #332. `AssertVersion` requires exact equality between `ExpectedSchemaVersion` and the
+   applied migration version. If an operator pre-creates an index by hand — or
+   `CONCURRENTLY`, to dodge the `ACCESS EXCLUSIVE` window, which a spec that tells them to
+   "check the table size first" actively invites — a bare `CREATE INDEX` errors,
+   golang-migrate marks the version dirty, and every pod refuses to start. Migration
+   `000101` already guards; copy that, not the bare form.
+
 ## Environment
 
 - **Use the LAN IP, not `localhost`** — a native Postgres squats on 127.0.0.1:
@@ -288,6 +322,14 @@ rows.
   The committed Makefile says `localhost`, correct everywhere else — do not change it.
 - `make dev` is broken (migrate containers fail with `exec: "up": executable file not found`).
   Apply migrations with `cd services/<svc> && DATABASE_URL=... go run ./cmd/migrate up`.
+- **Migrations apply via an initContainer, on ONE deployment.**
+  `mark8ly-marketplace-api-admin` has an init container named `migrate`;
+  `mark8ly-marketplace-api-storefront` does **not**, and both run the same image with the
+  same startup `AssertVersion` check. So on any migration rollout the two deployments are
+  briefly disagreeing with the database in opposite directions, and a storefront pod that
+  restarts in that window crashloops until its own rollout lands. Self-healing, but it
+  looks exactly like a failure if you are not expecting it. Verified on #332's rollout:
+  both reached `main-<sha7>` with 0 restarts.
 - **Deployment is Kargo-gated**, not direct ArgoCD: CI → ghcr → Kargo Warehouse →
   Freight → Promotion to the `prod` stage → ArgoCD sync. Expect ~10–20 min, and check
   `kubectl get stages,promotions -n kargo-mark8ly` rather than assuming a stall.

--- a/docs/superpowers/2026-08-23-platform-integration-handoff.md
+++ b/docs/superpowers/2026-08-23-platform-integration-handoff.md
@@ -31,15 +31,17 @@ no longer true.** Five issues joined the milestone: #329 (`/admin/tickets`), #33
 **Effort ordering, re-derived 2026-08-24 (session 3 close)** — reads-before-writes no
 longer sorts this queue:
 
-**#332 → #333 → #286 → #288 (purge, last) → #319.** — **#332 is now DELIVERED; start at #333.**
+**~~#332~~ → #333 → #286 → #288 (purge, last) → #319.** — #332 shipped 2026-08-25. **Start at #333.**
 
-#287 and #329 are now DELIVERED. **#333 is blocked on a decision, not on work:** its
+#287, #329 and #332 are now DELIVERED. **#333 is blocked on a decision, not on work:** its
 acceptance requires gating on the operator holding the `rotate-credentials` **capability**,
 but this surface checks capability **presence only, never the value**
 (`internal/handlers/platformadmin/middleware.go:153`). #287 deliberately did not invent a
 value vocabulary — the console asserts these names and a guess would refuse every real
 request. Settle the console's capability names first, or ship #333 with the gate
-explicitly deferred and say so. **#332 has no blocker and is the right next task.**
+explicitly deferred and say so. That decision is still open, and #333 is the head of the
+queue behind it — so the next task is either settling the capability names or starting
+**#286**.
 
 **#286 is NOT the small one its acceptance criteria suggest.** There is **no stored
 trial-end column anywhere** — searched every migration and every Go site. Trial end is
@@ -57,13 +59,15 @@ to `ids` *before* its two validation checks and then marks all of `ids` publishe
 event with an unparseable payload or missing `store_id` is dropped without its watermark
 being bumped **and recorded as successfully published**. Invisible to any monitor.
 
-**Open in the milestone:** #281 (part (a) only), #286, #288, plus the three remaining new
-reads #329/#331/#332/#333 and the #330 decision, plus the blocked #278/#280/#290, plus
-#319 (OpenBao credentials, a different concern grouped in).
+**Open in the milestone:** #281 (part (a) only), #286, #288, plus the remaining new reads
+#331 (blocked by #336) and #333 (blocked on a decision) and the #330 decision, plus the
+blocked #278/#280/#290, plus #319 (OpenBao credentials, a different concern grouped in).
+Also new: **#348** (email delivery log — scope widened by #332's review) and **#350**
+(`recipient_user_id` documented as the wrong kind of id).
 
-The remaining **writes** are #286, #287, #288 and #281(a) — see trap 3, and trap 2
-before touching #287's routing. They are no longer the only work left: see the four
-new reads above.
+The remaining **writes** are #286, #288 and #281(a) — see trap 3. (#287 shipped; its
+trap-2 routing warning is retained below because it applies to any future
+`/admin/tenants/...` route.)
 
 **Reusable pieces the next endpoint inherits**, beyond the surface itself:
 


### PR DESCRIPTION
Updates the platform-integration working doc after #332 shipped (#351).

**Trap 10 — running the search is not the same as reading it.** Trap 9 already said a negative needs a search rather than a lookup. #332 obeyed that and still published a false negative: the claim "no sent-mail log exists anywhere in the estate" was written *from* a grep whose output contained `000086_shipments_dispatched_email_sent_at.up.sql`, and the same document analysed `campaign_recipients` in detail two paragraphs before declaring nothing existed. It reached a spec, two Go doc comments and two issue bodies before the final review caught it.

The cheap corollary: a negative you are about to write down should name what you found that was *closest* to disconfirming it. "No delivery-outcome record; the two partial handoff records are X and Y" is checkable. "No record exists" is not.

Second instance the same round: `recipient_user_id` documented as a GIP UID by migration `000091` and `models.go:38`, when it holds `customers.id`. The spec trusted the comment instead of reading the writer and the reader, which both say otherwise (#350). A pre-existing comment is a claim of exactly the kind these traps warn about.

**Trap 11 — `CREATE INDEX` without `IF NOT EXISTS` can crashloop the estate.** `AssertVersion` demands exact equality; an operator pre-creating an index (which a spec saying "check the table size first" invites) makes the migration error, the version go dirty, and every pod refuse to start.

**Environment — the migrate initContainer asymmetry.** `marketplace-api-admin` carries the `migrate` initContainer; `marketplace-api-storefront` does not, and both run the same image with the same startup version check. A storefront pod restarting mid-rollout crashloops until its own rollout lands. Self-healing, but indistinguishable from a real failure if unexpected.