### PR TITLE
test: make three #287 tests fail on the assertion that names the property (#342)

### DIFF
--- a/services/marketplace-api/internal/handlers/admin/mobile_routes_tenantgate_test.go
+++ b/services/marketplace-api/internal/handlers/admin/mobile_routes_tenantgate_test.go
@@ -8,10 +8,13 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/auth"
 	"github.com/mark8ly/marketplace-api/internal/authz"
+	"github.com/mark8ly/marketplace-api/internal/stores"
 	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
 	"github.com/mark8ly/marketplace-api/internal/tenantgate"
 )
@@ -28,6 +31,52 @@ func (s *stubTenantLookup) Get(_ context.Context, id string) (*tenantdirectory.T
 	}, nil
 }
 
+// stubStoresRepo implements stores.Repository. Only ListForTenant — the
+// one method StoresHandler.List calls — returns anything; the rest are
+// inert stubs, mirroring fakeLifecycleStoreRepo in
+// internal/handlers/platformadmin/tenant_lifecycle_test.go.
+//
+// It exists so the route below has a WORKING terminus: with it wired, a
+// request that gets past the tenant gate reaches the handler and is
+// answered 200. That is what makes the 403 assertion the thing that
+// fails when the gate is removed (#342) rather than a nil-dereference
+// somewhere in the middleware chain.
+type stubStoresRepo struct{}
+
+func (r *stubStoresRepo) GetByIDForTenant(_ context.Context, _, _ string) (*stores.Store, error) {
+	return nil, stores.ErrNotFound
+}
+func (r *stubStoresRepo) GetBySlug(_ context.Context, _ string) (*stores.Store, error) {
+	return nil, stores.ErrNotFound
+}
+func (r *stubStoresRepo) ListForTenant(_ context.Context, tenantID string) ([]stores.Store, error) {
+	return []stores.Store{{
+		ID: "store-1", TenantID: tenantID, Slug: "the-bondi-store",
+		Name: "The Bondi Store", CountryCode: "AU", CurrencyCode: "AUD",
+		Timezone: "Australia/Sydney", Status: "active",
+	}}, nil
+}
+func (r *stubStoresRepo) Upsert(_ context.Context, _ *stores.Store) error { return nil }
+func (r *stubStoresRepo) GetProductsWatermark(_ context.Context, _ string) (time.Time, error) {
+	return time.Time{}, nil
+}
+func (r *stubStoresRepo) CountActiveOrSoftDeletedRestorable(_ context.Context, _ uuid.UUID) (int, error) {
+	return 0, nil
+}
+func (r *stubStoresRepo) CountActiveOrSoftDeletedRestorableTx(_ context.Context, _ *gorm.DB, _ uuid.UUID) (int, error) {
+	return 0, nil
+}
+func (r *stubStoresRepo) ListActiveOrSoftDeletedRestorable(_ context.Context, _ uuid.UUID) ([]stores.Store, error) {
+	return nil, nil
+}
+func (r *stubStoresRepo) InFlightOrderCount(_ context.Context, _ uuid.UUID) (int, error) {
+	return 0, nil
+}
+func (r *stubStoresRepo) SuspendActiveForTenant(_ context.Context, _ string) error { return nil }
+func (r *stubStoresRepo) MarkStaleForTenant(_ context.Context, _ string) error     { return nil }
+
+var _ stores.Repository = (*stubStoresRepo)(nil)
+
 // TestRegisterAdminMobile_SuspendedTenantRefusedOnNonStoreRoute is the F1
 // regression test (#287 review): mobile_routes.go is the FIFTH admin route
 // group, and it never applied deps.TenantGate — so a suspended tenant's
