### PR TITLE
test(marketplace-api): repair drifted integration fixtures and relight the CI suite (#316, #317)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,17 @@ test-int: ## Run integration tests against the running `make dev` stack
 	@# holds a transaction open while Svc.Submit writes the same row on a
 	@# separate pooled connection, so the two block each other forever and this
 	@# target would hang instead of failing. Filed separately; do not add the
-	@# ellipsis back until that deadlock is fixed.
+	@# ellipsis back until that deadlock is fixed. The missing ellipsis also
+	@# excludes internal/billing/tax/seaqueue — its status was never measured,
+	@# so it stays out until someone does.
+	@#
+	@# ./internal/subscription below is deliberately NOT ./internal/subscription/...
+	@# — recursing would pull in internal/subscription/planchange, which is
+	@# still red. Do not add the ellipsis back until that package is fixed.
+	@#
+	@# ./internal/campaignbudget/cron/... similarly leaves
+	@# internal/campaignbudget/concurrency and internal/campaignbudget/transactional
+	@# unassessed — their status was never measured, so they stay out too.
 	@cd services/marketplace-api && \
 	  TEST_DATABASE_URL='postgres://dev:dev@localhost:5432/marketplace_db?sslmode=disable' \
 	  go test -tags=integration -p 1 \
@@ -84,6 +94,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/billing/appaddon/... \
 	    ./internal/billing/dispatch/... \
 	    ./internal/billing/tax \
+	    ./internal/billing/trial/... \
 	    ./internal/subscription \
 	    ./internal/subscription/cancel/... \
 	    ./internal/subscription/harddelete/... \
@@ -92,7 +103,8 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/subscription/statemachine/... \
 	    ./internal/campaignbudget/cron/... \
 	    ./internal/handlers/webhooks/... \
-	    ./tests/integration/...
+	    ./tests/integration/... \
+	    ./pkg/testdb/...
 
 cover: ## Coverage report for both Go services
 	@cd services/platform-api && go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out | tail -5

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,8 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/audit/... \
 	    ./internal/handlers/platformadmin/... \
 	    ./internal/tenantpurge/... \
-	    ./internal/subscription/dunning/...
+	    ./internal/subscription/dunning/... \
+	    ./internal/handlers/internalsvc/...
 
 cover: ## Coverage report for both Go services
 	@cd services/platform-api && go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out | tail -5

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,13 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/handlers/internalsvc/... \
 	    ./internal/billing/appaddon/... \
 	    ./internal/billing/dispatch/... \
-	    ./internal/billing/tax
+	    ./internal/billing/tax \
+	    ./internal/subscription \
+	    ./internal/subscription/cancel/... \
+	    ./internal/subscription/harddelete/... \
+	    ./internal/subscription/lifecycle/... \
+	    ./internal/subscription/readonly/... \
+	    ./internal/subscription/statemachine/...
 
 cover: ## Coverage report for both Go services
 	@cd services/platform-api && go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out | tail -5

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,9 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/subscription/harddelete/... \
 	    ./internal/subscription/lifecycle/... \
 	    ./internal/subscription/readonly/... \
-	    ./internal/subscription/statemachine/...
+	    ./internal/subscription/statemachine/... \
+	    ./internal/campaignbudget/cron/... \
+	    ./tests/integration/...
 
 cover: ## Coverage report for both Go services
 	@cd services/platform-api && go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out | tail -5

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/subscription/readonly/... \
 	    ./internal/subscription/statemachine/... \
 	    ./internal/campaignbudget/cron/... \
+	    ./internal/handlers/webhooks/... \
 	    ./tests/integration/...
 
 cover: ## Coverage report for both Go services

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,10 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/handlers/platformadmin/... \
 	    ./internal/tenantpurge/... \
 	    ./internal/subscription/dunning/... \
-	    ./internal/handlers/internalsvc/...
+	    ./internal/handlers/internalsvc/... \
+	    ./internal/billing/appaddon/... \
+	    ./internal/billing/dispatch/... \
+	    ./internal/billing/tax
 
 cover: ## Coverage report for both Go services
 	@cd services/platform-api && go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out | tail -5

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	@cd services/marketplace-api && \
 	  TEST_DATABASE_URL='postgres://dev:dev@localhost:5432/marketplace_db?sslmode=disable' \
 	  go test -tags=integration -p 1 \
+	    ./internal/apikeys/... \
 	    ./internal/audit/... \
 	    ./internal/handlers/platformadmin/... \
 	    ./internal/tenantpurge/... \

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,13 @@ test-int: ## Run integration tests against the running `make dev` stack
 	@# red target is worse than a narrow green one: this suite was dark long
 	@# enough to hide a production dunning bug (see the sql.NullTime fix in
 	@# internal/subscription/dunning/ladder.go).
+	@#
+	@# ./internal/billing/tax below is deliberately NOT ./internal/billing/tax/...
+	@# — its revalidation subpackage deadlocks (not a normal failure): Cron.Run
+	@# holds a transaction open while Svc.Submit writes the same row on a
+	@# separate pooled connection, so the two block each other forever and this
+	@# target would hang instead of failing. Filed separately; do not add the
+	@# ellipsis back until that deadlock is fixed.
 	@cd services/marketplace-api && \
 	  TEST_DATABASE_URL='postgres://dev:dev@localhost:5432/marketplace_db?sslmode=disable' \
 	  go test -tags=integration -p 1 \

--- a/docs/superpowers/plans/2026-08-27-integration-fixture-drift-tail.md
+++ b/docs/superpowers/plans/2026-08-27-integration-fixture-drift-tail.md
@@ -1,0 +1,181 @@
+# Integration Fixture Drift — Tail Triage
+
+Task 7 of `docs/superpowers/plans/2026-08-27-integration-fixture-drift.md`. Re-measures the whole
+suite after Tasks 1–6 (clusters A, B, C), proves the branch added zero regressions, and classifies
+every remaining failure as **FIXTURE** (fixed by Tasks 10–15 below) or **PRODUCT** (a real defect,
+out of scope for this branch).
+
+## Measurement method — read this before re-measuring anything
+
+A plain `go test -tags=integration -p 1 ./...` run against the shared `TEST_DATABASE_URL` is **not
+a usable instrument on this branch**, for two independent reasons proven while measuring:
+
+1. **`internal/billing/tax/revalidation` deadlocks**, and under `-p 1` its poisoned transaction/held
+   lock makes every package that runs *after* it in the same `go test` invocation time out too — not
+   fail cleanly, time out at whatever `-timeout` was given. With the package included in the run,
+   `billing/trial`, `campaignbudget`, `campaignbudget/cron`, and `category` all hit the test timeout
+   and report nothing useful. With it simply excluded from the package list, those same packages run
+   in 11.3s, 1.1s, 0.6s, and 0.9s respectively. **Exclude `internal/billing/tax/revalidation` from any
+   `./...`-shaped run**, or every package alphabetically after it becomes uninterpretable.
+
+2. **Packages pollute each other through the shared database even with #1 solved.** `pkg/testdb.NewDB`
+   truncates only the tables it is explicitly told about (`testdb.NewDB(t, "campaign_email_budget")`,
+   for example, truncates exactly that table and nothing else). When two packages insert into the same
+   table under different truncate lists — or when a package's own truncate list is incomplete — rows
+   from an earlier package's run are still present when a later package's test queries `COUNT(*)` or a
+   list endpoint. A `./...` run measured this way invented roughly 46 "new failures" that do not
+   reproduce on a clean database, and 7 of the 19 packages that looked FAIL on a dirty database
+   actually pass cleanly. **A `./...` count is not a diffable signal.**
+
+**The only trustworthy instrument found: `TRUNCATE` all ~100 tables, then run exactly one package,
+repeat for every package, never let two packages share a database state.** This was run at both the
+baseline commit (`30c3fdff`) and this branch's HEAD. Anyone re-measuring this suite without truncating
+between packages will get fiction and should be told so before they burn a day on it — this note
+exists so the next person doesn't have to rediscover it.
+
+Per-package clean-DB result at this branch's HEAD (`/tmp/clean-iso.txt`):
+
+```
+./internal/apikeys :: FAIL
+./internal/arbitrage :: FAIL
+./internal/audit :: ok
+./internal/billing/dispatch :: ok
+./internal/billing/trial :: ok
+./internal/campaignbudget :: FAIL
+./internal/category :: FAIL
+./internal/handlers/admin :: FAIL
+./internal/handlers/platformadmin :: ok
+./internal/handlers/storefront :: FAIL
+./internal/handlers/webhooks :: FAIL
+./internal/orderrefund :: FAIL
+./internal/page :: FAIL
+./internal/product :: FAIL
+./internal/subscription/dunning :: ok
+./internal/subscription/lifecycle :: ok
+./internal/subscription/planchange :: FAIL
+./internal/tenantpurge :: ok
+./internal/whitelabel/lifecycle :: FAIL
+```
+
+## Before / after
+
+| | baseline `30c3fdff` | branch HEAD |
+|---|---|---|
+| failing tests | 187 | **25** |
+| failing packages | 22 | **12** |
+
+**FIXED: 162. REGRESSIONS: 0.** The baseline was independently re-measured with the same clean-DB
+method and diffed by test *name* against the original baseline capture — identical, so the original
+187 was accurate and the 162-fixed / 0-regression numbers are trustworthy, not an artifact of
+re-deriving the baseline differently.
+
+`make test-int` (16 packages) is green, verified twice. None of clusters A/B/C's signatures
+(`products.vendor_id` NOT NULL, `store_subscriptions_store_id_fkey`,
+`stores.storefront_customer_portal_secret` NOT NULL) appears anywhere in the remaining 25 — clusters
+A, B, C contribute zero failures, as Tasks 1–6 intended.
+
+## Remaining signature histogram (clean DB, this branch)
+
+```
+6  value too long for type character varying(60)       internal/apikeys
+2  value too long for type character varying(100)      internal/arbitrage
+2  column "created_at" of relation "stores" missing    internal/handlers/admin
+2  404 page not found                                  internal/handlers/admin (unmounted routes)
+1  nil pointer dereference                              internal/whitelabel/lifecycle (audit.Emitter)
+1  shipments_order_id_fkey                              internal/handlers/admin
+1  current transaction is aborted (25P02)                internal/page (downstream of another failure)
+```
+
+The 12 failing packages: `apikeys`, `arbitrage`, `campaignbudget`, `category`, `handlers/admin`,
+`handlers/storefront`, `handlers/webhooks`, `orderrefund`, `page`, `product`,
+`subscription/planchange`, `whitelabel/lifecycle`.
+
+## Classification — all 25 named failures
+
+**Already known, already being filed elsewhere — classified PRODUCT here without re-analysis, per
+the controller's instruction:**
+
+| Test | Package | Signature | Why PRODUCT |
+|---|---|---|---|
+| — (panic, no named test) | `whitelabel/lifecycle` | nil pointer dereference | `audit.NewEmitter` accepts a nil `Repo`; `write` (`internal/audit/emitter.go:216`) dereferences it on a background goroutine and kills the whole test binary. Filed: **issue #318**. Task 9 of the parent plan already covers this. |
+| `TestAppealService_MarksAuditRowUnderReview` | `arbitrage` | `value too long for type character varying(100)` | `internal/arbitrage/appeal.go:73-118` appends merchant-supplied justification/document-URL text to `mismatch_reason` (`varchar(100)`) with no length guard before the `UPDATE`. Confirmed by reading `appeal_test.go:31-69` and `appeal.go:88-96` — the appended string is routinely > 100 chars for realistic input. Production truncation/validation bug, not a fixture problem. |
+| `internal/billing/tax/revalidation` (deadlock, no named test in the 25) | — | hang, not a `--- FAIL` | Excluded from every `./...` run per the measurement-method section above. Already known, already filed separately. No further analysis performed, per instruction. |
+
+**apikeys — already covered by the existing Task 8, not re-analyzed or duplicated here:**
+
+| Test | Package | Signature |
+|---|---|---|
+| `TestLastUsedWorker_PersistsUpdate`, `TestRepo_Create_AndLookupByTenantPrefix`, `TestRepo_Revoke_FlipsRow`, `TestRepo_RotationOverlap_StaysUsableUntilExpiry`, `TestRepo_CountActiveForStore_ExcludesRevoked`, `TestRepo_UpdateLastUsed` | `apikeys` | `value too long for type character varying(60)` |
+
+Task 8 already diagnoses this precisely (a 63-character fixture literal against a 60-character
+column) and has its own verify/Makefile/commit steps. No new task is added for it here.
+
+**New PRODUCT-class findings, discovered during this triage:**
+
+| Test | Package | Signature | Evidence |
+|---|---|---|---|
+| `TestApplyTrialRamp_Idempotent_ReRunSameDay` | `campaignbudget` | assertion mismatch (`expected: 1800, actual: 2000`) | `internal/campaignbudget/ramp.go:56-73` — `ApplyTrialRamp`'s day-4 path runs `SET remaining = GREATEST(remaining, 2000)`. The docstring (`ramp.go:44-46`) claims this is idempotent — "re-running on the same transition day with a smaller remaining uses GREATEST semantics so consumed balance is never re-inflated" — but that is only true if `remaining` never *drops* below 2000 between runs. The test seeds 50→ramp(day4)→2000, then `Reserve(200)` drops remaining to 1800, then re-runs `ApplyTrialRamp(day4)` — `GREATEST(1800, 2000)` re-inflates `remaining` back to 2000, contradicting the docstring's own idempotency claim. Real bug: the cron is not idempotent against merchant consumption between runs. |
+| `TestIntegration_Category_ListActiveByStoreID_ExcludesInactiveAndDeleted` | `category` | assertion mismatch (expected 2 active rows, got 3 — the row explicitly created with `IsActive=false` came back active) | `internal/category/models.go:20` — `IsActive bool \`gorm:"column:is_active;not null;default:true"\`` combined with a plain (non-pointer) `bool` field. This is a documented GORM footgun: when a field carries a `default:` tag, GORM skips the field on `.Create()` if its value equals the Go zero value — and `false` **is** the zero value for `bool`. The result: `category.Repository.Create` (`internal/category/repository.go:33-41`) can never actually persist `is_active=false`; every insert silently falls back to the column default `true`, regardless of what the caller set. Confirmed by reading `repository_integration_test.go:249-253` (`inactive.IsActive = false` before `repo.Create`) against the DB result: `IsActive:true` in the failing test's dump. |
+| `TestRepository_GetBySlug_PublishedOnly`, `TestService_GetBySlug_FiltersUnpublishedOnStorefrontRead` | `page` | "unpublished page should not be returned" / "unpublished page must not leak to storefront" — both got the page back instead of nil | **Same root cause as the category finding above.** `internal/page/models.go:21` — `Published bool \`gorm:"column:published;not null;default:true"\`` — identical footgun. A page created with `Published: false` is silently stored as `published=true`. |
+| `TestStorefrontPages_Get_UnpublishedReturns404`, `TestStorefrontPages_List_OnlyPublished` | `handlers/storefront` | "want 404 for unpublished page, got 200" / "want 2 published pages, got 3" | Downstream of the same `page.Published` GORM-default bug — `seedPageForStorefront` (`pages_integration_test.go:52-69`) calls `page.Service.Create` with `Published: &pub` where `pub=false`; the write silently becomes `true`, so the "unpublished" fixture page is actually published and the storefront correctly (if confusingly) serves it. Not a separate bug — one root cause, five tests. |
+| `TestIntegration_ProductService_UpdateAggregate_RemovedVariantIDsSoftDelete` | `product` | assertion mismatch ("active variants = 4, want 2") | `internal/product/models.go:130` — `ProductVariant.DeletedAt *time.Time` (a plain pointer, not `gorm.DeletedAt`), so GORM's automatic soft-delete filtering never applies. Every `Preload("Variants")` call in `internal/product/repository.go` (lines 209, 281, 351, 405, 447) loads variants with no `deleted_at IS NULL` condition, so soft-deleted variants are returned alongside active ones on every aggregate read. The test's own soft-delete assertion (`deletedCount == 2`) passes — the deletion itself works — but the subsequent `svc.Get` still returns all 4 variants because the read path never filters them out. Systemic: this affects every caller of `GetByIDForStore` / the other four `Preload("Variants")` sites, not just this test. |
+| `TestIntegration_ProductService_UpdateAggregate_OptionValueInUseRejected` | `product` | got `variant_matrix_mismatch` instead of the expected `ErrOptionValueInUse` | `internal/product/service_aggregate.go:144-107` calls `ValidateMatrix` (`internal/product/matrix.go:52`) **before** the transaction that would reach `applyOptionsDiff`'s `OptionValueInUse` check (`service_aggregate.go:445`). `ValidateMatrix` rejects any variant whose `OptionValues` reference a value not present in the *desired* option spec — which by definition includes every variant still referencing a value that is being removed. Traced through: with the test's desired options (`Size:[M]`, `expected=1`) and 2 supplied variants, the count check (`expected != len(variants)`) fires first (`variant_matrix_mismatch`); even a variant-count-matching construction would still fail earlier on `ValidateMatrix`'s per-variant "references unknown option value" check, never reaching `applyOptionsDiff`. **`OptionValueInUse` at `service_aggregate.go:445` appears to be unreachable through the public `UpdateAggregate` API** given the current validation order — worth its own issue: either loosen `ValidateMatrix` to let this scenario through so the intended guard actually runs, or confirm the code path is genuinely dead and remove/document it as defense-in-depth. |
+| `TestExecute_Downgrade_StudioToStarter_OverQuota_Rejected` | `subscription/planchange` | assertion mismatch (audit row count: expected 1, got 0) | Read per the controller's specific ask: does the orchestrator write the `downgrade_blocked_over_quota` audit row on this path, or not? **It writes it, but the write is rolled back.** `internal/subscription/planchange/downgrade.go:41-50` calls `WritePlanChangeAuditRowTx(ctx, tx, ...)` with `Action: "downgrade_blocked_over_quota"`, using the *same* `tx` the whole call is running in, then returns `Output{}, ErrStoreCountOverQuota` at `downgrade.go:70`. That `tx` comes from `subscription.WithAdvisoryLock` (`internal/subscription/advisory_lock.go:15-22`), which wraps the entire operation in `db.Transaction(func(tx) error { ... })` — standard GORM semantics: a non-nil return rolls the transaction back. Since `executeDowngradeSchedule` returns `ErrStoreCountOverQuota` (non-nil) up through `Execute` (`planchange.go:154-198`), the whole transaction — including the audit-row insert written moments earlier — is rolled back. The comment at `downgrade.go:40` ("Write a blocked audit row so ops can see why the downgrade was refused") is defeated by the transaction it runs inside. Real bug: the audit trail for the one case ops most needs to see (a blocked downgrade) never persists. |
+
+**FIXTURE-class findings — fixed by Tasks 10–15 appended to the parent plan below:**
+
+| Test | Package | Signature | Root cause | Fixed by |
+|---|---|---|---|---|
+| `TestPromoApply_BelowAbsoluteFloor_INR`, `TestRefund_OutsideCoolingOff` | `handlers/admin` | `404 page not found` | The route **exists** — `internal/handlers/admin/routes.go:704-761` mounts `/subscription/apply-promo` and `/subscription/refund` inside `if deps.SubscriptionHandler != nil { ... if deps.PromoHandler != nil {...}; if deps.RefundHandler != nil {...} }`. Both test routers (`setupTestRouter` in `products_integration_test.go`, `setupRefundTestEnv` in `refund_integration_test.go`) construct `admin.Deps{}` without ever setting `SubscriptionHandler`, so the whole `/subscription` group — including the routes these two tests exercise — is never registered. This is exactly the "show from source the route exists and the test is wrong" case the brief called out; confirmed, not deleting anything. | Task 10 |
+| `TestShipmentDispatchedEmailGate` | `handlers/admin` | `shipments_order_id_fkey` violation | The test generates `orderID := uuid.New()` (`shipments_dispatched_dedup_test.go:39`) and inserts a `shipments` row referencing it directly, without ever inserting a parent `orders` row. `shipments.order_id` has a real FK. A `seedOrderRowForSync` helper already exists in the same package (`shipments_tracking_sync_test.go:290-309`) for exactly this. | Task 13 |
+| `TestShipmentsSync_AdvancesStatusLadder`, `TestShipmentsSync_CarrierErrorDoesNotBlockOthers` | `handlers/admin` | `column "created_at" of relation "stores" does not exist` | `seedStoreRowForSync` (`shipments_tracking_sync_test.go:273-286`) hand-rolls `INSERT INTO stores (..., created_at, ...)`. Per the parent plan's verified schema facts, **`stores` has no `created_at` column at all.** `testdb.SeedStore` (Task 1) already exists and is already used by every other cluster-C/A fixed site — this one was simply never migrated over. | Task 13 |
+| `TestGatewayFor_ActiveConfig` | `orderrefund` | "no secret store or encryptor wired" | Exactly the config-wiring gap named in the original brief for `resolver_integration_test.go:239`. `orderrefund.NewResolver(db)` (`resolver.go:51`) intentionally returns an unconfigured resolver — the doc comment at `resolver.go:48` says "Wire `WithSecretStore` (or `WithEncryptor`) before use." The test never chains either. The sibling test file in the same package, `resolver_creds_test.go:56`, already uses `crypto.NewNoopEncryptor()` for this exact purpose. | Task 11 |
+| `TestFullWebhookFlow_AllAllowlistedEvents` | `handlers/webhooks` | `open ../../scripts/webhook-fixtures: no such file or directory` | Off-by-one relative path. The test file lives at `internal/handlers/webhooks/stripe_integration_test.go` — three directories below `services/marketplace-api/` — but its `filepath.Join("..", "..", "scripts", "webhook-fixtures")` (`stripe_integration_test.go:41`) only climbs two. Verified: `ls ../../scripts/webhook-fixtures` from that package directory fails; `ls ../../../scripts/webhook-fixtures` lists the 11 fixture files that `git ls-files` confirms are tracked and present. | Task 12 |
+| `TestRepository_Create_DuplicateSlug_Errors` | `page` | `current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02)` | The test (`internal/page/repository_integration_test.go:148-176`) runs three `repo.Create` calls inside one shared `testdb.NewTx` transaction and *expects* the second one to fail (duplicate slug) while the third succeeds. Postgres aborts the entire transaction on any real constraint-violation error until `ROLLBACK`/a `SAVEPOINT` recovery — there is none here, so the third statement fails with 25P02 regardless of what it is. This is exactly the masking effect the parent plan's Task 7 brief predicted ("an early insert failure aborts the transaction and masks every assertion after it"), just occurring within a single test rather than across tests. `category`'s `expectCreateFails` helper (`repository_integration_test.go:39-52`) already solves this with `SAVEPOINT sp` / `ROLLBACK TO SAVEPOINT sp` around exactly this kind of expected-to-fail call. | Task 14 |
+| `TestIntegration_ProductRepo_ListPublished_ExcludesDraftArchivedDeletedUnpublished` | `product` | assertion mismatch (expected 1 published row, got 0) | Postgres freezes `now()` (`transaction_timestamp()`) to the moment a transaction begins and holds that value for every statement inside it. `testdb.NewTx` (`pkg/testdb/testdb.go:34-48`) opens the transaction with `db.Begin()` before the test does anything else. The test then calls `seedStore(t, tx)` and builds several aggregates before capturing `now := time.Now()` (`repository_integration_test.go:403`) and using it as `PublishedAt` on an app-clock timestamp captured *after* the transaction began. `ListPublished`'s `WHERE ... published_at <= now()` (`repository.go:319-320`) evaluates Postgres's `now()`, which is still pinned to the earlier transaction-start instant — so the freshly-set `published_at` (a later, real wall-clock value) reads as "in the future" relative to the frozen `now()`, and the row is filtered out. Deterministic, not flaky: the gap between `db.Begin()` and the `time.Now()` capture is real wall-clock time spent on prior seeding calls. Not a production issue — request-scoped transactions in production begin immediately before this query runs, so the gap is negligible there; it only bites a long-lived test transaction that seeds first and queries later. | Task 15 |
+
+## Cross-package pollution finding
+
+Documented here for the record, not turned into a task — it's a testing-infrastructure defect, not
+covered by "fixture" tasks scoped to specific test files, and deserves its own issue rather than
+folding into this plan's task numbering.
+
+**Root cause:** `pkg/testdb.NewDB(t, tablesToCleanup ...string)` truncates *only the tables the
+caller names*, per test, on cleanup (`pkg/testdb/testdb.go:50-59`). Nothing enforces that a package's
+truncate list is complete, or that two packages inserting into the same table (`stores`,
+`store_subscriptions`, `products`, etc.) agree on ownership. When package A's truncate list omits a
+table that package B also writes to, rows A left behind are still present when B's test runs a
+`COUNT(*)` or unscoped list query — and vice versa depending on run order.
+
+**Why this only became visible now, on this branch, and not at the `30c3fdff` baseline:** at
+baseline, 165 of 187 failures were early-insert failures — a `NOT NULL` violation or a missing FK
+parent row aborted the test's transaction (or the `NewDB` insert) before the test ever got far enough
+to leave meaningful rows behind for a later test to collide with. Clusters A–C (Tasks 1–6) fixed
+those early failures, which means tests now run to completion and actually commit real rows via
+`NewDB` — which is exactly the condition under which incomplete truncate lists start to matter. This
+is the masking effect the parent plan predicted, one level up: earlier, insert failures masked
+*assertions within a test*; now that inserts succeed, incomplete truncate lists let *state leak
+between tests*. Both are the same shape of problem — an early, silent failure hiding a later,
+real one — recurring at different levels of the same system as each layer of masking is peeled back.
+
+**Recommendation:** file a standalone issue on `pkg/testdb.NewDB`'s truncation contract — e.g. an
+audit of every truncate list against the tables its package's `INSERT`s actually touch, or a stronger
+primitive (`NewDB` truncating a fixed, comprehensive table list by default rather than a per-caller
+allowlist). Out of scope to design or implement here; this triage's only obligation is to name it so
+it isn't lost.
+
+## Summary
+
+- 25 named failing tests remain after Tasks 1–6.
+- 6 are already covered by the existing Task 8 (apikeys) — not duplicated.
+- 3 are already-known, already-being-filed production defects (arbitrage varchar overflow, the
+  `audit.Emitter` nil-repo panic behind `whitelabel/lifecycle`, the `billing/tax/revalidation`
+  deadlock) — no new analysis, no new task.
+- 10 are new PRODUCT-class findings from this triage (campaignbudget non-idempotence, the
+  `gorm:"default:true"` footgun shared by `category.IsActive` and `page.Published` across 5 tests,
+  the product soft-delete `Preload` gap, the unreachable `OptionValueInUse` validation order, and the
+  planchange audit-row rollback) — documented above with file:line evidence, no code changed, no
+  issues filed by this task (out of scope: documentation only).
+- 9 are FIXTURE-class and get concrete tasks (10–15) appended to the parent plan below.
+- 1 package (`whitelabel/lifecycle`) fails via panic with no named test, already covered by issue
+  #318 / Task 9.

--- a/docs/superpowers/plans/2026-08-27-integration-fixture-drift-tail.md
+++ b/docs/superpowers/plans/2026-08-27-integration-fixture-drift-tail.md
@@ -29,14 +29,16 @@ a usable instrument on this branch**, for two independent reasons proven while m
 
 **The only trustworthy instrument found: `TRUNCATE` all ~100 tables, then run exactly one package,
 repeat for every package, never let two packages share a database state.** This was run at both the
-baseline commit (`30c3fdff`) and this branch's HEAD. Anyone re-measuring this suite without truncating
-between packages will get fiction and should be told so before they burn a day on it — this note
-exists so the next person doesn't have to rediscover it.
+baseline commit (`30c3fdff`) and a mid-branch snapshot, below. Anyone re-measuring this suite without
+truncating between packages will get fiction and should be told so before they burn a day on it — this
+note exists so the next person doesn't have to rediscover it.
 
-Per-package clean-DB result at this branch's HEAD (`/tmp/clean-iso.txt`):
+Per-package clean-DB result at a mid-branch snapshot, **not** this branch's HEAD (`/tmp/clean-iso.txt`).
+Two of the FAILs below — `apikeys` and `handlers/webhooks` — were subsequently fixed later on this same
+branch; treat this table as history, not the current state:
 
 ```
-./internal/apikeys :: FAIL
+./internal/apikeys :: FAIL (fixed later on this branch)
 ./internal/arbitrage :: FAIL
 ./internal/audit :: ok
 ./internal/billing/dispatch :: ok
@@ -46,7 +48,7 @@ Per-package clean-DB result at this branch's HEAD (`/tmp/clean-iso.txt`):
 ./internal/handlers/admin :: FAIL
 ./internal/handlers/platformadmin :: ok
 ./internal/handlers/storefront :: FAIL
-./internal/handlers/webhooks :: FAIL
+./internal/handlers/webhooks :: FAIL (fixed later on this branch)
 ./internal/orderrefund :: FAIL
 ./internal/page :: FAIL
 ./internal/product :: FAIL

--- a/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
+++ b/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
@@ -894,6 +894,466 @@ git commit -m "docs(product): record why VendorID is still a pointer"
 
 ---
 
+### Task 10: Wire `SubscriptionHandler`/`PromoHandler` into the admin test routers (2 failures)
+
+Source: tail triage (`docs/superpowers/plans/2026-08-27-integration-fixture-drift-tail.md`).
+
+**Files:**
+- Modify: `services/marketplace-api/internal/handlers/admin/products_integration_test.go` — `setupTestRouter` (~line 74)
+- Modify: `services/marketplace-api/internal/handlers/admin/refund_integration_test.go` — `setupRefundTestEnv` (~line 35)
+
+**Interfaces:**
+- Consumes: `admin.NewSubscriptionHandler(svc *subscription.Service, logger *slog.Logger) *SubscriptionHandler`, `admin.NewPromoHandler(db, svc PromoApplier, subRepo subscription.Repository, logger) *PromoHandler`, `subscription.NewService(subscription.ServiceConfig{...}) *Service`, `promo.NewService(db, promo.NewRepository(), nil, nil) *Service`.
+- Produces: nothing new.
+
+**Root cause, not a routing bug.** `internal/handlers/admin/routes.go:704` mounts the entire
+`/subscription` group only `if deps.SubscriptionHandler != nil`, and nests `/apply-promo`,
+`/promo`, and `/refund` further behind `if deps.PromoHandler != nil` / `if deps.RefundHandler != nil`
+respectively. Both test routers construct `admin.Deps{}` without ever setting `SubscriptionHandler`,
+so the group is never registered — the routes exist in production and would work the moment a
+`SubscriptionHandler` is wired. Do not add a route; wire the missing dependency.
+
+- [ ] **Step 1: Confirm the current failures, by name**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/handlers/admin/... \
+  -run 'TestPromoApply_BelowAbsoluteFloor_INR|TestRefund_OutsideCoolingOff' -v 2>&1 | tee /tmp/t10-before.txt
+grep -c '404 page not found' /tmp/t10-before.txt
+```
+
+Expected: non-zero.
+
+- [ ] **Step 2: Wire the missing handlers**
+
+In `products_integration_test.go`, add imports `"github.com/mark8ly/marketplace-api/internal/promo"`
+and `"github.com/mark8ly/marketplace-api/internal/subscription"`. Inside `setupTestRouter`, before
+`r := gin.New()`:
+
+```go
+subSvc := subscription.NewService(subscription.ServiceConfig{
+	DB:   db,
+	Repo: subscription.NewRepository(),
+})
+subHandler := admin.NewSubscriptionHandler(subSvc, nil)
+promoHandler := admin.NewPromoHandler(db, promo.NewService(db, promo.NewRepository(), nil, nil), subscription.NewRepository(), nil)
+```
+
+Add `SubscriptionHandler: subHandler, PromoHandler: promoHandler,` to the `admin.Deps{}` literal
+passed to `admin.RegisterAdmin`.
+
+In `refund_integration_test.go`, `subscription` is already imported and `subRepo :=
+subscription.NewRepository()` already exists. Add, before `r := gin.New()`:
+
+```go
+subHandler := admin.NewSubscriptionHandler(
+	subscription.NewService(subscription.ServiceConfig{DB: db, Repo: subRepo}), nil,
+)
+```
+
+Add `SubscriptionHandler: subHandler,` to that file's `admin.Deps{}` literal (`RefundHandler` is
+already set there).
+
+- [ ] **Step 3: Run and verify**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/handlers/admin/... \
+  -run 'TestPromoApply_BelowAbsoluteFloor_INR|TestRefund_OutsideCoolingOff' -v 2>&1 | tee /tmp/t10-after.txt
+grep -E '^(---|ok|FAIL)' /tmp/t10-after.txt
+```
+
+Expected: `--- PASS` for both, by name.
+
+- [ ] **Step 4: Widen `make test-int`**
+
+Add `./internal/handlers/admin/...` only once Task 13 (below) also lands — this package has two
+other failing tests until then. Do not widen for a partially-red package.
+
+- [ ] **Step 5: Verify formatting and vet**
+
+```bash
+cd services/marketplace-api
+gofmt -l . && go build ./... && go vet ./... && go vet -tags=integration ./...
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "test(admin): wire SubscriptionHandler and PromoHandler into test routers"
+```
+
+---
+
+### Task 11: `orderrefund` — wire a `NoopEncryptor` in the resolver test (1 failure)
+
+Source: tail triage. Exactly the "config-wiring gap at `resolver_integration_test.go:239`" named in
+the original brief for #317.
+
+**Files:**
+- Modify: `services/marketplace-api/internal/orderrefund/resolver_integration_test.go:229` (`TestGatewayFor_ActiveConfig`)
+
+**Interfaces:**
+- Consumes: `orderrefund.(*Resolver).WithEncryptor(e crypto.Encryptor) *Resolver`, `crypto.NewNoopEncryptor()` — both already exist and are already used the same way by the sibling file `resolver_creds_test.go:56` in this package.
+- Produces: nothing new.
+
+`orderrefund.NewResolver(db)` deliberately returns an unconfigured resolver — see the doc comment at
+`resolver.go:48`: "Wire `WithSecretStore` (or `WithEncryptor`) before use." `TestGatewayFor_ActiveConfig`
+never chains either, so `GatewayFor` hits the intentional guard at `resolver.go:78`. This is not a
+production defect; every other test in the package already wires one.
+
+- [ ] **Step 1: Confirm the current failure**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/orderrefund/... -run 'TestGatewayFor_ActiveConfig' -v 2>&1 | tee /tmp/t11-before.txt
+grep -c 'no secret store or encryptor wired' /tmp/t11-before.txt
+```
+
+Expected: `1`.
+
+- [ ] **Step 2: Chain `.WithEncryptor`**
+
+Add import `"github.com/mark8ly/marketplace-api/internal/crypto"`. In `TestGatewayFor_ActiveConfig`:
+
+```go
+r := orderrefund.NewResolver(db).WithEncryptor(crypto.NewNoopEncryptor())
+```
+
+- [ ] **Step 3: Run and verify**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/orderrefund/... -run 'TestGatewayFor_ActiveConfig' -v 2>&1 | tee /tmp/t11-after.txt
+grep -E '^(---|ok|FAIL)' /tmp/t11-after.txt
+```
+
+Expected: `--- PASS: TestGatewayFor_ActiveConfig`. Do not widen `make test-int` for this package —
+`internal/orderrefund` has a separate cleanup deadlock named in #317 that this task does not touch.
+
+- [ ] **Step 4: Verify formatting and vet**
+
+```bash
+cd services/marketplace-api
+gofmt -l . && go build ./... && go vet ./... && go vet -tags=integration ./...
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "test(orderrefund): wire a NoopEncryptor into the resolver active-config test"
+```
+
+---
+
+### Task 12: `handlers/webhooks` — fix the off-by-one fixture path (1 failure)
+
+Source: tail triage.
+
+**Files:**
+- Modify: `services/marketplace-api/internal/handlers/webhooks/stripe_integration_test.go:41`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing new.
+
+The test file lives at `internal/handlers/webhooks/`, three directories below
+`services/marketplace-api/`. Its `filepath.Join("..", "..", "scripts", "webhook-fixtures")` only
+climbs two, landing on `internal/scripts/webhook-fixtures` — which does not exist. The fixtures are
+real, tracked, and present at `services/marketplace-api/scripts/webhook-fixtures/` (verified via
+`git ls-files` — 11 JSON files). This is a path bug, not a missing-fixture bug.
+
+- [ ] **Step 1: Confirm the current failure**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/handlers/webhooks/... -run 'TestFullWebhookFlow_AllAllowlistedEvents' -v 2>&1 | tee /tmp/t12-before.txt
+grep -c 'no such file or directory' /tmp/t12-before.txt
+```
+
+Expected: `1`.
+
+- [ ] **Step 2: Add the missing `..`**
+
+```go
+dir := filepath.Join("..", "..", "..", "scripts", "webhook-fixtures")
+```
+
+- [ ] **Step 3: Run and verify**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/handlers/webhooks/... -run 'TestFullWebhookFlow_AllAllowlistedEvents' -v 2>&1 | tee /tmp/t12-after.txt
+grep -E '^(---|ok|FAIL)' /tmp/t12-after.txt
+```
+
+Expected: `--- PASS: TestFullWebhookFlow_AllAllowlistedEvents`.
+
+- [ ] **Step 4: Widen `make test-int` for `./internal/handlers/webhooks/...`**, if the full package is green.
+
+- [ ] **Step 5: Verify formatting and vet**
+
+```bash
+cd services/marketplace-api
+gofmt -l . && go build ./... && go vet ./... && go vet -tags=integration ./...
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "test(webhooks): fix the off-by-one relative path to scripts/webhook-fixtures"
+```
+
+---
+
+### Task 13: `handlers/admin` shipments — seed the parent order and use `testdb.SeedStore` (3 failures)
+
+Source: tail triage. This is the `stores.created_at` / `shipments_order_id_fkey` cluster the original
+Task 7 brief named for `internal/handlers/admin`.
+
+**Files:**
+- Modify: `services/marketplace-api/internal/handlers/admin/shipments_dispatched_dedup_test.go:34` (`TestShipmentDispatchedEmailGate`)
+- Modify: `services/marketplace-api/internal/handlers/admin/shipments_tracking_sync_test.go:273` (`seedStoreRowForSync`)
+
+**Interfaces:**
+- Consumes: `testdb.SeedStore(t, db, tenantID, storeID)` from Task 1; `seedOrderRowForSync(t, db, orderID, storeID, tenantID)`, already defined in this package at `shipments_tracking_sync_test.go:290`.
+- Produces: nothing new.
+
+**`stores.created_at` does not exist.** `seedStoreRowForSync` hand-rolls
+`INSERT INTO stores (..., created_at, ...)`. Per this plan's verified schema facts, `stores` has no
+`created_at` column at all. Replace the hand-rolled insert with the shared helper, same as every
+other cluster-C/A site.
+
+**`shipments_order_id_fkey`.** `TestShipmentDispatchedEmailGate` mints `orderID := uuid.New()` and
+inserts a `shipments` row referencing it directly, without ever inserting the parent `orders` row.
+`seedOrderRowForSync` already exists in this same package for exactly this purpose.
+
+- [ ] **Step 1: Confirm the current failures, by name**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/handlers/admin/... \
+  -run 'TestShipmentDispatchedEmailGate|TestShipmentsSync_AdvancesStatusLadder|TestShipmentsSync_CarrierErrorDoesNotBlockOthers' -v 2>&1 | tee /tmp/t13-before.txt
+grep -cE 'created_at.*does not exist|shipments_order_id_fkey' /tmp/t13-before.txt
+```
+
+Expected: non-zero.
+
+- [ ] **Step 2: Apply both edits**
+
+In `shipments_tracking_sync_test.go`, replace `seedStoreRowForSync`'s body with a call to
+`testdb.SeedStore(t, db, tenantID, storeID)` (add the `pkg/testdb` import if not already present —
+it already is, per the file's existing `testdb.NewDB` usage). Delete the hand-rolled `INSERT INTO
+stores` and its comment about `migrations/000002_orders_initial.up.sql`.
+
+In `shipments_dispatched_dedup_test.go`, immediately before the `db.Create(&ship)` call in
+`TestShipmentDispatchedEmailGate`, add:
+
+```go
+seedOrderRowForSync(t, db, orderID, storeID, tenantID)
+```
+
+(Both files are in package `admin_test`, so the helper is already in scope — no new import needed.)
+
+- [ ] **Step 3: Run and verify**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/handlers/admin/... \
+  -run 'TestShipmentDispatchedEmailGate|TestShipmentsSync_AdvancesStatusLadder|TestShipmentsSync_CarrierErrorDoesNotBlockOthers' -v 2>&1 | tee /tmp/t13-after.txt
+grep -E '^(---|ok|FAIL)' /tmp/t13-after.txt
+```
+
+Expected: `--- PASS` for all three, by name.
+
+- [ ] **Step 4: Widen `make test-int` for `./internal/handlers/admin/...`**
+
+Only once this task's three tests and Task 10's two tests are all green — confirm with a full
+package run before widening:
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/handlers/admin/... 2>&1 | tail -5
+```
+
+Expected: `ok`.
+
+- [ ] **Step 5: Verify formatting and vet**
+
+```bash
+cd services/marketplace-api
+gofmt -l . && go build ./... && go vet ./... && go vet -tags=integration ./...
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "test(admin): seed the parent order for shipments and use testdb.SeedStore for sync tests"
+```
+
+---
+
+### Task 14: `page` — savepoint the expected-to-fail duplicate-slug insert (1 failure)
+
+Source: tail triage.
+
+**Files:**
+- Modify: `services/marketplace-api/internal/page/repository_integration_test.go:148` (`TestRepository_Create_DuplicateSlug_Errors`)
+
+**Interfaces:**
+- Consumes: nothing new — mirrors `category`'s existing `expectCreateFails` pattern at `internal/category/repository_integration_test.go:39-52`.
+- Produces: nothing new.
+
+The test runs three `repo.Create` calls inside one shared `testdb.NewTx` transaction and expects the
+second (a real duplicate-slug constraint violation) to fail while the third succeeds. Postgres aborts
+the whole transaction on any real SQL-level error until a `ROLLBACK` or a `SAVEPOINT` recovery; there
+is none here, so the third statement fails with `25P02` regardless of what it is. This is the masking
+effect the parent plan's Task 7 brief predicted, occurring within a single test instead of across
+tests.
+
+- [ ] **Step 1: Confirm the current failure**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/page/... -run 'TestRepository_Create_DuplicateSlug_Errors' -v 2>&1 | tee /tmp/t14-before.txt
+grep -c 'current transaction is aborted' /tmp/t14-before.txt
+```
+
+Expected: `1`.
+
+- [ ] **Step 2: Savepoint the expected-to-fail insert**
+
+Wrap the second `repo.Create` call (the one asserted to error) with `SAVEPOINT` /
+`ROLLBACK TO SAVEPOINT`, matching `category`'s `expectCreateFails`:
+
+```go
+require.NoError(t, tx.Exec("SAVEPOINT sp").Error)
+err := repo.Create(context.Background(), &Page{
+	TenantID: tenantID,
+	StoreID:  storeID,
+	Slug:     "dup-slug",
+	Title:    "Second",
+})
+require.Error(t, err, "inserting duplicate (store_id, slug) should violate the unique index")
+require.True(t, errors.Is(err, apperrors.ErrSlugTaken), "expected SlugTaken, got %v", err)
+require.NoError(t, tx.Exec("ROLLBACK TO SAVEPOINT sp").Error)
+```
+
+Leave the first and third `repo.Create` calls untouched — only the one expected to fail needs the
+savepoint.
+
+- [ ] **Step 3: Run and verify**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/page/... -run 'TestRepository_Create_DuplicateSlug_Errors' -v 2>&1 | tee /tmp/t14-after.txt
+grep -E '^(---|ok|FAIL)' /tmp/t14-after.txt
+```
+
+Expected: `--- PASS: TestRepository_Create_DuplicateSlug_Errors`. Do not widen `make test-int` for
+`internal/page` — the package still has two PRODUCT-class failures (see the tail triage doc) that are
+out of scope for this task.
+
+- [ ] **Step 4: Verify formatting and vet**
+
+```bash
+cd services/marketplace-api
+gofmt -l . && go build ./... && go vet ./... && go vet -tags=integration ./...
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "test(page): savepoint the expected-to-fail duplicate-slug insert"
+```
+
+---
+
+### Task 15: `product` — stop comparing against a transaction-frozen `now()` (1 failure)
+
+Source: tail triage.
+
+**Files:**
+- Modify: `services/marketplace-api/internal/product/repository_integration_test.go:403` (`TestIntegration_ProductRepo_ListPublished_ExcludesDraftArchivedDeletedUnpublished`)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: nothing new.
+
+Postgres freezes `now()` to the moment a transaction begins and holds that value for every statement
+inside it. `testdb.NewTx` opens the transaction before the test does anything else; the test then
+seeds a store and creates several aggregates before capturing `now := time.Now()` and using it as
+`PublishedAt` — an app-clock value captured strictly after the transaction began. `ListPublished`'s
+`WHERE ... published_at <= now()` evaluates Postgres's frozen `now()`, which is earlier than the
+freshly-captured Go timestamp, so the row reads as "published in the future" and is filtered out.
+Deterministic given any nonzero seeding time before the capture, not flaky.
+
+- [ ] **Step 1: Confirm the current failure**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/product/... -run 'TestIntegration_ProductRepo_ListPublished_ExcludesDraftArchivedDeletedUnpublished' -v 2>&1 | tee /tmp/t15-before.txt
+grep -c 'expected 1, got 0' /tmp/t15-before.txt
+```
+
+Expected: `1`.
+
+- [ ] **Step 2: Backdate `PublishedAt`**
+
+```go
+now := time.Now().Add(-time.Hour)
+```
+
+An hour is comfortably clear of any realistic transaction duration while still passing every other
+assertion in the test (the `d` aggregate's soft-delete check does not depend on the absolute value of
+`now`, only that it is a valid past timestamp).
+
+- [ ] **Step 3: Run and verify**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/product/... -run 'TestIntegration_ProductRepo_ListPublished_ExcludesDraftArchivedDeletedUnpublished' -v 2>&1 | tee /tmp/t15-after.txt
+grep -E '^(---|ok|FAIL)' /tmp/t15-after.txt
+```
+
+Expected: `--- PASS`. Do not widen `make test-int` for `internal/product` — the package still has two
+PRODUCT-class failures (soft-deleted variants leaking through `Preload`, and an apparently-unreachable
+`OptionValueInUse` path) documented in the tail triage doc, out of scope for this task.
+
+- [ ] **Step 4: Verify formatting and vet**
+
+```bash
+cd services/marketplace-api
+gofmt -l . && go build ./... && go vet ./... && go vet -tags=integration ./...
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "test(product): backdate PublishedAt to avoid the transaction-frozen now() gotcha"
+```
+
+---
+
 ## Definition of Done
 
 - `comm -13 baseline-tests.txt after-tests.txt` is empty — this branch added zero failures.

--- a/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
+++ b/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
@@ -1511,6 +1511,18 @@ Add the seed between those two statements:
 is needed. Pass the same `tenantID` — a store on a different tenant would insert cleanly and leave
 the test asserting nothing about tenancy.
 
+- [ ] **Step 2b: Fix the stale path comment in the same file**
+
+The comment above the fixture-path code (`stripe_integration_test.go:41`) still describes the old,
+wrong path:
+
+```go
+// ... relative to this file: ../../scripts/webhook-fixtures
+```
+
+Task 12 corrected the code to `../../../` but left the comment behind. Update it to match. A comment
+that contradicts the line beneath it is how the next person "fixes" working code.
+
 - [ ] **Step 3: Verify by name**
 
 ```bash

--- a/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
+++ b/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
@@ -1461,3 +1461,88 @@ git commit -m "test(product): backdate PublishedAt to avoid the transaction-froz
 - `make test-int` covers every package made green, and passes.
 - Two issues filed and read back; `models.go` references the model one.
 - Any remaining failure is either triaged in the tail doc with a named cause, or filed as its own issue. Nothing is left unexplained.
+
+---
+
+### Task 16: `handlers/webhooks` — seed the store behind the fixture subscription (1 failure)
+
+Found by Task 12, which fixed the fixture *path* for `TestFullWebhookFlow_AllAllowlistedEvents` and
+thereby let the test run far enough to hit a second, independent defect. Classic unmasking: the path
+error aborted before the seed was ever reached.
+
+**Files:**
+- Modify: `services/marketplace-api/internal/handlers/webhooks/stripe_integration_test.go:50-57`
+- Modify: `Makefile` (only if the package comes back fully green)
+
+**Interfaces:**
+- Consumes: `testdb.SeedStore(t, db, tenantID, storeID)` from Task 1.
+- Produces: nothing new.
+
+- [ ] **Step 1: Confirm the current failure**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 -run TestFullWebhookFlow_AllAllowlistedEvents \
+  ./internal/handlers/webhooks/... -v 2>&1 | grep -E '^(---|ok|FAIL)|store_id_fkey'
+```
+
+Expected: `--- FAIL`, with `store_subscriptions_store_id_fkey`.
+
+- [ ] **Step 2: Seed the store before the subscription insert**
+
+The test mints a tenant and store id and then inserts a `store_subscriptions` row referencing a
+`stores` row that was never created:
+
+```go
+	tenantID, storeID := uuid.New(), uuid.New()
+	require.NoError(t, db.Create(&subscription.StoreSubscription{
+```
+
+Add the seed between those two statements:
+
+```go
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
+	require.NoError(t, db.Create(&subscription.StoreSubscription{
+```
+
+`testdb` is already imported in this file (`testdb.NewDB` is called at line 47), so no import change
+is needed. Pass the same `tenantID` — a store on a different tenant would insert cleanly and leave
+the test asserting nothing about tenancy.
+
+- [ ] **Step 3: Verify by name**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 -run TestFullWebhookFlow_AllAllowlistedEvents \
+  ./internal/handlers/webhooks/... -v 2>&1 | grep -E '^(---|ok|FAIL)'
+```
+
+Expected: `--- PASS: TestFullWebhookFlow_AllAllowlistedEvents`. A `--- SKIP` means the database URL is
+wrong — fix it and re-run rather than reporting success.
+
+- [ ] **Step 4: Run the whole package and decide on the Makefile**
+
+```bash
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/handlers/webhooks/... 2>&1 | tail -5
+```
+
+Widen `make test-int` with `./internal/handlers/webhooks/...` **only** if the package is fully green.
+Append; do not replace. Verify, don't assume.
+
+- [ ] **Step 5: Verify formatting and vet**
+
+```bash
+cd services/marketplace-api
+gofmt -l . && go build ./... && go vet ./... && go vet -tags=integration ./...
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "test(webhooks): seed the store behind the fixture subscription"
+```

--- a/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
+++ b/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
@@ -296,12 +296,27 @@ Smallest of the three big clusters, and it exercises `SeedStore` end-to-end befo
 **Files:**
 - Modify: `services/marketplace-api/internal/category/repository_integration_test.go:64`
 - Modify: `services/marketplace-api/internal/handlers/internalsvc/storefront_status_test.go:81`
-- Modify: `services/marketplace-api/internal/subscription/planchange/criterion_39_test.go:41`
+- Modify: `services/marketplace-api/internal/subscription/planchange/planchange_integration_test.go:40` — the local `seedStores` helper
 - Modify: `Makefile:68-74`
 
 **Interfaces:**
 - Consumes: `testdb.SeedStore(t, db, tenantID, storeID)` from Task 1.
 - Produces: nothing new.
+
+**Note on `internal/subscription/planchange` — corrected site.** #317 points at
+`criterion_39_test.go:41`. That is the *call site* (`seedStores(t, db, tenantID, 1)`), not the broken
+insert. The defect is in the package-local `seedStores` helper at `planchange_integration_test.go:40`,
+whose INSERT omits `storefront_customer_portal_secret`. A second insert at
+`planchange_integration_test.go:302` already supplies it correctly — leave that one alone.
+
+Fix `seedStores` by having it call `testdb.SeedStore` in its loop, so there is one definition of a
+valid store. Keep its `(t, db, tenantID, n)` signature and its `synced_at` behaviour: `synced_at` is
+NOT NULL but carries a default, which is why `testdb.SeedStore` does not set it and still works. No
+planchange production code reads `synced_at`, so dropping the explicit `now()` is safe.
+
+Per the controller's pre-flight ruling: this task edits ONLY `planchange_integration_test.go`'s
+`seedStores` helper in that package, and does NOT widen the Makefile for planchange — the package
+stays red on cluster B until Task 5 owns it.
 
 **Note on `internal/outbox`.** #317 lists `outbox/publisher_integration_test.go:58` as a cluster-C
 site. It is **not** failing — the baseline records `ok  internal/outbox  3.002s`. The issue's site

--- a/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
+++ b/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
@@ -409,11 +409,24 @@ git commit -m "test(fixtures): seed stores via testdb.SeedStore and widen test-i
 - Modify: `services/marketplace-api/internal/product/models_integration_test.go:81` and siblings in that package
 - Modify: `services/marketplace-api/internal/handlers/storefront/storefront_integration_test.go:233` and siblings
 - Modify: `services/marketplace-api/internal/handlers/admin/products_integration_test.go:223`
+- Modify: `services/marketplace-api/internal/handlers/storefront/dto_test.go`
+- Modify: `services/marketplace-api/internal/handlers/admin/dto_test.go`
+- Modify: `services/marketplace-api/internal/product/repository_integration_test.go`
+- Modify: `services/marketplace-api/internal/category/` — **added after Task 2**, see below
 - Modify: `Makefile`
 
 **Interfaces:**
 - Consumes: `testdb.SeedVendor(t, db, tenantID) uuid.UUID` and `testdb.SeedStore` from Task 1.
 - Produces: nothing new.
+
+**`internal/category` was added to this task after Task 2 landed, and the reason matters.** At
+baseline `category` showed 16 `storefront_customer_portal_secret` failures and zero `vendor_id`
+failures. With cluster C fixed, it now shows **2 `vendor_id` failures that were previously invisible**
+— the earlier insert aborted the transaction (`SQLSTATE 25P02`) before the product insert was ever
+reached. This is the masking effect this plan predicted, observed for real, and it is why Task 7
+re-measures rather than trusting the baseline's per-package attribution. Expect the same to happen
+again: after this task, packages you did not touch may reveal new signatures. That is the process
+working, not a regression.
 
 **Note on the model.** `internal/product/models.go:52` declares `VendorID *string` against a `NOT NULL` column. That mismatch is *why* these fixtures compile while producing invalid rows. Tightening it is deliberately **out of scope** — it changes production code, JSON `omitempty` behaviour and every nil check. Task 9 files it as its own issue. Here, set the pointer.
 

--- a/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
+++ b/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
@@ -830,66 +830,166 @@ git commit -m "test(apikeys): fix varchar(60) overflow in fixtures and widen tes
 
 ---
 
-### Task 9: File the two production defects found while measuring
+### Task 9: File the production defects found while relighting the suite
 
-Neither is a fixture problem and neither should be fixed inside a test-repair branch. Both were found by running the dark suite — which is the argument for this whole plan.
+*(Rewritten after Task 7's triage. This was scoped as two issues; the triage found ten defects, so it
+is now eight new issues plus one comment. None is a fixture problem, and none may be fixed inside a
+test-repair branch. Every one of them was found by running a suite that had been dark — which is the
+entire argument for this plan.)*
 
 **Files:**
-- No code changes. Two GitHub issues.
+- No code changes except one comment in `internal/product/models.go`. Eight GitHub issues, one comment.
+
+**CHECK FOR DUPLICATES BEFORE FILING ANYTHING.** `gh issue list --state all --search "<keywords>"`
+for each defect. The `audit.Emitter` panic is **already filed as #318** (created 2026-08-23) — do NOT
+re-file it; add a comment recording the independent reproduction instead. A duplicate issue is worse
+than no issue. Read back every write with `gh issue view <n>` — a `gh` write that is not read back is
+not known to have happened.
+
+**Severity order — file the customer-facing one first**, so that if anything interrupts you the most
+important one exists:
+
+1. **GORM `default:` + non-pointer `bool`: `false` can never be persisted.** `page.Published`
+   (`internal/page/models.go:21`) and `category.IsActive` (`internal/category/models.go:20`) are plain
+   `bool` fields carrying `gorm:"...default:true"`. GORM omits a zero-valued field from the INSERT
+   when it has a `default:` tag, and `false` is the zero value for `bool`, so the column default
+   `true` silently wins. `page.Repository.Create` (`repository.go:29-34`) does a plain `.Create(p)`
+   with no workaround. **Consequence: categories cannot be deactivated, and unpublished pages are
+   served to customers on the storefront.** Five failing tests across `page`, `handlers/storefront`
+   and `category` share this one root cause. Suggested fix: `*bool` fields, or `Select`/`Omit` on
+   create, or drop the `default:` tag. Note in the issue that any other model with the same
+   shape (`bool` + `default:`) is suspect and worth an audit.
+2. **`Variant.DeletedAt` is `*time.Time`, not `gorm.DeletedAt`** (`internal/product/models.go:130`;
+   `gorm.DeletedAt` appears zero times in that file). GORM's automatic soft-delete filtering
+   therefore never applies, and all five `Preload("Variants")` sites in
+   `internal/product/repository.go` (lines 209, 281, 351, 405, 447) return soft-deleted variants
+   alongside active ones on every aggregate read. Systemic — affects every caller, not one test.
+3. **The tax revalidation cron deadlocks, and takes the whole integration suite with it.**
+   `Cron.Run` (`internal/billing/tax/revalidation/cron.go:78`) opens a transaction and takes
+   `pg_advisory_xact_lock`; `processOne` UPDATEs `store_subscriptions` inside it (`cron.go:143`);
+   then `c.Svc.Submit(ctx, in)` — which takes no `tx` (`internal/billing/tax/service.go:67`) — runs on
+   a different pooled connection and writes the same row. It blocks on the uncommitted row lock while
+   the outer transaction waits for it to return. Postgres's deadlock detector sees no cycle (the
+   outer transaction is idle-in-transaction, not waiting on a lock), so there is no error — just an
+   unbounded hang. **Include the blast radius**, measured: with this package in a `-p 1` run,
+   `billing/trial`, `campaignbudget`, `campaignbudget/cron` and `category` all hit the test timeout;
+   with it absent they take 11.3s, 1.1s, 0.6s and 0.9s. In production the cron hangs forever on the
+   first stale validation, holding the advisory lock and blocking every subsequent run. It has never
+   run successfully. Note that `make test-int` deliberately lists `./internal/billing/tax`
+   non-recursively because of this.
+4. **A blocked downgrade's audit row is written and then rolled back.**
+   `internal/subscription/planchange/downgrade.go:41-50` calls `WritePlanChangeAuditRowTx` with
+   `Action: "downgrade_blocked_over_quota"` on the same `tx` the operation runs in, then returns
+   `ErrStoreCountOverQuota` at `downgrade.go:70`. That `tx` comes from `WithAdvisoryLock`
+   (`internal/subscription/advisory_lock.go:15-22`), which wraps everything in
+   `db.Transaction(...)` — a non-nil return rolls it back. The comment at `downgrade.go:40` says the
+   row exists "so ops can see why the downgrade was refused"; it is defeated by the transaction it
+   runs inside. The audit trail for the one case ops most needs never persists.
+5. **Merchant appeals cannot be recorded.** `internal/arbitrage/appeal.go:89` builds
+   `existingReason + "\n---\nMERCHANT_APPEAL jurisdiction=" + country`, then appends
+   `" justification=" + <merchant free text>` and `" doc=" + <URL>`, and writes the result to
+   `subscription_arbitrage_audit.mismatch_reason`, which is `varchar(100)`. The boilerplate alone is
+   ~40 characters on top of an existing reason, so any realistic appeal overflows and the UPDATE
+   fails with SQLSTATE 22001 — the appeal is not recorded. Unbounded by design: every appeal appends
+   to the same 100-char column. Suggested fix: widen the column, or move appeals to their own table.
+6. **`ApplyTrialRamp` is not idempotent against consumption.**
+   `internal/campaignbudget/ramp.go:56-73` runs `SET remaining = GREATEST(remaining, 2000)`. Its own
+   docstring (`ramp.go:44-46`) claims idempotency, but if a merchant spends between runs, a re-run
+   re-inflates the balance they already consumed. Seed 50 → ramp(day4) → 2000 → `Reserve(200)` → 1800
+   → ramp(day4) again → back to 2000.
+7. **`OptionValueInUse` appears unreachable through the public API.**
+   `internal/product/service_aggregate.go:445`'s guard sits behind `ValidateMatrix`
+   (`internal/product/matrix.go:52`, called at `service_aggregate.go:108`), which rejects any variant
+   referencing an option value absent from the desired spec — which is precisely the scenario the
+   guard exists for. Either loosen the validation so the intended check can run, or confirm the path
+   is dead and document it as defence-in-depth. State the uncertainty honestly; this one is
+   "appears", not "is".
+8. **Cross-package integration-test pollution.** `pkg/testdb`'s `NewDB` truncates only the tables it
+   is explicitly given, so a package doing raw inserts leaves rows that break the next package. Since
+   the fixtures were repaired, a full `./...` run reports ~46 failures that do not reproduce, and 7 of
+   19 "failing" packages actually pass on a clean database. **Any full-suite measurement must
+   TRUNCATE between packages or it reports fiction.** This did not surface before because tests
+   aborted early on FK/NOT NULL violations and never wrote enough to pollute anything — the repair
+   made it visible. Include the reproduction: run the 19 packages sequentially without a reset and
+   watch `dispatch` and `dunning` flip between pass and fail depending on order.
 
 **Interfaces:**
 - Consumes: findings from the baseline run.
 - Produces: issue numbers to reference from `internal/product/models.go` and the tail triage doc.
 
-- [ ] **Step 1: File the `audit.Emitter` nil-repo panic**
-
-Title: `audit.NewEmitter accepts a nil Repo and the worker goroutine panics, killing the process`
-
-Body must contain:
-- `NewEmitter` (`internal/audit/emitter.go:76`) defaults `QueueSize` and `Workers` but never validates `cfg.Repo` or `cfg.DB`.
-- `Emit` (`:99`) explicitly guards `e == nil` with the comment *"safe to call when wiring opted out (e.g. unit tests)"* — so nil-tolerance is an intended part of this type's contract, and the validation gap is inconsistent with it.
-- With a nil `Repo`, `write` (`:216`) dereferences it inside `worker`, on a background goroutine. A panic there cannot be recovered by the caller and takes down the whole process — it does not return an error, and no request-scoped recovery middleware sees it.
-- Reproduced by `internal/whitelabel/lifecycle` in the 2026-08-27 baseline run; the panic aborts the test binary, so that package's remaining tests never ran.
-- Suggested fix: fail fast in `NewEmitter` when `Repo` or `DB` is nil, or make `write` degrade to a log line. Fail-fast at construction is preferable — a silently dropped audit trail is its own problem.
-
-- [ ] **Step 2: File the `Product.VendorID` type mismatch**
-
-Title: `product.Product.VendorID is *string against a NOT NULL column, so invalid products only fail at insert time`
-
-Body must contain:
-- `internal/product/models.go:52` declares `VendorID *string`; migration `000028_products_vendor_id_not_null.up.sql` made the column `NOT NULL`, with a guard that aborts if any row still has a NULL.
-- The migration is deliberate and correct — it documents that `product.Create` defaults new products to the tenant's self-vendor. The struct is what is stale.
-- Consequence: nothing prevents constructing a `Product` without a vendor, so the failure surfaces as a database error at insert. This is the direct cause of 74 integration failures across three packages, fixed at the fixture level in Task 3.
-- Tightening to a non-pointer `string` touches JSON `omitempty` behaviour and every nil check, so it needs its own change and its own review.
-
-- [ ] **Step 3: Read both issues back**
+- [ ] **Step 1: Check every defect for an existing issue before filing**
 
 ```bash
-for n in <issue-a> <issue-b>; do
-  gh issue view "$n" --json number,state,title,body --jq '"#\(.number) \(.state) bodylen=\(.body|length) \(.title)"'
+for q in "Emitter nil Repo" "revalidation deadlock" "mismatch_reason" "vendor_id NOT NULL" \
+         "soft delete variant" "published default" "ApplyTrialRamp" "OptionValueInUse" \
+         "testdb truncate"; do
+  printf "\n### %s\n" "$q"
+  gh issue list --state all --search "$q" --limit 5 --json number,state,title \
+    --jq '.[]|"  #\(.number) \(.state) \(.title)"'
 done
 ```
 
-A `gh` write that is not read back is not known to have happened.
+At the time of writing only one match existed: **#318**, `audit.NewEmitter accepts a nil Repo and
+panics a worker goroutine on first write`, created 2026-08-23. Verify that is still the case — if
+someone has filed one of the others in the meantime, comment on theirs instead of opening a second.
 
-- [ ] **Step 4: Reference the model issue from the code**
+- [ ] **Step 2: File the eight new issues, in the severity order given above**
 
-Add above `internal/product/models.go:52`:
+One issue per numbered defect in this task's header. Copy the file:line evidence verbatim — it was
+verified against source by two independent reviewers, and re-deriving it risks introducing errors.
+Do not merge defects 1 and 2 into a single "GORM modelling" issue: they have different fixes, different
+blast radii, and one is customer-facing while the other is not.
+
+- [ ] **Step 3: Comment on #318 rather than re-filing it**
+
+```bash
+gh issue comment 318 --body "<reproduction note>"
+```
+
+The comment should record: reproduced independently on 2026-08-27 by `internal/whitelabel/lifecycle`
+during the integration-fixture repair; the panic aborts the whole test binary, so that package's
+remaining tests never run; and that this is why the package still shows a failure after the fixture
+work. Do not restate the diagnosis already in the issue.
+
+- [ ] **Step 4: Read back every write**
+
+```bash
+for n in <each new issue number>; do
+  gh issue view "$n" --json number,state,title,body --jq '"#\(.number) \(.state) bodylen=\(.body|length) \(.title)"'
+done
+gh issue view 318 --json comments --jq '.comments[-1].body|length'
+```
+
+A `gh` write that is not read back is not known to have happened. A body length of 0 means the issue
+was created empty — refill it with `gh issue edit <n> --body-file`.
+
+- [ ] **Step 5: Reference the model issues from the code**
+
+Above `internal/product/models.go:52`:
 
 ```go
 // VendorID is a pointer for historical reasons; the column has been NOT NULL
-// since migration 000028. See issue #<issue-b> — tightening it to a plain
-// string touches JSON omitempty and every nil check, so it is tracked
+// since migration 000028. See issue #<vendor-id-issue> — tightening it to a
+// plain string touches JSON omitempty and every nil check, so it is tracked
 // separately.
 ```
 
-Run `gofmt -l .` afterwards: inserting a comment into an aligned struct re-aligns the fields above it.
+Above `internal/product/models.go:130` (the `Variant.DeletedAt` field):
 
-- [ ] **Step 5: Commit**
+```go
+// DeletedAt is a plain *time.Time, not gorm.DeletedAt, so GORM's automatic
+// soft-delete filtering does NOT apply — every Preload("Variants") returns
+// deleted rows. See issue #<soft-delete-issue>.
+```
+
+Run `gofmt -l .` afterwards: inserting a comment into an aligned struct re-aligns the fields above
+it, and the review will not catch it if you did not run the tooling.
+
+- [ ] **Step 6: Commit**
 
 ```bash
 git add services/marketplace-api/internal/product/models.go
-git commit -m "docs(product): record why VendorID is still a pointer"
+git commit -m "docs(product): record the VendorID and soft-delete modelling issues"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
+++ b/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
@@ -493,7 +493,7 @@ git commit -m "test(fixtures): seed vendors for product inserts and widen test-i
 
 ---
 
-### Task 4: Cluster B part 1 — billing packages (19 failures)
+### Task 4: Cluster B part 1 — billing packages (21 failures)
 
 Cluster B is one root cause across 13 packages: tests insert `store_subscriptions` for a `store_id` with no `stores` row. It is split across three tasks purely so each is reviewable; the edit is identical everywhere.
 
@@ -507,6 +507,12 @@ Cluster B is one root cause across 13 packages: tests insert `store_subscription
 **Interfaces:**
 - Consumes: `testdb.SeedStore` from Task 1.
 - Produces: nothing new.
+
+**Only four billing packages are failing.** `internal/billing/trial`, `internal/billing/migration`
+and `internal/billing/tax/windowguard` are GREEN at baseline — they reference `store_subscriptions`
+but seed correctly. Running `./internal/billing/...` exercises them, which is fine and desirable, but
+**do not edit them**. The failing four are `appaddon` (4), `dispatch` (9), `tax` (4) and
+`tax/revalidation` (4) = 21.
 
 **Why these first.** `internal/billing/dispatch` is the package #384 and #389 rewrote. Its tests currently do not run in CI at all, which means the email-delivery invariant those PRs established — `Send` returns `nil` iff a provider accepted — is guarded by tests nothing executes.
 
@@ -613,7 +619,7 @@ git commit -m "test(subscription): seed stores for subscription fixtures and wid
 
 ---
 
-### Task 6: Cluster B part 3 — remaining packages (28 failures)
+### Task 6: Cluster B part 3 — remaining packages (26 failures)
 
 **Files:**
 - Modify: `services/marketplace-api/internal/arbitrage/appeal_test.go:40` and siblings (15)

--- a/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
+++ b/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
@@ -40,7 +40,9 @@
 - Do not change production code in this plan. Two production defects were found while measuring; they are filed as separate issues in Task 9, not fixed here.
 - Schema facts, verified against the migrated database — do not re-derive:
   - `stores` NOT NULL with no default: `id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret`. **`stores` has no `created_at` column at all.**
-  - `vendors` NOT NULL: `id` (default `gen_random_uuid()`), `tenant_id`, `name`, `slug`, `status` (default `'active'`), `is_self` (default `false`), `created_at`/`updated_at` (default `now()`). **No unique constraint beyond the primary key.**
+  - `vendors` NOT NULL: `id` (default `gen_random_uuid()`), `tenant_id`, `name`, `slug`, `status` (default `'active'`), `is_self` (default `false`), `created_at`/`updated_at` (default `now()`).
+  - `vendors` unique **indexes** — `vendors_slug_key` on `slug`, and `vendors_tenant_self_idx`, a **partial unique index on `(tenant_id) WHERE is_self = true`** enforcing one self-vendor per tenant. These are `CREATE UNIQUE INDEX`, not table constraints, so **`pg_constraint` does not list them — query `pg_indexes`.** An earlier revision of this plan asserted "no unique constraint beyond the primary key" for exactly that reason and was wrong.
+  - `stores.synced_at` is NOT NULL but carries a default, which is why the seed helper omits it and still inserts cleanly.
   - `products.vendor_id` is `NOT NULL` with **no foreign key** — only `products_store_id_fkey` and `products_primary_category_id_fkey` exist.
   - `stores_slug_unique` exists, so seeded slugs must be derived from the store id.
 

--- a/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
+++ b/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
@@ -1,0 +1,865 @@
+# Integration Fixture Drift Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Repair the drifted integration-test fixtures in `services/marketplace-api` and widen `make test-int` from 4 packages toward `./...`, so CI actually guards the 47 packages currently dark.
+
+**Architecture:** Migrations added `NOT NULL` columns and foreign keys; fixtures were never updated. Three signatures account for 165 of 187 failures. Fix them with shared seed helpers in the existing untagged `pkg/testdb` package (imported by 136 test files already) rather than copying a helper into 13 packages, then widen the Makefile target one cluster at a time. Re-measure before triaging the tail: within a single test, an early insert failure masks everything after it, so the remaining ~22 failures cannot be honestly classified until the big three are gone.
+
+**Tech Stack:** Go 1.26, GORM v1.25, PostgreSQL 15, `stretchr/testify` v1.11.1, `google/uuid` v1.6.0, build tag `integration`.
+
+**Spec:**
+- GitHub issues [#316](https://github.com/tesserix/mark8ly/issues/316) and [#317](https://github.com/tesserix/mark8ly/issues/317)
+- Precedent for the fix pattern: #315 (`fix(dunning): repair the integration suite and the billing bug it was hiding`)
+- Measured baseline artifacts: `/private/tmp/m8-baseline-artifacts/` — `baseline-full.txt` (raw), `baseline-tests.txt` (187 unique test names), `baseline-sha.txt` (`30c3fdff`)
+
+---
+
+## Global Constraints
+
+- Module path `github.com/mark8ly/marketplace-api`; all work under `services/marketplace-api/`.
+- Single-line conventional commits. No signature, no `Co-Authored-By`, no multi-line body.
+- **Never push, open a PR, merge, deploy, or switch branches.** Ask before merging anything.
+- `gofmt -l .` must be empty before every commit. Inserting a comment into an aligned Go struct re-aligns neighbours — run it yourself, do not assume.
+- `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean.
+- **Use the isolated baseline container, never the shared dev DB.** Another session shares `dev-postgres-1`, and two integration suites against one database corrupt each other. The container is already running:
+  ```
+  TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable'
+  ```
+  If it is gone, recreate it — note port 55432 is taken by `tesserix-dev-postgres`:
+  ```bash
+  docker run -d --name m8-baseline -e POSTGRES_USER=dev -e POSTGRES_PASSWORD=dev \
+    -e POSTGRES_DB=marketplace_db -p 55433:5432 postgres:15
+  docker exec m8-baseline psql -U dev -d marketplace_db -c 'CREATE EXTENSION IF NOT EXISTS pgcrypto;'
+  cd services/marketplace-api && \
+    DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' go run ./cmd/migrate up
+  ```
+  `pgcrypto` must be enabled manually — migration 058 uses `gen_random_bytes`. Verify schema is **106** and `dirty=f` before trusting any run.
+- LAN IP `192.168.1.110`, never `localhost`. Always `-p 1` on integration runs (a shared Postgres exhausts its connection limit otherwise).
+- **`testdb.NewDB` and `NewTx` SKIP when `TEST_DATABASE_URL` is unset or unreachable.** `exit=0` does not distinguish PASS from SKIP. Confirm `--- PASS` by name in every verification step.
+- Do not change production code in this plan. Two production defects were found while measuring; they are filed as separate issues in Task 9, not fixed here.
+- Schema facts, verified against the migrated database — do not re-derive:
+  - `stores` NOT NULL with no default: `id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret`. **`stores` has no `created_at` column at all.**
+  - `vendors` NOT NULL: `id` (default `gen_random_uuid()`), `tenant_id`, `name`, `slug`, `status` (default `'active'`), `is_self` (default `false`), `created_at`/`updated_at` (default `now()`). **No unique constraint beyond the primary key.**
+  - `products.vendor_id` is `NOT NULL` with **no foreign key** — only `products_store_id_fkey` and `products_primary_category_id_fkey` exist.
+  - `stores_slug_unique` exists, so seeded slugs must be derived from the store id.
+
+## Measured Baseline
+
+187 failures / 22 packages at `30c3fdff`, on a clean isolated database at schema 106. Every failure is accounted for:
+
+| Cluster | Errors | Packages | Fixed by |
+|---|---|---|---|
+| **A** `products.vendor_id` NOT NULL | 74 | `product` (54), `handlers/storefront` (18), `handlers/admin` (2) | Task 3 |
+| **B** `store_subscriptions_store_id_fkey` | 69 | 13 packages | Tasks 4–6 |
+| **C** `stores.storefront_customer_portal_secret` NOT NULL | 22 | `category` (16), `handlers/internalsvc` (4), `subscription/planchange` (2) | Task 2 |
+| **D** `apikeys` `varchar(60)` overflow | 6 | `apikeys` | Task 8 |
+| **E–H** tail: `orderrefund` cleanup deadlock, unmounted routes (404), `shipments_order_id_fkey`, `stores.created_at` | ~16 | mixed | Task 7 triage |
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `pkg/testdb/seed.go` *(create)* | Shared fixture seeding: `SeedStore`, `SeedVendor`. Untagged, like the rest of `pkg/testdb`, so any package can import it. One responsibility: produce minimal valid parent rows. |
+| `pkg/testdb/seed_integration_test.go` *(create)* | Proves the helpers satisfy the live constraints — the helpers are themselves fixtures and must be tested, or a bug in them looks like a bug in 13 packages. |
+| `Makefile:68-74` *(modify)* | The `test-int` marketplace-api package list, widened once per cluster task. |
+| Per-package `*_test.go` *(modify)* | Call the shared helpers instead of hand-rolled inserts. Enumerated per task. |
+
+---
+
+### Task 1: Shared seed helpers in `pkg/testdb`
+
+**Files:**
+- Create: `services/marketplace-api/pkg/testdb/seed.go`
+- Create: `services/marketplace-api/pkg/testdb/seed_integration_test.go`
+
+**Interfaces:**
+- Consumes: nothing — this is the base of the plan.
+- Produces, relied on by every later task:
+  - `func SeedStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID)`
+  - `func SeedVendor(t *testing.T, db *gorm.DB, tenantID uuid.UUID) uuid.UUID`
+
+**Design notes — read before writing code.**
+
+`tenantID` is supplied by the caller, never minted inside the helper. This is the deliberate difference between `internal/subscription/dunning`'s helper and `internal/order`'s, and it is the whole point: tests already mint a tenant for the rows they seed, and the store must carry *that* tenant. If the helper minted its own, the store and the subscription would disagree about tenancy and every tenant-scoped assertion would pass while testing nothing.
+
+`SeedVendor` inserts a real `vendors` row even though `products.vendor_id` has no foreign key and any UUID would satisfy the `NOT NULL`. A real row keeps vendor-scoped filtering (`VendorScopeFilter`) and any products→vendors join meaningful. `is_self` is `true` to match `product.Create`, which defaults a new product to the tenant's self-vendor.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `services/marketplace-api/pkg/testdb/seed_integration_test.go`:
+
+```go
+//go:build integration
+
+package testdb_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+func TestSeedStore_SatisfiesNotNullAndUniqueConstraints(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID, storeID := uuid.New(), uuid.New()
+
+	testdb.SeedStore(t, db, tenantID, storeID)
+
+	var got struct {
+		TenantID uuid.UUID
+		Secret   string
+	}
+	err := db.Raw(
+		`SELECT tenant_id, storefront_customer_portal_secret AS secret FROM stores WHERE id = ?`,
+		storeID,
+	).Scan(&got).Error
+	require.NoError(t, err)
+	require.Equal(t, tenantID, got.TenantID, "store must carry the caller's tenant")
+	require.Len(t, got.Secret, 64, "portal secret must be 32 random bytes hex-encoded")
+}
+
+func TestSeedStore_TwoStoresInOneTestDoNotCollideOnSlug(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID := uuid.New()
+
+	testdb.SeedStore(t, db, tenantID, uuid.New())
+	testdb.SeedStore(t, db, tenantID, uuid.New())
+
+	var n int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM stores WHERE tenant_id = ?`, tenantID).Scan(&n).Error)
+	require.EqualValues(t, 2, n)
+}
+
+func TestSeedVendor_ReturnsUsableSelfVendorForTenant(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID := uuid.New()
+
+	vendorID := testdb.SeedVendor(t, db, tenantID)
+	require.NotEqual(t, uuid.Nil, vendorID)
+
+	var got struct {
+		TenantID uuid.UUID
+		IsSelf   bool
+	}
+	err := db.Raw(
+		`SELECT tenant_id, is_self FROM vendors WHERE id = ?`, vendorID,
+	).Scan(&got).Error
+	require.NoError(t, err)
+	require.Equal(t, tenantID, got.TenantID)
+	require.True(t, got.IsSelf, "seeded vendor stands in for the tenant's self-vendor")
+}
+
+// A product insert is the actual thing 74 baseline failures could not do.
+func TestSeededParents_AcceptAProductInsert(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID, storeID := uuid.New(), uuid.New()
+
+	testdb.SeedStore(t, db, tenantID, storeID)
+	vendorID := testdb.SeedVendor(t, db, tenantID)
+
+	err := db.Exec(
+		`INSERT INTO products (id, tenant_id, store_id, vendor_id, handle, title, status)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		uuid.New(), tenantID, storeID, vendorID, "seed-probe", "Seed Probe", "draft",
+	).Error
+	require.NoError(t, err)
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./pkg/testdb/... -run 'TestSeed' -v
+```
+
+Expected: **build failure** — `undefined: testdb.SeedStore`, `undefined: testdb.SeedVendor`. A `--- SKIP` here means `TEST_DATABASE_URL` is wrong; fix that before continuing.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `services/marketplace-api/pkg/testdb/seed.go`:
+
+```go
+package testdb
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// SeedStore inserts a minimal stores row for (tenantID, storeID), satisfying
+// every NOT NULL column the schema requires — including
+// storefront_customer_portal_secret, which a later migration added and most
+// fixtures never caught up with.
+//
+// tenantID is supplied by the caller rather than generated here. Callers
+// already mint a tenant for the rows they seed, and the store must carry that
+// same tenant: otherwise the store and whatever references it disagree about
+// tenancy, and every tenant-scoped assertion passes while testing nothing.
+//
+// Registers a t.Cleanup deleting the row, so packages using NewDB (which
+// truncates only the tables it was told about) still start clean.
+func SeedStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
+	t.Helper()
+
+	// Derived from the store id to dodge stores_slug_unique when one test
+	// seeds several stores.
+	slug := "tst-" + strings.ReplaceAll(storeID.String(), "-", "")[:20]
+
+	err := db.Exec(
+		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, encode(gen_random_bytes(32), 'hex'))`,
+		storeID, tenantID, slug, "Test Store", "IE", "EUR", "Europe/Dublin", "active",
+	).Error
+	if err != nil {
+		t.Fatalf("testdb.SeedStore: insert stores row: %v", err)
+	}
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM stores WHERE id = ?", storeID)
+	})
+}
+
+// SeedVendor inserts a vendors row owned by tenantID and returns its id, for
+// use as products.vendor_id — NOT NULL since migration 000028.
+//
+// The column has no foreign key, so any UUID would satisfy the constraint.
+// A real row is inserted anyway so that vendor-scoped filtering and any
+// products→vendors join stay meaningful; a synthetic id would make those
+// assertions vacuous in exactly the way this plan is trying to stop.
+//
+// is_self is true because product.Create defaults a new product to the
+// tenant's self-vendor, so that is the vendor a fixture should stand in for.
+func SeedVendor(t *testing.T, db *gorm.DB, tenantID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	vendorID := uuid.New()
+	slug := "vnd-" + strings.ReplaceAll(vendorID.String(), "-", "")[:20]
+
+	err := db.Exec(
+		`INSERT INTO vendors (id, tenant_id, name, slug, status, is_self)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		vendorID, tenantID, "Test Vendor", slug, "active", true,
+	).Error
+	if err != nil {
+		t.Fatalf("testdb.SeedVendor: insert vendors row: %v", err)
+	}
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM vendors WHERE id = ?", vendorID)
+	})
+
+	return vendorID
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./pkg/testdb/... -run 'TestSeed' -v
+```
+
+Expected: four `--- PASS` lines, by name. Not `ok` alone — confirm each name.
+
+- [ ] **Step 5: Verify formatting and vet**
+
+```bash
+cd services/marketplace-api
+gofmt -l . && go build ./... && go vet ./... && go vet -tags=integration ./...
+```
+
+Expected: `gofmt -l .` prints nothing; the rest exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/marketplace-api/pkg/testdb/seed.go services/marketplace-api/pkg/testdb/seed_integration_test.go
+git commit -m "test(testdb): add shared SeedStore and SeedVendor fixture helpers"
+```
+
+---
+
+### Task 2: Cluster C — `stores.storefront_customer_portal_secret` (22 failures)
+
+Smallest of the three big clusters, and it exercises `SeedStore` end-to-end before 13 packages depend on it.
+
+**Files:**
+- Modify: `services/marketplace-api/internal/category/repository_integration_test.go:64`
+- Modify: `services/marketplace-api/internal/handlers/internalsvc/storefront_status_test.go:81`
+- Modify: `services/marketplace-api/internal/subscription/planchange/criterion_39_test.go:41`
+- Modify: `Makefile:68-74`
+
+**Interfaces:**
+- Consumes: `testdb.SeedStore(t, db, tenantID, storeID)` from Task 1.
+- Produces: nothing new.
+
+**Note on `internal/outbox`.** #317 lists `outbox/publisher_integration_test.go:58` as a cluster-C
+site. It is **not** failing — the baseline records `ok  internal/outbox  3.002s`. The issue's site
+list is stale there. Leave that file alone; do not "fix" a passing test to match an issue.
+
+- [ ] **Step 1: Confirm the current failures, by name**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 \
+  ./internal/category/... ./internal/handlers/internalsvc/... \
+  ./internal/subscription/planchange/... 2>&1 | tee /tmp/c-before.txt
+grep -c 'storefront_customer_portal_secret' /tmp/c-before.txt
+```
+
+Expected: a non-zero count. Record it — you will assert it reaches 0.
+
+- [ ] **Step 2: Replace each hand-rolled stores INSERT with the helper**
+
+At each of the four sites, delete the inline `INSERT INTO stores (...)` and call the helper. The import to add is `"github.com/mark8ly/marketplace-api/pkg/testdb"` if not already present.
+
+Before (shape varies slightly per file):
+
+```go
+err := db.Exec(`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    storeID, tenantID, "test-store", "Test Store", "IE", "EUR", "Europe/Dublin", "active").Error
+require.NoError(t, err)
+```
+
+After:
+
+```go
+testdb.SeedStore(t, db, tenantID, storeID)
+```
+
+If a site does not already have a `tenantID` in scope, mint one with `uuid.New()` and pass the *same* value to every other row the test seeds. Do not let the helper invent one.
+
+- [ ] **Step 3: Run the four packages and verify the signature is gone**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 \
+  ./internal/category/... ./internal/handlers/internalsvc/... \
+  ./internal/subscription/planchange/... 2>&1 | tee /tmp/c-after.txt
+grep -c 'storefront_customer_portal_secret' /tmp/c-after.txt
+```
+
+Expected: `0`. Any remaining failures in these packages belong to cluster B or the tail — leave them, they are handled later. Do not widen the Makefile for a package that is not fully green.
+
+- [ ] **Step 4: Widen `make test-int` for whichever of these packages are now fully green**
+
+In `Makefile`, add the green packages to the marketplace-api list (currently `./internal/audit/...`, `./internal/handlers/platformadmin/...`, `./internal/tenantpurge/...`, `./internal/subscription/dunning/...`), keeping the existing comment block intact:
+
+```make
+	    ./internal/audit/... \
+	    ./internal/handlers/platformadmin/... \
+	    ./internal/tenantpurge/... \
+	    ./internal/subscription/dunning/... \
+	    ./internal/category/...
+```
+
+Add only packages whose full run is green. A permanently red target is worse than a narrow green one — that is exactly how #315's production dunning bug stayed hidden.
+
+- [ ] **Step 5: Verify formatting and vet**
+
+```bash
+cd services/marketplace-api
+gofmt -l . && go build ./... && go vet ./... && go vet -tags=integration ./...
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "test(fixtures): seed stores via testdb.SeedStore and widen test-int"
+```
+
+---
+
+### Task 3: Cluster A — `products.vendor_id` NOT NULL (74 failures)
+
+**Files:**
+- Modify: `services/marketplace-api/internal/product/models_integration_test.go:81` and siblings in that package
+- Modify: `services/marketplace-api/internal/handlers/storefront/storefront_integration_test.go:233` and siblings
+- Modify: `services/marketplace-api/internal/handlers/admin/products_integration_test.go:223`
+- Modify: `Makefile`
+
+**Interfaces:**
+- Consumes: `testdb.SeedVendor(t, db, tenantID) uuid.UUID` and `testdb.SeedStore` from Task 1.
+- Produces: nothing new.
+
+**Note on the model.** `internal/product/models.go:52` declares `VendorID *string` against a `NOT NULL` column. That mismatch is *why* these fixtures compile while producing invalid rows. Tightening it is deliberately **out of scope** — it changes production code, JSON `omitempty` behaviour and every nil check. Task 9 files it as its own issue. Here, set the pointer.
+
+- [ ] **Step 1: Confirm the current failures, by name**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 \
+  ./internal/product/... ./internal/handlers/storefront/... ./internal/handlers/admin/... 2>&1 | tee /tmp/a-before.txt
+grep -c 'null value in column "vendor_id"' /tmp/a-before.txt
+```
+
+Expected: non-zero (74 across these three packages at baseline).
+
+- [ ] **Step 2: Seed a vendor per test and attach it to every product insert**
+
+Where the test builds a `product.Product` struct:
+
+```go
+vendorID := testdb.SeedVendor(t, db, tenantID)
+vendorIDStr := vendorID.String()
+
+prod := &product.Product{
+	TenantID:          tenantID,
+	StoreID:           storeID,
+	VendorID:          &vendorIDStr,
+	Handle:            "linen-shirt",
+	Title:             "Linen Shirt",
+	Status:            product.StatusDraft,
+	Tags:              []string{"summer", "linen"},
+	PrimaryCategoryID: &shirtCat.ID,
+}
+```
+
+Where the test inserts products with raw SQL, add the column and the value:
+
+```go
+err := db.Exec(
+	`INSERT INTO products (id, tenant_id, store_id, vendor_id, handle, title, status)
+	 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+	uuid.New(), tenantID, storeID, vendorID, "linen-shirt", "Linen Shirt", "draft",
+).Error
+```
+
+Seed the vendor **once per test** and reuse the id for every product in that test. Pass the same `tenantID` used for the store and the products — a vendor on a different tenant makes vendor-scoped assertions vacuous.
+
+- [ ] **Step 3: Run the three packages and verify the signature is gone**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 \
+  ./internal/product/... ./internal/handlers/storefront/... ./internal/handlers/admin/... 2>&1 | tee /tmp/a-after.txt
+grep -c 'null value in column "vendor_id"' /tmp/a-after.txt
+```
+
+Expected: `0`. `internal/handlers/admin` will still fail on the `stores.created_at` signature — that is cluster F, Task 7. Do not widen the Makefile for it.
+
+- [ ] **Step 4: Widen `make test-int` for the packages now fully green**
+
+Same edit shape as Task 2, Step 4. `./internal/product/...` is the expected addition.
+
+- [ ] **Step 5: Verify formatting and vet**
+
+```bash
+cd services/marketplace-api
+gofmt -l . && go build ./... && go vet ./... && go vet -tags=integration ./...
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "test(fixtures): seed vendors for product inserts and widen test-int"
+```
+
+---
+
+### Task 4: Cluster B part 1 — billing packages (19 failures)
+
+Cluster B is one root cause across 13 packages: tests insert `store_subscriptions` for a `store_id` with no `stores` row. It is split across three tasks purely so each is reviewable; the edit is identical everywhere.
+
+**Files:**
+- Modify: `services/marketplace-api/internal/billing/appaddon/*_test.go` (4)
+- Modify: `services/marketplace-api/internal/billing/dispatch/*_test.go` (9)
+- Modify: `services/marketplace-api/internal/billing/tax/*_test.go` (4)
+- Modify: `services/marketplace-api/internal/billing/tax/revalidation/*_test.go` (4)
+- Modify: `Makefile`
+
+**Interfaces:**
+- Consumes: `testdb.SeedStore` from Task 1.
+- Produces: nothing new.
+
+**Why these first.** `internal/billing/dispatch` is the package #384 and #389 rewrote. Its tests currently do not run in CI at all, which means the email-delivery invariant those PRs established — `Send` returns `nil` iff a provider accepted — is guarded by tests nothing executes.
+
+- [ ] **Step 1: Confirm the current failures, by name**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/billing/... 2>&1 | tee /tmp/b1-before.txt
+grep -c 'store_subscriptions_store_id_fkey' /tmp/b1-before.txt
+```
+
+- [ ] **Step 2: Seed the store before each `store_subscriptions` insert**
+
+Add, immediately before the subscription insert:
+
+```go
+testdb.SeedStore(t, db, tenantID, storeID)
+```
+
+Some of these packages already define a local `seedStore`. Delete the local copy and use the shared helper, so there is one definition of a valid store. If a local helper does something extra (dropping per-store sequences, for instance), keep that extra behaviour in the caller rather than reintroducing a second store-seeding path.
+
+- [ ] **Step 3: Run and verify**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/billing/... 2>&1 | tee /tmp/b1-after.txt
+grep -c 'store_subscriptions_store_id_fkey' /tmp/b1-after.txt
+```
+
+Expected: `0`, and `--- PASS` for the dispatch tests by name.
+
+- [ ] **Step 4: Widen `make test-int` for the green billing packages**
+
+- [ ] **Step 5: Verify formatting and vet**
+
+```bash
+cd services/marketplace-api
+gofmt -l . && go build ./... && go vet ./... && go vet -tags=integration ./...
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "test(billing): seed stores for subscription fixtures and widen test-int"
+```
+
+---
+
+### Task 5: Cluster B part 2 — subscription packages (22 failures)
+
+**Files:**
+- Modify: `services/marketplace-api/internal/subscription/*_test.go` (6)
+- Modify: `services/marketplace-api/internal/subscription/planchange/*_test.go` (7)
+- Modify: `services/marketplace-api/internal/subscription/readonly/*_test.go` (2)
+- Modify: `services/marketplace-api/internal/subscription/statemachine/cas_conflict_test.go:34` and siblings (7)
+- Modify: `Makefile`
+
+**Interfaces:**
+- Consumes: `testdb.SeedStore` from Task 1.
+- Produces: nothing new.
+
+- [ ] **Step 1: Confirm the current failures, by name**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/subscription/... 2>&1 | tee /tmp/b2-before.txt
+grep -c 'store_subscriptions_store_id_fkey' /tmp/b2-before.txt
+```
+
+- [ ] **Step 2: Apply the same edit as Task 4, Step 2**
+
+`internal/subscription/dunning` is already correct and already in `make test-int` — it is the source of this pattern. Replace its local `seedStore` with the shared helper too, so there is one definition, but keep `seedPastDueSubscription` where it is: that helper encodes what "eligible for dunning" means and is dunning-specific.
+
+- [ ] **Step 3: Run and verify**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/subscription/... 2>&1 | tee /tmp/b2-after.txt
+grep -c 'store_subscriptions_store_id_fkey' /tmp/b2-after.txt
+```
+
+Expected: `0`. Confirm `internal/subscription/dunning` still passes — it is currently green and in CI, so a regression there is a real regression, not drift.
+
+- [ ] **Step 4: Widen `make test-int` for the green subscription packages**
+
+- [ ] **Step 5: Verify formatting and vet**
+
+```bash
+cd services/marketplace-api
+gofmt -l . && go build ./... && go vet ./... && go vet -tags=integration ./...
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "test(subscription): seed stores for subscription fixtures and widen test-int"
+```
+
+---
+
+### Task 6: Cluster B part 3 — remaining packages (28 failures)
+
+**Files:**
+- Modify: `services/marketplace-api/internal/arbitrage/appeal_test.go:40` and siblings (15)
+- Modify: `services/marketplace-api/internal/campaignbudget/*_test.go` (4)
+- Modify: `services/marketplace-api/internal/campaignbudget/cron/*_test.go` (2)
+- Modify: `services/marketplace-api/internal/handlers/webhooks/*_test.go` (2)
+- Modify: `services/marketplace-api/tests/integration/*_test.go` (3)
+- Modify: `Makefile`
+
+**Interfaces:**
+- Consumes: `testdb.SeedStore` from Task 1.
+- Produces: nothing new.
+
+- [ ] **Step 1: Confirm the current failures, by name**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 \
+  ./internal/arbitrage/... ./internal/campaignbudget/... \
+  ./internal/handlers/webhooks/... ./tests/integration/... 2>&1 | tee /tmp/b3-before.txt
+grep -c 'store_subscriptions_store_id_fkey' /tmp/b3-before.txt
+```
+
+- [ ] **Step 2: Apply the same edit as Task 4, Step 2**
+
+Note `internal/arbitrage/appeal_test.go:31` contains a stub `seedFlaggedAudit` whose body is an empty comment and whose `db` parameter is an anonymous `interface{}`. Give it the concrete `*gorm.DB` type and a real body, or delete it if nothing calls it — a helper that silently does nothing is how a test passes while asserting nothing.
+
+- [ ] **Step 3: Run and verify**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 \
+  ./internal/arbitrage/... ./internal/campaignbudget/... \
+  ./internal/handlers/webhooks/... ./tests/integration/... 2>&1 | tee /tmp/b3-after.txt
+grep -c 'store_subscriptions_store_id_fkey' /tmp/b3-after.txt
+```
+
+Expected: `0`.
+
+- [ ] **Step 4: Widen `make test-int` for the green packages**
+
+- [ ] **Step 5: Verify formatting and vet**
+
+```bash
+cd services/marketplace-api
+gofmt -l . && go build ./... && go vet ./... && go vet -tags=integration ./...
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "test(fixtures): seed stores across arbitrage, campaignbudget and webhooks"
+```
+
+---
+
+### Task 7: Re-measure and triage the tail
+
+The tail could not be classified before now: within a single test, an early insert failure aborts the transaction (`SQLSTATE 25P02`, "current transaction is aborted") and masks every assertion after it. Some tail failures will have disappeared with clusters A–C; others will only now become visible. Both directions are expected.
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-08-27-integration-fixture-drift-tail.md` (findings only; no code changes in this task)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–6.
+- Produces: a triaged list the next task acts on.
+
+- [ ] **Step 1: Re-run the full suite against the isolated container**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./... > /tmp/after-full.txt 2>&1
+grep -E '^\s*--- FAIL: ' /tmp/after-full.txt | sed -E 's/^[[:space:]]*--- FAIL: //; s/ \(.*//' | sort -u > /tmp/after-tests.txt
+wc -l < /tmp/after-tests.txt
+```
+
+- [ ] **Step 2: Diff both directions against the baseline**
+
+```bash
+[ -s /private/tmp/m8-baseline-artifacts/baseline-tests.txt ] || { echo "BASELINE MISSING — re-measure before trusting any diff"; exit 1; }
+echo "=== fixed by this branch ==="
+comm -23 /private/tmp/m8-baseline-artifacts/baseline-tests.txt /tmp/after-tests.txt
+echo "=== NEW failures — these are yours ==="
+comm -13 /private/tmp/m8-baseline-artifacts/baseline-tests.txt /tmp/after-tests.txt
+```
+
+The guard on the first line is not decoration: `comm` against a deleted baseline prints nothing and looks like total success. Any name under "NEW failures" is a regression this branch caused and must be fixed before proceeding.
+
+- [ ] **Step 3: Cluster whatever remains by error signature**
+
+```bash
+grep -oE '(ERROR: [^(]*\(SQLSTATE [0-9A-Z]+\)|value too long for type [a-z()0-9 ]+|deadlock detected|404 page not found|nil pointer dereference)' /tmp/after-full.txt \
+  | sed 's/ERROR: //' | sort | uniq -c | sort -rn
+```
+
+- [ ] **Step 4: Write up the triage**
+
+For each remaining signature record: the signature, affected packages, whether it is a **fixture**
+problem (fix here) or a **product/routing** problem (file an issue, do not paper over). The
+`404 page not found` failures in `tests/integration` are the ones to be most careful with — a test
+expecting an unmounted route may be asserting a real gap, and silently deleting it would destroy the
+signal.
+
+Then **append a concrete task to this plan for every fixture-class finding**, following the shape of
+Task 2: exact files, exact edit, a verify command scoped by `-run`, a Makefile widening, and a
+commit. A triage document that does not become tasks is where this work stalls. The known
+candidates, all named in #317 and all still unfixed at that point, are `internal/orderrefund`
+(cleanup deadlock plus a config-wiring gap at `resolver_integration_test.go:239`), `internal/page`,
+`internal/handlers/admin` (`stores.created_at`, a column the schema does not have at all), and
+`internal/whitelabel/lifecycle` (blocked on the Task 9 audit-emitter issue, since the panic is
+production-side).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-08-27-integration-fixture-drift-tail.md
+git commit -m "docs: triage the remaining integration failures after clusters A-C"
+```
+
+---
+
+### Task 8: Cluster D — `apikeys` `varchar(60)` overflow (6 failures)
+
+**Files:**
+- Modify: `services/marketplace-api/internal/apikeys/lastused_test.go:33`
+- Modify: `services/marketplace-api/internal/apikeys/repo_test.go:37,59,77`
+- Modify: `Makefile`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: nothing new.
+
+**This one is already resolved — do not re-derive it.** The table is `enterprise_api_keys`, not
+`api_keys`, and the offending column is `key_hash varchar(60)`. Both failing fixtures write the same
+literal:
+
+```
+$2a$12$abcdefghijklmnopqrstuv.QwertyuiopAsdfghjklZxcvbnmAsdfgh.
+```
+
+which is **63 characters**. A real bcrypt hash is exactly **60**. So `varchar(60)` is correct and the
+fixture is wrong — this is not a production bug, and no migration is needed.
+
+- [ ] **Step 1: Replace the over-long literal in both files**
+
+Use a literal that is exactly 60 characters and still bcrypt-shaped (`$2a$12$` + 53). Verify the
+length rather than trusting the eye — the current value is wrong by three characters, which is
+exactly the kind of error that reading does not catch:
+
+```bash
+python3 -c "s='\$2a\$12\$abcdefghijklmnopqrstuv.QwertyuiopAsdfghjklZxcvbnmAsd'; print(len(s))"
+```
+
+Expected: `60`. Then set `KeyHash` to that value in both
+`internal/apikeys/lastused_test.go:33` and `internal/apikeys/repo_test.go:37,59,77`.
+
+- [ ] **Step 2: Confirm no other fixture carries the bad literal**
+
+```bash
+cd services/marketplace-api
+grep -rn 'QwertyuiopAsdfghjklZxcvbnmAsdfgh' --include='*_test.go' . || echo "clean"
+```
+
+Expected: `clean`.
+
+- [ ] **Step 3: Verify**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:55433/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/apikeys/... -v 2>&1 | grep -E '^(---|ok|FAIL)'
+```
+
+Expected: `--- PASS` for all four previously failing tests, by name.
+
+- [ ] **Step 4: Widen `make test-int` for `./internal/apikeys/...`**
+
+- [ ] **Step 5: Verify formatting and vet**
+
+```bash
+cd services/marketplace-api
+gofmt -l . && go build ./... && go vet ./... && go vet -tags=integration ./...
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "test(apikeys): fix varchar(60) overflow in fixtures and widen test-int"
+```
+
+---
+
+### Task 9: File the two production defects found while measuring
+
+Neither is a fixture problem and neither should be fixed inside a test-repair branch. Both were found by running the dark suite — which is the argument for this whole plan.
+
+**Files:**
+- No code changes. Two GitHub issues.
+
+**Interfaces:**
+- Consumes: findings from the baseline run.
+- Produces: issue numbers to reference from `internal/product/models.go` and the tail triage doc.
+
+- [ ] **Step 1: File the `audit.Emitter` nil-repo panic**
+
+Title: `audit.NewEmitter accepts a nil Repo and the worker goroutine panics, killing the process`
+
+Body must contain:
+- `NewEmitter` (`internal/audit/emitter.go:76`) defaults `QueueSize` and `Workers` but never validates `cfg.Repo` or `cfg.DB`.
+- `Emit` (`:99`) explicitly guards `e == nil` with the comment *"safe to call when wiring opted out (e.g. unit tests)"* — so nil-tolerance is an intended part of this type's contract, and the validation gap is inconsistent with it.
+- With a nil `Repo`, `write` (`:216`) dereferences it inside `worker`, on a background goroutine. A panic there cannot be recovered by the caller and takes down the whole process — it does not return an error, and no request-scoped recovery middleware sees it.
+- Reproduced by `internal/whitelabel/lifecycle` in the 2026-08-27 baseline run; the panic aborts the test binary, so that package's remaining tests never ran.
+- Suggested fix: fail fast in `NewEmitter` when `Repo` or `DB` is nil, or make `write` degrade to a log line. Fail-fast at construction is preferable — a silently dropped audit trail is its own problem.
+
+- [ ] **Step 2: File the `Product.VendorID` type mismatch**
+
+Title: `product.Product.VendorID is *string against a NOT NULL column, so invalid products only fail at insert time`
+
+Body must contain:
+- `internal/product/models.go:52` declares `VendorID *string`; migration `000028_products_vendor_id_not_null.up.sql` made the column `NOT NULL`, with a guard that aborts if any row still has a NULL.
+- The migration is deliberate and correct — it documents that `product.Create` defaults new products to the tenant's self-vendor. The struct is what is stale.
+- Consequence: nothing prevents constructing a `Product` without a vendor, so the failure surfaces as a database error at insert. This is the direct cause of 74 integration failures across three packages, fixed at the fixture level in Task 3.
+- Tightening to a non-pointer `string` touches JSON `omitempty` behaviour and every nil check, so it needs its own change and its own review.
+
+- [ ] **Step 3: Read both issues back**
+
+```bash
+for n in <issue-a> <issue-b>; do
+  gh issue view "$n" --json number,state,title,body --jq '"#\(.number) \(.state) bodylen=\(.body|length) \(.title)"'
+done
+```
+
+A `gh` write that is not read back is not known to have happened.
+
+- [ ] **Step 4: Reference the model issue from the code**
+
+Add above `internal/product/models.go:52`:
+
+```go
+// VendorID is a pointer for historical reasons; the column has been NOT NULL
+// since migration 000028. See issue #<issue-b> — tightening it to a plain
+// string touches JSON omitempty and every nil check, so it is tracked
+// separately.
+```
+
+Run `gofmt -l .` afterwards: inserting a comment into an aligned struct re-aligns the fields above it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/marketplace-api/internal/product/models.go
+git commit -m "docs(product): record why VendorID is still a pointer"
+```
+
+---
+
+## Definition of Done
+
+- `comm -13 baseline-tests.txt after-tests.txt` is empty — this branch added zero failures.
+- Clusters A, B and C contribute zero failures; 165 of the 187 baseline failures are gone.
+- `make test-int` covers every package made green, and passes.
+- Two issues filed and read back; `models.go` references the model one.
+- Any remaining failure is either triaged in the tail doc with a named cause, or filed as its own issue. Nothing is left unexplained.

--- a/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
+++ b/docs/superpowers/plans/2026-08-27-integration-fixture-drift.md
@@ -43,6 +43,8 @@
   - `vendors` NOT NULL: `id` (default `gen_random_uuid()`), `tenant_id`, `name`, `slug`, `status` (default `'active'`), `is_self` (default `false`), `created_at`/`updated_at` (default `now()`).
   - `vendors` unique **indexes** — `vendors_slug_key` on `slug`, and `vendors_tenant_self_idx`, a **partial unique index on `(tenant_id) WHERE is_self = true`** enforcing one self-vendor per tenant. These are `CREATE UNIQUE INDEX`, not table constraints, so **`pg_constraint` does not list them — query `pg_indexes`.** An earlier revision of this plan asserted "no unique constraint beyond the primary key" for exactly that reason and was wrong.
   - `stores.synced_at` is NOT NULL but carries a default, which is why the seed helper omits it and still inserts cleanly.
+  - `products_handle_per_store_live_unique` — unique on `(store_id, handle) WHERE deleted_at IS NULL`. **Task 3 must not give two live products the same handle within one store.** Derive handles per product rather than reusing a literal like `"linen-shirt"` when a test seeds more than one.
+  - `eak_tenant_prefix_uniq` — unique on `enterprise_api_keys (tenant_id, key_prefix)`. Task 8's fixtures mint a fresh `tenantID` per test so the shared `"USED1234"` prefix is safe; it stops being safe the moment two keys share a tenant.
   - `products.vendor_id` is `NOT NULL` with **no foreign key** — only `products_store_id_fkey` and `products_primary_category_id_fkey` exist.
   - `stores_slug_unique` exists, so seeded slugs must be derived from the store id.
 

--- a/services/marketplace-api/internal/apikeys/lastused_test.go
+++ b/services/marketplace-api/internal/apikeys/lastused_test.go
@@ -26,7 +26,7 @@ func TestLastUsedWorker_PersistsUpdate(t *testing.T) {
 	key := apikeys.APIKey{
 		ID: uuid.New(), TenantID: tenantID, StoreID: storeID,
 		KeyPrefix: "USED1234",
-		KeyHash:   "$2a$12$abcdefghijklmnopqrstuv.QwertyuiopAsdfghjklZxcvbnmAsdfgh.",
+		KeyHash:   "$2a$12$abcdefghijklmnopqrstuvWXYZABCDEFGHIJKLMNOPQRSTUVwxyz0",
 		Scopes:    apikeys.ScopeSet{"products:read"},
 		Label:     "x", CreatedBy: uuid.New(),
 	}

--- a/services/marketplace-api/internal/apikeys/repo_test.go
+++ b/services/marketplace-api/internal/apikeys/repo_test.go
@@ -20,7 +20,7 @@ func sampleKey(tenantID, storeID, createdBy uuid.UUID, prefix string) apikeys.AP
 		TenantID:        tenantID,
 		StoreID:         storeID,
 		KeyPrefix:       prefix,
-		KeyHash:         "$2a$12$abcdefghijklmnopqrstuv.QwertyuiopAsdfghjklZxcvbnmAsdfgh.",
+		KeyHash:         "$2a$12$abcdefghijklmnopqrstuvWXYZABCDEFGHIJKLMNOPQRSTUVwxyz0",
 		Scopes:          apikeys.ScopeSet{"products:read", "orders:read"},
 		RateLimitPerMin: 100,
 		Label:           "Integration X",

--- a/services/marketplace-api/internal/arbitrage/appeal_test.go
+++ b/services/marketplace-api/internal/arbitrage/appeal_test.go
@@ -28,13 +28,6 @@ func (s *spyPublisher) Publish(_ context.Context, _ string, payload any) error {
 	return nil
 }
 
-func seedFlaggedAudit(t *testing.T, db interface { /* *gorm.DB */
-}, tenantID, storeID, subID uuid.UUID) {
-	t.Helper()
-	// Use the concrete *gorm.DB type in integration tests.
-	// This function is in the same build tag group as openIntegrationDB.
-}
-
 func TestAppealService_MarksAuditRowUnderReview(t *testing.T) {
 	db := openIntegrationDB(t)
 	tenantID, storeID, subID := seedPPPSubscription(t, db)

--- a/services/marketplace-api/internal/arbitrage/models_test.go
+++ b/services/marketplace-api/internal/arbitrage/models_test.go
@@ -25,8 +25,10 @@ func TestSubscriptionArbitrageAudit_NoRawIPColumn(t *testing.T) {
 func TestSubscriptionArbitrageAudit_RoundTrip(t *testing.T) {
 	db := testdb.NewDB(t, "subscription_arbitrage_audit", "store_subscriptions")
 
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	sub := subscription.StoreSubscription{
-		TenantID: uuid.New(), StoreID: uuid.New(),
+		TenantID: tenantID, StoreID: storeID,
 		StripeCustomerID: "cus_x", Plan: subscription.PlanStudio, Status: subscription.StatusActive,
 	}
 	require.NoError(t, db.Create(&sub).Error)

--- a/services/marketplace-api/internal/arbitrage/quarterly_cron_test.go
+++ b/services/marketplace-api/internal/arbitrage/quarterly_cron_test.go
@@ -14,15 +14,6 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 )
 
-func seedFlaggedAuditRow(t *testing.T, db interface { /* *gorm.DB — resolved at integration build time */
-},
-	tenantID, storeID, subID uuid.UUID, ageDays int) arbitrage.SubscriptionArbitrageAudit {
-	t.Helper()
-	// This helper is used only in integration tests where db is *gorm.DB.
-	// Type assertion is safe in this build-tagged file.
-	return arbitrage.SubscriptionArbitrageAudit{}
-}
-
 func TestQuarterlyAudit_ClearsAllowlistedFlags(t *testing.T) {
 	db := openIntegrationDB(t)
 	tenantID, storeID, subID := seedPPPSubscription(t, db)

--- a/services/marketplace-api/internal/arbitrage/testhelpers_integration_test.go
+++ b/services/marketplace-api/internal/arbitrage/testhelpers_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/arbitrage"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
 func openIntegrationDB(t *testing.T) *gorm.DB {
@@ -51,6 +52,7 @@ func seedSubscriptionWithTier(t *testing.T, db *gorm.DB, tier subscription.Price
 	t.Helper()
 	tenantID := uuid.New()
 	storeID := uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	sub := subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,

--- a/services/marketplace-api/internal/billing/appaddon/webhook_integration_test.go
+++ b/services/marketplace-api/internal/billing/appaddon/webhook_integration_test.go
@@ -17,6 +17,7 @@ import (
 
 func seedProSub(t *testing.T, tenantID, storeID uuid.UUID, plan subscription.SubscriptionPlan) *subscription.StoreSubscription {
 	db := testdb.NewDB(t, "store_subscriptions")
+	testdb.SeedStore(t, db, tenantID, storeID)
 	sub := &subscription.StoreSubscription{
 		ID: uuid.New(), TenantID: tenantID, StoreID: storeID,
 		StripeCustomerID: "cus_" + storeID.String()[:8],

--- a/services/marketplace-api/internal/billing/dispatch/deferred_sends_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/deferred_sends_test.go
@@ -64,12 +64,12 @@ func (c *visibilityEmailClient) Send(_ context.Context, _ email.TemplateID, to s
 func TestInvoicePaid_TrialBilled_SentAfterTransactionCommits(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events", "billing_email_sends")
 
-	storeID := uuid.New()
-	seedStore(t, db, storeID)
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	addr := "merchant@example.com"
 	customerID := "cus_" + uuid.NewString()[:12]
 	sub := subscription.StoreSubscription{
-		TenantID:         uuid.New(),
+		TenantID:         tenantID,
 		StoreID:          storeID,
 		StripeCustomerID: customerID,
 		Plan:             subscription.PlanStarter,

--- a/services/marketplace-api/internal/billing/dispatch/dispatcher_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/dispatcher_test.go
@@ -22,6 +22,7 @@ func TestDispatch_CheckoutSessionCompleted_BindsBillingCurrency(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -73,6 +74,7 @@ func TestDispatch_SubscriptionDeleted_StatusExpired(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -99,6 +101,7 @@ func TestDispatch_SubscriptionDeleted_ActiveIsNoOp(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -123,6 +126,7 @@ func TestDispatch_InvoicePaymentActionRequired_StatusUpdated(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -148,6 +152,7 @@ func TestDispatch_InvoicePaymentFailed_ActiveToPastDue(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -174,6 +179,7 @@ func TestDispatch_InvoicePaymentActionRequired_PersistsHostedInvoiceURL(t *testi
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -202,7 +208,7 @@ func TestDispatch_InvoicePaid_StampsFirstChargeAt_ClearsHostedURL(t *testing.T) 
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
 
 	tenantID, storeID := uuid.New(), uuid.New()
-	seedStore(t, db, storeID) // store_subscriptions.store_id has an enforced FK
+	testdb.SeedStore(t, db, tenantID, storeID)
 	hostedURL := "https://invoice.stripe.com/i/acct_123/test_yyy"
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
@@ -232,7 +238,7 @@ func TestDispatch_InvoicePaid_FirstChargeAtIdempotent_SecondEventDoesNotAdvance(
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
 
 	tenantID, storeID := uuid.New(), uuid.New()
-	seedStore(t, db, storeID) // store_subscriptions.store_id has an enforced FK
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -267,6 +273,7 @@ func TestHandleCheckoutSessionCompleted_BillingCurrencyLockedAfterFirstBind(t *t
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	bc := "GBP"
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
@@ -299,6 +306,8 @@ func TestDispatch_CustomerUpdated_SetsHasDefaultPaymentMethod(t *testing.T) {
 
 	tenantA, storeA := uuid.New(), uuid.New()
 	tenantB, storeB := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantA, storeA)
+	testdb.SeedStore(t, db, tenantB, storeB)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:                tenantA,
 		StoreID:                 storeA,
@@ -386,7 +395,7 @@ func TestDispatch_InvoicePaid_FirstChargeEmitsTrialBilledEmail(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events", "billing_email_sends")
 
 	tenantID, storeID := uuid.New(), uuid.New()
-	seedStore(t, db, storeID) // store_subscriptions.store_id has an enforced FK
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -421,7 +430,7 @@ func TestDispatch_InvoicePaid_NoEmailClientStillProcesses(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events", "billing_email_sends")
 
 	tenantID, storeID := uuid.New(), uuid.New()
-	seedStore(t, db, storeID) // store_subscriptions.store_id has an enforced FK
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -482,8 +491,8 @@ func runInvoicePaidFirstCharge(t *testing.T, client email.Client, addr *string) 
 
 	tenantID := uuid.New()
 	storeID = uuid.New()
-	seedStore(t, db, storeID)
-	storeName = "Test Store " + storeID.String() // must match seedStore's inserted name
+	testdb.SeedStore(t, db, tenantID, storeID)
+	storeName = "Test Store" // must match testdb.SeedStore's inserted name
 
 	customerID := "cus_" + uuid.NewString()[:12]
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
@@ -558,7 +567,7 @@ func TestDispatch_InvoicePaymentFailed_PersistsHostedInvoiceURL(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
 
 	tenantID, storeID := uuid.New(), uuid.New()
-	seedStore(t, db, storeID)
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -589,7 +598,7 @@ func TestDispatch_InvoicePaymentFailed_AbsentURLKeepsExistingValue(t *testing.T)
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
 
 	tenantID, storeID := uuid.New(), uuid.New()
-	seedStore(t, db, storeID)
+	testdb.SeedStore(t, db, tenantID, storeID)
 	existing := "https://invoice.stripe.com/i/acct_123/already_here"
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
@@ -626,7 +635,7 @@ func TestDispatch_InvoicePaymentFailed_DoesNotStampUpdatedAt(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events")
 
 	tenantID, storeID := uuid.New(), uuid.New()
-	seedStore(t, db, storeID)
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,

--- a/services/marketplace-api/internal/billing/dispatch/handlers_customer_updated_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/handlers_customer_updated_test.go
@@ -4,51 +4,26 @@ package dispatch_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-
-	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/billing/dispatch"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
-// seedStore inserts a minimal, valid row into the `stores` table so that a
-// store_subscriptions row referencing it (store_id FK) can be created.
-// store_subscriptions_store_id_fkey is a real, enforced constraint
-// (migrations/000015_subscriptions.up.sql), so any test that creates a
-// StoreSubscription must satisfy it. The row is deleted individually (not
-// TRUNCATEd) on cleanup, since store_subscriptions is a child of stores and
-// TRUNCATE ... CASCADE on stores would cascade into unrelated tables on this
-// shared database.
-func seedStore(t *testing.T, db *gorm.DB, storeID uuid.UUID) {
-	t.Helper()
-	secret := strings.Repeat("a", 64)
-	err := db.Exec(`
-		INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
-		VALUES (?, ?, ?, ?, 'US', 'USD', 'UTC', 'active', ?)`,
-		storeID, uuid.New(), "store-"+storeID.String(), "Test Store "+storeID.String(), secret,
-	).Error
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		db.Exec(`DELETE FROM stores WHERE id = ?`, storeID)
-	})
-}
-
 func TestHandleCustomerUpdated_MirrorsEmail(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions")
 	ctx := context.Background()
 
-	storeID := uuid.New()
-	seedStore(t, db, storeID)
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 
 	customerID := "cus_" + uuid.NewString()[:12]
 	sub := &subscription.StoreSubscription{
-		TenantID:         uuid.New(),
+		TenantID:         tenantID,
 		StoreID:          storeID,
 		StripeCustomerID: customerID,
 	}
@@ -77,13 +52,13 @@ func TestHandleCustomerUpdated_AbsentEmailPreservesExisting(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions")
 	ctx := context.Background()
 
-	storeID := uuid.New()
-	seedStore(t, db, storeID)
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 
 	existing := "keep@example.com"
 	customerID := "cus_" + uuid.NewString()[:12]
 	sub := &subscription.StoreSubscription{
-		TenantID:         uuid.New(),
+		TenantID:         tenantID,
 		StoreID:          storeID,
 		StripeCustomerID: customerID,
 		Email:            &existing,

--- a/services/marketplace-api/internal/billing/dispatch/orphan_resolver_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/orphan_resolver_test.go
@@ -20,6 +20,7 @@ func TestOrphanResolver_ResolvesStoreIDAndDispatches(t *testing.T) {
 	repo := webhookevents.NewRepository()
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,

--- a/services/marketplace-api/internal/billing/dispatch/trial_billed_claim_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/trial_billed_claim_test.go
@@ -25,12 +25,12 @@ func seedFirstChargeSub(t *testing.T) (*gorm.DB, subscription.StoreSubscription,
 	t.Helper()
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events", "billing_email_sends")
 
-	storeID := uuid.New()
-	seedStore(t, db, storeID)
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	addr := "merchant@example.com"
 	customerID := "cus_" + uuid.NewString()[:12]
 	sub := subscription.StoreSubscription{
-		TenantID:         uuid.New(),
+		TenantID:         tenantID,
 		StoreID:          storeID,
 		StripeCustomerID: customerID,
 		Plan:             subscription.PlanStarter,
@@ -147,12 +147,12 @@ func seedFirstChargeSubWithPlan(t *testing.T, plan subscription.SubscriptionPlan
 	t.Helper()
 	db := testdb.NewDB(t, "store_subscriptions", "stripe_webhook_events", "billing_email_sends")
 
-	storeID := uuid.New()
-	seedStore(t, db, storeID)
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	addr := "merchant@example.com"
 	customerID := "cus_" + uuid.NewString()[:12]
 	sub := subscription.StoreSubscription{
-		TenantID:         uuid.New(),
+		TenantID:         tenantID,
 		StoreID:          storeID,
 		StripeCustomerID: customerID,
 		Plan:             plan,

--- a/services/marketplace-api/internal/billing/tax/revalidation/cron_test.go
+++ b/services/marketplace-api/internal/billing/tax/revalidation/cron_test.go
@@ -29,6 +29,7 @@ func (r *recordingNotifier) Create(_ context.Context, n *notification.Notificati
 func seedValidatedSubscription(t *testing.T, db *gorm.DB, country, taxID, businessName string, validatedAt time.Time) (uuid.UUID, uuid.UUID) {
 	t.Helper()
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Exec(`
 		INSERT INTO store_subscriptions
 			(tenant_id, store_id, stripe_customer_id, plan, status,

--- a/services/marketplace-api/internal/billing/tax/service_test.go
+++ b/services/marketplace-api/internal/billing/tax/service_test.go
@@ -29,6 +29,7 @@ func TestService_ValidUK_FlipsRow_WritesMatched(t *testing.T) {
 	})
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Exec(`
 		INSERT INTO store_subscriptions
 			(tenant_id, store_id, stripe_customer_id, plan, status, tax_id_country, created_at, updated_at)
@@ -69,6 +70,7 @@ func TestService_SEAManualReview_EnqueuesAndPausesClockImmediately(t *testing.T)
 	})
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Exec(`
 		INSERT INTO store_subscriptions
 			(tenant_id, store_id, stripe_customer_id, plan, status, tax_id_country, created_at, updated_at)
@@ -111,6 +113,7 @@ func TestService_RegistryUnavailable_LogsOutage(t *testing.T) {
 	})
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Exec(`
 		INSERT INTO store_subscriptions
 			(tenant_id, store_id, stripe_customer_id, plan, status, tax_id_country, created_at, updated_at)
@@ -161,6 +164,7 @@ func TestService_OnFastPathApproved_FlipsWindowShortenedAt(t *testing.T) {
 	})
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Exec(`
 		INSERT INTO store_subscriptions
 			(tenant_id, store_id, stripe_customer_id, plan, status, tax_id_country, created_at, updated_at)

--- a/services/marketplace-api/internal/campaignbudget/cron/jobs_test.go
+++ b/services/marketplace-api/internal/campaignbudget/cron/jobs_test.go
@@ -25,6 +25,7 @@ func TestTrialRampJob_AppliesToTransitioningStores(t *testing.T) {
 
 	// Store A: day 4 today → should ramp (created 3 days ago).
 	storeA := uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeA)
 	sigA := time.Now().UTC().AddDate(0, 0, -3)
 	require.NoError(t, db.Exec(`
 		INSERT INTO store_subscriptions (tenant_id, store_id, stripe_customer_id, plan, status, created_at)
@@ -36,6 +37,7 @@ func TestTrialRampJob_AppliesToTransitioningStores(t *testing.T) {
 
 	// Store B: day 2 today → no-op (created 1 day ago).
 	storeB := uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeB)
 	sigB := time.Now().UTC().AddDate(0, 0, -1)
 	require.NoError(t, db.Exec(`
 		INSERT INTO store_subscriptions (tenant_id, store_id, stripe_customer_id, plan, status, created_at)
@@ -57,6 +59,7 @@ func TestTrialRampJob_SkipsNonTrialingStatuses(t *testing.T) {
 	// Only 'signup' and 'trialing' stores should be queried.
 	db := testdb.NewDB(t, "campaign_email_budget", "store_subscriptions")
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	// Store is 'active' so must be skipped by the cron even if day=4.
 	createdAt := time.Now().UTC().AddDate(0, 0, -3)
 	require.NoError(t, db.Exec(`

--- a/services/marketplace-api/internal/campaignbudget/monthly_reset_test.go
+++ b/services/marketplace-api/internal/campaignbudget/monthly_reset_test.go
@@ -19,6 +19,7 @@ func TestMonthlyReset_SeedsAllActiveSubscriptions(t *testing.T) {
 	tenantID := uuid.New()
 	storeIDs := []uuid.UUID{uuid.New(), uuid.New(), uuid.New()}
 	for _, sid := range storeIDs {
+		testdb.SeedStore(t, db, tenantID, sid)
 		require.NoError(t, db.Exec(`
 			INSERT INTO store_subscriptions (tenant_id, store_id, stripe_customer_id, plan, status)
 			VALUES ($1, $2, $3, 'starter', 'active')`, tenantID, sid, "cus_"+sid.String()).Error)
@@ -43,6 +44,7 @@ func TestMonthlyReset_IdempotentReRun(t *testing.T) {
 	db := testdb.NewDB(t, "campaign_email_budget", "store_subscriptions")
 	tenantID := uuid.New()
 	storeID := uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Exec(`
 		INSERT INTO store_subscriptions (tenant_id, store_id, stripe_customer_id, plan, status)
 		VALUES ($1, $2, 'cus_x', 'starter', 'active')`, tenantID, storeID).Error)
@@ -66,6 +68,8 @@ func TestMonthlyReset_SkipsNonActiveStatuses(t *testing.T) {
 	// expired / store_closed / pending_hard_delete subscriptions get no row.
 	db := testdb.NewDB(t, "campaign_email_budget", "store_subscriptions")
 	tenantID, activeID, expiredID := uuid.New(), uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, activeID)
+	testdb.SeedStore(t, db, tenantID, expiredID)
 	require.NoError(t, db.Exec(`
 		INSERT INTO store_subscriptions (tenant_id, store_id, stripe_customer_id, plan, status)
 		VALUES ($1, $2, 'cus_a', 'starter', 'active'),
@@ -86,6 +90,8 @@ func TestMonthlyReset_SkipsPro_Negotiated(t *testing.T) {
 	// Pro stores are excluded — ops sets limit_set manually.
 	db := testdb.NewDB(t, "campaign_email_budget", "store_subscriptions")
 	tenantID, proID, starterID := uuid.New(), uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, proID)
+	testdb.SeedStore(t, db, tenantID, starterID)
 	require.NoError(t, db.Exec(`
 		INSERT INTO store_subscriptions (tenant_id, store_id, stripe_customer_id, plan, status)
 		VALUES ($1, $2, 'cus_p', 'pro', 'active'),

--- a/services/marketplace-api/internal/category/repository_integration_test.go
+++ b/services/marketplace-api/internal/category/repository_integration_test.go
@@ -17,16 +17,10 @@ import (
 
 func insertStoreRow(t *testing.T, tx *gorm.DB) (storeID, tenantID string) {
 	t.Helper()
-	storeID = uuid.NewString()
-	tenantID = uuid.NewString()
-	err := tx.Exec(`
-		INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, synced_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, now())`,
-		storeID, tenantID, "cat-test-"+storeID[:8], "Test Store", "US", "USD", "UTC", "active").Error
-	if err != nil {
-		t.Fatalf("insert store: %v", err)
-	}
-	return
+	storeUUID := uuid.New()
+	tenantUUID := uuid.New()
+	testdb.SeedStore(t, tx, tenantUUID, storeUUID)
+	return storeUUID.String(), tenantUUID.String()
 }
 
 func newCategory(storeID, tenantID, slug string) *category.Category {

--- a/services/marketplace-api/internal/category/repository_integration_test.go
+++ b/services/marketplace-api/internal/category/repository_integration_test.go
@@ -20,6 +20,7 @@ func insertStoreRow(t *testing.T, tx *gorm.DB) (storeID, tenantID string) {
 	storeUUID := uuid.New()
 	tenantUUID := uuid.New()
 	testdb.SeedStore(t, tx, tenantUUID, storeUUID)
+	testdb.SeedVendor(t, tx, tenantUUID)
 	return storeUUID.String(), tenantUUID.String()
 }
 
@@ -193,10 +194,11 @@ func TestIntegration_Category_HasProducts_TrueAndFalse(t *testing.T) {
 
 	productID := uuid.NewString()
 	handle := "p-" + productID[:8]
+	vendorID := testdb.SeedVendor(t, tx, uuid.MustParse(tenantID))
 	if err := tx.Exec(`
-		INSERT INTO products (id, tenant_id, store_id, handle, title, status)
-		VALUES (?, ?, ?, ?, ?, 'draft')`,
-		productID, tenantID, storeID, handle, "Test Product").Error; err != nil {
+		INSERT INTO products (id, tenant_id, store_id, vendor_id, handle, title, status)
+		VALUES (?, ?, ?, ?, ?, ?, 'draft')`,
+		productID, tenantID, storeID, vendorID, handle, "Test Product").Error; err != nil {
 		t.Fatalf("insert product: %v", err)
 	}
 	if err := tx.Exec(`

--- a/services/marketplace-api/internal/category/service_integration_test.go
+++ b/services/marketplace-api/internal/category/service_integration_test.go
@@ -22,16 +22,10 @@ import (
 // to avoid cross-file collisions in the same test package.
 func seedStoreForService(t *testing.T, tx *gorm.DB) (storeID, tenantID string) {
 	t.Helper()
-	storeID = uuid.NewString()
-	tenantID = uuid.NewString()
-	err := tx.Exec(`
-		INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, synced_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, now())`,
-		storeID, tenantID, "svc-cat-"+storeID[:8], "Svc Test Store", "US", "USD", "UTC", "active").Error
-	if err != nil {
-		t.Fatalf("insert store: %v", err)
-	}
-	return
+	storeUUID := uuid.New()
+	tenantUUID := uuid.New()
+	testdb.SeedStore(t, tx, tenantUUID, storeUUID)
+	return storeUUID.String(), tenantUUID.String()
 }
 
 func newService(tx *gorm.DB) *category.Service {

--- a/services/marketplace-api/internal/category/service_integration_test.go
+++ b/services/marketplace-api/internal/category/service_integration_test.go
@@ -25,6 +25,7 @@ func seedStoreForService(t *testing.T, tx *gorm.DB) (storeID, tenantID string) {
 	storeUUID := uuid.New()
 	tenantUUID := uuid.New()
 	testdb.SeedStore(t, tx, tenantUUID, storeUUID)
+	testdb.SeedVendor(t, tx, tenantUUID)
 	return storeUUID.String(), tenantUUID.String()
 }
 
@@ -193,10 +194,11 @@ func TestIntegration_CategoryService_Delete_HasProducts_Refused(t *testing.T) {
 
 	productID := uuid.NewString()
 	handle := "p-" + productID[:8]
+	vendorID := testdb.SeedVendor(t, tx, uuid.MustParse(tenantID))
 	if err := tx.Exec(`
-		INSERT INTO products (id, tenant_id, store_id, handle, title, status)
-		VALUES (?, ?, ?, ?, ?, 'draft')`,
-		productID, tenantID, storeID, handle, "Test Product").Error; err != nil {
+		INSERT INTO products (id, tenant_id, store_id, vendor_id, handle, title, status)
+		VALUES (?, ?, ?, ?, ?, ?, 'draft')`,
+		productID, tenantID, storeID, vendorID, handle, "Test Product").Error; err != nil {
 		t.Fatalf("insert product: %v", err)
 	}
 	if err := tx.Exec(`

--- a/services/marketplace-api/internal/handlers/admin/products_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/products_integration_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/outbox"
 	"github.com/mark8ly/marketplace-api/internal/product"
 	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/internal/vendor"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
@@ -84,11 +85,12 @@ func setupTestRouter(t *testing.T) *testEnv {
 	fga := authz.NewFakeClient()
 
 	svc := product.NewService(product.Config{
-		DB:         db,
-		Repo:       productRepo,
-		StoresRepo: storesRepo,
-		OutboxRepo: outboxRepo,
-		Uploader:   uploader,
+		DB:           db,
+		Repo:         productRepo,
+		StoresRepo:   storesRepo,
+		OutboxRepo:   outboxRepo,
+		Uploader:     uploader,
+		VendorLookup: vendor.NewService(vendor.NewRepository(db)),
 	})
 
 	catSvc := category.NewService(category.Config{
@@ -145,6 +147,7 @@ func seedStoreRow(t *testing.T, db *gorm.DB, tenantID string) (string, string) {
 	if err := db.Create(s).Error; err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
+	testdb.SeedVendor(t, db, uuid.MustParse(tenantID))
 	return storeID, tenantID
 }
 
@@ -349,11 +352,12 @@ func TestAPI_AdminProducts_List_EmptyPage(t *testing.T) {
 func createProductsViaService(t *testing.T, env *testEnv, storeID, tenantID string, n int, status string) {
 	t.Helper()
 	svc := product.NewService(product.Config{
-		DB:         env.db,
-		Repo:       product.NewRepository(env.db),
-		StoresRepo: stores.NewRepository(env.db),
-		OutboxRepo: outbox.NewRepository(env.db),
-		Uploader:   env.uploader,
+		DB:           env.db,
+		Repo:         product.NewRepository(env.db),
+		StoresRepo:   stores.NewRepository(env.db),
+		OutboxRepo:   outbox.NewRepository(env.db),
+		Uploader:     env.uploader,
+		VendorLookup: vendor.NewService(vendor.NewRepository(env.db)),
 	})
 	for i := 0; i < n; i++ {
 		title := "Seed " + uuid.NewString()[:8]

--- a/services/marketplace-api/internal/handlers/admin/products_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/products_integration_test.go
@@ -29,7 +29,9 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/media"
 	"github.com/mark8ly/marketplace-api/internal/outbox"
 	"github.com/mark8ly/marketplace-api/internal/product"
+	"github.com/mark8ly/marketplace-api/internal/promo"
 	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
 	"github.com/mark8ly/marketplace-api/internal/vendor"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
@@ -110,15 +112,24 @@ func setupTestRouter(t *testing.T) *testEnv {
 	variantHandler := admin.NewVariantHandler(svc, nil)
 	mediaHandler := admin.NewMediaHandler(svc, uploader, nil)
 
+	subSvc := subscription.NewService(subscription.ServiceConfig{
+		DB:   db,
+		Repo: subscription.NewRepository(),
+	})
+	subHandler := admin.NewSubscriptionHandler(subSvc, nil)
+	promoHandler := admin.NewPromoHandler(db, promo.NewService(db, promo.NewRepository(), nil, nil), subscription.NewRepository(), nil)
+
 	r := gin.New()
 	admin.RegisterAdmin(r.Group("/api/v1"), admin.Deps{
-		ProductHandler:   handler,
-		CategoryHandler:  catHandler,
-		VariantHandler:   variantHandler,
-		MediaHandler:     mediaHandler,
-		StoresMiddleware: storeMW,
-		AuthzMiddleware:  authzMW,
-		InternalSecret:   "",
+		ProductHandler:      handler,
+		CategoryHandler:     catHandler,
+		VariantHandler:      variantHandler,
+		MediaHandler:        mediaHandler,
+		SubscriptionHandler: subHandler,
+		PromoHandler:        promoHandler,
+		StoresMiddleware:    storeMW,
+		AuthzMiddleware:     authzMW,
+		InternalSecret:      "",
 	})
 
 	return &testEnv{router: r, uploader: uploader, fga: fga, db: db}

--- a/services/marketplace-api/internal/handlers/admin/refund_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/refund_integration_test.go
@@ -41,6 +41,9 @@ func setupRefundTestEnv(t *testing.T) *testEnv {
 	subRepo := subscription.NewRepository()
 	svc := refund.NewService(db, refundRepo, subRepo, (*billingstripe.Client)(nil), nil)
 	refundHandler := admin.NewRefundHandler(db, svc, nil)
+	subHandler := admin.NewSubscriptionHandler(
+		subscription.NewService(subscription.ServiceConfig{DB: db, Repo: subRepo}), nil,
+	)
 
 	fga := authz.NewFakeClient()
 	authzMW := authz.NewMiddleware(fga, nil)
@@ -53,10 +56,11 @@ func setupRefundTestEnv(t *testing.T) *testEnv {
 
 	r := gin.New()
 	admin.RegisterAdmin(r.Group("/api/v1"), admin.Deps{
-		RefundHandler:    refundHandler,
-		StoresMiddleware: storeMW,
-		AuthzMiddleware:  authzMW,
-		InternalSecret:   "",
+		RefundHandler:       refundHandler,
+		SubscriptionHandler: subHandler,
+		StoresMiddleware:    storeMW,
+		AuthzMiddleware:     authzMW,
+		InternalSecret:      "",
 	})
 
 	return &testEnv{router: r, fga: fga, db: db}

--- a/services/marketplace-api/internal/handlers/admin/shipments_dispatched_dedup_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments_dispatched_dedup_test.go
@@ -51,6 +51,7 @@ func TestShipmentDispatchedEmailGate(t *testing.T) {
 		ShipTo:         datatypes.JSON([]byte(`{}`)),
 		CurrencyCode:   "INR",
 	}
+	seedOrderRowForSync(t, db, orderID, storeID, tenantID)
 	if err := db.Create(&ship).Error; err != nil {
 		t.Fatalf("seed shipment: %v", err)
 	}

--- a/services/marketplace-api/internal/handlers/admin/shipments_tracking_sync_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments_tracking_sync_test.go
@@ -108,6 +108,10 @@ func TestShipmentsSync_AdvancesStatusLadder(t *testing.T) {
 	if err := db.Create(&cfg).Error; err != nil {
 		t.Fatalf("seed config: %v", err)
 	}
+	// Seed the parent order before the shipment — shipments.order_id is
+	// a foreign key into orders(id), and order_events.order_id
+	// references it too.
+	seedOrderRowForSync(t, db, orderID, storeID, tenantID)
 	shipmentID := uuid.New()
 	ship := shipping.ShipmentRecord{
 		ID: shipmentID, TenantID: tenantID, StoreID: storeID, OrderID: orderID,
@@ -120,10 +124,6 @@ func TestShipmentsSync_AdvancesStatusLadder(t *testing.T) {
 	if err := db.Create(&ship).Error; err != nil {
 		t.Fatalf("seed shipment: %v", err)
 	}
-	// Also minimally seed orders so any FK constraint from order_events
-	// is satisfied. The sync doesn't read orders directly but
-	// order_events.order_id references orders(id).
-	seedOrderRowForSync(t, db, orderID, storeID, tenantID)
 
 	// Build the handler with a fake carrier that serves the ladder.
 	shippingRepo := shipping.NewRepository(db)
@@ -194,6 +194,8 @@ func TestShipmentsSync_CarrierErrorDoesNotBlockOthers(t *testing.T) {
 	// Two open shipments — A fails, B succeeds.
 	orderA := uuid.New()
 	orderB := uuid.New()
+	seedOrderRowForSync(t, db, orderA, storeID, tenantID)
+	seedOrderRowForSync(t, db, orderB, storeID, tenantID)
 	shipA := uuid.New()
 	shipB := uuid.New()
 	for _, s := range []shipping.ShipmentRecord{
@@ -210,8 +212,6 @@ func TestShipmentsSync_CarrierErrorDoesNotBlockOthers(t *testing.T) {
 			t.Fatalf("seed: %v", err)
 		}
 	}
-	seedOrderRowForSync(t, db, orderA, storeID, tenantID)
-	seedOrderRowForSync(t, db, orderB, storeID, tenantID)
 
 	shippingRepo := shipping.NewRepository(db)
 	h := admin.NewShipmentsHandler(db, shipping.NewShippingService(shippingRepo), shippingRepo, nil, nil).
@@ -273,18 +273,7 @@ func runSyncOnce(t *testing.T, h *admin.ShipmentsHandler) admin.SyncSummary {
 
 func seedStoreRowForSync(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
 	t.Helper()
-	// Direct SQL so we don't depend on the stores package test helpers —
-	// this file can run even when the stores projection table has
-	// evolved. Field list chosen to satisfy NOT NULL columns in
-	// migrations/000002_orders_initial.up.sql.
-	err := db.Exec(`
-		INSERT INTO stores (id, tenant_id, name, slug, country_code, currency_code, created_at, updated_at, storefront_customer_portal_secret)
-		VALUES (?, ?, 'Test', ?, 'IN', 'INR', now(), now(), encode(gen_random_bytes(32), 'hex'))
-		ON CONFLICT (id) DO NOTHING`,
-		storeID, tenantID, "test-"+storeID.String()[:8]).Error
-	if err != nil {
-		t.Fatalf("seed store: %v", err)
-	}
+	testdb.SeedStore(t, db, tenantID, storeID)
 }
 
 func seedOrderRowForSync(t *testing.T, db *gorm.DB, orderID, storeID, tenantID uuid.UUID) {
@@ -293,16 +282,16 @@ func seedOrderRowForSync(t *testing.T, db *gorm.DB, orderID, storeID, tenantID u
 	// sync loop doesn't read this row; we're just keeping referential
 	// integrity happy.
 	err := db.Exec(`
-		INSERT INTO orders (id, tenant_id, store_id, order_number, customer_email,
+		INSERT INTO orders (id, tenant_id, store_id, order_number, idempotency_key, customer_email,
 			status, payment_status, fulfillment_status,
 			subtotal, tax_total, shipping_total, grand_total, refunded_amount,
 			currency_code, placed_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, 'test@example.com',
-			'pending', 'pending', 'pending',
+		VALUES (?, ?, ?, ?, ?, 'test@example.com',
+			'pending', 'pending', 'unfulfilled',
 			'0', '0', '0', '0', '0',
 			'INR', now(), now(), now())
 		ON CONFLICT (id) DO NOTHING`,
-		orderID, tenantID, storeID, "M-SYNC-"+orderID.String()[:8]).Error
+		orderID, tenantID, storeID, "M-SYNC-"+orderID.String()[:8], "idem-"+orderID.String()).Error
 	if err != nil {
 		t.Fatalf("seed order: %v", err)
 	}

--- a/services/marketplace-api/internal/handlers/internalsvc/storefront_status_test.go
+++ b/services/marketplace-api/internal/handlers/internalsvc/storefront_status_test.go
@@ -34,8 +34,8 @@ func seedStoreFixture(t *testing.T, db *gorm.DB, slug string) seedStore {
 	tenantID, storeID := uuid.New(), uuid.New()
 	require.NoError(t, db.Exec(`
 		INSERT INTO stores
-			(id, tenant_id, slug, name, country_code, currency_code, timezone, status, synced_at)
-		VALUES (?, ?, ?, 'Acme Roasters', 'US', 'USD', 'UTC', 'active', now())
+			(id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
+		VALUES (?, ?, ?, 'Acme Roasters', 'US', 'USD', 'UTC', 'active', encode(gen_random_bytes(32), 'hex'))
 	`, storeID, tenantID, slug).Error)
 	return seedStore{tenantID: tenantID, storeID: storeID, slug: slug}
 }

--- a/services/marketplace-api/internal/handlers/storefront/storefront_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/storefront_integration_test.go
@@ -105,6 +105,7 @@ func seedStorefrontStore(t *testing.T, db *gorm.DB, slug, currency string) (stor
 		storeID, tenantID, slug, "Storefront Test Store", "US", currency, "UTC", stores.StatusActive).Error; err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
+	testdb.SeedVendor(t, db, uuid.MustParse(tenantID))
 	return
 }
 
@@ -150,10 +151,13 @@ func seedProduct(t *testing.T, db *gorm.DB, storeID, tenantID string, opts produ
 	if opts.Title == "" {
 		opts.Title = "Product " + opts.Handle
 	}
+	// Idempotent per tenant — seedStorefrontStore already seeded this
+	// tenant's self-vendor; this just looks it up.
+	vendorID := testdb.SeedVendor(t, db, uuid.MustParse(tenantID))
 	if err := db.Exec(`
-		INSERT INTO products (id, tenant_id, store_id, handle, title, status, published_at, deleted_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, now(), now())`,
-		productID, tenantID, storeID, opts.Handle, opts.Title, opts.Status, opts.PublishedAt, opts.DeletedAt).Error; err != nil {
+		INSERT INTO products (id, tenant_id, store_id, vendor_id, handle, title, status, published_at, deleted_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, now(), now())`,
+		productID, tenantID, storeID, vendorID, opts.Handle, opts.Title, opts.Status, opts.PublishedAt, opts.DeletedAt).Error; err != nil {
 		t.Fatalf("seed product: %v", err)
 	}
 	variantID := uuid.NewString()

--- a/services/marketplace-api/internal/handlers/webhooks/stripe_integration_test.go
+++ b/services/marketplace-api/internal/handlers/webhooks/stripe_integration_test.go
@@ -38,7 +38,7 @@ const fixtureSecret = "whsec_fixture_test"
 // skipped when TEST_DATABASE_URL is not set.
 func TestFullWebhookFlow_AllAllowlistedEvents(t *testing.T) {
 	// Fixtures live at services/marketplace-api/scripts/webhook-fixtures/
-	// relative to this file: ../../scripts/webhook-fixtures
+	// relative to this file: ../../../scripts/webhook-fixtures
 	dir := filepath.Join("..", "..", "..", "scripts", "webhook-fixtures")
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err, "fixture directory must exist")
@@ -48,6 +48,7 @@ func TestFullWebhookFlow_AllAllowlistedEvents(t *testing.T) {
 
 	// Seed the fixture subscription so customer resolution succeeds.
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,

--- a/services/marketplace-api/internal/handlers/webhooks/stripe_integration_test.go
+++ b/services/marketplace-api/internal/handlers/webhooks/stripe_integration_test.go
@@ -39,7 +39,7 @@ const fixtureSecret = "whsec_fixture_test"
 func TestFullWebhookFlow_AllAllowlistedEvents(t *testing.T) {
 	// Fixtures live at services/marketplace-api/scripts/webhook-fixtures/
 	// relative to this file: ../../scripts/webhook-fixtures
-	dir := filepath.Join("..", "..", "scripts", "webhook-fixtures")
+	dir := filepath.Join("..", "..", "..", "scripts", "webhook-fixtures")
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err, "fixture directory must exist")
 	require.NotEmpty(t, entries, "at least one fixture file required")

--- a/services/marketplace-api/internal/handlers/webhooks/stripe_test.go
+++ b/services/marketplace-api/internal/handlers/webhooks/stripe_test.go
@@ -63,6 +63,7 @@ func TestStripeWebhook_ValidSignature_InsertsAndDispatches(t *testing.T) {
 	db := testdb.NewDB(t, "stripe_webhook_events", "store_subscriptions")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -98,6 +99,7 @@ func TestStripeWebhook_DuplicateEvent_ReturnsDuplicateWithoutDispatch(t *testing
 	db := testdb.NewDB(t, "stripe_webhook_events", "store_subscriptions")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,

--- a/services/marketplace-api/internal/orderrefund/resolver_integration_test.go
+++ b/services/marketplace-api/internal/orderrefund/resolver_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shopspring/decimal"
 	"gorm.io/gorm"
 
+	"github.com/mark8ly/marketplace-api/internal/crypto"
 	"github.com/mark8ly/marketplace-api/internal/orderrefund"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
@@ -233,7 +234,7 @@ func TestGatewayFor_ActiveConfig(t *testing.T) {
 	seedStore(t, db, storeID, tenantID)
 	seedGatewayConfig(t, db, tenantID, storeID, "stripe", true)
 
-	r := orderrefund.NewResolver(db)
+	r := orderrefund.NewResolver(db).WithEncryptor(crypto.NewNoopEncryptor())
 	gw, err := r.GatewayFor(context.Background(), storeID, "stripe")
 	if err != nil {
 		t.Fatalf("GatewayFor: %v", err)

--- a/services/marketplace-api/internal/page/repository_integration_test.go
+++ b/services/marketplace-api/internal/page/repository_integration_test.go
@@ -160,6 +160,7 @@ func TestRepository_Create_DuplicateSlug_Errors(t *testing.T) {
 	}))
 
 	// Same store_id + same slug → must error (unique index violation)
+	require.NoError(t, tx.Exec("SAVEPOINT sp").Error)
 	err := repo.Create(context.Background(), &Page{
 		TenantID: tenantID,
 		StoreID:  storeID,
@@ -169,6 +170,7 @@ func TestRepository_Create_DuplicateSlug_Errors(t *testing.T) {
 	require.Error(t, err, "inserting duplicate (store_id, slug) should violate the unique index")
 	require.True(t, errors.Is(err, apperrors.ErrSlugTaken),
 		"expected SlugTaken, got %v", err)
+	require.NoError(t, tx.Exec("ROLLBACK TO SAVEPOINT sp").Error)
 
 	// Different store_id with same slug → must succeed
 	otherStoreID := uuid.New()

--- a/services/marketplace-api/internal/product/models.go
+++ b/services/marketplace-api/internal/product/models.go
@@ -42,13 +42,16 @@ const (
 
 // Product is the catalog record. No prices, no stock — see Variant.
 type Product struct {
-	ID                  string         `gorm:"primaryKey;column:id;type:uuid;default:gen_random_uuid()" json:"id"`
-	TenantID            string         `gorm:"column:tenant_id;type:uuid;not null"                      json:"tenant_id"`
-	StoreID             string         `gorm:"column:store_id;type:uuid;not null"                       json:"store_id"`
-	Handle              string         `gorm:"column:handle;type:varchar(200);not null"                 json:"handle"`
-	Title               string         `gorm:"column:title;type:varchar(300);not null"                  json:"title"`
-	Description         *string        `gorm:"column:description;type:text"                             json:"description,omitempty"`
-	Status              string         `gorm:"column:status;type:varchar(20);not null;default:draft"    json:"status"`
+	ID          string  `gorm:"primaryKey;column:id;type:uuid;default:gen_random_uuid()" json:"id"`
+	TenantID    string  `gorm:"column:tenant_id;type:uuid;not null"                      json:"tenant_id"`
+	StoreID     string  `gorm:"column:store_id;type:uuid;not null"                       json:"store_id"`
+	Handle      string  `gorm:"column:handle;type:varchar(200);not null"                 json:"handle"`
+	Title       string  `gorm:"column:title;type:varchar(300);not null"                  json:"title"`
+	Description *string `gorm:"column:description;type:text"                             json:"description,omitempty"`
+	Status      string  `gorm:"column:status;type:varchar(20);not null;default:draft"    json:"status"`
+	// VendorID is a pointer for historical reasons; the column has been NOT NULL
+	// since migration 000028. See issue #402 — tightening it to a plain string
+	// touches JSON omitempty and every nil check, so it is tracked separately.
 	VendorID            *string        `gorm:"column:vendor_id;type:uuid"                               json:"vendor_id,omitempty"`
 	Tags                pq.StringArray `gorm:"column:tags;type:text[];not null;default:'{}'"        json:"tags"`
 	SEOTitle            *string        `gorm:"column:seo_title;type:varchar(300)"                       json:"seo_title,omitempty"`
@@ -127,7 +130,10 @@ type Variant struct {
 	Position          int              `gorm:"column:position;not null;default:0"                       json:"position"`
 	CreatedAt         time.Time        `gorm:"column:created_at;not null;default:now()"                 json:"created_at"`
 	UpdatedAt         time.Time        `gorm:"column:updated_at;not null;default:now()"                 json:"updated_at"`
-	DeletedAt         *time.Time       `gorm:"column:deleted_at;index"                                  json:"deleted_at,omitempty"`
+	// DeletedAt is a plain *time.Time, not gorm.DeletedAt, so GORM's automatic
+	// soft-delete filtering does NOT apply — every Preload("Variants") returns
+	// deleted rows. See issue #395.
+	DeletedAt *time.Time `gorm:"column:deleted_at;index"                                  json:"deleted_at,omitempty"`
 
 	OptionValueLinks []VariantOptionValue `gorm:"foreignKey:VariantID" json:"option_value_links,omitempty"`
 }

--- a/services/marketplace-api/internal/product/models_integration_test.go
+++ b/services/marketplace-api/internal/product/models_integration_test.go
@@ -41,6 +41,7 @@ func TestIntegration_FullProductGraph_RoundTrip(t *testing.T) {
 	if err := tx.Create(store).Error; err != nil {
 		t.Fatalf("insert store: %v", err)
 	}
+	vendorID := testdb.SeedVendor(t, tx, uuid.MustParse(tenantID)).String()
 
 	// 2. Insert two categories (one root, one nested)
 	rootCat := &category.Category{
@@ -71,6 +72,7 @@ func TestIntegration_FullProductGraph_RoundTrip(t *testing.T) {
 	prod := &product.Product{
 		TenantID:          tenantID,
 		StoreID:           storeID,
+		VendorID:          &vendorID,
 		Handle:            "linen-shirt",
 		Title:             "Linen Shirt",
 		Status:            product.StatusDraft,
@@ -270,11 +272,13 @@ func TestIntegration_PartialUnique_SoftDelete(t *testing.T) {
 	if err := tx.Create(store).Error; err != nil {
 		t.Fatalf("insert store: %v", err)
 	}
+	vendorID := testdb.SeedVendor(t, tx, uuid.MustParse(tenantID)).String()
 
 	// Insert first product (real statement; stays committed inside the outer tx)
 	p1 := &product.Product{
 		TenantID: tenantID,
 		StoreID:  storeID,
+		VendorID: &vendorID,
 		Handle:   "silk-scarf",
 		Title:    "Silk Scarf",
 		Status:   product.StatusDraft,
@@ -291,6 +295,7 @@ func TestIntegration_PartialUnique_SoftDelete(t *testing.T) {
 	p2 := &product.Product{
 		TenantID: tenantID,
 		StoreID:  storeID,
+		VendorID: &vendorID,
 		Handle:   "silk-scarf",
 		Title:    "Silk Scarf (v2)",
 		Status:   product.StatusDraft,
@@ -313,6 +318,7 @@ func TestIntegration_PartialUnique_SoftDelete(t *testing.T) {
 	p3 := &product.Product{
 		TenantID: tenantID,
 		StoreID:  storeID,
+		VendorID: &vendorID,
 		Handle:   "silk-scarf",
 		Title:    "Silk Scarf (v3)",
 		Status:   product.StatusDraft,

--- a/services/marketplace-api/internal/product/repository_integration_test.go
+++ b/services/marketplace-api/internal/product/repository_integration_test.go
@@ -400,7 +400,7 @@ func TestIntegration_ProductRepo_ListPublished_ExcludesDraftArchivedDeletedUnpub
 	storeID, tenantID, vendorID := seedStore(t, tx)
 
 	// A: active + published → included
-	now := time.Now()
+	now := time.Now().Add(-time.Hour)
 	a := minimalAggregate(storeID, tenantID, vendorID, "visible", "V-1")
 	a.Product.Status = product.StatusActive
 	a.Product.PublishedAt = &now

--- a/services/marketplace-api/internal/product/repository_integration_test.go
+++ b/services/marketplace-api/internal/product/repository_integration_test.go
@@ -26,7 +26,7 @@ import (
 
 const testLocationID = "00000000-0000-0000-0000-000000000001"
 
-func seedStore(t *testing.T, db *gorm.DB) (storeID, tenantID string) {
+func seedStore(t *testing.T, db *gorm.DB) (storeID, tenantID, vendorID string) {
 	t.Helper()
 	storeID = uuid.NewString()
 	tenantID = uuid.NewString()
@@ -43,17 +43,19 @@ func seedStore(t *testing.T, db *gorm.DB) (storeID, tenantID string) {
 	if err := db.Create(s).Error; err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
+	vendorID = testdb.SeedVendor(t, db, uuid.MustParse(tenantID)).String()
 	return
 }
 
 // minimalAggregate builds a product with 0 options + 1 default variant.
-func minimalAggregate(storeID, tenantID, handle, sku string) *product.Aggregate {
+func minimalAggregate(storeID, tenantID, vendorID, handle, sku string) *product.Aggregate {
 	variantID := uuid.NewString()
 	return &product.Aggregate{
 		Product: product.Product{
 			ID:       uuid.NewString(),
 			TenantID: tenantID,
 			StoreID:  storeID,
+			VendorID: &vendorID,
 			Handle:   handle,
 			Title:    "Test " + handle,
 			Status:   product.StatusDraft,
@@ -71,7 +73,7 @@ func minimalAggregate(storeID, tenantID, handle, sku string) *product.Aggregate 
 
 // richAggregate builds a product with 2 options × 2 values × 2 variants +
 // 2 media + 1 category link. Used by the ListAdmin query-count gate.
-func richAggregate(t *testing.T, tx *gorm.DB, storeID, tenantID, handle, skuPrefix string, categoryID string) *product.Aggregate {
+func richAggregate(t *testing.T, tx *gorm.DB, storeID, tenantID, vendorID, handle, skuPrefix string, categoryID string) *product.Aggregate {
 	t.Helper()
 	opt1ID := uuid.NewString()
 	opt2ID := uuid.NewString()
@@ -110,6 +112,7 @@ func richAggregate(t *testing.T, tx *gorm.DB, storeID, tenantID, handle, skuPref
 			ID:       uuid.NewString(),
 			TenantID: tenantID,
 			StoreID:  storeID,
+			VendorID: &vendorID,
 			Handle:   handle,
 			Title:    "Rich " + handle,
 			Status:   product.StatusDraft,
@@ -188,8 +191,8 @@ func TestIntegration_ProductRepo_CreateAggregate_MinimalRoundTrip(t *testing.T) 
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
-	agg := minimalAggregate(storeID, tenantID, "linen-shirt", "LINEN-1")
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	agg := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
 	if err := repo.CreateAggregateInTx(ctx, tx, agg); err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -213,8 +216,8 @@ func TestIntegration_ProductRepo_GetByIDForStore_CrossTenant_NotFound(t *testing
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
-	agg := minimalAggregate(storeID, tenantID, "linen-shirt", "LINEN-1")
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	agg := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
 	if err := repo.CreateAggregateInTx(ctx, tx, agg); err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -232,13 +235,13 @@ func TestIntegration_ProductRepo_CreateAggregate_HandleCollision_Returns_HandleT
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
-	first := minimalAggregate(storeID, tenantID, "linen-shirt", "LINEN-1")
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	first := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
 	if err := repo.CreateAggregateInTx(ctx, tx, first); err != nil {
 		t.Fatalf("first: %v", err)
 	}
 
-	dup := minimalAggregate(storeID, tenantID, "linen-shirt", "LINEN-2")
+	dup := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-2")
 	err := withSavepoint(t, tx, func() error {
 		return repo.CreateAggregateInTx(ctx, tx, dup)
 	})
@@ -261,13 +264,13 @@ func TestIntegration_ProductRepo_CreateAggregate_SKUCollision_Returns_SKUTaken(t
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
-	first := minimalAggregate(storeID, tenantID, "linen-shirt", "DUPED-SKU")
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	first := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "DUPED-SKU")
 	if err := repo.CreateAggregateInTx(ctx, tx, first); err != nil {
 		t.Fatalf("first: %v", err)
 	}
 
-	dup := minimalAggregate(storeID, tenantID, "cotton-shirt", "DUPED-SKU")
+	dup := minimalAggregate(storeID, tenantID, vendorID, "cotton-shirt", "DUPED-SKU")
 	err := withSavepoint(t, tx, func() error {
 		return repo.CreateAggregateInTx(ctx, tx, dup)
 	})
@@ -283,8 +286,8 @@ func TestIntegration_ProductRepo_SoftDeleteThenRecreate_SameHandle_Succeeds(t *t
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
-	first := minimalAggregate(storeID, tenantID, "linen-shirt", "LINEN-1")
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	first := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
 	if err := repo.CreateAggregateInTx(ctx, tx, first); err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -293,7 +296,7 @@ func TestIntegration_ProductRepo_SoftDeleteThenRecreate_SameHandle_Succeeds(t *t
 		t.Fatalf("soft delete: %v", err)
 	}
 
-	recreated := minimalAggregate(storeID, tenantID, "linen-shirt", "LINEN-2")
+	recreated := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-2")
 	if err := repo.CreateAggregateInTx(ctx, tx, recreated); err != nil {
 		t.Fatalf("recreate: %v", err)
 	}
@@ -306,19 +309,19 @@ func TestIntegration_ProductRepo_UnDeleteSoftDeletedRow_Returns_HandleTaken(t *t
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, vendorID := seedStore(t, tx)
 
 	// 1. Seed a row that's already soft-deleted at handle "linen-shirt".
 	softID := uuid.NewString()
 	if err := tx.Exec(`
-		INSERT INTO products (id, tenant_id, store_id, handle, title, status, deleted_at)
-		VALUES (?, ?, ?, ?, ?, 'draft', now())`,
-		softID, tenantID, storeID, "linen-shirt", "Deleted Linen").Error; err != nil {
+		INSERT INTO products (id, tenant_id, store_id, vendor_id, handle, title, status, deleted_at)
+		VALUES (?, ?, ?, ?, ?, ?, 'draft', now())`,
+		softID, tenantID, storeID, vendorID, "linen-shirt", "Deleted Linen").Error; err != nil {
 		t.Fatalf("seed deleted: %v", err)
 	}
 
 	// 2. Insert a live row with the same handle (allowed by the partial index).
-	live := minimalAggregate(storeID, tenantID, "linen-shirt", "LINEN-LIVE")
+	live := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-LIVE")
 	if err := repo.CreateAggregateInTx(ctx, tx, live); err != nil {
 		t.Fatalf("create live: %v", err)
 	}
@@ -350,12 +353,12 @@ func TestIntegration_ProductRepo_ListAdmin_QueryCount_BelowCeiling(t *testing.T)
 	tx := testdb.NewTx(t)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, vendorID := seedStore(t, tx)
 	catID := seedCategory(t, tx, storeID, tenantID, "apparel")
 
 	repo := product.NewRepository(tx)
 	for i := 0; i < 3; i++ {
-		agg := richAggregate(t, tx, storeID, tenantID,
+		agg := richAggregate(t, tx, storeID, tenantID, vendorID,
 			fmt.Sprintf("prod-%d", i), fmt.Sprintf("SKU%d", i), catID)
 		if err := repo.CreateAggregateInTx(ctx, tx, agg); err != nil {
 			t.Fatalf("create %d: %v", i, err)
@@ -394,11 +397,11 @@ func TestIntegration_ProductRepo_ListPublished_ExcludesDraftArchivedDeletedUnpub
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, vendorID := seedStore(t, tx)
 
 	// A: active + published → included
 	now := time.Now()
-	a := minimalAggregate(storeID, tenantID, "visible", "V-1")
+	a := minimalAggregate(storeID, tenantID, vendorID, "visible", "V-1")
 	a.Product.Status = product.StatusActive
 	a.Product.PublishedAt = &now
 	if err := repo.CreateAggregateInTx(ctx, tx, a); err != nil {
@@ -406,13 +409,13 @@ func TestIntegration_ProductRepo_ListPublished_ExcludesDraftArchivedDeletedUnpub
 	}
 
 	// B: draft → excluded
-	b := minimalAggregate(storeID, tenantID, "draft", "D-1")
+	b := minimalAggregate(storeID, tenantID, vendorID, "draft", "D-1")
 	if err := repo.CreateAggregateInTx(ctx, tx, b); err != nil {
 		t.Fatalf("b: %v", err)
 	}
 
 	// C: archived → excluded. Spec forbids archived+published combo.
-	c := minimalAggregate(storeID, tenantID, "archived", "A-1")
+	c := minimalAggregate(storeID, tenantID, vendorID, "archived", "A-1")
 	c.Product.Status = product.StatusArchived
 	if err := repo.CreateAggregateInTx(ctx, tx, c); err != nil {
 		t.Fatalf("c: %v", err)
@@ -420,7 +423,7 @@ func TestIntegration_ProductRepo_ListPublished_ExcludesDraftArchivedDeletedUnpub
 
 	// D: soft-deleted → excluded. Must be active+published first to
 	// prove deleted_at alone filters it out.
-	d := minimalAggregate(storeID, tenantID, "deleted", "DD-1")
+	d := minimalAggregate(storeID, tenantID, vendorID, "deleted", "DD-1")
 	d.Product.Status = product.StatusActive
 	d.Product.PublishedAt = &now
 	if err := repo.CreateAggregateInTx(ctx, tx, d); err != nil {
@@ -453,8 +456,8 @@ func TestIntegration_ProductRepo_UpdateVariantStockInTx_TriggerUpdatesInventoryQ
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
-	agg := minimalAggregate(storeID, tenantID, "linen-shirt", "LINEN-1")
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	agg := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
 	if err := repo.CreateAggregateInTx(ctx, tx, agg); err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -492,8 +495,8 @@ func TestIntegration_ProductRepo_ReverseDirection_ProductVariantsInventory_DoesN
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
-	agg := minimalAggregate(storeID, tenantID, "linen-shirt", "LINEN-1")
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	agg := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
 	if err := repo.CreateAggregateInTx(ctx, tx, agg); err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -528,14 +531,14 @@ func TestIntegration_ProductRepo_ApplyVariantDiffInTx_AddUpdateRemove(t *testing
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, vendorID := seedStore(t, tx)
 
 	// Product with two variants to start.
 	v1ID := uuid.NewString()
 	v2ID := uuid.NewString()
 	agg := &product.Aggregate{
 		Product: product.Product{
-			ID: uuid.NewString(), TenantID: tenantID, StoreID: storeID,
+			ID: uuid.NewString(), TenantID: tenantID, StoreID: storeID, VendorID: &vendorID,
 			Handle: "diff-test", Title: "Diff Test", Status: product.StatusDraft,
 		},
 		Variants: []product.Variant{
@@ -597,12 +600,12 @@ func TestIntegration_ProductRepo_ReplaceCategoryLinksInTx_AddsAndRemoves(t *test
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, vendorID := seedStore(t, tx)
 	cat1 := seedCategory(t, tx, storeID, tenantID, "cat-1")
 	cat2 := seedCategory(t, tx, storeID, tenantID, "cat-2")
 	cat3 := seedCategory(t, tx, storeID, tenantID, "cat-3")
 
-	agg := minimalAggregate(storeID, tenantID, "cat-test", "C-1")
+	agg := minimalAggregate(storeID, tenantID, vendorID, "cat-test", "C-1")
 	agg.CategoryLinks = []product.ProductCategory{{CategoryID: cat1}, {CategoryID: cat2}}
 	if err := repo.CreateAggregateInTx(ctx, tx, agg); err != nil {
 		t.Fatalf("create: %v", err)
@@ -632,8 +635,8 @@ func TestIntegration_ProductRepo_ReplaceMediaInTx_PreservesByStorageKey(t *testi
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
-	agg := minimalAggregate(storeID, tenantID, "media-test", "M-1")
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	agg := minimalAggregate(storeID, tenantID, vendorID, "media-test", "M-1")
 	agg.Media = []product.Media{
 		{ID: uuid.NewString(), URL: "https://a", StorageKey: "key-a", MediaType: product.MediaTypeImage, Position: 0},
 		{ID: uuid.NewString(), URL: "https://b", StorageKey: "key-b", MediaType: product.MediaTypeImage, Position: 1},
@@ -701,7 +704,7 @@ func TestIntegration_ProductRepo_ConcurrentCreate_SameHandle_OneWinsOneFails(t *
 	)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, db)
+	storeID, tenantID, vendorID := seedStore(t, db)
 	repo := product.NewRepository(db)
 
 	var wg sync.WaitGroup
@@ -712,7 +715,7 @@ func TestIntegration_ProductRepo_ConcurrentCreate_SameHandle_OneWinsOneFails(t *
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			agg := minimalAggregate(storeID, tenantID, "race-handle",
+			agg := minimalAggregate(storeID, tenantID, vendorID, "race-handle",
 				fmt.Sprintf("RACE-%d", idx))
 			<-start
 			err := db.Transaction(func(tx *gorm.DB) error {
@@ -753,13 +756,13 @@ func TestIntegration_ProductRepo_ListPublished_LeakRegression(t *testing.T) {
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, vendorID := seedStore(t, tx)
 
 	past := time.Now().Add(-1 * time.Hour)
 	future := time.Now().Add(24 * time.Hour)
 
 	// 1. active + published in the past → INCLUDED
-	good := minimalAggregate(storeID, tenantID, "visible", "VIS-1")
+	good := minimalAggregate(storeID, tenantID, vendorID, "visible", "VIS-1")
 	good.Product.Status = product.StatusActive
 	good.Product.PublishedAt = &past
 	if err := repo.CreateAggregateInTx(ctx, tx, good); err != nil {
@@ -767,20 +770,20 @@ func TestIntegration_ProductRepo_ListPublished_LeakRegression(t *testing.T) {
 	}
 
 	// 2. draft → EXCLUDED
-	draft := minimalAggregate(storeID, tenantID, "draft-p", "DR-1")
+	draft := minimalAggregate(storeID, tenantID, vendorID, "draft-p", "DR-1")
 	if err := repo.CreateAggregateInTx(ctx, tx, draft); err != nil {
 		t.Fatalf("draft: %v", err)
 	}
 
 	// 3. archived → EXCLUDED
-	arch := minimalAggregate(storeID, tenantID, "arch-p", "AR-1")
+	arch := minimalAggregate(storeID, tenantID, vendorID, "arch-p", "AR-1")
 	arch.Product.Status = product.StatusArchived
 	if err := repo.CreateAggregateInTx(ctx, tx, arch); err != nil {
 		t.Fatalf("archived: %v", err)
 	}
 
 	// 4. active + published_at in the future → EXCLUDED
-	sched := minimalAggregate(storeID, tenantID, "sched-p", "SC-1")
+	sched := minimalAggregate(storeID, tenantID, vendorID, "sched-p", "SC-1")
 	sched.Product.Status = product.StatusActive
 	sched.Product.PublishedAt = &future
 	if err := repo.CreateAggregateInTx(ctx, tx, sched); err != nil {
@@ -788,7 +791,7 @@ func TestIntegration_ProductRepo_ListPublished_LeakRegression(t *testing.T) {
 	}
 
 	// 5. active + published + soft-deleted → EXCLUDED
-	del := minimalAggregate(storeID, tenantID, "del-p", "DL-1")
+	del := minimalAggregate(storeID, tenantID, vendorID, "del-p", "DL-1")
 	del.Product.Status = product.StatusActive
 	del.Product.PublishedAt = &past
 	if err := repo.CreateAggregateInTx(ctx, tx, del); err != nil {
@@ -819,7 +822,7 @@ func TestIntegration_ProductRepo_ListPublished_WithCategorySlug_Filters(t *testi
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, vendorID := seedStore(t, tx)
 	past := time.Now().Add(-1 * time.Hour)
 
 	apparelID := seedCategory(t, tx, storeID, tenantID, "apparel")
@@ -827,7 +830,7 @@ func TestIntegration_ProductRepo_ListPublished_WithCategorySlug_Filters(t *testi
 	bagsID := seedCategory(t, tx, storeID, tenantID, "bags")
 
 	mk := func(handle, sku, catID string) *product.Aggregate {
-		a := minimalAggregate(storeID, tenantID, handle, sku)
+		a := minimalAggregate(storeID, tenantID, vendorID, handle, sku)
 		a.Product.Status = product.StatusActive
 		a.Product.PublishedAt = &past
 		a.CategoryLinks = []product.ProductCategory{{CategoryID: catID}}
@@ -866,9 +869,9 @@ func TestIntegration_ProductRepo_GetPublishedByHandle_HappyPath(t *testing.T) {
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, vendorID := seedStore(t, tx)
 	past := time.Now().Add(-1 * time.Hour)
-	a := minimalAggregate(storeID, tenantID, "linen-shirt", "LS-1")
+	a := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LS-1")
 	a.Product.Status = product.StatusActive
 	a.Product.PublishedAt = &past
 	if err := repo.CreateAggregateInTx(ctx, tx, a); err != nil {
@@ -892,8 +895,8 @@ func TestIntegration_ProductRepo_GetPublishedByHandle_Draft_Returns_NotFound(t *
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
-	a := minimalAggregate(storeID, tenantID, "linen-shirt", "LS-1")
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	a := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LS-1")
 	if err := repo.CreateAggregateInTx(ctx, tx, a); err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -909,9 +912,9 @@ func TestIntegration_ProductRepo_GetPublishedByHandle_SoftDeleted_Returns_NotFou
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, vendorID := seedStore(t, tx)
 	past := time.Now().Add(-1 * time.Hour)
-	a := minimalAggregate(storeID, tenantID, "linen-shirt", "LS-1")
+	a := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LS-1")
 	a.Product.Status = product.StatusActive
 	a.Product.PublishedAt = &past
 	if err := repo.CreateAggregateInTx(ctx, tx, a); err != nil {
@@ -932,11 +935,11 @@ func TestIntegration_ProductRepo_GetPublishedByHandle_CrossStore_NotFound(t *tes
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeA, tenantA := seedStore(t, tx)
-	storeB, _ := seedStore(t, tx)
+	storeA, tenantA, vendorA := seedStore(t, tx)
+	storeB, _, _ := seedStore(t, tx)
 	past := time.Now().Add(-1 * time.Hour)
 
-	a := minimalAggregate(storeA, tenantA, "linen-shirt", "LS-1")
+	a := minimalAggregate(storeA, tenantA, vendorA, "linen-shirt", "LS-1")
 	a.Product.Status = product.StatusActive
 	a.Product.PublishedAt = &past
 	if err := repo.CreateAggregateInTx(ctx, tx, a); err != nil {
@@ -954,9 +957,9 @@ func TestIntegration_ProductRepo_GetPublishedByHandle_Archived_NotFound(t *testi
 	repo := product.NewRepository(tx)
 	ctx := context.Background()
 
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, vendorID := seedStore(t, tx)
 	past := time.Now().Add(-1 * time.Hour)
-	a := minimalAggregate(storeID, tenantID, "linen-shirt", "LS-1")
+	a := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LS-1")
 	a.Product.Status = product.StatusArchived
 	a.Product.PublishedAt = &past
 	if err := repo.CreateAggregateInTx(ctx, tx, a); err != nil {

--- a/services/marketplace-api/internal/product/service_aggregate_test.go
+++ b/services/marketplace-api/internal/product/service_aggregate_test.go
@@ -59,7 +59,7 @@ func findVariantBySKU(agg *product.Aggregate, sku string) *product.Variant {
 // gap #1: options rename + value add + variant add/update all in one PATCH.
 func TestIntegration_ProductService_UpdateAggregate_FullRoundTrip(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	ctx := context.Background()
 
@@ -153,7 +153,7 @@ func TestIntegration_ProductService_UpdateAggregate_FullRoundTrip(t *testing.T) 
 // exercises gap #2: RemovedVariantIDs path soft-deletes variants.
 func TestIntegration_ProductService_UpdateAggregate_RemovedVariantIDsSoftDelete(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	ctx := context.Background()
 
@@ -211,7 +211,7 @@ func TestIntegration_ProductService_UpdateAggregate_RemovedVariantIDsSoftDelete(
 // variant still references should return OptionValueInUse and roll back.
 func TestIntegration_ProductService_UpdateAggregate_OptionValueInUseRejected(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	ctx := context.Background()
 

--- a/services/marketplace-api/internal/product/service_integration_test.go
+++ b/services/marketplace-api/internal/product/service_integration_test.go
@@ -16,19 +16,26 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/outbox"
 	"github.com/mark8ly/marketplace-api/internal/product"
 	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/internal/vendor"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
 // buildService wires a product.Service against the given tx with a
 // fake Uploader pre-registered against any keys the caller will use.
+//
+// VendorLookup is wired to a real vendor.Service so svc.Create defaults
+// VendorID to the tenant's self-vendor (products.vendor_id is NOT NULL).
+// Callers must seed that self-vendor first — seedStore and
+// seedStoreWithCurrency both do this via testdb.SeedVendor.
 func buildService(tx *gorm.DB, uploader media.Uploader) *product.Service {
 	return product.NewService(product.Config{
-		DB:         tx,
-		Repo:       product.NewRepository(tx),
-		StoresRepo: stores.NewRepository(tx),
-		OutboxRepo: outbox.NewRepository(tx),
-		Uploader:   uploader,
+		DB:           tx,
+		Repo:         product.NewRepository(tx),
+		StoresRepo:   stores.NewRepository(tx),
+		OutboxRepo:   outbox.NewRepository(tx),
+		Uploader:     uploader,
+		VendorLookup: vendor.NewService(vendor.NewRepository(tx)),
 	})
 }
 
@@ -47,7 +54,7 @@ func countProductOutbox(t *testing.T, tx *gorm.DB, productID, eventType string) 
 
 func TestIntegration_ProductService_Create_SimpleProduct_HappyPath(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 
 	agg, err := svc.Create(context.Background(), product.CreateRequest{
@@ -94,7 +101,7 @@ func TestIntegration_ProductService_Create_SimpleProduct_HappyPath(t *testing.T)
 // hit on australia-store 2026-04-25.
 func TestIntegration_ProductService_Create_StatusActive_SetsPublishedAt(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 
 	active := product.StatusActive
@@ -123,7 +130,7 @@ func TestIntegration_ProductService_Create_StatusActive_SetsPublishedAt(t *testi
 
 func TestIntegration_ProductService_Create_EmptyTitle_ReturnsValidationFailed(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 
 	_, err := svc.Create(context.Background(), product.CreateRequest{
@@ -137,7 +144,7 @@ func TestIntegration_ProductService_Create_EmptyTitle_ReturnsValidationFailed(t 
 
 func TestIntegration_ProductService_Create_CurrencyMismatch(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx) // store currency = USD
+	storeID, tenantID, _ := seedStore(t, tx) // store currency = USD
 	svc := buildService(tx, media.NewFakeUploader())
 
 	_, err := svc.Create(context.Background(), product.CreateRequest{
@@ -153,7 +160,7 @@ func TestIntegration_ProductService_Create_CurrencyMismatch(t *testing.T) {
 
 func TestIntegration_ProductService_Create_WithOptions_Matrix(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 
 	agg, err := svc.Create(context.Background(), product.CreateRequest{
@@ -185,7 +192,7 @@ func TestIntegration_ProductService_Create_WithOptions_Matrix(t *testing.T) {
 
 func TestIntegration_ProductService_Create_MatrixMismatch(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 
 	_, err := svc.Create(context.Background(), product.CreateRequest{
@@ -205,7 +212,7 @@ func TestIntegration_ProductService_Create_MatrixMismatch(t *testing.T) {
 
 func TestIntegration_ProductService_Create_UploadNotFound(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 
 	_, err := svc.Create(context.Background(), product.CreateRequest{
@@ -222,7 +229,7 @@ func TestIntegration_ProductService_Create_UploadNotFound(t *testing.T) {
 
 func TestIntegration_ProductService_Create_HandleCollision_ReturnsHandleTaken(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	ctx := context.Background()
 
@@ -248,7 +255,7 @@ func TestIntegration_ProductService_Create_HandleCollision_ReturnsHandleTaken(t 
 
 func TestIntegration_ProductService_UpdateBasics_ChangesTitleAndStatus(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	ctx := context.Background()
 
@@ -285,7 +292,7 @@ func TestIntegration_ProductService_UpdateBasics_ChangesTitleAndStatus(t *testin
 
 func TestIntegration_ProductService_UpdateBasics_SanitizesDescription(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	ctx := context.Background()
 
@@ -314,7 +321,7 @@ func TestIntegration_ProductService_UpdateBasics_SanitizesDescription(t *testing
 
 func TestIntegration_ProductService_UpdateBasics_NotFound(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	title := "Nope"
 	_, err := svc.UpdateBasics(context.Background(), product.UpdateBasicsRequest{
@@ -327,7 +334,7 @@ func TestIntegration_ProductService_UpdateBasics_NotFound(t *testing.T) {
 
 func TestIntegration_ProductService_UpdateMedia_ReplacesSet(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	up := media.NewFakeUploader()
 	up.Register(media.Attrs{StorageKey: "k-a", Size: 1, ContentType: "image/jpeg"})
 	up.Register(media.Attrs{StorageKey: "k-b", Size: 1, ContentType: "image/jpeg"})
@@ -362,7 +369,7 @@ func TestIntegration_ProductService_UpdateMedia_ReplacesSet(t *testing.T) {
 
 func TestIntegration_ProductService_UpdateCategoryLinks_Replaces(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	ctx := context.Background()
 
@@ -395,7 +402,7 @@ func TestIntegration_ProductService_UpdateCategoryLinks_Replaces(t *testing.T) {
 
 func TestIntegration_ProductService_Delete_SoftDelete_EnqueuesOutbox(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	ctx := context.Background()
 
@@ -426,7 +433,7 @@ func TestIntegration_ProductService_Delete_SoftDelete_EnqueuesOutbox(t *testing.
 
 func TestIntegration_ProductService_Delete_NotFound(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	err := svc.Delete(context.Background(), uuid.NewString(), storeID, tenantID)
 	if !errors.Is(err, apperrors.ErrNotFound) {
@@ -454,6 +461,9 @@ func seedStoreWithCurrency(t *testing.T, db *gorm.DB, tenantID, currency string)
 	if err := db.Create(s).Error; err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
+	// Idempotent per tenant: a second store under the same tenant just
+	// returns the existing self-vendor.
+	testdb.SeedVendor(t, db, uuid.MustParse(tenantID))
 	return storeID
 }
 
@@ -589,7 +599,7 @@ func TestIntegration_ProductService_Copy_CrossStore_Success(t *testing.T) {
 
 func TestIntegration_ProductService_Copy_TargetInvalid_SameStore(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	srcCatID := seedCategory(t, tx, storeID, tenantID, "same-store-cat")
 	source := seedRichSourceProduct(t, tx, storeID, tenantID, "USD", srcCatID)
 	svc := buildService(tx, media.NewFakeUploader())
@@ -607,7 +617,7 @@ func TestIntegration_ProductService_Copy_TargetInvalid_SameStore(t *testing.T) {
 
 func TestIntegration_ProductService_Copy_TargetInvalid_NotFound(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	srcCatID := seedCategory(t, tx, storeID, tenantID, "notfound-cat")
 	source := seedRichSourceProduct(t, tx, storeID, tenantID, "USD", srcCatID)
 	svc := buildService(tx, media.NewFakeUploader())
@@ -625,7 +635,7 @@ func TestIntegration_ProductService_Copy_TargetInvalid_NotFound(t *testing.T) {
 
 func TestIntegration_ProductService_Copy_TargetInvalid_OtherTenant(t *testing.T) {
 	tx := testdb.NewTx(t)
-	srcStoreID, srcTenantID := seedStore(t, tx)
+	srcStoreID, srcTenantID, _ := seedStore(t, tx)
 	srcCatID := seedCategory(t, tx, srcStoreID, srcTenantID, "other-tenant-cat")
 	source := seedRichSourceProduct(t, tx, srcStoreID, srcTenantID, "USD", srcCatID)
 

--- a/services/marketplace-api/internal/product/service_media_recrop_integration_test.go
+++ b/services/marketplace-api/internal/product/service_media_recrop_integration_test.go
@@ -46,7 +46,7 @@ func seedMediaRow(t *testing.T, svc *product.Service, agg *product.Aggregate, st
 
 func TestIntegration_RecropMedia_SignsWithGivenContentType(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	up := &capturingUploader{FakeUploader: media.NewFakeUploader()}
 	up.Register(media.Attrs{StorageKey: "orig-webp", Size: 10, ContentType: "image/webp"})
 	svc := buildService(tx, up)
@@ -70,7 +70,7 @@ func TestIntegration_RecropMedia_SignsWithGivenContentType(t *testing.T) {
 
 func TestIntegration_RecropMedia_DefaultsContentTypeToJPEG(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	up := &capturingUploader{FakeUploader: media.NewFakeUploader()}
 	up.Register(media.Attrs{StorageKey: "orig-jpg", Size: 10, ContentType: "image/jpeg"})
 	svc := buildService(tx, up)

--- a/services/marketplace-api/internal/product/service_single_media_integration_test.go
+++ b/services/marketplace-api/internal/product/service_single_media_integration_test.go
@@ -36,7 +36,7 @@ func seedProductForMedia(t *testing.T, svc *product.Service, storeID, tenantID s
 
 func TestIntegration_Service_AddMedia_HappyPath(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	up := media.NewFakeUploader()
 	up.Register(media.Attrs{StorageKey: "k-happy", Size: 123, ContentType: "image/jpeg"})
 	svc := buildService(tx, up)
@@ -79,7 +79,7 @@ func TestIntegration_Service_AddMedia_HappyPath(t *testing.T) {
 
 func TestIntegration_Service_AddMedia_UploadNotFound(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	agg := seedProductForMedia(t, svc, storeID, tenantID)
 
@@ -98,7 +98,7 @@ func TestIntegration_Service_AddMedia_UploadNotFound(t *testing.T) {
 
 func TestIntegration_Service_UpdateMedia_UpdatesAlt(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	up := media.NewFakeUploader()
 	up.Register(media.Attrs{StorageKey: "k1", Size: 1, ContentType: "image/jpeg"})
 	svc := buildService(tx, up)
@@ -132,7 +132,7 @@ func TestIntegration_Service_UpdateMedia_UpdatesAlt(t *testing.T) {
 
 func TestIntegration_Service_UpdateMedia_NotFound(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	agg := seedProductForMedia(t, svc, storeID, tenantID)
 
@@ -149,7 +149,7 @@ func TestIntegration_Service_UpdateMedia_NotFound(t *testing.T) {
 
 func TestIntegration_Service_DeleteMedia_Succeeds(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	up := media.NewFakeUploader()
 	up.Register(media.Attrs{StorageKey: "kd", Size: 1, ContentType: "image/jpeg"})
 	svc := buildService(tx, up)
@@ -174,7 +174,7 @@ func TestIntegration_Service_DeleteMedia_Succeeds(t *testing.T) {
 
 func TestIntegration_Service_DeleteMedia_CrossTenant_NotFound(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	up := media.NewFakeUploader()
 	up.Register(media.Attrs{StorageKey: "kx", Size: 1, ContentType: "image/jpeg"})
 	svc := buildService(tx, up)

--- a/services/marketplace-api/internal/product/service_variant_patch_integration_test.go
+++ b/services/marketplace-api/internal/product/service_variant_patch_integration_test.go
@@ -45,7 +45,7 @@ func seedProductWithTwoVariants(t *testing.T, svc *product.Service, storeID, ten
 
 func TestIntegration_Service_UpdateVariantBasics_Price(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	agg := seedProductWithTwoVariants(t, svc, storeID, tenantID)
 	v := agg.Variants[0]
@@ -65,7 +65,7 @@ func TestIntegration_Service_UpdateVariantBasics_Price(t *testing.T) {
 
 func TestIntegration_Service_UpdateVariantBasics_Inventory_TriggerSyncs(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	agg := seedProductWithTwoVariants(t, svc, storeID, tenantID)
 	v := agg.Variants[0]
@@ -95,7 +95,7 @@ func TestIntegration_Service_UpdateVariantBasics_Inventory_TriggerSyncs(t *testi
 
 func TestIntegration_Service_UpdateVariantBasics_SKUCollision(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	agg := seedProductWithTwoVariants(t, svc, storeID, tenantID)
 	firstSKU := agg.Variants[0].SKU
@@ -113,7 +113,7 @@ func TestIntegration_Service_UpdateVariantBasics_SKUCollision(t *testing.T) {
 
 func TestIntegration_Service_UpdateVariantBasics_CurrencyChange_Forbidden(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	agg := seedProductWithTwoVariants(t, svc, storeID, tenantID)
 	v := agg.Variants[0]
@@ -131,7 +131,7 @@ func TestIntegration_Service_UpdateVariantBasics_CurrencyChange_Forbidden(t *tes
 
 func TestIntegration_Service_UpdateVariantBasics_NotFound(t *testing.T) {
 	tx := testdb.NewTx(t)
-	storeID, tenantID := seedStore(t, tx)
+	storeID, tenantID, _ := seedStore(t, tx)
 	svc := buildService(tx, media.NewFakeUploader())
 	agg := seedProductWithTwoVariants(t, svc, storeID, tenantID)
 

--- a/services/marketplace-api/internal/subscription/dunning/testhelpers_integration_test.go
+++ b/services/marketplace-api/internal/subscription/dunning/testhelpers_integration_test.go
@@ -12,42 +12,16 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/audit"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
-// seedStore inserts a minimal stores row for (tenantID, storeID) so that a
-// store_subscriptions row referencing storeID satisfies
-// store_subscriptions_store_id_fkey.
-//
-// Unlike internal/order's seedStore helper, tenantID is supplied by the
-// caller rather than generated here: dunning tests already mint their own
-// tenantID for the subscription/audit rows they seed, and the store must
-// carry that same tenant — otherwise the subscription and its store
-// disagree about tenancy and any tenant-scoped assertion becomes
-// meaningless.
-//
-// Registers a t.Cleanup that deletes the store row so consecutive test runs
-// start from a clean state. No per-store sequences are dropped here (unlike
-// internal/order's helper) — dunning doesn't touch order/return numbering.
+// seedStore delegates to the shared testdb.SeedStore helper, which was
+// derived from this package's original implementation and is behaviourally
+// identical: same signature, same column list, same slug derivation, same
+// cleanup. Kept as a thin wrapper so callers in this package don't change.
 func seedStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
 	t.Helper()
-
-	// Slug is derived from the store id to dodge the stores_slug_unique
-	// constraint when multiple tests (or multiple stores within one test)
-	// run in the same package.
-	slug := "tst-" + strings.ReplaceAll(storeID.String(), "-", "")[:20]
-
-	err := db.Exec(
-		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, encode(gen_random_bytes(32), 'hex'))`,
-		storeID, tenantID, slug, "Test Store", "IE", "EUR", "Europe/Dublin", "active",
-	).Error
-	if err != nil {
-		t.Fatalf("seedStore: insert stores row: %v", err)
-	}
-
-	t.Cleanup(func() {
-		db.Exec("DELETE FROM stores WHERE id = ?", storeID)
-	})
+	testdb.SeedStore(t, db, tenantID, storeID)
 }
 
 // seedPastDueSubscription inserts a stores row, a past_due

--- a/services/marketplace-api/internal/subscription/models_test.go
+++ b/services/marketplace-api/internal/subscription/models_test.go
@@ -22,6 +22,7 @@ func TestStoreSubscription_V23ColumnsRoundTrip(t *testing.T) {
 
 	tenantID := uuid.New()
 	storeID := uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 
 	sub := subscription.StoreSubscription{
 		TenantID:              tenantID,

--- a/services/marketplace-api/internal/subscription/planchange/criterion_39_test.go
+++ b/services/marketplace-api/internal/subscription/planchange/criterion_39_test.go
@@ -39,6 +39,7 @@ func TestCriterion39_DowngradeBlockedOverQuota_AtPeriodEnd(t *testing.T) {
 
 	// Seed 1 store — under Starter cap of 2, so scheduling succeeds.
 	seedStores(t, db, tenantID, 1)
+	testdb.SeedStore(t, db, tenantID, storeID)
 
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:             tenantID,

--- a/services/marketplace-api/internal/subscription/planchange/cron_integration_test.go
+++ b/services/marketplace-api/internal/subscription/planchange/cron_integration_test.go
@@ -33,6 +33,8 @@ func TestDowngradeRecheckCron_CommitsWhenEligible_Integration(t *testing.T) {
 	targetPlan := subscription.PlanStarter
 	targetPeriod := subscription.PeriodMonthly
 
+	testdb.SeedStore(t, db, tenantID, storeID)
+
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:                    tenantID,
 		StoreID:                     storeID,

--- a/services/marketplace-api/internal/subscription/planchange/grandfathering_test.go
+++ b/services/marketplace-api/internal/subscription/planchange/grandfathering_test.go
@@ -38,6 +38,7 @@ func TestGrandfathering_StudioToStarter_ImagesAllowed(t *testing.T) {
 
 	// Seed 1 store — under Starter cap of 2, so scheduling succeeds.
 	seedStores(t, db, tenantID, 1)
+	testdb.SeedStore(t, db, tenantID, storeID)
 
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:             tenantID,

--- a/services/marketplace-api/internal/subscription/planchange/period_switch_test.go
+++ b/services/marketplace-api/internal/subscription/planchange/period_switch_test.go
@@ -29,6 +29,7 @@ func TestPeriodSwitch_MonthlyToAnnual_Pro_CommitsImmediately(t *testing.T) {
 	tenantID := uuid.New()
 	storeID := uuid.New()
 	subID := "sub_period_switch_pro"
+	testdb.SeedStore(t, db, tenantID, storeID)
 
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:             tenantID,

--- a/services/marketplace-api/internal/subscription/planchange/planchange_integration_test.go
+++ b/services/marketplace-api/internal/subscription/planchange/planchange_integration_test.go
@@ -45,6 +45,7 @@ func TestExecute_Upgrade_StarterToStudio_CommitsImmediately(t *testing.T) {
 	tenantID := uuid.New()
 	storeID := uuid.New()
 	subID := "sub_upgrade_test"
+	testdb.SeedStore(t, db, tenantID, storeID)
 
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:             tenantID,
@@ -98,6 +99,7 @@ func TestExecute_Upgrade_Rejected_WhenStatusReadOnly(t *testing.T) {
 
 	tenantID := uuid.New()
 	storeID := uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:           tenantID,
@@ -134,6 +136,7 @@ func TestExecute_RejectsCurrencyChange(t *testing.T) {
 	tenantID := uuid.New()
 	storeID := uuid.New()
 	subID := "sub_currency_test"
+	testdb.SeedStore(t, db, tenantID, storeID)
 
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:             tenantID,
@@ -174,6 +177,7 @@ func TestExecute_Downgrade_StudioToStarter_ParksPending(t *testing.T) {
 	storeID := uuid.New()
 	subID := "sub_downgrade_test"
 	periodEnd := time.Now().Add(15 * 24 * time.Hour)
+	testdb.SeedStore(t, db, tenantID, storeID)
 
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:             tenantID,
@@ -233,6 +237,7 @@ func TestExecute_Downgrade_StudioToStarter_OverQuota_Rejected(t *testing.T) {
 	storeID := uuid.New()
 	subID := "sub_overquota_test"
 	periodEnd := time.Now().Add(15 * 24 * time.Hour)
+	testdb.SeedStore(t, db, tenantID, storeID)
 
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:             tenantID,

--- a/services/marketplace-api/internal/subscription/planchange/planchange_integration_test.go
+++ b/services/marketplace-api/internal/subscription/planchange/planchange_integration_test.go
@@ -34,15 +34,7 @@ func fakeStripeOK() *fakeStripe {
 func seedStores(t *testing.T, db *gorm.DB, tenantID uuid.UUID, count int) {
 	t.Helper()
 	for i := 0; i < count; i++ {
-		storeID := uuid.New()
-		slug := "test-store-" + uuid.NewString()[:8]
-		if err := db.Exec(
-			`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, synced_at)
-			 VALUES (?, ?, ?, 'Test Store', 'US', 'USD', 'UTC', 'active', now())`,
-			storeID, tenantID, slug,
-		).Error; err != nil {
-			t.Fatalf("seedStores: insert %d: %v", i, err)
-		}
+		testdb.SeedStore(t, db, tenantID, uuid.New())
 	}
 }
 

--- a/services/marketplace-api/internal/subscription/readonly/par_bypass_integration_test.go
+++ b/services/marketplace-api/internal/subscription/readonly/par_bypass_integration_test.go
@@ -26,6 +26,7 @@ func TestIntegration_PARBypass(t *testing.T) {
 	repo := subscription.NewRepository()
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -68,6 +69,7 @@ func TestIntegration_ExpiredBlocked(t *testing.T) {
 	repo := subscription.NewRepository()
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,

--- a/services/marketplace-api/internal/subscription/repository_plan_change_test.go
+++ b/services/marketplace-api/internal/subscription/repository_plan_change_test.go
@@ -18,6 +18,7 @@ func TestSetPendingDowngrade_PersistsTrio(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions")
 	repo := subscription.NewRepository()
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -47,6 +48,7 @@ func TestClearPendingDowngrade_UnsetsTrio(t *testing.T) {
 	effective := time.Now().Add(24 * time.Hour)
 	studioToStarter := subscription.PlanStarter
 	monthly := subscription.PeriodMonthly
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:                    tenantID,
 		StoreID:                     storeID,
@@ -74,6 +76,7 @@ func TestCommitDowngrade_SwapsPlanAndPeriod(t *testing.T) {
 	starter := subscription.PlanStarter
 	monthly := subscription.PeriodMonthly
 	effective := time.Now().Add(-1 * time.Hour)
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:                    tenantID,
 		StoreID:                     storeID,
@@ -109,6 +112,10 @@ func TestFindPendingDowngradesReady_ReturnsExpired(t *testing.T) {
 	monthly := subscription.PeriodMonthly
 	pastDue := time.Now().Add(-1 * time.Hour)
 	future := time.Now().Add(24 * time.Hour)
+
+	testdb.SeedStore(t, db, tenantID, readyStore)
+	testdb.SeedStore(t, db, tenantID, futureStore)
+	testdb.SeedStore(t, db, tenantID, noPendingStore)
 
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:                    tenantID,

--- a/services/marketplace-api/internal/subscription/repository_test.go
+++ b/services/marketplace-api/internal/subscription/repository_test.go
@@ -26,6 +26,7 @@ func TestRepository_GetByStoreID_RequiresTenantMatch(t *testing.T) {
 	tenantA := uuid.New()
 	tenantB := uuid.New()
 	store := uuid.New()
+	testdb.SeedStore(t, db, tenantA, store)
 
 	sub := subscription.StoreSubscription{
 		TenantID:         tenantA,

--- a/services/marketplace-api/internal/subscription/statemachine/cas_conflict_test.go
+++ b/services/marketplace-api/internal/subscription/statemachine/cas_conflict_test.go
@@ -31,6 +31,7 @@ func TestConcurrentTransition_CASConflict(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,

--- a/services/marketplace-api/internal/subscription/statemachine/machine_test.go
+++ b/services/marketplace-api/internal/subscription/statemachine/machine_test.go
@@ -22,6 +22,7 @@ func TestTransition_HappyPath(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -50,6 +51,7 @@ func TestTransition_CASConflict_WhenStatusAlreadyMoved(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -81,6 +83,7 @@ func TestTransition_InvalidTransition_Rejected(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -118,6 +121,7 @@ func TestTransition_EmitsAuditEvent(t *testing.T) {
 	})
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,

--- a/services/marketplace-api/internal/subscription/statemachine/sequential_path_test.go
+++ b/services/marketplace-api/internal/subscription/statemachine/sequential_path_test.go
@@ -25,6 +25,7 @@ func TestSequentialPath_ExpiredToHardDeleted(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,
@@ -77,6 +78,7 @@ func TestSequentialPath_NoShortcut(t *testing.T) {
 	db := testdb.NewDB(t, "store_subscriptions")
 
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Create(&subscription.StoreSubscription{
 		TenantID:         tenantID,
 		StoreID:          storeID,

--- a/services/marketplace-api/pkg/testdb/seed.go
+++ b/services/marketplace-api/pkg/testdb/seed.go
@@ -20,6 +20,12 @@ import (
 //
 // Registers a t.Cleanup deleting the row, so packages using NewDB (which
 // truncates only the tables it was told about) still start clean.
+//
+// The cleanup is best-effort: under NewTx it's a no-op, since the row is
+// rolled back before the DELETE would run anyway. Under NewDB it can fail —
+// products.store_id and categories.store_id are ON DELETE RESTRICT, so if
+// the caller's package left rows referencing this store, the DELETE errors
+// out silently unless the package also truncates stores itself.
 func SeedStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
 	t.Helper()
 
@@ -37,16 +43,22 @@ func SeedStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
 	}
 
 	t.Cleanup(func() {
-		db.Exec("DELETE FROM stores WHERE id = ?", storeID)
+		if err := db.Exec("DELETE FROM stores WHERE id = ?", storeID).Error; err != nil {
+			t.Logf("testdb.SeedStore: cleanup DELETE stores row %s: %v", storeID, err)
+		}
 	})
 }
 
 // SeedVendor inserts a vendors row owned by tenantID and returns its id, for
 // use as products.vendor_id — NOT NULL since migration 000028.
 //
-// A real row is inserted (not a synthetic UUID) so that vendor-scoped filtering
-// and any products→vendors join stay meaningful; a synthetic id would make those
-// assertions vacuous in exactly the way this plan is trying to stop.
+// A real row is inserted (not a synthetic UUID) even though there is no FK
+// from products.vendor_id to vendors(id) — migration 000027 creates the
+// vendors table and 000028 only adds a NOT NULL constraint on vendor_id, no
+// foreign key — so the database will not catch a bogus id. The real row
+// exists purely so vendor-scoped filtering and any products→vendors join
+// stay meaningful for assertions; a synthetic id would make those assertions
+// vacuous in exactly the way this plan is trying to stop.
 //
 // is_self is true because product.Create defaults a new product to the
 // tenant's self-vendor, so that is the vendor a fixture should stand in for.

--- a/services/marketplace-api/pkg/testdb/seed.go
+++ b/services/marketplace-api/pkg/testdb/seed.go
@@ -1,7 +1,6 @@
 package testdb
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
@@ -63,25 +62,27 @@ func SeedVendor(t *testing.T, db *gorm.DB, tenantID uuid.UUID) uuid.UUID {
 	t.Helper()
 
 	// Check if a self-vendor already exists for this tenant.
-	var existingID uuid.UUID
-	err := db.Raw(
+	var existing struct {
+		ID uuid.UUID `db:"id"`
+	}
+	result := db.Raw(
 		`SELECT id FROM vendors WHERE tenant_id = ? AND is_self = true`,
 		tenantID,
-	).Scan(&existingID).Error
-	if err == nil {
-		// Row found; return it without cleanup.
-		return existingID
-	}
-	if !errors.Is(err, gorm.ErrRecordNotFound) {
+	).Scan(&existing)
+	if result.Error != nil {
 		// Query failed; this is a real error.
-		t.Fatalf("testdb.SeedVendor: check for existing self-vendor: %v", err)
+		t.Fatalf("testdb.SeedVendor: check for existing self-vendor: %v", result.Error)
+	}
+	if result.RowsAffected > 0 {
+		// Row found; return it without cleanup.
+		return existing.ID
 	}
 
 	// No existing self-vendor; insert one.
 	vendorID := uuid.New()
 	slug := "vnd-" + strings.ReplaceAll(vendorID.String(), "-", "")[:20]
 
-	err = db.Exec(
+	err := db.Exec(
 		`INSERT INTO vendors (id, tenant_id, name, slug, status, is_self)
 		 VALUES (?, ?, ?, ?, ?, ?)`,
 		vendorID, tenantID, "Test Vendor", slug, "active", true,

--- a/services/marketplace-api/pkg/testdb/seed.go
+++ b/services/marketplace-api/pkg/testdb/seed.go
@@ -1,6 +1,7 @@
 package testdb
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -44,20 +45,43 @@ func SeedStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
 // SeedVendor inserts a vendors row owned by tenantID and returns its id, for
 // use as products.vendor_id — NOT NULL since migration 000028.
 //
-// The column has no foreign key, so any UUID would satisfy the constraint.
-// A real row is inserted anyway so that vendor-scoped filtering and any
-// products→vendors join stay meaningful; a synthetic id would make those
+// A real row is inserted (not a synthetic UUID) so that vendor-scoped filtering
+// and any products→vendors join stay meaningful; a synthetic id would make those
 // assertions vacuous in exactly the way this plan is trying to stop.
 //
 // is_self is true because product.Create defaults a new product to the
 // tenant's self-vendor, so that is the vendor a fixture should stand in for.
+//
+// SeedVendor is idempotent per tenant. The vendors_tenant_self_idx unique
+// constraint (UNIQUE (tenant_id) WHERE (is_self = true)) enforces that only
+// one self-vendor can exist per tenant. This mirrors production's
+// EnsureSelfVendor (migration 000028), which creates it once per tenant
+// lifecycle. Repeat calls for the same tenantID return the existing self-vendor
+// without inserting or registering cleanup, so multiple tests can safely use
+// the same tenant.
 func SeedVendor(t *testing.T, db *gorm.DB, tenantID uuid.UUID) uuid.UUID {
 	t.Helper()
 
+	// Check if a self-vendor already exists for this tenant.
+	var existingID uuid.UUID
+	err := db.Raw(
+		`SELECT id FROM vendors WHERE tenant_id = ? AND is_self = true`,
+		tenantID,
+	).Scan(&existingID).Error
+	if err == nil {
+		// Row found; return it without cleanup.
+		return existingID
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		// Query failed; this is a real error.
+		t.Fatalf("testdb.SeedVendor: check for existing self-vendor: %v", err)
+	}
+
+	// No existing self-vendor; insert one.
 	vendorID := uuid.New()
 	slug := "vnd-" + strings.ReplaceAll(vendorID.String(), "-", "")[:20]
 
-	err := db.Exec(
+	err = db.Exec(
 		`INSERT INTO vendors (id, tenant_id, name, slug, status, is_self)
 		 VALUES (?, ?, ?, ?, ?, ?)`,
 		vendorID, tenantID, "Test Vendor", slug, "active", true,

--- a/services/marketplace-api/pkg/testdb/seed.go
+++ b/services/marketplace-api/pkg/testdb/seed.go
@@ -1,0 +1,74 @@
+package testdb
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// SeedStore inserts a minimal stores row for (tenantID, storeID), satisfying
+// every NOT NULL column the schema requires — including
+// storefront_customer_portal_secret, which a later migration added and most
+// fixtures never caught up with.
+//
+// tenantID is supplied by the caller rather than generated here. Callers
+// already mint a tenant for the rows they seed, and the store must carry that
+// same tenant: otherwise the store and whatever references it disagree about
+// tenancy, and every tenant-scoped assertion passes while testing nothing.
+//
+// Registers a t.Cleanup deleting the row, so packages using NewDB (which
+// truncates only the tables it was told about) still start clean.
+func SeedStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
+	t.Helper()
+
+	// Derived from the store id to dodge stores_slug_unique when one test
+	// seeds several stores.
+	slug := "tst-" + strings.ReplaceAll(storeID.String(), "-", "")[:20]
+
+	err := db.Exec(
+		`INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, storefront_customer_portal_secret)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, encode(gen_random_bytes(32), 'hex'))`,
+		storeID, tenantID, slug, "Test Store", "IE", "EUR", "Europe/Dublin", "active",
+	).Error
+	if err != nil {
+		t.Fatalf("testdb.SeedStore: insert stores row: %v", err)
+	}
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM stores WHERE id = ?", storeID)
+	})
+}
+
+// SeedVendor inserts a vendors row owned by tenantID and returns its id, for
+// use as products.vendor_id — NOT NULL since migration 000028.
+//
+// The column has no foreign key, so any UUID would satisfy the constraint.
+// A real row is inserted anyway so that vendor-scoped filtering and any
+// products→vendors join stay meaningful; a synthetic id would make those
+// assertions vacuous in exactly the way this plan is trying to stop.
+//
+// is_self is true because product.Create defaults a new product to the
+// tenant's self-vendor, so that is the vendor a fixture should stand in for.
+func SeedVendor(t *testing.T, db *gorm.DB, tenantID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	vendorID := uuid.New()
+	slug := "vnd-" + strings.ReplaceAll(vendorID.String(), "-", "")[:20]
+
+	err := db.Exec(
+		`INSERT INTO vendors (id, tenant_id, name, slug, status, is_self)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		vendorID, tenantID, "Test Vendor", slug, "active", true,
+	).Error
+	if err != nil {
+		t.Fatalf("testdb.SeedVendor: insert vendors row: %v", err)
+	}
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM vendors WHERE id = ?", vendorID)
+	})
+
+	return vendorID
+}

--- a/services/marketplace-api/pkg/testdb/seed_integration_test.go
+++ b/services/marketplace-api/pkg/testdb/seed_integration_test.go
@@ -1,0 +1,78 @@
+//go:build integration
+
+package testdb_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+func TestSeedStore_SatisfiesNotNullAndUniqueConstraints(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID, storeID := uuid.New(), uuid.New()
+
+	testdb.SeedStore(t, db, tenantID, storeID)
+
+	var got struct {
+		TenantID uuid.UUID
+		Secret   string
+	}
+	err := db.Raw(
+		`SELECT tenant_id, storefront_customer_portal_secret AS secret FROM stores WHERE id = ?`,
+		storeID,
+	).Scan(&got).Error
+	require.NoError(t, err)
+	require.Equal(t, tenantID, got.TenantID, "store must carry the caller's tenant")
+	require.Len(t, got.Secret, 64, "portal secret must be 32 random bytes hex-encoded")
+}
+
+func TestSeedStore_TwoStoresInOneTestDoNotCollideOnSlug(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID := uuid.New()
+
+	testdb.SeedStore(t, db, tenantID, uuid.New())
+	testdb.SeedStore(t, db, tenantID, uuid.New())
+
+	var n int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM stores WHERE tenant_id = ?`, tenantID).Scan(&n).Error)
+	require.EqualValues(t, 2, n)
+}
+
+func TestSeedVendor_ReturnsUsableSelfVendorForTenant(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID := uuid.New()
+
+	vendorID := testdb.SeedVendor(t, db, tenantID)
+	require.NotEqual(t, uuid.Nil, vendorID)
+
+	var got struct {
+		TenantID uuid.UUID
+		IsSelf   bool
+	}
+	err := db.Raw(
+		`SELECT tenant_id, is_self FROM vendors WHERE id = ?`, vendorID,
+	).Scan(&got).Error
+	require.NoError(t, err)
+	require.Equal(t, tenantID, got.TenantID)
+	require.True(t, got.IsSelf, "seeded vendor stands in for the tenant's self-vendor")
+}
+
+// A product insert is the actual thing 74 baseline failures could not do.
+func TestSeededParents_AcceptAProductInsert(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID, storeID := uuid.New(), uuid.New()
+
+	testdb.SeedStore(t, db, tenantID, storeID)
+	vendorID := testdb.SeedVendor(t, db, tenantID)
+
+	err := db.Exec(
+		`INSERT INTO products (id, tenant_id, store_id, vendor_id, handle, title, status)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		uuid.New(), tenantID, storeID, vendorID, "seed-probe", "Seed Probe", "draft",
+	).Error
+	require.NoError(t, err)
+}

--- a/services/marketplace-api/pkg/testdb/seed_integration_test.go
+++ b/services/marketplace-api/pkg/testdb/seed_integration_test.go
@@ -77,6 +77,22 @@ func TestSeedVendor_IsIdempotentPerTenant(t *testing.T) {
 	require.EqualValues(t, 1, n, "vendors_tenant_self_idx allows exactly one self-vendor per tenant")
 }
 
+func TestSeedVendor_DistinctTenantsGetDistinctVendors(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantA, tenantB := uuid.New(), uuid.New()
+
+	vendorA := testdb.SeedVendor(t, db, tenantA)
+	vendorB := testdb.SeedVendor(t, db, tenantB)
+
+	require.NotEqual(t, vendorA, vendorB, "each tenant must get its own self-vendor")
+
+	var n int64
+	require.NoError(t, db.Raw(
+		`SELECT count(*) FROM vendors WHERE id IN (?, ?) AND is_self = true`, vendorA, vendorB,
+	).Scan(&n).Error)
+	require.EqualValues(t, 2, n)
+}
+
 // A product insert is the actual thing 74 baseline failures could not do.
 func TestSeededParents_AcceptAProductInsert(t *testing.T) {
 	db := testdb.NewTx(t)

--- a/services/marketplace-api/pkg/testdb/seed_integration_test.go
+++ b/services/marketplace-api/pkg/testdb/seed_integration_test.go
@@ -61,6 +61,22 @@ func TestSeedVendor_ReturnsUsableSelfVendorForTenant(t *testing.T) {
 	require.True(t, got.IsSelf, "seeded vendor stands in for the tenant's self-vendor")
 }
 
+func TestSeedVendor_IsIdempotentPerTenant(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID := uuid.New()
+
+	first := testdb.SeedVendor(t, db, tenantID)
+	second := testdb.SeedVendor(t, db, tenantID)
+
+	require.Equal(t, first, second, "repeat calls must return the tenant's existing self-vendor")
+
+	var n int64
+	require.NoError(t, db.Raw(
+		`SELECT count(*) FROM vendors WHERE tenant_id = ? AND is_self = true`, tenantID,
+	).Scan(&n).Error)
+	require.EqualValues(t, 1, n, "vendors_tenant_self_idx allows exactly one self-vendor per tenant")
+}
+
 // A product insert is the actual thing 74 baseline failures could not do.
 func TestSeededParents_AcceptAProductInsert(t *testing.T) {
 	db := testdb.NewTx(t)

--- a/services/marketplace-api/tests/integration/tax_validation_criteria_test.go
+++ b/services/marketplace-api/tests/integration/tax_validation_criteria_test.go
@@ -26,6 +26,7 @@ import (
 func seedActiveValidatedSubscription(t *testing.T, db *gorm.DB, country, taxID string, validatedAt time.Time) (uuid.UUID, uuid.UUID) {
 	t.Helper()
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Exec(`
 		INSERT INTO store_subscriptions
 			(tenant_id, store_id, stripe_customer_id, plan, status,
@@ -42,6 +43,7 @@ func seedActiveValidatedSubscription(t *testing.T, db *gorm.DB, country, taxID s
 func seedTrialingSubscription(t *testing.T, db *gorm.DB, country string) (uuid.UUID, uuid.UUID) {
 	t.Helper()
 	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
 	require.NoError(t, db.Exec(`
 		INSERT INTO store_subscriptions
 			(tenant_id, store_id, stripe_customer_id, plan, status,


### PR DESCRIPTION
Repairs the drifted integration-test fixtures in `services/marketplace-api` and widens the
`make test-int` CI target from **4 packages to 20**. Fixes #316. Fixes #317.

Migrations had added `NOT NULL` columns and foreign keys; fixtures never followed. The suite had been
scoped down far enough to stay green that 47 of 51 packages with integration tests — 92% — were dark
in CI.

## Result

Measured with TRUNCATE-between-packages isolation at **both** ends, so the comparison is like-for-like:

| | baseline `30c3fdff` | this branch |
|---|---|---|
| failing tests | 187 | **25** |
| failing packages | 22 | **12** |

**162 fixed, 0 regressions.** `make test-int` covers 20 packages and is green — verified three times,
including twice consecutively on an already-dirty database.

## What changed

- **`pkg/testdb/seed.go`** — two shared fixture helpers, `SeedStore` and `SeedVendor`, replacing
  hand-rolled inserts across ~20 packages. `tenantID` is caller-supplied on purpose: a parent seeded
  under a different tenant than its child still inserts, the test still passes, and every
  tenant-scoped assertion in it silently becomes vacuous. `SeedVendor` is idempotent per tenant
  because `vendors_tenant_self_idx` is a partial unique index on `(tenant_id) WHERE is_self = true`.
- **Three clusters, 165 of the 187 failures:** `products.vendor_id` NOT NULL (76), the
  `store_subscriptions` store FK (69), and `stores.storefront_customer_portal_secret` NOT NULL (22).
- **A tail of smaller fixture defects** — an over-long bcrypt literal against `varchar(60)`, a
  missing `NoopEncryptor`, an off-by-one fixture path, a savepoint around an expected-to-fail insert,
  a timestamp compared against a transaction-frozen `now()`, unmounted test routes, and an unseeded
  parent order.
- **`Makefile`** — `test-int` widened one cluster at a time, only ever to packages verified fully
  green. Two entries are deliberately non-recursive and now say why in comments.

## Ten production defects found, and deliberately not fixed here

Relighting the suite is what surfaced these. Each is filed with file:line evidence rather than
patched into a test-repair branch:

| Issue | Defect |
|---|---|
| **#394** | `page.Published` / `category.IsActive` are non-pointer `bool` with `gorm:"default:true"`. GORM omits zero-valued fields carrying a `default:` tag, so `false` can never be persisted — **unpublished pages are served to customers on the storefront**, and categories cannot be deactivated. |
| **#395** | `Variant.DeletedAt` is `*time.Time`, not `gorm.DeletedAt`. Soft-delete filtering never applies; all five `Preload("Variants")` sites return deleted variants. |
| **#396** | The tax revalidation cron deadlocks and has never run successfully. `Cron.Run` holds a transaction while `Svc.Submit` writes the same row on a different pooled connection; Postgres sees no cycle, so it hangs rather than erroring. It also poisons every package that runs after it under `-p 1`. |
| **#397** | A blocked downgrade's audit row is written inside the transaction that then returns an error, so it is rolled back. The audit trail for the one case ops most needs never persists. |
| **#398** | Merchant appeal text overflows `mismatch_reason varchar(100)`; any realistic appeal fails to record. |
| **#399** | `ApplyTrialRamp` re-inflates already-consumed budget on re-run, contradicting its own docstring. |
| **#400** | The `OptionValueInUse` guard is unreachable via variants-supplied edits, reachable via options-only edits. |
| **#401** | `testdb.NewDB` truncates only its given table list — cross-package pollution makes any full `./...` run report fiction unless you truncate between packages. |
| **#402** | `Product.VendorID` is `*string` against a `NOT NULL` column with no FK, so the type guards nothing and invalid products fail only at insert. |
| **#318** | Commented, not re-filed — independent reproduction of the `audit.NewEmitter` nil-repo panic. |

This is the third instance in this repo of the pattern #315 documented: a dark suite hiding a
production bug.

## On measuring this

`docs/superpowers/plans/2026-08-27-integration-fixture-drift-tail.md` records the method, and it is
the most reusable artifact here. Three instruments had to be discarded before one held up:

1. `./...` **with** `revalidation` — the deadlock cascades; every later package times out.
2. `./...` **without** it — cross-package pollution invents ~46 failures that do not reproduce.
3. Package-at-a-time with no reset — still order-dependent; packages flip between pass and fail.

Only `TRUNCATE`-all-tables between every package is stable. Anyone re-measuring without it will get
fiction, which is why #401 exists.

## Verification

- Unit suite: 88 packages green. `platform-api`, `auth-bff` and `otto` still build.
- `gofmt -l .` empty; `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean.
- Every task reviewed independently, then a whole-branch review on the most capable model: no
  Criticals, two Importants (both fixed), and it audited 118 seeding call sites across 19 packages
  for tenancy coherence — zero mismatches — and diffed every removed assertion line across all 31
  commits to confirm no test was weakened to reach green.

## Follow-ups deliberately left

`internal/handlers/internalsvc` still holds one hand-rolled `INSERT INTO stores`; `seedProSub` in
`billing/appaddon` opens a `NewDB` handle it discards; `internal/billing/tax/seaqueue`,
`campaignbudget/concurrency` and `/transactional` remain unmeasured and are excluded from the target
with comments saying so. `internal/subscription/planchange` stays out until #397 is resolved.
