### PR TITLE
fix(dispatch): record arbitrage after the webhook transaction commits, not on a second connection inside it (#438)

### DIFF
--- a/services/marketplace-api/internal/billing/dispatch/arbitrage_postcommit_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/arbitrage_postcommit_test.go
@@ -1,0 +1,176 @@
+//go:build integration
+
+package dispatch_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/arbitrage"
+	"github.com/mark8ly/marketplace-api/internal/billing/dispatch"
+	"github.com/mark8ly/marketplace-api/internal/postcommit"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// arbitrageSpyCounter satisfies arbitrage.Counter.
+type arbitrageSpyCounter struct {
+	flagged  int
+	cleared  int
+	mismatch int
+}
+
+func (s *arbitrageSpyCounter) IncArbitrageFlagged()              { s.flagged++ }
+func (s *arbitrageSpyCounter) IncArbitrageFalsePositiveCleared() { s.cleared++ }
+func (s *arbitrageSpyCounter) IncArbitrageTenantMismatch()       { s.mismatch++ }
+
+// arbitrageKeySource satisfies arbitrage.VersionsSource with one static key.
+type arbitrageKeySource struct{}
+
+func (arbitrageKeySource) ListEnabled(_ context.Context) ([]arbitrage.KeyVersion, error) {
+	return []arbitrage.KeyVersion{
+		{Name: "v1", Payload: []byte("test-key-32-bytes-padded--------"), CreatedAt: time.Now()},
+	}, nil
+}
+
+// TestArbitrage_RecordedAfterTransactionCommits pins #438.
+//
+// The failure mode is a HANG, not a wrong value, so run this package with an
+// explicit -timeout: without the fix the test never returns, it is killed by
+// the test binary's timeout and prints a goroutine dump.
+//
+// The stall: handleCheckoutSessionCompleted runs inside
+// subscription.WithAdvisoryLock and UPDATEs the store_subscriptions row on
+// tx, taking a FOR NO KEY UPDATE row lock held until commit. The arbitrage
+// recorder writes on the POOL handle — a different connection — and its flag
+// toggle is `UPDATE store_subscriptions ... SET arbitrage_flag = true` on that
+// same row. Called inline, the recorder's connection waits on the uncommitted
+// row lock while the transaction holding it waits, in Go, for the recorder to
+// return. Postgres sees one waiter and one idle-in-transaction session — no
+// cycle — so deadlock_timeout never fires, and the repo sets no lock_timeout
+// or statement_timeout. The webhook hangs forever.
+//
+// This test reproduces that shape exactly: locking UPDATE on tx first, then
+// the recorder call, with a RecordInput that actually flags (production
+// hard-codes IPCountry: "" and so never reaches the recorder's writes).
+func TestArbitrage_RecordedAfterTransactionCommits(t *testing.T) {
+	db := testdb.NewDB(t, "subscription_arbitrage_audit", "store_subscriptions", "stores")
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
+	customerID := "cus_" + uuid.NewString()[:12]
+	sub := subscription.StoreSubscription{
+		TenantID:         tenantID,
+		StoreID:          storeID,
+		StripeCustomerID: customerID,
+		Plan:             subscription.PlanStarter,
+		Status:           subscription.StatusActive,
+		PriceTier:        subscription.PriceTierPPP,
+	}
+	require.NoError(t, db.Create(&sub).Error)
+
+	spy := &arbitrageSpyCounter{}
+	hasher := arbitrage.NewHasher(arbitrage.NewKeyLoader(arbitrageKeySource{}, 5*time.Minute))
+	// The recorder gets the POOL handle, exactly as main.go wires it — that
+	// second connection is the whole point of the bug.
+	d := dispatch.New(nil).WithRecorder(arbitrage.NewRecorder(db, hasher, spy))
+
+	// A tier/country combination that Evaluate actually flags: a PPP-tier
+	// subscription paid with a developed-market card.
+	in := arbitrage.RecordInput{
+		SubscriptionID: sub.ID,
+		TenantID:       tenantID,
+		StoreID:        storeID,
+		PriceTier:      subscription.PriceTierPPP,
+		CardCountry:    "US",
+		BillingCountry: "IN",
+		IPCountry:      "IN",
+		RawIP:          "203.0.113.9",
+	}
+
+	// Production shape: collector installed before the lock, drained after.
+	ctx, deferred := postcommit.WithDeferredSends(context.Background())
+	require.NoError(t, subscription.WithAdvisoryLock(ctx, db, storeID, func(tx *gorm.DB) error {
+		// Stage 1 of handleCheckoutSessionCompleted: the row lock the
+		// recorder would collide with.
+		res := tx.WithContext(ctx).Exec(
+			`UPDATE store_subscriptions
+             SET stripe_subscription_id = ?, updated_at = ?
+             WHERE stripe_customer_id = ?`,
+			"sub_"+uuid.NewString()[:12], time.Now(), customerID)
+		require.NoError(t, res.Error)
+		require.EqualValues(t, 1, res.RowsAffected)
+
+		// If this runs inline it blocks forever on the lock taken above.
+		dispatch.RecordArbitrageForTest(ctx, d, sub, in)
+		return nil
+	}), "the advisory-lock transaction must complete; a hang here is #438")
+
+	// Nothing may have been written yet: the recorder call belongs after the
+	// commit, not inside it.
+	var pending int64
+	require.NoError(t, db.Model(&arbitrage.SubscriptionArbitrageAudit{}).
+		Where("subscription_id = ?", sub.ID).Count(&pending).Error)
+	require.Zero(t, pending, "the arbitrage write ran inside the webhook transaction")
+	require.Zero(t, spy.flagged)
+
+	// Draining does the work, on a connection that now contends with nobody.
+	require.Empty(t, deferred.Run(ctx), "the deferred arbitrage record must succeed")
+
+	var row arbitrage.SubscriptionArbitrageAudit
+	require.NoError(t, db.Where("subscription_id = ?", sub.ID).First(&row).Error)
+	require.Equal(t, arbitrage.ResolutionOngoing, row.Resolution)
+
+	var reloaded subscription.StoreSubscription
+	require.NoError(t, db.Where("id = ?", sub.ID).First(&reloaded).Error)
+	require.True(t, reloaded.ArbitrageFlag, "the flag toggle must have run post-commit")
+	require.Equal(t, 1, spy.flagged)
+}
+
+// TestArbitrage_NoCollectorFallsBackInline pins the fallback branch: a caller
+// that forgot postcommit.WithDeferredSends must still get the fraud record,
+// not silently lose it. Deliberately NOT inside a transaction — inline is only
+// safe when there is no open transaction holding the row, which is exactly
+// what the loud warning on that branch is there to say.
+func TestArbitrage_NoCollectorFallsBackInline(t *testing.T) {
+	db := testdb.NewDB(t, "subscription_arbitrage_audit", "store_subscriptions", "stores")
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
+	sub := subscription.StoreSubscription{
+		TenantID:         tenantID,
+		StoreID:          storeID,
+		StripeCustomerID: "cus_" + uuid.NewString()[:12],
+		Plan:             subscription.PlanStarter,
+		Status:           subscription.StatusActive,
+		PriceTier:        subscription.PriceTierPPP,
+	}
+	require.NoError(t, db.Create(&sub).Error)
+
+	spy := &arbitrageSpyCounter{}
+	hasher := arbitrage.NewHasher(arbitrage.NewKeyLoader(arbitrageKeySource{}, 5*time.Minute))
+	d := dispatch.New(nil).WithRecorder(arbitrage.NewRecorder(db, hasher, spy))
+
+	// No postcommit.WithDeferredSends on this context.
+	dispatch.RecordArbitrageForTest(context.Background(), d, sub, arbitrage.RecordInput{
+		SubscriptionID: sub.ID,
+		TenantID:       tenantID,
+		StoreID:        storeID,
+		PriceTier:      subscription.PriceTierPPP,
+		CardCountry:    "US",
+		BillingCountry: "IN",
+		IPCountry:      "IN",
+		RawIP:          "203.0.113.9",
+	})
+
+	var n int64
+	require.NoError(t, db.Model(&arbitrage.SubscriptionArbitrageAudit{}).
+		Where("subscription_id = ?", sub.ID).Count(&n).Error)
+	require.EqualValues(t, 1, n, "no collector must fall back to inline, never drop the fraud record")
+	require.Equal(t, 1, spy.flagged)
+}

--- a/services/marketplace-api/internal/billing/dispatch/export_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/export_test.go
@@ -7,6 +7,7 @@ import (
 
 	"gorm.io/gorm"
 
+	"github.com/mark8ly/marketplace-api/internal/arbitrage"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 )
 
@@ -20,4 +21,16 @@ func HandleCustomerUpdatedForTest(ctx context.Context, tx *gorm.DB, raw []byte) 
 // reporter (log + metric) to the package's external integration tests.
 func ReportArbitrageFailureForTest(sub subscription.StoreSubscription, err error) {
 	reportArbitrageFailure(sub, err)
+}
+
+// RecordArbitrageForTest exposes the post-commit arbitrage registration to
+// the package's external integration tests.
+//
+// It exists because the only production caller hard-codes IPCountry: "", and
+// arbitrage.Evaluate never flags without an IP country — so the recorder's
+// writes are unreachable through handleCheckoutSessionCompleted and the
+// cross-connection stall in #438 cannot be provoked through it. Tests build
+// the flagging RecordInput directly instead.
+func RecordArbitrageForTest(ctx context.Context, d *Dispatcher, sub subscription.StoreSubscription, in arbitrage.RecordInput) {
+	d.recordArbitrage(ctx, sub, in)
 }

--- a/services/marketplace-api/internal/billing/dispatch/handlers.go
+++ b/services/marketplace-api/internal/billing/dispatch/handlers.go
@@ -52,6 +52,68 @@ func reportArbitrageFailure(sub subscription.StoreSubscription, recErr error) {
 	}
 }
 
