### PR TITLE
fix(privacy): expire raw webhook payloads on an age-based prune since nothing can scope them to a customer (#440)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/ticket/... \
 	    ./internal/vendor/... \
 	    ./internal/webhookevents/... \
+	    ./internal/webhookprune/... \
 	    ./internal/whitelabel/lifecycle/... \
 	    ./pkg/testdb/... \
 	    ./tests/integration/...

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -126,6 +126,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/userprofile"
 	"github.com/mark8ly/marketplace-api/internal/vendor"
 	"github.com/mark8ly/marketplace-api/internal/webhookevents"
+	"github.com/mark8ly/marketplace-api/internal/webhookprune"
 	wlapple "github.com/mark8ly/marketplace-api/internal/whitelabel/apple"
 	wlfirebase "github.com/mark8ly/marketplace-api/internal/whitelabel/firebase"
 	wlgoogleplay "github.com/mark8ly/marketplace-api/internal/whitelabel/googleplay"
@@ -1819,6 +1820,26 @@ func main() {
 		}
 	}); err != nil {
 		log.Error("register audit prune cron", "err", err)
+	}
+
+	// webhook_events retention — daily prune at 03:30 UTC (#440). Two
+	// windows, in the table's own vocabulary: status='processed' rows go at
+	// 30 days, everything else (in practice 'received' — the unprocessed,
+	// stuck case someone may still want to inspect or replay) at 90 days.
+	// This table has no tenant_id, store_id or customer link, so neither
+	// GDPR erasure nor tenant purge can reach the raw provider payloads it
+	// stores; age is the only axis available. 03:30 is clear of every other
+	// daily cron in the service.
+	webhookPruneCron := webhookprune.NewPruneCron(conn, log, nil, 0).
+		WithCounter(func(label string, n int64) {
+			metrics.WebhookPruneRowsDeletedTotal.WithLabelValues(label).Add(float64(n))
+		})
+	if _, err := trialScheduler.AddFunc(webhookprune.PruneSpec, func() {
+		if _, err := webhookPruneCron.Run(workerCtx); err != nil {
+			log.Error("webhook prune cron failed", "err", err)
+		}
+	}); err != nil {
+		log.Error("register webhook prune cron", "err", err)
 	}
 
 	// Platform admin nonce sweep — daily at 09:45 UTC, deletes

--- a/services/marketplace-api/internal/metrics/registry.go
+++ b/services/marketplace-api/internal/metrics/registry.go
@@ -149,6 +149,19 @@ var (
 		[]string{"bucket"},
 	)
 
