### PR TITLE
fix(tenantgate): evict idle active cache entries so the map stops growing with every tenant ever seen (#345)

### DIFF
--- a/services/marketplace-api/internal/tenantgate/gate.go
+++ b/services/marketplace-api/internal/tenantgate/gate.go
@@ -62,14 +62,20 @@ type cacheEntry struct {
 // stay invisible, on any pod that didn't see the invalidation, for up to
 // ttl. Correctness currently depends on replicas: 1; multi-replica would
 // need a shared cache (e.g. Redis) or a pub/sub invalidation fan-out.
+//
+// Cache growth is bounded by sweepLocked, which evicts idle ACTIVE entries
+// past ttl (#345). Non-active entries are deliberately never evicted — see
+// sweepLocked for why dropping one would be a security regression rather
+// than a memory saving.
 type Gate struct {
 	lookup Lookup
 	logger *slog.Logger
 	ttl    time.Duration
 
-	mu     sync.Mutex
-	cache  map[string]cacheEntry
-	flight singleflight.Group
+	mu        sync.Mutex
+	cache     map[string]cacheEntry
+	lastSweep time.Time
+	flight    singleflight.Group
 }
 
 // New builds a Gate. ttl controls how long a cached ACTIVE status is
@@ -189,10 +195,54 @@ func (g *Gate) refresh(ctx context.Context, tenantID string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	now := time.Now()
 	g.mu.Lock()
-	g.cache[tenantID] = cacheEntry{status: detail.Status, fetchedAt: time.Now()}
+	g.cache[tenantID] = cacheEntry{status: detail.Status, fetchedAt: now}
+	g.sweepLocked(now)
 	g.mu.Unlock()
 	return detail.Status, nil
+}
+
+// sweepLocked drops idle ACTIVE entries, bounding a cache that otherwise
+// grew with the number of distinct tenants ever seen by the process rather
+// than with active load (#345). The caller holds g.mu.
+//
+// # Only active entries, and this is the whole point
+//
+// A non-active entry is authoritative at ANY age — that is what stops a
+// failed refresh decaying a suspension into access. Evicting one would
+// drop the next request into the cold-cache branch of RequireActiveTenant,
+// which fails OPEN, handing a suspended tenant access during exactly the
+// platform-api outage where enforcement matters most. So non-active
+// entries are kept indefinitely. That set is bounded by how many tenants
+// are actually suspended, which is small, and losing one is a security
+// regression rather than a memory saving.
+//
+// # Why dropping an idle active entry changes nothing
+//
+// An active entry past ttl is re-fetched on its next request regardless.
+// If that refresh fails, the request fails open either way: with the entry
+// present via the "cached active, refresh failed" branch, without it via
+// the cold-cache branch. Same outcome, different log line. So this is a
+// memory bound, not a change to the gate's access behaviour — the
+// deliberate absence of an absolute staleness ceiling documented on
+// RequireActiveTenant is untouched.
+//
+// # Throttled
+//
+// Scanning the map on every refresh would be O(entries) per cache miss.
+// Once per ttl is enough: entries only become evictable after ttl, so a
+// tighter interval could not find more of them.
+func (g *Gate) sweepLocked(now time.Time) {
+	if now.Sub(g.lastSweep) < g.ttl {
+		return
+	}
+	g.lastSweep = now
+	for id, entry := range g.cache {
+		if entry.status == statusActive && now.Sub(entry.fetchedAt) >= g.ttl {
+			delete(g.cache, id)
+		}
+	}
 }
 
 // Invalidate drops tenantID's cached status, so a suspend or unsuspend

--- a/services/marketplace-api/internal/tenantgate/gate_eviction_internal_test.go
+++ b/services/marketplace-api/internal/tenantgate/gate_eviction_internal_test.go
@@ -1,0 +1,139 @@
+package tenantgate
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
+)
+
+// #345: the cache had no eviction and no size bound. Entries were added on
+// lookup and removed only by Invalidate, so the map grew with the number of
+// DISTINCT TENANTS EVER SEEN by the process rather than with active load.
+//
+// These tests are in-package deliberately: asserting on the map means
+// reading g.cache directly, and the alternative — an exported accessor
+// that exists only for tests — would put test-only API on a production
+// type.
+
+// evictionLookup answers for any id, so a sweep can be triggered by
+// refreshing a tenant that is not the one under test.
+type evictionLookup struct {
+	status string
+	err    error
+}
+
+func (l *evictionLookup) Get(_ context.Context, id string) (*tenantdirectory.TenantDetail, error) {
+	if l.err != nil {
+		return nil, l.err
+	}
+	return &tenantdirectory.TenantDetail{
+		Tenant: tenantdirectory.Tenant{ID: id, Status: l.status},
+	}, nil
+}
+
+// seed puts an entry in the cache with an explicit age.
+func (g *Gate) seed(id, status string, age time.Duration) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.cache[id] = cacheEntry{status: status, fetchedAt: time.Now().Add(-age)}
+}
+
+func (g *Gate) cached(id string) (cacheEntry, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	e, ok := g.cache[id]
+	return e, ok
+}
+
+func (g *Gate) size() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.cache)
+}
+
+// triggerRefresh drives one request for tenantID through the middleware,
+// which is what causes a refresh (and therefore a sweep).
+func triggerRefresh(g *Gate, tenantID string) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Set("tenant_id", tenantID) })
+	r.GET("/x", g.RequireActiveTenant(), func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/x", nil))
+}
+
+// An idle tenant's active entry is dropped once it is past its TTL. It
+// would have been re-fetched on its next request anyway, so dropping it
+// costs nothing and is what stops the map growing forever.
+func TestGate_SweepDropsIdleActiveEntries(t *testing.T) {
+	g := New(&evictionLookup{status: statusActive}, nil, time.Minute)
+	g.seed("idle-1", statusActive, time.Hour)
+	g.seed("idle-2", statusActive, time.Hour)
+
+	triggerRefresh(g, "newcomer")
+
+	_, ok1 := g.cached("idle-1")
+	_, ok2 := g.cached("idle-2")
+	require.False(t, ok1, "an idle active entry past its TTL must be evicted")
+	require.False(t, ok2, "an idle active entry past its TTL must be evicted")
+	require.Equal(t, 1, g.size(), "only the tenant just refreshed should remain")
+}
+
+// The security-critical half. A suspended entry is authoritative at ANY
+// age — that is what stops a failed refresh decaying a suspension into
+// access. Evicting it would drop the request into the cold-cache branch,
+// which fails OPEN, handing a suspended tenant access during exactly the
+// platform-api outage where enforcement matters most.
+func TestGate_SweepNeverEvictsSuspendedEntriesAtAnyAge(t *testing.T) {
+	g := New(&evictionLookup{status: statusActive}, nil, time.Minute)
+	g.seed("suspended-tenant", "suspended", 30*24*time.Hour)
+
+	triggerRefresh(g, "newcomer")
+
+	entry, ok := g.cached("suspended-tenant")
+	require.True(t, ok,
+		"a suspended entry must survive eviction at any age: dropping it falls "+
+			"through to the cold-cache branch, which fails OPEN")
+	require.Equal(t, "suspended", entry.status)
+}
+
+// The end-to-end statement of the same property: after a sweep, a
+// suspended tenant is still refused even when the lookup is failing.
+func TestGate_SuspendedStaysRefusedAfterSweep(t *testing.T) {
+	g := New(&evictionLookup{status: statusActive}, nil, time.Minute)
+	g.seed("suspended-tenant", "suspended", 30*24*time.Hour)
+	g.seed("idle-active", statusActive, time.Hour)
+
+	triggerRefresh(g, "newcomer") // causes the sweep
+
+	// Now the lookup starts failing, so the cached verdict is all there is.
+	g.lookup = &evictionLookup{err: errors.New("platform-api unreachable")}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Set("tenant_id", "suspended-tenant") })
+	r.GET("/x", g.RequireActiveTenant(), func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	require.Equal(t, http.StatusForbidden, rec.Code,
+		"a suspended tenant must still be refused after a sweep, with the lookup down")
+}
+
+// A tenant in active use must not be evicted out from under itself.
+func TestGate_SweepKeepsFreshActiveEntries(t *testing.T) {
+	g := New(&evictionLookup{status: statusActive}, nil, time.Hour)
+	g.seed("fresh", statusActive, time.Second)
+
+	triggerRefresh(g, "newcomer")
+
+	_, ok := g.cached("fresh")
+	require.True(t, ok, "an entry still inside its TTL must not be evicted")
+}


