### PR TITLE
fix(admin): confirm provider removal in a dialog instead of relabelling the button

### DIFF
--- a/apps/admin/components/settings/ProviderCard.RemoveConfirm.test.tsx
+++ b/apps/admin/components/settings/ProviderCard.RemoveConfirm.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ProviderCard } from "./ProviderCard";
+
+// The remove flow used to confirm by RELABELLING the button in place
+// ("Remove" → "Confirm remove"). A single click then looked like nothing had
+// happened, which cost a real round trip. These tests pin the modal contract:
+// the first click must not remove anything, and it must say out loud what is
+// about to be removed.
+
+function renderCard(onRemove = vi.fn()) {
+  render(
+    <ProviderCard
+      providerName="stripe"
+      isActive
+      maskedKey="sk_test_••••1234"
+      mode="test"
+      onRemove={onRemove}
+    />,
+  );
+  return onRemove;
+}
+
+describe("ProviderCard — remove confirmation", () => {
+  it("first click opens a confirmation naming the provider, and removes nothing", async () => {
+    const user = userEvent.setup();
+    const onRemove = renderCard();
+
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(screen.getByText("Remove Stripe?")).toBeInTheDocument();
+    expect(onRemove).not.toHaveBeenCalled();
+  });
+
+  it("confirming in the dialog calls onRemove", async () => {
+    const user = userEvent.setup();
+    const onRemove = renderCard(vi.fn().mockResolvedValue({ ok: true }));
+
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+    // The dialog's own confirm button — distinct from the card's trigger,
+    // which is why the dialog heading is asserted above first.
+    const buttons = screen.getAllByRole("button", { name: "Remove" });
+    await user.click(buttons[buttons.length - 1]);
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancelling closes the dialog without removing", async () => {
+    const user = userEvent.setup();
+    const onRemove = renderCard();
+
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByText("Remove Stripe?")).not.toBeInTheDocument();
+    expect(onRemove).not.toHaveBeenCalled();
+  });
+
+  it("a failed removal surfaces the reason instead of looking successful", async () => {
+    const user = userEvent.setup();
+    const onRemove = renderCard(
+      vi.fn().mockResolvedValue({ ok: false, message: "Unauthorized." }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+    const buttons = screen.getAllByRole("button", { name: "Remove" });
+    await user.click(buttons[buttons.length - 1]);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unauthorized.");
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/admin/components/settings/ProviderCard.tsx
+++ b/apps/admin/components/settings/ProviderCard.tsx
@@ -5,7 +5,8 @@
 // mode badge, and action buttons. Accepts a children slot for the
 // inline configuration form that expands on "Configure".
 
-import { useRef, useState, useTransition, type ReactNode } from "react";
+import { useState, useTransition, type ReactNode } from "react";
+import { AlertDialog } from "@tesserix/web";
 
 // ─────────────────────────────────────────────────────────────────────────
 // Types
@@ -63,7 +64,7 @@ export function ProviderCard({
   banner,
 }: ProviderCardProps) {
   const [expanded, setExpanded] = useState(false);
-  const [confirmRemove, setConfirmRemove] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [removeError, setRemoveError] = useState<string | null>(null);
   const [removing, startRemoveTransition] = useTransition();
   const [testing, startTestTransition] = useTransition();
@@ -71,23 +72,20 @@ export function ProviderCard({
     success: boolean;
     error?: string;
   } | null>(null);
-  const confirmBtnRef = useRef<HTMLButtonElement>(null);
 
   function handleConfigure() {
     setExpanded((prev) => !prev);
-    setConfirmRemove(false);
+    setConfirmOpen(false);
     setTestResult(null);
     void onConfigure?.();
   }
 
-  function handleRemove() {
+  // Removal is two steps on purpose, but the second step is a modal, not a
+  // relabelled button: a button that quietly renames itself reads as "nothing
+  // happened" and costs the merchant a round trip before they realise the
+  // click registered.
+  function handleRemoveConfirmed() {
     if (!onRemove) return;
-    if (!confirmRemove) {
-      setConfirmRemove(true);
-      // Focus the button after React re-renders with confirmation state
-      requestAnimationFrame(() => confirmBtnRef.current?.focus());
-      return;
-    }
     setRemoveError(null);
     startRemoveTransition(async () => {
       const result = await onRemove();
@@ -97,9 +95,7 @@ export function ProviderCard({
         setRemoveError(
           result.message ?? "Could not remove this configuration.",
         );
-        return;
       }
-      setConfirmRemove(false);
     });
   }
 
@@ -169,17 +165,12 @@ export function ProviderCard({
           </button>
           {onRemove && configured && (
             <button
-              ref={confirmBtnRef}
               type="button"
-              onClick={handleRemove}
+              onClick={() => setConfirmOpen(true)}
               disabled={removing}
               className="rounded-md border border-[color:var(--ink-900)]/10 px-3 py-1.5 text-sm font-medium text-[color:var(--danger)] transition-colors hover:border-[color:var(--danger)]/30 hover:bg-[color:var(--danger)]/[0.04] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-40"
             >
-              {removing
-                ? "Removing..."
-                : confirmRemove
-                  ? "Confirm remove"
-                  : "Remove"}
+              {removing ? "Removing..." : "Remove"}
             </button>
           )}
         </div>
@@ -222,20 +213,6 @@ export function ProviderCard({
 
       {banner && <div className="pb-4">{banner}</div>}
 
-      {/* Confirm remove warning */}
-      {confirmRemove && !removing && (
-        <div className="pb-4">
-          <div
-            role="alert"
-            className="rounded-md border border-[color:var(--warning)]/30 bg-[color:var(--warning)]/[0.05] px-4 py-2.5 text-sm text-[color:var(--warning)]"
-          >
-            Remove {formatProviderName(providerName)}? You&rsquo;ll need to add
-            it again to re-enable. Click &quot;Confirm remove&quot; to proceed,
-            or close to cancel.
-          </div>
-        </div>
-      )}
-
       {/* Expandable form with smooth height transition */}
       <div
         className="grid transition-[grid-template-rows] duration-300 ease-in-out"
@@ -255,6 +232,20 @@ export function ProviderCard({
           )}
         </div>
       </div>
+
+      <AlertDialog
+        isOpen={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        title={`Remove ${formatProviderName(providerName)}?`}
+        message={`This deletes the stored ${formatProviderName(
+          providerName,
+        )} configuration. You will need to add it again to re-enable it.`}
+        type="confirm"
+        confirmLabel="Remove"
+        cancelLabel="Cancel"
+        onConfirm={handleRemoveConfirmed}
+        onCancel={() => setConfirmOpen(false)}
+      />
     </article>
   );
 }


### PR DESCRIPTION
`Remove` on a payment or shipping provider card used to confirm by **relabelling itself in place** — "Remove" became "Confirm remove", with a warning banner further down the card. A single click read as "nothing happened", and it cost a real round trip in the last session before anyone noticed the click had registered.

Now the first click opens a `@tesserix/web` `AlertDialog` naming the provider ("Remove Stripe?"), matching how every other destructive action in settings already confirms (`PagesList`, `HomepageTab`, `HomepageSectionsEditor`, `PageEditor`).

Behaviour kept: a failed removal still surfaces its reason in the `role="alert"` region rather than looking successful — that is #523's fix and it is now pinned by a test.

## Tests

`ProviderCard.RemoveConfirm.test.tsx`, 4 tests: first click removes nothing and names the provider; confirming calls `onRemove` once; cancelling closes without removing; a failed removal surfaces the message.

Mutation-tested: pointing the trigger straight at `handleRemoveConfirmed` compiles clean under `tsc --noEmit` and fails all 4.

`vitest run components/settings` — 8 files, 68 passed.

## Not in scope

`DomainsSettingsClient.tsx:643` has the same in-place "Confirm remove" relabel. Left alone deliberately; worth a follow-up.