+// recordArbitrage hands the arbitrage recorder call to the request's
+// post-commit collector so it runs AFTER the webhook's advisory-lock
+// transaction commits, instead of inside it.
+//
+// Why it cannot run inline (#438). The caller is inside
+// subscription.WithAdvisoryLock, and handleCheckoutSessionCompleted has
+// already run `UPDATE store_subscriptions ... WHERE stripe_customer_id = ?`
+// on tx, which holds a FOR NO KEY UPDATE row lock on the subscription row for
+// the rest of the transaction. The recorder writes on its own *gorm.DB — the
+// pool handle, a DIFFERENT connection — and its step 3 is
+// `UPDATE store_subscriptions ... SET arbitrage_flag = true` on that same row.
+// The recorder's connection blocks on the uncommitted row lock while the
+// transaction that holds it is blocked in Go waiting for the recorder to
+// return. Postgres sees one waiter and one idle-in-transaction session: no
+// cycle, so deadlock_timeout never fires, and no lock_timeout or
+// statement_timeout is configured. The webhook hangs indefinitely.
+//
+// This is latent today only because the call site hard-codes IPCountry: "" and
+// arbitrage.Evaluate never flags without an IP country, so the recorder's
+// writes are never reached. The first caller to supply a real IP country arms
+// the stall. Deferring the call removes the overlap regardless.
+//
+// Passing the caller's tx into the recorder would also remove the overlap, but
+// it would put the audit row back inside the webhook transaction — undoing
+// #423/#442, which deliberately moved it out so a failed flag toggle cannot
+// destroy the fraud record.
+//
+// Semantics are otherwise unchanged: a recorder failure stays NON-FATAL to the
+// webhook and still goes through reportArbitrageFailure so it is logged and
+// counted (#423).
+func (d *Dispatcher) recordArbitrage(ctx context.Context, sub subscription.StoreSubscription, in arbitrage.RecordInput) {
+	// runCtx is the context the collector hands us at drain time (request
+	// cancellation stripped, own timeout applied) — never the captured one.
+	record := func(runCtx context.Context) error {
+		if recErr := d.recorder.RecordIfFlagged(runCtx, in); recErr != nil {
+			// Swallowed on purpose: the arbitrage write must not block the
+			// subscription lifecycle or trigger a Stripe redelivery that
+			// re-fires every other side effect. Silence is what was wrong
+			// before (#423), so it is logged and counted instead.
+			reportArbitrageFailure(sub, recErr)
+		}
+		return nil
+	}
+
+	if postcommit.Add(ctx, record) {
+		return
+	}
+
+	// No collector in ctx — a caller that did not opt in (tests, or a future
+	// entry point that forgot postcommit.WithDeferredSends). Run inline
+	// rather than dropping the fraud signal, but say so loudly: a call site
+	// that silently reverts to the inline path is exactly how the stall
+	// above comes back, and it looks perfectly healthy in the logs while
+	// doing it.
+	slog.Default().Warn("dispatch: no post-commit collector in context; recording arbitrage INLINE, inside the webhook transaction — the caller of Dispatch is missing postcommit.WithDeferredSends (#438)",
+		"store_id", sub.StoreID.String(),
+		"tenant_id", sub.TenantID.String(),
+		"subscription_id", sub.ID.String())
+
+	_ = record(ctx)
+}
+
 // handleCheckoutSessionCompleted routes checkout.session.completed through
 // two stages:
 //  1. Raw UPDATE of NON-status columns (stripe_subscription_id,
