### PR TITLE
feat(platform-admin): publish the lifecycle reason codes (§8.8)

### DIFF
--- a/services/marketplace-api/internal/handlers/platformadmin/lifecycle_reason_codes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/lifecycle_reason_codes.go
@@ -1,0 +1,153 @@
+// services/marketplace-api/internal/handlers/platformadmin/lifecycle_reason_codes.go
+package platformadmin
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ReasonCode pairs a wire code with the words an operator reads.
+//
+// The code is what crosses the wire, lands in an audit row and is matched
+// exactly by the validators in this package. The label is presentation and
+// may be reworded freely; renaming a code may not.
+type ReasonCode struct {
+	Code  string `json:"code"`
+	Label string `json:"label"`
+}
+
+// LifecycleReasonCodesResponse is contract §8.8's body.
+//
+// A map rather than four named fields: §8.8 requires `suspend` and
+// `unsuspend` of every implementer and permits more, and a product's set of
+// consequential verbs is its own. Adding one here should not need a struct
+// field, and a console reading it should not need a new build to see one.
+type LifecycleReasonCodesResponse struct {
+	Data map[string][]ReasonCode `json:"data"`
+}
+
+// reasonCodeLabels supplies the human wording for each code, per verb.
+//
+// **Per verb, not global, and that is the whole reason this is a nested map.**
+// `operator_error` means "suspended in error" on unsuspend, "correcting a
+// mistaken earlier extension" on trial extension, and "a tenant created in
+// error" on purge. `fraud` and `legal` likewise differ between suspending a
+// tenant and destroying one. A single flat code→label map would have quietly
+// shown an operator the wrong sentence next to the right code, which is worse
+// than showing them the bare code.
+//
+// The `[]string` code lists remain the single authority on MEMBERSHIP and
+// ORDER — this map is consulted, never enumerated. That keeps the validators
+// (`isKnownReasonCode`) and the `allowed` array in the §4.4 error bodies
+// exactly as they were: publishing the vocabulary must not become a chance to
+// change what the vocabulary is.
+//
+// TestReasonCodeLabelsCoverEveryCode fails on a code with no label and on a
+// label with no code, so the two cannot drift apart.
+var reasonCodeLabels = map[string]map[string]string{
+	"suspend": {
+		"abuse":         "Abuse — abusive content or behaviour",
+		"fraud":         "Fraud — suspected fraudulent transactions or identity",
+		"non_payment":   "Non-payment — dunning exhausted",
+		"legal":         "Legal — legal or regulatory demand",
+		"tos_violation": "Terms breach — not covered by abuse or fraud",
+		"security":      "Security — compromised account or active incident",
+		"voluntary":     "Voluntary — the merchant asked for a pause",
+	},
+	"unsuspend": {
+		"resolved":       "Resolved — the issue is settled",
+		"appeal_upheld":  "Appeal upheld — the suspension was contested and reversed",
+		"operator_error": "Operator error — suspended in error",
+		"voluntary_end":  "Voluntary end — the merchant asked to resume",
+	},
+	"trial_extend": {
+		"support_escalation": "Support escalation — an open case needs more time",
+		"onboarding_delay":   "Onboarding delay — setup slipped, outside the merchant's control",
+		"billing_dispute":    "Billing dispute — open; the trial should not lapse meanwhile",
+		"goodwill":           "Goodwill — discretionary grant, no other category applies",
+		"operator_error":     "Operator error — correcting a mistaken earlier extension",
+	},
+	"purge": {
+		"merchant_request": "Merchant request — the merchant asked for deletion",
+		"erasure_request":  "Erasure request — a statutory demand (GDPR art.17)",
+		"fraud":            "Fraud — confirmed fraudulent tenant, removed after investigation",
+		"abandoned":        "Abandoned — onboarding never completed",
+		"legal":            "Legal — a demand other than erasure",
+		"operator_error":   "Operator error — created in error, or a test tenant",
+	},
+}
+
+// lifecycleVerbCodes maps each verb to its authoritative code list. Ordered
+// deliberately: suspend and unsuspend first because §8.8 requires them of
+// every implementer, the two mark8ly-specific verbs after.
+var lifecycleVerbCodes = []struct {
+	Verb  string
+	Codes []string
+}{
+	{"suspend", SuspendReasonCodes},
+	{"unsuspend", UnsuspendReasonCodes},
+	{"trial_extend", ExtendReasonCodes},
+	{"purge", PurgeReasonCodes},
+}
+
+// labelFor returns the wording for one code, falling back to the code itself.
+//
+// The fallback is never expected to fire — the coverage test makes a missing
+// label a build failure — but it must not be an empty string. §8.8 requires a
+// non-empty label on every entry, so an empty one would take a conforming
+// endpoint out of conformance to report a labelling mistake. The code is an
+// ugly menu option and an honest one.
+func labelFor(verb, code string) string {
+	if label, ok := reasonCodeLabels[verb][code]; ok && label != "" {
+		return label
+	}
+	return code
+}
+
+// LifecycleReasonCodes builds the §8.8 payload from the authoritative lists.
+//
+// Exported so the console-facing shape can be asserted from a test without
+// standing up a router, and so nothing is tempted to rebuild it by hand.
+func LifecycleReasonCodes() map[string][]ReasonCode {
+	out := make(map[string][]ReasonCode, len(lifecycleVerbCodes))
+	for _, verb := range lifecycleVerbCodes {
+		codes := make([]ReasonCode, 0, len(verb.Codes))
+		for _, code := range verb.Codes {
+			codes = append(codes, ReasonCode{Code: code, Label: labelFor(verb.Verb, code)})
+		}
+		out[verb.Verb] = codes
+	}
+	return out
+}
+
+// LifecycleReasonCodesHandler serves contract §8.8.
+//
+// It holds nothing. The response is a constant folded out of this package's
+// own `var` blocks, which is exactly the point of the endpoint: §8.3 made the
+// codes REQUIRED on suspend and unsuspend and said nothing about how a caller
+// was meant to learn them, so the console hand-copied mark8ly's out of
+// `tenant_lifecycle.go` (tesserix-home#345). A copied vocabulary drifts in the
+// silent direction — a code added here is simply missing from the operator's
+// menu, and they pick the nearest wrong one.
+type LifecycleReasonCodesHandler struct{}
+
+func NewLifecycleReasonCodesHandler() *LifecycleReasonCodesHandler {
+	return &LifecycleReasonCodesHandler{}
+}
+
+// Register mounts the route unconditionally, unlike the write endpoints it
+// describes.
+//
+// Those refuse to mount without an audit path, because an unattributed write
+// is worse than an absent one. This is a read of a compile-time constant: it
+// depends on nothing, can fail in no way, and gating it on the writes being
+// wired would answer 404 in exactly the deployment where an operator most
+// needs to see what the vocabulary is.
+func (h *LifecycleReasonCodesHandler) Register(g *gin.RouterGroup) {
+	g.GET("/admin/lifecycle/reason-codes", h.reasonCodes)
+}
+
+func (h *LifecycleReasonCodesHandler) reasonCodes(c *gin.Context) {
+	c.JSON(http.StatusOK, LifecycleReasonCodesResponse{Data: LifecycleReasonCodes()})
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/lifecycle_reason_codes_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/lifecycle_reason_codes_test.go
@@ -1,0 +1,159 @@
+package platformadmin_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+)
+
+// authoritativeCodes is the SAME data the handler builds from, restated here
+// as the four exported vars rather than as a literal copy.
+//
+// Restating the literals would make this file the fifth place the vocabulary
+// lives, which is the failure the endpoint exists to end. Reading the exported
+// vars means these tests assert the RELATIONSHIP — every code labelled, every
+// label used, every code published — and stay silent about membership, which
+// is the writers' business.
+func authoritativeCodes() map[string][]string {
+	return map[string][]string{
+		"suspend":      platformadmin.SuspendReasonCodes,
+		"unsuspend":    platformadmin.UnsuspendReasonCodes,
+		"trial_extend": platformadmin.ExtendReasonCodes,
+		"purge":        platformadmin.PurgeReasonCodes,
+	}
+}
+
+// TestReasonCodeLabelsCoverEveryCode is the drift guard the label map's
+// comment promises.
+//
+// The map and the `[]string` lists are two structures describing one
+// vocabulary, which is a drift waiting to happen. It cannot happen silently:
+// adding a code without a label fails here, and the fallback that would
+// otherwise ship the bare `tos_violation` to an operator never gets to fire in
+// production.
+func TestReasonCodeLabelsCoverEveryCode(t *testing.T) {
+	published := platformadmin.LifecycleReasonCodes()
+
+	for verb, codes := range authoritativeCodes() {
+		entries, ok := published[verb]
+		require.Truef(t, ok, "verb %q has codes but is not published", verb)
+		require.Lenf(t, entries, len(codes), "verb %q publishes a different number of codes than it validates", verb)
+
+		for i, code := range codes {
+			require.Equalf(t, code, entries[i].Code,
+				"verb %q entry %d: published order must follow the authoritative list", verb, i)
+			require.NotEmptyf(t, entries[i].Label, "verb %q code %q has no label", verb, code)
+			require.NotEqualf(t, code, entries[i].Label,
+				"verb %q code %q fell back to its own code as a label — add it to reasonCodeLabels", verb, code)
+		}
+	}
+}
+
+// The mirror of the test above: a label for a code that no longer exists is
+// dead weight that reads as though the code is still accepted.
+func TestNoOrphanedReasonCodeLabels(t *testing.T) {
+	published := platformadmin.LifecycleReasonCodes()
+	for verb := range published {
+		_, ok := authoritativeCodes()[verb]
+		require.Truef(t, ok, "verb %q is published but has no authoritative code list", verb)
+	}
+	require.Len(t, published, len(authoritativeCodes()),
+		"every verb with codes must be published, and nothing else")
+}
+
+// `operator_error` is the reason the label map is nested per verb rather than
+// flat. It means three different things, and a flat map would have shown an
+// operator the wrong sentence beside the right code.
+func TestSharedCodesCarryVerbSpecificLabels(t *testing.T) {
+	published := platformadmin.LifecycleReasonCodes()
+
+	labelOf := func(verb, code string) string {
+		for _, entry := range published[verb] {
+			if entry.Code == code {
+				return entry.Label
+			}
+		}
+		t.Fatalf("verb %q does not publish %q", verb, code)
+		return ""
+	}
+
+	unsuspend := labelOf("unsuspend", "operator_error")
+	extend := labelOf("trial_extend", "operator_error")
+	purge := labelOf("purge", "operator_error")
+
+	require.NotEqual(t, unsuspend, extend, "operator_error must not read the same on unsuspend and trial_extend")
+	require.NotEqual(t, extend, purge, "operator_error must not read the same on trial_extend and purge")
+	require.NotEqual(t, unsuspend, purge, "operator_error must not read the same on unsuspend and purge")
+}
+
+// §8.8 pins snake_case because the code lands verbatim in an audit row and is
+// matched exactly by isKnownReasonCode. A product serving `Non-Payment` would
+// pass its own validator and break the moment two products' rows were read
+// together.
+func TestPublishedCodesAreSnakeCase(t *testing.T) {
+	pattern := regexp.MustCompile(`^[a-z0-9]+(?:_[a-z0-9]+)*$`)
+	for verb, entries := range platformadmin.LifecycleReasonCodes() {
+		for _, entry := range entries {
+			require.Truef(t, pattern.MatchString(entry.Code),
+				"verb %q code %q is not snake_case (contract §8.8)", verb, entry.Code)
+		}
+	}
+}
+
+func TestReasonCodesEndpointServesTheContractShape(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	platformadmin.NewLifecycleReasonCodesHandler().Register(router.Group(""))
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/lifecycle/reason-codes", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Decoded into the wire shape rather than the handler's own struct: the
+	// contract is about what a console reading raw JSON sees, and unmarshalling
+	// into the producer's type would hide a wrong or missing json tag.
+	var body struct {
+		Data map[string][]struct {
+			Code  string `json:"code"`
+			Label string `json:"label"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	// §8.8 requires both verbs of every implementer and permits more.
+	require.Contains(t, body.Data, "suspend")
+	require.Contains(t, body.Data, "unsuspend")
+	require.NotEmpty(t, body.Data["suspend"])
+	require.NotEmpty(t, body.Data["unsuspend"])
+
+	for verb, entries := range body.Data {
+		for i, entry := range entries {
+			require.NotEmptyf(t, entry.Code, "%s[%d] has no code", verb, i)
+			require.NotEmptyf(t, entry.Label, "%s[%d] has no label", verb, i)
+		}
+	}
+}
+
+// The suspend and unsuspend sets are deliberately different — the reason a
+// suspension ends is not the reason it began — and a refactor that collapsed
+// them into one list would be invisible to every other test here.
+func TestSuspendAndUnsuspendVocabulariesStayDistinct(t *testing.T) {
+	published := platformadmin.LifecycleReasonCodes()
+
+	suspend := map[string]bool{}
+	for _, entry := range published["suspend"] {
+		suspend[entry.Code] = true
+	}
+	for _, entry := range published["unsuspend"] {
+		require.Falsef(t, suspend[entry.Code],
+			"unsuspend code %q also appears in suspend; the two sets are deliberately disjoint", entry.Code)
+	}
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -191,6 +191,11 @@ func Register(g *gin.RouterGroup, deps Deps) {
 	// nil *gorm.DB would otherwise panic on WithContext.
 	NewHealthHandler(NewDBHealthSource(deps.DB), deps.Logger).Register(group)
 
+	// §8.8. Mounted beside health and for the same reason: it depends on
+	// nothing. See LifecycleReasonCodesHandler.Register for why it is not
+	// gated on the writes it describes.
+	NewLifecycleReasonCodesHandler().Register(group)
+
 	if deps.TenantDirectory != nil {
 		NewEntitiesTenantsHandler(deps.TenantDirectory, deps.Logger).Register(group)
 		NewConversionsHandler(deps.TenantDirectory, deps.Logger).Register(group)

--- a/services/marketplace-api/internal/outbox/platform_list_integration_test.go
+++ b/services/marketplace-api/internal/outbox/platform_list_integration_test.go
@@ -119,7 +119,7 @@ func TestIntegration_ListPlatform_OlderThanMinutesExcludesPublished(t *testing.T
 	oldPub := listAsOf.Add(-30 * time.Minute)
 
 	oldPendingID := seedRow(t, db, tenantID, "product.created", listAsOf.Add(-60*time.Minute), nil, nil)
-	seedRow(t, db, tenantID, "product.updated", listAsOf.Add(-1*time.Minute), nil, nil)     // young pending
+	seedRow(t, db, tenantID, "product.updated", listAsOf.Add(-1*time.Minute), nil, nil)       // young pending
 	seedRow(t, db, tenantID, "product.deleted", listAsOf.Add(-600*time.Minute), &oldPub, nil) // very old, published
 
 	got, err := outbox.ListPlatform(context.Background(), db,


### PR DESCRIPTION
Closes the product half of tesserix-home#345.

## The gap

§8.3 requires a reason code on suspend and unsuspend so an audit row says *why* and not only *what*. This service complies and always has — seven suspend codes, four deliberately different unsuspend ones, an unrecognised code refused with §4.4's `invalid_reason_code`.

**Nothing exposed the list.** The codes were a Go var in `tenant_lifecycle.go`, reachable only by opening this file, so the console shipped a hand-copied duplicate. A copied vocabulary drifts in two directions and only one is loud: offering a **retired** code is refused where someone sees it, missing an **added** one is silent — the option simply is not there and the operator picks the nearest wrong reason, which lands on an audit row and is never questioned again.

## What this adds

`GET /admin/lifecycle/reason-codes` → `{"data": {"suspend": [{"code","label"}], ...}}`, per the new contract §8.8 (tesserix-home).

**It serves all four verbs, not two.** §8.8 requires `suspend` and `unsuspend` of every implementer and permits more, and this service has four consequential verbs — `trial_extend` and `purge` have their own sets. Publishing only the two the console needs today would have earned a second migration the first time anyone built a trial-extension form.

## What it deliberately does not change

The `[]string` code lists remain the single authority on membership and order. The new label map is **consulted, never enumerated**, so `isKnownReasonCode` and the `allowed` array in the §4.4 error bodies are byte-identical to before. Publishing a vocabulary must not become an opportunity to change what the vocabulary is.

**Labels are nested per verb, and that nesting is load-bearing.** `operator_error` means "suspended in error" on unsuspend, "correcting a mistaken earlier extension" on trial_extend, and "a tenant created in error" on purge; `fraud` and `legal` likewise differ between pausing a tenant and destroying one. A flat code→label map would have shown an operator the wrong sentence next to the right code — worse than showing the bare code.

**The route mounts unconditionally**, unlike the writes it describes. Those refuse to mount without an audit path because an unattributed write is worse than an absent one. This is a read of a compile-time constant: it depends on nothing, and gating it on the writes being wired would answer 404 in exactly the deployment where an operator most needs to know what the vocabulary is.

## Follow-up, deliberately not here

`admin-conformance.json` (mark8ly#290) is **not** in this PR. Declaring the two new endpoint ids requires `@tesserix/admin-conformance@0.4.0`, which is still in review as tesserix/design-system#33 — `parseEndpoints` throws on an id the installed package does not know, so the file cannot land first.

## Test plan

- [x] `go build ./...`, `go vet` clean
- [x] Full `platformadmin` package suite passes
- [x] Endpoint shape asserted by decoding **raw JSON** into an anonymous struct, not the producer's type — a wrong or missing json tag would otherwise be invisible
- [x] Drift guard fails on a code with no label. **Verified by adding one**: `verb "suspend" code "drift_probe" fell back to its own code as a label`
- [x] A test asserts the shared `operator_error` reads differently on all three verbs that use it
- [x] A test asserts suspend and unsuspend stay disjoint