### PR TITLE
feat(inventory): add stock_holds and the hold/commit/release repository (#231)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/reconciliation/... \
 	    ./internal/shipping/... \
 	    ./internal/signup/... \
+	    ./internal/stockhold/... \
 	    ./internal/stores/... \
 	    ./internal/subscription \
 	    ./internal/subscription/cancel/... \

--- a/services/marketplace-api/internal/stockhold/repository.go
+++ b/services/marketplace-api/internal/stockhold/repository.go
@@ -1,0 +1,180 @@
+// Package stockhold implements time-boxed stock reservations in Postgres
+// (#231, under the #229 epic).
+//
+// # The problem it exists for
+//
+// The storefront had no inventory control at all: with one unit in stock,
+// two concurrent customers both checked out and the quantity never moved
+// (#230). A comment claimed a decrement-on-sale trigger existed; it never
+// did.
+//
+// # Availability is computed, never stored
+//
+//	available = variant_stock.quantity
+//	          - SUM(qty) FILTER (WHERE state = 'held' AND expires_at > now())
+//
+// A hold therefore expires BY THE CLOCK, not by a job running. If the
+// sweeper stops, availability stays correct and only dead rows accumulate.
+// A stored "reserved" counter would make the sweeper load-bearing for
+// correctness, and a missed run would silently strand stock — the failure
+// mode you discover at Christmas.
+//
+// # Why Postgres and not Redis
+//
+// The hold lives in the same database and the same transaction as the order.
+// A hold in Redis with the order in Postgres cannot be made atomic, so a
+// Redis failover would release stock a paying customer is mid-checkout on.
+package stockhold
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// ErrInsufficientStock signals the requested quantity exceeds what is
+// available once live holds are subtracted.
+//
+// Deliberately distinct from a generic failure: the storefront turns this
+// into a 409 naming the variant, and a caller must never confuse "someone
+// else holds the last unit" with "the database is unreachable".
+var ErrInsufficientStock = errors.New("stockhold: insufficient stock")
+
+// sweepGrace is how long an expired hold is kept before the sweeper deletes
+// it. An expired hold already reduces availability by nothing, so there is
+// no rush — and keeping it briefly leaves evidence of what happened when
+// someone asks why a cart lost its unit.
+const sweepGrace = time.Hour
+
+type Repository struct{}
+
+func NewRepository() *Repository { return &Repository{} }
+
+// Hold reserves qty of a variant for cartToken until now()+ttl.
+//
+// It runs in the CALLER'S transaction so the reservation and whatever
+// prompted it commit or roll back together.
+//
+// Idempotent per (cart_token, variant_id, location_id): a repeat call
+// refreshes the expiry rather than stacking a second reservation, so a
+// customer revisiting checkout does not consume their own stock twice and
+// lock themselves out.
+func (r *Repository) Hold(ctx context.Context, tx *gorm.DB, cartToken, variantID, locationID string, qty int, ttl time.Duration) error {
+	if qty <= 0 {
+		return fmt.Errorf("stockhold: qty must be positive, got %d", qty)
+	}
+
+	// SELECT ... FOR UPDATE on the stock row serialises contenders. Without
+	// it, two transactions read the same availability, both find it
+	// sufficient, and both insert — the oversell in #230. The lock is taken
+	// on variant_stock rather than on the holds, because the holds a
+	// competitor is about to insert do not exist yet to be locked.
+	var quantity int
+	err := tx.WithContext(ctx).Raw(
+		`SELECT quantity FROM variant_stock WHERE variant_id = ? AND location_id = ? FOR UPDATE`,
+		variantID, locationID).Scan(&quantity).Error
+	if err != nil {
+		return fmt.Errorf("stockhold: lock stock row: %w", err)
+	}
+
+	// Sum live holds, EXCLUDING this cart's own: a refresh must not count
+	// the reservation it is replacing, or a cart could never re-hold what it
+	// already has.
+	var held int
+	err = tx.WithContext(ctx).Raw(
+		`SELECT COALESCE(SUM(qty), 0) FROM stock_holds
+		  WHERE variant_id = ? AND location_id = ?
+		    AND state = 'held' AND expires_at > now()
+		    AND cart_token <> ?`,
+		variantID, locationID, cartToken).Scan(&held).Error
+	if err != nil {
+		return fmt.Errorf("stockhold: sum live holds: %w", err)
+	}
+
+	if quantity-held < qty {
+		return fmt.Errorf("%w: want %d, available %d", ErrInsufficientStock, qty, quantity-held)
+	}
+
+	// ON CONFLICT makes the refresh atomic with the check above, inside the
+	// row lock. state is reset to 'held' so a cart that released and came
+	// back reuses its row rather than colliding with the unique constraint.
+	return tx.WithContext(ctx).Exec(
+		`INSERT INTO stock_holds (variant_id, location_id, cart_token, qty, expires_at, state)
+		 VALUES (?, ?, ?, ?, ?, 'held')
+		 ON CONFLICT (cart_token, variant_id, location_id)
+		 DO UPDATE SET qty = EXCLUDED.qty, expires_at = EXCLUDED.expires_at, state = 'held'`,
+		variantID, locationID, cartToken, qty, time.Now().Add(ttl)).Error
+}
+
+// Commit decrements variant_stock for every live hold on the cart and flips
+// those holds to 'committed', in the caller's transaction.
+//
+// The decrement and the state flip must be one statement pair inside one
+// transaction: a committed hold no longer reduces availability (the stock
+// row already reflects it), so a crash between them would either double-count
+// the sale or release it back to the pool.
+func (r *Repository) Commit(ctx context.Context, tx *gorm.DB, cartToken string) error {
+	err := tx.WithContext(ctx).Exec(
+		`UPDATE variant_stock vs
+		    SET quantity = vs.quantity - h.qty, updated_at = now()
+		   FROM stock_holds h
+		  WHERE h.cart_token = ? AND h.state = 'held'
+		    AND vs.variant_id = h.variant_id AND vs.location_id = h.location_id`,
+		cartToken).Error
+	if err != nil {
+		// variant_stock_quantity_non_negative fires here if the arithmetic
+		// would go below zero — the CHECK is the guarantee behind the
+		// FOR UPDATE discipline, not a duplicate of it.
+		return fmt.Errorf("stockhold: decrement stock: %w", err)
+	}
+
+	return tx.WithContext(ctx).Exec(
+		`UPDATE stock_holds SET state = 'committed' WHERE cart_token = ? AND state = 'held'`,
+		cartToken).Error
+}
+
+// Release returns a cart's live holds to the pool.
+func (r *Repository) Release(ctx context.Context, tx *gorm.DB, cartToken string) error {
+	return tx.WithContext(ctx).Exec(
+		`UPDATE stock_holds SET state = 'released' WHERE cart_token = ? AND state = 'held'`,
+		cartToken).Error
+}
+
+// Extend pushes a live cart's expiry out, for a customer still working
+// through checkout.
+//
+// It deliberately does NOT revive an expired hold: by then the units may be
+// someone else's, and silently taking them back would oversell exactly as if
+// no hold existed.
+func (r *Repository) Extend(ctx context.Context, tx *gorm.DB, cartToken string, ttl time.Duration) error {
+	return tx.WithContext(ctx).Exec(
+		`UPDATE stock_holds SET expires_at = ?
+		  WHERE cart_token = ? AND state = 'held' AND expires_at > now()`,
+		time.Now().Add(ttl), cartToken).Error
+}
+
+// Sweep deletes holds that expired more than sweepGrace ago, in bounded
+// batches, and returns how many it removed.
+//
+// It is housekeeping, not correctness: an expired hold already reduces
+// availability by nothing. FOR UPDATE SKIP LOCKED so concurrent sweepers on
+// multiple replicas do not block each other or double-delete.
+func (r *Repository) Sweep(ctx context.Context, db *gorm.DB, batch int) (int64, error) {
+	if batch <= 0 {
+		batch = 500
+	}
+	res := db.WithContext(ctx).Exec(
+		`DELETE FROM stock_holds
+		  WHERE id IN (
+		      SELECT id FROM stock_holds
+		       WHERE state = 'held' AND expires_at < now() - ?::interval
+		       ORDER BY expires_at
+		       LIMIT ?
+		       FOR UPDATE SKIP LOCKED
+		  )`,
+		fmt.Sprintf("%d seconds", int(sweepGrace.Seconds())), batch)
+	return res.RowsAffected, res.Error
+}

--- a/services/marketplace-api/internal/stockhold/repository_integration_test.go
+++ b/services/marketplace-api/internal/stockhold/repository_integration_test.go
@@ -1,0 +1,252 @@
+//go:build integration
+
+package stockhold_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/stockhold"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// #231. These are integration tests by necessity, not preference: the
+// property that matters is what happens when two connections contend for the
+// same unit, and that is invisible to a single-transaction test.
+
+const testLocation = "00000000-0000-0000-0000-000000000001"
+
+// seedVariant creates the minimum product/variant/stock rows a hold needs.
+func seedVariant(t *testing.T, db *gorm.DB, qty int) string {
+	t.Helper()
+	tenantID, storeID := uuid.NewString(), uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO stores (id, tenant_id, name, slug, status, country_code, currency_code, timezone,
+		                     storefront_customer_portal_secret)
+		 VALUES (?, ?, 'Stock Test', ?, 'active', 'AU', 'AUD', 'Australia/Sydney', ?)`,
+		storeID, tenantID, "stock-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	productID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		// status='active' requires published_at (products_published_requires_active).
+		`INSERT INTO products (id, tenant_id, store_id, title, handle, status, vendor_id, published_at)
+		 VALUES (?, ?, ?, 'Stock Test Product', ?, 'active', ?, now())`,
+		productID, tenantID, storeID, "stock-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	variantID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO product_variants (id, product_id, store_id, sku, price, currency_code)
+		 VALUES (?, ?, ?, ?, 10.00, 'AUD')`,
+		variantID, productID, storeID, "SKU-"+uuid.NewString()[:8]).Error)
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, ?, now())`, variantID, testLocation, qty).Error)
+	return variantID
+}
+
+func TestHold_ReducesAvailabilityAndRefusesWhenShort(t *testing.T) {
+	db := testdb.NewDB(t, "stock_holds")
+	repo := stockhold.NewRepository()
+	ctx := context.Background()
+	variantID := seedVariant(t, db, 3)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, uuid.NewString(), variantID, testLocation, 2, time.Minute)
+	}))
+
+	// 1 unit left; asking for 2 must fail rather than oversell.
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, uuid.NewString(), variantID, testLocation, 2, time.Minute)
+	})
+	require.True(t, errors.Is(err, stockhold.ErrInsufficientStock), "got %v", err)
+
+	// The remaining 1 is still obtainable.
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, uuid.NewString(), variantID, testLocation, 1, time.Minute)
+	}))
+}
+
+// A repeat Hold for the same cart must REFRESH, not stack a second
+// reservation — otherwise a customer revisiting checkout consumes their own
+// stock twice and locks themselves out.
+func TestHold_IsIdempotentPerCartAndRefreshesExpiry(t *testing.T) {
+	db := testdb.NewDB(t, "stock_holds")
+	repo := stockhold.NewRepository()
+	ctx := context.Background()
+	variantID := seedVariant(t, db, 1)
+	cart := uuid.NewString()
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, cart, variantID, testLocation, 1, time.Second)
+	}))
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, cart, variantID, testLocation, 1, time.Hour)
+	}))
+
+	var rows int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM stock_holds WHERE cart_token = ?`, cart).Scan(&rows).Error)
+	require.Equal(t, int64(1), rows, "a repeat hold must refresh the existing row, not add one")
+
+	var expires time.Time
+	require.NoError(t, db.Raw(`SELECT expires_at FROM stock_holds WHERE cart_token = ?`, cart).Scan(&expires).Error)
+	require.True(t, expires.After(time.Now().Add(30*time.Minute)), "expiry must be pushed out")
+}
+
+// The clock, not the sweeper, is what frees stock. Nothing is running here.
+func TestHold_ExpiredHoldDoesNotReduceAvailability(t *testing.T) {
+	db := testdb.NewDB(t, "stock_holds")
+	repo := stockhold.NewRepository()
+	ctx := context.Background()
+	variantID := seedVariant(t, db, 1)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, uuid.NewString(), variantID, testLocation, 1, -time.Minute)
+	}))
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, uuid.NewString(), variantID, testLocation, 1, time.Minute)
+	}), "an expired hold must not reserve anything, with no sweeper running")
+}
+
+func TestCommit_DecrementsStockAndFlipsHolds(t *testing.T) {
+	db := testdb.NewDB(t, "stock_holds")
+	repo := stockhold.NewRepository()
+	ctx := context.Background()
+	variantID := seedVariant(t, db, 5)
+	cart := uuid.NewString()
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, cart, variantID, testLocation, 2, time.Minute)
+	}))
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Commit(ctx, tx, cart)
+	}))
+
+	var qty int
+	require.NoError(t, db.Raw(`SELECT quantity FROM variant_stock WHERE variant_id = ?`, variantID).Scan(&qty).Error)
+	require.Equal(t, 3, qty, "a committed sale must decrement the stock row")
+
+	var state string
+	require.NoError(t, db.Raw(`SELECT state FROM stock_holds WHERE cart_token = ?`, cart).Scan(&state).Error)
+	require.Equal(t, "committed", state)
+
+	// The committed hold must no longer reduce availability — the stock row
+	// already reflects it, so counting both would double-charge the variant.
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, uuid.NewString(), variantID, testLocation, 3, time.Minute)
+	}))
+}
+
+func TestRelease_ReturnsStockToThePool(t *testing.T) {
+	db := testdb.NewDB(t, "stock_holds")
+	repo := stockhold.NewRepository()
+	ctx := context.Background()
+	variantID := seedVariant(t, db, 1)
+	cart := uuid.NewString()
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, cart, variantID, testLocation, 1, time.Hour)
+	}))
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Release(ctx, tx, cart)
+	}))
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, uuid.NewString(), variantID, testLocation, 1, time.Minute)
+	}), "a released hold must return its unit to the pool")
+}
+
+// THE TEST THIS PACKAGE EXISTS FOR.
+//
+// N goroutines on separate connections contend for M units. Exactly M may
+// win. This is the oversell #230 reports, and it cannot be reproduced with
+// testdb.NewTx — a single transaction cannot see another connection's
+// uncommitted rows, so the contention never happens.
+func TestHold_ConcurrentContendersCannotOversell(t *testing.T) {
+	db := testdb.NewDB(t, "stock_holds")
+	repo := stockhold.NewRepository()
+	ctx := context.Background()
+
+	const units, contenders = 3, 12
+	variantID := seedVariant(t, db, units)
+
+	var wg sync.WaitGroup
+	results := make(chan error, contenders)
+	start := make(chan struct{})
+	for i := 0; i < contenders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			results <- db.Transaction(func(tx *gorm.DB) error {
+				return repo.Hold(ctx, tx, uuid.NewString(), variantID, testLocation, 1, time.Minute)
+			})
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	var ok, short, other int
+	for err := range results {
+		switch {
+		case err == nil:
+			ok++
+		case errors.Is(err, stockhold.ErrInsufficientStock):
+			short++
+		default:
+			other++
+			t.Logf("unexpected error: %v", err)
+		}
+	}
+	require.Equal(t, 0, other, "no contender may fail for an unexpected reason")
+	require.Equal(t, units, ok, "exactly the available units may be held — more is an oversell")
+	require.Equal(t, contenders-units, short)
+}
+
+// The sweeper deletes dead rows only. It must never touch a live hold, and
+// availability must not change when it runs.
+func TestSweep_DeletesOnlyLongExpiredHolds(t *testing.T) {
+	db := testdb.NewDB(t, "stock_holds")
+	repo := stockhold.NewRepository()
+	ctx := context.Background()
+	variantID := seedVariant(t, db, 10)
+
+	live := uuid.NewString()
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, live, variantID, testLocation, 1, time.Hour)
+	}))
+	recentlyExpired := uuid.NewString()
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, recentlyExpired, variantID, testLocation, 1, -time.Minute)
+	}))
+	longExpired := uuid.NewString()
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, longExpired, variantID, testLocation, 1, -2*time.Hour)
+	}))
+
+	n, err := repo.Sweep(ctx, db, 100)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n, "only the hold expired beyond the grace window is dead")
+
+	require.Equal(t, int64(1), countHolds(t, db, live))
+	require.Equal(t, int64(1), countHolds(t, db, recentlyExpired),
+		"a recently expired hold is kept: it is evidence of what happened, and it "+
+			"already reduces availability by nothing")
+	require.Equal(t, int64(0), countHolds(t, db, longExpired))
+}
+
+func countHolds(t *testing.T, db *gorm.DB, cart string) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM stock_holds WHERE cart_token = ?`, cart).Scan(&n).Error)
+	return n
+}

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 114
+const ExpectedSchemaVersion uint = 115

--- a/services/marketplace-api/migrations/000115_stock_holds.down.sql
+++ b/services/marketplace-api/migrations/000115_stock_holds.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE variant_stock DROP CONSTRAINT IF EXISTS variant_stock_quantity_non_negative;
+DROP TABLE IF EXISTS stock_holds;

--- a/services/marketplace-api/migrations/000115_stock_holds.up.sql
+++ b/services/marketplace-api/migrations/000115_stock_holds.up.sql
@@ -1,0 +1,40 @@
+-- #231 — server-side stock holds.
+--
+-- Availability is COMPUTED, never stored:
+--
+--   available = variant_stock.quantity
+--             - SUM(qty) FILTER (WHERE state = 'held' AND expires_at > now())
+--
+-- so a hold expires by the clock rather than by a job running. If the sweeper
+-- stops, availability stays correct and only dead rows accumulate. Storing a
+-- reserved counter would make the sweeper load-bearing for correctness, and a
+-- missed run would silently strand stock.
+CREATE TABLE stock_holds (
+    id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    variant_id  uuid NOT NULL REFERENCES product_variants(id) ON DELETE CASCADE,
+    location_id uuid NOT NULL,
+    cart_token  uuid NOT NULL,
+    qty         integer NOT NULL CHECK (qty > 0),
+    expires_at  timestamptz NOT NULL,
+    state       text NOT NULL DEFAULT 'held'
+                CHECK (state IN ('held','committed','released')),
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    -- One hold per cart per variant per location, so a repeat Hold refreshes
+    -- rather than stacking a second reservation against the same cart.
+    UNIQUE (cart_token, variant_id, location_id)
+);
+
+-- Partial on state='held': the availability query only ever sums live holds,
+-- and committed/released rows are dead weight in that index.
+CREATE INDEX stock_holds_live_idx ON stock_holds (variant_id, location_id)
+    WHERE state = 'held';
+
+-- Partial on state='held': the sweeper only ever scans live rows.
+CREATE INDEX stock_holds_expiry_idx ON stock_holds (expires_at)
+    WHERE state = 'held';
+
+-- A decrement must never take stock below zero. The application serialises
+-- contenders with SELECT ... FOR UPDATE, but that is a discipline; this is the
+-- guarantee. Verified before adding: 0 negative rows of 380 in production.
+ALTER TABLE variant_stock
+    ADD CONSTRAINT variant_stock_quantity_non_negative CHECK (quantity >= 0);


### PR DESCRIPTION
Closes #231. First slice of the #229 epic. **Nothing calls this yet** — checkout wiring is #232/#230.

## Availability is computed, never stored

```sql
available = variant_stock.quantity
          - SUM(qty) FILTER (WHERE state = 'held' AND expires_at > now())
