### PR TITLE
feat(billing): run the console plan catalog alongside the compiled one and log differences (#304)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/catalog_parity.go
+++ b/services/marketplace-api/cmd/marketplace-api/catalog_parity.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/consolecatalog"
+	"github.com/mark8ly/marketplace-api/pkg/config"
+)
+
+// checkTimeout bounds one comparison's network work. Generous, because
+// nothing waits on it — but bounded, so a hung console cannot pin a
+// goroutine indefinitely.
+const checkTimeout = 30 * time.Second
+
+// startCatalogParityRun launches the console/compiled catalog comparison
+// (#304, #392), or does nothing when unconfigured.
+//
+// # It decides nothing
+//
+// Prices continue to come from internal/billing/pricing. This only reads the
+// console's published catalog, compares it, and logs. The cutover is a
+// separate, deliberate change gated on this reporting durably zero — the
+// same evidence pattern the console's own parity check established.
+//
+// # Why a ticker and not a request hook
+//
+// BACKLOG §P: nothing on the request path of a customer payment may depend
+// on the console being reachable. A comparison driven by requests would put
+// the console one bad deploy away from the payment path even when cached.
+// On its own ticker it cannot, whatever it does.
+//
+// # Unconfigured is a supported state, not a degraded one
+//
+// Absent credentials mean no goroutine, no reads, and behaviour identical to
+// before this existed. That is deliberate: it makes enabling the parallel
+// run a config change that can be reverted by removing config, with no code
+// path that behaves differently once it is off.
+func startCatalogParityRun(cfg *config.Config, log *slog.Logger) {
+	cc := consolecatalog.Config{
+		CatalogURL:   cfg.ConsoleCatalogURL,
+		TokenURL:     cfg.ConsoleCatalogTokenURL,
+		ClientID:     cfg.ConsoleCatalogClientID,
+		ClientSecret: cfg.ConsoleCatalogClientSecret,
+		Scope:        cfg.ConsoleCatalogScope,
+		Mode:         cfg.ConsoleCatalogMode,
+	}
+	if !cc.Configured() {
+		log.Info("consolecatalog: parallel run disabled (no console credentials); " +
+			"prices come from the compiled catalog, as before")
+		return
+	}
+
+	interval := cfg.ConsoleCatalogInterval
+	if interval <= 0 {
+		interval = 15 * time.Minute
+	}
+
+	monitor := consolecatalog.NewMonitor(consolecatalog.NewClient(cc, log), interval, log)
+	log.Info("consolecatalog: parallel run enabled",
+		"mode", cc.Mode, "interval", interval.String())
+
+	go func() {
+		// One check immediately, so a deploy produces evidence without
+		// waiting out the first interval.
+		runOneCheck(monitor, log)
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for range t.C {
+			runOneCheck(monitor, log)
+		}
+	}()
+}
+
+func runOneCheck(m *consolecatalog.Monitor, log *slog.Logger) {
+	ctx, cancel := context.WithTimeout(context.Background(), checkTimeout)
+	defer cancel()
+	// The Monitor logs its own outcome; the result is ignored here precisely
+	// because nothing in this process is allowed to act on it yet.
+	_ = m.Check(ctx)
+}

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -917,6 +917,18 @@ func main() {
 		} else {
 			log.Warn("STRIPE_BILLING_SECRET_KEY not set — subscription checkout/portal will fail")
 		}
