### PR TITLE
fix(ci): repin Node bases to the 20260827 rebuild — openssl 3.5.8-r0 …

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -8,7 +8,7 @@
 # differ.
 
 # ─── deps ──────────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:ac0254526efbc5bd4079193a010e9087ea722eada2f4bede2db1817b900b7a01 AS deps
+FROM ghcr.io/tesserix/base-node-builder-22@sha256:a8d70bc7af6346aeb8eef23c58a1c72b411facf6f3bb4a0924a1610fb7a730e6 AS deps
 USER 0:0
 WORKDIR /src
 
@@ -31,7 +31,7 @@ RUN --mount=type=secret,id=PACKAGE_READ_TOKEN \
     npm ci --no-audit --no-fund --legacy-peer-deps
 
 # ─── builder ───────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:ac0254526efbc5bd4079193a010e9087ea722eada2f4bede2db1817b900b7a01 AS builder
+FROM ghcr.io/tesserix/base-node-builder-22@sha256:a8d70bc7af6346aeb8eef23c58a1c72b411facf6f3bb4a0924a1610fb7a730e6 AS builder
 USER 0:0
 WORKDIR /src
 COPY --from=deps /src/node_modules ./node_modules
@@ -94,7 +94,7 @@ RUN --mount=type=secret,id=APPLICATION_BUILD_SECRET \
 
 # ─── runtime ───────────────────────────────────────────────────────────
 # base-node-runtime-22: libc6-compat, tini PID 1, USER 10001 (nextjs).
-FROM ghcr.io/tesserix/base-node-runtime-22@sha256:41ad466bd1f42a02eca0a3d8c7022d2a42438b9bba31c59f65001af283feb330 AS runtime
+FROM ghcr.io/tesserix/base-node-runtime-22@sha256:077d93e0d00a269fc64a54acb796158457dd478bd97d28805768c11e7d518f34 AS runtime
 WORKDIR /app
 
 ENV PORT=4202

--- a/apps/onboarding/Dockerfile
+++ b/apps/onboarding/Dockerfile
@@ -11,7 +11,7 @@
 # the repo root.
 
 # ─── deps ──────────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:ac0254526efbc5bd4079193a010e9087ea722eada2f4bede2db1817b900b7a01 AS deps
+FROM ghcr.io/tesserix/base-node-builder-22@sha256:a8d70bc7af6346aeb8eef23c58a1c72b411facf6f3bb4a0924a1610fb7a730e6 AS deps
 USER 0:0
 WORKDIR /src
 
@@ -33,7 +33,7 @@ RUN --mount=type=secret,id=PACKAGE_READ_TOKEN \
     npm ci --no-audit --no-fund --legacy-peer-deps
 
 # ─── builder ───────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:ac0254526efbc5bd4079193a010e9087ea722eada2f4bede2db1817b900b7a01 AS builder
+FROM ghcr.io/tesserix/base-node-builder-22@sha256:a8d70bc7af6346aeb8eef23c58a1c72b411facf6f3bb4a0924a1610fb7a730e6 AS builder
 USER 0:0
 WORKDIR /src
 COPY --from=deps /src/node_modules ./node_modules
@@ -83,7 +83,7 @@ RUN --mount=type=secret,id=APPLICATION_BUILD_SECRET \
 # Next.js standalone output for a workspace ends up at
 # apps/onboarding/.next/standalone/ with the monorepo directory layout
 # preserved, so the entrypoint is apps/onboarding/server.js.
-FROM ghcr.io/tesserix/base-node-runtime-22@sha256:41ad466bd1f42a02eca0a3d8c7022d2a42438b9bba31c59f65001af283feb330 AS runtime
+FROM ghcr.io/tesserix/base-node-runtime-22@sha256:077d93e0d00a269fc64a54acb796158457dd478bd97d28805768c11e7d518f34 AS runtime
 WORKDIR /app
 
 ENV PORT=4201

--- a/apps/storefront/Dockerfile
+++ b/apps/storefront/Dockerfile
@@ -7,7 +7,7 @@
 # apps/admin and apps/onboarding — only workspace name + port differ.
 
 # ─── deps ──────────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:ac0254526efbc5bd4079193a010e9087ea722eada2f4bede2db1817b900b7a01 AS deps
+FROM ghcr.io/tesserix/base-node-builder-22@sha256:a8d70bc7af6346aeb8eef23c58a1c72b411facf6f3bb4a0924a1610fb7a730e6 AS deps
 USER 0:0
 WORKDIR /src
 
@@ -29,7 +29,7 @@ RUN --mount=type=secret,id=PACKAGE_READ_TOKEN \
     npm ci --no-audit --no-fund --legacy-peer-deps
 
 # ─── builder ───────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:ac0254526efbc5bd4079193a010e9087ea722eada2f4bede2db1817b900b7a01 AS builder
