### PR TITLE
fix(breakglass): transfer break_glass_lockouts ownership to marketplace_api and correct the purge rationale (#457)

### DIFF
--- a/docs/ops/2026-08-30-break-glass-lockouts-ownership.md
+++ b/docs/ops/2026-08-30-break-glass-lockouts-ownership.md
@@ -1,0 +1,132 @@
+# break_glass_lockouts ownership fix — 2026-08-30
+
+Database: `mark8ly_marketplace_api`, cluster `mark8ly-postgres` (primary
+`mark8ly-postgres-3`). Closes #457.
+
+## Symptom
+
+```
+GET /api/v1/platform/admin/break-glass → 500
+platform break-glass list failed
+err="breakglass platform list: ERROR: permission denied for table
+     break_glass_lockouts (SQLSTATE 42501)"
+```
+
+Auth was never the problem: the request passed the HMAC check and the
+`rotate-credentials` capability gate and reached the handler. Only the
+database read failed.
+
+## The reported 500 was one symptom of three
+
+`marketplace_api` held **no privileges at all** on the table — confirmed via
+`information_schema.role_table_grants` (only `postgres` and
+`mark8ly_platform_admin` appeared) and by `SET ROLE marketplace_api; SELECT …`
+returning `permission denied`.
+
+Two more consequences follow, both in the break-glass **login** path, and
+neither was reported:
+
+1. **The durable 24h lockout had never been persisted.** `recordFailure` →
+   `Repo.LockIP` → `INSERT` → denied. The error is logged at `Warn` and
+   swallowed.
+2. **An existing lockout would never have been enforced.** The fast-path
+   `IsIPLocked` read fails open — the error is logged and `locked` stays
+   `false`.
+
+So brute-force protection on break-glass login was, in production, entirely
+the in-memory per-pod limiter: it resets on every deploy and does not span
+replicas. The "durable decision" layer the code describes had never
+functioned since #333 shipped it.
+
+Not unprotected — three strikes per hour per pod still applied, and login
+requires password **and** TOTP — but the documented 24h hard lockout did not
+exist.
+
+## Cause
+
+Migration `000073_break_glass_lockouts.up.sql` creates the table. Migrations
+run as `marketplace_api` (the migrate init container reads
+`mark8ly-postgres-marketplace-api`), so the migrating role owns what it
+creates. Every sibling table from the same migration run confirms it:
+
+```
+break_glass_accounts  -> marketplace_api
+enterprise_api_keys   -> marketplace_api
+tenant_sso_configs    -> marketplace_api
+break_glass_lockouts  -> postgres        ← the anomaly
+```
+
+The table was therefore created out-of-band by `postgres` at some point, not
+by the migration. **This is a production-only anomaly**: a fresh environment
+running `000073` as `marketplace_api` owns the table and never has this bug.
+
+## Why this was not a migration
+
+A role can only `GRANT` on a table it owns. Migrations connect as
+`marketplace_api`; the table was owned by `postgres`. A migration carrying
+the fix would fail with `permission denied` and block the rollout — and
+would be pointless anyway, since no other environment is affected.
+
+Same shape as the 2026-07-29 sequence-ownership fix, and applied the same
+way: privileged SQL by hand, written up here.
+
+## Applied
+
+```sql
+-- as postgres, on the primary (mark8ly-postgres-3)
+ALTER TABLE break_glass_lockouts OWNER TO marketplace_api;
+```
+
+Ownership rather than `GRANT SELECT, INSERT` deliberately: it makes
+production match every sibling table and match a fresh environment, so the
+anomaly stops existing instead of being papered over. The narrower grant
+would have left prod permanently different from everywhere else.
+
+## Verified
+
+```
+break_glass_accounts -> marketplace_api
+break_glass_lockouts -> marketplace_api
+SET ROLE marketplace_api; SELECT count(*) FROM break_glass_lockouts;  -- 0, no error
+```
+
+End to end, via the admin-conformance suite (which probes this endpoint
+because contract v3 declares it):
+
+```
+break-glass  (2 passed, 0 failed, 3 skipped)
+  PASS  §4.1  responds with the { data, pagination } envelope
+  PASS  §4.5  returns 200 with an empty array when there are no rows
+```
+
+It returned 500 before this change.
+
+## Rollback
+
+```sql
+ALTER TABLE break_glass_lockouts OWNER TO postgres;
+```
+
+Rolling back restores the 500 and re-breaks lockout persistence.
+
+## Consequences for the tenant purge
+
+`tenantpurge` excluded this table because `marketplace_api` had no DELETE and
+including it aborted the single-tx purge. That reason is now gone, and the
+comments in `purge.go` and `purge_test.go` have been corrected — they
+asserted a privilege state that is no longer true.
+
+The exclusion **stands**, on different grounds: `tenant_id` is NULLABLE, so
+rows with no tenant are IP-level lockouts belonging to nobody and a
+tenant-scoped purge must not touch them; and the rows are ephemeral and
+self-expiring via `locked_until`.
+
+Re-adding it as `tenantScoped()` is now possible and is a deliberate decision
+— it deletes a tenant's lockout rows on purge, defensible under art.17 and a
+change to rate-limit state. Filed separately rather than folded in here.
+
+## Not fixed here
+
+The login path's **fail-open on a lockout-read error** is a separate defect:
+a security control that silently degrades when its storage is unavailable is
+why this went unnoticed for so long. Filed separately.

--- a/services/marketplace-api/internal/tenantpurge/purge.go
+++ b/services/marketplace-api/internal/tenantpurge/purge.go
@@ -75,10 +75,12 @@
 //     the record of the destruction it is backing up. See the inline
 //     comment on the audit_logs step in group 5.
 //
-// break_glass_lockouts is the one table where the privilege claim IS
-// true: it is owned by `postgres` in production, so marketplace_api has
-// no DELETE and including it would abort the whole single-tx purge
-// (SQLSTATE 42501). See the inline comment in group 5.
+// break_glass_lockouts was the one table where the privilege claim was
+// true — owned by `postgres` in production, so marketplace_api had no
+// DELETE and including it would abort the whole single-tx purge
+// (SQLSTATE 42501). Ownership was transferred to marketplace_api on
+// 2026-08-30 (#457), so it is now excluded by choice rather than by
+// privilege. See the inline comment in group 5.
 //
 // See task-1-report.md for the full per-table FK/scoping audit.
 package tenantpurge
@@ -353,13 +355,20 @@ func purgePlan(tenantID string, storeIDs []string) []deleteStep {
 		tenantScoped("tenant_sso_configs", tenantID),       // 000070: tenant_id (PK)
 		tenantScoped("storefront_push_tokens", tenantID),   // 000022: tenant_id
 		tenantScoped("admin_push_tokens", tenantID),        // 000021: tenant_id, store_id
-		// break_glass_lockouts is intentionally NOT purged: in prod it is owned by
-		// `postgres` (a manual-migration anomaly), so the marketplace_api role has
-		// no DELETE privilege and including it aborts the whole single-tx purge
-		// (SQLSTATE 42501). Its rows are ephemeral, HMAC'd-IP rate-limit lockouts
-		// (self-expiring via locked_until) — safe to retain. See protectedTables
-		// in purge_test.go. break_glass_accounts (below) IS owned by marketplace_api
-		// and is still purged.
+		// break_glass_lockouts is intentionally NOT purged — by choice since
+		// #457, having previously been by necessity.
+		//
+		// The table was owned by `postgres` in prod (a manual-migration
+		// anomaly), so marketplace_api had no DELETE and including it aborted
+		// the whole single-tx purge. Ownership moved to marketplace_api on
+		// 2026-08-30 and a DELETE would now succeed.
+		//
+		// It stays excluded because tenant_id is NULLABLE: rows with no tenant
+		// are IP-level lockouts belonging to nobody, and the rows are ephemeral
+		// and self-expiring via locked_until. Re-adding it is now possible and
+		// is a deliberate decision, not a tidy-up. See protectedTables in
+		// purge_test.go. break_glass_accounts (below) IS owned by
+		// marketplace_api and is still purged.
 		tenantScoped("break_glass_accounts", tenantID), // 000072: tenant_id (PK)
 		tenantScoped("enterprise_api_keys", tenantID),  // 000068: tenant_id, store_id
 		// audit_logs is tenant-scoped EXCEPT for operator rows. A platform

--- a/services/marketplace-api/internal/tenantpurge/purge_test.go
+++ b/services/marketplace-api/internal/tenantpurge/purge_test.go
@@ -40,15 +40,30 @@ var protectedTables = []string{
 	"user_profiles",
 	"promo_codes",
 	"signup_anomaly_log",
-	// break_glass_lockouts is owned by `postgres` in prod (a manual-migration
-	// anomaly — migration 000073 intends marketplace_api ownership, but the row
-	// was created out-of-band), so marketplace_api has NO privileges on it and a
-	// DELETE aborts the whole single-tx purge (SQLSTATE 42501). Excluded here so
-	// the purge succeeds; its rows are ephemeral rate-limit lockouts (HMAC'd IP,
-	// nullable tenant_id, self-expiring via locked_until) — safe to retain.
-	// NOTE: break_glass_ACCOUNTS (the sensitive emergency-admin row) is owned by
-	// marketplace_api and IS still purged. If the ownership anomaly is ever fixed,
-	// break_glass_lockouts can be re-added to the plan.
+	// break_glass_lockouts is excluded by CHOICE, not by privilege (#457).
+	//
+	// It used to be excluded because it could not be deleted: the table was
+	// owned by `postgres` in prod — a manual-migration anomaly, since
+	// migration 000073 creates it as marketplace_api like every sibling table
+	// — so marketplace_api held NO privileges and a DELETE would abort the
+	// whole single-tx purge (SQLSTATE 42501).
+	//
+	// Ownership was transferred to marketplace_api on 2026-08-30 (see
+	// docs/ops/2026-08-30-break-glass-lockouts-ownership.md), so that reason
+	// is gone and a DELETE would now succeed.
+	//
+	// The exclusion stands on its own merits: the rows are ephemeral
+	// rate-limit lockouts (HMAC'd IP, self-expiring via locked_until) and
+	// tenant_id is NULLABLE — rows with no tenant are IP-level lockouts
+	// belonging to nobody, which a tenant-scoped purge must not touch.
+	//
+	// Re-adding it as tenantScoped() is now POSSIBLE and is a deliberate
+	// decision rather than a cleanup: it deletes a tenant's lockout rows on
+	// purge, which is defensible under art.17 and changes rate-limit state.
+	// Not made here — see the follow-up issue.
+	//
+	// break_glass_ACCOUNTS (the sensitive emergency-admin row) is owned by
+	// marketplace_api and IS still purged.
 	"break_glass_lockouts",
 }
 


### PR DESCRIPTION
Closes #457. **The database change is already applied and verified in production**; this PR carries the write-up and corrects code comments that now assert something false.

## The reported 500 was one symptom of three

`marketplace_api` held **no privileges at all** on `break_glass_lockouts` — confirmed from `information_schema.role_table_grants` and by `SET ROLE marketplace_api; SELECT … → permission denied`.

Two further consequences, both in the break-glass **login** path, neither reported:

1. **The durable 24h lockout had never been persisted** — `recordFailure` → `LockIP` → `INSERT` → denied, logged at `Warn` and swallowed.
2. **An existing lockout would never have been enforced** — the `IsIPLocked` fast path fails open; on error `locked` stays `false`.

So brute-force protection on break-glass login was, in production, entirely the in-memory per-pod limiter — it resets on every deploy and does not span replicas. The "durable decision" layer the code describes had never functioned since #333 shipped it.

Not unprotected (three strikes per hour per pod still applied, and login needs password **and** TOTP), but the documented 24h hard lockout did not exist.

## Why this is not a migration, despite being a schema-adjacent fix

A role can only `GRANT` on a table it owns. Migrations connect as `marketplace_api`; the table was owned by `postgres`. A migration carrying the fix would fail with `permission denied` and **block the rollout**.

It would also be pointless. Migration `000073` creates this table, migrations run as `marketplace_api`, and every sibling table from that same run is `marketplace_api`-owned:

```
break_glass_accounts  -> marketplace_api
enterprise_api_keys   -> marketplace_api
tenant_sso_configs    -> marketplace_api
break_glass_lockouts  -> postgres        ← the anomaly
```

The table was created out-of-band by `postgres`. **This is a production-only anomaly** — a fresh environment never has it. Same shape as the 2026-07-29 sequence-ownership incident, and applied the same way: privileged SQL by hand, written up in `docs/ops/`.

## Applied

```sql
ALTER TABLE break_glass_lockouts OWNER TO marketplace_api;
```

Ownership rather than `GRANT SELECT, INSERT`: it makes production match every sibling table and match a fresh environment, so the anomaly stops existing rather than being papered over. The narrower grant would have left prod permanently different from everywhere else.

## Verified in production

Via the admin-conformance suite, which probes this endpoint because contract v3 declares it:

```
break-glass  (2 passed, 0 failed, 3 skipped)
  PASS  §4.1  responds with the { data, pagination } envelope
  PASS  §4.5  returns 200 with an empty array when there are no rows
```

It returned 500 before the change.

## What changed in code

Only comments — but comments that were actively wrong the moment the ownership changed. `purge.go` and `purge_test.go` both justified excluding this table with *"marketplace_api has no DELETE"*, which is no longer true. They now say the exclusion is a **choice**, and record what it now rests on: `tenant_id` is NULLABLE, so rows with no tenant are IP-level lockouts belonging to nobody that a tenant-scoped purge must not touch.

A stale rationale in a purge plan is the kind of thing someone later reasons from. Correcting it is the point of this PR.

## Filed rather than folded in

- **#468** — the login path's fail-open on a lockout-read error. This is *why* a broken control went unnoticed: the only sign was a `Warn` nobody read. Failing closed is not obviously right either (a DB blip would lock everyone out of break-glass exactly when it is needed), so it needs a decision.
- **#469** — whether `break_glass_lockouts` should now be purged with its tenant, which the old test comment explicitly anticipated. Art.17 argues for it; the NULL-`tenant_id` rows are the trap.

## Verification

`go build ./...`, `go vet`, `go test ./internal/tenantpurge/` green.