### PR TITLE
fix(storefront): pass 204 through the checkout proxy instead of reporting a successful call as unreachable (#232)

### DIFF
--- a/apps/storefront/app/api/checkout/_proxy.test.ts
+++ b/apps/storefront/app/api/checkout/_proxy.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { proxyJson } from "./_proxy";
+
+// A 204/205/304 must not be given a body: `new Response(body, {status: 204})`
+// throws, the throw lands in proxyJson's catch, and the caller is told
+// `upstream_unreachable` for a request that SUCCEEDED — with the side effect
+// already applied upstream.
+//
+// Found live rather than in review: DELETE /cart/holds (#232) is the first
+// endpoint behind this proxy that answers 204. It released the hold in the
+// database and answered the browser 502.
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+function upstream(status: number, body = "") {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    status,
+    headers: new Headers({ "Content-Type": "application/json" }),
+    text: async () => body,
+  }) as unknown as typeof fetch;
+}
+
+describe("proxyJson", () => {
+  it("passes a 204 through without inventing a body", async () => {
+    upstream(204);
+
+    const res = await proxyJson("https://example.test/thing", { method: "DELETE" });
+
+    expect(res.status).toBe(204);
+    expect(await res.text()).toBe("");
+  });
+
+  it("does not report a successful 204 as unreachable", async () => {
+    upstream(204);
+
+    const res = await proxyJson("https://example.test/thing", { method: "DELETE" });
+
+    expect(res.status).not.toBe(502);
+  });
+
+  it("still forwards ordinary JSON responses", async () => {
+    upstream(200, '{"data":{"ok":true}}');
+
+    const res = await proxyJson("https://example.test/thing");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: { ok: true } });
+  });
+
+  it("reports a genuine network failure as 502", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("boom")) as unknown as typeof fetch;
+
+    const res = await proxyJson("https://example.test/thing");
+
+    expect(res.status).toBe(502);
+  });
+});

--- a/apps/storefront/app/api/checkout/_proxy.ts
+++ b/apps/storefront/app/api/checkout/_proxy.ts
@@ -26,6 +26,9 @@ function storefrontHeaders(extra?: HeadersInit): HeadersInit {
   return headers;
 }
 
+// Statuses the fetch spec forbids a body on.
+const NULL_BODY_STATUSES = new Set([204, 205, 304]);
+
 export function marketplaceStoreUrl(storeSlug: string): string {
   return `${MARKETPLACE_API_URL}/api/v1/storefront/stores/${encodeURIComponent(storeSlug)}`;
 }
@@ -44,6 +47,18 @@ export async function proxyJson(
       cache: "no-store",
     });
     const bodyText = await upstream.text();
+
+    // 204/205/304 are null-body statuses: constructing a Response with a
+    // body for one THROWS, and the throw lands in the catch below — so a
+    // call that actually succeeded upstream is reported to the client as
+    // `upstream_unreachable`, with the side effect already applied.
+    //
+    // Found live: DELETE /cart/holds (#232) returns 204, released the hold
+    // in the database, and answered the browser 502.
+    if (NULL_BODY_STATUSES.has(upstream.status)) {
+      return new Response(null, { status: upstream.status });
+    }
+
     return new Response(bodyText, {
       status: upstream.status,
       headers: {


### PR DESCRIPTION
Follow-up to #477, found by probing the deployed route rather than in review.

## The bug

`proxyJson` built every upstream response as `new Response(bodyText, { status })`. For a **204** that throws — the fetch spec forbids a body on 204/205/304 — and the throw lands in the function's own `catch`, which reports:

```json
{"error": "upstream_unreachable"}
```

with **502**, for a request that succeeded.

`DELETE /api/checkout/cart-holds` (#232) is the first endpoint behind this proxy to answer 204. Observed against production:

```
DELETE -> 502
after release: 0 held, 1 released      ← the release actually happened
```

The side effect applied and the browser was told the API was unreachable. A storefront acting on that would retry a completed release, or show a failure for a cart that emptied correctly.

## The fix

Null-body statuses pass through with no body. Four tests, and the two that matter **fail against the unfixed proxy** — verified by stashing the change and re-running.

## Why it was worth probing production for

Every automated check was green: `tsc`, `eslint`, 71 unit tests, full CI. The failure needed a real 204 through the real proxy, and nothing in the suite produced one. The new `_proxy.test.ts` now does, so the next null-body endpoint cannot reintroduce it.

## Verification

- 4 new tests; 75 pass in total
- `tsc --noEmit` clean apart from the 3 errors pre-existing on `main`