### PR TITLE
fix(product): make GORM enforce variant soft-delete so removed variants stop reaching customers (#395)

### DIFF
--- a/.superpowers/sdd/2026-08-28-variant-soft-delete/task-3-report.md
+++ b/.superpowers/sdd/2026-08-28-variant-soft-delete/task-3-report.md
@@ -1,0 +1,200 @@
+# Task 3 — Prove it, at the level that was broken
+
+Service: `services/marketplace-api`. Branch `fix/395-variant-soft-delete`, built on Task 2's
+commit `9b52bf44` (`Variant.DeletedAt` → `gorm.DeletedAt`).
+
+## What was added
+
+New file: `internal/product/repository_variant_softdelete_integration_test.go`
+(`//go:build integration`, gated on `TEST_DATABASE_URL` via `testdb.NewTx`, which runs the test
+inside a transaction that is automatically rolled back on cleanup — no manual row cleanup needed,
+and reruns are idempotent by construction).
+
+`TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants`:
+
+1. Seeds a product (status=active, published in the past, so it's storefront-visible) with two
+   variants: a survivor and one to be removed.
+2. Soft-deletes the second variant through the **real production code path** —
+   `repo.ApplyVariantDiffInTx(..., VariantDiff{Removes: [removedID]})`, i.e.
+   `repository_variants.go`'s Removes branch — not a hand-written `UPDATE`.
+3. Asserts each of the five `Preload("Variants")` sites named in the plan returns only the
+   survivor, as subtests naming each site and, for the two storefront ones, saying so explicitly:
+   - `GetByIDForStore (admin detail)` — `repository.go:209`
+   - `ListAdmin (admin list)` — `repository.go:281`
+   - `ListPublished (storefront — customer-visible)` — `repository.go:351`
+   - `ListPublishedBySlugs (storefront — customer-visible)` — `repository.go:405`
+   - `GetPublishedByHandle (storefront — customer-visible, PDP)` — `repository.go:447`
+4. Asserts the soft-deleted row **still exists** via `tx.Unscoped().Where("id = ?", removedID).First(...)`
+   and that `DeletedAt.Valid` is true — the assertion that distinguishes "filtered" from
+   "destroyed." A fix that hard-deleted the row instead of filtering it would make every assertion
+   in step 3 pass too; this is the one that would catch that.
+5. Re-add path: calls `ApplyVariantDiffInTx` again with `Adds` containing a **new** variant using
+   the **same SKU** as the soft-deleted one. Asserts it succeeds (not `SKUTaken`), that there are
+   now 2 live variants, that the new row has a new UUID (not `removedID`), and via
+   `tx.Unscoped().Model(&Variant{}).Where("store_id = ? AND sku = ?", ...).Count()` that both rows
+   (one soft-deleted, one live) coexist under the same SKU — proving
+   `variants_sku_per_store_live_unique`'s partial index (`WHERE deleted_at IS NULL`) does exactly
+   what Task 1's audit predicted.
+
+Result on the current code (with the fix): **all subtests pass.**
+
+## What I did with `repository_integration_test.go:577`
+
+The brief was correct: this test tolerated the bug. It iterated `got.Variants` and `continue`d
+past any row with `DeletedAt.Valid`, then asserted `live == 2` — so it would pass whether or not
+GORM filtered soft-deleted variants out of the preload, because it filtered them itself in Go
+first.
+
+Rewrote `TestIntegration_ProductRepo_ApplyVariantDiffInTx_AddUpdateRemove`
+(`internal/product/repository_integration_test.go`) to assert `len(got.Variants) == 2` directly
+(no skip-and-count), and to `t.Fatalf` if the soft-deleted `v2ID` shows up in the preload at all.
+Deleted the false "so sanity-check by iterating and ignoring deleted" comment and replaced it with
+one stating the actual invariant: GORM's implicit filter applies to `Variant`, including inside
+Preload. I did not find any reason the skip-and-count pattern was load-bearing for something else
+— nothing downstream of this test cared about the exact count of *all* variants including deleted
+ones, and the whole point of `#395` is that soft-deleted variants shouldn't be countable/visible
+here at all.
+
+## Re-add / partial-index result
+
+**Succeeds, as predicted by Task 1's audit — no defect found.** Re-adding a variant with the same
+SKU as a soft-deleted row inserts a new row with a new UUID; `variants_sku_per_store_live_unique`
+being a partial unique index (`WHERE deleted_at IS NULL`) means the new INSERT never sees the
+surviving soft-deleted row as a conflict. Confirmed both via the `ApplyVariantDiffInTx` call
+returning no error and via a raw `Unscoped()` count showing 2 rows share the SKU afterward (one
+`deleted_at IS NOT NULL`, one live). Not BLOCKED.
+
+## Proof the test fails without the fix
+
+Reverted, ran, captured failure, then fully restored — in that order:
+
+1. Backed up `internal/product/models.go`, `internal/product/service_aggregate.go`, and the new
+   test file to `/tmp/*.bak`.
+2. Edited `models.go`: `Variant.DeletedAt` back to `*time.Time` (marked
+   `// TEMP REVERT FOR TASK 3 PROOF — DO NOT COMMIT.`), removed the now-unused `gorm.io/gorm`
+   import (only used for `gorm.DeletedAt`).
+3. Edited `service_aggregate.go`: reverted both `v.DeletedAt.Valid` call sites (lines 230, 498)
+   back to `v.DeletedAt != nil` via `sed`.
+4. Edited the new test's `stillThere.DeletedAt.Valid` check to `stillThere.DeletedAt == nil` (this
+   one assertion in the "row still exists" subtest has to compile against either type; everything
+   else in the test only compares `.ID`, so it isn't type-dependent).
+5. `go build ./...` → exit 0 (confirms the revert alone compiles).
+6. `go vet -tags=integration ./...` → exit 0.
+7. Ran both the rewritten legacy test and the new test under
+   `TEST_DATABASE_URL=postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable
+   go test -tags=integration -p 1 -count=1 -run 'TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants|TestIntegration_ProductRepo_ApplyVariantDiffInTx_AddUpdateRemove' -v ./internal/product/...`
+
+**Verbatim failure output (reverted state):**
+
+```
+=== RUN   TestIntegration_ProductRepo_ApplyVariantDiffInTx_AddUpdateRemove
+    repository_integration_test.go:575: variants = 3, want 2: [{...SKU:D-3...DeletedAt:<nil>...} {...SKU:D-1...DeletedAt:<nil>...} {...SKU:D-2...DeletedAt:2026-08-28 18:32:29.769109 +1000 AEST...}]
+--- FAIL: TestIntegration_ProductRepo_ApplyVariantDiffInTx_AddUpdateRemove (0.04s)
+=== RUN   TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants
+=== RUN   TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants/GetByIDForStore_(admin_detail)
+    repository_variant_softdelete_integration_test.go:91: GetByIDForStore: variants = 2, want 1: [...LEAK-SURVIVOR...DeletedAt:<nil>...] [...LEAK-REMOVED...DeletedAt:2026-08-28 18:32:29.800256 +1000 AEST...]
+=== RUN   TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants/ListAdmin_(admin_list)
+    repository_variant_softdelete_integration_test.go:110: ListAdmin: variants = 2, want 1: [...same leak...]
+=== RUN   TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants/ListPublished_(storefront_—_customer-visible)
+    repository_variant_softdelete_integration_test.go:132: ListPublished: variants = 2, want 1: [...same leak...]
+=== RUN   TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants/ListPublishedBySlugs_(storefront_—_customer-visible)
+    repository_variant_softdelete_integration_test.go:143: ListPublishedBySlugs: variants = 2, want 1: [...same leak...]
+=== RUN   TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants/GetPublishedByHandle_(storefront_—_customer-visible,_PDP)
+    repository_variant_softdelete_integration_test.go:151: GetPublishedByHandle: variants = 2, want 1: [...same leak...]
+=== RUN   TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants/soft-deleted_row_still_exists_(not_destroyed)
+=== RUN   TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants/re-add_with_same_SKU_as_soft-deleted_variant_succeeds_(partial_index)
+    repository_variant_softdelete_integration_test.go:193: live variants after re-add = 3, want 2: [...LEAK-SURVIVOR... LEAK-REMOVED(soft-deleted)... LEAK-REMOVED(new, live)...]
+--- FAIL: TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants (0.04s)
+    --- FAIL: TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants/GetByIDForStore_(admin_detail) (0.00s)
+    --- FAIL: TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants/ListAdmin_(admin_list) (0.00s)
+    --- FAIL: TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants/ListPublished_(storefront_—_customer-visible) (0.00s)
+    --- FAIL: TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants/ListPublishedBySlugs_(storefront_—_customer-visible) (0.00s)
+    --- FAIL: TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants/GetPublishedByHandle_(storefront_—_customer-visible,_PDP) (0.00s)
+    --- PASS: TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants/soft-deleted_row_still_exists_(not_destroyed) (0.00s)
+    --- FAIL: TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants/re-add_with_same_SKU_as_soft-deleted_variant_succeeds_(partial_index) (0.00s)
+FAIL
+FAIL	github.com/mark8ly/marketplace-api/internal/product	1.223s
+```
+
+(Full untruncated output with complete struct dumps was also captured to `/tmp/revert_failure_output.txt`
+during the run — a local scratch file, not committed.)
+
+Note: the "soft-deleted row still exists" subtest correctly **PASSED** under the reverted type
+too — that assertion tests something GORM's filter change doesn't affect (existence in the table),
+so it's expected to pass in both states. This is exactly why it's a separate assertion from "not
+in the preload": it isolates "destroyed" from "filtered," and only the fix changes the filtered
+behavior.
+
+Also as expected, the re-add subtest failed in the reverted state — not because the insert failed,
+but because the pre-existing bug meant `GetByIDForStore` returned 3 "live" variants (the leaked
+soft-deleted one plus the two real live ones) instead of 2, since nothing filtered the leak. This
+confirms the assertion is actually exercising the fix, not something else.
+
+### Restore
+
+```
+cp /tmp/models.go.bak internal/product/models.go
+cp /tmp/service_aggregate.go.bak internal/product/service_aggregate.go
+cp /tmp/newtest.go.bak internal/product/repository_variant_softdelete_integration_test.go
+```
+
+Confirmed via `diff` against each backup — all three matched exactly (no residual edits). Then:
+
+```
+git diff --stat   # only internal/product/repository_integration_test.go (the intentional edit)
+git status --short
+  M internal/product/repository_integration_test.go
+  ?? internal/product/repository_variant_softdelete_integration_test.go  (untracked, new file)
+go build ./...              → exit 0
+go vet ./...                → exit 0
+go vet -tags=integration ./... → exit 0
+```
+
+## Commands run, with exit codes
+
+| Command | Exit |
+|---|---|
+| `go build ./...` | 0 |
+| `go vet ./...` | 0 |
+| `go vet -tags=integration ./...` | 0 |
+| `go test ./... -count=1` (full non-integration suite, service root) | 0, no `FAIL` lines |
+| `TEST_DATABASE_URL=... go test -tags=integration -p 1 -count=1 ./internal/product/...` | 1 |
+
+The one non-zero exit is `TestIntegration_ProductService_UpdateAggregate_OptionValueInUseRejected`
+(`service_aggregate_test.go:259`, `expected ErrOptionValueInUse, got variant_matrix_mismatch:
+variant count does not match option-value product`). **Confirmed pre-existing and unrelated**: ran
+the same targeted test with my new test file moved out of the package and
+`repository_integration_test.go` stashed back to its pre-Task-3 state (i.e. exactly Task 2's
+commit `9b52bf44`, no Task 3 changes at all) — it fails identically:
+
+```
+--- FAIL: TestIntegration_ProductService_UpdateAggregate_OptionValueInUseRejected (0.06s)
+    service_aggregate_test.go:259: expected ErrOptionValueInUse, got variant_matrix_mismatch: variant count does not match option-value product
+```
+
+This is not one of the three pre-existing failures named in the plan's Global Constraints
+(`internal/billing/trial`, `internal/subscription/planchange`, `internal/whitelabel`), so I'm
+flagging it explicitly here rather than silently absorbing it into "expected failures." It exists
+on the branch before any Task 3 work touched it and is out of scope for this task.
+
+I also started an additional, non-required full-service integration run
+(`go test -tags=integration -p 1 -count=1 ./...` from the service root) purely as extra
+confirmation beyond the task's own verify line. It surfaced two more pre-existing, unrelated
+failures before I killed it early (it was going to run every integration-tagged package in the
+repo and wasn't needed for this task):
+
+- `internal/arbitrage`: `TestAppealService_MarksAuditRowUnderReview` — `value too long for type
+  character varying(100)` on `subscription_arbitrage_audit.mismatch_reason`.
+- `internal/billing/migration`: 4 tests — `column "reviewer_operator_id" of relation
+  "migration_fast_path_reviews" does not exist` — a schema-drift issue (model doesn't match the
+  live migrations for that table).
+
+Neither touches `product_variants`, `Variant`, or anything in `internal/product`. Not caused by
+this change; flagging for completeness, not fixing (out of scope — see plan's Global Constraints,
+"pre-existing failures not yours to fix").
+
+## Concerns
+
+- None regarding correctness of the fix or this test. The one loose end is the
+  `variant_matrix_mismatch` failure above, which is pre-existing but not on the plan's named
+  exclusion list — worth someone filing separately.

--- a/docs/superpowers/plans/2026-08-28-variant-soft-delete.md
+++ b/docs/superpowers/plans/2026-08-28-variant-soft-delete.md
@@ -1,0 +1,89 @@
+# Variant soft-delete leaks through every Preload (#395) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A merchant removes a variant; it is soft-deleted; and it keeps appearing — including on the storefront. Make GORM enforce the filter rather than relying on five call sites to remember it.
+
+**Architecture:** `Variant.DeletedAt` becomes `gorm.DeletedAt`, so GORM's implicit `WHERE deleted_at IS NULL` applies to the model everywhere, including inside `Preload`. Queries that legitimately need to see deleted rows opt out with `Unscoped()`.
+
+**Issue:** [#395](https://github.com/tesserix/mark8ly/issues/395)
+
+---
+
+## Findings that shape this plan
+
+Verified against the code. Three of these change the issue's framing.
+
+**1. The bug is LIVE, not latent.** `internal/product/repository_variants.go:95-97` soft-deletes variants in the sync's "Removes" path: `Update("deleted_at", gorm.Expr("now()"))`. So rows really do get `deleted_at` set whenever a merchant removes a variant from a product.
+
+**2. Five `Preload("Variants")` sites, none filtering.** `internal/product/repository.go:209, 281, 351, 405, 447`. The `deleted_at IS NULL` at `:407` is the *product's*, in the outer `Where` — it does not constrain the preloaded variants. **Two of the five (`:405`, `:447`) are storefront paths** for published products, so this is customer-visible: a removed variant stays purchasable-looking.
+
+**3. It affects `Product` too, but harmlessly.** `gorm.DeletedAt` appears **zero** times as code in `internal/product/models.go` — the one grep hit is a comment. `Product.DeletedAt` (`:75`) is also `*time.Time`. It does not leak, because every product query filters `deleted_at IS NULL` explicitly (`:212, 262, 326, 407, 450, 499`). That is correct today and out of scope — but see the note at the end.
+
+**4. There is no hard-delete disaster.** Deletion is done via explicit `Update("deleted_at", …)` (`repository.go:514-519`, `repository_variants.go:95-97`), never `db.Delete()`. So the missing `gorm.DeletedAt` has not been silently hard-deleting rows. The consequence is only the leak.
+
+**5. Nothing reads the field, and nothing puts it on the wire.** No Go code references `Variant.DeletedAt` as a value, and no frontend reads `deleted_at` from a variant payload. So the type change breaks no reader, and the JSON tag can be dropped rather than reshaped.
+
+---
+
+## Global Constraints
+
+- **No migration.** The `deleted_at` column already exists and is indexed. This is a Go type change. Any DDL means the plan is wrong.
+- **`gorm.DeletedAt` serializes as a struct**, so `json:"deleted_at,omitempty"` would start emitting `{"Time":…,"Valid":false}` on every variant. Use **`json:"-"`** — a deleted-at timestamp has no business on an API response, and finding #5 confirms nothing consumes it.
+- **The dangerous direction is a query that NEEDS to see deleted rows and now silently cannot.** Once the model carries `gorm.DeletedAt`, GORM filters *every* query on `Variant`, not just Preloads. Any code that must see soft-deleted variants has to say `Unscoped()` explicitly. Auditing for those is the load-bearing part of this change — see Task 1.
+- **Do not change `Product.DeletedAt`.** Its manual filters are correct and tested; changing both at once doubles the audit surface for no additional fix.
+- Go: run from the service root, `cd services/marketplace-api && go test ./... -count=1`, never path-scoped. Plus `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`.
+- Integration tests use `//go:build integration`, gate on `TEST_DATABASE_URL`, and run with `-p 1`. Verified DSN: `postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable`.
+- Conventional single-line commit messages, no signature, no `Co-Authored-By` trailer.
+- **Use explicit paths when staging (`git add <path>`), never `git add -A`.**
+- **Pre-existing failures — not yours to fix:** `internal/billing/trial/subscribe_integration_test.go` (19 tests, #317), `internal/subscription/planchange` integration (9 FAIL), `internal/whitelabel` integration (nil-pointer panic).
+
+---
+
+## Tasks
+
+### Task 1 — Audit what must still see deleted variants
+
+Do this BEFORE changing the type. The change is one line; the risk is entirely in what it silently filters out.
+
+- [ ] Enumerate every query touching `product_variants` or the `Variant` model — GORM calls and raw SQL both. Start from `internal/product/repository_variants.go`, `internal/product/repository.go`, `internal/product/service_aggregate.go`, and grep the service for `product_variants`.
+- [ ] For each, decide and record: does it intend to see soft-deleted rows?
+  - The sync's **re-create / revive** path is the one to look hardest at. `service_aggregate.go:218` comments that "UPDATE on `product_variants` doesn't move it" — establish whether re-adding a previously-removed variant is expected to find and revive the soft-deleted row (which would need `Unscoped()`) or to insert a new one. If it looks up by SKU or option-value combination, a unique index may make an insert fail against the surviving soft-deleted row — **that would turn this fix into a new bug**, so settle it here.
+  - `internal/subscription/harddelete/sweeper.go` deletes via FK cascade and raw SQL; confirm it is unaffected.
+- [ ] Write the findings into the report as a table: query, intent, needs `Unscoped()` yes/no.
+
+**Verify:** the table, with a line per call site. This task produces no code.
+
+### Task 2 — Make GORM enforce it
+
+- [ ] `internal/product/models.go:136` — `DeletedAt gorm.DeletedAt` with `gorm:"column:deleted_at;index"` and `json:"-"`.
+- [ ] Replace the existing comment (which documents the bug) with one stating that GORM now filters automatically and that a query needing deleted rows must use `Unscoped()`.
+- [ ] Add `Unscoped()` to exactly the queries Task 1 identified, each with a comment saying why it needs to see deleted rows.
+- [ ] Let the compiler find readers. If anything fails to build against the new type, that is a site that was reading the timestamp — report it rather than coercing it.
+
+**Verify:** `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./... -count=1`.
+
+### Task 3 — Prove it, at the level that was broken
+
+The unit level cannot prove this: the filter is applied by GORM against a real database. This needs an integration test.
+
+- [ ] Add an integration test (`//go:build integration`, `TEST_DATABASE_URL`-gated, cleaned up in a transaction or defer) that:
+  - seeds a product with two variants, soft-deletes one via the real code path (`repository_variants.go`'s remove), and asserts each of the **five** `Preload("Variants")` methods returns only the surviving variant. Name the storefront ones explicitly — they are the customer-visible pair.
+  - asserts the soft-deleted row **still exists** in the table (`Unscoped().Count()` or raw SQL), so the test distinguishes "filtered" from "destroyed". A test that only counts returned variants would pass if the fix accidentally hard-deleted.
+  - covers whatever Task 1 found needs `Unscoped()` — that path must still see the deleted row.
+- [ ] **Prove the test fails without the fix:** revert the type to `*time.Time`, run, capture the failure verbatim, restore.
+
+**Verify:** `go vet -tags=integration ./...`, then `go test -tags=integration -p 1 -count=1 ./internal/product/...`, plus the full suite from the service root.
+
+### Task 4 — Close out
+
+- [ ] Comment on #395 with what shipped, and correct the record on two points: the issue named only `Variant`, and the leak is live rather than theoretical because variants really are soft-deleted on removal.
+- [ ] Note that `Product.DeletedAt` has the same declaration but does not leak, because every product query filters explicitly — and that this is a standing trap: a sixth product query added without the predicate would leak silently, exactly as the variant Preloads did. Worth its own issue rather than a silent fix.
+
+---
+
+## Out of scope
+
+- **`Product.DeletedAt`.** It works today via explicit filters. Changing it belongs in its own change with its own audit.
+- **Cascading product deletion to variants.** `repository.go:514-515` says deliberately: *"Variants carry their own deleted_at for future slices; we do NOT cascade here."* That is a product decision, not a defect.
+- **Any change to what deletion means.** This plan changes what queries *return*, never what they write.

--- a/services/marketplace-api/internal/product/models.go
+++ b/services/marketplace-api/internal/product/models.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
 )
 
 // Status constants match the CHECK constraint in migration 000001.
@@ -130,10 +131,11 @@ type Variant struct {
 	Position          int              `gorm:"column:position;not null;default:0"                       json:"position"`
 	CreatedAt         time.Time        `gorm:"column:created_at;not null;default:now()"                 json:"created_at"`
 	UpdatedAt         time.Time        `gorm:"column:updated_at;not null;default:now()"                 json:"updated_at"`
-	// DeletedAt is a plain *time.Time, not gorm.DeletedAt, so GORM's automatic
-	// soft-delete filtering does NOT apply — every Preload("Variants") returns
-	// deleted rows. See issue #395.
-	DeletedAt *time.Time `gorm:"column:deleted_at;index"                                  json:"deleted_at,omitempty"`
+	// DeletedAt is gorm.DeletedAt, so GORM applies its automatic soft-delete
+	// filter to every query against this model, including inside Preload. A
+	// query that must see soft-deleted variants has to opt out explicitly
+	// with Unscoped().
+	DeletedAt gorm.DeletedAt `gorm:"column:deleted_at;index"                                  json:"-"`
 
 	OptionValueLinks []VariantOptionValue `gorm:"foreignKey:VariantID" json:"option_value_links,omitempty"`
 }

--- a/services/marketplace-api/internal/product/models.go
+++ b/services/marketplace-api/internal/product/models.go
@@ -73,7 +73,15 @@ type Product struct {
 	UpdatedBy       *string          `gorm:"column:updated_by;type:uuid"                              json:"updated_by,omitempty"`
 	CreatedAt       time.Time        `gorm:"column:created_at;not null;default:now()"                 json:"created_at"`
 	UpdatedAt       time.Time        `gorm:"column:updated_at;not null;default:now()"                 json:"updated_at"`
-	DeletedAt       *time.Time       `gorm:"column:deleted_at;index"                                  json:"deleted_at,omitempty"`
+	// DeletedAt is a plain *time.Time, not gorm.DeletedAt, and that is
+	// intentional here: GORM applies no automatic "deleted_at IS NULL"
+	// filter to it. It is safe only because every product query filters
+	// on deleted_at IS NULL explicitly (see repository.go:212, 262, 326,
+	// 407, 450, 499). Do not "fix" this by switching to gorm.DeletedAt
+	// without auditing those call sites, and do not copy this pattern
+	// into a new model — a query that omits the explicit predicate will
+	// silently leak soft-deleted products.
+	DeletedAt *time.Time `gorm:"column:deleted_at;index"                                  json:"deleted_at,omitempty"`
 
 	// Eager-loaded relations (optional; populated via Preload)
 	Options  []Option  `gorm:"foreignKey:ProductID" json:"options,omitempty"`

--- a/services/marketplace-api/internal/product/repository_integration_test.go
+++ b/services/marketplace-api/internal/product/repository_integration_test.go
@@ -569,24 +569,22 @@ func TestIntegration_ProductRepo_ApplyVariantDiffInTx_AddUpdateRemove(t *testing
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	// Soft-deleted v2 should not be preloaded (preload has no deleted filter,
-	// so sanity-check by iterating and ignoring deleted).
-	live := 0
+	// Soft-deleted v2 must be absent from the preload — GORM's implicit
+	// deleted_at filter applies to Variant, including inside Preload.
+	if len(got.Variants) != 2 {
+		t.Fatalf("variants = %d, want 2: %+v", len(got.Variants), got.Variants)
+	}
 	sawV3 := false
 	for _, v := range got.Variants {
-		if v.DeletedAt.Valid {
-			continue
+		if v.ID == v2ID {
+			t.Fatalf("soft-deleted variant v2 leaked into preload")
 		}
-		live++
 		if v.ID == v1ID && !v.Price.Equal(decimal.NewFromInt(15)) {
 			t.Fatalf("v1 price = %s", v.Price.String())
 		}
 		if v.ID == v3ID {
 			sawV3 = true
 		}
-	}
-	if live != 2 {
-		t.Fatalf("live variants = %d, want 2", live)
 	}
 	if !sawV3 {
 		t.Fatalf("v3 not added")

--- a/services/marketplace-api/internal/product/repository_integration_test.go
+++ b/services/marketplace-api/internal/product/repository_integration_test.go
@@ -574,7 +574,7 @@ func TestIntegration_ProductRepo_ApplyVariantDiffInTx_AddUpdateRemove(t *testing
 	live := 0
 	sawV3 := false
 	for _, v := range got.Variants {
-		if v.DeletedAt != nil {
+		if v.DeletedAt.Valid {
 			continue
 		}
 		live++

--- a/services/marketplace-api/internal/product/repository_variant_softdelete_integration_test.go
+++ b/services/marketplace-api/internal/product/repository_variant_softdelete_integration_test.go
@@ -1,0 +1,226 @@
+//go:build integration
+
+package product_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/mark8ly/marketplace-api/internal/product"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants proves the
+// #395 fix: Variant.DeletedAt is gorm.DeletedAt, so GORM applies its
+// implicit `WHERE deleted_at IS NULL` filter to every query against the
+// Variant model, including inside Preload("Variants"). Before the fix
+// (Variant.DeletedAt was *time.Time), none of the five call sites below
+// filtered soft-deleted variants out of the preload.
+//
+// It exercises the real soft-delete code path — ApplyVariantDiffInTx's
+// Removes branch (repository_variants.go) — rather than a hand-written
+// UPDATE, because a fabricated delete would not prove the production
+// delete interacts correctly with the new GORM filter.
+//
+// Covers all five Preload("Variants") sites named in the plan:
+//   - repository.go:209 GetByIDForStore   (admin detail)
+//   - repository.go:281 ListAdmin         (admin list)
+//   - repository.go:351 ListPublished     (storefront — customer-visible)
+//   - repository.go:405 ListPublishedBySlugs (storefront — customer-visible)
+//   - repository.go:447 GetPublishedByHandle  (storefront — customer-visible)
+func TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := product.NewRepository(tx)
+	ctx := context.Background()
+
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	past := time.Now().Add(-1 * time.Hour)
+
+	survivorID := uuid.NewString()
+	removedID := uuid.NewString()
+	removedSKU := "LEAK-REMOVED"
+
+	agg := &product.Aggregate{
+		Product: product.Product{
+			ID:          uuid.NewString(),
+			TenantID:    tenantID,
+			StoreID:     storeID,
+			VendorID:    &vendorID,
+			Handle:      "leak-check",
+			Title:       "Leak Check",
+			Status:      product.StatusActive,
+			PublishedAt: &past,
+		},
+		Variants: []product.Variant{
+			{ID: survivorID, StoreID: storeID, SKU: "LEAK-SURVIVOR", Price: decimal.NewFromInt(10), CurrencyCode: "USD", InventoryPolicy: product.InventoryPolicyDeny},
+			{ID: removedID, StoreID: storeID, SKU: removedSKU, Price: decimal.NewFromInt(20), CurrencyCode: "USD", InventoryPolicy: product.InventoryPolicyDeny},
+		},
+	}
+	if err := repo.CreateAggregateInTx(ctx, tx, agg); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	productID := agg.Product.ID
+
+	// Soft-delete the second variant through the real production path —
+	// ApplyVariantDiffInTx's Removes branch — not a hand-written UPDATE.
+	if err := repo.ApplyVariantDiffInTx(ctx, tx, productID, storeID, product.VariantDiff{
+		Removes: []string{removedID},
+	}); err != nil {
+		t.Fatalf("remove variant via real code path: %v", err)
+	}
+
+	assertOnlySurvivor := func(t *testing.T, label string, variants []product.Variant) {
+		t.Helper()
+		if len(variants) != 1 {
+			t.Fatalf("%s: variants = %d, want 1: %+v", label, len(variants), variants)
+		}
+		if variants[0].ID != survivorID {
+			t.Fatalf("%s: got variant %s, want survivor %s (soft-deleted variant leaked)", label, variants[0].ID, survivorID)
+		}
+	}
+
+	t.Run("GetByIDForStore (admin detail)", func(t *testing.T) {
+		got, err := repo.GetByIDForStore(ctx, productID, storeID, tenantID)
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		assertOnlySurvivor(t, "GetByIDForStore", got.Variants)
+	})
+
+	t.Run("ListAdmin (admin list)", func(t *testing.T) {
+		rows, _, err := repo.ListAdmin(ctx, product.ListAdminQuery{
+			StoreID: storeID, TenantID: tenantID, Page: 1, PageSize: 20,
+		})
+		if err != nil {
+			t.Fatalf("list admin: %v", err)
+		}
+		var found *product.Aggregate
+		for i := range rows {
+			if rows[i].Product.ID == productID {
+				found = &rows[i]
+			}
+		}
+		if found == nil {
+			t.Fatalf("ListAdmin: product not found in results")
+		}
+		assertOnlySurvivor(t, "ListAdmin", found.Variants)
+	})
+
+	// Customer-visible pair — the reason this leak mattered: a removed
+	// variant staying preloaded here means a customer could still see (and
+	// potentially buy) a variant the merchant thought they had deleted.
+	t.Run("ListPublished (storefront — customer-visible)", func(t *testing.T) {
+		rows, err := repo.ListPublished(ctx, product.ListPublishedQuery{
+			StoreID: storeID, Page: 1, PageSize: 20,
+		})
+		if err != nil {
+			t.Fatalf("list published: %v", err)
+		}
+		var found *product.Aggregate
+		for i := range rows {
+			if rows[i].Product.ID == productID {
+				found = &rows[i]
+			}
+		}
+		if found == nil {
+			t.Fatalf("ListPublished: product not found in results")
+		}
+		assertOnlySurvivor(t, "ListPublished", found.Variants)
+	})
+
+	t.Run("ListPublishedBySlugs (storefront — customer-visible)", func(t *testing.T) {
+		rows, err := repo.ListPublishedBySlugs(ctx, storeID, []string{"leak-check"})
+		if err != nil {
+			t.Fatalf("list published by slugs: %v", err)
+		}
+		if len(rows) != 1 {
+			t.Fatalf("ListPublishedBySlugs: rows = %d, want 1", len(rows))
+		}
+		assertOnlySurvivor(t, "ListPublishedBySlugs", rows[0].Variants)
+	})
+
+	t.Run("GetPublishedByHandle (storefront — customer-visible, PDP)", func(t *testing.T) {
+		got, err := repo.GetPublishedByHandle(ctx, storeID, "leak-check")
+		if err != nil {
+			t.Fatalf("get published by handle: %v", err)
+		}
+		assertOnlySurvivor(t, "GetPublishedByHandle", got.Variants)
+	})
+
+	// The assertion that distinguishes "correctly filtered" from
+	// "accidentally hard-deleted": the soft-deleted row must still exist
+	// in the table. Without this, a fix that hard-deleted the row instead
+	// of filtering it would also make every assertion above pass.
+	t.Run("soft-deleted row still exists (not destroyed)", func(t *testing.T) {
+		var stillThere product.Variant
+		err := tx.Unscoped().Where("id = ?", removedID).First(&stillThere).Error
+		if err != nil {
+			t.Fatalf("Unscoped lookup of soft-deleted variant failed: %v (row was destroyed, not filtered)", err)
+		}
+		if !stillThere.DeletedAt.Valid {
+			t.Fatalf("row %s exists but deleted_at is not set", removedID)
+		}
+		if stillThere.SKU != removedSKU {
+			t.Fatalf("SKU = %q, want %q", stillThere.SKU, removedSKU)
+		}
+	})
+
+	// Re-add path (per Task 1's audit): re-adding a variant with the same
+	// SKU as a soft-deleted one must INSERT a new row, not fail against
+	// the surviving soft-deleted row. variants_sku_per_store_live_unique
+	// is a partial index (WHERE deleted_at IS NULL), so it must not
+	// collide. If this fails, the #395 fix introduced a real defect.
+	t.Run("re-add with same SKU as soft-deleted variant succeeds (partial index)", func(t *testing.T) {
+		newID := uuid.NewString()
+		err := repo.ApplyVariantDiffInTx(ctx, tx, productID, storeID, product.VariantDiff{
+			Adds: []product.Variant{
+				{ID: newID, StoreID: storeID, SKU: removedSKU, Price: decimal.NewFromInt(25), CurrencyCode: "USD", InventoryPolicy: product.InventoryPolicyDeny},
+			},
+		})
+		if err != nil {
+			t.Fatalf("BLOCKED: re-adding a variant with a previously-used SKU failed: %v — the partial unique index (variants_sku_per_store_live_unique, WHERE deleted_at IS NULL) should have let this insert succeed alongside the surviving soft-deleted row", err)
+		}
+
+		got, err := repo.GetByIDForStore(ctx, productID, storeID, tenantID)
+		if err != nil {
+			t.Fatalf("get after re-add: %v", err)
+		}
+		if len(got.Variants) != 2 {
+			t.Fatalf("live variants after re-add = %d, want 2: %+v", len(got.Variants), got.Variants)
+		}
+		var newRow *product.Variant
+		for i := range got.Variants {
+			if got.Variants[i].ID == newID {
+				newRow = &got.Variants[i]
+			}
+			if got.Variants[i].ID == removedID {
+				t.Fatalf("soft-deleted variant %s reappeared as live after re-add — a revive happened instead of an insert", removedID)
+			}
+		}
+		if newRow == nil {
+			t.Fatalf("new variant %s not found among live variants", newID)
+		}
+		if newRow.SKU != removedSKU {
+			t.Fatalf("new variant SKU = %q, want %q", newRow.SKU, removedSKU)
+		}
+		if newRow.ID == removedID {
+			t.Fatalf("re-add reused the soft-deleted row's ID — expected a new row with a new UUID")
+		}
+
+		// Confirm both rows (old soft-deleted, new live) exist side by
+		// side under the same SKU — the whole point of the partial index.
+		var count int64
+		if err := tx.Unscoped().Model(&product.Variant{}).
+			Where("store_id = ? AND sku = ?", storeID, removedSKU).
+			Count(&count).Error; err != nil {
+			t.Fatalf("count rows with reused SKU: %v", err)
+		}
+		if count != 2 {
+			t.Fatalf("rows with SKU %q = %d, want 2 (one soft-deleted, one live)", removedSKU, count)
+		}
+	})
+}

--- a/services/marketplace-api/internal/product/repository_variants.go
+++ b/services/marketplace-api/internal/product/repository_variants.go
@@ -77,6 +77,10 @@ func (r *gormRepository) ApplyVariantDiffInTx(ctx context.Context, tx *gorm.DB, 
 			"low_stock_threshold": v.LowStockThreshold,
 			"position":            v.Position,
 		}
+		// The explicit "deleted_at IS NULL" here is now redundant with
+		// Variant's gorm.DeletedAt, which GORM appends automatically for
+		// this model. Left in place deliberately — do not remove as
+		// dead code (see the Removes branch below for why it matters).
 		res := tx.Model(&Variant{}).
 			Where("id = ? AND product_id = ? AND store_id = ? AND deleted_at IS NULL",
 				v.ID, productID, storeID).
@@ -91,6 +95,10 @@ func (r *gormRepository) ApplyVariantDiffInTx(ctx context.Context, tx *gorm.DB, 
 
 	// Removes (soft delete).
 	if len(diff.Removes) > 0 {
+		// Redundant with GORM's automatic filter on gorm.DeletedAt, same
+		// as above — but here it is also load-bearing: without it, a
+		// row already soft-deleted would match and get its deleted_at
+		// re-stamped to now(), overwriting the original deletion time.
 		res := tx.Model(&Variant{}).
 			Where("id IN ? AND product_id = ? AND store_id = ? AND deleted_at IS NULL",
 				diff.Removes, productID, storeID).
@@ -113,6 +121,9 @@ func (r *gormRepository) UpdateVariantBasicsInTx(ctx context.Context, tx *gorm.D
 		return nil
 	}
 	sku, _ := fields["sku"].(string)
+	// Same deliberate redundancy as ApplyVariantDiffInTx above: GORM
+	// already appends "deleted_at IS NULL" for Variant's gorm.DeletedAt,
+	// but the explicit predicate stays for clarity and defense in depth.
 	res := tx.Model(&Variant{}).
 		Where(`id = ? AND product_id = ? AND deleted_at IS NULL AND EXISTS (
 				SELECT 1 FROM products p

--- a/services/marketplace-api/internal/product/service_aggregate.go
+++ b/services/marketplace-api/internal/product/service_aggregate.go
@@ -224,7 +224,10 @@ func (s *Service) UpdateAggregate(ctx context.Context, req UpdateAggregateReques
 			existingByID := make(map[string]Variant, len(existing.Variants))
 			existingBySKU := make(map[string]Variant, len(existing.Variants))
 			for _, v := range existing.Variants {
-				if v.DeletedAt != nil {
+				// GORM now filters soft-deleted variants out of existing.Variants
+				// itself (#395); this check is belt-and-braces, not the primary
+				// guard — do not delete it as dead code.
+				if v.DeletedAt.Valid {
 					continue
 				}
 				existingByID[v.ID] = v
@@ -489,7 +492,10 @@ func (s *Service) applyVariantsDiff(
 	existingByTuple := make(map[string]Variant)
 	existingByID := make(map[string]Variant)
 	for _, v := range existing.Variants {
-		if v.DeletedAt != nil {
+		// GORM now filters soft-deleted variants out of existing.Variants
+		// itself (#395); this check is belt-and-braces, not the primary
+		// guard — do not delete it as dead code.
+		if v.DeletedAt.Valid {
 			continue
 		}
 		existingByID[v.ID] = v


### PR DESCRIPTION
Closes #395.

`Variant.DeletedAt` was declared `*time.Time` rather than `gorm.DeletedAt`, so GORM's implicit `WHERE deleted_at IS NULL` never applied to the model. Five `Preload("Variants")` sites returned soft-deleted variants as if live — **two of them on customer-facing storefront paths for published products** (`repository.go:405`, `:447`).

Variants really are soft-deleted: `repository_variants.go` stamps `deleted_at = now()` when a merchant removes one. So a merchant removed a variant and customers kept seeing it.

## The fix

One line — `DeletedAt gorm.DeletedAt` — plus its consequences. GORM now enforces the filter for every query on the model, including inside `Preload`, rather than five call sites each remembering to.

## What the audit found before the change

The fix is one line; the risk is entirely in what it *silently filters out*. Once the model carries `gorm.DeletedAt`, GORM filters every query on it, and a query that legitimately needed to see a deleted row would stop seeing it with no compile error. So all 15 call sites touching `product_variants` or the `Variant` model were enumerated first:

- **Zero need `Unscoped()`.** The three `Model(&Variant{})` mutation sites already carry an explicit `deleted_at IS NULL`; the hard-delete sweeper and everything outside `internal/product` use raw SQL or `.Table()`.
- **The re-add hazard does not exist.** Re-adding a removed variant inserts a new row with a new UUID — there is no lookup-and-revive path — and `variants_sku_per_store_live_unique` is a **partial** index (`WHERE deleted_at IS NULL`), so the insert cannot collide with the surviving soft-deleted row. The schema already encoded this intent; the Go model just hadn't caught up.

## Three sites were already working around this bug

The compiler surfaced three places reading `DeletedAt` as a value — all of them manual "skip soft-deleted" guards. The test at `repository_integration_test.go:577` said so outright: *"sanity-check by iterating and ignoring deleted"*. Someone hit this leak and routed around it locally rather than fixing the model.

The two production guards were converted to `.Valid` and kept as belt-and-braces, with comments saying they are no longer the primary defence so nobody deletes them as dead code. **The test was not converted** — it tolerated deleted variants, so it would have passed whether or not GORM filtered anything. It now asserts their absence.

## Proving it

The filter is applied by GORM against a real database, so a unit test proves nothing. The new integration test:

- soft-deletes through the **real** `ApplyVariantDiffInTx` remove path, not a hand-written `UPDATE`
- asserts each of the **five** Preload methods individually returns only the survivor — hard count plus identity, not "no variant has DeletedAt set"
- asserts via `Unscoped()` that the soft-deleted row **still exists**, distinguishing "filtered" from "accidentally hard-deleted" — without this, a fix that destroyed the row would pass
- re-adds a variant with the deleted one's SKU and asserts it succeeds, turning the partial-index reasoning into an executable guard
- was confirmed to **fail** without the fix, then restored

## Test plan

- [x] `go build`, `go vet`, `go vet -tags=integration`, `go test ./... -count=1` — all exit 0
- [x] `go test -tags=integration -p 1 -count=1 ./internal/product/...` — the new suite passes; fixtures are transaction-scoped so the shared DB is left clean
- [x] Test verified to fail with the type reverted
- [x] No `Unscoped()` added to production code
- [x] `json:"-"` — `gorm.DeletedAt` is a struct, so `omitempty` would not suppress it and every variant would have started serialising `{"Time":…,"Valid":false}`. Handlers map through explicit DTOs and nothing reads the field on the wire, so it is off the wire entirely.

## Out of scope, deliberately

- **`Product.DeletedAt`** has the identical declaration but does not leak — every product query filters explicitly. Left alone, and now carries a comment explaining why it is safe and what would break that, since the comment documenting this trap previously lived on the `Variant` field and has been replaced.
- **#420**, filed from this review: `internal/wishlist/repository.go:66-67` computes a product's min/max price from `product_variants` with no `deleted_at` filter, so a removed cheap variant still sets the customer-visible "from" price. It is raw SQL, so this model change cannot reach it.

## Note

One pre-existing integration failure is unrelated and not fixed here: `TestIntegration_ProductService_UpdateAggregate_OptionValueInUseRejected` fails with `variant_matrix_mismatch`. Because that is a variant-counting test failing right after a change to which variants load, it was checked against the pre-fix commit in a separate worktree — identical failure, so it predates this work. Worth its own issue; it is not on the repo's known-failures list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jFmanqTbbCYUgqZRGgQT7
