### PR TITLE
feat(shipping): store-level warehouse, replacing the per-carrier address duplication (#177)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/tenantpurge/... \
 	    ./internal/ticket/... \
 	    ./internal/vendor/... \
+	    ./internal/warehouse/... \
 	    ./internal/webhookevents/... \
 	    ./internal/webhookprune/... \
 	    ./internal/whitelabel/lifecycle/... \

--- a/services/marketplace-api/internal/handlers/admin/settings.go
+++ b/services/marketplace-api/internal/handlers/admin/settings.go
@@ -1041,15 +1041,7 @@ func (h *ShippingSettingsHandler) syncWarehouseAsync(
 			// silently no-op. Delhivery is the only implementor today.
 			return
 		}
-		wh := shipping.Warehouse{
-			Name:        cfg.WarehouseName,
-			Phone:       cfg.WarehousePhone,
-			Address:     strings.TrimSpace(cfg.WarehouseLine1 + " " + cfg.WarehouseLine2),
-			City:        cfg.WarehouseCity,
-			PinCode:     cfg.WarehousePostal,
-			CountryCode: cfg.WarehouseCountry,
-			Region:      cfg.WarehouseRegion,
-		}
+		wh := h.resolveWarehouseForSync(ctx, cfg)
 		if err := syncer.UpsertWarehouse(ctx, wh); err != nil {
 			h.logger.Warn("warehouse sync: upsert failed",
 				"provider", provider, "store_id", cfg.StoreID.String(),
@@ -1060,6 +1052,51 @@ func (h *ShippingSettingsHandler) syncWarehouseAsync(
 			"provider", provider, "store_id", cfg.StoreID.String(),
 			"warehouse", cfg.WarehouseName)
 	}()
+}
+
+// resolveWarehouseForSync builds the shipping.Warehouse pushed to the
+// carrier, preferring the store-level warehouses row (#177, the read
+// half) over the legacy warehouse_* columns cfg was loaded from.
+//
+// cfg is read back from the DB inside the same Upsert transaction that
+// just wrote it (see Upsert above), so cfg.WarehouseID is already
+// populated when this runs. The fallback still matters here: this
+// function's caller only skips the sync entirely for a blank
+// WarehouseName, so a config saved by an older build of this handler —
+// legacy columns only, no warehouse_id — still reaches this path.
+//
+// Preferring the warehouses row is also what lets ContactPerson and Email
+// flow through to Delhivery: those fields have no equivalent among the
+// legacy columns, so the fallback below leaves them empty, same as before
+// #177.
+func (h *ShippingSettingsHandler) resolveWarehouseForSync(ctx context.Context, cfg ShippingCarrierConfigRow) shipping.Warehouse {
+	if cfg.WarehouseID != nil {
+		wh, err := h.warehouseRepo.ByID(ctx, h.db, cfg.WarehouseID.String())
+		if err == nil {
+			return shipping.Warehouse{
+				Name:          wh.Name,
+				Phone:         wh.Phone,
+				Email:         wh.Email,
+				Address:       strings.TrimSpace(wh.Line1 + " " + wh.Line2),
+				City:          wh.City,
+				PinCode:       wh.PostalCode,
+				CountryCode:   wh.CountryCode,
+				Region:        wh.Region,
+				ContactPerson: wh.ContactPerson,
+			}
+		}
+		h.logger.Warn("warehouse sync: warehouse_id has no matching row, falling back to legacy columns",
+			"store_id", cfg.StoreID.String(), "warehouse_id", cfg.WarehouseID.String(), "err", err)
+	}
+	return shipping.Warehouse{
+		Name:        cfg.WarehouseName,
+		Phone:       cfg.WarehousePhone,
+		Address:     strings.TrimSpace(cfg.WarehouseLine1 + " " + cfg.WarehouseLine2),
+		City:        cfg.WarehouseCity,
+		PinCode:     cfg.WarehousePostal,
+		CountryCode: cfg.WarehouseCountry,
+		Region:      cfg.WarehouseRegion,
+	}
 }
 
 // buildCarrierForSync resolves the stored credential references to

--- a/services/marketplace-api/internal/handlers/admin/settings.go
+++ b/services/marketplace-api/internal/handlers/admin/settings.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/crypto"
 	"github.com/mark8ly/marketplace-api/internal/shipping"
 	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
 )
 
 // ---------------------------------------------------------------------------
@@ -577,11 +578,16 @@ type ShippingSettingsHandler struct {
 	encryptor   crypto.Encryptor
 	secretStore carriersecrets.Store
 	logger      *slog.Logger
+	// warehouseRepo upserts the store-level warehouse row (#177, the cheap
+	// half) alongside the legacy warehouse_* columns below. Stateless, so
+	// constructing it here rather than threading it through every caller
+	// of NewShippingSettingsHandler costs nothing.
+	warehouseRepo *warehouse.Repository
 }
 
 // NewShippingSettingsHandler constructs a ShippingSettingsHandler.
 func NewShippingSettingsHandler(db *gorm.DB, countryRepo country.Repository, enc crypto.Encryptor, logger *slog.Logger) *ShippingSettingsHandler {
-	return &ShippingSettingsHandler{db: db, countryRepo: countryRepo, encryptor: enc, logger: logger}
+	return &ShippingSettingsHandler{db: db, countryRepo: countryRepo, encryptor: enc, logger: logger, warehouseRepo: warehouse.NewRepository()}
 }
 
 // WithSecretStore wires a carriersecrets.Store so carrier credential
