### PR TITLE
fix(outbox): mark a dropped event failed instead of published (#336)

### DIFF
--- a/docs/superpowers/plans/2026-08-26-outbox-failure-state.md
+++ b/docs/superpowers/plans/2026-08-26-outbox-failure-state.md
@@ -1109,6 +1109,44 @@ git commit -m "docs: record the origin/main failing-set diff for the outbox fail
 
 ---
 
+## Verification record (Task 5, 2026-08-26)
+
+**`go vet -tags=integration ./...`**: `exit=0` (clean — build-tagged files compile).
+
+**Branch (`fix/336-outbox-failure-state`)** — full integration suite, `TEST_DATABASE_URL` LAN
+Postgres, `-tags=integration -p 1`:
+- `go test` exit=1
+- Failing packages: **22** (`/tmp/branch-fails-pkgs.txt`)
+- Failing individual tests: **191** (`/tmp/branch-fails-tests.txt`)
+
+**`origin/main`** (5413e20f, throwaway worktree at `/tmp/m8-main-baseline`) — identical command:
+- `go test` exit=1
+- Failing packages: **23** (`/tmp/main-fails-pkgs.txt`)
+- Failing individual tests: **194** (`/tmp/main-fails-tests.txt`)
+
+**Both-directions package diff:**
+- Only on `origin/main`, not on branch (fixed by this branch): `internal/outbox` — the one package
+  this plan targeted.
+- Only on branch, not on `origin/main` (would be a regression): **none**.
+
+**Both-directions individual-test diff** (within the 22 packages that fail on both):
+- Only on `origin/main`, not on branch: `TestIntegration_Publisher_BumpsWatermark`,
+  `TestIntegration_Publisher_BatchMultipleEvents_MaxCreatedAt`,
+  `TestIntegration_Publisher_MissingStoreID_DropFloor` — the three tests broken by the
+  `insertStore` helper's missing `stores.storefront_customer_portal_secret` column, fixed in Task
+  3. The third was also renamed on the branch to
+  `TestIntegration_Publisher_MissingStoreID_MarksFailedNotPublished`, which now passes (does not
+  appear in either failing-test list).
+- Only on branch, not on `origin/main`: **none**.
+
+**Verdict:** This branch added zero test failures. It strictly reduced the pre-existing failing set
+by fixing `internal/outbox` (23 → 22 failing packages, 194 → 191 failing tests), all via the
+authorised `insertStore` test-helper fix from Task 3. The remaining 22 failing packages / 191
+failing tests are identical, by package and by individual test name, between `origin/main` and this
+branch — pre-existing failures unrelated to this work, unmodified by it.
+
+---
+
 ## Not in this plan
 
 - **`GET /admin/outbox` (#331).** Separate branch, separate plan, written after this ships. The

--- a/docs/superpowers/plans/2026-08-26-outbox-failure-state.md
+++ b/docs/superpowers/plans/2026-08-26-outbox-failure-state.md
@@ -1,0 +1,1122 @@
+# Outbox failure state (#336) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the outbox publisher recording dropped events as successfully published, and start
+persisting why a row was dropped, so a failed event is durable, terminal, and visible.
+
+**Architecture:** Three derived states over the existing `outbox_events` columns — `pending`
+(`published_at IS NULL AND error IS NULL`), `failed` (`published_at IS NULL AND error IS NOT
+NULL`, terminal), `published` (`published_at IS NOT NULL`). The publisher marks a dropped row
+failed instead of published, in the same transaction as the watermark bumps; the poll excludes
+failed rows so they are not retried forever; `/admin/health` counts them separately from pending
+and degrades on them. **No migration** — `outbox_events.error` already exists and is unused.
+
+**Tech Stack:** Go 1.26, GORM, Gin, Postgres 15, `testify/require`, build-tagged integration tests
+against a real Postgres via `pkg/testdb`.
+
+**Spec:** `docs/superpowers/specs/2026-08-26-outbox-failure-state-design.md`
+
+**Scope:** This plan is **#336 only** — the first of the spec's two PRs. #331
+(`GET /admin/outbox`) is a separate plan on a separate branch, written after this ships and
+deploys.
+
+## Global Constraints
+
+- Service root for every command: `/Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api`. Never run `go test` path-scoped for a full-suite run.
+- Integration DSN — LAN IP, **never `localhost`**: `TEST_DATABASE_URL=postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable`
+- Integration tests require `-tags=integration`. **`go test ./...` without the tag never compiles build-tagged files** and will report a false green (Trap 8).
+- Use `-p 1` on full integration runs.
+- `set -o pipefail` (or `${PIPESTATUS[0]}`) whenever a test exit code is reported as evidence — piping `go test` into `tail` reports *tail's* status, not the suite's (Trap 8 corollary).
+- Module path: `github.com/mark8ly/marketplace-api`.
+- **Do not push, open a PR, merge, or deploy.** This plan stops at local commits on the branch `fix/336-outbox-failure-state`. Deployment and the production verification exercise are handled separately, with explicit go-ahead at the moment of the write.
+- Commit messages: conventional commits, **single line**, no signatures.
+- `internal/outbox` is recorded at **2 FAIL** on `origin/main`. Do not fix them; do not accept them as pre-existing without the diff in Task 5.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `internal/outbox/models.go` | model + domain constants | **Modify** — add the two failure reason codes and the `Failure` type |
+| `internal/outbox/repository.go` | data access for `outbox_events` | **Modify** — narrow the poll predicate; add `MarkFailedInTx` |
+| `internal/outbox/publisher.go` | the polling loop and watermark bumps | **Modify** — build `ids` only from contributing rows; mark failures; rewrite the package doc comment |
+| `internal/outbox/repository_integration_test.go` | repository integration tests | **Modify** — `MarkFailedInTx` and poll-exclusion tests |
+| `internal/outbox/publisher_integration_test.go` | publisher integration tests | **Modify** — invert the test that enshrines the bug; add mixed-batch and unparseable-payload tests |
+| `internal/handlers/platformadmin/health.go` | health contract and status rules | **Modify** — `OutboxHealth.Errored`, degrade rule, replace the now-false doc comment |
+| `internal/handlers/platformadmin/health_checks.go` | the DB-backed health queries | **Modify** — split pending vs errored with `FILTER` |
+| `internal/handlers/platformadmin/health_test.go` | health status unit tests | **Modify** — degrade-on-errored cases |
+| `internal/handlers/platformadmin/health_checks_integration_test.go` | health query integration tests | **Modify** — errored rows excluded from pending and from the age |
+| `internal/handlers/platformadmin/testdata/health_response.json` | the console's pinned golden response | **Modify** — the outbox entry gains `errored`; breaking this is the deliberate friction that says the contract changed |
+
+---
+
+## Task 1: Failure vocabulary and `MarkFailedInTx`
+
+**Files:**
+- Modify: `internal/outbox/models.go` (append after the `EventType` constants block)
+- Modify: `internal/outbox/repository.go:10-21` (interface), and append the method
+- Test: `internal/outbox/repository_integration_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `outbox.ReasonPayloadUnparseable` (`string` const, value `"payload_unparseable"`)
+  - `outbox.ReasonPayloadMissingStoreID` (`string` const, value `"payload_missing_store_id"`)
+  - `type outbox.Failure struct { ID string; Reason string }`
+  - `Repository.MarkFailedInTx(tx *gorm.DB, failures []Failure) error` — used by Task 3.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/outbox/repository_integration_test.go`:
+
+```go
+func TestIntegration_MarkFailedInTx_SetsReasonAndLeavesUnpublished(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	bad := makeEvent(tenantID)
+	good := makeEvent(tenantID)
+	enqueueCommitted(t, db, bad)
+	enqueueCommitted(t, db, good)
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return repo.MarkFailedInTx(tx, []outbox.Failure{
+			{ID: bad.ID, Reason: outbox.ReasonPayloadUnparseable},
+		})
+	})
+	if err != nil {
+		t.Fatalf("MarkFailedInTx: %v", err)
+	}
+
+	var got outbox.OutboxEvent
+	if err := db.First(&got, "id = ?", bad.ID).Error; err != nil {
+		t.Fatalf("reload failed row: %v", err)
+	}
+	if got.Error == nil {
+		t.Fatalf("error is nil; want %q", outbox.ReasonPayloadUnparseable)
+	}
+	// Assert the EXACT code, not merely non-nil: a stub returns the zero
+	// value for a field nobody set.
+	if *got.Error != outbox.ReasonPayloadUnparseable {
+		t.Fatalf("error = %q, want %q", *got.Error, outbox.ReasonPayloadUnparseable)
+	}
+	if got.PublishedAt != nil {
+		t.Fatalf("a failed row must stay unpublished, got published_at=%v", got.PublishedAt)
+	}
+
+	var untouched outbox.OutboxEvent
+	if err := db.First(&untouched, "id = ?", good.ID).Error; err != nil {
+		t.Fatalf("reload untouched row: %v", err)
+	}
+	if untouched.Error != nil {
+		t.Fatalf("unrelated row was marked failed: %q", *untouched.Error)
+	}
+}
+
+func TestIntegration_MarkFailedInTx_GroupsDistinctReasons(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	unparseable := makeEvent(tenantID)
+	missingStore := makeEvent(tenantID)
+	enqueueCommitted(t, db, unparseable)
+	enqueueCommitted(t, db, missingStore)
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return repo.MarkFailedInTx(tx, []outbox.Failure{
+			{ID: unparseable.ID, Reason: outbox.ReasonPayloadUnparseable},
+			{ID: missingStore.ID, Reason: outbox.ReasonPayloadMissingStoreID},
+		})
+	})
+	if err != nil {
+		t.Fatalf("MarkFailedInTx: %v", err)
+	}
+
+	for _, tc := range []struct {
+		id   string
+		want string
+	}{
+		{unparseable.ID, outbox.ReasonPayloadUnparseable},
+		{missingStore.ID, outbox.ReasonPayloadMissingStoreID},
+	} {
+		var got outbox.OutboxEvent
+		if err := db.First(&got, "id = ?", tc.id).Error; err != nil {
+			t.Fatalf("reload %s: %v", tc.id, err)
+		}
+		if got.Error == nil || *got.Error != tc.want {
+			t.Fatalf("row %s error = %v, want %q", tc.id, got.Error, tc.want)
+		}
+	}
+}
+
+func TestIntegration_MarkFailedInTx_EmptyIsNoOp(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	repo := outbox.NewRepository(db)
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return repo.MarkFailedInTx(tx, nil)
+	})
+	if err != nil {
+		t.Fatalf("empty MarkFailedInTx must be a no-op, got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+set -o pipefail
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -run 'TestIntegration_MarkFailedInTx' ./internal/outbox/ -v
+```
+
+Expected: **compile failure** — `undefined: outbox.Failure`, `undefined: outbox.ReasonPayloadUnparseable`, `repo.MarkFailedInTx undefined`.
+
+- [ ] **Step 3: Add the vocabulary and the type**
+
+Append to `internal/outbox/models.go`, after the `EventType` constants block and before
+`IsOrderAggregate`:
+
+```go
+// Failure reason codes written to outbox_events.error when the publisher
+// cannot process a row. This vocabulary is CLOSED and the values are
+// STABLE: #331 serves this column cross-tenant to the platform console,
+// and a stable code is what lets the console render it.
+//
+// A raw error string must NEVER be stored here. encoding/json quotes the
+// offending input in its unmarshal errors, so persisting err.Error() would
+// copy fragments of an arbitrary customer-data JSONB payload into a column
+// that leaves this service — defeating the same reasoning that keeps
+// `payload` out of #331's response, through a field nobody would audit.
+const (
+	ReasonPayloadUnparseable    = "payload_unparseable"
+	ReasonPayloadMissingStoreID = "payload_missing_store_id"
+)
+
+// Failure is one row the publisher could not process, paired with the
+// reason code to persist. See MarkFailedInTx.
+type Failure struct {
+	ID     string
+	Reason string
+}
+```
+
+- [ ] **Step 4: Add `MarkFailedInTx` to the interface**
+
+In `internal/outbox/repository.go`, add to the `Repository` interface immediately below
+`MarkPublishedInTx`:
+
+```go
+	// MarkFailedInTx records why the publisher could not process each row,
+	// leaving published_at NULL. A row with error set is TERMINAL: the poll
+	// in ProcessBatch excludes it, so it is never retried. Requeueing is an
+	// operator action — clear error and the row re-enters the poll.
+	//
+	// Reason must be one of the Reason* constants in models.go, never a raw
+	// error string. See the comment on those constants.
+	MarkFailedInTx(tx *gorm.DB, failures []Failure) error
+```
+
+- [ ] **Step 5: Implement it**
+
+Append to `internal/outbox/repository.go`:
+
+```go
+func (r *gormRepository) MarkFailedInTx(tx *gorm.DB, failures []Failure) error {
+	if len(failures) == 0 {
+		return nil
+	}
+	// Grouped by reason so this is one statement per DISTINCT reason (two,
+	// today) rather than one per row. Map iteration order is unspecified
+	// and irrelevant: the id sets are disjoint, so the statements commute.
+	byReason := make(map[string][]string, len(failures))
+	for _, f := range failures {
+		byReason[f.Reason] = append(byReason[f.Reason], f.ID)
+	}
+	for reason, ids := range byReason {
+		if err := tx.Exec(`UPDATE outbox_events SET error = ? WHERE id IN ?`,
+			reason, ids).Error; err != nil {
+			return fmt.Errorf("outbox: mark failed: %w", err)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+set -o pipefail
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -run 'TestIntegration_MarkFailedInTx' ./internal/outbox/ -v
+```
+
+Expected: PASS, 3 tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly
+git add services/marketplace-api/internal/outbox/models.go \
+        services/marketplace-api/internal/outbox/repository.go \
+        services/marketplace-api/internal/outbox/repository_integration_test.go
+git commit -m "feat(outbox): persist a closed-vocabulary failure reason on a dropped event"
+```
+
+---
+
+## Task 2: The poll excludes failed rows
+
+Without this, a failed row left at `published_at IS NULL` is re-selected every 2s forever — a
+poison pill that sorts to the head of `ORDER BY tenant_id, created_at` and eventually consumes the
+whole batch window. This is what makes "terminal" true rather than aspirational.
+
+**Files:**
+- Modify: `internal/outbox/repository.go:41-51` (the `SELECT` inside `ProcessBatch`)
+- Test: `internal/outbox/repository_integration_test.go`
+
+**Interfaces:**
+- Consumes: `outbox.ReasonPayloadUnparseable`, `outbox.Failure`, `Repository.MarkFailedInTx` from Task 1.
+- Produces: no new symbols. Changes the behaviour of `ProcessBatch`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/outbox/repository_integration_test.go`:
+
+```go
+// A row with error set is TERMINAL. This is the poison-pill proof: nothing
+// else in the suite exercises the poll's error IS NULL term, which exists
+// precisely so a permanently-failing row cannot be re-selected forever and
+// starve real events out of the batch window.
+func TestIntegration_ProcessBatch_SkipsFailedRows(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	failed := makeEvent(tenantID)
+	fresh := makeEvent(tenantID)
+	enqueueCommitted(t, db, failed)
+	enqueueCommitted(t, db, fresh)
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return repo.MarkFailedInTx(tx, []outbox.Failure{
+			{ID: failed.ID, Reason: outbox.ReasonPayloadUnparseable},
+		})
+	}); err != nil {
+		t.Fatalf("seed failed row: %v", err)
+	}
+
+	var seen []string
+	count, err := repo.ProcessBatch(context.Background(), 10,
+		func(tx *gorm.DB, rows []outbox.OutboxEvent) error {
+			for _, r := range rows {
+				seen = append(seen, r.ID)
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("ProcessBatch: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("ProcessBatch saw %d rows, want 1 (the failed row must be skipped)", count)
+	}
+	if len(seen) != 1 || seen[0] != fresh.ID {
+		t.Fatalf("ProcessBatch saw %v, want only the un-failed row %s", seen, fresh.ID)
+	}
+}
+
+// Clearing error is the documented requeue path for an operator. It must
+// actually work, or "terminal" means "lost".
+func TestIntegration_ProcessBatch_ClearingErrorRequeues(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	evt := makeEvent(tenantID)
+	enqueueCommitted(t, db, evt)
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return repo.MarkFailedInTx(tx, []outbox.Failure{
+			{ID: evt.ID, Reason: outbox.ReasonPayloadMissingStoreID},
+		})
+	}); err != nil {
+		t.Fatalf("seed failed row: %v", err)
+	}
+
+	if err := db.Exec(`UPDATE outbox_events SET error = NULL WHERE id = ?`, evt.ID).Error; err != nil {
+		t.Fatalf("clear error: %v", err)
+	}
+
+	count, err := repo.ProcessBatch(context.Background(), 10,
+		func(tx *gorm.DB, rows []outbox.OutboxEvent) error { return nil })
+	if err != nil {
+		t.Fatalf("ProcessBatch: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("ProcessBatch saw %d rows, want 1 after error was cleared", count)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+set -o pipefail
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -run 'TestIntegration_ProcessBatch_(SkipsFailedRows|ClearingErrorRequeues)' ./internal/outbox/ -v
+```
+
+Expected: `SkipsFailedRows` **FAILS** with `ProcessBatch saw 2 rows, want 1`.
+`ClearingErrorRequeues` passes already — it is a regression guard for the requeue path, and it must
+keep passing after Step 3.
+
+- [ ] **Step 3: Narrow the poll predicate**
+
+In `internal/outbox/repository.go`, inside `ProcessBatch`, replace the `WHERE` line of the raw
+`SELECT`:
+
+```go
+			WHERE published_at IS NULL
+```
+
+with:
+
+```go
+			WHERE published_at IS NULL AND error IS NULL
+```
+
+and replace the `ProcessBatch` doc comment on the `Repository` interface
+(`internal/outbox/repository.go:13-20`) with:
+
+```go
+	// ProcessBatch opens its own transaction, locks up to `limit` PENDING
+	// rows via FOR UPDATE SKIP LOCKED, and calls fn with the rows and the
+	// same tx. If fn returns nil the tx commits (the caller is expected to
+	// have called MarkPublishedInTx inside fn); if fn returns an error the
+	// tx rolls back and the rows become visible to the next poll. Returns
+	// the number of rows the callback saw.
+	//
+	// PENDING means published_at IS NULL *and* error IS NULL. A row with
+	// error set is terminal and is never re-selected — see MarkFailedInTx.
+	// The partial index outbox_unpublished_idx (migration 000001) is on
+	// published_at IS NULL; the error term is a filter on top of it, which
+	// is fine while failed rows are ~0. If they ever become common, that
+	// index is the thing to revisit.
+	ProcessBatch(ctx context.Context, limit int,
+		fn func(tx *gorm.DB, rows []OutboxEvent) error) (int, error)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+set -o pipefail
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -run 'TestIntegration_' ./internal/outbox/ -v
+```
+
+Expected: both new tests PASS, and every pre-existing `internal/outbox` integration test still
+behaves as it did (note: `TestIntegration_Publisher_MissingStoreID_DropFloor` still passes here —
+Task 3 is what inverts it).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly
+git add services/marketplace-api/internal/outbox/repository.go \
+        services/marketplace-api/internal/outbox/repository_integration_test.go
+git commit -m "fix(outbox): exclude terminally-failed rows from the publisher poll"
+```
+
+---
+
+## Task 3: The publisher stops marking dropped events published
+
+This is #336's core. Note Step 1 **inverts an existing test that currently enshrines the bug** —
+`TestIntegration_Publisher_MissingStoreID_DropFloor` asserts *"expected malformed event to still be
+marked published"*.
+
+**Files:**
+- Modify: `internal/outbox/publisher.go:1-19` (package doc), `:13-19` (type doc), `:85-145` (`Tick`)
+- Test: `internal/outbox/publisher_integration_test.go:168-217` (invert), plus two new tests
+
+**Interfaces:**
+- Consumes: `outbox.Failure`, `outbox.ReasonPayloadUnparseable`, `outbox.ReasonPayloadMissingStoreID`, `Repository.MarkFailedInTx` (Task 1); the narrowed poll (Task 2).
+- Produces: no new symbols. Changes `Publisher.Tick` behaviour.
+
+- [ ] **Step 1: Invert the test that enshrines the bug**
+
+In `internal/outbox/publisher_integration_test.go`, in
+`TestIntegration_Publisher_MissingStoreID_DropFloor`, replace this block:
+
+```go
+	if got.PublishedAt == nil {
+		t.Fatalf("expected malformed event to still be marked published")
+	}
+```
+
+with:
+
+```go
+	if got.PublishedAt != nil {
+		t.Fatalf("a dropped event must NOT be marked published, got published_at=%v", got.PublishedAt)
+	}
+	if got.Error == nil {
+		t.Fatalf("error is nil; want %q", outbox.ReasonPayloadMissingStoreID)
+	}
+	if *got.Error != outbox.ReasonPayloadMissingStoreID {
+		t.Fatalf("error = %q, want %q", *got.Error, outbox.ReasonPayloadMissingStoreID)
+	}
+```
+
+and rename the test to state the new property:
+
+```go
+func TestIntegration_Publisher_MissingStoreID_MarksFailedNotPublished(t *testing.T) {
+```
+
+- [ ] **Step 2: Add the unparseable-payload and mixed-batch tests**
+
+Append to `internal/outbox/publisher_integration_test.go`:
+
+```go
+func TestIntegration_Publisher_UnparseablePayload_MarksFailedNotPublished(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events", "store_watermarks", "stores")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	storeID := uuid.NewString()
+	insertStore(t, db, storeID, tenantID)
+
+	// jsonb rejects malformed JSON at insert, so the unparseable-to-Go
+	// value is a well-formed JSON scalar: valid jsonb, but not the object
+	// json.Unmarshal into map[string]any requires.
+	evt := &outbox.OutboxEvent{
+		TenantID:    tenantID,
+		Aggregate:   outbox.AggregateProduct,
+		AggregateID: uuid.NewString(),
+		EventType:   outbox.EventProductCreated,
+		Payload:     datatypes.JSON([]byte(`"not-an-object"`)),
+	}
+	if err := db.Create(evt).Error; err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	pub := outbox.New(outbox.Config{
+		Repo: repo, DB: db, Logger: quietLogger(),
+		Interval: 1 * time.Second, BatchSize: 100,
+	})
+	if _, err := pub.Tick(context.Background()); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	var got outbox.OutboxEvent
+	if err := db.First(&got, "id = ?", evt.ID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.PublishedAt != nil {
+		t.Fatalf("a dropped event must NOT be marked published, got published_at=%v", got.PublishedAt)
+	}
+	if got.Error == nil || *got.Error != outbox.ReasonPayloadUnparseable {
+		t.Fatalf("error = %v, want %q", got.Error, outbox.ReasonPayloadUnparseable)
+	}
+}
+
+// The mixed batch is the composition no single-purpose test constructs, and
+// it is the whole point of the fix: one good row and one bad row in the SAME
+// tick. The good row must publish AND bump its watermark; the bad row must
+// be failed AND left unpublished. A regression that reverted the id-building
+// inversion would still pass every single-row test in this file.
+func TestIntegration_Publisher_MixedBatch_PublishesGoodFailsBad(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events", "store_watermarks", "stores")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	storeID := uuid.NewString()
+	insertStore(t, db, storeID, tenantID)
+
+	good := enqueueForStore(t, db, tenantID, storeID)
+
+	bad := &outbox.OutboxEvent{
+		TenantID:    tenantID,
+		Aggregate:   outbox.AggregateProduct,
+		AggregateID: uuid.NewString(),
+		EventType:   outbox.EventProductUpdated,
+		Payload:     datatypes.JSON([]byte(`{"unrelated":"value"}`)),
+	}
+	if err := db.Create(bad).Error; err != nil {
+		t.Fatalf("enqueue bad: %v", err)
+	}
+
+	pub := outbox.New(outbox.Config{
+		Repo: repo, DB: db, Logger: quietLogger(),
+		Interval: 1 * time.Second, BatchSize: 100,
+	})
+	count, err := pub.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("tick saw %d rows, want 2", count)
+	}
+
+	var gotGood outbox.OutboxEvent
+	if err := db.First(&gotGood, "id = ?", good.ID).Error; err != nil {
+		t.Fatalf("reload good: %v", err)
+	}
+	if gotGood.PublishedAt == nil {
+		t.Fatalf("the good event must be published even when a bad one shares its batch")
+	}
+	if gotGood.Error != nil {
+		t.Fatalf("the good event must not be marked failed, got %q", *gotGood.Error)
+	}
+
+	var gotBad outbox.OutboxEvent
+	if err := db.First(&gotBad, "id = ?", bad.ID).Error; err != nil {
+		t.Fatalf("reload bad: %v", err)
+	}
+	if gotBad.PublishedAt != nil {
+		t.Fatalf("the bad event must NOT be published, got published_at=%v", gotBad.PublishedAt)
+	}
+	if gotBad.Error == nil || *gotBad.Error != outbox.ReasonPayloadMissingStoreID {
+		t.Fatalf("bad event error = %v, want %q", gotBad.Error, outbox.ReasonPayloadMissingStoreID)
+	}
+
+	// The good row's watermark landed: the drop must not have suppressed it.
+	var n int64
+	if err := db.Raw(`SELECT count(*) FROM store_watermarks WHERE store_id = ?`, storeID).
+		Scan(&n).Error; err != nil {
+		t.Fatalf("count watermarks: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("watermark rows = %d, want 1", n)
+	}
+
+	// And the failed row is not retried on the next tick.
+	count, err = pub.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("second tick: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("second tick saw %d rows, want 0 (failed rows are terminal)", count)
+	}
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+set -o pipefail
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -run 'TestIntegration_Publisher_(MissingStoreID_MarksFailedNotPublished|UnparseablePayload_MarksFailedNotPublished|MixedBatch_PublishesGoodFailsBad)' ./internal/outbox/ -v
+```
+
+Expected: all three **FAIL** with `a dropped event must NOT be marked published, got
+published_at=…`.
+
+- [ ] **Step 4: Fix `Tick`**
+
+In `internal/outbox/publisher.go`, inside the `Tick` callback, replace the loop body's opening and
+the two drop branches so that `ids` is appended **after** both checks, and collect failures.
+Replace this:
+
+```go
+		byBucket := map[key]time.Time{}
+		ids := make([]string, 0, len(rows))
+		for _, r := range rows {
+			ids = append(ids, r.ID)
+			var payload map[string]any
+			if err := json.Unmarshal(r.Payload, &payload); err != nil {
+				if p.logger != nil {
+					p.logger.Warn("outbox publisher: unparseable payload; dropping",
+						"event_id", r.ID, "err", err)
+				}
+				continue
+			}
+			sid, _ := payload["store_id"].(string)
+			if sid == "" {
+				if p.logger != nil {
+					p.logger.Warn("outbox publisher: payload missing store_id; dropping",
+						"event_id", r.ID, "event_type", r.EventType)
+				}
+				continue
+			}
+			axis := "products"
+```
+
+with this:
+
+```go
+		byBucket := map[key]time.Time{}
+		ids := make([]string, 0, len(rows))
+		failures := make([]Failure, 0)
+		for _, r := range rows {
+			var payload map[string]any
+			if err := json.Unmarshal(r.Payload, &payload); err != nil {
+				if p.logger != nil {
+					p.logger.Warn("outbox publisher: unparseable payload; failing",
+						"event_id", r.ID, "err", err)
+				}
+				failures = append(failures, Failure{ID: r.ID, Reason: ReasonPayloadUnparseable})
+				continue
+			}
+			sid, _ := payload["store_id"].(string)
+			if sid == "" {
+				if p.logger != nil {
+					p.logger.Warn("outbox publisher: payload missing store_id; failing",
+						"event_id", r.ID, "event_type", r.EventType)
+				}
+				failures = append(failures, Failure{ID: r.ID, Reason: ReasonPayloadMissingStoreID})
+				continue
+			}
+			// Appended only now: a row reaches this line exactly when it is
+			// going to contribute a watermark bump. Appending before the
+			// checks above is what made a dropped event indistinguishable
+			// from a published one (#336).
+			ids = append(ids, r.ID)
+			axis := "products"
+```
+
+Then replace the final line of the callback:
+
+```go
+		return p.repo.MarkPublishedInTx(tx, ids)
+```
+
+with:
+
+```go
+		// Both marks run in the SAME transaction as the watermark bumps
+		// above, so a batch's outcome commits whole or not at all.
+		if err := p.repo.MarkFailedInTx(tx, failures); err != nil {
+			return err
+		}
+		return p.repo.MarkPublishedInTx(tx, ids)
+```
+
+- [ ] **Step 5: Rewrite the doc comments that now assert something false**
+
+Replace `internal/outbox/publisher.go:13-19` (the `Publisher` type doc):
+
+```go
+// Publisher polls outbox_events and bumps store_watermarks asynchronously.
+// See spec §14.1 (watermark separation) and §14.6 (publisher semantics).
+//
+// Payload invariant: every outbox row in slice 1 carries a "store_id" key
+// at the top level of its JSON payload. A row without it, or with a payload
+// that will not unmarshal, is logged and marked FAILED — error is set, and
+// published_at is left NULL. It never blocks the publisher (the original
+// reason for dropping it) and it is never retried (both causes are
+// deterministic properties of the row), but it is no longer recorded as a
+// successful publish. See #336; the failed state is served by #331.
+```
+
+And replace `internal/outbox/models.go:1-4` (the package doc), which describes only the two-state
+world:
+
+```go
+// Package outbox holds the OutboxEvent model. Events are written in the
+// same transaction as the mutation that produces them (see spec §13.2.7).
+// Slice 1's publisher reads these rows, upserts store_watermarks, and marks
+// them published. Slice 2 adds real Pub/Sub delivery.
+//
+// A row is in one of three states, all derived from existing columns:
+//
+//	pending    published_at IS NULL AND error IS NULL
+//	failed     published_at IS NULL AND error IS NOT NULL   (terminal)
+//	published  published_at IS NOT NULL
+//
+// failed is terminal: ProcessBatch's poll excludes it, so it is never
+// retried. Clearing error requeues the row. See #336.
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+set -o pipefail
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration ./internal/outbox/ -v
+```
+
+Expected: PASS for the whole `internal/outbox` package, including the previously-passing
+watermark and shutdown tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly
+git add services/marketplace-api/internal/outbox/publisher.go \
+        services/marketplace-api/internal/outbox/models.go \
+        services/marketplace-api/internal/outbox/publisher_integration_test.go
+git commit -m "fix(outbox): mark a dropped event failed instead of published"
+```
+
+---
+
+## Task 4: `/admin/health` separates pending from errored, and degrades on errored
+
+Without this, the first failed row makes `/admin/health` permanently degraded on
+`oldest_pending_age_seconds` — a false alarm shipped as a bug fix.
+
+**Files:**
+- Modify: `internal/handlers/platformadmin/health.go:62-70` (type + doc), `:151-162` (status rule)
+- Modify: `internal/handlers/platformadmin/health_checks.go:29-48` (the query)
+- Test: `internal/handlers/platformadmin/health_test.go`, `internal/handlers/platformadmin/health_checks_integration_test.go`
+
+**Interfaces:**
+- Consumes: the `error` column now being written (Tasks 1 and 3).
+- Produces: `platformadmin.OutboxHealth.Errored int64`, and an `"errored"` key in the `outbox` dependency's `metrics` map.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `internal/handlers/platformadmin/health_checks_integration_test.go`:
+
+```go
+// A terminally-failed row is NOT pending. If it counted as pending, the
+// first one would put /admin/health into a degraded state that never
+// clears, because oldest_pending_age_seconds would grow forever.
+func TestOutboxHealthExcludesFailedRowsFromPendingAndAge(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	src := platformadmin.NewDBHealthSource(db)
+	tenant := uuid.NewString()
+
+	// Failed and very old: must not count as pending, and must not drive
+	// the age.
+	require.NoError(t, db.Exec(`INSERT INTO outbox_events
+		(tenant_id, aggregate, aggregate_id, event_type, payload, created_at, error)
+		VALUES (?, 'product', ?, 'product.created', '{}'::jsonb, ?, 'payload_unparseable')`,
+		tenant, uuid.NewString(), healthAsOf.Add(-72*time.Hour)).Error)
+
+	// Genuinely pending, 5 minutes old.
+	require.NoError(t, db.Exec(`INSERT INTO outbox_events
+		(tenant_id, aggregate, aggregate_id, event_type, payload, created_at)
+		VALUES (?, 'product', ?, 'product.created', '{}'::jsonb, ?)`,
+		tenant, uuid.NewString(), healthAsOf.Add(-5*time.Minute)).Error)
+
+	got, err := src.Outbox(context.Background(), healthAsOf)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), got.Pending, "a failed row must not count as pending")
+	require.Equal(t, int64(1), got.Errored, "the failed row must be counted as errored")
+	require.Equal(t, int64(300), got.OldestPendingAgeSeconds,
+		"age must ignore failed rows, or the alarm never clears")
+}
+
+// Errored counts only unpublished failures. A published row is settled
+// whatever its error column happens to hold.
+func TestOutboxHealthErroredIsZeroWhenNoFailedRows(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	src := platformadmin.NewDBHealthSource(db)
+	tenant := uuid.NewString()
+
+	published := healthAsOf.Add(-time.Hour)
+	require.NoError(t, db.Exec(`INSERT INTO outbox_events
+		(tenant_id, aggregate, aggregate_id, event_type, payload, created_at, published_at)
+		VALUES (?, 'product', ?, 'product.created', '{}'::jsonb, ?, ?)`,
+		tenant, uuid.NewString(), published, published).Error)
+
+	got, err := src.Outbox(context.Background(), healthAsOf)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got.Pending)
+	require.Equal(t, int64(0), got.Errored)
+	require.Equal(t, int64(0), got.OldestPendingAgeSeconds)
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+set -o pipefail
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -run 'TestOutboxHealth' ./internal/handlers/platformadmin/ -v
+```
+
+Expected: **compile failure** — `got.Errored undefined (type platformadmin.OutboxHealth has no field or method Errored)`.
+
+- [ ] **Step 3: Add the field and replace the false doc comment**
+
+In `internal/handlers/platformadmin/health.go`, replace the `OutboxHealth` block at `:62-70`:
+
+```go
+// OutboxHealth is the measured state of outbox_events.
+//
+// Pending counts rows the publisher will still attempt: published_at IS
+// NULL AND error IS NULL. Errored counts rows it has given up on:
+// published_at IS NULL AND error IS NOT NULL, which #336 made a real state
+// by teaching the publisher to write outbox_events.error instead of marking
+// a dropped event published.
+//
+// The two are separate because they need different reactions. A pending
+// backlog drains on its own and is measured by age; an errored row never
+// drains — only an operator clears it — so counting it as pending would
+// make OldestPendingAgeSeconds grow forever and leave this surface
+// permanently degraded on a condition draining cannot fix.
+type OutboxHealth struct {
+	Pending                 int64
+	OldestPendingAgeSeconds int64
+	Errored                 int64
+}
+```
+
+- [ ] **Step 4: Split the query**
+
+In `internal/handlers/platformadmin/health_checks.go`, replace the body of the `Outbox` query —
+keep the outer `WHERE published_at IS NULL` so the partial index still applies, and split with
+`FILTER`:
+
+```go
+	// The published_at condition stays a WHERE, not a FILTER: outbox_events
+	// is never pruned, and only a WHERE lets Postgres use
+	// outbox_unpublished_idx (a partial index on published_at IS NULL,
+	// migration 000001) instead of scanning every row ever written on a
+	// shared db-f1-micro. The pending/errored split is done with FILTER
+	// *inside* that index-selected set, so the split costs nothing.
+	err := s.db.WithContext(ctx).Raw(`
+		SELECT
+			COUNT(*) FILTER (WHERE error IS NULL)                       AS pending,
+			COALESCE(EXTRACT(EPOCH FROM (
+				? - MIN(created_at) FILTER (WHERE error IS NULL)))::bigint, 0)
+			                                                            AS oldest_pending_age_seconds,
+			COUNT(*) FILTER (WHERE error IS NOT NULL)                   AS errored
+		FROM outbox_events
+		WHERE published_at IS NULL`, asOf).Scan(&out).Error
+```
+
+- [ ] **Step 5: Run the integration tests to verify they pass**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+set -o pipefail
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -run 'TestOutboxHealth' ./internal/handlers/platformadmin/ -v
+```
+
+Expected: PASS, including the pre-existing
+`TestOutboxHealthCountsPendingAndMeasuresAgeFromAsOf`.
+
+- [ ] **Step 6: Write the failing unit tests for the degrade rule**
+
+Append to `internal/handlers/platformadmin/health_test.go`. This file already provides
+`stubHealthSource` (a struct with an `outbox platformadmin.OutboxHealth` field, used as a pointer),
+`healthFixture()`, and `getHealth(t, src) (*httptest.ResponseRecorder, healthBody)` — use those, do
+not add duplicates. `outbox` is index 0 of `body.Data.Dependencies` because the registry order is
+contract-pinned by `TestHealthReportsEveryRegistryEntryInOrder`. Status comes back as a plain JSON
+string, so compare against the literals `"degraded"` / `"ok"`, matching the golden fixture.
+
+```go
+// An errored row degrades regardless of age. This alarm does not clear by
+// draining — only by an operator resolving the row — which is the correct
+// shape for a condition that requires a human, and the same shape
+// csv_import_jobs already uses for RunningStaleHeartbeat.
+func TestOutboxDegradesOnErroredEvenWhenNothingIsPending(t *testing.T) {
+	_, body := getHealth(t, &stubHealthSource{
+		outbox: platformadmin.OutboxHealth{Pending: 0, OldestPendingAgeSeconds: 0, Errored: 1},
+	})
+	dep := body.Data.Dependencies[0]
+	require.Equal(t, "outbox", dep.Name)
+	require.Equal(t, "degraded", dep.Status,
+		"a terminally-failed event must degrade even with an empty pending queue")
+	require.Equal(t, int64(1), dep.Metrics["errored"])
+	require.Equal(t, int64(0), dep.Metrics["pending"])
+}
+
+func TestOutboxIsOKWhenNothingErroredAndBacklogIsYoung(t *testing.T) {
+	_, body := getHealth(t, &stubHealthSource{
+		outbox: platformadmin.OutboxHealth{
+			Pending:                 3,
+			OldestPendingAgeSeconds: int64(platformadmin.OutboxPendingThreshold/time.Second) - 1,
+			Errored:                 0,
+		},
+	})
+	dep := body.Data.Dependencies[0]
+	require.Equal(t, "outbox", dep.Name)
+	require.Equal(t, "ok", dep.Status)
+	require.Equal(t, int64(0), dep.Metrics["errored"])
+}
+```
+
+- [ ] **Step 7: Run it to verify it fails**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+set -o pipefail
+go test -run 'TestOutbox(DegradesOnErrored|IsOKWhenNothingErrored)' ./internal/handlers/platformadmin/ -v
+```
+
+Expected: `TestOutboxDegradesOnErroredEvenWhenNothingIsPending` FAILS — status is `"ok"` and
+`dep.Metrics["errored"]` is absent (zero value).
+
+- [ ] **Step 8: Add the degrade rule and the metric**
+
+In `internal/handlers/platformadmin/health.go`, replace the outbox block in `health()`
+(`:151-162`):
+
+```go
+	if v, err := h.src.Outbox(ctx, asOf); err != nil {
+		h.logCheckFailed("outbox", err)
+	} else {
+		status := StatusOK
+		// Errored degrades regardless of age: a terminally-failed event is
+		// a silent divergence between this service and whatever consumes
+		// the watermark, and it does not resolve on its own.
+		if v.Errored > 0 ||
+			time.Duration(v.OldestPendingAgeSeconds)*time.Second >= OutboxPendingThreshold {
+			status = StatusDegraded
+		}
+		measured["outbox"] = dependencyRow{Status: status, Metrics: map[string]int64{
+			"pending":                    v.Pending,
+			"oldest_pending_age_seconds": v.OldestPendingAgeSeconds,
+			"errored":                    v.Errored,
+		}}
+	}
+```
+
+- [ ] **Step 9: Update the shared fixture and the golden response**
+
+Adding a key to the `outbox` metrics map **breaks the golden fixture on purpose** — that file is
+the console's pinned contract, and `TestHealthReportsEveryRegistryEntryInOrder`'s comment calls
+this friction deliberate. Two edits, made together.
+
+First, `healthFixture()` in `internal/handlers/platformadmin/health_test.go:50`. That file's own
+convention (`health_test.go:19-25`) is that every asserted value is **distinct and non-zero**, so a
+missing map key cannot masquerade as a passing zero. `Errored` must therefore be non-zero and
+unlike any other number in the fixture. `outbox` is already `degraded` (400 ≥ 300), so this does
+not change any status:
+
+```go
+		outbox:   platformadmin.OutboxHealth{Pending: 7, OldestPendingAgeSeconds: 400, Errored: 3},
+```
+
+Then `internal/handlers/platformadmin/testdata/health_response.json` — the outbox entry only:
+
+```json
+      { "name": "outbox", "status": "degraded",
+        "metrics": { "pending": 7, "oldest_pending_age_seconds": 400, "errored": 3 } },
+```
+
+- [ ] **Step 10: Run the whole package's unit tests**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+set -o pipefail
+go test ./internal/handlers/platformadmin/ 2>&1 | tail -40; echo "exit=${PIPESTATUS[0]}"
+```
+
+Expected: PASS, `exit=0`. If the golden-fixture test fails here, the JSON in Step 9 does not match
+what the handler now emits — fix the fixture to match the handler, **never** the handler to match
+the fixture.
+
+- [ ] **Step 11: Commit**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly
+git add services/marketplace-api/internal/handlers/platformadmin/health.go \
+        services/marketplace-api/internal/handlers/platformadmin/health_checks.go \
+        services/marketplace-api/internal/handlers/platformadmin/health_test.go \
+        services/marketplace-api/internal/handlers/platformadmin/health_checks_integration_test.go \
+        services/marketplace-api/internal/handlers/platformadmin/testdata/health_response.json
+git commit -m "feat(health): count terminally-failed outbox events and degrade on them"
+```
+
+---
+
+## Task 5: Whole-branch verification and the pre-existing-failure diff
+
+The point of this task is to find out whether this branch **added** a failure, which cannot be
+answered by looking at this branch alone.
+
+**Files:** none modified — this task produces evidence.
+
+- [ ] **Step 1: Verify build-tagged files actually compile**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+set -o pipefail
+go vet -tags=integration ./... 2>&1 | tail -20; echo "exit=${PIPESTATUS[0]}"
+```
+
+Expected: `exit=0`. `go vet -tags=integration` is the only thing that compiles build-tagged files.
+
+- [ ] **Step 2: Capture this branch's failing set**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 ./... > /tmp/branch-tests.txt 2>&1
+echo "go test exit=$?"
+grep -E '^FAIL' /tmp/branch-tests.txt | sort > /tmp/branch-fails.txt
+wc -l < /tmp/branch-fails.txt
+```
+
+No pipe on the `go test` line: its exit code is being reported as evidence, and piping would report
+the *last* command's status instead. A non-zero exit here is expected — the point of Steps 3 and 4
+is finding out whether it is the *same* non-zero as `origin/main`.
+
+- [ ] **Step 3: Capture `origin/main`'s failing set in a throwaway worktree**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly
+git worktree add /tmp/m8-main-baseline origin/main
+cd /tmp/m8-main-baseline/services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 ./... > /tmp/main-tests.txt 2>&1
+echo "go test exit=$?"
+grep -E '^FAIL' /tmp/main-tests.txt | sort > /tmp/main-fails.txt
+wc -l < /tmp/main-fails.txt
+```
+
+Note `> file 2>&1`, not `2>&1 > file` — the latter sends stderr to the terminal and only stdout to
+the file, which would silently drop half the output this comparison depends on.
+
+- [ ] **Step 4: Diff the two failing sets**
+
+```bash
+diff /tmp/main-fails.txt /tmp/branch-fails.txt && echo "IDENTICAL — no failure added"
+```
+
+Expected: identical, or the only difference is a package that this branch **fixed**. **A package
+failing on the branch but not on `origin/main` is a defect this work introduced** — stop and fix it
+before proceeding. Do not report "pre-existing" without this diff; that claim has been wrong twice
+in this milestone.
+
+- [ ] **Step 5: Clean up the worktree**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly
+git worktree remove /tmp/m8-main-baseline --force
+git worktree list
+```
+
+- [ ] **Step 6: Record the evidence**
+
+Append the two failing-set counts and the diff result to the plan's own file as a short
+"Verification record" section, then commit:
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly
+git add docs/superpowers/plans/2026-08-26-outbox-failure-state.md
+git commit -m "docs: record the origin/main failing-set diff for the outbox failure state branch"
+```
+
+---
+
+## Not in this plan
+
+- **`GET /admin/outbox` (#331).** Separate branch, separate plan, written after this ships. The
+  spec's §6 explains why they are not bundled.
+- **The production provoke-and-clean exercise** (spec §7). It runs after deploy, with explicit
+  go-ahead at the moment of the write. It is not a step an implementing agent performs.
+- **`metrics.OutboxEventsPending` / `OutboxEventsPublishedTotal`**, registered at
+  `internal/metrics/registry.go:165-166` and written by nothing. Same dead-declaration family as
+  `outbox_events.error` was. To be filed as its own issue — see spec §8.
+- **Producer-side validation** that would reject a malformed row at enqueue. A different defence at
+  a different layer, and it cannot help rows already in the table.

--- a/docs/superpowers/specs/2026-08-26-outbox-failure-state-design.md
+++ b/docs/superpowers/specs/2026-08-26-outbox-failure-state-design.md
@@ -63,11 +63,15 @@ Three states, all **derived from existing columns**. No migration.
 console needs no renegotiation.
 
 **`failed` is terminal by design.** A failed row is never retried. Requeueing is an operator
-action — clear `error` and the row re-enters the poll on the next tick. This is the deliberate
-answer to the "retry, dead-letter or alert" question #336 leaves open: with both known causes
-deterministic, bounded retries would burn work to fail identically, and a `attempts`/backoff column
-would be machinery for a transient-failure mode that does not exist here. If a transient drop cause
-is ever introduced, that is the point to revisit this, not before.
+action — clearing `error` re-enters the row into the poll on the next tick, but re-entry is not
+recovery. `store_watermarks` is upserted with `GREATEST` over the row's *original* `created_at`, so
+a row that sat failed while later events published for the same store will publish without moving
+the watermark — leaving consumers unaware and clearing the health alarm at the same time. Recovering
+a stale row means enqueuing a fresh event, or bumping `created_at` alongside clearing `error`. This
+is the deliberate answer to the "retry, dead-letter or alert" question #336 leaves open: with both
+known causes deterministic, bounded retries would burn work to fail identically, and a
+`attempts`/backoff column would be machinery for a transient-failure mode that does not exist here.
+If a transient drop cause is ever introduced, that is the point to revisit this, not before.
 
 ### Why the poll must exclude failed rows
 
@@ -201,6 +205,16 @@ already cites #331's `payload` exclusion.
   `older_than_minutes` is the tool for the "what is stuck" question.
 - Standard envelope: `{ data, pagination { page, limit, total } }`, RFC3339 UTC timestamps, bare
   ids — the #260 conventions.
+
+### `error` is opaque outside the service, not a three-way switch
+
+`outbox_events.error` is `text` with no `CHECK` constraint (migration
+`000001_products_initial.up.sql:256`). The closed vocabulary described in §3 is enforced in Go by
+`sanitizeReason`, which only covers writes going through `MarkFailedInTx`. Both the production
+verification exercise in §7 and the operator requeue path described in §2 are manual `UPDATE`s
+against this column, and neither goes through `sanitizeReason`. So the two known reason codes are
+what the *service* can produce, not what a *consumer* can observe. #331's console must treat `error`
+as an opaque string with an unknown-value fallback, never a three-way switch.
 
 ### Known cost, accepted
 

--- a/docs/superpowers/specs/2026-08-26-outbox-failure-state-design.md
+++ b/docs/superpowers/specs/2026-08-26-outbox-failure-state-design.md
@@ -1,0 +1,288 @@
+# Outbox failure state — design (#336, then #331)
+
+Date: 2026-08-26
+Issues: **#336** (publisher marks dropped events as published; `outbox_events.error` is never
+written) and **#331** (`GET /admin/outbox`). Milestone: Platform integration v1.
+Also touches **#289** (`/admin/health`), whose `errored` metric was dropped because it could not
+have returned a non-zero value.
+
+Two shippable pieces, in this order. #336 is a correctness fix with a live consequence; #331 is
+the read that #336 unblocks.
+
+---
+
+## 1. What is true today, measured not assumed
+
+Verified against production on 2026-08-26 (primary selected by role, per the handoff doc):
+
+| measure | value |
+|---|---|
+| `outbox_events` total | 688 |
+| `published_at IS NULL` (pending) | **0** |
+| `error IS NOT NULL` | **0** |
+| `payload->>'store_id' IS NULL` | **0** |
+| distinct stores in payloads | 1 |
+| `store_watermarks` rows | 1 |
+| oldest / newest event | 2026-04-30 / 2026-07-30 |
+
+**#336 has never fired.** No event has ever been dropped in production, and the one watermark row
+is consistent with the one store that produced all 688 events. This is a latent defect being fixed
+ahead of need — the same class as #360 and #361 — not incident response. It matters because it is
+unrecoverable and silent when it does fire.
+
+Confirmed in code at `origin/main`:
+
+- `internal/outbox/publisher.go:94` appends `r.ID` to `ids` **before** both `continue` drop paths
+  (unparseable payload, `payload.store_id` empty), and `publisher.go:144` then calls
+  `MarkPublishedInTx(tx, ids)`. A dropped event is recorded as a successful publish.
+- `outbox_events.error` is declared (`migrations/000001_products_initial.up.sql:257`), present on
+  the model (`internal/outbox/models.go:26`), selected by the poll (`repository.go:44`), and
+  **written by nothing**. The only write to the table is
+  `UPDATE outbox_events SET published_at = now()` (`repository.go:65`).
+- The publisher runs on a 2s ticker in `admin` and `both` modes (`cmd/marketplace-api/main.go:1548-1560`).
+
+Both drop causes are **deterministic properties of the row**: a payload that will not
+`json.Unmarshal` never will, and a payload without `store_id` never grows one. Nothing about
+retrying either case can succeed. Failures of the watermark upsert are a different thing — they
+return an error, roll the whole transaction back, and are retried on the next tick. That stays
+unchanged.
+
+---
+
+## 2. The state model
+
+Three states, all **derived from existing columns**. No migration.
+
+| state | predicate | meaning |
+|---|---|---|
+| `pending` | `published_at IS NULL AND error IS NULL` | waiting to be published |
+| `failed` | `published_at IS NULL AND error IS NOT NULL` | **terminal** — the publisher gave up |
+| `published` | `published_at IS NOT NULL` | watermark bumped |
+
+`failed` is exactly the predicate #331 already specifies, so the endpoint's contract with the
+console needs no renegotiation.
+
+**`failed` is terminal by design.** A failed row is never retried. Requeueing is an operator
+action — clear `error` and the row re-enters the poll on the next tick. This is the deliberate
+answer to the "retry, dead-letter or alert" question #336 leaves open: with both known causes
+deterministic, bounded retries would burn work to fail identically, and a `attempts`/backoff column
+would be machinery for a transient-failure mode that does not exist here. If a transient drop cause
+is ever introduced, that is the point to revisit this, not before.
+
+### Why the poll must exclude failed rows
+
+The poll is `WHERE published_at IS NULL ORDER BY tenant_id, created_at LIMIT ? FOR UPDATE SKIP
+LOCKED`. Leaving a permanently-failing row at `published_at IS NULL` without narrowing the
+predicate makes it a **poison pill**: it sorts at the head of that ordering and is re-selected every
+2s forever. Enough of them consume the whole batch window and starve real events. Narrowing the
+predicate to `AND error IS NULL` is what makes "terminal" true rather than aspirational.
+
+---
+
+## 3. #336 — the fix
+
+### `internal/outbox/repository.go`
+
+- Poll predicate becomes `WHERE published_at IS NULL AND error IS NULL`.
+- New `MarkFailedInTx(tx *gorm.DB, failures []Failure) error`, a sibling of `MarkPublishedInTx`,
+  writing `error` **inside the same transaction** as the watermark bumps and the publish marks.
+  Either the batch's whole outcome commits or none of it does.
+- With a closed vocabulary of two reasons, this is at most two
+  `UPDATE outbox_events SET error = ? WHERE id IN ?` statements per tick.
+
+### `internal/outbox/publisher.go`
+
+- `ids` is built **only from rows that contributed a watermark bucket**. This inversion at
+  `publisher.go:94` is the whole of #336 part 2.
+- Dropped rows are collected as `(id, reason)` and passed to `MarkFailedInTx`.
+- Existing `Warn` logging is kept. The log was never the problem; the absence of a durable record
+  was.
+
+### The failure reason is a closed vocabulary, never a raw error
+
+```
+ReasonPayloadUnparseable   = "payload_unparseable"
+ReasonPayloadMissingStoreID = "payload_missing_store_id"
+```
+
+**`err.Error()` must not be persisted.** `encoding/json`'s unmarshal errors quote the offending
+input, so storing the raw error would copy fragments of an arbitrary customer-data JSONB payload
+into a column that #331 then serves cross-tenant to the console. That defeats the same reasoning
+that keeps `payload` out of the #331 response, and it would do so through a field nobody would
+think to audit.
+
+The closed vocabulary is also what makes `error` safe to return on #331 at all. The two decisions
+hold each other up.
+
+### The package doc comment
+
+`publisher.go:16-19` currently documents the present behaviour as a deliberate choice: *"Rows
+without it are logged and marked published without a watermark bump — losing the signal is
+preferable to blocking the publisher on a producer bug."*
+
+The first half stays true — a bad row still never blocks the publisher. The second half becomes
+false. The comment is rewritten to describe the terminal-failed state, not deleted; a reader who
+finds only silence there will re-derive the old behaviour as intentional.
+
+---
+
+## 4. #289 `/admin/health` — the composition consequence
+
+This is the part no task-scoped review would surface, and it is the reason the fix is not a
+one-line change.
+
+`health_checks.go:38-45` derives `pending` and `oldest_pending_age_seconds` from `published_at IS
+NULL`, and `health.go:155` degrades the `outbox` dependency once the oldest pending row is
+`OutboxPendingThreshold` (5m) old. **Left alone, the first terminally-failed row would put the
+estate-wide health surface into a degraded state that never clears** — a false alarm shipped as a
+bug fix.
+
+### Query
+
+Keep the outer `WHERE published_at IS NULL` — this preserves the partial-index reasoning the
+existing comment spells out (`outbox_unpublished_idx`, migration `000001`, chosen so a
+never-pruned table is not scanned on a shared db-f1-micro) — and split with `FILTER`:
+
+```sql
+SELECT
+    COUNT(*) FILTER (WHERE error IS NULL)                          AS pending,
+    COALESCE(EXTRACT(EPOCH FROM (
+        ? - MIN(created_at) FILTER (WHERE error IS NULL)))::bigint, 0)
+                                                                   AS oldest_pending_age_seconds,
+    COUNT(*) FILTER (WHERE error IS NOT NULL)                      AS errored
+FROM outbox_events
+WHERE published_at IS NULL
+```
+
+### Contract
+
+- `OutboxHealth` gains `Errored int64`.
+- The doc comment at `health.go:62-66` — *"There is deliberately no `errored` metric. Nothing in
+  this service ever writes `outbox_events.error` … such a metric could never return a non-zero
+  value"* — is now false and is replaced with what makes it true, citing #336.
+- Degrade condition becomes `errored > 0 || oldest_pending_age_seconds >= OutboxPendingThreshold`.
+- `errored` is an **additive** key in the dependency's `metrics` map. Existing console consumers of
+  #289 are unaffected.
+
+**`errored > 0` degrades deliberately, and the alarm does not clear by draining** — only by an
+operator resolving the row. That is the correct shape for a condition that requires a human, and it
+is not a new pattern on this handler: `csv_import_jobs` already degrades on
+`RunningStaleHeartbeat > 0` (`health.go:169`).
+
+---
+
+## 5. #331 — `GET /admin/outbox`
+
+A **read**. It needs no entry in `RequiredWriteCapabilities` and no capability-value decision, so
+the vocabulary question blocking #333 does not touch it.
+
+Modelled field-for-field on `notifications.go` (#332), the nearest sibling — whose own doc comment
+already cites #331's `payload` exclusion.
+
+- **Query and filter live in `internal/outbox`** as `ListPlatform` + `PlatformListFilter`. The
+  handler (`internal/handlers/platformadmin/outbox.go`) holds a one-method `OutboxLister`
+  interface, matching `NotificationLister` / `TicketLister` / `EstateCounts`.
+- **Row shape:** `id`, `tenant_id`, `aggregate`, `aggregate_id`, `event_type`, `status`,
+  `created_at`, `age_seconds`, `published_at` (nullable), `error` (nullable).
+- **`payload` is excluded by construction** — a field-by-field projection like `toNotificationRow`,
+  not by which columns the query happens to select, so a column added to the model tomorrow cannot
+  leak.
+- **`status` is derived server-side in SQL**, per the issue's explicit requirement that the console
+  not reimplement the null-check.
+- **`age_seconds` is server-computed** from the same instant `older_than_minutes` filters on.
+  Deriving it client-side lets the console display an age that disagrees with the filter that
+  selected the row.
+- **Filters:** `status` (`pending` / `failed` / `published`), `event_type`, `older_than_minutes`,
+  `since_hours`, `limit` (clamped, never refused), `page`, and `tenant_id` to narrow. Unknown
+  values narrow nothing rather than erroring — the established contract across this surface.
+- **Empty is `200` with `[]`**, from a pre-allocated slice: a nil slice marshals to `null` and
+  defeats a caller's `?? []` exactly when there is no data.
+- **Default sort `created_at DESC`**, consistent with every sibling list on this surface;
+  `older_than_minutes` is the tool for the "what is stuck" question.
+- Standard envelope: `{ data, pagination { page, limit, total } }`, RFC3339 UTC timestamps, bare
+  ids — the #260 conventions.
+
+### Known cost, accepted
+
+`total` for `status=published` counts across a table that is never pruned, on a shared db-f1-micro.
+At 688 rows this is immaterial, and it is the same shape every sibling endpoint already has. Worth
+revisiting if the table reaches a size where the count dominates — not now.
+
+---
+
+## 6. Sequencing
+
+**Two branches, two PRs, #336 first.** #336 is a correctness fix with a live consequence and should
+not wait behind an endpoint. #331 then builds on a table whose state model is already true.
+
+Considered and **rejected**: provoking one synthetic row after #336 and leaving it in place as a
+fixture until #331 ships, so one row proves both. It would leave `/admin/health` degraded on the
+estate surface for however many days separate the two PRs. Two short provoke-and-clean exercises
+instead.
+
+---
+
+## 7. Verification
+
+The takeover doc's standing lesson from #288: *a green test suite plus a mounted route is not
+delivery evidence.* Production has zero malformed rows and will produce none on its own — the
+outbox is idle — so this fix's behaviour cannot be observed by waiting. It must be provoked or it
+stays unproven.
+
+### Integration tests (real Postgres)
+
+- **The mixed batch.** One good row and one malformed row in the *same* tick. Asserts the good row
+  published **and** its watermark bumped, **and** the bad row errored **and** left unpublished.
+  This is the Trap-15 case: #288's Criticals all lived in a composition no single test constructed,
+  and here the composition is the entire point of the fix.
+- **The poison-pill proof.** Tick twice; the errored row must not be re-selected on the second
+  tick. Nothing else tests the narrowed poll predicate, which is the reason it exists.
+- **Exact error codes asserted as strings**, never `error IS NOT NULL`. #358's lesson: a stub
+  returns the zero value for a field nobody set.
+- **The health split.** `pending` excludes errored rows, `oldest_pending_age_seconds` ignores them,
+  `errored` counts them, and `errored > 0` degrades.
+- **#331 status derivation** across all three states, and `payload` absent from every response.
+
+### Production exercise (#336, after deploy)
+
+With explicit go-ahead at the moment of the write, not merely by this document:
+
+1. Insert **one** synthetic `outbox_events` row with an unparseable payload.
+2. Observe the publisher set `error` to the expected code and leave `published_at` NULL.
+3. Confirm it is **not** re-selected on subsequent ticks.
+4. Confirm `/admin/health` reports `errored: 1`, `pending: 0`, and status `degraded`.
+5. `DELETE` the row and confirm health returns to healthy.
+
+Blast radius is one row we created ourselves in an idle queue, reversible by `DELETE`. Step 5 is
+part of the evidence, not cleanup after it — recovery is the half that a provoke-only exercise
+leaves unproven.
+
+Repeated for #331 after it deploys, to see the row as `status=failed`.
+
+### Discipline
+
+- `internal/outbox` is recorded at **2 FAIL** on `origin/main`. Diff the failing set against a
+  throwaway worktree of `origin/main` before calling anything pre-existing — the discipline the
+  handoff doc demands, and the way to find out whether a third was added.
+- Run with `-tags=integration` and `TEST_DATABASE_URL` set, from the service root, `-p 1`.
+  `go test ./...` without the tag never compiles build-tagged files (Trap 8).
+- `set -o pipefail` or `${PIPESTATUS[0]}` whenever an exit code is reported as evidence (Trap 8's
+  corollary).
+- Read back every `gh` write (Trap 16).
+
+---
+
+## 8. Found while reading, deliberately not in scope
+
+`metrics.OutboxEventsPending` and `metrics.OutboxEventsPublishedTotal` are declared **and
+registered** (`internal/metrics/registry.go:45,53,165-166`) and **written by nothing**. They are
+the same family of dead declaration as `outbox_events.error` itself, and as #322 and #323.
+
+Tempting to fix here, since the publisher is the only place that could set them. Kept out: it is a
+separate concern with its own contract question (what a gauge should read when the process holding
+it is one of several replicas), and bundling it would widen a correctness fix into an observability
+change. To be filed as its own issue.
+
+Also out of scope: producer-side validation that would stop a malformed row being enqueued at all.
+Worth considering, but it is a different defence at a different layer, and it cannot help the rows
+already in the table.

--- a/services/marketplace-api/internal/handlers/platformadmin/health.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/health.go
@@ -61,13 +61,21 @@ var DependencyRegistry = []dependencyKey{
 
 // OutboxHealth is the measured state of outbox_events.
 //
-// There is deliberately no `errored` metric. Nothing in this service ever
-// writes outbox_events.error — the only production write to the table is
-// `SET published_at = now()` — so such a metric could never return a
-// non-zero value. See the spec; the dead column is a separate follow-up.
+// Pending counts rows the publisher will still attempt: published_at IS
+// NULL AND error IS NULL. Errored counts rows it has given up on:
+// published_at IS NULL AND error IS NOT NULL, which #336 made a real state
+// by teaching the publisher to write outbox_events.error instead of marking
+// a dropped event published.
+//
+// The two are separate because they need different reactions. A pending
+// backlog drains on its own and is measured by age; an errored row never
+// drains — only an operator clears it — so counting it as pending would
+// make OldestPendingAgeSeconds grow forever and leave this surface
+// permanently degraded on a condition draining cannot fix.
 type OutboxHealth struct {
 	Pending                 int64
 	OldestPendingAgeSeconds int64
+	Errored                 int64
 }
 
 // CSVJobsHealth is the measured state of csv_import_jobs.
@@ -152,12 +160,17 @@ func (h *HealthHandler) health(c *gin.Context) {
 		h.logCheckFailed("outbox", err)
 	} else {
 		status := StatusOK
-		if time.Duration(v.OldestPendingAgeSeconds)*time.Second >= OutboxPendingThreshold {
+		// Errored degrades regardless of age: a terminally-failed event is
+		// a silent divergence between this service and whatever consumes
+		// the watermark, and it does not resolve on its own.
+		if v.Errored > 0 ||
+			time.Duration(v.OldestPendingAgeSeconds)*time.Second >= OutboxPendingThreshold {
 			status = StatusDegraded
 		}
 		measured["outbox"] = dependencyRow{Status: status, Metrics: map[string]int64{
 			"pending":                    v.Pending,
 			"oldest_pending_age_seconds": v.OldestPendingAgeSeconds,
+			"errored":                    v.Errored,
 		}}
 	}
 

--- a/services/marketplace-api/internal/handlers/platformadmin/health_checks.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/health_checks.go
@@ -31,14 +31,19 @@ func (s *dbHealthSource) Outbox(ctx context.Context, asOf time.Time) (OutboxHeal
 		return OutboxHealth{}, errNoDB
 	}
 	var out OutboxHealth
-	// The pending condition is a WHERE, not a FILTER: outbox_events is
-	// never pruned, and only a WHERE lets Postgres use outbox_unpublished_idx
-	// (a partial index on published_at IS NULL, migration 000001) instead of
-	// scanning every row ever written on a shared db-f1-micro.
+	// The published_at condition stays a WHERE, not a FILTER: outbox_events
+	// is never pruned, and only a WHERE lets Postgres use
+	// outbox_unpublished_idx (a partial index on published_at IS NULL,
+	// migration 000001) instead of scanning every row ever written on a
+	// shared db-f1-micro. The pending/errored split is done with FILTER
+	// *inside* that index-selected set, so the split costs nothing.
 	err := s.db.WithContext(ctx).Raw(`
 		SELECT
-			COUNT(*)                                                        AS pending,
-			COALESCE(EXTRACT(EPOCH FROM (? - MIN(created_at)))::bigint, 0)  AS oldest_pending_age_seconds
+			COUNT(*) FILTER (WHERE error IS NULL)                       AS pending,
+			COALESCE(EXTRACT(EPOCH FROM (
+				? - MIN(created_at) FILTER (WHERE error IS NULL)))::bigint, 0)
+			                                                            AS oldest_pending_age_seconds,
+			COUNT(*) FILTER (WHERE error IS NOT NULL)                   AS errored
 		FROM outbox_events
 		WHERE published_at IS NULL`, asOf).Scan(&out).Error
 	if err != nil {

--- a/services/marketplace-api/internal/handlers/platformadmin/health_checks_integration_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/health_checks_integration_test.go
@@ -178,3 +178,52 @@ func TestStripeWebhooksCountsUnprocessedAndManualReview(t *testing.T) {
 		"a flagged row that has been processed is resolved and must not count")
 	require.Equal(t, int64(1200), got.OldestUnprocessedAgeSeconds)
 }
+
+// A terminally-failed row is NOT pending. If it counted as pending, the
+// first one would put /admin/health into a degraded state that never
+// clears, because oldest_pending_age_seconds would grow forever.
+func TestOutboxHealthExcludesFailedRowsFromPendingAndAge(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	src := platformadmin.NewDBHealthSource(db)
+	tenant := uuid.NewString()
+
+	// Failed and very old: must not count as pending, and must not drive
+	// the age.
+	require.NoError(t, db.Exec(`INSERT INTO outbox_events
+		(tenant_id, aggregate, aggregate_id, event_type, payload, created_at, error)
+		VALUES (?, 'product', ?, 'product.created', '{}'::jsonb, ?, 'payload_unparseable')`,
+		tenant, uuid.NewString(), healthAsOf.Add(-72*time.Hour)).Error)
+
+	// Genuinely pending, 5 minutes old.
+	require.NoError(t, db.Exec(`INSERT INTO outbox_events
+		(tenant_id, aggregate, aggregate_id, event_type, payload, created_at)
+		VALUES (?, 'product', ?, 'product.created', '{}'::jsonb, ?)`,
+		tenant, uuid.NewString(), healthAsOf.Add(-5*time.Minute)).Error)
+
+	got, err := src.Outbox(context.Background(), healthAsOf)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), got.Pending, "a failed row must not count as pending")
+	require.Equal(t, int64(1), got.Errored, "the failed row must be counted as errored")
+	require.Equal(t, int64(300), got.OldestPendingAgeSeconds,
+		"age must ignore failed rows, or the alarm never clears")
+}
+
+// Errored counts only unpublished failures. A published row is settled
+// whatever its error column happens to hold.
+func TestOutboxHealthErroredIsZeroWhenNoFailedRows(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	src := platformadmin.NewDBHealthSource(db)
+	tenant := uuid.NewString()
+
+	published := healthAsOf.Add(-time.Hour)
+	require.NoError(t, db.Exec(`INSERT INTO outbox_events
+		(tenant_id, aggregate, aggregate_id, event_type, payload, created_at, published_at)
+		VALUES (?, 'product', ?, 'product.created', '{}'::jsonb, ?, ?)`,
+		tenant, uuid.NewString(), published, published).Error)
+
+	got, err := src.Outbox(context.Background(), healthAsOf)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got.Pending)
+	require.Equal(t, int64(0), got.Errored)
+	require.Equal(t, int64(0), got.OldestPendingAgeSeconds)
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/health_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/health_test.go
@@ -48,7 +48,7 @@ func (s *stubHealthSource) StripeWebhooks(context.Context, time.Time) (platforma
 // and the assertions here cannot drift apart.
 func healthFixture() *stubHealthSource {
 	return &stubHealthSource{
-		outbox:   platformadmin.OutboxHealth{Pending: 7, OldestPendingAgeSeconds: 400},
+		outbox:   platformadmin.OutboxHealth{Pending: 7, OldestPendingAgeSeconds: 400, Errored: 3},
 		csv:      platformadmin.CSVJobsHealth{Queued: 5, RunningStaleHeartbeat: 2},
 		campaign: platformadmin.CampaignSendsHealth{Sending: 9, SendingStaleHeartbeat: 4},
 		stripe: platformadmin.StripeWebhooksHealth{
@@ -334,4 +334,34 @@ func TestHealthNilDatabaseReportsUnknownNotFabricatedOK(t *testing.T) {
 	}
 	require.Equal(t, 4, seenInstrumented, "expected four instrumented dependencies")
 	require.Equal(t, 5, seenUninstrumented, "expected five uninstrumented dependencies")
+}
+
+// An errored row degrades regardless of age. This alarm does not clear by
+// draining — only by an operator resolving the row — which is the correct
+// shape for a condition that requires a human, and the same shape
+// csv_import_jobs already uses for RunningStaleHeartbeat.
+func TestOutboxDegradesOnErroredEvenWhenNothingIsPending(t *testing.T) {
+	_, body := getHealth(t, &stubHealthSource{
+		outbox: platformadmin.OutboxHealth{Pending: 0, OldestPendingAgeSeconds: 0, Errored: 1},
+	})
+	dep := body.Data.Dependencies[0]
+	require.Equal(t, "outbox", dep.Name)
+	require.Equal(t, "degraded", dep.Status,
+		"a terminally-failed event must degrade even with an empty pending queue")
+	require.Equal(t, int64(1), dep.Metrics["errored"])
+	require.Equal(t, int64(0), dep.Metrics["pending"])
+}
+
+func TestOutboxIsOKWhenNothingErroredAndBacklogIsYoung(t *testing.T) {
+	_, body := getHealth(t, &stubHealthSource{
+		outbox: platformadmin.OutboxHealth{
+			Pending:                 3,
+			OldestPendingAgeSeconds: int64(platformadmin.OutboxPendingThreshold/time.Second) - 1,
+			Errored:                 0,
+		},
+	})
+	dep := body.Data.Dependencies[0]
+	require.Equal(t, "outbox", dep.Name)
+	require.Equal(t, "ok", dep.Status)
+	require.Equal(t, int64(0), dep.Metrics["errored"])
 }

--- a/services/marketplace-api/internal/handlers/platformadmin/testdata/health_response.json
+++ b/services/marketplace-api/internal/handlers/platformadmin/testdata/health_response.json
@@ -3,7 +3,7 @@
     "checked_at": "PINNED",
     "dependencies": [
       { "name": "outbox", "status": "degraded",
-        "metrics": { "pending": 7, "oldest_pending_age_seconds": 400 } },
+        "metrics": { "pending": 7, "oldest_pending_age_seconds": 400, "errored": 3 } },
       { "name": "csv_import_jobs", "status": "degraded",
         "metrics": { "queued": 5, "running_stale_heartbeat": 2 } },
       { "name": "campaign_sends", "status": "degraded",

--- a/services/marketplace-api/internal/outbox/models.go
+++ b/services/marketplace-api/internal/outbox/models.go
@@ -1,7 +1,16 @@
 // Package outbox holds the OutboxEvent model. Events are written in the
 // same transaction as the mutation that produces them (see spec §13.2.7).
-// Slice 1's publisher reads these rows, upserts store_watermarks, and
-// marks them published. Slice 2 adds real Pub/Sub delivery.
+// Slice 1's publisher reads these rows, upserts store_watermarks, and marks
+// them published. Slice 2 adds real Pub/Sub delivery.
+//
+// A row is in one of three states, all derived from existing columns:
+//
+//	pending    published_at IS NULL AND error IS NULL
+//	failed     published_at IS NULL AND error IS NOT NULL   (terminal)
+//	published  published_at IS NOT NULL
+//
+// failed is terminal: ProcessBatch's poll excludes it, so it is never
+// retried. Clearing error requeues the row. See #336.
 package outbox
 
 import (

--- a/services/marketplace-api/internal/outbox/models.go
+++ b/services/marketplace-api/internal/outbox/models.go
@@ -61,6 +61,28 @@ const (
 	EventAbandonedCartRecoveryEmail = "abandoned_cart.recovery_email"
 )
 
+// Failure reason codes written to outbox_events.error when the publisher
+// cannot process a row. This vocabulary is CLOSED and the values are
+// STABLE: #331 serves this column cross-tenant to the platform console,
+// and a stable code is what lets the console render it.
+//
+// A raw error string must NEVER be stored here. encoding/json quotes the
+// offending input in its unmarshal errors, so persisting err.Error() would
+// copy fragments of an arbitrary customer-data JSONB payload into a column
+// that leaves this service — defeating the same reasoning that keeps
+// `payload` out of #331's response, through a field nobody would audit.
+const (
+	ReasonPayloadUnparseable    = "payload_unparseable"
+	ReasonPayloadMissingStoreID = "payload_missing_store_id"
+)
+
+// Failure is one row the publisher could not process, paired with the
+// reason code to persist. See MarkFailedInTx.
+type Failure struct {
+	ID     string
+	Reason string
+}
+
 // IsOrderAggregate reports whether an aggregate string belongs to the orders
 // domain. The watermark publisher uses this to decide which store_watermarks
 // column to bump (orders_updated_at vs products_updated_at).

--- a/services/marketplace-api/internal/outbox/models.go
+++ b/services/marketplace-api/internal/outbox/models.go
@@ -74,6 +74,12 @@ const (
 const (
 	ReasonPayloadUnparseable    = "payload_unparseable"
 	ReasonPayloadMissingStoreID = "payload_missing_store_id"
+	// ReasonUnknown is written when a caller supplies a reason outside this
+	// vocabulary. It exists so MarkFailedInTx can neutralise an unrecognised
+	// string WITHOUT failing the batch: returning an error there would roll
+	// back the publisher's transaction, leaving the offending rows pending
+	// and re-selected forever — the exact poison pill this work removes.
+	ReasonUnknown = "unknown"
 )
 
 // Failure is one row the publisher could not process, paired with the

--- a/services/marketplace-api/internal/outbox/models.go
+++ b/services/marketplace-api/internal/outbox/models.go
@@ -10,7 +10,13 @@
 //	published  published_at IS NOT NULL
 //
 // failed is terminal: ProcessBatch's poll excludes it, so it is never
-// retried. Clearing error requeues the row. See #336.
+// retried. Clearing error re-enters the row into the poll, but that alone
+// is NOT recovery: the watermark upsert is monotonic (GREATEST) over the
+// row's ORIGINAL created_at, so a row that sat failed while later events
+// published for the same store will publish without moving the watermark —
+// no consumer learns, and the health alarm clears. Recovery for a stale row
+// is a fresh enqueue (or bumping created_at alongside clearing error).
+// See #336.
 package outbox
 
 import (

--- a/services/marketplace-api/internal/outbox/publisher.go
+++ b/services/marketplace-api/internal/outbox/publisher.go
@@ -14,9 +14,12 @@ import (
 // See spec §14.1 (watermark separation) and §14.6 (publisher semantics).
 //
 // Payload invariant: every outbox row in slice 1 carries a "store_id" key
-// at the top level of its JSON payload. Rows without it are logged and
-// marked published without a watermark bump — losing the signal is
-// preferable to blocking the publisher on a producer bug.
+// at the top level of its JSON payload. A row without it, or with a payload
+// that will not unmarshal, is logged and marked FAILED — error is set, and
+// published_at is left NULL. It never blocks the publisher (the original
+// reason for dropping it) and it is never retried (both causes are
+// deterministic properties of the row), but it is no longer recorded as a
+// successful publish. See #336; the failed state is served by #331.
 type Publisher struct {
 	repo     Repository
 	db       *gorm.DB
@@ -91,24 +94,31 @@ func (p *Publisher) Tick(ctx context.Context) (int, error) {
 		}
 		byBucket := map[key]time.Time{}
 		ids := make([]string, 0, len(rows))
+		failures := make([]Failure, 0)
 		for _, r := range rows {
-			ids = append(ids, r.ID)
 			var payload map[string]any
 			if err := json.Unmarshal(r.Payload, &payload); err != nil {
 				if p.logger != nil {
-					p.logger.Warn("outbox publisher: unparseable payload; dropping",
+					p.logger.Warn("outbox publisher: unparseable payload; failing",
 						"event_id", r.ID, "err", err)
 				}
+				failures = append(failures, Failure{ID: r.ID, Reason: ReasonPayloadUnparseable})
 				continue
 			}
 			sid, _ := payload["store_id"].(string)
 			if sid == "" {
 				if p.logger != nil {
-					p.logger.Warn("outbox publisher: payload missing store_id; dropping",
+					p.logger.Warn("outbox publisher: payload missing store_id; failing",
 						"event_id", r.ID, "event_type", r.EventType)
 				}
+				failures = append(failures, Failure{ID: r.ID, Reason: ReasonPayloadMissingStoreID})
 				continue
 			}
+			// Appended only now: a row reaches this line exactly when it is
+			// going to contribute a watermark bump. Appending before the
+			// checks above is what made a dropped event indistinguishable
+			// from a published one (#336).
+			ids = append(ids, r.ID)
 			axis := "products"
 			if IsOrderAggregate(r.Aggregate) {
 				axis = "orders"
@@ -141,6 +151,11 @@ func (p *Publisher) Tick(ctx context.Context) (int, error) {
 			if err := tx.Exec(stmt, k.storeID, ts).Error; err != nil {
 				return err
 			}
+		}
+		// Both marks run in the SAME transaction as the watermark bumps
+		// above, so a batch's outcome commits whole or not at all.
+		if err := p.repo.MarkFailedInTx(tx, failures); err != nil {
+			return err
 		}
 		return p.repo.MarkPublishedInTx(tx, ids)
 	})

--- a/services/marketplace-api/internal/outbox/publisher_integration_test.go
+++ b/services/marketplace-api/internal/outbox/publisher_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,10 +25,15 @@ func quietLogger() *slog.Logger {
 
 func insertStore(t *testing.T, db *gorm.DB, id, tenantID string) {
 	t.Helper()
+	// storefront_customer_portal_secret is char(64) NOT NULL with no default
+	// and no Go hook — callers set it explicitly (internal/stores/models.go).
+	// Omitting it made every test using this helper fail at INSERT.
 	err := db.Exec(`
-		INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, synced_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, now())`,
-		id, tenantID, "test-"+id[:8], "Test Store", "US", "USD", "UTC", "active").Error
+		INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status,
+		                    storefront_customer_portal_secret, synced_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, now())`,
+		id, tenantID, "test-"+id[:8], "Test Store", "US", "USD", "UTC", "active",
+		strings.Repeat("0", 64)).Error
 	if err != nil {
 		t.Fatalf("insertStore: %v", err)
 	}

--- a/services/marketplace-api/internal/outbox/publisher_integration_test.go
+++ b/services/marketplace-api/internal/outbox/publisher_integration_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"strings"
 	"testing"
 	"time"
 
@@ -31,9 +30,8 @@ func insertStore(t *testing.T, db *gorm.DB, id, tenantID string) {
 	err := db.Exec(`
 		INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status,
 		                    storefront_customer_portal_secret, synced_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, now())`,
-		id, tenantID, "test-"+id[:8], "Test Store", "US", "USD", "UTC", "active",
-		strings.Repeat("0", 64)).Error
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, encode(gen_random_bytes(32), 'hex'), now())`,
+		id, tenantID, "test-"+id[:8], "Test Store", "US", "USD", "UTC", "active").Error
 	if err != nil {
 		t.Fatalf("insertStore: %v", err)
 	}

--- a/services/marketplace-api/internal/outbox/publisher_integration_test.go
+++ b/services/marketplace-api/internal/outbox/publisher_integration_test.go
@@ -171,7 +171,7 @@ func TestIntegration_Publisher_BatchMultipleEvents_MaxCreatedAt(t *testing.T) {
 	}
 }
 
-func TestIntegration_Publisher_MissingStoreID_DropFloor(t *testing.T) {
+func TestIntegration_Publisher_MissingStoreID_MarksFailedNotPublished(t *testing.T) {
 	db := testdb.NewDB(t, "outbox_events", "store_watermarks", "stores")
 	repo := outbox.NewRepository(db)
 
@@ -210,8 +210,14 @@ func TestIntegration_Publisher_MissingStoreID_DropFloor(t *testing.T) {
 	if err := db.First(&got, "id = ?", evt.ID).Error; err != nil {
 		t.Fatalf("reload: %v", err)
 	}
-	if got.PublishedAt == nil {
-		t.Fatalf("expected malformed event to still be marked published")
+	if got.PublishedAt != nil {
+		t.Fatalf("a dropped event must NOT be marked published, got published_at=%v", got.PublishedAt)
+	}
+	if got.Error == nil {
+		t.Fatalf("error is nil; want %q", outbox.ReasonPayloadMissingStoreID)
+	}
+	if *got.Error != outbox.ReasonPayloadMissingStoreID {
+		t.Fatalf("error = %q, want %q", *got.Error, outbox.ReasonPayloadMissingStoreID)
 	}
 
 	var n int64
@@ -245,5 +251,127 @@ func TestIntegration_Publisher_CleanShutdown(t *testing.T) {
 	case <-done:
 	case <-time.After(200 * time.Millisecond):
 		t.Fatalf("publisher did not shut down within 200ms")
+	}
+}
+
+func TestIntegration_Publisher_UnparseablePayload_MarksFailedNotPublished(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events", "store_watermarks", "stores")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	storeID := uuid.NewString()
+	insertStore(t, db, storeID, tenantID)
+
+	// jsonb rejects malformed JSON at insert, so the unparseable-to-Go
+	// value is a well-formed JSON scalar: valid jsonb, but not the object
+	// json.Unmarshal into map[string]any requires.
+	evt := &outbox.OutboxEvent{
+		TenantID:    tenantID,
+		Aggregate:   outbox.AggregateProduct,
+		AggregateID: uuid.NewString(),
+		EventType:   outbox.EventProductCreated,
+		Payload:     datatypes.JSON([]byte(`"not-an-object"`)),
+	}
+	if err := db.Create(evt).Error; err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	pub := outbox.New(outbox.Config{
+		Repo: repo, DB: db, Logger: quietLogger(),
+		Interval: 1 * time.Second, BatchSize: 100,
+	})
+	if _, err := pub.Tick(context.Background()); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	var got outbox.OutboxEvent
+	if err := db.First(&got, "id = ?", evt.ID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.PublishedAt != nil {
+		t.Fatalf("a dropped event must NOT be marked published, got published_at=%v", got.PublishedAt)
+	}
+	if got.Error == nil || *got.Error != outbox.ReasonPayloadUnparseable {
+		t.Fatalf("error = %v, want %q", got.Error, outbox.ReasonPayloadUnparseable)
+	}
+}
+
+// The mixed batch is the composition no single-purpose test constructs, and
+// it is the whole point of the fix: one good row and one bad row in the SAME
+// tick. The good row must publish AND bump its watermark; the bad row must
+// be failed AND left unpublished. A regression that reverted the id-building
+// inversion would still pass every single-row test in this file.
+func TestIntegration_Publisher_MixedBatch_PublishesGoodFailsBad(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events", "store_watermarks", "stores")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	storeID := uuid.NewString()
+	insertStore(t, db, storeID, tenantID)
+
+	good := enqueueForStore(t, db, tenantID, storeID)
+
+	bad := &outbox.OutboxEvent{
+		TenantID:    tenantID,
+		Aggregate:   outbox.AggregateProduct,
+		AggregateID: uuid.NewString(),
+		EventType:   outbox.EventProductUpdated,
+		Payload:     datatypes.JSON([]byte(`{"unrelated":"value"}`)),
+	}
+	if err := db.Create(bad).Error; err != nil {
+		t.Fatalf("enqueue bad: %v", err)
+	}
+
+	pub := outbox.New(outbox.Config{
+		Repo: repo, DB: db, Logger: quietLogger(),
+		Interval: 1 * time.Second, BatchSize: 100,
+	})
+	count, err := pub.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("tick saw %d rows, want 2", count)
+	}
+
+	var gotGood outbox.OutboxEvent
+	if err := db.First(&gotGood, "id = ?", good.ID).Error; err != nil {
+		t.Fatalf("reload good: %v", err)
+	}
+	if gotGood.PublishedAt == nil {
+		t.Fatalf("the good event must be published even when a bad one shares its batch")
+	}
+	if gotGood.Error != nil {
+		t.Fatalf("the good event must not be marked failed, got %q", *gotGood.Error)
+	}
+
+	var gotBad outbox.OutboxEvent
+	if err := db.First(&gotBad, "id = ?", bad.ID).Error; err != nil {
+		t.Fatalf("reload bad: %v", err)
+	}
+	if gotBad.PublishedAt != nil {
+		t.Fatalf("the bad event must NOT be published, got published_at=%v", gotBad.PublishedAt)
+	}
+	if gotBad.Error == nil || *gotBad.Error != outbox.ReasonPayloadMissingStoreID {
+		t.Fatalf("bad event error = %v, want %q", gotBad.Error, outbox.ReasonPayloadMissingStoreID)
+	}
+
+	// The good row's watermark landed: the drop must not have suppressed it.
+	var n int64
+	if err := db.Raw(`SELECT count(*) FROM store_watermarks WHERE store_id = ?`, storeID).
+		Scan(&n).Error; err != nil {
+		t.Fatalf("count watermarks: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("watermark rows = %d, want 1", n)
+	}
+
+	// And the failed row is not retried on the next tick.
+	count, err = pub.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("second tick: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("second tick saw %d rows, want 0 (failed rows are terminal)", count)
 	}
 }

--- a/services/marketplace-api/internal/outbox/repository.go
+++ b/services/marketplace-api/internal/outbox/repository.go
@@ -10,12 +10,19 @@ import (
 // Repository is the data-access interface for outbox_events.
 type Repository interface {
 	EnqueueInTx(ctx context.Context, tx *gorm.DB, evt *OutboxEvent) error
-	// ProcessBatch opens its own transaction, locks up to `limit` unpublished
+	// ProcessBatch opens its own transaction, locks up to `limit` PENDING
 	// rows via FOR UPDATE SKIP LOCKED, and calls fn with the rows and the
 	// same tx. If fn returns nil the tx commits (the caller is expected to
 	// have called MarkPublishedInTx inside fn); if fn returns an error the
 	// tx rolls back and the rows become visible to the next poll. Returns
 	// the number of rows the callback saw.
+	//
+	// PENDING means published_at IS NULL *and* error IS NULL. A row with
+	// error set is terminal and is never re-selected — see MarkFailedInTx.
+	// The partial index outbox_unpublished_idx (migration 000001) is on
+	// published_at IS NULL; the error term is a filter on top of it, which
+	// is fine while failed rows are ~0. If they ever become common, that
+	// index is the thing to revisit.
 	ProcessBatch(ctx context.Context, limit int,
 		fn func(tx *gorm.DB, rows []OutboxEvent) error) (int, error)
 	MarkPublishedInTx(tx *gorm.DB, ids []string) error
@@ -54,7 +61,7 @@ func (r *gormRepository) ProcessBatch(ctx context.Context, limit int,
 			SELECT id, tenant_id, aggregate, aggregate_id, event_type,
 			       payload, created_at, published_at, error
 			FROM outbox_events
-			WHERE published_at IS NULL
+			WHERE published_at IS NULL AND error IS NULL
 			ORDER BY tenant_id, created_at
 			LIMIT ?
 			FOR UPDATE SKIP LOCKED`, limit).Scan(&rows).Error; err != nil {

--- a/services/marketplace-api/internal/outbox/repository.go
+++ b/services/marketplace-api/internal/outbox/repository.go
@@ -25,7 +25,10 @@ type Repository interface {
 	// operator action — clear error and the row re-enters the poll.
 	//
 	// Reason must be one of the Reason* constants in models.go, never a raw
-	// error string. See the comment on those constants.
+	// error string. Anything outside the vocabulary is recorded as ReasonUnknown
+	// to prevent raw error strings (which may contain customer-data JSONB) from
+	// reaching a column served cross-tenant to the platform console. See the
+	// comment on those constants.
 	MarkFailedInTx(tx *gorm.DB, failures []Failure) error
 }
 
@@ -77,16 +80,38 @@ func (r *gormRepository) MarkPublishedInTx(tx *gorm.DB, ids []string) error {
 	return nil
 }
 
+// sanitizeReason is the ONLY gate between a caller's string and the error
+// column. Anything outside the closed vocabulary becomes ReasonUnknown, so a
+// raw err.Error() — which encoding/json fills with fragments of the offending
+// payload — cannot reach a column that is served cross-tenant to the console
+// (#331), even if a future caller passes one by mistake. The interface comment
+// says "never a raw error string"; this is what makes that true rather than
+// advisory.
+func sanitizeReason(reason string) string {
+	switch reason {
+	case ReasonPayloadUnparseable, ReasonPayloadMissingStoreID:
+		return reason
+	default:
+		return ReasonUnknown
+	}
+}
+
 func (r *gormRepository) MarkFailedInTx(tx *gorm.DB, failures []Failure) error {
 	if len(failures) == 0 {
 		return nil
 	}
-	// Grouped by reason so this is one statement per DISTINCT reason (two,
-	// today) rather than one per row. Map iteration order is unspecified
-	// and irrelevant: the id sets are disjoint, so the statements commute.
 	byReason := make(map[string][]string, len(failures))
+	seen := make(map[string]struct{}, len(failures))
 	for _, f := range failures {
-		byReason[f.Reason] = append(byReason[f.Reason], f.ID)
+		// First occurrence of an id wins. Without this, one id appearing under
+		// two reasons lands in two UPDATE groups and the surviving value
+		// depends on Go's randomised map iteration order.
+		if _, dup := seen[f.ID]; dup {
+			continue
+		}
+		seen[f.ID] = struct{}{}
+		r := sanitizeReason(f.Reason)
+		byReason[r] = append(byReason[r], f.ID)
 	}
 	for reason, ids := range byReason {
 		if err := tx.Exec(`UPDATE outbox_events SET error = ? WHERE id IN ?`,

--- a/services/marketplace-api/internal/outbox/repository.go
+++ b/services/marketplace-api/internal/outbox/repository.go
@@ -29,7 +29,10 @@ type Repository interface {
 	// MarkFailedInTx records why the publisher could not process each row,
 	// leaving published_at NULL. A row with error set is TERMINAL: the poll
 	// in ProcessBatch excludes it, so it is never retried. Requeueing is an
-	// operator action — clear error and the row re-enters the poll.
+	// operator action — clearing error re-enters the row into the poll.
+	// Note that is re-entry, not recovery: the watermark is monotonic over
+	// the row's original created_at, so a stale row publishes without moving
+	// it. See the package doc in models.go.
 	//
 	// Reason must be one of the Reason* constants in models.go, never a raw
 	// error string. Anything outside the vocabulary is recorded as ReasonUnknown

--- a/services/marketplace-api/internal/outbox/repository.go
+++ b/services/marketplace-api/internal/outbox/repository.go
@@ -19,6 +19,14 @@ type Repository interface {
 	ProcessBatch(ctx context.Context, limit int,
 		fn func(tx *gorm.DB, rows []OutboxEvent) error) (int, error)
 	MarkPublishedInTx(tx *gorm.DB, ids []string) error
+	// MarkFailedInTx records why the publisher could not process each row,
+	// leaving published_at NULL. A row with error set is TERMINAL: the poll
+	// in ProcessBatch excludes it, so it is never retried. Requeueing is an
+	// operator action — clear error and the row re-enters the poll.
+	//
+	// Reason must be one of the Reason* constants in models.go, never a raw
+	// error string. See the comment on those constants.
+	MarkFailedInTx(tx *gorm.DB, failures []Failure) error
 }
 
 type gormRepository struct {
@@ -65,6 +73,26 @@ func (r *gormRepository) MarkPublishedInTx(tx *gorm.DB, ids []string) error {
 	if err := tx.Exec(`UPDATE outbox_events SET published_at = now() WHERE id IN ?`,
 		ids).Error; err != nil {
 		return fmt.Errorf("outbox: mark published: %w", err)
+	}
+	return nil
+}
+
+func (r *gormRepository) MarkFailedInTx(tx *gorm.DB, failures []Failure) error {
+	if len(failures) == 0 {
+		return nil
+	}
+	// Grouped by reason so this is one statement per DISTINCT reason (two,
+	// today) rather than one per row. Map iteration order is unspecified
+	// and irrelevant: the id sets are disjoint, so the statements commute.
+	byReason := make(map[string][]string, len(failures))
+	for _, f := range failures {
+		byReason[f.Reason] = append(byReason[f.Reason], f.ID)
+	}
+	for reason, ids := range byReason {
+		if err := tx.Exec(`UPDATE outbox_events SET error = ? WHERE id IN ?`,
+			reason, ids).Error; err != nil {
+			return fmt.Errorf("outbox: mark failed: %w", err)
+		}
 	}
 	return nil
 }

--- a/services/marketplace-api/internal/outbox/repository_integration_test.go
+++ b/services/marketplace-api/internal/outbox/repository_integration_test.go
@@ -244,3 +244,96 @@ func TestIntegration_ProcessBatch_Ordering(t *testing.T) {
 		}
 	}
 }
+
+func TestIntegration_MarkFailedInTx_SetsReasonAndLeavesUnpublished(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	bad := makeEvent(tenantID)
+	good := makeEvent(tenantID)
+	enqueueCommitted(t, db, bad)
+	enqueueCommitted(t, db, good)
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return repo.MarkFailedInTx(tx, []outbox.Failure{
+			{ID: bad.ID, Reason: outbox.ReasonPayloadUnparseable},
+		})
+	})
+	if err != nil {
+		t.Fatalf("MarkFailedInTx: %v", err)
+	}
+
+	var got outbox.OutboxEvent
+	if err := db.First(&got, "id = ?", bad.ID).Error; err != nil {
+		t.Fatalf("reload failed row: %v", err)
+	}
+	if got.Error == nil {
+		t.Fatalf("error is nil; want %q", outbox.ReasonPayloadUnparseable)
+	}
+	// Assert the EXACT code, not merely non-nil: a stub returns the zero
+	// value for a field nobody set.
+	if *got.Error != outbox.ReasonPayloadUnparseable {
+		t.Fatalf("error = %q, want %q", *got.Error, outbox.ReasonPayloadUnparseable)
+	}
+	if got.PublishedAt != nil {
+		t.Fatalf("a failed row must stay unpublished, got published_at=%v", got.PublishedAt)
+	}
+
+	var untouched outbox.OutboxEvent
+	if err := db.First(&untouched, "id = ?", good.ID).Error; err != nil {
+		t.Fatalf("reload untouched row: %v", err)
+	}
+	if untouched.Error != nil {
+		t.Fatalf("unrelated row was marked failed: %q", *untouched.Error)
+	}
+}
+
+func TestIntegration_MarkFailedInTx_GroupsDistinctReasons(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	unparseable := makeEvent(tenantID)
+	missingStore := makeEvent(tenantID)
+	enqueueCommitted(t, db, unparseable)
+	enqueueCommitted(t, db, missingStore)
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return repo.MarkFailedInTx(tx, []outbox.Failure{
+			{ID: unparseable.ID, Reason: outbox.ReasonPayloadUnparseable},
+			{ID: missingStore.ID, Reason: outbox.ReasonPayloadMissingStoreID},
+		})
+	})
+	if err != nil {
+		t.Fatalf("MarkFailedInTx: %v", err)
+	}
+
+	for _, tc := range []struct {
+		id   string
+		want string
+	}{
+		{unparseable.ID, outbox.ReasonPayloadUnparseable},
+		{missingStore.ID, outbox.ReasonPayloadMissingStoreID},
+	} {
+		var got outbox.OutboxEvent
+		if err := db.First(&got, "id = ?", tc.id).Error; err != nil {
+			t.Fatalf("reload %s: %v", tc.id, err)
+		}
+		if got.Error == nil || *got.Error != tc.want {
+			t.Fatalf("row %s error = %v, want %q", tc.id, got.Error, tc.want)
+		}
+	}
+}
+
+func TestIntegration_MarkFailedInTx_EmptyIsNoOp(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	repo := outbox.NewRepository(db)
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return repo.MarkFailedInTx(tx, nil)
+	})
+	if err != nil {
+		t.Fatalf("empty MarkFailedInTx must be a no-op, got: %v", err)
+	}
+}

--- a/services/marketplace-api/internal/outbox/repository_integration_test.go
+++ b/services/marketplace-api/internal/outbox/repository_integration_test.go
@@ -401,3 +401,76 @@ func TestIntegration_MarkFailedInTx_DuplicateIDFirstReasonWins(t *testing.T) {
 		t.Fatalf("error = %v, want %q (first occurrence wins)", got.Error, outbox.ReasonPayloadUnparseable)
 	}
 }
+
+// A row with error set is TERMINAL. This is the poison-pill proof: nothing
+// else in the suite exercises the poll's error IS NULL term, which exists
+// precisely so a permanently-failing row cannot be re-selected forever and
+// starve real events out of the batch window.
+func TestIntegration_ProcessBatch_SkipsFailedRows(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	failed := makeEvent(tenantID)
+	fresh := makeEvent(tenantID)
+	enqueueCommitted(t, db, failed)
+	enqueueCommitted(t, db, fresh)
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return repo.MarkFailedInTx(tx, []outbox.Failure{
+			{ID: failed.ID, Reason: outbox.ReasonPayloadUnparseable},
+		})
+	}); err != nil {
+		t.Fatalf("seed failed row: %v", err)
+	}
+
+	var seen []string
+	count, err := repo.ProcessBatch(context.Background(), 10,
+		func(tx *gorm.DB, rows []outbox.OutboxEvent) error {
+			for _, r := range rows {
+				seen = append(seen, r.ID)
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("ProcessBatch: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("ProcessBatch saw %d rows, want 1 (the failed row must be skipped)", count)
+	}
+	if len(seen) != 1 || seen[0] != fresh.ID {
+		t.Fatalf("ProcessBatch saw %v, want only the un-failed row %s", seen, fresh.ID)
+	}
+}
+
+// Clearing error is the documented requeue path for an operator. It must
+// actually work, or "terminal" means "lost".
+func TestIntegration_ProcessBatch_ClearingErrorRequeues(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	evt := makeEvent(tenantID)
+	enqueueCommitted(t, db, evt)
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return repo.MarkFailedInTx(tx, []outbox.Failure{
+			{ID: evt.ID, Reason: outbox.ReasonPayloadMissingStoreID},
+		})
+	}); err != nil {
+		t.Fatalf("seed failed row: %v", err)
+	}
+
+	if err := db.Exec(`UPDATE outbox_events SET error = NULL WHERE id = ?`, evt.ID).Error; err != nil {
+		t.Fatalf("clear error: %v", err)
+	}
+
+	count, err := repo.ProcessBatch(context.Background(), 10,
+		func(tx *gorm.DB, rows []outbox.OutboxEvent) error { return nil })
+	if err != nil {
+		t.Fatalf("ProcessBatch: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("ProcessBatch saw %d rows, want 1 after error was cleared", count)
+	}
+}

--- a/services/marketplace-api/internal/outbox/repository_integration_test.go
+++ b/services/marketplace-api/internal/outbox/repository_integration_test.go
@@ -5,6 +5,7 @@ package outbox_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -335,5 +336,68 @@ func TestIntegration_MarkFailedInTx_EmptyIsNoOp(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("empty MarkFailedInTx must be a no-op, got: %v", err)
+	}
+}
+
+func TestIntegration_MarkFailedInTx_CoercesUnrecognisedReason(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	evt := makeEvent(tenantID)
+	enqueueCommitted(t, db, evt)
+
+	// Shaped like a real encoding/json error: it quotes the offending input,
+	// which is exactly how customer payload data would reach this column.
+	raw := `json: cannot unmarshal string into Go value of type map[string]interface {} "acme-secret-sku"`
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return repo.MarkFailedInTx(tx, []outbox.Failure{{ID: evt.ID, Reason: raw}})
+	}); err != nil {
+		t.Fatalf("MarkFailedInTx: %v", err)
+	}
+
+	var got outbox.OutboxEvent
+	if err := db.First(&got, "id = ?", evt.ID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.Error == nil {
+		t.Fatalf("error is nil; want %q", outbox.ReasonUnknown)
+	}
+	if *got.Error != outbox.ReasonUnknown {
+		t.Fatalf("error = %q, want %q", *got.Error, outbox.ReasonUnknown)
+	}
+	if strings.Contains(*got.Error, "acme-secret-sku") {
+		t.Fatalf("payload fragment leaked into outbox_events.error: %q", *got.Error)
+	}
+	if got.PublishedAt != nil {
+		t.Fatalf("a failed row must stay unpublished, got published_at=%v", got.PublishedAt)
+	}
+}
+
+func TestIntegration_MarkFailedInTx_DuplicateIDFirstReasonWins(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	evt := makeEvent(tenantID)
+	enqueueCommitted(t, db, evt)
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return repo.MarkFailedInTx(tx, []outbox.Failure{
+			{ID: evt.ID, Reason: outbox.ReasonPayloadUnparseable},
+			{ID: evt.ID, Reason: outbox.ReasonPayloadMissingStoreID},
+		})
+	}); err != nil {
+		t.Fatalf("MarkFailedInTx: %v", err)
+	}
+
+	var got outbox.OutboxEvent
+	if err := db.First(&got, "id = ?", evt.ID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	// Deterministic: the FIRST entry wins, regardless of map iteration order.
+	if got.Error == nil || *got.Error != outbox.ReasonPayloadUnparseable {
+		t.Fatalf("error = %v, want %q (first occurrence wins)", got.Error, outbox.ReasonPayloadUnparseable)
 	}
 }


