### PR TITLE
feat(storefront): server-side cart token and stock-hold endpoints (#232)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -109,6 +109,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/shipmentcancel"
 	"github.com/mark8ly/marketplace-api/internal/shipping"
 	"github.com/mark8ly/marketplace-api/internal/signup"
+	"github.com/mark8ly/marketplace-api/internal/stockhold"
 	"github.com/mark8ly/marketplace-api/internal/stores"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 	"github.com/mark8ly/marketplace-api/internal/subscription/cancel"
@@ -1513,6 +1514,9 @@ func main() {
 			ReviewsHandler: sfReviewsHandler,
 			// C4 wishlists.
 			WishlistHandler: wishlistHandler,
+			// #232 — server-side stock holds. Placed at cart-add for
+			// HoldTTL, committed inside the order transaction at checkout.
+			CartHoldsHandler: storefront.NewCartHoldsHandler(conn, stockhold.NewRepository(), log),
 			// B1 branding.
 			BrandingHandler:       sfBrandingHandler,
 			PagesHandler:          sfPagesHandler,

--- a/services/marketplace-api/internal/handlers/storefront/cart_holds.go
+++ b/services/marketplace-api/internal/handlers/storefront/cart_holds.go
@@ -1,0 +1,190 @@
+package storefront
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/product"
+	"github.com/mark8ly/marketplace-api/internal/stockhold"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+)
+
+// CartTokenCookie is the first-party cookie carrying the server-minted cart
+// identity.
+//
+// httpOnly: the token identifies a stock reservation, so script access buys
+// the storefront nothing and costs XSS exposure. The storefront learns its
+// token from the response body when it needs it; the cookie is what makes
+// the identity survive a reload.
+const CartTokenCookie = "mk_cart_token"
+
+// HoldTTL is how long a cart keeps its units.
+//
+// Placed AT CART-ADD, not at checkout-start — decided 2026-08-30 as the
+// epic's literal intent: the shopper who adds first keeps the unit. The cost
+// is real and accepted: an abandoned tab parks the last unit for fifteen
+// minutes, and abandoned carts are the norm. If that proves too expensive on
+// scarce variants, the lever is this constant plus a shorter hold at
+// cart-add, not a change to the mechanism.
+const HoldTTL = 15 * time.Minute
+
+// CartHoldsHandler serves the storefront's stock-hold surface (#232).
+type CartHoldsHandler struct {
+	db     *gorm.DB
+	holds  *stockhold.Repository
+	logger *slog.Logger
+}
+
+func NewCartHoldsHandler(db *gorm.DB, holds *stockhold.Repository, logger *slog.Logger) *CartHoldsHandler {
+	return &CartHoldsHandler{db: db, holds: holds, logger: logger}
+}
+
+type cartHoldItem struct {
+	VariantID string `json:"variant_id" binding:"required,uuid"`
+	Quantity  int    `json:"quantity"   binding:"required,min=1"`
+}
+
+type cartHoldsRequest struct {
+	CartToken string         `json:"cart_token"`
+	Items     []cartHoldItem `json:"items" binding:"required,min=1,dive"`
+}
+
+type cartHoldItemResult struct {
+	VariantID string `json:"variant_id"`
+	// Status is "held" or "insufficient".
+	Status string `json:"status"`
+	// Available is what the shopper can actually have right now. Reported
+	// so the storefront can say "only 2 left" rather than a bare failure.
+	Available int `json:"available"`
+}
+
+// Place creates or refreshes holds for a cart.
+//
+// # Per-item status rather than all-or-nothing
+//
+// A cart of five items where one is short must tell the shopper WHICH one.
+// Failing the whole request would lose the other four holds to whoever asks
+// next, and would give the storefront nothing to render.
+//
+// # One transaction for the whole cart
+//
+// Each item's hold takes a row lock on its own variant_stock row, and they
+// commit together. A partial commit would leave a cart holding some of what
+// the shopper believes they have.
+func (h *CartHoldsHandler) Place(c *gin.Context) {
+	var req cartHoldsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "message": "cart hold request could not be parsed"})
+		return
+	}
+
+	cartToken := req.CartToken
+	if cartToken == "" {
+		if ck, err := c.Cookie(CartTokenCookie); err == nil {
+			cartToken = ck
+		}
+	}
+	if _, err := uuid.Parse(cartToken); err != nil {
+		// Mint rather than reject: a first cart write has no token yet, and
+		// an unparseable one from a stale client is not worth an error the
+		// shopper cannot act on.
+		cartToken = uuid.NewString()
+	}
+
+	store := c.MustGet("store").(*stores.Store)
+	storeID := store.ID
+	expiresAt := time.Now().Add(HoldTTL)
+	results := make([]cartHoldItemResult, 0, len(req.Items))
+
+	err := h.db.Transaction(func(tx *gorm.DB) error {
+		for _, item := range req.Items {
+			// Ownership check FIRST. This surface is unauthenticated beyond
+			// the shared storefront key, so without it a caller could hold
+			// — and probe the stock of — any variant in the estate through
+			// any store's slug.
+			var owned int64
+			if err := tx.Raw(
+				`SELECT count(*) FROM product_variants WHERE id = ? AND store_id = ?`,
+				item.VariantID, storeID).Scan(&owned).Error; err != nil {
+				return err
+			}
+			if owned == 0 {
+				return errVariantNotInStore
+			}
+
+			err := h.holds.Hold(c.Request.Context(), tx, cartToken, item.VariantID,
+				product.DefaultLocationID, item.Quantity, HoldTTL)
+			switch {
+			case err == nil:
+				results = append(results, cartHoldItemResult{
+					VariantID: item.VariantID, Status: "held", Available: item.Quantity,
+				})
+			case errors.Is(err, stockhold.ErrInsufficientStock):
+				avail, aerr := h.holds.Available(c.Request.Context(), tx, item.VariantID, product.DefaultLocationID, cartToken)
+				if aerr != nil {
+					return aerr
+				}
+				results = append(results, cartHoldItemResult{
+					VariantID: item.VariantID, Status: "insufficient", Available: avail,
+				})
+			default:
+				return err
+			}
+		}
+		return nil
+	})
+
+	switch {
+	case errors.Is(err, errVariantNotInStore):
+		c.JSON(http.StatusNotFound, gin.H{"error": "variant_not_found", "message": "variant does not belong to this store"})
+		return
+	case err != nil:
+		if h.logger != nil {
+			h.logger.Error("cart holds: place failed", "err", err, "store_id", storeID)
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error", "message": "could not place stock holds"})
+		return
+	}
+
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie(CartTokenCookie, cartToken, int(HoldTTL.Seconds()), "/", "", c.Request.TLS != nil, true)
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{
+		"cart_token": cartToken,
+		"expires_at": expiresAt.UTC(),
+		"items":      results,
+	}})
+}
+
+// Release drops a cart's holds, for an explicit cart clear.
+//
+// Idempotent and deliberately incurious: releasing a cart that holds nothing
+// is a success, because the caller's intent — "this cart holds nothing" — is
+// satisfied either way.
+func (h *CartHoldsHandler) Release(c *gin.Context) {
+	cartToken := c.Param("cartToken")
+	if _, err := uuid.Parse(cartToken); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_cart_token", "message": "cart_token must be a UUID"})
+		return
+	}
+
+	if err := h.db.Transaction(func(tx *gorm.DB) error {
+		return h.holds.Release(c.Request.Context(), tx, cartToken)
+	}); err != nil {
+		if h.logger != nil {
+			h.logger.Error("cart holds: release failed", "err", err)
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error", "message": "could not release stock holds"})
+		return
+	}
+
+	c.SetCookie(CartTokenCookie, "", -1, "/", "", c.Request.TLS != nil, true)
+	c.Status(http.StatusNoContent)
+}
+
+var errVariantNotInStore = errors.New("storefront: variant does not belong to this store")

