### PR TITLE
feat(storefront): allocate orders across warehouses at placement (#177, PR 3 of 6)

### DIFF
--- a/docs/superpowers/plans/2026-08-31-multi-warehouse-03-checkout.md
+++ b/docs/superpowers/plans/2026-08-31-multi-warehouse-03-checkout.md
@@ -1,0 +1,778 @@
+# Multi-warehouse PR 3: checkout allocation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the allocator into checkout so an order is allocated across warehouses when it is placed, writing `order_allocations`, without changing behaviour for any store that has no warehouses.
+
+**Architecture:** A new availability snapshot loader, then `commitStock` gains an allocation path. The binding allocation happens at order placement, inside the order transaction, where `order_items` rows already exist. Cart-time holds stay provisional. Every change is gated on the store actually having warehouse rows — which no store has today, so this PR is a no-op in production until PR 5 lets merchants create them.
+
+**Tech Stack:** Go 1.26, GORM, PostgreSQL 15, testify.
+
+**Spec:** `docs/superpowers/specs/2026-08-31-multi-warehouse-allocation-design.md` (see "Checkout", "The allocator", and "The sentinel backfill, and why it is two deploys")
+
+## Global Constraints
+
+- Work in the worktree `.claude/worktrees/177-checkout`, branch `feat/177-checkout-allocation`. Never switch the main checkout's branch.
+- Run every Go command from `services/marketplace-api`, never path-scoped, always `-count=1`: `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./... -count=1`.
+- Integration tests: `//go:build integration`, gated on `TEST_DATABASE_URL` (**never** `TEST_DB_DSN`), run with `-p 1`. A skip prints `ok` and reads like a pass — every claim must name the DSN and the duration.
+- Verified DSN: `postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable` (container `dev-postgres-1`; the LAN IP, not localhost — a native Postgres owns 127.0.0.1:5432 on this machine).
+- Commits: conventional, single line, no signature, no `Co-Authored-By`, no emoji. Stage explicit paths; never `git add -A`.
+- Every guard added must be mutation-tested: delete it, watch a test fail, restore it.
+- Never mutate an input.
+
+## The four facts this plan is built on
+
+Each was verified against the code or the live database. Do not re-derive them; do not contradict them without saying so.
+
+**1. Production has ZERO warehouse rows.** Measured on the live database: `warehouses` = 0 rows, `variant_stock` = 380 rows all at the sentinel `00000000-0000-0000-0000-000000000001`, across one store. Warehouses are only created when a carrier config is saved, and no merchant has done that.
+
+  Therefore: **a store with no warehouses must keep behaving exactly as it does today.** If allocation ran unconditionally, `Plan` would return `ErrNoWarehouse` and every checkout in production would fail. The legacy path is not a fallback for tidiness — it is the only path that currently executes.
+
+**2. `Hold` REPLACES a quantity, it does not add to it.** `internal/stockhold/repository.go`: `ON CONFLICT (cart_token, variant_id, location_id) DO UPDATE SET qty = EXCLUDED.qty`. Two assignments for the same `(variant, warehouse)` — which happens whenever two order lines carry the same variant — would leave only the second quantity reserved.
+
+  Therefore: **aggregate assignments by `(variant, storage location)` before calling `Hold`, summing quantities.** `order_allocations` rows stay per line; only the holds are aggregated.
+
+**3. `WithinTx` runs AFTER the order items are inserted.** `internal/order/service.go`: `CreateInTx(tx, o, in.Items, …)` at ~line 197, then `in.WithinTx(tx, o)` at ~line 211. So inside `commitStock` the `order_items` rows exist and can be read back.
+
+  Therefore: build the allocation lines by querying `order_items` for the order, so each line carries its `order_item_id`. Do not thread ids through `CheckoutItemRequest`.
+
+**4. Stock lives at the SENTINEL, not at warehouse ids, until PR 6 backfills it.** A store can have a `warehouses` row whose id appears nowhere in `variant_stock`.
+
+  Therefore the availability snapshot must carry, for each `(variant, warehouse)` pair, BOTH the units available AND the **storage location id** the units are actually recorded under. Allocation reasons in warehouse-id space; holds and decrements must use the storage location id. After PR 6 the two coincide and nothing changes.
+
+---
+
+## File Structure
+
+- **Create** `services/marketplace-api/internal/handlers/storefront/checkout_availability.go` — the snapshot loader
+- **Create** `services/marketplace-api/internal/handlers/storefront/checkout_availability_integration_test.go`
+- **Modify** `services/marketplace-api/internal/handlers/storefront/checkout_stock.go` — `commitStock` gains the allocation path
+- **Create** `services/marketplace-api/internal/handlers/storefront/checkout_allocation_integration_test.go`
+
+`cart_holds.go` is deliberately NOT changed in this PR — see "Explicitly NOT in this PR".
+
+---
+
+### Task 1: The availability snapshot
+
+**Files:**
+- Create: `services/marketplace-api/internal/handlers/storefront/checkout_availability.go`
+- Test: `services/marketplace-api/internal/handlers/storefront/checkout_availability_integration_test.go`
+
+**Interfaces:**
+- Consumes: `allocation.Availability` from `internal/allocation` (PR 2, merged).
+- Produces:
+
+```go
+// storageLocations maps warehouseID -> the location_id the units are
+// actually stored under, per variant: storage[variantID][warehouseID].
+type storageLocations map[string]map[string]string
+
+func loadAvailability(
+    ctx context.Context, tx *gorm.DB, cartToken string,
+    warehouses []allocation.Warehouse, variantIDs []string,
+) (allocation.Availability, storageLocations, error)
+```
+
+  Task 2 calls this, passes the `Availability` to `allocation.Plan`, and uses `storageLocations` to decide which `location_id` each `Hold` targets.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `services/marketplace-api/internal/handlers/storefront/checkout_availability_integration_test.go`:
+
+```go
+//go:build integration
+
+// Package storefront — coverage for the multi-warehouse availability
+// snapshot (#177 PR 3).
+//
+// The snapshot is what allocation reasons over. Two things about it are
+// easy to get wrong and expensive to get wrong:
+//
+//   - It must EXCLUDE the calling cart's own live holds, matching
+//     stockhold.Hold and stockhold.Available. A cart asking what it can have
+//     must not be told its own reservation is competition.
+//   - Until PR 6's backfill, units are stored at the sentinel location, not
+//     at any warehouse id. The snapshot therefore reports availability
+//     against a WAREHOUSE while remembering the STORAGE location the units
+//     actually sit at, because that is where a hold has to be placed.
+package storefront
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/allocation"
+	"github.com/mark8ly/marketplace-api/internal/product"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedAvailStore creates a store, a product and one variant, and returns
+// (storeID, variantID).
+func seedAvailStore(t *testing.T, db *gorm.DB) (string, string) {
+	t.Helper()
+	tenantID, storeID := uuid.NewString(), uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO stores (id, tenant_id, name, slug, status, country_code, currency_code, timezone,
+		                     storefront_customer_portal_secret)
+		 VALUES (?, ?, 'Avail Test', ?, 'active', 'IN', 'INR', 'Asia/Kolkata', ?)`,
+		storeID, tenantID, "avail-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	productID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO products (id, tenant_id, store_id, title, handle, status, vendor_id, published_at)
+		 VALUES (?, ?, ?, 'Avail Product', ?, 'active', ?, now())`,
+		productID, tenantID, storeID, "avail-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	variantID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO product_variants (id, product_id, store_id, sku, price, currency_code)
+		 VALUES (?, ?, ?, ?, 10.00, 'INR')`,
+		variantID, productID, storeID, "SKU-"+uuid.NewString()[:8]).Error)
+	return storeID, variantID
+}
+
+func seedWarehouseRow(t *testing.T, db *gorm.DB, storeID, name string) string {
+	t.Helper()
+	var tenantID string
+	require.NoError(t, db.Raw(`SELECT tenant_id FROM stores WHERE id = ?`, storeID).Row().Scan(&tenantID))
+	id := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO warehouses (id, tenant_id, store_id, name, line1, city, region, postal_code, country_code, phone)
+		 VALUES (?, ?, ?, ?, '1 Dock Rd', 'Mumbai', 'MH', '400001', 'IN', '+912200000000')`,
+		id, tenantID, storeID, name).Error)
+	return id
+}
+
+func TestLoadAvailability_SentinelStockIsReportedAgainstTheFirstWarehouse(t *testing.T) {
+	db := testdb.NewTx(t)
+	storeID, variantID := seedAvailStore(t, db)
+	whID := seedWarehouseRow(t, db, storeID, "Main")
+
+	// Stock still lives at the sentinel — PR 6 has not backfilled yet.
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 7, now())`, variantID, product.DefaultLocationID).Error)
+
+	warehouses := []allocation.Warehouse{{ID: whID}}
+	avail, storage, err := loadAvailability(context.Background(), db, uuid.NewString(), warehouses, []string{variantID})
+	require.NoError(t, err)
+
+	require.Equal(t, 7, avail.At(variantID, whID),
+		"sentinel-stored units must be visible against the store's warehouse before the backfill")
+	require.Equal(t, product.DefaultLocationID, storage[variantID][whID],
+		"a hold must target the location the units are actually stored at")
+}
+
+func TestLoadAvailability_RealWarehouseStockIsReportedAgainstItself(t *testing.T) {
+	db := testdb.NewTx(t)
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	whB := seedWarehouseRow(t, db, storeID, "B")
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 3, now()), (?, ?, 4, now())`,
+		variantID, whA, variantID, whB).Error)
+
+	warehouses := []allocation.Warehouse{{ID: whA}, {ID: whB}}
+	avail, storage, err := loadAvailability(context.Background(), db, uuid.NewString(), warehouses, []string{variantID})
+	require.NoError(t, err)
+
+	require.Equal(t, 3, avail.At(variantID, whA))
+	require.Equal(t, 4, avail.At(variantID, whB))
+	require.Equal(t, whA, storage[variantID][whA], "post-backfill the storage location IS the warehouse")
+	require.Equal(t, whB, storage[variantID][whB])
+}
+
+// Matching stockhold.Hold and stockhold.Available: a cart must not see its
+// own reservation as competition, or it could never re-hold what it already
+// has and checkout would refuse a cart it had itself reserved.
+func TestLoadAvailability_ExcludesTheCallingCartsOwnHolds(t *testing.T) {
+	db := testdb.NewTx(t)
+	storeID, variantID := seedAvailStore(t, db)
+	whID := seedWarehouseRow(t, db, storeID, "Main")
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 10, now())`, variantID, product.DefaultLocationID).Error)
+
+	mine, theirs := uuid.NewString(), uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO stock_holds (variant_id, location_id, cart_token, qty, expires_at, state)
+		 VALUES (?, ?, ?, 4, ?, 'held'), (?, ?, ?, 3, ?, 'held')`,
+		variantID, product.DefaultLocationID, mine, time.Now().Add(time.Hour),
+		variantID, product.DefaultLocationID, theirs, time.Now().Add(time.Hour)).Error)
+
+	warehouses := []allocation.Warehouse{{ID: whID}}
+	avail, _, err := loadAvailability(context.Background(), db, mine, warehouses, []string{variantID})
+	require.NoError(t, err)
+
+	require.Equal(t, 7, avail.At(variantID, whID),
+		"10 units less the OTHER cart's 3; this cart's own 4 must not count against it")
+}
+
+func TestLoadAvailability_ExpiredHoldsDoNotReduceAvailability(t *testing.T) {
+	db := testdb.NewTx(t)
+	storeID, variantID := seedAvailStore(t, db)
+	whID := seedWarehouseRow(t, db, storeID, "Main")
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 5, now())`, variantID, product.DefaultLocationID).Error)
+	require.NoError(t, db.Exec(
+		`INSERT INTO stock_holds (variant_id, location_id, cart_token, qty, expires_at, state)
+		 VALUES (?, ?, ?, 5, ?, 'held')`,
+		variantID, product.DefaultLocationID, uuid.NewString(), time.Now().Add(-time.Minute)).Error)
+
+	avail, _, err := loadAvailability(context.Background(), db, uuid.NewString(),
+		[]allocation.Warehouse{{ID: whID}}, []string{variantID})
+	require.NoError(t, err)
+
+	require.Equal(t, 5, avail.At(variantID, whID),
+		"a hold expires by the clock, not by a sweeper running")
+}
+
+// A variant with no stock row anywhere must simply be absent, not zero-filled
+// — allocation treats a missing entry as zero, and inventing rows would hide
+// the difference between "none here" and "no such pairing".
+func TestLoadAvailability_VariantWithNoStockRowsIsAbsent(t *testing.T) {
+	db := testdb.NewTx(t)
+	storeID, variantID := seedAvailStore(t, db)
+	whID := seedWarehouseRow(t, db, storeID, "Main")
+
+	avail, storage, err := loadAvailability(context.Background(), db, uuid.NewString(),
+		[]allocation.Warehouse{{ID: whID}}, []string{variantID})
+	require.NoError(t, err)
+
+	require.Equal(t, 0, avail.At(variantID, whID))
+	require.Empty(t, storage[variantID])
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration ./internal/handlers/storefront/... -run TestLoadAvailability -count=1 -p 1
+```
+
+Expected: FAIL to compile — `undefined: loadAvailability`. If instead every test SKIPs, `TEST_DATABASE_URL` did not reach the process; fix that first, because a skip is indistinguishable from a pass.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `services/marketplace-api/internal/handlers/storefront/checkout_availability.go`:
+
+```go
+package storefront
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/allocation"
+	"github.com/mark8ly/marketplace-api/internal/product"
+)
+
+// storageLocations records, per variant and warehouse, the location_id the
+// units are actually stored under.
+//
+// It exists because of the expand phase: until PR 6 backfills
+// variant_stock.location_id, units sit at product.DefaultLocationID while
+// allocation reasons about real warehouse ids. A hold must be placed against
+// the location the row actually has, or it locks nothing. After the backfill
+// the two values coincide and this map becomes an identity.
+type storageLocations map[string]map[string]string
+
+// loadAvailability builds the snapshot allocation.Plan reasons over.
+//
+// Availability is variant_stock.quantity minus OTHER carts' live holds — the
+// same arithmetic stockhold.Available uses, and excluding the calling cart's
+// own holds for the same reason: a cart must not be told its own reservation
+// is competition.
+//
+// This is a READ. It takes no locks, and it is not what makes the decision
+// safe: stockhold.Hold re-checks under SELECT ... FOR UPDATE, and that is the
+// check that counts. A snapshot that is stale by the time it is used simply
+// produces a plan whose holds fail, which is the same outcome a
+// single-warehouse shopper gets today.
+func loadAvailability(
+	ctx context.Context,
+	tx *gorm.DB,
+	cartToken string,
+	warehouses []allocation.Warehouse,
+	variantIDs []string,
+) (allocation.Availability, storageLocations, error) {
+	avail := allocation.Availability{}
+	storage := storageLocations{}
+	if len(warehouses) == 0 || len(variantIDs) == 0 {
+		return avail, storage, nil
+	}
+
+	var rows []struct {
+		VariantID  string
+		LocationID string
+		Available  int
+	}
+	err := tx.WithContext(ctx).Raw(
+		`SELECT vs.variant_id,
+		        vs.location_id,
+		        vs.quantity - COALESCE((
+		            SELECT SUM(sh.qty) FROM stock_holds sh
+		             WHERE sh.variant_id = vs.variant_id
+		               AND sh.location_id = vs.location_id
+		               AND sh.state = 'held'
+		               AND sh.expires_at > now()
+		               AND sh.cart_token <> ?), 0) AS available
+		   FROM variant_stock vs
+		  WHERE vs.variant_id IN ?`, cartToken, variantIDs).Scan(&rows).Error
+	if err != nil {
+		return nil, nil, fmt.Errorf("storefront: load availability: %w", err)
+	}
+
+	// Which warehouse a stock row belongs to. Sentinel rows have no real
+	// warehouse of their own, so they answer for the store's FIRST warehouse
+	// in fill order — the one a single-warehouse store ships everything from
+	// anyway. Real rows answer for themselves.
+	byWarehouse := make(map[string]string, len(warehouses))
+	for _, w := range warehouses {
+		byWarehouse[w.ID] = w.ID
+	}
+
+	for _, r := range rows {
+		warehouseID := r.LocationID
+		if r.LocationID == product.DefaultLocationID {
+			warehouseID = warehouses[0].ID
+		} else if _, known := byWarehouse[r.LocationID]; !known {
+			// Stock at a location that is not one of this store's warehouses
+			// — another store's row cannot appear here (variantIDs are this
+			// order's), so this is a warehouse deleted out from under its
+			// stock. Skip it rather than allocate from somewhere that no
+			// longer exists.
+			continue
+		}
+
+		if r.Available < 0 {
+			// Holds can exceed stock if a merchant lowered the count while
+			// reservations were live. Allocation clamps too, but reporting a
+			// negative here would be nonsense on the way in.
+			r.Available = 0
+		}
+
+		if avail[r.VariantID] == nil {
+			avail[r.VariantID] = map[string]int{}
+			storage[r.VariantID] = map[string]string{}
+		}
+		avail[r.VariantID][warehouseID] += r.Available
+		storage[r.VariantID][warehouseID] = r.LocationID
+	}
+
+	return avail, storage, nil
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration ./internal/handlers/storefront/... -run TestLoadAvailability -count=1 -p 1 -v
+```
+
+Expected: all five PASS, with durations in the tens of milliseconds each (not zero — a zero-duration run means it skipped).
+
+- [ ] **Step 5: Mutation-test the own-cart exclusion**
+
+Change `AND sh.cart_token <> ?` to `AND sh.cart_token = ?`, re-run.
+
+Expected: FAIL — `TestLoadAvailability_ExcludesTheCallingCartsOwnHolds` reports 6 rather than 7. Restore and confirm green. If it still passes, the test is not pinning the exclusion.
+
+- [ ] **Step 6: Verify and commit**
+
+```bash
+cd services/marketplace-api
+go build ./... && go vet ./... && go vet -tags=integration ./... && gofmt -l .
+go test ./... -count=1
+```
+
+```bash
+git add services/marketplace-api/internal/handlers/storefront/checkout_availability.go \
+        services/marketplace-api/internal/handlers/storefront/checkout_availability_integration_test.go
+git commit -m "feat(storefront): per-warehouse availability snapshot for checkout allocation (#177)"
+```
+
+---
+
+### Task 2: Allocate at order placement
+
+**Files:**
+- Modify: `services/marketplace-api/internal/handlers/storefront/checkout_stock.go`
+- Test: `services/marketplace-api/internal/handlers/storefront/checkout_allocation_integration_test.go`
+
+**Interfaces:**
+- Consumes: `loadAvailability` and `storageLocations` from Task 1; `allocation.InPriorityOrder`, `allocation.Plan`, `allocation.CannotFillError` from `internal/allocation`.
+- Produces: `commitStock` writes `order_allocations` rows for stores that have warehouses. PR 4 groups those rows by warehouse to create one shipment each.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `services/marketplace-api/internal/handlers/storefront/checkout_allocation_integration_test.go`. It exercises `commitStock` directly rather than through an HTTP checkout, because the property under test is what lands in the database, and driving a full checkout would need payment and address fixtures irrelevant to it.
+
+```go
+//go:build integration
+
+// Package storefront — coverage for allocation at order placement (#177 PR 3).
+//
+// The load-bearing case is the FIRST one: a store with no warehouses must
+// behave exactly as it did before this PR. That is not a tidy fallback —
+// production has zero warehouse rows, so it is the only path that currently
+// runs, and a regression there breaks every checkout.
+package storefront
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/product"
+	"github.com/mark8ly/marketplace-api/internal/stockhold"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedOrderWithItems creates an order and one order_item per line and
+// returns (orderID, []orderItemID).
+func seedOrderWithItems(t *testing.T, db *gorm.DB, storeID string, lines []stockLine) (string, []string) {
+	t.Helper()
+	var tenantID string
+	require.NoError(t, db.Raw(`SELECT tenant_id FROM stores WHERE id = ?`, storeID).Row().Scan(&tenantID))
+
+	orderID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO orders (id, tenant_id, store_id, order_number, idempotency_key,
+		                     customer_email, currency_code, subtotal, grand_total)
+		 VALUES (?, ?, ?, ?, ?, 'buyer@example.com', 'INR', 10.00, 10.00)`,
+		orderID, tenantID, storeID, "AL-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	ids := make([]string, 0, len(lines))
+	for _, l := range lines {
+		itemID := uuid.NewString()
+		require.NoError(t, db.Exec(
+			`INSERT INTO order_items (id, order_id, variant_id, title_snapshot, sku_snapshot,
+			                          unit_price, quantity, line_total, currency_code)
+			 VALUES (?, ?, ?, 'Item', 'SKU', 10.00, ?, 10.00, 'INR')`,
+			itemID, orderID, l.VariantID, l.Quantity).Error)
+		ids = append(ids, itemID)
+	}
+	return orderID, ids
+}
+
+func stockAt(t *testing.T, db *gorm.DB, variantID, locationID string) int {
+	t.Helper()
+	var q int
+	require.NoError(t, db.Raw(
+		`SELECT COALESCE((SELECT quantity FROM variant_stock WHERE variant_id = ? AND location_id = ?), -1)`,
+		variantID, locationID).Row().Scan(&q))
+	return q
+}
+
+// THE load-bearing test. Production has zero warehouses; if this regresses,
+// every checkout fails.
+func TestCommitStock_StoreWithNoWarehousesBehavesExactlyAsBefore(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 5, now())`, variantID, product.DefaultLocationID).Error)
+
+	lines := []stockLine{{VariantID: variantID, Quantity: 2}}
+	orderID, _ := seedOrderWithItems(t, db, storeID, lines)
+	cart := uuid.NewString()
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), cart, orderID, storeID, lines)
+	}))
+
+	require.Equal(t, 3, stockAt(t, db, variantID, product.DefaultLocationID),
+		"the sentinel row must still be the one decremented")
+
+	var allocations int64
+	require.NoError(t, db.Raw(
+		`SELECT count(*) FROM order_allocations WHERE order_id = ?`, orderID).Scan(&allocations).Error)
+	require.Zero(t, allocations,
+		"a store with no warehouses has nothing to allocate against — order_allocations.warehouse_id is NOT NULL")
+}
+
+func TestCommitStock_AllocatesAcrossWarehousesAndRecordsThem(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	whB := seedWarehouseRow(t, db, storeID, "B")
+	require.NoError(t, db.Exec(`UPDATE warehouses SET priority = 0 WHERE id = ?`, whA).Error)
+	require.NoError(t, db.Exec(`UPDATE warehouses SET priority = 1 WHERE id = ?`, whB).Error)
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 3, now()), (?, ?, 4, now())`,
+		variantID, whA, variantID, whB).Error)
+
+	lines := []stockLine{{VariantID: variantID, Quantity: 5}}
+	orderID, itemIDs := seedOrderWithItems(t, db, storeID, lines)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	}))
+
+	var got []struct {
+		WarehouseID string
+		Quantity    int
+	}
+	require.NoError(t, db.Raw(
+		`SELECT warehouse_id, quantity FROM order_allocations
+		  WHERE order_item_id = ? ORDER BY quantity DESC`, itemIDs[0]).Scan(&got).Error)
+	require.Len(t, got, 2, "5 units from a 3+4 split must record two allocations")
+	require.Equal(t, whA, got[0].WarehouseID)
+	require.Equal(t, 3, got[0].Quantity)
+	require.Equal(t, whB, got[1].WarehouseID)
+	require.Equal(t, 2, got[1].Quantity)
+
+	require.Equal(t, 0, stockAt(t, db, variantID, whA), "the higher-priority warehouse is drained first")
+	require.Equal(t, 2, stockAt(t, db, variantID, whB))
+}
+
+// Two order lines carrying the SAME variant. stockLinesFromItems does not
+// merge by variant, and stock_holds' ON CONFLICT REPLACES a quantity rather
+// than adding to it — so holding per assignment without aggregating would
+// reserve only the second line's units and oversell the first.
+func TestCommitStock_TwoLinesOfOneVariantDoNotUnderHold(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 6, now())`, variantID, whA).Error)
+
+	lines := []stockLine{{VariantID: variantID, Quantity: 2}, {VariantID: variantID, Quantity: 3}}
+	orderID, itemIDs := seedOrderWithItems(t, db, storeID, lines)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	}))
+
+	require.Equal(t, 1, stockAt(t, db, variantID, whA),
+		"6 units less 2 and 3 is 1 — under-holding would have left 4 or 3 here")
+
+	for i, itemID := range itemIDs {
+		var q int
+		require.NoError(t, db.Raw(
+			`SELECT quantity FROM order_allocations WHERE order_item_id = ?`, itemID).Row().Scan(&q))
+		require.Equal(t, lines[i].Quantity, q, "each line records its own allocation")
+	}
+}
+
+func TestCommitStock_UnfillableOrderFailsAndTakesNoStock(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 2, now())`, variantID, whA).Error)
+
+	lines := []stockLine{{VariantID: variantID, Quantity: 9}}
+	orderID, _ := seedOrderWithItems(t, db, storeID, lines)
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	})
+	require.Error(t, err, "an order no combination of warehouses can fill must fail the transaction")
+
+	require.Equal(t, 2, stockAt(t, db, variantID, whA), "a failed checkout must move no stock")
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration ./internal/handlers/storefront/... -run TestCommitStock -count=1 -p 1
+```
+
+Expected: FAIL to compile — `commitStock` does not yet take `orderID` and `storeID`.
+
+- [ ] **Step 3: Change `commitStock`**
+
+In `services/marketplace-api/internal/handlers/storefront/checkout_stock.go`:
+
+1. Widen the signature to `commitStock(ctx context.Context, tx *gorm.DB, holds *stockhold.Repository, cartToken, orderID, storeID string, lines []stockLine) error`, and update its one caller at `internal/handlers/storefront/checkout_ext.go` (search for `commitStock(`) to pass `o.ID` and the store id it already has in scope.
+
+2. After the existing `inventoryPolicies` lookup, load the store's warehouses in fill order:
+
+```go
+	// A store with NO warehouses keeps the pre-#177 behaviour exactly:
+	// hold and decrement at the sentinel location, write no allocations.
+	// This is not a tidy fallback — production has zero warehouse rows, so
+	// it is the only path that currently runs, and allocation.Plan would
+	// return ErrNoWarehouse for every checkout if it ran unconditionally.
+	warehouses, err := storeWarehousesInFillOrder(ctx, tx, storeID)
+	if err != nil {
+		return err
+	}
+	if len(warehouses) == 0 {
+		return commitStockAtSentinel(ctx, tx, holds, cartToken, lines, policies)
+	}
+```
+
+   Move the existing per-line loop body verbatim into `commitStockAtSentinel` so the legacy path is provably unchanged rather than re-implemented.
+
+3. Add `storeWarehousesInFillOrder`, which reads the store's warehouses and returns `allocation.InPriorityOrder(...)` of them. `Plan` takes an ordered slice and cannot detect an unordered one, so ordering here is mandatory.
+
+4. Add the allocation path:
+
+```go
+	avail, storage, err := loadAvailability(ctx, tx, cartToken, warehouses, variantIDsOf(lines))
+	if err != nil {
+		return err
+	}
+
+	allocLines := make([]allocation.Line, 0, len(lines))
+	for _, l := range lines {
+		allocLines = append(allocLines, allocation.Line{
+			VariantID:     l.VariantID,
+			Quantity:      l.Quantity,
+			SellsPastZero: policies[l.VariantID] == inventoryPolicyContinue,
+		})
+	}
+
+	assignments, err := allocation.Plan(warehouses, avail, allocLines)
+	var cannot allocation.CannotFillError
+	if errors.As(err, &cannot) {
+		// Same shape the shopper already gets for a sold-out cart.
+		return outOfStockError{VariantID: cannot.VariantID}
+	}
+	if err != nil {
+		return err
+	}
+```
+
+5. Place the holds, **aggregated by `(variant, storage location)`**:
+
+```go
+	// stockhold.Hold's ON CONFLICT DO UPDATE SET qty = EXCLUDED.qty REPLACES
+	// a quantity rather than adding to it, and its unique key is
+	// (cart_token, variant_id, location_id). Two assignments for the same
+	// variant and warehouse — which happens whenever two order lines carry
+	// the same variant, because stockLinesFromItems does not merge them —
+	// would leave only the SECOND quantity reserved. Aggregate first.
+	type holdKey struct{ variantID, locationID string }
+	totals := map[holdKey]int{}
+	for _, a := range assignments {
+		if policies[a.VariantID] == inventoryPolicyContinue {
+			continue // sold past zero on purpose; decremented, not held
+		}
+		loc := storage[a.VariantID][a.WarehouseID]
+		if loc == "" {
+			loc = a.WarehouseID
+		}
+		totals[holdKey{a.VariantID, loc}] += a.Quantity
+	}
+	for k, qty := range totals {
+		err := holds.Hold(ctx, tx, cartToken, k.variantID, k.locationID, qty, HoldTTL)
+		if errors.Is(err, stockhold.ErrInsufficientStock) {
+			return outOfStockError{VariantID: k.variantID}
+		}
+		if err != nil {
+			return err
+		}
+	}
+```
+
+   Handle `continue`-policy variants with the same clamped decrement the legacy path uses, at their assigned warehouse's storage location.
+
+6. Write `order_allocations`, one row per assignment, mapped to the order's items:
+
+```go
+	// order_items rows already exist: order.CreateInput.WithinTx runs after
+	// CreateInTx inserts them. Reading them back is how an allocation gets
+	// its order_item_id without threading ids through the checkout request.
+	if err := recordAllocations(ctx, tx, orderID, assignments, lines); err != nil {
+		return err
+	}
+```
+
+   `recordAllocations` reads `SELECT id, variant_id, quantity FROM order_items WHERE order_id = ? ORDER BY created_at, id`, pairs them positionally with `lines` (same order, same length — assert it and fail loudly if not), and inserts one row per assignment carrying `tenant_id`, `store_id`, `order_id`, `order_item_id`, `warehouse_id`, `quantity`.
+
+7. Finish with the existing `holds.Commit(ctx, tx, cartToken)` — unchanged.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration ./internal/handlers/storefront/... -run TestCommitStock -count=1 -p 1 -v
+```
+
+Expected: all four PASS.
+
+- [ ] **Step 5: Mutation-test the hold aggregation**
+
+Replace the `totals` aggregation with a direct `Hold` per assignment, re-run.
+
+Expected: FAIL — `TestCommitStock_TwoLinesOfOneVariantDoNotUnderHold` finds 4 units left rather than 1, because the second `Hold` replaced the first rather than adding to it. That failure IS the oversell this aggregation exists to prevent. Restore and confirm green.
+
+- [ ] **Step 6: Mutation-test the no-warehouse guard**
+
+Delete the `if len(warehouses) == 0 { … }` early return, re-run.
+
+Expected: FAIL — `TestCommitStock_StoreWithNoWarehousesBehavesExactlyAsBefore` errors with `allocation: store has no warehouses`. That is the production-breaking regression this guard exists to prevent. Restore and confirm green.
+
+- [ ] **Step 7: Full verification**
+
+```bash
+cd services/marketplace-api
+go build ./... && go vet ./... && go vet -tags=integration ./... && gofmt -l .
+go test ./... -count=1
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/handlers/storefront/... ./internal/stockhold/... ./internal/order/... ./internal/warehouse/...
+```
+
+Expected: all `ok`, durations in seconds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add services/marketplace-api/internal/handlers/storefront/checkout_stock.go \
+        services/marketplace-api/internal/handlers/storefront/checkout_ext.go \
+        services/marketplace-api/internal/handlers/storefront/checkout_allocation_integration_test.go
+git commit -m "feat(storefront): allocate an order across warehouses at placement (#177)"
+```
+
+---
+
+## Done when
+
+- `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `gofmt -l .` clean
+- `go test ./... -count=1` green
+- The storefront, stockhold, order and warehouse integration packages green against the real DSN, with durations that prove they ran
+- Three guards mutation-tested: the own-cart hold exclusion, the hold aggregation, and the no-warehouse early return
+
+## Explicitly NOT in this PR
+
+- **`cart_holds.go` stays on the sentinel.** The spec calls for provisional per-location holds at cart time, but with zero warehouses in production that path allocates nothing today, and changing it would double this PR's surface for no behaviour change. It moves in its own PR once a merchant can actually create a second warehouse (PR 5).
+- Shipment-per-warehouse, `fulfillment_status = 'partial'`, the order-detail `Shipment` field becoming a list (PR 4)
+- Warehouse CRUD and per-location stock editing (PR 5)
+- The sentinel backfill and deleting `DefaultLocationID` (PR 6) — and note this PR is what makes that backfill safe, because it reads whatever location a stock row actually carries rather than assuming one
+- Re-planning when a hold is lost to a race: the spec defers it until the race is observed

--- a/docs/superpowers/plans/2026-08-31-multi-warehouse-03-checkout.md
+++ b/docs/superpowers/plans/2026-08-31-multi-warehouse-03-checkout.md
@@ -64,15 +64,28 @@ Each was verified against the code or the live database. Do not re-derive them; 
 - Produces:
 
 ```go
