### PR TITLE
feat(warehouse): archiving, deletion refusals and reordering (#177 PR 5a)

### DIFF
--- a/services/marketplace-api/internal/warehouse/archiving_integration_test.go
+++ b/services/marketplace-api/internal/warehouse/archiving_integration_test.go
@@ -1,0 +1,312 @@
+//go:build integration
+
+package warehouse_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// #177 PR 5a — archiving, the deletion refusals, and reordering.
+//
+// The rule these encode: a warehouse with ANY allocation history is
+// ARCHIVED, never deleted. order_allocations.warehouse_id is ON DELETE
+// RESTRICT because an allocation row is the record of which warehouse
+// shipped a line; deleting the warehouse would corrupt that record.
+// Delete therefore applies only to a warehouse with no history at all.
+
+// seedAllocation writes one order_allocations row for a warehouse.
+// shipped=false leaves shipment_id NULL — an unshipped parcel.
+func seedAllocation(t *testing.T, db *gorm.DB, tenantID, storeID, warehouseID string, shipped bool) {
+	t.Helper()
+	orderID, itemID := uuid.NewString(), uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO orders (id, tenant_id, store_id, order_number, idempotency_key,
+		                     customer_email, status, payment_status, fulfillment_status,
+		                     subtotal, shipping_total, tax_total, discount_total,
+		                     grand_total, refunded_amount, currency_code, placed_at)
+		 VALUES (?, ?, ?, ?, ?, 'wh-test@example.com', 'pending', 'pending', 'unfulfilled',
+		         0, 0, 0, 0, 0, 0, 'INR', now())`,
+		orderID, tenantID, storeID, "WH-"+uuid.NewString()[:8], uuid.NewString()).Error)
+	require.NoError(t, db.Exec(
+		`INSERT INTO order_items (id, order_id, title_snapshot, sku_snapshot,
+		                          unit_price, quantity, line_total, currency_code)
+		 VALUES (?, ?, 'WH Test Item', 'WH-SKU', 0, 1, 0, 'INR')`,
+		itemID, orderID).Error)
+
+	var shipmentID any
+	if shipped {
+		sid := uuid.NewString()
+		require.NoError(t, db.Exec(
+			`INSERT INTO shipments (id, tenant_id, store_id, order_id, carrier, status,
+			                        ship_from, ship_to, handling_fee, currency_code)
+			 VALUES (?, ?, ?, ?, 'shipengine', 'delivered', '{}'::jsonb, '{}'::jsonb, 0, 'INR')`,
+			sid, tenantID, storeID, orderID).Error)
+		shipmentID = sid
+	}
+	require.NoError(t, db.Exec(
+		`INSERT INTO order_allocations (id, tenant_id, store_id, order_id, order_item_id,
+		                                warehouse_id, quantity, shipment_id)
+		 VALUES (?, ?, ?, ?, ?, ?, 1, ?)`,
+		uuid.NewString(), tenantID, storeID, orderID, itemID, warehouseID, shipmentID).Error)
+}
+
+// seedVariantStock puts qty units of a fresh variant into a warehouse.
+func seedVariantStock(t *testing.T, db *gorm.DB, tenantID, storeID, warehouseID string, qty int) string {
+	t.Helper()
+	productID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		// status='active' requires published_at (products_published_requires_active).
+		`INSERT INTO products (id, tenant_id, store_id, title, handle, status, vendor_id, published_at)
+		 VALUES (?, ?, ?, 'WH Stock Product', ?, 'active', ?, now())`,
+		productID, tenantID, storeID, "wh-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	variantID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO product_variants (id, product_id, store_id, sku, price, currency_code)
+		 VALUES (?, ?, ?, ?, 10.00, 'INR')`,
+		variantID, productID, storeID, "SKU-"+uuid.NewString()[:8]).Error)
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, ?, now())`, variantID, warehouseID, qty).Error)
+	return variantID
+}
+
+func TestDelete_RemovesAWarehouseWithNoHistory(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	wh, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Spare"))
+	require.NoError(t, err)
+
+	require.NoError(t, repo.Delete(ctx, db, wh.ID))
+
+	_, err = repo.ByID(ctx, db, wh.ID)
+	require.ErrorIs(t, err, warehouse.ErrNotFound)
+}
+
+// Deleting a warehouse that still holds units would drop them from the
+// store's availability with no record they existed.
+func TestDelete_RefusesWhileStockRemains(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	wh, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Stocked"))
+	require.NoError(t, err)
+	seedVariantStock(t, db, tenantID, storeID, wh.ID, 5)
+
+	require.ErrorIs(t, repo.Delete(ctx, db, wh.ID), warehouse.ErrHasStock)
+}
+
+// An unshipped allocation means the warehouse owes a parcel; removing its
+// origin leaves an order that can never be fulfilled.
+func TestDelete_RefusesWithAnUnshippedParcel(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	wh, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Owing"))
+	require.NoError(t, err)
+	seedAllocation(t, db, tenantID, storeID, wh.ID, false)
+
+	require.ErrorIs(t, repo.Delete(ctx, db, wh.ID), warehouse.ErrHasUnshippedParcel)
+}
+
+// Fully shipped is still history. The caller must archive instead — and
+// this is the case the FK's RESTRICT would otherwise reject with a raw
+// database error.
+func TestDelete_RefusesShippedHistoryAndDirectsToArchive(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	wh, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Retired"))
+	require.NoError(t, err)
+	seedAllocation(t, db, tenantID, storeID, wh.ID, true)
+
+	require.ErrorIs(t, repo.Delete(ctx, db, wh.ID), warehouse.ErrHasHistory)
+
+	// ...and archiving it works, which is the whole point of the refusal.
+	require.NoError(t, repo.Archive(ctx, db, wh.ID))
+}
+
+// The trap the partial index exists to prevent: archiving must not burn the
+// name, or a merchant who archives "Main Warehouse" can never create another.
+func TestArchive_FreesTheNameForReuse(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	first, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Main Warehouse"))
+	require.NoError(t, err)
+	require.NoError(t, repo.Archive(ctx, db, first.ID))
+
+	second, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Main Warehouse"))
+	require.NoError(t, err)
+	require.NotEqual(t, first.ID, second.ID, "reusing an archived name must create a NEW warehouse, not resurrect the archived one")
+}
+
+// An archived warehouse must disappear from listings and stop being the
+// default — otherwise DefaultForStore keeps handing out a warehouse nothing
+// is allowed to allocate to.
+func TestArchive_ExcludesFromListAndClearsDefault(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	keep, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Keep"))
+	require.NoError(t, err)
+	gone, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Gone"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`UPDATE warehouses SET is_default = true WHERE id = ?`, gone.ID).Error)
+
+	require.NoError(t, repo.Archive(ctx, db, gone.ID))
+
+	live, err := repo.List(ctx, db, storeID, false)
+	require.NoError(t, err)
+	require.Len(t, live, 1)
+	require.Equal(t, keep.ID, live[0].ID)
+
+	all, err := repo.List(ctx, db, storeID, true)
+	require.NoError(t, err)
+	require.Len(t, all, 2, "includeArchived must still show it")
+
+	var isDefault bool
+	require.NoError(t, db.Raw(`SELECT is_default FROM warehouses WHERE id = ?`, gone.ID).Scan(&isDefault).Error)
+	require.False(t, isDefault, "an archived warehouse must not remain the store's default")
+}
+
+// A double-click must not rewrite the archive timestamp.
+func TestArchive_IsIdempotent(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	wh, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Twice"))
+	require.NoError(t, err)
+	require.NoError(t, repo.Archive(ctx, db, wh.ID))
+
+	var first string
+	require.NoError(t, db.Raw(`SELECT archived_at::text FROM warehouses WHERE id = ?`, wh.ID).Scan(&first).Error)
+
+	require.NoError(t, repo.Archive(ctx, db, wh.ID))
+
+	var second string
+	require.NoError(t, db.Raw(`SELECT archived_at::text FROM warehouses WHERE id = ?`, wh.ID).Scan(&second).Error)
+	require.Equal(t, first, second, "re-archiving must not move the timestamp")
+}
+
+func TestArchive_UnknownIDIsNotFound(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	require.ErrorIs(t, repo.Archive(context.Background(), db, uuid.NewString()), warehouse.ErrNotFound)
+}
+
+// Ordering must be stable: two warehouses at the same priority would
+// otherwise swap places between calls and make the reorder UI jump.
+func TestList_OrdersByPriorityThenName(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	for _, n := range []string{"Bravo", "Alpha", "Charlie"} {
+		_, err := repo.Upsert(ctx, db, sample(tenantID, storeID, n))
+		require.NoError(t, err)
+	}
+	// All at priority 0 → name breaks the tie.
+	got, err := repo.List(ctx, db, storeID, false)
+	require.NoError(t, err)
+	require.Equal(t, []string{"Alpha", "Bravo", "Charlie"}, namesOf(got))
+}
+
+func TestSetPriorities_ReordersInOneTransaction(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	a, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Alpha"))
+	require.NoError(t, err)
+	b, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Bravo"))
+	require.NoError(t, err)
+
+	require.NoError(t, repo.SetPriorities(ctx, db, storeID, []warehouse.PriorityUpdate{
+		{ID: b.ID, Priority: 0},
+		{ID: a.ID, Priority: 1},
+	}))
+
+	got, err := repo.List(ctx, db, storeID, false)
+	require.NoError(t, err)
+	require.Equal(t, []string{"Bravo", "Alpha"}, namesOf(got))
+}
+
+// A partial reorder is a silently different allocation order. One bad id
+// must roll the whole thing back.
+func TestSetPriorities_RollsBackEntirelyOnABadID(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	a, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Alpha"))
+	require.NoError(t, err)
+	b, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Bravo"))
+	require.NoError(t, err)
+
+	err = repo.SetPriorities(ctx, db, storeID, []warehouse.PriorityUpdate{
+		{ID: b.ID, Priority: 0},
+		{ID: uuid.NewString(), Priority: 1}, // not this store's
+	})
+	require.Error(t, err)
+
+	// Bravo's priority must NOT have been written.
+	got, err := repo.List(ctx, db, storeID, false)
+	require.NoError(t, err)
+	require.Equal(t, []string{"Alpha", "Bravo"}, namesOf(got), "a failed reorder must leave the original order intact")
+	_ = a
+}
+
+// Another store's warehouse must not be reprioritisable through a crafted id.
+func TestSetPriorities_IgnoresAnotherStoresWarehouse(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantA, storeA := seedStore(t, db)
+	_, storeB := seedStore(t, db)
+
+	mine, err := repo.Upsert(ctx, db, sample(tenantA, storeA, "Mine"))
+	require.NoError(t, err)
+
+	err = repo.SetPriorities(ctx, db, storeB, []warehouse.PriorityUpdate{{ID: mine.ID, Priority: 9}})
+	require.Error(t, err, "an id belonging to another store must be refused")
+
+	var priority int
+	require.NoError(t, db.Raw(`SELECT priority FROM warehouses WHERE id = ?`, mine.ID).Scan(&priority).Error)
+	require.Equal(t, 0, priority)
+}
+
+func namesOf(ws []warehouse.Warehouse) []string {
+	out := make([]string, 0, len(ws))
+	for _, w := range ws {
+		out = append(out, w.Name)
+	}
+	return out
+}

--- a/services/marketplace-api/internal/warehouse/repository.go
+++ b/services/marketplace-api/internal/warehouse/repository.go
@@ -48,6 +48,21 @@ import (
 // find out at the carrier API rather than here.
 var ErrNotFound = errors.New("warehouse: not found")
 
+// ErrHasStock refuses deletion of a warehouse still holding inventory:
+// deleting it would silently drop the units it holds from the store's
+// availability with no record that they ever existed.
+var ErrHasStock = errors.New("warehouse: still holds stock")
+
+// ErrHasUnshippedParcel refuses deletion of a warehouse that owes a parcel.
+// The allocation exists and is unshipped; removing its origin leaves an
+// order that can never be fulfilled.
+var ErrHasUnshippedParcel = errors.New("warehouse: has unshipped allocations")
+
+// ErrHasHistory means the warehouse has allocation history and therefore
+// cannot be deleted at all — it must be archived. Not a failure the caller
+// should surface as an error: it is the signal to call Archive instead.
+var ErrHasHistory = errors.New("warehouse: has allocation history; archive instead")
+
 // Warehouse is a store's pickup location.
 type Warehouse struct {
 	ID       string `gorm:"column:id;type:uuid;primaryKey"`
@@ -74,9 +89,18 @@ type Warehouse struct {
 	// #177 in the first place.
 	ContactPerson string `gorm:"column:contact_person;type:varchar(200)"`
 
-	IsDefault bool      `gorm:"column:is_default;not null"`
-	CreatedAt time.Time `gorm:"column:created_at"`
-	UpdatedAt time.Time `gorm:"column:updated_at"`
+	IsDefault bool `gorm:"column:is_default;not null"`
+	// Priority orders the allocator's candidate warehouses (000118).
+	Priority int `gorm:"column:priority;not null"`
+	// ArchivedAt marks a warehouse removed. Non-nil rows are excluded from
+	// every list, from the allocator's candidates, and from the admin
+	// pickers — but the row stays, because order_allocations.warehouse_id
+	// is ON DELETE RESTRICT and the allocation is the record of which
+	// warehouse shipped a line. Archiving IS removal for anything with
+	// history; see Delete vs Archive below.
+	ArchivedAt *time.Time `gorm:"column:archived_at"`
+	CreatedAt  time.Time  `gorm:"column:created_at"`
+	UpdatedAt  time.Time  `gorm:"column:updated_at"`
 }
 
 func (Warehouse) TableName() string { return "warehouses" }
@@ -113,6 +137,14 @@ func (r *Repository) Upsert(ctx context.Context, db *gorm.DB, w Warehouse) (Ware
 
 	err := db.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "store_id"}, {Name: "name"}},
+		// The unique index is PARTIAL (000122: WHERE archived_at IS NULL),
+		// and Postgres will not infer a partial index from a bare column
+		// list — it answers "no unique or exclusion constraint matching the
+		// ON CONFLICT specification". The predicate has to be restated here
+		// or every warehouse write fails, which is every carrier-config save.
+		TargetWhere: clause.Where{
+			Exprs: []clause.Expression{clause.Expr{SQL: "archived_at IS NULL"}},
+		},
 		DoUpdates: clause.AssignmentColumns([]string{
 			"line1", "line2", "city", "region", "postal_code",
 			"country_code", "phone", "email", "contact_person", "updated_at",
@@ -177,8 +209,14 @@ func (r *Repository) ByID(ctx context.Context, db *gorm.DB, id string) (Warehous
 // though nothing currently points at it by id.
 func (r *Repository) ByStoreAndName(ctx context.Context, db *gorm.DB, storeID, name string) (Warehouse, error) {
 	var w Warehouse
+	// Archived rows are excluded deliberately. Since 000122 a store may
+	// hold BOTH an archived and a live warehouse under one name (that is
+	// what the partial index allows), and this is Upsert's read-back — so
+	// matching an archived row would hand the caller a warehouse nothing
+	// is allowed to allocate to, and point the carrier config at it.
 	err := db.WithContext(ctx).
-		Where("store_id = ? AND name = ?", storeID, name).First(&w).Error
+		Where("store_id = ? AND name = ? AND archived_at IS NULL", storeID, name).
+		First(&w).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return Warehouse{}, ErrNotFound
 	}
@@ -186,4 +224,166 @@ func (r *Repository) ByStoreAndName(ctx context.Context, db *gorm.DB, storeID, n
 		return Warehouse{}, fmt.Errorf("warehouse: lookup: %w", err)
 	}
 	return w, nil
+}
+
+// List returns a store's warehouses, most preferred first.
+//
+// Ordered by priority then name: priority is the allocator's own ordering
+// (000118), and name breaks ties so two warehouses at the same priority do
+// not swap places between calls. An unstable list would make the admin
+// reorder UI jump under the merchant's cursor.
+//
+// Archived warehouses are excluded unless includeArchived. They must never
+// reach the allocator or a picker; the flag exists for an audit view.
+func (r *Repository) List(ctx context.Context, db *gorm.DB, storeID string, includeArchived bool) ([]Warehouse, error) {
+	q := db.WithContext(ctx).Where("store_id = ?", storeID)
+	if !includeArchived {
+		q = q.Where("archived_at IS NULL")
+	}
+	var out []Warehouse
+	if err := q.Order("priority ASC, name ASC").Find(&out).Error; err != nil {
+		return nil, fmt.Errorf("warehouse: list: %w", err)
+	}
+	return out, nil
+}
+
+// Archive marks a warehouse removed without deleting the row.
+//
+// This is what "remove" means for any warehouse with allocation history:
+// order_allocations.warehouse_id is ON DELETE RESTRICT precisely so the
+// record of which warehouse shipped a line cannot be destroyed.
+//
+// Idempotent — archiving an already-archived warehouse is a no-op rather
+// than an error, so a double-click cannot rewrite the archive timestamp.
+func (r *Repository) Archive(ctx context.Context, db *gorm.DB, id string) error {
+	res := db.WithContext(ctx).
+		Model(&Warehouse{}).
+		Where("id = ? AND archived_at IS NULL", id).
+		Updates(map[string]any{
+			"archived_at": time.Now().UTC(),
+			"updated_at":  time.Now().UTC(),
+			// An archived warehouse must not remain the store's default:
+			// DefaultForStore would keep handing out a warehouse nothing
+			// is allowed to allocate to.
+			"is_default": false,
+		})
+	if res.Error != nil {
+		return fmt.Errorf("warehouse: archive: %w", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		// Either it does not exist or it is already archived. Distinguish,
+		// so a caller deleting a genuinely missing id still gets ErrNotFound.
+		var count int64
+		if err := db.WithContext(ctx).Model(&Warehouse{}).
+			Where("id = ?", id).Count(&count).Error; err != nil {
+			return fmt.Errorf("warehouse: archive: %w", err)
+		}
+		if count == 0 {
+			return ErrNotFound
+		}
+	}
+	return nil
+}
+
+// Delete removes a warehouse outright. Only legal for one with NO allocation
+// history at all — anything else must be archived, and the FK's RESTRICT is
+// the hard backstop if this check is ever bypassed.
+//
+// Refusals, in the order a merchant would want to hear them:
+//
+//	ErrHasStock            — still holds inventory
+//	ErrHasUnshippedParcel  — owes a parcel that has not shipped
+//	ErrHasHistory          — shipped in the past; archive instead
+//
+// Runs its checks and the delete in the caller's db so the whole thing can
+// be one transaction: a check that passes and a delete that races another
+// allocation would otherwise leave the FK to reject it with a raw error.
+func (r *Repository) Delete(ctx context.Context, db *gorm.DB, id string) error {
+	var stock int64
+	if err := db.WithContext(ctx).
+		Table("variant_stock").
+		Where("location_id = ? AND quantity > 0", id).
+		Count(&stock).Error; err != nil {
+		return fmt.Errorf("warehouse: delete: stock check: %w", err)
+	}
+	if stock > 0 {
+		return ErrHasStock
+	}
+
+	// Unshipped first: it is the more actionable of the two, and an
+	// unshipped allocation is also history, so checking history first
+	// would mask it behind the vaguer "archive instead".
+	var unshipped int64
+	if err := db.WithContext(ctx).
+		Table("order_allocations").
+		Where("warehouse_id = ? AND shipment_id IS NULL", id).
+		Count(&unshipped).Error; err != nil {
+		return fmt.Errorf("warehouse: delete: unshipped check: %w", err)
+	}
+	if unshipped > 0 {
+		return ErrHasUnshippedParcel
+	}
+
+	var history int64
+	if err := db.WithContext(ctx).
+		Table("order_allocations").
+		Where("warehouse_id = ?", id).
+		Count(&history).Error; err != nil {
+		return fmt.Errorf("warehouse: delete: history check: %w", err)
+	}
+	if history > 0 {
+		return ErrHasHistory
+	}
+
+	res := db.WithContext(ctx).Where("id = ?", id).Delete(&Warehouse{})
+	if res.Error != nil {
+		return fmt.Errorf("warehouse: delete: %w", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// PriorityUpdate is one entry in a reorder.
+type PriorityUpdate struct {
+	ID       string
+	Priority int
+}
+
+// SetPriorities rewrites the ordering of a store's warehouses in ONE
+// transaction.
+//
+// Takes the full ordered set rather than a delta: a delta applied to a list
+// that changed underneath (a warehouse archived in another tab) reorders the
+// wrong rows. A partial application is not acceptable either — half-applied
+// priorities are a silently different allocation order, so any failure rolls
+// the whole thing back.
+//
+// Scoped by store_id as well as id so a crafted request cannot reprioritise
+// another store's warehouses.
+func (r *Repository) SetPriorities(ctx context.Context, db *gorm.DB, storeID string, updates []PriorityUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for _, u := range updates {
+			res := tx.Model(&Warehouse{}).
+				Where("id = ? AND store_id = ? AND archived_at IS NULL", u.ID, storeID).
+				Updates(map[string]any{
+					"priority":   u.Priority,
+					"updated_at": time.Now().UTC(),
+				})
+			if res.Error != nil {
+				return fmt.Errorf("warehouse: set priorities: %w", res.Error)
+			}
+			if res.RowsAffected == 0 {
+				// An id that is not this store's, or is archived. Failing
+				// the whole reorder is deliberate: applying the rest would
+				// leave an ordering the merchant never asked for.
+				return fmt.Errorf("warehouse: set priorities: %w (id %s)", ErrNotFound, u.ID)
+			}
+		}
+		return nil
+	})
 }

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 121
+const ExpectedSchemaVersion uint = 122

--- a/services/marketplace-api/migrations/000122_warehouse_archiving.down.sql
+++ b/services/marketplace-api/migrations/000122_warehouse_archiving.down.sql
@@ -1,0 +1,16 @@
+-- Restores the total unique index. This can only succeed when no two rows
+-- share (store_id, name) — which is violated exactly when a name has been
+-- reused after archiving, the very case the partial index exists to allow.
+--
+-- Failing loudly here is correct: silently dropping or renaming a merchant's
+-- warehouse to force the old index through would lose the record of which
+-- warehouse shipped an order. Resolve the duplicate deliberately, then roll
+-- back.
+DROP INDEX IF EXISTS warehouses_store_live_idx;
+DROP INDEX IF EXISTS warehouses_store_name_live_key;
+
+CREATE UNIQUE INDEX warehouses_store_name_key
+    ON warehouses (store_id, name);
+
+ALTER TABLE warehouses
+    DROP COLUMN IF EXISTS archived_at;

--- a/services/marketplace-api/migrations/000122_warehouse_archiving.up.sql
+++ b/services/marketplace-api/migrations/000122_warehouse_archiving.up.sql
@@ -1,0 +1,30 @@
+-- #177 PR 5a — archiving as the removal mechanism for a warehouse that has
+-- allocation history.
+--
+-- A warehouse with ANY allocation history — even fully shipped — must never
+-- be deleted: order_allocations.warehouse_id is ON DELETE RESTRICT, and an
+-- allocation row is the record of which warehouse shipped a line. Deleting
+-- the warehouse would corrupt that record, so RESTRICT refuses it outright.
+-- Archiving is what "remove" actually means for such a warehouse.
+ALTER TABLE warehouses
+    ADD COLUMN IF NOT EXISTS archived_at timestamptz;
+
+-- The uniqueness must become PARTIAL, or archiving permanently burns a name:
+-- a merchant who archives "Main Warehouse" could never create another one,
+-- because the old row still occupies (store_id, name).
+--
+-- Safe to swap in either order only if no two LIVE rows collide, which the
+-- old total index already guarantees — every existing row has archived_at
+-- NULL, so the partial index covers exactly the same set today.
+DROP INDEX IF EXISTS warehouses_store_name_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS warehouses_store_name_live_key
+    ON warehouses (store_id, name)
+    WHERE archived_at IS NULL;
+
+-- Archived warehouses must never be offered to the allocator or the admin
+-- pickers, and both filter on archived_at. Index the live set so that filter
+-- stays cheap as archived rows accumulate.
+CREATE INDEX IF NOT EXISTS warehouses_store_live_idx
+    ON warehouses (store_id)
+    WHERE archived_at IS NULL;


### PR DESCRIPTION
First slice of #177 PR 5, per the plan in #515. Schema + repository only —
no API, no UI. Nothing calls the new methods yet.

## Why PR 5 exists at all

Multi-warehouse allocation is merged and working (PRs 1–4b), but **a merchant
cannot create a second warehouse**. The only path that creates one is saving a
carrier config (`settings.go:998`), which gives exactly one per store. Bondi's
`Main Warehouse` was inserted with SQL, not through the UI. So the allocator
can never split anything, because there is nothing to split across.

## What this adds

**Migration 000122** — `archived_at`, and the `(store_id, name)` unique index
becomes **partial** on `archived_at IS NULL`.

**Repository** — `List`, `Archive`, `Delete`, `SetPriorities`, plus `Priority`
and `ArchivedAt` on the model.

## Delete vs Archive

A warehouse with ANY allocation history is **archived, never deleted**:
`order_allocations.warehouse_id` is `ON DELETE RESTRICT` because the allocation
row is the record of which warehouse shipped a line. `Delete` therefore applies
only to a warehouse with no history at all, and refuses in the order a merchant
would want to hear:

| refusal | when |
|---|---|
| `ErrHasStock` | still holds inventory |
| `ErrHasUnshippedParcel` | owes a parcel that has not shipped |
| `ErrHasHistory` | shipped in the past — archive instead |

Unshipped is checked **before** history deliberately: an unshipped allocation
is also history, so checking history first would mask the actionable message
behind the vaguer one.

## Two bugs the integration tests caught — both in this PR

**1. The partial index broke every warehouse write.** Postgres will not infer a
partial index from a bare column list, so `Upsert`'s `ON CONFLICT (store_id,
name)` started failing with *"no unique or exclusion constraint matching the ON
CONFLICT specification"*. That is the path behind **every carrier-config save**
— it would have broken shipping setup in production. Fixed by restating the
predicate as `TargetWhere`. The plan called the partial index "the quiet one";
it was.

**2. `ByStoreAndName` could return an archived row.** Since a store may now
hold both an archived and a live warehouse under one name — exactly what the
partial index allows — and this is `Upsert`'s read-back, it could hand back a
warehouse nothing may allocate to and point the carrier config at it. GORM's
`First()` silently orders by id, so which one you got was luck. Now scoped to
live rows.

Neither is reachable from unit tests. Both fell out of running against a real
database.

## Test plan

- [x] 12 new integration tests: delete with no history; the three refusals;
      archive frees the name for reuse; archive excludes from list and clears
      `is_default`; archive is idempotent; unknown id; stable ordering;
      reorder in one transaction; reorder rolls back entirely on a bad id;
      another store's warehouse is not reprioritisable
- [x] **Ran for real**: `TEST_DATABASE_URL=postgres://dev:dev@192.168.1.110:5432/marketplace_db`,
      `-tags=integration -count=1 -p 1` → **29 PASS, 0 SKIP, ~1.6s**. (A skip
      prints `ok` and reads exactly like a pass, so the counts are stated.)
- [x] Mutation-tested: removing the unshipped-parcel refusal fails
      `TestDelete_RefusesWithAnUnshippedParcel`; leaving `is_default` set on
      archive fails `TestArchive_ExcludesFromListAndClearsDefault`
- [x] `go vet -tags=integration ./...` clean, `gofmt` clean
- [x] `go test -count=1 ./...` — 94/94 packages
- [x] `ExpectedSchemaVersion` bumped 121 → 122

## Down migration is not a blind mirror

It restores the total unique index, which **fails loudly** if a name has been
reused after archiving — the very case the partial index exists to allow.
Silently dropping or renaming a merchant's warehouse to force the old index
through would lose the record of which warehouse shipped an order. Resolve the
duplicate deliberately, then roll back.

## Next

5b (admin API), 5c (settings page), 5d (carrier form picker — which deletes
`warehouse-validation.ts` from #508 and updates `shipping-readiness.ts` from
#511), 5e (per-location stock).