### PR TITLE
feat(warehouse): admin CRUD API with archiving, reorder and default (#177 PR 5b)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1191,6 +1191,7 @@ func main() {
 			CSVImportsHandler:        csvImportsHandler,
 			PaymentSettingsHandler:   paymentSettingsHandler,
 			ShippingSettingsHandler:  shippingSettingsHandler,
+			WarehousesHandler:        admin.NewWarehousesHandler(conn, log),
 			ShipmentsHandler:         shipmentsHandler,
 			TaxSettingsHandler:       taxSettingsHandler,
 			SettingsMetaHandler:      settingsMetaHandler,

--- a/services/marketplace-api/internal/handlers/admin/errors.go
+++ b/services/marketplace-api/internal/handlers/admin/errors.go
@@ -71,6 +71,9 @@ var codeStatus = map[apperrors.Code]int{
 	apperrors.CodeCampaignNoRecipients: http.StatusUnprocessableEntity,
 	apperrors.CodeCampaignSchedulePast: http.StatusUnprocessableEntity,
 	apperrors.CodeSegmentInUse:         http.StatusConflict,
+
+	// Warehouses — #177 PR 5b.
+	apperrors.CodeWarehouseNameTaken: http.StatusConflict,
 }
 
 // RespondErr writes the standard error envelope for the given error.

--- a/services/marketplace-api/internal/handlers/admin/products_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/products_integration_test.go
@@ -138,6 +138,7 @@ func setupTestRouter(t *testing.T) *testEnv {
 		MediaHandler:        mediaHandler,
 		SubscriptionHandler: subHandler,
 		PromoHandler:        promoHandler,
+		WarehousesHandler:   admin.NewWarehousesHandler(db, nil),
 		StoresMiddleware:    storeMW,
 		AuthzMiddleware:     authzMW,
 		InternalSecret:      "",

--- a/services/marketplace-api/internal/handlers/admin/route_parity_test.go
+++ b/services/marketplace-api/internal/handlers/admin/route_parity_test.go
@@ -66,6 +66,7 @@ var webOnlySubtrees = map[string]string{
 	"/stores/:storeId/settings":                 "payment/shipping/tax provider credentials — secret entry stays on web",
 	"/stores/:storeId/subscription":             "plan, invoices, checkout, promo, cancel — all billing is web-only (app-store policy + PCI surface)",
 	"/stores/:storeId/tax":                      "tax-ID submission + US/CA attestation — legal attestation flow, web-only by design",
+	"/stores/:storeId/warehouses":               "warehouse CRUD (#177 PR 5b) — address forms + drag-to-reorder, a desktop settings task; mobile ships no warehouse screen. If mobile ever wants a read-only list, replace this subtree with exact webOnlyRoutes entries.",
 }
 
 // webOnlyRoutes exempts a single route INSIDE a group mobile does mirror.

--- a/services/marketplace-api/internal/handlers/admin/routes.go
+++ b/services/marketplace-api/internal/handlers/admin/routes.go
@@ -33,6 +33,7 @@ type Deps struct {
 	CSVImportsHandler       *CSVImportsHandler
 	PaymentSettingsHandler  *PaymentSettingsHandler
 	ShippingSettingsHandler *ShippingSettingsHandler
+	WarehousesHandler       *WarehousesHandler
 	TaxSettingsHandler      *TaxSettingsHandler
 	SettingsMetaHandler     *SettingsMetaHandler
 	CouponHandler           *CouponHandler
@@ -462,6 +463,35 @@ func RegisterAdmin(router *gin.RouterGroup, deps Deps) {
 				ss.DELETE("/:provider",
 					deps.AuthzMiddleware.RequireTenantRelation(authz.RoleOwner),
 					deps.ShippingSettingsHandler.Delete)
+			}
+		}
+		// Warehouses — #177 PR 5b. Mounted OUTSIDE /settings/shipping on
+		// purpose: a warehouse is a property of the store, not of a carrier
+		// account, and burying it under a carrier's settings is what let it
+		// become a side effect of the carrier form in the first place.
+		if deps.WarehousesHandler != nil {
+			wh := storeRoute.Group("/warehouses")
+			{
+				wh.GET("",
+					deps.AuthzMiddleware.RequireTenantRelation(authz.RoleAdmin),
+					deps.WarehousesHandler.List)
+				wh.POST("",
+					deps.AuthzMiddleware.RequireTenantRelation(authz.RoleOwner),
+					deps.WarehousesHandler.Create)
+				// Static sibling of "/:id" — gin resolves the literal first,
+				// so a warehouse can never be shadowed by this path.
+				wh.PUT("/reorder",
+					deps.AuthzMiddleware.RequireTenantRelation(authz.RoleOwner),
+					deps.WarehousesHandler.Reorder)
+				wh.PATCH("/:id",
+					deps.AuthzMiddleware.RequireTenantRelation(authz.RoleOwner),
+					deps.WarehousesHandler.Update)
+				wh.DELETE("/:id",
+					deps.AuthzMiddleware.RequireTenantRelation(authz.RoleOwner),
+					deps.WarehousesHandler.Delete)
+				wh.PUT("/:id/default",
+					deps.AuthzMiddleware.RequireTenantRelation(authz.RoleOwner),
+					deps.WarehousesHandler.SetDefault)
 			}
 		}
 		if deps.TaxSettingsHandler != nil {

--- a/services/marketplace-api/internal/handlers/admin/warehouses.go
+++ b/services/marketplace-api/internal/handlers/admin/warehouses.go
@@ -1,0 +1,403 @@
+// Package admin — warehouses.go: per-store warehouse CRUD, mounted at
+// /admin/stores/:storeId/warehouses (#177 PR 5b).
+//
+// # Why this surface exists
+//
+// Until now a warehouse was a side effect. Saving a shipping carrier config
+// upserted one behind the form, keyed on (store_id, name), so a merchant who
+// typed a slightly different name got a SECOND, stockless warehouse instead
+// of an edit — allocation then reported nothing available and the order never
+// shipped. #505 and #508 made that visible; this makes the warehouse a thing
+// the merchant manages directly, which is the actual fix.
+//
+// # One verb, not two
+//
+// The spec splits removal in half: a warehouse with any allocation history is
+// archived (order_allocations.warehouse_id is ON DELETE RESTRICT, and the
+// allocation row is the record of which warehouse shipped a line), and only a
+// warehouse with no history at all can be deleted. That distinction is real
+// but it is not the merchant's to make, so DELETE decides: it deletes when it
+// can, archives when it must, and reports which happened.
+package admin
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+)
+
+// WarehousesHandler serves the per-store warehouse endpoints.
+type WarehousesHandler struct {
+	db     *gorm.DB
+	repo   *warehouse.Repository
+	logger *slog.Logger
+}
+
+// NewWarehousesHandler constructs a WarehousesHandler.
+func NewWarehousesHandler(db *gorm.DB, logger *slog.Logger) *WarehousesHandler {
+	return &WarehousesHandler{db: db, repo: warehouse.NewRepository(), logger: logger}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Wire types
+// ─────────────────────────────────────────────────────────────────────────
+
+// WarehouseResponse is one warehouse on the wire.
+type WarehouseResponse struct {
+	ID            string  `json:"id"`
+	Name          string  `json:"name"`
+	Line1         string  `json:"line1"`
+	Line2         string  `json:"line2,omitempty"`
+	City          string  `json:"city"`
+	Region        string  `json:"region"`
+	PostalCode    string  `json:"postal_code"`
+	CountryCode   string  `json:"country_code"`
+	Phone         string  `json:"phone"`
+	Email         string  `json:"email,omitempty"`
+	ContactPerson string  `json:"contact_person,omitempty"`
+	IsDefault     bool    `json:"is_default"`
+	Priority      int     `json:"priority"`
+	ArchivedAt    *string `json:"archived_at,omitempty"`
+}
+
+// WarehouseWriteRequest is the create and update body. Deliberately one
+// type: a create and an edit collect exactly the same fields, and two
+// near-identical structs is how one of them ends up missing a rule.
+type WarehouseWriteRequest struct {
+	Name          string `json:"name"`
+	Line1         string `json:"line1"`
+	Line2         string `json:"line2"`
+	City          string `json:"city"`
+	Region        string `json:"region"`
+	PostalCode    string `json:"postal_code"`
+	CountryCode   string `json:"country_code"`
+	Phone         string `json:"phone"`
+	Email         string `json:"email"`
+	ContactPerson string `json:"contact_person"`
+}
+
+// ReorderWarehousesRequest carries the FULL ordered set of live warehouse
+// ids, not a delta — see Reorder.
+type ReorderWarehousesRequest struct {
+	Order []string `json:"order"`
+}
+
+func toWarehouseResponse(w warehouse.Warehouse) WarehouseResponse {
+	out := WarehouseResponse{
+		ID: w.ID, Name: w.Name, Line1: w.Line1, Line2: w.Line2,
+		City: w.City, Region: w.Region, PostalCode: w.PostalCode,
+		CountryCode: w.CountryCode, Phone: w.Phone, Email: w.Email,
+		ContactPerson: w.ContactPerson, IsDefault: w.IsDefault, Priority: w.Priority,
+	}
+	if w.ArchivedAt != nil {
+		s := w.ArchivedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
+		out.ArchivedAt = &s
+	}
+	return out
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Handlers
+// ─────────────────────────────────────────────────────────────────────────
+
+// List handles GET /admin/stores/:storeId/warehouses.
+//
+// Archived warehouses are excluded unless ?include_archived=true. They are
+// excluded from the allocator's candidates too (checkout_stock.go) — a list
+// that showed them while the allocator ignored them would be an oversell
+// waiting to happen.
+func (h *WarehousesHandler) List(c *gin.Context) {
+	storeID := c.Param("storeId")
+	includeArchived := c.Query("include_archived") == "true"
+
+	rows, err := h.repo.List(c.Request.Context(), h.db, storeID, includeArchived)
+	if err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+	out := make([]WarehouseResponse, 0, len(rows))
+	for _, w := range rows {
+		out = append(out, toWarehouseResponse(w))
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out})
+}
+
+// Create handles POST /admin/stores/:storeId/warehouses.
+func (h *WarehousesHandler) Create(c *gin.Context) {
+	storeID := c.Param("storeId")
+	tenantID := c.GetString("tenant_id")
+
+	var req WarehouseWriteRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		RespondErr(c, apperrors.ValidationFailed("body", err.Error()), h.logger)
+		return
+	}
+	if err := validateWarehouseWrite(req); err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+
+	w := applyWarehouseWrite(warehouse.Warehouse{TenantID: tenantID, StoreID: storeID}, req)
+	created, err := h.repo.Create(c.Request.Context(), h.db, w)
+	if err != nil {
+		RespondErr(c, mapWarehouseErr(err, req.Name), h.logger)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"data": toWarehouseResponse(created)})
+}
+
+// Update handles PATCH /admin/stores/:storeId/warehouses/:id.
+//
+// Keyed on the id, so a RENAME edits the row rather than forking a second
+// one. That is the whole point of the slice — the carrier form's name-keyed
+// upsert is what stranded stock on an orphan warehouse.
+func (h *WarehousesHandler) Update(c *gin.Context) {
+	storeID := c.Param("storeId")
+	tenantID := c.GetString("tenant_id")
+
+	var req WarehouseWriteRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		RespondErr(c, apperrors.ValidationFailed("body", err.Error()), h.logger)
+		return
+	}
+	if err := validateWarehouseWrite(req); err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+
+	w := applyWarehouseWrite(warehouse.Warehouse{
+		ID: c.Param("id"), TenantID: tenantID, StoreID: storeID,
+	}, req)
+	updated, err := h.repo.UpdateByID(c.Request.Context(), h.db, w)
+	if err != nil {
+		RespondErr(c, mapWarehouseErr(err, req.Name), h.logger)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": toWarehouseResponse(updated)})
+}
+
+// Delete handles DELETE /admin/stores/:storeId/warehouses/:id.
+//
+// Deletes when the warehouse has no allocation history and holds no stock;
+// archives otherwise. The merchant asked for one thing — "remove this" — and
+// gets one answer, with `outcome` saying which path ran so the UI can tell
+// them the row is still on past orders.
+//
+// `units_remaining` is not decoration: archiving does NOT move stock, and
+// those units stop being sellable the moment the allocator skips the row.
+// The caller needs the number to warn before, or explain after.
+func (h *WarehousesHandler) Delete(c *gin.Context) {
+	ctx := c.Request.Context()
+	storeID, id := c.Param("storeId"), c.Param("id")
+
+	// Prove ownership first: Delete and Archive both take an id alone, and
+	// an id is a guessable handle to another store's row.
+	if _, err := h.repo.LiveForStore(ctx, h.db, id, storeID); err != nil {
+		RespondErr(c, mapWarehouseErr(err, ""), h.logger)
+		return
+	}
+
+	units, err := h.repo.UnitsHeld(ctx, h.db, id)
+	if err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+
+	err = h.repo.Delete(ctx, h.db, id)
+	switch {
+	case err == nil:
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{
+			"id": id, "outcome": "deleted", "units_remaining": 0,
+		}})
+		return
+	case errors.Is(err, warehouse.ErrHasStock),
+		errors.Is(err, warehouse.ErrHasUnshippedParcel),
+		errors.Is(err, warehouse.ErrHasHistory):
+		// Every refusal Delete can report is a reason to ARCHIVE, not a
+		// reason to tell the merchant no. Refusing outright would leave a
+		// stocked warehouse permanently unremovable.
+		if archiveErr := h.repo.Archive(ctx, h.db, id); archiveErr != nil {
+			RespondErr(c, mapWarehouseErr(archiveErr, ""), h.logger)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{
+			"id": id, "outcome": "archived", "reason": warehouseRemovalReason(err),
+			"units_remaining": units,
+		}})
+		return
+	default:
+		RespondErr(c, mapWarehouseErr(err, ""), h.logger)
+	}
+}
+
+// Reorder handles PUT /admin/stores/:storeId/warehouses/reorder.
+//
+// The body must be the store's COMPLETE live set. A delta applied to a list
+// that changed underneath — a warehouse archived in another tab — reorders
+// the wrong rows, and the caller would never know. Comparing against the
+// live set turns that into a 400 instead of a silently wrong fill order.
+func (h *WarehousesHandler) Reorder(c *gin.Context) {
+	ctx := c.Request.Context()
+	storeID := c.Param("storeId")
+
+	var req ReorderWarehousesRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		RespondErr(c, apperrors.ValidationFailed("body", err.Error()), h.logger)
+		return
+	}
+
+	live, err := h.repo.List(ctx, h.db, storeID, false)
+	if err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+	if err := requireCompleteSet(req.Order, live); err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+
+	updates := make([]warehouse.PriorityUpdate, 0, len(req.Order))
+	for i, id := range req.Order {
+		updates = append(updates, warehouse.PriorityUpdate{ID: id, Priority: i})
+	}
+	if err := h.repo.SetPriorities(ctx, h.db, storeID, updates); err != nil {
+		RespondErr(c, mapWarehouseErr(err, ""), h.logger)
+		return
+	}
+
+	rows, err := h.repo.List(ctx, h.db, storeID, false)
+	if err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+	out := make([]WarehouseResponse, 0, len(rows))
+	for _, w := range rows {
+		out = append(out, toWarehouseResponse(w))
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out})
+}
+
+// SetDefault handles PUT /admin/stores/:storeId/warehouses/:id/default.
+func (h *WarehousesHandler) SetDefault(c *gin.Context) {
+	ctx := c.Request.Context()
+	storeID, id := c.Param("storeId"), c.Param("id")
+
+	if err := h.repo.SetDefault(ctx, h.db, storeID, id); err != nil {
+		RespondErr(c, mapWarehouseErr(err, ""), h.logger)
+		return
+	}
+	w, err := h.repo.LiveForStore(ctx, h.db, id, storeID)
+	if err != nil {
+		RespondErr(c, mapWarehouseErr(err, ""), h.logger)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": toWarehouseResponse(w)})
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+// validateWarehouseWrite enforces the fields a warehouse must carry to be
+// usable for shipping.
+//
+// Phone is required and that is not bureaucracy: a warehouse saved without
+// one made every ShipEngine quote fail with a bare "valid from zip code"
+// error and no indication of the cause (#508, fixed in 5ed07a2b). The rule
+// used to live in the carrier form's own validator; the address moves here,
+// so the rule moves with it rather than being enforced in two places that
+// drift.
+func validateWarehouseWrite(req WarehouseWriteRequest) error {
+	for _, f := range []struct {
+		name, value string
+	}{
+		{"name", req.Name},
+		{"line1", req.Line1},
+		{"city", req.City},
+		{"postal_code", req.PostalCode},
+		{"country_code", req.CountryCode},
+		{"phone", req.Phone},
+	} {
+		if trimmed(f.value) == "" {
+			return apperrors.ValidationFailed(f.name, f.name+" is required")
+		}
+	}
+	if len(trimmed(req.CountryCode)) != 2 {
+		return apperrors.ValidationFailed("country_code", "country_code must be a 2-letter ISO code")
+	}
+	return nil
+}
+
+func applyWarehouseWrite(w warehouse.Warehouse, req WarehouseWriteRequest) warehouse.Warehouse {
+	w.Name = trimmed(req.Name)
+	w.Line1 = trimmed(req.Line1)
+	w.Line2 = trimmed(req.Line2)
+	w.City = trimmed(req.City)
+	w.Region = trimmed(req.Region)
+	w.PostalCode = trimmed(req.PostalCode)
+	w.CountryCode = trimmed(req.CountryCode)
+	w.Phone = trimmed(req.Phone)
+	w.Email = trimmed(req.Email)
+	w.ContactPerson = trimmed(req.ContactPerson)
+	return w
+}
+
+// requireCompleteSet checks that ids is exactly the live set, once each.
+func requireCompleteSet(ids []string, live []warehouse.Warehouse) error {
+	if len(ids) != len(live) {
+		return apperrors.ValidationFailed("order",
+			"order must list every live warehouse exactly once")
+	}
+	want := make(map[string]struct{}, len(live))
+	for _, w := range live {
+		want[w.ID] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if _, ok := want[id]; !ok {
+			return apperrors.ValidationFailed("order", "unknown warehouse in order: "+id)
+		}
+		if _, dup := seen[id]; dup {
+			return apperrors.ValidationFailed("order", "duplicate warehouse in order: "+id)
+		}
+		seen[id] = struct{}{}
+	}
+	return nil
+}
+
+// warehouseRemovalReason names why a delete became an archive.
+func warehouseRemovalReason(err error) string {
+	switch {
+	case errors.Is(err, warehouse.ErrHasStock):
+		return "holds_stock"
+	case errors.Is(err, warehouse.ErrHasUnshippedParcel):
+		return "unshipped_parcel"
+	default:
+		return "allocation_history"
+	}
+}
+
+// mapWarehouseErr turns repository sentinels into wire errors. Anything
+// unrecognised falls through untouched so RespondErr logs and 500s it,
+// rather than being flattened into a misleading 404.
+func mapWarehouseErr(err error, name string) error {
+	switch {
+	case errors.Is(err, warehouse.ErrNotFound):
+		return apperrors.NotFound("warehouse")
+	case errors.Is(err, warehouse.ErrNameTaken):
+		return apperrors.WarehouseNameTaken(name)
+	default:
+		return err
+	}
+}
+
+// trimmed is strings.TrimSpace, named for readability at the call sites
+// above where every field goes through it.
+func trimmed(s string) string { return strings.TrimSpace(s) }

--- a/services/marketplace-api/internal/handlers/admin/warehouses_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/warehouses_integration_test.go
@@ -1,0 +1,335 @@
+//go:build integration
+
+package admin_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/authz"
+)
+
+// #177 PR 5b — the admin warehouse API.
+//
+// The rule the whole slice exists for is TestAPI_Warehouses_Rename_*: a
+// rename must EDIT the row. The carrier form's name-keyed upsert forked a
+// second, stockless warehouse instead, and allocation then reported nothing
+// available while the stock sat on the orphan.
+
+func warehousesURL(storeID string) string {
+	return "/api/v1/admin/stores/" + storeID + "/warehouses"
+}
+
+func warehouseBody(name string) map[string]any {
+	return map[string]any{
+		"name": name, "line1": "12 Industrial Estate", "city": "Mumbai",
+		"region": "MH", "postal_code": "400001", "country_code": "IN",
+		"phone": "+912200000000", "contact_person": "Warehouse Manager",
+	}
+}
+
+// createWarehouse posts one and returns its id.
+func createWarehouse(t *testing.T, env *testEnv, storeID, tenantID, userID, name string) string {
+	t.Helper()
+	w := request(t, env.router, http.MethodPost, warehousesURL(storeID),
+		warehouseBody(name), authHeaders(userID, tenantID))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create %q: status = %d, body = %s", name, w.Code, w.Body.String())
+	}
+	return dataObject(t, w.Body.Bytes())["id"].(string)
+}
+
+func dataObject(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var resp map[string]any
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v (%s)", err, string(raw))
+	}
+	data, ok := resp["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing data object: %s", string(raw))
+	}
+	return data
+}
+
+func dataArray(t *testing.T, raw []byte) []any {
+	t.Helper()
+	var resp map[string]any
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v (%s)", err, string(raw))
+	}
+	data, ok := resp["data"].([]any)
+	if !ok {
+		t.Fatalf("missing data array: %s", string(raw))
+	}
+	return data
+}
+
+// ownerEnv sets up a store whose caller holds RoleOwner.
+func ownerEnv(t *testing.T) (*testEnv, string, string, string) {
+	t.Helper()
+	env := setupTestRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+	env.fga.Grant(userID, authz.RoleAdmin, tenantID)
+	return env, storeID, tenantID, userID
+}
+
+func TestAPI_Warehouses_Create_HappyPath(t *testing.T) {
+	env, storeID, tenantID, userID := ownerEnv(t)
+
+	w := request(t, env.router, http.MethodPost, warehousesURL(storeID),
+		warehouseBody("Main Warehouse"), authHeaders(userID, tenantID))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	data := dataObject(t, w.Body.Bytes())
+	if data["name"] != "Main Warehouse" || data["phone"] != "+912200000000" {
+		t.Fatalf("unexpected body: %s", w.Body.String())
+	}
+	if data["id"] == nil || data["id"] == "" {
+		t.Fatalf("missing id: %s", w.Body.String())
+	}
+}
+
+// A warehouse with no phone made every ShipEngine quote fail with a bare
+// "valid from zip code" and no cause (#508). The rule lives here now.
+func TestAPI_Warehouses_Create_WithoutPhone_400(t *testing.T) {
+	env, storeID, tenantID, userID := ownerEnv(t)
+
+	body := warehouseBody("No Phone")
+	delete(body, "phone")
+	w := request(t, env.router, http.MethodPost, warehousesURL(storeID), body,
+		authHeaders(userID, tenantID))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPI_Warehouses_Create_DuplicateLiveName_409(t *testing.T) {
+	env, storeID, tenantID, userID := ownerEnv(t)
+	createWarehouse(t, env, storeID, tenantID, userID, "Main Warehouse")
+
+	w := request(t, env.router, http.MethodPost, warehousesURL(storeID),
+		warehouseBody("Main Warehouse"), authHeaders(userID, tenantID))
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["error"] != "warehouse_name_taken" {
+		t.Fatalf("expected warehouse_name_taken, got %s", w.Body.String())
+	}
+}
+
+// THE test. A rename must move the row, not fork it.
+func TestAPI_Warehouses_Rename_EditsTheRowInsteadOfForkingIt(t *testing.T) {
+	env, storeID, tenantID, userID := ownerEnv(t)
+	id := createWarehouse(t, env, storeID, tenantID, userID, "Main Warehouse")
+
+	body := warehouseBody("Bondi Depot")
+	w := request(t, env.router, http.MethodPatch, warehousesURL(storeID)+"/"+id, body,
+		authHeaders(userID, tenantID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	data := dataObject(t, w.Body.Bytes())
+	if data["id"] != id {
+		t.Fatalf("rename created a new row: %v != %v", data["id"], id)
+	}
+	if data["name"] != "Bondi Depot" {
+		t.Fatalf("name = %v", data["name"])
+	}
+
+	list := request(t, env.router, http.MethodGet, warehousesURL(storeID), nil,
+		authHeaders(userID, tenantID))
+	if got := len(dataArray(t, list.Body.Bytes())); got != 1 {
+		t.Fatalf("after rename the store has %d warehouses, want 1 — the old row kept the stock", got)
+	}
+}
+
+func TestAPI_Warehouses_Update_AnotherStoresWarehouse_404(t *testing.T) {
+	env, storeID, tenantID, userID := ownerEnv(t)
+	id := createWarehouse(t, env, storeID, tenantID, userID, "Mine")
+
+	otherStore, otherTenant := seedStoreRow(t, env.db, "")
+	otherUser := uuid.NewString()
+	env.fga.Grant(otherUser, authz.RoleOwner, otherTenant)
+
+	w := request(t, env.router, http.MethodPatch, warehousesURL(otherStore)+"/"+id,
+		warehouseBody("Stolen"), authHeaders(otherUser, otherTenant))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	var name string
+	if err := env.db.Raw(`SELECT name FROM warehouses WHERE id = ?`, id).Scan(&name).Error; err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if name != "Mine" {
+		t.Fatalf("another store's warehouse was renamed to %q", name)
+	}
+}
+
+func TestAPI_Warehouses_Delete_NoHistory_IsADelete(t *testing.T) {
+	env, storeID, tenantID, userID := ownerEnv(t)
+	id := createWarehouse(t, env, storeID, tenantID, userID, "Temp")
+
+	w := request(t, env.router, http.MethodDelete, warehousesURL(storeID)+"/"+id, nil,
+		authHeaders(userID, tenantID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if outcome := dataObject(t, w.Body.Bytes())["outcome"]; outcome != "deleted" {
+		t.Fatalf("outcome = %v, want deleted", outcome)
+	}
+
+	var rows int64
+	_ = env.db.Raw(`SELECT count(*) FROM warehouses WHERE id = ?`, id).Scan(&rows).Error
+	if rows != 0 {
+		t.Fatalf("row still present")
+	}
+}
+
+// The merchant gets ONE verb. A warehouse holding stock cannot be deleted,
+// so "remove" archives it — and says how many units it stranded, because
+// archiving does not move stock and those units stop being sellable.
+func TestAPI_Warehouses_Delete_WithStock_ArchivesAndReportsUnits(t *testing.T) {
+	env, storeID, tenantID, userID := ownerEnv(t)
+	id := createWarehouse(t, env, storeID, tenantID, userID, "Stocked")
+	seedStockAt(t, env.db, storeID, id, 7)
+
+	w := request(t, env.router, http.MethodDelete, warehousesURL(storeID)+"/"+id, nil,
+		authHeaders(userID, tenantID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	data := dataObject(t, w.Body.Bytes())
+	if data["outcome"] != "archived" || data["reason"] != "holds_stock" {
+		t.Fatalf("unexpected outcome: %s", w.Body.String())
+	}
+	if units, _ := data["units_remaining"].(float64); units != 7 {
+		t.Fatalf("units_remaining = %v, want 7", data["units_remaining"])
+	}
+
+	// Archived: gone from the default list, still there with the flag.
+	list := request(t, env.router, http.MethodGet, warehousesURL(storeID), nil,
+		authHeaders(userID, tenantID))
+	if got := len(dataArray(t, list.Body.Bytes())); got != 0 {
+		t.Fatalf("archived warehouse still listed (%d rows)", got)
+	}
+	withArchived := request(t, env.router, http.MethodGet,
+		warehousesURL(storeID)+"?include_archived=true", nil, authHeaders(userID, tenantID))
+	if got := len(dataArray(t, withArchived.Body.Bytes())); got != 1 {
+		t.Fatalf("include_archived returned %d rows, want 1", got)
+	}
+}
+
+func TestAPI_Warehouses_Delete_AnotherStoresWarehouse_404(t *testing.T) {
+	env, storeID, tenantID, userID := ownerEnv(t)
+	id := createWarehouse(t, env, storeID, tenantID, userID, "Mine")
+
+	otherStore, otherTenant := seedStoreRow(t, env.db, "")
+	otherUser := uuid.NewString()
+	env.fga.Grant(otherUser, authz.RoleOwner, otherTenant)
+
+	w := request(t, env.router, http.MethodDelete, warehousesURL(otherStore)+"/"+id, nil,
+		authHeaders(otherUser, otherTenant))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var rows int64
+	_ = env.db.Raw(`SELECT count(*) FROM warehouses WHERE id = ?`, id).Scan(&rows).Error
+	if rows != 1 {
+		t.Fatalf("another store's warehouse was removed")
+	}
+}
+
+func TestAPI_Warehouses_Reorder_AppliesTheGivenOrder(t *testing.T) {
+	env, storeID, tenantID, userID := ownerEnv(t)
+	first := createWarehouse(t, env, storeID, tenantID, userID, "Alpha")
+	second := createWarehouse(t, env, storeID, tenantID, userID, "Bravo")
+
+	w := request(t, env.router, http.MethodPut, warehousesURL(storeID)+"/reorder",
+		map[string]any{"order": []string{second, first}}, authHeaders(userID, tenantID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	rows := dataArray(t, w.Body.Bytes())
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows", len(rows))
+	}
+	if rows[0].(map[string]any)["id"] != second {
+		t.Fatalf("list is not in the new fill order: %s", w.Body.String())
+	}
+}
+
+// A delta over a list that changed underneath reorders the wrong rows and
+// the caller never finds out. Requiring the complete set makes it a 400.
+func TestAPI_Warehouses_Reorder_PartialSet_400(t *testing.T) {
+	env, storeID, tenantID, userID := ownerEnv(t)
+	first := createWarehouse(t, env, storeID, tenantID, userID, "Alpha")
+	createWarehouse(t, env, storeID, tenantID, userID, "Bravo")
+
+	w := request(t, env.router, http.MethodPut, warehousesURL(storeID)+"/reorder",
+		map[string]any{"order": []string{first}}, authHeaders(userID, tenantID))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPI_Warehouses_SetDefault_MovesTheFlag(t *testing.T) {
+	env, storeID, tenantID, userID := ownerEnv(t)
+	first := createWarehouse(t, env, storeID, tenantID, userID, "Alpha")
+	second := createWarehouse(t, env, storeID, tenantID, userID, "Bravo")
+
+	for _, id := range []string{first, second} {
+		w := request(t, env.router, http.MethodPut, warehousesURL(storeID)+"/"+id+"/default",
+			nil, authHeaders(userID, tenantID))
+		if w.Code != http.StatusOK {
+			t.Fatalf("set default %s: status = %d, body = %s", id, w.Code, w.Body.String())
+		}
+	}
+
+	var defaults []string
+	if err := env.db.Raw(
+		`SELECT id FROM warehouses WHERE store_id = ? AND is_default`, storeID).
+		Scan(&defaults).Error; err != nil {
+		t.Fatalf("read defaults: %v", err)
+	}
+	if len(defaults) != 1 || defaults[0] != second {
+		t.Fatalf("defaults = %v, want exactly [%s]", defaults, second)
+	}
+}
+
+// seedStockAt puts qty units of a fresh variant into a warehouse.
+func seedStockAt(t *testing.T, db *gorm.DB, storeID, warehouseID string, qty int) {
+	t.Helper()
+	var tenantID string
+	if err := db.Raw(`SELECT tenant_id FROM stores WHERE id = ?`, storeID).Row().Scan(&tenantID); err != nil {
+		t.Fatalf("tenant lookup: %v", err)
+	}
+	productID, variantID := uuid.NewString(), uuid.NewString()
+	if err := db.Exec(
+		`INSERT INTO products (id, tenant_id, store_id, title, handle, status, vendor_id, published_at)
+		 VALUES (?, ?, ?, 'WH Product', ?, 'active', ?, now())`,
+		productID, tenantID, storeID, "wh-"+uuid.NewString()[:8], uuid.NewString()).Error; err != nil {
+		t.Fatalf("seed product: %v", err)
+	}
+	if err := db.Exec(
+		`INSERT INTO product_variants (id, product_id, store_id, sku, price, currency_code)
+		 VALUES (?, ?, ?, ?, 10.00, 'INR')`,
+		variantID, productID, storeID, "SKU-"+uuid.NewString()[:8]).Error; err != nil {
+		t.Fatalf("seed variant: %v", err)
+	}
+	if err := db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, ?, now())`, variantID, warehouseID, qty).Error; err != nil {
+		t.Fatalf("seed stock: %v", err)
+	}
+}

--- a/services/marketplace-api/internal/warehouse/crud_integration_test.go
+++ b/services/marketplace-api/internal/warehouse/crud_integration_test.go
@@ -1,0 +1,214 @@
+//go:build integration
+
+package warehouse_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// #177 PR 5b — the repository half of warehouse CRUD.
+//
+// Upsert cannot serve the admin API. It is keyed on (store_id, name), which
+// is precisely the trap #177 exists to remove: an edit that renames a
+// warehouse would land on a DIFFERENT row and leave the stock behind on the
+// old one. Create and UpdateByID key on the id instead, and a name
+// collision is a reported conflict rather than a silent overwrite.
+
+func TestCreate_RejectsADuplicateLiveName(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	_, err := repo.Create(ctx, db, sample(tenantID, storeID, "Main Warehouse"))
+	require.NoError(t, err)
+
+	_, err = repo.Create(ctx, db, sample(tenantID, storeID, "Main Warehouse"))
+	require.ErrorIs(t, err, warehouse.ErrNameTaken,
+		"a second warehouse under a live name must be refused, NOT silently merged into the first")
+
+	all, err := repo.List(ctx, db, storeID, true)
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+}
+
+// The partial index (000122) exists so an archived name can be reused.
+func TestCreate_AllowsAnArchivedName(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	first, err := repo.Create(ctx, db, sample(tenantID, storeID, "Main Warehouse"))
+	require.NoError(t, err)
+	require.NoError(t, repo.Archive(ctx, db, first.ID))
+
+	second, err := repo.Create(ctx, db, sample(tenantID, storeID, "Main Warehouse"))
+	require.NoError(t, err)
+	require.NotEqual(t, first.ID, second.ID)
+}
+
+// THE test this slice exists for. Renaming must move the row, not fork it.
+func TestUpdateByID_RenameKeepsTheSameRow(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	created, err := repo.Create(ctx, db, sample(tenantID, storeID, "Main Warehouse"))
+	require.NoError(t, err)
+
+	updated := created
+	updated.Name = "Bondi Depot"
+	updated.City = "Bondi Beach"
+	got, err := repo.UpdateByID(ctx, db, updated)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, got.ID, "a rename must edit the row, not create a second one")
+	require.Equal(t, "Bondi Depot", got.Name)
+	require.Equal(t, "Bondi Beach", got.City)
+
+	all, err := repo.List(ctx, db, storeID, true)
+	require.NoError(t, err)
+	require.Len(t, all, 1, "renaming must not leave the old row behind holding the stock")
+}
+
+func TestUpdateByID_RejectsANameAnotherLiveWarehouseHolds(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	_, err := repo.Create(ctx, db, sample(tenantID, storeID, "Main Warehouse"))
+	require.NoError(t, err)
+	other, err := repo.Create(ctx, db, sample(tenantID, storeID, "Overflow"))
+	require.NoError(t, err)
+
+	other.Name = "Main Warehouse"
+	_, err = repo.UpdateByID(ctx, db, other)
+	require.ErrorIs(t, err, warehouse.ErrNameTaken)
+}
+
+func TestUpdateByID_UnknownIDIsNotFound(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	ghost := sample(tenantID, storeID, "Ghost")
+	ghost.ID = "00000000-0000-0000-0000-0000000000ff"
+	_, err := repo.UpdateByID(ctx, db, ghost)
+	require.ErrorIs(t, err, warehouse.ErrNotFound)
+}
+
+// An archived warehouse is removed as far as the merchant is concerned.
+// Editing one would be editing something the UI does not show.
+func TestUpdateByID_RefusesAnArchivedWarehouse(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	created, err := repo.Create(ctx, db, sample(tenantID, storeID, "Gone"))
+	require.NoError(t, err)
+	require.NoError(t, repo.Archive(ctx, db, created.ID))
+
+	created.Name = "Back From The Dead"
+	_, err = repo.UpdateByID(ctx, db, created)
+	require.ErrorIs(t, err, warehouse.ErrNotFound)
+
+	// Asserting the error alone is not enough, and a mutation proved it: an
+	// UPDATE that omits the archived filter still reports ErrNotFound,
+	// because the read-back applies it — while having already rewritten the
+	// archived row. The row itself is the assertion that matters.
+	var name string
+	require.NoError(t, db.Raw(`SELECT name FROM warehouses WHERE id = ?`, created.ID).Scan(&name).Error)
+	require.Equal(t, "Gone", name, "an archived warehouse must not be written to at all")
+}
+
+func TestSetDefault_MovesTheFlagAndLeavesExactlyOne(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	first, err := repo.Create(ctx, db, sample(tenantID, storeID, "First"))
+	require.NoError(t, err)
+	second, err := repo.Create(ctx, db, sample(tenantID, storeID, "Second"))
+	require.NoError(t, err)
+	require.NoError(t, repo.SetDefault(ctx, db, storeID, first.ID))
+
+	require.NoError(t, repo.SetDefault(ctx, db, storeID, second.ID))
+
+	var defaults []string
+	require.NoError(t, db.Raw(
+		`SELECT id FROM warehouses WHERE store_id = ? AND is_default`, storeID).Scan(&defaults).Error)
+	require.Equal(t, []string{second.ID}, defaults,
+		"exactly one default per store — the old flag must be cleared in the same transaction")
+}
+
+func TestSetDefault_RefusesAnArchivedWarehouse(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	live, err := repo.Create(ctx, db, sample(tenantID, storeID, "Live"))
+	require.NoError(t, err)
+	require.NoError(t, repo.SetDefault(ctx, db, storeID, live.ID))
+	archived, err := repo.Create(ctx, db, sample(tenantID, storeID, "Archived"))
+	require.NoError(t, err)
+	require.NoError(t, repo.Archive(ctx, db, archived.ID))
+
+	err = repo.SetDefault(ctx, db, storeID, archived.ID)
+	require.ErrorIs(t, err, warehouse.ErrNotFound)
+
+	var stillDefault string
+	require.NoError(t, db.Raw(
+		`SELECT id FROM warehouses WHERE store_id = ? AND is_default`, storeID).Scan(&stillDefault).Error)
+	require.Equal(t, live.ID, stillDefault,
+		"a refused SetDefault must not have cleared the existing default first")
+}
+
+// Another store's warehouse must not be reachable by id alone.
+func TestSetDefault_IgnoresAnotherStoresWarehouse(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantA, storeA := seedStore(t, db)
+	_, storeB := seedStore(t, db)
+
+	mine, err := repo.Create(ctx, db, sample(tenantA, storeA, "Mine"))
+	require.NoError(t, err)
+
+	err = repo.SetDefault(ctx, db, storeB, mine.ID)
+	require.ErrorIs(t, err, warehouse.ErrNotFound)
+}
+
+// An id alone is a guessable handle to another tenant's row; the handler
+// takes the store from the URL, so the repository must scope by it too.
+func TestUpdateByID_IgnoresAnotherStoresWarehouse(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantA, storeA := seedStore(t, db)
+	_, storeB := seedStore(t, db)
+
+	mine, err := repo.Create(ctx, db, sample(tenantA, storeA, "Mine"))
+	require.NoError(t, err)
+
+	attempt := mine
+	attempt.StoreID = storeB
+	attempt.Name = "Stolen"
+	_, err = repo.UpdateByID(ctx, db, attempt)
+	require.ErrorIs(t, err, warehouse.ErrNotFound)
+
+	var name string
+	require.NoError(t, db.Raw(`SELECT name FROM warehouses WHERE id = ?`, mine.ID).Scan(&name).Error)
+	require.Equal(t, "Mine", name, "another store's warehouse must be untouched")
+}

--- a/services/marketplace-api/internal/warehouse/repository.go
+++ b/services/marketplace-api/internal/warehouse/repository.go
@@ -37,6 +37,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -62,6 +63,11 @@ var ErrHasUnshippedParcel = errors.New("warehouse: has unshipped allocations")
 // cannot be deleted at all — it must be archived. Not a failure the caller
 // should surface as an error: it is the signal to call Archive instead.
 var ErrHasHistory = errors.New("warehouse: has allocation history; archive instead")
+
+// ErrNameTaken means another LIVE warehouse in the same store already holds
+// the name. Archived rows do not collide — that is what 000122's partial
+// unique index buys, and reusing an archived name is legitimate.
+var ErrNameTaken = errors.New("warehouse: name already in use")
 
 // Warehouse is a store's pickup location.
 type Warehouse struct {
@@ -393,4 +399,177 @@ func (r *Repository) SetPriorities(ctx context.Context, db *gorm.DB, storeID str
 		}
 		return nil
 	})
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// #177 PR 5b — id-keyed CRUD for the admin API.
+//
+// Upsert (above) is keyed on (store_id, name) and cannot serve this
+// surface: a merchant renaming a warehouse through Upsert would land on a
+// DIFFERENT row and leave the stock behind on the old one. That is the
+// exact trap #177 exists to remove, so the admin API keys on the id and a
+// name collision is reported rather than silently merged.
+// ─────────────────────────────────────────────────────────────────────────
+
+// Create inserts a new warehouse. A live warehouse already holding the name
+// is ErrNameTaken; an ARCHIVED one is not a conflict at all, which is what
+// the partial index (000122) is for.
+func (r *Repository) Create(ctx context.Context, db *gorm.DB, w Warehouse) (Warehouse, error) {
+	if err := normalize(&w); err != nil {
+		return Warehouse{}, err
+	}
+	w.ID = uuid.NewString()
+
+	if err := db.WithContext(ctx).Create(&w).Error; err != nil {
+		if isUniqueViolation(err) {
+			return Warehouse{}, ErrNameTaken
+		}
+		return Warehouse{}, fmt.Errorf("warehouse: create: %w", err)
+	}
+	return w, nil
+}
+
+// UpdateByID edits a live warehouse in place, id-keyed so a rename moves
+// the row instead of forking it.
+//
+// Scoped to store_id as well as id: an id alone is a guessable handle to
+// another tenant's row, and the handler takes the store from the URL.
+// Archived rows are not editable — the merchant has been told they are
+// gone, and an edit would be editing something the UI does not show.
+func (r *Repository) UpdateByID(ctx context.Context, db *gorm.DB, w Warehouse) (Warehouse, error) {
+	if err := normalize(&w); err != nil {
+		return Warehouse{}, err
+	}
+	if w.ID == "" {
+		return Warehouse{}, ErrNotFound
+	}
+
+	res := db.WithContext(ctx).
+		Model(&Warehouse{}).
+		Where("id = ? AND store_id = ? AND archived_at IS NULL", w.ID, w.StoreID).
+		Updates(map[string]any{
+			"name":           w.Name,
+			"line1":          w.Line1,
+			"line2":          w.Line2,
+			"city":           w.City,
+			"region":         w.Region,
+			"postal_code":    w.PostalCode,
+			"country_code":   w.CountryCode,
+			"phone":          w.Phone,
+			"email":          w.Email,
+			"contact_person": w.ContactPerson,
+			"updated_at":     time.Now().UTC(),
+		})
+	if res.Error != nil {
+		if isUniqueViolation(res.Error) {
+			return Warehouse{}, ErrNameTaken
+		}
+		return Warehouse{}, fmt.Errorf("warehouse: update: %w", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		// Postgres reports no rows for an update whose values all match, so
+		// a genuine no-op edit would look like a miss. Distinguish by
+		// reading, rather than telling a merchant their warehouse vanished
+		// because they pressed Save without changing anything.
+		return r.LiveForStore(ctx, db, w.ID, w.StoreID)
+	}
+	return r.LiveForStore(ctx, db, w.ID, w.StoreID)
+}
+
+// SetDefault moves the store's is_default flag onto one live warehouse.
+//
+// Both writes are one transaction: clearing the old flag and failing to set
+// the new one would leave the store with NO default, and DefaultForStore
+// would start answering with whichever row happens to be oldest.
+func (r *Repository) SetDefault(ctx context.Context, db *gorm.DB, storeID, id string) error {
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// The TRANSACTION is the guard here, not this ordering: a mutation
+		// that both moved this check after the clear AND kept the tx still
+		// passed, because the rollback undoes the clear either way. Drop
+		// the transaction as well and a refused call leaves the store with
+		// NO default at all — which is what the refusal test pins.
+		if _, err := r.LiveForStore(ctx, tx, id, storeID); err != nil {
+			return err
+		}
+		if err := tx.Model(&Warehouse{}).
+			Where("store_id = ? AND is_default", storeID).
+			Updates(map[string]any{"is_default": false, "updated_at": time.Now().UTC()}).
+			Error; err != nil {
+			return fmt.Errorf("warehouse: set default: clear: %w", err)
+		}
+		if err := tx.Model(&Warehouse{}).
+			Where("id = ?", id).
+			Updates(map[string]any{"is_default": true, "updated_at": time.Now().UTC()}).
+			Error; err != nil {
+			return fmt.Errorf("warehouse: set default: set: %w", err)
+		}
+		return nil
+	})
+}
+
+// LiveForStore loads one non-archived warehouse belonging to storeID.
+//
+// Exported because Delete and Archive take an id alone: an id is a guessable
+// handle, so the admin handler must prove the row belongs to the store in
+// the URL before touching it.
+func (r *Repository) LiveForStore(ctx context.Context, db *gorm.DB, id, storeID string) (Warehouse, error) {
+	var w Warehouse
+	err := db.WithContext(ctx).
+		Where("id = ? AND store_id = ? AND archived_at IS NULL", id, storeID).
+		First(&w).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return Warehouse{}, ErrNotFound
+	}
+	if err != nil {
+		return Warehouse{}, fmt.Errorf("warehouse: load: %w", err)
+	}
+	return w, nil
+}
+
+// normalize trims and validates the fields every write shares.
+func normalize(w *Warehouse) error {
+	w.Name = strings.TrimSpace(w.Name)
+	if w.Name == "" {
+		return fmt.Errorf("warehouse: name is required")
+	}
+	if w.StoreID == "" || w.TenantID == "" {
+		return fmt.Errorf("warehouse: tenant and store are required")
+	}
+	w.CountryCode = strings.ToUpper(strings.TrimSpace(w.CountryCode))
+	return nil
+}
+
+// isUniqueViolation reports whether err is Postgres 23505.
+//
+// Matched on SQLSTATE, not on the index name or the message text: the
+// partial index was renamed by 000122 (warehouses_store_name_key ->
+// warehouses_store_name_live_key), and a check keyed on the old name would
+// have kept compiling and quietly stopped matching.
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "23505"
+	}
+	return false
+}
+
+// UnitsHeld reports how many units still sit in a warehouse.
+//
+// Read before archiving, because archiving does NOT move stock: those units
+// stop being sellable the moment the allocator skips the row. The caller
+// needs the number to warn the merchant rather than silently stranding
+// inventory.
+func (r *Repository) UnitsHeld(ctx context.Context, db *gorm.DB, id string) (int64, error) {
+	var total *int64
+	if err := db.WithContext(ctx).
+		Table("variant_stock").
+		Where("location_id = ?", id).
+		Select("COALESCE(SUM(quantity), 0)").
+		Scan(&total).Error; err != nil {
+		return 0, fmt.Errorf("warehouse: units held: %w", err)
+	}
+	if total == nil {
+		return 0, nil
+	}
+	return *total, nil
 }

--- a/services/marketplace-api/pkg/apperrors/errors.go
+++ b/services/marketplace-api/pkg/apperrors/errors.go
@@ -78,6 +78,11 @@ const (
 	// clause, so the delete is refused by Postgres; this code turns that
 	// refusal into an actionable 409 instead of a driver-level 500.
 	CodeSegmentInUse Code = "segment_in_use"
+
+	// CodeWarehouseNameTaken — another LIVE warehouse in the store already
+	// holds the name. Archived rows do not collide (000122's partial unique
+	// index), so reusing an archived name is not this error.
+	CodeWarehouseNameTaken Code = "warehouse_name_taken"
 )
 
 // Error is the marketplace-api envelope. Satisfies the error interface.
@@ -192,6 +197,7 @@ var knownCodes = []Code{
 	CodeCampaignNotFound, CodeCampaignNotDraft, CodeCampaignNotSending,
 	CodeCampaignNotPaused, CodeSegmentNotFound, CodeSegmentInvalidRules,
 	CodeCampaignNoRecipients, CodeCampaignSchedulePast, CodeSegmentInUse,
+	CodeWarehouseNameTaken,
 }
 
 // IsKnownCode reports whether the given code string is one of the
@@ -455,4 +461,13 @@ func SegmentInUse(campaignCount int64) *Error {
 	return &Error{Code: CodeSegmentInUse,
 		Message: fmt.Sprintf("segment is still used by %d %s and cannot be deleted", campaignCount, noun),
 		Details: map[string]any{"campaign_count": campaignCount}}
+}
+
+// WarehouseNameTaken reports a live name collision within one store.
+func WarehouseNameTaken(name string) *Error {
+	return &Error{
+		Code:    CodeWarehouseNameTaken,
+		Message: "a warehouse with this name already exists",
+		Details: map[string]any{"name": name},
+	}
 }


### PR DESCRIPTION
Refs #177. Rebased onto `main` now that #528 is merged; this replaces #529, which GitHub auto-closed when its base branch was deleted.

Until now a warehouse was a *side effect*: saving a shipping carrier config upserted one behind the form, keyed on `(store_id, name)`. A merchant who typed a slightly different name got a second, stockless warehouse instead of an edit, allocation then reported nothing available, and the order never shipped. #505 and #508 made that visible. This makes the warehouse a thing the merchant manages directly, which is the actual fix.

## The API

`/api/v1/admin/stores/:storeId/warehouses` — `GET` (list, `?include_archived=true`), `POST`, `PATCH /:id`, `DELETE /:id`, `PUT /reorder`, `PUT /:id/default`. Read is `RoleAdmin`; every write is `RoleOwner`.

### Repository: id-keyed, because Upsert cannot serve this

`Upsert` is keyed on `(store_id, name)` and a rename through it lands on a *different row*, leaving the stock behind — the exact trap #177 exists to remove. So 5b adds `Create`, `UpdateByID`, `SetDefault` and `UnitsHeld`, all keyed on the id and scoped by `store_id` (an id alone is a guessable handle to another tenant's row). A live name collision is `409 warehouse_name_taken`; an **archived** name is free to reuse, which is what 000122's partial unique index buys.

### One verb, not two

The spec splits removal in half — archive when there is allocation history, delete only when there is none — and that distinction is real but is not the merchant's to make. `DELETE` decides: it deletes when it can, archives when it must, and reports which happened plus `units_remaining`. Every refusal `Delete` can raise is a reason to archive, not a reason to say no; refusing outright would leave a stocked warehouse permanently unremovable.

`units_remaining` is not decoration. Archiving does **not** move stock, and (per #528) those units stop being sellable the moment the allocator skips the row. 5c needs the number to warn before, or explain after.

### Reorder takes the complete set

A delta applied to a list that changed underneath — a warehouse archived in another tab — reorders the wrong rows and the caller never finds out. The handler compares against the live set and returns 400 instead.

## A guard I did not know existed

`TestAdminRouteParity` caught all six new routes as missing from the mobile admin table. Declared web-only, alongside `/settings`: warehouse CRUD is address forms plus drag-to-reorder, a desktop settings task, and mobile ships no warehouse screen. The test refuses a subtree exemption the moment mobile registers anything under the prefix, so a future read-only mobile list has to be justified route-by-route.

## Tests

**16 new integration tests** — 9 repository, 7 API — including the one the slice exists for: a rename edits the row and the store still has exactly one warehouse afterwards.

Mutation-tested, each mutant confirmed to **compile** first:

| mutation | test that caught it |
|---|---|
| `Create` drops the `ErrNameTaken` mapping | `TestCreate_RejectsADuplicateLiveName` |
| `UpdateByID` drops the archived filter | `TestUpdateByID_RefusesAnArchivedWarehouse` |
| `UpdateByID` drops store scoping | `TestUpdateByID_IgnoresAnotherStoresWarehouse` |
| `SetDefault` loses its transaction | `TestSetDefault_RefusesAnArchivedWarehouse` |
| phone no longer required | `TestAPI_Warehouses_Create_WithoutPhone_400` |
| `Delete` ignores the ownership check | `TestAPI_Warehouses_Delete_AnotherStoresWarehouse_404` |
| `Reorder` accepts a partial set | `TestAPI_Warehouses_Reorder_PartialSet_400` |
| `Delete` reports `archived` without archiving | `TestAPI_Warehouses_Delete_WithStock_ArchivesAndReportsUnits` |

Two mutations were instructive rather than confirmatory and both changed the code:

- **`UpdateByID` without the archived filter initially survived.** The test asserted only the returned error, and the read-back applies the filter — so `ErrNotFound` came back *after* the archived row had already been rewritten. The test now asserts the row's name is untouched.
- **`SetDefault` with the verify moved after the clear also survived**, because the transaction rolls it back. The ordering is not the guard; the transaction is. Dropping the transaction too does fail the test. The comment now says that instead of claiming a reason that was not real.

Full suite, from `services/marketplace-api`, DSN `postgres://dev:dev@192.168.1.110:5432/marketplace_db`:

`go test -tags=integration -count=1 -p 1 ./...` — exit 0, 120 packages ok, **3274 PASS / 25 SKIP / 0 FAIL** (the 25 skips are the pre-existing real-OpenFGA and subscription-trial-cron tests). `go vet -tags=integration ./...` clean.

No migration — 000122 already carries `archived_at` and the partial index — so no `ExpectedSchemaVersion` bump.

## Not in scope

5c (the settings page), 5d (carrier form drops the address; deletes `warehouse-validation.ts`), 5e (per-location stock). Nothing here retires `DefaultLocationID` or touches the allocator — that is PR 6.
