### PR TITLE
fix: stop leaking per-store sequences from test fixtures and tenant purge (#436)

### DIFF
--- a/docs/ops/2026-08-29-dev-orphan-sequence-sweep.md
+++ b/docs/ops/2026-08-29-dev-orphan-sequence-sweep.md
@@ -1,0 +1,143 @@
+# Dev database: orphan `mk_seq_*` sequence sweep
+
+**Date:** 2026-08-29
+**Database:** `marketplace_db` on the shared dev Postgres (`dev-postgres-1`)
+**Issue:** [#436](https://github.com/tesserix/mark8ly/issues/436)
+**Scope:** dev only. Production was never affected — see "Production" below.
+
+## Why
+
+Migration `000004_orders_seq_eager` installs an `AFTER INSERT ON stores`
+trigger that creates two Postgres sequences per store,
+`mk_seq_order_<id>` and `mk_seq_return_<id>`. Nothing dropped them:
+
+- `pkg/testdb.SeedStore`'s cleanup deleted the `stores` row but issued no
+  `DROP SEQUENCE`, and `NewDB`'s `TRUNCATE ... CASCADE` does not reach a
+  catalog relation. Every `NewDB`-based integration test leaked two
+  sequences per seeded store, permanently. (Tests using `testdb.NewTx` did
+  not leak — the DDL rolls back with the fixture.)
+- `internal/tenantpurge` had no sequence handling at all, so a purged
+  tenant orphaned two catalog objects per store.
+
+Both are fixed in code alongside this sweep. This document records the
+one-off cleanup of the residue that had already accumulated.
+
+## Production
+
+Not an incident. `docs/ops/2026-07-29-bondi-sequence-ownership.md` records
+16 `mk_seq_order_*` sequences in production as of 2026-07-29 — 16 stores,
+32 sequences, proportional to real stores. The runaway count was a
+property of the shared dev database, which absorbs every integration run.
+
+## Orphan predicate
+
+A sequence is an orphan iff its embedded uuid matches no live `stores` row.
+The name is parsed back to a uuid by stripping the kind prefix and
+translating `_` to `-`:
+
+```sql
+SELECT c.relname
+FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind = 'S' AND n.nspname = 'public'
+  AND (c.relname LIKE 'mk\_seq\_order\_%' OR c.relname LIKE 'mk\_seq\_return\_%')
+  AND NOT EXISTS (
+    SELECT 1 FROM stores s
+    WHERE s.id::text = translate(regexp_replace(c.relname, '^mk_seq_(order|return)_', ''), '_', '-')
+  );
+```
+
+The predicate was verified in both directions before anything was dropped,
+because "orphan" was about to authorise a `DROP` on a database shared with
+other work:
+
+- **Negative half:** `live_store_seqs` = 0 against `stores` = 0 rows, so no
+  sequence belonging to a live store was in the drop set.
+- **Positive half:** inside a rolled-back transaction, a probe store was
+  inserted; the predicate then classified exactly 2 sequences as live and
+  excluded them from the orphan set. Without this check a predicate that
+  simply matched everything would have looked identical against an empty
+  `stores` table.
+
+## Execution
+
+Batched at 2000 drops per transaction. A single transaction was not an
+option: `max_locks_per_transaction` is 64 with `max_connections` 100
+(~6,400 lock slots), and `DROP SEQUENCE` takes a lock per relation, so
+28k drops in one transaction would have exhausted the lock table — the
+same limit that made `pg_dump` fail in the first place. Orphan status is
+recomputed inside each batch, so a store created concurrently by other
+work could never fall into a later batch's drop set.
+
+## Result
+
+| | Before | After |
+|---|---|---|
+| `mk_seq_order_*` + `mk_seq_return_*` | 27,990 | 0 |
+| All sequences in `public` | 27,991 | 1 |
+| `stores` rows | 0 | 0 |
+
+Every one of the 27,990 was residue. The one remaining sequence is
+unrelated to this trigger and was never in the drop set.
+
+`pg_dump -U dev -d marketplace_db` was run afterwards and succeeded
+(0.25s, 214,940 bytes), confirming the lock-exhaustion symptom that
+opened #436 is gone.
+
+## Residual leak sources — the fixes above are NOT the whole leak
+
+Measured, not assumed. After the sweep the count was 0; running the
+marketplace-api integration suite once put **4,152** back. `testdb.SeedStore`
+was one leak path, not the leak.
+
+Nineteen test files run `INSERT INTO stores` directly; only three drop the
+sequences afterwards (`internal/order/testhelpers_integration_test.go`,
+`internal/order/lifecycle_integration_test.go`, and
+`internal/tenantpurge/purge_integration_test.go`). The other sixteen do not
+go through `testdb.SeedStore` at all, so fixing that one fixture cannot
+reach them:
+
+```
+cmd/backfill-email/main_integration_test.go
+internal/outbox/publisher_integration_test.go
+internal/subscription/repository_crosstenant_integration_test.go
+internal/subscription/harddelete/sweep_via_parent_integration_test.go
+internal/subscription/lifecycle/winback_integration_test.go
+internal/subscription/planchange/planchange_integration_test.go
+internal/audit/prune_cron_storeless_integration_test.go
+internal/campaign/segment_delete_integration_test.go
+internal/orderrefund/resolver_integration_test.go
+internal/giftcard/repository_integration_test.go
+internal/giftcard/repository_status_integration_test.go
+internal/handlers/storefront/webhooks_capture_integration_test.go
+internal/handlers/storefront/storefront_integration_test.go
+internal/handlers/internalsvc/storefront_status_test.go
+internal/billing/trial/expiring_integration_test.go
+internal/billing/trial/extend_stripelive_test.go
+```
+
+Handler tests that create a store through the HTTP API leak the same way.
+
+Per-fixture drops are the wrong shape for sixteen files and counting: the
+next one added leaks again, silently, and nothing fails. The durable fix is
+a single teardown that sweeps orphans — the predicate above is exactly it —
+run once per package or once per suite, so a fixture cannot opt out by
+forgetting. That is a design decision, not a cleanup, and is left for #436's
+follow-up rather than folded into this sweep.
+
+Until then this sweep is repeatable: re-run the batched drop above. It is
+safe at any time, because orphan status is recomputed inside each batch and
+a live store's sequences are never selected.
+
+## Recurrence
+
+Closed on two of the paths, with a mutation-verified regression test on
+each:
+
+- `pkg/testdb.SeedStore` now drops both sequences in its cleanup
+  (`TestSeedStore_CleanupDropsPerStoreSequences`, which must use `NewDB` —
+  under `NewTx` it would pass either way and prove nothing).
+- `tenantpurge.Purge` now drops them inside the purge transaction
+  (`TestIntegration_Purge_DropsPerStoreSequences`).
+
+The count will still grow from the sixteen fixtures listed above until the
+suite-level sweep lands.

--- a/services/marketplace-api/internal/order/number.go
+++ b/services/marketplace-api/internal/order/number.go
@@ -37,7 +37,7 @@ func NextDocumentNumber(ctx context.Context, tx *gorm.DB, storeID uuid.UUID, kin
 		return 0, fmt.Errorf("order: NextDocumentNumber requires a transaction handle")
 	}
 
-	seqName := buildSequenceName(storeID, kind)
+	seqName := SequenceName(storeID, kind)
 
 	// nextval() is not parameterizable (it takes a regclass, not a text
 	// bind variable), so we format the name into the SQL. The name is
@@ -53,14 +53,26 @@ func NextDocumentNumber(ctx context.Context, tx *gorm.DB, storeID uuid.UUID, kin
 	return next, nil
 }
 
-// buildSequenceName returns the Postgres sequence name for a given
+// SequenceName returns the Postgres sequence name for a given
 // (store_id, kind) pair. MUST stay in lockstep with the SQL trigger
 // function mk_create_store_sequences() in migration 000004 — both sides
 // produce the same name from the same inputs.
 //
 // Format: mk_seq_<kind>_<uuid with dashes replaced by underscores>
 // Example: mk_seq_order_11111111_1111_1111_1111_111111111111
-func buildSequenceName(storeID uuid.UUID, kind string) string {
+//
+// Exported because the trigger creates these sequences but nothing in the
+// database drops them: every caller that destroys a store — the tenant
+// purge (internal/tenantpurge) and the test fixtures (pkg/testdb) — has to
+// name the sequences to DROP them, and a second hand-written copy of this
+// format is exactly how the two sides would drift apart. The returned name
+// draws only on a uuid and a kind, so its character set is [a-z0-9_]; it is
+// safe to interpolate into an identifier position, which is the only place
+// it can go (a sequence name is an identifier, never a bind value).
+//
+// kind must be one of "order" or "return"; callers pass a literal, so this
+// is not validated here.
+func SequenceName(storeID uuid.UUID, kind string) string {
 	return "mk_seq_" + kind + "_" + strings.ReplaceAll(storeID.String(), "-", "_")
 }
 

--- a/services/marketplace-api/internal/tenantpurge/purge.go
+++ b/services/marketplace-api/internal/tenantpurge/purge.go
@@ -88,7 +88,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/order"
 )
 
 // deleteStep is one DELETE statement in the purge plan.
@@ -125,9 +128,15 @@ type Report struct {
 // retention/append-only tables — see the package doc comment for the full
 // list and rationale.
 //
+// After the last delete, and inside the same transaction, Purge drops the
+// per-store Postgres sequences migration 000004's AFTER INSERT trigger
+// created for each of storeIDs — see dropStoreSequences. That step is not a
+// deleteStep and does not appear in the returned Report; both facts are
+// explained there.
+//
 // Purge is idempotent: every delete is a `WHERE` clause that matches zero
-// rows on a second run, so calling Purge twice for the same tenant is safe
-// and returns nil both times.
+// rows on a second run and the sequence drops use IF EXISTS, so calling
+// Purge twice for the same tenant is safe and returns nil both times.
 func Purge(ctx context.Context, db *gorm.DB, tenantID string, storeIDs []string) (Report, error) {
 	if db == nil {
 		return Report{}, fmt.Errorf("tenantpurge: db must not be nil")
@@ -150,7 +159,12 @@ func Purge(ctx context.Context, db *gorm.DB, tenantID string, storeIDs []string)
 			rep.Tables = append(rep.Tables, TableResult{Table: step.table, RowsDeleted: res.RowsAffected})
 			rep.TotalRows += res.RowsAffected
 		}
-		return nil
+		// AFTER the final `stores` delete, and inside the same transaction:
+		// DDL is transactional in Postgres, so the drops commit or roll back
+		// atomically with the deletes above. Doing it before the delete would
+		// leave a live store whose sequences NextDocumentNumber needs, for as
+		// long as the transaction ran.
+		return dropStoreSequences(tx, storeIDs)
 	})
 	if err != nil {
 		return Report{}, err
@@ -468,4 +482,77 @@ func toAnySlice(ss []string) []any {
 		out[i] = s
 	}
 	return out
+}
+
+// sequenceKinds are the two document kinds migration 000004's
+// stores_after_insert_create_sequences trigger creates a sequence for on
+// every stores INSERT. Kept as data so storeSequenceNames and any future
+// caller cannot disagree about how many there are.
+var sequenceKinds = []string{"order", "return"}
+
+// storeSequenceNames maps store ids to the Postgres sequence names that
+// migration 000004's AFTER INSERT trigger created for them — two per store,
+// mk_seq_order_<id> and mk_seq_return_<id>.
+//
+// Pure and unit-testable, deliberately: the names go into an identifier
+// position in DDL (see dropStoreSequences), which is the one place a bind
+// value cannot go, so the safety of the whole step rests on this function
+// and nothing else. Every id is parsed as a uuid before it is used, so the
+// only characters that can reach the SQL are the [a-z0-9_] that
+// order.SequenceName produces from a canonical uuid. An unparseable id is
+// an error, not a skip: it means the caller handed Purge something that was
+// never a store id, and quietly dropping nothing would leave the sequences
+// orphaned exactly as before.
+//
+// The name format is order.SequenceName's, not a second copy of it — the
+// trigger, the nextval caller and the drop must all agree, and a
+// hand-written duplicate is how they would stop agreeing.
+func storeSequenceNames(storeIDs []string) ([]string, error) {
+	names := make([]string, 0, len(storeIDs)*len(sequenceKinds))
+	for _, id := range storeIDs {
+		parsed, err := uuid.Parse(id)
+		if err != nil {
+			return nil, fmt.Errorf("tenantpurge: store id %q is not a uuid: %w", id, err)
+		}
+		for _, kind := range sequenceKinds {
+			names = append(names, order.SequenceName(parsed, kind))
+		}
+	}
+	return names, nil
+}
+
+// dropStoreSequences drops the per-store sequences for storeIDs. It runs as
+// a step of the purge transaction rather than as a deleteStep in purgePlan,
+// for a structural reason: every deleteStep is a parameterized statement,
+// and `DROP SEQUENCE ?` is not valid SQL — a sequence name is an
+// identifier, never a bind value. purgePlan stays pure and fully
+// parameterized; this is the one thing that cannot be expressed there.
+//
+// Nothing in the database does this for us. The trigger creates the
+// sequences on INSERT and has no ON DELETE counterpart, and a sequence is a
+// catalog relation, so the `stores` delete's CASCADE does not reach it.
+// Before this step a purged tenant orphaned two catalog objects per store,
+// permanently and monotonically (#436).
+//
+// IF EXISTS keeps the step idempotent, matching Purge's contract: a second
+// purge of the same tenant drops nothing and returns nil.
+//
+// The result is deliberately NOT reported. Report lists TableResults —
+// (table, rows) pairs — and a DROP has neither: there is no table, and
+// RowsAffected is meaningless for DDL. Report is documented as listing
+// every step of the PLAN including the zero-row ones, and this is not a
+// plan step; countPlan derives from purgePlan, so Count could not preview a
+// DROP either. A synthetic zero-row entry would read to an operator as "a
+// table that held nothing", which is a different and false claim.
+func dropStoreSequences(tx *gorm.DB, storeIDs []string) error {
+	names, err := storeSequenceNames(storeIDs)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		if err := tx.Exec("DROP SEQUENCE IF EXISTS " + name).Error; err != nil {
+			return fmt.Errorf("tenantpurge: drop sequence %s: %w", name, err)
+		}
+	}
+	return nil
 }

--- a/services/marketplace-api/internal/tenantpurge/purge_integration_test.go
+++ b/services/marketplace-api/internal/tenantpurge/purge_integration_test.go
@@ -16,6 +16,7 @@ package tenantpurge_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -482,4 +483,78 @@ func TestPurge_PaymentActionReminders_DeletesOnlyPurgedTenantRowsViaStoreId(t *t
 	require.NoError(t, db.Raw(`SELECT count(*) FROM payment_action_reminders WHERE store_id = ?`, storeB).Scan(&countB).Error)
 	require.EqualValues(t, 0, countA, "tenant A's payment_action_reminders rows must be deleted")
 	require.EqualValues(t, 2, countB, "tenant B's payment_action_reminders rows must survive — cross-tenant isolation")
+}
+
+// countSequencesForStore returns how many of the two per-store sequences
+// migration 000004's trigger creates still exist for storeID.
+func countSequencesForStore(t *testing.T, db *gorm.DB, storeID string) int64 {
+	t.Helper()
+	underscored := strings.ReplaceAll(storeID, "-", "_")
+	var n int64
+	require.NoError(t, db.Raw(
+		`SELECT count(*) FROM pg_class WHERE relkind = 'S' AND relname IN (?, ?)`,
+		"mk_seq_order_"+underscored, "mk_seq_return_"+underscored,
+	).Scan(&n).Error)
+	return n
+}
+
+// A purged tenant must leave no per-store sequences behind. The trigger
+// creates two per store on INSERT and has no ON DELETE counterpart, and a
+// sequence is a catalog relation that the stores CASCADE does not reach —
+// so before #436's fix every purge orphaned two catalog objects per store,
+// permanently.
+//
+// The name is spelled out from the raw uuid here rather than taken from
+// storeSequenceNames, so the assertion cannot pass by agreeing with a bug
+// in the helper it is checking.
+func TestIntegration_Purge_DropsPerStoreSequences(t *testing.T) {
+	db := testdb.NewDB(t, domainTablesToCleanup...)
+	ctx := context.Background()
+
+	tenantID := uuid.NewString()
+	storeID := seedStore(t, db, tenantID)
+	t.Cleanup(func() {
+		underscored := strings.ReplaceAll(storeID, "-", "_")
+		db.Exec("DROP SEQUENCE IF EXISTS mk_seq_order_" + underscored)
+		db.Exec("DROP SEQUENCE IF EXISTS mk_seq_return_" + underscored)
+	})
+
+	require.EqualValues(t, 2, countSequencesForStore(t, db, storeID),
+		"the stores AFTER INSERT trigger must have created both sequences")
+
+	if _, err := tenantpurge.Purge(ctx, db, tenantID, []string{storeID}); err != nil {
+		t.Fatalf("Purge: %v", err)
+	}
+
+	require.EqualValues(t, 0, countSequencesForStore(t, db, storeID),
+		"Purge must drop both per-store sequences; leaving them behind is the #436 leak")
+
+	// Idempotent: the drops are IF EXISTS, so a second purge is still a
+	// nil-error no-op.
+	if _, err := tenantpurge.Purge(ctx, db, tenantID, []string{storeID}); err != nil {
+		t.Fatalf("second Purge (idempotency check): %v", err)
+	}
+}
+
+// A store id that is not a uuid can never reach an identifier position in
+// the DROP: Purge fails, and — because the drops run inside the purge
+// transaction — the deletes roll back with them rather than leaving the
+// tenant half-purged.
+func TestIntegration_Purge_RejectsNonUUIDStoreIDAndRollsBack(t *testing.T) {
+	db := testdb.NewDB(t, domainTablesToCleanup...)
+	ctx := context.Background()
+
+	tenantID := uuid.NewString()
+	storeID := seedStore(t, db, tenantID)
+	t.Cleanup(func() {
+		underscored := strings.ReplaceAll(storeID, "-", "_")
+		db.Exec("DROP SEQUENCE IF EXISTS mk_seq_order_" + underscored)
+		db.Exec("DROP SEQUENCE IF EXISTS mk_seq_return_" + underscored)
+	})
+
+	_, err := tenantpurge.Purge(ctx, db, tenantID, []string{"not-a-uuid"})
+	require.Error(t, err, "a non-uuid store id must abort the purge")
+
+	require.EqualValues(t, 1, countRows(t, db, "stores", "tenant_id", tenantID),
+		"the failed purge must roll back, leaving the tenant's store intact")
 }

--- a/services/marketplace-api/internal/tenantpurge/purge_test.go
+++ b/services/marketplace-api/internal/tenantpurge/purge_test.go
@@ -284,3 +284,53 @@ func TestCountPlan_SelectsRatherThanDeletes(t *testing.T) {
 			"a preview step must contain no DELETE at all: %q", s.sql)
 	}
 }
