### PR TITLE
fix(campaignbudget): seed trial at the D1-3 tier and stop deriving the ramp ceiling from consumption (#424)

### DIFF
--- a/services/marketplace-api/internal/campaignbudget/monthly_reset.go
+++ b/services/marketplace-api/internal/campaignbudget/monthly_reset.go
@@ -15,10 +15,15 @@ import (
 // payment_action_required, cancel_scheduled. Statuses excluded (merchant cannot
 // send campaigns): expired, store_closed, pending_hard_delete, hard_deleted.
 //
-// The limit_set + remaining start at the plan allowance. Stores currently in
-// trial (D1-7) will have their limit_set overwritten by the trial-ramp cron
-// that runs at 00:00 UTC daily — the ramp cron uses GREATEST semantics so
-// the values remain consistent. Pro subscriptions (plangate.Negotiated) are
+// limit_set + remaining start at the plan allowance, EXCEPT trial, which
+// starts at the §5.1 D1-3 tier of 500 and is raised by the trial-ramp cron
+// on day 4 (to 2000) and day 8 (to the 5000 trial allowance). Seeding trial
+// at the full allowance defeated the ramp entirely: the day-4 step could
+// never raise a ceiling that already exceeded it, so a brand-new store had
+// its whole month's quota on day one (#424).
+//
+// Each ramp step applies at most once, guarded by ramp_step_applied (#399).
+// Pro subscriptions (plangate.Negotiated) are
 // intentionally excluded — ops sets limit_set manually via direct DB update.
 func MonthlyReset(ctx context.Context, db *gorm.DB) error {
 	// Use a CTE to inline plan allowances without needing a DB function.
@@ -26,7 +31,7 @@ func MonthlyReset(ctx context.Context, db *gorm.DB) error {
 	// 'marketplace' is omitted — internal plan, not subject to campaign gates.
 	const sqlWithCTE = `
 		WITH allowance(plan, amount) AS (VALUES
-			('trial',                     5000),
+			('trial',                      500),
 			('starter',                  15000),
 			('studio',                   50000)
 			-- 'pro' intentionally omitted: Negotiated, operator sets manually

--- a/services/marketplace-api/internal/campaignbudget/monthly_reset_test.go
+++ b/services/marketplace-api/internal/campaignbudget/monthly_reset_test.go
@@ -40,6 +40,71 @@ func TestMonthlyReset_SeedsAllActiveSubscriptions(t *testing.T) {
 	}
 }
 
+// A trial store must start at the §5.1 D1-3 tier of 500, NOT at the 5000
+// trial allowance. Seeding at the allowance defeated the ramp entirely: the
+// day-4 step raises the ceiling to 2000, which can never raise a ceiling
+// already at 5000, so a brand-new store had its whole month's quota on day
+// one and the documented D4-7 tier never applied to anyone (#424).
+func TestMonthlyReset_SeedsTrialAtTheD1To3Tier(t *testing.T) {
+	db := testdb.NewDB(t, "campaign_email_budget", "store_subscriptions")
+	tenantID := uuid.New()
+	storeID := uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
+	require.NoError(t, db.Exec(`
+		INSERT INTO store_subscriptions (tenant_id, store_id, stripe_customer_id, plan, status)
+		VALUES ($1, $2, $3, 'trial', 'trialing')`, tenantID, storeID, "cus_"+storeID.String()).Error)
+
+	require.NoError(t, campaignbudget.MonthlyReset(context.Background(), db))
+
+	var remaining, limitSet int
+	require.NoError(t, db.Raw(`
+		SELECT remaining, limit_set FROM campaign_email_budget
+		WHERE store_id = $1 AND month = $2`, storeID, firstOfMonthUTC(time.Now()),
+	).Row().Scan(&remaining, &limitSet))
+
+	require.Equal(t, 500, limitSet, "trial seeds at the D1-3 tier, not the 5000 allowance (#424)")
+	require.Equal(t, 500, remaining)
+
+	// And the ramp must then be able to raise it — proving the tier is a
+	// floor to climb from, not a cap the ramp cannot move.
+	require.NoError(t, campaignbudget.ApplyTrialRamp(context.Background(), db, storeID, 4, "trial"))
+	require.NoError(t, db.Raw(`
+		SELECT remaining, limit_set FROM campaign_email_budget
+		WHERE store_id = $1 AND month = $2`, storeID, firstOfMonthUTC(time.Now()),
+	).Row().Scan(&remaining, &limitSet))
+	require.Equal(t, 2000, limitSet, "day-4 raises the ceiling to the D4-7 tier")
+	require.Equal(t, 2000, remaining)
+}
+
+// The day-4 ceiling must come from limit_set, never from remaining. A store
+// that has SPENT its balance down must not have its ceiling cut as a result
+// — under `GREATEST(remaining, 2000)` this row's ceiling collapsed from 5000
+// to 2000 purely because the merchant used their quota, while an identical
+// store that had sent nothing kept 5000 (#424).
+//
+// It also pins that the step only ever RAISES: a row seeded at the old full
+// allowance must not be cut to the 2000 tier on day 4.
+func TestApplyTrialRamp_Day4CeilingIgnoresConsumption(t *testing.T) {
+	db := testdb.NewDB(t, "campaign_email_budget")
+	storeID := uuid.New()
+	month := firstOfMonthUTC(time.Now())
+	// A legacy row seeded at the full allowance, mostly spent.
+	require.NoError(t, db.Exec(`
+		INSERT INTO campaign_email_budget (store_id, month, remaining, limit_set)
+		VALUES ($1, $2, 100, 5000)`, storeID, month).Error)
+
+	require.NoError(t, campaignbudget.ApplyTrialRamp(context.Background(), db, storeID, 4, "trial"))
+
+	var remaining, limitSet int
+	require.NoError(t, db.Raw(`
+		SELECT remaining, limit_set FROM campaign_email_budget WHERE store_id = $1`, storeID,
+	).Row().Scan(&remaining, &limitSet))
+
+	require.Equal(t, 5000, limitSet,
+		"the ceiling must not be cut because the merchant spent: derive it from limit_set, not remaining (#424)")
+	require.Equal(t, 2000, remaining, "the balance is still raised to the D4-7 floor")
+}
+
 func TestMonthlyReset_IdempotentReRun(t *testing.T) {
 	db := testdb.NewDB(t, "campaign_email_budget", "store_subscriptions")
 	tenantID := uuid.New()

--- a/services/marketplace-api/internal/campaignbudget/ramp.go
+++ b/services/marketplace-api/internal/campaignbudget/ramp.go
@@ -38,12 +38,26 @@ func IsRampTransitionDay(day int) bool {
 	return day == 4 || day == 8
 }
 
-// ApplyTrialRamp mutates the current-month budget row per spec §5.1:
-//   - day 4 (transition from D3): limit_set = GREATEST(remaining, 2000),
-//     remaining = limit_set
+// ApplyTrialRamp mutates the current-month budget row per spec §5.1, which
+// documents the tiers as D1-3 = 500, D4-7 = 2000, D8+ = plan allowance
+// (migration 000047's COMMENT on limit_set):
+//   - day 4 (transition from D3): limit_set = GREATEST(limit_set, 2000),
+//     remaining = GREATEST(remaining, 2000)
 //   - day 8 (transition from D7): limit_set = plan_allowance,
 //     remaining = GREATEST(remaining, plan_allowance)
 //   - all other days: no-op
+//
+// limit_set is the TIER CEILING and is raised from its own previous value,
+// never derived from remaining. Deriving it (`GREATEST(remaining, 2000)`)
+// made the ceiling a function of how much the merchant had SPENT: a store
+// that had burned its balance down to 100 got its ceiling cut to 2000, while
+// an identical store that had spent nothing kept a higher one. Same plan,
+// same day, different ceiling (#424).
+//
+// GREATEST(limit_set, 2000) rather than a flat 2000 so the step can only
+// ever RAISE a ceiling. A row seeded at the full allowance before #424 fixed
+// the seeding must not be cut to 2000 on day 4 — a merchant's ceiling going
+// backwards mid-month is a worse outcome than an over-generous legacy row.
 //
 // Idempotency: each transition day is applied AT MOST ONCE per budget row,
 // enforced by the `ramp_step_applied < N` guard in the WHERE clause. GREATEST
@@ -68,7 +82,7 @@ func ApplyTrialRamp(ctx context.Context, db *gorm.DB, storeID uuid.UUID, day int
 		// what makes this idempotent.
 		const sql = `
 			UPDATE campaign_email_budget
-			SET limit_set         = GREATEST(remaining, 2000),
+			SET limit_set         = GREATEST(limit_set, 2000),
 			    remaining         = GREATEST(remaining, 2000),
 			    ramp_step_applied = 4
 			WHERE store_id = $1


### PR DESCRIPTION
Closes #424.

Migration 000047 documents the trial ramp as **D1-3 = 500, D4-7 = 2000, D8+ = plan allowance**. Neither half of that was true.

## Two defects

**1. Trial stores were seeded at the full allowance.** `monthly_reset.go`'s CTE seeded `('trial', 5000)` — ten times the documented D1-3 tier. Since the day-4 step raises the ceiling to 2000, and 2000 can never raise a ceiling already at 5000, **the documented D4-7 tier never applied to anyone**. A brand-new trial store had its entire month's quota on day one, which defeats the point of having a ramp at all.

**2. The ceiling was derived from consumption.** `limit_set = GREATEST(remaining, 2000)` made the *ceiling* a function of how much the merchant had **spent**. A store that had burned its balance down to 100 got its ceiling cut to 2000; an identical store on the same plan and the same day that had sent nothing kept a higher one.

Per the product decision: the comment is right, the seed was wrong.

## The fix

- `monthly_reset.go`: trial seeds at **500**.
- `ramp.go` day 4: `limit_set = GREATEST(limit_set, 2000)` — raised from its own previous value, never from `remaining`.

**`GREATEST(limit_set, 2000)` rather than a flat `2000`, deliberately.** A flat value would *cut* the ceiling of any row seeded at 5000 before this change — a merchant's ceiling going backwards mid-month is a worse outcome than an over-generous legacy row. The step can now only ever raise. A mutation test pins this specifically.

Day 8 already set `limit_set = allowance` flat and is unchanged.

## Existing rows

`MonthlyReset` inserts with `ON CONFLICT DO NOTHING`, so rows already created this month keep their 5000 and are not retroactively reduced. The new seeding takes effect from the next monthly reset.

## Test plan

Integration runs used `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'` with `-p 1 -count=1`.

Two new tests, because the existing suite pinned **neither** defect — `TestMonthlyReset_SeedsAllActiveSubscriptions` only ever seeded a `starter` subscription, so nothing asserted the trial value at all.

- [x] `TestMonthlyReset_SeedsTrialAtTheD1To3Tier` — trial seeds at 500, and the day-4 ramp then raises it to 2000, proving the tier is a floor to climb from rather than a cap the ramp cannot move
- [x] `TestApplyTrialRamp_Day4CeilingIgnoresConsumption` — a legacy row at `remaining=100, limit_set=5000` keeps its 5000 ceiling while its balance is raised to 2000
- [x] **Mutation:** revert the seed to 5000 → the seed test fails `expected: 500, actual: 5000`
- [x] **Mutation:** `limit_set = GREATEST(remaining, 2000)` → the ceiling test fails `expected: 5000, actual: 2000`
- [x] **Mutation:** `limit_set = 2000` flat → the ceiling test fails the same way, catching the reduction regression
- [x] All four `campaignbudget` subpackages green; both #399 idempotency tests and both first-run tests still pass unchanged
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `gofmt -l` clean

## Not changed

`RecomputeLimitForPlan` sets `limit_set` to the new plan's allowance on a plan change. That is correct and unrelated — it only runs when the plan actually changes, so it does not undo the ramp during a trial.