@@ -646,24 +652,29 @@ type shippingConfigResponse struct {
 // columns including warehouse fields. The shipping.CarrierConfig model is
 // already available but we define a local view to cover all DB columns.
 type ShippingCarrierConfigRow struct {
-	ID                 uuid.UUID       `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()"`
-	TenantID           uuid.UUID       `gorm:"column:tenant_id;type:uuid;not null"`
-	StoreID            uuid.UUID       `gorm:"column:store_id;type:uuid;not null"`
-	Provider           string          `gorm:"column:provider;type:varchar(20);not null"`
-	APIKeyEncrypted    string          `gorm:"column:api_key_encrypted;type:text;not null"`
-	SecretKeyEncrypted string          `gorm:"column:secret_key_encrypted;type:text"`
-	Mode               string          `gorm:"column:mode;type:varchar(10);not null;default:test"`
-	IsActive           bool            `gorm:"column:is_active;type:boolean;not null;default:false"`
-	WarehouseName      string          `gorm:"column:warehouse_name;type:varchar(200)"`
-	WarehouseLine1     string          `gorm:"column:warehouse_line1;type:varchar(300)"`
-	WarehouseLine2     string          `gorm:"column:warehouse_line2;type:varchar(300)"`
-	WarehouseCity      string          `gorm:"column:warehouse_city;type:varchar(200)"`
-	WarehouseRegion    string          `gorm:"column:warehouse_region;type:varchar(200)"`
-	WarehousePostal    string          `gorm:"column:warehouse_postal;type:varchar(40)"`
-	WarehouseCountry   string          `gorm:"column:warehouse_country;type:char(2)"`
-	WarehousePhone     string          `gorm:"column:warehouse_phone;type:varchar(40)"`
-	HandlingFee        decimal.Decimal `gorm:"column:handling_fee;type:numeric(12,2);not null;default:0"`
-	FreeShippingMin    decimal.Decimal `gorm:"column:free_shipping_min;type:numeric(12,2)"`
+	ID                 uuid.UUID `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()"`
+	TenantID           uuid.UUID `gorm:"column:tenant_id;type:uuid;not null"`
+	StoreID            uuid.UUID `gorm:"column:store_id;type:uuid;not null"`
+	Provider           string    `gorm:"column:provider;type:varchar(20);not null"`
+	APIKeyEncrypted    string    `gorm:"column:api_key_encrypted;type:text;not null"`
+	SecretKeyEncrypted string    `gorm:"column:secret_key_encrypted;type:text"`
+	Mode               string    `gorm:"column:mode;type:varchar(10);not null;default:test"`
+	IsActive           bool      `gorm:"column:is_active;type:boolean;not null;default:false"`
+	WarehouseName      string    `gorm:"column:warehouse_name;type:varchar(200)"`
+	WarehouseLine1     string    `gorm:"column:warehouse_line1;type:varchar(300)"`
+	WarehouseLine2     string    `gorm:"column:warehouse_line2;type:varchar(300)"`
+	WarehouseCity      string    `gorm:"column:warehouse_city;type:varchar(200)"`
+	WarehouseRegion    string    `gorm:"column:warehouse_region;type:varchar(200)"`
+	WarehousePostal    string    `gorm:"column:warehouse_postal;type:varchar(40)"`
+	WarehouseCountry   string    `gorm:"column:warehouse_country;type:char(2)"`
+	WarehousePhone     string    `gorm:"column:warehouse_phone;type:varchar(40)"`
+	// WarehouseID points at the store-level warehouses row (migration
+	// 000095, #177). Nullable: a config saved with a blank warehouse name
+	// never gets one, and the FK is ON DELETE SET NULL. *uuid.UUID rather
+	// than uuid.UUID so GORM writes SQL NULL instead of the zero UUID.
+	WarehouseID     *uuid.UUID      `gorm:"column:warehouse_id;type:uuid"`
+	HandlingFee     decimal.Decimal `gorm:"column:handling_fee;type:numeric(12,2);not null;default:0"`
+	FreeShippingMin decimal.Decimal `gorm:"column:free_shipping_min;type:numeric(12,2)"`
 	// Pickup automation. See shipping.CarrierConfig for the rationale.
 	AutoSchedulePickup     bool      `gorm:"column:auto_schedule_pickup;type:boolean;not null;default:true"`
 	DefaultPickupSlotStart string    `gorm:"column:default_pickup_slot_start;type:varchar(8);default:14:00:00"`
@@ -908,17 +919,43 @@ func (h *ShippingSettingsHandler) Upsert(c *gin.Context) {
 		DefaultPickupSlotEnd:   slotEnd,
 	}
 
-	if isCreate {
-		cfg.ID = uuid.New()
-		if err := h.db.WithContext(c.Request.Context()).Create(&cfg).Error; err != nil {
-			h.logger.Error("create shipping config", "store_id", store.ID, "provider", provider, "err", err)
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-				"error":   "internal",
-				"message": "failed to save shipping configuration",
+	// The carrier-config write and the warehouse upsert share a transaction:
+	// a warehouse created here for a config that then failed to save would
+	// be a row nothing references, and warehouse.Repository.Upsert takes a
+	// *gorm.DB precisely so it can join a caller's transaction like this one.
+	txErr := h.db.WithContext(c.Request.Context()).Transaction(func(tx *gorm.DB) error {
+		// A blank name was never a usable warehouse — the migration's own
+		// backfill skips those rows too, and Delhivery keys on the name.
+		// Leave warehouse_id untouched (nil on create, whatever it already
+		// was on update) rather than manufacturing an empty warehouse row.
+		if strings.TrimSpace(req.WarehouseName) != "" {
+			wh, err := h.warehouseRepo.Upsert(c.Request.Context(), tx, warehouse.Warehouse{
+				TenantID:    store.TenantID,
+				StoreID:     store.ID,
+				Name:        req.WarehouseName,
+				Line1:       req.WarehouseLine1,
+				Line2:       req.WarehouseLine2,
+				City:        req.WarehouseCity,
+				Region:      req.WarehouseRegion,
+				PostalCode:  req.WarehousePostal,
+				CountryCode: req.WarehouseCountry,
+				Phone:       req.WarehousePhone,
 			})
-			return
+			if err != nil {
+				return err
+			}
+			whID, err := uuid.Parse(wh.ID)
+			if err != nil {
+				return err
+			}
+			cfg.WarehouseID = &whID
 		}
-	} else {
+
+		if isCreate {
+			cfg.ID = uuid.New()
+			return tx.Create(&cfg).Error
+		}
+
 		updates := map[string]any{
 			"api_key_encrypted":         apiKeyEnc,
 			"secret_key_encrypted":      secretKeyEnc,
@@ -939,20 +976,31 @@ func (h *ShippingSettingsHandler) Upsert(c *gin.Context) {
 			"default_pickup_slot_end":   slotEnd,
 			"updated_at":                time.Now(),
 		}
-		if err := h.db.WithContext(c.Request.Context()).
-			Model(&ShippingCarrierConfigRow{}).
+		// warehouse_id tracks the legacy columns exactly, including when
+		// they are blanked: this map is a full overwrite, so a merchant
+		// clearing warehouse_name today clears the pickup address, and the
+		// read path must keep behaving that way once it prefers
+		// warehouse_id over the columns. Leaving a stale id here would
+		// mean a cleared address silently kept shipping from the old one.
+		//
+		// This only clears THIS config's pointer. The warehouses row is
+		// untouched and other carriers for the store keep their own
+		// warehouse_id, so nothing is orphaned by it.
+		updates["warehouse_id"] = cfg.WarehouseID
+		if err := tx.Model(&ShippingCarrierConfigRow{}).
 			Where("store_id = ? AND provider = ?", storeUUID, provider).
 			Updates(updates).Error; err != nil {
-			h.logger.Error("update shipping config", "store_id", store.ID, "provider", provider, "err", err)
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-				"error":   "internal",
-				"message": "failed to save shipping configuration",
-			})
-			return
+			return err
 		}
-		h.db.WithContext(c.Request.Context()).
-			Where("store_id = ? AND provider = ?", storeUUID, provider).
-			First(&cfg)
+		return tx.Where("store_id = ? AND provider = ?", storeUUID, provider).First(&cfg).Error
+	})
+	if txErr != nil {
+		h.logger.Error("save shipping config", "store_id", store.ID, "provider", provider, "err", txErr)
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+			"error":   "internal",
+			"message": "failed to save shipping configuration",
+		})
+		return
 	}
 
 	// Push the merchant's pickup location to the carrier so one.delhivery.com

--- a/services/marketplace-api/internal/handlers/admin/settings_warehouse_read_test.go
+++ b/services/marketplace-api/internal/handlers/admin/settings_warehouse_read_test.go
@@ -1,0 +1,149 @@
+//go:build integration
+
+// Package admin — read-path coverage for #177 (the cheap half) at the
+// syncWarehouseAsync site in settings.go.
+//
+// syncWarehouseAsync builds the shipping.Warehouse pushed to the carrier
+// via WarehouseSyncer.UpsertWarehouse. Before this change it read the
+// legacy warehouse_* columns unconditionally; now
+// (*ShippingSettingsHandler).resolveWarehouseForSync must prefer the
+// store-level warehouses row when the config's warehouse_id is set, and
+// fall back to the legacy columns otherwise. This is also the site where
+// ContactPerson and Email — which have no legacy-column equivalent — flow
+// into shipping.Warehouse for the first time (#177's stated bonus fix for
+// the "ClientWarehouse matching query does not exist" Delhivery failure).
+package admin
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+var settingsWarehouseReadTables = []string{
+	"shipping_carrier_configs",
+	"warehouses",
+	"stores",
+}
+
+func newSettingsWarehouseReadHandler(db *gorm.DB) *ShippingSettingsHandler {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	return &ShippingSettingsHandler{db: db, warehouseRepo: warehouse.NewRepository(), logger: logger}
+}
+
+func seedSettingsWarehouseReadStore(t *testing.T, db *gorm.DB) (storeID, tenantID string) {
+	t.Helper()
+	tenantID = uuid.NewString()
+	storeID = uuid.NewString()
+	s := &stores.Store{
+		ID:           storeID,
+		TenantID:     tenantID,
+		Slug:         "wh-sync-" + storeID[:8],
+		Name:         "Warehouse Sync Test Store",
+		CountryCode:  "IN",
+		CurrencyCode: "INR",
+		Timezone:     "Asia/Kolkata",
+		Status:       stores.StatusActive,
+		SyncedAt:     time.Now(),
+	}
+	require.NoError(t, db.Create(s).Error)
+	return storeID, tenantID
+}
+
+func legacySettingsCarrierConfigRow(storeID, tenantID string, warehouseID *uuid.UUID) ShippingCarrierConfigRow {
+	return ShippingCarrierConfigRow{
+		TenantID:         uuid.MustParse(tenantID),
+		StoreID:          uuid.MustParse(storeID),
+		Provider:         "delhivery",
+		APIKeyEncrypted:  "legacy-key",
+		Mode:             "test",
+		IsActive:         true,
+		WarehouseName:    "Legacy Warehouse",
+		WarehouseLine1:   "1 Legacy Lane",
+		WarehouseCity:    "Legacy City",
+		WarehouseRegion:  "LG",
+		WarehousePostal:  "111111",
+		WarehouseCountry: "IN",
+		WarehousePhone:   "+911111111111",
+		WarehouseID:      warehouseID,
+	}
+}
+
+// TestResolveWarehouseForSync_PrefersTheWarehousesRowAndCarriesContactAndEmail
+// pins both halves of the read fix in one place: the warehouses row wins
+// over a legacy address that deliberately differs, and ContactPerson +
+// Email — which the legacy columns can't express at all — reach the
+// shipping.Warehouse handed to the carrier.
+func TestResolveWarehouseForSync_PrefersTheWarehousesRowAndCarriesContactAndEmail(t *testing.T) {
+	db := testdb.NewDB(t, settingsWarehouseReadTables...)
+	storeID, tenantID := seedSettingsWarehouseReadStore(t, db)
+	whRepo := warehouse.NewRepository()
+
+	wh, err := whRepo.Upsert(context.Background(), db, warehouse.Warehouse{
+		TenantID: tenantID, StoreID: storeID, Name: "Main",
+		Line1: "99 Warehouses-Table Road", City: "Mumbai", Region: "MH",
+		PostalCode: "400001", CountryCode: "IN", Phone: "+912200000000",
+		ContactPerson: "Warehouse Manager", Email: "warehouse@example.com",
+	})
+	require.NoError(t, err)
+	whUUID := uuid.MustParse(wh.ID)
+
+	cfg := legacySettingsCarrierConfigRow(storeID, tenantID, &whUUID)
+
+	h := newSettingsWarehouseReadHandler(db)
+	got := h.resolveWarehouseForSync(context.Background(), cfg)
+
+	require.Equal(t, "99 Warehouses-Table Road", got.Address,
+		"must build the address from the warehouses row, not the legacy columns")
+	require.Equal(t, "Mumbai", got.City)
+	require.Equal(t, "Warehouse Manager", got.ContactPerson,
+		"contact_person is what Delhivery clientwarehouse registration needs and had no home before #177")
+	require.Equal(t, "warehouse@example.com", got.Email)
+}
+
+// TestResolveWarehouseForSync_FallsBackToLegacyColumnsWhenWarehouseIDIsNil
+// covers configs saved before #177's write path, or by a writer that
+// hasn't been updated — warehouse_id is NULL and the legacy columns are
+// all there is. ContactPerson/Email must stay empty, exactly as before
+// this change, since the legacy columns never carried them.
+func TestResolveWarehouseForSync_FallsBackToLegacyColumnsWhenWarehouseIDIsNil(t *testing.T) {
+	db := testdb.NewDB(t, settingsWarehouseReadTables...)
+	storeID, tenantID := seedSettingsWarehouseReadStore(t, db)
+
+	cfg := legacySettingsCarrierConfigRow(storeID, tenantID, nil)
+
+	h := newSettingsWarehouseReadHandler(db)
+	got := h.resolveWarehouseForSync(context.Background(), cfg)
+
+	require.Equal(t, "Legacy Warehouse", got.Name)
+	require.Equal(t, "Legacy City", got.City)
+	require.Empty(t, got.ContactPerson)
+	require.Empty(t, got.Email)
+}
+
+// TestResolveWarehouseForSync_FallsBackToLegacyColumnsWhenWarehouseIDIsDangling
+// mirrors the shipments.go label-creation test: a warehouse_id that
+// points at nothing must fall back rather than break the background sync.
+func TestResolveWarehouseForSync_FallsBackToLegacyColumnsWhenWarehouseIDIsDangling(t *testing.T) {
+	db := testdb.NewDB(t, settingsWarehouseReadTables...)
+	storeID, tenantID := seedSettingsWarehouseReadStore(t, db)
+
+	dangling := uuid.New()
+	cfg := legacySettingsCarrierConfigRow(storeID, tenantID, &dangling)
+
+	h := newSettingsWarehouseReadHandler(db)
+	got := h.resolveWarehouseForSync(context.Background(), cfg)
+
+	require.Equal(t, "Legacy Warehouse", got.Name, "a dangling warehouse_id must fall back, not panic or leave the warehouse blank")
+	require.Equal(t, "Legacy City", got.City)
+}

--- a/services/marketplace-api/internal/handlers/admin/shipments.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/orderdoc"
 	"github.com/mark8ly/marketplace-api/internal/shipmentcancel"
 	"github.com/mark8ly/marketplace-api/internal/shipping"
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 )
 
