### PR TITLE
fix(pricing): correct the Stripe Price object count from 8 to 42, and stop the doc carrying the number

### DIFF
--- a/.planning/quick/20260828-price-object-count/PLAN.md
+++ b/.planning/quick/20260828-price-object-count/PLAN.md
@@ -1,0 +1,61 @@
+---
+slug: price-object-count
+issue: tesserix/mark8ly#414
+created: 2026-08-28
+---
+
+# Correct the Stripe Price object count: 8 → 42
+
+Two places state how many Stripe Price objects `billing-bootstrap` creates. Both
+say **8**. The real number is **42**, measured by calling `AllDescriptors()`
+directly on 2026-08-28:
+
+```
+total=42  developed=6  ppp=36
+```
+
+## Why it matters beyond a stale comment
+
+`docs/superpowers/plans/2026-04-19-p20-prod-launch-readiness.md:134` is item
+**B1.8**, a live launch-readiness checkbox owned by "Platform lead", whose
+acceptance is a `cmd/billing-bootstrap` run against **prod** Stripe.
+
+An operator verifying that run against "8 Price objects" sees roughly eight
+developed-market prices, ticks the box, and stops. The 34 PPP prices that did
+not get created fail **only** for INR, MYR, THB, PHP, IDR and VND merchants —
+the six markets least likely to appear in a smoke test, and the ones where
+`PriceIDFor` (`internal/billing/stripe/update.go:123`) returns a Stripe
+`ErrNotFound` that surfaces as a generic error rather than "catalog drift".
+
+This becomes materially more likely to bite now that tesserix-home#396 has
+shipped and the console can write the catalog to Stripe.
+
+## Tasks
+
+1. **`internal/billing/pricing/catalog.go:3`** — the package doc says
+   "8 developed-market Price objects (Starter+Studio+Pro × monthly+annual)".
+   It contradicts itself before it contradicts the code: that parenthetical is
+   **6**, not 8. It also omits the PPP tier entirely, which is the larger error.
+   State the real shape: 6 developed-market Price objects (3 plans × 2 periods),
+   each carrying `currency_options` for 7 currencies, plus 36 PPP Price objects
+   (3 plans × 2 periods × 6 currencies) = 42 total.
+
+2. **`docs/superpowers/plans/2026-04-19-p20-prod-launch-readiness.md:134`** —
+   B1.8 says "create all 8 Price objects + products". Same correction, and it
+   should say what a correct verification looks like rather than just a number.
+
+3. **A test asserting the count by tier**, so the next divergence fails CI
+   instead of a production checklist. `internal/plangate/matrix_test.go` already
+   uses this pattern for `allFeatures` — follow it.
+
+## Verification
+
+- `go test ./internal/billing/pricing/...` passes, including the new test
+- `go build ./...`
+- `go vet ./internal/billing/pricing/...`
+- The new test FAILS if a descriptor is added or removed without updating it
+
+## Out of scope
+
+Anything about what the catalog contains or how it is published. This is a
+counting and documentation correction only — no behaviour change.

--- a/.planning/quick/20260828-price-object-count/SUMMARY.md
+++ b/.planning/quick/20260828-price-object-count/SUMMARY.md
@@ -1,0 +1,74 @@
+---
+slug: price-object-count
+issue: tesserix/mark8ly#414
+status: complete
+completed: 2026-08-28
+branch: fix/414-price-object-count
+---
+
+# Correct the Stripe Price object count: 8 → 42
+
+## What was wrong
+
+Two places stated how many Stripe Price objects `cmd/billing-bootstrap` creates,
+both saying **8**. `init()` produces **42**.
+
+The package doc contradicted itself before it contradicted the code: its own
+parenthetical, `Starter+Studio+Pro × monthly+annual`, is 6 — and it omitted the
+PPP tier entirely, which was the larger error.
+
+## Counts, measured rather than assumed
+
+Verified twice independently — once by the controller before filing, once by the
+executor before writing anything, each via a temporary test calling
+`AllDescriptors()` directly and deleted afterwards:
+
+```
+total=42  developed=6  ppp=36
+```
+
+## Changes
+
+- `services/marketplace-api/internal/billing/pricing/catalog.go` — package doc
+  rewritten to describe the real shape (6 developed-market prices carrying
+  `currency_options` for 7 currencies, plus 36 PPP prices, one per currency) and
+  to point at `AllDescriptors()` and the tests as the source of truth rather than
+  restating a figure that can rot.
+- `docs/superpowers/plans/2026-04-19-p20-prod-launch-readiness.md` — **two**
+  occurrences, not one: B1.8 at line 134 and the go-live checklist at line 543.
+  Both now describe verification by counting `mark8ly_`-prefixed lookup keys
+  rather than checking against a fixed number.
+- `services/marketplace-api/internal/billing/pricing/catalog_test.go` — added
+  `TestCatalog_TotalDescriptorCount`.
+
+## On the new test, and a correction made during review
+
+`TestCatalog_DevelopedDescriptorCount` and `TestCatalog_PPPDescriptorCount`
+already existed, so the per-tier counts were *already* under test. The doc drifted
+anyway — the tests were never the missing piece, checking the doc against them was.
+
+The new test was initially justified in its own comment as catching a descriptor
+**swapped** between tiers. That justification is wrong: the two existing tests
+already catch a swap (developed would read 5, PPP 37, failing both). The comment
+was corrected to state what it actually adds — `len(AllDescriptors()) == 42` plus
+`developed + ppp == len(all)`, which together catch a descriptor whose `Tier` is
+*neither* value and is therefore counted by neither existing loop while both stay
+green.
+
+Worth recording that this was the same defect the issue itself is about — a
+comment asserting something the code does not do — reintroduced in the fix for it,
+and caught in review.
+
+## Verification
+
+- `go build ./...` clean
+- `go vet ./internal/billing/pricing/...` clean
+- `go test ./internal/billing/pricing/... -run . -v` — 32 tests pass
+- **Discrimination check:** deleted one PPP descriptor (INR/Starter/Monthly); the
+  new test failed (`expected: 36, actual: 35`); reverted; re-ran green. The test
+  bites.
+
+## Out of scope
+
+No behaviour change. `developedAmounts`, `pppAmounts`, `init()` and every
+descriptor are untouched.

