### PR TITLE
fix(admin): two traps in the shipping carrier form

### DIFF
--- a/apps/admin/components/forms/AddressFieldset.tsx
+++ b/apps/admin/components/forms/AddressFieldset.tsx
@@ -227,8 +227,14 @@ export function AddressFieldset({
             disabled={disabled}
             onChange={(e) => update("name", e.target.value)}
             className={inputClass}
-            placeholder="Primary"
+            placeholder="e.g. Main Warehouse"
           />
+          <p className="text-xs text-[color:var(--ink-900)]/40 mt-1">
+            This name identifies the warehouse. If your store already has
+            one, type its name <strong>exactly</strong> — a different name
+            creates a second warehouse, and stock stays with the first, so
+            orders find nothing to ship.
+          </p>
         </Field>
       )}
 

--- a/apps/admin/components/settings/ShippingConfigForm.tsx
+++ b/apps/admin/components/settings/ShippingConfigForm.tsx
@@ -16,6 +16,10 @@ import {
 import { saveShippingConfig } from "@/app/(admin)/settings/shipping/actions";
 import type { ShippingConfig } from "@/lib/api/settings-api";
 import {
+  defaultAutoSchedulePickup,
+  supportsPickupAutomation,
+} from "@/lib/settings/pickup-automation";
+import {
   AddressFieldset,
   type AddressValue,
 } from "@/components/forms/AddressFieldset";
@@ -48,11 +52,13 @@ export function ShippingConfigForm({
     existing?.free_shipping_threshold ?? "0",
   );
 
-  // Pickup automation. Defaults mirror the DB: TRUE + 14:00-18:00 so
-  // existing merchants get the zero-friction path the moment they load
-  // the edit form, without needing to flip the checkbox first.
+  // Pickup automation. A saved value always wins; the unset default is
+  // ON only for carriers that actually implement SchedulePickup, so a
+  // ShipEngine merchant is no longer shown a pre-ticked Delhivery
+  // option. See lib/settings/pickup-automation.
+  const showPickupAutomation = supportsPickupAutomation(provider);
   const [autoSchedulePickup, setAutoSchedulePickup] = useState(
-    existing?.auto_schedule_pickup ?? true,
+    defaultAutoSchedulePickup(provider, existing?.auto_schedule_pickup),
   );
   const [defaultPickupSlotStart, setDefaultPickupSlotStart] = useState(
     existing?.default_pickup_slot_start ?? "14:00:00",
@@ -259,11 +265,11 @@ export function ShippingConfigForm({
         </div>
       </fieldset>
 
-      {/* Pickup automation — Delhivery only, but the form is
-          carrier-agnostic so the fields stay visible for all providers.
-          A merchant with ShipEngine sees the checkbox but it no-ops
-          because the backend only calls SchedulePickup when the carrier
-          implements the interface. */}
+      {/* Pickup automation — only rendered for carriers that implement
+          SchedulePickup. Showing it elsewhere advertised a Delhivery
+          feature to (say) an Australian ShipEngine store, pre-ticked,
+          where it silently no-ops. */}
+      {showPickupAutomation && (
       <fieldset className="space-y-4">
         <legend className="text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ink-900)]/50 mb-2">
           Pickup automation
@@ -304,6 +310,7 @@ export function ShippingConfigForm({
           </p>
         </Field>
       </fieldset>
+      )}
 
       {/* Fees */}
       <fieldset className="space-y-4">

--- a/apps/admin/lib/settings/pickup-automation.test.ts
+++ b/apps/admin/lib/settings/pickup-automation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  defaultAutoSchedulePickup,
+  supportsPickupAutomation,
+} from "./pickup-automation";
+
+describe("supportsPickupAutomation", () => {
+  it("is true only for carriers that implement SchedulePickup", () => {
+    expect(supportsPickupAutomation("delhivery")).toBe(true);
+    expect(supportsPickupAutomation("shipengine")).toBe(false);
+    expect(supportsPickupAutomation("ninjavan")).toBe(false);
+  });
+
+  it("ignores casing and padding from the provider id", () => {
+    expect(supportsPickupAutomation("Delhivery")).toBe(true);
+    expect(supportsPickupAutomation(" delhivery ")).toBe(true);
+  });
+});
+
+describe("defaultAutoSchedulePickup", () => {
+  // The bug: this defaulted to true for every provider, so an AU store
+  // adding ShipEngine saw a pre-ticked Delhivery pickup option.
+  it("defaults off for a carrier without pickup automation", () => {
+    expect(defaultAutoSchedulePickup("shipengine", undefined)).toBe(false);
+  });
+
+  it("defaults on for Delhivery", () => {
+    expect(defaultAutoSchedulePickup("delhivery", undefined)).toBe(true);
+  });
+
+  it("always honours a saved value over the default", () => {
+    expect(defaultAutoSchedulePickup("delhivery", false)).toBe(false);
+    expect(defaultAutoSchedulePickup("shipengine", true)).toBe(true);
+  });
+});

--- a/apps/admin/lib/settings/pickup-automation.ts
+++ b/apps/admin/lib/settings/pickup-automation.ts
@@ -1,0 +1,29 @@
+/**
+ * Pickup automation is a Delhivery capability: DelhiveryCarrier is the
+ * only carrier implementing SchedulePickup (marketplace-api
+ * shipping/delhivery.go:941). The backend simply no-ops for everyone
+ * else, so the form used to show the controls to every provider and
+ * default them ON — an AU store configuring ShipEngine was greeted by a
+ * pre-ticked "Auto-schedule Delhivery pickup", which reads either as a
+ * broken store or as a carrier they never chose.
+ *
+ * Keep this list in step with the carriers implementing SchedulePickup.
+ */
+const PICKUP_AUTOMATION_PROVIDERS = new Set(["delhivery"]);
+
+export function supportsPickupAutomation(provider: string): boolean {
+  return PICKUP_AUTOMATION_PROVIDERS.has(provider.trim().toLowerCase());
+}
+
+/**
+ * defaultAutoSchedulePickup decides the checkbox's initial state.
+ * A saved value always wins, so a merchant who deliberately turned it
+ * off keeps it off. Only the *unset* default is provider-aware.
+ */
+export function defaultAutoSchedulePickup(
+  provider: string,
+  saved: boolean | undefined,
+): boolean {
+  if (saved !== undefined) return saved;
+  return supportsPickupAutomation(provider);
+}


### PR DESCRIPTION
Both found by walking the real form on the-bondi-store (an **AU** store,
carrier ShipEngine, no config yet) while working #494.

## 1. The warehouse-name placeholder invited a silent data trap

`AddressFieldset` placeholdered the warehouse name as **`Primary`**. The upsert
keys on `(store_id, name)`:

```go
// warehouse/repository.go:114
Columns: []clause.Column{{Name: "store_id"}, {Name: "name"}},
```

the-bondi-store already has a warehouse named **`Main Warehouse`**
(`52b67b6b-…`) holding all its stock. Saving the form with `Primary` would not
update it — it creates a **second** warehouse with no stock, so allocation
reports nothing available and orders never ship. The failure surfaces far from
the cause and looks like broken shipping, not a typo.

The proper fix is to prefill from the store's existing warehouses, but there is
no warehouses endpoint yet — that is #177 PR 5. Until then this stops the form
*suggesting* a destructive value: the placeholder becomes `e.g. Main Warehouse`
and the field carries an explicit warning that a different name creates a
second warehouse and leaves stock with the first.

## 2. A Delhivery option, pre-ticked, on an Australian ShipEngine store

`existing?.auto_schedule_pickup ?? true` defaulted ON for every provider, and
the section rendered for every provider. The existing comment acknowledged it:

> Delhivery only, but the form is carrier-agnostic so the fields stay visible
> for all providers. A merchant with ShipEngine sees the checkbox but it no-ops

`DelhiveryCarrier` is the only carrier implementing `SchedulePickup`
(`shipping/delhivery.go:941`), and Delhivery is India-only. So an Australian
merchant configuring ShipEngine was shown "Auto-schedule Delhivery pickup",
already ticked, doing nothing.

Now gated on a tested `supportsPickupAutomation(provider)`, and the unset
default is provider-aware. **A saved value always wins**, so a merchant who
deliberately turned it off is unaffected.

## Test plan

- [x] New `pickup-automation.test.ts` — 5 cases: per-provider support, casing and
      padding, the off-by-default and on-by-default paths, and saved-value-wins
- [x] Mutation-tested: forcing `return true` fails "defaults off for a carrier
      without pickup automation"; restoring passes
- [x] `npx vitest run lib/settings lib/auth` 45/45
- [x] `tsc --noEmit` clean for touched files

Note: `lib/markdown.test.tsx` and `lib/products/useProductSelection.test.ts`
fail to resolve `react` in a *fresh worktree* with no install; both pass in a
normal checkout. Unrelated to this change.

## Not fixed here

Prefilling the warehouse name/address from the store's existing warehouse —
blocked on the warehouse CRUD API in #177 PR 5. Refs #494.