+	// WebhookPruneRowsDeletedTotal counts webhook_events rows hard-deleted by
+	// the retention prune cron, labeled by retention class (processed_30d,
+	// unprocessed_90d). The table holds raw provider event bodies carrying
+	// customer PII and cannot be scoped to a tenant or customer, so this
+	// age-based prune is the only path that expires it (#440).
+	WebhookPruneRowsDeletedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mark8ly_webhook_prune_rows_deleted_total",
+			Help: "Count of webhook_events rows deleted by the retention prune cron.",
+		},
+		[]string{"class"},
+	)
+
 	// DunningSuppressedRefundWindowTotal counts past_due→expired ladder steps
 	// skipped due to the 14-day refund window (§16.5). P6 dunning metrics.
 	DunningSuppressedRefundWindowTotal = prometheus.NewCounter(
@@ -206,6 +219,7 @@ func init() {
 		BillingEmailsSkippedTotal,
 		BillingEmailsSentTotal,
 		AuditPruneRowsDeletedTotal,
+		WebhookPruneRowsDeletedTotal,
 		DunningSuppressedRefundWindowTotal,
 		APIKeyUsedTotal,
 		APIKeyAuthFailedTotal,

--- a/services/marketplace-api/internal/webhookprune/prune_cron.go
+++ b/services/marketplace-api/internal/webhookprune/prune_cron.go
@@ -1,0 +1,254 @@
+// Package webhookprune enforces an age-based retention window on
+// webhook_events, the raw provider event log written by the storefront
+// payment webhook handler.
+//
+// WHY AN AGE-BASED PRUNE AND NOT ERASURE (#440). webhook_events.payload holds
+// the provider's event body verbatim — for Stripe that carries
+// billing_details.email, shipping.address and customer_details. The table has
+// only (id, provider, provider_event_id, event_type, payload, status,
+// processed_at, created_at): no tenant_id, no store_id, no order_id, no
+// customer link. So neither GDPR erasure (#259/#435) nor tenant purge can
+// reach it — internal/tenantpurge/purge.go:21-25 records exactly that as the
+// reason the table is excluded. Age is the only axis this table exposes.
+//
+// SAFE TO DELETE. Nothing reads the payload back. The only two statements
+// touching this table are the INSERT and the `UPDATE ... SET
+// status='processed'` in internal/handlers/storefront/webhooks.go. The
+// payload's value is operational — debugging a delivery, replaying a stuck
+// event — and it decays within days.
+package webhookprune
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// PruneSpec is the cron expression for the webhook_events retention prune —
+// 03:30 UTC daily. Deliberately offset from every other daily cron in the
+// service: 00:00 campaign ramp, 00:15 trial expiry, 00:30 trial activation,
+// 01:00 finalize, 01:30 close, 02:00 audit prune + tax revalidation + queue
+// hard-delete, 03:00 hard delete, 05:00 signup anomaly, and the 09:xx email
+// block. 03:30 is the widest gap left in the small hours.
+const PruneSpec = "30 3 * * *"
+
+// PruneBatchSize is the number of webhook_events rows deleted per statement.
+// Keeps each transaction short so the webhook INSERT path — which runs on the
+// provider's delivery timeout — is never queued behind the prune.
+const PruneBatchSize = 5000
+
+// ProcessedRetentionDays is how long a row that COMPLETED processing is kept,
+// counted from created_at.
+//
+// `status = 'processed'` is written by the UPDATE at
+// internal/handlers/storefront/webhooks.go once processEvent has run. Its
+// payload has already done its job; thirty days is a debugging tail, not a
+// record.
+const ProcessedRetentionDays = 30
+
+// UnprocessedRetentionDays is how long a row that never completed processing
+// is kept, counted from created_at.
+//
+// IN THIS TABLE'S ACTUAL VOCABULARY: there is no 'failed' status. The INSERT
+// writes 'received' and the only UPDATE writes 'processed' — those are the
+// two values that exist. So the long-retention class is everything that is
+// NOT 'processed', which in practice means 'received': the event was accepted
+// and stored but processing never reached the UPDATE. That is the stuck or
+// half-applied case, and it is the one an operator may still need to inspect
+// or replay, so it gets the longer window rather than the shorter one.
+//
+// Ninety days matches the audit trial/starter bucket, so the estate has one
+// "three months of operational history" number rather than two.
+const UnprocessedRetentionDays = 90
+
+// Metric labels for the two retention classes, so they stay distinguishable
+// in monitoring.
+const (
+	ProcessedMetricLabel   = "processed_30d"
+	UnprocessedMetricLabel = "unprocessed_90d"
+)
+
+// batchCeiling bounds one cron tick. 100 × 5000 = 500K rows, far beyond any
+// realistic daily webhook volume; whatever is left resumes on the next tick.
+const batchCeiling = 100
+
+// retentionClass pairs a retention window with the status predicate that
+// selects the rows it governs.
+type retentionClass struct {
+	// ProcessedOnly selects `status = 'processed'` when true, and everything
+	// else when false. A boolean rather than a status string because the
+	// long-retention class is defined by exclusion — it must cover any value
+	// that is not 'processed', including one a future provider integration
+	// introduces.
+	ProcessedOnly bool
+	RetentionDays int
+	Description   string
+	MetricLabel   string
+}
+
+var retentionClasses = []retentionClass{
+	{
+		ProcessedOnly: true,
+		RetentionDays: ProcessedRetentionDays,
+		Description:   "processed (30 day retention)",
+		MetricLabel:   ProcessedMetricLabel,
+	},
+	{
+		ProcessedOnly: false,
+		RetentionDays: UnprocessedRetentionDays,
+		Description:   "unprocessed (90 day retention)",
+		MetricLabel:   UnprocessedMetricLabel,
+	},
+}
+
+// CounterFn is the metric injection hook. Called once per class per Run with
+// (label, rowsDeleted). Kept generic so this package does not import
+// prometheus.
+type CounterFn func(label string, increment int64)
+
+// PruneCron deletes webhook_events rows past their retention window.
+type PruneCron struct {
+	db        *gorm.DB
+	logger    *slog.Logger
+	clock     func() time.Time
+	batchSize int
+	counter   CounterFn
+}
+
+// NewPruneCron constructs a PruneCron with sensible defaults. logger and
+// clock may be nil; batchSize <= 0 falls back to PruneBatchSize.
+func NewPruneCron(db *gorm.DB, logger *slog.Logger, clock func() time.Time, batchSize int) *PruneCron {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if clock == nil {
+		clock = func() time.Time { return time.Now().UTC() }
+	}
+	if batchSize <= 0 {
+		batchSize = PruneBatchSize
+	}
+	return &PruneCron{db: db, logger: logger, clock: clock, batchSize: batchSize}
+}
+
+// WithCounter attaches a metric incrementer. Pass nil to disable.
+func (c *PruneCron) WithCounter(fn CounterFn) *PruneCron {
+	c.counter = fn
+	return c
+}
+
+// PruneStats summarises one Run pass.
+type PruneStats struct {
+	ClassesRun         int
+	ProcessedDeleted   int64
+	UnprocessedDeleted int64
+	BatchesRun         int
+	ErrorsByClass      map[string]int
+}
+
+// RowsDeleted is the total across both retention classes.
+func (s PruneStats) RowsDeleted() int64 { return s.ProcessedDeleted + s.UnprocessedDeleted }
+
+// Run executes one prune pass over both retention classes. A per-class
+// failure is logged and recorded in stats.ErrorsByClass rather than aborting
+// the pass: a transient lock conflict on one class must not block the other,
+// and a prune failure must never take the service down.
+func (c *PruneCron) Run(ctx context.Context) (PruneStats, error) {
+	now := c.clock().UTC()
+	stats := PruneStats{ErrorsByClass: map[string]int{}}
+
+	for _, class := range retentionClasses {
+		stats.ClassesRun++
+		cutoff := now.AddDate(0, 0, -class.RetentionDays)
+		deleted, batches, err := c.pruneClass(ctx, class.ProcessedOnly, cutoff)
+		if class.ProcessedOnly {
+			stats.ProcessedDeleted += deleted
+		} else {
+			stats.UnprocessedDeleted += deleted
+		}
+		stats.BatchesRun += batches
+
+		if c.counter != nil && deleted > 0 {
+			c.counter(class.MetricLabel, deleted)
+		}
+
+		if err != nil {
+			stats.ErrorsByClass[class.Description]++
+			// A cancelled context means workerCtx was torn down by a routine
+			// shutdown mid-pass, not that the prune broke. Logging that at
+			// ERROR on every clean shutdown is the kind of line that costs an
+			// operator ten minutes at the wrong moment.
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				c.logger.Info("webhook prune: class interrupted by shutdown",
+					"class", class.Description, "deleted_so_far", deleted, "err", err.Error())
+			} else {
+				c.logger.Error("webhook prune: class failed; continuing",
+					"class", class.Description, "deleted_so_far", deleted, "err", err.Error())
+			}
+			continue
+		}
+
+		c.logger.Info("webhook prune: class complete",
+			"class", class.Description,
+			"cutoff", cutoff.Format(time.RFC3339),
+			"rows_deleted", deleted,
+			"batches", batches)
+	}
+
+	return stats, nil
+}
+
+// pruneClass loops batched DELETEs until a batch affects zero rows or ctx
+// cancels, and returns (rowsDeleted, batches, error).
+//
+// The DELETE uses a keyset subquery because Postgres has no DELETE ... LIMIT.
+// The subquery's LIMIT bounds per-statement work and is served by the
+// (status, created_at) index added in migration 000114; the outer
+// `WHERE id IN (…)` then locates rows by primary key.
+func (c *PruneCron) pruneClass(ctx context.Context, processedOnly bool, cutoff time.Time) (int64, int, error) {
+	statusPredicate := "status <> 'processed'"
+	if processedOnly {
+		statusPredicate = "status = 'processed'"
+	}
+
+	stmt := fmt.Sprintf(`
+		DELETE FROM webhook_events
+		WHERE id IN (
+			SELECT id
+			FROM webhook_events
+			WHERE %s
+			  AND created_at < ?
+			LIMIT ?
+		)`, statusPredicate)
+
+	var totalDeleted int64
+	batchCount := 0
+
+	for {
+		select {
+		case <-ctx.Done():
+			return totalDeleted, batchCount, ctx.Err()
+		default:
+		}
+
+		res := c.db.WithContext(ctx).Exec(stmt, cutoff, c.batchSize)
+		if res.Error != nil {
+			return totalDeleted, batchCount, fmt.Errorf("webhook prune delete: %w", res.Error)
+		}
+		batchCount++
+		totalDeleted += res.RowsAffected
+
+		if res.RowsAffected == 0 {
+			return totalDeleted, batchCount, nil
+		}
+
+		if batchCount >= batchCeiling {
+			c.logger.Warn("webhook prune: hit batch ceiling; deferring rest to next tick",
+				"processed_only", processedOnly, "batches", batchCount)
+			return totalDeleted, batchCount, nil
+		}
+	}
+}

--- a/services/marketplace-api/internal/webhookprune/prune_cron_integration_test.go
+++ b/services/marketplace-api/internal/webhookprune/prune_cron_integration_test.go
@@ -1,0 +1,216 @@
+//go:build integration
+
+package webhookprune_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/webhookprune"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// now is the pinned clock every test in this file runs against. Fixed, with
+// zero sub-second component, so every seeded created_at below is exact down
+// to the value Postgres stores rather than merely close to it.
+var now = time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+
+// insertEvent seeds one webhook_events row with an explicit status and
+// created_at, and returns its id.
+//
+// ABSOLUTE AGES ONLY. Callers pass `now.AddDate(0, 0, -31)`, never
+// `now.AddDate(0, 0, -webhookprune.ProcessedRetentionDays-1)`. A fixture
+// derived from the constant moves with the constant: widen the window from 30
+// days to 300 and a constant-derived "just past the edge" row is still just
+// past the edge, so the test pins the comparison operator and never the
+// window's VALUE. That exact mistake was caught during #369 and is not
+// repeated here — 31 means thirty-one days, and if the policy changes to
+// something other than 30/90 these tests must be edited deliberately.
+func insertEvent(t *testing.T, db *gorm.DB, status string, createdAt time.Time) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO webhook_events (id, provider, provider_event_id, event_type, payload, status, created_at)
+		 VALUES (?, 'stripe', ?, 'payment_intent.succeeded', '{"data":{"object":{"billing_details":{"email":"a@b.test"}}}}'::jsonb, ?, ?)`,
+		id, "evt_"+id.String(), status, createdAt,
+	).Error)
+	return id
+}
+
+func countRows(t *testing.T, db *gorm.DB, id uuid.UUID) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM webhook_events WHERE id = ?`, id).Scan(&n).Error)
+	return n
+}
+
+func runPrune(t *testing.T, db *gorm.DB, batchSize int) webhookprune.PruneStats {
+	t.Helper()
+	cron := webhookprune.NewPruneCron(db, nil, func() time.Time { return now }, batchSize)
+	stats, err := cron.Run(context.Background())
+	require.NoError(t, err)
+	return stats
+}
+
+// THE BOUNDARY, ON THE BOUNDARY — processed rows, 30 days.
+// 29 days old survives; 31 days old is deleted. Absolute ages, not
+// constant-derived offsets: these two numbers assert that the window is
+// THIRTY days, and they go red if it is moved.
+func TestPrune_ProcessedThirtyDayBoundary(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_events")
+
+	survives := insertEvent(t, db, "processed", now.AddDate(0, 0, -29))
+	deleted := insertEvent(t, db, "processed", now.AddDate(0, 0, -31))
+
+	stats := runPrune(t, db, 0)
+	require.Equal(t, int64(1), stats.ProcessedDeleted)
+
+	require.Equal(t, int64(1), countRows(t, db, survives),
+		"a processed row 29 days old is inside the 30 day window and must survive")
+	require.Equal(t, int64(0), countRows(t, db, deleted),
+		"a processed row 31 days old is past the 30 day window and must be deleted")
+}
+
+// The exact edge. created_at == cutoff is the only row that can distinguish
+// `<` from `<=`; the ±1 day rows above cannot, because neither is ever equal
+// to the cutoff. The rule is strict `<`, so a row created exactly 30 days ago
+// has not yet EXCEEDED 30 days and must survive.
+func TestPrune_ProcessedExactlyAtCutoffSurvives(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_events")
+
+	exact := insertEvent(t, db, "processed", now.AddDate(0, 0, -30))
+
+	runPrune(t, db, 0)
+
+	require.Equal(t, int64(1), countRows(t, db, exact),
+		"created_at < cutoff is strict, and equal is not less-than")
+}
+
+// THE BOUNDARY, ON THE BOUNDARY — unprocessed rows, 90 days.
+// 89 days old survives; 91 days old is deleted. The 89-day row is also the
+// guard that the two classes have DIFFERENT windows: it is 59 days past the
+// processed cutoff and must still be here.
+func TestPrune_UnprocessedNinetyDayBoundary(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_events")
+
+	survives := insertEvent(t, db, "received", now.AddDate(0, 0, -89))
+	deleted := insertEvent(t, db, "received", now.AddDate(0, 0, -91))
+
+	stats := runPrune(t, db, 0)
+	require.Equal(t, int64(1), stats.UnprocessedDeleted)
+	require.Equal(t, int64(0), stats.ProcessedDeleted,
+		"no processed rows were seeded, so the processed class must delete nothing")
+
+	require.Equal(t, int64(1), countRows(t, db, survives),
+		"an unprocessed row 89 days old is inside the 90 day window and must survive "+
+			"— it is well past the 30 day processed window, so this also asserts the two classes differ")
+	require.Equal(t, int64(0), countRows(t, db, deleted),
+		"an unprocessed row 91 days old is past the 90 day window and must be deleted")
+}
+
+func TestPrune_UnprocessedExactlyAtCutoffSurvives(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_events")
+
+	exact := insertEvent(t, db, "received", now.AddDate(0, 0, -90))
+
+	runPrune(t, db, 0)
+
+	require.Equal(t, int64(1), countRows(t, db, exact),
+		"created_at < cutoff is strict, and equal is not less-than")
+}
+
+// THE STATUS DISTINCTION, asserted in one pass. A processed row and an
+// unprocessed row of the SAME age — 60 days, between the two windows — must
+// get opposite outcomes. Drop the status distinction in either direction and
+// this test goes red.
+func TestPrune_SameAgeDifferentStatusGetOppositeOutcomes(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_events")
+
+	sixtyDays := now.AddDate(0, 0, -60)
+	processed := insertEvent(t, db, "processed", sixtyDays)
+	unprocessed := insertEvent(t, db, "received", sixtyDays)
+
+	stats := runPrune(t, db, 0)
+	require.Equal(t, int64(1), stats.ProcessedDeleted)
+	require.Equal(t, int64(0), stats.UnprocessedDeleted)
+
+	require.Equal(t, int64(0), countRows(t, db, processed),
+		"60 days is past the 30 day processed window")
+	require.Equal(t, int64(1), countRows(t, db, unprocessed),
+		"60 days is inside the 90 day unprocessed window — the same age must NOT decide both classes")
+}
+
+// The long-retention class is defined by EXCLUSION, not by matching
+// 'received'. This table writes only 'received' and 'processed' today, but a
+// future provider integration adding a third value must inherit the safer,
+// longer window rather than silently falling outside the prune (or worse,
+// into the short one).
+func TestPrune_UnknownStatusTakesTheLongWindow(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_events")
+
+	young := insertEvent(t, db, "quarantined", now.AddDate(0, 0, -60))
+	old := insertEvent(t, db, "quarantined", now.AddDate(0, 0, -91))
+
+	runPrune(t, db, 0)
+
+	require.Equal(t, int64(1), countRows(t, db, young),
+		"a non-'processed' status must get the 90 day window, not the 30 day one")
+	require.Equal(t, int64(0), countRows(t, db, old),
+		"a non-'processed' status must still be pruned once past 90 days")
+}
+
+// The batch loop must terminate and delete everything eligible, not just one
+// batch's worth.
+func TestPrune_DeletesBeyondOneBatch(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_events")
+
+	old := now.AddDate(0, 0, -31)
+	for i := 0; i < 5; i++ {
+		insertEvent(t, db, "processed", old)
+	}
+
+	stats := runPrune(t, db, 2) // batchSize 2
+	require.Equal(t, int64(5), stats.ProcessedDeleted,
+		"the loop must continue past the first batch")
+}
+
+// A cancelled context stops the pass without erroring out of Run — shutdown
+// is not a prune failure.
+func TestPrune_CancelledContextIsNotAFailure(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_events")
+
+	insertEvent(t, db, "processed", now.AddDate(0, 0, -31))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cron := webhookprune.NewPruneCron(db, nil, func() time.Time { return now }, 0)
+	stats, err := cron.Run(ctx)
+	require.NoError(t, err, "Run swallows per-class failure by design")
+	require.Equal(t, int64(0), stats.RowsDeleted())
+	require.NotEmpty(t, stats.ErrorsByClass)
+}
+
+// The counter hook fires once per class with the class's own label.
+func TestPrune_CounterHookReportsPerClass(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_events")
+
+	insertEvent(t, db, "processed", now.AddDate(0, 0, -31))
+	insertEvent(t, db, "received", now.AddDate(0, 0, -91))
+
+	seen := map[string]int64{}
+	cron := webhookprune.NewPruneCron(db, nil, func() time.Time { return now }, 0).
+		WithCounter(func(label string, n int64) { seen[label] += n })
+	_, err := cron.Run(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]int64{
+		webhookprune.ProcessedMetricLabel:   1,
+		webhookprune.UnprocessedMetricLabel: 1,
+	}, seen)
+}

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 113
+const ExpectedSchemaVersion uint = 114

