### PR TITLE
fix(arbitrage): stop discarding the fraud audit row when the flag toggle fails, and make a tenant mismatch loud (#423)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -2539,6 +2539,16 @@ func (c *arbitragePrometheusCounter) IncArbitrageFlagged() {
 	}
 }
 
+// IncArbitrageTenantMismatch records a refused audit write where the caller's
+// tenant does not own the subscription (#423). Distinct reason label so P17
+// can alert on it independently — it is a bug or a probe, never routine.
+func (c *arbitragePrometheusCounter) IncArbitrageTenantMismatch() {
+	if metrics.Subscription != nil {
+		metrics.Subscription.SubscriptionArbitrageFlaggedTotal.
+			WithLabelValues("tenant_mismatch").Inc()
+	}
+}
+
 func (c *arbitragePrometheusCounter) IncArbitrageFalsePositiveCleared() {
 	// P17 dashboard reads the arbitrage_flagged counter; false-positive-cleared
 	// is a separate counter that P17 alert rules reference. Emit on the same

--- a/services/marketplace-api/internal/arbitrage/recorder.go
+++ b/services/marketplace-api/internal/arbitrage/recorder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -17,6 +18,11 @@ import (
 type Counter interface {
 	IncArbitrageFlagged()
 	IncArbitrageFalsePositiveCleared()
+	// IncArbitrageTenantMismatch counts refused audit writes where the
+	// caller's tenant does not own the subscription. This is never routine —
+	// it is a caller bug or a cross-tenant probe — so it is counted
+	// separately from a successful flag and alerted on (#423).
+	IncArbitrageTenantMismatch()
 }
 
 // RecordInput carries every field needed for a triangulation decision and
@@ -31,6 +37,11 @@ type RecordInput struct {
 	IPCountry      string
 	RawIP          string // hashed then dropped; NEVER persisted or logged directly
 }
+
+// ErrTenantMismatch is returned when the tenant that the caller supplied does
+// not own the subscription being flagged. No audit row is written on this path
+// — see RecordIfFlagged for why persisting it would be worse than losing it.
+var ErrTenantMismatch = errors.New("arbitrage: subscription not found or tenant mismatch")
 
 // Recorder persists arbitrage audit rows and toggles the arbitrage_flag on
 // the subscription. It is the only component that writes to
@@ -49,9 +60,14 @@ func NewRecorder(db *gorm.DB, hasher *Hasher, count Counter) *Recorder {
 // RecordIfFlagged evaluates the three country signals against the price tier.
 // When the decision is a flag it:
 //  1. Hashes rawIP with HMAC-SHA256 (never persisting the plaintext).
-//  2. Inserts a subscription_arbitrage_audit row.
-//  3. Updates store_subscriptions.arbitrage_flag = true.
-//  4. Increments the Prometheus counter.
+//  2. Verifies the caller's tenant owns the subscription.
+//  3. Inserts a subscription_arbitrage_audit row on its own statement.
+//  4. Updates store_subscriptions.arbitrage_flag = true on a separate one.
+//  5. Increments the Prometheus counter.
+//
+// Steps 3 and 4 are deliberately NOT one transaction. See the inline comments:
+// the audit row must outlive a failed flag toggle, and must never be written
+// when step 2 says the tenant does not own the subscription (#423).
 //
 // On a clean decision it is a no-op (no DB writes, no counter increment).
 //
@@ -80,49 +96,92 @@ func (r *Recorder) RecordIfFlagged(ctx context.Context, in RecordInput) error {
 	billingNorm := NormalizeCountry(in.BillingCountry)
 	ipNorm := NormalizeCountry(in.IPCountry)
 
-	if err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		row := SubscriptionArbitrageAudit{
-			SubscriptionID:    in.SubscriptionID,
-			TenantID:          in.TenantID,
-			StoreID:           in.StoreID,
-			ResolvedPriceTier: string(in.PriceTier),
-			Resolution:        ResolutionOngoing,
-		}
-		if cardNorm != "??" {
-			row.CardCountry = &cardNorm
-		}
-		if billingNorm != "??" {
-			row.BillingCountry = &billingNorm
-		}
-		if ipNorm != "??" {
-			row.IPCountry = &ipNorm
-		}
-		if hash.Hex != "" {
-			row.IPHash = &hash.Hex
-		}
-		if dec.MismatchReason != "" {
-			row.MismatchReason = &dec.MismatchReason
-		}
+	db := r.db.WithContext(ctx)
 
-		if err := tx.Create(&row).Error; err != nil {
-			return fmt.Errorf("insert arbitrage audit: %w", err)
-		}
-
-		res := tx.Model(&subscription.StoreSubscription{}).
-			Where("id = ? AND tenant_id = ?", in.SubscriptionID, in.TenantID).
-			Update("arbitrage_flag", true)
-		if res.Error != nil {
-			return fmt.Errorf("toggle arbitrage_flag: %w", res.Error)
-		}
-		if res.RowsAffected == 0 {
-			return errors.New("arbitrage: subscription not found or tenant mismatch")
-		}
-		return nil
-	}); err != nil {
-		return err
+	// Step 1 — ownership check. The audit table carries tenant_id and store_id
+	// with no foreign key, so nothing in the schema stops a fraud row being
+	// written under a tenant that does not own the subscription. billing-ops
+	// filters the inbox on tenant_id alone (internal/inbox/arbitrage.go), so
+	// such a row would surface the case in the WRONG tenant's queue. That is
+	// strictly worse than losing the row: it leaks one merchant's fraud signal
+	// to another. So a mismatch refuses the write outright — but loudly, since
+	// it is a caller bug or a cross-tenant probe, never routine (#423).
+	var owned int64
+	if err := db.Model(&subscription.StoreSubscription{}).
+		Where("id = ? AND tenant_id = ?", in.SubscriptionID, in.TenantID).
+		Count(&owned).Error; err != nil {
+		return fmt.Errorf("arbitrage: verify subscription ownership: %w", err)
+	}
+	if owned == 0 {
+		slog.Default().Error("arbitrage: refusing audit row — subscription not found or tenant mismatch",
+			"subscription_id", in.SubscriptionID.String(),
+			"tenant_id", in.TenantID.String(),
+			"store_id", in.StoreID.String(),
+			"price_tier", string(in.PriceTier))
+		r.count.IncArbitrageTenantMismatch()
+		return ErrTenantMismatch
 	}
 
-	// Increment counter only after a successful commit.
+	row := SubscriptionArbitrageAudit{
+		SubscriptionID:    in.SubscriptionID,
+		TenantID:          in.TenantID,
+		StoreID:           in.StoreID,
+		ResolvedPriceTier: string(in.PriceTier),
+		Resolution:        ResolutionOngoing,
+	}
+	if cardNorm != "??" {
+		row.CardCountry = &cardNorm
+	}
+	if billingNorm != "??" {
+		row.BillingCountry = &billingNorm
+	}
+	if ipNorm != "??" {
+		row.IPCountry = &ipNorm
+	}
+	if hash.Hex != "" {
+		row.IPHash = &hash.Hex
+	}
+	if dec.MismatchReason != "" {
+		row.MismatchReason = &dec.MismatchReason
+	}
+
+	// Step 2 — the audit row is committed on its OWN statement, deliberately
+	// NOT sharing a transaction with the flag toggle below. Previously both ran
+	// inside one transaction, so any error from the toggle rolled the audit row
+	// back and the fraud case was lost with no log, no metric and no row (#423).
+	// The FK to store_subscriptions is satisfied because step 1 just proved the
+	// parent exists.
+	//
+	// Duplicate rows from a Stripe redelivery are expected and harmless — see
+	// the method doc: billing-ops groups by subscription_id.
+	if err := db.Create(&row).Error; err != nil {
+		return fmt.Errorf("insert arbitrage audit: %w", err)
+	}
+
+	// Step 3 — toggle the denormalised convenience flag. If this fails the
+	// audit row above is already durable, which is the whole point: losing the
+	// flag degrades one admin screen (internal/handlers/admin/subscription.go),
+	// losing the row loses the fraud case. The error is still returned so
+	// Stripe redelivers and the toggle is retried.
+	res := db.Model(&subscription.StoreSubscription{}).
+		Where("id = ? AND tenant_id = ?", in.SubscriptionID, in.TenantID).
+		Update("arbitrage_flag", true)
+	if res.Error != nil {
+		return fmt.Errorf("toggle arbitrage_flag: %w", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		// The subscription vanished between step 1 and here (a concurrent
+		// hard delete). The audit row is already committed and that is the
+		// outcome we want; the ON DELETE CASCADE will reap it if the parent
+		// really is gone. Report so the caller logs and Stripe redelivers.
+		slog.Default().Error("arbitrage: flag toggle matched no subscription after ownership check",
+			"subscription_id", in.SubscriptionID.String(),
+			"tenant_id", in.TenantID.String())
+		r.count.IncArbitrageTenantMismatch()
+		return ErrTenantMismatch
+	}
+
+	// Increment counter only after the audit row is durable.
 	r.count.IncArbitrageFlagged()
 	return nil
 }

--- a/services/marketplace-api/internal/arbitrage/recorder_test.go
+++ b/services/marketplace-api/internal/arbitrage/recorder_test.go
@@ -3,11 +3,16 @@
 package arbitrage_test
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/arbitrage"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
@@ -15,12 +20,14 @@ import (
 
 // spyCounter satisfies arbitrage.Counter and records calls.
 type spyCounter struct {
-	flaggedCalls int
-	clearedCalls int
+	flaggedCalls  int
+	clearedCalls  int
+	mismatchCalls int
 }
 
 func (s *spyCounter) IncArbitrageFlagged()              { s.flaggedCalls++ }
 func (s *spyCounter) IncArbitrageFalsePositiveCleared() { s.clearedCalls++ }
+func (s *spyCounter) IncArbitrageTenantMismatch()       { s.mismatchCalls++ }
 
 // stubVersionsSource implements arbitrage.VersionsSource for test use.
 type stubVersionsSource struct {
@@ -118,4 +125,120 @@ func TestRecorder_IncrementsCounter(t *testing.T) {
 		RawIP:          "2.2.2.2",
 	})
 	require.Equal(t, 1, spy.flaggedCalls)
+}
+
+// --- #423 regression tests -------------------------------------------------
+//
+// Both failure paths of RecordIfFlagged used to share one transaction with the
+// audit-row insert, so any failure discarded the fraud row with no log, no
+// metric and no trace. They now get different answers, and each is pinned here.
+
+// failStoreSubscriptionUpdate injects a DB error on UPDATEs of
+// store_subscriptions only, leaving the audit-row INSERT working. That is
+// exactly the shape of the old recorder.go:115 path.
+func failStoreSubscriptionUpdate(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	err := db.Callback().Update().Before("gorm:update").
+		Register("test:fail_store_subscription_update", func(tx *gorm.DB) {
+			if tx.Statement != nil && tx.Statement.Table == "store_subscriptions" {
+				tx.AddError(errors.New("injected: toggle failed"))
+			}
+		})
+	require.NoError(t, err)
+}
+
+// TestRecorder_AuditRowSurvivesFailedFlagToggle pins the #423 fix for the
+// toggle-error path: the flag is lost, the fraud row is NOT.
+func TestRecorder_AuditRowSurvivesFailedFlagToggle(t *testing.T) {
+	db := openIntegrationDB(t)
+	tenantID, storeID, subID := seedPPPSubscription(t, db)
+	failStoreSubscriptionUpdate(t, db)
+
+	spy := &spyCounter{}
+	rec := arbitrage.NewRecorder(db, makeTestHasher(t), spy)
+
+	err := rec.RecordIfFlagged(context.Background(), arbitrage.RecordInput{
+		SubscriptionID: subID,
+		TenantID:       tenantID,
+		StoreID:        storeID,
+		PriceTier:      subscription.PriceTierPPP,
+		CardCountry:    "US",
+		BillingCountry: "IN",
+		IPCountry:      "IN",
+		RawIP:          "203.0.113.9",
+	})
+	require.Error(t, err, "a failed flag toggle must still be reported to the caller")
+	require.Contains(t, err.Error(), "toggle arbitrage_flag")
+
+	// The whole point of #423: the audit row outlives the failed toggle.
+	var count int64
+	require.NoError(t, db.Model(&arbitrage.SubscriptionArbitrageAudit{}).
+		Where("subscription_id = ?", subID).Count(&count).Error)
+	require.Equal(t, int64(1), count, "audit row must survive a failed flag toggle")
+
+	var row arbitrage.SubscriptionArbitrageAudit
+	require.NoError(t, db.Where("subscription_id = ?", subID).First(&row).Error)
+	require.Equal(t, tenantID, row.TenantID)
+	require.NotNil(t, row.MismatchReason)
+
+	// The flag is the acceptable casualty — it degrades one admin screen.
+	var sub subscription.StoreSubscription
+	require.NoError(t, db.Where("id = ?", subID).First(&sub).Error)
+	require.False(t, sub.ArbitrageFlag)
+
+	// Not a successful flag, so the success counter must not move.
+	require.Zero(t, spy.flaggedCalls)
+}
+
+// TestRecorder_TenantMismatchWritesNothingAndIsLoud pins the #423 fix for the
+// mismatch path: the rollback is kept (a row under the wrong tenant would leak
+// into that tenant's billing-ops inbox) but it is logged and counted.
+func TestRecorder_TenantMismatchWritesNothingAndIsLoud(t *testing.T) {
+	db := openIntegrationDB(t)
+	_, storeID, subID := seedPPPSubscription(t, db)
+	wrongTenant := uuid.New()
+
+	var logBuf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	spy := &spyCounter{}
+	rec := arbitrage.NewRecorder(db, makeTestHasher(t), spy)
+
+	err := rec.RecordIfFlagged(context.Background(), arbitrage.RecordInput{
+		SubscriptionID: subID,
+		TenantID:       wrongTenant,
+		StoreID:        storeID,
+		PriceTier:      subscription.PriceTierPPP,
+		CardCountry:    "US",
+		BillingCountry: "IN",
+		IPCountry:      "IN",
+		RawIP:          "203.0.113.9",
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, arbitrage.ErrTenantMismatch)
+
+	// No row at all — not under the wrong tenant, not under the right one.
+	var count int64
+	require.NoError(t, db.Model(&arbitrage.SubscriptionArbitrageAudit{}).
+		Where("subscription_id = ?", subID).Count(&count).Error)
+	require.Zero(t, count, "a tenant mismatch must not persist an audit row")
+
+	var mismatchRows int64
+	require.NoError(t, db.Model(&arbitrage.SubscriptionArbitrageAudit{}).
+		Where("tenant_id = ?", wrongTenant).Count(&mismatchRows).Error)
+	require.Zero(t, mismatchRows, "no row may be written under the non-owning tenant")
+
+	// Loud: counted...
+	require.Equal(t, 1, spy.mismatchCalls, "tenant mismatch must increment its own counter")
+	require.Zero(t, spy.flaggedCalls)
+
+	// ...and logged, with enough identifiers to chase the caller down.
+	logged := logBuf.String()
+	require.Contains(t, logged, "tenant mismatch")
+	require.Contains(t, logged, subID.String())
+	require.Contains(t, logged, wrongTenant.String())
+	// The raw IP must never reach the log.
+	require.NotContains(t, logged, "203.0.113.9")
 }

--- a/services/marketplace-api/internal/billing/dispatch/arbitrage_failure_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/arbitrage_failure_test.go
@@ -1,0 +1,52 @@
+//go:build integration
+
+package dispatch_test
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/dispatch"
+	"github.com/mark8ly/marketplace-api/internal/metrics"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// TestReportArbitrageFailure_LogsAndCounts pins the #423 fix at the call site.
+// The recorder error stays non-fatal to the webhook — but it used to be
+// discarded into `_ = fmt.Errorf(...)`, producing no log and no metric despite a
+// comment claiming it "surfaces in webhook metrics". It does now.
+func TestReportArbitrageFailure_LogsAndCounts(t *testing.T) {
+	sub := subscription.StoreSubscription{
+		ID:       uuid.New(),
+		TenantID: uuid.New(),
+		StoreID:  uuid.New(),
+	}
+
+	var logBuf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	require.NotNil(t, metrics.Subscription)
+	counter := metrics.Subscription.StripeWebhookFailedTotal.
+		WithLabelValues("checkout.session.completed", "arbitrage_record")
+	before := testutil.ToFloat64(counter)
+
+	dispatch.ReportArbitrageFailureForTest(sub, errors.New("insert arbitrage audit: boom"))
+
+	require.Equal(t, before+1, testutil.ToFloat64(counter),
+		"a swallowed arbitrage failure must still increment stripe_webhook_failed_total")
+
+	logged := logBuf.String()
+	require.Contains(t, logged, "arbitrage record failed")
+	require.Contains(t, logged, sub.ID.String())
+	require.Contains(t, logged, sub.TenantID.String())
+	require.Contains(t, logged, sub.StoreID.String())
+	require.Contains(t, logged, "insert arbitrage audit: boom")
+}

--- a/services/marketplace-api/internal/billing/dispatch/export_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/export_test.go
@@ -6,10 +6,18 @@ import (
 	"context"
 
 	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
 )
 
 // HandleCustomerUpdatedForTest exposes the unexported handler to the
 // package's external integration tests.
 func HandleCustomerUpdatedForTest(ctx context.Context, tx *gorm.DB, raw []byte) error {
 	return handleCustomerUpdated(ctx, tx, raw)
+}
+
+// ReportArbitrageFailureForTest exposes the non-fatal arbitrage failure
+// reporter (log + metric) to the package's external integration tests.
+func ReportArbitrageFailureForTest(sub subscription.StoreSubscription, err error) {
+	reportArbitrageFailure(sub, err)
 }

--- a/services/marketplace-api/internal/billing/dispatch/handlers.go
+++ b/services/marketplace-api/internal/billing/dispatch/handlers.go
@@ -13,10 +13,44 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/arbitrage"
 	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/metrics"
 	"github.com/mark8ly/marketplace-api/internal/postcommit"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 	"github.com/mark8ly/marketplace-api/internal/subscription/statemachine"
 )
+
+// arbitrageFailureReason is the stripe_webhook_failed_total reason label used
+// when the arbitrage recorder fails on a checkout event. The failure is
+// non-fatal to the webhook, so it never reaches Dispatch()'s classifier and has
+// to be counted at the call site (#423).
+const arbitrageFailureReason = "arbitrage_record"
+
+// arbitrageFailureEventType is the event_type label for the counter above.
+// Only checkout.session.completed drives the recorder today.
+const arbitrageFailureEventType = "checkout.session.completed"
+
+// reportArbitrageFailure logs and counts a non-fatal arbitrage recorder
+// failure. Dispatch() only classifies errors a handler RETURNS, and this one is
+// deliberately swallowed, so the counter has to be incremented here or the
+// failure is invisible (#423).
+//
+// Note for whoever picks up #438: today this branch is unreachable in
+// production, because checkout.session.completed carries no IP country and
+// arbitrage.Evaluate never flags without one. It is still wired — and tested —
+// so that moving the recorder call somewhere with an IP signal does not
+// silently reintroduce the swallow.
+func reportArbitrageFailure(sub subscription.StoreSubscription, recErr error) {
+	slog.Default().Error("dispatch: arbitrage record failed (non-fatal)",
+		"event_type", arbitrageFailureEventType,
+		"subscription_id", sub.ID.String(),
+		"tenant_id", sub.TenantID.String(),
+		"store_id", sub.StoreID.String(),
+		"err", recErr.Error())
+	if metrics.Subscription != nil {
+		metrics.Subscription.StripeWebhookFailedTotal.
+			WithLabelValues(arbitrageFailureEventType, arbitrageFailureReason).Inc()
+	}
+}
 
 // handleCheckoutSessionCompleted routes checkout.session.completed through
 // two stages:
@@ -108,10 +142,12 @@ func (d *Dispatcher) handleCheckoutSessionCompleted(ctx context.Context, tx *gor
 			RawIP:          "", // no raw IP at webhook time
 		})
 		if recErr != nil {
-			// Arbitrage write failure must NOT block the subscription lifecycle.
-			// Log via fmt.Errorf wrapping so the error surfaces in webhook metrics
-			// but we swallow it here to preserve Stripe idempotency.
-			_ = fmt.Errorf("dispatch: arbitrage record (non-fatal): %w", recErr)
+			// Arbitrage write failure must NOT block the subscription
+			// lifecycle, so the error is still swallowed here to preserve
+			// Stripe idempotency. Silence is what was wrong: the previous
+			// `_ = fmt.Errorf(...)` produced no log, no metric and no return,
+			// so every arbitrage failure vanished (#423).
+			reportArbitrageFailure(sub, recErr)
 		}
 	}
 

--- a/services/marketplace-api/internal/metrics/subscription.go
+++ b/services/marketplace-api/internal/metrics/subscription.go
@@ -27,11 +27,15 @@ type SubscriptionCollectors struct {
 	StripeWebhookProcessingDuration *prometheus.HistogramVec
 
 	// StripeWebhookFailedTotal counts Stripe webhook handler failures.
-	// Labels: event_type, reason ("cas_conflict"|"invalid_transition"|"db"|"stripe_api"|"unknown").
+	// Labels: event_type, reason ("cas_conflict"|"invalid_transition"|"db"|"stripe_api"|"arbitrage_record"|"unknown").
+	// "arbitrage_record" is emitted at the call site rather than by
+	// Dispatch()'s classifier — that failure is non-fatal and never returned.
 	StripeWebhookFailedTotal *prometheus.CounterVec
 
 	// SubscriptionArbitrageFlaggedTotal counts subscriptions flagged for
-	// arbitrage. Labels: reason. Wired to a placeholder; P8 populates.
+	// arbitrage. Labels: reason ("ppp_developed_signal"|"false_positive_cleared"|
+	// "tenant_mismatch"). "tenant_mismatch" is a refused write, not a flag —
+	// it means a caller passed a tenant that does not own the subscription.
 	SubscriptionArbitrageFlaggedTotal *prometheus.CounterVec
 
 	// PromoAppliedTotal counts promo code applications. Labels: plan, currency,


### PR DESCRIPTION
Closes #423.

## What was wrong

`recorder.go` inserted the arbitrage audit row at `:107` inside a transaction opened at `:83`, then could return non-nil at `:115` (DB error toggling `arbitrage_flag`) or `:118` (`RowsAffected == 0`). Either rolled the fraud row back. Same mechanism as #397, different judgement call.

## The two paths deserve different answers

**`:118` is not a lost row — it is a tenant mismatch.** The FK `subscription_id REFERENCES store_subscriptions(id)` is enforced (migration 000044:6, confirmed live), and `store_subscriptions` has no soft delete. So if the insert's FK check passed, the subscription **exists** — meaning `RowsAffected == 0` on `WHERE id = ? AND tenant_id = ?` can only mean the caller supplied a tenant that does not own it.

`tenant_id` on the audit table has **no** FK, so nothing in the schema stops a fraud row landing under the wrong tenant — and `internal/inbox/arbitrage.go` filters the billing-ops queue on `tenant_id` alone. Writing that row would leak one merchant's fraud case into another's queue. **Losing it is correct; losing it silently is not.**

**`:115` is a genuine loss.** The subscription exists and the row is referentially valid; a transient write failure on a denormalised flag should not destroy the fraud signal.

## The restructure

The brief I wrote for this was self-contradictory — "commit the audit row first" and "keep the `:118` rollback" cannot both hold, because `RowsAffected == 0` is only observable *from* the toggle, and by then there is nothing left to roll back. Resolved by making ownership an explicit step **before** the insert:

1. `SELECT count(*) FROM store_subscriptions WHERE id = ? AND tenant_id = ?` → zero means refuse, log, count, return `ErrTenantMismatch`. **No row written.**
2. INSERT the audit row on its own statement. The FK is satisfied because step 1 just proved the parent exists.
3. UPDATE `arbitrage_flag` separately. On failure, return the error — the audit row is already durable.

No compensating delete, and both halves of the intent hold.

**Trade-off, stated:** the audit row can now exist without `arbitrage_flag = true`. That is cheap — billing-ops reads the audit table alone (`inbox/arbitrage.go:33-38`), never the flag; the flag is a denormalised convenience on one admin screen (`admin/subscription.go:145`). Losing the flag degrades a screen; losing the row loses the fraud case. `recorder.go:58-59` already blesses duplicate rows on redelivery.

**Residual, documented in code:** if the subscription is hard-deleted between steps 1 and 3, the row is already committed. That branch keeps it — `ON DELETE CASCADE` reaps it if the parent is truly gone — and returns `ErrTenantMismatch` so Stripe redelivers.

## The caller was discarding the error entirely

`handlers.go:114` was `_ = fmt.Errorf("dispatch: arbitrage record (non-fatal): %w", recErr)` — a value constructed and thrown away. No log, no metric, no return. Its comment claimed the error "surfaces in webhook metrics"; it did not, because `Dispatch()` only classifies errors a handler *returns*.

Now `reportArbitrageFailure` logs at Error with the subscription/tenant/store ids and increments `stripe_webhook_failed_total{event_type="checkout.session.completed", reason="arbitrage_record"}`. The webhook still does not fail — the non-fatal intent was right; only the silence was wrong.

## Test plan

All runs used `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'` with `-p 1 -count=1`, all EXECUTED.

There were **no** tests for either failure path before this.

- [x] `TestRecorder_AuditRowSurvivesFailedFlagToggle` — injects a GORM callback erroring only on `store_subscriptions`. Asserts the error mentions the toggle, exactly one audit row exists, the flag is still false, and the success counter did not move
- [x] `TestRecorder_TenantMismatchWritesNothingAndIsLoud` — asserts `ErrTenantMismatch`, zero rows under either tenant, the counter incremented, the log carries both ids, and **does not contain the raw IP**
- [x] `TestReportArbitrageFailure_LogsAndCounts` — asserts the webhook failure counter moves by exactly one
- [x] **Mutation:** put INSERT and toggle back in one transaction → audit-row test fails `expected: 1, actual: 0`
- [x] **Mutation:** strip the mismatch log and counter → mismatch test fails `expected: 1, actual: 0`
- [x] **Mutation:** restore the `_ = fmt.Errorf` swallow → caller test fails `expected: 1, actual: 0`
- [x] `./internal/arbitrage` green (it is in `make test-int` as of #398); build and both vets clean

## Out of scope, filed separately

**#438** — the recorder writes on a second pooled connection *inside* the webhook's advisory-lock transaction, on a row that transaction already locked: the same cross-connection stall as #396. It is latent only because `handleCheckoutSessionCompleted` hard-codes `IPCountry: ""`, so `Evaluate` never flags. That also means this call site is **currently unreachable in production** — worth knowing when judging this PR's urgency. Fixing it needs a decision about where the recorder call belongs, which is #438's job, not this one's.

## Note for the merger

The shared dev Postgres was heavily contended while this was developed (concurrent worktrees on the same database). `./internal/arbitrage` was green on every run, but wider `make test-int` runs were flaky **on a stashed clean tree too** — different tests each time, with FK violations and `deadlock detected (SQLSTATE 40P01)`. Worth one clean `make test-int` when the database is idle before merging.