```

A hold therefore expires **by the clock, not by a job running**. If the sweeper stops, availability stays correct and only dead rows accumulate. A stored `reserved` counter would make the sweeper load-bearing for correctness, and a missed run would silently strand stock — the failure you discover at Christmas.

## How the oversell is actually prevented

`SELECT quantity FROM variant_stock … FOR UPDATE` serialises contenders. Without it two transactions read the same availability, both find it sufficient, and both insert — exactly the #230 bug.

The lock is taken on `variant_stock`, not on the holds, because the holds a competitor is about to insert **do not exist yet to be locked**.

`CHECK (quantity >= 0)` on `variant_stock` is the guarantee behind that discipline rather than a duplicate of it: `FOR UPDATE` is something the code must remember to do, the constraint is not. Verified before adding — 0 negative rows of 380 in production.

## Details that are easy to get wrong, and the tests that pin them

- **A refresh must not count its own reservation.** The live-hold sum excludes the calling cart, or a cart could never re-hold what it already has. `ON CONFLICT … DO UPDATE` makes the refresh atomic inside the row lock, so a customer revisiting checkout does not stack a second reservation and lock themselves out.
- **A committed hold must stop reducing availability.** The stock row already reflects it; counting both would double-charge the variant.
- **`Extend` deliberately does not revive an expired hold.** By then the units may be someone else's, and silently taking them back would oversell exactly as if no hold existed.
- **The sweeper keeps recently-expired rows** (1h grace). They reduce availability by nothing, and they are evidence of what happened when someone asks why a cart lost its unit. `FOR UPDATE SKIP LOCKED` so concurrent sweepers on multiple replicas neither block nor double-delete.

## The test the package exists for

12 goroutines on separate connections contend for 3 units; exactly 3 win, 9 get `ErrInsufficientStock`, none fail for another reason. Run `-count=5` to check it is not flaky.

It is an integration test by necessity, not preference: `testdb.NewTx` cannot see across connections, so in a single transaction the contention never happens and the test would pass against the broken code.

## Purge interaction

`stock_holds.variant_id` is `ON DELETE CASCADE` to `product_variants`, which the tenant purge already deletes — so holds go with the tenant and `tenantpurge`'s schema-coverage guard passes unchanged. No new purge step needed.

## An existing guard did its job

`TestEveryIntegrationPackageIsInTheTestIntTarget` (#446) failed because `internal/stockhold` was not in the Makefile's `test-int` list — meaning a failure in this brand-new concurrency-critical package would have been invisible to CI. Added, in alphabetical position.

## Verification

- migration `000115`, `ExpectedSchemaVersion` bumped to 115
- 7 integration tests, written first and watched fail
- concurrency test green across `-count=5`
- `go build`, `go vet`, full unit suite, and the **entire integration suite** clean against a real database