-// storageLocations maps warehouseID -> the location_id the units are
-// actually stored under, per variant: storage[variantID][warehouseID].
-type storageLocations map[string]map[string]string
+// stockAt is units of a variant available at ONE physical storage location.
+type stockAt struct {
+    LocationID string
+    Units      int
+}
+
+// storageLocations records, per variant and warehouse, where the units
+// backing that warehouse's availability actually sit — possibly in more than
+// one place while sentinel and real rows coexist. Sorted by LocationID.
+type storageLocations map[string]map[string][]stockAt
 
 func loadAvailability(
     ctx context.Context, tx *gorm.DB, cartToken string,
     warehouses []allocation.Warehouse, variantIDs []string,
 ) (allocation.Availability, storageLocations, error)
 ```
+
+**Note (amended after Task 1's review):** this returns a per-location
+BREAKDOWN, not a single location. A warehouse's availability can be backed by
+units in two places during the transition — PR 5's per-location stock editing
+writes to a real warehouse id while the sentinel row still exists. An
+assignment may therefore need MORE THAN ONE hold.
 
   Task 2 calls this, passes the `Availability` to `allocation.Plan`, and uses `storageLocations` to decide which `location_id` each `Hold` targets.
 
@@ -683,11 +696,32 @@ In `services/marketplace-api/internal/handlers/storefront/checkout_stock.go`:
 		if policies[a.VariantID] == inventoryPolicyContinue {
 			continue // sold past zero on purpose; decremented, not held
 		}
-		loc := storage[a.VariantID][a.WarehouseID]
-		if loc == "" {
-			loc = a.WarehouseID
+		// A warehouse's units can sit in more than one physical location
+		// while the sentinel and real rows coexist, so draw the assigned
+		// quantity from that warehouse's locations in order until it is
+		// covered. The breakdown is sorted by LocationID, so the same
+		// inputs always produce the same holds.
+		want := a.Quantity
+		for _, at := range storage[a.VariantID][a.WarehouseID] {
+			if want == 0 {
+				break
+			}
+			take := min(want, at.Units)
+			if take <= 0 {
+				continue
+			}
+			totals[holdKey{a.VariantID, at.LocationID}] += take
+			want -= take
 		}
-		totals[holdKey{a.VariantID, loc}] += a.Quantity
+		if want > 0 {
+			// The snapshot said this warehouse had the units and the
+			// breakdown does not account for them. That is a bug in the
+			// snapshot, not a stock shortage — fail loudly rather than
+			// under-hold and oversell.
+			return fmt.Errorf(
+				"storefront: allocation for variant %s at warehouse %s is %d units short of its storage breakdown",
+				a.VariantID, a.WarehouseID, want)
+		}
 	}
 	for k, qty := range totals {
 		err := holds.Hold(ctx, tx, cartToken, k.variantID, k.locationID, qty, HoldTTL)
@@ -726,6 +760,43 @@ TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=
 ```
 
 Expected: all four PASS.
