### PR TITLE
fix(platform-api): use an unrestricted server API key for GIP admin calls

### DIFF
--- a/services/platform-api/cmd/server/main.go
+++ b/services/platform-api/cmd/server/main.go
@@ -241,11 +241,15 @@ func main() {
 	// tenant_id GIP custom claim after onboarding completes, and the
 	// invitation service needs it to stamp the same claim on accept.
 	var gipAdmin *gipadmin.AdminClient
-	if cfg.GIPProjectID != "" && cfg.GIPTenantID != "" && cfg.GIPWebAPIKey != "" {
+	// GIPKey prefers the unrestricted server key and falls back to the
+	// public web key. The web key is referrer-restricted, so admin calls
+	// such as resetPassword fail 403 "Requests from referer <empty> are
+	// blocked" when it is all that is configured.
+	if cfg.GIPProjectID != "" && cfg.GIPTenantID != "" && cfg.GIPKey() != "" {
 		admin, adminErr := gipadmin.New(context.Background(), gipadmin.Config{
 			ProjectID: cfg.GIPProjectID,
 			TenantID:  cfg.GIPTenantID,
-			WebAPIKey: cfg.GIPWebAPIKey,
+			WebAPIKey: cfg.GIPKey(),
 		})
 		if adminErr != nil {
 			log.Error("gipadmin: init", "err", adminErr)
@@ -268,7 +272,7 @@ func main() {
 				"reset_url", cfg.AdminResetBaseURL)
 		}
 	} else {
-		log.Warn("auth: password reset disabled — missing GIP_PROJECT_ID/GIP_TENANT_ID/GIP_WEB_API_KEY")
+		log.Warn("auth: password reset disabled — missing GIP_PROJECT_ID/GIP_TENANT_ID and GIP_SERVER_API_KEY or GIP_WEB_API_KEY")
 	}
 
 	// Assign through a typed interface variable only when non-nil, so the
@@ -310,7 +314,7 @@ func main() {
 	accountHandler := account.NewHandler(accountSvc)
 	merchantAccountRoutes := fga != nil && gipAdmin != nil
 	if !merchantAccountRoutes {
-		log.Warn("account: merchant teardown endpoint disabled — missing OpenFGA store or GIP_PROJECT_ID/GIP_TENANT_ID/GIP_WEB_API_KEY; operator teardown (#288) stays mounted")
+		log.Warn("account: merchant teardown endpoint disabled — missing OpenFGA store or GIP_PROJECT_ID/GIP_TENANT_ID and a GIP API key; operator teardown (#288) stays mounted")
 	}
 
 	// ─── Outbox drainer ────────────────────────────────────────────────

--- a/services/platform-api/pkg/config/config.go
+++ b/services/platform-api/pkg/config/config.go
@@ -83,13 +83,39 @@ type Config struct {
 	InternalAuthSecret string `envconfig:"INTERNAL_AUTH_SECRET"`
 
 	// GIP (Google Identity Platform) admin settings used by the
-	// password-reset flow. ProjectID + TenantID are required in prod;
-	// WebAPIKey is the public Firebase Web API key. If any of the
-	// three are blank, platform-api skips wiring the password-reset
-	// handler (dev convenience — local dev without real GIP).
+	// password-reset flow. ProjectID + TenantID are required in prod.
+	// If project, tenant and a usable key are not all present,
+	// platform-api skips wiring the password-reset handler (dev
+	// convenience — local dev without real GIP).
 	GIPProjectID string `envconfig:"GIP_PROJECT_ID"`
 	GIPTenantID  string `envconfig:"GIP_TENANT_ID"`
+
+	// GIPWebAPIKey is the PUBLIC Firebase Web API key — the same value the
+	// admin browser bundle embeds. Browser keys carry an HTTP-referrer
+	// restriction, and a server sends no Referer, so GIP answers
+	// "Requests from referer <empty> are blocked" (403) to anything this
+	// service calls with it. Kept only as a fallback so a deployment that
+	// has not yet been given a server key behaves exactly as before.
 	GIPWebAPIKey string `envconfig:"GIP_WEB_API_KEY"`
+
+	// GIPServerAPIKey is a key with NO referrer restriction, for
+	// server-to-server GIP calls. Prefer it over GIPWebAPIKey; see
+	// GIPKey below. Relaxing the web key instead is not an option —
+	// it is public by construction.
+	GIPServerAPIKey string `envconfig:"GIP_SERVER_API_KEY"`
+}
+
+// GIPKey returns the API key to use for server-side GIP calls: the
+// server key when configured, otherwise the public web key.
+//
+// The fallback exists so this change can ship before the server key does.
+// It is not a permanent arrangement — a web key will keep failing
+// referrer-restricted admin operations like resetPassword.
+func (c *Config) GIPKey() string {
+	if c.GIPServerAPIKey != "" {
+		return c.GIPServerAPIKey
+	}
+	return c.GIPWebAPIKey
 }
 
 // Load reads .env (if present) and binds environment variables into Config.

--- a/services/platform-api/pkg/config/gip_key_test.go
+++ b/services/platform-api/pkg/config/gip_key_test.go
@@ -1,0 +1,53 @@
+package config
+
+import "testing"
+
+// TestGIPKey covers the choice between the server key and the public web
+// key.
+//
+// The distinction is not cosmetic: the web key is the value the admin
+// browser bundle embeds, so it carries an HTTP-referrer restriction. A
+// server sends no Referer, and GIP answers referrer-restricted admin calls
+// such as resetPassword with 403 "Requests from referer <empty> are
+// blocked". Preferring the server key is what makes password reset work.
+func TestGIPKey(t *testing.T) {
+	tests := []struct {
+		name   string
+		server string
+		web    string
+		want   string
+	}{
+		{
+			name:   "server key wins when both are set",
+			server: "server-key",
+			web:    "web-key",
+			want:   "server-key",
+		},
+		{
+			// The fallback exists so this change can ship before the
+			// server key is provisioned; such a deployment behaves
+			// exactly as it did before.
+			name: "falls back to the web key when no server key is set",
+			web:  "web-key",
+			want: "web-key",
+		},
+		{
+			name:   "server key is used even when the web key is absent",
+			server: "server-key",
+			want:   "server-key",
+		},
+		{
+			name: "empty when neither is set, so the caller skips wiring GIP",
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{GIPServerAPIKey: tc.server, GIPWebAPIKey: tc.web}
+			if got := c.GIPKey(); got != tc.want {
+				t.Fatalf("GIPKey() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Password-reset **confirm** fails with a 500. The cause, from platform-api's
own log:

```
ERROR auth: reset confirm failed
  err: gipadmin: resetPassword 403: Requests from referer <empty> are blocked.
POST /internal/auth/password-reset/confirm → 500
```

platform-api authenticates to GIP with `GIP_WEB_API_KEY` — **the same key the
admin browser bundle embeds** via `NEXT_PUBLIC_GIP_API_KEY`, both sourced from
`mark8ly-gip/GIP_WEB_API_KEY`. That key is referrer-restricted, as a public
browser key must be. A server sends no `Referer`, matches no entry in the
allowlist, and GIP rejects the call.

Relaxing the web key is not an option: it ships to every browser. The fix is a
second key that was never referrer-restricted in the first place.

## What changed

`Config.GIPKey()` returns `GIP_SERVER_API_KEY` when set, and falls back to
`GIP_WEB_API_KEY` otherwise. Every server-side GIP construction now goes
through it — there are no remaining direct reads of the web key.

**The fallback is deliberate**, so this can merge before the key is
provisioned anywhere: a deployment without a server key behaves exactly as it
does today. It is not a permanent arrangement — a web key will keep failing
referrer-restricted admin operations.

The companion `tesserix-k8s` change adds `GIP_SERVER_API_KEY` to the
`mark8ly-gip` ExternalSecret and wires it into the deployment with
`optional: true`, so the pod starts whether or not the key exists yet.

## Blast radius is wider than password reset

`gipadmin.AdminClient` is shared. The merchant-teardown endpoint builds on the
same client and would fail the same way — it simply has not been exercised.
Any future server-side GIP admin call would have hit this too.

## Testing

`TestGIPKey` covers all four combinations: server key preferred over web,
fallback to web, server key alone, and neither set (the caller then skips
wiring GIP, which is existing dev-convenience behaviour).

`go build`, `go vet`, `gofmt` clean; full unit suite green.

## Deploy note

Merge order does not matter. `optional: true` on the secret reference and the
`GIPKey()` fallback both mean the absence of the key is a no-op rather than a
failure. The GCP secret `prod-mark8ly-gip-server-api-key` already exists
(verified: 39 bytes, no trailing newline — a stored key with `\n` fails
authentication with an error that does not explain itself).

Found while diagnosing #493.
