### PR TITLE
feat(admin): warn when a product has no weight set

### DIFF
--- a/apps/admin/components/products/form/GeneralTab.tsx
+++ b/apps/admin/components/products/form/GeneralTab.tsx
@@ -12,6 +12,7 @@ import type { AdminCategory } from "@/lib/api/marketplace-api";
 import type { ProductFormValues } from "@/lib/validation/product-form";
 import { ProductCategoriesPicker } from "../ProductCategoriesPicker";
 import { Field } from "./Field";
+import { isUsableWeight } from "@/lib/products/usable-weight";
 
 export interface GeneralTabProps {
   mode: "create" | "edit";
@@ -30,6 +31,11 @@ export function GeneralTab({
 }: GeneralTabProps) {
   const form = useFormContext<ProductFormValues>();
   const { register, formState, watch, setValue } = form;
+
+  // Blank, whitespace, unparseable or non-positive all mean "no usable
+  // weight" — each ends up as the fallback at checkout.
+  const weightKgValue = watch("weightKg");
+  const isWeightMissing = !isUsableWeight(weightKgValue);
 
   return (
     <div className="flex flex-col gap-8">
@@ -166,8 +172,8 @@ export function GeneralTab({
           </legend>
           <p className="mb-3 mt-1 text-xs text-[color:var(--ink-900)] opacity-60">
             Carriers (Australia Post / ShipEngine / etc.) need package
-            dimensions and weight to quote real rates. Leave blank to use
-            the default 30 × 20 × 10 cm envelope.
+            dimensions and weight to quote real rates. Blank dimensions fall
+            back to a 30 × 20 × 10 cm envelope. Weight is different — see below.
           </p>
           <div className="grid gap-4 sm:grid-cols-4">
             <Field
@@ -181,6 +187,18 @@ export function GeneralTab({
                 {...register("weightKg")}
                 className="w-full rounded-md border border-[color:var(--ink-900)] border-opacity-20 bg-[color:var(--background-elevated,white)] px-3 py-2 text-sm text-[color:var(--ink-900)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]"
               />
+              {/* A blank weight is not a neutral default the way blank
+                  dimensions are: checkout substitutes the store's fallback
+                  and the shopper is charged carrier rates derived from it.
+                  Silent until the field is actually empty, so it reads as
+                  guidance rather than an error. */}
+              {isWeightMissing && (
+                <p className="mt-1 text-xs text-[color:var(--warning)]">
+                  No weight set — shipping is quoted using your store&rsquo;s
+                  default parcel weight, so rates for this product may be
+                  wrong. Set a weight for accurate pricing.
+                </p>
+              )}
             </Field>
             <Field
               label="Length (cm)"

--- a/apps/admin/lib/products/usable-weight.test.ts
+++ b/apps/admin/lib/products/usable-weight.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { isUsableWeight } from "./usable-weight";
+
+describe("isUsableWeight", () => {
+  it("accepts a positive decimal", () => {
+    expect(isUsableWeight("1.20")).toBe(true);
+    expect(isUsableWeight("0.2")).toBe(true);
+  });
+
+  it("rejects empty and whitespace", () => {
+    expect(isUsableWeight("")).toBe(false);
+    expect(isUsableWeight("   ")).toBe(false);
+  });
+
+  it("rejects null and undefined", () => {
+    expect(isUsableWeight(null)).toBe(false);
+    expect(isUsableWeight(undefined)).toBe(false);
+  });
+
+  // A zero weight is exactly what made ShipEngine refuse every rate and
+  // 500 the order — it must not read as "set".
+  it("rejects zero and negatives", () => {
+    expect(isUsableWeight("0")).toBe(false);
+    expect(isUsableWeight("0.0")).toBe(false);
+    expect(isUsableWeight("-1")).toBe(false);
+  });
+
+  it("rejects text that is not a number", () => {
+    expect(isUsableWeight("heavy")).toBe(false);
+    expect(isUsableWeight("1.2kg")).toBe(false);
+  });
+});

--- a/apps/admin/lib/products/usable-weight.ts
+++ b/apps/admin/lib/products/usable-weight.ts
@@ -1,0 +1,20 @@
+/**
+ * A product weight only counts if a carrier could price on it.
+ *
+ * Blank dimensions fall back to a standard envelope and cost nothing;
+ * a blank WEIGHT is different. Checkout substitutes the store's default
+ * parcel weight and the shopper is charged carrier rates derived from
+ * that guess — so "no weight" is a silently mispriced product, not a
+ * neutral default.
+ *
+ * The field is a free-text decimal input, so this has to cope with
+ * whitespace, unparseable text, and non-positive numbers as well as an
+ * empty string.
+ */
+export function isUsableWeight(value: string | null | undefined): boolean {
+  if (value == null) return false;
+  const trimmed = value.trim();
+  if (trimmed === "") return false;
+  const n = Number(trimmed);
+  return Number.isFinite(n) && n > 0;
+}


### PR DESCRIPTION
Closes the last gap in the shipping-misconfiguration series. Refs #494.

## Why

The product form said:

> Leave blank to use the default 30 × 20 × 10 cm envelope.

True for **dimensions**, misleading for **weight**. A blank weight is not a
neutral default: checkout substitutes the store's fallback parcel weight and
the shopper is charged carrier rates derived from that guess. A store selling
200g tanks quotes as though each weighs the fallback.

Worse before #516: a zero weight made ShipEngine refuse *every* rate
("Packages must weigh more than zero kg"), so the order 500'd on submit —
a product that could be quoted but never bought.

## Change

- The copy now separates the two: blank dimensions fall back to an envelope,
  weight is called out as different.
- An inline warning appears under the weight field while it has no usable
  value, saying rates for this product may be wrong.

Deliberately a warning, not a validation error. Weight is genuinely optional
for a store that does not ship (digital goods, local pickup), so blocking the
save would be wrong. This tells the merchant what it costs them.

## Why a helper rather than `!value`

The field is free-text decimal, so "no usable weight" covers more than empty:
whitespace, unparseable text, `0`, and negatives all end up as the fallback at
checkout. `isUsableWeight` is the single definition, unit-tested.

## Test plan

- [x] `usable-weight.test.ts` — 5 cases: positive decimals, empty/whitespace,
      null/undefined, zero/negative, non-numeric text
- [x] Mutation-tested: dropping the `> 0` check fails "rejects zero and
      negatives"; restoring passes
- [x] `tsc --noEmit` clean for touched files

## Related, and not a bug

While verifying this I confirmed the `"A valid from zip code must be
specified"` error in the checkout logs is **not** ours. `fetchCarrierIDs`
sends every carrier enabled on the ShipEngine account, and the sandbox's
US-only carriers reject an AU origin. UPS answers, so rates work. A real
account with AU carriers resolves it — no code change warranted.