+
+- [ ] **Step 4b: Add a test for an assignment spanning two storage locations**
+
+This is the case Task 1's review added the breakdown for, and nothing in the
+tests above reaches it. In `checkout_allocation_integration_test.go`:
+
+```go
+// A warehouse whose units sit in two places — the sentinel row that predates
+// the backfill, plus a real row written by per-location stock editing. One
+// assignment against that warehouse must produce a hold in EACH location,
+// adding up to the assignment.
+func TestCommitStock_AssignmentSpanningTwoStorageLocationsHoldsInBoth(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 3, now()), (?, ?, 4, now())`,
+		variantID, product.DefaultLocationID, variantID, whA).Error)
+
+	lines := []stockLine{{VariantID: variantID, Quantity: 5}}
+	orderID, _ := seedOrderWithItems(t, db, storeID, lines)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	}))
+
+	// 5 units drawn from a 3 + 4 breakdown: the sentinel is exhausted and the
+	// remainder comes from the real row.
+	require.Equal(t, 0, stockAt(t, db, variantID, product.DefaultLocationID))
+	require.Equal(t, 2, stockAt(t, db, variantID, whA))
+}
+```
+
+Run it, expect PASS.
 
 - [ ] **Step 5: Mutation-test the hold aggregation**
 

--- a/services/marketplace-api/internal/handlers/storefront/checkout.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout.go
@@ -222,8 +222,8 @@ func (h *CheckoutHandler) Checkout(c *gin.Context) {
 	if h.stockHolds != nil {
 		lines := stockLinesFromItems(req.Items)
 		cartToken := cartTokenForCheckout(c)
-		in.WithinTx = func(tx *gorm.DB, _ *order.Order) error {
-			return commitStock(c.Request.Context(), tx, h.stockHolds, cartToken, lines)
+		in.WithinTx = func(tx *gorm.DB, o *order.Order) error {
+			return commitStock(c.Request.Context(), tx, h.stockHolds, cartToken, o.ID.String(), storeID.String(), lines)
 		}
 	}
 

--- a/services/marketplace-api/internal/handlers/storefront/checkout_allocation_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_allocation_integration_test.go
@@ -10,6 +10,7 @@ package storefront
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -21,8 +22,14 @@ import (
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
-// seedOrderWithItems creates an order and one order_item per line and
-// returns (orderID, []orderItemID).
+// seedOrderWithItems creates an order and its order_items in ONE multi-row
+// INSERT, mirroring internal/order/repository.go's batch tx.Create(&items):
+// production inserts all of an order's items in a single statement, so they
+// share one created_at and the only tie-break Postgres has is the random
+// gen_random_uuid() id. A test that inserted items with separate statements
+// (and therefore strictly increasing created_at) would stay green against a
+// production-broken assumption that order_items come back in line order.
+// Returns (orderID, []orderItemID) in the SAME order as lines.
 func seedOrderWithItems(t *testing.T, db *gorm.DB, storeID string, lines []stockLine) (string, []string) {
 	t.Helper()
 	var tenantID string
@@ -36,15 +43,18 @@ func seedOrderWithItems(t *testing.T, db *gorm.DB, storeID string, lines []stock
 		orderID, tenantID, storeID, "AL-"+uuid.NewString()[:8], uuid.NewString()).Error)
 
 	ids := make([]string, 0, len(lines))
+	placeholders := make([]string, 0, len(lines))
+	args := make([]interface{}, 0, len(lines)*9)
 	for _, l := range lines {
 		itemID := uuid.NewString()
-		require.NoError(t, db.Exec(
-			`INSERT INTO order_items (id, order_id, variant_id, title_snapshot, sku_snapshot,
-			                          unit_price, quantity, line_total, currency_code)
-			 VALUES (?, ?, ?, 'Item', 'SKU', 10.00, ?, 10.00, 'INR')`,
-			itemID, orderID, l.VariantID, l.Quantity).Error)
 		ids = append(ids, itemID)
+		placeholders = append(placeholders, "(?, ?, ?, 'Item', 'SKU', 10.00, ?, 10.00, 'INR')")
+		args = append(args, itemID, orderID, l.VariantID, l.Quantity)
 	}
+	require.NoError(t, db.Exec(
+		`INSERT INTO order_items (id, order_id, variant_id, title_snapshot, sku_snapshot,
+		                          unit_price, quantity, line_total, currency_code)
+		 VALUES `+strings.Join(placeholders, ", "), args...).Error)
 	return orderID, ids
 }
 
@@ -208,4 +218,182 @@ func TestCommitStock_AssignmentSpanningTwoStorageLocationsHoldsInBoth(t *testing
 	// remainder comes from the real row.
 	require.Equal(t, 0, stockUnitsAt(t, db, variantID, product.DefaultLocationID))
 	require.Equal(t, 2, stockUnitsAt(t, db, variantID, whA))
+}
+
+// seedAvailVariant creates one more product+variant for an existing store,
+// for tests that need two distinct variants.
+func seedAvailVariant(t *testing.T, db *gorm.DB, storeID string) string {
+	t.Helper()
+	var tenantID string
+	require.NoError(t, db.Raw(`SELECT tenant_id FROM stores WHERE id = ?`, storeID).Row().Scan(&tenantID))
+
+	productID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO products (id, tenant_id, store_id, title, handle, status, vendor_id, published_at)
+		 VALUES (?, ?, ?, 'Avail Product 2', ?, 'active', ?, now())`,
+		productID, tenantID, storeID, "avail-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	variantID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO product_variants (id, product_id, store_id, sku, price, currency_code)
+		 VALUES (?, ?, ?, ?, 10.00, 'INR')`,
+		variantID, productID, storeID, "SKU-"+uuid.NewString()[:8]).Error)
+	return variantID
+}
+
+// order_items are inserted in ONE batch statement (seedOrderWithItems
+// mirrors production's tx.Create(&items)), so all rows share one created_at
+// and Postgres's tie-break — a random UUID — is the only thing left to sort
+// by. recordAllocations must not rely on that order: it must find each
+// line's item by (variant_id, quantity), and its per-warehouse attribution
+// must not confuse two DIFFERENT variants split across the SAME two
+// warehouses.
+func TestCommitStock_RecordsAllocationsForTwoDifferentVariantsAcrossWarehouses(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantX := seedAvailStore(t, db)
+	variantY := seedAvailVariant(t, db, storeID)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	whB := seedWarehouseRow(t, db, storeID, "B")
+	require.NoError(t, db.Exec(`UPDATE warehouses SET priority = 0 WHERE id = ?`, whA).Error)
+	require.NoError(t, db.Exec(`UPDATE warehouses SET priority = 1 WHERE id = ?`, whB).Error)
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at) VALUES
+		   (?, ?, 2, now()), (?, ?, 1, now()),
+		   (?, ?, 1, now()), (?, ?, 2, now())`,
+		variantX, whA, variantX, whB,
+		variantY, whA, variantY, whB).Error)
+
+	// X: 2 at A, 1 at B — needs both. Y: 1 at A, 2 at B — needs both too,
+	// so both variants' assignments interleave across the same warehouses.
+	lines := []stockLine{{VariantID: variantX, Quantity: 3}, {VariantID: variantY, Quantity: 3}}
+	orderID, itemIDs := seedOrderWithItems(t, db, storeID, lines)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	}))
+
+	assertAllocs := func(itemID string, want map[string]int) {
+		t.Helper()
+		var got []struct {
+			WarehouseID string
+			Quantity    int
+		}
+		require.NoError(t, db.Raw(
+			`SELECT warehouse_id, quantity FROM order_allocations WHERE order_item_id = ?`, itemID).
+			Scan(&got).Error)
+		have := map[string]int{}
+		for _, g := range got {
+			have[g.WarehouseID] = g.Quantity
+		}
+		require.Equal(t, want, have)
+	}
+
+	// itemIDs[0] is line0 (variantX): 2 from A, 1 from B.
+	assertAllocs(itemIDs[0], map[string]int{whA: 2, whB: 1})
+	// itemIDs[1] is line1 (variantY): 1 from A, 2 from B.
+	assertAllocs(itemIDs[1], map[string]int{whA: 1, whB: 2})
+
+	require.Equal(t, 0, stockUnitsAt(t, db, variantX, whA))
+	require.Equal(t, 0, stockUnitsAt(t, db, variantX, whB))
+	require.Equal(t, 0, stockUnitsAt(t, db, variantY, whA))
+	require.Equal(t, 0, stockUnitsAt(t, db, variantY, whB))
+}
+
+// Two lines of the SAME variant but DIFFERENT quantities. Their order_items
+// rows are indistinguishable by variant alone, but the (variant, quantity)
+// pair is unique to each line here, so this proves recordAllocations pairs
+// by that key rather than by whatever order order_items happens to load in.
+func TestCommitStock_TwoLinesOfSameVariantDifferentQuantitiesAttributeCorrectly(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 10, now())`, variantID, whA).Error)
+
+	lines := []stockLine{{VariantID: variantID, Quantity: 2}, {VariantID: variantID, Quantity: 5}}
+	orderID, itemIDs := seedOrderWithItems(t, db, storeID, lines)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	}))
+
+	for i, itemID := range itemIDs {
+		var q int
+		require.NoError(t, db.Raw(
+			`SELECT quantity FROM order_allocations WHERE order_item_id = ?`, itemID).Row().Scan(&q))
+		require.Equal(t, lines[i].Quantity, q,
+			"each item's allocation must match ITS OWN line's quantity, not the other line's")
+	}
+}
+
+// A continue-policy (sell-past-zero) variant with NO variant_stock row at
+// all — the common case, since it never needed one to sell — must succeed
+// on the allocation path exactly as the legacy sentinel path does: its
+// UPDATE matches zero rows and that is fine.
+func TestCommitStock_ContinuePolicyWithNoStorageSucceedsOnAllocationPath(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	require.NoError(t, db.Exec(
+		`UPDATE product_variants SET inventory_policy = 'continue' WHERE id = ?`, variantID).Error)
+	// Deliberately no variant_stock row for variantID anywhere.
+
+	lines := []stockLine{{VariantID: variantID, Quantity: 3}}
+	orderID, itemIDs := seedOrderWithItems(t, db, storeID, lines)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	}))
+
+	require.Equal(t, -1, stockUnitsAt(t, db, variantID, whA),
+		"no variant_stock row existed and none should have been created")
+
+	var got struct {
+		WarehouseID string
+		Quantity    int
+	}
+	require.NoError(t, db.Raw(
+		`SELECT warehouse_id, quantity FROM order_allocations WHERE order_item_id = ?`, itemIDs[0]).
+		Row().Scan(&got.WarehouseID, &got.Quantity))
+	require.Equal(t, whA, got.WarehouseID)
+	require.Equal(t, 3, got.Quantity)
+}
+
+// A continue-policy variant whose warehouse's units span TWO storage
+// locations (the sentinel row plus a real one). Both must be decremented,
+// not just the first one the breakdown happens to list.
+func TestCommitStock_ContinuePolicyDecrementsAcrossMultipleStorageLocations(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	require.NoError(t, db.Exec(
+		`UPDATE product_variants SET inventory_policy = 'continue' WHERE id = ?`, variantID).Error)
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 1, now()), (?, ?, 1, now())`,
+		variantID, product.DefaultLocationID, variantID, whA).Error)
+
+	// 2 units requested against two locations holding 1 each: whichever
+	// sorts first can only cover 1, so the second MUST be touched too, or
+	// this fails regardless of storage order.
+	lines := []stockLine{{VariantID: variantID, Quantity: 2}}
+	orderID, _ := seedOrderWithItems(t, db, storeID, lines)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	}))
+
+	require.Equal(t, 0, stockUnitsAt(t, db, variantID, product.DefaultLocationID),
+		"the sentinel location must be decremented, not left untouched")
+	require.Equal(t, 0, stockUnitsAt(t, db, variantID, whA),
+		"the real warehouse location must be decremented too")
 }