--- a/services/marketplace-api/internal/handlers/storefront/cart_holds_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/cart_holds_integration_test.go
@@ -1,0 +1,256 @@
+//go:build integration
+
+package storefront_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/singleflight"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/storefront"
+	"github.com/mark8ly/marketplace-api/internal/stockhold"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// #232 — the storefront's server-side hold surface.
+//
+// The cart was pure client-side state, so there was no server identity to
+// attach a hold to (#229). cart_token is that identity: minted by the server,
+// carried by the browser as an httpOnly cookie.
+//
+// Decision recorded 2026-08-30: holds are placed AT CART-ADD for the full 15
+// minutes. That is the epic's literal intent — the shopper who adds first
+// keeps the unit. The cost is accepted: an abandoned tab parks the last unit
+// for 15 minutes, and abandoned carts are the norm.
+
+func postHolds(t *testing.T, r *http.Handler, slug, key, cartToken string, items []map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	body := map[string]any{"items": items}
+	if cartToken != "" {
+		body["cart_token"] = cartToken
+	}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/api/v1/storefront/stores/%s/cart/holds", slug), bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Storefront-Key", key)
+	rec := httptest.NewRecorder()
+	(*r).ServeHTTP(rec, req)
+	return rec
+}
+
+type holdsResponse struct {
+	Data struct {
+		CartToken string `json:"cart_token"`
+		ExpiresAt string `json:"expires_at"`
+		Items     []struct {
+			VariantID string `json:"variant_id"`
+			Status    string `json:"status"`
+			Available int    `json:"available"`
+		} `json:"items"`
+	} `json:"data"`
+}
+
+func TestCartHolds_PlacesAHoldAndMintsACartToken(t *testing.T) {
+	router, db, store, key := setupHoldsRouter(t)
+	variantID := seedHoldVariant(t, db, store, 5)
+
+	rec := postHolds(t, &router, store.Slug, key, "", []map[string]any{
+		{"variant_id": variantID, "quantity": 2},
+	})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var body holdsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.NotEmpty(t, body.Data.CartToken, "the server mints the cart identity")
+	require.Len(t, body.Data.Items, 1)
+	require.Equal(t, "held", body.Data.Items[0].Status)
+
+	// The token must come back as an httpOnly cookie: it identifies a
+	// reservation, so script access buys nothing and costs XSS exposure.
+	var found bool
+	for _, ck := range rec.Result().Cookies() {
+		if ck.Name == "mk_cart_token" {
+			found = true
+			require.True(t, ck.HttpOnly, "cart_token must be httpOnly")
+			require.Equal(t, body.Data.CartToken, ck.Value)
+		}
+	}
+	require.True(t, found, "cart_token cookie must be set")
+
+	var held int
+	require.NoError(t, db.Raw(
+		`SELECT COALESCE(SUM(qty),0) FROM stock_holds WHERE variant_id = ? AND state = 'held'`,
+		variantID).Scan(&held).Error)
+	require.Equal(t, 2, held)
+}
+
+// Per-item status, not all-or-nothing: a cart of five items where one is
+// short must tell the shopper WHICH one, not fail opaquely.
+func TestCartHolds_ReportsPerItemInsufficientWithoutFailingTheRequest(t *testing.T) {
+	router, db, store, key := setupHoldsRouter(t)
+	plenty := seedHoldVariant(t, db, store, 10)
+	scarce := seedHoldVariant(t, db, store, 1)
+
+	rec := postHolds(t, &router, store.Slug, key, "", []map[string]any{
+		{"variant_id": plenty, "quantity": 2},
+		{"variant_id": scarce, "quantity": 5},
+	})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var body holdsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	byVariant := map[string]string{}
+	avail := map[string]int{}
+	for _, it := range body.Data.Items {
+		byVariant[it.VariantID] = it.Status
+		avail[it.VariantID] = it.Available
+	}
+	require.Equal(t, "held", byVariant[plenty])
+	require.Equal(t, "insufficient", byVariant[scarce])
+	require.Equal(t, 1, avail[scarce], "the shopper is told how many are actually left")
+
+	// The obtainable item is still held — a short line must not cost the
+	// customer the rest of their cart.
+	var heldPlenty int
+	require.NoError(t, db.Raw(
+		`SELECT COALESCE(SUM(qty),0) FROM stock_holds WHERE variant_id = ? AND state = 'held'`,
+		plenty).Scan(&heldPlenty).Error)
+	require.Equal(t, 2, heldPlenty)
+}
+
+// Re-posting the same cart refreshes rather than stacking, so a shopper
+// adjusting quantities does not consume their own stock twice.
+func TestCartHolds_RepostRefreshesTheSameCart(t *testing.T) {
+	router, db, store, key := setupHoldsRouter(t)
+	variantID := seedHoldVariant(t, db, store, 3)
+
+	first := postHolds(t, &router, store.Slug, key, "", []map[string]any{
+		{"variant_id": variantID, "quantity": 1},
+	})
+	require.Equal(t, http.StatusOK, first.Code)
+	var body holdsResponse
+	require.NoError(t, json.Unmarshal(first.Body.Bytes(), &body))
+	cart := body.Data.CartToken
+
+	second := postHolds(t, &router, store.Slug, key, cart, []map[string]any{
+		{"variant_id": variantID, "quantity": 3},
+	})
+	require.Equal(t, http.StatusOK, second.Code, second.Body.String())
+
+	var rows, total int
+	require.NoError(t, db.Raw(`SELECT count(*), COALESCE(SUM(qty),0) FROM stock_holds
+	                            WHERE cart_token = ? AND state = 'held'`, cart).Row().Scan(&rows, &total))
+	require.Equal(t, 1, rows, "one row per (cart, variant), refreshed")
+	require.Equal(t, 3, total, "quantity is replaced, not added to")
+}
+
+func TestCartHolds_ReleaseReturnsStockToThePool(t *testing.T) {
+	router, db, store, key := setupHoldsRouter(t)
+	variantID := seedHoldVariant(t, db, store, 1)
+
+	rec := postHolds(t, &router, store.Slug, key, "", []map[string]any{
+		{"variant_id": variantID, "quantity": 1},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body holdsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	req := httptest.NewRequest(http.MethodDelete,
+		fmt.Sprintf("/api/v1/storefront/stores/%s/cart/holds/%s", store.Slug, body.Data.CartToken), nil)
+	req.Header.Set("X-Storefront-Key", key)
+	del := httptest.NewRecorder()
+	router.ServeHTTP(del, req)
+	require.Equal(t, http.StatusNoContent, del.Code, del.Body.String())
+
+	// The unit is obtainable by someone else.
+	other := postHolds(t, &router, store.Slug, key, uuid.NewString(), []map[string]any{
+		{"variant_id": variantID, "quantity": 1},
+	})
+	var otherBody holdsResponse
+	require.NoError(t, json.Unmarshal(other.Body.Bytes(), &otherBody))
+	require.Equal(t, "held", otherBody.Data.Items[0].Status)
+}
+
+// A variant belonging to another store must not be holdable through this
+// store's slug — the hold surface is storefront-facing and unauthenticated
+// beyond the shared key, so it must not become a cross-tenant stock oracle.
+func TestCartHolds_RefusesAVariantFromAnotherStore(t *testing.T) {
+	router, db, store, key := setupHoldsRouter(t)
+	foreign := seedForeignVariant(t, db, 5)
+
+	rec := postHolds(t, &router, store.Slug, key, "", []map[string]any{
+		{"variant_id": foreign, "quantity": 1},
+	})
+	require.Equal(t, http.StatusNotFound, rec.Code, rec.Body.String())
+
+	var held int
+	require.NoError(t, db.Raw(
+		`SELECT COALESCE(SUM(qty),0) FROM stock_holds WHERE variant_id = ?`, foreign).Scan(&held).Error)
+	require.Equal(t, 0, held, "no hold may be placed against another store's variant")
+}
+
+func setupHoldsRouter(t *testing.T) (http.Handler, *gorm.DB, *stores.Store, string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	db := testdb.NewDB(t, append(checkoutTruncateTables, "stock_holds")...)
+	storesRepo := stores.NewRepository(db)
+	slugCache := stores.NewSlugCache(storesRepo, fakeStoresClient{}, &singleflight.Group{}, 5*time.Minute)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	r := gin.New()
+	storefront.RegisterStorefront(r.Group("/api/v1"), storefront.Deps{
+		CartHoldsHandler: storefront.NewCartHoldsHandler(db, stockhold.NewRepository(), logger),
+		SlugCache:        slugCache,
+		StorefrontKey:    "",
+	})
+	return r, db, seedCheckoutStore(t, db), ""
+}
+
+// seedHoldVariant creates a variant in the given store with qty in stock.
+func seedHoldVariant(t *testing.T, db *gorm.DB, s *stores.Store, qty int) string {
+	t.Helper()
+	return insertVariantWithStock(t, db, s.TenantID, s.ID, qty)
+}
+
+// seedForeignVariant creates a variant in a DIFFERENT store.
+func seedForeignVariant(t *testing.T, db *gorm.DB, qty int) string {
+	t.Helper()
+	other := seedCheckoutStore(t, db)
+	return insertVariantWithStock(t, db, other.TenantID, other.ID, qty)
+}
+
+func insertVariantWithStock(t *testing.T, db *gorm.DB, tenantID, storeID string, qty int) string {
+	t.Helper()
+	productID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO products (id, tenant_id, store_id, title, handle, status, vendor_id, published_at)
+		 VALUES (?, ?, ?, 'Hold Test', ?, 'active', ?, now())`,
+		productID, tenantID, storeID, "hold-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	variantID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO product_variants (id, product_id, store_id, sku, price, currency_code)
+		 VALUES (?, ?, ?, ?, 10.00, 'EUR')`,
+		variantID, productID, storeID, "SKU-"+uuid.NewString()[:8]).Error)
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, '00000000-0000-0000-0000-000000000001', ?, now())`, variantID, qty).Error)
+	return variantID
+}

--- a/services/marketplace-api/internal/handlers/storefront/routes.go
+++ b/services/marketplace-api/internal/handlers/storefront/routes.go
@@ -41,6 +41,8 @@ type Deps struct {
 	ReviewsHandler *ReviewsHandler
 	// C4 wishlists.
 	WishlistHandler *WishlistHandler
+	// #232 server-side stock holds.
+	CartHoldsHandler *CartHoldsHandler
 	// B1 branding.
 	BrandingHandler *BrandingHandler
 	// Content pages.
@@ -95,6 +97,15 @@ func RegisterStorefront(router *gin.RouterGroup, deps Deps) {
 		group.GET("/products", deps.Handler.List)
 		group.GET("/products/:handle", deps.Handler.GetByHandle)
 		group.GET("/categories", deps.Handler.ListCategories)
+
+		// #232 — server-side stock holds. Mounted on the same key+store
+		// middleware as the rest of the storefront surface; the handler
+		// additionally checks each variant belongs to THIS store, because
+		// the shared key is not a per-store credential.
+		if deps.CartHoldsHandler != nil {
+			group.POST("/cart/holds", deps.CartHoldsHandler.Place)
+			group.DELETE("/cart/holds/:cartToken", deps.CartHoldsHandler.Release)
+		}
 		group.GET("/categories/:slug/products", deps.Handler.ListByCategorySlug)
 
 		// Checkout — use extended handler (with payment/tax/shipping) if

--- a/services/marketplace-api/internal/stockhold/repository.go
+++ b/services/marketplace-api/internal/stockhold/repository.go
@@ -109,6 +109,41 @@ func (r *Repository) Hold(ctx context.Context, tx *gorm.DB, cartToken, variantID
 		variantID, locationID, cartToken, qty, time.Now().Add(ttl)).Error
 }
 
+// Available reports how many units a cart could still hold, live holds
+// subtracted.
+//
+// It excludes the calling cart's own holds for the same reason Hold does: a
+// cart asking what it can have must not be told its own reservation is
+// competition.
+//
+// This is a READ for display — "only 2 left" beats a bare refusal. It takes
+// no lock and must not be used to decide whether a hold may be placed: by
+// the time a caller acted on it, the answer could be stale. Hold does its
+// own check under FOR UPDATE, and that is the one that counts.
+func (r *Repository) Available(ctx context.Context, tx *gorm.DB, variantID, locationID, exceptCart string) (int, error) {
+	var available int
+	err := tx.WithContext(ctx).Raw(
+		`SELECT COALESCE(vs.quantity, 0) - COALESCE((
+		            SELECT SUM(h.qty) FROM stock_holds h
+		             WHERE h.variant_id = vs.variant_id AND h.location_id = vs.location_id
+		               AND h.state = 'held' AND h.expires_at > now()
+		               AND h.cart_token <> ?
+		        ), 0)
+		   FROM variant_stock vs
+		  WHERE vs.variant_id = ? AND vs.location_id = ?`,
+		exceptCart, variantID, locationID).Scan(&available).Error
+	if err != nil {
+		return 0, fmt.Errorf("stockhold: available: %w", err)
+	}
+	if available < 0 {
+		// Defensive: a committed sale already decremented the stock row, so
+		// arithmetic cannot normally go below zero. Reporting a negative
+		// count to a storefront would render as nonsense.
+		return 0, nil
+	}
+	return available, nil
+}
+
 // Commit decrements variant_stock for every live hold on the cart and flips
 // those holds to 'committed', in the caller's transaction.
 //


### PR DESCRIPTION
First half of #232, on top of #231. Adds the server-side cart identity and the hold surface.

**The checkout commit is deliberately NOT here** — it follows in its own PR, because that is where stock meets money and it deserves review on its own. Until it lands, holds are placed and expire but nothing decrements stock; #230 stays open.

## The decision this issue asked to confirm

**Holds are placed at cart-add, for the full 15 minutes** — confirmed with @mahesh-sangawar, the epic's literal intent: the shopper who adds first keeps the unit.

The cost is real and recorded at the constant rather than left implicit: an abandoned tab parks the last unit for fifteen minutes, and abandoned carts are the norm. If that proves too expensive on scarce variants, the lever is the TTL plus a shorter cart-add hold — not a change to the mechanism.

## Endpoints

- `POST /storefront/stores/:storeSlug/cart/holds` — places or refreshes, returns per-item `held | insufficient` with `available`, plus `expires_at`
- `DELETE /storefront/stores/:storeSlug/cart/holds/:cartToken` — explicit release on cart clear

## Three decisions worth reviewing

**Per-item status, not all-or-nothing.** A cart of five items where one is short must tell the shopper *which* one. Failing the whole request would lose the other four holds to whoever asks next, and give the storefront nothing to render. One transaction still covers the cart, so a partial commit cannot leave a shopper holding less than they believe.

**Ownership is checked before every hold.** This surface is unauthenticated beyond the shared storefront key, which is not a per-store credential. Without the check a caller could hold — and probe the stock of — any variant in the estate through any store's slug. `TestCartHolds_RefusesAVariantFromAnotherStore` asserts both the 404 and that no hold row is written.

**`cart_token` is httpOnly.** It identifies a stock reservation, so script access buys the storefront nothing and costs XSS exposure. The storefront reads its token from the response body; the cookie is what makes the identity survive a reload. An absent or unparseable token is *minted* rather than rejected — a first cart write has no token, and a stale one is not an error a shopper can act on.

## Also added

`stockhold.Available` — a read for display, so the storefront can say "only 2 left" instead of a bare refusal. Its doc is explicit that it takes no lock and must not gate a hold: by the time a caller acted on it the answer could be stale. `Hold` does its own check under `FOR UPDATE`, and that is the one that counts.

## Verification

- 5 integration tests, written first against the intended API and watched fail
- covers minting, per-item insufficiency with the real remaining count, refresh-not-stack, release returning stock to the pool, and cross-store refusal
- `go build`, `go vet`, full unit suite, and the **entire integration suite** clean against a real database