### PR TITLE
refactor(platform-api): move the /internal route-to-guard mapping into a testable package so a downgraded guard cannot ship green (#323)

### DIFF
--- a/services/platform-api/cmd/server/internal_wiring_test.go
+++ b/services/platform-api/cmd/server/internal_wiring_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/platform-api/internal/routes"
+)
+
+// routes.MountInternal owns the route-to-guard mapping and is tested
+// directly (#323). What that test cannot see is this file: main.go could
+// leave a field of InternalHandlers unset, which would silently unmount
+// the route rather than move it.
+//
+// So this asserts the literal in main.go populates every declared field.
+// Narrow on purpose — it reads field NAMES only, exactly like
+// marketplace-api's TestPlatformadminRegisterSitesAgree. Two fields given
+// each other's values would still pass; a field quietly dropped would
+// not, and that is the failure that leaves no trace anywhere else.
+func TestMainSetsEveryInternalHandlersField(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, 0)
+	require.NoError(t, err)
+
+	var got []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		sel, ok := lit.Type.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "InternalHandlers" {
+			return true
+		}
+		for _, elt := range lit.Elts {
+			if kv, ok := elt.(*ast.KeyValueExpr); ok {
+				if key, ok := kv.Key.(*ast.Ident); ok {
+					got = append(got, key.Name)
+				}
+			}
+		}
+		return true
+	})
+
+	var want []string
+	rt := reflect.TypeOf(routes.InternalHandlers{})
+	for i := 0; i < rt.NumField(); i++ {
+		want = append(want, rt.Field(i).Name)
+	}
+
+	require.ElementsMatch(t, want, got,
+		"every field of routes.InternalHandlers must be set in main.go — an unset "+
+			"field is a route that silently does not exist in the running service")
+}

--- a/services/platform-api/cmd/server/main.go
+++ b/services/platform-api/cmd/server/main.go
@@ -23,6 +23,7 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 
+	"github.com/gin-gonic/gin"
 	platformapi "github.com/mark8ly/platform-api"
 	"github.com/mark8ly/platform-api/internal/account"
 	"github.com/mark8ly/platform-api/internal/audit"
