### PR TITLE
feat(platformadmin): GET /admin/break-glass — emergency account inventory and usage audit (#333)

### DIFF
--- a/docs/superpowers/plans/2026-08-28-break-glass-inventory.md
+++ b/docs/superpowers/plans/2026-08-28-break-glass-inventory.md
@@ -1,0 +1,181 @@
+# Break-Glass Inventory (#333) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the emergency-account audit trail readable outside mark8ly. `break_glass_accounts` already records when an emergency credential was used; nothing outside this service can see it, so in practice the control on a deliberate auth bypass is rotation, not oversight. This adds the read — and only the read — that closes that gap.
+
+**Architecture:** `GET /api/v1/platform/admin/break-glass` on the `platformadmin` surface. A new cross-tenant read in `internal/breakglass` (the existing `Repository` is tenant-scoped by construction and cannot serve this) feeds a handler that mirrors `email_sends.go` (#348D) exactly: same envelope, same `...Func` adapter wiring, same "excluded by construction" discipline on the wire struct. The route is additionally gated on an **exact** `rotate-credentials` capability via a new `RequiredReadCapabilities` map — the first read on this surface to require anything beyond a valid signature.
+
+**Tech Stack:** Go 1.26, Gin, GORM, PostgreSQL 15, testify. One service: `services/marketplace-api`.
+
+**Issue:** https://github.com/tesserix/mark8ly/issues/333
+
+---
+
+## Global Constraints
+
+- **No migration.** `000072` and `000073` already hold everything this reads. `ExpectedSchemaVersion` does not move. If you find yourself writing DDL, the plan is wrong.
+- **Never load `breakglass.Account` for this endpoint.** That struct carries `SecretPath`, `PasswordHash` and `TOTPSecretRef`. The platform read uses its own row type and an **explicit column list** — never `SELECT *`, never a GORM `Find` into `Account`. A column added to the table tomorrow must not be able to reach the wire.
+- **Integration tests gate on `TEST_DATABASE_URL`**, never `TEST_DB_DSN` — files using the latter skip silently (#317).
+- **Integration tests run with `-p 1`** and `//go:build integration`; `go vet -tags=integration ./...` is the only command that compiles them, and is part of every task's verification.
+- **`go test ./...` from the service root**, never path-scoped, or the root schema-version guard silently does not run. Use `-count=1`.
+- Envelope is exactly `{"data": …, "pagination": …}`; timestamps RFC3339 UTC; ids bare strings; never a `source` field.
+- Allocate slices with `make([]T, 0, n)` — a nil slice marshals to `null` and defeats the caller's `?? []`.
+- marketplace-api test packages are **external** (`package platformadmin_test`).
+- Commit messages: conventional, single line, no signature.
+
+---
+
+## File Structure
+
+| file | responsibility |
+|---|---|
+| `internal/breakglass/platform_list.go` (create) | `PlatformListFilter`, `PlatformRow`, `PlatformListResult`, `ListPlatform` — the cross-tenant read |
+| `internal/breakglass/platform_list_test.go` (create) | filter/sort semantics against sqlite where expressible; the struct-shape leak guard |
+| `internal/breakglass/platform_list_integration_test.go` (create) | real Postgres: lockout join, NULLS LAST ordering, explicit column list |
+| `internal/handlers/platformadmin/break_glass.go` (create) | `BreakGlassLister` iface + `...Func` adapter, handler, wire struct, filter parsing |
+| `internal/handlers/platformadmin/break_glass_test.go` (create) | envelope, empty `200 []`, filter/sort plumbing, **marshalled-response leak test** |
+| `internal/handlers/platformadmin/middleware.go` (modify) | `RequiredReadCapabilities` + the read branch of `RequirePlatformAuth` |
+| `internal/handlers/platformadmin/middleware_test.go` (modify) | read-gate: match, mismatch, absent, undeclared-read-route-still-open |
+| `internal/handlers/platformadmin/routes.go` (modify) | `Deps.BreakGlass`, nil-safe mount |
+| `internal/handlers/platformadmin/routes_capability_coverage_test.go` (modify) | assert the break-glass GET is declared, and that no OTHER read route accidentally is |
+| `cmd/marketplace-api/main.go` (modify) | wire `BreakGlassListerFunc(breakglass.ListPlatform)` at **both** Deps sites (≈2135, ≈2287) |
+
+---
+
+## Contract
+
+`GET /api/v1/platform/admin/break-glass`
+
+**Headers:** standard platform signature set, plus `X-Platform-Capability: rotate-credentials` (exact) and a non-empty `X-Platform-Operator`.
+
+**Query:** `tenant_id`, `used_after`, `used_before` (RFC3339, filter on `last_used_at`), `used` (`true`/`false` — has the account ever been used), `locked` (`true`/`false`), `sort` (`last_used_at` | `-last_used_at`, default `-last_used_at`), `page`, `limit`. A malformed parameter takes the default and never errors, matching every other read on this surface.
+
+**Row:**
+
+```json
+{
+  "tenant_id": "…",
+  "tenant_name": "Acme Ltd",
+  "totp_enrolled": true,
+  "last_used_at": "2026-08-27T09:14:00Z",
+  "last_rotated_at": "2026-08-27T09:14:00Z",
+  "rotation_scheduled_at": "2026-08-28T09:14:00Z",
+  "locked_out": false,
+  "lockout_expires_at": null,
+  "created_at": "2026-04-18T00:00:00Z"
+}
+```
+
+**Absent by construction:** `password_hash`, `secret_path`, `totp_secret_ref`.
+
+---
+
+## Two places the issue text and the schema disagree — resolved here
+
+**1. Lockouts are per-IP, not per-account.** `break_glass_lockouts`' primary key is `(ip_hash, locked_until)`; `tenant_id` is nullable and is only populated when the failed login actually resolved a tenant (`internal/handlers/admin/break_glass_login.go:180-184`). `locked_out` therefore means **"at least one active lockout row currently names this tenant"**, not "this account is locked". Attempts that never resolved a tenant carry `tenant_id IS NULL` and are invisible to this view. Say exactly that in the struct comment; do not let the field name imply account-level lockout.
+
+**2. `last_used_at` is nullable.** A never-used account sorts *last* under `-last_used_at`, not first. `ORDER BY last_used_at DESC NULLS LAST` — the surface exists to answer "which emergency accounts have been used recently", and floating never-used rows to the top defeats it. Assert this in the integration test; sqlite and Postgres disagree on default NULL ordering, so it must be explicit in the SQL rather than inherited.
+
+---
+
+## The read gate
+
+Reads on this surface currently require **nothing** beyond a valid signature — `RequirePlatformAuth`'s operator/capability block is inside `if isWrite(...)`. This adds a per-route requirement for reads:
+
+```go
+// RequiredReadCapabilities declares reads that require a specific
+// capability VALUE, not merely a valid signature.
+//
+// Unlike RequiredWriteCapabilities this map is NOT gated on
+// CapabilityValueChecked and its values are NOT empty: it is opt-in per
+// route, and a read route ABSENT from it keeps today's behaviour
+// (signature only, no operator, no capability). That asymmetry is
+// deliberate — flipping value enforcement on for every write at once is
+// #364's problem and needs the console to send more than one value;
+// requiring one named capability on one route does not.
+var RequiredReadCapabilities = map[string]string{
+    CapabilityKey(http.MethodGet, "/api/v1/platform/admin/break-glass"): "rotate-credentials",
+}
+```
+
+Enforcement mirrors the write branch: declared route ⇒ operator required, capability required, exact string equality, `403 capability_insufficient` on mismatch. No lattice, no prefix match, no implication — per #275 mark8ly records the capability and refuses a mismatch; it never reasons about what one capability implies about another.
+
+**What this pins on the console.** platform-api has no break-glass module today (`aiusage audit billing crm entities health inbox kpis tenants tickets tools`), so **no request is being refused by this that succeeds today**. But the audit module sets `X-Platform-Capability: platform` for its own calls, so when the break-glass module is built it must send `rotate-credentials` — matching what the console's own route config already declares for `platform.breakGlass`. Put that sentence in the code comment, so whoever builds the module finds the requirement from this file rather than from a 403.
+
+---
+
+## Tasks
+
+### Task 1 — The leak guard, first and failing
+
+- [ ] Write `TestPlatformRowCannotCarryCredentialFields` in `internal/breakglass/platform_list_test.go`: reflect over `breakglass.PlatformRow`'s fields and JSON tags, fail if any field name or tag matches `secret_path`, `password_hash`, `totp_secret_ref`, or case-insensitively contains `secret`, `hash` or `password`.
+- [ ] Write the handler-side twin in `break_glass_test.go`: marshal a response built from a fully-populated `PlatformRow` and assert none of the three strings appears anywhere in the JSON bytes.
+- [ ] Run both. They MUST fail to compile (no `PlatformRow` yet). Record that.
+
+**Verify:** `go test ./internal/breakglass/... -count=1` fails for the stated reason, not another.
+
+### Task 2 — `ListPlatform`
+
+- [ ] `internal/breakglass/platform_list.go`: `DefaultPlatformPageSize = 50`, `MaxPlatformPageSize = 200` (mirror `emaillog`).
+- [ ] `PlatformListFilter{TenantID *uuid.UUID; UsedAfter, UsedBefore *time.Time; Used, Locked *bool; SortDesc bool; Page, Limit int}`.
+- [ ] `PlatformRow` with the contract fields above and nothing else.
+- [ ] `ListPlatform(ctx, db, f, asOf)`: `db.Table("break_glass_accounts a")`, **explicit** `Select` naming only the six safe columns plus the two derived lockout columns. Active lockout via correlated subqueries against `break_glass_lockouts` filtered `tenant_id = a.tenant_id AND locked_until > ?asOf` — `EXISTS` for `locked_out`, `MAX(locked_until)` for `lockout_expires_at`.
+- [ ] `Count` BEFORE `Select`/paging, so `Total` is the full match count.
+- [ ] `ORDER BY last_used_at DESC NULLS LAST, tenant_id` (or `ASC NULLS LAST` when `SortDesc` is false). The tie-break on `tenant_id` makes paging deterministic across the many rows sharing a NULL `last_used_at`.
+- [ ] Task 1's struct test now passes.
+
+**Verify:** `go test ./internal/breakglass/... -count=1` and `go vet ./...`.
+
+### Task 3 — Integration test for the read
+
+- [ ] `platform_list_integration_test.go`, `//go:build integration`, gated on `TEST_DATABASE_URL`.
+- [ ] Seed: three accounts (never used; used 2h ago; used 30d ago), one active lockout naming tenant B, one **expired** lockout naming tenant C, one active lockout with `tenant_id IS NULL`.
+- [ ] Assert: default sort puts the 2h row first and the never-used row last; B is `locked_out` with the right `lockout_expires_at`; C is not (expired); the NULL-tenant lockout affects no row; `used_after` narrows correctly; `Total` is the unpaginated count.
+- [ ] Assert the generated SQL names an explicit column list — capture it via a GORM session logger or `db.ToSQL`, and fail if it contains `*`, `secret_path`, `password_hash` or `totp_secret_ref`.
+
+**Verify:** `go vet -tags=integration ./...` then `go test -tags=integration -p 1 -count=1 ./internal/breakglass/...`.
+
+### Task 4 — Handler
+
+- [ ] `BreakGlassLister` interface (one method) + `BreakGlassListerFunc` adapter, mirroring `EmailSendLister`.
+- [ ] `BreakGlassHandler` with `db`, `repo`, `dir TenantDirectory`, `logger`, `now`.
+- [ ] `Register` mounts `GET /admin/break-glass`.
+- [ ] Wire struct populated **field by field** from `PlatformRow` — never embedded, never re-marshalled from the model.
+- [ ] `tenant_name` enrichment via `lookupTenantNames` over the page's distinct tenant ids, `omitempty`, and a directory failure degrades to ids rather than failing the request — mirror `BillingSubscriptionsHandler.lookupTenantNames` exactly.
+- [ ] `parseFilter` never errors; `effectiveBreakGlassLimit` reports the limit actually applied.
+- [ ] Handler tests: envelope shape; empty result is `200` with `"data": []`; each filter reaches the repo stub; both sort values; unknown `sort` falls back to the default; the Task 1 marshal test now passes.
+
+**Verify:** `go test ./internal/handlers/platformadmin/... -count=1`.
+
+### Task 5 — Read gate
+
+- [ ] Add `RequiredReadCapabilities` to `middleware.go` with the comment text above.
+- [ ] Add `AuthConfig.RequiredReadCaps map[string]string` (nil ⇒ production map), matching the existing test-override pattern for writes.
+- [ ] Add the read branch to `RequirePlatformAuth`: for a non-write method, look up `CapabilityKey(method, c.FullPath())`; if undeclared, proceed exactly as today; if declared, require non-empty operator, non-empty capability, and exact equality — `401 operator_required` / `401 capability_required` / `403 capability_insufficient`.
+- [ ] Tests: declared route + correct capability ⇒ 200; declared + `platform` ⇒ 403; declared + absent ⇒ 401; **undeclared read route with no capability at all ⇒ still 200** (this is the regression that would break `/admin/audit-logs`, `/admin/health` and every shipped read, so it is the most important assertion in the task).
+- [ ] Extend `routes_capability_coverage_test.go`: build the real router, assert `GET /api/v1/platform/admin/break-glass` is present in `RequiredReadCapabilities`, and assert no other mounted read route is — so a future read cannot pick up an unintended gate by accident.
+
+**Verify:** `go test ./internal/handlers/platformadmin/... -count=1`.
+
+### Task 6 — Wiring
+
+- [ ] `Deps.BreakGlass BreakGlassLister` with the doc comment convention used by `EmailSends`; nil leaves the route unmounted.
+- [ ] Mount in `Register` under `if deps.BreakGlass != nil`.
+- [ ] Wire `platformadmin.BreakGlassListerFunc(breakglass.ListPlatform)` at **both** `platformadmin.Deps` sites in `main.go` (≈2135 and ≈2287). Missing the second is the standard failure here — grep for `EmailSends:` and match the count.
+- [ ] Full-surface route test: the route exists, answers `200` with a valid signature and `rotate-credentials`, and `403`s on `platform`.
+
+**Verify:** `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./... -count=1` from the service root.
+
+### Task 7 — Close out
+
+- [ ] Re-read the issue's acceptance list and tick each item against a named test.
+- [ ] Comment on #333 with what shipped, the two schema-vs-issue-text resolutions above, and the explicit statement that platform-api's break-glass module must send `rotate-credentials`.
+
+---
+
+## Out of scope — deliberately
+
+- **`CapabilityValueChecked` / `RequiredWriteCapabilities` stay untouched.** Those gate the four POST routes. Per #364 a single global value is the wrong shape, and per the issue's own second comment no route anywhere in the estate requires a verb capability yet — making `purge` the first route gated on `hard-delete` deserves its own review, not a ride-along with a read.
+- **`FEDERATION_MARK8LY_ENDPOINTS` is unset in tesserix-home**, so platform-api believes mark8ly implements no optional contract endpoints. This is why #284/#285 shipped and the console's Billing page still says nothing federates billing. Not a mark8ly change; file it against tesserix-home and reference it from #333 so the dependency is visible before this endpoint ships and shows nothing.
+- **platform-api's break-glass module and the console's `pending: true` route.** Both tesserix-home side.

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/billing/trial"
 	"github.com/mark8ly/marketplace-api/internal/billingarchive"
 	"github.com/mark8ly/marketplace-api/internal/branding"
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
 	"github.com/mark8ly/marketplace-api/internal/campaign"
 	"github.com/mark8ly/marketplace-api/internal/campaignbudget"
 	"github.com/mark8ly/marketplace-api/internal/campaignbudget/concurrency"
@@ -2141,6 +2142,7 @@ func main() {
 			InboxActionExecutors:  inboxActionExecutors(migrationRepo),
 			EstateUsers:           estateUsersClient,
 			EmailSends:            platformadmin.EmailSendListerFunc(emaillog.ListPlatform),
+			BreakGlass:            platformadmin.BreakGlassListerFunc(breakglass.ListPlatform),
 		})
 		storefront.RegisterStorefront(r.Group("/api/v1"), storefrontDeps)
 		storefront.RegisterMobileStorefrontSupport(r.Group("/api/v1"), storefrontSupportHandler, storefrontDeps.SlugCache, storefrontCustomerVerifier)
@@ -2285,6 +2287,7 @@ func main() {
 				InboxActionExecutors:  inboxActionExecutors(migrationRepo),
 				EstateUsers:           estateUsersClient,
 				EmailSends:            platformadmin.EmailSendListerFunc(emaillog.ListPlatform),
+				BreakGlass:            platformadmin.BreakGlassListerFunc(breakglass.ListPlatform),
 			})
 			// Public Delhivery webhook receiver. Mounted on the admin
 			// engine because the merchant-configured URL points at the

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -2117,7 +2117,7 @@ func main() {
 			tenantTeardownClient = lifecycleClient
 		}
 		platformSubscriptionRepo := subscription.NewRepository()
-		platformadmin.Register(r.Group("/api/v1/platform"), platformadmin.Deps{
+		platformadmin.Register(r.Group(platformadmin.MountPrefix), platformadmin.Deps{
 			DB:                    conn,
 			Repo:                  auditRepo,
 			Logger:                log,
@@ -2262,7 +2262,7 @@ func main() {
 				tenantTeardownClient = lifecycleClient
 			}
 			platformSubscriptionRepo := subscription.NewRepository()
-			platformadmin.Register(engine.Group("/api/v1/platform"), platformadmin.Deps{
+			platformadmin.Register(engine.Group(platformadmin.MountPrefix), platformadmin.Deps{
 				DB:                    conn,
 				Repo:                  auditRepo,
 				Logger:                log,

--- a/services/marketplace-api/internal/breakglass/platform_list.go
+++ b/services/marketplace-api/internal/breakglass/platform_list.go
@@ -41,11 +41,13 @@ type PlatformListFilter struct {
 // TestPlatformRowCannotCarryCredentialFields, which guards this by
 // reflection so a column added later cannot silently become reachable.
 //
-// TenantName is populated by the handler layer from tenantdirectory, not by
-// ListPlatform — break_glass_accounts has no tenant_name column.
+// Tenant name is NOT a field here: break_glass_accounts has no
+// tenant_name column, and the handler layer resolves display names from
+// tenantdirectory independently (see toBreakGlassRow in
+// internal/handlers/platformadmin/break_glass.go), keyed by TenantID
+// below — never by a field on this struct.
 type PlatformRow struct {
 	TenantID            uuid.UUID  `json:"tenant_id"`
-	TenantName          string     `json:"tenant_name"`
 	TOTPEnrolled        bool       `json:"totp_enrolled"`
 	LastUsedAt          *time.Time `json:"last_used_at"`
 	LastRotatedAt       time.Time  `json:"last_rotated_at"`
@@ -111,6 +113,18 @@ func ListPlatform(ctx context.Context, db *gorm.DB, f PlatformListFilter,
 		}
 	}
 
+	// Clone q for the page query BEFORE Count runs: Count(...) mutates q's
+	// underlying gorm Statement in place (q's chain calls have already
+	// collapsed to in-place mutation by this point, which is how gorm's
+	// builder pattern normally works), and gorm only resets that
+	// Statement's built SQL after a REAL execution — a query built via
+	// gorm.Session{DryRun: true} skips that reset. Reusing q for both
+	// finishers would therefore make the page query silently reuse
+	// Count's leftover SQL under DryRun, even though the two queries are
+	// independent against a live connection. Cloning here keeps that
+	// independence explicit rather than accidental.
+	pageQ := q.Session(&gorm.Session{Context: ctx})
+
 	// Count BEFORE Select: the page below adds computed lockout columns,
 	// and Total must be the full match count, not the page size.
 	if err := q.Count(&result.Total).Error; err != nil {
@@ -131,7 +145,7 @@ func ListPlatform(ctx context.Context, db *gorm.DB, f PlatformListFilter,
 		order = "a.last_used_at ASC NULLS LAST, a.tenant_id"
 	}
 
-	if err := q.
+	if err := pageQ.
 		Select(`a.tenant_id, a.totp_enrolled, a.last_used_at,
 			a.last_rotated_at, a.rotation_scheduled_at, a.created_at,
 			EXISTS (

--- a/services/marketplace-api/internal/breakglass/platform_list.go
+++ b/services/marketplace-api/internal/breakglass/platform_list.go
@@ -1,0 +1,152 @@
+package breakglass
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// Page sizing, mirroring the outbox/email-log platform reads (#331, #348D).
+const (
+	DefaultPlatformPageSize = 50
+	MaxPlatformPageSize     = 200
+)
+
+// PlatformListFilter narrows the cross-tenant break-glass inventory (#333).
+type PlatformListFilter struct {
+	TenantID *uuid.UUID
+	// UsedAfter/UsedBefore filter on last_used_at.
+	UsedAfter, UsedBefore *time.Time
+	// Used, when non-nil, narrows to accounts that have (true) or have not
+	// (false) ever been used — i.e. whether last_used_at IS NOT NULL.
+	Used *bool
+	// Locked, when non-nil, narrows to accounts whose tenant currently has
+	// (true) or does not have (false) an active lockout row. See
+	// PlatformRow.LockedOut for what "locked" means here.
+	Locked   *bool
+	SortDesc bool
+	Page     int
+	Limit    int
+}
+
+// PlatformRow is one break-glass account in the cross-tenant platform-console
+// view.
+//
+// Deliberately excludes secret_path, password_hash, and totp_secret_ref —
+// the three columns on break_glass_accounts that can reach the live
+// plaintext credential or its bcrypt hash. See
+// TestPlatformRowCannotCarryCredentialFields, which guards this by
+// reflection so a column added later cannot silently become reachable.
+//
+// TenantName is populated by the handler layer from tenantdirectory, not by
+// ListPlatform — break_glass_accounts has no tenant_name column.
+type PlatformRow struct {
+	TenantID            uuid.UUID  `json:"tenant_id"`
+	TenantName          string     `json:"tenant_name"`
+	TOTPEnrolled        bool       `json:"totp_enrolled"`
+	LastUsedAt          *time.Time `json:"last_used_at"`
+	LastRotatedAt       time.Time  `json:"last_rotated_at"`
+	RotationScheduledAt *time.Time `json:"rotation_scheduled_at"`
+	// LockedOut means "at least one break_glass_lockouts row currently
+	// names this tenant" — lockouts are keyed per-IP, not per-account, and
+	// tenant_id is only populated on a lockout row once a failed login
+	// attempt actually resolved a tenant. An attempt that never resolved a
+	// tenant is invisible here. This is NOT "this account is locked" in
+	// any account-level sense.
+	LockedOut bool `json:"locked_out"`
+	// LockoutExpiresAt is the latest locked_until among this tenant's
+	// active lockout rows, or nil when LockedOut is false.
+	LockoutExpiresAt *time.Time `json:"lockout_expires_at"`
+	CreatedAt        time.Time  `json:"created_at"`
+}
+
+// PlatformListResult is a page plus the unpaginated total.
+type PlatformListResult struct {
+	Accounts []PlatformRow
+	Total    int64
+}
+
+// ListPlatform serves the platform console's cross-tenant break-glass
+// inventory (#333).
+//
+// A package function rather than a method, so it can be wired through a
+// ...Func adapter in main.go exactly as emaillog.ListPlatform is.
+//
+// asOf pins "now" for the active-lockout window (locked_until > asOf) so
+// the query is reproducible in tests instead of racing time.Now().
+func ListPlatform(ctx context.Context, db *gorm.DB, f PlatformListFilter,
+	asOf time.Time) (PlatformListResult, error) {
+	result := PlatformListResult{Accounts: make([]PlatformRow, 0)}
+
+	q := db.WithContext(ctx).Table("break_glass_accounts a")
+
+	if f.TenantID != nil {
+		q = q.Where("a.tenant_id = ?", *f.TenantID)
+	}
+	if f.UsedAfter != nil {
+		q = q.Where("a.last_used_at >= ?", *f.UsedAfter)
+	}
+	if f.UsedBefore != nil {
+		q = q.Where("a.last_used_at <= ?", *f.UsedBefore)
+	}
+	if f.Used != nil {
+		if *f.Used {
+			q = q.Where("a.last_used_at IS NOT NULL")
+		} else {
+			q = q.Where("a.last_used_at IS NULL")
+		}
+	}
+	if f.Locked != nil {
+		exists := `EXISTS (
+			SELECT 1 FROM break_glass_lockouts l
+			WHERE l.tenant_id = a.tenant_id AND l.locked_until > ?
+		)`
+		if *f.Locked {
+			q = q.Where(exists, asOf)
+		} else {
+			q = q.Where("NOT "+exists, asOf)
+		}
+	}
+
+	// Count BEFORE Select: the page below adds computed lockout columns,
+	// and Total must be the full match count, not the page size.
+	if err := q.Count(&result.Total).Error; err != nil {
+		return result, fmt.Errorf("breakglass platform list count: %w", err)
+	}
+
+	limit := f.Limit
+	if limit <= 0 {
+		limit = DefaultPlatformPageSize
+	}
+	if limit > MaxPlatformPageSize {
+		limit = MaxPlatformPageSize
+	}
+	page := max(f.Page, 1)
+
+	order := "a.last_used_at DESC NULLS LAST, a.tenant_id"
+	if !f.SortDesc {
+		order = "a.last_used_at ASC NULLS LAST, a.tenant_id"
+	}
+
+	if err := q.
+		Select(`a.tenant_id, a.totp_enrolled, a.last_used_at,
+			a.last_rotated_at, a.rotation_scheduled_at, a.created_at,
+			EXISTS (
+				SELECT 1 FROM break_glass_lockouts l
+				WHERE l.tenant_id = a.tenant_id AND l.locked_until > ?
+			) AS locked_out,
+			(
+				SELECT MAX(l.locked_until) FROM break_glass_lockouts l
+				WHERE l.tenant_id = a.tenant_id AND l.locked_until > ?
+			) AS lockout_expires_at`, asOf, asOf).
+		Order(order).
+		Offset((page - 1) * limit).
+		Limit(limit).
+		Scan(&result.Accounts).Error; err != nil {
+		return result, fmt.Errorf("breakglass platform list: %w", err)
+	}
+	return result, nil
+}

--- a/services/marketplace-api/internal/breakglass/platform_list_integration_test.go
+++ b/services/marketplace-api/internal/breakglass/platform_list_integration_test.go
@@ -99,6 +99,43 @@ func TestIntegration_ListPlatform_NeverUsedSortsLastUnderDefaultDescOrder(t *tes
 		"a never-used account must sort LAST under DESC NULLS LAST, not first")
 }
 
+// Sibling to TestIntegration_ListPlatform_NeverUsedSortsLastUnderDefaultDescOrder:
+// that test proves NULLS LAST holds under the default DESC order
+// (order.go's "a.last_used_at DESC NULLS LAST, a.tenant_id" branch). This
+// proves the OTHER branch — "a.last_used_at ASC NULLS LAST, a.tenant_id",
+// reachable only via ?sort=last_used_at (SortDesc: false) — is reachable
+// and still puts the never-used account last. Someone who "simplified"
+// that branch to plain ASC (dropping NULLS LAST) would regress ordering
+// only in Postgres, not sqlite, and only under this one query parameter —
+// exactly what this asserts against.
+func TestIntegration_ListPlatform_NeverUsedSortsLastUnderAscOrderToo(t *testing.T) {
+	db := testdb.NewTx(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	older30d, recent2h, neverUsed := uuid.New(), uuid.New(), uuid.New()
+	used30d := now.Add(-30 * 24 * time.Hour)
+	used2h := now.Add(-2 * time.Hour)
+
+	seedAccount(t, db, older30d, &used30d)
+	seedAccount(t, db, recent2h, &used2h)
+	seedAccount(t, db, neverUsed, nil)
+
+	res, err := breakglass.ListPlatform(context.Background(), db,
+		breakglass.PlatformListFilter{SortDesc: false}, now)
+	require.NoError(t, err)
+
+	idx := indexByTenant(res.Accounts)
+	posOlder, ok1 := idx[older30d]
+	posRecent, ok2 := idx[recent2h]
+	posNever, ok3 := idx[neverUsed]
+	require.True(t, ok1 && ok2 && ok3, "all three seeded accounts must appear in the page")
+
+	require.Less(t, posOlder, posRecent,
+		"an older-used account must sort before a more recently used one under ASC")
+	require.Less(t, posRecent, posNever,
+		"a never-used account must sort LAST under ASC NULLS LAST too, not first")
+}
+
 // break_glass_lockouts is keyed (ip_hash, locked_until) with a nullable
 // tenant_id: "locked_out" means "at least one active lockout row currently
 // names this tenant", not "this account is locked" in any account-level
@@ -140,6 +177,53 @@ func TestIntegration_ListPlatform_LockoutVisibilitySemantics(t *testing.T) {
 	require.False(t, resD.Accounts[0].LockedOut,
 		"a lockout row with tenant_id IS NULL must not attach to any account")
 	require.Nil(t, resD.Accounts[0].LockoutExpiresAt)
+}
+
+// TestIntegration_ListPlatform_LockedFilterMatchesTheNotExistsInversion
+// covers PlatformListFilter.Locked at the data layer: only the
+// handler→filter plumbing (parseBreakGlassBool wiring "locked" into
+// f.Locked) had coverage before this, never the NOT EXISTS inversion
+// Locked=false compiles down to in ListPlatform. Reuses the same lockout
+// fixture shapes as TestIntegration_ListPlatform_LockoutVisibilitySemantics
+// above: an active lockout naming a tenant, and an EXPIRED lockout naming
+// a different tenant.
+func TestIntegration_ListPlatform_LockedFilterMatchesTheNotExistsInversion(t *testing.T) {
+	db := testdb.NewTx(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	activelyLocked, expiredOnly := uuid.New(), uuid.New()
+	seedAccount(t, db, activelyLocked, nil)
+	seedAccount(t, db, expiredOnly, nil)
+
+	seedLockout(t, db, &activelyLocked, now.Add(1*time.Hour), "3-strike") // active
+	seedLockout(t, db, &expiredOnly, now.Add(-1*time.Hour), "3-strike")   // expired
+
+	trueVal, falseVal := true, false
+
+	resLocked, err := breakglass.ListPlatform(context.Background(), db,
+		breakglass.PlatformListFilter{Locked: &trueVal}, now)
+	require.NoError(t, err)
+	idxLocked := indexByTenant(resLocked.Accounts)
+	_, hasActive := idxLocked[activelyLocked]
+	_, hasExpired := idxLocked[expiredOnly]
+	require.True(t, hasActive,
+		"Locked:true must include the tenant with an active lockout")
+	require.False(t, hasExpired,
+		"Locked:true must exclude the tenant whose only lockout is EXPIRED — "+
+			"an expired lockout must behave as unlocked")
+
+	resUnlocked, err := breakglass.ListPlatform(context.Background(), db,
+		breakglass.PlatformListFilter{Locked: &falseVal}, now)
+	require.NoError(t, err)
+	idxUnlocked := indexByTenant(resUnlocked.Accounts)
+	_, hasActiveUnlocked := idxUnlocked[activelyLocked]
+	_, hasExpiredUnlocked := idxUnlocked[expiredOnly]
+	require.False(t, hasActiveUnlocked,
+		"Locked:false (the NOT EXISTS inversion) must exclude the actively "+
+			"locked tenant")
+	require.True(t, hasExpiredUnlocked,
+		"Locked:false must include the tenant whose only lockout is "+
+			"EXPIRED — it must behave as unlocked in BOTH directions")
 }
 
 func TestIntegration_ListPlatform_UsedAfterAndUsedBeforeNarrow(t *testing.T) {

--- a/services/marketplace-api/internal/breakglass/platform_list_integration_test.go
+++ b/services/marketplace-api/internal/breakglass/platform_list_integration_test.go
@@ -1,0 +1,255 @@
+//go:build integration
+
+package breakglass_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedAccount inserts a minimal break_glass_accounts row for tenantID,
+// satisfying every NOT NULL column (secret_path, password_hash,
+// totp_secret_ref) with harmless test placeholders — none of these three
+// columns should ever be reachable through ListPlatform, which is exactly
+// what TestIntegration_ListPlatform_SelectsExplicitColumnsNeverCredentialFields
+// guards.
+func seedAccount(t *testing.T, db *gorm.DB, tenantID uuid.UUID, lastUsedAt *time.Time) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`INSERT INTO break_glass_accounts
+			(tenant_id, secret_path, password_hash, totp_secret_ref, totp_enrolled, last_used_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		tenantID,
+		"/projects/tesserix-test/secrets/break-glass-"+tenantID.String(),
+		"$2a$12$test-hash-not-a-real-bcrypt-value",
+		"$.totp_secret",
+		false,
+		lastUsedAt,
+	).Error)
+}
+
+// seedLockout inserts a break_glass_lockouts row. tenantID may be nil,
+// matching an attempt that never resolved a tenant. ip_hash is random per
+// call so repeated inserts in one test never collide on the
+// (ip_hash, locked_until) primary key.
+//
+// Uses the Create(map) builder rather than a raw Exec with a `VALUES (?, ...)`
+// string: GORM's raw-SQL placeholder expansion treats any slice/array
+// argument immediately inside parentheses as an IN-list and explodes a
+// []byte ip_hash into one bound value per byte, which Postgres then rejects
+// as "INSERT has more expressions than target columns".
+func seedLockout(t *testing.T, db *gorm.DB, tenantID *uuid.UUID, lockedUntil time.Time, reason string) {
+	t.Helper()
+	ipHash := uuid.New()
+	require.NoError(t, db.Table("break_glass_lockouts").Create(map[string]interface{}{
+		"ip_hash":      ipHash[:],
+		"tenant_id":    tenantID,
+		"locked_until": lockedUntil,
+		"reason":       reason,
+	}).Error)
+}
+
+func indexByTenant(rows []breakglass.PlatformRow) map[uuid.UUID]int {
+	m := make(map[uuid.UUID]int, len(rows))
+	for i, r := range rows {
+		m[r.TenantID] = i
+	}
+	return m
+}
+
+// The endpoint exists to answer "which emergency accounts have been used
+// recently". A never-used account floating to the top under the default
+// sort would defeat that. sqlite and Postgres disagree on default NULL
+// ordering, which is exactly why this needs a real-Postgres assertion.
+func TestIntegration_ListPlatform_NeverUsedSortsLastUnderDefaultDescOrder(t *testing.T) {
+	db := testdb.NewTx(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	recentUsed, olderUsed, neverUsed := uuid.New(), uuid.New(), uuid.New()
+	used2h := now.Add(-2 * time.Hour)
+	used30d := now.Add(-30 * 24 * time.Hour)
+
+	seedAccount(t, db, recentUsed, &used2h)
+	seedAccount(t, db, olderUsed, &used30d)
+	seedAccount(t, db, neverUsed, nil)
+
+	res, err := breakglass.ListPlatform(context.Background(), db,
+		breakglass.PlatformListFilter{SortDesc: true}, now)
+	require.NoError(t, err)
+
+	idx := indexByTenant(res.Accounts)
+	posRecent, ok1 := idx[recentUsed]
+	posOlder, ok2 := idx[olderUsed]
+	posNever, ok3 := idx[neverUsed]
+	require.True(t, ok1 && ok2 && ok3, "all three seeded accounts must appear in the page")
+
+	require.Less(t, posRecent, posOlder,
+		"a more recently used account must sort before an older one under DESC")
+	require.Less(t, posOlder, posNever,
+		"a never-used account must sort LAST under DESC NULLS LAST, not first")
+}
+
+// break_glass_lockouts is keyed (ip_hash, locked_until) with a nullable
+// tenant_id: "locked_out" means "at least one active lockout row currently
+// names this tenant", not "this account is locked" in any account-level
+// sense. This test seeds all three shapes the plan calls out.
+func TestIntegration_ListPlatform_LockoutVisibilitySemantics(t *testing.T) {
+	db := testdb.NewTx(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	tenantB, tenantC, tenantD := uuid.New(), uuid.New(), uuid.New()
+	seedAccount(t, db, tenantB, nil)
+	seedAccount(t, db, tenantC, nil)
+	seedAccount(t, db, tenantD, nil)
+
+	activeExpiry := now.Add(1 * time.Hour)
+	seedLockout(t, db, &tenantB, activeExpiry, "3-strike")                           // active, names B
+	seedLockout(t, db, &tenantC, now.Add(-1*time.Hour), "3-strike")                  // expired, names C
+	seedLockout(t, db, nil, now.Add(1*time.Hour), "attempt never resolved a tenant") // active, tenant_id IS NULL
+
+	resB, err := breakglass.ListPlatform(context.Background(), db,
+		breakglass.PlatformListFilter{TenantID: &tenantB}, now)
+	require.NoError(t, err)
+	require.Len(t, resB.Accounts, 1)
+	require.True(t, resB.Accounts[0].LockedOut,
+		"an active lockout naming this tenant must show as locked out")
+	require.NotNil(t, resB.Accounts[0].LockoutExpiresAt)
+	require.WithinDuration(t, activeExpiry, *resB.Accounts[0].LockoutExpiresAt, time.Second)
+
+	resC, err := breakglass.ListPlatform(context.Background(), db,
+		breakglass.PlatformListFilter{TenantID: &tenantC}, now)
+	require.NoError(t, err)
+	require.Len(t, resC.Accounts, 1)
+	require.False(t, resC.Accounts[0].LockedOut, "an EXPIRED lockout must not count as active")
+	require.Nil(t, resC.Accounts[0].LockoutExpiresAt)
+
+	resD, err := breakglass.ListPlatform(context.Background(), db,
+		breakglass.PlatformListFilter{TenantID: &tenantD}, now)
+	require.NoError(t, err)
+	require.Len(t, resD.Accounts, 1)
+	require.False(t, resD.Accounts[0].LockedOut,
+		"a lockout row with tenant_id IS NULL must not attach to any account")
+	require.Nil(t, resD.Accounts[0].LockoutExpiresAt)
+}
+
+func TestIntegration_ListPlatform_UsedAfterAndUsedBeforeNarrow(t *testing.T) {
+	db := testdb.NewTx(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	early, mid, late, never := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	tEarly := now.Add(-3 * time.Hour)
+	tMid := now.Add(-90 * time.Minute)
+	tLate := now.Add(-10 * time.Minute)
+
+	seedAccount(t, db, early, &tEarly)
+	seedAccount(t, db, mid, &tMid)
+	seedAccount(t, db, late, &tLate)
+	seedAccount(t, db, never, nil)
+
+	after := now.Add(-2 * time.Hour)
+	res, err := breakglass.ListPlatform(context.Background(), db,
+		breakglass.PlatformListFilter{UsedAfter: &after}, now)
+	require.NoError(t, err)
+	idx := indexByTenant(res.Accounts)
+	_, hasMid := idx[mid]
+	_, hasLate := idx[late]
+	_, hasEarly := idx[early]
+	_, hasNever := idx[never]
+	require.True(t, hasMid && hasLate, "rows used after the bound must be included")
+	require.False(t, hasEarly, "a row used before the bound must be excluded")
+	require.False(t, hasNever, "a never-used row must not match used_after")
+
+	before := now.Add(-1 * time.Hour)
+	res, err = breakglass.ListPlatform(context.Background(), db,
+		breakglass.PlatformListFilter{UsedBefore: &before}, now)
+	require.NoError(t, err)
+	idx = indexByTenant(res.Accounts)
+	_, hasEarly = idx[early]
+	_, hasMid = idx[mid]
+	_, hasLate = idx[late]
+	_, hasNever = idx[never]
+	require.True(t, hasEarly && hasMid, "rows used before the bound must be included")
+	require.False(t, hasLate, "a row used after the bound must be excluded")
+	require.False(t, hasNever, "a never-used row must not match used_before")
+}
+
+// Total is the unpaginated match count while the returned page is limited —
+// the property that makes total/limit a correct page count.
+func TestIntegration_ListPlatform_TotalIsUnpaginatedCount(t *testing.T) {
+	db := testdb.NewTx(t)
+	now := time.Now().UTC()
+
+	for i := 0; i < 5; i++ {
+		used := now.Add(-time.Duration(i) * time.Hour)
+		seedAccount(t, db, uuid.New(), &used)
+	}
+
+	res, err := breakglass.ListPlatform(context.Background(), db,
+		breakglass.PlatformListFilter{Limit: 2}, now)
+	require.NoError(t, err)
+	require.EqualValues(t, 5, res.Total, "Total must be the full match count, not the page size")
+	require.Len(t, res.Accounts, 2, "the returned page must respect Limit")
+}
+
+// sqlCapture is a minimal gorm logger.Interface that records every SQL
+// statement traced through it, so the test can inspect the exact query
+// ListPlatform sends to Postgres.
+type sqlCapture struct {
+	queries *[]string
+}
+
+func (c *sqlCapture) LogMode(logger.LogLevel) logger.Interface      { return c }
+func (c *sqlCapture) Info(context.Context, string, ...interface{})  {}
+func (c *sqlCapture) Warn(context.Context, string, ...interface{})  {}
+func (c *sqlCapture) Error(context.Context, string, ...interface{}) {}
+func (c *sqlCapture) Trace(_ context.Context, _ time.Time, fc func() (string, int64), _ error) {
+	sql, _ := fc()
+	*c.queries = append(*c.queries, sql)
+}
+
+func findPageQuery(t *testing.T, queries []string) string {
+	t.Helper()
+	for _, q := range queries {
+		if strings.Contains(q, "lockout_expires_at") {
+			return q
+		}
+	}
+	t.Fatalf("no captured query looked like the row-fetch select; captured: %v", queries)
+	return ""
+}
+
+// This is the security property of the whole change: break_glass_accounts
+// holds a GCP Secret Manager path pointing at the live plaintext password
+// and TOTP secret, a bcrypt hash, and a JSON pointer into that blob. None of
+// them may be reachable from this cross-tenant platform read.
+func TestIntegration_ListPlatform_SelectsExplicitColumnsNeverCredentialFields(t *testing.T) {
+	db := testdb.NewTx(t)
+	now := time.Now().UTC()
+	tid := uuid.New()
+	seedAccount(t, db, tid, nil)
+
+	var captured []string
+	capDB := db.Session(&gorm.Session{Logger: &sqlCapture{queries: &captured}})
+
+	_, err := breakglass.ListPlatform(context.Background(), capDB,
+		breakglass.PlatformListFilter{TenantID: &tid}, now)
+	require.NoError(t, err)
+
+	pageQuery := findPageQuery(t, captured)
+	t.Logf("captured page query: %s", pageQuery)
+
+	for _, forbidden := range []string{"*", "secret_path", "password_hash", "totp_secret_ref"} {
+		require.NotContains(t, pageQuery, forbidden,
+			"the row-fetch query must never be able to reach %q", forbidden)
+	}
+}

--- a/services/marketplace-api/internal/breakglass/platform_list_sql_shape_test.go
+++ b/services/marketplace-api/internal/breakglass/platform_list_sql_shape_test.go
@@ -1,0 +1,95 @@
+package breakglass_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+)
+
+// dryRunSQLCapture is a minimal gorm logger.Interface that records every
+// SQL statement traced through it. Same pattern as sqlCapture in
+// platform_list_integration_test.go (which needs a live Postgres and the
+// `integration` build tag to run, so it never executes in CI — see
+// TestListPlatform_PageQueryNeverSelectsStarOrCredentialColumns below).
+// Named distinctly from its integration-test counterpart so both compile
+// together without a symbol clash under `-tags=integration`.
+type dryRunSQLCapture struct {
+	queries *[]string
+}
+
+func (c *dryRunSQLCapture) LogMode(logger.LogLevel) logger.Interface      { return c }
+func (c *dryRunSQLCapture) Info(context.Context, string, ...interface{})  {}
+func (c *dryRunSQLCapture) Warn(context.Context, string, ...interface{})  {}
+func (c *dryRunSQLCapture) Error(context.Context, string, ...interface{}) {}
+func (c *dryRunSQLCapture) Trace(_ context.Context, _ time.Time, fc func() (string, int64), _ error) {
+	sql, _ := fc()
+	*c.queries = append(*c.queries, sql)
+}
+
+func findDryRunPageQuery(t *testing.T, queries []string) string {
+	t.Helper()
+	for _, q := range queries {
+		if strings.Contains(q, "lockout_expires_at") {
+			return q
+		}
+	}
+	t.Fatalf("no captured query looked like the row-fetch select; captured: %v", queries)
+	return ""
+}
+
+// TestListPlatform_PageQueryNeverSelectsStarOrCredentialColumns is the
+// CI-visible twin of
+// TestIntegration_ListPlatform_SelectsExplicitColumnsNeverCredentialFields
+// (platform_list_integration_test.go): that test guards the security
+// property of this whole endpoint — that the generated page query can
+// never reach secret_path, password_hash, or totp_secret_ref — but it sits
+// behind `//go:build integration` plus a live TEST_DATABASE_URL, which the
+// PR pipeline does not provide, so it never runs on a PR.
+//
+// This test asserts the identical four things against the identical query
+// ListPlatform builds, without a database: gorm.Session{DryRun: true} on a
+// Postgres dialector backed by an unconnected sql.DB builds the exact SQL
+// string a real run would send, but never opens a connection (DryRun skips
+// execution entirely — see gorm's callbacks/query.go — and
+// DisableAutomaticPing skips gorm.Open's connectivity check). A PR that
+// regresses the Select to `SELECT *` now goes red without Postgres.
+func TestListPlatform_PageQueryNeverSelectsStarOrCredentialColumns(t *testing.T) {
+	base, err := gorm.Open(postgres.Open("postgres://dry-run:unused@127.0.0.1:1/dry-run?sslmode=disable"), &gorm.Config{
+		DisableAutomaticPing: true,
+	})
+	require.NoError(t, err, "gorm.Open must not dial — DryRun below never executes a query")
+
+	var captured []string
+	dryDB := base.Session(&gorm.Session{
+		DryRun: true,
+		Logger: &dryRunSQLCapture{queries: &captured},
+	})
+
+	// ListPlatform's page fetch goes through gorm's Scan(), which builds
+	// on Rows() — and Rows() does not support DryRun (gorm returns
+	// ErrDryRunModeUnsupported for it once it reaches the point where it
+	// would otherwise execute). That error is expected and harmless here:
+	// by the time it's produced, BuildQuerySQL has already run and the
+	// full SQL text has already reached dryRunSQLCapture.Trace below, which
+	// is the only thing this test needs — it never reads res.Accounts.
+	tid := uuid.New()
+	_, _ = breakglass.ListPlatform(context.Background(), dryDB,
+		breakglass.PlatformListFilter{TenantID: &tid}, time.Now())
+
+	pageQuery := findDryRunPageQuery(t, captured)
+	t.Logf("captured page query: %s", pageQuery)
+
+	for _, forbidden := range []string{"*", "secret_path", "password_hash", "totp_secret_ref"} {
+		require.NotContains(t, pageQuery, forbidden,
+			"the row-fetch query must never be able to reach %q", forbidden)
+	}
+}

--- a/services/marketplace-api/internal/breakglass/platform_list_test.go
+++ b/services/marketplace-api/internal/breakglass/platform_list_test.go
@@ -1,0 +1,47 @@
+package breakglass_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+)
+
+// TestPlatformRowCannotCarryCredentialFields is the core guarantee behind
+// the platform break-glass read (#333): break_glass_accounts holds
+// secret_path (a GCP Secret Manager path pointing at the live plaintext
+// password and TOTP secret), password_hash (bcrypt), and totp_secret_ref (a
+// JSON pointer into that blob). None of the three may ever be reachable
+// from breakglass.PlatformRow, by field name or by JSON tag, and a field
+// merely containing "secret", "hash", or "password" is forbidden outright
+// so a differently-named credential column added later still trips this
+// guard.
+func TestPlatformRowCannotCarryCredentialFields(t *testing.T) {
+	exact := []string{"secret_path", "password_hash", "totp_secret_ref"}
+	substrings := []string{"secret", "hash", "password"}
+
+	tp := reflect.TypeOf(breakglass.PlatformRow{})
+	for i := 0; i < tp.NumField(); i++ {
+		f := tp.Field(i)
+		tag := f.Tag.Get("json")
+		name := strings.SplitN(tag, ",", 2)[0]
+
+		for _, bad := range exact {
+			if name == bad {
+				t.Errorf("PlatformRow.%s has forbidden json tag %q", f.Name, name)
+			}
+			if strings.EqualFold(f.Name, bad) {
+				t.Errorf("PlatformRow.%s has forbidden field name %q", f.Name, f.Name)
+			}
+		}
+		for _, sub := range substrings {
+			if strings.Contains(strings.ToLower(name), sub) {
+				t.Errorf("PlatformRow.%s json tag %q contains forbidden substring %q", f.Name, name, sub)
+			}
+			if strings.Contains(strings.ToLower(f.Name), sub) {
+				t.Errorf("PlatformRow.%s field name contains forbidden substring %q", f.Name, sub)
+			}
+		}
+	}
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/break_glass.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/break_glass.go
@@ -1,0 +1,285 @@
+package platformadmin
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
+)
+
+// BreakGlassLister is the subset of the cross-tenant break-glass read this
+// handler needs. Narrowed to one method for the same reason as
+// EmailSendLister.
+type BreakGlassLister interface {
+	ListPlatform(ctx context.Context, db *gorm.DB, f breakglass.PlatformListFilter,
+		asOf time.Time) (breakglass.PlatformListResult, error)
+}
+
+// BreakGlassListerFunc adapts a plain function, so breakglass.ListPlatform —
+// a package function, not a method — can be wired directly in main.go. Same
+// pattern as EmailSendListerFunc.
+type BreakGlassListerFunc func(ctx context.Context, db *gorm.DB,
+	f breakglass.PlatformListFilter, asOf time.Time) (breakglass.PlatformListResult, error)
+
+func (fn BreakGlassListerFunc) ListPlatform(ctx context.Context, db *gorm.DB,
+	f breakglass.PlatformListFilter, asOf time.Time) (breakglass.PlatformListResult, error) {
+	return fn(ctx, db, f, asOf)
+}
+
+// BreakGlassHandler serves GET /admin/break-glass — the cross-tenant
+// emergency-account inventory (#333).
+//
+// break_glass_accounts is a deliberate authentication bypass; before this
+// endpoint the only control on its use was rotation, because nothing outside
+// mark8ly could see when an emergency credential was used. This is the read
+// that closes that gap — and only the read: it never touches secret_path,
+// password_hash or totp_secret_ref, which breakglass.ListPlatform already
+// excludes at the query layer, and breakGlassRow below excludes again at the
+// wire layer.
+type BreakGlassHandler struct {
+	db     *gorm.DB
+	repo   BreakGlassLister
+	dir    TenantDirectory
+	logger *slog.Logger
+	now    func() time.Time
+}
+
+// NewBreakGlassHandler constructs the handler. logger may be nil.
+func NewBreakGlassHandler(db *gorm.DB, repo BreakGlassLister, dir TenantDirectory, logger *slog.Logger) *BreakGlassHandler {
+	return &BreakGlassHandler{db: db, repo: repo, dir: dir, logger: logger, now: time.Now}
+}
+
+// Register mounts the route on the supplied group. The read is additionally
+// gated on an exact `rotate-credentials` platform capability — see
+// RequiredReadCapabilities in middleware.go — but that gate is enforced by
+// middleware ahead of this handler, not here.
+func (h *BreakGlassHandler) Register(g *gin.RouterGroup) {
+	g.GET("/admin/break-glass", h.List)
+}
+
+// breakGlassRow is the pinned contract shape (see the plan's Contract
+// section). Populated field by field from breakglass.PlatformRow — never
+// embedded, never re-marshalled — so a column added to that struct tomorrow
+// cannot reach the wire without a deliberate edit here.
+type breakGlassRow struct {
+	TenantID   string `json:"tenant_id"`
+	TenantName string `json:"tenant_name,omitempty"`
+	// TOTPEnrolled mirrors PlatformRow.TOTPEnrolled.
+	TOTPEnrolled bool `json:"totp_enrolled"`
+	// LastUsedAt is nullable: a never-used account has this absent.
+	LastUsedAt    *string `json:"last_used_at"`
+	LastRotatedAt string  `json:"last_rotated_at"`
+	// RotationScheduledAt is nullable.
+	RotationScheduledAt *string `json:"rotation_scheduled_at"`
+	// LockedOut means "at least one break_glass_lockouts row currently
+	// names this tenant" — see breakglass.PlatformRow.LockedOut for the
+	// per-IP, not per-account, caveat this does NOT repeat on the wire
+	// because the contract row does not carry prose.
+	LockedOut bool `json:"locked_out"`
+	// LockoutExpiresAt is nullable, and nil whenever LockedOut is false.
+	LockoutExpiresAt *string `json:"lockout_expires_at"`
+	CreatedAt        string  `json:"created_at"`
+}
+
+type breakGlassListResponse struct {
+	Data       []breakGlassRow `json:"data"`
+	Pagination pagination      `json:"pagination"`
+}
+
+// List serves GET /admin/break-glass.
+func (h *BreakGlassHandler) List(c *gin.Context) {
+	f, asOf := h.parseFilter(c)
+
+	res, err := h.repo.ListPlatform(c.Request.Context(), h.db, f, asOf)
+	if err != nil {
+		if h.logger != nil {
+			h.logger.Error("platform break-glass list failed", "err", err)
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "internal", "message": "could not load the break-glass inventory",
+		})
+		return
+	}
+
+	names := h.lookupTenantNames(c.Request.Context(), res.Accounts)
+
+	// Allocate before appending: a nil slice marshals to null, which defeats
+	// a caller's `?? []` exactly when there is no data.
+	rows := make([]breakGlassRow, 0, len(res.Accounts))
+	for _, a := range res.Accounts {
+		rows = append(rows, toBreakGlassRow(a, names))
+	}
+
+	c.JSON(http.StatusOK, breakGlassListResponse{
+		Data: rows,
+		Pagination: pagination{
+			Page:  max(f.Page, 1),
+			Limit: effectiveBreakGlassLimit(f.Limit),
+			Total: res.Total,
+		},
+	})
+}
+
+// lookupTenantNames collects the DISTINCT tenant ids on the page and makes
+// exactly one tenantdirectory.List call for all of them, never one call per
+// row. A page with zero rows makes no call at all: an empty IDs slice would
+// otherwise match "no id filter" on the wire and pull back the whole
+// directory instead of nothing. Mirrors
+// BillingSubscriptionsHandler.lookupTenantNames — with one deliberate
+// difference: this surface is a security control, and a platform-api outage
+// must not hide it. A directory error therefore DEGRADES to the bare tenant
+// id standing in for its own name, rather than failing the request.
+func (h *BreakGlassHandler) lookupTenantNames(ctx context.Context, accounts []breakglass.PlatformRow) map[string]string {
+	names := map[string]string{}
+	if len(accounts) == 0 {
+		return names
+	}
+
+	seen := make(map[string]bool, len(accounts))
+	ids := make([]string, 0, len(accounts))
+	for _, a := range accounts {
+		id := a.TenantID.String()
+		if !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+	}
+
+	res, err := h.dir.List(ctx, tenantdirectory.ListParams{IDs: ids, Limit: len(ids)})
+	if err != nil {
+		if h.logger != nil {
+			h.logger.Warn("break-glass: tenant directory unavailable, degrading to ids", "err", err)
+		}
+		for _, id := range ids {
+			names[id] = id
+		}
+		return names
+	}
+
+	for _, t := range res.Tenants {
+		names[t.ID] = t.Name
+	}
+
+	// A tenant id present on a break-glass row but absent from the
+	// directory response means the two services disagree about which
+	// tenants exist. The row still appears, falling back to the bare id
+	// rather than an anonymous row, but this is worth a log line.
+	for _, id := range ids {
+		if _, ok := names[id]; !ok {
+			if h.logger != nil {
+				h.logger.Warn("break-glass: tenant missing from directory", "tenant_id", id)
+			}
+			names[id] = id
+		}
+	}
+
+	return names
+}
+
+func toBreakGlassRow(a breakglass.PlatformRow, names map[string]string) breakGlassRow {
+	tenantID := a.TenantID.String()
+	row := breakGlassRow{
+		TenantID:      tenantID,
+		TenantName:    names[tenantID],
+		TOTPEnrolled:  a.TOTPEnrolled,
+		LastRotatedAt: a.LastRotatedAt.UTC().Format(time.RFC3339),
+		LockedOut:     a.LockedOut,
+		CreatedAt:     a.CreatedAt.UTC().Format(time.RFC3339),
+	}
+	if a.LastUsedAt != nil {
+		v := a.LastUsedAt.UTC().Format(time.RFC3339)
+		row.LastUsedAt = &v
+	}
+	if a.RotationScheduledAt != nil {
+		v := a.RotationScheduledAt.UTC().Format(time.RFC3339)
+		row.RotationScheduledAt = &v
+	}
+	if a.LockoutExpiresAt != nil {
+		v := a.LockoutExpiresAt.UTC().Format(time.RFC3339)
+		row.LockoutExpiresAt = &v
+	}
+	return row
+}
+
+// parseFilter never errors: a malformed parameter takes the default, matching
+// every other read on this surface.
+func (h *BreakGlassHandler) parseFilter(c *gin.Context) (breakglass.PlatformListFilter, time.Time) {
+	f := breakglass.PlatformListFilter{
+		Page:     parsePositiveIntDefault(c.Query("page"), 1),
+		Limit:    parsePositiveIntDefault(c.Query("limit"), 0),
+		SortDesc: parseBreakGlassSort(c.Query("sort")),
+	}
+
+	if raw := strings.TrimSpace(c.Query("tenant_id")); raw != "" {
+		if id, err := uuid.Parse(raw); err == nil {
+			f.TenantID = &id
+		}
+	}
+	if t, ok := parseBreakGlassTime(c.Query("used_after")); ok {
+		f.UsedAfter = &t
+	}
+	if t, ok := parseBreakGlassTime(c.Query("used_before")); ok {
+		f.UsedBefore = &t
+	}
+	if b, ok := parseBreakGlassBool(c.Query("used")); ok {
+		f.Used = &b
+	}
+	if b, ok := parseBreakGlassBool(c.Query("locked")); ok {
+		f.Locked = &b
+	}
+
+	return f, h.now().UTC()
+}
+
+// parseBreakGlassSort accepts only "last_used_at" and "-last_used_at";
+// anything else — including an absent or unknown value — falls back to the
+// default descending sort, never erroring.
+func parseBreakGlassSort(raw string) bool {
+	switch strings.TrimSpace(raw) {
+	case "last_used_at":
+		return false
+	default:
+		return true
+	}
+}
+
+func parseBreakGlassTime(v string) (time.Time, bool) {
+	t, err := time.Parse(time.RFC3339, strings.TrimSpace(v))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+func parseBreakGlassBool(v string) (bool, bool) {
+	switch strings.TrimSpace(v) {
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+// effectiveBreakGlassLimit reports the limit actually applied, so
+// total/limit is a correct page count even when the caller asked for more
+// than the ceiling.
+func effectiveBreakGlassLimit(limit int) int {
+	switch {
+	case limit <= 0:
+		return breakglass.DefaultPlatformPageSize
+	case limit > breakglass.MaxPlatformPageSize:
+		return breakglass.MaxPlatformPageSize
+	default:
+		return limit
+	}
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/break_glass.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/break_glass.go
@@ -135,8 +135,10 @@ func (h *BreakGlassHandler) List(c *gin.Context) {
 // directory instead of nothing. Mirrors
 // BillingSubscriptionsHandler.lookupTenantNames — with one deliberate
 // difference: this surface is a security control, and a platform-api outage
-// must not hide it. A directory error therefore DEGRADES to the bare tenant
-// id standing in for its own name, rather than failing the request.
+// must not hide it. A directory error therefore DEGRADES to rows still
+// identified by tenant_id with the name OMITTED (dropped by omitempty),
+// rather than failing the request — and never to a fabricated name, which
+// would read as real and is worse than none.
 func (h *BreakGlassHandler) lookupTenantNames(ctx context.Context, accounts []breakglass.PlatformRow) map[string]string {
 	names := map[string]string{}
 	if len(accounts) == 0 {
@@ -155,11 +157,16 @@ func (h *BreakGlassHandler) lookupTenantNames(ctx context.Context, accounts []br
 
 	res, err := h.dir.List(ctx, tenantdirectory.ListParams{IDs: ids, Limit: len(ids)})
 	if err != nil {
+		// Degrade to rows identified by tenant_id with the name OMITTED —
+		// NOT a fabricated name. The console renders tenant_name as a
+		// display string, so putting the raw uuid there would read as a
+		// real (if odd) name rather than "unknown", which is worse than
+		// omitting it. The request still returns 200: the whole point of
+		// deviating from BillingSubscriptionsHandler here is that a
+		// platform-api outage must not hide a security control, and that
+		// is satisfied by returning the rows with ids and no names.
 		if h.logger != nil {
-			h.logger.Warn("break-glass: tenant directory unavailable, degrading to ids", "err", err)
-		}
-		for _, id := range ids {
-			names[id] = id
+			h.logger.Warn("break-glass: tenant directory unavailable, omitting names", "err", err)
 		}
 		return names
 	}
@@ -170,14 +177,11 @@ func (h *BreakGlassHandler) lookupTenantNames(ctx context.Context, accounts []br
 
 	// A tenant id present on a break-glass row but absent from the
 	// directory response means the two services disagree about which
-	// tenants exist. The row still appears, falling back to the bare id
-	// rather than an anonymous row, but this is worth a log line.
+	// tenants exist. The row still appears with its name simply omitted
+	// (never a fabricated fallback), but this is worth a log line.
 	for _, id := range ids {
-		if _, ok := names[id]; !ok {
-			if h.logger != nil {
-				h.logger.Warn("break-glass: tenant missing from directory", "tenant_id", id)
-			}
-			names[id] = id
+		if _, ok := names[id]; !ok && h.logger != nil {
+			h.logger.Warn("break-glass: tenant missing from directory", "tenant_id", id)
 		}
 	}
 

--- a/services/marketplace-api/internal/handlers/platformadmin/break_glass_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/break_glass_test.go
@@ -1,0 +1,296 @@
+package platformadmin_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
+)
+
+type stubBreakGlassLister struct {
+	res   breakglass.PlatformListResult
+	err   error
+	gotF  breakglass.PlatformListFilter
+	calls int
+}
+
+func (s *stubBreakGlassLister) ListPlatform(_ context.Context, _ *gorm.DB,
+	f breakglass.PlatformListFilter, _ time.Time) (breakglass.PlatformListResult, error) {
+	s.calls++
+	s.gotF = f
+	return s.res, s.err
+}
+
+type stubBreakGlassDirectory struct {
+	res *tenantdirectory.ListResult
+	err error
+}
+
+func (s *stubBreakGlassDirectory) List(_ context.Context, _ tenantdirectory.ListParams) (*tenantdirectory.ListResult, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.res != nil {
+		return s.res, nil
+	}
+	return &tenantdirectory.ListResult{}, nil
+}
+
+func (s *stubBreakGlassDirectory) Get(_ context.Context, _ string) (*tenantdirectory.TenantDetail, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubBreakGlassDirectory) FindByOwnerEmail(_ context.Context, _ string) (*tenantdirectory.Tenant, error) {
+	return nil, errors.New("not implemented")
+}
+
+func breakGlassRouter(t *testing.T, repo platformadmin.BreakGlassLister, dir platformadmin.TenantDirectory) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	platformadmin.NewBreakGlassHandler(nil, repo, dir, nil).Register(r.Group(""))
+	return r
+}
+
+// TestBreakGlassResponseCannotCarryCredentialFields is the handler-side twin
+// of breakglass.TestPlatformRowCannotCarryCredentialFields: it marshals a
+// response built from a FULLY-POPULATED PlatformRow and asserts none of the
+// three forbidden strings appears anywhere in the JSON bytes. The struct-shape
+// test guards PlatformRow itself; this one guards the wire response actually
+// sent, which is what a caller can observe.
+func TestBreakGlassResponseCannotCarryCredentialFields(t *testing.T) {
+	tid := uuid.New()
+	usedAt := time.Now().UTC()
+	rotatedAt := usedAt.Add(-24 * time.Hour)
+	scheduledAt := usedAt.Add(24 * time.Hour)
+	lockoutExpires := usedAt.Add(time.Hour)
+	createdAt := usedAt.Add(-720 * time.Hour)
+
+	repo := &stubBreakGlassLister{res: breakglass.PlatformListResult{
+		Total: 1,
+		Accounts: []breakglass.PlatformRow{{
+			TenantID:            tid,
+			TenantName:          "",
+			TOTPEnrolled:        true,
+			LastUsedAt:          &usedAt,
+			LastRotatedAt:       rotatedAt,
+			RotationScheduledAt: &scheduledAt,
+			LockedOut:           true,
+			LockoutExpiresAt:    &lockoutExpires,
+			CreatedAt:           createdAt,
+		}},
+	}}
+
+	rec := httptest.NewRecorder()
+	breakGlassRouter(t, repo, &stubBreakGlassDirectory{}).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/break-glass", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	body := rec.Body.String()
+	for _, forbidden := range []string{"password_hash", "secret_path", "totp_secret_ref"} {
+		require.NotContainsf(t, body, forbidden,
+			"%q must never reach the wire — break_glass_accounts holds the live credential behind it", forbidden)
+	}
+}
+
+func TestBreakGlassEnvelopeShape(t *testing.T) {
+	tid := uuid.New()
+	usedAt := time.Now().UTC()
+	rotatedAt := usedAt.Add(-24 * time.Hour)
+	createdAt := usedAt.Add(-720 * time.Hour)
+
+	repo := &stubBreakGlassLister{res: breakglass.PlatformListResult{
+		Total: 1,
+		Accounts: []breakglass.PlatformRow{{
+			TenantID:      tid,
+			TOTPEnrolled:  true,
+			LastUsedAt:    &usedAt,
+			LastRotatedAt: rotatedAt,
+			CreatedAt:     createdAt,
+		}},
+	}}
+	dir := &stubBreakGlassDirectory{res: &tenantdirectory.ListResult{
+		Tenants: []tenantdirectory.Tenant{{ID: tid.String(), Name: "Acme Ltd"}},
+	}}
+
+	rec := httptest.NewRecorder()
+	breakGlassRouter(t, repo, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/break-glass", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data []struct {
+			TenantID            string  `json:"tenant_id"`
+			TenantName          string  `json:"tenant_name"`
+			TOTPEnrolled        bool    `json:"totp_enrolled"`
+			LastUsedAt          string  `json:"last_used_at"`
+			LastRotatedAt       string  `json:"last_rotated_at"`
+			RotationScheduledAt *string `json:"rotation_scheduled_at"`
+			LockedOut           bool    `json:"locked_out"`
+			LockoutExpiresAt    *string `json:"lockout_expires_at"`
+			CreatedAt           string  `json:"created_at"`
+		} `json:"data"`
+		Pagination struct {
+			Page  int   `json:"page"`
+			Limit int   `json:"limit"`
+			Total int64 `json:"total"`
+		} `json:"pagination"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Data, 1)
+	row := body.Data[0]
+	require.Equal(t, tid.String(), row.TenantID)
+	require.Equal(t, "Acme Ltd", row.TenantName)
+	require.True(t, row.TOTPEnrolled)
+	require.Equal(t, usedAt.Format(time.RFC3339), row.LastUsedAt)
+	require.Equal(t, rotatedAt.Format(time.RFC3339), row.LastRotatedAt)
+	require.Nil(t, row.RotationScheduledAt)
+	require.False(t, row.LockedOut)
+	require.Nil(t, row.LockoutExpiresAt)
+	require.Equal(t, createdAt.Format(time.RFC3339), row.CreatedAt)
+
+	require.Equal(t, 1, body.Pagination.Page)
+	require.Equal(t, breakglass.DefaultPlatformPageSize, body.Pagination.Limit)
+	require.EqualValues(t, 1, body.Pagination.Total)
+
+	require.NotContains(t, rec.Body.String(), `"source"`)
+}
+
+func TestBreakGlassEmptyIsArray(t *testing.T) {
+	rec := httptest.NewRecorder()
+	breakGlassRouter(t, &stubBreakGlassLister{}, &stubBreakGlassDirectory{}).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/break-glass", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body struct {
+		Data json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "[]", string(body.Data))
+}
+
+func TestBreakGlassForwardsFilters(t *testing.T) {
+	repo := &stubBreakGlassLister{}
+	tid := uuid.New()
+	usedAfter := "2026-01-01T00:00:00Z"
+	usedBefore := "2026-06-01T00:00:00Z"
+
+	rec := httptest.NewRecorder()
+	url := "/admin/break-glass?tenant_id=" + tid.String() +
+		"&used_after=" + usedAfter + "&used_before=" + usedBefore +
+		"&used=true&locked=false&page=3&limit=25"
+	breakGlassRouter(t, repo, &stubBreakGlassDirectory{}).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, url, nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, repo.gotF.TenantID)
+	require.Equal(t, tid, *repo.gotF.TenantID)
+	require.NotNil(t, repo.gotF.UsedAfter)
+	require.Equal(t, usedAfter, repo.gotF.UsedAfter.UTC().Format(time.RFC3339))
+	require.NotNil(t, repo.gotF.UsedBefore)
+	require.Equal(t, usedBefore, repo.gotF.UsedBefore.UTC().Format(time.RFC3339))
+	require.NotNil(t, repo.gotF.Used)
+	require.True(t, *repo.gotF.Used)
+	require.NotNil(t, repo.gotF.Locked)
+	require.False(t, *repo.gotF.Locked)
+	require.Equal(t, 3, repo.gotF.Page)
+	require.Equal(t, 25, repo.gotF.Limit)
+}
+
+func TestBreakGlassMalformedTenantIsIgnoredNotZeroed(t *testing.T) {
+	repo := &stubBreakGlassLister{}
+	rec := httptest.NewRecorder()
+	breakGlassRouter(t, repo, &stubBreakGlassDirectory{}).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/break-glass?tenant_id=not-a-uuid", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Nil(t, repo.gotF.TenantID)
+}
+
+func TestBreakGlassSortValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		wantDesc bool
+	}{
+		{"default", "", true},
+		{"explicit desc", "sort=-last_used_at", true},
+		{"asc", "sort=last_used_at", false},
+		{"unknown falls back to default", "sort=bogus", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &stubBreakGlassLister{}
+			rec := httptest.NewRecorder()
+			url := "/admin/break-glass"
+			if tt.query != "" {
+				url += "?" + tt.query
+			}
+			breakGlassRouter(t, repo, &stubBreakGlassDirectory{}).ServeHTTP(rec, httptest.NewRequest(
+				http.MethodGet, url, nil))
+			require.Equal(t, http.StatusOK, rec.Code)
+			require.Equal(t, tt.wantDesc, repo.gotF.SortDesc)
+		})
+	}
+}
+
+func TestBreakGlassReportsTheClampedLimit(t *testing.T) {
+	repo := &stubBreakGlassLister{res: breakglass.PlatformListResult{Total: 900}}
+	rec := httptest.NewRecorder()
+	breakGlassRouter(t, repo, &stubBreakGlassDirectory{}).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/break-glass?limit=100000", nil))
+
+	var body struct {
+		Pagination struct {
+			Limit int   `json:"limit"`
+			Total int64 `json:"total"`
+		} `json:"pagination"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, breakglass.MaxPlatformPageSize, body.Pagination.Limit)
+	require.EqualValues(t, 900, body.Pagination.Total)
+}
+
+func TestBreakGlassTenantNameEnrichmentDegradesOnDirectoryError(t *testing.T) {
+	tid := uuid.New()
+	repo := &stubBreakGlassLister{res: breakglass.PlatformListResult{
+		Total: 1,
+		Accounts: []breakglass.PlatformRow{{
+			TenantID:      tid,
+			LastRotatedAt: time.Now().UTC(),
+			CreatedAt:     time.Now().UTC(),
+		}},
+	}}
+	dir := &stubBreakGlassDirectory{err: errors.New("platform-api unreachable")}
+
+	rec := httptest.NewRecorder()
+	breakGlassRouter(t, repo, dir).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/break-glass", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body struct {
+		Data []struct {
+			TenantID   string `json:"tenant_id"`
+			TenantName string `json:"tenant_name"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Data, 1)
+	require.Equal(t, tid.String(), body.Data[0].TenantID)
+	// A directory failure degrades to the bare id rather than failing the
+	// request or leaving the row anonymous.
+	require.Equal(t, tid.String(), body.Data[0].TenantName)
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/break_glass_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/break_glass_test.go
@@ -264,6 +264,11 @@ func TestBreakGlassReportsTheClampedLimit(t *testing.T) {
 	require.EqualValues(t, 900, body.Pagination.Total)
 }
 
+// A directory failure must not put a fabricated name (the raw tenant uuid)
+// where the console renders a display string. It degrades to the row still
+// being returned, identified by tenant_id, with tenant_name OMITTED
+// (dropped by omitempty) — not present as empty string, not present as the
+// id — and the request still 200.
 func TestBreakGlassTenantNameEnrichmentDegradesOnDirectoryError(t *testing.T) {
 	tid := uuid.New()
 	repo := &stubBreakGlassLister{res: breakglass.PlatformListResult{
@@ -282,15 +287,11 @@ func TestBreakGlassTenantNameEnrichmentDegradesOnDirectoryError(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	var body struct {
-		Data []struct {
-			TenantID   string `json:"tenant_id"`
-			TenantName string `json:"tenant_name"`
-		} `json:"data"`
+		Data []map[string]any `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	require.Len(t, body.Data, 1)
-	require.Equal(t, tid.String(), body.Data[0].TenantID)
-	// A directory failure degrades to the bare id rather than failing the
-	// request or leaving the row anonymous.
-	require.Equal(t, tid.String(), body.Data[0].TenantName)
+	require.Equal(t, tid.String(), body.Data[0]["tenant_id"])
+	require.NotContains(t, body.Data[0], "tenant_name",
+		"a directory outage must omit the name, never fabricate one from the uuid")
 }

--- a/services/marketplace-api/internal/handlers/platformadmin/break_glass_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/break_glass_test.go
@@ -82,7 +82,6 @@ func TestBreakGlassResponseCannotCarryCredentialFields(t *testing.T) {
 		Total: 1,
 		Accounts: []breakglass.PlatformRow{{
 			TenantID:            tid,
-			TenantName:          "",
 			TOTPEnrolled:        true,
 			LastUsedAt:          &usedAt,
 			LastRotatedAt:       rotatedAt,

--- a/services/marketplace-api/internal/handlers/platformadmin/middleware.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/middleware.go
@@ -99,6 +99,39 @@ var RequiredWriteCapabilities = map[string]string{
 	CapabilityKey(http.MethodPost, "/api/v1/platform/admin/tenants/:id/purge"):              "",
 }
 
+// RequiredReadCapabilities declares reads that require a specific
+// capability VALUE, not merely a valid signature.
+//
+// Unlike RequiredWriteCapabilities this map is NOT gated on
+// CapabilityValueChecked and its values are NOT empty: it is opt-in per
+// route, and a read route ABSENT from it keeps today's behaviour —
+// signature only, no operator required, no capability required. That
+// undeclared-route behaviour is load-bearing: every read this surface
+// already serves in production (/admin/audit-logs, /admin/billing/subscriptions,
+// /admin/billing/trials, /admin/health) has no entry here and must keep
+// working exactly as it does today.
+//
+// That asymmetry with the write map is deliberate, not an oversight:
+// flipping value enforcement on for every write at once is #364's problem,
+// and it needs the console to send more than one capability value before
+// that switch can be turned on safely. Requiring one named capability on
+// one route does not carry that same requirement, so this map can enforce
+// today without waiting on #364.
+//
+// What this pins on the console: platform-api has no break-glass module
+// yet, so nothing that succeeds today is refused by this entry. But the
+// audit module currently sends "platform" as its X-Platform-Capability
+// value, and that is NOT the value break-glass must send. When the
+// break-glass module is built, it MUST send "rotate-credentials" — matching
+// what the console's own route config already declares for
+// platform.breakGlass — or every request it makes will be refused with 403
+// capability_insufficient. Whoever builds that module should find this
+// requirement here, in the code, rather than discover it as a production
+// 403.
+var RequiredReadCapabilities = map[string]string{
+	CapabilityKey(http.MethodGet, "/api/v1/platform/admin/break-glass"): "rotate-credentials",
+}
+
 // AuthConfig configures RequirePlatformAuth.
 type AuthConfig struct {
 	// Secret is the shared HMAC key. Empty means NOT CONFIGURED, and every
@@ -133,6 +166,14 @@ type AuthConfig struct {
 	// without touching the production matrix, whose values #364 requires
 	// stay empty until #333.
 	RequiredCapabilities map[string]string
+
+	// RequiredReadCaps overrides RequiredReadCapabilities for this
+	// instance of RequirePlatformAuth. Nil — again, every production
+	// caller's value — falls back to the real RequiredReadCapabilities map
+	// declared above. Tests use this to exercise declared-and-matched,
+	// declared-and-mismatched, and undeclared-read behaviour without
+	// touching the production map, which only break-glass needs today.
+	RequiredReadCaps map[string]string
 }
 
 // RequirePlatformAuth verifies the gateway signature, enforces the replay
@@ -291,6 +332,43 @@ func RequirePlatformAuth(cfg AuthConfig) gin.HandlerFunc {
 						"this route has not declared a required capability")
 					return
 				}
+				if in.Capability != required {
+					abort(c, http.StatusForbidden, "capability_insufficient",
+						"the presented capability does not authorize this request")
+					return
+				}
+			}
+		} else {
+			// Reads are ungated by default — see RequiredReadCapabilities'
+			// doc comment. Only a route with an entry in that map requires
+			// an operator and a matching capability; every other read on
+			// this surface (audit logs, billing subscriptions, billing
+			// trials, health) has no entry and must proceed exactly as it
+			// does today. This is the reverse posture from the write branch
+			// above, deliberately: an UNDECLARED write fails closed because
+			// every write must declare; an undeclared READ is simply an
+			// ungated read, because gating every read has never been
+			// required and this map exists to opt specific routes in, not
+			// to opt every route out by default.
+			readRequirements := RequiredReadCapabilities
+			if cfg.RequiredReadCaps != nil {
+				readRequirements = cfg.RequiredReadCaps
+			}
+
+			if required, declared := readRequirements[CapabilityKey(writeMethod, c.FullPath())]; declared {
+				if in.Operator == "" {
+					abort(c, http.StatusUnauthorized, "operator_required",
+						"this read requires an operator identity")
+					return
+				}
+				if in.Capability == "" {
+					abort(c, http.StatusUnauthorized, "capability_required",
+						"this read requires a capability")
+					return
+				}
+				// Same exact-match rule as the write branch: no lattice, no
+				// prefix match, no implication between capabilities — see
+				// RequiredWriteCapabilities' doc comment and #275.
 				if in.Capability != required {
 					abort(c, http.StatusForbidden, "capability_insufficient",
 						"the presented capability does not authorize this request")

--- a/services/marketplace-api/internal/handlers/platformadmin/middleware.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/middleware.go
@@ -65,6 +65,15 @@ func CapabilityKey(method, routeTemplate string) string {
 	return strings.ToUpper(strings.TrimSpace(method)) + " " + routeTemplate
 }
 
+// MountPrefix is the path prefix this surface is always mounted under —
+// see the Register doc comment in routes.go for why it must be
+// /api/v1/platform and never /api/v1/admin. It is the single source for
+// that literal: RequiredReadCapabilities below, cmd/marketplace-api/main.go
+// (both call sites), and routes_capability_coverage_test.go all build off
+// this constant so that changing the mount prefix in one of them cannot
+// silently drift from the others and ungate break-glass.
+const MountPrefix = "/api/v1/platform"
+
 // RequiredWriteCapabilities is the per-route capability enforcement
 // matrix. It replaces what used to be a single global RequiredWriteCapability
 // string: one value could never express that this surface's four writes
@@ -129,7 +138,7 @@ var RequiredWriteCapabilities = map[string]string{
 // requirement here, in the code, rather than discover it as a production
 // 403.
 var RequiredReadCapabilities = map[string]string{
-	CapabilityKey(http.MethodGet, "/api/v1/platform/admin/break-glass"): "rotate-credentials",
+	CapabilityKey(http.MethodGet, MountPrefix+"/admin/break-glass"): "rotate-credentials",
 }
 
 // AuthConfig configures RequirePlatformAuth.

--- a/services/marketplace-api/internal/handlers/platformadmin/middleware_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/middleware_test.go
@@ -551,3 +551,162 @@ func TestCapabilityCheckedOnFailsClosedForUndeclaredRoute(t *testing.T) {
 	require.Equal(t, "capability_route_undeclared", errorCode(t, rec))
 	require.NotEqual(t, "capability_insufficient", errorCode(t, rec))
 }
+
+// newRouterWithReadCapabilityConfig is newRouter's counterpart for the read
+// gate: it lets a test override AuthConfig.RequiredReadCaps, which newRouter
+// deliberately does not expose. A nil required argument leaves
+// RequiredReadCaps unset, exactly as every production caller does, and the
+// route is mounted with the SAME GET method every read on this surface uses.
+func newRouterWithReadCapabilityConfig(t *testing.T, required map[string]string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(platformadmin.RequirePlatformAuth(platformadmin.AuthConfig{
+		Secret:           testSecret,
+		NonceStore:       newMemNonces(),
+		Now:              func() time.Time { return fixedNow },
+		RequiredReadCaps: required,
+	}))
+	r.GET("/admin/ping", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"operator":   c.GetString("platform_operator_id"),
+			"capability": c.GetString("platform_capability"),
+		})
+	})
+	return r
+}
+
+// TestDeclaredReadWithExactCapabilityIsAdmitted: a read route declared in
+// RequiredReadCaps, presented with an operator and the exact required
+// capability, is admitted.
+func TestDeclaredReadWithExactCapabilityIsAdmitted(t *testing.T) {
+	required := map[string]string{
+		platformadmin.CapabilityKey(http.MethodGet, "/admin/ping"): "rotate-credentials",
+	}
+	r := newRouterWithReadCapabilityConfig(t, required)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, signedRequest(t, http.MethodGet, "/admin/ping", nil,
+		withCapability("rotate-credentials")))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+}
+
+// TestDeclaredReadWithWrongCapabilityIsRefused: the same declared route,
+// presented with "platform" — the value the console's audit module
+// actually sends today — is refused. Exact string equality, no
+// implication between capabilities (#275).
+func TestDeclaredReadWithWrongCapabilityIsRefused(t *testing.T) {
+	required := map[string]string{
+		platformadmin.CapabilityKey(http.MethodGet, "/admin/ping"): "rotate-credentials",
+	}
+	r := newRouterWithReadCapabilityConfig(t, required)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, signedRequest(t, http.MethodGet, "/admin/ping", nil,
+		withCapability("platform")))
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Equal(t, "capability_insufficient", errorCode(t, rec))
+}
+
+// TestDeclaredReadWithNoCapabilityHeaderIsRefused: the declared route,
+// presented with an operator but no capability header at all, is refused
+// 401 capability_required — not silently admitted.
+func TestDeclaredReadWithNoCapabilityHeaderIsRefused(t *testing.T) {
+	required := map[string]string{
+		platformadmin.CapabilityKey(http.MethodGet, "/admin/ping"): "rotate-credentials",
+	}
+	r := newRouterWithReadCapabilityConfig(t, required)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, signedRequest(t, http.MethodGet, "/admin/ping", nil, withoutCapability))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Equal(t, "capability_required", errorCode(t, rec))
+}
+
+// TestDeclaredReadWithCapabilityButNoOperatorIsRefused: the declared route,
+// presented with a capability but no operator, is refused 401
+// operator_required. Operator is checked first, mirroring the write
+// branch's ordering.
+func TestDeclaredReadWithCapabilityButNoOperatorIsRefused(t *testing.T) {
+	required := map[string]string{
+		platformadmin.CapabilityKey(http.MethodGet, "/admin/ping"): "rotate-credentials",
+	}
+	r := newRouterWithReadCapabilityConfig(t, required)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, signedRequest(t, http.MethodGet, "/admin/ping", nil,
+		withoutOperator, withCapability("rotate-credentials")))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Equal(t, "operator_required", errorCode(t, rec))
+}
+
+// TestUndeclaredReadRouteWithNoCapabilityAtAllStillSucceeds is the
+// load-bearing assertion of this task: a read route that is ABSENT from
+// RequiredReadCapabilities — every shipped read on this surface today,
+// including /admin/audit-logs, /admin/health, and both billing reads — must
+// keep working with no operator and no capability header whatsoever. This
+// is the regression that would take down four routes already live in
+// production if the read gate's undeclared branch ever changed to fail
+// closed instead of proceeding.
+func TestUndeclaredReadRouteWithNoCapabilityAtAllStillSucceeds(t *testing.T) {
+	// Empty map, not nil: proves an explicitly-empty read map — the
+	// production shape before break-glass's own entry is considered —
+	// still lets an undeclared route straight through.
+	r := newRouterWithReadCapabilityConfig(t, map[string]string{})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, signedRequest(t, http.MethodGet, "/admin/ping", nil,
+		withoutOperator, withoutCapability))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+}
+
+// TestRequiredReadCapabilitiesHasExactlyTheBreakGlassEntry pins the
+// production map's shape: exactly one entry, keyed on the break-glass GET
+// route's full template, requiring "rotate-credentials". A second entry
+// appearing here without a corresponding update to this test is exactly
+// the kind of silent scope creep #364's write-map coverage test guards
+// against on the write side.
+func TestRequiredReadCapabilitiesHasExactlyTheBreakGlassEntry(t *testing.T) {
+	require.Len(t, platformadmin.RequiredReadCapabilities, 1)
+
+	key := platformadmin.CapabilityKey(http.MethodGet, "/api/v1/platform/admin/break-glass")
+	required, declared := platformadmin.RequiredReadCapabilities[key]
+	require.True(t, declared, "break-glass GET route must be declared in RequiredReadCapabilities")
+	require.Equal(t, "rotate-credentials", required)
+}
+
+// TestAuthConfigRequiredReadCapsNilDefaultsToProductionMap mirrors
+// TestAuthConfigCapabilityCheckedNilDefaultsToProductionOff: leaving
+// RequiredReadCaps unset — what every production caller does — must behave
+// exactly like falling back to the real RequiredReadCapabilities map, so a
+// request against the real break-glass route template is gated even though
+// this test never set RequiredReadCaps itself.
+func TestAuthConfigRequiredReadCapsNilDefaultsToProductionMap(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(platformadmin.RequirePlatformAuth(platformadmin.AuthConfig{
+		Secret:     testSecret,
+		NonceStore: newMemNonces(),
+		Now:        func() time.Time { return fixedNow },
+	}))
+	r.GET("/api/v1/platform/admin/break-glass", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	// No capability at all against the real, undeclared-in-test-but-real
+	// production route: refused, because RequiredReadCapabilities really
+	// does declare it even though this test passed nothing for
+	// RequiredReadCaps.
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, signedRequest(t, http.MethodGet, "/api/v1/platform/admin/break-glass", nil,
+		withoutOperator, withoutCapability))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Equal(t, "operator_required", errorCode(t, rec))
+
+	// And the exact required value admits it.
+	okRec := httptest.NewRecorder()
+	r.ServeHTTP(okRec, signedRequest(t, http.MethodGet, "/api/v1/platform/admin/break-glass", nil,
+		withCapability("rotate-credentials")))
+	require.Equal(t, http.StatusOK, okRec.Code, okRec.Body.String())
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -163,6 +163,14 @@ type Deps struct {
 	// The conformance suite fails an endpoint a product serves but does not
 	// declare, so a one-sided change turns the nightly job red.
 	EstateUsers EstateUserDirectory
+
+	// BreakGlass serves GET /admin/break-glass (#333), the cross-tenant
+	// emergency-account inventory. Nil leaves the route unmounted, matching
+	// the nil-safe pattern used for EmailSends above. It also requires
+	// TenantDirectory (non-nil) for tenant-name enrichment, matching the
+	// Trials/AllSubscriptions pattern above: both must be non-nil for the
+	// route to mount.
+	BreakGlass BreakGlassLister
 }
 
 // TenantGateInvalidator drops a tenant's cached admin-gate status. Declared
@@ -267,6 +275,10 @@ func Register(g *gin.RouterGroup, deps Deps) {
 
 	if deps.EmailSends != nil {
 		NewEmailSendsHandler(deps.DB, deps.EmailSends, deps.Logger).Register(group)
+	}
+
+	if deps.BreakGlass != nil && deps.TenantDirectory != nil {
+		NewBreakGlassHandler(deps.DB, deps.BreakGlass, deps.TenantDirectory, deps.Logger).Register(group)
 	}
 
 	if deps.EstateUsers != nil {

--- a/services/marketplace-api/internal/handlers/platformadmin/routes_break_glass_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes_break_glass_test.go
@@ -1,0 +1,67 @@
+package platformadmin_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+)
+
+// breakGlassMountedRouter builds the REAL router, via platformadmin.Register,
+// with exactly the dependencies GET /admin/break-glass needs to mount:
+// BreakGlass and TenantDirectory (routes.go's mount guard), alongside the
+// base auth wiring every route on this surface sits behind.
+func breakGlassMountedRouter(t *testing.T, nonces platformadmin.NonceStore) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	platformadmin.Register(r.Group("/api/v1/platform"), platformadmin.Deps{
+		Repo:            &stubRepo{},
+		Secret:          testSecret,
+		NonceStore:      nonces,
+		TenantDirectory: &stubBreakGlassDirectory{},
+		BreakGlass: platformadmin.BreakGlassListerFunc(
+			func(_ context.Context, _ *gorm.DB, _ breakglass.PlatformListFilter,
+				_ time.Time) (breakglass.PlatformListResult, error) {
+				return breakglass.PlatformListResult{}, nil
+			}),
+	})
+	return r
+}
+
+// TestBreakGlassRouteHonoursTheReadCapabilityGate is the full-surface proof
+// that GET /api/v1/platform/admin/break-glass is mounted AND sits behind
+// RequiredReadCapabilities' declared "rotate-credentials" requirement — not
+// merely that the map has the right entry (routes_capability_coverage_test.go
+// covers that), but that a real signed request is actually admitted or
+// refused by it.
+//
+// "platform" is asserted 403, not just "any wrong value", because it is the
+// value the console's audit module sends TODAY (see RequiredReadCapabilities'
+// doc comment in middleware.go) — the exact near-miss that would be easy to
+// wave through with a lattice or prefix match, which this surface
+// deliberately does not implement (#275).
+func TestBreakGlassRouteHonoursTheReadCapabilityGate(t *testing.T) {
+	r := breakGlassMountedRouter(t, newMemNonces())
+
+	okRec := httptest.NewRecorder()
+	r.ServeHTTP(okRec, signedRequest(t, http.MethodGet,
+		"/api/v1/platform/admin/break-glass", nil,
+		withCapability("rotate-credentials"), withCurrentTimestamp))
+	require.Equal(t, http.StatusOK, okRec.Code, okRec.Body.String())
+
+	forbiddenRec := httptest.NewRecorder()
+	r.ServeHTTP(forbiddenRec, signedRequest(t, http.MethodGet,
+		"/api/v1/platform/admin/break-glass", nil,
+		withCapability("platform"), withCurrentTimestamp))
+	require.Equal(t, http.StatusForbidden, forbiddenRec.Code, forbiddenRec.Body.String())
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/routes_capability_coverage_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes_capability_coverage_test.go
@@ -110,3 +110,135 @@ func TestAllWriteRoutesDeclareACapability(t *testing.T) {
 			"RequiredWriteCapabilities",
 		writeRouteCount)
 }
+
+// allReadRoutesDeps wires EVERY dependency Register (routes.go) needs to
+// mount every read route this surface has today, break-glass (#333)
+// included, alongside every write route (allWriteRoutesDeps' set, embedded
+// here too). Wiring only some read dependencies would leave some read
+// routes unmounted, and both assertions in
+// TestBreakGlassIsTheOnlyDeclaredReadCapability below would pass VACUOUSLY
+// on any route it never saw — the same hazard allWriteRoutesDeps' doc
+// comment describes for the write side. That is why this helper wires
+// everything, and why the test separately requires the break-glass route
+// was genuinely found rather than trusting an empty failure list alone.
+func allReadRoutesDeps() platformadmin.Deps {
+	deps := allWriteRoutesDeps()
+	deps.OnboardingFunnel = &stubFunnelClient{}
+	deps.EstateCounts = &stubEstateCounts{}
+	deps.Subscriptions = &stubSubscriptions{}
+	deps.Trials = &stubTrialLister{}
+	deps.AllSubscriptions = &stubSubscriptionLister{}
+	deps.Tickets = &stubTicketLister{}
+	deps.Notifications = &stubNotificationLister{}
+	deps.Outbox = &stubOutboxLister{}
+	deps.EmailSends = &stubSendLister{}
+	deps.EstateUsers = &stubUserDirectory{}
+	deps.Inbox = &routeInboxAggregator{}
+	deps.InboxItems = stubItemSource{}
+	deps.BreakGlass = &stubBreakGlassLister{}
+	return deps
+}
+
+// TestBreakGlassIsTheOnlyDeclaredReadCapability is the read-side counterpart
+// to TestAllWriteRoutesDeclareACapability, and closes the gap the previous
+// task's reviewer flagged: RequiredReadCapabilities is keyed on the LITERAL
+// STRING "GET /api/v1/platform/admin/break-glass". If the mount prefix or
+// the route path ever changed, that key would silently stop matching, the
+// read-capability gate would stop applying, and break-glass would become an
+// ungated read with NO TEST FAILING — the write side has
+// TestAllWriteRoutesDeclareACapability as a loud, by-name failure for the
+// equivalent drift; the read side had nothing.
+//
+// It builds the REAL router via platformadmin.Register with every read
+// (and write) dependency wired (allReadRoutesDeps), enumerates gin's OWN
+// route table — never a hand-written route string — and asserts two
+// things:
+//
+//  1. GET /api/v1/platform/admin/break-glass is actually mounted, and its
+//     CapabilityKey (built with the exported platformadmin.CapabilityKey,
+//     not a hand-written string) is present in
+//     platformadmin.RequiredReadCapabilities. Asserting the route was
+//     FOUND — not merely that a not-found route is absent from the map —
+//     is what keeps this from passing vacuously if the mount itself
+//     regresses.
+//  2. Every OTHER GET route this surface mounts has NO entry in
+//     RequiredReadCapabilities. A future read must not pick up an
+//     unintended gate by accident — this is what would catch it. The four
+//     reads already live in production today (/admin/audit-logs,
+//     /admin/billing/subscriptions, /admin/billing/trials, /admin/health)
+//     are asserted absent by name, since a stray entry on any of them
+//     would 403 real operator traffic.
+func TestBreakGlassIsTheOnlyDeclaredReadCapability(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	platformadmin.Register(r.Group("/api/v1/platform"), allReadRoutesDeps())
+
+	const breakGlassPath = "/api/v1/platform/admin/break-glass"
+
+	breakGlassFound := false
+	otherReadRouteCount := 0
+	for _, route := range r.Routes() {
+		if route.Method != http.MethodGet {
+			continue
+		}
+
+		key := platformadmin.CapabilityKey(route.Method, route.Path)
+
+		if route.Path == breakGlassPath {
+			breakGlassFound = true
+			required, declared := platformadmin.RequiredReadCapabilities[key]
+			require.True(t, declared,
+				"break-glass route %s %s has no entry in RequiredReadCapabilities — "+
+					"an undeclared read is ungated by design (see the map's doc "+
+					"comment), so this would silently reopen the emergency-account "+
+					"inventory to any valid signature",
+				route.Method, route.Path)
+			require.Equal(t, "rotate-credentials", required,
+				"break-glass must require exactly the capability value the "+
+					"console's break-glass module sends")
+			continue
+		}
+
+		otherReadRouteCount++
+		_, declared := platformadmin.RequiredReadCapabilities[key]
+		require.Falsef(t, declared,
+			"read route %s %s unexpectedly has an entry in RequiredReadCapabilities — "+
+				"only break-glass (#333) should be gated on this surface today; a "+
+				"stray entry here would 403 real operator traffic on this route",
+			route.Method, route.Path)
+	}
+
+	require.True(t, breakGlassFound,
+		"GET %s was never found in the route table — either it failed to "+
+			"mount (allReadRoutesDeps is missing a dependency) or its route "+
+			"template changed; without this the assertions above would pass "+
+			"vacuously",
+		breakGlassPath)
+
+	// Pins that this test actually exercised other mounted read routes too
+	// — including the four already live in production
+	// (/admin/audit-logs, /admin/billing/subscriptions,
+	// /admin/billing/trials, /admin/health) — rather than the "every OTHER
+	// route is absent" loop above passing vacuously because nothing else
+	// mounted.
+	require.Greater(t, otherReadRouteCount, 0,
+		"expected other read routes besides break-glass to be mounted; got "+
+			"none — allReadRoutesDeps is likely missing a dependency, which "+
+			"would make the absence assertions above vacuous")
+
+	for _, knownProductionRead := range []string{
+		"/api/v1/platform/admin/audit-logs",
+		"/api/v1/platform/admin/billing/subscriptions",
+		"/api/v1/platform/admin/billing/trials",
+		"/api/v1/platform/admin/health",
+	} {
+		key := platformadmin.CapabilityKey(http.MethodGet, knownProductionRead)
+		_, declared := platformadmin.RequiredReadCapabilities[key]
+		require.Falsef(t, declared,
+			"production read route GET %s must have no entry in "+
+				"RequiredReadCapabilities — an entry here would 403 real "+
+				"operator traffic that has never needed a capability before",
+			knownProductionRead)
+	}
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/routes_capability_coverage_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes_capability_coverage_test.go
@@ -172,9 +172,9 @@ func TestBreakGlassIsTheOnlyDeclaredReadCapability(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	r := gin.New()
-	platformadmin.Register(r.Group("/api/v1/platform"), allReadRoutesDeps())
+	platformadmin.Register(r.Group(platformadmin.MountPrefix), allReadRoutesDeps())
 
-	const breakGlassPath = "/api/v1/platform/admin/break-glass"
+	const breakGlassPath = platformadmin.MountPrefix + "/admin/break-glass"
 
 	breakGlassFound := false
 	otherReadRouteCount := 0


### PR DESCRIPTION
Closes #333.

`break_glass_accounts` already knew when an emergency credential was used. Nothing outside mark8ly could read it, which meant the control on a deliberate auth bypass was rotation, not oversight. This adds the read that closes that gap.

## `GET /api/v1/platform/admin/break-glass`

Cross-tenant, standard `{data, pagination}` envelope, empty is `200` with `[]`.

Per row: `tenant_id`, `tenant_name`, `totp_enrolled`, `last_used_at`, `last_rotated_at`, `rotation_scheduled_at`, `locked_out`, `lockout_expires_at`, `created_at`.

Filters and sort: `tenant_id`, `used_after`, `used_before`, `used`, `locked`, `sort` (`last_used_at` / `-last_used_at`, default descending), `page`, `limit`.

## The three forbidden fields, excluded by construction

`password_hash`, `secret_path` and `totp_secret_ref` cannot reach the wire, in three independent layers rather than by remembering to omit them:

1. The query names an explicit column list — no `SELECT *`, and `breakglass.Account` (which carries all three) is never loaded on this path.
2. `PlatformRow` has no field any of them could land in. This is the layer that actually holds: `Scan` discards columns with no matching field, so even a regression to `SELECT *` leaks nothing.
3. The handler's wire struct is populated field by field — never embedded, never re-marshalled from the model.

A reflection test rejects any field whose name or JSON tag contains `secret`, `hash` or `password`, so a differently-named credential column added later trips it too. It runs on every PR with no database required.

## First read on this surface to require a capability

Reads here previously needed only a valid signature. `RequiredReadCapabilities` is **opt-in per route**: a read absent from it keeps today's behaviour exactly — signature only, no operator, no capability. The four live reads (`/admin/audit-logs`, `/admin/billing/subscriptions`, `/admin/billing/trials`, `/admin/health`) are asserted absent by name, and every other mounted read is asserted absent by enumerating gin's own route table. Nothing that succeeds today is refused.

Break-glass requires exactly `rotate-credentials` — exact string equality, no lattice, no prefix match, no implication between capabilities, per #275.

**This pins a requirement on the console.** platform-api has no break-glass module yet, so nothing is refused today that works today. When that module is built it must send `X-Platform-Capability: rotate-credentials`, *not* the `platform` value the audit module currently sends. That requirement is written into `middleware.go` beside the map so it is found in the code, not as a production 403.

`CapabilityValueChecked` stays `false` and every `RequiredWriteCapabilities` value stays empty — turning value enforcement on for the four writes is #364's problem and needs the console to send more than one value.

## Two places the issue text and the schema disagreed

**`locked_out` is per-IP, not per-account.** `break_glass_lockouts` is keyed `(ip_hash, locked_until)` with a nullable `tenant_id`, populated only when a failed login resolved a tenant. So the field means *at least one active lockout row currently names this tenant*; attempts that never resolved one are invisible. Stated on the model rather than papered over, with the `tenant_id IS NULL` case seeded and asserted.

**`last_used_at` is nullable, so a never-used account sorts last.** `ORDER BY last_used_at DESC NULLS LAST` with a `tenant_id` tie-break for deterministic paging. The surface answers "which emergency accounts were used recently"; floating never-used rows to the top defeats it. Asserted against real Postgres in **both** directions, since sqlite and Postgres disagree on default NULL ordering.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` — all clean
- [x] `go test ./... -count=1` from the service root — exit 0
- [x] `go test -tags=integration -p 1 -count=1 ./internal/breakglass/...` — 10 tests pass against local Postgres
- [x] Credential-leak guard runs in CI without a database (reflection over the row type + a DryRun SQL-shape assertion)
- [x] Undeclared reads still return 200 with no operator and no capability — the regression that would break all four live reads
- [x] Signed round-trip: `rotate-credentials` → 200, `platform` → 403
- [x] Key-drift guard verified non-vacuous across three regressions: nil dep, path drift, deleted map entry
- [ ] Console-side verification is blocked until platform-api grows a break-glass module — see #333 comment 4

## Not in scope

`FEDERATION_MARK8LY_ENDPOINTS` is unset in tesserix-home, so platform-api believes mark8ly implements no optional contract endpoints. This already costs #284 and #285 — both shipped, and the console's Billing page still reads "No product is federating billing to the console yet." That, platform-api's break-glass module, and the console's `pending: true` route are all tesserix-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jFmanqTbbCYUgqZRGgQT7
