### PR TITLE
feat(shipping): make the fallback parcel weight a store setting

### DIFF
--- a/apps/admin/components/settings/ShippingConfigForm.tsx
+++ b/apps/admin/components/settings/ShippingConfigForm.tsx
@@ -55,6 +55,11 @@ export function ShippingConfigForm({
   const [freeShippingMin, setFreeShippingMin] = useState(
     existing?.free_shipping_threshold ?? "0",
   );
+  // 500g is what checkout hardcoded before this was configurable, so an
+  // untouched store keeps quoting exactly as it did.
+  const [parcelWeight, setParcelWeight] = useState(
+    String(existing?.default_parcel_weight_grams ?? 500),
+  );
 
   // Pickup automation. A saved value always wins; the unset default is
   // ON only for carriers that actually implement SchedulePickup, so a
@@ -118,6 +123,9 @@ export function ShippingConfigForm({
         is_active: isActive,
         handling_fee: parseFloat(handlingFee) || 0,
         free_shipping_min: parseFloat(freeShippingMin) || 0,
+        // 0 or unparseable means "leave it alone" server-side, so a blank
+        // box cannot silently reset a merchant's chosen weight.
+        default_parcel_weight_grams: parseInt(parcelWeight, 10) || 0,
         warehouse_name: address.name || undefined,
         warehouse_line1: address.line1 || undefined,
         warehouse_line2: address.line2 || undefined,
@@ -368,6 +376,23 @@ export function ShippingConfigForm({
             />
             <p className="text-xs text-[color:var(--ink-900)]/40 mt-1">
               Orders above this amount ship free. Set to 0 to disable.
+            </p>
+          </Field>
+          <Field label="Default parcel weight (g)" htmlFor={`${provider}-parcel-weight`}>
+            <input
+              id={`${provider}-parcel-weight`}
+              type="number"
+              step="1"
+              min="1"
+              value={parcelWeight}
+              onChange={(e) => { setParcelWeight(e.target.value); setSuccess(false); }}
+              disabled={pending}
+              className={inputClass}
+            />
+            <p className="text-xs text-[color:var(--ink-900)]/40 mt-1">
+              Used only when a product has no weight of its own. Carriers price
+              on this, so a wrong value over- or under-charges every such item.
+              Set weights on your products for accurate rates.
             </p>
           </Field>
         </div>

--- a/apps/admin/lib/api/settings-api.ts
+++ b/apps/admin/lib/api/settings-api.ts
@@ -58,6 +58,12 @@ export interface ShippingConfig {
   enabled: boolean;
   handling_fee: string;
   free_shipping_threshold: string;
+  /**
+   * Fallback weight for products with none of their own. Defaults to
+   * 500 — exactly what checkout used to hardcode — so an existing store
+   * quotes identically until the merchant changes it.
+   */
+  default_parcel_weight_grams?: number;
   warehouse_name?: string;
   warehouse_line1?: string;
   warehouse_line2?: string;
@@ -85,6 +91,8 @@ export interface ShippingConfigUpsertInput {
   is_active: boolean;
   handling_fee: number;
   free_shipping_min: number;
+  /** 0 leaves the stored value untouched. */
+  default_parcel_weight_grams?: number;
   warehouse_name?: string;
   warehouse_line1?: string;
   warehouse_line2?: string;

--- a/apps/storefront/app/checkout/page.tsx
+++ b/apps/storefront/app/checkout/page.tsx
@@ -37,6 +37,7 @@ import {
   type CheckoutItemBody,
   type CheckoutAddressBody,
 } from "@/lib/api/checkout-api";
+import { fallbackParcelWeight } from "@/lib/checkout/parcel-weight";
 
 // ---------------------------------------------------------------------------
 // Store slug — client-side resolution via hostname + fallback
@@ -181,6 +182,9 @@ export default function CheckoutPage() {
   const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([]);
   const [shippingRates, setShippingRates] = useState<ShippingRate[]>([]);
   const [shippingOptions, setShippingOptions] = useState<ShippingOption[]>([]);
+  // Weight to assume for items whose product carries none. Store-configured
+  // (migration 000120), defaulting to the 500g checkout used to inline.
+  const fallbackWeightGrams = fallbackParcelWeight(shippingOptions);
   const [selectedShipping, setSelectedShipping] = useState<string>("");
   const [selectedProvider, setSelectedProvider] = useState<string>("");
   const [loadingRates, setLoadingRates] = useState(false);
@@ -350,7 +354,8 @@ export default function CheckoutPage() {
         quantity: i.qty,
         // Real weight + dims from the variant the buyer selected.
         // Server falls back to default envelope when these are 0/missing.
-        weight_grams: i.weightGrams && i.weightGrams > 0 ? i.weightGrams : 500,
+        weight_grams:
+          i.weightGrams && i.weightGrams > 0 ? i.weightGrams : fallbackWeightGrams,
         length_cm: i.lengthCm,
         width_cm: i.widthCm,
         height_cm: i.heightCm,

--- a/apps/storefront/lib/api/checkout-api.ts
+++ b/apps/storefront/lib/api/checkout-api.ts
@@ -284,6 +284,13 @@ export interface ShippingOption {
   mode?: string;
   services: string[];
   supported_countries: string[];
+  /**
+   * Fallback weight for a cart item whose product carries no weight.
+   * Checkout hardcoded 500g for that case, so an invisible constant set
+   * real carrier prices. Optional: an older API build omits it and the
+   * 500g default still applies.
+   */
+  default_parcel_weight_grams?: number;
 }
 
 /**

--- a/apps/storefront/lib/checkout/parcel-weight.test.ts
+++ b/apps/storefront/lib/checkout/parcel-weight.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_PARCEL_WEIGHT_GRAMS,
+  fallbackParcelWeight,
+} from "./parcel-weight";
+import type { ShippingOption } from "@/lib/api/checkout-api";
+
+const opt = (w?: number) =>
+  ({
+    carrier: "shipengine",
+    services: ["standard"],
+    supported_countries: ["AU"],
+    default_parcel_weight_grams: w,
+  }) as unknown as ShippingOption;
+
+describe("fallbackParcelWeight", () => {
+  it("uses the store's configured weight", () => {
+    expect(fallbackParcelWeight([opt(250)])).toBe(250);
+  });
+
+  // An older API build omits the field entirely; the previous behaviour
+  // must still apply rather than quoting on undefined.
+  it("falls back to 500 when the field is absent", () => {
+    expect(fallbackParcelWeight([opt(undefined)])).toBe(
+      DEFAULT_PARCEL_WEIGHT_GRAMS,
+    );
+  });
+
+  it("falls back to 500 when there are no options at all", () => {
+    expect(fallbackParcelWeight([])).toBe(DEFAULT_PARCEL_WEIGHT_GRAMS);
+  });
+
+  // A zero or negative weight would make the carrier request nonsense.
+  it("rejects non-positive and non-finite values", () => {
+    expect(fallbackParcelWeight([opt(0)])).toBe(DEFAULT_PARCEL_WEIGHT_GRAMS);
+    expect(fallbackParcelWeight([opt(-100)])).toBe(DEFAULT_PARCEL_WEIGHT_GRAMS);
+    expect(fallbackParcelWeight([opt(Number.NaN)])).toBe(
+      DEFAULT_PARCEL_WEIGHT_GRAMS,
+    );
+  });
+
+  it("skips an unusable value and takes the next usable one", () => {
+    expect(fallbackParcelWeight([opt(0), opt(300)])).toBe(300);
+  });
+});

--- a/apps/storefront/lib/checkout/parcel-weight.ts
+++ b/apps/storefront/lib/checkout/parcel-weight.ts
@@ -1,0 +1,34 @@
+import type { ShippingOption } from "@/lib/api/checkout-api";
+
+/**
+ * Weight assumed for a cart item whose product carries none, when the
+ * store has not configured its own.
+ *
+ * Kept at 500 because that is exactly what checkout hardcoded before
+ * this was configurable — so nothing a shopper is quoted changes until a
+ * merchant deliberately sets a different value.
+ */
+export const DEFAULT_PARCEL_WEIGHT_GRAMS = 500;
+
+/**
+ * fallbackParcelWeight returns the weight to assume for items with no
+ * weight of their own.
+ *
+ * Checkout used to inline `500`, so an invisible constant in frontend
+ * code set real carrier prices: a store selling 200g tanks was quoting as
+ * though every one weighed half a kilo, and had no way to correct it.
+ *
+ * Per-product weights remain the accurate answer. This is only the
+ * fallback when one is missing.
+ */
+export function fallbackParcelWeight(options: ShippingOption[]): number {
+  for (const o of options) {
+    const w = o.default_parcel_weight_grams;
+    // Guard the wire value: a 0, a negative, or a non-finite number from
+    // an older or misbehaving API must not become a weight we quote on.
+    if (typeof w === "number" && Number.isFinite(w) && w > 0) {
+      return w;
+    }
+  }
+  return DEFAULT_PARCEL_WEIGHT_GRAMS;
+}

--- a/services/marketplace-api/internal/handlers/admin/settings.go
+++ b/services/marketplace-api/internal/handlers/admin/settings.go
@@ -623,24 +623,27 @@ func (h *ShippingSettingsHandler) maskKeyField(ctx context.Context, ref string) 
 
 // shippingConfigResponse is the safe wire DTO for carrier configs.
 type shippingConfigResponse struct {
-	ID                     string `json:"id"`
-	Provider               string `json:"provider"`
-	APIKey                 string `json:"api_key"`
-	SecretKey              string `json:"secret_key"`
-	Mode                   string `json:"mode"`
-	Enabled                bool   `json:"enabled"`
-	HandlingFee            string `json:"handling_fee"`
-	FreeShippingThreshold  string `json:"free_shipping_threshold"`
-	WarehouseName          string `json:"warehouse_name,omitempty"`
-	WarehouseLine1         string `json:"warehouse_line1,omitempty"`
-	WarehouseLine2         string `json:"warehouse_line2,omitempty"`
-	WarehouseCity          string `json:"warehouse_city,omitempty"`
-	WarehouseRegion        string `json:"warehouse_region,omitempty"`
-	WarehousePostal        string `json:"warehouse_postal,omitempty"`
-	WarehouseCountry       string `json:"warehouse_country,omitempty"`
-	WarehousePhone         string `json:"warehouse_phone,omitempty"`
-	WarehouseContactPerson string `json:"warehouse_contact_person,omitempty"`
-	WarehouseEmail         string `json:"warehouse_email,omitempty"`
+	ID                    string `json:"id"`
+	Provider              string `json:"provider"`
+	APIKey                string `json:"api_key"`
+	SecretKey             string `json:"secret_key"`
+	Mode                  string `json:"mode"`
+	Enabled               bool   `json:"enabled"`
+	HandlingFee           string `json:"handling_fee"`
+	FreeShippingThreshold string `json:"free_shipping_threshold"`
+	// Fallback weight for products that carry none. 500 unless the
+	// merchant changes it — see migration 000120.
+	DefaultParcelWeightGrams int    `json:"default_parcel_weight_grams"`
+	WarehouseName            string `json:"warehouse_name,omitempty"`
+	WarehouseLine1           string `json:"warehouse_line1,omitempty"`
+	WarehouseLine2           string `json:"warehouse_line2,omitempty"`
+	WarehouseCity            string `json:"warehouse_city,omitempty"`
+	WarehouseRegion          string `json:"warehouse_region,omitempty"`
+	WarehousePostal          string `json:"warehouse_postal,omitempty"`
+	WarehouseCountry         string `json:"warehouse_country,omitempty"`
+	WarehousePhone           string `json:"warehouse_phone,omitempty"`
+	WarehouseContactPerson   string `json:"warehouse_contact_person,omitempty"`
+	WarehouseEmail           string `json:"warehouse_email,omitempty"`
 	// Pickup automation — surfaced so the admin UI can render the
 	// "Auto-schedule Delhivery pickup" checkbox + slot selector and
 	// preserve the merchant's choice across saves.
@@ -673,9 +676,10 @@ type ShippingCarrierConfigRow struct {
 	// warehouse_* columns: they are no longer read anywhere (see
 	// toShippingResponse and resolveWarehouseForSync), which is what
 	// makes dropping those columns in a later migration safe.
-	WarehouseID     *uuid.UUID      `gorm:"column:warehouse_id;type:uuid"`
-	HandlingFee     decimal.Decimal `gorm:"column:handling_fee;type:numeric(12,2);not null;default:0"`
-	FreeShippingMin decimal.Decimal `gorm:"column:free_shipping_min;type:numeric(12,2)"`
+	WarehouseID              *uuid.UUID      `gorm:"column:warehouse_id;type:uuid"`
+	HandlingFee              decimal.Decimal `gorm:"column:handling_fee;type:numeric(12,2);not null;default:0"`
+	FreeShippingMin          decimal.Decimal `gorm:"column:free_shipping_min;type:numeric(12,2)"`
+	DefaultParcelWeightGrams int             `gorm:"column:default_parcel_weight_grams;not null;default:500"`
 	// Pickup automation. See shipping.CarrierConfig for the rationale.
 	AutoSchedulePickup     bool      `gorm:"column:auto_schedule_pickup;type:boolean;not null;default:true"`
 	DefaultPickupSlotStart string    `gorm:"column:default_pickup_slot_start;type:varchar(8);default:14:00:00"`
@@ -705,29 +709,30 @@ func (h *ShippingSettingsHandler) toShippingResponse(ctx context.Context, cfg Sh
 		}
 	}
 	return shippingConfigResponse{
-		ID:                     cfg.ID.String(),
-		Provider:               cfg.Provider,
-		APIKey:                 h.maskKeyField(ctx, cfg.APIKeyEncrypted),
-		SecretKey:              h.maskKeyField(ctx, cfg.SecretKeyEncrypted),
-		Mode:                   cfg.Mode,
-		Enabled:                cfg.IsActive,
-		HandlingFee:            cfg.HandlingFee.String(),
-		FreeShippingThreshold:  cfg.FreeShippingMin.String(),
-		WarehouseName:          wh.Name,
-		WarehouseLine1:         wh.Line1,
-		WarehouseLine2:         wh.Line2,
-		WarehouseCity:          wh.City,
-		WarehouseRegion:        wh.Region,
-		WarehousePostal:        wh.PostalCode,
-		WarehouseCountry:       wh.CountryCode,
-		WarehousePhone:         wh.Phone,
-		WarehouseContactPerson: wh.ContactPerson,
-		WarehouseEmail:         wh.Email,
-		AutoSchedulePickup:     cfg.AutoSchedulePickup,
-		DefaultPickupSlotStart: cfg.DefaultPickupSlotStart,
-		DefaultPickupSlotEnd:   cfg.DefaultPickupSlotEnd,
-		CreatedAt:              cfg.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:              cfg.UpdatedAt.Format(time.RFC3339),
+		ID:                       cfg.ID.String(),
+		Provider:                 cfg.Provider,
+		APIKey:                   h.maskKeyField(ctx, cfg.APIKeyEncrypted),
+		SecretKey:                h.maskKeyField(ctx, cfg.SecretKeyEncrypted),
+		Mode:                     cfg.Mode,
+		Enabled:                  cfg.IsActive,
+		HandlingFee:              cfg.HandlingFee.String(),
+		FreeShippingThreshold:    cfg.FreeShippingMin.String(),
+		DefaultParcelWeightGrams: cfg.DefaultParcelWeightGrams,
+		WarehouseName:            wh.Name,
+		WarehouseLine1:           wh.Line1,
+		WarehouseLine2:           wh.Line2,
+		WarehouseCity:            wh.City,
+		WarehouseRegion:          wh.Region,
+		WarehousePostal:          wh.PostalCode,
+		WarehouseCountry:         wh.CountryCode,
+		WarehousePhone:           wh.Phone,
+		WarehouseContactPerson:   wh.ContactPerson,
+		WarehouseEmail:           wh.Email,
+		AutoSchedulePickup:       cfg.AutoSchedulePickup,
+		DefaultPickupSlotStart:   cfg.DefaultPickupSlotStart,
+		DefaultPickupSlotEnd:     cfg.DefaultPickupSlotEnd,
+		CreatedAt:                cfg.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:                cfg.UpdatedAt.Format(time.RFC3339),
 	}
 }
 
@@ -768,22 +773,25 @@ func (h *ShippingSettingsHandler) List(c *gin.Context) {
 // keeps the previously-encrypted value. A blank submit on a new row (no
 // existing row) still fails — validated after the lookup below.
 type shippingUpsertRequest struct {
-	APIKey                 string  `json:"api_key"`
-	SecretKey              string  `json:"secret_key"`
-	Mode                   string  `json:"mode"       binding:"required,oneof=test live"`
-	IsActive               bool    `json:"is_active"`
-	HandlingFee            float64 `json:"handling_fee"`
-	FreeShippingMin        float64 `json:"free_shipping_min"`
-	WarehouseName          string  `json:"warehouse_name"`
-	WarehouseLine1         string  `json:"warehouse_line1"`
-	WarehouseLine2         string  `json:"warehouse_line2"`
-	WarehouseCity          string  `json:"warehouse_city"`
-	WarehouseRegion        string  `json:"warehouse_region"`
-	WarehousePostal        string  `json:"warehouse_postal"`
-	WarehouseCountry       string  `json:"warehouse_country"`
-	WarehousePhone         string  `json:"warehouse_phone"`
-	WarehouseContactPerson string  `json:"warehouse_contact_person"`
-	WarehouseEmail         string  `json:"warehouse_email"`
+	APIKey          string  `json:"api_key"`
+	SecretKey       string  `json:"secret_key"`
+	Mode            string  `json:"mode"       binding:"required,oneof=test live"`
+	IsActive        bool    `json:"is_active"`
+	HandlingFee     float64 `json:"handling_fee"`
+	FreeShippingMin float64 `json:"free_shipping_min"`
+	// Optional: 0 or absent keeps whatever the row already has, so an
+	// older client cannot silently reset a merchant's chosen weight.
+	DefaultParcelWeightGrams int    `json:"default_parcel_weight_grams"`
+	WarehouseName            string `json:"warehouse_name"`
+	WarehouseLine1           string `json:"warehouse_line1"`
+	WarehouseLine2           string `json:"warehouse_line2"`
+	WarehouseCity            string `json:"warehouse_city"`
+	WarehouseRegion          string `json:"warehouse_region"`
+	WarehousePostal          string `json:"warehouse_postal"`
+	WarehouseCountry         string `json:"warehouse_country"`
+	WarehousePhone           string `json:"warehouse_phone"`
+	WarehouseContactPerson   string `json:"warehouse_contact_person"`
+	WarehouseEmail           string `json:"warehouse_email"`
 	// Pickup automation. AutoSchedulePickup is a *bool so zero-value
 	// (JSON omitted) keeps the DB default instead of forcing false
 	// on every save — we don't want the checkbox to flip itself off
@@ -1035,6 +1043,12 @@ func (h *ShippingSettingsHandler) Upsert(c *gin.Context) {
 			"default_pickup_slot_start": slotStart,
 			"default_pickup_slot_end":   slotEnd,
 			"updated_at":                time.Now(),
+		}
+		// Only written when supplied. A 0 (absent in JSON) leaves the
+		// existing value alone, so an older admin build cannot silently
+		// reset a merchant's chosen parcel weight back to the default.
+		if req.DefaultParcelWeightGrams > 0 {
+			updates["default_parcel_weight_grams"] = req.DefaultParcelWeightGrams
 		}
 		// #484: the legacy warehouse_* columns are no longer written here.
 		// warehouse_id is still updated on every save, including when it's

--- a/services/marketplace-api/internal/handlers/storefront/shipping_options.go
+++ b/services/marketplace-api/internal/handlers/storefront/shipping_options.go
@@ -37,6 +37,11 @@ type shippingOptionResponse struct {
 	Mode               string   `json:"mode,omitempty"`
 	Services           []string `json:"services"`
 	SupportedCountries []string `json:"supported_countries"`
+	// Fallback weight for a cart item whose product carries none.
+	// Checkout used to hardcode 500g for that case, so an invisible
+	// frontend constant set real carrier prices. Migration 000120
+	// defaults the column to 500, so exposing it changes no live quote.
+	DefaultParcelWeightGrams int `json:"default_parcel_weight_grams"`
 }
 
 // serviceLevelsByCarrier mirrors the admin SERVICE_LEVELS catalog.
@@ -109,10 +114,11 @@ func (h *ShippingOptionsHandler) GetOptions(c *gin.Context) {
 			}
 		}
 		out = append(out, shippingOptionResponse{
-			Carrier:            cfg.Provider,
-			Mode:               cfg.Mode,
-			Services:           services,
-			SupportedCountries: countries,
+			Carrier:                  cfg.Provider,
+			Mode:                     cfg.Mode,
+			Services:                 services,
+			SupportedCountries:       countries,
+			DefaultParcelWeightGrams: cfg.DefaultParcelWeightGrams,
 		})
 	}
 	c.JSON(http.StatusOK, gin.H{"data": out})

--- a/services/marketplace-api/internal/shipping/repository.go
+++ b/services/marketplace-api/internal/shipping/repository.go
@@ -102,7 +102,14 @@ type CarrierConfig struct {
 	Mode                  string          `gorm:"column:mode;type:varchar(10);not null;default:test"`
 	HandlingFee           decimal.Decimal `gorm:"column:handling_fee;type:numeric(12,2);not null;default:0"`
 	FreeShippingThreshold decimal.Decimal `gorm:"column:free_shipping_min;type:numeric(12,2)"`
-	Enabled               bool            `gorm:"column:is_active;not null;default:false"`
+	// DefaultParcelWeightGrams is used when a product carries no weight.
+	// Checkout hardcoded 500 for that case, so an invisible constant in
+	// frontend code was setting real carrier prices. Migration 000120
+	// defaults this to 500 so no live quote moves; it only makes the
+	// number visible and adjustable. Per-product weights remain the
+	// accurate answer — this is the fallback when one is missing.
+	DefaultParcelWeightGrams int  `gorm:"column:default_parcel_weight_grams;not null;default:500"`
+	Enabled                  bool `gorm:"column:is_active;not null;default:false"`
 	// WarehouseID points at the store-level warehouses row (migration
 	// 000095, #177) when one has been linked. Nullable: a config saved
 	// with a blank warehouse name never gets one, and the FK is ON DELETE

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 119
+const ExpectedSchemaVersion uint = 120

--- a/services/marketplace-api/migrations/000120_default_parcel_weight.down.sql
+++ b/services/marketplace-api/migrations/000120_default_parcel_weight.down.sql
@@ -1,0 +1,7 @@
+-- Safe to drop: the column only ever supplies a fallback weight, and
+-- checkout's own 500g default stands in when it is absent.
+ALTER TABLE shipping_carrier_configs
+    DROP CONSTRAINT IF EXISTS shipping_carrier_configs_default_parcel_weight_positive;
+
+ALTER TABLE shipping_carrier_configs
+    DROP COLUMN IF EXISTS default_parcel_weight_grams;

--- a/services/marketplace-api/migrations/000120_default_parcel_weight.up.sql
+++ b/services/marketplace-api/migrations/000120_default_parcel_weight.up.sql
@@ -1,0 +1,20 @@
+-- A merchant's typical parcel weight, used when a product carries none.
+--
+-- Storefront checkout hardcoded `500` grams for any item without a weight
+-- (apps/storefront/app/checkout/page.tsx). Shoppers pay carrier rates
+-- derived from that number, so an invisible constant in frontend code was
+-- setting real prices — and a store selling 200g tanks or 3kg cookware had
+-- no way to correct it.
+--
+-- Defaults to 500 precisely so this migration changes NO live quote: every
+-- existing config keeps the value checkout was already assuming. It only
+-- makes the number visible and adjustable.
+--
+-- NOT a replacement for per-product weights, which remain the accurate
+-- answer. This is the fallback when one is missing.
+ALTER TABLE shipping_carrier_configs
+    ADD COLUMN IF NOT EXISTS default_parcel_weight_grams integer NOT NULL DEFAULT 500;
+
+ALTER TABLE shipping_carrier_configs
+    ADD CONSTRAINT shipping_carrier_configs_default_parcel_weight_positive
+    CHECK (default_parcel_weight_grams > 0);


### PR DESCRIPTION
## Problem

Storefront checkout hardcoded the weight of any product that carries none:

```tsx
// apps/storefront/app/checkout/page.tsx
weight_grams: i.weightGrams && i.weightGrams > 0 ? i.weightGrams : 500,
```

Carriers price on that number, so an invisible constant in frontend code was
setting real money. A store selling 200g tanks quoted as though every one
weighed half a kilo; a store selling 3kg cookware under-charged on every
shipment. Neither had any way to correct it, or any way to know.

Spotted while checking why a cotton tank quoted A$81 Sydney→Melbourne. (That
number turned out to be the ShipEngine **sandbox** offering US UPS
international services, not this — but the 500g was real and worth fixing.)

## Change

`shipping_carrier_configs.default_parcel_weight_grams`, surfaced in the admin
Fees section and consumed by checkout.

**No live quote moves.** The column defaults to `500` — exactly what checkout
already assumed — so every existing store prices identically until a merchant
deliberately changes the value. This makes the number visible and adjustable;
it does not change anyone's prices by itself.

## Not a replacement for per-product weights

Per-product weights remain the accurate answer, and the field says so. This is
only the fallback when one is missing. A follow-up worth doing: warn merchants
which products have no weight, the same way #511 surfaces carrier blockers.

## Details worth review

- `default_parcel_weight_grams` is **optional** on the upsert: a 0 or absent
  value leaves the stored value alone, so an older admin build cannot silently
  reset a merchant's chosen weight.
- `fallbackParcelWeight` guards the wire value — 0, negative and non-finite all
  fall back to 500 rather than becoming a weight we quote on.
- CHECK constraint enforces `> 0` at the DB.

## Test plan

- [x] New `parcel-weight.test.ts` — 5 cases: configured value, absent field,
      no options, non-positive/non-finite rejection, skip-unusable-take-next
- [x] `go vet -tags=integration ./...` clean
- [x] `go test -count=1 ./...` — 93/93 packages. The schema-version guard test
      caught the missing `ExpectedSchemaVersion` bump (119 → 120); fixed.
- [x] `npx vitest run lib` — storefront 72/72, admin 106 passed
- [x] `tsc --noEmit` clean for touched files in both apps

Note: `lib/markdown.test.tsx` and `lib/products/useProductSelection.test.ts`
fail to resolve `react` in a fresh worktree with no install; both pass in a
normal checkout. Unrelated.