@@ -38,16 +87,26 @@ func (s *stubTenantLookup) Get(_ context.Context, id string) (*tenantdirectory.T
 // This exercises GET /api/v1/mobile/admin/stores specifically: it is
 // tenant-wide, NOT store-scoped, so deps.StoresMiddleware never runs on
 // it and only deps.TenantGate can catch a suspended tenant here.
+//
+// Everything downstream of the gate is wired to WORK (#342): a real FGA
+// fake granting the caller staff on the tenant, and a stores repo that
+// returns a row. Delete the TenantGate line from mobile_routes.go and
+// this request is answered 200 — so the assertion that fails is the 403
+// below, not a panic on a nil FGA client. A mutation that crashes proves
+// only that something crashed; this one proves the assertion discriminates.
 func TestRegisterAdminMobile_SuspendedTenantRefusedOnNonStoreRoute(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 
 	gate := tenantgate.New(&stubTenantLookup{status: "suspended"}, nil, time.Minute)
 
+	fga := authz.NewFakeClient()
+	fga.Grant("user-1", authz.RoleStaff, "tenant-1")
+
 	RegisterAdminMobile(r.Group("/api/v1"), MobileDeps{
 		Deps: Deps{
-			StoresHandler:   &StoresHandler{},
-			AuthzMiddleware: authz.NewMiddleware(nil, nil),
+			StoresHandler:   NewStoresHandler(&stubStoresRepo{}, nil),
+			AuthzMiddleware: authz.NewMiddleware(fga, nil),
 			TenantGate:      gate.RequireActiveTenant(),
 			StoresMiddleware: func(c *gin.Context) {
 				c.Next()

--- a/services/marketplace-api/internal/handlers/admin/shipments_tracking_sync_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments_tracking_sync_test.go
@@ -32,6 +32,11 @@ import (
 var trackingSyncTables = []string{
 	"order_events",
 	"shipments",
+	// orders has NO foreign key to stores, so truncating stores does not
+	// reach it — the exact shape cmd/testdb-leakcheck's help text warns
+	// about. seedOrderRowForSync INSERTs here and, until this entry, every
+	// run committed rows that outlived the fixture (#342 caught it).
+	"orders",
 	"shipping_carrier_configs",
 	"stores",
 }

--- a/services/marketplace-api/internal/tenantlifecycle/client_test.go
+++ b/services/marketplace-api/internal/tenantlifecycle/client_test.go
@@ -25,6 +25,14 @@ func TestSuspend_MapsStatusCodes(t *testing.T) {
 		{"conflict", 409, `{"error":"invalid_status_transition"}`, tenantlifecycle.ErrConflict},
 		{"server error", 500, `{"error":"internal_error"}`, tenantlifecycle.ErrUnavailable},
 		{"bad gateway", 502, ``, tenantlifecycle.ErrUnavailable},
+		// The contract is "200, 404 and 409 are the only recognised
+		// statuses; anything else is ErrUnavailable". Without a case
+		// outside {200, 404, 409, 5xx} the `default:` branch is never
+		// pinned to that answer for a NON-5xx status (#342). 400 is the
+		// error-shaped one; 204 is the success-shaped one — a 2xx that is
+		// still not a result, which is the easier of the two to get wrong.
+		{"bad request", 400, `{"error":"bad_request"}`, tenantlifecycle.ErrUnavailable},
+		{"no content", 204, ``, tenantlifecycle.ErrUnavailable},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/services/platform-api/internal/tenant/suspend_integration_test.go
+++ b/services/platform-api/internal/tenant/suspend_integration_test.go
@@ -78,13 +78,21 @@ func TestSuspendThenUnsuspendPreservesIndividuallySuspendedStore(t *testing.T) {
 	res, err = repo.Unsuspend(ctx, tenantID)
 	require.NoError(t, err)
 	require.True(t, res.Changed)
-	require.Equal(t, 1, res.StoresAffected)
 
-	require.Equal(t, "active", storeStatus(t, db, activeStore),
-		"the store the cascade suspended must be restored")
+	// Order matters here (#342). Under the naive cascade — Unsuspend's
+	// UPDATE reduced to `WHERE tenant_id = ?`, dropping
+	// `AND suspended_by_tenant` — BOTH the per-store status below and
+	// res.StoresAffected are wrong, and require aborts on whichever runs
+	// first. The count is a symptom; the per-store status is the property
+	// this test is named after, so it is asserted first and the count is
+	// checked afterwards as corroboration.
 	require.Equal(t, "suspended", storeStatus(t, db, alreadySuspended),
 		"a store suspended individually BEFORE the tenant suspension must stay suspended")
+	require.Equal(t, "active", storeStatus(t, db, activeStore),
+		"the store the cascade suspended must be restored")
 	require.False(t, suspendedByTenant(t, db, activeStore), "flag must be cleared after unsuspend")
+	require.Equal(t, 1, res.StoresAffected,
+		"only the store the cascade suspended is restored")
 }
 
 // A second suspend is a no-op: no extra stores affected, Changed false, and


### PR DESCRIPTION
Closes #342.

Three tests that passed for the right reason but would not have **caught** a regression for the reason their names claim. No production code changed — nothing here indicates a shipped bug.

The acceptance criterion for each was the same: after the fix, does the mutation fail on the assertion that *names* the property? Not on a count, not on a panic.

## 1. The count fired before the property

`TestSuspendThenUnsuspendPreservesIndividuallySuspendedStore` justifies the entire `suspended_by_tenant` column. Under the naive-cascade mutation it aborted on `require.Equal(t, 1, res.StoresAffected)` — a **count** — so the per-store assertions naming the property never ran.

Before, with the mutation:
```
suspend_integration_test.go:81: expected: 1   actual: 2
```

After, same mutation:
```
suspend_integration_test.go:89: expected: "suspended"   actual: "active"
  Messages: a store suspended individually BEFORE the tenant suspension must stay suspended
```

The count assertion is kept, as corroboration rather than as the tripwire.

## 2. The `default:` branch was unpinned

The table covered 200, 404, 409, 500, 502. The contract is "anything else maps to `ErrUnavailable`", and nothing pinned it. Added 400 and 204 — one error-shaped and one success-shaped non-5xx.

Proved with a **sharper mutation than the issue suggested**: rather than making `default:` return nil outright (which the 5xx cases already catch), it was narrowed to return `ErrUnavailable` only for `>= 500`. The old table cannot detect that at all; the two new cases catch it and nothing else does:

```
--- PASS: .../ok          --- PASS: .../not_found     --- PASS: .../conflict
--- PASS: .../server_error --- PASS: .../bad_gateway
--- FAIL: .../bad_request  --- FAIL: .../no_content
```

## 3. A mutation that fired on a panic, not on the assertion

The mobile tenant-gate test built `authz.NewMiddleware(nil, nil)`. Removing the gate let the request reach `RequireTenantRelation`, which **panicked** on that nil client (`authz/middleware.go:42`) before the 403 assertion ran. So the proof established "removing the gate crashes something", not "the 403 assertion catches it" — and it would evaporate the moment anyone wired a real FGA client in.

The route now has a working terminus: a fake FGA client granting the staff role, and an inert `stores.Repository` stub in place of the zero-value handler. **No assertion was weakened** — the 403 and `tenant_suspended` body checks are unchanged.

After, with the gate removed — no `panic:` anywhere in the output:
```
mobile_routes_tenantgate_test.go:123: expected: 403   actual: 200
  Messages: a suspended tenant must be refused on the mobile route, exactly as on the web admin table
```

`actual: 200` is the point: the un-gated request now reaches the handler cleanly, so the 403 assertion is what discriminates.

## A real leak, caught by the check merged an hour ago

`cmd/testdb-leakcheck` (#401) fired on its first real use:

```
testdb-leakcheck: 1 table(s) hold rows after the run:
  orders (4 rows)
```

Not from anything in this PR — those tests write nothing to the database. Attributed to `seedOrderRowForSync` in `shipments_tracking_sync_test.go`, and proved pre-existing by stashing all changes, truncating, and running that file alone (3 rows left behind).

Root cause is exactly the shape the check's help text warns about: **`orders` has no foreign key to `stores`** — every FK on it is inbound, confirmed against `pg_constraint` — so `TRUNCATE ... CASCADE` on the fixture's `stores` entry never reaches it. Same mechanism as #446's `promo_codes`.

Fixed by adding `orders` to that fixture's table list, **not** by allowlisting it. That is the distinction the check exists to enforce.

## Test plan

Runs used the LAN IP — `marketplace_db` for marketplace-api, `platform_api` for platform-api — with `-tags=integration -p 1 -count=1`, all EXECUTED.

- [x] All three mutations now fail on the **named** assertion; outputs quoted above
- [x] `internal/tenantlifecycle`, `internal/handlers/admin`, and platform-api's `internal/tenant` all green
- [x] `testdb-leakcheck: clean` afterwards
- [x] Both services: `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean
- [x] Diff is **test files only** — 4 files, no production code
