### PR TITLE
fix(billing): detect orphaned Stripe subscriptions and plan drift, and narrow the upgrade's post-Stripe window (#425)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/subscription/statemachine/... \
 	    ./internal/campaignbudget/... \
 	    ./internal/handlers/webhooks/... \
+	    ./internal/reconciliation/... \
 	    ./tests/integration/... \
 	    ./pkg/testdb/...
 

--- a/services/marketplace-api/cmd/reconciliation-cron/main.go
+++ b/services/marketplace-api/cmd/reconciliation-cron/main.go
@@ -1,8 +1,9 @@
 // Command reconciliation-cron runs the daily Stripe subscription status
 // reconciliation job (P17 Task 10).
 //
-// It fetches up to 500 active StoreSubscriptions with a stripe_subscription_id,
-// compares each against Stripe's authoritative status, and emits:
+// It fetches up to 500 live StoreSubscriptions (active, signup or trialing)
+// that we hold either a Stripe subscription id or a Stripe customer id for,
+// compares each against Stripe, and emits:
 //   - mark8ly_subscription_reconciliation_drift_total{drift_type} counter
 //   - audit_logs rows via the audit.Emitter for ops triage
 //

--- a/services/marketplace-api/internal/billing/stripe/subscription.go
+++ b/services/marketplace-api/internal/billing/stripe/subscription.go
@@ -2,6 +2,7 @@ package stripe
 
 import (
 	"context"
+	"errors"
 
 	sdk "github.com/stripe/stripe-go/v82"
 )
