### PR TITLE
fix(outbox): close the last poison-pill cause, wire the dead metrics (#374, #375, #376)

### DIFF
--- a/docs/superpowers/plans/2026-08-26-outbox-followups.md
+++ b/docs/superpowers/plans/2026-08-26-outbox-followups.md
@@ -1,0 +1,615 @@
+# Outbox follow-ups (#374, #375, #376) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the three follow-ups found during #336's whole-branch review — the last poison-pill
+cause, the dead outbox metrics, and a comment that contradicts its own file.
+
+**Architecture:** #336 established that a deterministic, permanent property of an outbox row becomes
+a terminal `failed` state carrying a reason from a closed vocabulary. #374 extends that shape to a
+third cause (a `store_id` with no matching store) by checking store existence *before* the watermark
+upsert, rather than letting an FK violation abort the whole transaction. #375 wires the publish/fail
+counters and deletes a redundant gauge. #376 is a comment.
+
+**Tech Stack:** Go 1.26, GORM, Postgres 15, Prometheus client, build-tagged integration tests via
+`pkg/testdb`.
+
+**Spec:** `docs/superpowers/specs/2026-08-26-outbox-failure-state-design.md` — this plan extends its
+§2 state model with a fourth reason code. The three-state model itself is unchanged.
+
+## Global Constraints
+
+- Service root for every command: `/Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api`
+- Integration DSN — LAN IP, **never `localhost`**: `TEST_DATABASE_URL=postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable`
+- Integration tests require `-tags=integration` and `-count=1`. **Without the tag, build-tagged files are never compiled and the run is a false green.**
+- **Run whole packages, never a `-run`-scoped subset, for final GREEN evidence.**
+- Never pipe the measured `go test` — capture with `> file 2>&1` and report `$?` separately.
+- Module path: `github.com/mark8ly/marketplace-api`.
+- Commit messages: conventional commits, **single line**, no signatures.
+- **Do not push, open a PR, merge, or deploy.** Local commits on `fix/374-outbox-followups` only.
+- Branch base: `main` at `0fc2763f` (the #336 merge).
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `internal/outbox/models.go` | model + vocabulary | **Modify** — add `ReasonStoreNotFound` |
+| `internal/outbox/repository.go` | data access | **Modify** — add the new code to `sanitizeReason`'s allowlist |
+| `internal/outbox/publisher.go` | polling loop | **Modify** — track ids per store; store-existence pre-check; counters; document `Tick`'s return |
+| `internal/outbox/publisher_integration_test.go` | publisher tests | **Modify** — FK-row tests |
+| `internal/outbox/repository_integration_test.go` | repository tests | **Modify** — allowlist guard for the new code |
+| `internal/metrics/registry.go` | Prometheus definitions | **Modify** — delete the gauge, add a failed counter |
+| `cmd/marketplace-api/main.go` | wiring | **Modify** — one comment (#376) |
+| `docs/superpowers/specs/2026-08-26-outbox-failure-state-design.md` | the design doc | **Modify** — document the fourth reason code |
+
+---
+
+## Task 1: #374 — store-existence pre-check
+
+**Files:**
+- Modify: `internal/outbox/models.go`, `internal/outbox/repository.go`, `internal/outbox/publisher.go`
+- Modify: `docs/superpowers/specs/2026-08-26-outbox-failure-state-design.md`
+- Test: `internal/outbox/publisher_integration_test.go`, `internal/outbox/repository_integration_test.go`
+
+**Interfaces:**
+- Consumes: `Failure`, `MarkFailedInTx`, `sanitizeReason` (all from #336).
+- Produces: `outbox.ReasonStoreNotFound` (`string` const, `"store_not_found"`).
+
+**The trap in this task.** `sanitizeReason` (`repository.go`) coerces anything outside its allowlist
+to `ReasonUnknown`. **Adding the constant without adding it to that switch means every store-not-found
+row silently records `"unknown"`** — and the tests below are written to catch exactly that.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/outbox/publisher_integration_test.go`:
+
+```go
+// A store_id that is well-formed but absent from `stores` used to raise an FK
+// violation on the watermark upsert, which ABORTS the whole Postgres
+// transaction — taking the good rows and the failure marks with it and
+// leaving the entire batch pending forever. #374.
+func TestIntegration_Publisher_StoreNotFound_MarksFailedAndCommits(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events", "store_watermarks", "stores")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	ghostStoreID := uuid.NewString() // deliberately never inserted
+
+	evt := enqueueForStore(t, db, tenantID, ghostStoreID)
+
+	pub := outbox.New(outbox.Config{
+		Repo: repo, DB: db, Logger: quietLogger(),
+		Interval: 1 * time.Second, BatchSize: 100,
+	})
+	if _, err := pub.Tick(context.Background()); err != nil {
+		t.Fatalf("tick must not error on a missing store: %v", err)
+	}
+
+	var got outbox.OutboxEvent
+	if err := db.First(&got, "id = ?", evt.ID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.PublishedAt != nil {
+		t.Fatalf("a row for a missing store must not be published, got %v", got.PublishedAt)
+	}
+	if got.Error == nil {
+		t.Fatalf("error is nil; want %q", outbox.ReasonStoreNotFound)
+	}
+	// Exact code. If the constant was added but not allowlisted in
+	// sanitizeReason, this reads "unknown" and this line is what catches it.
+	if *got.Error != outbox.ReasonStoreNotFound {
+		t.Fatalf("error = %q, want %q", *got.Error, outbox.ReasonStoreNotFound)
+	}
+
+	var n int64
+	if err := db.Raw(`SELECT count(*) FROM store_watermarks`).Scan(&n).Error; err != nil {
+		t.Fatalf("count watermarks: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("watermark rows = %d, want 0", n)
+	}
+}
+
+// The composition that matters: one good row and one ghost-store row in the
+// SAME batch. Before #374 the FK violation rolled back BOTH.
+func TestIntegration_Publisher_StoreNotFound_DoesNotRollBackGoodRows(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events", "store_watermarks", "stores")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	realStoreID := uuid.NewString()
+	insertStore(t, db, realStoreID, tenantID)
+	ghostStoreID := uuid.NewString()
+
+	good := enqueueForStore(t, db, tenantID, realStoreID)
+	ghost := enqueueForStore(t, db, tenantID, ghostStoreID)
+
+	pub := outbox.New(outbox.Config{
+		Repo: repo, DB: db, Logger: quietLogger(),
+		Interval: 1 * time.Second, BatchSize: 100,
+	})
+	count, err := pub.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("tick saw %d rows, want 2", count)
+	}
+
+	var gotGood outbox.OutboxEvent
+	if err := db.First(&gotGood, "id = ?", good.ID).Error; err != nil {
+		t.Fatalf("reload good: %v", err)
+	}
+	if gotGood.PublishedAt == nil {
+		t.Fatalf("the good row must publish even when a ghost-store row shares its batch")
+	}
+	if gotGood.Error != nil {
+		t.Fatalf("the good row must not be failed, got %q", *gotGood.Error)
+	}
+
+	var gotGhost outbox.OutboxEvent
+	if err := db.First(&gotGhost, "id = ?", ghost.ID).Error; err != nil {
+		t.Fatalf("reload ghost: %v", err)
+	}
+	if gotGhost.PublishedAt != nil {
+		t.Fatalf("the ghost row must not be published, got %v", gotGhost.PublishedAt)
+	}
+	if gotGhost.Error == nil || *gotGhost.Error != outbox.ReasonStoreNotFound {
+		t.Fatalf("ghost row error = %v, want %q", gotGhost.Error, outbox.ReasonStoreNotFound)
+	}
+
+	// The real store's watermark landed — the FK row did not suppress it.
+	var n int64
+	if err := db.Raw(`SELECT count(*) FROM store_watermarks WHERE store_id = ?`, realStoreID).
+		Scan(&n).Error; err != nil {
+		t.Fatalf("count watermarks: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("watermark rows for the real store = %d, want 1", n)
+	}
+
+	// And nothing is retried.
+	count, err = pub.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("second tick: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("second tick saw %d rows, want 0", count)
+	}
+}
+```
+
+Append to `internal/outbox/repository_integration_test.go`:
+
+```go
+// Guard against adding a reason constant without allowlisting it in
+// sanitizeReason, which would silently record "unknown" instead.
+func TestIntegration_MarkFailedInTx_StoreNotFoundIsInTheVocabulary(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	evt := makeEvent(tenantID)
+	enqueueCommitted(t, db, evt)
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return repo.MarkFailedInTx(tx, []outbox.Failure{
+			{ID: evt.ID, Reason: outbox.ReasonStoreNotFound},
+		})
+	}); err != nil {
+		t.Fatalf("MarkFailedInTx: %v", err)
+	}
+
+	var got outbox.OutboxEvent
+	if err := db.First(&got, "id = ?", evt.ID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.Error == nil || *got.Error != outbox.ReasonStoreNotFound {
+		t.Fatalf("error = %v, want %q (is it in sanitizeReason's switch?)", got.Error, outbox.ReasonStoreNotFound)
+	}
+}
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -count=1 -run 'StoreNotFound' ./internal/outbox/ -v
+```
+
+Expected: **compile failure** — `undefined: outbox.ReasonStoreNotFound`.
+
+- [ ] **Step 3: Add the constant**
+
+In `internal/outbox/models.go`, add to the existing Reason const block, before `ReasonUnknown`:
+
+```go
+	// ReasonStoreNotFound is written when a payload's store_id is
+	// well-formed but has no matching row in `stores`. The watermark upsert
+	// would raise an FK violation (store_watermarks.store_id REFERENCES
+	// stores(id)), which ABORTS the whole transaction rather than failing
+	// one row — see #374. Permanent in practice: stores are removed only by
+	// tenant purge and hard-delete, both of which sweep this tenant's
+	// outbox_events too.
+	ReasonStoreNotFound = "store_not_found"
+```
+
+- [ ] **Step 4: Allowlist it — the step that is easy to miss**
+
+In `internal/outbox/repository.go`, add it to `sanitizeReason`'s switch:
+
+```go
+	case ReasonPayloadUnparseable, ReasonPayloadMissingStoreID, ReasonStoreNotFound:
+		return reason
+```
+
+- [ ] **Step 5: Track ids per store in `Tick`**
+
+In `internal/outbox/publisher.go`, replace the flat `ids` accumulation with a per-store map so a
+store's rows can be moved to `failures` wholesale once it is known to be missing.
+
+Replace:
+
+```go
+		ids := make([]string, 0, len(rows))
+		failures := make([]Failure, 0)
+```
+
+with:
+
+```go
+		idsByStore := make(map[string][]string, len(rows))
+		failures := make([]Failure, 0)
+```
+
+and replace the append line (the one whose comment begins "Appended only now"):
+
+```go
+			ids = append(ids, r.ID)
+```
+
+with:
+
+```go
+			idsByStore[sid] = append(idsByStore[sid], r.ID)
+```
+
+- [ ] **Step 6: Add the pre-check and rebuild `ids`**
+
+Still in `Tick`, insert this **between** the row loop and the `for k, ts := range byBucket` upsert
+loop:
+
+```go
+		// Store-existence pre-check (#374). store_watermarks.store_id is
+		// REFERENCES stores(id), so upserting a watermark for a store that
+		// does not exist raises an FK violation — and an FK violation ABORTS
+		// the Postgres transaction, so it does not fail one row, it takes the
+		// whole batch: the good rows, the failure marks, everything. Those
+		// rows then stay pending and are re-selected forever.
+		//
+		// Checking first turns that into a per-row terminal failure, the same
+		// shape as the other two causes. One extra SELECT per tick, and only
+		// when at least one row survived validation.
+		if len(idsByStore) > 0 {
+			storeIDs := make([]string, 0, len(idsByStore))
+			for sid := range idsByStore {
+				storeIDs = append(storeIDs, sid)
+			}
+			var found []struct{ ID string }
+			if err := tx.Raw(`SELECT id FROM stores WHERE id IN ?`, storeIDs).
+				Scan(&found).Error; err != nil {
+				return err
+			}
+			present := make(map[string]struct{}, len(found))
+			for _, f := range found {
+				present[f.ID] = struct{}{}
+			}
+			for sid, rowIDs := range idsByStore {
+				if _, ok := present[sid]; ok {
+					continue
+				}
+				if p.logger != nil {
+					p.logger.Warn("outbox publisher: store not found; failing",
+						"store_id", sid, "events", len(rowIDs))
+				}
+				for _, id := range rowIDs {
+					failures = append(failures, Failure{ID: id, Reason: ReasonStoreNotFound})
+				}
+				delete(idsByStore, sid)
+			}
+			// Drop every bucket whose store is gone, both axes.
+			for k := range byBucket {
+				if _, ok := present[k.storeID]; !ok {
+					delete(byBucket, k)
+				}
+			}
+		}
+
+		ids := make([]string, 0, len(rows))
+		for _, rowIDs := range idsByStore {
+			ids = append(ids, rowIDs...)
+		}
+```
+
+Deleting from a map while ranging over it is defined behaviour in Go — entries removed during
+iteration are simply not produced.
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -count=1 ./internal/outbox/ > /tmp/t374.txt 2>&1
+echo "exit=$?"
+tail -5 /tmp/t374.txt
+```
+
+Expected: whole package passes, including every #336 test.
+
+- [ ] **Step 8: Document the fourth code in the design doc**
+
+In `docs/superpowers/specs/2026-08-26-outbox-failure-state-design.md`, in the section listing the
+closed vocabulary (§3, "The failure reason is a closed vocabulary, never a raw error"), add
+`ReasonStoreNotFound = "store_not_found"` to the code block and one sentence of prose in the
+document's voice explaining that it covers the FK case #374 describes, and that it is terminal for
+the same reason the other two are — the condition is a permanent property of the row.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly
+git add services/marketplace-api/internal/outbox docs/superpowers/specs/2026-08-26-outbox-failure-state-design.md
+git commit -m "fix(outbox): fail rows whose store is missing instead of aborting the batch"
+```
+
+---
+
+## Task 2: #375 metrics and #376 comment
+
+Two independent small changes, batched because both are trivial and neither needs its own review
+surface. **Two separate commits.**
+
+**Files:**
+- Modify: `internal/metrics/registry.go`, `internal/outbox/publisher.go` (#375)
+- Modify: `cmd/marketplace-api/main.go` (#376)
+
+**Interfaces:**
+- Consumes: `ids` and `failures` from Task 1's `Tick`.
+- Produces: `metrics.OutboxEventsFailedTotal`. Removes `metrics.OutboxEventsPending`.
+
+**The correctness point in this task.** The counters must be incremented **after `ProcessBatch`
+returns nil**, never inside the callback. The callback runs inside a transaction that can roll back,
+and incrementing there would count work that never committed. A Prometheus counter cannot be
+decremented, so an over-count is permanent.
+
+- [ ] **Step 1: Delete the dead gauge, add a failed counter**
+
+In `internal/metrics/registry.go`, delete the whole `OutboxEventsPending` block:
+
+```go
+	// OutboxEventsPending tracks the current outbox queue depth.
+	OutboxEventsPending = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "outbox_events_pending",
+			Help: "Number of pending outbox events.",
+		},
+	)
+```
+
+and delete its line from the `prometheus.MustRegister(...)` list:
+
+```go
+		OutboxEventsPending,
+```
+
+Then add, immediately after the `OutboxEventsPublishedTotal` block:
+
+```go
+	// OutboxEventsFailedTotal counts outbox events the publisher gave up on.
+	// There is deliberately no pending GAUGE beside these two counters:
+	// /admin/health reports pending depth, oldest-pending age and errored
+	// count from a DB query, authoritatively, whereas a gauge set by the
+	// publisher would be reported identically by every replica running in
+	// admin or both mode — so any dashboard summing it would multiply.
+	OutboxEventsFailedTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "outbox_events_failed_total",
+			Help: "Total outbox events marked terminally failed by the publisher.",
+		},
+	)
+```
+
+and add `OutboxEventsFailedTotal,` to the `MustRegister` list where `OutboxEventsPending` was.
+
+- [ ] **Step 2: Wire the counters and document `Tick`'s return**
+
+In `internal/outbox/publisher.go`, add the metrics import
+(`"github.com/mark8ly/marketplace-api/internal/metrics"`) and restructure `Tick` so the counters are
+incremented only after a successful commit:
+
+```go
+func (p *Publisher) Tick(ctx context.Context) (int, error) {
+	var published, failed int
+	seen, err := p.repo.ProcessBatch(ctx, p.batch, func(tx *gorm.DB, rows []OutboxEvent) error {
+		// Reset per attempt: ProcessBatch's callback can run again, and a
+		// counter that survived a rolled-back attempt would over-count.
+		published, failed = 0, 0
+
+		// ... existing body unchanged, up to and including the two marks ...
+
+		published, failed = len(ids), len(failures)
+		if err := p.repo.MarkFailedInTx(tx, failures); err != nil {
+			return err
+		}
+		return p.repo.MarkPublishedInTx(tx, ids)
+	})
+	if err != nil {
+		return seen, err
+	}
+	// AFTER the commit, never inside the callback: the transaction can roll
+	// back, and a Prometheus counter cannot be decremented, so an over-count
+	// is permanent.
+	metrics.OutboxEventsPublishedTotal.Add(float64(published))
+	metrics.OutboxEventsFailedTotal.Add(float64(failed))
+	return seen, nil
+}
+```
+
+Keep the existing body of the callback exactly as Task 1 left it; only the wrapper changes.
+
+Then extend `Tick`'s doc comment with:
+
+```go
+// The returned int is the number of rows the poll SAW — not the number
+// published. Since #336 a batch can be entirely failed, so a non-zero return
+// says work was examined, not that anything was delivered. The
+// outbox_events_published_total and outbox_events_failed_total counters are
+// what separate those two outcomes.
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+go build ./... && echo "build ok"
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -count=1 ./internal/outbox/ > /tmp/t375.txt 2>&1
+echo "exit=$?"
+tail -3 /tmp/t375.txt
+grep -rn "OutboxEventsPending" --include=*.go . || echo "gauge fully removed"
+```
+
+Expected: build ok, package green, and no remaining reference to the deleted gauge (a leftover in
+`MustRegister` is a compile error, which is the point).
+
+- [ ] **Step 4: Commit #375**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly
+git add services/marketplace-api/internal/metrics/registry.go services/marketplace-api/internal/outbox/publisher.go
+git commit -m "feat(outbox): count published and failed events, drop the dead pending gauge"
+```
+
+- [ ] **Step 5: Fix the #376 comment**
+
+In `services/marketplace-api/cmd/marketplace-api/main.go`, replace:
+
+```go
+	// Outbox publisher — runs in admin and both modes; the storefront
+	// process does not produce events, so running it there would just poll
+	// an always-empty table and waste a connection.
+```
+
+with:
+
+```go
+	// Outbox publisher — runs in admin and both modes because admin owns
+	// draining, not because the storefront produces nothing. It does: public
+	// checkout in storefront mode writes outbox_events rows through
+	// orderSvcSF (see the Orders M5 wiring above), and this replica drains
+	// them. Running a second publisher there would duplicate the poll, not
+	// find an empty table.
+```
+
+- [ ] **Step 6: Verify and commit #376**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+go build ./... && echo "build ok"
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly
+git add services/marketplace-api/cmd/marketplace-api/main.go
+git commit -m "docs: correct the outbox publisher comment about storefront event production"
+```
+
+---
+
+## Task 3: Whole-branch verification
+
+**Files:** none modified — this task produces evidence.
+
+- [ ] **Step 1: Build-tagged compile check**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+go vet -tags=integration ./... > /tmp/vet374.txt 2>&1
+echo "exit=$?"
+tail -10 /tmp/vet374.txt
+```
+
+Expected: `exit=0`.
+
+- [ ] **Step 2: Capture the branch failing set**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly/services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 ./... > /tmp/fu-branch.txt 2>&1
+echo "go test exit=$?"
+grep -E '^FAIL\s+github' /tmp/fu-branch.txt | awk '{print $2}' | sort -u > /tmp/fu-branch-pkgs.txt
+wc -l < /tmp/fu-branch-pkgs.txt
+```
+
+- [ ] **Step 3: Compare against the merge base**
+
+The baseline is `main` at `0fc2763f`, which already contains #336. Its failing set was measured
+during that work at **22 packages / 191 tests**. Re-measure rather than trusting that number:
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly
+git worktree remove /tmp/m8-fu-baseline --force 2>/dev/null
+git worktree add /tmp/m8-fu-baseline 0fc2763f
+cd /tmp/m8-fu-baseline/services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 ./... > /tmp/fu-main.txt 2>&1
+echo "go test exit=$?"
+grep -E '^FAIL\s+github' /tmp/fu-main.txt | awk '{print $2}' | sort -u > /tmp/fu-main-pkgs.txt
+wc -l < /tmp/fu-main-pkgs.txt
+```
+
+**Run the two sequentially, never concurrently — they share one database** and would corrupt each
+other's fixtures, making both results meaningless.
+
+- [ ] **Step 4: Diff both directions**
+
+```bash
+echo ">>> failing on BRANCH but not on 0fc2763f (must be empty):"
+comm -13 /tmp/fu-main-pkgs.txt /tmp/fu-branch-pkgs.txt
+echo ">>> failing on 0fc2763f but not on BRANCH:"
+comm -23 /tmp/fu-main-pkgs.txt /tmp/fu-branch-pkgs.txt
+```
+
+Expected: the first list EMPTY. Unlike the #336 branch, no reduction is expected here either — this
+work fixes no pre-existing test. A package in the first list is a defect this branch introduced;
+**stop and report it, do not fix it silently.**
+
+- [ ] **Step 5: Clean up**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly
+git worktree remove /tmp/m8-fu-baseline --force
+git worktree list
+```
+
+- [ ] **Step 6: Record the evidence**
+
+Append a "Verification record" section to this plan file with both counts, the both-directions
+comparison, and the verdict. Commit:
+
+```bash
+git add docs/superpowers/plans/2026-08-26-outbox-followups.md
+git commit -m "docs: record the verification diff for the outbox follow-ups branch"
+```
+
+---
+
+## Not in this plan
+
+- **The #336 production verification exercise.** Still outstanding, separate, and requires explicit
+  go-ahead at the moment of the write.
+- **A `CHECK` constraint on `outbox_events.error`.** It would make the vocabulary a database
+  guarantee rather than a Go one, but it reopens the no-migration decision and would break the
+  manual-`UPDATE` requeue path. The design doc §5 already records that #331 must treat the column as
+  opaque, which is the mitigation.

--- a/docs/superpowers/plans/2026-08-26-outbox-followups.md
+++ b/docs/superpowers/plans/2026-08-26-outbox-followups.md
@@ -605,6 +605,29 @@ git commit -m "docs: record the verification diff for the outbox follow-ups bran
 
 ---
 
+## Verification record
+
+Executed 2026-08-26. Branch `fix/374-outbox-followups` at `cf20ea47f7f1ba27c5cc4fceebdd0bc8b7f996c9`,
+compared against baseline `main` at `0fc2763f6cdc3b3fdbaf04aa1cfe226d8e8bdace` (contains #336).
+
+- **`go vet -tags=integration ./...`** — `exit=0`, no output.
+- **Branch full-suite integration run** — `go test -tags=integration -p 1 ./...`, exit=1 (expected —
+  pre-existing failures). Failing set: **22 packages / 191 tests**.
+- **Baseline full-suite integration run** (`/tmp/m8-fu-baseline` worktree at `0fc2763f`) — same
+  command, exit=1. Failing set: **22 packages / 191 tests**.
+- **Both-directions package diff**:
+  - Failing on BRANCH but not on `0fc2763f`: empty.
+  - Failing on `0fc2763f` but not on BRANCH: empty.
+  - The two package lists are byte-identical.
+- **Test-name diff** (to rule out same-package-different-test drift): the 191 `--- FAIL:` test names
+  on each side are identical after stripping per-run timing suffixes; only timing values differed.
+
+**Verdict:** the branch introduced no new test failures and fixed none — the failing set is
+identical in both directions, as expected for a branch whose scope (#374, #375, #376) touches no
+code path covered by the pre-existing failures.
+
+---
+
 ## Not in this plan
 
 - **The #336 production verification exercise.** Still outstanding, separate, and requires explicit

--- a/docs/superpowers/specs/2026-04-10-production-readiness-design.md
+++ b/docs/superpowers/specs/2026-04-10-production-readiness-design.md
@@ -164,7 +164,7 @@ tax_calculation_fallback_total{provider}             counter
 
 # System metrics
 db_query_duration_seconds{operation}                 histogram
-outbox_events_pending                                gauge
+outbox_events_failed_total                           counter
 outbox_events_published_total                        counter
 ```
 

--- a/docs/superpowers/specs/2026-08-26-outbox-failure-state-design.md
+++ b/docs/superpowers/specs/2026-08-26-outbox-failure-state-design.md
@@ -296,14 +296,15 @@ Repeated for #331 after it deploys, to see the row as `status=failed`.
 
 ## 8. Found while reading, deliberately not in scope
 
-`metrics.OutboxEventsPending` and `metrics.OutboxEventsPublishedTotal` are declared **and
-registered** (`internal/metrics/registry.go:45,53,165-166`) and **written by nothing**. They are
-the same family of dead declaration as `outbox_events.error` itself, and as #322 and #323.
+**Done.** `metrics.OutboxEventsPending` and `metrics.OutboxEventsPublishedTotal` were declared and
+registered but written by nothing — the same family of dead declaration as `outbox_events.error`
+itself, and as #322 and #323. This was filed as its own issue, #375, and closed on this branch.
 
-Tempting to fix here, since the publisher is the only place that could set them. Kept out: it is a
-separate concern with its own contract question (what a gauge should read when the process holding
-it is one of several replicas), and bundling it would widen a correctness fix into an observability
-change. To be filed as its own issue.
+The gauge (`OutboxEventsPending`) was deleted rather than wired up: it is redundant with
+`/admin/health`, and a per-replica gauge would be reported identically by every replica running in
+`admin` or `both` mode, so any dashboard summing it across replicas would multiply the true value.
+`outbox_events_published_total` is now written by the publisher, and `outbox_events_failed_total`
+was added alongside it.
 
 Also out of scope: producer-side validation that would stop a malformed row being enqueued at all.
 Worth considering, but it is a different defence at a different layer, and it cannot help the rows

--- a/docs/superpowers/specs/2026-08-26-outbox-failure-state-design.md
+++ b/docs/superpowers/specs/2026-08-26-outbox-failure-state-design.md
@@ -107,7 +107,15 @@ predicate to `AND error IS NULL` is what makes "terminal" true rather than aspir
 ```
 ReasonPayloadUnparseable   = "payload_unparseable"
 ReasonPayloadMissingStoreID = "payload_missing_store_id"
+ReasonStoreNotFound        = "store_not_found"
 ```
+
+`ReasonStoreNotFound` (#374) covers a third row shape: a `store_id` that is well-formed and present
+but has no matching row in `stores`. Before this fix that row reached the watermark upsert and its
+FK violation (`store_watermarks.store_id REFERENCES stores(id)`) aborted the whole transaction,
+taking the batch's good rows and failure marks down with it. It is terminal for the same reason the
+other two are — a missing store is a permanent property of the row, not a transient condition to
+retry.
 
 **`err.Error()` must not be persisted.** `encoding/json`'s unmarshal errors quote the offending
 input, so storing the raw error would copy fragments of an arbitrary customer-data JSONB payload

--- a/scripts/ci/verify-dashboard-queries.sh
+++ b/scripts/ci/verify-dashboard-queries.sh
@@ -51,8 +51,16 @@ KNOWN_METRICS=(
     http_request_duration_seconds_sum
     orders_created_total
     webhook_received_total
-    outbox_events_pending
     outbox_events_published_total
+    outbox_events_failed_total
+    # RETAINED DELIBERATELY, NOT AN OVERSIGHT. The gauge was deleted from
+    # registry.go in #375 — nothing exports it any more. This entry stays only
+    # because tesserix-k8s/grafana/dashboards/webhook-pipeline.json still has a
+    # panel querying it, and this script validates that repo's dashboards
+    # against this list: removing the entry first would fail CI on a dashboard
+    # this repo cannot edit. Remove this line once that panel is repointed or
+    # deleted.
+    outbox_events_pending
     mark8ly_trial_signup_anomaly_alerts_total
     mark8ly_trial_activation_day30_total
     mark8ly_subscription_dunning_emails_sent_total

--- a/scripts/ci/verify-dashboard-queries.sh
+++ b/scripts/ci/verify-dashboard-queries.sh
@@ -59,7 +59,7 @@ KNOWN_METRICS=(
     # panel querying it, and this script validates that repo's dashboards
     # against this list: removing the entry first would fail CI on a dashboard
     # this repo cannot edit. Remove this line once that panel is repointed or
-    # deleted.
+    # deleted (tesserix-k8s#631).
     outbox_events_pending
     mark8ly_trial_signup_anomaly_alerts_total
     mark8ly_trial_activation_day30_total

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1542,9 +1542,12 @@ func main() {
 		log.Info("campaign: send worker started")
 	}
 
-	// Outbox publisher — runs in admin and both modes; the storefront
-	// process does not produce events, so running it there would just poll
-	// an always-empty table and waste a connection.
+	// Outbox publisher — runs in admin and both modes because admin owns
+	// draining, not because the storefront produces nothing. It does: public
+	// checkout in storefront mode writes outbox_events rows through
+	// orderSvcSF (see the Orders M5 wiring above), and this replica drains
+	// them. Running a second publisher there would duplicate the poll, not
+	// find an empty table.
 	publisherCtx, publisherCancel := context.WithCancel(context.Background())
 	defer publisherCancel()
 	var publisherDone <-chan struct{}

--- a/services/marketplace-api/internal/metrics/registry.go
+++ b/services/marketplace-api/internal/metrics/registry.go
@@ -41,19 +41,24 @@ var (
 		[]string{"provider", "event_type"},
 	)
 
-	// OutboxEventsPending tracks the current outbox queue depth.
-	OutboxEventsPending = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "outbox_events_pending",
-			Help: "Number of pending outbox events.",
-		},
-	)
-
 	// OutboxEventsPublishedTotal counts outbox events published.
 	OutboxEventsPublishedTotal = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "outbox_events_published_total",
 			Help: "Total outbox events published.",
+		},
+	)
+
+	// OutboxEventsFailedTotal counts outbox events the publisher gave up on.
+	// There is deliberately no pending GAUGE beside these two counters:
+	// /admin/health reports pending depth, oldest-pending age and errored
+	// count from a DB query, authoritatively, whereas a gauge set by the
+	// publisher would be reported identically by every replica running in
+	// admin or both mode — so any dashboard summing it would multiply.
+	OutboxEventsFailedTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "outbox_events_failed_total",
+			Help: "Total outbox events marked terminally failed by the publisher.",
 		},
 	)
 
