### PR TITLE
test(ci): fail the integration run when a test leaves rows behind (#401)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,18 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/wishlist/... \
 	    ./pkg/testdb/... \
 	    ./tests/integration/...
+	@# A green suite is not the same as a clean database. testdb.NewDB
+	@# truncates only the tables a test names, so one that raw-INSERTs
+	@# elsewhere leaves rows for whatever package runs next — which is how
+	@# #401's phantom failures happened, packages passing or failing on run
+	@# order alone. #446's promo fixture and #436's per-store sequences were
+	@# both this, and both were found by accident. This makes the next one
+	@# loud, at the only point the invariant can be checked: after every
+	@# package has run.
+	@echo "▶ marketplace-api leak check"
+	@cd services/marketplace-api && \
+	  TEST_DATABASE_URL='postgres://dev:dev@localhost:5432/marketplace_db?sslmode=disable' \
+	  go run ./cmd/testdb-leakcheck
 
 cover: ## Coverage report for both Go services
 	@cd services/platform-api && go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out | tail -5

--- a/services/marketplace-api/cmd/testdb-leakcheck/main.go
+++ b/services/marketplace-api/cmd/testdb-leakcheck/main.go
@@ -1,0 +1,170 @@
+// Command testdb-leakcheck reports tables holding rows after an integration
+// run, so a test that leaves state behind is caught at the moment it does so
+// rather than as someone else's mysterious failure later.
+//
+// Usage:
+//
+//	TEST_DATABASE_URL=postgres://... testdb-leakcheck
+//
+// Exit 0 when the database is clean, 1 when it is not, 2 on a usage or
+// connection error. `make test-int` runs it as its final step.
+//
+// # Why this exists
+//
+// pkg/testdb's NewDB truncates only the table list the caller passes it
+// (testdb.go:60). A test that raw-INSERTs into a table it did not name leaves
+// those rows behind for whatever package runs next in the same database, and
+// nothing anywhere notices. #401 measured the result: a full run reporting
+// ~46 failures that did not reproduce in isolation, with packages flipping
+// between pass and fail purely on run order.
+//
+// Two concrete instances have since been found and fixed. #446's promo
+// fixture seeded a hardcoded code into promo_codes — a table absent from its
+// truncate list and, unlike its neighbours, carrying no ON DELETE CASCADE
+// from stores — so the row committed permanently. That test passed exactly
+// once, in August 2026, and its own success is what broke every run after.
+// #436 was the same shape in the catalog: per-store sequences that TRUNCATE
+// cannot reach, accumulating to 27,990 until pg_dump could no longer run.
+//
+// Both were found by accident. This makes the next one loud.
+//
+// # Why a command rather than a test
+//
+// The invariant is about the state left after EVERY package has run, so it
+// cannot be a Go test: package test binaries are independent, and one that
+// asserted an empty database would fail depending on which package happened
+// to run before it.
+//
+// # Why not simply truncate everything in NewDB
+//
+// #401 suggests widening NewDB's truncation to all tenant-scoped tables. That
+// would fix pollution and break something worse: this database is shared, and
+// a fixture that truncates products and stores destroys a concurrent run's
+// data mid-flight. Tests that need real commits should name their tables;
+// tests that do not should use testdb.NewTx, whose rollback leaks nothing and
+// is safe under concurrency. This command enforces the outcome without
+// dictating which of the two a test picks.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// allowed are tables that legitimately hold rows in a clean database. Each
+// value is why — an entry without one is not a decision, it is a silenced
+// alarm, and this list is the only way to quiet the check.
+//
+// Migrations also INSERT into vendors, warehouses and shipments, but all of
+// those are backfills (INSERT ... SELECT over existing rows) that match
+// nothing on an empty database, so they are correctly absent here.
+var allowed = map[string]string{
+	"supported_countries":              "reference data seeded by migration 000030; global, not tenant-scoped, and no purge or fixture should remove it",
+	"shipping_zones":                   "reference data seeded by migration; same class as supported_countries",
+	"marketplace_db_schema_migrations": "golang-migrate's own bookkeeping — the record of which migrations have run",
+}
+
+func main() {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		dsn = os.Getenv("DATABASE_URL")
+	}
+	if dsn == "" {
+		fail("TEST_DATABASE_URL (or DATABASE_URL) is required")
+	}
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		fail("open: %v", err)
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	dirty, err := nonEmptyTables(ctx, db)
+	if err != nil {
+		fail("scan: %v", err)
+	}
+
+	var leaked []string
+	for table, n := range dirty {
+		if _, ok := allowed[table]; !ok {
+			leaked = append(leaked, fmt.Sprintf("%s (%d rows)", table, n))
+		}
+	}
+	sort.Strings(leaked)
+
+	if len(leaked) > 0 {
+		fmt.Fprintf(os.Stderr, "testdb-leakcheck: %d table(s) hold rows after the run:\n", len(leaked))
+		for _, l := range leaked {
+			fmt.Fprintf(os.Stderr, "  %s\n", l)
+		}
+		fmt.Fprintf(os.Stderr, `
+A test committed rows and did not clean them up. The next package to run
+against this database inherits them, which is how #401's phantom failures
+happened — packages passing or failing on run order alone.
+
+Fix the fixture, not this list:
+  - testdb.NewDB(t, ...): pass EVERY table the test writes, so the truncate
+    reaches them. Watch for tables with no ON DELETE CASCADE from stores —
+    those are not swept for you (that was #446).
+  - testdb.NewTx(t): if the test does not need real commits, the rollback
+    leaks nothing at all and is safe when runs overlap.
+
+Add to the allowlist in cmd/testdb-leakcheck ONLY for data that SHOULD
+survive, such as migration-seeded reference tables, and say why.
+`)
+		os.Exit(1)
+	}
+
+	fmt.Println("testdb-leakcheck: clean")
+}
+
+// nonEmptyTables returns an exact row count for every public table that has
+// any, keyed by table name.
+//
+// Exact counts, deliberately, not pg_stat_user_tables.n_live_tup: that is an
+// estimate maintained by autovacuum and it under-reports on a database this
+// quiet. Measured while building this check — n_live_tup reported two
+// non-empty tables where there were three, missing shipping_zones entirely.
+// A leak detector that silently misses rows is worse than none.
+func nonEmptyTables(ctx context.Context, db *sql.DB) (map[string]int64, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT c.relname,
+		       (xpath('/row/c/text()',
+		           query_to_xml(format('SELECT count(*) AS c FROM %I.%I', n.nspname, c.relname),
+		                        false, true, '')))[1]::text::bigint AS n
+		  FROM pg_class c
+		  JOIN pg_namespace n ON n.oid = c.relnamespace
+		 WHERE c.relkind = 'r'
+		   AND n.nspname = 'public'`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := map[string]int64{}
+	for rows.Next() {
+		var name string
+		var n int64
+		if err := rows.Scan(&name, &n); err != nil {
+			return nil, err
+		}
+		if n > 0 {
+			out[name] = n
+		}
+	}
+	return out, rows.Err()
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "testdb-leakcheck: "+format+"\n", args...)
+	os.Exit(2)
+}


### PR DESCRIPTION
Closes #401.

## First, the measurement: the symptom is gone

#401 reports "~46 failures that do not reproduce in isolation, and 7 of 19 failing packages pass cleanly when run alone". Re-measured on current `main`:

**A full `go test -tags=integration -p 1 ./...` run: 115 packages, ZERO failures.** Afterwards the database holds rows in exactly three tables — `supported_countries` (15), `shipping_zones` (3), `marketplace_db_schema_migrations` (1) — all migration-seeded reference data. **No leaked rows at all.**

Several fixes since the issue was filed removed the causes, two of them concrete instances of precisely this bug: **#446**'s promo fixture (a hardcoded code committed into `promo_codes`, a table absent from its truncate list and carrying no `ON DELETE CASCADE` from `stores`) and **#436**'s per-store sequences (catalog objects `TRUNCATE` cannot reach, accumulated to 27,990 until `pg_dump` stopped working).

So there is nothing left to repair. What remains is that **the mechanism is unchanged** — `NewDB` still truncates only what it is told — and both instances above were found *by accident*. This makes the next one loud.

## What this adds

`cmd/testdb-leakcheck`: after a run, any table outside a small justified allowlist holding rows is a leak. `make test-int` runs it as its final step, because that is the only point the invariant can be checked — the state left after *every* package has run.

It cannot be a Go test: package test binaries are independent, so one asserting an empty database would pass or fail on which package happened to precede it — the very failure mode being fixed.

Its output names the fixture patterns rather than just the table, so the fix is to the test and not to the allowlist.

## Why not the issue's first suggestion

#401 offers "widen `NewDB`'s truncation to cover every tenant-scoped table". That would fix pollution and break something worse.

This database is **shared**. A fixture that truncates `products` and `stores` destroys a concurrent run's data mid-flight — which is not hypothetical: while fixing #420 an agent correctly declined to use `NewDB(t, tables...)` for exactly this reason and used `NewTx` instead, verifying afterwards that it left zero rows and zero sequences behind. Making every `NewDB` call truncate everything would make overlapping runs impossible and silently corrupt each other's fixtures.

The right split stays as it is — tests needing real commits name their tables; tests that do not use `NewTx`, whose rollback leaks nothing and is safe under concurrency. This check enforces the *outcome* without dictating which a test picks.

## One detail worth keeping

The counts are **exact**, not `pg_stat_user_tables.n_live_tup`. That column is an autovacuum-maintained estimate and it under-reports on a database this quiet — measured while building this: it reported two non-empty tables where there were three, missing `shipping_zones` entirely. A leak detector that silently misses rows is worse than none.

## Test plan

- [x] Against the clean database: `testdb-leakcheck: clean`, exit 0
- [x] **Mutation — planted a leak of exactly #446's shape**, a stray `promo_codes` row:
  ```
  testdb-leakcheck: 1 table(s) hold rows after the run:
    promo_codes (1 rows)
  exit=1
  ```
  Removing the row returns it to `clean`, exit 0
- [x] Full `./...` integration run: 115 ok, 0 failures; leak check clean afterwards
- [x] #446's `TestEveryIntegrationPackageIsInTheTestIntTarget` still passes (the new package is under `cmd/` and carries no integration tag)
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `gofmt` clean

Note the check runs only when the suite itself passes, since `make` stops at the first failing recipe. That ordering is deliberate: a failing suite is the louder signal, and a dirty database found underneath it would be noise.