@@ -26,7 +27,12 @@ type Subscription struct {
 	// is bounded at two years FROM THE ANCHOR, not from now.
 	TrialEnd           int64 `json:"trial_end"`
 	BillingCycleAnchor int64 `json:"billing_cycle_anchor"`
-	Items              struct {
+	// Metadata carries the keys CreateSubscription stamps on the object
+	// (mark8ly_store_id / _plan / _period). Reconciliation uses
+	// mark8ly_store_id to attribute a Stripe subscription back to a local
+	// store when the local row never recorded its id.
+	Metadata map[string]string `json:"metadata"`
+	Items    struct {
 		Data []SubscriptionItem `json:"data"`
 	} `json:"items"`
 }
@@ -57,6 +63,7 @@ func mapSubscription(s *sdk.Subscription) *Subscription {
 		Customer:           customerID,
 		TrialEnd:           s.TrialEnd,
 		BillingCycleAnchor: s.BillingCycleAnchor,
+		Metadata:           s.Metadata,
 	}
 
 	if s.Items != nil {
@@ -79,4 +86,31 @@ func mapSubscription(s *sdk.Subscription) *Subscription {
 	}
 
 	return out
+}
+
+// ListSubscriptionsByCustomer returns every subscription Stripe currently
+// holds for customerID that is not canceled (Stripe's default list filter).
+//
+// Used by reconciliation to find subscriptions that exist at Stripe but that
+// no local row points at — the orphan left behind when a subscription is
+// created and the transaction that would have persisted its id then rolls
+// back. Canceled subscriptions are deliberately excluded: they bill nothing,
+// so they are not the divergence worth alerting on.
+func ListSubscriptionsByCustomer(ctx context.Context, c *Client, customerID string) ([]*Subscription, error) {
+	if customerID == "" {
+		return nil, errors.New("stripe: ListSubscriptionsByCustomer: customer required")
+	}
+
+	params := &sdk.SubscriptionListParams{Customer: sdk.String(customerID)}
+	params.Context = ctx
+	params.Limit = sdk.Int64(100)
+
+	var out []*Subscription
+	for s, err := range c.sdk.V1Subscriptions.List(ctx, params) {
+		if err != nil {
+			return nil, toAPIError(err)
+		}
+		out = append(out, mapSubscription(s))
+	}
+	return out, nil
 }

--- a/services/marketplace-api/internal/reconciliation/drift_types_test.go
+++ b/services/marketplace-api/internal/reconciliation/drift_types_test.go
@@ -1,0 +1,242 @@
+package reconciliation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// stripeStub is a minimal Stripe API stand-in covering the three endpoints
+// reconciliation touches: subscription retrieve, subscription list, price
+// list. It records which paths were hit so a test can assert a lookup was
+// NOT made.
+type stripeStub struct {
+	// retrieve is returned from GET /v1/subscriptions/{id}.
+	retrieve map[string]any
+	// list is returned as the data array of GET /v1/subscriptions.
+	list []map[string]any
+	// priceID is returned as the single result of GET /v1/prices.
+	priceID string
+
+	seenPaths []string
+}
+
+func (s *stripeStub) client(t *testing.T) *billingstripe.Client {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.seenPaths = append(s.seenPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Request-Id", "req_test")
+
+		switch {
+		case r.URL.Path == "/v1/prices":
+			data := []map[string]any{}
+			if s.priceID != "" {
+				data = append(data, map[string]any{"id": s.priceID, "object": "price"})
+			}
+			writeList(t, w, data)
+		case r.URL.Path == "/v1/subscriptions":
+			writeList(t, w, s.list)
+		case strings.HasPrefix(r.URL.Path, "/v1/subscriptions/"):
+			require.NotNil(t, s.retrieve, "unexpected subscription retrieve")
+			require.NoError(t, json.NewEncoder(w).Encode(s.retrieve))
+		default:
+			t.Errorf("stripeStub: unexpected path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	// Deliberately not shaped like a real Stripe secret key: gitleaks'
+	// stripe-access-token rule matches that prefix on sight, and a fake key
+	// in a test is indistinguishable to it from a real one. The stub server
+	// below never inspects the value.
+	c := billingstripe.New("reconciliation-fake-key")
+	c.SetBaseURLForTesting(srv.URL)
+	return c
+}
+
+func writeList(t *testing.T, w http.ResponseWriter, data []map[string]any) {
+	t.Helper()
+	if data == nil {
+		data = []map[string]any{}
+	}
+	require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+		"object":   "list",
+		"url":      "/v1/x",
+		"has_more": false,
+		"data":     data,
+	}))
+}
+
+// stripeSubJSON builds a subscription payload carrying one item on priceID.
+func stripeSubJSON(id, status, priceID string, metadata map[string]string) map[string]any {
+	return map[string]any{
+		"id":       id,
+		"object":   "subscription",
+		"status":   status,
+		"customer": "cus_reconcile",
+		"metadata": metadata,
+		"items": map[string]any{
+			"object": "list",
+			"data": []map[string]any{
+				{"id": "si_1", "object": "subscription_item", "price": map[string]any{"id": priceID, "object": "price"}},
+			},
+		},
+	}
+}
+
+func activeRow(storeID uuid.UUID, stripeSubID string) row {
+	return row{
+		StoreID:              storeID,
+		TenantID:             uuid.New(),
+		LocalStatus:          subscription.StatusActive,
+		StripeCustomerID:     "cus_reconcile",
+		StripeSubscriptionID: stripeSubID,
+		Plan:                 subscription.PlanStarter,
+		SubscriptionPeriod:   subscription.PeriodMonthly,
+		BillingCurrency:      "USD",
+		PriceTier:            subscription.PriceTierDeveloped,
+	}
+}
+
+func driftCount(t *testing.T, driftType string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(driftTotal.WithLabelValues(driftType))
+}
+
+// --- plan_mismatch ----------------------------------------------------------
+
+// TestCheckOne_PlanMismatch_DetectedWhenStripePriceDiffers is the #425
+// upgrade case: Stripe accepted the price swap, the local transaction rolled
+// back, so the local plan resolves to a different price than the one Stripe
+// is billing.
+func TestCheckOne_PlanMismatch_DetectedWhenStripePriceDiffers(t *testing.T) {
+	stub := &stripeStub{
+		priceID:  "price_starter_monthly",
+		retrieve: stripeSubJSON("sub_drift", "active", "price_pro_monthly", nil),
+	}
+	r := New(nil, stub.client(t), nil, nil)
+
+	before := driftCount(t, DriftTypePlanMismatch)
+	drift, err := r.checkOne(context.Background(), activeRow(uuid.New(), "sub_drift"))
+	require.NoError(t, err)
+
+	assert.Equal(t, DriftTypePlanMismatch, drift)
+	assert.Equal(t, before+1, driftCount(t, DriftTypePlanMismatch),
+		"plan_mismatch must increment the drift counter alerts are wired to")
+}
+
+// TestCheckOne_PlanMatch_NoDrift guards against the counter firing on every
+// healthy subscription.
+func TestCheckOne_PlanMatch_NoDrift(t *testing.T) {
+	stub := &stripeStub{
+		priceID:  "price_starter_monthly",
+		retrieve: stripeSubJSON("sub_ok", "active", "price_starter_monthly", nil),
+	}
+	r := New(nil, stub.client(t), nil, nil)
+
+	drift, err := r.checkOne(context.Background(), activeRow(uuid.New(), "sub_ok"))
+	require.NoError(t, err)
+	assert.Equal(t, "", drift)
+}
+
+// TestCheckOne_NonBillablePlan_SkipsPriceLookup pins the guard that keeps a
+// signup row on the default `trial` plan from reaching
+// pricing.MustGetDescriptor, which panics for plans with no Price object.
+func TestCheckOne_NonBillablePlan_SkipsPriceLookup(t *testing.T) {
+	stub := &stripeStub{
+		priceID:  "price_starter_monthly",
+		retrieve: stripeSubJSON("sub_trial", "active", "price_anything", nil),
+	}
+	r := New(nil, stub.client(t), nil, nil)
+
+	sub := activeRow(uuid.New(), "sub_trial")
+	sub.Plan = subscription.PlanTrial
+
+	drift, err := r.checkOne(context.Background(), sub)
+	require.NoError(t, err)
+	assert.Equal(t, "", drift)
+	assert.NotContains(t, stub.seenPaths, "/v1/prices",
+		"a non-billable plan must never reach the catalog price lookup")
+}
+
+// --- locally_missing --------------------------------------------------------
+
+// TestCheckOne_LocallyMissing_DetectsOrphanedStripeSubscription is the #425
+// initial-subscription case: Stripe created and is billing a subscription
+// tagged with our store id, and the local row records no id for it.
+func TestCheckOne_LocallyMissing_DetectsOrphanedStripeSubscription(t *testing.T) {
+	storeID := uuid.New()
+	stub := &stripeStub{
+		list: []map[string]any{
+			stripeSubJSON("sub_orphan", "trialing", "price_starter_monthly",
+				map[string]string{"mark8ly_store_id": storeID.String()}),
+		},
+	}
+	r := New(nil, stub.client(t), nil, nil)
+
+	sub := activeRow(storeID, "")
+	sub.LocalStatus = subscription.StatusSignup
+
+	before := driftCount(t, DriftTypeLocallyMissing)
+	drift, err := r.checkOne(context.Background(), sub)
+	require.NoError(t, err)
+
+	assert.Equal(t, DriftTypeLocallyMissing, drift)
+	assert.Equal(t, before+1, driftCount(t, DriftTypeLocallyMissing))
+}
+
+// TestCheckOne_LocallyMissing_IgnoresSubscriptionForAnotherStore verifies the
+// match is attributed by metadata, not by "the customer has any subscription".
+func TestCheckOne_LocallyMissing_IgnoresSubscriptionForAnotherStore(t *testing.T) {
+	stub := &stripeStub{
+		list: []map[string]any{
+			stripeSubJSON("sub_other", "active", "price_starter_monthly",
+				map[string]string{"mark8ly_store_id": uuid.NewString()}),
+		},
+	}
+	r := New(nil, stub.client(t), nil, nil)
+
+	sub := activeRow(uuid.New(), "")
+	sub.LocalStatus = subscription.StatusSignup
+
+	drift, err := r.checkOne(context.Background(), sub)
+	require.NoError(t, err)
+	assert.Equal(t, "", drift)
+}
+
+// TestCheckOne_LocallyMissing_NoCustomerIsNotDrift: a row we never bootstrapped
+// at Stripe has nothing to diverge from.
+func TestCheckOne_LocallyMissing_NoCustomerIsNotDrift(t *testing.T) {
+	stub := &stripeStub{}
+	r := New(nil, stub.client(t), nil, nil)
+
+	sub := activeRow(uuid.New(), "")
+	sub.StripeCustomerID = ""
+	sub.LocalStatus = subscription.StatusSignup
+
+	drift, err := r.checkOne(context.Background(), sub)
+	require.NoError(t, err)
+	assert.Equal(t, "", drift)
+	assert.Empty(t, stub.seenPaths, "no Stripe call should be made without a customer id")
+}
+
+// TestNewDriftTypeConstants pins the label values the Prometheus alert rules
+// and dashboards will match on.
+func TestNewDriftTypeConstants(t *testing.T) {
+	assert.Equal(t, "locally_missing", DriftTypeLocallyMissing)
+	assert.Equal(t, "plan_mismatch", DriftTypePlanMismatch)
+}

--- a/services/marketplace-api/internal/reconciliation/reconciler.go
+++ b/services/marketplace-api/internal/reconciliation/reconciler.go
@@ -6,9 +6,16 @@
 // Drift types detected:
 //   - status_mismatch  — Stripe status disagrees with our local status
 //   - stripe_not_found — we hold a stripe_subscription_id that Stripe 404s
+//   - locally_missing  — Stripe bills a subscription for one of our customers
+//     that no local row records (#425: the plan-change transaction rolled
+//     back after the Stripe call succeeded, orphaning the subscription)
+//   - plan_mismatch    — the Stripe subscription item is on a different price
+//     than the local (plan, period, currency, tier) resolves to (#425: the
+//     Stripe price swap committed but the local plan write rolled back)
 //
-// "locally_missing" (Stripe has it, we don't) requires iterating Stripe
-// customers and is deferred to v2 — it is expensive for large tenants.
+// The locally_missing scan is bounded, not a full customer crawl: it lists
+// subscriptions only for customers we already know about, and only for rows
+// whose stripe_subscription_id is NULL.
 package reconciliation
 
 import (
@@ -35,6 +42,17 @@ const (
 	DriftTypeStatusMismatch = "status_mismatch"
 	// DriftTypeStripeNotFound is emitted when our stripe_subscription_id 404s on Stripe.
 	DriftTypeStripeNotFound = "stripe_not_found"
+	// DriftTypeLocallyMissing is emitted when Stripe holds a subscription
+	// tagged with one of our store ids that the local row does not record.
+	DriftTypeLocallyMissing = "locally_missing"
+	// DriftTypePlanMismatch is emitted when the Stripe subscription item's
+	// price differs from the price our local plan/period/currency/tier
+	// resolves to.
+	DriftTypePlanMismatch = "plan_mismatch"
+
+	// storeIDMetadataKey is the metadata key CreateSubscription stamps on
+	// every subscription it creates (internal/billing/stripe/subscription_create.go).
+	storeIDMetadataKey = "mark8ly_store_id"
 )
 
 // driftTotal is the Prometheus counter for reconciliation drift events.
@@ -52,12 +70,38 @@ func init() {
 	prometheus.MustRegister(driftTotal)
 }
 
+// billablePlans are the plans that have a Stripe Price object in the catalog.
+//
+// This guard is load-bearing, not defensive tidiness: PriceIDFor reaches
+// pricing.MustGetDescriptor, which PANICS for a (plan, period, tier) the
+// catalog does not carry — and trial (the store_subscriptions default) and
+// marketplace carry none. Broadening the batch to signup rows without this
+// would crash the cron on the first trial row it met.
+//
+// For the three plans below the catalog defines both monthly and annual at
+// the developed tier, so MustGetDescriptor is total over what can reach it;
+// the PPP tier returns an error rather than panicking. A plan added here
+// without catalog entries reintroduces the panic.
+var billablePlans = map[subscription.SubscriptionPlan]bool{
+	subscription.PlanStarter: true,
+	subscription.PlanStudio:  true,
+	subscription.PlanPro:     true,
+}
+
 // row is an internal projection used in the batch SELECT query.
+//
+// StripeSubscriptionID and BillingCurrency are nullable columns projected
+// through COALESCE, so "" means NULL here.
 type row struct {
 	StoreID              uuid.UUID
 	TenantID             uuid.UUID
 	LocalStatus          subscription.SubscriptionStatus
+	StripeCustomerID     string
 	StripeSubscriptionID string
+	Plan                 subscription.SubscriptionPlan
+	SubscriptionPeriod   subscription.SubscriptionPeriod
+	BillingCurrency      string
+	PriceTier            subscription.PriceTier
 }
 
 // Reconciler queries active StoreSubscriptions and compares their status
@@ -67,6 +111,13 @@ type Reconciler struct {
 	stripe  *billingstripe.Client
 	emitter *audit.Emitter
 	logger  *slog.Logger
+
+	// priceCache memoises PriceIDFor lookups for the life of the process.
+	// Without it a 500-row batch issues 500 Stripe price lookups for what is
+	// at most a handful of distinct (plan, period, currency, tier) tuples.
+	// The reconciliation process is a short-lived CronJob, so a price
+	// re-pointed mid-run is not a concern.
+	priceCache map[string]string
 }
 
 // New constructs a Reconciler. stripe may be nil — in that case all Stripe
@@ -76,7 +127,13 @@ func New(db *gorm.DB, stripe *billingstripe.Client, emitter *audit.Emitter, logg
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Reconciler{db: db, stripe: stripe, emitter: emitter, logger: logger}
+	return &Reconciler{
+		db:         db,
+		stripe:     stripe,
+		emitter:    emitter,
+		logger:     logger,
+		priceCache: make(map[string]string),
+	}
 }
 
 // RunOnce processes up to batchSize subscriptions and returns the count of
@@ -88,14 +145,31 @@ func (r *Reconciler) RunOnce(ctx context.Context) (int, error) {
 		return 0, nil
 	}
 
-	// Fetch a batch of active subscriptions that have a Stripe subscription ID.
+	// Fetch a batch of live subscriptions. signup and trialing are included
+	// alongside active because the two drift types added for #425 are
+	// invisible otherwise: an orphaned Stripe subscription belongs to a row
+	// still sitting in signup, and a rolled-back upgrade can leave a
+	// trialing row on the wrong price.
+	//
+	// Rows with a NULL stripe_subscription_id are included for the same
+	// reason — that NULL is precisely the locally_missing signal — provided
+	// we hold a customer id to ask Stripe about.
+	//
 	// SKIP LOCKED ensures concurrent replicas don't race.
 	var rows []row
 	err := r.db.WithContext(ctx).Raw(`
-		SELECT store_id, tenant_id, status AS local_status, stripe_subscription_id
+		SELECT store_id,
+		       tenant_id,
+		       status AS local_status,
+		       stripe_customer_id,
+		       COALESCE(stripe_subscription_id, '') AS stripe_subscription_id,
+		       plan,
+		       subscription_period,
+		       COALESCE(billing_currency, '') AS billing_currency,
+		       price_tier
 		FROM store_subscriptions
-		WHERE status = 'active'
-		  AND stripe_subscription_id IS NOT NULL
+		WHERE status IN ('active', 'signup', 'trialing')
+		  AND (stripe_subscription_id IS NOT NULL OR stripe_customer_id <> '')
 		ORDER BY updated_at
 		LIMIT ?
 		FOR UPDATE SKIP LOCKED
@@ -129,6 +203,12 @@ func (r *Reconciler) RunOnce(ctx context.Context) (int, error) {
 // checkOne reconciles a single subscription against Stripe and emits a drift
 // event if a mismatch is found. Returns the drift type ("" if clean).
 func (r *Reconciler) checkOne(ctx context.Context, sub row) (string, error) {
+	// No local stripe_subscription_id: the only question worth asking is
+	// whether Stripe is nonetheless billing one for this store.
+	if sub.StripeSubscriptionID == "" {
+		return r.checkLocallyMissing(ctx, sub)
+	}
+
 	stripeSub, err := billingstripe.GetSubscription(ctx, r.stripe, sub.StripeSubscriptionID)
 	if err != nil {
 		var apiErr *billingstripe.APIError
@@ -153,7 +233,102 @@ func (r *Reconciler) checkOne(ctx context.Context, sub row) (string, error) {
 		return DriftTypeStatusMismatch, nil
 	}
 
+	// Status agrees — is the merchant on the price their local plan says?
+	return r.checkPlanMismatch(ctx, sub, stripeSub), nil
+}
+
+// checkLocallyMissing asks Stripe whether it holds a live subscription for
+// this store's customer that the local row does not record. A match is
+// attributed by the mark8ly_store_id metadata CreateSubscription stamps, so a
+// subscription created outside our flow is never mistaken for one of ours.
+//
+// Returns "" (and no error) when nothing can be concluded — an unknown
+// customer, or a Stripe list call that failed — rather than failing the whole
+// batch over one row.
+func (r *Reconciler) checkLocallyMissing(ctx context.Context, sub row) (string, error) {
+	if sub.StripeCustomerID == "" {
+		return "", nil
+	}
+
+	stripeSubs, err := billingstripe.ListSubscriptionsByCustomer(ctx, r.stripe, sub.StripeCustomerID)
+	if err != nil {
+		return "", fmt.Errorf("reconciliation: stripe list subscriptions for customer %s: %w", sub.StripeCustomerID, err)
+	}
+
+	for _, candidate := range stripeSubs {
+		if candidate == nil || candidate.Metadata[storeIDMetadataKey] != sub.StoreID.String() {
+			continue
+		}
+		// Copy rather than mutate: recordDrift reports the Stripe id we
+		// found, while the caller's row keeps its (empty) local value.
+		found := sub
+		found.StripeSubscriptionID = candidate.ID
+		r.recordDrift(ctx, found, DriftTypeLocallyMissing,
+			fmt.Sprintf("stripe has subscription %s (status=%s) for customer %s; local stripe_subscription_id is NULL",
+				candidate.ID, candidate.Status, sub.StripeCustomerID))
+		return DriftTypeLocallyMissing, nil
+	}
+
 	return "", nil
+}
+
+// checkPlanMismatch compares the price on the Stripe subscription item
+// against the price the local (plan, period, currency, tier) resolves to.
+//
+// A price that cannot be resolved is not drift: the catalog legitimately has
+// no entry for some combinations (a PPP currency without a PPP price, say),
+// and reporting that as a plan change would bury the real signal. Same for a
+// subscription Stripe returned with no items.
+func (r *Reconciler) checkPlanMismatch(ctx context.Context, sub row, stripeSub *billingstripe.Subscription) string {
+	if stripeSub == nil || len(stripeSub.Items.Data) == 0 {
+		return ""
+	}
+	if !billablePlans[sub.Plan] {
+		return ""
+	}
+	actualPriceID := stripeSub.Items.Data[0].Price.ID
+	if actualPriceID == "" {
+		return ""
+	}
+
+	expectedPriceID, err := r.expectedPriceID(ctx, sub)
+	if err != nil || expectedPriceID == "" {
+		r.logger.Debug("reconciliation: price lookup skipped",
+			"store_id", sub.StoreID,
+			"plan", sub.Plan,
+			"period", sub.SubscriptionPeriod,
+			"err", err)
+		return ""
+	}
+
+	if actualPriceID == expectedPriceID {
+		return ""
+	}
+
+	r.recordDrift(ctx, sub, DriftTypePlanMismatch,
+		fmt.Sprintf("local plan=%s period=%s currency=%s tier=%s expects price %s; stripe subscription %s is on price %s",
+			sub.Plan, sub.SubscriptionPeriod, sub.BillingCurrency, sub.PriceTier,
+			expectedPriceID, sub.StripeSubscriptionID, actualPriceID))
+	return DriftTypePlanMismatch
+}
+
+// expectedPriceID resolves the local plan to a Stripe price id, memoised per
+// (plan, period, currency, tier).
+func (r *Reconciler) expectedPriceID(ctx context.Context, sub row) (string, error) {
+	key := fmt.Sprintf("%s|%s|%s|%s", sub.Plan, sub.SubscriptionPeriod, sub.BillingCurrency, sub.PriceTier)
+	if cached, ok := r.priceCache[key]; ok {
+		return cached, nil
+	}
+
+	priceID, err := billingstripe.PriceIDFor(ctx, r.stripe,
+		sub.Plan, sub.SubscriptionPeriod, sub.BillingCurrency, sub.PriceTier)
+	if err != nil {
+		return "", err
+	}
+	if r.priceCache != nil {
+		r.priceCache[key] = priceID
+	}
+	return priceID, nil
 }
 
 // recordDrift increments the drift counter, logs the finding, and emits an

--- a/services/marketplace-api/internal/reconciliation/runonce_integration_test.go
+++ b/services/marketplace-api/internal/reconciliation/runonce_integration_test.go
@@ -1,0 +1,52 @@
+//go:build integration
+
+package reconciliation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// TestRunOnce_SelectsSignupRowWithNullSubscriptionID proves the widened batch
+// query reaches the rows #425 leaves behind. Before this change the WHERE
+// clause was `status = 'active' AND stripe_subscription_id IS NOT NULL`, which
+// excluded exactly the row an orphaned Stripe subscription belongs to, so the
+// drift was structurally undetectable.
+func TestRunOnce_SelectsSignupRowWithNullSubscriptionID(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions")
+
+	tenantID := uuid.New()
+	storeID := uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
+
+	require.NoError(t, db.Create(&subscription.StoreSubscription{
+		TenantID:         tenantID,
+		StoreID:          storeID,
+		StripeCustomerID: "cus_reconcile",
+		// stripe_subscription_id deliberately NULL: the local write that
+		// would have recorded it rolled back after Stripe created it.
+		Plan:               subscription.PlanTrial,
+		Status:             subscription.StatusSignup,
+		SubscriptionPeriod: subscription.PeriodMonthly,
+		PriceTier:          subscription.PriceTierDeveloped,
+	}).Error)
+
+	stub := &stripeStub{
+		list: []map[string]any{
+			stripeSubJSON("sub_orphan_int", "trialing", "price_starter_monthly",
+				map[string]string{"mark8ly_store_id": storeID.String()}),
+		},
+	}
+	r := New(db, stub.client(t), nil, nil)
+
+	count, err := r.RunOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "the orphaned Stripe subscription must be reported as drift")
+}

--- a/services/marketplace-api/internal/subscription/planchange/planchange.go
+++ b/services/marketplace-api/internal/subscription/planchange/planchange.go
@@ -317,30 +317,6 @@ func (o *Orchestrator) executeUpgrade(ctx context.Context, tx *gorm.DB, in Input
 		return Output{}, fmt.Errorf("planchange: resolve price id: %w", err)
 	}
 
-	// Idempotency key scoped to (store, target plan, target period, 5-min bucket).
-	// The 5-min window matches the advisory lock TTL — duplicate requests within
-	// the same minute get deduplicated by Stripe rather than creating double charges.
-	idempotencyKey := fmt.Sprintf("plan-change:%s:%s:%s:%d",
-		in.StoreID, in.TargetPlan, in.TargetPeriod,
-		in.Now.Truncate(5*time.Minute).Unix(),
-	)
-
-	stripeSub, err := o.deps.Stripe.UpdateSubscription(ctx, billingstripe.UpdateSubscriptionParams{
-		SubscriptionID:    *sub.StripeSubscriptionID,
-		PriceID:           priceID,
-		ProrationBehavior: billingstripe.ProrationAlwaysInvoice,
-		IdempotencyKey:    idempotencyKey,
-		Metadata: map[string]string{
-			"tenant_id":     in.TenantID.String(),
-			"store_id":      in.StoreID.String(),
-			"target_plan":   string(in.TargetPlan),
-			"target_period": string(in.TargetPeriod),
-		},
-	})
-	if err != nil {
-		return Output{}, fmt.Errorf("planchange: stripe update subscription: %w", err)
-	}
-
 	// Determine action label: upgrade_committed when plan changes, period_switch_committed
 	// when only the billing period changes within the same plan tier.
 	action := "upgrade_committed"
@@ -350,20 +326,6 @@ func (o *Orchestrator) executeUpgrade(ctx context.Context, tx *gorm.DB, in Input
 		result = ResultPeriodSwitchCommitted
 	}
 
-	if err := o.deps.SubscriptionRepo.CommitUpgrade(ctx, tx, in.TenantID, in.StoreID,
-		in.TargetPlan, in.TargetPeriod, action); err != nil {
-		return Output{}, fmt.Errorf("planchange: commit upgrade: %w", err)
-	}
-
-	// P9 — recompute campaign email budget limit inside the same transaction
-	// so plan row and budget row always commit atomically. Nil-safe: existing
-	// callers that don't inject BudgetRecomputer are unaffected.
-	if o.deps.BudgetRecomputer != nil {
-		if err := o.deps.BudgetRecomputer.RecomputeLimitForPlan(ctx, tx, in.StoreID, string(in.TargetPlan)); err != nil {
-			return Output{}, fmt.Errorf("planchange: recompute budget limit: %w", err)
-		}
-	}
-
 	// BillingCurrency is stored upper-cased to satisfy the CHAR(3) NOT NULL
 	// constraint with canonical ISO-4217 form (e.g. "USD" not "usd").
 	auditCurrency := strings.ToUpper(currency)
@@ -371,14 +333,31 @@ func (o *Orchestrator) executeUpgrade(ctx context.Context, tx *gorm.DB, in Input
 		auditCurrency = "USD" // fallback for subscriptions without explicit currency
 	}
 
-	// TODO: backfill proration fields from invoice webhook — ProrationCents and
-	// StripeInvoiceID are set to zero/"" here and populated when
-	// invoice.payment_succeeded arrives from the Stripe webhook handler.
-	stripeSubID := ""
-	if stripeSub != nil {
-		stripeSubID = stripeSub.ID
-	}
+	// --- everything fallible that CAN happen before Stripe, DOES (#425) -----
+	//
+	// Stripe's UpdateSubscription is an external side effect with
+	// proration_behavior=always_invoice: it issues a real invoice, and no
+	// error path here can un-issue it. Every non-nil return from this closure
+	// rolls the local transaction back, so each fallible statement standing
+	// AFTER the Stripe call is a way for Stripe and the database to end up
+	// disagreeing. This ordering leaves exactly one — CommitUpgrade.
+	//
+	// Moving these two earlier is NOT a behaviour change on the failure path:
+	// both write through tx, so if the Stripe call below fails the rows
+	// written here roll back with everything else. That is what makes the
+	// move safe. It is the opposite of the #397 refusal row, which had to
+	// move OUT of the transaction precisely because rollback erased it.
 
+	// The subscription id is known before the call and does not change across
+	// it: Stripe returns the same subscription it was asked to update, and
+	// the guard at the top of this function proves the local value is set.
+	// Reading it from sub rather than from the response is what lets the
+	// audit row be written first.
+	stripeSubID := *sub.StripeSubscriptionID
+
+	// ProrationCents and StripeInvoiceID stay zero/"" here and are backfilled
+	// when invoice.payment_succeeded arrives from the Stripe webhook handler
+	// — the same deferred-backfill approach this row already used for them.
 	if err := WritePlanChangeAuditRowTx(ctx, tx, PlanChangeAuditRow{
 		TenantID:             in.TenantID,
 		StoreID:              in.StoreID,
@@ -396,6 +375,50 @@ func (o *Orchestrator) executeUpgrade(ctx context.Context, tx *gorm.DB, in Input
 		EffectiveAt:          in.Now,
 	}); err != nil {
 		return Output{}, fmt.Errorf("planchange: write audit row: %w", err)
+	}
+
+	// P9 — recompute campaign email budget limit inside the same transaction
+	// so plan row and budget row always commit atomically. Nil-safe: existing
+	// callers that don't inject BudgetRecomputer are unaffected.
+	if o.deps.BudgetRecomputer != nil {
+		if err := o.deps.BudgetRecomputer.RecomputeLimitForPlan(ctx, tx, in.StoreID, string(in.TargetPlan)); err != nil {
+			return Output{}, fmt.Errorf("planchange: recompute budget limit: %w", err)
+		}
+	}
+
+	// --- the irreversible step ---------------------------------------------
+
+	// Idempotency key scoped to (store, target plan, target period, 5-min bucket).
+	// The 5-min window matches the advisory lock TTL — duplicate requests within
+	// the same minute get deduplicated by Stripe rather than creating double charges.
+	idempotencyKey := fmt.Sprintf("plan-change:%s:%s:%s:%d",
+		in.StoreID, in.TargetPlan, in.TargetPeriod,
+		in.Now.Truncate(5*time.Minute).Unix(),
+	)
+
+	if _, err := o.deps.Stripe.UpdateSubscription(ctx, billingstripe.UpdateSubscriptionParams{
+		SubscriptionID:    stripeSubID,
+		PriceID:           priceID,
+		ProrationBehavior: billingstripe.ProrationAlwaysInvoice,
+		IdempotencyKey:    idempotencyKey,
+		Metadata: map[string]string{
+			"tenant_id":     in.TenantID.String(),
+			"store_id":      in.StoreID.String(),
+			"target_plan":   string(in.TargetPlan),
+			"target_period": string(in.TargetPeriod),
+		},
+	}); err != nil {
+		return Output{}, fmt.Errorf("planchange: stripe update subscription: %w", err)
+	}
+
+	// --- the only fallible statement left after the Stripe call -------------
+	//
+	// A failure here still diverges (Stripe re-priced, local plan did not);
+	// the reconciliation sweep reports that as plan_mismatch drift (#425).
+	// Nothing may be added below this line without reopening the window.
+	if err := o.deps.SubscriptionRepo.CommitUpgrade(ctx, tx, in.TenantID, in.StoreID,
+		in.TargetPlan, in.TargetPeriod, action); err != nil {
+		return Output{}, fmt.Errorf("planchange: commit upgrade: %w", err)
 	}
 
 	// Emit to audit log (non-blocking; nil emitter is safe).

--- a/services/marketplace-api/internal/subscription/planchange/stripe_window_integration_test.go
+++ b/services/marketplace-api/internal/subscription/planchange/stripe_window_integration_test.go
@@ -1,0 +1,185 @@
+//go:build integration
+
+package planchange_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/internal/subscription/planchange"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// countingStripe records how many times the irreversible Stripe call was
+// made, so a test can assert it was NOT made.
+type countingStripe struct {
+	updateCalls int
+	updateErr   error
+}
+
+func (f *countingStripe) UpdateSubscription(_ context.Context, in billingstripe.UpdateSubscriptionParams) (*billingstripe.Subscription, error) {
+	f.updateCalls++
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+	return &billingstripe.Subscription{ID: in.SubscriptionID, Status: "active"}, nil
+}
+
+func (f *countingStripe) CreateSubscription(_ context.Context, _ billingstripe.CreateSubscriptionInput) (*billingstripe.Subscription, error) {
+	return nil, errors.New("not expected in these tests")
+}
+
+func (f *countingStripe) PriceIDFor(_ context.Context, _ subscription.SubscriptionPlan, _ subscription.SubscriptionPeriod, _ string, _ subscription.PriceTier) (string, error) {
+	return "price_studio_monthly", nil
+}
+
+// erroringBudget stands in for campaignbudget.Service failing — one of the
+// three fallible steps that used to sit AFTER the Stripe call.
+type erroringBudget struct{ err error }
+
+func (b erroringBudget) RecomputeLimitForPlan(_ context.Context, _ *gorm.DB, _ uuid.UUID, _ string) error {
+	return b.err
+}
+
+// seedUpgradeableSubscription inserts an active starter/monthly subscription
+// with a Stripe subscription id, ready to be upgraded to studio.
+func seedUpgradeableSubscription(t *testing.T, db *gorm.DB) (uuid.UUID, uuid.UUID) {
+	t.Helper()
+	tenantID := uuid.New()
+	storeID := uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
+
+	subID := "sub_stripe_window"
+	require.NoError(t, db.Create(&subscription.StoreSubscription{
+		TenantID:             tenantID,
+		StoreID:              storeID,
+		StripeCustomerID:     "cus_stripe_window",
+		StripeSubscriptionID: &subID,
+		Plan:                 subscription.PlanStarter,
+		Status:               subscription.StatusActive,
+		SubscriptionPeriod:   subscription.PeriodMonthly,
+		PriceTier:            subscription.PriceTierDeveloped,
+		BillingCurrency:      strPtr("USD"),
+	}).Error)
+	return tenantID, storeID
+}
+
+func upgradeInput(tenantID, storeID uuid.UUID) planchange.Input {
+	return planchange.Input{
+		TenantID:          tenantID,
+		StoreID:           storeID,
+		TargetPlan:        subscription.PlanStudio,
+		TargetPeriod:      subscription.PeriodMonthly,
+		RequestedCurrency: "USD",
+		Actor:             "user:" + uuid.NewString(),
+		Reason:            "stripe_window_test",
+	}
+}
+
+func countAuditRows(t *testing.T, db *gorm.DB, storeID uuid.UUID) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, db.Table("subscription_plan_change_audit").
+		Where("store_id = ?", storeID).Count(&n).Error)
+	return n
+}
+
+func currentPlan(t *testing.T, db *gorm.DB, storeID uuid.UUID) string {
+	t.Helper()
+	var plan string
+	require.NoError(t, db.Raw(
+		`SELECT plan FROM store_subscriptions WHERE store_id = ?`, storeID,
+	).Row().Scan(&plan))
+	return plan
+}
+
+// TestUpgrade_BudgetRecomputeFailure_NeverReachesStripe is the #425 guard: a
+// failing budget recompute used to run AFTER Stripe had already re-priced the
+// subscription and issued a proration invoice, rolling the local transaction
+// back and leaving the two systems disagreeing. It now runs before, so the
+// same failure costs the merchant nothing.
+func TestUpgrade_BudgetRecomputeFailure_NeverReachesStripe(t *testing.T) {
+	db := testdb.NewDB(t, "subscription_plan_change_audit", "store_subscriptions")
+	tenantID, storeID := seedUpgradeableSubscription(t, db)
+
+	stripe := &countingStripe{}
+	o := planchange.NewOrchestrator(planchange.Deps{
+		DB:               db,
+		Stripe:           stripe,
+		SubscriptionRepo: subscription.NewRepository(),
+		Clock:            fixedClock{t: time.Now()},
+		BudgetRecomputer: erroringBudget{err: errors.New("budget row locked")},
+	})
+
+	_, err := o.Execute(context.Background(), upgradeInput(tenantID, storeID))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "recompute budget limit")
+
+	assert.Equal(t, 0, stripe.updateCalls,
+		"a failure that can be discovered locally must never bill the merchant")
+	assert.Equal(t, int64(0), countAuditRows(t, db, storeID))
+	assert.Equal(t, string(subscription.PlanStarter), currentPlan(t, db, storeID))
+}
+
+// TestUpgrade_StripeFailure_LeavesNoAuditRow pins the behaviour that makes the
+// reordering safe: the audit row is now written BEFORE the Stripe call, but it
+// is written through the same transaction, so a Stripe failure still erases
+// it. No audit row is ever left recording an upgrade that did not happen.
+func TestUpgrade_StripeFailure_LeavesNoAuditRow(t *testing.T) {
+	db := testdb.NewDB(t, "subscription_plan_change_audit", "store_subscriptions")
+	tenantID, storeID := seedUpgradeableSubscription(t, db)
+
+	stripe := &countingStripe{updateErr: errors.New("stripe: card_declined")}
+	o := planchange.NewOrchestrator(planchange.Deps{
+		DB:               db,
+		Stripe:           stripe,
+		SubscriptionRepo: subscription.NewRepository(),
+		Clock:            fixedClock{t: time.Now()},
+	})
+
+	_, err := o.Execute(context.Background(), upgradeInput(tenantID, storeID))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stripe update subscription")
+
+	assert.Equal(t, 1, stripe.updateCalls)
+	assert.Equal(t, int64(0), countAuditRows(t, db, storeID),
+		"an audit row for an upgrade Stripe refused must not persist")
+	assert.Equal(t, string(subscription.PlanStarter), currentPlan(t, db, storeID))
+}
+
+// TestUpgrade_Success_WritesAuditRowWithStripeSubscriptionID confirms the
+// audit row still carries the Stripe subscription id after the reorder — it
+// is now read from the local row rather than from the Stripe response.
+func TestUpgrade_Success_WritesAuditRowWithStripeSubscriptionID(t *testing.T) {
+	db := testdb.NewDB(t, "subscription_plan_change_audit", "store_subscriptions")
+	tenantID, storeID := seedUpgradeableSubscription(t, db)
+
+	o := planchange.NewOrchestrator(planchange.Deps{
+		DB:               db,
+		Stripe:           &countingStripe{},
+		SubscriptionRepo: subscription.NewRepository(),
+		Clock:            fixedClock{t: time.Now()},
+	})
+
+	out, err := o.Execute(context.Background(), upgradeInput(tenantID, storeID))
+	require.NoError(t, err)
+	assert.Equal(t, planchange.ResultUpgradeCommitted, out.Result)
+
+	var gotSubID, gotAction string
+	require.NoError(t, db.Raw(
+		`SELECT stripe_subscription_id, action FROM subscription_plan_change_audit WHERE store_id = ?`,
+		storeID,
+	).Row().Scan(&gotSubID, &gotAction))
+	assert.Equal(t, "sub_stripe_window", gotSubID)
+	assert.Equal(t, "upgrade_committed", gotAction)
+	assert.Equal(t, string(subscription.PlanStudio), currentPlan(t, db, storeID))
+}


### PR DESCRIPTION
Closes #425.

Two plan-change paths mutate a real Stripe subscription and can then return non-nil from inside the advisory-lock transaction, rolling the local database back while the Stripe change stands.

## Neither path self-heals — the issue's prioritisation assumption was wrong

I expected the upgrade path might recover via webhooks. It does not: `handleSubscriptionUpdated` (`dispatch/handlers.go:152-193`) writes only period dates and `cancel_at_period_end` — never `plan`, `subscription_period` or `stripe_subscription_id`. And `customer.subscription.created` is neither in the allowlist (`config.go:104`) nor registered in `dispatch.New`.

- **Path B (upgrade)** invoices immediately (`ProrationAlwaysInvoice`), so the merchant is billed for a plan the app still gates at the old limits. Loud, within hours.
- **Path A (initial subscription)** leaves an orphaned Stripe subscription nothing local points at. The merchant is charged 90 days later for a plan they were never given, with no confirmation email. Silent.

**No compensation exists today.** `dispatch/orphan_resolver.go` resolves orphaned *webhook events*, not subscriptions. `reconciliation/reconciler.go` only queried `status='active' AND stripe_subscription_id IS NOT NULL` and compared active-vs-active — its own doc defers "locally_missing" to v2.

## Commit 1 — detection (no write-path change)

Extends the reconciler to see both failures:
- batch broadened to `status IN ('active','signup','trialing')` and rows with a customer but no subscription id;
- `locally_missing` — Stripe has a subscription carrying `metadata.mark8ly_store_id`, we have none;
- `plan_mismatch` — the Stripe item's price differs from `PriceIDFor(local plan, period, currency, tier)`.

Both report through the existing `recordDrift`, so they inherit the Prometheus counter and audit event alerts are already wired to.

Two things this needed that did not exist: `Metadata` was never projected onto our `Subscription` struct (so `mark8ly_store_id` was unreachable from Go), and there was no `ListSubscriptionsByCustomer`.

**A production crash avoided.** `PriceIDFor` reaches `pricing.MustGetDescriptor`, which **panics** (`catalog.go:401`) for a plan the catalog does not carry — and `trial`, the `store_subscriptions` default, carries none. Broadening the batch to `signup` rows without a guard would have panicked the cron on the first trial row. A `billablePlans` whitelist gates the price lookup, with a test pinning it.

`./internal/reconciliation/...` is added to `make test-int` — it was absent, and a new integration test that never runs is worthless.

## Commit 2 — narrow Path B's window

`WritePlanChangeAuditRowTx` and `RecomputeLimitForPlan` move **before** the Stripe call, leaving `CommitUpgrade` as the only fallible statement after it: 3 → 1.

**A premise in the issue that turns out to be false, worth stating.** I expected moving the audit write earlier would mean it persists even when Stripe then fails. It does not: that row writes through `tx`, the same transaction a Stripe failure aborts, so it still rolls back. This is the *opposite* of #397, where the refusal row had to move **out** of the transaction precisely because rollback erased it. `TestUpgrade_StripeFailure_LeavesNoAuditRow` pins it rather than leaving it as an argument.

`stripeSubID` needed no deferral either — the guard at the top of `executeUpgrade` proves `*sub.StripeSubscriptionID` is set, and Stripe returns the subscription it was asked to update, so reading it locally is equivalent. `ProrationCents`/`StripeInvoiceID` keep their existing invoice-webhook backfill comment.

## Deliberately not done

- **Reordering so Stripe runs after commit** — puts local ahead of Stripe (features unpaid), and discards the `always_invoice` result.
- **A compensating Stripe rollback** — can itself fail, and cannot un-issue a proration invoice already raised.
- **Deferring to `postcommit`** — its contract is explicitly non-fatal, which inverts the bug; and it cannot work for Path A, where the value being persisted comes *from* the call.
- **The third instance, `commitDowngrade` (`cron.go:196-234`)** — same shape, but its Stripe call uses `ProrationNone`, so it issues no invoice and its divergence costs the merchant nothing. It is now visible as `plan_mismatch` drift from Commit 1, and deserves its own tested change rather than being smuggled in here.

Path A still cannot be fixed in the write path — the id comes from Stripe — so detection is the answer there, which Commit 1 provides.

## Test plan

All runs used `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'` with `-p 1 -count=1`, all EXECUTED.

- [x] `./internal/subscription/planchange/...` **38 PASS / 0 FAIL** (baseline 35 + 3 new); `./internal/reconciliation/...` green
- [x] **Mutation:** disable `plan_mismatch` → its test fails `expected: 1, actual: 0`
- [x] **Mutation:** disable the `locally_missing` metadata match → `batch complete checked=1 drift=0`, test fails
- [x] **Mutation:** revert the batch query → `checked=0 drift=0`, "the orphaned Stripe subscription must be reported as drift"
- [x] **Mutation:** move the budget recompute back after the Stripe call → `TestUpgrade_BudgetRecomputeFailure_NeverReachesStripe` fails `expected: 0, actual: 1` — "a failure that can be discovered locally must never bill the merchant"
- [x] `TestCheckOne_NonBillablePlan_SkipsPriceLookup` pins the panic guard
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean

Note: no reconciler test fixtures or Stripe stub existed (`reconciler_test.go` was 51 lines of nil-client assertions); an `httptest`-based stub was built following the `internal/billing/stripe` `SetBaseURLForTesting` convention.
