### PR TITLE
feat(admin): warehouses settings page — add, edit, reorder, remove (#177 PR 5c)

### DIFF
--- a/apps/admin/app/(admin)/settings/warehouses/actions.ts
+++ b/apps/admin/app/(admin)/settings/warehouses/actions.ts
@@ -1,0 +1,142 @@
+"use server";
+
+// Server actions for the warehouses settings page (#177 PR 5c).
+
+import { headers } from "next/headers";
+import { revalidatePath } from "next/cache";
+
+import {
+  createWarehouse,
+  updateWarehouse,
+  removeWarehouse,
+  setDefaultWarehouse,
+  reorderWarehouses,
+} from "@/lib/api/warehouses-api";
+import type {
+  WarehouseWriteInput,
+  WarehouseRemoval,
+} from "@/lib/api/warehouses-api";
+import { canEditSettings, resolveStoreId } from "@/lib/auth/serverSession";
+import type { TenantRole } from "@/lib/api/platform-api";
+
+export type ActionResult<T = undefined> =
+  | { ok: true; data?: T }
+  | { ok: false; code: string; message: string };
+
+async function getSession() {
+  const h = await headers();
+  const userId = h.get("x-session-user-id") ?? "";
+  const tenantId = h.get("x-session-tenant-id") ?? "";
+  const role = (h.get("x-session-role") ?? "viewer") as TenantRole;
+  const storeId = await resolveStoreId();
+  return { userId, tenantId, role, storeId };
+}
+
+// guard returns the session when the caller may write, or the refusal to
+// hand straight back. Every action starts with it — a missing check on one
+// action is how a whole surface ends up half-protected.
+async function guard() {
+  const session = await getSession();
+  if (!session.userId || !session.tenantId || !session.storeId) {
+    return {
+      refusal: {
+        ok: false as const,
+        code: "no_session",
+        message: "Session expired. Please sign in again.",
+      },
+    };
+  }
+  if (!canEditSettings(session.role)) {
+    return {
+      refusal: {
+        ok: false as const,
+        code: "forbidden",
+        message: "You do not have permission to edit warehouses.",
+      },
+    };
+  }
+  return { session };
+}
+
+function refresh() {
+  revalidatePath("/settings/warehouses");
+  // The shipping page reads warehouses too — its readiness banner is
+  // computed from them, so a stale cache there would keep telling the
+  // merchant a carrier cannot quote after they just fixed the address.
+  revalidatePath("/settings/shipping");
+}
+
+export async function saveWarehouse(
+  id: string | null,
+  input: WarehouseWriteInput,
+): Promise<ActionResult> {
+  const { session, refusal } = await guard();
+  if (refusal) return refusal;
+
+  const creds = { userId: session.userId, tenantId: session.tenantId };
+  const result = id
+    ? await updateWarehouse(session.storeId, id, input, creds)
+    : await createWarehouse(session.storeId, input, creds);
+
+  if (!result.ok) {
+    return { ok: false, code: result.error.code, message: result.error.message };
+  }
+  refresh();
+  return { ok: true };
+}
+
+/**
+ * Remove is ONE verb by design. The API decides between deleting and
+ * archiving and reports which it did, so the merchant is told what
+ * happened instead of being asked to choose between two words for the
+ * same intent.
+ */
+export async function deleteWarehouse(
+  id: string,
+): Promise<ActionResult<WarehouseRemoval>> {
+  const { session, refusal } = await guard();
+  if (refusal) return refusal;
+
+  const result = await removeWarehouse(session.storeId, id, {
+    userId: session.userId,
+    tenantId: session.tenantId,
+  });
+  if (!result.ok) {
+    return { ok: false, code: result.error.code, message: result.error.message };
+  }
+  refresh();
+  return { ok: true, data: result.data };
+}
+
+export async function makeDefaultWarehouse(id: string): Promise<ActionResult> {
+  const { session, refusal } = await guard();
+  if (refusal) return refusal;
+
+  const result = await setDefaultWarehouse(session.storeId, id, {
+    userId: session.userId,
+    tenantId: session.tenantId,
+  });
+  if (!result.ok) {
+    return { ok: false, code: result.error.code, message: result.error.message };
+  }
+  refresh();
+  return { ok: true };
+}
+
+/** order must be the complete live set — see reorderWarehouses. */
+export async function reorderWarehouseList(
+  order: string[],
+): Promise<ActionResult> {
+  const { session, refusal } = await guard();
+  if (refusal) return refusal;
+
+  const result = await reorderWarehouses(session.storeId, order, {
+    userId: session.userId,
+    tenantId: session.tenantId,
+  });
+  if (!result.ok) {
+    return { ok: false, code: result.error.code, message: result.error.message };
+  }
+  refresh();
+  return { ok: true };
+}

--- a/apps/admin/app/(admin)/settings/warehouses/page.tsx
+++ b/apps/admin/app/(admin)/settings/warehouses/page.tsx
@@ -1,0 +1,69 @@
+import { AdminPage, ReadOnlyNotice } from "@/components/layout";
+import {
+  canEditSettings,
+  getServerSessionContext,
+} from "@/lib/auth/serverSession";
+import { listWarehouses } from "@/lib/api/warehouses-api";
+import { WarehousesSettingsClient } from "@/components/settings/WarehousesSettingsClient";
+
+/**
+ * /settings/warehouses — the store's pickup locations (#177 PR 5c).
+ *
+ * Deliberately its own page rather than a section of /settings/shipping: a
+ * warehouse belongs to the store, and every carrier ships from the same
+ * ones. Editing it inside a carrier card is what let a mistyped name
+ * create a second, stockless warehouse that quietly took allocations.
+ */
+export default async function WarehousesSettingsPage() {
+  const { role, tenantId, userId, currentStore } =
+    await getServerSessionContext();
+
+  const editable = canEditSettings(role);
+
+  return (
+    <AdminPage
+      eyebrow="Selling"
+      title="Warehouses"
+      description="The locations you ship from. Carriers quote rates from a warehouse address, and orders are allocated to them in the order listed here."
+      readOnlyNotice={!editable && role ? <ReadOnlyNotice role={role} /> : undefined}
+    >
+      {currentStore ? (
+        <WarehousesContent
+          storeId={currentStore.id}
+          userId={userId}
+          tenantId={tenantId}
+          editable={editable}
+          storeCountry={(currentStore.country_code ?? "").toUpperCase()}
+        />
+      ) : (
+        <p className="text-sm text-danger">
+          No store found. Please create a store before adding warehouses.
+        </p>
+      )}
+    </AdminPage>
+  );
+}
+
+async function WarehousesContent({
+  storeId,
+  userId,
+  tenantId,
+  editable,
+  storeCountry,
+}: {
+  storeId: string;
+  userId: string;
+  tenantId: string;
+  editable: boolean;
+  storeCountry: string;
+}) {
+  const warehouses = await listWarehouses(storeId, { userId, tenantId });
+
+  return (
+    <WarehousesSettingsClient
+      warehouses={warehouses}
+      editable={editable}
+      storeCountry={storeCountry}
+    />
+  );
+}

--- a/apps/admin/components/settings/WarehouseForm.tsx
+++ b/apps/admin/components/settings/WarehouseForm.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+// WarehouseForm — create/edit one warehouse (#177 PR 5c).
+//
+// Reuses AddressFieldset, the same component the carrier form used to
+// embed. The difference is where the address now LIVES: on the warehouse,
+// keyed by id, so a rename edits the row instead of forking a second,
+// stockless one that quietly takes allocations.
+
+import { useState, useTransition } from "react";
+
+import {
+  AddressFieldset,
+  EMPTY_ADDRESS,
+  type AddressValue,
+} from "@/components/forms/AddressFieldset";
+import type { Warehouse, WarehouseWriteInput } from "@/lib/api/warehouses-api";
+
+interface WarehouseFormProps {
+  /** Absent when creating. */
+  existing?: Warehouse;
+  storeCountry: string;
+  onSubmit: (input: WarehouseWriteInput) => Promise<{ ok: boolean; message?: string }>;
+  onCancel: () => void;
+}
+
+function toAddressValue(w: Warehouse | undefined): AddressValue {
+  if (!w) return EMPTY_ADDRESS;
+  return {
+    name: w.name,
+    line1: w.line1,
+    line2: w.line2 ?? "",
+    city: w.city,
+    region: w.region,
+    postal: w.postal_code,
+    country: w.country_code,
+    phone: w.phone,
+  };
+}
+
+export function WarehouseForm({
+  existing,
+  storeCountry,
+  onSubmit,
+  onCancel,
+}: WarehouseFormProps) {
+  const [address, setAddress] = useState<AddressValue>(toAddressValue(existing));
+  const [contactPerson, setContactPerson] = useState(existing?.contact_person ?? "");
+  const [email, setEmail] = useState(existing?.email ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  // Mirrors validateWarehouseWrite on the server. Checked here too so the
+  // merchant sees the rule at the field rather than as a round-tripped
+  // error — but the server remains the authority, and its message wins
+  // when the two ever disagree.
+  function localError(): string | null {
+    if (!address.name.trim()) return "Give this warehouse a name.";
+    if (!address.line1.trim()) return "Street address is required.";
+    if (!address.city.trim()) return "City is required.";
+    if (!address.postal.trim()) return "Postcode is required.";
+    if (address.country.trim().length !== 2) return "Select a country.";
+    // Not bureaucracy: a warehouse saved without a phone made every rate
+    // request fail with a bare "valid from zip code" and no cause (#508).
+    if (!address.phone.trim()) {
+      return "Add a phone number — carriers reject rate requests without one, and your storefront would show no delivery options.";
+    }
+    return null;
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const invalid = localError();
+    if (invalid) {
+      setError(invalid);
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      const result = await onSubmit({
+        name: address.name.trim(),
+        line1: address.line1.trim(),
+        line2: address.line2.trim() || undefined,
+        city: address.city.trim(),
+        region: address.region.trim() || undefined,
+        postal_code: address.postal.trim(),
+        country_code: address.country.trim().toUpperCase(),
+        phone: address.phone.trim(),
+        email: email.trim() || undefined,
+        contact_person: contactPerson.trim() || undefined,
+      });
+      if (!result.ok) {
+        setError(result.message ?? "Could not save this warehouse.");
+      }
+    });
+  }
+
+  const inputClass =
+    "w-full rounded-md border border-[color:var(--ink-900)]/10 bg-[color:var(--paper-200)] px-3 py-2 text-sm text-[color:var(--ink-900)] placeholder:text-[color:var(--ink-900)]/30 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:opacity-50";
+  const idPrefix = existing ? `wh-${existing.id}` : "wh-new";
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <AddressFieldset
+        value={address}
+        onChange={(next) => {
+          setAddress(next);
+          setError(null);
+        }}
+        defaultCountryCode={storeCountry}
+        lockCountry={Boolean(storeCountry)}
+        disabled={pending}
+        idPrefix={idPrefix}
+      />
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label
+            htmlFor={`${idPrefix}-contact`}
+            className="mb-1.5 block text-sm text-[color:var(--ink-900)]/70"
+          >
+            Contact person (optional)
+          </label>
+          <input
+            id={`${idPrefix}-contact`}
+            type="text"
+            value={contactPerson}
+            onChange={(e) => setContactPerson(e.target.value)}
+            disabled={pending}
+            className={inputClass}
+          />
+          <p className="mt-1 text-xs text-[color:var(--ink-900)]/40">
+            Who the courier asks for at pickup. Falls back to the warehouse
+            name.
+          </p>
+        </div>
+        <div>
+          <label
+            htmlFor={`${idPrefix}-email`}
+            className="mb-1.5 block text-sm text-[color:var(--ink-900)]/70"
+          >
+            Contact email (optional)
+          </label>
+          <input
+            id={`${idPrefix}-email`}
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={pending}
+            className={inputClass}
+          />
+        </div>
+      </div>
+
+      <div aria-live="polite">
+        {error && (
+          <div
+            role="alert"
+            className="rounded-md border border-[color:var(--danger)]/25 bg-[color:var(--danger)]/[0.06] px-4 py-2.5 text-sm text-[color:var(--danger)]"
+          >
+            {error}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md bg-[color:var(--ink-900)] px-4 py-2 text-sm font-medium text-[color:var(--primary-foreground)] transition-colors hover:bg-[color:var(--moss-700)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {pending ? "Saving..." : existing ? "Save changes" : "Add warehouse"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={pending}
+          className="rounded-md border border-[color:var(--ink-900)]/10 px-4 py-2 text-sm font-medium text-[color:var(--ink-900)]/70 transition-colors hover:bg-[color:var(--ink-900)]/[0.03] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:opacity-40"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/admin/components/settings/WarehousesSettingsClient.test.tsx
+++ b/apps/admin/components/settings/WarehousesSettingsClient.test.tsx
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { Warehouse } from "@/lib/api/warehouses-api";
+
+const saveWarehouse = vi.fn();
+const deleteWarehouse = vi.fn();
+const makeDefaultWarehouse = vi.fn();
+const reorderWarehouseList = vi.fn();
+const refresh = vi.fn();
+
+vi.mock("@/app/(admin)/settings/warehouses/actions", () => ({
+  saveWarehouse: (...args: unknown[]) => saveWarehouse(...args),
+  deleteWarehouse: (...args: unknown[]) => deleteWarehouse(...args),
+  makeDefaultWarehouse: (...args: unknown[]) => makeDefaultWarehouse(...args),
+  reorderWarehouseList: (...args: unknown[]) => reorderWarehouseList(...args),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+import { WarehousesSettingsClient } from "./WarehousesSettingsClient";
+
+function warehouse(overrides: Partial<Warehouse> = {}): Warehouse {
+  return {
+    id: "wh-1",
+    name: "Main Warehouse",
+    line1: "1 Campbell Parade",
+    city: "Bondi Beach",
+    region: "NSW",
+    postal_code: "2026",
+    country_code: "AU",
+    phone: "+61200000000",
+    is_default: true,
+    priority: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("WarehousesSettingsClient — removal", () => {
+  it("removing asks first and calls nothing until confirmed", async () => {
+    const user = userEvent.setup();
+    render(
+      <WarehousesSettingsClient
+        warehouses={[warehouse()]}
+        editable
+        storeCountry="AU"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+    expect(screen.getByText("Remove Main Warehouse?")).toBeInTheDocument();
+    expect(deleteWarehouse).not.toHaveBeenCalled();
+  });
+
+  // An archive reported as a delete would leave the merchant expecting the
+  // row to be gone from past orders, where it deliberately still appears —
+  // and, worse, unaware that its stock just became unsellable.
+  it("an archive says so, and names the stock it stranded", async () => {
+    const user = userEvent.setup();
+    deleteWarehouse.mockResolvedValue({
+      ok: true,
+      data: {
+        id: "wh-1",
+        outcome: "archived",
+        reason: "holds_stock",
+        units_remaining: 12,
+      },
+    });
+    render(
+      <WarehousesSettingsClient
+        warehouses={[warehouse()]}
+        editable
+        storeCountry="AU"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+    const buttons = screen.getAllByRole("button", { name: "Remove" });
+    await user.click(buttons[buttons.length - 1]);
+
+    const status = await screen.findByRole("status");
+    expect(status).toHaveTextContent("archived");
+    expect(status).toHaveTextContent("12 units");
+    expect(status).toHaveTextContent("can no longer be sold");
+  });
+
+  it("a plain delete does not claim anything was archived", async () => {
+    const user = userEvent.setup();
+    deleteWarehouse.mockResolvedValue({
+      ok: true,
+      data: { id: "wh-1", outcome: "deleted", units_remaining: 0 },
+    });
+    render(
+      <WarehousesSettingsClient
+        warehouses={[warehouse()]}
+        editable
+        storeCountry="AU"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+    const buttons = screen.getAllByRole("button", { name: "Remove" });
+    await user.click(buttons[buttons.length - 1]);
+
+    const status = await screen.findByRole("status");
+    expect(status).toHaveTextContent("was removed");
+    expect(status).not.toHaveTextContent("archived");
+  });
+
+  it("a failed removal surfaces the reason instead of looking successful", async () => {
+    const user = userEvent.setup();
+    deleteWarehouse.mockResolvedValue({
+      ok: false,
+      code: "forbidden",
+      message: "You do not have permission to edit warehouses.",
+    });
+    render(
+      <WarehousesSettingsClient
+        warehouses={[warehouse()]}
+        editable
+        storeCountry="AU"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+    const buttons = screen.getAllByRole("button", { name: "Remove" });
+    await user.click(buttons[buttons.length - 1]);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "You do not have permission",
+    );
+  });
+});
+
+describe("WarehousesSettingsClient — fill order", () => {
+  const two = [
+    warehouse({ id: "wh-1", name: "Alpha", priority: 0 }),
+    warehouse({ id: "wh-2", name: "Bravo", priority: 1, is_default: false }),
+  ];
+
+  // The API rejects a delta. Sending one would 400 every reorder.
+  it("moving one sends the COMPLETE reordered set", async () => {
+    const user = userEvent.setup();
+    reorderWarehouseList.mockResolvedValue({ ok: true });
+    render(
+      <WarehousesSettingsClient warehouses={two} editable storeCountry="AU" />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Move Bravo earlier in the fill order" }),
+    );
+
+    await waitFor(() => expect(reorderWarehouseList).toHaveBeenCalledTimes(1));
+    expect(reorderWarehouseList).toHaveBeenCalledWith(["wh-2", "wh-1"]);
+  });
+
+  it("the first warehouse cannot move up and the last cannot move down", () => {
+    render(
+      <WarehousesSettingsClient warehouses={two} editable storeCountry="AU" />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Move Alpha earlier in the fill order" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Move Bravo later in the fill order" }),
+    ).toBeDisabled();
+  });
+
+  // Reordering decides where an order ships from. Behind a drag handle it
+  // would be unreachable without a mouse.
+  it("reordering is done with real buttons, not drag-only affordances", () => {
+    render(
+      <WarehousesSettingsClient warehouses={two} editable storeCountry="AU" />,
+    );
+    expect(
+      screen.getAllByRole("button", { name: /fill order/ }),
+    ).toHaveLength(4);
+  });
+});
+
+describe("WarehousesSettingsClient — read-only", () => {
+  it("a viewer gets no write affordances at all", () => {
+    render(
+      <WarehousesSettingsClient
+        warehouses={[warehouse()]}
+        editable={false}
+        storeCountry="AU"
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Remove" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Add warehouse" })).toBeNull();
+  });
+
+  it("the empty state explains why a warehouse is needed", () => {
+    render(
+      <WarehousesSettingsClient warehouses={[]} editable storeCountry="AU" />,
+    );
+    expect(
+      screen.getByText(/Carriers cannot quote a rate without an origin address/),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/admin/components/settings/WarehousesSettingsClient.tsx
+++ b/apps/admin/components/settings/WarehousesSettingsClient.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+// WarehousesSettingsClient — the store's pickup locations (#177 PR 5c).
+//
+// List, add, edit, reorder, set default, remove. Ordering is not cosmetic:
+// the allocator fills warehouses in this order, so moving one to the top
+// changes which location ships an order.
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { AlertDialog } from "@tesserix/web";
+
+import type { Warehouse, WarehouseWriteInput } from "@/lib/api/warehouses-api";
+import { WarehouseForm } from "./WarehouseForm";
+import {
+  saveWarehouse,
+  deleteWarehouse,
+  makeDefaultWarehouse,
+  reorderWarehouseList,
+} from "@/app/(admin)/settings/warehouses/actions";
+
+interface WarehousesSettingsClientProps {
+  warehouses: Warehouse[];
+  editable: boolean;
+  storeCountry: string;
+}
+
+type Editing = { mode: "none" } | { mode: "new" } | { mode: "edit"; id: string };
+
+export function WarehousesSettingsClient({
+  warehouses,
+  editable,
+  storeCountry,
+}: WarehousesSettingsClientProps) {
+  const router = useRouter();
+  const [editing, setEditing] = useState<Editing>({ mode: "none" });
+  const [confirmRemove, setConfirmRemove] = useState<Warehouse | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function done(message?: string) {
+    setEditing({ mode: "none" });
+    setError(null);
+    if (message) setNotice(message);
+    router.refresh();
+  }
+
+  async function handleSave(id: string | null, input: WarehouseWriteInput) {
+    const result = await saveWarehouse(id, input);
+    if (!result.ok) return { ok: false, message: result.message };
+    done(id ? "Warehouse updated." : "Warehouse added.");
+    return { ok: true };
+  }
+
+  function handleRemoveConfirmed() {
+    const target = confirmRemove;
+    if (!target) return;
+    setConfirmRemove(null);
+    setError(null);
+    startTransition(async () => {
+      const result = await deleteWarehouse(target.id);
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      // Say which of the two things happened. An archive that reported
+      // itself as a delete would leave the merchant expecting the row to
+      // be gone from past orders, where it deliberately still appears.
+      const removal = result.data;
+      if (removal?.outcome === "archived") {
+        setNotice(
+          removal.units_remaining > 0
+            ? `${target.name} was archived because it has order history. ${removal.units_remaining} unit${removal.units_remaining === 1 ? "" : "s"} of stock stayed there and can no longer be sold — move it to another warehouse if you still need it.`
+            : `${target.name} was archived because it has order history. It stays on past orders but will not receive new ones.`,
+        );
+      } else {
+        setNotice(`${target.name} was removed.`);
+      }
+      router.refresh();
+    });
+  }
+
+  function handleMakeDefault(w: Warehouse) {
+    setError(null);
+    startTransition(async () => {
+      const result = await makeDefaultWarehouse(w.id);
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      setNotice(`${w.name} is now the default warehouse.`);
+      router.refresh();
+    });
+  }
+
+  // move sends the COMPLETE reordered set, which is what the API requires:
+  // a delta over a list that changed underneath reorders the wrong rows.
+  function move(index: number, direction: -1 | 1) {
+    const target = index + direction;
+    if (target < 0 || target >= warehouses.length) return;
+    const next = warehouses.map((w, i) => {
+      if (i === index) return warehouses[target] as Warehouse;
+      if (i === target) return warehouses[index] as Warehouse;
+      return w;
+    });
+
+    setError(null);
+    startTransition(async () => {
+      const result = await reorderWarehouseList(next.map((w) => w.id));
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  if (editing.mode === "new") {
+    return (
+      <section className="border-t border-border-subtle pt-8">
+        <h2 className="mb-6 font-serif text-xl text-[color:var(--ink-900)]">
+          Add a warehouse
+        </h2>
+        <WarehouseForm
+          storeCountry={storeCountry}
+          onSubmit={(input) => handleSave(null, input)}
+          onCancel={() => setEditing({ mode: "none" })}
+        />
+      </section>
+    );
+  }
+
+  if (editing.mode === "edit") {
+    const target = warehouses.find((w) => w.id === editing.id);
+    if (target) {
+      return (
+        <section className="border-t border-border-subtle pt-8">
+          <h2 className="mb-6 font-serif text-xl text-[color:var(--ink-900)]">
+            Edit {target.name}
+          </h2>
+          <WarehouseForm
+            existing={target}
+            storeCountry={storeCountry}
+            onSubmit={(input) => handleSave(target.id, input)}
+            onCancel={() => setEditing({ mode: "none" })}
+          />
+        </section>
+      );
+    }
+  }
+
+  return (
+    <section>
+      <div aria-live="polite" className="space-y-3">
+        {notice && (
+          <div
+            role="status"
+            className="rounded-md border border-[color:var(--moss-700)]/20 bg-[color:var(--moss-700)]/5 px-4 py-2.5 text-sm text-[color:var(--moss-700)]"
+          >
+            {notice}
+          </div>
+        )}
+        {error && (
+          <div
+            role="alert"
+            className="rounded-md border border-[color:var(--danger)]/25 bg-[color:var(--danger)]/[0.06] px-4 py-2.5 text-sm text-[color:var(--danger)]"
+          >
+            {error}
+          </div>
+        )}
+      </div>
+
+      {warehouses.length === 0 ? (
+        <div className="border-t border-border-subtle py-10">
+          <p className="text-sm text-foreground-tertiary">
+            No warehouses yet. Carriers cannot quote a rate without an origin
+            address, so add the location you ship from.
+          </p>
+          {editable && (
+            <button
+              type="button"
+              onClick={() => setEditing({ mode: "new" })}
+              className="mt-4 rounded-md bg-[color:var(--ink-900)] px-4 py-2 text-sm font-medium text-[color:var(--primary-foreground)] transition-colors hover:bg-[color:var(--moss-700)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]"
+            >
+              Add warehouse
+            </button>
+          )}
+        </div>
+      ) : (
+        <>
+          <ul className="mt-6 border-t border-border-subtle">
+            {warehouses.map((w, i) => (
+              <li
+                key={w.id}
+                className="flex flex-wrap items-start justify-between gap-4 border-b border-border-subtle py-5"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2.5">
+                    <h3 className="font-serif text-lg text-[color:var(--ink-900)]">
+                      {w.name}
+                    </h3>
+                    {w.is_default && (
+                      <span className="rounded-full bg-[color:var(--moss-700)]/10 px-2.5 py-0.5 text-xs font-medium text-[color:var(--moss-700)]">
+                        Default
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-1 text-sm text-foreground-secondary">
+                    {[w.line1, w.line2, w.city, w.region, w.postal_code, w.country_code]
+                      .filter(Boolean)
+                      .join(", ")}
+                  </p>
+                  <p className="mt-0.5 text-sm text-foreground-tertiary">{w.phone}</p>
+                </div>
+
+                {editable && (
+                  <div className="flex items-center gap-2">
+                    {warehouses.length > 1 && (
+                      <div className="flex items-center gap-1">
+                        <OrderButton
+                          label={`Move ${w.name} earlier in the fill order`}
+                          glyph="↑"
+                          disabled={pending || i === 0}
+                          onClick={() => move(i, -1)}
+                        />
+                        <OrderButton
+                          label={`Move ${w.name} later in the fill order`}
+                          glyph="↓"
+                          disabled={pending || i === warehouses.length - 1}
+                          onClick={() => move(i, 1)}
+                        />
+                      </div>
+                    )}
+                    {!w.is_default && (
+                      <SecondaryButton
+                        disabled={pending}
+                        onClick={() => handleMakeDefault(w)}
+                      >
+                        Make default
+                      </SecondaryButton>
+                    )}
+                    <SecondaryButton
+                      disabled={pending}
+                      onClick={() => setEditing({ mode: "edit", id: w.id })}
+                    >
+                      Edit
+                    </SecondaryButton>
+                    <button
+                      type="button"
+                      disabled={pending}
+                      onClick={() => setConfirmRemove(w)}
+                      className="rounded-md border border-[color:var(--ink-900)]/10 px-3 py-1.5 text-sm font-medium text-[color:var(--danger)] transition-colors hover:border-[color:var(--danger)]/30 hover:bg-[color:var(--danger)]/[0.04] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+
+          {warehouses.length > 1 && (
+            <p className="mt-4 text-xs text-foreground-tertiary">
+              Orders are allocated from the top of this list down. A warehouse
+              lower in the order is only used once the ones above it run out.
+            </p>
+          )}
+
+          {editable && (
+            <button
+              type="button"
+              onClick={() => setEditing({ mode: "new" })}
+              disabled={pending}
+              className="mt-6 rounded-md bg-[color:var(--ink-900)] px-4 py-2 text-sm font-medium text-[color:var(--primary-foreground)] transition-colors hover:bg-[color:var(--moss-700)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:opacity-40"
+            >
+              Add warehouse
+            </button>
+          )}
+        </>
+      )}
+
+      <AlertDialog
+        isOpen={confirmRemove !== null}
+        onClose={() => setConfirmRemove(null)}
+        title={confirmRemove ? `Remove ${confirmRemove.name}?` : ""}
+        message={
+          confirmRemove
+            ? "If this warehouse has shipped anything it is archived rather than deleted, so past orders keep their record of where they shipped from. Either way it stops receiving new orders."
+            : ""
+        }
+        type="confirm"
+        confirmLabel="Remove"
+        cancelLabel="Cancel"
+        onConfirm={handleRemoveConfirmed}
+        onCancel={() => setConfirmRemove(null)}
+      />
+    </section>
+  );
+}
+
+function SecondaryButton({
+  children,
+  disabled,
+  onClick,
+}: {
+  children: React.ReactNode;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className="rounded-md border border-[color:var(--ink-900)]/10 px-3 py-1.5 text-sm font-medium text-[color:var(--ink-900)]/70 transition-colors hover:bg-[color:var(--ink-900)]/[0.03] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-40"
+    >
+      {children}
+    </button>
+  );
+}
+
+// Reordering is keyboard-operable by construction: two real buttons with
+// spelled-out labels, not a drag handle. Drag-only reordering would put the
+// fill order — which decides where an order ships from — out of reach of
+// anyone not using a mouse.
+function OrderButton({
+  label,
+  glyph,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  glyph: string;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      disabled={disabled}
+      onClick={onClick}
+      className="rounded-md border border-[color:var(--ink-900)]/10 px-2 py-1.5 text-sm text-[color:var(--ink-900)]/60 transition-colors hover:bg-[color:var(--ink-900)]/[0.03] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-30"
+    >
+      <span aria-hidden="true">{glyph}</span>
+    </button>
+  );
+}

--- a/apps/admin/components/shell/AdminShell.tsx
+++ b/apps/admin/components/shell/AdminShell.tsx
@@ -148,6 +148,7 @@ const navigation: NavSection[] = [
       { group: "Store", label: "Domains", href: "/settings/domains" },
       { group: "Selling", label: "Payments", href: "/settings/payments" },
       { group: "Selling", label: "Shipping", href: "/settings/shipping" },
+      { group: "Selling", label: "Warehouses", href: "/settings/warehouses" },
       { group: "Team & access", label: "Team", href: "/settings/team" },
       { group: "Team & access", label: "Audit Logs", href: "/settings/audit-logs" },
       { group: "Account", label: "Account", href: "/settings/account" },
@@ -630,6 +631,9 @@ function getPageTitle(pathname: string | null): {
   }
   if (pathname.startsWith("/settings/shipping")) {
     return { eyebrow: "Selling", title: "Shipping" };
+  }
+  if (pathname.startsWith("/settings/warehouses")) {
+    return { eyebrow: "Selling", title: "Warehouses" };
   }
   if (pathname.startsWith("/settings/team")) {
     return { eyebrow: "Team & access", title: "Team" };

--- a/apps/admin/lib/api/warehouses-api.ts
+++ b/apps/admin/lib/api/warehouses-api.ts
@@ -1,0 +1,244 @@
+// apps/admin/lib/api/warehouses-api.ts
+//
+// Typed client for the per-store warehouse endpoints (#177 PR 5b).
+//
+// Warehouses live OUTSIDE /settings on the backend, and deliberately so: a
+// warehouse is a property of the store, not of a carrier account. Burying it
+// under a carrier's settings is exactly how it became a side effect of the
+// shipping form, where a mistyped name silently created a second, stockless
+// warehouse and the orders it was picked for never shipped.
+
+import type {
+  SessionHeaders,
+  MutationResult,
+  MutationError,
+} from "./marketplace-api";
+
+const MARKETPLACE_API_URL =
+  process.env.MARKETPLACE_API_URL ?? "http://localhost:8088";
+
+const MARKETPLACE_INTERNAL_AUTH =
+  process.env.MARKETPLACE_INTERNAL_AUTH_SECRET ?? "";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Wire DTOs — match WarehouseResponse in internal/handlers/admin/warehouses.go
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface Warehouse {
+  id: string;
+  name: string;
+  line1: string;
+  line2?: string;
+  city: string;
+  region: string;
+  postal_code: string;
+  country_code: string;
+  phone: string;
+  email?: string;
+  contact_person?: string;
+  is_default: boolean;
+  priority: number;
+  archived_at?: string;
+}
+
+export interface WarehouseWriteInput {
+  name: string;
+  line1: string;
+  line2?: string;
+  city: string;
+  region?: string;
+  postal_code: string;
+  country_code: string;
+  phone: string;
+  email?: string;
+  contact_person?: string;
+}
+
+/**
+ * What DELETE actually did.
+ *
+ * The API decides between deleting and archiving so the merchant does not
+ * have to — a warehouse with allocation history can never be deleted
+ * (order_allocations.warehouse_id is ON DELETE RESTRICT), and one holding
+ * stock would otherwise be permanently unremovable. `units_remaining` is
+ * the number of units the archive just stranded: archiving does not move
+ * stock, and those units stop being sellable the moment the allocator
+ * skips the row.
+ */
+export interface WarehouseRemoval {
+  id: string;
+  outcome: "deleted" | "archived";
+  reason?: "holds_stock" | "unshipped_parcel" | "allocation_history";
+  units_remaining: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers — same conventions as settings-api.ts
+// ─────────────────────────────────────────────────────────────────────────
+
+function readHeaders(session: SessionHeaders): HeadersInit {
+  const headers: Record<string, string> = {
+    "X-User-Id": session.userId,
+    "X-Tenant-Id": session.tenantId,
+    Accept: "application/json",
+  };
+  if (MARKETPLACE_INTERNAL_AUTH) {
+    headers["X-Internal-Auth"] = MARKETPLACE_INTERNAL_AUTH;
+  }
+  return headers;
+}
+
+function writeHeaders(session: SessionHeaders): HeadersInit {
+  return { ...readHeaders(session), "Content-Type": "application/json" };
+}
+
+interface ApiError {
+  error: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+async function parseMutationError(res: Response): Promise<MutationError> {
+  const body = (await res.json().catch(() => null)) as ApiError | null;
+  return {
+    code: body?.error ?? "unknown_error",
+    message: body?.message ?? `marketplace-api returned ${res.status}`,
+    field:
+      typeof body?.details?.field === "string"
+        ? (body.details.field as string)
+        : undefined,
+    details: body?.details,
+  };
+}
+
+function warehousesUrl(storeId: string, path = ""): string {
+  return `${MARKETPLACE_API_URL}/api/v1/admin/stores/${storeId}/warehouses${path}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Reads
+// ─────────────────────────────────────────────────────────────────────────
+
+export async function listWarehouses(
+  storeId: string,
+  session: SessionHeaders,
+): Promise<Warehouse[]> {
+  const res = await fetch(warehousesUrl(storeId), {
+    cache: "no-store",
+    headers: readHeaders(session),
+  });
+  if (res.status === 401 || res.status === 403 || res.status === 404) {
+    return [];
+  }
+  if (!res.ok) {
+    throw new Error(`marketplace-api: listWarehouses ${res.status}`);
+  }
+  const body = (await res.json()) as { data: Warehouse[] };
+  return body.data ?? [];
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Writes
+//
+// Every one of these goes through writeHeaders — including the DELETE.
+// A hand-rolled header literal on a DELETE is what made removing a payment
+// or shipping config 401 for months while the UI showed nothing (#523).
+// ─────────────────────────────────────────────────────────────────────────
+
+export async function createWarehouse(
+  storeId: string,
+  input: WarehouseWriteInput,
+  session: SessionHeaders,
+): Promise<MutationResult<Warehouse>> {
+  const res = await fetch(warehousesUrl(storeId), {
+    method: "POST",
+    cache: "no-store",
+    headers: writeHeaders(session),
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    return { ok: false, error: await parseMutationError(res) };
+  }
+  const body = (await res.json()) as { data: Warehouse };
+  return { ok: true, data: body.data };
+}
+
+export async function updateWarehouse(
+  storeId: string,
+  id: string,
+  input: WarehouseWriteInput,
+  session: SessionHeaders,
+): Promise<MutationResult<Warehouse>> {
+  const res = await fetch(warehousesUrl(storeId, `/${encodeURIComponent(id)}`), {
+    method: "PATCH",
+    cache: "no-store",
+    headers: writeHeaders(session),
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    return { ok: false, error: await parseMutationError(res) };
+  }
+  const body = (await res.json()) as { data: Warehouse };
+  return { ok: true, data: body.data };
+}
+
+export async function removeWarehouse(
+  storeId: string,
+  id: string,
+  session: SessionHeaders,
+): Promise<MutationResult<WarehouseRemoval>> {
+  const res = await fetch(warehousesUrl(storeId, `/${encodeURIComponent(id)}`), {
+    method: "DELETE",
+    cache: "no-store",
+    headers: writeHeaders(session),
+  });
+  if (!res.ok) {
+    return { ok: false, error: await parseMutationError(res) };
+  }
+  const body = (await res.json()) as { data: WarehouseRemoval };
+  return { ok: true, data: body.data };
+}
+
+export async function setDefaultWarehouse(
+  storeId: string,
+  id: string,
+  session: SessionHeaders,
+): Promise<MutationResult<Warehouse>> {
+  const res = await fetch(
+    warehousesUrl(storeId, `/${encodeURIComponent(id)}/default`),
+    {
+      method: "PUT",
+      cache: "no-store",
+      headers: writeHeaders(session),
+    },
+  );
+  if (!res.ok) {
+    return { ok: false, error: await parseMutationError(res) };
+  }
+  const body = (await res.json()) as { data: Warehouse };
+  return { ok: true, data: body.data };
+}
+
+/**
+ * Reorder takes the COMPLETE ordered set of live warehouse ids, not a
+ * delta — the backend rejects anything else with a 400. A delta applied to
+ * a list that changed underneath (a warehouse archived in another tab)
+ * reorders the wrong rows and the caller never finds out.
+ */
+export async function reorderWarehouses(
+  storeId: string,
+  order: string[],
+  session: SessionHeaders,
+): Promise<MutationResult<Warehouse[]>> {
+  const res = await fetch(warehousesUrl(storeId, "/reorder"), {
+    method: "PUT",
+    cache: "no-store",
+    headers: writeHeaders(session),
+    body: JSON.stringify({ order }),
+  });
+  if (!res.ok) {
+    return { ok: false, error: await parseMutationError(res) };
+  }
+  const body = (await res.json()) as { data: Warehouse[] };
+  return { ok: true, data: body.data };
+}


### PR DESCRIPTION
Refs #177. Builds on #530 (5b's API), now on `main`.

A new `/settings/warehouses` page, and a nav entry under **Selling** next to Shipping. Its own page, not a section of `/settings/shipping`, for the reason the whole issue exists: a warehouse belongs to the *store*, every carrier ships from the same ones, and editing it inside a carrier card is what let a mistyped name create a second, stockless warehouse that quietly took allocations.

## What the merchant can do

Add, edit, reorder, set default, remove. Empty state says *why* a warehouse is needed — carriers cannot quote a rate without an origin address — rather than just noting the list is empty.

**Ordering is not cosmetic and the page says so.** The allocator fills warehouses top-down, so the list carries a line explaining that a warehouse lower in the order is only used once the ones above it run out.

**Reordering uses two real buttons, not a drag handle.** Dragging alone would put the decision of *where an order ships from* out of reach of anyone not using a mouse. Each button's accessible name spells out the effect ("Move Bravo earlier in the fill order"), and a test pins that they are buttons.

**Removal is one verb.** The page calls DELETE and reports what the API decided, because the merchant asked for one thing. An archive is announced as an archive, and when it stranded stock it says how much: "12 units of stock stayed there and can no longer be sold" — true as of #528, where the allocator started skipping archived rows. An archive silently reported as a delete would leave the merchant expecting the row gone from past orders (it deliberately isn't) and unaware their stock just became unsellable.

## Validation

`WarehouseForm` mirrors the server's `validateWarehouseWrite`, including the phone requirement — a warehouse saved without one made every ShipEngine quote fail with a bare "valid from zip code" and no cause (#508). Mirrored so the merchant sees the rule at the field instead of as a round trip; the server stays the authority. The address inputs are the existing `AddressFieldset`, the same component the carrier form embeds today — 5d is where that form loses it.

## Tests

9 tests in `WarehousesSettingsClient.test.tsx`. Three mutations, each confirmed to **compile** first:

| mutation | caught by |
|---|---|
| reorder sends a delta instead of the full set | `moving one sends the COMPLETE reordered set` (1 fail) |
| `outcome` compared against the wrong value, so an archive reports as a plain removal | 2 fails |
| Remove deletes immediately with no confirmation | 3 fails |

A fourth mutation — calling `handleRemoveConfirmed()` alongside `setConfirmRemove` — survived, but on inspection it is a no-op rather than an untested gap: React has not committed the state yet, so the handler reads `null` and returns. Replaced with the mutation above, which actually bypasses the dialog and does fail.

`vitest run` across the whole admin app: **105 files, 826 tests, all passing.** `tsc --noEmit` clean.

## One thing I could not verify locally

`next build` fails on this machine at `@tesserix/otto-widget` — a pre-existing missing workspace dependency that also breaks `tsc` on `main` and is unrelated to this change (it hits `components/support/LiveChatInbox.tsx` and `PlatformChat.tsx`). CI's Next.js job builds it fine, so the check on this PR is the real signal.

**This page has not been exercised in the running product yet.** Every seam bug last session had passing unit tests, so treat the green suite as necessary and not sufficient — I would like to drive it once on the deployed admin before 5d.

## Not in scope

5d (carrier form drops `AddressFieldset`, gains a warehouse picker, and deletes `lib/settings/warehouse-validation.ts`) and 5e (per-location stock).