### PR TITLE
refactor(payment): delete the superseded webhook path whose model named four columns that do not exist (#441)

### DIFF
--- a/services/marketplace-api/internal/payment/repository.go
+++ b/services/marketplace-api/internal/payment/repository.go
@@ -66,28 +66,6 @@ func (r *RefundTransaction) BeforeCreate(_ *gorm.DB) error {
 	return nil
 }
 
-// WebhookEventRecord represents a row in the webhook_events table.
-type WebhookEventRecord struct {
-	ID              string    `gorm:"column:id;type:uuid;primaryKey"                       json:"id"`
-	TenantID        string    `gorm:"column:tenant_id;type:uuid;not null;index"             json:"tenant_id"`
-	StoreID         string    `gorm:"column:store_id;type:uuid;not null;index"              json:"store_id"`
-	Provider        string    `gorm:"column:provider;type:varchar(20);not null"              json:"provider"`
-	ProviderEventID string    `gorm:"column:provider_event_id;type:varchar(255);not null;uniqueIndex" json:"provider_event_id"`
-	EventType       string    `gorm:"column:event_type;type:varchar(50);not null"            json:"event_type"`
-	OrderID         string    `gorm:"column:order_id;type:uuid"                              json:"order_id,omitempty"`
-	RawPayload      []byte    `gorm:"column:raw_payload;type:jsonb"                          json:"-"`
-	CreatedAt       time.Time `gorm:"column:created_at;autoCreateTime"                       json:"created_at"`
-}
-
-func (WebhookEventRecord) TableName() string { return "webhook_events" }
-
-func (w *WebhookEventRecord) BeforeCreate(_ *gorm.DB) error {
-	if w.ID == "" {
-		w.ID = uuid.New().String()
-	}
-	return nil
-}
-
 // ---------------------------------------------------------------------------
 // Repository interface + GORM implementation
 // ---------------------------------------------------------------------------
@@ -109,9 +87,6 @@ type Repository interface {
 	UpdateRefundOutcome(tx *gorm.DB, ledgerID, providerRefundID, status string) error
 	// GetRefundByIdempotencyKey reads a ledger row by its unique key.
 	GetRefundByIdempotencyKey(ctx context.Context, key string) (*RefundTransaction, error)
-
-	CreateWebhookEvent(ctx context.Context, evt *WebhookEventRecord) error
-	GetWebhookEventByProviderID(ctx context.Context, providerEventID string) (*WebhookEventRecord, error)
 }
 
 type gormRepository struct{ db *gorm.DB }
@@ -217,23 +192,4 @@ func (r *gormRepository) GetRefundByIdempotencyKey(ctx context.Context, key stri
 		return nil, err
 	}
 	return &row, nil
-}
-
-// ---------------------------------------------------------------------------
-// WebhookEventRecord CRUD
-// ---------------------------------------------------------------------------
-
-func (r *gormRepository) CreateWebhookEvent(ctx context.Context, evt *WebhookEventRecord) error {
-	return r.db.WithContext(ctx).Create(evt).Error
-}
-
-func (r *gormRepository) GetWebhookEventByProviderID(ctx context.Context, providerEventID string) (*WebhookEventRecord, error) {
-	var evt WebhookEventRecord
-	err := r.db.WithContext(ctx).
-		Where("provider_event_id = ?", providerEventID).
-		First(&evt).Error
-	if err != nil {
-		return nil, err
-	}
-	return &evt, nil
 }

--- a/services/marketplace-api/internal/payment/service.go
+++ b/services/marketplace-api/internal/payment/service.go
@@ -59,51 +59,6 @@ func (s *Service) CreatePaymentIntent(
 	return intent, nil
 }
 