--- a/services/marketplace-api/internal/handlers/storefront/checkout_allocation_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_allocation_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -396,4 +397,185 @@ func TestCommitStock_ContinuePolicyDecrementsAcrossMultipleStorageLocations(t *t
 		"the sentinel location must be decremented, not left untouched")
 	require.Equal(t, 0, stockUnitsAt(t, db, variantID, whA),
 		"the real warehouse location must be decremented too")
+}
+
+// FIX 1 (final review): the storage draw must track units already consumed
+// by EARLIER assignments in this call, not restart from the full breakdown
+// snapshot for every assignment. Two lines of the same variant, both filled
+// at one warehouse whose units span the sentinel row and a real row —
+// breakdown [sentinel:3, A:4], lines of 2 and 3 — must total 3 at the
+// sentinel and 2 at A, not 5 at a location that only holds 3.
+func TestCommitStock_TwoLinesFilledAtSameWarehouseDoNotDoubleCountTheBreakdown(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 3, now()), (?, ?, 4, now())`,
+		variantID, product.DefaultLocationID, variantID, whA).Error)
+
+	lines := []stockLine{{VariantID: variantID, Quantity: 2}, {VariantID: variantID, Quantity: 3}}
+	orderID, itemIDs := seedOrderWithItems(t, db, storeID, lines)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	}), "a cart the store can fully fill must not see out_of_stock")
+
+	require.Equal(t, 0, stockUnitsAt(t, db, variantID, product.DefaultLocationID),
+		"3 units at the sentinel, fully drawn across both lines")
+	require.Equal(t, 2, stockUnitsAt(t, db, variantID, whA),
+		"4 units at A, only the 2 units the sentinel could not cover")
+
+	var total int64
+	require.NoError(t, db.Raw(
+		`SELECT COALESCE(SUM(quantity), 0) FROM order_allocations WHERE order_id = ?`, orderID).
+		Scan(&total).Error)
+	require.Equal(t, int64(5), total, "5 units requested, 5 units allocated")
+	_ = itemIDs
+}
+
+// FIX 2 (final review): a cart-time hold that no longer matches the final
+// placement plan must be released before Commit runs, or Commit decrements
+// it a second time alongside the plan's own hold — or, when the stale
+// location no longer has the units, the variant_stock non-negative CHECK
+// fires and the checkout 500s instead of succeeding.
+//
+// The stale hold is manufactured the way it happens in production: a
+// cart-add hold succeeds against the sentinel while it still has stock, and
+// by checkout time an admin has corrected that count to zero — the hold
+// still exists, but the sentinel no longer has anything to give, so the
+// warehouse allocation plan must fill entirely from the real row instead.
+func TestCommitStock_StaleCartHoldAtAnUnusedLocationIsReleasedNotDoubleCommitted(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 2, now()), (?, ?, 5, now())`,
+		variantID, product.DefaultLocationID, variantID, whA).Error)
+
+	cart := uuid.NewString()
+	holds := stockhold.NewRepository()
+
+	// The cart-add hold, placed while the sentinel still had stock.
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return holds.Hold(context.Background(), tx, cart, variantID, product.DefaultLocationID, 2, time.Hour)
+	}))
+
+	// An admin corrects the count between cart-add and checkout. The hold
+	// row is untouched — it still says 2 units held at the sentinel.
+	require.NoError(t, db.Exec(
+		`UPDATE variant_stock SET quantity = 0 WHERE variant_id = ? AND location_id = ?`,
+		variantID, product.DefaultLocationID).Error)
+
+	lines := []stockLine{{VariantID: variantID, Quantity: 2}}
+	orderID, itemIDs := seedOrderWithItems(t, db, storeID, lines)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, holds, cart, orderID, storeID, lines)
+	}), "the stale sentinel hold must be released, not decremented a second time")
+
+	require.Equal(t, 0, stockUnitsAt(t, db, variantID, product.DefaultLocationID),
+		"the sentinel had nothing left and must stay at zero, not go negative")
+	require.Equal(t, 3, stockUnitsAt(t, db, variantID, whA),
+		"the whole order must be filled from A, the only location with real stock")
+
+	var state string
+	require.NoError(t, db.Raw(
+		`SELECT state FROM stock_holds WHERE cart_token = ? AND location_id = ?`,
+		cart, product.DefaultLocationID).Row().Scan(&state))
+	require.Equal(t, "released", state, "the stale hold must be released, not left held or committed")
+
+	var allocWarehouse string
+	require.NoError(t, db.Raw(
+		`SELECT warehouse_id FROM order_allocations WHERE order_item_id = ?`, itemIDs[0]).
+		Row().Scan(&allocWarehouse))
+	require.Equal(t, whA, allocWarehouse)
+}
+
+// FIX 3 (final review): a checkout item with a NULL variant_id (a custom or
+// unstocked line) must not make recordAllocations 500 the whole checkout.
+// Only order_items that correspond to a stock line are considered; the rest
+// are ignored, matching the legacy path's silent skip.
+func TestCommitStock_ItemWithNilVariantIDIsIgnoredNotAFailure(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 5, now())`, variantID, whA).Error)
+
+	var tenantID string
+	require.NoError(t, db.Raw(`SELECT tenant_id FROM stores WHERE id = ?`, storeID).Row().Scan(&tenantID))
+	orderID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO orders (id, tenant_id, store_id, order_number, idempotency_key,
+		                     customer_email, currency_code, subtotal, grand_total)
+		 VALUES (?, ?, ?, ?, ?, 'buyer@example.com', 'INR', 10.00, 10.00)`,
+		orderID, tenantID, storeID, "AL-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	stockedItemID := uuid.NewString()
+	unstockedItemID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO order_items (id, order_id, variant_id, title_snapshot, sku_snapshot,
+		                          unit_price, quantity, line_total, currency_code)
+		 VALUES (?, ?, ?, 'Stocked', 'SKU-A', 10.00, 2, 20.00, 'INR'),
+		        (?, ?, NULL, 'Custom', 'SKU-B', 5.00, 1, 5.00, 'INR')`,
+		stockedItemID, orderID, variantID, unstockedItemID, orderID).Error)
+
+	// Mirrors stockLinesFromItems: the nil-variant item produced no line.
+	lines := []stockLine{{VariantID: variantID, Quantity: 2}}
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	}), "a variantless item must not turn a paid checkout into a 500")
+
+	require.Equal(t, 3, stockUnitsAt(t, db, variantID, whA))
+
+	var allocCount int64
+	require.NoError(t, db.Raw(
+		`SELECT count(*) FROM order_allocations WHERE order_id = ?`, orderID).Scan(&allocCount).Error)
+	require.Equal(t, int64(1), allocCount,
+		"exactly one allocation row for the stocked line — the variantless item is ignored, not attributed")
+
+	var allocItemID string
+	require.NoError(t, db.Raw(
+		`SELECT order_item_id FROM order_allocations WHERE order_id = ?`, orderID).Row().Scan(&allocItemID))
+	require.Equal(t, stockedItemID, allocItemID)
+}
+
+// FIX 5 (final review): the legacy path passed the client's variant_id string
+// straight into SQL, where Postgres casts to uuid case-insensitively. The
+// allocation path does Go map lookups against ids read back from the
+// database in canonical lowercase, so an uppercase client-supplied id must
+// be normalised at the boundary or it reads as zero availability.
+func TestCommitStock_UppercaseVariantIDStillMatchesAvailability(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 5, now())`, variantID, whA).Error)
+
+	upper := strings.ToUpper(variantID)
+	qty := 2
+	lines := stockLinesFromItems([]CheckoutItemRequest{{VariantID: &upper, Quantity: qty}})
+	require.Len(t, lines, 1)
+	require.Equal(t, strings.ToLower(upper), lines[0].VariantID,
+		"lines must be normalised to lowercase so map lookups against DB-canonical ids succeed")
+
+	orderID, _ := seedOrderWithItems(t, db, storeID, lines)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	}), "an uppercase client-supplied variant id must not produce a false out_of_stock")
+
+	require.Equal(t, 3, stockUnitsAt(t, db, variantID, whA))
 }

