### PR TITLE
feat(payments): auto-provision each store's Stripe webhook on save

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -99,6 +99,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/outbox"
 	"github.com/mark8ly/marketplace-api/internal/page"
 	"github.com/mark8ly/marketplace-api/internal/payment"
+	"github.com/mark8ly/marketplace-api/internal/payment/stripewebhook"
 	"github.com/mark8ly/marketplace-api/internal/plangate"
 	"github.com/mark8ly/marketplace-api/internal/product"
 	"github.com/mark8ly/marketplace-api/internal/promo"
@@ -795,7 +796,11 @@ func main() {
 		// Settings handlers (P5a).
 		countryRepoAdmin := country.NewRepository(conn)
 		paymentSettingsHandler := admin.NewPaymentSettingsHandler(conn, countryRepoAdmin, apiKeyEncryptor, log).
-			WithSecretStore(carrierSecretStore)
+			WithSecretStore(carrierSecretStore).
+			// Registers the store's Stripe webhook on save so a merchant
+			// never has to touch the Stripe dashboard. Disabled when the
+			// public API base is unset, which leaves the manual flow.
+			WithStripeWebhookProvisioner(stripewebhook.New(), cfg.PublicAPIBaseURL)
 		shippingSettingsHandler := admin.NewShippingSettingsHandler(conn, countryRepoAdmin, apiKeyEncryptor, log).
 			WithSecretStore(carrierSecretStore)
 		shippingRepo := shipping.NewRepository(conn)

--- a/services/marketplace-api/internal/handlers/admin/settings.go
+++ b/services/marketplace-api/internal/handlers/admin/settings.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/carriersecrets"
 	"github.com/mark8ly/marketplace-api/internal/country"
 	"github.com/mark8ly/marketplace-api/internal/crypto"
+	"github.com/mark8ly/marketplace-api/internal/payment/stripewebhook"
 	"github.com/mark8ly/marketplace-api/internal/shipping"
 	"github.com/mark8ly/marketplace-api/internal/stores"
 	"github.com/mark8ly/marketplace-api/internal/warehouse"
@@ -161,6 +162,21 @@ type PaymentSettingsHandler struct {
 	// deployments remain buildable.
 	secretStore carriersecrets.Store
 	logger      *slog.Logger
+	// webhookProvisioner + publicAPIBase auto-register the store's Stripe
+	// webhook endpoint on save. Nil/empty disables it, leaving the manual
+	// dashboard flow — never a hard failure, because a saved API key is
+	// still useful without one.
+	webhookProvisioner *stripewebhook.Provisioner
+	publicAPIBase      string
+}
+
+// WithStripeWebhookProvisioner enables automatic webhook registration.
+func (h *PaymentSettingsHandler) WithStripeWebhookProvisioner(
+	p *stripewebhook.Provisioner, publicAPIBase string,
+) *PaymentSettingsHandler {
+	h.webhookProvisioner = p
+	h.publicAPIBase = publicAPIBase
+	return h
 }
 
 // NewPaymentSettingsHandler constructs a PaymentSettingsHandler.
@@ -415,6 +431,16 @@ func (h *PaymentSettingsHandler) Upsert(c *gin.Context) {
 			First(&cfg)
 	}
 
+	// Auto-provision the Stripe webhook so the merchant never has to open
+	// the Stripe dashboard. Without it, payment succeeds at Stripe and the
+	// order stays Pending forever — and nothing surfaces, because the
+	// webhook handler answers 200 even when it rejects an unverifiable
+	// event, so Stripe reports delivery as successful.
+	//
+	// Best-effort: the credentials are already saved and useful, so a
+	// Stripe outage here must not fail the save.
+	webhookStatus := h.provisionStripeWebhook(c, store.Slug, provider, req, cfg)
+
 	h.audit.Emit(c, audit.Event{
 		Action:       "payment_provider.updated",
 		ResourceType: "payment_provider",
@@ -426,7 +452,69 @@ func (h *PaymentSettingsHandler) Upsert(c *gin.Context) {
 			"is_active": req.IsActive,
 		},
 	})
-	c.JSON(http.StatusOK, gin.H{"data": h.toPaymentResponse(c.Request.Context(), cfg)})
+	resp := gin.H{"data": h.toPaymentResponse(c.Request.Context(), cfg)}
+	if webhookStatus != "" {
+		resp["webhook_status"] = webhookStatus
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+// provisionStripeWebhook registers (or confirms) the store's Stripe webhook
+// endpoint and persists the signing secret Stripe returns.
+//
+// Returns a short status for the response, or "" when provisioning does not
+// apply. Never returns an error: the payment config is already saved, and
+// telling a merchant their save failed because a webhook call timed out
+// would be worse than leaving them the manual path.
+func (h *PaymentSettingsHandler) provisionStripeWebhook(
+	c *gin.Context, storeSlug, provider string, req paymentUpsertRequest, cfg PaymentGatewayConfig,
+) string {
+	if provider != "stripe" || h.webhookProvisioner == nil || h.publicAPIBase == "" {
+		return ""
+	}
+	// The plaintext secret key is only in hand when the caller just sent
+	// it; we deliberately do not read it back out of the secret store to
+	// re-provision on an unrelated save.
+	if req.SecretKey == "" {
+		return ""
+	}
+
+	ctx := c.Request.Context()
+	endpoint := stripewebhook.EndpointURL(h.publicAPIBase, storeSlug)
+	// A merchant-supplied secret on this same request wins — they are
+	// telling us which endpoint to verify against.
+	haveSecret := cfg.WebhookSecretEncrypted != "" ||
+		(req.WebhookSecret != nil && *req.WebhookSecret != "")
+
+	res, err := h.webhookProvisioner.Ensure(ctx, req.SecretKey, endpoint, haveSecret, nil)
+	if err != nil {
+		h.logger.Warn("payment: stripe webhook provisioning failed",
+			"store", storeSlug, "endpoint", endpoint, "err", err)
+		return "failed"
+	}
+	if res.Secret == "" {
+		return string(res.Action)
+	}
+
+	enc, err := h.putCredential(ctx, cfg.TenantID.String(), provider, "webhook_secret", res.Secret)
+	if err != nil {
+		// The endpoint now exists but we cannot verify its events. Log
+		// loudly: this is the state that looks healthy from Stripe.
+		h.logger.Error("payment: stripe webhook secret could not be encrypted",
+			"store", storeSlug, "endpoint_id", res.EndpointID, "err", err)
+		return "failed"
+	}
+	if err := h.db.WithContext(ctx).
+		Model(&PaymentGatewayConfig{}).
+		Where("id = ?", cfg.ID).
+		Update("webhook_secret_encrypted", enc).Error; err != nil {
+		h.logger.Error("payment: stripe webhook secret could not be stored",
+			"store", storeSlug, "endpoint_id", res.EndpointID, "err", err)
+		return "failed"
+	}
+	h.logger.Info("payment: stripe webhook provisioned",
+		"store", storeSlug, "action", string(res.Action), "endpoint_id", res.EndpointID)
+	return string(res.Action)
 }
 
 // putCredential routes a plaintext credential through the wired Store,

--- a/services/marketplace-api/internal/payment/stripewebhook/provision.go
+++ b/services/marketplace-api/internal/payment/stripewebhook/provision.go
@@ -1,0 +1,261 @@
+// Package stripewebhook provisions a store's Stripe webhook endpoint
+// automatically, so a merchant never has to open the Stripe dashboard.
+//
+// Why this exists: mark8ly uses the direct-key model — each store pastes
+// its own Stripe secret key. Payment then succeeds at Stripe while the
+// order stays Pending forever unless someone ALSO registers a webhook
+// endpoint pointing back at us and copies the signing secret across.
+// Nothing surfaced when they hadn't: the webhook handler answers 200 even
+// when it rejects an unverifiable event (so Stripe stops retrying), so
+// Stripe's dashboard reports delivery as successful while nothing is
+// processed. A store could take money and never mark a single order paid.
+//
+// The key the merchant already gave us can create the endpoint itself.
+package stripewebhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// DefaultEvents are the events the order lifecycle actually depends on.
+// Deliberately narrow: subscribing to everything means paying attention
+// to nothing, and every extra event is another row in webhook_events.
+var DefaultEvents = []string{
+	"checkout.session.completed",
+	"payment_intent.succeeded",
+	"payment_intent.payment_failed",
+	"charge.refunded",
+}
+
+// Action describes what Ensure did, for logging and for telling the
+// merchant what happened.
+type Action string
+
+const (
+	// ActionCreated — no endpoint existed for this URL; one was created
+	// and its signing secret captured.
+	ActionCreated Action = "created"
+	// ActionReplaced — an endpoint for this URL existed but we had no
+	// signing secret for it. Stripe only returns the secret at creation
+	// time and never on read, so the only way to obtain one is to delete
+	// and recreate. See Ensure for why that is safe here.
+	ActionReplaced Action = "replaced"
+	// ActionUnchanged — an endpoint exists and we already hold its
+	// secret. Nothing to do.
+	ActionUnchanged Action = "unchanged"
+)
+
+// Result is the outcome of Ensure. Secret is empty for ActionUnchanged —
+// the caller already has it stored.
+type Result struct {
+	Action Action
+	Secret string
+	// EndpointID is Stripe's `we_…` id, useful in logs when a merchant
+	// asks which endpoint we own.
+	EndpointID string
+}
+
+// Provisioner talks to Stripe's webhook_endpoints API.
+type Provisioner struct {
+	httpClient *http.Client
+	apiBase    string
+}
+
+// New builds a Provisioner against the real Stripe API.
+func New() *Provisioner {
+	return &Provisioner{
+		httpClient: &http.Client{Timeout: 15 * time.Second},
+		apiBase:    "https://api.stripe.com",
+	}
+}
+
+// WithHTTPClient overrides the client (tests point this at httptest).
+func (p *Provisioner) WithHTTPClient(c *http.Client) *Provisioner {
+	p.httpClient = c
+	return p
+}
+
+// WithAPIBase overrides the Stripe base URL (tests only).
+func (p *Provisioner) WithAPIBase(base string) *Provisioner {
+	p.apiBase = strings.TrimRight(base, "/")
+	return p
+}
+
+// Ensure makes the store's webhook endpoint exist and returns its signing
+// secret when one had to be obtained.
+//
+// haveSecret says whether we already hold a usable signing secret for this
+// store. It is what keeps the operation idempotent: without it, every save
+// of the payment settings would delete and recreate the endpoint, churning
+// the signing secret and dropping any event in flight.
+//
+// The delete-and-recreate path only ever touches an endpoint whose URL is
+// byte-identical to the one we construct for this store, which no other
+// system would have reason to register. We never touch a merchant's other
+// endpoints.
+func (p *Provisioner) Ensure(
+	ctx context.Context,
+	secretKey, endpointURL string,
+	haveSecret bool,
+	events []string,
+) (Result, error) {
+	if strings.TrimSpace(secretKey) == "" {
+		return Result{}, fmt.Errorf("stripewebhook: secret key is required")
+	}
+	if strings.TrimSpace(endpointURL) == "" {
+		return Result{}, fmt.Errorf("stripewebhook: endpoint url is required")
+	}
+	if len(events) == 0 {
+		events = DefaultEvents
+	}
+
+	existing, err := p.findByURL(ctx, secretKey, endpointURL)
+	if err != nil {
+		return Result{}, err
+	}
+
+	if existing != "" && haveSecret {
+		return Result{Action: ActionUnchanged, EndpointID: existing}, nil
+	}
+
+	action := ActionCreated
+	if existing != "" {
+		// Stripe returns `secret` only from the create call, so an
+		// endpoint we cannot verify against is worse than no endpoint:
+		// every event would be rejected while Stripe reports success.
+		if err := p.deleteEndpoint(ctx, secretKey, existing); err != nil {
+			return Result{}, err
+		}
+		action = ActionReplaced
+	}
+
+	id, secret, err := p.createEndpoint(ctx, secretKey, endpointURL, events)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{Action: action, Secret: secret, EndpointID: id}, nil
+}
+
+type endpointListResponse struct {
+	Data []struct {
+		ID  string `json:"id"`
+		URL string `json:"url"`
+	} `json:"data"`
+	HasMore bool `json:"has_more"`
+}
+
+// findByURL returns the id of an endpoint registered for exactly this URL,
+// or "" when none exists.
+func (p *Provisioner) findByURL(ctx context.Context, secretKey, endpointURL string) (string, error) {
+	// 100 is Stripe's maximum page size. A merchant with more than 100
+	// endpoints AND ours beyond the first page would read as "not found"
+	// and we would create a duplicate, so paginate rather than assume.
+	startingAfter := ""
+	for {
+		q := "limit=100"
+		if startingAfter != "" {
+			q += "&starting_after=" + url.QueryEscape(startingAfter)
+		}
+		var out endpointListResponse
+		if err := p.do(ctx, http.MethodGet, "/v1/webhook_endpoints?"+q, secretKey, nil, &out); err != nil {
+			return "", fmt.Errorf("stripewebhook: list endpoints: %w", err)
+		}
+		for _, e := range out.Data {
+			if e.URL == endpointURL {
+				return e.ID, nil
+			}
+		}
+		if !out.HasMore || len(out.Data) == 0 {
+			return "", nil
+		}
+		startingAfter = out.Data[len(out.Data)-1].ID
+	}
+}
+
+func (p *Provisioner) deleteEndpoint(ctx context.Context, secretKey, id string) error {
+	if err := p.do(ctx, http.MethodDelete, "/v1/webhook_endpoints/"+url.PathEscape(id), secretKey, nil, nil); err != nil {
+		return fmt.Errorf("stripewebhook: delete endpoint %s: %w", id, err)
+	}
+	return nil
+}
+
+func (p *Provisioner) createEndpoint(
+	ctx context.Context, secretKey, endpointURL string, events []string,
+) (id, secret string, err error) {
+	form := url.Values{}
+	form.Set("url", endpointURL)
+	for _, e := range events {
+		form.Add("enabled_events[]", e)
+	}
+	form.Set("description", "mark8ly — order payment events (managed automatically)")
+
+	var out struct {
+		ID     string `json:"id"`
+		Secret string `json:"secret"`
+	}
+	body := strings.NewReader(form.Encode())
+	if err := p.do(ctx, http.MethodPost, "/v1/webhook_endpoints", secretKey, body, &out); err != nil {
+		return "", "", fmt.Errorf("stripewebhook: create endpoint: %w", err)
+	}
+	if out.Secret == "" {
+		// Without a signing secret the endpoint is worse than useless —
+		// it would receive events we can never verify.
+		return "", "", fmt.Errorf("stripewebhook: create endpoint: response carried no signing secret")
+	}
+	return out.ID, out.Secret, nil
+}
+
+func (p *Provisioner) do(ctx context.Context, method, path, secretKey string, body *strings.Reader, out any) error {
+	var req *http.Request
+	var err error
+	if body != nil {
+		req, err = http.NewRequestWithContext(ctx, method, p.apiBase+path, body)
+	} else {
+		req, err = http.NewRequestWithContext(ctx, method, p.apiBase+path, nil)
+	}
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+secretKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var e struct {
+			Error struct {
+				Message string `json:"message"`
+				Code    string `json:"code"`
+			} `json:"error"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&e)
+		msg := e.Error.Message
+		if msg == "" {
+			msg = resp.Status
+		}
+		return fmt.Errorf("stripe %d: %s", resp.StatusCode, msg)
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// EndpointURL builds the scoped webhook URL for a store. Mirrors the route
+// registered in handlers/storefront/routes.go.
+func EndpointURL(publicAPIBase, storeSlug string) string {
+	return fmt.Sprintf("%s/api/v1/webhooks/%s/stripe",
+		strings.TrimRight(publicAPIBase, "/"), url.PathEscape(storeSlug))
+}

--- a/services/marketplace-api/internal/payment/stripewebhook/provision_test.go
+++ b/services/marketplace-api/internal/payment/stripewebhook/provision_test.go
@@ -1,0 +1,253 @@
+package stripewebhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const ourURL = "https://api.mark8ly.com/api/v1/webhooks/the-bondi-store/stripe"
+
+type call struct {
+	method string
+	path   string
+	body   string
+}
+
+// stripeStub records every call and serves canned endpoint lists.
+type stripeStub struct {
+	existing  []map[string]string // id + url pairs already registered
+	calls     []call
+	createErr int  // non-zero → create responds with this status
+	noSecret  bool // create responds 200 but without a secret
+	pages     [][]map[string]string
+}
+
+func (s *stripeStub) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		s.calls = append(s.calls, call{r.Method, r.URL.Path + "?" + r.URL.RawQuery, string(raw)})
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/webhook_endpoints":
+			if len(s.pages) > 0 {
+				page := s.pages[0]
+				s.pages = s.pages[1:]
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data": page, "has_more": len(s.pages) > 0,
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": s.existing, "has_more": false,
+			})
+		case r.Method == http.MethodDelete:
+			_ = json.NewEncoder(w).Encode(map[string]any{"deleted": true})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/webhook_endpoints":
+			if s.createErr != 0 {
+				w.WriteHeader(s.createErr)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"error": map[string]string{"message": "Invalid API Key provided"},
+				})
+				return
+			}
+			out := map[string]any{"id": "we_new"}
+			if !s.noSecret {
+				out["secret"] = "whsec_abc123"
+			}
+			_ = json.NewEncoder(w).Encode(out)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func provisioner(t *testing.T, s *stripeStub) *Provisioner {
+	return New().WithAPIBase(s.server(t).URL)
+}
+
+func (s *stripeStub) counts() (gets, posts, deletes int) {
+	for _, c := range s.calls {
+		switch c.method {
+		case http.MethodGet:
+			gets++
+		case http.MethodPost:
+			posts++
+		case http.MethodDelete:
+			deletes++
+		}
+	}
+	return
+}
+
+func TestEnsureCreatesWhenNoEndpointExists(t *testing.T) {
+	s := &stripeStub{}
+	res, err := provisioner(t, s).Ensure(context.Background(), "sk_test_x", ourURL, false, nil)
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if res.Action != ActionCreated {
+		t.Errorf("action = %q, want created", res.Action)
+	}
+	if res.Secret != "whsec_abc123" {
+		t.Errorf("secret = %q, want the created signing secret", res.Secret)
+	}
+	_, _, deletes := s.counts()
+	if deletes != 0 {
+		t.Errorf("deletes = %d, want 0 — nothing existed to replace", deletes)
+	}
+}
+
+// THE idempotency case. Saving payment settings repeatedly must not churn
+// the endpoint: a delete+recreate rotates the signing secret and drops any
+// event in flight.
+func TestEnsureIsIdempotentWhenSecretAlreadyHeld(t *testing.T) {
+	s := &stripeStub{existing: []map[string]string{{"id": "we_1", "url": ourURL}}}
+	res, err := provisioner(t, s).Ensure(context.Background(), "sk_test_x", ourURL, true, nil)
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if res.Action != ActionUnchanged {
+		t.Errorf("action = %q, want unchanged", res.Action)
+	}
+	if res.Secret != "" {
+		t.Errorf("secret = %q, want empty — caller already holds it", res.Secret)
+	}
+	_, posts, deletes := s.counts()
+	if posts != 0 || deletes != 0 {
+		t.Errorf("posts=%d deletes=%d, want 0/0 — endpoint must not be touched", posts, deletes)
+	}
+}
+
+// An endpoint exists but we hold no secret: unrecoverable by reading,
+// because Stripe returns `secret` only at creation. Replace it.
+func TestEnsureReplacesEndpointWhenSecretMissing(t *testing.T) {
+	s := &stripeStub{existing: []map[string]string{{"id": "we_1", "url": ourURL}}}
+	res, err := provisioner(t, s).Ensure(context.Background(), "sk_test_x", ourURL, false, nil)
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if res.Action != ActionReplaced {
+		t.Errorf("action = %q, want replaced", res.Action)
+	}
+	if res.Secret == "" {
+		t.Error("secret is empty, want the recreated endpoint's secret")
+	}
+	_, _, deletes := s.counts()
+	if deletes != 1 {
+		t.Errorf("deletes = %d, want exactly 1", deletes)
+	}
+}
+
+// A merchant's own unrelated endpoints must never be deleted.
+func TestEnsureIgnoresOtherEndpoints(t *testing.T) {
+	s := &stripeStub{existing: []map[string]string{
+		{"id": "we_theirs", "url": "https://merchant.example.com/stripe"},
+		{"id": "we_other", "url": "https://api.mark8ly.com/api/v1/webhooks/another-store/stripe"},
+	}}
+	res, err := provisioner(t, s).Ensure(context.Background(), "sk_test_x", ourURL, false, nil)
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if res.Action != ActionCreated {
+		t.Errorf("action = %q, want created — no endpoint matched our URL", res.Action)
+	}
+	_, _, deletes := s.counts()
+	if deletes != 0 {
+		t.Errorf("deletes = %d, want 0 — another store's endpoint must not be touched", deletes)
+	}
+}
+
+// Ours sitting past the first page must not read as "absent", or every
+// save would register another duplicate endpoint.
+func TestEnsureFindsEndpointOnLaterPage(t *testing.T) {
+	first := make([]map[string]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		first = append(first, map[string]string{
+			"id": fmt.Sprintf("we_%d", i), "url": fmt.Sprintf("https://x.example.com/%d", i),
+		})
+	}
+	s := &stripeStub{pages: [][]map[string]string{
+		first,
+		{{"id": "we_ours", "url": ourURL}},
+	}}
+	res, err := provisioner(t, s).Ensure(context.Background(), "sk_test_x", ourURL, true, nil)
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if res.Action != ActionUnchanged {
+		t.Errorf("action = %q, want unchanged — ours was on page 2", res.Action)
+	}
+	gets, posts, _ := s.counts()
+	if gets != 2 {
+		t.Errorf("gets = %d, want 2 pages walked", gets)
+	}
+	if posts != 0 {
+		t.Errorf("posts = %d, want 0 — a duplicate endpoint must not be created", posts)
+	}
+}
+
+func TestEnsureSubscribesToTheOrderLifecycleEvents(t *testing.T) {
+	s := &stripeStub{}
+	if _, err := provisioner(t, s).Ensure(context.Background(), "sk_test_x", ourURL, false, nil); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	var created string
+	for _, c := range s.calls {
+		if c.method == http.MethodPost {
+			created = c.body
+		}
+	}
+	for _, want := range []string{"checkout.session.completed", "payment_intent.succeeded"} {
+		if !strings.Contains(created, want) {
+			t.Errorf("create body missing %q; got %s", want, created)
+		}
+	}
+}
+
+func TestEnsureSurfacesStripeErrors(t *testing.T) {
+	s := &stripeStub{createErr: http.StatusUnauthorized}
+	_, err := provisioner(t, s).Ensure(context.Background(), "sk_bad", ourURL, false, nil)
+	if err == nil {
+		t.Fatal("want an error for a rejected key")
+	}
+	if !strings.Contains(err.Error(), "Invalid API Key") {
+		t.Errorf("err = %v, want Stripe's own message surfaced", err)
+	}
+}
+
+// An endpoint with no signing secret receives events we can never verify —
+// strictly worse than having none, because Stripe reports delivery as fine.
+func TestEnsureRejectsCreateWithoutSecret(t *testing.T) {
+	s := &stripeStub{noSecret: true}
+	_, err := provisioner(t, s).Ensure(context.Background(), "sk_test_x", ourURL, false, nil)
+	if err == nil {
+		t.Fatal("want an error when Stripe returns no signing secret")
+	}
+}
+
+func TestEndpointURL(t *testing.T) {
+	got := EndpointURL("https://api.mark8ly.com/", "the-bondi-store")
+	if got != ourURL {
+		t.Errorf("EndpointURL = %q, want %q", got, ourURL)
+	}
+}
+
+func TestEnsureValidatesInputs(t *testing.T) {
+	s := &stripeStub{}
+	p := provisioner(t, s)
+	if _, err := p.Ensure(context.Background(), "", ourURL, false, nil); err == nil {
+		t.Error("want an error for an empty secret key")
+	}
+	if _, err := p.Ensure(context.Background(), "sk_test_x", "", false, nil); err == nil {
+		t.Error("want an error for an empty endpoint url")
+	}
+}

--- a/services/marketplace-api/pkg/config/config.go
+++ b/services/marketplace-api/pkg/config/config.go
@@ -180,6 +180,17 @@ type Config struct {
 	// the single-brand v1 setup this static host is sufficient.
 	PublicStorefrontHost string `envconfig:"PUBLIC_STOREFRONT_HOST" default:""`
 
+	// PublicAPIBaseURL is the externally reachable origin for this
+	// service — the host Stripe must call back on. It is NOT the
+	// storefront host: the Istio wildcard routes api.mark8ly.com to
+	// marketplace-api and every other *.mark8ly.com to the Next.js
+	// apps, so a webhook registered against a store's own domain 404s.
+	//
+	// Used to auto-provision each store's Stripe webhook endpoint.
+	// Empty disables provisioning (and is logged) rather than
+	// registering an endpoint at a URL that cannot receive events.
+	PublicAPIBaseURL string `envconfig:"MARKETPLACE_PUBLIC_API_BASE_URL" default:"https://api.mark8ly.com"`
+
 	// Marketing M2 — Storefront URL template for gift card delivery
 	// emails. {slug} is substituted with the store slug. Empty disables
 	// the "Shop storefront" CTA in gift card emails.


### PR DESCRIPTION
A merchant pastes their Stripe API key and is done. We register the webhook
endpoint for them and store the signing secret.

## The failure this removes

mark8ly uses the direct-key model — each store brings its own Stripe secret
key. Nothing ever registered a webhook endpoint, so payment succeeded at
Stripe and the order stayed `Pending` **forever**.

Found on the-bondi-store: order `M-THE-260901-00051` paid, order still
`Pending / Pending`. The July order `M-THE-260729-00001` is stuck identically,
so this has been broken for over a month.

**Nothing surfaced it.** The webhook handler answers `200` even when it
*rejects* an unverifiable event (deliberate — it stops Stripe retrying
garbage), so Stripe's dashboard reports delivery as successful while nothing
is processed. A store can take money and never mark a single order paid, with
no signal at either end.

Doing it by hand meant every merchant finding Developers → Webhooks, pasting a
URL containing their own store slug, copying a `whsec_` back into mark8ly —
and silently losing orders if they got any of it wrong. The key they already
gave us can do it for them.

## Behaviour

On saving Stripe credentials **with a secret key present**, we call Stripe's
`webhook_endpoints` API, register
`{PublicAPIBaseURL}/api/v1/webhooks/{slug}/stripe` for the order-lifecycle
events, and persist the returned signing secret into the
`webhook_secret_encrypted` column that already existed and was never populated.

The response carries `webhook_status`: `created`, `replaced`, `unchanged`, or
`failed`.

## Idempotency — the part that would have hurt

Naively creating on every save would register a duplicate endpoint each time.
The guard is `haveSecret`:

| state | action |
|---|---|
| no endpoint for our URL | create, capture secret |
| endpoint exists, secret held | **unchanged** — do not touch it |
| endpoint exists, no secret held | delete + recreate |

That last row is forced by Stripe: `secret` is returned **only** from the
create call, never on read. An endpoint we cannot verify against is worse than
none, because Stripe reports its deliveries as successful. Delete-and-recreate
only ever touches an endpoint whose URL is byte-identical to the one we build
for this store — a merchant's own endpoints are never touched, and that is
tested.

Listing paginates. Ours sitting on page 2 of a merchant's endpoints must not
read as "absent", or every save would add another duplicate.

## Best-effort by design

Provisioning never fails the save. The credentials are already stored and
useful; telling a merchant their save failed because a Stripe call timed out
would be worse than leaving them the manual path. Failures log and return
`webhook_status: failed`.

Disabled when `MARKETPLACE_PUBLIC_API_BASE_URL` is empty, rather than
registering an endpoint at a URL that cannot receive events. Default is
`https://api.mark8ly.com` — verified as the host Istio routes to
marketplace-api. A store's own domain 404s, which is worth knowing: the
wildcard sends every other `*.mark8ly.com` to the Next.js apps.

## Test plan

- [x] 10 tests in `provision_test.go` against an httptest Stripe stub: create,
      unchanged, replace, other-merchant-endpoints-untouched, found-on-page-2,
      subscribed events, Stripe error surfaced, create-without-secret rejected,
      URL building, input validation
- [x] Mutation-tested: neutering the `haveSecret` guard fails the idempotency
      and pagination tests; restoring passes
- [x] `go vet -tags=integration ./...` clean, `gofmt` clean
- [x] `go test -count=1 ./...` — 94/94 packages

## Follow-up worth doing

The payments settings page still shows Stripe as `Active` on the strength of an
API key alone. A readiness signal there — the way #511 does for shipping —
would tell a merchant their webhook is wired instead of leaving them to infer
it from unpaid orders.