### PR TITLE
fix(platformadmin): re-apply local enforcement on a no-op lifecycle call so a retry can repair a failed projection update (#344)

### DIFF
--- a/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle.go
@@ -234,31 +234,54 @@ func (h *TenantLifecycleHandler) handle(
 		return
 	}
 
+	// Local enforcement runs REGARDLESS of res.Changed (#344).
+	//
+	// These two side effects are what make the upstream status real on
+	// this side. They used to run only under `if res.Changed`, which left
+	// no way to repair a failed one: the projection update is
+	// best-effort, so when it fails the request still returns 200 and
+	// changed:true while local enforcement has not been applied. The
+	// operator's only recourse is to retry — but platform-api has already
+	// suspended the tenant, so the retry returns changed:false and, under
+	// the old guard, did nothing at all. Re-enforcement was unreachable
+	// through the API.
+	//
+	// Running them unconditionally is safe because both are idempotent:
+	// SuspendActiveForTenant filters on `status = active` and so matches
+	// no rows on a genuine no-op, and MarkStaleForTenant only backdates
+	// synced_at to force a refetch. A retry therefore costs a cheap
+	// no-op write in the common case and repairs the divergence in the
+	// case this exists for.
+	//
+	// The audit emission below stays under res.Changed: #287's acceptance
+	// is that a no-op writes no audit row, and a retry that re-applies
+	// local state has not changed the tenant's status.
+
+	// #287 fix-round-1: drop the admin gate's cached status for this
+	// tenant so the suspend/unsuspend takes effect on the very next
+	// admin request, instead of lagging behind by up to the gate's
+	// TTL. Best-effort like projectionUpdate below: nil-safe, and its
+	// absence is a degraded-lag, not a failure worth surfacing to the
+	// caller — the upstream write already succeeded.
+	if h.invalidate != nil {
+		h.invalidate.Invalidate(tenantIDStr)
+	}
+
+	if err := projectionUpdate(c.Request.Context(), tenantIDStr); err != nil {
+		// The upstream call already SUCCEEDED. A projection-update
+		// failure must not turn that into an error response — log
+		// loudly and let the response reflect the real outcome. The
+		// local projection will still catch up: suspend's worst case
+		// is a brief window of under-enforcement (same as before this
+		// endpoint existed), and unsuspend never enforces off local
+		// rows without a refresh anyway.
+		if h.logger != nil {
+			h.logger.Error("tenant lifecycle: local projection update failed",
+				"action", action, "tenant_id", tenantIDStr, "err", err)
+		}
+	}
+
 	if res.Changed {
-		// #287 fix-round-1: drop the admin gate's cached status for this
-		// tenant so the suspend/unsuspend takes effect on the very next
-		// admin request, instead of lagging behind by up to the gate's
-		// TTL. Best-effort like projectionUpdate below: nil-safe, and its
-		// absence is a degraded-lag, not a failure worth surfacing to the
-		// caller — the upstream write already succeeded.
-		if h.invalidate != nil {
-			h.invalidate.Invalidate(tenantIDStr)
-		}
-
-		if err := projectionUpdate(c.Request.Context(), tenantIDStr); err != nil {
-			// The upstream call already SUCCEEDED. A projection-update
-			// failure must not turn that into an error response — log
-			// loudly and let the response reflect the real outcome. The
-			// local projection will still catch up: suspend's worst case
-			// is a brief window of under-enforcement (same as before this
-			// endpoint existed), and unsuspend never enforces off local
-			// rows without a refresh anyway.
-			if h.logger != nil {
-				h.logger.Error("tenant lifecycle: local projection update failed",
-					"action", action, "tenant_id", tenantIDStr, "err", err)
-			}
-		}
-
 		tenantUUID, _ := uuid.Parse(tenantIDStr) // already validated above
 		if err := h.emit(c, tenantUUID, audit.Event{
 			Action:       auditAction,

--- a/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_gate_invalidation_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_gate_invalidation_test.go
@@ -116,19 +116,39 @@ func TestUnsuspend_InvalidatesGate_NoTTLWait(t *testing.T) {
 		"unsuspend must invalidate the gate cache so the very next admin request is served, with no TTL wait")
 }
 
-// TestLifecycle_NoopDoesNotInvalidateGate asserts the negative: a call
-// upstream reports as unchanged (Changed: false) must NOT touch the
-// cache, consistent with the audit side effect also being skipped for a
-// no-op.
-func TestLifecycle_NoopDoesNotInvalidateGate(t *testing.T) {
+// TestLifecycle_NoopStillInvalidatesGate replaces an earlier assertion
+// that a no-op must NOT invalidate the cache (#344).
+//
+// That assertion justified itself as "consistent with the audit side
+// effect also being skipped for a no-op". The consistency is superficial
+// and the two are not alike: an audit row RECORDS a change, so skipping
+// it for a no-op is right; cache invalidation ENFORCES a status, and the
+// status is a fact about the tenant whether or not this particular call
+// is what changed it.
+//
+// Read the scenario below and the old expectation is plainly wrong.
+// Upstream is suspended. The gate holds a cached "active". The old test
+// required the admin gate to keep serving that tenant as active — for up
+// to the TTL, five minutes in production — and called that correct. It
+// pinned under-enforcement in place.
+//
+// It also made #344 unfixable: after a failed projection update the only
+// recourse is a retry, and a retry always reports Changed: false, so
+// every repair path was closed.
+//
+// Invalidation is cheap — it drops one cache entry and costs one refetch
+// — so there is no reason to withhold it from the call that is trying to
+// make enforcement true.
+func TestLifecycle_NoopStillInvalidatesGate(t *testing.T) {
 	lookup := &switchableLookup{status: "active"}
 	gate := tenantgate.New(lookup, nil, time.Hour)
 	adminRouter := buildAdminGateRouter(t, gate)
 
 	require.Equal(t, http.StatusOK, doAdminGet(adminRouter).Code)
 
-	// Upstream is now suspended, but this call reports Changed: false (the
-	// tenant was already suspended, say) — the cache must stay untouched.
+	// Upstream is now suspended, but this call reports Changed: false —
+	// the tenant was already suspended, e.g. an operator retrying after a
+	// failed local projection update.
 	lookup.set("suspended")
 	stub := &stubLifecycle{res: &tenantlifecycle.Result{
 		TenantID: testTenant, Status: "suspended", StoresAffected: 0, Changed: false}}
@@ -136,8 +156,9 @@ func TestLifecycle_NoopDoesNotInvalidateGate(t *testing.T) {
 	rec := postLifecycleTenant(t, h, testTenant, "suspend", `{"reason_code":"abuse"}`)
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	require.Equal(t, http.StatusOK, doAdminGet(adminRouter).Code,
-		"a no-op (Changed: false) must not invalidate the gate cache")
+	require.Equal(t, http.StatusForbidden, doAdminGet(adminRouter).Code,
+		"a retry must drop the stale cached status so the suspension is enforced "+
+			"on the very next admin request, rather than lingering for the TTL")
 }
 
 // TestLifecycle_NilInvalidatorDoesNotPanic asserts the handler degrades

--- a/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_reenforce_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/tenant_lifecycle_reenforce_test.go
@@ -1,0 +1,81 @@
+package platformadmin_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/internal/tenantlifecycle"
+)
+
+// #344: a retry must be able to re-apply local enforcement.
+//
+// The projection update is best-effort — when it fails, the upstream
+// write has already succeeded, so the request still returns 200 with
+// changed:true. Local enforcement has NOT been applied.
+//
+// The operator's only recourse is to retry. But platform-api has already
+// suspended the tenant, so the retry comes back changed:false, and when
+// the projection update runs only under `if res.Changed` the retry is a
+// no-op that cannot repair anything. There is no way to force
+// re-enforcement through the API at all.
+//
+// Running the projection update regardless of Changed makes the retry
+// mean something. Both updates are idempotent — SuspendActiveForTenant
+// filters on `status = active`, so on a genuine no-op it matches no rows.
+func TestSuspend_NoOpStillReappliesLocalProjection(t *testing.T) {
+	repo := &fakeLifecycleStoreRepo{}
+	noop := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "suspended", StoresAffected: 0, Changed: false}}
+	h := platformadmin.NewTenantLifecycleHandler(noop, repo, discardAudit, nil, nil)
+
+	rec := postLifecycle(t, h, "suspend", `{"reason_code":"abuse"}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, []string{testTenant}, repo.suspendedTenants,
+		"a retry after a failed projection update must re-apply it, or the operator "+
+			"has no way to force local enforcement")
+	require.Empty(t, repo.staleTenants, "suspend must never mark rows stale")
+}
+
+func TestUnsuspend_NoOpStillMarksProjectionStale(t *testing.T) {
+	repo := &fakeLifecycleStoreRepo{}
+	noop := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "active", StoresAffected: 0, Changed: false}}
+	h := platformadmin.NewTenantLifecycleHandler(noop, repo, discardAudit, nil, nil)
+
+	rec := postLifecycle(t, h, "unsuspend", `{"reason_code":"resolved"}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, []string{testTenant}, repo.staleTenants,
+		"a retry must be able to force the refetch, for the same reason as suspend")
+	require.Empty(t, repo.suspendedTenants, "unsuspend must never call the suspend-projection path")
+}
+
+// countingInvalidator records Invalidate calls. Deliberately a distinct
+// type from the gate used in tenant_lifecycle_gate_invalidation_test.go:
+// that file proves the real Gate drops its cache, this one only needs to
+// know whether the handler dispatched at all.
+type countingInvalidator struct{ tenants []string }
+
+func (c *countingInvalidator) Invalidate(tenantID string) {
+	c.tenants = append(c.tenants, tenantID)
+}
+
+// The gate is what enforces on non-store-scoped admin routes, so a retry
+// that cannot re-invalidate it is as stuck as one that cannot re-apply
+// the projection.
+func TestSuspend_NoOpStillInvalidatesTenantGate(t *testing.T) {
+	inv := &countingInvalidator{}
+	noop := &stubLifecycle{res: &tenantlifecycle.Result{
+		TenantID: testTenant, Status: "suspended", StoresAffected: 0, Changed: false}}
+	h := platformadmin.NewTenantLifecycleHandler(noop, &fakeLifecycleStoreRepo{}, discardAudit, inv, nil)
+
+	rec := postLifecycle(t, h, "suspend", `{"reason_code":"abuse"}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, []string{testTenant}, inv.tenants,
+		"a no-op must still drop the gate's cached status so a retry re-enforces")
+}


### PR DESCRIPTION
Closes #344.

The projection update and the gate invalidation now run regardless of `res.Changed`. The audit emission stays under `res.Changed`.

## The trap this closes

The projection update is best-effort by design: when it fails, the upstream write has already succeeded, so the request returns 200 with `changed: true` while local enforcement has **not** been applied.

The operator's only recourse is to retry — but platform-api has already suspended the tenant, so the retry returns `changed: false` and, under the old guard, did nothing at all. Re-enforcement was unreachable through the API. The endpoint's failure mode had no repair path.

Running both side effects unconditionally is safe because both are idempotent: `SuspendActiveForTenant` filters on `status = active` and matches no rows on a genuine no-op, and `MarkStaleForTenant` only backdates `synced_at` to force a refetch. A retry costs a cheap no-op write in the common case and repairs the divergence in the case this exists for.

## One deliberate behaviour change, and it needs a look

`TestLifecycle_NoopDoesNotInvalidateGate` asserted the opposite — that a no-op must **not** invalidate the gate cache — so this PR replaces it with `TestLifecycle_NoopStillInvalidatesGate`. Flagging it rather than burying it.

The old test justified itself as *"consistent with the audit side effect also being skipped for a no-op"*. That consistency is superficial, and the two side effects are not alike:

- an audit row **records** a change — skipping it for a no-op is right
- cache invalidation **enforces** a status — and the status is a fact about the tenant whether or not this particular call is what changed it

Its own scenario shows the cost. Upstream is suspended; the gate holds a cached `active`; the old test required the admin gate to keep serving that tenant as **active**, for up to the TTL — five minutes in production — and called that correct. It pinned under-enforcement in place, and it was also what made #344 unfixable, since every repair path runs through a `changed: false` retry.

Invalidation drops one cache entry and costs one refetch, so there is no reason to withhold it from the call that is trying to make enforcement true.

## Tests

Three new tests, each written first and watched fail:
- a no-op suspend re-applies `SuspendActiveForTenant`
- a no-op unsuspend re-applies `MarkStaleForTenant`
- a no-op still invalidates the tenant gate

`TestSuspend_AuditsOncePerChangeAndNeverForNoOp` is unchanged and still passes — it is what holds the audit side to the old semantics, and it is the reason the audit emission stayed inside `if res.Changed`.

## Verification

- `go build ./...`, `go vet`, full unit `go test ./...` green in `services/marketplace-api`
- **Integration tests actually run**, not skipped: `-tags=integration -p 1 -count=1` against `postgres://…@192.168.1.110:5432/marketplace_db`. `TestIntegration_Suspend_UpdatesLocalProjectionImmediately` and `TestIntegration_Unsuspend_MarksLocalProjectionStaleNotActive` both pass against real rows.

## Scope note

This closes the repair path, which is what #344 asked for. It does not add the issue's second suggestion — a distinct response signal when the upstream write succeeded but local enforcement did not. That would change the response contract and is worth its own decision; the failure is still logged loudly either way.