--- a/services/marketplace-api/internal/handlers/storefront/checkout_allocation_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_allocation_integration_test.go
@@ -1,0 +1,211 @@
+//go:build integration
+
+// Package storefront — coverage for allocation at order placement (#177 PR 3).
+//
+// The load-bearing case is the FIRST one: a store with no warehouses must
+// behave exactly as it did before this PR. That is not a tidy fallback —
+// production has zero warehouse rows, so it is the only path that currently
+// runs, and a regression there breaks every checkout.
+package storefront
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/product"
+	"github.com/mark8ly/marketplace-api/internal/stockhold"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedOrderWithItems creates an order and one order_item per line and
+// returns (orderID, []orderItemID).
+func seedOrderWithItems(t *testing.T, db *gorm.DB, storeID string, lines []stockLine) (string, []string) {
+	t.Helper()
+	var tenantID string
+	require.NoError(t, db.Raw(`SELECT tenant_id FROM stores WHERE id = ?`, storeID).Row().Scan(&tenantID))
+
+	orderID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO orders (id, tenant_id, store_id, order_number, idempotency_key,
+		                     customer_email, currency_code, subtotal, grand_total)
+		 VALUES (?, ?, ?, ?, ?, 'buyer@example.com', 'INR', 10.00, 10.00)`,
+		orderID, tenantID, storeID, "AL-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	ids := make([]string, 0, len(lines))
+	for _, l := range lines {
+		itemID := uuid.NewString()
+		require.NoError(t, db.Exec(
+			`INSERT INTO order_items (id, order_id, variant_id, title_snapshot, sku_snapshot,
+			                          unit_price, quantity, line_total, currency_code)
+			 VALUES (?, ?, ?, 'Item', 'SKU', 10.00, ?, 10.00, 'INR')`,
+			itemID, orderID, l.VariantID, l.Quantity).Error)
+		ids = append(ids, itemID)
+	}
+	return orderID, ids
+}
+
+// stockUnitsAt reads variant_stock.quantity for one (variant, location) pair.
+//
+// Named to avoid colliding with the stockAt struct type declared in
+// checkout_availability.go — the brief's helper of the same name does not
+// compile in this package, since a type and a function cannot share an
+// identifier.
+func stockUnitsAt(t *testing.T, db *gorm.DB, variantID, locationID string) int {
+	t.Helper()
+	var q int
+	require.NoError(t, db.Raw(
+		`SELECT COALESCE((SELECT quantity FROM variant_stock WHERE variant_id = ? AND location_id = ?), -1)`,
+		variantID, locationID).Row().Scan(&q))
+	return q
+}
+
+// THE load-bearing test. Production has zero warehouses; if this regresses,
+// every checkout fails.
+func TestCommitStock_StoreWithNoWarehousesBehavesExactlyAsBefore(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 5, now())`, variantID, product.DefaultLocationID).Error)
+
+	lines := []stockLine{{VariantID: variantID, Quantity: 2}}
+	orderID, _ := seedOrderWithItems(t, db, storeID, lines)
+	cart := uuid.NewString()
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), cart, orderID, storeID, lines)
+	}))
+
+	require.Equal(t, 3, stockUnitsAt(t, db, variantID, product.DefaultLocationID),
+		"the sentinel row must still be the one decremented")
+
+	var allocations int64
+	require.NoError(t, db.Raw(
+		`SELECT count(*) FROM order_allocations WHERE order_id = ?`, orderID).Scan(&allocations).Error)
+	require.Zero(t, allocations,
+		"a store with no warehouses has nothing to allocate against — order_allocations.warehouse_id is NOT NULL")
+}
+
+func TestCommitStock_AllocatesAcrossWarehousesAndRecordsThem(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	whB := seedWarehouseRow(t, db, storeID, "B")
+	require.NoError(t, db.Exec(`UPDATE warehouses SET priority = 0 WHERE id = ?`, whA).Error)
+	require.NoError(t, db.Exec(`UPDATE warehouses SET priority = 1 WHERE id = ?`, whB).Error)
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 3, now()), (?, ?, 4, now())`,
+		variantID, whA, variantID, whB).Error)
+
+	lines := []stockLine{{VariantID: variantID, Quantity: 5}}
+	orderID, itemIDs := seedOrderWithItems(t, db, storeID, lines)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	}))
+
+	var got []struct {
+		WarehouseID string
+		Quantity    int
+	}
+	require.NoError(t, db.Raw(
+		`SELECT warehouse_id, quantity FROM order_allocations
+		  WHERE order_item_id = ? ORDER BY quantity DESC`, itemIDs[0]).Scan(&got).Error)
+	require.Len(t, got, 2, "5 units from a 3+4 split must record two allocations")
+	require.Equal(t, whA, got[0].WarehouseID)
+	require.Equal(t, 3, got[0].Quantity)
+	require.Equal(t, whB, got[1].WarehouseID)
+	require.Equal(t, 2, got[1].Quantity)
+
+	require.Equal(t, 0, stockUnitsAt(t, db, variantID, whA), "the higher-priority warehouse is drained first")
+	require.Equal(t, 2, stockUnitsAt(t, db, variantID, whB))
+}
+
+// Two order lines carrying the SAME variant. stockLinesFromItems does not
+// merge by variant, and stock_holds' ON CONFLICT REPLACES a quantity rather
+// than adding to it — so holding per assignment without aggregating would
+// reserve only the second line's units and oversell the first.
+func TestCommitStock_TwoLinesOfOneVariantDoNotUnderHold(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 6, now())`, variantID, whA).Error)
+
+	lines := []stockLine{{VariantID: variantID, Quantity: 2}, {VariantID: variantID, Quantity: 3}}
+	orderID, itemIDs := seedOrderWithItems(t, db, storeID, lines)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	}))
+
+	require.Equal(t, 1, stockUnitsAt(t, db, variantID, whA),
+		"6 units less 2 and 3 is 1 — under-holding would have left 4 or 3 here")
+
+	for i, itemID := range itemIDs {
+		var q int
+		require.NoError(t, db.Raw(
+			`SELECT quantity FROM order_allocations WHERE order_item_id = ?`, itemID).Row().Scan(&q))
+		require.Equal(t, lines[i].Quantity, q, "each line records its own allocation")
+	}
+}
+
+func TestCommitStock_UnfillableOrderFailsAndTakesNoStock(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 2, now())`, variantID, whA).Error)
+
+	lines := []stockLine{{VariantID: variantID, Quantity: 9}}
+	orderID, _ := seedOrderWithItems(t, db, storeID, lines)
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	})
+	require.Error(t, err, "an order no combination of warehouses can fill must fail the transaction")
+
+	require.Equal(t, 2, stockUnitsAt(t, db, variantID, whA), "a failed checkout must move no stock")
+}
+
+// A warehouse whose units sit in two places — the sentinel row that predates
+// the backfill, plus a real row written by per-location stock editing. One
+// assignment against that warehouse must produce a hold in EACH location,
+// adding up to the assignment.
+func TestCommitStock_AssignmentSpanningTwoStorageLocationsHoldsInBoth(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 3, now()), (?, ?, 4, now())`,
+		variantID, product.DefaultLocationID, variantID, whA).Error)
+
+	lines := []stockLine{{VariantID: variantID, Quantity: 5}}
+	orderID, _ := seedOrderWithItems(t, db, storeID, lines)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	}))
+
+	// 5 units drawn from a 3 + 4 breakdown: the sentinel is exhausted and the
+	// remainder comes from the real row.
+	require.Equal(t, 0, stockUnitsAt(t, db, variantID, product.DefaultLocationID))
+	require.Equal(t, 2, stockUnitsAt(t, db, variantID, whA))
+}

--- a/services/marketplace-api/internal/handlers/storefront/checkout_availability.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_availability.go
@@ -1,0 +1,107 @@
+package storefront
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/allocation"
+	"github.com/mark8ly/marketplace-api/internal/product"
+)
+
+// storageLocations records, per variant and warehouse, the location_id the
+// units are actually stored under.
+//
+// It exists because of the expand phase: until PR 6 backfills
+// variant_stock.location_id, units sit at product.DefaultLocationID while
+// allocation reasons about real warehouse ids. A hold must be placed against
+// the location the row actually has, or it locks nothing. After the backfill
+// the two values coincide and this map becomes an identity.
+type storageLocations map[string]map[string]string
+
+// loadAvailability builds the snapshot allocation.Plan reasons over.
+//
+// Availability is variant_stock.quantity minus OTHER carts' live holds — the
+// same arithmetic stockhold.Available uses, and excluding the calling cart's
+// own holds for the same reason: a cart must not be told its own reservation
+// is competition.
+//
+// This is a READ. It takes no locks, and it is not what makes the decision
+// safe: stockhold.Hold re-checks under SELECT ... FOR UPDATE, and that is the
+// check that counts. A snapshot that is stale by the time it is used simply
+// produces a plan whose holds fail, which is the same outcome a
+// single-warehouse shopper gets today.
+func loadAvailability(
+	ctx context.Context,
+	tx *gorm.DB,
+	cartToken string,
+	warehouses []allocation.Warehouse,
+	variantIDs []string,
+) (allocation.Availability, storageLocations, error) {
+	avail := allocation.Availability{}
+	storage := storageLocations{}
+	if len(warehouses) == 0 || len(variantIDs) == 0 {
+		return avail, storage, nil
+	}
+
+	var rows []struct {
+		VariantID  string
+		LocationID string
+		Available  int
+	}
+	err := tx.WithContext(ctx).Raw(
+		`SELECT vs.variant_id,
+		        vs.location_id,
+		        vs.quantity - COALESCE((
+		            SELECT SUM(sh.qty) FROM stock_holds sh
+		             WHERE sh.variant_id = vs.variant_id
+		               AND sh.location_id = vs.location_id
+		               AND sh.state = 'held'
+		               AND sh.expires_at > now()
+		               AND sh.cart_token <> ?), 0) AS available
+		   FROM variant_stock vs
+		  WHERE vs.variant_id IN ?`, cartToken, variantIDs).Scan(&rows).Error
+	if err != nil {
+		return nil, nil, fmt.Errorf("storefront: load availability: %w", err)
+	}
+
+	// Which warehouse a stock row belongs to. Sentinel rows have no real
+	// warehouse of their own, so they answer for the store's FIRST warehouse
+	// in fill order — the one a single-warehouse store ships everything from
+	// anyway. Real rows answer for themselves.
+	byWarehouse := make(map[string]string, len(warehouses))
+	for _, w := range warehouses {
+		byWarehouse[w.ID] = w.ID
+	}
+
+	for _, r := range rows {
+		warehouseID := r.LocationID
+		if r.LocationID == product.DefaultLocationID {
+			warehouseID = warehouses[0].ID
+		} else if _, known := byWarehouse[r.LocationID]; !known {
+			// Stock at a location that is not one of this store's warehouses
+			// — another store's row cannot appear here (variantIDs are this
+			// order's), so this is a warehouse deleted out from under its
+			// stock. Skip it rather than allocate from somewhere that no
+			// longer exists.
+			continue
+		}
+
+		if r.Available < 0 {
+			// Holds can exceed stock if a merchant lowered the count while
+			// reservations were live. Allocation clamps too, but reporting a
+			// negative here would be nonsense on the way in.
+			r.Available = 0
+		}
+
+		if avail[r.VariantID] == nil {
+			avail[r.VariantID] = map[string]int{}
+			storage[r.VariantID] = map[string]string{}
+		}
+		avail[r.VariantID][warehouseID] += r.Available
+		storage[r.VariantID][warehouseID] = r.LocationID
+	}
+
+	return avail, storage, nil
+}

--- a/services/marketplace-api/internal/handlers/storefront/checkout_availability.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_availability.go
@@ -3,6 +3,7 @@ package storefront
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"gorm.io/gorm"
 
@@ -10,15 +11,26 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/product"
 )
 
-// storageLocations records, per variant and warehouse, the location_id the
-// units are actually stored under.
+// stockAt is units of a variant available at one physical storage location.
+type stockAt struct {
+	LocationID string
+	Units      int
+}
+
+// storageLocations records, per variant and warehouse, WHERE the units
+// backing that warehouse's availability actually sit — possibly in more
+// than one place while the sentinel and real rows coexist.
 //
 // It exists because of the expand phase: until PR 6 backfills
 // variant_stock.location_id, units sit at product.DefaultLocationID while
 // allocation reasons about real warehouse ids. A hold must be placed against
-// the location the row actually has, or it locks nothing. After the backfill
-// the two values coincide and this map becomes an identity.
-type storageLocations map[string]map[string]string
+// the location(s) the rows actually have, or it locks nothing. A single
+// warehouse can be backed by MORE than one storage location even before the
+// backfill completes: PR 5 adds per-location stock editing, which can write
+// a real warehouse-id row while the sentinel row for that same variant still
+// exists. After the backfill every warehouse has exactly one contributing
+// location and this collapses to the obvious case.
+type storageLocations map[string]map[string][]stockAt
 
 // loadAvailability builds the snapshot allocation.Plan reasons over.
 //
@@ -97,10 +109,28 @@ func loadAvailability(
 
 		if avail[r.VariantID] == nil {
 			avail[r.VariantID] = map[string]int{}
-			storage[r.VariantID] = map[string]string{}
+			storage[r.VariantID] = map[string][]stockAt{}
 		}
 		avail[r.VariantID][warehouseID] += r.Available
-		storage[r.VariantID][warehouseID] = r.LocationID
+		// Append rather than overwrite: the sentinel row and a real
+		// warehouse-id row can both back the same warehouse (PR 5 writes
+		// real rows before PR 6 backfills the sentinel away), and a hold
+		// must be able to target every location the units actually sit at.
+		storage[r.VariantID][warehouseID] = append(
+			storage[r.VariantID][warehouseID],
+			stockAt{LocationID: r.LocationID, Units: r.Available},
+		)
+	}
+
+	// Deterministic order: two runs over the same data must produce the same
+	// plan, and map iteration order is not stable.
+	for _, byWarehouse := range storage {
+		for warehouseID, entries := range byWarehouse {
+			sort.Slice(entries, func(i, j int) bool {
+				return entries[i].LocationID < entries[j].LocationID
+			})
+			byWarehouse[warehouseID] = entries
+		}
 	}
 
 	return avail, storage, nil

--- a/services/marketplace-api/internal/handlers/storefront/checkout_availability_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_availability_integration_test.go
@@ -82,7 +82,7 @@ func TestLoadAvailability_SentinelStockIsReportedAgainstTheFirstWarehouse(t *tes
 
 	require.Equal(t, 7, avail.At(variantID, whID),
 		"sentinel-stored units must be visible against the store's warehouse before the backfill")
-	require.Equal(t, product.DefaultLocationID, storage[variantID][whID],
+	require.Equal(t, []stockAt{{LocationID: product.DefaultLocationID, Units: 7}}, storage[variantID][whID],
 		"a hold must target the location the units are actually stored at")
 }
 
@@ -103,8 +103,9 @@ func TestLoadAvailability_RealWarehouseStockIsReportedAgainstItself(t *testing.T
 
 	require.Equal(t, 3, avail.At(variantID, whA))
 	require.Equal(t, 4, avail.At(variantID, whB))
-	require.Equal(t, whA, storage[variantID][whA], "post-backfill the storage location IS the warehouse")
-	require.Equal(t, whB, storage[variantID][whB])
+	require.Equal(t, []stockAt{{LocationID: whA, Units: 3}}, storage[variantID][whA],
+		"post-backfill the storage location IS the warehouse")
+	require.Equal(t, []stockAt{{LocationID: whB, Units: 4}}, storage[variantID][whB])
 }
 
 // Matching stockhold.Hold and stockhold.Available: a cart must not see its
@@ -160,6 +161,56 @@ func TestLoadAvailability_VariantWithNoStockRowsIsAbsent(t *testing.T) {
 	db := testdb.NewTx(t)
 	storeID, variantID := seedAvailStore(t, db)
 	whID := seedWarehouseRow(t, db, storeID, "Main")
+
+	avail, storage, err := loadAvailability(context.Background(), db, uuid.NewString(),
+		[]allocation.Warehouse{{ID: whID}}, []string{variantID})
+	require.NoError(t, err)
+
+	require.Equal(t, 0, avail.At(variantID, whID))
+	require.Empty(t, storage[variantID])
+}
+
+// A single warehouse can be backed by MORE than one storage location before
+// PR 6's backfill completes: PR 5 adds per-location stock editing, which can
+// write a real warehouse-id row while the sentinel row for the same variant
+// still exists. Availability must sum across both, and the storage
+// breakdown must name both locations — collapsing to one would under-lock a
+// hold.
+func TestLoadAvailability_MixedSentinelAndRealStockForSameWarehouseIsSummedAndBothLocationsRecorded(t *testing.T) {
+	db := testdb.NewTx(t)
+	storeID, variantID := seedAvailStore(t, db)
+	whID := seedWarehouseRow(t, db, storeID, "Main")
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 3, now()), (?, ?, 4, now())`,
+		variantID, product.DefaultLocationID, variantID, whID).Error)
+
+	avail, storage, err := loadAvailability(context.Background(), db, uuid.NewString(),
+		[]allocation.Warehouse{{ID: whID}}, []string{variantID})
+	require.NoError(t, err)
+
+	require.Equal(t, 7, avail.At(variantID, whID),
+		"3 sentinel-stored plus 4 stored directly at the warehouse")
+	require.Equal(t, []stockAt{
+		{LocationID: product.DefaultLocationID, Units: 3},
+		{LocationID: whID, Units: 4},
+	}, storage[variantID][whID],
+		"a hold must be able to target both locations the units actually sit at")
+}
+
+// Stock at a location that is neither the sentinel nor one of the store's
+// warehouses (a warehouse deleted out from under its stock) must contribute
+// nothing — not error, not appear in the total.
+func TestLoadAvailability_StockAtUnknownLocationContributesNothing(t *testing.T) {
+	db := testdb.NewTx(t)
+	storeID, variantID := seedAvailStore(t, db)
+	whID := seedWarehouseRow(t, db, storeID, "Main")
+	orphanLocationID := uuid.NewString()
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 9, now())`, variantID, orphanLocationID).Error)
 
 	avail, storage, err := loadAvailability(context.Background(), db, uuid.NewString(),
 		[]allocation.Warehouse{{ID: whID}}, []string{variantID})

