### PR TITLE
feat(platformadmin): per-route write capability lookup, shipped inert (#364)

### DIFF
--- a/services/marketplace-api/internal/handlers/platformadmin/middleware.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/middleware.go
@@ -43,17 +43,61 @@ const maxIdentityLen = 256
 // reason #287 declined to invent capability names.
 //
 // This is a SWITCH, not a marker: RequirePlatformAuth's write branch reads
-// it. Flipping it to true, with RequiredWriteCapability set, turns value
-// enforcement on for every write on this surface with no other edit. It
-// lives here, beside the check it controls, so that reading the
-// enforcement matrix in this file tells you the whole truth about it.
+// it. Flipping it to true, with RequiredWriteCapabilities' values filled
+// in, turns value enforcement on for every write on this surface with no
+// other edit. It lives here, beside the check it controls and beside
+// RequiredWriteCapabilities itself, so that reading the enforcement matrix
+// in this file tells you the whole truth about it.
 const CapabilityValueChecked = false
 
-// RequiredWriteCapability is the capability value a write must present
-// once CapabilityValueChecked is true. Empty while it is false: an empty
-// required value with enforcement ON would refuse every real request,
-// which is the failure mode #333 has to resolve before this can flip.
-const RequiredWriteCapability = ""
+// CapabilityKey builds the lookup key that RequiredWriteCapabilities (and
+// RequirePlatformAuth's write branch, below) use: the write's HTTP method,
+// upper-cased, plus the route TEMPLATE gin matched — exactly what
+// c.FullPath() returns once routing has resolved (populated by the time
+// this middleware runs, per gin's docs), not the literal request path.
+// Keying on the template rather than the literal path is what lets one map
+// entry cover every tenant this route is ever called for.
+//
+// Exported so tests build the SAME key this file computes internally,
+// rather than a hand-written string that could silently drift from it —
+// see routes_capability_coverage_test.go.
+func CapabilityKey(method, routeTemplate string) string {
+	return strings.ToUpper(strings.TrimSpace(method)) + " " + routeTemplate
+}
+
+// RequiredWriteCapabilities is the per-route capability enforcement
+// matrix. It replaces what used to be a single global RequiredWriteCapability
+// string: one value could never express that this surface's four writes
+// are NOT equally privileged (#288's tenant purge needs "the
+// highest-privilege capability the gateway can assert" — a claim a single
+// shared value cannot make against three lesser writes at the same time).
+//
+// Match rule is EXACT STRING EQUALITY against ONE required capability per
+// route — not a set, not a lattice, not a prefix match. Per #275, mark8ly
+// does not own the privilege model: the console asserts the capability for
+// the action it is performing, and this surface's job is only to record it
+// and refuse a mismatch, never to reason about what a capability implies
+// or ranks against another.
+//
+// Every value below is EMPTY, and CapabilityValueChecked (above) is FALSE:
+// this map exists to have the right SHAPE — one declared entry per write
+// route — not the right VALUES. #287 declined to invent capability names
+// and #275 says the vocabulary belongs to the console, so no value here is
+// a guess; #333's entire job is filling these in once that vocabulary is
+// settled, not reshaping this map.
+//
+// Every write route Register (routes.go) can mount MUST have an entry
+// here, even while every value is empty. TestAllWriteRoutesDeclareACapability
+// (routes_capability_coverage_test.go) builds the real router with every
+// write route wired and fails the build — naming the offending route — if
+// one is undeclared, so a route added without a line here is caught here,
+// not as a production 403 the day #333 turns enforcement on.
+var RequiredWriteCapabilities = map[string]string{
+	CapabilityKey(http.MethodPost, "/api/v1/platform/admin/billing/trials/:storeID/extend"): "",
+	CapabilityKey(http.MethodPost, "/api/v1/platform/admin/tenants/:id/suspend"):            "",
+	CapabilityKey(http.MethodPost, "/api/v1/platform/admin/tenants/:id/unsuspend"):          "",
+	CapabilityKey(http.MethodPost, "/api/v1/platform/admin/tenants/:id/purge"):              "",
+}
 
 // AuthConfig configures RequirePlatformAuth.
 type AuthConfig struct {
@@ -68,6 +112,27 @@ type AuthConfig struct {
 	Window time.Duration
 	// Logger receives rejection detail. Optional.
 	Logger *slog.Logger
+
+	// CapabilityChecked overrides CapabilityValueChecked for this
+	// instance of RequirePlatformAuth. Nil — the value every production
+	// caller (Register in routes.go, and cmd/marketplace-api/main.go,
+	// which never sets this field) leaves it at — falls back to
+	// CapabilityValueChecked, the actual production switch, which stays
+	// false. This exists ONLY so middleware_test.go can exercise both
+	// arms of the capability-value gate without editing the production
+	// constant; it is not a runtime knob production wiring is meant to
+	// use. See TestAuthConfigCapabilityCheckedNilDefaultsToProductionOff
+	// for the proof that leaving it unset really does mean "off".
+	CapabilityChecked *bool
+
+	// RequiredCapabilities overrides RequiredWriteCapabilities for this
+	// instance of RequirePlatformAuth. Nil — again, every production
+	// caller's value — falls back to the real RequiredWriteCapabilities
+	// matrix declared above. Tests use this to exercise match, mismatch,
+	// and undeclared-route behaviour with non-empty capability values
+	// without touching the production matrix, whose values #364 requires
+	// stay empty until #333.
+	RequiredCapabilities map[string]string
 }
 
 // RequirePlatformAuth verifies the gateway signature, enforces the replay
@@ -166,7 +231,8 @@ func RequirePlatformAuth(cfg AuthConfig) gin.HandlerFunc {
 		// Normalise case here the same way CanonicalString does (it upper-
 		// cases Method before signing), so the method the HMAC covers is
 		// exactly the method write-enforcement classifies.
-		if isWrite(strings.ToUpper(strings.TrimSpace(c.Request.Method))) {
+		writeMethod := strings.ToUpper(strings.TrimSpace(c.Request.Method))
+		if isWrite(writeMethod) {
 			if in.Operator == "" {
 				abort(c, http.StatusUnauthorized, "operator_required",
 					"write requests must carry an operator identity")
@@ -177,6 +243,7 @@ func RequirePlatformAuth(cfg AuthConfig) gin.HandlerFunc {
 					"write requests must carry a capability")
 				return
 			}
+
 			// Capability PRESENCE is enforced (above). Capability VALUE is
 			// NOT — pending #333. Every write on this surface, including
 			// the irreversible tenant purge (#288), is admitted on ANY
@@ -186,13 +253,49 @@ func RequirePlatformAuth(cfg AuthConfig) gin.HandlerFunc {
 			// That is deliberate, not an oversight: the console's
 			// capability vocabulary is not settled, and hard-coding a
 			// value here would refuse every real request. This block is
-			// the gate, wired and inert: when #333 lands, set
-			// RequiredWriteCapability and flip CapabilityValueChecked, and
-			// enforcement starts here — nothing else needs writing.
-			if CapabilityValueChecked && in.Capability != RequiredWriteCapability {
-				abort(c, http.StatusForbidden, "capability_insufficient",
-					"the presented capability does not authorize this request")
-				return
+			// the gate, wired and inert: when #333 lands, fill in
+			// RequiredWriteCapabilities' values and flip
+			// CapabilityValueChecked, and enforcement starts here —
+			// nothing else needs writing.
+			capabilityChecked := CapabilityValueChecked
+			if cfg.CapabilityChecked != nil {
+				capabilityChecked = *cfg.CapabilityChecked
+			}
+			if capabilityChecked {
+				requirements := RequiredWriteCapabilities
+				if cfg.RequiredCapabilities != nil {
+					requirements = cfg.RequiredCapabilities
+				}
+
+				// c.FullPath() is the matched route TEMPLATE (e.g.
+				// ".../tenants/:id/purge"), not the literal request path —
+				// see CapabilityKey's doc comment. It is populated by gin
+				// before middleware runs.
+				required, declared := requirements[CapabilityKey(writeMethod, c.FullPath())]
+				if !declared {
+					// Distinguishable from "capability_insufficient" below
+					// on purpose: this means the GATEWAY hasn't declared
+					// what this route needs, not that the CALLER presented
+					// the wrong thing. The two point an operator at
+					// different fixes — one at mark8ly's route
+					// declaration, the other at the console's capability
+					// assertion — and conflating them would send whoever
+					// is debugging a production refusal to the wrong
+					// place. Fails CLOSED: an undeclared write route is
+					// refused, never admitted on any capability, so a
+					// forgotten declaration is a refusal in production,
+					// not a silent hole — the same posture this surface
+					// already takes on a missing secret (503
+					// not_configured, above).
+					abort(c, http.StatusForbidden, "capability_route_undeclared",
+						"this route has not declared a required capability")
+					return
+				}
+				if in.Capability != required {
+					abort(c, http.StatusForbidden, "capability_insufficient",
+						"the presented capability does not authorize this request")
+					return
+				}
 			}
 		}
 

--- a/services/marketplace-api/internal/handlers/platformadmin/middleware_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/middleware_test.go
@@ -422,10 +422,15 @@ func withCapability(v string) reqOpt {
 //   - with it off, an arbitrary capability string admits a write.
 //
 // MUTATION: flip CapabilityValueChecked to true in middleware.go and the
-// second half fails with 403 capability_insufficient — which is the point.
-// The constant is a real switch wired to the real check, not a marker;
-// a future #333 implementer flips it and sets RequiredWriteCapability
-// rather than writing the gate from scratch.
+// second half fails — with 403 capability_route_undeclared here, since
+// "/admin/ping" is this test's own throwaway route and was never declared
+// in RequiredWriteCapabilities (a real mounted write route with a matching
+// declared-but-empty entry would instead fail with capability_insufficient,
+// since "not.a.real.capability" != ""). Either way the write stops being
+// admitted — which is the point. The constant is a real switch wired to
+// the real check, not a marker; a future #333 implementer flips it and
+// fills in RequiredWriteCapabilities' values rather than writing the gate
+// from scratch.
 func TestWriteCapabilityValueIsRecordedButNotEnforced(t *testing.T) {
 	require.False(t, platformadmin.CapabilityValueChecked,
 		"value enforcement is off pending #333; if this is now on, the second half of this test and the note in middleware.go both need updating")
@@ -447,4 +452,102 @@ func TestWriteCapabilityValueIsRecordedButNotEnforced(t *testing.T) {
 		withCapability("not.a.real.capability")))
 	require.Equal(t, http.StatusOK, readRec.Code)
 	require.Contains(t, readRec.Body.String(), `"capability":"not.a.real.capability"`)
+}
+
+// boolPtr is a tiny helper for AuthConfig.CapabilityChecked, which is a
+// *bool specifically so its zero value (nil) is distinguishable from an
+// explicit false — see AuthConfig's doc comment in middleware.go.
+func boolPtr(b bool) *bool { return &b }
+
+// newRouterWithCapabilityConfig is newRouter's counterpart for the tests
+// below: it lets a test override AuthConfig.CapabilityChecked and
+// RequiredCapabilities, which newRouter deliberately does not expose —
+// every other test in this file exercises the shipped, switch-off state.
+// A nil checked argument leaves CapabilityChecked unset, exactly as every
+// production caller (Register, cmd/marketplace-api/main.go) does.
+func newRouterWithCapabilityConfig(t *testing.T, checked *bool, required map[string]string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(platformadmin.RequirePlatformAuth(platformadmin.AuthConfig{
+		Secret:               testSecret,
+		NonceStore:           newMemNonces(),
+		Now:                  func() time.Time { return fixedNow },
+		CapabilityChecked:    checked,
+		RequiredCapabilities: required,
+	}))
+	r.POST("/admin/ping", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+	return r
+}
+
+// TestAuthConfigCapabilityCheckedNilDefaultsToProductionOff proves the
+// thing #364 requires above everything else: leaving CapabilityChecked
+// unset — what every production caller does — behaves EXACTLY like the
+// shipped CapabilityValueChecked=false constant, not like some other
+// default. If this ever starts failing, either the fallback in
+// RequirePlatformAuth broke or CapabilityValueChecked itself changed; both
+// are shipping-blocking for #364.
+func TestAuthConfigCapabilityCheckedNilDefaultsToProductionOff(t *testing.T) {
+	require.False(t, platformadmin.CapabilityValueChecked,
+		"production default must be off; #364 must not flip this")
+
+	r := newRouterWithCapabilityConfig(t, nil, nil)
+	body := []byte(`{"x":1}`)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, signedRequest(t, http.MethodPost, "/admin/ping", body,
+		withCapability("literally.anything")))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+}
+
+// TestCapabilityCheckedOnAdmitsMatchingCapability: switch ON, presented
+// capability equals the declared required value -> admitted.
+func TestCapabilityCheckedOnAdmitsMatchingCapability(t *testing.T) {
+	required := map[string]string{
+		platformadmin.CapabilityKey(http.MethodPost, "/admin/ping"): "billing.trial.extend",
+	}
+	r := newRouterWithCapabilityConfig(t, boolPtr(true), required)
+	body := []byte(`{"x":1}`)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, signedRequest(t, http.MethodPost, "/admin/ping", body,
+		withCapability("billing.trial.extend")))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+}
+
+// TestCapabilityCheckedOnRefusesMismatchedCapability: switch ON,
+// presented capability differs from the declared required value -> 403
+// capability_insufficient. This is the "your capability is wrong" cell —
+// distinguishable from the "this route declared nothing" cell below.
+func TestCapabilityCheckedOnRefusesMismatchedCapability(t *testing.T) {
+	required := map[string]string{
+		platformadmin.CapabilityKey(http.MethodPost, "/admin/ping"): "billing.trial.extend",
+	}
+	r := newRouterWithCapabilityConfig(t, boolPtr(true), required)
+	body := []byte(`{"x":1}`)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, signedRequest(t, http.MethodPost, "/admin/ping", body,
+		withCapability("something.else")))
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Equal(t, "capability_insufficient", errorCode(t, rec))
+}
+
+// TestCapabilityCheckedOnFailsClosedForUndeclaredRoute: switch ON, the
+// write route has NO entry in the lookup at all -> refused with a code
+// distinguishable from a capability mismatch. A missing declaration is a
+// mark8ly bug (nothing to fix on the caller's side by presenting a
+// different capability); a mismatch is a caller bug. Conflating them would
+// send whoever is debugging a production refusal to the wrong place.
+func TestCapabilityCheckedOnFailsClosedForUndeclaredRoute(t *testing.T) {
+	r := newRouterWithCapabilityConfig(t, boolPtr(true), map[string]string{})
+	body := []byte(`{"x":1}`)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, signedRequest(t, http.MethodPost, "/admin/ping", body,
+		withCapability("anything")))
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Equal(t, "capability_route_undeclared", errorCode(t, rec))
+	require.NotEqual(t, "capability_insufficient", errorCode(t, rec))
 }

--- a/services/marketplace-api/internal/handlers/platformadmin/routes_capability_coverage_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes_capability_coverage_test.go
@@ -1,0 +1,112 @@
+package platformadmin_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
+)
+
+// allWriteRoutesDeps wires every dependency Register (routes.go) needs to
+// mount ALL FOUR of this surface's write routes at once: POST
+// /admin/billing/trials/:storeID/extend, POST /admin/tenants/:id/suspend,
+// POST /admin/tenants/:id/unsuspend, and POST /admin/tenants/:id/purge.
+//
+// Register's switch statements (routes.go) mount each write route group
+// only when THAT group's own dependency set is fully non-nil —
+// TrialExtender needs DB+Emitter, TenantLifecycle needs DB+Emitter, and the
+// purge pair needs DB+Emitter+TenantDirectory+TenantTeardown+Purger.
+// Wiring only some of these would mount only some write routes, and
+// TestAllWriteRoutesDeclareACapability below would pass VACUOUSLY on the
+// ones it never saw. That is why this helper wires every dependency, and
+// why the test separately asserts the mounted write-route count is exactly
+// 4 rather than trusting an empty failure list alone.
+func allWriteRoutesDeps() platformadmin.Deps {
+	return platformadmin.Deps{
+		Repo:            &stubRepo{},
+		Secret:          testSecret,
+		DB:              &gorm.DB{},
+		NonceStore:      newMemNonces(),
+		TenantDirectory: &stubDirectory{detail: &tenantdirectory.TenantDetail{}},
+		Emitter:         audit.NewEmitter(audit.EmitterConfig{Repo: &recordingRepo{}}),
+		TenantLifecycle: &stubLifecycle{},
+		TrialExtender:   &stubExtender{},
+		TenantTeardown:  &fakeTeardown{seq: &seq{}},
+		Purger:          &fakePurger{seq: &seq{}},
+	}
+}
+
+// isWriteMethod mirrors isWrite's classification in middleware.go (POST,
+// PUT, PATCH, DELETE). Deliberately duplicated here rather than exported
+// from the production package: this test independently derives "which
+// routes are writes" from the SAME rule the gate itself uses, so if the
+// two definitions ever drift apart from each other, that drift is exactly
+// what should make this test fail — not something to hide by sharing one
+// implementation.
+func isWriteMethod(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+// TestAllWriteRoutesDeclareACapability is #364's real deliverable. #364's
+// own premise: there is ZERO operator traffic on this surface to shake out
+// a missing capability declaration, so without this test the first symptom
+// of one is a 403 in production the day #333 turns enforcement on.
+//
+// It builds the REAL router via platformadmin.Register with every
+// write-route dependency wired (allWriteRoutesDeps), enumerates gin's OWN
+// route table (not a hand-maintained list), and fails — naming the
+// offending route — if any write-method route has no entry in
+// RequiredWriteCapabilities.
+//
+// This test is proven to catch both failure modes it claims to catch (see
+// the 364-report.md mutation log):
+//   - a write route added without a capability declaration, and
+//   - a declared route renamed (c.FullPath() / route.Path changes, so the
+//     old lookup key silently stops matching).
+func TestAllWriteRoutesDeclareACapability(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	platformadmin.Register(r.Group("/api/v1/platform"), allWriteRoutesDeps())
+
+	writeRouteCount := 0
+	for _, route := range r.Routes() {
+		if !isWriteMethod(route.Method) {
+			continue
+		}
+		writeRouteCount++
+
+		key := platformadmin.CapabilityKey(route.Method, route.Path)
+		_, declared := platformadmin.RequiredWriteCapabilities[key]
+		require.True(t, declared,
+			"write route %s %s has no entry in RequiredWriteCapabilities — "+
+				"a route added without declaring its capability fails OPEN "+
+				"today and will 403 in production the day #333 turns "+
+				"enforcement on",
+			route.Method, route.Path)
+	}
+
+	// Pins the count so a route that silently fails to MOUNT (e.g. a stray
+	// nil in allWriteRoutesDeps' wiring) is caught too — without this, the
+	// loop above would just see fewer routes and pass on the ones it never
+	// saw, exactly the vacuous-pass hazard this file's doc comments warn
+	// about.
+	require.Equal(t, 4, writeRouteCount,
+		"expected exactly the 4 known write routes to be mounted; got %d — "+
+			"either allWriteRoutesDeps is missing a dependency, or a new "+
+			"write route was added and this test's expected count needs "+
+			"updating alongside its capability declaration in "+
+			"RequiredWriteCapabilities",
+		writeRouteCount)
+}


### PR DESCRIPTION
Closes #364.

`RequiredWriteCapability` was a **single global string**. Flipping `CapabilityValueChecked` as-built would have forced all four write routes on this surface — trial extend, tenant suspend, unsuspend, purge — to present the *same* capability, which #288's acceptance contradicts by asking purge for "the highest-privilege capability the gateway can assert".

## What changed

- `RequiredWriteCapability` (one string) → `RequiredWriteCapabilities` (a lookup keyed on `METHOD + " " + c.FullPath()`, the matched route template).
- **Exact equality**, one capability per route. Not a set, not a lattice: per #275 mark8ly does not own the privilege model — the console asserts the capability for the action it is performing, and mark8ly records it and refuses a mismatch.
- **Undeclared write routes fail closed** with `capability_route_undeclared`, deliberately distinct from `capability_insufficient`. The two mean different things to an operator: one says "your capability is wrong", the other says "this service never declared what this route needs".

## It ships inert

`CapabilityValueChecked` stays `false` and all four declared values stay `""`. **Production behaviour is byte-for-byte unchanged**, and both `Register` call sites are untouched. No capability names were invented — that vocabulary is the console's, and #287 declined to invent it for the same reason. This PR gives the gate the right *shape* so #333 fills in values rather than reshaping the gate.

## The actual deliverable: the coverage test

#364's own observation is that there is **zero** operator traffic on this surface to shake out a mismatch — `audit_logs` held no `actor_type='operator'` rows at all until #288's verification. So without a guard, the first symptom of a missing entry is a `403` in production.

`TestAllWriteRoutesDeclareACapability` builds the **real** router via `Register`, enumerates its routes, asserts the write-route count is exactly 4, and checks every one against the lookup. The count assertion matters because routes mount conditionally on non-nil deps — without it, a route silently failing to mount would let the test pass while proving nothing.

**The failure mode it exists to prevent:** the lookup keys carry the full production path (`/api/v1/platform/admin/...`). Had they omitted that prefix, flipping the switch would have refused *every* write route while all unit tests still passed. The coverage test mounts at the same prefix as both production call sites, and a prefix mismatch is caught — verified by mutation.

## Verification

Every claim above is pinned by a mutation that fails for the reason it names:

| mutation | result |
|---|---|
| delete one route's lookup entry | coverage test fails, naming `POST …/admin/tenants/:id/suspend` |
| add an undeclared write route to `Register` | coverage test fails, naming it |
| change the test's mount prefix | coverage test fails — every route reads as undeclared, the exact catastrophe |
| flip the production default to ON | a test fails explicitly ("production default must be off") |
| let an undeclared route fall through to admitted | the fail-closed test fails (expected 403, got 200) |

That fourth one is worth calling out: the shipped default being *off* is now pinned by a test, so a later edit cannot enable enforcement silently.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go vet -tags=stripelive ./internal/billing/trial/` — all clean
- [x] whole module untagged: clean
- [x] `internal/handlers/platformadmin` and `internal/billing/trial` green under `-tags=integration -p 1 -count=1`
- [x] `internal/subscription/planchange` still exactly its 9 pre-existing `store_subscriptions_store_id_fkey` failures (#317) — sixth measurement against `origin/main`, never 10
- [x] both production `Register` call sites confirmed unchanged, and the new `AuthConfig` fields nil at both

## What this does NOT do

It does not flip the switch, and it does not decide any capability value. #333 still needs the console's vocabulary before enforcement can be turned on — this PR removes the *mechanism* blocker in front of it, which is the whole of #364's scope.
