### PR TITLE
feat(erasure): execute GDPR art.17 erasure requests (#259)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,13 @@ test-int: ## Run integration tests against the running `make dev` stack
 	@# it is green as of #397 and must keep running so that guard cannot
 	@# silently stop.
 	@#
+	@# ./internal/customererasure/... is included from #259. It was measured
+	@# green against the dev database (schema 113) before being added, which is
+	@# the precondition for widening this list at all. It carries the GDPR
+	@# art.17 schema-coverage guard: a table added later that names a customer
+	@# fails this target rather than silently escaping erasure, so it must keep
+	@# running or the guard stops guarding.
+	@#
 	@# ./internal/campaignbudget/... is the full subtree: the parent package plus
 	@# cron, concurrency and transactional. All four were measured green against
 	@# the dev database on 2026-08-28 when the #399 trial-ramp idempotency guard
@@ -87,6 +94,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	  go test -tags=integration -p 1 \
 	    ./internal/apikeys/... \
 	    ./internal/audit/... \
+	    ./internal/customererasure/... \
 	    ./internal/arbitrage/... \
 	    ./internal/handlers/platformadmin/... \
 	    ./internal/tenantpurge/... \

--- a/docs/superpowers/2026-08-28-259-erasure-design-proposal.md
+++ b/docs/superpowers/2026-08-28-259-erasure-design-proposal.md
@@ -196,3 +196,21 @@ Not a plan, but the shape one would take:
 Live schema queried via `information_schema` (92 tables) plus the full FK graph; migrations read directly; repo-wide greps for retention, anonymisation and `customer_erasure_requests` usage. No tests were run. Claims are marked in the source survey as verified-by-reading, verified-by-query, or inferred; the three items in §4 marked "unclassified" are genuinely unresolved and are flagged rather than guessed.
 
 One environment note found along the way, relevant to anyone testing this: **the dev database is at schema version 106 while the migration files go to 110.** `inbox_action_idempotency` (000107) is therefore absent from it — which is the real cause of the two `internal/handlers/platformadmin` integration failures previously recorded as a "migration gap in the test environment". The gap is that the dev database has not been migrated, not that a migration is missing.
+
+---
+
+## Corrections found during implementation (2026-08-29)
+
+Implementing the plan meant verifying every column against the live schema, which found four errors in the survey above. They are recorded here rather than silently edited, because the survey's method — and where it fell short — is the useful part.
+
+1. **`promo_redemptions` is NOT customer data.** §4 lists it under "Direct — the row names the customer". It is the *subscription* promo-code engine (§7): `promo.Service` writes `normaliseEmail(in.MerchantEmail)` (`internal/promo/service.go:156`) and the row carries `subscription_id NOT NULL`, not an order. Its `email` is the **merchant's billing address**. Anonymising it during a customer erasure would have rewritten a merchant's own billing record. It is now a declared exclusion with that justification.
+
+2. **Four of the five "anonymise via `order_id`" tables have no personal column at all.** `payment_transactions`, `refund_transactions`, `platform_fee_ledger` and `shipments` hold none — their only PII is inside JSONB (`payment_transactions.metadata`, `shipments.ship_from`/`ship_to`), which is out of scope per decision 5. They therefore carry **no erasure step**. They still take the 7-year retention `COMMENT` from migration 000113, because the retention basis applies to the rows regardless.
+
+3. **`returns.pickup_details` is `text`, not JSONB.** §4 lists it among the uninspected blobs. It is a free-text customer pickup address and nullable, so it is **in scope** and is cleared.
+
+4. **Two tables have no name column.** §6.1 groups "`coupon_usage`, `promo_redemptions`, `customer_loyalties`: email → token, name → RedactedName". Only `customer_loyalties` has a name column. `coupon_usage` has only `customer_email`.
+
+Also worth recording, since it changes how the console should think about scoping: `campaign_recipients` has no `store_id` (only `tenant_id` + `campaign_id`, scoped through `campaigns`), and `storefront_push_tokens` / `product_notify_subscriptions` carry `store_slug` rather than `store_id` and have no FK to `customer_profiles`.
+
+**The blocking question in §3 is answered.** `orders.customer_id` is populated only when a logged-in profile is in request context (`internal/handlers/storefront/checkout.go:175-181`); guest checkouts leave it NULL while `customer_email` is `NOT NULL`. Erasure therefore keys on **email**, matching `customer_id` only as a supplementary predicate.

--- a/docs/superpowers/plans/2026-08-28-customer-erasure-executor.md
+++ b/docs/superpowers/plans/2026-08-28-customer-erasure-executor.md
@@ -1,0 +1,510 @@
+# #259 — GDPR erasure execution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `marketplace-api` a mechanism that takes a `customer_erasure_requests` row from `pending` to `completed`, actually erasing the customer's personal data — deleting what serves only the customer, anonymising what must survive for financial-record reasons, and recording what it did.
+
+**Architecture:** Mirrors `internal/tenantpurge`. A **pure** `erasurePlan(storeID, email, token)` function returns an ordered list of steps, each a parameterised statement with a declared disposition (DELETE or ANONYMISE). An executor runs them in one transaction under an advisory lock. A schema-coverage guard fails when a table linking to a customer has no declared disposition, so a table added next year cannot silently escape erasure.
+
+**Tech Stack:** Go 1.26, GORM, Postgres, golang-migrate, testify.
+
+**Spec:** `docs/superpowers/2026-08-28-259-erasure-design-proposal.md` (merged in #432) and GitHub issue tesserix/mark8ly#259. Read the proposal first — it carries the full data-model survey this plan assumes.
+
+## Global Constraints
+
+- Run all Go commands from `services/marketplace-api`, never path-scoped, always `-count=1`.
+- Required command set: `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./... -count=1`.
+- Integration tests: `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'`, `-p 1`. **Without that variable they skip silently and a skip prints `ok`.** Any claim about an integration test must name the DSN. **Use the LAN IP — `localhost:5432` reaches a different Postgres with no `dev` role.**
+- **The dev database is now migrated to 112.** New migration is **000113**, and `ExpectedSchemaVersion` must go 112 → 113 in the same commit.
+- Commits: conventional, single line, no signature, no `Co-Authored-By` trailer, no emoji.
+- Stage with explicit paths (`git add <path>`). Never `git add -A`.
+- **Never log, and never write into a receipt, the subject's email, name, phone or address.** Counts and the request id are the diagnostics. This whole feature exists to remove that data.
+- Work only inside this worktree: `.claude/worktrees/259-erasure-executor`.
+
+## Decisions already made (by the product owner — implement these, do not re-open)
+
+1. **Scope is `(store_id, email)`** — one request, one store. Matches the table's own `UNIQUE (store_id, customer_email)` and the storefront endpoint. Cross-store grouping stays a console concern.
+2. **Erasure keys on `customer_email`, not `customer_id`.** Verified: `orders.customer_id` is set only when a logged-in profile is in context (`internal/handlers/storefront/checkout.go:175-181`), so guests have NULL, while `customer_email` is `NOT NULL`. `customer_id` is a *supplementary* match, never the primary one.
+3. **Financial records are ANONYMISED, retained 7 years, legal-obligation basis** — matching `billing_archive`'s §23.2 window (`migrations/000046:24`). #365 chose that number so the estate has *"ONE retention story to defend rather than two that have to be reconciled"*; this reuses it for the same reason. Covers `orders`, `order_items`, `order_addresses`, `payment_transactions`, `refund_transactions`, `platform_fee_ledger`, `returns`, `shipments`, `coupon_usage`, `promo_redemptions`, `customer_loyalties`, `gift_cards`.
+4. **Reviews are ANONYMISED**, not deleted — deleting retroactively changes a merchant's historical star rating. `review_media` (customer photographs) is deleted.
+5. **JSONB blobs are OUT OF SCOPE**, with the risk recorded and a follow-up issue filed. Nine columns can embed a customer email or address; inspecting and safely key-stripping nine differently-shaped payloads is its own effort, and guessing at their shapes risks corrupting payment metadata.
+
+## Verified findings (do not re-litigate)
+
+1. **Nothing has ever processed a request** — zero `UPDATE` statements against `customer_erasure_requests` anywhere in the repo.
+2. **The status vocabulary in #259 is WRONG.** The issue claims `processing`, `completed` and `failed` "exist in the schema". The real constraint (`migrations/000059:12`) is `CHECK (status IN ('pending', 'processed', 'rejected'))`. There is **no in-flight state**, so Task 1's migration is mandatory, not optional.
+3. **The subject identifier is email only** — the table has `customer_email TEXT NOT NULL` and no `customer_id`, no `gip_uid`.
+4. **`tenantpurge` cannot be reused.** Its coverage of `customer_profiles`, `customer_addresses`, `gift_cards`, `campaigns` and `campaign_recipients` is implicit — those are swept by the group-6 `stores` CASCADE and never named in a step. A per-customer erasure deletes no store, so it gets no CASCADE. **Explicit customer-scoped deletes for those tables do not exist anywhere today.**
+5. **There is no anonymisation precedent in the codebase.** Everything matching `anonymi|redact|scrub|tombstone` is secret-redaction in API responses or log masking; nothing mutates a stored PII column. This plan invents the pattern.
+6. **NOT NULL columns constrain the anonymisation.** `customer_profiles.email`, and `order_addresses.name`, `line1`, `city`, `country_code` are all `NOT NULL` — they must be overwritten with placeholders, not set to NULL. `order_addresses.country_code` is **kept as-is**: it is needed for tax reporting and is not personally identifying on its own.
+7. **The inbox surface already exists and is waiting.** `internal/inbox/erasure.go` lists pending rows and declares `process` (`Destructive: true`) and `reject`; `cmd/marketplace-api/inbox_wiring.go:61-77` registers no executor for the kind, so it answers 501. The wiring comment says they should not get a one-click path *"before the behaviour beneath it is settled"* — this plan settles it.
+8. **The executor interface is fixed:** `Execute(ctx context.Context, item inbox.Item, actionID, operatorID, notes string) (InboxActionResult, error)` (`inbox_actions.go:60`), returning `InboxActionResult{TenantID, StoreID, Status}` (`:40`).
+9. **Idempotency machinery exists and should be reused:** `subscription.WithAdvisoryLock` (`advisory_lock.go:12-17`), and `inbox_action_idempotency` (migration 000107) which the action handler already uses to replay a stored outcome.
+
+## File Structure
+
+- `migrations/000113_customer_erasure_execution.up.sql` / `.down.sql` — status vocabulary, `attempts`, and the retention COMMENTs.
+- `migrations.go` — `ExpectedSchemaVersion` 112 → 113.
+- `internal/customererasure/plan.go` — the pure plan. **The reviewable artefact.**
+- `internal/customererasure/token.go` — the anonymisation token.
+- `internal/customererasure/executor.go` — runs the plan, writes the receipt.
+- `internal/customererasure/models.go` — the request model and status constants.
+- `internal/customererasure/plan_test.go` — pure unit tests, no DB.
+- `internal/customererasure/coverage_integration_test.go` — the schema-coverage guard.
+- `internal/customererasure/executor_integration_test.go` — end-to-end.
+- `internal/handlers/platformadmin/inbox_action_erasure.go` — the inbox executor.
+- `cmd/erasure-worker/main.go` — the console-down path.
+- `Makefile` — add the package to `test-int`.
+
+---
+
+### Task 1: Migration — status vocabulary, attempts, and the retention basis
+
+**Files:**
+- Create: `services/marketplace-api/migrations/000113_customer_erasure_execution.up.sql` / `.down.sql`
+- Modify: `services/marketplace-api/migrations.go`
+
+**Interfaces:**
+- Produces: statuses `processing`, `completed`, `failed` (in addition to the existing `pending`, `processed`, `rejected`); column `attempts INT NOT NULL DEFAULT 0`; documented retention on the financial tables.
+
+- [ ] **Step 1: Write the up migration**
+
+```sql
+-- 000113 — GDPR art.17 erasure EXECUTION (#259).
+--
+-- Two things, both prerequisites for a worker that can actually run.
+--
+-- 1. A state machine. The original CHECK admitted only
+--    ('pending','processed','rejected') — there was no in-flight state at
+--    all, so a worker could not mark a row as being worked on, and a crash
+--    mid-erasure was indistinguishable from one never started. #259
+--    describes 'processing'/'completed'/'failed' as already existing; they
+--    did not. 'processed' is kept as a terminal alias so existing rows stay
+--    valid and no backfill is needed.
+ALTER TABLE customer_erasure_requests
+    DROP CONSTRAINT IF EXISTS customer_erasure_requests_status_check;
+
+ALTER TABLE customer_erasure_requests
+    ADD CONSTRAINT customer_erasure_requests_status_check
+    CHECK (status IN ('pending', 'processing', 'completed', 'failed', 'processed', 'rejected'));
+
+-- attempts bounds retry: a request that fails repeatedly must stop being
+-- retried forever and become visible to an operator instead.
+ALTER TABLE customer_erasure_requests
+    ADD COLUMN IF NOT EXISTS attempts INT NOT NULL DEFAULT 0;
+
+-- 2. The retention basis, written down where it is enforced.
+--    Until now the ONLY retention text in any migration was
+--    billing_archive's (000046). The erasure below ANONYMISES rather than
+--    deletes these tables, and that choice needs its justification recorded
+--    next to the data, not only in a design document.
+COMMENT ON TABLE orders IS
+    'Financial record. Personal fields are anonymised on GDPR art.17 erasure; the row is retained 7 years under legal-obligation basis, matching billing_archive (§23.2). See #259.';
+COMMENT ON TABLE order_addresses IS
+    'Financial record (delivery evidence). Personal fields anonymised on erasure; country_code retained for tax reporting. 7-year legal-obligation retention (§23.2). See #259.';
+COMMENT ON TABLE payment_transactions IS
+    'Financial record. Anonymised, not deleted, on GDPR art.17 erasure; retained 7 years under legal-obligation basis (§23.2). See #259.';
+COMMENT ON TABLE refund_transactions IS
+    'Financial record. Anonymised, not deleted, on GDPR art.17 erasure; retained 7 years under legal-obligation basis (§23.2). See #259.';
+COMMENT ON TABLE platform_fee_ledger IS
+    'Financial record. Anonymised, not deleted, on GDPR art.17 erasure; retained 7 years under legal-obligation basis (§23.2). See #259.';
+```
+
+- [ ] **Step 2: Write the down migration**
+
+```sql
+ALTER TABLE customer_erasure_requests DROP COLUMN IF EXISTS attempts;
+
+-- Rows in a state the old constraint forbids must be normalised before it
+-- can be re-added, otherwise the ALTER fails on real data.
+UPDATE customer_erasure_requests SET status = 'processed' WHERE status = 'completed';
+UPDATE customer_erasure_requests SET status = 'pending'   WHERE status IN ('processing', 'failed');
+
+ALTER TABLE customer_erasure_requests
+    DROP CONSTRAINT IF EXISTS customer_erasure_requests_status_check;
+ALTER TABLE customer_erasure_requests
+    ADD CONSTRAINT customer_erasure_requests_status_check
+    CHECK (status IN ('pending', 'processed', 'rejected'));
+
+COMMENT ON TABLE orders IS NULL;
+COMMENT ON TABLE order_addresses IS NULL;
+COMMENT ON TABLE payment_transactions IS NULL;
+COMMENT ON TABLE refund_transactions IS NULL;
+COMMENT ON TABLE platform_fee_ledger IS NULL;
+```
+
+- [ ] **Step 3: Find the real constraint name first**
+
+The plan guesses `customer_erasure_requests_status_check`. Verify before relying on it:
+
+```bash
+docker exec dev-postgres-1 psql -U dev -d marketplace_db -tAc \
+  "select conname from pg_constraint where conrelid='customer_erasure_requests'::regclass and contype='c'"
+```
+
+If the real name differs, use the real one in both migrations. Do not `DROP CONSTRAINT` a name that does not exist without `IF EXISTS`.
+
+- [ ] **Step 4: Bump the schema version**
+
+`services/marketplace-api/migrations.go`: `ExpectedSchemaVersion` 112 → **113**.
+
+- [ ] **Step 5: Apply and verify**
+
+```bash
+cd services/marketplace-api
+DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' go run ./cmd/migrate up
+DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' go run ./cmd/migrate version
+```
+
+Expected: `version=113 dirty=false`. Then confirm the constraint admits the new values:
+
+```bash
+docker exec dev-postgres-1 psql -U dev -d marketplace_db -tAc \
+  "select pg_get_constraintdef(oid) from pg_constraint where conrelid='customer_erasure_requests'::regclass and contype='c'"
+```
+
+- [ ] **Step 6: Build, vet, migration test, commit**
+
+```bash
+go build ./... && go vet ./... && go vet -tags=integration ./...
+go test . -count=1 -run Migration -v
+```
+
+Expected: `TestExpectedSchemaVersionMatchesHighestMigration` PASS.
+
+```bash
+git add services/marketplace-api/migrations/000113_customer_erasure_execution.up.sql \
+        services/marketplace-api/migrations/000113_customer_erasure_execution.down.sql \
+        services/marketplace-api/migrations.go
+git commit -m "feat(erasure): add the erasure state machine and record the 7-year financial retention basis (#259)"
+```
+
+---
+
+### Task 2: The pure erasure plan and its coverage guard
+
+**Files:**
+- Create: `services/marketplace-api/internal/customererasure/token.go`
+- Create: `services/marketplace-api/internal/customererasure/plan.go`
+- Create: `services/marketplace-api/internal/customererasure/plan_test.go`
+- Create: `services/marketplace-api/internal/customererasure/coverage_integration_test.go`
+
+**Interfaces:**
+- Produces:
+  ```go
+  type Disposition string
+  const (
+      DispositionDelete    Disposition = "delete"
+      DispositionAnonymise Disposition = "anonymise"
+  )
+
+  type Step struct {
+      Table       string
+      Disposition Disposition
+      SQL         string
+      Args        []any
+  }
+
+  func Token(requestID uuid.UUID) string
+  func erasurePlan(storeID uuid.UUID, email string, token string) []Step
+  ```
+  `erasurePlan` is unexported and **pure** — no DB handle, no I/O — so it is unit-testable and the coverage guard can assert against it. Task 3's executor consumes it.
+
+This is the **reviewable artefact**. Get it right before any execution code exists.
+
+- [ ] **Step 1: The anonymisation token**
+
+Create `token.go`:
+
+```go
+package customererasure
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// Token is the value that replaces a subject's email everywhere the row must
+// survive erasure. It is derived from the ERASURE REQUEST ID, not from the
+// email: a hash of the email would still be a pseudonym of the personal data
+// and brute-forceable against a known address list, whereas the request id is
+// unrelated to the person and already exists.
+//
+// Deterministic per request, so two anonymised orders by the same subject
+// still group together — which is what makes the financial record coherent
+// after erasure — while identifying nobody.
+//
+// .invalid is reserved by RFC 2606 and can never be routed, so an anonymised
+// address cannot accidentally receive mail.
+func Token(requestID uuid.UUID) string {
+	return fmt.Sprintf("erased+%s@erased.invalid", requestID.String())
+}
+
+// RedactedName replaces a person's name where the column is NOT NULL.
+const RedactedName = "Erased customer"
+
+// RedactedLine replaces a NOT NULL address line.
+const RedactedLine = "[erased]"
+```
+
+- [ ] **Step 2: The plan**
+
+Create `plan.go`. Every step carries the migration that introduced its table, matching `tenantpurge/purge.go`'s convention. Order matters only where an FK is `RESTRICT`; deletes of leaves come before their parents.
+
+```go
+// Package customererasure executes GDPR art.17 erasure for one customer in
+// one store (#259).
+//
+// Scope is (store_id, email), matching customer_erasure_requests' own
+// UNIQUE (store_id, customer_email). A person with accounts in three stores
+// files three requests; grouping them is a console presentation concern.
+//
+// KEYED ON EMAIL, NOT customer_id. orders.customer_id is set only when a
+// logged-in profile is in context (handlers/storefront/checkout.go:175-181),
+// so guest orders carry NULL, while customer_email is NOT NULL. customer_id
+// is matched as well where present, never instead.
+//
+// TWO DISPOSITIONS. A row that exists only to serve the customer is DELETED.
+// A row that must survive for financial-record reasons is ANONYMISED: its
+// personal fields are overwritten and the row is retained 7 years under
+// legal-obligation basis, matching billing_archive (§23.2, migration 000046)
+// — the same number #365 chose so the estate has one retention story rather
+// than two.
+//
+// OUT OF SCOPE, deliberately: nine JSONB columns can embed a customer email
+// or address (stripe_webhook_events.payload, payment_transactions.metadata,
+// shipments.ship_from/ship_to, returns.pickup_details, and others). None are
+// inspected here — safely key-stripping nine differently-shaped payloads is
+// its own effort and guessing at their shapes risks corrupting payment
+// metadata. Tracked separately; see the package's coverage guard, which
+// records them as known residual PII rather than letting them pass silently.
+package customererasure
+```
+
+Then the plan itself. Build it as `[]Step` in these groups:
+
+**Group 1 — DELETE, customer-only leaves** (order matters: children before parents):
+- `review_reactions` where `customer_profile_id IN (SELECT id FROM customer_profiles WHERE store_id = ? AND email = ?)` — 000017
+- `review_media` where `review_id IN (SELECT id FROM reviews WHERE store_id = ? AND customer_email = ?)` — 000017
+- `wishlists` (via `customer_id IN (SELECT id FROM customer_profiles ...)`) — 000018
+- `customer_addresses` (same subquery) — 000013
+- `abandoned_carts` where `store_id = ? AND customer_email = ?` — 000002
+- `storefront_push_tokens` (via the profile subquery) — 000022
+- `product_notify_subscriptions` (via the profile subquery) — 000023
+- `campaign_recipients` where `customer_email = ?` scoped through `campaigns.store_id` — check the actual FK before writing this one
+- `notifications` where `recipient_user_id IN (SELECT id::text FROM customer_profiles WHERE store_id = ? AND email = ?)` — 000091. **Note `recipient_user_id` is `varchar`, so the subquery must cast.** (Established while fixing #350: this column holds `customer_profiles.id`.)
+- `email_sends` where `store_id = ? AND recipient = ?` — 000108
+
+**Group 2 — ANONYMISE, financial and reputational**:
+- `orders`: `SET customer_email = ?, customer_name = ?, customer_id = NULL WHERE store_id = ? AND customer_email = ?` — 000001
+- `order_addresses`: `SET name = ?, line1 = ?, line2 = NULL, city = ?, region = NULL, postal_code = NULL, phone = NULL WHERE order_id IN (SELECT id FROM orders WHERE store_id = ? AND customer_email = ?)`. **`country_code` is deliberately NOT touched** — it is required for tax reporting and is not identifying on its own.
+- `order_events`: `SET actor_email = ? WHERE actor_email = ? AND order_id IN (...)` — only rows whose actor is the customer
+- `reviews`: `SET customer_email = ?, customer_name = ?, customer_profile_id = NULL WHERE store_id = ? AND customer_email = ?`
+- `review_replies`: `SET author_email = ?, author_name = ? WHERE author_email = ?` — **only where `author_type` marks a customer**; check the column's values first
+- `coupon_usage`, `promo_redemptions`, `customer_loyalties`: email → token, name → RedactedName
+- `gift_cards`: **four roles per row** — `sender_email`, `recipient_email`, `purchased_by_email` and their name columns, plus the free-text `message`. Write one step per role that matches, and null the message where the subject is the sender.
+- `support_tickets` / `tickets` / their reply tables: `submitted_by_email`/`author_email` → token, names → RedactedName, **only where the author is the customer** not staff
+- `payment_transactions`, `refund_transactions`, `platform_fee_ledger`, `returns`, `shipments`: these link via `order_id`; anonymise any directly-held personal column. **Inspect each table's columns first** — several hold personal data only inside JSONB, which is out of scope.
+
+**Group 3 — DELETE last**:
+- `customer_profiles`: `WHERE store_id = ? AND email = ?` — 000013. Last, because groups 1 and 2 reference it by subquery.
+
+**Before writing any step, verify the column exists.** The proposal's survey is good but was not exhaustive on every column. Run:
+```bash
+docker exec dev-postgres-1 psql -U dev -d marketplace_db -c "\d <table>"
+```
+for each table you touch. **If a column the plan names does not exist, STOP and report it — do not invent a substitute.**
+
+- [ ] **Step 3: Pure unit tests**
+
+Create `plan_test.go` (no build tag, no DB). Assert:
+- Every step's SQL is non-empty and every `?` has a matching arg.
+- `customer_profiles` is the **last** step (nothing may reference it afterwards).
+- Every step declares a `Disposition`.
+- No step's SQL contains the raw email as a literal — every use is a bound parameter. (Guards against a future edit interpolating it into the string.)
+- `Token` is deterministic and contains neither the email nor a name.
+
+- [ ] **Step 4: The coverage guard — the most important test in this change**
+
+Create `coverage_integration_test.go` (`//go:build integration`), modelled on `internal/tenantpurge/schema_coverage_integration_test.go`. Read that file first and mirror its shape.
+
+It must: read the **live schema**, find every table with a column that links to a customer (`customer_id`, `customer_email`, `customer_profile_id`, `recipient_user_id`, `author_email`, `submitted_by_email`, `actor_email`, `recipient`, `sender_email`, `purchased_by_email`, `email`), and fail when such a table is neither in the plan nor in a `declaredExclusions` map with a written justification.
+
+Seed the exclusions with the ones already established, each with its reason:
+
+```go
+declaredExclusions := map[string]string{
+	"user_profiles":            "GIP merchant/staff uid, not a customer",
+	"admin_push_tokens":        "staff device tokens",
+	"store_subscriptions":      "merchant billing contact, not a customer",
+	"billing_archive":          "merchant billing record; 7-year legal-obligation retention (§23.2)",
+	"warehouses":               "merchant facility contact",
+	"store_branding":           "merchant support address",
+	"tenant_sso_user_mappings": "merchant SSO identity",
+	"enterprise_api_keys":      "created_by is a merchant user",
+	"audit_logs":               "governance record; operator rows are retained deliberately (#288, #365)",
+	"customer_erasure_requests": "the request itself — its own status is the receipt; retained as evidence the erasure happened",
+	"webhook_events":           "no tenant, store or order column; cannot be scoped. JSONB payload — known residual PII, out of scope (#259)",
+	"stripe_webhook_events":    "JSONB payload only — known residual PII, out of scope (#259)",
+}
+```
+
+**Every exclusion must carry a justification string, and the test must fail if one is empty.** That is what stops the map becoming a place to silence the guard.
+
+- [ ] **Step 5: Run and mutation-test the guard**
+
+```bash
+cd services/marketplace-api
+go test ./internal/customererasure/ -count=1 -v
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/customererasure/ -v
+```
+
+Expected: all pass.
+
+**Mutation test:** delete one step from the plan — say `wishlists`. Re-run the coverage guard.
+Expected: **FAIL**, naming `wishlists`. Restore; confirm pass.
+
+If removing a step does not fail the guard, the guard is not reading what it claims to — STOP and escalate.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/marketplace-api/internal/customererasure/
+git commit -m "feat(erasure): add the pure erasure plan and a schema-coverage guard (#259)"
+```
+
+---
+
+### Task 3: The executor
+
+**Files:**
+- Create: `services/marketplace-api/internal/customererasure/models.go`
+- Create: `services/marketplace-api/internal/customererasure/executor.go`
+- Create: `services/marketplace-api/internal/customererasure/executor_integration_test.go`
+
+**Interfaces:**
+- Consumes: `erasurePlan`, `Token` from Task 2; `subscription.WithAdvisoryLock`.
+- Produces:
+  ```go
+  type Request struct { ID uuid.UUID; TenantID, StoreID uuid.UUID; CustomerEmail string; Status string; Attempts int; ... }
+  func (Request) TableName() string { return "customer_erasure_requests" }
+
+  type Receipt struct { RequestID uuid.UUID; Deleted map[string]int64; Anonymised map[string]int64; RetainedTables []string }
+
+  type Executor struct { DB *gorm.DB; Logger *slog.Logger }
+  func NewExecutor(db *gorm.DB, logger *slog.Logger) (*Executor, error)
+  func (e *Executor) Process(ctx context.Context, requestID uuid.UUID) (Receipt, error)
+  ```
+  `NewExecutor` returns an error on a nil `db` rather than deferring the panic — the pattern #318 established.
+
+- [ ] **Step 1: Status transitions**
+
+`Process` must:
+1. Claim the row: `UPDATE ... SET status='processing', attempts = attempts + 1 WHERE id = ? AND status IN ('pending','failed') RETURNING *`. **The claim is the concurrency control** — if it matches zero rows another worker has it, and `Process` returns a sentinel `ErrAlreadyClaimed`, not an error state.
+2. Run the plan inside `subscription.WithAdvisoryLock(ctx, e.DB, storeID, ...)`, in one transaction, accumulating `RowsAffected` per step.
+3. On success: `status='completed'`, `processed_at=now()`, `notes=<receipt summary>`.
+4. On failure: `status='failed'`, `notes=<error>`, and return the error. **The status write must not be inside the rolled-back transaction** — that is exactly the #397 defect. Write it after the transaction unwinds, on the pooled handle, using `context.WithoutCancel`.
+
+- [ ] **Step 2: The receipt must record what was RETAINED, not only what was destroyed**
+
+`notes` gets a compact JSON summary: per-table counts for deletes and anonymisations, plus the list of tables deliberately retained with their basis. "We erased it" is a claim that may need evidencing; "we retained the order rows under legal-obligation basis, anonymised" is the half that answers a regulator.
+
+**The receipt must not contain the email, name, phone or address.** Counts and table names only.
+
+- [ ] **Step 3: Integration tests**
+
+Create `executor_integration_test.go` (`//go:build integration`). Seed a customer with: a profile, an address, a wishlist, a review with media, an order with an order_address and a payment_transaction, and an `email_sends` row. Then assert after `Process`:
+
+- **Deleted:** profile, address, wishlist, review_media, email_sends row are gone.
+- **Anonymised and PRESENT:** the order still exists, `customer_email` is the token, `customer_name` is redacted, `customer_id` is NULL, but `total`/`currency`/`created_at` are **unchanged** — the financial record survives intact.
+- **`order_addresses.country_code` is unchanged** while `name`/`line1`/`city` are redacted.
+- **The review still exists** with its rating unchanged and its author anonymised.
+- Status is `completed`, `processed_at` is set, `notes` is non-empty and **contains neither the email nor the name**.
+- **Another customer in the same store is untouched** — seed a second customer and assert every one of their rows survives. This is the test that catches an unscoped `WHERE`.
+
+- [ ] **Step 4: Idempotency test**
+
+Run `Process` twice on the same request. The second must not error and must not double-count. Assert the end state is identical.
+
+- [ ] **Step 5: MUTATION TESTS**
+
+- Remove `AND store_id = ?` from the `orders` anonymise step → the "other customer untouched" test must FAIL. Restore.
+- Change the `orders` step from ANONYMISE to a DELETE → the "financial record survives" test must FAIL. Restore.
+- Move the failure-path status write inside the transaction → the failed-status test must FAIL (the status would roll back). Restore.
+
+Report each observation verbatim. If any leaves the suite green, escalate.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/marketplace-api/internal/customererasure/
+git commit -m "feat(erasure): execute a customer erasure request and record what was erased and retained (#259)"
+```
+
+---
+
+### Task 4: Wire it in — inbox action, worker, and the runner
+
+**Files:**
+- Create: `services/marketplace-api/internal/handlers/platformadmin/inbox_action_erasure.go`
+- Modify: `services/marketplace-api/cmd/marketplace-api/inbox_wiring.go`
+- Create: `services/marketplace-api/cmd/erasure-worker/main.go`
+- Modify: `Makefile`
+
+**Interfaces:**
+- Consumes: `Executor.Process` from Task 3; the executor interface at `inbox_actions.go:60`.
+
+- [ ] **Step 1: The inbox executor**
+
+Implement `Kind() string { return inbox.KindErasureRequest }` and `Execute(...)` handling two actions:
+- `process` → `Executor.Process`, returning `InboxActionResult{TenantID, StoreID, Status: "completed"}`.
+- `reject` → sets `status='rejected'` with the operator's `notes`.
+- Any other `actionID` → an explicit error, mirroring `MigrationFastPathExecutor`'s comment: an action added to the provider's declaration but not here must fail loudly, never silently erase.
+
+Map an already-claimed request to `inbox.ErrItemNotFound` so the handler answers 409 "already actioned", exactly as the migration executor does for a second decision.
+
+- [ ] **Step 2: Register it, replacing the 501**
+
+In `inbox_wiring.go`, register the new executor alongside `NewMigrationFastPathExecutor`. **Update the comment** that currently says erasure "should not get a one-click path before the behaviour beneath it is settled" — it is settled now, and leaving that text next to a registered executor would mislead the next reader.
+
+- [ ] **Step 3: The console-down path**
+
+`cmd/erasure-worker/main.go`: a CLI that processes pending requests, so erasure works when the console is unavailable — the coupling test from tesserix-home#160. Model it on an existing `cmd/*-cron` binary. Support `--request-id` for one and `--all` with a bounded batch.
+
+- [ ] **Step 4: Add the package to `test-int`**
+
+Add `./internal/customererasure/... \` to the `test-int` list. **Precondition: the package must be fully green first.** If anything fails, do not add it.
+
+- [ ] **Step 5: Full verification**
+
+```bash
+cd services/marketplace-api
+go build ./... && go vet ./... && go vet -tags=integration ./...
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/customererasure/... ./internal/handlers/platformadmin/... ./internal/tenantpurge/...
+go test ./... -count=1
+```
+
+Expected: all green. `platformadmin`'s two `inbox_action_idempotency` failures are **gone** as of the dev DB reaching version 112 — if you see them, the database is behind; report it rather than dismissing them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/marketplace-api/internal/handlers/platformadmin/inbox_action_erasure.go \
+        services/marketplace-api/cmd/marketplace-api/inbox_wiring.go \
+        services/marketplace-api/cmd/erasure-worker/main.go \
+        Makefile
+git commit -m "feat(erasure): wire the erasure executor into the admin inbox and add a standalone worker (#259)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** #259 asks for four things: a worker/endpoint driving the state machine (Tasks 1, 3, 4), the deletion itself spanning the customer's data while preserving what law requires (Task 2's two dispositions, with the retention basis recorded in Task 1's migration), idempotency (Task 3 Steps 1 and 4), and an audit record of what was deleted and retained (Task 3 Step 2). The console contract is Task 4 Steps 1–3.
+
+**Placeholder scan.** Task 1's migrations and Task 2's token are verbatim. Task 2's plan is deliberately specified as a *table-by-table description with the exact WHERE shapes* rather than 40 literal SQL statements, with an explicit instruction to verify every column against the live schema before writing it and to STOP if one is missing. Writing 40 statements here from a survey that was not exhaustive at column level would manufacture false precision — the verification instruction is the safer specification. Task 3's interfaces are given as exact signatures.
+
+**Type consistency.** `Step`, `Disposition`, `Token`, `erasurePlan`, `Request`, `Receipt`, `Executor.Process` are declared once in the Interfaces blocks and used consistently. `erasurePlan` stays unexported; only the coverage guard and the executor (same package) call it.

--- a/services/marketplace-api/cmd/erasure-worker/main.go
+++ b/services/marketplace-api/cmd/erasure-worker/main.go
@@ -1,0 +1,153 @@
+// Command erasure-worker runs GDPR art.17 customer erasures without the
+// console (#259).
+//
+// It exists because the console must not be the only way to satisfy a
+// statutory obligation. GDPR's response window keeps running while
+// platform-admin is down, mid-deploy, or unreachable to whoever is on call,
+// and "we could not reach our own admin UI" is not a defence a regulator
+// accepts. This binary needs nothing but DATABASE_URL.
+//
+// Usage:
+//
+//	erasure-worker --request-id <uuid>   process exactly one request
+//	erasure-worker --all [--limit N]     process the pending queue, bounded
+//
+// One of the two is REQUIRED. There is no default mode: a binary that erases
+// customer data when run with no arguments is a mistake waiting to be made,
+// and a no-argument invocation is far more likely to be a typo than an
+// instruction to destroy every pending subject's data.
+//
+// Exit codes: 0 when every request attempted completed (a run that finds
+// nothing pending is a normal, successful run); 1 on a usage or
+// infrastructure failure; 2 when at least one erasure failed — those rows are
+// left in 'failed' with a PII-free note and are claimable again on the next
+// run.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/customererasure"
+	"github.com/mark8ly/marketplace-api/pkg/db"
+)
+
+// defaultLimit bounds --all. An erasure is irreversible and holds a
+// per-store advisory lock, so a run that swept an unbounded queue would be
+// both a long lock hold and a large blast radius from one command. Raise it
+// deliberately with --limit.
+const defaultLimit = 50
+
+// runTimeout bounds the whole run. Each erasure is one transaction over a
+// couple of dozen statements; a run that has not finished in this long is
+// stuck on a lock, and failing loudly beats holding it longer.
+const runTimeout = 10 * time.Minute
+
+const (
+	exitUsageOrInfra = 1
+	exitErasureFail  = 2
+)
+
+func main() {
+	var (
+		requestID = flag.String("request-id", "", "process exactly one erasure request by id")
+		all       = flag.Bool("all", false, "process pending erasure requests, oldest first")
+		limit     = flag.Int("limit", defaultLimit, "maximum requests to process with --all")
+	)
+	flag.Parse()
+
+	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	one, sweep := *requestID != "", *all
+	if one == sweep {
+		log.Error("erasure-worker: pass exactly one of --request-id or --all")
+		os.Exit(exitUsageOrInfra)
+	}
+	if *all && *limit <= 0 {
+		log.Error("erasure-worker: --limit must be positive")
+		os.Exit(exitUsageOrInfra)
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		log.Error("erasure-worker: DATABASE_URL not set")
+		os.Exit(exitUsageOrInfra)
+	}
+	conn, err := db.Open(databaseURL)
+	if err != nil {
+		log.Error("erasure-worker: db open failed", "err", err)
+		os.Exit(exitUsageOrInfra)
+	}
+
+	executor, err := customererasure.NewExecutor(conn, log)
+	if err != nil {
+		log.Error("erasure-worker: executor could not be built", "err", err)
+		os.Exit(exitUsageOrInfra)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), runTimeout)
+	defer cancel()
+
+	ids, err := targets(ctx, executor, *requestID, *all, *limit)
+	if err != nil {
+		log.Error("erasure-worker: could not determine what to process", "err", err)
+		os.Exit(exitUsageOrInfra)
+	}
+
+	var completed, skipped, failed int
+	for _, id := range ids {
+		receipt, err := executor.Process(ctx, id)
+		switch {
+		case err == nil:
+			completed++
+			// Counts and table names only — never the subject's address.
+			log.Info("erasure-worker: request completed",
+				"request_id", id.String(),
+				"deleted_tables", len(receipt.Deleted),
+				"anonymised_tables", len(receipt.Anonymised),
+				"retained_tables", len(receipt.RetainedTables))
+		case errors.Is(err, customererasure.ErrAlreadyClaimed):
+			// Another worker, or an operator in the console, got there first.
+			// Not a failure: the request is somebody's, just not ours.
+			skipped++
+			log.Info("erasure-worker: request already claimed elsewhere", "request_id", id.String())
+		case errors.Is(err, customererasure.ErrRequestNotFound):
+			// Only reachable via --request-id; --all reads live ids.
+			failed++
+			log.Error("erasure-worker: no such erasure request", "request_id", id.String())
+		default:
+			// The row is now 'failed' with a PII-free note, written by the
+			// executor OUTSIDE the rolled-back transaction, and is claimable
+			// again on the next run.
+			failed++
+			log.Error("erasure-worker: request failed", "request_id", id.String(), "err", err)
+		}
+	}
+
+	log.Info("erasure-worker: done", "completed", completed, "skipped", skipped, "failed", failed)
+	if failed > 0 {
+		os.Exit(exitErasureFail)
+	}
+}
+
+// targets resolves the flags into the ids to attempt. --request-id does NOT
+// consult the queue: an operator naming a specific request usually wants one
+// the queue would not have offered — a 'failed' retry, or a row somebody else
+// left in a strange state — and silently doing nothing would be the worst
+// answer to an explicit instruction.
+func targets(ctx context.Context, e *customererasure.Executor, requestID string, all bool, limit int) ([]uuid.UUID, error) {
+	if !all {
+		id, err := uuid.Parse(requestID)
+		if err != nil {
+			return nil, err
+		}
+		return []uuid.UUID{id}, nil
+	}
+	return e.PendingIDs(ctx, limit)
+}

--- a/services/marketplace-api/cmd/marketplace-api/inbox_wiring.go
+++ b/services/marketplace-api/cmd/marketplace-api/inbox_wiring.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"log/slog"
+
 	"gorm.io/gorm"
 
+	"github.com/mark8ly/marketplace-api/internal/customererasure"
 	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
 	"github.com/mark8ly/marketplace-api/internal/inbox"
 )
@@ -60,19 +63,58 @@ func inboxItemSource(agg *inbox.Aggregator) platformadmin.InboxItemSource {
 
 // inboxActionExecutors lists the kinds that can actually be acted on.
 //
-// Only migration_fast_path today. Every other kind is readable but not
-// actionable and answers 501 — deliberately, not as an oversight:
-// sea_manual_review's underlying SEA support is only partially implemented,
-// and erasure_request's `process` action is irreversible destruction of
-// customer data. Neither should get a one-click path before the behaviour
-// beneath it is settled.
-func inboxActionExecutors(reviews platformadmin.MigrationFastPathReviewer) []platformadmin.InboxActionExecutor {
-	if reviews == nil {
+// migration_fast_path and erasure_request. sea_manual_review and the rest are
+// readable but not actionable and answer 501 — deliberately, not as an
+// oversight: SEA's underlying support is only partially implemented, and
+// wiring a one-click approve into half-built behaviour is worse than an
+// honest "not implemented".
+//
+// erasure_request USED to be in that list, on the grounds that its `process`
+// action is irreversible destruction of customer data and should not get a
+// one-click path "before the behaviour beneath it is settled". #259 settled
+// it: internal/customererasure now runs a reviewed, store-scoped plan in one
+// transaction, writes a receipt of what it destroyed AND what it retained,
+// and refuses a request another worker holds. The 501 was the honest answer
+// while nothing existed underneath; it would be a misleading one now.
+//
+// Each executor is registered only when its dependency exists, for the same
+// reason the providers above are: an executor holding a nil dependency does
+// not degrade, it panics on the first click.
+func inboxActionExecutors(
+	reviews platformadmin.MigrationFastPathReviewer,
+	eraser platformadmin.CustomerEraser,
+) []platformadmin.InboxActionExecutor {
+	var executors []platformadmin.InboxActionExecutor
+	if reviews != nil {
+		executors = append(executors, platformadmin.NewMigrationFastPathExecutor(reviews))
+	}
+	// Typed-nil trap, as with funnel above: eraser is an interface, so a nil
+	// *customererasure.Executor stored in it would NOT be == nil here.
+	// newCustomerEraser returns an untyped nil interface for that reason.
+	if eraser != nil {
+		executors = append(executors, platformadmin.NewErasureExecutor(eraser))
+	}
+	if len(executors) == 0 {
 		return nil
 	}
-	return []platformadmin.InboxActionExecutor{
-		platformadmin.NewMigrationFastPathExecutor(reviews),
+	return executors
+}
+
+// newCustomerEraser builds the erasure executor, or an untyped nil interface
+// when there is no database to erase from.
+//
+// The error from NewExecutor is not swallowed into a nil: a nil db is a
+// WIRING bug, and this returning nil silently would turn it into a 501 that
+// reads as a deliberate product decision rather than a broken deployment.
+func newCustomerEraser(db *gorm.DB, logger *slog.Logger) (platformadmin.CustomerEraser, error) {
+	if db == nil {
+		return nil, nil
 	}
+	eraser, err := customererasure.NewExecutor(db, logger)
+	if err != nil {
+		return nil, err
+	}
+	return eraser, nil
 }
 
 // inboxDep converts the aggregator to the interface Deps expects, preserving

--- a/services/marketplace-api/cmd/marketplace-api/inbox_wiring_test.go
+++ b/services/marketplace-api/cmd/marketplace-api/inbox_wiring_test.go
@@ -5,9 +5,13 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
+	"github.com/mark8ly/marketplace-api/internal/billing/migration"
+	"github.com/mark8ly/marketplace-api/internal/customererasure"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
 	"github.com/mark8ly/marketplace-api/internal/inbox"
 	"github.com/mark8ly/marketplace-api/internal/onboardingfunnel"
 )
@@ -70,4 +74,59 @@ func TestNewInboxAggregatorCoversEveryAdvertisedKind(t *testing.T) {
 		require.Truef(t, kindIsRegistered(t, agg, kind),
 			"kind %q is advertised by the handler but not registered by the wiring", kind)
 	}
+}
+
+// stubEraser stands in for *customererasure.Executor. inboxActionExecutors
+// only needs to know whether it is nil.
+type stubEraser struct{}
+
+func (stubEraser) Process(context.Context, uuid.UUID) (customererasure.Receipt, error) {
+	return customererasure.Receipt{}, nil
+}
+func (stubEraser) Reject(context.Context, uuid.UUID, string) (customererasure.Request, error) {
+	return customererasure.Request{}, nil
+}
+func (stubEraser) Lookup(context.Context, uuid.UUID) (customererasure.Request, error) {
+	return customererasure.Request{}, nil
+}
+
+func executorKinds(executors []platformadmin.InboxActionExecutor) []string {
+	kinds := make([]string, 0, len(executors))
+	for _, e := range executors {
+		kinds = append(kinds, e.Kind())
+	}
+	return kinds
+}
+
+// #259: erasure_request used to answer 501 because no executor was wired for
+// it. This is the assertion that the 501 is genuinely replaced rather than
+// merely implemented somewhere unreachable — an executor that exists but is
+// never registered leaves the endpoint exactly as it was.
+func TestInboxActionExecutorsRegistersErasure(t *testing.T) {
+	executors := inboxActionExecutors(&migration.Repository{}, stubEraser{})
+	require.Contains(t, executorKinds(executors), inbox.KindErasureRequest,
+		"the erasure executor must be registered, or /admin/inbox/erasure_request/... still answers 501")
+	require.Contains(t, executorKinds(executors), inbox.KindMigrationFastPath,
+		"adding erasure must not displace the migration fast path")
+}
+
+// Each executor is registered only when its own dependency exists. A missing
+// eraser must not take the migration action down with it, and vice versa.
+func TestInboxActionExecutorsRegistersOnlyWhatItCanReach(t *testing.T) {
+	require.Equal(t, []string{inbox.KindMigrationFastPath},
+		executorKinds(inboxActionExecutors(&migration.Repository{}, nil)))
+	require.Equal(t, []string{inbox.KindErasureRequest},
+		executorKinds(inboxActionExecutors(nil, stubEraser{})))
+	require.Nil(t, inboxActionExecutors(nil, nil),
+		"nothing reachable means no executors, so every kind keeps its honest 501")
+}
+
+// newCustomerEraser must not hand back a non-nil INTERFACE holding a nil
+// pointer: that would pass inboxActionExecutors' nil check and register an
+// executor that panics on the first click.
+func TestNewCustomerEraserReturnsAnUntypedNilWithoutADatabase(t *testing.T) {
+	eraser, err := newCustomerEraser(nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, eraser)
+	require.Nil(t, inboxActionExecutors(nil, eraser))
 }

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -534,6 +534,11 @@ func main() {
 	// inbox action executor (#281a) is built in both engine-switch cases
 	// below, outside the admin wiring branch that constructs it.
 	var migrationRepo *migration.Repository
+	// customerEraser is hoisted for the same reason: the erasure inbox action
+	// (#259) is built in both engine-switch cases below. It is an INTERFACE,
+	// not a *customererasure.Executor, so the "no database" case stays an
+	// untyped nil that inboxActionExecutors can actually test.
+	var customerEraser platformadmin.CustomerEraser
 	// downgradeCron is non-nil only when STRIPE_BILLING_SECRET_KEY is set.
 	// Declared at func scope so the cron-start block below the admin-mode
 	// block can reference it.
@@ -1047,6 +1052,16 @@ func main() {
 
 		// P5 — Migration fast-path submit handler.
 		migrationRepo = migration.NewRepository(conn)
+
+		// #259 — the erasure inbox action. A construction failure is a wiring
+		// bug and is fatal: degrading to a 501 here would present a broken
+		// deployment as a deliberate "not implemented", which is exactly the
+		// misreading this action was added to remove.
+		customerEraser, err = newCustomerEraser(conn, log)
+		if err != nil {
+			log.Error("marketplace-api: customer erasure executor could not be built", "err", err)
+			os.Exit(1)
+		}
 		migrationHandler = migration.NewHandler(migrationRepo, migration.NoOpValidator{}, log).WithAudit(auditEmitter)
 
 		// P8 — Arbitrage appeal handler (§18.8.1).
@@ -2144,7 +2159,7 @@ func main() {
 			Purger:                tenantpurge.NewGormPurger(conn),
 			Inbox:                 inboxDep(newInboxAggregator(conn, onboardingFunnelClient, 0)),
 			InboxItems:            inboxItemSource(newInboxAggregator(conn, onboardingFunnelClient, 0)),
-			InboxActionExecutors:  inboxActionExecutors(migrationRepo),
+			InboxActionExecutors:  inboxActionExecutors(migrationRepo, customerEraser),
 			EstateUsers:           estateUsersClient,
 			EmailSends:            platformadmin.EmailSendListerFunc(emaillog.ListPlatform),
 			BreakGlass:            platformadmin.BreakGlassListerFunc(breakglass.ListPlatform),
@@ -2289,7 +2304,7 @@ func main() {
 				Purger:                tenantpurge.NewGormPurger(conn),
 				Inbox:                 inboxDep(newInboxAggregator(conn, onboardingFunnelClient, 0)),
 				InboxItems:            inboxItemSource(newInboxAggregator(conn, onboardingFunnelClient, 0)),
-				InboxActionExecutors:  inboxActionExecutors(migrationRepo),
+				InboxActionExecutors:  inboxActionExecutors(migrationRepo, customerEraser),
 				EstateUsers:           estateUsersClient,
 				EmailSends:            platformadmin.EmailSendListerFunc(emaillog.ListPlatform),
 				BreakGlass:            platformadmin.BreakGlassListerFunc(breakglass.ListPlatform),

--- a/services/marketplace-api/internal/customererasure/coverage_integration_test.go
+++ b/services/marketplace-api/internal/customererasure/coverage_integration_test.go
@@ -53,6 +53,7 @@ var declaredExclusions = map[string]string{
 	"store_subscriptions":       "merchant billing contact, not a customer",
 	"warehouses":                "merchant facility contact, not a customer",
 	"tenant_sso_user_mappings":  "merchant SSO identity, not a customer",
+	"promo_redemptions":         "subscription promo-code redemption (§7). Its `email` is the MERCHANT's billing address — promo.Service writes normaliseEmail(in.MerchantEmail) (internal/promo/service.go:156) and the row references a subscription_id, not an order. Anonymising it during a customer erasure would rewrite a merchant's own billing record",
 	"audit_logs":                "governance record; operator rows are retained deliberately under their own retention path (#288, #365). Its actor_email is an operator, and its metadata JSONB is known residual PII, out of scope (#259)",
 	"customer_erasure_requests": "the request itself — its own status and receipt are the evidence the erasure happened, and destroying it would destroy the proof",
 }

--- a/services/marketplace-api/internal/customererasure/coverage_integration_test.go
+++ b/services/marketplace-api/internal/customererasure/coverage_integration_test.go
@@ -1,0 +1,177 @@
+//go:build integration
+
+// This file is in the INTERNAL package (unlike marketplace-api's other
+// integration tests, which are external `_test` packages) because it
+// asserts against erasurePlan, which is unexported by design — the plan is
+// an implementation detail everywhere except here.
+package customererasure
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// customerLinkColumns are the column names by which a row names a customer.
+// A table carrying any of them holds data attributable to one person and
+// must therefore have a declared disposition.
+//
+// It reads the LIVE schema rather than the migrations, because the
+// migrations are what the plan was derived from and re-reading them would
+// only re-derive the same answer.
+var customerLinkColumns = []string{
+	"customer_id",
+	"customer_email",
+	"customer_profile_id",
+	"recipient_user_id",
+	"author_email",
+	"submitted_by_email",
+	"actor_email",
+	"recipient",
+	"sender_email",
+	"recipient_email",
+	"purchased_by_email",
+	"email",
+}
+
+// declaredExclusions are tables that carry a customer-link column but are
+// deliberately NOT erased. Each value is the justification, and it is a
+// DECISION about a person's data surviving their own erasure request — the
+// test below exists to make that decision explicit rather than accidental.
+//
+// This map is the only way to silence the guard, so it is deliberately
+// expensive to abuse: an empty justification fails the test, and so does an
+// entry the guard would never have flagged in the first place. It cannot
+// quietly accumulate dead weight.
+var declaredExclusions = map[string]string{
+	"user_profiles":             "GIP merchant/staff uid — a store's operators, not its customers",
+	"store_subscriptions":       "merchant billing contact, not a customer",
+	"warehouses":                "merchant facility contact, not a customer",
+	"tenant_sso_user_mappings":  "merchant SSO identity, not a customer",
+	"audit_logs":                "governance record; operator rows are retained deliberately under their own retention path (#288, #365). Its actor_email is an operator, and its metadata JSONB is known residual PII, out of scope (#259)",
+	"customer_erasure_requests": "the request itself — its own status and receipt are the evidence the erasure happened, and destroying it would destroy the proof",
+}
+
+// TestErasurePlan_CoversEveryCustomerLinkedTable fails when a table exists
+// that names a customer and that the plan neither erases nor declares as a
+// deliberate exclusion. A table added next year cannot silently escape
+// erasure.
+func TestErasurePlan_CoversEveryCustomerLinkedTable(t *testing.T) {
+	db := testdb.NewDB(t)
+	require.Empty(t, uncoveredCustomerLinkedTables(t, db),
+		"tables naming a customer that the erasure plan neither deletes nor anonymises nor declares an exclusion.\n"+
+			"A GDPR art.17 erasure would leave this person's data behind. Either add a step to erasurePlan or add the "+
+			"table to declaredExclusions WITH a justification.")
+}
+
+// TestDeclaredExclusions_AreJustifiedAndLive keeps the escape hatch honest.
+// An exclusion with no reason is a silenced guard; an exclusion for a table
+// the guard would never flag is dead weight that makes the map look more
+// considered than it is.
+func TestDeclaredExclusions_AreJustifiedAndLive(t *testing.T) {
+	db := testdb.NewDB(t)
+	linked := customerLinkedTables(t, db)
+	planned := plannedTables()
+
+	for table, justification := range declaredExclusions {
+		require.NotEmpty(t, justification,
+			"exclusion %q has no justification — excluding a table from GDPR erasure requires a written reason", table)
+		require.Contains(t, linked, table,
+			"exclusion %q names no customer-link column, so the guard would never flag it; remove the entry", table)
+		require.NotContains(t, planned, table,
+			"exclusion %q is also covered by the plan; an entry that excludes nothing is misleading", table)
+	}
+}
+
+// uncoveredCustomerLinkedTables is the guard's computation, extracted so the
+// test above and the probe test below run the SAME code — one asserting it
+// finds nothing, the other asserting it finds a table planted for it.
+func uncoveredCustomerLinkedTables(t *testing.T, db *gorm.DB) []string {
+	t.Helper()
+
+	planned := plannedTables()
+	uncovered := make([]string, 0, 4)
+	for _, table := range customerLinkedTables(t, db) {
+		if planned[table] {
+			continue
+		}
+		if _, excluded := declaredExclusions[table]; excluded {
+			continue
+		}
+		uncovered = append(uncovered, table)
+	}
+	sort.Strings(uncovered)
+	return uncovered
+}
+
+// plannedTables is the set of tables the plan writes to. It is derived from
+// erasurePlan itself, not from a hand-maintained list, so the guard and the
+// erasure can never enumerate different sets of tables.
+func plannedTables() map[string]bool {
+	planned := map[string]bool{}
+	for _, s := range erasurePlan(uuid.New(), "guard@example.test", Token(uuid.New())) {
+		planned[s.Table] = true
+	}
+	return planned
+}
+
+// customerLinkedTables reads the live schema for every base table carrying a
+// column by which a row names a customer.
+func customerLinkedTables(t *testing.T, db *gorm.DB) []string {
+	t.Helper()
+
+	var names []string
+	require.NoError(t, db.Raw(`
+		SELECT DISTINCT c.table_name
+		FROM information_schema.columns c
+		JOIN information_schema.tables tb
+		  ON tb.table_schema = c.table_schema AND tb.table_name = c.table_name
+		WHERE c.table_schema = 'public'
+		  AND tb.table_type = 'BASE TABLE'
+		  AND c.column_name IN (?)
+		ORDER BY c.table_name`, customerLinkColumns).Scan(&names).Error)
+	require.NotEmpty(t, names, "found no customer-linked tables at all — the guard would pass vacuously")
+	return names
+}
+
+// The guard is only worth having if it can fail. This runs the SAME
+// computation against a deliberately-uncovered table and asserts it is
+// reported.
+//
+// Asserting instead that information_schema can see the probe table would be
+// a test of information_schema, not of the guard: a coverage function that
+// returned "everything is covered" unconditionally would pass it.
+func TestErasurePlan_CoverageGuardDetectsAnUncoveredTable(t *testing.T) {
+	db := testdb.NewDB(t)
+
+	require.NoError(t, db.Exec(`CREATE TABLE IF NOT EXISTS customererasure_guard_probe (
+		id uuid PRIMARY KEY DEFAULT gen_random_uuid(), customer_email varchar(300) NOT NULL)`).Error)
+	t.Cleanup(func() { _ = db.Exec(`DROP TABLE IF EXISTS customererasure_guard_probe`).Error })
+
+	require.Contains(t, uncoveredCustomerLinkedTables(t, db), "customererasure_guard_probe",
+		"a table naming a customer that the plan neither erases nor excludes must be reported")
+}
+
+// TestErasurePlan_EveryStepIsValidSQLAgainstTheLiveSchema executes the whole
+// plan against a real database inside a transaction that is rolled back. It
+// asserts nothing about row counts — that is the executor's test. What it
+// catches is the failure the pure tests cannot see: a column that does not
+// exist, a table renamed under the plan, a cast Postgres refuses. The plan
+// matches a store and an email that exist nowhere, so every statement
+// affects zero rows and the rollback makes even that moot.
+func TestErasurePlan_EveryStepIsValidSQLAgainstTheLiveSchema(t *testing.T) {
+	db := testdb.NewTx(t)
+
+	steps := erasurePlan(uuid.New(), "no-such-subject@erasure.test", Token(uuid.New()))
+	require.NotEmpty(t, steps)
+
+	for i, s := range steps {
+		require.NoError(t, db.Exec(s.SQL, s.Args...).Error,
+			"step %d (%s, %s) is not executable against the live schema", i, s.Table, s.Disposition)
+	}
+}

--- a/services/marketplace-api/internal/customererasure/executor.go
+++ b/services/marketplace-api/internal/customererasure/executor.go
@@ -1,0 +1,374 @@
+package customererasure
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// StepError is what a failed statement reports.
+//
+// IT DELIBERATELY DISCARDS THE DRIVER'S MESSAGE. A Postgres constraint or
+// type error embeds the offending VALUE — here, the subject's email address —
+// and this error is written into the request's notes column and handed to a
+// logger. Carrying the driver text would put the address back into the audit
+// trail the erasure exists to clear. The SQLSTATE is the actionable half and
+// is PII-free, so that is what survives.
+type StepError struct {
+	Table       string
+	Disposition Disposition
+	// SQLState is the Postgres error code, or "" when the failure did not
+	// come from Postgres (a cancelled context, say).
+	SQLState string
+}
+
+func (e *StepError) Error() string {
+	if e.SQLState == "" {
+		return fmt.Sprintf("customererasure: %s step on %s failed", e.Disposition, e.Table)
+	}
+	return fmt.Sprintf("customererasure: %s step on %s failed with SQLSTATE %s", e.Disposition, e.Table, e.SQLState)
+}
+
+// newStepError sanitises a driver error into a StepError.
+func newStepError(step Step, err error) *StepError {
+	se := &StepError{Table: step.Table, Disposition: step.Disposition}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		se.SQLState = pgErr.Code
+	}
+	return se
+}
+
+// Executor takes a customer_erasure_requests row from pending to completed.
+type Executor struct {
+	db     *gorm.DB
+	logger *slog.Logger
+}
+
+// NewExecutor refuses a nil db at construction rather than deferring the
+// panic to the first erasure — the pattern #318 established after an audit
+// emitter with a nil Repo killed the process at request time instead of at
+// wiring time. logger may be nil; the default logger is used.
+func NewExecutor(db *gorm.DB, logger *slog.Logger) (*Executor, error) {
+	if db == nil {
+		return nil, errors.New("customererasure: db must not be nil")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Executor{db: db, logger: logger}, nil
+}
+
+// Process erases one request's subject.
+//
+// # The claim is the concurrency control
+//
+// Process begins by moving the row to 'processing' with a conditional UPDATE
+// on the POOLED handle, outside the erasure transaction. Matching zero rows
+// means somebody else has it, or it is already decided. That write commits
+// immediately and on purpose: `attempts` must survive a rollback, or a
+// request that fails deterministically would be retried forever with its
+// counter reset each time.
+//
+// # Idempotency
+//
+// Re-processing a completed request is not an error and does not erase
+// anything twice: the stored receipt is parsed back out of notes and
+// returned. A caller that retries after a timeout gets the same answer, with
+// the same counts, rather than a second destructive pass whose counts would
+// all be zero and would read as "nothing was there".
+//
+// # The failure write is NOT in the transaction
+//
+// On failure the erasure transaction rolls back, and only THEN is 'failed'
+// written, on the pooled handle, under context.WithoutCancel. Writing it
+// inside would roll it back along with the erasure and leave the row stuck in
+// 'processing' with no record of why — the #397 defect exactly. WithoutCancel
+// is what stops a client disconnect from losing the same row.
+func (e *Executor) Process(ctx context.Context, requestID uuid.UUID) (Receipt, error) {
+	req, claimErr := e.claim(ctx, requestID)
+	if claimErr != nil {
+		replay, err := e.replayIfCompleted(ctx, requestID, claimErr)
+		if replay != nil {
+			return *replay, nil
+		}
+		return Receipt{}, err
+	}
+
+	receipt, runErr := e.run(ctx, req)
+	if runErr != nil {
+		e.markFailed(ctx, req, runErr)
+		return Receipt{}, runErr
+	}
+	return receipt, nil
+}
+
+// claim moves the row to 'processing' and returns it. 'failed' is claimable
+// as well as 'pending': a rolled-back attempt left nothing behind, so
+// retrying it is safe.
+func (e *Executor) claim(ctx context.Context, requestID uuid.UUID) (Request, error) {
+	var req Request
+	res := e.db.WithContext(ctx).Raw(`
+		UPDATE customer_erasure_requests
+		   SET status = ?, attempts = attempts + 1
+		 WHERE id = ? AND status IN (?, ?)
+		RETURNING id, tenant_id, store_id, customer_email, status, attempts, requested_at, processed_at, notes`,
+		StatusProcessing, requestID, StatusPending, StatusFailed,
+	).Scan(&req)
+	if res.Error != nil {
+		return Request{}, fmt.Errorf("customererasure: claim request %s: %w", requestID, res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return Request{}, ErrAlreadyClaimed
+	}
+	return req, nil
+}
+
+// replayIfCompleted turns a lost claim on an already-completed request into
+// the receipt that request already produced. It returns a nil receipt (and
+// the error to surface) in every other case.
+func (e *Executor) replayIfCompleted(ctx context.Context, requestID uuid.UUID, claimErr error) (*Receipt, error) {
+	if !errors.Is(claimErr, ErrAlreadyClaimed) {
+		return nil, claimErr
+	}
+
+	var existing Request
+	res := e.db.WithContext(ctx).
+		Table("customer_erasure_requests").
+		Where("id = ?", requestID).
+		Take(&existing)
+	if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+		return nil, ErrRequestNotFound
+	}
+	if res.Error != nil {
+		return nil, fmt.Errorf("customererasure: read request %s: %w", requestID, res.Error)
+	}
+	if existing.Status != StatusCompleted {
+		return nil, ErrAlreadyClaimed
+	}
+
+	var receipt Receipt
+	if existing.Notes == nil || json.Unmarshal([]byte(*existing.Notes), &receipt) != nil {
+		// Completed but with an unreadable receipt. Report the completion
+		// honestly rather than inventing counts: the erasure DID happen, and
+		// claiming zero rows were touched would be a false record.
+		receipt = Receipt{RequestID: requestID}
+	}
+	return &receipt, nil
+}
+
+// run executes the plan and, on success, writes the receipt — both in the
+// SAME transaction, under the store's advisory lock. The receipt commits with
+// the erasure it describes, so there is no window in which the data is gone
+// and the evidence is not.
+func (e *Executor) run(ctx context.Context, req Request) (Receipt, error) {
+	token := Token(req.ID)
+	steps := erasurePlan(req.StoreID, req.CustomerEmail, token)
+
+	receipt := Receipt{
+		RequestID:      req.ID,
+		Deleted:        map[string]int64{},
+		Anonymised:     map[string]int64{},
+		RetentionBasis: RetentionBasis,
+	}
+
+	err := subscription.WithAdvisoryLock(ctx, e.db, req.StoreID, func(tx *gorm.DB) error {
+		// Reset per attempt: WithAdvisoryLock's transaction can be retried by
+		// a caller, and counts accumulated across attempts would overstate
+		// what was destroyed.
+		clear(receipt.Deleted)
+		clear(receipt.Anonymised)
+
+		for _, step := range steps {
+			res := tx.Exec(step.SQL, step.Args...)
+			if res.Error != nil {
+				return newStepError(step, res.Error)
+			}
+			switch step.Disposition {
+			case DispositionDelete:
+				receipt.Deleted[step.Table] += res.RowsAffected
+			case DispositionAnonymise:
+				receipt.Anonymised[step.Table] += res.RowsAffected
+			}
+		}
+
+		receipt.RetainedTables = retainedTables(receipt.Anonymised)
+		receipt.CompletedAt = time.Now().UTC()
+
+		notes, mErr := json.Marshal(receipt)
+		if mErr != nil {
+			return fmt.Errorf("customererasure: encode receipt: %w", mErr)
+		}
+		res := tx.Exec(`
+			UPDATE customer_erasure_requests
+			   SET status = ?, processed_at = now(), notes = ?
+			 WHERE id = ?`, StatusCompleted, string(notes), req.ID)
+		if res.Error != nil {
+			return fmt.Errorf("customererasure: write receipt: %w", res.Error)
+		}
+		return nil
+	})
+	if err != nil {
+		return Receipt{}, err
+	}
+
+	// Counts and table names only — never the subject's address.
+	e.logger.Info("customer erasure completed",
+		"request_id", req.ID.String(),
+		"store_id", req.StoreID.String(),
+		"attempt", req.Attempts,
+		"deleted_rows", total(receipt.Deleted),
+		"anonymised_rows", total(receipt.Anonymised),
+	)
+	return receipt, nil
+}
+
+// failureNote is what a failed attempt records. Like Receipt, it carries no
+// personal data: the failing table, the disposition it was attempting, and a
+// SQLSTATE.
+type failureNote struct {
+	RequestID uuid.UUID `json:"request_id"`
+	Status    string    `json:"status"`
+	Attempt   int       `json:"attempt"`
+	Table     string    `json:"failed_table,omitempty"`
+	SQLState  string    `json:"sqlstate,omitempty"`
+	Error     string    `json:"error"`
+	FailedAt  time.Time `json:"failed_at"`
+}
+
+// markFailed writes 'failed' AFTER the erasure transaction has unwound.
+//
+// context.WithoutCancel: the caller's context is very often an HTTP request's,
+// and the operator who triggered the erasure may well have closed the tab by
+// the time it fails. A cancelled context here would drop the only record that
+// the attempt happened, leaving the row in 'processing' forever — visible to
+// nobody and claimable by no worker.
+func (e *Executor) markFailed(ctx context.Context, req Request, cause error) {
+	note := failureNote{
+		RequestID: req.ID,
+		Status:    StatusFailed,
+		Attempt:   req.Attempts,
+		Error:     cause.Error(),
+		FailedAt:  time.Now().UTC(),
+	}
+	var se *StepError
+	if errors.As(cause, &se) {
+		note.Table = se.Table
+		note.SQLState = se.SQLState
+	}
+
+	encoded, err := json.Marshal(note)
+	if err != nil {
+		encoded = []byte(`{"status":"failed","error":"receipt could not be encoded"}`)
+	}
+
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+
+	if err := e.db.WithContext(writeCtx).Exec(`
+		UPDATE customer_erasure_requests
+		   SET status = ?, notes = ?
+		 WHERE id = ?`, StatusFailed, string(encoded), req.ID).Error; err != nil {
+		// Nothing left to fall back on. Log loudly: the row is now stuck in
+		// 'processing' and only an operator can free it.
+		e.logger.Error("customer erasure failed AND its failure could not be recorded",
+			"request_id", req.ID.String(), "store_id", req.StoreID.String(), "err", err)
+		return
+	}
+	e.logger.Error("customer erasure failed",
+		"request_id", req.ID.String(),
+		"store_id", req.StoreID.String(),
+		"attempt", req.Attempts,
+		"failed_table", note.Table,
+		"sqlstate", note.SQLState,
+	)
+}
+
+// Reject records an operator's refusal. It is the other half of the inbox
+// decision and lives here so the status vocabulary has exactly one owner.
+//
+// notes is operator free text and is stored as given — it is the operator's
+// reason, not the subject's data. Only a 'pending' or 'failed' request can be
+// rejected; anything else returns ErrAlreadyClaimed so a second decision
+// cannot overwrite the first.
+func (e *Executor) Reject(ctx context.Context, requestID uuid.UUID, notes string) (Request, error) {
+	var req Request
+	res := e.db.WithContext(ctx).Raw(`
+		UPDATE customer_erasure_requests
+		   SET status = ?, processed_at = now(), notes = NULLIF(?, '')
+		 WHERE id = ? AND status IN (?, ?)
+		RETURNING id, tenant_id, store_id, customer_email, status, attempts, requested_at, processed_at, notes`,
+		StatusRejected, notes, requestID, StatusPending, StatusFailed,
+	).Scan(&req)
+	if res.Error != nil {
+		return Request{}, fmt.Errorf("customererasure: reject request %s: %w", requestID, res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return Request{}, ErrAlreadyClaimed
+	}
+	e.logger.Info("customer erasure rejected",
+		"request_id", req.ID.String(), "store_id", req.StoreID.String())
+	return req, nil
+}
+
+// PendingIDs lists requests waiting to be processed, oldest first. It is the
+// worker's queue read; the claim is what actually makes taking one safe.
+func (e *Executor) PendingIDs(ctx context.Context, limit int) ([]uuid.UUID, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	var ids []uuid.UUID
+	err := e.db.WithContext(ctx).Raw(`
+		SELECT id FROM customer_erasure_requests
+		 WHERE status IN (?, ?)
+		 ORDER BY requested_at ASC
+		 LIMIT ?`, StatusPending, StatusFailed, limit).Scan(&ids).Error
+	if err != nil {
+		return nil, fmt.Errorf("customererasure: list pending: %w", err)
+	}
+	return ids, nil
+}
+
+// retainedTables is every table whose rows survive: the ones this erasure
+// anonymised, plus the ones that needed no statement because they hold no
+// personal column.
+func retainedTables(anonymised map[string]int64) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(anonymised)+len(retainedWithoutStep))
+	for _, list := range [][]string{keys(anonymised), retainedWithoutStep} {
+		for _, t := range list {
+			if !seen[t] {
+				seen[t] = true
+				out = append(out, t)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func keys(m map[string]int64) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func total(m map[string]int64) int64 {
+	var n int64
+	for _, v := range m {
+		n += v
+	}
+	return n
+}

--- a/services/marketplace-api/internal/customererasure/executor.go
+++ b/services/marketplace-api/internal/customererasure/executor.go
@@ -142,16 +142,9 @@ func (e *Executor) replayIfCompleted(ctx context.Context, requestID uuid.UUID, c
 		return nil, claimErr
 	}
 
-	var existing Request
-	res := e.db.WithContext(ctx).
-		Table("customer_erasure_requests").
-		Where("id = ?", requestID).
-		Take(&existing)
-	if errors.Is(res.Error, gorm.ErrRecordNotFound) {
-		return nil, ErrRequestNotFound
-	}
-	if res.Error != nil {
-		return nil, fmt.Errorf("customererasure: read request %s: %w", requestID, res.Error)
+	existing, err := e.Lookup(ctx, requestID)
+	if err != nil {
+		return nil, err
 	}
 	if existing.Status != StatusCompleted {
 		return nil, ErrAlreadyClaimed
@@ -318,6 +311,28 @@ func (e *Executor) Reject(ctx context.Context, requestID uuid.UUID, notes string
 	}
 	e.logger.Info("customer erasure rejected",
 		"request_id", req.ID.String(), "store_id", req.StoreID.String())
+	return req, nil
+}
+
+// Lookup reads one request without claiming it.
+//
+// It exists because Receipt deliberately carries no tenant or store: a
+// receipt is evidence about DATA, not about who owns it, and widening it
+// would put ownership metadata in the one artefact that must stay free of
+// anything but counts. Callers that need attribution — the inbox action,
+// which must name a tenant on its audit row — read it from here instead.
+func (e *Executor) Lookup(ctx context.Context, requestID uuid.UUID) (Request, error) {
+	var req Request
+	res := e.db.WithContext(ctx).
+		Table("customer_erasure_requests").
+		Where("id = ?", requestID).
+		Take(&req)
+	if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+		return Request{}, ErrRequestNotFound
+	}
+	if res.Error != nil {
+		return Request{}, fmt.Errorf("customererasure: read request %s: %w", requestID, res.Error)
+	}
 	return req, nil
 }
 

--- a/services/marketplace-api/internal/customererasure/executor_integration_test.go
+++ b/services/marketplace-api/internal/customererasure/executor_integration_test.go
@@ -1,0 +1,492 @@
+//go:build integration
+
+// In the INTERNAL package, like coverage_integration_test.go: the failure
+// path is asserted by calling markFailed directly, which is the only way to
+// pin context.WithoutCancel deterministically.
+package customererasure
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// customer is one seeded subject and everything of theirs the erasure must
+// reach. The second customer in every test is seeded with the SAME shape in
+// the SAME store, so "untouched" is a claim about identical data, not about
+// data the plan would never have matched anyway.
+type customer struct {
+	email     string
+	name      string
+	profileID uuid.UUID
+	addressID uuid.UUID
+	wishlist  uuid.UUID
+	reviewID  uuid.UUID
+	mediaID   uuid.UUID
+	orderID   uuid.UUID
+	emailSend uuid.UUID
+}
+
+type fixture struct {
+	db       *gorm.DB
+	tenantID uuid.UUID
+	storeID  uuid.UUID
+	subject  customer
+	// other is a DIFFERENT person in the SAME store. They catch a statement
+	// that lost its email predicate.
+	other customer
+	// twin is the SAME address in a DIFFERENT store — a real case, since one
+	// person shops at several merchants and files a request per store. They
+	// catch a statement that lost its store predicate, which `other` cannot:
+	// dropping `AND store_id = ?` while keeping the email still misses a
+	// bystander whose address differs.
+	twin        customer
+	twinStoreID uuid.UUID
+	request     uuid.UUID
+}
+
+const (
+	subjectAddr = "erasure-subject@example.test"
+	otherAddr   = "bystander@example.test"
+	orderTotal  = "42.50"
+	orderCcy    = "EUR"
+	addrCountry = "IE"
+)
+
+func newFixture(t *testing.T) fixture {
+	t.Helper()
+	db := testdb.NewTx(t)
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
+	vendorID := testdb.SeedVendor(t, db, tenantID)
+
+	productID := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO products (id, tenant_id, store_id, handle, title, status, vendor_id)
+		 VALUES (?, ?, ?, ?, ?, 'draft', ?)`,
+		productID, tenantID, storeID, "p-"+productID.String()[:8], "Test product", vendorID,
+	).Error)
+
+	f := fixture{db: db, tenantID: tenantID, storeID: storeID}
+	f.subject = seedCustomer(t, db, tenantID, storeID, productID, subjectAddr, "Subject Person")
+	f.other = seedCustomer(t, db, tenantID, storeID, productID, otherAddr, "Bystander Person")
+
+	// A second merchant entirely, where the SAME address shops. The erasure
+	// request names one store; this person's data at every other store is
+	// none of its business.
+	twinTenantID, twinStoreID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, twinTenantID, twinStoreID)
+	twinVendorID := testdb.SeedVendor(t, db, twinTenantID)
+	twinProductID := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO products (id, tenant_id, store_id, handle, title, status, vendor_id)
+		 VALUES (?, ?, ?, ?, ?, 'draft', ?)`,
+		twinProductID, twinTenantID, twinStoreID, "p-"+twinProductID.String()[:8], "Other store product", twinVendorID,
+	).Error)
+	f.twinStoreID = twinStoreID
+	f.twin = seedCustomer(t, db, twinTenantID, twinStoreID, twinProductID, subjectAddr, "Subject Person")
+
+	f.request = uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO customer_erasure_requests (id, tenant_id, store_id, customer_email)
+		 VALUES (?, ?, ?, ?)`,
+		f.request, tenantID, storeID, subjectAddr,
+	).Error)
+
+	return f
+}
+
+func seedCustomer(t *testing.T, db *gorm.DB, tenantID, storeID, productID uuid.UUID, email, name string) customer {
+	t.Helper()
+	c := customer{
+		email: email, name: name,
+		profileID: uuid.New(), addressID: uuid.New(), wishlist: uuid.New(),
+		reviewID: uuid.New(), mediaID: uuid.New(), orderID: uuid.New(), emailSend: uuid.New(),
+	}
+
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		require.NoError(t, db.Exec(sql, args...).Error, "seeding %s", email)
+	}
+
+	exec(`INSERT INTO customer_profiles (id, tenant_id, store_id, email, first_name, last_name, phone)
+	      VALUES (?, ?, ?, ?, ?, 'Person', '+353100000000')`,
+		c.profileID, tenantID, storeID, email, name)
+
+	exec(`INSERT INTO customer_addresses (id, tenant_id, customer_id, name, line1, city, country_code)
+	      VALUES (?, ?, ?, ?, '1 Test Lane', 'Dublin', ?)`,
+		c.addressID, tenantID, c.profileID, name, addrCountry)
+
+	exec(`INSERT INTO wishlists (id, tenant_id, store_id, customer_id, product_id)
+	      VALUES (?, ?, ?, ?, ?)`,
+		c.wishlist, tenantID, storeID, c.profileID, productID)
+
+	exec(`INSERT INTO reviews (id, tenant_id, store_id, product_id, customer_profile_id,
+	                           customer_name, customer_email, rating, content, status)
+	      VALUES (?, ?, ?, ?, ?, ?, ?, 5, 'Great product', 'published')`,
+		c.reviewID, tenantID, storeID, productID, c.profileID, name, email)
+
+	exec(`INSERT INTO review_media (id, review_id, url) VALUES (?, ?, 'https://cdn.test/photo.jpg')`,
+		c.mediaID, c.reviewID)
+
+	exec(`INSERT INTO orders (id, tenant_id, store_id, order_number, idempotency_key, customer_id,
+	                          customer_email, customer_name, subtotal, grand_total, currency_code)
+	      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		c.orderID, tenantID, storeID, "ORD-"+c.orderID.String()[:8], c.orderID.String(),
+		c.profileID, email, name, orderTotal, orderTotal, orderCcy)
+
+	exec(`INSERT INTO order_addresses (order_id, kind, name, line1, line2, city, region, postal_code, country_code, phone)
+	      VALUES (?, 'shipping', ?, '1 Test Lane', 'Apt 2', 'Dublin', 'Leinster', 'D01 X1X1', ?, '+353100000000')`,
+		c.orderID, name, addrCountry)
+
+	exec(`INSERT INTO payment_transactions (tenant_id, store_id, order_id, provider, amount, currency_code, status)
+	      VALUES (?, ?, ?, 'stripe', ?, ?, 'succeeded')`,
+		tenantID, storeID, c.orderID, orderTotal, orderCcy)
+
+	exec(`INSERT INTO email_sends (id, tenant_id, store_id, recipient, kind, status)
+	      VALUES (?, ?, ?, ?, 'order_confirmation', 'sent')`,
+		c.emailSend, tenantID, storeID, email)
+
+	return c
+}
+
+func newExecutor(t *testing.T, db *gorm.DB) *Executor {
+	t.Helper()
+	e, err := NewExecutor(db, nil)
+	require.NoError(t, err)
+	return e
+}
+
+func count(t *testing.T, db *gorm.DB, sql string, args ...any) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, db.Raw(sql, args...).Scan(&n).Error)
+	return n
+}
+
+// ---------------------------------------------------------------------------
+
+func TestNewExecutor_RefusesNilDB(t *testing.T) {
+	_, err := NewExecutor(nil, nil)
+	require.Error(t, err, "a nil db must be refused at construction, not panicked on at erasure time (#318)")
+}
+
+// TestProcess_DeletesWhatServesOnlyTheCustomer covers the DELETE half.
+func TestProcess_DeletesWhatServesOnlyTheCustomer(t *testing.T) {
+	f := newFixture(t)
+	_, err := newExecutor(t, f.db).Process(context.Background(), f.request)
+	require.NoError(t, err)
+
+	require.Zero(t, count(t, f.db, `SELECT count(*) FROM customer_profiles WHERE id = ?`, f.subject.profileID))
+	require.Zero(t, count(t, f.db, `SELECT count(*) FROM customer_addresses WHERE id = ?`, f.subject.addressID))
+	require.Zero(t, count(t, f.db, `SELECT count(*) FROM wishlists WHERE id = ?`, f.subject.wishlist))
+	require.Zero(t, count(t, f.db, `SELECT count(*) FROM review_media WHERE id = ?`, f.subject.mediaID))
+	require.Zero(t, count(t, f.db, `SELECT count(*) FROM email_sends WHERE id = ?`, f.subject.emailSend))
+}
+
+// TestProcess_KeepsTheFinancialRecordAndAnonymisesIt is the ANONYMISE half:
+// the money must still be reconcilable after the person is gone.
+func TestProcess_KeepsTheFinancialRecordAndAnonymisesIt(t *testing.T) {
+	f := newFixture(t)
+	token := Token(f.request)
+
+	_, err := newExecutor(t, f.db).Process(context.Background(), f.request)
+	require.NoError(t, err)
+
+	var order struct {
+		CustomerEmail string
+		CustomerName  *string
+		CustomerID    *uuid.UUID
+		GrandTotal    string
+		CurrencyCode  string
+	}
+	require.NoError(t, f.db.Raw(
+		`SELECT customer_email, customer_name, customer_id, grand_total::text AS grand_total, currency_code
+		   FROM orders WHERE id = ?`, f.subject.orderID).Scan(&order).Error)
+
+	require.Equal(t, token, order.CustomerEmail, "the order must survive with the token in place of the address")
+	require.NotNil(t, order.CustomerName)
+	require.Equal(t, RedactedName, *order.CustomerName)
+	require.Nil(t, order.CustomerID, "the link back to the deleted profile must be severed")
+	require.Equal(t, orderTotal, order.GrandTotal, "the financial figures must be untouched")
+	require.Equal(t, orderCcy, order.CurrencyCode)
+
+	// The payment row is retained whole: it holds no personal column at all.
+	require.EqualValues(t, 1,
+		count(t, f.db, `SELECT count(*) FROM payment_transactions WHERE order_id = ?`, f.subject.orderID),
+		"payment_transactions is a financial record and carries no step; it must survive")
+
+	var addr struct {
+		Name, Line1, City, CountryCode string
+		Line2, Region, PostalCode      *string
+		Phone                          *string
+	}
+	require.NoError(t, f.db.Raw(
+		`SELECT name, line1, city, country_code, line2, region, postal_code, phone
+		   FROM order_addresses WHERE order_id = ?`, f.subject.orderID).Scan(&addr).Error)
+	require.Equal(t, RedactedName, addr.Name)
+	require.Equal(t, RedactedLine, addr.Line1)
+	require.Equal(t, RedactedLine, addr.City)
+	require.Nil(t, addr.Line2)
+	require.Nil(t, addr.Region)
+	require.Nil(t, addr.PostalCode)
+	require.Nil(t, addr.Phone)
+	require.Equal(t, addrCountry, strings.TrimSpace(addr.CountryCode),
+		"country_code is kept deliberately: tax reporting needs it and it identifies nobody alone")
+}
+
+// TestProcess_KeepsTheReviewAndItsRating — deleting the review would
+// retroactively change the merchant's historical star rating.
+func TestProcess_KeepsTheReviewAndItsRating(t *testing.T) {
+	f := newFixture(t)
+	token := Token(f.request)
+
+	_, err := newExecutor(t, f.db).Process(context.Background(), f.request)
+	require.NoError(t, err)
+
+	var review struct {
+		CustomerEmail     string
+		CustomerName      string
+		Rating            int
+		CustomerProfileID *uuid.UUID
+	}
+	require.NoError(t, f.db.Raw(
+		`SELECT customer_email, customer_name, rating, customer_profile_id
+		   FROM reviews WHERE id = ?`, f.subject.reviewID).Scan(&review).Error)
+
+	require.Equal(t, token, review.CustomerEmail)
+	require.Equal(t, RedactedName, review.CustomerName)
+	require.Equal(t, 5, review.Rating, "the rating carries the merchant's reputation and must not move")
+	require.Nil(t, review.CustomerProfileID)
+}
+
+// TestProcess_LeavesEveryOtherCustomerUntouched is THE test.
+//
+// An unscoped WHERE — a missing `AND store_id = ?`, a subquery that forgot
+// the email — would erase a different person who never asked for it. That is
+// the worst thing this feature can do, and it is silent: every other
+// assertion in this file would still pass.
+//
+// It takes BOTH bystanders to pin both predicates. A different person in the
+// same store catches a dropped email; the same person at a different store
+// catches a dropped store_id. Either one alone leaves half the mutation
+// space green.
+func TestProcess_LeavesEveryOtherCustomerUntouched(t *testing.T) {
+	f := newFixture(t)
+	_, err := newExecutor(t, f.db).Process(context.Background(), f.request)
+	require.NoError(t, err)
+
+	assertCustomerIntact(t, f.db, f.other)
+	assertCustomerIntact(t, f.db, f.twin)
+}
+
+// assertCustomerIntact asserts EVERY row seeded for c is exactly as seeded —
+// not merely present, but still carrying the person's own name and address.
+// An anonymised-but-present row is as much a wrongful erasure as a deleted
+// one, and a bare count(*) would not notice.
+func assertCustomerIntact(t *testing.T, db *gorm.DB, c customer) {
+	t.Helper()
+	require.EqualValues(t, 1, count(t, db, `SELECT count(*) FROM customer_profiles WHERE id = ? AND email = ?`, c.profileID, c.email))
+	require.EqualValues(t, 1, count(t, db, `SELECT count(*) FROM customer_addresses WHERE id = ? AND name = ?`, c.addressID, c.name))
+	require.EqualValues(t, 1, count(t, db, `SELECT count(*) FROM wishlists WHERE id = ?`, c.wishlist))
+	require.EqualValues(t, 1, count(t, db, `SELECT count(*) FROM review_media WHERE id = ?`, c.mediaID))
+	require.EqualValues(t, 1, count(t, db, `SELECT count(*) FROM email_sends WHERE id = ? AND recipient = ?`, c.emailSend, c.email))
+	require.EqualValues(t, 1, count(t, db,
+		`SELECT count(*) FROM reviews WHERE id = ? AND customer_email = ? AND customer_name = ? AND customer_profile_id = ?`,
+		c.reviewID, c.email, c.name, c.profileID))
+	require.EqualValues(t, 1, count(t, db,
+		`SELECT count(*) FROM orders WHERE id = ? AND customer_email = ? AND customer_name = ? AND customer_id = ?`,
+		c.orderID, c.email, c.name, c.profileID))
+	require.EqualValues(t, 1, count(t, db,
+		`SELECT count(*) FROM order_addresses WHERE order_id = ? AND name = ? AND line1 = '1 Test Lane' AND city = 'Dublin'`,
+		c.orderID, c.name))
+}
+
+// TestProcess_WritesAReceiptCarryingNoPersonalData. The receipt is the
+// evidence, and evidence that names the subject re-creates the record the
+// erasure removed.
+func TestProcess_WritesAReceiptCarryingNoPersonalData(t *testing.T) {
+	f := newFixture(t)
+
+	receipt, err := newExecutor(t, f.db).Process(context.Background(), f.request)
+	require.NoError(t, err)
+	require.Equal(t, f.request, receipt.RequestID)
+	require.EqualValues(t, 1, receipt.Deleted["customer_profiles"])
+	require.EqualValues(t, 1, receipt.Anonymised["orders"])
+	require.NotContains(t, receipt.Deleted, "orders",
+		"orders is a financial record: the receipt must record it as retained-and-anonymised, never as destroyed")
+	require.Contains(t, receipt.RetainedTables, "orders")
+	require.Contains(t, receipt.RetainedTables, "payment_transactions",
+		"a table retained WITHOUT a step must still be named, or a reader cannot tell it was considered")
+	require.NotEmpty(t, receipt.RetentionBasis)
+
+	var row struct {
+		Status      string
+		Notes       *string
+		ProcessedAt *string
+	}
+	require.NoError(t, f.db.Raw(
+		`SELECT status, notes, processed_at::text AS processed_at
+		   FROM customer_erasure_requests WHERE id = ?`, f.request).Scan(&row).Error)
+
+	require.Equal(t, StatusCompleted, row.Status)
+	require.NotNil(t, row.ProcessedAt)
+	require.NotNil(t, row.Notes)
+	require.NotEmpty(t, *row.Notes)
+
+	require.NotContains(t, *row.Notes, subjectAddr, "the receipt must never carry the subject's email")
+	require.NotContains(t, *row.Notes, f.subject.name, "the receipt must never carry the subject's name")
+	require.NotContains(t, *row.Notes, "+353100000000", "the receipt must never carry the subject's phone")
+	require.NotContains(t, *row.Notes, "1 Test Lane", "the receipt must never carry the subject's address")
+
+	var stored Receipt
+	require.NoError(t, json.Unmarshal([]byte(*row.Notes), &stored),
+		"notes must be the machine-readable receipt, not prose")
+	require.Equal(t, receipt.Deleted, stored.Deleted)
+}
+
+// TestProcess_IsIdempotent — a retry after a timeout must not read as
+// "nothing was there", and must not run a second destructive pass.
+func TestProcess_IsIdempotent(t *testing.T) {
+	f := newFixture(t)
+	e := newExecutor(t, f.db)
+
+	first, err := e.Process(context.Background(), f.request)
+	require.NoError(t, err)
+
+	beforeAttempts := count(t, f.db, `SELECT attempts FROM customer_erasure_requests WHERE id = ?`, f.request)
+
+	second, err := e.Process(context.Background(), f.request)
+	require.NoError(t, err, "re-processing a completed request must not error")
+	require.Equal(t, first.Deleted, second.Deleted, "the replay must report the ORIGINAL counts, not a second pass's zeroes")
+	require.Equal(t, first.Anonymised, second.Anonymised)
+
+	require.EqualValues(t, beforeAttempts,
+		count(t, f.db, `SELECT attempts FROM customer_erasure_requests WHERE id = ?`, f.request),
+		"a replay must not consume an attempt")
+	require.Equal(t, StatusCompleted, statusOf(t, f.db, f.request))
+	require.Zero(t, count(t, f.db, `SELECT count(*) FROM customer_profiles WHERE id = ?`, f.subject.profileID))
+}
+
+// TestProcess_RefusesARequestAnotherWorkerHolds. The claim is the
+// concurrency control; a second worker must bounce off it, not run in
+// parallel and double-decrement.
+func TestProcess_RefusesARequestAnotherWorkerHolds(t *testing.T) {
+	f := newFixture(t)
+	require.NoError(t, f.db.Exec(
+		`UPDATE customer_erasure_requests SET status = ? WHERE id = ?`, StatusProcessing, f.request).Error)
+
+	_, err := newExecutor(t, f.db).Process(context.Background(), f.request)
+	require.ErrorIs(t, err, ErrAlreadyClaimed)
+	require.EqualValues(t, 1, count(t, f.db, `SELECT count(*) FROM customer_profiles WHERE id = ?`, f.subject.profileID),
+		"a worker that lost the claim must not have erased anything")
+}
+
+func TestProcess_UnknownRequestIsNotFound(t *testing.T) {
+	f := newFixture(t)
+	_, err := newExecutor(t, f.db).Process(context.Background(), uuid.New())
+	require.ErrorIs(t, err, ErrRequestNotFound)
+}
+
+// TestProcess_RecordsFailureAfterTheTransactionRollsBack is the #397 guard.
+//
+// A BEFORE UPDATE trigger on orders — the LAST anonymise step — makes the
+// erasure transaction fail once everything before it has run. Everything in
+// that transaction rolls back. The 'failed' status must NOT: written inside
+// it, it would roll back too, leaving the row stuck in 'processing' with no
+// record of why, which is precisely the defect #397 fixed elsewhere.
+func TestProcess_RecordsFailureAfterTheTransactionRollsBack(t *testing.T) {
+	f := newFixture(t)
+	require.NoError(t, f.db.Exec(`
+		CREATE OR REPLACE FUNCTION pg_temp.erasure_forced_failure() RETURNS trigger AS $$
+		BEGIN RAISE EXCEPTION 'forced failure for the erasure failure-path test'; END;
+		$$ LANGUAGE plpgsql`).Error)
+	require.NoError(t, f.db.Exec(`
+		CREATE TRIGGER erasure_forced_failure BEFORE UPDATE ON orders
+		FOR EACH ROW EXECUTE FUNCTION pg_temp.erasure_forced_failure()`).Error)
+
+	_, err := newExecutor(t, f.db).Process(context.Background(), f.request)
+	require.Error(t, err)
+
+	var se *StepError
+	require.ErrorAs(t, err, &se, "a failed statement must report which table and disposition failed")
+	require.Equal(t, "orders", se.Table)
+	require.Equal(t, DispositionAnonymise, se.Disposition)
+
+	require.Equal(t, StatusFailed, statusOf(t, f.db, f.request),
+		"the failed status must survive the rolled-back transaction — write it AFTER, on the pooled handle (#397)")
+
+	// Everything the transaction did is gone: the erasure is all-or-nothing.
+	require.EqualValues(t, 1, count(t, f.db, `SELECT count(*) FROM customer_profiles WHERE id = ?`, f.subject.profileID))
+	require.EqualValues(t, 1, count(t, f.db, `SELECT count(*) FROM wishlists WHERE id = ?`, f.subject.wishlist))
+
+	var notes *string
+	require.NoError(t, f.db.Raw(`SELECT notes FROM customer_erasure_requests WHERE id = ?`, f.request).Scan(&notes).Error)
+	require.NotNil(t, notes)
+	require.Contains(t, *notes, "orders")
+	require.NotContains(t, *notes, subjectAddr,
+		"a Postgres error message embeds the offending value; the failure note must carry the SQLSTATE, never the driver text")
+
+	// Claimable again: 'failed' is a retryable state, and the attempt was counted.
+	require.EqualValues(t, 1, count(t, f.db, `SELECT attempts FROM customer_erasure_requests WHERE id = ?`, f.request))
+}
+
+// TestMarkFailed_WritesEvenWhenTheCallerContextIsCancelled pins
+// context.WithoutCancel. The operator who triggered an erasure has very often
+// closed the tab by the time it fails; a cancelled context must not be able
+// to drop the only record that the attempt happened.
+func TestMarkFailed_WritesEvenWhenTheCallerContextIsCancelled(t *testing.T) {
+	f := newFixture(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	newExecutor(t, f.db).markFailed(ctx, Request{ID: f.request, StoreID: f.storeID, Attempts: 1},
+		errors.New("customererasure: synthetic failure"))
+
+	require.Equal(t, StatusFailed, statusOf(t, f.db, f.request),
+		"a cancelled caller context must not lose the failure record")
+}
+
+// TestReject_IsTerminalAndDestroysNothing.
+func TestReject_IsTerminalAndDestroysNothing(t *testing.T) {
+	f := newFixture(t)
+	e := newExecutor(t, f.db)
+
+	req, err := e.Reject(context.Background(), f.request, "identity could not be verified")
+	require.NoError(t, err)
+	require.Equal(t, StatusRejected, req.Status)
+	require.Equal(t, StatusRejected, statusOf(t, f.db, f.request))
+
+	require.EqualValues(t, 1, count(t, f.db, `SELECT count(*) FROM customer_profiles WHERE id = ?`, f.subject.profileID),
+		"a rejection must not erase anything")
+
+	_, err = e.Reject(context.Background(), f.request, "second opinion")
+	require.ErrorIs(t, err, ErrAlreadyClaimed, "a second decision must not overwrite the first")
+
+	_, err = e.Process(context.Background(), f.request)
+	require.ErrorIs(t, err, ErrAlreadyClaimed, "a rejected request must not be processable")
+}
+
+func TestPendingIDs_ListsClaimableRequests(t *testing.T) {
+	f := newFixture(t)
+	ids, err := newExecutor(t, f.db).PendingIDs(context.Background(), 50)
+	require.NoError(t, err)
+	require.Contains(t, ids, f.request)
+}
+
+func statusOf(t *testing.T, db *gorm.DB, requestID uuid.UUID) string {
+	t.Helper()
+	var status string
+	require.NoError(t, db.Raw(`SELECT status FROM customer_erasure_requests WHERE id = ?`, requestID).Scan(&status).Error)
+	return status
+}

--- a/services/marketplace-api/internal/customererasure/models.go
+++ b/services/marketplace-api/internal/customererasure/models.go
@@ -1,0 +1,112 @@
+package customererasure
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Status values for customer_erasure_requests.status.
+//
+// The vocabulary is what migration 000113 widened the CHECK constraint to.
+// #259 described 'processing'/'completed'/'failed' as already existing; they
+// did not — the original constraint (000059) admitted only pending, processed
+// and rejected, so there was no in-flight state and a crash mid-erasure was
+// indistinguishable from a request nobody had started.
+const (
+	// StatusPending — filed by the storefront, nobody has acted on it.
+	StatusPending = "pending"
+	// StatusProcessing — a worker holds the claim. This is the state that
+	// makes the claim a concurrency control rather than a label.
+	StatusProcessing = "processing"
+	// StatusCompleted — the erasure ran and the receipt is in notes.
+	StatusCompleted = "completed"
+	// StatusFailed — the erasure was attempted and rolled back. Retryable:
+	// the claim below matches 'failed' as well as 'pending'.
+	StatusFailed = "failed"
+	// StatusRejected — an operator refused the request.
+	StatusRejected = "rejected"
+	// StatusProcessed is the pre-000113 terminal state, kept valid so
+	// existing rows need no backfill. Nothing writes it any more.
+	StatusProcessed = "processed"
+)
+
+// Request is one row of customer_erasure_requests.
+//
+// CustomerEmail is the subject's address and is the one field in this struct
+// that is personal data. It is read to build the plan and must never reach a
+// log line or a receipt.
+type Request struct {
+	ID            uuid.UUID  `gorm:"column:id"`
+	TenantID      uuid.UUID  `gorm:"column:tenant_id"`
+	StoreID       uuid.UUID  `gorm:"column:store_id"`
+	CustomerEmail string     `gorm:"column:customer_email"`
+	Status        string     `gorm:"column:status"`
+	Attempts      int        `gorm:"column:attempts"`
+	RequestedAt   time.Time  `gorm:"column:requested_at"`
+	ProcessedAt   *time.Time `gorm:"column:processed_at"`
+	Notes         *string    `gorm:"column:notes"`
+}
+
+// TableName pins the table; GORM's default pluralisation would guess
+// "requests" from the struct name.
+func (Request) TableName() string { return "customer_erasure_requests" }
+
+// Receipt is the evidence the erasure happened, and the evidence of what it
+// deliberately did NOT destroy.
+//
+// IT CONTAINS NO PERSONAL DATA. Table names, counts and the request id only —
+// no email, name, phone or address. A receipt that named the subject would
+// re-create, in the audit trail, exactly the record the erasure removed.
+//
+// RetainedTables is not decoration. "We erased it" is a claim that may need
+// evidencing; "we retained the order rows, anonymised, under legal-obligation
+// basis" is the half of the answer a regulator actually asks for.
+type Receipt struct {
+	RequestID uuid.UUID `json:"request_id"`
+	// Deleted maps table -> rows destroyed.
+	Deleted map[string]int64 `json:"deleted"`
+	// Anonymised maps table -> rows whose personal fields were overwritten
+	// while the row itself survived. gift_cards can exceed its row count:
+	// one row holds the subject in up to three roles, each its own step.
+	Anonymised map[string]int64 `json:"anonymised"`
+	// RetainedTables lists every table whose rows survive this erasure —
+	// the anonymised ones plus those that carry no personal column at all
+	// and so needed no statement.
+	RetainedTables []string `json:"retained_tables"`
+	// RetentionBasis records WHY they survive, next to the fact that they do.
+	RetentionBasis string    `json:"retention_basis"`
+	CompletedAt    time.Time `json:"completed_at"`
+}
+
+// RetentionBasis is the justification recorded in every receipt, and the same
+// one migration 000113 wrote onto the tables themselves.
+const RetentionBasis = "financial record; anonymised and retained 7 years under legal-obligation basis (§23.2), matching billing_archive"
+
+// retainedWithoutStep are tables whose rows survive an erasure and that carry
+// NO statement in the plan, because they hold no personal column at all —
+// verified column-by-column against the live schema, not assumed. They are
+// named in the receipt anyway: a table absent from both halves of a receipt
+// is indistinguishable, to a reader, from one the plan never considered.
+//
+// Their only residual PII risk is JSONB (payment_transactions.metadata,
+// shipments.ship_from/ship_to), which is out of scope for #259 and recorded
+// as such in the package doc.
+var retainedWithoutStep = []string{
+	"order_items",
+	"payment_transactions",
+	"platform_fee_ledger",
+	"refund_transactions",
+	"shipments",
+}
+
+// ErrRequestNotFound — no such erasure request.
+var ErrRequestNotFound = errors.New("customererasure: no such erasure request")
+
+// ErrAlreadyClaimed — the row is not available to this worker: another
+// process holds it in 'processing', or an operator already rejected it.
+//
+// It is NOT an error state for the request. A caller that races another
+// worker has nothing to fix; the inbox executor maps this to a 409.
+var ErrAlreadyClaimed = errors.New("customererasure: erasure request is already claimed or decided")

--- a/services/marketplace-api/internal/customererasure/plan.go
+++ b/services/marketplace-api/internal/customererasure/plan.go
@@ -1,0 +1,350 @@
+// Package customererasure executes GDPR art.17 erasure for one customer in
+// one store (#259).
+//
+// Scope is (store_id, email), matching customer_erasure_requests' own
+// UNIQUE (store_id, customer_email). A person with accounts in three stores
+// files three requests; grouping them is a console presentation concern.
+//
+// KEYED ON EMAIL, NOT customer_id. orders.customer_id is set only when a
+// logged-in profile is in context (handlers/storefront/checkout.go), so guest
+// orders carry NULL, while customer_email is NOT NULL. customer_id is nulled
+// where present, never used as the primary match.
+//
+// TWO DISPOSITIONS. A row that exists only to serve the customer is DELETED.
+// A row that must survive for financial-record reasons is ANONYMISED: its
+// personal fields are overwritten and the row is retained 7 years under
+// legal-obligation basis, matching billing_archive (§23.2, migration 000046)
+// — the same number #365 chose so the estate has one retention story rather
+// than two. Migration 000113 writes that basis onto the tables themselves.
+//
+// EVERY STATEMENT IS SCOPED TO THE STORE, directly by store_id or through a
+// store-scoped subquery, and the subject's email is ALWAYS a bound
+// parameter, never interpolated. An unscoped WHERE here would erase a
+// different merchant's customers.
+//
+// ORDER MATTERS in two places, and both are load-bearing:
+//   - review_media is deleted while reviews still carry the subject's email;
+//     the reviews anonymisation runs later.
+//   - orders is the LAST anonymise step, because order_addresses,
+//     order_events and returns all locate their rows through
+//     `orders WHERE customer_email = <subject>`. Anonymising orders first
+//     would orphan them.
+//   - customer_profiles is the LAST step overall; groups 1 and 2 reference
+//     it by subquery.
+//
+// TABLES DELIBERATELY CARRYING NO STEP, verified column-by-column against
+// the live schema rather than assumed:
+//   - payment_transactions, refund_transactions, platform_fee_ledger hold no
+//     personal column at all. Their only PII risk is
+//     payment_transactions.metadata (JSONB), which is out of scope below.
+//   - shipments holds personal data only in ship_from/ship_to (JSONB).
+//   - order_items, order_tax_lines, return_items, loyalty_transactions,
+//     gift_card_transactions and referrals hold no personal column; they
+//     survive attached to rows that have been anonymised.
+//
+// OUT OF SCOPE, deliberately: nine JSONB columns can embed a customer email
+// or address (stripe_webhook_events.payload, payment_transactions.metadata,
+// shipments.ship_from/ship_to, abandoned_carts.items_snapshot,
+// audit_logs.metadata, outbox_events.payload and others). None are inspected
+// here — safely key-stripping nine differently-shaped payloads is its own
+// effort and guessing at their shapes risks corrupting payment metadata.
+// abandoned_carts is deleted outright so its snapshot goes with it; the rest
+// are known residual PII, tracked separately.
+package customererasure
+
+import (
+	"github.com/google/uuid"
+)
+
+// Disposition is what the erasure does to a table: destroy the rows, or keep
+// them and overwrite the personal fields.
+type Disposition string
+
+const (
+	// DispositionDelete — the row exists only to serve the customer.
+	DispositionDelete Disposition = "delete"
+	// DispositionAnonymise — the row must survive for financial or
+	// integrity reasons, but its personal fields must not.
+	DispositionAnonymise Disposition = "anonymise"
+)
+
+// authorTypeCustomer is the discriminator on the mixed-subject reply tables.
+// A merchant's or platform operator's reply on the same thread is NOT the
+// subject's personal data and must not be touched. Value verified against
+// the live CHECK constraints on review_replies and support_ticket_replies.
+const authorTypeCustomer = "customer"
+
+// Step is one parameterised statement in the erasure plan.
+type Step struct {
+	// Table is the table the statement writes to. Three gift_cards steps
+	// share a name because one row can hold the subject in three roles.
+	Table string
+	// Disposition declares what the statement does. Every step has one.
+	Disposition Disposition
+	// SQL is a GORM-style statement with `?` placeholders. The subject's
+	// email NEVER appears in this string.
+	SQL string
+	// Args are the positional args for SQL's `?` placeholders, in order.
+	Args []any
+}
+
+// erasurePlan returns the ordered statements that erase one subject from one
+// store. It is PURE — no DB handle, no I/O — so it is unit-testable and the
+// schema-coverage guard can assert against it directly.
+//
+// token replaces the subject's email wherever a row survives; see Token.
+func erasurePlan(storeID uuid.UUID, email string, token string) []Step {
+	// profileIDs locates the subject's profile row(s) for the tables that
+	// key on customer_profiles.id rather than on an email column. It is
+	// itself store-scoped, so a table without its own store_id (e.g.
+	// customer_addresses) is still confined to this merchant.
+	const profileIDs = `SELECT id FROM customer_profiles WHERE store_id = ? AND email = ?`
+	// subjectOrders locates the subject's orders. Only usable BEFORE the
+	// orders anonymisation step, which is why orders runs last.
+	const subjectOrders = `SELECT id FROM orders WHERE store_id = ? AND customer_email = ?`
+
+	steps := []Step{
+		// ---- Group 1: DELETE. Rows that exist only to serve the customer.
+		// Children before parents.
+		{
+			Table:       "review_reactions", // 000017
+			Disposition: DispositionDelete,
+			SQL:         `DELETE FROM review_reactions WHERE customer_profile_id IN (` + profileIDs + `)`,
+			Args:        []any{storeID, email},
+		},
+		{
+			// Customer-uploaded photographs. Deleted, not anonymised: a
+			// photograph is not aggregate-rating-bearing, and it can show
+			// the person.
+			Table:       "review_media", // 000017
+			Disposition: DispositionDelete,
+			SQL: `DELETE FROM review_media WHERE review_id IN (
+				SELECT id FROM reviews WHERE store_id = ? AND customer_email = ?)`,
+			Args: []any{storeID, email},
+		},
+		{
+			Table:       "wishlists", // 000018
+			Disposition: DispositionDelete,
+			SQL:         `DELETE FROM wishlists WHERE store_id = ? AND customer_id IN (` + profileIDs + `)`,
+			Args:        []any{storeID, storeID, email},
+		},
+		{
+			Table:       "customer_addresses", // 000013
+			Disposition: DispositionDelete,
+			SQL:         `DELETE FROM customer_addresses WHERE customer_id IN (` + profileIDs + `)`,
+			Args:        []any{storeID, email},
+		},
+		{
+			// Deleting the cart takes items_snapshot (JSONB) with it, which
+			// is why abandoned_carts needs no blob handling.
+			Table:       "abandoned_carts", // 000002
+			Disposition: DispositionDelete,
+			SQL:         `DELETE FROM abandoned_carts WHERE store_id = ? AND customer_email = ?`,
+			Args:        []any{storeID, email},
+		},
+		{
+			// storefront_push_tokens carries store_slug, not store_id, and
+			// has no FK to customer_profiles — the profile subquery is what
+			// makes this store-scoped.
+			Table:       "storefront_push_tokens", // 000022
+			Disposition: DispositionDelete,
+			SQL:         `DELETE FROM storefront_push_tokens WHERE customer_id IN (` + profileIDs + `)`,
+			Args:        []any{storeID, email},
+		},
+		{
+			// Same shape as storefront_push_tokens: store_slug, no FK.
+			Table:       "product_notify_subscriptions", // 000023
+			Disposition: DispositionDelete,
+			SQL:         `DELETE FROM product_notify_subscriptions WHERE customer_id IN (` + profileIDs + `)`,
+			Args:        []any{storeID, email},
+		},
+		{
+			// campaign_recipients has NO store_id — only tenant_id and a
+			// campaign_id FK. Scoped through campaigns.store_id.
+			Table:       "campaign_recipients", // 000024
+			Disposition: DispositionDelete,
+			SQL: `DELETE FROM campaign_recipients WHERE customer_email = ?
+				AND campaign_id IN (SELECT id FROM campaigns WHERE store_id = ?)`,
+			Args: []any{email, storeID},
+		},
+		{
+			// recipient_user_id is varchar with no FK, and holds
+			// customer_profiles.id — established while fixing #350. Hence
+			// the ::text cast.
+			Table:       "notifications", // 000091
+			Disposition: DispositionDelete,
+			SQL: `DELETE FROM notifications WHERE store_id = ? AND recipient_user_id IN (
+				SELECT id::text FROM customer_profiles WHERE store_id = ? AND email = ?)`,
+			Args: []any{storeID, storeID, email},
+		},
+		{
+			Table:       "email_sends", // 000108
+			Disposition: DispositionDelete,
+			SQL:         `DELETE FROM email_sends WHERE store_id = ? AND recipient = ?`,
+			Args:        []any{storeID, email},
+		},
+
+		// ---- Group 2: ANONYMISE. Rows that must survive.
+
+		{
+			// name, line1 and city are NOT NULL — they take placeholders,
+			// not NULL. country_code is DELIBERATELY untouched: it is
+			// required for tax reporting and is not identifying alone.
+			Table:       "order_addresses", // 000001
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE order_addresses SET name = ?, line1 = ?, line2 = NULL, city = ?,
+				region = NULL, postal_code = NULL, phone = NULL
+				WHERE order_id IN (` + subjectOrders + `)`,
+			Args: []any{RedactedName, RedactedLine, RedactedLine, storeID, email},
+		},
+		{
+			// order_events is mixed-subject: staff actors appear here too.
+			// Only rows whose actor IS the subject are rewritten.
+			Table:       "order_events", // 000001
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE order_events SET actor_email = ?
+				WHERE actor_email = ? AND order_id IN (` + subjectOrders + `)`,
+			Args: []any{token, email, storeID, email},
+		},
+		{
+			// pickup_details is free text holding the customer's pickup
+			// address. It is nullable, so it is cleared outright.
+			Table:       "returns", // 000006
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE returns SET pickup_details = NULL
+				WHERE store_id = ? AND order_id IN (` + subjectOrders + `)`,
+			Args: []any{storeID, storeID, email},
+		},
+		{
+			// Anonymised, not deleted: deleting retroactively changes the
+			// merchant's historical star rating. customer_name and
+			// customer_email are both NOT NULL.
+			Table:       "reviews", // 000017
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE reviews SET customer_email = ?, customer_name = ?, customer_profile_id = NULL
+				WHERE store_id = ? AND customer_email = ?`,
+			Args: []any{token, RedactedName, storeID, email},
+		},
+		{
+			// Scoped by store through reviews, but NOT by the subject's
+			// email on reviews — a customer can reply on someone else's
+			// review. author_name is NOT NULL.
+			Table:       "review_replies", // 000017
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE review_replies SET author_email = ?, author_name = ?
+				WHERE author_type = ? AND author_email = ?
+				AND review_id IN (SELECT id FROM reviews WHERE store_id = ?)`,
+			Args: []any{token, RedactedName, authorTypeCustomer, email, storeID},
+		},
+		{
+			// coupon_usage has no store_id and NO name column — only
+			// customer_email. Scoped through orders.store_id.
+			Table:       "coupon_usage", // 000025
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE coupon_usage SET customer_email = ?
+				WHERE customer_email = ? AND order_id IN (SELECT id FROM orders WHERE store_id = ?)`,
+			Args: []any{token, email, storeID},
+		},
+		{
+			// promo_redemptions has no name column; its email column is
+			// literally `email`.
+			Table:       "promo_redemptions",
+			Disposition: DispositionAnonymise,
+			SQL:         `UPDATE promo_redemptions SET email = ? WHERE store_id = ? AND email = ?`,
+			Args:        []any{token, storeID, email},
+		},
+		{
+			Table:       "customer_loyalties", // 000026
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE customer_loyalties SET customer_email = ?, customer_name = ?
+				WHERE store_id = ? AND customer_email = ?`,
+			Args: []any{token, RedactedName, storeID, email},
+		},
+		{
+			// gift_cards holds the subject in THREE roles, each its own
+			// pair of columns, and any one row can hold the subject in more
+			// than one. One step per role. The free-text `message` is the
+			// sender's, so it is cleared with the sender.
+			Table:       "gift_cards", // 000027
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE gift_cards SET sender_email = ?, sender_name = ?, message = NULL
+				WHERE store_id = ? AND sender_email = ?`,
+			Args: []any{token, RedactedName, storeID, email},
+		},
+		{
+			Table:       "gift_cards",
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE gift_cards SET recipient_email = ?, recipient_name = ?
+				WHERE store_id = ? AND recipient_email = ?`,
+			Args: []any{token, RedactedName, storeID, email},
+		},
+		{
+			Table:       "gift_cards",
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE gift_cards SET purchased_by_email = ?, purchased_by_name = ?
+				WHERE store_id = ? AND purchased_by_email = ?`,
+			Args: []any{token, RedactedName, storeID, email},
+		},
+		{
+			// support_tickets is the CUSTOMER support table (000089);
+			// submitted_by_name and submitted_by_email are both NOT NULL.
+			Table:       "support_tickets", // 000089
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE support_tickets SET submitted_by_email = ?, submitted_by_name = ?
+				WHERE store_id = ? AND submitted_by_email = ?`,
+			Args: []any{token, RedactedName, storeID, email},
+		},
+		{
+			Table:       "support_ticket_replies", // 000089
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE support_ticket_replies SET author_email = ?, author_name = ?
+				WHERE author_type = ? AND author_email = ?
+				AND ticket_id IN (SELECT id FROM support_tickets WHERE store_id = ?)`,
+			Args: []any{token, RedactedName, authorTypeCustomer, email, storeID},
+		},
+		{
+			// `tickets` (000019) is the platform-engineering table, normally
+			// merchant-submitted. It is covered anyway: the match is on the
+			// subject's exact email within this store, so a row only changes
+			// if it really does name the subject.
+			Table:       "tickets", // 000019
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE tickets SET submitted_by_email = ?, submitted_by_name = ?
+				WHERE store_id = ? AND submitted_by_email = ?`,
+			Args: []any{token, RedactedName, storeID, email},
+		},
+		{
+			Table:       "ticket_replies", // 000019
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE ticket_replies SET author_email = ?, author_name = ?
+				WHERE author_type = ? AND author_email = ?
+				AND ticket_id IN (SELECT id FROM tickets WHERE store_id = ?)`,
+			Args: []any{token, RedactedName, authorTypeCustomer, email, storeID},
+		},
+		{
+			// LAST anonymise step: order_addresses, order_events and returns
+			// all find their rows through orders.customer_email.
+			// customer_email is NOT NULL; customer_name is nullable but is
+			// given the placeholder rather than NULL so the row still reads
+			// as deliberately erased rather than as a guest order.
+			Table:       "orders", // 000001
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE orders SET customer_email = ?, customer_name = ?, customer_id = NULL
+				WHERE store_id = ? AND customer_email = ?`,
+			Args: []any{token, RedactedName, storeID, email},
+		},
+
+		// ---- Group 3: DELETE the identity itself, last.
+		{
+			// Everything above either deleted its rows or nulled its
+			// customer_profile_id, so nothing references this row by the
+			// time it goes.
+			Table:       "customer_profiles", // 000013
+			Disposition: DispositionDelete,
+			SQL:         `DELETE FROM customer_profiles WHERE store_id = ? AND email = ?`,
+			Args:        []any{storeID, email},
+		},
+	}
+
+	return steps
+}

--- a/services/marketplace-api/internal/customererasure/plan.go
+++ b/services/marketplace-api/internal/customererasure/plan.go
@@ -246,14 +246,6 @@ func erasurePlan(storeID uuid.UUID, email string, token string) []Step {
 			Args: []any{token, email, storeID},
 		},
 		{
-			// promo_redemptions has no name column; its email column is
-			// literally `email`.
-			Table:       "promo_redemptions",
-			Disposition: DispositionAnonymise,
-			SQL:         `UPDATE promo_redemptions SET email = ? WHERE store_id = ? AND email = ?`,
-			Args:        []any{token, storeID, email},
-		},
-		{
 			Table:       "customer_loyalties", // 000026
 			Disposition: DispositionAnonymise,
 			SQL: `UPDATE customer_loyalties SET customer_email = ?, customer_name = ?

--- a/services/marketplace-api/internal/customererasure/plan_test.go
+++ b/services/marketplace-api/internal/customererasure/plan_test.go
@@ -1,0 +1,159 @@
+package customererasure
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// subjectEmail is deliberately distinctive so the "never interpolated"
+// assertion below cannot pass by accident on a substring.
+const subjectEmail = "erasure-subject-9f3a@example.test"
+
+func testPlan(t *testing.T) (uuid.UUID, uuid.UUID, []Step) {
+	t.Helper()
+	storeID := uuid.New()
+	requestID := uuid.New()
+	return storeID, requestID, erasurePlan(storeID, subjectEmail, Token(requestID))
+}
+
+func TestErasurePlan_EveryStepIsWellFormed(t *testing.T) {
+	_, _, steps := testPlan(t)
+	require.NotEmpty(t, steps, "an empty plan would make every other assertion vacuous")
+
+	for i, s := range steps {
+		require.NotEmpty(t, s.Table, "step %d has no table", i)
+		require.NotEmpty(t, s.SQL, "step %d (%s) has no SQL", i, s.Table)
+		require.Contains(t, []Disposition{DispositionDelete, DispositionAnonymise}, s.Disposition,
+			"step %d (%s) must declare a known disposition", i, s.Table)
+		require.Equal(t, strings.Count(s.SQL, "?"), len(s.Args),
+			"step %d (%s): every ? must have exactly one bound arg", i, s.Table)
+	}
+}
+
+// An unscoped WHERE would erase a different merchant's customers. Every
+// statement must be confined to the store, directly or through a subquery.
+func TestErasurePlan_EveryStepIsScopedToTheStore(t *testing.T) {
+	storeID, _, steps := testPlan(t)
+
+	for i, s := range steps {
+		require.Contains(t, s.SQL, "store_id = ?",
+			"step %d (%s) is not scoped to a store", i, s.Table)
+		require.Contains(t, s.Args, any(storeID),
+			"step %d (%s) names store_id but does not bind the store", i, s.Table)
+	}
+}
+
+// The subject's email must reach Postgres as a bound parameter and never as
+// part of the statement text. This guards against a future edit reaching for
+// fmt.Sprintf.
+func TestErasurePlan_NeverInterpolatesTheEmail(t *testing.T) {
+	_, _, steps := testPlan(t)
+
+	sawEmailBound := false
+	for i, s := range steps {
+		require.NotContains(t, s.SQL, subjectEmail,
+			"step %d (%s) interpolated the subject's email into the SQL string", i, s.Table)
+		for _, a := range s.Args {
+			if a == any(subjectEmail) {
+				sawEmailBound = true
+			}
+		}
+	}
+	require.True(t, sawEmailBound, "no step bound the email at all — the plan cannot be matching the subject")
+}
+
+// customer_profiles is the identity row that groups 1 and 2 reach by
+// subquery. If anything ran after it, that subquery would find nothing and
+// the step would silently erase nothing.
+func TestErasurePlan_DeletesCustomerProfilesLast(t *testing.T) {
+	_, _, steps := testPlan(t)
+
+	last := steps[len(steps)-1]
+	require.Equal(t, "customer_profiles", last.Table)
+	require.Equal(t, DispositionDelete, last.Disposition)
+
+	for i, s := range steps[:len(steps)-1] {
+		require.NotEqual(t, "customer_profiles", s.Table,
+			"step %d also touches customer_profiles; it must appear exactly once, last", i)
+	}
+}
+
+// order_addresses, order_events and returns all locate their rows through
+// `orders WHERE customer_email = <subject>`. Anonymising orders first would
+// orphan every one of them and they would erase nothing.
+func TestErasurePlan_AnonymisesOrdersAfterEveryOrderScopedStep(t *testing.T) {
+	_, _, steps := testPlan(t)
+
+	ordersIdx := -1
+	for i, s := range steps {
+		if s.Table == "orders" {
+			require.Equal(t, -1, ordersIdx, "orders must appear exactly once")
+			ordersIdx = i
+		}
+	}
+	require.NotEqual(t, -1, ordersIdx, "the plan must anonymise orders")
+
+	for _, dependent := range []string{"order_addresses", "order_events", "returns"} {
+		found := false
+		for i, s := range steps {
+			if s.Table != dependent {
+				continue
+			}
+			found = true
+			require.Less(t, i, ordersIdx,
+				"%s reads orders.customer_email and must run before orders is anonymised", dependent)
+		}
+		require.True(t, found, "the plan must cover %s", dependent)
+	}
+}
+
+// review_media is deleted by joining reviews on the subject's email, so it
+// must run while reviews still carry that email.
+func TestErasurePlan_DeletesReviewMediaBeforeAnonymisingReviews(t *testing.T) {
+	_, _, steps := testPlan(t)
+
+	mediaIdx, reviewsIdx := -1, -1
+	for i, s := range steps {
+		switch s.Table {
+		case "review_media":
+			mediaIdx = i
+		case "reviews":
+			reviewsIdx = i
+		}
+	}
+	require.NotEqual(t, -1, mediaIdx, "the plan must delete review_media")
+	require.NotEqual(t, -1, reviewsIdx, "the plan must anonymise reviews")
+	require.Less(t, mediaIdx, reviewsIdx)
+}
+
+// country_code is required for tax reporting and is not identifying on its
+// own. Erasing it would break the merchant's tax record for no privacy gain.
+func TestErasurePlan_LeavesOrderAddressCountryCodeAlone(t *testing.T) {
+	_, _, steps := testPlan(t)
+
+	for _, s := range steps {
+		if s.Table != "order_addresses" {
+			continue
+		}
+		require.NotContains(t, s.SQL, "country_code",
+			"order_addresses.country_code is retained for tax reporting")
+		return
+	}
+	t.Fatal("the plan must cover order_addresses")
+}
+
+func TestToken_IsDeterministicAndCarriesNoPersonalData(t *testing.T) {
+	requestID := uuid.New()
+
+	require.Equal(t, Token(requestID), Token(requestID), "the token must be stable for one request")
+	require.NotEqual(t, Token(requestID), Token(uuid.New()), "two requests must not share a token")
+
+	tok := Token(requestID)
+	require.NotContains(t, tok, subjectEmail)
+	require.NotContains(t, tok, RedactedName)
+	require.True(t, strings.HasSuffix(tok, "@erased.invalid"),
+		".invalid is reserved by RFC 2606 and can never be routed")
+}

--- a/services/marketplace-api/internal/customererasure/token.go
+++ b/services/marketplace-api/internal/customererasure/token.go
@@ -1,0 +1,29 @@
+package customererasure
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// Token is the value that replaces a subject's email everywhere the row must
+// survive erasure. It is derived from the ERASURE REQUEST ID, not from the
+// email: a hash of the email would still be a pseudonym of the personal data
+// and brute-forceable against a known address list, whereas the request id is
+// unrelated to the person and already exists.
+//
+// Deterministic per request, so two anonymised orders by the same subject
+// still group together — which is what makes the financial record coherent
+// after erasure — while identifying nobody.
+//
+// .invalid is reserved by RFC 2606 and can never be routed, so an anonymised
+// address cannot accidentally receive mail.
+func Token(requestID uuid.UUID) string {
+	return fmt.Sprintf("erased+%s@erased.invalid", requestID.String())
+}
+
+// RedactedName replaces a person's name where the column is NOT NULL.
+const RedactedName = "Erased customer"
+
+// RedactedLine replaces a NOT NULL address line.
+const RedactedLine = "[erased]"

--- a/services/marketplace-api/internal/handlers/platformadmin/inbox_action_erasure.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/inbox_action_erasure.go
@@ -1,0 +1,115 @@
+package platformadmin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/customererasure"
+	"github.com/mark8ly/marketplace-api/internal/inbox"
+)
+
+// CustomerEraser is the slice of *customererasure.Executor this action needs,
+// declared here as a local interface for the same reason every other
+// dependency in this package is: the handler stays testable without a
+// database, and this package does not depend on the concrete executor.
+//
+// Lookup is separate from Process because a Receipt deliberately carries no
+// tenant or store — it is evidence about data, not about ownership — and the
+// audit row needs a tenant to be attributable at all (#310).
+type CustomerEraser interface {
+	Process(ctx context.Context, requestID uuid.UUID) (customererasure.Receipt, error)
+	Reject(ctx context.Context, requestID uuid.UUID, notes string) (customererasure.Request, error)
+	Lookup(ctx context.Context, requestID uuid.UUID) (customererasure.Request, error)
+}
+
+// ErasureExecutor executes process/reject for the erasure_request inbox kind
+// (#259).
+//
+// This is the surface that turns a GDPR art.17 request into IRREVERSIBLE
+// destruction of a person's data, so two things are deliberate and neither is
+// defensive padding:
+//
+//   - An unknown actionID is an explicit error, never a fall-through. The
+//     handler already checks the item's declared actions, so this is
+//     unreachable today; it exists so that an action added to
+//     inbox.ErasureProvider's declaration but not implemented here fails
+//     loudly rather than landing in whatever branch happens to be last.
+//   - A missing operator id is refused. An erasure that cannot be attributed
+//     to anyone must not run: the audit row would record an anonymous
+//     destruction of customer data, and there is nothing to undo it with.
+type ErasureExecutor struct{ eraser CustomerEraser }
+
+// NewErasureExecutor constructs the executor.
+func NewErasureExecutor(eraser CustomerEraser) *ErasureExecutor {
+	return &ErasureExecutor{eraser: eraser}
+}
+
+func (e *ErasureExecutor) Kind() string { return inbox.KindErasureRequest }
+
+func (e *ErasureExecutor) Execute(
+	ctx context.Context, item inbox.Item, actionID, operatorID, notes string,
+) (InboxActionResult, error) {
+	requestID, err := uuid.Parse(item.ID)
+	if err != nil {
+		return InboxActionResult{}, fmt.Errorf("erasure: item id is not a uuid: %w", err)
+	}
+	if strings.TrimSpace(operatorID) == "" {
+		return InboxActionResult{}, ErrMissingOperator
+	}
+
+	switch actionID {
+	case "process":
+		return e.process(ctx, requestID, item.ID)
+	case "reject":
+		return e.reject(ctx, requestID, item.ID, notes)
+	default:
+		return InboxActionResult{}, fmt.Errorf("erasure: unsupported action %q", actionID)
+	}
+}
+
+func (e *ErasureExecutor) process(ctx context.Context, requestID uuid.UUID, itemID string) (InboxActionResult, error) {
+	if _, err := e.eraser.Process(ctx, requestID); err != nil {
+		return InboxActionResult{}, translateErasureErr(err, itemID)
+	}
+	// Read AFTER the erasure, not before: the row is still there (its own
+	// status is the receipt) and reading it afterwards means the attribution
+	// describes a request that actually completed, rather than one that was
+	// merely about to be attempted.
+	req, err := e.eraser.Lookup(ctx, requestID)
+	if err != nil {
+		return InboxActionResult{}, translateErasureErr(err, itemID)
+	}
+	return erasureResult(req), nil
+}
+
+func (e *ErasureExecutor) reject(ctx context.Context, requestID uuid.UUID, itemID, notes string) (InboxActionResult, error) {
+	req, err := e.eraser.Reject(ctx, requestID, notes)
+	if err != nil {
+		return InboxActionResult{}, translateErasureErr(err, itemID)
+	}
+	return erasureResult(req), nil
+}
+
+func erasureResult(req customererasure.Request) InboxActionResult {
+	storeID := req.StoreID
+	return InboxActionResult{TenantID: req.TenantID, StoreID: &storeID, Status: req.Status}
+}
+
+// translateErasureErr maps a claim that another worker or operator already
+// took into the inbox vocabulary, so the handler answers 409 "already
+// actioned" rather than 500 — exactly as the migration executor does for a
+// second decision. Two operators clicking the same queue row is the common
+// race, and 409 is the answer that tells them what happened.
+func translateErasureErr(err error, itemID string) error {
+	if errors.Is(err, customererasure.ErrAlreadyClaimed) || errors.Is(err, customererasure.ErrRequestNotFound) {
+		return fmt.Errorf("%w: %s", inbox.ErrItemNotFound, itemID)
+	}
+	// Everything else is surfaced as-is. The erasure package's own errors are
+	// already free of the subject's personal data (see StepError), which
+	// matters because the handler logs this.
+	return err
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/inbox_action_erasure_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/inbox_action_erasure_test.go
@@ -1,0 +1,190 @@
+package platformadmin_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/customererasure"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/internal/inbox"
+)
+
+// fakeEraser records what the inbox action asked for. The real erasure is
+// exercised against a live schema in internal/customererasure; what matters
+// here is the ROUTING — that "process" destroys and "reject" does not, and
+// that neither happens without an operator.
+type fakeEraser struct {
+	processed []uuid.UUID
+	rejected  []uuid.UUID
+	notes     string
+	req       customererasure.Request
+	procErr   error
+	rejErr    error
+}
+
+func (f *fakeEraser) Process(_ context.Context, id uuid.UUID) (customererasure.Receipt, error) {
+	f.processed = append(f.processed, id)
+	if f.procErr != nil {
+		return customererasure.Receipt{}, f.procErr
+	}
+	return customererasure.Receipt{RequestID: id}, nil
+}
+
+func (f *fakeEraser) Reject(_ context.Context, id uuid.UUID, notes string) (customererasure.Request, error) {
+	f.rejected = append(f.rejected, id)
+	f.notes = notes
+	if f.rejErr != nil {
+		return customererasure.Request{}, f.rejErr
+	}
+	out := f.req
+	out.Status = customererasure.StatusRejected
+	return out, nil
+}
+
+func (f *fakeEraser) Lookup(_ context.Context, id uuid.UUID) (customererasure.Request, error) {
+	out := f.req
+	out.ID = id
+	return out, nil
+}
+
+func newFakeEraser() *fakeEraser {
+	return &fakeEraser{req: customererasure.Request{
+		TenantID: uuid.New(), StoreID: uuid.New(), Status: customererasure.StatusCompleted,
+	}}
+}
+
+func erasureItem() inbox.Item {
+	return inbox.Item{
+		ID:   "22222222-2222-2222-2222-222222222222",
+		Kind: inbox.KindErasureRequest,
+		Actions: []inbox.Action{
+			{ID: "process", Label: "Process erasure", Destructive: true},
+			{ID: "reject", Label: "Reject", Destructive: false},
+		},
+	}
+}
+
+func TestErasureExecutor_ProcessErasesAndReportsTheTenant(t *testing.T) {
+	f := newFakeEraser()
+	res, err := platformadmin.NewErasureExecutor(f).
+		Execute(context.Background(), erasureItem(), "process", "op-1", "")
+
+	require.NoError(t, err)
+	require.Len(t, f.processed, 1)
+	require.Equal(t, uuid.MustParse(erasureItem().ID), f.processed[0])
+	require.Equal(t, customererasure.StatusCompleted, res.Status)
+	require.Equal(t, f.req.TenantID, res.TenantID,
+		"the audit row needs a tenant; EmitOperatorAction refuses uuid.Nil (#310)")
+	require.NotNil(t, res.StoreID)
+	require.Equal(t, f.req.StoreID, *res.StoreID)
+}
+
+func TestErasureExecutor_RejectDestroysNothing(t *testing.T) {
+	f := newFakeEraser()
+	res, err := platformadmin.NewErasureExecutor(f).
+		Execute(context.Background(), erasureItem(), "reject", "op-1", "identity unverified")
+
+	require.NoError(t, err)
+	require.Empty(t, f.processed, "a rejection must never reach the erasure path")
+	require.Len(t, f.rejected, 1)
+	require.Equal(t, "identity unverified", f.notes)
+	require.Equal(t, customererasure.StatusRejected, res.Status)
+}
+
+// An erasure that cannot be attributed to anyone must not run: the audit row
+// would record an anonymous, irreversible destruction of customer data.
+func TestErasureExecutor_RefusesAnUnattributedErasure(t *testing.T) {
+	f := newFakeEraser()
+	_, err := platformadmin.NewErasureExecutor(f).
+		Execute(context.Background(), erasureItem(), "process", "  ", "")
+
+	require.ErrorIs(t, err, platformadmin.ErrMissingOperator)
+	require.Empty(t, f.processed)
+}
+
+// An action added to the provider's declaration but not implemented here must
+// fail loudly. Falling through to the destructive branch would be the worst
+// possible default for this kind.
+func TestErasureExecutor_UnknownActionFailsAndErasesNothing(t *testing.T) {
+	f := newFakeEraser()
+	_, err := platformadmin.NewErasureExecutor(f).
+		Execute(context.Background(), erasureItem(), "archive", "op-1", "")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "archive")
+	require.Empty(t, f.processed)
+	require.Empty(t, f.rejected)
+}
+
+func TestErasureExecutor_NonUUIDItemIDIsRejected(t *testing.T) {
+	f := newFakeEraser()
+	item := erasureItem()
+	item.ID = "not-a-uuid"
+	_, err := platformadmin.NewErasureExecutor(f).
+		Execute(context.Background(), item, "process", "op-1", "")
+
+	require.Error(t, err)
+	require.Empty(t, f.processed)
+}
+
+// Two operators on the same queue row is the common race. 409 "already
+// actioned" tells them what happened; 500 does not.
+func TestErasureExecutor_AlreadyClaimedBecomesItemNotFound(t *testing.T) {
+	for name, injected := range map[string]error{
+		"another worker holds it": customererasure.ErrAlreadyClaimed,
+		"the row is gone":         customererasure.ErrRequestNotFound,
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := newFakeEraser()
+			f.procErr = injected
+			_, err := platformadmin.NewErasureExecutor(f).
+				Execute(context.Background(), erasureItem(), "process", "op-1", "")
+			require.ErrorIs(t, err, inbox.ErrItemNotFound)
+		})
+	}
+}
+
+func TestErasureExecutor_OtherFailuresSurfaceUnchanged(t *testing.T) {
+	f := newFakeEraser()
+	f.procErr = errors.New("customererasure: anonymise step on orders failed with SQLSTATE 23503")
+	_, err := platformadmin.NewErasureExecutor(f).
+		Execute(context.Background(), erasureItem(), "process", "op-1", "")
+
+	require.Error(t, err)
+	require.NotErrorIs(t, err, inbox.ErrItemNotFound,
+		"a real failure must not be dressed up as a race — it needs a 500 and a log line")
+}
+
+// The 501 is genuinely gone. Before #259 the erasure kind had no executor and
+// the handler answered "action_not_implemented"; this asserts the registered
+// executor is what now answers, end to end through the handler.
+func TestInboxAction_ErasureKindIsNoLongerNotImplemented(t *testing.T) {
+	f := newFakeEraser()
+	item := erasureItem()
+	r := actionRouter(t, stubItemSource{item: item}, platformadmin.NewErasureExecutor(f), newMemIdempotency())
+
+	rec := post(t, r, "/admin/inbox/"+inbox.KindErasureRequest+"/"+item.ID+"/actions/process", "erase-key-1", `{}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotContains(t, rec.Body.String(), "action_not_implemented")
+	require.Len(t, f.processed, 1, "the registered executor must be the thing that ran")
+}
+
+// The destructive action still requires an idempotency key. A retried erasure
+// must replay, not erase a second time.
+func TestInboxAction_ErasureProcessStillRequiresAnIdempotencyKey(t *testing.T) {
+	f := newFakeEraser()
+	item := erasureItem()
+	r := actionRouter(t, stubItemSource{item: item}, platformadmin.NewErasureExecutor(f), newMemIdempotency())
+
+	rec := post(t, r, "/admin/inbox/"+inbox.KindErasureRequest+"/"+item.ID+"/actions/process", "", `{}`)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "idempotency_key_required")
+	require.Empty(t, f.processed, "nothing may be erased before the key is checked")
+}

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 112
+const ExpectedSchemaVersion uint = 113

--- a/services/marketplace-api/migrations/000113_customer_erasure_execution.down.sql
+++ b/services/marketplace-api/migrations/000113_customer_erasure_execution.down.sql
@@ -1,0 +1,18 @@
+ALTER TABLE customer_erasure_requests DROP COLUMN IF EXISTS attempts;
+
+-- Rows in a state the old constraint forbids must be normalised before it
+-- can be re-added, otherwise the ALTER fails on real data.
+UPDATE customer_erasure_requests SET status = 'processed' WHERE status = 'completed';
+UPDATE customer_erasure_requests SET status = 'pending'   WHERE status IN ('processing', 'failed');
+
+ALTER TABLE customer_erasure_requests
+    DROP CONSTRAINT IF EXISTS customer_erasure_requests_status_check;
+ALTER TABLE customer_erasure_requests
+    ADD CONSTRAINT customer_erasure_requests_status_check
+    CHECK (status IN ('pending', 'processed', 'rejected'));
+
+COMMENT ON TABLE orders IS NULL;
+COMMENT ON TABLE order_addresses IS NULL;
+COMMENT ON TABLE payment_transactions IS NULL;
+COMMENT ON TABLE refund_transactions IS NULL;
+COMMENT ON TABLE platform_fee_ledger IS NULL;

--- a/services/marketplace-api/migrations/000113_customer_erasure_execution.up.sql
+++ b/services/marketplace-api/migrations/000113_customer_erasure_execution.up.sql
@@ -1,0 +1,41 @@
+-- 000113 — GDPR art.17 erasure EXECUTION (#259).
+--
+-- Two things, both prerequisites for a worker that can actually run.
+--
+-- 1. A state machine. The original CHECK admitted only
+--    ('pending','processed','rejected') — there was no in-flight state at
+--    all, so a worker could not mark a row as being worked on, and a crash
+--    mid-erasure was indistinguishable from one never started. #259
+--    describes 'processing'/'completed'/'failed' as already existing; they
+--    did not. 'processed' is kept as a terminal alias so existing rows stay
+--    valid and no backfill is needed.
+--
+--    Constraint name verified against the live schema before this migration
+--    was written: customer_erasure_requests_status_check.
+ALTER TABLE customer_erasure_requests
+    DROP CONSTRAINT IF EXISTS customer_erasure_requests_status_check;
+
+ALTER TABLE customer_erasure_requests
+    ADD CONSTRAINT customer_erasure_requests_status_check
+    CHECK (status IN ('pending', 'processing', 'completed', 'failed', 'processed', 'rejected'));
+
+-- attempts bounds retry: a request that fails repeatedly must stop being
+-- retried forever and become visible to an operator instead.
+ALTER TABLE customer_erasure_requests
+    ADD COLUMN IF NOT EXISTS attempts INT NOT NULL DEFAULT 0;
+
+-- 2. The retention basis, written down where it is enforced.
+--    Until now the ONLY retention text in any migration was
+--    billing_archive's (000046). The erasure below ANONYMISES rather than
+--    deletes these tables, and that choice needs its justification recorded
+--    next to the data, not only in a design document.
+COMMENT ON TABLE orders IS
+    'Financial record. Personal fields are anonymised on GDPR art.17 erasure; the row is retained 7 years under legal-obligation basis, matching billing_archive (§23.2). See #259.';
+COMMENT ON TABLE order_addresses IS
+    'Financial record (delivery evidence). Personal fields anonymised on erasure; country_code retained for tax reporting. 7-year legal-obligation retention (§23.2). See #259.';
+COMMENT ON TABLE payment_transactions IS
+    'Financial record. Anonymised, not deleted, on GDPR art.17 erasure; retained 7 years under legal-obligation basis (§23.2). See #259.';
+COMMENT ON TABLE refund_transactions IS
+    'Financial record. Anonymised, not deleted, on GDPR art.17 erasure; retained 7 years under legal-obligation basis (§23.2). See #259.';
+COMMENT ON TABLE platform_fee_ledger IS
+    'Financial record. Anonymised, not deleted, on GDPR art.17 erasure; retained 7 years under legal-obligation basis (§23.2). See #259.';


### PR DESCRIPTION
Closes #259.

`customer_erasure_requests` has collected GDPR art.17 requests since migration 059 and **nothing has ever processed one** — confirmed: zero `UPDATE` statements against that table anywhere in the repo. This adds the half that honours them.

Design proposal: #432 (merged). Decisions in it were made by the product owner; this implements them.

## Three corrections to the issue

- **The status vocabulary was wrong.** #259 says `processing`, `completed` and `failed` "exist in the schema". The real constraint was `CHECK (status IN ('pending','processed','rejected'))` — there was **no in-flight state at all**, so a worker could not mark a row as being worked on and a crash mid-erasure was indistinguishable from one never started. Migration 000113 adds them; `processed` is kept as a terminal alias so no backfill is needed.
- **The subject is identified by email only** — no `customer_id`, no `gip_uid` on the table.
- **The dedupe comment is inaccurate:** migration 059 says a second request "re-sets the clock"; the insert is `ON CONFLICT DO NOTHING`, so it does not.

## Erasure keys on email, not customer_id

`orders.customer_id` is set **only** when a logged-in profile is in request context (`handlers/storefront/checkout.go:175-181`), so guest checkouts leave it NULL, while `customer_email` is `NOT NULL`. `customer_id` is matched as a supplementary predicate, never the primary one. This was the blocking question in the proposal's §3; it is answered from the code, not from a sample.

## Shape

Mirrors `internal/tenantpurge`: a **pure** `erasurePlan(storeID, email, token)` returning 26 ordered steps, each with a declared disposition, and an executor that runs them in one transaction under a per-store advisory lock.

**Two dispositions.** A row that exists only to serve the customer is DELETED. A row that must survive for financial-record reasons is ANONYMISED and retained **7 years under legal-obligation basis**, matching `billing_archive` (§23.2) — the number #365 chose so the estate has one retention story rather than two. Migration 000113 writes that basis into `COMMENT ON TABLE` for the five financial tables, because until now the only retention text in any migration was `billing_archive`'s.

**The anonymisation token is derived from the request id**, not the email: hashing the email would still be a pseudonym of the personal data and brute-forceable against a known address list. `erased+<request-id>@erased.invalid` — `.invalid` is RFC 2606 reserved and can never be routed. Deterministic per request, so two anonymised orders still group together while identifying nobody.

`order_addresses.country_code` is deliberately **not** touched — required for tax reporting, not identifying on its own.

## The coverage guard is the load-bearing test

`TestErasurePlan_CoversEveryCustomerLinkedTable` reads the **live schema**, finds every table with a customer-link column, and fails when one is neither erased nor a declared exclusion. A table added next year cannot silently escape erasure.

`declaredExclusions` is the only way to silence it, so it is deliberately expensive to abuse: `TestDeclaredExclusions_AreJustifiedAndLive` fails on an empty justification, on an exclusion the guard would never have flagged (no inert entries), and on one the plan also covers.

`TestErasurePlan_EveryStepIsValidSQLAgainstTheLiveSchema` executes all 26 statements inside a rolled-back transaction — catching a column that does not exist, which the pure tests cannot see.

## Four errors in my own survey, found by verifying rather than trusting

Recorded in #432's doc rather than silently edited:

1. **`promo_redemptions` is NOT customer data.** It is the subscription promo engine (§7): `promo.Service` writes `normaliseEmail(in.MerchantEmail)` and the row carries `subscription_id`, not an order. Its email is the **merchant's**. Anonymising it during a customer erasure would have rewritten a merchant's billing record. Now an exclusion.
2. **`payment_transactions`, `refund_transactions`, `platform_fee_ledger`, `shipments` have no personal column at all** — their only PII is in JSONB, out of scope. They carry no step, but still take the retention comment.
3. **`returns.pickup_details` is `text`, not JSONB** — so it is in scope and is cleared.
4. `coupon_usage` has no name column.

## Privacy details worth calling out

- **Driver error text is discarded.** A Postgres constraint message embeds the offending value — here, the subject's email. `StepError` keeps only `{Table, Disposition, SQLState}`. Asserted in the failure test.
- The receipt records **what was RETAINED and why**, not only what was destroyed — that is the half that answers a regulator — and contains no email, name, phone or address.

## The failure status is written outside the transaction

Deliberately, and pinned by a mutation test: writing `status='failed'` inside the transaction that just rolled back would discard it — exactly the #397 defect this same milestone fixed. It is written after the transaction unwinds, on the pooled handle, under `context.WithoutCancel`.

## Console contract

The erasure inbox item already declared `process` and `reject` and answered **501**, with a wiring comment saying they should not get a one-click path *"before the behaviour beneath it is settled"*. It is settled; the executor is registered and the comment rewritten. `process` still requires an `Idempotency-Key`; a second decision maps to 409 "already actioned".

`cmd/erasure-worker` satisfies tesserix-home#160's coupling test — erasure works with the console down. It requires exactly one of `--request-id` / `--all` (bounded, default 50); there is no default mode, because a binary that erases customer data when run bare is a mistake waiting to happen.

## Test plan

All integration runs used `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'` with `-p 1 -count=1`. **The LAN IP is required — `localhost:5432` reaches a different Postgres with no `dev` role.**

- [x] **Full `test-int` package list: 31 packages ok, zero failures.** Unit suite: 91 packages, no failures
- [x] **Two bystanders, not one.** A same-store different-email customer catches a lost email predicate; a same-email different-store customer catches a lost `store_id` predicate (a real case — one person, several merchants, one request each). Each is asserted still to carry their own name and address, not merely to exist: an anonymised-but-present row is as much a wrongful erasure as a deleted one, and `count(*)` would not notice
- [x] **Mutation:** drop `AND store_id = ?` from the orders step → bystander test FAILS. Restored → green
- [x] **Mutation:** orders ANONYMISE → DELETE → the financial-record test FAILS. (Its immediate cause is the `payment_transactions → orders` RESTRICT FK, so the receipt test was strengthened to assert `Anonymised["orders"] == 1` and `NotContains(Deleted, "orders")` — failing on disposition regardless of referential integrity)
- [x] **Mutation:** move the failure status write inside the transaction → status is `processing`, not `failed`. Restored → green
- [x] **Mutation:** remove a plan step → the coverage guard FAILS naming that table. Blank a justification → the exclusion test FAILS
- [x] Idempotency: a second `Process` on a completed request returns the original receipt, not a second pass's zeroes
- [x] `./internal/customererasure/...` added to `make test-int`

## Known residual, filed

**#435** — nine JSONB columns can embed a customer email or address. They are declared exclusions here **with that issue as the justification**, so the guard passes them for a stated, reviewable reason rather than silently.
