### PR TITLE
feat(allocation): priority-order warehouse allocator (#177, PR 2 of 6)

### DIFF
--- a/docs/superpowers/plans/2026-08-31-multi-warehouse-02-allocator.md
+++ b/docs/superpowers/plans/2026-08-31-multi-warehouse-02-allocator.md
@@ -1,0 +1,621 @@
+# Multi-warehouse PR 2: the allocator — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A pure `internal/allocation` package that decides which warehouse ships how much of each order line, with no database access and no callers.
+
+**Architecture:** One package, two files, both pure functions over plain structs. `InPriorityOrder` implements the ordering rule; `Plan` walks that order filling lines greedily. Nothing imports it yet — PR 3 wires it into checkout. Because it touches no database, its interesting cases are table tests rather than fixtures, and it is the cheapest place in this feature to get the semantics right.
+
+**Tech Stack:** Go 1.26, testify. No GORM, no SQL, no `context`.
+
+**Spec:** `docs/superpowers/specs/2026-08-31-multi-warehouse-allocation-design.md` (see "The allocator")
+
+## Global Constraints
+
+- Work in the worktree `.claude/worktrees/177-allocator`, branch `feat/177-allocator`. Never switch the main checkout's branch.
+- Run every Go command from `services/marketplace-api`, never path-scoped, always `-count=1`: `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./... -count=1`.
+- **This package has no integration tests and must not gain any.** It touches no database. If a test needs `testdb`, the design has gone wrong — stop and escalate.
+- **Never mutate an input.** Repo style is strict on this: functions return new values rather than modifying what they were given. `InPriorityOrder` must not reorder the caller's slice.
+- Commits: conventional, single line, no signature, no `Co-Authored-By` trailer, no emoji.
+- Stage with explicit paths (`git add <path>`). Never `git add -A`.
+- Every guard added must be mutation-tested: delete the guard, watch a test fail, restore it.
+- Exported identifiers carry doc comments explaining *why*, matching the density of neighbouring packages (see `internal/campaignbudget`).
+
+---
+
+## File Structure
+
+- **Create** `services/marketplace-api/internal/allocation/allocation.go` — the package doc, the types, and `InPriorityOrder`
+- **Create** `services/marketplace-api/internal/allocation/allocation_test.go` — table tests for ordering
+- **Create** `services/marketplace-api/internal/allocation/plan.go` — `Plan` and its errors
+- **Create** `services/marketplace-api/internal/allocation/plan_test.go` — table tests for allocation
+
+Two files rather than one because the ordering rule and the filling algorithm change for different reasons: ordering is a merchant-facing policy, filling is arithmetic.
+
+---
+
+### Task 1: Types and the ordering rule
+
+**Files:**
+- Create: `services/marketplace-api/internal/allocation/allocation.go`
+- Test: `services/marketplace-api/internal/allocation/allocation_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Warehouse`, `Line`, `Availability`, `Assignment`, and `InPriorityOrder([]Warehouse) []Warehouse`. Task 2's `Plan` consumes all of them. PR 3 calls `InPriorityOrder` on rows loaded from `warehouses` before calling `Plan`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `services/marketplace-api/internal/allocation/allocation_test.go`:
+
+```go
+package allocation_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/allocation"
+)
+
+func at(day int) time.Time {
+	return time.Date(2026, 1, day, 0, 0, 0, 0, time.UTC)
+}
+
+// The ordering must be TOTAL: any two warehouses must compare unequal on some
+// key, or two requests could allocate the same order differently and a
+// merchant would see the same cart ship from different cities.
+func TestInPriorityOrder(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []allocation.Warehouse
+		want  []string
+	}{
+		{
+			name: "lower priority number ships first",
+			input: []allocation.Warehouse{
+				{ID: "b", Priority: 2, CreatedAt: at(1)},
+				{ID: "a", Priority: 1, CreatedAt: at(2)},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "equal priority breaks to the default warehouse",
+			input: []allocation.Warehouse{
+				{ID: "b", Priority: 1, IsDefault: false, CreatedAt: at(1)},
+				{ID: "a", Priority: 1, IsDefault: true, CreatedAt: at(2)},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "equal priority and default breaks to the older row",
+			input: []allocation.Warehouse{
+				{ID: "b", Priority: 1, IsDefault: true, CreatedAt: at(2)},
+				{ID: "a", Priority: 1, IsDefault: true, CreatedAt: at(1)},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "identical on every key breaks to the id, so the order is total",
+			input: []allocation.Warehouse{
+				{ID: "b", Priority: 1, IsDefault: true, CreatedAt: at(1)},
+				{ID: "a", Priority: 1, IsDefault: true, CreatedAt: at(1)},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name:  "empty stays empty",
+			input: nil,
+			want:  []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := allocation.InPriorityOrder(tc.input)
+			ids := make([]string, 0, len(got))
+			for _, w := range got {
+				ids = append(ids, w.ID)
+			}
+			require.Equal(t, tc.want, ids)
+		})
+	}
+}
+
+// Repo style forbids mutating an input. A caller that ordered a slice for the
+// allocator and then reused its own slice for display would otherwise see it
+// silently reordered underneath them.
+func TestInPriorityOrder_DoesNotMutateItsInput(t *testing.T) {
+	input := []allocation.Warehouse{
+		{ID: "b", Priority: 2, CreatedAt: at(1)},
+		{ID: "a", Priority: 1, CreatedAt: at(2)},
+	}
+
+	_ = allocation.InPriorityOrder(input)
+
+	require.Equal(t, "b", input[0].ID, "the caller's slice must be untouched")
+	require.Equal(t, "a", input[1].ID)
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd services/marketplace-api
+go test ./internal/allocation/... -count=1
+```
+
+Expected: FAIL — the package does not exist yet (`no required module provides package`).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `services/marketplace-api/internal/allocation/allocation.go`:
+
+```go
+// Package allocation decides which warehouse ships how much of each line of
+// an order (#177).
+//
+// It is deliberately pure: no database, no context, no clock. The inputs are
+// a store's warehouses in the order they should be filled from, a snapshot of
+// what is available where, and the lines to place. Everything that makes the
+// decision hard to reason about — locking, transactions, the fact that the
+// snapshot can be stale by the time it is used — lives in the caller.
+//
+// The plan this package returns is ADVISORY. stockhold.Hold's per-location
+// availability check under SELECT ... FOR UPDATE remains the thing that
+// actually stops two orders taking the last unit; a plan that loses that race
+// simply fails, exactly as a single-warehouse order does today.
+package allocation
+
+import (
+	"cmp"
+	"slices"
+	"time"
+)
+
+// Warehouse is one candidate origin, reduced to what the decision needs.
+type Warehouse struct {
+	ID        string
+	Priority  int
+	IsDefault bool
+	CreatedAt time.Time
+}
+
+// Line is one order line to place.
+type Line struct {
+	VariantID string
+	Quantity  int
+	// SellsPastZero mirrors product_variants.inventory_policy == "continue":
+	// the merchant sells this variant past zero on purpose, so availability
+	// does not constrain where it ships from.
+	SellsPastZero bool
+}
+
+// Availability is units on hand per variant, per warehouse: avail[variantID][warehouseID].
+// A missing entry means zero — callers do not have to enumerate empty pairs.
+type Availability map[string]map[string]int
+
+// At returns the units of variantID available at warehouseID.
+func (a Availability) At(variantID, warehouseID string) int {
+	return a[variantID][warehouseID]
+}
+
+// Assignment is one unit of the answer: ship Quantity of VariantID from
+// WarehouseID. A line split across two warehouses produces two Assignments.
+type Assignment struct {
+	WarehouseID string
+	VariantID   string
+	Quantity    int
+}
+
+// InPriorityOrder returns a NEW slice ordered the way allocation fills:
+// merchant-set priority first, then the store's default warehouse, then the
+// older row, then the id.
+//
+// The final id tiebreak exists to make the ordering TOTAL. Without it two
+// warehouses created in the same second with equal priority could compare
+// equal, and two identical carts could then allocate differently — a merchant
+// would see the same order ship from different cities with nothing to explain
+// it.
+//
+// The input slice is not modified.
+func InPriorityOrder(warehouses []Warehouse) []Warehouse {
+	ordered := slices.Clone(warehouses)
+	if ordered == nil {
+		ordered = []Warehouse{}
+	}
+	slices.SortStableFunc(ordered, func(a, b Warehouse) int {
+		if c := cmp.Compare(a.Priority, b.Priority); c != 0 {
+			return c
+		}
+		// IsDefault true sorts first, so invert the boolean comparison.
+		if a.IsDefault != b.IsDefault {
+			if a.IsDefault {
+				return -1
+			}
+			return 1
+		}
+		if c := a.CreatedAt.Compare(b.CreatedAt); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.ID, b.ID)
+	})
+	return ordered
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd services/marketplace-api
+go test ./internal/allocation/... -count=1 -v
+```
+
+Expected: all subtests PASS.
+
+- [ ] **Step 5: Mutation-test the totality tiebreak**
+
+Delete the final `return cmp.Compare(a.ID, b.ID)` line and replace it with `return 0`, then:
+
+```bash
+cd services/marketplace-api
+go test ./internal/allocation/... -count=1 -run TestInPriorityOrder
+```
+
+Expected: FAIL on the "identical on every key" case. If it PASSES, the test is not pinning totality — note that `SortStableFunc` preserves input order for equal elements, so the test case must supply its inputs in the order that a working tiebreak would REVERSE (`b` before `a`, as written above). Restore the line and confirm green.
+
+- [ ] **Step 6: Verify and commit**
+
+```bash
+cd services/marketplace-api
+go build ./... && go vet ./... && go vet -tags=integration ./... && gofmt -l .
+go test ./... -count=1
+```
+
+```bash
+git add services/marketplace-api/internal/allocation/allocation.go \
+        services/marketplace-api/internal/allocation/allocation_test.go
+git commit -m "feat(allocation): warehouse ordering rule and the allocator's value types (#177)"
+```
+
+---
+
+### Task 2: The filling algorithm
+
+**Files:**
+- Create: `services/marketplace-api/internal/allocation/plan.go`
+- Test: `services/marketplace-api/internal/allocation/plan_test.go`
+
+**Interfaces:**
+- Consumes: `Warehouse`, `Line`, `Availability`, `Assignment` from Task 1.
+- Produces: `Plan(warehouses []Warehouse, avail Availability, lines []Line) ([]Assignment, error)`, `CannotFillError{VariantID string, Short int}`, and `ErrNoWarehouse`. PR 3 calls `Plan` inside the order transaction and writes one `order_allocations` row per returned `Assignment`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `services/marketplace-api/internal/allocation/plan_test.go`:
+
+```go
+package allocation_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/allocation"
+)
+
+func wh(id string, priority int) allocation.Warehouse {
+	return allocation.Warehouse{ID: id, Priority: priority, CreatedAt: at(1)}
+}
+
+func TestPlan(t *testing.T) {
+	tests := []struct {
+		name       string
+		warehouses []allocation.Warehouse
+		avail      allocation.Availability
+		lines      []allocation.Line
+		want       []allocation.Assignment
+	}{
+		{
+			name:       "one warehouse fills the line",
+			warehouses: []allocation.Warehouse{wh("a", 1)},
+			avail:      allocation.Availability{"v1": {"a": 5}},
+			lines:      []allocation.Line{{VariantID: "v1", Quantity: 3}},
+			want: []allocation.Assignment{
+				{WarehouseID: "a", VariantID: "v1", Quantity: 3},
+			},
+		},
+		{
+			name:       "the higher-priority warehouse is filled from first",
+			warehouses: []allocation.Warehouse{wh("a", 1), wh("b", 2)},
+			avail:      allocation.Availability{"v1": {"a": 5, "b": 5}},
+			lines:      []allocation.Line{{VariantID: "v1", Quantity: 3}},
+			want: []allocation.Assignment{
+				{WarehouseID: "a", VariantID: "v1", Quantity: 3},
+			},
+		},
+		{
+			name:       "a line no single warehouse can fill is split",
+			warehouses: []allocation.Warehouse{wh("a", 1), wh("b", 2)},
+			avail:      allocation.Availability{"v1": {"a": 3, "b": 4}},
+			lines:      []allocation.Line{{VariantID: "v1", Quantity: 5}},
+			want: []allocation.Assignment{
+				{WarehouseID: "a", VariantID: "v1", Quantity: 3},
+				{WarehouseID: "b", VariantID: "v1", Quantity: 2},
+			},
+		},
+		{
+			name:       "a warehouse holding none of a variant is skipped, not zero-assigned",
+			warehouses: []allocation.Warehouse{wh("a", 1), wh("b", 2)},
+			avail:      allocation.Availability{"v1": {"b": 4}},
+			lines:      []allocation.Line{{VariantID: "v1", Quantity: 4}},
+			want: []allocation.Assignment{
+				{WarehouseID: "b", VariantID: "v1", Quantity: 4},
+			},
+		},
+		{
+			name:       "several lines each allocate independently",
+			warehouses: []allocation.Warehouse{wh("a", 1), wh("b", 2)},
+			avail: allocation.Availability{
+				"v1": {"a": 1, "b": 5},
+				"v2": {"a": 9},
+			},
+			lines: []allocation.Line{
+				{VariantID: "v1", Quantity: 3},
+				{VariantID: "v2", Quantity: 2},
+			},
+			want: []allocation.Assignment{
+				{WarehouseID: "a", VariantID: "v1", Quantity: 1},
+				{WarehouseID: "a", VariantID: "v2", Quantity: 2},
+				{WarehouseID: "b", VariantID: "v1", Quantity: 2},
+			},
+		},
+		{
+			name:       "a sells-past-zero line goes whole to the first warehouse regardless of stock",
+			warehouses: []allocation.Warehouse{wh("a", 1), wh("b", 2)},
+			avail:      allocation.Availability{"v1": {"b": 100}},
+			lines:      []allocation.Line{{VariantID: "v1", Quantity: 7, SellsPastZero: true}},
+			want: []allocation.Assignment{
+				{WarehouseID: "a", VariantID: "v1", Quantity: 7},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := allocation.Plan(tc.warehouses, tc.avail, tc.lines)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// The allocator's central invariant: what it assigns for a line must add up to
+// exactly what the line asked for. Under-assigning ships a short parcel;
+// over-assigning takes stock the customer did not buy.
+func TestPlan_AssignmentsSumToTheLineQuantity(t *testing.T) {
+	warehouses := []allocation.Warehouse{wh("a", 1), wh("b", 2), wh("c", 3)}
+	avail := allocation.Availability{"v1": {"a": 2, "b": 2, "c": 2}}
+
+	got, err := allocation.Plan(warehouses, avail, []allocation.Line{{VariantID: "v1", Quantity: 5}})
+	require.NoError(t, err)
+
+	total := 0
+	for _, a := range got {
+		total += a.Quantity
+	}
+	require.Equal(t, 5, total)
+}
+
+func TestPlan_ReturnsCannotFillWhenNoCombinationSatisfiesTheLine(t *testing.T) {
+	warehouses := []allocation.Warehouse{wh("a", 1), wh("b", 2)}
+	avail := allocation.Availability{"v1": {"a": 2, "b": 1}}
+
+	_, err := allocation.Plan(warehouses, avail, []allocation.Line{{VariantID: "v1", Quantity: 6}})
+
+	var cannot allocation.CannotFillError
+	require.True(t, errors.As(err, &cannot), "got %v", err)
+	require.Equal(t, "v1", cannot.VariantID)
+	require.Equal(t, 3, cannot.Short, "6 wanted, 3 available, so 3 short")
+}
+
+func TestPlan_RefusesAStoreWithNoWarehouses(t *testing.T) {
+	_, err := allocation.Plan(nil, allocation.Availability{}, []allocation.Line{{VariantID: "v1", Quantity: 1}})
+	require.ErrorIs(t, err, allocation.ErrNoWarehouse)
+}
+
+func TestPlan_RefusesANonPositiveLineQuantity(t *testing.T) {
+	warehouses := []allocation.Warehouse{wh("a", 1)}
+	avail := allocation.Availability{"v1": {"a": 5}}
+
+	_, err := allocation.Plan(warehouses, avail, []allocation.Line{{VariantID: "v1", Quantity: 0}})
+	require.Error(t, err, "a line for zero units is a caller bug, not an empty allocation")
+}
+
+func TestPlan_NoLinesIsNoAssignmentsNotAnError(t *testing.T) {
+	got, err := allocation.Plan([]allocation.Warehouse{wh("a", 1)}, allocation.Availability{}, nil)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd services/marketplace-api
+go test ./internal/allocation/... -count=1
+```
+
+Expected: FAIL to compile — `undefined: allocation.Plan`, `undefined: allocation.CannotFillError`, `undefined: allocation.ErrNoWarehouse`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `services/marketplace-api/internal/allocation/plan.go`:
+
+```go
+package allocation
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrNoWarehouse means the store has nowhere to ship from. Allocation cannot
+// answer that with a plan, and a caller must not treat it as "out of stock":
+// the merchant has a configuration problem, not an inventory one.
+var ErrNoWarehouse = errors.New("allocation: store has no warehouses")
+
+// CannotFillError names the first line no combination of warehouses can
+// satisfy, and by how much it falls short.
+//
+// It carries the variant because a bare failure is unactionable on a cart of
+// six items — the storefront needs to know which line to mark, exactly as
+// storefront's outOfStockError does.
+type CannotFillError struct {
+	VariantID string
+	Short     int
+}
+
+func (e CannotFillError) Error() string {
+	return fmt.Sprintf("allocation: variant %s is %d short across all warehouses", e.VariantID, e.Short)
+}
+
+// Plan decides which warehouse ships how much of each line.
+//
+// warehouses must already be in fill order — pass them through
+// InPriorityOrder. Taking an ordered slice rather than sorting internally is
+// deliberate: a later ordering rule (nearest-pincode, say) becomes a
+// different function feeding this one, not a change to this one.
+//
+// The algorithm walks warehouses in order and takes min(remaining, available)
+// for every unsatisfied line at each. That fills from the merchant's first
+// warehouse down, which is the sentence you can say to a merchant. It does
+// NOT minimise the number of parcels: a true minimum is a bin-packing problem,
+// and one fewer parcel in a rare case is worth less than an explainable rule.
+//
+// Assignments come back grouped by warehouse in fill order, and by line order
+// within a warehouse, so the same inputs always produce the same slice.
+func Plan(warehouses []Warehouse, avail Availability, lines []Line) ([]Assignment, error) {
+	if len(lines) == 0 {
+		return []Assignment{}, nil
+	}
+	if len(warehouses) == 0 {
+		return nil, ErrNoWarehouse
+	}
+
+	remaining := make([]int, len(lines))
+	for i, line := range lines {
+		if line.Quantity <= 0 {
+			return nil, fmt.Errorf("allocation: line %d (variant %s): quantity must be positive, got %d",
+				i, line.VariantID, line.Quantity)
+		}
+		remaining[i] = line.Quantity
+	}
+
+	assignments := make([]Assignment, 0, len(lines))
+
+	for w, warehouse := range warehouses {
+		for i, line := range lines {
+			if remaining[i] == 0 {
+				continue
+			}
+
+			take := 0
+			switch {
+			case line.SellsPastZero:
+				// The merchant sells this past zero on purpose, so stock does
+				// not constrain it. Assign it whole to the first warehouse —
+				// leaving it unassigned because no location has units would
+				// produce an order line that ships from nothing.
+				if w != 0 {
+					continue
+				}
+				take = remaining[i]
+			default:
+				take = min(remaining[i], avail.At(line.VariantID, warehouse.ID))
+			}
+
+			if take == 0 {
+				continue
+			}
+			assignments = append(assignments, Assignment{
+				WarehouseID: warehouse.ID,
+				VariantID:   line.VariantID,
+				Quantity:    take,
+			})
+			remaining[i] -= take
+		}
+	}
+
+	for i, left := range remaining {
+		if left > 0 {
+			return nil, CannotFillError{VariantID: lines[i].VariantID, Short: left}
+		}
+	}
+
+	return assignments, nil
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd services/marketplace-api
+go test ./internal/allocation/... -count=1 -v
+```
+
+Expected: every test PASSES.
+
+Note on the expected ordering in the "several lines" case: assignments are emitted warehouse-outer, line-inner, so warehouse `a` contributes its `v1` and `v2` rows before warehouse `b` contributes its `v1` row. If your implementation emits line-outer instead, that test fails — and the fix is the implementation, not the test, because grouping by warehouse is what PR 4 needs to create one shipment per warehouse.
+
+- [ ] **Step 5: Mutation-test the shortfall check**
+
+Delete the final `for i, left := range remaining` loop that returns `CannotFillError`, then:
+
+```bash
+cd services/marketplace-api
+go test ./internal/allocation/... -count=1
+```
+
+Expected: FAIL — `TestPlan_ReturnsCannotFillWhenNoCombinationSatisfiesTheLine`. Without that loop the function silently returns a SHORT plan, which downstream would become an order that ships fewer units than the customer paid for. Restore it and confirm green.
+
+- [ ] **Step 6: Mutation-test the sells-past-zero branch**
+
+Change `if w != 0 { continue }` to `if w != 0 { break }`, then re-run. Expected: still green — which is fine, `break` is equivalent here. Now instead delete the whole `case line.SellsPastZero:` arm so those lines fall through to the availability path, and re-run.
+
+Expected: FAIL — "a sells-past-zero line goes whole to the first warehouse regardless of stock" fails, because the variant has no units at warehouse `a` and the line would go unassigned and then error as unfillable. Restore and confirm green.
+
+- [ ] **Step 7: Verify and commit**
+
+```bash
+cd services/marketplace-api
+go build ./... && go vet ./... && go vet -tags=integration ./... && gofmt -l .
+go test ./... -count=1
+```
+
+```bash
+git add services/marketplace-api/internal/allocation/plan.go \
+        services/marketplace-api/internal/allocation/plan_test.go
+git commit -m "feat(allocation): fill lines across warehouses in priority order (#177)"
+```
+
+---
+
+## Done when
+
+- `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `gofmt -l .` clean
+- `go test ./... -count=1` green
+- `go test ./internal/allocation/... -count=1` green with no database available at all — the package must not need one
+- Three guards mutation-tested: the totality tiebreak, the shortfall check, and the sells-past-zero branch
+
+## Explicitly NOT in this PR
+
+- Any caller. `internal/allocation` is imported by nothing when this merges; PR 3 wires it into `commitStock` and `cart_holds.go`.
+- Reading warehouses or availability from the database — that is PR 3's job, and it is why `Plan` takes a snapshot rather than a `*gorm.DB`.
+- Writing `order_allocations` rows (PR 3).
+- Re-planning when a hold is lost to a race. The spec rules that out until the race is observed.
+- Nearest-pincode or most-stock ordering. `InPriorityOrder` is one comparator; another would be a sibling function.

--- a/services/marketplace-api/internal/allocation/allocation.go
+++ b/services/marketplace-api/internal/allocation/allocation.go
@@ -1,0 +1,90 @@
+// Package allocation decides which warehouse ships how much of each line of
+// an order (#177).
+//
+// It is deliberately pure: no database, no context, no clock. The inputs are
+// a store's warehouses in the order they should be filled from, a snapshot of
+// what is available where, and the lines to place. Everything that makes the
+// decision hard to reason about — locking, transactions, the fact that the
+// snapshot can be stale by the time it is used — lives in the caller.
+//
+// The plan this package returns is ADVISORY. stockhold.Hold's per-location
+// availability check under SELECT ... FOR UPDATE remains the thing that
+// actually stops two orders taking the last unit; a plan that loses that race
+// simply fails, exactly as a single-warehouse order does today.
+package allocation
+
+import (
+	"cmp"
+	"slices"
+	"time"
+)
+
+// Warehouse is one candidate origin, reduced to what the decision needs.
+type Warehouse struct {
+	ID        string
+	Priority  int
+	IsDefault bool
+	CreatedAt time.Time
+}
+
+// Line is one order line to place.
+type Line struct {
+	VariantID string
+	Quantity  int
+	// SellsPastZero mirrors product_variants.inventory_policy == "continue":
+	// the merchant sells this variant past zero on purpose, so availability
+	// does not constrain where it ships from.
+	SellsPastZero bool
+}
+
+// Availability is units on hand per variant, per warehouse: avail[variantID][warehouseID].
+// A missing entry means zero — callers do not have to enumerate empty pairs.
+type Availability map[string]map[string]int
+
+// At returns the units of variantID available at warehouseID.
+func (a Availability) At(variantID, warehouseID string) int {
+	return a[variantID][warehouseID]
+}
+
+// Assignment is one unit of the answer: ship Quantity of VariantID from
+// WarehouseID. A line split across two warehouses produces two Assignments.
+type Assignment struct {
+	WarehouseID string
+	VariantID   string
+	Quantity    int
+}
+
+// InPriorityOrder returns a NEW slice ordered the way allocation fills:
+// merchant-set priority first, then the store's default warehouse, then the
+// older row, then the id.
+//
+// The final id tiebreak exists to make the ordering TOTAL. Without it two
+// warehouses created in the same second with equal priority could compare
+// equal, and two identical carts could then allocate differently — a merchant
+// would see the same order ship from different cities with nothing to explain
+// it.
+//
+// The input slice is not modified.
+func InPriorityOrder(warehouses []Warehouse) []Warehouse {
+	ordered := slices.Clone(warehouses)
+	if ordered == nil {
+		ordered = []Warehouse{}
+	}
+	slices.SortStableFunc(ordered, func(a, b Warehouse) int {
+		if c := cmp.Compare(a.Priority, b.Priority); c != 0 {
+			return c
+		}
+		// IsDefault true sorts first, so invert the boolean comparison.
+		if a.IsDefault != b.IsDefault {
+			if a.IsDefault {
+				return -1
+			}
+			return 1
+		}
+		if c := a.CreatedAt.Compare(b.CreatedAt); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.ID, b.ID)
+	})
+	return ordered
+}

--- a/services/marketplace-api/internal/allocation/allocation_test.go
+++ b/services/marketplace-api/internal/allocation/allocation_test.go
@@ -1,0 +1,89 @@
+package allocation_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/allocation"
+)
+
+func at(day int) time.Time {
+	return time.Date(2026, 1, day, 0, 0, 0, 0, time.UTC)
+}
+
+// The ordering must be TOTAL: any two warehouses must compare unequal on some
+// key, or two requests could allocate the same order differently and a
+// merchant would see the same cart ship from different cities.
+func TestInPriorityOrder(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []allocation.Warehouse
+		want  []string
+	}{
+		{
+			name: "lower priority number ships first",
+			input: []allocation.Warehouse{
+				{ID: "b", Priority: 2, CreatedAt: at(1)},
+				{ID: "a", Priority: 1, CreatedAt: at(2)},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "equal priority breaks to the default warehouse",
+			input: []allocation.Warehouse{
+				{ID: "b", Priority: 1, IsDefault: false, CreatedAt: at(1)},
+				{ID: "a", Priority: 1, IsDefault: true, CreatedAt: at(2)},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "equal priority and default breaks to the older row",
+			input: []allocation.Warehouse{
+				{ID: "b", Priority: 1, IsDefault: true, CreatedAt: at(2)},
+				{ID: "a", Priority: 1, IsDefault: true, CreatedAt: at(1)},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "identical on every key breaks to the id, so the order is total",
+			input: []allocation.Warehouse{
+				{ID: "b", Priority: 1, IsDefault: true, CreatedAt: at(1)},
+				{ID: "a", Priority: 1, IsDefault: true, CreatedAt: at(1)},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name:  "empty stays empty",
+			input: nil,
+			want:  []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := allocation.InPriorityOrder(tc.input)
+			ids := make([]string, 0, len(got))
+			for _, w := range got {
+				ids = append(ids, w.ID)
+			}
+			require.Equal(t, tc.want, ids)
+		})
+	}
+}
+
+// Repo style forbids mutating an input. A caller that ordered a slice for the
+// allocator and then reused its own slice for display would otherwise see it
+// silently reordered underneath them.
+func TestInPriorityOrder_DoesNotMutateItsInput(t *testing.T) {
+	input := []allocation.Warehouse{
+		{ID: "b", Priority: 2, CreatedAt: at(1)},
+		{ID: "a", Priority: 1, CreatedAt: at(2)},
+	}
+
+	_ = allocation.InPriorityOrder(input)
+
+	require.Equal(t, "b", input[0].ID, "the caller's slice must be untouched")
+	require.Equal(t, "a", input[1].ID)
+}

--- a/services/marketplace-api/internal/allocation/allocation_test.go
+++ b/services/marketplace-api/internal/allocation/allocation_test.go
@@ -73,6 +73,59 @@ func TestInPriorityOrder(t *testing.T) {
 	}
 }
 
+// A 2-element case cannot pin the direction of the IsDefault tiebreak: with
+// only two elements, flipping "IsDefault true sorts first" to "sorts last"
+// still passes because the comparator is only ever evaluated in one
+// direction. With four elements and mixed input order, the wrong direction
+// changes the output.
+func TestInPriorityOrder_IsDefaultTiebreakIsPinned(t *testing.T) {
+	in := []allocation.Warehouse{
+		{ID: "y", Priority: 1, IsDefault: true, CreatedAt: at(2)},
+		{ID: "x", Priority: 1, IsDefault: false, CreatedAt: at(1)},
+		{ID: "z", Priority: 1, IsDefault: false, CreatedAt: at(3)},
+		{ID: "w", Priority: 1, IsDefault: true, CreatedAt: at(4)},
+	}
+
+	got := allocation.InPriorityOrder(in)
+	ids := make([]string, 0, len(got))
+	for _, w := range got {
+		ids = append(ids, w.ID)
+	}
+	require.Equal(t, []string{"y", "w", "x", "z"}, ids)
+}
+
+// Ordering must be TOTAL: whatever order the same set of warehouses arrives
+// in, InPriorityOrder must produce the identical result every time.
+func TestInPriorityOrder_IsPermutationInvariant(t *testing.T) {
+	base := []allocation.Warehouse{
+		{ID: "y", Priority: 1, IsDefault: true, CreatedAt: at(2)},
+		{ID: "x", Priority: 1, IsDefault: false, CreatedAt: at(1)},
+		{ID: "z", Priority: 1, IsDefault: false, CreatedAt: at(3)},
+		{ID: "w", Priority: 1, IsDefault: true, CreatedAt: at(4)},
+	}
+
+	permutations := [][]allocation.Warehouse{
+		{base[0], base[1], base[2], base[3]},
+		{base[3], base[2], base[1], base[0]},
+		{base[1], base[3], base[0], base[2]},
+		{base[2], base[0], base[3], base[1]},
+	}
+
+	var want []string
+	for i, perm := range permutations {
+		got := allocation.InPriorityOrder(perm)
+		ids := make([]string, 0, len(got))
+		for _, w := range got {
+			ids = append(ids, w.ID)
+		}
+		if i == 0 {
+			want = ids
+			continue
+		}
+		require.Equal(t, want, ids, "input order must not change the result")
+	}
+}
+
 // Repo style forbids mutating an input. A caller that ordered a slice for the
 // allocator and then reused its own slice for display would otherwise see it
 // silently reordered underneath them.

--- a/services/marketplace-api/internal/allocation/plan.go
+++ b/services/marketplace-api/internal/allocation/plan.go
@@ -10,6 +10,13 @@ import (
 // the merchant has a configuration problem, not an inventory one.
 var ErrNoWarehouse = errors.New("allocation: store has no warehouses")
 
+// ErrInvalidInput means the caller passed Plan something it should never have
+// produced — a non-positive line quantity, or the same warehouse ID twice.
+// It is a caller bug, not a domain failure like CannotFillError, and is kept
+// distinct so a caller mapping allocator errors to HTTP responses does not
+// have to string-match to tell the two apart.
+var ErrInvalidInput = errors.New("allocation: invalid input")
+
 // CannotFillError names the first line no combination of warehouses can
 // satisfy, and by how much it falls short.
 //
@@ -48,18 +55,32 @@ func Plan(warehouses []Warehouse, avail Availability, lines []Line) ([]Assignmen
 		return nil, ErrNoWarehouse
 	}
 
+	seenWarehouse := make(map[string]struct{}, len(warehouses))
+	for _, warehouse := range warehouses {
+		if _, ok := seenWarehouse[warehouse.ID]; ok {
+			return nil, fmt.Errorf("%w: warehouse %s appears more than once", ErrInvalidInput, warehouse.ID)
+		}
+		seenWarehouse[warehouse.ID] = struct{}{}
+	}
+
 	remaining := make([]int, len(lines))
 	for i, line := range lines {
 		if line.Quantity <= 0 {
-			return nil, fmt.Errorf("allocation: line %d (variant %s): quantity must be positive, got %d",
-				i, line.VariantID, line.Quantity)
+			return nil, fmt.Errorf("%w: line %d (variant %s): quantity must be positive, got %d",
+				ErrInvalidInput, i, line.VariantID, line.Quantity)
 		}
 		remaining[i] = line.Quantity
 	}
 
 	assignments := make([]Assignment, 0, len(lines))
 
-	for w, warehouse := range warehouses {
+	// used tracks, per variant and warehouse, how much of that warehouse's
+	// availability has already been committed to an earlier line. Without
+	// it, two lines carrying the same variant would each read avail.At
+	// fresh and could double-spend the same units of stock.
+	used := make(map[string]map[string]int)
+
+	for _, warehouse := range warehouses {
 		for i, line := range lines {
 			if remaining[i] == 0 {
 				continue
@@ -72,15 +93,21 @@ func Plan(warehouses []Warehouse, avail Availability, lines []Line) ([]Assignmen
 				// not constrain it. Assign it whole to the first warehouse —
 				// leaving it unassigned because no location has units would
 				// produce an order line that ships from nothing.
-				if w != 0 {
-					continue
-				}
 				take = remaining[i]
 			default:
-				take = min(remaining[i], avail.At(line.VariantID, warehouse.ID))
+				already := used[line.VariantID][warehouse.ID]
+				// avail.At can be negative — PR 3's availability snapshot is
+				// quantity minus live holds, not floored at zero. Clamp it
+				// here rather than let a negative take reduce remaining[i]
+				// (which would INCREASE what looks left to fill).
+				free := avail.At(line.VariantID, warehouse.ID) - already
+				if free < 0 {
+					free = 0
+				}
+				take = min(remaining[i], free)
 			}
 
-			if take == 0 {
+			if take <= 0 {
 				continue
 			}
 			assignments = append(assignments, Assignment{
@@ -89,6 +116,12 @@ func Plan(warehouses []Warehouse, avail Availability, lines []Line) ([]Assignmen
 				Quantity:    take,
 			})
 			remaining[i] -= take
+			if !line.SellsPastZero {
+				if used[line.VariantID] == nil {
+					used[line.VariantID] = make(map[string]int)
+				}
+				used[line.VariantID][warehouse.ID] += take
+			}
 		}
 	}
 

--- a/services/marketplace-api/internal/allocation/plan.go
+++ b/services/marketplace-api/internal/allocation/plan.go
@@ -1,0 +1,102 @@
+package allocation
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrNoWarehouse means the store has nowhere to ship from. Allocation cannot
+// answer that with a plan, and a caller must not treat it as "out of stock":
+// the merchant has a configuration problem, not an inventory one.
+var ErrNoWarehouse = errors.New("allocation: store has no warehouses")
+
+// CannotFillError names the first line no combination of warehouses can
+// satisfy, and by how much it falls short.
+//
+// It carries the variant because a bare failure is unactionable on a cart of
+// six items — the storefront needs to know which line to mark, exactly as
+// storefront's outOfStockError does.
+type CannotFillError struct {
+	VariantID string
+	Short     int
+}
+
+func (e CannotFillError) Error() string {
+	return fmt.Sprintf("allocation: variant %s is %d short across all warehouses", e.VariantID, e.Short)
+}
+
+// Plan decides which warehouse ships how much of each line.
+//
+// warehouses must already be in fill order — pass them through
+// InPriorityOrder. Taking an ordered slice rather than sorting internally is
+// deliberate: a later ordering rule (nearest-pincode, say) becomes a
+// different function feeding this one, not a change to this one.
+//
+// The algorithm walks warehouses in order and takes min(remaining, available)
+// for every unsatisfied line at each. That fills from the merchant's first
+// warehouse down, which is the sentence you can say to a merchant. It does
+// NOT minimise the number of parcels: a true minimum is a bin-packing problem,
+// and one fewer parcel in a rare case is worth less than an explainable rule.
+//
+// Assignments come back grouped by warehouse in fill order, and by line order
+// within a warehouse, so the same inputs always produce the same slice.
+func Plan(warehouses []Warehouse, avail Availability, lines []Line) ([]Assignment, error) {
+	if len(lines) == 0 {
+		return []Assignment{}, nil
+	}
+	if len(warehouses) == 0 {
+		return nil, ErrNoWarehouse
+	}
+
+	remaining := make([]int, len(lines))
+	for i, line := range lines {
+		if line.Quantity <= 0 {
+			return nil, fmt.Errorf("allocation: line %d (variant %s): quantity must be positive, got %d",
+				i, line.VariantID, line.Quantity)
+		}
+		remaining[i] = line.Quantity
+	}
+
+	assignments := make([]Assignment, 0, len(lines))
+
+	for w, warehouse := range warehouses {
+		for i, line := range lines {
+			if remaining[i] == 0 {
+				continue
+			}
+
+			take := 0
+			switch {
+			case line.SellsPastZero:
+				// The merchant sells this past zero on purpose, so stock does
+				// not constrain it. Assign it whole to the first warehouse —
+				// leaving it unassigned because no location has units would
+				// produce an order line that ships from nothing.
+				if w != 0 {
+					continue
+				}
+				take = remaining[i]
+			default:
+				take = min(remaining[i], avail.At(line.VariantID, warehouse.ID))
+			}
+
+			if take == 0 {
+				continue
+			}
+			assignments = append(assignments, Assignment{
+				WarehouseID: warehouse.ID,
+				VariantID:   line.VariantID,
+				Quantity:    take,
+			})
+			remaining[i] -= take
+		}
+	}
+
+	for i, left := range remaining {
+		if left > 0 {
+			return nil, CannotFillError{VariantID: lines[i].VariantID, Short: left}
+		}
+	}
+
+	return assignments, nil
+}

--- a/services/marketplace-api/internal/allocation/plan_test.go
+++ b/services/marketplace-api/internal/allocation/plan_test.go
@@ -1,0 +1,144 @@
+package allocation_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/allocation"
+)
+
+func wh(id string, priority int) allocation.Warehouse {
+	return allocation.Warehouse{ID: id, Priority: priority, CreatedAt: at(1)}
+}
+
+func TestPlan(t *testing.T) {
+	tests := []struct {
+		name       string
+		warehouses []allocation.Warehouse
+		avail      allocation.Availability
+		lines      []allocation.Line
+		want       []allocation.Assignment
+	}{
+		{
+			name:       "one warehouse fills the line",
+			warehouses: []allocation.Warehouse{wh("a", 1)},
+			avail:      allocation.Availability{"v1": {"a": 5}},
+			lines:      []allocation.Line{{VariantID: "v1", Quantity: 3}},
+			want: []allocation.Assignment{
+				{WarehouseID: "a", VariantID: "v1", Quantity: 3},
+			},
+		},
+		{
+			name:       "the higher-priority warehouse is filled from first",
+			warehouses: []allocation.Warehouse{wh("a", 1), wh("b", 2)},
+			avail:      allocation.Availability{"v1": {"a": 5, "b": 5}},
+			lines:      []allocation.Line{{VariantID: "v1", Quantity: 3}},
+			want: []allocation.Assignment{
+				{WarehouseID: "a", VariantID: "v1", Quantity: 3},
+			},
+		},
+		{
+			name:       "a line no single warehouse can fill is split",
+			warehouses: []allocation.Warehouse{wh("a", 1), wh("b", 2)},
+			avail:      allocation.Availability{"v1": {"a": 3, "b": 4}},
+			lines:      []allocation.Line{{VariantID: "v1", Quantity: 5}},
+			want: []allocation.Assignment{
+				{WarehouseID: "a", VariantID: "v1", Quantity: 3},
+				{WarehouseID: "b", VariantID: "v1", Quantity: 2},
+			},
+		},
+		{
+			name:       "a warehouse holding none of a variant is skipped, not zero-assigned",
+			warehouses: []allocation.Warehouse{wh("a", 1), wh("b", 2)},
+			avail:      allocation.Availability{"v1": {"b": 4}},
+			lines:      []allocation.Line{{VariantID: "v1", Quantity: 4}},
+			want: []allocation.Assignment{
+				{WarehouseID: "b", VariantID: "v1", Quantity: 4},
+			},
+		},
+		{
+			name:       "several lines each allocate independently",
+			warehouses: []allocation.Warehouse{wh("a", 1), wh("b", 2)},
+			avail: allocation.Availability{
+				"v1": {"a": 1, "b": 5},
+				"v2": {"a": 9},
+			},
+			lines: []allocation.Line{
+				{VariantID: "v1", Quantity: 3},
+				{VariantID: "v2", Quantity: 2},
+			},
+			want: []allocation.Assignment{
+				{WarehouseID: "a", VariantID: "v1", Quantity: 1},
+				{WarehouseID: "a", VariantID: "v2", Quantity: 2},
+				{WarehouseID: "b", VariantID: "v1", Quantity: 2},
+			},
+		},
+		{
+			name:       "a sells-past-zero line goes whole to the first warehouse regardless of stock",
+			warehouses: []allocation.Warehouse{wh("a", 1), wh("b", 2)},
+			avail:      allocation.Availability{"v1": {"b": 100}},
+			lines:      []allocation.Line{{VariantID: "v1", Quantity: 7, SellsPastZero: true}},
+			want: []allocation.Assignment{
+				{WarehouseID: "a", VariantID: "v1", Quantity: 7},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := allocation.Plan(tc.warehouses, tc.avail, tc.lines)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// The allocator's central invariant: what it assigns for a line must add up to
+// exactly what the line asked for. Under-assigning ships a short parcel;
+// over-assigning takes stock the customer did not buy.
+func TestPlan_AssignmentsSumToTheLineQuantity(t *testing.T) {
+	warehouses := []allocation.Warehouse{wh("a", 1), wh("b", 2), wh("c", 3)}
+	avail := allocation.Availability{"v1": {"a": 2, "b": 2, "c": 2}}
+
+	got, err := allocation.Plan(warehouses, avail, []allocation.Line{{VariantID: "v1", Quantity: 5}})
+	require.NoError(t, err)
+
+	total := 0
+	for _, a := range got {
+		total += a.Quantity
+	}
+	require.Equal(t, 5, total)
+}
+
+func TestPlan_ReturnsCannotFillWhenNoCombinationSatisfiesTheLine(t *testing.T) {
+	warehouses := []allocation.Warehouse{wh("a", 1), wh("b", 2)}
+	avail := allocation.Availability{"v1": {"a": 2, "b": 1}}
+
+	_, err := allocation.Plan(warehouses, avail, []allocation.Line{{VariantID: "v1", Quantity: 6}})
+
+	var cannot allocation.CannotFillError
+	require.True(t, errors.As(err, &cannot), "got %v", err)
+	require.Equal(t, "v1", cannot.VariantID)
+	require.Equal(t, 3, cannot.Short, "6 wanted, 3 available, so 3 short")
+}
+
+func TestPlan_RefusesAStoreWithNoWarehouses(t *testing.T) {
+	_, err := allocation.Plan(nil, allocation.Availability{}, []allocation.Line{{VariantID: "v1", Quantity: 1}})
+	require.ErrorIs(t, err, allocation.ErrNoWarehouse)
+}
+
+func TestPlan_RefusesANonPositiveLineQuantity(t *testing.T) {
+	warehouses := []allocation.Warehouse{wh("a", 1)}
+	avail := allocation.Availability{"v1": {"a": 5}}
+
+	_, err := allocation.Plan(warehouses, avail, []allocation.Line{{VariantID: "v1", Quantity: 0}})
+	require.Error(t, err, "a line for zero units is a caller bug, not an empty allocation")
+}
+
+func TestPlan_NoLinesIsNoAssignmentsNotAnError(t *testing.T) {
+	got, err := allocation.Plan([]allocation.Warehouse{wh("a", 1)}, allocation.Availability{}, nil)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}

--- a/services/marketplace-api/internal/allocation/plan_test.go
+++ b/services/marketplace-api/internal/allocation/plan_test.go
@@ -2,6 +2,7 @@ package allocation_test
 
 import (
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -105,6 +106,15 @@ func TestPlan_AssignmentsSumToTheLineQuantity(t *testing.T) {
 	got, err := allocation.Plan(warehouses, avail, []allocation.Line{{VariantID: "v1", Quantity: 5}})
 	require.NoError(t, err)
 
+	// A total-only assertion is satisfiable by an arithmetically broken plan
+	// (e.g. one that double-spends stock and still nets out to 5), so assert
+	// the actual per-warehouse split too.
+	require.Equal(t, []allocation.Assignment{
+		{WarehouseID: "a", VariantID: "v1", Quantity: 2},
+		{WarehouseID: "b", VariantID: "v1", Quantity: 2},
+		{WarehouseID: "c", VariantID: "v1", Quantity: 1},
+	}, got)
+
 	total := 0
 	for _, a := range got {
 		total += a.Quantity
@@ -130,11 +140,121 @@ func TestPlan_RefusesAStoreWithNoWarehouses(t *testing.T) {
 }
 
 func TestPlan_RefusesANonPositiveLineQuantity(t *testing.T) {
-	warehouses := []allocation.Warehouse{wh("a", 1)}
-	avail := allocation.Availability{"v1": {"a": 5}}
+	tests := []struct {
+		name     string
+		quantity int
+	}{
+		{name: "zero", quantity: 0},
+		{name: "negative", quantity: -3},
+	}
 
-	_, err := allocation.Plan(warehouses, avail, []allocation.Line{{VariantID: "v1", Quantity: 0}})
-	require.Error(t, err, "a line for zero units is a caller bug, not an empty allocation")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			warehouses := []allocation.Warehouse{wh("a", 1)}
+			avail := allocation.Availability{"v1": {"a": 5}}
+
+			_, err := allocation.Plan(warehouses, avail, []allocation.Line{{VariantID: "v1", Quantity: tc.quantity}})
+			require.Error(t, err, "a line for non-positive units is a caller bug, not an empty allocation")
+			require.ErrorIs(t, err, allocation.ErrInvalidInput)
+		})
+	}
+}
+
+// A caller passing the same warehouse twice would otherwise produce two
+// assignments naming the same warehouse for one line, which violates
+// order_allocations' UNIQUE (order_item_id, warehouse_id) constraint in PR 3.
+func TestPlan_RefusesDuplicateWarehouseIDs(t *testing.T) {
+	warehouses := []allocation.Warehouse{wh("a", 1), wh("a", 2)}
+	avail := allocation.Availability{"v1": {"a": 10}}
+
+	_, err := allocation.Plan(warehouses, avail, []allocation.Line{{VariantID: "v1", Quantity: 3}})
+	require.ErrorIs(t, err, allocation.ErrInvalidInput)
+}
+
+// Two lines carrying the same variant must be filled from the combined
+// availability without double-spending it: each line reads avail.At fresh,
+// so without a shared consumption budget both could see the same units as
+// available and together take more than the warehouse actually holds.
+func TestPlan_DuplicateVariantLinesShareAvailability(t *testing.T) {
+	warehouses := []allocation.Warehouse{wh("a", 1), wh("b", 2)}
+	avail := allocation.Availability{"v1": {"a": 4, "b": 2}}
+	lines := []allocation.Line{
+		{VariantID: "v1", Quantity: 3},
+		{VariantID: "v1", Quantity: 3},
+	}
+
+	got, err := allocation.Plan(warehouses, avail, lines)
+	require.NoError(t, err)
+
+	byWarehouse := map[string]int{}
+	total := 0
+	for _, a := range got {
+		require.Equal(t, "v1", a.VariantID)
+		byWarehouse[a.WarehouseID] += a.Quantity
+		total += a.Quantity
+	}
+	require.Equal(t, 6, total)
+	require.LessOrEqual(t, byWarehouse["a"], 4, "must not exceed warehouse a's availability")
+	require.LessOrEqual(t, byWarehouse["b"], 2, "must not exceed warehouse b's availability")
+}
+
+// When the combined quantity of duplicate-variant lines exceeds all
+// availability, Plan must report CannotFillError rather than over-assign.
+func TestPlan_DuplicateVariantLinesExceedingAvailabilityCannotFill(t *testing.T) {
+	warehouses := []allocation.Warehouse{wh("a", 1)}
+	avail := allocation.Availability{"v1": {"a": 4}}
+	lines := []allocation.Line{
+		{VariantID: "v1", Quantity: 3},
+		{VariantID: "v1", Quantity: 3},
+	}
+
+	_, err := allocation.Plan(warehouses, avail, lines)
+
+	var cannot allocation.CannotFillError
+	require.True(t, errors.As(err, &cannot), "got %v", err)
+	require.Equal(t, "v1", cannot.VariantID)
+	require.Equal(t, 2, cannot.Short, "6 wanted, 4 available, so 2 short")
+}
+
+// Negative availability (an unfloored quantity-minus-holds snapshot) must
+// never produce a negative-quantity assignment, and must never make the
+// remaining quantity APPEAR to grow.
+func TestPlan_NegativeAvailabilityProducesNoNegativeAssignment(t *testing.T) {
+	warehouses := []allocation.Warehouse{wh("a", 1), wh("b", 2)}
+	avail := allocation.Availability{"v1": {"a": -3, "b": 20}}
+	lines := []allocation.Line{{VariantID: "v1", Quantity: 5}}
+
+	got, err := allocation.Plan(warehouses, avail, lines)
+	require.NoError(t, err)
+
+	total := 0
+	for _, a := range got {
+		require.Positive(t, a.Quantity, "no assignment may carry a non-positive quantity")
+		require.NotEqual(t, "a", a.WarehouseID, "warehouse a has negative availability and must not be assigned")
+		total += a.Quantity
+	}
+	require.Equal(t, 5, total)
+	require.Equal(t, []allocation.Assignment{
+		{WarehouseID: "b", VariantID: "v1", Quantity: 5},
+	}, got)
+}
+
+// Plan must not mutate its inputs — the repo-wide immutability rule.
+func TestPlan_DoesNotMutateItsInputs(t *testing.T) {
+	warehouses := []allocation.Warehouse{wh("a", 1), wh("b", 2)}
+	avail := allocation.Availability{"v1": {"a": 2, "b": 5}}
+	lines := []allocation.Line{{VariantID: "v1", Quantity: 4}}
+
+	wantWarehouses := slices.Clone(warehouses)
+	wantAvail := allocation.Availability{"v1": {"a": 2, "b": 5}}
+	wantLines := slices.Clone(lines)
+
+	_, err := allocation.Plan(warehouses, avail, lines)
+	require.NoError(t, err)
+
+	require.Equal(t, wantWarehouses, warehouses)
+	require.Equal(t, wantAvail, avail)
+	require.Equal(t, wantLines, lines)
 }
 
 func TestPlan_NoLinesIsNoAssignmentsNotAnError(t *testing.T) {


### PR DESCRIPTION
**PR 2 of 6** toward multi-warehouse support. A pure `internal/allocation`
package that decides which warehouse ships how much of each order line.

Part of #177. Follows #488 (the schema).

## It has no callers

That is deliberate. PR 3 wires it into `commitStock` and `cart_holds.go`.
Landing the decision logic on its own means the arithmetic gets reviewed as
arithmetic, before it is entangled with transactions, locking and GORM.

The package touches no database: no `gorm`, no `context`, no `database/sql`.
`go list -deps` confirms it structurally rather than by reading imports. Its
tests run in under a second with no DSN.

## What it does

`InPriorityOrder` sorts a store's warehouses by `priority ASC, is_default DESC,
created_at ASC, id ASC`. `Plan` walks that order taking
`min(remaining, available)` for every unsatisfied line at each warehouse.

The **id** tiebreak makes the order **total**. Without it two warehouses
created in the same second with equal priority compare equal, and two identical
carts could allocate differently — a merchant would see the same order ship
from different cities with nothing to explain it.

It deliberately does **not** minimise parcel count. Filling from the merchant's
first warehouse down is a rule you can say out loud to a merchant; a true
minimum is a bin-packing problem worth less than an explainable answer.

The plan is **advisory**. `stockhold.Hold`'s per-location check under
`SELECT … FOR UPDATE` remains what actually stops two orders taking the last
unit. Nothing here adds a concurrency primitive.

## Three bugs review found, by running the code

### Duplicate variants double-spent stock

`remaining` was tracked per line, and availability read fresh per line, so two
lines carrying the same variant each saw the full figure:

```
lines [{v1,3},{v1,3}], avail v1:{a:4,b:2}
  → [{a v1 3} {a v1 3}]        # 6 units promised from a warehouse holding 4
```

Not hypothetical for PR 3: `stockLinesFromItems` emits one line per checkout
**item** and does not merge by variant. And because `stock_holds` is
`UNIQUE (cart_token, variant_id, location_id)`, the second `Hold` would
*refresh* rather than stack — the cart reserves 3 units for a 6-unit order.
That is an oversell channel, not merely a rejected order.

Fixed with a per-`(variant, warehouse)` consumption budget. Keyed on both, not
on variant alone — keying on variant would forbid drawing one variant from two
warehouses, which is the entire split behaviour.

### Negative availability produced a negative assignment

```
avail v1:{a:-3,b:20}, line {v1,5}
  → [{a v1 -3} {b v1 8}]
```

`remaining -= take` with a negative take *increases* the remainder, and the
per-line invariant cannot catch it because −3 + 8 still sums to 5. Downstream
that is an `order_allocations` INSERT violating `CHECK (quantity > 0)` — a
constraint error instead of a domain error.

Reachable because PR 3's snapshot is `variant_stock.quantity − live holds`, and
that subtraction is not floored: a merchant lowering stock while holds are live
produces a negative. `stockhold` already clamps this exact case; the allocator
now matches its sibling.

### One of my own guards was decoration

Mutating the `IsDefault` tiebreak left the entire suite green — that line had
**zero executions**, because a two-element test only evaluates the comparator in
one direction. It is the guard whose failure the spec explicitly forbids.

Now pinned by a four-element case and by a permutation-invariance test: several
input orderings of the same set must produce one identical output, which is what
"the ordering is total" actually asserts.

## Testing

28 subtests, no database. Three guards mutation-tested — removed, tests failed,
restored:

- the shortfall check (without it `Plan` silently returns a plan that ships
  fewer units than were paid for)
- the sells-past-zero branch (without it a `continue`-policy line allocates
  nowhere)
- the `IsDefault` tiebreak (mutant yields `[x z y w]` against an expected
  `[y w x z]`, and also fails permutation-invariance)

`go build`, `go vet`, `go vet -tags=integration`, `gofmt -l .` clean; full unit
suite green. This is the first #177 PR whose tests CI actually runs, following
#489.

## Also fixed while here

Duplicate warehouse ids are rejected (they would violate `order_allocations`'
`UNIQUE (order_item_id, warehouse_id)` downstream); invalid input now wraps an
`ErrInvalidInput` sentinel so PR 3 can distinguish a caller bug from a domain
failure without matching on strings; an unreachable branch in the
sells-past-zero path is gone.

## Next

PR 3 wires this into checkout: allocation at cart (provisional) and at order
placement (binding), writing `order_allocations`. It must order warehouses
through `InPriorityOrder` before calling `Plan` — `Plan` takes an ordered slice
and cannot detect an unordered one, which is deliberate so a later
nearest-pincode comparator is a sibling function rather than a rewrite.
