### PR TITLE
fix(billing): derive lookup_key in one place and refuse a bootstrap price whose amount changed (#459)

### DIFF
--- a/services/marketplace-api/cmd/billing-bootstrap/bootstrap/bootstrap.go
+++ b/services/marketplace-api/cmd/billing-bootstrap/bootstrap/bootstrap.go
@@ -49,6 +49,14 @@ func Run(ctx context.Context, c *stripec.Client, descriptors []pricing.PriceDesc
 			logger.Info("bootstrap: creating price", "lookup_key", d.LookupKey, "plan", d.Plan, "period", d.Period, "tier", d.Tier)
 			_, err = stripec.CreatePrice(ctx, c, prodID, d)
 		} else if err == nil {
+			if mismatch := stripec.DescribeMismatch(d, existing); mismatch != "" {
+				return fmt.Errorf(
+					"bootstrap: refusing to reuse price %s (%s): %s. "+
+						"lookup_key is stable identity, and a Stripe Price is immutable in amount — "+
+						"changing one means creating a new Price and migrating subscribers, which is "+
+						"a deliberate operation, not a side effect of a bootstrap run (#459)",
+					d.LookupKey, existing.ID, mismatch)
+			}
 			logger.Info("bootstrap: reusing price", "lookup_key", d.LookupKey, "price_id", existing.ID)
 		}
 		if err != nil {

--- a/services/marketplace-api/cmd/billing-bootstrap/bootstrap/bootstrap_test.go
+++ b/services/marketplace-api/cmd/billing-bootstrap/bootstrap/bootstrap_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -111,6 +112,13 @@ func (m *stripeMock) handler() http.Handler {
 				"currency":   v.Get("currency"),
 				"active":     true,
 			}
+			if ua := v.Get("unit_amount"); ua != "" {
+				n, _ := strconv.ParseInt(ua, 10, 64)
+				price["unit_amount"] = n
+			}
+			if tb := v.Get("tax_behavior"); tb != "" {
+				price["tax_behavior"] = tb
+			}
 			m.pricesByLookup[lookup] = price
 			m.priceCreates++
 			_ = json.NewEncoder(w).Encode(price)
@@ -169,4 +177,77 @@ func TestBootstrap_AbortsOnErrorEarly(t *testing.T) {
 
 	err := bootstrap.Run(context.Background(), c, pricing.AllDescriptors(), nil)
 	require.Error(t, err)
+}
+
+// #459: bootstrap was create-only. An existing lookup_key meant "reuse",
+// full stop — the amount was never compared. So a price change whose key
+// does not change was SILENTLY a no-op: bootstrap logged "reusing price"
+// and exited 0, Stripe kept charging the old amount, and the console
+// showed the new one. The operator saw a successful publish.
+//
+// The parity check cannot catch this either: it compares the console's
+// catalog to Stripe, so it is structurally blind to a divergence the
+// console does not know about.
+//
+// Resolved 2026-08-29: lookup_key is STABLE IDENTITY, and bootstrap
+// REFUSES on a differing amount rather than updating. Stripe Prices are
+// immutable in amount, so "change the price" really means create-new-and-
+// migrate-subscribers — something mark8ly has never done and has no
+// runbook for. Refusing turns a silent no-op into a loud stop.
+func TestBootstrap_RefusesWhenExistingPriceAmountDiffers(t *testing.T) {
+	m := newStripeMock()
+	srv := httptest.NewServer(m.handler())
+	defer srv.Close()
+	c := stripec.New("sk_test_x")
+	c.SetBaseURLForTesting(srv.URL)
+
+	descriptors := []pricing.PriceDescriptor{oneDescriptor(t)}
+
+	// First run creates the price at the catalog's amount.
+	require.NoError(t, bootstrap.Run(context.Background(), c, descriptors, nil))
+	require.Equal(t, 1, m.priceCreates)
+
+	// Stripe now holds a DIFFERENT amount under the same lookup_key —
+	// exactly the state a changed catalog amount produces.
+	m.mu.Lock()
+	m.pricesByLookup[descriptors[0].LookupKey]["unit_amount"] = int64(999999)
+	m.mu.Unlock()
+	m.resetCounters()
+
+	err := bootstrap.Run(context.Background(), c, descriptors, nil)
+
+	require.Error(t, err, "a differing amount must not be silently reused")
+	require.Contains(t, err.Error(), descriptors[0].LookupKey,
+		"the error must name the key so an operator knows which price to look at")
+	require.Contains(t, err.Error(), "999999", "the error must show what Stripe holds")
+	require.Equal(t, 0, m.priceCreates,
+		"refusing means creating nothing — not quietly creating a second price")
+}
+
+// The other half: an unchanged amount must still be a clean no-op, or
+// every re-run of a correct bootstrap would now fail.
+func TestBootstrap_ReusesWhenAmountMatches(t *testing.T) {
+	m := newStripeMock()
+	srv := httptest.NewServer(m.handler())
+	defer srv.Close()
+	c := stripec.New("sk_test_x")
+	c.SetBaseURLForTesting(srv.URL)
+
+	descriptors := []pricing.PriceDescriptor{oneDescriptor(t)}
+
+	require.NoError(t, bootstrap.Run(context.Background(), c, descriptors, nil))
+	m.resetCounters()
+
+	require.NoError(t, bootstrap.Run(context.Background(), c, descriptors, nil),
+		"an unchanged catalog must remain idempotent")
+	require.Equal(t, 0, m.priceCreates)
+}
+
+// oneDescriptor returns a single real catalog descriptor, so the test runs
+// against the shape bootstrap actually receives rather than a fabricated one.
+func oneDescriptor(t *testing.T) pricing.PriceDescriptor {
+	t.Helper()
+	all := pricing.AllDescriptors()
+	require.NotEmpty(t, all)
+	return all[0]
 }

--- a/services/marketplace-api/internal/billing/pricing/catalog.go
+++ b/services/marketplace-api/internal/billing/pricing/catalog.go
@@ -392,6 +392,32 @@ func AllDescriptors() []PriceDescriptor {
 
 // MustGetDescriptor returns the PriceDescriptor for (plan, period, tier). Panics on miss.
 // For TierPPP with multiple currencies, returns the first match — prefer direct map access.
+// LookupKeyFor returns the canonical Stripe lookup_key for one price, and
+// is the ONLY way anything outside this package should obtain one (#459).
+//
+// It exists because MustGetDescriptor keys on (plan, period, tier) alone,
+// which is ambiguous for TierPPP: PPP descriptors are one-per-currency, so
+// that lookup returns whichever happens to sort first. Callers worked
+// around this by re-deriving the key with their own fmt.Sprintf, putting a
+// second copy of the format in another package with nothing enforcing
+// agreement. Change the format here and the copy kept writing the old
+// string: no compile error, no failing test, prices silently missed.
+//
+// currency is ignored for TierDeveloped (one Price object carries all
+// currency_options) and required for TierPPP.
+func LookupKeyFor(p Plan, period Period, tier Tier, currency string) (string, bool) {
+	for _, d := range allDescriptors {
+		if d.Plan != p || d.Period != period || d.Tier != tier {
+			continue
+		}
+		if tier == TierPPP && d.Currency != currency {
+			continue
+		}
+		return d.LookupKey, true
+	}
+	return "", false
+}
+
 func MustGetDescriptor(p Plan, period Period, tier Tier) PriceDescriptor {
 	for _, d := range allDescriptors {
 		if d.Plan == p && d.Period == period && d.Tier == tier {

--- a/services/marketplace-api/internal/billing/stripe/describe_mismatch_test.go
+++ b/services/marketplace-api/internal/billing/stripe/describe_mismatch_test.go
@@ -1,0 +1,62 @@
+package stripe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+)
+
+// The zero-decimal trap, which is why DescribeMismatch lives beside
+// stripeUnitAmount rather than in the bootstrap package (#459).
+//
+// The catalog stores zero-decimal currencies pre-multiplied by 100 and the
+// conversion is applied on the way into Stripe. A comparison written
+// anywhere else has to re-implement that conversion — and a first draft of
+// this check, written in the bootstrap package, did not: it compared the
+// raw catalog field and declared every VND price divergent by a factor of
+// 100, which would have refused every bootstrap run outright.
+func TestDescribeMismatch_ZeroDecimalCurrencyIsNotAFalsePositive(t *testing.T) {
+	var vnd *pricing.PriceDescriptor
+	for _, d := range pricing.AllDescriptors() {
+		if d.Baseline.Currency == "vnd" {
+			cp := d
+			vnd = &cp
+			break
+		}
+	}
+	require.NotNil(t, vnd, "expected a VND descriptor in the catalog")
+
+	// What bootstrap actually wrote to Stripe for this descriptor.
+	stored := &Price{
+		UnitAmount:  stripeUnitAmount(vnd.Baseline.Currency, vnd.Baseline.UnitAmountMinor),
+		Currency:    vnd.Baseline.Currency,
+		TaxBehavior: vnd.Baseline.TaxBehavior,
+	}
+	require.Equal(t, vnd.Baseline.UnitAmountMinor/100, stored.UnitAmount,
+		"fixture check: VND must actually be divided, or this test proves nothing")
+
+	require.Empty(t, DescribeMismatch(*vnd, stored),
+		"a correctly bootstrapped zero-decimal price must not read as divergent")
+}
+
+// The case the refusal exists for.
+func TestDescribeMismatch_ReportsAChangedAmount(t *testing.T) {
+	d := pricing.AllDescriptors()[0]
+	stored := &Price{
+		UnitAmount:  stripeUnitAmount(d.Baseline.Currency, d.Baseline.UnitAmountMinor) + 500,
+		Currency:    d.Baseline.Currency,
+		TaxBehavior: d.Baseline.TaxBehavior,
+	}
+
+	got := DescribeMismatch(d, stored)
+	require.NotEmpty(t, got, "a changed amount must be reported, not silently reused")
+	require.Contains(t, got, "unit_amount")
+}
+
+// A nil existing price means "not found", which is the create path, not a
+// divergence.
+func TestDescribeMismatch_NilExistingIsNotADivergence(t *testing.T) {
+	require.Empty(t, DescribeMismatch(pricing.AllDescriptors()[0], nil))
+}

--- a/services/marketplace-api/internal/billing/stripe/lookup_key_guard_test.go
+++ b/services/marketplace-api/internal/billing/stripe/lookup_key_guard_test.go
@@ -1,0 +1,54 @@
+package stripe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// #459: the lookup_key format lived in TWO packages. catalog.go derived it
+// canonically; lookupKeyFor here re-derived it with its own fmt.Sprintf,
+// having called MustGetDescriptor purely to validate and then thrown the
+// descriptor away with descriptor.LookupKey sitting unused.
+//
+// Nothing compared the two. Change the catalog to _v2 and this path keeps
+// writing _v1, pointing the subscription UPDATE path at prices that are
+// stale or absent — no compile error, no failing test, and it rots longest
+// in the unattended downgrade cron.
+//
+// This is the guard the issue asked for. It walks the WHOLE catalog rather
+// than sampling, so a divergence cannot hide in a plan or currency nobody
+// thought to spot-check.
+func TestLookupKeyFor_AgreesWithEveryCatalogDescriptor(t *testing.T) {
+	descriptors := pricing.AllDescriptors()
+	require.NotEmpty(t, descriptors, "a vacuous loop would prove nothing")
+
+	var checked int
+	for _, d := range descriptors {
+		var tier subscription.PriceTier
+		switch d.Tier {
+		case pricing.TierDeveloped:
+			tier = subscription.PriceTierDeveloped
+		case pricing.TierPPP:
+			tier = subscription.PriceTierPPP
+		default:
+			t.Fatalf("unknown tier %q in catalog — this test must be taught about it", d.Tier)
+		}
+
+		got, err := lookupKeyFor(
+			subscription.SubscriptionPlan(d.Plan),
+			subscription.SubscriptionPeriod(d.Period),
+			d.Currency,
+			tier,
+		)
+		require.NoError(t, err, "descriptor %s must be resolvable from the subscription layer", d.LookupKey)
+		require.Equal(t, d.LookupKey, got,
+			"the subscription path must return the catalog's own LookupKey, not a "+
+				"second derivation of the format — see #459")
+		checked++
+	}
+	require.Equal(t, len(descriptors), checked)
+}

--- a/services/marketplace-api/internal/billing/stripe/price.go
+++ b/services/marketplace-api/internal/billing/stripe/price.go
@@ -2,6 +2,7 @@ package stripe
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	sdk "github.com/stripe/stripe-go/v82"
@@ -28,6 +29,43 @@ func stripeUnitAmount(currency string, catalogMinor int64) int64 {
 		return catalogMinor / 100
 	}
 	return catalogMinor
+}
+
+// DescribeMismatch reports how an existing Stripe Price disagrees with the
+// descriptor claiming the same lookup_key, or "" when they agree.
+//
+// It lives HERE, beside stripeUnitAmount, deliberately. The catalog stores
+// zero-decimal currencies pre-multiplied by 100 and that conversion is
+// applied on the way into Stripe, so a comparison written anywhere else
+// would have to re-implement it — which is the exact second-derivation
+// mistake #459 exists to remove. Keeping the check next to the conversion
+// means the two cannot drift.
+//
+// # Known limit: currency_options are not compared
+//
+// A developed-tier Price carries currency_options for seven currencies, and
+// Stripe does not return them unless the read expands them — which
+// FindPriceByLookupKey does not do and Price does not map. A change confined
+// to a NON-baseline currency is therefore still undetected. That is a much
+// narrower hole than the one this closes; it is stated so it is not
+// mistaken for covered.
+func DescribeMismatch(d pricing.PriceDescriptor, existing *Price) string {
+	if existing == nil {
+		return ""
+	}
+	want := stripeUnitAmount(d.Baseline.Currency, d.Baseline.UnitAmountMinor)
+	if existing.UnitAmount != want {
+		return fmt.Sprintf("catalog says unit_amount=%d, Stripe holds %d", want, existing.UnitAmount)
+	}
+	if !strings.EqualFold(existing.Currency, d.Baseline.Currency) {
+		return fmt.Sprintf("catalog says currency=%q, Stripe holds %q", d.Baseline.Currency, existing.Currency)
+	}
+	// An empty TaxBehavior in the catalog means "Stripe's default", which
+	// Stripe reports back as "unspecified" — not a divergence.
+	if d.Baseline.TaxBehavior != "" && !strings.EqualFold(existing.TaxBehavior, d.Baseline.TaxBehavior) {
+		return fmt.Sprintf("catalog says tax_behavior=%q, Stripe holds %q", d.Baseline.TaxBehavior, existing.TaxBehavior)
+	}
+	return ""
 }
 
 // Price represents a Stripe Price object (fields used by billing-bootstrap).

--- a/services/marketplace-api/internal/billing/stripe/update.go
+++ b/services/marketplace-api/internal/billing/stripe/update.go
@@ -139,9 +139,20 @@ func PriceIDFor(
 	return p.ID, nil
 }
 
-// lookupKeyFor derives the Stripe price lookup key from subscription-layer types.
-// It mirrors the catalog key format without importing the full descriptor (which
-// would require a currency argument that MustGetDescriptor does not accept for PPP).
+// lookupKeyFor resolves the Stripe price lookup key for subscription-layer
+// types by ASKING THE CATALOG for it (#459).
+//
+// It deliberately does not build the key itself. It used to: it called
+// MustGetDescriptor only to validate the descriptor existed, discarded it,
+// and rebuilt the string with its own fmt.Sprintf — leaving the format
+// literal in two packages with nothing checking they agreed. A change to
+// the catalog format would have left this path writing the old key,
+// pointing subscription updates at prices that are stale or absent, and it
+// would have rotted longest in the unattended downgrade cron.
+//
+// pricing.LookupKeyFor takes the currency that MustGetDescriptor could not,
+// which was the stated reason for the second copy.
+// TestLookupKeyFor_AgreesWithEveryCatalogDescriptor holds the invariant.
 func lookupKeyFor(
 	plan subscription.SubscriptionPlan,
 	period subscription.SubscriptionPeriod,
@@ -153,15 +164,17 @@ func lookupKeyFor(
 
 	switch tier {
 	case subscription.PriceTierDeveloped:
-		// Validate (plan, period) exist in the catalog.
-		pricing.MustGetDescriptor(p, per, pricing.TierDeveloped)
-		return fmt.Sprintf("mark8ly_%s_%s_developed_v1", p, per), nil
+		key, ok := pricing.LookupKeyFor(p, per, pricing.TierDeveloped, currency)
+		if !ok {
+			return "", fmt.Errorf("stripe: no developed price for plan=%s period=%s", plan, period)
+		}
+		return key, nil
 	case subscription.PriceTierPPP:
-		// Validate the (plan, period, currency) combination exists in the PPP catalog.
-		if _, ok := pricing.LookupPPPOption(p, per, currency); !ok {
+		key, ok := pricing.LookupKeyFor(p, per, pricing.TierPPP, currency)
+		if !ok {
 			return "", fmt.Errorf("stripe: no PPP price for plan=%s period=%s currency=%s", plan, period, currency)
 		}
-		return fmt.Sprintf("mark8ly_%s_%s_ppp_%s_v1", p, per, currency), nil
+		return key, nil
 	default:
 		return "", fmt.Errorf("stripe: unknown price tier %q", tier)
 	}


### PR DESCRIPTION
Closes #459. This gates the live arc — #303, #366 and #371 should not proceed while a published price change can be a silent no-op.

## The decision this issue asked for

**`lookup_key` is STABLE IDENTITY, and bootstrap REFUSES on a differing amount.** Confirmed with @mahesh-sangawar before any code was written.

A Stripe Price is immutable in amount, so "change the price" really means create-a-new-Price-and-migrate-subscribers — something mark8ly has never done and has no runbook for. Refusing turns a silent no-op into a loud stop and leaves that migration a deliberate act rather than a side effect of a bootstrap run.

## 1. One derivation

`pricing.LookupKeyFor(plan, period, tier, currency)` is now the only way to obtain a key. `update.go` calls it instead of rebuilding the string.

It takes the currency argument whose absence was the stated reason for the second copy: `MustGetDescriptor` keys on `(plan, period, tier)` alone, which is ambiguous for `TierPPP` because PPP descriptors are one-per-currency, so it returns whichever sorts first. That is a reason to fix the signature, not to duplicate the format — as the issue argued.

`grep` for the format literal now returns `catalog.go` and nothing else.

## 2. The guard test

`TestLookupKeyFor_AgreesWithEveryCatalogDescriptor` walks the **whole** catalog rather than sampling, so a divergence cannot hide in a plan or currency nobody thought to spot-check.

It passes today, as a guard should — the two copies currently agree. So I verified it by mutation: changing the catalog's format to `_v2` makes it fail with `expected _v2, actual _v1`, which is precisely the silent breakage described in the issue.

## 3. Bootstrap refuses

`stripec.DescribeMismatch` compares the existing Price against the descriptor; a divergence returns an error naming the key, the price id and both amounts, and nothing is created.

### Where that check lives, and why — the interesting part

It sits in the `stripe` package beside `stripeUnitAmount`, not in `bootstrap`. That was not the first design, and the existing suite is what corrected it.

My first version lived in `bootstrap` and compared `d.Baseline.UnitAmountMinor` directly. `TestBootstrap_SecondRunIsNoop` failed immediately:

```
catalog says unit_amount=1978800000, Stripe holds 19788000
```

The catalog stores zero-decimal currencies (VND) pre-multiplied by 100, and the conversion is applied on the way into Stripe. A comparison written outside that package has to re-implement the conversion — **which is the exact second-derivation mistake this whole issue exists to remove.** Putting the check next to the conversion means the two cannot drift, and `TestDescribeMismatch_ZeroDecimalCurrencyIsNotAFalsePositive` now pins it.

Had that existing test not been there, this PR would have shipped a bootstrap that refused every run outright.

## Known limit, stated rather than implied

**`currency_options` are not compared.** A developed-tier Price carries options for seven currencies, and Stripe does not return them unless the read expands them — which `FindPriceByLookupKey` does not do and `Price` does not map. A change confined to a non-baseline currency is therefore still undetected.

That is a much narrower hole than the one this closes (baseline amount, currency, tax_behavior are all now checked). Closing it needs an expanded read plus a mapped field. Documented at `DescribeMismatch` so it is not mistaken for covered.

## Verification

- `go build ./...`, `go vet`, full unit `go test ./...` green in `services/marketplace-api`
- Integration tests **actually ran** against a real database: `./internal/billing/...` and `./cmd/billing-bootstrap/...` clean with `-tags=integration -p 1 -count=1`
- Both new behaviours verified by mutation before the tests were kept