### PR DESCRIPTION
Closes #336.

## The bug

`Publisher.Tick` appended every row's id to `ids` **before** its two validation checks, then called
`MarkPublishedInTx(tx, ids)` — so an event it dropped was recorded as a successful publish,
indistinguishable from a real one. Its watermark was never bumped, so the downstream consumer never
learned the aggregate changed, and the only trace was a `Warn` line nothing aggregates.

Separately, `outbox_events.error` was declared, selected by the poll, and **written by nothing** —
which is why #289 shipped `/admin/health` with no `errored` metric, and why #331's `failed` filter
(`published_at IS NULL AND error IS NOT NULL`) could never have matched a row.

## Measured before building

Production holds 688 outbox rows: **0 pending, 0 with `error` set, 0 with a payload missing
`store_id`**, one store, one watermark row, newest event 2026-07-30. **This defect has never
fired.** It is a latent fix — same class as #360 and #361 — not incident response.

## What changed

Three states derived from existing columns. **No migration.**

| state | predicate |
|---|---|
| `pending` | `published_at IS NULL AND error IS NULL` |
| `failed` | `published_at IS NULL AND error IS NOT NULL` (terminal) |
| `published` | `published_at IS NOT NULL` |

- **`internal/outbox/publisher.go`** — `ids` is built only from rows that actually contribute a
  watermark bump; dropped rows are collected and marked failed in the *same* transaction.