@@ -65,6 +66,12 @@ type ShipmentsHandler struct {
 	// shipment (manual button). Nil-safe: the endpoint returns 503 when unwired.
 	canceller *shipmentcancel.Executor
 	logger    *slog.Logger
+	// warehouseRepo resolves a carrier config's warehouse_id (#177, the
+	// read half) to the store-level warehouses row. Stateless, so
+	// constructing it here — rather than threading it through every
+	// caller of NewShipmentsHandler — costs nothing, matching
+	// ShippingSettingsHandler's warehouseRepo on the write side.
+	warehouseRepo *warehouse.Repository
 }
 
 // NewShipmentsHandler constructs a ShipmentsHandler. docMailer is
@@ -76,7 +83,7 @@ func NewShipmentsHandler(
 	docMailer *orderdoc.Service,
 	logger *slog.Logger,
 ) *ShipmentsHandler {
-	return &ShipmentsHandler{db: db, svc: svc, repo: repo, docMailer: docMailer, logger: logger}
+	return &ShipmentsHandler{db: db, svc: svc, repo: repo, docMailer: docMailer, logger: logger, warehouseRepo: warehouse.NewRepository()}
 }
 
 // WithNotifier attaches the notification service so delivery events fire
@@ -179,6 +186,71 @@ func (h *ShipmentsHandler) decryptCarrierCreds(cfg *shipping.CarrierConfig) (api
 		}
 	}
 	return apiKey, secretKey, nil
+}
+
+// pickupAddress is the merchant's origin address for a shipment label,
+// resolved by resolvePickupAddress. It exists so this file has one shape
+// to build shipping.Address / shipping.Warehouse from, regardless of
+// whether the data came from the warehouses table or the legacy columns.
+type pickupAddress struct {
+	Name          string
+	Line1         string
+	Line2         string
+	City          string
+	Region        string
+	PostalCode    string
+	CountryCode   string
+	Phone         string
+	ContactPerson string
+	Email         string
+}
+
+// resolvePickupAddress loads cfg's pickup address, preferring the
+// store-level warehouses row (#177, the read half) and falling back to
+// the legacy warehouse_* columns on shipping_carrier_configs.
+//
+// The fallback is required, not defensive: rows written before the write
+// path in #177 landed, or by any writer that hasn't been updated, still
+// only have the legacy columns and cfg.WarehouseID is nil for them. A
+// non-nil WarehouseID pointing at a row that no longer exists (the FK is
+// ON DELETE SET NULL, so this is unlikely but not impossible) also falls
+// back rather than failing the request — shipping a label matters more
+// than strictness here.
+func (h *ShipmentsHandler) resolvePickupAddress(ctx context.Context, cfg *shipping.CarrierConfig) pickupAddress {
+	if cfg.WarehouseID != nil {
+		wh, err := h.warehouseRepo.ByID(ctx, h.db, cfg.WarehouseID.String())
+		if err == nil {
+			return pickupAddress{
+				Name:          wh.Name,
+				Line1:         wh.Line1,
+				Line2:         wh.Line2,
+				City:          wh.City,
+				Region:        wh.Region,
+				PostalCode:    wh.PostalCode,
+				CountryCode:   wh.CountryCode,
+				Phone:         wh.Phone,
+				ContactPerson: wh.ContactPerson,
+				Email:         wh.Email,
+			}
+		}
+		if h.logger != nil {
+			h.logger.Warn("shipments: carrier config's warehouse_id has no matching row, falling back to legacy columns",
+				"store_id", cfg.StoreID.String(), "provider", cfg.Provider,
+				"warehouse_id", cfg.WarehouseID.String(), "err", err)
+		}
+	}
+	return pickupAddress{
+		Name:        cfg.WarehouseName,
+		Line1:       cfg.WarehouseLine1,
+		Line2:       cfg.WarehouseLine2,
+		City:        cfg.WarehouseCity,
+		Region:      cfg.WarehouseRegion,
+		PostalCode:  cfg.WarehousePostal,
+		CountryCode: cfg.WarehouseCountry,
+		Phone:       cfg.WarehousePhone,
+		// ContactPerson and Email have no equivalent among the legacy
+		// columns — they stay empty on this path, same as before #177.
+	}
 }
 
 // resolveCarrierCreds is the store-aware sibling of decryptCarrierCreds.
@@ -462,8 +534,13 @@ func (h *ShipmentsHandler) Create(c *gin.Context) {
 		return
 	}
 
+	// Resolve the pickup address, preferring the store-level warehouses row
+	// over the legacy warehouse_* columns it was copied from (#177, the
+	// read half). See resolvePickupAddress for why the fallback matters.
+	pickup := h.resolvePickupAddress(ctx, carrierCfg)
+
 	// Validate warehouse address is configured.
