### PR TITLE
fix(product): make Product.VendorID a non-pointer string to match the NOT NULL column (#402)

### DIFF
--- a/services/marketplace-api/internal/product/models.go
+++ b/services/marketplace-api/internal/product/models.go
@@ -50,10 +50,25 @@ type Product struct {
 	Title       string  `gorm:"column:title;type:varchar(300);not null"                  json:"title"`
 	Description *string `gorm:"column:description;type:text"                             json:"description,omitempty"`
 	Status      string  `gorm:"column:status;type:varchar(20);not null;default:draft"    json:"status"`
-	// VendorID is a pointer for historical reasons; the column has been NOT NULL
-	// since migration 000028. See issue #402 — tightening it to a plain string
-	// touches JSON omitempty and every nil check, so it is tracked separately.
-	VendorID            *string        `gorm:"column:vendor_id;type:uuid"                               json:"vendor_id,omitempty"`
+	// VendorID matches the column, which has been NOT NULL since migration
+	// 000028 (#402). It was a *string long after that stopped being true.
+	//
+	// products.vendor_id carries NO foreign key — only store_id and
+	// primary_category_id do — so any non-empty value satisfies the
+	// database. That makes this type the only structural guard there is,
+	// and as a pointer it guarded nothing: a Product could be built with no
+	// vendor at all and the failure surfaced as a NOT NULL violation at
+	// insert time. It cost 74 integration-test failures across three
+	// packages before anyone asked why.
+	//
+	// A plain string does not make an INVALID vendor impossible — "" is
+	// still constructible, and would reach Postgres as a malformed uuid.
+	// What it removes is the nil case and every nil check that came with
+	// it; resolveVendorID closes the empty case at the point of entry.
+	//
+	// json has no omitempty: the field is always present in the database,
+	// so hiding it from a response would misrepresent the row.
+	VendorID            string         `gorm:"column:vendor_id;type:uuid;not null"                      json:"vendor_id"`
 	Tags                pq.StringArray `gorm:"column:tags;type:text[];not null;default:'{}'"        json:"tags"`
 	SEOTitle            *string        `gorm:"column:seo_title;type:varchar(300)"                       json:"seo_title,omitempty"`
 	SEODescription      *string        `gorm:"column:seo_description;type:varchar(500)"                 json:"seo_description,omitempty"`

--- a/services/marketplace-api/internal/product/models_integration_test.go
+++ b/services/marketplace-api/internal/product/models_integration_test.go
@@ -72,7 +72,7 @@ func TestIntegration_FullProductGraph_RoundTrip(t *testing.T) {
 	prod := &product.Product{
 		TenantID:          tenantID,
 		StoreID:           storeID,
-		VendorID:          &vendorID,
+		VendorID:          vendorID,
 		Handle:            "linen-shirt",
 		Title:             "Linen Shirt",
 		Status:            product.StatusDraft,
@@ -278,7 +278,7 @@ func TestIntegration_PartialUnique_SoftDelete(t *testing.T) {
 	p1 := &product.Product{
 		TenantID: tenantID,
 		StoreID:  storeID,
-		VendorID: &vendorID,
+		VendorID: vendorID,
 		Handle:   "silk-scarf",
 		Title:    "Silk Scarf",
 		Status:   product.StatusDraft,
@@ -295,7 +295,7 @@ func TestIntegration_PartialUnique_SoftDelete(t *testing.T) {
 	p2 := &product.Product{
 		TenantID: tenantID,
 		StoreID:  storeID,
-		VendorID: &vendorID,
+		VendorID: vendorID,
 		Handle:   "silk-scarf",
 		Title:    "Silk Scarf (v2)",
 		Status:   product.StatusDraft,
@@ -318,7 +318,7 @@ func TestIntegration_PartialUnique_SoftDelete(t *testing.T) {
 	p3 := &product.Product{
 		TenantID: tenantID,
 		StoreID:  storeID,
-		VendorID: &vendorID,
+		VendorID: vendorID,
 		Handle:   "silk-scarf",
 		Title:    "Silk Scarf (v3)",
 		Status:   product.StatusDraft,

--- a/services/marketplace-api/internal/product/repository_integration_test.go
+++ b/services/marketplace-api/internal/product/repository_integration_test.go
@@ -55,7 +55,7 @@ func minimalAggregate(storeID, tenantID, vendorID, handle, sku string) *product.
 			ID:       uuid.NewString(),
 			TenantID: tenantID,
 			StoreID:  storeID,
-			VendorID: &vendorID,
+			VendorID: vendorID,
 			Handle:   handle,
 			Title:    "Test " + handle,
 			Status:   product.StatusDraft,
@@ -112,7 +112,7 @@ func richAggregate(t *testing.T, tx *gorm.DB, storeID, tenantID, vendorID, handl
 			ID:       uuid.NewString(),
 			TenantID: tenantID,
 			StoreID:  storeID,
-			VendorID: &vendorID,
+			VendorID: vendorID,
 			Handle:   handle,
 			Title:    "Rich " + handle,
 			Status:   product.StatusDraft,
@@ -538,7 +538,7 @@ func TestIntegration_ProductRepo_ApplyVariantDiffInTx_AddUpdateRemove(t *testing
 	v2ID := uuid.NewString()
 	agg := &product.Aggregate{
 		Product: product.Product{
-			ID: uuid.NewString(), TenantID: tenantID, StoreID: storeID, VendorID: &vendorID,
+			ID: uuid.NewString(), TenantID: tenantID, StoreID: storeID, VendorID: vendorID,
 			Handle: "diff-test", Title: "Diff Test", Status: product.StatusDraft,
 		},
 		Variants: []product.Variant{

--- a/services/marketplace-api/internal/product/repository_variant_softdelete_integration_test.go
+++ b/services/marketplace-api/internal/product/repository_variant_softdelete_integration_test.go
@@ -49,7 +49,7 @@ func TestIntegration_ProductRepo_Preload_FiltersSoftDeletedVariants(t *testing.T
 			ID:          uuid.NewString(),
 			TenantID:    tenantID,
 			StoreID:     storeID,
-			VendorID:    &vendorID,
+			VendorID:    vendorID,
 			Handle:      "leak-check",
 			Title:       "Leak Check",
 			Status:      product.StatusActive,

--- a/services/marketplace-api/internal/product/service.go
+++ b/services/marketplace-api/internal/product/service.go
@@ -325,7 +325,7 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (*Aggregate, er
 			TaxCode:           req.TaxCode,
 			TaxRateOverride:   req.TaxRateOverride,
 			TaxCategory:       req.TaxCategory,
-			VendorID:          req.VendorID,
+			VendorID:          *req.VendorID, // non-nil and non-empty: resolveVendorID guarantees it above
 			CreatedBy:         req.CreatedBy,
 			UpdatedBy:         req.CreatedBy,
 		},
@@ -577,8 +577,14 @@ func resolveVendorID(ctx context.Context, lookup SelfVendorLookup, in *CreateReq
 	if in.VendorID != nil && *in.VendorID != "" {
 		return nil
 	}
+	// No explicit vendor AND no way to resolve one. This used to be a
+	// silent no-op, which left VendorID nil all the way to the insert and
+	// turned a wiring bug into a NOT NULL violation from Postgres (#402).
+	// The nil lookup is for callers that always supply an explicit vendor —
+	// and those have already returned above.
 	if lookup == nil {
-		return nil
+		return apperrors.ValidationFailed("vendor_id",
+			"no vendor supplied and no self-vendor lookup is configured")
 	}
 	vid, err := lookup.GetSelfVendorID(ctx, in.TenantID)
 	if err != nil {

--- a/services/marketplace-api/internal/product/vendor_default_test.go
+++ b/services/marketplace-api/internal/product/vendor_default_test.go
@@ -33,10 +33,46 @@ func TestResolveVendorID_RespectsExplicit(t *testing.T) {
 	require.Equal(t, "v-explicit", *in.VendorID)
 }
 
-func TestResolveVendorID_NoLookup_NoOp(t *testing.T) {
+// Replaces TestResolveVendorID_NoLookup_NoOp, which asserted that a nil
+// lookup with no VendorID was a silent no-op (#402).
+//
+// That was the hole. products.vendor_id has been NOT NULL since migration
+// 000028 and carries NO foreign key, so the type was the only guard and it
+// guarded nothing: a Product could be built with no vendor and the failure
+// surfaced as a database error at insert time. It cost 74 integration-test
+// failures across three packages before anyone looked at why.
+//
+// The nil lookup exists for paths that always supply an explicit VendorID —
+// and that case still works, because the function returns early before ever
+// consulting the lookup. What cannot happen any more is reaching the end
+// with nothing set. A path that supplies neither a vendor nor a way to find
+// one is a wiring bug, and it should say so here rather than 22 lines later
+// in Postgres.
+func TestResolveVendorID_NoLookupAndNoVendor_Errors(t *testing.T) {
 	in := &CreateRequest{TenantID: "t1"}
+	err := resolveVendorID(context.Background(), nil, in)
+	require.Error(t, err,
+		"a product with no vendor and no way to resolve one must fail here, "+
+			"not as a NOT NULL violation at insert time")
+	require.True(t, errors.Is(err, apperrors.ErrValidationFailed))
+}
+
+// The documented purpose of the nil lookup is preserved: an explicit vendor
+// still needs no lookup at all.
+func TestResolveVendorID_NoLookupWithExplicitVendor_Succeeds(t *testing.T) {
+	explicit := "v-explicit"
+	in := &CreateRequest{TenantID: "t1", VendorID: &explicit}
 	require.NoError(t, resolveVendorID(context.Background(), nil, in))
-	require.Nil(t, in.VendorID)
+	require.Equal(t, "v-explicit", *in.VendorID)
+}
+
+// The invariant every caller downstream relies on: once this returns nil,
+// VendorID is set and non-empty, so the model can hold a plain string.
+func TestResolveVendorID_SuccessGuaranteesANonEmptyVendor(t *testing.T) {
+	in := &CreateRequest{TenantID: "t1"}
+	require.NoError(t, resolveVendorID(context.Background(), fakeVendorLookup{id: "v-abc"}, in))
+	require.NotNil(t, in.VendorID)
+	require.NotEmpty(t, *in.VendorID)
 }
 
 func TestResolveVendorID_LookupReturnsEmpty_Errors(t *testing.T) {


### PR DESCRIPTION
Closes #402.

`products.vendor_id` has been `NOT NULL` since migration `000028`; the struct stayed `*string` long after that stopped being true.

## Why the type was the only guard, and guarded nothing

`products.vendor_id` carries **no foreign key** — only `store_id` and `primary_category_id` do — so any non-empty value satisfies the database. The type was the sole structural guard, and as a pointer it permitted constructing a `Product` with no vendor at all, with the failure surfacing as a `NOT NULL` violation at insert time. Per the issue that cost **74 integration-test failures across three packages** before anyone asked why.

## Two changes, and the second is the one that matters

**1. `Product.VendorID` is now `string`.** Honest about what this buys: it removes the nil case and every nil check with it. It does **not** make an invalid vendor impossible — `""` is still constructible and would reach Postgres as a malformed uuid.

**2. `resolveVendorID` now refuses to return successfully with nothing set.** This is the actual fix. It previously treated "no explicit vendor AND no lookup configured" as a silent no-op, leaving `VendorID` nil all the way to the insert. A path that supplies neither a vendor nor a way to find one is a wiring bug, and it now says so at the point of entry instead of 22 lines later in Postgres.

Together they give the model a real invariant: once `resolveVendorID` returns nil, the vendor is set and non-empty, which is what lets the field be a plain string.

## An existing test asserted the hole

`TestResolveVendorID_NoLookup_NoOp` pinned the old behaviour, so this PR replaces it — flagging that rather than burying it.

The nil lookup exists for callers that always supply an explicit vendor, and **that case still works**: the function returns early before ever consulting the lookup, and `TestResolveVendorID_NoLookupWithExplicitVendor_Succeeds` pins it. What can no longer happen is reaching the end with nothing set.

## JSON change, stated

`json:"vendor_id,omitempty"` → `json:"vendor_id"`. The field is always present in the database, so hiding it from a response would misrepresent the row. In practice the wire shape is unchanged, since a real row always has a vendor.

## A mistake worth recording

My first pass at updating test fixtures used a regex over every `VendorID: &x`, which also rewrote `CreateRequest` literals — a type that is **correctly** still a pointer, since the vendor is optional input defaulted to the tenant's self-vendor. `go vet -tags=integration` caught it in `handlers/admin`. Fixed by rewriting only `Product` literals; `CreateRequest` usages are untouched, and the diff shows them still taking `&`.

Worth knowing that build-tagged integration files are invisible to `go build ./...` — the first sign of the breakage was a `[build failed]` in an integration run, not the compiler.

## Verification

- `go build ./...`, `go vet ./...`, full unit suite green
- `go vet -tags=integration` clean across the affected packages
- **full integration suite actually run** against a real database (`-tags=integration -p 1 -count=1`): clean, including `product`, `handlers/storefront` and `handlers/admin` — the three packages the issue names