### PR TITLE
fix(auth-bff): surface rate-limit as 429 and log autologin OTP send failures

### DIFF
--- a/services/auth-bff/internal/autologin/handler.go
+++ b/services/auth-bff/internal/autologin/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/mark8ly/auth-bff/internal/emailotp"
 	"github.com/mark8ly/auth-bff/internal/geoip"
 )
 
@@ -101,7 +102,11 @@ func (h *Handler) autoLogin(c *gin.Context) {
 //
 //	after the retry budget this is a real "not authorized" answer
 //
-// 503: openfga is unreachable — the system is broken, retry the call
+// 429: the email-OTP rate limit was tripped — waiting is the only way out
+// 503: openfga is unreachable, or the sign-in code could not otherwise be
+//
+//	sent — the system is broken, retry the call
+//
 // 500: anything else (session mint failure, internal bugs)
 func respondError(c *gin.Context, err error) {
 	switch {
@@ -119,6 +124,14 @@ func respondError(c *gin.Context, err error) {
 		c.JSON(http.StatusServiceUnavailable, gin.H{
 			"error":   "openfga_unreachable",
 			"message": "authorization service is temporarily unavailable; please retry",
+		})
+	// Checked ahead of ErrChallengeSendFail: a rate limit is wrapped by
+	// ErrChallengeSendFail, and errors.Is matches either, so the more
+	// specific case must win.
+	case errors.Is(err, emailotp.ErrRateLimited):
+		c.JSON(http.StatusTooManyRequests, gin.H{
+			"error":   "rate_limited",
+			"message": "too many sign-in codes requested; please wait before trying again",
 		})
 	case errors.Is(err, ErrChallengeSendFail):
 		c.JSON(http.StatusServiceUnavailable, gin.H{

--- a/services/auth-bff/internal/autologin/respond_error_test.go
+++ b/services/auth-bff/internal/autologin/respond_error_test.go
@@ -1,0 +1,100 @@
+package autologin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/auth-bff/internal/emailotp"
+)
+
+// TestAutoLogin_RateLimitedChallenge_Returns429 asserts a rate-limited
+// IssueChallenge failure is reported as 429 rate_limited, matching what
+// loginotp's classify() returns for the identical emailotp condition —
+// not the generic 503 challenge_send_failed that told users to retry
+// straight into the limit. It exercises the real service.AutoLogin ->
+// respondError path so both the error-wrap fix and the new 429 case are
+// covered together.
+func TestAutoLogin_RateLimitedChallenge_Returns429(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	issuer := &stubIssuer{err: emailotp.ErrRateLimited}
+	svc := newOTPService(t, &stubDevices{isNew: true}, issuer)
+
+	_, err := svc.AutoLogin(context.Background(), httptest.NewRecorder(), loginReq())
+	if err == nil {
+		t.Fatal("expected an error when the challenge is rate limited")
+	}
+	if !errors.Is(err, emailotp.ErrRateLimited) {
+		t.Fatalf("errors.Is(err, emailotp.ErrRateLimited) = false; err = %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	respondError(c, err)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusTooManyRequests)
+	}
+	if body := w.Body.String(); !strings.Contains(body, `"error":"rate_limited"`) {
+		t.Errorf("body = %s, want error code rate_limited", body)
+	}
+}
+
+// TestAutoLogin_GenericChallengeFailure_Returns503 asserts the old
+// behaviour survives for every non-rate-limit send failure: this is the
+// regression guard that fix A/B must not disturb.
+func TestAutoLogin_GenericChallengeFailure_Returns503(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	issuer := &stubIssuer{err: errors.New("smtp: connection refused")}
+	svc := newOTPService(t, &stubDevices{isNew: true}, issuer)
+
+	_, err := svc.AutoLogin(context.Background(), httptest.NewRecorder(), loginReq())
+	if err == nil {
+		t.Fatal("expected an error when the challenge send fails")
+	}
+	if errors.Is(err, emailotp.ErrRateLimited) {
+		t.Fatal("a generic send failure must not match ErrRateLimited")
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	respondError(c, err)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"error":"challenge_send_failed"`) {
+		t.Errorf("body = %s, want error code challenge_send_failed", body)
+	}
+	if !strings.Contains(body, "could not send your sign-in code; please retry") {
+		t.Errorf("body = %s, want the original 503 message preserved", body)
+	}
+}
+
+// TestErrorChain_RateLimitSurvivesWrap is the narrow unit-level property
+// that fix A exists for: errors.Is must see through the
+// ErrChallengeSendFail wrap down to the emailotp sentinel, independent
+// of any HTTP-layer behaviour.
+func TestErrorChain_RateLimitSurvivesWrap(t *testing.T) {
+	issuer := &stubIssuer{err: emailotp.ErrRateLimited}
+	svc := newOTPService(t, &stubDevices{isNew: true}, issuer)
+
+	_, err := svc.AutoLogin(context.Background(), httptest.NewRecorder(), loginReq())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !errors.Is(err, ErrChallengeSendFail) {
+		t.Error("errors.Is(err, ErrChallengeSendFail) = false")
+	}
+	if !errors.Is(err, emailotp.ErrRateLimited) {
+		t.Error("errors.Is(err, emailotp.ErrRateLimited) = false")
+	}
+}

--- a/services/auth-bff/internal/autologin/service.go
+++ b/services/auth-bff/internal/autologin/service.go
@@ -217,7 +217,7 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 				Email:    tok.Email,
 				TenantID: req.WorkspaceTenant,
 			}); err != nil {
-				return nil, fmt.Errorf("%w: %s", ErrSessionMintFail, err)
+				return nil, fmt.Errorf("%w: %w", ErrSessionMintFail, err)
 			}
 			return &Result{
 				UID:         tok.UID,
@@ -262,7 +262,11 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 	// second device safe rather than merely possible.
 	if newDevice && s.emailOTP != nil {
 		if err := s.emailOTP.IssueChallenge(ctx, tok.Email, req.IPAddress); err != nil {
-			return nil, fmt.Errorf("%w: %s", ErrChallengeSendFail, err)
+			if s.logger != nil {
+				s.logger.Error("autologin: challenge send failed",
+					"err", err, "user_id", tok.UID, "tenant_id", req.WorkspaceTenant)
+			}
+			return nil, fmt.Errorf("%w: %w", ErrChallengeSendFail, err)
 		}
 		if err := s.sessions.MintPending(w, session.Pending{
 			UID:         tok.UID,
@@ -272,7 +276,7 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 			Device:      device,
 			IPAddress:   req.IPAddress,
 		}); err != nil {
-			return nil, fmt.Errorf("%w: %s", ErrSessionMintFail, err)
+			return nil, fmt.Errorf("%w: %w", ErrSessionMintFail, err)
 		}
 		return &Result{
 			UID:              tok.UID,
@@ -288,7 +292,7 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 		Email:    tok.Email,
 		TenantID: req.WorkspaceTenant,
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrSessionMintFail, err)
+		return nil, fmt.Errorf("%w: %w", ErrSessionMintFail, err)
 	}
 
 	// Step 4 (best-effort): record the new session in the registry for


### PR DESCRIPTION
Fixes #493 (code half).

## Problem

Autologin swallowed `emailotp.ErrRateLimited` into `ErrChallengeSendFail`, so a
rate-limited user got a 503 "could not send your sign-in code; please retry" —
telling them to do the exact thing that makes it worse. The limit is 5 codes per
15 minutes, so every retry pushes the window out further.

`loginotp`'s `classify()` already returns 429 for the same condition; autologin
was the odd one out.

## Root cause

`service.go` wrapped with `fmt.Errorf("%w: %s", ...)`, which flattens the
underlying error to a string — `errors.Is` could not match through it. The
rate-limit signal was destroyed at the wrap site, so `respondError` never had a
chance to see it.

## Fix

- `service.go`: wrap with `%w: %w` at all four sites so the cause survives.
- `handler.go`: add an `errors.Is(err, emailotp.ErrRateLimited)` case returning
  429 `rate_limited`. It is ordered **ahead** of the `ErrChallengeSendFail` case,
  because the rate limit is wrapped by it and `errors.Is` matches either — the
  more specific case must win.
- `service.go`: log the underlying error at ERROR on challenge-send failure.
  Never logs the email address or the code itself.

## Test plan

- [x] `go vet -tags=integration ./...` clean
- [x] `go test -count=1 ./...` — full auth-bff suite green
- [x] New `respond_error_test.go` covers the 429 case and the ordering
- [x] Both guards mutation-tested (removed → a test fails; restored → green)