### PR TITLE
fix(storefront): decrement stock in the order transaction so checkout cannot oversell (#230)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/checkout_stock_wiring_test.go
+++ b/services/marketplace-api/cmd/marketplace-api/checkout_stock_wiring_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// #230: stock enforcement lives behind a builder call, and a builder call
+// that is simply absent leaves the storefront overselling exactly as it did
+// before — silently, with every test still green.
+//
+// That is the same shape as #341: a guard that is not wired is
+// indistinguishable from no guard. Both checkout handlers must be wired, and
+// the EXT one especially: routes.go prefers it whenever it is set, so
+// enforcement on the simple handler alone would fix nothing in production.
+//
+// Narrow by design, exactly like TestPlatformadminRegisterSitesAgree: it
+// reads method names off the builder chains and nothing else.
+func TestMainWiresStockHoldsIntoCheckout(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, 0)
+	require.NoError(t, err)
+
+	// constructor name -> whether WithStockHolds appears in its chain
+	wired := map[string]bool{
+		"NewCheckoutHandler":    false,
+		"NewCheckoutExtHandler": false,
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		root, methods := unwindChain(call)
+		if root == "" {
+			return true
+		}
+		if _, tracked := wired[root]; !tracked {
+			return true
+		}
+		for _, m := range methods {
+			if m == "WithStockHolds" {
+				wired[root] = true
+			}
+		}
+		return true
+	})
+
+	for ctor, ok := range wired {
+		require.True(t, ok,
+			"%s must be built .WithStockHolds(...) — without it a storefront sale "+
+				"does not touch inventory and oversells without limit (#230)", ctor)
+	}
+}
+
+// unwindChain walks a builder chain back to its constructor, returning the
+// constructor's function name and every method called on it.
+func unwindChain(call *ast.CallExpr) (string, []string) {
+	var methods []string
+	for {
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			// Reached the root call: storefront.NewCheckoutHandler(...) or
+			// a bare NewCheckoutHandler(...).
+			switch fn := call.Fun.(type) {
+			case *ast.Ident:
+				return fn.Name, methods
+			}
+			return "", methods
+		}
+		inner, ok := sel.X.(*ast.CallExpr)
+		if !ok {
+			// sel.X is a package identifier, so sel.Sel is the constructor.
+			return sel.Sel.Name, methods
+		}
+		methods = append(methods, sel.Sel.Name)
+		call = inner
+	}
+}

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1341,7 +1341,10 @@ func main() {
 		returnSvcSF := order.NewReturnService(conn, returnRepoSF, orderRepoSF, orderSvcSF, outboxRepoSF)
 		checkoutHandler := storefront.NewCheckoutHandler(conn, orderSvcSF, orderRepoSF, log).
 			WithAudit(auditEmitter).
-			WithNotifier(notificationSvc)
+			WithNotifier(notificationSvc).
+			// #230 — without this a storefront sale does not touch
+			// inventory and oversells without limit.
+			WithStockHolds(stockhold.NewRepository())
 
 		countryRepo := country.NewRepository(conn)
 		countryHandler := country.NewHandler(countryRepo)
@@ -1403,6 +1406,9 @@ func main() {
 
 		// P5b — extended checkout, payment methods, shipping rates, webhooks.
 		checkoutExtHandler := storefront.NewCheckoutExtHandler(conn, orderSvcSF, couponSvc, giftCardSvcSF, apiKeyEncryptor, log).
+			// #230 — this is the handler routes.go actually mounts when
+			// wired, so enforcement here is what stops the oversell.
+			WithStockHolds(stockhold.NewRepository()).
 			WithAudit(auditEmitter).
 			WithSecretStore(carrierSecretStore).
 			WithNotifier(notificationSvc)

--- a/services/marketplace-api/internal/handlers/storefront/checkout.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout.go
@@ -6,6 +6,7 @@
 package storefront
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/customer"
 	"github.com/mark8ly/marketplace-api/internal/notification"
 	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/internal/stockhold"
 	"github.com/mark8ly/marketplace-api/internal/stores"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 )
@@ -27,12 +29,13 @@ import (
 // CheckoutHandler is the public storefront checkout endpoint. Constructed
 // in cmd/marketplace-api/main.go for storefront and both modes.
 type CheckoutHandler struct {
-	db        *gorm.DB
-	orderSvc  *order.Service
-	orderRepo order.Repository
-	audit     *audit.Emitter        // optional — nil-safe
-	notify    *notification.Service // optional — nil-safe
-	logger    *slog.Logger
+	db         *gorm.DB
+	orderSvc   *order.Service
+	stockHolds *stockhold.Repository
+	orderRepo  order.Repository
+	audit      *audit.Emitter        // optional — nil-safe
+	notify     *notification.Service // optional — nil-safe
+	logger     *slog.Logger
 }
 
 // NewCheckoutHandler constructs a CheckoutHandler.
@@ -42,6 +45,17 @@ func NewCheckoutHandler(db *gorm.DB, orderSvc *order.Service, orderRepo order.Re
 
 // WithAudit attaches an audit emitter so storefront checkouts emit
 // order.created as system events. Nil-safe.
+// WithStockHolds enables stock enforcement on checkout (#230).
+//
+// Without it a sale does not touch inventory and the storefront oversells,
+// which is the bug this exists to fix — so main.go must call it, and
+// TestMainWiresStockHoldsIntoCheckout asserts that it does. A nil repository
+// here is not a supported configuration, it is an unenforced storefront.
+func (h *CheckoutHandler) WithStockHolds(r *stockhold.Repository) *CheckoutHandler {
+	h.stockHolds = r
+	return h
+}
+
 func (h *CheckoutHandler) WithAudit(e *audit.Emitter) *CheckoutHandler {
 	h.audit = e
 	return h
@@ -202,6 +216,17 @@ func (h *CheckoutHandler) Checkout(c *gin.Context) {
 		CurrencyCode:   store.CurrencyCode,
 	}
 
+	// #230 — take the stock inside the order transaction. Before this,
+	// checkout never read inventory at all and two customers could buy the
+	// same last unit.
+	if h.stockHolds != nil {
+		lines := stockLinesFromItems(req.Items)
+		cartToken := cartTokenForCheckout(c)
+		in.WithinTx = func(tx *gorm.DB, _ *order.Order) error {
+			return commitStock(c.Request.Context(), tx, h.stockHolds, cartToken, lines)
+		}
+	}
+
 	result, err := h.orderSvc.Create(c.Request.Context(), in)
 	if err != nil {
 		h.respondErr(c, err)
@@ -274,6 +299,20 @@ func (h *CheckoutHandler) Checkout(c *gin.Context) {
 // surface deliberately collapses any not_found into 404 with no body
 // detail to prevent existence leaks (mirrors RequireStorefrontKey behavior).
 func (h *CheckoutHandler) respondErr(c *gin.Context, err error) {
+	// #230 — a sold-out line is a 409 naming the variant, never a 500. The
+	// shopper can act on it: remove that line and retry. It is checked
+	// first because it travels up through order.Create's transaction as an
+	// ordinary error and would otherwise fall through to internal_error.
+	var oos outOfStockError
+	if errors.As(err, &oos) {
+		c.AbortWithStatusJSON(http.StatusConflict, map[string]any{
+			"error":      "out_of_stock",
+			"message":    "one or more items are no longer available in the requested quantity",
+			"variant_id": oos.VariantID,
+		})
+		return
+	}
+
 	var ae *apperrors.Error
 	if asErr, ok := err.(*apperrors.Error); ok {
 		ae = asErr

--- a/services/marketplace-api/internal/handlers/storefront/checkout_ext.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_ext.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/order"
 	"github.com/mark8ly/marketplace-api/internal/payment"
 	"github.com/mark8ly/marketplace-api/internal/shipping"
+	"github.com/mark8ly/marketplace-api/internal/stockhold"
 	"github.com/mark8ly/marketplace-api/internal/stores"
 	"github.com/mark8ly/marketplace-api/internal/tax"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
@@ -47,6 +48,7 @@ type CheckoutExtHandler struct {
 	loyaltySvc  *loyalty.Service      // nil-safe: no-ops when nil
 	audit       *audit.Emitter        // optional — nil-safe
 	notify      *notification.Service // optional — nil-safe
+	stockHolds  *stockhold.Repository // #230 — nil leaves the storefront unenforced
 	encryptor   crypto.Encryptor      // decrypts API keys for payment/tax/shipping
 	// secretStore, when non-nil, resolves gsm:// references as well as
 	// legacy inline ciphertext. Tracks the same pattern as shipments /
@@ -63,6 +65,14 @@ func NewCheckoutExtHandler(db *gorm.DB, orderSvc *order.Service, couponSvc *coup
 
 // WithAudit attaches an audit emitter so extended storefront checkouts
 // emit order.created as system events. Nil-safe.
+// WithStockHolds enables stock enforcement (#230). This is the handler
+// production uses, so main.go must call it; TestMainWiresStockHoldsIntoCheckout
+// asserts that it does.
+func (h *CheckoutExtHandler) WithStockHolds(r *stockhold.Repository) *CheckoutExtHandler {
+	h.stockHolds = r
+	return h
+}
+
 func (h *CheckoutExtHandler) WithAudit(e *audit.Emitter) *CheckoutExtHandler {
 	h.audit = e
 	return h
@@ -598,7 +608,23 @@ func (h *CheckoutExtHandler) Checkout(c *gin.Context) {
 	// logWarn + respondErr + return and NO compensation — so a gift card that
 	// failed to debit left a real, committed order discounted by money the
 	// merchant never received. Do not move them back out.
+	// #230 — stock is taken in the SAME transaction as the order and the
+	// discount consumption below, for the same reason those moved here: a
+	// failure must roll the order back entirely rather than leave a
+	// committed order whose stock was never taken.
+	//
+	// This is the handler production actually uses — routes.go prefers the
+	// ext handler whenever it is wired — so enforcement living only on the
+	// simple CheckoutHandler would have fixed nothing.
+	stockLines := stockLinesFromItems(req.Items)
+	stockCartToken := cartTokenForCheckout(c)
+
 	consumeDiscounts := func(tx *gorm.DB, o *order.Order) error {
+		if h.stockHolds != nil {
+			if err := commitStock(ctx, tx, h.stockHolds, stockCartToken, stockLines); err != nil {
+				return err
+			}
+		}
 		if appliedCouponCode != nil && h.couponSvc != nil {
 			applier := coupon.NewCouponApplier(h.couponSvc, *appliedCouponCode, req.CustomerEmail)
 			if _, err := applier.Apply(ctx, tx, discount.ApplyInput{
@@ -1231,6 +1257,20 @@ func (paymentGatewayConfigRow) TableName() string { return "payment_gateway_conf
 
 // respondErr mirrors the checkout.go error response pattern.
 func (h *CheckoutExtHandler) respondErr(c *gin.Context, err error) {
+	// #230 — a sold-out line is a 409 naming the variant, never a 500. It
+	// arrives here as an ordinary error from the order transaction, so it
+	// must be matched before the apperrors switch or it falls through to
+	// internal_error and the shopper is told nothing actionable.
+	var oos outOfStockError
+	if errors.As(err, &oos) {
+		c.AbortWithStatusJSON(http.StatusConflict, map[string]any{
+			"error":      "out_of_stock",
+			"message":    "one or more items are no longer available in the requested quantity",
+			"variant_id": oos.VariantID,
+		})
+		return
+	}
+
 	// Amendment LOW FIX 9: use errors.As instead of manual type assertion.
 	var ae *apperrors.Error
 	if errors.As(err, &ae) {

--- a/services/marketplace-api/internal/handlers/storefront/checkout_lowstock.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_lowstock.go
@@ -3,15 +3,33 @@
 // "many small files over few large files" convention — checkout_ext.go is
 // already large.
 //
-// A customer purchase decrements stock via a DB trigger (see
-// internal/product/models.go: Variant.InventoryQuantity is
-// trigger-maintained from variant_stock; do not write it directly), so this
-// package can only observe the POST-sale quantity, never a directly
-// snapshotted pre-sale quantity the way the admin manual variant-edit PATCH
-// does (internal/handlers/admin/variants.go). crossedLowStock reformulates
-// the same "did this write cross the threshold" predicate purely in terms
-// of post-sale stock plus the quantity just sold, since
-// preSaleQty == postSaleQty + qty always holds for a single sale.
+// # Corrected 2026-08-30 (#230)
+//
+// This file used to claim "a customer purchase decrements stock via a DB
+// trigger". No such trigger ever existed. `grep 'CREATE TRIGGER' migrations`
+// returns eleven triggers and the only stock one is sync_variant_inventory(),
+// which mirrors variant_stock into the denormalised
+// product_variants.inventory_quantity and does nothing on order insert. A
+// storefront sale changed no stock at all, and two customers could buy the
+// same last unit.
+//
+// A sale now decrements variant_stock inside the ORDER TRANSACTION, via
+// stockhold.Commit from checkout_stock.go. So the post-sale reading below is
+// finally true — but by a different mechanism than the one this file
+// originally described, which is worth stating because the old comment was
+// load-bearing in the wrong direction: it explained away the absence of the
+// thing it claimed existed.
+//
+// crossedLowStock still reformulates "did this write cross the threshold"
+// purely in terms of post-sale stock plus the quantity just sold, since
+// preSaleQty == postSaleQty + qty holds for a single sale.
+//
+// # Not wired
+//
+// crossedLowStock has no non-test caller. The predicate is correct and
+// tested; nothing calls it, so no low-stock notification fires for a
+// storefront sale today. Wiring it is out of scope for #230, whose
+// acceptance was the decrement and this correction.
 package storefront
 
 import (

--- a/services/marketplace-api/internal/handlers/storefront/checkout_stock.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_stock.go
@@ -1,0 +1,167 @@
+package storefront
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/product"
+	"github.com/mark8ly/marketplace-api/internal/stockhold"
+)
+
+// inventoryPolicyContinue means the merchant sells past zero on purpose.
+const inventoryPolicyContinue = "continue"
+
+// outOfStockError names the variant a shopper has to remove.
+//
+// It carries the id because a bare "out of stock" is unactionable on a cart
+// of six items — the storefront needs to know which line to mark.
+type outOfStockError struct {
+	VariantID string
+}
+
+func (e outOfStockError) Error() string {
+	return fmt.Sprintf("storefront: variant %s is out of stock", e.VariantID)
+}
+
+// stockLine is one checkout item that consumes inventory.
+type stockLine struct {
+	VariantID string
+	Quantity  int
+}
+
+// commitStock reserves and consumes inventory for a checkout, INSIDE the
+// order's transaction (#230).
+//
+// # Why it runs in the order transaction
+//
+// Decrementing after the order commits would leave a paid order whose stock
+// was never taken when the decrement failed; decrementing before would strand
+// stock when the order failed. order.CreateInput.WithinTx exists for exactly
+// this shape — returning an error here rolls the order back entirely, which
+// is the only correct outcome: the buyer can retry and nothing has moved.
+//
+// # Hold-then-commit, even for a cart that already holds
+//
+// stockhold.Hold is idempotent per (cart_token, variant, location) and its
+// availability sum excludes the calling cart, so re-holding what this cart
+// already reserved is free and does not double-count. That makes one code
+// path serve both cases: a storefront that placed holds at cart-add, and any
+// caller that did not. Checkout enforces availability either way, which is
+// what stops #230's oversell independently of the UI.
+//
+// A hold placed at cart-add that has since EXPIRED simply fails here if the
+// units are gone — which is correct, and is what the shopper is told.
+func commitStock(
+	ctx context.Context,
+	tx *gorm.DB,
+	holds *stockhold.Repository,
+	cartToken string,
+	lines []stockLine,
+) error {
+	if len(lines) == 0 {
+		return nil
+	}
+
+	policies, err := inventoryPolicies(tx, lines)
+	if err != nil {
+		return err
+	}
+
+	for _, line := range lines {
+		if policies[line.VariantID] == inventoryPolicyContinue {
+			// Sell past zero on purpose. No hold, no gate — and the
+			// decrement is clamped, because variant_stock carries a
+			// non-negative CHECK (#231) that cannot be policy-aware: the
+			// policy lives on product_variants, and a CHECK cannot read
+			// another table.
+			//
+			// The consequence, stated rather than hidden: how far a
+			// 'continue' variant is oversold is NOT tracked. The orders
+			// are the record of what was sold; this column stops at zero.
+			if err := tx.WithContext(ctx).Exec(
+				`UPDATE variant_stock
+				    SET quantity = GREATEST(quantity - ?, 0), updated_at = now()
+				  WHERE variant_id = ? AND location_id = ?`,
+				line.Quantity, line.VariantID, product.DefaultLocationID).Error; err != nil {
+				return fmt.Errorf("storefront: decrement continue-policy variant: %w", err)
+			}
+			continue
+		}
+
+		err := holds.Hold(ctx, tx, cartToken, line.VariantID,
+			product.DefaultLocationID, line.Quantity, HoldTTL)
+		if errors.Is(err, stockhold.ErrInsufficientStock) {
+			return outOfStockError{VariantID: line.VariantID}
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	// One Commit for the whole cart: it decrements every live hold this cart
+	// holds and flips them to 'committed' in the same transaction.
+	return holds.Commit(ctx, tx, cartToken)
+}
+
+// inventoryPolicies reads the policy for each line's variant in one query.
+//
+// A variant with no row is treated as 'deny' — the column's own default, and
+// the safe reading: refusing to oversell something we cannot classify is
+// recoverable, overselling it is not.
+func inventoryPolicies(tx *gorm.DB, lines []stockLine) (map[string]string, error) {
+	ids := make([]string, 0, len(lines))
+	for _, l := range lines {
+		ids = append(ids, l.VariantID)
+	}
+
+	var rows []struct {
+		ID              string
+		InventoryPolicy string
+	}
+	if err := tx.Raw(
+		`SELECT id, COALESCE(inventory_policy, 'deny') AS inventory_policy
+		   FROM product_variants WHERE id IN ?`, ids).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("storefront: read inventory policies: %w", err)
+	}
+
+	out := make(map[string]string, len(rows))
+	for _, r := range rows {
+		out[r.ID] = r.InventoryPolicy
+	}
+	return out, nil
+}
+
+// stockLinesFromItems selects the checkout items that consume inventory.
+//
+// An item with no variant_id is a custom or unstocked line — refusing those
+// would break every unstocked sale, and there is nothing to decrement.
+func stockLinesFromItems(items []CheckoutItemRequest) []stockLine {
+	lines := make([]stockLine, 0, len(items))
+	for _, it := range items {
+		if it.VariantID == nil || *it.VariantID == "" || it.Quantity <= 0 {
+			continue
+		}
+		lines = append(lines, stockLine{VariantID: *it.VariantID, Quantity: it.Quantity})
+	}
+	return lines
+}
+
+// cartTokenForCheckout returns the cart identity to commit holds against.
+//
+// A checkout arriving without one — an API client, or a storefront build
+// predating #232 — gets a fresh token, so the hold-then-commit path still
+// enforces availability for it. Enforcement must not depend on the caller
+// having cooperated.
+func cartTokenForCheckout(c *gin.Context) string {
+	if ck, err := c.Cookie(CartTokenCookie); err == nil {
+		if _, perr := uuid.Parse(ck); perr == nil {
+			return ck
+		}
+	}
+	return uuid.NewString()
+}

--- a/services/marketplace-api/internal/handlers/storefront/checkout_stock_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_stock_integration_test.go
@@ -1,0 +1,219 @@
+//go:build integration
+
+package storefront_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/singleflight"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/storefront"
+	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/internal/outbox"
+	"github.com/mark8ly/marketplace-api/internal/stockhold"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// #230 — a storefront sale must decrement stock, and two customers must not
+// be able to buy the same last unit.
+//
+// The bug: checkout never read inventory at all. A comment in
+// checkout_lowstock.go claimed a decrement-on-sale trigger existed; it never
+// did. The only stock trigger mirrors variant_stock into the denormalised
+// product_variants.inventory_quantity and does nothing on order insert.
+
+func checkoutBodyForVariant(variantID string, qty int) map[string]any {
+	return map[string]any{
+		"idempotency_key": "stock-" + uuid.NewString(),
+		"customer_email":  "stock@example.com",
+		"items": []map[string]any{{
+			"title_snapshot": "Stocked Widget",
+			"sku_snapshot":   "STK-1",
+			"variant_id":     variantID,
+			"unit_price":     "10.00",
+			"quantity":       qty,
+			"line_total":     fmt.Sprintf("%d.00", 10*qty),
+			"currency_code":  "EUR",
+		}},
+		"subtotal":       fmt.Sprintf("%d.00", 10*qty),
+		"shipping_total": "0.00",
+		"tax_total":      "0.00",
+		"discount_total": "0.00",
+		"grand_total":    fmt.Sprintf("%d.00", 10*qty),
+		"shipping":       checkoutAddress(),
+		"billing":        checkoutAddress(),
+	}
+}
+
+func stockOf(t *testing.T, db *gorm.DB, variantID string) int {
+	t.Helper()
+	var q int
+	require.NoError(t, db.Raw(`SELECT quantity FROM variant_stock WHERE variant_id = ?`, variantID).Scan(&q).Error)
+	return q
+}
+
+func TestStorefrontCheckout_DecrementsStock(t *testing.T) {
+	r, db, store := setupStockCheckoutRouter(t)
+	variantID := insertVariantWithStock(t, db, store.TenantID, store.ID, 5)
+
+	rec := doRequest(t, r, http.MethodPost,
+		"/api/v1/storefront/stores/"+store.Slug+"/checkout", checkoutBodyForVariant(variantID, 2))
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	require.Equal(t, 3, stockOf(t, db, variantID), "a committed sale must decrement variant_stock")
+}
+
+// The acceptance test for this issue. Two concurrent checkouts for one unit:
+// exactly one succeeds, the other gets a 409 naming the variant.
+func TestStorefrontCheckout_ConcurrentBuyersCannotBothTakeTheLastUnit(t *testing.T) {
+	r, db, store := setupStockCheckoutRouter(t)
+	variantID := insertVariantWithStock(t, db, store.TenantID, store.ID, 1)
+	url := "/api/v1/storefront/stores/" + store.Slug + "/checkout"
+
+	var wg sync.WaitGroup
+	codes := make(chan int, 2)
+	bodies := make(chan string, 2)
+	start := make(chan struct{})
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			rec := doRequest(t, r, http.MethodPost, url, checkoutBodyForVariant(variantID, 1))
+			codes <- rec.Code
+			bodies <- rec.Body.String()
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(codes)
+	close(bodies)
+
+	var created, conflict int
+	for code := range codes {
+		switch code {
+		case http.StatusCreated:
+			created++
+		case http.StatusConflict:
+			conflict++
+		default:
+			t.Errorf("unexpected status %d", code)
+		}
+	}
+	require.Equal(t, 1, created, "exactly one buyer may take the last unit")
+	require.Equal(t, 1, conflict, "the loser must get a 409, not a 500 and not a second order")
+
+	var sawCode, sawVariant bool
+	for b := range bodies {
+		if len(b) == 0 {
+			continue
+		}
+		var parsed map[string]any
+		if json.Unmarshal([]byte(b), &parsed) == nil {
+			if parsed["error"] == "out_of_stock" {
+				sawCode = true
+			}
+			if fmt.Sprint(parsed["variant_id"]) == variantID {
+				sawVariant = true
+			}
+		}
+	}
+	require.True(t, sawCode, "the refusal must carry a machine-readable out_of_stock code")
+	require.True(t, sawVariant, "and must name the variant the shopper has to remove")
+
+	require.Equal(t, 0, stockOf(t, db, variantID), "stock must land at zero, never negative")
+}
+
+// A rolled-back order must not consume stock. This is why the decrement runs
+// in the order transaction rather than after it.
+func TestStorefrontCheckout_RefusedOrderLeavesStockUntouched(t *testing.T) {
+	r, db, store := setupStockCheckoutRouter(t)
+	variantID := insertVariantWithStock(t, db, store.TenantID, store.ID, 1)
+	url := "/api/v1/storefront/stores/" + store.Slug + "/checkout"
+
+	require.Equal(t, http.StatusConflict,
+		doRequest(t, r, http.MethodPost, url, checkoutBodyForVariant(variantID, 5)).Code)
+
+	require.Equal(t, 1, stockOf(t, db, variantID), "a refused checkout must not move stock")
+
+	var orders int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM orders WHERE store_id = ?`, store.ID).Scan(&orders).Error)
+	require.Equal(t, int64(0), orders, "no order may persist for a refused checkout")
+}
+
+// inventory_policy = 'continue' means the merchant sells past zero on
+// purpose. The column exists and must be honoured, not ignored.
+func TestStorefrontCheckout_ContinuePolicyStillSellsPastZero(t *testing.T) {
+	r, db, store := setupStockCheckoutRouter(t)
+	variantID := insertVariantWithStock(t, db, store.TenantID, store.ID, 1)
+	require.NoError(t, db.Exec(
+		`UPDATE product_variants SET inventory_policy = 'continue' WHERE id = ?`, variantID).Error)
+
+	rec := doRequest(t, r, http.MethodPost,
+		"/api/v1/storefront/stores/"+store.Slug+"/checkout", checkoutBodyForVariant(variantID, 5))
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	// Clamped at zero rather than negative: variant_stock carries a
+	// non-negative CHECK (#231) and it cannot be policy-aware, since the
+	// policy lives on another table.
+	require.Equal(t, 0, stockOf(t, db, variantID))
+}
+
+// An item with no variant_id (a custom or unstocked line) must still check
+// out — stock enforcement applies to variants, and refusing these would
+// break every unstocked sale.
+func TestStorefrontCheckout_ItemWithoutAVariantIsUnaffected(t *testing.T) {
+	r, _, store := setupStockCheckoutRouter(t)
+	body := checkoutBodyForVariant("", 1)
+	items := body["items"].([]map[string]any)
+	delete(items[0], "variant_id")
+
+	rec := doRequest(t, r, http.MethodPost,
+		"/api/v1/storefront/stores/"+store.Slug+"/checkout", body)
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+}
+
+func checkoutAddress() map[string]any {
+	return map[string]any{
+		"name": "Buyer", "line1": "1 High St", "city": "Dublin", "country_code": "IE",
+	}
+}
+
+// setupStockCheckoutRouter mirrors setupCheckoutRouter but wires the stock
+// holds repository, which is what makes checkout enforce availability.
+func setupStockCheckoutRouter(t *testing.T) (*gin.Engine, *gorm.DB, *stores.Store) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	db := testdb.NewDB(t, append(checkoutTruncateTables, "stock_holds")...)
+	storesRepo := stores.NewRepository(db)
+	slugCache := stores.NewSlugCache(storesRepo, fakeStoresClient{}, &singleflight.Group{}, 5*time.Minute)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	orderRepo := order.NewRepository()
+	outboxRepo := outbox.NewRepository(db)
+	orderSvc := order.NewService(db, orderRepo, outboxRepo)
+	checkoutHandler := storefront.NewCheckoutHandler(db, orderSvc, orderRepo, logger).
+		WithStockHolds(stockhold.NewRepository())
+
+	r := gin.New()
+	storefront.RegisterStorefront(r.Group("/api/v1"), storefront.Deps{
+		CheckoutHandler: checkoutHandler,
+		SlugCache:       slugCache,
+		StorefrontKey:   "",
+	})
+	return r, db, seedCheckoutStore(t, db)
+}


### PR DESCRIPTION
Closes #230, completing the backend of #229 on top of #231 and #232.

A storefront sale now takes stock. Two customers can no longer buy the same last unit.

## Acceptance

- [x] Two concurrent checkouts for one unit — exactly one succeeds, the other gets **409 `out_of_stock`** naming the variant
- [x] A committed sale decrements `variant_stock` **in the order transaction**
- [x] `CHECK (quantity >= 0)` — shipped in #231
- [x] `inventory_policy = 'continue'` still sells past zero
- [x] The stale comment at `checkout_lowstock.go:6` is corrected

## Why it runs inside the order transaction

Decrementing *after* the order commits leaves a paid order whose stock was never taken. Decrementing *before* strands stock when the order fails. `order.CreateInput.WithinTx` exists for precisely this shape — its doc describes the same bug for gift cards — and returning an error there rolls the order back entirely: the buyer can retry and nothing has moved.

`TestStorefrontCheckout_RefusedOrderLeavesStockUntouched` asserts both halves: stock unchanged **and** no order row.

## The bug this nearly repeated

**Both checkout handlers had to be wired, and the ext one is the one that matters.** `routes.go` prefers `CheckoutExtHandler` whenever it is set, so enforcement on the simple `CheckoutHandler` alone would have fixed nothing in production while every test passed.

`TestMainWiresStockHoldsIntoCheckout` reads the builder chains in main.go and fails if either constructor is missing `.WithStockHolds(...)`. Verified by deleting the ext wiring — it fails with the message naming that constructor. Same shape as #341: a guard that is not wired is indistinguishable from no guard.

## Hold-then-commit, one path for every caller

`stockhold.Hold` is idempotent per `(cart_token, variant, location)` and its availability sum excludes the calling cart, so re-holding what this cart already reserved is free. One code path therefore serves both a storefront that placed holds at cart-add (#232) and any caller that did not — **checkout enforces availability either way**, so the fix does not depend on the UI landing first.

A cart-add hold that has since expired simply fails here if the units are gone, which is correct and is what the shopper is told.

## `inventory_policy = 'continue'`, and a limitation I am stating rather than hiding

A 'continue' variant skips the gate and decrements **clamped at zero**.

It cannot go negative, because #231's `CHECK (quantity >= 0)` cannot be policy-aware — the policy lives on `product_variants` and a CHECK cannot read another table. So **how far a 'continue' variant is oversold is not tracked**; the orders are the record of what sold, and the column stops at zero.

Making that faithful needs a trigger or a policy column on `variant_stock`. Both are larger than this issue, and neither is needed for the oversell #230 reports.

## The corrected comment

The old text claimed "a customer purchase decrements stock via a DB trigger" and built an argument on top of it. No such trigger existed — that comment explained away the absence of the very thing it claimed. The replacement says what happens now, by which mechanism, and adds something the issue did not ask for but a reader needs: **`crossedLowStock` has no non-test caller**, so no low-stock notification fires for a storefront sale today. The predicate is correct and tested; nothing calls it. Wiring it is out of scope here.

## Verification

- 5 new integration tests written first, including the concurrency acceptance test — green across `-count=3`
- `go build`, `go vet`, full unit suite, and the **entire integration suite** clean against a real database