-	if carrierCfg.WarehouseLine1 == "" || carrierCfg.WarehouseCity == "" || carrierCfg.WarehouseCountry == "" {
+	if pickup.Line1 == "" || pickup.City == "" || pickup.CountryCode == "" {
 		RespondErr(c, apperrors.ValidationFailed("provider",
 			"warehouse address is not configured for this carrier"), h.logger)
 		return
@@ -500,14 +577,14 @@ func (h *ShipmentsHandler) Create(c *gin.Context) {
 	// shipping_carrier_configs and surface it in admin → Settings →
 	// Shipping; this fallback unblocks label generation in the meantime.
 	fromAddress := shipping.Address{
-		Name:        carrierCfg.WarehouseName,
-		Line1:       carrierCfg.WarehouseLine1,
-		Line2:       carrierCfg.WarehouseLine2,
-		City:        carrierCfg.WarehouseCity,
-		Region:      carrierCfg.WarehouseRegion,
-		PostalCode:  carrierCfg.WarehousePostal,
-		CountryCode: carrierCfg.WarehouseCountry,
-		Phone:       carrierCfg.WarehousePhone,
+		Name:        pickup.Name,
+		Line1:       pickup.Line1,
+		Line2:       pickup.Line2,
+		City:        pickup.City,
+		Region:      pickup.Region,
+		PostalCode:  pickup.PostalCode,
+		CountryCode: pickup.CountryCode,
+		Phone:       pickup.Phone,
 		Email:       o.CustomerEmail,
 	}
 
@@ -621,15 +698,31 @@ func (h *ShipmentsHandler) Create(c *gin.Context) {
 	var whErr *shipping.WarehouseNotRegisteredError
 	if errors.As(err, &whErr) {
 		if syncer, ok := carrier.(shipping.WarehouseSyncer); ok {
+			// Email falls back to the buyer's order email, same as
+			// fromAddress above, when the resolved pickup has none (the
+			// legacy-columns fallback never does — that data only exists
+			// on the warehouses row).
+			whEmail := pickup.Email
+			if whEmail == "" {
+				whEmail = o.CustomerEmail
+			}
 			wh := shipping.Warehouse{
-				Name:        carrierCfg.WarehouseName,
-				Phone:       carrierCfg.WarehousePhone,
-				Email:       o.CustomerEmail,
-				Address:     strings.TrimSpace(carrierCfg.WarehouseLine1 + " " + carrierCfg.WarehouseLine2),
-				City:        carrierCfg.WarehouseCity,
-				PinCode:     carrierCfg.WarehousePostal,
-				CountryCode: carrierCfg.WarehouseCountry,
-				Region:      carrierCfg.WarehouseRegion,
+				Name:        pickup.Name,
+				Phone:       pickup.Phone,
+				Email:       whEmail,
+				Address:     strings.TrimSpace(pickup.Line1 + " " + pickup.Line2),
+				City:        pickup.City,
+				PinCode:     pickup.PostalCode,
+				CountryCode: pickup.CountryCode,
+				Region:      pickup.Region,
+				// ContactPerson is Delhivery clientwarehouse registration's
+				// own requirement (#177's root cause: it had no home on the
+				// legacy columns at all, so registration failed with
+				// "ClientWarehouse matching query does not exist"). Only
+				// populated when the resolved pickup came from the
+				// warehouses row — the legacy fallback leaves it empty,
+				// same as before this change.
+				ContactPerson: pickup.ContactPerson,
 			}
 			if regErr := syncer.UpsertWarehouse(ctx, wh); regErr != nil {
 				// Registration itself failed — that's the real blocker, so
@@ -637,7 +730,7 @@ func (h *ShipmentsHandler) Create(c *gin.Context) {
 				if h.logger != nil {
 					h.logger.Error("shipments: warehouse auto-register failed",
 						"order_id", orderID.String(), "provider", provider,
-						"warehouse", carrierCfg.WarehouseName, "err", regErr.Error())
+						"warehouse", pickup.Name, "err", regErr.Error())
 				}
 				c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{
 					"error":   "warehouse_register_failed",
@@ -648,7 +741,7 @@ func (h *ShipmentsHandler) Create(c *gin.Context) {
 			if h.logger != nil {
 				h.logger.Info("shipments: warehouse auto-registered, retrying label",
 					"order_id", orderID.String(), "provider", provider,
-					"warehouse", carrierCfg.WarehouseName)
+					"warehouse", pickup.Name)
 			}
 			shipment, err = h.svc.CreateShipment(
 				ctx, orderID.String(), fromAddress, toAddress,
@@ -683,14 +776,14 @@ func (h *ShipmentsHandler) Create(c *gin.Context) {
 	// shipments table. Build them from the warehouse + customer address
 	// we already loaded.
 	fromJSON, _ := json.Marshal(map[string]any{
-		"name":         carrierCfg.WarehouseName,
-		"line1":        carrierCfg.WarehouseLine1,
-		"line2":        carrierCfg.WarehouseLine2,
-		"city":         carrierCfg.WarehouseCity,
-		"region":       carrierCfg.WarehouseRegion,
-		"postal_code":  carrierCfg.WarehousePostal,
-		"country_code": carrierCfg.WarehouseCountry,
-		"phone":        carrierCfg.WarehousePhone,
+		"name":         pickup.Name,
+		"line1":        pickup.Line1,
+		"line2":        pickup.Line2,
+		"city":         pickup.City,
+		"region":       pickup.Region,
+		"postal_code":  pickup.PostalCode,
+		"country_code": pickup.CountryCode,
+		"phone":        pickup.Phone,
 	})
 	toJSON, _ := json.Marshal(map[string]any{
 		"name":         shippingAddr.Name,

--- a/services/marketplace-api/internal/handlers/admin/shipments_warehouse_read_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments_warehouse_read_test.go
@@ -1,0 +1,168 @@
+//go:build integration
+
+// Package admin — read-path coverage for #177 (the cheap half) at the
+// shipments.go label-creation site.
+//
+// cf71fe67 taught the admin settings save to upsert a store-level
+// warehouses row and point shipping_carrier_configs.warehouse_id at it,
+// while STILL writing the legacy warehouse_* columns (the expand half).
+// This file pins the corresponding read: (*ShipmentsHandler).
+// resolvePickupAddress must prefer the warehouses row over the legacy
+// columns when warehouse_id is set, and must fall back to the legacy
+// columns — never error — when it is NULL or dangling. Driving this
+// through the full label-creation HTTP handler would require a live
+// carrier; resolvePickupAddress is the single seam that decides which
+// source wins, so it is tested directly here, in-package.
+package admin
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/shipping"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+var shipmentsWarehouseReadTables = []string{
+	"shipping_carrier_configs",
+	"warehouses",
+	"stores",
+}
+
+func newShipmentsWarehouseReadHandler(db *gorm.DB) *ShipmentsHandler {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	return &ShipmentsHandler{db: db, warehouseRepo: warehouse.NewRepository(), logger: logger}
+}
+
+func seedShipmentsWarehouseReadStore(t *testing.T, db *gorm.DB) (storeID, tenantID string) {
+	t.Helper()
+	tenantID = uuid.NewString()
+	storeID = uuid.NewString()
+	s := &stores.Store{
+		ID:           storeID,
+		TenantID:     tenantID,
+		Slug:         "wh-read-" + storeID[:8],
+		Name:         "Warehouse Read Test Store",
+		CountryCode:  "IN",
+		CurrencyCode: "INR",
+		Timezone:     "Asia/Kolkata",
+		Status:       stores.StatusActive,
+		SyncedAt:     time.Now(),
+	}
+	require.NoError(t, db.Create(s).Error)
+	return storeID, tenantID
+}
+
+// legacyCarrierConfig builds a shipping_carrier_configs row with the
+// legacy warehouse_* columns populated. warehouseID, when non-nil, links
+// it to a warehouses row.
+func legacyCarrierConfig(storeID, tenantID string, warehouseID *uuid.UUID) *shipping.CarrierConfig {
+	storeUUID := uuid.MustParse(storeID)
+	tenantUUID := uuid.MustParse(tenantID)
+	return &shipping.CarrierConfig{
+		TenantID:         tenantUUID,
+		StoreID:          storeUUID,
+		Provider:         "delhivery",
+		APIKey:           "legacy-key",
+		Mode:             "test",
+		Enabled:          true,
+		WarehouseName:    "Legacy Warehouse",
+		WarehouseLine1:   "1 Legacy Lane",
+		WarehouseCity:    "Legacy City",
+		WarehouseRegion:  "LG",
+		WarehousePostal:  "111111",
+		WarehouseCountry: "IN",
+		WarehousePhone:   "+911111111111",
+		HandlingFee:      decimal.Zero,
+		WarehouseID:      warehouseID,
+	}
+}
+
+// TestResolvePickupAddress_PrefersTheWarehousesRowWhenLinked is the core
+// assertion for #177's read half: given a config whose warehouse_id points
+// at a warehouses row with a DIFFERENT address than the legacy columns,
+// the resolved address must come from the warehouses row. Making the two
+// addresses differ is deliberate — a test where they agree would pass
+// whichever source the code actually reads from.
+func TestResolvePickupAddress_PrefersTheWarehousesRowWhenLinked(t *testing.T) {
+	db := testdb.NewDB(t, shipmentsWarehouseReadTables...)
+	storeID, tenantID := seedShipmentsWarehouseReadStore(t, db)
+	whRepo := warehouse.NewRepository()
+
+	wh, err := whRepo.Upsert(context.Background(), db, warehouse.Warehouse{
+		TenantID: tenantID, StoreID: storeID, Name: "Main",
+		Line1: "99 Warehouses-Table Road", City: "Mumbai", Region: "MH",
+		PostalCode: "400001", CountryCode: "IN", Phone: "+912200000000",
+		ContactPerson: "Warehouse Manager",
+	})
+	require.NoError(t, err)
+	whUUID := uuid.MustParse(wh.ID)
+
+	cfg := legacyCarrierConfig(storeID, tenantID, &whUUID)
+	require.NoError(t, db.Create(cfg).Error)
+
+	h := newShipmentsWarehouseReadHandler(db)
+	got := h.resolvePickupAddress(context.Background(), cfg)
+
+	require.Equal(t, "99 Warehouses-Table Road", got.Line1, "must read the warehouses row, not the legacy column")
+	require.Equal(t, "Mumbai", got.City)
+	require.Equal(t, "Warehouse Manager", got.ContactPerson,
+		"contact_person has no legacy equivalent — it only flows through when the warehouses row wins")
+}
+
+// TestResolvePickupAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsNil
+// covers every config written before #177's write path landed (or by a
+// writer that still hasn't been updated) — warehouse_id is NULL and the
+// legacy columns are the only data there is.
+func TestResolvePickupAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsNil(t *testing.T) {
+	db := testdb.NewDB(t, shipmentsWarehouseReadTables...)
+	storeID, tenantID := seedShipmentsWarehouseReadStore(t, db)
+
+	cfg := legacyCarrierConfig(storeID, tenantID, nil)
+	require.NoError(t, db.Create(cfg).Error)
+
+	h := newShipmentsWarehouseReadHandler(db)
+	got := h.resolvePickupAddress(context.Background(), cfg)
+
+	require.Equal(t, "1 Legacy Lane", got.Line1)
+	require.Equal(t, "Legacy City", got.City)
+	require.Empty(t, got.ContactPerson, "the legacy columns have no contact_person equivalent")
+}
+
+// TestResolvePickupAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsDangling
+// simulates the rare case the FK's ON DELETE SET NULL is meant to prevent
+// but cannot fully rule out under concurrent writes: warehouse_id is set
+// but points at nothing. Shipping a label from the last-known-good
+// (legacy) address matters more than failing the request.
+//
+// The dangling id is never persisted on the config row: warehouse_id has
+// a real FK to warehouses, so Postgres itself refuses to let a genuine
+// row point at a nonexistent one (and ON DELETE SET NULL means it can't
+// go dangling by deleting the parent, either). resolvePickupAddress only
+// reads cfg's in-memory fields to decide what to look up, so building the
+// dangling reference in Go — without persisting the config row — still
+// exercises exactly the code path a hypothetical race would hit.
+func TestResolvePickupAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsDangling(t *testing.T) {
+	db := testdb.NewDB(t, shipmentsWarehouseReadTables...)
+	storeID, tenantID := seedShipmentsWarehouseReadStore(t, db)
+
+	dangling := uuid.New()
+	cfg := legacyCarrierConfig(storeID, tenantID, &dangling)
+
+	h := newShipmentsWarehouseReadHandler(db)
+	got := h.resolvePickupAddress(context.Background(), cfg)
+
+	require.Equal(t, "1 Legacy Lane", got.Line1,
+		"a dangling warehouse_id must fall back, not error the request")
+	require.Equal(t, "Legacy City", got.City)
+}

--- a/services/marketplace-api/internal/handlers/admin/shipping_warehouse_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipping_warehouse_integration_test.go
@@ -1,0 +1,347 @@
+//go:build integration
+
+// Package admin_test — write-path coverage for #177 (the cheap half).
+//
+// Before this change, a "warehouse" was 8 warehouse_* columns hanging off
+// shipping_carrier_configs — a row per (store, carrier). Configuring a
+// second carrier for the same store meant retyping the same physical
+// address into a second row, with no mechanism keeping the two copies in
+// sync. These tests pin the fix at the HTTP boundary: PUT
+// /settings/shipping/:provider must now ALSO upsert the store-level
+// warehouses row (migration 000095) and point warehouse_id at it, while
+// continuing to write the legacy columns untouched (the contract half —
+// dropping those columns — is separate future work).
+package admin_test
+
+import (
+	"log/slog"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/singleflight"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/authz"
+	"github.com/mark8ly/marketplace-api/internal/country"
+	"github.com/mark8ly/marketplace-api/internal/crypto"
+	"github.com/mark8ly/marketplace-api/internal/handlers/admin"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// shippingWarehouseTables is the dependency-ordered truncate list for this
+// file's fixtures. supported_countries is deliberately NOT here — it is
+// seeded once by migration and shared across the whole suite; this file
+// adds its own throw-away row (country code "ZZ", cleaned up per-test)
+// rather than truncating a table other packages depend on.
+var shippingWarehouseTables = []string{
+	"shipping_carrier_configs",
+	"warehouses",
+	"stores",
+}
+
+// shippingWarehouseTestEnv bundles the router, db, and fga fake.
+type shippingWarehouseTestEnv struct {
+	router *gin.Engine
+	db     *gorm.DB
+	fga    *authz.FakeClient
+}
+
+func setupShippingWarehouseRouter(t *testing.T) *shippingWarehouseTestEnv {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	db := testdb.NewDB(t, shippingWarehouseTables...)
+
+	countryRepo := country.NewRepository(db)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	shippingHandler := admin.NewShippingSettingsHandler(db, countryRepo, crypto.NewNoopEncryptor(), logger)
+
+	fga := authz.NewFakeClient()
+	storeMW := stores.StoreMiddleware(stores.MiddlewareConfig{
+		Repo:   stores.NewRepository(db),
+		Client: stubClient{},
+		Flight: &singleflight.Group{},
+	})
+	authzMW := authz.NewMiddleware(fga, nil)
+
+	r := gin.New()
+	admin.RegisterAdmin(r.Group("/api/v1"), admin.Deps{
+		ShippingSettingsHandler: shippingHandler,
+		StoresMiddleware:        storeMW,
+		AuthzMiddleware:         authzMW,
+		InternalSecret:          "",
+	})
+
+	return &shippingWarehouseTestEnv{router: r, db: db, fga: fga}
+}
+
+// seedShippingCountry inserts a throw-away supported_countries row ("ZZ")
+// that supports TWO shipping carriers, so a single test store can
+// configure both and exercise the shared-warehouse-row scenario. The real
+// seed rows (migration 000090) each list exactly one carrier per country,
+// which cannot express "second carrier for the same store" — hence the
+// dedicated fixture country instead of mutating real data.
+func seedShippingCountry(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`INSERT INTO supported_countries
+		    (country_code, name, currency_code, region, payment_providers, shipping_carriers, tax_strategy)
+		 VALUES ('ZZ', 'Warehouse Test Land', 'USD', 'test', '{}', '{delhivery,couriersplease}', 'flat')
+		 ON CONFLICT (country_code) DO NOTHING`).Error)
+	t.Cleanup(func() {
+		db.Exec(`DELETE FROM supported_countries WHERE country_code = 'ZZ'`)
+	})
+}
+
+func seedShippingWarehouseStore(t *testing.T, db *gorm.DB) (storeID, tenantID string) {
+	t.Helper()
+	tenantID = uuid.NewString()
+	storeID = uuid.NewString()
+	s := &stores.Store{
+		ID:           storeID,
+		TenantID:     tenantID,
+		Slug:         "wh-" + storeID[:8],
+		Name:         "Warehouse Test Store",
+		CountryCode:  "ZZ",
+		CurrencyCode: "USD",
+		Timezone:     "UTC",
+		Status:       stores.StatusActive,
+		SyncedAt:     time.Now(),
+	}
+	require.NoError(t, db.Create(s).Error)
+	return storeID, tenantID
+}
+
+func shippingSettingsURL(storeID, provider string) string {
+	return "/api/v1/admin/stores/" + storeID + "/settings/shipping/" + provider
+}
+
+func warehouseUpsertBody(name string) map[string]any {
+	return map[string]any{
+		"api_key":           "test-token-1234",
+		"mode":              "test",
+		"is_active":         true,
+		"warehouse_name":    name,
+		"warehouse_line1":   "12 Industrial Estate",
+		"warehouse_city":    "Mumbai",
+		"warehouse_region":  "MH",
+		"warehouse_postal":  "400001",
+		"warehouse_country": "IN",
+		"warehouse_phone":   "+912200000000",
+	}
+}
+
+type warehouseRow struct {
+	ID   string
+	Name string
+}
+
+func loadWarehousesForStore(t *testing.T, db *gorm.DB, storeID string) []warehouseRow {
+	t.Helper()
+	var rows []warehouseRow
+	require.NoError(t, db.Raw(`SELECT id, name FROM warehouses WHERE store_id = ?`, storeID).Scan(&rows).Error)
+	return rows
+}
+
+func warehouseIDForConfig(t *testing.T, db *gorm.DB, storeID, provider string) *string {
+	t.Helper()
+	var id *string
+	require.NoError(t, db.Raw(
+		`SELECT warehouse_id::text FROM shipping_carrier_configs WHERE store_id = ? AND provider = ?`,
+		storeID, provider).Row().Scan(&id))
+	return id
+}
+
+// TestShippingUpsert_SavingAWarehouseCreatesTheWarehouseRowAndLinksIt is the
+// baseline: saving a single carrier config with a warehouse name must
+// create exactly one warehouses row for the store and point
+// shipping_carrier_configs.warehouse_id at it.
+func TestShippingUpsert_SavingAWarehouseCreatesTheWarehouseRowAndLinksIt(t *testing.T) {
+	env := setupShippingWarehouseRouter(t)
+	seedShippingCountry(t, env.db)
+	storeID, tenantID := seedShippingWarehouseStore(t, env.db)
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+
+	w := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+		warehouseUpsertBody("Main Warehouse"), authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	rows := loadWarehousesForStore(t, env.db, storeID)
+	require.Len(t, rows, 1, "exactly one warehouse row must exist for the store")
+	require.Equal(t, "Main Warehouse", rows[0].Name)
+
+	linkedID := warehouseIDForConfig(t, env.db, storeID, "delhivery")
+	require.NotNil(t, linkedID)
+	require.Equal(t, rows[0].ID, *linkedID)
+}
+
+// TestShippingUpsert_SecondCarrierReusesTheSameWarehouseRow is the single
+// most important test in this file: it pins the whole point of #177.
+// Configuring a SECOND carrier for the same store, with the same warehouse
+// name, must NOT create a second warehouses row — both carrier configs
+// must point at the one row that already exists.
+func TestShippingUpsert_SecondCarrierReusesTheSameWarehouseRow(t *testing.T) {
+	env := setupShippingWarehouseRouter(t)
+	seedShippingCountry(t, env.db)
+	storeID, tenantID := seedShippingWarehouseStore(t, env.db)
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+
+	w1 := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+		warehouseUpsertBody("Main Warehouse"), authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, w1.Code, w1.Body.String())
+
+	w2 := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "couriersplease"),
+		warehouseUpsertBody("Main Warehouse"), authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, w2.Code, w2.Body.String())
+
+	rows := loadWarehousesForStore(t, env.db, storeID)
+	require.Len(t, rows, 1, "the second carrier must reuse the store's warehouse, not create another")
+
+	delhiveryID := warehouseIDForConfig(t, env.db, storeID, "delhivery")
+	couriersPleaseID := warehouseIDForConfig(t, env.db, storeID, "couriersplease")
+	require.NotNil(t, delhiveryID)
+	require.NotNil(t, couriersPleaseID)
+	require.Equal(t, *delhiveryID, *couriersPleaseID, "both carrier configs must point at the same warehouse row")
+	require.Equal(t, rows[0].ID, *delhiveryID)
+}
+
+// TestShippingUpsert_EditingAddressUpdatesTheSharedRowForBothCarriers
+// verifies the address is shared, not duplicated: editing it through one
+// carrier's config must be visible to the other carrier's config too.
+func TestShippingUpsert_EditingAddressUpdatesTheSharedRowForBothCarriers(t *testing.T) {
+	env := setupShippingWarehouseRouter(t)
+	seedShippingCountry(t, env.db)
+	storeID, tenantID := seedShippingWarehouseStore(t, env.db)
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+
+	for _, provider := range []string{"delhivery", "couriersplease"} {
+		w := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, provider),
+			warehouseUpsertBody("Main Warehouse"), authHeaders(userID, tenantID))
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	}
+
+	moved := warehouseUpsertBody("Main Warehouse")
+	moved["warehouse_line1"] = "99 New Road"
+	moved["warehouse_postal"] = "400002"
+	wEdit := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+		moved, authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, wEdit.Code, wEdit.Body.String())
+
+	rows := loadWarehousesForStore(t, env.db, storeID)
+	require.Len(t, rows, 1, "editing the address must update the existing row, not create a new one")
+
+	var line1, postal string
+	require.NoError(t, env.db.Raw(`SELECT line1, postal_code FROM warehouses WHERE id = ?`, rows[0].ID).
+		Row().Scan(&line1, &postal))
+	require.Equal(t, "99 New Road", line1)
+	require.Equal(t, "400002", postal)
+
+	// The unedited carrier's warehouse_id must still resolve to the same,
+	// now-updated row — it never had its own copy to fall out of sync.
+	couriersPleaseID := warehouseIDForConfig(t, env.db, storeID, "couriersplease")
+	require.NotNil(t, couriersPleaseID)
+	require.Equal(t, rows[0].ID, *couriersPleaseID)
+}
+
+// TestShippingUpsert_BlankWarehouseNameCreatesNoWarehouseRow guards the
+// "was never a usable warehouse" rule from migration 000095's own
+// backfill: a config saved with no warehouse name must leave warehouse_id
+// NULL and create nothing in the warehouses table.
+func TestShippingUpsert_BlankWarehouseNameCreatesNoWarehouseRow(t *testing.T) {
+	env := setupShippingWarehouseRouter(t)
+	seedShippingCountry(t, env.db)
+	storeID, tenantID := seedShippingWarehouseStore(t, env.db)
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+
+	body := warehouseUpsertBody("")
+	w := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+		body, authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	rows := loadWarehousesForStore(t, env.db, storeID)
+	require.Empty(t, rows, "a blank warehouse_name must not create a warehouse row")
+
+	linkedID := warehouseIDForConfig(t, env.db, storeID, "delhivery")
+	require.Nil(t, linkedID, "warehouse_id must stay NULL when no warehouse name was given")
+}
+
+// TestShippingUpsert_StillWritesLegacyWarehouseColumns guards the
+// expand/contract contract: the old warehouse_* columns on
+// shipping_carrier_configs must keep being written exactly as before.
+// Dropping them is a separate, future contract-half change (#177 is only
+// the expand half's write path) and other readers still depend on them.
+func TestShippingUpsert_StillWritesLegacyWarehouseColumns(t *testing.T) {
+	env := setupShippingWarehouseRouter(t)
+	seedShippingCountry(t, env.db)
+	storeID, tenantID := seedShippingWarehouseStore(t, env.db)
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+
+	w := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+		warehouseUpsertBody("Main Warehouse"), authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var name, line1, city, region, postal, phone string
+	require.NoError(t, env.db.Raw(
+		`SELECT warehouse_name, warehouse_line1, warehouse_city, warehouse_region, warehouse_postal, warehouse_phone
+		 FROM shipping_carrier_configs WHERE store_id = ? AND provider = 'delhivery'`, storeID).
+		Row().Scan(&name, &line1, &city, &region, &postal, &phone))
+	require.Equal(t, "Main Warehouse", name)
+	require.Equal(t, "12 Industrial Estate", line1)
+	require.Equal(t, "Mumbai", city)
+	require.Equal(t, "MH", region)
+	require.Equal(t, "400001", postal)
+	require.Equal(t, "+912200000000", phone)
+}
+
+// TestShippingUpsert_ClearingTheWarehouseNameClearsTheLink covers the UPDATE
+// path that the create-path blank test above cannot reach: a merchant who
+// saved a warehouse and then clears the name.
+//
+// The legacy warehouse_* columns are a full overwrite, so clearing the name
+// has always cleared the pickup address. warehouse_id has to track that. If
+// it kept pointing at the old row, the read path — which prefers
+// warehouse_id over the columns — would go on shipping from an address the
+// merchant deliberately removed.
+//
+// Only this config's pointer is cleared: the warehouses row survives, so a
+// second carrier still referencing it is unaffected.
+func TestShippingUpsert_ClearingTheWarehouseNameClearsTheLink(t *testing.T) {
+	env := setupShippingWarehouseRouter(t)
+	seedShippingCountry(t, env.db)
+	storeID, tenantID := seedShippingWarehouseStore(t, env.db)
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+
+	// Two carriers share the store's one warehouse.
+	for _, provider := range []string{"delhivery", "couriersplease"} {
+		w := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, provider),
+			warehouseUpsertBody("Main Warehouse"), authHeaders(userID, tenantID))
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	}
+	shared := warehouseIDForConfig(t, env.db, storeID, "couriersplease")
+	require.NotNil(t, shared)
+
+	// Now clear it on one of them.
+	w := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+		warehouseUpsertBody(""), authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	require.Nil(t, warehouseIDForConfig(t, env.db, storeID, "delhivery"),
+		"clearing the name must clear the link, or a removed address keeps shipping")
+
+	stillLinked := warehouseIDForConfig(t, env.db, storeID, "couriersplease")
+	require.NotNil(t, stillLinked, "the other carrier's link must be untouched")
+	require.Equal(t, *shared, *stillLinked)
+	require.Len(t, loadWarehousesForStore(t, env.db, storeID), 1,
+		"the warehouse row itself must survive — it is still in use")
+}

--- a/services/marketplace-api/internal/handlers/storefront/shipping_rates.go
+++ b/services/marketplace-api/internal/handlers/storefront/shipping_rates.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/crypto"
 	"github.com/mark8ly/marketplace-api/internal/shipping"
 	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
 )
 
 // ShippingRatesHandler serves shipping rate quotes for a store.
@@ -26,11 +27,15 @@ type ShippingRatesHandler struct {
 	encryptor   crypto.Encryptor
 	secretStore carriersecrets.Store
 	logger      *slog.Logger
+	// warehouseRepo resolves a carrier config's warehouse_id (#177, the
+	// read half) to the store-level warehouses row. Stateless, so
+	// constructing it here costs nothing.
+	warehouseRepo *warehouse.Repository
 }
 
 // NewShippingRatesHandler constructs a ShippingRatesHandler.
 func NewShippingRatesHandler(db *gorm.DB, enc crypto.Encryptor, logger *slog.Logger) *ShippingRatesHandler {
-	return &ShippingRatesHandler{db: db, encryptor: enc, logger: logger}
+	return &ShippingRatesHandler{db: db, encryptor: enc, logger: logger, warehouseRepo: warehouse.NewRepository()}
 }
 
 // WithSecretStore wires a carriersecrets.Store so the storefront
@@ -113,6 +118,10 @@ type carrierConfigRow struct {
 	WarehousePostal  *string          `gorm:"column:warehouse_postal"`
 	WarehouseCountry *string          `gorm:"column:warehouse_country"`
 	WarehousePhone   *string          `gorm:"column:warehouse_phone"`
+	// WarehouseID points at the store-level warehouses row (migration
+	// 000095, #177) when one has been linked. Nullable — see
+	// resolveWarehouseAddress for the fallback this requires.
+	WarehouseID *string `gorm:"column:warehouse_id"`
 }
 
 func (carrierConfigRow) TableName() string { return "shipping_carrier_configs" }
@@ -222,8 +231,10 @@ func (h *ShippingRatesHandler) GetRates(c *gin.Context) {
 		return
 	}
 
-	// Build origin address from warehouse config.
-	fromAddr := warehouseAddress(cfg)
+	// Build origin address, preferring the store-level warehouses row over
+	// the legacy warehouse_* columns it was copied from (#177, the read
+	// half).
+	fromAddr := h.resolveWarehouseAddress(ctx, cfg)
 
 	// Build parcel items from request.
 	parcels := make([]shipping.ParcelItem, 0, len(req.Items))
@@ -341,8 +352,42 @@ func (h *ShippingRatesHandler) maybeRewrapRow(ctx context.Context, cfg carrierCo
 	}
 }
 
