### PR TITLE
fix(wishlist): stop advertising withdrawn variants' prices and stock (#420)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/webhookevents/... \
 	    ./internal/webhookprune/... \
 	    ./internal/whitelabel/lifecycle/... \
+	    ./internal/wishlist/... \
 	    ./pkg/testdb/... \
 	    ./tests/integration/...
 

--- a/services/marketplace-api/internal/wishlist/repository.go
+++ b/services/marketplace-api/internal/wishlist/repository.go
@@ -64,10 +64,40 @@ func (r *gormRepo) List(ctx context.Context, customerID string, page, limit int)
 			p.title AS product_title,
 			p.handle AS product_handle,
 			(SELECT url FROM product_media WHERE product_id = p.id ORDER BY position LIMIT 1) AS product_image_url,
-			COALESCE((SELECT MIN(price)::text FROM product_variants WHERE product_id = p.id), '0') AS product_min_price,
-			COALESCE((SELECT MAX(price)::text FROM product_variants WHERE product_id = p.id), '0') AS product_max_price,
+			-- deleted_at IS NULL is load-bearing, not defensive: variants are
+			-- SOFT-deleted (repository_variants.go), so a withdrawn variant's
+			-- row survives with deleted_at set. Without the predicate a
+			-- merchant who removes a $10 variant from a $10/$30 product keeps
+			-- advertising "from $10" here for a product whose cheapest
+			-- purchasable variant is now $30 — a price checkout will not
+			-- honour. It errs low, which is the bad direction (#420).
+			--
+			-- #395 made GORM add this predicate implicitly by moving
+			-- Variant.DeletedAt to gorm.DeletedAt, but this is RAW SQL against
+			-- the table, so no implicit predicate reaches it.
+			COALESCE((SELECT MIN(price)::text FROM product_variants
+			           WHERE product_id = p.id AND deleted_at IS NULL), '0') AS product_min_price,
+			COALESCE((SELECT MAX(price)::text FROM product_variants
+			           WHERE product_id = p.id AND deleted_at IS NULL), '0') AS product_max_price,
 			COALESCE(s.currency_code, 'AUD') AS currency_code,
-			p.status = 'active' AS in_stock
+			-- in_stock means what its name says: the product is purchasable.
+			-- This was a bare p.status = 'active' test, so an active product whose
+			-- every variant had zero inventory advertised itself as in stock —
+			-- and disagreed with its OWN product page, which derives the flag
+			-- per variant from InventoryQuantity > 0 (handlers/storefront/
+			-- dto.go:139). Two surfaces, one word, opposite answers (#420).
+			--
+			-- Both halves are required: an inactive product is not purchasable
+			-- however much stock it has, and an active one with none is not
+			-- purchasable either. deleted_at IS NULL for the same reason as
+			-- the price subqueries above — a withdrawn variant's stock must
+			-- not keep a product looking available.
+			(p.status = 'active' AND EXISTS (
+				SELECT 1 FROM product_variants
+				 WHERE product_id = p.id
+				   AND deleted_at IS NULL
+				   AND inventory_quantity > 0
+			)) AS in_stock
 		FROM wishlists w
 		JOIN products p ON p.id = w.product_id
 		LEFT JOIN stores s ON s.id = w.store_id

--- a/services/marketplace-api/internal/wishlist/repository_integration_test.go
+++ b/services/marketplace-api/internal/wishlist/repository_integration_test.go
@@ -1,0 +1,260 @@
+//go:build integration
+
+// Package wishlist_test covers the raw-SQL read projection in
+// wishlist.Repository.List — the only place in the service where a customer's
+// saved products get a price range and an availability flag.
+//
+// These are the first tests the wishlist package has ever had. They exist
+// because the two values that query computes are customer-visible promises:
+// "from $X" is a price a shopper expects checkout to honour, and in_stock is a
+// claim they can add the thing to a basket. Both were computed from data that
+// included WITHDRAWN variants (#420), so both could lie in the direction that
+// costs the merchant — advertising a price that has been retracted, and
+// advertising availability that does not exist.
+//
+// The query is raw SQL, so GORM's soft-delete predicate from #395 does not
+// reach it. That is precisely why it needs tests at this level: nothing in the
+// type system or the ORM will notice if `AND deleted_at IS NULL` goes missing
+// again.
+package wishlist_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/wishlist"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// --------------- fixtures ---------------
+
+// fixture is one customer with one wishlisted product, ready for variants.
+type fixture struct {
+	tenantID   uuid.UUID
+	storeID    uuid.UUID
+	productID  uuid.UUID
+	customerID uuid.UUID
+}
+
+// seedWishlistedProduct builds the smallest graph the List query joins over:
+// store -> vendor -> product -> (customer, wishlist entry). Variants are left
+// to the caller, since which variants exist — and which are soft-deleted — is
+// the entire subject of these tests.
+//
+// status is a products.status value. 'active' additionally requires
+// published_at (products_published_requires_active), so it is set in lockstep
+// rather than left to the caller to remember.
+func seedWishlistedProduct(t *testing.T, db *gorm.DB, status string) fixture {
+	t.Helper()
+
+	f := fixture{
+		tenantID:   uuid.New(),
+		storeID:    uuid.New(),
+		productID:  uuid.New(),
+		customerID: uuid.New(),
+	}
+
+	testdb.SeedStore(t, db, f.tenantID, f.storeID)
+	vendorID := testdb.SeedVendor(t, db, f.tenantID)
+
+	publishedAt := "now()"
+	if status != "active" {
+		publishedAt = "NULL"
+	}
+	err := db.Exec(`
+		INSERT INTO products (id, tenant_id, store_id, vendor_id, handle, title, status, published_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, `+publishedAt+`)`,
+		f.productID, f.tenantID, f.storeID, vendorID,
+		"wl-"+f.productID.String()[:8], "Wishlisted Product", status,
+	).Error
+	require.NoError(t, err, "seed products row")
+
+	err = db.Exec(`
+		INSERT INTO customer_profiles (id, tenant_id, store_id, email)
+		VALUES (?, ?, ?, ?)`,
+		f.customerID, f.tenantID, f.storeID, f.customerID.String()+"@example.test",
+	).Error
+	require.NoError(t, err, "seed customer_profiles row")
+
+	err = db.Exec(`
+		INSERT INTO wishlists (tenant_id, store_id, customer_id, product_id)
+		VALUES (?, ?, ?, ?)`,
+		f.tenantID, f.storeID, f.customerID, f.productID,
+	).Error
+	require.NoError(t, err, "seed wishlists row")
+
+	return f
+}
+
+// seedVariant inserts one product_variants row.
+//
+// deleted models the SOFT delete the admin path performs
+// (product/repository_variants.go): the row stays, deleted_at is stamped. That
+// surviving row is the whole hazard — a hard DELETE here would make every one
+// of these tests pass against the buggy query and prove nothing.
+//
+// The column is inventory_quantity, not stock_quantity. It is denormalised
+// from variant_stock by trigger in production, but writing it directly is the
+// established fixture shape in this repo and is what the List query reads.
+func seedVariant(t *testing.T, db *gorm.DB, f fixture, sku, price string, qty int, deleted bool) uuid.UUID {
+	t.Helper()
+
+	id := uuid.New()
+	deletedAt := "NULL"
+	if deleted {
+		deletedAt = "now()"
+	}
+	err := db.Exec(`
+		INSERT INTO product_variants
+			(id, product_id, store_id, sku, price, currency_code, inventory_quantity, deleted_at)
+		VALUES (?, ?, ?, ?, ?, 'EUR', ?, `+deletedAt+`)`,
+		id, f.productID, f.storeID, sku, price, qty,
+	).Error
+	require.NoError(t, err, "seed product_variants row (sku %s)", sku)
+	return id
+}
+
+// listOne runs the projection under test and asserts the customer sees exactly
+// their one wishlisted product.
+func listOne(t *testing.T, db *gorm.DB, f fixture) wishlist.WishlistItem {
+	t.Helper()
+
+	items, total, err := wishlist.NewRepository(db).List(context.Background(), f.customerID.String(), 1, 20)
+	require.NoError(t, err, "List must not error")
+	require.EqualValues(t, 1, total, "the fixture wishlisted exactly one product")
+	require.Len(t, items, 1, "the fixture wishlisted exactly one product")
+	return items[0]
+}
+
+// --------------- price range ---------------
+
+// The headline case for #420. A merchant lists a product at $10 and $30, then
+// withdraws the $10 variant. The wishlist must stop advertising "from $10":
+// that price is retracted and checkout will not honour it.
+func TestIntegration_WishlistList_MinPrice_IgnoresSoftDeletedVariant(t *testing.T) {
+	db := testdb.NewTx(t)
+	f := seedWishlistedProduct(t, db, "active")
+
+	seedVariant(t, db, f, "WL-CHEAP", "10.00", 5, true) // withdrawn by the merchant
+	seedVariant(t, db, f, "WL-DEAR", "30.00", 5, false) // the cheapest one still purchasable
+
+	got := listOne(t, db, f)
+
+	require.Equal(t, "30.00", got.ProductMinPrice,
+		"the wishlist advertised a price the merchant has WITHDRAWN: it quoted the "+
+			"soft-deleted $10 variant, so a shopper is shown 'from $10' for a product "+
+			"whose cheapest purchasable variant is $30 and whose checkout will charge $30")
+	require.Equal(t, "30.00", got.ProductMaxPrice,
+		"max price must come from live variants only")
+}
+
+// The soft-deleted row must not win the top of the range either — the same
+// defect in the other direction, where a withdrawn premium variant inflates
+// the advertised ceiling.
+func TestIntegration_WishlistList_MaxPrice_IgnoresSoftDeletedVariant(t *testing.T) {
+	db := testdb.NewTx(t)
+	f := seedWishlistedProduct(t, db, "active")
+
+	seedVariant(t, db, f, "WL-LIVE", "20.00", 5, false)
+	seedVariant(t, db, f, "WL-GONE", "99.00", 5, true)
+
+	got := listOne(t, db, f)
+
+	require.Equal(t, "20.00", got.ProductMinPrice)
+	require.Equal(t, "20.00", got.ProductMaxPrice,
+		"a withdrawn $99 variant must not set the top of the advertised range")
+}
+
+// With every variant withdrawn there is no live price at all. The COALESCE
+// fallback must take over: '0' is a visibly empty range the storefront can
+// render, whereas quoting the withdrawn price would be the #420 bug at its
+// worst — a product with nothing purchasable still showing a price tag.
+func TestIntegration_WishlistList_Price_FallsBackToZeroWhenEveryVariantIsSoftDeleted(t *testing.T) {
+	db := testdb.NewTx(t)
+	f := seedWishlistedProduct(t, db, "active")
+
+	seedVariant(t, db, f, "WL-D1", "10.00", 5, true)
+	seedVariant(t, db, f, "WL-D2", "30.00", 5, true)
+
+	got := listOne(t, db, f)
+
+	require.Equal(t, "0", got.ProductMinPrice,
+		"no live variant means no live price; the COALESCE fallback must apply "+
+			"rather than the query erroring or quoting a withdrawn amount")
+	require.Equal(t, "0", got.ProductMaxPrice)
+}
+
+// --------------- in_stock ---------------
+
+// The happy path, asserted first-class so the flag cannot be satisfied by
+// simply always being false — which every other in_stock test here would
+// otherwise accept.
+func TestIntegration_WishlistList_InStock_TrueForActiveProductWithLiveStockedVariant(t *testing.T) {
+	db := testdb.NewTx(t)
+	f := seedWishlistedProduct(t, db, "active")
+
+	seedVariant(t, db, f, "WL-OK", "15.00", 3, false)
+
+	got := listOne(t, db, f)
+
+	require.True(t, got.InStock,
+		"an active product with a live variant holding 3 units IS purchasable; "+
+			"reporting it out of stock loses the merchant a sale")
+}
+
+// in_stock was a bare `p.status = 'active'`, so this product — active, but
+// with nothing on the shelf — advertised itself as in stock, contradicting its
+// own product page, which derives the flag from InventoryQuantity > 0
+// (handlers/storefront/dto.go:139).
+func TestIntegration_WishlistList_InStock_FalseWhenEveryLiveVariantHasZeroInventory(t *testing.T) {
+	db := testdb.NewTx(t)
+	f := seedWishlistedProduct(t, db, "active")
+
+	seedVariant(t, db, f, "WL-EMPTY-1", "15.00", 0, false)
+	seedVariant(t, db, f, "WL-EMPTY-2", "25.00", 0, false)
+
+	got := listOne(t, db, f)
+
+	require.False(t, got.InStock,
+		"every live variant holds zero units, so nothing can be bought; the "+
+			"wishlist claimed in_stock anyway and the product's own page said the "+
+			"opposite — two surfaces, one word, contradictory answers")
+}
+
+// A withdrawn variant's stock must not keep a product looking available: the
+// units exist in the table but are not for sale.
+func TestIntegration_WishlistList_InStock_FalseWhenTheOnlyStockedVariantIsSoftDeleted(t *testing.T) {
+	db := testdb.NewTx(t)
+	f := seedWishlistedProduct(t, db, "active")
+
+	seedVariant(t, db, f, "WL-GONE-STOCK", "15.00", 50, true) // withdrawn, still holds 50
+	seedVariant(t, db, f, "WL-LIVE-EMPTY", "15.00", 0, false)
+
+	got := listOne(t, db, f)
+
+	require.False(t, got.InStock,
+		"the 50 units sit on a WITHDRAWN variant, so none of them are purchasable; "+
+			"counting them keeps an unbuyable product advertised as available")
+}
+
+// The status half of the condition still has to hold: stock on the shelf does
+// not make a draft or archived product purchasable.
+func TestIntegration_WishlistList_InStock_FalseForInactiveProductDespiteStock(t *testing.T) {
+	for _, status := range []string{"draft", "archived"} {
+		t.Run(status, func(t *testing.T) {
+			db := testdb.NewTx(t)
+			f := seedWishlistedProduct(t, db, status)
+
+			seedVariant(t, db, f, "WL-"+status, "15.00", 99, false)
+
+			got := listOne(t, db, f)
+
+			require.False(t, got.InStock,
+				"a %s product is not on sale however much stock it holds", status)
+		})
+	}
+}


### PR DESCRIPTION
Closes #420.

## The advertised price could be one the merchant had withdrawn

`internal/wishlist/repository.go`'s `MIN(price)`/`MAX(price)` subqueries had no `deleted_at IS NULL`. Variants are **soft**-deleted, so the row survives with `deleted_at` set.

A merchant lists a product at $10 and $30, then removes the $10 variant. The wishlist kept advertising **"from $10"** for a product whose cheapest purchasable variant is $30 — a price checkout will not honour. It errs *low*, which is the bad direction, and it is the same category as #413, where the pricing page advertised amounts billing does not charge.

**#395 does not reach this.** That change moved `Variant.DeletedAt` to `gorm.DeletedAt` so GORM appends the predicate implicitly — but this is raw SQL against the table, so nothing is appended.

## in_stock claimed more than it checked

`p.status = 'active' AS in_stock` meant an active product whose every variant held zero units advertised itself as in stock — **and disagreed with its own product page**, which derives the flag per variant from `InventoryQuantity > 0` (`handlers/storefront/dto.go:139`). Two surfaces, one word, opposite answers.

Now `p.status = 'active' AND EXISTS (... deleted_at IS NULL AND inventory_quantity > 0)`. Both halves are load-bearing: an inactive product is not purchasable however much stock it has, and an active one with none is not purchasable either. The `EXISTS` filters `deleted_at` for the same reason as the price subqueries — stock sitting on a withdrawn variant must not keep a product looking available.

The issue flagged this as possibly intentional shorthand rather than asserting it; confirmed as a real divergence and fixed on the product owner's call.

## Scope audit — two things the issue did not have

Every raw `product_variants` read in the service was enumerated:

- `handlers/admin/dashboard.go:155` — **not listed in the issue**, and clean (`AND pv.deleted_at IS NULL AND p.deleted_at IS NULL`).
- `product/repository_export.go:37` — clean, as the issue said.
- The wishlist's two subqueries — the defect.

Also checked: the sibling `product_media` subquery in the same statement needs no predicate — **that table has no `deleted_at` column** at all.

So the wishlist is genuinely the only affected site.

## This package had no tests

`internal/wishlist` had **zero** test files, so either change would have shipped unpinned. Seven integration tests added — the first this package has ever had — and `./internal/wishlist/...` added to `test-int` (#446's coverage guard confirms it is now covered).

## Test plan

All runs used `TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable'` with `-p 1 -count=1`, all EXECUTED.

- [x] **Mutation:** drop `deleted_at IS NULL` from the price subqueries → the withdrawn price is quoted verbatim:
  ```
  expected: "30.00"   actual: "10.00"
  Messages: the wishlist advertised a price the merchant has WITHDRAWN ...
            a shopper is shown 'from $10' for a product whose cheapest
            purchasable variant is $30 and whose checkout will charge $30
  ```
- [x] **Mutation:** revert `in_stock` to the bare status test → both stock tests fail, including the withdrawn-variant case ("the 50 units sit on a WITHDRAWN variant, so none of them are purchasable")
- [x] Coverage includes the happy path, so the flag cannot simply be always-false, plus `draft`/`archived` subtests
- [x] Passes twice consecutively; verified afterwards that the database holds **0 stores, 0 products, 0 wishlists, 0 `mk_seq_*` sequences** — this fixture cannot reproduce #446's poisoning or #436's sequence leak
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean

## Note on the fixture

It uses `testdb.NewTx` rather than `NewDB(t, tables...)`. Seeding this case needs `stores`, `products`, `product_variants`, `customer_profiles` and `wishlists`; truncating those on a **shared** database would destroy a concurrent stream's data mid-run. `NewTx` rolls the transaction back instead — strictly more self-cleaning while destroying nothing — and is the dominant pattern in `internal/product`'s integration tests. The leak check above verifies it rather than assuming it.

One piece of benign noise: each test logs `testdb.SeedStore: cleanup DELETE stores row ...: violates foreign key constraint`. Cleanups run LIFO, so `SeedStore`'s best-effort delete fires before `NewTx`'s rollback and trips over a product row still inside the open transaction. It is logged, not fatal, and the rollback removes everything. Pre-existing `pkg/testdb` behaviour under `NewTx` — flagged rather than papered over, and relevant to #401.
