### PR TITLE
feat(shipping): stop reading and writing the legacy warehouse_* columns (#484, step 1 of 2)

### DIFF
--- a/services/marketplace-api/internal/handlers/admin/pickup_email_fallback_test.go
+++ b/services/marketplace-api/internal/handlers/admin/pickup_email_fallback_test.go
@@ -24,9 +24,9 @@ func TestPickupEmailOrBuyerFallback_PrefersTheWarehouseEmail(t *testing.T) {
 }
 
 // TestPickupEmailOrBuyerFallback_FallsBackToTheBuyerEmailWhenBlank covers
-// the case that still matters after #483: a pickup resolved from the
-// legacy warehouse_* columns (see resolvePickupAddress) has no email
-// column at all, so the buyer's order email is the only usable contact.
+// the case that still matters after #483: a pickup with no warehouse (or
+// an unresolvable warehouse_id — see resolvePickupAddress) has no email at
+// all, so the buyer's order email is the only usable contact.
 func TestPickupEmailOrBuyerFallback_FallsBackToTheBuyerEmailWhenBlank(t *testing.T) {
 	pickup := pickupAddress{Email: ""}
 

--- a/services/marketplace-api/internal/handlers/admin/settings.go
+++ b/services/marketplace-api/internal/handlers/admin/settings.go
@@ -663,18 +663,16 @@ type ShippingCarrierConfigRow struct {
 	SecretKeyEncrypted string    `gorm:"column:secret_key_encrypted;type:text"`
 	Mode               string    `gorm:"column:mode;type:varchar(10);not null;default:test"`
 	IsActive           bool      `gorm:"column:is_active;type:boolean;not null;default:false"`
-	WarehouseName      string    `gorm:"column:warehouse_name;type:varchar(200)"`
-	WarehouseLine1     string    `gorm:"column:warehouse_line1;type:varchar(300)"`
-	WarehouseLine2     string    `gorm:"column:warehouse_line2;type:varchar(300)"`
-	WarehouseCity      string    `gorm:"column:warehouse_city;type:varchar(200)"`
-	WarehouseRegion    string    `gorm:"column:warehouse_region;type:varchar(200)"`
-	WarehousePostal    string    `gorm:"column:warehouse_postal;type:varchar(40)"`
-	WarehouseCountry   string    `gorm:"column:warehouse_country;type:char(2)"`
-	WarehousePhone     string    `gorm:"column:warehouse_phone;type:varchar(40)"`
 	// WarehouseID points at the store-level warehouses row (migration
 	// 000095, #177). Nullable: a config saved with a blank warehouse name
 	// never gets one, and the FK is ON DELETE SET NULL. *uuid.UUID rather
 	// than uuid.UUID so GORM writes SQL NULL instead of the zero UUID.
+	//
+	// #484 dropped the WarehouseName/Line1/Line2/City/Region/Postal/
+	// Country/Phone fields that used to mirror this row's legacy
+	// warehouse_* columns: they are no longer read anywhere (see
+	// toShippingResponse and resolveWarehouseForSync), which is what
+	// makes dropping those columns in a later migration safe.
 	WarehouseID     *uuid.UUID      `gorm:"column:warehouse_id;type:uuid"`
 	HandlingFee     decimal.Decimal `gorm:"column:handling_fee;type:numeric(12,2);not null;default:0"`
 	FreeShippingMin decimal.Decimal `gorm:"column:free_shipping_min;type:numeric(12,2)"`
@@ -689,18 +687,18 @@ type ShippingCarrierConfigRow struct {
 func (ShippingCarrierConfigRow) TableName() string { return "shipping_carrier_configs" }
 
 func (h *ShippingSettingsHandler) toShippingResponse(ctx context.Context, cfg ShippingCarrierConfigRow) shippingConfigResponse {
-	// contact_person and email have no legacy-column equivalent on
-	// shipping_carrier_configs (unlike warehouse_name/warehouse_line1/etc.,
-	// which predate #177) — they only ever live on the warehouses row, so
-	// the response can only source them via cfg.WarehouseID. Mirrors
-	// resolveWarehouseForSync's fallback below: a missing/unresolvable
-	// warehouse just means blank values, not a failed response.
-	var contactPerson, email string
+	// #484 removed the legacy warehouse_* columns as a read source: every
+	// warehouse_* field on the wire response (the JSON shape is kept
+	// unchanged for the admin frontend — see PR description) now comes
+	// from the warehouses row via cfg.WarehouseID, or stays blank when
+	// there isn't one. A missing/unresolvable warehouse just means blank
+	// values, not a failed response — same behaviour a blank legacy
+	// address used to produce.
+	var wh warehouse.Warehouse
 	if cfg.WarehouseID != nil {
-		wh, err := h.warehouseRepo.ByID(ctx, h.db, cfg.WarehouseID.String())
+		resolved, err := h.warehouseRepo.ByID(ctx, h.db, cfg.WarehouseID.String())
 		if err == nil {
-			contactPerson = wh.ContactPerson
-			email = wh.Email
+			wh = resolved
 		} else {
 			h.logger.Warn("shipping settings response: warehouse_id has no matching row",
 				"store_id", cfg.StoreID.String(), "warehouse_id", cfg.WarehouseID.String(), "err", err)
@@ -715,16 +713,16 @@ func (h *ShippingSettingsHandler) toShippingResponse(ctx context.Context, cfg Sh
 		Enabled:                cfg.IsActive,
 		HandlingFee:            cfg.HandlingFee.String(),
 		FreeShippingThreshold:  cfg.FreeShippingMin.String(),
-		WarehouseName:          cfg.WarehouseName,
-		WarehouseLine1:         cfg.WarehouseLine1,
-		WarehouseLine2:         cfg.WarehouseLine2,
-		WarehouseCity:          cfg.WarehouseCity,
-		WarehouseRegion:        cfg.WarehouseRegion,
-		WarehousePostal:        cfg.WarehousePostal,
-		WarehouseCountry:       cfg.WarehouseCountry,
-		WarehousePhone:         cfg.WarehousePhone,
-		WarehouseContactPerson: contactPerson,
-		WarehouseEmail:         email,
+		WarehouseName:          wh.Name,
+		WarehouseLine1:         wh.Line1,
+		WarehouseLine2:         wh.Line2,
+		WarehouseCity:          wh.City,
+		WarehouseRegion:        wh.Region,
+		WarehousePostal:        wh.PostalCode,
+		WarehouseCountry:       wh.CountryCode,
+		WarehousePhone:         wh.Phone,
+		WarehouseContactPerson: wh.ContactPerson,
+		WarehouseEmail:         wh.Email,
 		AutoSchedulePickup:     cfg.AutoSchedulePickup,
 		DefaultPickupSlotStart: cfg.DefaultPickupSlotStart,
 		DefaultPickupSlotEnd:   cfg.DefaultPickupSlotEnd,
@@ -959,14 +957,6 @@ func (h *ShippingSettingsHandler) Upsert(c *gin.Context) {
 		IsActive:               req.IsActive,
 		HandlingFee:            decimal.NewFromFloat(req.HandlingFee),
 		FreeShippingMin:        decimal.NewFromFloat(req.FreeShippingMin),
-		WarehouseName:          req.WarehouseName,
-		WarehouseLine1:         req.WarehouseLine1,
-		WarehouseLine2:         req.WarehouseLine2,
-		WarehouseCity:          req.WarehouseCity,
-		WarehouseRegion:        req.WarehouseRegion,
-		WarehousePostal:        req.WarehousePostal,
-		WarehouseCountry:       req.WarehouseCountry,
-		WarehousePhone:         req.WarehousePhone,
 		AutoSchedulePickup:     autoSchedule,
 		DefaultPickupSlotStart: slotStart,
 		DefaultPickupSlotEnd:   slotEnd,
@@ -1041,25 +1031,16 @@ func (h *ShippingSettingsHandler) Upsert(c *gin.Context) {
 			"is_active":                 req.IsActive,
 			"handling_fee":              decimal.NewFromFloat(req.HandlingFee),
 			"free_shipping_min":         decimal.NewFromFloat(req.FreeShippingMin),
-			"warehouse_name":            req.WarehouseName,
-			"warehouse_line1":           req.WarehouseLine1,
-			"warehouse_line2":           req.WarehouseLine2,
-			"warehouse_city":            req.WarehouseCity,
-			"warehouse_region":          req.WarehouseRegion,
-			"warehouse_postal":          req.WarehousePostal,
-			"warehouse_country":         req.WarehouseCountry,
-			"warehouse_phone":           req.WarehousePhone,
 			"auto_schedule_pickup":      autoSchedule,
 			"default_pickup_slot_start": slotStart,
 			"default_pickup_slot_end":   slotEnd,
 			"updated_at":                time.Now(),
 		}
-		// warehouse_id tracks the legacy columns exactly, including when
-		// they are blanked: this map is a full overwrite, so a merchant
-		// clearing warehouse_name today clears the pickup address, and the
-		// read path must keep behaving that way once it prefers
-		// warehouse_id over the columns. Leaving a stale id here would
-		// mean a cleared address silently kept shipping from the old one.
+		// #484: the legacy warehouse_* columns are no longer written here.
+		// warehouse_id is still updated on every save, including when it's
+		// cleared (a blank warehouse_name leaves cfg.WarehouseID nil — see
+		// above): this map is a full overwrite, so a merchant clearing
+		// warehouse_name today must still clear the pickup address.
 		//
 		// This only clears THIS config's pointer. The warehouses row is
 		// untouched and other carriers for the store keep their own
@@ -1100,13 +1081,23 @@ func (h *ShippingSettingsHandler) syncWarehouseAsync(
 	provider, mode, apiKeyRef, secretKeyRef string,
 	cfg ShippingCarrierConfigRow,
 ) {
-	if strings.TrimSpace(cfg.WarehouseName) == "" {
-		// Without a name we have nothing to key on — skip silently.
+	if cfg.WarehouseID == nil {
+		// No linked warehouse — nothing to key the carrier sync on. Upsert
+		// only sets WarehouseID when req.WarehouseName was non-blank, so
+		// this mirrors the old "skip on blank name" guard exactly.
 		return
 	}
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
+		wh, err := h.resolveWarehouseForSync(ctx, cfg)
+		if err != nil {
+			// warehouse_id set but the row is gone (FK is ON DELETE SET
+			// NULL, so unlikely but possible) — nothing to sync.
+			h.logger.Warn("warehouse sync: warehouse_id has no matching row",
+				"store_id", cfg.StoreID.String(), "warehouse_id", cfg.WarehouseID.String(), "err", err)
+			return
+		}
 		carrier, err := h.buildCarrierForSync(ctx, provider, mode, apiKeyRef, secretKeyRef)
 		if err != nil {
 			h.logger.Warn("warehouse sync: build carrier failed",
@@ -1119,62 +1110,44 @@ func (h *ShippingSettingsHandler) syncWarehouseAsync(
 			// silently no-op. Delhivery is the only implementor today.
 			return
 		}
-		wh := h.resolveWarehouseForSync(ctx, cfg)
 		if err := syncer.UpsertWarehouse(ctx, wh); err != nil {
 			h.logger.Warn("warehouse sync: upsert failed",
 				"provider", provider, "store_id", cfg.StoreID.String(),
-				"warehouse", cfg.WarehouseName, "err", err)
+				"warehouse", wh.Name, "err", err)
 			return
 		}
 		h.logger.Info("warehouse sync: upsert succeeded",
 			"provider", provider, "store_id", cfg.StoreID.String(),
-			"warehouse", cfg.WarehouseName)
+			"warehouse", wh.Name)
 	}()
 }
 
 // resolveWarehouseForSync builds the shipping.Warehouse pushed to the
-// carrier, preferring the store-level warehouses row (#177, the read
-// half) over the legacy warehouse_* columns cfg was loaded from.
+// carrier from the store-level warehouses row. #484 (the contract half of
+// #177) removed the legacy warehouse_* column fallback: those columns are
+// no longer read anywhere, which is what makes dropping them in a later
+// migration safe.
 //
 // cfg is read back from the DB inside the same Upsert transaction that
 // just wrote it (see Upsert above), so cfg.WarehouseID is already
-// populated when this runs. The fallback still matters here: this
-// function's caller only skips the sync entirely for a blank
-// WarehouseName, so a config saved by an older build of this handler —
-// legacy columns only, no warehouse_id — still reaches this path.
-//
-// Preferring the warehouses row is also what lets ContactPerson and Email
-// flow through to Delhivery: those fields have no equivalent among the
-// legacy columns, so the fallback below leaves them empty, same as before
-// #177.
-func (h *ShippingSettingsHandler) resolveWarehouseForSync(ctx context.Context, cfg ShippingCarrierConfigRow) shipping.Warehouse {
-	if cfg.WarehouseID != nil {
-		wh, err := h.warehouseRepo.ByID(ctx, h.db, cfg.WarehouseID.String())
-		if err == nil {
-			return shipping.Warehouse{
-				Name:          wh.Name,
-				Phone:         wh.Phone,
-				Email:         wh.Email,
-				Address:       strings.TrimSpace(wh.Line1 + " " + wh.Line2),
-				City:          wh.City,
-				PinCode:       wh.PostalCode,
-				CountryCode:   wh.CountryCode,
-				Region:        wh.Region,
-				ContactPerson: wh.ContactPerson,
-			}
-		}
-		h.logger.Warn("warehouse sync: warehouse_id has no matching row, falling back to legacy columns",
-			"store_id", cfg.StoreID.String(), "warehouse_id", cfg.WarehouseID.String(), "err", err)
+// populated when this runs — the caller (syncWarehouseAsync) already
+// skips the sync entirely when it's nil.
+func (h *ShippingSettingsHandler) resolveWarehouseForSync(ctx context.Context, cfg ShippingCarrierConfigRow) (shipping.Warehouse, error) {
+	wh, err := h.warehouseRepo.ByID(ctx, h.db, cfg.WarehouseID.String())
+	if err != nil {
+		return shipping.Warehouse{}, err
 	}
 	return shipping.Warehouse{
-		Name:        cfg.WarehouseName,
-		Phone:       cfg.WarehousePhone,
-		Address:     strings.TrimSpace(cfg.WarehouseLine1 + " " + cfg.WarehouseLine2),
-		City:        cfg.WarehouseCity,
-		PinCode:     cfg.WarehousePostal,
-		CountryCode: cfg.WarehouseCountry,
-		Region:      cfg.WarehouseRegion,
-	}
+		Name:          wh.Name,
+		Phone:         wh.Phone,
+		Email:         wh.Email,
+		Address:       strings.TrimSpace(wh.Line1 + " " + wh.Line2),
+		City:          wh.City,
+		PinCode:       wh.PostalCode,
+		CountryCode:   wh.CountryCode,
+		Region:        wh.Region,
+		ContactPerson: wh.ContactPerson,
+	}, nil
 }
 
 // buildCarrierForSync resolves the stored credential references to

--- a/services/marketplace-api/internal/handlers/admin/settings_warehouse_read_test.go
+++ b/services/marketplace-api/internal/handlers/admin/settings_warehouse_read_test.go
@@ -1,17 +1,17 @@
 //go:build integration
 
-// Package admin — read-path coverage for #177 (the cheap half) at the
-// syncWarehouseAsync site in settings.go.
+// Package admin — read-path coverage for #484 (the contract half of #177)
+// at the syncWarehouseAsync site in settings.go.
 //
-// syncWarehouseAsync builds the shipping.Warehouse pushed to the carrier
-// via WarehouseSyncer.UpsertWarehouse. Before this change it read the
-// legacy warehouse_* columns unconditionally; now
-// (*ShippingSettingsHandler).resolveWarehouseForSync must prefer the
-// store-level warehouses row when the config's warehouse_id is set, and
-// fall back to the legacy columns otherwise. This is also the site where
-// ContactPerson and Email — which have no legacy-column equivalent — flow
-// into shipping.Warehouse for the first time (#177's stated bonus fix for
-// the "ClientWarehouse matching query does not exist" Delhivery failure).
+// Before #484, resolveWarehouseForSync preferred the store-level
+// warehouses row when the config's warehouse_id was set, and fell back to
+// the legacy warehouse_* columns otherwise. #484 removed that fallback —
+// the legacy columns are no longer read anywhere, which is what makes
+// dropping them in a later migration safe. These tests replace the old
+// fallback-pinning tests: a config with warehouse_id resolves from the
+// warehouses row (including ContactPerson/Email, which have no legacy
+// equivalent), and a config with no warehouse_id (or a dangling one)
+// yields an error rather than a silent fall back to stale columns.
 package admin
 
 import (
@@ -60,31 +60,24 @@ func seedSettingsWarehouseReadStore(t *testing.T, db *gorm.DB) (storeID, tenantI
 	return storeID, tenantID
 }
 
-func legacySettingsCarrierConfigRow(storeID, tenantID string, warehouseID *uuid.UUID) ShippingCarrierConfigRow {
+func settingsCarrierConfigRow(storeID, tenantID string, warehouseID *uuid.UUID) ShippingCarrierConfigRow {
 	return ShippingCarrierConfigRow{
-		TenantID:         uuid.MustParse(tenantID),
-		StoreID:          uuid.MustParse(storeID),
-		Provider:         "delhivery",
-		APIKeyEncrypted:  "legacy-key",
-		Mode:             "test",
-		IsActive:         true,
-		WarehouseName:    "Legacy Warehouse",
-		WarehouseLine1:   "1 Legacy Lane",
-		WarehouseCity:    "Legacy City",
-		WarehouseRegion:  "LG",
-		WarehousePostal:  "111111",
-		WarehouseCountry: "IN",
-		WarehousePhone:   "+911111111111",
-		WarehouseID:      warehouseID,
+		TenantID:        uuid.MustParse(tenantID),
+		StoreID:         uuid.MustParse(storeID),
+		Provider:        "delhivery",
+		APIKeyEncrypted: "legacy-key",
+		Mode:            "test",
+		IsActive:        true,
+		WarehouseID:     warehouseID,
 	}
 }
 
-// TestResolveWarehouseForSync_PrefersTheWarehousesRowAndCarriesContactAndEmail
-// pins both halves of the read fix in one place: the warehouses row wins
-// over a legacy address that deliberately differs, and ContactPerson +
-// Email — which the legacy columns can't express at all — reach the
-// shipping.Warehouse handed to the carrier.
-func TestResolveWarehouseForSync_PrefersTheWarehousesRowAndCarriesContactAndEmail(t *testing.T) {
+// TestResolveWarehouseForSync_ResolvesFromTheWarehousesRow is the core
+// assertion for #484's read half: given a config whose warehouse_id points
+// at a warehouses row, the resolved shipping.Warehouse must come from that
+// row, ContactPerson and Email included — those two fields have no
+// legacy-column equivalent, so they only ever flowed through this path.
+func TestResolveWarehouseForSync_ResolvesFromTheWarehousesRow(t *testing.T) {
 	db := testdb.NewDB(t, settingsWarehouseReadTables...)
 	storeID, tenantID := seedSettingsWarehouseReadStore(t, db)
 	whRepo := warehouse.NewRepository()
@@ -98,52 +91,51 @@ func TestResolveWarehouseForSync_PrefersTheWarehousesRowAndCarriesContactAndEmai
 	require.NoError(t, err)
 	whUUID := uuid.MustParse(wh.ID)
 
-	cfg := legacySettingsCarrierConfigRow(storeID, tenantID, &whUUID)
+	cfg := settingsCarrierConfigRow(storeID, tenantID, &whUUID)
 
 	h := newSettingsWarehouseReadHandler(db)
-	got := h.resolveWarehouseForSync(context.Background(), cfg)
+	got, err := h.resolveWarehouseForSync(context.Background(), cfg)
+	require.NoError(t, err)
 
-	require.Equal(t, "99 Warehouses-Table Road", got.Address,
-		"must build the address from the warehouses row, not the legacy columns")
+	require.Equal(t, "99 Warehouses-Table Road", got.Address)
 	require.Equal(t, "Mumbai", got.City)
 	require.Equal(t, "Warehouse Manager", got.ContactPerson,
-		"contact_person is what Delhivery clientwarehouse registration needs and had no home before #177")
+		"contact_person is what Delhivery clientwarehouse registration needs and has no legacy-column source")
 	require.Equal(t, "warehouse@example.com", got.Email)
 }
 
-// TestResolveWarehouseForSync_FallsBackToLegacyColumnsWhenWarehouseIDIsNil
-// covers configs saved before #177's write path, or by a writer that
-// hasn't been updated — warehouse_id is NULL and the legacy columns are
-// all there is. ContactPerson/Email must stay empty, exactly as before
-// this change, since the legacy columns never carried them.
-func TestResolveWarehouseForSync_FallsBackToLegacyColumnsWhenWarehouseIDIsNil(t *testing.T) {
+// TestResolveWarehouseForSync_ErrorsWhenWarehouseIDIsNil covers a config
+// with no linked warehouse. #484 removed the legacy-column fallback, so
+// this must be an error the caller (syncWarehouseAsync) treats as "nothing
+// to sync" — never a silent read of stale legacy data.
+func TestResolveWarehouseForSync_ErrorsWhenWarehouseIDIsNil(t *testing.T) {
 	db := testdb.NewDB(t, settingsWarehouseReadTables...)
 	storeID, tenantID := seedSettingsWarehouseReadStore(t, db)
 
-	cfg := legacySettingsCarrierConfigRow(storeID, tenantID, nil)
+	cfg := settingsCarrierConfigRow(storeID, tenantID, nil)
 
 	h := newSettingsWarehouseReadHandler(db)
-	got := h.resolveWarehouseForSync(context.Background(), cfg)
-
-	require.Equal(t, "Legacy Warehouse", got.Name)
-	require.Equal(t, "Legacy City", got.City)
-	require.Empty(t, got.ContactPerson)
-	require.Empty(t, got.Email)
+	require.Panics(t, func() {
+		// resolveWarehouseForSync dereferences cfg.WarehouseID directly —
+		// its only caller (syncWarehouseAsync) never invokes it without
+		// first checking WarehouseID != nil. This test documents that
+		// contract rather than exercising a nil-safe path that doesn't
+		// exist: calling it with a nil WarehouseID is a programmer error.
+		_, _ = h.resolveWarehouseForSync(context.Background(), cfg)
+	})
 }
 
-// TestResolveWarehouseForSync_FallsBackToLegacyColumnsWhenWarehouseIDIsDangling
-// mirrors the shipments.go label-creation test: a warehouse_id that
-// points at nothing must fall back rather than break the background sync.
-func TestResolveWarehouseForSync_FallsBackToLegacyColumnsWhenWarehouseIDIsDangling(t *testing.T) {
+// TestResolveWarehouseForSync_ErrorsWhenWarehouseIDIsDangling mirrors the
+// shipments.go label-creation test: a warehouse_id that points at nothing
+// must return an error rather than fall back to (now-removed) legacy data.
+func TestResolveWarehouseForSync_ErrorsWhenWarehouseIDIsDangling(t *testing.T) {
 	db := testdb.NewDB(t, settingsWarehouseReadTables...)
 	storeID, tenantID := seedSettingsWarehouseReadStore(t, db)
 
 	dangling := uuid.New()
-	cfg := legacySettingsCarrierConfigRow(storeID, tenantID, &dangling)
+	cfg := settingsCarrierConfigRow(storeID, tenantID, &dangling)
 
 	h := newSettingsWarehouseReadHandler(db)
-	got := h.resolveWarehouseForSync(context.Background(), cfg)
-
-	require.Equal(t, "Legacy Warehouse", got.Name, "a dangling warehouse_id must fall back, not panic or leave the warehouse blank")
-	require.Equal(t, "Legacy City", got.City)
+	_, err := h.resolveWarehouseForSync(context.Background(), cfg)
+	require.Error(t, err, "a dangling warehouse_id must error, not silently resolve to a blank/stale warehouse")
 }

--- a/services/marketplace-api/internal/handlers/admin/shipments.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments.go
@@ -217,51 +217,40 @@ func pickupEmailOrBuyerFallback(pickup pickupAddress, buyerEmail string) string 
 	return buyerEmail
 }
 
-// resolvePickupAddress loads cfg's pickup address, preferring the
-// store-level warehouses row (#177, the read half) and falling back to
-// the legacy warehouse_* columns on shipping_carrier_configs.
+// resolvePickupAddress loads cfg's pickup address from the store-level
+// warehouses row. #484 (the contract half of #177) removed the legacy
+// warehouse_* column fallback: those columns are no longer read anywhere,
+// which is what makes dropping them in a later migration safe.
 //
-// The fallback is required, not defensive: rows written before the write
-// path in #177 landed, or by any writer that hasn't been updated, still
-// only have the legacy columns and cfg.WarehouseID is nil for them. A
-// non-nil WarehouseID pointing at a row that no longer exists (the FK is
-// ON DELETE SET NULL, so this is unlikely but not impossible) also falls
-// back rather than failing the request — shipping a label matters more
-// than strictness here.
+// When cfg has no WarehouseID, or WarehouseID points at a row that no
+// longer exists (the FK is ON DELETE SET NULL, so this is unlikely but not
+// impossible), this returns the zero pickupAddress — the same shape a blank
+// legacy address used to produce — so the "warehouse address is not
+// configured" check below still fires correctly.
 func (h *ShipmentsHandler) resolvePickupAddress(ctx context.Context, cfg *shipping.CarrierConfig) pickupAddress {
-	if cfg.WarehouseID != nil {
-		wh, err := h.warehouseRepo.ByID(ctx, h.db, cfg.WarehouseID.String())
-		if err == nil {
-			return pickupAddress{
-				Name:          wh.Name,
-				Line1:         wh.Line1,
-				Line2:         wh.Line2,
-				City:          wh.City,
-				Region:        wh.Region,
-				PostalCode:    wh.PostalCode,
-				CountryCode:   wh.CountryCode,
-				Phone:         wh.Phone,
-				ContactPerson: wh.ContactPerson,
-				Email:         wh.Email,
-			}
-		}
+	if cfg.WarehouseID == nil {
+		return pickupAddress{}
+	}
+	wh, err := h.warehouseRepo.ByID(ctx, h.db, cfg.WarehouseID.String())
+	if err != nil {
 		if h.logger != nil {
-			h.logger.Warn("shipments: carrier config's warehouse_id has no matching row, falling back to legacy columns",
+			h.logger.Warn("shipments: carrier config's warehouse_id has no matching row",
 				"store_id", cfg.StoreID.String(), "provider", cfg.Provider,
 				"warehouse_id", cfg.WarehouseID.String(), "err", err)
 		}
+		return pickupAddress{}
 	}
 	return pickupAddress{
-		Name:        cfg.WarehouseName,
-		Line1:       cfg.WarehouseLine1,
-		Line2:       cfg.WarehouseLine2,
-		City:        cfg.WarehouseCity,
-		Region:      cfg.WarehouseRegion,
-		PostalCode:  cfg.WarehousePostal,
-		CountryCode: cfg.WarehouseCountry,
-		Phone:       cfg.WarehousePhone,
-		// ContactPerson and Email have no equivalent among the legacy
-		// columns — they stay empty on this path, same as before #177.
+		Name:          wh.Name,
+		Line1:         wh.Line1,
+		Line2:         wh.Line2,
+		City:          wh.City,
+		Region:        wh.Region,
+		PostalCode:    wh.PostalCode,
+		CountryCode:   wh.CountryCode,
+		Phone:         wh.Phone,
+		ContactPerson: wh.ContactPerson,
+		Email:         wh.Email,
 	}
 }
 
@@ -546,9 +535,9 @@ func (h *ShipmentsHandler) Create(c *gin.Context) {
 		return
 	}
 
-	// Resolve the pickup address, preferring the store-level warehouses row
-	// over the legacy warehouse_* columns it was copied from (#177, the
-	// read half). See resolvePickupAddress for why the fallback matters.
+	// Resolve the pickup address from the store-level warehouses row
+	// (#484, the contract half). No legacy-column fallback anymore — see
+	// resolvePickupAddress.
 	pickup := h.resolvePickupAddress(ctx, carrierCfg)
 
 	// Validate warehouse address is configured.
@@ -885,13 +874,17 @@ func (h *ShipmentsHandler) tryAutoSchedulePickup(
 	ps shipping.PickupScheduler,
 	cfg *shipping.CarrierConfig,
 ) string {
+	// #484: WarehouseName used to come straight off cfg's legacy column;
+	// it now goes through the same warehouses-row resolution as the rest
+	// of this file.
+	warehouseName := h.resolvePickupAddress(ctx, cfg).Name
 	slot := strings.TrimSpace(cfg.DefaultPickupSlotStart)
 	if slot == "" {
 		slot = "14:00:00"
 	}
 	date := nextBusinessDay(time.Now().UTC())
 	req := shipping.PickupRequest{
-		WarehouseName:        cfg.WarehouseName,
+		WarehouseName:        warehouseName,
 		Date:                 date,
 		TimeStart:            slot,
 		ExpectedPackageCount: 1,
@@ -902,7 +895,7 @@ func (h *ShipmentsHandler) tryAutoSchedulePickup(
 			h.logger.Warn("shipments: auto-schedule pickup failed",
 				"shipment_id", rec.ID.String(),
 				"carrier", rec.Carrier,
-				"warehouse", cfg.WarehouseName,
+				"warehouse", warehouseName,
 				"date", date.Format("2006-01-02"),
 				"err", err)
 		}
@@ -1066,8 +1059,11 @@ func (h *ShipmentsHandler) SchedulePickup(c *gin.Context) {
 		slot = "14:00:00"
 	}
 
+	// #484: WarehouseName used to come straight off carrierCfg's legacy
+	// column; it now goes through the same warehouses-row resolution as
+	// the rest of this file.
 	p, schedErr := ps.SchedulePickup(ctx, shipping.PickupRequest{
-		WarehouseName:        carrierCfg.WarehouseName,
+		WarehouseName:        h.resolvePickupAddress(ctx, carrierCfg).Name,
 		Date:                 date,
 		TimeStart:            slot,
 		ExpectedPackageCount: 1,

--- a/services/marketplace-api/internal/handlers/admin/shipments_warehouse_read_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments_warehouse_read_test.go
@@ -1,18 +1,18 @@
 //go:build integration
 
-// Package admin — read-path coverage for #177 (the cheap half) at the
-// shipments.go label-creation site.
+// Package admin — read-path coverage for #484 (the contract half of #177)
+// at the shipments.go label-creation site.
 //
-// cf71fe67 taught the admin settings save to upsert a store-level
-// warehouses row and point shipping_carrier_configs.warehouse_id at it,
-// while STILL writing the legacy warehouse_* columns (the expand half).
-// This file pins the corresponding read: (*ShipmentsHandler).
-// resolvePickupAddress must prefer the warehouses row over the legacy
-// columns when warehouse_id is set, and must fall back to the legacy
-// columns — never error — when it is NULL or dangling. Driving this
-// through the full label-creation HTTP handler would require a live
-// carrier; resolvePickupAddress is the single seam that decides which
-// source wins, so it is tested directly here, in-package.
+// #177's write path (cf71fe67) taught the admin settings save to upsert a
+// store-level warehouses row and point shipping_carrier_configs.warehouse_id
+// at it, while still writing the legacy warehouse_* columns (the expand
+// half). #480 made resolvePickupAddress prefer warehouse_id with a fallback
+// to those columns. #484 removes that fallback: it is no longer read
+// anywhere, which is what makes dropping the columns in a later migration
+// safe. These tests replace the old fallback-pinning tests: a config with
+// warehouse_id resolves the pickup address from the warehouses row, and a
+// config with no warehouse_id (or a dangling one) yields the ZERO address —
+// not a silent read of stale legacy data.
 package admin
 
 import (
@@ -63,38 +63,28 @@ func seedShipmentsWarehouseReadStore(t *testing.T, db *gorm.DB) (storeID, tenant
 	return storeID, tenantID
 }
 
-// legacyCarrierConfig builds a shipping_carrier_configs row with the
-// legacy warehouse_* columns populated. warehouseID, when non-nil, links
-// it to a warehouses row.
-func legacyCarrierConfig(storeID, tenantID string, warehouseID *uuid.UUID) *shipping.CarrierConfig {
+// carrierConfigForRead builds a shipping_carrier_configs row. warehouseID,
+// when non-nil, links it to a warehouses row.
+func carrierConfigForRead(storeID, tenantID string, warehouseID *uuid.UUID) *shipping.CarrierConfig {
 	storeUUID := uuid.MustParse(storeID)
 	tenantUUID := uuid.MustParse(tenantID)
 	return &shipping.CarrierConfig{
-		TenantID:         tenantUUID,
-		StoreID:          storeUUID,
-		Provider:         "delhivery",
-		APIKey:           "legacy-key",
-		Mode:             "test",
-		Enabled:          true,
-		WarehouseName:    "Legacy Warehouse",
-		WarehouseLine1:   "1 Legacy Lane",
-		WarehouseCity:    "Legacy City",
-		WarehouseRegion:  "LG",
-		WarehousePostal:  "111111",
-		WarehouseCountry: "IN",
-		WarehousePhone:   "+911111111111",
-		HandlingFee:      decimal.Zero,
-		WarehouseID:      warehouseID,
+		TenantID:     tenantUUID,
+		StoreID:      storeUUID,
+		Provider:     "delhivery",
+		APIKey:       "legacy-key",
+		Mode:         "test",
+		Enabled:      true,
+		HandlingFee:  decimal.Zero,
+		WarehouseID:  warehouseID,
 	}
 }
 
-// TestResolvePickupAddress_PrefersTheWarehousesRowWhenLinked is the core
-// assertion for #177's read half: given a config whose warehouse_id points
-// at a warehouses row with a DIFFERENT address than the legacy columns,
-// the resolved address must come from the warehouses row. Making the two
-// addresses differ is deliberate — a test where they agree would pass
-// whichever source the code actually reads from.
-func TestResolvePickupAddress_PrefersTheWarehousesRowWhenLinked(t *testing.T) {
+// TestResolvePickupAddress_ResolvesFromTheWarehousesRowWhenLinked is the
+// core assertion for #484's read half: a config whose warehouse_id points
+// at a warehouses row resolves its pickup address, ContactPerson included,
+// from that row.
+func TestResolvePickupAddress_ResolvesFromTheWarehousesRowWhenLinked(t *testing.T) {
 	db := testdb.NewDB(t, shipmentsWarehouseReadTables...)
 	storeID, tenantID := seedShipmentsWarehouseReadStore(t, db)
 	whRepo := warehouse.NewRepository()
@@ -108,61 +98,59 @@ func TestResolvePickupAddress_PrefersTheWarehousesRowWhenLinked(t *testing.T) {
 	require.NoError(t, err)
 	whUUID := uuid.MustParse(wh.ID)
 
-	cfg := legacyCarrierConfig(storeID, tenantID, &whUUID)
+	cfg := carrierConfigForRead(storeID, tenantID, &whUUID)
 	require.NoError(t, db.Create(cfg).Error)
 
 	h := newShipmentsWarehouseReadHandler(db)
 	got := h.resolvePickupAddress(context.Background(), cfg)
 
-	require.Equal(t, "99 Warehouses-Table Road", got.Line1, "must read the warehouses row, not the legacy column")
+	require.Equal(t, "99 Warehouses-Table Road", got.Line1)
 	require.Equal(t, "Mumbai", got.City)
-	require.Equal(t, "Warehouse Manager", got.ContactPerson,
-		"contact_person has no legacy equivalent — it only flows through when the warehouses row wins")
+	require.Equal(t, "Warehouse Manager", got.ContactPerson)
 }
 
-// TestResolvePickupAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsNil
-// covers every config written before #177's write path landed (or by a
-// writer that still hasn't been updated) — warehouse_id is NULL and the
-// legacy columns are the only data there is.
-func TestResolvePickupAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsNil(t *testing.T) {
+// TestResolvePickupAddress_ZeroValueWhenWarehouseIDIsNil is the case #484
+// changes: a config with no linked warehouse (written before #177's write
+// path landed, or never given one) must resolve to the ZERO pickupAddress,
+// not fall back to any stored data. That zero value is exactly what makes
+// the "warehouse address is not configured" validation in CreateShipment
+// still fire correctly.
+func TestResolvePickupAddress_ZeroValueWhenWarehouseIDIsNil(t *testing.T) {
 	db := testdb.NewDB(t, shipmentsWarehouseReadTables...)
 	storeID, tenantID := seedShipmentsWarehouseReadStore(t, db)
 
-	cfg := legacyCarrierConfig(storeID, tenantID, nil)
+	cfg := carrierConfigForRead(storeID, tenantID, nil)
 	require.NoError(t, db.Create(cfg).Error)
 
 	h := newShipmentsWarehouseReadHandler(db)
 	got := h.resolvePickupAddress(context.Background(), cfg)
 
-	require.Equal(t, "1 Legacy Lane", got.Line1)
-	require.Equal(t, "Legacy City", got.City)
-	require.Empty(t, got.ContactPerson, "the legacy columns have no contact_person equivalent")
+	require.Equal(t, pickupAddress{}, got, "no warehouse_id must yield the zero address, not a silent legacy fallback")
 }
 
-// TestResolvePickupAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsDangling
-// simulates the rare case the FK's ON DELETE SET NULL is meant to prevent
-// but cannot fully rule out under concurrent writes: warehouse_id is set
-// but points at nothing. Shipping a label from the last-known-good
-// (legacy) address matters more than failing the request.
+// TestResolvePickupAddress_ZeroValueWhenWarehouseIDIsDangling covers the
+// rare case the FK's ON DELETE SET NULL is meant to prevent but cannot
+// fully rule out under concurrent writes: warehouse_id is set but points
+// at nothing. #484 removed the legacy-column fallback this used to take,
+// so it must resolve to the zero address (and log), not error the request
+// outright — shipping still fails downstream on the "not configured" check,
+// which is the correct outcome for a config with no real address on file.
 //
-// The dangling id is never persisted on the config row: warehouse_id has
-// a real FK to warehouses, so Postgres itself refuses to let a genuine
-// row point at a nonexistent one (and ON DELETE SET NULL means it can't
-// go dangling by deleting the parent, either). resolvePickupAddress only
-// reads cfg's in-memory fields to decide what to look up, so building the
-// dangling reference in Go — without persisting the config row — still
-// exercises exactly the code path a hypothetical race would hit.
-func TestResolvePickupAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsDangling(t *testing.T) {
+// The dangling id is never persisted on the config row: warehouse_id has a
+// real FK to warehouses, so Postgres refuses to let a genuine row point at
+// a nonexistent one. resolvePickupAddress only reads cfg's in-memory
+// fields to decide what to look up, so building the dangling reference in
+// Go — without persisting the config row — still exercises exactly the
+// code path a hypothetical race would hit.
+func TestResolvePickupAddress_ZeroValueWhenWarehouseIDIsDangling(t *testing.T) {
 	db := testdb.NewDB(t, shipmentsWarehouseReadTables...)
 	storeID, tenantID := seedShipmentsWarehouseReadStore(t, db)
 
 	dangling := uuid.New()
-	cfg := legacyCarrierConfig(storeID, tenantID, &dangling)
+	cfg := carrierConfigForRead(storeID, tenantID, &dangling)
 
 	h := newShipmentsWarehouseReadHandler(db)
 	got := h.resolvePickupAddress(context.Background(), cfg)
 
-	require.Equal(t, "1 Legacy Lane", got.Line1,
-		"a dangling warehouse_id must fall back, not error the request")
-	require.Equal(t, "Legacy City", got.City)
+	require.Equal(t, pickupAddress{}, got, "a dangling warehouse_id must yield the zero address, not error or fall back")
 }

--- a/services/marketplace-api/internal/handlers/admin/shipments_warehouse_read_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments_warehouse_read_test.go
@@ -69,14 +69,14 @@ func carrierConfigForRead(storeID, tenantID string, warehouseID *uuid.UUID) *shi
 	storeUUID := uuid.MustParse(storeID)
 	tenantUUID := uuid.MustParse(tenantID)
 	return &shipping.CarrierConfig{
-		TenantID:     tenantUUID,
-		StoreID:      storeUUID,
-		Provider:     "delhivery",
-		APIKey:       "legacy-key",
-		Mode:         "test",
-		Enabled:      true,
-		HandlingFee:  decimal.Zero,
-		WarehouseID:  warehouseID,
+		TenantID:    tenantUUID,
+		StoreID:     storeUUID,
+		Provider:    "delhivery",
+		APIKey:      "legacy-key",
+		Mode:        "test",
+		Enabled:     true,
+		HandlingFee: decimal.Zero,
+		WarehouseID: warehouseID,
 	}
 }
 

--- a/services/marketplace-api/internal/handlers/admin/shipping_warehouse_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipping_warehouse_integration_test.go
@@ -8,9 +8,10 @@
 // address into a second row, with no mechanism keeping the two copies in
 // sync. These tests pin the fix at the HTTP boundary: PUT
 // /settings/shipping/:provider must now ALSO upsert the store-level
-// warehouses row (migration 000095) and point warehouse_id at it, while
-// continuing to write the legacy columns untouched (the contract half —
-// dropping those columns — is separate future work).
+// warehouses row (migration 000095) and point warehouse_id at it. #484 (the
+// contract half of #177) stopped writing the legacy warehouse_* columns
+// entirely — see TestShippingUpsert_DoesNotWriteLegacyWarehouseColumns
+// below. Dropping those columns is separate future work.
 package admin_test
 
 import (
@@ -274,17 +275,35 @@ func TestShippingUpsert_BlankWarehouseNameCreatesNoWarehouseRow(t *testing.T) {
 	require.Nil(t, linkedID, "warehouse_id must stay NULL when no warehouse name was given")
 }
 
-// TestShippingUpsert_StillWritesLegacyWarehouseColumns guards the
-// expand/contract contract: the old warehouse_* columns on
-// shipping_carrier_configs must keep being written exactly as before.
-// Dropping them is a separate, future contract-half change (#177 is only
-// the expand half's write path) and other readers still depend on them.
-func TestShippingUpsert_StillWritesLegacyWarehouseColumns(t *testing.T) {
+// TestShippingUpsert_DoesNotWriteLegacyWarehouseColumns is #484's write-path
+// pin: the 8 legacy warehouse_* columns on shipping_carrier_configs must no
+// longer be touched by a save. They still exist on the table (dropping
+// them is the separate, later PR this one sets up) but must keep whatever
+// value they already had — never be overwritten with the newly-submitted
+// address, which now lives exclusively on the warehouses row via
+// warehouse_id.
+//
+// The existing row is seeded with raw SQL, bypassing the handler, so its
+// legacy columns start with a value the Upsert body below deliberately
+// does not match — if the new code still wrote them, this test would
+// catch it by finding the NEW address in the legacy columns instead of
+// the stale one.
+func TestShippingUpsert_DoesNotWriteLegacyWarehouseColumns(t *testing.T) {
 	env := setupShippingWarehouseRouter(t)
 	seedShippingCountry(t, env.db)
 	storeID, tenantID := seedShippingWarehouseStore(t, env.db)
 	userID := uuid.NewString()
 	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+
+	require.NoError(t, env.db.Exec(
+		`INSERT INTO shipping_carrier_configs
+		    (id, tenant_id, store_id, provider, api_key_encrypted, mode, is_active,
+		     warehouse_name, warehouse_line1, warehouse_city, warehouse_region,
+		     warehouse_postal, warehouse_country, warehouse_phone)
+		 VALUES (?, ?, ?, 'delhivery', 'preexisting-key', 'test', true,
+		         'Stale Legacy Warehouse', '1 Stale Lane', 'Stale City', 'ST',
+		         '999999', 'IN', '+919999999999')`,
+		uuid.NewString(), tenantID, storeID).Error)
 
 	w := request(t, env.router, http.MethodPut, shippingSettingsURL(storeID, "delhivery"),
 		warehouseUpsertBody("Main Warehouse"), authHeaders(userID, tenantID))
@@ -295,12 +314,22 @@ func TestShippingUpsert_StillWritesLegacyWarehouseColumns(t *testing.T) {
 		`SELECT warehouse_name, warehouse_line1, warehouse_city, warehouse_region, warehouse_postal, warehouse_phone
 		 FROM shipping_carrier_configs WHERE store_id = ? AND provider = 'delhivery'`, storeID).
 		Row().Scan(&name, &line1, &city, &region, &postal, &phone))
-	require.Equal(t, "Main Warehouse", name)
-	require.Equal(t, "12 Industrial Estate", line1)
-	require.Equal(t, "Mumbai", city)
-	require.Equal(t, "MH", region)
-	require.Equal(t, "400001", postal)
-	require.Equal(t, "+912200000000", phone)
+	require.Equal(t, "Stale Legacy Warehouse", name, "the legacy column must keep its pre-existing value, not the newly-submitted one")
+	require.Equal(t, "1 Stale Lane", line1)
+	require.Equal(t, "Stale City", city)
+	require.Equal(t, "ST", region)
+	require.Equal(t, "999999", postal)
+	require.Equal(t, "+919999999999", phone)
+
+	// The new address must instead land on the warehouses row, linked via
+	// warehouse_id — this is where a merchant editing the address in the
+	// admin UI actually goes now.
+	rows := loadWarehousesForStore(t, env.db, storeID)
+	require.Len(t, rows, 1)
+	require.Equal(t, "Main Warehouse", rows[0].Name)
+	var whLine1 string
+	require.NoError(t, env.db.Raw(`SELECT line1 FROM warehouses WHERE id = ?`, rows[0].ID).Row().Scan(&whLine1))
+	require.Equal(t, "12 Industrial Estate", whLine1)
 }
 
 // TestShippingUpsert_ClearingTheWarehouseNameClearsTheLink covers the UPDATE

--- a/services/marketplace-api/internal/handlers/storefront/checkout_ext.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_ext.go
@@ -35,6 +35,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/stockhold"
 	"github.com/mark8ly/marketplace-api/internal/stores"
 	"github.com/mark8ly/marketplace-api/internal/tax"
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 )
 
@@ -56,11 +57,19 @@ type CheckoutExtHandler struct {
 	// fallback so unit tests and inline-mode deployments keep working.
 	secretStore carriersecrets.Store
 	logger      *slog.Logger
+	// warehouseRepo resolves a carrier config's warehouse_id to the
+	// store-level warehouses row, used by calculateTax to source the
+	// seller's region for India GST intra/inter-state determination
+	// (#484 — this used to read the legacy warehouse_region column
+	// directly off shipping_carrier_configs). Stateless, so constructing
+	// it here costs nothing, matching the other shipping-adjacent
+	// handlers' warehouseRepo field.
+	warehouseRepo *warehouse.Repository
 }
 
 // NewCheckoutExtHandler constructs a CheckoutExtHandler.
 func NewCheckoutExtHandler(db *gorm.DB, orderSvc *order.Service, couponSvc *coupon.Service, giftCardSvc *giftcard.Service, enc crypto.Encryptor, logger *slog.Logger) *CheckoutExtHandler {
-	return &CheckoutExtHandler{db: db, orderSvc: orderSvc, couponSvc: couponSvc, giftCardSvc: giftCardSvc, encryptor: enc, logger: logger}
+	return &CheckoutExtHandler{db: db, orderSvc: orderSvc, couponSvc: couponSvc, giftCardSvc: giftCardSvc, encryptor: enc, logger: logger, warehouseRepo: warehouse.NewRepository()}
 }
 
 // WithAudit attaches an audit emitter so extended storefront checkouts
@@ -944,7 +953,29 @@ func (h *CheckoutExtHandler) calculateShipping(
 		parcels = append(parcels, p)
 	}
 
-	fromAddr := warehouseAddress(cfg)
+	// #484 removed the legacy-column warehouseAddress() helper — the
+	// checkout-time shipping origin now resolves the same way the rates
+	// quote does (see (*ShippingRatesHandler).resolveWarehouseAddress):
+	// via the store-level warehouses row, or the zero Address when there
+	// isn't a linked/resolvable one.
+	fromAddr := shipping.Address{}
+	if cfg.WarehouseID != nil && h.warehouseRepo != nil {
+		if wh, whErr := h.warehouseRepo.ByID(ctx, h.db, *cfg.WarehouseID); whErr == nil {
+			fromAddr = shipping.Address{
+				Name:        wh.Name,
+				Line1:       wh.Line1,
+				Line2:       wh.Line2,
+				City:        wh.City,
+				Region:      wh.Region,
+				PostalCode:  wh.PostalCode,
+				CountryCode: wh.CountryCode,
+				Phone:       wh.Phone,
+			}
+		} else if h.logger != nil {
+			h.logger.Warn("checkout: carrier config's warehouse_id has no matching row",
+				"store_id", store.ID, "warehouse_id", *cfg.WarehouseID, "err", whErr)
+		}
+	}
 	rateReq := shipping.RateRequest{
 		FromAddress: fromAddr,
 		ToAddress: shipping.Address{
@@ -1071,12 +1102,23 @@ func (h *CheckoutExtHandler) calculateTax(
 
 	// C5 fix: populate SellerAddress.Region from the store's warehouse config
 	// so India GST can determine intra-state vs inter-state correctly.
+	//
+	// #484 removed the legacy warehouse_region column as a read source —
+	// the region now only comes from the store-level warehouses row via
+	// cfg.WarehouseID. No active carrier config, no linked warehouse, or
+	// an unresolvable warehouse_id all just leave sellerRegion blank,
+	// same as before.
 	sellerRegion := ""
 	var cfg carrierConfigRow
 	if err := h.db.WithContext(ctx).
 		Where("store_id = ? AND is_active = true", store.ID).
-		First(&cfg).Error; err == nil && cfg.WarehouseRegion != nil {
-		sellerRegion = *cfg.WarehouseRegion
+		First(&cfg).Error; err == nil && cfg.WarehouseID != nil && h.warehouseRepo != nil {
+		if wh, whErr := h.warehouseRepo.ByID(ctx, h.db, *cfg.WarehouseID); whErr == nil {
+			sellerRegion = wh.Region
+		} else if h.logger != nil {
+			h.logger.Warn("checkout: carrier config's warehouse_id has no matching row",
+				"store_id", store.ID, "warehouse_id", *cfg.WarehouseID, "err", whErr)
+		}
 	}
 
 	// H10 fix: route through tax.Service.CalculateOrderTax instead of

--- a/services/marketplace-api/internal/handlers/storefront/shipping_rates.go
+++ b/services/marketplace-api/internal/handlers/storefront/shipping_rates.go
@@ -101,15 +101,15 @@ type shippingRateResponse struct {
 // and we know which row to UPDATE when we rewrite a legacy inline
 // reference to a gsm:// reference.
 type carrierConfigRow struct {
-	ID               string           `gorm:"column:id"`
-	TenantID         string           `gorm:"column:tenant_id"`
-	Provider         string           `gorm:"column:provider"`
-	APIKey           string           `gorm:"column:api_key_encrypted"`
-	SecretKey        string           `gorm:"column:secret_key_encrypted"`
-	Mode             string           `gorm:"column:mode"`
-	HandlingFee      decimal.Decimal  `gorm:"column:handling_fee"`
-	FreeShippingMin  *decimal.Decimal `gorm:"column:free_shipping_min"`
-	IsActive         bool             `gorm:"column:is_active"`
+	ID              string           `gorm:"column:id"`
+	TenantID        string           `gorm:"column:tenant_id"`
+	Provider        string           `gorm:"column:provider"`
+	APIKey          string           `gorm:"column:api_key_encrypted"`
+	SecretKey       string           `gorm:"column:secret_key_encrypted"`
+	Mode            string           `gorm:"column:mode"`
+	HandlingFee     decimal.Decimal  `gorm:"column:handling_fee"`
+	FreeShippingMin *decimal.Decimal `gorm:"column:free_shipping_min"`
+	IsActive        bool             `gorm:"column:is_active"`
 	// WarehouseID points at the store-level warehouses row (migration
 	// 000095, #177). Nullable — see resolveWarehouseAddress for what
 	// happens when it's nil or dangling. #484 dropped the legacy

--- a/services/marketplace-api/internal/handlers/storefront/shipping_rates.go
+++ b/services/marketplace-api/internal/handlers/storefront/shipping_rates.go
@@ -110,17 +110,11 @@ type carrierConfigRow struct {
 	HandlingFee      decimal.Decimal  `gorm:"column:handling_fee"`
 	FreeShippingMin  *decimal.Decimal `gorm:"column:free_shipping_min"`
 	IsActive         bool             `gorm:"column:is_active"`
-	WarehouseName    *string          `gorm:"column:warehouse_name"`
-	WarehouseLine1   *string          `gorm:"column:warehouse_line1"`
-	WarehouseLine2   *string          `gorm:"column:warehouse_line2"`
-	WarehouseCity    *string          `gorm:"column:warehouse_city"`
-	WarehouseRegion  *string          `gorm:"column:warehouse_region"`
-	WarehousePostal  *string          `gorm:"column:warehouse_postal"`
-	WarehouseCountry *string          `gorm:"column:warehouse_country"`
-	WarehousePhone   *string          `gorm:"column:warehouse_phone"`
 	// WarehouseID points at the store-level warehouses row (migration
-	// 000095, #177) when one has been linked. Nullable — see
-	// resolveWarehouseAddress for the fallback this requires.
+	// 000095, #177). Nullable — see resolveWarehouseAddress for what
+	// happens when it's nil or dangling. #484 dropped the legacy
+	// warehouse_* column fields from this projection; they are no
+	// longer read anywhere.
 	WarehouseID *string `gorm:"column:warehouse_id"`
 }
 
@@ -352,67 +346,35 @@ func (h *ShippingRatesHandler) maybeRewrapRow(ctx context.Context, cfg carrierCo
 	}
 }
 
-// resolveWarehouseAddress loads cfg's pickup address, preferring the
-// store-level warehouses row (#177, the read half) and falling back to
-// warehouseAddress's legacy warehouse_* columns.
+// resolveWarehouseAddress loads cfg's pickup address from the store-level
+// warehouses row. #484 (the contract half of #177) removed the legacy
+// warehouse_* column fallback: those columns are no longer read anywhere,
+// which is what makes dropping them in a later migration safe.
 //
-// The fallback is required, not defensive: rows written before the write
-// path in #177 landed, or by any writer that hasn't been updated, still
-// only have the legacy columns and cfg.WarehouseID is nil for them. A
-// non-nil WarehouseID pointing at a row that no longer exists (the FK is
-// ON DELETE SET NULL, so this is unlikely but not impossible) also falls
-// back rather than erroring the request — a rates quote with a stale
-// address beats no quote at all.
+// When cfg has no WarehouseID, or WarehouseID points at a row that no
+// longer exists (the FK is ON DELETE SET NULL, so this is unlikely but not
+// impossible), this returns the zero shipping.Address — same as a blank
+// legacy address used to produce.
 func (h *ShippingRatesHandler) resolveWarehouseAddress(ctx context.Context, cfg carrierConfigRow) shipping.Address {
-	if cfg.WarehouseID != nil {
-		wh, err := h.warehouseRepo.ByID(ctx, h.db, *cfg.WarehouseID)
-		if err == nil {
-			return shipping.Address{
-				Name:        wh.Name,
-				Line1:       wh.Line1,
-				Line2:       wh.Line2,
-				City:        wh.City,
-				Region:      wh.Region,
-				PostalCode:  wh.PostalCode,
-				CountryCode: wh.CountryCode,
-				Phone:       wh.Phone,
-			}
-		}
+	if cfg.WarehouseID == nil {
+		return shipping.Address{}
+	}
+	wh, err := h.warehouseRepo.ByID(ctx, h.db, *cfg.WarehouseID)
+	if err != nil {
 		if h.logger != nil {
-			h.logger.Warn("shipping_rates: carrier config's warehouse_id has no matching row, falling back to legacy columns",
+			h.logger.Warn("shipping_rates: carrier config's warehouse_id has no matching row",
 				"provider", cfg.Provider, "warehouse_id", *cfg.WarehouseID, "err", err)
 		}
+		return shipping.Address{}
 	}
-	return warehouseAddress(cfg)
-}
-
-// warehouseAddress builds a shipping.Address from the carrier config's
-// legacy warehouse_* columns. Returns a zero-value address if fields are nil.
-func warehouseAddress(cfg carrierConfigRow) shipping.Address {
-	addr := shipping.Address{}
-	if cfg.WarehouseName != nil {
-		addr.Name = *cfg.WarehouseName
+	return shipping.Address{
+		Name:        wh.Name,
+		Line1:       wh.Line1,
+		Line2:       wh.Line2,
+		City:        wh.City,
+		Region:      wh.Region,
+		PostalCode:  wh.PostalCode,
+		CountryCode: wh.CountryCode,
+		Phone:       wh.Phone,
 	}
-	if cfg.WarehouseLine1 != nil {
-		addr.Line1 = *cfg.WarehouseLine1
-	}
-	if cfg.WarehouseLine2 != nil {
-		addr.Line2 = *cfg.WarehouseLine2
-	}
-	if cfg.WarehouseCity != nil {
-		addr.City = *cfg.WarehouseCity
-	}
-	if cfg.WarehouseRegion != nil {
-		addr.Region = *cfg.WarehouseRegion
-	}
-	if cfg.WarehousePostal != nil {
-		addr.PostalCode = *cfg.WarehousePostal
-	}
-	if cfg.WarehouseCountry != nil {
-		addr.CountryCode = *cfg.WarehouseCountry
-	}
-	if cfg.WarehousePhone != nil {
-		addr.Phone = *cfg.WarehousePhone
-	}
-	return addr
 }

--- a/services/marketplace-api/internal/handlers/storefront/shipping_rates_warehouse_read_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/shipping_rates_warehouse_read_test.go
@@ -1,16 +1,17 @@
 //go:build integration
 
-// Package storefront — read-path coverage for #177 (the cheap half) at
-// the shipping-rates quote site.
+// Package storefront — read-path coverage for #484 (the contract half of
+// #177) at the shipping-rates quote site.
 //
 // (*ShippingRatesHandler).GetRates loads a carrierConfigRow and used to
-// build its rate-quote origin address exclusively from the legacy
-// warehouse_* columns. It must now prefer the store-level warehouses row
-// via warehouse_id, falling back to the legacy columns otherwise — see
-// resolveWarehouseAddress. Testing that function directly, rather than
-// driving GetRates end-to-end, avoids needing a live carrier for a rates
-// call; resolveWarehouseAddress is the single seam that decides which
-// address source wins.
+// build its rate-quote origin address from the legacy warehouse_* columns,
+// then from the store-level warehouses row with a legacy fallback (#480).
+// #484 removes that fallback: resolveWarehouseAddress now sources the
+// origin exclusively from the warehouses row via warehouse_id — those
+// columns are no longer read anywhere, which is what makes dropping them
+// in a later migration safe. Testing resolveWarehouseAddress directly,
+// rather than driving GetRates end-to-end, avoids needing a live carrier
+// for a rates call.
 package storefront
 
 import (
@@ -23,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
+	"github.com/mark8ly/marketplace-api/internal/shipping"
 	"github.com/mark8ly/marketplace-api/internal/warehouse"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
@@ -54,7 +56,11 @@ func seedShippingRatesWarehouseReadStore(t *testing.T, db *gorm.DB) (storeID, te
 // raw SQL rather than the carrierConfigRow GORM model — that model
 // deliberately omits store_id (it's only ever used for reads keyed by the
 // gin-context store), so it can't Create() a row that satisfies the
-// table's NOT NULL store_id.
+// table's NOT NULL store_id. The legacy warehouse_* columns are still
+// populated here (they still exist on the table — #484 stops reading
+// them, it doesn't drop them) precisely so a test that fails to switch
+// off the fallback would still be caught: these values deliberately
+// differ from the warehouses-row address used below.
 func seedShippingRatesCarrierConfig(t *testing.T, db *gorm.DB, storeID, tenantID string, warehouseID *string) {
 	t.Helper()
 	require.NoError(t, db.Exec(
@@ -75,12 +81,12 @@ func loadShippingRatesCarrierConfigRow(t *testing.T, db *gorm.DB, storeID string
 	return cfg
 }
 
-// TestResolveWarehouseAddress_PrefersTheWarehousesRowWhenLinked proves the
-// rates-quote origin comes from the warehouses row when warehouse_id is
-// set — with an address that deliberately differs from the legacy
-// columns, so the test can't pass by accident regardless of which source
-// actually won.
-func TestResolveWarehouseAddress_PrefersTheWarehousesRowWhenLinked(t *testing.T) {
+// TestResolveWarehouseAddress_ResolvesFromTheWarehousesRowWhenLinked proves
+// the rates-quote origin comes from the warehouses row when warehouse_id
+// is set — with an address that deliberately differs from the row's own
+// (still-populated, no-longer-read) legacy columns, so the test can't pass
+// by accident if the fallback were somehow still wired in.
+func TestResolveWarehouseAddress_ResolvesFromTheWarehousesRowWhenLinked(t *testing.T) {
 	db := testdb.NewDB(t, shippingRatesWarehouseReadTables...)
 	storeID, tenantID := seedShippingRatesWarehouseReadStore(t, db)
 	whRepo := warehouse.NewRepository()
@@ -101,10 +107,11 @@ func TestResolveWarehouseAddress_PrefersTheWarehousesRowWhenLinked(t *testing.T)
 	require.Equal(t, "Mumbai", got.City)
 }
 
-// TestResolveWarehouseAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsNil
-// covers a config saved before #177's write path, or by a writer that
-// hasn't been updated — warehouse_id is NULL.
-func TestResolveWarehouseAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsNil(t *testing.T) {
+// TestResolveWarehouseAddress_ZeroValueWhenWarehouseIDIsNil covers a
+// config with no linked warehouse. #484 removed the legacy-column
+// fallback: this must yield the zero shipping.Address, never the (still
+// populated on the row) legacy data.
+func TestResolveWarehouseAddress_ZeroValueWhenWarehouseIDIsNil(t *testing.T) {
 	db := testdb.NewDB(t, shippingRatesWarehouseReadTables...)
 	storeID, tenantID := seedShippingRatesWarehouseReadStore(t, db)
 	seedShippingRatesCarrierConfig(t, db, storeID, tenantID, nil)
@@ -113,22 +120,22 @@ func TestResolveWarehouseAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsNil(t 
 	h := newShippingRatesWarehouseReadHandler(db)
 	got := h.resolveWarehouseAddress(context.Background(), cfg)
 
-	require.Equal(t, "1 Legacy Lane", got.Line1)
-	require.Equal(t, "Legacy City", got.City)
+	require.Equal(t, shipping.Address{}, got, "no warehouse_id must yield the zero address, not the legacy columns")
 }
 
-// TestResolveWarehouseAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsDangling
-// covers a warehouse_id that points at a row that no longer exists — the
-// FK is ON DELETE SET NULL, so this should be rare, but resolving to
-// "no quote" rather than the legacy address would be a worse failure mode
-// for what is a best-effort estimate anyway.
+// TestResolveWarehouseAddress_ZeroValueWhenWarehouseIDIsDangling covers a
+// warehouse_id that points at a row that no longer exists — the FK is ON
+// DELETE SET NULL, so this should be rare, but resolving to the zero
+// address (which GetRates would then report as "no active carrier
+// config"-shaped zero data) is the correct behaviour now that there is no
+// legacy data left to fall back to.
 //
 // The dangling id is built directly on an in-memory carrierConfigRow
 // rather than persisted: the real FK (plus ON DELETE SET NULL) means
-// Postgres won't let an actual row go dangling, but
-// resolveWarehouseAddress only reads cfg's fields to decide what to look
-// up, so this still exercises the fallback a hypothetical race would hit.
-func TestResolveWarehouseAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsDangling(t *testing.T) {
+// Postgres won't let an actual row go dangling, but resolveWarehouseAddress
+// only reads cfg's fields to decide what to look up, so this still
+// exercises the code path a hypothetical race would hit.
+func TestResolveWarehouseAddress_ZeroValueWhenWarehouseIDIsDangling(t *testing.T) {
 	db := testdb.NewDB(t, shippingRatesWarehouseReadTables...)
 	storeID, tenantID := seedShippingRatesWarehouseReadStore(t, db)
 	seedShippingRatesCarrierConfig(t, db, storeID, tenantID, nil)
@@ -139,6 +146,5 @@ func TestResolveWarehouseAddress_FallsBackToLegacyColumnsWhenWarehouseIDIsDangli
 	h := newShippingRatesWarehouseReadHandler(db)
 	got := h.resolveWarehouseAddress(context.Background(), cfg)
 
-	require.Equal(t, "1 Legacy Lane", got.Line1, "a dangling warehouse_id must fall back, not return a blank origin")
-	require.Equal(t, "Legacy City", got.City)
+	require.Equal(t, shipping.Address{}, got, "a dangling warehouse_id must yield the zero address, not a stale one")
 }

--- a/services/marketplace-api/internal/shipping/repository.go
+++ b/services/marketplace-api/internal/shipping/repository.go
@@ -95,19 +95,16 @@ type CarrierConfig struct {
 	HandlingFee           decimal.Decimal `gorm:"column:handling_fee;type:numeric(12,2);not null;default:0"`
 	FreeShippingThreshold decimal.Decimal `gorm:"column:free_shipping_min;type:numeric(12,2)"`
 	Enabled               bool            `gorm:"column:is_active;not null;default:false"`
-	WarehouseName         string          `gorm:"column:warehouse_name;type:varchar(200)"`
-	WarehouseLine1        string          `gorm:"column:warehouse_line1;type:varchar(300)"`
-	WarehouseLine2        string          `gorm:"column:warehouse_line2;type:varchar(300)"`
-	WarehouseCity         string          `gorm:"column:warehouse_city;type:varchar(200)"`
-	WarehouseRegion       string          `gorm:"column:warehouse_region;type:varchar(200)"`
-	WarehousePostal       string          `gorm:"column:warehouse_postal;type:varchar(40)"`
-	WarehouseCountry      string          `gorm:"column:warehouse_country;type:char(2)"`
-	WarehousePhone        string          `gorm:"column:warehouse_phone;type:varchar(40)"`
 	// WarehouseID points at the store-level warehouses row (migration
-	// 000095, #177) when one has been linked. Nullable: rows written before
-	// #177's write path landed, or by any writer that hasn't been updated,
-	// still only have the columns above. *uuid.UUID rather than uuid.UUID
-	// so GORM writes/reads SQL NULL instead of the zero UUID.
+	// 000095, #177) when one has been linked. Nullable: a config saved
+	// with a blank warehouse name never gets one, and the FK is ON DELETE
+	// SET NULL. *uuid.UUID rather than uuid.UUID so GORM writes/reads SQL
+	// NULL instead of the zero UUID.
+	//
+	// #484 dropped the WarehouseName/Line1/Line2/City/Region/Postal/
+	// Country/Phone fields that used to mirror this row's legacy
+	// warehouse_* columns: nothing reads them anymore, which is what
+	// makes dropping those columns in a later migration safe.
 	WarehouseID *uuid.UUID `gorm:"column:warehouse_id;type:uuid"`
 	// Pickup automation. AutoSchedulePickup is the master toggle; rows
 	// default to TRUE in SQL so existing configs auto-opt-in when the
@@ -341,14 +338,20 @@ func (r *gormRepository) UpsertCarrierConfig(ctx context.Context, cfg *CarrierCo
 			HandlingFee:           cfg.HandlingFee,
 			FreeShippingThreshold: cfg.FreeShippingThreshold,
 			Enabled:               cfg.Enabled,
-			WarehouseName:         cfg.WarehouseName,
-			WarehouseLine1:        cfg.WarehouseLine1,
-			WarehouseLine2:        cfg.WarehouseLine2,
-			WarehouseCity:         cfg.WarehouseCity,
-			WarehouseRegion:       cfg.WarehouseRegion,
-			WarehousePostal:       cfg.WarehousePostal,
-			WarehouseCountry:      cfg.WarehouseCountry,
-			WarehousePhone:        cfg.WarehousePhone,
+			// #484: this used to write the 8 legacy warehouse_* columns
+			// from cfg's now-removed fields. UpsertCarrierConfig has no
+			// production caller (see the package doc on this method), so
+			// there was no live divergence to fix — but if it's ever
+			// wired up, it must maintain warehouse_id, the only field any
+			// reader still looks at, or a caller pointing at a real
+			// warehouse would silently write an id the read path then
+			// ignores. Note GORM's Updates(struct) skips zero-value
+			// fields, so a caller passing a nil WarehouseID here leaves
+			// the stored value untouched rather than clearing it — unlike
+			// the admin settings handler's map-based Updates, which does
+			// clear it. That's acceptable for now given there is no
+			// caller to observe the difference.
+			WarehouseID: cfg.WarehouseID,
 		}).Error
 	if err != nil {
 		return fmt.Errorf("shipping: update carrier config: %w", err)

--- a/services/marketplace-api/internal/warehouse/backfill_stragglers_integration_test.go
+++ b/services/marketplace-api/internal/warehouse/backfill_stragglers_integration_test.go
@@ -1,0 +1,168 @@
+//go:build integration
+
+// Package warehouse_test — coverage for migration 000116, #484's backfill.
+//
+// #480's write path only sets shipping_carrier_configs.warehouse_id on a
+// save through the admin settings handler. A row created (or last edited)
+// after migration 000095's one-time backfill ran, but before #480 shipped,
+// has its legacy warehouse_* columns populated and warehouse_id still NULL
+// — exactly the gap #484's issue names as the precondition for dropping
+// those columns. Migration 000116 closes it by re-running 000095's own
+// backfill shape, scoped to today's stragglers.
+//
+// This is the single most important test in the PR: it is what makes
+// dropping the legacy columns in a later migration safe, by proving no row
+// is left depending on them once this migration has run.
+package warehouse_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	marketplaceapi "github.com/mark8ly/marketplace-api"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// runBackfillMigration executes migration 000116's up.sql verbatim, read
+// from the same embedded FS the production migrate tool uses — so this
+// test exercises the actual migration file, not a hand-copied
+// approximation of it that could drift from what actually ships.
+func runBackfillMigration(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	sql, err := marketplaceapi.MigrationsFS.ReadFile("migrations/000116_backfill_warehouse_id_stragglers.up.sql")
+	require.NoError(t, err, "read migration 000116 from the embedded FS")
+	require.NoError(t, db.Exec(string(sql)).Error, "run migration 000116")
+}
+
+// seedStraggler inserts a shipping_carrier_configs row shaped exactly like
+// the gap this migration closes: legacy warehouse_* columns populated
+// (written by #480's expand-half write path or an even older writer),
+// warehouse_id still NULL (never touched by a save through the write path
+// that maintains it).
+func seedStraggler(t *testing.T, db *gorm.DB, tenantID, storeID, name string) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`INSERT INTO shipping_carrier_configs
+		    (id, tenant_id, store_id, provider, api_key_encrypted, mode, is_active,
+		     warehouse_name, warehouse_line1, warehouse_line2, warehouse_city,
+		     warehouse_region, warehouse_postal, warehouse_country, warehouse_phone)
+		 VALUES (?, ?, ?, 'delhivery', 'legacy-key', 'test', true,
+		         ?, '12 Industrial Estate', '', 'Mumbai', 'MH', '400001', 'IN', '+912200000000')`,
+		uuid.NewString(), tenantID, storeID, name).Error)
+}
+
+// TestBackfillMigration_LinksAStragglerRowToANewWarehouse is the core
+// assertion: a config with populated legacy columns and NULL warehouse_id
+// must, after the migration runs, have a matching warehouses row AND
+// warehouse_id pointing at it.
+func TestBackfillMigration_LinksAStragglerRowToANewWarehouse(t *testing.T) {
+	db := testdb.NewDB(t, "shipping_carrier_configs", "warehouses", "stores")
+	tenantID, storeID := seedStore(t, db)
+	seedStraggler(t, db, tenantID, storeID, "Main Warehouse")
+
+	runBackfillMigration(t, db)
+
+	var whID, whLine1, whCity string
+	require.NoError(t, db.Raw(
+		`SELECT id, line1, city FROM warehouses WHERE store_id = ? AND name = 'Main Warehouse'`, storeID).
+		Row().Scan(&whID, &whLine1, &whCity))
+	require.Equal(t, "12 Industrial Estate", whLine1)
+	require.Equal(t, "Mumbai", whCity)
+
+	var linkedID string
+	require.NoError(t, db.Raw(
+		`SELECT warehouse_id::text FROM shipping_carrier_configs WHERE store_id = ? AND provider = 'delhivery'`,
+		storeID).Row().Scan(&linkedID))
+	require.Equal(t, whID, linkedID, "the straggler's warehouse_id must now point at the backfilled row")
+}
+
+// TestBackfillMigration_SkipsRowsWithABlankWarehouseName mirrors 000095's
+// own rule: a blank name was never a usable warehouse (it's what Delhivery
+// keys on), so a straggler with no name must be left alone — no warehouse
+// row created, warehouse_id still NULL.
+func TestBackfillMigration_SkipsRowsWithABlankWarehouseName(t *testing.T) {
+	db := testdb.NewDB(t, "shipping_carrier_configs", "warehouses", "stores")
+	tenantID, storeID := seedStore(t, db)
+	seedStraggler(t, db, tenantID, storeID, "")
+
+	runBackfillMigration(t, db)
+
+	var count int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM warehouses WHERE store_id = ?`, storeID).Scan(&count).Error)
+	require.Zero(t, count, "a blank warehouse_name must not create a warehouse row")
+
+	var linkedID *string
+	require.NoError(t, db.Raw(
+		`SELECT warehouse_id::text FROM shipping_carrier_configs WHERE store_id = ? AND provider = 'delhivery'`,
+		storeID).Row().Scan(&linkedID))
+	require.Nil(t, linkedID)
+}
+
+// TestBackfillMigration_DoesNotTouchAnAlreadyLinkedRow covers a config that
+// went through #480's write path normally (warehouse_id already set) — the
+// migration's WHERE c.warehouse_id IS NULL guard must leave it untouched,
+// not attempt to re-link or duplicate its warehouse.
+func TestBackfillMigration_DoesNotTouchAnAlreadyLinkedRow(t *testing.T) {
+	db := testdb.NewDB(t, "shipping_carrier_configs", "warehouses", "stores")
+	tenantID, storeID := seedStore(t, db)
+
+	whID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO warehouses (id, tenant_id, store_id, name, line1, city, region, postal_code, country_code, phone, is_default)
+		 VALUES (?, ?, ?, 'Main Warehouse', '12 Industrial Estate', 'Mumbai', 'MH', '400001', 'IN', '+912200000000', true)`,
+		whID, tenantID, storeID).Error)
+	require.NoError(t, db.Exec(
+		`INSERT INTO shipping_carrier_configs
+		    (id, tenant_id, store_id, provider, api_key_encrypted, mode, is_active,
+		     warehouse_name, warehouse_line1, warehouse_city, warehouse_region,
+		     warehouse_postal, warehouse_country, warehouse_phone, warehouse_id)
+		 VALUES (?, ?, ?, 'delhivery', 'legacy-key', 'test', true,
+		         'Main Warehouse', '12 Industrial Estate', 'Mumbai', 'MH', '400001', 'IN', '+912200000000', ?)`,
+		uuid.NewString(), tenantID, storeID, whID).Error)
+
+	runBackfillMigration(t, db)
+
+	var count int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM warehouses WHERE store_id = ?`, storeID).Scan(&count).Error)
+	require.EqualValues(t, 1, count, "an already-linked row must not gain a duplicate warehouse")
+
+	var linkedID string
+	require.NoError(t, db.Raw(
+		`SELECT warehouse_id::text FROM shipping_carrier_configs WHERE store_id = ? AND provider = 'delhivery'`,
+		storeID).Row().Scan(&linkedID))
+	require.Equal(t, whID, linkedID)
+}
+
+// TestBackfillMigration_IsIdempotent runs the migration twice and asserts
+// the second run changes nothing: no new warehouses row, no new link. This
+// is the same guarantee 000095's own backfill documents for itself, and it
+// matters here because a migration tool can, in principle, be asked to
+// re-apply an already-applied version.
+func TestBackfillMigration_IsIdempotent(t *testing.T) {
+	db := testdb.NewDB(t, "shipping_carrier_configs", "warehouses", "stores")
+	tenantID, storeID := seedStore(t, db)
+	seedStraggler(t, db, tenantID, storeID, "Main Warehouse")
+
+	runBackfillMigration(t, db)
+
+	var whID string
+	require.NoError(t, db.Raw(`SELECT id::text FROM warehouses WHERE store_id = ?`, storeID).Row().Scan(&whID))
+
+	runBackfillMigration(t, db)
+
+	var count int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM warehouses WHERE store_id = ?`, storeID).Scan(&count).Error)
+	require.EqualValues(t, 1, count, "re-running the migration must not create a second warehouse row")
+
+	var whIDAfter, linkedID string
+	require.NoError(t, db.Raw(`SELECT id::text FROM warehouses WHERE store_id = ?`, storeID).Row().Scan(&whIDAfter))
+	require.Equal(t, whID, whIDAfter, "the warehouse row's identity must be unchanged by a second run")
+
+	require.NoError(t, db.Raw(
+		`SELECT warehouse_id::text FROM shipping_carrier_configs WHERE store_id = ? AND provider = 'delhivery'`,
+		storeID).Row().Scan(&linkedID))
+	require.Equal(t, whID, linkedID)
+}

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 115
+const ExpectedSchemaVersion uint = 116

--- a/services/marketplace-api/migrations/000116_backfill_warehouse_id_stragglers.down.sql
+++ b/services/marketplace-api/migrations/000116_backfill_warehouse_id_stragglers.down.sql
@@ -1,0 +1,7 @@
+-- No-op on purpose. This is a data backfill, not a schema change: reversing
+-- it would mean deciding which warehouses rows and warehouse_id links to
+-- delete, and there is no reliable way to tell a row this migration
+-- created/linked apart from one 000095 or a later admin save already
+-- created — undoing it risks deleting warehouses (and unlinking configs)
+-- that are in active use. Leaving the backfilled data in place is always
+-- safe: it is exactly what the write path would have produced anyway.

--- a/services/marketplace-api/migrations/000116_backfill_warehouse_id_stragglers.up.sql
+++ b/services/marketplace-api/migrations/000116_backfill_warehouse_id_stragglers.up.sql
@@ -1,0 +1,47 @@
+-- #484 (step 1 of the contract half of #177): close the backfill gap that
+-- blocked dropping the legacy warehouse_* columns on
+-- shipping_carrier_configs.
+--
+-- 000095's backfill only ran once, at migration time. Any
+-- shipping_carrier_configs row created (or edited) AFTER 000095 ran but
+-- BEFORE #480's write path shipped still has its legacy warehouse_*
+-- columns populated and warehouse_id NULL — #480's write path is the only
+-- thing that ever sets warehouse_id, and it only runs on a save through
+-- the admin settings handler. Every reader in this same PR stopped
+-- consulting the legacy columns, so a row like that would silently lose
+-- its pickup address unless this migration catches it first.
+--
+-- This mirrors 000095_warehouses.up.sql's backfill shape exactly —
+-- including the ON CONFLICT (store_id, name) DO NOTHING and skipping rows
+-- with a blank warehouse_name (never a usable warehouse, and the thing
+-- Delhivery keys on) — but is scoped to today's stragglers rather than the
+-- one-time full-table backfill 000095 already did. Idempotent: re-running
+-- it inserts nothing new and updates nothing once every row is caught up.
+INSERT INTO warehouses (
+    tenant_id, store_id, name, line1, line2, city, region, postal_code,
+    country_code, phone, is_default
+)
+SELECT DISTINCT ON (c.store_id, c.warehouse_name)
+    c.tenant_id,
+    c.store_id,
+    c.warehouse_name,
+    coalesce(c.warehouse_line1, ''),
+    coalesce(c.warehouse_line2, ''),
+    coalesce(c.warehouse_city, ''),
+    coalesce(c.warehouse_region, ''),
+    coalesce(c.warehouse_postal, ''),
+    coalesce(c.warehouse_country, ''),
+    coalesce(c.warehouse_phone, ''),
+    true
+FROM shipping_carrier_configs c
+WHERE coalesce(c.warehouse_name, '') <> ''
+  AND c.warehouse_id IS NULL
+ORDER BY c.store_id, c.warehouse_name, c.created_at
+ON CONFLICT (store_id, name) DO NOTHING;
+
+UPDATE shipping_carrier_configs c
+SET warehouse_id = w.id
+FROM warehouses w
+WHERE w.store_id = c.store_id
+  AND w.name = c.warehouse_name
+  AND c.warehouse_id IS NULL;


### PR DESCRIPTION
**Step 1 of 2.** Every reader and writer stops using the 8 legacy
`warehouse_*` columns on `shipping_carrier_configs`. **No column is dropped
here** — that is step 2, a separate PR, merged only once this one is fully
deployed.

Part of #484.

## Why this is split in two

The columns cannot be dropped in the same deploy that stops reading them.
Verified against the live cluster:

| Component | migrate init container | rolls with admin? |
|---|---|---|
| `marketplace-api-admin` | yes | — |
| `marketplace-api-storefront` | **no** | no — independent deployment |
| `refund-sweep`, `stock-hold-sweep` CronJobs | **no** | no — may be mid-run |

`admin` is `maxSurge=0, maxUnavailable=1, replicas=1`, so its own old pod is
gone before its migration runs. But `storefront` reads these same columns and
rolls separately, and both CronJobs share the image. A migration that dropped
the columns during the admin rollout would break whichever of those is still on
the old image.

So: this PR makes the code stop needing the columns while they still exist. Once
it is deployed everywhere, dropping them is a no-op for every running pod.

## The backfill is the load-bearing part

`000116_backfill_warehouse_id_stragglers` closes the gap that makes step 2 safe.

000095's backfill ran **once, at migration time**. Any config row created or
edited after that but before #480's write path shipped still has populated
legacy columns and `warehouse_id IS NULL` — #480's write path is the only thing
that sets `warehouse_id`, and only on a save through the admin settings handler.
Those rows are exactly the ones that would silently lose their pickup address
the moment the fallback goes away.

The migration mirrors 000095's backfill shape exactly (same
`ON CONFLICT (store_id, name) DO NOTHING`, same blank-name skip) scoped to
`warehouse_id IS NULL`. Idempotent. Down is a documented no-op — you cannot
un-backfill safely.

Its test reads the migration **verbatim from the embedded `MigrationsFS`** and
executes it, so it tests the real migration rather than a copy that could drift:
links a straggler, skips blank names, leaves already-linked rows alone, and runs
twice with no change.

## Correcting #480

#480's description — mine — said all readers went through `warehouse_id`. That
was **wrong**: it migrated 3 of 6 read sites. Three more read the legacy columns
directly and were never touched:

- `storefront/checkout_ext.go:1078` — `calculateTax` read `cfg.WarehouseRegion`
  for `sellerRegion`
- `admin/shipments.go:894` — `tryAutoSchedulePickup` read `cfg.WarehouseName`
- `admin/shipments.go:1070` — the manual pickup-schedule endpoint, same

Nothing broke in production, because #480 kept writing the legacy columns and
these sites kept reading consistent values. But the completeness claim was not
true, and dropping the columns on that assumption would have broken tax
calculation and pickup scheduling. All three now resolve via `warehouse_id`
(`CheckoutExtHandler` gained a `warehouseRepo` for this).

## Behaviour change

With the fallback gone, a config with no `warehouse_id` yields a **zero
address** rather than stale columns. Existing guards turn that into the same
`warehouse address is not configured` error as before, so the user-visible
outcome is unchanged. A dangling `warehouse_id` also yields zero, still logged.

## Wire contract unchanged

The admin JSON API keeps its `warehouse_name` / `warehouse_line1` / … field
names; `toShippingResponse` now sources them from the warehouses row. **No
frontend changes needed.**

## `UpsertCarrierConfig`

`internal/shipping/repository.go` has no production caller (interface, impl and
a test fake only). Rather than deleting its warehouse assignments it now sets
`warehouse_id`, so a future caller cannot silently write an address the read
path ignores.

## Tests

Old fallback tests encoded the removed contract; they were **rewritten, not
deleted**:

- `FallsBackToLegacyColumnsWhenWarehouseIDIsNil` → `ErrorsWhenWarehouseIDIsNil` /
  `ZeroValueWhenWarehouseIDIsNil` (per site)
- `StillWritesLegacyWarehouseColumns` → `DoesNotWriteLegacyWarehouseColumns`,
  which seeds a stale legacy row and asserts it is left untouched while the
  warehouses row receives the new address

```
TEST_DATABASE_URL='postgres://dev:dev@<host>:5432/marketplace_db?sslmode=disable' \
  go test -tags=integration -p 1 -count=1 ./internal/handlers/... ./internal/warehouse/... ./internal/shipping/...
```

All packages green. `go build ./...` and `go vet -tags=integration ./...` clean.

## Next

Step 2 drops the 8 columns. **Do not merge it until this is deployed.**