--- a/services/marketplace-api/internal/handlers/storefront/checkout_availability_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_availability_integration_test.go
@@ -1,0 +1,170 @@
+//go:build integration
+
+// Package storefront — coverage for the multi-warehouse availability
+// snapshot (#177 PR 3).
+//
+// The snapshot is what allocation reasons over. Two things about it are
+// easy to get wrong and expensive to get wrong:
+//
+//   - It must EXCLUDE the calling cart's own live holds, matching
+//     stockhold.Hold and stockhold.Available. A cart asking what it can have
+//     must not be told its own reservation is competition.
+//   - Until PR 6's backfill, units are stored at the sentinel location, not
+//     at any warehouse id. The snapshot therefore reports availability
+//     against a WAREHOUSE while remembering the STORAGE location the units
+//     actually sit at, because that is where a hold has to be placed.
+package storefront
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/allocation"
+	"github.com/mark8ly/marketplace-api/internal/product"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedAvailStore creates a store, a product and one variant, and returns
+// (storeID, variantID).
+func seedAvailStore(t *testing.T, db *gorm.DB) (string, string) {
+	t.Helper()
+	tenantID, storeID := uuid.NewString(), uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO stores (id, tenant_id, name, slug, status, country_code, currency_code, timezone,
+		                     storefront_customer_portal_secret)
+		 VALUES (?, ?, 'Avail Test', ?, 'active', 'IN', 'INR', 'Asia/Kolkata', ?)`,
+		storeID, tenantID, "avail-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	productID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO products (id, tenant_id, store_id, title, handle, status, vendor_id, published_at)
+		 VALUES (?, ?, ?, 'Avail Product', ?, 'active', ?, now())`,
+		productID, tenantID, storeID, "avail-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	variantID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO product_variants (id, product_id, store_id, sku, price, currency_code)
+		 VALUES (?, ?, ?, ?, 10.00, 'INR')`,
+		variantID, productID, storeID, "SKU-"+uuid.NewString()[:8]).Error)
+	return storeID, variantID
+}
+
+func seedWarehouseRow(t *testing.T, db *gorm.DB, storeID, name string) string {
+	t.Helper()
+	var tenantID string
+	require.NoError(t, db.Raw(`SELECT tenant_id FROM stores WHERE id = ?`, storeID).Row().Scan(&tenantID))
+	id := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO warehouses (id, tenant_id, store_id, name, line1, city, region, postal_code, country_code, phone)
+		 VALUES (?, ?, ?, ?, '1 Dock Rd', 'Mumbai', 'MH', '400001', 'IN', '+912200000000')`,
+		id, tenantID, storeID, name).Error)
+	return id
+}
+
+func TestLoadAvailability_SentinelStockIsReportedAgainstTheFirstWarehouse(t *testing.T) {
+	db := testdb.NewTx(t)
+	storeID, variantID := seedAvailStore(t, db)
+	whID := seedWarehouseRow(t, db, storeID, "Main")
+
+	// Stock still lives at the sentinel — PR 6 has not backfilled yet.
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 7, now())`, variantID, product.DefaultLocationID).Error)
+
+	warehouses := []allocation.Warehouse{{ID: whID}}
+	avail, storage, err := loadAvailability(context.Background(), db, uuid.NewString(), warehouses, []string{variantID})
+	require.NoError(t, err)
+
+	require.Equal(t, 7, avail.At(variantID, whID),
+		"sentinel-stored units must be visible against the store's warehouse before the backfill")
+	require.Equal(t, product.DefaultLocationID, storage[variantID][whID],
+		"a hold must target the location the units are actually stored at")
+}
+
+func TestLoadAvailability_RealWarehouseStockIsReportedAgainstItself(t *testing.T) {
+	db := testdb.NewTx(t)
+	storeID, variantID := seedAvailStore(t, db)
+	whA := seedWarehouseRow(t, db, storeID, "A")
+	whB := seedWarehouseRow(t, db, storeID, "B")
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 3, now()), (?, ?, 4, now())`,
+		variantID, whA, variantID, whB).Error)
+
+	warehouses := []allocation.Warehouse{{ID: whA}, {ID: whB}}
+	avail, storage, err := loadAvailability(context.Background(), db, uuid.NewString(), warehouses, []string{variantID})
+	require.NoError(t, err)
+
+	require.Equal(t, 3, avail.At(variantID, whA))
+	require.Equal(t, 4, avail.At(variantID, whB))
+	require.Equal(t, whA, storage[variantID][whA], "post-backfill the storage location IS the warehouse")
+	require.Equal(t, whB, storage[variantID][whB])
+}
+
+// Matching stockhold.Hold and stockhold.Available: a cart must not see its
+// own reservation as competition, or it could never re-hold what it already
+// has and checkout would refuse a cart it had itself reserved.
+func TestLoadAvailability_ExcludesTheCallingCartsOwnHolds(t *testing.T) {
+	db := testdb.NewTx(t)
+	storeID, variantID := seedAvailStore(t, db)
+	whID := seedWarehouseRow(t, db, storeID, "Main")
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 10, now())`, variantID, product.DefaultLocationID).Error)
+
+	mine, theirs := uuid.NewString(), uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO stock_holds (variant_id, location_id, cart_token, qty, expires_at, state)
+		 VALUES (?, ?, ?, 4, ?, 'held'), (?, ?, ?, 3, ?, 'held')`,
+		variantID, product.DefaultLocationID, mine, time.Now().Add(time.Hour),
+		variantID, product.DefaultLocationID, theirs, time.Now().Add(time.Hour)).Error)
+
+	warehouses := []allocation.Warehouse{{ID: whID}}
+	avail, _, err := loadAvailability(context.Background(), db, mine, warehouses, []string{variantID})
+	require.NoError(t, err)
+
+	require.Equal(t, 7, avail.At(variantID, whID),
+		"10 units less the OTHER cart's 3; this cart's own 4 must not count against it")
+}
+
+func TestLoadAvailability_ExpiredHoldsDoNotReduceAvailability(t *testing.T) {
+	db := testdb.NewTx(t)
+	storeID, variantID := seedAvailStore(t, db)
+	whID := seedWarehouseRow(t, db, storeID, "Main")
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 5, now())`, variantID, product.DefaultLocationID).Error)
+	require.NoError(t, db.Exec(
+		`INSERT INTO stock_holds (variant_id, location_id, cart_token, qty, expires_at, state)
+		 VALUES (?, ?, ?, 5, ?, 'held')`,
+		variantID, product.DefaultLocationID, uuid.NewString(), time.Now().Add(-time.Minute)).Error)
+
+	avail, _, err := loadAvailability(context.Background(), db, uuid.NewString(),
+		[]allocation.Warehouse{{ID: whID}}, []string{variantID})
+	require.NoError(t, err)
+
+	require.Equal(t, 5, avail.At(variantID, whID),
+		"a hold expires by the clock, not by a sweeper running")
+}
+
+// A variant with no stock row anywhere must simply be absent, not zero-filled
+// — allocation treats a missing entry as zero, and inventing rows would hide
+// the difference between "none here" and "no such pairing".
+func TestLoadAvailability_VariantWithNoStockRowsIsAbsent(t *testing.T) {
+	db := testdb.NewTx(t)
+	storeID, variantID := seedAvailStore(t, db)
+	whID := seedWarehouseRow(t, db, storeID, "Main")
+
+	avail, storage, err := loadAvailability(context.Background(), db, uuid.NewString(),
+		[]allocation.Warehouse{{ID: whID}}, []string{variantID})
+	require.NoError(t, err)
+
+	require.Equal(t, 0, avail.At(variantID, whID))
+	require.Empty(t, storage[variantID])
+}

--- a/services/marketplace-api/internal/handlers/storefront/checkout_ext.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_ext.go
@@ -630,7 +630,7 @@ func (h *CheckoutExtHandler) Checkout(c *gin.Context) {
 
 	consumeDiscounts := func(tx *gorm.DB, o *order.Order) error {
 		if h.stockHolds != nil {
-			if err := commitStock(ctx, tx, h.stockHolds, stockCartToken, stockLines); err != nil {
+			if err := commitStock(ctx, tx, h.stockHolds, stockCartToken, o.ID.String(), storeID.String(), stockLines); err != nil {
 				return err
 			}
 		}

--- a/services/marketplace-api/internal/handlers/storefront/checkout_stock.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_stock.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -120,6 +122,16 @@ func commitStock(
 	// would leave only the SECOND quantity reserved. Aggregate first.
 	type holdKey struct{ variantID, locationID string }
 	totals := map[holdKey]int{}
+	// drawn tracks, per (variant, location), how many units EARLIER
+	// assignments in this loop already claimed from that location's
+	// breakdown. storage[...] is an immutable snapshot taken once before the
+	// loop — without this, every assignment would draw from the FULL
+	// breakdown again, and two lines of the same variant filled at the same
+	// warehouse would double-count what the location actually holds (e.g. a
+	// breakdown of [sentinel:3, A:4] with two assignments of 2 and 3 must
+	// draw 3 from the sentinel and 2 from A in total, not 5 from the
+	// sentinel).
+	drawn := map[holdKey]int{}
 	for _, a := range assignments {
 		if policies[a.VariantID] == inventoryPolicyContinue {
 			// Sell past zero on purpose. No hold, no gate — decrement at
@@ -175,11 +187,14 @@ func commitStock(
 			if want == 0 {
 				break
 			}
-			take := min(want, at.Units)
+			key := holdKey{a.VariantID, at.LocationID}
+			remaining := at.Units - drawn[key]
+			take := min(want, remaining)
 			if take <= 0 {
 				continue
 			}
-			totals[holdKey{a.VariantID, at.LocationID}] += take
+			totals[key] += take
+			drawn[key] += take
 			want -= take
 		}
 		if want > 0 {
@@ -192,7 +207,37 @@ func commitStock(
 				a.VariantID, a.WarehouseID, want)
 		}
 	}
-	for k, qty := range totals {
+	// Release any cart-time hold whose (variant, location) is not part of
+	// this plan BEFORE placing the plan's holds and BEFORE Commit runs.
+	// cart_holds.go places holds at product.DefaultLocationID; a placement
+	// plan is free to target a different warehouse, and holds.Commit
+	// decrements EVERY live hold this cart owns regardless of whether it
+	// matches. Left in place, a stale cart-add hold gets decremented a
+	// second time alongside the plan's own hold for the same units.
+	keep := make([]stockhold.VariantLocation, 0, len(totals))
+	for k := range totals {
+		keep = append(keep, stockhold.VariantLocation{VariantID: k.variantID, LocationID: k.locationID})
+	}
+	if err := holds.ReleaseExcept(ctx, tx, cartToken, keep); err != nil {
+		return err
+	}
+
+	// Sorted rather than ranged directly: map iteration order is randomised,
+	// and each Hold takes a SELECT ... FOR UPDATE row lock. Two concurrent
+	// checkouts of identical carts taking the same two locks in opposite
+	// orders is a deadlock waiting to happen; a fixed order rules it out.
+	keys := make([]holdKey, 0, len(totals))
+	for k := range totals {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].variantID != keys[j].variantID {
+			return keys[i].variantID < keys[j].variantID
+		}
+		return keys[i].locationID < keys[j].locationID
+	})
+	for _, k := range keys {
+		qty := totals[k]
 		err := holds.Hold(ctx, tx, cartToken, k.variantID, k.locationID, qty, HoldTTL)
 		if errors.Is(err, stockhold.ErrInsufficientStock) {
 			return outOfStockError{VariantID: k.variantID}
@@ -300,9 +345,18 @@ func variantIDsOf(lines []stockLine) []string {
 // id — gen_random_uuid(). items[i] is then a RANDOM permutation of lines,
 // not lines[i]'s item: pairing positionally silently attaches every
 // allocation to the wrong line the moment an order has two or more items.
-// A cart mixing stocked and unstocked items would also make lines shorter
-// than order_items — the length assert below exists to catch that mismatch
-// loudly rather than mis-pair rows silently.
+//
+// # Items without a variant_id are not lines
+//
+// order.CreateInput.WithinTx inserts an order_items row for EVERY checkout
+// item, including ones whose variant_id is nil or unparseable, but
+// stockLinesFromItems drops those — they carry nothing to allocate. The
+// query below only reads order_items whose variant_id IS NOT NULL, so items
+// is naturally restricted to the ones that can correspond to a line; a
+// variantless item is simply ignored here, matching the legacy sentinel path
+// which silently skipped it too. What still fails loudly is a genuine
+// attribution mismatch: a line for which no matching order_item can be
+// found, in the per-line pairing loop below.
 //
 // Paired instead by the (variant_id, quantity) MULTISET: two lines
 // identical in both are genuinely interchangeable — swapping which gets
@@ -336,14 +390,10 @@ func recordAllocations(
 		Quantity  int
 	}
 	if err := tx.WithContext(ctx).Raw(
-		`SELECT id, variant_id, quantity FROM order_items WHERE order_id = ? ORDER BY created_at, id`,
+		`SELECT id, variant_id, quantity FROM order_items
+		  WHERE order_id = ? AND variant_id IS NOT NULL ORDER BY created_at, id`,
 		orderID).Scan(&items).Error; err != nil {
 		return fmt.Errorf("storefront: load order items for allocation: %w", err)
-	}
-	if len(items) != len(lines) {
-		return fmt.Errorf(
-			"storefront: order %s has %d order_items but commitStock was given %d lines — "+
-				"allocations cannot be paired to lines", orderID, len(items), len(lines))
 	}
 
 	var tenantID, storeID string
@@ -462,13 +512,20 @@ func inventoryPolicies(tx *gorm.DB, lines []stockLine) (map[string]string, error
 //
 // An item with no variant_id is a custom or unstocked line — refusing those
 // would break every unstocked sale, and there is nothing to decrement.
+//
+// Variant ids are lowercased here, at the boundary where lines are built.
+// The legacy path passed the client's string straight into SQL, where
+// Postgres casts to uuid case-insensitively; everything downstream of this
+// function does Go map lookups against ids read back from the database in
+// canonical lowercase, so an uppercase id from a client would otherwise miss
+// every lookup and read as zero availability.
 func stockLinesFromItems(items []CheckoutItemRequest) []stockLine {
 	lines := make([]stockLine, 0, len(items))
 	for _, it := range items {
 		if it.VariantID == nil || *it.VariantID == "" || it.Quantity <= 0 {
 			continue
 		}
-		lines = append(lines, stockLine{VariantID: *it.VariantID, Quantity: it.Quantity})
+		lines = append(lines, stockLine{VariantID: strings.ToLower(*it.VariantID), Quantity: it.Quantity})
 	}
 	return lines
 }

--- a/services/marketplace-api/internal/handlers/storefront/checkout_stock.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_stock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
+	"github.com/mark8ly/marketplace-api/internal/allocation"
 	"github.com/mark8ly/marketplace-api/internal/product"
 	"github.com/mark8ly/marketplace-api/internal/stockhold"
 )
@@ -61,6 +62,8 @@ func commitStock(
 	tx *gorm.DB,
 	holds *stockhold.Repository,
 	cartToken string,
+	orderID string,
+	storeID string,
 	lines []stockLine,
 ) error {
 	if len(lines) == 0 {
@@ -72,6 +75,133 @@ func commitStock(
 		return err
 	}
 
+	// A store with NO warehouses keeps the pre-#177 behaviour exactly:
+	// hold and decrement at the sentinel location, write no allocations.
+	// This is not a tidy fallback — production has zero warehouse rows, so
+	// it is the only path that currently runs, and allocation.Plan would
+	// return ErrNoWarehouse for every checkout if it ran unconditionally.
+	warehouses, err := storeWarehousesInFillOrder(ctx, tx, storeID)
+	if err != nil {
+		return err
+	}
+	if len(warehouses) == 0 {
+		return commitStockAtSentinel(ctx, tx, holds, cartToken, lines, policies)
+	}
+
+	avail, storage, err := loadAvailability(ctx, tx, cartToken, warehouses, variantIDsOf(lines))
+	if err != nil {
+		return err
+	}
+
+	allocLines := make([]allocation.Line, 0, len(lines))
+	for _, l := range lines {
+		allocLines = append(allocLines, allocation.Line{
+			VariantID:     l.VariantID,
+			Quantity:      l.Quantity,
+			SellsPastZero: policies[l.VariantID] == inventoryPolicyContinue,
+		})
+	}
+
+	assignments, err := allocation.Plan(warehouses, avail, allocLines)
+	var cannot allocation.CannotFillError
+	if errors.As(err, &cannot) {
+		// Same shape the shopper already gets for a sold-out cart.
+		return outOfStockError{VariantID: cannot.VariantID}
+	}
+	if err != nil {
+		return err
+	}
+
+	// stockhold.Hold's ON CONFLICT DO UPDATE SET qty = EXCLUDED.qty REPLACES
+	// a quantity rather than adding to it, and its unique key is
+	// (cart_token, variant_id, location_id). Two assignments for the same
+	// variant and warehouse — which happens whenever two order lines carry
+	// the same variant, because stockLinesFromItems does not merge them —
+	// would leave only the SECOND quantity reserved. Aggregate first.
+	type holdKey struct{ variantID, locationID string }
+	totals := map[holdKey]int{}
+	for _, a := range assignments {
+		if policies[a.VariantID] == inventoryPolicyContinue {
+			// Sell past zero on purpose. No hold, no gate — decrement at
+			// this assignment's warehouse, clamped for the same reason the
+			// sentinel path clamps (#231's non-negative CHECK).
+			at := storage[a.VariantID][a.WarehouseID]
+			if len(at) == 0 {
+				return fmt.Errorf(
+					"storefront: no storage location found for continue-policy variant %s at warehouse %s",
+					a.VariantID, a.WarehouseID)
+			}
+			if err := tx.WithContext(ctx).Exec(
+				`UPDATE variant_stock
+				    SET quantity = GREATEST(quantity - ?, 0), updated_at = now()
+				  WHERE variant_id = ? AND location_id = ?`,
+				a.Quantity, a.VariantID, at[0].LocationID).Error; err != nil {
+				return fmt.Errorf("storefront: decrement continue-policy variant: %w", err)
+			}
+			continue // sold past zero on purpose; decremented, not held
+		}
+		// A warehouse's units can sit in more than one physical location
+		// while the sentinel and real rows coexist, so draw the assigned
+		// quantity from that warehouse's locations in order until it is
+		// covered. The breakdown is sorted by LocationID, so the same
+		// inputs always produce the same holds.
+		want := a.Quantity
+		for _, at := range storage[a.VariantID][a.WarehouseID] {
+			if want == 0 {
+				break
+			}
+			take := min(want, at.Units)
+			if take <= 0 {
+				continue
+			}
+			totals[holdKey{a.VariantID, at.LocationID}] += take
+			want -= take
+		}
+		if want > 0 {
+			// The snapshot said this warehouse had the units and the
+			// breakdown does not account for them. That is a bug in the
+			// snapshot, not a stock shortage — fail loudly rather than
+			// under-hold and oversell.
+			return fmt.Errorf(
+				"storefront: allocation for variant %s at warehouse %s is %d units short of its storage breakdown",
+				a.VariantID, a.WarehouseID, want)
+		}
+	}
+	for k, qty := range totals {
+		err := holds.Hold(ctx, tx, cartToken, k.variantID, k.locationID, qty, HoldTTL)
+		if errors.Is(err, stockhold.ErrInsufficientStock) {
+			return outOfStockError{VariantID: k.variantID}
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	// order_items rows already exist: order.CreateInput.WithinTx runs after
+	// CreateInTx inserts them. Reading them back is how an allocation gets
+	// its order_item_id without threading ids through the checkout request.
+	if err := recordAllocations(ctx, tx, orderID, assignments, lines); err != nil {
+		return err
+	}
+
+	// One Commit for the whole cart: it decrements every live hold this cart
+	// holds and flips them to 'committed' in the same transaction.
+	return holds.Commit(ctx, tx, cartToken)
+}
+
+// commitStockAtSentinel is the pre-#177 behaviour, moved here verbatim: hold
+// and decrement everything at the single sentinel location, and write no
+// order_allocations rows. This is the ONLY path production exercises today
+// — there are zero warehouse rows — so its body must stay provably
+// unchanged rather than be re-implemented alongside the allocation path.
+func commitStockAtSentinel(
+	ctx context.Context,
+	tx *gorm.DB,
+	holds *stockhold.Repository,
+	cartToken string,
+	lines []stockLine,
+	policies map[string]string,
+) error {
 	for _, line := range lines {
 		if policies[line.VariantID] == inventoryPolicyContinue {
 			// Sell past zero on purpose. No hold, no gate — and the
@@ -106,6 +236,134 @@ func commitStock(
 	// One Commit for the whole cart: it decrements every live hold this cart
 	// holds and flips them to 'committed' in the same transaction.
 	return holds.Commit(ctx, tx, cartToken)
+}
+
+// storeWarehousesInFillOrder reads storeID's warehouses and returns them in
+// the order allocation.Plan should fill them. Plan takes an ordered slice
+// and cannot detect an unordered one, so ordering here is mandatory.
+func storeWarehousesInFillOrder(ctx context.Context, tx *gorm.DB, storeID string) ([]allocation.Warehouse, error) {
+	var rows []allocation.Warehouse
+	if err := tx.WithContext(ctx).Raw(
+		`SELECT id, priority, is_default, created_at FROM warehouses WHERE store_id = ?`, storeID).
+		Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("storefront: load warehouses: %w", err)
+	}
+	return allocation.InPriorityOrder(rows), nil
+}
+
+// variantIDsOf returns the distinct variant ids across lines.
+func variantIDsOf(lines []stockLine) []string {
+	seen := make(map[string]struct{}, len(lines))
+	ids := make([]string, 0, len(lines))
+	for _, l := range lines {
+		if _, ok := seen[l.VariantID]; ok {
+			continue
+		}
+		seen[l.VariantID] = struct{}{}
+		ids = append(ids, l.VariantID)
+	}
+	return ids
+}
+
+// recordAllocations writes one order_allocations row per assignment.
+//
+// order_items rows are paired to lines POSITIONALLY: items[i] is line[i]'s
+// item, because order.CreateInput.WithinTx inserts one order_item per line
+// in the same order commitStock was given, and stockLinesFromItems preserves
+// item order. That means a cart mixing stocked and unstocked items would
+// make lines shorter than order_items — the length assert below exists to
+// catch that mismatch loudly rather than mis-pair rows silently.
+//
+// # Attributing an assignment back to a line
+//
+// allocation.Plan documents its output as "grouped by warehouse in fill
+// order, and by LINE order within a warehouse" — not grouped by line. So two
+// lines sharing a variant, split across warehouses with partial fills, can
+// interleave: {whA: line0, whA: line2, whB: line0, whB: line2}. A running
+// "current line" pointer over the flat assignment slice mis-attributes that
+// case. Instead, every time the warehouse changes, the set of not-yet-filled
+// lines for each variant is rebuilt in ascending index order; within one
+// warehouse's contribution to a given variant, Plan visits at most one
+// assignment per line, in that same ascending order, so consuming that
+// queue front-to-back for each variant, only resetting on a warehouse
+// change, is exact.
+func recordAllocations(
+	ctx context.Context,
+	tx *gorm.DB,
+	orderID string,
+	assignments []allocation.Assignment,
+	lines []stockLine,
+) error {
+	var items []struct {
+		ID        string
+		VariantID string
+		Quantity  int
+	}
+	if err := tx.WithContext(ctx).Raw(
+		`SELECT id, variant_id, quantity FROM order_items WHERE order_id = ? ORDER BY created_at, id`,
+		orderID).Scan(&items).Error; err != nil {
+		return fmt.Errorf("storefront: load order items for allocation: %w", err)
+	}
+	if len(items) != len(lines) {
+		return fmt.Errorf(
+			"storefront: order %s has %d order_items but commitStock was given %d lines — "+
+				"allocations cannot be paired positionally", orderID, len(items), len(lines))
+	}
+
+	var tenantID, storeID string
+	if err := tx.WithContext(ctx).Raw(
+		`SELECT tenant_id, store_id FROM orders WHERE id = ?`, orderID).
+		Row().Scan(&tenantID, &storeID); err != nil {
+		return fmt.Errorf("storefront: load order for allocation: %w", err)
+	}
+
+	remaining := make([]int, len(lines))
+	for i, l := range lines {
+		remaining[i] = l.Quantity
+	}
+
+	var prevWarehouse string
+	haveWarehouse := false
+	queues := map[string][]int{} // variantID -> ascending line indices still owed, as of the current warehouse
+	pointer := map[string]int{}  // variantID -> next queue position to consume
+
+	for _, a := range assignments {
+		if !haveWarehouse || a.WarehouseID != prevWarehouse {
+			queues = map[string][]int{}
+			pointer = map[string]int{}
+			for i, l := range lines {
+				if remaining[i] > 0 {
+					queues[l.VariantID] = append(queues[l.VariantID], i)
+				}
+			}
+			prevWarehouse = a.WarehouseID
+			haveWarehouse = true
+		}
+
+		idxList := queues[a.VariantID]
+		p := pointer[a.VariantID]
+		if p >= len(idxList) {
+			// Plan produced an assignment for a variant with no line left
+			// owing it in this warehouse's chunk — a bug in this pairing
+			// logic or in Plan's ordering contract, not a data problem.
+			// Fail loudly rather than attribute it to the wrong line.
+			return fmt.Errorf(
+				"storefront: cannot attribute allocation of %d units of variant %s at warehouse %s to any order line",
+				a.Quantity, a.VariantID, a.WarehouseID)
+		}
+		lineIdx := idxList[p]
+		pointer[a.VariantID] = p + 1
+		remaining[lineIdx] -= a.Quantity
+
+		id := uuid.NewString()
+		if err := tx.WithContext(ctx).Exec(
+			`INSERT INTO order_allocations (id, tenant_id, store_id, order_id, order_item_id, warehouse_id, quantity)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			id, tenantID, storeID, orderID, items[lineIdx].ID, a.WarehouseID, a.Quantity).Error; err != nil {
+			return fmt.Errorf("storefront: insert order_allocations: %w", err)
+		}
+	}
+	return nil
 }
 
 // inventoryPolicies reads the policy for each line's variant in one query.