- **`internal/outbox/repository.go`** — new `MarkFailedInTx`; the poll narrows to
  `published_at IS NULL AND error IS NULL` so a failed row is genuinely terminal rather than a
  poison pill re-selected every 2s forever.
- **`internal/outbox/models.go`** — a closed reason vocabulary. `sanitizeReason` coerces anything
  outside it to `unknown`, so a raw `err.Error()` cannot reach the column: `encoding/json` quotes
  the offending input in unmarshal errors, and #331 serves this column cross-tenant to the console.
  It coerces rather than erroring — returning an error would roll back the publisher's transaction
  and leave the offending rows pending forever, reintroducing the poison pill.
- **`internal/handlers/platformadmin/`** — `/admin/health` now counts `errored` separately from
  `pending` and degrades on `errored > 0`. Without this, the first failed row would sit at
  `published_at IS NULL` forever, inflating `oldest_pending_age_seconds` and pinning the
  estate-wide health surface to `degraded` — a false alarm shipped as a bug fix. The outer
  `WHERE published_at IS NULL` is kept so the partial index `outbox_unpublished_idx` still applies;
  the split is done with `FILTER` inside it.

`testdata/health_response.json` changes because the console's metrics map gains `errored`. That
golden file is the pinned contract, and breaking it is the deliberate signal that the contract moved.