+
+// storeSequenceNames is the whole safety argument for the one part of the
+// purge that cannot be parameterized, so it is tested directly: both kinds
+// per store, in the trigger's format, and nothing but [a-z0-9_] reaching
+// the SQL.
+
+func TestStoreSequenceNames_TwoPerStoreInTriggerFormat(t *testing.T) {
+	names, err := storeSequenceNames(testStoreIDs)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"mk_seq_order_22222222_2222_2222_2222_222222222222",
+		"mk_seq_return_22222222_2222_2222_2222_222222222222",
+		"mk_seq_order_33333333_3333_3333_3333_333333333333",
+		"mk_seq_return_33333333_3333_3333_3333_333333333333",
+	}, names, "must match mk_create_store_sequences() in migration 000004 exactly")
+}
+
+func TestStoreSequenceNames_EmptyStoreListIsANoOpNotAnError(t *testing.T) {
+	names, err := storeSequenceNames(nil)
+	require.NoError(t, err)
+	require.Empty(t, names, "a tenant with no stores has no sequences to drop")
+}
+
+func TestStoreSequenceNames_RejectsAnythingThatIsNotAUUID(t *testing.T) {
+	// The names go into an identifier position in DDL. A non-uuid id is a
+	// caller bug; failing the purge is correct, silently dropping nothing
+	// would re-create the leak this step exists to close.
+	for _, bad := range []string{
+		"",
+		"not-a-uuid",
+		"22222222-2222-2222-2222-222222222222; DROP TABLE stores; --",
+		"22222222_2222_2222_2222_222222222222",
+	} {
+		_, err := storeSequenceNames([]string{bad})
+		require.Error(t, err, "store id %q must be rejected", bad)
+	}
+}
+
+func TestStoreSequenceNames_ProduceOnlyIdentifierSafeCharacters(t *testing.T) {
+	names, err := storeSequenceNames(testStoreIDs)
+	require.NoError(t, err)
+	require.NotEmpty(t, names)
+	for _, name := range names {
+		for _, r := range name {
+			require.Truef(t,
+				(r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_',
+				"sequence name %q contains %q, outside the [a-z0-9_] set that makes interpolation safe", name, r)
+		}
+	}
+}

--- a/services/marketplace-api/migrations/000004_orders_seq_eager.up.sql
+++ b/services/marketplace-api/migrations/000004_orders_seq_eager.up.sql
@@ -22,7 +22,7 @@ BEGIN;
 -- Trigger function: create both per-store sequences (order + return) whenever
 -- a new store row is inserted.
 --
--- Naming convention MUST match internal/order/number.go buildSequenceName:
+-- Naming convention MUST match internal/order/number.go SequenceName:
 --     mk_seq_<kind>_<uuid-with-dashes-replaced-by-underscores>
 -- with kind ∈ {'order','return'}.
 --

--- a/services/marketplace-api/pkg/testdb/seed.go
+++ b/services/marketplace-api/pkg/testdb/seed.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/order"
 )
 
 // SeedStore inserts a minimal stores row for (tenantID, storeID), satisfying
