### PR TITLE
Fix/360 harddelete sweep

### DIFF
--- a/services/marketplace-api/internal/subscription/harddelete/sweep_via_parent_integration_test.go
+++ b/services/marketplace-api/internal/subscription/harddelete/sweep_via_parent_integration_test.go
@@ -1,0 +1,369 @@
+//go:build integration
+
+// Package harddelete_test covers the §15.2 hard-delete sweep (issue #360):
+// nine tables in the Sweep list have no store_id column of their own, so
+// `DELETE FROM <table> WHERE store_id = ?` raised SQLSTATE 42703 on the
+// first one, aborted the transaction, and the 150-day GDPR hard-delete
+// never completed for any store. These tests seed rows in all nine tables
+// (plus the parent each is reached through), run Sweep, and assert every
+// row disappears — for the swept store only.
+package harddelete_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/subscription/harddelete"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// nineTableFixture is the id of every row seeded by seedNineTableFixture,
+// keyed by table name, so tests can assert on exact rows rather than just
+// counts.
+type nineTableFixture struct {
+	reviewID   uuid.UUID
+	loyaltyID  uuid.UUID
+	campaignID uuid.UUID
+	giftCardID uuid.UUID
+	couponID   uuid.UUID
+	ticketID   uuid.UUID
+	productID  uuid.UUID
+	categoryID uuid.UUID
+	orderID    uuid.UUID
+}
+
+// swweptTables lists every table (parents + the nine store_id-less
+// children) seedNineTableFixture populates, in an order safe for cleanup
+// (children before parents; TRUNCATE ... CASCADE makes strict order
+// unnecessary but this keeps the list self-documenting).
+var sweptTables = []string{
+	"review_reactions", "review_replies", "review_media", "reviews",
+	"loyalty_transactions", "customer_loyalties",
+	"campaign_recipients", "campaigns",
+	"gift_card_transactions", "gift_cards",
+	"coupon_usage", "coupons",
+	"ticket_replies", "tickets",
+	"product_categories", "products", "categories", "vendors",
+	"customer_profiles",
+	"orders",
+	"audit_logs",
+	"stores",
+}
+
+// seedNineTableFixture inserts a store plus one row in each of the nine
+// store_id-less tables named in issue #360 (and the parent each is FK'd
+// to). It returns the ids needed to assert on specific rows.
+func seedNineTableFixture(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) nineTableFixture {
+	t.Helper()
+
+	slug := "tst-" + strings.ReplaceAll(storeID.String(), "-", "")[:20]
+	require.NoError(t, db.Exec(
+		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, encode(gen_random_bytes(32), 'hex'))`,
+		storeID, tenantID, slug, "Test Store", "IE", "EUR", "Europe/Dublin", "active",
+	).Error, "seed stores")
+
+	// vendors (products.vendor_id is NOT NULL as of migration 000028).
+	vendorID := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO vendors (id, tenant_id, name, slug) VALUES (?, ?, ?, ?)`,
+		vendorID, tenantID, "Test Vendor", "vendor-"+vendorID.String()[:20],
+	).Error, "seed vendors")
+
+	// products + categories (parents of product_categories).
+	productID := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO products (id, tenant_id, store_id, handle, title, vendor_id) VALUES (?, ?, ?, ?, ?, ?)`,
+		productID, tenantID, storeID, "prod-"+productID.String()[:8], "Test Product", vendorID,
+	).Error, "seed products")
+
+	categoryID := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO categories (id, tenant_id, store_id, name, slug) VALUES (?, ?, ?, ?, ?)`,
+		categoryID, tenantID, storeID, "Test Category", "cat-"+categoryID.String()[:8],
+	).Error, "seed categories")
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO product_categories (product_id, category_id) VALUES (?, ?)`,
+		productID, categoryID,
+	).Error, "seed product_categories")
+
+	// customer_profiles (parent of review_reactions).
+	customerProfileID := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO customer_profiles (id, tenant_id, store_id, email) VALUES (?, ?, ?, ?)`,
+		customerProfileID, tenantID, storeID, "cust-"+customerProfileID.String()[:8]+"@example.com",
+	).Error, "seed customer_profiles")
+
+	// reviews (parent of review_reactions/review_replies/review_media).
+	reviewID := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO reviews (id, tenant_id, store_id, product_id, customer_name, customer_email, rating, content)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		reviewID, tenantID, storeID, productID, "Test Customer", "reviewer-"+reviewID.String()[:8]+"@example.com", 5, "Great product",
+	).Error, "seed reviews")
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO review_reactions (id, review_id, customer_profile_id, reaction) VALUES (?, ?, ?, ?)`,
+		uuid.New(), reviewID, customerProfileID, "helpful",
+	).Error, "seed review_reactions")
+	require.NoError(t, db.Exec(
+		`INSERT INTO review_replies (id, review_id, author_type, author_name, content) VALUES (?, ?, ?, ?, ?)`,
+		uuid.New(), reviewID, "merchant", "Store Owner", "Thanks!",
+	).Error, "seed review_replies")
+	require.NoError(t, db.Exec(
+		`INSERT INTO review_media (id, review_id, url) VALUES (?, ?, ?)`,
+		uuid.New(), reviewID, "https://example.com/photo.jpg",
+	).Error, "seed review_media")
+
+	// customer_loyalties (parent of loyalty_transactions).
+	loyaltyID := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO customer_loyalties (id, tenant_id, store_id, customer_email, referral_code)
+		 VALUES (?, ?, ?, ?, ?)`,
+		loyaltyID, tenantID, storeID, "loyal-"+loyaltyID.String()[:8]+"@example.com", loyaltyID.String()[:8],
+	).Error, "seed customer_loyalties")
+	require.NoError(t, db.Exec(
+		`INSERT INTO loyalty_transactions (id, tenant_id, loyalty_id, type, points, balance_after)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		uuid.New(), tenantID, loyaltyID, "earn", 10, 10,
+	).Error, "seed loyalty_transactions")
+
+	// campaigns (parent of campaign_recipients).
+	campaignID := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO campaigns (id, tenant_id, store_id, name) VALUES (?, ?, ?, ?)`,
+		campaignID, tenantID, storeID, "Test Campaign",
+	).Error, "seed campaigns")
+	require.NoError(t, db.Exec(
+		`INSERT INTO campaign_recipients (id, tenant_id, campaign_id, customer_email) VALUES (?, ?, ?, ?)`,
+		uuid.New(), tenantID, campaignID, "recipient-"+campaignID.String()[:8]+"@example.com",
+	).Error, "seed campaign_recipients")
+
+	// gift_cards (parent of gift_card_transactions).
+	giftCardID := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO gift_cards (id, tenant_id, store_id, code, initial_balance, current_balance, currency_code)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		giftCardID, tenantID, storeID, "GC-"+giftCardID.String()[:8], 100, 100, "EUR",
+	).Error, "seed gift_cards")
+	require.NoError(t, db.Exec(
+		`INSERT INTO gift_card_transactions (id, tenant_id, gift_card_id, type, amount, balance_after)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		uuid.New(), tenantID, giftCardID, "redeem", 10, 90,
+	).Error, "seed gift_card_transactions")
+
+	// orders (needed for coupon_usage.order_id NOT NULL FK — no cascade, so
+	// coupon_usage must be swept before orders; see the ordering note in
+	// Sweep's comment).
+	orderID := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO orders (id, tenant_id, store_id, order_number, idempotency_key, customer_email, subtotal, grand_total, currency_code)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		orderID, tenantID, storeID, "ORD-"+orderID.String()[:8], "idem-"+orderID.String(), "buyer-"+orderID.String()[:8]+"@example.com", 10, 10, "EUR",
+	).Error, "seed orders")
+
+	// coupons (parent of coupon_usage).
+	couponID := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO coupons (id, tenant_id, store_id, code, title, type, value) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		couponID, tenantID, storeID, "CODE-"+couponID.String()[:8], "Test Coupon", "percentage", 10,
+	).Error, "seed coupons")
+	require.NoError(t, db.Exec(
+		`INSERT INTO coupon_usage (id, tenant_id, coupon_id, order_id, customer_email, discount_amount, currency_code)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		uuid.New(), tenantID, couponID, orderID, "buyer-"+couponID.String()[:8]+"@example.com", 1, "EUR",
+	).Error, "seed coupon_usage")
+
+	// tickets (parent of ticket_replies).
+	ticketID := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO tickets (id, tenant_id, store_id, ticket_number, subject, description, submitted_by_name, submitted_by_email)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		ticketID, tenantID, storeID, "TKT-"+ticketID.String()[:8], "Help", "I need help", "Test Customer", "ticket-"+ticketID.String()[:8]+"@example.com",
+	).Error, "seed tickets")
+	require.NoError(t, db.Exec(
+		`INSERT INTO ticket_replies (id, ticket_id, author_type, author_name, content) VALUES (?, ?, ?, ?, ?)`,
+		uuid.New(), ticketID, "customer", "Test Customer", "Still broken",
+	).Error, "seed ticket_replies")
+
+	return nineTableFixture{
+		reviewID:   reviewID,
+		loyaltyID:  loyaltyID,
+		campaignID: campaignID,
+		giftCardID: giftCardID,
+		couponID:   couponID,
+		ticketID:   ticketID,
+		productID:  productID,
+		categoryID: categoryID,
+		orderID:    orderID,
+	}
+}
+
+// countRows returns the number of rows in table matching whereCol = id.
+func countRows(t *testing.T, db *gorm.DB, table, whereCol string, id uuid.UUID) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, db.Raw(
+		"SELECT count(*) FROM "+table+" WHERE "+whereCol+" = ?", id, //nolint:gosec // table/col are test constants
+	).Scan(&n).Error)
+	return n
+}
+
+// assertNineTablesEmpty asserts every store_id-less table from issue #360
+// has zero rows for the given fixture's parent ids.
+func assertNineTablesEmpty(t *testing.T, db *gorm.DB, f nineTableFixture) {
+	t.Helper()
+	require.Zero(t, countRows(t, db, "review_reactions", "review_id", f.reviewID), "review_reactions")
+	require.Zero(t, countRows(t, db, "review_replies", "review_id", f.reviewID), "review_replies")
+	require.Zero(t, countRows(t, db, "review_media", "review_id", f.reviewID), "review_media")
+	require.Zero(t, countRows(t, db, "loyalty_transactions", "loyalty_id", f.loyaltyID), "loyalty_transactions")
+	require.Zero(t, countRows(t, db, "campaign_recipients", "campaign_id", f.campaignID), "campaign_recipients")
+	require.Zero(t, countRows(t, db, "gift_card_transactions", "gift_card_id", f.giftCardID), "gift_card_transactions")
+	require.Zero(t, countRows(t, db, "coupon_usage", "coupon_id", f.couponID), "coupon_usage")
+	require.Zero(t, countRows(t, db, "ticket_replies", "ticket_id", f.ticketID), "ticket_replies")
+	require.Zero(t, countRows(t, db, "product_categories", "product_id", f.productID), "product_categories")
+}
+
+func newEmitter(db *gorm.DB) *audit.Emitter {
+	return audit.NewEmitter(audit.EmitterConfig{
+		DB:     db,
+		Repo:   audit.NewRepository(),
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+}
+
+// TestSweep_NineOrphanTables_DeletesViaParent is the test that fails on
+// unfixed main: Sweep hits `column "store_id" does not exist`
+// (SQLSTATE 42703) on the first store_id-less table it reaches and returns
+// an error before deleting anything. On the fix, Sweep returns nil and
+// every row — including the nine tables that have no store_id column — is
+// gone.
+func TestSweep_NineOrphanTables_DeletesViaParent(t *testing.T) {
+	db := testdb.NewDB(t, sweptTables...)
+
+	tenantID := uuid.New()
+	storeID := uuid.New()
+	fixture := seedNineTableFixture(t, db, tenantID, storeID)
+
+	emitter := newEmitter(db)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	tx := db.Begin()
+	require.NoError(t, tx.Error)
+
+	err := harddelete.Sweep(context.Background(), tx, emitter, logger, storeID, tenantID)
+	require.NoError(t, err, "Sweep must succeed now that store_id-less tables are reached via their parent")
+	require.NoError(t, tx.Commit().Error)
+
+	assertNineTablesEmpty(t, db, fixture)
+
+	// The store row itself (last in the sweep list) must also be gone.
+	require.Zero(t, countRows(t, db, "stores", "id", storeID), "stores")
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	emitter.Stop(stopCtx)
+}
+
+// TestSweep_CrossStoreIsolation is the important test: a subquery on the
+// parent table that forgets `WHERE store_id = ?` (e.g.
+// "DELETE FROM review_reactions WHERE review_id IN (SELECT id FROM
+// reviews)") would delete every store's rows through that parent, not just
+// the swept one. This activates a destructive cron that has never
+// successfully completed a run, so cross-store leakage here is the
+// highest-severity failure mode this fix can introduce.
+func TestSweep_CrossStoreIsolation(t *testing.T) {
+	db := testdb.NewDB(t, sweptTables...)
+
+	sweptTenantID := uuid.New()
+	sweptStoreID := uuid.New()
+	sweptFixture := seedNineTableFixture(t, db, sweptTenantID, sweptStoreID)
+
+	survivorTenantID := uuid.New()
+	survivorStoreID := uuid.New()
+	survivorFixture := seedNineTableFixture(t, db, survivorTenantID, survivorStoreID)
+
+	emitter := newEmitter(db)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	tx := db.Begin()
+	require.NoError(t, tx.Error)
+
+	err := harddelete.Sweep(context.Background(), tx, emitter, logger, sweptStoreID, sweptTenantID)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit().Error)
+
+	// Swept store: every one of the nine tables is empty.
+	assertNineTablesEmpty(t, db, sweptFixture)
+	require.Zero(t, countRows(t, db, "stores", "id", sweptStoreID), "swept store row")
+
+	// Survivor store: every one of the nine tables still has its row.
+	require.EqualValues(t, 1, countRows(t, db, "review_reactions", "review_id", survivorFixture.reviewID), "survivor review_reactions")
+	require.EqualValues(t, 1, countRows(t, db, "review_replies", "review_id", survivorFixture.reviewID), "survivor review_replies")
+	require.EqualValues(t, 1, countRows(t, db, "review_media", "review_id", survivorFixture.reviewID), "survivor review_media")
+	require.EqualValues(t, 1, countRows(t, db, "loyalty_transactions", "loyalty_id", survivorFixture.loyaltyID), "survivor loyalty_transactions")
+	require.EqualValues(t, 1, countRows(t, db, "campaign_recipients", "campaign_id", survivorFixture.campaignID), "survivor campaign_recipients")
+	require.EqualValues(t, 1, countRows(t, db, "gift_card_transactions", "gift_card_id", survivorFixture.giftCardID), "survivor gift_card_transactions")
+	require.EqualValues(t, 1, countRows(t, db, "coupon_usage", "coupon_id", survivorFixture.couponID), "survivor coupon_usage")
+	require.EqualValues(t, 1, countRows(t, db, "ticket_replies", "ticket_id", survivorFixture.ticketID), "survivor ticket_replies")
+	require.EqualValues(t, 1, countRows(t, db, "product_categories", "product_id", survivorFixture.productID), "survivor product_categories")
+	require.EqualValues(t, 1, countRows(t, db, "stores", "id", survivorStoreID), "survivor store row")
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	emitter.Stop(stopCtx)
+}
+
+// TestSweep_EmitsAuditEventPerTable pins the compliance trail the design
+// explicitly chose to preserve: sweepTable emits a
+// "subscription.hard_delete_sweep" audit event per table, including the
+// nine reached via their parent. Dropping those nine from the sweep list
+// (and relying on cascade instead) was considered and rejected because it
+// would leave those tables with no deletion evidence in a GDPR path — this
+// test is what would catch that regression.
+func TestSweep_EmitsAuditEventPerTable(t *testing.T) {
+	db := testdb.NewDB(t, append(sweptTables, "audit_logs")...)
+
+	tenantID := uuid.New()
+	storeID := uuid.New()
+	seedNineTableFixture(t, db, tenantID, storeID)
+
+	emitter := newEmitter(db)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	tx := db.Begin()
+	require.NoError(t, tx.Error)
+
+	err := harddelete.Sweep(context.Background(), tx, emitter, logger, storeID, tenantID)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit().Error)
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	emitter.Stop(stopCtx)
+
+	for _, table := range []string{
+		"review_reactions", "review_replies", "review_media",
+		"loyalty_transactions", "campaign_recipients",
+		"gift_card_transactions", "coupon_usage", "ticket_replies",
+		"product_categories",
+	} {
+		var n int64
+		require.NoError(t, db.Raw(
+			`SELECT count(*) FROM audit_logs
+			 WHERE action = 'subscription.hard_delete_sweep' AND resource_type = ? AND store_id = ?`,
+			table, storeID,
+		).Scan(&n).Error)
+		require.EqualValues(t, 1, n, "expected one hard_delete_sweep audit event for table %s", table)
+	}
+}

