### PR TITLE
fix(payments): read Stripe's key from api_key when provisioning the webhook

### DIFF
--- a/services/marketplace-api/internal/handlers/admin/provisioning_secret_test.go
+++ b/services/marketplace-api/internal/handlers/admin/provisioning_secret_test.go
@@ -1,0 +1,66 @@
+package admin
+
+import "testing"
+
+// Regression for a bug shipped in #518: webhook provisioning read
+// req.SecretKey, but Stripe's sk_… arrives in req.APIKey — the admin form
+// hides the Secret key field for Stripe entirely. The result was that
+// provisioning never ran for the only provider it supports, silently.
+func TestProvisioningSecretFor(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		req      paymentUpsertRequest
+		want     string
+	}{
+		{
+			name:     "stripe reads the API key field, where sk_ actually is",
+			provider: "stripe",
+			req:      paymentUpsertRequest{APIKey: "sk_test_abc", SecretKey: ""},
+			want:     "sk_test_abc",
+		},
+		{
+			name:     "stripe ignores secret_key even when populated",
+			provider: "stripe",
+			req:      paymentUpsertRequest{APIKey: "sk_test_abc", SecretKey: "ignored"},
+			want:     "sk_test_abc",
+		},
+		{
+			name:     "case of the provider name does not matter",
+			provider: "Stripe",
+			req:      paymentUpsertRequest{APIKey: "sk_test_abc"},
+			want:     "sk_test_abc",
+		},
+		{
+			name:     "whitespace-only key counts as absent",
+			provider: "stripe",
+			req:      paymentUpsertRequest{APIKey: "   "},
+			want:     "",
+		},
+		{
+			name:     "an unchanged save carries no key, so nothing is provisioned",
+			provider: "stripe",
+			req:      paymentUpsertRequest{APIKey: ""},
+			want:     "",
+		},
+		{
+			name:     "other providers do not provision webhooks",
+			provider: "razorpay",
+			req:      paymentUpsertRequest{APIKey: "rzp_test_abc", SecretKey: "shh"},
+			want:     "",
+		},
+		{
+			name:     "paypal does not provision webhooks",
+			provider: "paypal",
+			req:      paymentUpsertRequest{APIKey: "client-id", SecretKey: "client-secret"},
+			want:     "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := provisioningSecretFor(tc.provider, tc.req); got != tc.want {
+				t.Errorf("provisioningSecretFor(%q) = %q, want %q", tc.provider, got, tc.want)
+			}
+		})
+	}
+}

--- a/services/marketplace-api/internal/handlers/admin/settings.go
+++ b/services/marketplace-api/internal/handlers/admin/settings.go
@@ -459,6 +459,26 @@ func (h *PaymentSettingsHandler) Upsert(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
+// provisioningSecretFor returns the plaintext key that can call Stripe's
+// management API, or "" when the request did not carry one.
+//
+// The subtlety this exists to pin: **Stripe's sk_… lives in api_key, not
+// secret_key.** Stripe has only one non-webhook secret, so
+// PaymentConfigForm relabels the API key field "Secret API key" and hides
+// the Secret key field entirely (see its comment). Reading req.SecretKey
+// for Stripe therefore always yields "" — webhook provisioning would
+// silently never run for the one provider it is written for, and nothing
+// would look broken.
+//
+// Other providers genuinely have a separate Key + Secret, but none of them
+// provisions webhooks today, so they return "" rather than guessing.
+func provisioningSecretFor(provider string, req paymentUpsertRequest) string {
+	if strings.ToLower(provider) != "stripe" {
+		return ""
+	}
+	return strings.TrimSpace(req.APIKey)
+}
+
 // provisionStripeWebhook registers (or confirms) the store's Stripe webhook
 // endpoint and persists the signing secret Stripe returns.
 //
@@ -472,10 +492,17 @@ func (h *PaymentSettingsHandler) provisionStripeWebhook(
 	if provider != "stripe" || h.webhookProvisioner == nil || h.publicAPIBase == "" {
 		return ""
 	}
-	// The plaintext secret key is only in hand when the caller just sent
-	// it; we deliberately do not read it back out of the secret store to
+	// Stripe's sk_… lives in api_key, NOT secret_key: Stripe has only one
+	// non-webhook secret, so PaymentConfigForm relabels the API key field
+	// "Secret API key" and hides the Secret key field entirely. Keying off
+	// req.SecretKey meant this never ran for the one provider it exists
+	// for.
+	//
+	// The plaintext key is only in hand when the caller just sent it; we
+	// deliberately do not read it back out of the secret store to
 	// re-provision on an unrelated save.
-	if req.SecretKey == "" {
+	stripeSecret := provisioningSecretFor(provider, req)
+	if stripeSecret == "" {
 		return ""
 	}
 
@@ -486,7 +513,7 @@ func (h *PaymentSettingsHandler) provisionStripeWebhook(
 	haveSecret := cfg.WebhookSecretEncrypted != "" ||
 		(req.WebhookSecret != nil && *req.WebhookSecret != "")
 
-	res, err := h.webhookProvisioner.Ensure(ctx, req.SecretKey, endpoint, haveSecret, nil)
+	res, err := h.webhookProvisioner.Ensure(ctx, stripeSecret, endpoint, haveSecret, nil)
 	if err != nil {
 		h.logger.Warn("payment: stripe webhook provisioning failed",
 			"store", storeSlug, "endpoint", endpoint, "err", err)


### PR DESCRIPTION
Fixes a bug I shipped in #518. As merged, **webhook auto-provisioning never
runs.**

## The bug

`provisionStripeWebhook` gated on `req.SecretKey`:

```go
if req.SecretKey == "" {
    return ""
}
```

But **Stripe's `sk_…` arrives in `api_key`, not `secret_key`.** Stripe has only
one non-webhook secret, so `PaymentConfigForm` relabels the API key field
"Secret API key" and **hides the Secret key field entirely** for Stripe — its
comment says exactly that:

> Stripe has only ONE non-webhook secret (the "Secret key", sk_…) […] So we
> relabel the API key field as "Secret API key" and hide the redundant Secret
> key field.

So `req.SecretKey` is always empty for Stripe, the guard always returned early,
and provisioning silently never ran for the one provider it was written for.

Worse than an error: the save succeeds, no `webhook_status` appears, nothing
logs. It looks exactly like a store that simply has not been saved yet.

Caught before testing it against bondi — otherwise the symptom would have been
"I re-saved the key and nothing happened", which is the same shape as the
original webhook problem.

## Fix

`provisioningSecretFor(provider, req)` — a pure function that returns the key
able to call Stripe's management API. Stripe reads `api_key`; other providers
return "" rather than guessing, since none provisions webhooks today.

Extracted rather than inlined precisely so it can be tested: the original bug
lived in a function that needs a gin context and a database, which is why it
shipped untested.

## Test plan

- [x] 7 table cases: stripe reads api_key; ignores secret_key even when
      populated; provider name case-insensitive; whitespace-only counts as
      absent; an unchanged save provisions nothing; razorpay and paypal return ""
- [x] **Mutation-tested by reintroducing the exact original bug** — switching
      back to `req.SecretKey` fails 4 of the 7 subtests
- [x] `go vet -tags=integration ./...` clean, `gofmt` clean
- [x] `go test -count=1 ./...` — 94/94 packages

## Note

#518 is already deployed (`main-bb85106`), so provisioning is live but inert
until this lands. No store has been affected: the column it writes was already
empty everywhere.