### PR TITLE
fix: stop a phoneless warehouse silently killing every shipping quote

### DIFF
--- a/apps/admin/components/forms/AddressFieldset.tsx
+++ b/apps/admin/components/forms/AddressFieldset.tsx
@@ -432,7 +432,16 @@ export function AddressFieldset({
             disabled={disabled}
             onChange={(e) => update("phone", e.target.value)}
             className={inputClass}
+            aria-describedby={`${idPrefix}-phone-help`}
           />
+          <p
+            id={`${idPrefix}-phone-help`}
+            className="text-xs text-[color:var(--ink-900)]/40 mt-1"
+          >
+            Required by carriers. ShipEngine rejects rate requests for an
+            origin address with no phone, and the storefront then shows no
+            delivery options at all.
+          </p>
         </Field>
       </div>
     </div>

--- a/apps/admin/components/settings/ShippingConfigForm.tsx
+++ b/apps/admin/components/settings/ShippingConfigForm.tsx
@@ -19,6 +19,7 @@ import {
   defaultAutoSchedulePickup,
   supportsPickupAutomation,
 } from "@/lib/settings/pickup-automation";
+import { validateWarehouseAddress } from "@/lib/settings/warehouse-validation";
 import {
   AddressFieldset,
   type AddressValue,
@@ -97,6 +98,14 @@ export function ShippingConfigForm({
     e.preventDefault();
     setError(null);
     setSuccess(false);
+
+    // A config whose origin address cannot produce rates is worse than a
+    // refused save — see lib/settings/warehouse-validation.
+    const addressError = validateWarehouseAddress(address);
+    if (addressError) {
+      setError(addressError);
+      return;
+    }
 
     startTransition(async () => {
       const result = await saveShippingConfig(provider, {

--- a/apps/admin/lib/settings/warehouse-validation.test.ts
+++ b/apps/admin/lib/settings/warehouse-validation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { validateWarehouseAddress } from "./warehouse-validation";
+
+const base = { line1: "1 Campbell Parade", city: "Bondi Beach", postal: "2026", phone: "" };
+
+describe("validateWarehouseAddress", () => {
+  // The exact production failure: address saved, phone left blank,
+  // ShipEngine 400s every quote and the storefront shows nothing.
+  it("rejects an address with no phone", () => {
+    expect(validateWarehouseAddress(base)).toMatch(/phone/i);
+  });
+
+  it("treats a whitespace-only phone as missing", () => {
+    expect(validateWarehouseAddress({ ...base, phone: "   " })).toMatch(/phone/i);
+  });
+
+  it("accepts an address with a phone", () => {
+    expect(validateWarehouseAddress({ ...base, phone: "+61255500000" })).toBeNull();
+  });
+
+  // Saving credentials before the address is a legitimate half-step;
+  // blocking it would be a worse trap than the one we are preventing.
+  it("allows a completely empty address through", () => {
+    expect(
+      validateWarehouseAddress({ line1: "", city: "", postal: "", phone: "" }),
+    ).toBeNull();
+  });
+
+  it("requires a phone as soon as any address field is filled", () => {
+    expect(
+      validateWarehouseAddress({ line1: "", city: "Bondi Beach", postal: "", phone: "" }),
+    ).toMatch(/phone/i);
+  });
+});

--- a/apps/admin/lib/settings/warehouse-validation.ts
+++ b/apps/admin/lib/settings/warehouse-validation.ts
@@ -1,0 +1,35 @@
+/**
+ * Carriers reject a rate request whose ORIGIN address carries no phone.
+ * ShipEngine answers 400 `business_rules: "'phone' should not be empty"`,
+ * and because the field is serialised `omitempty` an empty string is
+ * dropped from the payload entirely rather than sent as blank.
+ *
+ * The storefront cannot explain any of that to a shopper — it can only
+ * report that no rates came back. So the check belongs here, at the point
+ * the merchant saves a config that could never quote.
+ */
+export interface WarehouseAddressLike {
+  line1: string;
+  city: string;
+  postal: string;
+  phone: string;
+}
+
+/**
+ * Returns an error message when the warehouse address cannot produce
+ * rates, or null when it is fine to save.
+ *
+ * A completely empty address is allowed through: a merchant may save
+ * credentials first and fill the address later, and blocking that would
+ * be a worse trap than the one this prevents.
+ */
+export function validateWarehouseAddress(
+  address: WarehouseAddressLike,
+): string | null {
+  const hasAddress = Boolean(address.line1 || address.city || address.postal);
+  if (!hasAddress) return null;
+  if (!address.phone.trim()) {
+    return "Add a warehouse phone number — carriers reject rate requests without one, and your storefront would show no delivery options.";
+  }
+  return null;
+}

--- a/apps/storefront/app/checkout/page.tsx
+++ b/apps/storefront/app/checkout/page.tsx
@@ -1039,7 +1039,9 @@ export default function CheckoutPage() {
                           {humanizeService(rate.service)}
                         </p>
                         <p className="text-xs text-[color:var(--storefront-text,var(--ink-900))] opacity-50">
-                          Est. {rate.estimated_days} business day{rate.estimated_days !== 1 ? "s" : ""}
+                          {rate.estimated_days > 0
+                            ? `Est. ${rate.estimated_days} business day${rate.estimated_days !== 1 ? "s" : ""}`
+                            : "Delivery estimate unavailable"}
                         </p>
                       </div>
                     </div>
@@ -1695,7 +1697,7 @@ function NoShippingFallback({
     <div className="mt-4 space-y-3 rounded-md border border-[color:var(--storefront-text,var(--ink-900))]/15 bg-[color:var(--storefront-background,var(--paper-200))] px-4 py-3 text-sm">
       <p className="text-[color:var(--storefront-text,var(--ink-900))]">
         {shipsHere
-          ? "We couldn\u2019t get a live rate for this address right now. Please try again in a moment or double-check your postal code."
+          ? "We couldn\u2019t get a live rate for this address right now. Please try again in a moment \u2014 if it keeps happening, the store\u2019s shipping settings may need attention."
           : `Sorry \u2014 we don\u2019t currently ship to ${pretty(country) || "this country"}.`}
       </p>
       <div className="space-y-1.5 text-xs text-[color:var(--storefront-text,var(--ink-900))] opacity-80">


### PR DESCRIPTION
Found by driving a real checkout on the-bondi-store after configuring
ShipEngine. Refs #494.

## What happened

Checkout showed *"We couldn't get a live rate for this address right now.
Please try again in a moment or **double-check your postal code**."*

The postal code was fine. ShipEngine was answering:

```
400 business_rules: "'phone' should not be empty."  field_name: phone
```

`ship_from` is built from the merchant's warehouse config
(`shipengine.go:260`), and `Phone` is tagged `omitempty` — so a blank
warehouse phone is dropped from the payload entirely. Every quote 500s.

Filling the *customer's* phone changes nothing; I tried that first and it
still failed. Only the warehouse phone matters. Adding it produced live rates
immediately.

So the shopper is told to check something they control and cannot fix, while
the merchant is never told anything at all.

## Fixes

1. **Refuse to save a config that could never quote.** New
   `validateWarehouseAddress` blocks a save when an address is present but the
   phone is blank, and says why. A *completely* empty address still saves —
   filling credentials first is a legitimate half-step, and blocking it would
   be a worse trap than the one this prevents.
2. **Say so on the field.** The phone input now carries help text explaining
   carriers reject origin addresses without one.
3. **Stop blaming the postal code.** The storefront message now points at the
   store's shipping settings instead of sending shoppers to re-check an
   address that is already correct.
4. **Don't render "Est. 0 business days."** ShipEngine returned no
   `delivery_days`, and the Go zero value rendered literally as `Est. 0
   business days`. Now shows "Delivery estimate unavailable" below 1.

## Test plan

- [x] New `warehouse-validation.test.ts` — 5 cases including whitespace-only
      phone and the empty-address escape hatch
- [x] Mutation-tested: neutering the phone check fails 3 of the 5; restoring passes
- [x] `npx vitest run lib/settings` 10/10
- [x] `tsc --noEmit` clean for touched files in both apps (pre-existing
      `@tesserix/otto-widget` errors unrelated)
- [x] Verified live: adding the warehouse phone made rates appear on the
      bondi storefront

## Deliberately not changed

- **`weight_grams` falls back to a hardcoded `500`** when a product has no
  weight (`checkout/page.tsx:353`). A silent magic number that shoppers pay
  for — but changing it moves real prices, so it wants its own decision.
- **Rate realism.** The sandbox quoted A$81.40 "Ups express" and A$76.80 "Ups
  worldwide saver" for a cotton tank Sydney→Melbourne. Those are US-account
  international UPS services from the ShipEngine sandbox, not a pricing bug in
  this code. Domestic AU carriers need a real ShipEngine account.