-// ProcessWebhook verifies and processes a provider webhook callback.
-// It persists the event for idempotency and updates the related
-// transaction status.
-func (s *Service) ProcessWebhook(
-	ctx context.Context,
-	provider string,
-	payload []byte,
-	signature string,
-	gateway Gateway,
-) (*WebhookEvent, error) {
-	evt, err := gateway.VerifyWebhook(ctx, payload, signature)
-	if err != nil {
-		return nil, fmt.Errorf("payment service: process webhook: %w", err)
-	}
-
-	// Check idempotency — skip if we have already processed this event.
-	existing, _ := s.repo.GetWebhookEventByProviderID(ctx, evt.ProviderEventID)
-	if existing != nil {
-		return evt, nil
-	}
-
-	record := WebhookEventRecord{
-		Provider:        provider,
-		ProviderEventID: evt.ProviderEventID,
-		EventType:       evt.EventType,
-		OrderID:         evt.OrderID,
-		RawPayload:      evt.RawPayload,
-	}
-	if err := s.repo.CreateWebhookEvent(ctx, &record); err != nil {
-		return nil, fmt.Errorf("payment service: persist webhook event: %w", err)
-	}
-
-	// Update the corresponding transaction status when we can correlate it.
-	if evt.OrderID != "" {
-		statusUpdate := webhookEventToStatus(evt.EventType)
-		if statusUpdate != "" {
-			if err := s.repo.UpdateTransactionStatus(ctx, evt.OrderID, statusUpdate); err != nil {
-				return nil, fmt.Errorf("payment service: update transaction: %w", err)
-			}
-		}
-	}
-
-	return evt, nil
-}
-
 // ReserveRefundInput describes a refund reservation — the first step of the
 // refund saga (ledger row inserted before any provider call is made). It
 // carries CurrencyCode for later gateway use; refund_transactions has no

--- a/services/marketplace-api/internal/payment/service_test.go
+++ b/services/marketplace-api/internal/payment/service_test.go
@@ -80,14 +80,6 @@ func (f *fakeRepo) ListRefundsByPaymentID(ctx context.Context, providerPaymentID
 	return nil, nil
 }
 
-func (f *fakeRepo) CreateWebhookEvent(ctx context.Context, evt *WebhookEventRecord) error {
-	return nil
-}
-
-func (f *fakeRepo) GetWebhookEventByProviderID(ctx context.Context, providerEventID string) (*WebhookEventRecord, error) {
-	return nil, nil
-}
-
 func (f *fakeRepo) InsertRefundPending(tx *gorm.DB, row *RefundTransaction) (*RefundTransaction, bool, error) {
 	// Not used directly by unit tests below — repository-level fake logic
 	// isn't exercised because ReserveRefund's idempotency guarantee is


### PR DESCRIPTION
Closes #441.

## The model was worse than filed, and less dead than filed

`WebhookEventRecord` (`internal/payment/repository.go:69`) declared `tenant_id`, `store_id`, `order_id` and `raw_payload`. **None of those four columns exist** on `webhook_events`, which is only `id, provider, provider_event_id, event_type, payload, status, processed_at, created_at`.

The issue guessed it was unused. It is not: `payment.Service.ProcessWebhook` constructs it and writes it through `CreateWebhookEvent`, and both sit in the exported `Repository` interface with real GORM implementations. So this compiles, type-checks, and looks entirely live — **anyone wiring it up gets a runtime failure**, not a compile error.

What saves it today is that nothing calls `ProcessWebhook`. Verified: the only references were its own definition and doc comment. `payment.Service` *is* constructed in three places, but for refunds — this method was never reached.

## Why deleting rather than correcting the model

The real webhook path already exists and supersedes it. `internal/handlers/storefront/webhooks.go:415` inserts into `webhook_events` with raw SQL against the actual schema, with its own idempotency:

```sql
INSERT INTO webhook_events (id, provider, provider_event_id, event_type, payload, status, created_at)
VALUES (gen_random_uuid(), ?, ?, ?, ?::jsonb, 'received', now())
ON CONFLICT (provider, provider_event_id) DO NOTHING
```

`ProcessWebhook` duplicates that same idempotency check — a `GetWebhookEventByProviderID` lookup followed by a create — against a model that does not match the table. Correcting the struct would leave two competing implementations of one concern, one of them dead. Deleting leaves the one that works.

Removed: `ProcessWebhook`, `WebhookEventRecord` and its hooks, `CreateWebhookEvent` and `GetWebhookEventByProviderID` from the interface and the GORM implementation, and the two now-unused test fakes. Nothing else referenced any of it — `grep` for both symbols across the module returns nothing after the change.

## Why it mattered even while dead

A wrong model answers a question confidently. This one is why "`webhook_events` has an `order_id`, so we can scope it to a customer" sounded plausible during the #435 analysis — a claim that only fell over when the live schema was checked. #440 exists precisely because that table *cannot* be scoped.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean — the deletion is compile-verified, since anything still referencing these symbols would fail to build
- [x] `./internal/payment` unit and integration green
- [x] The real webhook path unaffected: `./internal/handlers/storefront` and `./internal/webhookevents` green
- [x] `grep -rn "WebhookEventRecord\|ProcessWebhook"` across the module → no matches
- [x] #446's `TestEveryIntegrationPackageIsInTheTestIntTarget` still passes
