### PR TITLE
fix(erasure): strip customer PII from the shipments, audit_logs and outbox_events JSONB blobs (#435)

### DIFF
--- a/services/marketplace-api/internal/customererasure/coverage_integration_test.go
+++ b/services/marketplace-api/internal/customererasure/coverage_integration_test.go
@@ -54,7 +54,6 @@ var declaredExclusions = map[string]string{
 	"warehouses":                "merchant facility contact, not a customer",
 	"tenant_sso_user_mappings":  "merchant SSO identity, not a customer",
 	"promo_redemptions":         "subscription promo-code redemption (§7). Its `email` is the MERCHANT's billing address — promo.Service writes normaliseEmail(in.MerchantEmail) (internal/promo/service.go:156) and the row references a subscription_id, not an order. Anonymising it during a customer erasure would rewrite a merchant's own billing record",
-	"audit_logs":                "governance record; operator rows are retained deliberately under their own retention path (#288, #365). Its actor_email is an operator, and its metadata JSONB is known residual PII, out of scope (#259)",
 	"customer_erasure_requests": "the request itself — its own status and receipt are the evidence the erasure happened, and destroying it would destroy the proof",
 }
 

--- a/services/marketplace-api/internal/customererasure/executor_integration_test.go
+++ b/services/marketplace-api/internal/customererasure/executor_integration_test.go
@@ -33,6 +33,12 @@ type customer struct {
 	mediaID   uuid.UUID
 	orderID   uuid.UUID
 	emailSend uuid.UUID
+	// The JSONB half (#435): each of these rows SURVIVES the erasure with
+	// its non-personal fields intact, and loses only the named keys.
+	shipmentID uuid.UUID
+	auditID    uuid.UUID
+	cartID     uuid.UUID
+	outboxID   uuid.UUID
 }
 
 type fixture struct {
@@ -59,6 +65,10 @@ const (
 	orderTotal  = "42.50"
 	orderCcy    = "EUR"
 	addrCountry = "IE"
+	// cartRecoveryURL embeds a per-customer token, so it is personal data in
+	// its own right: anyone holding it can reopen that person's cart.
+	cartRecoveryURLPrefix = "https://shop.test/recover/"
+	auditAction           = "customer.updated"
 )
 
 func newFixture(t *testing.T) fixture {
@@ -111,6 +121,7 @@ func seedCustomer(t *testing.T, db *gorm.DB, tenantID, storeID, productID uuid.U
 		email: email, name: name,
 		profileID: uuid.New(), addressID: uuid.New(), wishlist: uuid.New(),
 		reviewID: uuid.New(), mediaID: uuid.New(), orderID: uuid.New(), emailSend: uuid.New(),
+		shipmentID: uuid.New(), auditID: uuid.New(), cartID: uuid.New(), outboxID: uuid.New(),
 	}
 
 	exec := func(sql string, args ...any) {
@@ -156,7 +167,78 @@ func seedCustomer(t *testing.T, db *gorm.DB, tenantID, storeID, productID uuid.U
 	      VALUES (?, ?, ?, ?, 'order_confirmation', 'sent')`,
 		c.emailSend, tenantID, storeID, email)
 
+	// ---- the JSONB blobs (#435) ------------------------------------------
+	// A shipment whose ship_to is the customer's delivery address. ship_from
+	// is seeded as the customer's address too, which is exactly what
+	// shipmentcancel writes onto a reverse leg — the case that makes
+	// stripping BOTH columns necessary rather than fussy.
+	exec(`INSERT INTO shipments (id, tenant_id, store_id, order_id, carrier, tracking_number,
+	                             status, ship_from, ship_to, currency_code)
+	      VALUES (?, ?, ?, ?, 'delhivery', ?, 'pending', ?::jsonb, ?::jsonb, ?)`,
+		c.shipmentID, tenantID, storeID, c.orderID, "TRK-"+c.shipmentID.String()[:8],
+		shipmentAddressJSON(name), shipmentAddressJSON(name), orderCcy)
+
+	// An audit row whose metadata names the customer. store_id is set, and
+	// `action` is the structural field that must survive the strip.
+	exec(`INSERT INTO audit_logs (id, tenant_id, store_id, actor_type, action, resource_type, resource_id, metadata)
+	      VALUES (?, ?, ?, 'user', ?, 'customer', ?, ?::jsonb)`,
+		c.auditID, tenantID, storeID, auditAction, c.profileID.String(), auditMetadataJSON(email))
+
+	exec(`INSERT INTO abandoned_carts (id, tenant_id, store_id, cart_session_id, customer_email,
+	                                   customer_name, item_count, subtotal, currency_code,
+	                                   items_snapshot, recovery_url, last_active_at)
+	      VALUES (?, ?, ?, ?, ?, ?, 2, ?, ?, '[]'::jsonb, ?, now())`,
+		c.cartID, tenantID, storeID, c.cartID.String(), email, name,
+		orderTotal, orderCcy, cartRecoveryURLPrefix+c.cartID.String())
+
+	exec(`INSERT INTO outbox_events (id, tenant_id, aggregate, aggregate_id, event_type, payload)
+	      VALUES (?, ?, 'abandoned_cart', ?, 'abandoned_cart.recovery_email', ?::jsonb)`,
+		c.outboxID, tenantID, c.cartID, outboxPayloadJSON(storeID, c.cartID, email))
+
 	return c
+}
+
+// shipmentAddressJSON is the eight-key blob handlers/admin/shipments.go:694
+// writes into ship_to / ship_from.
+func shipmentAddressJSON(name string) string {
+	b, _ := json.Marshal(map[string]any{
+		"name": name, "line1": "1 Test Lane", "line2": "Apt 2", "city": "Dublin",
+		"region": "Leinster", "postal_code": "D01 X1X1", "country_code": addrCountry,
+		"phone": "+353100000000",
+	})
+	return string(b)
+}
+
+// auditMetadataJSON carries the customer under ALL SIX stripped key names at
+// once, plus a structural key that must survive. One row exercising every
+// name is stronger than six rows each exercising one: a step that strips only
+// the first key still fails here.
+func auditMetadataJSON(email string) string {
+	b, _ := json.Marshal(map[string]any{
+		"customer_email":  email,
+		"email":           email,
+		"recipient_email": email,
+		"submitter_email": email,
+		"author_email":    email,
+		"actor_email":     email,
+		"source":          "storefront",
+	})
+	return string(b)
+}
+
+// outboxPayloadJSON is what order/abandoned_cart_service.go:128 enqueues.
+// store_id and item_count are the routing/reporting fields that must survive
+// — outbox/publisher.go:112 fails a batch whose payload has no store_id.
+func outboxPayloadJSON(storeID, cartID uuid.UUID, email string) string {
+	b, _ := json.Marshal(map[string]any{
+		"store_id":          storeID.String(),
+		"abandoned_cart_id": cartID.String(),
+		"customer_email":    email,
+		"recovery_url":      cartRecoveryURLPrefix + cartID.String(),
+		"item_count":        2,
+		"currency":          orderCcy,
+	})
+	return string(b)
 }
 
 func newExecutor(t *testing.T, db *gorm.DB) *Executor {
@@ -309,6 +391,100 @@ func assertCustomerIntact(t *testing.T, db *gorm.DB, c customer) {
 	require.EqualValues(t, 1, count(t, db,
 		`SELECT count(*) FROM order_addresses WHERE order_id = ? AND name = ? AND line1 = '1 Test Lane' AND city = 'Dublin'`,
 		c.orderID, c.name))
+
+	// The JSONB blobs (#435). Asserted key-by-key, not by row count: a strip
+	// that lost its predicate leaves the row present and empty, and count(*)
+	// would call that intact.
+	require.EqualValues(t, 1, count(t, db,
+		`SELECT count(*) FROM shipments
+		  WHERE id = ? AND ship_to ->> 'name' = ? AND ship_from ->> 'name' = ?
+		    AND ship_to ->> 'phone' = '+353100000000'`,
+		c.shipmentID, c.name, c.name))
+	require.EqualValues(t, 1, count(t, db,
+		`SELECT count(*) FROM audit_logs
+		  WHERE id = ? AND metadata ->> 'customer_email' = ? AND metadata ->> 'actor_email' = ?`,
+		c.auditID, c.email, c.email))
+	require.EqualValues(t, 1, count(t, db,
+		`SELECT count(*) FROM abandoned_carts WHERE id = ? AND customer_email = ?`,
+		c.cartID, c.email))
+	require.EqualValues(t, 1, count(t, db,
+		`SELECT count(*) FROM outbox_events
+		  WHERE id = ? AND payload ->> 'customer_email' = ? AND payload ->> 'recovery_url' <> ''`,
+		c.outboxID, c.email))
+}
+
+// TestProcess_StripsPersonalKeysFromJSONBBlobsAndKeepsTheRest is the #435
+// test.
+//
+// Three blobs outlive every other copy of the subject's address:
+// shipments.ship_to/ship_from, audit_logs.metadata (retained FOREVER on a Pro
+// plan — audit/prune_cron.go:42) and outbox_events.payload. Each row must
+// survive with its operational fields byte-identical and lose only the keys
+// that name the person. A step that emptied the whole blob would pass a
+// "the PII is gone" assertion and destroy a governance record; that is why
+// every assertion below has a matching "and this survived".
+func TestProcess_StripsPersonalKeysFromJSONBBlobsAndKeepsTheRest(t *testing.T) {
+	f := newFixture(t)
+	_, err := newExecutor(t, f.db).Process(context.Background(), f.request)
+	require.NoError(t, err)
+
+	// ---- shipments -------------------------------------------------------
+	var ship struct {
+		ShipTo, ShipFrom, Carrier, TrackingNumber, Status string
+	}
+	require.NoError(t, f.db.Raw(
+		`SELECT ship_to::text AS ship_to, ship_from::text AS ship_from,
+		        carrier, tracking_number, status
+		   FROM shipments WHERE id = ?`, f.subject.shipmentID).Scan(&ship).Error)
+
+	require.Equal(t, "{}", ship.ShipTo, "ship_to is the customer's delivery address and must be emptied")
+	require.Equal(t, "{}", ship.ShipFrom,
+		"ship_from carries the customer on a reverse leg (shipmentcancel/executor.go:254) and must be emptied too")
+	require.Equal(t, "delhivery", ship.Carrier, "the shipment itself must survive: it is the carrier record")
+	require.NotEmpty(t, ship.TrackingNumber, "the waybill is not personal data and must not be destroyed")
+	require.Equal(t, "pending", ship.Status)
+
+	// ---- audit_logs ------------------------------------------------------
+	var audit struct {
+		Metadata, Action, ResourceType string
+	}
+	require.NoError(t, f.db.Raw(
+		`SELECT metadata::text AS metadata, action, resource_type
+		   FROM audit_logs WHERE id = ?`, f.subject.auditID).Scan(&audit).Error)
+
+	require.Equal(t, auditAction, audit.Action, "the governance record must survive the strip")
+	require.Equal(t, "customer", audit.ResourceType)
+	require.NotContains(t, audit.Metadata, subjectAddr,
+		"no stripped key may leave the subject's address behind in the metadata")
+	for _, key := range []string{
+		"customer_email", "\"email\"", "recipient_email",
+		"submitter_email", "author_email", "actor_email",
+	} {
+		require.NotContains(t, audit.Metadata, key, "metadata still carries the %s key", key)
+	}
+	require.Contains(t, audit.Metadata, "storefront",
+		"the strip must remove named keys only — the rest of the object is the audit record")
+
+	// ---- outbox_events ---------------------------------------------------
+	var evt struct {
+		Payload, Aggregate, EventType string
+	}
+	require.NoError(t, f.db.Raw(
+		`SELECT payload::text AS payload, aggregate, event_type
+		   FROM outbox_events WHERE id = ?`, f.subject.outboxID).Scan(&evt).Error)
+
+	require.Equal(t, "abandoned_cart", evt.Aggregate, "the event row must survive; only its payload keys go")
+	require.Equal(t, "abandoned_cart.recovery_email", evt.EventType)
+	require.NotContains(t, evt.Payload, subjectAddr)
+	require.NotContains(t, evt.Payload, "customer_email")
+	require.NotContains(t, evt.Payload, "recovery_url",
+		"the recovery URL is a bearer token for the person's cart")
+	require.Contains(t, evt.Payload, f.storeID.String(),
+		"store_id must survive: outbox/publisher.go:112 fails a batch whose payload has no store_id")
+	require.Contains(t, evt.Payload, "item_count")
+
+	// The cart itself is deleted outright, taking items_snapshot with it.
+	require.Zero(t, count(t, f.db, `SELECT count(*) FROM abandoned_carts WHERE id = ?`, f.subject.cartID))
 }
 
 // TestProcess_WritesAReceiptCarryingNoPersonalData. The receipt is the

--- a/services/marketplace-api/internal/customererasure/models.go
+++ b/services/marketplace-api/internal/customererasure/models.go
@@ -90,15 +90,15 @@ const RetentionBasis = "financial record; anonymised and retained 7 years under 
 // named in the receipt anyway: a table absent from both halves of a receipt
 // is indistinguishable, to a reader, from one the plan never considered.
 //
-// Their only residual PII risk is JSONB (payment_transactions.metadata,
-// shipments.ship_from/ship_to), which is out of scope for #259 and recorded
-// as such in the package doc.
+// payment_transactions.metadata (JSONB) is the one blob among them, and it
+// is a dead column — nothing writes it — as #435 established. shipments used
+// to be listed here; it now carries its own step, because its ship_to /
+// ship_from blobs do hold the subject.
 var retainedWithoutStep = []string{
 	"order_items",
 	"payment_transactions",
 	"platform_fee_ledger",
 	"refund_transactions",
-	"shipments",
 }
 
 // ErrRequestNotFound — no such erasure request.

--- a/services/marketplace-api/internal/customererasure/plan.go
+++ b/services/marketplace-api/internal/customererasure/plan.go
@@ -35,21 +35,30 @@
 // TABLES DELIBERATELY CARRYING NO STEP, verified column-by-column against
 // the live schema rather than assumed:
 //   - payment_transactions, refund_transactions, platform_fee_ledger hold no
-//     personal column at all. Their only PII risk is
-//     payment_transactions.metadata (JSONB), which is out of scope below.
-//   - shipments holds personal data only in ship_from/ship_to (JSONB).
+//     personal column at all. payment_transactions.metadata (JSONB) is a
+//     DEAD column — payment.PaymentTransaction declares no Metadata field
+//     and no production statement writes it, so it is always '{}' (#435).
 //   - order_items, order_tax_lines, return_items, loyalty_transactions,
 //     gift_card_transactions and referrals hold no personal column; they
 //     survive attached to rows that have been anonymised.
 //
-// OUT OF SCOPE, deliberately: nine JSONB columns can embed a customer email
-// or address (stripe_webhook_events.payload, payment_transactions.metadata,
-// shipments.ship_from/ship_to, abandoned_carts.items_snapshot,
-// audit_logs.metadata, outbox_events.payload and others). None are inspected
-// here — safely key-stripping nine differently-shaped payloads is its own
-// effort and guessing at their shapes risks corrupting payment metadata.
-// abandoned_carts is deleted outright so its snapshot goes with it; the rest
-// are known residual PII, tracked separately.
+// JSONB COLUMNS. #435 audited the nine blobs that can embed a customer email
+// or address and resolved each one:
+//   - shipments.ship_to / ship_from, audit_logs.metadata and
+//     outbox_events.payload carry the subject and are key-stripped by steps
+//     below. Keys are stripped by NAME — never a wholesale rewrite — so a
+//     blob's non-personal structure survives intact.
+//   - abandoned_carts.items_snapshot goes with the row, which is deleted.
+//   - returns.pickup_details is text, not JSONB, and is already nulled.
+//   - payment_transactions.metadata is the dead column described above.
+//   - stripe_webhook_events.payload is merchant subscription billing: its
+//     "customer" is the tenant, not a shopper, and a tenant purge already
+//     destroys it.
+//   - idempotency_keys.response is platform-operator only and self-expires
+//     on a 24h TTL.
+//   - webhook_events.payload is genuinely unscopable — the table has no
+//     tenant, store or order column, so a subject's rows cannot be found. It
+//     needs an age-based prune, tracked separately as #440.
 package customererasure
 
 import (
@@ -73,6 +82,15 @@ const (
 // subject's personal data and must not be touched. Value verified against
 // the live CHECK constraints on review_replies and support_ticket_replies.
 const authorTypeCustomer = "customer"
+
+// aggregateAbandonedCart is the outbox_events.aggregate discriminator for the
+// one event whose payload names a shopper. It is the value of
+// outbox.AggregateAbandonedCart, duplicated as a local const rather than
+// imported so the plan stays a pure, dependency-free description of
+// statements. There is NO CHECK constraint on outbox_events.aggregate, so
+// nothing but this pairing keeps the two in step — the integration test seeds
+// a row with the literal the producer writes and asserts the strip reaches it.
+const aggregateAbandonedCart = "abandoned_cart"
 
 // Step is one parameterised statement in the erasure plan.
 type Step struct {
@@ -133,6 +151,28 @@ func erasurePlan(storeID uuid.UUID, email string, token string) []Step {
 			Disposition: DispositionDelete,
 			SQL:         `DELETE FROM customer_addresses WHERE customer_id IN (` + profileIDs + `)`,
 			Args:        []any{storeID, email},
+		},
+		{
+			// outbox_events has NO store_id column — only tenant_id — so it
+			// is scoped through abandoned_carts, the one aggregate whose
+			// payload names a shopper: order/abandoned_cart_service.go:128
+			// writes customer_email and recovery_url into it.
+			//
+			// MUST RUN BEFORE the abandoned_carts DELETE immediately below,
+			// which destroys the very rows this subquery reads. Same
+			// ordering hazard as review_media/reviews, and pinned by a test.
+			//
+			// Only those two keys go; store_id, item_count, subtotal and
+			// currency stay, because outbox/publisher.go:112 reads store_id
+			// to route the event and an unroutable row poisons its batch. On
+			// an unpublished row this degrades to a recovery email that is
+			// never sent, which is the correct outcome for an erased person.
+			Table:       "outbox_events", // 000001
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE outbox_events SET payload = payload - 'customer_email' - 'recovery_url'
+				WHERE aggregate = ? AND aggregate_id IN (
+					SELECT id FROM abandoned_carts WHERE store_id = ? AND customer_email = ?)`,
+			Args: []any{aggregateAbandonedCart, storeID, email},
 		},
 		{
 			// Deleting the cart takes items_snapshot (JSONB) with it, which
@@ -214,6 +254,76 @@ func erasurePlan(storeID uuid.UUID, email string, token string) []Step {
 			SQL: `UPDATE returns SET pickup_details = NULL
 				WHERE store_id = ? AND order_id IN (` + subjectOrders + `)`,
 			Args: []any{storeID, storeID, email},
+		},
+		{
+			// ship_to is the customer's delivery address — eight keys
+			// written at handlers/admin/shipments.go:694. ship_from is
+			// normally the MERCHANT's warehouse, but
+			// shipmentcancel/executor.go:254 persists reverse-leg rows with
+			// ShipFrom = the forward row's ShipTo, i.e. the customer's
+			// address. Which column holds whom is not decidable per row
+			// without re-deriving the leg, so BOTH are stripped: a merchant
+			// warehouse address is recoverable from warehouses, a person's
+			// is not recoverable at all once erasure is due.
+			//
+			// Both are NOT NULL, so they are emptied, not nulled. The one
+			// reader, shipmentcancel.parseShipmentAddress, treats an
+			// address with no line1 as unusable and the reverse pickup
+			// fails cleanly with "arrange the return manually".
+			//
+			// Scoped through orders, so it MUST run before orders is
+			// anonymised.
+			Table:       "shipments", // 000008
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE shipments SET ship_to = '{}'::jsonb, ship_from = '{}'::jsonb
+				WHERE store_id = ? AND order_id IN (` + subjectOrders + `)`,
+			Args: []any{storeID, storeID, email},
+		},
+		{
+			// audit_logs.metadata is the highest-value blob in this plan,
+			// because it is the longest-lived: retention is plan-tiered
+			// (audit/prune_cron.go:42) at 90d trial/starter, 365d studio,
+			// and NEVER for Pro. A Pro merchant's audit metadata outlives
+			// every other copy of the address.
+			//
+			// Six keys, each traced to a writer: customer_email
+			// (storefront/checkout.go:242, checkout_ext.go:681), email
+			// (customer/service.go:103), recipient_email
+			// (admin/gift_cards.go:127), submitter_email / author_email /
+			// actor_email (storefront/tickets.go:189,501,628).
+			//
+			// The audit_logs.actor_EMAIL COLUMN is deliberately untouched:
+			// it names the operator or staff member who performed the
+			// action, which is the governance record itself and is not the
+			// subject's personal data. Only the metadata key of that name is
+			// stripped.
+			//
+			// The row is matched by the subject's address appearing in any
+			// of those six keys AND by store. `->> = ?` rather than
+			// jsonb_exists: existence alone would strip a bystander's email
+			// out of the subject's audit rows, and there is no key by which
+			// a row "belongs to" one shopper other than the address itself.
+			// Absent keys yield NULL, which is not equal to anything, so a
+			// row with none of them is never rewritten. Deliberately NOT the
+			// infix `metadata ? 'k'` operator — GORM consumes `?` as a bind
+			// placeholder and would misbind the statement (#369).
+			//
+			// store_id is NULLABLE here (operator rows carry NULL by
+			// design); `store_id = ?` excludes them, which is correct: an
+			// operator row is not a customer record.
+			Table:       "audit_logs", // 000035
+			Disposition: DispositionAnonymise,
+			SQL: `UPDATE audit_logs
+				SET metadata = metadata - 'customer_email' - 'email' - 'recipient_email'
+					- 'submitter_email' - 'author_email' - 'actor_email'
+				WHERE store_id = ?
+				  AND (metadata ->> 'customer_email' = ?
+					OR metadata ->> 'email' = ?
+					OR metadata ->> 'recipient_email' = ?
+					OR metadata ->> 'submitter_email' = ?
+					OR metadata ->> 'author_email' = ?
+					OR metadata ->> 'actor_email' = ?)`,
+			Args: []any{storeID, email, email, email, email, email, email},
 		},
 		{
 			// Anonymised, not deleted: deleting retroactively changes the

--- a/services/marketplace-api/internal/customererasure/plan_test.go
+++ b/services/marketplace-api/internal/customererasure/plan_test.go
@@ -157,3 +157,108 @@ func TestToken_IsDeterministicAndCarriesNoPersonalData(t *testing.T) {
 	require.True(t, strings.HasSuffix(tok, "@erased.invalid"),
 		".invalid is reserved by RFC 2606 and can never be routed")
 }
+
+// stepIndex is the position of the single step writing to table, or -1.
+func stepIndex(t *testing.T, steps []Step, table string) int {
+	t.Helper()
+	idx := -1
+	for i, s := range steps {
+		if s.Table == table {
+			require.Equal(t, -1, idx, "%s must appear exactly once", table)
+			idx = i
+		}
+	}
+	return idx
+}
+
+// TestErasurePlan_StripsTheOutboxBeforeDeletingTheCart.
+//
+// outbox_events has no store_id of its own; it is scoped through
+// `abandoned_carts WHERE store_id = ? AND customer_email = ?`. Deleting the
+// cart first would empty that subquery and the strip would silently leave the
+// customer's address and recovery URL in the payload — a green suite with the
+// PII still on disk (#435).
+func TestErasurePlan_StripsTheOutboxBeforeDeletingTheCart(t *testing.T) {
+	_, _, steps := testPlan(t)
+
+	outboxIdx := stepIndex(t, steps, "outbox_events")
+	cartIdx := stepIndex(t, steps, "abandoned_carts")
+	require.NotEqual(t, -1, outboxIdx, "the plan must strip outbox_events")
+	require.NotEqual(t, -1, cartIdx, "the plan must delete abandoned_carts")
+	require.Less(t, outboxIdx, cartIdx,
+		"outbox_events locates its rows through abandoned_carts and must run before the cart is deleted")
+}
+
+// TestErasurePlan_StripsShipmentsBeforeAnonymisingOrders — shipments is
+// order-scoped like order_addresses and returns.
+func TestErasurePlan_StripsShipmentsBeforeAnonymisingOrders(t *testing.T) {
+	_, _, steps := testPlan(t)
+
+	shipIdx := stepIndex(t, steps, "shipments")
+	ordersIdx := stepIndex(t, steps, "orders")
+	require.NotEqual(t, -1, shipIdx, "the plan must strip shipments")
+	require.Less(t, shipIdx, ordersIdx,
+		"shipments reads orders.customer_email and must run before orders is anonymised")
+}
+
+// TestErasurePlan_StripsJSONBKeysByNameRatherThanRewritingTheBlob.
+//
+// A `SET metadata = '{}'` would erase a governance record's structure along
+// with the address; a `jsonb_set` would rewrite a value the subject never
+// owned. The `-` operator removes exactly the named key and leaves everything
+// else byte-identical, which is what makes stripping a shared audit row safe.
+func TestErasurePlan_StripsJSONBKeysByNameRatherThanRewritingTheBlob(t *testing.T) {
+	_, _, steps := testPlan(t)
+
+	wantKeys := map[string][]string{
+		"audit_logs": {
+			"customer_email", "email", "recipient_email",
+			"submitter_email", "author_email", "actor_email",
+		},
+		"outbox_events": {"customer_email", "recovery_url"},
+	}
+
+	for table, keys := range wantKeys {
+		idx := stepIndex(t, steps, table)
+		require.NotEqual(t, -1, idx, "the plan must cover %s", table)
+		sql := steps[idx].SQL
+		for _, k := range keys {
+			require.Contains(t, sql, "- '"+k+"'",
+				"%s must strip the %q key by name", table, k)
+		}
+		require.NotContains(t, sql, "jsonb_set",
+			"%s must remove keys, not rewrite values", table)
+	}
+}
+
+// TestErasurePlan_EmptiesShipmentAddressesRatherThanNullingThem.
+// shipments.ship_to and ship_from are NOT NULL; a NULL would raise, and the
+// erasure is all-or-nothing, so it would take the whole request down.
+func TestErasurePlan_EmptiesShipmentAddressesRatherThanNullingThem(t *testing.T) {
+	_, _, steps := testPlan(t)
+
+	idx := stepIndex(t, steps, "shipments")
+	require.NotEqual(t, -1, idx)
+	sql := steps[idx].SQL
+	require.Contains(t, sql, "ship_to = '{}'::jsonb")
+	require.Contains(t, sql, "ship_from = '{}'::jsonb")
+	require.NotContains(t, sql, "ship_to = NULL")
+	require.NotContains(t, sql, "ship_from = NULL")
+}
+
+// TestErasurePlan_NeverUsesTheInfixJSONBExistsOperator. GORM consumes `?` as
+// a bind placeholder, so `metadata ? 'k'` misbinds every later argument —
+// the same trap #369 documented in pruneOperatorFreeText. Every `?` in a step
+// must be a placeholder, which TestErasurePlan_EveryStepIsWellFormed counts;
+// this asserts the operator forms that would break that count are absent.
+func TestErasurePlan_NeverUsesTheInfixJSONBExistsOperator(t *testing.T) {
+	_, _, steps := testPlan(t)
+
+	for i, s := range steps {
+		for _, forbidden := range []string{"? '", "?| ", "?& ", "?|", "?&"} {
+			require.NotContains(t, s.SQL, forbidden,
+				"step %d (%s) uses a jsonb `?` operator; GORM would bind it as a placeholder — use jsonb_exists / ->> instead",
+				i, s.Table)
+		}
+	}
+}

--- a/services/marketplace-api/internal/handlers/admin/shipment_cancel_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipment_cancel_integration_test.go
@@ -64,13 +64,23 @@ func (r *recordingCarrier) SupportedCountries() []string { return []string{"IN"}
 // seedShipmentWithStatus inserts a delhivery shipment for the order in the
 // given lifecycle status ('pending' = pre-pickup, 'in_transit' = picked up,
 // etc). ship_from/ship_to are NOT NULL jsonb on the table.
+//
+// They are seeded with REAL addresses, in the eight-key shape
+// handlers/admin/shipments.go writes. They used to be '{}', which was
+// scaffolding rather than intent — but since #435 an address with no line1
+// is refused by shipmentcancel.parseShipmentAddress, because a GDPR erasure
+// strips these very columns to '{}' and a blank address must never reach a
+// carrier as a pickup point. A '{}' fixture would now exercise that refusal
+// instead of the reverse-pickup path these tests are about.
 func seedShipmentWithStatus(t *testing.T, db *gorm.DB, tenantID, storeID, orderID uuid.UUID, waybill, status string) {
 	t.Helper()
+	const warehouse = `{"name":"Test Warehouse","line1":"12 Depot Road","city":"Mumbai","region":"MH","postal_code":"400001","country_code":"IN","phone":"+911100000000"}`
+	const customer = `{"name":"Test Customer","line1":"9 Buyer Street","city":"Pune","region":"MH","postal_code":"411001","country_code":"IN","phone":"+911122222222"}`
 	err := db.Exec(
 		`INSERT INTO shipments
 			(id, tenant_id, store_id, order_id, carrier, tracking_number, status, ship_from, ship_to, currency_code, created_at, updated_at)
-		 VALUES (gen_random_uuid(), ?, ?, ?, 'delhivery', ?, ?, '{}'::jsonb, '{}'::jsonb, 'INR', now(), now())`,
-		tenantID, storeID, orderID, waybill, status,
+		 VALUES (gen_random_uuid(), ?, ?, ?, 'delhivery', ?, ?, ?::jsonb, ?::jsonb, 'INR', now(), now())`,
+		tenantID, storeID, orderID, waybill, status, warehouse, customer,
 	).Error
 	if err != nil {
 		t.Fatalf("seedShipmentWithStatus(%s): %v", status, err)

--- a/services/marketplace-api/internal/shipmentcancel/executor.go
+++ b/services/marketplace-api/internal/shipmentcancel/executor.go
@@ -14,6 +14,13 @@ import (
 
 // errEmptyAddress is returned by parseShipmentAddress when the stored ship_from
 // / ship_to JSONB blob is empty — a shipment we can't build a reverse leg from.
+//
+// "Empty" means EITHER no bytes at all OR a blob with no line1. The second
+// case is not hypothetical: a GDPR art.17 erasure strips ship_to/ship_from to
+// '{}' (customererasure/plan.go), and those columns are NOT NULL so the
+// erasure cannot null them instead. Two bytes of valid JSON would otherwise
+// decode into a wholly blank Address and be handed to a carrier as a real
+// pickup point, which is worse than failing (#435).
 var errEmptyAddress = errors.New("empty address")
 
 // ShipmentStore is the narrow persistence surface the executor needs.
@@ -284,6 +291,12 @@ func parseShipmentAddress(raw []byte) (shipping.Address, error) {
 	}
 	if err := json.Unmarshal(raw, &a); err != nil {
 		return shipping.Address{}, err
+	}
+	// line1 is the one field no deliverable address can omit; every writer
+	// of these blobs supplies it. Its absence means the blob is a placeholder
+	// — erased, or never populated — not an address.
+	if a.Line1 == "" {
+		return shipping.Address{}, errEmptyAddress
 	}
 	return shipping.Address{
 		Name: a.Name, Line1: a.Line1, Line2: a.Line2, City: a.City,

--- a/services/marketplace-api/internal/shipmentcancel/executor_test.go
+++ b/services/marketplace-api/internal/shipmentcancel/executor_test.go
@@ -350,3 +350,26 @@ func TestExecutor_Delivered_NoReverseCapability_Unsupported(t *testing.T) {
 		t.Fatalf("out = %+v, want reverse_pickup/unsupported for a carrier without the capability", out)
 	}
 }
+
+// TestParseShipmentAddress_RejectsAnErasedBlob pins the guard added for #435.
+//
+// A GDPR art.17 erasure strips shipments.ship_to / ship_from to '{}' — the
+// columns are NOT NULL, so it cannot use NULL. That is two bytes of perfectly
+// valid JSON, and without the line1 check it would decode into a blank
+// Address and be handed to a carrier as a real pickup point. The reverse-leg
+// path must instead fail and tell the operator to arrange the return by hand.
+func TestParseShipmentAddress_RejectsAnErasedBlob(t *testing.T) {
+	for _, raw := range []string{"", "{}", `{"country_code":"IE"}`} {
+		if _, err := parseShipmentAddress([]byte(raw)); !errors.Is(err, errEmptyAddress) {
+			t.Fatalf("parseShipmentAddress(%q) = %v, want errEmptyAddress — a blob with no line1 is not an address", raw, err)
+		}
+	}
+
+	got, err := parseShipmentAddress([]byte(`{"name":"A Person","line1":"1 Test Lane","city":"Dublin","country_code":"IE"}`))
+	if err != nil {
+		t.Fatalf("a populated blob must still parse: %v", err)
+	}
+	if got.Line1 != "1 Test Lane" || got.Name != "A Person" {
+		t.Fatalf("populated address decoded wrong: %+v", got)
+	}
+}


### PR DESCRIPTION
Closes #435.

#437's erasure covered the structured columns and declared nine JSONB columns as known residual PII. Investigation narrowed those nine to **three** that are real, erasable and retained forever.

## The other six, resolved

**Already erased** — `abandoned_carts.items_snapshot` (the whole row is deleted) and `returns.pickup_details` (it is `text`, not JSONB, and already nulled).

**Not customer data** — `payment_transactions.metadata` is a **dead column** (`PaymentTransaction` has no `Metadata` field; the only statements naming it are in `_test.go`, so it is always `{}`); `stripe_webhook_events.payload` is *merchant* billing, resolved via `store_subscriptions.stripe_customer_id`, and already purged with the tenant; `idempotency_keys.response` is platform-operator trial extensions with a 24h TTL and a daily sweeper.

**Unscopable, split out to #440** — `webhook_events.payload` holds raw provider events with `billing_details.email`, kept forever, but the table has no tenant, store or order column. There is no key by which to find a subject's rows; it needs an age-based prune, not an erasure step. Nothing reads the payload back, so a prune breaks nothing.

## The three that are fixed

1. **`shipments.ship_to` / `ship_from`** — the eight-key address written at `handlers/admin/shipments.go:694`. `ship_from` is normally the merchant facility, **but** `shipmentcancel/executor.go:254` writes reverse-leg rows with `ShipFrom: sh.ShipTo`, so both are stripped for the subject's shipments. Both are NOT NULL, so they go to `'{}'::jsonb`.
2. **`audit_logs.metadata`** — six keys stripped: `customer_email`, `email`, `recipient_email`, `submitter_email`, `author_email`, `actor_email`. This one matters most: retention is plan-tiered (`audit/prune_cron.go:42`) at 90d trial/starter, 365d studio, and **never for Pro**.
3. **`outbox_events.payload`** — `customer_email` and `recovery_url` on abandoned-cart rows.

## A hazard this fix introduced, and had to fix

The brief asserted `parseShipmentAddress` already handles an empty blob. **It does not.** The guard is `len(raw) == 0`, and `'{}'::jsonb` is two bytes of valid JSON — it unmarshals into a wholly blank `shipping.Address` and would have been handed to a carrier as a real pickup point. That is worse than failing.

Since both columns are NOT NULL and cannot be nulled, the value could not be chosen around. Added the minimal guard — reject a blob with no `line1`, the one field no deliverable address can omit — plus a unit test. The reverse-leg path now fails cleanly with the existing "arrange the return manually" message.

That surfaced a second thing: `shipment_cancel_integration_test.go` seeded `'{}'` for both columns and asserted a reverse pickup *was* created. That `{}` was scaffolding ("NOT NULL jsonb"), not a claim that blank addresses are shippable, so the fixture now uses realistic addresses in the shape the writer produces.

## The `audit_logs` predicate, and why it is equality not existence

```sql
WHERE store_id = ?
  AND (metadata ->> 'customer_email' = ? OR metadata ->> 'email' = ? OR ...)
```

**Equality on the value, not `jsonb_exists`.** There is no key by which an audit row "belongs to" one shopper other than the address itself, so stripping on mere key-existence would erase a **bystander's** address out of every row in the same store. Absent keys yield NULL, which equals nothing, so a row carrying none is never rewritten.

`->>` and `-`, never the infix `metadata ? 'key'` — GORM consumes `?` as a bind placeholder, exactly as `pruneOperatorFreeText` (#369) documents. `TestErasurePlan_NeverUsesTheInfixJSONBExistsOperator` stops a future step reaching for it.

`store_id = ?` deliberately excludes operator rows, which carry `store_id = NULL` by design — an operator row is not a customer record. The `audit_logs.actor_email` **column** is untouched; only the metadata key of that name.

## Ordering

Two orderings are load-bearing and each has its own test: the `outbox_events` strip runs **immediately before** the `abandoned_carts` DELETE (it reads rows that DELETE destroys), and the `shipments` strip runs before the `orders` anonymise (it locates rows by the subject's email on `orders`).

`audit_logs` was removed from `declaredExclusions` — `TestDeclaredExclusions_AreJustifiedAndLive` asserts a covered table is not also excluded.

## Test plan

All runs used `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'` with `-p 1 -count=1`, all EXECUTED.

- [x] `./internal/customererasure/` **30/30 PASS**, including all six pre-existing plan guards; `shipmentcancel`, `outbox`, `audit` green
- [x] **Mutation ×3** — dropping each strip fails its own assertions, including the coverage guard reporting `[audit_logs]` and the raw subject address appearing in the stored blob. All restored and re-verified
- [x] The executor test asserts the PII keys are gone while non-PII keys (`source`, `currency`, `item_count`, `store_id`) survive, and the bystander customers are untouched
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean

**Two pre-existing failures, verified at `main` rather than assumed:** `TestPromoApply_BelowAbsoluteFloor_INR` (`internal/handlers/admin`) and `TestIntegration_ProductService_UpdateAggregate_OptionValueInUseRejected` (`internal/product`). Both fail on a clean checkout of `main`; both packages are absent from `make test-int`, which is why they went unnoticed. Filed separately.