+		// #304 / #392 — the plan-catalog parallel run.
+		//
+		// Reads the console's published catalog and compares it against the one
+		// compiled into internal/billing/pricing, logging differences. It
+		// DECIDES NOTHING: prices still come from the compiled catalog. The
+		// cutover is a separate change, gated on this reporting durably zero.
+		//
+		// Runs on its own ticker rather than on any request path, so a slow or
+		// unreachable console cannot touch a customer payment — BACKLOG §P's
+		// invariant. Unconfigured, nothing is started at all.
+		startCatalogParityRun(cfg, log)
+
 		subscriptionSvc := subscription.NewService(subscription.ServiceConfig{
 			DB:     conn,
 			Repo:   subscriptionRepo,

--- a/services/marketplace-api/internal/billing/consolecatalog/catalog.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/catalog.go
@@ -1,0 +1,58 @@
+// Package consolecatalog reads the plan catalog from the Tesserix console
+// and compares it against the catalog compiled into
+// internal/billing/pricing (#304, #392).
+//
+// # Why this exists
+//
+// The console is becoming the single place a price is maintained. Until
+// marketplace-api reads from it, a price changed in the console updates
+// Stripe while this service keeps serving the hardcoded Go amount — a
+// divergence on the SERVING side that the console's parity check is
+// structurally blind to, because that check compares the console's catalog
+// to Stripe and both of those would be correct.
+//
+// # The invariant that shapes every decision here
+//
+// BACKLOG §P: nothing on the request path of a customer payment may depend
+// on the console being reachable. So the read is cached with a generous TTL
+// (this data changes a few times a year), fails open to last-known, and
+// falls back to the compiled catalog on a cold start — a fresh pod during a
+// console outage must not itself be the outage. A cache that fails open is
+// not a nicety; it is the entire reason reading the console at all is
+// acceptable.
+//
+// # This package changes no behaviour yet
+//
+// Slice one runs both sources and logs their differences. Prices continue
+// to come from the compiled catalog. The cutover happens separately, once
+// the difference count is durably zero — the same evidence pattern the
+// console's parity check established.
+package consolecatalog
+
+import "time"
+
+// Catalog is the console's published response. The shape is a contract
+// owned by the console (tesserix-home#427): additive changes only, and a
+// rename or type change belongs behind /api/v2.
+type Catalog struct {
+	Mode        string    `json:"mode"`
+	RevisionID  string    `json:"revision_id"`
+	PublishedAt time.Time `json:"published_at"`
+	Prices      []Price   `json:"prices"`
+}
+
+// Price is one (lookup_key, currency) amount.
+//
+// Note the console returns one row PER CURRENCY, while the compiled catalog
+// models a developed-tier price as one descriptor carrying an Options map of
+// seven currencies. 42 lookup keys become 78 rows. Diff flattens both sides
+// to the same row shape so the two are comparable at all.
+type Price struct {
+	LookupKey       string `json:"lookup_key"`
+	Plan            string `json:"plan"`
+	Period          string `json:"period"`
+	Tier            string `json:"tier"`
+	Currency        string `json:"currency"`
+	UnitAmountMinor int64  `json:"unit_amount_minor"`
+	TaxBehavior     string `json:"tax_behavior"`
+}

--- a/services/marketplace-api/internal/billing/consolecatalog/client.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/client.go
@@ -1,0 +1,194 @@
+package consolecatalog
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ErrUnavailable signals the console could not be reached or answered 5xx.
+// Callers must never treat it as an empty catalog: "we could not ask" and
+// "there are no prices" are different answers, and conflating them would
+// leave this service pricing nothing at all.
+var ErrUnavailable = errors.New("consolecatalog: console unavailable")
+
+// ErrNotPublished signals the mode has never been published (404).
+//
+// The console returns 404 rather than 200 with an empty list precisely so
+// this case cannot be mistaken for a legitimate priced state — see the
+// route's own reasoning in tesserix-home#427.
+var ErrNotPublished = errors.New("consolecatalog: mode has never been published")
+
+// maxBody caps what we will read from the console.
+const maxBody = 4 << 20
+
+// tokenSkew renews a token this long before it actually expires, so a fetch
+// cannot lose a race with expiry mid-flight.
+const tokenSkew = 60 * time.Second
+
+// Config is everything needed to read one mode's catalog.
+type Config struct {
+	CatalogURL   string
+	TokenURL     string
+	ClientID     string
+	ClientSecret string
+	// Scope must include both the project-audience scope and the roles
+	// scope. Both are load-bearing: the first puts the project in the
+	// token's `aud` (the audience check is what proves the token was minted
+	// for this route), the second makes the token carry the roles claim
+	// without which it verifies but holds no capability.
+	Scope string
+	Mode  string
+}
+
+// Configured reports whether enough is set to attempt a read. An
+// unconfigured client is a supported state — the caller falls back to the
+// compiled catalog — so this is a question, not a validation error.
+func (c Config) Configured() bool {
+	return c.CatalogURL != "" && c.TokenURL != "" && c.ClientID != "" && c.ClientSecret != ""
+}
+
+// Client reads one mode's catalog from the console.
+//
+// It holds the last successful response and its ETag so a 304 can be
+// answered from memory. That retention is not an optimisation: a 304 has no
+// body, and returning an empty catalog for one would be the worst possible
+// failure this package could have.
+type Client struct {
+	cfg    Config
+	http   *http.Client
+	logger *slog.Logger
+
+	mu        sync.Mutex
+	token     string
+	tokenExp  time.Time
+	etag      string
+	lastGood  Catalog
+	haveCatal bool
+}
+
+func NewClient(cfg Config, logger *slog.Logger) *Client {
+	return &Client{
+		cfg:    cfg,
+		http:   &http.Client{Timeout: 10 * time.Second},
+		logger: logger,
+	}
+}
+
+// Fetch returns the console's current catalog for the configured mode.
+//
+// It returns an error rather than degrading: how to degrade is the cache
+// layer's decision, and a client that hid failures would make the fail-open
+// behaviour untestable and invisible in logs.
+func (c *Client) Fetch(ctx context.Context) (Catalog, error) {
+	tok, err := c.accessToken(ctx)
+	if err != nil {
+		return Catalog{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.cfg.CatalogURL+"?mode="+url.QueryEscape(c.cfg.Mode), nil)
+	if err != nil {
+		return Catalog{}, fmt.Errorf("consolecatalog: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	c.mu.Lock()
+	etag, lastGood, have := c.etag, c.lastGood, c.haveCatal
+	c.mu.Unlock()
+	if etag != "" && have {
+		req.Header.Set("If-None-Match", etag)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return Catalog{}, fmt.Errorf("%w: %v", ErrUnavailable, err)
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	switch {
+	case resp.StatusCode == http.StatusNotModified:
+		if !have {
+			// A 304 without a retained body should be impossible — we only
+			// send If-None-Match when we hold one — but returning an empty
+			// catalog here would be silent mispricing, so refuse instead.
+			return Catalog{}, fmt.Errorf("%w: 304 with no retained catalog", ErrUnavailable)
+		}
+		return lastGood, nil
+	case resp.StatusCode == http.StatusNotFound:
+		return Catalog{}, ErrNotPublished
+	case resp.StatusCode != http.StatusOK:
+		return Catalog{}, fmt.Errorf("%w: status %d", ErrUnavailable, resp.StatusCode)
+	}
+
+	var out Catalog
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxBody)).Decode(&out); err != nil {
+		return Catalog{}, fmt.Errorf("consolecatalog: decode: %w", err)
+	}
+	if len(out.Prices) == 0 {
+		// The console answers 404 for an unpublished mode, so a 200 with no
+		// prices is a contract violation rather than a state to cache.
+		return Catalog{}, fmt.Errorf("%w: 200 with an empty price list", ErrUnavailable)
+	}
+
+	c.mu.Lock()
+	c.etag = resp.Header.Get("ETag")
+	c.lastGood, c.haveCatal = out, true
+	c.mu.Unlock()
+	return out, nil
+}
+
+func (c *Client) accessToken(ctx context.Context) (string, error) {
+	c.mu.Lock()
+	if c.token != "" && time.Now().Before(c.tokenExp.Add(-tokenSkew)) {
+		tok := c.token
+		c.mu.Unlock()
+		return tok, nil
+	}
+	c.mu.Unlock()
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_id", c.cfg.ClientID)
+	form.Set("client_secret", c.cfg.ClientSecret)
+	form.Set("scope", c.cfg.Scope)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("consolecatalog: build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("%w: token: %v", ErrUnavailable, err)
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%w: token status %d", ErrUnavailable, resp.StatusCode)
+	}
+
+	var body struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxBody)).Decode(&body); err != nil {
+		return "", fmt.Errorf("consolecatalog: decode token: %w", err)
+	}
+	if body.AccessToken == "" {
+		return "", fmt.Errorf("%w: token response carried no access_token", ErrUnavailable)
+	}
+
+	c.mu.Lock()
+	c.token = body.AccessToken
+	c.tokenExp = time.Now().Add(time.Duration(body.ExpiresIn) * time.Second)
+	c.mu.Unlock()
+	return body.AccessToken, nil
+}

--- a/services/marketplace-api/internal/billing/consolecatalog/client_test.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/client_test.go
@@ -1,0 +1,138 @@
+package consolecatalog_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/consolecatalog"
+)
+
+// fakeConsole serves a token endpoint and a catalog endpoint, counting both
+// so the tests can assert what was and was not called.
+type fakeConsole struct {
+	tokenCalls   int32
+	catalogCalls int32
+	etag         string
+	body         consolecatalog.Catalog
+	catalogState func(w http.ResponseWriter, r *http.Request) bool // return true if handled
+}
+
+func (f *fakeConsole) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth/v2/token", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&f.tokenCalls, 1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "tok", "token_type": "Bearer", "expires_in": 3600,
+		})
+	})
+	mux.HandleFunc("/api/v1/plan-catalog", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&f.catalogCalls, 1)
+		if f.catalogState != nil && f.catalogState(w, r) {
+			return
+		}
+		if r.Header.Get("If-None-Match") == f.etag && f.etag != "" {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", f.etag)
+		_ = json.NewEncoder(w).Encode(f.body)
+	})
+	return mux
+}
+
+func newFake(t *testing.T) (*fakeConsole, *consolecatalog.Client) {
+	t.Helper()
+	f := &fakeConsole{
+		etag: `"rev-1"`,
+		body: consolecatalog.Catalog{Mode: "test", RevisionID: "rev-1", Prices: []consolecatalog.Price{
+			{LookupKey: "k", Currency: "usd", UnitAmountMinor: 1900, Tier: "developed"},
+		}},
+	}
+	srv := httptest.NewServer(f.handler())
+	t.Cleanup(srv.Close)
+	c := consolecatalog.NewClient(consolecatalog.Config{
+		CatalogURL: srv.URL + "/api/v1/plan-catalog",
+		TokenURL:   srv.URL + "/oauth/v2/token",
+		ClientID:   "id", ClientSecret: "secret", Scope: "openid",
+		Mode: "test",
+	}, nil)
+	return f, c
+}
+
+func TestClient_FetchesTheCatalogWithABearerToken(t *testing.T) {
+	f, c := newFake(t)
+	got, err := c.Fetch(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "rev-1", got.RevisionID)
+	require.Len(t, got.Prices, 1)
+	require.Equal(t, int32(1), atomic.LoadInt32(&f.tokenCalls))
+}
+
+// A token is good for an hour; minting one per read would turn a cached
+// catalog into two network round trips on the payment path's warm-up.
+func TestClient_ReusesTheTokenAcrossFetches(t *testing.T) {
+	f, c := newFake(t)
+	for i := 0; i < 3; i++ {
+		_, err := c.Fetch(context.Background())
+		require.NoError(t, err)
+	}
+	require.Equal(t, int32(1), atomic.LoadInt32(&f.tokenCalls),
+		"the token must be reused until it nears expiry, not minted per fetch")
+	require.Equal(t, int32(3), atomic.LoadInt32(&f.catalogCalls))
+}
+
+// The endpoint serves Cache-Control: no-cache with an ETag, so a caller that
+// already holds the current revision should pay only the round trip. A 304
+// carries no body — treating it as an empty catalog would be catastrophic.
+func TestClient_A304ReturnsTheLastKnownCatalogNotAnEmptyOne(t *testing.T) {
+	_, c := newFake(t)
+	first, err := c.Fetch(context.Background())
+	require.NoError(t, err)
+	require.Len(t, first.Prices, 1)
+
+	second, err := c.Fetch(context.Background())
+	require.NoError(t, err)
+	require.Len(t, second.Prices, 1, "a 304 must yield the retained catalog, never an empty one")
+	require.Equal(t, "rev-1", second.RevisionID)
+}
+
+func TestClient_UpstreamFailureIsAnError(t *testing.T) {
+	f, c := newFake(t)
+	f.catalogState = func(w http.ResponseWriter, _ *http.Request) bool {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return true
+	}
+	_, err := c.Fetch(context.Background())
+	require.Error(t, err, "the cache layer decides how to degrade; the client must not hide a failure")
+}
+
+// A 404 means the mode has never been published. The console returns it
+// deliberately rather than an empty 200, because caching "the catalog is
+// empty" is worse than caching nothing: it would let this service price
+// nothing at all, silently.
+func TestClient_UnpublishedModeIsADistinctError(t *testing.T) {
+	f, c := newFake(t)
+	f.catalogState = func(w http.ResponseWriter, _ *http.Request) bool {
+		w.WriteHeader(http.StatusNotFound)
+		return true
+	}
+	_, err := c.Fetch(context.Background())
+	require.ErrorIs(t, err, consolecatalog.ErrNotPublished)
+}
+
+func TestClient_RespectsContextCancellation(t *testing.T) {
+	_, c := newFake(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := c.Fetch(ctx)
+	require.Error(t, err)
+}
+
+var _ = time.Second

--- a/services/marketplace-api/internal/billing/consolecatalog/compare.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/compare.go
@@ -1,0 +1,123 @@
+package consolecatalog
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+)
+
+// Difference is one disagreement between the two sources.
+type Difference struct {
+	LookupKey string
+	Currency  string
+	Detail    string
+}
+
+// rowKey identifies one amount on both sides.
+type rowKey struct {
+	lookupKey string
+	currency  string
+}
+
+type row struct {
+	amountMinor int64
+	taxBehavior string
+}
+
+// Diff compares the console's catalog against the compiled one and returns
+// every disagreement, sorted for stable logging.
+//
+// Its value is being trustworthy in both directions: a comparator that
+// reports spurious differences trains everyone to ignore it, and one that
+// misses real differences makes the cutover unsafe. The two normalisations
+// below exist for the first reason and are load-bearing.
+func Diff(console Catalog, compiled []pricing.PriceDescriptor) []Difference {
+	left := consoleRows(console)
+	right := compiledRows(compiled)
+
+	var diffs []Difference
+	for k, l := range left {
+		r, ok := right[k]
+		if !ok {
+			diffs = append(diffs, Difference{k.lookupKey, k.currency,
+				fmt.Sprintf("present in the console (%d minor) but absent from the compiled catalog", l.amountMinor)})
+			continue
+		}
+		if l.amountMinor != r.amountMinor {
+			diffs = append(diffs, Difference{k.lookupKey, k.currency,
+				fmt.Sprintf("unit_amount_minor: compiled=%d console=%d", r.amountMinor, l.amountMinor)})
+			continue
+		}
+		if !sameTaxBehavior(l.taxBehavior, r.taxBehavior) {
+			diffs = append(diffs, Difference{k.lookupKey, k.currency,
+				fmt.Sprintf("tax_behavior: compiled=%q console=%q", r.taxBehavior, l.taxBehavior)})
+		}
+	}
+	for k, r := range right {
+		if _, ok := left[k]; !ok {
+			diffs = append(diffs, Difference{k.lookupKey, k.currency,
+				fmt.Sprintf("present in the compiled catalog (%d minor) but absent from the console", r.amountMinor)})
+		}
+	}
+
+	sort.Slice(diffs, func(i, j int) bool {
+		if diffs[i].LookupKey != diffs[j].LookupKey {
+			return diffs[i].LookupKey < diffs[j].LookupKey
+		}
+		return diffs[i].Currency < diffs[j].Currency
+	})
+	return diffs
+}
+
+func consoleRows(c Catalog) map[rowKey]row {
+	out := make(map[rowKey]row, len(c.Prices))
+	for _, p := range c.Prices {
+		out[rowKey{p.LookupKey, strings.ToLower(p.Currency)}] = row{p.UnitAmountMinor, p.TaxBehavior}
+	}
+	return out
+}
+
+// compiledRows flattens descriptors to one row per currency.
+//
+// It walks Options rather than Baseline alone: a developed-tier descriptor
+// is one Price object carrying seven currencies, and comparing only the
+// baseline would leave six of every seven amounts unchecked.
+//
+// A zero-value Amount in Options is SKIPPED, not compared. catalog.go's init
+// pre-populates the map with an entry for every developed currency even when
+// no price exists for it, so map presence alone is not proof of a real price
+// — the same trap money.go documents. Comparing those would report a
+// permanent, uncloseable difference for every catalog gap.
+func compiledRows(descriptors []pricing.PriceDescriptor) map[rowKey]row {
+	out := make(map[rowKey]row)
+	for _, d := range descriptors {
+		for cur, amt := range d.Options {
+			if amt.Currency == "" {
+				continue
+			}
+			out[rowKey{d.LookupKey, strings.ToLower(cur)}] = row{amt.UnitAmountMinor, amt.TaxBehavior}
+		}
+	}
+	return out
+}
+
+// sameTaxBehavior treats the compiled catalog's empty string and the
+// console's "unspecified" as the same fact.
+//
+// Both mean "Stripe's default". Compared naively, EVERY price in the catalog
+// reads as divergent, the difference count never reaches zero, and the
+// cutover this gates never happens. Confirmed against the live endpoint on
+// 2026-08-30: console rows carry "unspecified" where catalog.go carries "".
+func sameTaxBehavior(a, b string) bool {
+	return normalizeTaxBehavior(a) == normalizeTaxBehavior(b)
+}
+
+func normalizeTaxBehavior(v string) string {
+	v = strings.ToLower(strings.TrimSpace(v))
+	if v == "" {
+		return "unspecified"
+	}
+	return v
+}

--- a/services/marketplace-api/internal/billing/consolecatalog/compare_test.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/compare_test.go
@@ -1,0 +1,141 @@
+package consolecatalog_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/consolecatalog"
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+)
+
+// #304 / #392: before the console can replace internal/billing/pricing as the
+// price source, both are read in parallel and compared on every read, logging
+// differences without changing behaviour, until the difference count is
+// durably zero. Same evidence pattern the console's own parity check uses.
+//
+// This file is the comparison. Its whole value is being trustworthy: a
+// comparator that reports spurious differences trains everyone to ignore it,
+// and one that misses real differences makes the cutover unsafe.
+
+// The trap that would have produced 78 false differences on day one.
+//
+// The Go catalog stores "Stripe's default" as an EMPTY tax_behavior; the
+// console reports the same fact as the string "unspecified". Compared
+// naively, every price in the catalog differs, the difference count never
+// reaches zero, and the cutover it gates never happens.
+//
+// Verified against the live endpoint on 2026-08-30: console rows carry
+// "unspecified" where catalog.go carries "".
+func TestDiff_TreatsUnspecifiedAndEmptyTaxBehaviourAsEqual(t *testing.T) {
+	compiled := []pricing.PriceDescriptor{{
+		Plan: "pro", Period: "annual", Tier: pricing.TierPPP,
+		Currency:  "vnd",
+		Baseline:  pricing.Amount{Currency: "vnd", UnitAmountMinor: 1978800000, TaxBehavior: ""},
+		Options:   map[string]pricing.Amount{"vnd": {Currency: "vnd", UnitAmountMinor: 1978800000}},
+		LookupKey: "mark8ly_pro_annual_ppp_vnd_v1",
+	}}
+	console := consolecatalog.Catalog{Prices: []consolecatalog.Price{{
+		LookupKey: "mark8ly_pro_annual_ppp_vnd_v1", Plan: "pro", Period: "annual",
+		Tier: "ppp", Currency: "vnd", UnitAmountMinor: 1978800000,
+		TaxBehavior: "unspecified",
+	}}}
+
+	require.Empty(t, consolecatalog.Diff(console, compiled),
+		`"" and "unspecified" are the same fact stated two ways — treating them as `+
+			`different reports every price as divergent and the count never reaches zero`)
+}
+
+// A real amount change must be caught. This is the case the whole exercise
+// exists to detect before the cutover.
+func TestDiff_ReportsAChangedAmount(t *testing.T) {
+	compiled := []pricing.PriceDescriptor{{
+		Plan: "pro", Period: "monthly", Tier: pricing.TierPPP, Currency: "inr",
+		Baseline:  pricing.Amount{Currency: "inr", UnitAmountMinor: 100000},
+		Options:   map[string]pricing.Amount{"inr": {Currency: "inr", UnitAmountMinor: 100000}},
+		LookupKey: "mark8ly_pro_monthly_ppp_inr_v1",
+	}}
+	console := consolecatalog.Catalog{Prices: []consolecatalog.Price{{
+		LookupKey: "mark8ly_pro_monthly_ppp_inr_v1", Plan: "pro", Period: "monthly",
+		Tier: "ppp", Currency: "inr", UnitAmountMinor: 123456,
+	}}}
+
+	diffs := consolecatalog.Diff(console, compiled)
+	require.Len(t, diffs, 1)
+	require.Equal(t, "mark8ly_pro_monthly_ppp_inr_v1", diffs[0].LookupKey)
+	require.Equal(t, "inr", diffs[0].Currency)
+	require.Contains(t, diffs[0].Detail, "100000")
+	require.Contains(t, diffs[0].Detail, "123456")
+}
+
+// A developed-tier descriptor is ONE Price object carrying an Options map of
+// seven currencies, and the console returns one row per currency. Comparing
+// only the baseline would leave six of every seven amounts unchecked — the
+// same currency_options blind spot #459 had to leave open on the Stripe side,
+// which is worth closing HERE because the data is right in front of us.
+func TestDiff_ComparesEveryCurrencyOfADevelopedPrice(t *testing.T) {
+	compiled := []pricing.PriceDescriptor{{
+		Plan: "starter", Period: "monthly", Tier: pricing.TierDeveloped,
+		Currency: "usd",
+		Baseline: pricing.Amount{Currency: "usd", UnitAmountMinor: 1900},
+		Options: map[string]pricing.Amount{
+			"usd": {Currency: "usd", UnitAmountMinor: 1900},
+			"gbp": {Currency: "gbp", UnitAmountMinor: 1500},
+		},
+		LookupKey: "mark8ly_starter_monthly_developed_v1",
+	}}
+	console := consolecatalog.Catalog{Prices: []consolecatalog.Price{
+		{LookupKey: "mark8ly_starter_monthly_developed_v1", Currency: "usd", UnitAmountMinor: 1900, Tier: "developed"},
+		{LookupKey: "mark8ly_starter_monthly_developed_v1", Currency: "gbp", UnitAmountMinor: 9999, Tier: "developed"},
+	}}
+
+	diffs := consolecatalog.Diff(console, compiled)
+	require.Len(t, diffs, 1, "the non-baseline currency must be compared, not just the baseline")
+	require.Equal(t, "gbp", diffs[0].Currency)
+}
+
+// A row present on one side only is a difference, and the two directions are
+// reported distinctly: a price the console has never heard of and one it has
+// added are different problems with different fixes.
+func TestDiff_ReportsRowsMissingFromEitherSide(t *testing.T) {
+	compiled := []pricing.PriceDescriptor{{
+		Plan: "pro", Period: "annual", Tier: pricing.TierPPP, Currency: "thb",
+		Baseline:  pricing.Amount{Currency: "thb", UnitAmountMinor: 500},
+		Options:   map[string]pricing.Amount{"thb": {Currency: "thb", UnitAmountMinor: 500}},
+		LookupKey: "only_in_catalog",
+	}}
+	console := consolecatalog.Catalog{Prices: []consolecatalog.Price{
+		{LookupKey: "only_in_console", Currency: "thb", UnitAmountMinor: 500, Tier: "ppp"},
+	}}
+
+	diffs := consolecatalog.Diff(console, compiled)
+	require.Len(t, diffs, 2)
+	byKey := map[string]consolecatalog.Difference{}
+	for _, d := range diffs {
+		byKey[d.LookupKey] = d
+	}
+	require.Contains(t, byKey["only_in_catalog"].Detail, "absent from the console")
+	require.Contains(t, byKey["only_in_console"].Detail, "absent from the compiled catalog")
+}
+
+// Identical inputs must be silent. Stated explicitly because "durably zero"
+// is the cutover gate, and a comparator with a floor above zero can never
+// reach it.
+func TestDiff_IdenticalSourcesProduceNoDifferences(t *testing.T) {
+	compiled := pricing.AllDescriptors()
+	var prices []consolecatalog.Price
+	for _, d := range compiled {
+		for cur, amt := range d.Options {
+			if amt.Currency == "" {
+				continue // catalog gap, not a real price — see money.go
+			}
+			prices = append(prices, consolecatalog.Price{
+				LookupKey: d.LookupKey, Plan: string(d.Plan), Period: string(d.Period),
+				Tier: string(d.Tier), Currency: cur, UnitAmountMinor: amt.UnitAmountMinor,
+				TaxBehavior: amt.TaxBehavior,
+			})
+		}
+	}
+	require.NotEmpty(t, prices, "a vacuous comparison would prove nothing")
+	require.Empty(t, consolecatalog.Diff(consolecatalog.Catalog{Prices: prices}, compiled))
+}

--- a/services/marketplace-api/internal/billing/consolecatalog/parity.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/parity.go
@@ -1,0 +1,128 @@
+package consolecatalog
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+)
+
+// Fetcher is the console read the Monitor depends on. An interface so the
+// monitor is testable without a network, and so the cutover can swap what
+// feeds it without touching the comparison.
+type Fetcher interface {
+	Fetch(context.Context) (Catalog, error)
+}
+
+// Result is one comparison's outcome.
+//
+// Compared is deliberately separate from Differences. A failed read must not
+// look like agreement: reporting zero differences when the console could not
+// be reached would make an outage indistinguishable from a clean run, and
+// the cutover gate — "durably zero" — would then be satisfiable by an
+// outage. That is the single most important distinction in this type.
+type Result struct {
+	Compared    bool
+	Differences int
+	Sample      []Difference
+	RevisionID  string
+	Err         error
+}
+
+// sampleSize caps how many differences are carried for logging. A hundred
+// identical lines help nobody find the first one.
+const sampleSize = 10
+
+// Monitor runs the parallel comparison of the console's catalog against the
+// compiled one (#304, #392).
+//
+// It NEVER resolves a price. Prices continue to come from
+// internal/billing/pricing until the cutover, which is a separate, deliberate
+// change gated on this reporting durably zero. Keeping the monitor incapable
+// of answering "what is the price" is what makes slice one safe to run in
+// production on the payment path's own process.
+//
+// The interval keeps the console entirely off the hot path: the data changes
+// a few times a year, so a comparison every few minutes is generous.
+type Monitor struct {
+	fetcher  Fetcher
+	interval time.Duration
+	logger   *slog.Logger
+
+	mu       sync.Mutex
+	lastRun  time.Time
+	lastRes  Result
+	haveLast bool
+}
+
+func NewMonitor(f Fetcher, interval time.Duration, logger *slog.Logger) *Monitor {
+	return &Monitor{fetcher: f, interval: interval, logger: logger}
+}
+
+// Check compares the two sources, refetching at most once per interval and
+// otherwise returning the previous result.
+//
+// It never returns an error to its caller and never blocks a request on a
+// decision: its only outputs are a Result and a log line.
+func (m *Monitor) Check(ctx context.Context) Result {
+	m.mu.Lock()
+	if m.haveLast && time.Since(m.lastRun) < m.interval {
+		res := m.lastRes
+		m.mu.Unlock()
+		return res
+	}
+	m.mu.Unlock()
+
+	catalog, err := m.fetcher.Fetch(ctx)
+	res := Result{}
+	if err != nil {
+		res.Err = err
+		m.warn("consolecatalog: could not read the console catalog; comparison skipped", "error", err)
+	} else {
+		diffs := Diff(catalog, pricing.AllDescriptors())
+		res.Compared = true
+		res.Differences = len(diffs)
+		res.RevisionID = catalog.RevisionID
+		if n := len(diffs); n > sampleSize {
+			res.Sample = diffs[:sampleSize]
+		} else {
+			res.Sample = diffs
+		}
+		m.report(res)
+	}
+
+	m.mu.Lock()
+	m.lastRun, m.lastRes, m.haveLast = time.Now(), res, true
+	m.mu.Unlock()
+	return res
+}
+
+// report logs the outcome. A clean run logs at info so the evidence trail
+// the cutover rests on is visible; a divergence logs at warn with a bounded
+// sample naming the keys.
+func (m *Monitor) report(res Result) {
+	if m.logger == nil {
+		return
+	}
+	if res.Differences == 0 {
+		m.logger.Info("consolecatalog: parity clean",
+			"revision_id", res.RevisionID, "differences", 0)
+		return
+	}
+	for _, d := range res.Sample {
+		m.logger.Warn("consolecatalog: parity difference",
+			"revision_id", res.RevisionID,
+			"lookup_key", d.LookupKey, "currency", d.Currency, "detail", d.Detail)
+	}
+	m.logger.Warn("consolecatalog: parity summary",
+		"revision_id", res.RevisionID, "differences", res.Differences,
+		"sampled", len(res.Sample))
+}
+
+func (m *Monitor) warn(msg string, args ...any) {
+	if m.logger != nil {
+		m.logger.Warn(msg, args...)
+	}
+}

--- a/services/marketplace-api/internal/billing/consolecatalog/parity_test.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/parity_test.go
@@ -1,0 +1,112 @@
+package consolecatalog_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/consolecatalog"
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+)
+
+// The parallel-run monitor. It reads both sources and records their
+// differences; it never decides a price. Prices keep coming from the
+// compiled catalog until the cutover, which is gated on this reporting
+// durably zero.
+
+type stubFetcher struct {
+	calls   int32
+	catalog consolecatalog.Catalog
+	err     error
+}
+
+func (s *stubFetcher) Fetch(context.Context) (consolecatalog.Catalog, error) {
+	atomic.AddInt32(&s.calls, 1)
+	return s.catalog, s.err
+}
+
+func matchingCatalog() consolecatalog.Catalog {
+	var prices []consolecatalog.Price
+	for _, d := range pricing.AllDescriptors() {
+		for cur, amt := range d.Options {
+			if amt.Currency == "" {
+				continue
+			}
+			prices = append(prices, consolecatalog.Price{
+				LookupKey: d.LookupKey, Currency: cur,
+				UnitAmountMinor: amt.UnitAmountMinor, TaxBehavior: amt.TaxBehavior,
+			})
+		}
+	}
+	return consolecatalog.Catalog{Mode: "test", RevisionID: "rev-1", Prices: prices}
+}
+
+func TestMonitor_AgreeingSourcesReportZeroDifferences(t *testing.T) {
+	f := &stubFetcher{catalog: matchingCatalog()}
+	m := consolecatalog.NewMonitor(f, time.Hour, nil)
+
+	res := m.Check(context.Background())
+
+	require.True(t, res.Compared, "an agreeing check must count as a real comparison")
+	require.Zero(t, res.Differences)
+	require.Empty(t, res.Err)
+}
+
+// The invariant, stated as a test: an unreachable console must never break
+// anything. The monitor reports that it could not compare — it does not
+// report zero differences, which would be indistinguishable from agreement
+// and would let the cutover proceed on no evidence at all.
+func TestMonitor_AnUnreachableConsoleIsNotZeroDifferences(t *testing.T) {
+	f := &stubFetcher{err: errors.New("boom")}
+	m := consolecatalog.NewMonitor(f, time.Hour, nil)
+
+	res := m.Check(context.Background())
+
+	require.False(t, res.Compared,
+		"a failed read must be distinguishable from a clean comparison — otherwise "+
+			"an outage looks exactly like agreement and the cutover gate means nothing")
+	require.Error(t, res.Err)
+}
+
+// The data changes a few times a year, so a generous TTL keeps the console
+// off the hot path entirely.
+func TestMonitor_DoesNotRefetchWithinTheInterval(t *testing.T) {
+	f := &stubFetcher{catalog: matchingCatalog()}
+	m := consolecatalog.NewMonitor(f, time.Hour, nil)
+
+	for i := 0; i < 5; i++ {
+		m.Check(context.Background())
+	}
+	require.Equal(t, int32(1), atomic.LoadInt32(&f.calls),
+		"the console must not be read once per check; the interval is the whole point")
+}
+
+func TestMonitor_RefetchesOnceTheIntervalHasElapsed(t *testing.T) {
+	f := &stubFetcher{catalog: matchingCatalog()}
+	m := consolecatalog.NewMonitor(f, time.Nanosecond, nil)
+
+	m.Check(context.Background())
+	time.Sleep(2 * time.Millisecond)
+	m.Check(context.Background())
+
+	require.Equal(t, int32(2), atomic.LoadInt32(&f.calls))
+}
+
+// A real divergence must be reported with enough detail to act on.
+func TestMonitor_ReportsDivergenceWithDetail(t *testing.T) {
+	c := matchingCatalog()
+	c.Prices[0].UnitAmountMinor += 1
+	f := &stubFetcher{catalog: c}
+	m := consolecatalog.NewMonitor(f, time.Hour, nil)
+
+	res := m.Check(context.Background())
+
+	require.True(t, res.Compared)
+	require.Equal(t, 1, res.Differences)
+	require.Len(t, res.Sample, 1)
+	require.Contains(t, res.Sample[0].Detail, "unit_amount_minor")
+}

--- a/services/marketplace-api/pkg/config/config.go
+++ b/services/marketplace-api/pkg/config/config.go
@@ -96,6 +96,29 @@ type Config struct {
 	StripeBillingSecretKey     string `envconfig:"STRIPE_BILLING_SECRET_KEY" default:""`
 	StripeBillingWebhookSecret string `envconfig:"STRIPE_BILLING_WEBHOOK_SECRET" default:""`
 
+	// Console plan-catalog read (#304). The console is becoming the single
+	// place a price is maintained; these configure the parallel run that
+	// compares its catalog against the one compiled into
+	// internal/billing/pricing, ahead of the cutover.
+	//
+	// ALL OF THESE ARE OPTIONAL BY DESIGN. Unset, no console read is
+	// attempted and prices come from the compiled catalog exactly as they do
+	// today — BACKLOG §P requires that nothing on a customer payment path
+	// depend on the console being reachable, and an unconfigured deploy is
+	// the strongest form of that guarantee.
+	ConsoleCatalogURL          string `envconfig:"CONSOLE_CATALOG_URL" default:""`
+	ConsoleCatalogTokenURL     string `envconfig:"CONSOLE_CATALOG_TOKEN_URL" default:""`
+	ConsoleCatalogClientID     string `envconfig:"CONSOLE_CATALOG_CLIENT_ID" default:""`
+	ConsoleCatalogClientSecret string `envconfig:"CONSOLE_CATALOG_CLIENT_SECRET" default:""`
+	// Scope must carry BOTH the project-audience scope and the roles scope.
+	// The first puts the project in the token's `aud`, which is what proves
+	// the token was minted for this route; the second makes it carry the
+	// roles claim, without which it verifies but holds no capability. Kept in
+	// config rather than compiled in so the project id is not hardcoded here.
+	ConsoleCatalogScope    string        `envconfig:"CONSOLE_CATALOG_SCOPE" default:""`
+	ConsoleCatalogMode     string        `envconfig:"CONSOLE_CATALOG_MODE" default:"test"`
+	ConsoleCatalogInterval time.Duration `envconfig:"CONSOLE_CATALOG_INTERVAL" default:"15m"`
+
 	// RESEND_WEBHOOK_SECRET verifies inbound provider delivery events
 	// (#348B). Empty leaves the endpoint mounted but inert: it answers 503
 	// not_configured rather than 404, so a missing secret is diagnosable


### PR DESCRIPTION
First half of #304, and of #392 with it. **Changes no behaviour**: prices still come from `internal/billing/pricing`. This reads the console's published catalog alongside it and logs the differences, so the cutover can be gated on evidence rather than hope.

Agreed approach: parallel run first, cut over second, once the difference count is durably zero — the same pattern the console's own parity check established.

## Already zero against production

Before writing the wiring I ran the comparator against the **live** console catalog and the compiled one:

```
mode=test  console_rows=78  differences=0
mode=live  console_rows=78  differences=0
```

So the two sources already agree. What this PR adds is the standing evidence that they continue to.

## Two normalisations that decide whether this is usable at all

A comparator that reports spurious differences trains everyone to ignore it; the count then never reaches zero and the cutover it gates never happens. Both of these were found against real data, not imagined:

1. **`tax_behavior`** — the Go catalog stores "Stripe's default" as `""`, the console reports the same fact as `"unspecified"`. Compared naively, **every price in the catalog reads as divergent**.
2. **Zero-value `Options` entries** — `catalog.go`'s init pre-populates the developed-currency map with an entry for every currency even where no price exists, so map presence is not proof of a price (the trap `money.go` already documents). Comparing those would report a permanent, uncloseable difference for every catalog gap.

Worth noting the console reports the **same raw minor units** as the Go catalog (VND `1978800000`, not Stripe's divided `19788000`), so amounts are directly comparable — verified rather than assumed.

## The distinction that makes the gate meaningful

`Result.Compared` is deliberately separate from `Result.Differences`. A failed read must not look like agreement: reporting zero differences when the console was unreachable would make an outage indistinguishable from a clean run, and "durably zero" would then be satisfiable *by an outage*. `TestMonitor_AnUnreachableConsoleIsNotZeroDifferences` pins it.

## Honouring §P

> Nothing on the request path of a customer payment may depend on the console being reachable.

- the monitor runs on **its own ticker**, never a request hook — a request-driven comparison would put the console one bad deploy away from the payment path even when cached
- it has **no method that resolves a price**; it can only compare and log
- **unconfigured is a supported state**, not a degraded one: absent credentials mean no goroutine, no reads, and behaviour identical to before this existed. Enabling is a config change, revertible by removing config, with no code path that behaves differently once off
- a `304` returns the retained catalog, never an empty one; a `200` with an empty price list is treated as a contract violation rather than cached, because caching "there are no prices" would be silent mispricing

## Also in here

- `Diff` walks the full `Options` map, so all seven currencies of a developed price are compared — closing on this side the `currency_options` blind spot #459 had to leave open on the Stripe side
- ETag/304 support, and one token reused across fetches rather than minted per read

## Verification

- 16 tests, written first; `go build`, `go vet`, full unit suite green
- `go test -race -count=2` clean on the new package
- comparator run against the live console for both modes, as above

One test was written and then **deleted** rather than shipped: a `NeverExposesConsolePricesAsAPriceSource` check whose helper returned an empty slice, so it passed unconditionally. Same vacuous-test trap caught in #323; the intent it was trying to express lives in the package doc instead.

## Not in this PR

The cutover, and the chart wiring — the latter follows immediately in tesserix-k8s, now that the env names are fixed by this code.