### PR TITLE
fix(billing): deliver dunning, trial, payment-action, win-back and trial-billed email (#381)

### DIFF
--- a/docs/superpowers/plans/2026-08-26-billing-email-delivery.md
+++ b/docs/superpowers/plans/2026-08-26-billing-email-delivery.md
@@ -1,0 +1,3035 @@
+# Billing Email Delivery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make dunning, trial-reminder, payment-action, win-back and trial-billed emails actually reach merchants, with counters that cannot overstate delivery.
+
+**Architecture:** A single new `email.Client` implementation renders a key through the existing `emailtemplates.Loader` and delegates to the existing SendGrid→Resend `Sender` chain. Callers resolve the recipient from a new `store_subscriptions.email` column (they already scan that table) and pass a real address. The adapter refuses undeliverable addresses with a typed sentinel instead of returning `nil`, which is what makes the existing counters honest. Two unguarded crons gain claim-first idempotency markers.
+
+**Tech Stack:** Go 1.26, Gin, GORM, PostgreSQL (golang-migrate), Prometheus client_golang, Stripe Go SDK v82, `html/template` + `text/template`.
+
+**Spec:** `docs/superpowers/specs/2026-08-26-billing-email-delivery-design.md`
+
+## Global Constraints
+
+- Branch `fix/381-billing-email-delivery`, worktree `/tmp/m8-381`. **Never** push, open a PR, merge or deploy.
+- Module path is `github.com/mark8ly/marketplace-api`; all work is under `services/marketplace-api/`.
+- Integration tests are build-tagged. `go vet -tags=integration ./...` is the only thing that compiles them. Run integration suites with `-p 1`.
+- `TEST_DATABASE_URL=postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable` — LAN IP `192.168.1.110`, never `localhost`. The dev Postgres is container `dev-postgres-1`; if `5432` is refused, `docker start dev-postgres-1`.
+- Before starting any integration run, check nothing else is running one: `ps aux | grep "go test -tags=integration"`.
+- **There are 22 packages / 191 tests already failing at baseline.** Never call a failure pre-existing without diffing against a throwaway worktree of the base commit, in both directions.
+- Migration files are pairs: `migrations/000NNN_<name>.up.sql` and `.down.sql`. Next free number is **000104**. Every `.up.sql` and `.down.sql` opens with a comment explaining intent and, for `.down.sql`, what data is lost.
+- Commit messages are single-line conventional commits. No signatures, no `Co-Authored-By`, no multi-line bodies.
+- Template keys are the existing `email.TemplateID` string values. Do not invent a second identifier.
+
+---
+
+### Task 1: Undeliverable-recipient sentinel
+
+The rule that makes every counter in this plan honest: the adapter must never return `nil` for mail it did not send. This task builds the classifier; Task 3 wires it in.
+
+**Files:**
+- Create: `internal/email/recipient.go`
+- Test: `internal/email/recipient_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `var ErrUndeliverable error`
+  - `type UndeliverableError struct{ Reason string }` with `Error() string` and `Unwrap() error`
+  - `func ValidateRecipient(to string) error` — returns `nil` or `*UndeliverableError`
+  - `func UndeliverableReason(err error) (string, bool)`
+  - `const ReasonNoAddress = "no_address"`, `ReasonInvalidAddress = "invalid_address"`, `ReasonPlaceholderAddress = "placeholder_address"`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/email/recipient_test.go`:
+
+```go
+package email_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+)
+
+func TestValidateRecipient(t *testing.T) {
+	cases := []struct {
+		name       string
+		to         string
+		wantReason string // "" means deliverable
+	}{
+		{"plain address", "merchant@example.com", ""},
+		{"address with display parts trimmed", "  merchant@example.com  ", ""},
+		{"subaddressed", "billing+store@example.com", ""},
+		{"empty", "", email.ReasonNoAddress},
+		{"whitespace only", "   ", email.ReasonNoAddress},
+		{"no at sign", "merchant.example.com", email.ReasonInvalidAddress},
+		{"two at signs", "a@b@example.com", email.ReasonInvalidAddress},
+		{"empty local part", "@example.com", email.ReasonInvalidAddress},
+		{"empty domain", "merchant@", email.ReasonInvalidAddress},
+		{"domain without dot", "merchant@localhost", email.ReasonPlaceholderAddress},
+		{"bootstrap placeholder", "billing+7f3a@mark8ly.local", email.ReasonPlaceholderAddress},
+		{"uppercase placeholder", "ops@MARK8LY.LOCAL", email.ReasonPlaceholderAddress},
+		{"rfc2606 invalid", "ops@something.invalid", email.ReasonPlaceholderAddress},
+		{"rfc2606 test", "ops@something.test", email.ReasonPlaceholderAddress},
+		{"rfc2606 example", "ops@something.example", email.ReasonPlaceholderAddress},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := email.ValidateRecipient(tc.to)
+			if tc.wantReason == "" {
+				if err != nil {
+					t.Fatalf("ValidateRecipient(%q) = %v, want nil", tc.to, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateRecipient(%q) = nil, want %s", tc.to, tc.wantReason)
+			}
+			if !errors.Is(err, email.ErrUndeliverable) {
+				t.Errorf("errors.Is(err, ErrUndeliverable) = false for %q", tc.to)
+			}
+			reason, ok := email.UndeliverableReason(err)
+			if !ok {
+				t.Fatalf("UndeliverableReason(%v) not recognised", err)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestUndeliverableReason_UnrelatedError(t *testing.T) {
+	if _, ok := email.UndeliverableReason(errors.New("boom")); ok {
+		t.Error("unrelated error reported as undeliverable")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go test ./internal/email/ -run TestValidateRecipient -v
+```
+
+Expected: FAIL — build error, `undefined: email.ValidateRecipient`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `internal/email/recipient.go`:
+
+```go
+package email
+
+// recipient.go — the guard that keeps billing mail out of the bit bucket
+// and keeps the delivery counters honest.
+//
+// subscription/service.go mints billing+<store_id>@mark8ly.local whenever a
+// subscription is bootstrapped without a real email. `.local` is unroutable,
+// so sending there hard-bounces and costs sender reputation. Rather than
+// discover that at the provider, we classify the address up front and return
+// a typed error — never nil — so a caller can count the skip instead of
+// recording a delivery that never happened.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrUndeliverable marks a recipient we refuse to attempt delivery to.
+// Wrapped, so callers can errors.Is regardless of reason.
+var ErrUndeliverable = errors.New("undeliverable recipient")
+
+// Reasons an address is refused. These become the `reason` label on
+// mark8ly_subscription_billing_emails_skipped_total, so keep them stable.
+const (
+	ReasonNoAddress          = "no_address"
+	ReasonInvalidAddress     = "invalid_address"
+	ReasonPlaceholderAddress = "placeholder_address"
+)
+
+// placeholderSuffixes are domains that can never receive mail: the RFC 2606
+// reserved TLDs plus bare `localhost`. `.local` catches the
+// billing+<uuid>@mark8ly.local addresses minted at bootstrap.
+var placeholderSuffixes = []string{
+	".local",
+	".invalid",
+	".test",
+	".example",
+	"localhost",
+}
+
+// UndeliverableError carries why an address was refused.
+type UndeliverableError struct{ Reason string }
+
+func (e *UndeliverableError) Error() string {
+	return fmt.Sprintf("email: %s: %s", ErrUndeliverable.Error(), e.Reason)
+}
+
+// Unwrap lets errors.Is(err, ErrUndeliverable) succeed.
+func (e *UndeliverableError) Unwrap() error { return ErrUndeliverable }
+
+// ValidateRecipient reports whether `to` is worth handing to a provider.
+// Deliberately conservative: this is a bounce guard, not an RFC 5321 parser.
+func ValidateRecipient(to string) error {
+	addr := strings.TrimSpace(to)
+	if addr == "" {
+		return &UndeliverableError{Reason: ReasonNoAddress}
+	}
+
+	local, domain, found := strings.Cut(addr, "@")
+	if !found || local == "" || domain == "" || strings.Contains(domain, "@") {
+		return &UndeliverableError{Reason: ReasonInvalidAddress}
+	}
+
+	lower := strings.ToLower(domain)
+	for _, suffix := range placeholderSuffixes {
+		if lower == suffix || strings.HasSuffix(lower, suffix) {
+			return &UndeliverableError{Reason: ReasonPlaceholderAddress}
+		}
+	}
+	if !strings.Contains(lower, ".") {
+		// No dot at all — not a routable public domain.
+		return &UndeliverableError{Reason: ReasonPlaceholderAddress}
+	}
+	return nil
+}
+
+// UndeliverableReason extracts the reason from an error produced by
+// ValidateRecipient, reporting false for anything else (e.g. a transport
+// failure, which must be counted differently).
+func UndeliverableReason(err error) (string, bool) {
+	var ue *UndeliverableError
+	if errors.As(err, &ue) {
+		return ue.Reason, true
+	}
+	return "", false
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go test ./internal/email/ -run 'TestValidateRecipient|TestUndeliverableReason' -v
+```
+
+Expected: PASS, all subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/m8-381 && git add services/marketplace-api/internal/email/recipient.go services/marketplace-api/internal/email/recipient_test.go
+git commit -m "feat(email): classify undeliverable recipients with a typed sentinel"
+```
+
+---
+
+### Task 2: Skipped-delivery metric
+
+Counters that record *not* sending. Without this the `.local` population is invisible rather than merely uncounted.
+
+**Files:**
+- Modify: `internal/metrics/registry.go` (add to the `var` block near `DunningEmailsSentTotal` at :79-87, and to the `MustRegister` list at :168-182)
+- Modify: `internal/subscription/dunning/metrics_adapter.go`
+- Test: `internal/subscription/dunning/metrics_adapter_test.go` — **this file already exists**; append to it, do not recreate it.
+
+**Interfaces:**
+- Consumes: `dunning.CounterIncrementer` (exists, has `Inc()`).
+- Produces:
+  - `metrics.BillingEmailsSkippedTotal *prometheus.CounterVec` with labels `{"template","reason"}`
+  - `dunning.SkipCounter` interface: `WithTemplateReason(template, reason string) CounterIncrementer`
+  - `dunning.WrapPrometheusSkipCounter(cv *prometheus.CounterVec) SkipCounter`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the existing `internal/subscription/dunning/metrics_adapter_test.go`
+(match its package clause — do not add a second one):
+
+```go
+// --- appended for #381 ---
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription/dunning"
+)
+
+func TestWrapPrometheusSkipCounter_IncrementsLabelledSeries(t *testing.T) {
+	cv := prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "test_skipped_total", Help: "test"},
+		[]string{"template", "reason"},
+	)
+
+	sc := dunning.WrapPrometheusSkipCounter(cv)
+	sc.WithTemplateReason("dunning_day_5", "placeholder_address").Inc()
+	sc.WithTemplateReason("dunning_day_5", "placeholder_address").Inc()
+	sc.WithTemplateReason("dunning_day_7", "no_address").Inc()
+
+	if got := testutil.ToFloat64(cv.WithLabelValues("dunning_day_5", "placeholder_address")); got != 2 {
+		t.Errorf("day_5/placeholder = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(cv.WithLabelValues("dunning_day_7", "no_address")); got != 1 {
+		t.Errorf("day_7/no_address = %v, want 1", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go test ./internal/subscription/dunning/ -run TestWrapPrometheusSkipCounter -v
+```
+
+Expected: FAIL — `undefined: dunning.WrapPrometheusSkipCounter`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/subscription/dunning/metrics_adapter.go`:
+
+```go
+// SkipCounter counts billing emails that were deliberately NOT sent,
+// labeled by template and reason. Defined here at the point of use rather
+// than in the metrics package so the crons stay testable with a stub.
+type SkipCounter interface {
+	WithTemplateReason(template, reason string) CounterIncrementer
+}
+
+// WrapPrometheusSkipCounter adapts a two-label *prometheus.CounterVec to
+// SkipCounter. Use with metrics.BillingEmailsSkippedTotal in main.go.
+func WrapPrometheusSkipCounter(cv *prometheus.CounterVec) SkipCounter {
+	return &prometheusSkipCounter{cv: cv}
+}
+
+type prometheusSkipCounter struct{ cv *prometheus.CounterVec }
+
+func (p *prometheusSkipCounter) WithTemplateReason(template, reason string) CounterIncrementer {
+	return prometheusCounter{c: p.cv.WithLabelValues(template, reason)}
+}
+```
+
+In `internal/metrics/registry.go`, add after the `DunningEmailsSentTotal` block (ends at :87):
+
+```go
+	// BillingEmailsSkippedTotal counts subscription emails deliberately not
+	// sent — an undeliverable recipient, a render failure, or a transport
+	// failure. Its companion *_sent_total counters only ever increment on a
+	// real delivery, so sent+skipped is the eligible population. #381.
+	BillingEmailsSkippedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mark8ly_subscription_billing_emails_skipped_total",
+			Help: "Count of subscription emails not sent, labeled by template and reason (no_address, placeholder_address, invalid_address, render_failed, transport_failed).",
+		},
+		[]string{"template", "reason"},
+	)
+```
+
+And add `BillingEmailsSkippedTotal,` to the `MustRegister(...)` list, immediately after `TrialRemindersSentTotal,`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go test ./internal/subscription/dunning/ -run TestWrapPrometheusSkipCounter -v && go build ./...
+```
+
+Expected: PASS, and the build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/m8-381 && git add services/marketplace-api/internal/metrics/registry.go services/marketplace-api/internal/subscription/dunning/metrics_adapter.go services/marketplace-api/internal/subscription/dunning/metrics_adapter_test.go
+git commit -m "feat(metrics): count billing emails skipped by template and reason"
+```
+
+---
+
+### Task 3: The template client — the only real `email.Client`
+
+**Files:**
+- Create: `internal/email/template_client.go`
+- Test: `internal/email/template_client_test.go`
+
+**Interfaces:**
+- Consumes: `ValidateRecipient`, `UndeliverableReason`, `ErrUndeliverable` (Task 1); `emailtemplates.Loader.Render`, `emailtemplates.EmbeddedFallback`, `Loader.Register` (existing); `email.Sender`, `email.Message` (existing).
+- Produces:
+  - `func NewTemplateClient(loader *emailtemplates.Loader, sender Sender, from string, logger *slog.Logger) Client`
+  - `var ErrRender error`, `var ErrTransport error`
+  - `const ReasonRenderFailed = "render_failed"`, `ReasonTransportFailed = "transport_failed"`, `ReasonUnknown = "unknown"`
+  - `func SkipReason(err error) string`
+
+There is no import cycle: `internal/emailtemplates` does not import `internal/email`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/email/template_client_test.go`:
+
+```go
+package email_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+)
+
+// captureSender records every Message handed to it.
+type captureSender struct {
+	mu   sync.Mutex
+	msgs []email.Message
+	err  error
+}
+
+func (s *captureSender) Send(_ context.Context, msg email.Message) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return s.err
+	}
+	s.msgs = append(s.msgs, msg)
+	return nil
+}
+
+func (s *captureSender) last(t *testing.T) email.Message {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.msgs) == 0 {
+		t.Fatal("no message sent")
+	}
+	return s.msgs[len(s.msgs)-1]
+}
+
+// loaderWith returns a DB-less loader with one key registered.
+func loaderWith(key, subject, html, text string) *emailtemplates.Loader {
+	l := emailtemplates.NewLoader(nil)
+	l.Register(key, emailtemplates.EmbeddedFallback{
+		Subject: subject, HTMLBody: html, TextBody: text,
+	})
+	return l
+}
+
+func TestTemplateClient_Send_BuildsEnvelope(t *testing.T) {
+	sender := &captureSender{}
+	loader := loaderWith("dunning_day_5",
+		"Payment failed for {{.store_name}}",
+		"<p>Hi {{.store_name}}, day {{.day}}</p>",
+		"Hi {{.store_name}}, day {{.day}}")
+
+	c := email.NewTemplateClient(loader, sender, "noreply@mark8ly.com", slog.Default())
+
+	err := c.Send(context.Background(), email.TemplateDunningDay5, "merchant@example.com", map[string]any{
+		"store_name": "Acme",
+		"day":        5,
+		"tenant_id":  "tenant-123",
+	})
+	if err != nil {
+		t.Fatalf("Send returned %v, want nil", err)
+	}
+
+	msg := sender.last(t)
+	if msg.To != "merchant@example.com" {
+		t.Errorf("To = %q", msg.To)
+	}
+	if msg.From != "noreply@mark8ly.com" {
+		t.Errorf("From = %q", msg.From)
+	}
+	if msg.FromName != "Mark8ly Billing" {
+		t.Errorf("FromName = %q", msg.FromName)
+	}
+	if msg.Subject != "Payment failed for Acme" {
+		t.Errorf("Subject = %q", msg.Subject)
+	}
+	if !strings.Contains(msg.HTMLBody, "day 5") {
+		t.Errorf("HTMLBody = %q", msg.HTMLBody)
+	}
+	if !strings.Contains(msg.TextBody, "day 5") {
+		t.Errorf("TextBody = %q", msg.TextBody)
+	}
+	if msg.CustomArgs["product"] != "mark8ly" {
+		t.Errorf("product arg = %q", msg.CustomArgs["product"])
+	}
+	if msg.CustomArgs["kind"] != "dunning_day_5" {
+		t.Errorf("kind arg = %q", msg.CustomArgs["kind"])
+	}
+	if msg.CustomArgs["tenant_id"] != "tenant-123" {
+		t.Errorf("tenant_id arg = %q", msg.CustomArgs["tenant_id"])
+	}
+}
+
+// The whole point of #381: never report success for mail we did not send.
+func TestTemplateClient_Send_UndeliverableNeverReachesSender(t *testing.T) {
+	sender := &captureSender{}
+	loader := loaderWith("dunning_day_5", "s", "<p>h</p>", "t")
+	c := email.NewTemplateClient(loader, sender, "noreply@mark8ly.com", slog.Default())
+
+	for _, to := range []string{"", "b0a1-uuid-not-an-email", "billing+7f3a@mark8ly.local"} {
+		err := c.Send(context.Background(), email.TemplateDunningDay5, to, map[string]any{})
+		if err == nil {
+			t.Fatalf("Send(%q) = nil, want ErrUndeliverable", to)
+		}
+		if !errors.Is(err, email.ErrUndeliverable) {
+			t.Errorf("Send(%q) err = %v, want ErrUndeliverable", to, err)
+		}
+	}
+	if len(sender.msgs) != 0 {
+		t.Errorf("sender received %d messages, want 0", len(sender.msgs))
+	}
+}
+
+func TestTemplateClient_Send_UnknownKeyIsRenderFailure(t *testing.T) {
+	sender := &captureSender{}
+	c := email.NewTemplateClient(emailtemplates.NewLoader(nil), sender, "noreply@mark8ly.com", slog.Default())
+
+	err := c.Send(context.Background(), email.TemplateDunningDay5, "merchant@example.com", map[string]any{})
+	if err == nil {
+		t.Fatal("Send with unregistered key = nil, want error")
+	}
+	if !errors.Is(err, email.ErrRender) {
+		t.Errorf("err = %v, want ErrRender", err)
+	}
+	if email.SkipReason(err) != email.ReasonRenderFailed {
+		t.Errorf("SkipReason = %q, want %q", email.SkipReason(err), email.ReasonRenderFailed)
+	}
+}
+
+func TestTemplateClient_Send_TransportFailurePropagates(t *testing.T) {
+	sender := &captureSender{err: errors.New("sendgrid 503")}
+	loader := loaderWith("dunning_day_5", "s", "<p>h</p>", "t")
+	c := email.NewTemplateClient(loader, sender, "noreply@mark8ly.com", slog.Default())
+
+	err := c.Send(context.Background(), email.TemplateDunningDay5, "merchant@example.com", map[string]any{})
+	if err == nil {
+		t.Fatal("Send = nil, want transport error")
+	}
+	if !errors.Is(err, email.ErrTransport) {
+		t.Errorf("err = %v, want ErrTransport", err)
+	}
+	if email.SkipReason(err) != email.ReasonTransportFailed {
+		t.Errorf("SkipReason = %q, want %q", email.SkipReason(err), email.ReasonTransportFailed)
+	}
+}
+
+func TestSkipReason_UndeliverableWins(t *testing.T) {
+	err := email.ValidateRecipient("x@y.local")
+	if got := email.SkipReason(err); got != email.ReasonPlaceholderAddress {
+		t.Errorf("SkipReason = %q, want %q", got, email.ReasonPlaceholderAddress)
+	}
+	if got := email.SkipReason(errors.New("boom")); got != email.ReasonUnknown {
+		t.Errorf("SkipReason(unrelated) = %q, want %q", got, email.ReasonUnknown)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go test ./internal/email/ -run TestTemplateClient -v
+```
+
+Expected: FAIL — `undefined: email.NewTemplateClient`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `internal/email/template_client.go`:
+
+```go
+package email
+
+// template_client.go — the production implementation of Client.
+//
+// Before this landed, Client had exactly one implementation (NoOpClient),
+// so no merchant had ever received a dunning notice, trial reminder,
+// payment-action reminder, win-back promo or trial-billed confirmation
+// (#381). This adapter renders a template key through the shared
+// emailtemplates registry — the same one orderdoc and giftcard use, so
+// operators can reword billing copy without a deploy — and hands the
+// finished envelope to the shared SendGrid→Resend Sender chain.
+//
+// Contract, and the reason the delivery counters can be trusted: Send
+// returns nil if and only if a provider accepted the message. Every other
+// outcome returns a classified error. Callers map that to a
+// billing_emails_skipped_total{template,reason} increment; they must never
+// increment a *_sent_total counter for it.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+)
+
+// fromName is the display name on every billing email.
+const fromName = "Mark8ly Billing"
+
+// Sentinels so callers can classify a failure without string matching.
+var (
+	// ErrRender means the template could not be rendered — an unknown key,
+	// or a published DB override with broken syntax.
+	ErrRender = errors.New("template render failed")
+	// ErrTransport means every configured provider refused the message.
+	ErrTransport = errors.New("transport failed")
+)
+
+// Additional reason labels, complementing those in recipient.go.
+const (
+	ReasonRenderFailed    = "render_failed"
+	ReasonTransportFailed = "transport_failed"
+	ReasonUnknown         = "unknown"
+)
+
+// SkipReason maps a Send error onto a stable metric label.
+func SkipReason(err error) string {
+	if reason, ok := UndeliverableReason(err); ok {
+		return reason
+	}
+	switch {
+	case errors.Is(err, ErrRender):
+		return ReasonRenderFailed
+	case errors.Is(err, ErrTransport):
+		return ReasonTransportFailed
+	default:
+		return ReasonUnknown
+	}
+}
+
+type templateClient struct {
+	loader *emailtemplates.Loader
+	sender Sender
+	from   string
+	logger *slog.Logger
+}
+
+// NewTemplateClient returns the production Client. loader and sender are
+// required; a nil logger falls back to slog.Default().
+func NewTemplateClient(loader *emailtemplates.Loader, sender Sender, from string, logger *slog.Logger) Client {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &templateClient{loader: loader, sender: sender, from: from, logger: logger}
+}
+
+// Send renders `template` with `data` and delivers it to `to`.
+//
+// `to` is an email address. It used to be a store UUID at four call sites
+// and a Stripe customer ID at a fifth; callers now resolve the address from
+// store_subscriptions.email before calling.
+func (c *templateClient) Send(ctx context.Context, template TemplateID, to string, data map[string]any) error {
+	if err := ValidateRecipient(to); err != nil {
+		c.logger.Warn("billing email: undeliverable recipient; not sending",
+			"template", string(template), "reason", SkipReason(err))
+		return err
+	}
+
+	rendered, err := c.loader.Render(ctx, string(template), data)
+	if err != nil {
+		c.logger.Error("billing email: render failed",
+			"template", string(template), "err", err.Error())
+		return fmt.Errorf("email: render %s: %w: %v", template, ErrRender, err)
+	}
+
+	msg := Message{
+		From:     c.from,
+		FromName: fromName,
+		To:       strings.TrimSpace(to),
+		Subject:  rendered.Subject,
+		HTMLBody: rendered.HTMLBody,
+		TextBody: rendered.TextBody,
+		// Wave 1.5 attribution — the same shape the five working mailers
+		// emit, so the notification-service webhook receiver groups these
+		// without parsing subjects, and #348's send log picks them up free.
+		CustomArgs: map[string]string{
+			"product": "mark8ly",
+			"kind":    string(template),
+		},
+	}
+	if tenantID, ok := data["tenant_id"].(string); ok && tenantID != "" {
+		msg.CustomArgs["tenant_id"] = tenantID
+	}
+
+	if err := c.sender.Send(ctx, msg); err != nil {
+		c.logger.Error("billing email: transport failed",
+			"template", string(template), "err", err.Error())
+		return fmt.Errorf("email: send %s: %w: %v", template, ErrTransport, err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go test ./internal/email/ -v
+```
+
+Expected: PASS, including the pre-existing `noop_test.go` and `fallback_test.go` cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/m8-381 && git add services/marketplace-api/internal/email/template_client.go services/marketplace-api/internal/email/template_client_test.go
+git commit -m "feat(email): add the production template client over the shared sender chain"
+```
+
+---
+
+### Task 4: The eleven templates and their registration
+
+Registers every billing key against the shared `emailtemplates.Loader` so an
+operator can reword copy without a deploy, with an embedded fallback that keeps
+mail flowing when the DB row is absent (which it is for all of them today — see
+the spec's "no seed rows" decision).
+
+`hosted_invoice_url` is guarded with `{{if}}` because it is only populated by
+`invoice.payment_action_required` and cleared on `invoice.paid`
+(`subscription/models.go:150-155`), so dunning rows may legitimately lack it.
+
+**Files:**
+- Modify: `internal/email/client.go` (add `TemplateWinBack`)
+- Modify: `internal/subscription/lifecycle/winback.go:20-23` (drop the local const, use `email.TemplateWinBack`)
+- Replace: `internal/email/templates.go` (currently a 3-line stub)
+- Create: `internal/email/templates_content.go`
+- Test: `internal/email/templates_test.go`
+
+**Interfaces:**
+- Consumes: `emailtemplates.Loader.Register`, `emailtemplates.EmbeddedFallback`, `TemplateID` constants.
+- Produces:
+  - `func RegisterFallbacks(loader *emailtemplates.Loader)`
+  - `func BillingTemplateKeys() []TemplateID`
+  - `const TemplateWinBack TemplateID = "win_back_day30"`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/email/templates_test.go`:
+
+```go
+package email_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+)
+
+// sampleVars covers every field any billing template references, so one
+// map renders all eleven. Extra keys are harmless.
+func sampleVars() map[string]any {
+	return map[string]any{
+		"store_id":           "11111111-2222-3333-4444-555555555555",
+		"tenant_id":          "66666666-7777-8888-9999-000000000000",
+		"store_name":         "Acme Supply Co",
+		"day":                5,
+		"offset":             "t_minus_7",
+		"days_remaining":     7,
+		"has_payment_method": false,
+		"plan":               "growth",
+		"period":             "monthly",
+		"promo":              "20%-off-6-months",
+		"hosted_invoice_url": "https://invoice.stripe.com/i/test",
+	}
+}
+
+func TestRegisterFallbacks_EveryKeyRenders(t *testing.T) {
+	loader := emailtemplates.NewLoader(nil)
+	email.RegisterFallbacks(loader)
+
+	keys := email.BillingTemplateKeys()
+	if len(keys) != 11 {
+		t.Fatalf("BillingTemplateKeys() has %d keys, want 11", len(keys))
+	}
+
+	for _, key := range keys {
+		t.Run(string(key), func(t *testing.T) {
+			r, err := loader.Render(context.Background(), string(key), sampleVars())
+			if err != nil {
+				t.Fatalf("Render(%s) failed: %v", key, err)
+			}
+			if strings.TrimSpace(r.Subject) == "" {
+				t.Error("empty subject")
+			}
+			if strings.TrimSpace(r.TextBody) == "" {
+				t.Error("empty text body")
+			}
+			if !strings.Contains(r.HTMLBody, "<!doctype html>") {
+				t.Error("html body is not a full document — chrome not applied")
+			}
+			if strings.Contains(r.HTMLBody, "<!--BODY-->") {
+				t.Error("chrome placeholder was not substituted")
+			}
+			// Every template addresses the merchant by store name.
+			if !strings.Contains(r.HTMLBody, "Acme Supply Co") {
+				t.Error("html body does not reference store_name")
+			}
+			// No unresolved template actions should survive rendering.
+			if strings.Contains(r.HTMLBody, "{{") || strings.Contains(r.TextBody, "{{") {
+				t.Error("unrendered template action left in output")
+			}
+		})
+	}
+}
+
+func TestRegisterFallbacks_HostedInvoiceURLIsOptional(t *testing.T) {
+	loader := emailtemplates.NewLoader(nil)
+	email.RegisterFallbacks(loader)
+
+	vars := sampleVars()
+	vars["hosted_invoice_url"] = ""
+
+	r, err := loader.Render(context.Background(), string(email.TemplateDunningDay5), vars)
+	if err != nil {
+		t.Fatalf("Render without invoice url failed: %v", err)
+	}
+	if strings.Contains(r.HTMLBody, "href=\"\"") {
+		t.Error("emitted an empty href instead of omitting the CTA")
+	}
+}
+
+func TestBillingTemplateKeys_IncludesWinBack(t *testing.T) {
+	var found bool
+	for _, k := range email.BillingTemplateKeys() {
+		if k == email.TemplateWinBack {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("win_back_day30 missing from the billing catalog")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go test ./internal/email/ -run 'TestRegisterFallbacks|TestBillingTemplateKeys' -v
+```
+
+Expected: FAIL — `undefined: email.RegisterFallbacks`, `undefined: email.BillingTemplateKeys`, `undefined: email.TemplateWinBack`.
+
+- [ ] **Step 3a: Move the win-back template constant into the email package**
+
+In `internal/email/client.go`, add to the existing `const (...)` block, after `TemplateTrialStartedBilled`:
+
+```go
+	// Day-30 post-expiry win-back promo. Lived in the lifecycle package
+	// until #381; moved here so the billing catalog is complete in one
+	// place and the email package can register its fallback without
+	// importing lifecycle (which imports email).
+	TemplateWinBack TemplateID = "win_back_day30"
+```
+
+In `internal/subscription/lifecycle/winback.go`, delete lines 20-23 (the
+`TemplateWinBack` doc comment and const) and change the reference at what is
+currently line 76 from `TemplateWinBack` to `email.TemplateWinBack`.
+
+- [ ] **Step 3b: Write the template content**
+
+Create `internal/email/templates_content.go`:
+
+```go
+package email
+
+// templates_content.go — embedded fallback copy for the eleven billing
+// templates (#381).
+//
+// These are FALLBACKS. The authoritative copy, once an operator writes one,
+// is the published row in email_templates; the loader prefers it and only
+// reaches for these when the row is absent, draft, or the DB is unreachable.
+// Keep them plain and provider-agnostic: no external images, no web fonts,
+// table-based layout, inline styles only.
+//
+// Brand: paper (#F7F6F2) page, white card, ink (#0E0E0C) text, moss
+// (#2D4A2B) for the single call to action. One accent, no decoration.
+
+// chromeHTML wraps every fragment. <!--BODY--> is substituted at
+// registration time; it is deliberately an HTML comment rather than a
+// template action so the chrome itself is never parsed as a template.
+const chromeHTML = `<!doctype html>
+<html>
+<body style="margin:0;padding:0;background:#F7F6F2;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#F7F6F2;">
+<tr><td align="center" style="padding:40px 16px;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;background:#FFFFFF;border-radius:6px;">
+<tr><td style="padding:40px;font-family:'Source Sans 3',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:16px;line-height:1.6;color:#0E0E0C;">
+<!--BODY-->
+<hr style="border:none;border-top:1px solid #E4E2DC;margin:32px 0 16px;">
+<p style="font-size:12px;line-height:1.5;color:#6B6A64;margin:0;">Mark8ly · You are receiving this because you run a store on Mark8ly.</p>
+</td></tr></table>
+</td></tr></table>
+</body>
+</html>`
+
+// h1 is the shared editorial headline style — Source Serif 4, per the
+// brand direction that the serif carries the brand.
+const h1 = `style="font-family:'Source Serif 4',Georgia,serif;font-size:26px;line-height:1.25;font-weight:600;margin:0 0 20px;"`
+
+// cta renders the single moss button. Guarded by {{if}} at each call site
+// so a missing URL omits the button rather than emitting an empty href.
+const ctaOpen = `<p style="margin:28px 0 0;"><a href="`
+const ctaMid = `" style="display:inline-block;background:#2D4A2B;color:#FFFFFF;text-decoration:none;padding:12px 22px;border-radius:6px;font-weight:600;">`
+const ctaClose = `</a></p>`
+
+// --- subjects -------------------------------------------------------
+
+var billingSubjects = map[TemplateID]string{
+	TemplateDunningDay5:           `We could not process your payment for {{.store_name}}`,
+	TemplateDunningDay7:           `Action needed to keep {{.store_name}} open`,
+	TemplatePaymentActionReminder: `Confirm your payment for {{.store_name}}`,
+	TemplateTrialNoPMT15:          `15 days left in your {{.store_name}} trial`,
+	TemplateTrialNoPMT10:          `10 days left in your {{.store_name}} trial`,
+	TemplateTrialNoPMT7:           `One week left in your {{.store_name}} trial`,
+	TemplateTrialNoPMT3:           `3 days left in your {{.store_name}} trial`,
+	TemplateTrialNoPMT1:           `Your {{.store_name}} trial ends tomorrow`,
+	TemplateTrialHasPMT1:          `Your {{.plan}} plan for {{.store_name}} starts tomorrow`,
+	TemplateTrialStartedBilled:    `Your {{.plan}} plan for {{.store_name}} is active`,
+	TemplateWinBack:               `Come back to Mark8ly — 20% off six months`,
+}
+
+// --- HTML fragments -------------------------------------------------
+
+var billingHTMLFragments = map[TemplateID]string{
+	TemplateDunningDay5: `<h1 ` + h1 + `>Your payment did not go through</h1>
+<p>We tried to charge the card on file for <strong>{{.store_name}}</strong> and it was declined. Your store is still open.</p>
+<p>Updating your payment method now avoids any interruption.</p>
+{{if .hosted_invoice_url}}` + ctaOpen + `{{.hosted_invoice_url}}` + ctaMid + `Complete your payment` + ctaClose + `{{else}}<p>Open your Mark8ly billing settings to update your card.</p>{{end}}`,
+
+	TemplateDunningDay7: `<h1 ` + h1 + `>Action needed to keep {{.store_name}} open</h1>
+<p>It has been {{.day}} days since your payment failed. If it stays unpaid, <strong>{{.store_name}}</strong> will be suspended and your storefront will stop serving customers.</p>
+<p>This is reversible right up until suspension.</p>
+{{if .hosted_invoice_url}}` + ctaOpen + `{{.hosted_invoice_url}}` + ctaMid + `Pay now` + ctaClose + `{{else}}<p>Open your Mark8ly billing settings to update your card.</p>{{end}}`,
+
+	TemplatePaymentActionReminder: `<h1 ` + h1 + `>One step left to confirm your payment</h1>
+<p>Your bank asked for extra confirmation before charging the card for <strong>{{.store_name}}</strong>. Until you approve it, the payment is not complete.</p>
+{{if .hosted_invoice_url}}` + ctaOpen + `{{.hosted_invoice_url}}` + ctaMid + `Confirm payment` + ctaClose + `{{else}}<p>Open your Mark8ly billing settings to finish confirming.</p>{{end}}`,
+
+	TemplateTrialNoPMT15: `<h1 ` + h1 + `>15 days left in your trial</h1>
+<p><strong>{{.store_name}}</strong> has {{.days_remaining}} days left on the free trial. There is no card on file yet.</p>
+<p>Adding one now means your storefront keeps serving customers the moment the trial ends. Nothing is charged until then.</p>`,
+
+	TemplateTrialNoPMT10: `<h1 ` + h1 + `>10 days left in your trial</h1>
+<p><strong>{{.store_name}}</strong> has {{.days_remaining}} days left on the free trial, and no payment method on file.</p>
+<p>Choose a plan whenever you are ready — you will not be charged before the trial ends.</p>`,
+
+	TemplateTrialNoPMT7: `<h1 ` + h1 + `>One week left in your trial</h1>
+<p><strong>{{.store_name}}</strong> has {{.days_remaining}} days of trial remaining. There is still no card on file.</p>
+<p>Without one, your storefront stops serving customers when the trial ends.</p>`,
+
+	TemplateTrialNoPMT3: `<h1 ` + h1 + `>3 days left in your trial</h1>
+<p><strong>{{.store_name}}</strong> has {{.days_remaining}} days left. Adding a payment method takes a minute and keeps everything running.</p>`,
+
+	TemplateTrialNoPMT1: `<h1 ` + h1 + `>Your trial ends tomorrow</h1>
+<p>Tomorrow the free trial for <strong>{{.store_name}}</strong> ends. With no payment method on file, the storefront will stop serving customers.</p>
+<p>Your products, orders and settings are kept — adding a card restores the store immediately.</p>`,
+
+	TemplateTrialHasPMT1: `<h1 ` + h1 + `>Your {{.plan}} plan starts tomorrow</h1>
+<p>The free trial for <strong>{{.store_name}}</strong> ends tomorrow, and your <strong>{{.plan}}</strong> plan begins. We will charge the card on file — nothing for you to do.</p>
+<p>If you would rather change plan, you can do that before the charge.</p>`,
+
+	TemplateTrialStartedBilled: `<h1 ` + h1 + `>Your {{.plan}} plan is active</h1>
+<p>Thank you — the first payment for <strong>{{.store_name}}</strong> went through and your <strong>{{.plan}}</strong> plan is now active, billed {{.period}}.</p>
+<p>Your receipt is in your billing settings.</p>`,
+
+	TemplateWinBack: `<h1 ` + h1 + `>Your store is still here</h1>
+<p><strong>{{.store_name}}</strong> has been closed for a month. Everything — products, orders, settings — is exactly as you left it.</p>
+<p>If you want to pick it back up, we will take <strong>20% off your first six months</strong>.</p>`,
+}
+
+// --- text fragments -------------------------------------------------
+
+var billingTextFragments = map[TemplateID]string{
+	TemplateDunningDay5: `Your payment did not go through
+
+We tried to charge the card on file for {{.store_name}} and it was declined. Your store is still open.
+
+Updating your payment method now avoids any interruption.
+{{if .hosted_invoice_url}}
+Complete your payment: {{.hosted_invoice_url}}
+{{else}}
+Open your Mark8ly billing settings to update your card.
+{{end}}
+Mark8ly`,
+
+	TemplateDunningDay7: `Action needed to keep {{.store_name}} open
+
+It has been {{.day}} days since your payment failed. If it stays unpaid, {{.store_name}} will be suspended and your storefront will stop serving customers.
+
+This is reversible right up until suspension.
+{{if .hosted_invoice_url}}
+Pay now: {{.hosted_invoice_url}}
+{{else}}
+Open your Mark8ly billing settings to update your card.
+{{end}}
+Mark8ly`,
+
+	TemplatePaymentActionReminder: `One step left to confirm your payment
+
+Your bank asked for extra confirmation before charging the card for {{.store_name}}. Until you approve it, the payment is not complete.
+{{if .hosted_invoice_url}}
+Confirm payment: {{.hosted_invoice_url}}
+{{else}}
+Open your Mark8ly billing settings to finish confirming.
+{{end}}
+Mark8ly`,
+
+	TemplateTrialNoPMT15: `15 days left in your trial
+
+{{.store_name}} has {{.days_remaining}} days left on the free trial. There is no card on file yet.
+
+Adding one now means your storefront keeps serving customers the moment the trial ends. Nothing is charged until then.
+
+Mark8ly`,
+
+	TemplateTrialNoPMT10: `10 days left in your trial
+
+{{.store_name}} has {{.days_remaining}} days left on the free trial, and no payment method on file.
+
+Choose a plan whenever you are ready — you will not be charged before the trial ends.
+
+Mark8ly`,
+
+	TemplateTrialNoPMT7: `One week left in your trial
+
+{{.store_name}} has {{.days_remaining}} days of trial remaining. There is still no card on file.
+
+Without one, your storefront stops serving customers when the trial ends.
+
+Mark8ly`,
+
+	TemplateTrialNoPMT3: `3 days left in your trial
+
+{{.store_name}} has {{.days_remaining}} days left. Adding a payment method takes a minute and keeps everything running.
+
+Mark8ly`,
+
+	TemplateTrialNoPMT1: `Your trial ends tomorrow
+
+Tomorrow the free trial for {{.store_name}} ends. With no payment method on file, the storefront will stop serving customers.
+
+Your products, orders and settings are kept — adding a card restores the store immediately.
+
+Mark8ly`,
+
+	TemplateTrialHasPMT1: `Your {{.plan}} plan starts tomorrow
+
+The free trial for {{.store_name}} ends tomorrow, and your {{.plan}} plan begins. We will charge the card on file — nothing for you to do.
+
+If you would rather change plan, you can do that before the charge.
+
+Mark8ly`,
+
+	TemplateTrialStartedBilled: `Your {{.plan}} plan is active
+
+Thank you — the first payment for {{.store_name}} went through and your {{.plan}} plan is now active, billed {{.period}}.
+
+Your receipt is in your billing settings.
+
+Mark8ly`,
+
+	TemplateWinBack: `Your store is still here
+
+{{.store_name}} has been closed for a month. Everything — products, orders, settings — is exactly as you left it.
+
+If you want to pick it back up, we will take 20% off your first six months.
+
+Mark8ly`,
+}
+```
+
+- [ ] **Step 3c: Write the registration**
+
+Replace the whole of `internal/email/templates.go` with:
+
+```go
+// Package-level template registration for billing mail (#381).
+//
+// Every key here is registered against the shared emailtemplates.Loader at
+// boot, exactly as orderdoc and giftcard do. Registration makes a key
+// overridable from the operator console; it does not seed a DB row, so
+// until someone authors one these embedded fallbacks are what sends.
+package email
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+)
+
+// bodyMarker is the substitution point in chromeHTML.
+const bodyMarker = "<!--BODY-->"
+
+// billingTemplateKeys is the catalog, in the order an operator would
+// encounter them across a subscription's life.
+var billingTemplateKeys = []TemplateID{
+	TemplateTrialNoPMT15,
+	TemplateTrialNoPMT10,
+	TemplateTrialNoPMT7,
+	TemplateTrialNoPMT3,
+	TemplateTrialNoPMT1,
+	TemplateTrialHasPMT1,
+	TemplateTrialStartedBilled,
+	TemplatePaymentActionReminder,
+	TemplateDunningDay5,
+	TemplateDunningDay7,
+	TemplateWinBack,
+}
+
+// BillingTemplateKeys returns a copy of the catalog. A copy, so a caller
+// cannot reorder or truncate the registry it is reading.
+func BillingTemplateKeys() []TemplateID {
+	out := make([]TemplateID, len(billingTemplateKeys))
+	copy(out, billingTemplateKeys)
+	return out
+}
+
+// RegisterFallbacks binds every billing template's embedded fallback to
+// the loader. Call once at boot, before any cron can fire.
+//
+// Panics if a key is missing content — a programming error that would
+// otherwise surface as a silently unsent email at 09:05 UTC.
+func RegisterFallbacks(loader *emailtemplates.Loader) {
+	for _, key := range billingTemplateKeys {
+		subject, ok := billingSubjects[key]
+		if !ok {
+			panic(fmt.Sprintf("email: no subject registered for template %q", key))
+		}
+		htmlFragment, ok := billingHTMLFragments[key]
+		if !ok {
+			panic(fmt.Sprintf("email: no html fragment registered for template %q", key))
+		}
+		textBody, ok := billingTextFragments[key]
+		if !ok {
+			panic(fmt.Sprintf("email: no text fragment registered for template %q", key))
+		}
+		loader.Register(string(key), emailtemplates.EmbeddedFallback{
+			Subject:  subject,
+			HTMLBody: strings.Replace(chromeHTML, bodyMarker, htmlFragment, 1),
+			TextBody: textBody,
+		})
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go build ./... && go test ./internal/email/ ./internal/subscription/lifecycle/ -v
+```
+
+Expected: PASS. All eleven subtests of `TestRegisterFallbacks_EveryKeyRenders` render, and `lifecycle` still compiles against `email.TemplateWinBack`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/m8-381 && git add services/marketplace-api/internal/email/ services/marketplace-api/internal/subscription/lifecycle/winback.go
+git commit -m "feat(email): register embedded fallbacks for the eleven billing templates"
+```
+
+---
+
+### Task 5: The `store_subscriptions.email` column
+
+**Files:**
+- Create: `migrations/000104_store_subscriptions_email.up.sql`
+- Create: `migrations/000104_store_subscriptions_email.down.sql`
+- Modify: `internal/subscription/models.go` (add a field after `StripeCustomerID` at :110)
+
+**Interfaces:**
+- Produces: `subscription.StoreSubscription.Email *string` mapped to column `email`.
+
+- [ ] **Step 1: Write the migration**
+
+Create `migrations/000104_store_subscriptions_email.up.sql`:
+
+```sql
+-- Billing mail needs somewhere to send to (#381). Until now dunning, trial
+-- reminder, payment-action, win-back and trial-billed mailers passed a store
+-- UUID as the "to" address, which was harmless only because every one of them
+-- was wired to a no-op client.
+--
+-- NULL means "not known yet" and is explicitly expected: customer.updated only
+-- fires on change, so rows predating this column stay NULL until
+-- cmd/backfill-email reads them from Stripe. A NULL recipient is refused by
+-- email.ValidateRecipient and counted as skipped — never sent, never counted
+-- as delivered.
+--
+-- citext because email comparison is case-insensitive and we do not want two
+-- rows differing only by case to read as different merchants.
+CREATE EXTENSION IF NOT EXISTS citext;
+
+ALTER TABLE store_subscriptions ADD COLUMN IF NOT EXISTS email CITEXT;
+```
+
+Create `migrations/000104_store_subscriptions_email.down.sql`:
+
+```sql
+-- DESTRUCTIVE: drops every merchant billing address mirrored from Stripe.
+-- Recoverable by re-running cmd/backfill-email, since Stripe remains the
+-- source of truth — but every cron reverts to sending nothing in the
+-- meantime, because a NULL recipient is refused.
+--
+-- The citext extension is deliberately NOT dropped: other objects may depend
+-- on it, and dropping a shared extension during a rollback is how you take
+-- down unrelated tables.
+ALTER TABLE store_subscriptions DROP COLUMN IF EXISTS email;
+```
+
+- [ ] **Step 2: Add the model field**
+
+In `internal/subscription/models.go`, immediately after the `StripeCustomerID` line (:110):
+
+```go
+	// Email is the merchant's billing address, mirrored from the Stripe
+	// customer by handleCustomerUpdated and backfilled by cmd/backfill-email
+	// (migration 104, #381). NULL means "not known yet" — every mailer
+	// refuses to send and counts a skip rather than guessing.
+	Email *string `gorm:"column:email;type:citext"`
+```
+
+- [ ] **Step 3: Apply and verify the migration**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && make migrate-up 2>/dev/null || \
+  go run ./cmd/migrate -database "$TEST_DATABASE_URL" up
+docker run --rm postgres:15 psql "postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable" \
+  -c "\d store_subscriptions" | grep -i email
+```
+
+Expected: a row showing `email | citext |`.
+
+If the connection is refused, `docker start dev-postgres-1` and retry. If no
+`migrate` target exists, check `Makefile` for the project's migrate invocation
+and use that — do not invent a new migration runner.
+
+- [ ] **Step 4: Verify the model compiles and nothing regressed**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go build ./... && go vet ./internal/subscription/...
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/m8-381 && git add services/marketplace-api/migrations/000104_store_subscriptions_email.up.sql services/marketplace-api/migrations/000104_store_subscriptions_email.down.sql services/marketplace-api/internal/subscription/models.go
+git commit -m "feat(subscription): add store_subscriptions.email for billing mail"
+```
+
+---
+
+### Task 6: Mirror the address from `customer.updated`
+
+The webhook that already updates this table for `has_default_payment_method`
+gains one field and one column in the same statement — no new subscription, no
+new query, no new failure mode.
+
+**Files:**
+- Modify: `internal/billing/dispatch/handlers.go:413-444` (`handleCustomerUpdated`)
+- Test: `internal/billing/dispatch/handlers_customer_updated_test.go`
+
+**Interfaces:**
+- Consumes: `subscription.StoreSubscription.Email` (Task 5).
+- Produces: nothing new; behaviour change only.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/billing/dispatch/handlers_customer_updated_test.go`. This is an
+integration test because it asserts a real `UPDATE`:
+
+The package's integration tests open the database with
+`pkg/testdb.NewDB(t, tables...)`, which truncates the named tables before and
+after each test — see `dispatcher_test.go:21`. Use that; do not write a new
+helper.
+
+```go
+//go:build integration
+
+package dispatch_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/dispatch"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+func TestHandleCustomerUpdated_MirrorsEmail(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions")
+	ctx := context.Background()
+
+	customerID := "cus_" + uuid.NewString()[:12]
+	sub := &subscription.StoreSubscription{
+		TenantID:         uuid.New(),
+		StoreID:          uuid.New(),
+		StripeCustomerID: customerID,
+	}
+	require.NoError(t, db.Create(sub).Error)
+
+	raw := []byte(`{"data":{"object":{"id":"` + customerID + `","email":"merchant@example.com","invoice_settings":{"default_payment_method":"pm_123"}}}}`)
+
+	if err := dispatch.HandleCustomerUpdatedForTest(ctx, db, raw); err != nil {
+		t.Fatalf("handleCustomerUpdated: %v", err)
+	}
+
+	var got subscription.StoreSubscription
+	if err := db.Where("stripe_customer_id = ?", customerID).First(&got).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.Email == nil || *got.Email != "merchant@example.com" {
+		t.Errorf("Email = %v, want merchant@example.com", got.Email)
+	}
+	if !got.HasDefaultPaymentMethod {
+		t.Error("HasDefaultPaymentMethod regressed to false")
+	}
+}
+
+// An event without an email must not blank an address we already have.
+func TestHandleCustomerUpdated_AbsentEmailPreservesExisting(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions")
+	ctx := context.Background()
+
+	existing := "keep@example.com"
+	customerID := "cus_" + uuid.NewString()[:12]
+	sub := &subscription.StoreSubscription{
+		TenantID:         uuid.New(),
+		StoreID:          uuid.New(),
+		StripeCustomerID: customerID,
+		Email:            &existing,
+	}
+	if err := db.Create(sub).Error; err != nil {
+		t.Fatalf("seed subscription: %v", err)
+	}
+
+	raw := []byte(`{"data":{"object":{"id":"` + customerID + `","invoice_settings":{"default_payment_method":null}}}}`)
+
+	if err := dispatch.HandleCustomerUpdatedForTest(ctx, db, raw); err != nil {
+		t.Fatalf("handleCustomerUpdated: %v", err)
+	}
+
+	var got subscription.StoreSubscription
+	if err := db.Where("stripe_customer_id = ?", customerID).First(&got).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.Email == nil || *got.Email != existing {
+		t.Errorf("Email = %v, want it preserved as %q", got.Email, existing)
+	}
+}
+```
+
+`handleCustomerUpdated` is unexported and the tests live in `dispatch_test`, so
+add an export-for-test shim in a new `//go:build integration` file inside the
+package:
+
+```go
+//go:build integration
+
+package dispatch
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// HandleCustomerUpdatedForTest exposes the unexported handler to the
+// package's external integration tests.
+func HandleCustomerUpdatedForTest(ctx context.Context, tx *gorm.DB, raw []byte) error {
+	return handleCustomerUpdated(ctx, tx, raw)
+}
+```
+
+Note `testdb.NewDB` **skips** rather than fails when the database is
+unreachable. A green run with no output is not proof; check for `--- PASS` on
+the named tests, not merely `exit=0`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && ps aux | grep -c "[g]o test -tags=integration"
+TEST_DATABASE_URL="postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable" \
+  go test -tags=integration -p 1 ./internal/billing/dispatch/ -run TestHandleCustomerUpdated -v
+```
+
+Expected: the `grep -c` prints `0` (nothing else is running a suite), then FAIL —
+`Email = <nil>, want merchant@example.com`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `internal/billing/dispatch/handlers.go`, extend the anonymous payload struct
+in `handleCustomerUpdated` to parse the address, and widen the `UPDATE`:
+
+```go
+	var e struct {
+		Data struct {
+			Object struct {
+				Customer        string `json:"id"`
+				Email           string `json:"email"`
+				InvoiceSettings struct {
+					DefaultPaymentMethod *string `json:"default_payment_method"`
+				} `json:"invoice_settings"`
+			} `json:"object"`
+		} `json:"data"`
+	}
+```
+
+Replace the `UPDATE` with:
+
+```go
+	// email is written only when the event carries one. Stripe omits the
+	// field on some replays, and an absent field must not blank an address
+	// we already hold — COALESCE on the parameter, not on the column, so an
+	// empty string is treated as "no value in this event".
+	email := strings.TrimSpace(e.Data.Object.Email)
+
+	res := tx.WithContext(ctx).Exec(`
+		UPDATE store_subscriptions
+		SET has_default_payment_method = ?,
+		    email                      = COALESCE(NULLIF(?, ''), email),
+		    updated_at                 = now()
+		WHERE stripe_customer_id = ?`,
+		hasPM, email, customer,
+	)
+	if res.Error != nil {
+		return fmt.Errorf("dispatch: customer.updated has_default_payment_method: %w", res.Error)
+	}
+	return nil
+```
+
+Add `"strings"` to the file's imports if it is not already there.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && \
+TEST_DATABASE_URL="postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable" \
+  go test -tags=integration -p 1 ./internal/billing/dispatch/ -run TestHandleCustomerUpdated -v
+```
+
+Expected: PASS, both cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/m8-381 && git add services/marketplace-api/internal/billing/dispatch/
+git commit -m "feat(billing): mirror the Stripe customer email onto store_subscriptions"
+```
+
+---
+
+### Task 7: Backfill addresses for rows predating the column
+
+`customer.updated` only fires on change, so every existing subscription stays
+NULL without this. Modeled on `cmd/backfill-has-pm`, which exists for exactly
+this shape.
+
+**Files:**
+- Modify: `internal/billing/stripe/customer.go` (add `GetCustomerEmail`)
+- Create: `cmd/backfill-email/main.go`
+- Test: `internal/billing/stripe/customer_email_test.go`
+
+**Interfaces:**
+- Consumes: `billingstripe.Client`, `subscription.StoreSubscription.Email` (Task 5).
+- Produces: `func GetCustomerEmail(ctx context.Context, c *Client, customerID string) (string, error)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/billing/stripe/customer_email_test.go`:
+
+```go
+package stripe_test
+
+import (
+	"context"
+	"testing"
+
+	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
+)
+
+func TestGetCustomerEmail_EmptyCustomerID(t *testing.T) {
+	got, err := billingstripe.GetCustomerEmail(context.Background(), nil, "")
+	if err != nil {
+		t.Fatalf("err = %v, want nil for an empty customer id", err)
+	}
+	if got != "" {
+		t.Errorf("email = %q, want empty", got)
+	}
+}
+```
+
+Check the package's existing `customer_test.go` for an established fake-transport
+harness. If one exists, add a case asserting a customer payload with
+`"email":"merchant@example.com"` yields that address; if not, this
+guard-clause test plus the backfill's integration coverage is sufficient — do
+not stand up a new HTTP fake for one getter.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go test ./internal/billing/stripe/ -run TestGetCustomerEmail -v
+```
+
+Expected: FAIL — `undefined: stripe.GetCustomerEmail`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/billing/stripe/customer.go`:
+
+```go
+// GetCustomerEmail returns the billing address Stripe holds for a customer,
+// or "" when the customer has none. Used by cmd/backfill-email to populate
+// store_subscriptions.email for rows predating migration 104 (#381).
+//
+// An empty customerID is not an error — it means the subscription was never
+// bootstrapped against Stripe, which the caller skips.
+func GetCustomerEmail(ctx context.Context, c *Client, customerID string) (string, error) {
+	if customerID == "" {
+		return "", nil
+	}
+	params := &sdk.CustomerRetrieveParams{}
+	params.Context = ctx
+	cu, err := c.sdk.V1Customers.Retrieve(ctx, customerID, params)
+	if err != nil {
+		return "", toAPIError(err)
+	}
+	if cu == nil {
+		return "", nil
+	}
+	return cu.Email, nil
+}
+```
+
+- [ ] **Step 4: Write the backfill command**
+
+Create `cmd/backfill-email/main.go`:
+
+```go
+// Command backfill-email populates store_subscriptions.email for rows that
+// pre-date migration 104. customer.updated webhooks only fire on change, so
+// historical customers with an email already set in Stripe won't have the
+// column populated without this script (#381).
+//
+// Run once per environment after migration 104 lands. Idempotent — safe to
+// re-run; it always re-reads from Stripe and writes the current value.
+//
+// Addresses Stripe reports that we would refuse to send to (the
+// billing+<store_id>@mark8ly.local placeholders minted by subscription
+// bootstrap) are counted as `Placeholder` and NOT written: storing one would
+// only move the refusal from send time to a column nobody reads.
+//
+// Multi-tenant safety: each row is keyed by stripe_customer_id (1:1 with
+// (tenant_id, store_id)). A failure on one row does not block other rows or
+// other tenants — failures are logged and the script continues.
+package main
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"os"
+	"time"
+
+	"gorm.io/gorm"
+
+	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/db"
+)
+
+func main() {
+	var (
+		batchSize int
+		throttle  time.Duration
+		dryRun    bool
+	)
+	flag.IntVar(&batchSize, "batch", 200, "rows fetched per DB scan")
+	flag.DurationVar(&throttle, "throttle", 50*time.Millisecond, "sleep between Stripe API calls (rate-limit hedge)")
+	flag.BoolVar(&dryRun, "dry-run", false, "log changes without writing")
+	flag.Parse()
+
+	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		log.Error("backfill-email: DATABASE_URL not set")
+		os.Exit(1)
+	}
+	stripeKey := os.Getenv("STRIPE_BILLING_SECRET_KEY")
+	if stripeKey == "" {
+		log.Error("backfill-email: STRIPE_BILLING_SECRET_KEY not set")
+		os.Exit(1)
+	}
+
+	conn, err := db.Open(databaseURL)
+	if err != nil {
+		log.Error("backfill-email: db open failed", "err", err)
+		os.Exit(1)
+	}
+	stripeClient := billingstripe.New(stripeKey)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	stats, err := run(ctx, conn, stripeClient, batchSize, throttle, dryRun, log)
+	if err != nil {
+		log.Error("backfill-email: run failed", "err", err, "stats", stats)
+		os.Exit(1)
+	}
+	log.Info("backfill-email: done", "stats", stats)
+}
+
+type runStats struct {
+	Scanned     int
+	Updated     int
+	Unchanged   int
+	NoneInStripe int
+	Placeholder int // Stripe holds an address we would refuse to send to
+	Failed      int
+}
+
+func run(ctx context.Context, conn *gorm.DB, sc *billingstripe.Client, batchSize int, throttle time.Duration, dryRun bool, log *slog.Logger) (runStats, error) {
+	var stats runStats
+
+	// Keyset pagination via id ordering — avoids OFFSET drift on a live table
+	// and keeps memory bounded regardless of subscription count.
+	lastID := ""
+
+	for {
+		var rows []subscription.StoreSubscription
+		q := conn.WithContext(ctx).
+			Where("stripe_customer_id <> ''").
+			Order("id ASC").
+			Limit(batchSize)
+		if lastID != "" {
+			q = q.Where("id > ?", lastID)
+		}
+		if err := q.Find(&rows).Error; err != nil {
+			return stats, err
+		}
+		if len(rows) == 0 {
+			return stats, nil
+		}
+
+		for i := range rows {
+			row := &rows[i]
+			stats.Scanned++
+			lastID = row.ID.String()
+
+			addr, err := billingstripe.GetCustomerEmail(ctx, sc, row.StripeCustomerID)
+			if err != nil {
+				stats.Failed++
+				log.Warn("backfill-email: stripe lookup failed; skipping",
+					"tenant_id", row.TenantID.String(),
+					"store_id", row.StoreID.String(),
+					"stripe_customer_id", row.StripeCustomerID,
+					"err", err.Error())
+				time.Sleep(throttle)
+				continue
+			}
+
+			if addr == "" {
+				stats.NoneInStripe++
+				time.Sleep(throttle)
+				continue
+			}
+
+			if err := email.ValidateRecipient(addr); err != nil {
+				stats.Placeholder++
+				log.Warn("backfill-email: stripe holds an undeliverable address; not storing",
+					"tenant_id", row.TenantID.String(),
+					"store_id", row.StoreID.String(),
+					"reason", email.SkipReason(err))
+				time.Sleep(throttle)
+				continue
+			}
+
+			if row.Email != nil && *row.Email == addr {
+				stats.Unchanged++
+				time.Sleep(throttle)
+				continue
+			}
+
+			if dryRun {
+				log.Info("backfill-email: dry-run would update",
+					"tenant_id", row.TenantID.String(),
+					"store_id", row.StoreID.String())
+				stats.Updated++
+				time.Sleep(throttle)
+				continue
+			}
+
+			// Per-row UPDATE keyed by id — narrowest possible blast radius.
+			res := conn.WithContext(ctx).Exec(`
+				UPDATE store_subscriptions
+				SET email = ?, updated_at = now()
+				WHERE id = ?`,
+				addr, row.ID,
+			)
+			if res.Error != nil {
+				stats.Failed++
+				log.Warn("backfill-email: update failed",
+					"store_id", row.StoreID.String(), "err", res.Error.Error())
+				time.Sleep(throttle)
+				continue
+			}
+			stats.Updated++
+			time.Sleep(throttle)
+		}
+	}
+}
+```
+
+Confirm `billingstripe.New` and `db.Open` are the exact constructor names used
+by `cmd/backfill-has-pm/main.go`; mirror whatever it does rather than guessing.
+
+- [ ] **Step 5: Run tests and build**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go build ./... && go test ./internal/billing/stripe/ -run TestGetCustomerEmail -v && go run ./cmd/backfill-email -h
+```
+
+Expected: build clean, test PASS, and `-h` prints the three flags.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /tmp/m8-381 && git add services/marketplace-api/internal/billing/stripe/ services/marketplace-api/cmd/backfill-email/
+git commit -m "feat(billing): backfill store_subscriptions.email from Stripe"
+```
+
+---
+
+### Task 8: Claim-first idempotency for the unguarded crons
+
+Trial reminders and payment-action reminders already claim a slot before
+sending. Dunning and win-back re-derive eligibility on every run, so a second
+run the same day re-sends. Behind a no-op that was harmless; with a real
+transport it is duplicate billing mail. One generic table rather than two more
+bespoke ones.
+
+**Files:**
+- Create: `migrations/000105_billing_email_sends.up.sql`
+- Create: `migrations/000105_billing_email_sends.down.sql`
+- Create: `internal/subscription/email_claim.go`
+- Test: `internal/subscription/email_claim_integration_test.go`
+
+**Interfaces:**
+- Produces: `func ClaimEmailSend(ctx context.Context, db *gorm.DB, subscriptionID uuid.UUID, templateKey, periodKey string, now time.Time) (bool, error)` — returns `true` when this caller won the claim and must send, `false` when someone already has it.
+
+- [ ] **Step 1: Write the migration**
+
+Create `migrations/000105_billing_email_sends.up.sql`:
+
+```sql
+-- Claim-first idempotency for billing mail (#381).
+--
+-- trial_reminders and payment_action_reminders already do this per-feature.
+-- Dunning and win-back did not: both re-derive eligibility on every run
+-- (dunning from audit_logs date arithmetic, win-back from an updated_at
+-- window), so a second run on the same day re-sent to the same merchants.
+-- That was invisible while every send was a no-op.
+--
+-- Generic rather than two more bespoke tables: four near-identical marker
+-- tables is three too many, and this is where trial_reminders and
+-- payment_action_reminders should eventually be folded in.
+--
+-- period_key disambiguates repeats of the same template for the same
+-- subscription: the target date for dunning, the window-start date for
+-- win-back. template_key alone would suppress a legitimate day-7 notice
+-- after a day-5 one; period_key alone would collide across templates.
+CREATE TABLE IF NOT EXISTS billing_email_sends (
+    subscription_id UUID        NOT NULL,
+    template_key    TEXT        NOT NULL,
+    period_key      TEXT        NOT NULL,
+    sent_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (subscription_id, template_key, period_key)
+);
+
+-- Supports the operational question "what did we send this store, when?"
+-- without scanning; the primary key already covers the claim path.
+CREATE INDEX IF NOT EXISTS billing_email_sends_sent_at_idx
+    ON billing_email_sends (sent_at DESC);
+```
+
+Create `migrations/000105_billing_email_sends.down.sql`:
+
+```sql
+-- DESTRUCTIVE: drops every claim marker. Rolling back past 105 means the
+-- next dunning or win-back run re-sends to every merchant currently inside
+-- an eligibility window — real duplicate mail to real merchants, not just
+-- lost bookkeeping.
+DROP INDEX IF EXISTS billing_email_sends_sent_at_idx;
+DROP TABLE IF EXISTS billing_email_sends;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `internal/subscription/email_claim_integration_test.go`:
+
+```go
+//go:build integration
+
+package subscription_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+func TestClaimEmailSend_SecondClaimLoses(t *testing.T) {
+	db := testdb.NewDB(t, "billing_email_sends")
+	ctx := context.Background()
+	subID := uuid.New()
+	now := time.Now().UTC()
+
+	won, err := subscription.ClaimEmailSend(ctx, db, subID, "dunning_day_5", "2026-08-26", now)
+	if err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if !won {
+		t.Fatal("first claim did not win")
+	}
+
+	won, err = subscription.ClaimEmailSend(ctx, db, subID, "dunning_day_5", "2026-08-26", now)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if won {
+		t.Error("second claim won — duplicate mail would be sent")
+	}
+}
+
+func TestClaimEmailSend_DifferentTemplateAndPeriodBothWin(t *testing.T) {
+	db := testdb.NewDB(t, "billing_email_sends")
+	ctx := context.Background()
+	subID := uuid.New()
+	now := time.Now().UTC()
+
+	if won, err := subscription.ClaimEmailSend(ctx, db, subID, "dunning_day_5", "2026-08-26", now); err != nil || !won {
+		t.Fatalf("day_5 claim: won=%v err=%v", won, err)
+	}
+	// A day-7 notice after a day-5 one is legitimate, not a duplicate.
+	if won, err := subscription.ClaimEmailSend(ctx, db, subID, "dunning_day_7", "2026-08-26", now); err != nil || !won {
+		t.Errorf("day_7 same date should win: won=%v err=%v", won, err)
+	}
+	// The same template in a later period is also legitimate.
+	if won, err := subscription.ClaimEmailSend(ctx, db, subID, "dunning_day_5", "2026-09-26", now); err != nil || !won {
+		t.Errorf("day_5 later period should win: won=%v err=%v", won, err)
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && ps aux | grep -c "[g]o test -tags=integration"
+TEST_DATABASE_URL="postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable" \
+  go test -tags=integration -p 1 ./internal/subscription/ -run TestClaimEmailSend -v
+```
+
+Expected: `0` running suites, then FAIL — `undefined: subscription.ClaimEmailSend`.
+
+- [ ] **Step 4: Write minimal implementation**
+
+Create `internal/subscription/email_claim.go`:
+
+```go
+package subscription
+
+// email_claim.go — claim-first idempotency for billing mail (#381).
+//
+// The contract mirrors payment_action_reminders: claim the slot BEFORE
+// sending, and never release it on a send failure. That makes delivery
+// at-most-once — a transient provider error costs the merchant that one
+// notice rather than risking a duplicate. The failure is visible through
+// the caller's skipped counter and Warn log.
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// ClaimEmailSend attempts to claim (subscriptionID, templateKey, periodKey).
+//
+// Returns true when this caller inserted the row and is therefore the one
+// that must send. Returns false when the slot was already claimed — by
+// another pod, or by an earlier run of the same cron today.
+func ClaimEmailSend(ctx context.Context, db *gorm.DB, subscriptionID uuid.UUID, templateKey, periodKey string, now time.Time) (bool, error) {
+	res := db.WithContext(ctx).Exec(`
+		INSERT INTO billing_email_sends (subscription_id, template_key, period_key, sent_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT DO NOTHING`,
+		subscriptionID, templateKey, periodKey, now,
+	)
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}
+```
+
+- [ ] **Step 5: Apply the migration and run the test**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go run ./cmd/migrate -database "$TEST_DATABASE_URL" up 2>/dev/null || make migrate-up
+TEST_DATABASE_URL="postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable" \
+  go test -tags=integration -p 1 ./internal/subscription/ -run TestClaimEmailSend -v
+```
+
+Expected: PASS, both tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /tmp/m8-381 && git add services/marketplace-api/migrations/000105_billing_email_sends.up.sql services/marketplace-api/migrations/000105_billing_email_sends.down.sql services/marketplace-api/internal/subscription/email_claim.go services/marketplace-api/internal/subscription/email_claim_integration_test.go
+git commit -m "feat(subscription): add claim-first billing_email_sends idempotency table"
+```
+
+---
+
+### Task 9: Dunning cron — real recipient, claim, honest counters
+
+**Files:**
+- Modify: `internal/subscription/dunning/dunning_emails.go` (`emailRow` :38-42, `runForDay` :91-131, constructor :59)
+- Test: `internal/subscription/dunning/dunning_emails_integration_test.go` (extend — it exists) and `testhelpers_integration_test.go` (add one seeder)
+
+**Interfaces:**
+- Consumes: `subscription.ClaimEmailSend` (Task 8), `email.SkipReason` (Task 3), `dunning.SkipCounter` (Task 2), `StoreSubscription.Email` (Task 5).
+- Produces: `func (s *SendDunningEmails) WithSkipCounter(c SkipCounter) *SendDunningEmails`
+
+A builder method rather than a new constructor parameter, so existing call
+sites and tests keep compiling.
+
+- [ ] **Step 1: Write the failing test**
+
+The dunning cron is only reachable through the database, and this package
+already has the seams: `testdb.NewDB`, plus `seedStore` in
+`testhelpers_integration_test.go:27`. Follow
+`dunning_emails_integration_test.go` for how a `past_due` row and its matching
+`audit_logs` transition are seeded — read it before writing this, and reuse its
+helpers rather than adding parallel ones.
+
+Add to `internal/subscription/dunning/dunning_emails_integration_test.go`:
+
+```go
+// stubClient records recipients and can fail on demand.
+type stubClient struct {
+	sent []string
+	err  error
+}
+
+func (c *stubClient) Send(_ context.Context, _ email.TemplateID, to string, _ map[string]any) error {
+	if c.err != nil {
+		return c.err
+	}
+	c.sent = append(c.sent, to)
+	return nil
+}
+
+// stubVec / stubSkip count increments by label.
+type stubVec struct{ n map[string]int }
+
+func (s *stubVec) WithDay(day string) dunning.CounterIncrementer {
+	if s.n == nil {
+		s.n = map[string]int{}
+	}
+	return stubInc{s.n, day}
+}
+
+type stubSkip struct{ n map[string]int }
+
+func (s *stubSkip) WithTemplateReason(template, reason string) dunning.CounterIncrementer {
+	if s.n == nil {
+		s.n = map[string]int{}
+	}
+	return stubInc{s.n, template + "/" + reason}
+}
+
+type stubInc struct {
+	n   map[string]int
+	key string
+}
+
+func (s stubInc) Inc() { s.n[s.key]++ }
+
+func TestDunning_UndeliverableCountsSkippedNotSent(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores", "audit_logs", "billing_email_sends")
+	now := time.Now().UTC()
+
+	placeholder := "billing+7f3a@mark8ly.local"
+	seedPastDueSubscription(t, db, now.AddDate(0, 0, -5), &placeholder)
+
+	client := &stubClient{}
+	sent, skipped := &stubVec{}, &stubSkip{}
+	cron := dunning.NewSendDunningEmails(db, client, nil, sent, func() time.Time { return now }).
+		WithSkipCounter(skipped)
+
+	require.NoError(t, cron.Run(context.Background()))
+
+	require.Empty(t, client.sent, "mailed a .local address")
+	require.Zero(t, sent.n["day_5"], "sent counter incremented for mail never sent — the #381 lie")
+	require.Equal(t, 1, skipped.n["dunning_day_5/placeholder_address"])
+}
+
+func TestDunning_SecondRunSameDayDoesNotResend(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores", "audit_logs", "billing_email_sends")
+	now := time.Now().UTC()
+
+	addr := "merchant@example.com"
+	seedPastDueSubscription(t, db, now.AddDate(0, 0, -5), &addr)
+
+	client := &stubClient{}
+	newCron := func() *dunning.SendDunningEmails {
+		return dunning.NewSendDunningEmails(db, client, nil, &stubVec{}, func() time.Time { return now })
+	}
+
+	require.NoError(t, newCron().Run(context.Background()))
+	require.Len(t, client.sent, 1, "first run should send exactly once")
+
+	require.NoError(t, newCron().Run(context.Background()))
+	require.Len(t, client.sent, 1, "second run re-sent — duplicate dunning mail")
+}
+```
+
+Write `seedPastDueSubscription(t, db, transitionedAt, email)` in
+`testhelpers_integration_test.go` alongside `seedStore`: it inserts a
+`store_subscriptions` row with `status='past_due'` and the given `email`, calls
+`seedStore` for the name, and inserts the `audit_logs` row with
+`action='subscription.state_transition'`, `metadata->>'to_status'='past_due'`
+and `created_at=transitionedAt`. Copy the exact column set from the existing
+`dunning_emails_integration_test.go` seeding rather than inferring it.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go test ./internal/subscription/dunning/ -run TestDunning_Undeliverable -v
+```
+
+Expected: FAIL — `WithSkipCounter` undefined, or the sent counter incrementing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Widen `emailRow` in `internal/subscription/dunning/dunning_emails.go`:
+
+```go
+// emailRow is the minimal projection returned by the dunning email query.
+// Email and StoreName come from the merchant-facing side of the join: the
+// address to send to, and the name the templates address them by.
+type emailRow struct {
+	SubscriptionID   uuid.UUID
+	StoreID          string
+	TenantID         string
+	Email            *string
+	StoreName        string
+	HostedInvoiceURL *string
+}
+```
+
+Add the skip counter field and builder:
+
+```go
+// WithSkipCounter attaches the counter for emails deliberately not sent.
+// Optional: nil means skips are logged but not counted.
+func (s *SendDunningEmails) WithSkipCounter(c SkipCounter) *SendDunningEmails {
+	s.skip = c
+	return s
+}
+```
+
+...with `skip SkipCounter` added to the `SendDunningEmails` struct.
+
+Widen the query in `runForDay` to select the new columns:
+
+```go
+	err := s.db.WithContext(ctx).Raw(`
+		SELECT DISTINCT
+		    ss.id   AS subscription_id,
+		    ss.store_id,
+		    ss.tenant_id,
+		    ss.email,
+		    ss.hosted_invoice_url,
+		    COALESCE(st.name, 'your store') AS store_name
+		FROM store_subscriptions ss
+		JOIN audit_logs a ON a.store_id = ss.store_id
+		LEFT JOIN stores st ON st.id = ss.store_id
+		WHERE ss.status = ?
+		  AND a.action = 'subscription.state_transition'
+		  AND a.metadata->>'to_status' = ?
+		  AND date_trunc('day', a.created_at) = date_trunc('day', ? ::timestamptz)`,
+		string(subscription.StatusPastDue),
+		string(subscription.StatusPastDue),
+		targetDay,
+	).Scan(&rows).Error
+```
+
+`LEFT JOIN` with a `COALESCE` default, because `stores` is a lazily-populated
+local projection (`internal/stores/models.go:1-9`) — a missing row must not
+drop a merchant from the dunning ladder.
+
+Replace the send loop body:
+
+```go
+	dayLabel := fmt.Sprintf("day_%d", t.Day)
+	periodKey := targetDay.Format("2006-01-02")
+
+	for _, r := range rows {
+		// Claim before sending. Dunning re-derives eligibility from
+		// audit_logs on every run, so without this a second run on the
+		// same day re-sends to the same merchants (#381).
+		won, err := subscription.ClaimEmailSend(ctx, s.db, r.SubscriptionID, string(t.Template), periodKey, now)
+		if err != nil {
+			s.logger.Error("dunning email: claim failed; skipping row",
+				"day", t.Day, "store_id", r.StoreID, "err", err.Error())
+			continue
+		}
+		if !won {
+			continue // already claimed by another pod or an earlier run
+		}
+
+		to := ""
+		if r.Email != nil {
+			to = *r.Email
+		}
+		invoiceURL := ""
+		if r.HostedInvoiceURL != nil {
+			invoiceURL = *r.HostedInvoiceURL
+		}
+
+		if err := s.emailCl.Send(ctx, t.Template, to, map[string]any{
+			"store_id":           r.StoreID,
+			"tenant_id":          r.TenantID,
+			"store_name":         r.StoreName,
+			"day":                t.Day,
+			"hosted_invoice_url": invoiceURL,
+		}); err != nil {
+			// Never increment the sent counter here. Before #381 this
+			// branch was unreachable because the client was a no-op that
+			// always returned nil, so the counter reported deliveries
+			// that never happened.
+			s.logger.Warn("dunning email not sent",
+				"day", t.Day, "store_id", r.StoreID,
+				"reason", email.SkipReason(err), "err", err.Error())
+			if s.skip != nil {
+				s.skip.WithTemplateReason(string(t.Template), email.SkipReason(err)).Inc()
+			}
+			continue
+		}
+		if s.counter != nil {
+			s.counter.WithDay(dayLabel).Inc()
+		}
+	}
+	return nil
+```
+
+`runForDay` needs `now` — it currently derives `targetDay` from a `now`
+parameter; pass the same value through to `ClaimEmailSend`. Add `"github.com/google/uuid"` to the imports.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go build ./... && go test ./internal/subscription/dunning/ -v
+```
+
+Expected: PASS, including the pre-existing dunning tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/m8-381 && git add services/marketplace-api/internal/subscription/dunning/dunning_emails.go services/marketplace-api/internal/subscription/dunning/dunning_emails_test.go
+git commit -m "fix(dunning): send to a real address, claim before sending, stop overcounting"
+```
+
+---
+
+### Task 10: Win-back cron — real recipient, claim, and a corrected comment
+
+`winback.go:25-27` currently claims *"It is idempotent by design: stores already
+past 31 days are never selected, so double-runs on the same day produce the same
+send."* Producing the same send twice is not idempotence — it is a duplicate.
+This is the "documentation promising more than the code enforces" pattern the
+handoff calls out across three branches, so the comment is corrected in the same
+change that makes it true.
+
+**Files:**
+- Modify: `internal/subscription/lifecycle/winback.go` (struct :32-37, comment :25-31, `sendOne` :72-89)
+- Create: `internal/subscription/lifecycle/winback_integration_test.go` — **the `lifecycle` package has no test files whatsoever today.** This is the first one. There is no local helper to reuse; use `pkg/testdb.NewDB` as every other integration suite does.
+
+**Interfaces:**
+- Consumes: `subscription.ClaimEmailSend` (Task 8), `email.SkipReason` and `email.TemplateWinBack` (Tasks 3, 4).
+- Produces:
+  - `type CounterIncrementer interface{ Inc() }`
+  - `type SkipCounter interface{ WithTemplateReason(template, reason string) CounterIncrementer }`
+  - `func (c *WinBackCron) WithSkipCounter(sc SkipCounter) *WinBackCron`
+
+Interfaces are declared here rather than imported from `dunning`, because
+`lifecycle` does not depend on `dunning` today and adding that edge to satisfy
+two three-line interfaces is the wrong trade. Consumer-side interface
+declaration is idiomatic Go.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/subscription/lifecycle/winback_integration_test.go`:
+
+```go
+//go:build integration
+
+package lifecycle_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/internal/subscription/lifecycle"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+type stubClient struct {
+	sent []string
+	err  error
+}
+
+func (c *stubClient) Send(_ context.Context, _ email.TemplateID, to string, _ map[string]any) error {
+	if c.err != nil {
+		return c.err
+	}
+	c.sent = append(c.sent, to)
+	return nil
+}
+
+type stubSkip struct{ n map[string]int }
+
+func (s *stubSkip) WithTemplateReason(template, reason string) lifecycle.CounterIncrementer {
+	if s.n == nil {
+		s.n = map[string]int{}
+	}
+	return stubInc{s.n, template + "/" + reason}
+}
+
+type stubInc struct {
+	n   map[string]int
+	key string
+}
+
+func (s stubInc) Inc() { s.n[s.key]++ }
+
+// seedExpired inserts an expired subscription whose updated_at sits inside
+// the 30-31 day win-back window, then forces updated_at past GORM's
+// autoupdate (which would otherwise stamp now()).
+func seedExpired(t *testing.T, db *gorm.DB, now time.Time, addr *string) subscription.StoreSubscription {
+	t.Helper()
+	sub := subscription.StoreSubscription{
+		TenantID:         uuid.New(),
+		StoreID:          uuid.New(),
+		StripeCustomerID: "cus_" + uuid.NewString()[:12],
+		Status:           subscription.StatusExpired,
+		Email:            addr,
+	}
+	require.NoError(t, db.Create(&sub).Error)
+	require.NoError(t, db.Exec(
+		`UPDATE store_subscriptions SET updated_at = ? WHERE id = ?`,
+		now.Add(-30*24*time.Hour-time.Hour), sub.ID).Error)
+	return sub
+}
+
+func TestWinBack_UndeliverableIsSkippedNotSent(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "billing_email_sends")
+	now := time.Now().UTC()
+
+	placeholder := "billing+7f3a@mark8ly.local"
+	seedExpired(t, db, now, &placeholder)
+
+	client := &stubClient{}
+	skipped := &stubSkip{}
+	cron := lifecycle.NewWinBackCron(db, client, nil, func() time.Time { return now }).
+		WithSkipCounter(skipped)
+
+	require.NoError(t, cron.Run(context.Background()))
+
+	require.Empty(t, client.sent, "mailed a .local address")
+	require.Equal(t, 1, skipped.n["win_back_day30/placeholder_address"])
+}
+
+func TestWinBack_SecondRunSameDayDoesNotResend(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "billing_email_sends")
+	now := time.Now().UTC()
+
+	addr := "merchant@example.com"
+	seedExpired(t, db, now, &addr)
+
+	client := &stubClient{}
+	newCron := func() *lifecycle.WinBackCron {
+		return lifecycle.NewWinBackCron(db, client, nil, func() time.Time { return now })
+	}
+
+	require.NoError(t, newCron().Run(context.Background()))
+	require.Len(t, client.sent, 1, "first run should send exactly once")
+
+	require.NoError(t, newCron().Run(context.Background()))
+	require.Len(t, client.sent, 1, "second run re-sent — duplicate win-back mail")
+}
+```
+
+Add `"gorm.io/gorm"` to the imports for `seedExpired`. If `Create` does not
+honour an explicit `updated_at`, the follow-up `UPDATE` above is what places
+the row inside the window — keep it even if it looks redundant.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go test ./internal/subscription/lifecycle/ -run TestWinBack -v
+```
+
+Expected: FAIL — the second run sends again, and `WithSkipCounter` is undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the misleading doc comment on `WinBackCron` (:25-31) with:
+
+```go
+// WinBackCron sends a 20%-off-6-months promo email to expired stores at day 30
+// post-expiry (§15.3).
+//
+// Idempotence comes from the billing_email_sends claim, NOT from the window
+// query. The window selects the same rows on every run within the same day —
+// before #381 the comment here claimed that was idempotent, which it was only
+// because the client was a no-op that never sent anything.
+//
+// NOTE: The actual promo code attachment (P10 promo service) is deferred.
+type WinBackCron struct {
+	db     *gorm.DB
+	mailer email.Client
+	logger *slog.Logger
+	clock  func() time.Time
+	skip   SkipCounter
+}
+```
+
+Add the interfaces and builder:
+
+```go
+// CounterIncrementer is a one-method counter so tests can stub it.
+type CounterIncrementer interface{ Inc() }
+
+// SkipCounter counts win-back emails deliberately not sent, labeled by
+// template and reason. Declared here rather than imported from the dunning
+// package so lifecycle keeps its current dependency set.
+type SkipCounter interface {
+	WithTemplateReason(template, reason string) CounterIncrementer
+}
+
+// WithSkipCounter attaches the skipped-delivery counter. Optional.
+func (c *WinBackCron) WithSkipCounter(sc SkipCounter) *WinBackCron {
+	c.skip = sc
+	return c
+}
+```
+
+`Run` must pass the window start to `sendOne` so it can form a period key.
+Change the loop at :66-68 to:
+
+```go
+	periodKey := windowStart.Format("2006-01-02")
+	for i := range rows {
+		c.sendOne(ctx, &rows[i], periodKey, now)
+	}
+```
+
+Replace `sendOne` entirely:
+
+```go
+func (c *WinBackCron) sendOne(ctx context.Context, row *subscription.StoreSubscription, periodKey string, now time.Time) {
+	won, err := subscription.ClaimEmailSend(ctx, c.db, row.ID, string(email.TemplateWinBack), periodKey, now)
+	if err != nil {
+		c.logger.Error("lifecycle: win-back claim failed; skipping",
+			"store_id", row.StoreID, "err", err.Error())
+		return
+	}
+	if !won {
+		return // already sent for this window
+	}
+
+	to := ""
+	if row.Email != nil {
+		to = *row.Email
+	}
+
+	err = c.mailer.Send(ctx, email.TemplateWinBack, to, map[string]any{
+		"store_id":   row.StoreID.String(),
+		"tenant_id":  row.TenantID.String(),
+		"store_name": subscription.StoreNameFor(ctx, c.db, row.StoreID),
+		"promo":      "20%-off-6-months",
+	})
+	if err != nil {
+		c.logger.Warn("lifecycle: win-back email not sent",
+			"store_id", row.StoreID, "tenant_id", row.TenantID,
+			"reason", email.SkipReason(err), "err", err.Error())
+		if c.skip != nil {
+			c.skip.WithTemplateReason(string(email.TemplateWinBack), email.SkipReason(err)).Inc()
+		}
+		return
+	}
+	c.logger.Info("lifecycle: win-back email sent",
+		"store_id", row.StoreID, "tenant_id", row.TenantID)
+}
+```
+
+The win-back query selects full `StoreSubscription` rows, so `Email` is already
+loaded — no query change needed. `StoreNameFor` is a single scalar lookup per
+row, acceptable because this cron processes a handful of rows a day; the
+dunning ladder joins instead because it is the higher-volume path.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go build ./... && go test ./internal/subscription/lifecycle/ -v
+TEST_DATABASE_URL="postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable" \
+  go test -tags=integration -p 1 ./internal/subscription/lifecycle/ -run TestWinBack -v
+```
+
+Expected: PASS both, and the second run sends zero.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/m8-381 && git add services/marketplace-api/internal/subscription/lifecycle/
+git commit -m "fix(lifecycle): claim win-back sends and correct the idempotence claim"
+```
+
+---
+
+### Task 11: Trial reminders and payment-action reminders
+
+Both already claim before sending, so they need the recipient and the skipped
+counter only — no new marker.
+
+**Files:**
+- Modify: `internal/subscription/dunning/trial_reminders.go` (`processOne` :144-184, struct :64-70)
+- Modify: `internal/subscription/dunning/payment_action_reminders.go` (`processOne` :113-141, struct :36-41)
+- Test: extend the two packages' existing test files
+
+**Interfaces:**
+- Consumes: `email.SkipReason`, `dunning.SkipCounter`, `StoreSubscription.Email`.
+- Produces:
+  - `func (s *SendTrialReminders) WithSkipCounter(c SkipCounter) *SendTrialReminders`
+  - `func (s *SendPaymentActionReminders) WithSkipCounter(c SkipCounter) *SendPaymentActionReminders`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the trial-reminders test file:
+
+```go
+func TestTrialReminders_UndeliverableCountsSkippedNotSent(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores", "trial_reminders")
+	now := time.Now().UTC()
+
+	placeholder := "billing+7f3a@mark8ly.local"
+	// A trial ending in 7 days, with no payment method — the t_minus_7 nudge.
+	seedTrialSub(t, db, now.AddDate(0, 0, -83), nil, false, &placeholder)
+
+	client := &stubClient{}
+	sent, skipped := &stubVec{}, &stubSkip{}
+	cron := dunning.NewSendTrialReminders(db, client, nil, sent, func() time.Time { return now }).
+		WithSkipCounter(skipped)
+
+	require.NoError(t, cron.Run(context.Background()))
+
+	require.Empty(t, client.sent, "mailed a .local address")
+	require.Zero(t, sent.n["t_minus_7"], "sent counter incremented for mail never sent")
+	require.Equal(t, 1, skipped.n["trial_no_pm_t7/placeholder_address"])
+}
+
+// The claim is deliberately NOT released on failure: at-most-once beats a
+// duplicate. This pins that contract so nobody "fixes" it into at-least-once.
+func TestTrialReminders_FailedSendDoesNotReleaseTheClaim(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores", "trial_reminders")
+	now := time.Now().UTC()
+
+	addr := "merchant@example.com"
+	seedTrialSub(t, db, now.AddDate(0, 0, -83), nil, false, &addr)
+
+	client := &stubClient{err: errors.New("sendgrid 503")}
+	cron := dunning.NewSendTrialReminders(db, client, nil, &stubVec{}, func() time.Time { return now })
+	require.NoError(t, cron.Run(context.Background()))
+
+	var claims int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM trial_reminders`).Scan(&claims).Error)
+	require.EqualValues(t, 1, claims, "the burned slot must stay claimed")
+}
+```
+
+Add the equivalent `TestPaymentActionReminders_UndeliverableCountsSkippedNotSent`
+to `payment_action_reminders_integration_test.go`, expecting the label
+`payment_action_reminder/placeholder_address`.
+
+Both are integration tests. The seams already exist: `testdb.NewDB` for the
+connection, `seedTrialSub` in `trial_reminders_extension_integration_test.go:29`
+for a trialing subscription, and `seedStore` in
+`testhelpers_integration_test.go:27` for the store name. `seedTrialSub` will
+need an `email` argument — add it there rather than writing a second seeder, and
+update its existing callers in the same commit. Reuse the `stubClient` /
+`stubSkip` types added to this package in Task 9; do not declare them twice.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go test ./internal/subscription/dunning/ -run 'TestTrialReminders|TestPaymentActionReminders' -v
+```
+
+Expected: FAIL — `WithSkipCounter` undefined on both types.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `skip SkipCounter` to both structs and a builder on each:
+
+```go
+// WithSkipCounter attaches the counter for emails deliberately not sent.
+func (s *SendTrialReminders) WithSkipCounter(c SkipCounter) *SendTrialReminders {
+	s.skip = c
+	return s
+}
+```
+
+```go
+// WithSkipCounter attaches the counter for emails deliberately not sent.
+func (s *SendPaymentActionReminders) WithSkipCounter(c SkipCounter) *SendPaymentActionReminders {
+	s.skip = c
+	return s
+}
+```
+
+In `trial_reminders.go`, replace the `Send` call and its TODO comment block
+(:160-179) with:
+
+```go
+	to := ""
+	if row.Email != nil {
+		to = *row.Email
+	}
+
+	if err := s.emailCl.Send(ctx, t.Template, to, map[string]any{
+		"store_id":           row.StoreID.String(),
+		"tenant_id":          row.TenantID.String(),
+		"store_name":         subscription.StoreNameFor(ctx, s.db, row.StoreID),
+		"offset":             t.OffsetKey,
+		"days_remaining":     t.DaysBefore,
+		"has_payment_method": t.HasPM,
+		"plan":               string(row.Plan),
+	}); err != nil {
+		s.logger.Warn("trial reminder not sent",
+			"store_id", row.StoreID.String(),
+			"offset", t.OffsetKey,
+			"reason", email.SkipReason(err),
+			"err", err.Error())
+		if s.skip != nil {
+			s.skip.WithTemplateReason(string(t.Template), email.SkipReason(err)).Inc()
+		}
+		// Do not delete the idempotency row — that would risk a double-send.
+		// At-most-once is the deliberate contract: see the spec, §6.
+		return nil
+	}
+```
+
+In `payment_action_reminders.go`, replace the `Send` call (:129-138) with:
+
+```go
+	to := ""
+	if row.Email != nil {
+		to = *row.Email
+	}
+	invoiceURL := ""
+	if row.HostedInvoiceURL != nil {
+		invoiceURL = *row.HostedInvoiceURL
+	}
+
+	if err := s.emailCl.Send(ctx, email.TemplatePaymentActionReminder, to, map[string]any{
+		"store_id":           row.StoreID.String(),
+		"tenant_id":          row.TenantID.String(),
+		"store_name":         subscription.StoreNameFor(ctx, s.db, row.StoreID),
+		"offset":             t.OffsetKey,
+		"hosted_invoice_url": invoiceURL,
+	}); err != nil {
+		s.logger.Warn("SCA reminder not sent",
+			"store_id", row.StoreID.String(), "offset", t.OffsetKey,
+			"reason", email.SkipReason(err), "err", err.Error())
+		if s.skip != nil {
+			s.skip.WithTemplateReason(string(email.TemplatePaymentActionReminder), email.SkipReason(err)).Inc()
+		}
+		// Don't delete the idempotency row — we'd risk double-send on retry.
+		return nil
+	}
+```
+
+Create the shared helper in `internal/subscription/store_name.go` — the
+`subscription` package, not `dunning`, because `lifecycle` needs it too and
+does not import `dunning`:
+
+```go
+package subscription
+
+// store_name.go — the merchant-facing store name for email copy.
+//
+// Both reminder crons load full StoreSubscription rows, which carry no name;
+// the name lives in the local `stores` projection. A single scalar lookup per
+// row is acceptable here because these crons process tens of rows daily, not
+// thousands — unlike the dunning ladder, which joins instead.
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// StoreNameFor returns the store's display name, or "your store" when the
+// local projection has no row yet. Never returns an error: a cosmetic field
+// must not be able to stop a billing email.
+func StoreNameFor(ctx context.Context, db *gorm.DB, storeID uuid.UUID) string {
+	var name string
+	err := db.WithContext(ctx).
+		Raw(`SELECT name FROM stores WHERE id = ?`, storeID).
+		Scan(&name).Error
+	if err != nil || name == "" {
+		return "your store"
+	}
+	return name
+}
+```
+
+Add `"github.com/mark8ly/marketplace-api/internal/email"` to
+`trial_reminders.go`'s imports if it is not already present.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go build ./... && go test ./internal/subscription/dunning/ -v
+```
+
+Expected: PASS across the whole package.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/m8-381 && git add services/marketplace-api/internal/subscription/dunning/
+git commit -m "fix(dunning): send trial and SCA reminders to real addresses"
+```
+
+---
+
+### Task 12: Trial-billed confirmation
+
+No claim marker: this fires from the `invoice.paid` webhook, which
+`handlers/webhooks/stripe.go:98-111` already deduplicates with an `InsertIfNew`
+on `event_id` before dispatch ever runs.
+
+**Files:**
+- Modify: `internal/billing/dispatch/handlers.go:281-296`
+- Test: `internal/billing/dispatch/dispatcher_test.go` (extend — there is no `handlers_test.go`)
+
+**Interfaces:**
+- Consumes: `StoreSubscription.Email` (Task 5), `email.SkipReason` (Task 3).
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/billing/dispatch/dispatcher_test.go`, which is already
+`//go:build integration` / `package dispatch_test` and uses
+`testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")`. Follow
+`TestDispatch_InvoicePaid_StampsFirstChargeAt_ClearsHostedURL` (:200) for how an
+`invoice.paid` first charge is driven, and reuse its construction rather than
+inventing a new harness:
+
+```go
+func TestInvoicePaid_TrialBilledUsesRealAddress(t *testing.T) {
+	// sub is the StoreSubscription the handler loads; give it an address.
+	addr := "merchant@example.com"
+	client := &captureEmailClient{}
+
+	runInvoicePaidFirstCharge(t, client, &addr)
+
+	if len(client.recipients) != 1 {
+		t.Fatalf("sent %d emails, want 1", len(client.recipients))
+	}
+	if client.recipients[0] != addr {
+		t.Errorf("recipient = %q, want %q — a store UUID would bounce", client.recipients[0], addr)
+	}
+}
+
+func TestInvoicePaid_TrialBilledWithoutAddressDoesNotFailTheWebhook(t *testing.T) {
+	client := &captureEmailClient{}
+	err := runInvoicePaidFirstCharge(t, client, nil)
+	if err != nil {
+		t.Errorf("webhook returned %v; email failure must stay non-fatal", err)
+	}
+}
+```
+
+`captureEmailClient` is a two-field stub implementing `email.Client` that
+appends each `to` to a slice; attach it with the existing
+`dispatch.New(...).WithEmail(client)` builder (`dispatcher.go:83-89`).
+`runInvoicePaidFirstCharge` seeds a `store_subscriptions` row with
+`first_charge_at` NULL and the given `email`, then dispatches an `invoice.paid`
+payload — lift both from the `:200` test rather than writing them fresh.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go test ./internal/billing/dispatch/ -run TestInvoicePaid_TrialBilled -v
+```
+
+Expected: FAIL — recipient is the store UUID, not the address.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the block at `internal/billing/dispatch/handlers.go:281-296`:
+
+```go
+	if wasFirstCharge && d.emailCl != nil {
+		to := ""
+		if sub.Email != nil {
+			to = *sub.Email
+		}
+		if sendErr := d.emailCl.Send(ctx, email.TemplateTrialStartedBilled, to, map[string]any{
+			"store_id":   sub.StoreID.String(),
+			"tenant_id":  sub.TenantID.String(),
+			"store_name": "your store",
+			"plan":       string(sub.Plan),
+			"period":     string(sub.SubscriptionPeriod),
+		}); sendErr != nil {
+			// Don't fail the webhook — Stripe would retry, double-firing every
+			// other side effect. Email failure is a soft error: log and move on.
+			// Idempotency is preserved by first_charge_at being non-nil after
+			// this UPDATE, so a retried invoice.paid event won't re-emit.
+			slog.Default().Warn("dispatch: trial-billed email not sent",
+				"store_id", sub.StoreID.String(),
+				"reason", email.SkipReason(sendErr),
+				"err", sendErr.Error())
+		}
+	}
+```
+
+Two things about this replacement:
+
+`Dispatcher` has **no** logger field (`dispatcher.go:42-47` is
+`emitter`/`recorder`/`emailCl`/`handlers`) and the `dispatch` package imports
+`log/slog` nowhere today. Rather than widen the struct and every constructor
+for one warning, use `slog.Default()` and add `"log/slog"` to the file's
+imports. The process configures the default logger at boot, so this lands in
+the same JSON stream as everything else.
+
+The line it replaces — `_ = fmt.Errorf("dispatch: trial-billed email
+(non-fatal): %w", sendErr)` — was dead code: it constructed an error and
+discarded it, so every trial-billed send failure was invisible. That is why
+this task exists at all.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go build ./... && go test ./internal/billing/dispatch/ -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/m8-381 && git add services/marketplace-api/internal/billing/dispatch/
+git commit -m "fix(billing): send the trial-billed confirmation to a real address"
+```
+
+---
+
+### Task 13: Wire it up — replace all three `NoOpClient` sites
+
+The switch-flip. Until this task, everything built above is inert.
+
+**Files:**
+- Modify: `cmd/marketplace-api/main.go` — `:277-279` (registration), `:550-554` (after the sender), `:1599`, `:1761-1764`, `:1777-1790`, `:1825-1830`, `:1879-1881`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-12.
+- Produces: a running service that sends billing mail.
+
+- [ ] **Step 1: Register the billing fallbacks**
+
+After `giftcard.RegisterFallbacks(templateLoader)` at `:279`:
+
+```go
+	// #381 — billing mail (dunning, trial cadence, payment-action, win-back,
+	// trial-billed). Registered here so an operator can reword any of it from
+	// the console without a deploy.
+	email.RegisterFallbacks(templateLoader)
+```
+
+- [ ] **Step 2: Construct the one real client**
+
+Immediately after the `emailSender := email.NewFromConfig(...)` block ends at
+`:554`:
+
+```go
+	// billingEmailClient is the production email.Client. Before #381 the only
+	// implementation was NoOpClient, wired at three sites below, so no
+	// merchant had ever received a dunning notice, trial reminder,
+	// payment-action reminder, win-back promo or trial-billed confirmation.
+	// One instance shared by all three, so failover and attribution are
+	// identical wherever billing mail originates.
+	billingEmailClient := email.NewTemplateClient(templateLoader, emailSender, cfg.EmailFrom, log)
+```
+
+This must come after `emailSender`, which is why it is not next to the
+`templateLoader` at `:277`.
+
+- [ ] **Step 3: Replace the three no-op wirings**
+
+At `:1599`, replace:
+
+```go
+		dispatcherEmailClient := email.NoOpClient{Logger: log}
+```
+
+with:
+
+```go
+		dispatcherEmailClient := billingEmailClient
+```
+
+At `:1761-1764`, replace the comment and assignment:
+
+```go
+	// P6 dunning + SCA recovery crons. Emails route through the NoOpClient
+	...
+	dunningEmailClient := email.NoOpClient{Logger: log}
+```
+
+with:
+
+```go
+	// P6 dunning + SCA recovery crons. Emails route through the real
+	// template client as of #381 — recipients come from
+	// store_subscriptions.email, and an unknown or placeholder address is
+	// counted as skipped rather than reported as delivered.
+	dunningEmailClient := billingEmailClient
+```
+
+At `:1879`, replace:
+
+```go
+	winBackEmailClient := email.NoOpClient{Logger: log}
+```
+
+with:
+
+```go
+	winBackEmailClient := billingEmailClient
+```
+
+- [ ] **Step 4: Attach the skip counters**
+
+Chain `WithSkipCounter` onto each cron constructor. At `:1777-1779`:
+
+```go
+	dunningEmailsCron := dunning.NewSendDunningEmails(conn, dunningEmailClient, log,
+		dunning.WrapPrometheusCounterVec(metrics.DunningEmailsSentTotal),
+		nil,
+	).WithSkipCounter(dunning.WrapPrometheusSkipCounter(metrics.BillingEmailsSkippedTotal))
+```
+
+At `:1788-1790`:
+
+```go
+	scaRemindersCron := dunning.NewSendPaymentActionReminders(conn, dunningEmailClient, log,
+		dunning.WrapPrometheusCounterVec(metrics.PaymentActionRemindersSentTotal),
+		nil,
+	).WithSkipCounter(dunning.WrapPrometheusSkipCounter(metrics.BillingEmailsSkippedTotal))
+```
+
+At `:1825-1827`:
+
+```go
+	trialRemindersCron := dunning.NewSendTrialReminders(conn, dunningEmailClient, log,
+		dunning.WrapPrometheusCounterVec(metrics.TrialRemindersSentTotal),
+		nil,
+	).WithSkipCounter(dunning.WrapPrometheusSkipCounter(metrics.BillingEmailsSkippedTotal))
+```
+
+At `:1880`:
+
+```go
+	winBackCron := lifecycle.NewWinBackCron(conn, winBackEmailClient, log, nil).
+		WithSkipCounter(lifecycleSkipCounter{metrics.BillingEmailsSkippedTotal})
+```
+
+`lifecycle.SkipCounter` is a distinct interface from `dunning.SkipCounter`, so
+add a two-line adapter near the other wiring helpers in `main.go`:
+
+```go
+// lifecycleSkipCounter adapts the shared skipped-emails CounterVec to
+// lifecycle.SkipCounter. Separate from dunning's adapter because the two
+// packages declare their own consumer-side interfaces.
+type lifecycleSkipCounter struct{ cv *prometheus.CounterVec }
+
+func (l lifecycleSkipCounter) WithTemplateReason(template, reason string) lifecycle.CounterIncrementer {
+	return l.cv.WithLabelValues(template, reason)
+}
+```
+
+`prometheus.Counter` already has `Inc()`, so it satisfies
+`lifecycle.CounterIncrementer` directly. Preserve the existing argument values
+at each call site — copy them from the current code rather than trusting the
+`nil` shown above, which stands for whatever clock argument is already there.
+
+- [ ] **Step 5: Verify the whole build and the full unit suite**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && go build ./... && go vet ./... && go vet -tags=integration ./...
+grep -rn "NoOpClient" cmd/marketplace-api/main.go
+```
+
+Expected: build and both vets clean; the `grep` returns **nothing** — every
+production wiring is gone. `NoOpClient` itself stays in the package: it is used
+by tests and is a legitimate dev double.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /tmp/m8-381 && git add services/marketplace-api/cmd/marketplace-api/main.go
+git commit -m "feat(marketplace-api): wire the real billing email client at all three sites"
+```
+
+---
+
+## Final verification
+
+Run this after Task 13, before requesting review. It is not optional: the
+handoff records 22 packages / 191 tests already failing at baseline, and the
+only way to know you added none is to diff both directions.
+
+- [ ] **Step 1: Confirm no other integration suite is running**
+
+```bash
+ps aux | grep "[g]o test -tags=integration"
+```
+
+Expected: no output. Two suites against one database corrupt each other and the
+resulting diff still looks authoritative.
+
+- [ ] **Step 2: Capture the branch result**
+
+```bash
+cd /tmp/m8-381/services/marketplace-api && \
+TEST_DATABASE_URL="postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable" \
+  go test -tags=integration -p 1 ./... 2>&1 | tee /tmp/m8-381-branch.txt | tail -40
+```
+
+- [ ] **Step 3: Capture the baseline from a throwaway worktree**
+
+```bash
+\
+  git worktree add /tmp/m8-381-base d52b5cd2 && cd /tmp/m8-381-base/services/marketplace-api && \
+TEST_DATABASE_URL="postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable" \
+  go test -tags=integration -p 1 ./... 2>&1 | tee /tmp/m8-381-base.txt | tail -40
+```
+
+- [ ] **Step 4: Diff both directions**
+
+```bash
+grep -E "^(--- FAIL|FAIL)" /tmp/m8-381-branch.txt | sort -u > /tmp/branch-fails.txt
+grep -E "^(--- FAIL|FAIL)" /tmp/m8-381-base.txt   | sort -u > /tmp/base-fails.txt
+echo "=== NEW failures introduced by this branch (must be empty) ==="
+comm -23 /tmp/branch-fails.txt /tmp/base-fails.txt
+echo "=== failures the branch FIXED (informational) ==="
+comm -13 /tmp/branch-fails.txt /tmp/base-fails.txt
+```
+
+Expected: the first list is **empty**. Anything in it is yours.
+
+Then confirm the suites actually ran. `pkg/testdb.NewDB` **skips** when the
+database is unreachable, and `exit=0` does not distinguish PASS from SKIP:
+
+```bash
+grep -c "^--- SKIP" /tmp/m8-381-branch.txt
+grep -E "^--- (PASS|SKIP)" /tmp/m8-381-branch.txt | grep -E "ClaimEmailSend|Dunning_|WinBack_|TrialReminders_|HandleCustomerUpdated"
+```
+
+Every test this plan added must appear as `--- PASS`. A `--- SKIP` there means
+the run proved nothing.
+
+- [ ] **Step 5: Clean up the baseline worktree**
+
+```bash
+cd /Users/Mahesh.Sangawar/personal/tesserix-new/mark8ly && git worktree remove /tmp/m8-381-base --force
+```
+
+- [ ] **Step 6: Whole-branch review**
+
+Request a review of the **entire branch diff**, not the individual task diffs,
+on the most capable model. Across #373, #377 and #379 the whole-branch review
+found defects no task-scoped review could: a requeue-contract bug, a fourth
+poison-pill shape, and an unproven cross-tenant claim. None lived inside a
+single task's diff.
+
+Ask it specifically to check three things this plan asserts but a reviewer
+should not take on trust:
+
+1. Is there any path where `Send` returns `nil` without a provider accepting
+   the message? That is the single invariant the honest counters rest on.
+2. Does any caller increment a `*_sent_total` counter on an error path?
+3. Do the claim keys actually distinguish a legitimate day-7-after-day-5 from
+   a duplicate day-5?
+
+- [ ] **Step 7: Do NOT push, open a PR, merge, or deploy**
+
+Report the results and wait. Deployment sends real mail to real merchants, and
+the backfill must run before the first cron fires — sequencing that is the
+user's call.
+
+## Operational note for whoever ships this
+
+Order matters on deploy:
+
+1. Migrations 104 and 105 land.
+2. `cmd/backfill-email` runs to completion (start with `--dry-run` and read the
+   `Placeholder` and `NoneInStripe` counts — they are the population that will
+   still get nothing).
+3. Only then does the new image serve, so the first 09:05 cron has addresses to
+   send to.
+
+Running the image before the backfill is not dangerous — every row simply
+counts as `skipped{reason="no_address"}` — but it burns the trial-reminder
+idempotency slots for that day, and those do not come back.

--- a/docs/superpowers/plans/2026-08-26-billing-email-delivery.md
+++ b/docs/superpowers/plans/2026-08-26-billing-email-delivery.md
@@ -248,18 +248,15 @@ Counters that record *not* sending. Without this the `.local` population is invi
 
 - [ ] **Step 1: Write the failing test**
 
-Append to the existing `internal/subscription/dunning/metrics_adapter_test.go`
-(match its package clause — do not add a second one):
+Append **only the test function** to the existing
+`internal/subscription/dunning/metrics_adapter_test.go`. Do **not** add a
+package clause and do **not** add an import block: the file is already
+`package dunning_test` and already imports `prometheus`, `prometheus/testutil`
+and `dunning` at lines 3-11. A second import of the same package in one file
+is a compile error.
 
 ```go
 // --- appended for #381 ---
-
-import (
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
-
-	"github.com/mark8ly/marketplace-api/internal/subscription/dunning"
-)
 
 func TestWrapPrometheusSkipCounter_IncrementsLabelledSeries(t *testing.T) {
 	cv := prometheus.NewCounterVec(
@@ -2415,6 +2412,43 @@ loaded — no query change needed. `StoreNameFor` is a single scalar lookup per
 row, acceptable because this cron processes a handful of rows a day; the
 dunning ladder joins instead because it is the higher-volume path.
 
+**This task creates `StoreNameFor`**, because it is its first consumer. Create
+`internal/subscription/store_name.go` — the `subscription` package, not
+`lifecycle` or `dunning`, because Task 11 needs it too and neither of those
+packages is importable from the other:
+
+```go
+package subscription
+
+// store_name.go — the merchant-facing store name for email copy.
+//
+// The crons load StoreSubscription rows, which carry no name; the name lives
+// in the local `stores` projection. A scalar lookup per row is acceptable on
+// the reminder paths, which process tens of rows daily. The dunning ladder
+// joins instead, being the higher-volume path.
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// StoreNameFor returns the store's display name, or "your store" when the
+// local projection has no row yet. Never returns an error: a cosmetic field
+// must not be able to stop a billing email.
+func StoreNameFor(ctx context.Context, db *gorm.DB, storeID uuid.UUID) string {
+	var name string
+	err := db.WithContext(ctx).
+		Raw(`SELECT name FROM stores WHERE id = ?`, storeID).
+		Scan(&name).Error
+	if err != nil || name == "" {
+		return "your store"
+	}
+	return name
+}
+```
+
 - [ ] **Step 4: Run tests to verify they pass**
 
 ```bash
@@ -2596,41 +2630,8 @@ In `payment_action_reminders.go`, replace the `Send` call (:129-138) with:
 	}
 ```
 
-Create the shared helper in `internal/subscription/store_name.go` — the
-`subscription` package, not `dunning`, because `lifecycle` needs it too and
-does not import `dunning`:
-
-```go
-package subscription
-
-// store_name.go — the merchant-facing store name for email copy.
-//
-// Both reminder crons load full StoreSubscription rows, which carry no name;
-// the name lives in the local `stores` projection. A single scalar lookup per
-// row is acceptable here because these crons process tens of rows daily, not
-// thousands — unlike the dunning ladder, which joins instead.
-
-import (
-	"context"
-
-	"github.com/google/uuid"
-	"gorm.io/gorm"
-)
-
-// StoreNameFor returns the store's display name, or "your store" when the
-// local projection has no row yet. Never returns an error: a cosmetic field
-// must not be able to stop a billing email.
-func StoreNameFor(ctx context.Context, db *gorm.DB, storeID uuid.UUID) string {
-	var name string
-	err := db.WithContext(ctx).
-		Raw(`SELECT name FROM stores WHERE id = ?`, storeID).
-		Scan(&name).Error
-	if err != nil || name == "" {
-		return "your store"
-	}
-	return name
-}
-```
+`subscription.StoreNameFor` already exists — **Task 10 created it**. Do not
+create it again; just call it.
 
 Add `"github.com/mark8ly/marketplace-api/internal/email"` to
 `trial_reminders.go`'s imports if it is not already present.

--- a/docs/superpowers/specs/2026-08-26-billing-email-delivery-design.md
+++ b/docs/superpowers/specs/2026-08-26-billing-email-delivery-design.md
@@ -1,0 +1,231 @@
+# Billing email delivery — design (#381, piece A)
+
+Status: **approved**, implementation plan not yet written.
+Scope: piece **A** only — make the mail actually arrive. Piece **B** (a template
+catalog endpoint for the new console) is sketched at the end and files as its own
+issue.
+
+## The problem
+
+No merchant has ever received a dunning notice, a trial-expiry reminder, a
+payment-action reminder, a win-back promo, or a trial-billed confirmation from
+`marketplace-api`.
+
+`email.Client` (`internal/email/client.go:33`) has exactly one implementation —
+`NoOpClient`, which logs and returns `nil`. It is wired at three places in
+`cmd/marketplace-api/main.go` (`:1599`, `:1764`, `:1879`), which between them
+cover every template the interface declares. A merchant whose card fails gets no
+day-5 notice, no day-7 notice and no payment-action reminder, and proceeds
+toward suspension in silence.
+
+This is not an inert "adapter not wired yet" gap. Three things make it worse.
+
+## What the issue got right, and one thing it got wrong
+
+**Right:** the recipient is unusable. `dunning_emails.go:115-120` passes
+`r.StoreID` — a UUID — as the `to` address, awaiting a
+`StoreSubscription.email` column. Swapping in a real transport without fixing
+that would attempt delivery to a UUID.
+
+**Right:** the metrics overstate. `DunningEmailsSentTotal` and its siblings
+increment on every eligible row, because the no-op always returns `nil`. Same
+family as the dead outbox gauge from #375, but worse: that one read zero, this
+one reads a plausible non-zero.
+
+**Wrong:** #381 attributes the metric lie to the increment *placement* —
+"increments after the no-op returns". The placement is correct.
+Increment-after-`Send`-returns-`nil` is exactly right. What was fake was the
+implementation behind it. **There is no counter to move.** The fix that makes
+the counter honest is the rule in §3: the adapter must never return `nil` for
+mail it did not send.
+
+## What the issue did not find
+
+**1. The `to` parameter carries two different identifier kinds.** Four callers
+pass a store UUID; `lifecycle/winback.go:76` passes a **Stripe customer ID**.
+One `string` parameter, two incompatible meanings, no compiler help.
+
+**2. Some Stripe customer emails are undeliverable by construction.**
+`subscription/service.go:104-109` mints `billing+<store_id>@mark8ly.local`
+whenever `Bootstrap` is called without an email, and the real value is merely
+`user_email` from whichever admin session first hit the bootstrap endpoint.
+`.local` is an unroutable TLD; sending there hard-bounces and costs sender
+reputation.
+
+**3. Two of the four crons can double-send.** Trial reminders and payment-action
+reminders claim an idempotency slot before sending. Dunning and win-back do not
+— they re-derive eligibility on every run (dunning from `audit_logs` date
+arithmetic, win-back from an `updated_at` window), so a second run on the same
+day re-sends. `mark8ly-marketplace-api-admin` runs 1 replica, so the window is a
+rolling deploy overlapping 09:05 / 10:00, or a restart re-firing the schedule.
+Harmless behind a no-op; **duplicate billing mail once the sender is real.** This
+defect is introduced by the fix, so the fix closes it.
+
+**4. There is no renderer.** `internal/email/templates.go` is a three-line stub
+("lands when real adapter arrives"), and neither provider adapter supports
+provider-side dynamic templates — `Message` carries a finished
+`Subject`/`HTMLBody`. All 11 templates must render in Go.
+
+## Decisions
+
+### 1. `to` means an email address, and callers resolve it
+
+The interface signature is unchanged; its `to` parameter finally means what it
+says. Callers pass `row.Email`.
+
+Callers resolve, not the adapter, because every caller already runs a SQL scan
+over `store_subscriptions` — they select one more column instead of forcing an
+N+1 lookup inside the send loop. This keeps the adapter a pure render-and-send
+unit with no DB handle, testable in isolation.
+
+`winback.go` stops passing `StripeCustomerID`. The two-meanings-in-one-parameter
+hazard disappears because there is now exactly one meaning.
+
+Templates also need a store name. It is already in the local `stores`
+projection — the callers join it. No column required, and this closes the
+`trial_reminders.go:160-164` TODO asking for an "email/store_name pair".
+
+### 2. `store_subscriptions.email`, written by the webhook that already fires
+
+New nullable `citext` column. Two writers:
+
+- **`handleCustomerUpdated`** (`billing/dispatch/handlers.go:413`) already parses
+  the Stripe payload and `UPDATE`s this table for `has_default_payment_method`.
+  It gains one JSON field and one column **in the same statement** — no new
+  webhook subscription, no new query, no new failure mode.
+- **`cmd/backfill-email`**, modeled directly on `cmd/backfill-has-pm`, which
+  exists for precisely this shape: read Stripe per row, write the column,
+  idempotent, throttled, `--dry-run`. Covers rows predating the column, since
+  `customer.updated` only fires on change.
+
+### 3. The adapter never returns `nil` for mail it did not send
+
+`email.templateClient` (`internal/email/template_client.go`), the only
+implementation of `email.Client`. It renders a key through the existing
+`emailtemplates.Loader`, builds a `Message`, and hands it to the existing
+`Sender` chain — so billing mail inherits the SendGrid→Resend failover the five
+working mailers already use, and #348's send-log decorator will pick it up for
+free.
+
+It rejects a recipient that is empty, has no `@`, or ends in `.local` /
+`.invalid`, returning a sentinel **`email.ErrUndeliverable`**.
+
+**This sentinel is what makes the counters honest**, and it is the whole of the
+metric fix. Callers distinguish it from transport failure: never increment
+`sent`, increment a new `skipped_total{reason}` instead, and log at Warn with
+the `store_id`. An undeliverable row becomes visible rather than merely
+uncounted.
+
+Envelope: `From: cfg.EmailFrom`, `FromName: "Mark8ly Billing"`, and
+`CustomArgs{product, kind, tenant_id}` — the attribution shape the working
+mailers already emit, which the notification-service webhook receiver consumes.
+
+### 4. Templates register on the existing loader; no seed rows
+
+All 11 keys (10 in `client.go` plus `win_back_day30` from `lifecycle`) register
+against `emailtemplates.Loader` with embedded `.html`/`.txt` fallbacks — the
+`orderdoc`/`giftcard` pattern, added alongside `main.go:278-279`. Keys are the
+existing `TemplateID` values, so there is one identifier rather than two.
+
+**No seed migration.** The current console lists templates by querying
+`email_templates` rows and has no create flow, so a key is invisible until a row
+exists — which is why one might reach for seeding. But piece B replaces
+rows-as-discovery with an explicit catalog, so seeding now would build the thing
+B removes. A key with no row simply renders from its embedded default.
+
+### 5. Claim-first markers for dunning and win-back
+
+New `billing_email_sends(subscription_id, template_key, period_key)` with a
+unique constraint, claimed `INSERT … ON CONFLICT DO NOTHING` **before** the
+send, mirroring `payment_action_reminders`.
+
+One generic table rather than two more bespoke ones: four near-identical marker
+tables is three too many, and this is a natural home to later subsume
+`trial_reminders` and `payment_action_reminders`. That consolidation is **not**
+in this piece.
+
+`period_key` disambiguates repeats of the same template for the same
+subscription: for dunning it is the target date in `YYYY-MM-DD` form (the day
+the merchant entered `past_due` plus the offset), and for win-back it is the
+window-start date. `template_key` alone would suppress a legitimate day-7 notice
+after a day-5 one; `period_key` alone would collide across templates.
+
+The trial-billed confirmation (`billing/dispatch/handlers.go:285`) gets **no**
+marker. It fires from the `invoice.paid` webhook, which is already deduplicated
+upstream: `handlers/webhooks/stripe.go:98-111` does an `InsertIfNew` keyed on
+`event_id` and returns `duplicate` before dispatch ever runs. A second marker
+would guard nothing.
+
+(That dedup inserts *before* dispatching, so a dispatch failure makes the retry
+look like a duplicate and the confirmation is dropped rather than doubled — the
+opposite failure mode, in the same family as #336. Out of scope here.)
+
+### 6. At-most-once is kept, and it self-heals
+
+`processOne` claims the slot *before* sending and deliberately does not release
+it on failure — so a transient transport error permanently costs that merchant
+that one reminder. Verified in code, not taken from the comment.
+
+This is kept. A dropped reminder is better than a duplicate, and the failure is
+now visible through the Warn log and the `skipped`/failure counters rather than
+silent.
+
+**No cleanup migration is needed for the no-op era.** Marker rows are only
+inserted when an offset's day arrives, so future offsets are unclaimed. A
+merchant mid-trial loses at most the offset that passed while the no-op was live
+and still receives the rest of the cadence. The gap closes itself.
+
+## Components
+
+| unit | file | depends on |
+|---|---|---|
+| `templateClient` | `internal/email/template_client.go` | `emailtemplates.Loader`, `email.Sender` |
+| embedded templates | `internal/email/templates/*.{html,txt}` | — |
+| address writer | `billing/dispatch/handlers.go` | Stripe payload |
+| backfill | `cmd/backfill-email/main.go` | Stripe API, DB |
+| claim markers | `internal/subscription/dunning`, `.../lifecycle` | DB |
+
+## Testing
+
+**Unit** — adapter envelope construction; every `ErrUndeliverable` case (empty,
+no `@`, `.local`, `.invalid`); the webhook handler's new column write; golden
+output for all 11 embedded templates.
+
+**Integration** (`-tags=integration`, `-p 1`) — backfill idempotency across
+re-runs; a dunning-cron test asserting `sent` does **not** increment for a
+`.local` row; a double-run test asserting the claim marker suppresses the second
+send for dunning and win-back.
+
+Per the handoff's recurring theme — documentation promising more than the code
+enforces — every property asserted in a comment here gets a test that makes it
+true. Specifically: the `.local` rejection, the never-`nil`-without-delivery
+rule, and the claim-first suppression.
+
+## Out of scope
+
+- Bounce and complaint handling (belongs with #348 piece B, which receives
+  provider delivery events).
+- Consolidating `trial_reminders` / `payment_action_reminders` into
+  `billing_email_sends`.
+- Retrying reminders whose slot was burned by a transient failure.
+- The undeliverable `billing+<uuid>@mark8ly.local` addresses themselves — this
+  design refuses to send to them and makes them countable; sourcing a better
+  address for those stores is separate.
+
+## Piece B — template catalog endpoint (files separately)
+
+`internal/emailtemplates` exposes `POST /internal/templates/refresh` and
+`POST /internal/templates/:key/test`, but **no way to list the catalog**. So the
+console reads `email_templates` directly over the cross-DB grant on
+`mark8ly_platform_admin` and can only display keys that already have a row —
+even though the service knows the full set, because every key is
+`loader.Register`ed at boot.
+
+B adds `GET /internal/templates`: registered key, declared variables, whether a
+DB override exists, and its status/version. The new console then lists
+everything the service can actually send, needs no cross-DB read to enumerate,
+and seed rows stop being necessary. This fixes the same invisibility for
+`orderdoc`'s 5 keys and `giftcard`'s 1, not only the 11 added here.
+
+Deliberately not designed further: the response shape should answer to the new
+console's needs, and that console is not specified yet.

--- a/services/marketplace-api/cmd/backfill-email/main.go
+++ b/services/marketplace-api/cmd/backfill-email/main.go
@@ -1,0 +1,178 @@
+// Command backfill-email populates store_subscriptions.email for rows that
+// pre-date migration 104. customer.updated webhooks only fire on change, so
+// historical customers with an email already set in Stripe won't have the
+// column populated without this script (#381).
+//
+// Run once per environment after migration 104 lands. Idempotent — safe to
+// re-run; it always re-reads from Stripe and writes the current value.
+//
+// Addresses Stripe reports that we would refuse to send to (the
+// billing+<store_id>@mark8ly.local placeholders minted by subscription
+// bootstrap) are counted as `Placeholder` and NOT written: storing one would
+// only move the refusal from send time to a column nobody reads.
+//
+// Multi-tenant safety: each row is keyed by stripe_customer_id (1:1 with
+// (tenant_id, store_id)). A failure on one row does not block other rows or
+// other tenants — failures are logged and the script continues.
+package main
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"os"
+	"time"
+
+	"gorm.io/gorm"
+
+	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/db"
+)
+
+func main() {
+	var (
+		batchSize int
+		throttle  time.Duration
+		dryRun    bool
+	)
+	flag.IntVar(&batchSize, "batch", 200, "rows fetched per DB scan")
+	flag.DurationVar(&throttle, "throttle", 50*time.Millisecond, "sleep between Stripe API calls (rate-limit hedge)")
+	flag.BoolVar(&dryRun, "dry-run", false, "log changes without writing")
+	flag.Parse()
+
+	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		log.Error("backfill-email: DATABASE_URL not set")
+		os.Exit(1)
+	}
+	stripeKey := os.Getenv("STRIPE_BILLING_SECRET_KEY")
+	if stripeKey == "" {
+		log.Error("backfill-email: STRIPE_BILLING_SECRET_KEY not set")
+		os.Exit(1)
+	}
+
+	conn, err := db.Open(databaseURL)
+	if err != nil {
+		log.Error("backfill-email: db open failed", "err", err)
+		os.Exit(1)
+	}
+	stripeClient := billingstripe.New(stripeKey)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	stats, err := run(ctx, conn, stripeClient, batchSize, throttle, dryRun, log)
+	if err != nil {
+		log.Error("backfill-email: run failed", "err", err, "stats", stats)
+		os.Exit(1)
+	}
+	log.Info("backfill-email: done", "stats", stats)
+}
+
+type runStats struct {
+	Scanned      int
+	Updated      int
+	Unchanged    int
+	NoneInStripe int
+	Placeholder  int // Stripe holds an address we would refuse to send to
+	Failed       int
+}
+
+func run(ctx context.Context, conn *gorm.DB, sc *billingstripe.Client, batchSize int, throttle time.Duration, dryRun bool, log *slog.Logger) (runStats, error) {
+	var stats runStats
+
+	// Keyset pagination via id ordering — avoids OFFSET drift on a live table
+	// and keeps memory bounded regardless of subscription count.
+	lastID := ""
+
+	for {
+		var rows []subscription.StoreSubscription
+		q := conn.WithContext(ctx).
+			Where("stripe_customer_id <> ''").
+			Order("id ASC").
+			Limit(batchSize)
+		if lastID != "" {
+			q = q.Where("id > ?", lastID)
+		}
+		if err := q.Find(&rows).Error; err != nil {
+			return stats, err
+		}
+		if len(rows) == 0 {
+			return stats, nil
+		}
+
+		for i := range rows {
+			row := &rows[i]
+			stats.Scanned++
+			lastID = row.ID.String()
+
+			addr, err := billingstripe.GetCustomerEmail(ctx, sc, row.StripeCustomerID)
+			if err != nil {
+				stats.Failed++
+				log.Warn("backfill-email: stripe lookup failed; skipping",
+					"tenant_id", row.TenantID.String(),
+					"store_id", row.StoreID.String(),
+					"stripe_customer_id", row.StripeCustomerID,
+					"err", err.Error())
+				time.Sleep(throttle)
+				continue
+			}
+
+			if addr == "" {
+				stats.NoneInStripe++
+				time.Sleep(throttle)
+				continue
+			}
+
+			if err := email.ValidateRecipient(addr); err != nil {
+				stats.Placeholder++
+				log.Warn("backfill-email: stripe holds an undeliverable address; not storing",
+					"tenant_id", row.TenantID.String(),
+					"store_id", row.StoreID.String(),
+					"reason", email.SkipReason(err))
+				time.Sleep(throttle)
+				continue
+			}
+
+			if row.Email != nil && *row.Email == addr {
+				stats.Unchanged++
+				time.Sleep(throttle)
+				continue
+			}
+
+			if dryRun {
+				log.Info("backfill-email: dry-run would update",
+					"tenant_id", row.TenantID.String(),
+					"store_id", row.StoreID.String())
+				stats.Updated++
+				time.Sleep(throttle)
+				continue
+			}
+
+			// Per-row UPDATE keyed by id — narrowest possible blast radius.
+			res := conn.WithContext(ctx).Exec(`
+				UPDATE store_subscriptions
+				SET email = ?, updated_at = now()
+				WHERE id = ?`,
+				addr, row.ID,
+			)
+			if res.Error != nil {
+				stats.Failed++
+				log.Warn("backfill-email: update failed",
+					"store_id", row.StoreID.String(), "err", res.Error.Error())
+				time.Sleep(throttle)
+				continue
+			}
+			stats.Updated++
+			time.Sleep(throttle)
+		}
+
+		if len(rows) < batchSize {
+			return stats, nil
+		}
+	}
+}

--- a/services/marketplace-api/cmd/backfill-email/main.go
+++ b/services/marketplace-api/cmd/backfill-email/main.go
@@ -6,6 +6,18 @@
 // Run once per environment after migration 104 lands. Idempotent — safe to
 // re-run; it always re-reads from Stripe and writes the current value.
 //
+// The UPDATE deliberately does NOT touch updated_at. On store_subscriptions
+// that column carries business semantics, not bookkeeping: the day-30
+// win-back cron (internal/subscription/lifecycle/winback.go) selects expired
+// rows by `updated_at` falling in the 30–31-day-post-expiry window and
+// derives its idempotency key from the row's own updated_at. Stamping
+// updated_at here would reset every merchant's win-back clock — nothing
+// eligible for 30 days, then the whole historical expired cohort arriving in
+// one window with a "closed for a month" claim that is false for most of
+// them, and permanent loss of the win-back for any store mid-window at
+// backfill time. Email is a bookkeeping column; writing it must be invisible
+// to lifecycle timing.
+//
 // Addresses Stripe reports that we would refuse to send to (the
 // billing+<store_id>@mark8ly.local placeholders minted by subscription
 // bootstrap) are counted as `Placeholder` and NOT written: storing one would
@@ -21,6 +33,7 @@ import (
 	"flag"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -65,12 +78,16 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
-	stats, err := run(ctx, conn, stripeClient, batchSize, throttle, dryRun, log)
+	lookup := func(ctx context.Context, customerID string) (string, error) {
+		return billingstripe.GetCustomerEmail(ctx, stripeClient, customerID)
+	}
+
+	stats, err := run(ctx, conn, lookup, batchSize, throttle, dryRun, log)
 	if err != nil {
 		log.Error("backfill-email: run failed", "err", err, "stats", stats)
 		os.Exit(1)
 	}
-	log.Info("backfill-email: done", "stats", stats)
+	log.Info("backfill-email: done", "dry_run", dryRun, "stats", stats)
 }
 
 type runStats struct {
@@ -82,7 +99,11 @@ type runStats struct {
 	Failed       int
 }
 
-func run(ctx context.Context, conn *gorm.DB, sc *billingstripe.Client, batchSize int, throttle time.Duration, dryRun bool, log *slog.Logger) (runStats, error) {
+// emailLookup resolves a Stripe customer's email address. Injected so the
+// backfill's DB behaviour is testable without a Stripe account.
+type emailLookup func(ctx context.Context, customerID string) (string, error)
+
+func run(ctx context.Context, conn *gorm.DB, lookup emailLookup, batchSize int, throttle time.Duration, dryRun bool, log *slog.Logger) (runStats, error) {
 	var stats runStats
 
 	// Keyset pagination via id ordering — avoids OFFSET drift on a live table
@@ -110,7 +131,7 @@ func run(ctx context.Context, conn *gorm.DB, sc *billingstripe.Client, batchSize
 			stats.Scanned++
 			lastID = row.ID.String()
 
-			addr, err := billingstripe.GetCustomerEmail(ctx, sc, row.StripeCustomerID)
+			addr, err := lookup(ctx, row.StripeCustomerID)
 			if err != nil {
 				stats.Failed++
 				log.Warn("backfill-email: stripe lookup failed; skipping",
@@ -138,7 +159,10 @@ func run(ctx context.Context, conn *gorm.DB, sc *billingstripe.Client, batchSize
 				continue
 			}
 
-			if row.Email != nil && *row.Email == addr {
+			// citext column: a case-only difference is the SAME address to
+			// Postgres, so `==` would report "changed" and rewrite the row on
+			// every re-run of a script documented as idempotent.
+			if row.Email != nil && strings.EqualFold(*row.Email, addr) {
 				stats.Unchanged++
 				time.Sleep(throttle)
 				continue
@@ -154,9 +178,10 @@ func run(ctx context.Context, conn *gorm.DB, sc *billingstripe.Client, batchSize
 			}
 
 			// Per-row UPDATE keyed by id — narrowest possible blast radius.
+			// updated_at is intentionally left alone; see the package comment.
 			res := conn.WithContext(ctx).Exec(`
 				UPDATE store_subscriptions
-				SET email = ?, updated_at = now()
+				SET email = ?
 				WHERE id = ?`,
 				addr, row.ID,
 			)

--- a/services/marketplace-api/cmd/backfill-email/main_integration_test.go
+++ b/services/marketplace-api/cmd/backfill-email/main_integration_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func seedStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
+	t.Helper()
+	slug := "tst-" + strings.ReplaceAll(storeID.String(), "-", "")[:20]
+	err := db.Exec(
+		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, encode(gen_random_bytes(32), 'hex'))`,
+		storeID, tenantID, slug, "Test Store", "IE", "EUR", "Europe/Dublin", "active",
+	).Error
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Exec("DELETE FROM stores WHERE id = ?", storeID) })
+}
+
+// seedSub inserts an expired subscription and forces updated_at to a fixed
+// point in the past, past GORM's autoupdate.
+func seedSub(t *testing.T, db *gorm.DB, addr *string, updatedAt time.Time) subscription.StoreSubscription {
+	t.Helper()
+	storeID, tenantID := uuid.New(), uuid.New()
+	seedStore(t, db, tenantID, storeID)
+
+	sub := subscription.StoreSubscription{
+		TenantID:         tenantID,
+		StoreID:          storeID,
+		StripeCustomerID: "cus_" + uuid.NewString()[:12],
+		Status:           subscription.StatusExpired,
+		Email:            addr,
+	}
+	require.NoError(t, db.Create(&sub).Error)
+	require.NoError(t, db.Exec(
+		`UPDATE store_subscriptions SET updated_at = ? WHERE id = ?`, updatedAt, sub.ID).Error)
+	return sub
+}
+
+func readUpdatedAt(t *testing.T, db *gorm.DB, id uuid.UUID) time.Time {
+	t.Helper()
+	var got time.Time
+	require.NoError(t, db.Raw(`SELECT updated_at FROM store_subscriptions WHERE id = ?`, id).Scan(&got).Error)
+	return got
+}
+
+// The win-back cron selects expired rows by updated_at and derives its
+// idempotency key from it. If the backfill stamped updated_at, every
+// merchant's win-back clock would be reset — see the package comment.
+func TestBackfill_DoesNotTouchUpdatedAt(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	ctx := context.Background()
+
+	was := time.Now().UTC().Add(-30*24*time.Hour - time.Hour).Truncate(time.Microsecond)
+	sub := seedSub(t, db, nil, was)
+	before := readUpdatedAt(t, db, sub.ID)
+
+	lookup := func(_ context.Context, customerID string) (string, error) {
+		if customerID == sub.StripeCustomerID {
+			return "merchant@example.com", nil
+		}
+		return "", nil
+	}
+
+	stats, err := run(ctx, db.Where("id = ?", sub.ID), lookup, 200, 0, false, quietLogger())
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.Updated)
+
+	var email *string
+	require.NoError(t, db.Raw(`SELECT email FROM store_subscriptions WHERE id = ?`, sub.ID).Scan(&email).Error)
+	require.NotNil(t, email)
+	require.Equal(t, "merchant@example.com", *email)
+
+	after := readUpdatedAt(t, db, sub.ID)
+	require.True(t, before.Equal(after),
+		"backfill moved updated_at (%s -> %s): win-back timing destroyed", before, after)
+}
+
+// citext: a case-only difference is the same address to Postgres, so the
+// row must count as Unchanged rather than being rewritten on every re-run.
+func TestBackfill_CaseOnlyDifferenceIsUnchanged(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	ctx := context.Background()
+
+	stored := "Merchant@Example.com"
+	sub := seedSub(t, db, &stored, time.Now().UTC().Add(-90*24*time.Hour))
+
+	lookup := func(context.Context, string) (string, error) { return "merchant@example.com", nil }
+
+	stats, err := run(ctx, db.Where("id = ?", sub.ID), lookup, 200, 0, false, quietLogger())
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.Unchanged, "case-only difference counted as a change")
+	require.Equal(t, 0, stats.Updated)
+}

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -225,6 +225,29 @@ func (l lifecycleSkipCounter) WithTemplateReason(template, reason string) lifecy
 	return l.cv.WithLabelValues(template, reason)
 }
 
+// lifecycleSentCounter adapts the shared delivered-emails CounterVec to
+// lifecycle.SentCounter — win_back_day30 has no per-feature sent counter of
+// its own, so without this the sent+skipped identity would be false for it.
+type lifecycleSentCounter struct{ cv *prometheus.CounterVec }
+
+func (l lifecycleSentCounter) WithTemplate(template string) lifecycle.CounterIncrementer {
+	return l.cv.WithLabelValues(template)
+}
+
+// dispatchSkipCounter / dispatchSentCounter do the same for the
+// trial_started_billed confirmation emitted from the invoice.paid webhook.
+type dispatchSkipCounter struct{ cv *prometheus.CounterVec }
+
+func (d dispatchSkipCounter) WithTemplateReason(template, reason string) dispatch.CounterIncrementer {
+	return d.cv.WithLabelValues(template, reason)
+}
+
+type dispatchSentCounter struct{ cv *prometheus.CounterVec }
+
+func (d dispatchSentCounter) WithTemplate(template string) dispatch.CounterIncrementer {
+	return d.cv.WithLabelValues(template)
+}
+
 // otelServiceName is the OpenTelemetry service.name reported for traces and
 // metrics. Both MODE variants (admin/storefront) run the same binary/image,
 // so they share one logical service name; the MODE is distinguished via
@@ -286,10 +309,6 @@ func main() {
 	templateLoader := emailtemplates.NewLoader(conn)
 	orderdoc.RegisterFallbacks(templateLoader)
 	giftcard.RegisterFallbacks(templateLoader)
-	// #381 — billing mail (dunning, trial cadence, payment-action, win-back,
-	// trial-billed). Registered here so an operator can reword any of it from
-	// the console without a deploy.
-	email.RegisterFallbacks(templateLoader)
 	{
 		seedCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		if seedErr := templateLoader.SeedFromEmbedded(seedCtx); seedErr != nil {
@@ -297,6 +316,17 @@ func main() {
 		}
 		cancel()
 	}
+	// #381 — billing mail (dunning, trial cadence, payment-action, win-back,
+	// trial-billed). Registered AFTER SeedFromEmbedded, deliberately: spec §4
+	// says "no seed migration ... a key with no row simply renders from its
+	// embedded default". Registration makes a key overridable from the
+	// operator console; seeding it as a published row would mean the first
+	// boot wins forever, because SeedFromEmbedded is ON CONFLICT DO NOTHING
+	// and Loader.Render prefers a published row — so a later edit to
+	// templates_content.go would deploy and silently never reach a merchant.
+	// orderdoc/giftcard keep their existing seed-then-render behaviour: they
+	// are registered above and so still seed, unchanged.
+	email.RegisterFallbacks(templateLoader)
 	// Test-send dispatcher used by /internal/templates/:key/test. nil
 	// SendGrid key is acceptable — handler returns 503 with a clear
 	// message so dev users don't get silent fail.
@@ -1613,12 +1643,18 @@ func main() {
 		}
 		dispatcher := dispatch.New(auditEmitter)
 
-		// Email adapter — currently the NoOp implementation pending real SMTP/SendGrid
-		// wiring (deferred when email/store_name columns land on StoreSubscription).
-		// Used by the dispatcher for the trial-billed confirmation email on first
-		// invoice.paid, and by the dunning + trial reminder crons.
+		// Email adapter — the real template client (render → SendGrid → Resend),
+		// shared with the dunning, trial reminder and win-back crons so failover
+		// and attribution are identical wherever billing mail originates.
+		// WithDB hands the dispatcher a NON-transactional handle: the
+		// trial-billed confirmation claims a billing_email_sends row before
+		// sending, and that claim has to survive a rollback of the webhook
+		// transaction it is sent from (see dispatch.sendTrialBilled).
 		dispatcherEmailClient := billingEmailClient
-		dispatcher.WithEmail(dispatcherEmailClient)
+		dispatcher.WithEmail(dispatcherEmailClient).
+			WithDB(conn).
+			WithSkipCounter(dispatchSkipCounter{metrics.BillingEmailsSkippedTotal}).
+			WithSentCounter(dispatchSentCounter{metrics.BillingEmailsSentTotal})
 
 		// P7 §19.2: annotate B2B invoices with the reverse-charge clause on
 		// invoice.finalized for validated tax IDs in reverse-charge jurisdictions.
@@ -1900,7 +1936,8 @@ func main() {
 
 	winBackEmailClient := billingEmailClient
 	winBackCron := lifecycle.NewWinBackCron(conn, winBackEmailClient, log, nil).
-		WithSkipCounter(lifecycleSkipCounter{metrics.BillingEmailsSkippedTotal})
+		WithSkipCounter(lifecycleSkipCounter{metrics.BillingEmailsSkippedTotal}).
+		WithSentCounter(lifecycleSentCounter{metrics.BillingEmailsSentTotal})
 	if _, err := trialScheduler.AddFunc(lifecycle.WinBackSpec, func() {
 		if err := winBackCron.Run(workerCtx); err != nil {
 			log.Error("lifecycle win-back cron failed", "err", err)

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -216,6 +216,15 @@ func (stubPlatformClient) GetStoreBySlug(ctx context.Context, slug string) (*sto
 	return nil, stores.ErrPlatformUnavailable
 }
 
+// lifecycleSkipCounter adapts the shared skipped-emails CounterVec to
+// lifecycle.SkipCounter. Separate from dunning's adapter because the two
+// packages declare their own consumer-side interfaces.
+type lifecycleSkipCounter struct{ cv *prometheus.CounterVec }
+
+func (l lifecycleSkipCounter) WithTemplateReason(template, reason string) lifecycle.CounterIncrementer {
+	return l.cv.WithLabelValues(template, reason)
+}
+
 // otelServiceName is the OpenTelemetry service.name reported for traces and
 // metrics. Both MODE variants (admin/storefront) run the same binary/image,
 // so they share one logical service name; the MODE is distinguished via
@@ -277,6 +286,10 @@ func main() {
 	templateLoader := emailtemplates.NewLoader(conn)
 	orderdoc.RegisterFallbacks(templateLoader)
 	giftcard.RegisterFallbacks(templateLoader)
+	// #381 — billing mail (dunning, trial cadence, payment-action, win-back,
+	// trial-billed). Registered here so an operator can reword any of it from
+	// the console without a deploy.
+	email.RegisterFallbacks(templateLoader)
 	{
 		seedCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		if seedErr := templateLoader.SeedFromEmbedded(seedCtx); seedErr != nil {
@@ -551,6 +564,14 @@ func main() {
 		email.ProviderSendGrid: cfg.SendGridAPIKey,
 		email.ProviderResend:   cfg.ResendAPIKey,
 	}, cfg.EmailPrimaryProvider, log)
+
+	// billingEmailClient is the production email.Client. Before #381 the only
+	// implementation was the no-op logger, wired at three sites below, so no
+	// merchant had ever received a dunning notice, trial reminder,
+	// payment-action reminder, win-back promo or trial-billed confirmation.
+	// One instance shared by all three, so failover and attribution are
+	// identical wherever billing mail originates.
+	billingEmailClient := email.NewTemplateClient(templateLoader, emailSender, cfg.EmailFrom, log)
 
 	// Dashboard D2 — Tickets. Hoisted for the same reason as the
 	// notification service: the storefront /support/tickets endpoint
@@ -1596,7 +1617,7 @@ func main() {
 		// wiring (deferred when email/store_name columns land on StoreSubscription).
 		// Used by the dispatcher for the trial-billed confirmation email on first
 		// invoice.paid, and by the dunning + trial reminder crons.
-		dispatcherEmailClient := email.NoOpClient{Logger: log}
+		dispatcherEmailClient := billingEmailClient
 		dispatcher.WithEmail(dispatcherEmailClient)
 
 		// P7 §19.2: annotate B2B invoices with the reverse-charge clause on
@@ -1758,10 +1779,11 @@ func main() {
 	defer trialScheduler.Stop()
 	log.Info("P5 crons started", "count", 5)
 
-	// P6 dunning + SCA recovery crons. Emails route through the NoOpClient
-	// until a real adapter is wired (email columns on StoreSubscription are
-	// deferred). All state mutations go through statemachine.Transition.
-	dunningEmailClient := email.NoOpClient{Logger: log}
+	// P6 dunning + SCA recovery crons. Emails route through the real
+	// template client as of #381 — recipients come from
+	// store_subscriptions.email, and an unknown or placeholder address is
+	// counted as skipped rather than reported as delivered.
+	dunningEmailClient := billingEmailClient
 
 	ladderCron := dunning.NewStepDailyLadder(conn, auditEmitter, log,
 		dunning.WrapPrometheusCounter(metrics.DunningSuppressedRefundWindowTotal),
@@ -1776,7 +1798,7 @@ func main() {
 
 	dunningEmailsCron := dunning.NewSendDunningEmails(conn, dunningEmailClient, log,
 		dunning.WrapPrometheusCounterVec(metrics.DunningEmailsSentTotal),
-		nil)
+		nil).WithSkipCounter(dunning.WrapPrometheusSkipCounter(metrics.BillingEmailsSkippedTotal))
 	if _, err := trialScheduler.AddFunc(dunning.DunningEmailsSpec, func() {
 		if err := dunningEmailsCron.Run(workerCtx); err != nil {
 			log.Error("dunning emails cron failed", "err", err)
@@ -1787,7 +1809,7 @@ func main() {
 
 	scaRemindersCron := dunning.NewSendPaymentActionReminders(conn, dunningEmailClient, log,
 		dunning.WrapPrometheusCounterVec(metrics.PaymentActionRemindersSentTotal),
-		nil)
+		nil).WithSkipCounter(dunning.WrapPrometheusSkipCounter(metrics.BillingEmailsSkippedTotal))
 
 	// P7 §19.5 — quarterly tax-ID revalidation cron. Daily 02:00 UTC. Re-runs
 	// the validator for each subscription with a >90d-old validation; on
@@ -1824,7 +1846,7 @@ func main() {
 	// via the trial_reminders table (migration 088). See spec §5.3.
 	trialRemindersCron := dunning.NewSendTrialReminders(conn, dunningEmailClient, log,
 		dunning.WrapPrometheusCounterVec(metrics.TrialRemindersSentTotal),
-		nil)
+		nil).WithSkipCounter(dunning.WrapPrometheusSkipCounter(metrics.BillingEmailsSkippedTotal))
 	if _, err := trialScheduler.AddFunc(dunning.TrialRemindersSpec, func() {
 		if err := trialRemindersCron.Run(workerCtx); err != nil {
 			log.Error("trial reminders cron failed", "err", err)
@@ -1876,8 +1898,9 @@ func main() {
 		log.Error("register lifecycle hard-delete cron", "err", err)
 	}
 
-	winBackEmailClient := email.NoOpClient{Logger: log}
-	winBackCron := lifecycle.NewWinBackCron(conn, winBackEmailClient, log, nil)
+	winBackEmailClient := billingEmailClient
+	winBackCron := lifecycle.NewWinBackCron(conn, winBackEmailClient, log, nil).
+		WithSkipCounter(lifecycleSkipCounter{metrics.BillingEmailsSkippedTotal})
 	if _, err := trialScheduler.AddFunc(lifecycle.WinBackSpec, func() {
 		if err := winBackCron.Run(workerCtx); err != nil {
 			log.Error("lifecycle win-back cron failed", "err", err)

--- a/services/marketplace-api/cmd/marketplace-api/wiring_test.go
+++ b/services/marketplace-api/cmd/marketplace-api/wiring_test.go
@@ -68,3 +68,49 @@ func TestPlatformadminRegisterSitesAgree(t *testing.T) {
 		"the two platformadmin.Register sites construct different Deps field sets — "+
 			"one deployment will differ from the other (#323)")
 }
+
+// TestBillingTemplatesRegisteredAfterSeeding guards spec §4: "No seed
+// migration ... A key with no row simply renders from its embedded default."
+//
+// SeedFromEmbedded inserts every REGISTERED fallback as status='published',
+// and Loader.Render prefers a published row. If email.RegisterFallbacks ran
+// before it, the 11 billing templates would be seeded as published rows —
+// day one identical, and then permanently stale, because the seed is
+// ON CONFLICT (key) DO NOTHING: an edit to templates_content.go would
+// deploy and silently never reach a merchant.
+//
+// Ordering in a single function body is exactly the kind of thing a later
+// refactor reshuffles without noticing, so it is asserted here on source
+// position rather than left to review.
+func TestBillingTemplatesRegisteredAfterSeeding(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, 0)
+	require.NoError(t, err)
+
+	var registerPos, seedPos token.Pos
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		switch sel.Sel.Name {
+		case "RegisterFallbacks":
+			if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "email" {
+				registerPos = call.Pos()
+			}
+		case "SeedFromEmbedded":
+			seedPos = call.Pos()
+		}
+		return true
+	})
+
+	require.NotZero(t, registerPos, "email.RegisterFallbacks call not found in main.go")
+	require.NotZero(t, seedPos, "SeedFromEmbedded call not found in main.go")
+	require.Greater(t, int(registerPos), int(seedPos),
+		"email.RegisterFallbacks must run AFTER SeedFromEmbedded, or the billing "+
+			"templates get seeded as published rows and go stale forever (spec §4)")
+}

--- a/services/marketplace-api/internal/billing/dispatch/dispatcher.go
+++ b/services/marketplace-api/internal/billing/dispatch/dispatcher.go
@@ -43,6 +43,14 @@ type Dispatcher struct {
 	emitter  *audit.Emitter
 	recorder *arbitrage.Recorder // nil-safe: arbitrage check is skipped when nil
 	emailCl  email.Client        // nil-safe: trial-billed confirmation email is skipped when nil
+	// db is a NON-transactional handle, deliberately separate from the tx
+	// passed to Dispatch. The trial-billed claim must survive a rollback of
+	// the webhook transaction (see handleInvoicePaid), which a claim written
+	// on tx would not. Nil disables the trial-billed email entirely — there
+	// is no way to make it at-most-once without a claim store.
+	db       *gorm.DB
+	skip     SkipCounter // nil-safe: skipped-send counting is optional
+	sent     SentCounter // nil-safe: delivered-send counting is optional
 	handlers map[string]Handler
 }
 
@@ -80,10 +88,49 @@ func (d *Dispatcher) WithRecorder(r *arbitrage.Recorder) *Dispatcher {
 	return d
 }
 
+// CounterIncrementer is a one-method counter so tests can stub it.
+type CounterIncrementer interface{ Inc() }
+
+// SkipCounter counts billing emails deliberately not sent, labeled by
+// template and reason. Mirrors dunning.SkipCounter and lifecycle.SkipCounter
+// so main can feed all three from metrics.BillingEmailsSkippedTotal.
+type SkipCounter interface {
+	WithTemplateReason(template, reason string) CounterIncrementer
+}
+
+// SentCounter counts billing emails actually delivered, labeled by template.
+type SentCounter interface {
+	WithTemplate(template string) CounterIncrementer
+}
+
+// WithDB attaches a non-transactional database handle used to claim a
+// billing_email_sends row before the trial-billed confirmation is sent.
+// It must NOT be the webhook transaction: the whole point is that the claim
+// outlives a rollback of that transaction.
+func (d *Dispatcher) WithDB(conn *gorm.DB) *Dispatcher {
+	d.db = conn
+	return d
+}
+
+// WithSkipCounter attaches the counter for trial-billed emails deliberately
+// not sent. Optional.
+func (d *Dispatcher) WithSkipCounter(c SkipCounter) *Dispatcher {
+	d.skip = c
+	return d
+}
+
+// WithSentCounter attaches the counter for trial-billed emails delivered.
+// Optional.
+func (d *Dispatcher) WithSentCounter(c SentCounter) *Dispatcher {
+	d.sent = c
+	return d
+}
+
 // WithEmail attaches an email.Client so the dispatcher can emit the
 // trial-billed confirmation email on the first successful invoice charge.
 // emailCl may be nil — the send is then skipped without affecting other
-// invoice.paid side effects.
+// invoice.paid side effects. WithDB must be called too; without a claim
+// store the send is skipped.
 func (d *Dispatcher) WithEmail(c email.Client) *Dispatcher {
 	d.emailCl = c
 	return d

--- a/services/marketplace-api/internal/billing/dispatch/dispatcher_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/dispatcher_test.go
@@ -202,6 +202,7 @@ func TestDispatch_InvoicePaid_StampsFirstChargeAt_ClearsHostedURL(t *testing.T) 
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	seedStore(t, db, storeID) // store_subscriptions.store_id has an enforced FK
 	hostedURL := "https://invoice.stripe.com/i/acct_123/test_yyy"
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
@@ -231,6 +232,7 @@ func TestDispatch_InvoicePaid_FirstChargeAtIdempotent_SecondEventDoesNotAdvance(
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	seedStore(t, db, storeID) // store_subscriptions.store_id has an enforced FK
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -381,9 +383,10 @@ func (r *dispatchEmailRecorder) Send(_ context.Context, t email.TemplateID, _ st
 // email client is wired. This is the merchant-facing confirmation that
 // "your chosen plan is now active and we just billed your card".
 func TestDispatch_InvoicePaid_FirstChargeEmitsTrialBilledEmail(t *testing.T) {
-	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
+	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events", "billing_email_sends")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	seedStore(t, db, storeID) // store_subscriptions.store_id has an enforced FK
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -394,7 +397,7 @@ func TestDispatch_InvoicePaid_FirstChargeEmitsTrialBilledEmail(t *testing.T) {
 	}).Error)
 
 	rec := &dispatchEmailRecorder{}
-	d := dispatch.New(nil).WithEmail(rec)
+	d := dispatch.New(nil).WithEmail(rec).WithDB(db)
 	payload := []byte(`{"id":"evt_first","type":"invoice.paid","data":{"object":{"customer":"cus_first_charge"}}}`)
 	require.NoError(t, d.Dispatch(context.Background(), db, webhookevents.StripeWebhookEvent{
 		EventID: "evt_first", EventType: "invoice.paid", Payload: payload,
@@ -415,9 +418,10 @@ func TestDispatch_InvoicePaid_FirstChargeEmitsTrialBilledEmail(t *testing.T) {
 // is robust to no email client being wired (e.g. dev mode without the
 // adapter): first_charge_at is still stamped, no panic, no error.
 func TestDispatch_InvoicePaid_NoEmailClientStillProcesses(t *testing.T) {
-	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
+	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events", "billing_email_sends")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	seedStore(t, db, storeID) // store_subscriptions.store_id has an enforced FK
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -474,7 +478,7 @@ func (c *captureEmailClient) Send(_ context.Context, _ email.TemplateID, to stri
 // callers can assert on webhook-level failure behavior.
 func runInvoicePaidFirstCharge(t *testing.T, client email.Client, addr *string) (db *gorm.DB, storeID uuid.UUID, storeName string, err error) {
 	t.Helper()
-	db = testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
+	db = testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events", "billing_email_sends")
 
 	tenantID := uuid.New()
 	storeID = uuid.New()
@@ -492,7 +496,7 @@ func runInvoicePaidFirstCharge(t *testing.T, client email.Client, addr *string) 
 		// FirstChargeAt deliberately nil — this is the first charge.
 	}).Error)
 
-	d := dispatch.New(nil).WithEmail(client)
+	d := dispatch.New(nil).WithEmail(client).WithDB(db)
 	eventID := "evt_" + uuid.NewString()[:12]
 	payload := []byte(`{"id":"` + eventID + `","type":"invoice.paid","data":{"object":{"customer":"` + customerID + `"}}}`)
 	err = d.Dispatch(context.Background(), db, webhookevents.StripeWebhookEvent{

--- a/services/marketplace-api/internal/billing/dispatch/dispatcher_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/dispatcher_test.go
@@ -547,3 +547,68 @@ func TestInvoicePaid_TrialBilledWithoutAddressDoesNotFailTheWebhook(t *testing.T
 	require.NotNil(t, sub.FirstChargeAt, "first_charge_at must be stamped even though the email failed")
 	require.Nil(t, sub.HostedInvoiceURL, "hosted_invoice_url must be cleared even though the email failed")
 }
+
+// TestDispatch_InvoicePaymentFailed_PersistsHostedInvoiceURL pins the fix for
+// the dunning cohort's missing payment link: invoice.payment_failed is the
+// handler that produces past_due, and the day-5 / day-7 dunning emails only
+// render a payment button when hosted_invoice_url is set. Before this, only
+// the SCA path (invoice.payment_action_required) ever wrote the column, so
+// the ordinary declined-card merchant got the linkless {{else}} branch.
+func TestDispatch_InvoicePaymentFailed_PersistsHostedInvoiceURL(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	seedStore(t, db, storeID)
+	require.NoError(t, db.Create(&subscription.StoreSubscription{
+		TenantID:         tenantID,
+		StoreID:          storeID,
+		StripeCustomerID: "cus_pf_url",
+		Plan:             subscription.PlanStarter,
+		Status:           subscription.StatusActive,
+	}).Error)
+
+	stripeURL := "https://invoice.stripe.com/i/acct_123/pf_xxx"
+	payload := []byte(`{"id":"evt_pf_url","type":"invoice.payment_failed","data":{"object":{"customer":"cus_pf_url","hosted_invoice_url":"` + stripeURL + `"}}}`)
+	d := dispatch.New(nil)
+	require.NoError(t, d.Dispatch(context.Background(), db, webhookevents.StripeWebhookEvent{
+		EventID: "evt_pf_url", EventType: "invoice.payment_failed", Payload: payload,
+	}))
+
+	var sub subscription.StoreSubscription
+	require.NoError(t, db.Where("store_id=?", storeID).First(&sub).Error)
+	require.NotNil(t, sub.HostedInvoiceURL, "dunning emails have no payment link without this")
+	require.Equal(t, stripeURL, *sub.HostedInvoiceURL)
+	require.Equal(t, subscription.StatusPastDue, sub.Status)
+}
+
+// TestDispatch_InvoicePaymentFailed_AbsentURLKeepsExistingValue verifies an
+// event without hosted_invoice_url does not blank a URL we already hold —
+// Stripe omits the field on some payloads, and overwriting with "" would
+// re-break the dunning link for a merchant who already had one.
+func TestDispatch_InvoicePaymentFailed_AbsentURLKeepsExistingValue(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	seedStore(t, db, storeID)
+	existing := "https://invoice.stripe.com/i/acct_123/already_here"
+	require.NoError(t, db.Create(&subscription.StoreSubscription{
+		TenantID:         tenantID,
+		StoreID:          storeID,
+		StripeCustomerID: "cus_pf_nourl",
+		Plan:             subscription.PlanStarter,
+		Status:           subscription.StatusActive,
+		HostedInvoiceURL: &existing,
+	}).Error)
+
+	payload := []byte(`{"id":"evt_pf_nourl","type":"invoice.payment_failed","data":{"object":{"customer":"cus_pf_nourl"}}}`)
+	d := dispatch.New(nil)
+	require.NoError(t, d.Dispatch(context.Background(), db, webhookevents.StripeWebhookEvent{
+		EventID: "evt_pf_nourl", EventType: "invoice.payment_failed", Payload: payload,
+	}))
+
+	var sub subscription.StoreSubscription
+	require.NoError(t, db.Where("store_id=?", storeID).First(&sub).Error)
+	require.NotNil(t, sub.HostedInvoiceURL, "an absent field must not blank an existing URL")
+	require.Equal(t, existing, *sub.HostedInvoiceURL)
+	require.Equal(t, subscription.StatusPastDue, sub.Status)
+}

--- a/services/marketplace-api/internal/billing/dispatch/dispatcher_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/dispatcher_test.go
@@ -435,3 +435,78 @@ func TestDispatch_InvoicePaid_NoEmailClientStillProcesses(t *testing.T) {
 	require.NoError(t, db.Where("store_id=?", storeID).First(&sub).Error)
 	require.NotNil(t, sub.FirstChargeAt, "first_charge_at must be stamped even without email client")
 }
+
+// captureEmailClient is a minimal email.Client stub that records every
+// recipient it was asked to send to. Unlike dispatchEmailRecorder above (which
+// only cares which template fired), this one exists to catch the actual bug
+// in Task 12: the recipient passed to Send was a store UUID, not an address.
+// Send honours the same contract the real client enforces — validating the
+// recipient first — so a test double here can't mask a bounce the
+// production client would have caught.
+type captureEmailClient struct {
+	recipients []string
+}
+
+func (c *captureEmailClient) Send(_ context.Context, _ email.TemplateID, to string, _ map[string]any) error {
+	if err := email.ValidateRecipient(to); err != nil {
+		return err
+	}
+	c.recipients = append(c.recipients, to)
+	return nil
+}
+
+// runInvoicePaidFirstCharge seeds a store and a store_subscriptions row with
+// first_charge_at NULL and the given email (nil leaves it unset), attaches
+// client as the dispatcher's email client, and dispatches a first-charge
+// invoice.paid event. Returns the error from Dispatch so callers can assert
+// on webhook-level failure behavior.
+func runInvoicePaidFirstCharge(t *testing.T, client email.Client, addr *string) error {
+	t.Helper()
+	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	seedStore(t, db, storeID)
+
+	customerID := "cus_" + uuid.NewString()[:12]
+	require.NoError(t, db.Create(&subscription.StoreSubscription{
+		TenantID:         tenantID,
+		StoreID:          storeID,
+		StripeCustomerID: customerID,
+		Plan:             subscription.PlanStarter,
+		Status:           subscription.StatusActive,
+		Email:            addr,
+		// FirstChargeAt deliberately nil — this is the first charge.
+	}).Error)
+
+	d := dispatch.New(nil).WithEmail(client)
+	eventID := "evt_" + uuid.NewString()[:12]
+	payload := []byte(`{"id":"` + eventID + `","type":"invoice.paid","data":{"object":{"customer":"` + customerID + `"}}}`)
+	return d.Dispatch(context.Background(), db, webhookevents.StripeWebhookEvent{
+		EventID: eventID, EventType: "invoice.paid", Payload: payload,
+	})
+}
+
+// TestInvoicePaid_TrialBilledUsesRealAddress verifies the trial-billed
+// confirmation email is sent to the merchant's actual address, not the
+// store UUID that used to be passed as `to`.
+func TestInvoicePaid_TrialBilledUsesRealAddress(t *testing.T) {
+	addr := "merchant@example.com"
+	client := &captureEmailClient{}
+
+	require.NoError(t, runInvoicePaidFirstCharge(t, client, &addr))
+
+	require.Len(t, client.recipients, 1, "sent %d emails, want 1", len(client.recipients))
+	require.Equal(t, addr, client.recipients[0], "a store UUID would bounce")
+}
+
+// TestInvoicePaid_TrialBilledWithoutAddressDoesNotFailTheWebhook verifies a
+// missing/invalid recipient keeps the webhook non-fatal — Stripe must not
+// retry and re-fire every other invoice.paid side effect.
+func TestInvoicePaid_TrialBilledWithoutAddressDoesNotFailTheWebhook(t *testing.T) {
+	client := &captureEmailClient{}
+
+	err := runInvoicePaidFirstCharge(t, client, nil)
+
+	require.NoError(t, err, "webhook must stay non-fatal on email failure")
+	require.Empty(t, client.recipients, "no address means nothing should have been sent")
+}

--- a/services/marketplace-api/internal/billing/dispatch/dispatcher_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/dispatcher_test.go
@@ -612,3 +612,49 @@ func TestDispatch_InvoicePaymentFailed_AbsentURLKeepsExistingValue(t *testing.T)
 	require.Equal(t, existing, *sub.HostedInvoiceURL)
 	require.Equal(t, subscription.StatusPastDue, sub.Status)
 }
+
+// TestDispatch_InvoicePaymentFailed_DoesNotStampUpdatedAt guards against
+// reintroducing the exact bug cmd/backfill-email fixed: store_subscriptions.
+// updated_at is both the win-back cron's 30-to-31-day eligibility window AND
+// its idempotency key, and it also drives the expired->store_closed timer and
+// the 150-day hard-delete cutoff. Stripe keeps retrying a failed invoice for
+// weeks after a subscription is already expired, so invoice.payment_failed
+// commonly arrives against an already-terminal row. Persisting
+// hosted_invoice_url must not stamp updated_at as a side effect — only a real
+// business-state transition may.
+func TestDispatch_InvoicePaymentFailed_DoesNotStampUpdatedAt(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	seedStore(t, db, storeID)
+	require.NoError(t, db.Create(&subscription.StoreSubscription{
+		TenantID:         tenantID,
+		StoreID:          storeID,
+		StripeCustomerID: "cus_pf_noupdate",
+		Plan:             subscription.PlanStarter,
+		Status:           subscription.StatusExpired,
+	}).Error)
+
+	// GORM stamps updated_at on create, so pin it to a known past value with
+	// a raw UPDATE before dispatching.
+	knownPast := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Exec(
+		`UPDATE store_subscriptions SET updated_at = ? WHERE store_id = ?`,
+		knownPast, storeID,
+	).Error)
+
+	stripeURL := "https://invoice.stripe.com/i/acct_123/pf_noupdate"
+	payload := []byte(`{"id":"evt_pf_noupdate","type":"invoice.payment_failed","data":{"object":{"customer":"cus_pf_noupdate","hosted_invoice_url":"` + stripeURL + `"}}}`)
+	d := dispatch.New(nil)
+	require.NoError(t, d.Dispatch(context.Background(), db, webhookevents.StripeWebhookEvent{
+		EventID: "evt_pf_noupdate", EventType: "invoice.payment_failed", Payload: payload,
+	}))
+
+	var sub subscription.StoreSubscription
+	require.NoError(t, db.Where("store_id=?", storeID).First(&sub).Error)
+	require.NotNil(t, sub.HostedInvoiceURL, "hosted_invoice_url must still be persisted")
+	require.Equal(t, stripeURL, *sub.HostedInvoiceURL)
+	require.Equal(t, subscription.StatusExpired, sub.Status, "expired is terminal, payment_failed must no-op the transition")
+	require.True(t, knownPast.Equal(sub.UpdatedAt),
+		"updated_at must not be stamped by the bookkeeping hosted_invoice_url write; got %v want %v", sub.UpdatedAt, knownPast)
+}

--- a/services/marketplace-api/internal/billing/dispatch/dispatcher_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/dispatcher_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/billing/dispatch"
 	"github.com/mark8ly/marketplace-api/internal/email"
@@ -436,36 +437,49 @@ func TestDispatch_InvoicePaid_NoEmailClientStillProcesses(t *testing.T) {
 	require.NotNil(t, sub.FirstChargeAt, "first_charge_at must be stamped even without email client")
 }
 
-// captureEmailClient is a minimal email.Client stub that records every
-// recipient it was asked to send to. Unlike dispatchEmailRecorder above (which
-// only cares which template fired), this one exists to catch the actual bug
-// in Task 12: the recipient passed to Send was a store UUID, not an address.
-// Send honours the same contract the real client enforces — validating the
-// recipient first — so a test double here can't mask a bounce the
-// production client would have caught.
-type captureEmailClient struct {
-	recipients []string
+// capturedSend records one call to captureEmailClient.Send, so tests can
+// assert on both the recipient and the data map (e.g. store_name).
+type capturedSend struct {
+	to   string
+	data map[string]any
 }
 
-func (c *captureEmailClient) Send(_ context.Context, _ email.TemplateID, to string, _ map[string]any) error {
+// captureEmailClient is a minimal email.Client stub that records every send
+// it was asked to make. Unlike dispatchEmailRecorder above (which only cares
+// which template fired), this one exists to catch the actual bugs in Task
+// 12: the recipient passed to Send was a store UUID, not an address, and
+// store_name was a hardcoded literal. Send honours the same contract the
+// real client enforces — validating the recipient first — so a test double
+// here can't mask a bounce the production client would have caught.
+type captureEmailClient struct {
+	recipients []string
+	sends      []capturedSend
+}
+
+func (c *captureEmailClient) Send(_ context.Context, _ email.TemplateID, to string, data map[string]any) error {
 	if err := email.ValidateRecipient(to); err != nil {
 		return err
 	}
 	c.recipients = append(c.recipients, to)
+	c.sends = append(c.sends, capturedSend{to: to, data: data})
 	return nil
 }
 
 // runInvoicePaidFirstCharge seeds a store and a store_subscriptions row with
 // first_charge_at NULL and the given email (nil leaves it unset), attaches
 // client as the dispatcher's email client, and dispatches a first-charge
-// invoice.paid event. Returns the error from Dispatch so callers can assert
-// on webhook-level failure behavior.
-func runInvoicePaidFirstCharge(t *testing.T, client email.Client, addr *string) error {
+// invoice.paid event. Returns the db handle and storeID so callers can
+// re-query store_subscriptions afterward, the seeded store's name so
+// callers can assert it was used verbatim, and the error from Dispatch so
+// callers can assert on webhook-level failure behavior.
+func runInvoicePaidFirstCharge(t *testing.T, client email.Client, addr *string) (db *gorm.DB, storeID uuid.UUID, storeName string, err error) {
 	t.Helper()
-	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
+	db = testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
 
-	tenantID, storeID := uuid.New(), uuid.New()
+	tenantID := uuid.New()
+	storeID = uuid.New()
 	seedStore(t, db, storeID)
+	storeName = "Test Store " + storeID.String() // must match seedStore's inserted name
 
 	customerID := "cus_" + uuid.NewString()[:12]
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
@@ -481,32 +495,51 @@ func runInvoicePaidFirstCharge(t *testing.T, client email.Client, addr *string) 
 	d := dispatch.New(nil).WithEmail(client)
 	eventID := "evt_" + uuid.NewString()[:12]
 	payload := []byte(`{"id":"` + eventID + `","type":"invoice.paid","data":{"object":{"customer":"` + customerID + `"}}}`)
-	return d.Dispatch(context.Background(), db, webhookevents.StripeWebhookEvent{
+	err = d.Dispatch(context.Background(), db, webhookevents.StripeWebhookEvent{
 		EventID: eventID, EventType: "invoice.paid", Payload: payload,
 	})
+	return db, storeID, storeName, err
 }
 
 // TestInvoicePaid_TrialBilledUsesRealAddress verifies the trial-billed
-// confirmation email is sent to the merchant's actual address, not the
-// store UUID that used to be passed as `to`.
+// confirmation email is sent to the merchant's actual address (not the
+// store UUID that used to be passed as `to`), carries the store's real
+// name (not the "your store" literal), and that the webhook's own side
+// effects (first_charge_at stamped, hosted_invoice_url cleared) happened.
 func TestInvoicePaid_TrialBilledUsesRealAddress(t *testing.T) {
 	addr := "merchant@example.com"
 	client := &captureEmailClient{}
 
-	require.NoError(t, runInvoicePaidFirstCharge(t, client, &addr))
+	db, storeID, storeName, err := runInvoicePaidFirstCharge(t, client, &addr)
+	require.NoError(t, err)
 
 	require.Len(t, client.recipients, 1, "sent %d emails, want 1", len(client.recipients))
 	require.Equal(t, addr, client.recipients[0], "a store UUID would bounce")
+	require.Len(t, client.sends, 1)
+	require.Equal(t, storeName, client.sends[0].data["store_name"],
+		"store_name must be the real store name, not the \"your store\" literal")
+
+	var sub subscription.StoreSubscription
+	require.NoError(t, db.Where("store_id=?", storeID).First(&sub).Error)
+	require.NotNil(t, sub.FirstChargeAt, "first_charge_at must be stamped")
+	require.Nil(t, sub.HostedInvoiceURL, "hosted_invoice_url must be cleared")
 }
 
 // TestInvoicePaid_TrialBilledWithoutAddressDoesNotFailTheWebhook verifies a
 // missing/invalid recipient keeps the webhook non-fatal — Stripe must not
-// retry and re-fire every other invoice.paid side effect.
+// retry and re-fire every other invoice.paid side effect — and that those
+// side effects (first_charge_at stamped, hosted_invoice_url cleared) still
+// happened even though the email send failed.
 func TestInvoicePaid_TrialBilledWithoutAddressDoesNotFailTheWebhook(t *testing.T) {
 	client := &captureEmailClient{}
 
-	err := runInvoicePaidFirstCharge(t, client, nil)
+	db, storeID, _, err := runInvoicePaidFirstCharge(t, client, nil)
 
 	require.NoError(t, err, "webhook must stay non-fatal on email failure")
 	require.Empty(t, client.recipients, "no address means nothing should have been sent")
+
+	var sub subscription.StoreSubscription
+	require.NoError(t, db.Where("store_id=?", storeID).First(&sub).Error)
+	require.NotNil(t, sub.FirstChargeAt, "first_charge_at must be stamped even though the email failed")
+	require.Nil(t, sub.HostedInvoiceURL, "hosted_invoice_url must be cleared even though the email failed")
 }

--- a/services/marketplace-api/internal/billing/dispatch/export_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/export_test.go
@@ -1,0 +1,15 @@
+//go:build integration
+
+package dispatch
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// HandleCustomerUpdatedForTest exposes the unexported handler to the
+// package's external integration tests.
+func HandleCustomerUpdatedForTest(ctx context.Context, tx *gorm.DB, raw []byte) error {
+	return handleCustomerUpdated(ctx, tx, raw)
+}

--- a/services/marketplace-api/internal/billing/dispatch/handlers.go
+++ b/services/marketplace-api/internal/billing/dispatch/handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -279,20 +280,25 @@ func (d *Dispatcher) handleInvoicePaid(ctx context.Context, tx *gorm.DB, raw []b
 	}
 
 	if wasFirstCharge && d.emailCl != nil {
-		// TODO: real email recipient — see trial.ExpiryCron / SendTrialReminders.
-		// StoreID placeholder mirrors the existing convention until store_email
-		// columns land on StoreSubscription.
-		if sendErr := d.emailCl.Send(ctx, email.TemplateTrialStartedBilled, sub.StoreID.String(), map[string]any{
-			"store_id":  sub.StoreID.String(),
-			"tenant_id": sub.TenantID.String(),
-			"plan":      string(sub.Plan),
-			"period":    string(sub.SubscriptionPeriod),
+		to := ""
+		if sub.Email != nil {
+			to = *sub.Email
+		}
+		if sendErr := d.emailCl.Send(ctx, email.TemplateTrialStartedBilled, to, map[string]any{
+			"store_id":   sub.StoreID.String(),
+			"tenant_id":  sub.TenantID.String(),
+			"store_name": "your store",
+			"plan":       string(sub.Plan),
+			"period":     string(sub.SubscriptionPeriod),
 		}); sendErr != nil {
 			// Don't fail the webhook — Stripe would retry, double-firing every
 			// other side effect. Email failure is a soft error: log and move on.
 			// Idempotency is preserved by first_charge_at being non-nil after
 			// this UPDATE, so a retried invoice.paid event won't re-emit.
-			_ = fmt.Errorf("dispatch: trial-billed email (non-fatal): %w", sendErr)
+			slog.Default().Warn("dispatch: trial-billed email not sent",
+				"store_id", sub.StoreID.String(),
+				"reason", email.SkipReason(sendErr),
+				"err", sendErr.Error())
 		}
 	}
 	return nil

--- a/services/marketplace-api/internal/billing/dispatch/handlers.go
+++ b/services/marketplace-api/internal/billing/dispatch/handlers.go
@@ -415,6 +415,7 @@ func handleCustomerUpdated(ctx context.Context, tx *gorm.DB, raw []byte) error {
 		Data struct {
 			Object struct {
 				Customer        string `json:"id"`
+				Email           string `json:"email"`
 				InvoiceSettings struct {
 					DefaultPaymentMethod *string `json:"default_payment_method"`
 				} `json:"invoice_settings"`
@@ -432,12 +433,19 @@ func handleCustomerUpdated(ctx context.Context, tx *gorm.DB, raw []byte) error {
 	hasPM := e.Data.Object.InvoiceSettings.DefaultPaymentMethod != nil &&
 		*e.Data.Object.InvoiceSettings.DefaultPaymentMethod != ""
 
+	// email is written only when the event carries one. Stripe omits the
+	// field on some replays, and an absent field must not blank an address
+	// we already hold — COALESCE on the parameter, not on the column, so an
+	// empty string is treated as "no value in this event".
+	email := strings.TrimSpace(e.Data.Object.Email)
+
 	res := tx.WithContext(ctx).Exec(`
 		UPDATE store_subscriptions
 		SET has_default_payment_method = ?,
+		    email                      = COALESCE(NULLIF(?, ''), email),
 		    updated_at                 = now()
 		WHERE stripe_customer_id = ?`,
-		hasPM, customer,
+		hasPM, email, customer,
 	)
 	if res.Error != nil {
 		return fmt.Errorf("dispatch: customer.updated has_default_payment_method: %w", res.Error)

--- a/services/marketplace-api/internal/billing/dispatch/handlers.go
+++ b/services/marketplace-api/internal/billing/dispatch/handlers.go
@@ -375,10 +375,50 @@ func (d *Dispatcher) countSkip(reason string) {
 // machine. Valid From states per §17.2: active, payment_action_required.
 // Idempotent replays where the status has already advanced are silently
 // dropped via ErrCASConflict.
+//
+// It also persists hosted_invoice_url from the payload, mirroring
+// handleInvoicePaymentActionRequired. This handler is the one that produces
+// past_due — i.e. the entire dunning cohort — and the dunning ladder's day-5
+// and day-7 emails render a "pay this invoice" button only when
+// hosted_invoice_url is set. Without this write the ordinary "card declined,
+// no SCA challenge" merchant reaches the two emails immediately preceding
+// suspension with no payment link at all.
+//
+// The write is unconditional and happens BEFORE the status transition, so a
+// replay (or an event arriving when the status has already advanced) still
+// refreshes the URL. An empty/absent field is left alone rather than blanking
+// a good URL; clearing on success stays where it belongs, in handleInvoicePaid.
 func (d *Dispatcher) handleInvoicePaymentFailed(ctx context.Context, tx *gorm.DB, raw []byte) error {
-	customer, err := extractCustomerID(raw)
-	if err != nil {
-		return err
+	var e struct {
+		Data struct {
+			Object struct {
+				Customer         string `json:"customer"`
+				HostedInvoiceURL string `json:"hosted_invoice_url"`
+			} `json:"object"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &e); err != nil {
+		return fmt.Errorf("dispatch: unmarshal invoice.payment_failed: %w", err)
+	}
+	customer := e.Data.Object.Customer
+	if customer == "" {
+		return errors.New("dispatch: invoice.payment_failed missing customer")
+	}
+
+	// Persist hosted_invoice_url unconditionally so the merchant can always
+	// reach the Stripe-hosted payment page the dunning emails link to, even
+	// on event replay.
+	if e.Data.Object.HostedInvoiceURL != "" {
+		res := tx.WithContext(ctx).Exec(`
+			UPDATE store_subscriptions
+			SET hosted_invoice_url = ?,
+			    updated_at         = now()
+			WHERE stripe_customer_id = ?`,
+			e.Data.Object.HostedInvoiceURL, customer,
+		)
+		if res.Error != nil {
+			return fmt.Errorf("dispatch: persist hosted_invoice_url: %w", res.Error)
+		}
 	}
 
 	var sub subscription.StoreSubscription
@@ -391,7 +431,7 @@ func (d *Dispatcher) handleInvoicePaymentFailed(ctx context.Context, tx *gorm.DB
 		return nil
 	}
 
-	err = statemachine.Transition(ctx, statemachine.TransitionInput{
+	err := statemachine.Transition(ctx, statemachine.TransitionInput{
 		DB:       tx,
 		Emitter:  d.emitter,
 		TenantID: sub.TenantID,

--- a/services/marketplace-api/internal/billing/dispatch/handlers.go
+++ b/services/marketplace-api/internal/billing/dispatch/handlers.go
@@ -287,7 +287,7 @@ func (d *Dispatcher) handleInvoicePaid(ctx context.Context, tx *gorm.DB, raw []b
 		if sendErr := d.emailCl.Send(ctx, email.TemplateTrialStartedBilled, to, map[string]any{
 			"store_id":   sub.StoreID.String(),
 			"tenant_id":  sub.TenantID.String(),
-			"store_name": "your store",
+			"store_name": subscription.StoreNameFor(ctx, tx, sub.StoreID),
 			"plan":       string(sub.Plan),
 			"period":     string(sub.SubscriptionPeriod),
 		}); sendErr != nil {

--- a/services/marketplace-api/internal/billing/dispatch/handlers.go
+++ b/services/marketplace-api/internal/billing/dispatch/handlers.go
@@ -249,6 +249,9 @@ func (d *Dispatcher) handleSubscriptionDeleted(ctx context.Context, tx *gorm.DB,
 // Multi-pod safety: the dispatcher holds pg_advisory_xact_lock on the store
 // for the duration of webhook processing (see dispatcher.go), so two pods
 // cannot race to detect "first charge" — only one will see first_charge_at=nil.
+// The confirmation email's own at-most-once guarantee comes from a
+// billing_email_sends claim on a non-transactional handle, NOT from
+// first_charge_at — see sendTrialBilled.
 func (d *Dispatcher) handleInvoicePaid(ctx context.Context, tx *gorm.DB, raw []byte) error {
 	customer, err := extractCustomerID(raw)
 	if err != nil {
@@ -280,28 +283,92 @@ func (d *Dispatcher) handleInvoicePaid(ctx context.Context, tx *gorm.DB, raw []b
 	}
 
 	if wasFirstCharge && d.emailCl != nil {
-		to := ""
-		if sub.Email != nil {
-			to = *sub.Email
-		}
-		if sendErr := d.emailCl.Send(ctx, email.TemplateTrialStartedBilled, to, map[string]any{
-			"store_id":   sub.StoreID.String(),
-			"tenant_id":  sub.TenantID.String(),
-			"store_name": subscription.StoreNameFor(ctx, tx, sub.StoreID),
-			"plan":       string(sub.Plan),
-			"period":     string(sub.SubscriptionPeriod),
-		}); sendErr != nil {
-			// Don't fail the webhook — Stripe would retry, double-firing every
-			// other side effect. Email failure is a soft error: log and move on.
-			// Idempotency is preserved by first_charge_at being non-nil after
-			// this UPDATE, so a retried invoice.paid event won't re-emit.
-			slog.Default().Warn("dispatch: trial-billed email not sent",
-				"store_id", sub.StoreID.String(),
-				"reason", email.SkipReason(sendErr),
-				"err", sendErr.Error())
-		}
+		d.sendTrialBilled(ctx, tx, sub)
 	}
 	return nil
+}
+
+// trialBilledPeriodKey is the period_key for the trial-billed confirmation.
+//
+// It is a constant rather than the Stripe event id because the guarantee we
+// want is "at most one trial-billed confirmation per subscription, ever" —
+// which is exactly what the claim's primary key
+// (subscription_id, template_key, period_key) gives with a fixed period.
+// The event id would only deduplicate redeliveries of the *same* Stripe
+// event; a distinct invoice.paid event arriving after a rolled-back
+// transaction (first_charge_at back to NULL) would carry a different id and
+// send a second confirmation. This email fires once in a subscription's
+// life, so the period is its whole life.
+const trialBilledPeriodKey = "first_charge"
+
+// sendTrialBilled emits the trial-started-billed confirmation.
+//
+// Idempotency guarantee, and why it is NOT first_charge_at: the send happens
+// inside the locked webhook transaction, and invoice.paid is dispatched as a
+// chain (see dispatcher.go) whose later handler can fail — or the commit
+// itself can fail — rolling first_charge_at back to NULL. The email is
+// already gone at that point, and Stripe's retry would see wasFirstCharge
+// again. So the claim is written on d.db, a NON-transactional handle: it
+// survives the rollback and the retry loses the claim.
+//
+// Without d.db there is no way to make this at-most-once, so the send is
+// skipped rather than risked.
+func (d *Dispatcher) sendTrialBilled(ctx context.Context, tx *gorm.DB, sub subscription.StoreSubscription) {
+	log := slog.Default()
+
+	if d.db == nil {
+		log.Warn("dispatch: trial-billed email skipped — no claim store wired (WithDB)",
+			"store_id", sub.StoreID.String())
+		d.countSkip("no_claim_store")
+		return
+	}
+
+	won, claimErr := subscription.ClaimEmailSend(ctx, d.db, sub.ID,
+		string(email.TemplateTrialStartedBilled), trialBilledPeriodKey, time.Now().UTC())
+	if claimErr != nil {
+		log.Error("dispatch: trial-billed claim failed; not sending",
+			"store_id", sub.StoreID.String(), "err", claimErr.Error())
+		d.countSkip("claim_failed")
+		return
+	}
+	if !won {
+		// Already sent for this subscription — a retry after a rolled-back
+		// transaction, or a second pod. Nothing to do.
+		return
+	}
+
+	to := ""
+	if sub.Email != nil {
+		to = *sub.Email
+	}
+	if sendErr := d.emailCl.Send(ctx, email.TemplateTrialStartedBilled, to, map[string]any{
+		"store_id":   sub.StoreID.String(),
+		"tenant_id":  sub.TenantID.String(),
+		"store_name": subscription.StoreNameFor(ctx, tx, sub.StoreID),
+		"plan":       string(sub.Plan),
+		"period":     string(sub.SubscriptionPeriod),
+	}); sendErr != nil {
+		// Don't fail the webhook — Stripe would retry, double-firing every
+		// other side effect. Email failure is a soft error: log and move on.
+		// The claim is deliberately NOT released: at-most-once beats a
+		// duplicate, matching the other four billing mail paths.
+		log.Warn("dispatch: trial-billed email not sent",
+			"store_id", sub.StoreID.String(),
+			"reason", email.SkipReason(sendErr),
+			"err", sendErr.Error())
+		d.countSkip(email.SkipReason(sendErr))
+		return
+	}
+	if d.sent != nil {
+		d.sent.WithTemplate(string(email.TemplateTrialStartedBilled)).Inc()
+	}
+}
+
+// countSkip increments the skipped-emails counter when one is wired.
+func (d *Dispatcher) countSkip(reason string) {
+	if d.skip != nil {
+		d.skip.WithTemplateReason(string(email.TemplateTrialStartedBilled), reason).Inc()
+	}
 }
 
 // handleInvoicePaymentFailed routes invoice.payment_failed through the state

--- a/services/marketplace-api/internal/billing/dispatch/handlers.go
+++ b/services/marketplace-api/internal/billing/dispatch/handlers.go
@@ -245,6 +245,9 @@ func (d *Dispatcher) handleSubscriptionDeleted(ctx context.Context, tx *gorm.DB,
 // update, this invoice is the first successful charge — meaning the trial
 // has just transitioned to a paid plan. We emit a TemplateTrialStartedBilled
 // confirmation email so the merchant knows their selected plan is now active.
+// The confirmation is suppressed when plan is still 'trial' — see
+// sendTrialBilled — because the template would then name "trial" as the plan
+// the merchant is being billed for.
 //
 // Multi-pod safety: the dispatcher holds pg_advisory_xact_lock on the store
 // for the duration of webhook processing (see dispatcher.go), so two pods
@@ -315,6 +318,28 @@ const trialBilledPeriodKey = "first_charge"
 // skipped rather than risked.
 func (d *Dispatcher) sendTrialBilled(ctx context.Context, tx *gorm.DB, sub subscription.StoreSubscription) {
 	log := slog.Default()
+
+	// The template says "your <plan> plan is active ... billed monthly". A
+	// subscription is bootstrapped on plan='trial' and only advanced by
+	// CommitUpgrade / CommitDowngrade / planchange's initial_selection, so a
+	// merchant who reached first charge through the legacy CreateCheckoutSession
+	// route (which never persists the plan) would be told their "trial plan" is
+	// now being billed. That is a false billing statement, so skip the send.
+	//
+	// Ordering: the guard sits BEFORE the claim on purpose. The claim's job is
+	// to stop a SECOND send after the webhook transaction rolls back
+	// (first_charge_at returns to NULL and Stripe retries) — see the doc comment
+	// above. A skip sends nothing, so there is no send to deduplicate, and
+	// burning the one-per-subscription slot here would permanently suppress a
+	// correct confirmation if the plan is resolved before the retry lands.
+	if sub.Plan == subscription.PlanTrial {
+		log.Warn("dispatch: trial-billed email skipped — plan still 'trial' at first charge; no plan was ever recorded for this subscription",
+			"store_id", sub.StoreID.String(),
+			"tenant_id", sub.TenantID.String(),
+			"reason", "plan_unresolved")
+		d.countSkip("plan_unresolved")
+		return
+	}
 
 	if d.db == nil {
 		log.Warn("dispatch: trial-billed email skipped — no claim store wired (WithDB)",

--- a/services/marketplace-api/internal/billing/dispatch/handlers.go
+++ b/services/marketplace-api/internal/billing/dispatch/handlers.go
@@ -433,11 +433,21 @@ func (d *Dispatcher) handleInvoicePaymentFailed(ctx context.Context, tx *gorm.DB
 	// Persist hosted_invoice_url unconditionally so the merchant can always
 	// reach the Stripe-hosted payment page the dunning emails link to, even
 	// on event replay.
+	//
+	// Deliberately NOT stamping updated_at here: it is not a business-state
+	// change, it is bookkeeping. store_subscriptions.updated_at is both the
+	// win-back cron's 30-to-31-day eligibility window AND its idempotency
+	// key, and it also feeds the expired->store_closed timer and the 150-day
+	// hard-delete cutoff (see cmd/backfill-email for the original fix of
+	// this exact bug). Stripe keeps retrying failed invoices for weeks after
+	// a subscription is already expired, so this handler runs against
+	// already-terminal rows far more often than the SCA path below — bumping
+	// updated_at here would silently move or drop those merchants from the
+	// win-back window and push back their retention timers.
 	if e.Data.Object.HostedInvoiceURL != "" {
 		res := tx.WithContext(ctx).Exec(`
 			UPDATE store_subscriptions
-			SET hosted_invoice_url = ?,
-			    updated_at         = now()
+			SET hosted_invoice_url = ?
 			WHERE stripe_customer_id = ?`,
 			e.Data.Object.HostedInvoiceURL, customer,
 		)
@@ -498,11 +508,16 @@ func (d *Dispatcher) handleInvoicePaymentActionRequired(ctx context.Context, tx 
 
 	// Persist hosted_invoice_url unconditionally so the merchant can always
 	// reach the Stripe-hosted payment page, even on event replay.
+	//
+	// Deliberately NOT stamping updated_at here either — same reasoning as
+	// handleInvoicePaymentFailed above: this UPDATE only touches the
+	// bookkeeping hosted_invoice_url column, not status, so it must not move
+	// the win-back cron's eligibility/idempotency window or the lifecycle
+	// crons' retention timers.
 	if e.Data.Object.HostedInvoiceURL != "" {
 		res := tx.WithContext(ctx).Exec(`
 			UPDATE store_subscriptions
-			SET hosted_invoice_url = ?,
-			    updated_at         = now()
+			SET hosted_invoice_url = ?
 			WHERE stripe_customer_id = ?`,
 			e.Data.Object.HostedInvoiceURL, customer,
 		)

--- a/services/marketplace-api/internal/billing/dispatch/handlers_customer_updated_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/handlers_customer_updated_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+
+package dispatch_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/dispatch"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedStore inserts a minimal, valid row into the `stores` table so that a
+// store_subscriptions row referencing it (store_id FK) can be created.
+// store_subscriptions_store_id_fkey is a real, enforced constraint
+// (migrations/000015_subscriptions.up.sql), so any test that creates a
+// StoreSubscription must satisfy it. The row is deleted individually (not
+// TRUNCATEd) on cleanup, since store_subscriptions is a child of stores and
+// TRUNCATE ... CASCADE on stores would cascade into unrelated tables on this
+// shared database.
+func seedStore(t *testing.T, db *gorm.DB, storeID uuid.UUID) {
+	t.Helper()
+	secret := strings.Repeat("a", 64)
+	err := db.Exec(`
+		INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
+		VALUES (?, ?, ?, ?, 'US', 'USD', 'UTC', 'active', ?)`,
+		storeID, uuid.New(), "store-"+storeID.String(), "Test Store "+storeID.String(), secret,
+	).Error
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		db.Exec(`DELETE FROM stores WHERE id = ?`, storeID)
+	})
+}
+
+func TestHandleCustomerUpdated_MirrorsEmail(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions")
+	ctx := context.Background()
+
+	storeID := uuid.New()
+	seedStore(t, db, storeID)
+
+	customerID := "cus_" + uuid.NewString()[:12]
+	sub := &subscription.StoreSubscription{
+		TenantID:         uuid.New(),
+		StoreID:          storeID,
+		StripeCustomerID: customerID,
+	}
+	require.NoError(t, db.Create(sub).Error)
+
+	raw := []byte(`{"data":{"object":{"id":"` + customerID + `","email":"merchant@example.com","invoice_settings":{"default_payment_method":"pm_123"}}}}`)
+
+	if err := dispatch.HandleCustomerUpdatedForTest(ctx, db, raw); err != nil {
+		t.Fatalf("handleCustomerUpdated: %v", err)
+	}
+
+	var got subscription.StoreSubscription
+	if err := db.Where("stripe_customer_id = ?", customerID).First(&got).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.Email == nil || *got.Email != "merchant@example.com" {
+		t.Errorf("Email = %v, want merchant@example.com", got.Email)
+	}
+	if !got.HasDefaultPaymentMethod {
+		t.Error("HasDefaultPaymentMethod regressed to false")
+	}
+}
+
+// An event without an email must not blank an address we already have.
+func TestHandleCustomerUpdated_AbsentEmailPreservesExisting(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions")
+	ctx := context.Background()
+
+	storeID := uuid.New()
+	seedStore(t, db, storeID)
+
+	existing := "keep@example.com"
+	customerID := "cus_" + uuid.NewString()[:12]
+	sub := &subscription.StoreSubscription{
+		TenantID:         uuid.New(),
+		StoreID:          storeID,
+		StripeCustomerID: customerID,
+		Email:            &existing,
+	}
+	if err := db.Create(sub).Error; err != nil {
+		t.Fatalf("seed subscription: %v", err)
+	}
+
+	raw := []byte(`{"data":{"object":{"id":"` + customerID + `","invoice_settings":{"default_payment_method":null}}}}`)
+
+	if err := dispatch.HandleCustomerUpdatedForTest(ctx, db, raw); err != nil {
+		t.Fatalf("handleCustomerUpdated: %v", err)
+	}
+
+	var got subscription.StoreSubscription
+	if err := db.Where("stripe_customer_id = ?", customerID).First(&got).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.Email == nil || *got.Email != existing {
+		t.Errorf("Email = %v, want it preserved as %q", got.Email, existing)
+	}
+}

--- a/services/marketplace-api/internal/billing/dispatch/trial_billed_claim_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/trial_billed_claim_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+
+package dispatch_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/dispatch"
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/internal/webhookevents"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedFirstChargeSub inserts a store + a subscription with first_charge_at
+// NULL, returning the db handle, the row and its Stripe customer id.
+func seedFirstChargeSub(t *testing.T) (*gorm.DB, subscription.StoreSubscription, string) {
+	t.Helper()
+	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events", "billing_email_sends")
+
+	storeID := uuid.New()
+	seedStore(t, db, storeID)
+	addr := "merchant@example.com"
+	customerID := "cus_" + uuid.NewString()[:12]
+	sub := subscription.StoreSubscription{
+		TenantID:         uuid.New(),
+		StoreID:          storeID,
+		StripeCustomerID: customerID,
+		Plan:             subscription.PlanStarter,
+		Status:           subscription.StatusActive,
+		Email:            &addr,
+	}
+	require.NoError(t, db.Create(&sub).Error)
+	return db, sub, customerID
+}
+
+func dispatchInvoicePaid(t *testing.T, d *dispatch.Dispatcher, db *gorm.DB, customerID string) error {
+	t.Helper()
+	eventID := "evt_" + uuid.NewString()[:12]
+	payload := []byte(`{"id":"` + eventID + `","type":"invoice.paid","data":{"object":{"customer":"` + customerID + `"}}}`)
+	return d.Dispatch(context.Background(), db, webhookevents.StripeWebhookEvent{
+		EventID: eventID, EventType: "invoice.paid", Payload: payload,
+	})
+}
+
+// The confirmation is sent inside the locked webhook transaction, and
+// invoice.paid runs a handler chain — a later handler error, or a failed
+// commit, rolls first_charge_at back to NULL while the email has already
+// left. Stripe then retries and sees a "first charge" again. The claim is
+// written on a non-transactional handle precisely so it survives that
+// rollback; this test reproduces the rollback by resetting first_charge_at.
+func TestInvoicePaid_TrialBilled_NotResentAfterRollback(t *testing.T) {
+	db, sub, customerID := seedFirstChargeSub(t)
+
+	client := &captureEmailClient{}
+	d := dispatch.New(nil).WithEmail(client).WithDB(db)
+
+	require.NoError(t, dispatchInvoicePaid(t, d, db, customerID))
+	require.Len(t, client.recipients, 1, "first charge must send one confirmation")
+
+	// Simulate the transaction rolling back after the email went out.
+	require.NoError(t, db.Exec(
+		`UPDATE store_subscriptions SET first_charge_at = NULL WHERE id = ?`, sub.ID).Error)
+
+	// Stripe retries (or redelivers as a fresh event).
+	require.NoError(t, dispatchInvoicePaid(t, d, db, customerID))
+
+	require.Len(t, client.recipients, 1,
+		"a second trial-billed confirmation was sent after a rollback")
+}
+
+// The claim is the guarantee, so it must exist after a successful send —
+// keyed by the constant first_charge period, i.e. once per subscription.
+func TestInvoicePaid_TrialBilled_ClaimsRow(t *testing.T) {
+	db, sub, customerID := seedFirstChargeSub(t)
+
+	d := dispatch.New(nil).WithEmail(&captureEmailClient{}).WithDB(db)
+	require.NoError(t, dispatchInvoicePaid(t, d, db, customerID))
+
+	var n int64
+	require.NoError(t, db.Raw(
+		`SELECT count(*) FROM billing_email_sends
+		 WHERE subscription_id = ? AND template_key = ? AND period_key = 'first_charge'`,
+		sub.ID, string(email.TemplateTrialStartedBilled)).Scan(&n).Error)
+	require.EqualValues(t, 1, n, "no claim row written — at-most-once is unenforced")
+}
+
+// Without a claim store there is no way to make the send at-most-once, so it
+// is skipped rather than risked. The webhook's own side effects still run.
+func TestInvoicePaid_TrialBilled_NoClaimStoreSkipsSend(t *testing.T) {
+	db, sub, customerID := seedFirstChargeSub(t)
+
+	client := &captureEmailClient{}
+	d := dispatch.New(nil).WithEmail(client) // no WithDB
+	require.NoError(t, dispatchInvoicePaid(t, d, db, customerID))
+
+	require.Empty(t, client.recipients, "sent without a claim store — cannot be at-most-once")
+
+	var reloaded subscription.StoreSubscription
+	require.NoError(t, db.Where("id = ?", sub.ID).First(&reloaded).Error)
+	require.NotNil(t, reloaded.FirstChargeAt, "webhook side effects must still run")
+}

--- a/services/marketplace-api/internal/billing/dispatch/trial_billed_claim_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/trial_billed_claim_test.go
@@ -105,3 +105,67 @@ func TestInvoicePaid_TrialBilled_NoClaimStoreSkipsSend(t *testing.T) {
 	require.NoError(t, db.Where("id = ?", sub.ID).First(&reloaded).Error)
 	require.NotNil(t, reloaded.FirstChargeAt, "webhook side effects must still run")
 }
+
+// seedFirstChargeSubWithPlan is seedFirstChargeSub with an explicit plan, so
+// the two tests below differ only in the plan column.
+func seedFirstChargeSubWithPlan(t *testing.T, plan subscription.SubscriptionPlan) (*gorm.DB, subscription.StoreSubscription, string) {
+	t.Helper()
+	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events", "billing_email_sends")
+
+	storeID := uuid.New()
+	seedStore(t, db, storeID)
+	addr := "merchant@example.com"
+	customerID := "cus_" + uuid.NewString()[:12]
+	sub := subscription.StoreSubscription{
+		TenantID:         uuid.New(),
+		StoreID:          storeID,
+		StripeCustomerID: customerID,
+		Plan:             plan,
+		Status:           subscription.StatusActive,
+		Email:            &addr,
+	}
+	require.NoError(t, db.Create(&sub).Error)
+	return db, sub, customerID
+}
+
+// The trial-billed template names the plan the merchant is now being billed
+// for. plan='trial' at first charge means no plan was ever recorded (e.g. the
+// legacy CreateCheckoutSession route, which never persists it), so the email
+// would tell the merchant their "trial plan" is active and billed monthly.
+// Skip the send instead.
+func TestInvoicePaid_TrialBilled_SkippedWhenPlanStillTrial(t *testing.T) {
+	db, sub, customerID := seedFirstChargeSubWithPlan(t, subscription.PlanTrial)
+
+	client := &captureEmailClient{}
+	d := dispatch.New(nil).WithEmail(client).WithDB(db)
+	require.NoError(t, dispatchInvoicePaid(t, d, db, customerID))
+
+	require.Empty(t, client.recipients, "confirmed a 'trial plan' the merchant was never billed for")
+
+	// The claim must NOT be burned: the skip sends nothing, so there is no
+	// double-send to guard against, and a claim would suppress a correct
+	// confirmation if the plan is resolved before a retry lands.
+	var n int64
+	require.NoError(t, db.Raw(
+		`SELECT count(*) FROM billing_email_sends
+		 WHERE subscription_id = ? AND template_key = ?`,
+		sub.ID, string(email.TemplateTrialStartedBilled)).Scan(&n).Error)
+	require.EqualValues(t, 0, n, "the at-most-once slot was burned on a send that never happened")
+
+	// The webhook's own side effects still run.
+	var reloaded subscription.StoreSubscription
+	require.NoError(t, db.Where("id = ?", sub.ID).First(&reloaded).Error)
+	require.NotNil(t, reloaded.FirstChargeAt, "webhook side effects must still run")
+}
+
+// The counterpart: with a real plan the confirmation must still be sent.
+// Without this the guard could silently disable the template entirely.
+func TestInvoicePaid_TrialBilled_StillSendsWithRealPlan(t *testing.T) {
+	db, _, customerID := seedFirstChargeSubWithPlan(t, subscription.PlanStarter)
+
+	client := &captureEmailClient{}
+	d := dispatch.New(nil).WithEmail(client).WithDB(db)
+	require.NoError(t, dispatchInvoicePaid(t, d, db, customerID))
+
+	require.Len(t, client.recipients, 1, "a merchant on a real plan must still get the confirmation")
+}

--- a/services/marketplace-api/internal/billing/stripe/customer.go
+++ b/services/marketplace-api/internal/billing/stripe/customer.go
@@ -136,6 +136,28 @@ func summariseSDKPaymentMethod(pm *sdk.PaymentMethod) (PaymentMethodSummary, boo
 	return PaymentMethodSummary{}, false
 }
 
+// GetCustomerEmail returns the billing address Stripe holds for a customer,
+// or "" when the customer has none. Used by cmd/backfill-email to populate
+// store_subscriptions.email for rows predating migration 104 (#381).
+//
+// An empty customerID is not an error — it means the subscription was never
+// bootstrapped against Stripe, which the caller skips.
+func GetCustomerEmail(ctx context.Context, c *Client, customerID string) (string, error) {
+	if customerID == "" {
+		return "", nil
+	}
+	params := &sdk.CustomerRetrieveParams{}
+	params.Context = ctx
+	cu, err := c.sdk.V1Customers.Retrieve(ctx, customerID, params)
+	if err != nil {
+		return "", toAPIError(err)
+	}
+	if cu == nil {
+		return "", nil
+	}
+	return cu.Email, nil
+}
+
 // Idempotent: if the customer is already deleted in Stripe (HTTP 404), the
 // error is treated as a no-op success so the caller can safely retry.
 func DeleteCustomer(ctx context.Context, c *Client, customerID string) error {

--- a/services/marketplace-api/internal/billing/stripe/customer_email_test.go
+++ b/services/marketplace-api/internal/billing/stripe/customer_email_test.go
@@ -1,0 +1,18 @@
+package stripe_test
+
+import (
+	"context"
+	"testing"
+
+	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
+)
+
+func TestGetCustomerEmail_EmptyCustomerID(t *testing.T) {
+	got, err := billingstripe.GetCustomerEmail(context.Background(), nil, "")
+	if err != nil {
+		t.Fatalf("err = %v, want nil for an empty customer id", err)
+	}
+	if got != "" {
+		t.Errorf("email = %q, want empty", got)
+	}
+}

--- a/services/marketplace-api/internal/billing/stripe/customer_email_test.go
+++ b/services/marketplace-api/internal/billing/stripe/customer_email_test.go
@@ -2,7 +2,11 @@ package stripe_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
 )
@@ -15,4 +19,34 @@ func TestGetCustomerEmail_EmptyCustomerID(t *testing.T) {
 	if got != "" {
 		t.Errorf("email = %q, want empty", got)
 	}
+}
+
+func TestGetCustomerEmail_ReturnsEmailFromStripe(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Request-Id", "req_test")
+		_, _ = w.Write([]byte(`{"id":"cus_x","email":"merchant@example.com"}`))
+	}))
+	defer srv.Close()
+
+	c := billingstripe.New("sk_test_x")
+	c.SetBaseURLForTesting(srv.URL)
+
+	got, err := billingstripe.GetCustomerEmail(context.Background(), c, "cus_x")
+	require.NoError(t, err)
+	require.Equal(t, "merchant@example.com", got)
+}
+
+func TestGetCustomerEmail_NoEmailOnCustomer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Request-Id", "req_test")
+		_, _ = w.Write([]byte(`{"id":"cus_x"}`))
+	}))
+	defer srv.Close()
+
+	c := billingstripe.New("sk_test_x")
+	c.SetBaseURLForTesting(srv.URL)
+
+	got, err := billingstripe.GetCustomerEmail(context.Background(), c, "cus_x")
+	require.NoError(t, err)
+	require.Equal(t, "", got)
 }

--- a/services/marketplace-api/internal/email/client.go
+++ b/services/marketplace-api/internal/email/client.go
@@ -27,6 +27,12 @@ const (
 	// Sent from invoice.paid webhook on the first successful charge —
 	// confirms the chosen plan is now active.
 	TemplateTrialStartedBilled TemplateID = "trial_started_billed"
+
+	// Day-30 post-expiry win-back promo. Lived in the lifecycle package
+	// until #381; moved here so the billing catalog is complete in one
+	// place and the email package can register its fallback without
+	// importing lifecycle (which imports email).
+	TemplateWinBack TemplateID = "win_back_day30"
 )
 
 // Client is the narrow interface every caller uses.

--- a/services/marketplace-api/internal/email/recipient.go
+++ b/services/marketplace-api/internal/email/recipient.go
@@ -1,0 +1,87 @@
+package email
+
+// recipient.go — the guard that keeps billing mail out of the bit bucket
+// and keeps the delivery counters honest.
+//
+// subscription/service.go mints billing+<store_id>@mark8ly.local whenever a
+// subscription is bootstrapped without a real email. `.local` is unroutable,
+// so sending there hard-bounces and costs sender reputation. Rather than
+// discover that at the provider, we classify the address up front and return
+// a typed error — never nil — so a caller can count the skip instead of
+// recording a delivery that never happened.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrUndeliverable marks a recipient we refuse to attempt delivery to.
+// Wrapped, so callers can errors.Is regardless of reason.
+var ErrUndeliverable = errors.New("undeliverable recipient")
+
+// Reasons an address is refused. These become the `reason` label on
+// mark8ly_subscription_billing_emails_skipped_total, so keep them stable.
+const (
+	ReasonNoAddress          = "no_address"
+	ReasonInvalidAddress     = "invalid_address"
+	ReasonPlaceholderAddress = "placeholder_address"
+)
+
+// placeholderSuffixes are domains that can never receive mail: the RFC 2606
+// reserved TLDs plus bare `localhost`. `.local` catches the
+// billing+<uuid>@mark8ly.local addresses minted at bootstrap.
+var placeholderSuffixes = []string{
+	".local",
+	".invalid",
+	".test",
+	".example",
+	"localhost",
+}
+
+// UndeliverableError carries why an address was refused.
+type UndeliverableError struct{ Reason string }
+
+func (e *UndeliverableError) Error() string {
+	return fmt.Sprintf("email: %s: %s", ErrUndeliverable.Error(), e.Reason)
+}
+
+// Unwrap lets errors.Is(err, ErrUndeliverable) succeed.
+func (e *UndeliverableError) Unwrap() error { return ErrUndeliverable }
+
+// ValidateRecipient reports whether `to` is worth handing to a provider.
+// Deliberately conservative: this is a bounce guard, not an RFC 5321 parser.
+func ValidateRecipient(to string) error {
+	addr := strings.TrimSpace(to)
+	if addr == "" {
+		return &UndeliverableError{Reason: ReasonNoAddress}
+	}
+
+	local, domain, found := strings.Cut(addr, "@")
+	if !found || local == "" || domain == "" || strings.Contains(domain, "@") {
+		return &UndeliverableError{Reason: ReasonInvalidAddress}
+	}
+
+	lower := strings.ToLower(domain)
+	for _, suffix := range placeholderSuffixes {
+		if lower == suffix || strings.HasSuffix(lower, suffix) {
+			return &UndeliverableError{Reason: ReasonPlaceholderAddress}
+		}
+	}
+	if !strings.Contains(lower, ".") {
+		// No dot at all — not a routable public domain.
+		return &UndeliverableError{Reason: ReasonPlaceholderAddress}
+	}
+	return nil
+}
+
+// UndeliverableReason extracts the reason from an error produced by
+// ValidateRecipient, reporting false for anything else (e.g. a transport
+// failure, which must be counted differently).
+func UndeliverableReason(err error) (string, bool) {
+	var ue *UndeliverableError
+	if errors.As(err, &ue) {
+		return ue.Reason, true
+	}
+	return "", false
+}

--- a/services/marketplace-api/internal/email/recipient_test.go
+++ b/services/marketplace-api/internal/email/recipient_test.go
@@ -1,0 +1,63 @@
+package email_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+)
+
+func TestValidateRecipient(t *testing.T) {
+	cases := []struct {
+		name       string
+		to         string
+		wantReason string // "" means deliverable
+	}{
+		{"plain address", "merchant@example.com", ""},
+		{"address with display parts trimmed", "  merchant@example.com  ", ""},
+		{"subaddressed", "billing+store@example.com", ""},
+		{"empty", "", email.ReasonNoAddress},
+		{"whitespace only", "   ", email.ReasonNoAddress},
+		{"no at sign", "merchant.example.com", email.ReasonInvalidAddress},
+		{"two at signs", "a@b@example.com", email.ReasonInvalidAddress},
+		{"empty local part", "@example.com", email.ReasonInvalidAddress},
+		{"empty domain", "merchant@", email.ReasonInvalidAddress},
+		{"domain without dot", "merchant@localhost", email.ReasonPlaceholderAddress},
+		{"bootstrap placeholder", "billing+7f3a@mark8ly.local", email.ReasonPlaceholderAddress},
+		{"uppercase placeholder", "ops@MARK8LY.LOCAL", email.ReasonPlaceholderAddress},
+		{"rfc2606 invalid", "ops@something.invalid", email.ReasonPlaceholderAddress},
+		{"rfc2606 test", "ops@something.test", email.ReasonPlaceholderAddress},
+		{"rfc2606 example", "ops@something.example", email.ReasonPlaceholderAddress},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := email.ValidateRecipient(tc.to)
+			if tc.wantReason == "" {
+				if err != nil {
+					t.Fatalf("ValidateRecipient(%q) = %v, want nil", tc.to, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateRecipient(%q) = nil, want %s", tc.to, tc.wantReason)
+			}
+			if !errors.Is(err, email.ErrUndeliverable) {
+				t.Errorf("errors.Is(err, ErrUndeliverable) = false for %q", tc.to)
+			}
+			reason, ok := email.UndeliverableReason(err)
+			if !ok {
+				t.Fatalf("UndeliverableReason(%v) not recognised", err)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestUndeliverableReason_UnrelatedError(t *testing.T) {
+	if _, ok := email.UndeliverableReason(errors.New("boom")); ok {
+		t.Error("unrelated error reported as undeliverable")
+	}
+}

--- a/services/marketplace-api/internal/email/seed_ordering_integration_test.go
+++ b/services/marketplace-api/internal/email/seed_ordering_integration_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+package email_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// Spec §4: "No seed migration ... A key with no row simply renders from its
+// embedded default." Registering the billing fallbacks AFTER SeedFromEmbedded
+// is what makes that true — main.go's ordering is guarded separately in
+// cmd/marketplace-api/wiring_test.go; this asserts the resulting behaviour.
+func TestRegisterFallbacksAfterSeed_LeavesNoPublishedRows(t *testing.T) {
+	tx := testdb.NewTx(t)
+	ctx := context.Background()
+
+	loader := emailtemplates.NewLoader(tx)
+	require.NoError(t, loader.SeedFromEmbedded(ctx))
+	email.RegisterFallbacks(loader)
+
+	keys := email.BillingTemplateKeys()
+	strs := make([]string, len(keys))
+	for i, k := range keys {
+		strs[i] = string(k)
+	}
+
+	var n int64
+	require.NoError(t, tx.Raw(
+		`SELECT count(*) FROM email_templates WHERE key IN ?`, strs).Scan(&n).Error)
+	require.EqualValues(t, 0, n,
+		"billing templates were seeded as DB rows — an edit to templates_content.go "+
+			"would then never reach a merchant (ON CONFLICT DO NOTHING)")
+
+	// And the embedded default still renders, so nothing is lost.
+	rendered, err := loader.Render(ctx, string(email.TemplateDunningDay5), map[string]any{
+		"store_name": "Acme", "day": 5,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, rendered.Subject)
+}
+
+// The inverse, so the ordering's consequence is not merely asserted but
+// demonstrated: registering BEFORE the seed does write published rows.
+func TestRegisterFallbacksBeforeSeed_WouldSeedPublishedRows(t *testing.T) {
+	tx := testdb.NewTx(t)
+	ctx := context.Background()
+
+	loader := emailtemplates.NewLoader(tx)
+	email.RegisterFallbacks(loader)
+	require.NoError(t, loader.SeedFromEmbedded(ctx))
+
+	var n int64
+	require.NoError(t, tx.Raw(
+		`SELECT count(*) FROM email_templates WHERE key = ? AND status = 'published'`,
+		string(email.TemplateDunningDay5)).Scan(&n).Error)
+	require.EqualValues(t, 1, n, "expected the wrong ordering to seed a published row")
+}

--- a/services/marketplace-api/internal/email/template_client.go
+++ b/services/marketplace-api/internal/email/template_client.go
@@ -92,7 +92,7 @@ func (c *templateClient) Send(ctx context.Context, template TemplateID, to strin
 	if err != nil {
 		c.logger.Error("billing email: render failed",
 			"template", string(template), "err", err.Error())
-		return fmt.Errorf("email: render %s: %w: %v", template, ErrRender, err)
+		return fmt.Errorf("email: render %s: %w: %w", template, ErrRender, err)
 	}
 
 	msg := Message{
@@ -117,7 +117,7 @@ func (c *templateClient) Send(ctx context.Context, template TemplateID, to strin
 	if err := c.sender.Send(ctx, msg); err != nil {
 		c.logger.Error("billing email: transport failed",
 			"template", string(template), "err", err.Error())
-		return fmt.Errorf("email: send %s: %w: %v", template, ErrTransport, err)
+		return fmt.Errorf("email: send %s: %w: %w", template, ErrTransport, err)
 	}
 	return nil
 }

--- a/services/marketplace-api/internal/email/template_client.go
+++ b/services/marketplace-api/internal/email/template_client.go
@@ -11,10 +11,19 @@ package email
 // finished envelope to the shared SendGrid→Resend Sender chain.
 //
 // Contract, and the reason the delivery counters can be trusted: Send
-// returns nil if and only if a provider accepted the message. Every other
-// outcome returns a classified error. Callers map that to a
+// returns nil if and only if a real provider accepted the message. Every
+// other outcome — including the log-only dev transport, which delivers
+// nothing — returns a classified error. Callers map that to a
 // billing_emails_skipped_total{template,reason} increment; they must never
 // increment a *_sent_total counter for it.
+//
+// The log-only case is called out explicitly because it is the pre-#381
+// failure in a new costume: NewFromConfig falls back to LogSender when
+// neither SENDGRID_API_KEY nor RESEND_API_KEY is set, and LogSender.Send
+// returns nil. Reporting that as success would put dashboards back to
+// showing delivery while nothing is sent, one missing secret away. Local
+// dev still works — the send is logged exactly as before — the metric just
+// stops lying: the caller counts ErrNoProvider as a `no_provider` skip.
 
 import (
 	"context"
@@ -36,12 +45,16 @@ var (
 	ErrRender = errors.New("template render failed")
 	// ErrTransport means every configured provider refused the message.
 	ErrTransport = errors.New("transport failed")
+	// ErrNoProvider means no real provider is configured, so the message
+	// was only logged. Nothing was delivered.
+	ErrNoProvider = errors.New("no email provider configured")
 )
 
 // Additional reason labels, complementing those in recipient.go.
 const (
 	ReasonRenderFailed    = "render_failed"
 	ReasonTransportFailed = "transport_failed"
+	ReasonNoProvider      = "no_provider"
 	ReasonUnknown         = "unknown"
 )
 
@@ -55,6 +68,8 @@ func SkipReason(err error) string {
 		return ReasonRenderFailed
 	case errors.Is(err, ErrTransport):
 		return ReasonTransportFailed
+	case errors.Is(err, ErrNoProvider):
+		return ReasonNoProvider
 	default:
 		return ReasonUnknown
 	}
@@ -65,6 +80,23 @@ type templateClient struct {
 	sender Sender
 	from   string
 	logger *slog.Logger
+	// logOnly is true when sender delivers nothing (no provider key set).
+	// Send then reports ErrNoProvider instead of nil, so no caller can
+	// increment a *_sent_total for a message that never left the process.
+	logOnly bool
+}
+
+// isLogOnly reports whether s is the dev transport that logs instead of
+// delivering. Matched both by concrete type and by the Named contract, so
+// any future log-only adapter naming itself "log" is caught too.
+func isLogOnly(s Sender) bool {
+	if _, ok := s.(*LogSender); ok {
+		return true
+	}
+	if n, ok := s.(Named); ok && n.Name() == "log" {
+		return true
+	}
+	return false
 }
 
 // NewTemplateClient returns the production Client. loader and sender are
@@ -73,7 +105,13 @@ func NewTemplateClient(loader *emailtemplates.Loader, sender Sender, from string
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &templateClient{loader: loader, sender: sender, from: from, logger: logger}
+	return &templateClient{
+		loader:  loader,
+		sender:  sender,
+		from:    from,
+		logger:  logger,
+		logOnly: isLogOnly(sender),
+	}
 }
 
 // Send renders `template` with `data` and delivers it to `to`.
@@ -118,6 +156,14 @@ func (c *templateClient) Send(ctx context.Context, template TemplateID, to strin
 		c.logger.Error("billing email: transport failed",
 			"template", string(template), "err", err.Error())
 		return fmt.Errorf("email: send %s: %w: %w", template, ErrTransport, err)
+	}
+
+	// The message was logged, not delivered. Say so, rather than let the
+	// caller record a delivery.
+	if c.logOnly {
+		c.logger.Warn("billing email: logged only — no provider configured",
+			"template", string(template))
+		return fmt.Errorf("email: send %s: %w", template, ErrNoProvider)
 	}
 	return nil
 }

--- a/services/marketplace-api/internal/email/template_client.go
+++ b/services/marketplace-api/internal/email/template_client.go
@@ -1,0 +1,123 @@
+package email
+
+// template_client.go — the production implementation of Client.
+//
+// Before this landed, Client had exactly one implementation (NoOpClient),
+// so no merchant had ever received a dunning notice, trial reminder,
+// payment-action reminder, win-back promo or trial-billed confirmation
+// (#381). This adapter renders a template key through the shared
+// emailtemplates registry — the same one orderdoc and giftcard use, so
+// operators can reword billing copy without a deploy — and hands the
+// finished envelope to the shared SendGrid→Resend Sender chain.
+//
+// Contract, and the reason the delivery counters can be trusted: Send
+// returns nil if and only if a provider accepted the message. Every other
+// outcome returns a classified error. Callers map that to a
+// billing_emails_skipped_total{template,reason} increment; they must never
+// increment a *_sent_total counter for it.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+)
+
+// fromName is the display name on every billing email.
+const fromName = "Mark8ly Billing"
+
+// Sentinels so callers can classify a failure without string matching.
+var (
+	// ErrRender means the template could not be rendered — an unknown key,
+	// or a published DB override with broken syntax.
+	ErrRender = errors.New("template render failed")
+	// ErrTransport means every configured provider refused the message.
+	ErrTransport = errors.New("transport failed")
+)
+
+// Additional reason labels, complementing those in recipient.go.
+const (
+	ReasonRenderFailed    = "render_failed"
+	ReasonTransportFailed = "transport_failed"
+	ReasonUnknown         = "unknown"
+)
+
+// SkipReason maps a Send error onto a stable metric label.
+func SkipReason(err error) string {
+	if reason, ok := UndeliverableReason(err); ok {
+		return reason
+	}
+	switch {
+	case errors.Is(err, ErrRender):
+		return ReasonRenderFailed
+	case errors.Is(err, ErrTransport):
+		return ReasonTransportFailed
+	default:
+		return ReasonUnknown
+	}
+}
+
+type templateClient struct {
+	loader *emailtemplates.Loader
+	sender Sender
+	from   string
+	logger *slog.Logger
+}
+
+// NewTemplateClient returns the production Client. loader and sender are
+// required; a nil logger falls back to slog.Default().
+func NewTemplateClient(loader *emailtemplates.Loader, sender Sender, from string, logger *slog.Logger) Client {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &templateClient{loader: loader, sender: sender, from: from, logger: logger}
+}
+
+// Send renders `template` with `data` and delivers it to `to`.
+//
+// `to` is an email address. It used to be a store UUID at four call sites
+// and a Stripe customer ID at a fifth; callers now resolve the address from
+// store_subscriptions.email before calling.
+func (c *templateClient) Send(ctx context.Context, template TemplateID, to string, data map[string]any) error {
+	if err := ValidateRecipient(to); err != nil {
+		c.logger.Warn("billing email: undeliverable recipient; not sending",
+			"template", string(template), "reason", SkipReason(err))
+		return err
+	}
+
+	rendered, err := c.loader.Render(ctx, string(template), data)
+	if err != nil {
+		c.logger.Error("billing email: render failed",
+			"template", string(template), "err", err.Error())
+		return fmt.Errorf("email: render %s: %w: %v", template, ErrRender, err)
+	}
+
+	msg := Message{
+		From:     c.from,
+		FromName: fromName,
+		To:       strings.TrimSpace(to),
+		Subject:  rendered.Subject,
+		HTMLBody: rendered.HTMLBody,
+		TextBody: rendered.TextBody,
+		// Wave 1.5 attribution — the same shape the five working mailers
+		// emit, so the notification-service webhook receiver groups these
+		// without parsing subjects, and #348's send log picks them up free.
+		CustomArgs: map[string]string{
+			"product": "mark8ly",
+			"kind":    string(template),
+		},
+	}
+	if tenantID, ok := data["tenant_id"].(string); ok && tenantID != "" {
+		msg.CustomArgs["tenant_id"] = tenantID
+	}
+
+	if err := c.sender.Send(ctx, msg); err != nil {
+		c.logger.Error("billing email: transport failed",
+			"template", string(template), "err", err.Error())
+		return fmt.Errorf("email: send %s: %w: %v", template, ErrTransport, err)
+	}
+	return nil
+}

--- a/services/marketplace-api/internal/email/template_client_test.go
+++ b/services/marketplace-api/internal/email/template_client_test.go
@@ -1,0 +1,160 @@
+package email_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+)
+
+// captureSender records every Message handed to it.
+type captureSender struct {
+	mu   sync.Mutex
+	msgs []email.Message
+	err  error
+}
+
+func (s *captureSender) Send(_ context.Context, msg email.Message) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return s.err
+	}
+	s.msgs = append(s.msgs, msg)
+	return nil
+}
+
+func (s *captureSender) last(t *testing.T) email.Message {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.msgs) == 0 {
+		t.Fatal("no message sent")
+	}
+	return s.msgs[len(s.msgs)-1]
+}
+
+// loaderWith returns a DB-less loader with one key registered.
+func loaderWith(key, subject, html, text string) *emailtemplates.Loader {
+	l := emailtemplates.NewLoader(nil)
+	l.Register(key, emailtemplates.EmbeddedFallback{
+		Subject: subject, HTMLBody: html, TextBody: text,
+	})
+	return l
+}
+
+func TestTemplateClient_Send_BuildsEnvelope(t *testing.T) {
+	sender := &captureSender{}
+	loader := loaderWith("dunning_day_5",
+		"Payment failed for {{.store_name}}",
+		"<p>Hi {{.store_name}}, day {{.day}}</p>",
+		"Hi {{.store_name}}, day {{.day}}")
+
+	c := email.NewTemplateClient(loader, sender, "noreply@mark8ly.com", slog.Default())
+
+	err := c.Send(context.Background(), email.TemplateDunningDay5, "merchant@example.com", map[string]any{
+		"store_name": "Acme",
+		"day":        5,
+		"tenant_id":  "tenant-123",
+	})
+	if err != nil {
+		t.Fatalf("Send returned %v, want nil", err)
+	}
+
+	msg := sender.last(t)
+	if msg.To != "merchant@example.com" {
+		t.Errorf("To = %q", msg.To)
+	}
+	if msg.From != "noreply@mark8ly.com" {
+		t.Errorf("From = %q", msg.From)
+	}
+	if msg.FromName != "Mark8ly Billing" {
+		t.Errorf("FromName = %q", msg.FromName)
+	}
+	if msg.Subject != "Payment failed for Acme" {
+		t.Errorf("Subject = %q", msg.Subject)
+	}
+	if !strings.Contains(msg.HTMLBody, "day 5") {
+		t.Errorf("HTMLBody = %q", msg.HTMLBody)
+	}
+	if !strings.Contains(msg.TextBody, "day 5") {
+		t.Errorf("TextBody = %q", msg.TextBody)
+	}
+	if msg.CustomArgs["product"] != "mark8ly" {
+		t.Errorf("product arg = %q", msg.CustomArgs["product"])
+	}
+	if msg.CustomArgs["kind"] != "dunning_day_5" {
+		t.Errorf("kind arg = %q", msg.CustomArgs["kind"])
+	}
+	if msg.CustomArgs["tenant_id"] != "tenant-123" {
+		t.Errorf("tenant_id arg = %q", msg.CustomArgs["tenant_id"])
+	}
+}
+
+// The whole point of #381: never report success for mail we did not send.
+func TestTemplateClient_Send_UndeliverableNeverReachesSender(t *testing.T) {
+	sender := &captureSender{}
+	loader := loaderWith("dunning_day_5", "s", "<p>h</p>", "t")
+	c := email.NewTemplateClient(loader, sender, "noreply@mark8ly.com", slog.Default())
+
+	for _, to := range []string{"", "b0a1-uuid-not-an-email", "billing+7f3a@mark8ly.local"} {
+		err := c.Send(context.Background(), email.TemplateDunningDay5, to, map[string]any{})
+		if err == nil {
+			t.Fatalf("Send(%q) = nil, want ErrUndeliverable", to)
+		}
+		if !errors.Is(err, email.ErrUndeliverable) {
+			t.Errorf("Send(%q) err = %v, want ErrUndeliverable", to, err)
+		}
+	}
+	if len(sender.msgs) != 0 {
+		t.Errorf("sender received %d messages, want 0", len(sender.msgs))
+	}
+}
+
+func TestTemplateClient_Send_UnknownKeyIsRenderFailure(t *testing.T) {
+	sender := &captureSender{}
+	c := email.NewTemplateClient(emailtemplates.NewLoader(nil), sender, "noreply@mark8ly.com", slog.Default())
+
+	err := c.Send(context.Background(), email.TemplateDunningDay5, "merchant@example.com", map[string]any{})
+	if err == nil {
+		t.Fatal("Send with unregistered key = nil, want error")
+	}
+	if !errors.Is(err, email.ErrRender) {
+		t.Errorf("err = %v, want ErrRender", err)
+	}
+	if email.SkipReason(err) != email.ReasonRenderFailed {
+		t.Errorf("SkipReason = %q, want %q", email.SkipReason(err), email.ReasonRenderFailed)
+	}
+}
+
+func TestTemplateClient_Send_TransportFailurePropagates(t *testing.T) {
+	sender := &captureSender{err: errors.New("sendgrid 503")}
+	loader := loaderWith("dunning_day_5", "s", "<p>h</p>", "t")
+	c := email.NewTemplateClient(loader, sender, "noreply@mark8ly.com", slog.Default())
+
+	err := c.Send(context.Background(), email.TemplateDunningDay5, "merchant@example.com", map[string]any{})
+	if err == nil {
+		t.Fatal("Send = nil, want transport error")
+	}
+	if !errors.Is(err, email.ErrTransport) {
+		t.Errorf("err = %v, want ErrTransport", err)
+	}
+	if email.SkipReason(err) != email.ReasonTransportFailed {
+		t.Errorf("SkipReason = %q, want %q", email.SkipReason(err), email.ReasonTransportFailed)
+	}
+}
+
+func TestSkipReason_UndeliverableWins(t *testing.T) {
+	err := email.ValidateRecipient("x@y.local")
+	if got := email.SkipReason(err); got != email.ReasonPlaceholderAddress {
+		t.Errorf("SkipReason = %q, want %q", got, email.ReasonPlaceholderAddress)
+	}
+	if got := email.SkipReason(errors.New("boom")); got != email.ReasonUnknown {
+		t.Errorf("SkipReason(unrelated) = %q, want %q", got, email.ReasonUnknown)
+	}
+}

--- a/services/marketplace-api/internal/email/template_client_test.go
+++ b/services/marketplace-api/internal/email/template_client_test.go
@@ -158,3 +158,33 @@ func TestSkipReason_UndeliverableWins(t *testing.T) {
 		t.Errorf("SkipReason(unrelated) = %q, want %q", got, email.ReasonUnknown)
 	}
 }
+
+func TestTemplateClient_Send_PreservesUnderlyingCause_Transport(t *testing.T) {
+	sentinel := errors.New("sendgrid 503 upstream")
+	sender := &captureSender{err: sentinel}
+	loader := loaderWith("dunning_day_5", "s", "<p>h</p>", "t")
+	c := email.NewTemplateClient(loader, sender, "noreply@mark8ly.com", slog.Default())
+
+	err := c.Send(context.Background(), email.TemplateDunningDay5, "merchant@example.com", map[string]any{})
+	if !errors.Is(err, email.ErrTransport) {
+		t.Errorf("lost the sentinel: %v", err)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("lost the underlying cause: %v", err)
+	}
+}
+
+func TestTemplateClient_Send_PreservesUnderlyingCause_Render(t *testing.T) {
+	// Verify the render sentinel is preserved in the error chain.
+	// TestTemplateClient_Send_PreservesUnderlyingCause_Transport verifies
+	// that both the sentinel and underlying cause are preserved for transport errors.
+	// For render, we verify at minimum that errors.Is works for the sentinel.
+	emptyLoader := emailtemplates.NewLoader(nil)
+	sender := &captureSender{}
+	c := email.NewTemplateClient(emptyLoader, sender, "noreply@mark8ly.com", slog.Default())
+
+	err := c.Send(context.Background(), email.TemplateDunningDay5, "merchant@example.com", map[string]any{})
+	if !errors.Is(err, email.ErrRender) {
+		t.Errorf("lost the render sentinel: %v", err)
+	}
+}

--- a/services/marketplace-api/internal/email/template_client_test.go
+++ b/services/marketplace-api/internal/email/template_client_test.go
@@ -191,3 +191,36 @@ func TestTemplateClient_Send_PreservesUnderlyingCause_Render(t *testing.T) {
 		t.Errorf("render failure still reached the sender")
 	}
 }
+
+// A log-only sender delivers nothing, so Send must not report success —
+// otherwise a single missing provider key puts the delivery dashboards
+// back to the pre-#381 lie.
+func TestTemplateClient_Send_LogOnlySenderIsNotSuccess(t *testing.T) {
+	loader := loaderWith("dunning_day_5", "Subject", "<p>body</p>", "body")
+	c := email.NewTemplateClient(loader, &email.LogSender{Logger: slog.Default()},
+		"noreply@mark8ly.com", slog.Default())
+
+	err := c.Send(context.Background(), email.TemplateDunningDay5,
+		"merchant@example.com", map[string]any{"store_name": "Acme"})
+
+	if err == nil {
+		t.Fatal("Send returned nil over a log-only sender — caller would count a delivery")
+	}
+	if !errors.Is(err, email.ErrNoProvider) {
+		t.Errorf("err = %v, want ErrNoProvider", err)
+	}
+	if got := email.SkipReason(err); got != email.ReasonNoProvider {
+		t.Errorf("SkipReason = %q, want %q", got, email.ReasonNoProvider)
+	}
+}
+
+// A real provider still returns nil — the guard must not swallow success.
+func TestTemplateClient_Send_RealSenderStillSucceeds(t *testing.T) {
+	loader := loaderWith("dunning_day_5", "Subject", "<p>body</p>", "body")
+	c := email.NewTemplateClient(loader, &captureSender{}, "noreply@mark8ly.com", slog.Default())
+
+	if err := c.Send(context.Background(), email.TemplateDunningDay5,
+		"merchant@example.com", map[string]any{"store_name": "Acme"}); err != nil {
+		t.Fatalf("Send over a real sender: %v", err)
+	}
+}

--- a/services/marketplace-api/internal/email/template_client_test.go
+++ b/services/marketplace-api/internal/email/template_client_test.go
@@ -175,16 +175,19 @@ func TestTemplateClient_Send_PreservesUnderlyingCause_Transport(t *testing.T) {
 }
 
 func TestTemplateClient_Send_PreservesUnderlyingCause_Render(t *testing.T) {
-	// Verify the render sentinel is preserved in the error chain.
-	// TestTemplateClient_Send_PreservesUnderlyingCause_Transport verifies
-	// that both the sentinel and underlying cause are preserved for transport errors.
-	// For render, we verify at minimum that errors.Is works for the sentinel.
-	emptyLoader := emailtemplates.NewLoader(nil)
+	// A loader with no registered fallback for the key: Render returns
+	// an error wrapping emailtemplates.ErrUnknownKey.
 	sender := &captureSender{}
-	c := email.NewTemplateClient(emptyLoader, sender, "noreply@mark8ly.com", slog.Default())
+	c := email.NewTemplateClient(emailtemplates.NewLoader(nil), sender, "noreply@mark8ly.com", slog.Default())
 
 	err := c.Send(context.Background(), email.TemplateDunningDay5, "merchant@example.com", map[string]any{})
 	if !errors.Is(err, email.ErrRender) {
-		t.Errorf("lost the render sentinel: %v", err)
+		t.Errorf("lost the sentinel: %v", err)
+	}
+	if !errors.Is(err, emailtemplates.ErrUnknownKey) {
+		t.Errorf("lost the underlying cause: %v", err)
+	}
+	if len(sender.msgs) != 0 {
+		t.Errorf("render failure still reached the sender")
 	}
 }

--- a/services/marketplace-api/internal/email/templates.go
+++ b/services/marketplace-api/internal/email/templates.go
@@ -1,3 +1,68 @@
-// Package email — reserved for template-level helpers.
-// Intentionally empty today; lands when real adapter arrives.
+// Package-level template registration for billing mail (#381).
+//
+// Every key here is registered against the shared emailtemplates.Loader at
+// boot, exactly as orderdoc and giftcard do. Registration makes a key
+// overridable from the operator console; it does not seed a DB row, so
+// until someone authors one these embedded fallbacks are what sends.
 package email
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+)
+
+// bodyMarker is the substitution point in chromeHTML.
+const bodyMarker = "<!--BODY-->"
+
+// billingTemplateKeys is the catalog, in the order an operator would
+// encounter them across a subscription's life.
+var billingTemplateKeys = []TemplateID{
+	TemplateTrialNoPMT15,
+	TemplateTrialNoPMT10,
+	TemplateTrialNoPMT7,
+	TemplateTrialNoPMT3,
+	TemplateTrialNoPMT1,
+	TemplateTrialHasPMT1,
+	TemplateTrialStartedBilled,
+	TemplatePaymentActionReminder,
+	TemplateDunningDay5,
+	TemplateDunningDay7,
+	TemplateWinBack,
+}
+
+// BillingTemplateKeys returns a copy of the catalog. A copy, so a caller
+// cannot reorder or truncate the registry it is reading.
+func BillingTemplateKeys() []TemplateID {
+	out := make([]TemplateID, len(billingTemplateKeys))
+	copy(out, billingTemplateKeys)
+	return out
+}
+
+// RegisterFallbacks binds every billing template's embedded fallback to
+// the loader. Call once at boot, before any cron can fire.
+//
+// Panics if a key is missing content — a programming error that would
+// otherwise surface as a silently unsent email at 09:05 UTC.
+func RegisterFallbacks(loader *emailtemplates.Loader) {
+	for _, key := range billingTemplateKeys {
+		subject, ok := billingSubjects[key]
+		if !ok {
+			panic(fmt.Sprintf("email: no subject registered for template %q", key))
+		}
+		htmlFragment, ok := billingHTMLFragments[key]
+		if !ok {
+			panic(fmt.Sprintf("email: no html fragment registered for template %q", key))
+		}
+		textBody, ok := billingTextFragments[key]
+		if !ok {
+			panic(fmt.Sprintf("email: no text fragment registered for template %q", key))
+		}
+		loader.Register(string(key), emailtemplates.EmbeddedFallback{
+			Subject:  subject,
+			HTMLBody: strings.Replace(chromeHTML, bodyMarker, htmlFragment, 1),
+			TextBody: textBody,
+		})
+	}
+}

--- a/services/marketplace-api/internal/email/templates_content.go
+++ b/services/marketplace-api/internal/email/templates_content.go
@@ -1,0 +1,206 @@
+package email
+
+// templates_content.go — embedded fallback copy for the eleven billing
+// templates (#381).
+//
+// These are FALLBACKS. The authoritative copy, once an operator writes one,
+// is the published row in email_templates; the loader prefers it and only
+// reaches for these when the row is absent, draft, or the DB is unreachable.
+// Keep them plain and provider-agnostic: no external images, no web fonts,
+// table-based layout, inline styles only.
+//
+// Brand: paper (#F7F6F2) page, white card, ink (#0E0E0C) text, moss
+// (#2D4A2B) for the single call to action. One accent, no decoration.
+
+// chromeHTML wraps every fragment. <!--BODY--> is substituted at
+// registration time; it is deliberately an HTML comment rather than a
+// template action so the chrome itself is never parsed as a template.
+const chromeHTML = `<!doctype html>
+<html>
+<body style="margin:0;padding:0;background:#F7F6F2;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#F7F6F2;">
+<tr><td align="center" style="padding:40px 16px;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;background:#FFFFFF;border-radius:6px;">
+<tr><td style="padding:40px;font-family:'Source Sans 3',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:16px;line-height:1.6;color:#0E0E0C;">
+<!--BODY-->
+<hr style="border:none;border-top:1px solid #E4E2DC;margin:32px 0 16px;">
+<p style="font-size:12px;line-height:1.5;color:#6B6A64;margin:0;">Mark8ly · You are receiving this because you run a store on Mark8ly.</p>
+</td></tr></table>
+</td></tr></table>
+</body>
+</html>`
+
+// h1 is the shared editorial headline style — Source Serif 4, per the
+// brand direction that the serif carries the brand.
+const h1 = `style="font-family:'Source Serif 4',Georgia,serif;font-size:26px;line-height:1.25;font-weight:600;margin:0 0 20px;"`
+
+// cta renders the single moss button. Guarded by {{if}} at each call site
+// so a missing URL omits the button rather than emitting an empty href.
+const ctaOpen = `<p style="margin:28px 0 0;"><a href="`
+const ctaMid = `" style="display:inline-block;background:#2D4A2B;color:#FFFFFF;text-decoration:none;padding:12px 22px;border-radius:6px;font-weight:600;">`
+const ctaClose = `</a></p>`
+
+// --- subjects -------------------------------------------------------
+
+var billingSubjects = map[TemplateID]string{
+	TemplateDunningDay5:           `We could not process your payment for {{.store_name}}`,
+	TemplateDunningDay7:           `Action needed to keep {{.store_name}} open`,
+	TemplatePaymentActionReminder: `Confirm your payment for {{.store_name}}`,
+	TemplateTrialNoPMT15:          `15 days left in your {{.store_name}} trial`,
+	TemplateTrialNoPMT10:          `10 days left in your {{.store_name}} trial`,
+	TemplateTrialNoPMT7:           `One week left in your {{.store_name}} trial`,
+	TemplateTrialNoPMT3:           `3 days left in your {{.store_name}} trial`,
+	TemplateTrialNoPMT1:           `Your {{.store_name}} trial ends tomorrow`,
+	TemplateTrialHasPMT1:          `Your {{.plan}} plan for {{.store_name}} starts tomorrow`,
+	TemplateTrialStartedBilled:    `Your {{.plan}} plan for {{.store_name}} is active`,
+	TemplateWinBack:               `Come back to Mark8ly — 20% off six months`,
+}
+
+// --- HTML fragments -------------------------------------------------
+
+var billingHTMLFragments = map[TemplateID]string{
+	TemplateDunningDay5: `<h1 ` + h1 + `>Your payment did not go through</h1>
+<p>We tried to charge the card on file for <strong>{{.store_name}}</strong> and it was declined. Your store is still open.</p>
+<p>Updating your payment method now avoids any interruption.</p>
+{{if .hosted_invoice_url}}` + ctaOpen + `{{.hosted_invoice_url}}` + ctaMid + `Complete your payment` + ctaClose + `{{else}}<p>Open your Mark8ly billing settings to update your card.</p>{{end}}`,
+
+	TemplateDunningDay7: `<h1 ` + h1 + `>Action needed to keep {{.store_name}} open</h1>
+<p>It has been {{.day}} days since your payment failed. If it stays unpaid, <strong>{{.store_name}}</strong> will be suspended and your storefront will stop serving customers.</p>
+<p>This is reversible right up until suspension.</p>
+{{if .hosted_invoice_url}}` + ctaOpen + `{{.hosted_invoice_url}}` + ctaMid + `Pay now` + ctaClose + `{{else}}<p>Open your Mark8ly billing settings to update your card.</p>{{end}}`,
+
+	TemplatePaymentActionReminder: `<h1 ` + h1 + `>One step left to confirm your payment</h1>
+<p>Your bank asked for extra confirmation before charging the card for <strong>{{.store_name}}</strong>. Until you approve it, the payment is not complete.</p>
+{{if .hosted_invoice_url}}` + ctaOpen + `{{.hosted_invoice_url}}` + ctaMid + `Confirm payment` + ctaClose + `{{else}}<p>Open your Mark8ly billing settings to finish confirming.</p>{{end}}`,
+
+	TemplateTrialNoPMT15: `<h1 ` + h1 + `>15 days left in your trial</h1>
+<p><strong>{{.store_name}}</strong> has {{.days_remaining}} days left on the free trial. There is no card on file yet.</p>
+<p>Adding one now means your storefront keeps serving customers the moment the trial ends. Nothing is charged until then.</p>`,
+
+	TemplateTrialNoPMT10: `<h1 ` + h1 + `>10 days left in your trial</h1>
+<p><strong>{{.store_name}}</strong> has {{.days_remaining}} days left on the free trial, and no payment method on file.</p>
+<p>Choose a plan whenever you are ready — you will not be charged before the trial ends.</p>`,
+
+	TemplateTrialNoPMT7: `<h1 ` + h1 + `>One week left in your trial</h1>
+<p><strong>{{.store_name}}</strong> has {{.days_remaining}} days of trial remaining. There is still no card on file.</p>
+<p>Without one, your storefront stops serving customers when the trial ends.</p>`,
+
+	TemplateTrialNoPMT3: `<h1 ` + h1 + `>3 days left in your trial</h1>
+<p><strong>{{.store_name}}</strong> has {{.days_remaining}} days left. Adding a payment method takes a minute and keeps everything running.</p>`,
+
+	TemplateTrialNoPMT1: `<h1 ` + h1 + `>Your trial ends tomorrow</h1>
+<p>Tomorrow the free trial for <strong>{{.store_name}}</strong> ends. With no payment method on file, the storefront will stop serving customers.</p>
+<p>Your products, orders and settings are kept — adding a card restores the store immediately.</p>`,
+
+	TemplateTrialHasPMT1: `<h1 ` + h1 + `>Your {{.plan}} plan starts tomorrow</h1>
+<p>The free trial for <strong>{{.store_name}}</strong> ends tomorrow, and your <strong>{{.plan}}</strong> plan begins. We will charge the card on file — nothing for you to do.</p>
+<p>If you would rather change plan, you can do that before the charge.</p>`,
+
+	TemplateTrialStartedBilled: `<h1 ` + h1 + `>Your {{.plan}} plan is active</h1>
+<p>Thank you — the first payment for <strong>{{.store_name}}</strong> went through and your <strong>{{.plan}}</strong> plan is now active, billed {{.period}}.</p>
+<p>Your receipt is in your billing settings.</p>`,
+
+	TemplateWinBack: `<h1 ` + h1 + `>Your store is still here</h1>
+<p><strong>{{.store_name}}</strong> has been closed for a month. Everything — products, orders, settings — is exactly as you left it.</p>
+<p>If you want to pick it back up, we will take <strong>20% off your first six months</strong>.</p>`,
+}
+
+// --- text fragments -------------------------------------------------
+
+var billingTextFragments = map[TemplateID]string{
+	TemplateDunningDay5: `Your payment did not go through
+
+We tried to charge the card on file for {{.store_name}} and it was declined. Your store is still open.
+
+Updating your payment method now avoids any interruption.
+{{if .hosted_invoice_url}}
+Complete your payment: {{.hosted_invoice_url}}
+{{else}}
+Open your Mark8ly billing settings to update your card.
+{{end}}
+Mark8ly`,
+
+	TemplateDunningDay7: `Action needed to keep {{.store_name}} open
+
+It has been {{.day}} days since your payment failed. If it stays unpaid, {{.store_name}} will be suspended and your storefront will stop serving customers.
+
+This is reversible right up until suspension.
+{{if .hosted_invoice_url}}
+Pay now: {{.hosted_invoice_url}}
+{{else}}
+Open your Mark8ly billing settings to update your card.
+{{end}}
+Mark8ly`,
+
+	TemplatePaymentActionReminder: `One step left to confirm your payment
+
+Your bank asked for extra confirmation before charging the card for {{.store_name}}. Until you approve it, the payment is not complete.
+{{if .hosted_invoice_url}}
+Confirm payment: {{.hosted_invoice_url}}
+{{else}}
+Open your Mark8ly billing settings to finish confirming.
+{{end}}
+Mark8ly`,
+
+	TemplateTrialNoPMT15: `15 days left in your trial
+
+{{.store_name}} has {{.days_remaining}} days left on the free trial. There is no card on file yet.
+
+Adding one now means your storefront keeps serving customers the moment the trial ends. Nothing is charged until then.
+
+Mark8ly`,
+
+	TemplateTrialNoPMT10: `10 days left in your trial
+
+{{.store_name}} has {{.days_remaining}} days left on the free trial, and no payment method on file.
+
+Choose a plan whenever you are ready — you will not be charged before the trial ends.
+
+Mark8ly`,
+
+	TemplateTrialNoPMT7: `One week left in your trial
+
+{{.store_name}} has {{.days_remaining}} days of trial remaining. There is still no card on file.
+
+Without one, your storefront stops serving customers when the trial ends.
+
+Mark8ly`,
+
+	TemplateTrialNoPMT3: `3 days left in your trial
+
+{{.store_name}} has {{.days_remaining}} days left. Adding a payment method takes a minute and keeps everything running.
+
+Mark8ly`,
+
+	TemplateTrialNoPMT1: `Your trial ends tomorrow
+
+Tomorrow the free trial for {{.store_name}} ends. With no payment method on file, the storefront will stop serving customers.
+
+Your products, orders and settings are kept — adding a card restores the store immediately.
+
+Mark8ly`,
+
+	TemplateTrialHasPMT1: `Your {{.plan}} plan starts tomorrow
+
+The free trial for {{.store_name}} ends tomorrow, and your {{.plan}} plan begins. We will charge the card on file — nothing for you to do.
+
+If you would rather change plan, you can do that before the charge.
+
+Mark8ly`,
+
+	TemplateTrialStartedBilled: `Your {{.plan}} plan is active
+
+Thank you — the first payment for {{.store_name}} went through and your {{.plan}} plan is now active, billed {{.period}}.
+
+Your receipt is in your billing settings.
+
+Mark8ly`,
+
+	TemplateWinBack: `Your store is still here
+
+{{.store_name}} has been closed for a month. Everything — products, orders, settings — is exactly as you left it.
+
+If you want to pick it back up, we will take 20% off your first six months.
+
+Mark8ly`,
+}

--- a/services/marketplace-api/internal/email/templates_lint_test.go
+++ b/services/marketplace-api/internal/email/templates_lint_test.go
@@ -1,0 +1,56 @@
+package email
+
+// templates_lint_test.go — catches a template variable that was misspelled
+// or renamed. Production HTML renders through html/template, which prints a
+// missing map key as an empty string rather than "<no value>" — silent, and
+// invisible to an output-based assertion. Parsing the same source with
+// text/template surfaces it. This lints the fragment source only; nothing
+// here affects what is actually sent.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	texttpl "text/template"
+)
+
+func TestBillingTemplates_NoMissingVariables(t *testing.T) {
+	vars := map[string]any{
+		"store_id":           "11111111-2222-3333-4444-555555555555",
+		"tenant_id":          "66666666-7777-8888-9999-000000000000",
+		"store_name":         "Acme Supply Co",
+		"day":                5,
+		"offset":             "t_minus_7",
+		"days_remaining":     7,
+		"has_payment_method": false,
+		"plan":               "growth",
+		"period":             "monthly",
+		"promo":              "20%-off-6-months",
+		"hosted_invoice_url": "https://invoice.stripe.com/i/test",
+	}
+
+	for _, key := range billingTemplateKeys {
+		for _, part := range []struct {
+			name string
+			src  string
+		}{
+			{"subject", billingSubjects[key]},
+			{"html", billingHTMLFragments[key]},
+			{"text", billingTextFragments[key]},
+		} {
+			tpl, err := texttpl.New(string(key) + ":" + part.name).Parse(part.src)
+			if err != nil {
+				t.Errorf("%s/%s: parse: %v", key, part.name, err)
+				continue
+			}
+			var buf bytes.Buffer
+			if err := tpl.Execute(&buf, vars); err != nil {
+				t.Errorf("%s/%s: execute: %v", key, part.name, err)
+				continue
+			}
+			if strings.Contains(buf.String(), "<no value>") {
+				t.Errorf("%s/%s references a variable not in the caller's data map", key, part.name)
+			}
+		}
+	}
+}

--- a/services/marketplace-api/internal/email/templates_test.go
+++ b/services/marketplace-api/internal/email/templates_test.go
@@ -1,0 +1,95 @@
+package email_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+)
+
+// sampleVars covers every field any billing template references, so one
+// map renders all eleven. Extra keys are harmless.
+func sampleVars() map[string]any {
+	return map[string]any{
+		"store_id":           "11111111-2222-3333-4444-555555555555",
+		"tenant_id":          "66666666-7777-8888-9999-000000000000",
+		"store_name":         "Acme Supply Co",
+		"day":                5,
+		"offset":             "t_minus_7",
+		"days_remaining":     7,
+		"has_payment_method": false,
+		"plan":               "growth",
+		"period":             "monthly",
+		"promo":              "20%-off-6-months",
+		"hosted_invoice_url": "https://invoice.stripe.com/i/test",
+	}
+}
+
+func TestRegisterFallbacks_EveryKeyRenders(t *testing.T) {
+	loader := emailtemplates.NewLoader(nil)
+	email.RegisterFallbacks(loader)
+
+	keys := email.BillingTemplateKeys()
+	if len(keys) != 11 {
+		t.Fatalf("BillingTemplateKeys() has %d keys, want 11", len(keys))
+	}
+
+	for _, key := range keys {
+		t.Run(string(key), func(t *testing.T) {
+			r, err := loader.Render(context.Background(), string(key), sampleVars())
+			if err != nil {
+				t.Fatalf("Render(%s) failed: %v", key, err)
+			}
+			if strings.TrimSpace(r.Subject) == "" {
+				t.Error("empty subject")
+			}
+			if strings.TrimSpace(r.TextBody) == "" {
+				t.Error("empty text body")
+			}
+			if !strings.Contains(r.HTMLBody, "<!doctype html>") {
+				t.Error("html body is not a full document — chrome not applied")
+			}
+			if strings.Contains(r.HTMLBody, "<!--BODY-->") {
+				t.Error("chrome placeholder was not substituted")
+			}
+			// Every template addresses the merchant by store name.
+			if !strings.Contains(r.HTMLBody, "Acme Supply Co") {
+				t.Error("html body does not reference store_name")
+			}
+			// No unresolved template actions should survive rendering.
+			if strings.Contains(r.HTMLBody, "{{") || strings.Contains(r.TextBody, "{{") {
+				t.Error("unrendered template action left in output")
+			}
+		})
+	}
+}
+
+func TestRegisterFallbacks_HostedInvoiceURLIsOptional(t *testing.T) {
+	loader := emailtemplates.NewLoader(nil)
+	email.RegisterFallbacks(loader)
+
+	vars := sampleVars()
+	vars["hosted_invoice_url"] = ""
+
+	r, err := loader.Render(context.Background(), string(email.TemplateDunningDay5), vars)
+	if err != nil {
+		t.Fatalf("Render without invoice url failed: %v", err)
+	}
+	if strings.Contains(r.HTMLBody, "href=\"\"") {
+		t.Error("emitted an empty href instead of omitting the CTA")
+	}
+}
+
+func TestBillingTemplateKeys_IncludesWinBack(t *testing.T) {
+	var found bool
+	for _, k := range email.BillingTemplateKeys() {
+		if k == email.TemplateWinBack {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("win_back_day30 missing from the billing catalog")
+	}
+}

--- a/services/marketplace-api/internal/email/templates_test.go
+++ b/services/marketplace-api/internal/email/templates_test.go
@@ -62,6 +62,15 @@ func TestRegisterFallbacks_EveryKeyRenders(t *testing.T) {
 			if strings.Contains(r.HTMLBody, "{{") || strings.Contains(r.TextBody, "{{") {
 				t.Error("unrendered template action left in output")
 			}
+			// A misspelled field renders as the literal "<no value>" rather
+			// than failing, so absence of "{{" is not enough — assert the
+			// rendered output does not contain it. html/template escapes the
+			// angle brackets, so check both forms.
+			for _, body := range []string{r.HTMLBody, r.TextBody, r.Subject} {
+				if strings.Contains(body, "<no value>") || strings.Contains(body, "&lt;no value&gt;") {
+					t.Errorf("template rendered a missing variable as <no value>: %s", body)
+				}
+			}
 		})
 	}
 }

--- a/services/marketplace-api/internal/metrics/registry.go
+++ b/services/marketplace-api/internal/metrics/registry.go
@@ -107,6 +107,18 @@ var (
 		[]string{"offset"},
 	)
 
+	// BillingEmailsSkippedTotal counts subscription emails deliberately not
+	// sent — an undeliverable recipient, a render failure, or a transport
+	// failure. Its companion *_sent_total counters only ever increment on a
+	// real delivery, so sent+skipped is the eligible population. #381.
+	BillingEmailsSkippedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mark8ly_subscription_billing_emails_skipped_total",
+			Help: "Count of subscription emails not sent, labeled by template and reason (no_address, placeholder_address, invalid_address, render_failed, transport_failed).",
+		},
+		[]string{"template", "reason"},
+	)
+
 	// AuditPruneRowsDeletedTotal counts audit_logs rows hard-deleted by the
 	// retention prune cron, labeled by retention bucket
 	// (trial_starter_90d, studio_365d, operator_7y). Pro is unlimited and never pruned.
@@ -174,6 +186,7 @@ func init() {
 		DunningEmailsSentTotal,
 		PaymentActionRemindersSentTotal,
 		TrialRemindersSentTotal,
+		BillingEmailsSkippedTotal,
 		AuditPruneRowsDeletedTotal,
 		DunningSuppressedRefundWindowTotal,
 		APIKeyUsedTotal,

--- a/services/marketplace-api/internal/metrics/registry.go
+++ b/services/marketplace-api/internal/metrics/registry.go
@@ -118,7 +118,7 @@ var (
 	BillingEmailsSkippedTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "mark8ly_subscription_billing_emails_skipped_total",
-			Help: "Count of subscription emails not sent, labeled by template and reason (no_address, placeholder_address, invalid_address, render_failed, transport_failed, no_provider, claim_failed, no_claim_store).",
+			Help: "Count of subscription emails not sent, labeled by template and reason (no_address, placeholder_address, invalid_address, render_failed, transport_failed, no_provider, claim_failed, no_claim_store). Exception: plan_unresolved is deliberately counted outside the idempotency claim, so on repeat same-day cron runs it may be incremented more than once per merchant — for that reason, sent+skipped is an inequality rather than an equality.",
 		},
 		[]string{"template", "reason"},
 	)

--- a/services/marketplace-api/internal/metrics/registry.go
+++ b/services/marketplace-api/internal/metrics/registry.go
@@ -108,15 +108,32 @@ var (
 	)
 
 	// BillingEmailsSkippedTotal counts subscription emails deliberately not
-	// sent — an undeliverable recipient, a render failure, or a transport
-	// failure. Its companion *_sent_total counters only ever increment on a
-	// real delivery, so sent+skipped is the eligible population. #381.
+	// sent — an undeliverable recipient, a render failure, a transport
+	// failure, or no configured provider. Every billing template has a
+	// companion sent counter that increments only on a real delivery
+	// (dunning_emails_sent_total, payment_action_reminders_sent_total,
+	// trial_reminders_sent_total, and billing_emails_sent_total for
+	// win_back_day30 and trial_started_billed), so per template
+	// sent+skipped is the eligible population. #381.
 	BillingEmailsSkippedTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "mark8ly_subscription_billing_emails_skipped_total",
-			Help: "Count of subscription emails not sent, labeled by template and reason (no_address, placeholder_address, invalid_address, render_failed, transport_failed).",
+			Help: "Count of subscription emails not sent, labeled by template and reason (no_address, placeholder_address, invalid_address, render_failed, transport_failed, no_provider, claim_failed, no_claim_store).",
 		},
 		[]string{"template", "reason"},
+	)
+
+	// BillingEmailsSentTotal counts billing emails actually delivered for the
+	// two templates with no per-feature sent counter of their own:
+	// win_back_day30 (lifecycle win-back cron) and trial_started_billed
+	// (invoice.paid dispatcher). Without it the sent+skipped identity
+	// documented on BillingEmailsSkippedTotal would be false for both. #381.
+	BillingEmailsSentTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mark8ly_subscription_billing_emails_sent_total",
+			Help: "Count of billing emails delivered, labeled by template (win_back_day30, trial_started_billed).",
+		},
+		[]string{"template"},
 	)
 
 	// AuditPruneRowsDeletedTotal counts audit_logs rows hard-deleted by the
@@ -187,6 +204,7 @@ func init() {
 		PaymentActionRemindersSentTotal,
 		TrialRemindersSentTotal,
 		BillingEmailsSkippedTotal,
+		BillingEmailsSentTotal,
 		AuditPruneRowsDeletedTotal,
 		DunningSuppressedRefundWindowTotal,
 		APIKeyUsedTotal,

--- a/services/marketplace-api/internal/subscription/dunning/criterion_38_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/criterion_38_integration_test.go
@@ -30,6 +30,7 @@ func TestCriterion38_DunningLeavesPaymentActionRequiredAlone(t *testing.T) {
 	tenantID := uuid.New()
 	seedStore(t, db, tenantID, storeID)
 	hostedURL := "https://stripe.example/i/criterion38"
+	merchantEmail := "merchant-c38@example.com"
 
 	// FirstChargeAt 30 days ago simulates an established sub — well outside the
 	// 14-day refund window if it were in past_due. Irrelevant for PAR logic but
@@ -46,6 +47,7 @@ func TestCriterion38_DunningLeavesPaymentActionRequiredAlone(t *testing.T) {
 		Status:           subscription.StatusPaymentActionRequired,
 		HostedInvoiceURL: &hostedURL,
 		FirstChargeAt:    &thirtyDaysAgo,
+		Email:            &merchantEmail,
 	}
 	if err := db.Create(&sub).Error; err != nil {
 		t.Fatalf("seed sub: %v", err)
@@ -105,7 +107,7 @@ func TestCriterion38_DunningLeavesPaymentActionRequiredAlone(t *testing.T) {
 	scaMailer.mu.Lock()
 	scaCall := scaMailer.Calls[0]
 	scaMailer.mu.Unlock()
-	if scaCall.To != storeID.String() {
-		t.Fatalf("SCA reminder To = %q; want store_id %q", scaCall.To, storeID.String())
+	if scaCall.To != merchantEmail {
+		t.Fatalf("SCA reminder To = %q; want merchant email %q", scaCall.To, merchantEmail)
 	}
 }

--- a/services/marketplace-api/internal/subscription/dunning/dunning_emails.go
+++ b/services/marketplace-api/internal/subscription/dunning/dunning_emails.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/email"
@@ -36,9 +37,15 @@ var dunningEmailTargets = []dunningEmailTarget{
 }
 
 // emailRow is the minimal projection returned by the dunning email query.
+// Email and StoreName come from the merchant-facing side of the join: the
+// address to send to, and the name the templates address them by.
 type emailRow struct {
-	StoreID  string
-	TenantID string
+	SubscriptionID   uuid.UUID
+	StoreID          string
+	TenantID         string
+	Email            *string
+	StoreName        string
+	HostedInvoiceURL *string
 }
 
 // SendDunningEmails is a daily cron that sends day-5 and day-7 nudge emails
@@ -51,6 +58,7 @@ type SendDunningEmails struct {
 	logger  *slog.Logger
 	clock   func() time.Time
 	counter CounterVecIncrementer
+	skip    SkipCounter
 }
 
 // NewSendDunningEmails constructs a SendDunningEmails cron. All parameters
@@ -70,6 +78,13 @@ func NewSendDunningEmails(db *gorm.DB, em email.Client, logger *slog.Logger, cou
 		counter: counter,
 		clock:   clock,
 	}
+}
+
+// WithSkipCounter attaches the counter for emails deliberately not sent.
+// Optional: nil means skips are logged but not counted.
+func (s *SendDunningEmails) WithSkipCounter(c SkipCounter) *SendDunningEmails {
+	s.skip = c
+	return s
 }
 
 // Run executes one pass: for each target day, finds subscriptions that entered
@@ -97,10 +112,15 @@ func (s *SendDunningEmails) runForDay(ctx context.Context, now time.Time, t dunn
 	var rows []emailRow
 	err := s.db.WithContext(ctx).Raw(`
 		SELECT DISTINCT
+		    ss.id   AS subscription_id,
 		    ss.store_id,
-		    ss.tenant_id
+		    ss.tenant_id,
+		    ss.email,
+		    ss.hosted_invoice_url,
+		    COALESCE(st.name, 'your store') AS store_name
 		FROM store_subscriptions ss
 		JOIN audit_logs a ON a.store_id = ss.store_id
+		LEFT JOIN stores st ON st.id = ss.store_id
 		WHERE ss.status = ?
 		  AND a.action = 'subscription.state_transition'
 		  AND a.metadata->>'to_status' = ?
@@ -113,20 +133,63 @@ func (s *SendDunningEmails) runForDay(ctx context.Context, now time.Time, t dunn
 		return fmt.Errorf("dunning emails day %d: query: %w", t.Day, err)
 	}
 
+	dayLabel := fmt.Sprintf("day_%d", t.Day)
+	periodKey := targetDay.Format("2006-01-02")
+
 	for _, r := range rows {
-		// TODO: wire real merchant email address when StoreSubscription.email
-		// column lands. Until then the store_id string is passed as the "to"
-		// address; NoOpClient logs intent without performing I/O.
-		if err := s.emailCl.Send(ctx, t.Template, r.StoreID, map[string]any{
-			"store_id": r.StoreID,
-			"day":      t.Day,
-		}); err != nil {
-			s.logger.Warn("dunning email send failed",
+		// Claim before sending. Dunning re-derives eligibility from
+		// audit_logs on every run, so without this a second run on the
+		// same day re-sends to the same merchants (#381).
+		won, err := subscription.ClaimEmailSend(ctx, s.db, r.SubscriptionID, string(t.Template), periodKey, now)
+		if err != nil {
+			s.logger.Error("dunning email: claim failed; skipping row",
 				"day", t.Day, "store_id", r.StoreID, "err", err.Error())
 			continue
 		}
+		if !won {
+			continue // already claimed by another pod or an earlier run
+		}
+
+		to := ""
+		if r.Email != nil {
+			to = *r.Email
+		}
+		invoiceURL := ""
+		if r.HostedInvoiceURL != nil {
+			invoiceURL = *r.HostedInvoiceURL
+		}
+
+		if err := email.ValidateRecipient(to); err != nil {
+			s.logger.Warn("dunning email not sent",
+				"day", t.Day, "store_id", r.StoreID,
+				"reason", email.SkipReason(err), "err", err.Error())
+			if s.skip != nil {
+				s.skip.WithTemplateReason(string(t.Template), email.SkipReason(err)).Inc()
+			}
+			continue
+		}
+
+		if err := s.emailCl.Send(ctx, t.Template, to, map[string]any{
+			"store_id":           r.StoreID,
+			"tenant_id":          r.TenantID,
+			"store_name":         r.StoreName,
+			"day":                t.Day,
+			"hosted_invoice_url": invoiceURL,
+		}); err != nil {
+			// Never increment the sent counter here. Before #381 this
+			// branch was unreachable because the client was a no-op that
+			// always returned nil, so the counter reported deliveries
+			// that never happened.
+			s.logger.Warn("dunning email not sent",
+				"day", t.Day, "store_id", r.StoreID,
+				"reason", email.SkipReason(err), "err", err.Error())
+			if s.skip != nil {
+				s.skip.WithTemplateReason(string(t.Template), email.SkipReason(err)).Inc()
+			}
+			continue
+		}
 		if s.counter != nil {
-			s.counter.WithDay(fmt.Sprintf("day_%d", t.Day)).Inc()
+			s.counter.WithDay(dayLabel).Inc()
 		}
 	}
 	return nil

--- a/services/marketplace-api/internal/subscription/dunning/dunning_emails.go
+++ b/services/marketplace-api/internal/subscription/dunning/dunning_emails.go
@@ -159,16 +159,6 @@ func (s *SendDunningEmails) runForDay(ctx context.Context, now time.Time, t dunn
 			invoiceURL = *r.HostedInvoiceURL
 		}
 
-		if err := email.ValidateRecipient(to); err != nil {
-			s.logger.Warn("dunning email not sent",
-				"day", t.Day, "store_id", r.StoreID,
-				"reason", email.SkipReason(err), "err", err.Error())
-			if s.skip != nil {
-				s.skip.WithTemplateReason(string(t.Template), email.SkipReason(err)).Inc()
-			}
-			continue
-		}
-
 		if err := s.emailCl.Send(ctx, t.Template, to, map[string]any{
 			"store_id":           r.StoreID,
 			"tenant_id":          r.TenantID,

--- a/services/marketplace-api/internal/subscription/dunning/dunning_emails.go
+++ b/services/marketplace-api/internal/subscription/dunning/dunning_emails.go
@@ -50,8 +50,8 @@ type emailRow struct {
 
 // SendDunningEmails is a daily cron that sends day-5 and day-7 nudge emails
 // to merchants whose subscription entered past_due status N days ago and is
-// still past_due. Email routing uses email.Client (NoOpClient until a real
-// adapter wires in).
+// still past_due. Email routing goes through email.Client — since #381 that
+// is the real template client (render → SendGrid → Resend), not a no-op.
 type SendDunningEmails struct {
 	db      *gorm.DB
 	emailCl email.Client

--- a/services/marketplace-api/internal/subscription/dunning/dunning_emails_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/dunning_emails_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mark8ly/marketplace-api/internal/audit"
 	"github.com/mark8ly/marketplace-api/internal/email"
@@ -46,7 +47,7 @@ func (c *capturingClient) count() int {
 // an audit entry 5 days ago receives the day-5 email, and one with a 7-day
 // audit entry receives the day-7 email.
 func TestSendDunningEmails_SendsOnDay5AndDay7(t *testing.T) {
-	db := testdb.NewDB(t, "audit_logs", "store_subscriptions")
+	db := testdb.NewDB(t, "audit_logs", "store_subscriptions", "billing_email_sends")
 
 	now := time.Now().UTC()
 	fiveDaysAgo := now.AddDate(0, 0, -5)
@@ -56,6 +57,7 @@ func TestSendDunningEmails_SendsOnDay5AndDay7(t *testing.T) {
 	storeA := uuid.New()
 	tenantA := uuid.New()
 	seedStore(t, db, tenantA, storeA)
+	emailA := "merchant-a@example.com"
 	subA := subscription.StoreSubscription{
 		ID:               uuid.New(),
 		TenantID:         tenantA,
@@ -63,6 +65,7 @@ func TestSendDunningEmails_SendsOnDay5AndDay7(t *testing.T) {
 		StripeCustomerID: "cus_a",
 		Plan:             subscription.PlanStarter,
 		Status:           subscription.StatusPastDue,
+		Email:            &emailA,
 	}
 	if err := db.Create(&subA).Error; err != nil {
 		t.Fatalf("seed subA: %v", err)
@@ -87,6 +90,7 @@ func TestSendDunningEmails_SendsOnDay5AndDay7(t *testing.T) {
 	storeB := uuid.New()
 	tenantB := uuid.New()
 	seedStore(t, db, tenantB, storeB)
+	emailB := "merchant-b@example.com"
 	subB := subscription.StoreSubscription{
 		ID:               uuid.New(),
 		TenantID:         tenantB,
@@ -94,6 +98,7 @@ func TestSendDunningEmails_SendsOnDay5AndDay7(t *testing.T) {
 		StripeCustomerID: "cus_b",
 		Plan:             subscription.PlanStarter,
 		Status:           subscription.StatusPastDue,
+		Email:            &emailB,
 	}
 	if err := db.Create(&subB).Error; err != nil {
 		t.Fatalf("seed subB: %v", err)
@@ -128,7 +133,7 @@ func TestSendDunningEmails_SendsOnDay5AndDay7(t *testing.T) {
 // TestSendDunningEmails_NoEmailIfSubNoLongerPastDue verifies that a sub that
 // entered past_due 5 days ago but is now active receives no email.
 func TestSendDunningEmails_NoEmailIfSubNoLongerPastDue(t *testing.T) {
-	db := testdb.NewDB(t, "audit_logs", "store_subscriptions")
+	db := testdb.NewDB(t, "audit_logs", "store_subscriptions", "billing_email_sends")
 
 	now := time.Now().UTC()
 	fiveDaysAgo := now.AddDate(0, 0, -5)
@@ -136,6 +141,7 @@ func TestSendDunningEmails_NoEmailIfSubNoLongerPastDue(t *testing.T) {
 	storeID := uuid.New()
 	tenantID := uuid.New()
 	seedStore(t, db, tenantID, storeID)
+	emailRecovered := "merchant-recovered@example.com"
 	sub := subscription.StoreSubscription{
 		ID:               uuid.New(),
 		TenantID:         tenantID,
@@ -143,6 +149,7 @@ func TestSendDunningEmails_NoEmailIfSubNoLongerPastDue(t *testing.T) {
 		StripeCustomerID: "cus_recovered",
 		Plan:             subscription.PlanStarter,
 		Status:           subscription.StatusActive, // recovered
+		Email:            &emailRecovered,
 	}
 	if err := db.Create(&sub).Error; err != nil {
 		t.Fatalf("seed sub: %v", err)
@@ -172,4 +179,82 @@ func TestSendDunningEmails_NoEmailIfSubNoLongerPastDue(t *testing.T) {
 	if got := client.count(); got != 0 {
 		t.Fatalf("expected 0 sends (sub recovered), got %d", got)
 	}
+}
+
+// stubClient records recipients and can fail on demand.
+type stubClient struct {
+	sent []string
+	err  error
+}
+
+func (c *stubClient) Send(_ context.Context, _ email.TemplateID, to string, _ map[string]any) error {
+	if c.err != nil {
+		return c.err
+	}
+	c.sent = append(c.sent, to)
+	return nil
+}
+
+// stubVec / stubSkip count increments by label.
+type stubVec struct{ n map[string]int }
+
+func (s *stubVec) WithDay(day string) dunning.CounterIncrementer {
+	if s.n == nil {
+		s.n = map[string]int{}
+	}
+	return stubInc{s.n, day}
+}
+
+type stubSkip struct{ n map[string]int }
+
+func (s *stubSkip) WithTemplateReason(template, reason string) dunning.CounterIncrementer {
+	if s.n == nil {
+		s.n = map[string]int{}
+	}
+	return stubInc{s.n, template + "/" + reason}
+}
+
+type stubInc struct {
+	n   map[string]int
+	key string
+}
+
+func (s stubInc) Inc() { s.n[s.key]++ }
+
+func TestDunning_UndeliverableCountsSkippedNotSent(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores", "audit_logs", "billing_email_sends")
+	now := time.Now().UTC()
+
+	placeholder := "billing+7f3a@mark8ly.local"
+	seedPastDueSubscription(t, db, now.AddDate(0, 0, -5), &placeholder)
+
+	client := &stubClient{}
+	sent, skipped := &stubVec{}, &stubSkip{}
+	cron := dunning.NewSendDunningEmails(db, client, nil, sent, func() time.Time { return now }).
+		WithSkipCounter(skipped)
+
+	require.NoError(t, cron.Run(context.Background()))
+
+	require.Empty(t, client.sent, "mailed a .local address")
+	require.Zero(t, sent.n["day_5"], "sent counter incremented for mail never sent — the #381 lie")
+	require.Equal(t, 1, skipped.n["dunning_day_5/placeholder_address"])
+}
+
+func TestDunning_SecondRunSameDayDoesNotResend(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores", "audit_logs", "billing_email_sends")
+	now := time.Now().UTC()
+
+	addr := "merchant@example.com"
+	seedPastDueSubscription(t, db, now.AddDate(0, 0, -5), &addr)
+
+	client := &stubClient{}
+	newCron := func() *dunning.SendDunningEmails {
+		return dunning.NewSendDunningEmails(db, client, nil, &stubVec{}, func() time.Time { return now })
+	}
+
+	require.NoError(t, newCron().Run(context.Background()))
+	require.Len(t, client.sent, 1, "first run should send exactly once")
+
+	require.NoError(t, newCron().Run(context.Background()))
+	require.Len(t, client.sent, 1, "second run re-sent — duplicate dunning mail")
 }

--- a/services/marketplace-api/internal/subscription/dunning/dunning_emails_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/dunning_emails_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/audit"
 	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 	"github.com/mark8ly/marketplace-api/internal/subscription/dunning"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
@@ -31,6 +32,13 @@ type capturedSend struct {
 }
 
 func (c *capturingClient) Send(_ context.Context, tmpl email.TemplateID, to string, _ map[string]any) error {
+	// Mirror the production client's contract: it refuses an
+	// undeliverable recipient and never reports success for mail it
+	// did not send. A double that skips this would let the cron pass
+	// tests the real client would fail.
+	if err := email.ValidateRecipient(to); err != nil {
+		return err
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.sends = append(c.sends, capturedSend{Template: tmpl, To: to})
@@ -188,6 +196,13 @@ type stubClient struct {
 }
 
 func (c *stubClient) Send(_ context.Context, _ email.TemplateID, to string, _ map[string]any) error {
+	// Mirror the production client's contract: it refuses an
+	// undeliverable recipient and never reports success for mail it
+	// did not send. A double that skips this would let the cron pass
+	// tests the real client would fail.
+	if err := email.ValidateRecipient(to); err != nil {
+		return err
+	}
 	if c.err != nil {
 		return c.err
 	}
@@ -257,4 +272,48 @@ func TestDunning_SecondRunSameDayDoesNotResend(t *testing.T) {
 
 	require.NoError(t, newCron().Run(context.Background()))
 	require.Len(t, client.sent, 1, "second run re-sent — duplicate dunning mail")
+}
+
+// captureSender records every Message handed to it — a tiny email.Sender
+// double used to prove the REAL email.templateClient's contract (recipient
+// validation, error classification) end-to-end through the dunning cron,
+// rather than trusting a hand-rolled client double to imitate it correctly.
+type captureSender struct {
+	mu   sync.Mutex
+	msgs []email.Message
+}
+
+func (s *captureSender) Send(_ context.Context, msg email.Message) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.msgs = append(s.msgs, msg)
+	return nil
+}
+
+// TestDunning_RealClientRefusesPlaceholderAddress wires the production
+// email.Client (NewTemplateClient) instead of a test double, so this test
+// fails if recipient validation is ever removed from the real client — a
+// double-only test wouldn't catch that regression.
+func TestDunning_RealClientRefusesPlaceholderAddress(t *testing.T) {
+	db := testdb.NewDB(t, "audit_logs", "store_subscriptions", "billing_email_sends")
+	now := time.Now().UTC()
+
+	placeholder := "billing+7f3a@mark8ly.local"
+	seedPastDueSubscription(t, db, now.AddDate(0, 0, -5), &placeholder)
+
+	// The real template client over a capturing transport — not a double.
+	loader := emailtemplates.NewLoader(nil)
+	email.RegisterFallbacks(loader)
+	sender := &captureSender{}
+	client := email.NewTemplateClient(loader, sender, "noreply@mark8ly.com", nil)
+
+	sent, skipped := &stubVec{}, &stubSkip{}
+	cron := dunning.NewSendDunningEmails(db, client, nil, sent, func() time.Time { return now }).
+		WithSkipCounter(skipped)
+
+	require.NoError(t, cron.Run(context.Background()))
+
+	require.Empty(t, sender.msgs, "a .local address reached the transport")
+	require.Zero(t, sent.n["day_5"], "counted a delivery that never happened")
+	require.Equal(t, 1, skipped.n["dunning_day_5/placeholder_address"])
 }

--- a/services/marketplace-api/internal/subscription/dunning/metrics_adapter.go
+++ b/services/marketplace-api/internal/subscription/dunning/metrics_adapter.go
@@ -28,3 +28,22 @@ type prometheusCounterVec struct{ cv *prometheus.CounterVec }
 func (p *prometheusCounterVec) WithDay(label string) CounterIncrementer {
 	return prometheusCounter{c: p.cv.WithLabelValues(label)}
 }
+
+// SkipCounter counts billing emails that were deliberately NOT sent,
+// labeled by template and reason. Defined here at the point of use rather
+// than in the metrics package so the crons stay testable with a stub.
+type SkipCounter interface {
+	WithTemplateReason(template, reason string) CounterIncrementer
+}
+
+// WrapPrometheusSkipCounter adapts a two-label *prometheus.CounterVec to
+// SkipCounter. Use with metrics.BillingEmailsSkippedTotal in main.go.
+func WrapPrometheusSkipCounter(cv *prometheus.CounterVec) SkipCounter {
+	return &prometheusSkipCounter{cv: cv}
+}
+
+type prometheusSkipCounter struct{ cv *prometheus.CounterVec }
+
+func (p *prometheusSkipCounter) WithTemplateReason(template, reason string) CounterIncrementer {
+	return prometheusCounter{c: p.cv.WithLabelValues(template, reason)}
+}

--- a/services/marketplace-api/internal/subscription/dunning/metrics_adapter_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/metrics_adapter_test.go
@@ -37,3 +37,24 @@ func TestWrapPrometheusCounterVec_WithDay_Inc(t *testing.T) {
 	assert.Equal(t, float64(2), testutil.ToFloat64(cv.WithLabelValues("day_5")))
 	assert.Equal(t, float64(1), testutil.ToFloat64(cv.WithLabelValues("day_7")))
 }
+
+// --- appended for #381 ---
+
+func TestWrapPrometheusSkipCounter_IncrementsLabelledSeries(t *testing.T) {
+	cv := prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "test_skipped_total", Help: "test"},
+		[]string{"template", "reason"},
+	)
+
+	sc := dunning.WrapPrometheusSkipCounter(cv)
+	sc.WithTemplateReason("dunning_day_5", "placeholder_address").Inc()
+	sc.WithTemplateReason("dunning_day_5", "placeholder_address").Inc()
+	sc.WithTemplateReason("dunning_day_7", "no_address").Inc()
+
+	if got := testutil.ToFloat64(cv.WithLabelValues("dunning_day_5", "placeholder_address")); got != 2 {
+		t.Errorf("day_5/placeholder = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(cv.WithLabelValues("dunning_day_7", "no_address")); got != 1 {
+		t.Errorf("day_7/no_address = %v, want 1", got)
+	}
+}

--- a/services/marketplace-api/internal/subscription/dunning/payment_action_reminders.go
+++ b/services/marketplace-api/internal/subscription/dunning/payment_action_reminders.go
@@ -39,6 +39,7 @@ type SendPaymentActionReminders struct {
 	logger  *slog.Logger
 	clock   func() time.Time
 	counter CounterVecIncrementer
+	skip    SkipCounter
 }
 
 // NewSendPaymentActionReminders constructs a SendPaymentActionReminders cron.
@@ -57,6 +58,13 @@ func NewSendPaymentActionReminders(db *gorm.DB, em email.Client, logger *slog.Lo
 		counter: counter,
 		clock:   clock,
 	}
+}
+
+// WithSkipCounter attaches the counter for emails deliberately not sent.
+// Optional: nil means skips are logged but not counted.
+func (s *SendPaymentActionReminders) WithSkipCounter(c SkipCounter) *SendPaymentActionReminders {
+	s.skip = c
+	return s
 }
 
 // Run executes one pass: for each offset (14d/7d/1d), finds subscriptions in
@@ -126,13 +134,28 @@ func (s *SendPaymentActionReminders) processOne(ctx context.Context, row *subscr
 		return nil
 	}
 
-	if err := s.emailCl.Send(ctx, email.TemplatePaymentActionReminder, row.StoreID.String(), map[string]any{
+	to := ""
+	if row.Email != nil {
+		to = *row.Email
+	}
+	invoiceURL := ""
+	if row.HostedInvoiceURL != nil {
+		invoiceURL = *row.HostedInvoiceURL
+	}
+
+	if err := s.emailCl.Send(ctx, email.TemplatePaymentActionReminder, to, map[string]any{
 		"store_id":           row.StoreID.String(),
+		"tenant_id":          row.TenantID.String(),
+		"store_name":         subscription.StoreNameFor(ctx, s.db, row.StoreID),
 		"offset":             t.OffsetKey,
-		"hosted_invoice_url": row.HostedInvoiceURL,
+		"hosted_invoice_url": invoiceURL,
 	}); err != nil {
-		s.logger.Warn("SCA reminder email failed",
-			"store_id", row.StoreID.String(), "offset", t.OffsetKey, "err", err.Error())
+		s.logger.Warn("SCA reminder not sent",
+			"store_id", row.StoreID.String(), "offset", t.OffsetKey,
+			"reason", email.SkipReason(err), "err", err.Error())
+		if s.skip != nil {
+			s.skip.WithTemplateReason(string(email.TemplatePaymentActionReminder), email.SkipReason(err)).Inc()
+		}
 		// Don't delete the idempotency row — we'd risk double-send on retry.
 		return nil
 	}

--- a/services/marketplace-api/internal/subscription/dunning/payment_action_reminders_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/payment_action_reminders_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mark8ly/marketplace-api/internal/audit"
 	"github.com/mark8ly/marketplace-api/internal/email"
@@ -40,6 +41,7 @@ func TestSCAReminders_SendsAtT14T7T1(t *testing.T) {
 		storeID := uuid.New()
 		tenantID := uuid.New()
 		seedStore(t, db, tenantID, storeID)
+		merchantEmail := "merchant-sca-" + o.key + "@example.com"
 		sub := subscription.StoreSubscription{
 			ID:               uuid.New(),
 			TenantID:         tenantID,
@@ -48,6 +50,7 @@ func TestSCAReminders_SendsAtT14T7T1(t *testing.T) {
 			Plan:             subscription.PlanStarter,
 			Status:           subscription.StatusPaymentActionRequired,
 			HostedInvoiceURL: &hostedURL,
+			Email:            &merchantEmail,
 		}
 		if err := db.Create(&sub).Error; err != nil {
 			t.Fatalf("seed sub (%s): %v", o.key, err)
@@ -93,6 +96,7 @@ func TestSCAReminders_Idempotent_OnConflict(t *testing.T) {
 	seedStore(t, db, tenantID, storeID)
 	fourteenDaysAgo := now.AddDate(0, 0, -14)
 
+	merchantEmail := "merchant-sca-idem@example.com"
 	sub := subscription.StoreSubscription{
 		ID:               uuid.New(),
 		TenantID:         tenantID,
@@ -101,6 +105,7 @@ func TestSCAReminders_Idempotent_OnConflict(t *testing.T) {
 		Plan:             subscription.PlanStarter,
 		Status:           subscription.StatusPaymentActionRequired,
 		HostedInvoiceURL: &hostedURL,
+		Email:            &merchantEmail,
 	}
 	if err := db.Create(&sub).Error; err != nil {
 		t.Fatalf("seed sub: %v", err)
@@ -153,6 +158,7 @@ func TestSCAReminders_SkipsSubsWithoutHostedInvoiceURL(t *testing.T) {
 	seedStore(t, db, tenantID, storeID)
 	fourteenDaysAgo := now.AddDate(0, 0, -14)
 
+	merchantEmail := "merchant-sca-no-url@example.com"
 	sub := subscription.StoreSubscription{
 		ID:               uuid.New(),
 		TenantID:         tenantID,
@@ -161,6 +167,7 @@ func TestSCAReminders_SkipsSubsWithoutHostedInvoiceURL(t *testing.T) {
 		Plan:             subscription.PlanStarter,
 		Status:           subscription.StatusPaymentActionRequired,
 		HostedInvoiceURL: nil, // no URL
+		Email:            &merchantEmail,
 	}
 	if err := db.Create(&sub).Error; err != nil {
 		t.Fatalf("seed sub: %v", err)
@@ -190,4 +197,56 @@ func TestSCAReminders_SkipsSubsWithoutHostedInvoiceURL(t *testing.T) {
 	if got := client.count(); got != 0 {
 		t.Fatalf("expected 0 sends (no hosted_invoice_url), got %d", got)
 	}
+}
+
+// TestPaymentActionReminders_UndeliverableCountsSkippedNotSent verifies that
+// a payment_action_required subscription seeded with a placeholder (.local)
+// address is not mailed, and the skip lands on the skip counter rather than
+// the sent counter.
+func TestPaymentActionReminders_UndeliverableCountsSkippedNotSent(t *testing.T) {
+	db := testdb.NewDB(t, "payment_action_reminders", "audit_logs", "store_subscriptions", "stores")
+
+	now := time.Now().UTC()
+	hostedURL := "https://invoice.stripe.com/i/placeholder-test"
+	storeID := uuid.New()
+	tenantID := uuid.New()
+	seedStore(t, db, tenantID, storeID)
+	placeholder := "billing+7f3a@mark8ly.local"
+	fourteenDaysAgo := now.AddDate(0, 0, -14)
+
+	sub := subscription.StoreSubscription{
+		ID:               uuid.New(),
+		TenantID:         tenantID,
+		StoreID:          storeID,
+		StripeCustomerID: "cus_placeholder",
+		Plan:             subscription.PlanStarter,
+		Status:           subscription.StatusPaymentActionRequired,
+		HostedInvoiceURL: &hostedURL,
+		Email:            &placeholder,
+	}
+	require.NoError(t, db.Create(&sub).Error)
+	auditEntry := audit.Entry{
+		ID:           uuid.New(),
+		TenantID:     tenantID,
+		StoreID:      &storeID,
+		ActorType:    audit.ActorSystem,
+		Action:       "subscription.state_transition",
+		ResourceType: "subscription",
+		Status:       audit.StatusSuccess,
+		Severity:     audit.SeverityWarning,
+		Metadata:     audit.Metadata{"to_status": "payment_action_required", "from_status": "active"},
+		CreatedAt:    fourteenDaysAgo,
+	}
+	require.NoError(t, db.Create(&auditEntry).Error)
+
+	client := &stubClient{}
+	sent, skipped := &stubVec{}, &stubSkip{}
+	cron := dunning.NewSendPaymentActionReminders(db, client, nil, sent, func() time.Time { return now }).
+		WithSkipCounter(skipped)
+
+	require.NoError(t, cron.Run(context.Background()))
+
+	require.Empty(t, client.sent, "mailed a .local address")
+	require.Zero(t, sent.n["t_minus_14"], "sent counter incremented for mail never sent")
+	require.Equal(t, 1, skipped.n["payment_action_reminder/placeholder_address"])
 }

--- a/services/marketplace-api/internal/subscription/dunning/sca_recovery_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/sca_recovery_integration_test.go
@@ -38,6 +38,7 @@ func TestSCARecovery_WebhookPaymentActionRequired_SCAReminders_InvoicePaidClears
 	seedStore(t, db, tenantID, storeID)
 	stripeCustomerID := "cus_sca_recovery_" + storeID.String()[:8]
 	hostedURL := "https://stripe.example/i/test"
+	merchantEmail := "merchant-sca-recovery@example.com"
 
 	// Seed an active subscription.
 	sub := subscription.StoreSubscription{
@@ -47,6 +48,7 @@ func TestSCARecovery_WebhookPaymentActionRequired_SCAReminders_InvoicePaidClears
 		StripeCustomerID: stripeCustomerID,
 		Plan:             subscription.PlanStarter,
 		Status:           subscription.StatusActive,
+		Email:            &merchantEmail,
 	}
 	if err := db.Create(&sub).Error; err != nil {
 		t.Fatalf("seed sub: %v", err)
@@ -122,8 +124,8 @@ func TestSCARecovery_WebhookPaymentActionRequired_SCAReminders_InvoicePaidClears
 	if call.Template != email.TemplatePaymentActionReminder {
 		t.Fatalf("expected template %q, got %q", email.TemplatePaymentActionReminder, call.Template)
 	}
-	if call.To != storeID.String() {
-		t.Fatalf("expected To = store_id %q, got %q", storeID.String(), call.To)
+	if call.To != merchantEmail {
+		t.Fatalf("expected To = merchant email %q, got %q", merchantEmail, call.To)
 	}
 
 	// Assert idempotency row inserted for (store_id, t_minus_14).

--- a/services/marketplace-api/internal/subscription/dunning/testhelpers_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/testhelpers_integration_test.go
@@ -5,9 +5,13 @@ package dunning_test
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
 )
 
 // seedStore inserts a minimal stores row for (tenantID, storeID) so that a
@@ -44,4 +48,49 @@ func seedStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
 	t.Cleanup(func() {
 		db.Exec("DELETE FROM stores WHERE id = ?", storeID)
 	})
+}
+
+// seedPastDueSubscription inserts a stores row, a past_due
+// store_subscriptions row with the given email, and the audit_logs entry
+// recording the transition INTO past_due at transitionedAt. It mirrors the
+// exact seeding shape used by TestSendDunningEmails_SendsOnDay5AndDay7 so
+// dunning cron tests share one source of truth for what "eligible" means.
+func seedPastDueSubscription(t *testing.T, db *gorm.DB, transitionedAt time.Time, emailAddr *string) (subscriptionID, storeID, tenantID uuid.UUID) {
+	t.Helper()
+
+	storeID = uuid.New()
+	tenantID = uuid.New()
+	seedStore(t, db, tenantID, storeID)
+
+	subscriptionID = uuid.New()
+	sub := subscription.StoreSubscription{
+		ID:               subscriptionID,
+		TenantID:         tenantID,
+		StoreID:          storeID,
+		StripeCustomerID: "cus_" + strings.ReplaceAll(subscriptionID.String(), "-", "")[:14],
+		Plan:             subscription.PlanStarter,
+		Status:           subscription.StatusPastDue,
+		Email:            emailAddr,
+	}
+	if err := db.Create(&sub).Error; err != nil {
+		t.Fatalf("seedPastDueSubscription: seed subscription: %v", err)
+	}
+
+	auditEntry := audit.Entry{
+		ID:           uuid.New(),
+		TenantID:     tenantID,
+		StoreID:      &storeID,
+		ActorType:    audit.ActorSystem,
+		Action:       "subscription.state_transition",
+		ResourceType: "subscription",
+		Status:       audit.StatusSuccess,
+		Severity:     audit.SeverityInfo,
+		Metadata:     audit.Metadata{"to_status": "past_due", "from_status": "active"},
+		CreatedAt:    transitionedAt,
+	}
+	if err := db.Create(&auditEntry).Error; err != nil {
+		t.Fatalf("seedPastDueSubscription: seed audit: %v", err)
+	}
+
+	return subscriptionID, storeID, tenantID
 }

--- a/services/marketplace-api/internal/subscription/dunning/trial_reminders.go
+++ b/services/marketplace-api/internal/subscription/dunning/trial_reminders.go
@@ -68,6 +68,7 @@ type SendTrialReminders struct {
 	logger  *slog.Logger
 	clock   func() time.Time
 	counter CounterVecIncrementer
+	skip    SkipCounter
 }
 
 // NewSendTrialReminders constructs a SendTrialReminders cron. db and emailCl
@@ -86,6 +87,13 @@ func NewSendTrialReminders(db *gorm.DB, em email.Client, logger *slog.Logger, co
 		counter: counter,
 		clock:   clock,
 	}
+}
+
+// WithSkipCounter attaches the counter for emails deliberately not sent.
+// Optional: nil means skips are logged but not counted.
+func (s *SendTrialReminders) WithSkipCounter(c SkipCounter) *SendTrialReminders {
+	s.skip = c
+	return s
 }
 
 // Run executes one pass through every reminder target. Per-offset failures
@@ -157,24 +165,30 @@ func (s *SendTrialReminders) processOne(ctx context.Context, row *subscription.S
 		return nil
 	}
 
-	// TODO: trial reminder email recipient — the StoreSubscription row does
-	// not yet carry an email/store_name pair. Mirroring the placeholder used
-	// by trial.ExpiryCron and SendPaymentActionReminders, we pass StoreID as
-	// the recipient string for now; the real recipient is resolved by the
-	// email adapter via tenant lookup. Revisit when the columns land.
-	if err := s.emailCl.Send(ctx, t.Template, row.StoreID.String(), map[string]any{
+	to := ""
+	if row.Email != nil {
+		to = *row.Email
+	}
+
+	if err := s.emailCl.Send(ctx, t.Template, to, map[string]any{
 		"store_id":           row.StoreID.String(),
 		"tenant_id":          row.TenantID.String(),
+		"store_name":         subscription.StoreNameFor(ctx, s.db, row.StoreID),
 		"offset":             t.OffsetKey,
 		"days_remaining":     t.DaysBefore,
 		"has_payment_method": t.HasPM,
 		"plan":               string(row.Plan),
 	}); err != nil {
-		s.logger.Warn("trial reminder email failed",
+		s.logger.Warn("trial reminder not sent",
 			"store_id", row.StoreID.String(),
 			"offset", t.OffsetKey,
+			"reason", email.SkipReason(err),
 			"err", err.Error())
-		// Do not delete the idempotency row — preserves at-most-once semantics.
+		if s.skip != nil {
+			s.skip.WithTemplateReason(string(t.Template), email.SkipReason(err)).Inc()
+		}
+		// Do not delete the idempotency row — that would risk a double-send.
+		// At-most-once is the deliberate contract: see the spec, §6.
 		return nil
 	}
 

--- a/services/marketplace-api/internal/subscription/dunning/trial_reminders.go
+++ b/services/marketplace-api/internal/subscription/dunning/trial_reminders.go
@@ -151,6 +151,30 @@ func (s *SendTrialReminders) runForOffset(ctx context.Context, now time.Time, t 
 // skip without sending. Email-send failures intentionally do NOT delete the
 // idempotency row — that would risk a double-send on the next tick.
 func (s *SendTrialReminders) processOne(ctx context.Context, row *subscription.StoreSubscription, t trialReminderTarget, now time.Time) error {
+	// The has-PM T-1 template tells the merchant "your <plan> plan begins
+	// tomorrow — we will charge the card on file". has_default_payment_method
+	// is mirrored from Stripe's invoice_settings.default_payment_method and
+	// says nothing about whether a plan was ever selected, so a merchant who
+	// attached a card but never finished plan selection is still on
+	// plan='trial' and nothing will be charged: no Stripe subscription exists.
+	// Sending would be a false billing statement, so skip it.
+	//
+	// The guard sits BEFORE the idempotency claim deliberately. The slot must
+	// stay unclaimed: if the merchant selects a plan before the trial ends, a
+	// later tick should still be able to send them a correct reminder. Nothing
+	// is sent here, so there is no double-send for the claim to protect against.
+	if t.HasPM && row.Plan == subscription.PlanTrial {
+		s.logger.Warn("trial reminder skipped: plan still 'trial' at a billing reminder — merchant has a card but never selected a plan",
+			"store_id", row.StoreID.String(),
+			"tenant_id", row.TenantID.String(),
+			"offset", t.OffsetKey,
+			"reason", "plan_unresolved")
+		if s.skip != nil {
+			s.skip.WithTemplateReason(string(t.Template), "plan_unresolved").Inc()
+		}
+		return nil
+	}
+
 	res := s.db.WithContext(ctx).Exec(`
 		INSERT INTO trial_reminders (subscription_id, tenant_id, store_id, offset_key, sent_at)
 		VALUES (?, ?, ?, ?, ?)

--- a/services/marketplace-api/internal/subscription/dunning/trial_reminders_extension_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/trial_reminders_extension_integration_test.go
@@ -26,7 +26,7 @@ func (r *recordingEmail) Send(_ context.Context, template email.TemplateID, to s
 	return nil
 }
 
-func seedTrialSub(t *testing.T, db *gorm.DB, createdAt time.Time, trialEndsAt *time.Time, hasPM bool) subscription.StoreSubscription {
+func seedTrialSub(t *testing.T, db *gorm.DB, createdAt time.Time, trialEndsAt *time.Time, hasPM bool, emailAddr *string) subscription.StoreSubscription {
 	t.Helper()
 	tenantID, storeID := uuid.New(), uuid.New()
 	seedStore(t, db, tenantID, storeID)
@@ -37,6 +37,7 @@ func seedTrialSub(t *testing.T, db *gorm.DB, createdAt time.Time, trialEndsAt *t
 		HasDefaultPaymentMethod: hasPM,
 		CreatedAt:               createdAt,
 		TrialEndsAt:             trialEndsAt,
+		Email:                   emailAddr,
 	}
 	require.NoError(t, db.Create(&sub).Error)
 	return sub
@@ -53,7 +54,8 @@ func TestTrialReminders_FireRelativeToTheExtendedEnd(t *testing.T) {
 	created := now.Add(-75 * 24 * time.Hour)
 	// Real end is 60 days away, so nothing should fire today.
 	extended := now.Add(60 * 24 * time.Hour)
-	sub := seedTrialSub(t, db, created, &extended, false)
+	merchantEmail := "merchant@example.com"
+	sub := seedTrialSub(t, db, created, &extended, false, &merchantEmail)
 
 	rec := &recordingEmail{}
 	cron := dunning.NewSendTrialReminders(db, rec, nil, nil, func() time.Time { return now })
@@ -77,7 +79,8 @@ func TestTrialReminders_FireOnTheExtendedEndsT15(t *testing.T) {
 	// value can put this row in the T-15 bucket.
 	created := now.Add(-200 * 24 * time.Hour)
 	extended := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC) // 15 days out
-	sub := seedTrialSub(t, db, created, &extended, false)
+	merchantEmail := "merchant@example.com"
+	sub := seedTrialSub(t, db, created, &extended, false, &merchantEmail)
 
 	rec := &recordingEmail{}
 	cron := dunning.NewSendTrialReminders(db, rec, nil, nil, func() time.Time { return now })

--- a/services/marketplace-api/internal/subscription/dunning/trial_reminders_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/trial_reminders_integration_test.go
@@ -4,11 +4,13 @@ package dunning_test
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mark8ly/marketplace-api/internal/billing/trial"
 	"github.com/mark8ly/marketplace-api/internal/email"
@@ -51,6 +53,7 @@ func TestTrialReminders_SendsAtAllNoPMOffsets(t *testing.T) {
 		tenantID := uuid.New()
 		storeID := uuid.New()
 		seedStore(t, db, tenantID, storeID)
+		merchantEmail := "merchant-" + c.desc + "@example.com"
 		sub := subscription.StoreSubscription{
 			ID:                      uuid.New(),
 			TenantID:                tenantID,
@@ -60,6 +63,7 @@ func TestTrialReminders_SendsAtAllNoPMOffsets(t *testing.T) {
 			Status:                  subscription.StatusTrialing,
 			HasDefaultPaymentMethod: c.hasPM,
 			CreatedAt:               created,
+			Email:                   &merchantEmail,
 		}
 		if err := db.Create(&sub).Error; err != nil {
 			t.Fatalf("seed sub (%s): %v", c.desc, err)
@@ -101,6 +105,7 @@ func TestTrialReminders_HasPMSendsOnlyT1(t *testing.T) {
 	tenantID := uuid.New()
 	storeID := uuid.New()
 	seedStore(t, db, tenantID, storeID)
+	merchantEmail := "merchant-haspm@example.com"
 	sub := subscription.StoreSubscription{
 		ID:                      uuid.New(),
 		TenantID:                tenantID,
@@ -110,6 +115,7 @@ func TestTrialReminders_HasPMSendsOnlyT1(t *testing.T) {
 		Status:                  subscription.StatusTrialing,
 		HasDefaultPaymentMethod: true,
 		CreatedAt:               created,
+		Email:                   &merchantEmail,
 	}
 	if err := db.Create(&sub).Error; err != nil {
 		t.Fatalf("seed: %v", err)
@@ -142,6 +148,7 @@ func TestTrialReminders_Idempotent(t *testing.T) {
 	tenantID := uuid.New()
 	storeID := uuid.New()
 	seedStore(t, db, tenantID, storeID)
+	merchantEmail := "merchant-idem@example.com"
 	sub := subscription.StoreSubscription{
 		ID:                      uuid.New(),
 		TenantID:                tenantID,
@@ -151,6 +158,7 @@ func TestTrialReminders_Idempotent(t *testing.T) {
 		Status:                  subscription.StatusTrialing,
 		HasDefaultPaymentMethod: false,
 		CreatedAt:               created,
+		Email:                   &merchantEmail,
 	}
 	if err := db.Create(&sub).Error; err != nil {
 		t.Fatalf("seed: %v", err)
@@ -191,6 +199,7 @@ func TestTrialReminders_TenantIsolation(t *testing.T) {
 		tenantID := uuid.New()
 		storeID := uuid.New()
 		seedStore(t, db, tenantID, storeID)
+		merchantEmail := "merchant-iso-" + suffix + "@example.com"
 		sub := subscription.StoreSubscription{
 			ID:                      uuid.New(),
 			TenantID:                tenantID,
@@ -200,6 +209,7 @@ func TestTrialReminders_TenantIsolation(t *testing.T) {
 			Status:                  subscription.StatusTrialing,
 			HasDefaultPaymentMethod: false,
 			CreatedAt:               created,
+			Email:                   &merchantEmail,
 		}
 		if err := db.Create(&sub).Error; err != nil {
 			t.Fatalf("seed %s: %v", suffix, err)
@@ -231,6 +241,7 @@ func TestTrialReminders_ExpiredSubsAreSkipped(t *testing.T) {
 	tenantID := uuid.New()
 	storeID := uuid.New()
 	seedStore(t, db, tenantID, storeID)
+	merchantEmail := "merchant-expired@example.com"
 	sub := subscription.StoreSubscription{
 		ID:                      uuid.New(),
 		TenantID:                tenantID,
@@ -240,6 +251,7 @@ func TestTrialReminders_ExpiredSubsAreSkipped(t *testing.T) {
 		Status:                  subscription.StatusExpired,
 		HasDefaultPaymentMethod: false,
 		CreatedAt:               created,
+		Email:                   &merchantEmail,
 	}
 	if err := db.Create(&sub).Error; err != nil {
 		t.Fatalf("seed: %v", err)
@@ -253,4 +265,46 @@ func TestTrialReminders_ExpiredSubsAreSkipped(t *testing.T) {
 	if got := client.count(); got != 0 {
 		t.Fatalf("expected 0 sends (expired sub), got %d", got)
 	}
+}
+
+// TestTrialReminders_UndeliverableCountsSkippedNotSent verifies that a trial
+// subscription seeded with a placeholder (.local) address is not mailed, and
+// that the skip is recorded on the skip counter rather than the sent
+// counter — the same #381-style lie this cron must not repeat.
+func TestTrialReminders_UndeliverableCountsSkippedNotSent(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores", "trial_reminders")
+	now := time.Now().UTC()
+
+	placeholder := "billing+7f3a@mark8ly.local"
+	// A trial ending in 7 days, with no payment method — the t_minus_7 nudge.
+	seedTrialSub(t, db, now.AddDate(0, 0, -83), nil, false, &placeholder)
+
+	client := &stubClient{}
+	sent, skipped := &stubVec{}, &stubSkip{}
+	cron := dunning.NewSendTrialReminders(db, client, nil, sent, func() time.Time { return now }).
+		WithSkipCounter(skipped)
+
+	require.NoError(t, cron.Run(context.Background()))
+
+	require.Empty(t, client.sent, "mailed a .local address")
+	require.Zero(t, sent.n["t_minus_7"], "sent counter incremented for mail never sent")
+	require.Equal(t, 1, skipped.n["trial_no_pm_t7/placeholder_address"])
+}
+
+// The claim is deliberately NOT released on failure: at-most-once beats a
+// duplicate. This pins that contract so nobody "fixes" it into at-least-once.
+func TestTrialReminders_FailedSendDoesNotReleaseTheClaim(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores", "trial_reminders")
+	now := time.Now().UTC()
+
+	addr := "merchant@example.com"
+	seedTrialSub(t, db, now.AddDate(0, 0, -83), nil, false, &addr)
+
+	client := &stubClient{err: errors.New("sendgrid 503")}
+	cron := dunning.NewSendTrialReminders(db, client, nil, &stubVec{}, func() time.Time { return now })
+	require.NoError(t, cron.Run(context.Background()))
+
+	var claims int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM trial_reminders`).Scan(&claims).Error)
+	require.EqualValues(t, 1, claims, "the burned slot must stay claimed")
 }

--- a/services/marketplace-api/internal/subscription/dunning/trial_reminders_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/trial_reminders_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/billing/trial"
 	"github.com/mark8ly/marketplace-api/internal/email"
@@ -307,4 +308,70 @@ func TestTrialReminders_FailedSendDoesNotReleaseTheClaim(t *testing.T) {
 	var claims int64
 	require.NoError(t, db.Raw(`SELECT count(*) FROM trial_reminders`).Scan(&claims).Error)
 	require.EqualValues(t, 1, claims, "the burned slot must stay claimed")
+}
+
+// seedHasPMTrialSub seeds a T-1 has-payment-method trial subscription with the
+// given plan, so the two tests below differ only in the plan column.
+func seedHasPMTrialSub(t *testing.T, db *gorm.DB, now time.Time, plan subscription.SubscriptionPlan, addr string) {
+	t.Helper()
+	created := time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, time.UTC).
+		AddDate(0, 0, -(trial.TrialDays - 1))
+	tenantID, storeID := uuid.New(), uuid.New()
+	seedStore(t, db, tenantID, storeID)
+	require.NoError(t, db.Create(&subscription.StoreSubscription{
+		ID:                      uuid.New(),
+		TenantID:                tenantID,
+		StoreID:                 storeID,
+		StripeCustomerID:        "cus_" + storeID.String()[:8],
+		Plan:                    plan,
+		Status:                  subscription.StatusTrialing,
+		HasDefaultPaymentMethod: true,
+		CreatedAt:               created,
+		Email:                   &addr,
+	}).Error)
+}
+
+// trial_has_pm_t1 says "your <plan> plan begins tomorrow — we will charge the
+// card on file". has_default_payment_method is mirrored from Stripe and is
+// independent of plan selection, so a merchant who attached a card but never
+// picked a plan is still on plan='trial' and will not be charged: nothing was
+// ever subscribed. Sending would be a false billing statement.
+func TestTrialReminders_HasPMT1SkippedWhenPlanStillTrial(t *testing.T) {
+	db := testdb.NewDB(t, "trial_reminders", "store_subscriptions", "stores")
+	now := time.Now().UTC()
+
+	seedHasPMTrialSub(t, db, now, subscription.PlanTrial, "merchant-plan-trial@example.com")
+
+	client := &capturingClient{}
+	skipped := &stubSkip{}
+	cron := dunning.NewSendTrialReminders(db, client, slog.Default(), nil, func() time.Time { return now }).
+		WithSkipCounter(skipped)
+	require.NoError(t, cron.Run(context.Background()))
+
+	require.Zero(t, client.count(), "told a merchant they are about to be charged with no plan recorded")
+	require.Equal(t, 1, skipped.n[string(email.TemplateTrialHasPMT1)+"/plan_unresolved"])
+
+	// The idempotency slot must stay free: if the merchant picks a plan before
+	// the trial ends, a later tick has to be able to send a correct reminder.
+	var claims int64
+	require.NoError(t, db.Raw(
+		`SELECT count(*) FROM trial_reminders WHERE offset_key = 'has_pm_t_minus_1'`).Scan(&claims).Error)
+	require.EqualValues(t, 0, claims, "the slot was burned; a correct reminder can never be sent")
+}
+
+// The counterpart to the test above: with a real plan the reminder must still
+// go out. Without this assertion the guard could silently disable the whole
+// template and nothing would notice.
+func TestTrialReminders_HasPMT1StillSendsWithRealPlan(t *testing.T) {
+	db := testdb.NewDB(t, "trial_reminders", "store_subscriptions", "stores")
+	now := time.Now().UTC()
+
+	seedHasPMTrialSub(t, db, now, subscription.PlanStarter, "merchant-plan-starter@example.com")
+
+	client := &capturingClient{}
+	cron := dunning.NewSendTrialReminders(db, client, slog.Default(), nil, func() time.Time { return now })
+	require.NoError(t, cron.Run(context.Background()))
+
+	require.Equal(t, 1, client.count(), "a merchant on a real plan must still get the T-1 heads-up")
+	require.Equal(t, email.TemplateTrialHasPMT1, client.sends[0].Template)
 }

--- a/services/marketplace-api/internal/subscription/email_claim.go
+++ b/services/marketplace-api/internal/subscription/email_claim.go
@@ -1,0 +1,35 @@
+package subscription
+
+// email_claim.go — claim-first idempotency for billing mail (#381).
+//
+// The contract mirrors payment_action_reminders: claim the slot BEFORE
+// sending, and never release it on a send failure. That makes delivery
+// at-most-once — a transient provider error costs the merchant that one
+// notice rather than risking a duplicate. The failure is visible through
+// the caller's skipped counter and Warn log.
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// ClaimEmailSend attempts to claim (subscriptionID, templateKey, periodKey).
+//
+// Returns true when this caller inserted the row and is therefore the one
+// that must send. Returns false when the slot was already claimed — by
+// another pod, or by an earlier run of the same cron today.
+func ClaimEmailSend(ctx context.Context, db *gorm.DB, subscriptionID uuid.UUID, templateKey, periodKey string, now time.Time) (bool, error) {
+	res := db.WithContext(ctx).Exec(`
+		INSERT INTO billing_email_sends (subscription_id, template_key, period_key, sent_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT DO NOTHING`,
+		subscriptionID, templateKey, periodKey, now,
+	)
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}

--- a/services/marketplace-api/internal/subscription/email_claim_integration_test.go
+++ b/services/marketplace-api/internal/subscription/email_claim_integration_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+
+package subscription_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+func TestClaimEmailSend_SecondClaimLoses(t *testing.T) {
+	db := testdb.NewDB(t, "billing_email_sends")
+	ctx := context.Background()
+	subID := uuid.New()
+	now := time.Now().UTC()
+
+	won, err := subscription.ClaimEmailSend(ctx, db, subID, "dunning_day_5", "2026-08-26", now)
+	if err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if !won {
+		t.Fatal("first claim did not win")
+	}
+
+	won, err = subscription.ClaimEmailSend(ctx, db, subID, "dunning_day_5", "2026-08-26", now)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if won {
+		t.Error("second claim won — duplicate mail would be sent")
+	}
+}
+
+func TestClaimEmailSend_DifferentTemplateAndPeriodBothWin(t *testing.T) {
+	db := testdb.NewDB(t, "billing_email_sends")
+	ctx := context.Background()
+	subID := uuid.New()
+	now := time.Now().UTC()
+
+	if won, err := subscription.ClaimEmailSend(ctx, db, subID, "dunning_day_5", "2026-08-26", now); err != nil || !won {
+		t.Fatalf("day_5 claim: won=%v err=%v", won, err)
+	}
+	// A day-7 notice after a day-5 one is legitimate, not a duplicate.
+	if won, err := subscription.ClaimEmailSend(ctx, db, subID, "dunning_day_7", "2026-08-26", now); err != nil || !won {
+		t.Errorf("day_7 same date should win: won=%v err=%v", won, err)
+	}
+	// The same template in a later period is also legitimate.
+	if won, err := subscription.ClaimEmailSend(ctx, db, subID, "dunning_day_5", "2026-09-26", now); err != nil || !won {
+		t.Errorf("day_5 later period should win: won=%v err=%v", won, err)
+	}
+}

--- a/services/marketplace-api/internal/subscription/lifecycle/winback.go
+++ b/services/marketplace-api/internal/subscription/lifecycle/winback.go
@@ -18,17 +18,30 @@ const WinBackSpec = "0 10 * * *"
 const winBack30Days = 30 * 24 * time.Hour
 
 // WinBackCron sends a 20%-off-6-months promo email to expired stores at day 30
-// post-expiry (§15.3). It is idempotent by design: stores already past 31 days
-// are never selected, so double-runs on the same day produce the same send.
+// post-expiry (§15.3).
+//
+// Idempotence comes from the billing_email_sends claim, NOT from the window
+// query. The window selects the same rows on every run within the same day —
+// before #381 the comment here claimed that was idempotent, which it was only
+// because the client was a no-op that never sent anything.
 //
 // NOTE: The actual promo code attachment (P10 promo service) is deferred.
-// Until P10 is wired this cron sends only the notification email via the
-// email.NoOpClient facade established in P6.
 type WinBackCron struct {
 	db     *gorm.DB
 	mailer email.Client
 	logger *slog.Logger
 	clock  func() time.Time
+	skip   SkipCounter
+}
+
+// CounterIncrementer is a one-method counter so tests can stub it.
+type CounterIncrementer interface{ Inc() }
+
+// SkipCounter counts win-back emails deliberately not sent, labeled by
+// template and reason. Declared here rather than imported from the dunning
+// package so lifecycle keeps its current dependency set.
+type SkipCounter interface {
+	WithTemplateReason(template, reason string) CounterIncrementer
 }
 
 // NewWinBackCron constructs a WinBackCron.
@@ -40,6 +53,12 @@ func NewWinBackCron(db *gorm.DB, mailer email.Client, logger *slog.Logger, clock
 		logger = slog.Default()
 	}
 	return &WinBackCron{db: db, mailer: mailer, logger: logger, clock: clock}
+}
+
+// WithSkipCounter attaches the skipped-delivery counter. Optional.
+func (c *WinBackCron) WithSkipCounter(sc SkipCounter) *WinBackCron {
+	c.skip = sc
+	return c
 }
 
 // Run selects expired subscriptions whose updated_at is exactly in the 30-day
@@ -58,27 +77,44 @@ func (c *WinBackCron) Run(ctx context.Context) error {
 		return err
 	}
 	c.logger.Info("lifecycle: win-back cron started", "eligible", len(rows))
+	periodKey := windowStart.Format("2006-01-02")
 	for i := range rows {
-		c.sendOne(ctx, &rows[i])
+		c.sendOne(ctx, &rows[i], periodKey, now)
 	}
 	return nil
 }
 
-func (c *WinBackCron) sendOne(ctx context.Context, row *subscription.StoreSubscription) {
-	// StripeCustomerID is the stable identity for the merchant. Email address
-	// is not on StoreSubscription (deferred per P6 comment); the NoOpClient
-	// logs the intent and the real adapter will resolve it via Stripe customer lookup.
-	err := c.mailer.Send(ctx, email.TemplateWinBack, row.StripeCustomerID, map[string]any{
-		"store_id":  row.StoreID.String(),
-		"tenant_id": row.TenantID.String(),
-		"promo":     "20%-off-6-months",
-		"note":      "email resolved by adapter from stripe_customer_id",
-	})
+func (c *WinBackCron) sendOne(ctx context.Context, row *subscription.StoreSubscription, periodKey string, now time.Time) {
+	won, err := subscription.ClaimEmailSend(ctx, c.db, row.ID, string(email.TemplateWinBack), periodKey, now)
 	if err != nil {
-		c.logger.Error("lifecycle: win-back email failed",
-			"store_id", row.StoreID, "tenant_id", row.TenantID, "err", err)
+		c.logger.Error("lifecycle: win-back claim failed; skipping",
+			"store_id", row.StoreID, "err", err.Error())
 		return
 	}
-	c.logger.Info("lifecycle: win-back email sent (or logged by no-op adapter)",
+	if !won {
+		return // already sent for this window
+	}
+
+	to := ""
+	if row.Email != nil {
+		to = *row.Email
+	}
+
+	err = c.mailer.Send(ctx, email.TemplateWinBack, to, map[string]any{
+		"store_id":   row.StoreID.String(),
+		"tenant_id":  row.TenantID.String(),
+		"store_name": subscription.StoreNameFor(ctx, c.db, row.StoreID),
+		"promo":      "20%-off-6-months",
+	})
+	if err != nil {
+		c.logger.Warn("lifecycle: win-back email not sent",
+			"store_id", row.StoreID, "tenant_id", row.TenantID,
+			"reason", email.SkipReason(err), "err", err.Error())
+		if c.skip != nil {
+			c.skip.WithTemplateReason(string(email.TemplateWinBack), email.SkipReason(err)).Inc()
+		}
+		return
+	}
+	c.logger.Info("lifecycle: win-back email sent",
 		"store_id", row.StoreID, "tenant_id", row.TenantID)
 }

--- a/services/marketplace-api/internal/subscription/lifecycle/winback.go
+++ b/services/marketplace-api/internal/subscription/lifecycle/winback.go
@@ -77,14 +77,22 @@ func (c *WinBackCron) Run(ctx context.Context) error {
 		return err
 	}
 	c.logger.Info("lifecycle: win-back cron started", "eligible", len(rows))
-	periodKey := windowStart.Format("2006-01-02")
 	for i := range rows {
-		c.sendOne(ctx, &rows[i], periodKey, now)
+		c.sendOne(ctx, &rows[i], now)
 	}
 	return nil
 }
 
-func (c *WinBackCron) sendOne(ctx context.Context, row *subscription.StoreSubscription, periodKey string, now time.Time) {
+func (c *WinBackCron) sendOne(ctx context.Context, row *subscription.StoreSubscription, now time.Time) {
+	// The period key is anchored to the row's own updated_at, not to the
+	// cron's wall-clock windowStart. Eligibility here is a sliding window,
+	// so two runs (e.g. a missed run followed by a catch-up near a UTC day
+	// boundary) can both select the same row with different windowStart
+	// values. A wall-clock key would then differ between the two runs and
+	// the claim would let both through — two win-back emails. Deriving the
+	// key from row.UpdatedAt guarantees any two runs that select this row
+	// agree on the same key, so the second claim always loses.
+	periodKey := row.UpdatedAt.UTC().Format("2006-01-02")
 	won, err := subscription.ClaimEmailSend(ctx, c.db, row.ID, string(email.TemplateWinBack), periodKey, now)
 	if err != nil {
 		c.logger.Error("lifecycle: win-back claim failed; skipping",

--- a/services/marketplace-api/internal/subscription/lifecycle/winback.go
+++ b/services/marketplace-api/internal/subscription/lifecycle/winback.go
@@ -17,11 +17,6 @@ const WinBackSpec = "0 10 * * *"
 // winBack30Days is the post-expiry window after which the win-back promo is sent.
 const winBack30Days = 30 * 24 * time.Hour
 
-// TemplateWinBack is the email template ID for the day-30 win-back promo.
-// The actual template lives in the email provider (SendGrid); the NoOpClient
-// logs it until the real adapter is wired.
-const TemplateWinBack email.TemplateID = "win_back_day30"
-
 // WinBackCron sends a 20%-off-6-months promo email to expired stores at day 30
 // post-expiry (§15.3). It is idempotent by design: stores already past 31 days
 // are never selected, so double-runs on the same day produce the same send.
@@ -73,7 +68,7 @@ func (c *WinBackCron) sendOne(ctx context.Context, row *subscription.StoreSubscr
 	// StripeCustomerID is the stable identity for the merchant. Email address
 	// is not on StoreSubscription (deferred per P6 comment); the NoOpClient
 	// logs the intent and the real adapter will resolve it via Stripe customer lookup.
-	err := c.mailer.Send(ctx, TemplateWinBack, row.StripeCustomerID, map[string]any{
+	err := c.mailer.Send(ctx, email.TemplateWinBack, row.StripeCustomerID, map[string]any{
 		"store_id":  row.StoreID.String(),
 		"tenant_id": row.TenantID.String(),
 		"promo":     "20%-off-6-months",

--- a/services/marketplace-api/internal/subscription/lifecycle/winback.go
+++ b/services/marketplace-api/internal/subscription/lifecycle/winback.go
@@ -32,6 +32,7 @@ type WinBackCron struct {
 	logger *slog.Logger
 	clock  func() time.Time
 	skip   SkipCounter
+	sent   SentCounter
 }
 
 // CounterIncrementer is a one-method counter so tests can stub it.
@@ -42,6 +43,14 @@ type CounterIncrementer interface{ Inc() }
 // package so lifecycle keeps its current dependency set.
 type SkipCounter interface {
 	WithTemplateReason(template, reason string) CounterIncrementer
+}
+
+// SentCounter counts win-back emails actually delivered, labeled by
+// template. Without it there would be no sent counter for win_back_day30 at
+// all, and the sent+skipped identity documented on
+// metrics.BillingEmailsSkippedTotal would be false for this template.
+type SentCounter interface {
+	WithTemplate(template string) CounterIncrementer
 }
 
 // NewWinBackCron constructs a WinBackCron.
@@ -58,6 +67,12 @@ func NewWinBackCron(db *gorm.DB, mailer email.Client, logger *slog.Logger, clock
 // WithSkipCounter attaches the skipped-delivery counter. Optional.
 func (c *WinBackCron) WithSkipCounter(sc SkipCounter) *WinBackCron {
 	c.skip = sc
+	return c
+}
+
+// WithSentCounter attaches the delivered-email counter. Optional.
+func (c *WinBackCron) WithSentCounter(sc SentCounter) *WinBackCron {
+	c.sent = sc
 	return c
 }
 
@@ -122,6 +137,9 @@ func (c *WinBackCron) sendOne(ctx context.Context, row *subscription.StoreSubscr
 			c.skip.WithTemplateReason(string(email.TemplateWinBack), email.SkipReason(err)).Inc()
 		}
 		return
+	}
+	if c.sent != nil {
+		c.sent.WithTemplate(string(email.TemplateWinBack)).Inc()
 	}
 	c.logger.Info("lifecycle: win-back email sent",
 		"store_id", row.StoreID, "tenant_id", row.TenantID)

--- a/services/marketplace-api/internal/subscription/lifecycle/winback.go
+++ b/services/marketplace-api/internal/subscription/lifecycle/winback.go
@@ -112,6 +112,9 @@ func (c *WinBackCron) sendOne(ctx context.Context, row *subscription.StoreSubscr
 	if err != nil {
 		c.logger.Error("lifecycle: win-back claim failed; skipping",
 			"store_id", row.StoreID, "err", err.Error())
+		if c.skip != nil {
+			c.skip.WithTemplateReason(string(email.TemplateWinBack), "claim_failed").Inc()
+		}
 		return
 	}
 	if !won {

--- a/services/marketplace-api/internal/subscription/lifecycle/winback_integration_test.go
+++ b/services/marketplace-api/internal/subscription/lifecycle/winback_integration_test.go
@@ -162,6 +162,38 @@ func TestWinBack_SecondRunSameDayDoesNotResend(t *testing.T) {
 // email.Client (NewTemplateClient) instead of a test double, so this test
 // fails if recipient validation is ever removed from the real client — a
 // double-only test wouldn't catch that regression.
+// TestWinBack_OverlappingRunsAcrossClockDoNotResend uses two DIFFERENT
+// clocks (12h apart) whose windows both cover the same seeded row, unlike
+// TestWinBack_SecondRunSameDayDoesNotResend which reuses one clock and so
+// cannot distinguish a row-anchored period key from a wall-clock one. Under
+// a wall-clock key (`windowStart.Format(...)`), the two runs' windowStart
+// values fall on different calendar dates here, so the row claims under two
+// different period keys and gets mailed twice — the bug this task exists to
+// close. Under a row-anchored key the two runs agree on the same period key
+// and the second claim loses.
+func TestWinBack_OverlappingRunsAcrossClockDoNotResend(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores", "billing_email_sends")
+	// Fixed anchor (not time.Now()) so the two windowStart values are
+	// guaranteed to land on different calendar dates regardless of when
+	// this test runs.
+	now := time.Date(2026, 8, 20, 23, 0, 0, 0, time.UTC)
+
+	addr := "merchant@example.com"
+	seedExpired(t, db, now, &addr)
+
+	client := &stubClient{}
+	firstRunNow := now
+	secondRunNow := now.Add(12 * time.Hour)
+
+	firstCron := lifecycle.NewWinBackCron(db, client, nil, func() time.Time { return firstRunNow })
+	require.NoError(t, firstCron.Run(context.Background()))
+	require.Len(t, client.sent, 1, "first run should send exactly once")
+
+	secondCron := lifecycle.NewWinBackCron(db, client, nil, func() time.Time { return secondRunNow })
+	require.NoError(t, secondCron.Run(context.Background()))
+	require.Len(t, client.sent, 1, "second run (different clock, overlapping window) re-sent — duplicate win-back mail")
+}
+
 func TestWinBack_RealClientRefusesPlaceholderAddress(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions", "stores", "billing_email_sends")
 	now := time.Now().UTC()

--- a/services/marketplace-api/internal/subscription/lifecycle/winback_integration_test.go
+++ b/services/marketplace-api/internal/subscription/lifecycle/winback_integration_test.go
@@ -1,0 +1,185 @@
+//go:build integration
+
+package lifecycle_test
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/internal/subscription/lifecycle"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// stubClient mirrors the production client's contract: it refuses an
+// undeliverable recipient and never reports success for mail it did not
+// send. A double that skips this would let the cron pass tests the real
+// client would fail.
+type stubClient struct {
+	sent []string
+	err  error
+}
+
+func (c *stubClient) Send(_ context.Context, _ email.TemplateID, to string, _ map[string]any) error {
+	if err := email.ValidateRecipient(to); err != nil {
+		return err
+	}
+	if c.err != nil {
+		return c.err
+	}
+	c.sent = append(c.sent, to)
+	return nil
+}
+
+type stubSkip struct{ n map[string]int }
+
+func (s *stubSkip) WithTemplateReason(template, reason string) lifecycle.CounterIncrementer {
+	if s.n == nil {
+		s.n = map[string]int{}
+	}
+	return stubInc{s.n, template + "/" + reason}
+}
+
+type stubInc struct {
+	n   map[string]int
+	key string
+}
+
+func (s stubInc) Inc() { s.n[s.key]++ }
+
+// captureSender records every Message handed to it — a tiny email.Sender
+// double used to prove the REAL email.templateClient's contract (recipient
+// validation, error classification) end-to-end through the win-back cron,
+// rather than trusting a hand-rolled client double to imitate it correctly.
+type captureSender struct {
+	mu   sync.Mutex
+	msgs []email.Message
+}
+
+func (s *captureSender) Send(_ context.Context, msg email.Message) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.msgs = append(s.msgs, msg)
+	return nil
+}
+
+// seedStore inserts a minimal stores row for (tenantID, storeID) so that a
+// store_subscriptions row referencing storeID satisfies
+// store_subscriptions_store_id_fkey. Copied from the dunning package's
+// helper of the same name — lifecycle has no shared test helper package to
+// draw from and neither package imports the other's test files.
+func seedStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
+	t.Helper()
+
+	slug := "tst-" + strings.ReplaceAll(storeID.String(), "-", "")[:20]
+
+	err := db.Exec(
+		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, encode(gen_random_bytes(32), 'hex'))`,
+		storeID, tenantID, slug, "Test Store", "IE", "EUR", "Europe/Dublin", "active",
+	).Error
+	if err != nil {
+		t.Fatalf("seedStore: insert stores row: %v", err)
+	}
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM stores WHERE id = ?", storeID)
+	})
+}
+
+// seedExpired inserts an expired subscription whose updated_at sits inside
+// the 30-31 day win-back window, then forces updated_at past GORM's
+// autoupdate (which would otherwise stamp now()).
+func seedExpired(t *testing.T, db *gorm.DB, now time.Time, addr *string) subscription.StoreSubscription {
+	t.Helper()
+
+	storeID := uuid.New()
+	tenantID := uuid.New()
+	seedStore(t, db, tenantID, storeID)
+
+	sub := subscription.StoreSubscription{
+		TenantID:         tenantID,
+		StoreID:          storeID,
+		StripeCustomerID: "cus_" + uuid.NewString()[:12],
+		Status:           subscription.StatusExpired,
+		Email:            addr,
+	}
+	require.NoError(t, db.Create(&sub).Error)
+	require.NoError(t, db.Exec(
+		`UPDATE store_subscriptions SET updated_at = ? WHERE id = ?`,
+		now.Add(-30*24*time.Hour-time.Hour), sub.ID).Error)
+	return sub
+}
+
+func TestWinBack_UndeliverableIsSkippedNotSent(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores", "billing_email_sends")
+	now := time.Now().UTC()
+
+	placeholder := "billing+7f3a@mark8ly.local"
+	seedExpired(t, db, now, &placeholder)
+
+	client := &stubClient{}
+	skipped := &stubSkip{}
+	cron := lifecycle.NewWinBackCron(db, client, nil, func() time.Time { return now }).
+		WithSkipCounter(skipped)
+
+	require.NoError(t, cron.Run(context.Background()))
+
+	require.Empty(t, client.sent, "mailed a .local address")
+	require.Equal(t, 1, skipped.n["win_back_day30/placeholder_address"])
+}
+
+func TestWinBack_SecondRunSameDayDoesNotResend(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores", "billing_email_sends")
+	now := time.Now().UTC()
+
+	addr := "merchant@example.com"
+	seedExpired(t, db, now, &addr)
+
+	client := &stubClient{}
+	newCron := func() *lifecycle.WinBackCron {
+		return lifecycle.NewWinBackCron(db, client, nil, func() time.Time { return now })
+	}
+
+	require.NoError(t, newCron().Run(context.Background()))
+	require.Len(t, client.sent, 1, "first run should send exactly once")
+
+	require.NoError(t, newCron().Run(context.Background()))
+	require.Len(t, client.sent, 1, "second run re-sent — duplicate win-back mail")
+}
+
+// TestWinBack_RealClientRefusesPlaceholderAddress wires the production
+// email.Client (NewTemplateClient) instead of a test double, so this test
+// fails if recipient validation is ever removed from the real client — a
+// double-only test wouldn't catch that regression.
+func TestWinBack_RealClientRefusesPlaceholderAddress(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores", "billing_email_sends")
+	now := time.Now().UTC()
+
+	placeholder := "billing+7f3a@mark8ly.local"
+	seedExpired(t, db, now, &placeholder)
+
+	loader := emailtemplates.NewLoader(nil)
+	email.RegisterFallbacks(loader)
+	sender := &captureSender{}
+	client := email.NewTemplateClient(loader, sender, "noreply@mark8ly.com", nil)
+
+	skipped := &stubSkip{}
+	cron := lifecycle.NewWinBackCron(db, client, slog.Default(), func() time.Time { return now }).
+		WithSkipCounter(skipped)
+
+	require.NoError(t, cron.Run(context.Background()))
+
+	require.Empty(t, sender.msgs, "a .local address reached the transport")
+	require.Equal(t, 1, skipped.n["win_back_day30/placeholder_address"])
+}

--- a/services/marketplace-api/internal/subscription/models.go
+++ b/services/marketplace-api/internal/subscription/models.go
@@ -104,10 +104,10 @@ const (
 // StoreSubscription is the GORM model for the store_subscriptions table.
 // Column definitions must stay aligned with migrations 036-040.
 type StoreSubscription struct {
-	ID                   uuid.UUID          `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()"`
-	TenantID             uuid.UUID          `gorm:"column:tenant_id;type:uuid;not null;index:ss_tenant_idx"`
-	StoreID              uuid.UUID          `gorm:"column:store_id;type:uuid;not null;uniqueIndex"`
-	StripeCustomerID     string             `gorm:"column:stripe_customer_id;type:varchar(100);not null"`
+	ID               uuid.UUID `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()"`
+	TenantID         uuid.UUID `gorm:"column:tenant_id;type:uuid;not null;index:ss_tenant_idx"`
+	StoreID          uuid.UUID `gorm:"column:store_id;type:uuid;not null;uniqueIndex"`
+	StripeCustomerID string    `gorm:"column:stripe_customer_id;type:varchar(100);not null"`
 	// Email is the merchant's billing address, mirrored from the Stripe
 	// customer by handleCustomerUpdated and backfilled by cmd/backfill-email
 	// (migration 104, #381). NULL means "not known yet" — every mailer

--- a/services/marketplace-api/internal/subscription/models.go
+++ b/services/marketplace-api/internal/subscription/models.go
@@ -108,6 +108,11 @@ type StoreSubscription struct {
 	TenantID             uuid.UUID          `gorm:"column:tenant_id;type:uuid;not null;index:ss_tenant_idx"`
 	StoreID              uuid.UUID          `gorm:"column:store_id;type:uuid;not null;uniqueIndex"`
 	StripeCustomerID     string             `gorm:"column:stripe_customer_id;type:varchar(100);not null"`
+	// Email is the merchant's billing address, mirrored from the Stripe
+	// customer by handleCustomerUpdated and backfilled by cmd/backfill-email
+	// (migration 104, #381). NULL means "not known yet" — every mailer
+	// refuses to send and counts a skip rather than guessing.
+	Email                *string            `gorm:"column:email;type:citext"`
 	StripeSubscriptionID *string            `gorm:"column:stripe_subscription_id;type:varchar(100)"`
 	Plan                 SubscriptionPlan   `gorm:"column:plan;type:varchar(30);not null;default:trial"`
 	Status               SubscriptionStatus `gorm:"column:status;type:varchar(30);not null;default:signup"`

--- a/services/marketplace-api/internal/subscription/models.go
+++ b/services/marketplace-api/internal/subscription/models.go
@@ -154,6 +154,7 @@ type StoreSubscription struct {
 
 	// v2.3 P6 — SCA fallback + dunning refund-window guard (§4.7, §16.5).
 	// HostedInvoiceURL is populated by invoice.payment_action_required and
+	// invoice.payment_failed (the dunning ladder's emails link to it) and
 	// cleared on invoice.paid. FirstChargeAt is stamped once on the first
 	// successful invoice.paid and never updated thereafter — it anchors the
 	// 14-day refund window that blocks ladder-driven expiry.

--- a/services/marketplace-api/internal/subscription/store_name.go
+++ b/services/marketplace-api/internal/subscription/store_name.go
@@ -1,0 +1,29 @@
+package subscription
+
+// store_name.go — the merchant-facing store name for email copy.
+//
+// The crons load StoreSubscription rows, which carry no name; the name lives
+// in the local `stores` projection. A scalar lookup per row is acceptable on
+// the reminder paths, which process tens of rows daily. The dunning ladder
+// joins instead, being the higher-volume path.
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// StoreNameFor returns the store's display name, or "your store" when the
+// local projection has no row yet. Never returns an error: a cosmetic field
+// must not be able to stop a billing email.
+func StoreNameFor(ctx context.Context, db *gorm.DB, storeID uuid.UUID) string {
+	var name string
+	err := db.WithContext(ctx).
+		Raw(`SELECT name FROM stores WHERE id = ?`, storeID).
+		Scan(&name).Error
+	if err != nil || name == "" {
+		return "your store"
+	}
+	return name
+}

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 103
+const ExpectedSchemaVersion uint = 105

--- a/services/marketplace-api/migrations/000104_store_subscriptions_email.down.sql
+++ b/services/marketplace-api/migrations/000104_store_subscriptions_email.down.sql
@@ -1,0 +1,9 @@
+-- DESTRUCTIVE: drops every merchant billing address mirrored from Stripe.
+-- Recoverable by re-running cmd/backfill-email, since Stripe remains the
+-- source of truth — but every cron reverts to sending nothing in the
+-- meantime, because a NULL recipient is refused.
+--
+-- The citext extension is deliberately NOT dropped: other objects may depend
+-- on it, and dropping a shared extension during a rollback is how you take
+-- down unrelated tables.
+ALTER TABLE store_subscriptions DROP COLUMN IF EXISTS email;

--- a/services/marketplace-api/migrations/000104_store_subscriptions_email.up.sql
+++ b/services/marketplace-api/migrations/000104_store_subscriptions_email.up.sql
@@ -1,0 +1,16 @@
+-- Billing mail needs somewhere to send to (#381). Until now dunning, trial
+-- reminder, payment-action, win-back and trial-billed mailers passed a store
+-- UUID as the "to" address, which was harmless only because every one of them
+-- was wired to a no-op client.
+--
+-- NULL means "not known yet" and is explicitly expected: customer.updated only
+-- fires on change, so rows predating this column stay NULL until
+-- cmd/backfill-email reads them from Stripe. A NULL recipient is refused by
+-- email.ValidateRecipient and counted as skipped — never sent, never counted
+-- as delivered.
+--
+-- citext because email comparison is case-insensitive and we do not want two
+-- rows differing only by case to read as different merchants.
+CREATE EXTENSION IF NOT EXISTS citext;
+
+ALTER TABLE store_subscriptions ADD COLUMN IF NOT EXISTS email CITEXT;

--- a/services/marketplace-api/migrations/000105_billing_email_sends.down.sql
+++ b/services/marketplace-api/migrations/000105_billing_email_sends.down.sql
@@ -1,0 +1,6 @@
+-- DESTRUCTIVE: drops every claim marker. Rolling back past 105 means the
+-- next dunning or win-back run re-sends to every merchant currently inside
+-- an eligibility window — real duplicate mail to real merchants, not just
+-- lost bookkeeping.
+DROP INDEX IF EXISTS billing_email_sends_sent_at_idx;
+DROP TABLE IF EXISTS billing_email_sends;

--- a/services/marketplace-api/migrations/000105_billing_email_sends.up.sql
+++ b/services/marketplace-api/migrations/000105_billing_email_sends.up.sql
@@ -11,9 +11,15 @@
 -- payment_action_reminders should eventually be folded in.
 --
 -- period_key disambiguates repeats of the same template for the same
--- subscription: the target date for dunning, the window-start date for
--- win-back. template_key alone would suppress a legitimate day-7 notice
--- after a day-5 one; period_key alone would collide across templates.
+-- subscription. Its meaning is per-template and chosen so that any two runs
+-- selecting the same row agree on the same key:
+--   dunning              — the target date;
+--   win_back_day30       — the row's own updated_at date (NOT the cron's
+--                          window-start, which drifts between runs);
+--   trial_started_billed — the constant 'first_charge', because that email
+--                          fires at most once in a subscription's life.
+-- template_key alone would suppress a legitimate day-7 notice after a day-5
+-- one; period_key alone would collide across templates.
 CREATE TABLE IF NOT EXISTS billing_email_sends (
     subscription_id UUID        NOT NULL,
     template_key    TEXT        NOT NULL,

--- a/services/marketplace-api/migrations/000105_billing_email_sends.up.sql
+++ b/services/marketplace-api/migrations/000105_billing_email_sends.up.sql
@@ -1,0 +1,28 @@
+-- Claim-first idempotency for billing mail (#381).
+--
+-- trial_reminders and payment_action_reminders already do this per-feature.
+-- Dunning and win-back did not: both re-derive eligibility on every run
+-- (dunning from audit_logs date arithmetic, win-back from an updated_at
+-- window), so a second run on the same day re-sent to the same merchants.
+-- That was invisible while every send was a no-op.
+--
+-- Generic rather than two more bespoke tables: four near-identical marker
+-- tables is three too many, and this is where trial_reminders and
+-- payment_action_reminders should eventually be folded in.
+--
+-- period_key disambiguates repeats of the same template for the same
+-- subscription: the target date for dunning, the window-start date for
+-- win-back. template_key alone would suppress a legitimate day-7 notice
+-- after a day-5 one; period_key alone would collide across templates.
+CREATE TABLE IF NOT EXISTS billing_email_sends (
+    subscription_id UUID        NOT NULL,
+    template_key    TEXT        NOT NULL,
+    period_key      TEXT        NOT NULL,
+    sent_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (subscription_id, template_key, period_key)
+);
+
+-- Supports the operational question "what did we send this store, when?"
+-- without scanning; the primary key already covers the claim path.
+CREATE INDEX IF NOT EXISTS billing_email_sends_sent_at_idx
+    ON billing_email_sends (sent_at DESC);


### PR DESCRIPTION
Fixes #381.

## What was wrong

`email.Client` had exactly one implementation in the estate — `NoOpClient`, which logged and returned `nil` — wired at three sites in `cmd/marketplace-api/main.go`. Between them those cover every template the interface declares.

**No merchant has ever received a dunning notice, a trial-expiry reminder, a payment-action reminder, a win-back promo, or a trial-billed confirmation.**

Two things made it worse than a missing adapter:

- The crons increment `*_sent_total` whenever `Send` returns `nil`, and the no-op always did. Dashboards showed dunning working perfectly. Same family as the dead outbox gauge in #375 — except that one read zero, and this one read a plausible non-zero.
- The recipient argument was a **store UUID**, not an email address (and a Stripe customer id in the win-back cron). Dropping in a real adapter would have attempted delivery to a UUID.

## What this does

**The address.** New nullable `store_subscriptions.email` (`citext`, migration 104), written by the `customer.updated` webhook handler that already updates that table — one extra field in the same statement — plus `cmd/backfill-email` for rows predating the column, modelled on the existing `cmd/backfill-has-pm`.

**The client.** `email.NewTemplateClient` renders through the existing `emailtemplates.Loader` and delegates to the existing SendGrid→Resend chain, so billing mail inherits the same failover and attribution as the five mailers that already worked. Its contract is the invariant everything else rests on: **`Send` returns `nil` if and only if a provider accepted the message.** Undeliverable recipients (empty, malformed, or the `billing+<uuid>@mark8ly.local` placeholders this service mints at bootstrap) return a typed `ErrUndeliverable`, never `nil`.

**The templates.** Eleven keys registered against the shared loader with embedded fallbacks, so operators can reword billing copy without a deploy.

**Idempotency.** Trial and payment-action reminders already claimed a slot before sending. Dunning and win-back did not — both re-derived eligibility on every run, so a second run the same day re-sent. Harmless behind a no-op; duplicate billing mail with a real sender. New `billing_email_sends` claim table (migration 105) closes it.

**The counters.** No code moved. The increment placement was always correct — increment-after-`Send`-returns-`nil`. What was fake was the implementation behind it. A new `billing_emails_skipped_total{template,reason}` makes the refused population visible rather than merely absent.

## Found by the whole-branch review

Every one of the 13 task-level reviews came back clean. The branch-wide pass then found two Critical defects, both cross-task interactions no single diff could show:

- **`cmd/backfill-email` set `updated_at = now()`.** Win-back uses `updated_at` as *both* its eligibility window and its idempotency key. Running the backfill — which the command's own docs instruct — would have reset the whole table: 30 days of silence, then the entire historical expired cohort told simultaneously that their store "closed a month ago". Stores mid-window would have lost their win-back permanently.
- **The trial-billed confirmation sent inside the webhook transaction.** The dispatcher chains a second `invoice.paid` handler and rolls back on its error — after the mail had already gone. Stripe retries, merchant gets it twice. The comment above it asserted idempotency that only holds after commit.

Also fixed: `LogSender` returned `nil` with no provider key configured, which would have re-created the original lie one missing secret away; the eleven templates were being seeded as *published* DB rows, so future edits to the embedded copy would never have reached merchants.

## Two behaviour changes worth calling out

- **`hosted_invoice_url` is now persisted on `invoice.payment_failed`**, not only on the SCA path. It previously had one writer, so the ordinary dunning cohort rendered the fallback branch and the day-5/day-7 emails — the two immediately preceding suspension — shipped with no payment link at all.
- **Trial-plan sends are skipped while `plan` is still `trial`.** `trial_has_pm_t1` fires on "has a card", independently of plan selection, so a merchant who attached a card but never chose a plan was told "we will charge the card on file" when nothing would be charged. Skipped and logged at `Warn` with reason `plan_unresolved` rather than sending a false billing statement.

## Test plan

- [x] Full integration suite diffed against `d52b5cd2` **in both directions**: **zero new failures**. Branch 187 unique failures vs 191 at baseline — this branch *fixes* 4 pre-existing FK-seeding failures in `dispatcher_test.go`.
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `gofmt -l .` all clean.
- [x] Undeliverable recipients never reach the transport, and never increment a sent counter — pinned by tests wiring the **real** client, not a double.
- [x] Claim-before-send suppression proven for dunning and win-back by two-run tests; the win-back one uses two clocks 12h apart, and fails with two emails under the pre-fix key.
- [x] Template lint catches a misspelled variable in subject, HTML and text for all 11 keys (`html/template` renders a missing key as empty, so output assertions alone were not enough).
- [ ] **Deploy sequencing — needs a human.** Migrations 104/105 land, then `cmd/backfill-email` runs to completion (start with `--dry-run` and read the `Placeholder`/`NoneInStripe` counts — that is the population that still gets nothing), and only then the new image. Serving before the backfill is not dangerous (every row counts as `skipped{reason="no_address"}`) but it burns that day's trial-reminder idempotency slots, and those do not come back.
- [ ] Confirm `SENDGRID_API_KEY`/`RESEND_API_KEY` are present in the target environment. Without them the client now reports `skipped{reason="no_provider"}` rather than false success — correct, but nothing will be delivered.

## Known follow-ups (not in this PR)

- Neither `hosted_invoice_url` write stamps `updated_at` any more — a late-review catch, because `store_subscriptions.updated_at` is simultaneously the win-back eligibility window, the win-back idempotency key, the expired→store_closed timer and the 150-day hard-delete cutoff. Stamping it as a side effect of bookkeeping moves all four.
- The trial-billed send still happens inside a `pg_advisory_xact_lock` on a 5-connection pool, with a provider HTTP call against Stripe's 30s webhook timeout. It fires once per merchant lifetime and a timed-out retry now loses its claim rather than duplicating, but an outbox row would be the right shape.
- `payment_action_reminders` stores a store id in a column named `subscription_id` (pre-existing). Anyone folding these per-feature marker tables into `billing_email_sends` later needs to know.
- All four crons claim before discovering an address is undeliverable, so a merchant backfilled on day 6 has already lost their day-5 notice. A one-time migration-window artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MGRGtY6SWG5ocFKctLoEb
