### PR TITLE
feat(admin): tell merchants why their store cannot quote shipping rates

### DIFF
--- a/apps/admin/components/settings/ShippingSettingsClient.tsx
+++ b/apps/admin/components/settings/ShippingSettingsClient.tsx
@@ -13,6 +13,7 @@ import type {
 } from "@/lib/api/settings-api";
 import { ProviderCard } from "./ProviderCard";
 import { ShippingConfigForm } from "./ShippingConfigForm";
+import { readinessFor } from "@/lib/settings/shipping-readiness";
 import { removeShippingConfig } from "@/app/(admin)/settings/shipping/actions";
 
 interface ShippingSettingsClientProps {
@@ -54,6 +55,10 @@ export function ShippingSettingsClient({
       {supported.shipping_carriers.map((carrier) => {
         const cfg = configByCarrier.get(carrier);
         const configured = Boolean(cfg);
+        // Everything standing between this carrier and a live rate. Only
+        // shown once credentials exist — "no carrier" is already obvious
+        // from the card's own Add-credentials state.
+        const blockers = configured ? readinessFor(cfg) : [];
 
         return (
           <ProviderCard
@@ -73,6 +78,25 @@ export function ShippingSettingsClient({
                 : undefined
             }
           >
+            {blockers.length > 0 && (
+              <div
+                role="status"
+                className="mb-5 space-y-2 rounded-md border border-[color:var(--signal,#B7410E)]/25 bg-[color:var(--signal,#B7410E)]/[0.04] px-4 py-3"
+              >
+                <p className="text-sm font-medium text-foreground">
+                  This carrier isn&rsquo;t quoting rates yet
+                </p>
+                <ul className="space-y-1 text-sm text-foreground-secondary">
+                  {blockers.map((b) => (
+                    <li key={b.code} className="flex gap-2">
+                      <span aria-hidden="true">&middot;</span>
+                      <span>{b.message}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
             {editable ? (
               <ShippingConfigForm
                 provider={carrier}

--- a/apps/admin/lib/settings/shipping-readiness.test.ts
+++ b/apps/admin/lib/settings/shipping-readiness.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { readinessFor } from "./shipping-readiness";
+import type { ShippingConfig } from "@/lib/api/settings-api";
+
+// Minimal shape — readinessFor only reads these fields.
+const ready = {
+  provider: "shipengine",
+  enabled: true,
+  mode: "test",
+  warehouse_line1: "1 Campbell Parade",
+  warehouse_city: "Bondi Beach",
+  warehouse_postal: "2026",
+  warehouse_phone: "+61255500000",
+} as unknown as ShippingConfig;
+
+const codes = (cfg: ShippingConfig | undefined) =>
+  readinessFor(cfg).map((b) => b.code);
+
+describe("readinessFor", () => {
+  it("reports nothing when the carrier can quote", () => {
+    expect(readinessFor(ready)).toEqual([]);
+  });
+
+  it("reports a missing carrier", () => {
+    expect(codes(undefined)).toEqual(["no_carrier"]);
+  });
+
+  // The exact production state: everything filled, Active left unticked,
+  // storefront silently shows no delivery options.
+  it("reports an inactive carrier", () => {
+    expect(codes({ ...ready, enabled: false })).toEqual(["inactive"]);
+  });
+
+  // The exact ShipEngine 400 we hit on the-bondi-store.
+  it("reports a warehouse with no phone", () => {
+    expect(codes({ ...ready, warehouse_phone: "" })).toEqual([
+      "no_warehouse_phone",
+    ]);
+  });
+
+  it("treats a whitespace-only phone as missing", () => {
+    expect(codes({ ...ready, warehouse_phone: "   " })).toEqual([
+      "no_warehouse_phone",
+    ]);
+  });
+
+  it("reports a missing address, and does not also nag about the phone", () => {
+    // A phone with no address to attach it to is not the useful advice.
+    expect(
+      codes({
+        ...ready,
+        warehouse_line1: "",
+        warehouse_city: "",
+        warehouse_postal: "",
+        warehouse_phone: "",
+      }),
+    ).toEqual(["no_warehouse_address"]);
+  });
+
+  // Reporting only the first blocker would send the merchant round the
+  // loop twice.
+  it("reports every blocker at once", () => {
+    expect(
+      codes({ ...ready, enabled: false, warehouse_phone: "" }),
+    ).toEqual(["inactive", "no_warehouse_phone"]);
+  });
+});

--- a/apps/admin/lib/settings/shipping-readiness.ts
+++ b/apps/admin/lib/settings/shipping-readiness.ts
@@ -1,0 +1,79 @@
+import type { ShippingConfig } from "@/lib/api/settings-api";
+
+/**
+ * Why a store cannot quote shipping rates.
+ *
+ * Three separate misconfigurations all surface to the shopper as the same
+ * thing — no delivery options, no explanation — and each was hit for real
+ * on the-bondi-store before it could take an order:
+ *
+ *   • no carrier configured at all
+ *   • a carrier configured but left inactive (marketplace-api filters
+ *     `is_active = true`, shipping/repository.go:303)
+ *   • a warehouse address with no phone (ShipEngine answers
+ *     400 "'phone' should not be empty"; the field is `omitempty`, so a
+ *     blank phone is dropped from the payload entirely)
+ *   • no warehouse address, so there is no origin to quote from
+ *
+ * Each is individually reasonable and collectively a maze, because the
+ * rate path can only report that nothing came back. This turns them into
+ * one answer the merchant can act on.
+ */
+export interface ShippingBlocker {
+  /** Stable key, for tests and for keying React lists. */
+  code:
+    | "no_carrier"
+    | "inactive"
+    | "no_warehouse_address"
+    | "no_warehouse_phone";
+  message: string;
+}
+
+/**
+ * readinessFor returns every blocker for a single carrier, most
+ * fundamental first. An empty array means the carrier can quote.
+ *
+ * Reports ALL blockers rather than stopping at the first: a merchant who
+ * fixes the phone only to be told next about the inactive checkbox has
+ * been sent round the loop twice for no reason.
+ */
+export function readinessFor(cfg: ShippingConfig | undefined): ShippingBlocker[] {
+  if (!cfg) {
+    return [
+      {
+        code: "no_carrier",
+        message: "No credentials yet — add them to start quoting rates.",
+      },
+    ];
+  }
+
+  const blockers: ShippingBlocker[] = [];
+
+  if (!cfg.enabled) {
+    blockers.push({
+      code: "inactive",
+      message:
+        "This carrier is inactive, so it is never quoted at checkout. Tick “Active” to enable it.",
+    });
+  }
+
+  const hasAddress = Boolean(
+    cfg.warehouse_line1 || cfg.warehouse_city || cfg.warehouse_postal,
+  );
+  if (!hasAddress) {
+    blockers.push({
+      code: "no_warehouse_address",
+      message:
+        "No warehouse address — carriers need an origin to quote a rate from.",
+    });
+  } else if (!cfg.warehouse_phone?.trim()) {
+    // Only meaningful once there is an address to attach it to.
+    blockers.push({
+      code: "no_warehouse_phone",
+      message:
+        "The warehouse has no phone number. Carriers reject rate requests without one, so checkout shows no delivery options.",
+    });
+  }
+
+  return blockers;
+}


### PR DESCRIPTION
Three separate misconfigurations produce the **same** symptom — no delivery
options at checkout, no error, nothing pointing at the cause. Each was hit for
real on the-bondi-store, one after another, before it could take an order:

1. **No carrier configured** — nothing to quote with.
2. **Carrier configured but inactive** — marketplace-api filters
   `is_active = true` (`shipping/repository.go:303`), so it is never asked.
   Fixed as a *default* in #509; existing configs can still be off.
3. **Warehouse address with no phone** — ShipEngine answers
   `400 "'phone' should not be empty"`, and because the field is `omitempty`
   a blank phone is dropped from the payload entirely. Fixed as a *save-time*
   guard in #508; configs saved before that are still broken.
4. **No warehouse address at all** — no origin to quote from.

Each is individually reasonable. Together they are a maze, because the rate
path can only report that nothing came back — and the storefront then blamed
the shopper's postal code (also fixed in #508).

#508 and #509 stop *new* configs reaching these states. This tells a merchant
already in one which state they are in.

## What it does

The Shipping settings page now renders, per carrier, everything standing
between it and a live rate — only once credentials exist, since "no carrier"
is already obvious from the card's own Add-credentials state.

Reports **all** blockers at once rather than stopping at the first: fixing the
phone only to be told next about the Active checkbox sends the merchant round
the loop twice for no reason. A missing address suppresses the phone message,
because a phone with no address to attach it to is not the useful advice.

## Test plan

- [x] New `shipping-readiness.test.ts` — 7 cases: the ready state, each blocker
      alone, whitespace-only phone, address-suppresses-phone, and all-at-once
- [x] Mutation-tested: neutering the `enabled` check fails 2 of the 7; restoring passes
- [x] `npx vitest run lib/settings` 20/20
- [x] `tsc --noEmit` clean for touched files

## Note

Read-only and derived entirely from config already on the page — no new
endpoint, no extra request. It cannot detect a *rejected* credential; that
needs a live probe against the carrier, which is worth doing separately.