@@ -162,8 +167,8 @@ func init() {
 		HTTPRequestDuration,
 		OrdersCreatedTotal,
 		WebhookReceivedTotal,
-		OutboxEventsPending,
 		OutboxEventsPublishedTotal,
+		OutboxEventsFailedTotal,
 		TrialSignupAnomalyAlertsTotal,
 		TrialActivationDay30Total,
 		DunningEmailsSentTotal,

--- a/services/marketplace-api/internal/outbox/models.go
+++ b/services/marketplace-api/internal/outbox/models.go
@@ -89,6 +89,14 @@ const (
 const (
 	ReasonPayloadUnparseable    = "payload_unparseable"
 	ReasonPayloadMissingStoreID = "payload_missing_store_id"
+	// ReasonStoreNotFound is written when a payload's store_id is
+	// well-formed but has no matching row in `stores`. The watermark upsert
+	// would raise an FK violation (store_watermarks.store_id REFERENCES
+	// stores(id)), which ABORTS the whole transaction rather than failing
+	// one row — see #374. Permanent in practice: stores are removed only by
+	// tenant purge and hard-delete, both of which sweep this tenant's
+	// outbox_events too.
+	ReasonStoreNotFound = "store_not_found"
 	// ReasonUnknown is written when a caller supplies a reason outside this
 	// vocabulary. It exists so MarkFailedInTx can neutralise an unrecognised
 	// string WITHOUT failing the batch: returning an error there would roll

--- a/services/marketplace-api/internal/outbox/models.go
+++ b/services/marketplace-api/internal/outbox/models.go
@@ -87,7 +87,16 @@ const (
 // that leaves this service — defeating the same reasoning that keeps
 // `payload` out of #331's response, through a field nobody would audit.
 const (
-	ReasonPayloadUnparseable    = "payload_unparseable"
+	ReasonPayloadUnparseable = "payload_unparseable"
+	// ReasonPayloadMissingStoreID is written when a payload's store_id is
+	// absent, not a string, an empty string, or a non-empty string that does
+	// not parse as a UUID. All four are the same terminal producer bug and
+	// require the same operator action, so they share one code rather than
+	// widening this closed vocabulary. The UUID case is rejected here, in
+	// the row loop, rather than left to the store pre-check below: stores.id
+	// is uuid, and passing a non-UUID value to that SELECT raises `invalid
+	// input syntax for type uuid`, which ABORTS the transaction and rolls
+	// back the whole batch — see #374.
 	ReasonPayloadMissingStoreID = "payload_missing_store_id"
 	// ReasonStoreNotFound is written when a payload's store_id is
 	// well-formed but has no matching row in `stores`. The watermark upsert

--- a/services/marketplace-api/internal/outbox/models.go
+++ b/services/marketplace-api/internal/outbox/models.go
@@ -14,8 +14,14 @@
 // is NOT recovery: the watermark upsert is monotonic (GREATEST) over the
 // row's ORIGINAL created_at, so a row that sat failed while later events
 // published for the same store will publish without moving the watermark —
-// no consumer learns, and the health alarm clears. Recovery for a stale row
-// is a fresh enqueue (or bumping created_at alongside clearing error).
+// no consumer learns, and the health alarm clears. That caveat assumes a
+// later event DID publish for the same store while this row sat failed; it
+// is unavailable for a store_not_found row, since no later event can have
+// published for a store that did not exist — if the store exists by the
+// time such a row is requeued, store_watermarks has no row for it yet, so
+// the upsert INSERTs at the original created_at, a change consumers DO
+// observe. Recovery for a stale row is a fresh enqueue (or bumping
+// created_at alongside clearing error).
 // See #336.
 package outbox
 

--- a/services/marketplace-api/internal/outbox/publisher.go
+++ b/services/marketplace-api/internal/outbox/publisher.go
@@ -93,7 +93,7 @@ func (p *Publisher) Tick(ctx context.Context) (int, error) {
 			axis    string
 		}
 		byBucket := map[key]time.Time{}
-		ids := make([]string, 0, len(rows))
+		idsByStore := make(map[string][]string, len(rows))
 		failures := make([]Failure, 0)
 		for _, r := range rows {
 			var payload map[string]any
@@ -118,7 +118,7 @@ func (p *Publisher) Tick(ctx context.Context) (int, error) {
 			// going to contribute a watermark bump. Appending before the
 			// checks above is what made a dropped event indistinguishable
 			// from a published one (#336).
-			ids = append(ids, r.ID)
+			idsByStore[sid] = append(idsByStore[sid], r.ID)
 			axis := "products"
 			if IsOrderAggregate(r.Aggregate) {
 				axis = "orders"
@@ -128,6 +128,56 @@ func (p *Publisher) Tick(ctx context.Context) (int, error) {
 				byBucket[k] = r.CreatedAt
 			}
 		}
+		// Store-existence pre-check (#374). store_watermarks.store_id is
+		// REFERENCES stores(id), so upserting a watermark for a store that
+		// does not exist raises an FK violation — and an FK violation ABORTS
+		// the Postgres transaction, so it does not fail one row, it takes the
+		// whole batch: the good rows, the failure marks, everything. Those
+		// rows then stay pending and are re-selected forever.
+		//
+		// Checking first turns that into a per-row terminal failure, the same
+		// shape as the other two causes. One extra SELECT per tick, and only
+		// when at least one row survived validation.
+		if len(idsByStore) > 0 {
+			storeIDs := make([]string, 0, len(idsByStore))
+			for sid := range idsByStore {
+				storeIDs = append(storeIDs, sid)
+			}
+			var found []struct{ ID string }
+			if err := tx.Raw(`SELECT id FROM stores WHERE id IN ?`, storeIDs).
+				Scan(&found).Error; err != nil {
+				return err
+			}
+			present := make(map[string]struct{}, len(found))
+			for _, f := range found {
+				present[f.ID] = struct{}{}
+			}
+			for sid, rowIDs := range idsByStore {
+				if _, ok := present[sid]; ok {
+					continue
+				}
+				if p.logger != nil {
+					p.logger.Warn("outbox publisher: store not found; failing",
+						"store_id", sid, "events", len(rowIDs))
+				}
+				for _, id := range rowIDs {
+					failures = append(failures, Failure{ID: id, Reason: ReasonStoreNotFound})
+				}
+				delete(idsByStore, sid)
+			}
+			// Drop every bucket whose store is gone, both axes.
+			for k := range byBucket {
+				if _, ok := present[k.storeID]; !ok {
+					delete(byBucket, k)
+				}
+			}
+		}
+
+		ids := make([]string, 0, len(rows))
+		for _, rowIDs := range idsByStore {
+			ids = append(ids, rowIDs...)
+		}
+
 		for k, ts := range byBucket {
 			var stmt string
 			switch k.axis {

--- a/services/marketplace-api/internal/outbox/publisher.go
+++ b/services/marketplace-api/internal/outbox/publisher.go
@@ -125,8 +125,14 @@ func (p *Publisher) Tick(ctx context.Context) (int, error) {
 			// pill this pre-check exists to remove.
 			if _, err := uuid.Parse(sid); sid == "" || err != nil {
 				if p.logger != nil {
-					p.logger.Warn("outbox publisher: payload missing store_id; failing",
-						"event_id", r.ID, "event_type", r.EventType)
+					// store_id_present discriminates the two cases this guard
+					// now covers — absent/empty vs present-but-unparseable —
+					// without emitting the value itself, which is producer
+					// controlled. "missing" alone would send an operator
+					// looking for an absent field that is in fact there.
+					p.logger.Warn("outbox publisher: missing or invalid store_id; failing",
+						"event_id", r.ID, "event_type", r.EventType,
+						"store_id_present", sid != "")
 				}
 				failures = append(failures, Failure{ID: r.ID, Reason: ReasonPayloadMissingStoreID})
 				continue

--- a/services/marketplace-api/internal/outbox/publisher.go
+++ b/services/marketplace-api/internal/outbox/publisher.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/mark8ly/marketplace-api/internal/metrics"
 	"gorm.io/gorm"
 )
 
@@ -85,8 +86,18 @@ func (p *Publisher) Start(ctx context.Context) <-chan struct{} {
 // (product, category, media) bumps products_updated_at. This lets storefront
 // clients poll the orders signal independently of product edits. See spec
 // §14.1 and Orders M2 plan (Option A).
+//
+// The returned int is the number of rows the poll SAW — not the number
+// published. Since #336 a batch can be entirely failed, so a non-zero return
+// says work was examined, not that anything was delivered. The
+// outbox_events_published_total and outbox_events_failed_total counters are
+// what separate those two outcomes.
 func (p *Publisher) Tick(ctx context.Context) (int, error) {
-	return p.repo.ProcessBatch(ctx, p.batch, func(tx *gorm.DB, rows []OutboxEvent) error {
+	var published, failed int
+	seen, err := p.repo.ProcessBatch(ctx, p.batch, func(tx *gorm.DB, rows []OutboxEvent) error {
+		// Reset per attempt: ProcessBatch's callback can run again, and a
+		// counter that survived a rolled-back attempt would over-count.
+		published, failed = 0, 0
 		// Group by (store_id, axis) where axis ∈ {"products","orders"}.
 		type key struct {
 			storeID string
@@ -204,9 +215,19 @@ func (p *Publisher) Tick(ctx context.Context) (int, error) {
 		}
 		// Both marks run in the SAME transaction as the watermark bumps
 		// above, so a batch's outcome commits whole or not at all.
+		published, failed = len(ids), len(failures)
 		if err := p.repo.MarkFailedInTx(tx, failures); err != nil {
 			return err
 		}
 		return p.repo.MarkPublishedInTx(tx, ids)
 	})
+	if err != nil {
+		return seen, err
+	}
+	// AFTER the commit, never inside the callback: the transaction can roll
+	// back, and a Prometheus counter cannot be decremented, so an over-count
+	// is permanent.
+	metrics.OutboxEventsPublishedTotal.Add(float64(published))
+	metrics.OutboxEventsFailedTotal.Add(float64(failed))
+	return seen, nil
 }

--- a/services/marketplace-api/internal/outbox/publisher.go
+++ b/services/marketplace-api/internal/outbox/publisher.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/mark8ly/marketplace-api/internal/metrics"
 	"gorm.io/gorm"
 )
@@ -117,7 +118,12 @@ func (p *Publisher) Tick(ctx context.Context) (int, error) {
 				continue
 			}
 			sid, _ := payload["store_id"].(string)
-			if sid == "" {
+			// A non-UUID value must be rejected HERE, not left to the store
+			// pre-check below: stores.id is uuid, so passing "store-42" to that
+			// SELECT raises `invalid input syntax for type uuid`, which ABORTS
+			// the transaction and rolls back the whole batch — the very poison
+			// pill this pre-check exists to remove.
+			if _, err := uuid.Parse(sid); sid == "" || err != nil {
 				if p.logger != nil {
 					p.logger.Warn("outbox publisher: payload missing store_id; failing",
 						"event_id", r.ID, "event_type", r.EventType)

--- a/services/marketplace-api/internal/outbox/publisher_integration_test.go
+++ b/services/marketplace-api/internal/outbox/publisher_integration_test.go
@@ -487,3 +487,74 @@ func TestIntegration_Publisher_StoreNotFound_DoesNotRollBackGoodRows(t *testing.
 		t.Fatalf("second tick saw %d rows, want 0", count)
 	}
 }
+
+// A store_id that is a non-empty string but not a parseable UUID used to
+// reach the store pre-check's `SELECT id FROM stores WHERE id IN ?`, where
+// Postgres raises `invalid input syntax for type uuid` — which ABORTS the
+// transaction and rolls back the whole batch, good rows included. #374.
+func TestIntegration_Publisher_NonUUIDStoreID_MarksFailedAndCommits(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events", "store_watermarks", "stores")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	storeID := uuid.NewString()
+	insertStore(t, db, storeID, tenantID)
+
+	good := enqueueForStore(t, db, tenantID, storeID)
+
+	bad := &outbox.OutboxEvent{
+		TenantID:    tenantID,
+		Aggregate:   outbox.AggregateProduct,
+		AggregateID: uuid.NewString(),
+		EventType:   outbox.EventProductUpdated,
+		Payload:     datatypes.JSON([]byte(`{"store_id":"store-42"}`)),
+	}
+	if err := db.Create(bad).Error; err != nil {
+		t.Fatalf("enqueue bad: %v", err)
+	}
+
+	pub := outbox.New(outbox.Config{
+		Repo: repo, DB: db, Logger: quietLogger(),
+		Interval: 1 * time.Second, BatchSize: 100,
+	})
+	if _, err := pub.Tick(context.Background()); err != nil {
+		t.Fatalf("tick must not error on a non-UUID store_id: %v", err)
+	}
+
+	var gotGood outbox.OutboxEvent
+	if err := db.First(&gotGood, "id = ?", good.ID).Error; err != nil {
+		t.Fatalf("reload good: %v", err)
+	}
+	if gotGood.PublishedAt == nil {
+		t.Fatalf("the good event must be published even when a non-UUID store_id shares its batch")
+	}
+
+	var wmCount int64
+	if err := db.Raw(`SELECT count(*) FROM store_watermarks WHERE store_id = ?`, storeID).
+		Scan(&wmCount).Error; err != nil {
+		t.Fatalf("count watermarks: %v", err)
+	}
+	if wmCount != 1 {
+		t.Fatalf("watermark rows = %d, want 1", wmCount)
+	}
+
+	var gotBad outbox.OutboxEvent
+	if err := db.First(&gotBad, "id = ?", bad.ID).Error; err != nil {
+		t.Fatalf("reload bad: %v", err)
+	}
+	if gotBad.PublishedAt != nil {
+		t.Fatalf("the non-UUID store_id event must NOT be published, got published_at=%v", gotBad.PublishedAt)
+	}
+	if gotBad.Error == nil || *gotBad.Error != outbox.ReasonPayloadMissingStoreID {
+		t.Fatalf("bad event error = %v, want %q", gotBad.Error, outbox.ReasonPayloadMissingStoreID)
+	}
+
+	// And the bad row is not retried on the next tick.
+	count, err := pub.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("second tick: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("second tick saw %d rows, want 0 (failed rows are terminal)", count)
+	}
+}

--- a/services/marketplace-api/internal/outbox/publisher_integration_test.go
+++ b/services/marketplace-api/internal/outbox/publisher_integration_test.go
@@ -373,3 +373,117 @@ func TestIntegration_Publisher_MixedBatch_PublishesGoodFailsBad(t *testing.T) {
 		t.Fatalf("second tick saw %d rows, want 0 (failed rows are terminal)", count)
 	}
 }
+
+// A store_id that is well-formed but absent from `stores` used to raise an FK
+// violation on the watermark upsert, which ABORTS the whole Postgres
+// transaction — taking the good rows and the failure marks with it and
+// leaving the entire batch pending forever. #374.
+func TestIntegration_Publisher_StoreNotFound_MarksFailedAndCommits(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events", "store_watermarks", "stores")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	ghostStoreID := uuid.NewString() // deliberately never inserted
+
+	evt := enqueueForStore(t, db, tenantID, ghostStoreID)
+
+	pub := outbox.New(outbox.Config{
+		Repo: repo, DB: db, Logger: quietLogger(),
+		Interval: 1 * time.Second, BatchSize: 100,
+	})
+	if _, err := pub.Tick(context.Background()); err != nil {
+		t.Fatalf("tick must not error on a missing store: %v", err)
+	}
+
+	var got outbox.OutboxEvent
+	if err := db.First(&got, "id = ?", evt.ID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.PublishedAt != nil {
+		t.Fatalf("a row for a missing store must not be published, got %v", got.PublishedAt)
+	}
+	if got.Error == nil {
+		t.Fatalf("error is nil; want %q", outbox.ReasonStoreNotFound)
+	}
+	// Exact code. If the constant was added but not allowlisted in
+	// sanitizeReason, this reads "unknown" and this line is what catches it.
+	if *got.Error != outbox.ReasonStoreNotFound {
+		t.Fatalf("error = %q, want %q", *got.Error, outbox.ReasonStoreNotFound)
+	}
+
+	var n int64
+	if err := db.Raw(`SELECT count(*) FROM store_watermarks`).Scan(&n).Error; err != nil {
+		t.Fatalf("count watermarks: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("watermark rows = %d, want 0", n)
+	}
+}
+
+// The composition that matters: one good row and one ghost-store row in the
+// SAME batch. Before #374 the FK violation rolled back BOTH.
+func TestIntegration_Publisher_StoreNotFound_DoesNotRollBackGoodRows(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events", "store_watermarks", "stores")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	realStoreID := uuid.NewString()
+	insertStore(t, db, realStoreID, tenantID)
+	ghostStoreID := uuid.NewString()
+
+	good := enqueueForStore(t, db, tenantID, realStoreID)
+	ghost := enqueueForStore(t, db, tenantID, ghostStoreID)
+
+	pub := outbox.New(outbox.Config{
+		Repo: repo, DB: db, Logger: quietLogger(),
+		Interval: 1 * time.Second, BatchSize: 100,
+	})
+	count, err := pub.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("tick saw %d rows, want 2", count)
+	}
+
+	var gotGood outbox.OutboxEvent
+	if err := db.First(&gotGood, "id = ?", good.ID).Error; err != nil {
+		t.Fatalf("reload good: %v", err)
+	}
+	if gotGood.PublishedAt == nil {
+		t.Fatalf("the good row must publish even when a ghost-store row shares its batch")
+	}
+	if gotGood.Error != nil {
+		t.Fatalf("the good row must not be failed, got %q", *gotGood.Error)
+	}
+
+	var gotGhost outbox.OutboxEvent
+	if err := db.First(&gotGhost, "id = ?", ghost.ID).Error; err != nil {
+		t.Fatalf("reload ghost: %v", err)
+	}
+	if gotGhost.PublishedAt != nil {
+		t.Fatalf("the ghost row must not be published, got %v", gotGhost.PublishedAt)
+	}
+	if gotGhost.Error == nil || *gotGhost.Error != outbox.ReasonStoreNotFound {
+		t.Fatalf("ghost row error = %v, want %q", gotGhost.Error, outbox.ReasonStoreNotFound)
+	}
+
+	// The real store's watermark landed — the FK row did not suppress it.
+	var n int64
+	if err := db.Raw(`SELECT count(*) FROM store_watermarks WHERE store_id = ?`, realStoreID).
+		Scan(&n).Error; err != nil {
+		t.Fatalf("count watermarks: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("watermark rows for the real store = %d, want 1", n)
+	}
+
+	// And nothing is retried.
+	count, err = pub.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("second tick: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("second tick saw %d rows, want 0", count)
+	}
+}

--- a/services/marketplace-api/internal/outbox/publisher_integration_test.go
+++ b/services/marketplace-api/internal/outbox/publisher_integration_test.go
@@ -11,9 +11,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 
+	"github.com/mark8ly/marketplace-api/internal/metrics"
 	"github.com/mark8ly/marketplace-api/internal/outbox"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
@@ -324,12 +326,23 @@ func TestIntegration_Publisher_MixedBatch_PublishesGoodFailsBad(t *testing.T) {
 		Repo: repo, DB: db, Logger: quietLogger(),
 		Interval: 1 * time.Second, BatchSize: 100,
 	})
+	// Captured BEFORE the tick and asserted as a delta: these are
+	// package-level globals other tests in the same process also move, so
+	// an absolute assertion would be order-dependent and flaky.
+	beforePublished := testutil.ToFloat64(metrics.OutboxEventsPublishedTotal)
+	beforeFailed := testutil.ToFloat64(metrics.OutboxEventsFailedTotal)
 	count, err := pub.Tick(context.Background())
 	if err != nil {
 		t.Fatalf("tick: %v", err)
 	}
 	if count != 2 {
 		t.Fatalf("tick saw %d rows, want 2", count)
+	}
+	if got := testutil.ToFloat64(metrics.OutboxEventsPublishedTotal) - beforePublished; got != 1 {
+		t.Fatalf("published counter delta = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.OutboxEventsFailedTotal) - beforeFailed; got != 1 {
+		t.Fatalf("failed counter delta = %v, want 1", got)
 	}
 
 	var gotGood outbox.OutboxEvent

--- a/services/marketplace-api/internal/outbox/repository.go
+++ b/services/marketplace-api/internal/outbox/repository.go
@@ -99,7 +99,7 @@ func (r *gormRepository) MarkPublishedInTx(tx *gorm.DB, ids []string) error {
 // advisory.
 func sanitizeReason(reason string) string {
 	switch reason {
-	case ReasonPayloadUnparseable, ReasonPayloadMissingStoreID:
+	case ReasonPayloadUnparseable, ReasonPayloadMissingStoreID, ReasonStoreNotFound:
 		return reason
 	default:
 		return ReasonUnknown

--- a/services/marketplace-api/internal/outbox/repository_integration_test.go
+++ b/services/marketplace-api/internal/outbox/repository_integration_test.go
@@ -474,3 +474,30 @@ func TestIntegration_ProcessBatch_ClearingErrorRequeues(t *testing.T) {
 		t.Fatalf("ProcessBatch saw %d rows, want 1 after error was cleared", count)
 	}
 }
+
+// Guard against adding a reason constant without allowlisting it in
+// sanitizeReason, which would silently record "unknown" instead.
+func TestIntegration_MarkFailedInTx_StoreNotFoundIsInTheVocabulary(t *testing.T) {
+	db := testdb.NewDB(t, "outbox_events")
+	repo := outbox.NewRepository(db)
+
+	tenantID := uuid.NewString()
+	evt := makeEvent(tenantID)
+	enqueueCommitted(t, db, evt)
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return repo.MarkFailedInTx(tx, []outbox.Failure{
+			{ID: evt.ID, Reason: outbox.ReasonStoreNotFound},
+		})
+	}); err != nil {
+		t.Fatalf("MarkFailedInTx: %v", err)
+	}
+
+	var got outbox.OutboxEvent
+	if err := db.First(&got, "id = ?", evt.ID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.Error == nil || *got.Error != outbox.ReasonStoreNotFound {
+		t.Fatalf("error = %v, want %q (is it in sanitizeReason's switch?)", got.Error, outbox.ReasonStoreNotFound)
+	}
+}


### PR DESCRIPTION
Closes #374, #375, #376.

The three follow-ups found during #336's whole-branch review. #336 is merged, deployed on `main-0fc2763`, and [verified in production](https://github.com/tesserix/mark8ly/issues/336#issuecomment-5419220955).

## #374 — the last poison-pill cause

`store_watermarks.store_id` is `REFERENCES stores(id)`. A payload whose `store_id` was well-formed but had **no matching store** passed both of #336's checks, reached the watermark upsert, and the FK violation **aborted the Postgres transaction** — so it did not fail one row, it took the whole batch: the good rows, the failure marks, everything. Those rows then stayed pending and were re-selected forever.

Worse than the two causes #336 fixed, because one bad row starves *every other tenant's* events out of the batch window rather than just losing its own signal.

Fixed with a store-existence `SELECT` before the upsert loop. Rows referencing a missing store become terminal failures carrying a new reason code `store_not_found` — the same shape #336 established — and the batch commits with the good rows published.

Chosen over `SAVEPOINT` per bucket deliberately: savepoints catch any upsert error, but pay that cost on every tick including the overwhelmingly common all-healthy case, and that is more machinery than the one known cause needs.

### A fifth shape, found by the whole-branch review

The pre-check as first written **moved** the abort rather than removing it. `stores.id` is `uuid`, so a `store_id` that is a non-empty string but not a parseable UUID — `"store-42"` — passed the `sid == ""` guard, reached that `SELECT`, and Postgres raised `invalid input syntax for type uuid`, aborting the transaction exactly as the FK violation had. Confirmed against the real database, including that it poisons the transaction.

Now rejected in the row loop by `uuid.Parse`, before it can reach the query. It reuses `ReasonPayloadMissingStoreID` rather than adding a fifth code: that value already deliberately collapses "absent", "not a string" and "empty", and a non-UUID is the same terminal producer bug requiring the same operator action.

## #375 — metrics that were registered and written by nothing

`OutboxEventsPending` and `OutboxEventsPublishedTotal` were both constructed and both passed to `prometheus.MustRegister`, so they were exported on `/metrics` and read as real. Nothing ever called `.Set()`, `.Inc()` or `.Add()` — `outbox_events_published_total` had read `0` since it was added.

- The published counter is now wired, and `outbox_events_failed_total` added.
- **Both increment only after `ProcessBatch` returns `nil`**, never inside the callback. The callback runs in a transaction that can roll back and can be re-run; a Prometheus counter cannot be decremented, so counting uncommitted work would be a permanent over-count.
- **The gauge is deleted, not wired.** `/admin/health` already reports pending depth, oldest-pending age and errored count from a DB query, authoritatively. A gauge set by the publisher would additionally be a footgun: it runs in both `admin` and `both` modes, so every replica would report the same global number and any dashboard summing them would silently multiply.

## #376 — a comment contradicting its own file

`main.go` claimed the storefront process produces no outbox events. It does — public checkout writes them through `orderSvcSF`, and `main.go:1226-1228` says so correctly. The conclusion (don't run the publisher there) was right; the stated reason was false.

## Testing

`internal/outbox` is green: **21 PASS, 0 FAIL, 0 SKIP**. New coverage:

- A ghost-store row alone → failed with `store_not_found`, batch commits, no watermark written.
- A ghost-store row **sharing a batch with a good row** → the good row publishes and its watermark bumps; the ghost row is terminal; a second tick sees 0 rows. This is the composition the FK violation used to roll back wholesale.
- A non-UUID `store_id` in a mixed batch → same guarantees. Its RED was the real `SQLSTATE 22P02`.
- A guard test asserting `store_not_found` survives `sanitizeReason` — adding a constant without allowlisting it compiles fine and would silently record `unknown`.
- Delta-based assertions on both counters in the mixed-batch test (deltas, not absolutes: these are package-level globals other tests also move).

Full suite, branch vs `0fc2763f`, run sequentially against one shared DB: **22 packages / 191 tests failing on both, empty diff in both directions.** This branch added zero failures and fixed none — the expected result, since unlike #336's branch it repairs no pre-existing test. `go vet -tags=integration` clean.

## One deliberate non-deletion

`scripts/ci/verify-dashboard-queries.sh` keeps `outbox_events_pending` in `KNOWN_METRICS`, with a comment explaining why.

That script validates the Grafana dashboards in **tesserix-k8s** against this allowlist, and `.github/workflows/dashboard-validation.yml` runs it in CI. `webhook-pipeline.json` there still has a panel querying the deleted metric, so removing the entry would fail CI on a dashboard this repo cannot edit. Proven by removing the line (`exit=1`, `references unknown metric(s): outbox_events_pending`) and restoring it (`exit=0`).

Tracked as tesserix-k8s#631, which carries the ordering constraint: repoint the panel first, then drop the allowlist entry.

## Follow-ups, not in this PR

- **The TOCTOU window.** The store `SELECT` is not `FOR UPDATE`, so a concurrent tenant purge could in principle still reach the FK path. Deliberately left: both purge paths delete `outbox_events` **before** `stores` in a single transaction, and the publisher holds `FOR UPDATE` on its batch rows — so either the purge blocks until the publisher commits, or its uncommitted deletes make `SKIP LOCKED` pass the rows over. `FOR UPDATE` would add nothing and would take row locks on a hot table on a shared `db-f1-micro` every tick.
- **`store_id` is not tenant-scoped** in the new read, matching the pre-existing FK and the deliberately cross-tenant poll. Noted so the next reader need not re-derive that it is intentional.
