### PR TITLE
fix(admin): removing a payment or shipping config was silently failing with 401

### DIFF
--- a/apps/admin/components/settings/PaymentSettingsClient.tsx
+++ b/apps/admin/components/settings/PaymentSettingsClient.tsx
@@ -73,8 +73,14 @@ export function PaymentSettingsClient({
                   configured
                     ? async () => {
                         if (!editable) return;
-                        await removePaymentConfig(provider);
+                        // Surface the failure rather than refreshing over it:
+                        // this DELETE was 401 for months and looked like a no-op.
+                        const result = await removePaymentConfig(provider);
+                        if (!result.ok) {
+                          return { ok: false, message: result.message };
+                        }
                         router.refresh();
+                        return { ok: true };
                       }
                     : undefined
                 }

--- a/apps/admin/components/settings/ProviderCard.tsx
+++ b/apps/admin/components/settings/ProviderCard.tsx
@@ -24,7 +24,13 @@ interface ProviderCardProps {
   configured?: boolean;
   onConfigure?: () => Promise<void> | void;
   /** When absent, the Remove button is hidden (nothing to remove). */
-  onRemove?: () => Promise<void> | void;
+  /**
+   * Returns the outcome so a failure can be shown. It used to return void,
+   * which meant a rejected remove (both DELETEs were 401 for months) looked
+   * exactly like a successful one: the card re-rendered unchanged and said
+   * nothing. `void` is still accepted for callers with nothing to report.
+   */
+  onRemove?: () => Promise<{ ok: boolean; message?: string } | void> | void;
   onTest?: () => Promise<{ success: boolean; error?: string }>;
   /** The inline configuration form rendered when expanded. */
   children?: ReactNode;
@@ -47,6 +53,7 @@ export function ProviderCard({
 }: ProviderCardProps) {
   const [expanded, setExpanded] = useState(false);
   const [confirmRemove, setConfirmRemove] = useState(false);
+  const [removeError, setRemoveError] = useState<string | null>(null);
   const [removing, startRemoveTransition] = useTransition();
   const [testing, startTestTransition] = useTransition();
   const [testResult, setTestResult] = useState<{
@@ -70,8 +77,15 @@ export function ProviderCard({
       requestAnimationFrame(() => confirmBtnRef.current?.focus());
       return;
     }
+    setRemoveError(null);
     startRemoveTransition(async () => {
-      await onRemove();
+      const result = await onRemove();
+      // A falsy `ok` is a real failure; `void` means the caller has nothing
+      // to report and the refresh below tells the story.
+      if (result && !result.ok) {
+        setRemoveError(result.message ?? "Could not remove this configuration.");
+        return;
+      }
       setConfirmRemove(false);
     });
   }
@@ -160,6 +174,17 @@ export function ProviderCard({
 
       {/* Test connection feedback */}
       <div aria-live="polite" aria-atomic="true">
+        {removeError && (
+          <div className="pb-4">
+            <div
+              role="alert"
+              className="rounded-md border border-[color:var(--danger,#7B2D26)]/25 bg-[color:var(--danger,#7B2D26)]/[0.06] px-4 py-2.5 text-sm text-[color:var(--danger,#7B2D26)]"
+            >
+              {removeError}
+            </div>
+          </div>
+        )}
+
         {testResult && (
           <div className="pb-4">
             {testResult.success ? (

--- a/apps/admin/components/settings/ShippingSettingsClient.tsx
+++ b/apps/admin/components/settings/ShippingSettingsClient.tsx
@@ -72,8 +72,14 @@ export function ShippingSettingsClient({
               configured
                 ? async () => {
                     if (!editable) return;
-                    await removeShippingConfig(carrier);
+                    // Surface the failure rather than refreshing over it:
+                    // this DELETE was 401 for months and looked like a no-op.
+                    const result = await removeShippingConfig(carrier);
+                    if (!result.ok) {
+                      return { ok: false, message: result.message };
+                    }
                     router.refresh();
+                    return { ok: true };
                   }
                 : undefined
             }

--- a/apps/admin/lib/api/settings-api.ts
+++ b/apps/admin/lib/api/settings-api.ts
@@ -272,10 +272,12 @@ export async function deletePaymentConfig(
     {
       method: "DELETE",
       cache: "no-store",
-      headers: {
-        "X-User-Id": session.userId,
-        "X-Tenant-Id": session.tenantId,
-      },
+      // readHeaders, not a hand-rolled literal: it carries X-Internal-Auth,
+      // which marketplace-api requires. Both DELETEs omitted it and were
+      // rejected 401 every time — removing a payment or shipping config
+      // never worked, and the UI discarded the error so it looked like
+      // nothing happened.
+      headers: readHeaders(session),
     },
   );
   if (res.status === 204 || res.ok) {
@@ -358,10 +360,12 @@ export async function deleteShippingConfig(
     {
       method: "DELETE",
       cache: "no-store",
-      headers: {
-        "X-User-Id": session.userId,
-        "X-Tenant-Id": session.tenantId,
-      },
+      // readHeaders, not a hand-rolled literal: it carries X-Internal-Auth,
+      // which marketplace-api requires. Both DELETEs omitted it and were
+      // rejected 401 every time — removing a payment or shipping config
+      // never worked, and the UI discarded the error so it looked like
+      // nothing happened.
+      headers: readHeaders(session),
     },
   );
   if (res.status === 204 || res.ok) {


### PR DESCRIPTION
**Removing a payment or shipping config has never worked.** Both DELETEs were
rejected 401 and the UI discarded the error, so it looked like nothing happened.

## How it was found

Trying to remove bondi's Stripe config to re-add it. Clicking Remove →
Confirm remove left the card unchanged. Production logs:

```
DELETE /api/v1/admin/stores/…/settings/payments/stripe   status 401  dur 177µs
```

Reaching the backend, rejected in middleware, and the browser saw `200` from
the server action because the failure was thrown away.

## Cause 1 — the DELETE omits X-Internal-Auth

`commonHeaders()` / `readHeaders()` attach `X-Internal-Auth`, the shared secret
marketplace-api requires. Both DELETE helpers hand-rolled their headers
instead:

```ts
headers: {
  "X-User-Id": session.userId,
  "X-Tenant-Id": session.tenantId,
},            // ← no X-Internal-Auth
```

Every other call in the file uses the helpers, which is why saving works and
removing does not. Now both use `readHeaders(session)`.

This affects **payments and shipping** — the same copy-paste in both.

## Cause 2 — the UI threw the error away

```tsx
await removePaymentConfig(provider);   // result discarded
router.refresh();
```

The action correctly returned `{ok: false, code, message}`. The caller ignored
it and refreshed over the top. `ProviderCard.onRemove` was typed
`() => Promise<void>`, so the card had nothing to render even if it wanted to —
the *contract* discarded it, not just the caller.

Compare `onTest`, which returns `{success, error}` and renders the outcome. The
remove path simply never got the same treatment.

Now `onRemove` returns `{ok, message?}` and the card renders a failure the way
it renders a failed connection test. `void` is still accepted for callers with
nothing to report.

## Why this matters beyond the bug

A 401 that renders as "nothing happened" is unfalsifiable from the UI. Two of
us stared at it and concluded the click had not registered. The error existed,
was correctly constructed, and was deliberately dropped one layer from where a
person would have seen it.

## Test plan

- [x] `tsc --noEmit` clean for touched files
- [x] `npx vitest run lib` — 126 passed (`markdown.test.tsx` and
      `useProductSelection.test.ts` fail to resolve `react` in a fresh worktree
      with no install; both pass in a normal checkout, unrelated)
- [x] Verified both `method: "DELETE"` blocks now use `readHeaders(session)`
- [ ] **Not verified end to end**: needs deploy, then an actual remove. The 401
      is a server response I can only observe in production logs.