### PR TITLE
fix(warehouse): exclude archived warehouses from allocation and the store default

### DIFF
--- a/services/marketplace-api/internal/handlers/storefront/checkout_allocation_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_allocation_integration_test.go
@@ -579,3 +579,38 @@ func TestCommitStock_UppercaseVariantIDStillMatchesAvailability(t *testing.T) {
 
 	require.Equal(t, 3, stockUnitsAt(t, db, variantID, whA))
 }
+
+// #177 PR 5a added archiving; the allocator's candidate query did not learn
+// about it. An archived warehouse still holding stock would keep receiving
+// allocations — the merchant removes a warehouse from the settings page and
+// orders keep being routed to it, with nobody there to pick them.
+//
+// The order below needs 5 units. Only the LIVE warehouse's 3 count, so it
+// must fail rather than quietly draw the other 2 from an archived one.
+func TestCommitStock_ArchivedWarehouseIsNotAllocatedTo(t *testing.T) {
+	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
+		"variant_stock", "product_variants", "products", "stores")
+	storeID, variantID := seedAvailStore(t, db)
+	live := seedWarehouseRow(t, db, storeID, "Live")
+	archived := seedWarehouseRow(t, db, storeID, "Archived")
+	require.NoError(t, db.Exec(`UPDATE warehouses SET priority = 0 WHERE id = ?`, live).Error)
+	require.NoError(t, db.Exec(`UPDATE warehouses SET priority = 1 WHERE id = ?`, archived).Error)
+	require.NoError(t, db.Exec(`UPDATE warehouses SET archived_at = now() WHERE id = ?`, archived).Error)
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 3, now()), (?, ?, 4, now())`,
+		variantID, live, variantID, archived).Error)
+
+	lines := []stockLine{{VariantID: variantID, Quantity: 5}}
+	orderID, _ := seedOrderWithItems(t, db, storeID, lines)
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	})
+	require.Error(t, err,
+		"5 units against 3 live + 4 archived must not fill — archived stock is not sellable")
+
+	require.Equal(t, 3, stockUnitsAt(t, db, variantID, live), "a failed checkout must move no stock")
+	require.Equal(t, 4, stockUnitsAt(t, db, variantID, archived))
+}

--- a/services/marketplace-api/internal/handlers/storefront/checkout_stock.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_stock.go
@@ -308,13 +308,21 @@ func commitStockAtSentinel(
 	return holds.Commit(ctx, tx, cartToken)
 }
 
-// storeWarehousesInFillOrder reads storeID's warehouses and returns them in
-// the order allocation.Plan should fill them. Plan takes an ordered slice
+// storeWarehousesInFillOrder reads storeID's LIVE warehouses and returns them
+// in the order allocation.Plan should fill them. Plan takes an ordered slice
 // and cannot detect an unordered one, so ordering here is mandatory.
+//
+// archived_at IS NULL is not a nicety. Archiving (#177 PR 5a) is what the
+// settings page's "remove" does to any warehouse with allocation history —
+// the row survives so the record of which warehouse shipped a line survives
+// with it. Without this filter a removed warehouse keeps receiving
+// allocations for whatever stock it still holds, and orders route to a
+// location the merchant believes is gone.
 func storeWarehousesInFillOrder(ctx context.Context, tx *gorm.DB, storeID string) ([]allocation.Warehouse, error) {
 	var rows []allocation.Warehouse
 	if err := tx.WithContext(ctx).Raw(
-		`SELECT id, priority, is_default, created_at FROM warehouses WHERE store_id = ?`, storeID).
+		`SELECT id, priority, is_default, created_at FROM warehouses
+		  WHERE store_id = ? AND archived_at IS NULL`, storeID).
 		Scan(&rows).Error; err != nil {
 		return nil, fmt.Errorf("storefront: load warehouses: %w", err)
 	}

--- a/services/marketplace-api/internal/warehouse/archiving_integration_test.go
+++ b/services/marketplace-api/internal/warehouse/archiving_integration_test.go
@@ -310,3 +310,45 @@ func namesOf(ws []warehouse.Warehouse) []string {
 	}
 	return out
 }
+
+// Archive() clears is_default, but DefaultForStore's ordering — is_default
+// DESC, created_at ASC — would still hand back an ARCHIVED row whenever it
+// is the oldest, or whenever every warehouse has been archived. Callers use
+// this to fill a carrier config's pickup address, so an archived answer
+// binds a live carrier to a warehouse nothing is allowed to allocate to.
+func TestDefaultForStore_SkipsArchived(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	// Oldest first, so it wins the created_at ASC tie-break once both have
+	// is_default = false.
+	old, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Old"))
+	require.NoError(t, err)
+	current, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Current"))
+	require.NoError(t, err)
+
+	require.NoError(t, repo.Archive(ctx, db, old.ID))
+
+	got, err := repo.DefaultForStore(ctx, db, storeID)
+	require.NoError(t, err)
+	require.Equal(t, current.ID, got.ID,
+		"an archived warehouse must never be offered as the store default")
+}
+
+// Every warehouse archived is not "the oldest one, then" — it is the same
+// answer as a store with no warehouses at all.
+func TestDefaultForStore_AllArchivedIsNotFound(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	only, err := repo.Upsert(ctx, db, sample(tenantID, storeID, "Only"))
+	require.NoError(t, err)
+	require.NoError(t, repo.Archive(ctx, db, only.ID))
+
+	_, err = repo.DefaultForStore(ctx, db, storeID)
+	require.ErrorIs(t, err, warehouse.ErrNotFound)
+}

--- a/services/marketplace-api/internal/warehouse/repository.go
+++ b/services/marketplace-api/internal/warehouse/repository.go
@@ -168,7 +168,14 @@ func (r *Repository) Upsert(ctx context.Context, db *gorm.DB, w Warehouse) (Ware
 func (r *Repository) DefaultForStore(ctx context.Context, db *gorm.DB, storeID string) (Warehouse, error) {
 	var w Warehouse
 	err := db.WithContext(ctx).
-		Where("store_id = ?", storeID).
+		// Archive() clears is_default, but that alone is not enough: with
+		// every candidate then at is_default = false, created_at ASC would
+		// hand back the archived row whenever it is the oldest, and a store
+		// whose warehouses are ALL archived would get one rather than
+		// ErrNotFound. Callers fill a carrier config's pickup address from
+		// this, so an archived answer binds a live carrier to a warehouse
+		// the allocator refuses to use.
+		Where("store_id = ? AND archived_at IS NULL", storeID).
 		Order("is_default DESC, created_at ASC").
 		First(&w).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {


### PR DESCRIPTION
Refs #177. Found while reviewing #515 before starting PR 5b.

PR 5a (#520) added archiving. Nothing that *reads* warehouses learned about it — two well-built pieces, a broken join, each with passing tests. Harmless today only because nothing is archived yet and all 16,355 units still sit on the sentinel; the moment 5b/5c ship the archive button, both bugs are live.

## 1. The allocator's candidate set ignored `archived_at`

`checkout_stock.go:317` selected every warehouse for the store. Archiving is what the settings page's "remove" does to any warehouse with allocation history — the row survives so the record of which warehouse shipped a line survives with it. Without the filter, a removed warehouse keeps receiving allocations for whatever stock it still holds, and orders route to a location the merchant believes is gone.

## 2. `DefaultForStore` could return an archived warehouse

`Archive()` clears `is_default`, which looks sufficient and is not. With every candidate then at `is_default = false`, the `created_at ASC` tie-break hands back the archived row whenever it is the oldest — and a store whose warehouses are *all* archived gets one back instead of `ErrNotFound`. Callers fill a carrier config's pickup address from this, so an archived answer binds a live carrier to a warehouse the allocator now refuses to use.

This also settles the open question in #515's Risks section — "decide explicitly whether archiving is refused while stock remains, or whether the allocator must exclude archived rows." **The allocator excludes them.** Archiving stays permitted with stock in place; that stock simply stops being sellable, which is what "this location is gone" should mean. 5c should warn when archiving a warehouse that still holds units.

## Tests

Three new integration tests, each written first and each failing against the unpatched code — the pre-fix tree compiled clean and is itself the mutation:

- `TestCommitStock_ArchivedWarehouseIsNotAllocatedTo` — 5 units against 3 live + 4 archived must fail rather than quietly draw from the archived one, and must move no stock. Before: allocated and succeeded.
- `TestDefaultForStore_SkipsArchived` — before: returned the archived row.
- `TestDefaultForStore_AllArchivedIsNotFound` — before: returned a warehouse instead of `ErrNotFound`.

Full suite, from `services/marketplace-api`, DSN `postgres://dev:dev@192.168.1.110:5432/marketplace_db`:

`go test -tags=integration -count=1 -p 1 ./...` — exit 0, 120 packages ok, **3253 PASS / 25 SKIP / 0 FAIL**. The 25 skips are the pre-existing real-OpenFGA and subscription-trial-cron tests, none warehouse-related. Touched packages alone: 205 PASS, 0 SKIP.

`go vet -tags=integration ./...` clean.

No migration, so no `ExpectedSchemaVersion` bump.