### PR TITLE
fix: password reset actually completes (tenantId on redeem + no 404 sign-in link)

### DIFF
--- a/apps/admin/components/auth/ForgotPasswordForm.tsx
+++ b/apps/admin/components/auth/ForgotPasswordForm.tsx
@@ -12,11 +12,13 @@
 
 import { useState, useTransition } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { Input } from "@tesserix/web";
 import { Field } from "@repo/ui/field";
+import { signInHref } from "@/lib/auth/sign-in-href";
 
 import { requestPasswordResetAction } from "@/app/forgot-password/actions";
 
@@ -30,6 +32,9 @@ const schema = z.object({
 type FormValues = z.infer<typeof schema>;
 
 export function ForgotPasswordForm() {
+  // Canonical /login 404s without a valid returnUrl, so only link when
+  // the page carries one we can hand straight back. See signInHref.
+  const backHref = signInHref(useSearchParams().get("returnUrl"));
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [sent, setSent] = useState(false);
   const [pending, startTransition] = useTransition();
@@ -72,12 +77,13 @@ export function ForgotPasswordForm() {
             choose a new password.
           </p>
         </div>
-        <Link
-          href="/login"
-          className="inline-flex h-10 items-center rounded-md bg-[color:var(--ink-900)] px-5 text-sm font-medium text-white transition-colors hover:bg-[color:var(--ink-800)]"
-        >
-          Back to sign in
-        </Link>
+        {backHref ? (
+          <Link href={backHref} className="inline-flex h-10 items-center rounded-md bg-[color:var(--ink-900)] px-5 text-sm font-medium text-white transition-colors hover:bg-[color:var(--ink-800)]">
+            Back to sign in
+          </Link>
+        ) : (
+          <p className="max-w-md text-xs leading-relaxed text-foreground-secondary">Sign in from your store&rsquo;s own address &mdash; <span className="whitespace-nowrap">{"{slug}"}-admin.mark8ly.com</span>.</p>
+        )}
       </div>
     );
   }
@@ -126,12 +132,13 @@ export function ForgotPasswordForm() {
         </button>
 
         <div className="flex justify-center">
-          <Link
-            href="/login"
-            className="text-xs text-foreground-secondary underline underline-offset-4 decoration-border-subtle transition-colors hover:text-foreground hover:decoration-foreground-tertiary"
-          >
-            Back to sign in
-          </Link>
+          {backHref ? (
+            <Link href={backHref} className="text-xs text-foreground-secondary underline underline-offset-4 decoration-border-subtle transition-colors hover:text-foreground hover:decoration-foreground-tertiary">
+              Back to sign in
+            </Link>
+          ) : (
+            <p className="max-w-md text-xs leading-relaxed text-foreground-secondary">Sign in from your store&rsquo;s own address &mdash; <span className="whitespace-nowrap">{"{slug}"}-admin.mark8ly.com</span>.</p>
+          )}
         </div>
       </form>
     </div>

--- a/apps/admin/components/auth/ResetPasswordForm.tsx
+++ b/apps/admin/components/auth/ResetPasswordForm.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useTransition } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -15,6 +15,7 @@ import { Input } from "@tesserix/web";
 import { Field } from "@repo/ui/field";
 
 import { confirmPasswordResetAction } from "@/app/reset-password/actions";
+import { signInHref } from "@/lib/auth/sign-in-href";
 
 const schema = z
   .object({
@@ -37,6 +38,9 @@ interface ResetPasswordFormProps {
 
 export function ResetPasswordForm({ oobCode }: ResetPasswordFormProps) {
   const router = useRouter();
+  // Canonical /login 404s without a valid returnUrl, so only link when
+  // the page carries one we can hand straight back. See signInHref.
+  const backHref = signInHref(useSearchParams().get("returnUrl"));
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [done, setDone] = useState(false);
   const [pending, startTransition] = useTransition();
@@ -101,12 +105,13 @@ export function ResetPasswordForm({ oobCode }: ResetPasswordFormProps) {
             You can now sign in with your new password.
           </p>
         </div>
-        <Link
-          href="/login"
-          className="inline-flex h-10 items-center rounded-md bg-[color:var(--ink-900)] px-5 text-sm font-medium text-white transition-colors hover:bg-[color:var(--ink-800)]"
-        >
-          Go to sign in
-        </Link>
+        {backHref ? (
+          <Link href={backHref} className="inline-flex h-10 items-center rounded-md bg-[color:var(--ink-900)] px-5 text-sm font-medium text-white transition-colors hover:bg-[color:var(--ink-800)]">
+            Go to sign in
+          </Link>
+        ) : (
+          <p className="max-w-md text-xs leading-relaxed text-foreground-secondary">Sign in from your store&rsquo;s own address &mdash; <span className="whitespace-nowrap">{"{slug}"}-admin.mark8ly.com</span>.</p>
+        )}
       </div>
     );
   }
@@ -174,12 +179,13 @@ export function ResetPasswordForm({ oobCode }: ResetPasswordFormProps) {
         </button>
 
         <div className="flex justify-center">
-          <Link
-            href="/login"
-            className="text-xs text-foreground-secondary underline underline-offset-4 decoration-border-subtle transition-colors hover:text-foreground hover:decoration-foreground-tertiary"
-          >
-            Back to sign in
-          </Link>
+          {backHref ? (
+            <Link href={backHref} className="text-xs text-foreground-secondary underline underline-offset-4 decoration-border-subtle transition-colors hover:text-foreground hover:decoration-foreground-tertiary">
+              Back to sign in
+            </Link>
+          ) : (
+            <p className="max-w-md text-xs leading-relaxed text-foreground-secondary">Sign in from your store&rsquo;s own address &mdash; <span className="whitespace-nowrap">{"{slug}"}-admin.mark8ly.com</span>.</p>
+          )}
         </div>
       </form>
     </div>

--- a/apps/admin/lib/auth/sign-in-href.test.ts
+++ b/apps/admin/lib/auth/sign-in-href.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { signInHref } from "./sign-in-href";
+
+describe("signInHref", () => {
+  it("builds a canonical /login link when the returnUrl is a real slug-admin URL", () => {
+    expect(signInHref("https://the-bondi-store-admin.mark8ly.com/dashboard")).toBe(
+      "/login?returnUrl=https%3A%2F%2Fthe-bondi-store-admin.mark8ly.com%2Fdashboard",
+    );
+  });
+
+  it("returns null when there is no returnUrl", () => {
+    // Canonical /login 404s without a valid returnUrl, so the caller must
+    // render guidance instead of a dead link.
+    expect(signInHref(null)).toBeNull();
+    expect(signInHref("")).toBeNull();
+  });
+
+  it("returns null for a returnUrl the middleware would reject", () => {
+    // Canonical host is not a valid bounce-back target.
+    expect(signInHref("https://admin.mark8ly.com/dashboard")).toBeNull();
+    // Off-platform host must never become a login redirect target.
+    expect(signInHref("https://evil.example.com/")).toBeNull();
+    expect(signInHref("http://the-bondi-store-admin.mark8ly.com/")).toBeNull();
+  });
+});

--- a/apps/admin/lib/auth/sign-in-href.ts
+++ b/apps/admin/lib/auth/sign-in-href.ts
@@ -1,0 +1,24 @@
+import { isValidSlugReturnUrl } from "./host-policy";
+
+/**
+ * signInHref builds the "back to sign in" target for the password-reset
+ * and forgot-password pages.
+ *
+ * Those pages render on the CANONICAL admin host (platform-api mails
+ * `{admin}/reset-password?oobCode=…`), and middleware hard-404s canonical
+ * `/login` unless it carries a returnUrl pointing at a real slug-admin
+ * host — that gate is deliberate anti-phishing and stays. A bare
+ * `href="/login"` therefore dead-ends every merchant who clicks it.
+ *
+ * We cannot synthesize a returnUrl here: password reset is cross-tenant
+ * (see RequestPasswordReset — "no tenant_id to forward"), and a merchant
+ * may belong to several stores, so there is no single slug to guess.
+ *
+ * So: link only when the page was reached with a returnUrl we can hand
+ * straight back to middleware. Otherwise return null and let the caller
+ * render guidance rather than a link that 404s.
+ */
+export function signInHref(returnUrl: string | null | undefined): string | null {
+  if (!isValidSlugReturnUrl(returnUrl)) return null;
+  return `/login?returnUrl=${encodeURIComponent(returnUrl as string)}`;
+}

--- a/services/platform-api/internal/gipadmin/client.go
+++ b/services/platform-api/internal/gipadmin/client.go
@@ -169,6 +169,12 @@ func (c *AdminClient) ResetPassword(ctx context.Context, oobCode, newPassword st
 	body := map[string]any{
 		"oobCode":     oobCode,
 		"newPassword": newPassword,
+		// The code was minted inside this tenant (SendPasswordResetOobCode
+		// sends the same tenantId), and Identity Toolkit only resolves an
+		// oobCode within the tenant that issued it. Omitting this looks the
+		// code up at project level, where it does not exist — GIP answers
+		// INVALID_OOB_CODE and a freshly-issued link reads as expired.
+		"tenantId": c.cfg.TenantID,
 	}
 	raw, err := json.Marshal(body)
 	if err != nil {

--- a/services/platform-api/internal/gipadmin/reset_password_test.go
+++ b/services/platform-api/internal/gipadmin/reset_password_test.go
@@ -1,0 +1,59 @@
+package gipadmin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+)
+
+// The oobCode is minted inside a GIP tenant (SendPasswordResetOobCode
+// sends tenantId), so it only resolves when it is redeemed in that same
+// tenant. Omitting tenantId here makes Identity Toolkit look the code up
+// at project level, where it does not exist — GIP then answers
+// INVALID_OOB_CODE and the merchant is told their brand-new link is
+// "invalid or has expired". Config documents TenantID as "sent as
+// tenantId on every call"; this pins that for the redeem call.
+func TestResetPasswordSendsTenantID(t *testing.T) {
+	var got map[string]any
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	if err := c.ResetPassword(context.Background(), "oob-123", "correct horse battery staple"); err != nil {
+		t.Fatalf("ResetPassword: %v", err)
+	}
+
+	if got["tenantId"] != "MP-Internal-e986p" {
+		t.Errorf("tenantId = %v, want %q", got["tenantId"], "MP-Internal-e986p")
+	}
+	// Guard the rest of the payload so adding tenantId cannot silently
+	// drop what GIP actually needs to perform the reset.
+	if got["oobCode"] != "oob-123" {
+		t.Errorf("oobCode = %v, want %q", got["oobCode"], "oob-123")
+	}
+	if got["newPassword"] != "correct horse battery staple" {
+		t.Errorf("newPassword = %v", got["newPassword"])
+	}
+}
+
+// An expired code must still map to ErrInvalidOobCode once tenantId is
+// present, so the handler keeps returning 410 rather than a 500.
+func TestResetPasswordExpiredCodeMapsToSentinel(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"EXPIRED_OOB_CODE","code":400}}`))
+	})
+
+	err := c.ResetPassword(context.Background(), "oob-123", "correct horse battery staple")
+	if !errors.Is(err, ErrInvalidOobCode) {
+		t.Fatalf("err = %v, want ErrInvalidOobCode", err)
+	}
+}


### PR DESCRIPTION
Two bugs in the admin password-reset flow. Fixes #501; unblocks the reset
that #499 / tesserix-k8s#780 got as far as a 410.

## 1. `resetPassword` never sent `tenantId` (the live 410)

After the GIP server-key fix removed the 403, confirm started returning
**410 `invalid_oob_code`** — "This reset link is invalid or has expired" — on a
link that was seconds old. Production logs:

```
17:15:57  POST /internal/auth/password-reset/request  204
17:16:26  POST /internal/auth/password-reset/confirm  410
```

29 seconds apart, so expiry is ruled out.

**Root cause.** `SendPasswordResetOobCode` mints the code inside the GIP tenant
(`client.go:109` sends `tenantId`), but `ResetPassword` omitted it. Identity
Toolkit then resolves the code at *project* level, where it does not exist, and
answers `INVALID_OOB_CODE`. `Config.TenantID` is documented as "Sent as
`tenantId` on every call" (`client.go:53`) — the redeem call was the exception.
It had no test coverage, which is why it survived.

## 2. "Back to sign in" linked to a page that 404s (#501)

Those pages render on the **canonical** host, and middleware hard-404s canonical
`/login` without a valid `returnUrl` — deliberate anti-phishing, left untouched.
Five bare `/login` links dead-ended there.

We cannot synthesize a `returnUrl`: password reset is explicitly cross-tenant
("no tenant_id to forward"), and a merchant may own several stores, so there is
no single slug to guess. **This rules out option 1 in #501** — I've noted that
on the issue. New `signInHref()` links only when the page already carries a
returnUrl middleware will accept, and otherwise renders guidance instead of a
dead link.

## Test plan

- [x] `TestResetPasswordSendsTenantID` — written first, failed with
      `tenantId = <nil>`, passes with the fix
- [x] Mutation-tested: dropping the `tenantId` line fails the test; restoring passes
- [x] `TestResetPasswordExpiredCodeMapsToSentinel` — a real expiry still maps to
      `ErrInvalidOobCode`, so the handler keeps returning 410 rather than 500
- [x] `signInHref` unit tests, including rejection of the canonical host and of
      an off-platform `evil.example.com` returnUrl
- [x] `go vet -tags=integration ./...` clean; `go test -count=1 ./...` 20/20 packages
- [x] `npx vitest run lib/auth` 37/37; `tsc --noEmit` clean for touched files

## Not fixed here

Anonymous `admin.mark8ly.com/` → `/dashboard` → `/login?returnUrl=<canonical>/dashboard`
→ **404**, because a canonical returnUrl fails `isValidSlugReturnUrl`. Same root
shape, wider than the reset flow, and it needs a product decision about what
canonical should show a signed-out visitor. Left alone deliberately.