### PR TITLE
fix(migrations): make the chain replayable, and run integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,59 @@ jobs:
     name: Secrets
     uses: tesserix/tesserix-workflows/.github/workflows/secret-scan.yml@v2.2.1
 
+  integration:
+    name: Integration (marketplace-api)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: dev
+          POSTGRES_PASSWORD: dev
+          POSTGRES_DB: marketplace_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      # Host-side, because the job's steps run on the runner, not in a
+      # container on the services network.
+      DSN: postgres://dev:dev@127.0.0.1:5432/marketplace_db?sslmode=disable
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.26.6"
+          cache-dependency-path: services/marketplace-api/go.sum
+      - name: Apply migrations
+        working-directory: services/marketplace-api
+        run: DATABASE_URL="$DSN" go run ./cmd/migrate up
+      - name: Prove the database is actually reachable
+        working-directory: services/marketplace-api
+        # An integration test with no TEST_DATABASE_URL SKIPS and the package
+        # still prints "ok" — a green suite here would otherwise prove nothing.
+        # This canary must visibly RUN, so a broken DSN fails the job loudly
+        # instead of passing silently.
+        run: |
+          out=$(TEST_DATABASE_URL="$DSN" go test -tags=integration -count=1 -v \
+                  ./internal/product/... -run TestInventorySync_SumsAcrossLocations)
+          printf '%s\n' "$out"
+          grep -q -- '--- PASS: TestInventorySync_SumsAcrossLocations' <<<"$out" || {
+            echo "::error::canary did not run — integration tests are skipping, not passing"
+            exit 1
+          }
+      - name: Integration tests
+        working-directory: services/marketplace-api
+        # -p 1: the packages share one database; parallel runs exhaust
+        # connections and surface as data pollution rather than as a clear
+        # failure.
+        run: TEST_DATABASE_URL="$DSN" go test -tags=integration -p 1 -count=1 ./...
+
   containers:
     name: Containers
     if: ${{ github.event_name == 'pull_request' }}
@@ -129,7 +182,7 @@ jobs:
   gate:
     name: CI gate
     if: ${{ always() }}
-    needs: [policy, go, nextjs, secrets, containers, release]
+    needs: [policy, go, nextjs, secrets, integration, containers, release]
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/services/marketplace-api/migrations/000058_customer_portal_and_cancel.up.sql
+++ b/services/marketplace-api/migrations/000058_customer_portal_and_cancel.up.sql
@@ -1,6 +1,19 @@
 -- Migration 058: customer portal secret + cancellation_reason column
 -- Part of P11 — cancellation + GDPR customer portal.
 
+-- gen_random_bytes below is a pgcrypto function, not core PostgreSQL. Nothing
+-- in the chain created the extension, so replaying these migrations against a
+-- FRESH database failed here with "function gen_random_bytes(integer) does not
+-- exist" — which broke CI, disaster recovery, and every new developer machine,
+-- while every existing database kept working because pgcrypto had been
+-- installed out of band. 000072 depends on it too.
+--
+-- Adding it to an already-applied migration is safe: golang-migrate tracks
+-- version numbers and never re-runs this file, and IF NOT EXISTS makes it a
+-- no-op for anyone who does. (gen_random_uuid, used by 39 other migrations,
+-- is core in PG13+ and needs nothing.)
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
 -- Per-store HMAC signing key for the customer portal token (§15.4).
 -- Generated at migration time using gen_random_bytes so existing stores are
 -- backfilled immediately. The DEFAULT is then dropped so every future INSERT


### PR DESCRIPTION
Two commits: a latent migration defect, and the CI job that could not exist
until it was fixed.

## The migration chain could not replay on a fresh database

`000058_customer_portal_and_cancel` backfills a per-store HMAC secret with
`encode(gen_random_bytes(32), 'hex')`. `gen_random_bytes` is a **pgcrypto**
function, and nothing in the chain ever created that extension. `000072`
depends on it too.

Every existing database works only because pgcrypto was installed out of band
at some point. A database created today fails:

```
$ createdb ci_probe && migrate up
(details: pq: function gen_random_bytes(integer) does not exist (42883))
version=58 dirty=true
```

That breaks disaster recovery and every new developer machine, not just CI, and
nothing would have surfaced it until someone needed a rebuild.

Fixed by adding `CREATE EXTENSION IF NOT EXISTS pgcrypto;` to 000058, above its
first use.

**On editing an already-applied migration:** golang-migrate tracks version
numbers, so this file will never re-run against an existing database, and
`IF NOT EXISTS` makes it a no-op for anyone who does replay it. A new migration
could not fix this — on a fresh database 000058 runs long before it.

`gen_random_uuid`, used by 39 other migrations, is core in PG13+ and needs
nothing. `citext` is already created properly by 000071 and 000104.

Verified: dropped and recreated a database, replayed 0 → 119 clean.

## Integration tests now run in CI

A `postgres:15` service, migrations applied with the real `cmd/migrate` binary,
then the suite. Wired into the CI gate so it blocks merge.

### The canary step is the point

An integration test with no `TEST_DATABASE_URL` **skips, and its package still
prints `ok`**. A green integration job would otherwise prove nothing — and this
repo has been bitten by exactly that twice, most memorably when a run reported
that known-failing packages "all pass now" after skipping every one of them.

So before the suite runs, the job runs one named test with `-v` and greps for
`--- PASS`. A broken DSN fails the job loudly instead of passing silently.

`-p 1` because the packages share one database; parallel runs exhaust
connections and present as data pollution rather than a clear failure.

### Why this is safe to turn on

The suite was run against a **fresh** database — not the local dev one with
months of accumulated state — to prove nothing depends on rows another package
left behind:

```
go test -tags=integration -p 1 -count=1 ./...   # exit 0, no failures
```

Also of note: the "known pre-existing failures" list in the M3 takeover notes is
**stale**. #317 billing/trial, subscription/planchange, platformadmin's missing
`inbox_action_idempotency`, and #400's `variant_matrix_mismatch` no longer
reproduce — 118 packages green. No allowlist is needed, which is what would have
made this job worth arguing about.

### Cost

One extra job per PR, a few minutes of runner time on the free plan. It is the
only thing that will guard the integration coverage added by #177's six PRs,
whose correctness lives almost entirely in tests that need a database.

The `actions/setup-go` pin is the verified commit SHA for v5
(`40f1582b2485089dde7abd97c1529aa768e1baff`), matching the repo's existing
pinning convention. `.github/scripts/test-ci-contract.py` passes — it constrains
which reusable workflows are called, and this job is defined locally.