--- a/services/marketplace-api/internal/handlers/storefront/checkout_stock.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_stock.go
@@ -127,16 +127,41 @@ func commitStock(
 			// sentinel path clamps (#231's non-negative CHECK).
 			at := storage[a.VariantID][a.WarehouseID]
 			if len(at) == 0 {
-				return fmt.Errorf(
-					"storefront: no storage location found for continue-policy variant %s at warehouse %s",
-					a.VariantID, a.WarehouseID)
+				// No variant_stock row exists for this warehouse — the
+				// common case for a sell-past-zero variant, since it never
+				// needed a stock row to sell. The legacy sentinel path's
+				// UPDATE simply matches zero rows and succeeds; erroring
+				// here would hard-fail a checkout that used to work the
+				// moment a merchant has a warehouse at all (PR 5).
+				continue // sold past zero on purpose; nothing to decrement
 			}
-			if err := tx.WithContext(ctx).Exec(
-				`UPDATE variant_stock
-				    SET quantity = GREATEST(quantity - ?, 0), updated_at = now()
-				  WHERE variant_id = ? AND location_id = ?`,
-				a.Quantity, a.VariantID, at[0].LocationID).Error; err != nil {
-				return fmt.Errorf("storefront: decrement continue-policy variant: %w", err)
+			// Walk every location the way the hold path does, rather than
+			// only at[0]: a warehouse whose units span the sentinel row and
+			// a real row must have BOTH decremented, or the second silently
+			// keeps stale stock. The last location absorbs whatever is left
+			// after the others — continue-policy is unconstrained by
+			// availability, so there is no "short" to error on here the way
+			// the hold path does; GREATEST clamps it at zero.
+			want := a.Quantity
+			for i, loc := range at {
+				take := want
+				if i < len(at)-1 {
+					take = min(want, loc.Units)
+				}
+				if take <= 0 {
+					continue
+				}
+				if err := tx.WithContext(ctx).Exec(
+					`UPDATE variant_stock
+					    SET quantity = GREATEST(quantity - ?, 0), updated_at = now()
+					  WHERE variant_id = ? AND location_id = ?`,
+					take, a.VariantID, loc.LocationID).Error; err != nil {
+					return fmt.Errorf("storefront: decrement continue-policy variant: %w", err)
+				}
+				want -= take
+				if want == 0 {
+					break
+				}
 			}
 			continue // sold past zero on purpose; decremented, not held
 		}
@@ -267,12 +292,23 @@ func variantIDsOf(lines []stockLine) []string {
 
 // recordAllocations writes one order_allocations row per assignment.
 //
-// order_items rows are paired to lines POSITIONALLY: items[i] is line[i]'s
-// item, because order.CreateInput.WithinTx inserts one order_item per line
-// in the same order commitStock was given, and stockLinesFromItems preserves
-// item order. That means a cart mixing stocked and unstocked items would
-// make lines shorter than order_items — the length assert below exists to
-// catch that mismatch loudly rather than mis-pair rows silently.
+// # Why order_items cannot be paired to lines by position
+//
+// Production inserts every item of an order in ONE batch tx.Create(&items)
+// (internal/order/repository.go), so all of an order's rows share a single
+// created_at, and the only tie-break `ORDER BY created_at, id` has left is
+// id — gen_random_uuid(). items[i] is then a RANDOM permutation of lines,
+// not lines[i]'s item: pairing positionally silently attaches every
+// allocation to the wrong line the moment an order has two or more items.
+// A cart mixing stocked and unstocked items would also make lines shorter
+// than order_items — the length assert below exists to catch that mismatch
+// loudly rather than mis-pair rows silently.
+//
+// Paired instead by the (variant_id, quantity) MULTISET: two lines
+// identical in both are genuinely interchangeable — swapping which gets
+// which order_item_id changes nothing observable — so matching on that key
+// is exact, and does not depend on any ordering order_items happens to
+// come back in.
 //
 // # Attributing an assignment back to a line
 //
@@ -307,7 +343,7 @@ func recordAllocations(
 	if len(items) != len(lines) {
 		return fmt.Errorf(
 			"storefront: order %s has %d order_items but commitStock was given %d lines — "+
-				"allocations cannot be paired positionally", orderID, len(items), len(lines))
+				"allocations cannot be paired to lines", orderID, len(items), len(lines))
 	}
 
 	var tenantID, storeID string
@@ -315,6 +351,34 @@ func recordAllocations(
 		`SELECT tenant_id, store_id FROM orders WHERE id = ?`, orderID).
 		Row().Scan(&tenantID, &storeID); err != nil {
 		return fmt.Errorf("storefront: load order for allocation: %w", err)
+	}
+
+	type itemKey struct {
+		variantID string
+		quantity  int
+	}
+	byKey := map[itemKey][]string{}
+	for _, it := range items {
+		k := itemKey{it.VariantID, it.Quantity}
+		byKey[k] = append(byKey[k], it.ID)
+	}
+
+	lineItemID := make([]string, len(lines))
+	for i, l := range lines {
+		k := itemKey{l.VariantID, l.Quantity}
+		queue := byKey[k]
+		if len(queue) == 0 {
+			// Every line was supposed to have created exactly one
+			// order_item with its own (variant, quantity). Running out
+			// means the order_items this order actually has don't match
+			// what commitStock was told to place — fail loudly rather
+			// than attribute the allocation to an unrelated line.
+			return fmt.Errorf(
+				"storefront: no order_item left matching variant %s quantity %d for line %d of order %s",
+				l.VariantID, l.Quantity, i, orderID)
+		}
+		lineItemID[i] = queue[0]
+		byKey[k] = queue[1:]
 	}
 
 	remaining := make([]int, len(lines))
@@ -359,7 +423,7 @@ func recordAllocations(
 		if err := tx.WithContext(ctx).Exec(
 			`INSERT INTO order_allocations (id, tenant_id, store_id, order_id, order_item_id, warehouse_id, quantity)
 			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-			id, tenantID, storeID, orderID, items[lineIdx].ID, a.WarehouseID, a.Quantity).Error; err != nil {
+			id, tenantID, storeID, orderID, lineItemID[lineIdx], a.WarehouseID, a.Quantity).Error; err != nil {
 			return fmt.Errorf("storefront: insert order_allocations: %w", err)
 		}
 	}

--- a/services/marketplace-api/internal/stockhold/repository.go
+++ b/services/marketplace-api/internal/stockhold/repository.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -176,6 +177,44 @@ func (r *Repository) Release(ctx context.Context, tx *gorm.DB, cartToken string)
 	return tx.WithContext(ctx).Exec(
 		`UPDATE stock_holds SET state = 'released' WHERE cart_token = ? AND state = 'held'`,
 		cartToken).Error
+}
+
+// VariantLocation identifies one (variant, location) pair a cart holds units
+// at.
+type VariantLocation struct {
+	VariantID  string
+	LocationID string
+}
+
+// ReleaseExcept returns a cart's live holds to the pool, except those whose
+// (variant_id, location_id) appears in keep.
+//
+// It exists for the case Release does not cover: a placement plan retargets
+// an assignment to a location different from wherever a cart-add hold
+// landed it. Commit decrements EVERY live hold the cart owns, so a hold that
+// no longer matches the final plan must be released before Commit runs, or
+// the same units get decremented twice — once for the stale hold, once for
+// the plan's own hold on the replacement location.
+func (r *Repository) ReleaseExcept(ctx context.Context, tx *gorm.DB, cartToken string, keep []VariantLocation) error {
+	if len(keep) == 0 {
+		return r.Release(ctx, tx, cartToken)
+	}
+
+	conds := make([]string, len(keep))
+	args := make([]interface{}, 0, len(keep)*2+1)
+	args = append(args, cartToken)
+	for i, k := range keep {
+		conds[i] = "(variant_id = ? AND location_id = ?)"
+		args = append(args, k.VariantID, k.LocationID)
+	}
+
+	query := fmt.Sprintf(
+		`UPDATE stock_holds SET state = 'released'
+		  WHERE cart_token = ? AND state = 'held'
+		    AND NOT (%s)`,
+		strings.Join(conds, " OR "))
+
+	return tx.WithContext(ctx).Exec(query, args...).Error
 }
 
 // Extend pushes a live cart's expiry out, for a customer still working

--- a/services/marketplace-api/internal/stockhold/repository_integration_test.go
+++ b/services/marketplace-api/internal/stockhold/repository_integration_test.go
@@ -164,6 +164,69 @@ func TestRelease_ReturnsStockToThePool(t *testing.T) {
 	}), "a released hold must return its unit to the pool")
 }
 
+// second location a store's stock holds may also sit at, for tests exercising
+// more than one (variant, location) pair for the same cart.
+const testLocation2 = "00000000-0000-0000-0000-000000000002"
+
+// ReleaseExcept must release every hold NOT in keep, and leave the ones in
+// keep untouched — the shape checkout needs before Commit runs, since
+// Commit decrements every live hold the cart owns.
+func TestReleaseExcept_ReleasesEverythingNotKept(t *testing.T) {
+	db := testdb.NewDB(t, "stock_holds")
+	repo := stockhold.NewRepository()
+	ctx := context.Background()
+	variantID := seedVariant(t, db, 5)
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 5, now())`, variantID, testLocation2).Error)
+	cart := uuid.NewString()
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		if err := repo.Hold(ctx, tx, cart, variantID, testLocation, 1, time.Hour); err != nil {
+			return err
+		}
+		return repo.Hold(ctx, tx, cart, variantID, testLocation2, 1, time.Hour)
+	}))
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.ReleaseExcept(ctx, tx, cart, []stockhold.VariantLocation{
+			{VariantID: variantID, LocationID: testLocation2},
+		})
+	}))
+
+	var states []string
+	require.NoError(t, db.Raw(
+		`SELECT state FROM stock_holds WHERE cart_token = ? ORDER BY location_id`, cart).
+		Scan(&states).Error)
+	require.Equal(t, []string{"released", "held"}, states,
+		"testLocation sorts before testLocation2 — the kept hold must stay 'held', the other must be released")
+
+	// The released unit at testLocation must be obtainable by someone else.
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, uuid.NewString(), variantID, testLocation, 1, time.Minute)
+	}))
+}
+
+// An empty keep list must behave exactly like Release — release everything.
+func TestReleaseExcept_EmptyKeepReleasesEverything(t *testing.T) {
+	db := testdb.NewDB(t, "stock_holds")
+	repo := stockhold.NewRepository()
+	ctx := context.Background()
+	variantID := seedVariant(t, db, 1)
+	cart := uuid.NewString()
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, cart, variantID, testLocation, 1, time.Hour)
+	}))
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.ReleaseExcept(ctx, tx, cart, nil)
+	}))
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return repo.Hold(ctx, tx, uuid.NewString(), variantID, testLocation, 1, time.Minute)
+	}), "an empty keep list must release everything, same as Release")
+}
+
 // THE TEST THIS PACKAGE EXISTS FOR.
 //
 // N goroutines on separate connections contend for M units. Exactly M may


