### PR TITLE
test: run every integration package and guard the list against narrowing again (#446)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,13 @@ test-unit: ## Run unit tests across every Go service and TS workspace
 	@cd services/platform-api && go test ./...
 	@echo "▶ auth-bff"
 	@cd services/auth-bff && go test ./...
+	@# marketplace-api was missing here while the target's own help text claimed
+	@# "every Go service" (#446). CI covered it, so nothing was unverified — but
+	@# it meant the untagged guards in this service, including the test-int
+	@# coverage guard below, could not go red on a developer's machine. A guard
+	@# nobody sees locally is only half a guard.
+	@echo "▶ marketplace-api"
+	@cd services/marketplace-api && go test ./...
 	@echo "▶ turbo (TS workspaces)"
 	@npx turbo run test
 

--- a/Makefile
+++ b/Makefile
@@ -54,68 +54,85 @@ test-int: ## Run integration tests against the running `make dev` stack
 	@# -p 1: these share one local Postgres, and parallel package execution
 	@# exhausts its connection limit ("sorry, too many clients already").
 	@#
-	@# Scoped to the packages whose fixtures are currently correct, NOT ./... —
-	@# the rest fail on schema drift: migrations added NOT NULL columns and FKs
-	@# without updating test fixtures (products.vendor_id, store_subscriptions'
-	@# store FK, stores.storefront_customer_portal_secret, an apikeys varchar(60)
-	@# overflow, orderrefund cleanup deadlocks, and a nil-Repo panic in
-	@# whitelabel/lifecycle). Tracked separately.
+	@# This list covers EVERY package in the service that has integration tests.
+	@# It is hand-maintained but not hand-audited: the untagged unit test
+	@# TestEveryIntegrationPackageIsInTheTestIntTarget (services/marketplace-api/
+	@# testint_coverage_test.go) parses this target and fails on any package
+	@# carrying a `//go:build integration` file that is missing from it. Add a
+	@# package here and `go test ./...` goes green; forget to, and it goes red.
 	@#
-	@# Widen this one package at a time as each cluster is fixed. A permanently
-	@# red target is worse than a narrow green one: this suite was dark long
-	@# enough to hide a production dunning bug (see the sql.NullTime fix in
-	@# internal/subscription/dunning/ladder.go).
+	@# It was not always complete. 32 of 60 integration packages — more than
+	@# half — were absent, and four defects (#397, #398, #399, #446) survived in
+	@# them because the test that caught each one had never been executed. The
+	@# earlier text here justified the omissions with schema drift
+	@# (products.vendor_id, a nil-Repo panic in whitelabel/lifecycle, an apikeys
+	@# varchar(60) overflow); those causes were fixed by #403, #318 and #395, and
+	@# the exclusions simply outlived their reasons. That is the failure mode the
+	@# guard above now prevents: a stale justification cannot keep a package dark,
+	@# because the guard checks the list, not the prose.
 	@#
-	@# ./internal/billing/tax/... is fully included again: the revalidation
-	@# deadlock it used to hide was fixed in #396 — Cron.Run no longer holds a
-	@# transaction open across Svc.Submit, so the pass cannot wait on its own
-	@# row lock.
-	@#
-	@# ./internal/subscription below is deliberately NOT ./internal/subscription/...
-	@# — recursing would pull in sibling packages whose status was never
-	@# measured. internal/subscription/planchange is listed explicitly below:
-	@# it is green as of #397 and must keep running so that guard cannot
-	@# silently stop.
-	@#
-	@# ./internal/customererasure/... is included from #259. It was measured
-	@# green against the dev database (schema 113) before being added, which is
-	@# the precondition for widening this list at all. It carries the GDPR
-	@# art.17 schema-coverage guard: a table added later that names a customer
-	@# fails this target rather than silently escaping erasure, so it must keep
-	@# running or the guard stops guarding.
-	@#
-	@# ./internal/campaignbudget/... is the full subtree: the parent package plus
-	@# cron, concurrency and transactional. All four were measured green against
-	@# the dev database on 2026-08-28 when the #399 trial-ramp idempotency guard
-	@# landed, so the ellipsis is safe — and the parent package must keep running
-	@# or that guard could silently regress again.
+	@# ./internal/subscription is deliberately NOT ./internal/subscription/... —
+	@# its siblings are listed individually so adding one is a visible decision.
+	@# Whole list is green and takes ~5 minutes (4m54s, measured 2026-08-29).
 	@cd services/marketplace-api && \
 	  TEST_DATABASE_URL='postgres://dev:dev@localhost:5432/marketplace_db?sslmode=disable' \
 	  go test -tags=integration -p 1 \
+	    ./cmd/backfill-email/... \
 	    ./internal/apikeys/... \
-	    ./internal/audit/... \
-	    ./internal/customererasure/... \
 	    ./internal/arbitrage/... \
-	    ./internal/handlers/platformadmin/... \
-	    ./internal/tenantpurge/... \
-	    ./internal/subscription/dunning/... \
-	    ./internal/handlers/internalsvc/... \
+	    ./internal/attestation/... \
+	    ./internal/audit/... \
+	    ./internal/authz/... \
 	    ./internal/billing/appaddon/... \
+	    ./internal/billing/attestations/... \
 	    ./internal/billing/dispatch/... \
+	    ./internal/billing/migration/... \
 	    ./internal/billing/tax/... \
 	    ./internal/billing/trial/... \
+	    ./internal/branding/... \
+	    ./internal/breakglass/... \
+	    ./internal/campaign/... \
+	    ./internal/campaignbudget/... \
+	    ./internal/category/... \
+	    ./internal/csvjob/... \
+	    ./internal/customererasure/... \
+	    ./internal/email/... \
+	    ./internal/emailevents/... \
+	    ./internal/emaillog/... \
+	    ./internal/giftcard/... \
+	    ./internal/handlers/admin/... \
+	    ./internal/handlers/internalsvc/... \
+	    ./internal/handlers/platformadmin/... \
+	    ./internal/handlers/storefront/... \
+	    ./internal/handlers/webhooks/... \
+	    ./internal/idempotency/... \
+	    ./internal/inbox/... \
+	    ./internal/notification/... \
+	    ./internal/order/... \
+	    ./internal/orderrefund/... \
+	    ./internal/outbox/... \
+	    ./internal/page/... \
+	    ./internal/payment/... \
+	    ./internal/product/... \
+	    ./internal/reconciliation/... \
+	    ./internal/shipping/... \
+	    ./internal/signup/... \
+	    ./internal/stores/... \
 	    ./internal/subscription \
 	    ./internal/subscription/cancel/... \
+	    ./internal/subscription/dunning/... \
 	    ./internal/subscription/harddelete/... \
 	    ./internal/subscription/lifecycle/... \
 	    ./internal/subscription/planchange/... \
 	    ./internal/subscription/readonly/... \
 	    ./internal/subscription/statemachine/... \
-	    ./internal/campaignbudget/... \
-	    ./internal/handlers/webhooks/... \
-	    ./internal/reconciliation/... \
-	    ./tests/integration/... \
-	    ./pkg/testdb/...
+	    ./internal/tenantpurge/... \
+	    ./internal/ticket/... \
+	    ./internal/vendor/... \
+	    ./internal/webhookevents/... \
+	    ./internal/whitelabel/lifecycle/... \
+	    ./pkg/testdb/... \
+	    ./tests/integration/...
 
 cover: ## Coverage report for both Go services
 	@cd services/platform-api && go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out | tail -5

--- a/services/marketplace-api/internal/handlers/admin/products_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/products_integration_test.go
@@ -50,8 +50,19 @@ func (stubClient) GetStoreBySlug(_ context.Context, _ string) (*stores.Store, er
 
 // productsTables is the dependency-ordered truncate list for tests that
 // run through the admin products surface.
+//
+// promo_redemptions/promo_codes are here even though no products test touches
+// them: promo_integration_test.go shares this fixture and seeds a promo code
+// with a fixed literal `code`. Nothing else reclaims those rows — promo_codes
+// has no FK to `stores`, so the TRUNCATE ... CASCADE below never reaches it —
+// and the seed therefore committed permanently, so the second-ever run of that
+// test collided on promo_codes_code_uidx. It passed exactly once (2026-08-23)
+// and its own success is what broke it (#446). Truncating the pair fixes the
+// whole class rather than one test's literal.
 var productsTables = []string{
 	"outbox_events",
+	"promo_redemptions",
+	"promo_codes",
 	"product_media",
 	"variant_option_values",
 	"variant_stock",

--- a/services/marketplace-api/internal/product/service_aggregate_test.go
+++ b/services/marketplace-api/internal/product/service_aggregate_test.go
@@ -209,6 +209,18 @@ func TestIntegration_ProductService_UpdateAggregate_RemovedVariantIDsSoftDelete(
 // TestIntegration_ProductService_UpdateAggregate_OptionValueInUseRejected
 // exercises semantics (c): removing an option value that a surviving
 // variant still references should return OptionValueInUse and roll back.
+//
+// This is deliberately an options-ONLY PATCH. It used to also send Variants,
+// and that made the assertion structurally unreachable: two variants against a
+// one-value Size option is a cartesian product of 1 against 2 rows, so
+// ValidateMatrix rejected the request with variant_matrix_mismatch before the
+// transaction opened, and the OptionValueInUse guard was never reached. The
+// test never passed once (#446). Whenever req.Variants != nil the surviving
+// variants are the ones the caller just sent, so a request that both drops a
+// value and keeps a variant on it can only ever fail the matrix check —
+// variant_matrix_mismatch already has coverage in service_integration_test.go.
+// Sending options alone is the only shape that reaches this guard: the stored
+// variants survive untouched and one of them still references Size=S.
 func TestIntegration_ProductService_UpdateAggregate_OptionValueInUseRejected(t *testing.T) {
 	tx := testdb.NewTx(t)
 	storeID, tenantID, _ := seedStore(t, tx)
@@ -231,26 +243,20 @@ func TestIntegration_ProductService_UpdateAggregate_OptionValueInUseRejected(t *
 	if err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	sVar := findVariantBySKU(agg, "S-1")
-	mVar := findVariantBySKU(agg, "S-2")
+	if findVariantBySKU(agg, "S-1") == nil || findVariantBySKU(agg, "S-2") == nil {
+		t.Fatalf("seed lookup failed")
+	}
 
-	// Act: remove value "S" from Size while still including a variant
-	// that references Size=S. This is a client contract violation.
+	// Act: remove value "S" from Size and send nothing else. The stored
+	// variant S-1 survives the PATCH and still references Size=S, so the
+	// value cannot be deleted.
 	newOptions := []product.OptionSpec{
 		{Name: "Size", Values: []product.OptionValueSpec{{Value: "M"}}},
-	}
-	newVariants := []product.VariantInput{
-		// Still referencing Size=S — should be rejected.
-		{ID: sVar.ID, SKU: "S-1", Price: decimal.NewFromInt(10), CurrencyCode: "USD",
-			OptionValues: []product.OptionValueRef{{OptionName: "Size", Value: "S"}}},
-		{ID: mVar.ID, SKU: "S-2", Price: decimal.NewFromInt(11), CurrencyCode: "USD",
-			OptionValues: []product.OptionValueRef{{OptionName: "Size", Value: "M"}}},
 	}
 
 	_, err = svc.UpdateAggregate(ctx, product.UpdateAggregateRequest{
 		ID: agg.Product.ID, StoreID: storeID, TenantID: tenantID,
-		Options:  &newOptions,
-		Variants: &newVariants,
+		Options: &newOptions,
 	})
 	if err == nil {
 		t.Fatalf("expected error, got nil")

--- a/services/marketplace-api/testint_coverage_test.go
+++ b/services/marketplace-api/testint_coverage_test.go
@@ -1,0 +1,224 @@
+package marketplaceapi
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// testIntExclusions are integration packages deliberately left out of the
+// `test-int` target. Each value is the reason, and the test below fails on an
+// empty one — an exclusion without a justification is how the gap this guard
+// exists to close reopens.
+//
+// Empty is the correct state. Add an entry only when a package genuinely
+// cannot run in the target, not when it is merely failing: a failing package
+// is a bug to fix, and hiding it here is precisely the mistake of #446.
+var testIntExclusions = map[string]string{}
+
+// TestEveryIntegrationPackageIsInTheTestIntTarget fails when a package
+// containing `//go:build integration` files is not run by `make test-int`.
+//
+// This is deliberately a UNIT test — no build tag, no database. A guard that
+// only runs under the conditions it is guarding would share the fate of what
+// it guards. `go test ./...` runs it.
+//
+// WHY THIS EXISTS. The package list in the Makefile is hand-maintained, so a
+// package is only ever covered by someone remembering to add it. When
+// milestone "Correctness & data integrity" was worked, 32 of the service's 60
+// integration packages were absent from the target — more than half — and
+// four separate defects had survived in them because the test that caught
+// each one had never run:
+//
+//   - #397 asserted a blocked-downgrade audit row persisted; it was rolled
+//     back, and the assertion had been failing for as long as the bug existed.
+//   - #399 asserted the trial ramp was idempotent; re-runs were refunding
+//     consumed budget.
+//   - #398's appeal test failed with SQLSTATE 22001 on every realistic appeal.
+//   - #446's own two failures, found only by measuring the gap.
+//
+// In each case the test was correct and had simply never been executed. The
+// cost of the gap is not a missing test — it is a *correct* test whose failure
+// nobody sees. This guard makes that impossible to reintroduce silently.
+//
+// It is the same shape as TestExpectedSchemaVersionMatchesHighestMigration in
+// this package (adding a migration without bumping the version), and as
+// tenantpurge's and customererasure's schema-coverage guards (a table escaping
+// a plan). All four fail loudly at the moment the omission is made rather than
+// at the moment it costs something.
+func TestEveryIntegrationPackageIsInTheTestIntTarget(t *testing.T) {
+	pkgs, err := integrationPackages(".")
+	if err != nil {
+		t.Fatalf("scan for integration packages: %v", err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatal("found no integration packages at all — the scan is broken, " +
+			"and a guard that finds nothing passes for the wrong reason")
+	}
+
+	patterns, err := testIntPatterns(filepath.Join("..", "..", "Makefile"))
+	if err != nil {
+		t.Fatalf("parse test-int target: %v", err)
+	}
+	if len(patterns) == 0 {
+		t.Fatal("parsed no package patterns from the test-int target — the " +
+			"parser is broken, or the target moved")
+	}
+
+	var uncovered []string
+	for _, pkg := range pkgs {
+		if _, excluded := testIntExclusions[pkg]; excluded {
+			continue
+		}
+		if !coveredByAny(pkg, patterns) {
+			uncovered = append(uncovered, pkg)
+		}
+	}
+	sort.Strings(uncovered)
+
+	if len(uncovered) > 0 {
+		t.Errorf("these packages have integration tests that `make test-int` "+
+			"never runs, so a failure in them is invisible:\n  %s\n\n"+
+			"Add each to the test-int package list in the root Makefile. If one "+
+			"genuinely cannot run there, add it to testIntExclusions WITH a "+
+			"reason — but a package that merely FAILS is a bug to fix, not to "+
+			"exclude (#446).", strings.Join(uncovered, "\n  "))
+	}
+
+	for pkg, reason := range testIntExclusions {
+		if strings.TrimSpace(reason) == "" {
+			t.Errorf("exclusion %q has no justification — leaving a package out "+
+				"of the integration runner is a decision that needs a stated reason", pkg)
+		}
+		if coveredByAny(pkg, patterns) {
+			t.Errorf("%q is both excluded and covered by the test-int list; "+
+				"remove the stale exclusion so the map cannot accumulate dead weight", pkg)
+		}
+	}
+}
+
+// integrationPackages returns every directory under root holding at least one
+// file with a `//go:build integration` constraint, as slash-separated paths
+// relative to root.
+func integrationPackages(root string) ([]string, error) {
+	seen := map[string]bool{}
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// Skip hidden trees (.claude holds worktrees, whose packages would
+			// otherwise be counted twice) and node_modules.
+			//
+			// `vendor` is skipped only at the module ROOT, where Go gives it
+			// its special meaning. This service has a real `internal/vendor`
+			// package — skipping it by name anywhere would have hidden it from
+			// this guard, which is the exact failure the guard exists to catch.
+			name := d.Name()
+			rel := filepath.ToSlash(path)
+			if name != "." && (strings.HasPrefix(name, ".") || name == "node_modules" || rel == "vendor" || rel == "./vendor") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		tagged, err := hasIntegrationTag(path)
+		if err != nil || !tagged {
+			return err
+		}
+		dir := filepath.ToSlash(filepath.Dir(path))
+		seen[strings.TrimPrefix(dir, "./")] = true
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(seen))
+	for d := range seen {
+		out = append(out, d)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// hasIntegrationTag reports whether the file carries a `//go:build integration`
+// constraint. Only the build-constraint prologue is read: a `//go:build` line
+// must precede the package clause, so scanning past it would only risk
+// matching the string in unrelated code.
+func hasIntegrationTag(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if strings.HasPrefix(line, "package ") {
+			return false, nil
+		}
+		if strings.HasPrefix(line, "//go:build") && strings.Contains(line, "integration") {
+			return true, nil
+		}
+	}
+	return false, sc.Err()
+}
+
+// testIntPatterns extracts the `./...`-style package arguments from the
+// marketplace-api section of the Makefile's test-int target.
+//
+// The section is identified by its `cd services/marketplace-api` line and runs
+// to the end of that shell continuation, so the platform-api and auth-bff
+// sections of the same target are not mistaken for it.
+func testIntPatterns(makefilePath string) ([]string, error) {
+	raw, err := os.ReadFile(makefilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var patterns []string
+	inSection := false
+	for _, line := range strings.Split(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(trimmed, "cd services/marketplace-api") {
+			inSection = true
+			continue
+		}
+		if !inSection {
+			continue
+		}
+		for _, field := range strings.Fields(strings.TrimSuffix(trimmed, "\\")) {
+			if strings.HasPrefix(field, "./") {
+				patterns = append(patterns, strings.TrimPrefix(field, "./"))
+			}
+		}
+		// The section ends at the first line that does not continue.
+		if !strings.HasSuffix(trimmed, "\\") {
+			inSection = false
+		}
+	}
+	return patterns, nil
+}
+
+// coveredByAny reports whether pkg is matched by a `go test` package pattern,
+// honouring the `/...` recursive suffix.
+func coveredByAny(pkg string, patterns []string) bool {
+	for _, p := range patterns {
+		if base, ok := strings.CutSuffix(p, "/..."); ok {
+			if pkg == base || strings.HasPrefix(pkg, base+"/") {
+				return true
+			}
+			continue
+		}
+		if pkg == p {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #446.

## The gap was 53%, not two tests

`make test-int` ran **28 of the service's 60** integration packages. The other **32 never ran**, so a failure in any of them was invisible.

That is not a hypothetical cost. Four defects in the "Correctness & data integrity" milestone survived in exactly this way — a *correct* test asserting the *correct* behaviour, failing for as long as the bug existed, never executed:

- **#397** asserted a blocked-downgrade audit row persisted; it was being rolled back.
- **#399** asserted the trial ramp was idempotent; re-runs were refunding consumed budget.
- **#398**'s appeal test failed with `SQLSTATE 22001` on every realistic appeal.

The expensive part was never the missing test. It was a correct test whose failure nobody saw.

## Both named tests are test bugs, not code bugs

Established by running, not reasoning — which matters, because the milestone's precedent was the opposite.

**`TestPromoApply_BelowAbsoluteFloor_INR` poisoned itself.** It seeds a hardcoded promo code and never cleans up: the harness truncates `productsTables`, `promo_codes` is not in it, and — unlike `store_subscriptions`, the fixture's other extra seed — it has no `REFERENCES stores(id) ON DELETE CASCADE` to be swept by. So the seed commits permanently. The poisoning row was still in the dev database, stamped `2026-08-23 05:48:45`: **the test passed exactly once, and its own success is what broke it.**

Fixed by adding `promo_codes` and `promo_redemptions` to `productsTables` — the class, not the instance. The ₹800 INR floor was verified to work correctly, so there was no money bug hiding here.

**`TestIntegration_ProductService_UpdateAggregate_OptionValueInUseRejected` was born broken.** It sent `Options = [Size:{M}]` (cartesian product 1) with **2** variants, so `ValidateMatrix` rejected it *before the transaction opened* and the `OptionValueInUse` branch was never reached. Whenever `req.Variants != nil` the expected error is structurally unreachable: either the count mismatches, or it matches and the stale reference trips the unknown-value check instead. It has never passed since it was added in April.

Fixed by rewriting it as an options-only PATCH, which is the path that genuinely reaches the guard. Deliberately **not** by changing the assertion to `variant_matrix_mismatch` — that duplicates existing coverage and would leave the `OptionValueInUse` guard untested, which is the one thing the test exists for. Its doc comment now records why, so nobody "helpfully" adds `Variants` back.

## The runner now covers everything, and cannot quietly narrow again

All 32 absent packages were measured against a quiet database first: **30 were already green.** Only the two above failed, so no ratchet or baseline was needed — the target now lists all 60.

`TestEveryIntegrationPackageIsInTheTestIntTarget` fails when an integration-tagged package is not covered. It is deliberately an **untagged unit test**: a guard that only ran under the conditions it guards would share the fate of what it guards. `testIntExclusions` is **empty**, and the test fails on an entry with a blank justification or one that is both excluded and covered — so the map cannot accumulate dead weight.

Same shape as `TestExpectedSchemaVersionMatchesHighestMigration` in the same package, and as `tenantpurge`'s and `customererasure`'s schema-coverage guards. All fail at the moment the omission is made rather than when it costs something.

The Makefile's exclusion rationale is deleted rather than edited: it justified exclusions by schema drift (`products.vendor_id`, the whitelabel nil-Repo panic, the apikeys `varchar(60)` overflow) that #403/#318/#395 have since fixed. The prose had outlived its reasons and was keeping packages dark.

## `test-unit` was not running marketplace-api at all

Found while checking the guard would actually fire: `test-unit`'s help text says "across every Go service", but it ran platform-api, auth-bff and turbo only. CI covered marketplace-api, so nothing was unverified — but it meant this service's untagged guards, **including the new one**, could not go red on a developer's machine. A guard nobody sees locally is only half a guard. Now added; the service's 91 unit packages are green.

## Test plan

Integration runs used `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'` with `-p 1 -count=1`, all EXECUTED.

- [x] Both fixed tests pass **twice consecutively** — both were state- or input-dependent, so one pass proves less than usual. `promo_codes` is left empty afterwards, confirming the fixture no longer leaks
- [x] **Full target: 64 packages, all green, 4m54s.** (The ~55s figure quoted during investigation was the *marginal* cost of the 30 added packages, not the total)
- [x] Guard passes with empty exclusions
- [x] **Mutation:** remove `./internal/orderrefund/...` from the list → the guard names exactly that package and nothing else
- [x] **Mutation:** add an exclusion with a blank justification → fails with the justification error
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean

## Known flake, not addressed here

`internal/apikeys`'s `TestRepo_CountActiveForStore_ExcludesRevoked` compares a Go-clock timestamp against Postgres's `now()` with no margin, and this machine's container clock sits ~45 ms from the host's. It failed twice during investigation, then passed 6/6 unchanged. Filed as **#447** — it is a pre-existing flake in a package that was already in the runner, and fixing it here would have muddied this change.