@@ -131,7 +193,7 @@ func (d *Dispatcher) handleCheckoutSessionCompleted(ctx context.Context, tx *gor
 	// header), so the evaluator returns ReasonIPUnknown and does not flag on
 	// card alone — preventing false positives for travelers/dual-citizens.
 	if d.recorder != nil {
-		recErr := d.recorder.RecordIfFlagged(ctx, arbitrage.RecordInput{
+		d.recordArbitrage(ctx, sub, arbitrage.RecordInput{
 			SubscriptionID: sub.ID,
 			TenantID:       sub.TenantID,
 			StoreID:        sub.StoreID,
@@ -141,14 +203,6 @@ func (d *Dispatcher) handleCheckoutSessionCompleted(ctx context.Context, tx *gor
 			IPCountry:      "", // unknown at webhook time — evaluated as "??"
 			RawIP:          "", // no raw IP at webhook time
 		})
-		if recErr != nil {
-			// Arbitrage write failure must NOT block the subscription
-			// lifecycle, so the error is still swallowed here to preserve
-			// Stripe idempotency. Silence is what was wrong: the previous
-			// `_ = fmt.Errorf(...)` produced no log, no metric and no return,
-			// so every arbitrage failure vanished (#423).
-			reportArbitrageFailure(sub, recErr)
-		}
 	}
 
 	if sub.Status != subscription.StatusSignup {


### PR DESCRIPTION
Closes #438.

## The stall

`dispatchLocked` (`handlers/webhooks/stripe.go:169`) runs dispatch inside `subscription.WithAdvisoryLock`. Inside that transaction, `dispatch/handlers.go:72-79` takes a `FOR NO KEY UPDATE` row lock on `store_subscriptions` and holds it for the rest of the pass. The same closure then called the arbitrage recorder, which writes on the **pool handle** — a second connection — updating `arbitrage_flag` on that same row.

The second connection blocks on the first transaction's uncommitted row lock while the first is blocked in Go waiting for the recorder to return. Postgres sees one waiter and one idle-in-transaction session — no cycle — so `deadlock_timeout` never fires. Unbounded hang. **The same mechanism as #396.**

Latent only because `handlers.go:107` hard-codes `IPCountry: ""` and `evaluator.go:53-55` returns early on `"??"`, so nothing is ever flagged.

## The fix

The recorder call moves to post-commit, mirroring the `sendTrialBilled` pattern twelve lines away in the same file — including its no-collector fallback, which runs inline with a loud warning rather than dropping the signal. A call site that silently reverts to the inline path is exactly how this comes back, and it looks perfectly healthy in the logs while doing it.

**Not by passing the caller's `tx` into the recorder.** That would put the audit row back inside the webhook transaction and undo #442, which deliberately moved it out so a failed flag toggle cannot destroy the fraud record.

Semantics preserved: the recorder error stays non-fatal to the webhook and still routes through `reportArbitrageFailure` (log + `stripe_webhook_failed_total{reason="arbitrage_record"}`).

## Verified rather than assumed

**The collector really is drained after commit.** `stripe.go:167-186` installs it before the lock and calls `deferred.Run(ctx)` only once `WithAdvisoryLock` returns nil. On rollback the queue is deliberately dropped — the right semantics here too: no audit row for a checkout that never happened.

**Nothing depends on the arbitrage write landing before commit.** The only code after the recorder call is `statemachine.Transition(signup → trialing)` on `tx`. The only non-test readers of `arbitrage_flag` are an admin screen and the quarterly cron; nothing in dispatch, statemachine or the webhook path reads it.

**A correction to the issue's description:** the colliding statement is the flag `UPDATE`, which is step 3. Step 2 — the audit `INSERT` — would *not* have blocked, because its FK takes `FOR KEY SHARE`, which does not conflict with `FOR NO KEY UPDATE`. So the stall lands one statement later than a quick read suggests. Same outcome, but the audit row is durable by the time the hang begins.

## Test plan

Runs used `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'` with `-p 1 -count=1`, all EXECUTED (84 `--- PASS`, 0 `--- SKIP` across the three packages).

The bug is unreachable through the handler, so the test constructs the flagging input directly via an integration-tagged export, takes the same locking `UPDATE` on `tx` inside `WithAdvisoryLock`, and asserts nothing is written before the commit and everything after the drain. A second test proves the no-collector fallback still records rather than dropping.

- [x] **Mutation — the proof.** Forcing the inline path makes the test **hang**, not fail:
  ```
  panic: test timed out after 1m0s
      running tests:
          TestArbitrage_RecordedAfterTransactionCommits (1m0s)
  ...
  github.com/jackc/pgx/v5/pgconn/internal/bgreader.(*BGReader).Read(...)
  ```
  The goroutine is parked in a pgx socket read — the second connection waiting on the uncommitted row lock, exactly the stall described. Restored: `--- PASS (0.34s)`. **60s hang → 0.34s pass.**
- [x] `./internal/arbitrage`, `./internal/billing/dispatch`, `./internal/handlers/webhooks` all green (all three are in `make test-int`)
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean

## Deliberately unchanged

`IPCountry: ""` stays hard-coded. Supplying a real IP country is a product decision about whether checkout-time triangulation should flag at all — and it is what would *arm* this bug, not fix it. The fix has to stand independently of it, which is why the test constructs the flagging input directly rather than going through the handler.

Note for anyone repeating the mutation: killing the test binary mid-transaction leaves a wedged connection. `testdb.NewDB` truncates up-front so later runs are unaffected, but it is worth knowing on a shared database.