+// resolveWarehouseAddress loads cfg's pickup address, preferring the
+// store-level warehouses row (#177, the read half) and falling back to
+// warehouseAddress's legacy warehouse_* columns.
+//
+// The fallback is required, not defensive: rows written before the write
+// path in #177 landed, or by any writer that hasn't been updated, still
+// only have the legacy columns and cfg.WarehouseID is nil for them. A
+// non-nil WarehouseID pointing at a row that no longer exists (the FK is
+// ON DELETE SET NULL, so this is unlikely but not impossible) also falls
+// back rather than erroring the request — a rates quote with a stale
+// address beats no quote at all.
+func (h *ShippingRatesHandler) resolveWarehouseAddress(ctx context.Context, cfg carrierConfigRow) shipping.Address {
+	if cfg.WarehouseID != nil {
+		wh, err := h.warehouseRepo.ByID(ctx, h.db, *cfg.WarehouseID)
+		if err == nil {
+			return shipping.Address{
+				Name:        wh.Name,
+				Line1:       wh.Line1,
+				Line2:       wh.Line2,
+				City:        wh.City,
+				Region:      wh.Region,
+				PostalCode:  wh.PostalCode,
+				CountryCode: wh.CountryCode,
+				Phone:       wh.Phone,
+			}
+		}
+		if h.logger != nil {
+			h.logger.Warn("shipping_rates: carrier config's warehouse_id has no matching row, falling back to legacy columns",
+				"provider", cfg.Provider, "warehouse_id", *cfg.WarehouseID, "err", err)
+		}
+	}
+	return warehouseAddress(cfg)
+}
+
 // warehouseAddress builds a shipping.Address from the carrier config's
