### PR TITLE
fix(breakglass): degrade the lockout check to the in-memory limiter instead of failing open (#468)

### DIFF
--- a/services/marketplace-api/internal/handlers/admin/break_glass_degraded_test.go
+++ b/services/marketplace-api/internal/handlers/admin/break_glass_degraded_test.go
@@ -1,0 +1,50 @@
+package admin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+)
+
+// #468: when the lockout store cannot be read, the login path used to fail
+// OPEN unconditionally — the error was logged at Warn and `locked` stayed
+// false, so an existing lockout went unenforced.
+//
+// #457 proved that is not hypothetical: marketplace_api held no privileges
+// on break_glass_lockouts, so every read failed, and the only outward sign
+// was a Warn line nobody was reading.
+//
+// Failing CLOSED unconditionally is not the answer either. It would turn a
+// database blip into "nobody can break-glass in" — precisely when
+// break-glass is most likely to be needed, since this endpoint exists to
+// survive states other paths cannot.
+//
+// So the decision degrades to the in-memory limiter, which is per-pod and
+// resets on deploy but is the one signal still available: an IP already at
+// the failure threshold is refused, and an IP with no recent failures is
+// still let through to try its credentials.
+
+func TestDegradedLockDecision_RefusesAnIPAlreadyAtTheThreshold(t *testing.T) {
+	require.True(t, degradedLockDecision(breakglass.LoginMaxFailures),
+		"an IP that has already hit the threshold must not gain access just "+
+			"because the lockout store is unreachable")
+	require.True(t, degradedLockDecision(breakglass.LoginMaxFailures+5))
+}
+
+func TestDegradedLockDecision_AllowsAnIPWithNoRecentFailures(t *testing.T) {
+	require.False(t, degradedLockDecision(0),
+		"a database blip must not lock out an operator who has done nothing wrong — "+
+			"break-glass exists to work when other things do not")
+	require.False(t, degradedLockDecision(breakglass.LoginMaxFailures-1),
+		"below the threshold behaves exactly as it would with the store readable")
+}
+
+// The boundary is the same one RecordFailure uses to decide whether to
+// persist a lockout, so degraded and normal operation agree on what
+// "too many" means rather than drifting apart.
+func TestDegradedLockDecision_SharesTheThresholdWithNormalOperation(t *testing.T) {
+	require.False(t, degradedLockDecision(breakglass.LoginMaxFailures-1))
+	require.True(t, degradedLockDecision(breakglass.LoginMaxFailures))
+}

