### PR TITLE
fix(tenantpurge): purge email_sends so a tenant purge does not leave customer addresses behind

### DIFF
--- a/services/marketplace-api/internal/tenantpurge/purge.go
+++ b/services/marketplace-api/internal/tenantpurge/purge.go
@@ -381,6 +381,7 @@ func purgePlan(tenantID string, storeIDs []string) []deleteStep {
 		tenantScoped("tax_validation_outage_log", tenantID),   // 000066: tenant_id (nullable)
 		tenantScoped("migration_fast_path_reviews", tenantID), // 000051: tenant_id, store_id
 		tenantScoped("customer_erasure_requests", tenantID),   // 000059: tenant_id, store_id
+		tenantScoped("email_sends", tenantID),                 // 000108: tenant_id (nullable), store_id — holds the customer's address in `recipient`
 		storeScoped("promo_redemptions", storeIDs),            // 000061: store_id only, no tenant_id
 		storeScoped("campaign_email_budget", storeIDs),        // 000047ish: store_id only, no tenant_id
 		storeScoped("store_transactional_counter", storeIDs),  // 000064: store_id only, no tenant_id


### PR DESCRIPTION
## What is wrong

`email_sends` (migration 000108) is tenant-scoped and holds the customer's address in `recipient TEXT NOT NULL`. It has **no step in `purgePlan`** and **no FK to `stores`**, so it is not reached by the group-6 CASCADE either.

A tenant purge therefore leaves every customer email address that tenant ever sent to sitting in the table — including after a purge run with `reason_code = erasure_request`.

## How it surfaced

`TestPurgePlan_CoversEveryTenantScopedTable` exists precisely to catch this, and it does:

```
Should be empty, but was [email_sends]
tenant-scoped tables neither purged, nor cascaded, nor declared an exclusion.
A tenant purge would leave these rows behind.
```

**It had never fired**, because the dev database was pinned at schema version 106 while the migration files had reached 112 — so `email_sends` did not exist locally and the guard had nothing to find. The guard reads the *live* schema by design. Bringing the dev database up to date is what exposed it.

The same table was independently flagged while surveying the data model for #259: *"`email_sends` (migration 000108) has `recipient TEXT NOT NULL` — a direct customer-email column in a table no purge plan covers."* Two routes, same conclusion.

## The fix

One step added to `purgePlan`, in the tenant-scoped group. `email_sends` has no foreign keys, so it carries no ordering constraint.

`tenant_id` is nullable on this table, so a row written without one is not matched by `WHERE tenant_id = ?`. That is the same shape as the neighbouring `tax_validation_outage_log` (000066), and is left consistent with it rather than special-cased here.

## Test plan

Integration runs used `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'` with `-p 1 -count=1`, against a database migrated to 112.

- [x] `./internal/tenantpurge/...` green, including the coverage guard
- [x] **Mutation test:** removing the new step makes the guard fail again with `[email_sends]`; restoring it returns the package to green
- [x] `countPlan` needs no change — it is mechanically derived from `purgePlan`, so the preview and the purge cannot disagree
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean
