### PR TITLE
feat(billing): resolve prices from the console behind a flag, with the compiled catalog as fallback (#304)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/catalog_parity.go
+++ b/services/marketplace-api/cmd/marketplace-api/catalog_parity.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/mark8ly/marketplace-api/internal/billing/consolecatalog"
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
 	"github.com/mark8ly/marketplace-api/pkg/config"
 )
 
@@ -57,18 +58,60 @@ func startCatalogParityRun(cfg *config.Config, log *slog.Logger) {
 		interval = 15 * time.Minute
 	}
 
-	monitor := consolecatalog.NewMonitor(consolecatalog.NewClient(cc, log), interval, log)
-	log.Info("consolecatalog: parallel run enabled",
-		"mode", cc.Mode, "interval", interval.String())
+	client := consolecatalog.NewClient(cc, log)
+
+	if !cfg.ConsoleCatalogAuthoritative {
+		monitor := consolecatalog.NewMonitor(client, interval, log)
+		log.Info("consolecatalog: parallel run enabled (comparison only)",
+			"mode", cc.Mode, "interval", interval.String())
+		go func() {
+			// One check immediately, so a deploy produces evidence without
+			// waiting out the first interval.
+			runOneCheck(monitor, log)
+			t := time.NewTicker(interval)
+			defer t.Stop()
+			for range t.C {
+				runOneCheck(monitor, log)
+			}
+		}()
+		return
+	}
+
+	// ── Cutover (#304) ────────────────────────────────────────────────
+	//
+	// The console becomes the price source, with the compiled catalog as
+	// the fallback for anything it cannot answer.
+	//
+	// The FIRST refresh is deliberately synchronous. Installing the source
+	// before it holds a catalog would leave a window where every lookup
+	// falls through to the compiled catalog — harmless, but it would make
+	// the first seconds after a deploy silently behave like the pre-cutover
+	// build, which is exactly the kind of thing nobody notices until a
+	// price is wrong and the logs say everything was fine.
+	//
+	// A FAILED first refresh is NOT fatal: the source is still installed
+	// and simply declines until a later refresh succeeds, so pricing serves
+	// the baked snapshot. A console outage must never stop this service
+	// starting.
+	source := consolecatalog.NewSource(client, interval, log)
+	ctx, cancel := context.WithTimeout(context.Background(), checkTimeout)
+	err := source.Refresh(ctx)
+	cancel()
+	if err != nil {
+		log.Warn("consolecatalog: cutover enabled but the first refresh failed; "+
+			"serving the compiled catalog until a refresh succeeds", "error", err)
+	}
+	pricing.UseSource(source)
+	log.Info("consolecatalog: CUTOVER ACTIVE — prices resolve from the console",
+		"mode", cc.Mode, "interval", interval.String(), "first_refresh_ok", err == nil)
 
 	go func() {
-		// One check immediately, so a deploy produces evidence without
-		// waiting out the first interval.
-		runOneCheck(monitor, log)
 		t := time.NewTicker(interval)
 		defer t.Stop()
 		for range t.C {
-			runOneCheck(monitor, log)
+			ctx, cancel := context.WithTimeout(context.Background(), checkTimeout)
+			_ = source.Refresh(ctx)
+			cancel()
 		}
 	}()
 }

--- a/services/marketplace-api/internal/billing/consolecatalog/source.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/source.go
@@ -1,0 +1,142 @@
+package consolecatalog
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+)
+
+// Source answers price lookups from the console's catalog, and declines when
+// it has nothing trustworthy to answer with (#304 cutover).
+//
+// It implements pricing.Source, so installing it swaps the DATA behind
+// LookupPPPOption and DevelopedCurrencyOptions while every caller and
+// signature stays as it is.
+//
+// # Declining is the safety property
+//
+// This type answers only from a catalog it actually fetched. Cold, or after
+// a failure with nothing cached, it returns false and pricing falls through
+// to the compiled catalog — the baked snapshot. It must never answer with a
+// zero Amount: money.go reads a zero as a real price, so a fabricated answer
+// is silent mispricing, which is strictly worse than a slightly stale one.
+//
+// # Fail open to last known
+//
+// Once it holds a catalog, a later failed refresh does not discard it. The
+// console being unreachable is not a reason to reprice anything —
+// BACKLOG §P again: nothing on a payment path may depend on the console.
+type Source struct {
+	fetcher  Fetcher
+	interval time.Duration
+	logger   *slog.Logger
+
+	mu        sync.RWMutex
+	ppp       map[pppKey]pricing.Amount
+	developed map[planKey]map[string]pricing.Amount
+	loaded    bool
+	fetchedAt time.Time
+	revision  string
+}
+
+type pppKey struct {
+	plan, period, currency string
+}
+
+type planKey struct {
+	plan, period string
+}
+
+func NewSource(f Fetcher, interval time.Duration, logger *slog.Logger) *Source {
+	return &Source{fetcher: f, interval: interval, logger: logger}
+}
+
+// Refresh fetches and replaces the held catalog. A failure leaves any
+// previously held catalog in place and is returned for logging.
+func (s *Source) Refresh(ctx context.Context) error {
+	catalog, err := s.fetcher.Fetch(ctx)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("consolecatalog: refresh failed; serving last known prices", "error", err)
+		}
+		return err
+	}
+
+	ppp := make(map[pppKey]pricing.Amount)
+	developed := make(map[planKey]map[string]pricing.Amount)
+	for _, p := range catalog.Prices {
+		cur := strings.ToLower(p.Currency)
+		amt := pricing.Amount{
+			Currency:        cur,
+			UnitAmountMinor: p.UnitAmountMinor,
+			TaxBehavior:     taxBehaviorForCatalog(p.TaxBehavior),
+		}
+		switch strings.ToLower(p.Tier) {
+		case "ppp":
+			ppp[pppKey{p.Plan, p.Period, cur}] = amt
+		case "developed":
+			k := planKey{p.Plan, p.Period}
+			if developed[k] == nil {
+				developed[k] = make(map[string]pricing.Amount)
+			}
+			developed[k][cur] = amt
+		}
+	}
+
+	s.mu.Lock()
+	s.ppp, s.developed = ppp, developed
+	s.loaded, s.fetchedAt, s.revision = true, time.Now(), catalog.RevisionID
+	s.mu.Unlock()
+
+	if s.logger != nil {
+		s.logger.Info("consolecatalog: prices refreshed from the console",
+			"revision_id", catalog.RevisionID, "ppp_prices", len(ppp), "developed_groups", len(developed))
+	}
+	return nil
+}
+
+// PPPOption implements pricing.Source.
+func (s *Source) PPPOption(plan pricing.Plan, period pricing.Period, currency string) (pricing.Amount, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.loaded {
+		return pricing.Amount{}, false
+	}
+	amt, ok := s.ppp[pppKey{string(plan), string(period), strings.ToLower(currency)}]
+	return amt, ok
+}
+
+// DevelopedOptions implements pricing.Source.
+func (s *Source) DevelopedOptions(plan pricing.Plan, period pricing.Period) (map[string]pricing.Amount, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.loaded {
+		return nil, false
+	}
+	opts, ok := s.developed[planKey{string(plan), string(period)}]
+	if !ok || len(opts) == 0 {
+		return nil, false
+	}
+	// Copied because callers receive it as the catalog's own map and must
+	// not be able to mutate the source out from under other requests.
+	out := make(map[string]pricing.Amount, len(opts))
+	for k, v := range opts {
+		out[k] = v
+	}
+	return out, true
+}
+
+// taxBehaviorForCatalog converts the console's "unspecified" back to the
+// empty string the compiled catalog uses for Stripe's default, so an Amount
+// from either source compares equal — the same normalisation Diff applies,
+// kept consistent deliberately.
+func taxBehaviorForCatalog(v string) string {
+	if strings.EqualFold(strings.TrimSpace(v), "unspecified") {
+		return ""
+	}
+	return v
+}

--- a/services/marketplace-api/internal/billing/consolecatalog/source_test.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/source_test.go
@@ -1,0 +1,104 @@
+package consolecatalog_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/consolecatalog"
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+)
+
+// The cutover source: it answers from the console's last SUCCESSFUL read and
+// says "no" otherwise, letting pricing fall through to the compiled catalog.
+
+func TestSource_AnswersFromAFetchedCatalog(t *testing.T) {
+	f := &stubFetcher{catalog: consolecatalog.Catalog{Prices: []consolecatalog.Price{
+		{LookupKey: "k", Plan: "pro", Period: "annual", Tier: "ppp", Currency: "vnd", UnitAmountMinor: 42},
+	}}}
+	s := consolecatalog.NewSource(f, time.Hour, nil)
+	require.NoError(t, s.Refresh(context.Background()))
+
+	amt, ok := s.PPPOption("pro", "annual", "vnd")
+	require.True(t, ok)
+	require.Equal(t, int64(42), amt.UnitAmountMinor)
+	require.Equal(t, "vnd", amt.Currency)
+}
+
+// Cold start with a dead console. The source must decline, so pricing serves
+// the baked snapshot. Answering with an empty Amount would be silent
+// mispricing — money.go reads a zero amount as a real price.
+func TestSource_ColdAndFailedDeclinesRatherThanAnsweringZero(t *testing.T) {
+	s := consolecatalog.NewSource(&stubFetcher{err: errors.New("dead")}, time.Hour, nil)
+	require.Error(t, s.Refresh(context.Background()))
+
+	_, ok := s.PPPOption("pro", "annual", "vnd")
+	require.False(t, ok, "a cold source must decline so the compiled catalog answers")
+
+	_, ok = s.DevelopedOptions("pro", "annual")
+	require.False(t, ok)
+}
+
+// Fail open to last known: once it has data, a later failed refresh must not
+// throw it away. The console being down is not a reason to reprice.
+func TestSource_KeepsLastKnownWhenARefreshFails(t *testing.T) {
+	f := &stubFetcher{catalog: consolecatalog.Catalog{Prices: []consolecatalog.Price{
+		{LookupKey: "k", Plan: "pro", Period: "annual", Tier: "ppp", Currency: "vnd", UnitAmountMinor: 42},
+	}}}
+	s := consolecatalog.NewSource(f, time.Hour, nil)
+	require.NoError(t, s.Refresh(context.Background()))
+
+	f.err = errors.New("console down")
+	require.Error(t, s.Refresh(context.Background()))
+
+	amt, ok := s.PPPOption("pro", "annual", "vnd")
+	require.True(t, ok, "a failed refresh must not discard a good catalog")
+	require.Equal(t, int64(42), amt.UnitAmountMinor)
+}
+
+// A currency the console does not carry must decline per lookup, so the
+// compiled catalog fills the gap instead of the price vanishing.
+func TestSource_DeclinesForACurrencyItDoesNotCarry(t *testing.T) {
+	f := &stubFetcher{catalog: consolecatalog.Catalog{Prices: []consolecatalog.Price{
+		{LookupKey: "k", Plan: "pro", Period: "annual", Tier: "ppp", Currency: "vnd", UnitAmountMinor: 42},
+	}}}
+	s := consolecatalog.NewSource(f, time.Hour, nil)
+	require.NoError(t, s.Refresh(context.Background()))
+
+	_, ok := s.PPPOption("pro", "annual", "inr")
+	require.False(t, ok)
+}
+
+func TestSource_DevelopedOptionsCarryEveryCurrency(t *testing.T) {
+	f := &stubFetcher{catalog: consolecatalog.Catalog{Prices: []consolecatalog.Price{
+		{LookupKey: "d", Plan: "starter", Period: "monthly", Tier: "developed", Currency: "usd", UnitAmountMinor: 1900},
+		{LookupKey: "d", Plan: "starter", Period: "monthly", Tier: "developed", Currency: "gbp", UnitAmountMinor: 1500},
+	}}}
+	s := consolecatalog.NewSource(f, time.Hour, nil)
+	require.NoError(t, s.Refresh(context.Background()))
+
+	opts, ok := s.DevelopedOptions("starter", "monthly")
+	require.True(t, ok)
+	require.Len(t, opts, 2)
+	require.Equal(t, int64(1500), opts["gbp"].UnitAmountMinor)
+}
+
+// Installing it must not change what pricing answers while the two agree —
+// which is exactly the state the parallel run has been proving.
+func TestSource_InstalledOverAnAgreeingCatalogChangesNothing(t *testing.T) {
+	f := &stubFetcher{catalog: matchingCatalog()}
+	s := consolecatalog.NewSource(f, time.Hour, nil)
+	require.NoError(t, s.Refresh(context.Background()))
+
+	before, okBefore := pricing.LookupPPPOption("pro", "annual", "vnd")
+	pricing.UseSource(s)
+	t.Cleanup(func() { pricing.UseSource(nil) })
+	after, okAfter := pricing.LookupPPPOption("pro", "annual", "vnd")
+
+	require.Equal(t, okBefore, okAfter)
+	require.Equal(t, before.UnitAmountMinor, after.UnitAmountMinor,
+		"cutting over while the sources agree must be a no-op at the point of use")
+}

