### PR TITLE
fix(account): stop the outbox drainer racing the inline tenant purge (#288)

### DIFF
--- a/services/platform-api/cmd/server/account_wiring.go
+++ b/services/platform-api/cmd/server/account_wiring.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -56,8 +57,10 @@ func newAccountService(
 	fga authz.Client,
 	gipAdmin *gipadmin.AdminClient,
 	// enqueue is deliberately an UNNAMED func type: a named type here would
-	// not be assignable to internal/account's named outboxEnqueuer.
-	enqueue func(tx *gorm.DB, kind string, payload any) error,
+	// not be assignable to internal/account's named outboxEnqueuer. The
+	// delay parameter is outbox.EnqueueAfter's — see account.outboxEnqueuer
+	// for why the two tenant.deleted callers want different values.
+	enqueue func(tx *gorm.DB, kind string, payload any, delay time.Duration) error,
 	log *slog.Logger,
 ) *account.Service {
 	var gipCleanup gipAccountDeleter

--- a/services/platform-api/cmd/server/account_wiring_test.go
+++ b/services/platform-api/cmd/server/account_wiring_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -53,7 +54,7 @@ func TestNewAccountService_OperatorPurgeSurvivesAbsentGIPAndFGA(t *testing.T) {
 	}}
 
 	enqueued := 0
-	enqueue := func(*gorm.DB, string, any) error { enqueued++; return nil }
+	enqueue := func(*gorm.DB, string, any, time.Duration) error { enqueued++; return nil }
 
 	// nil conn, nil fga, nil gipAdmin — precisely the unconfigured
 	// deployment the startup warning in main.go describes.

--- a/services/platform-api/cmd/server/main.go
+++ b/services/platform-api/cmd/server/main.go
@@ -303,7 +303,7 @@ func main() {
 	// a non-nil interface holding a nil pointer, which would defeat
 	// cleanupAfterTeardown's nil guard and panic AFTER the teardown
 	// transaction commits. See newAccountService.
-	accountSvc := newAccountService(conn, tenantRepo, fga, gipAdmin, outbox.Enqueue, log)
+	accountSvc := newAccountService(conn, tenantRepo, fga, gipAdmin, outbox.EnqueueAfter, log)
 	accountHandler := account.NewHandler(accountSvc)
 	merchantAccountRoutes := fga != nil && gipAdmin != nil
 	if !merchantAccountRoutes {

--- a/services/platform-api/internal/account/purge.go
+++ b/services/platform-api/internal/account/purge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -35,6 +36,31 @@ type PurgeResult struct {
 	StoreIDs   []string
 	StoreSlugs []string
 }
+
+// PurgeBackstopDelay defers the first drain attempt of the tenant.deleted
+// event enqueued by PurgeTenant.
+//
+// The operator purge does the marketplace-side purge INLINE, and its whole
+// point is to report what it destroyed. The outbox event exists so the purge
+// still happens if this process dies between the teardown commit and that
+// inline call — a backstop.
+//
+// Undelayed, it is not a backstop but a competitor, and it wins. Measured in
+// production on 2026-08-25: the teardown committed at 14:12:55.405, the
+// drainer completed the whole marketplace purge at 14:12:55.580, and the
+// inline purge did not finish until 14:12:57.211 — so it deleted 0 rows and
+// reported `total_rows: 0` for a purge that destroyed 5. The operator was
+// told nothing was destroyed, and the permanent audit record said the same.
+// That is a direct violation of #288's "audited with ... what was destroyed",
+// and it is non-deterministic: whichever transaction gets the locks first
+// wins.
+//
+// 30s is chosen to be far longer than any plausible inline purge (the plan
+// issues 53 DELETEs in one transaction; the run above took ~1.8s) while
+// still bounding how long a crashed request leaves rows stranded. It costs
+// nothing in the happy path: the inline purge finishes first, so the drained
+// event is a no-op re-run, which Purge is designed for.
+const PurgeBackstopDelay = 30 * time.Second
 
 // PurgeTenant is the operator-initiated tenant teardown behind
 // POST /admin/tenants/{id}/purge (#288). It is IRREVERSIBLE.
@@ -106,10 +132,13 @@ func (s *Service) PurgeTenant(ctx context.Context, tenantID string, suppliedSlug
 		if err := s.repo.DeleteInTx(ctx, tx, tenantID); err != nil {
 			return err
 		}
+		// PurgeBackstopDelay, not 0: this request purges marketplace-api
+		// INLINE and reports what it destroyed. An immediately-drainable
+		// event makes the drainer race that inline purge — see the constant.
 		return s.outbox(tx, TenantDeletedOutboxKind, tenantDeletedPayload{
 			TenantID: tenantID,
 			StoreIDs: idsOf(snap.Stores),
-		})
+		}, PurgeBackstopDelay)
 	}
 
 	if s.db == nil {

--- a/services/platform-api/internal/account/purge_integration_test.go
+++ b/services/platform-api/internal/account/purge_integration_test.go
@@ -35,7 +35,7 @@ func testDB(t *testing.T) *gorm.DB {
 // them configured.
 func realService(t *testing.T, db *gorm.DB) *Service {
 	t.Helper()
-	return NewService(db, tenant.NewRepository(db), nil, nil, outbox.Enqueue, slog.Default())
+	return NewService(db, tenant.NewRepository(db), nil, nil, outbox.EnqueueAfter, slog.Default())
 }
 
 // seedTenantWithStores inserts a tenant with a single store under the

--- a/services/platform-api/internal/account/purge_test.go
+++ b/services/platform-api/internal/account/purge_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
@@ -33,10 +34,14 @@ func (f *fakePurgeTenantRepo) SnapshotForTeardown(_ context.Context, _ *gorm.DB,
 	return f.snap, f.snapErr
 }
 
-type recordingOutbox struct{ kinds []string }
+type recordingOutbox struct {
+	kinds  []string
+	delays []time.Duration
+}
 
-func (r *recordingOutbox) enqueue(_ *gorm.DB, kind string, _ any) error {
+func (r *recordingOutbox) enqueue(_ *gorm.DB, kind string, _ any, delay time.Duration) error {
 	r.kinds = append(r.kinds, kind)
+	r.delays = append(r.delays, delay)
 	return nil
 }
 
@@ -145,4 +150,33 @@ func TestPurgeTenant_UnknownTenantPropagatesNotFound(t *testing.T) {
 	ae, ok := apperrors.As(err)
 	require.True(t, ok, "want an *apperrors.AppError, got %T", err)
 	require.Equal(t, "tenant_not_found", ae.Code)
+}
+
+// The operator purge's tenant.deleted event must be enqueued as a BACKSTOP,
+// not as a competitor to the inline purge this same request performs.
+//
+// Undelayed, the drainer wins: measured in production, it completed the whole
+// marketplace purge 175ms after the teardown committed and 1.6s before the
+// inline purge finished, so the inline purge deleted 0 rows and reported
+// `total_rows: 0` for a purge that destroyed 5. #288 requires the audit row to
+// record "what was destroyed"; 0 is not that.
+//
+// The merchant self-serve path is the OPPOSITE case and is asserted alongside
+// it deliberately — there is no inline purge there, the event IS the purge,
+// and delaying it would stall a real teardown for no reason. A single
+// assertion on either path alone would pass against a service that used one
+// delay everywhere.
+func TestPurgeTenant_EnqueuesTheBackstopDelayed(t *testing.T) {
+	repo := &fakePurgeTenantRepo{snap: snapshotWith("the-bondi-store")}
+	ob := &recordingOutbox{}
+	svc := newTestService(repo, ob.enqueue)
+
+	_, err := svc.PurgeTenant(t.Context(), "t-1", []string{"the-bondi-store"})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{TenantDeletedOutboxKind}, ob.kinds)
+	require.Equal(t, []time.Duration{PurgeBackstopDelay}, ob.delays,
+		"the operator purge purges inline and reports what it destroyed; its outbox event must not race that")
+	require.Greater(t, PurgeBackstopDelay, 5*time.Second,
+		"the delay must comfortably exceed a real inline purge (53 DELETEs; ~1.8s observed in prod)")
 }

--- a/services/platform-api/internal/account/service.go
+++ b/services/platform-api/internal/account/service.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -45,12 +46,20 @@ type gipDeleter interface {
 	DeleteAccount(ctx context.Context, uid string) error
 }
 
-// outboxEnqueuer matches the real outbox.Enqueue function's signature
+// outboxEnqueuer matches the real outbox.EnqueueAfter function's signature
 // (see internal/outbox/outbox.go). It's a func type rather than a
-// method-interface so outbox.Enqueue itself can be passed directly in
+// method-interface so outbox.EnqueueAfter itself can be passed directly in
 // production with no adapter, while tests supply a recording fake's
 // method value.
-type outboxEnqueuer func(tx *gorm.DB, kind string, payload any) error
+//
+// The delay is part of the TYPE, not a detail hidden inside the outbox
+// package, because the two paths that enqueue tenant.deleted want opposite
+// things from it. The merchant self-serve delete has no inline purge — the
+// outbox IS the purge, so it passes 0. The operator purge (#288) does the
+// purge inline and needs the event to be a genuine backstop rather than a
+// competitor, so it passes PurgeBackstopDelay. A caller that has to choose
+// a value is a caller that has to think about which it is.
+type outboxEnqueuer func(tx *gorm.DB, kind string, payload any, delay time.Duration) error
 
 // TenantRepo is the subset of tenant.Repository the service uses.
 // ListStoreIDs is needed before the DB cascade removes the stores out
@@ -150,7 +159,9 @@ func (s *Service) teardownTenantTx(ctx context.Context, tenantID string, storeID
 			return err
 		}
 		payload := tenantDeletedPayload{TenantID: tenantID, StoreIDs: storeIDs}
-		return s.outbox(tx, TenantDeletedOutboxKind, payload)
+		// 0: the merchant path runs NO inline purge, so this event is the
+		// only thing that will ever purge marketplace-api. Drain it at once.
+		return s.outbox(tx, TenantDeletedOutboxKind, payload, 0)
 	}
 	if s.db == nil {
 		// Unit tests construct the service with a nil db and fakes that

--- a/services/platform-api/internal/account/service_test.go
+++ b/services/platform-api/internal/account/service_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"testing"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -74,14 +75,15 @@ func (f *fakeGIP) DeleteAccount(ctx context.Context, uid string) error {
 }
 
 // fakeOutbox is an in-memory double satisfying the outboxEnqueuer func
-// type via its Enqueue method value (fakeOutbox{}.Enqueue matches the
-// func(tx *gorm.DB, kind string, payload any) error shape).
+// type via its Enqueue method value.
 type fakeOutbox struct {
-	kinds []string
+	kinds  []string
+	delays []time.Duration
 }
 
-func (f *fakeOutbox) Enqueue(tx *gorm.DB, kind string, payload any) error {
+func (f *fakeOutbox) Enqueue(tx *gorm.DB, kind string, payload any, delay time.Duration) error {
 	f.kinds = append(f.kinds, kind)
+	f.delays = append(f.delays, delay)
 	return nil
 }
 
@@ -236,5 +238,32 @@ func TestDeleteAccount_Owner_TeardownFailure_FailsCall(t *testing.T) {
 	}
 	if ob.has("tenant.deleted") {
 		t.Error("tenant.deleted should not be enqueued when DB teardown fails")
+	}
+}
+
+// The merchant self-serve teardown runs NO inline purge — the outbox event is
+// the only thing that will ever purge marketplace-api — so it must be
+// drainable immediately. This is the counterweight to
+// TestPurgeTenant_EnqueuesTheBackstopDelayed: together they pin that the
+// delay is a per-path decision, not a constant applied everywhere.
+func TestDeleteAccount_OwnerEnqueuesTenantDeletedWithNoDelay(t *testing.T) {
+	ctx := context.Background()
+	fga := authz.NewFake()
+	if err := fga.WriteOwnership(ctx, "owner-1", "t1"); err != nil {
+		t.Fatalf("seed ownership: %v", err)
+	}
+	repo := &fakeTenantRepo{stores: map[string][]string{"t1": {"s1"}}}
+	ob := &fakeOutbox{}
+
+	svc := NewService(nil, repo, fga, &fakeGIP{}, ob.Enqueue, testLogger())
+	if err := svc.DeleteAccount(ctx, "t1", "owner-1"); err != nil {
+		t.Fatalf("DeleteAccount() error = %v", err)
+	}
+
+	if !ob.has(TenantDeletedOutboxKind) {
+		t.Fatalf("expected %s to be enqueued", TenantDeletedOutboxKind)
+	}
+	if len(ob.delays) != 1 || ob.delays[0] != 0 {
+		t.Errorf("delays = %v, want [0]: the merchant path has no inline purge, so its event must drain at once", ob.delays)
 	}
 }

--- a/services/platform-api/internal/outbox/outbox.go
+++ b/services/platform-api/internal/outbox/outbox.go
@@ -83,15 +83,38 @@ type Handler func(ctx context.Context, payload json.RawMessage) error
 // originating entity). The whole point is atomic visibility: either both
 // the entity and the outbox row commit, or neither does.
 func Enqueue(tx *gorm.DB, kind string, payload any) error {
+	return EnqueueAfter(tx, kind, payload, 0)
+}
+
+// EnqueueAfter is Enqueue with the FIRST attempt deferred by delay. The row
+// is still written inside the caller's transaction — durability is
+// unchanged — only its eligibility is pushed out, because Tick claims
+// pending events on `next_attempt_at <= now()`.
+//
+// This exists for events that BACK UP work the enqueuing request also does
+// inline. Draining such an event immediately does not make the system more
+// durable; it makes the drainer race the request. The operator tenant purge
+// (#288) is the case that forced this: the drainer completed the purge 175ms
+// after the teardown committed, ~1.6s before the request's own purge
+// finished, so the inline purge deleted 0 rows and the operator — and the
+// permanent audit record — were told 0 rows were destroyed for a purge that
+// destroyed 5. See account.PurgeBackstopDelay.
+//
+// A non-positive delay behaves exactly like Enqueue: eligible immediately.
+func EnqueueAfter(tx *gorm.DB, kind string, payload any, delay time.Duration) error {
 	raw, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("outbox: marshal payload: %w", err)
+	}
+	next := time.Now()
+	if delay > 0 {
+		next = next.Add(delay)
 	}
 	evt := Event{
 		Kind:          kind,
 		Payload:       raw,
 		Status:        StatusPending,
-		NextAttemptAt: time.Now(),
+		NextAttemptAt: next,
 	}
 	if err := tx.Create(&evt).Error; err != nil {
 		return fmt.Errorf("outbox: enqueue %q: %w", kind, err)

--- a/services/platform-api/internal/outbox/outbox_integration_test.go
+++ b/services/platform-api/internal/outbox/outbox_integration_test.go
@@ -219,3 +219,63 @@ func TestIntegration_Enqueue_RollsBackWithTransaction(t *testing.T) {
 		t.Errorf("rolled-back tx left %d outbox row(s); should be 0", count)
 	}
 }
+
+// TestIntegration_EnqueueAfter_IsNotDrainedBeforeItsDelay is the property the
+// operator tenant purge (#288) depends on: an event enqueued as a BACKSTOP for
+// work the same request also does inline must not be claimable while that
+// inline work is still running.
+//
+// Both halves are asserted against ONE drainer and ONE event, because the
+// failure this guards against is "the delay is written but Tick ignores it" —
+// and a test that only checked the early Tick would pass against an event that
+// never becomes claimable at all.
+func TestIntegration_EnqueueAfter_IsNotDrainedBeforeItsDelay(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var called atomic.Int32
+	d := NewDrainer(db, log, Config{})
+	d.Register("test.delayed", func(ctx context.Context, p json.RawMessage) error {
+		called.Add(1)
+		return nil
+	})
+
+	if err := EnqueueAfter(db, "test.delayed", map[string]string{"k": "v"}, 30*time.Second); err != nil {
+		t.Fatalf("EnqueueAfter: %v", err)
+	}
+
+	// The row is durable immediately — the delay defers ELIGIBILITY, not the
+	// write. A backstop that isn't committed with the transaction is no
+	// backstop at all.
+	var row Event
+	if err := db.First(&row).Error; err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if row.Status != StatusPending {
+		t.Errorf("Status = %q, want %q", row.Status, StatusPending)
+	}
+	if !row.NextAttemptAt.After(time.Now().Add(25 * time.Second)) {
+		t.Errorf("NextAttemptAt = %v, want ~30s in the future", row.NextAttemptAt)
+	}
+
+	// Half 1: not claimable yet.
+	if err := d.Tick(context.Background()); err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if called.Load() != 0 {
+		t.Fatalf("handler called %d times before the delay elapsed, want 0 — the drainer is racing the inline purge", called.Load())
+	}
+
+	// Half 2: once due, it drains normally. Move the row's due time into the
+	// past rather than sleeping 30s.
+	if err := db.Model(&Event{}).Where("id = ?", row.ID).
+		Update("next_attempt_at", time.Now().Add(-time.Second)).Error; err != nil {
+		t.Fatalf("age the row: %v", err)
+	}
+	if err := d.Tick(context.Background()); err != nil {
+		t.Fatalf("Tick after delay: %v", err)
+	}
+	if called.Load() != 1 {
+		t.Errorf("handler called %d times after the delay elapsed, want 1 — the backstop must still fire", called.Load())
+	}
+}


### PR DESCRIPTION
Follow-up to #362, found by running the purge end to end against production on a throwaway tenant.

## The bug

`PurgeTenant` enqueues `tenant.deleted` inside the teardown transaction as a **backstop** — so the marketplace purge still happens if the process dies before the request's own inline purge runs. Undelayed, that event is not a backstop but a competitor, and it wins.

Measured in production, 2026-08-25:

```
14:12:55.405  outbox tenant.deleted enqueued (teardown committed)
14:12:55.580  outbox COMPLETED   <- drainer purged all 5 rows, 175ms later
14:12:57.211  inline purge finished, audit row written  <- found 0 rows
```

The operator was answered `total_rows: 0` with every table at zero, and **the permanent audit record said the same**, for a purge that destroyed 5 rows. The preview had correctly reported 5 moments earlier.

That directly violates #288's acceptance — *"A successful purge is audited with ... what was destroyed"* — and it is non-deterministic: whichever transaction takes the locks first wins. It is the same class of problem as the audit-row deletion fixed in #362: the record of an irreversible act is wrong.

## The fix

Defer the first drain attempt rather than paper over the report.

- `outbox.EnqueueAfter(tx, kind, payload, delay)` — the row is still written **inside the caller's transaction**, so durability is unchanged; only eligibility moves, because `Tick` claims pending events on `next_attempt_at <= now()`. `Enqueue` delegates with `0`.
- `account.PurgeBackstopDelay = 30s`, used only by the operator purge.
- The merchant self-serve delete keeps `0` — it has **no** inline purge, so its event *is* the purge and must drain at once.

The delay is part of the `outboxEnqueuer` type rather than hidden inside the outbox package, because the two `tenant.deleted` callers want opposite things from it. A caller that has to choose a value is a caller that has to think about which it is.

No migration — `next_attempt_at` already exists and the drainer already honours it.

## Tests

| Test | Property |
|---|---|
| `TestIntegration_EnqueueAfter_IsNotDrainedBeforeItsDelay` | Row is durable immediately, `next_attempt_at` ~30s out, **not** claimable by `Tick`, and **still fires** once due |
| `TestPurgeTenant_EnqueuesTheBackstopDelayed` | Operator path enqueues with `PurgeBackstopDelay` |
| `TestDeleteAccount_OwnerEnqueuesTenantDeletedWithNoDelay` | Merchant path enqueues with `0` |

The last two are deliberate counterweights: either alone would pass against a service that used one delay everywhere.

All three mutation-checked:

- operator path → `0`: `TestPurgeTenant_EnqueuesTheBackstopDelayed` FAILS
- `EnqueueAfter` ignores delay: `handler called 1 times before the delay elapsed, want 0 — the drainer is racing the inline purge`
- merchant path → `PurgeBackstopDelay`: `delays = [30s], want [0]`

## Verification

`go build`, `go vet`, `go vet -tags=integration`, `go test -count=1 ./...` all green from the service root. Integration suite failing-test set is **byte-identical to the pre-change baseline** (4 pre-existing failures in `onboarding`, `outbox`, `pkg/migrate` — my new `outbox` test passes).

## Test plan

- [ ] After deploy, purge a throwaway tenant and confirm the response and audit row report the real row counts
- [ ] Confirm the outbox event drains ~30s later as a clean no-op re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MGRGtY6SWG5ocFKctLoEb