### PR TITLE
docs(notification): recipient_user_id holds customer_profiles.id, not a GIP UID (#350)

### DIFF
--- a/services/marketplace-api/internal/notification/models.go
+++ b/services/marketplace-api/internal/notification/models.go
@@ -35,8 +35,15 @@ type Notification struct {
 	ID       uuid.UUID `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()"`
 	TenantID uuid.UUID `gorm:"column:tenant_id;type:uuid;not null"`
 	StoreID  uuid.UUID `gorm:"column:store_id;type:uuid;not null"`
-	// RecipientUserID, when set, targets a storefront customer (GIP string id)
-	// for the customer notification bell. NULL = store/staff notification.
+	// RecipientUserID, when set, targets a storefront customer by CUSTOMER
+	// PROFILE ID (customer_profiles.id) for the customer notification bell.
+	// NULL = store/staff notification.
+	//
+	// NOT customer_profiles.gip_uid. Both are opaque strings in the same
+	// conceptual role, so the distinction is easy to lose: a GIP UID pasted
+	// into the /admin/notifications recipient_user_id filter matches nothing
+	// and returns an empty 200, which on a governance surface is
+	// indistinguishable from "this customer was never notified" (#350).
 	RecipientUserID *string          `gorm:"column:recipient_user_id;type:varchar(255)"`
 	Type            NotificationType `gorm:"column:type;type:varchar(40);not null"`
 	Title           string           `gorm:"column:title;type:varchar(200);not null"`

--- a/services/marketplace-api/migrations/000091_notifications_recipient_user_id.up.sql
+++ b/services/marketplace-api/migrations/000091_notifications_recipient_user_id.up.sql
@@ -1,5 +1,6 @@
 -- Customer-targeted notifications. When recipient_user_id is set, the
--- notification belongs to a storefront customer (GIP string user id) and
+-- notification belongs to a storefront customer, identified by CUSTOMER
+-- PROFILE ID (customer_profiles.id) — not customer_profiles.gip_uid — and
 -- powers the customer notification bell; when NULL it is the existing
 -- store/staff notification. Nullable so existing rows are unaffected.
 ALTER TABLE notifications ADD COLUMN IF NOT EXISTS recipient_user_id VARCHAR(255);


### PR DESCRIPTION
Closes #350.

## What was actually wrong

Two comments described `notifications.recipient_user_id` as a Google Identity Platform user id. It holds the customer profile UUID. The code was already correct and consistent at both ends — only the prose disagreed:

- **Writer** — `internal/handlers/storefront/webhooks.go:706-713` sets it from `row.CustomerID`, and its own comment says `recipient_user_id = customer profile id`.
- **Reader** — `internal/handlers/storefront/customer_notifications.go:1-4` says the same.

## The issue's own prescribed fix was wrong

#350 says to correct the comments to say `customers.id`, and states that *"`customers` has a separate `gip_uid` column"*. **There is no `customers` table.** Verified two ways:

- Live schema: the `customer%` tables are `customer_addresses`, `customer_erasure_requests`, `customer_loyalties`, `customer_profiles`, `customer_segments`.
- Migrations: the FK is `customer_id UUID NOT NULL REFERENCES customer_profiles(id)` (`migrations/000013_customer_profiles.up.sql:32`).

The correct names are `customer_profiles.id` and `customer_profiles.gip_uid`. Applying the issue verbatim would have replaced one wrong comment with another — which is the exact defect class this issue is about, so it seemed worth catching rather than following.

## Scope

Every file mentioning `recipient_user_id` was enumerated and checked for GIP wording; only these two carried it. Note that a grep requiring "gip" and "recipient_user_id" on the *same line* finds nothing — the wording sits on adjacent lines.

Both comments now name the adjacent `gip_uid` column explicitly and say why the distinction matters: a GIP UID pasted into `/admin/notifications`'s `recipient_user_id` filter matches nothing and returns an empty `200`, which on a governance surface is indistinguishable from "this customer was never notified".

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` — clean
- [x] `TestExpectedSchemaVersionMatchesHighestMigration` passes (verified it is a real PASS, not a skip)
- [x] Confirmed no checksum pinning over migration file contents, so editing an applied migration's comment is safe
- [x] Comment-only: no SQL statement, struct tag, field type, or logic changed. Migration 000091's `ALTER TABLE`/`CREATE INDEX` are byte-identical
