### PR TITLE
feat(tenantpurge): purge break_glass_lockouts with its tenant, sparing platform-wide rows (#469)

### DIFF
--- a/services/marketplace-api/internal/tenantpurge/break_glass_lockouts_purge_integration_test.go
+++ b/services/marketplace-api/internal/tenantpurge/break_glass_lockouts_purge_integration_test.go
@@ -1,0 +1,69 @@
+//go:build integration
+
+package tenantpurge_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/tenantpurge"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// #469, against a real database rather than the plan alone.
+//
+// Two things need proving, and neither is visible in purgePlan's SQL:
+//
+//  1. The DELETE actually SUCCEEDS. Until #457 it could not — the table was
+//     `postgres`-owned in production and the statement aborted the whole
+//     single-tx purge with SQLSTATE 42501. A plan test cannot see that; only
+//     running it can.
+//  2. A NULL-tenant row SURVIVES. Those are IP-level lockouts belonging to
+//     nobody, earned against the platform rather than one merchant. If a
+//     purge cleared them, anyone could drop a live lockout by having any
+//     tenant purged.
+func TestIntegration_Purge_BreakGlassLockouts(t *testing.T) {
+	db := testdb.NewDB(t, append(domainTablesToCleanup, "break_glass_lockouts")...)
+	ctx := context.Background()
+
+	purged := seedTenant(t, db, uuid.NewString())
+	other := seedTenant(t, db, uuid.NewString())
+
+	ins := `INSERT INTO break_glass_lockouts (ip_hash, tenant_id, locked_until, reason) VALUES (decode(?, 'hex'), ?, ?, ?)`
+	until := time.Now().Add(24 * time.Hour)
+	if err := db.Exec(ins, "010203", purged.tenantID, until, "test_purged").Error; err != nil {
+		t.Fatalf("seed lockout for purged tenant: %v", err)
+	}
+	if err := db.Exec(ins, "040506", other.tenantID, until, "test_other").Error; err != nil {
+		t.Fatalf("seed lockout for other tenant: %v", err)
+	}
+	// The one that must survive: no tenant at all.
+	if err := db.Exec(`INSERT INTO break_glass_lockouts (ip_hash, tenant_id, locked_until, reason) VALUES (decode(?, 'hex'), NULL, ?, ?)`,
+		"070809", until, "test_platform_wide").Error; err != nil {
+		t.Fatalf("seed platform-wide lockout: %v", err)
+	}
+
+	if _, err := tenantpurge.Purge(ctx, db, purged.tenantID, []string{purged.storeID}); err != nil {
+		t.Fatalf("Purge: %v — a permission error here means the table's ownership regressed (#457)", err)
+	}
+
+	if n := countRows(t, db, "break_glass_lockouts", "tenant_id", purged.tenantID); n != 0 {
+		t.Errorf("purged tenant's lockouts should be gone, got %d", n)
+	}
+	if n := countRows(t, db, "break_glass_lockouts", "tenant_id", other.tenantID); n != 1 {
+		t.Errorf("another tenant's lockout must be untouched, got %d rows", n)
+	}
+
+	var nullTenant int64
+	if err := db.Raw(`SELECT count(*) FROM break_glass_lockouts WHERE tenant_id IS NULL AND reason = 'test_platform_wide'`).
+		Scan(&nullTenant).Error; err != nil {
+		t.Fatalf("count null-tenant lockouts: %v", err)
+	}
+	if nullTenant != 1 {
+		t.Errorf("a NULL-tenant lockout is platform-wide protection belonging to nobody "+
+			"and must survive any tenant purge; got %d rows", nullTenant)
+	}
+}

--- a/services/marketplace-api/internal/tenantpurge/break_glass_lockouts_purge_test.go
+++ b/services/marketplace-api/internal/tenantpurge/break_glass_lockouts_purge_test.go
@@ -1,0 +1,58 @@
+package tenantpurge
+
+import (
+	"strings"
+	"testing"
+)
+
+// #469: break_glass_lockouts is now purged with its tenant.
+//
+// It was excluded because it COULD NOT be deleted — the table was owned by
+// `postgres` in production, marketplace_api had no DELETE, and including it
+// aborted the whole single-tx purge (SQLSTATE 42501). #457 transferred
+// ownership, so that constraint is gone and the exclusion became a choice.
+//
+// The choice is to purge it: the row links a tenant to an HMAC'd client IP,
+// which is pseudonymous personal data, and "we could not delete it" is no
+// longer an answer under art.17.
+
+func TestPurgePlan_IncludesBreakGlassLockouts(t *testing.T) {
+	steps := purgePlan(testTenantID, testStoreIDs)
+	if stepIndex(steps, "break_glass_lockouts") < 0 {
+		t.Fatal("break_glass_lockouts must be purged with its tenant (#469) — " +
+			"the ownership constraint that forced its exclusion was removed in #457")
+	}
+}
+
+// THE TRAP THIS TEST EXISTS FOR.
+//
+// tenant_id is NULLABLE. A row with no tenant is an IP-level lockout
+// belonging to nobody — protection earned against the platform, not against
+// one merchant. A purge that deleted those would let anyone clear an active
+// lockout by having any tenant purged, and would silently discard other
+// tenants' protection too.
+//
+// `WHERE tenant_id = ?` never matches NULL in SQL, so the correct behaviour
+// falls out of tenantScoped for free. This asserts it deliberately rather
+// than relying on that remaining true through a future refactor — a broader
+// predicate, an OR IS NULL, or a switch to a different scoping helper would
+// all compile and all be wrong.
+func TestPurgePlan_BreakGlassLockoutsNeverTouchesNullTenantRows(t *testing.T) {
+	steps := purgePlan(testTenantID, testStoreIDs)
+	i := stepIndex(steps, "break_glass_lockouts")
+	if i < 0 {
+		t.Fatal("step missing; see TestPurgePlan_IncludesBreakGlassLockouts")
+	}
+	sql := strings.ToUpper(steps[i].sql)
+
+	if !strings.Contains(sql, "WHERE TENANT_ID = ?") {
+		t.Errorf("must scope on an equality against tenant_id, which cannot match NULL; got: %s", steps[i].sql)
+	}
+	if strings.Contains(sql, "IS NULL") || strings.Contains(sql, " OR ") {
+		t.Errorf("must not widen past a single tenant — NULL-tenant rows are "+
+			"platform-wide lockouts belonging to nobody; got: %s", steps[i].sql)
+	}
+	if len(steps[i].args) != 1 || steps[i].args[0] != testTenantID {
+		t.Errorf("must bind exactly the purged tenant; got args %v", steps[i].args)
+	}
+}

--- a/services/marketplace-api/internal/tenantpurge/purge.go
+++ b/services/marketplace-api/internal/tenantpurge/purge.go
@@ -78,9 +78,9 @@
 // break_glass_lockouts was the one table where the privilege claim was
 // true — owned by `postgres` in production, so marketplace_api had no
 // DELETE and including it would abort the whole single-tx purge
-// (SQLSTATE 42501). Ownership was transferred to marketplace_api on
-// 2026-08-30 (#457), so it is now excluded by choice rather than by
-// privilege. See the inline comment in group 5.
+// (SQLSTATE 42501). #457 transferred ownership; #469 then added it to the
+// plan. Its tenant_id is NULLABLE, and rows with no tenant are
+// platform-wide lockouts that a tenant-scoped DELETE must never match.
 //
 // See task-1-report.md for the full per-table FK/scoping audit.
 package tenantpurge
@@ -355,20 +355,22 @@ func purgePlan(tenantID string, storeIDs []string) []deleteStep {
 		tenantScoped("tenant_sso_configs", tenantID),       // 000070: tenant_id (PK)
 		tenantScoped("storefront_push_tokens", tenantID),   // 000022: tenant_id
 		tenantScoped("admin_push_tokens", tenantID),        // 000021: tenant_id, store_id
-		// break_glass_lockouts is intentionally NOT purged — by choice since
-		// #457, having previously been by necessity.
+		// break_glass_lockouts links a tenant to an HMAC'd client IP, which
+		// is pseudonymous personal data, so it goes with the tenant (#469).
 		//
-		// The table was owned by `postgres` in prod (a manual-migration
-		// anomaly), so marketplace_api had no DELETE and including it aborted
-		// the whole single-tx purge. Ownership moved to marketplace_api on
-		// 2026-08-30 and a DELETE would now succeed.
+		// It was excluded until 2026-08-30 because it COULD NOT be deleted:
+		// the table was owned by `postgres` in production, marketplace_api had
+		// no DELETE, and including it aborted the whole single-tx purge
+		// (SQLSTATE 42501). #457 transferred ownership and removed that
+		// constraint.
 		//
-		// It stays excluded because tenant_id is NULLABLE: rows with no tenant
-		// are IP-level lockouts belonging to nobody, and the rows are ephemeral
-		// and self-expiring via locked_until. Re-adding it is now possible and
-		// is a deliberate decision, not a tidy-up. See protectedTables in
-		// purge_test.go. break_glass_accounts (below) IS owned by
-		// marketplace_api and is still purged.
+		// tenant_id is NULLABLE and that matters here: a row with no tenant is
+		// an IP-level lockout belonging to nobody, earned against the platform
+		// rather than one merchant. `WHERE tenant_id = ?` never matches NULL,
+		// so those survive — which is the point, not an accident. Widening this
+		// predicate would let any purge clear a live platform-wide lockout. See
+		// TestPurgePlan_BreakGlassLockoutsNeverTouchesNullTenantRows.
+		tenantScoped("break_glass_lockouts", tenantID), // 000073: tenant_id (nullable)
 		tenantScoped("break_glass_accounts", tenantID), // 000072: tenant_id (PK)
 		tenantScoped("enterprise_api_keys", tenantID),  // 000068: tenant_id, store_id
 		// audit_logs is tenant-scoped EXCEPT for operator rows. A platform

--- a/services/marketplace-api/internal/tenantpurge/purge_test.go
+++ b/services/marketplace-api/internal/tenantpurge/purge_test.go
@@ -40,31 +40,14 @@ var protectedTables = []string{
 	"user_profiles",
 	"promo_codes",
 	"signup_anomaly_log",
-	// break_glass_lockouts is excluded by CHOICE, not by privilege (#457).
-	//
-	// It used to be excluded because it could not be deleted: the table was
-	// owned by `postgres` in prod — a manual-migration anomaly, since
-	// migration 000073 creates it as marketplace_api like every sibling table
-	// — so marketplace_api held NO privileges and a DELETE would abort the
-	// whole single-tx purge (SQLSTATE 42501).
-	//
-	// Ownership was transferred to marketplace_api on 2026-08-30 (see
-	// docs/ops/2026-08-30-break-glass-lockouts-ownership.md), so that reason
-	// is gone and a DELETE would now succeed.
-	//
-	// The exclusion stands on its own merits: the rows are ephemeral
-	// rate-limit lockouts (HMAC'd IP, self-expiring via locked_until) and
-	// tenant_id is NULLABLE — rows with no tenant are IP-level lockouts
-	// belonging to nobody, which a tenant-scoped purge must not touch.
-	//
-	// Re-adding it as tenantScoped() is now POSSIBLE and is a deliberate
-	// decision rather than a cleanup: it deletes a tenant's lockout rows on
-	// purge, which is defensible under art.17 and changes rate-limit state.
-	// Not made here — see the follow-up issue.
+	// break_glass_lockouts is NO LONGER protected: #457 removed the
+	// ownership constraint and #469 added it to the plan, because the row
+	// links a tenant to an HMAC'd client IP. Its NULL-tenant rows are
+	// guarded by TestPurgePlan_BreakGlassLockoutsNeverTouchesNullTenantRows
+	// rather than by exclusion.
 	//
 	// break_glass_ACCOUNTS (the sensitive emergency-admin row) is owned by
-	// marketplace_api and IS still purged.
-	"break_glass_lockouts",
+	// marketplace_api and has always been purged.
 }
 
 func stepIndex(steps []deleteStep, table string) int {


### PR DESCRIPTION
Closes #469. Adds `break_glass_lockouts` to the purge plan as `tenantScoped()`.

## Why now

It was excluded because it **could not** be deleted: the table was `postgres`-owned in production, `marketplace_api` had no DELETE, and including it aborted the whole single-tx purge with `SQLSTATE 42501`. #457 transferred ownership, so the exclusion became a choice rather than a constraint — and `purge_test.go`'s own note anticipated exactly this: *"If the ownership anomaly is ever fixed, break_glass_lockouts can be re-added to the plan."*

The choice is to purge it. The row links a tenant to an HMAC'd client IP — pseudonymous personal data — and *"we could not delete it"* is no longer an answer under art.17.

## The trap, and the test that exists for it

**`tenant_id` is NULLABLE.** A row with no tenant is an IP-level lockout belonging to nobody — protection earned against the platform, not against one merchant. If a purge cleared those, anyone could drop a live lockout by having any tenant purged, and other tenants' protection would go with it.

`WHERE tenant_id = ?` never matches NULL, so the correct behaviour falls out of `tenantScoped` for free. That is exactly why it deserves an explicit test rather than a comment: a broader predicate, an added `OR IS NULL`, or a switch to a different scoping helper would all compile and all be wrong, and nothing would notice.

## Two tests, doing different jobs

**Structural** — asserts the step scopes on an equality against `tenant_id`, contains no `IS NULL` or `OR`, and binds exactly the purged tenant.

**Integration, against a real database** — proves two things the plan cannot show:

1. **The DELETE actually succeeds.** Until #457 it could not. A plan test cannot see a permission failure; only running it can. The failure message says so, so a future ownership regression reads as an ownership regression rather than a mystery.
2. **A NULL-tenant row survives.** Seeded alongside two tenant-scoped rows; after purging one tenant, the other tenant's row and the platform-wide row are both still there.

## Verification

- both tests written first and watched fail
- `go build`, `go vet`, full unit suite green
- integration suite **actually ran** against a real database: `./internal/tenantpurge/...` clean

Comments in `purge.go` and `purge_test.go` updated again — they were corrected in #457 to say the exclusion was a choice, and now say what the plan actually does.