### PR DESCRIPTION
Closes #345.

`sweepLocked` drops idle **active** entries past `ttl`, called from `refresh` under the lock it already takes, throttled to once per `ttl`.

## Only active entries — this is the whole design

Blanket TTL eviction would be a security regression, not a memory saving.

A non-active entry is authoritative at **any** age; that is what stops a failed refresh decaying a suspension into access. Evict one and the next request falls into `RequireActiveTenant`'s cold-cache branch, which **fails open** — handing a suspended tenant access during exactly the platform-api outage where enforcement matters most.

So non-active entries are kept indefinitely. That set is bounded by how many tenants are actually suspended, which is small.

## Why dropping an idle active entry changes nothing

An active entry past `ttl` is re-fetched on its next request regardless. If that refresh fails, the request fails open either way — with the entry present via the "cached active, refresh failed" branch, without it via the cold-cache branch. Same outcome, different log line.

So this is a memory bound and **not** a change to the gate's access behaviour. `TestGate_StaleActiveWithFailedRefreshStillServes` and the rest of the existing suite pass untouched.

## The staleness ceiling is deliberately NOT included

The issue proposed "evict on TTL expiry plus an absolute ceiling" as a single fix. I have done only the first half, deliberately.

`gate.go` documents the absent ceiling as a considered divergence from `StoreMiddleware`'s 24h `StaleCeil`, on the reasoning that a platform-api outage must not lock out every merchant. Adding a refuse-past-24h ceiling reverses that decision and trades merchant availability for enforcement — a real trade, not a tidy-up, and it deserves its own issue rather than riding along with a memory fix. Note the exposure is narrower than it first looks: a cached suspended verdict is already authoritative at any age, so the gap only affects tenants suspended *during* an outage.

Confirmed with @mahesh-sangawar before writing the code.

## Tests

Four new tests in an in-package file — asserting on the map means reading `g.cache`, and the alternative would be an exported accessor existing only for tests.

- idle active entries past TTL are evicted (this one was RED first; the other three guard existing properties)
- **a suspended entry survives at any age** — seeded 30 days old, still present after a sweep
- end-to-end: after a sweep, with the lookup failing, a suspended tenant is still refused 403
- an entry still inside its TTL is not evicted out from under an active tenant

## Verification

- `go build ./...`, `go vet`, full unit `go test ./...` green in `services/marketplace-api`
- `go test -race -count=2 ./internal/tenantgate/` clean — the sweep runs under the existing mutex
- Integration tests **actually ran** against a real database: `./internal/tenantgate/` and `./internal/handlers/platformadmin/` both pass with `-tags=integration -p 1 -count=1`