--- a/docs/superpowers/plans/2026-04-19-p20-prod-launch-readiness.md
+++ b/docs/superpowers/plans/2026-04-19-p20-prod-launch-readiness.md
@@ -131,7 +131,7 @@ WS-H        [CVE triage ──┤[critical + high remediation ─────┤
 - [ ] **B1.5** Stripe live secret key in Secret Manager as `stripe-billing-secret-key`
 - [ ] **B1.6** Radar rules reviewed — `radar.early_fraud_warning` webhook wired (P2), confirm Radar enabled in Stripe Dashboard
 - [ ] **B1.7** Test `invoice.payment_action_required` flow end-to-end on Stripe India sandbox — use test card `4000 0035 6000 0008` — spec §26.1 blocker
-- [ ] **B1.8** Run `cmd/billing-bootstrap` against **prod** Stripe to create all 8 Price objects + products
+- [ ] **B1.8** Run `cmd/billing-bootstrap` against **prod** Stripe to create every Price object + product in `pricing.AllDescriptors()` (developed-market and PPP tiers both — see `internal/billing/pricing/catalog.go` for the shape). Verify by counting Price objects with `lookup_key` prefix `mark8ly_` in the Stripe Dashboard against `len(pricing.AllDescriptors())`, not by eyeballing a fixed number — a partial run (e.g. developed tier only) must fail this check.
 - [ ] **B1.9** Stripe Australia bank account remains single-currency (split-currency USD-AU settlement deferred per §4.2.2 until $200k ARR)
 - **Owner:** Platform lead
 - **Duration:** 2-3 weeks (Stripe verification can take 2 weeks)
@@ -540,7 +540,7 @@ Check these the day of public launch. Any `✗` = no-go, investigate.
 
 **Billing**
 - [ ] Stripe AU prod verified
-- [ ] 8 Price objects exist in prod Stripe with correct lookup_keys
+- [ ] Every Price object in `pricing.AllDescriptors()` exists in prod Stripe with correct lookup_keys (developed + PPP tiers — see B1.8)
 - [ ] Webhook signing secret rotated; test event round-trips
 - [ ] Stripe India SCA test passed
 - [ ] AU Stripe Tax registration confirmed

--- a/services/marketplace-api/internal/billing/pricing/catalog.go
+++ b/services/marketplace-api/internal/billing/pricing/catalog.go
@@ -1,8 +1,15 @@
 // Package pricing is the Go source of truth for all Stripe pricing.
 //
-// Architecture: 8 developed-market Price objects (Starter+Studio+Pro × monthly+annual),
-// each with currency_options for 7 currencies. PPP tiers use separate Price objects per
-// currency (can't share currency_options amounts across PPP and developed-market tiers).
+// Architecture: developed-market tier gets one Price object per (plan, period) —
+// Starter+Studio+Pro × monthly+annual — with currency_options carrying all 7
+// developed-market currencies on that same object. PPP tiers use a separate
+// Price object per (plan, period, currency), since currency_options amounts
+// can't be shared across the PPP and developed-market tiers.
+//
+// For the exact object count by tier, see AllDescriptors and the
+// TestCatalog_DevelopedDescriptorCount / TestCatalog_PPPDescriptorCount /
+// TestCatalog_TotalDescriptorCount assertions in catalog_test.go — those tests
+// are the source of truth and fail if the shape changes without being updated.
 //
 // Spec reference: docs/superpowers/specs/2026-04-17-subscription-model-design.md §4.1 and §4.1.1.
 package pricing

--- a/services/marketplace-api/internal/billing/pricing/catalog_test.go
+++ b/services/marketplace-api/internal/billing/pricing/catalog_test.go
@@ -269,6 +269,36 @@ func TestCatalog_PPPDescriptorCount(t *testing.T) {
 	require.Equal(t, 36, count, "expected 36 PPP descriptors (6 plan/period combos × 6 currencies)")
 }
 
+// TestCatalog_TotalDescriptorCount guards the total object count that
+// cmd/billing-bootstrap pushes to Stripe — the number tesserix/mark8ly#414
+// found stated as "8" in this package's doc and in the prod launch
+// checklist's B1.8 while init() produced 42.
+//
+// What this adds over the two per-tier tests above, precisely: they already
+// catch a descriptor SWAPPED between tiers (developed would read 5 and PPP
+// 37, failing both). What neither catches is a descriptor whose Tier is
+// NEITHER value — it is counted by neither loop, so both stay green while
+// len(AllDescriptors()) has moved. The last two assertions here are the
+// load-bearing ones: the total, and that developed+ppp exhausts it.
+//
+// Bump all three deliberately when the catalog shape genuinely changes.
+func TestCatalog_TotalDescriptorCount(t *testing.T) {
+	all := pricing.AllDescriptors()
+	developed, ppp := 0, 0
+	for _, d := range all {
+		switch d.Tier {
+		case pricing.TierDeveloped:
+			developed++
+		case pricing.TierPPP:
+			ppp++
+		}
+	}
+	require.Equal(t, 6, developed, "developed-tier count drifted")
+	require.Equal(t, 36, ppp, "PPP-tier count drifted")
+	require.Equal(t, 42, len(all), "total descriptor count drifted")
+	require.Equal(t, len(all), developed+ppp, "every descriptor must be exactly one of developed or PPP")
+}
+
 func TestCatalog_AllDescriptors_PPPOptionsHaveOneCurrency(t *testing.T) {
 	for _, d := range pricing.AllDescriptors() {
 		if d.Tier != pricing.TierPPP {


### PR DESCRIPTION
Closes #414.

Two places stated how many Stripe Price objects `cmd/billing-bootstrap` creates. Both said **8**. `init()` produces **42**.

## Measured, not assumed

Verified twice independently — before filing and again before writing the fix — each time by calling `AllDescriptors()` directly from a temporary test that was then deleted:

```
total=42  developed=6  ppp=36
```

The package doc contradicted itself before it contradicted the code: its own parenthetical, `Starter+Studio+Pro × monthly+annual`, is **6**, not 8. And it omitted the PPP tier entirely, which is the larger error — 36 of the 42.

## Why it was worth fixing now

`docs/superpowers/plans/2026-04-19-p20-prod-launch-readiness.md` **B1.8** is a live launch-readiness checkbox owned by "Platform lead", whose acceptance is a `billing-bootstrap` run against **prod** Stripe.

An operator verifying that run against "8 Price objects" sees roughly eight developed-market prices, ticks the box, and stops. The 34 PPP prices that did not get created fail **only** for INR, MYR, THB, PHP, IDR and VND merchants — the six markets least likely to appear in a smoke test, and the ones where `PriceIDFor` (`internal/billing/stripe/update.go:123`) surfaces a Stripe `ErrNotFound` as a generic error rather than "catalog drift".

This matters more now that tesserix-home#396 has shipped and the console can write the catalog to Stripe.

## Changes

- **`internal/billing/pricing/catalog.go`** — package doc rewritten to describe the real shape (6 developed-market Price objects carrying `currency_options` for 7 currencies, plus 36 PPP Price objects, one per currency) and to point at `AllDescriptors()` and the tests as the source of truth, rather than restating a figure that can rot the same way.
- **`docs/.../p20-prod-launch-readiness.md`** — the wrong number appeared in **two** places, not one: B1.8 at line 134 and the go-live checklist at line 543. Both now describe verification by counting `mark8ly_`-prefixed lookup keys, instead of matching a fixed number.
- **`internal/billing/pricing/catalog_test.go`** — adds `TestCatalog_TotalDescriptorCount`.

## Two things found while doing it

**The per-tier tests already existed.** `TestCatalog_DevelopedDescriptorCount` and `TestCatalog_PPPDescriptorCount` were already asserting 6 and 36. So the counts were never untested — the documentation drifted for months while correct tests sat beside it, because nothing ever checked the prose against them. That is why the doc now points at the tests rather than carrying its own number.

**The first draft of the new test reintroduced this issue's own bug.** Its comment justified the test as catching a descriptor *swapped* between tiers — which is false, since the two existing tests already catch that (developed would read 5 and PPP 37, failing both). Corrected in review to state what it genuinely adds: `len(AllDescriptors()) == 42` and `developed + ppp == len(all)`, which together catch a descriptor whose `Tier` is *neither* value and is therefore counted by neither existing loop while both stay green.

A comment asserting something the code does not do, inside the fix for a comment asserting something the code does not do. Recorded rather than quietly corrected, because it is the same shape as #393 and worth noticing as a pattern.

## Verification

- `go build ./...` — clean
- `go vet ./internal/billing/pricing/...` — clean
- `go test ./internal/billing/pricing/... -run . -v` — 32 tests pass
- **Discrimination check:** deleted one PPP descriptor (INR/Starter/Monthly); the new test failed with `expected: 36, actual: 35`; reverted; re-ran green. The test bites rather than merely existing.

## Scope

No behaviour change. `developedAmounts`, `pppAmounts`, `init()` and every descriptor are untouched — this is a counting and documentation correction plus one test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