--- a/services/marketplace-api/internal/subscription/harddelete/sweeper.go
+++ b/services/marketplace-api/internal/subscription/harddelete/sweeper.go
@@ -56,9 +56,15 @@ func sweepTable(ctx context.Context, tx *gorm.DB, emitter *audit.Emitter, logger
 	if res.Error != nil {
 		return fmt.Errorf("harddelete: sweep %s: %w", tableName, res.Error)
 	}
-	logger.Info("harddelete: swept table",
-		"table", tableName, "column", s.column,
-		"store_id", storeID, "rows_deleted", res.RowsAffected)
+	if s.via != nil {
+		logger.Info("harddelete: swept table",
+			"table", tableName, "via", fmt.Sprintf("%s.%s", s.via.parentTable, s.via.fkColumn),
+			"store_id", storeID, "rows_deleted", res.RowsAffected)
+	} else {
+		logger.Info("harddelete: swept table",
+			"table", tableName, "column", s.column,
+			"store_id", storeID, "rows_deleted", res.RowsAffected)
+	}
 
 	// Emit per-table audit event for compliance trail.
 	emitter.Emit(nil, audit.Event{

--- a/services/marketplace-api/internal/subscription/harddelete/sweeper.go
+++ b/services/marketplace-api/internal/subscription/harddelete/sweeper.go
@@ -14,21 +14,50 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/audit"
 )
 
-// sweepTable deletes all rows in tableName where the given column = id.
+// viaParent describes how to reach a store-scoped table that has no
+// store_id column of its own: its rows are deleted by joining through a
+// parent table (already present earlier in the sweep list) that does carry
+// store_id.
+type viaParent struct {
+	fkColumn    string // column on the child referencing the parent's id, e.g. "review_id"
+	parentTable string // parent table, e.g. "reviews"
+}
+
+// sweepStep describes one table to sweep. Exactly one of column or via is
+// set: column for tables with their own store-scoped column, via for
+// tables reached only through a parent FK.
+type sweepStep struct {
+	table  string
+	column string // store-scoped column, when the table has one
+	via    *viaParent
+}
+
+// sweepTable deletes all rows in s.table that belong to storeID, either
+// directly via s.column or, for tables with no store-scoped column of
+// their own, via s.via's FK to a parent table that does carry store_id.
 // It logs the delete count via the audit emitter for compliance visibility.
 // Errors are returned so the caller can abort the transaction.
 func sweepTable(ctx context.Context, tx *gorm.DB, emitter *audit.Emitter, logger *slog.Logger,
-	tableName, column string, storeID, tenantID uuid.UUID) error {
+	s sweepStep, storeID, tenantID uuid.UUID) error {
 
-	res := tx.WithContext(ctx).Exec(
-		fmt.Sprintf("DELETE FROM %s WHERE %s = ?", tableName, column), //nolint:gosec // table/column names are internal constants
+	tableName := s.table
+
+	var query string
+	if s.via != nil {
+		query = fmt.Sprintf("DELETE FROM %s WHERE %s IN (SELECT id FROM %s WHERE store_id = ?)",
+			tableName, s.via.fkColumn, s.via.parentTable)
+	} else {
+		query = fmt.Sprintf("DELETE FROM %s WHERE %s = ?", tableName, s.column)
+	}
+
+	res := tx.WithContext(ctx).Exec(query, //nolint:gosec // table/column names are internal constants
 		storeID,
 	)
 	if res.Error != nil {
 		return fmt.Errorf("harddelete: sweep %s: %w", tableName, res.Error)
 	}
 	logger.Info("harddelete: swept table",
-		"table", tableName, "column", column,
+		"table", tableName, "column", s.column,
 		"store_id", storeID, "rows_deleted", res.RowsAffected)
 
 	// Emit per-table audit event for compliance trail.
@@ -64,75 +93,87 @@ func Sweep(ctx context.Context, tx *gorm.DB, emitter *audit.Emitter, logger *slo
 	// order_items, abandoned_carts, and order_events cascade from orders.
 	// product_variants, product_options, product_media cascade from products via FK.
 	// We delete them explicitly before the parent for clarity and safety.
+	//
+	// Nine tables below (review_reactions, review_replies, review_media,
+	// loyalty_transactions, campaign_recipients, gift_card_transactions,
+	// coupon_usage, ticket_replies, product_categories) have no store_id
+	// column of their own — they carry only an FK to a parent that does
+	// (reviews, customer_loyalties, campaigns, gift_cards, coupons,
+	// tickets, products, respectively). Those are given a `via` instead of
+	// a `column`, which reaches them with
+	// `DELETE ... WHERE <fk> IN (SELECT id FROM <parent> WHERE store_id = ?)`.
+	// They stay in the sweep explicitly — rather than being dropped in
+	// favor of the parent's CASCADE — because sweepTable emits the
+	// per-table audit event that is this pipeline's compliance trail;
+	// dropping them would leave a GDPR hard-delete with no deletion record
+	// for those tables. Each keeps its original position in the list:
+	// coupon_usage must still precede orders (NO ACTION FK — surviving
+	// rows would block the orders delete), and product_categories must
+	// still precede categories (RESTRICT FK).
 
-	type tableSpec struct {
-		table  string
-		column string
-	}
-
-	sweeps := []tableSpec{
+	sweeps := []sweepStep{
 		// Audit logs for this store (compliance: deleted with the store per §15.2).
-		{"audit_logs", "store_id"},
+		{table: "audit_logs", column: "store_id"},
 		// Subscription lifecycle audit.
-		{"subscription_plan_change_audit", "store_id"},
-		{"migration_fast_path_reviews", "store_id"},
+		{table: "subscription_plan_change_audit", column: "store_id"},
+		{table: "migration_fast_path_reviews", column: "store_id"},
 		// Review-related child rows.
-		{"review_reactions", "store_id"},
-		{"review_replies", "store_id"},
-		{"review_media", "store_id"},
-		{"reviews", "store_id"},
+		{table: "review_reactions", via: &viaParent{fkColumn: "review_id", parentTable: "reviews"}},
+		{table: "review_replies", via: &viaParent{fkColumn: "review_id", parentTable: "reviews"}},
+		{table: "review_media", via: &viaParent{fkColumn: "review_id", parentTable: "reviews"}},
+		{table: "reviews", column: "store_id"},
 		// Loyalty.
-		{"loyalty_transactions", "store_id"},
-		{"customer_loyalties", "store_id"},
-		{"loyalty_programs", "store_id"},
+		{table: "loyalty_transactions", via: &viaParent{fkColumn: "loyalty_id", parentTable: "customer_loyalties"}},
+		{table: "customer_loyalties", column: "store_id"},
+		{table: "loyalty_programs", column: "store_id"},
 		// Campaigns.
-		{"campaign_recipients", "store_id"},
-		{"campaigns", "store_id"},
+		{table: "campaign_recipients", via: &viaParent{fkColumn: "campaign_id", parentTable: "campaigns"}},
+		{table: "campaigns", column: "store_id"},
 		// Gift cards.
-		{"gift_card_transactions", "store_id"},
-		{"gift_cards", "store_id"},
+		{table: "gift_card_transactions", via: &viaParent{fkColumn: "gift_card_id", parentTable: "gift_cards"}},
+		{table: "gift_cards", column: "store_id"},
 		// Coupons.
-		{"coupon_usage", "store_id"},
-		{"coupons", "store_id"},
+		{table: "coupon_usage", via: &viaParent{fkColumn: "coupon_id", parentTable: "coupons"}},
+		{table: "coupons", column: "store_id"},
 		// Orders (cascade deletes order_items, order_addresses, order_events).
-		{"abandoned_carts", "store_id"},
-		{"returns", "store_id"},
-		{"orders", "store_id"},
+		{table: "abandoned_carts", column: "store_id"},
+		{table: "returns", column: "store_id"},
+		{table: "orders", column: "store_id"},
 		// Shipping, payment, tax configs.
-		{"shipments", "store_id"},
-		{"payment_transactions", "store_id"},
-		{"payment_gateway_configs", "store_id"},
-		{"tax_provider_configs", "store_id"},
+		{table: "shipments", column: "store_id"},
+		{table: "payment_transactions", column: "store_id"},
+		{table: "payment_gateway_configs", column: "store_id"},
+		{table: "tax_provider_configs", column: "store_id"},
 		// Notifications.
-		{"notification_preferences", "store_id"},
-		{"notifications", "store_id"},
+		{table: "notification_preferences", column: "store_id"},
+		{table: "notifications", column: "store_id"},
 		// Tickets.
-		{"ticket_replies", "store_id"},
-		{"tickets", "store_id"},
+		{table: "ticket_replies", via: &viaParent{fkColumn: "ticket_id", parentTable: "tickets"}},
+		{table: "tickets", column: "store_id"},
 		// Pages.
-		{"pages", "store_id"},
+		{table: "pages", column: "store_id"},
 		// Media / product child rows (FK cascades from products).
-		{"product_categories", "store_id"},
-		{"products", "store_id"},
-		{"categories", "store_id"},
+		{table: "product_categories", via: &viaParent{fkColumn: "product_id", parentTable: "products"}},
+		{table: "products", column: "store_id"},
+		{table: "categories", column: "store_id"},
 		// Customer profiles.
-		{"customer_profiles", "store_id"},
+		{table: "customer_profiles", column: "store_id"},
 		// Wishlists.
-		{"wishlists", "store_id"},
+		{table: "wishlists", column: "store_id"},
 		// Custom domains.
-		{"custom_domains", "store_id"},
+		{table: "custom_domains", column: "store_id"},
 		// Branding.
-		{"store_branding", "store_id"},
+		{table: "store_branding", column: "store_id"},
 		// Push tokens.
-		{"admin_push_tokens", "store_id"},
+		{table: "admin_push_tokens", column: "store_id"},
 		// Subscription row.
-		{"store_subscriptions", "store_id"},
+		{table: "store_subscriptions", column: "store_id"},
 		// Outbox events (best-effort — may already be consumed).
-		{"outbox_events", "tenant_id"},
+		{table: "outbox_events", column: "tenant_id"},
 		// Idempotency keys (best-effort).
-		{"idempotency_keys", "tenant_id"},
+		{table: "idempotency_keys", column: "tenant_id"},
 		// Stores table — must be last (other tables FK to it).
-		{"stores", "id"},
+		{table: "stores", column: "id"},
 	}
 
 	for _, s := range sweeps {
@@ -140,7 +181,7 @@ func Sweep(ctx context.Context, tx *gorm.DB, emitter *audit.Emitter, logger *slo
 		if s.column == "tenant_id" {
 			id = tenantID
 		}
-		if err := sweepTable(ctx, tx, emitter, logger, s.table, s.column, id, tenantID); err != nil {
+		if err := sweepTable(ctx, tx, emitter, logger, s, id, tenantID); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes #360.

## What was wrong

`harddelete.Sweep` runs `DELETE FROM <table> WHERE store_id = ?` across a 40-entry list inside a single transaction. **Nine of those tables have no `store_id` column.** The first one raises `SQLSTATE 42703`, the transaction aborts, and `runner.go` never reaches its `pending_hard_delete → hard_deleted` transition.

**The 150-day GDPR hard-delete has never completed for any store.** Data intended for destruction has been retained past its cutoff.

The nine, verified against the live schema:

`campaign_recipients`, `coupon_usage`, `gift_card_transactions`, `loyalty_transactions`, `product_categories`, `review_media`, `review_reactions`, `review_replies`, `ticket_replies`

The file's header already states the right intent — *"child rows before parent rows… we delete them explicitly before the parent for clarity and safety"*. What was wrong is the assumption that every child carries `store_id`. These nine are reachable only through their parent.

## The fix

Sweep entries gain an optional `via`, so `sweepTable` issues one of two statements:

```sql
DELETE FROM <table> WHERE <column> = ?
DELETE FROM <table> WHERE <fkColumn> IN (SELECT id FROM <parentTable> WHERE store_id = ?)
```

Each of the nine maps to a parent already in the list — `reviews`, `customer_loyalties`, `campaigns`, `gift_cards`, `coupons`, `tickets`, `products` — and every mapping was checked against the actual foreign key definitions rather than inferred.

**They keep their original list positions**, because two orderings are load-bearing: `coupon_usage` must precede `orders` (a `NO ACTION` FK, so surviving rows would block that delete) and `product_categories` must precede `categories` (`RESTRICT`).

**Why not just drop the nine and let FK cascade handle them.** It would delete the data correctly, but `sweepTable` emits a per-table audit event (`subscription.hard_delete_sweep`, severity Critical, with `rows_deleted`) that the code calls the compliance trail. Cascade deletions aren't observed by the sweeper, so nine tables would lose their deletion evidence — the wrong trade in a GDPR path.

## This arms a destructive cron that has never successfully run

Worth stating plainly. Today the sweep aborts before deleting anything; afterwards, a store reaching `pending_hard_delete` + 150 days is irreversibly destroyed. That is the intended behaviour, and it is one-way.

Blast radius today is nil — production currently has **zero `store_subscriptions` rows**, so nothing is eligible — which makes this much better fixed before launch than after.

## Test plan

- [x] Three integration tests, all against a dev database, never production.
- [x] **The bug is demonstrated, not asserted** — the sweep test fails on unfixed code, where `Sweep` returns an error before deleting anything.
- [x] **Cross-store isolation is proven empirically.** A too-broad subquery would pass a single-store test happily, so the falsification was actually observed: with the inner `WHERE store_id = ?` removed, `TestSweep_CrossStoreIsolation` fails with `expected: 1, actual: 0` on the survivor's rows. That run was done on an **ephemeral throwaway Postgres container**, not the shared dev instance — an earlier attempt on the shared box hung and had to be killed.
- [x] Per-table audit emission asserted, so the compliance trail this design preserves is pinned rather than assumed.
- [x] Full integration suite diffed against `394ac0c3` in **both directions**: base 187, branch 187, **zero new failures**.
- [x] `go build ./...`, `go vet -tags=integration ./...`, `gofmt -l .` clean.

## Known follow-ups, not in this PR

- Nothing in the schema prevents a `product_categories` row from linking a product in store A to a category in store B. Sweeping A would leave that join row alive and the later `categories` delete would hit the `RESTRICT` and abort — a **loud** failure, not a silent leak or a cross-tenant delete, and not reachable through normal app flow.
- `vendors` is not in the sweep list at all (pre-existing, out of scope for #360).
- `products.vendor_id` being `NOT NULL` required seeding a `vendors` fixture row — another instance of the fixture drift tracked in #316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MGRGtY6SWG5ocFKctLoEb
