### PR TITLE
chore(payments): stop offering PayPal until it is validated end to end

### DIFF
--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 120
+const ExpectedSchemaVersion uint = 121

--- a/services/marketplace-api/migrations/000121_retire_untested_paypal.down.sql
+++ b/services/marketplace-api/migrations/000121_retire_untested_paypal.down.sql
@@ -1,0 +1,15 @@
+-- Restores PayPal to the countries 000090 seeded it into.
+--
+-- India is deliberately EXCLUDED: PayPal does not support domestic INR
+-- payments for Indian merchants, so putting it back there would re-offer a
+-- gateway that cannot work. If India is ever wanted, add it explicitly with
+-- a reason.
+--
+-- Does not reactivate any payment_gateway_configs row: whether a merchant
+-- wants PayPal live again is their decision, not a rollback's.
+UPDATE supported_countries
+   SET payment_providers = array_append(payment_providers, 'paypal')
+ WHERE country_code IN (
+         'US','CA','GB','DE','FR','IT','ES','NL','AU','SG','MY','TH','PH','ID'
+       )
+   AND NOT ('paypal' = ANY(payment_providers));

--- a/services/marketplace-api/migrations/000121_retire_untested_paypal.up.sql
+++ b/services/marketplace-api/migrations/000121_retire_untested_paypal.up.sql
@@ -1,0 +1,28 @@
+-- Stop offering PayPal until it has been validated against a real account.
+--
+-- `paypal.go` is a genuine 483-line gateway with unit tests, and it is wired
+-- into payment.NewGateway — so a merchant in any supported country can open
+-- Settings → Payments, click "Add credentials" on PayPal, and put a gateway
+-- nobody has ever run against live PayPal in front of their customers.
+--
+-- The admin card list and the storefront's payment methods both read this
+-- column (see handlers/admin/settings_meta.go and
+-- handlers/storefront/payment_methods.go — "making that array the single
+-- source"), so removing the entry hides PayPal everywhere without touching
+-- a line of the implementation. Re-adding it is a one-line migration once
+-- someone has taken a real PayPal payment end to end.
+--
+-- India additionally must NOT get PayPal back by default even after that:
+-- PayPal discontinued DOMESTIC payments for Indian merchants in 2021 and
+-- supports only cross-border, so an INR store selling to Indian customers
+-- cannot use it. 000100 already demoted PayPal there; this removes it.
+UPDATE supported_countries
+   SET payment_providers = array_remove(payment_providers, 'paypal')
+ WHERE 'paypal' = ANY(payment_providers);
+
+-- Any store that somehow configured PayPal is deactivated rather than
+-- deleted: the credentials stay encrypted at rest so re-enabling is a flip,
+-- not a re-entry. Expected to affect zero rows today.
+UPDATE payment_gateway_configs
+   SET is_active = false, updated_at = now()
+ WHERE provider = 'paypal' AND is_active = true;


### PR DESCRIPTION
Hides PayPal from every store. **No implementation code is deleted.**

## Why

`paypal.go` is a genuine 483-line gateway with unit tests, wired into
`payment.NewGateway`. So a merchant in any of the 15 supported countries can
open Settings → Payments today, click "Add credentials" on the PayPal card,
and put a gateway **nobody has ever run against live PayPal** in front of
their customers.

Everything found in this session sat exactly in that gap — between "unit
tested" and "works against the real service". The Stripe webhook was never
registered, ShipEngine refused labels an AU origin, checkout sent zero
weights. All had passing tests.

## What changes

One data migration. `supported_countries.payment_providers` is the single
source for both the admin card list (`handlers/admin/settings_meta.go`) and
the storefront's payment methods (`handlers/storefront/payment_methods.go` —
*"making that array the single source"*), so removing the entry hides PayPal
everywhere without touching the implementation.

Re-enabling is a one-line migration once someone has taken a real PayPal
payment end to end. Deleting 483 lines of working code to hide a UI option
would mean writing it again.

Also deactivates (never deletes) any `payment_gateway_configs` row on PayPal.
Credentials stay encrypted at rest, so re-enabling is a flip rather than a
re-entry. Expected to affect zero rows — no store has PayPal configured.

## India stays out even after validation

PayPal **discontinued domestic payments for Indian merchants in 2021** and
supports only cross-border. An INR store selling to Indian customers cannot
use it, yet India's array was `{razorpay, paypal, cashfree}` — offering a
gateway that cannot work. 000100 already demoted it; this removes it.

The down migration therefore restores PayPal to the other 14 countries and
**deliberately excludes India**. A rollback should not re-introduce a known
broken combination.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -count=1 ./...` — 93/93 packages
- [x] `ExpectedSchemaVersion` bumped 120 → 121 (the guard test enforces this;
      forgetting fails service startup, not CI)
- [x] Down migration is not a blind mirror of up — India excluded by design,
      and configs are not reactivated

## Follow-up

A payments readiness signal, like #511 for shipping: the settings page shows a
provider as `Active` on the strength of an API key alone, with no indication
of whether it can actually take a payment.