--- a/services/marketplace-api/internal/handlers/admin/break_glass_login.go
+++ b/services/marketplace-api/internal/handlers/admin/break_glass_login.go
@@ -73,7 +73,19 @@ func (h *BreakGlassLoginHandler) Login(c *gin.Context) {
 	// so timing can't distinguish locked vs. unlocked states.
 	locked, err := h.deps.Repo.IsIPLocked(ctx, ipHash)
 	if err != nil {
-		h.logger().Warn("break-glass: lockout lookup failed", "err", err)
+		// The lockout store is unreachable. This used to fail open
+		// unconditionally: the error was logged at Warn and `locked` stayed
+		// false, so an existing lockout went unenforced (#468). #457 showed
+		// that is not hypothetical — every read failed for weeks and the
+		// only sign was a Warn line nobody read.
+		//
+		// Degrade to the in-memory limiter rather than choosing one extreme.
+		// It is per-pod and resets on deploy, but it is the signal still
+		// available, and it refuses exactly the IPs that have earned it.
+		recent := h.deps.RateLimiter.Count(rlKey(ipHash))
+		locked = degradedLockDecision(recent)
+		h.logger().Error("break-glass: lockout lookup failed; degraded to the in-memory limiter",
+			"err", err, "recent_failures", recent, "treated_as_locked", locked)
 	}
 	if locked {
 		c.JSON(http.StatusTooManyRequests, gin.H{"error": "locked"})
@@ -182,7 +194,12 @@ func (h *BreakGlassLoginHandler) recordFailure(c *gin.Context, ipHash []byte, te
 			tidPtr = &tenantID
 		}
 		if err := h.deps.Repo.LockIP(c.Request.Context(), ipHash, tidPtr, reason, breakglass.LoginLockoutDuration); err != nil {
-			h.logger().Warn("break-glass: LockIP failed", "err", err)
+			// Error, not Warn (#468). This is the durable half of a security
+			// control failing: the 24h lockout is not persisted, so it will
+			// not survive this pod, and every other replica remains unaware.
+			// It was logged at Warn while broken for weeks and nobody saw it.
+			h.logger().Error("break-glass: lockout NOT persisted; the 24h hard lockout is not in effect",
+				"err", err, "failures_in_window", count)
 		}
 	}
 
@@ -226,4 +243,24 @@ var breakGlassNamespace = uuid.MustParse("1ffb2c0e-8c3a-4d78-9aee-62267a3c110a")
 // collides with a real user).
 func BreakGlassUserID(tenantID uuid.UUID) uuid.UUID {
 	return uuid.NewSHA1(breakGlassNamespace, []byte(tenantID.String()))
+}
+
+// degradedLockDecision decides whether to treat a login as locked when the
+// lockout store could not be read (#468).
+//
+// Neither extreme is right. Failing open unconditionally — the old
+// behaviour — means an existing lockout is silently unenforced for as long
+// as the store is unreachable, which #457 showed can be weeks. Failing
+// closed unconditionally turns a database blip into "nobody can break-glass
+// in", precisely when break-glass is most likely to be needed: this
+// endpoint is mounted outside the store-scoped group specifically to
+// survive states other paths cannot.
+//
+// So it falls back to the in-memory limiter. That counter is per-pod and
+// resets on deploy, so it is a weaker signal than the table — but it is the
+// signal still available, and it refuses only IPs that have already reached
+// the same threshold a persisted lockout would have used. An operator whose
+// IP has done nothing wrong is unaffected.
+func degradedLockDecision(recentFailures int) bool {
+	return recentFailures >= breakglass.LoginMaxFailures
 }


### PR DESCRIPTION
Closes #468.

## What was wrong

When the lockout store could not be read, the login path failed **open** unconditionally: the error was logged at `Warn`, `locked` stayed false, and an existing lockout went unenforced.

#457 showed that is not hypothetical. `marketplace_api` held no privileges on `break_glass_lockouts`, so every read failed — for weeks — and the only outward sign was a `Warn` line nobody was reading. The persist side failed the same way, so the durable 24h lockout was never written either.

## Why neither extreme is the answer

**Failing open** is what we had: a security control silently absent for as long as its storage is unavailable, with no way to tell whether it is working.

**Failing closed** turns a database blip into "nobody can break-glass in" — precisely when break-glass is most likely to be needed. This endpoint is mounted outside the store-scoped `RequireActive` group specifically to survive states other paths cannot; making it the first thing to break under stress inverts its purpose.

## What it does instead

Degrades to the in-memory limiter, which already exists and is already consulted on every failure:

```go
recent := h.deps.RateLimiter.Count(rlKey(ipHash))
locked = degradedLockDecision(recent)
```

That counter is per-pod and resets on deploy, so it is a weaker signal than the table — but it is the signal still available, and it refuses **only** IPs that have already reached the same threshold a persisted lockout would have used. An operator whose IP has done nothing wrong is unaffected; an IP mid-attack does not gain access because the database is sick.

The decision is a pure function so the policy is testable without a database — `Repo` is a concrete type, and the alternative was no test at all.

## Also: the persist failure is now an Error

```
break-glass: lockout NOT persisted; the 24h hard lockout is not in effect
```

Previously `Warn`. This is the durable half of a security control failing — the lockout will not survive the pod and no other replica learns of it. It sat at `Warn` while broken for weeks.

## Deliberately not added

**A dedicated Slack alert for the persist failure.** The issue suggested reusing the existing on-call signal, but `PostLoginAlert(tenantID, success)` reports *login outcomes*; firing it here would misreport a storage failure as an authentication event. A new interface method would be the honest way, and that is scope beyond this fix. `Error`-level logging is the proportionate change.

## Verification

- 3 tests, written first, covering both sides of the threshold and asserting the degraded path shares its boundary with normal operation rather than drifting
- `go build`, `go vet`, full unit suite green
- integration tests **actually ran** against a real database: `handlers/admin` and `breakglass` both clean