### PR TITLE
fix(admin): post-reset redirect and placeholder copy on the reset pages

### DIFF
--- a/apps/admin/components/auth/ForgotPasswordForm.tsx
+++ b/apps/admin/components/auth/ForgotPasswordForm.tsx
@@ -82,7 +82,7 @@ export function ForgotPasswordForm() {
             Back to sign in
           </Link>
         ) : (
-          <p className="max-w-md text-xs leading-relaxed text-foreground-secondary">Sign in from your store&rsquo;s own address &mdash; <span className="whitespace-nowrap">{"{slug}"}-admin.mark8ly.com</span>.</p>
+          <p className="max-w-md text-xs leading-relaxed text-foreground-secondary">Sign in from your store&rsquo;s own admin address &mdash; the one ending in <span className="whitespace-nowrap">-admin.mark8ly.com</span>.</p>
         )}
       </div>
     );
@@ -137,7 +137,7 @@ export function ForgotPasswordForm() {
               Back to sign in
             </Link>
           ) : (
-            <p className="max-w-md text-xs leading-relaxed text-foreground-secondary">Sign in from your store&rsquo;s own address &mdash; <span className="whitespace-nowrap">{"{slug}"}-admin.mark8ly.com</span>.</p>
+            <p className="max-w-md text-xs leading-relaxed text-foreground-secondary">Sign in from your store&rsquo;s own admin address &mdash; the one ending in <span className="whitespace-nowrap">-admin.mark8ly.com</span>.</p>
           )}
         </div>
       </form>

--- a/apps/admin/components/auth/ResetPasswordForm.tsx
+++ b/apps/admin/components/auth/ResetPasswordForm.tsx
@@ -85,8 +85,13 @@ export function ResetPasswordForm({ oobCode }: ResetPasswordFormProps) {
       const result = await confirmPasswordResetAction(oobCode, values.password);
       if (result.ok) {
         setDone(true);
-        // Give the success screen a beat to land, then bounce to login.
-        setTimeout(() => router.push("/login"), 1500);
+        // Only bounce when we have a sign-in target middleware accepts.
+        // Bare /login 404s on the canonical host, so without a valid
+        // returnUrl we leave the success screen up (it explains where to
+        // sign in) rather than redirecting the user into a dead page.
+        if (backHref) {
+          setTimeout(() => router.push(backHref), 1500);
+        }
         return;
       }
       setSubmitError(result.message);
@@ -110,7 +115,7 @@ export function ResetPasswordForm({ oobCode }: ResetPasswordFormProps) {
             Go to sign in
           </Link>
         ) : (
-          <p className="max-w-md text-xs leading-relaxed text-foreground-secondary">Sign in from your store&rsquo;s own address &mdash; <span className="whitespace-nowrap">{"{slug}"}-admin.mark8ly.com</span>.</p>
+          <p className="max-w-md text-xs leading-relaxed text-foreground-secondary">Sign in from your store&rsquo;s own admin address &mdash; the one ending in <span className="whitespace-nowrap">-admin.mark8ly.com</span>.</p>
         )}
       </div>
     );
@@ -184,7 +189,7 @@ export function ResetPasswordForm({ oobCode }: ResetPasswordFormProps) {
               Back to sign in
             </Link>
           ) : (
-            <p className="max-w-md text-xs leading-relaxed text-foreground-secondary">Sign in from your store&rsquo;s own address &mdash; <span className="whitespace-nowrap">{"{slug}"}-admin.mark8ly.com</span>.</p>
+            <p className="max-w-md text-xs leading-relaxed text-foreground-secondary">Sign in from your store&rsquo;s own admin address &mdash; the one ending in <span className="whitespace-nowrap">-admin.mark8ly.com</span>.</p>
           )}
         </div>
       </form>


### PR DESCRIPTION
Two follow-ups to #502, both found by actually walking the flow in production.

## 1. The post-reset redirect still landed on the 404 (the real one)

`ResetPasswordForm.tsx:89` did `setTimeout(() => router.push("/login"), 1500)`
on success. #502 fixed the four `<Link href="/login">` sites but missed this
one, because I grepped for `Link`/`href=` and not `router.push`. So the reset
succeeded, the success screen showed for 1.5s, and the user was then bounced
into `admin.mark8ly.com/login` → **404**. Reported from production:

> password updated and got This admin.mark8ly.com page can't be found

Now it redirects only when `backHref` is set — i.e. when a returnUrl middleware
accepts is present. Otherwise it stays on the success screen, which already says
where to sign in.

Swept the whole app for `push("/login")`, `href="/login"`, `replace("/login")`
and `redirect("/login")`: no other occurrences remain.

## 2. `{slug}` rendered literally to the merchant

The #502 guidance text shipped `{"{slug}"}-admin.mark8ly.com`, which a merchant
sees verbatim as `{slug}-admin.mark8ly.com` — it reads like a broken template.
Replaced with a description of the address rather than a fake placeholder:

> Sign in from your store's own admin address — the one ending in `-admin.mark8ly.com`.

## Verified in production before this PR

The #502 `tenantId` fix works — the reset itself now completes ("password
updated"). This PR is only about where the user lands afterwards.

## Test plan

- [x] `npx vitest run lib/auth` — 37/37
- [x] `tsc --noEmit` clean for touched files (pre-existing `@tesserix/otto-widget`
      errors unrelated)
- [x] Grep sweep confirms no bare `/login` navigation left in `apps/admin`