### PR TITLE
fix(admin): render the shipment pickup_warning instead of dropping it

### DIFF
--- a/apps/admin/components/orders/ShippingLabelPanel.tsx
+++ b/apps/admin/components/orders/ShippingLabelPanel.tsx
@@ -255,6 +255,15 @@ function ShipmentDetails({
           })}
         </div>
       )}
+      {shipment.pickup_warning && (
+        <div
+          role="status"
+          className="rounded-md border border-[color:var(--warning)]/30 bg-[color:var(--warning)]/[0.06] px-4 py-3 text-xs text-[color:var(--warning)]"
+        >
+          The label was created, but something after it did not complete:{" "}
+          {shipment.pickup_warning}
+        </div>
+      )}
       <LabelActions
         storeId={storeId}
         orderId={orderId}

--- a/apps/admin/lib/api/shipping-api.ts
+++ b/apps/admin/lib/api/shipping-api.ts
@@ -42,6 +42,16 @@ export interface ShipmentResponse {
   /** UTC timestamp combining pickup date + slot start. */
   pickup_scheduled_for?: string;
   /**
+   * Non-fatal problems from label creation — a failed auto-pickup
+   * schedule, or a failed fulfilment-status transition.
+   *
+   * The backend deliberately returns 200 with this set rather than
+   * failing the request: by that point real labels exist at the carrier,
+   * so a 502 would be worse than a warning. That trade only pays off if
+   * the merchant actually sees it, which is what this field is for.
+   */
+  pickup_warning?: string;
+  /**
    * Set when the backend has auto-cancelled/returned this shipment
    * (full refund or order cancel) or when a manual cancel was
    * requested via cancelShipment(). Omitted when no cancel/return has


### PR DESCRIPTION
Half of #497 — the first of its two loose ends. The second (cancelling a
shipment locking the order out of re-labelling) needs a store change and
integration tests, and follows separately.

## Problem

`ShipmentResponse.PickupWarning` carries real information — a failed
auto-pickup schedule, or a failed fulfilment-status transition
(`admin/shipments.go:1029` and `:1617`). The field did not exist in
`apps/admin/lib/api/shipping-api.ts` and was rendered nowhere.

The backend deliberately returns **200 with a warning** rather than failing:
by that point real labels exist at the carrier, so a 502 would be worse. That
trade only pays off if the merchant sees the warning. Dropped on the floor, it
produced a log line and nothing else — the label silently has no pickup booked.

## Change

- Add `pickup_warning?: string` to the client `ShipmentResponse`, documenting
  why the backend returns 200 with it set.
- Render it on the shipping panel using the existing warning-banner treatment
  already used for stub waybills and failed cancels, so it reads as one
  vocabulary rather than a new kind of alert.

## Test plan

- [x] `tsc --noEmit` clean for touched files

No component test: `apps/admin/components/orders/` has no test harness, and I
did not stand one up for a conditional banner. The logic is a single truthiness
check on a field the backend already sets and existing banners already model.
Verifying it renders needs a shipment whose pickup schedule actually failed,
which is worth doing when part 2 lands and this can be exercised for real.