### PR TITLE
test(apikeys): stop racing Go's clock against Postgres's in the revocation count test (#447)

### DIFF
--- a/services/marketplace-api/internal/apikeys/repo.go
+++ b/services/marketplace-api/internal/apikeys/repo.go
@@ -77,6 +77,20 @@ func (r *Repo) ListForStore(ctx context.Context, tenantID, storeID uuid.UUID) ([
 
 // CountActiveForStore counts active (non-revoked) keys for a tenant+store.
 // Used for plan-ceiling enforcement.
+// CountActiveForStore counts keys still usable for a store.
+//
+// This is the ONLY place in this package that compares a Go-written
+// `revoked_at` against Postgres's own `now()`. Everywhere revocation actually
+// gates access — IsUsable (model.go), the auth middleware (middleware.go:74),
+// Rotate and Revoke (service.go) — both sides come from the same application
+// clock, so those paths cannot disagree with themselves.
+//
+// That asymmetry is deliberate and worth keeping in mind rather than
+// "fixing": making Revoke write the database's now() instead would introduce
+// a mixed-clock comparison on the AUTH path, where today there is none. The
+// cost is confined here, to a quota count, where a few milliseconds of skew
+// between the app and the database cannot matter — no caller revokes a key
+// and counts it in the same instant. A test did, and was flaky for it (#447).
 func (r *Repo) CountActiveForStore(ctx context.Context, tenantID, storeID uuid.UUID) (int64, error) {
 	var n int64
 	err := r.dbCtx(ctx).Model(&APIKey{}).

--- a/services/marketplace-api/internal/apikeys/repo_test.go
+++ b/services/marketplace-api/internal/apikeys/repo_test.go
@@ -94,7 +94,19 @@ func TestRepo_CountActiveForStore_ExcludesRevoked(t *testing.T) {
 	b := sampleKey(tenantID, storeID, by, "BBBB2222")
 	require.NoError(t, repo.Create(context.Background(), &a))
 	require.NoError(t, repo.Create(context.Background(), &b))
-	require.NoError(t, repo.Revoke(context.Background(), b.ID, time.Now(), "test"))
+
+	// A minute in the past, not time.Now(). Revoke's `at` is an EXPIRY, not a
+	// revocation stamp (see its doc), and CountActiveForStore is the one query
+	// in this package that compares a Go-written timestamp against Postgres's
+	// own now() (repo.go:83) — every other check is Go clock against Go clock.
+	//
+	// With `at` = time.Now() the assertion is decided by which of two
+	// independent clocks is ahead. That is not hypothetical: the dev Postgres
+	// runs in a VM whose clock was measured ~45ms from the host's and drifts
+	// either way, so this failed twice and then passed six times unchanged
+	// (#447). A margin tests what the name says — a revoked key is excluded —
+	// without racing. Same shape as security_test.go:96.
+	require.NoError(t, repo.Revoke(context.Background(), b.ID, time.Now().Add(-time.Minute), "test"))
 
 	n, err := repo.CountActiveForStore(context.Background(), tenantID, storeID)
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #447.

`TestRepo_CountActiveForStore_ExcludesRevoked` wrote `revoked_at` from Go's clock and then counted with `revoked_at > now()` — Postgres's clock — with no margin. Whether the key still counted as active was decided by which of two independent clocks was ahead.

Measured on this machine: the Postgres container's clock sits **~44.8 ms** from the host's, and it drifts either way, so the sign is not stable. The test failed twice during a full-suite run and then passed 6/6 minutes later with nothing changed. `internal/apikeys` is in `make test-int`, so this made that target intermittently red.

## The fix

Pass a time comfortably in the past instead of racing:

```go
repo.Revoke(ctx, b.ID, time.Now().Add(-time.Minute), "test")
```

`Revoke`'s `at` is an **expiry**, not a revocation stamp (its own doc says so), so "revoke now" meant "expires at exactly this instant" — the worst possible value for a cross-clock comparison. A margin tests what the name says, that a revoked key is excluded, without depending on the two clocks agreeing.

This is not a new pattern: `security_test.go:96` already does exactly this. The sibling at `repo_test.go:61` looks similar but is safe — it compares Go clock to Go clock via `IsUsable`, never touching SQL `now()`.

## What I did NOT do, and why

The issue suggested considering whether `Revoke` should write the database's `now()` instead. **That would make things worse.**

Every place revocation actually gates access uses the application clock on both sides — `IsUsable` (`model.go:73`), the auth middleware (`middleware.go:74`), `Rotate` and `Revoke` (`service.go:169,235,238`). Those paths cannot disagree with themselves today. `CountActiveForStore` (`repo.go:83`) is the **only** query in the package that compares a Go-written timestamp against SQL `now()`.

Making `Revoke` write the DB clock would introduce a mixed-clock comparison on the **auth** path, where there is none — trading a flaky quota count for a correctness question about when a revoked key stops authenticating. So the asymmetry stays, and `CountActiveForStore` now documents why it is deliberate rather than an oversight for someone to "fix" later.

No production exposure either way: nothing revokes a key and counts it in the same instant.

## Test plan

Runs used `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'` with `-p 1 -count=1`, all EXECUTED.

- [x] 8 consecutive runs of the fixed test: **0 failures**
- [x] `./internal/apikeys/...` green
- [x] **Mutation — the one that actually proves it.** Repeated runs cannot demonstrate a fix for a race, since the unfixed test passed 6/6 too. So the adverse skew was simulated directly: revoking at `time.Now().Add(50*time.Millisecond)` — an app clock 50 ms ahead — reproduces the reported symptom exactly:
  ```
  --- FAIL: TestRepo_CountActiveForStore_ExcludesRevoked
              expected: 1
              actual  : 2
  ```
  The `-time.Minute` margin is immune to it. Restoring gives `ok`.
- [x] For completeness, the original `time.Now()` form passed 3/3 when re-run — which is the point: today's skew happens to favour passing, which is why this is flaky rather than broken
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `gofmt` clean
