### PR TITLE
fix(platform-api): reject a malformed tenant id on the lifecycle routes with 400, not 500 (#343)

### DIFF
--- a/services/platform-api/internal/tenant/handler.go
+++ b/services/platform-api/internal/tenant/handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 
 	"github.com/mark8ly/platform-api/internal/authz"
 	apperrors "github.com/mark8ly/platform-api/pkg/errors"
@@ -306,6 +307,14 @@ func (h *Handler) unsuspendTenant(c *gin.Context) {
 // returns current state, not an error.
 func (h *Handler) lifecycle(c *gin.Context, op func(context.Context, string) (*SuspendResult, error)) {
 	id := c.Param("id")
+	// A malformed id is a caller error, not a server error. Unvalidated it
+	// reaches Postgres, which raises 22P02 and surfaces as a 500 that pages
+	// someone (#343). marketplace-api's console-facing half already rejects
+	// it with the same code, so the two halves of one operation agree.
+	if _, err := uuid.Parse(id); err != nil {
+		respondError(c, apperrors.BadRequest("invalid_tenant_id", "id must be a UUID"))
+		return
+	}
 	res, err := op(c.Request.Context(), id)
 	if err != nil {
 		respondError(c, err)

--- a/services/platform-api/internal/tenant/suspend_handler_test.go
+++ b/services/platform-api/internal/tenant/suspend_handler_test.go
@@ -18,17 +18,21 @@ const testTenantID = "11111111-1111-1111-1111-111111111111"
 // stubLifecycleRepo returns canned results for Suspend/Unsuspend.
 type stubLifecycleRepo struct {
 	Repository
-	suspend      *SuspendResult
-	suspendErr   error
-	unsuspend    *SuspendResult
-	unsuspendErr error
+	suspend         *SuspendResult
+	suspendErr      error
+	suspendCalled   bool
+	unsuspend       *SuspendResult
+	unsuspendErr    error
+	unsuspendCalled bool
 }
 
 func (s *stubLifecycleRepo) Suspend(_ context.Context, _ string) (*SuspendResult, error) {
+	s.suspendCalled = true
 	return s.suspend, s.suspendErr
 }
 
 func (s *stubLifecycleRepo) Unsuspend(_ context.Context, _ string) (*SuspendResult, error) {
+	s.unsuspendCalled = true
 	return s.unsuspend, s.unsuspendErr
 }
 
@@ -128,4 +132,37 @@ func TestUnsuspendHandler_UnknownTenantIs404(t *testing.T) {
 	})
 	rec := doPost(t, h, "/tenants/"+testTenantID+"/unsuspend")
 	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// A malformed :id is a caller error. Without validation it reaches Postgres,
+// which raises 22P02 (invalid input syntax for type uuid), and that surfaces
+// as a 500 that pages someone. marketplace-api's console-facing handler
+// already rejects it (internal/handlers/platformadmin/tenant_lifecycle.go,
+// uuid.Parse -> 400); the two halves of the same operation must agree.
+//
+// The repository assertion is the point of the test: 400 alone could be
+// produced by the same query failing differently. The id must not reach the
+// database at all.
+func TestSuspendHandler_MalformedIDIs400AndNeverReachesRepo(t *testing.T) {
+	repo := &stubLifecycleRepo{suspend: &SuspendResult{
+		Status: StatusSuspended, StoresAffected: 1, Changed: true,
+	}}
+	rec := doPost(t, newTestHandler(repo), "/tenants/not-a-uuid/suspend")
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.False(t, repo.suspendCalled,
+		"a malformed id must be rejected before the repository sees it")
+	require.Contains(t, rec.Body.String(), `"error":"invalid_tenant_id"`)
+}
+
+func TestUnsuspendHandler_MalformedIDIs400AndNeverReachesRepo(t *testing.T) {
+	repo := &stubLifecycleRepo{unsuspend: &SuspendResult{
+		Status: StatusActive, StoresAffected: 1, Changed: true,
+	}}
+	rec := doPost(t, newTestHandler(repo), "/tenants/not-a-uuid/unsuspend")
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.False(t, repo.unsuspendCalled,
+		"a malformed id must be rejected before the repository sees it")
+	require.Contains(t, rec.Body.String(), `"error":"invalid_tenant_id"`)
 }


### PR DESCRIPTION
Closes #343.

`POST /internal/tenants/:id/suspend` and `/unsuspend` passed `:id` straight to the repository. A malformed id reached Postgres, which raised `22P02 invalid input syntax for type uuid`, and that was wrapped into a **500** — a caller error paging someone.

`lifecycle()` now parses the id as a UUID first and returns `invalid_tenant_id` / 400, matching what marketplace-api's console-facing half already does (`internal/handlers/platformadmin/tenant_lifecycle.go`, `uuid.Parse` → 400). The two halves of the same operation no longer disagree about the same input.

## On the tests

Written first, and they failed with **200**, not 500 — the stub repository accepted `not-a-uuid` without complaint. That is the defect in miniature.

Each test therefore asserts the repository was **never called**, not just the status code. A 400 on its own could be produced by the same query failing a different way; the point is that a malformed id must not reach the database at all.

## Verification

- `go build ./...`, `go vet`, full `go test ./...` green in `services/platform-api`
- Integration tests skipped — no `TEST_DATABASE_URL` in this environment; this change touches no DB path

## Scope

Affects direct callers of the internal `strictInternal` surface only. The console always goes through marketplace-api, which validates first.