### PR TITLE
feat(admin): warn when a gateway can take payments it will not record

### DIFF
--- a/apps/admin/components/settings/PaymentSettingsClient.tsx
+++ b/apps/admin/components/settings/PaymentSettingsClient.tsx
@@ -17,6 +17,7 @@ import type {
 } from "@/lib/api/settings-api";
 import { ProviderCard } from "./ProviderCard";
 import { PaymentConfigForm } from "./PaymentConfigForm";
+import { paymentReadinessFor } from "@/lib/settings/payments-readiness";
 import { TaxJarConfigForm } from "./TaxJarConfigForm";
 import {
   removePaymentConfig,
@@ -55,6 +56,10 @@ export function PaymentSettingsClient({
           supported.payment_providers.map((provider) => {
             const cfg = configByProvider.get(provider);
             const configured = Boolean(cfg);
+            // Everything between this gateway and a recorded payment. Only
+            // shown once credentials exist — "no gateway" is already plain
+            // from the card's own Add-credentials state.
+            const blockers = configured ? paymentReadinessFor(cfg) : [];
 
             return (
               <ProviderCard
@@ -88,6 +93,27 @@ export function PaymentSettingsClient({
                     : undefined
                 }
               >
+                {blockers.length > 0 && (
+                  <div
+                    role="status"
+                    className="mb-5 space-y-2 rounded-md border border-[color:var(--signal,#B7410E)]/25 bg-[color:var(--signal,#B7410E)]/[0.04] px-4 py-3"
+                  >
+                    <p className="text-sm font-medium text-foreground">
+                      {blockers.some((b) => b.severity === "silently_loses_orders")
+                        ? "This gateway can take payments it will not record"
+                        : "This gateway isn’t taking payments yet"}
+                    </p>
+                    <ul className="space-y-1 text-sm text-foreground-secondary">
+                      {blockers.map((b) => (
+                        <li key={b.code} className="flex gap-2">
+                          <span aria-hidden="true">&middot;</span>
+                          <span>{b.message}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
                 {editable ? (
                   <PaymentConfigForm
                     provider={provider}

--- a/apps/admin/lib/settings/payments-readiness.test.ts
+++ b/apps/admin/lib/settings/payments-readiness.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { paymentReadinessFor } from "./payments-readiness";
+import type { PaymentConfig } from "@/lib/api/settings-api";
+
+const healthy = {
+  provider: "stripe",
+  is_active: true,
+  mode: "test",
+  webhook_secret: "whse****",
+} as unknown as PaymentConfig;
+
+const codes = (cfg: PaymentConfig | undefined) =>
+  paymentReadinessFor(cfg).map((b) => b.code);
+
+describe("paymentReadinessFor", () => {
+  it("reports nothing when the gateway can take and record a payment", () => {
+    expect(paymentReadinessFor(healthy)).toEqual([]);
+  });
+
+  it("reports a missing gateway", () => {
+    expect(codes(undefined)).toEqual(["no_gateway"]);
+  });
+
+  it("reports an inactive gateway", () => {
+    expect(codes({ ...healthy, is_active: false })).toEqual(["inactive"]);
+  });
+
+  // The exact production state: Stripe Active, payment taken, order stuck
+  // Pending for over a month because no webhook was ever registered.
+  it("reports a missing webhook secret", () => {
+    expect(codes({ ...healthy, webhook_secret: "" })).toEqual([
+      "no_webhook_secret",
+    ]);
+  });
+
+  it("treats a whitespace-only webhook secret as missing", () => {
+    expect(codes({ ...healthy, webhook_secret: "   " })).toEqual([
+      "no_webhook_secret",
+    ]);
+  });
+
+  it("reports every blocker at once rather than one at a time", () => {
+    expect(codes({ ...healthy, is_active: false, webhook_secret: "" })).toEqual([
+      "inactive",
+      "no_webhook_secret",
+    ]);
+  });
+
+  // The distinction worth drawing: one stops a sale, the other takes the
+  // money and loses the record of it.
+  it("marks the webhook gap as silently losing orders", () => {
+    const [b] = paymentReadinessFor({ ...healthy, webhook_secret: "" });
+    expect(b?.severity).toBe("silently_loses_orders");
+  });
+
+  it("marks an inactive gateway as blocking checkout", () => {
+    const [b] = paymentReadinessFor({ ...healthy, is_active: false });
+    expect(b?.severity).toBe("blocks_checkout");
+  });
+});

--- a/apps/admin/lib/settings/payments-readiness.ts
+++ b/apps/admin/lib/settings/payments-readiness.ts
@@ -1,0 +1,69 @@
+import type { PaymentConfig } from "@/lib/api/settings-api";
+
+/**
+ * Why a store cannot actually take money, or cannot record that it did.
+ *
+ * The payments page shows a provider as `Active` on the strength of an API
+ * key alone. That is not the same as working, and the gap is expensive:
+ *
+ *   • **No webhook signing secret** is the quiet one. Stripe accepts the
+ *     payment, the shopper is charged, and the order sits `Pending`
+ *     forever because nothing tells us the payment succeeded. Worse, the
+ *     webhook handler answers 200 even when it REJECTS an unverifiable
+ *     event (so Stripe stops retrying garbage) — so Stripe's dashboard
+ *     reports delivery as successful while nothing is processed. Silent at
+ *     both ends. the-bondi-store took a real payment on 2026-09-01 and the
+ *     order never left `Pending`; a July order was stuck the same way.
+ *
+ *   • **Inactive** means the gateway is never offered at checkout, so a
+ *     shopper reaches payment and finds no method.
+ *
+ * Auto-provisioning now registers the webhook on save, so a new config
+ * should never lack a secret. This is what tells a merchant configured
+ * BEFORE that — or one whose provisioning failed — which state they are in.
+ */
+export interface PaymentBlocker {
+  code: "no_gateway" | "inactive" | "no_webhook_secret";
+  message: string;
+  /**
+   * Blockers differ in kind: a shopper can't pay at all, versus the store
+   * takes money it never records. Both matter; only the second is silent.
+   */
+  severity: "blocks_checkout" | "silently_loses_orders";
+}
+
+export function paymentReadinessFor(
+  cfg: PaymentConfig | undefined,
+): PaymentBlocker[] {
+  if (!cfg) {
+    return [
+      {
+        code: "no_gateway",
+        message: "No credentials yet — customers cannot pay until this is configured.",
+        severity: "blocks_checkout",
+      },
+    ];
+  }
+
+  const blockers: PaymentBlocker[] = [];
+
+  if (!cfg.is_active) {
+    blockers.push({
+      code: "inactive",
+      message:
+        "This gateway is inactive, so it is never offered at checkout. Tick “Active” to enable it.",
+      severity: "blocks_checkout",
+    });
+  }
+
+  if (!cfg.webhook_secret?.trim()) {
+    blockers.push({
+      code: "no_webhook_secret",
+      message:
+        "No webhook signing secret. Payments will succeed but orders will stay unpaid, because nothing tells your store the payment went through. Re-save your API key to register the webhook automatically.",
+      severity: "silently_loses_orders",
+    });
+  }
+
+  return blockers;
+}


### PR DESCRIPTION
The payments analogue of #511. Closes the gap that hid a month-long outage.

## The failure it surfaces

The payments page shows a provider as **Active** on the strength of an API key
alone. That is not the same as working.

Without a webhook signing secret, Stripe accepts the payment, the shopper is
charged, and the order sits `Pending` **forever** — nothing tells the store the
payment succeeded. And it is silent at both ends: the webhook handler answers
`200` even when it *rejects* an unverifiable event (deliberate, so Stripe stops
retrying garbage), so Stripe's dashboard reports delivery as **successful**
while nothing is processed.

the-bondi-store took a real payment on 2026-09-01 and the order never left
`Pending`. A July order was stuck identically — over a month, with no signal
anywhere. Nothing in admin said a word.

## What it shows

Per configured gateway, everything standing between it and a **recorded**
payment:

| blocker | severity |
|---|---|
| gateway inactive — never offered at checkout | `blocks_checkout` |
| no webhook signing secret | `silently_loses_orders` |

The severity distinction drives the heading, and it is the point: one stops a
sale, the other **takes the money and loses the record of it**. A merchant
reading "isn't taking payments yet" would under-react to the second.

Reports all blockers at once rather than one at a time, so fixing one does not
reveal the next.

## Relationship to #518/#521

Auto-provisioning now registers the webhook on save, so a *new* config should
never lack a secret. This is what tells a merchant configured **before** that —
or whose provisioning failed — which state they are in. The two are
complementary: one prevents, one reveals.

## Test plan

- [x] 8 cases: healthy, missing gateway, inactive, missing secret,
      whitespace-only secret, all-at-once, and both severity classifications
- [x] Mutation-tested: neutering the webhook check fails 4 of the 8
- [x] `npx vitest run lib/settings` 28/28
- [x] `tsc --noEmit` clean for touched files
- [x] Caught during development that `PaymentConfig` uses `is_active`, not
      `enabled` (that is the shipping type) — the wrong field would have made
      the inactive blocker fire always or never