### PR TITLE
fix(admin): prompt for the emailed sign-in code instead of silently bouncing

### DIFF
--- a/apps/admin/app/login/actions.ts
+++ b/apps/admin/app/login/actions.ts
@@ -11,6 +11,8 @@ import { cookies, headers } from "next/headers";
 
 import {
   autoLogin,
+  completeEmailOTPChallenge,
+  resendEmailOTP,
   completeMFAChallenge,
   AuthBffError,
 } from "@/lib/auth/auth-bff";
@@ -78,6 +80,12 @@ interface SignInSuccess {
   // The UI must collect a 6-digit code and call confirmMFALogin
   // before treating the sign-in as complete.
   mfaRequired: boolean;
+  // true when the sign-in came from an unrecognised device and auth-bff
+  // emailed a one-time code, writing only a PENDING cookie. Treating
+  // this as success redirects into a middleware bounce back to /login
+  // with no error — the UI must collect the code and call
+  // confirmEmailOTPLogin.
+  emailOtpRequired: boolean;
 }
 
 export async function signIn(
@@ -154,6 +162,7 @@ export async function signIn(
         tenantId: primary.tenant_id,
         multipleTenants,
         mfaRequired: result.mfaRequired,
+        emailOtpRequired: result.emailOtpRequired,
       },
     };
   } catch (err) {
@@ -201,6 +210,68 @@ export async function confirmMFALogin(
       }
     }
     return { ok: true, data: { tenantId: result.tenant_id } };
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/**
+ * confirmEmailOTPLogin finishes a sign-in that auth-bff challenged with
+ * an emailed code. Mirrors confirmMFALogin: the browser already holds
+ * the pending cookie from signIn, we forward it with the code, and set
+ * whatever cookies auth-bff mints in return.
+ */
+export async function confirmEmailOTPLogin(
+  code: string,
+): Promise<Result<{ tenantId: string }>> {
+  try {
+    const trimmed = code.trim();
+    if (!trimmed) {
+      return {
+        ok: false,
+        code: "invalid_code",
+        message: "Enter the 6-digit code we emailed you.",
+      };
+    }
+    const c = await cookies();
+    const cookieHeader = c
+      .getAll()
+      .map((x) => `${x.name}=${x.value}`)
+      .join("; ");
+    const result = await completeEmailOTPChallenge(trimmed, cookieHeader);
+    for (const raw of result.setCookies) {
+      const parsed = parseSetCookie(raw);
+      if (parsed) {
+        c.set({
+          name: parsed.name,
+          value: parsed.value,
+          path: parsed.path ?? "/",
+          domain: parsed.domain,
+          httpOnly: parsed.httpOnly,
+          secure: parsed.secure,
+          sameSite: "lax",
+          maxAge: parsed.maxAge,
+        });
+      }
+    }
+    return { ok: true, data: { tenantId: result.tenant_id } };
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/** resendEmailOTPCode asks for a fresh emailed code on the same pending
+ *  session. A 429 here means the rate limit tripped — waiting is the
+ *  only way out, so the message must not tell the user to retry. */
+export async function resendEmailOTPCode(): Promise<Result<null>> {
+  try {
+    const c = await cookies();
+    const cookieHeader = c
+      .getAll()
+      .map((x) => `${x.name}=${x.value}`)
+      .join("; ");
+    await resendEmailOTP(cookieHeader);
+    return { ok: true, data: null };
   } catch (err) {
     return fail(err);
   }

--- a/apps/admin/components/auth/SignInForm.tsx
+++ b/apps/admin/components/auth/SignInForm.tsx
@@ -26,7 +26,12 @@ import { getGoogleCredential } from "@/lib/gip/google-gsi";
 import { getAppleCredential } from "@/lib/gip/apple-js";
 import { appleSignInEnabled } from "@/lib/config";
 import { linkGoogleToInternalPassword } from "@/lib/gip/link";
-import { signIn, confirmMFALogin } from "@/app/login/actions";
+import {
+  signIn,
+  confirmMFALogin,
+  confirmEmailOTPLogin,
+  resendEmailOTPCode,
+} from "@/app/login/actions";
 import { prepareCrossDomainNavigation } from "@/lib/auth/cross-domain-handoff";
 import { LinkProviderPrompt } from "@repo/ui/auth/link-provider-prompt";
 
@@ -93,6 +98,11 @@ export function SignInForm({ returnUrl }: SignInFormProps = {}) {
   // of redirecting. `mfaMultipleTenants` is remembered from the
   // first step so the post-challenge redirect still respects
   // pick-tenant vs dashboard.
+  // Which challenge the server asked for. "mfa" is an authenticator
+  // app; "email_otp" is the new-device code auth-bff emails. Both leave
+  // only a PENDING cookie, so neither may skip to goToDestination.
+  const [challenge, setChallenge] = useState<"mfa" | "email_otp" | null>(null);
+  const [resendNotice, setResendNotice] = useState<string | null>(null);
   const [mfaStep, setMfaStep] = useState(false);
   const [mfaCode, setMfaCode] = useState("");
   const [mfaPending, setMfaPending] = useState(false);
@@ -148,8 +158,9 @@ export function SignInForm({ returnUrl }: SignInFormProps = {}) {
         }
         return;
       }
-      if (r.data.mfaRequired) {
+      if (r.data.mfaRequired || r.data.emailOtpRequired) {
         setMfaMultipleTenants(r.data.multipleTenants);
+        setChallenge(r.data.mfaRequired ? "mfa" : "email_otp");
         setMfaStep(true);
         return;
       }
@@ -167,8 +178,9 @@ export function SignInForm({ returnUrl }: SignInFormProps = {}) {
       );
       return;
     }
-    if (r.data.mfaRequired) {
+    if (r.data.mfaRequired || r.data.emailOtpRequired) {
       setMfaMultipleTenants(r.data.multipleTenants);
+      setChallenge(r.data.mfaRequired ? "mfa" : "email_otp");
       setMfaStep(true);
       return;
     }
@@ -265,7 +277,10 @@ export function SignInForm({ returnUrl }: SignInFormProps = {}) {
     setSubmitError(null);
     setMfaPending(true);
     try {
-      const r = await confirmMFALogin(mfaCode);
+      const r =
+        challenge === "email_otp"
+          ? await confirmEmailOTPLogin(mfaCode)
+          : await confirmMFALogin(mfaCode);
       if (!r.ok) {
         setSubmitError(r.message);
         return;
@@ -278,8 +293,24 @@ export function SignInForm({ returnUrl }: SignInFormProps = {}) {
 
   function cancelMFA() {
     setMfaStep(false);
+    setChallenge(null);
     setMfaCode("");
     setSubmitError(null);
+    setResendNotice(null);
+  }
+
+  async function handleResend() {
+    setSubmitError(null);
+    setResendNotice(null);
+    setMfaPending(true);
+    try {
+      const r = await resendEmailOTPCode();
+      setResendNotice(
+        r.ok ? "We've sent a new code. It expires in 5 minutes." : r.message,
+      );
+    } finally {
+      setMfaPending(false);
+    }
   }
 
   if (mfaStep) {
@@ -288,16 +319,20 @@ export function SignInForm({ returnUrl }: SignInFormProps = {}) {
         <div className="space-y-2">
           <p className="eyebrow">mark8ly admin</p>
           <h1 className="font-serif text-4xl font-medium tracking-tight text-foreground">
-            Two-factor check
+            {challenge === "email_otp" ? "Check your email" : "Two-factor check"}
           </h1>
           <p className="text-base leading-7 text-foreground-secondary">
-            Enter the 6-digit code from your authenticator app to finish
-            signing in.
+            {challenge === "email_otp"
+              ? "We emailed you a 6-digit code because this is a new device. It expires in 5 minutes."
+              : "Enter the 6-digit code from your authenticator app to finish signing in."}
           </p>
         </div>
 
         <form onSubmit={handleMFA} className="mt-8 space-y-5">
-          <Field id="mfa-code" label="Verification code">
+          <Field
+            id="mfa-code"
+            label={challenge === "email_otp" ? "Sign-in code" : "Verification code"}
+          >
             <Input
               id="mfa-code"
               type="text"
@@ -313,6 +348,12 @@ export function SignInForm({ returnUrl }: SignInFormProps = {}) {
             />
           </Field>
 
+          {resendNotice && (
+            <p aria-live="polite" className="text-sm text-foreground-secondary">
+              {resendNotice}
+            </p>
+          )}
+
           {submitError && (
             <p role="alert" aria-live="polite" className="text-sm text-danger">
               {submitError}
@@ -326,6 +367,17 @@ export function SignInForm({ returnUrl }: SignInFormProps = {}) {
           >
             {mfaPending ? "Verifying…" : "Verify and continue"}
           </button>
+
+          {challenge === "email_otp" && (
+            <button
+              type="button"
+              onClick={handleResend}
+              disabled={mfaPending}
+              className="inline-flex h-11 w-full items-center justify-center text-sm text-foreground-secondary underline underline-offset-4 decoration-border-subtle hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Send a new code
+            </button>
+          )}
 
           <button
             type="button"

--- a/apps/admin/lib/auth/auth-bff.test.ts
+++ b/apps/admin/lib/auth/auth-bff.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { autoLogin } from "./auth-bff";
+
+function stubFetch(body: unknown) {
+  const res = new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(res));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const req = {
+  idToken: "id-token",
+  expectedTenantId: "MP-Internal-e986p",
+  workspaceTenant: "tenant-1",
+};
+
+describe("autoLogin", () => {
+  // Regression: auth-bff returns email_otp_required alongside
+  // mfa_required, and dropping it made a new-device sign-in look like a
+  // completed one. The caller then redirected on a PENDING cookie and
+  // middleware bounced the user back to /login showing no error at all.
+  it("surfaces email_otp_required as emailOtpRequired", async () => {
+    stubFetch({
+      data: {
+        uid: "u1",
+        email: "merchant@example.com",
+        tenant_id: "tenant-1",
+        email_otp_required: true,
+      },
+    });
+
+    const result = await autoLogin(req);
+
+    expect(result.emailOtpRequired).toBe(true);
+    expect(result.mfaRequired).toBe(false);
+  });
+
+  it("surfaces mfa_required independently", async () => {
+    stubFetch({
+      data: {
+        uid: "u1",
+        email: "merchant@example.com",
+        tenant_id: "tenant-1",
+        mfa_required: true,
+      },
+    });
+
+    const result = await autoLogin(req);
+
+    expect(result.mfaRequired).toBe(true);
+    expect(result.emailOtpRequired).toBe(false);
+  });
+
+  it("treats an unchallenged sign-in as neither", async () => {
+    stubFetch({
+      data: { uid: "u1", email: "merchant@example.com", tenant_id: "tenant-1" },
+    });
+
+    const result = await autoLogin(req);
+
+    expect(result.mfaRequired).toBe(false);
+    expect(result.emailOtpRequired).toBe(false);
+  });
+});

--- a/apps/admin/lib/auth/auth-bff.ts
+++ b/apps/admin/lib/auth/auth-bff.ts
@@ -38,6 +38,12 @@ interface AutoLoginResult {
    *  this as a successful sign-in; it must collect the 6-digit code and
    *  call completeMFAChallenge before authenticated requests work. */
   mfaRequired: boolean;
+  /** True when the sign-in came from an unrecognised device and auth-bff
+   *  emailed a one-time code. Like mfaRequired this is NOT a completed
+   *  sign-in — auto-login minted only a PENDING cookie, so redirecting
+   *  now bounces the user straight back to /login with no error shown.
+   *  The caller must collect the code and call completeEmailOTPChallenge. */
+  emailOtpRequired: boolean;
 }
 
 interface MFAChallengeResult {
@@ -164,6 +170,7 @@ export async function autoLogin(
       email: string;
       tenant_id: string;
       mfa_required?: boolean;
+      email_otp_required?: boolean;
     };
   };
   const setCookies = readAllSetCookies(res);
@@ -174,7 +181,68 @@ export async function autoLogin(
     tenant_id: body.data.tenant_id,
     setCookies,
     mfaRequired: body.data.mfa_required === true,
+    emailOtpRequired: body.data.email_otp_required === true,
   };
+}
+
+/**
+ * completeEmailOTPChallenge finishes a sign-in that auth-bff challenged
+ * with an emailed one-time code. The caller forwards the pending cookie
+ * auto-login set, plus the 6-digit code from the email. On success
+ * auth-bff mints the real session cookie and clears the pending one.
+ */
+export async function completeEmailOTPChallenge(
+  code: string,
+  cookieHeader: string,
+): Promise<{ uid: string; tenant_id: string; setCookies: string[] }> {
+  const res = await fetch(`${base}/auth/otp/verify`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Cookie: cookieHeader },
+    body: JSON.stringify({ code }),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    let body: { error?: string; message?: string } = {};
+    try {
+      body = await res.json();
+    } catch {
+      // ignore
+    }
+    throw new AuthBffError(
+      res.status,
+      body.error ?? `http_${res.status}`,
+      body.message ?? `HTTP ${res.status}`,
+    );
+  }
+  const body = (await res.json()) as { uid: string; tenant_id: string };
+  return {
+    uid: body.uid,
+    tenant_id: body.tenant_id,
+    setCookies: readAllSetCookies(res),
+  };
+}
+
+/** resendEmailOTP asks auth-bff for a fresh code on the same pending
+ *  session. Rate limited upstream (429), which the caller surfaces. */
+export async function resendEmailOTP(cookieHeader: string): Promise<void> {
+  const res = await fetch(`${base}/auth/otp/resend`, {
+    method: "POST",
+    headers: { Cookie: cookieHeader },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    let body: { error?: string; message?: string } = {};
+    try {
+      body = await res.json();
+    } catch {
+      // ignore
+    }
+    throw new AuthBffError(
+      res.status,
+      body.error ?? `http_${res.status}`,
+      body.message ?? `HTTP ${res.status}`,
+    );
+  }
 }
 
 // readAllSetCookies returns every Set-Cookie header auth-bff sent.


### PR DESCRIPTION
Fixes #493. This is the actual reason nobody can log into admin.

## Symptom

Correct password, correct new password after a reset — and **nothing happens.
No error.** The user is returned to the sign-in page. Meanwhile they receive
"757155 is your Mark8ly sign-in code … Enter this code in the window where you
started signing in", and no such window ever appears.

## Root cause

auth-bff returns **two** challenge flags (`autologin/handler.go:90-91`):

```go
"mfa_required":       res.MFARequired,
"email_otp_required": res.EmailOTPRequired,
```

`apps/admin/lib/auth/auth-bff.ts` parsed only `mfa_required` and dropped
`email_otp_required`. On an unrecognised device auth-bff emails a code and mints
a **pending** cookie — not a session. The admin app saw `mfaRequired: false`,
treated it as a completed sign-in, and redirected; middleware found only the
pending cookie and bounced back to `/login`. Nothing errored, so nothing was
shown.

Production logs for two attempts, no errors anywhere:

```
17:47:46  GET  /api/v1/users/me/tenants      200
17:47:47  POST /internal/notifications/send  200   ← the code
17:48:00  (identical, second attempt)
```

## Fix

Frontend only — auth-bff already exposes `POST /auth/otp/verify` and
`/auth/otp/resend`, and both work.

- `auth-bff.ts`: parse `email_otp_required`; add `completeEmailOTPChallenge`
  and `resendEmailOTP`.
- `actions.ts`: return `emailOtpRequired` from `signIn`; add
  `confirmEmailOTPLogin` and `resendEmailOTPCode`.
- `SignInForm.tsx`: reuse the existing 6-digit challenge screen rather than
  building a second one — a `challenge` state selects `"mfa"` vs `"email_otp"`
  for the copy and the verify action. The email path also gets a "Send a new
  code" button, since the codes expire in 5 minutes.

## Test plan

- [x] New `auth-bff.test.ts` pins all three shapes: email-OTP, MFA, and neither
- [x] Mutation-tested: hardcoding `emailOtpRequired: false` fails the new test;
      restoring passes
- [x] `npx vitest run lib/auth` 40/40
- [x] `tsc --noEmit` clean for touched files

## Note

Rate-limit handling on resend already returns 429 via #500, so a rate-limited
user is told to wait rather than to retry.