### PR TITLE
feat(platformadmin): declare the contract v3 endpoints

### DIFF
--- a/admin-conformance.json
+++ b/admin-conformance.json
@@ -1,6 +1,6 @@
 {
   "slug": "mark8ly",
-  "contractVersion": 2,
+  "contractVersion": 3,
   "endpoints": {
     "kpis": true,
     "inbox": {
@@ -19,6 +19,13 @@
     "billing/subscriptions": true,
     "billing/trials": true,
     "tenant-lifecycle": true,
-    "lifecycle/reason-codes": true
+    "lifecycle/reason-codes": true,
+    "outbox": true,
+    "email-sends": true,
+    "notifications": true,
+    "conversions": true,
+    "onboarding/funnel": true,
+    "onboarding/sessions": true,
+    "tenant-purge": true
   }
 }

--- a/admin-conformance.json
+++ b/admin-conformance.json
@@ -23,6 +23,7 @@
     "outbox": true,
     "email-sends": true,
     "notifications": true,
+    "break-glass": true,
     "conversions": true,
     "onboarding/funnel": true,
     "onboarding/sessions": true,

--- a/services/marketplace-api/internal/handlers/platformadmin/conformance_declaration_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/conformance_declaration_test.go
@@ -32,6 +32,17 @@ var contractEndpointIDs = []string{
 	"billing/trials",
 	"tenant-lifecycle",
 	"lifecycle/reason-codes",
+	// contract v3 (design-system#…, 2026-08-29). Same rule as above: whoever
+	// adds an eighteenth id to contract.ts updates this slice in the same
+	// change, or this guard silently stops covering it.
+	"outbox",
+	"email-sends",
+	"notifications",
+	"break-glass",
+	"conversions",
+	"onboarding/funnel",
+	"onboarding/sessions",
+	"tenant-purge",
 }
 
 // routeToContractID maps every route TEMPLATE (as gin's own route table
@@ -51,22 +62,43 @@ var contractEndpointIDs = []string{
 // for one to mount without the other, so — unlike entities — a single
 // mounted/declared bit for the id is accurate here.
 //
-// Routes this surface mounts that have NO entry here (outbox, email-sends,
-// notifications, tickets, break-glass, conversions, onboarding/funnel,
-// onboarding/sessions, the inbox actions write, tenant purge) are exactly
-// the mark8ly-specific reads and writes docs/admin-conformance.md documents
-// as structurally undeclarable — this test deliberately has nothing to say
-// about them, because the nine-id vocabulary has nowhere to put them.
+// Routes this surface mounts that have NO entry here (tickets, the inbox
+// actions write) are exactly the mark8ly-specific reads and writes
+// docs/admin-conformance.md documents as structurally undeclarable — this
+// test deliberately has nothing to say about them, because the seventeen-id
+// vocabulary has nowhere to put them.
+//
+// contract v3 additions (design-system#…, 2026-08-29): outbox, email-sends,
+// notifications, break-glass, conversions each mount a single route.
+// onboarding/funnel mounts BOTH /onboarding/funnel and /onboarding/sessions
+// atomically — routes.go's NewOnboardingFunnelHandler(...).Register(group)
+// call is gated on a single `deps.OnboardingFunnel != nil` check that mounts
+// both, so a single id covers both templates the same way tenant-lifecycle
+// covers suspend+unsuspend above. tenant-purge mounts BOTH
+// /tenants/:id/purge/preview (GET) and /tenants/:id/purge (POST)
+// atomically for the same reason — routes.go's tenant-purge switch case
+// registers both from one NewTenantPurgeHandler(...).Register(group) call
+// gated on one non-nil check (TenantTeardown, Purger, Emitter, DB,
+// TenantDirectory all non-nil).
 var routeToContractID = map[string]string{
-	platformadmin.MountPrefix + "/admin/kpis":                   "kpis",
-	platformadmin.MountPrefix + "/admin/inbox":                  "inbox",
-	platformadmin.MountPrefix + "/admin/audit-logs":             "audit-logs",
-	platformadmin.MountPrefix + "/admin/health":                 "health",
-	platformadmin.MountPrefix + "/admin/billing/subscriptions":  "billing/subscriptions",
-	platformadmin.MountPrefix + "/admin/billing/trials":         "billing/trials",
-	platformadmin.MountPrefix + "/admin/tenants/:id/suspend":    "tenant-lifecycle",
-	platformadmin.MountPrefix + "/admin/tenants/:id/unsuspend":  "tenant-lifecycle",
-	platformadmin.MountPrefix + "/admin/lifecycle/reason-codes": "lifecycle/reason-codes",
+	platformadmin.MountPrefix + "/admin/kpis":                      "kpis",
+	platformadmin.MountPrefix + "/admin/inbox":                     "inbox",
+	platformadmin.MountPrefix + "/admin/audit-logs":                "audit-logs",
+	platformadmin.MountPrefix + "/admin/health":                    "health",
+	platformadmin.MountPrefix + "/admin/billing/subscriptions":     "billing/subscriptions",
+	platformadmin.MountPrefix + "/admin/billing/trials":            "billing/trials",
+	platformadmin.MountPrefix + "/admin/tenants/:id/suspend":       "tenant-lifecycle",
+	platformadmin.MountPrefix + "/admin/tenants/:id/unsuspend":     "tenant-lifecycle",
+	platformadmin.MountPrefix + "/admin/lifecycle/reason-codes":    "lifecycle/reason-codes",
+	platformadmin.MountPrefix + "/admin/outbox":                    "outbox",
+	platformadmin.MountPrefix + "/admin/email-sends":               "email-sends",
+	platformadmin.MountPrefix + "/admin/notifications":             "notifications",
+	platformadmin.MountPrefix + "/admin/break-glass":               "break-glass",
+	platformadmin.MountPrefix + "/admin/conversions":               "conversions",
+	platformadmin.MountPrefix + "/admin/onboarding/funnel":         "onboarding/funnel",
+	platformadmin.MountPrefix + "/admin/onboarding/sessions":       "onboarding/sessions",
+	platformadmin.MountPrefix + "/admin/tenants/:id/purge/preview": "tenant-purge",
+	platformadmin.MountPrefix + "/admin/tenants/:id/purge":         "tenant-purge",
 }
 
 // entitySubtypeRoutes maps each `entities` subtype this product can declare


### PR DESCRIPTION
Declares all eight contract v3 endpoint ids, moving mark8ly to `contractVersion: 3`.

Gated on `@tesserix/admin-conformance@0.8.0` being live on registry.npmjs.org — verified before this branch was written. Declaring against 0.7.0 would have thrown on the unknown keys and failed the entire nightly run, not just those endpoints.

## Declared

`outbox`, `email-sends`, `notifications`, `break-glass`, `conversions`, `onboarding/funnel`, `onboarding/sessions`, `tenant-purge` — every platform-admin surface this service mounts that the contract now has a vocabulary for.

`conversions` and `tenant-purge` are declared with `probe: false` in the contract, so the suite never calls them. The rest are probed.

## break-glass, and a plan premise that was wrong

The plan held `break-glass` back on the belief that the CronJob's signing identity had to *hold* the `rotate-credentials` capability, and that this needed verifying first.

Reading `internal/handlers/platformadmin/middleware.go:367-385`, that requirement does not exist. The read gate is exact string equality against the capability value the caller sends, plus a non-empty operator. No grant list, no allowlist, no identity check — `middleware_test.go:670` pins the map at exactly one entry. So there was nothing to verify and no reason to defer.

`middleware.go:355-361` and `:388-392` confirm the other direction: an undeclared read is ungated, and a presented operator/capability is only recorded into context. The companion tesserix-k8s change adds `--operator`/`--capability` run-wide, and that breaks no other endpoint.

## The Go guard

`conformance_declaration_test.go` holds a hand-maintained, cross-repo, cross-language mirror of `contract.ts`'s vocabulary. It now lists all seventeen ids, and `routeToContractID` gains the eight new route templates — verified against the handlers' own `g.GET`/`g.POST` calls, in gin's `:id` form with `MountPrefix` included, not guessed from REST convention.

Note the two lists are deliberately different in kind: `contractEndpointIDs` mirrors the contract's vocabulary; the declaration states what this product opts into enforcement for. They happen to coincide now, and need not.

**No allowlist, no skip, and no loosened assertion was added.** The guard is green because the declaration is complete, not because it was silenced.

## Verified against production, not just the test binary

The guard proves routes are mounted with test dependencies — never that production wiring is non-nil. So all eight were probed unauthenticated against the running pod:

```
401  /admin/outbox                401  /admin/break-glass
401  /admin/email-sends           401  /admin/conversions
401  /admin/notifications         401  /admin/onboarding/funnel
401  /admin/onboarding/sessions   401  /admin/tenants/{id}/purge/preview
404  /admin/definitely-not-a-route      <- control
```

401 is auth rejecting a mounted route; the 404 control proves the probe discriminates. This declaration does not over-declare.

## Test plan

- [x] Guard red first, naming every mounted-but-undeclared route
- [x] `go test ./internal/handlers/platformadmin/ -v` green, no handler modified
- [x] Both declaration copies normalised and compared: identical, 17 ids, `contractVersion: 3`
- [x] All eight routes confirmed serving in production
- [ ] After the chart syncs — an on-demand conformance run reporting more than the prior 11 endpoints