@@ -34,11 +35,12 @@ import (
 	"github.com/mark8ly/platform-api/internal/invitation"
 	"github.com/mark8ly/platform-api/internal/location"
 	"github.com/mark8ly/platform-api/internal/marketplaceapi"
-	"github.com/mark8ly/platform-api/internal/middleware"
+
 	"github.com/mark8ly/platform-api/internal/notification"
 	"github.com/mark8ly/platform-api/internal/observability"
 	"github.com/mark8ly/platform-api/internal/onboarding"
 	"github.com/mark8ly/platform-api/internal/outbox"
+	"github.com/mark8ly/platform-api/internal/routes"
 	"github.com/mark8ly/platform-api/internal/store"
 	"github.com/mark8ly/platform-api/internal/tenant"
 	testhelper "github.com/mark8ly/platform-api/internal/test"
@@ -339,46 +341,34 @@ func main() {
 	r.Use(otelgin.Middleware(serviceName))
 	v1 := r.Group("/api/v1")
 	// /internal/* is the in-cluster trust surface — admin BFF, auth-bff,
-	// marketplace-api call into here. RequireInternalAuth gates every
-	// route with a constant-time X-Internal-Auth check; an empty
-	// secret no-ops the gate so the binary stays bootable in dev and
-	// during the cutover before the secret is provisioned.
-	internal := r.Group("/internal", middleware.RequireInternalAuth(cfg.InternalAuthSecret))
+	// marketplace-api call into here. The route-to-guard mapping lives in
+	// internal/routes so it can be TESTED (#323): while it was inline
+	// here, moving an estate-wide handler onto the permissive guard left
+	// the build and the whole test suite green, and the downgrade would
+	// have shipped undetected.
+	//
+	// Handlers that also mount on /api/v1 are wrapped so that both halves
+	// stay at their original call sites; MountInternal only decides which
+	// /internal guard each one sits behind.
+	routes.MountInternal(r, cfg.InternalAuthSecret, routes.InternalHandlers{
+		TenantDirectory:     tenantHandler.RegisterDirectory,
+		TenantLifecycle:     tenantHandler.RegisterLifecycle,
+		OnboardingAnalytics: onboardingHandler.RegisterAnalytics,
+		EstateCounts:        estate.NewHandler(estate.NewRepository(conn)).Register,
+		EstateUsers:         estateuser.NewHandler(estateuser.NewRepository(conn)).Register,
+		AccountOperator:     accountHandler.RegisterOperator,
 
-	// The tenant directory (#277) returns EVERY tenant on the platform,
-	// unscoped, so it gets the fail-closed guard rather than the permissive
-	// one above: an unconfigured deploy must refuse, not serve the lot.
-	// Deliberately a different group with different middleware — see
-	// middleware.RequireInternalAuthStrict. The onboarding funnel/sessions
-	// analytics routes (#283) share this guard for the same reason: both
-	// are estate-wide reads with no tenant scoping. The estate counts
-	// endpoint (#282) joins them here too — GET /estate/counts reads
-	// across every tenant and store on the platform, same fail-closed
-	// requirement.
-	strictInternal := r.Group("/internal", middleware.RequireInternalAuthStrict(cfg.InternalAuthSecret))
-	tenantHandler.RegisterDirectory(strictInternal)
-	tenantHandler.RegisterLifecycle(strictInternal)
-	onboardingHandler.RegisterAnalytics(strictInternal)
-	estate.NewHandler(estate.NewRepository(conn)).Register(strictInternal)
-	// Estate-wide staff directory (#278). Strict-internal for the same reason
-	// as the tenant directory above: it returns every staff identity on the
-	// platform.
-	estateuser.NewHandler(estateuser.NewRepository(conn)).Register(strictInternal)
-	accountHandler.RegisterOperator(strictInternal)
+		Tenant:          func(g *gin.RouterGroup) { tenantHandler.Register(v1, g) },
+		Store:           func(g *gin.RouterGroup) { storeHandler.Register(v1, g) },
+		Invitation:      func(g *gin.RouterGroup) { invitationHandler.Register(v1, g) },
+		Auth:            authInternalRegistrar(authHandler),
+		MerchantAccount: merchantAccountRegistrar(merchantAccountRoutes, accountHandler),
+		Notification:    notification.NewHandler(templateLoader, sender, cfg.EmailFrom).Register,
+	})
 
 	locationHandler.Register(v1)
-	tenantHandler.Register(v1, internal)
-	storeHandler.Register(v1, internal)
 	verifHandler.Register(v1)
 	onboardingHandler.Register(v1)
-	invitationHandler.Register(v1, internal)
-	if authHandler != nil {
-		authHandler.Register(internal)
-	}
-	if merchantAccountRoutes {
-		accountHandler.Register(internal)
-	}
-	notification.NewHandler(templateLoader, sender, cfg.EmailFrom).Register(internal)
 
 	// e2e helper routes — only mounted outside production. Gives Playwright
 	// a way to grab the latest magic-link token for an email without
@@ -398,4 +388,27 @@ func main() {
 		log.Error("http server", "err", err)
 		panic(err)
 	}
+}
+
+// authInternalRegistrar returns nil when the auth handler is not
+// configured, preserving main.go's original `if authHandler != nil`
+// guard. A nil Registrar is skipped by routes.MountInternal — the typed
+// nil is deliberate here: returning a non-nil closure that wraps a nil
+// handler would make the skip unreachable and dispatch on a nil receiver
+// (the shape #341 was filed for).
+func authInternalRegistrar(h *auth.Handler) routes.Registrar {
+	if h == nil {
+		return nil
+	}
+	return h.Register
+}
+
+// merchantAccountRegistrar mirrors main.go's `if merchantAccountRoutes`
+// guard: the merchant-facing account routes are mounted only when both
+// FGA and the GIP admin client are available.
+func merchantAccountRegistrar(enabled bool, h *account.Handler) routes.Registrar {
+	if !enabled || h == nil {
+		return nil
+	}
+	return h.Register
 }

--- a/services/platform-api/internal/routes/internal.go
+++ b/services/platform-api/internal/routes/internal.go
@@ -1,0 +1,87 @@
+// Package routes owns platform-api's /internal route mounting.
+//
+// It exists so the route-to-guard mapping is testable (#323). It used to
+// live inline in cmd/server/main.go, where nothing could assert it:
+// moving a handler from the fail-closed group to the permissive one left
+// `go build` and `go test ./...` green, so an estate-wide endpoint could
+// be downgraded to a permissive guard and ship undetected.
+package routes
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/platform-api/internal/middleware"
+)
+
+// Registrar mounts one handler's routes on a group.
+type Registrar func(*gin.RouterGroup)
+
+// InternalHandlers names every registrar mounted under /internal. A nil
+// field is skipped — authHandler and the merchant account routes are
+// conditional on configuration.
+type InternalHandlers struct {
+	TenantDirectory     Registrar
+	TenantLifecycle     Registrar
+	OnboardingAnalytics Registrar
+	EstateCounts        Registrar
+	EstateUsers         Registrar
+	AccountOperator     Registrar
+
+	Tenant          Registrar
+	Store           Registrar
+	Invitation      Registrar
+	Auth            Registrar
+	MerchantAccount Registrar
+	Notification    Registrar
+}
+
+// StrictSlots and PermissiveSlots name which fields go behind which
+// guard. They are the mapping in data form, so a test can assert it.
+func StrictSlots() []string {
+	return []string{
+		"TenantDirectory", "TenantLifecycle", "OnboardingAnalytics",
+		"EstateCounts", "EstateUsers", "AccountOperator",
+	}
+}
+
+func PermissiveSlots() []string {
+	return []string{
+		"Tenant", "Store", "Invitation", "Auth", "MerchantAccount", "Notification",
+	}
+}
+
+// MountInternal mounts both /internal groups.
+//
+// Two groups share the prefix deliberately. The permissive one no-ops on
+// an empty secret, which keeps local dev working and makes the cutover
+// safe; it is right for routes already scoped by something the caller had
+// to know — you need a tenant id to ask for its members.
+//
+// The strict group refuses with 503 on an empty secret instead. Its
+// routes return ESTATE-WIDE data — every tenant (#277), every staff
+// identity (#278), platform-wide counts (#282), the onboarding funnel
+// (#283) — so an unconfigured deploy must refuse rather than serve the
+// lot to anything that reaches the pod.
+//
+// A nil registrar is skipped: authHandler and the merchant account routes
+// are conditional on configuration.
+func MountInternal(r gin.IRouter, secret string, h InternalHandlers) {
+	strict := r.Group("/internal", middleware.RequireInternalAuthStrict(secret))
+	mount(strict,
+		h.TenantDirectory, h.TenantLifecycle, h.OnboardingAnalytics,
+		h.EstateCounts, h.EstateUsers, h.AccountOperator,
+	)
+
+	permissive := r.Group("/internal", middleware.RequireInternalAuth(secret))
+	mount(permissive,
+		h.Tenant, h.Store, h.Invitation, h.Auth, h.MerchantAccount, h.Notification,
+	)
+}
+
+func mount(g *gin.RouterGroup, regs ...Registrar) {
+	for _, reg := range regs {
+		if reg != nil {
+			reg(g)
+		}
+	}
+}