-// warehouse fields. Returns a zero-value address if fields are nil.
+// legacy warehouse_* columns. Returns a zero-value address if fields are nil.
 func warehouseAddress(cfg carrierConfigRow) shipping.Address {
 	addr := shipping.Address{}
 	if cfg.WarehouseName != nil {

--- a/services/marketplace-api/internal/handlers/storefront/shipping_rates_warehouse_read_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/shipping_rates_warehouse_read_test.go
@@ -1,0 +1,144 @@
+//go:build integration
+
+// Package storefront — read-path coverage for #177 (the cheap half) at
+// the shipping-rates quote site.
+//
+// (*ShippingRatesHandler).GetRates loads a carrierConfigRow and used to
+// build its rate-quote origin address exclusively from the legacy
+// warehouse_* columns. It must now prefer the store-level warehouses row
+// via warehouse_id, falling back to the legacy columns otherwise — see
+// resolveWarehouseAddress. Testing that function directly, rather than
+// driving GetRates end-to-end, avoids needing a live carrier for a rates
+// call; resolveWarehouseAddress is the single seam that decides which
+// address source wins.
+package storefront
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+var shippingRatesWarehouseReadTables = []string{
+	"shipping_carrier_configs",
+	"warehouses",
+	"stores",
+}
+
+func newShippingRatesWarehouseReadHandler(db *gorm.DB) *ShippingRatesHandler {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	return &ShippingRatesHandler{db: db, warehouseRepo: warehouse.NewRepository(), logger: logger}
+}
+
+func seedShippingRatesWarehouseReadStore(t *testing.T, db *gorm.DB) (storeID, tenantID string) {
+	t.Helper()
+	tenantID = uuid.NewString()
+	storeID = uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO stores (id, tenant_id, name, slug, status, country_code, currency_code, timezone,
+		                     storefront_customer_portal_secret)
+		 VALUES (?, ?, 'WH Rates Test', ?, 'active', 'IN', 'INR', 'Asia/Kolkata', ?)`,
+		storeID, tenantID, "wh-rates-"+storeID[:8], uuid.NewString()).Error)
+	return storeID, tenantID
+}
+
+// seedShippingRatesCarrierConfig inserts a shipping_carrier_configs row via
+// raw SQL rather than the carrierConfigRow GORM model — that model
+// deliberately omits store_id (it's only ever used for reads keyed by the
+// gin-context store), so it can't Create() a row that satisfies the
+// table's NOT NULL store_id.
+func seedShippingRatesCarrierConfig(t *testing.T, db *gorm.DB, storeID, tenantID string, warehouseID *string) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`INSERT INTO shipping_carrier_configs
+		    (id, tenant_id, store_id, provider, api_key_encrypted, mode, is_active,
+		     warehouse_name, warehouse_line1, warehouse_city, warehouse_region,
+		     warehouse_postal, warehouse_country, warehouse_phone, warehouse_id)
+		 VALUES (?, ?, ?, 'delhivery', 'legacy-key', 'test', true,
+		         'Legacy Warehouse', '1 Legacy Lane', 'Legacy City', 'LG',
+		         '111111', 'IN', '+911111111111', ?)`,
+		uuid.NewString(), tenantID, storeID, warehouseID).Error)
+}
+
+func loadShippingRatesCarrierConfigRow(t *testing.T, db *gorm.DB, storeID string) carrierConfigRow {
+	t.Helper()
+	var cfg carrierConfigRow
+	require.NoError(t, db.Where("store_id = ?", storeID).First(&cfg).Error)
+	return cfg
+}
+
+// TestResolveWarehouseAddress_PrefersTheWarehousesRowWhenLinked proves the
+// rates-quote origin comes from the warehouses row when warehouse_id is
+// set — with an address that deliberately differs from the legacy
+// columns, so the test can't pass by accident regardless of which source
+// actually won.
+func TestResolveWarehouseAddress_PrefersTheWarehousesRowWhenLinked(t *testing.T) {
+	db := testdb.NewDB(t, shippingRatesWarehouseReadTables...)
+	storeID, tenantID := seedShippingRatesWarehouseReadStore(t, db)
+	whRepo := warehouse.NewRepository()
+
+	wh, err := whRepo.Upsert(context.Background(), db, warehouse.Warehouse{
+		TenantID: tenantID, StoreID: storeID, Name: "Main",
+		Line1: "99 Warehouses-Table Road", City: "Mumbai", Region: "MH",
+		PostalCode: "400001", CountryCode: "IN", Phone: "+912200000000",
+	})
+	require.NoError(t, err)
+	seedShippingRatesCarrierConfig(t, db, storeID, tenantID, &wh.ID)
+	cfg := loadShippingRatesCarrierConfigRow(t, db, storeID)
+
+	h := newShippingRatesWarehouseReadHandler(db)
+	got := h.resolveWarehouseAddress(context.Background(), cfg)
+
+	require.Equal(t, "99 Warehouses-Table Road", got.Line1, "must read the warehouses row, not the legacy column")
+	require.Equal(t, "Mumbai", got.City)
+}
+
+// TestResolveWarehouseAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsNil
+// covers a config saved before #177's write path, or by a writer that
+// hasn't been updated — warehouse_id is NULL.
+func TestResolveWarehouseAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsNil(t *testing.T) {
+	db := testdb.NewDB(t, shippingRatesWarehouseReadTables...)
+	storeID, tenantID := seedShippingRatesWarehouseReadStore(t, db)
+	seedShippingRatesCarrierConfig(t, db, storeID, tenantID, nil)
+	cfg := loadShippingRatesCarrierConfigRow(t, db, storeID)
+
+	h := newShippingRatesWarehouseReadHandler(db)
+	got := h.resolveWarehouseAddress(context.Background(), cfg)
+
+	require.Equal(t, "1 Legacy Lane", got.Line1)
+	require.Equal(t, "Legacy City", got.City)
+}
+
+// TestResolveWarehouseAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsDangling
+// covers a warehouse_id that points at a row that no longer exists — the
+// FK is ON DELETE SET NULL, so this should be rare, but resolving to
+// "no quote" rather than the legacy address would be a worse failure mode
+// for what is a best-effort estimate anyway.
+//
+// The dangling id is built directly on an in-memory carrierConfigRow
+// rather than persisted: the real FK (plus ON DELETE SET NULL) means
+// Postgres won't let an actual row go dangling, but
+// resolveWarehouseAddress only reads cfg's fields to decide what to look
+// up, so this still exercises the fallback a hypothetical race would hit.
+func TestResolveWarehouseAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsDangling(t *testing.T) {
+	db := testdb.NewDB(t, shippingRatesWarehouseReadTables...)
+	storeID, tenantID := seedShippingRatesWarehouseReadStore(t, db)
+	seedShippingRatesCarrierConfig(t, db, storeID, tenantID, nil)
+	cfg := loadShippingRatesCarrierConfigRow(t, db, storeID)
+	dangling := uuid.NewString()
+	cfg.WarehouseID = &dangling
+
+	h := newShippingRatesWarehouseReadHandler(db)
+	got := h.resolveWarehouseAddress(context.Background(), cfg)
+
+	require.Equal(t, "1 Legacy Lane", got.Line1, "a dangling warehouse_id must fall back, not return a blank origin")
+	require.Equal(t, "Legacy City", got.City)
+}

--- a/services/marketplace-api/internal/shipping/repository.go
+++ b/services/marketplace-api/internal/shipping/repository.go
@@ -103,6 +103,12 @@ type CarrierConfig struct {
 	WarehousePostal       string          `gorm:"column:warehouse_postal;type:varchar(40)"`
 	WarehouseCountry      string          `gorm:"column:warehouse_country;type:char(2)"`
 	WarehousePhone        string          `gorm:"column:warehouse_phone;type:varchar(40)"`
+	// WarehouseID points at the store-level warehouses row (migration
+	// 000095, #177) when one has been linked. Nullable: rows written before
+	// #177's write path landed, or by any writer that hasn't been updated,
+	// still only have the columns above. *uuid.UUID rather than uuid.UUID
+	// so GORM writes/reads SQL NULL instead of the zero UUID.
+	WarehouseID *uuid.UUID `gorm:"column:warehouse_id;type:uuid"`
 	// Pickup automation. AutoSchedulePickup is the master toggle; rows
 	// default to TRUE in SQL so existing configs auto-opt-in when the
 	// shipping_pickup.sql ALTERs apply. DefaultPickupSlotStart is fed

--- a/services/marketplace-api/internal/warehouse/repository.go
+++ b/services/marketplace-api/internal/warehouse/repository.go
@@ -148,6 +148,24 @@ func (r *Repository) DefaultForStore(ctx context.Context, db *gorm.DB, storeID s
 	return w, nil
 }
 
+// ByID loads a warehouse by its primary key. This is the read side of
+// #177's expand/contract migration: every site that used to read the
+// pickup address off shipping_carrier_configs.warehouse_* now resolves it
+// via a config's warehouse_id through this method instead, falling back to
+// the legacy columns when warehouse_id is NULL or (rarely — the FK is ON
+// DELETE SET NULL) points at a row that no longer exists.
+func (r *Repository) ByID(ctx context.Context, db *gorm.DB, id string) (Warehouse, error) {
+	var w Warehouse
+	err := db.WithContext(ctx).Where("id = ?", id).First(&w).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return Warehouse{}, ErrNotFound
+	}
+	if err != nil {
+		return Warehouse{}, fmt.Errorf("warehouse: by id: %w", err)
+	}
+	return w, nil
+}
+
 func (r *Repository) byStoreAndName(ctx context.Context, db *gorm.DB, storeID, name string) (Warehouse, error) {
 	var w Warehouse
 	err := db.WithContext(ctx).

--- a/services/marketplace-api/internal/warehouse/repository.go
+++ b/services/marketplace-api/internal/warehouse/repository.go
@@ -1,0 +1,162 @@
+// Package warehouse owns the store-level pickup location (#177, the cheap
+// half).
+//
+// # What it replaces
+//
+// A "warehouse" used to be eight `warehouse_*` columns hanging off
+// `shipping_carrier_configs` — a row per (store, carrier). A merchant
+// running Delhivery AND CouriersPlease typed the same physical address
+// twice, into two rows, and kept them in sync by hand. The address is a
+// property of the STORE, not of the carrier account used to ship from it.
+//
+// Migration 000095 did the expand half: created this table, backfilled one
+// row per distinct (store, name), and added
+// `shipping_carrier_configs.warehouse_id`. The old columns are still
+// present and still written, deliberately — dropping them is the contract
+// half, and only safe once every reader goes through warehouse_id.
+//
+// # What it deliberately does NOT do
+//
+// Multi-warehouse ALLOCATION. #177 argues, correctly, that choosing which
+// warehouse ships an order is a product decision — nearest pincode, most
+// stock, explicit priority? and what happens when no single location can
+// fill an order — and that building it before a merchant with two
+// warehouses asks means guessing their fulfilment rules.
+//
+// So this supports ONE default warehouse per store, which is exactly what
+// every store has today. The table's shape and `variant_stock`'s
+// (variant_id, location_id) key leave the door open; nothing here forecloses
+// it.
+package warehouse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// ErrNotFound signals the store has no warehouse.
+//
+// Distinct from a zero-value Warehouse on purpose: a caller that filled a
+// carrier config with blank address fields would ship nothing, and would
+// find out at the carrier API rather than here.
+var ErrNotFound = errors.New("warehouse: not found")
+
+// Warehouse is a store's pickup location.
+type Warehouse struct {
+	ID       string `gorm:"column:id;type:uuid;primaryKey"`
+	TenantID string `gorm:"column:tenant_id;type:uuid;not null"`
+	StoreID  string `gorm:"column:store_id;type:uuid;not null"`
+	Name     string `gorm:"column:name;type:varchar(200);not null"`
+
+	Line1      string `gorm:"column:line1;type:varchar(300);not null"`
+	Line2      string `gorm:"column:line2;type:varchar(300);not null"`
+	City       string `gorm:"column:city;type:varchar(200);not null"`
+	Region     string `gorm:"column:region;type:varchar(200);not null"`
+	PostalCode string `gorm:"column:postal_code;type:varchar(40);not null"`
+	// CountryCode is ISO 3166-1 alpha-2.
+	CountryCode string `gorm:"column:country_code;type:char(2);not null"`
+	Phone       string `gorm:"column:phone;type:varchar(40);not null"`
+	// Email and ContactPerson are nullable in migration 000095 and left
+	// NULL by its backfill — the admin UI does not collect them yet. GORM
+	// reads a NULL into the zero value, so a backfilled row is still safe
+	// to load (pinned by a test).
+	Email string `gorm:"column:email;type:varchar(200)"`
+	// ContactPerson is required by Delhivery's warehouse registration and
+	// had no home on the old carrier columns at all — which is how a label
+	// failure ("ClientWarehouse matching query does not exist") led to
+	// #177 in the first place.
+	ContactPerson string `gorm:"column:contact_person;type:varchar(200)"`
+
+	IsDefault bool      `gorm:"column:is_default;not null"`
+	CreatedAt time.Time `gorm:"column:created_at"`
+	UpdatedAt time.Time `gorm:"column:updated_at"`
+}
+
+func (Warehouse) TableName() string { return "warehouses" }
+
+type Repository struct{}
+
+func NewRepository() *Repository { return &Repository{} }
+
+// Upsert creates the store's warehouse or updates it in place, keyed on
+// (store_id, name) — the table's own unique index.
+//
+// Keying on the NAME rather than minting a row per call is the whole point:
+// the second carrier configured for a store lands on the same row, so an
+// edited address is seen by both instead of drifting between two copies.
+//
+// Runs in the caller's *gorm.DB so it can join a transaction that also
+// writes the carrier config; a warehouse created for a config that then
+// failed to save would be a row nothing references.
+func (r *Repository) Upsert(ctx context.Context, db *gorm.DB, w Warehouse) (Warehouse, error) {
+	w.Name = strings.TrimSpace(w.Name)
+	if w.Name == "" {
+		return Warehouse{}, fmt.Errorf("warehouse: name is required")
+	}
+	if w.StoreID == "" || w.TenantID == "" {
+		return Warehouse{}, fmt.Errorf("warehouse: tenant and store are required")
+	}
+	w.CountryCode = strings.ToUpper(strings.TrimSpace(w.CountryCode))
+	if w.ID == "" {
+		// The column has a gen_random_uuid() default, but GORM sends the
+		// zero value for a non-pointer string primary key rather than
+		// omitting it, so Postgres receives "" and rejects it as a uuid.
+		w.ID = uuid.NewString()
+	}
+
+	err := db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "store_id"}, {Name: "name"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"line1", "line2", "city", "region", "postal_code",
+			"country_code", "phone", "email", "contact_person", "updated_at",
+		}),
+	}).Create(&w).Error
+	if err != nil {
+		return Warehouse{}, fmt.Errorf("warehouse: upsert: %w", err)
+	}
+
+	// Read back rather than trusting the in-memory struct: on the conflict
+	// path the row's id is the EXISTING one, not the id GORM generated for
+	// this call, and callers use it as a foreign key.
+	return r.byStoreAndName(ctx, db, w.StoreID, w.Name)
+}
+
+// DefaultForStore returns the store's warehouse.
+//
+// Prefers the row flagged is_default, then the oldest — a deterministic
+// answer matters because callers use it to fill a carrier config, and a
+// result that varied per request would produce configs that disagree.
+func (r *Repository) DefaultForStore(ctx context.Context, db *gorm.DB, storeID string) (Warehouse, error) {
+	var w Warehouse
+	err := db.WithContext(ctx).
+		Where("store_id = ?", storeID).
+		Order("is_default DESC, created_at ASC").
+		First(&w).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return Warehouse{}, ErrNotFound
+	}
+	if err != nil {
+		return Warehouse{}, fmt.Errorf("warehouse: default for store: %w", err)
+	}
+	return w, nil
+}
+
+func (r *Repository) byStoreAndName(ctx context.Context, db *gorm.DB, storeID, name string) (Warehouse, error) {
+	var w Warehouse
+	err := db.WithContext(ctx).
+		Where("store_id = ? AND name = ?", storeID, name).First(&w).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return Warehouse{}, ErrNotFound
+	}
+	if err != nil {
+		return Warehouse{}, fmt.Errorf("warehouse: lookup: %w", err)
+	}
+	return w, nil
+}

--- a/services/marketplace-api/internal/warehouse/repository_integration_test.go
+++ b/services/marketplace-api/internal/warehouse/repository_integration_test.go
@@ -1,0 +1,161 @@
+//go:build integration
+
+package warehouse_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// The cheap half of #177.
+//
+// A "warehouse" used to be 8 warehouse_* columns hanging off
+// shipping_carrier_configs — a row per (store, carrier). A merchant running
+// Delhivery AND CouriersPlease typed the same physical address twice and
+// kept the two copies in sync by hand. The address is a property of the
+// STORE, not of the carrier account used to ship from it.
+//
+// Migration 000095 already did the expand half (table, backfill,
+// warehouse_id). This is the repository that lets writers stop duplicating.
+//
+// Multi-warehouse ALLOCATION is deliberately not here — see #177, where the
+// issue argues that choosing a warehouse per order is a product decision.
+// One default warehouse per store is what this supports, which is exactly
+// what every store has today.
+
+func seedStore(t *testing.T, db *gorm.DB) (tenantID, storeID string) {
+	t.Helper()
+	tenantID, storeID = uuid.NewString(), uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO stores (id, tenant_id, name, slug, status, country_code, currency_code, timezone,
+		                     storefront_customer_portal_secret)
+		 VALUES (?, ?, 'WH Test', ?, 'active', 'IN', 'INR', 'Asia/Kolkata', ?)`,
+		storeID, tenantID, "wh-"+uuid.NewString()[:8], uuid.NewString()).Error)
+	return tenantID, storeID
+}
+
+func sample(tenantID, storeID, name string) warehouse.Warehouse {
+	return warehouse.Warehouse{
+		TenantID: tenantID, StoreID: storeID, Name: name,
+		Line1: "12 Industrial Estate", City: "Mumbai", Region: "MH",
+		PostalCode: "400001", CountryCode: "IN", Phone: "+912200000000",
+		ContactPerson: "Warehouse Manager",
+	}
+}
+
+func TestUpsert_CreatesThenReusesTheSameRowForAStore(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	first, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Main"))
+	require.NoError(t, err)
+	require.NotEmpty(t, first.ID)
+
+	// The SECOND carrier being configured for the same store must land on
+	// the same warehouse — that is the duplication this removes.
+	second, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Main"))
+	require.NoError(t, err)
+	require.Equal(t, first.ID, second.ID, "a second carrier must reuse the store's warehouse, not create another")
+
+	var rows int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM warehouses WHERE store_id = ?`, storeID).Scan(&rows).Error)
+	require.Equal(t, int64(1), rows)
+}
+
+// An edited address must update in place, so both carriers see the change.
+// Keeping two rows in sync by hand is precisely the failure being removed.
+func TestUpsert_UpdatesTheExistingRowInPlace(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	created, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Main"))
+	require.NoError(t, err)
+
+	moved := sample(tenantID, storeID, "Main")
+	moved.Line1 = "99 New Road"
+	moved.PostalCode = "400002"
+	updated, err := repo.Upsert(ctx, db, moved)
+	require.NoError(t, err)
+
+	require.Equal(t, created.ID, updated.ID)
+	require.Equal(t, "99 New Road", updated.Line1)
+	require.Equal(t, "400002", updated.PostalCode)
+}
+
+// Two stores must never share a warehouse row, even with the same name —
+// they are different addresses belonging to different merchants.
+func TestUpsert_IsScopedPerStore(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	t1, s1 := seedStore(t, db)
+	t2, s2 := seedStore(t, db)
+
+	a, err := repo.Upsert(ctx, db, sample(t1, s1, "Main"))
+	require.NoError(t, err)
+	b, err := repo.Upsert(ctx, db, sample(t2, s2, "Main"))
+	require.NoError(t, err)
+
+	require.NotEqual(t, a.ID, b.ID, "same name, different stores — must not collide")
+}
+
+func TestDefaultForStore_ReturnsNotFoundWhenNoneExists(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	_, storeID := seedStore(t, db)
+
+	_, err := repo.DefaultForStore(context.Background(), db, storeID)
+	require.ErrorIs(t, err, warehouse.ErrNotFound,
+		"absent must be distinguishable from a zero-value address — a caller "+
+			"that filled a carrier config with blanks would ship nothing")
+}
+
+func TestDefaultForStore_ReturnsTheStoresWarehouse(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	created, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Main"))
+	require.NoError(t, err)
+
+	got, err := repo.DefaultForStore(ctx, db, storeID)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, got.ID)
+	require.Equal(t, "Mumbai", got.City)
+	require.Equal(t, "Warehouse Manager", got.ContactPerson,
+		"contact_person is the field Delhivery registration needs and the old "+
+			"carrier columns never had")
+}
+
+// Migration 000095's backfill inserts no email/contact_person, so every
+// pre-existing warehouse row has them NULL. Those rows are the common case
+// in production, and a model that could not read them would break every
+// store that existed before this table did.
+func TestDefaultForStore_ReadsABackfilledRowWithNullContactColumns(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	tenantID, storeID := seedStore(t, db)
+	require.NoError(t, db.Exec(
+		`INSERT INTO warehouses (id, tenant_id, store_id, name, line1, city, region,
+		                         postal_code, country_code, phone, email, contact_person, is_default)
+		 VALUES (?, ?, ?, 'Main', '12 Industrial Estate', 'Mumbai', 'MH',
+		         '400001', 'IN', '+912200000000', NULL, NULL, true)`,
+		uuid.NewString(), tenantID, storeID).Error)
+
+	got, err := warehouse.NewRepository().DefaultForStore(context.Background(), db, storeID)
+	require.NoError(t, err, "a backfilled row must be readable")
+	require.Equal(t, "Mumbai", got.City)
+	require.Empty(t, got.Email)
+	require.Empty(t, got.ContactPerson)
+}

--- a/services/marketplace-api/internal/warehouse/repository_integration_test.go
+++ b/services/marketplace-api/internal/warehouse/repository_integration_test.go
@@ -159,3 +159,37 @@ func TestDefaultForStore_ReadsABackfilledRowWithNullContactColumns(t *testing.T)
 	require.Empty(t, got.Email)
 	require.Empty(t, got.ContactPerson)
 }
+
+// ByID is the read half of #177: every site that used to read the pickup
+// address off shipping_carrier_configs.warehouse_* now looks it up by
+// primary key via a config's warehouse_id. These two tests pin its
+// contract directly, ahead of the handler-level tests that build on it.
+
+func TestByID_ReturnsTheWarehouse(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	created, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Main"))
+	require.NoError(t, err)
+
+	got, err := repo.ByID(ctx, db, created.ID)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, got.ID)
+	require.Equal(t, "Mumbai", got.City)
+	require.Equal(t, "Warehouse Manager", got.ContactPerson)
+}
+
+// A dangling id (the FK is ON DELETE SET NULL, so this should be rare, but
+// not impossible under concurrent writes) must be distinguishable from a
+// zero-value warehouse, exactly like DefaultForStore's ErrNotFound — every
+// read-site caller falls back to the legacy columns on this error rather
+// than failing the request outright.
+func TestByID_ReturnsNotFoundForAMissingID(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+
+	_, err := repo.ByID(context.Background(), db, uuid.NewString())
+	require.ErrorIs(t, err, warehouse.ErrNotFound)
+}


### PR DESCRIPTION
Extracts the merchant's pickup location into the store-level `warehouses` table
and moves every writer and reader onto it. This is the **cheap half** of #177 —
multi-warehouse *allocation* is deliberately not here.

## The problem

A "warehouse" was 8 `warehouse_*` columns hanging off `shipping_carrier_configs`,
which is a row per (store, carrier). A merchant running Delhivery **and**
CouriersPlease typed the same physical address twice, into two rows, and kept
them in sync by hand. The address is a property of the **store**, not of the
carrier account used to ship from it.

Migration `000095` (already on main) did the expand half: created `warehouses`,
added `shipping_carrier_configs.warehouse_id`, and backfilled both. Nothing read
or wrote it. This PR is the code half.

## What changed

**`internal/warehouse`** — repository over the table. `Upsert` is keyed on
`(store_id, name)`, so the second carrier configured for a store lands on the
*same* row instead of minting a duplicate. It takes the caller's `*gorm.DB` so
it can join a transaction.

**Write path** (`admin/settings.go`) — the carrier-config write and the
warehouse upsert now share one transaction; a warehouse created for a config
that then failed to save would be a row nothing references. `warehouse_id`
tracks the legacy columns exactly, including when they are blanked.

**Read path** (3 sites) — each prefers the `warehouses` row via `warehouse_id`
and falls back to the legacy columns:
- `admin/shipments.go` — label origin + the warehouse auto-registration retry
- `storefront/shipping_rates.go` — rate-quote origin
- `admin/settings.go` `syncWarehouseAsync` — the address pushed to the carrier

The fallback is **required, not defensive**: rows written before this landed
have `warehouse_id` NULL. A non-NULL id pointing at a missing row also falls
back rather than failing the request — shipping a label matters more than
strictness — and logs.

## Expand/contract

The 8 legacy columns are **still present and still written**. Dropping them is
the contract half and only becomes safe now that every reader goes through
`warehouse_id`; that is a follow-up, not this PR.

## Partial fix worth calling out

`shipping.Warehouse.ContactPerson`/`Email` have existed since the interface was
written and **no caller has ever set them** — that is the root of the
`ClientWarehouse matching query does not exist` Delhivery label failure that
opened #177. They now flow through when the address resolves from the
warehouses row. This is only half a fix: nothing collects them from merchants
yet, so in practice they are still empty. Follow-up to be filed.

## Testing

23 integration tests, run against a real Postgres:

```
TEST_DATABASE_URL='postgres://dev:dev@<host>:5432/marketplace_db?sslmode=disable' \
  go test -tags=integration -p 1 -count=1 ./internal/handlers/... ./internal/warehouse/... ./internal/shipping/...
```

Notable cases:
- a second carrier reuses the store's warehouse row (the duplication this removes)
- editing the address updates the shared row, and both carriers see it
- clearing the warehouse name clears `warehouse_id` — verified to fail without the fix
- each read site prefers the warehouses row over **differing** legacy values, so
  the assertion proves which source won
- each read site falls back on a NULL id, and on a dangling one
- the legacy columns are still written

No regressions in `admin`, `storefront`, `shipping`, `warehouse`, `internalsvc`,
`platformadmin`, `public`, `webhooks`. `go build ./...` and
`go vet -tags=integration ./...` clean.

## Not in scope

- **Allocation** (which warehouse ships an order) — a product decision, per #177
- Dropping the legacy columns (contract half)
- Collecting `contact_person`/`email` in the admin UI
- `variant_stock.location_id` backfill off the sentinel

Refs #177
