### PR TITLE
fix(checkout): apply the parcel-weight fallback when placing an order, not just when quoting

### DIFF
--- a/services/marketplace-api/internal/handlers/storefront/checkout_ext.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_ext.go
@@ -931,11 +931,13 @@ func (h *CheckoutExtHandler) calculateShipping(
 	parcels := make([]shipping.ParcelItem, 0, len(req.Items))
 	for _, it := range req.Items {
 		p := shipping.ParcelItem{Quantity: it.Quantity}
+		// Always resolved, even when the variant row is missing: a zero
+		// weight makes every carrier refuse the whole request, so an
+		// order that quoted fine would fail on submit.
+		p.WeightGrams = parcelWeightGrams(nil, cfg.DefaultParcelWeightGrams)
 		if it.VariantID != nil {
 			if vs, ok := shipByVariant[*it.VariantID]; ok {
-				if vs.WeightGrams != nil {
-					p.WeightGrams = *vs.WeightGrams
-				}
+				p.WeightGrams = parcelWeightGrams(vs.WeightGrams, cfg.DefaultParcelWeightGrams)
 				if vs.LengthCM != nil {
 					f, _ := vs.LengthCM.Float64()
 					p.LengthCM = f

--- a/services/marketplace-api/internal/handlers/storefront/parcel_weight_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/parcel_weight_test.go
@@ -1,0 +1,49 @@
+package storefront
+
+import "testing"
+
+func intp(v int) *int { return &v }
+
+// A zero weight makes ShipEngine return NO rates at all
+// ("Packages must weigh more than zero kg"), so an order that quoted
+// fine at checkout fails on submit. This is the exact production
+// failure on the-bondi-store: the storefront applied a 500g fallback
+// when fetching the quote, the server applied none when placing the
+// order.
+func TestParcelWeightGrams(t *testing.T) {
+	tests := []struct {
+		name          string
+		variantWeight *int
+		configured    int
+		want          int
+	}{
+		{"real variant weight wins", intp(220), 500, 220},
+		{"nil variant weight uses the store's configured default", nil, 300, 300},
+		{"zero variant weight uses the configured default", intp(0), 300, 300},
+		{"negative variant weight is not trusted", intp(-5), 300, 300},
+		{"no variant weight and no config falls back to 500", nil, 0, FallbackParcelWeightGrams},
+		{"zero variant weight and no config falls back to 500", intp(0), 0, FallbackParcelWeightGrams},
+		{"a negative configured value is not trusted either", nil, -10, FallbackParcelWeightGrams},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parcelWeightGrams(tc.variantWeight, tc.configured)
+			if got != tc.want {
+				t.Errorf("parcelWeightGrams(%v, %d) = %d, want %d",
+					tc.variantWeight, tc.configured, got, tc.want)
+			}
+		})
+	}
+}
+
+// The invariant that actually matters: whatever the inputs, the weight
+// sent to a carrier is never zero or negative.
+func TestParcelWeightGramsIsAlwaysPositive(t *testing.T) {
+	for _, vw := range []*int{nil, intp(-1), intp(0), intp(1), intp(5000)} {
+		for _, cfg := range []int{-1, 0, 1, 500} {
+			if got := parcelWeightGrams(vw, cfg); got <= 0 {
+				t.Errorf("parcelWeightGrams(%v, %d) = %d, want > 0", vw, cfg, got)
+			}
+		}
+	}
+}

--- a/services/marketplace-api/internal/handlers/storefront/shipping_rates.go
+++ b/services/marketplace-api/internal/handlers/storefront/shipping_rates.go
@@ -116,6 +116,36 @@ type carrierConfigRow struct {
 	// warehouse_* column fields from this projection; they are no
 	// longer read anywhere.
 	WarehouseID *string `gorm:"column:warehouse_id"`
+	// DefaultParcelWeightGrams (migration 000120) is the weight to assume
+	// for a variant that carries none. See parcelWeightGrams.
+	DefaultParcelWeightGrams int `gorm:"column:default_parcel_weight_grams"`
+}
+
+// FallbackParcelWeightGrams is the weight assumed for a variant with no
+// weight of its own when the store has not configured one. 500 matches
+// what storefront checkout has always sent for that case, so nothing a
+// shopper is quoted changes.
+const FallbackParcelWeightGrams = 500
+
+// parcelWeightGrams resolves the weight to send a carrier for one line.
+//
+// A zero weight is not a rounding detail: ShipEngine answers "Packages
+// must weigh more than zero kg" and returns NO rates, so an order that
+// quoted fine at checkout fails outright on submit. That is exactly what
+// happened on the-bondi-store — the storefront applied a 500g fallback
+// when fetching the quote, the server applied none when placing the
+// order, and every product without a weight could be priced but never
+// bought.
+//
+// Both paths now resolve the fallback here so they cannot drift apart.
+func parcelWeightGrams(variantWeight *int, configured int) int {
+	if variantWeight != nil && *variantWeight > 0 {
+		return *variantWeight
+	}
+	if configured > 0 {
+		return configured
+	}
+	return FallbackParcelWeightGrams
 }
 
 func (carrierConfigRow) TableName() string { return "shipping_carrier_configs" }


### PR DESCRIPTION
Found by placing a real order on the-bondi-store. Refs #494.

## Symptom

Rates quote fine. Selecting one and pressing **Place order** returns 500 and
"Could not place order. Please review your details and try again." — advice the
shopper cannot act on, because nothing about their details is wrong.

## Root cause

The quote path and the submit path built **different** carrier requests.

- Quote: storefront sends `weight_grams: … : 500` for a variant with no weight
  (`apps/storefront/app/checkout/page.tsx`).
- Submit: `calculateShipping` sets `p.WeightGrams` **only** when the variant row
  has one. A NULL weight left it at `0`.

Zero weight is not a rounding detail — ShipEngine refuses the whole request:

```
no rates returned (status=partial, 3 carrier(s) tried):
  "Packages must weigh more than zero kg."
  "A valid from zip code must be specified."
```

With one carrier still succeeding, the *quote* returned 200. With zero weight,
all three failed, so the submit got no rates and 500'd.

Net effect: **any product without a weight can be quoted but never bought.**
The code comment right above the bug even describes the failure mode — it just
only handled the case where the DB *has* a weight.

(The "from zip" line is a second carrier complaining; it is present on the
quote too and harmless while another carrier answers. Not addressed here.)

## Fix

One `parcelWeightGrams(variantWeight, configured)` resolver, used by both
paths, so they cannot drift apart again. It prefers the variant's real weight,
then the store's configured default (`default_parcel_weight_grams`, #514), then
500 — which is what the storefront has always sent, so no quote changes.

Applied even when the variant row is missing entirely, which the old code did
not cover.

## Test plan

- [x] `parcel_weight_test.go` — 7 table cases plus an invariant test asserting
      the result is **never** ≤ 0 across every combination of nil/negative/zero
      variant weight and negative/zero config
- [x] Mutation-tested: neutering the configured-default branch fails 3 cases;
      restoring passes
- [x] `go vet -tags=integration ./...` clean, `gofmt` clean
- [x] `go test -count=1 ./...` — 93/93 packages

## Still unverified

This fixes the 500. Whether the order then *completes* and allocation resolves
against `Main Warehouse` needs another run once this deploys — that is the
remaining unexercised leg of #177.