--- a/services/platform-api/internal/routes/internal_test.go
+++ b/services/platform-api/internal/routes/internal_test.go
@@ -1,0 +1,156 @@
+package routes_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/platform-api/internal/routes"
+)
+
+// #323: RequireInternalAuthStrict is unit-tested, but nothing asserted
+// WHICH routes sit behind it. Moving onboardingHandler.RegisterAnalytics
+// from the strict group to the permissive one left `go build` and
+// `go test ./...` entirely green — the downgrade shipped undetected.
+//
+// These tests exercise routes.MountInternal, the function main.go now
+// calls, so the assertion covers the real mapping rather than a
+// reconstruction of it.
+
+const probeSecret = "s3cr3t"
+
+// The expected mapping is declared HERE, not read from the package under
+// test. Deriving it from routes.StrictSlots() would let an all-permissive
+// implementation pass vacuously — the strict loop would simply iterate
+// over nothing. Pinning it in the test means moving a handler between
+// guards forces an edit to this list, which is the change a reviewer
+// needs to see.
+var (
+	wantStrict = []string{
+		"TenantDirectory", "TenantLifecycle", "OnboardingAnalytics",
+		"EstateCounts", "EstateUsers", "AccountOperator",
+	}
+	wantPermissive = []string{
+		"Tenant", "Store", "Invitation", "Auth", "MerchantAccount", "Notification",
+	}
+)
+
+// The package's own declaration must match what this file expects, so the
+// behavioural loops below cannot silently cover the wrong set.
+func TestMountInternal_DeclaredSlotsMatchTheExpectedMapping(t *testing.T) {
+	require.ElementsMatch(t, wantStrict, routes.StrictSlots(),
+		"a handler moved between guards must be an explicit edit here")
+	require.ElementsMatch(t, wantPermissive, routes.PermissiveSlots())
+	require.NotEmpty(t, wantStrict, "a vacuous strict loop would prove nothing")
+}
+
+// probe returns a registrar that mounts GET /<name> and records that it
+// was called, so a test can address each slot's route individually.
+func probe(name string, calls *[]string) routes.Registrar {
+	return func(g *gin.RouterGroup) {
+		*calls = append(*calls, name)
+		g.GET("/"+name, func(c *gin.Context) { c.String(http.StatusOK, name) })
+	}
+}
+
+// fill returns an InternalHandlers with every field set to a probe named
+// after the field, so no slot can be silently skipped.
+func fill(calls *[]string) routes.InternalHandlers {
+	var h routes.InternalHandlers
+	v := reflect.ValueOf(&h).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		name := v.Type().Field(i).Name
+		v.Field(i).Set(reflect.ValueOf(probe(name, calls)))
+	}
+	return h
+}
+
+func get(t *testing.T, r *gin.Engine, path, header string) int {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/internal/"+path, nil)
+	if header != "" {
+		req.Header.Set("X-Internal-Auth", header)
+	}
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec.Code
+}
+
+func newEngine() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	return gin.New()
+}
+
+// The property #277 verified by hand, made permanent: with no secret
+// configured, every estate-wide route refuses rather than serving the lot.
+func TestMountInternal_StrictRoutesRefuseWhenSecretUnset(t *testing.T) {
+	var calls []string
+	r := newEngine()
+	routes.MountInternal(r, "", fill(&calls))
+
+	for _, name := range wantStrict {
+		require.Equal(t, http.StatusServiceUnavailable, get(t, r, name, ""),
+			"%s returns estate-wide data and must be fail-closed: an unconfigured "+
+				"deploy has to refuse, not serve the whole platform", name)
+	}
+}
+
+// The other half of the mapping. A permissive route is already scoped by
+// something the caller had to know, so an empty secret must NOT break it
+// — that is the dev/cutover escape hatch RequireInternalAuth exists for.
+func TestMountInternal_PermissiveRoutesStillServeWhenSecretUnset(t *testing.T) {
+	var calls []string
+	r := newEngine()
+	routes.MountInternal(r, "", fill(&calls))
+
+	for _, name := range wantPermissive {
+		require.Equal(t, http.StatusOK, get(t, r, name, ""),
+			"%s is scoped by its caller; an empty secret must stay a no-op for it", name)
+	}
+}
+
+// Guards against the strict test passing for the wrong reason — a 503 for
+// every request regardless of configuration would satisfy it too.
+func TestMountInternal_BothGroupsServeWithTheRightSecret(t *testing.T) {
+	var calls []string
+	r := newEngine()
+	routes.MountInternal(r, probeSecret, fill(&calls))
+
+	for _, name := range append(append([]string{}, wantStrict...), wantPermissive...) {
+		require.Equal(t, http.StatusOK, get(t, r, name, probeSecret), "%s with the secret", name)
+		require.Equal(t, http.StatusUnauthorized, get(t, r, name, "wrong"), "%s with a bad secret", name)
+	}
+}
+
+// A field added to InternalHandlers and never mounted would be a route
+// silently absent from the running service. Reflection over the struct
+// means adding a field forces a decision about which guard it belongs
+// behind, rather than defaulting to neither.
+func TestMountInternal_MountsEveryDeclaredHandler(t *testing.T) {
+	var calls []string
+	h := fill(&calls)
+	routes.MountInternal(newEngine(), probeSecret, h)
+
+	declared := reflect.TypeOf(h).NumField()
+	require.Len(t, calls, declared,
+		"every field of InternalHandlers must be mounted exactly once")
+
+	slots := append(append([]string{}, wantStrict...), wantPermissive...)
+	require.ElementsMatch(t, slots, calls,
+		"the expected mapping and the fields actually mounted must agree")
+}
+
+// authHandler and the merchant account routes are conditional in main.go,
+// so a nil registrar is a normal configuration, not a bug.
+func TestMountInternal_SkipsNilRegistrars(t *testing.T) {
+	require.NotPanics(t, func() {
+		routes.MountInternal(newEngine(), probeSecret, routes.InternalHandlers{})
+	}, "an unconfigured optional handler must be skipped, not dereferenced")
+}
+
+var _ = fmt.Sprintf