--- a/services/marketplace-api/internal/billing/pricing/catalog.go
+++ b/services/marketplace-api/internal/billing/pricing/catalog.go
@@ -348,7 +348,16 @@ func LookupBaseline(p Plan, period Period, tier Tier) (Amount, bool) {
 }
 
 // LookupPPPOption returns the Amount for a specific PPP currency.
+//
+// An installed Source (the console, #304) is consulted first and the
+// compiled catalog answers when it cannot — see Source for why that
+// fallthrough is the whole fail-open design rather than an afterthought.
 func LookupPPPOption(p Plan, period Period, currency string) (Amount, bool) {
+	if src := sourceOrNil(); src != nil {
+		if amt, ok := src.PPPOption(p, period, currency); ok {
+			return amt, true
+		}
+	}
 	k := pppKey{plan: p, period: period, currency: currency}
 	amt, ok := pppAmounts[k]
 	return amt, ok
@@ -357,6 +366,11 @@ func LookupPPPOption(p Plan, period Period, currency string) (Amount, bool) {
 // DevelopedCurrencyOptions returns the Options map for the developed-tier descriptor
 // of (plan, period). The map contains all 7 developed-market currencies.
 func DevelopedCurrencyOptions(p Plan, period Period) (map[string]Amount, bool) {
+	if src := sourceOrNil(); src != nil {
+		if opts, ok := src.DevelopedOptions(p, period); ok && len(opts) > 0 {
+			return opts, true
+		}
+	}
 	for _, d := range allDescriptors {
 		if d.Plan == p && d.Period == period && d.Tier == TierDeveloped {
 			return d.Options, true

--- a/services/marketplace-api/internal/billing/pricing/source.go
+++ b/services/marketplace-api/internal/billing/pricing/source.go
@@ -1,0 +1,57 @@
+package pricing
+
+import "sync/atomic"
+
+// Source supplies prices from somewhere other than the compiled catalog —
+// in practice the Tesserix console (#304, #392).
+//
+// It exists so the catalog's DATA can move to the console while its API and
+// every call site stay exactly as they are. Deleting this package was
+// explicitly not proposed: the lookup helpers have callers whose signatures
+// should survive, and replacing the data behind them is a far smaller and
+// safer change than removing them.
+//
+// # Returning false is a first-class answer, not an error
+//
+// A Source that cannot answer — cold cache, failed refresh, a currency it
+// does not carry — returns false, and the helper falls through to the
+// compiled catalog. That fallthrough IS the baked-snapshot cold start and
+// the fail-open behaviour BACKLOG §P requires; there is no second mechanism
+// for it, and none is wanted. A fresh pod during a console outage must not
+// itself be the outage.
+//
+// The fallthrough is per lookup rather than wholesale, so a source carrying
+// most currencies does not have to be abandoned for the one it lacks.
+type Source interface {
+	PPPOption(plan Plan, period Period, currency string) (Amount, bool)
+	DevelopedOptions(plan Plan, period Period) (map[string]Amount, bool)
+}
+
+// active holds the installed Source, or nil for "use the compiled catalog".
+//
+// atomic because it is installed at startup and refreshed by a background
+// ticker while requests read it concurrently. A plain field here would be a
+// data race on the price of a subscription.
+var active atomic.Pointer[Source]
+
+// UseSource installs s as the price source, or restores the compiled catalog
+// when s is nil.
+//
+// Nil is the default and the shipped state: the console cutover is enabled
+// by configuration, so it can be reverted by removing configuration rather
+// than by deploying.
+func UseSource(s Source) {
+	if s == nil {
+		active.Store(nil)
+		return
+	}
+	active.Store(&s)
+}
+
+// sourceOrNil returns the installed Source, if any.
+func sourceOrNil() Source {
+	if p := active.Load(); p != nil {
+		return *p
+	}
+	return nil
+}

--- a/services/marketplace-api/internal/billing/pricing/source_test.go
+++ b/services/marketplace-api/internal/billing/pricing/source_test.go
@@ -1,0 +1,138 @@
+package pricing_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+)
+
+// #304 cutover: the console becomes the DATA SOURCE behind these helpers
+// while their signatures and callers stay exactly as they are — the issue is
+// explicit that deleting this package is not proposed.
+//
+// Everything here turns on one property: an installed source that cannot
+// answer must fall through to the compiled catalog rather than return a
+// miss. That fallthrough IS the baked-snapshot cold start and the fail-open
+// behaviour BACKLOG §P requires; there is no separate mechanism for it.
+
+type stubSource struct {
+	ppp       map[string]pricing.Amount // keyed by currency
+	developed map[string]pricing.Amount
+	answer    bool
+}
+
+func (s *stubSource) PPPOption(_ pricing.Plan, _ pricing.Period, currency string) (pricing.Amount, bool) {
+	if !s.answer {
+		return pricing.Amount{}, false
+	}
+	a, ok := s.ppp[currency]
+	return a, ok
+}
+
+func (s *stubSource) DevelopedOptions(_ pricing.Plan, _ pricing.Period) (map[string]pricing.Amount, bool) {
+	if !s.answer {
+		return nil, false
+	}
+	return s.developed, true
+}
+
+// restore keeps tests independent — an installed source is process-wide.
+func restore(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { pricing.UseSource(nil) })
+}
+
+// The regression that matters most: with nothing installed, behaviour is
+// byte-for-byte what it is today. This is what makes the cutover flag safe
+// to ship turned off.
+func TestNoSourceInstalledUsesTheCompiledCatalog(t *testing.T) {
+	restore(t)
+	pricing.UseSource(nil)
+
+	amt, ok := pricing.LookupPPPOption("pro", "annual", "vnd")
+	require.True(t, ok)
+	require.Equal(t, int64(1978800000), amt.UnitAmountMinor)
+
+	opts, ok := pricing.DevelopedCurrencyOptions("pro", "annual")
+	require.True(t, ok)
+	require.NotEmpty(t, opts)
+}
+
+func TestInstalledSourceAnswersPPP(t *testing.T) {
+	restore(t)
+	pricing.UseSource(&stubSource{
+		answer: true,
+		ppp:    map[string]pricing.Amount{"vnd": {Currency: "vnd", UnitAmountMinor: 42}},
+	})
+
+	amt, ok := pricing.LookupPPPOption("pro", "annual", "vnd")
+	require.True(t, ok)
+	require.Equal(t, int64(42), amt.UnitAmountMinor, "the console's amount must win once it is authoritative")
+}
+
+// The cold start. A source installed but unable to answer — a fresh pod
+// during a console outage — must NOT produce a miss. money.go treats a miss
+// as "no price", and reporting no price is worse than reporting a slightly
+// stale one.
+func TestSourceThatCannotAnswerFallsBackToTheCompiledCatalog(t *testing.T) {
+	restore(t)
+	pricing.UseSource(&stubSource{answer: false})
+
+	amt, ok := pricing.LookupPPPOption("pro", "annual", "vnd")
+	require.True(t, ok, "a cold or failed source must fall through to the baked snapshot, not miss")
+	require.Equal(t, int64(1978800000), amt.UnitAmountMinor)
+
+	opts, ok := pricing.DevelopedCurrencyOptions("pro", "annual")
+	require.True(t, ok)
+	require.NotEmpty(t, opts)
+}
+
+// A source that answers for one currency but not another must fall through
+// per lookup, not wholesale.
+func TestFallthroughIsPerLookupNotAllOrNothing(t *testing.T) {
+	restore(t)
+	pricing.UseSource(&stubSource{
+		answer: true,
+		ppp:    map[string]pricing.Amount{"vnd": {Currency: "vnd", UnitAmountMinor: 42}},
+	})
+
+	fromConsole, ok := pricing.LookupPPPOption("pro", "annual", "vnd")
+	require.True(t, ok)
+	require.Equal(t, int64(42), fromConsole.UnitAmountMinor)
+
+	fromCatalog, ok := pricing.LookupPPPOption("pro", "annual", "inr")
+	require.True(t, ok, "a currency the source does not carry must still resolve from the catalog")
+	require.NotZero(t, fromCatalog.UnitAmountMinor)
+}
+
+// The source is installed at startup and refreshed by a background ticker
+// while requests read it. Racing here would be a data race on the price of
+// a subscription.
+func TestUseSourceIsSafeUnderConcurrentReadsAndSwaps(t *testing.T) {
+	restore(t)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				_, _ = pricing.LookupPPPOption("pro", "annual", "vnd")
+				_, _ = pricing.DevelopedCurrencyOptions("pro", "annual")
+			}
+		}()
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				pricing.UseSource(&stubSource{answer: true, ppp: map[string]pricing.Amount{}})
+				pricing.UseSource(nil)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/services/marketplace-api/pkg/config/config.go
+++ b/services/marketplace-api/pkg/config/config.go
@@ -118,6 +118,17 @@ type Config struct {
 	ConsoleCatalogScope    string        `envconfig:"CONSOLE_CATALOG_SCOPE" default:""`
 	ConsoleCatalogMode     string        `envconfig:"CONSOLE_CATALOG_MODE" default:"test"`
 	ConsoleCatalogInterval time.Duration `envconfig:"CONSOLE_CATALOG_INTERVAL" default:"15m"`
+	// CONSOLE_CATALOG_AUTHORITATIVE performs the #304 cutover: when true and
+	// the console is configured, prices are RESOLVED from the console with
+	// the compiled catalog as the fallback. False (the default) keeps the
+	// compiled catalog authoritative and the console read as a comparison
+	// only.
+	//
+	// A flag rather than a code-only cutover so the change can be reverted by
+	// setting one variable, without building and shipping an image — the
+	// difference between a minute and a deploy cycle on the one code path
+	// that decides what a customer is charged.
+	ConsoleCatalogAuthoritative bool `envconfig:"CONSOLE_CATALOG_AUTHORITATIVE" default:"false"`
 
 	// RESEND_WEBHOOK_SECRET verifies inbound provider delivery events
 	// (#348B). Empty leaves the endpoint mounted but inert: it answers 503


### PR DESCRIPTION
Second half of #304 — the cutover. **Deliberately a draft: not to be merged until the parallel run has been clean for several days.** One clean check on deploy day is not "durably zero".

Shipped state is **off**. With `CONSOLE_CATALOG_AUTHORITATIVE` unset, behaviour is byte-for-byte what it is today and the console read stays a comparison.

## Replace the data, keep the API

`pricing.Source` is a two-method interface installed via `pricing.UseSource`. `LookupPPPOption` and `DevelopedCurrencyOptions` consult it first and fall through to the compiled catalog. No call site changes, no signature changes — the issue is explicit that deleting the package was never proposed.

After #459 the surface is smaller than #392's original inventory: `update.go` reads only lookup keys now, so `money.go` is the only runtime reader of amounts.

## Declining is the entire safety design

The console Source answers **only from a catalog it actually fetched**. Cold, or failed with nothing cached, it returns `false` and pricing serves the compiled catalog. That fallthrough *is* the baked-snapshot cold start and the fail-open behaviour — there is no second mechanism, and none is wanted.

It must never answer with a zero `Amount`: `money.go` reads a zero as a real price, so a fabricated answer is silent mispricing, strictly worse than a slightly stale one. `TestSource_ColdAndFailedDeclinesRatherThanAnsweringZero` pins that.

Fallthrough is **per lookup**, not wholesale, so a source carrying most currencies is not abandoned for the one it lacks.

## Why a flag rather than a code-only cutover

This is the one code path that decides what a customer is charged. A flag makes reverting one variable and a restart, not a build-and-ship cycle. It also lets this merge safely while the evidence accumulates, so the cutover itself is a config change made deliberately on a day someone chooses.

## Two startup decisions worth reviewing

**The first refresh is synchronous.** Installing the source before it holds a catalog would leave a window where every lookup falls through — harmless in effect, but the first seconds after a deploy would silently behave like the pre-cutover build, which is the kind of thing nobody notices until a price is wrong and the logs say everything was fine.

**A failed first refresh is not fatal.** The source installs anyway and declines until a refresh succeeds. A console outage must never stop this service starting.

## Verification

- 11 new tests, written first. `go build`, `go vet`, full unit suite green
- `go test -race -count=2` clean on `pricing` and `consolecatalog` — the source is installed at startup and refreshed by a ticker while requests read it, so a race here would be a data race on the price of a subscription
- integration tests **actually ran** against a real database: `./internal/billing/...` and `./internal/handlers/platformadmin/` clean
- `TestSource_InstalledOverAnAgreeingCatalogChangesNothing` asserts the property the parallel run has been proving — cutting over while the sources agree is a no-op at the point of use

## Before merging

- [ ] several days of `consolecatalog: parity clean differences=0` in production
- [ ] decide `CONSOLE_CATALOG_MODE` for the cutover — currently `test`; live pricing needs `live`
- [ ] enable the flag as a separate, deliberate config change after this merges, not with it