## Testing

- **The mixed batch** — one good row and one bad row in the *same* tick, asserting the good row
  published *and* its watermark bumped, *and* the bad row errored *and* left unpublished. This is
  the composition no single-purpose test constructs.
- **The poison-pill proof** — two ticks; the errored row must not be re-selected on the second.
- Exact error codes asserted as strings, never `error IS NOT NULL`.
- A leak test asserting a raw json error containing a payload fragment cannot reach the column.

Full suite, branch vs `origin/main`, run sequentially against one shared DB: **packages 23 → 22,
tests 194 → 191. Zero packages and zero tests fail on this branch that do not fail on `origin/main`.**
`go vet -tags=integration` clean.

The reduction is expected: this branch also fixes the `insertStore` test helper, which omitted the
`char(64) NOT NULL` column `stores.storefront_customer_portal_secret` and had been failing three
tests at INSERT since that column landed.

## One contract correction worth reading

The recovery path is documented in three places as "clear `error` and the row re-enters the poll."
Whole-branch review caught that this is incomplete in a way that matters, so all three now say more.

The watermark upsert is monotonic — `GREATEST(existing, EXCLUDED)` where `EXCLUDED` is the row's
**original** `created_at`. An operator who clears `error` on a row that sat failed while later events
published for the same store gets the row published, `error` NULL, health back to `ok`, and the
watermark **unmoved**. No consumer learns — the exact silent divergence this PR exists to remove,
reintroduced through the recovery path, now with the alarm cleared too.

