### PR TITLE
fix(admin): default a new carrier config to active

### DIFF
--- a/apps/admin/components/settings/ShippingConfigForm.tsx
+++ b/apps/admin/components/settings/ShippingConfigForm.tsx
@@ -20,6 +20,7 @@ import {
   supportsPickupAutomation,
 } from "@/lib/settings/pickup-automation";
 import { validateWarehouseAddress } from "@/lib/settings/warehouse-validation";
+import { defaultCarrierActive } from "@/lib/settings/carrier-active";
 import {
   AddressFieldset,
   type AddressValue,
@@ -47,7 +48,9 @@ export function ShippingConfigForm({
   const [mode, setMode] = useState<"test" | "live">(
     (existing?.mode as "test" | "live") ?? "test",
   );
-  const [isActive, setIsActive] = useState(existing?.enabled ?? false);
+  // New configs default ON: an inactive carrier quotes nothing and says
+  // nothing. A saved choice always wins. See lib/settings/carrier-active.
+  const [isActive, setIsActive] = useState(defaultCarrierActive(existing?.enabled));
   const [handlingFee, setHandlingFee] = useState(existing?.handling_fee ?? "0");
   const [freeShippingMin, setFreeShippingMin] = useState(
     existing?.free_shipping_threshold ?? "0",
@@ -216,17 +219,27 @@ export function ShippingConfigForm({
             </Select>
           </Field>
 
-          <label className="flex items-center gap-2 cursor-pointer select-none pt-5">
-            <input
-              type="checkbox"
-              checked={isActive}
-              onChange={(e) => { setIsActive(e.target.checked); setSuccess(false); }}
-              disabled={pending}
-              className="h-4 w-4 rounded border-[color:var(--ink-900)]/20 text-[color:var(--moss-700)] focus:ring-[color:var(--moss-700)]"
-            />
-            <span className="text-sm text-[color:var(--ink-900)]">Active</span>
-          </label>
         </div>
+
+        {/* Kept out of the Mode row: "Test/Live" and "Active" are
+            unrelated, and sitting on one line read as though Active
+            modified the mode. */}
+        <label className="flex items-start gap-2 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={isActive}
+            onChange={(e) => { setIsActive(e.target.checked); setSuccess(false); }}
+            disabled={pending}
+            className="mt-0.5 h-4 w-4 rounded border-[color:var(--ink-900)]/20 text-[color:var(--moss-700)] focus:ring-[color:var(--moss-700)]"
+          />
+          <span className="text-sm text-[color:var(--ink-900)]">
+            Active
+            <span className="block text-xs text-[color:var(--ink-900)]/40">
+              Only active carriers are quoted at checkout. Untick to pause
+              this carrier without deleting its credentials.
+            </span>
+          </span>
+        </label>
       </fieldset>
 
       {/* Warehouse address */}

--- a/apps/admin/lib/settings/carrier-active.test.ts
+++ b/apps/admin/lib/settings/carrier-active.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultCarrierActive } from "./carrier-active";
+
+describe("defaultCarrierActive", () => {
+  // The bug: a new config defaulted to false, so a fully-filled carrier
+  // saved inactive and quoted nothing with no explanation.
+  it("defaults a new config to active", () => {
+    expect(defaultCarrierActive(undefined)).toBe(true);
+  });
+
+  // A merchant who deliberately switched a carrier off during an outage
+  // must not have it silently switched back on when they reopen the form.
+  it("keeps a deliberate off", () => {
+    expect(defaultCarrierActive(false)).toBe(false);
+  });
+
+  it("keeps an explicit on", () => {
+    expect(defaultCarrierActive(true)).toBe(true);
+  });
+});

--- a/apps/admin/lib/settings/carrier-active.ts
+++ b/apps/admin/lib/settings/carrier-active.ts
@@ -1,0 +1,18 @@
+/**
+ * `is_active` gates the rate query outright — marketplace-api filters
+ * `WHERE store_id = ? AND provider = ? AND is_active = true`
+ * (shipping/repository.go:303). An inactive carrier quotes nothing, and
+ * the storefront can only report that no delivery options came back.
+ *
+ * The column defaults to FALSE, and the form mirrored that for brand-new
+ * configs. So a merchant could enter an API key and a full warehouse
+ * address, save, and end up with a carrier that silently never quotes —
+ * the same symptom as a phoneless warehouse, with no hint of the cause.
+ *
+ * Nobody enters carrier credentials intending to leave the carrier off,
+ * so a NEW config defaults on. An existing config always keeps whatever
+ * the merchant chose, including a deliberate off.
+ */
+export function defaultCarrierActive(saved: boolean | undefined): boolean {
+  return saved ?? true;
+}


### PR DESCRIPTION
Follow-up to #508, from the same live run on the-bondi-store.

## Problem

`is_active` gates the rate query outright:

```go
// shipping/repository.go:303
Where("store_id = ? AND provider = ? AND is_active = true", storeID, provider)
```

The column is `default:false`, and the form mirrored that for brand-new
configs:

```tsx
const [isActive, setIsActive] = useState(existing?.enabled ?? false);
```

So a merchant enters an API key and a full warehouse address, hits Save, and
gets a carrier that silently never quotes. That is exactly what happened here
— the ShipEngine config sat `Inactive` until it was ticked by hand, and the
storefront just showed no delivery options.

It is the **same symptom** as the phoneless warehouse #508 fixed: no rates, no
explanation, and nothing pointing at the cause. This is the other half.

## Fix

- New configs default **on**. Nobody enters carrier credentials intending to
  leave the carrier off.
- A saved value always wins, so a merchant who deliberately paused a carrier
  during an outage does not get it switched back on when they reopen the form.
- The checkbox moves out of the "Mode" row. `Test/Live mode` and `Active` are
  unrelated concepts, and sharing a line read as though Active modified the
  mode. It now carries a line explaining what it does and why you would untick
  it.

## Why keep the checkbox at all

It was worth asking. It stays because a store can configure several carriers,
and pausing one during an outage should not require deleting its credentials
and re-entering them. The capability is right; only the default was wrong.

## Test plan

- [x] New `carrier-active.test.ts` — new-config default, deliberate off preserved,
      explicit on preserved
- [x] Mutation-tested: flipping the default back to `false` fails
      "defaults a new config to active"; restoring passes
- [x] `npx vitest run lib/settings` 13/13
- [x] `tsc --noEmit` clean for touched files