### PR TITLE
feat(shipping): one shipment per warehouse, and partial fulfilment (#177, PR 4b of 7)

### DIFF
--- a/docs/superpowers/plans/2026-08-31-multi-warehouse-04b-shipment-per-warehouse.md
+++ b/docs/superpowers/plans/2026-08-31-multi-warehouse-04b-shipment-per-warehouse.md
@@ -55,9 +55,48 @@ Verified in the code and against production. Do not re-derive; do not contradict
 - Consumes: `order_allocations` (PR 1 schema, written by PR 3), `warehouse.Repository.ByID`.
 - Produces: one `shipments` row per contributing warehouse with `warehouse_id` set, and `order_allocations.shipment_id` stamped. Task 2 reads those rows to decide `partial` versus `fulfilled`.
 
+- [ ] **Step 0: Add the carrier seam `Create` needs to be testable**
+
+`Create` calls `shipping.NewCarrier(provider, apiKey, secretKey, cfg.Mode)`
+directly, so it cannot be exercised without a live carrier. The existing
+`carrierFactory` is NOT the seam to use — its doc comment scopes it to the
+tracking-sync loop deliberately, and its signature (`func(provider string, sh
+any)`) is shaped for that loop's projection.
+
+Add a separate, nil-safe override mirroring how `labelMailer` and
+`carrierFactory` are already attached in this file:
+
+```go
+	// newCarrier overrides shipping.NewCarrier inside Create. Nil on
+	// production builds, where Create constructs the carrier directly as
+	// before. It exists because label creation cannot otherwise be tested
+	// without a live carrier account — and the sync loop's carrierFactory
+	// is deliberately scoped to that loop, so overloading it would blur a
+	// boundary its own doc comment draws.
+	newCarrier func(provider, apiKey, secretKey, mode string) (shipping.Carrier, error)
+```
+
+with a `WithCarrierConstructor` setter alongside the existing `With…`
+methods, and in `Create`:
+
+```go
+	construct := shipping.NewCarrier
+	if h.newCarrier != nil {
+		construct = h.newCarrier
+	}
+	carrier, err := construct(provider, apiKey, secretKey, carrierCfg.Mode)
+```
+
+Production behaviour is unchanged: nothing calls the setter outside tests.
+
 - [ ] **Step 1: Write the failing test**
 
 Create `services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go`.
+
+Your stub carrier implements `shipping.Carrier` and returns a canned
+shipment (a tracking number that encodes which pickup address it was called
+with, so the two-warehouse test can prove each parcel shipped from the right
+origin). Attach it with `WithCarrierConstructor`.
 
 The load-bearing case is the FIRST one. Every order in production has no allocations, so if that path changes, label creation breaks for all of them.
 

--- a/docs/superpowers/plans/2026-08-31-multi-warehouse-04b-shipment-per-warehouse.md
+++ b/docs/superpowers/plans/2026-08-31-multi-warehouse-04b-shipment-per-warehouse.md
@@ -1,0 +1,333 @@
+# Multi-warehouse PR 4b: a shipment per warehouse — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Label creation produces one shipment per contributing warehouse, each shipping from its own address with its own parcel contents, and an order whose parcels are only partly shipped reports `fulfillment_status = 'partial'`.
+
+**Architecture:** `ShipmentsHandler.Create` groups the order's `order_allocations` by warehouse and creates a shipment per group. An order with **no** allocations — every order placed before PR 3, and every order on a store with no warehouse — takes the existing single-shipment path unchanged.
+
+**Tech Stack:** Go 1.26, Gin, GORM, PostgreSQL 15, testify.
+
+**Spec:** `docs/superpowers/specs/2026-08-31-multi-warehouse-allocation-design.md` (see "Fulfilment")
+
+## Global Constraints
+
+- Work in the worktree `.claude/worktrees/177-fulfilment-4b`, branch `feat/177-shipment-per-warehouse`. Never switch the main checkout's branch.
+- Run every Go command from `services/marketplace-api`, never path-scoped, always `-count=1`: `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./... -count=1`.
+- Integration tests: `//go:build integration`, gated on `TEST_DATABASE_URL` (**never** `TEST_DB_DSN`), run with `-p 1`. A skip prints `ok` and reads like a pass — name the DSN and the duration in every claim.
+- Verified DSN: `postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable` (container `dev-postgres-1`; the LAN IP, not localhost).
+- Commits: conventional, single line, no signature, no `Co-Authored-By`, no emoji. Stage explicit paths; never `git add -A`.
+- Every guard added must be mutation-tested.
+- Never mutate an input.
+
+## The facts this plan is built on
+
+Verified in the code and against production. Do not re-derive; do not contradict without saying so.
+
+**1. Every existing order has ZERO allocations.** `order_allocations` is empty in production. Allocation only began with PR 3 (deployed today), and no order has been placed since. So the no-allocations path is the only one that currently executes, and a regression there breaks label creation for every real order — including `the-bondi-store`'s seven.
+
+**2. `Create` currently makes one shipment for the whole order.** `CreateShipmentRequest` is `{provider, service}`; parcel contents come from all of the order's items; the pickup address comes from the carrier config's warehouse via `resolvePickupAddress`.
+
+**3. The dispatched-email path is already per-shipment and deduped.** `dispatchShipmentDispatchedEmail` gates on `shipments.dispatched_email_sent_at IS NULL`, so N shipments send N emails without extra work. Only the copy does not name which parcel, and that template lives outside this service — out of scope here.
+
+**4. `fulfillment_status` already permits `'partial'`.** The CHECK allows `unfulfilled | partial | fulfilled` and `internal/order/status.go` defines the value with a legal `unfulfilled → partial → fulfilled` transition. It has simply never been written.
+
+**5. Carrier calls are external and not transactional.** A label that succeeds cannot be rolled back. The design consequence is in Task 1: create shipments group by group, persisting each as it succeeds, so a later failure leaves the earlier parcels intact and retryable rather than orphaning a label at the carrier.
+
+---
+
+## File Structure
+
+- **Modify** `services/marketplace-api/internal/handlers/admin/shipments.go` — group by warehouse, one shipment per group
+- **Create** `services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go`
+- **Modify** `services/marketplace-api/internal/order/service.go` — a `MarkPartiallyFulfilled` transition
+- **Create** `services/marketplace-api/internal/order/partial_fulfilment_integration_test.go`
+
+---
+
+### Task 1: One shipment per warehouse group
+
+**Files:**
+- Modify: `services/marketplace-api/internal/handlers/admin/shipments.go`
+- Test: `services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go`
+
+**Interfaces:**
+- Consumes: `order_allocations` (PR 1 schema, written by PR 3), `warehouse.Repository.ByID`.
+- Produces: one `shipments` row per contributing warehouse with `warehouse_id` set, and `order_allocations.shipment_id` stamped. Task 2 reads those rows to decide `partial` versus `fulfilled`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go`.
+
+The load-bearing case is the FIRST one. Every order in production has no allocations, so if that path changes, label creation breaks for all of them.
+
+```go
+//go:build integration
+
+// Package admin — coverage for creating one shipment per contributing
+// warehouse (#177 PR 4b).
+//
+// An order with NO allocations must behave exactly as it did before this
+// change: one shipment, pickup from the carrier config's warehouse. That is
+// not a fallback for tidiness — order_allocations is empty in production, so
+// it is the only path that currently runs.
+package admin
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// groupsForOrder returns (warehouse_id, quantity) per allocation group,
+// ordered for stable assertions.
+func groupsForOrder(t *testing.T, db *gorm.DB, orderID string) []struct {
+	WarehouseID string
+	Quantity    int
+	ShipmentID  *string
+} {
+	t.Helper()
+	var rows []struct {
+		WarehouseID string
+		Quantity    int
+		ShipmentID  *string
+	}
+	require.NoError(t, db.Raw(
+		`SELECT warehouse_id, sum(quantity) AS quantity, max(shipment_id::text) AS shipment_id
+		   FROM order_allocations WHERE order_id = ?
+		  GROUP BY warehouse_id ORDER BY warehouse_id`, orderID).Scan(&rows).Error)
+	return rows
+}
+
+func shipmentsForOrder(t *testing.T, db *gorm.DB, orderID string) []struct {
+	ID          string
+	WarehouseID *string
+} {
+	t.Helper()
+	var rows []struct {
+		ID          string
+		WarehouseID *string
+	}
+	require.NoError(t, db.Raw(
+		`SELECT id, warehouse_id::text AS warehouse_id FROM shipments
+		  WHERE order_id = ? ORDER BY created_at, id`, orderID).Scan(&rows).Error)
+	return rows
+}
+```
+
+**The remaining test bodies need the package's existing shipment-test harness** — a router, a fake carrier, and a seeded carrier config. Find it: `grep -rn "func setup.*Shipment\|fakeCarrier\|stubCarrier" internal/handlers/admin/*_test.go`. Reuse that harness rather than building a second one; the carrier must be a stub, because a real carrier call cannot run in a test.
+
+Write these four tests against that harness:
+
+1. `TestCreateShipment_OrderWithNoAllocationsCreatesOneShipmentAsBefore` — seed an order with items and NO `order_allocations`; create a shipment; assert exactly one `shipments` row, and that its `warehouse_id` is NULL (there was no allocation to attribute it to). This is the production path.
+2. `TestCreateShipment_OneAllocationGroupCreatesOneShipmentWithItsWarehouse` — one warehouse, allocations present; assert one shipment with `warehouse_id` set to that warehouse, and the allocation rows stamped with that shipment's id.
+3. `TestCreateShipment_TwoAllocationGroupsCreateTwoShipments` — two warehouses; assert two shipments, each carrying its own `warehouse_id`, and each group's allocation rows stamped with the matching shipment. Assert the two shipments have DIFFERENT `ship_from` addresses, since shipping from the wrong warehouse is the failure this feature exists to prevent.
+4. `TestCreateShipment_AlreadyShippedGroupIsNotShippedTwice` — run creation twice; assert the second run adds no shipment for a group whose allocations already carry a `shipment_id`. This is what makes retry-after-partial-failure safe.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration ./internal/handlers/admin/... -run TestCreateShipment_ -count=1 -p 1
+```
+
+Expected: the three allocation-aware tests FAIL (one shipment created, no `warehouse_id`); the no-allocations test PASSES already, because that behaviour is what exists today. A test that passes before the change is fine here — it is a regression guard, and Step 5 mutation-tests it.
+
+- [ ] **Step 3: Group by warehouse in `Create`**
+
+In `internal/handlers/admin/shipments.go`, after the order, address, items and carrier config are loaded and the carrier is instantiated:
+
+1. Load the unshipped allocation groups:
+
+```go
+// Groups this order still owes a parcel for. An order with none — every
+// order placed before allocation shipped, and every order on a store with
+// no warehouse — takes the single-shipment path below, unchanged.
+type allocationGroup struct {
+	WarehouseID string
+	ItemIDs     []string
+	Quantities  map[string]int
+}
+groups, err := h.unshippedAllocationGroups(ctx, orderID)
+if err != nil {
+	RespondErr(c, err, h.logger)
+	return
+}
+```
+
+  `unshippedAllocationGroups` reads
+  `SELECT warehouse_id, order_item_id, quantity FROM order_allocations WHERE order_id = ? AND shipment_id IS NULL ORDER BY warehouse_id, order_item_id`
+  and folds it into one group per warehouse. Ordering by `warehouse_id` makes the parcel sequence deterministic — two runs on the same order must produce the same parcels in the same order.
+
+2. When `len(groups) == 0`, run the existing body exactly as it is today. Extract it into a helper (`createSingleShipment`) by MOVING it verbatim rather than rewriting, so the production path is provably unchanged.
+
+3. When there are groups, loop. For each group:
+   - resolve the pickup address from **that group's warehouse** (`h.warehouseRepo.ByID`), not from the carrier config
+   - build `parcelItems` from **that group's** allocations — the order items it names, at the allocated quantities, not the whole order
+   - call the carrier, persist the `shipments` row with `WarehouseID` set
+   - stamp `order_allocations.shipment_id` for that group's rows
+   - fire `dispatchShipmentDispatchedEmail` for that shipment
+
+4. **A carrier failure part-way through must not undo earlier parcels.** Persist each shipment as it succeeds. On failure, respond with what was created and what failed, and leave the remaining groups unshipped so a retry picks them up:
+
+```go
+	if err != nil {
+		// The label already created for an earlier group cannot be
+		// un-created at the carrier, so it stays. The failed group keeps
+		// shipment_id NULL and a retry will pick up exactly the groups
+		// still owing a parcel.
+		if h.logger != nil {
+			h.logger.Error("shipments: carrier create failed for group",
+				"order_id", orderID.String(), "warehouse_id", g.WarehouseID,
+				"created", len(created), "err", err.Error())
+		}
+		c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{
+			"error":   "carrier_create_failed",
+			"message": err.Error(),
+			"created": len(created),
+		})
+		return
+	}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration ./internal/handlers/admin/... -run TestCreateShipment_ -count=1 -p 1 -v
+```
+
+Expected: all four PASS.
+
+- [ ] **Step 5: Mutation-test the no-allocations guard**
+
+Remove the `len(groups) == 0` branch so every order takes the grouping path, re-run.
+
+Expected: FAIL — `TestCreateShipment_OrderWithNoAllocationsCreatesOneShipmentAsBefore` produces no shipment at all, because an order with no allocations has no groups to loop over. That failure is the production regression this guard exists to prevent. Restore and confirm green.
+
+- [ ] **Step 6: Mutation-test the already-shipped filter**
+
+Drop `AND shipment_id IS NULL` from the group query, re-run.
+
+Expected: FAIL — `TestCreateShipment_AlreadyShippedGroupIsNotShippedTwice` creates a duplicate parcel for an already-shipped group. Restore and confirm green.
+
+- [ ] **Step 7: Verify and commit**
+
+```bash
+cd services/marketplace-api
+go build ./... && go vet ./... && go vet -tags=integration ./... && gofmt -l .
+go test ./... -count=1
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/handlers/admin/... ./internal/shipping/... ./internal/order/...
+```
+
+```bash
+git add services/marketplace-api/internal/handlers/admin/shipments.go \
+        services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go
+git commit -m "feat(shipping): create one shipment per contributing warehouse (#177)"
+```
+
+---
+
+### Task 2: `partial` fulfilment status
+
+**Files:**
+- Modify: `services/marketplace-api/internal/order/service.go`
+- Modify: `services/marketplace-api/internal/handlers/admin/shipments.go`
+- Test: `services/marketplace-api/internal/order/partial_fulfilment_integration_test.go`
+
+**Interfaces:**
+- Consumes: the shipments Task 1 creates, and `order_allocations.shipment_id`.
+- Produces: `Service.MarkPartiallyFulfilled(ctx, tx, orderID) error`, and shipment creation choosing between it and the existing `MarkFulfilled`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `services/marketplace-api/internal/order/partial_fulfilment_integration_test.go` with tests that:
+
+1. `TestMarkPartiallyFulfilled_SetsPartial` — an `unfulfilled` order transitions to `partial`.
+2. `TestMarkPartiallyFulfilled_RefusesFromFulfilled` — `fulfilled → partial` is not a legal transition and must return an invalid-transition error, not silently downgrade a completed order.
+3. `TestMarkPartiallyFulfilled_IsIdempotent` — calling it twice on an already-`partial` order does not error.
+
+Model these on the existing `MarkFulfilled` tests — find them with `grep -rn "MarkFulfilled" internal/order/*_test.go` and follow their fixture and transaction shape exactly.
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration ./internal/order/... -run TestMarkPartiallyFulfilled -count=1 -p 1
+```
+
+Expected: FAIL to compile — `MarkPartiallyFulfilled` undefined.
+
+- [ ] **Step 3: Add the transition**
+
+In `internal/order/service.go`, add `MarkPartiallyFulfilled` modelled on `MarkFulfilled` directly above or below it. It must use the same `CanTransitionTo` guard, the same repository update, and emit the same kind of status-change event with `To: string(FulfillmentStatusPartial)`. Do not copy `MarkFulfilled`'s `orders.status` change — `partial` moves only `fulfillment_status`; the order is not fulfilled.
+
+- [ ] **Step 4: Call it from shipment creation**
+
+In `shipments.go`, after the groups have been shipped, decide which transition to make:
+
+```go
+// An order is fulfilled only when every group it owes a parcel for has
+// one. While any allocation still has a NULL shipment_id, the order is
+// partially shipped — a status the schema and the transition table have
+// always allowed but nothing has ever written.
+remaining, err := h.unshippedAllocationCount(ctx, orderID)
+```
+
+  Zero remaining → the existing `MarkFulfilled` call. More than zero → `MarkPartiallyFulfilled`. An order with no allocations at all keeps whatever the single-shipment path does today — do not change it.
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+cd services/marketplace-api
+TEST_DATABASE_URL='postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable' \
+  go test -tags=integration -p 1 -count=1 ./internal/order/... ./internal/handlers/admin/...
+```
+
+Expected: all `ok`.
+
+- [ ] **Step 6: Mutation-test the remaining-groups check**
+
+Make the decision always call `MarkFulfilled`, re-run.
+
+Expected: FAIL — a two-group order with one parcel shipped reports `fulfilled`, which would tell a customer their order is complete while a parcel has not been created. Restore and confirm green.
+
+- [ ] **Step 7: Verify and commit**
+
+```bash
+cd services/marketplace-api
+go build ./... && go vet ./... && go vet -tags=integration ./... && gofmt -l .
+go test ./... -count=1
+```
+
+```bash
+git add services/marketplace-api/internal/order/service.go \
+        services/marketplace-api/internal/order/partial_fulfilment_integration_test.go \
+        services/marketplace-api/internal/handlers/admin/shipments.go
+git commit -m "feat(orders): report partial fulfilment while an order still owes a parcel (#177)"
+```
+
+---
+
+## Done when
+
+- `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `gofmt -l .` clean
+- `go test ./... -count=1` green
+- `internal/handlers/admin`, `internal/order`, `internal/shipping` integration packages green against the real DSN, with durations that prove they ran
+- Three guards mutation-tested: the no-allocations branch, the already-shipped filter, and the remaining-groups check
+
+## Explicitly NOT in this PR
+
+- **Cancel narrowing.** Cancelling an order must eventually only cover groups that have not shipped. It touches order-cancel semantics and refund-adjacent code and deserves its own review.
+- **Naming the parcel in the dispatched email.** `dispatchShipmentDispatchedEmail` is already per-shipment and deduped on `dispatched_email_sent_at`, so N parcels already send N emails correctly; only the copy is generic, and that template lives outside this service.
+- Warehouse CRUD and per-location stock editing (PR 5)
+- The sentinel backfill (PR 6)
+- Any change to `commitStockAtSentinel` or the allocation path itself

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -807,7 +807,8 @@ func main() {
 		shipmentsHandler := admin.NewShipmentsHandler(conn, shippingService, shippingRepo, orderDocSvc, log).
 			WithEncryptor(apiKeyEncryptor).
 			WithSecretStore(carrierSecretStore).
-			WithLabelMailer(labelMailer)
+			WithLabelMailer(labelMailer).
+			WithOrderService(orderSvc)
 
 		// Shipment-cancel executor — resolves + executes the carrier action
 		// when an order is fully refunded or cancelled. Reuses the shipments

--- a/services/marketplace-api/internal/handlers/admin/shipments.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments.go
@@ -1156,7 +1156,11 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 	// Route it into the first group's parcel instead — the
 	// highest-priority warehouse (unshippedAllocationGroups orders
 	// deterministically by warehouse_id), which is also where a
-	// single-warehouse store ships everything from anyway.
+	// single-warehouse store ships everything from anyway. That routing
+	// is only ever applied once per order — see isFirstShipmentOverall
+	// below, computed from the order's existing shipments rows rather
+	// than the group's position in this call's (remaining-only) groups
+	// slice, so a retry after a partial failure can't ship it twice.
 	allocatedItemIDs := make(map[string]bool, len(items))
 	for _, g := range groups {
 		for _, itemID := range g.ItemIDs {
@@ -1170,6 +1174,31 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 			unallocatedItemIDs = append(unallocatedItemIDs, id)
 		}
 	}
+
+	// Whether the unallocated items should ride along is decided ONCE,
+	// before the loop, off durable state — not off gi==0 inside the loop.
+	// gi is only an index into `groups`, and groups comes from
+	// unshippedAllocationGroups, which is recomputed REMAINING-only on
+	// every call: it folds in only allocations still missing a
+	// shipment_id. So gi==0 means "first group THIS call", not "first
+	// group ever" — after a partial failure (group A ships, group B's
+	// carrier call fails and the handler returns), a retry recomputes
+	// groups as [B] alone, B is now gi==0, and the variantless items
+	// would be appended to B's parcel too, shipping them a second time
+	// with no allocation row to have caught it. Counting this order's
+	// existing shipments rows instead is stable across retries: it is
+	// zero only on the order's actual first shipment overall, and stays
+	// nonzero afterwards regardless of which warehouse group failed or
+	// how many times the endpoint is retried.
+	var existingShipmentCount int64
+	if err := h.db.WithContext(ctx).
+		Table("shipments").
+		Where("order_id = ?", orderID).
+		Count(&existingShipmentCount).Error; err != nil {
+		RespondErr(c, fmt.Errorf("shipments: count existing shipments: %w", err), h.logger)
+		return
+	}
+	isFirstShipmentOverall := existingShipmentCount == 0
 
 	const defaultWeightGramsPerUnit = 500
 	storeUUID, _ := uuid.Parse(storeID)
@@ -1247,12 +1276,15 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 
 		// Build parcel items from THIS group's allocations — the order
 		// items it names, at the allocated quantities, not the whole
-		// order — plus, on the first group only, any order item no
-		// allocation covers at all (variantless/unstocked lines; see the
-		// unallocatedItemIDs comment above). Those ship at their full
-		// order quantity since no allocation split them.
+		// order — plus, on the order's first group ever, any order item
+		// no allocation covers at all (variantless/unstocked lines; see
+		// the unallocatedItemIDs comment above). Those ship at their full
+		// order quantity since no allocation split them. Gated on
+		// isFirstShipmentOverall (existing shipments rows == 0), NOT on
+		// gi == 0 — see the comment above that computation for why a
+		// positional index isn't safe across retries.
 		groupItemIDs := g.ItemIDs
-		if gi == 0 && len(unallocatedItemIDs) > 0 {
+		if gi == 0 && isFirstShipmentOverall && len(unallocatedItemIDs) > 0 {
 			groupItemIDs = append(append([]string{}, g.ItemIDs...), unallocatedItemIDs...)
 		}
 		parcelItems := make([]shipping.ParcelItem, 0, len(groupItemIDs))

--- a/services/marketplace-api/internal/handlers/admin/shipments.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments.go
@@ -79,6 +79,12 @@ type ShipmentsHandler struct {
 	// is deliberately scoped to that loop, so overloading it would blur a
 	// boundary its own doc comment draws.
 	newCarrier func(provider, apiKey, secretKey, mode string) (shipping.Carrier, error)
+	// orderSvc, when non-nil, lets createShipmentsPerWarehouse report
+	// order.fulfillment_status after shipping a batch of groups: fulfilled
+	// when nothing remains unshipped, partial when at least one group
+	// still owes a parcel. Nil-safe (skipped) so tests that don't wire an
+	// order service keep working — see WithOrderService.
+	orderSvc *order.Service
 }
 
 // NewShipmentsHandler constructs a ShipmentsHandler. docMailer is
@@ -127,6 +133,16 @@ func (h *ShipmentsHandler) WithLabelMailer(m LabelMailer) *ShipmentsHandler {
 // cancel endpoint. Chainable, nil-safe by omission.
 func (h *ShipmentsHandler) WithCanceller(e *shipmentcancel.Executor) *ShipmentsHandler {
 	h.canceller = e
+	return h
+}
+
+// WithOrderService attaches the order service so createShipmentsPerWarehouse
+// can report order.fulfillment_status after shipping a batch of groups.
+// Optional — without it, this behaviour is skipped (see orderSvc's doc
+// comment), matching the single-shipment path, which has never reported
+// fulfilment status automatically.
+func (h *ShipmentsHandler) WithOrderService(s *order.Service) *ShipmentsHandler {
+	h.orderSvc = s
 	return h
 }
 
@@ -1420,6 +1436,39 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 				"created": len(created),
 			})
 			return
+		}
+
+		// An order is fulfilled only when every group it owes a parcel for
+		// has one. While any allocation still has a NULL shipment_id, the
+		// order is partially shipped — a status the schema and the
+		// transition table have always allowed but nothing has ever
+		// written. Recomputed after EVERY group, not once after the whole
+		// loop: a later group in this same call can still fail and abort
+		// the request (see the carrier-call and persist-failure aborts
+		// above), and the parcel that DID ship a moment ago is real and
+		// un-cancellable — the order must reflect that even if the
+		// response comes back non-2xx.
+		//
+		// Best-effort: a failure recomputing or writing fulfilment status
+		// must not turn an already-real shipment into a 5xx for the admin.
+		// The order is left for a later read (or a retry Create()) to
+		// reconcile.
+		if remaining, err := h.unshippedAllocationGroups(ctx, orderID); err != nil {
+			if h.logger != nil {
+				h.logger.Error("shipments: recount remaining allocation groups failed",
+					"order_id", orderID.String(), "err", err)
+			}
+		} else if h.orderSvc != nil {
+			var fulfilErr error
+			if len(remaining) == 0 {
+				fulfilErr = h.orderSvc.MarkFulfilled(ctx, nil, orderID)
+			} else {
+				fulfilErr = h.orderSvc.MarkPartiallyFulfilled(ctx, nil, orderID)
+			}
+			if fulfilErr != nil && h.logger != nil {
+				h.logger.Error("shipments: report order fulfilment status failed",
+					"order_id", orderID.String(), "remaining_groups", len(remaining), "err", fulfilErr)
+			}
 		}
 
 		// Auto-schedule a pickup for THIS group's warehouse — mirrors

--- a/services/marketplace-api/internal/handlers/admin/shipments.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments.go
@@ -551,24 +551,63 @@ func (h *ShipmentsHandler) Create(c *gin.Context) {
 		return
 	}
 
-	// Groups this order still owes a parcel for. An order with none — every
-	// order placed before allocation shipped, and every order on a store with
-	// no warehouse — takes the single-shipment path below, unchanged. That is
-	// not a fallback for tidiness: order_allocations is empty in production
+	// Routing is a three-state decision, not two. Conflating "no
+	// allocations at all" with "every allocation already shipped" into a
+	// single len(groups)==0 check would route a re-POST on a fully-shipped
+	// order into createSingleShipment, which ignores order_allocations
+	// entirely and would buy a second, real, un-cancellable label for
+	// goods that already shipped.
+	totalAllocations, err := h.totalAllocationsForOrder(ctx, orderID)
+	if err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+
+	// An order with NO allocations at all — every order placed before
+	// allocation shipped, and every order on a store with no warehouse —
+	// takes the single-shipment path below, unchanged. That is not a
+	// fallback for tidiness: order_allocations is empty in production
 	// today (#177 PR 3 only just started writing it), so this IS the only
 	// path currently executing for a real order.
+	if totalAllocations == 0 {
+		h.createSingleShipment(c, ctx, orderID, storeID, tenantID, o, shippingAddr, items, provider, req, carrierCfg)
+		return
+	}
+
 	groups, err := h.unshippedAllocationGroups(ctx, orderID)
 	if err != nil {
 		RespondErr(c, err, h.logger)
 		return
 	}
 
+	// Allocations exist but every one is already stamped with a
+	// shipment_id: this order is fully shipped and a re-POST is a no-op,
+	// not a request for another shipment.
 	if len(groups) == 0 {
-		h.createSingleShipment(c, ctx, orderID, storeID, tenantID, o, shippingAddr, items, provider, req, carrierCfg)
+		c.AbortWithStatusJSON(http.StatusConflict, gin.H{
+			"error":   "already_shipped",
+			"message": "every allocation for this order already has a shipment; nothing to create",
+		})
 		return
 	}
 
 	h.createShipmentsPerWarehouse(c, ctx, orderID, storeID, tenantID, o, shippingAddr, items, provider, req, carrierCfg, groups)
+}
+
+// totalAllocationsForOrder counts every order_allocations row for orderID,
+// shipped or not. Distinct from unshippedAllocationGroups's count: this is
+// what tells Create() whether the order has ANY allocations at all (the
+// legacy no-allocations path) versus allocations that are all already
+// shipped (a no-op re-POST, not a fresh single-shipment order).
+func (h *ShipmentsHandler) totalAllocationsForOrder(ctx context.Context, orderID uuid.UUID) (int64, error) {
+	var total int64
+	if err := h.db.WithContext(ctx).
+		Table("order_allocations").
+		Where("order_id = ?", orderID).
+		Count(&total).Error; err != nil {
+		return 0, fmt.Errorf("shipments: count allocations: %w", err)
+	}
+	return total, nil
 }
 
 // allocationGroup is one warehouse's still-unshipped share of an order:
@@ -960,7 +999,7 @@ func (h *ShipmentsHandler) createSingleShipment(
 	var pickupWarning string
 	if carrierCfg.AutoSchedulePickup {
 		if ps, ok := carrier.(shipping.PickupScheduler); ok {
-			pickupWarning = h.tryAutoSchedulePickup(ctx, rec, ps, carrierCfg)
+			pickupWarning = h.tryAutoSchedulePickup(ctx, rec, ps, carrierCfg, pickup.Name)
 		}
 	}
 
@@ -1095,6 +1134,7 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 	tenantUUID, _ := uuid.Parse(tenantID)
 
 	created := make([]*shipping.ShipmentRecord, 0, len(groups))
+	pickupWarnings := make([]string, 0, len(groups))
 	for _, g := range groups {
 		wh, err := h.warehouseRepo.ByID(ctx, h.db, g.WarehouseID)
 		if err != nil {
@@ -1105,6 +1145,22 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 			c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{
 				"error":   "warehouse_not_found",
 				"message": fmt.Sprintf("warehouse %s referenced by this order's allocation no longer exists", g.WarehouseID),
+				"created": len(created),
+			})
+			return
+		}
+		whID, err := uuid.Parse(wh.ID)
+		if err != nil {
+			// wh.ID comes straight out of the warehouses table's uuid
+			// primary key, so a parse failure here means data corruption,
+			// not a bad request — 500, not a panic via MustParse.
+			if h.logger != nil {
+				h.logger.Error("shipments: warehouse row has a malformed id",
+					"order_id", orderID.String(), "warehouse_id", wh.ID, "err", err)
+			}
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error":   "malformed_warehouse_id",
+				"message": err.Error(),
 				"created": len(created),
 			})
 			return
@@ -1120,6 +1176,19 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 			Phone:         wh.Phone,
 			ContactPerson: wh.ContactPerson,
 			Email:         wh.Email,
+		}
+
+		// Same validation createSingleShipment applies to the carrier
+		// config's warehouse — a half-filled warehouse must fail here
+		// with a clear message, not be sent to the carrier and come back
+		// as an opaque 502.
+		if pickup.Line1 == "" || pickup.City == "" || pickup.CountryCode == "" {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+				"error":   "warehouse_address_incomplete",
+				"message": fmt.Sprintf("warehouse %q's address is not fully configured", pickup.Name),
+				"created": len(created),
+			})
+			return
 		}
 
 		fromAddress := shipping.Address{
@@ -1170,7 +1239,24 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 			}
 			parcelItems = append(parcelItems, p)
 		}
+		if len(parcelItems) == 0 {
+			// Every itemID this group named was missing from the order's
+			// own items — an allocation/order_items data mismatch. Sending
+			// a zero-item parcel to a real carrier is worse than refusing:
+			// carriers accept it as a valid, empty, billable shipment.
+			if h.logger != nil {
+				h.logger.Error("shipments: allocation group named no resolvable order items",
+					"order_id", orderID.String(), "warehouse_id", g.WarehouseID)
+			}
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error":   "empty_parcel",
+				"message": fmt.Sprintf("warehouse %q's allocation names no items on this order", pickup.Name),
+				"created": len(created),
+			})
+			return
+		}
 
+		// Call the carrier to create shipment.
 		shipment, err := h.svc.CreateShipment(
 			ctx,
 			orderID.String(),
@@ -1181,6 +1267,52 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 			o.CurrencyCode,
 			carrier,
 		)
+		// Self-heal: same as createSingleShipment — Delhivery rejects a
+		// label when its pickup location isn't registered on the
+		// carrier's side. Secondary warehouses are exactly the ones most
+		// likely to have never been registered, so this is the FIRST
+		// thing a real multi-warehouse label attempt is likely to hit.
+		// Without this, the original #177 failure reappears inside the
+		// feature meant to fix it.
+		var whErr *shipping.WarehouseNotRegisteredError
+		if errors.As(err, &whErr) {
+			if syncer, ok := carrier.(shipping.WarehouseSyncer); ok {
+				whEmail := pickupEmailOrBuyerFallback(pickup, o.CustomerEmail)
+				carrierWh := shipping.Warehouse{
+					Name:          pickup.Name,
+					Phone:         pickup.Phone,
+					Email:         whEmail,
+					Address:       strings.TrimSpace(pickup.Line1 + " " + pickup.Line2),
+					City:          pickup.City,
+					PinCode:       pickup.PostalCode,
+					CountryCode:   pickup.CountryCode,
+					Region:        pickup.Region,
+					ContactPerson: pickup.ContactPerson,
+				}
+				if regErr := syncer.UpsertWarehouse(ctx, carrierWh); regErr != nil {
+					if h.logger != nil {
+						h.logger.Error("shipments: warehouse auto-register failed for group",
+							"order_id", orderID.String(), "provider", provider,
+							"warehouse", pickup.Name, "err", regErr.Error())
+					}
+					c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{
+						"error":   "warehouse_register_failed",
+						"message": "Couldn't register your pickup location with " + provider + ": " + regErr.Error(),
+						"created": len(created),
+					})
+					return
+				}
+				if h.logger != nil {
+					h.logger.Info("shipments: warehouse auto-registered, retrying label for group",
+						"order_id", orderID.String(), "provider", provider,
+						"warehouse", pickup.Name)
+				}
+				shipment, err = h.svc.CreateShipment(
+					ctx, orderID.String(), fromAddress, toAddress,
+					parcelItems, req.Service, o.CurrencyCode, carrier,
+				)
+			}
+		}
 		if err != nil {
 			// The label already created for an earlier group cannot be
 			// un-created at the carrier, so it stays. The failed group
@@ -1210,7 +1342,6 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 			"phone":        pickup.Phone,
 		})
 
-		whID := uuid.MustParse(wh.ID)
 		rec := &shipping.ShipmentRecord{
 			TenantID:          tenantUUID,
 			StoreID:           storeUUID,
@@ -1243,31 +1374,87 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 			})
 			return
 		}
+		// From here on the shipment row (and its real carrier label) is
+		// persisted, so it counts toward "created" for every remaining
+		// error path in this iteration — a stamp failure below does not
+		// undo the label that already exists.
+		created = append(created, rec)
+
+		// Some carriers (Delhivery) gate the label PDF behind an
+		// Authorization header, so the browser can't deep-link directly
+		// to the provider's packing-slip URL. Same proxy URL
+		// createSingleShipment sets — without it a label exists at the
+		// carrier that the admin UI cannot print.
+		if rec.LabelURL == "" {
+			if _, ok := carrier.(shipping.LabelFetcher); ok {
+				rec.LabelURL = fmt.Sprintf("/api/v1/admin/stores/%s/orders/%s/shipments/%s/label",
+					storeID, orderID.String(), rec.ID.String())
+				if err := h.db.WithContext(ctx).
+					Table("shipments").
+					Where("id = ?", rec.ID).
+					Update("label_url", rec.LabelURL).Error; err != nil && h.logger != nil {
+					h.logger.Warn("shipments: persist label_url failed",
+						"shipment_id", rec.ID, "err", err)
+				}
+			}
+		}
 
 		// Stamp this group's allocation rows with the shipment that just
 		// covered them, so a retry does not re-ship an already-shipped
-		// group.
+		// group. This write is what idempotency rests on: if it fails,
+		// the group looks unshipped to the next Create() call even
+		// though a real, un-cancellable label now exists for it — so a
+		// failure here must fail the response, not just log.
 		if err := h.db.WithContext(ctx).
 			Table("order_allocations").
 			Where("order_id = ? AND warehouse_id = ? AND shipment_id IS NULL", orderID, g.WarehouseID).
-			Update("shipment_id", rec.ID).Error; err != nil && h.logger != nil {
-			h.logger.Error("shipments: stamp allocation shipment_id failed",
-				"order_id", orderID.String(), "warehouse_id", g.WarehouseID,
-				"shipment_id", rec.ID.String(), "err", err)
+			Update("shipment_id", rec.ID).Error; err != nil {
+			if h.logger != nil {
+				h.logger.Error("shipments: stamp allocation shipment_id failed — label exists but allocation not marked shipped",
+					"order_id", orderID.String(), "warehouse_id", g.WarehouseID,
+					"shipment_id", rec.ID.String(), "err", err)
+			}
+			c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{
+				"error":   "allocation_stamp_failed",
+				"message": fmt.Sprintf("shipment %s was created but its allocation could not be marked shipped: %s", rec.ID.String(), err.Error()),
+				"created": len(created),
+			})
+			return
 		}
+
+		// Auto-schedule a pickup for THIS group's warehouse — mirrors
+		// createSingleShipment, but keyed on the group's own pickup name
+		// rather than the carrier config's, since each group can ship
+		// from a different warehouse.
+		var pickupWarning string
+		if carrierCfg.AutoSchedulePickup {
+			if ps, ok := carrier.(shipping.PickupScheduler); ok {
+				pickupWarning = h.tryAutoSchedulePickup(ctx, rec, ps, carrierCfg, pickup.Name)
+			}
+		}
+		pickupWarnings = append(pickupWarnings, pickupWarning)
 
 		h.appendShipmentEvent(ctx, orderID, rec, order.EventKindShipmentCreated,
 			"Shipping label created — package will be picked up shortly.")
-		h.dispatchShipmentDispatchedEmail(orderID, rec)
-
-		created = append(created, rec)
+		// Deliberately NOT dispatchShipmentDispatchedEmail here: that
+		// email means "your order has shipped" and the single-shipment
+		// path only ever fires it on the in_transit transition (manual
+		// status update or the tracking-sync loop), not at label
+		// creation. Firing it here would email the customer at label
+		// creation — days before pickup — for every group, then nothing
+		// when the parcels actually ship. The existing in_transit
+		// trigger already dedups per shipment id and needs no change.
 	}
 
-	resp := make([]ShipmentResponse, 0, len(created))
-	for _, rec := range created {
-		resp = append(resp, toShipmentResponse(rec))
-	}
-	c.JSON(http.StatusCreated, gin.H{"shipments": resp})
+	// The admin client (apps/admin/lib/api/shipping-api.ts) types this
+	// endpoint's response as a single ShipmentResponse, matching
+	// createSingleShipment's shape — not an array. Returning the first
+	// created shipment here keeps that contract intact without touching
+	// the frontend; a later PR can teach the client (and this response)
+	// about multiple shipments per order.
+	resp := toShipmentResponse(created[0])
+	resp.PickupWarning = pickupWarnings[0]
+	c.JSON(http.StatusCreated, resp)
 }
 
 // tryAutoSchedulePickup calls SchedulePickup with the next-business-day
@@ -1283,11 +1470,8 @@ func (h *ShipmentsHandler) tryAutoSchedulePickup(
 	rec *shipping.ShipmentRecord,
 	ps shipping.PickupScheduler,
 	cfg *shipping.CarrierConfig,
+	warehouseName string,
 ) string {
-	// #484: WarehouseName used to come straight off cfg's legacy column;
-	// it now goes through the same warehouses-row resolution as the rest
-	// of this file.
-	warehouseName := h.resolvePickupAddress(ctx, cfg).Name
 	slot := strings.TrimSpace(cfg.DefaultPickupSlotStart)
 	if slot == "" {
 		slot = "14:00:00"

--- a/services/marketplace-api/internal/handlers/admin/shipments.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments.go
@@ -1450,24 +1450,41 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 		// response comes back non-2xx.
 		//
 		// Best-effort: a failure recomputing or writing fulfilment status
-		// must not turn an already-real shipment into a 5xx for the admin.
-		// The order is left for a later read (or a retry Create()) to
-		// reconcile.
-		if remaining, err := h.unshippedAllocationGroups(ctx, orderID); err != nil {
-			if h.logger != nil {
-				h.logger.Error("shipments: recount remaining allocation groups failed",
-					"order_id", orderID.String(), "err", err)
-			}
-		} else if h.orderSvc != nil {
-			var fulfilErr error
-			if len(remaining) == 0 {
-				fulfilErr = h.orderSvc.MarkFulfilled(ctx, nil, orderID)
+		// must not turn an already-real shipment into a 5xx for the admin —
+		// the carrier label already exists and is un-cancellable. But it
+		// must not be swallowed either: an order stuck on `confirmed`-only
+		// transitions (MarkFulfilled/MarkPartiallyFulfilled both require
+		// specific order.status preconditions the way orders.Confirm does)
+		// can leave every parcel shipped while fulfillment_status silently
+		// never advances — e.g. a still-`pending` order, which the admin
+		// UI explicitly allows labelling. Surface that on the same
+		// pickup-warning channel the response already carries, alongside
+		// the log line, so the admin actually sees it.
+		var fulfilWarning string
+		if h.orderSvc != nil {
+			remaining, err := h.unshippedAllocationGroups(ctx, orderID)
+			if err != nil {
+				if h.logger != nil {
+					h.logger.Error("shipments: recount remaining allocation groups failed",
+						"order_id", orderID.String(), "err", err)
+				}
 			} else {
-				fulfilErr = h.orderSvc.MarkPartiallyFulfilled(ctx, nil, orderID)
-			}
-			if fulfilErr != nil && h.logger != nil {
-				h.logger.Error("shipments: report order fulfilment status failed",
-					"order_id", orderID.String(), "remaining_groups", len(remaining), "err", fulfilErr)
+				var fulfilErr error
+				var targetStatus string
+				if len(remaining) == 0 {
+					targetStatus = "fulfilled"
+					fulfilErr = h.orderSvc.MarkFulfilled(ctx, nil, orderID)
+				} else {
+					targetStatus = "partially fulfilled"
+					fulfilErr = h.orderSvc.MarkPartiallyFulfilled(ctx, nil, orderID)
+				}
+				if fulfilErr != nil {
+					if h.logger != nil {
+						h.logger.Error("shipments: report order fulfilment status failed",
+							"order_id", orderID.String(), "remaining_groups", len(remaining), "err", fulfilErr)
+					}
+					fulfilWarning = fmt.Sprintf("parcel shipped, but the order could not be marked %s: %s", targetStatus, fulfilErr.Error())
+				}
 			}
 		}
 
@@ -1479,6 +1496,13 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 		if carrierCfg.AutoSchedulePickup {
 			if ps, ok := carrier.(shipping.PickupScheduler); ok {
 				pickupWarning = h.tryAutoSchedulePickup(ctx, rec, ps, carrierCfg, pickup.Name)
+			}
+		}
+		if fulfilWarning != "" {
+			if pickupWarning != "" {
+				pickupWarning = pickupWarning + "; " + fulfilWarning
+			} else {
+				pickupWarning = fulfilWarning
 			}
 		}
 		pickupWarnings = append(pickupWarnings, pickupWarning)
@@ -1502,7 +1526,19 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 	// the frontend; a later PR can teach the client (and this response)
 	// about multiple shipments per order.
 	resp := toShipmentResponse(created[0])
-	resp.PickupWarning = pickupWarnings[0]
+	// Join every group's warning, not just the first shipment's: a
+	// fulfilment-status warning (see above) can land on ANY group in this
+	// batch, not necessarily the one whose shipment this response
+	// describes, and dropping it here would silently hide the one signal
+	// the admin gets that an order is stuck unable to report its true
+	// fulfilment state.
+	var warnings []string
+	for _, w := range pickupWarnings {
+		if w != "" {
+			warnings = append(warnings, w)
+		}
+	}
+	resp.PickupWarning = strings.Join(warnings, "; ")
 	c.JSON(http.StatusCreated, resp)
 }
 

--- a/services/marketplace-api/internal/handlers/admin/shipments.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments.go
@@ -1145,13 +1145,39 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 		itemsByID[it.ID.String()] = it
 	}
 
+	// stockLinesFromItems (checkout_stock.go) deliberately skips order
+	// items with a nil/empty variant_id when it computes allocations — a
+	// custom or otherwise unstocked line is a supported order shape, and
+	// refusing it there "would break every unstocked sale". That was
+	// harmless when the parcel was built from ALL of the order's items
+	// regardless of allocation. Now the parcel is built per warehouse
+	// group from allocations alone, so a variantless item never lands in
+	// any group's ItemIDs and would silently vanish from every shipment.
+	// Route it into the first group's parcel instead — the
+	// highest-priority warehouse (unshippedAllocationGroups orders
+	// deterministically by warehouse_id), which is also where a
+	// single-warehouse store ships everything from anyway.
+	allocatedItemIDs := make(map[string]bool, len(items))
+	for _, g := range groups {
+		for _, itemID := range g.ItemIDs {
+			allocatedItemIDs[itemID] = true
+		}
+	}
+	unallocatedItemIDs := make([]string, 0, len(items))
+	for _, it := range items {
+		id := it.ID.String()
+		if !allocatedItemIDs[id] {
+			unallocatedItemIDs = append(unallocatedItemIDs, id)
+		}
+	}
+
 	const defaultWeightGramsPerUnit = 500
 	storeUUID, _ := uuid.Parse(storeID)
 	tenantUUID, _ := uuid.Parse(tenantID)
 
 	created := make([]*shipping.ShipmentRecord, 0, len(groups))
 	pickupWarnings := make([]string, 0, len(groups))
-	for _, g := range groups {
+	for gi, g := range groups {
 		wh, err := h.warehouseRepo.ByID(ctx, h.db, g.WarehouseID)
 		if err != nil {
 			if h.logger != nil {
@@ -1219,19 +1245,30 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 			Email:       pickupEmailOrBuyerFallback(pickup, o.CustomerEmail),
 		}
 
-		// Build parcel items from THIS group's allocations only — the
-		// order items it names, at the allocated quantities, not the
-		// whole order.
-		parcelItems := make([]shipping.ParcelItem, 0, len(g.ItemIDs))
-		for _, itemID := range g.ItemIDs {
+		// Build parcel items from THIS group's allocations — the order
+		// items it names, at the allocated quantities, not the whole
+		// order — plus, on the first group only, any order item no
+		// allocation covers at all (variantless/unstocked lines; see the
+		// unallocatedItemIDs comment above). Those ship at their full
+		// order quantity since no allocation split them.
+		groupItemIDs := g.ItemIDs
+		if gi == 0 && len(unallocatedItemIDs) > 0 {
+			groupItemIDs = append(append([]string{}, g.ItemIDs...), unallocatedItemIDs...)
+		}
+		parcelItems := make([]shipping.ParcelItem, 0, len(groupItemIDs))
+		for _, itemID := range groupItemIDs {
 			it, ok := itemsByID[itemID]
 			if !ok {
 				continue
 			}
+			qty := g.Quantities[itemID]
+			if qty == 0 {
+				qty = it.Quantity
+			}
 			p := shipping.ParcelItem{
 				Title:       it.TitleSnapshot,
 				SKU:         it.SKUSnapshot,
-				Quantity:    g.Quantities[itemID],
+				Quantity:    qty,
 				WeightGrams: defaultWeightGramsPerUnit,
 			}
 			if it.VariantID != nil {
@@ -1452,14 +1489,14 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 		// Best-effort: a failure recomputing or writing fulfilment status
 		// must not turn an already-real shipment into a 5xx for the admin —
 		// the carrier label already exists and is un-cancellable. But it
-		// must not be swallowed either: an order stuck on `confirmed`-only
-		// transitions (MarkFulfilled/MarkPartiallyFulfilled both require
-		// specific order.status preconditions the way orders.Confirm does)
-		// can leave every parcel shipped while fulfillment_status silently
-		// never advances — e.g. a still-`pending` order, which the admin
-		// UI explicitly allows labelling. Surface that on the same
-		// pickup-warning channel the response already carries, alongside
-		// the log line, so the admin actually sees it.
+		// must not be swallowed either: MarkFulfillmentComplete and
+		// MarkPartiallyFulfilled both still have a fulfillment_status
+		// precondition of their own (fulfillmentStatusTransitions), so an
+		// order already at the target fulfillment_status, or otherwise
+		// mid-transition, can leave every parcel shipped while
+		// fulfillment_status silently never advances. Surface that on the
+		// same pickup-warning channel the response already carries,
+		// alongside the log line, so the admin actually sees it.
 		var fulfilWarning string
 		if h.orderSvc != nil {
 			remaining, err := h.unshippedAllocationGroups(ctx, orderID)
@@ -1473,7 +1510,14 @@ func (h *ShipmentsHandler) createShipmentsPerWarehouse(
 				var targetStatus string
 				if len(remaining) == 0 {
 					targetStatus = "fulfilled"
-					fulfilErr = h.orderSvc.MarkFulfilled(ctx, nil, orderID)
+					// MarkFulfillmentComplete, not MarkFulfilled: label
+					// creation must move only fulfillment_status.
+					// orders.status is terminal at "fulfilled" (status.go),
+					// so advancing it here at label-creation time — before
+					// pickup — would permanently block Cancel. The manual
+					// /fulfill admin endpoint is the deliberate two-axis
+					// action; this is not it.
+					fulfilErr = h.orderSvc.MarkFulfillmentComplete(ctx, nil, orderID)
 				} else {
 					targetStatus = "partially fulfilled"
 					fulfilErr = h.orderSvc.MarkPartiallyFulfilled(ctx, nil, orderID)

--- a/services/marketplace-api/internal/handlers/admin/shipments.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments.go
@@ -72,6 +72,13 @@ type ShipmentsHandler struct {
 	// caller of NewShipmentsHandler — costs nothing, matching
 	// ShippingSettingsHandler's warehouseRepo on the write side.
 	warehouseRepo *warehouse.Repository
+	// newCarrier overrides shipping.NewCarrier inside Create. Nil on
+	// production builds, where Create constructs the carrier directly as
+	// before. It exists because label creation cannot otherwise be tested
+	// without a live carrier account — and the sync loop's carrierFactory
+	// is deliberately scoped to that loop, so overloading it would blur a
+	// boundary its own doc comment draws.
+	newCarrier func(provider, apiKey, secretKey, mode string) (shipping.Carrier, error)
 }
 
 // NewShipmentsHandler constructs a ShipmentsHandler. docMailer is
@@ -120,6 +127,15 @@ func (h *ShipmentsHandler) WithLabelMailer(m LabelMailer) *ShipmentsHandler {
 // cancel endpoint. Chainable, nil-safe by omission.
 func (h *ShipmentsHandler) WithCanceller(e *shipmentcancel.Executor) *ShipmentsHandler {
 	h.canceller = e
+	return h
+}
+
+// WithCarrierConstructor overrides shipping.NewCarrier inside Create.
+// Test-only: production code never calls this, so Create keeps
+// constructing the real carrier via shipping.NewCarrier. Exists because
+// Create cannot otherwise be exercised without a live carrier account.
+func (h *ShipmentsHandler) WithCarrierConstructor(fn func(provider, apiKey, secretKey, mode string) (shipping.Carrier, error)) *ShipmentsHandler {
+	h.newCarrier = fn
 	return h
 }
 
@@ -535,6 +551,96 @@ func (h *ShipmentsHandler) Create(c *gin.Context) {
 		return
 	}
 
+	// Groups this order still owes a parcel for. An order with none — every
+	// order placed before allocation shipped, and every order on a store with
+	// no warehouse — takes the single-shipment path below, unchanged. That is
+	// not a fallback for tidiness: order_allocations is empty in production
+	// today (#177 PR 3 only just started writing it), so this IS the only
+	// path currently executing for a real order.
+	groups, err := h.unshippedAllocationGroups(ctx, orderID)
+	if err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+
+	if len(groups) == 0 {
+		h.createSingleShipment(c, ctx, orderID, storeID, tenantID, o, shippingAddr, items, provider, req, carrierCfg)
+		return
+	}
+
+	h.createShipmentsPerWarehouse(c, ctx, orderID, storeID, tenantID, o, shippingAddr, items, provider, req, carrierCfg, groups)
+}
+
+// allocationGroup is one warehouse's still-unshipped share of an order:
+// the order items it must ship, and the quantity of each — which can be
+// less than the order item's own Quantity when a line is split across
+// warehouses.
+type allocationGroup struct {
+	WarehouseID string
+	ItemIDs     []string
+	Quantities  map[string]int
+}
+
+// unshippedAllocationGroups folds order_allocations into one group per
+// warehouse still owing this order a parcel. Ordering by warehouse_id
+// makes the parcel sequence deterministic — two runs on the same order
+// (e.g. a retry after a partial carrier failure) must walk the remaining
+// groups in the same order. A group whose allocations already carry a
+// shipment_id is excluded entirely — its parcel already shipped.
+func (h *ShipmentsHandler) unshippedAllocationGroups(ctx context.Context, orderID uuid.UUID) ([]allocationGroup, error) {
+	type allocRow struct {
+		WarehouseID string
+		OrderItemID string
+		Quantity    int
+	}
+	var rows []allocRow
+	if err := h.db.WithContext(ctx).
+		Table("order_allocations").
+		Select("warehouse_id", "order_item_id", "quantity").
+		Where("order_id = ? AND shipment_id IS NULL", orderID).
+		Order("warehouse_id, order_item_id").
+		Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("shipments: load allocation groups: %w", err)
+	}
+
+	groups := make([]allocationGroup, 0, len(rows))
+	indexByWarehouse := make(map[string]int, len(rows))
+	for _, r := range rows {
+		idx, ok := indexByWarehouse[r.WarehouseID]
+		if !ok {
+			idx = len(groups)
+			indexByWarehouse[r.WarehouseID] = idx
+			groups = append(groups, allocationGroup{
+				WarehouseID: r.WarehouseID,
+				Quantities:  map[string]int{},
+			})
+		}
+		groups[idx].ItemIDs = append(groups[idx].ItemIDs, r.OrderItemID)
+		groups[idx].Quantities[r.OrderItemID] += r.Quantity
+	}
+	return groups, nil
+}
+
+// createSingleShipment is the production path today: an order with no
+// unshipped allocation groups gets exactly one shipment, pickup resolved
+// from the carrier config's warehouse — identical to CreateShipment's
+// behavior before #177 PR 4b. Moved out of Create() verbatim (the carrier
+// construction line is the one sanctioned change — see WithCarrierConstructor)
+// so this path is provably unchanged by the grouping work in
+// createShipmentsPerWarehouse.
+func (h *ShipmentsHandler) createSingleShipment(
+	c *gin.Context,
+	ctx context.Context,
+	orderID uuid.UUID,
+	storeID string,
+	tenantID string,
+	o order.Order,
+	shippingAddr order.OrderAddress,
+	items []order.OrderItem,
+	provider string,
+	req CreateShipmentRequest,
+	carrierCfg *shipping.CarrierConfig,
+) {
 	// Resolve the pickup address from the store-level warehouses row
 	// (#484, the contract half). No legacy-column fallback anymore — see
 	// resolvePickupAddress.
@@ -564,8 +670,17 @@ func (h *ShipmentsHandler) Create(c *gin.Context) {
 	}
 	h.maybeRewrapCarrierCreds(ctx, carrierCfg, apiKey, secretKey)
 
-	// Create the carrier instance.
-	carrier, err := shipping.NewCarrier(provider, apiKey, secretKey, carrierCfg.Mode)
+	// Create the carrier instance. construct is shipping.NewCarrier on
+	// production builds; tests override it via WithCarrierConstructor
+	// since label creation cannot otherwise be exercised without a live
+	// carrier account.
+	construct := func(provider, apiKey, secretKey, mode string) (shipping.Carrier, error) {
+		return shipping.NewCarrier(provider, apiKey, secretKey, mode)
+	}
+	if h.newCarrier != nil {
+		construct = h.newCarrier
+	}
+	carrier, err := construct(provider, apiKey, secretKey, carrierCfg.Mode)
 	if err != nil {
 		RespondErr(c, fmt.Errorf("shipments: create carrier: %w", err), h.logger)
 		return
@@ -858,6 +973,301 @@ func (h *ShipmentsHandler) Create(c *gin.Context) {
 	resp := toShipmentResponse(rec)
 	resp.PickupWarning = pickupWarning
 	c.JSON(http.StatusCreated, resp)
+}
+
+// createShipmentsPerWarehouse is #177 PR 4b: one shipment per warehouse
+// group still owing this order a parcel. Each group resolves its OWN
+// pickup address (not the carrier config's), ships only the order items
+// (and quantities) that group allocated, and stamps its allocation rows
+// with the resulting shipment's id so a retry doesn't re-ship it.
+//
+// A carrier failure part-way through does not undo earlier parcels: each
+// shipment is persisted as soon as its carrier call succeeds, so a failed
+// group leaves its allocations with shipment_id still NULL — exactly the
+// set a retry needs to pick up.
+func (h *ShipmentsHandler) createShipmentsPerWarehouse(
+	c *gin.Context,
+	ctx context.Context,
+	orderID uuid.UUID,
+	storeID string,
+	tenantID string,
+	o order.Order,
+	shippingAddr order.OrderAddress,
+	items []order.OrderItem,
+	provider string,
+	req CreateShipmentRequest,
+	carrierCfg *shipping.CarrierConfig,
+	groups []allocationGroup,
+) {
+	// Decrypt credentials once — every group ships through the same
+	// carrier account, only the pickup address and parcel contents vary.
+	apiKey, secretKey, err := h.resolveCarrierCreds(ctx, carrierCfg)
+	if err != nil {
+		if h.logger != nil {
+			h.logger.Error("shipments: resolve carrier creds",
+				"store_id", storeID, "provider", provider, "err", err)
+		}
+		RespondErr(c, fmt.Errorf("shipments: %w", err), h.logger)
+		return
+	}
+	h.maybeRewrapCarrierCreds(ctx, carrierCfg, apiKey, secretKey)
+
+	construct := func(provider, apiKey, secretKey, mode string) (shipping.Carrier, error) {
+		return shipping.NewCarrier(provider, apiKey, secretKey, mode)
+	}
+	if h.newCarrier != nil {
+		construct = h.newCarrier
+	}
+	carrier, err := construct(provider, apiKey, secretKey, carrierCfg.Mode)
+	if err != nil {
+		RespondErr(c, fmt.Errorf("shipments: create carrier: %w", err), h.logger)
+		return
+	}
+
+	// Destination address is the same for every parcel on this order.
+	toAddress := shipping.Address{
+		Name:        shippingAddr.Name,
+		Line1:       shippingAddr.Line1,
+		City:        shippingAddr.City,
+		CountryCode: shippingAddr.CountryCode,
+		Email:       o.CustomerEmail,
+	}
+	if shippingAddr.Line2 != nil {
+		toAddress.Line2 = *shippingAddr.Line2
+	}
+	if shippingAddr.Region != nil {
+		toAddress.Region = *shippingAddr.Region
+	}
+	if shippingAddr.PostalCode != nil {
+		toAddress.PostalCode = *shippingAddr.PostalCode
+	}
+	if shippingAddr.Phone != nil {
+		toAddress.Phone = *shippingAddr.Phone
+	}
+
+	toJSON, _ := json.Marshal(map[string]any{
+		"name":         shippingAddr.Name,
+		"line1":        shippingAddr.Line1,
+		"line2":        derefStringPtr(shippingAddr.Line2),
+		"city":         shippingAddr.City,
+		"region":       derefStringPtr(shippingAddr.Region),
+		"postal_code":  derefStringPtr(shippingAddr.PostalCode),
+		"country_code": shippingAddr.CountryCode,
+		"phone":        derefStringPtr(shippingAddr.Phone),
+	})
+
+	// Per-variant weight/dims, same lookup createSingleShipment uses —
+	// keyed once across every item on the order so each group's parcel
+	// build below is a pure slice-and-lookup.
+	variantIDs := make([]string, 0, len(items))
+	for _, it := range items {
+		if it.VariantID != nil {
+			variantIDs = append(variantIDs, it.VariantID.String())
+		}
+	}
+	type variantShipRow struct {
+		ID          string
+		WeightGrams *int
+		LengthCM    *decimal.Decimal
+		WidthCM     *decimal.Decimal
+		HeightCM    *decimal.Decimal
+	}
+	shipByVariant := map[string]variantShipRow{}
+	if len(variantIDs) > 0 {
+		var rows []variantShipRow
+		if err := h.db.WithContext(ctx).
+			Table("product_variants").
+			Select("id", "weight_grams", "length_cm", "width_cm", "height_cm").
+			Where("id IN ?", variantIDs).
+			Find(&rows).Error; err == nil {
+			for _, r := range rows {
+				shipByVariant[r.ID] = r
+			}
+		}
+	}
+	itemsByID := make(map[string]order.OrderItem, len(items))
+	for _, it := range items {
+		itemsByID[it.ID.String()] = it
+	}
+
+	const defaultWeightGramsPerUnit = 500
+	storeUUID, _ := uuid.Parse(storeID)
+	tenantUUID, _ := uuid.Parse(tenantID)
+
+	created := make([]*shipping.ShipmentRecord, 0, len(groups))
+	for _, g := range groups {
+		wh, err := h.warehouseRepo.ByID(ctx, h.db, g.WarehouseID)
+		if err != nil {
+			if h.logger != nil {
+				h.logger.Error("shipments: allocation group's warehouse_id has no matching row",
+					"order_id", orderID.String(), "warehouse_id", g.WarehouseID, "err", err)
+			}
+			c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{
+				"error":   "warehouse_not_found",
+				"message": fmt.Sprintf("warehouse %s referenced by this order's allocation no longer exists", g.WarehouseID),
+				"created": len(created),
+			})
+			return
+		}
+		pickup := pickupAddress{
+			Name:          wh.Name,
+			Line1:         wh.Line1,
+			Line2:         wh.Line2,
+			City:          wh.City,
+			Region:        wh.Region,
+			PostalCode:    wh.PostalCode,
+			CountryCode:   wh.CountryCode,
+			Phone:         wh.Phone,
+			ContactPerson: wh.ContactPerson,
+			Email:         wh.Email,
+		}
+
+		fromAddress := shipping.Address{
+			Name:        pickup.Name,
+			Line1:       pickup.Line1,
+			Line2:       pickup.Line2,
+			City:        pickup.City,
+			Region:      pickup.Region,
+			PostalCode:  pickup.PostalCode,
+			CountryCode: pickup.CountryCode,
+			Phone:       pickup.Phone,
+			Email:       pickupEmailOrBuyerFallback(pickup, o.CustomerEmail),
+		}
+
+		// Build parcel items from THIS group's allocations only — the
+		// order items it names, at the allocated quantities, not the
+		// whole order.
+		parcelItems := make([]shipping.ParcelItem, 0, len(g.ItemIDs))
+		for _, itemID := range g.ItemIDs {
+			it, ok := itemsByID[itemID]
+			if !ok {
+				continue
+			}
+			p := shipping.ParcelItem{
+				Title:       it.TitleSnapshot,
+				SKU:         it.SKUSnapshot,
+				Quantity:    g.Quantities[itemID],
+				WeightGrams: defaultWeightGramsPerUnit,
+			}
+			if it.VariantID != nil {
+				if vs, ok := shipByVariant[it.VariantID.String()]; ok {
+					if vs.WeightGrams != nil && *vs.WeightGrams > 0 {
+						p.WeightGrams = *vs.WeightGrams
+					}
+					if vs.LengthCM != nil {
+						f, _ := vs.LengthCM.Float64()
+						p.LengthCM = f
+					}
+					if vs.WidthCM != nil {
+						f, _ := vs.WidthCM.Float64()
+						p.WidthCM = f
+					}
+					if vs.HeightCM != nil {
+						f, _ := vs.HeightCM.Float64()
+						p.HeightCM = f
+					}
+				}
+			}
+			parcelItems = append(parcelItems, p)
+		}
+
+		shipment, err := h.svc.CreateShipment(
+			ctx,
+			orderID.String(),
+			fromAddress,
+			toAddress,
+			parcelItems,
+			req.Service,
+			o.CurrencyCode,
+			carrier,
+		)
+		if err != nil {
+			// The label already created for an earlier group cannot be
+			// un-created at the carrier, so it stays. The failed group
+			// keeps shipment_id NULL and a retry will pick up exactly
+			// the groups still owing a parcel.
+			if h.logger != nil {
+				h.logger.Error("shipments: carrier create failed for group",
+					"order_id", orderID.String(), "warehouse_id", g.WarehouseID,
+					"created", len(created), "err", err.Error())
+			}
+			c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{
+				"error":   "carrier_create_failed",
+				"message": err.Error(),
+				"created": len(created),
+			})
+			return
+		}
+
+		fromJSON, _ := json.Marshal(map[string]any{
+			"name":         pickup.Name,
+			"line1":        pickup.Line1,
+			"line2":        pickup.Line2,
+			"city":         pickup.City,
+			"region":       pickup.Region,
+			"postal_code":  pickup.PostalCode,
+			"country_code": pickup.CountryCode,
+			"phone":        pickup.Phone,
+		})
+
+		whID := uuid.MustParse(wh.ID)
+		rec := &shipping.ShipmentRecord{
+			TenantID:          tenantUUID,
+			StoreID:           storeUUID,
+			OrderID:           orderID,
+			Carrier:           provider,
+			TrackingNumber:    shipment.TrackingNumber,
+			LabelURL:          shipment.LabelURL,
+			Status:            "pending",
+			ShipFrom:          datatypes.JSON(fromJSON),
+			ShipTo:            datatypes.JSON(toJSON),
+			CurrencyCode:      o.CurrencyCode,
+			EstimatedDelivery: shipment.EstimatedDelivery,
+			WarehouseID:       &whID,
+			// Response-only fields — not persisted, but carried so the
+			// wire DTO can surface them.
+			Provider:           provider,
+			ProviderShipmentID: shipment.ProviderShipmentID,
+			Service:            shipment.Service,
+		}
+
+		if err := h.repo.CreateShipment(ctx, rec); err != nil {
+			if h.logger != nil {
+				h.logger.Error("shipments: persist record for group failed",
+					"order_id", orderID.String(), "warehouse_id", g.WarehouseID, "err", err)
+			}
+			c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{
+				"error":   "persist_failed",
+				"message": err.Error(),
+				"created": len(created),
+			})
+			return
+		}
+
+		// Stamp this group's allocation rows with the shipment that just
+		// covered them, so a retry does not re-ship an already-shipped
+		// group.
+		if err := h.db.WithContext(ctx).
+			Table("order_allocations").
+			Where("order_id = ? AND warehouse_id = ? AND shipment_id IS NULL", orderID, g.WarehouseID).
+			Update("shipment_id", rec.ID).Error; err != nil && h.logger != nil {
+			h.logger.Error("shipments: stamp allocation shipment_id failed",
+				"order_id", orderID.String(), "warehouse_id", g.WarehouseID,
+				"shipment_id", rec.ID.String(), "err", err)
+		}
+
+		h.appendShipmentEvent(ctx, orderID, rec, order.EventKindShipmentCreated,
+			"Shipping label created — package will be picked up shortly.")
+		h.dispatchShipmentDispatchedEmail(orderID, rec)
+
+		created = append(created, rec)
+	}
+
+	resp := make([]ShipmentResponse, 0, len(created))
+	for _, rec := range created {
+		resp = append(resp, toShipmentResponse(rec))
+	}
+	c.JSON(http.StatusCreated, gin.H{"shipments": resp})
 }
 
 // tryAutoSchedulePickup calls SchedulePickup with the next-business-day

--- a/services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go
@@ -625,7 +625,7 @@ func TestCreateShipment_PendingOrderShipsAndFulfilmentStatusStillAdvances(t *tes
 	require.Empty(t, resp.PickupWarning, "fulfilment-status reporting must succeed, not warn, once it no longer depends on orders.status")
 }
 
-// TestCreateShipment_VariantlessItemIsIncludedInFirstGroupsParcel pins
+// TestCreateShipment_VariantlessItemIsIncludedInFirstShipmentsParcel pins
 // task-2 FIX 2: stockLinesFromItems (checkout_stock.go) deliberately skips
 // order items with a nil variant_id when computing allocations — a
 // custom/unstocked line is a supported order shape. Such an item never
@@ -634,8 +634,12 @@ func TestCreateShipment_PendingOrderShipsAndFulfilmentStatusStillAdvances(t *tes
 // group's parcel from ONLY that group's ItemIDs, so the variantless item
 // would silently vanish from every shipment — the order gets marked
 // fulfilled having shipped an incomplete parcel. It must instead ride
-// along in the first (highest-priority) group's parcel.
-func TestCreateShipment_VariantlessItemIsIncludedInFirstGroupsParcel(t *testing.T) {
+// along in the first (highest-priority) group's parcel. This single-call,
+// single-group order can't distinguish "first group of this call" from
+// "first shipment overall" — see
+// TestCreateShipment_UnallocatedItemShipsOnlyOnceAcrossRetry below for the
+// case that does.
+func TestCreateShipment_VariantlessItemIsIncludedInFirstShipmentsParcel(t *testing.T) {
 	db := testdb.NewDB(t, perWarehouseTables...)
 	storeID, tenantID := seedPerWarehouseStore(t, db)
 	wh := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Warehouse A", "1 Warehouse A Road")
@@ -676,4 +680,83 @@ func TestCreateShipment_VariantlessItemIsIncludedInFirstGroupsParcel(t *testing.
 	groups := groupsForOrder(t, db, orderID.String())
 	require.Len(t, groups, 1)
 	require.NotNil(t, groups[0].ShipmentID)
+}
+
+// TestCreateShipment_UnallocatedItemShipsOnlyOnceAcrossRetry is the
+// regression test for the double-ship bug: an unallocated (variantless)
+// item riding along in "the first group's parcel" must be gated on this
+// being the order's first shipment EVER, not on gi==0 within one call.
+//
+// groups comes from unshippedAllocationGroups, which is recomputed
+// REMAINING-only on every call. Sequence:
+//  1. Call 1: groups = [A, B]. A is gi==0, so the variantless item rides in
+//     A's parcel. A's label succeeds and persists.
+//  2. B's carrier call fails; Create() aborts having created exactly one
+//     shipment (for A), leaving B's allocation unshipped.
+//  3. Retry: groups = [B] alone (A no longer owes a parcel). B is now
+//     gi==0 for THIS call — a positional check would append the
+//     variantless item to B's parcel too, shipping it a second time. The
+//     item has no allocation row, so nothing would ever catch the
+//     duplicate: it just goes out twice, for real, at a carrier that
+//     can't un-create a label.
+//
+// Gating on "does this order already have any shipments rows" instead
+// stays correct across the retry: it was true only on call 1's group A.
+func TestCreateShipment_UnallocatedItemShipsOnlyOnceAcrossRetry(t *testing.T) {
+	db := testdb.NewDB(t, perWarehouseTables...)
+	storeID, tenantID := seedPerWarehouseStore(t, db)
+	whA := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Warehouse A", "1 Warehouse A Road")
+	whB := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Warehouse B", "2 Warehouse B Road")
+	seedPerWarehouseCarrierConfig(t, db, storeID, tenantID, nil)
+	orderID := seedPerWarehouseOrder(t, db, storeID, tenantID)
+	itemA := seedPerWarehouseItem(t, db, orderID, "SKU-A", 1)
+	itemB := seedPerWarehouseItem(t, db, orderID, "SKU-B", 1)
+	seedAllocation(t, db, tenantID, storeID, orderID, itemA, whA.ID, 1)
+	seedAllocation(t, db, tenantID, storeID, orderID, itemB, whB.ID, 1)
+
+	// The variantless line: no VariantID, no order_allocations row at all.
+	seedPerWarehouseItem(t, db, orderID, "SKU-CUSTOM", 1)
+
+	// Groups are walked in warehouse_id order. Fail whichever of A/B sorts
+	// SECOND, so the first call's gi==0 group (which gets the variantless
+	// item, correctly, under both the old and new code) is the one that
+	// succeeds and persists — and the failing group is the one left for
+	// the retry to pick up as its OWN gi==0.
+	failLine1 := "2 Warehouse B Road"
+	if whB.ID < whA.ID {
+		failLine1 = "1 Warehouse A Road"
+	}
+	carrier := &stubCarrier{failOnceForLine1: failLine1}
+	h := newPerWarehouseHandler(db, carrier)
+
+	// First call: one group succeeds (carrying the variantless item),
+	// the other fails the whole request.
+	w1 := createShipmentViaHandler(t, h, storeID, orderID, tenantID)
+	require.Equal(t, http.StatusBadGateway, w1.Code, w1.Body.String())
+	require.Len(t, carrier.calls, 1, "exactly one parcel must have been sent to the carrier before the failure")
+
+	// Retry: only the previously-failed group remains, and it is gi==0 for
+	// THIS call.
+	w2 := createShipmentViaHandler(t, h, storeID, orderID, tenantID)
+	require.Equal(t, http.StatusCreated, w2.Code, w2.Body.String())
+
+	require.Len(t, carrier.calls, 2, "the retry must add exactly one more parcel, for the previously-failed group")
+
+	// The load-bearing assertion: SKU-CUSTOM must appear in EXACTLY ONE of
+	// the two parcels sent to the carrier across both calls — never zero
+	// (it must still ship), never two (it must not ship twice).
+	parcelsContainingCustom := 0
+	for _, call := range carrier.calls {
+		for _, item := range call.Items {
+			if item.SKU == "SKU-CUSTOM" {
+				parcelsContainingCustom++
+				require.Equal(t, 1, item.Quantity)
+			}
+		}
+	}
+	require.Equal(t, 1, parcelsContainingCustom,
+		"the unallocated item must ship in exactly one parcel across the call and its retry, not zero and not two")
+
+	shipments := shipmentsForOrder(t, db, orderID.String())
+	require.Len(t, shipments, 2, "one shipment per allocation group, across both calls")
 }

--- a/services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go
@@ -430,3 +430,37 @@ func TestCreateShipment_AlreadyShippedGroupIsNotShippedTwice(t *testing.T) {
 		require.NotNil(t, g.ShipmentID, "both groups must be stamped after the retry")
 	}
 }
+
+// TestCreateShipment_FullyShippedOrderReCallIsNoOp pins CRITICAL 1 from
+// fix round 1: an order whose allocations are ALL already shipped is a
+// different state from "no allocations at all" — len(groups)==0 alone
+// cannot tell them apart. A re-POST on a fully-shipped order must be a
+// 409 no-op, not fall through to createSingleShipment and buy a second,
+// real, un-cancellable label for the whole order.
+func TestCreateShipment_FullyShippedOrderReCallIsNoOp(t *testing.T) {
+	db := testdb.NewDB(t, perWarehouseTables...)
+	storeID, tenantID := seedPerWarehouseStore(t, db)
+	wh := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Warehouse A", "1 Warehouse A Road")
+	seedPerWarehouseCarrierConfig(t, db, storeID, tenantID, nil)
+	orderID := seedPerWarehouseOrder(t, db, storeID, tenantID)
+	itemID := seedPerWarehouseItem(t, db, orderID, "SKU-1", 2)
+	seedAllocation(t, db, tenantID, storeID, orderID, itemID, wh.ID, 2)
+
+	h := newPerWarehouseHandler(db, &stubCarrier{})
+
+	w1 := createShipmentViaHandler(t, h, storeID, orderID, tenantID)
+	require.Equal(t, http.StatusCreated, w1.Code, w1.Body.String())
+
+	shipmentsAfterFirst := shipmentsForOrder(t, db, orderID.String())
+	require.Len(t, shipmentsAfterFirst, 1)
+
+	// Every allocation is now shipped. A second Create() call must be a
+	// no-op: 409, and NOT a second whole-order shipment via
+	// createSingleShipment falling through on len(groups)==0.
+	w2 := createShipmentViaHandler(t, h, storeID, orderID, tenantID)
+	require.Equal(t, http.StatusConflict, w2.Code, w2.Body.String())
+
+	shipmentsAfterRecall := shipmentsForOrder(t, db, orderID.String())
+	require.Len(t, shipmentsAfterRecall, 1, "a re-POST on a fully-shipped order must not create another shipment")
+	require.Equal(t, shipmentsAfterFirst[0].ID, shipmentsAfterRecall[0].ID)
+}

--- a/services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go
@@ -33,6 +33,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/internal/outbox"
 	"github.com/mark8ly/marketplace-api/internal/shipping"
 	"github.com/mark8ly/marketplace-api/internal/warehouse"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
@@ -135,6 +136,8 @@ func (s *stubCarrier) SupportedCountries() []string { return []string{"IN"} }
 var perWarehouseTables = []string{
 	"order_allocations",
 	"shipments",
+	"order_events",
+	"outbox_events",
 	"order_addresses",
 	"order_items",
 	"orders",
@@ -143,15 +146,34 @@ var perWarehouseTables = []string{
 	"stores",
 }
 
+// newPerWarehouseHandler wires a real order.Service (backed by the same
+// db) so createShipmentsPerWarehouse's fulfilment-status reporting is
+// exercised end-to-end, not skipped as it would be if orderSvc were left
+// nil — see TestCreateShipment_* fulfillmentStatusForOrder assertions
+// below, which are what step 6 of the task-2 brief mutation-tests.
 func newPerWarehouseHandler(db *gorm.DB, carrier shipping.Carrier) *ShipmentsHandler {
 	repo := shipping.NewRepository(db)
 	svc := shipping.NewShippingService(repo)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	h := NewShipmentsHandler(db, svc, repo, nil, logger)
+	orderRepo := order.NewRepository()
+	outboxRepo := outbox.NewRepository(db)
+	orderSvc := order.NewService(db, orderRepo, outboxRepo)
+	h := NewShipmentsHandler(db, svc, repo, nil, logger).WithOrderService(orderSvc)
 	h.WithCarrierConstructor(func(provider, apiKey, secretKey, mode string) (shipping.Carrier, error) {
 		return carrier, nil
 	})
 	return h
+}
+
+// fulfillmentStatusForOrder reads orders.fulfillment_status directly —
+// the property createShipmentsPerWarehouse's remaining-groups decision
+// (brief step 4) is responsible for.
+func fulfillmentStatusForOrder(t *testing.T, db *gorm.DB, orderID uuid.UUID) string {
+	t.Helper()
+	var status string
+	require.NoError(t, db.Raw(
+		`SELECT fulfillment_status FROM orders WHERE id = ?`, orderID).Row().Scan(&status))
+	return status
 }
 
 func seedPerWarehouseStore(t *testing.T, db *gorm.DB) (storeID, tenantID uuid.UUID) {
@@ -291,6 +313,12 @@ func TestCreateShipment_OrderWithNoAllocationsCreatesOneShipmentAsBefore(t *test
 	shipments := shipmentsForOrder(t, db, orderID.String())
 	require.Len(t, shipments, 1, "an order with no allocations must produce exactly one shipment")
 	require.Nil(t, shipments[0].WarehouseID, "with no allocation to attribute it to, warehouse_id must stay NULL")
+
+	// The no-allocations path keeps whatever behaviour it had before #177
+	// PR 4b: createSingleShipment has never reported fulfilment status, and
+	// this task must not start it doing so.
+	require.Equal(t, "unfulfilled", fulfillmentStatusForOrder(t, db, orderID),
+		"the single-shipment path must not change fulfilment status")
 }
 
 // TestCreateShipment_OneAllocationGroupCreatesOneShipmentWithItsWarehouse
@@ -320,6 +348,10 @@ func TestCreateShipment_OneAllocationGroupCreatesOneShipmentWithItsWarehouse(t *
 	require.Len(t, groups, 1)
 	require.NotNil(t, groups[0].ShipmentID, "the allocation row must be stamped with the shipment it went out on")
 	require.Equal(t, shipments[0].ID, *groups[0].ShipmentID)
+
+	// Every group this order owed a parcel for now has one — fulfilled,
+	// not partial.
+	require.Equal(t, "fulfilled", fulfillmentStatusForOrder(t, db, orderID))
 }
 
 // TestCreateShipment_TwoAllocationGroupsCreateTwoShipments is the core
@@ -367,6 +399,9 @@ func TestCreateShipment_TwoAllocationGroupsCreateTwoShipments(t *testing.T) {
 		require.NotNil(t, g.ShipmentID)
 		require.Equal(t, gotWarehouses[g.WarehouseID], *g.ShipmentID)
 	}
+
+	// Both groups shipped in this one call — the order is fully fulfilled.
+	require.Equal(t, "fulfilled", fulfillmentStatusForOrder(t, db, orderID))
 }
 
 // TestCreateShipment_AlreadyShippedGroupIsNotShippedTwice pins the
@@ -404,6 +439,13 @@ func TestCreateShipment_AlreadyShippedGroupIsNotShippedTwice(t *testing.T) {
 	shipmentsAfterFirst := shipmentsForOrder(t, db, orderID.String())
 	require.Len(t, shipmentsAfterFirst, 1, "the succeeding group's shipment must be persisted despite the other group's failure")
 
+	// One of two groups has a real, persisted parcel; the other still owes
+	// one. The order must report partial — not fulfilled (that would tell
+	// a customer their order is complete while a parcel is missing) and
+	// not unfulfilled (that would hide the parcel that already shipped).
+	require.Equal(t, "partial", fulfillmentStatusForOrder(t, db, orderID),
+		"a two-group order with only one parcel shipped must report partial fulfilment")
+
 	// Second call: the retry. The already-shipped group must not be
 	// re-shipped; only the previously-failed group gets a new shipment.
 	w2 := createShipmentViaHandler(t, h, storeID, orderID, tenantID)
@@ -411,6 +453,9 @@ func TestCreateShipment_AlreadyShippedGroupIsNotShippedTwice(t *testing.T) {
 
 	shipmentsAfterRetry := shipmentsForOrder(t, db, orderID.String())
 	require.Len(t, shipmentsAfterRetry, 2, "the retry must add exactly one shipment, for the group that had failed")
+
+	// Now every group owed a parcel has one.
+	require.Equal(t, "fulfilled", fulfillmentStatusForOrder(t, db, orderID))
 
 	firstIDs := map[string]bool{}
 	for _, s := range shipmentsAfterFirst {
@@ -453,6 +498,7 @@ func TestCreateShipment_FullyShippedOrderReCallIsNoOp(t *testing.T) {
 
 	shipmentsAfterFirst := shipmentsForOrder(t, db, orderID.String())
 	require.Len(t, shipmentsAfterFirst, 1)
+	require.Equal(t, "fulfilled", fulfillmentStatusForOrder(t, db, orderID))
 
 	// Every allocation is now shipped. A second Create() call must be a
 	// no-op: 409, and NOT a second whole-order shipment via
@@ -463,4 +509,8 @@ func TestCreateShipment_FullyShippedOrderReCallIsNoOp(t *testing.T) {
 	shipmentsAfterRecall := shipmentsForOrder(t, db, orderID.String())
 	require.Len(t, shipmentsAfterRecall, 1, "a re-POST on a fully-shipped order must not create another shipment")
 	require.Equal(t, shipmentsAfterFirst[0].ID, shipmentsAfterRecall[0].ID)
+
+	// The no-op recall must not touch fulfilment status either — it never
+	// reaches createShipmentsPerWarehouse's per-group reporting.
+	require.Equal(t, "fulfilled", fulfillmentStatusForOrder(t, db, orderID))
 }

--- a/services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -103,6 +104,12 @@ func shipFromLine1(t *testing.T, db *gorm.DB, shipmentID string) string {
 type stubCarrier struct {
 	failOnceForLine1 string
 	failed           atomic.Bool
+
+	// mu guards calls — createShipmentsPerWarehouse calls CreateShipment
+	// sequentially within one Create() request, but a test may hold onto
+	// this stub across the request, so guard it anyway.
+	mu    sync.Mutex
+	calls []shipping.ShipmentRequest
 }
 
 func (s *stubCarrier) GetRates(context.Context, shipping.RateRequest) ([]shipping.Rate, error) {
@@ -113,6 +120,9 @@ func (s *stubCarrier) CreateShipment(_ context.Context, in shipping.ShipmentRequ
 	if s.failOnceForLine1 != "" && in.FromAddress.Line1 == s.failOnceForLine1 && s.failed.CompareAndSwap(false, true) {
 		return nil, fmt.Errorf("stubCarrier: simulated carrier failure for %s", in.FromAddress.Line1)
 	}
+	s.mu.Lock()
+	s.calls = append(s.calls, in)
+	s.mu.Unlock()
 	return &shipping.Shipment{
 		ProviderShipmentID: "PSID-" + in.FromAddress.Line1,
 		TrackingNumber:     "TRK-" + in.FromAddress.Line1,
@@ -173,6 +183,18 @@ func fulfillmentStatusForOrder(t *testing.T, db *gorm.DB, orderID uuid.UUID) str
 	var status string
 	require.NoError(t, db.Raw(
 		`SELECT fulfillment_status FROM orders WHERE id = ?`, orderID).Row().Scan(&status))
+	return status
+}
+
+// orderStatusForOrder reads orders.status directly — the axis label
+// creation must NEVER touch (task-2 FIX 1). Label creation only ever
+// advances fulfillment_status; orders.status is the manual /fulfill admin
+// endpoint's job.
+func orderStatusForOrder(t *testing.T, db *gorm.DB, orderID uuid.UUID) string {
+	t.Helper()
+	var status string
+	require.NoError(t, db.Raw(
+		`SELECT status FROM orders WHERE id = ?`, orderID).Row().Scan(&status))
 	return status
 }
 
@@ -362,6 +384,16 @@ func TestCreateShipment_OneAllocationGroupCreatesOneShipmentWithItsWarehouse(t *
 	// Every group this order owed a parcel for now has one — fulfilled,
 	// not partial.
 	require.Equal(t, "fulfilled", fulfillmentStatusForOrder(t, db, orderID))
+
+	// task-2 FIX 1: label creation must move ONLY fulfillment_status.
+	// orders.status stays exactly where it started (confirmed, per
+	// seedPerWarehouseOrder) — orders.status="fulfilled" is TERMINAL
+	// (status.go), so if this ever regresses to calling MarkFulfilled here,
+	// the order becomes permanently un-cancellable the moment its first
+	// (and, for a single-warehouse store, only) label is created — before
+	// the parcel is even picked up.
+	require.Equal(t, "confirmed", orderStatusForOrder(t, db, orderID),
+		"orders.status must be untouched by label creation, not advanced to fulfilled")
 }
 
 // TestCreateShipment_TwoAllocationGroupsCreateTwoShipments is the core
@@ -412,6 +444,9 @@ func TestCreateShipment_TwoAllocationGroupsCreateTwoShipments(t *testing.T) {
 
 	// Both groups shipped in this one call — the order is fully fulfilled.
 	require.Equal(t, "fulfilled", fulfillmentStatusForOrder(t, db, orderID))
+
+	// orders.status is a separate axis label creation never touches.
+	require.Equal(t, "confirmed", orderStatusForOrder(t, db, orderID))
 }
 
 // TestCreateShipment_AlreadyShippedGroupIsNotShippedTwice pins the
@@ -540,7 +575,17 @@ func TestCreateShipment_FullyShippedOrderReCallIsNoOp(t *testing.T) {
 // order is left stuck on fulfillment_status=partial (never advanced to
 // fulfilled), and that must be surfaced to the admin via the response's
 // pickup-warning channel, not just logged.
-func TestCreateShipment_PendingOrderShipsButFulfilmentStatusReportedAsWarning(t *testing.T) {
+// TestCreateShipment_PendingOrderShipsAndFulfilmentStatusStillAdvances pins
+// task-2 FIX 1's actual mechanism: fulfillment_status is reported via
+// MarkFulfillmentComplete/MarkPartiallyFulfilled, which have ONLY a
+// fulfillment_status precondition — never an orders.status one. Before the
+// fix, the last group's report went through MarkFulfilled, which also
+// requires orders.status to legally reach "fulfilled" (confirmed only);
+// on a still-pending order that precondition failed, silently stranding
+// fulfillment_status at "partial" even though every parcel had shipped.
+// Post-fix, both parcels ship AND fulfillment_status correctly reaches
+// "fulfilled" regardless of orders.status — which itself is never touched.
+func TestCreateShipment_PendingOrderShipsAndFulfilmentStatusStillAdvances(t *testing.T) {
 	db := testdb.NewDB(t, perWarehouseTables...)
 	storeID, tenantID := seedPerWarehouseStore(t, db)
 	whA := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Warehouse A", "1 Warehouse A Road")
@@ -555,13 +600,10 @@ func TestCreateShipment_PendingOrderShipsButFulfilmentStatusReportedAsWarning(t 
 	h := newPerWarehouseHandler(db, &stubCarrier{})
 	w := createShipmentViaHandler(t, h, storeID, orderID, tenantID)
 
-	// The label creation itself succeeded — a fulfilment-status write
-	// failure downstream of two real, persisted carrier labels must not
-	// turn this into an error response.
 	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
 
 	shipments := shipmentsForOrder(t, db, orderID.String())
-	require.Len(t, shipments, 2, "both parcels must be created despite the order being unable to report fulfilled")
+	require.Len(t, shipments, 2)
 
 	groups := groupsForOrder(t, db, orderID.String())
 	require.Len(t, groups, 2)
@@ -569,20 +611,69 @@ func TestCreateShipment_PendingOrderShipsButFulfilmentStatusReportedAsWarning(t 
 		require.NotNil(t, g.ShipmentID, "both allocation groups must be stamped shipped")
 	}
 
-	// The order is stuck at partial — the last group's MarkFulfilled call
-	// failed, so fulfillment_status never advanced past what the first
-	// group's MarkPartiallyFulfilled call set it to.
-	require.Equal(t, "partial", fulfillmentStatusForOrder(t, db, orderID))
+	// fulfillment_status reaches "fulfilled" — no longer gated on
+	// orders.status, which a pending order would have failed under the
+	// old MarkFulfilled call.
+	require.Equal(t, "fulfilled", fulfillmentStatusForOrder(t, db, orderID))
 
 	// orders.status itself must be untouched — still pending, never
-	// silently bumped.
-	var status string
-	require.NoError(t, db.Raw(`SELECT status FROM orders WHERE id = ?`, orderID).Row().Scan(&status))
-	require.Equal(t, "pending", status)
+	// silently bumped by label creation.
+	require.Equal(t, "pending", orderStatusForOrder(t, db, orderID))
 
 	var resp ShipmentResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.NotEmpty(t, resp.PickupWarning, "the response must surface the fulfilment-status failure as a warning")
-	require.Contains(t, resp.PickupWarning, "could not be marked fulfilled",
-		"the warning must name what failed, not just that something did")
+	require.Empty(t, resp.PickupWarning, "fulfilment-status reporting must succeed, not warn, once it no longer depends on orders.status")
+}
+
+// TestCreateShipment_VariantlessItemIsIncludedInFirstGroupsParcel pins
+// task-2 FIX 2: stockLinesFromItems (checkout_stock.go) deliberately skips
+// order items with a nil variant_id when computing allocations — a
+// custom/unstocked line is a supported order shape. Such an item never
+// gets an order_allocations row, so it never lands in any allocation
+// group's ItemIDs. Before the fix, createShipmentsPerWarehouse built each
+// group's parcel from ONLY that group's ItemIDs, so the variantless item
+// would silently vanish from every shipment — the order gets marked
+// fulfilled having shipped an incomplete parcel. It must instead ride
+// along in the first (highest-priority) group's parcel.
+func TestCreateShipment_VariantlessItemIsIncludedInFirstGroupsParcel(t *testing.T) {
+	db := testdb.NewDB(t, perWarehouseTables...)
+	storeID, tenantID := seedPerWarehouseStore(t, db)
+	wh := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Warehouse A", "1 Warehouse A Road")
+	seedPerWarehouseCarrierConfig(t, db, storeID, tenantID, nil)
+	orderID := seedPerWarehouseOrder(t, db, storeID, tenantID)
+
+	// A stocked line — allocated to Warehouse A, so it drives the one
+	// allocation group this order has.
+	stockedID := seedPerWarehouseItem(t, db, orderID, "SKU-STOCKED", 2)
+	seedAllocation(t, db, tenantID, storeID, orderID, stockedID, wh.ID, 2)
+
+	// A custom/unstocked line with NO variant_id and, critically, NO
+	// order_allocations row at all — nothing "stockLinesFromItems" ever
+	// wrote for it. seedPerWarehouseItem never sets VariantID, so it is
+	// nil by default, matching this order shape exactly.
+	seedPerWarehouseItem(t, db, orderID, "SKU-CUSTOM", 1)
+
+	carrier := &stubCarrier{}
+	h := newPerWarehouseHandler(db, carrier)
+	w := createShipmentViaHandler(t, h, storeID, orderID, tenantID)
+
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+	shipments := shipmentsForOrder(t, db, orderID.String())
+	require.Len(t, shipments, 1, "one allocation group means one shipment — the unallocated item must not create a second one")
+
+	require.Len(t, carrier.calls, 1)
+	skus := make(map[string]int, 2)
+	for _, item := range carrier.calls[0].Items {
+		skus[item.SKU] = item.Quantity
+	}
+	require.Equal(t, 2, skus["SKU-STOCKED"], "the allocated item must still ship at its allocated quantity")
+	require.Equal(t, 1, skus["SKU-CUSTOM"], "the variantless item must ride along in the parcel at its full order quantity, not vanish")
+
+	// The unallocated item has no order_allocations row, so it stays
+	// invisible to groupsForOrder — only the stocked line's allocation is
+	// there, and it must be stamped shipped.
+	groups := groupsForOrder(t, db, orderID.String())
+	require.Len(t, groups, 1)
+	require.NotNil(t, groups[0].ShipmentID)
 }

--- a/services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go
@@ -214,13 +214,23 @@ func seedPerWarehouseCarrierConfig(t *testing.T, db *gorm.DB, storeID, tenantID 
 
 func seedPerWarehouseOrder(t *testing.T, db *gorm.DB, storeID, tenantID uuid.UUID) uuid.UUID {
 	t.Helper()
+	return seedPerWarehouseOrderWithStatus(t, db, storeID, tenantID, "confirmed")
+}
+
+// seedPerWarehouseOrderWithStatus is seedPerWarehouseOrder with the
+// orders.status column exposed — used to cover the "order still pending
+// when parcels ship" fulfilment-status-can't-report case, which requires
+// an order Create() will accept (Create has no order-status precondition)
+// but MarkFulfilled's confirmed->fulfilled guard will reject.
+func seedPerWarehouseOrderWithStatus(t *testing.T, db *gorm.DB, storeID, tenantID uuid.UUID, status string) uuid.UUID {
+	t.Helper()
 	o := &order.Order{
 		TenantID:       tenantID,
 		StoreID:        storeID,
 		OrderNumber:    "M-" + uuid.NewString()[:8],
 		IdempotencyKey: "idem-" + uuid.NewString(),
 		CustomerEmail:  "buyer@example.com",
-		Status:         "confirmed",
+		Status:         status,
 		PaymentStatus:  "paid",
 		Subtotal:       decimal.NewFromInt(1000),
 		GrandTotal:     decimal.NewFromInt(1000),
@@ -513,4 +523,66 @@ func TestCreateShipment_FullyShippedOrderReCallIsNoOp(t *testing.T) {
 	// The no-op recall must not touch fulfilment status either — it never
 	// reaches createShipmentsPerWarehouse's per-group reporting.
 	require.Equal(t, "fulfilled", fulfillmentStatusForOrder(t, db, orderID))
+}
+
+// TestCreateShipment_PendingOrderShipsButFulfilmentStatusReportedAsWarning
+// covers fix-round-1 IMPORTANT 1: Create() has no order-status
+// precondition, and the admin UI explicitly allows labelling a `pending`
+// order — but MarkFulfilled requires orders.status == confirmed, and
+// MarkPartiallyFulfilled's guard is on the fulfillment axis only (no order
+// axis check). So on a two-group pending order, the first group's
+// MarkPartiallyFulfilled call succeeds (no order-status guard fires), then
+// the second group recomputes remaining==0 and calls MarkFulfilled, which
+// fails InvalidTransition because orders.status is still "pending".
+//
+// Both parcels must exist at the carrier regardless — the failure must
+// NOT turn into a 5xx that would suggest the shipment itself failed. The
+// order is left stuck on fulfillment_status=partial (never advanced to
+// fulfilled), and that must be surfaced to the admin via the response's
+// pickup-warning channel, not just logged.
+func TestCreateShipment_PendingOrderShipsButFulfilmentStatusReportedAsWarning(t *testing.T) {
+	db := testdb.NewDB(t, perWarehouseTables...)
+	storeID, tenantID := seedPerWarehouseStore(t, db)
+	whA := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Warehouse A", "1 Warehouse A Road")
+	whB := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Warehouse B", "2 Warehouse B Road")
+	seedPerWarehouseCarrierConfig(t, db, storeID, tenantID, nil)
+	orderID := seedPerWarehouseOrderWithStatus(t, db, storeID, tenantID, "pending")
+	itemA := seedPerWarehouseItem(t, db, orderID, "SKU-A", 1)
+	itemB := seedPerWarehouseItem(t, db, orderID, "SKU-B", 1)
+	seedAllocation(t, db, tenantID, storeID, orderID, itemA, whA.ID, 1)
+	seedAllocation(t, db, tenantID, storeID, orderID, itemB, whB.ID, 1)
+
+	h := newPerWarehouseHandler(db, &stubCarrier{})
+	w := createShipmentViaHandler(t, h, storeID, orderID, tenantID)
+
+	// The label creation itself succeeded — a fulfilment-status write
+	// failure downstream of two real, persisted carrier labels must not
+	// turn this into an error response.
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+	shipments := shipmentsForOrder(t, db, orderID.String())
+	require.Len(t, shipments, 2, "both parcels must be created despite the order being unable to report fulfilled")
+
+	groups := groupsForOrder(t, db, orderID.String())
+	require.Len(t, groups, 2)
+	for _, g := range groups {
+		require.NotNil(t, g.ShipmentID, "both allocation groups must be stamped shipped")
+	}
+
+	// The order is stuck at partial — the last group's MarkFulfilled call
+	// failed, so fulfillment_status never advanced past what the first
+	// group's MarkPartiallyFulfilled call set it to.
+	require.Equal(t, "partial", fulfillmentStatusForOrder(t, db, orderID))
+
+	// orders.status itself must be untouched — still pending, never
+	// silently bumped.
+	var status string
+	require.NoError(t, db.Raw(`SELECT status FROM orders WHERE id = ?`, orderID).Row().Scan(&status))
+	require.Equal(t, "pending", status)
+
+	var resp ShipmentResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.PickupWarning, "the response must surface the fulfilment-status failure as a warning")
+	require.Contains(t, resp.PickupWarning, "could not be marked fulfilled",
+		"the warning must name what failed, not just that something did")
 }

--- a/services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments_per_warehouse_integration_test.go
@@ -1,0 +1,432 @@
+//go:build integration
+
+// Package admin — coverage for creating one shipment per contributing
+// warehouse (#177 PR 4b).
+//
+// An order with NO allocations must behave exactly as it did before this
+// change: one shipment, pickup from the carrier config's warehouse. That is
+// not a fallback for tidiness — order_allocations is empty in production, so
+// it is the only path that currently runs.
+//
+// Create() constructs its carrier directly via shipping.NewCarrier, so it
+// cannot be exercised without a live carrier account. WithCarrierConstructor
+// (Step 0 of this task's brief) is the test-only seam that lets these tests
+// substitute stubCarrier below instead.
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/internal/shipping"
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// ─── shared read helpers (from the brief) ──────────────────────────────
+
+// groupsForOrder returns (warehouse_id, quantity) per allocation group,
+// ordered for stable assertions.
+func groupsForOrder(t *testing.T, db *gorm.DB, orderID string) []struct {
+	WarehouseID string
+	Quantity    int
+	ShipmentID  *string
+} {
+	t.Helper()
+	var rows []struct {
+		WarehouseID string
+		Quantity    int
+		ShipmentID  *string
+	}
+	require.NoError(t, db.Raw(
+		`SELECT warehouse_id, sum(quantity) AS quantity, max(shipment_id::text) AS shipment_id
+		   FROM order_allocations WHERE order_id = ?
+		  GROUP BY warehouse_id ORDER BY warehouse_id`, orderID).Scan(&rows).Error)
+	return rows
+}
+
+func shipmentsForOrder(t *testing.T, db *gorm.DB, orderID string) []struct {
+	ID          string
+	WarehouseID *string
+} {
+	t.Helper()
+	var rows []struct {
+		ID          string
+		WarehouseID *string
+	}
+	require.NoError(t, db.Raw(
+		`SELECT id, warehouse_id::text AS warehouse_id FROM shipments
+		  WHERE order_id = ? ORDER BY created_at, id`, orderID).Scan(&rows).Error)
+	return rows
+}
+
+// shipFromLine1 reads ship_from->>'line1' for a shipment — used to prove
+// two shipments actually shipped from DIFFERENT pickup addresses, not just
+// that two shipment rows exist.
+func shipFromLine1(t *testing.T, db *gorm.DB, shipmentID string) string {
+	t.Helper()
+	var line1 string
+	require.NoError(t, db.Raw(
+		`SELECT ship_from->>'line1' FROM shipments WHERE id = ?`, shipmentID).
+		Row().Scan(&line1))
+	return line1
+}
+
+// ─── stub carrier ───────────────────────────────────────────────────────
+
+// stubCarrier implements shipping.Carrier without any network call. Its
+// CreateShipment response encodes the pickup address it was given into the
+// tracking number, so a test can prove a parcel shipped from the RIGHT
+// warehouse — not merely that some parcel was created. Shipping from the
+// wrong warehouse is the failure #177 exists to prevent.
+//
+// failOnceForLine1, when set, makes the FIRST CreateShipment call for that
+// exact pickup Line1 fail, then succeed on every call after — simulating a
+// carrier failure part-way through a multi-warehouse Create() and the
+// retry that follows.
+type stubCarrier struct {
+	failOnceForLine1 string
+	failed           atomic.Bool
+}
+
+func (s *stubCarrier) GetRates(context.Context, shipping.RateRequest) ([]shipping.Rate, error) {
+	return nil, fmt.Errorf("stubCarrier: GetRates not implemented")
+}
+
+func (s *stubCarrier) CreateShipment(_ context.Context, in shipping.ShipmentRequest) (*shipping.Shipment, error) {
+	if s.failOnceForLine1 != "" && in.FromAddress.Line1 == s.failOnceForLine1 && s.failed.CompareAndSwap(false, true) {
+		return nil, fmt.Errorf("stubCarrier: simulated carrier failure for %s", in.FromAddress.Line1)
+	}
+	return &shipping.Shipment{
+		ProviderShipmentID: "PSID-" + in.FromAddress.Line1,
+		TrackingNumber:     "TRK-" + in.FromAddress.Line1,
+		Service:            in.Service,
+	}, nil
+}
+
+func (s *stubCarrier) GetTracking(context.Context, string) (*shipping.Tracking, error) {
+	return nil, fmt.Errorf("stubCarrier: GetTracking not implemented")
+}
+
+func (s *stubCarrier) CancelShipment(context.Context, string) error {
+	return fmt.Errorf("stubCarrier: CancelShipment not implemented")
+}
+
+func (s *stubCarrier) ProviderName() string         { return "stubcarrier" }
+func (s *stubCarrier) SupportedCountries() []string { return []string{"IN"} }
+
+// ─── fixtures ────────────────────────────────────────────────────────────
+
+var perWarehouseTables = []string{
+	"order_allocations",
+	"shipments",
+	"order_addresses",
+	"order_items",
+	"orders",
+	"shipping_carrier_configs",
+	"warehouses",
+	"stores",
+}
+
+func newPerWarehouseHandler(db *gorm.DB, carrier shipping.Carrier) *ShipmentsHandler {
+	repo := shipping.NewRepository(db)
+	svc := shipping.NewShippingService(repo)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	h := NewShipmentsHandler(db, svc, repo, nil, logger)
+	h.WithCarrierConstructor(func(provider, apiKey, secretKey, mode string) (shipping.Carrier, error) {
+		return carrier, nil
+	})
+	return h
+}
+
+func seedPerWarehouseStore(t *testing.T, db *gorm.DB) (storeID, tenantID uuid.UUID) {
+	t.Helper()
+	tenantID, storeID = uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
+	return storeID, tenantID
+}
+
+func seedPerWarehouseWarehouse(t *testing.T, db *gorm.DB, storeID, tenantID uuid.UUID, name, line1 string) warehouse.Warehouse {
+	t.Helper()
+	repo := warehouse.NewRepository()
+	wh, err := repo.Upsert(context.Background(), db, warehouse.Warehouse{
+		TenantID: tenantID.String(), StoreID: storeID.String(), Name: name,
+		Line1: line1, City: "Mumbai", Region: "MH",
+		PostalCode: "400001", CountryCode: "IN", Phone: "+912200000000",
+		ContactPerson: "Warehouse Manager",
+	})
+	require.NoError(t, err)
+	return wh
+}
+
+func seedPerWarehouseCarrierConfig(t *testing.T, db *gorm.DB, storeID, tenantID uuid.UUID, whID *uuid.UUID) *shipping.CarrierConfig {
+	t.Helper()
+	cfg := &shipping.CarrierConfig{
+		TenantID:    tenantID,
+		StoreID:     storeID,
+		Provider:    "stubcarrier",
+		APIKey:      "test-key",
+		Mode:        "test",
+		Enabled:     true,
+		HandlingFee: decimal.Zero,
+		WarehouseID: whID,
+	}
+	require.NoError(t, db.Create(cfg).Error)
+	return cfg
+}
+
+func seedPerWarehouseOrder(t *testing.T, db *gorm.DB, storeID, tenantID uuid.UUID) uuid.UUID {
+	t.Helper()
+	o := &order.Order{
+		TenantID:       tenantID,
+		StoreID:        storeID,
+		OrderNumber:    "M-" + uuid.NewString()[:8],
+		IdempotencyKey: "idem-" + uuid.NewString(),
+		CustomerEmail:  "buyer@example.com",
+		Status:         "confirmed",
+		PaymentStatus:  "paid",
+		Subtotal:       decimal.NewFromInt(1000),
+		GrandTotal:     decimal.NewFromInt(1000),
+		CurrencyCode:   "INR",
+	}
+	require.NoError(t, db.Create(o).Error)
+
+	addr := &order.OrderAddress{
+		OrderID:     o.ID,
+		Kind:        "shipping",
+		Name:        "Jane Doe",
+		Line1:       "42 Example Lane",
+		City:        "Mumbai",
+		CountryCode: "IN",
+	}
+	require.NoError(t, db.Create(addr).Error)
+
+	return o.ID
+}
+
+func seedPerWarehouseItem(t *testing.T, db *gorm.DB, orderID uuid.UUID, sku string, qty int) uuid.UUID {
+	t.Helper()
+	it := &order.OrderItem{
+		OrderID:       orderID,
+		TitleSnapshot: "Test Widget " + sku,
+		SKUSnapshot:   sku,
+		UnitPrice:     decimal.NewFromInt(500),
+		Quantity:      qty,
+		LineTotal:     decimal.NewFromInt(500 * int64(qty)),
+		CurrencyCode:  "INR",
+	}
+	require.NoError(t, db.Create(it).Error)
+	return it.ID
+}
+
+func seedAllocation(t *testing.T, db *gorm.DB, tenantID, storeID, orderID, itemID uuid.UUID, warehouseID string, qty int) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`INSERT INTO order_allocations (tenant_id, store_id, order_id, order_item_id, warehouse_id, quantity)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		tenantID, storeID, orderID, itemID, warehouseID, qty).Error)
+}
+
+// createShipmentViaHandler calls Create() directly against a hand-built
+// gin.Context — the same lightweight pattern shipments_cancel_test.go
+// already uses in this package — rather than standing up the full
+// RegisterAdmin router with auth/tenant middleware, which Create() itself
+// does not depend on.
+func createShipmentViaHandler(t *testing.T, h *ShipmentsHandler, storeID, orderID, tenantID uuid.UUID) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	body, err := json.Marshal(CreateShipmentRequest{Provider: "stubcarrier", Service: "standard"})
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{
+		{Key: "storeId", Value: storeID.String()},
+		{Key: "id", Value: orderID.String()},
+	}
+	c.Set("tenant_id", tenantID.String())
+	c.Request = httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+
+	h.Create(c)
+	return w
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────
+
+// TestCreateShipment_OrderWithNoAllocationsCreatesOneShipmentAsBefore is
+// the load-bearing case: every order in production today has no
+// order_allocations rows, so this is the ONLY path currently executing.
+// It must produce exactly one shipment, pickup from the carrier config's
+// warehouse, warehouse_id left NULL — unchanged from before #177 PR 4b.
+func TestCreateShipment_OrderWithNoAllocationsCreatesOneShipmentAsBefore(t *testing.T) {
+	db := testdb.NewDB(t, perWarehouseTables...)
+	storeID, tenantID := seedPerWarehouseStore(t, db)
+	wh := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Main Warehouse", "1 Main Warehouse Road")
+	whUUID := uuid.MustParse(wh.ID)
+	seedPerWarehouseCarrierConfig(t, db, storeID, tenantID, &whUUID)
+	orderID := seedPerWarehouseOrder(t, db, storeID, tenantID)
+	seedPerWarehouseItem(t, db, orderID, "SKU-1", 2)
+	// Deliberately NO order_allocations rows.
+
+	h := newPerWarehouseHandler(db, &stubCarrier{})
+	w := createShipmentViaHandler(t, h, storeID, orderID, tenantID)
+
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+	shipments := shipmentsForOrder(t, db, orderID.String())
+	require.Len(t, shipments, 1, "an order with no allocations must produce exactly one shipment")
+	require.Nil(t, shipments[0].WarehouseID, "with no allocation to attribute it to, warehouse_id must stay NULL")
+}
+
+// TestCreateShipment_OneAllocationGroupCreatesOneShipmentWithItsWarehouse
+// covers a single warehouse with allocations present: one shipment,
+// carrying that warehouse's id, and the allocation rows stamped with the
+// resulting shipment's id.
+func TestCreateShipment_OneAllocationGroupCreatesOneShipmentWithItsWarehouse(t *testing.T) {
+	db := testdb.NewDB(t, perWarehouseTables...)
+	storeID, tenantID := seedPerWarehouseStore(t, db)
+	wh := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Warehouse A", "1 Warehouse A Road")
+	seedPerWarehouseCarrierConfig(t, db, storeID, tenantID, nil)
+	orderID := seedPerWarehouseOrder(t, db, storeID, tenantID)
+	itemID := seedPerWarehouseItem(t, db, orderID, "SKU-1", 3)
+	seedAllocation(t, db, tenantID, storeID, orderID, itemID, wh.ID, 3)
+
+	h := newPerWarehouseHandler(db, &stubCarrier{})
+	w := createShipmentViaHandler(t, h, storeID, orderID, tenantID)
+
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+	shipments := shipmentsForOrder(t, db, orderID.String())
+	require.Len(t, shipments, 1)
+	require.NotNil(t, shipments[0].WarehouseID)
+	require.Equal(t, wh.ID, *shipments[0].WarehouseID)
+
+	groups := groupsForOrder(t, db, orderID.String())
+	require.Len(t, groups, 1)
+	require.NotNil(t, groups[0].ShipmentID, "the allocation row must be stamped with the shipment it went out on")
+	require.Equal(t, shipments[0].ID, *groups[0].ShipmentID)
+}
+
+// TestCreateShipment_TwoAllocationGroupsCreateTwoShipments is the core
+// property: two warehouses produce two shipments, each carrying its OWN
+// warehouse_id, and — critically — shipping from DIFFERENT ship_from
+// addresses. Shipping from the wrong warehouse is the failure #177 exists
+// to prevent, so two shipment rows alone would not be enough to trust.
+func TestCreateShipment_TwoAllocationGroupsCreateTwoShipments(t *testing.T) {
+	db := testdb.NewDB(t, perWarehouseTables...)
+	storeID, tenantID := seedPerWarehouseStore(t, db)
+	whA := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Warehouse A", "1 Warehouse A Road")
+	whB := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Warehouse B", "2 Warehouse B Road")
+	seedPerWarehouseCarrierConfig(t, db, storeID, tenantID, nil)
+	orderID := seedPerWarehouseOrder(t, db, storeID, tenantID)
+	itemA := seedPerWarehouseItem(t, db, orderID, "SKU-A", 2)
+	itemB := seedPerWarehouseItem(t, db, orderID, "SKU-B", 5)
+	seedAllocation(t, db, tenantID, storeID, orderID, itemA, whA.ID, 2)
+	seedAllocation(t, db, tenantID, storeID, orderID, itemB, whB.ID, 5)
+
+	h := newPerWarehouseHandler(db, &stubCarrier{})
+	w := createShipmentViaHandler(t, h, storeID, orderID, tenantID)
+
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+	shipments := shipmentsForOrder(t, db, orderID.String())
+	require.Len(t, shipments, 2)
+
+	gotWarehouses := map[string]string{} // warehouse_id -> shipment id
+	for _, s := range shipments {
+		require.NotNil(t, s.WarehouseID)
+		gotWarehouses[*s.WarehouseID] = s.ID
+	}
+	require.Contains(t, gotWarehouses, whA.ID)
+	require.Contains(t, gotWarehouses, whB.ID)
+
+	line1A := shipFromLine1(t, db, gotWarehouses[whA.ID])
+	line1B := shipFromLine1(t, db, gotWarehouses[whB.ID])
+	require.Equal(t, "1 Warehouse A Road", line1A)
+	require.Equal(t, "2 Warehouse B Road", line1B)
+	require.NotEqual(t, line1A, line1B, "the two shipments must ship from DIFFERENT pickup addresses")
+
+	groups := groupsForOrder(t, db, orderID.String())
+	require.Len(t, groups, 2)
+	for _, g := range groups {
+		require.NotNil(t, g.ShipmentID)
+		require.Equal(t, gotWarehouses[g.WarehouseID], *g.ShipmentID)
+	}
+}
+
+// TestCreateShipment_AlreadyShippedGroupIsNotShippedTwice pins the
+// retry-after-partial-failure property. Warehouse A's parcel succeeds on
+// the first Create() call; warehouse B's carrier call fails, so Create
+// aborts having created exactly one shipment. A second Create() call (the
+// retry) must NOT re-ship A — its allocation already carries a
+// shipment_id — and must create exactly one new shipment, for B.
+func TestCreateShipment_AlreadyShippedGroupIsNotShippedTwice(t *testing.T) {
+	db := testdb.NewDB(t, perWarehouseTables...)
+	storeID, tenantID := seedPerWarehouseStore(t, db)
+	whA := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Warehouse A", "1 Warehouse A Road")
+	whB := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Warehouse B", "2 Warehouse B Road")
+	seedPerWarehouseCarrierConfig(t, db, storeID, tenantID, nil)
+	orderID := seedPerWarehouseOrder(t, db, storeID, tenantID)
+	itemA := seedPerWarehouseItem(t, db, orderID, "SKU-A", 1)
+	itemB := seedPerWarehouseItem(t, db, orderID, "SKU-B", 1)
+	seedAllocation(t, db, tenantID, storeID, orderID, itemA, whA.ID, 1)
+	seedAllocation(t, db, tenantID, storeID, orderID, itemB, whB.ID, 1)
+
+	// Groups are walked in warehouse_id order, so fail whichever of A/B
+	// sorts second — the FIRST call in that order must succeed and
+	// persist before the failing one aborts the request.
+	failLine1 := "2 Warehouse B Road"
+	if whB.ID < whA.ID {
+		failLine1 = "1 Warehouse A Road"
+	}
+	carrier := &stubCarrier{failOnceForLine1: failLine1}
+	h := newPerWarehouseHandler(db, carrier)
+
+	// First call: one group succeeds, the other fails the whole request.
+	w1 := createShipmentViaHandler(t, h, storeID, orderID, tenantID)
+	require.Equal(t, http.StatusBadGateway, w1.Code, w1.Body.String())
+
+	shipmentsAfterFirst := shipmentsForOrder(t, db, orderID.String())
+	require.Len(t, shipmentsAfterFirst, 1, "the succeeding group's shipment must be persisted despite the other group's failure")
+
+	// Second call: the retry. The already-shipped group must not be
+	// re-shipped; only the previously-failed group gets a new shipment.
+	w2 := createShipmentViaHandler(t, h, storeID, orderID, tenantID)
+	require.Equal(t, http.StatusCreated, w2.Code, w2.Body.String())
+
+	shipmentsAfterRetry := shipmentsForOrder(t, db, orderID.String())
+	require.Len(t, shipmentsAfterRetry, 2, "the retry must add exactly one shipment, for the group that had failed")
+
+	firstIDs := map[string]bool{}
+	for _, s := range shipmentsAfterFirst {
+		firstIDs[s.ID] = true
+	}
+	newCount := 0
+	for _, s := range shipmentsAfterRetry {
+		if !firstIDs[s.ID] {
+			newCount++
+		}
+	}
+	require.Equal(t, 1, newCount, "the retry must not touch the shipment already created for the succeeding group")
+
+	groups := groupsForOrder(t, db, orderID.String())
+	require.Len(t, groups, 2)
+	for _, g := range groups {
+		require.NotNil(t, g.ShipmentID, "both groups must be stamped after the retry")
+	}
+}

--- a/services/marketplace-api/internal/handlers/storefront/order_detail.go
+++ b/services/marketplace-api/internal/handlers/storefront/order_detail.go
@@ -470,6 +470,8 @@ func defaultTimelineDescription(kind string) string {
 		return "Payment received."
 	case "fulfilled":
 		return "Order fulfilled."
+	case "partially_fulfilled":
+		return "Part of your order has shipped."
 	case "cancelled":
 		return "Order cancelled."
 	case "refunded":

--- a/services/marketplace-api/internal/handlers/storefront/order_detail_timeline_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/order_detail_timeline_test.go
@@ -1,0 +1,33 @@
+package storefront
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDefaultTimelineDescription_PartiallyFulfilledHasHumanCopy pins task-2
+// FIX 3: MarkPartiallyFulfilled (internal/order/service.go) writes a
+// status-changed event with no "description" field in its payload, so
+// every successful two-group order falls through to
+// defaultTimelineDescription's kind-string fallback. Before this fix that
+// switch had no case for "partially_fulfilled", so the customer-facing
+// storefront timeline rendered the raw event kind string instead of human
+// copy.
+func TestDefaultTimelineDescription_PartiallyFulfilledHasHumanCopy(t *testing.T) {
+	got := defaultTimelineDescription("partially_fulfilled")
+	require.NotEqual(t, "partially_fulfilled", got,
+		"the raw event kind must never reach the customer-facing timeline")
+	require.Equal(t, "Part of your order has shipped.", got)
+}
+
+// TestPartiallyFulfilled_IsNotCustomerHidden guards the other half of FIX
+// 3's instruction: a customer whose parcel shipped must SEE the event, not
+// have it silently filtered by customerHiddenEventKinds the way
+// merchant-only operational kinds are.
+func TestPartiallyFulfilled_IsNotCustomerHidden(t *testing.T) {
+	for _, hidden := range customerHiddenEventKinds {
+		require.NotEqual(t, "partially_fulfilled", hidden,
+			"partially_fulfilled must remain visible on the customer timeline")
+	}
+}

--- a/services/marketplace-api/internal/order/events.go
+++ b/services/marketplace-api/internal/order/events.go
@@ -13,17 +13,18 @@ import (
 type EventKind string
 
 const (
-	EventKindCreated         EventKind = "created"
-	EventKindStatusChanged   EventKind = "status_changed"
-	EventKindPaymentRecorded EventKind = "payment_recorded"
-	EventKindFulfilled       EventKind = "fulfilled"
-	EventKindCancelled       EventKind = "cancelled"
-	EventKindRefunded        EventKind = "refunded"
-	EventKindReturnRequested EventKind = "return_requested"
-	EventKindReturnApproved  EventKind = "return_approved"
-	EventKindReturnReceived  EventKind = "return_received"
-	EventKindReturnRefunded  EventKind = "return_refunded"
-	EventKindReturnRejected  EventKind = "return_rejected"
+	EventKindCreated            EventKind = "created"
+	EventKindStatusChanged      EventKind = "status_changed"
+	EventKindPaymentRecorded    EventKind = "payment_recorded"
+	EventKindFulfilled          EventKind = "fulfilled"
+	EventKindPartiallyFulfilled EventKind = "partially_fulfilled"
+	EventKindCancelled          EventKind = "cancelled"
+	EventKindRefunded           EventKind = "refunded"
+	EventKindReturnRequested    EventKind = "return_requested"
+	EventKindReturnApproved     EventKind = "return_approved"
+	EventKindReturnReceived     EventKind = "return_received"
+	EventKindReturnRefunded     EventKind = "return_refunded"
+	EventKindReturnRejected     EventKind = "return_rejected"
 
 	// Fulfillment / shipment timeline. These feed the customer-facing
 	// order tracking view. `shipment_created` fires when a label is

--- a/services/marketplace-api/internal/order/partial_fulfilment_integration_test.go
+++ b/services/marketplace-api/internal/order/partial_fulfilment_integration_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package order_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/internal/outbox"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// newPartialFulfilmentOrder seeds a store + confirmed order the same way
+// TestOrderLifecycle_FullJourney does, and returns its id. Cribbed from
+// that test's fixture shape (see lifecycle_integration_test.go) rather
+// than duplicated wholesale — it reuses seedStoreWithTenant, which is
+// package-level in this _test package.
+func newPartialFulfilmentOrder(t *testing.T, db *gorm.DB, svc *order.Service) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	storeID := uuid.New()
+	tenantID := uuid.New()
+	seedStoreWithTenant(t, db, storeID, tenantID)
+
+	createInput := order.CreateInput{
+		TenantID:       tenantID,
+		StoreID:        storeID,
+		StorePrefix:    "PFT",
+		OrderNumberSeq: 1,
+		IdempotencyKey: "partial-fulfilment-" + uuid.NewString(),
+		CustomerEmail:  "partial@example.com",
+		Items: []order.OrderItem{
+			{
+				TitleSnapshot: "Widget",
+				SKUSnapshot:   "WID-1",
+				UnitPrice:     decimal.NewFromInt(50),
+				Quantity:      2,
+				LineTotal:     decimal.NewFromInt(100),
+				CurrencyCode:  "EUR",
+			},
+		},
+		Shipping: order.OrderAddress{
+			Name: "A", Line1: "1", City: "Dublin", CountryCode: "IE",
+		},
+		Billing: order.OrderAddress{
+			Name: "A", Line1: "1", City: "Dublin", CountryCode: "IE",
+		},
+		Subtotal:     decimal.NewFromInt(100),
+		GrandTotal:   decimal.NewFromInt(100),
+		CurrencyCode: "EUR",
+		PlacedAt:     time.Now().UTC(),
+	}
+	result, err := svc.Create(ctx, createInput)
+	require.NoError(t, err)
+
+	target := order.PaymentStatusPaid
+	require.NoError(t, svc.Confirm(ctx, nil, result.Order.ID, &target, "stripe-auth"))
+
+	return result.Order.ID
+}
+
+// TestMarkPartiallyFulfilled_SetsPartial: an unfulfilled order transitions
+// to partial, and orders.status is left untouched — partial shipment does
+// not fulfil the order.
+func TestMarkPartiallyFulfilled_SetsPartial(t *testing.T) {
+	ctx := context.Background()
+	db := testdb.NewDB(t,
+		"order_events",
+		"order_addresses",
+		"order_items",
+		"orders",
+		"outbox_events",
+		"store_watermarks",
+	)
+	repo := order.NewRepository()
+	outboxRepo := outbox.NewRepository(db)
+	svc := order.NewService(db, repo, outboxRepo)
+
+	orderID := newPartialFulfilmentOrder(t, db, svc)
+
+	require.NoError(t, svc.MarkPartiallyFulfilled(ctx, nil, orderID))
+
+	final, _, _, err := repo.GetByID(ctx, db, orderID)
+	require.NoError(t, err)
+	require.Equal(t, string(order.FulfillmentStatusPartial), final.FulfillmentStatus)
+	require.Equal(t, string(order.OrderStatusConfirmed), final.Status,
+		"MarkPartiallyFulfilled must not touch orders.status")
+
+	var events []order.OrderEvent
+	require.NoError(t, db.Where("order_id = ? AND kind = ?", orderID, string(order.EventKindPartiallyFulfilled)).
+		Find(&events).Error)
+	require.Len(t, events, 1, "exactly one partially_fulfilled event must be recorded")
+}
+
+// TestMarkPartiallyFulfilled_RefusesFromFulfilled: fulfilled -> partial is
+// not a legal transition. A completed order must never be downgraded.
+func TestMarkPartiallyFulfilled_RefusesFromFulfilled(t *testing.T) {
+	ctx := context.Background()
+	db := testdb.NewDB(t,
+		"order_events",
+		"order_addresses",
+		"order_items",
+		"orders",
+		"outbox_events",
+		"store_watermarks",
+	)
+	repo := order.NewRepository()
+	outboxRepo := outbox.NewRepository(db)
+	svc := order.NewService(db, repo, outboxRepo)
+
+	orderID := newPartialFulfilmentOrder(t, db, svc)
+	require.NoError(t, svc.MarkFulfilled(ctx, nil, orderID))
+
+	err := svc.MarkPartiallyFulfilled(ctx, nil, orderID)
+	require.Error(t, err)
+	var ae *apperrors.Error
+	require.ErrorAs(t, err, &ae)
+	require.Equal(t, apperrors.CodeInvalidTransition, ae.Code,
+		"fulfilled -> partial must be refused, not silently applied")
+
+	final, _, _, err := repo.GetByID(ctx, db, orderID)
+	require.NoError(t, err)
+	require.Equal(t, string(order.FulfillmentStatusFulfilled), final.FulfillmentStatus,
+		"a completed order must not be downgraded to partial")
+	require.Equal(t, string(order.OrderStatusFulfilled), final.Status)
+}
+
+// TestMarkPartiallyFulfilled_IsIdempotent: calling it twice on an
+// already-partial order does not error — a retried shipment-creation call
+// reporting "still owes a parcel" a second time is not an illegal
+// transition.
+func TestMarkPartiallyFulfilled_IsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	db := testdb.NewDB(t,
+		"order_events",
+		"order_addresses",
+		"order_items",
+		"orders",
+		"outbox_events",
+		"store_watermarks",
+	)
+	repo := order.NewRepository()
+	outboxRepo := outbox.NewRepository(db)
+	svc := order.NewService(db, repo, outboxRepo)
+
+	orderID := newPartialFulfilmentOrder(t, db, svc)
+
+	require.NoError(t, svc.MarkPartiallyFulfilled(ctx, nil, orderID))
+	require.NoError(t, svc.MarkPartiallyFulfilled(ctx, nil, orderID))
+
+	final, _, _, err := repo.GetByID(ctx, db, orderID)
+	require.NoError(t, err)
+	require.Equal(t, string(order.FulfillmentStatusPartial), final.FulfillmentStatus)
+}

--- a/services/marketplace-api/internal/order/service.go
+++ b/services/marketplace-api/internal/order/service.go
@@ -309,6 +309,51 @@ func (s *Service) MarkFulfilled(ctx context.Context, tx *gorm.DB, orderID uuid.U
 	})
 }
 
+// MarkPartiallyFulfilled moves fulfillment_status → partial. It does NOT
+// touch orders.status — a partial shipment does not fulfil the order, so
+// the order axis stays exactly where it is (typically confirmed). This is
+// the counterpart to MarkFulfilled for orders that still owe at least one
+// parcel: createShipmentsPerWarehouse calls this when unshipped allocation
+// groups remain after shipping the ones it can.
+//
+// Idempotent: calling it again on an order already partial is a no-op — the
+// fulfillmentStatusTransitions table only allows partial → fulfilled, not
+// partial → partial, so a second "still owes a parcel" report (e.g. from a
+// retried shipment-creation call) must not be treated as an illegal
+// transition.
+func (s *Service) MarkPartiallyFulfilled(ctx context.Context, tx *gorm.DB, orderID uuid.UUID) error {
+	return s.runMaybeOwnTx(ctx, tx, func(tx *gorm.DB) error {
+		o, err := s.loadForUpdate(tx, orderID)
+		if err != nil {
+			return err
+		}
+		if o.FulfillmentStatus == string(FulfillmentStatusPartial) {
+			return nil
+		}
+		if !FulfillmentStatus(o.FulfillmentStatus).CanTransitionTo(FulfillmentStatusPartial) {
+			return apperrors.InvalidTransition("fulfillment", o.FulfillmentStatus, string(FulfillmentStatusPartial))
+		}
+		if err := s.repo.UpdateFulfillmentStatus(tx, orderID, FulfillmentStatusPartial); err != nil {
+			return err
+		}
+		if err := s.repo.AppendEvent(tx, &OrderEvent{
+			OrderID: orderID,
+			Kind:    string(EventKindPartiallyFulfilled),
+			Payload: EncodeStatusChanged(StatusChangedPayload{
+				Axis: "fulfillment",
+				From: o.FulfillmentStatus,
+				To:   string(FulfillmentStatusPartial),
+			}),
+		}); err != nil {
+			return err
+		}
+		return s.enqueueOutbox(ctx, tx, o.TenantID, outbox.AggregateOrder, orderID, outbox.EventOrderPartiallyFulfilled, map[string]any{
+			"store_id": o.StoreID.String(),
+			"order_id": orderID.String(),
+		})
+	})
+}
+
 // Cancel transitions an order to cancelled. Reason is recorded in the
 // order_events row.
 func (s *Service) Cancel(ctx context.Context, tx *gorm.DB, orderID uuid.UUID, reason string) error {

--- a/services/marketplace-api/internal/order/service.go
+++ b/services/marketplace-api/internal/order/service.go
@@ -354,6 +354,45 @@ func (s *Service) MarkPartiallyFulfilled(ctx context.Context, tx *gorm.DB, order
 	})
 }
 
+// MarkFulfillmentComplete moves fulfillment_status → fulfilled. Unlike
+// MarkFulfilled it does NOT touch orders.status — label creation is not the
+// "this order is done" action; the manual /fulfill admin endpoint (which
+// still calls MarkFulfilled) is. orders.status has fulfilled as a TERMINAL
+// state (see status.go), so advancing it here would permanently block
+// Cancel on every order the moment its first (and, for a single-warehouse
+// store, only) group ships — before the parcel is even picked up. This is
+// the fulfillment-only counterpart to MarkPartiallyFulfilled, called by
+// createShipmentsPerWarehouse when no unshipped allocation groups remain.
+func (s *Service) MarkFulfillmentComplete(ctx context.Context, tx *gorm.DB, orderID uuid.UUID) error {
+	return s.runMaybeOwnTx(ctx, tx, func(tx *gorm.DB) error {
+		o, err := s.loadForUpdate(tx, orderID)
+		if err != nil {
+			return err
+		}
+		if !FulfillmentStatus(o.FulfillmentStatus).CanTransitionTo(FulfillmentStatusFulfilled) {
+			return apperrors.InvalidTransition("fulfillment", o.FulfillmentStatus, string(FulfillmentStatusFulfilled))
+		}
+		if err := s.repo.UpdateFulfillmentStatus(tx, orderID, FulfillmentStatusFulfilled); err != nil {
+			return err
+		}
+		if err := s.repo.AppendEvent(tx, &OrderEvent{
+			OrderID: orderID,
+			Kind:    string(EventKindFulfilled),
+			Payload: EncodeStatusChanged(StatusChangedPayload{
+				Axis: "fulfillment",
+				From: o.FulfillmentStatus,
+				To:   string(FulfillmentStatusFulfilled),
+			}),
+		}); err != nil {
+			return err
+		}
+		return s.enqueueOutbox(ctx, tx, o.TenantID, outbox.AggregateOrder, orderID, outbox.EventOrderFulfilled, map[string]any{
+			"store_id": o.StoreID.String(),
+			"order_id": orderID.String(),
+		})
+	})
+}
+
 // Cancel transitions an order to cancelled. Reason is recorded in the
 // order_events row.
 func (s *Service) Cancel(ctx context.Context, tx *gorm.DB, orderID uuid.UUID, reason string) error {

--- a/services/marketplace-api/internal/outbox/models.go
+++ b/services/marketplace-api/internal/outbox/models.go
@@ -72,6 +72,7 @@ const (
 	EventOrderPlaced                = "order.placed"
 	EventOrderConfirmed             = "order.confirmed"
 	EventOrderFulfilled             = "order.fulfilled"
+	EventOrderPartiallyFulfilled    = "order.partially_fulfilled"
 	EventOrderCancelled             = "order.cancelled"
 	EventOrderRefunded              = "order.refunded"
 	EventReturnRequested            = "return.requested"

--- a/services/marketplace-api/internal/shipping/repository.go
+++ b/services/marketplace-api/internal/shipping/repository.go
@@ -69,6 +69,14 @@ type ShipmentRecord struct {
 	CancelReason      string     `gorm:"column:cancel_reason;type:text"`
 	CancelRequestedAt *time.Time `gorm:"column:cancel_requested_at"`
 
+	// WarehouseID is where this shipment actually shipped from (#177,
+	// migration 000118). Nullable: every shipment created before that
+	// migration has no honest answer, and a shipment created for an order
+	// with no allocations (the whole store today) attributes to the
+	// carrier config's warehouse instead of a specific allocation group,
+	// so it is left NULL rather than guessed.
+	WarehouseID *uuid.UUID `gorm:"column:warehouse_id;type:uuid"`
+
 	// Response-shape only — never touch the DB. Callers map these after
 	// reading a row, and the carrier layer sets them on create.
 	Provider           string `gorm:"-"`


### PR DESCRIPTION
**PR 4b of 7** toward multi-warehouse support. Label creation now produces one
shipment per contributing warehouse — each shipping from its own address with
its own parcel contents — and an order still owing a parcel reports
`fulfillment_status = 'partial'`.

Part of #177. Follows #492.

## The production path is untouched

`order_allocations` is empty in production: allocation began with #491, deployed
today, and no order has been placed since. So **every existing order takes the
no-allocations path**, and that path is a byte-for-byte move into
`createSingleShipment`. Verified mechanically against `06f2bb8f` rather than by
assertion — exactly seven removed lines, all sanctioned:

- the carrier construction, now behind a nil-safe `newCarrier` seam
- `tryAutoSchedulePickup` gaining a `warehouseName` parameter whose caller
  passes the value the function previously recomputed internally

Before the routing decision, the only new work on that path is one indexed
`COUNT` on `order_allocations`.

## Routing has three states, not two

- no allocations → `createSingleShipment`, unchanged
- allocations exist, none unshipped → **409**, nothing created
- otherwise → one shipment per unshipped warehouse group

The middle state is the important one. Collapsing it into the first — which is
what this PR originally did — meant a re-POST on a fully shipped order fell
through and minted a **duplicate whole-order label at the carrier**, which
cannot be un-created.

## Partial failure keeps what it made

A carrier failure part-way through leaves the already-created parcels
persisted and the rest unshipped. A label cannot be un-created, so rollback
isn't available; `order_allocations.shipment_id IS NULL` is precisely the
marker a retry needs. The merchant sees a partly-shipped order — the honest
state — and retries the rest.

**This is not idempotency.** Two simultaneous POSTs still both buy a label:
the group read, the carrier call and the stamp are three statements with no
row lock and no unique constraint. That is pre-existing on the single path
too, and it is called out below rather than papered over.

## Nine defects found in review, six of them in the plan

Worth listing, because several were invisible to a green suite:

- **Duplicate label on re-POST** — the two-state routing above.
- **The allocation stamp failed open.** It logged and still returned 201; that
  single write is what makes a retry safe, so a failure meant the next retry
  bought a second label. It now fails the response.
- **The Delhivery self-heal was missing** from the grouped path. Secondary
  warehouses are exactly the ones never registered carrier-side, so the first
  real multi-warehouse label attempt was the most likely case to hit
  `ClientWarehouse matching query does not exist` — #177's own root cause,
  reappearing inside the feature meant to fix it.
- **Label-URL proxying was missing**, so a Delhivery label would exist at the
  carrier with no way to print it from the admin UI.
- **Label creation advanced `orders.status` to `fulfilled`, which is terminal.**
  The merchant would permanently lose the ability to cancel — before pickup.
  Label creation now moves only `fulfillment_status`; `MarkFulfilled` stays for
  the manual `/fulfill` endpoint, which is the deliberate "this order is done"
  action.
- **Unstocked line items vanished from every parcel.** Items with no
  `variant_id` get no allocation row by design (refusing them "would break
  every unstocked sale"), which was harmless when the parcel came from all
  order items. They now ride in the first shipment's parcel.
- **…and that fix introduced a double-shipment**, caught in re-review: "first
  group" is positional within a call, and groups are recomputed remaining-only
  on retry, so after a partial failure the item shipped a second time. Now
  gated on the order's first shipment overall.
- **A pending order stranded at `partial` silently** — dissolved by the
  `orders.status` fix, since the order-axis precondition is gone.
- **The customer timeline rendered the literal string `partially_fulfilled`.**

## Testing

Eight integration tests on the grouped path plus fulfilment-transition
coverage, real DSN, `-p 1`, durations that prove they ran (admin 26.4s, order
2.3s, storefront 17.3s, shipping 0.7s). Full unit suite green.

Mutation-tested, each removed and confirmed to break a test: the no-allocations
branch, the already-shipped filter, the remaining-groups check, the
fulfilment-axis-only transition, and the unallocated-item gate. The last one
reproduced the actual double-ship — the same item in two parcels.

## Known gaps, deliberately not fixed here

- **The admin UI can only see and operate one parcel per order.**
  `GetShipmentByOrderID` is a `First()` with no ordering, and manual status
  updates 404 on the second parcel. Not reachable today — the only store with a
  warehouse has exactly one — but **this must land before PR 5 gives any
  merchant a second warehouse.**
- **`pickup_warning` is not rendered by the admin UI**, so the fulfilment-status
  warning is currently a log line in practice. The server side is correct; the
  app change ships separately, as the order-detail field did in #492.
- **Cancelling a shipment leaves its allocations stamped**, so re-labelling
  returns 409 permanently and only `Delete` recovers. Correct as a
  duplicate-label defence, undocumented as a dead end.
- Concurrent `Create` can still mint duplicate labels, as above.

Follow-up issues are filed for the first three.
