### PR TITLE
fix(shipping): free allocations when a cancel means the goods never left

### DIFF
--- a/services/marketplace-api/internal/handlers/public/delhivery_webhook_test.go
+++ b/services/marketplace-api/internal/handlers/public/delhivery_webhook_test.go
@@ -74,6 +74,10 @@ func (f *fakeShippingRepo) UpdateShipmentStatus(context.Context, uuid.UUID, stri
 func (f *fakeShippingRepo) SetShipmentCancelState(context.Context, uuid.UUID, string, string, string) error {
 	panic("not implemented")
 }
+
+func (f *fakeShippingRepo) ReleaseAllocationsForShipment(context.Context, uuid.UUID) (int64, error) {
+	return 0, nil
+}
 func (f *fakeShippingRepo) ListCarrierConfigs(context.Context, string) ([]shipping.CarrierConfig, error) {
 	panic("not implemented")
 }

--- a/services/marketplace-api/internal/shipmentcancel/executor.go
+++ b/services/marketplace-api/internal/shipmentcancel/executor.go
@@ -30,6 +30,10 @@ type ShipmentStore interface {
 	GetShipmentByID(ctx context.Context, id uuid.UUID) (*shipping.ShipmentRecord, error)
 	SetShipmentCancelState(ctx context.Context, shipmentID uuid.UUID, action, status, reason string) error
 	CreateShipment(ctx context.Context, rec *shipping.ShipmentRecord) error
+	// ReleaseAllocationsForShipment un-stamps the shipment's allocations
+	// so the order can be re-labelled. Only ever called for a cancel that
+	// means the goods never left — see releaseAllocations.
+	ReleaseAllocationsForShipment(ctx context.Context, shipmentID uuid.UUID) (int64, error)
 }
 
 // CarrierResolver builds a carrier client for a (store, provider). Kept as a
@@ -166,7 +170,40 @@ func (e *Executor) execCancelForward(ctx context.Context, sh *shipping.ShipmentR
 		return Outcome{ShipmentID: sh.ID, Action: ActionCancelForward, Status: statusFailed, Reason: reason}
 	}
 	e.record(ctx, sh.ID, ActionCancelForward, statusSucceeded, "")
+	e.releaseAllocations(ctx, sh)
 	return Outcome{ShipmentID: sh.ID, Action: ActionCancelForward, Status: statusSucceeded}
+}
+
+// releaseAllocations frees the shipment's allocation rows so the order can
+// be labelled again.
+//
+// Cancelling used to leave order_allocations stamped with shipment_id.
+// Create() then found totalAllocations > 0 and no unshipped groups, and
+// returned 409 already_shipped — permanently. The only escape was Delete,
+// whose hard delete fires ON DELETE SET NULL. A cancelled shipment is not
+// a shipped one, so the stamp should go when the cancel succeeds.
+//
+// ONLY safe for ActionCancelForward. ResolveAction maps that from
+// pending/created/manifested — states where nothing has physically left.
+// in_transit and out_for_delivery resolve to ActionTriggerRTO, delivered to
+// ActionReversePickup; freeing those would let a merchant create a second
+// label for goods already moving.
+//
+// Best-effort: the cancel itself has already succeeded at the carrier, so a
+// failure here must not turn a completed cancel into an error. The merchant
+// is left in the old dead end, which is recoverable, rather than being told
+// a successful cancel failed.
+func (e *Executor) releaseAllocations(ctx context.Context, sh *shipping.ShipmentRecord) {
+	freed, err := e.store.ReleaseAllocationsForShipment(ctx, sh.ID)
+	if err != nil {
+		e.warn("shipmentcancel: release allocations failed",
+			"shipment_id", sh.ID.String(), "err", err)
+		return
+	}
+	if freed > 0 && e.logger != nil {
+		e.logger.Info("shipmentcancel: allocations released for re-labelling",
+			"shipment_id", sh.ID.String(), "allocations", freed)
+	}
 }
 
 // execReturnToOrigin returns an in-transit shipment to origin. Carriers that

