### PR TITLE
fix(admin): readiness warnings were hidden inside collapsed provider cards

### DIFF
--- a/apps/admin/components/settings/PaymentSettingsClient.tsx
+++ b/apps/admin/components/settings/PaymentSettingsClient.tsx
@@ -98,28 +98,31 @@ export function PaymentSettingsClient({
                       }
                     : undefined
                 }
+                banner={
+                  blockers.length > 0 ? (
+                    <div
+                      role="status"
+                      className="mb-5 space-y-2 rounded-md border border-[color:var(--signal,#B7410E)]/25 bg-[color:var(--signal,#B7410E)]/[0.04] px-4 py-3"
+                    >
+                      <p className="text-sm font-medium text-foreground">
+                        {blockers.some(
+                          (b) => b.severity === "silently_loses_orders",
+                        )
+                          ? "This gateway can take payments it will not record"
+                          : "This gateway isn’t taking payments yet"}
+                      </p>
+                      <ul className="space-y-1 text-sm text-foreground-secondary">
+                        {blockers.map((b) => (
+                          <li key={b.code} className="flex gap-2">
+                            <span aria-hidden="true">&middot;</span>
+                            <span>{b.message}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null
+                }
               >
-                {blockers.length > 0 && (
-                  <div
-                    role="status"
-                    className="mb-5 space-y-2 rounded-md border border-[color:var(--signal,#B7410E)]/25 bg-[color:var(--signal,#B7410E)]/[0.04] px-4 py-3"
-                  >
-                    <p className="text-sm font-medium text-foreground">
-                      {blockers.some((b) => b.severity === "silently_loses_orders")
-                        ? "This gateway can take payments it will not record"
-                        : "This gateway isn’t taking payments yet"}
-                    </p>
-                    <ul className="space-y-1 text-sm text-foreground-secondary">
-                      {blockers.map((b) => (
-                        <li key={b.code} className="flex gap-2">
-                          <span aria-hidden="true">&middot;</span>
-                          <span>{b.message}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-
                 {editable ? (
                   <PaymentConfigForm
                     provider={provider}

--- a/apps/admin/components/settings/ProviderCard.tsx
+++ b/apps/admin/components/settings/ProviderCard.tsx
@@ -34,6 +34,16 @@ interface ProviderCardProps {
   onTest?: () => Promise<{ success: boolean; error?: string }>;
   /** The inline configuration form rendered when expanded. */
   children?: ReactNode;
+  /**
+   * Always-visible slot, rendered whether or not the card is expanded.
+   *
+   * For anything the merchant must see WITHOUT opening the card — chiefly
+   * readiness warnings. Passing those as `children` hides them behind the
+   * expand toggle, which is exactly how both the shipping (#511) and
+   * payments (#522) panels shipped invisible: the card renders children
+   * only under `{expanded && …}`, so a collapsed card showed nothing.
+   */
+  banner?: ReactNode;
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -50,6 +60,7 @@ export function ProviderCard({
   onRemove,
   onTest,
   children,
+  banner,
 }: ProviderCardProps) {
   const [expanded, setExpanded] = useState(false);
   const [confirmRemove, setConfirmRemove] = useState(false);
@@ -83,7 +94,9 @@ export function ProviderCard({
       // A falsy `ok` is a real failure; `void` means the caller has nothing
       // to report and the refresh below tells the story.
       if (result && !result.ok) {
-        setRemoveError(result.message ?? "Could not remove this configuration.");
+        setRemoveError(
+          result.message ?? "Could not remove this configuration.",
+        );
         return;
       }
       setConfirmRemove(false);
@@ -199,12 +212,15 @@ export function ProviderCard({
                 role="alert"
                 className="rounded-md border border-[color:var(--danger)]/20 bg-[color:var(--danger)]/[0.05] px-4 py-2.5 text-sm text-[color:var(--danger)]"
               >
-                Connection failed{testResult.error ? `: ${testResult.error}` : "."}
+                Connection failed
+                {testResult.error ? `: ${testResult.error}` : "."}
               </div>
             )}
           </div>
         )}
       </div>
+
+      {banner && <div className="pb-4">{banner}</div>}
 
       {/* Confirm remove warning */}
       {confirmRemove && !removing && (
@@ -213,9 +229,9 @@ export function ProviderCard({
             role="alert"
             className="rounded-md border border-[color:var(--warning)]/30 bg-[color:var(--warning)]/[0.05] px-4 py-2.5 text-sm text-[color:var(--warning)]"
           >
-            Remove {formatProviderName(providerName)}? You&rsquo;ll need to add it
-            again to re-enable. Click &quot;Confirm remove&quot; to proceed, or
-            close to cancel.
+            Remove {formatProviderName(providerName)}? You&rsquo;ll need to add
+            it again to re-enable. Click &quot;Confirm remove&quot; to proceed,
+            or close to cancel.
           </div>
         </div>
       )}
@@ -303,5 +319,8 @@ function formatProviderName(provider: string): string {
     // Tax
     taxjar: "TaxJar",
   };
-  return names[provider.toLowerCase()] ?? provider.charAt(0).toUpperCase() + provider.slice(1);
+  return (
+    names[provider.toLowerCase()] ??
+    provider.charAt(0).toUpperCase() + provider.slice(1)
+  );
 }

--- a/apps/admin/components/settings/ShippingSettingsClient.tsx
+++ b/apps/admin/components/settings/ShippingSettingsClient.tsx
@@ -83,26 +83,27 @@ export function ShippingSettingsClient({
                   }
                 : undefined
             }
+            banner={
+              blockers.length > 0 ? (
+                <div
+                  role="status"
+                  className="mb-5 space-y-2 rounded-md border border-[color:var(--signal,#B7410E)]/25 bg-[color:var(--signal,#B7410E)]/[0.04] px-4 py-3"
+                >
+                  <p className="text-sm font-medium text-foreground">
+                    This carrier isn&rsquo;t quoting rates yet
+                  </p>
+                  <ul className="space-y-1 text-sm text-foreground-secondary">
+                    {blockers.map((b) => (
+                      <li key={b.code} className="flex gap-2">
+                        <span aria-hidden="true">&middot;</span>
+                        <span>{b.message}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null
+            }
           >
-            {blockers.length > 0 && (
-              <div
-                role="status"
-                className="mb-5 space-y-2 rounded-md border border-[color:var(--signal,#B7410E)]/25 bg-[color:var(--signal,#B7410E)]/[0.04] px-4 py-3"
-              >
-                <p className="text-sm font-medium text-foreground">
-                  This carrier isn&rsquo;t quoting rates yet
-                </p>
-                <ul className="space-y-1 text-sm text-foreground-secondary">
-                  {blockers.map((b) => (
-                    <li key={b.code} className="flex gap-2">
-                      <span aria-hidden="true">&middot;</span>
-                      <span>{b.message}</span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-
             {editable ? (
               <ShippingConfigForm
                 provider={carrier}


### PR DESCRIPTION
Both readiness panels — shipping (#511) and payments (#522) — shipped
**invisible**. Neither has ever been seen by a merchant.

## The bug

Both were passed to `ProviderCard` as `children`. `ProviderCard` renders
children only when the card is expanded:

```tsx
{expanded && (
  …
  {children}
)}
```

Cards start collapsed. So a warning whose entire purpose is *"you would not
otherwise know this"* was placed behind a toggle the merchant has no reason to
open — they open the card to edit, and the warning exists precisely so they
know they need to.

Caught by looking for the panel on the live payments page after #522 deployed
and finding nothing there. My first two theories were wrong (stale pod, then
a non-empty `webhook_secret`); the render location was the actual cause.

## Fix

New `banner` slot on `ProviderCard`, rendered whether or not the card is
expanded, documented as the place for anything the merchant must see without
opening the card. Both panels move into it.

`children` keeps its meaning — the inline configuration form.

## Why a slot rather than moving the JSX up

The warning belongs to the card visually; hoisting it above would detach it
from the provider it describes when several are listed. A named slot keeps
ownership with the card and makes the always-visible contract explicit, so the
next panel added does not repeat this.

## Test plan

- [x] `tsc --noEmit` clean for touched files
- [x] `npx vitest run lib/settings` 28/28 (the readiness logic itself is
      unchanged and was already covered)
- [x] `prettier --write` on all three files
- [ ] **Visual confirmation still pending deploy** — this is a rendering bug
      that unit tests cannot catch, which is exactly how it shipped twice.

## Note

Worth remembering as a pattern: both panels had thorough logic tests and
mutation-tested guards, and neither was ever rendered. The tests proved the
*decision* was right and said nothing about whether anyone could see it.