### PR TITLE
feat(storefront): place stock holds from the cart and surface a sold-out checkout (#232)

### DIFF
--- a/apps/storefront/app/api/checkout/cart-holds/route.ts
+++ b/apps/storefront/app/api/checkout/cart-holds/route.ts
@@ -1,0 +1,103 @@
+import { cookies } from "next/headers";
+import { marketplaceStoreUrl, proxyJson, requireStoreSlug } from "../_proxy";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Cart stock holds (#232).
+ *
+ * # Why this route owns the cookie
+ *
+ * marketplace-api sets its own `mk_cart_token` cookie, but `proxyJson`
+ * deliberately does not forward upstream `Set-Cookie` headers — and even if
+ * it did, the cookie would carry the API's domain, not the storefront's.
+ *
+ * So the cart identity is minted and stored HERE, on the storefront origin,
+ * and passed upstream in the request body (which the API accepts for exactly
+ * this case). One owner, no cross-domain cookie rewriting.
+ *
+ * httpOnly because the token identifies a stock reservation: script access
+ * buys the storefront nothing and costs XSS exposure. The client learns its
+ * token from the response body when it needs it.
+ */
+const CART_TOKEN_COOKIE = "mk_cart_token";
+
+// Matches HoldTTL in the API. If they drift, the countdown lies to the
+// shopper — the API's value is the one that decides, this only bounds how
+// long the browser keeps the identity.
+const HOLD_TTL_SECONDS = 15 * 60;
+
+export async function POST(req: Request): Promise<Response> {
+  const parsed = requireStoreSlug(req);
+  if (parsed instanceof Response) return parsed;
+
+  const cookieStore = await cookies();
+  const existing = cookieStore.get(CART_TOKEN_COOKIE)?.value;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json(
+      { error: "invalid_request", message: "cart hold request could not be parsed" },
+      { status: 400 },
+    );
+  }
+
+  const payload = {
+    ...(typeof body === "object" && body !== null ? body : {}),
+    ...(existing ? { cart_token: existing } : {}),
+  };
+
+  const upstream = await proxyJson(`${marketplaceStoreUrl(parsed.slug)}/cart/holds`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  // Persist whatever token the API settled on — it mints one when we had
+  // none, so reading it back is how a first cart write gains an identity.
+  if (upstream.ok) {
+    const text = await upstream.clone().text();
+    try {
+      const parsedBody = JSON.parse(text) as { data?: { cart_token?: string } };
+      const token = parsedBody?.data?.cart_token;
+      if (token && token !== existing) {
+        cookieStore.set(CART_TOKEN_COOKIE, token, {
+          httpOnly: true,
+          sameSite: "lax",
+          secure: process.env.NODE_ENV === "production",
+          path: "/",
+          maxAge: HOLD_TTL_SECONDS,
+        });
+      }
+    } catch {
+      // A response we cannot parse is still a successful hold upstream;
+      // the shopper keeps whatever identity they had rather than losing
+      // their reservation to a parsing detail.
+    }
+  }
+
+  return upstream;
+}
+
+/**
+ * Release the cart's holds — called when the shopper empties their cart.
+ *
+ * Idempotent and quiet: releasing a cart that holds nothing is a success,
+ * because the caller's intent is satisfied either way.
+ */
+export async function DELETE(req: Request): Promise<Response> {
+  const parsed = requireStoreSlug(req);
+  if (parsed instanceof Response) return parsed;
+
+  const cookieStore = await cookies();
+  const token = cookieStore.get(CART_TOKEN_COOKIE)?.value;
+  if (!token) return new Response(null, { status: 204 });
+
+  const upstream = await proxyJson(
+    `${marketplaceStoreUrl(parsed.slug)}/cart/holds/${encodeURIComponent(token)}`,
+    { method: "DELETE" },
+  );
+  cookieStore.delete(CART_TOKEN_COOKIE);
+  return upstream;
+}

--- a/apps/storefront/app/checkout/page.tsx
+++ b/apps/storefront/app/checkout/page.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
+import { HoldCountdown } from "@/components/HoldCountdown";
 import { useCart } from "@/components/CartProvider";
 import { StorefrontNav } from "@/components/StorefrontNav";
 import { toast } from "@/lib/toast";
@@ -28,6 +29,7 @@ import {
   fetchShippingRates,
   fetchTaxPreview,
   submitCheckout,
+  isOutOfStock,
   type PaymentMethod,
   type ShippingOption,
   type ShippingRate,
@@ -166,7 +168,7 @@ function formatPrice(amount: number, currencyCode: string): string {
 
 export default function CheckoutPage() {
   const router = useRouter();
-  const { items, subtotal, count, clear } = useCart();
+  const { items, subtotal, count, clear, holdExpiresAt } = useCart();
   const storeSlug = useMemo(() => resolveSlugClient(), []);
   const currencyCode = items[0]?.currencyCode ?? "USD";
 
@@ -511,6 +513,31 @@ export default function CheckoutPage() {
     };
 
     const result = await submitCheckout(storeSlug, body);
+
+    // Someone else took the stock while this buyer was checking out
+    // (#230/#232). This is not a site fault and must not read as one: the
+    // shopper can remove that line and try again. Before this, every
+    // non-2xx collapsed into "something went wrong", which told them
+    // nothing and looked like the store was broken.
+    if (isOutOfStock(result)) {
+      const item = result.variantId
+        ? items.find((i) => i.variantId === result.variantId)
+        : undefined;
+      const named = item ? `"${item.title}"` : "One of your items";
+      setError(
+        `${named} just sold out while you were checking out. Remove it from your cart to continue — your card was not charged.`,
+      );
+      toast({
+        title: "Someone else took the last one",
+        description: item
+          ? `${item.title} is no longer available in that quantity.`
+          : "An item in your cart is no longer available in that quantity.",
+        tone: "error",
+      });
+      setSubmitting(false);
+      return;
+    }
+
     if (!result) {
       setError("Something went wrong placing your order. Please try again.");
       toast({
@@ -727,6 +754,12 @@ export default function CheckoutPage() {
         <h1 className="mt-4 font-[family-name:var(--storefront-heading-font,var(--font-source-serif))] text-3xl text-[color:var(--storefront-text,var(--ink-900))]">
           Checkout
         </h1>
+
+        {/* #232 — how long these items stay reserved. Renders nothing when
+            there is no hold, which is a normal state. */}
+        <div className="mt-2">
+          <HoldCountdown expiresAt={holdExpiresAt} />
+        </div>
 
         {/* Step indicator */}
         <CheckoutSteps

--- a/apps/storefront/components/CartProvider.tsx
+++ b/apps/storefront/components/CartProvider.tsx
@@ -25,6 +25,7 @@ import {
   count,
   type CartItem,
 } from "@/lib/cart";
+import { placeCartHolds, releaseCartHolds } from "@/lib/api/checkout-api";
 
 // ---------------------------------------------------------------------------
 // Context shape
@@ -38,6 +39,12 @@ interface CartContextValue {
   clear: () => void;
   count: number;
   subtotal: number;
+  /**
+   * ISO timestamp when this cart's stock holds lapse, or null when nothing
+   * is reserved (#232). Null is a normal state, not an error: a failed hold
+   * is silent by design, because checkout enforces availability anyway.
+   */
+  holdExpiresAt: string | null;
 }
 
 const CartContext = createContext<CartContextValue | null>(null);
@@ -111,12 +118,21 @@ export interface CartProviderProps {
 
 const PERSIST_DEBOUNCE_MS = 250;
 
+// Long enough that a qty stepper collapses into one call, short enough that
+// a shopper who adds and immediately opens checkout is already holding.
+const HOLD_SYNC_DEBOUNCE_MS = 700;
+
 export function CartProvider({ storeSlug, children }: CartProviderProps) {
   const [items, dispatch] = useReducer(reducer, []);
   // Gate the persist effect until after hydration has run — otherwise
   // the first render (items=[]) overwrites a non-empty stored cart in
   // the milliseconds before HYDRATE lands.
   const [hydrated, setHydrated] = useState(false);
+  // When the current cart's stock holds expire, for the checkout countdown.
+  // Null means "no hold" — either nothing is reserved yet, or the last
+  // attempt failed, which is not an error the shopper needs to see.
+  const [holdExpiresAt, setHoldExpiresAt] = useState<string | null>(null);
+  const heldRef = useRef(false);
   const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Hydrate from localStorage on mount (client-only).
@@ -165,6 +181,46 @@ export function CartProvider({ storeSlug, children }: CartProviderProps) {
     };
   }, [storeSlug, items, hydrated]);
 
+  // #232 — mirror the cart to server-side stock holds.
+  //
+  // Holds are placed AT CART-ADD for the full TTL: the shopper who adds
+  // first keeps the unit. Debounced for the same reason the persist effect
+  // is — a qty stepper should produce one hold call, not one per click —
+  // and the API is idempotent per (cart, variant), so re-posting the whole
+  // cart refreshes rather than stacking.
+  //
+  // Deliberately best-effort and silent. A failed hold must never block
+  // shopping: checkout enforces availability regardless (#230), so the worst
+  // case is the shopper finds out at checkout instead of now. Blocking the
+  // add would turn a backend blip into a store that cannot sell.
+  useEffect(() => {
+    if (!hydrated) return;
+
+    const variants = items
+      .filter((i) => i.variantId && i.qty > 0)
+      .map((i) => ({ variantId: i.variantId, qty: i.qty }));
+
+    if (variants.length === 0) {
+      // Emptied cart: give the units back rather than making the next
+      // shopper wait out the TTL.
+      if (heldRef.current) {
+        heldRef.current = false;
+        setHoldExpiresAt(null);
+        void releaseCartHolds(storeSlug);
+      }
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      void placeCartHolds(storeSlug, variants).then((res) => {
+        if (!res) return;
+        heldRef.current = true;
+        setHoldExpiresAt(res.expires_at);
+      });
+    }, HOLD_SYNC_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [storeSlug, items, hydrated]);
+
   const add = useCallback(
     (item: CartItem) => dispatch({ type: "ADD", item }),
     [],
@@ -190,8 +246,9 @@ export function CartProvider({ storeSlug, children }: CartProviderProps) {
       clear,
       count: count(items),
       subtotal: subtotal(items),
+      holdExpiresAt,
     }),
-    [items, add, remove, updateQty, clear],
+    [items, add, remove, updateQty, clear, holdExpiresAt],
   );
 
   return <CartContext value={value}>{children}</CartContext>;

--- a/apps/storefront/components/HoldCountdown.tsx
+++ b/apps/storefront/components/HoldCountdown.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Shows how long the cart's stock holds have left (#232).
+ *
+ * # Why it is quiet by default
+ *
+ * A countdown is a pressure device, and this store's voice is calm and
+ * unhurried. So it reads as a statement of fact in the page's own ink at low
+ * emphasis, and only takes on the signal colour in the last two minutes,
+ * when it is genuinely information the shopper needs rather than a nudge.
+ *
+ * It renders nothing at all when there is no hold, which is a normal state:
+ * a hold may have failed silently, and inventing "unreserved" text would
+ * manufacture anxiety about something the shopper cannot act on and that
+ * checkout will enforce anyway.
+ */
+export function HoldCountdown({ expiresAt }: { expiresAt: string | null }) {
+  const [remainingMs, setRemainingMs] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!expiresAt) {
+      setRemainingMs(null);
+      return;
+    }
+    const target = new Date(expiresAt).getTime();
+    if (Number.isNaN(target)) {
+      setRemainingMs(null);
+      return;
+    }
+    const tick = () => setRemainingMs(target - Date.now());
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [expiresAt]);
+
+  if (remainingMs === null) return null;
+
+  // Expired: say what it means for the shopper rather than showing 0:00.
+  // The items may still be there — checkout re-checks — so the honest
+  // wording is that they are no longer reserved, not that they are gone.
+  if (remainingMs <= 0) {
+    return (
+      <p
+        className="text-sm text-[color:var(--storefront-text,var(--ink-900))] opacity-70"
+        role="status"
+      >
+        Your items are no longer reserved. They may still be available —
+        we&rsquo;ll check when you place your order.
+      </p>
+    );
+  }
+
+  const totalSeconds = Math.floor(remainingMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  const urgent = remainingMs <= 2 * 60 * 1000;
+
+  return (
+    <p
+      className={
+        urgent
+          ? "text-sm text-[color:var(--signal,#C2410C)]"
+          : "text-sm text-[color:var(--storefront-text,var(--ink-900))] opacity-70"
+      }
+      // polite, not assertive: this updates every second and must not
+      // interrupt a screen-reader user mid-field.
+      aria-live="polite"
+      role="status"
+    >
+      Items reserved for{" "}
+      <span className="tabular-nums">
+        {minutes}:{seconds.toString().padStart(2, "0")}
+      </span>
+    </p>
+  );
+}

--- a/apps/storefront/lib/api/checkout-api.test.ts
+++ b/apps/storefront/lib/api/checkout-api.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isOutOfStock, submitCheckout } from "./checkout-api";
+
+// #232 — a sold-out line must be distinguishable from a site fault.
+//
+// submitCheckout used to return null for EVERY non-2xx, so a 409 naming the
+// variant arrived at the page identical to a 500. The shopper was told
+// "something went wrong" for a situation they could resolve by removing one
+// line.
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+function mockFetch(status: number, body: unknown) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  }) as unknown as typeof fetch;
+}
+
+const requestBody = { idempotency_key: "k", items: [] } as never;
+
+describe("submitCheckout out-of-stock handling", () => {
+  it("reports a 409 out_of_stock with the variant so the page can name the item", async () => {
+    mockFetch(409, { error: "out_of_stock", variant_id: "v-123" });
+
+    const result = await submitCheckout("store", requestBody);
+
+    expect(isOutOfStock(result)).toBe(true);
+    expect(isOutOfStock(result) && result.variantId).toBe("v-123");
+  });
+
+  // The status is the fact that matters. Losing it because the body did not
+  // parse would drop the shopper back into the generic error they cannot act
+  // on — which is the bug this exists to fix.
+  it("still reports out-of-stock when the 409 body cannot be parsed", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => {
+        throw new Error("not json");
+      },
+    }) as unknown as typeof fetch;
+
+    const result = await submitCheckout("store", requestBody);
+
+    expect(isOutOfStock(result)).toBe(true);
+  });
+
+  it("does not treat other failures as out-of-stock", async () => {
+    mockFetch(500, { error: "internal_error" });
+
+    const result = await submitCheckout("store", requestBody);
+
+    expect(result).toBeNull();
+    expect(isOutOfStock(result)).toBe(false);
+  });
+
+  it("returns the order on success", async () => {
+    mockFetch(201, { order_id: "o-1", order_number: "M-1", payment_token: "t" });
+
+    const result = await submitCheckout("store", requestBody);
+
+    expect(isOutOfStock(result)).toBe(false);
+    expect(result && "order_id" in result && result.order_id).toBe("o-1");
+  });
+});

--- a/apps/storefront/lib/api/checkout-api.ts
+++ b/apps/storefront/lib/api/checkout-api.ts
@@ -373,10 +373,31 @@ export async function fetchTaxPreview(
  * Submits the checkout. Returns the checkout result with payment token
  * and computed totals. Returns null on failure.
  */
+/**
+ * A checkout that failed because someone else took the stock (#230/#232).
+ *
+ * Distinguished from every other failure on purpose. The backend answers
+ * 409 `out_of_stock` naming the variant, and a shopper can act on that —
+ * remove the line and retry. Collapsing it into the generic "something went
+ * wrong" path, which is what this function used to do for every non-2xx,
+ * tells a buyer nothing and reads as a site fault rather than a sold-out
+ * item.
+ */
+export interface CheckoutOutOfStock {
+  outOfStock: true;
+  variantId?: string;
+}
+
+export type CheckoutOutcome = CheckoutResult | CheckoutOutOfStock | null;
+
+export function isOutOfStock(o: CheckoutOutcome): o is CheckoutOutOfStock {
+  return o !== null && (o as CheckoutOutOfStock).outOfStock === true;
+}
+
 export async function submitCheckout(
   storeSlug: string,
   body: CheckoutBody,
-): Promise<CheckoutResult | null> {
+): Promise<CheckoutOutcome> {
   const url = IS_BROWSER
     ? proxyUrl("submit", storeSlug)
     : `${storeUrl(storeSlug)}/checkout`;
@@ -386,6 +407,21 @@ export async function submitCheckout(
       headers: commonHeaders(),
       body: JSON.stringify(body),
     });
+    if (res.status === 409) {
+      // Read the variant so the page can name the item. A body we cannot
+      // parse still yields outOfStock: the status is the fact that
+      // matters, and losing it would drop the shopper back into the
+      // generic error they cannot act on.
+      try {
+        const parsed = (await res.json()) as { error?: string; variant_id?: string };
+        if (parsed?.error === "out_of_stock") {
+          return { outOfStock: true, variantId: parsed.variant_id };
+        }
+      } catch {
+        return { outOfStock: true };
+      }
+      return { outOfStock: true };
+    }
     if (!res.ok) return null;
     return (await res.json()) as CheckoutResult;
   } catch {
@@ -455,4 +491,67 @@ export async function checkGiftCardBalance(
 
   const json = await res.json();
   return json.data as GiftCardBalanceResult;
+}
+
+// ---------------------------------------------------------------------------
+// Stock holds (#232)
+// ---------------------------------------------------------------------------
+
+export interface CartHoldItemResult {
+  variant_id: string;
+  /** "held" or "insufficient". */
+  status: string;
+  /** What the shopper can actually have right now. */
+  available: number;
+}
+
+export interface CartHoldsResult {
+  cart_token: string;
+  expires_at: string;
+  items: CartHoldItemResult[];
+}
+
+/**
+ * Place or refresh stock holds for the cart.
+ *
+ * Browser-only: the cart identity is an httpOnly cookie owned by the
+ * `/api/checkout/cart-holds` route handler, so there is nothing useful this
+ * can do server-side.
+ *
+ * Returns null on any failure, and callers treat that as "no reservation" —
+ * NOT as an error to show. A failed hold must never block adding to a cart:
+ * checkout enforces availability regardless (#230), so the worst case is the
+ * shopper learns at checkout instead of at add-time. Blocking the add would
+ * turn a backend blip into a store that cannot sell.
+ */
+export async function placeCartHolds(
+  storeSlug: string,
+  items: ReadonlyArray<{ variantId: string; qty: number }>,
+): Promise<CartHoldsResult | null> {
+  if (!IS_BROWSER || items.length === 0) return null;
+  try {
+    const res = await fetch(proxyUrl("cart-holds", storeSlug), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        items: items.map((i) => ({ variant_id: i.variantId, quantity: i.qty })),
+      }),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { data?: CartHoldsResult };
+    return body?.data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Release the cart's holds. Best-effort: an unreleased hold expires anyway. */
+export async function releaseCartHolds(storeSlug: string): Promise<void> {
+  if (!IS_BROWSER) return;
+  try {
+    await fetch(proxyUrl("cart-holds", storeSlug), { method: "DELETE" });
+  } catch {
+    // Nothing to do: holds expire by the clock, so a failed release costs
+    // at most one TTL of a reservation nobody is using.
+  }
 }


### PR DESCRIPTION
Completes #232 and the #229 epic's UI half, on top of #230/#231.

## The fix with the most value per line

`submitCheckout` returned `null` for **every** non-2xx, so the 409 naming the sold-out variant arrived at the page identical to a 500 — and the shopper was told *"Something went wrong placing your order"* for a situation they could resolve by removing one line.

It now returns a discriminated outcome, and the page names the item:

> **"Linen Slip Dress" just sold out while you were checking out.** Remove it from your cart to continue — your card was not charged.

The "your card was not charged" is not decoration: the order is rolled back entirely in the same transaction (#230), so it is true and it is the first thing a buyer wants to know.

A 409 whose body will not parse **still** reports out-of-stock. The status is the fact that matters; losing it to a parsing detail would drop the shopper back into the generic error.

## Holds are placed from the cart

`CartProvider` mirrors the cart to `/cart/holds`, debounced 700ms — same reasoning as the existing persist debounce: a qty stepper should produce one call, not one per click. The API is idempotent per `(cart, variant)`, so re-posting the whole cart refreshes rather than stacks.

**Deliberately best-effort and silent.** A failed hold never blocks shopping: checkout enforces availability regardless (#230), so the worst case is the shopper finds out at checkout instead of now. Blocking the add would turn a backend blip into a store that cannot sell. Emptying the cart releases, rather than making the next shopper wait out the TTL.

## The route handler owns the cookie, not the API

marketplace-api sets its own `mk_cart_token`, but `_proxy.ts` deliberately does not forward upstream `Set-Cookie` — and even if it did, the cookie would carry the API's domain rather than the storefront's.

So the cart identity is minted and stored on the storefront origin and passed upstream in the body, which the API accepts for exactly this case. One owner, no cross-domain cookie rewriting. httpOnly, because the token identifies a stock reservation: script access buys nothing and costs XSS exposure.

## The countdown, and why it is quiet

A countdown is a pressure device, and this store's voice is calm rather than urgent. It reads as a statement of fact in the page's own ink at low emphasis, and only takes the `--signal` colour in the last two minutes, when it is information rather than a nudge. `tabular-nums` so it does not jitter each second; `aria-live="polite"` so a per-second update never interrupts a screen-reader user mid-field.

**It renders nothing when there is no hold** — a normal state, since a hold may have failed silently. Inventing "unreserved" text would manufacture anxiety about something the shopper cannot act on and checkout will enforce anyway.

On expiry it says the items are *no longer reserved*, not that they are gone: they may well still be there, and checkout re-checks. Showing `0:00` would be a smaller lie but still a lie.

## Verification

- 4 new unit tests on the 409 path, including the unparseable-body case; 71 tests pass
- `tsc --noEmit` clean — the 3 remaining errors are pre-existing on `main` (stale `.next` validator types, missing `@tesserix/otto-widget`), verified by stashing
- `eslint` clean: 0 errors, 4 pre-existing env-var warnings in a file this PR only appends to