--- a/services/marketplace-api/internal/shipmentcancel/executor_test.go
+++ b/services/marketplace-api/internal/shipmentcancel/executor_test.go
@@ -21,6 +21,20 @@ type fakeStore struct {
 	byID    map[uuid.UUID]shipping.ShipmentRecord
 	sets    []recordedSet
 	created []shipping.ShipmentRecord
+	// released records every shipment whose allocations were un-stamped,
+	// so tests can assert the never-shipped boundary.
+	released []uuid.UUID
+	// releaseErr makes the release fail, to prove a successful cancel is
+	// still reported as succeeded.
+	releaseErr error
+}
+
+func (f *fakeStore) ReleaseAllocationsForShipment(_ context.Context, id uuid.UUID) (int64, error) {
+	if f.releaseErr != nil {
+		return 0, f.releaseErr
+	}
+	f.released = append(f.released, id)
+	return 2, nil
 }
 
 func (f *fakeStore) CreateShipment(_ context.Context, rec *shipping.ShipmentRecord) error {
@@ -371,5 +385,84 @@ func TestParseShipmentAddress_RejectsAnErasedBlob(t *testing.T) {
 	}
 	if got.Line1 != "1 Test Lane" || got.Name != "A Person" {
 		t.Fatalf("populated address decoded wrong: %+v", got)
+	}
+}
+
+// --- allocation release on cancel (#497) ---
+//
+// Cancelling used to leave order_allocations stamped with shipment_id, so
+// Create() returned 409 already_shipped forever and the only escape was
+// deleting the shipment. A cancelled shipment is not a shipped one.
+
+func TestExecutor_CancelForward_ReleasesAllocations(t *testing.T) {
+	oid, sid := uuid.New(), uuid.New()
+	store := &fakeStore{byOrder: map[uuid.UUID][]shipping.ShipmentRecord{
+		oid: {{ID: sid, Carrier: "delhivery", TrackingNumber: "WBN1", Status: "pending"}},
+	}}
+	e := NewExecutor(store, resolverFor(&fakeCarrier{}), nil)
+
+	e.CancelForOrder(context.Background(), oid)
+
+	if len(store.released) != 1 || store.released[0] != sid {
+		t.Errorf("released = %v, want [%s]", store.released, sid)
+	}
+}
+
+// The boundary that matters. in_transit resolves to ActionTriggerRTO and
+// delivered to ActionReversePickup — the goods are moving or already
+// there. Freeing those allocations would let a merchant create a SECOND
+// label for the same goods.
+func TestExecutor_ShippedStatuses_DoNotReleaseAllocations(t *testing.T) {
+	for _, status := range []string{"in_transit", "out_for_delivery", "delivered"} {
+		t.Run(status, func(t *testing.T) {
+			oid, sid := uuid.New(), uuid.New()
+			store := &fakeStore{byOrder: map[uuid.UUID][]shipping.ShipmentRecord{
+				oid: {{ID: sid, Carrier: "delhivery", TrackingNumber: "WBN1", Status: status}},
+			}}
+			e := NewExecutor(store, resolverFor(&fakeCarrier{}), nil)
+
+			e.CancelForOrder(context.Background(), oid)
+
+			if len(store.released) != 0 {
+				t.Errorf("released = %v for status %q, want none", store.released, status)
+			}
+		})
+	}
+}
+
+// A carrier that refused the cancel means the label still stands, so the
+// allocations must stay stamped.
+func TestExecutor_FailedCancel_DoesNotReleaseAllocations(t *testing.T) {
+	oid, sid := uuid.New(), uuid.New()
+	store := &fakeStore{byOrder: map[uuid.UUID][]shipping.ShipmentRecord{
+		oid: {{ID: sid, Carrier: "delhivery", TrackingNumber: "WBN1", Status: "pending"}},
+	}}
+	car := &fakeCarrier{err: errors.New("delhivery: cancel shipment: Incorrect Waybill")}
+	e := NewExecutor(store, resolverFor(car), nil)
+
+	e.CancelForOrder(context.Background(), oid)
+
+	if len(store.released) != 0 {
+		t.Errorf("released = %v after a failed cancel, want none", store.released)
+	}
+}
+
+// The cancel already succeeded at the carrier by this point. A failure to
+// free allocations must not downgrade that to an error — the merchant is
+// left in the old (recoverable) dead end rather than being told a
+// successful cancel failed.
+func TestExecutor_ReleaseFailure_StillReportsSucceeded(t *testing.T) {
+	oid, sid := uuid.New(), uuid.New()
+	store := &fakeStore{
+		byOrder: map[uuid.UUID][]shipping.ShipmentRecord{
+			oid: {{ID: sid, Carrier: "delhivery", TrackingNumber: "WBN1", Status: "pending"}},
+		},
+		releaseErr: errors.New("db down"),
+	}
+	e := NewExecutor(store, resolverFor(&fakeCarrier{}), nil)
+
+	out := e.CancelForOrder(context.Background(), oid)
+	if len(out) != 1 || out[0].Status != "succeeded" {
+		t.Fatalf("outcomes = %+v, want one succeeded despite release failure", out)
 	}
 }