### PR DESCRIPTION
**PR 3 of 6** toward multi-warehouse support. Wires the allocator into checkout:
an order is allocated across warehouses when it is placed, holds are taken per
storage location, and `order_allocations` records which warehouse owes which
line.

Part of #177. Follows #488 (schema) and #490 (the allocator).

## This is inert in production

Verified on the live database: **zero `warehouses` rows across all three
stores**, and all 380 `variant_stock` rows sit at the sentinel location. A
store with no warehouses takes an early return into `commitStockAtSentinel` —
which is the pre-existing loop body, moved verbatim, not re-implemented. It was
diffed mechanically against `b052e84c`: 34 lines each, zero differences.

So the only new work a production checkout does today is one indexed
`SELECT … FROM warehouses WHERE store_id = ?` returning no rows.

**Deploy precondition:** that query selects `warehouses.priority`, added by
migration `000118` in #488. Production is at schema 119 (the
`variant_stock_sync_delete` trigger from 000119 is present on the live table),
so the column exists. Were it not, a storefront pod running this image would
500 every checkout — storefront rolls independently of the admin deployment
that applies migrations.

## How allocation works here

1. Load the store's warehouses, ordered through `allocation.InPriorityOrder`.
2. Snapshot availability per `(variant, warehouse)` — stock minus *other*
   carts' live holds, matching `stockhold.Available`'s arithmetic exactly.
3. `allocation.Plan` returns assignments; `CannotFillError` becomes the same
   `out_of_stock` response a sold-out cart already gets.
4. Hold per `(variant, storage location)`, aggregated.
5. Write one `order_allocations` row per assignment.

All of it inside the order transaction, so a failure anywhere rolls the order
back and moves no stock.

### The snapshot carries two values, not one

Until the backfill (PR 6), units live at the **sentinel** while allocation
reasons in **warehouse-id** space. The snapshot therefore reports availability
against a warehouse while recording where the units physically sit — because
that is where the hold must be placed. A warehouse's units can span two
locations at once (PR 5's per-location editing writes to a real id while the
sentinel row still exists), so it is a per-location breakdown rather than a
single value.

A consequence worth stating: while a store's stock is entirely at the sentinel,
it is attributed to the merchant's **first** warehouse. A merchant who adds a
second warehouse will see nothing ship from it until stock is recorded there.

## Four defects review caught, and why the tests could not

**Allocations were attributed to order lines by a random permutation.**
`recordAllocations` read `order_items` with `ORDER BY created_at, id`. In
production every item of an order is inserted in ONE batch, so they share a
`created_at` and the tie-break is `gen_random_uuid()`. Every allocation row
would have carried a valid but wrong `order_item_id` — and
`UNIQUE(order_item_id, warehouse_id)` cannot catch it, because a mis-mapping is
still a bijection. PR 4 would have built a parcel from the wrong line while the
order looked internally consistent.

The suite could not see it: the fixture inserted each item with a **separate**
statement, giving strictly increasing timestamps. Deterministic in test, random
in production. Both halves are fixed — pairing is now on the
`(variant_id, quantity)` multiset, and the fixture batch-inserts like
production does. With the fixture corrected, the old pairing fails 4 runs in 5,
which is what a random tie-break should look like.

**Stale cart holds were double-decremented.** The spec requires holds that no
longer match to be released at placement. They were not, and `Commit`
decrements every live hold the cart owns — 4 units consumed for a 2-unit order
once a plan targets a location the cart-add hold did not. Fixed with a new
`stockhold.ReleaseExcept`, cart- and state-scoped, with its own tests.

**Two lines at one multi-location warehouse over-drew the first location**,
because the breakdown restarted per assignment — a spurious `out_of_stock` on a
cart the store could fill.

**Non-deterministic lock ordering.** `totals` was a map, and each `Hold` takes
`SELECT … FOR UPDATE`; two concurrent identical carts could take the same locks
in opposite orders and deadlock. Keys are now sorted.

Also fixed: an item with a missing `variant_id` 500'd where the legacy path
silently completed (a public endpoint whose own contract marks the field
optional), and an uppercase UUID from a client produced a false `out_of_stock`
because Go map lookups are case-sensitive where Postgres's `uuid` cast is not.

## Testing

Integration, real DSN, `-p 1`, durations that prove they ran: storefront
17.8s, stockhold 0.7s, order 2.0s, warehouse 1.0s, allocation 0.4s. Full unit
suite green. `TestCommitStock` run 5 times independently — one green run proves
little when the bug it replaced failed only 4 times in 5.

Guards mutation-tested: the hold aggregation, the no-warehouse early return
(deleting it fails with `allocation: store has no warehouses`, which is what
every production checkout would do), the storage draw, and the own-cart hold
exclusion.

## Known gaps, stated rather than buried

- **`cart_holds.go` still holds at the sentinel.** The spec's provisional-at-cart
  design is unchanged; with one warehouse there is nothing to allocate between,
  so it moves in its own PR alongside PR 5.
- **No dedicated deadlock test** for the lock ordering. Forcing one
  deterministically is inherently flaky; the sorting was verified by inspection
  and every map iteration driving ordered writes was checked.
- **A `continue`-policy variant whose stock sits only at a non-first warehouse
  is never decremented** — `Plan` pins sell-past-zero lines to the first
  warehouse. Consistent with the existing documented behaviour that
  `continue` oversell is not tracked.
- `internal/order/repository.go` orders items by `created_at` alone — the same
  random-permutation problem, still live for customer-facing item ordering.
  Pre-existing, not touched here, worth its own issue.
