### PR TITLE
fix(admin): say that new-device verification is always on

### DIFF
--- a/apps/admin/components/settings/AccountSettingsClient.tsx
+++ b/apps/admin/components/settings/AccountSettingsClient.tsx
@@ -342,7 +342,8 @@ function MFASection({
             Two-factor authentication
           </h2>
           <p className="text-sm text-foreground-secondary">
-            Add an extra layer of security to your account.
+            Add an extra layer of security to your account with an
+            authenticator app.
           </p>
         </div>
         <span
@@ -354,6 +355,28 @@ function MFASection({
         >
           {mfaEnabled ? "Enabled" : "Disabled"}
         </span>
+      </div>
+
+      {/* "Disabled" above refers ONLY to the authenticator app. New-device
+          verification is always on and is not user-configurable — it keys
+          on the device being unrecognised, never on MFA enrolment
+          (auth-bff autologin/service.go:263). Without this note the badge
+          reads as "this account has no second factor", and a merchant who
+          then receives a sign-in code reasonably reports it as a bug. */}
+      <div className="flex items-start gap-4 rounded-md bg-[color:var(--paper-200)] px-4 py-3">
+        <Shield
+          className="mt-0.5 h-4 w-4 shrink-0 text-foreground-secondary"
+          aria-hidden="true"
+        />
+        <p className="text-sm text-foreground-secondary">
+          <span className="font-medium text-foreground">
+            New-device verification is always on.
+          </span>{" "}
+          Whether or not two-factor is enabled, signing in from a device we
+          don&rsquo;t recognise requires a one-time code emailed to you. That
+          is why you may receive a sign-in code while the setting above reads
+          &ldquo;Disabled&rdquo;.
+        </p>
       </div>
 
       {enrolling && (


### PR DESCRIPTION
Fixes #506.

## Problem

The Security page shows one control — **Two-factor authentication · Disabled**
— which reads as "this account has no second factor". It isn't true: signing in
from an unrecognised device always requires an emailed one-time code.

Reported by a merchant who saw MFA marked Disabled, then received
"757155 is your Mark8ly sign-in code", and reasonably asked whether it was a bug.

## Why they differ

Two independent mechanisms; auth-bff returns a separate flag for each
(`autologin/handler.go:90-91`).

- **MFA** — opt-in TOTP. This is what the page toggles.
- **New-device verification** — always on, keyed only on the device being
  unrecognised:

  ```go
  // autologin/service.go:263
  if newDevice && s.emailOTP != nil {
  ```

Nothing about MFA enrolment gates it. The behaviour is right; only the page
was misleading.

## Change

Copy only — no behaviour change. The card now says two-factor is specifically
about an authenticator app, and a note below states plainly that new-device
verification is always on and explains why a code can arrive while the badge
reads "Disabled".

## Not included

Listing recognised devices / recent sign-ins, which #506 also suggests. The
session registry already records device, IP and user agent
(`loginotp/handler.go` `CreateSession`), so it is buildable — but it needs an
endpoint and a real UI, and it is worth doing properly rather than bolted on
here. Left on the issue.

## Context

The same two-mechanism split caused #493: the admin client parsed
`mfa_required` and dropped `email_otp_required`, so the code screen never
rendered (fixed in #504). This is the user-facing half of that confusion.