+FROM ghcr.io/tesserix/base-node-builder-22@sha256:a8d70bc7af6346aeb8eef23c58a1c72b411facf6f3bb4a0924a1610fb7a730e6 AS builder
 USER 0:0
 WORKDIR /src
 COPY --from=deps /src/node_modules ./node_modules
@@ -72,7 +72,7 @@ RUN --mount=type=secret,id=APPLICATION_BUILD_SECRET \
 
 # ─── runtime ───────────────────────────────────────────────────────────
 # base-node-runtime-22: libc6-compat, tini PID 1, USER 10001 (nextjs).
-FROM ghcr.io/tesserix/base-node-runtime-22@sha256:41ad466bd1f42a02eca0a3d8c7022d2a42438b9bba31c59f65001af283feb330 AS runtime
+FROM ghcr.io/tesserix/base-node-runtime-22@sha256:077d93e0d00a269fc64a54acb796158457dd478bd97d28805768c11e7d518f34 AS runtime
 WORKDIR /app
 
 ENV PORT=4203


### PR DESCRIPTION
`main` has been red since #390 merged, and the deploy has been stuck behind it. This repins the three
Next.js images to Node bases rebuilt today.

## What was broken

Trivy failed the `mark8ly-admin`, `mark8ly-storefront` and `mark8ly-onboarding` publishes on
[run 33026665474](https://github.com/tesserix/mark8ly/actions/runs/33026665474):

```
ghcr.io/tesserix/mark8ly-admin (alpine 3.24.1)   Total: 2 (HIGH: 2, CRITICAL: 0)
libcrypto3 / libssl3   CVE-2026-14456   3.5.7-r0 → fixed 3.5.8-r0
openssl: Denial of Service via unbounded memory growth in QUIC server
```

Three failed publishes fail the CI gate, Kargo will not promote a red commit, and so
`mark8ly-marketplace-api` has stayed on `main-1dc04a8` with production schema at **105** — meaning
#389 and #390, including migration 106 and the GDPR hard-delete fix, have not shipped.

## Why it happened

Nothing was misconfigured. It was staleness with no automated escape:

- Upstream `node:22-alpine3.24` still ships openssl `3.5.7-r0`, and its digest has not moved
  (`sha256:c610fcdf…` — the same one `base-docker-images` already pins).
- Alpine `v3.24/main` does carry `3.5.8-r0` (`apk policy libssl3` confirms), and the base Dockerfiles
  already run `apk upgrade --no-cache` — so a **rebuild** picks the fix up.
- But the bases were last built **2026-08-22T15:06**, before Alpine published `3.5.8-r0`, and the
  weekly rebuild runs Saturdays 03:00 UTC. This repo already pinned the newest bases that existed,
  so repinning alone could not have helped.

Fixed by dispatching `weekly-rebuild.yml` on `tesserix/base-docker-images` manually
([run 33027502954](https://github.com/tesserix/base-docker-images/actions/runs/33027502954)) —
all ten images green, published as `20260827`.

## The change

Nine `FROM` lines across `apps/{admin,storefront,onboarding}/Dockerfile`, two distinct digests:

| image | old (20260822) | new (20260827) |
|---|---|---|
| `base-node-builder-22` | `ac025452…` | `a8d70bc7…` |
| `base-node-runtime-22` | `41ad466b…` | `077d93e0…` |

Both bases pulled and inspected directly rather than assumed:

```
$ docker run --rm --platform linux/amd64 --entrypoint sh \
    ghcr.io/tesserix/base-node-runtime-22@sha256:077d93e0… -c 'apk list --installed | grep -E "^lib(ssl|crypto)3"'
libcrypto3-3.5.8-r0 x86_64 {openssl} [installed]
libssl3-3.5.8-r0    x86_64 {openssl} [installed]
```

`base-node-builder-22@sha256:a8d70bc7…` reports the same. npm's bundled `tar` is `7.5.21`, still
above CVE-2026-73566. `python3 .github/scripts/test-ci-contract.py` passes — bases stay immutable and
digest-pinned, and Dependabot coverage for all three app directories is unchanged.

Go and distroless pins are deliberately untouched; they were never failing, and they have their own
open Dependabot PRs.

## Follow-up, not part of this PR

`tesserix/base-docker-images#23` — the "Upstream base drift" workflow has failed daily since
2026-08-25 with `GitHub Actions is not permitted to create or approve pull requests`
(`can_approve_pull_request_reviews: false` at both org and repo level). It did **not** cause this
outage, since upstream's node digest never moved, but it is the automated path that would move a
pinned upstream digest forward, and it is currently dead.

## After merge

Kargo should promote `marketplace-api` off `main-1dc04a8` and migration 106 applies, taking
production schema 105 → 106. `ExpectedSchemaVersion` is strict equality, so that migration and its
code roll together or not at all. This also arms the 150-day hard-delete sweep in production for the
first time — irreversible by design.