--- a/services/marketplace-api/migrations/000114_webhook_events_retention_index.down.sql
+++ b/services/marketplace-api/migrations/000114_webhook_events_retention_index.down.sql
@@ -1,0 +1,3 @@
+-- 000114 down — drop the webhook_events retention prune index (#440).
+-- The prune cron still runs correctly without it; it just seq-scans.
+DROP INDEX IF EXISTS idx_webhook_events_status_created_at;

--- a/services/marketplace-api/migrations/000114_webhook_events_retention_index.up.sql
+++ b/services/marketplace-api/migrations/000114_webhook_events_retention_index.up.sql
@@ -1,0 +1,39 @@
+-- 000114 — index supporting the webhook_events retention prune (#440).
+--
+-- WHY. webhook_events.payload stores the provider's raw event body verbatim
+-- (internal/handlers/storefront/webhooks.go), which for Stripe carries
+-- billing_details.email, shipping.address and customer_details. The table has
+-- no tenant_id, store_id, order_id or customer link — see the DDL in
+-- 000008_payments_shipping_tax.up.sql — so no erasure or purge path can scope
+-- a delete to a person or a tenant (internal/tenantpurge/purge.go:21-25 says
+-- so explicitly). Age is the only axis this table exposes, so retention is
+-- enforced by an age-based prune cron: internal/webhookprune.
+--
+-- THE POLICY THIS INDEX SERVES, in the table's own vocabulary:
+--   * status = 'processed'  -> 30 days. Set by the UPDATE in webhooks.go once
+--     processEvent has run; the payload has already done its job.
+--   * everything else       -> 90 days. In practice that is 'received', the
+--     value the INSERT writes. This table has NO 'failed' status — 'received'
+--     and 'processed' are the only two values any code writes — so the
+--     long-retention class is the UNPROCESSED/stuck case: accepted and stored
+--     but never carried to completion, and therefore the one someone may
+--     still need to inspect or replay. The predicate is written as an
+--     exclusion (status <> 'processed') so a future provider integration
+--     adding a third status inherits the SAFER, longer window by default.
+--
+-- WHY AN INDEX AT ALL. Before this migration the table carried only its
+-- primary key and the UNIQUE (provider, provider_event_id) idempotency
+-- constraint — nothing on created_at and nothing on status. The prune's
+-- `WHERE status ... AND created_at < ?` would seq-scan a table that receives
+-- every payment webhook in the estate. It is empty in dev and will not be in
+-- production.
+--
+-- COLUMN ORDER. status first, created_at second: status is the equality
+-- predicate and created_at the range, so this ordering lets one index scan
+-- serve both classes' queries and return rows already ordered by age, which
+-- is what the prune's LIMIT batching wants.
+CREATE INDEX IF NOT EXISTS idx_webhook_events_status_created_at
+    ON webhook_events (status, created_at);
+
+COMMENT ON INDEX idx_webhook_events_status_created_at IS
+    'Supports the webhook_events retention prune (#440): processed rows 30 days, unprocessed (status <> ''processed'', i.e. ''received'') 90 days.';


### PR DESCRIPTION
Closes #440.

`webhook_events.payload` holds raw provider event bodies — Stripe and Razorpay events carrying `billing_details.email`, `shipping.address`, `customer_details` — retained **forever**, and **unreachable by any erasure or purge path**.

It cannot be scoped. The table is only `id, provider, provider_event_id, event_type, payload, status, processed_at, created_at`: no tenant, store, order or customer column. `tenantpurge/purge.go:21-25` already documents that as the reason it is excluded from tenant purge, and #435 hit the same wall from the erasure side. There is no key by which to find one person's rows, so an age-based prune is the only mechanism available.

Safe to prune because **nothing reads the payload back**: the only two statements touching this table are the INSERT at `handlers/storefront/webhooks.go:415` and the `UPDATE ... SET status='processed'` at `:437`.

## Retention

- `status = 'processed'` → **30 days**
- everything else → **90 days**

**A translation worth flagging.** The policy was decided as "30 days, failures kept longer", but **this table has no `'failed'` status** — the INSERT writes `'received'` and the only UPDATE writes `'processed'`, and those are the sole values. The long-retention class is therefore `'received'`: rows that never completed processing, which are exactly the ones someone may still need to inspect or replay. That preserves the intent; it just uses the vocabulary the table actually has rather than inventing one.

The predicate is `status <> 'processed'` — an **exclusion**, deliberately, so a future third status inherits the safer longer window rather than silently falling into the 30-day one.

## Shape

Modelled on `internal/audit/prune_cron.go`: batched `DELETE ... WHERE id IN (SELECT id ... LIMIT n)`, a `ctx.Done()` check per batch, termination on `RowsAffected == 0`, a `CounterFn` metric hook, and per-class failure logged rather than fatal (a cancelled context logs at INFO — a clean shutdown must not read as "the prune broke").

Migration 000114 adds `(status, created_at)` — equality column first, range second, so one index serves both classes and returns rows age-ordered for the `LIMIT` batching. The table previously had only its PK and the `(provider, provider_event_id)` unique constraint, so the prune would have seq-scanned a table that receives every payment webhook in production. `ExpectedSchemaVersion` goes 113 → 114 in the same commit.

Scheduled at **03:30 UTC** — chosen after enumerating every existing daily spec in the service (00:00, 00:15, 00:30, 01:00, 01:30, 02:00, 03:00, 05:00, the 09:00–10:00 cluster, plus hourly dunning). It is the widest free gap in the small hours.

## Test plan

All runs used `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'` with `-p 1 -count=1`, all EXECUTED — confirmed by per-test log lines showing real cutoffs and non-zero `rows_deleted`, not a silent skip.

- [x] 9 integration tests, all passing, including exact-cutoff cases that distinguish `<` from `<=`
- [x] **Boundary fixtures use ABSOLUTE ages** (29/31/89/91 days) — never ages derived from the retention constants. A constant-derived fixture moves with the constant and pins only the comparison, never the window's *value*; that exact mistake was caught during #369. The clock is pinned with a zero sub-second component so the timestamps are exact rather than close
- [x] **Mutation:** widen the processed window to 300 days → the 31-day boundary test fails `expected: 1, actual: 0`
- [x] **Mutation:** apply 30 days to unprocessed rows too → the 89-day test fails
- [x] **Mutation:** drop the status distinction (`TRUE` for both classes) → five tests fail, including one asserting an unknown status takes the long window
- [x] `./internal/webhookprune/...` added to `test-int`; **verified in both directions** — removing the Makefile line makes #446's coverage guard fail naming `internal/webhookprune`, restoring it passes
- [x] Migration applied to dev; `migrate version` → `114 dirty=false`; index present
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean

## Note

`internal/audit/operator_prune_integration_test.go` — which I pointed at as the model for boundary rigour — actually derives its fixtures from `OperatorRetentionYears`, i.e. the pattern this PR deliberately avoids. Its *structure* was mirrored, not its fixture style. Worth tightening there separately.

Also note the pre-existing `internal/webhookevents` package is unrelated: it models `stripe_webhook_events`, a different, tenant-scoped billing table that tenant purge already covers.
