### PR TITLE
feat(inventory): stock-hold sweeper binary and its image entrypoint (#229)

### DIFF
--- a/services/marketplace-api/Dockerfile
+++ b/services/marketplace-api/Dockerfile
@@ -22,7 +22,9 @@ RUN go build -trimpath -ldflags="-s -w" \
  && go build -trimpath -ldflags="-s -w" \
       -o /out/migrate ./cmd/migrate \
  && go build -trimpath -ldflags="-s -w" \
-      -o /out/refund-sweep-cron ./cmd/refund-sweep-cron
+      -o /out/refund-sweep-cron ./cmd/refund-sweep-cron \
+ && go build -trimpath -ldflags="-s -w" \
+      -o /out/stock-hold-sweep-cron ./cmd/stock-hold-sweep-cron
 
 # ─── migrate ────────────────────────────────────────────────────────────
 # Standalone image used by the K8s Job pattern.
@@ -31,14 +33,15 @@ COPY --from=builder --chown=10001:10001 /out/migrate /usr/local/bin/migrate
 CMD ["/usr/local/bin/migrate"]
 
 # ─── runtime ────────────────────────────────────────────────────────────
-# Runtime image carries all three binaries — server (default ENTRYPOINT),
-# the migrate CLI at /usr/local/bin/migrate, and the refund-sweep-cron at
-# /usr/local/bin/refund-sweep-cron — so the Helm init container and the
-# refund-sweep CronJob can override ENTRYPOINT to run migrations / the
-# stuck-refund sweeper from the same image.
+# Runtime image carries every binary — server (default ENTRYPOINT), the
+# migrate CLI at /usr/local/bin/migrate, the refund-sweep-cron and the
+# stock-hold-sweep-cron — so the Helm init container and the CronJobs can
+# override ENTRYPOINT and run migrations / the stuck-refund sweeper / the
+# expired-hold sweeper from the same image.
 FROM ghcr.io/tesserix/base-distroless-static@sha256:ccf26e72c62d53b69caae2ab73f3b059fe46785c0e5c18868e103b63c52a729f AS runtime
 COPY --from=builder --chown=10001:10001 /out/marketplace-api /usr/local/bin/marketplace-api
 COPY --from=builder --chown=10001:10001 /out/migrate /usr/local/bin/migrate
 COPY --from=builder --chown=10001:10001 /out/refund-sweep-cron /usr/local/bin/refund-sweep-cron
+COPY --from=builder --chown=10001:10001 /out/stock-hold-sweep-cron /usr/local/bin/stock-hold-sweep-cron
 EXPOSE 8091
 CMD ["/usr/local/bin/marketplace-api"]

--- a/services/marketplace-api/cmd/stock-hold-sweep-cron/README.md
+++ b/services/marketplace-api/cmd/stock-hold-sweep-cron/README.md
@@ -1,0 +1,46 @@
+# stock-hold-sweep-cron
+
+Deletes `stock_holds` rows that expired more than an hour ago (#229/#231).
+
+## It is housekeeping, not correctness
+
+Availability is computed, never stored:
+
+```sql
+available = variant_stock.quantity
+          - SUM(qty) FILTER (WHERE state = 'held' AND expires_at > now())
+```
+
+An expired hold therefore already reduces availability by **nothing**. If this
+job never runs again, stock, pricing and checkout all stay correct — only dead
+rows accumulate.
+
+That is deliberate. A stored `reserved` counter would have made this sweeper
+load-bearing for correctness, and a missed run would silently strand stock.
+Read an alert from this job accordingly: it means rows are piling up, not that
+anything is wrong with what customers can buy.
+
+## Why expired rows are kept for an hour
+
+They reduce availability by nothing, and they are the evidence of what happened
+when someone asks why a cart lost its unit. The grace window is
+`sweepGrace` in `internal/stockhold`.
+
+## Environment
+
+| var | required | default | notes |
+|---|---|---|---|
+| `DATABASE_URL` | yes | — | |
+| `STOCK_HOLD_SWEEP_BATCH` | no | 500 | must be a positive integer; a bad value exits non-zero rather than silently falling back |
+
+## Exit codes
+
+Non-zero only on infrastructure failure (no `DATABASE_URL`, bad batch size,
+DB unreachable, query error). **A sweep that deletes zero rows is a normal,
+successful run** — the usual case once the backlog is drained.
+
+## Concurrency
+
+The delete runs `FOR UPDATE SKIP LOCKED` in bounded batches, so overlapping
+runs on multiple replicas neither block each other nor double-delete, and a
+large backlog drains over several runs instead of one long-held lock.

--- a/services/marketplace-api/cmd/stock-hold-sweep-cron/main.go
+++ b/services/marketplace-api/cmd/stock-hold-sweep-cron/main.go
@@ -1,0 +1,76 @@
+// Command stock-hold-sweep-cron deletes stock holds that expired long ago
+// (#229/#231).
+//
+// # This is housekeeping, not correctness
+//
+// Availability is COMPUTED, never stored:
+//
+//	available = variant_stock.quantity
+//	          - SUM(qty) FILTER (WHERE state = 'held' AND expires_at > now())
+//
+// so an expired hold already reduces availability by nothing. If this job
+// never runs again, prices, stock and checkout all stay correct — only dead
+// rows accumulate. That is the whole reason availability is computed rather
+// than stored: a "reserved" counter would have made this sweeper
+// load-bearing, and a missed run would silently strand stock.
+//
+// Because of that, a failure here is not urgent and must not read as though
+// it were. It exits non-zero only on infrastructure failures; a sweep that
+// deletes zero rows is a normal, successful run.
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/stockhold"
+	"github.com/mark8ly/marketplace-api/pkg/db"
+)
+
+// defaultBatch bounds one run's delete. Batched with FOR UPDATE SKIP LOCKED
+// so concurrent runs on multiple replicas neither block each other nor
+// double-delete, and so a large backlog is drained over several runs rather
+// than in one long-held lock.
+const defaultBatch = 500
+
+func main() {
+	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		log.Error("stock-hold-sweep-cron: DATABASE_URL not set")
+		os.Exit(1)
+	}
+
+	batch := defaultBatch
+	if v := os.Getenv("STOCK_HOLD_SWEEP_BATCH"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			// Refuse rather than silently falling back: a typo'd batch size
+			// that quietly becomes 500 is a configuration that lies.
+			log.Error("stock-hold-sweep-cron: STOCK_HOLD_SWEEP_BATCH must be a positive integer", "value", v)
+			os.Exit(1)
+		}
+		batch = n
+	}
+
+	conn, err := db.Open(databaseURL)
+	if err != nil {
+		log.Error("stock-hold-sweep-cron: db open failed", "err", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	n, err := stockhold.NewRepository().Sweep(ctx, conn, batch)
+	if err != nil {
+		log.Error("stock-hold-sweep-cron: run failed", "err", err)
+		os.Exit(1)
+	}
+
+	log.Info("stock-hold-sweep-cron: done", "deleted", n, "batch", batch)
+}


### PR DESCRIPTION
Adds `cmd/stock-hold-sweep-cron`, the last piece of the #229 epic. Its CronJob is tesserix-k8s#726.

## Housekeeping, and the code says so

Availability is computed, never stored:

```sql
available = variant_stock.quantity
          - SUM(qty) FILTER (WHERE state = 'held' AND expires_at > now())
```

An expired hold therefore already reduces availability by **nothing**. If this job never runs again, stock, pricing and checkout all stay correct — only dead rows accumulate.

That is the point of computing availability rather than storing it: a `reserved` counter would have made this sweeper load-bearing for correctness, and a missed run would silently strand stock. The binary doc, the README and the CronJob comment all say so, because an alert from this job means *rows are piling up*, not that anything customers can buy is wrong. It runs hourly for the same reason — contrast refund-sweep at every 5 minutes, where a stuck row is money that has not moved.

## Two small decisions

**A bad `STOCK_HOLD_SWEEP_BATCH` exits non-zero** rather than falling back to the default. A typo'd batch size that silently becomes 500 is a configuration that lies about what it is doing.

**Zero deleted is a successful run**, and will be the normal case once the backlog drains. Non-zero exit is reserved for infrastructure failure, so the CronJob's failure count stays meaningful.

## Verification

- `go build ./...`, `go vet`, full unit suite green; `internal/stockhold` integration tests clean against a real database
- Dockerfile builds and installs the binary alongside `marketplace-api`, `migrate` and `refund-sweep-cron`; the runtime-image comment updated to match