### PR TITLE
feat(product): per-warehouse stock, end to end (#177 PR 5e)

### DIFF
--- a/apps/admin/app/(admin)/products/[id]/page.tsx
+++ b/apps/admin/app/(admin)/products/[id]/page.tsx
@@ -7,6 +7,7 @@ import { notFound } from "next/navigation";
 
 import { getServerSessionContext } from "@/lib/auth/serverSession";
 import { getProduct, listCategories } from "@/lib/api/marketplace-api";
+import { listWarehouses } from "@/lib/api/warehouses-api";
 import { Breadcrumbs } from "@/components/layout";
 import { ProductForm } from "@/components/products/ProductForm";
 
@@ -23,9 +24,12 @@ export default async function ProductDetailPage({ params }: PageProps) {
     notFound();
   }
 
-  const [product, categories] = await Promise.all([
+  const [product, categories, warehouses] = await Promise.all([
     getProduct(currentStore.id, id, { userId, tenantId }),
     listCategories(currentStore.id, { userId, tenantId }),
+    // Drives the per-warehouse stock editor (#177 PR 5e). With fewer than
+    // two the form renders exactly as it did before.
+    listWarehouses(currentStore.id, { userId, tenantId }),
   ]);
 
   if (!product) {
@@ -51,6 +55,7 @@ export default async function ProductDetailPage({ params }: PageProps) {
         canArchive={role === "owner" || role === "admin"}
         session={{ userId, tenantId }}
         storeSlug={currentStore.slug}
+        warehouses={warehouses}
       />
     </main>
   );

--- a/apps/admin/app/(admin)/products/actions.ts
+++ b/apps/admin/app/(admin)/products/actions.ts
@@ -24,6 +24,7 @@ import {
   getProduct,
   type CreateProductRequest,
   type UpdateProductRequest,
+  setVariantStockByLocation,
 } from "@/lib/api/marketplace-api";
 import { productFormSchema, type ProductFormValues } from "@/lib/validation/product-form";
 import { bulkActionSchema } from "@/lib/validation/bulk-action";
@@ -423,4 +424,43 @@ export async function bulkAssignCategoryAction(
   categoryIds: string[],
 ): Promise<BulkActionResult> {
   return executeBulkAction(storeId, "assign_category", productIds, { category_ids: categoryIds });
+}
+
+/**
+ * saveVariantStockByLocation writes one variant's per-warehouse stock
+ * (#177 PR 5e).
+ *
+ * Separate from the product save on purpose. A store with ONE warehouse
+ * keeps the single Stock field and the existing save path untouched —
+ * that is the spec's rule, and routing it through here too would change
+ * behaviour for every merchant who has no second location.
+ */
+export async function saveVariantStockByLocation(
+  storeId: string,
+  productId: string,
+  variantId: string,
+  byLocation: Record<string, number>,
+): Promise<ActionResult> {
+  const ctx = await readContext(storeId, "");
+  if (!ctx) {
+    return {
+      ok: false,
+      error: { code: "no_session", message: "Session expired. Please sign in again." },
+    };
+  }
+
+  const result = await setVariantStockByLocation(
+    storeId,
+    productId,
+    variantId,
+    byLocation,
+    { userId: ctx.userId, tenantId: ctx.tenantId, email: ctx.email },
+  );
+  if (!result.ok) {
+    return { ok: false, error: result.error };
+  }
+
+  revalidatePath("/products");
+  revalidatePath(`/products/${productId}`);
+  return { ok: true };
 }

--- a/apps/admin/components/products/ProductForm.tsx
+++ b/apps/admin/components/products/ProductForm.tsx
@@ -50,6 +50,7 @@ import {
   type ProductFormTabId,
 } from "./form/ProductFormTabs";
 import { GeneralTab } from "./form/GeneralTab";
+import type { Warehouse } from "@/lib/api/warehouses-api";
 import { OptionsTab } from "./form/OptionsTab";
 import { VariantsTab } from "./form/VariantsTab";
 import { MediaTab } from "./form/MediaTab";
@@ -74,6 +75,12 @@ export interface ProductFormProps {
   canArchive: boolean;
   session: SessionHeaders;
   storeSlug?: string;
+  /**
+   * The store's live warehouses (#177 PR 5e). Empty or one keeps the
+   * single Stock field and the ordinary product save — a store with one
+   * warehouse must see exactly what it saw before.
+   */
+  warehouses?: Warehouse[];
 }
 
 export function ProductForm({
@@ -86,6 +93,7 @@ export function ProductForm({
   canDelete,
   session,
   storeSlug,
+  warehouses = [],
 }: ProductFormProps) {
   const router = useRouter();
   const { toast } = useToast();
@@ -450,6 +458,10 @@ export function ProductForm({
               currencyCode={currencyCode}
               hasMultipleVariants={hasMultipleVariants}
               storeId={storeId}
+              warehouses={warehouses}
+              productId={initialProduct?.id}
+              variantId={firstVariant?.id}
+              stockByLocation={firstVariant?.inventory_by_location ?? {}}
             />
           )}
           {currentTab === "media" && mode === "edit" && initialProduct && (

--- a/apps/admin/components/products/form/GeneralTab.StockField.test.tsx
+++ b/apps/admin/components/products/form/GeneralTab.StockField.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+
+import type { Warehouse } from "@/lib/api/warehouses-api";
+import type { ProductFormValues } from "@/lib/validation/product-form";
+
+vi.mock("@/app/(admin)/products/actions", () => ({
+  saveVariantStockByLocation: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+vi.mock("../ProductCategoriesPicker", () => ({
+  ProductCategoriesPicker: () => null,
+}));
+
+import { GeneralTab, type GeneralTabProps } from "./GeneralTab";
+
+function warehouse(id: string, name: string): Warehouse {
+  return {
+    id, name, line1: "1 Dock Rd", city: "Bondi Beach", region: "NSW",
+    postal_code: "2026", country_code: "AU", phone: "+61200000000",
+    is_default: false, priority: 0,
+  };
+}
+
+function Harness(props: Partial<GeneralTabProps>) {
+  const methods = useForm<ProductFormValues>({
+    defaultValues: {
+      title: "", handle: "", description: "", status: "draft",
+      price: "10", inventoryQuantity: "7", alwaysInStock: false, sku: "",
+      weightKg: "1", lengthCm: "", widthCm: "", heightCm: "",
+      categoryIds: [], options: [], variants: [],
+    } as unknown as ProductFormValues,
+  });
+  return (
+    <FormProvider {...methods}>
+      <GeneralTab
+        mode="edit"
+        categories={[]}
+        currencyCode="AUD"
+        hasMultipleVariants={false}
+        storeId="store-1"
+        productId="prod-1"
+        variantId="var-1"
+        {...props}
+      />
+    </FormProvider>
+  );
+}
+
+// The spec's rule for this slice, stated as a test: a store with one
+// warehouse must see EXACTLY what it saw before. Anything else is a
+// regression for every merchant who has not added a second location.
+describe("GeneralTab — stock field", () => {
+  it("one warehouse keeps the single Stock field and no per-warehouse editor", () => {
+    render(<Harness warehouses={[warehouse("wh-1", "Main")]} />);
+
+    expect(screen.getByLabelText("Stock")).toHaveValue("7");
+    expect(screen.queryByText(/Stock by warehouse/i)).toBeNull();
+  });
+
+  it("no warehouses at all also keeps the single field", () => {
+    render(<Harness warehouses={[]} />);
+
+    expect(screen.getByLabelText("Stock")).toHaveValue("7");
+    expect(screen.queryByText(/Stock by warehouse/i)).toBeNull();
+  });
+
+  it("two warehouses replace the single field with the per-warehouse editor", () => {
+    render(
+      <Harness
+        warehouses={[warehouse("wh-1", "Main"), warehouse("wh-2", "Overflow")]}
+        stockByLocation={{ "wh-1": 4, "wh-2": 3 }}
+      />,
+    );
+
+    expect(screen.queryByLabelText("Stock")).toBeNull();
+    expect(screen.getByText(/Stock by warehouse/i)).toBeInTheDocument();
+  });
+
+  // On create there is no saved variant to write against, so the split
+  // has to wait until the product exists.
+  it("create mode keeps the single field even with two warehouses", () => {
+    render(
+      <Harness
+        mode="create"
+        productId={undefined}
+        variantId={undefined}
+        warehouses={[warehouse("wh-1", "Main"), warehouse("wh-2", "Overflow")]}
+      />,
+    );
+
+    expect(screen.getByLabelText("Stock")).toHaveValue("7");
+    expect(screen.queryByText(/Stock by warehouse/i)).toBeNull();
+  });
+});

--- a/apps/admin/components/products/form/GeneralTab.tsx
+++ b/apps/admin/components/products/form/GeneralTab.tsx
@@ -13,6 +13,8 @@ import type { ProductFormValues } from "@/lib/validation/product-form";
 import { ProductCategoriesPicker } from "../ProductCategoriesPicker";
 import { Field } from "./Field";
 import { isUsableWeight } from "@/lib/products/usable-weight";
+import type { Warehouse } from "@/lib/api/warehouses-api";
+import { VariantStockByWarehouse } from "./VariantStockByWarehouse";
 
 export interface GeneralTabProps {
   mode: "create" | "edit";
@@ -20,6 +22,17 @@ export interface GeneralTabProps {
   currencyCode: string;
   hasMultipleVariants: boolean;
   storeId?: string;
+  /**
+   * The store's live warehouses (#177 PR 5e). With fewer than two, the
+   * single Stock field below stays exactly as it was — a store with one
+   * warehouse must see no change at all.
+   */
+  warehouses?: Warehouse[];
+  /** Set on edit only — the per-warehouse editor saves against a real variant. */
+  productId?: string;
+  variantId?: string;
+  /** Current per-warehouse breakdown for that variant. */
+  stockByLocation?: Record<string, number>;
 }
 
 export function GeneralTab({
@@ -28,6 +41,10 @@ export function GeneralTab({
   currencyCode,
   hasMultipleVariants,
   storeId,
+  warehouses = [],
+  productId,
+  variantId,
+  stockByLocation = {},
 }: GeneralTabProps) {
   const form = useFormContext<ProductFormValues>();
   const { register, formState, watch, setValue } = form;
@@ -36,6 +53,16 @@ export function GeneralTab({
   // weight" — each ends up as the fallback at checkout.
   const weightKgValue = watch("weightKg");
   const isWeightMissing = !isUsableWeight(weightKgValue);
+
+  // Per-warehouse stock replaces the single field only when there is an
+  // actual choice to make AND a saved variant to write against. On create
+  // there is no variant id yet, so the single field stays and the merchant
+  // splits the stock after the product exists.
+  const perWarehouseStock =
+    warehouses.length > 1 &&
+    mode === "edit" &&
+    !hasMultipleVariants &&
+    Boolean(storeId && productId && variantId);
 
   return (
     <div className="flex flex-col gap-8">
@@ -125,18 +152,20 @@ export function GeneralTab({
               className="w-full rounded-md border border-[color:var(--ink-900)] border-opacity-20 bg-[color:var(--background-elevated,white)] px-3 py-2 text-sm text-[color:var(--ink-900)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]"
             />
           </Field>
-          <Field
-            label="Stock"
-            error={formState.errors.inventoryQuantity?.message}
-          >
-            <input
-              type="text"
-              inputMode="numeric"
-              placeholder="0"
-              {...register("inventoryQuantity")}
-              className="w-full rounded-md border border-[color:var(--ink-900)] border-opacity-20 bg-[color:var(--background-elevated,white)] px-3 py-2 text-sm text-[color:var(--ink-900)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]"
-            />
-          </Field>
+          {!perWarehouseStock && (
+            <Field
+              label="Stock"
+              error={formState.errors.inventoryQuantity?.message}
+            >
+              <input
+                type="text"
+                inputMode="numeric"
+                placeholder="0"
+                {...register("inventoryQuantity")}
+                className="w-full rounded-md border border-[color:var(--ink-900)] border-opacity-20 bg-[color:var(--background-elevated,white)] px-3 py-2 text-sm text-[color:var(--ink-900)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]"
+              />
+            </Field>
+          )}
           <Field label="SKU" error={formState.errors.sku?.message}>
             <input
               type="text"
@@ -146,6 +175,16 @@ export function GeneralTab({
             />
           </Field>
         </div>
+      )}
+
+      {perWarehouseStock && storeId && productId && variantId && (
+        <VariantStockByWarehouse
+          storeId={storeId}
+          productId={productId}
+          variantId={variantId}
+          warehouses={warehouses}
+          byLocation={stockByLocation}
+        />
       )}
 
       {!hasMultipleVariants && (

--- a/apps/admin/components/products/form/VariantStockByWarehouse.test.tsx
+++ b/apps/admin/components/products/form/VariantStockByWarehouse.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { Warehouse } from "@/lib/api/warehouses-api";
+import { SENTINEL_LOCATION_ID } from "@/lib/api/marketplace-api";
+
+const saveVariantStockByLocation = vi.fn();
+const refresh = vi.fn();
+
+vi.mock("@/app/(admin)/products/actions", () => ({
+  saveVariantStockByLocation: (...args: unknown[]) =>
+    saveVariantStockByLocation(...args),
+}));
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh }) }));
+
+import { VariantStockByWarehouse } from "./VariantStockByWarehouse";
+
+function warehouse(id: string, name: string): Warehouse {
+  return {
+    id,
+    name,
+    line1: "1 Dock Rd",
+    city: "Bondi Beach",
+    region: "NSW",
+    postal_code: "2026",
+    country_code: "AU",
+    phone: "+61200000000",
+    is_default: id === "wh-1",
+    priority: 0,
+  };
+}
+
+const two = [warehouse("wh-1", "Main"), warehouse("wh-2", "Overflow")];
+
+function renderEditor(byLocation: Record<string, number>) {
+  render(
+    <VariantStockByWarehouse
+      storeId="store-1"
+      productId="prod-1"
+      variantId="var-1"
+      warehouses={two}
+      byLocation={byLocation}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  saveVariantStockByLocation.mockResolvedValue({ ok: true });
+});
+
+describe("VariantStockByWarehouse", () => {
+  it("shows one input per warehouse, seeded from the current breakdown", () => {
+    renderEditor({ "wh-1": 10, "wh-2": 5 });
+
+    expect(screen.getByLabelText(/Main/)).toHaveValue("10");
+    expect(screen.getByLabelText(/Overflow/)).toHaveValue("5");
+  });
+
+  it("the total is the sum, and follows edits", async () => {
+    const user = userEvent.setup();
+    renderEditor({ "wh-1": 10, "wh-2": 5 });
+    expect(screen.getByText("15")).toBeInTheDocument();
+
+    const main = screen.getByLabelText(/Main/);
+    await user.clear(main);
+    await user.type(main, "20");
+
+    expect(screen.getByText("25")).toBeInTheDocument();
+  });
+
+  // Units on the sentinel are not at any warehouse yet. Folding them
+  // silently into the first one would record stock somewhere the merchant
+  // never said it was.
+  it("calls out unassigned sentinel units without pre-filling them anywhere", () => {
+    renderEditor({ [SENTINEL_LOCATION_ID]: 12 });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "12 units not yet assigned",
+    );
+    expect(screen.getByLabelText(/Main/)).toHaveValue("0");
+    expect(screen.getByLabelText(/Overflow/)).toHaveValue("0");
+  });
+
+  it("says nothing about unassigned units when there are none", () => {
+    renderEditor({ "wh-1": 10 });
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("saves the complete map, including zeroes", async () => {
+    const user = userEvent.setup();
+    renderEditor({ [SENTINEL_LOCATION_ID]: 12 });
+
+    const main = screen.getByLabelText(/Main/);
+    await user.clear(main);
+    await user.type(main, "12");
+    await user.click(screen.getByRole("button", { name: /save stock/i }));
+
+    await waitFor(() => expect(saveVariantStockByLocation).toHaveBeenCalled());
+    expect(saveVariantStockByLocation).toHaveBeenCalledWith(
+      "store-1",
+      "prod-1",
+      "var-1",
+      { "wh-1": 12, "wh-2": 0 },
+    );
+  });
+
+  it("refuses a negative quantity and sends nothing", async () => {
+    const user = userEvent.setup();
+    renderEditor({ "wh-1": 10, "wh-2": 5 });
+
+    const main = screen.getByLabelText(/Main/);
+    await user.clear(main);
+    await user.type(main, "-3");
+    await user.click(screen.getByRole("button", { name: /save stock/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "whole number, zero or more",
+    );
+    expect(saveVariantStockByLocation).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a failed save instead of reporting success", async () => {
+    const user = userEvent.setup();
+    saveVariantStockByLocation.mockResolvedValue({
+      ok: false,
+      error: { code: "validation_failed", message: "unknown or archived warehouse" },
+    });
+    renderEditor({ "wh-1": 10, "wh-2": 5 });
+
+    await user.click(screen.getByRole("button", { name: /save stock/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "unknown or archived warehouse",
+    );
+    expect(screen.queryByText("Stock saved.")).toBeNull();
+  });
+});

--- a/apps/admin/components/products/form/VariantStockByWarehouse.tsx
+++ b/apps/admin/components/products/form/VariantStockByWarehouse.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+// VariantStockByWarehouse — per-warehouse stock for one variant
+// (#177 PR 5e).
+//
+// Only rendered once a store has TWO OR MORE warehouses. With one, the
+// merchant keeps the single Stock field and the ordinary product save,
+// untouched: a store with one warehouse must see exactly what it saw
+// before this slice, and "which of your one locations?" is not a question
+// worth asking.
+//
+// Saving here is its own action rather than part of the product save,
+// because the backend conserves the total by clearing the variant's
+// sentinel row in the same transaction — see SetVariantStockByLocationInTx.
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { SENTINEL_LOCATION_ID } from "@/lib/api/marketplace-api";
+import type { Warehouse } from "@/lib/api/warehouses-api";
+import { saveVariantStockByLocation } from "@/app/(admin)/products/actions";
+
+interface VariantStockByWarehouseProps {
+  storeId: string;
+  productId: string;
+  variantId: string;
+  warehouses: Warehouse[];
+  /** Current breakdown from the product detail response. */
+  byLocation: Record<string, number>;
+}
+
+export function VariantStockByWarehouse({
+  storeId,
+  productId,
+  variantId,
+  warehouses,
+  byLocation,
+}: VariantStockByWarehouseProps) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  // Units still on the sentinel are not at any warehouse yet. They are
+  // shown, not silently folded into the first one: the merchant is about
+  // to decide where they actually are, and pre-filling that decision with
+  // a guess is how stock ends up recorded in the wrong place.
+  const unassigned = byLocation[SENTINEL_LOCATION_ID] ?? 0;
+
+  const [draft, setDraft] = useState<Record<string, string>>(() => {
+    const initial: Record<string, string> = {};
+    for (const w of warehouses) {
+      initial[w.id] = String(byLocation[w.id] ?? 0);
+    }
+    return initial;
+  });
+
+  const total = useMemo(
+    () =>
+      warehouses.reduce((sum, w) => {
+        const n = Number.parseInt(draft[w.id] ?? "0", 10);
+        return sum + (Number.isFinite(n) ? n : 0);
+      }, 0),
+    [draft, warehouses],
+  );
+
+  function handleSave() {
+    setError(null);
+    setSaved(false);
+
+    const byWarehouse: Record<string, number> = {};
+    for (const w of warehouses) {
+      const n = Number.parseInt(draft[w.id] ?? "0", 10);
+      if (!Number.isFinite(n) || n < 0) {
+        setError(`${w.name} needs a whole number, zero or more.`);
+        return;
+      }
+      byWarehouse[w.id] = n;
+    }
+
+    startTransition(async () => {
+      const result = await saveVariantStockByLocation(
+        storeId,
+        productId,
+        variantId,
+        byWarehouse,
+      );
+      if (!result.ok) {
+        setError(result.error?.message ?? "Could not save stock.");
+        return;
+      }
+      setSaved(true);
+      router.refresh();
+    });
+  }
+
+  const inputClass =
+    "w-28 rounded-md border border-[color:var(--ink-900)] border-opacity-20 bg-[color:var(--background-elevated,white)] px-3 py-2 text-sm text-[color:var(--ink-900)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]";
+
+  return (
+    <section className="space-y-4">
+      <div className="space-y-1">
+        <h3 className="text-sm font-medium text-[color:var(--ink-900)]">
+          Stock by warehouse
+        </h3>
+        <p className="text-xs text-[color:var(--ink-900)] opacity-60">
+          Orders are filled from your warehouses in the order set on the
+          Shipping page.
+        </p>
+      </div>
+
+      {unassigned > 0 && (
+        <div
+          role="status"
+          className="rounded-md border border-[color:var(--warning)]/30 bg-[color:var(--warning)]/[0.05] px-4 py-3 text-sm text-[color:var(--ink-900)]"
+        >
+          <strong className="font-medium">
+            {unassigned} unit{unassigned === 1 ? "" : "s"} not yet assigned to a
+            warehouse.
+          </strong>{" "}
+          They are still sellable, but nothing knows where they are. Set the
+          numbers below and save to place them — the totals replace the
+          unassigned count rather than adding to it.
+        </div>
+      )}
+
+      <ul className="space-y-3">
+        {warehouses.map((w) => (
+          <li key={w.id} className="flex items-center justify-between gap-4">
+            <label
+              htmlFor={`stock-${variantId}-${w.id}`}
+              className="min-w-0 text-sm text-[color:var(--ink-900)]"
+            >
+              {w.name}
+              <span className="ml-2 opacity-50">{w.city}</span>
+            </label>
+            <input
+              id={`stock-${variantId}-${w.id}`}
+              type="text"
+              inputMode="numeric"
+              value={draft[w.id] ?? "0"}
+              disabled={pending}
+              onChange={(e) => {
+                setDraft((prev) => ({ ...prev, [w.id]: e.target.value }));
+                setSaved(false);
+              }}
+              className={inputClass}
+            />
+          </li>
+        ))}
+      </ul>
+
+      <div className="flex items-center justify-between border-t border-border-subtle pt-3">
+        <span className="text-sm text-[color:var(--ink-900)] opacity-70">
+          Total
+        </span>
+        <span className="text-sm font-medium text-[color:var(--ink-900)]">
+          {total}
+        </span>
+      </div>
+
+      <div aria-live="polite">
+        {error && (
+          <div
+            role="alert"
+            className="rounded-md border border-[color:var(--danger)]/25 bg-[color:var(--danger)]/[0.06] px-4 py-2.5 text-sm text-[color:var(--danger)]"
+          >
+            {error}
+          </div>
+        )}
+        {saved && !error && (
+          <p className="text-sm text-[color:var(--moss-700)]">Stock saved.</p>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={handleSave}
+        disabled={pending}
+        className="rounded-md bg-[color:var(--ink-900)] px-4 py-2 text-sm font-medium text-[color:var(--primary-foreground)] transition-colors hover:bg-[color:var(--moss-700)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {pending ? "Saving..." : "Save stock"}
+      </button>
+    </section>
+  );
+}

--- a/apps/admin/lib/api/marketplace-api.ts
+++ b/apps/admin/lib/api/marketplace-api.ts
@@ -89,6 +89,17 @@ export interface AdminVariantResponse {
   width_cm: string | null;
   height_cm: string | null;
   inventory_quantity: number;
+  /**
+   * Per-warehouse breakdown (#177 PR 5e), keyed by warehouse id. Present
+   * on the product DETAIL response only.
+   *
+   * The SENTINEL id `00000000-0000-0000-0000-000000000001` appears here
+   * for a variant PR 6 has not migrated yet — it means "these units exist
+   * but are not assigned to a location", which is a different thing from
+   * a warehouse holding them, and the merchant's first per-location save
+   * is what resolves it.
+   */
+  inventory_by_location?: Record<string, number>;
   inventory_policy: "deny" | "continue";
   low_stock_threshold: number | null;
   option_values: AdminVariantOptionRef[];
@@ -2523,4 +2534,37 @@ export async function setReturnPickup(
   );
   if (!res.ok) return { ok: false, error: await parseMutationError(res) };
   return { ok: true, data: (await res.json()) as AdminReturn };
+}
+
+/** The un-migrated location every product's stock still sits on (PR 6 clears it). */
+export const SENTINEL_LOCATION_ID = "00000000-0000-0000-0000-000000000001";
+
+/**
+ * setVariantStockByLocation writes a variant's per-warehouse stock.
+ *
+ * The backend clears the variant's sentinel row in the same transaction,
+ * so the total is conserved — see SetVariantStockByLocationInTx. Sending
+ * this alongside `inventory_quantity` is refused with a 400 rather than
+ * the service guessing which the merchant meant.
+ */
+export async function setVariantStockByLocation(
+  storeId: string,
+  productId: string,
+  variantId: string,
+  byLocation: Record<string, number>,
+  session: SessionHeaders,
+): Promise<MutationResult<AdminVariantResponse>> {
+  const res = await fetch(
+    `${MARKETPLACE_API_URL}/api/v1/admin/stores/${storeId}/products/${productId}/variants/${variantId}`,
+    {
+      method: "PATCH",
+      cache: "no-store",
+      headers: commonHeaders(session),
+      body: JSON.stringify({ inventory_by_location: byLocation }),
+    },
+  );
+  if (!res.ok) {
+    return { ok: false, error: await parseMutationError(res) };
+  }
+  return { ok: true, data: (await res.json()) as AdminVariantResponse };
 }

--- a/services/marketplace-api/internal/handlers/admin/dto.go
+++ b/services/marketplace-api/internal/handlers/admin/dto.go
@@ -125,22 +125,28 @@ type AdminProductOptionValue struct {
 }
 
 type AdminVariantResponse struct {
-	ID                string                  `json:"id"`
-	SKU               string                  `json:"sku"`
-	Barcode           *string                 `json:"barcode,omitempty"`
-	Price             decimal.Decimal         `json:"price"`
-	CompareAtPrice    *decimal.Decimal        `json:"compare_at_price,omitempty"`
-	CostPrice         *decimal.Decimal        `json:"cost_price,omitempty"`
-	CurrencyCode      string                  `json:"currency_code"`
-	WeightGrams       *int                    `json:"weight_grams,omitempty"`
-	LengthCM          *decimal.Decimal        `json:"length_cm,omitempty"`
-	WidthCM           *decimal.Decimal        `json:"width_cm,omitempty"`
-	HeightCM          *decimal.Decimal        `json:"height_cm,omitempty"`
-	InventoryQuantity int                     `json:"inventory_quantity"`
-	InventoryPolicy   string                  `json:"inventory_policy"`
-	LowStockThreshold *int                    `json:"low_stock_threshold,omitempty"`
-	OptionValues      []AdminVariantOptionRef `json:"option_values"`
-	Position          int                     `json:"position"`
+	ID                string           `json:"id"`
+	SKU               string           `json:"sku"`
+	Barcode           *string          `json:"barcode,omitempty"`
+	Price             decimal.Decimal  `json:"price"`
+	CompareAtPrice    *decimal.Decimal `json:"compare_at_price,omitempty"`
+	CostPrice         *decimal.Decimal `json:"cost_price,omitempty"`
+	CurrencyCode      string           `json:"currency_code"`
+	WeightGrams       *int             `json:"weight_grams,omitempty"`
+	LengthCM          *decimal.Decimal `json:"length_cm,omitempty"`
+	WidthCM           *decimal.Decimal `json:"width_cm,omitempty"`
+	HeightCM          *decimal.Decimal `json:"height_cm,omitempty"`
+	InventoryQuantity int              `json:"inventory_quantity"`
+	// InventoryByLocation is the per-warehouse breakdown (#177 PR 5e),
+	// keyed by warehouse id. The SENTINEL location appears under its own id
+	// for a variant PR 6 has not migrated yet — the admin needs to tell
+	// "this warehouse holds 10" apart from "10 units exist but are not
+	// assigned to a location". Omitted when the caller did not ask for it.
+	InventoryByLocation map[string]int          `json:"inventory_by_location,omitempty"`
+	InventoryPolicy     string                  `json:"inventory_policy"`
+	LowStockThreshold   *int                    `json:"low_stock_threshold,omitempty"`
+	OptionValues        []AdminVariantOptionRef `json:"option_values"`
+	Position            int                     `json:"position"`
 }
 
 type AdminVariantOptionRef struct {

--- a/services/marketplace-api/internal/handlers/admin/products.go
+++ b/services/marketplace-api/internal/handlers/admin/products.go
@@ -101,7 +101,30 @@ func (h *ProductHandler) Get(c *gin.Context) {
 		return
 	}
 	categories := h.resolveCategoryRefs(c, agg.CategoryLinks, storeID, tenantID)
-	c.JSON(http.StatusOK, ToAdminProductResponse(agg, categories))
+	resp := ToAdminProductResponse(agg, categories)
+
+	// Per-warehouse stock, on the detail view only (#177 PR 5e). The list
+	// view does not carry it: it renders a total, and one extra query per
+	// page of products to fill a field nothing reads is a cost with no
+	// buyer. A failure here degrades to the total rather than failing the
+	// whole product load — the breakdown is an editing aid, not the
+	// product.
+	variantIDs := make([]string, 0, len(agg.Variants))
+	for i := range agg.Variants {
+		variantIDs = append(variantIDs, agg.Variants[i].ID)
+	}
+	byVariant, err := h.svc.StockByLocation(c.Request.Context(), variantIDs)
+	if err != nil {
+		h.logger.Warn("product get: per-location stock unavailable",
+			"product_id", id, "store_id", storeID, "err", err)
+	} else {
+		for i := range resp.Variants {
+			if breakdown, ok := byVariant[resp.Variants[i].ID]; ok {
+				resp.Variants[i].InventoryByLocation = breakdown
+			}
+		}
+	}
+	c.JSON(http.StatusOK, resp)
 }
 
 // Create handles POST /admin/stores/:storeId/products.
@@ -235,7 +258,30 @@ func (h *ProductHandler) Patch(c *gin.Context) {
 		},
 	})
 	categories := h.resolveCategoryRefs(c, agg.CategoryLinks, storeID, tenantID)
-	c.JSON(http.StatusOK, ToAdminProductResponse(agg, categories))
+	resp := ToAdminProductResponse(agg, categories)
+
+	// Per-warehouse stock, on the detail view only (#177 PR 5e). The list
+	// view does not carry it: it renders a total, and one extra query per
+	// page of products to fill a field nothing reads is a cost with no
+	// buyer. A failure here degrades to the total rather than failing the
+	// whole product load — the breakdown is an editing aid, not the
+	// product.
+	variantIDs := make([]string, 0, len(agg.Variants))
+	for i := range agg.Variants {
+		variantIDs = append(variantIDs, agg.Variants[i].ID)
+	}
+	byVariant, err := h.svc.StockByLocation(c.Request.Context(), variantIDs)
+	if err != nil {
+		h.logger.Warn("product get: per-location stock unavailable",
+			"product_id", id, "store_id", storeID, "err", err)
+	} else {
+		for i := range resp.Variants {
+			if breakdown, ok := byVariant[resp.Variants[i].ID]; ok {
+				resp.Variants[i].InventoryByLocation = breakdown
+			}
+		}
+	}
+	c.JSON(http.StatusOK, resp)
 }
 
 // Delete handles DELETE /admin/stores/:storeId/products/:id.

--- a/services/marketplace-api/internal/handlers/admin/validation.go
+++ b/services/marketplace-api/internal/handlers/admin/validation.go
@@ -52,9 +52,13 @@ type UpdateVariantRequest struct {
 	WidthCM           *decimal.Decimal `json:"width_cm,omitempty"`
 	HeightCM          *decimal.Decimal `json:"height_cm,omitempty"`
 	InventoryQuantity *int             `json:"inventory_quantity,omitempty"`
-	InventoryPolicy   *string          `json:"inventory_policy,omitempty" binding:"omitempty,oneof=deny continue"`
-	LowStockThreshold *int             `json:"low_stock_threshold,omitempty"`
-	Position          *int             `json:"position,omitempty"`
+	// InventoryByLocation is the per-warehouse breakdown (#177 PR 5e),
+	// keyed by warehouse id. Mutually exclusive with InventoryQuantity —
+	// the service rejects both together rather than guessing.
+	InventoryByLocation map[string]int `json:"inventory_by_location,omitempty"`
+	InventoryPolicy     *string        `json:"inventory_policy,omitempty" binding:"omitempty,oneof=deny continue"`
+	LowStockThreshold   *int           `json:"low_stock_threshold,omitempty"`
+	Position            *int           `json:"position,omitempty"`
 }
 
 // UploadURLRequest is the wire body for POST /media/upload-url.
@@ -177,24 +181,25 @@ func toServiceUpdateCategory(req UpdateCategoryRequest, id, tenantID, storeID st
 // through so the service can reject cross-currency mutations.
 func toServiceUpdateVariantBasics(req UpdateVariantRequest, productID, variantID, storeID, tenantID string) product.UpdateVariantBasicsRequest {
 	return product.UpdateVariantBasicsRequest{
-		ProductID:         productID,
-		VariantID:         variantID,
-		StoreID:           storeID,
-		TenantID:          tenantID,
-		SKU:               req.SKU,
-		Barcode:           req.Barcode,
-		Price:             req.Price,
-		CompareAtPrice:    req.CompareAtPrice,
-		CostPrice:         req.CostPrice,
-		WeightGrams:       req.WeightGrams,
-		LengthCM:          req.LengthCM,
-		WidthCM:           req.WidthCM,
-		HeightCM:          req.HeightCM,
-		InventoryQuantity: req.InventoryQuantity,
-		InventoryPolicy:   req.InventoryPolicy,
-		LowStockThreshold: req.LowStockThreshold,
-		Position:          req.Position,
-		CurrencyCode:      req.CurrencyCode,
+		ProductID:           productID,
+		VariantID:           variantID,
+		StoreID:             storeID,
+		TenantID:            tenantID,
+		SKU:                 req.SKU,
+		Barcode:             req.Barcode,
+		Price:               req.Price,
+		CompareAtPrice:      req.CompareAtPrice,
+		CostPrice:           req.CostPrice,
+		WeightGrams:         req.WeightGrams,
+		LengthCM:            req.LengthCM,
+		WidthCM:             req.WidthCM,
+		HeightCM:            req.HeightCM,
+		InventoryQuantity:   req.InventoryQuantity,
+		InventoryByLocation: req.InventoryByLocation,
+		InventoryPolicy:     req.InventoryPolicy,
+		LowStockThreshold:   req.LowStockThreshold,
+		Position:            req.Position,
+		CurrencyCode:        req.CurrencyCode,
 	}
 }
 

--- a/services/marketplace-api/internal/handlers/admin/variant_stock_by_location_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/variant_stock_by_location_integration_test.go
@@ -1,0 +1,246 @@
+//go:build integration
+
+// Package admin_test — #177 PR 5e at the HTTP boundary.
+//
+// The rule the slice is built around: a store with ONE warehouse sees
+// exactly what it saw before. Everything here that exercises the
+// per-warehouse path is therefore a two-warehouse store.
+package admin_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/authz"
+	"github.com/mark8ly/marketplace-api/internal/product"
+)
+
+// seedWarehouseFor inserts a live warehouse for a store.
+func seedStockWarehouse(t *testing.T, db *gorm.DB, tenantID, storeID, name string) string {
+	t.Helper()
+	id := uuid.NewString()
+	if err := db.Exec(
+		`INSERT INTO warehouses (id, tenant_id, store_id, name, line1, city, region,
+		                         postal_code, country_code, phone)
+		 VALUES (?, ?, ?, ?, '1 Dock Rd', 'Mumbai', 'MH', '400001', 'IN', '+912200000000')`,
+		id, tenantID, storeID, name).Error; err != nil {
+		t.Fatalf("seed warehouse: %v", err)
+	}
+	return id
+}
+
+func stockAtLoc(t *testing.T, db *gorm.DB, variantID, locationID string) int {
+	t.Helper()
+	var q int
+	if err := db.Raw(
+		`SELECT COALESCE((SELECT quantity FROM variant_stock
+		                   WHERE variant_id = ? AND location_id = ?), -1)`,
+		variantID, locationID).Scan(&q).Error; err != nil {
+		t.Fatalf("read stock: %v", err)
+	}
+	return q
+}
+
+// seedProductWithStock creates a product whose single variant holds qty on
+// the SENTINEL — the state every product in production is in today.
+func seedProductWithStock(t *testing.T, env *testEnv, storeID, tenantID, userID string, qty int) (string, string) {
+	t.Helper()
+	body := map[string]any{
+		"title": "Linen Shirt", "handle": "linen-" + uuid.NewString()[:8],
+		"status": "draft",
+		"variants": []map[string]any{
+			{"sku": "SKU-" + uuid.NewString()[:8], "price": "10.00", "inventory_quantity": qty},
+		},
+	}
+	w := request(t, env.router, http.MethodPost,
+		"/api/v1/admin/stores/"+storeID+"/products", body, authHeaders(userID, tenantID))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("seed product: status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		ID       string `json:"id"`
+		Variants []struct {
+			ID string `json:"id"`
+		} `json:"variants"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v (%s)", err, w.Body.String())
+	}
+	if len(resp.Variants) == 0 {
+		t.Fatalf("no variants: %s", w.Body.String())
+	}
+	return resp.ID, resp.Variants[0].ID
+}
+
+// THE test. A merchant opening a product that reads 10, typing 10 against
+// their main warehouse and 5 against a new one, must end up with 15 — not
+// 25. Leaving the sentinel row behind sums it with the real row for the
+// same warehouse in checkout_availability, and their stock doubles.
+func TestAPI_VariantStock_PerLocationSaveConservesTheTotal(t *testing.T) {
+	env := setupTestRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+	env.fga.Grant(userID, authz.RoleAdmin, tenantID)
+	env.fga.Grant(userID, authz.RoleStaff, tenantID)
+
+	productID, variantID := seedProductWithStock(t, env, storeID, tenantID, userID, 10)
+	if got := stockAtLoc(t, env.db, variantID, product.DefaultLocationID); got != 10 {
+		t.Fatalf("precondition: sentinel stock = %d, want 10", got)
+	}
+
+	whA := seedStockWarehouse(t, env.db, tenantID, storeID, "Alpha")
+	whB := seedStockWarehouse(t, env.db, tenantID, storeID, "Bravo")
+
+	w := request(t, env.router, http.MethodPatch, variantURL(storeID, productID, variantID),
+		map[string]any{"inventory_by_location": map[string]int{whA: 10, whB: 5}},
+		authHeaders(userID, tenantID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	if got := stockAtLoc(t, env.db, variantID, product.DefaultLocationID); got != -1 {
+		t.Fatalf("sentinel row survived with %d units — its stock is double-counted", got)
+	}
+	if got := stockAtLoc(t, env.db, variantID, whA); got != 10 {
+		t.Fatalf("warehouse A = %d, want 10", got)
+	}
+	if got := stockAtLoc(t, env.db, variantID, whB); got != 5 {
+		t.Fatalf("warehouse B = %d, want 5", got)
+	}
+
+	var total int
+	_ = env.db.Raw(`SELECT inventory_quantity FROM product_variants WHERE id = ?`, variantID).
+		Scan(&total).Error
+	if total != 15 {
+		t.Fatalf("inventory_quantity = %d, want 15 (10 + 5), not 25", total)
+	}
+}
+
+// The single-warehouse path must be untouched by this slice.
+func TestAPI_VariantStock_PlainQuantityStillWritesTheSentinel(t *testing.T) {
+	env := setupTestRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+	env.fga.Grant(userID, authz.RoleAdmin, tenantID)
+	env.fga.Grant(userID, authz.RoleStaff, tenantID)
+
+	productID, variantID := seedProductWithStock(t, env, storeID, tenantID, userID, 10)
+
+	w := request(t, env.router, http.MethodPatch, variantURL(storeID, productID, variantID),
+		map[string]any{"inventory_quantity": 42}, authHeaders(userID, tenantID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if got := stockAtLoc(t, env.db, variantID, product.DefaultLocationID); got != 42 {
+		t.Fatalf("sentinel = %d, want 42 — the single-warehouse path must be unchanged", got)
+	}
+}
+
+func TestAPI_VariantStock_BothFieldsIsRefused(t *testing.T) {
+	env := setupTestRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+	env.fga.Grant(userID, authz.RoleAdmin, tenantID)
+	env.fga.Grant(userID, authz.RoleStaff, tenantID)
+
+	productID, variantID := seedProductWithStock(t, env, storeID, tenantID, userID, 10)
+	whA := seedStockWarehouse(t, env.db, tenantID, storeID, "Alpha")
+
+	w := request(t, env.router, http.MethodPatch, variantURL(storeID, productID, variantID),
+		map[string]any{"inventory_quantity": 3, "inventory_by_location": map[string]int{whA: 7}},
+		authHeaders(userID, tenantID))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+}
+
+// Stock written against another store's warehouse is stock the allocator
+// will never offer — to the merchant it reads as inventory that vanished.
+func TestAPI_VariantStock_AnotherStoresWarehouseIsRefused(t *testing.T) {
+	env := setupTestRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	otherStoreID, otherTenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+	env.fga.Grant(userID, authz.RoleAdmin, tenantID)
+	env.fga.Grant(userID, authz.RoleStaff, tenantID)
+
+	productID, variantID := seedProductWithStock(t, env, storeID, tenantID, userID, 10)
+	foreign := seedStockWarehouse(t, env.db, otherTenantID, otherStoreID, "Theirs")
+
+	w := request(t, env.router, http.MethodPatch, variantURL(storeID, productID, variantID),
+		map[string]any{"inventory_by_location": map[string]int{foreign: 7}},
+		authHeaders(userID, tenantID))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if got := stockAtLoc(t, env.db, variantID, product.DefaultLocationID); got != 10 {
+		t.Fatalf("a refused save moved stock: sentinel = %d, want 10", got)
+	}
+}
+
+func TestAPI_VariantStock_ArchivedWarehouseIsRefused(t *testing.T) {
+	env := setupTestRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+	env.fga.Grant(userID, authz.RoleAdmin, tenantID)
+	env.fga.Grant(userID, authz.RoleStaff, tenantID)
+
+	productID, variantID := seedProductWithStock(t, env, storeID, tenantID, userID, 10)
+	whA := seedStockWarehouse(t, env.db, tenantID, storeID, "Gone")
+	if err := env.db.Exec(`UPDATE warehouses SET archived_at = now() WHERE id = ?`, whA).Error; err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	w := request(t, env.router, http.MethodPatch, variantURL(storeID, productID, variantID),
+		map[string]any{"inventory_by_location": map[string]int{whA: 7}},
+		authHeaders(userID, tenantID))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+}
+
+// The detail view must expose the breakdown, including a variant still on
+// the sentinel — the admin needs to tell "this warehouse holds 10" from
+// "10 units exist but are not assigned anywhere yet".
+func TestAPI_ProductGet_CarriesThePerLocationBreakdown(t *testing.T) {
+	env := setupTestRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+	env.fga.Grant(userID, authz.RoleAdmin, tenantID)
+	env.fga.Grant(userID, authz.RoleStaff, tenantID)
+
+	productID, variantID := seedProductWithStock(t, env, storeID, tenantID, userID, 10)
+
+	get := request(t, env.router, http.MethodGet,
+		"/api/v1/admin/stores/"+storeID+"/products/"+productID, nil,
+		authHeaders(userID, tenantID))
+	if get.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", get.Code, get.Body.String())
+	}
+	var resp struct {
+		Variants []struct {
+			ID                  string         `json:"id"`
+			InventoryByLocation map[string]int `json:"inventory_by_location"`
+		} `json:"variants"`
+	}
+	if err := json.Unmarshal(get.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Variants) == 0 {
+		t.Fatalf("no variants: %s", get.Body.String())
+	}
+	if got := resp.Variants[0].InventoryByLocation[product.DefaultLocationID]; got != 10 {
+		t.Fatalf("sentinel breakdown = %d, want 10 (variant %s): %s",
+			got, variantID, get.Body.String())
+	}
+}

--- a/services/marketplace-api/internal/product/repository.go
+++ b/services/marketplace-api/internal/product/repository.go
@@ -56,6 +56,8 @@ type Repository interface {
 	// SetVariantStockByLocationInTx writes per-warehouse stock and clears
 	// the variant's sentinel row in the same transaction (#177 PR 5e).
 	SetVariantStockByLocationInTx(ctx context.Context, tx *gorm.DB, variantID string, byLocation map[string]int) error
+	// StockByLocationForVariants reads variantID -> locationID -> quantity.
+	StockByLocationForVariants(ctx context.Context, db *gorm.DB, variantIDs []string) (map[string]map[string]int, error)
 	UpdateVariantBasicsInTx(ctx context.Context, tx *gorm.DB, productID, variantID, storeID, tenantID string, fields map[string]any) error
 	SoftDeleteInTx(ctx context.Context, tx *gorm.DB, id, storeID, tenantID string) error
 }

--- a/services/marketplace-api/internal/product/repository.go
+++ b/services/marketplace-api/internal/product/repository.go
@@ -53,6 +53,9 @@ type Repository interface {
 	UpdateMediaInTx(ctx context.Context, tx *gorm.DB, productID, mediaID, storeID, tenantID string, fields map[string]any) error
 	DeleteMediaInTx(ctx context.Context, tx *gorm.DB, productID, mediaID, storeID, tenantID string) error
 	UpdateVariantStockInTx(ctx context.Context, tx *gorm.DB, variantID, locationID string, quantity int) error
+	// SetVariantStockByLocationInTx writes per-warehouse stock and clears
+	// the variant's sentinel row in the same transaction (#177 PR 5e).
+	SetVariantStockByLocationInTx(ctx context.Context, tx *gorm.DB, variantID string, byLocation map[string]int) error
 	UpdateVariantBasicsInTx(ctx context.Context, tx *gorm.DB, productID, variantID, storeID, tenantID string, fields map[string]any) error
 	SoftDeleteInTx(ctx context.Context, tx *gorm.DB, id, storeID, tenantID string) error
 }

--- a/services/marketplace-api/internal/product/repository_variants.go
+++ b/services/marketplace-api/internal/product/repository_variants.go
@@ -233,3 +233,39 @@ func (r *gormRepository) SetVariantStockByLocationInTx(
 	}
 	return nil
 }
+
+// StockByLocationForVariants reads the per-location breakdown for a set of
+// variants: variantID -> locationID -> quantity.
+//
+// The SENTINEL is reported under its own id rather than folded into a
+// warehouse. Callers rendering the admin's per-warehouse editor need to
+// know a variant is still un-migrated — that is the difference between
+// "this warehouse holds 10" and "10 units exist but are not yet assigned
+// anywhere", and the merchant's first per-location save is what resolves
+// it (see SetVariantStockByLocationInTx).
+func (r *gormRepository) StockByLocationForVariants(
+	ctx context.Context, db *gorm.DB, variantIDs []string,
+) (map[string]map[string]int, error) {
+	out := map[string]map[string]int{}
+	if len(variantIDs) == 0 {
+		return out, nil
+	}
+	var rows []struct {
+		VariantID  string
+		LocationID string
+		Quantity   int
+	}
+	if err := db.WithContext(ctx).Raw(
+		`SELECT variant_id, location_id, quantity
+		   FROM variant_stock
+		  WHERE variant_id IN ?`, variantIDs).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("product: stock by location: %w", err)
+	}
+	for _, row := range rows {
+		if out[row.VariantID] == nil {
+			out[row.VariantID] = map[string]int{}
+		}
+		out[row.VariantID][row.LocationID] = row.Quantity
+	}
+	return out, nil
+}

--- a/services/marketplace-api/internal/product/repository_variants.go
+++ b/services/marketplace-api/internal/product/repository_variants.go
@@ -9,6 +9,7 @@ package product
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"gorm.io/gorm"
@@ -168,6 +169,67 @@ func (r *gormRepository) UpdateVariantStockInTx(ctx context.Context, tx *gorm.DB
 		row.VariantID, row.LocationID, row.Quantity)
 	if res.Error != nil {
 		return fmt.Errorf("product: upsert variant stock: %w", res.Error)
+	}
+	return nil
+}
+
+// SetVariantStockByLocationInTx writes a variant's stock across real
+// warehouses and CONSERVES the total by dropping its sentinel row.
+//
+// # Why the sentinel has to go
+//
+// Until PR 6's backfill runs, a variant's units live on DefaultLocationID.
+// checkout_availability.go attributes a sentinel row to the store's FIRST
+// warehouse and SUMS it with any real row for that same warehouse:
+//
+//	avail[variantID][warehouseID] += r.Available
+//
+// So writing a real row for the first warehouse while the sentinel row
+// survives reports both. A merchant opening a product that shows 10 units,
+// typing 10 against their main warehouse and 5 against a new one, would end
+// up selling 25. They changed nothing and doubled their stock.
+//
+// Dropping the sentinel row here makes the edit a per-variant backfill:
+// after it, that variant is fully migrated and PR 6 has one less row to
+// sweep. It is also why this is one transaction — a write that landed
+// without the delete is precisely the double-count.
+//
+// Goes through UpdateVariantStockInTx per location rather than writing
+// variant_stock directly, keeping that the single mutation chokepoint the
+// sync_variant_inventory trigger is reasoned about through.
+func (r *gormRepository) SetVariantStockByLocationInTx(
+	ctx context.Context, tx *gorm.DB, variantID string, byLocation map[string]int,
+) error {
+	if len(byLocation) == 0 {
+		// Nothing asked for. Deleting the sentinel here would destroy stock
+		// on an empty request, so refuse rather than "helpfully" clear.
+		return nil
+	}
+
+	// Deterministic order. A map's iteration order is random, and two
+	// concurrent saves touching the same pair of locations in opposite
+	// orders can deadlock on the row locks.
+	locations := make([]string, 0, len(byLocation))
+	for id := range byLocation {
+		locations = append(locations, id)
+	}
+	slices.Sort(locations)
+
+	for _, locationID := range locations {
+		if locationID == DefaultLocationID {
+			// The sentinel is not a place a merchant can choose. Accepting
+			// it here would write the row this method exists to remove.
+			return fmt.Errorf("product: set stock by location: sentinel is not a warehouse")
+		}
+		if err := r.UpdateVariantStockInTx(ctx, tx, variantID, locationID, byLocation[locationID]); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.WithContext(ctx).Exec(
+		`DELETE FROM variant_stock WHERE variant_id = ? AND location_id = ?`,
+		variantID, DefaultLocationID).Error; err != nil {
+		return fmt.Errorf("product: set stock by location: clear sentinel: %w", err)
 	}
 	return nil
 }

--- a/services/marketplace-api/internal/product/service_variant_patch.go
+++ b/services/marketplace-api/internal/product/service_variant_patch.go
@@ -11,6 +11,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/outbox"
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 )
 
@@ -33,10 +34,15 @@ type UpdateVariantBasicsRequest struct {
 	WidthCM           *decimal.Decimal
 	HeightCM          *decimal.Decimal
 	InventoryQuantity *int
-	InventoryPolicy   *string
-	LowStockThreshold *int
-	Position          *int
-	CurrencyCode      *string
+	// InventoryByLocation is the per-warehouse breakdown (#177 PR 5e).
+	// Mutually exclusive with InventoryQuantity: one names a total with no
+	// location, the other names locations with no total, and accepting both
+	// would leave the service guessing which the merchant meant.
+	InventoryByLocation map[string]int
+	InventoryPolicy     *string
+	LowStockThreshold   *int
+	Position            *int
+	CurrencyCode        *string
 }
 
 // UpdateVariantBasics applies the non-nil fields to one variant row.
@@ -51,6 +57,27 @@ func (s *Service) UpdateVariantBasics(ctx context.Context, req UpdateVariantBasi
 		}
 		if *req.CurrencyCode != store.CurrencyCode {
 			return nil, apperrors.CurrencyChangeForbidden()
+		}
+	}
+
+	if req.InventoryQuantity != nil && len(req.InventoryByLocation) > 0 {
+		return nil, apperrors.ValidationFailed("inventory_by_location",
+			"send either inventory_quantity or inventory_by_location, not both")
+	}
+	// Every named location must be a LIVE warehouse of this store. An id is
+	// a guessable handle, and stock written against another store's
+	// warehouse — or an archived one — is stock the allocator will never
+	// offer, which reads to the merchant as inventory that vanished.
+	if len(req.InventoryByLocation) > 0 {
+		live, err := s.liveWarehouseIDs(ctx, req.StoreID)
+		if err != nil {
+			return nil, err
+		}
+		for id := range req.InventoryByLocation {
+			if _, ok := live[id]; !ok {
+				return nil, apperrors.ValidationFailed("inventory_by_location",
+					"unknown or archived warehouse: "+id)
+			}
 		}
 	}
 
@@ -104,7 +131,18 @@ func (s *Service) UpdateVariantBasics(ctx context.Context, req UpdateVariantBasi
 				return err
 			}
 		}
-		if req.InventoryQuantity != nil {
+		switch {
+		case len(req.InventoryByLocation) > 0:
+			// Per-warehouse stock. SetVariantStockByLocationInTx also drops
+			// the variant's sentinel row, which is what keeps the total
+			// honest — see its doc comment for why leaving it doubles the
+			// merchant's stock.
+			if err := s.repo.SetVariantStockByLocationInTx(ctx, tx, req.VariantID, req.InventoryByLocation); err != nil {
+				return err
+			}
+		case req.InventoryQuantity != nil:
+			// The single-warehouse path, unchanged. A store with one
+			// warehouse must behave exactly as it did before this slice.
 			if err := s.repo.UpdateVariantStockInTx(ctx, tx, req.VariantID, DefaultLocationID, *req.InventoryQuantity); err != nil {
 				return err
 			}
@@ -126,4 +164,24 @@ func (s *Service) UpdateVariantBasics(ctx context.Context, req UpdateVariantBasi
 		}
 	}
 	return nil, apperrors.NotFound("variant")
+}
+
+// liveWarehouseIDs is the set of warehouse ids a store may hold stock at.
+func (s *Service) liveWarehouseIDs(ctx context.Context, storeID string) (map[string]struct{}, error) {
+	rows, err := warehouse.NewRepository().List(ctx, s.db, storeID, false)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]struct{}, len(rows))
+	for _, w := range rows {
+		out[w.ID] = struct{}{}
+	}
+	return out, nil
+}
+
+// StockByLocation returns the per-warehouse breakdown for a set of
+// variants. Read-only; used by the admin product detail view to render
+// the per-warehouse editor (#177 PR 5e).
+func (s *Service) StockByLocation(ctx context.Context, variantIDs []string) (map[string]map[string]int, error) {
+	return s.repo.StockByLocationForVariants(ctx, s.db, variantIDs)
 }

--- a/services/marketplace-api/internal/product/stock_by_location_integration_test.go
+++ b/services/marketplace-api/internal/product/stock_by_location_integration_test.go
@@ -1,0 +1,201 @@
+//go:build integration
+
+// Package product_test — #177 PR 5e: per-warehouse stock.
+//
+// The trap this file exists for: until PR 6's backfill runs, a variant's
+// units live on the SENTINEL location, and checkout_availability.go
+// attributes sentinel rows to the store's FIRST warehouse while SUMMING
+// them with any real row for that same warehouse. So writing a real row
+// without clearing the sentinel silently doubles the merchant's stock —
+// they type the number already on screen and end up with twice it.
+//
+// SetVariantStockByLocation therefore CONSERVES: it writes the real rows
+// and drops the variant's sentinel row in the same transaction.
+package product_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/product"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// stockAtLocation reads one variant_stock quantity, or -1 when no row.
+func stockAtLocation(t *testing.T, tx *gorm.DB, variantID, locationID string) int {
+	t.Helper()
+	var q int
+	require.NoError(t, tx.Raw(
+		`SELECT COALESCE((SELECT quantity FROM variant_stock
+		                   WHERE variant_id = ? AND location_id = ?), -1)`,
+		variantID, locationID).Scan(&q).Error)
+	return q
+}
+
+// seedWarehouseRowForStock inserts a live warehouse for the store.
+func seedWarehouseRowForStock(t *testing.T, tx *gorm.DB, tenantID, storeID, name string) string {
+	t.Helper()
+	id := uuid.NewString()
+	require.NoError(t, tx.Exec(
+		`INSERT INTO warehouses (id, tenant_id, store_id, name, line1, city, region,
+		                         postal_code, country_code, phone)
+		 VALUES (?, ?, ?, ?, '1 Dock Rd', 'Mumbai', 'MH', '400001', 'IN', '+912200000000')`,
+		id, tenantID, storeID, name).Error)
+	return id
+}
+
+func TestSetVariantStockByLocation_WritesRealRowsAndClearsTheSentinel(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := product.NewRepository(tx)
+	ctx := context.Background()
+
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	agg := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
+	require.NoError(t, repo.CreateAggregateInTx(ctx, tx, agg))
+	variantID := agg.Variants[0].ID
+
+	// The pre-5e world: everything on the sentinel.
+	require.NoError(t, repo.UpdateVariantStockInTx(ctx, tx, variantID, product.DefaultLocationID, 10))
+
+	whA := seedWarehouseRowForStock(t, tx, tenantID, storeID, "Alpha")
+	whB := seedWarehouseRowForStock(t, tx, tenantID, storeID, "Bravo")
+
+	require.NoError(t, repo.SetVariantStockByLocationInTx(ctx, tx, variantID,
+		map[string]int{whA: 10, whB: 5}))
+
+	var sentinel int64
+	require.NoError(t, tx.Raw(
+		`SELECT count(*) FROM variant_stock WHERE variant_id = ? AND location_id = ?`,
+		variantID, product.DefaultLocationID).Scan(&sentinel).Error)
+	require.Zero(t, sentinel,
+		"the sentinel row must be gone — left behind it is summed with the real row for the same warehouse and the merchant's stock doubles")
+
+	require.Equal(t, 10, stockAtLocation(t, tx, variantID, whA))
+	require.Equal(t, 5, stockAtLocation(t, tx, variantID, whB))
+}
+
+// The denormalised column is trigger-maintained and must end up as the
+// TOTAL across locations, not the last one written.
+func TestSetVariantStockByLocation_InventoryQuantityIsTheTotal(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := product.NewRepository(tx)
+	ctx := context.Background()
+
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	agg := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
+	require.NoError(t, repo.CreateAggregateInTx(ctx, tx, agg))
+	variantID := agg.Variants[0].ID
+	require.NoError(t, repo.UpdateVariantStockInTx(ctx, tx, variantID, product.DefaultLocationID, 10))
+
+	whA := seedWarehouseRowForStock(t, tx, tenantID, storeID, "Alpha")
+	whB := seedWarehouseRowForStock(t, tx, tenantID, storeID, "Bravo")
+	require.NoError(t, repo.SetVariantStockByLocationInTx(ctx, tx, variantID,
+		map[string]int{whA: 10, whB: 5}))
+
+	got, err := repo.GetByIDForStore(ctx, agg.Product.ID, storeID, tenantID)
+	require.NoError(t, err)
+	require.Equal(t, 15, got.Variants[0].InventoryQuantity,
+		"inventory_quantity must be the sum across locations")
+}
+
+// Setting a location to zero must leave a zero row rather than deleting
+// it: a missing row and a zero row read the same to availability, but the
+// merchant explicitly said "none here", and a later edit needs the row to
+// exist to show the location at all.
+func TestSetVariantStockByLocation_ZeroIsRecordedNotDropped(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := product.NewRepository(tx)
+	ctx := context.Background()
+
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	agg := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
+	require.NoError(t, repo.CreateAggregateInTx(ctx, tx, agg))
+	variantID := agg.Variants[0].ID
+
+	whA := seedWarehouseRowForStock(t, tx, tenantID, storeID, "Alpha")
+	whB := seedWarehouseRowForStock(t, tx, tenantID, storeID, "Bravo")
+	require.NoError(t, repo.SetVariantStockByLocationInTx(ctx, tx, variantID,
+		map[string]int{whA: 7, whB: 0}))
+
+	require.Equal(t, 7, stockAtLocation(t, tx, variantID, whA))
+	require.Equal(t, 0, stockAtLocation(t, tx, variantID, whB))
+
+	var rows int64
+	require.NoError(t, tx.Raw(
+		`SELECT count(*) FROM variant_stock WHERE variant_id = ? AND location_id = ?`,
+		variantID, whB).Scan(&rows).Error)
+	require.EqualValues(t, 1, rows, "an explicit zero must still have a row")
+}
+
+// Calling it twice with the same numbers must not change the totals — the
+// merchant pressing Save twice is not a stock movement.
+func TestSetVariantStockByLocation_IsIdempotent(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := product.NewRepository(tx)
+	ctx := context.Background()
+
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	agg := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
+	require.NoError(t, repo.CreateAggregateInTx(ctx, tx, agg))
+	variantID := agg.Variants[0].ID
+	require.NoError(t, repo.UpdateVariantStockInTx(ctx, tx, variantID, product.DefaultLocationID, 10))
+
+	whA := seedWarehouseRowForStock(t, tx, tenantID, storeID, "Alpha")
+	for range 2 {
+		require.NoError(t, repo.SetVariantStockByLocationInTx(ctx, tx, variantID,
+			map[string]int{whA: 10}))
+	}
+
+	require.Equal(t, 10, stockAtLocation(t, tx, variantID, whA))
+	got, err := repo.GetByIDForStore(ctx, agg.Product.ID, storeID, tenantID)
+	require.NoError(t, err)
+	require.Equal(t, 10, got.Variants[0].InventoryQuantity)
+}
+
+// The sentinel is not a place a merchant can choose, and accepting it
+// would write back the very row this method exists to delete — the write
+// and the delete would race within one call and the outcome would depend
+// on statement order. Refuse it outright.
+//
+// Found by mutation: removing the guard broke no test until this one.
+func TestSetVariantStockByLocation_RefusesTheSentinelAsALocation(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := product.NewRepository(tx)
+	ctx := context.Background()
+
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	agg := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
+	require.NoError(t, repo.CreateAggregateInTx(ctx, tx, agg))
+	variantID := agg.Variants[0].ID
+	require.NoError(t, repo.UpdateVariantStockInTx(ctx, tx, variantID, product.DefaultLocationID, 10))
+
+	err := repo.SetVariantStockByLocationInTx(ctx, tx, variantID,
+		map[string]int{product.DefaultLocationID: 99})
+	require.Error(t, err)
+
+	require.Equal(t, 10, stockAtLocation(t, tx, variantID, product.DefaultLocationID),
+		"a refused call must not have touched the stock")
+}
+
+// An empty map is "nothing asked for", not "clear this variant". Treating
+// it as the latter would destroy stock on a no-op save.
+func TestSetVariantStockByLocation_EmptyMapChangesNothing(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := product.NewRepository(tx)
+	ctx := context.Background()
+
+	storeID, tenantID, vendorID := seedStore(t, tx)
+	agg := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
+	require.NoError(t, repo.CreateAggregateInTx(ctx, tx, agg))
+	variantID := agg.Variants[0].ID
+	require.NoError(t, repo.UpdateVariantStockInTx(ctx, tx, variantID, product.DefaultLocationID, 10))
+
+	require.NoError(t, repo.SetVariantStockByLocationInTx(ctx, tx, variantID, map[string]int{}))
+
+	require.Equal(t, 10, stockAtLocation(t, tx, variantID, product.DefaultLocationID),
+		"an empty request must not have cleared the sentinel")
+}


### PR DESCRIPTION
Refs #177. The **backend half** of 5e — the product-form UI is deliberately not here; see *What is not in this PR* below.

## The trap this is built around

`checkout_availability.go` attributes a SENTINEL stock row to the store's **first** warehouse, and *sums* it with any real row for that same warehouse:

```go
avail[r.VariantID][warehouseID] += r.Available
```

Every unit in production is still on the sentinel — I re-checked: **380 rows, 16,354 units, all at `00000000-…-0001`, zero at Main Warehouse.** So a naive per-location write is a stock-doubling bug: a merchant opens a product that reads 10, types 10 against their main warehouse and 5 against a new one, and ends up selling **25**. They changed nothing and doubled their inventory.

`SetVariantStockByLocationInTx` therefore **conserves**: it writes the real rows and drops that variant's sentinel row *in the same transaction*. The edit becomes a per-variant backfill — after it, that variant is fully migrated and PR 6 has one less row to sweep. One transaction because a write that landed without the delete is precisely the double-count.

## Surface

- `PATCH …/variants/:variantId` accepts `inventory_by_location` (warehouse id → quantity). Mutually exclusive with `inventory_quantity`: one names a total with no location, the other locations with no total, and accepting both would leave the service guessing. **400** if both are sent.
- Every named location must be a **live warehouse of this store**. Stock written against another store's warehouse, or an archived one, is stock the allocator will never offer — to the merchant that reads as inventory that vanished.
- `GET …/products/:id` carries `inventory_by_location` per variant. The **sentinel appears under its own id** rather than folded into a warehouse: the admin has to tell "this warehouse holds 10" from "10 units exist but are not assigned anywhere yet", and the merchant's first per-location save is what resolves it. Detail view only — the list renders a total, and a query per page to fill a field nothing reads has no buyer. A failure degrades to the total rather than failing the product load.
- `UpdateVariantStockInTx` remains the single mutation chokepoint; the new method loops through it rather than writing `variant_stock` directly.
- **The single-warehouse path is untouched.** A store with one warehouse sees exactly what it saw before, pinned by a test.

Locations are written in sorted order — map iteration is random, and two concurrent saves touching the same pair in opposite orders can deadlock on the row locks.

## Tests

**11 new integration tests** (6 repository, 5 API + read side), including the one the slice exists for: 10 on the sentinel + a save of A=10, B=5 ends at **15, not 25**.

Six mutations, each confirmed to **compile** first:

| mutation | caught by |
|---|---|
| the sentinel row is left behind — *the double-count bug itself* | 3 repository tests |
| the sentinel accepted as a writable location | *(see below)* |
| an empty map falls through to the delete | `EmptyMapChangesNothing` |
| any warehouse id accepted | 2 API tests |
| both fields accepted together | `BothFieldsIsRefused` |
| per-location writes ignored | `PerLocationSaveConservesTheTotal` |

The sentinel-as-a-location mutation **survived at first** — removing that guard broke no test. `RefusesTheSentinelAsALocation` and `EmptyMapChangesNothing` were written in response, and both now fail without their guards. Worth flagging: two guards I wrote were untested until the mutation pass said so.

Full suite from `services/marketplace-api`, DSN `postgres://dev:dev@192.168.1.110:5432/marketplace_db` — exit 0, 120 packages ok, **3293 PASS / 25 SKIP / 0 FAIL**. `go vet -tags=integration ./...` clean. No migration, so no `ExpectedSchemaVersion` bump.

## What is not in this PR

**The product-form UI.** The rule from the spec — *a store with one warehouse sees exactly what it sees today; the form expands to a per-warehouse breakdown only once a second warehouse exists* — needs warehouses threaded into `ProductForm`, a per-warehouse editor, and the multi-variant tab handled too. That is its own reviewable change, and this contract is worth landing first because it makes the double-count impossible **before** any UI can trigger it.

Nothing here retires `DefaultLocationID` or backfills existing rows — that is PR 6.