### PR TITLE
feat(shipping): collect warehouse contact person and email (#483)

### DIFF
--- a/apps/admin/components/settings/ShippingConfigForm.tsx
+++ b/apps/admin/components/settings/ShippingConfigForm.tsx
@@ -253,7 +253,7 @@ export function ShippingConfigForm({
             />
             <p className="text-xs text-[color:var(--ink-900)]/40 mt-1">
               Used for shipping label pickup notifications. Falls back to the
-              customer's email if left blank.
+              customer&apos;s email if left blank.
             </p>
           </Field>
         </div>

--- a/apps/admin/components/settings/ShippingConfigForm.tsx
+++ b/apps/admin/components/settings/ShippingConfigForm.tsx
@@ -76,6 +76,13 @@ export function ShippingConfigForm({
     phone: existing?.warehouse_phone ?? "",
   });
 
+  const [warehouseContactPerson, setWarehouseContactPerson] = useState(
+    existing?.warehouse_contact_person ?? "",
+  );
+  const [warehouseEmail, setWarehouseEmail] = useState(
+    existing?.warehouse_email ?? "",
+  );
+
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const [pending, startTransition] = useTransition();
@@ -101,6 +108,8 @@ export function ShippingConfigForm({
         warehouse_postal: address.postal || undefined,
         warehouse_country: address.country || undefined,
         warehouse_phone: address.phone || undefined,
+        warehouse_contact_person: warehouseContactPerson || undefined,
+        warehouse_email: warehouseEmail || undefined,
         auto_schedule_pickup: autoSchedulePickup,
         default_pickup_slot_start: defaultPickupSlotStart,
         // Slot end mirrors the start + 4h — kept implicit because the UI
@@ -218,6 +227,36 @@ export function ShippingConfigForm({
           disabled={pending}
           idPrefix={`${provider}-wh`}
         />
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field label="Contact person (optional)" htmlFor={`${provider}-wh-contact`}>
+            <input
+              id={`${provider}-wh-contact`}
+              type="text"
+              value={warehouseContactPerson}
+              onChange={(e) => { setWarehouseContactPerson(e.target.value); setSuccess(false); }}
+              disabled={pending}
+              className={inputClass}
+            />
+            <p className="text-xs text-[color:var(--ink-900)]/40 mt-1">
+              Who the courier should ask for when picking up. Falls back to the
+              warehouse name if left blank.
+            </p>
+          </Field>
+          <Field label="Contact email (optional)" htmlFor={`${provider}-wh-email`}>
+            <input
+              id={`${provider}-wh-email`}
+              type="email"
+              value={warehouseEmail}
+              onChange={(e) => { setWarehouseEmail(e.target.value); setSuccess(false); }}
+              disabled={pending}
+              className={inputClass}
+            />
+            <p className="text-xs text-[color:var(--ink-900)]/40 mt-1">
+              Used for shipping label pickup notifications. Falls back to the
+              customer's email if left blank.
+            </p>
+          </Field>
+        </div>
       </fieldset>
 
       {/* Pickup automation — Delhivery only, but the form is

--- a/apps/admin/lib/api/settings-api.ts
+++ b/apps/admin/lib/api/settings-api.ts
@@ -66,6 +66,8 @@ export interface ShippingConfig {
   warehouse_postal?: string;
   warehouse_country?: string;
   warehouse_phone?: string;
+  warehouse_contact_person?: string;
+  warehouse_email?: string;
   /** Whether a Delhivery pickup is auto-scheduled when a label is created. */
   auto_schedule_pickup?: boolean;
   /** "HH:MM:SS" — pickup slot start; fed back to Delhivery as pickup_time. */
@@ -91,6 +93,8 @@ export interface ShippingConfigUpsertInput {
   warehouse_postal?: string;
   warehouse_country?: string;
   warehouse_phone?: string;
+  warehouse_contact_person?: string;
+  warehouse_email?: string;
   auto_schedule_pickup?: boolean;
   default_pickup_slot_start?: string;
   default_pickup_slot_end?: string;

--- a/services/marketplace-api/internal/handlers/admin/pickup_email_fallback_test.go
+++ b/services/marketplace-api/internal/handlers/admin/pickup_email_fallback_test.go
@@ -1,0 +1,36 @@
+// Package admin — unit coverage for pickupEmailOrBuyerFallback (#483).
+//
+// A pure function test, deliberately in-package with no //go:build tag and
+// no database: pickupEmailOrBuyerFallback has no I/O, so it doesn't need
+// testdb or an integration run to exercise both branches.
+package admin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPickupEmailOrBuyerFallback_PrefersTheWarehouseEmail pins the #483
+// behavior change: once a pickup address carries its own email (collected
+// via the admin shipping settings form and stored on the warehouses row),
+// the label path must use it instead of the buyer's order email.
+func TestPickupEmailOrBuyerFallback_PrefersTheWarehouseEmail(t *testing.T) {
+	pickup := pickupAddress{Email: "warehouse@example.com"}
+
+	got := pickupEmailOrBuyerFallback(pickup, "buyer@example.com")
+
+	require.Equal(t, "warehouse@example.com", got, "the warehouse's own email must win, ignoring the buyer email entirely")
+}
+
+// TestPickupEmailOrBuyerFallback_FallsBackToTheBuyerEmailWhenBlank covers
+// the case that still matters after #483: a pickup resolved from the
+// legacy warehouse_* columns (see resolvePickupAddress) has no email
+// column at all, so the buyer's order email is the only usable contact.
+func TestPickupEmailOrBuyerFallback_FallsBackToTheBuyerEmailWhenBlank(t *testing.T) {
+	pickup := pickupAddress{Email: ""}
+
+	got := pickupEmailOrBuyerFallback(pickup, "buyer@example.com")
+
+	require.Equal(t, "buyer@example.com", got)
+}

--- a/services/marketplace-api/internal/handlers/admin/settings.go
+++ b/services/marketplace-api/internal/handlers/admin/settings.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/mail"
 	"strings"
 	"time"
 
@@ -622,22 +623,24 @@ func (h *ShippingSettingsHandler) maskKeyField(ctx context.Context, ref string) 
 
 // shippingConfigResponse is the safe wire DTO for carrier configs.
 type shippingConfigResponse struct {
-	ID                    string `json:"id"`
-	Provider              string `json:"provider"`
-	APIKey                string `json:"api_key"`
-	SecretKey             string `json:"secret_key"`
-	Mode                  string `json:"mode"`
-	Enabled               bool   `json:"enabled"`
-	HandlingFee           string `json:"handling_fee"`
-	FreeShippingThreshold string `json:"free_shipping_threshold"`
-	WarehouseName         string `json:"warehouse_name,omitempty"`
-	WarehouseLine1        string `json:"warehouse_line1,omitempty"`
-	WarehouseLine2        string `json:"warehouse_line2,omitempty"`
-	WarehouseCity         string `json:"warehouse_city,omitempty"`
-	WarehouseRegion       string `json:"warehouse_region,omitempty"`
-	WarehousePostal       string `json:"warehouse_postal,omitempty"`
-	WarehouseCountry      string `json:"warehouse_country,omitempty"`
-	WarehousePhone        string `json:"warehouse_phone,omitempty"`
+	ID                     string `json:"id"`
+	Provider               string `json:"provider"`
+	APIKey                 string `json:"api_key"`
+	SecretKey              string `json:"secret_key"`
+	Mode                   string `json:"mode"`
+	Enabled                bool   `json:"enabled"`
+	HandlingFee            string `json:"handling_fee"`
+	FreeShippingThreshold  string `json:"free_shipping_threshold"`
+	WarehouseName          string `json:"warehouse_name,omitempty"`
+	WarehouseLine1         string `json:"warehouse_line1,omitempty"`
+	WarehouseLine2         string `json:"warehouse_line2,omitempty"`
+	WarehouseCity          string `json:"warehouse_city,omitempty"`
+	WarehouseRegion        string `json:"warehouse_region,omitempty"`
+	WarehousePostal        string `json:"warehouse_postal,omitempty"`
+	WarehouseCountry       string `json:"warehouse_country,omitempty"`
+	WarehousePhone         string `json:"warehouse_phone,omitempty"`
+	WarehouseContactPerson string `json:"warehouse_contact_person,omitempty"`
+	WarehouseEmail         string `json:"warehouse_email,omitempty"`
 	// Pickup automation — surfaced so the admin UI can render the
 	// "Auto-schedule Delhivery pickup" checkbox + slot selector and
 	// preserve the merchant's choice across saves.
@@ -686,6 +689,23 @@ type ShippingCarrierConfigRow struct {
 func (ShippingCarrierConfigRow) TableName() string { return "shipping_carrier_configs" }
 
 func (h *ShippingSettingsHandler) toShippingResponse(ctx context.Context, cfg ShippingCarrierConfigRow) shippingConfigResponse {
+	// contact_person and email have no legacy-column equivalent on
+	// shipping_carrier_configs (unlike warehouse_name/warehouse_line1/etc.,
+	// which predate #177) — they only ever live on the warehouses row, so
+	// the response can only source them via cfg.WarehouseID. Mirrors
+	// resolveWarehouseForSync's fallback below: a missing/unresolvable
+	// warehouse just means blank values, not a failed response.
+	var contactPerson, email string
+	if cfg.WarehouseID != nil {
+		wh, err := h.warehouseRepo.ByID(ctx, h.db, cfg.WarehouseID.String())
+		if err == nil {
+			contactPerson = wh.ContactPerson
+			email = wh.Email
+		} else {
+			h.logger.Warn("shipping settings response: warehouse_id has no matching row",
+				"store_id", cfg.StoreID.String(), "warehouse_id", cfg.WarehouseID.String(), "err", err)
+		}
+	}
 	return shippingConfigResponse{
 		ID:                     cfg.ID.String(),
 		Provider:               cfg.Provider,
@@ -703,6 +723,8 @@ func (h *ShippingSettingsHandler) toShippingResponse(ctx context.Context, cfg Sh
 		WarehousePostal:        cfg.WarehousePostal,
 		WarehouseCountry:       cfg.WarehouseCountry,
 		WarehousePhone:         cfg.WarehousePhone,
+		WarehouseContactPerson: contactPerson,
+		WarehouseEmail:         email,
 		AutoSchedulePickup:     cfg.AutoSchedulePickup,
 		DefaultPickupSlotStart: cfg.DefaultPickupSlotStart,
 		DefaultPickupSlotEnd:   cfg.DefaultPickupSlotEnd,
@@ -748,20 +770,22 @@ func (h *ShippingSettingsHandler) List(c *gin.Context) {
 // keeps the previously-encrypted value. A blank submit on a new row (no
 // existing row) still fails — validated after the lookup below.
 type shippingUpsertRequest struct {
-	APIKey           string  `json:"api_key"`
-	SecretKey        string  `json:"secret_key"`
-	Mode             string  `json:"mode"       binding:"required,oneof=test live"`
-	IsActive         bool    `json:"is_active"`
-	HandlingFee      float64 `json:"handling_fee"`
-	FreeShippingMin  float64 `json:"free_shipping_min"`
-	WarehouseName    string  `json:"warehouse_name"`
-	WarehouseLine1   string  `json:"warehouse_line1"`
-	WarehouseLine2   string  `json:"warehouse_line2"`
-	WarehouseCity    string  `json:"warehouse_city"`
-	WarehouseRegion  string  `json:"warehouse_region"`
-	WarehousePostal  string  `json:"warehouse_postal"`
-	WarehouseCountry string  `json:"warehouse_country"`
-	WarehousePhone   string  `json:"warehouse_phone"`
+	APIKey                 string  `json:"api_key"`
+	SecretKey              string  `json:"secret_key"`
+	Mode                   string  `json:"mode"       binding:"required,oneof=test live"`
+	IsActive               bool    `json:"is_active"`
+	HandlingFee            float64 `json:"handling_fee"`
+	FreeShippingMin        float64 `json:"free_shipping_min"`
+	WarehouseName          string  `json:"warehouse_name"`
+	WarehouseLine1         string  `json:"warehouse_line1"`
+	WarehouseLine2         string  `json:"warehouse_line2"`
+	WarehouseCity          string  `json:"warehouse_city"`
+	WarehouseRegion        string  `json:"warehouse_region"`
+	WarehousePostal        string  `json:"warehouse_postal"`
+	WarehouseCountry       string  `json:"warehouse_country"`
+	WarehousePhone         string  `json:"warehouse_phone"`
+	WarehouseContactPerson string  `json:"warehouse_contact_person"`
+	WarehouseEmail         string  `json:"warehouse_email"`
 	// Pickup automation. AutoSchedulePickup is a *bool so zero-value
 	// (JSON omitted) keeps the DB default instead of forcing false
 	// on every save — we don't want the checkbox to flip itself off
@@ -770,6 +794,21 @@ type shippingUpsertRequest struct {
 	AutoSchedulePickup     *bool  `json:"auto_schedule_pickup"`
 	DefaultPickupSlotStart string `json:"default_pickup_slot_start"`
 	DefaultPickupSlotEnd   string `json:"default_pickup_slot_end"`
+}
+
+// blankPreservesExistingWarehouseField resolves what to write for a warehouse
+// contact_person/email field on save: a non-blank submitted value always wins: a
+// blank one means "the merchant didn't touch this field" and must NOT overwrite a
+// previously-saved value, because warehouse.Repository.Upsert's ON CONFLICT clause
+// unconditionally overwrites both columns and has no "leave unchanged" mode of its
+// own. Every pre-#483 warehouses row has these NULL (migration 000095's backfill
+// never set them), so falling through to "" on a genuinely new/untouched warehouse
+// is correct too — there is nothing to preserve yet.
+func blankPreservesExistingWarehouseField(submitted, existing string) string {
+	if v := strings.TrimSpace(submitted); v != "" {
+		return v
+	}
+	return existing
 }
 
 // Upsert handles PUT /settings/shipping/:provider — create or update a shipping
@@ -795,6 +834,20 @@ func (h *ShippingSettingsHandler) Upsert(c *gin.Context) {
 			"message": err.Error(),
 		})
 		return
+	}
+
+	// warehouse_contact_person is a free-text name — no format validation.
+	// warehouse_email only gets checked when non-blank; a blank submit
+	// means "leave it unchanged" (see blankPreservesExistingWarehouseField
+	// below) and isn't a value to validate at all.
+	if v := strings.TrimSpace(req.WarehouseEmail); v != "" {
+		if _, err := mail.ParseAddress(v); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+				"error":   "validation_failed",
+				"message": "warehouse_email is not a valid email address",
+			})
+			return
+		}
 	}
 
 	// Validate carrier is supported for the store's country.
@@ -929,17 +982,38 @@ func (h *ShippingSettingsHandler) Upsert(c *gin.Context) {
 		// Leave warehouse_id untouched (nil on create, whatever it already
 		// was on update) rather than manufacturing an empty warehouse row.
 		if strings.TrimSpace(req.WarehouseName) != "" {
+			// A blank contact_person/email in this save means "the merchant
+			// didn't touch this field", not "clear it" — warehouseRepo.Upsert's
+			// ON CONFLICT clause overwrites both columns unconditionally, so we
+			// resolve what to actually write ourselves before calling it. Only
+			// look up the prior row on an update with a warehouse already
+			// attached; a lookup failure just means nothing to fall back to,
+			// same as the create path — log and continue rather than failing
+			// the whole save over it.
+			var existingContactPerson, existingEmail string
+			if !isCreate && existing.WarehouseID != nil {
+				prior, err := h.warehouseRepo.ByID(c.Request.Context(), tx, existing.WarehouseID.String())
+				if err == nil {
+					existingContactPerson = prior.ContactPerson
+					existingEmail = prior.Email
+				} else {
+					h.logger.Warn("shipping settings upsert: warehouse_id has no matching row",
+						"store_id", store.ID, "warehouse_id", existing.WarehouseID.String(), "err", err)
+				}
+			}
 			wh, err := h.warehouseRepo.Upsert(c.Request.Context(), tx, warehouse.Warehouse{
-				TenantID:    store.TenantID,
-				StoreID:     store.ID,
-				Name:        req.WarehouseName,
-				Line1:       req.WarehouseLine1,
-				Line2:       req.WarehouseLine2,
-				City:        req.WarehouseCity,
-				Region:      req.WarehouseRegion,
-				PostalCode:  req.WarehousePostal,
-				CountryCode: req.WarehouseCountry,
-				Phone:       req.WarehousePhone,
+				TenantID:      store.TenantID,
+				StoreID:       store.ID,
+				Name:          req.WarehouseName,
+				Line1:         req.WarehouseLine1,
+				Line2:         req.WarehouseLine2,
+				City:          req.WarehouseCity,
+				Region:        req.WarehouseRegion,
+				PostalCode:    req.WarehousePostal,
+				CountryCode:   req.WarehouseCountry,
+				Phone:         req.WarehousePhone,
+				ContactPerson: blankPreservesExistingWarehouseField(req.WarehouseContactPerson, existingContactPerson),
+				Email:         blankPreservesExistingWarehouseField(req.WarehouseEmail, existingEmail),
 			})
 			if err != nil {
 				return err

--- a/services/marketplace-api/internal/handlers/admin/settings.go
+++ b/services/marketplace-api/internal/handlers/admin/settings.go
@@ -985,21 +985,25 @@ func (h *ShippingSettingsHandler) Upsert(c *gin.Context) {
 			// A blank contact_person/email in this save means "the merchant
 			// didn't touch this field", not "clear it" — warehouseRepo.Upsert's
 			// ON CONFLICT clause overwrites both columns unconditionally, so we
-			// resolve what to actually write ourselves before calling it. Only
-			// look up the prior row on an update with a warehouse already
-			// attached; a lookup failure just means nothing to fall back to,
-			// same as the create path — log and continue rather than failing
-			// the whole save over it.
-			var existingContactPerson, existingEmail string
-			if !isCreate && existing.WarehouseID != nil {
-				prior, err := h.warehouseRepo.ByID(c.Request.Context(), tx, existing.WarehouseID.String())
-				if err == nil {
-					existingContactPerson = prior.ContactPerson
-					existingEmail = prior.Email
-				} else {
-					h.logger.Warn("shipping settings upsert: warehouse_id has no matching row",
-						"store_id", store.ID, "warehouse_id", existing.WarehouseID.String(), "err", err)
-				}
+			// resolve what to actually write ourselves before calling it.
+			//
+			// Resolved by (store_id, name) — the SAME key Upsert conflicts on
+			// below — not by existing.WarehouseID. The two can disagree:
+			// clearing warehouse_name on a config nils cfg.WarehouseID (see
+			// the block below this one) while the underlying warehouses row
+			// survives untouched, so a later re-save of the SAME name must
+			// still find that row to preserve its contact fields, even though
+			// nothing currently points at it by id. A lookup miss (brand new
+			// name) or any other error just means nothing to fall back to —
+			// log and continue with blanks rather than failing the save.
+			existingContactPerson, existingEmail := "", ""
+			prior, err := h.warehouseRepo.ByStoreAndName(c.Request.Context(), tx, store.ID, strings.TrimSpace(req.WarehouseName))
+			if err == nil {
+				existingContactPerson = prior.ContactPerson
+				existingEmail = prior.Email
+			} else if !errors.Is(err, warehouse.ErrNotFound) {
+				h.logger.Warn("shipping settings upsert: warehouse lookup by name failed",
+					"store_id", store.ID, "warehouse_name", req.WarehouseName, "err", err)
 			}
 			wh, err := h.warehouseRepo.Upsert(c.Request.Context(), tx, warehouse.Warehouse{
 				TenantID:      store.TenantID,

--- a/services/marketplace-api/internal/handlers/admin/shipments.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments.go
@@ -205,6 +205,18 @@ type pickupAddress struct {
 	Email         string
 }
 
+// pickupEmailOrBuyerFallback resolves the label's pickup contact email: the
+// warehouse's own email when the resolved pickup address has one, falling back to
+// the buyer's order email otherwise. The fallback still matters after #483 — a
+// pickup resolved from the legacy warehouse_* columns (see resolvePickupAddress)
+// has no email at all, since those columns never carried one.
+func pickupEmailOrBuyerFallback(pickup pickupAddress, buyerEmail string) string {
+	if e := strings.TrimSpace(pickup.Email); e != "" {
+		return e
+	}
+	return buyerEmail
+}
+
 // resolvePickupAddress loads cfg's pickup address, preferring the
 // store-level warehouses row (#177, the read half) and falling back to
 // the legacy warehouse_* columns on shipping_carrier_configs.
@@ -570,12 +582,12 @@ func (h *ShipmentsHandler) Create(c *gin.Context) {
 		return
 	}
 
-	// Build origin address from warehouse config. Email defaults to the
-	// buyer's order email so CouriersPlease (and any other carrier that
-	// validates pickup_email format) accepts the label. Long-term we
-	// should add a dedicated warehouse_email column on
-	// shipping_carrier_configs and surface it in admin → Settings →
-	// Shipping; this fallback unblocks label generation in the meantime.
+	// Build origin address from warehouse config. Email prefers the
+	// warehouse's own email (#483 — collected via admin → Settings →
+	// Shipping and stored on the warehouses row), falling back to the
+	// buyer's order email for pickups still resolved from the legacy
+	// warehouse_* columns, which never carried an email at all (see
+	// resolvePickupAddress).
 	fromAddress := shipping.Address{
 		Name:        pickup.Name,
 		Line1:       pickup.Line1,
@@ -585,7 +597,7 @@ func (h *ShipmentsHandler) Create(c *gin.Context) {
 		PostalCode:  pickup.PostalCode,
 		CountryCode: pickup.CountryCode,
 		Phone:       pickup.Phone,
-		Email:       o.CustomerEmail,
+		Email:       pickupEmailOrBuyerFallback(pickup, o.CustomerEmail),
 	}
 
 	// Build destination address from order. Email comes from the order
@@ -698,14 +710,7 @@ func (h *ShipmentsHandler) Create(c *gin.Context) {
 	var whErr *shipping.WarehouseNotRegisteredError
 	if errors.As(err, &whErr) {
 		if syncer, ok := carrier.(shipping.WarehouseSyncer); ok {
-			// Email falls back to the buyer's order email, same as
-			// fromAddress above, when the resolved pickup has none (the
-			// legacy-columns fallback never does — that data only exists
-			// on the warehouses row).
-			whEmail := pickup.Email
-			if whEmail == "" {
-				whEmail = o.CustomerEmail
-			}
+			whEmail := pickupEmailOrBuyerFallback(pickup, o.CustomerEmail)
 			wh := shipping.Warehouse{
 				Name:        pickup.Name,
 				Phone:       pickup.Phone,

--- a/services/marketplace-api/internal/handlers/admin/warehouse_contact_fields_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/warehouse_contact_fields_integration_test.go
@@ -191,3 +191,63 @@ func TestShippingUpsert_ExistingWarehouseWithNullContactColumnsStillSavesFine(t 
 	require.Empty(t, contactPerson, "a NULL-backfilled row with no submitted value must stay blank, not error or fabricate a value")
 	require.Empty(t, email, "a NULL-backfilled row with no submitted value must stay blank, not error or fabricate a value")
 }
+
+// TestShippingUpsert_ClearingThenRestoringTheWarehouseNamePreservesContactFields
+// pins the real-world trigger for the bug the by-ID lookup had: clearing a
+// config's warehouse_name (existing, documented pre-#483 behavior) sets
+// cfg.WarehouseID back to nil, even though the underlying warehouses row is
+// untouched and still holds its contact_person/email. A merchant who then
+// re-enters the SAME warehouse name is doing an UPDATE (isCreate is false),
+// but a lookup keyed on existing.WarehouseID would find nothing — that
+// pointer is still nil from the clear — so it would resolve "nothing to
+// preserve" and blankPreservesExistingWarehouseField would return "", which
+// warehouseRepo.Upsert's ON CONFLICT DO UPDATE on (store_id, name) would
+// then write straight over the still-existing row, wiping its contact
+// fields. Resolving the prior row by (store_id, name) instead — the same
+// key Upsert conflicts on — finds it correctly across this clear/restore
+// cycle. This is also reachable within a single store once two carriers
+// share one warehouse row (see internal/warehouse's own package doc), not
+// just via this clear-then-restore sequence.
+func TestShippingUpsert_ClearingThenRestoringTheWarehouseNamePreservesContactFields(t *testing.T) {
+	env := setupShippingWarehouseRouter(t)
+	seedShippingCountry(t, env.db)
+	storeID, tenantID := seedShippingWarehouseStore(t, env.db)
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+
+	// 1. Save the warehouse with a contact person.
+	withContact := warehouseUpsertBody("Main Warehouse")
+	withContact["warehouse_contact_person"] = "Priya Sharma"
+	withContact["warehouse_email"] = "priya@example.com"
+	w1 := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+		withContact, authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, w1.Code, w1.Body.String())
+
+	rows := loadWarehousesForStore(t, env.db, storeID)
+	require.Len(t, rows, 1)
+	warehouseID := rows[0].ID
+
+	// 2. Clear the warehouse name. warehouse_id must go NULL on the config,
+	// but the warehouses row itself (and its contact fields) survives.
+	w2 := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+		warehouseUpsertBody(""), authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, w2.Code, w2.Body.String())
+	require.Nil(t, warehouseIDForConfig(t, env.db, storeID, "delhivery"),
+		"clearing the name must clear the config's warehouse_id link")
+
+	// 3. Re-enter the SAME warehouse name, still omitting contact/email.
+	// isCreate is false here, but the config's warehouse_id has been nil
+	// since step 2 — a by-ID lookup would miss entirely. The fix must
+	// still find the row by (store_id, name) and preserve its fields.
+	w3 := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+		warehouseUpsertBody("Main Warehouse"), authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, w3.Code, w3.Body.String())
+
+	require.Len(t, loadWarehousesForStore(t, env.db, storeID), 1,
+		"re-entering the same name must reuse the existing warehouse row, not create a second one")
+	contactPerson, email := loadWarehouseContact(t, env.db, warehouseID)
+	require.Equal(t, "Priya Sharma", contactPerson,
+		"restoring the same warehouse name must not wipe the contact person saved before it was cleared")
+	require.Equal(t, "priya@example.com", email,
+		"restoring the same warehouse name must not wipe the email saved before it was cleared")
+}

--- a/services/marketplace-api/internal/handlers/admin/warehouse_contact_fields_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/warehouse_contact_fields_integration_test.go
@@ -1,0 +1,189 @@
+//go:build integration
+
+// Package admin_test — write/read-path coverage for #483.
+//
+// #177 added warehouses.contact_person/email (migration 000095) and taught
+// warehouse.Repository.Upsert to write them, and the read paths
+// (resolveWarehouseForSync in settings.go, resolvePickupAddress in
+// shipments.go) already forwarded them to Delhivery — but nothing in the
+// admin shipping settings HTTP handler ever collected these two fields from
+// the merchant: shippingUpsertRequest had no contact_person/email field, so
+// every save sent them blank, silently wiping any value a merchant might
+// have set another way, and the settings GET/PUT response never returned
+// them either. This file pins the fix at the HTTP boundary: PUT
+// /settings/shipping/:provider now collects, persists, and round-trips
+// warehouse_contact_person/warehouse_email, and a save that omits them does
+// NOT clear a previously-saved value.
+package admin_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/authz"
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
+)
+
+// loadWarehouseContact reads contact_person/email directly off the
+// warehouses row, bypassing the HTTP layer, so these tests assert against
+// what actually landed in the database rather than trusting the handler's
+// own response echo.
+func loadWarehouseContact(t *testing.T, db *gorm.DB, warehouseID string) (contactPerson, email string) {
+	t.Helper()
+	require.NoError(t, db.Raw(
+		`SELECT COALESCE(contact_person, ''), COALESCE(email, '') FROM warehouses WHERE id = ?`,
+		warehouseID).Row().Scan(&contactPerson, &email))
+	return contactPerson, email
+}
+
+// shippingUpsertResponseData is the subset of the PUT response body this
+// file cares about — just enough to decode data.warehouse_contact_person
+// and data.warehouse_email for the round-trip assertions.
+type shippingUpsertResponseData struct {
+	Data struct {
+		WarehouseContactPerson string `json:"warehouse_contact_person"`
+		WarehouseEmail         string `json:"warehouse_email"`
+	} `json:"data"`
+}
+
+// TestShippingUpsert_SavingContactPersonAndEmailPersistsThemOnTheWarehouseRow
+// is the baseline for #483: a save that supplies warehouse_contact_person
+// and warehouse_email must actually reach the warehouses row, not just be
+// accepted and dropped (the bug this issue reports).
+func TestShippingUpsert_SavingContactPersonAndEmailPersistsThemOnTheWarehouseRow(t *testing.T) {
+	env := setupShippingWarehouseRouter(t)
+	seedShippingCountry(t, env.db)
+	storeID, tenantID := seedShippingWarehouseStore(t, env.db)
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+
+	body := warehouseUpsertBody("Main Warehouse")
+	body["warehouse_contact_person"] = "Priya Sharma"
+	body["warehouse_email"] = "priya@example.com"
+
+	w := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+		body, authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	rows := loadWarehousesForStore(t, env.db, storeID)
+	require.Len(t, rows, 1)
+
+	contactPerson, email := loadWarehouseContact(t, env.db, rows[0].ID)
+	require.Equal(t, "Priya Sharma", contactPerson)
+	require.Equal(t, "priya@example.com", email)
+}
+
+// TestShippingUpsert_ContactPersonAndEmailRoundTripOnTheResponse asserts the
+// PUT response itself (which calls toShippingResponse, same as GET /settings
+// would) reflects what was just saved. Asserting off the PUT's own response
+// body is simpler than issuing a second GET request and exercises the exact
+// same toShippingResponse code path this task changed.
+func TestShippingUpsert_ContactPersonAndEmailRoundTripOnTheResponse(t *testing.T) {
+	env := setupShippingWarehouseRouter(t)
+	seedShippingCountry(t, env.db)
+	storeID, tenantID := seedShippingWarehouseStore(t, env.db)
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+
+	body := warehouseUpsertBody("Main Warehouse")
+	body["warehouse_contact_person"] = "Priya Sharma"
+	body["warehouse_email"] = "priya@example.com"
+
+	w := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+		body, authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var resp shippingUpsertResponseData
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "Priya Sharma", resp.Data.WarehouseContactPerson)
+	require.Equal(t, "priya@example.com", resp.Data.WarehouseEmail)
+}
+
+// TestShippingUpsert_OmittingContactPersonAndEmailDoesNotWipeExistingValues
+// is the regression #483 calls out by name: warehouse.Repository.Upsert's
+// ON CONFLICT clause unconditionally overwrites contact_person/email, so a
+// merchant resaving the form WITHOUT touching these two fields (e.g. only
+// changing is_active, or re-entering an API key) must not blank out values
+// saved on an earlier PUT. blankPreservesExistingWarehouseField in
+// settings.go is the fix: a blank/omitted submission falls back to the
+// warehouse's currently-stored value rather than overwriting it with "".
+func TestShippingUpsert_OmittingContactPersonAndEmailDoesNotWipeExistingValues(t *testing.T) {
+	env := setupShippingWarehouseRouter(t)
+	seedShippingCountry(t, env.db)
+	storeID, tenantID := seedShippingWarehouseStore(t, env.db)
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+
+	seeded := warehouseUpsertBody("Main Warehouse")
+	seeded["warehouse_contact_person"] = "Priya Sharma"
+	seeded["warehouse_email"] = "priya@example.com"
+	w1 := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+		seeded, authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, w1.Code, w1.Body.String())
+
+	rows := loadWarehousesForStore(t, env.db, storeID)
+	require.Len(t, rows, 1)
+
+	// Second save omits both keys entirely — not an explicit "", just
+	// absent from the JSON body, though Go's json.Unmarshal treats a
+	// missing key and an explicit "" identically for a plain string field,
+	// so this also covers the empty-string case.
+	resave := warehouseUpsertBody("Main Warehouse")
+	resave["is_active"] = false
+	w2 := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+		resave, authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, w2.Code, w2.Body.String())
+
+	contactPerson, email := loadWarehouseContact(t, env.db, rows[0].ID)
+	require.Equal(t, "Priya Sharma", contactPerson, "a blank resave must not wipe the previously-saved contact person")
+	require.Equal(t, "priya@example.com", email, "a blank resave must not wipe the previously-saved email")
+}
+
+// TestShippingUpsert_ExistingWarehouseWithNullContactColumnsStillSavesFine
+// covers migration 000095's own backfill state: every pre-#483 warehouses
+// row has contact_person/email as NULL (the backfill never set them). A
+// save that resolves to this warehouse and still doesn't touch these two
+// fields must succeed (200, not an error) and must NOT populate them with
+// garbage — there's nothing to preserve on a row that never had a value,
+// so the fields stay blank, matching blankPreservesExistingWarehouseField's
+// documented behavior for "nothing to fall back to".
+func TestShippingUpsert_ExistingWarehouseWithNullContactColumnsStillSavesFine(t *testing.T) {
+	env := setupShippingWarehouseRouter(t)
+	seedShippingCountry(t, env.db)
+	storeID, tenantID := seedShippingWarehouseStore(t, env.db)
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+
+	// Seed a warehouse row directly, simulating the 000095 backfill state:
+	// ContactPerson/Email left at their Go zero value (never set).
+	whRepo := warehouse.NewRepository()
+	wh, err := whRepo.Upsert(t.Context(), env.db, warehouse.Warehouse{
+		TenantID:    tenantID,
+		StoreID:     storeID,
+		Name:        "Main Warehouse",
+		Line1:       "12 Industrial Estate",
+		City:        "Mumbai",
+		Region:      "MH",
+		PostalCode:  "400001",
+		CountryCode: "IN",
+		Phone:       "+912200000000",
+	})
+	require.NoError(t, err)
+
+	// Link a carrier config to it the same way the handler's own Upsert
+	// would, so the PUT below resolves existing.WarehouseID and takes the
+	// "look up the prior row" branch this test is targeting.
+	body := warehouseUpsertBody("Main Warehouse")
+	w := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+		body, authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	contactPerson, email := loadWarehouseContact(t, env.db, wh.ID)
+	require.Empty(t, contactPerson, "a NULL-backfilled row with no submitted value must stay blank, not error or fabricate a value")
+	require.Empty(t, email, "a NULL-backfilled row with no submitted value must stay blank, not error or fabricate a value")
+}

--- a/services/marketplace-api/internal/handlers/admin/warehouse_contact_fields_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/warehouse_contact_fields_integration_test.go
@@ -26,7 +26,6 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/authz"
-	"github.com/mark8ly/marketplace-api/internal/warehouse"
 )
 
 // loadWarehouseContact reads contact_person/email directly off the
@@ -146,12 +145,19 @@ func TestShippingUpsert_OmittingContactPersonAndEmailDoesNotWipeExistingValues(t
 
 // TestShippingUpsert_ExistingWarehouseWithNullContactColumnsStillSavesFine
 // covers migration 000095's own backfill state: every pre-#483 warehouses
-// row has contact_person/email as NULL (the backfill never set them). A
-// save that resolves to this warehouse and still doesn't touch these two
-// fields must succeed (200, not an error) and must NOT populate them with
-// garbage — there's nothing to preserve on a row that never had a value,
-// so the fields stay blank, matching blankPreservesExistingWarehouseField's
-// documented behavior for "nothing to fall back to".
+// row has contact_person/email as NULL (the backfill never set them), and
+// the UPDATE path in Upsert only looks up a prior warehouse row to fall
+// back to (blankPreservesExistingWarehouseField) when !isCreate &&
+// existing.WarehouseID != nil. A single PUT never reaches that branch — the
+// first save for a (store, provider) is always a create — so this test does
+// TWO PUTs for the same store/provider, neither touching contact/email:
+// the first creates the config and links a fresh (NULL-contact) warehouse
+// row, the second is the real UPDATE that exercises the "look up the prior
+// row" branch. It must succeed (200, not an error) and must NOT populate
+// the fields with garbage — there's nothing to preserve on a row that never
+// had a value, so they stay blank, matching
+// blankPreservesExistingWarehouseField's documented behavior for "nothing
+// to fall back to".
 func TestShippingUpsert_ExistingWarehouseWithNullContactColumnsStillSavesFine(t *testing.T) {
 	env := setupShippingWarehouseRouter(t)
 	seedShippingCountry(t, env.db)
@@ -159,31 +165,29 @@ func TestShippingUpsert_ExistingWarehouseWithNullContactColumnsStillSavesFine(t 
 	userID := uuid.NewString()
 	env.fga.Grant(userID, authz.RoleOwner, tenantID)
 
-	// Seed a warehouse row directly, simulating the 000095 backfill state:
-	// ContactPerson/Email left at their Go zero value (never set).
-	whRepo := warehouse.NewRepository()
-	wh, err := whRepo.Upsert(t.Context(), env.db, warehouse.Warehouse{
-		TenantID:    tenantID,
-		StoreID:     storeID,
-		Name:        "Main Warehouse",
-		Line1:       "12 Industrial Estate",
-		City:        "Mumbai",
-		Region:      "MH",
-		PostalCode:  "400001",
-		CountryCode: "IN",
-		Phone:       "+912200000000",
-	})
-	require.NoError(t, err)
-
-	// Link a carrier config to it the same way the handler's own Upsert
-	// would, so the PUT below resolves existing.WarehouseID and takes the
-	// "look up the prior row" branch this test is targeting.
+	// First PUT: create path. No contact/email in the body, so the linked
+	// warehouse row lands with NULL contact_person/email — the 000095
+	// backfill state this test targets.
 	body := warehouseUpsertBody("Main Warehouse")
-	w := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+	w1 := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
 		body, authHeaders(userID, tenantID))
-	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Equal(t, http.StatusOK, w1.Code, w1.Body.String())
 
-	contactPerson, email := loadWarehouseContact(t, env.db, wh.ID)
+	rows := loadWarehousesForStore(t, env.db, storeID)
+	require.Len(t, rows, 1)
+	contactPerson, email := loadWarehouseContact(t, env.db, rows[0].ID)
+	require.Empty(t, contactPerson, "the freshly-created warehouse must have no contact person")
+	require.Empty(t, email, "the freshly-created warehouse must have no email")
+
+	// Second PUT: same store, same provider, still no contact/email. This
+	// is the UPDATE — existing.WarehouseID is now set from the first PUT —
+	// so it's the one that actually exercises the "look up the prior row"
+	// branch in Upsert.
+	w2 := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
+		body, authHeaders(userID, tenantID))
+	require.Equal(t, http.StatusOK, w2.Code, w2.Body.String())
+
+	contactPerson, email = loadWarehouseContact(t, env.db, rows[0].ID)
 	require.Empty(t, contactPerson, "a NULL-backfilled row with no submitted value must stay blank, not error or fabricate a value")
 	require.Empty(t, email, "a NULL-backfilled row with no submitted value must stay blank, not error or fabricate a value")
 }

--- a/services/marketplace-api/internal/shipping/carrier.go
+++ b/services/marketplace-api/internal/shipping/carrier.go
@@ -47,7 +47,13 @@ type Warehouse struct {
 	Region      string
 	// ContactPerson and RegisteredName are Delhivery clientwarehouse
 	// requirements. Optional here — carriers that don't need them ignore
-	// them, and Delhivery defaults both to Name when empty.
+	// them, and Delhivery defaults both to Name when empty (see
+	// firstNonEmpty in delhivery.go's UpsertWarehouse). Email has no such
+	// default: Delhivery validates its format, so an empty Email is
+	// simply omitted from the request rather than defaulted to Name,
+	// which would fail validation. Collected from the merchant via the
+	// admin shipping settings form (#483) — see settings.go's
+	// shippingUpsertRequest.
 	ContactPerson  string
 	RegisteredName string
 }

--- a/services/marketplace-api/internal/warehouse/repository.go
+++ b/services/marketplace-api/internal/warehouse/repository.go
@@ -125,7 +125,7 @@ func (r *Repository) Upsert(ctx context.Context, db *gorm.DB, w Warehouse) (Ware
 	// Read back rather than trusting the in-memory struct: on the conflict
 	// path the row's id is the EXISTING one, not the id GORM generated for
 	// this call, and callers use it as a foreign key.
-	return r.byStoreAndName(ctx, db, w.StoreID, w.Name)
+	return r.ByStoreAndName(ctx, db, w.StoreID, w.Name)
 }
 
 // DefaultForStore returns the store's warehouse.
@@ -166,7 +166,16 @@ func (r *Repository) ByID(ctx context.Context, db *gorm.DB, id string) (Warehous
 	return w, nil
 }
 
-func (r *Repository) byStoreAndName(ctx context.Context, db *gorm.DB, storeID, name string) (Warehouse, error) {
+// ByStoreAndName loads a warehouse by the same key Upsert conflicts on
+// (store_id, name) — the table's unique index. Exported so callers that
+// need to resolve "the warehouse a given name currently maps to" can use
+// the identical key Upsert itself uses, rather than going through a
+// config's warehouse_id, which can go stale relative to that key: clearing
+// warehouse_name on a config nils its warehouse_id (see settings.go's
+// Upsert) while the underlying warehouses row survives untouched, so a
+// later re-save of the SAME name must find that same row again even
+// though nothing currently points at it by id.
+func (r *Repository) ByStoreAndName(ctx context.Context, db *gorm.DB, storeID, name string) (Warehouse, error) {
 	var w Warehouse
 	err := db.WithContext(ctx).
 		Where("store_id = ? AND name = ?", storeID, name).First(&w).Error

--- a/services/marketplace-api/pkg/testdb/testdb.go
+++ b/services/marketplace-api/pkg/testdb/testdb.go
@@ -138,8 +138,44 @@ func openOrSkip(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("testdb: open: %v", err)
 	}
+
+	// Cap and release the pool.
+	//
+	// Every call here opens a NEW pool, and nothing used to close one. Go's
+	// default is unlimited max-open connections, so a package simply
+	// accumulated pools until the shared server refused them:
+	//
+	//	FATAL: sorry, too many clients already (SQLSTATE 53300)
+	//
+	// That surfaces on whichever test happens to run once the ceiling is
+	// reached, which makes it read as that test's own bug. It is not — it
+	// is the tests before it never having given their connections back.
+	// Adding four tests to internal/handlers/admin was enough to cross it.
+	//
+	// The cleanup registered here runs AFTER the caller's truncate cleanup
+	// (t.Cleanup is LIFO and NewDB registers its own after this one), so the
+	// connection stays usable for the truncate that needs it.
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("testdb: pool handle: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(testPoolMaxOpen)
+	sqlDB.SetMaxIdleConns(testPoolMaxIdle)
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Logf("testdb: close pool: %v", err)
+		}
+	})
 	return db
 }
+
+// Pool bounds for a single test. Tests run sequentially (-p 1) and a handler
+// test holds only a handful of connections at once, so these are generous;
+// the point is that they are BOUNDED, not that they are large.
+const (
+	testPoolMaxOpen = 4
+	testPoolMaxIdle = 1
+)
 
 func truncate(t *testing.T, db *gorm.DB, tables []string) {
 	t.Helper()


### PR DESCRIPTION
Merchants can now enter a pickup **contact person** and **contact email**, and
those values reach the carrier. Closes #483.

## What changed

**Backend** — `contact_person` / `email` added to the shipping settings request
and response. They are stored ONLY on the `warehouses` row (there are no legacy
`shipping_carrier_configs` columns for them), so the response sources them by
resolving `warehouse_id`. Both are optional: every existing row has them NULL,
and requiring them would break saves for every current store.

**Frontend** — two optional inputs in the existing Warehouse address section of
`ShippingConfigForm.tsx`, plus the two fields on the request/response types.

**Label path** — `shipments.go` now prefers the warehouse's own email for the
pickup contact, falling back to the buyer's email only when the warehouse has
none.

## Correcting the premise of #483

I wrote that issue claiming the unset `ContactPerson` was "the root of" the
`ClientWarehouse matching query does not exist` failure. **That was wrong**, and
reading `delhivery.go` while implementing this is what showed it:

```go
// delhivery.go:769
contactPerson  := firstNonEmpty(wh.ContactPerson, wh.Name)
registeredName := firstNonEmpty(wh.RegisteredName, wh.Name)
```

`contact_person` has always been populated — it defaults to the warehouse name,
and the comment above it says exactly that. So it was never missing, and this PR
does **not** fix that registration error. Whatever caused it lies elsewhere
(most likely the warehouse simply never having been created carrier-side, which
the existing `WarehouseNotRegisteredError` auto-registration retry addresses).

**What this PR does genuinely fix** is the email. Delhivery is sent `email` only
when non-empty, and the value being sent was `o.CustomerEmail` — the **buyer's**
address — as the warehouse's pickup email. That is both wrong and a small
privacy leak of customer data to the carrier. A merchant can now set a real one.

I will post the same correction on #483 so the issue does not keep asserting a
cause that is not real.

## Also here: a test-infrastructure fix

`pkg/testdb.openOrSkip` opened a new pool per test and **never closed it**, with
no bound on max-open connections. Packages accumulated pools until the shared
server refused them:

```
FATAL: sorry, too many clients already (SQLSTATE 53300)
```

Adding four tests to `internal/handlers/admin` was enough to cross the ceiling,
and the failure surfaces on whichever test happens to run at that moment — so it
reads as that test's own bug. It is not. Pools are now bounded and closed on
cleanup (registered before `NewDB`'s truncate cleanup, which is LIFO, so the
connection is still alive for the truncate that needs it).

This is separate from `cmd/testdb-leakcheck`, which catches leftover *rows*.

## Testing

```
TEST_DATABASE_URL='postgres://dev:dev@<host>:5432/marketplace_db?sslmode=disable' \
  go test -tags=integration -p 1 -count=1 ./internal/handlers/admin/... ./internal/warehouse/... ./internal/handlers/storefront/...
```

All green. New cases: values persist on the warehouses row; they round-trip on
the response; omitting them does not wipe stored values; a row with NULL contact
columns still saves; the label path prefers the warehouse email and falls back
to the buyer's.

`apps/admin` typecheck introduces no new errors — the two `@tesserix/otto-widget`
failures are present on `main` and unrelated.

## Not in scope

Dropping the legacy `warehouse_*` columns is #484.
