### PR TITLE
fix(shipping): let the admin see and operate every parcel of a multi-warehouse order (#496)

### DIFF
--- a/services/marketplace-api/internal/handlers/admin/shipments.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments.go
@@ -1945,12 +1945,17 @@ func (h *ShipmentsHandler) UpdateStatus(c *gin.Context) {
 		return
 	}
 
-	rec, err := h.repo.GetShipmentByOrderID(ctx, orderID)
+	// Resolve by the shipment's own id — not the order's — so any parcel
+	// on a multi-warehouse order can be advanced, not just the one
+	// GetShipmentByOrderID happens to pick. The order/store checks below
+	// are a real authorisation boundary (a shipment id from another order
+	// or store must still 404), so they stay.
+	rec, err := h.repo.GetShipmentByID(ctx, shipmentID)
 	if err != nil {
 		RespondErr(c, apperrors.NotFound("shipment"), h.logger)
 		return
 	}
-	if rec.ID != shipmentID || rec.StoreID.String() != c.Param("storeId") {
+	if rec.OrderID != orderID || rec.StoreID.String() != c.Param("storeId") {
 		RespondErr(c, apperrors.NotFound("shipment"), h.logger)
 		return
 	}
@@ -2011,12 +2016,38 @@ func (h *ShipmentsHandler) UpdateStatus(c *gin.Context) {
 }
 
 // GetByOrder handles GET /admin/stores/:storeId/orders/:id/shipments.
+//
+// Without ?all=true it keeps the pre-#496 response shape (a single object,
+// or null) so the existing admin client keeps working — but now
+// deterministically the FIRST parcel (created_at ASC, id ASC), not an
+// arbitrary one. With ?all=true it returns every parcel on the order as a
+// JSON array, letting a multi-warehouse order's second (and later) parcel
+// be seen at all.
 func (h *ShipmentsHandler) GetByOrder(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	orderID, err := uuid.Parse(c.Param("id"))
 	if err != nil {
 		RespondErr(c, apperrors.ValidationFailed("id", "must be a uuid"), h.logger)
+		return
+	}
+	storeID := c.Param("storeId")
+
+	if c.Query("all") == "true" {
+		recs, err := h.repo.ListShipmentsByOrderID(ctx, orderID)
+		if err != nil {
+			RespondErr(c, fmt.Errorf("shipments: list by order: %w", err), h.logger)
+			return
+		}
+		out := make([]ShipmentResponse, 0, len(recs))
+		for i := range recs {
+			rec := &recs[i]
+			if rec.StoreID.String() != storeID {
+				continue
+			}
+			out = append(out, toShipmentResponse(rec))
+		}
+		c.JSON(http.StatusOK, out)
 		return
 	}
 
@@ -2028,7 +2059,7 @@ func (h *ShipmentsHandler) GetByOrder(c *gin.Context) {
 	}
 
 	// Verify the shipment belongs to this store.
-	if rec.StoreID.String() != c.Param("storeId") {
+	if rec.StoreID.String() != storeID {
 		c.JSON(http.StatusOK, nil)
 		return
 	}

--- a/services/marketplace-api/internal/handlers/admin/shipments_multi_parcel_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments_multi_parcel_integration_test.go
@@ -1,0 +1,221 @@
+//go:build integration
+
+// Package admin — coverage for #496: the admin surface only ever showed and
+// let you operate one parcel of a multi-warehouse order.
+//
+// GetShipmentByOrderID's First() with no ORDER BY returned an arbitrary
+// parcel (effectively by primary key), and UpdateStatus resolved the record
+// via that same call before checking rec.ID == :shipmentId — so the second
+// parcel on a two-warehouse order 404'd on every manual status update. This
+// file proves: (1) GetByOrder?all=true returns both parcels, oldest first;
+// (2) GetByOrder with no param deterministically returns the FIRST parcel;
+// (3) UpdateStatus now succeeds for the SECOND parcel; (4) a shipment id
+// belonging to a different order or store still 404s.
+//
+// It reuses the per-warehouse test harness (stubCarrier, newPerWarehouseHandler,
+// seed helpers) from shipments_per_warehouse_integration_test.go to build a
+// real two-parcel order via Create(), rather than hand-inserting shipment
+// rows — that keeps these tests honest about what production actually
+// produces.
+package admin
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedTwoParcelOrder builds a confirmed order allocated across two
+// warehouses and ships it via Create(), producing two real shipments rows.
+// Returns the store/tenant/order ids and the two shipment ids in creation
+// order (first, second).
+func seedTwoParcelOrder(t *testing.T, db *gorm.DB) (storeID, tenantID, orderID uuid.UUID, firstShipmentID, secondShipmentID string) {
+	t.Helper()
+	storeID, tenantID = seedPerWarehouseStore(t, db)
+	whA := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Warehouse A", "1 Warehouse A Road")
+	whB := seedPerWarehouseWarehouse(t, db, storeID, tenantID, "Warehouse B", "2 Warehouse B Road")
+	seedPerWarehouseCarrierConfig(t, db, storeID, tenantID, nil)
+	orderID = seedPerWarehouseOrder(t, db, storeID, tenantID)
+	itemA := seedPerWarehouseItem(t, db, orderID, "SKU-A", 1)
+	itemB := seedPerWarehouseItem(t, db, orderID, "SKU-B", 1)
+	seedAllocation(t, db, tenantID, storeID, orderID, itemA, whA.ID, 1)
+	seedAllocation(t, db, tenantID, storeID, orderID, itemB, whB.ID, 1)
+
+	h := newPerWarehouseHandler(db, &stubCarrier{})
+	w := createShipmentViaHandler(t, h, storeID, orderID, tenantID)
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+	shipments := shipmentsForOrder(t, db, orderID.String())
+	require.Len(t, shipments, 2, "expected two parcels for a two-warehouse allocation")
+	// shipmentsForOrder already orders by created_at, id.
+	return storeID, tenantID, orderID, shipments[0].ID, shipments[1].ID
+}
+
+// getByOrderViaHandler calls GetByOrder directly against a hand-built
+// gin.Context, mirroring createShipmentViaHandler's pattern.
+func getByOrderViaHandler(t *testing.T, h *ShipmentsHandler, storeID, orderID uuid.UUID, all bool) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{
+		{Key: "storeId", Value: storeID.String()},
+		{Key: "id", Value: orderID.String()},
+	}
+	target := "/"
+	if all {
+		target = "/?all=true"
+	}
+	c.Request = httptest.NewRequest(http.MethodGet, target, nil)
+
+	h.GetByOrder(c)
+	return w
+}
+
+// updateStatusViaHandler calls UpdateStatus directly against a hand-built
+// gin.Context for the given shipmentId/orderId/storeId path params.
+func updateStatusViaHandler(t *testing.T, h *ShipmentsHandler, storeID, orderID uuid.UUID, shipmentID, status string) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	body, err := json.Marshal(UpdateStatusRequest{Status: status})
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{
+		{Key: "storeId", Value: storeID.String()},
+		{Key: "id", Value: orderID.String()},
+		{Key: "shipmentId", Value: shipmentID},
+	}
+	c.Request = httptest.NewRequest(http.MethodPatch, "/", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.UpdateStatus(c)
+	return w
+}
+
+// TestGetByOrder_AllTrueReturnsBothParcelsOldestFirst covers defect 3: the
+// admin previously had no way to fetch every parcel. ?all=true must return
+// both, in created_at ASC, id ASC order.
+func TestGetByOrder_AllTrueReturnsBothParcelsOldestFirst(t *testing.T) {
+	db := testdb.NewDB(t, perWarehouseTables...)
+	storeID, _, orderID, firstID, secondID := seedTwoParcelOrder(t, db)
+
+	h := newPerWarehouseHandler(db, &stubCarrier{})
+	w := getByOrderViaHandler(t, h, storeID, orderID, true)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var got []ShipmentResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Len(t, got, 2, "?all=true must return both parcels")
+	require.Equal(t, firstID, got[0].ID, "first parcel must be oldest")
+	require.Equal(t, secondID, got[1].ID, "second parcel must be second")
+}
+
+// TestGetByOrder_WithoutAllReturnsFirstParcelDeterministically covers
+// defect 1: GetShipmentByOrderID had no ORDER BY, so it returned an
+// arbitrary parcel. Without ?all=true, GetByOrder must consistently return
+// the FIRST parcel (by created_at, id) across repeated calls.
+func TestGetByOrder_WithoutAllReturnsFirstParcelDeterministically(t *testing.T) {
+	db := testdb.NewDB(t, perWarehouseTables...)
+	storeID, _, orderID, firstID, secondID := seedTwoParcelOrder(t, db)
+	require.NotEqual(t, firstID, secondID)
+
+	// stubCarrier encodes its pickup Line1 into the tracking number
+	// ("TRK-1 Warehouse A Road" / "TRK-2 Warehouse B Road"), so asserting
+	// on it (not just the id) proves GetByOrder returned the actual first
+	// parcel's data, not merely a row with a matching id.
+	wantTrackingNumber := trackingNumberForShipment(t, db, firstID)
+	otherTrackingNumber := trackingNumberForShipment(t, db, secondID)
+	require.NotEqual(t, wantTrackingNumber, otherTrackingNumber)
+
+	h := newPerWarehouseHandler(db, &stubCarrier{})
+
+	for i := 0; i < 5; i++ {
+		w := getByOrderViaHandler(t, h, storeID, orderID, false)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		var got ShipmentResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+		require.Equal(t, firstID, got.ID,
+			"call %d: GetByOrder without ?all=true must always return the first parcel", i)
+		require.Equal(t, wantTrackingNumber, got.TrackingNumber,
+			"call %d: must return the first parcel's own tracking number", i)
+		require.NotEqual(t, secondID, got.ID)
+	}
+}
+
+// TestUpdateStatus_SucceedsForSecondParcel is the core regression for
+// defect 2: UpdateStatus resolved the record via GetShipmentByOrderID (by
+// ORDER id) and then rejected any :shipmentId that didn't match, so the
+// second parcel could never be advanced. It must now resolve by the
+// shipment's own id, and must NOT touch the first parcel's status.
+func TestUpdateStatus_SucceedsForSecondParcel(t *testing.T) {
+	db := testdb.NewDB(t, perWarehouseTables...)
+	storeID, _, orderID, firstID, secondID := seedTwoParcelOrder(t, db)
+
+	h := newPerWarehouseHandler(db, &stubCarrier{})
+	w := updateStatusViaHandler(t, h, storeID, orderID, secondID, "in_transit")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var got ShipmentResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Equal(t, secondID, got.ID)
+	require.Equal(t, "in_transit", got.Status)
+
+	firstStatus := statusForShipment(t, db, firstID)
+	secondStatus := statusForShipment(t, db, secondID)
+	require.Equal(t, "in_transit", secondStatus, "the second parcel's status must have advanced")
+	require.Equal(t, "pending", firstStatus, "the first parcel's status must NOT have changed")
+}
+
+// TestUpdateStatus_MismatchedOrderOrStore404s covers the authorisation
+// boundary UpdateStatus must keep: a shipment id that does not belong to
+// the order/store in the path still 404s.
+func TestUpdateStatus_MismatchedOrderOrStore404s(t *testing.T) {
+	db := testdb.NewDB(t, perWarehouseTables...)
+	storeID, tenantID, orderID, _, secondID := seedTwoParcelOrder(t, db)
+
+	h := newPerWarehouseHandler(db, &stubCarrier{})
+
+	t.Run("wrong order id", func(t *testing.T) {
+		otherOrderID := seedPerWarehouseOrder(t, db, storeID, tenantID)
+		w := updateStatusViaHandler(t, h, storeID, otherOrderID, secondID, "in_transit")
+		require.Equal(t, http.StatusNotFound, w.Code, w.Body.String())
+	})
+
+	t.Run("wrong store id", func(t *testing.T) {
+		otherStoreID := uuid.New()
+		w := updateStatusViaHandler(t, h, otherStoreID, orderID, secondID, "in_transit")
+		require.Equal(t, http.StatusNotFound, w.Code, w.Body.String())
+	})
+}
+
+// statusForShipment reads shipments.status directly for a given shipment
+// id — used to assert one parcel's status advanced without disturbing the
+// other's.
+func statusForShipment(t *testing.T, db *gorm.DB, shipmentID string) string {
+	t.Helper()
+	var status string
+	require.NoError(t, db.Raw(
+		`SELECT status FROM shipments WHERE id = ?`, shipmentID).Row().Scan(&status))
+	return status
+}
+
+// trackingNumberForShipment reads shipments.tracking_number directly.
+func trackingNumberForShipment(t *testing.T, db *gorm.DB, shipmentID string) string {
+	t.Helper()
+	var trackingNumber string
+	require.NoError(t, db.Raw(
+		`SELECT tracking_number FROM shipments WHERE id = ?`, shipmentID).Row().Scan(&trackingNumber))
+	return trackingNumber
+}

--- a/services/marketplace-api/internal/handlers/admin/shipments_multi_parcel_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments_multi_parcel_integration_test.go
@@ -22,15 +22,20 @@ package admin
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 
+	"github.com/mark8ly/marketplace-api/internal/shipping"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
@@ -58,6 +63,78 @@ func seedTwoParcelOrder(t *testing.T, db *gorm.DB) (storeID, tenantID, orderID u
 	require.Len(t, shipments, 2, "expected two parcels for a two-warehouse allocation")
 	// shipmentsForOrder already orders by created_at, id.
 	return storeID, tenantID, orderID, shipments[0].ID, shipments[1].ID
+}
+
+// seedShuffledParcels seeds n shipment rows directly (bypassing Create(),
+// which has no reason to control id/created_at relationships) for one
+// order, choosing ids and created_at values that deliberately DISAGREE.
+//
+// The first attempt at this fixture only inverted PHYSICAL INSERT order
+// against created_at, on the theory that an unordered query falls back to
+// heap/physical scan order. Re-running the mutation (drop the explicit
+// .Order(...) in GetShipmentByOrderID) against that fixture still only
+// caught it ~50-60% of the time — because that theory was wrong. GORM's
+// First() silently injects `ORDER BY id ASC` whenever no explicit Order()
+// is given (a documented GORM convention for First/Last), so the "no
+// ordering" mutant is not actually unordered — it orders by the random
+// v4 UUID primary key, which is unrelated to created_at and only
+// disagrees with the intended row part of the time.
+//
+// The reliable fixture therefore has to invert id order against created_at
+// order, not insertion order: the row that should sort FIRST by created_at
+// is given the LARGEST id, and the row that should sort LAST is given the
+// SMALLEST id. That makes the two possible answers provably different
+// instead of probabilistically different:
+//   - correct code (ORDER BY created_at ASC, id ASC) returns the
+//     earliest-created_at row, regardless of its id.
+//   - the mutant (GORM's implicit ORDER BY id ASC) returns the
+//     smallest-id row, which by construction is the row that should sort
+//     LAST — never the same row as the correct answer.
+//
+// Returns the shipment ids in INTENDED (created_at ASC) order — index 0 is
+// the row every correct caller must treat as "the first parcel".
+func seedShuffledParcels(t *testing.T, db *gorm.DB, n int) (storeID, tenantID, orderID uuid.UUID, orderedIDs []string) {
+	t.Helper()
+	storeID, tenantID = seedPerWarehouseStore(t, db)
+	orderID = seedPerWarehouseOrder(t, db, storeID, tenantID)
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	orderedIDs = make([]string, n)
+	for i := 0; i < n; i++ {
+		// Intended position i (0 = first/earliest) gets an ASCENDING
+		// created_at but a DESCENDING id — id value (n-1-i), so index 0
+		// (earliest created_at) holds the LARGEST id and index n-1
+		// (latest created_at) holds the SMALLEST id (0000...0000).
+		createdAt := base.Add(time.Duration(i) * time.Hour)
+		id := deterministicUUID(n - 1 - i)
+		rec := shipping.ShipmentRecord{
+			ID:             id,
+			TenantID:       tenantID,
+			StoreID:        storeID,
+			OrderID:        orderID,
+			Carrier:        "stubcarrier",
+			TrackingNumber: fmt.Sprintf("TRK-SHUFFLED-%d", i),
+			Status:         "pending",
+			ShipFrom:       datatypes.JSON(`{}`),
+			ShipTo:         datatypes.JSON(`{}`),
+			HandlingFee:    decimal.Zero,
+			CurrencyCode:   "INR",
+			CreatedAt:      createdAt,
+			UpdatedAt:      createdAt,
+		}
+		require.NoError(t, db.Create(&rec).Error)
+		orderedIDs[i] = rec.ID.String()
+	}
+	return storeID, tenantID, orderID, orderedIDs
+}
+
+// deterministicUUID builds a valid, lexicographically-ordered uuid.UUID
+// from a small non-negative integer — value 0 sorts smallest, larger
+// values sort larger, ascending in step with the integer. Used so a
+// fixture can pin id ordering independently of created_at ordering
+// (see seedShuffledParcels).
+func deterministicUUID(value int) uuid.UUID {
+	return uuid.MustParse(fmt.Sprintf("00000000-0000-4000-8000-%012d", value))
 }
 
 // getByOrderViaHandler calls GetByOrder directly against a hand-built
@@ -125,18 +202,24 @@ func TestGetByOrder_AllTrueReturnsBothParcelsOldestFirst(t *testing.T) {
 // defect 1: GetShipmentByOrderID had no ORDER BY, so it returned an
 // arbitrary parcel. Without ?all=true, GetByOrder must consistently return
 // the FIRST parcel (by created_at, id) across repeated calls.
+//
+// Uses seedShuffledParcels (4 rows) rather than seedTwoParcelOrder: id
+// order there is the exact REVERSE of intended created_at order, so
+// GORM's implicit "ORDER BY id ASC" fallback (what actually runs when the
+// explicit .Order(...) is removed — see seedShuffledParcels' doc comment)
+// disagrees with the correct answer by construction, not by chance. See
+// seedShuffledParcels' doc comment and REPORT.md's Mutation A note for why
+// a naively-seeded fixture only caught the regression ~50-60% of the time.
 func TestGetByOrder_WithoutAllReturnsFirstParcelDeterministically(t *testing.T) {
 	db := testdb.NewDB(t, perWarehouseTables...)
-	storeID, _, orderID, firstID, secondID := seedTwoParcelOrder(t, db)
-	require.NotEqual(t, firstID, secondID)
+	storeID, _, orderID, orderedIDs := seedShuffledParcels(t, db, 4)
+	wantID := orderedIDs[0]
 
-	// stubCarrier encodes its pickup Line1 into the tracking number
-	// ("TRK-1 Warehouse A Road" / "TRK-2 Warehouse B Road"), so asserting
-	// on it (not just the id) proves GetByOrder returned the actual first
+	// stubCarrier-independent: seedShuffledParcels stamps each row's own
+	// tracking number ("TRK-SHUFFLED-<intended position>"), so asserting on
+	// it (not just the id) proves GetByOrder returned the actual first
 	// parcel's data, not merely a row with a matching id.
-	wantTrackingNumber := trackingNumberForShipment(t, db, firstID)
-	otherTrackingNumber := trackingNumberForShipment(t, db, secondID)
-	require.NotEqual(t, wantTrackingNumber, otherTrackingNumber)
+	wantTrackingNumber := trackingNumberForShipment(t, db, wantID)
 
 	h := newPerWarehouseHandler(db, &stubCarrier{})
 
@@ -146,11 +229,13 @@ func TestGetByOrder_WithoutAllReturnsFirstParcelDeterministically(t *testing.T) 
 
 		var got ShipmentResponse
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
-		require.Equal(t, firstID, got.ID,
+		require.Equal(t, wantID, got.ID,
 			"call %d: GetByOrder without ?all=true must always return the first parcel", i)
 		require.Equal(t, wantTrackingNumber, got.TrackingNumber,
 			"call %d: must return the first parcel's own tracking number", i)
-		require.NotEqual(t, secondID, got.ID)
+		for _, otherID := range orderedIDs[1:] {
+			require.NotEqual(t, otherID, got.ID)
+		}
 	}
 }
 

--- a/services/marketplace-api/internal/shipping/repository.go
+++ b/services/marketplace-api/internal/shipping/repository.go
@@ -193,9 +193,18 @@ func (r *gormRepository) GetShipmentByID(ctx context.Context, id uuid.UUID) (*Sh
 	return &rec, nil
 }
 
+// GetShipmentByOrderID returns the first parcel on an order, ordered
+// created_at ASC, id ASC. A multi-warehouse order has one shipments row per
+// warehouse (#177); without an explicit order Postgres returns whichever row
+// it likes (effectively by primary key), which made this pick an arbitrary
+// parcel. Ordering here matches storefront/order_detail.go's loadShipments
+// (added in #492) so "the shipment" means the same parcel everywhere (#496).
 func (r *gormRepository) GetShipmentByOrderID(ctx context.Context, orderID uuid.UUID) (*ShipmentRecord, error) {
 	var rec ShipmentRecord
-	err := r.db.WithContext(ctx).Where("order_id = ?", orderID).First(&rec).Error
+	err := r.db.WithContext(ctx).
+		Where("order_id = ?", orderID).
+		Order("created_at ASC, id ASC").
+		First(&rec).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, fmt.Errorf("shipping: shipment not found for order")
 	}
@@ -228,7 +237,7 @@ func (r *gormRepository) ListShipmentsByOrderID(ctx context.Context, orderID uui
 	var recs []ShipmentRecord
 	if err := r.db.WithContext(ctx).
 		Where("order_id = ?", orderID).
-		Order("created_at ASC").
+		Order("created_at ASC, id ASC").
 		Find(&recs).Error; err != nil {
 		return nil, fmt.Errorf("shipping: list shipments by order id: %w", err)
 	}


### PR DESCRIPTION
An order shipped from two warehouses has two `shipments` rows, but the admin
surface could only reach one of them. Closes #496.

This is a **prerequisite for #177's PR 5**: that PR ships warehouse CRUD, and
the moment a merchant creates a second warehouse, multi-parcel orders become
real.

## Three fixes

**1. `GetShipmentByOrderID` returned an arbitrary parcel.** It used `First()`
with no explicit ordering. Now `created_at ASC, id ASC` — the same ordering
`order_detail.go`'s `loadShipments` already uses (#492), so "the shipment"
consistently means the *first* parcel.

Worth recording, because the issue description and my own brief both had this
wrong: `First()` is **not** an unordered scan. GORM appends a primary-key
`ORDER BY`, so the old query was ordered by `id` — deterministic, but by random
uuid, which is arbitrary in business terms. An explicit `Order(...)` leads and
GORM's implicit one becomes the tiebreak.

**2. `UpdateStatus` 404'd on every parcel but one.** It took `:shipmentId` from
the path but resolved the record by *order* id, then rejected when the two
disagreed — so the second parcel's status could never be advanced manually. It
now resolves by shipment id and verifies the row belongs to this order **and**
this store.

That check is an authorisation boundary, not bookkeeping. It was reviewed
adversarially: with the store tree already behind `StoreMiddleware` +
`RequireTenantRelation`, a cross-store shipment fails the `StoreID` check and a
cross-order one fails the `OrderID` check, and the `Updates` runs only after
both. Deleting the check fails both 404 subtests deterministically.

**3. There was no way to fetch every parcel.** `GET /:id/shipments?all=true`
now returns them all, oldest first. Without the parameter the endpoint returns
exactly what it returned before — a single object or `null`, now
deterministically the oldest parcel. `apps/admin` builds this URL with no query
string, so the deployed client is byte-identical in behaviour. Its own change
ships separately, as the order-detail field did in #492.

## The determinism test was probabilistic, and now isn't

The first version of the guard caught its mutation only **3 runs in 5** —
reported honestly rather than rounded up, which is why it got fixed.

The cause was my wrong model: I assumed row order came from the physical scan,
so the first fixture attempt inverted insert order and still failed 2 runs in
5. The real cause is GORM's implicit `ORDER BY id`. The fixture now assigns
deterministic uuids so that **id order is the exact reverse of `created_at`
order** — correct code returns `…0003`, the mutant returns `…0000`. Disjoint by
construction. 5/5.

## Testing

Four integration tests against the real DSN: both parcels via `?all=true`
oldest-first; the no-parameter form returning the same parcel on repeated
calls; a status update succeeding on the **second** parcel while leaving the
first untouched; and 404s for a shipment belonging to another order or store.

Two guards mutation-tested — the explicit ordering (5/5 after the fixture fix)
and the ownership check (deterministic).

`go build`, `go vet`, `go vet -tags=integration`, `gofmt` clean; full unit
suite green; admin 27.0s and shipping 0.5s integration green.

## Known, not fixed here

The customer's singular `shipment` field (`loadShipment`, `DESC LIMIT 1`) still
means the **newest** parcel while admin's singular now means the **oldest**, so
on a two-parcel order the two surfaces name different parcels. Pre-existing and
documented at that call site; the singular field is scheduled for retirement in
#177's PR 6 once nothing reads it.

Also minor: the `?all=true` branch surfaces a repository error as a 500 while
the single form swallows it as `200 null`. The new behaviour is the better one;
noting the asymmetry so nothing assumes the endpoint never errors.