@@ -18,14 +20,29 @@ import (
 // same tenant: otherwise the store and whatever references it disagree about
 // tenancy, and every tenant-scoped assertion passes while testing nothing.
 //
-// Registers a t.Cleanup deleting the row, so packages using NewDB (which
-// truncates only the tables it was told about) still start clean.
+// Registers a t.Cleanup deleting the row AND dropping the two per-store
+// sequences the insert created, so packages using NewDB (which truncates
+// only the tables it was told about) still start clean.
 //
-// The cleanup is best-effort: under NewTx it's a no-op, since the row is
-// rolled back before the DELETE would run anyway. Under NewDB it can fail —
-// products.store_id and categories.store_id are ON DELETE RESTRICT, so if
-// the caller's package left rows referencing this store, the DELETE errors
-// out silently unless the package also truncates stores itself.
+// The sequences are not an incidental detail. Migration 000004's
+// stores_after_insert_create_sequences trigger creates mk_seq_order_<id>
+// and mk_seq_return_<id> for every row inserted into stores, and a sequence
+// is a catalog relation, not a row: neither the DELETE below nor NewDB's
+// TRUNCATE ... CASCADE reclaims it. Without an explicit DROP every NewDB
+// run left two sequences behind forever, which is how the shared dev
+// database reached ~28,000 orphaned sequences against zero stores (#436).
+//
+// Order: sequences first, store row second. The trigger fires on INSERT
+// only, so there is no ON DELETE counterpart that would recreate them, and
+// dropping first means a failure to delete the store (see below) still
+// reclaims the catalog objects — the direction that leaks.
+//
+// The cleanup is best-effort and never fails the test: under NewTx it's a
+// no-op, since both the row and the DDL are rolled back before this runs.
+// Under NewDB the DELETE can fail — products.store_id and categories.store_id
+// are ON DELETE RESTRICT, so if the caller's package left rows referencing
+// this store, the DELETE errors out (logged, not fatal) unless the package
+// also truncates stores itself.
 func SeedStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
 	t.Helper()
 
@@ -43,6 +60,16 @@ func SeedStore(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID) {
 	}
 
 	t.Cleanup(func() {
+		// A sequence name is an identifier, not a bind value, so DROP
+		// SEQUENCE cannot be parameterized. order.SequenceName derives the
+		// name from a uuid and a literal kind, so the character set is
+		// [a-z0-9_] only and interpolation is safe.
+		for _, kind := range []string{"order", "return"} {
+			seq := order.SequenceName(storeID, kind)
+			if err := db.Exec("DROP SEQUENCE IF EXISTS " + seq).Error; err != nil {
+				t.Logf("testdb.SeedStore: cleanup DROP SEQUENCE %s: %v", seq, err)
+			}
+		}
 		if err := db.Exec("DELETE FROM stores WHERE id = ?", storeID).Error; err != nil {
 			t.Logf("testdb.SeedStore: cleanup DELETE stores row %s: %v", storeID, err)
 		}

--- a/services/marketplace-api/pkg/testdb/seed_integration_test.go
+++ b/services/marketplace-api/pkg/testdb/seed_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mark8ly/marketplace-api/internal/order"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
@@ -107,4 +108,41 @@ func TestSeededParents_AcceptAProductInsert(t *testing.T) {
 		uuid.New(), tenantID, storeID, vendorID, "seed-probe", "Seed Probe", "draft",
 	).Error
 	require.NoError(t, err)
+}
+
+// SeedStore's cleanup must reclaim the two per-store sequences migration
+// 000004's AFTER INSERT trigger creates, not just the stores row. This is
+// the regression guard for #436: a sequence is a catalog relation, so
+// neither the cleanup DELETE nor NewDB's TRUNCATE ... CASCADE reaches it,
+// and without an explicit DROP every run of every NewDB-based integration
+// test leaked two sequences permanently.
+//
+// NewDB (not NewTx) is essential here. Under NewTx the CREATE SEQUENCE the
+// trigger issues is rolled back with the rest of the transaction, so the
+// assertion would hold with or without the DROP and the test would prove
+// nothing.
+func TestSeedStore_CleanupDropsPerStoreSequences(t *testing.T) {
+	db := testdb.NewDB(t, "stores")
+	tenantID, storeID := uuid.New(), uuid.New()
+
+	countSequences := func() int64 {
+		t.Helper()
+		var n int64
+		require.NoError(t, db.Raw(
+			`SELECT count(*) FROM pg_class WHERE relkind = 'S' AND relname IN (?, ?)`,
+			order.SequenceName(storeID, "order"), order.SequenceName(storeID, "return"),
+		).Scan(&n).Error)
+		return n
+	}
+
+	// The nested subtest scopes SeedStore's t.Cleanup: it runs when the
+	// subtest returns, so the outer test can observe the post-cleanup state.
+	t.Run("fixture", func(st *testing.T) {
+		testdb.SeedStore(st, db, tenantID, storeID)
+		require.EqualValues(t, 2, countSequences(),
+			"the stores AFTER INSERT trigger must have created both sequences")
+	})
+
+	require.EqualValues(t, 0, countSequences(),
+		"SeedStore cleanup must DROP both per-store sequences; leaving them behind is the #436 leak")
 }

--- a/services/marketplace-api/pkg/testdb/testdb.go
+++ b/services/marketplace-api/pkg/testdb/testdb.go
@@ -14,6 +14,7 @@ package testdb
 
 import (
 	"os"
+	"slices"
 	"testing"
 
 	"gorm.io/driver/postgres"
@@ -66,8 +67,61 @@ func NewDB(t *testing.T, tablesToCleanup ...string) *gorm.DB {
 
 	t.Cleanup(func() {
 		truncate(t, db, tablesToCleanup)
+		dropOrphanStoreSequences(t, db, tablesToCleanup)
 	})
 	return db
+}
+
+// dropOrphanStoreSequences reclaims per-store sequences whose store no longer
+// exists, but only when this fixture truncated `stores` — which is precisely
+// the operation that orphans them.
+//
+// SeedStore drops the sequences it created, but it is not the only source:
+// nineteen test files INSERT INTO stores directly and handler tests create
+// stores over HTTP, so a per-fixture drop cannot reach them all and the next
+// fixture added leaks again with nothing failing. A sweep here is self-healing
+// and needs no discipline from whoever writes the next test (#436).
+//
+// Why this matters: migration 000004's AFTER INSERT trigger creates two
+// sequences per store, TRUNCATE does not touch catalog objects, and nothing
+// ever dropped them — the dev database reached 27,990, at which point pg_dump
+// failed with "out of shared memory" because it locks every relation in one
+// transaction. One suite pass alone put 4,152 back.
+//
+// Best-effort by design: a sweep failure must never fail a test that passed.
+func dropOrphanStoreSequences(t *testing.T, db *gorm.DB, tablesToCleanup []string) {
+	t.Helper()
+	if !slices.Contains(tablesToCleanup, "stores") {
+		return
+	}
+
+	// LIMIT bounds the work so this stays cheap once the catalog is healthy;
+	// a large backlog drains over successive runs rather than stalling one.
+	var names []string
+	if err := db.Raw(`
+		SELECT c.relname
+		  FROM pg_class c
+		  JOIN pg_namespace n ON n.oid = c.relnamespace
+		 WHERE c.relkind = 'S'
+		   AND n.nspname = 'public'
+		   AND (c.relname LIKE 'mk\_seq\_order\_%' OR c.relname LIKE 'mk\_seq\_return\_%')
+		   AND NOT EXISTS (
+		       SELECT 1 FROM stores s
+		        WHERE s.id::text = translate(
+		              regexp_replace(c.relname, '^mk_seq_(order|return)_', ''), '_', '-'))
+		 LIMIT 500`).Scan(&names).Error; err != nil {
+		t.Logf("testdb: sweep orphan store sequences: %v", err)
+		return
+	}
+
+	for _, name := range names {
+		// Identifier, not a bind value. Safe to interpolate: every name came
+		// from pg_class and matched the mk_seq_(order|return)_ pattern above,
+		// so the charset is [a-z0-9_] only.
+		if err := db.Exec(`DROP SEQUENCE IF EXISTS ` + name).Error; err != nil {
+			t.Logf("testdb: drop orphan sequence %s: %v", name, err)
+		}
+	}
 }
 
 func openOrSkip(t *testing.T) *gorm.DB {


### PR DESCRIPTION
Closes #436.

## What was actually wrong

`migrations/000004_orders_seq_eager.up.sql:33-60` installs an `AFTER INSERT ON stores` trigger creating **two** sequences per store (`mk_seq_order_<id>`, `mk_seq_return_<id>`). Nothing ever drops them — `TRUNCATE` does not touch catalog objects, and `tenantpurge` had zero sequence handling.

The dev database reached **27,990**, all of them orphaned (`stores` = 0 rows), at which point `pg_dump` failed outright:

```
pg_dump: error: out of shared memory
HINT: You might need to increase max_locks_per_transaction.
```

`pg_dump` takes `ACCESS SHARE` on every relation in one transaction, and `max_locks_per_transaction` is 64 with `max_connections` 100 — roughly 6,400 slots.

## Correcting my own issue title

**This is not a production emergency.** `docs/ops/2026-07-29-bondi-sequence-ownership.md:26` records **16 `mk_seq_order_*` sequences** in production as of 2026-07-29 — 16 stores, 32 sequences, growth proportional to real stores. The 27,990 was a dev/test pathology. The issue is retitled accordingly.

Two real bugs remained, both smaller than the original title implied.

## 1. Tenant purge left them behind (production-relevant, small)

A purged tenant orphaned two catalog objects per store, permanently. Fixed by dropping each purged store's sequences inside the same purge transaction, after the final `stores` delete — DDL is transactional in Postgres, so it commits or rolls back atomically with the purge.

**It could not be a `deleteStep`**: those carry *parameterised* statements, and a sequence name is an identifier, not a bind value. A pure `storeSequenceNames` helper parses each id as a uuid and errors on anything else, so a malformed id aborts the purge rather than silently dropping nothing.

**Excluded from `Report`, deliberately.** `Report` documents every step *of the plan*, and this is not one. `TableResult` is a `(table, rows)` pair; `RowsAffected` is meaningless for DDL, and a synthetic zero-row entry would read to an operator as "a table that held nothing" — a different and false claim. `countPlan` derives from `purgePlan`, so it could not preview a DROP in principle.

## 2. Test fixtures leaked them — and the first fix was not enough

`SeedStore` now drops both sequences before deleting the store row (sequences first, so a `RESTRICT`-blocked delete still reclaims the catalog objects).

**But `SeedStore` turned out to be one of at least seventeen sources.** After sweeping the dev database to zero, a single suite pass put **4,152 back**: nineteen test files `INSERT INTO stores` directly and only three drop sequences, and handler tests create stores over HTTP. A per-fixture drop cannot reach them, and the next fixture added leaks again with nothing failing.

So `testdb.NewDB`'s cleanup now sweeps orphans whenever it truncates `stores` — the operation that creates them. That is self-healing and needs no discipline from whoever writes the next test. Measured across the two guarded packages: **586 → 2**.

The work is bounded (`LIMIT 500`, so a backlog drains over runs rather than stalling one) and best-effort (a sweep failure never fails a passing test).

## 3. The dev database

Swept 27,990 → 0. The orphan predicate was verified in **both** directions before dropping anything: the negative half (`live_store_seqs = 0`), and the positive half by inserting a probe store inside a rolled-back transaction and confirming the predicate classified exactly 2 as live and excluded them. Without that second check, a predicate matching *everything* would look identical against an empty `stores` table.

Batched at 2,000 per transaction — one transaction would have exhausted the same lock table that broke `pg_dump`.

**`pg_dump` now succeeds**: 254,525 bytes.

## Test plan

All runs used `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'` with `-p 1 -count=1`, all EXECUTED.

- [x] `TestSeedStore_CleanupDropsPerStoreSequences` — **mutation:** remove the drop loop → fails `expected: 0, actual: 2`
- [x] `TestIntegration_Purge_DropsPerStoreSequences` — **mutation:** `return nil` instead of `dropStoreSequences` → fails `expected: 0, actual: 2`
- [x] The first test **must** use `testdb.NewDB`, not `NewTx` — under `NewTx` the trigger's `CREATE SEQUENCE` rolls back and the assertion would hold with or without the fix
- [x] `pkg/testdb` and `internal/tenantpurge` green; the sweep verified to drop 584 orphans in one run
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `gofmt` clean

**On the intermittent failures seen during development:** `internal/tenantpurge` failed on some runs while a concurrent worktree held ~44 sessions against the same database. Ruled out as environmental by running the identical package combination at base and at HEAD once contention cleared — **0 failures in every case**, and `tenantpurge` alone is green.

## Not done

The long-term fix is retiring catalog objects for document numbering — a per-store counter *row* in the `store_transactional_counter` shape, which would be purgeable by a plain `DELETE`. Migration 000003 pivoted *away* from that on contention grounds (p99 ~244ms → ~60ms), so it needs re-benchmarking against the 75ms M1 gate before adoption. Worth noting the numbers are explicitly **not** required to be gapless (`000004:29-31`), so the counter could commit in its own short transaction rather than being held for the life of the order-create transaction — which is likely the whole difference. Out of scope here.