### PR DESCRIPTION
Closes #323.

`RequireInternalAuthStrict` was unit-tested; **which routes sat behind it** was not. The issue demonstrated the consequence: moving `onboardingHandler.RegisterAnalytics` from the strict group to the permissive one left `go build` and `go test ./...` entirely green, so an estate-wide endpoint could be downgraded to a permissive guard and ship undetected.

## What changed

The mapping moves out of `main.go` into `internal/routes`, as the issue proposed — a reconstruction of the wiring inside a test would only have proved the *duplicate* correct, not the thing that would actually be edited.

- `routes.InternalHandlers` names every registrar mounted under `/internal`.
- `routes.MountInternal` decides which guard each named slot sits behind, and `StrictSlots()` / `PermissiveSlots()` expose that mapping as data.
- `main.go` fills in the named fields. Handlers that also mount on `/api/v1` are wrapped so both halves stay where they were; `MountInternal` only decides the `/internal` guard.
- The two conditional handlers keep their guards via `authInternalRegistrar` / `merchantAccountRegistrar`, which return a **nil** `Registrar` when unconfigured. Deliberately nil rather than a closure over a nil handler — that is the shape #341 was filed for, and it would make `MountInternal`'s skip unreachable.

## The assertion the issue asked for, plus the hole I nearly left

