### PR TITLE
feat(shipping): multi-warehouse schema and per-location inventory sum (#177, PR 1 of 6)

### DIFF
--- a/docs/superpowers/plans/2026-08-31-multi-warehouse-01-schema-and-trigger.md
+++ b/docs/superpowers/plans/2026-08-31-multi-warehouse-01-schema-and-trigger.md
@@ -1,0 +1,673 @@
+# Multi-warehouse PR 1: schema and inventory trigger — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the schema multi-warehouse needs and fix `product_variants.inventory_quantity` to be the sum across locations rather than the last one written.
+
+**Architecture:** Two migrations, additive only. Nothing in Go changes behaviour: while every store has one warehouse, a SUM over one row is that row, so this PR is a no-op in production and safe to deploy alone. It exists so that later PRs — the allocator, checkout, fulfilment, admin — have somewhere to write.
+
+**Tech Stack:** Go 1.26, PostgreSQL 15, golang-migrate (embedded `MigrationsFS`), GORM, testify.
+
+**Spec:** `docs/superpowers/specs/2026-08-31-multi-warehouse-allocation-design.md`
+
+## Global Constraints
+
+- Work in the worktree `.claude/worktrees/177-multi-warehouse`, branch `feat/177-multi-warehouse`. Never switch the main checkout's branch.
+- Run every Go command from `services/marketplace-api`, never path-scoped, always `-count=1`: `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./... -count=1`. `go vet -tags=integration ./...` is the only command that compiles build-tagged files — include it.
+- Integration tests: `//go:build integration`, gated on `TEST_DATABASE_URL` (**never** `TEST_DB_DSN`), run with `-p 1`.
+- Verified DSN: `postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable` (container `dev-postgres-1`; use the LAN IP, not localhost — a native Postgres owns 127.0.0.1:5432 on this machine).
+- **A skipped integration test reads exactly like a passing one.** Any claim that an integration test passed must name the DSN it ran with. `./internal/whitelabel/lifecycle` takes 1.4s skipping versus 3.2s running — check the duration.
+- Migrations are embedded. After adding a migration file, apply it before running integration tests: `DATABASE_URL=<dsn> go run ./cmd/migrate up`.
+- `ExpectedSchemaVersion` in `services/marketplace-api/migrations.go` must equal the highest migration number on disk. `TestExpectedSchemaVersionMatchesHighestMigration` fails at CI time if not.
+- Commits: conventional, single line, no signature, no `Co-Authored-By` trailer, no emoji.
+- Stage with explicit paths (`git add <path>`). Never `git add -A`.
+- Every guard added must be mutation-tested: delete the guard, watch a test fail, restore it. A guard whose removal breaks nothing is decoration.
+
+---
+
+## File Structure
+
+- **Create** `services/marketplace-api/migrations/000118_multi_warehouse_schema.up.sql` — `warehouses.priority`, `order_allocations`, `shipments.warehouse_id`
+- **Create** `services/marketplace-api/migrations/000118_multi_warehouse_schema.down.sql`
+- **Create** `services/marketplace-api/migrations/000119_variant_inventory_sum.up.sql` — trigger function → SUM, plus the AFTER DELETE arm
+- **Create** `services/marketplace-api/migrations/000119_variant_inventory_sum.down.sql`
+- **Modify** `services/marketplace-api/migrations.go` — `ExpectedSchemaVersion` 117 → 119
+- **Create** `services/marketplace-api/internal/warehouse/allocations_schema_integration_test.go` — behavioural coverage for the 000118 schema
+- **Create** `services/marketplace-api/internal/product/variant_inventory_sum_integration_test.go` — coverage for the 000119 trigger
+
+Two migration files rather than one: the 000118 additions are inert, while 000119 changes the behaviour of a trigger every stock write goes through. Separating them means a revert of the risky half does not take the schema with it.
+
+---
+
+### Task 1: Schema additions (000118)
+
+**Files:**
+- Create: `services/marketplace-api/migrations/000118_multi_warehouse_schema.up.sql`
+- Create: `services/marketplace-api/migrations/000118_multi_warehouse_schema.down.sql`
+- Modify: `services/marketplace-api/migrations.go:17`
+- Test: `services/marketplace-api/internal/warehouse/allocations_schema_integration_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: the `order_allocations` table, `warehouses.priority integer NOT NULL DEFAULT 0`, and `shipments.warehouse_id uuid NULL`. PR 2's allocator orders warehouses by `priority ASC, is_default DESC, created_at ASC`; PR 3 inserts `order_allocations` rows; PR 4 sets `shipments.warehouse_id` and stamps `order_allocations.shipment_id`.
+
+- [ ] **Step 1: Write the migration**
+
+Create `services/marketplace-api/migrations/000118_multi_warehouse_schema.up.sql`:
+
+```sql
+-- #177 multi-warehouse, schema half. Everything here is additive and inert:
+-- no running code reads these columns or this table, and a store with one
+-- warehouse behaves identically before and after. The allocator (PR 2) and
+-- checkout (PR 3) are what give them meaning.
+
+-- The order the allocator walks a store's warehouses. Merchant-ranked.
+ALTER TABLE warehouses
+    ADD COLUMN IF NOT EXISTS priority integer NOT NULL DEFAULT 0;
+
+-- Which warehouse ships how much of which order line.
+--
+-- A separate table rather than a warehouse_id on order_items, because
+-- refunds.order_item_id is a RESTRICT FK onto order_items: splitting a line
+-- across warehouses by splitting its row would change what a refund points
+-- at. Lines stay whole; allocation is its own concern with its own lifecycle.
+CREATE TABLE IF NOT EXISTS order_allocations (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id     uuid NOT NULL,
+    store_id      uuid NOT NULL,
+    order_id      uuid NOT NULL REFERENCES orders(id)      ON DELETE CASCADE,
+    order_item_id uuid NOT NULL REFERENCES order_items(id) ON DELETE CASCADE,
+    warehouse_id  uuid NOT NULL REFERENCES warehouses(id)  ON DELETE RESTRICT,
+    quantity      integer NOT NULL CHECK (quantity > 0),
+    -- NULL until a label is printed. This is the flag that makes
+    -- re-allocation safe before printing and refused after.
+    shipment_id   uuid REFERENCES shipments(id)            ON DELETE SET NULL,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    -- One row per (line, warehouse): a second allocation of the same line to
+    -- the same warehouse is a bug, not a top-up.
+    UNIQUE (order_item_id, warehouse_id)
+);
+
+CREATE INDEX IF NOT EXISTS order_allocations_order_idx
+    ON order_allocations (order_id);
+CREATE INDEX IF NOT EXISTS order_allocations_shipment_idx
+    ON order_allocations (shipment_id);
+
+-- Where a shipment actually shipped from. Nullable because every shipment
+-- created before this migration has no honest answer; every one created
+-- after it sets the column.
+ALTER TABLE shipments
+    ADD COLUMN IF NOT EXISTS warehouse_id uuid REFERENCES warehouses(id);
+```
+
+Create `services/marketplace-api/migrations/000118_multi_warehouse_schema.down.sql`:
+
+```sql
+-- Reversible without loss for the columns; order_allocations rows are lost,
+-- which is correct — they only have meaning alongside the code that writes
+-- them, and that code does not exist until PR 3.
+DROP TABLE IF EXISTS order_allocations;
+
+ALTER TABLE shipments  DROP COLUMN IF EXISTS warehouse_id;
+ALTER TABLE warehouses DROP COLUMN IF EXISTS priority;
+```
+
+- [ ] **Step 2: Bump the schema version**
+
+In `services/marketplace-api/migrations.go`, change:
+
+```go
+const ExpectedSchemaVersion uint = 117
+```
+
+to:
+
+```go
+const ExpectedSchemaVersion uint = 118
+```
+
+- [ ] **Step 3: Run the schema-version guard, expect PASS**
+
+```bash
+cd services/marketplace-api
+go test . -count=1
+```
+
+Expected: PASS. If it fails with `ExpectedSchemaVersion = 118, but highest migration on disk is N`, the migration filename is wrong — it must be exactly `000118_multi_warehouse_schema.up.sql`.
+
+- [ ] **Step 4: Write the failing test**
+
+Create `services/marketplace-api/internal/warehouse/allocations_schema_integration_test.go`:
+
+```go
+//go:build integration
+
+// Package warehouse_test — coverage for migration 000118, the schema half
+// of #177's multi-warehouse work.
+//
+// These assert BEHAVIOUR (what the table refuses) rather than catalogue
+// entries: a test that only checks a column exists passes against a table
+// whose constraints were all dropped.
+package warehouse_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedAllocatableOrder creates the store, warehouse, order and order line an
+// order_allocations row needs, and returns their ids.
+func seedAllocatableOrder(t *testing.T, db *gorm.DB) (tenantID, storeID, warehouseID, orderID, orderItemID string) {
+	t.Helper()
+	tenantID, storeID = seedStore(t, db)
+
+	warehouseID = uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO warehouses (id, tenant_id, store_id, name, line1, city, region, postal_code, country_code, phone)
+		 VALUES (?, ?, ?, 'Alloc WH', '1 Dock Rd', 'Mumbai', 'MH', '400001', 'IN', '+912200000000')`,
+		warehouseID, tenantID, storeID).Error)
+
+	orderID = uuid.NewString()
+	require.NoError(t, db.Exec(
+		// customer_email, not email. idempotency_key is NOT NULL with no
+		// default and is unique per store, so it gets a fresh uuid.
+		`INSERT INTO orders (id, tenant_id, store_id, order_number, idempotency_key,
+		                     customer_email, currency_code, subtotal, grand_total)
+		 VALUES (?, ?, ?, ?, ?, 'buyer@example.com', 'INR', 100.00, 100.00)`,
+		orderID, tenantID, storeID, "AL-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	orderItemID = uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO order_items (id, order_id, title_snapshot, sku_snapshot, unit_price,
+		                          quantity, line_total, currency_code)
+		 VALUES (?, ?, 'Ink Tee', 'SKU-1', 50.00, 2, 100.00, 'INR')`,
+		orderItemID, orderID).Error)
+
+	return tenantID, storeID, warehouseID, orderID, orderItemID
+}
+
+func insertAllocation(db *gorm.DB, tenantID, storeID, orderID, orderItemID, warehouseID string, qty int) error {
+	return db.Exec(
+		`INSERT INTO order_allocations (tenant_id, store_id, order_id, order_item_id, warehouse_id, quantity)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		tenantID, storeID, orderID, orderItemID, warehouseID, qty).Error
+}
+
+func TestOrderAllocations_AcceptsARowAndDefaultsShipmentToNull(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID, storeID, warehouseID, orderID, orderItemID := seedAllocatableOrder(t, db)
+
+	require.NoError(t, insertAllocation(db, tenantID, storeID, orderID, orderItemID, warehouseID, 2))
+
+	var shipmentID *string
+	require.NoError(t, db.Raw(
+		`SELECT shipment_id FROM order_allocations WHERE order_item_id = ?`, orderItemID,
+	).Row().Scan(&shipmentID))
+	require.Nil(t, shipmentID, "an allocation is unshipped until a label is printed")
+}
+
+// A line allocated twice to the same warehouse is a bug, not a top-up: the
+// allocator emits one row per (line, warehouse).
+func TestOrderAllocations_RejectsASecondRowForTheSameLineAndWarehouse(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID, storeID, warehouseID, orderID, orderItemID := seedAllocatableOrder(t, db)
+
+	require.NoError(t, insertAllocation(db, tenantID, storeID, orderID, orderItemID, warehouseID, 1))
+	err := insertAllocation(db, tenantID, storeID, orderID, orderItemID, warehouseID, 1)
+	require.Error(t, err, "the (order_item_id, warehouse_id) unique key must refuse the duplicate")
+}
+
+func TestOrderAllocations_RejectsZeroQuantity(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID, storeID, warehouseID, orderID, orderItemID := seedAllocatableOrder(t, db)
+
+	err := insertAllocation(db, tenantID, storeID, orderID, orderItemID, warehouseID, 0)
+	require.Error(t, err, "an allocation of nothing is meaningless and must be refused")
+}
+
+// The FK is the backstop behind the repository's deletion rules (PR 5): a
+// path that forgets them must fail loudly rather than orphan a parcel.
+func TestOrderAllocations_WarehouseCannotBeDeletedWhileAllocated(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID, storeID, warehouseID, orderID, orderItemID := seedAllocatableOrder(t, db)
+	require.NoError(t, insertAllocation(db, tenantID, storeID, orderID, orderItemID, warehouseID, 2))
+
+	err := db.Exec(`DELETE FROM warehouses WHERE id = ?`, warehouseID).Error
+	require.Error(t, err, "ON DELETE RESTRICT must refuse while an allocation references the warehouse")
+}
+
+func TestWarehouses_PriorityDefaultsToZero(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID, storeID := seedStore(t, db)
+
+	warehouseID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO warehouses (id, tenant_id, store_id, name) VALUES (?, ?, ?, 'Prio WH')`,
+		warehouseID, tenantID, storeID).Error)
+
+	var priority int
+	require.NoError(t, db.Raw(`SELECT priority FROM warehouses WHERE id = ?`, warehouseID).
+		Row().Scan(&priority))
+	require.Equal(t, 0, priority, "an unranked warehouse sorts with the rest, not ahead of them")
+}
+```
+
+Note: `seedStore` already exists in this package, in `repository_integration_test.go:33`. Do not redefine it.
+
+- [ ] **Step 5: Run the test to verify it fails**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration ./internal/warehouse/... -run 'TestOrderAllocations|TestWarehouses_Priority' -count=1 -p 1 -v
+```
+
+Expected: FAIL with `relation "order_allocations" does not exist` — the migration has not been applied to the test database yet. If instead every test reports `--- SKIP`, `TEST_DATABASE_URL` did not reach the process; fix that before continuing, because a skip is indistinguishable from a pass.
+
+- [ ] **Step 6: Apply the migration**
+
+```bash
+cd services/marketplace-api
+DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go run ./cmd/migrate up
+DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go run ./cmd/migrate version
+```
+
+Expected: `migrations applied`, then `version=118 dirty=false`.
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration ./internal/warehouse/... -count=1 -p 1
+```
+
+Expected: `ok`. A run under ~0.3s means it skipped — check the DSN.
+
+- [ ] **Step 8: Verify the down migration**
+
+```bash
+cd services/marketplace-api
+DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go run ./cmd/migrate down 1
+DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go run ./cmd/migrate up
+DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go run ./cmd/migrate version
+```
+
+Expected: rollback succeeds, re-apply succeeds, `version=118 dirty=false`. A down that errors is a defect in this task, not a later one.
+
+- [ ] **Step 9: Full verification**
+
+```bash
+cd services/marketplace-api
+go build ./... && go vet ./... && go vet -tags=integration ./... && gofmt -l .
+go test ./... -count=1
+```
+
+Expected: no output from `gofmt -l .`, no vet findings, all unit packages `ok`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add services/marketplace-api/migrations/000118_multi_warehouse_schema.up.sql \
+        services/marketplace-api/migrations/000118_multi_warehouse_schema.down.sql \
+        services/marketplace-api/migrations.go \
+        services/marketplace-api/internal/warehouse/allocations_schema_integration_test.go
+git commit -m "feat(shipping): add warehouse priority, order_allocations and shipments.warehouse_id (#177)"
+```
+
+---
+
+### Task 2: `inventory_quantity` becomes a SUM across locations (000119)
+
+**Files:**
+- Create: `services/marketplace-api/migrations/000119_variant_inventory_sum.up.sql`
+- Create: `services/marketplace-api/migrations/000119_variant_inventory_sum.down.sql`
+- Modify: `services/marketplace-api/migrations.go:17`
+- Test: `services/marketplace-api/internal/product/variant_inventory_sum_integration_test.go`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 — the two migrations are independent.
+- Produces: the guarantee every later PR depends on, that
+  `product_variants.inventory_quantity` equals `SUM(variant_stock.quantity)`
+  for the variant. PR 3 relies on it for shopper-facing availability; PR 5
+  relies on it so the product form's total stays right while a merchant edits
+  one location.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `services/marketplace-api/internal/product/variant_inventory_sum_integration_test.go`:
+
+```go
+//go:build integration
+
+// Package product_test — coverage for migration 000119.
+//
+// product_variants.inventory_quantity is what browse, PDP and cart read.
+// Until 000119 the sync trigger assigned the LAST WRITTEN location's
+// quantity, which is the total only while a variant has one stock row. The
+// second warehouse would have made the storefront's stock number mean
+// "whichever warehouse was touched most recently" — wrong, and silently so.
+package product_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedVariantForSum creates the store/product/variant a stock row needs and
+// returns the variant id. No variant_stock row is created: each test decides
+// how many locations it wants.
+func seedVariantForSum(t *testing.T, db *gorm.DB) string {
+	t.Helper()
+	tenantID, storeID := uuid.NewString(), uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO stores (id, tenant_id, name, slug, status, country_code, currency_code, timezone,
+		                     storefront_customer_portal_secret)
+		 VALUES (?, ?, 'Sum Test', ?, 'active', 'IN', 'INR', 'Asia/Kolkata', ?)`,
+		storeID, tenantID, "sum-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	productID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		// status='active' requires published_at (products_published_requires_active).
+		`INSERT INTO products (id, tenant_id, store_id, title, handle, status, vendor_id, published_at)
+		 VALUES (?, ?, ?, 'Sum Test Product', ?, 'active', ?, now())`,
+		productID, tenantID, storeID, "sum-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	variantID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO product_variants (id, product_id, store_id, sku, price, currency_code)
+		 VALUES (?, ?, ?, ?, 10.00, 'INR')`,
+		variantID, productID, storeID, "SKU-"+uuid.NewString()[:8]).Error)
+	return variantID
+}
+
+func addStock(t *testing.T, db *gorm.DB, variantID, locationID string, qty int) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, ?, now())`, variantID, locationID, qty).Error)
+}
+
+func inventoryQuantity(t *testing.T, db *gorm.DB, variantID string) int {
+	t.Helper()
+	var qty int
+	require.NoError(t, db.Raw(
+		`SELECT inventory_quantity FROM product_variants WHERE id = ?`, variantID,
+	).Row().Scan(&qty))
+	return qty
+}
+
+func TestInventorySync_SumsAcrossLocations(t *testing.T) {
+	db := testdb.NewTx(t)
+	variantID := seedVariantForSum(t, db)
+
+	addStock(t, db, variantID, uuid.NewString(), 3)
+	addStock(t, db, variantID, uuid.NewString(), 2)
+
+	require.Equal(t, 5, inventoryQuantity(t, db, variantID),
+		"the storefront's stock number must be the total across warehouses")
+}
+
+// The pre-000119 trigger assigned NEW.quantity, so writing the SMALLER
+// location second would have reported 2 for a variant holding 5. This is the
+// case that pins the fix rather than merely exercising it.
+func TestInventorySync_UpdatingOneLocationKeepsTheTotal(t *testing.T) {
+	db := testdb.NewTx(t)
+	variantID := seedVariantForSum(t, db)
+	locA, locB := uuid.NewString(), uuid.NewString()
+
+	addStock(t, db, variantID, locA, 4)
+	addStock(t, db, variantID, locB, 1)
+	require.Equal(t, 5, inventoryQuantity(t, db, variantID))
+
+	require.NoError(t, db.Exec(
+		`UPDATE variant_stock SET quantity = 2 WHERE variant_id = ? AND location_id = ?`,
+		variantID, locB).Error)
+
+	require.Equal(t, 6, inventoryQuantity(t, db, variantID),
+		"updating one location must re-sum, not overwrite the total with that location")
+}
+
+// Without an AFTER DELETE arm the trigger never fires on removal and
+// inventory_quantity keeps counting stock in a warehouse that no longer has
+// a row — an oversell that no test would otherwise catch.
+func TestInventorySync_DeletingALocationLowersTheTotal(t *testing.T) {
+	db := testdb.NewTx(t)
+	variantID := seedVariantForSum(t, db)
+	locA, locB := uuid.NewString(), uuid.NewString()
+
+	addStock(t, db, variantID, locA, 4)
+	addStock(t, db, variantID, locB, 3)
+	require.Equal(t, 7, inventoryQuantity(t, db, variantID))
+
+	require.NoError(t, db.Exec(
+		`DELETE FROM variant_stock WHERE variant_id = ? AND location_id = ?`,
+		variantID, locB).Error)
+
+	require.Equal(t, 4, inventoryQuantity(t, db, variantID),
+		"removing a location's stock must lower the total")
+}
+
+func TestInventorySync_LastLocationRemovedLeavesZeroNotNull(t *testing.T) {
+	db := testdb.NewTx(t)
+	variantID := seedVariantForSum(t, db)
+	loc := uuid.NewString()
+
+	addStock(t, db, variantID, loc, 6)
+	require.NoError(t, db.Exec(
+		`DELETE FROM variant_stock WHERE variant_id = ?`, variantID).Error)
+
+	require.Equal(t, 0, inventoryQuantity(t, db, variantID),
+		"SUM over no rows is NULL; the trigger must coalesce it to zero")
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration ./internal/product/... -run TestInventorySync -count=1 -p 1 -v
+```
+
+Expected: `TestInventorySync_SumsAcrossLocations` FAILS with `expected: 5, actual: 2` — the old trigger assigned the last row written. `TestInventorySync_DeletingALocationLowersTheTotal` FAILS with `expected: 4, actual: 7`.
+
+If they SKIP, the DSN did not reach the process. If they PASS, migration 000119 has already been applied to this database — check `go run ./cmd/migrate version` before assuming the code is right.
+
+Note: `./internal/product/...` currently has one known pre-existing failure,
+`TestIntegration_ProductService_UpdateAggregate_OptionValueInUseRejected`
+(`variant_matrix_mismatch`, tracked as #400). It is unrelated to this work —
+do not fix it here, and do not let it mask these results. The `-run
+TestInventorySync` filter above excludes it.
+
+- [ ] **Step 3: Write the migration**
+
+Create `services/marketplace-api/migrations/000119_variant_inventory_sum.up.sql`:
+
+```sql
+-- #177: product_variants.inventory_quantity becomes the SUM across a
+-- variant's locations.
+--
+-- 000001 created this trigger with `SET inventory_quantity = NEW.quantity`
+-- and a comment saying slice 2 would change it to a SUM. That assignment is
+-- the total only while a variant has one stock row; with two warehouses the
+-- number browse, PDP and cart all read would become whichever location was
+-- written most recently.
+--
+-- The DELETE arm is new. Without it, removing a warehouse's stock row leaves
+-- inventory_quantity counting units that no longer exist — an oversell with
+-- no error anywhere.
+--
+-- NOTE for anyone editing this: in a DELETE trigger PL/pgSQL leaves NEW
+-- unassigned, and referencing NEW.variant_id there raises "record new is not
+-- assigned yet". Branch on TG_OP; do not reach for COALESCE(NEW, OLD).
+
+CREATE OR REPLACE FUNCTION sync_variant_inventory() RETURNS trigger AS $$
+DECLARE
+    v_variant uuid;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        v_variant := OLD.variant_id;
+    ELSE
+        v_variant := NEW.variant_id;
+    END IF;
+
+    UPDATE product_variants
+       SET inventory_quantity = COALESCE(
+               (SELECT SUM(quantity) FROM variant_stock WHERE variant_id = v_variant), 0)
+     WHERE id = v_variant;
+
+    -- AFTER trigger: the return value is ignored.
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER variant_stock_sync_delete
+    AFTER DELETE ON variant_stock
+    FOR EACH ROW EXECUTE FUNCTION sync_variant_inventory();
+```
+
+Create `services/marketplace-api/migrations/000119_variant_inventory_sum.down.sql`:
+
+```sql
+-- Restores 000001's function verbatim and drops the DELETE arm. Safe while
+-- every variant has one stock row, which is the only state a rollback to
+-- this point can be in: nothing writes a second location until PR 5.
+DROP TRIGGER IF EXISTS variant_stock_sync_delete ON variant_stock;
+
+CREATE OR REPLACE FUNCTION sync_variant_inventory() RETURNS trigger AS $$
+BEGIN
+    UPDATE product_variants
+    SET inventory_quantity = NEW.quantity
+    WHERE id = NEW.variant_id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+```
+
+- [ ] **Step 4: Bump the schema version**
+
+In `services/marketplace-api/migrations.go`, change `ExpectedSchemaVersion` from `118` to `119`.
+
+- [ ] **Step 5: Apply the migration and run the tests**
+
+```bash
+cd services/marketplace-api
+DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go run ./cmd/migrate up
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration ./internal/product/... -run TestInventorySync -count=1 -p 1 -v
+```
+
+Expected: all five `TestInventorySync_*` tests PASS.
+
+- [ ] **Step 6: Mutation-test the DELETE arm**
+
+The DELETE arm is the guard most likely to be quietly wrong, so prove a test catches its absence.
+
+```bash
+docker exec -i dev-postgres-1 psql -U dev -d marketplace_db -v ON_ERROR_STOP=1 \
+  -c "DROP TRIGGER variant_stock_sync_delete ON variant_stock;"
+
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration ./internal/product/... -run TestInventorySync -count=1 -p 1
+```
+
+Expected: FAIL — `TestInventorySync_DeletingALocationLowersTheTotal` and
+`TestInventorySync_LastLocationRemovedLeavesZeroNotNull` both fail. If they
+pass, the tests are decoration and must be fixed before continuing.
+
+Restore it:
+
+```bash
+docker exec -i dev-postgres-1 psql -U dev -d marketplace_db -v ON_ERROR_STOP=1 \
+  -c "CREATE TRIGGER variant_stock_sync_delete AFTER DELETE ON variant_stock FOR EACH ROW EXECUTE FUNCTION sync_variant_inventory();"
+
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration ./internal/product/... -run TestInventorySync -count=1 -p 1
+```
+
+Expected: `ok` again.
+
+- [ ] **Step 7: Verify the down migration**
+
+```bash
+cd services/marketplace-api
+DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go run ./cmd/migrate down 1
+DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go run ./cmd/migrate up
+DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go run ./cmd/migrate version
+```
+
+Expected: `version=119 dirty=false`.
+
+- [ ] **Step 8: Run the affected integration packages**
+
+The trigger sits under every stock write, so the packages that write stock must be re-run — this is the blast radius of the change.
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 \
+  ./internal/stockhold/... ./internal/warehouse/... ./internal/handlers/storefront/...
+```
+
+Expected: all `ok`. Durations should be seconds, not milliseconds.
+
+- [ ] **Step 9: Full verification**
+
+```bash
+cd services/marketplace-api
+go build ./... && go vet ./... && go vet -tags=integration ./... && gofmt -l .
+go test ./... -count=1
+```
+
+Expected: clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add services/marketplace-api/migrations/000119_variant_inventory_sum.up.sql \
+        services/marketplace-api/migrations/000119_variant_inventory_sum.down.sql \
+        services/marketplace-api/migrations.go \
+        services/marketplace-api/internal/product/variant_inventory_sum_integration_test.go
+git commit -m "fix(product): sum variant stock across locations instead of taking the last write (#177)"
+```
+
+---
+
+## Done when
+
+- `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `gofmt -l .` all clean
+- `go test ./... -count=1` green, including `TestExpectedSchemaVersionMatchesHighestMigration` at 119
+- Integration packages `internal/warehouse`, `internal/product` (`-run TestInventorySync`), `internal/stockhold`, `internal/handlers/storefront` green against the real DSN, with durations that prove they ran
+- Both down migrations exercised
+- The DELETE arm mutation-tested: removed, tests failed, restored, tests passed
+
+## Explicitly NOT in this PR
+
+- `internal/allocation` and the allocator (PR 2)
+- Any change to `commitStock`, `cart_holds.go`, or anything that writes `order_allocations` (PR 3)
+- Shipment-per-warehouse, `fulfillment_status = 'partial'`, the order-detail `Shipment` field becoming a list (PR 4)
+- Warehouse CRUD, the carrier-config picker, per-location stock editing (PR 5)
+- The sentinel backfill and deleting `DefaultLocationID` — that is PR 6 and must not land until PRs 1–5 are deployed on admin, storefront and both CronJobs
+- Fixing `TestIntegration_ProductService_UpdateAggregate_OptionValueInUseRejected` (#400), which fails before this PR and after it

--- a/docs/superpowers/plans/2026-08-31-multi-warehouse-01-schema-and-trigger.md
+++ b/docs/superpowers/plans/2026-08-31-multi-warehouse-01-schema-and-trigger.md
@@ -574,7 +574,7 @@ TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=
   go test -tags=integration ./internal/product/... -run TestInventorySync -count=1 -p 1 -v
 ```
 
-Expected: all five `TestInventorySync_*` tests PASS.
+Expected: all four `TestInventorySync_*` tests PASS.
 
 - [ ] **Step 6: Mutation-test the DELETE arm**
 

--- a/docs/superpowers/specs/2026-08-31-multi-warehouse-allocation-design.md
+++ b/docs/superpowers/specs/2026-08-31-multi-warehouse-allocation-design.md
@@ -1,0 +1,345 @@
+# Multi-warehouse: per-location inventory and order allocation
+
+Design for the remainder of #177. Written 2026-08-31, after #480 (store-level
+`warehouses` table, readers and writers moved onto `warehouse_id`) and #484
+(the eight legacy `warehouse_*` columns dropped, migration 000117, live in
+production).
+
+## What this delivers
+
+A store can run more than one warehouse. Stock is held per warehouse, an
+order is allocated across warehouses when it is placed, and each warehouse
+that contributes ships its own parcel.
+
+## Product decisions
+
+These three were decided by the product owner on 2026-08-31. They are
+recorded here because each one has cheaper alternatives that a later reader
+might otherwise assume were overlooked.
+
+1. **Allocation rule: explicit priority order.** The merchant ranks their
+   warehouses; allocation fills from the top down. Not nearest-pincode
+   (needs distance data marketplace-api does not hold) and not most-stock
+   (non-deterministic between two similar orders minutes apart).
+2. **An order that no single warehouse can fill is split**, not rejected and
+   not backordered. Two warehouses contributing means two shipments, two
+   labels, two tracking numbers.
+3. **The binding allocation happens at order placement**, not at
+   add-to-cart and not at label creation.
+
+### One refinement decision 3 forces
+
+`stock_holds.location_id` is `NOT NULL` and part of the
+`(cart_token, variant_id, location_id)` unique key, so a cart-time hold must
+name a location. A cart hold parked on a sentinel would reserve nothing real
+and the units could be sold from under the shopper between cart and
+checkout — losing the guarantee #231 exists to provide.
+
+So cart-time holds are **provisional**: add-to-cart runs the allocator and
+places per-location holds. Order placement runs the allocator again against
+fresh availability, adjusts the holds if the plan has changed, and only that
+second plan is written to `order_allocations`. The binding decision is at
+placement, as decided; the reservation is continuous, as #231 requires.
+
+## Non-goals
+
+- **Minimising parcel count.** Filling from the merchant's first warehouse
+  down is explainable to a merchant; a true minimum is a bin-packing problem
+  and buys one fewer parcel in rare cases.
+- **Nearest-warehouse allocation.** Excluded by decision 1. The allocator's
+  interface takes an ordered warehouse list, so adding a different ordering
+  later does not change its callers.
+- **Backorders.** No order line may be left partly unfulfilled at placement.
+- **Re-planning on a lost hold race.** If a hold fails between snapshot and
+  placement the order fails out-of-stock, exactly as a single-warehouse
+  shopper's does today. Build the retry when the race is observed, not
+  before.
+- **Transfers between warehouses.** Stock moves by editing both numbers.
+
+## Data model
+
+### `warehouses.priority`
+
+```sql
+ALTER TABLE warehouses ADD COLUMN priority integer NOT NULL DEFAULT 0;
+```
+
+Allocation orders by `priority ASC, is_default DESC, created_at ASC`. The
+tiebreakers make the ordering total: two warehouses created in the same
+second must not allocate differently between two requests.
+
+### `order_allocations`
+
+```sql
+CREATE TABLE order_allocations (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id     uuid NOT NULL,
+    store_id      uuid NOT NULL,
+    order_id      uuid NOT NULL REFERENCES orders(id)       ON DELETE CASCADE,
+    order_item_id uuid NOT NULL REFERENCES order_items(id)  ON DELETE CASCADE,
+    warehouse_id  uuid NOT NULL REFERENCES warehouses(id)   ON DELETE RESTRICT,
+    quantity      integer NOT NULL CHECK (quantity > 0),
+    shipment_id   uuid REFERENCES shipments(id)             ON DELETE SET NULL,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (order_item_id, warehouse_id)
+);
+CREATE INDEX order_allocations_order_idx    ON order_allocations (order_id);
+CREATE INDEX order_allocations_shipment_idx ON order_allocations (shipment_id);
+```
+
+One row per (line, warehouse). `ON DELETE RESTRICT` on `warehouse_id` is what
+stops a merchant deleting a warehouse that owes a parcel.
+
+The invariant — for each line, `SUM(quantity)` equals `order_items.quantity` —
+cannot be a table CHECK, since it spans rows. It is enforced in the allocator
+and pinned by a test that deletes the enforcement and watches the test fail.
+
+`shipment_id` is NULL until a label is printed. That is the flag that makes
+re-allocation safe before printing and refused after.
+
+### `shipments.warehouse_id`
+
+```sql
+ALTER TABLE shipments ADD COLUMN warehouse_id uuid REFERENCES warehouses(id);
+```
+
+Nullable: every shipment created before this has no honest answer. Every
+shipment created after it sets the column.
+
+### The `sync_variant_inventory` trigger
+
+Today:
+
+```sql
+UPDATE product_variants SET inventory_quantity = NEW.quantity
+ WHERE id = NEW.variant_id;
+```
+
+It assigns the *last touched* location's quantity. With one location that is
+the total; with two, `product_variants.inventory_quantity` — which browse,
+PDP and cart all read — becomes whichever warehouse was written most
+recently. The function's own comment says slice 2 changes it to a SUM.
+
+It becomes a SUM over the variant's rows, and gains an `AFTER DELETE` arm it
+does not have today: removing a warehouse's stock row must lower the total,
+and with only INSERT and UPDATE triggers it would not.
+
+### Warehouse deletion
+
+Refused while the warehouse holds stock (`variant_stock.quantity > 0`) or owes
+a parcel (`order_allocations` rows with a NULL `shipment_id`).
+
+The `ON DELETE RESTRICT` FK is a backstop, not the rule: it refuses while
+*any* allocation row references the warehouse, including long-shipped ones,
+which would make a warehouse undeletable forever. Both rules therefore live in
+the repository with their own tests, and the FK exists so that a path which
+forgets them fails loudly instead of orphaning an unshipped parcel. Deleting a
+warehouse with shipped history is allowed and nulls nothing — the allocation
+rows keep pointing at it, which is why it is RESTRICT and not CASCADE.
+
+## The sentinel backfill, and why it is two deploys
+
+`variant_stock` and `stock_holds` both carry
+`location_id = '00000000-0000-0000-0000-000000000001'`, the `DefaultLocationID`
+constant in `internal/product/service.go`. Nine non-test call sites pass it:
+five under `internal/product/`, and four in storefront checkout and cart-hold
+code that did not exist when #177 was filed (the issue's count of seven
+predates `stock_holds`).
+
+A store can hold stock while having no `warehouses` row at all: warehouses are
+created only when a carrier config is saved, and production currently has zero
+of both. So the backfill must first *create* a warehouse for each store that
+holds stock — `name = 'Main Warehouse'`, blank address, `is_default = true` —
+then rewrite `location_id` to it. A blank address is the honest state: that
+store has not told us where it ships from, and the existing admin settings
+flow is what fills it in.
+
+**This cannot be one deploy.** Migrations run in the `migrate` initContainer
+on the **admin** deployment only; `marketplace-api-storefront` and the sweeper
+CronJobs share the image but roll independently (verified while shipping #484
+and #486). Code still on the old image reads and writes the sentinel. If the
+backfill lands first, an old storefront pod holds stock against a location id
+that no longer has rows, availability reads zero, and every shopper is told
+the item is sold out.
+
+So, the same expand/contract shape #484 used:
+
+1. **Expand.** Add `priority`, `order_allocations`, `shipments.warehouse_id`,
+   change the trigger to SUM (a no-op while every variant has one row). Ship
+   code that resolves the store's warehouse and tolerates BOTH: a
+   `variant_stock` row on a real warehouse id and one on the sentinel.
+2. **Contract.** Once that is deployed on admin, storefront and the CronJobs,
+   run the backfill and remove the sentinel tolerance.
+
+`DefaultLocationID` is deleted at the end of step 2, not before.
+
+## The allocator
+
+A new package, `internal/allocation`, with a pure decision core:
+
+```go
+// Plan returns which warehouse ships how much of each line, or
+// ErrCannotFill naming the first line that no combination satisfies.
+func Plan(warehouses []Warehouse, avail Availability, lines []Line) ([]Assignment, error)
+```
+
+No database access in the decision, so its interesting cases are table tests
+rather than fixtures.
+
+**Algorithm.** Walk the warehouses in priority order. At each, take
+`min(remaining, available)` for every line not yet satisfied. Stop when all
+lines are satisfied; fail if any line still has a remainder.
+
+**`continue`-policy variants sell past zero**, so availability does not
+constrain them and a naive loop assigns them nowhere. They are assigned whole
+to the highest-priority warehouse. Stated explicitly because the silent
+alternative is an order line that ships from nothing.
+
+**The plan is advisory; `stockhold.Hold` is the guarantee.** Allocation runs
+inside the order transaction, then a hold is placed per assignment. `Hold`'s
+own availability check, under the existing `SELECT … FOR UPDATE` discipline,
+is what stops two orders taking the last unit. Nothing in this design adds a
+new concurrency primitive.
+
+## Checkout
+
+`commitStock` in `internal/handlers/storefront/checkout_stock.go` is the
+chokepoint and keeps its shape. It changes from "hold each line at the
+sentinel" to:
+
+1. Load the store's warehouses in priority order and the per-location
+   availability snapshot.
+2. `allocation.Plan(...)`.
+3. Place a hold per assignment, at that assignment's warehouse.
+4. Write `order_allocations` from the plan.
+5. `holds.Commit(cartToken)` — unchanged; it already commits every live hold
+   the cart owns.
+
+A line split across two warehouses becomes two holds for the same cart and
+variant at different locations, which the `(cart_token, variant_id,
+location_id)` unique key already permits.
+
+`cart_holds.go` runs steps 1–3 only: provisional holds, no
+`order_allocations` row. At placement, assignments that no longer match are
+released and replaced before the commit.
+
+Shopper-facing availability is the sum across locations — already what the
+storefront displays, because it reads `product_variants.inventory_quantity`.
+
+## Fulfilment
+
+Label creation groups `order_allocations` by warehouse and creates one
+shipment per group. Each shipment:
+
+- resolves `ship_from` from **its own** warehouse, not from the carrier
+  config's `warehouse_id`,
+- sets `shipments.warehouse_id`,
+- stamps its id onto the allocation rows it covers.
+
+The carrier config continues to supply credentials and provider; only the
+origin moves. Each warehouse registers with the carrier separately —
+`UpsertWarehouse` already does adopt-or-create by name.
+
+`fulfillment_status` becomes `partial` while any allocation group has no
+shipment, and `fulfilled` when every group has one. Both values and the
+`unfulfilled → partial → fulfilled` transition already exist in
+`internal/order/status.go`; `partial` has simply never been written.
+
+## Admin
+
+**The warehouse stops being a sub-form of a carrier config.** Today
+`ShippingConfigForm` embeds `AddressFieldset` and saving a Delhivery config
+upserts the warehouse behind it — #480 removed the duplicated storage but a
+merchant still types an address into a carrier form.
+
+- New `settings/warehouses` page: list, create, edit, delete, mark default,
+  set priority.
+- `ShippingConfigForm` drops `AddressFieldset` and gains a warehouse picker.
+- `/api/v1/admin/stores/:storeId/warehouses` — list, create, update, delete,
+  reorder. `internal/warehouse` has `Upsert`, `DefaultForStore` and `ByID`
+  already; it gains `List`, `Delete` (with the refusal rules above) and
+  `SetPriorities`.
+
+**Per-location stock editing, under one rule: a store with one warehouse sees
+exactly what it sees today.** The product form keeps its single stock field
+until a second warehouse exists, then expands to a per-warehouse breakdown
+with the total shown. Otherwise every existing merchant pays complexity for a
+feature they are not using.
+
+`UpdateVariantStockInTx` remains the single mutation chokepoint, guarded by
+its existing test. It already takes a location; the change is carrying a real
+warehouse id down from the API instead of the sentinel.
+
+## Consumers of split shipments
+
+**Refunds are unaffected**, and this is the reason for a separate
+`order_allocations` table rather than a `warehouse_id` on `order_items`.
+`refunds.order_item_id` is a RESTRICT FK onto `order_items`; lines are never
+split, so a refund means the same thing whether the order shipped as one
+parcel or three.
+
+**The customer order page must change.** `order_detail.go` exposes
+`Shipment *storefrontShipmentResponse` — singular — and `loadShipment(orderID)`
+returns one row. With two parcels the customer sees one tracking number and
+silently loses the other. The field becomes a list. This is a public
+response-shape change, so the storefront app rendering it ships in the same
+release.
+
+**Cancellation narrows.** Cancelling a shipment stays coherent per parcel.
+Cancelling an *order* may only cover groups that have not shipped; attempting
+it against a shipped group is refused rather than half-applied.
+
+**`orderdoc`** is already partly multi-shipment aware (`lookupDeliveredAt`
+reads the most recently delivered shipment). The dispatched email is written
+per shipment and will now send once per parcel. That is correct, and the copy
+must name the parcel — two identical "your order has shipped" emails read as
+a bug.
+
+## Testing
+
+- **Allocator:** table tests over the pure core. Cases: single warehouse
+  fills; two warehouses split one line; a line no combination can fill;
+  `continue`-policy assignment; priority ties broken deterministically.
+- **Every guard is mutation-tested.** Delete the guard, watch a test fail. A
+  guard whose removal breaks nothing is decoration. This applies at minimum
+  to the per-line quantity invariant, the warehouse-deletion refusals, and
+  the trigger's DELETE arm.
+- **Integration tests** are `//go:build integration`, gated on
+  `TEST_DATABASE_URL` (never `TEST_DB_DSN`), run with `-p 1`. A skip reads as
+  a pass, so any claim about an integration run must name the DSN it ran
+  with.
+- **Trigger coverage** reads the migration verbatim from the embedded
+  `MigrationsFS`, as migration 000116's test did, so the test exercises what
+  ships rather than a copy that can drift.
+- **The backfill** is tested at both deploy steps: sentinel rows tolerated
+  before it, absent after.
+
+## Risks
+
+- **The two-deploy sequence is the highest risk in this design.** Landing the
+  backfill before the tolerant code reaches storefront presents as every
+  product being sold out. The contract migration must not merge until the
+  expand half is confirmed running on admin, storefront and both CronJobs.
+- **The trigger change is silent if wrong.** A SUM that misses the DELETE arm
+  overstates stock and oversells. Mutation-test it.
+- **The public `Shipment` field change** breaks any consumer not updated in
+  the same release. The storefront app is the only known one; that must be
+  verified, not assumed.
+- **Nobody is using warehouses yet.** Production has zero warehouses and zero
+  carrier configs, so none of this can be validated against real merchant
+  data before it ships. Integration coverage carries the whole weight.
+
+## Suggested delivery order
+
+Each is a separate PR; each is deployable on its own.
+
+1. `priority`, `order_allocations`, `shipments.warehouse_id`, trigger → SUM
+   with the DELETE arm. Additive; no behaviour change while every store has
+   one warehouse.
+2. `internal/allocation` — the pure core and its tests. No callers.
+3. Checkout: allocation at cart and at placement, tolerating the sentinel.
+4. Fulfilment: shipment per group, `partial` fulfillment status, order-detail
+   `Shipment` → list, storefront app updated.
+5. Admin: warehouse CRUD, carrier-config picker, per-location stock editing.
+6. **Contract:** backfill the sentinel, delete `DefaultLocationID`. Only after
+   1–5 are deployed everywhere.

--- a/docs/superpowers/specs/2026-08-31-multi-warehouse-allocation-design.md
+++ b/docs/superpowers/specs/2026-08-31-multi-warehouse-allocation-design.md
@@ -126,16 +126,20 @@ and with only INSERT and UPDATE triggers it would not.
 
 ### Warehouse deletion
 
-Refused while the warehouse holds stock (`variant_stock.quantity > 0`) or owes
-a parcel (`order_allocations` rows with a NULL `shipment_id`).
+A warehouse with ANY allocation history — even fully shipped — is **archived,
+never deleted**. `ON DELETE RESTRICT` on `order_allocations.warehouse_id` is
+correct as the hard backstop for this: an allocation row is the record of
+which warehouse shipped a line, and deleting the warehouse would corrupt that
+record. There is no separate "shipped history is deletable" case for the
+repository to special-case — `RESTRICT` refuses it outright, which is what we
+want.
 
-The `ON DELETE RESTRICT` FK is a backstop, not the rule: it refuses while
-*any* allocation row references the warehouse, including long-shipped ones,
-which would make a warehouse undeletable forever. Both rules therefore live in
-the repository with their own tests, and the FK exists so that a path which
-forgets them fails loudly instead of orphaning an unshipped parcel. Deleting a
-warehouse with shipped history is allowed and nulls nothing — the allocation
-rows keep pointing at it, which is why it is RESTRICT and not CASCADE.
+PR 5 implements archiving (an `archived_at` column on `warehouses`) as the
+actual removal mechanism. The repository's deletion rules — refused while the
+warehouse holds stock or owes a parcel — therefore apply only to warehouses
+with no allocation history at all; a warehouse with any history is archived
+instead, and `shipments.warehouse_id`'s FK is moot for deletion purposes
+rather than a second trap to reason about.
 
 ## The sentinel backfill, and why it is two deploys
 
@@ -308,9 +312,12 @@ a bug.
   `TEST_DATABASE_URL` (never `TEST_DB_DSN`), run with `-p 1`. A skip reads as
   a pass, so any claim about an integration run must name the DSN it ran
   with.
-- **Trigger coverage** reads the migration verbatim from the embedded
-  `MigrationsFS`, as migration 000116's test did, so the test exercises what
-  ships rather than a copy that can drift.
+- **Trigger coverage** asserts against the already-migrated test database
+  rather than parsing the migration file directly. That database is itself
+  migrated from the same embedded `MigrationsFS`, so this is equivalent to
+  reading the migration verbatim and matches the existing convention in
+  these packages — no test in this codebase re-parses SQL out of
+  `MigrationsFS` at assertion time.
 - **The backfill** is tested at both deploy steps: sentinel rows tolerated
   before it, absent after.
 

--- a/services/marketplace-api/internal/product/variant_inventory_sum_integration_test.go
+++ b/services/marketplace-api/internal/product/variant_inventory_sum_integration_test.go
@@ -11,6 +11,7 @@ package product_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -124,4 +125,89 @@ func TestInventorySync_LastLocationRemovedLeavesZeroNotNull(t *testing.T) {
 
 	require.Equal(t, 0, inventoryQuantity(t, db, variantID),
 		"SUM over no rows is NULL; the trigger must coalesce it to zero")
+}
+
+// waitForBlockedLock polls pg_locks until it sees ANY ungranted lock request,
+// or the timeout elapses. Used instead of a bare sleep so the interleaving
+// below is deterministic rather than hoping a fixed delay was long enough.
+//
+// Deliberately not scoped to a specific relation: a second transaction
+// waiting on a first transaction's uncommitted UPDATE of a conflicting row
+// shows up as a `transactionid` wait (PostgreSQL's XactLockTableWait), not a
+// `relation`-typed tuple lock joinable to pg_class — so filtering by relname
+// would miss exactly the wait this test relies on.
+func waitForBlockedLock(t *testing.T, db *gorm.DB, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var n int64
+		require.NoError(t, db.Raw(
+			`SELECT count(*) FROM pg_locks WHERE NOT granted`,
+		).Row().Scan(&n))
+		if n > 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for a blocked lock")
+}
+
+// TestInventorySync_ConcurrentWritesToDifferentLocationsDoNotLoseUpdates
+// reproduces the race the reviewer found on Postgres 15: a variant with
+// locations A=5, B=4 (inventory_quantity=9). Tx1 sets A=3 and sleeps before
+// commit; Tx2 sets B=2 and commits.
+//
+// Without the row lock this test would still (correctly) see Tx2 block on
+// Tx1's held lock on the product_variants row — but the trigger's `SELECT
+// SUM(...)` sub-select is evaluated against Tx2's PRE-BLOCK snapshot (where A
+// is still 5), and PostgreSQL's EvalPlanQual re-checks only the UPDATE's
+// qual on unblocking, not that sub-select. The result is inventory_quantity
+// = 7 (5 + 2) even though the true total, once both commit, is 5 (3 + 2).
+//
+// This needs two real connections, not testdb.NewTx (one transaction can't
+// interleave with itself). testdb.NewDB's pool has room for both: the setup
+// connection plus one each for tx1 and tx2.
+func TestInventorySync_ConcurrentWritesToDifferentLocationsDoNotLoseUpdates(t *testing.T) {
+	db := testdb.NewDB(t, "variant_stock", "product_variants", "products", "stores")
+	variantID := seedVariantForSum(t, db)
+	locA, locB := uuid.NewString(), uuid.NewString()
+
+	addStock(t, db, variantID, locA, 5)
+	addStock(t, db, variantID, locB, 4)
+	require.Equal(t, 9, inventoryQuantity(t, db, variantID))
+
+	tx1 := db.Begin()
+	require.NoError(t, tx1.Error)
+	require.NoError(t, tx1.Exec(
+		`UPDATE variant_stock SET quantity = 3 WHERE variant_id = ? AND location_id = ?`,
+		variantID, locA).Error)
+
+	tx2Done := make(chan error, 1)
+	go func() {
+		tx2 := db.Begin()
+		if tx2.Error != nil {
+			tx2Done <- tx2.Error
+			return
+		}
+		if err := tx2.Exec(
+			`UPDATE variant_stock SET quantity = 2 WHERE variant_id = ? AND location_id = ?`,
+			variantID, locB).Error; err != nil {
+			tx2.Rollback()
+			tx2Done <- err
+			return
+		}
+		tx2Done <- tx2.Commit().Error
+	}()
+
+	// Confirm tx2 is genuinely blocked on tx1's lock before committing tx1 —
+	// otherwise the two writes might not interleave at all and the test
+	// would pass without exercising the race.
+	waitForBlockedLock(t, db, 3*time.Second)
+
+	require.NoError(t, tx1.Commit().Error)
+	require.NoError(t, <-tx2Done, "tx2 must succeed once tx1's lock is released")
+
+	require.Equal(t, 5, inventoryQuantity(t, db, variantID),
+		"concurrent writes to different locations of the same variant must not lose an update: "+
+			"true total after both commits is 5 (3+2), not 7 (the pre-block snapshot of A plus B)")
 }

--- a/services/marketplace-api/internal/product/variant_inventory_sum_integration_test.go
+++ b/services/marketplace-api/internal/product/variant_inventory_sum_integration_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+// Package product_test — coverage for migration 000119.
+//
+// product_variants.inventory_quantity is what browse, PDP and cart read.
+// Until 000119 the sync trigger assigned the LAST WRITTEN location's
+// quantity, which is the total only while a variant has one stock row. The
+// second warehouse would have made the storefront's stock number mean
+// "whichever warehouse was touched most recently" — wrong, and silently so.
+package product_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedVariantForSum creates the store/product/variant a stock row needs and
+// returns the variant id. No variant_stock row is created: each test decides
+// how many locations it wants.
+func seedVariantForSum(t *testing.T, db *gorm.DB) string {
+	t.Helper()
+	tenantID, storeID := uuid.NewString(), uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO stores (id, tenant_id, name, slug, status, country_code, currency_code, timezone,
+		                     storefront_customer_portal_secret)
+		 VALUES (?, ?, 'Sum Test', ?, 'active', 'IN', 'INR', 'Asia/Kolkata', ?)`,
+		storeID, tenantID, "sum-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	productID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		// status='active' requires published_at (products_published_requires_active).
+		`INSERT INTO products (id, tenant_id, store_id, title, handle, status, vendor_id, published_at)
+		 VALUES (?, ?, ?, 'Sum Test Product', ?, 'active', ?, now())`,
+		productID, tenantID, storeID, "sum-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	variantID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO product_variants (id, product_id, store_id, sku, price, currency_code)
+		 VALUES (?, ?, ?, ?, 10.00, 'INR')`,
+		variantID, productID, storeID, "SKU-"+uuid.NewString()[:8]).Error)
+	return variantID
+}
+
+func addStock(t *testing.T, db *gorm.DB, variantID, locationID string, qty int) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, ?, now())`, variantID, locationID, qty).Error)
+}
+
+func inventoryQuantity(t *testing.T, db *gorm.DB, variantID string) int {
+	t.Helper()
+	var qty int
+	require.NoError(t, db.Raw(
+		`SELECT inventory_quantity FROM product_variants WHERE id = ?`, variantID,
+	).Row().Scan(&qty))
+	return qty
+}
+
+func TestInventorySync_SumsAcrossLocations(t *testing.T) {
+	db := testdb.NewTx(t)
+	variantID := seedVariantForSum(t, db)
+
+	addStock(t, db, variantID, uuid.NewString(), 3)
+	addStock(t, db, variantID, uuid.NewString(), 2)
+
+	require.Equal(t, 5, inventoryQuantity(t, db, variantID),
+		"the storefront's stock number must be the total across warehouses")
+}
+
+// The pre-000119 trigger assigned NEW.quantity, so writing the SMALLER
+// location second would have reported 2 for a variant holding 5. This is the
+// case that pins the fix rather than merely exercising it.
+func TestInventorySync_UpdatingOneLocationKeepsTheTotal(t *testing.T) {
+	db := testdb.NewTx(t)
+	variantID := seedVariantForSum(t, db)
+	locA, locB := uuid.NewString(), uuid.NewString()
+
+	addStock(t, db, variantID, locA, 4)
+	addStock(t, db, variantID, locB, 1)
+	require.Equal(t, 5, inventoryQuantity(t, db, variantID))
+
+	require.NoError(t, db.Exec(
+		`UPDATE variant_stock SET quantity = 2 WHERE variant_id = ? AND location_id = ?`,
+		variantID, locB).Error)
+
+	require.Equal(t, 6, inventoryQuantity(t, db, variantID),
+		"updating one location must re-sum, not overwrite the total with that location")
+}
+
+// Without an AFTER DELETE arm the trigger never fires on removal and
+// inventory_quantity keeps counting stock in a warehouse that no longer has
+// a row — an oversell that no test would otherwise catch.
+func TestInventorySync_DeletingALocationLowersTheTotal(t *testing.T) {
+	db := testdb.NewTx(t)
+	variantID := seedVariantForSum(t, db)
+	locA, locB := uuid.NewString(), uuid.NewString()
+
+	addStock(t, db, variantID, locA, 4)
+	addStock(t, db, variantID, locB, 3)
+	require.Equal(t, 7, inventoryQuantity(t, db, variantID))
+
+	require.NoError(t, db.Exec(
+		`DELETE FROM variant_stock WHERE variant_id = ? AND location_id = ?`,
+		variantID, locB).Error)
+
+	require.Equal(t, 4, inventoryQuantity(t, db, variantID),
+		"removing a location's stock must lower the total")
+}
+
+func TestInventorySync_LastLocationRemovedLeavesZeroNotNull(t *testing.T) {
+	db := testdb.NewTx(t)
+	variantID := seedVariantForSum(t, db)
+	loc := uuid.NewString()
+
+	addStock(t, db, variantID, loc, 6)
+	require.NoError(t, db.Exec(
+		`DELETE FROM variant_stock WHERE variant_id = ?`, variantID).Error)
+
+	require.Equal(t, 0, inventoryQuantity(t, db, variantID),
+		"SUM over no rows is NULL; the trigger must coalesce it to zero")
+}

--- a/services/marketplace-api/internal/warehouse/allocations_schema_integration_test.go
+++ b/services/marketplace-api/internal/warehouse/allocations_schema_integration_test.go
@@ -1,0 +1,115 @@
+//go:build integration
+
+// Package warehouse_test — coverage for migration 000118, the schema half
+// of #177's multi-warehouse work.
+//
+// These assert BEHAVIOUR (what the table refuses) rather than catalogue
+// entries: a test that only checks a column exists passes against a table
+// whose constraints were all dropped.
+package warehouse_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedAllocatableOrder creates the store, warehouse, order and order line an
+// order_allocations row needs, and returns their ids.
+func seedAllocatableOrder(t *testing.T, db *gorm.DB) (tenantID, storeID, warehouseID, orderID, orderItemID string) {
+	t.Helper()
+	tenantID, storeID = seedStore(t, db)
+
+	warehouseID = uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO warehouses (id, tenant_id, store_id, name, line1, city, region, postal_code, country_code, phone)
+		 VALUES (?, ?, ?, 'Alloc WH', '1 Dock Rd', 'Mumbai', 'MH', '400001', 'IN', '+912200000000')`,
+		warehouseID, tenantID, storeID).Error)
+
+	orderID = uuid.NewString()
+	require.NoError(t, db.Exec(
+		// customer_email, not email. idempotency_key is NOT NULL with no
+		// default and is unique per store, so it gets a fresh uuid.
+		`INSERT INTO orders (id, tenant_id, store_id, order_number, idempotency_key,
+		                     customer_email, currency_code, subtotal, grand_total)
+		 VALUES (?, ?, ?, ?, ?, 'buyer@example.com', 'INR', 100.00, 100.00)`,
+		orderID, tenantID, storeID, "AL-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	orderItemID = uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO order_items (id, order_id, title_snapshot, sku_snapshot, unit_price,
+		                          quantity, line_total, currency_code)
+		 VALUES (?, ?, 'Ink Tee', 'SKU-1', 50.00, 2, 100.00, 'INR')`,
+		orderItemID, orderID).Error)
+
+	return tenantID, storeID, warehouseID, orderID, orderItemID
+}
+
+func insertAllocation(db *gorm.DB, tenantID, storeID, orderID, orderItemID, warehouseID string, qty int) error {
+	return db.Exec(
+		`INSERT INTO order_allocations (tenant_id, store_id, order_id, order_item_id, warehouse_id, quantity)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		tenantID, storeID, orderID, orderItemID, warehouseID, qty).Error
+}
+
+func TestOrderAllocations_AcceptsARowAndDefaultsShipmentToNull(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID, storeID, warehouseID, orderID, orderItemID := seedAllocatableOrder(t, db)
+
+	require.NoError(t, insertAllocation(db, tenantID, storeID, orderID, orderItemID, warehouseID, 2))
+
+	var shipmentID *string
+	require.NoError(t, db.Raw(
+		`SELECT shipment_id FROM order_allocations WHERE order_item_id = ?`, orderItemID,
+	).Row().Scan(&shipmentID))
+	require.Nil(t, shipmentID, "an allocation is unshipped until a label is printed")
+}
+
+// A line allocated twice to the same warehouse is a bug, not a top-up: the
+// allocator emits one row per (line, warehouse).
+func TestOrderAllocations_RejectsASecondRowForTheSameLineAndWarehouse(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID, storeID, warehouseID, orderID, orderItemID := seedAllocatableOrder(t, db)
+
+	require.NoError(t, insertAllocation(db, tenantID, storeID, orderID, orderItemID, warehouseID, 1))
+	err := insertAllocation(db, tenantID, storeID, orderID, orderItemID, warehouseID, 1)
+	require.Error(t, err, "the (order_item_id, warehouse_id) unique key must refuse the duplicate")
+}
+
+func TestOrderAllocations_RejectsZeroQuantity(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID, storeID, warehouseID, orderID, orderItemID := seedAllocatableOrder(t, db)
+
+	err := insertAllocation(db, tenantID, storeID, orderID, orderItemID, warehouseID, 0)
+	require.Error(t, err, "an allocation of nothing is meaningless and must be refused")
+}
+
+// The FK is the backstop behind the repository's deletion rules (PR 5): a
+// path that forgets them must fail loudly rather than orphan a parcel.
+func TestOrderAllocations_WarehouseCannotBeDeletedWhileAllocated(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID, storeID, warehouseID, orderID, orderItemID := seedAllocatableOrder(t, db)
+	require.NoError(t, insertAllocation(db, tenantID, storeID, orderID, orderItemID, warehouseID, 2))
+
+	err := db.Exec(`DELETE FROM warehouses WHERE id = ?`, warehouseID).Error
+	require.Error(t, err, "ON DELETE RESTRICT must refuse while an allocation references the warehouse")
+}
+
+func TestWarehouses_PriorityDefaultsToZero(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID, storeID := seedStore(t, db)
+
+	warehouseID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO warehouses (id, tenant_id, store_id, name) VALUES (?, ?, ?, 'Prio WH')`,
+		warehouseID, tenantID, storeID).Error)
+
+	var priority int
+	require.NoError(t, db.Raw(`SELECT priority FROM warehouses WHERE id = ?`, warehouseID).
+		Row().Scan(&priority))
+	require.Equal(t, 0, priority, "an unranked warehouse sorts with the rest, not ahead of them")
+}

--- a/services/marketplace-api/internal/warehouse/allocations_schema_integration_test.go
+++ b/services/marketplace-api/internal/warehouse/allocations_schema_integration_test.go
@@ -113,3 +113,21 @@ func TestWarehouses_PriorityDefaultsToZero(t *testing.T) {
 		Row().Scan(&priority))
 	require.Equal(t, 0, priority, "an unranked warehouse sorts with the rest, not ahead of them")
 }
+
+// A default of 0 would still hold even if NOT NULL were dropped, so
+// TestWarehouses_PriorityDefaultsToZero alone doesn't pin the constraint.
+// This asserts the constraint directly: an explicit NULL must be refused.
+//
+// The failing INSERT aborts the transaction, so this test does not attempt
+// any further DB call afterward — a later assertion in the same
+// testdb.NewTx would fail for the unrelated reason that the transaction is
+// already aborted, not because the behaviour under test changed.
+func TestWarehouses_PriorityRejectsExplicitNull(t *testing.T) {
+	db := testdb.NewTx(t)
+	tenantID, storeID := seedStore(t, db)
+
+	err := db.Exec(
+		`INSERT INTO warehouses (id, tenant_id, store_id, name, priority) VALUES (?, ?, ?, 'Null Prio WH', NULL)`,
+		uuid.NewString(), tenantID, storeID).Error
+	require.Error(t, err, "priority is NOT NULL; an explicit NULL insert must be refused")
+}

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 117
+const ExpectedSchemaVersion uint = 118

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 118
+const ExpectedSchemaVersion uint = 119

--- a/services/marketplace-api/migrations/000118_multi_warehouse_schema.down.sql
+++ b/services/marketplace-api/migrations/000118_multi_warehouse_schema.down.sql
@@ -1,6 +1,9 @@
--- Reversible without loss for the columns; order_allocations rows are lost,
--- which is correct — they only have meaning alongside the code that writes
--- them, and that code does not exist until PR 3.
+-- Reversible without loss ONLY up to PR 4: order_allocations rows are lost,
+-- which is fine before PR 3 exists to write them, but from PR 4 onward
+-- shipments.warehouse_id holds recorded shipment origins, and dropping it
+-- here silently discards that history.
+DROP INDEX IF EXISTS shipments_warehouse_idx;
+
 DROP TABLE IF EXISTS order_allocations;
 
 ALTER TABLE shipments  DROP COLUMN IF EXISTS warehouse_id;

--- a/services/marketplace-api/migrations/000118_multi_warehouse_schema.down.sql
+++ b/services/marketplace-api/migrations/000118_multi_warehouse_schema.down.sql
@@ -1,0 +1,7 @@
+-- Reversible without loss for the columns; order_allocations rows are lost,
+-- which is correct — they only have meaning alongside the code that writes
+-- them, and that code does not exist until PR 3.
+DROP TABLE IF EXISTS order_allocations;
+
+ALTER TABLE shipments  DROP COLUMN IF EXISTS warehouse_id;
+ALTER TABLE warehouses DROP COLUMN IF EXISTS priority;

--- a/services/marketplace-api/migrations/000118_multi_warehouse_schema.up.sql
+++ b/services/marketplace-api/migrations/000118_multi_warehouse_schema.up.sql
@@ -34,9 +34,19 @@ CREATE INDEX IF NOT EXISTS order_allocations_order_idx
     ON order_allocations (order_id);
 CREATE INDEX IF NOT EXISTS order_allocations_shipment_idx
     ON order_allocations (shipment_id);
+-- Postgres does not index the referencing side of an FK automatically.
+-- Without this, DELETE FROM warehouses sequential-scans order_allocations,
+-- and PR 5's "does this warehouse owe a parcel" query has nothing to use.
+CREATE INDEX IF NOT EXISTS order_allocations_warehouse_idx
+    ON order_allocations (warehouse_id);
 
 -- Where a shipment actually shipped from. Nullable because every shipment
 -- created before this migration has no honest answer; every one created
 -- after it sets the column.
 ALTER TABLE shipments
     ADD COLUMN IF NOT EXISTS warehouse_id uuid REFERENCES warehouses(id);
+
+-- Same FK-indexing gap as above: without this, DELETE FROM warehouses
+-- sequential-scans shipments too.
+CREATE INDEX IF NOT EXISTS shipments_warehouse_idx
+    ON shipments (warehouse_id);

--- a/services/marketplace-api/migrations/000118_multi_warehouse_schema.up.sql
+++ b/services/marketplace-api/migrations/000118_multi_warehouse_schema.up.sql
@@ -1,0 +1,42 @@
+-- #177 multi-warehouse, schema half. Everything here is additive and inert:
+-- no running code reads these columns or this table, and a store with one
+-- warehouse behaves identically before and after. The allocator (PR 2) and
+-- checkout (PR 3) are what give them meaning.
+
+-- The order the allocator walks a store's warehouses. Merchant-ranked.
+ALTER TABLE warehouses
+    ADD COLUMN IF NOT EXISTS priority integer NOT NULL DEFAULT 0;
+
+-- Which warehouse ships how much of which order line.
+--
+-- A separate table rather than a warehouse_id on order_items, because
+-- refunds.order_item_id is a RESTRICT FK onto order_items: splitting a line
+-- across warehouses by splitting its row would change what a refund points
+-- at. Lines stay whole; allocation is its own concern with its own lifecycle.
+CREATE TABLE IF NOT EXISTS order_allocations (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id     uuid NOT NULL,
+    store_id      uuid NOT NULL,
+    order_id      uuid NOT NULL REFERENCES orders(id)      ON DELETE CASCADE,
+    order_item_id uuid NOT NULL REFERENCES order_items(id) ON DELETE CASCADE,
+    warehouse_id  uuid NOT NULL REFERENCES warehouses(id)  ON DELETE RESTRICT,
+    quantity      integer NOT NULL CHECK (quantity > 0),
+    -- NULL until a label is printed. This is the flag that makes
+    -- re-allocation safe before printing and refused after.
+    shipment_id   uuid REFERENCES shipments(id)            ON DELETE SET NULL,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    -- One row per (line, warehouse): a second allocation of the same line to
+    -- the same warehouse is a bug, not a top-up.
+    UNIQUE (order_item_id, warehouse_id)
+);
+
+CREATE INDEX IF NOT EXISTS order_allocations_order_idx
+    ON order_allocations (order_id);
+CREATE INDEX IF NOT EXISTS order_allocations_shipment_idx
+    ON order_allocations (shipment_id);
+
+-- Where a shipment actually shipped from. Nullable because every shipment
+-- created before this migration has no honest answer; every one created
+-- after it sets the column.
+ALTER TABLE shipments
+    ADD COLUMN IF NOT EXISTS warehouse_id uuid REFERENCES warehouses(id);

--- a/services/marketplace-api/migrations/000119_variant_inventory_sum.down.sql
+++ b/services/marketplace-api/migrations/000119_variant_inventory_sum.down.sql
@@ -1,0 +1,13 @@
+-- Restores 000001's function verbatim and drops the DELETE arm. Safe while
+-- every variant has one stock row, which is the only state a rollback to
+-- this point can be in: nothing writes a second location until PR 5.
+DROP TRIGGER IF EXISTS variant_stock_sync_delete ON variant_stock;
+
+CREATE OR REPLACE FUNCTION sync_variant_inventory() RETURNS trigger AS $$
+BEGIN
+    UPDATE product_variants
+    SET inventory_quantity = NEW.quantity
+    WHERE id = NEW.variant_id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/services/marketplace-api/migrations/000119_variant_inventory_sum.up.sql
+++ b/services/marketplace-api/migrations/000119_variant_inventory_sum.up.sql
@@ -1,0 +1,40 @@
+-- #177: product_variants.inventory_quantity becomes the SUM across a
+-- variant's locations.
+--
+-- 000001 created this trigger with `SET inventory_quantity = NEW.quantity`
+-- and a comment saying slice 2 would change it to a SUM. That assignment is
+-- the total only while a variant has one stock row; with two warehouses the
+-- number browse, PDP and cart all read would become whichever location was
+-- written most recently.
+--
+-- The DELETE arm is new. Without it, removing a warehouse's stock row leaves
+-- inventory_quantity counting units that no longer exist — an oversell with
+-- no error anywhere.
+--
+-- NOTE for anyone editing this: in a DELETE trigger PL/pgSQL leaves NEW
+-- unassigned, and referencing NEW.variant_id there raises "record new is not
+-- assigned yet". Branch on TG_OP; do not reach for COALESCE(NEW, OLD).
+
+CREATE OR REPLACE FUNCTION sync_variant_inventory() RETURNS trigger AS $$
+DECLARE
+    v_variant uuid;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        v_variant := OLD.variant_id;
+    ELSE
+        v_variant := NEW.variant_id;
+    END IF;
+
+    UPDATE product_variants
+       SET inventory_quantity = COALESCE(
+               (SELECT SUM(quantity) FROM variant_stock WHERE variant_id = v_variant), 0)
+     WHERE id = v_variant;
+
+    -- AFTER trigger: the return value is ignored.
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER variant_stock_sync_delete
+    AFTER DELETE ON variant_stock
+    FOR EACH ROW EXECUTE FUNCTION sync_variant_inventory();

--- a/services/marketplace-api/migrations/000119_variant_inventory_sum.up.sql
+++ b/services/marketplace-api/migrations/000119_variant_inventory_sum.up.sql
@@ -25,6 +25,15 @@ BEGIN
         v_variant := NEW.variant_id;
     END IF;
 
+    -- Serialise writers on the parent row BEFORE computing the sum. Without
+    -- this, two transactions writing different locations of the same variant
+    -- both evaluate the SUM sub-select against their pre-block snapshot, and
+    -- the second overwrites the first's contribution: EvalPlanQual re-checks
+    -- the qual on unblocking, not the sub-select. Unreachable while every
+    -- variant has one stock row; reachable the moment multi-location writes
+    -- land.
+    PERFORM 1 FROM product_variants WHERE id = v_variant FOR UPDATE;
+
     UPDATE product_variants
        SET inventory_quantity = COALESCE(
                (SELECT SUM(quantity) FROM variant_stock WHERE variant_id = v_variant), 0)


### PR DESCRIPTION
**PR 1 of 6** toward multi-warehouse support. Schema only, plus one behavioural
fix. Nothing in the running Go code reads what this adds.

Part of #177.

## What this is

`warehouses` became a store-level table in #480; #484/#487 dropped the last of
the per-carrier duplication. This begins the actual multi-warehouse feature:
somewhere to record which warehouse ships which order line, and a stock number
that stays correct once a variant lives in more than one place.

Design: `docs/superpowers/specs/2026-08-31-multi-warehouse-allocation-design.md`
Plan: `docs/superpowers/plans/2026-08-31-multi-warehouse-01-schema-and-trigger.md`

The three product decisions the design records — priority-order allocation,
splitting an order no single warehouse can fill, and pinning the allocation at
order placement — were taken deliberately over cheaper alternatives. The spec
says why, so a later reader does not assume they were overlooked.

## 000118 — schema, entirely inert

- `warehouses.priority` — the order allocation will walk a store's warehouses
- `order_allocations` — one row per (order line, warehouse), `shipment_id` NULL
  until a label is printed
- `shipments.warehouse_id` — where a shipment actually shipped from, nullable
  because no existing shipment has an honest answer

`order_allocations` is a separate table rather than a `warehouse_id` on
`order_items` for one specific reason: `refunds.order_item_id` is a RESTRICT FK
onto `order_items`. Splitting a line across warehouses by splitting its row
would change what a refund points at. Lines stay whole.

## 000119 — the storefront's stock number was wrong for two warehouses

`sync_variant_inventory` did `SET inventory_quantity = NEW.quantity`. That is
the total only while a variant has one stock row. With two, the number browse,
PDP and cart all read would have become *whichever warehouse was written most
recently*. The function's own comment, since 000001, said slice 2 would change
it to a SUM.

It now sums across locations and has an `AFTER DELETE` arm it never had —
without which removing a warehouse's stock row leaves `inventory_quantity`
counting units that no longer exist.

A note is in the migration for whoever edits it next: in a DELETE trigger
PL/pgSQL leaves `NEW` unassigned, so `COALESCE(NEW.variant_id, OLD.variant_id)`
raises *"record new is not assigned yet"*. It branches on `TG_OP`.

## The bug review found, which is the reason to read this PR

The first version of that trigger **lost updates**. Two transactions writing
different locations of the same variant: A=5 and B=4, tx1 sets A=3 and tx2 sets
B=2, and `inventory_quantity` lands on 7 for a true total of 5.

The `SELECT SUM(...)` sub-select is evaluated against the snapshot taken before
`UPDATE product_variants` blocks on the other transaction's row lock. On
unblocking, EvalPlanQual re-checks the qual — not the sub-select. It is the
documented `UPDATE … SET x = (SELECT …)` hazard.

Fixed by taking the parent row lock explicitly first, so writers serialise
before either computes its sum:

```sql
PERFORM 1 FROM product_variants WHERE id = v_variant FOR UPDATE;
```

Unreachable today — one row per variant means both writers contend on that same
row and serialise correctly — and reachable the moment per-location writes land
in PR 3. It was found by reproducing it on a real Postgres, and the regression
test reproduces the same numbers (expected 5, actual 7) with the lock removed.

## Deploy safety

Safe to deploy alone, and verified rather than argued:

- All nine `variant_stock` write sites pass `DefaultLocationID`, so every
  variant has exactly one stock row and the SUM equals the old assignment
- All three triggers on `variant_stock` are AFTER row triggers, so the
  function's `RETURN NULL` cancels nothing. Had either existing trigger been
  BEFORE, this would have silently discarded stock writes
- The DELETE arm fires under `products → product_variants → variant_stock`
  cascade and updates an already-deleted parent: 0 rows matched, no error
- Tenant purge and customer erasure suites pass; orders and their cascaded
  allocations are deleted long before warehouses, so RESTRICT never fires
- Nothing reads `inventory_quantity` for correctness — display, low-stock
  alerts, CSV export, one skip-if-equal shortcut. The oversell guard is
  `stockhold`'s per-location `SELECT … FOR UPDATE`, untouched here

## Testing

Integration, real DSN, `-p 1`, durations that prove they ran (not skips):
`internal/product` 5/5 `TestInventorySync_*`, `internal/warehouse` 17/17, plus
`internal/stockhold`, `internal/handlers/storefront`, `internal/order`,
`internal/tenantpurge`, `internal/customererasure`. Full unit suite green
across 92 packages. Both down migrations exercised; `down 2` → 117 → `up` →
119, clean.

Two guards were mutation-tested rather than assumed:

- dropping the AFTER DELETE trigger failed exactly the two deletion tests
  (`expected 4, actual 7`; `expected 0, actual 6`) and correctly left the
  INSERT/UPDATE tests passing
- removing the `FOR UPDATE` line reproduced the lost update

## Known gaps, stated rather than buried

- **None of this integration coverage runs in CI.** `ci.yml` has no Postgres
  service and sets no `TEST_DATABASE_URL`, so on `main` the only automated
  guard here is `TestExpectedSchemaVersionMatchesHighestMigration`. Worth
  fixing, and deliberately not fixed inside a schema PR.
- **A pre-deploy check has not been run:** counts of non-sentinel
  `variant_stock` rows, multi-location variants, and variants whose
  `inventory_quantity` has drifted from the sum. If multi-location variants
  exist, this PR changes live stock numbers on first write. Production pods are
  distroless, so it needs a Cloud SQL connection. The query is in the review
  notes and expected to return zeroes.
- `warehouses.archived_at` is not here. The design was corrected during review:
  a warehouse with allocation history is archived, never deleted, because the
  allocation row is the record of which warehouse shipped a line. PR 5
  implements it.
