### PR TITLE
fix(webhooks): stop logging a duplicate Stripe delivery as an error

### DIFF
--- a/services/marketplace-api/internal/handlers/storefront/noop_transition_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/noop_transition_test.go
@@ -1,0 +1,74 @@
+package storefront
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+)
+
+// Stripe sends BOTH checkout.session.completed and payment_intent.succeeded
+// for one payment. The second arrives after the first confirmed the order,
+// so Confirm refuses it with invalid_transition "confirmed" → "confirmed".
+// That is a duplicate delivery, not a failure — and logging it at ERROR put
+// a scary line in the logs for every successful payment, which is exactly
+// how a real confirm failure gets missed.
+func TestIsNoOpTransition(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "same state is a duplicate delivery",
+			err:  apperrors.InvalidTransition("order", "confirmed", "confirmed"),
+			want: true,
+		},
+		{
+			name: "payment axis, same state",
+			err:  apperrors.InvalidTransition("payment", "paid", "paid"),
+			want: true,
+		},
+		// The case that must NEVER be swallowed: a genuinely wrong move.
+		{
+			name: "cancelled to confirmed is a real failure",
+			err:  apperrors.InvalidTransition("order", "cancelled", "confirmed"),
+			want: false,
+		},
+		{
+			name: "pending to confirmed is a real failure",
+			err:  apperrors.InvalidTransition("order", "pending", "confirmed"),
+			want: false,
+		},
+		{
+			name: "a different app error is not a no-op",
+			err:  apperrors.NotFound("order"),
+			want: false,
+		},
+		{
+			name: "a plain error is not a no-op",
+			err:  errors.New("db down"),
+			want: false,
+		},
+		{
+			name: "nil is not a no-op",
+			err:  nil,
+			want: false,
+		},
+		// Must survive wrapping: the webhook receives whatever the service
+		// layer wrapped it in.
+		{
+			name: "wrapped same-state transition is still a duplicate",
+			err:  fmt.Errorf("confirm: %w", apperrors.InvalidTransition("order", "confirmed", "confirmed")),
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNoOpTransition(tc.err); got != tc.want {
+				t.Errorf("isNoOpTransition(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/services/marketplace-api/internal/handlers/storefront/webhooks.go
+++ b/services/marketplace-api/internal/handlers/storefront/webhooks.go
@@ -41,6 +41,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/orderdoc"
 	"github.com/mark8ly/marketplace-api/internal/payment"
 	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 )
 
 // webhookGatewayConfigRow is a read-only projection of payment_gateway_configs
@@ -626,10 +627,26 @@ func (h *WebhookHandler) handlePaymentSucceeded(ctx context.Context, provider st
 		}
 		paidStatus := order.PaymentStatusPaid
 		if err := h.orderSvc.Confirm(ctx, nil, orderID, &paidStatus, "payment webhook: "+provider); err != nil {
-			h.logError("webhook: order confirm failed",
-				"order_id", evt.OrderID,
-				"err", err)
-			return
+			// Webhooks are at-least-once by contract, and Stripe sends BOTH
+			// checkout.session.completed and payment_intent.succeeded for a
+			// single payment. The second arrives after the first already
+			// confirmed the order, so Confirm refuses it with
+			// invalid_transition "confirmed" → "confirmed".
+			//
+			// That is a duplicate delivery, not a failure: the order is
+			// already in exactly the state we wanted. Logging it at ERROR
+			// put a scary line in the logs for EVERY successful payment,
+			// which is how a real confirm failure would get missed.
+			if isNoOpTransition(err) {
+				h.logInfo("webhook: order already in target state, ignoring duplicate delivery",
+					"order_id", evt.OrderID,
+					"provider", provider)
+			} else {
+				h.logError("webhook: order confirm failed",
+					"order_id", evt.OrderID,
+					"err", err)
+				return
+			}
 		}
 
 		// Order placed + paid → the buyer's invoice email goes out now.
@@ -791,6 +808,30 @@ func extractWebhookSignature(c *gin.Context, provider string) string {
 	default:
 		return c.GetHeader("X-Webhook-Signature")
 	}
+}
+
+// logInfo emits a structured info log entry. Silently no-ops when logger is nil.
+func (h *WebhookHandler) logInfo(msg string, args ...any) {
+	if h.logger != nil {
+		h.logger.Info(msg, args...)
+	}
+}
+
+// isNoOpTransition reports whether err is an invalid_transition that was
+// refused because the entity is ALREADY in the requested state.
+//
+// Distinguished from a genuinely wrong transition (say cancelled →
+// confirmed) by comparing the structured from/to details rather than
+// matching the message, so a reworded error cannot silently turn a real
+// failure into an ignored one.
+func isNoOpTransition(err error) bool {
+	var appErr *apperrors.Error
+	if !errors.As(err, &appErr) || appErr.Code != apperrors.CodeInvalidTransition {
+		return false
+	}
+	from, okFrom := appErr.Details["from"].(string)
+	to, okTo := appErr.Details["to"].(string)
+	return okFrom && okTo && from == to
 }
 
 // logError emits a structured error log entry. Silently no-ops when logger is nil.


### PR DESCRIPTION
Every successful payment logs an ERROR. Found while verifying the first
end-to-end paid order on the-bondi-store (`M-THE-260901-00101`).

## What happens

```
ERROR webhook: order confirm failed
  order_id=8387cc68-…
  err=invalid_transition: order cannot transition from "confirmed" to "confirmed"
```

Stripe sends **both** `checkout.session.completed` and
`payment_intent.succeeded` for a single payment — that is the documented
contract, not a fault. The first confirms the order; the second arrives to find
it already confirmed and `Confirm` correctly refuses.

So the order is in exactly the state we wanted, and we log an ERROR saying it
failed.

## Why it matters

The payment succeeded, so nothing is broken — which is the problem. Every paid
order now emits a red herring, and a **genuine** confirm failure looks
identical to routine noise. That is how the important one gets missed.

## Fix

`isNoOpTransition(err)` — the webhook treats an `invalid_transition` whose
`from` equals its `to` as a duplicate delivery and logs it at INFO. Anything
else still logs ERROR and returns.

Detection uses the error's structured `Details["from"]`/`["to"]`, **not** its
message, so rewording the error cannot silently turn a real failure into an
ignored one. `errors.As` means it survives wrapping.

`order.Service.Confirm` is deliberately unchanged — its guard is correct, and
loosening it would affect every caller. At-least-once tolerance belongs at the
webhook, which is the only caller with that contract.

## Test plan

- [x] 8 cases: same-state (order and payment axes), wrapped same-state, the two
      genuinely-wrong transitions that must **never** be swallowed
      (`cancelled → confirmed`, `pending → confirmed`), a different app error,
      a plain error, and nil
- [x] Mutation-tested: flipping `from == to` to `!=` fails 5 of 8, including
      both real-failure cases
- [x] `go vet -tags=integration ./...` clean, `gofmt` clean
- [x] `go test -count=1 ./...` — 94/94 packages

Worth noting: my first two mutation attempts left `from`/`to` unused and failed
to **compile**, so the suite reported no failures and looked like the guard was
untested. A mutation that does not build proves nothing — the third attempt
(`==` → `!=`) is the one that actually exercises it.