Six tests in `internal/routes`, the central one being #277's hand-verified property made permanent: with the secret unset, every strict route answers **503** and every permissive route still serves.

Worth calling out one thing. My first version read the expected mapping from `routes.StrictSlots()`, and it **passed against a deliberately all-permissive implementation** — the strict loop simply iterated over nothing. The expected mapping is now declared in the test file itself, with `TestMountInternal_DeclaredSlotsMatchTheExpectedMapping` asserting the package agrees with it. Moving a handler between guards must now be an explicit edit to a list a reviewer sees.

Supporting tests:
- both groups serve with the right secret and 401 on a wrong one, so the 503 test cannot pass via a blanket refusal
- every field of `InternalHandlers` is mounted exactly once (reflection), so a new field forces a decision instead of defaulting to neither guard
- a nil registrar is skipped, not dereferenced

And in `cmd/server`, `TestMainSetsEveryInternalHandlersField` reads main.go's literal and requires every declared field to be set — an unset field is a route that silently does not exist. Narrow by design, exactly like marketplace-api's `TestPlatformadminRegisterSitesAgree`: it reads field names only.

## Verified by mutation

Both failures were confirmed by hand before the tests were kept:

| mutation | caught by |
|---|---|
| move `OnboardingAnalytics` to the permissive group | `TestMountInternal_DeclaredSlotsMatchTheExpectedMapping` |
| drop `OnboardingAnalytics` from main.go's literal | `TestMainSetsEveryInternalHandlersField` |

The first is the exact mutation from the issue, which previously left everything green.

## Verification

- `go build ./...`, `go vet ./...`, full unit `go test ./...` green in `services/platform-api`.
- **Integration tests were run and are NOT clean** — but the failures are pre-existing, not from this change. `TestIntegration_Complete_TenantAndOutboxCommitAtomically` panics with a nil dereference, and two drainer tests fail. I confirmed this by stashing the change and re-running on clean `main` (`c5cf186a`): identical failures. Possibly local schema drift rather than a real defect; either way it predates this PR and deserves a look on its own.

## Residual gap, stated

Two fields given each other's values in main.go would still pass — the AST test reads names, not values. That is a much more visible error than a silent guard downgrade, and closing it would mean asserting on real handler identities, which needs a DB-backed boot. Not worth it here.