The code is right; monotonic watermarks are correct. Clearing `error` is **re-entry, not recovery**.
Recovering a stale row means a fresh enqueue, or bumping `created_at` alongside clearing `error`.
Note this is conditional: where no later events published for that store, the simple requeue is fine.

## Not in this PR

- **#331 `GET /admin/outbox`** — separate branch. This PR is what unblocks it.
- **Production verification.** The spec's §7 provoke-and-clean exercise runs after deploy: insert one
  synthetic malformed row, watch it get errored and *not* re-selected, confirm health degrades, then
  delete it and confirm health recovers. Production cannot produce a malformed row on its own, so
  this behaviour is unobservable by waiting.

## Follow-ups found while building, to be filed separately

1. **A third poison-pill cause this PR does not cover.** A payload with a well-formed `store_id`
   that does not exist in `stores` passes both checks, hits the watermark upsert, and the FK
   violation *aborts the Postgres transaction* — so the mark calls below it are unreachable by
   construction. The whole batch rolls back, good rows included, and those rows stay pending
   forever. Fixing it needs per-row savepoints or a store-existence pre-check, not a predicate
   change.
2. **`metrics.OutboxEventsPending` and `OutboxEventsPublishedTotal`** are registered and written by
   nothing — the same dead-declaration family as `outbox_events.error` was.
3. **`cmd/marketplace-api/main.go:1544-1546`** claims the storefront process produces no outbox
   events; `main.go:1226-1228` in the same file says the opposite and is correct.
4. **#331 must treat `error` as opaque.** The column is `text` with no `CHECK`; the vocabulary is
   Go-enforced only, and the requeue path is a manual `UPDATE`. Recorded in the spec.