--- a/services/marketplace-api/internal/shipping/repository.go
+++ b/services/marketplace-api/internal/shipping/repository.go
@@ -150,6 +150,7 @@ type Repository interface {
 	ListShipmentsByStore(ctx context.Context, storeID uuid.UUID, limit, offset int) ([]ShipmentRecord, int64, error)
 	UpdateShipmentStatus(ctx context.Context, id uuid.UUID, status string) error
 	SetShipmentCancelState(ctx context.Context, shipmentID uuid.UUID, action, status, reason string) error
+	ReleaseAllocationsForShipment(ctx context.Context, shipmentID uuid.UUID) (int64, error)
 
 	// Carrier configs
 	GetCarrierConfig(ctx context.Context, storeID, provider string) (*CarrierConfig, error)
@@ -264,6 +265,32 @@ func (r *gormRepository) SetShipmentCancelState(ctx context.Context, shipmentID 
 		return fmt.Errorf("shipping: shipment not found")
 	}
 	return nil
+}
+
+// ReleaseAllocationsForShipment clears order_allocations.shipment_id for
+// every row stamped with shipmentID, making those allocation groups
+// unshipped again so a new label can be created for them.
+//
+// Called ONLY after a cancel that means the goods never left
+// (pending/created/manifested → ActionCancelForward). An in-transit or
+// delivered shipment must keep its stamp: freeing those would let a
+// merchant create a second label for goods already moving.
+//
+// Returns the number of allocations freed so the caller can log it. Zero
+// is normal, not an error — orders placed before allocation shipped have
+// no allocation rows at all.
+func (r *gormRepository) ReleaseAllocationsForShipment(ctx context.Context, shipmentID uuid.UUID) (int64, error) {
+	res := r.db.WithContext(ctx).
+		Table("order_allocations").
+		Where("shipment_id = ?", shipmentID).
+		Updates(map[string]any{
+			"shipment_id": nil,
+			"updated_at":  time.Now().UTC(),
+		})
+	if res.Error != nil {
+		return 0, fmt.Errorf("shipping: release allocations for shipment: %w", res.Error)
+	}
+	return res.RowsAffected, nil
 }
 
 func (r *gormRepository) ListShipmentsByStore(ctx context.Context, storeID uuid.UUID, limit, offset int) ([]ShipmentRecord, int64, error) {


### PR DESCRIPTION
Closes #497 (its second half; the first was #512).

## Problem

`CancelShipment` left the `shipments` row in place, so its
`order_allocations` rows stayed stamped with `shipment_id`. The next
`Create` therefore found `totalAllocations > 0` and no unshipped groups,
and returned **409 `already_shipped`** — permanently:

```
"every allocation for this order already has a shipment; nothing to create"
```

The only escape was `Delete`, whose hard delete fires `ON DELETE SET NULL`
and frees the allocations. Nothing told the merchant that. A cancelled
shipment is not a shipped one.

## Fix

`ReleaseAllocationsForShipment` clears `shipment_id` for the shipment's
allocations, called after a **successful forward-cancel** only.

## The boundary, which is the whole point

`ResolveAction` (`action.go:27`) already draws the line:

| shipment status | action | goods |
|---|---|---|
| `pending`, `created`, `manifested` | `ActionCancelForward` | never left → **safe to free** |
| `in_transit`, `out_for_delivery` | `ActionTriggerRTO` | moving → **must not free** |
| `delivered` | `ActionReversePickup` | delivered → **must not free** |

Freeing an in-transit shipment's allocations would let a merchant print a
**second label for goods already on a van** — worse than the dead end this
fixes. The release is therefore inside `execCancelForward`'s success path,
not in `resolveAndExecute`, and a failed carrier cancel does not release
either (the label still stands).

## Best-effort by design

The carrier cancel has already succeeded when the release runs. A DB failure
logs a warning and returns; the merchant lands in the old dead end, which is
recoverable, rather than being told a successful cancel failed. Pinned by a
test.

## Test plan

- [x] 4 new tests: releases on forward-cancel; does **not** release for
      `in_transit` / `out_for_delivery` / `delivered`; does not release after a
      failed carrier cancel; a release failure still reports `succeeded`
- [x] Mutation-tested: moving the release into `resolveAndExecute` so it fires
      for every action fails all four safety tests; restoring passes
- [x] `go vet -tags=integration ./...` clean — it caught a webhook test fake
      missing the new interface method, which `go build` alone did not
- [x] `go test -count=1 ./...` — 93/93 packages, no failures