### PR TITLE
feat(warehouse): backfill sentinel stock onto real warehouses (#177 PR 6, step 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	@cd services/marketplace-api && \
 	  TEST_DATABASE_URL='postgres://dev:dev@localhost:5432/marketplace_db?sslmode=disable' \
 	  go test -tags=integration -p 1 \
+	    . \
 	    ./cmd/backfill-email/... \
 	    ./internal/apikeys/... \
 	    ./internal/arbitrage/... \

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 122
+const ExpectedSchemaVersion uint = 123

--- a/services/marketplace-api/migrations/000123_backfill_sentinel_stock.down.sql
+++ b/services/marketplace-api/migrations/000123_backfill_sentinel_stock.down.sql
@@ -1,0 +1,16 @@
+-- Deliberately NOT reversible.
+--
+-- Reversing would mean summing every warehouse row back onto the sentinel,
+-- which cannot distinguish stock this migration moved from a per-warehouse
+-- split the merchant made themselves through the product form (#177 PR 5e).
+-- A merchant who genuinely holds 10 in Sydney and 5 in Melbourne would come
+-- back with 15 units in one undifferentiated pile and no record of the
+-- split — silent, and impossible to reconstruct.
+--
+-- Failing loudly is the honest answer. To roll back, restore from a
+-- snapshot taken before the up migration ran.
+DO $$
+BEGIN
+    RAISE EXCEPTION
+        'migration 000123 is not reversible: rolling the sentinel backfill back would merge merchant-entered per-warehouse splits into one pile. Restore from a pre-migration snapshot instead.';
+END $$;

--- a/services/marketplace-api/migrations/000123_backfill_sentinel_stock.up.sql
+++ b/services/marketplace-api/migrations/000123_backfill_sentinel_stock.up.sql
@@ -1,0 +1,139 @@
+-- #177 PR 6 (contract, step 1 of 2) — move every unit off the SENTINEL
+-- location and onto a real warehouse.
+--
+-- variant_stock and stock_holds both carry
+-- location_id = '00000000-0000-0000-0000-000000000001', the DefaultLocationID
+-- constant. Allocation reasons about real warehouse ids, so while stock sits
+-- on the sentinel the allocator is structurally correct and economically
+-- hollow: it can only tolerate those rows, never fill from them properly.
+--
+-- This migration does NOT remove the sentinel tolerance in code, and does not
+-- delete DefaultLocationID. Both stay until this backfill is confirmed run in
+-- production — a contract step that lands with its own tolerance still in
+-- place is safe in either order; the reverse is not.
+--
+-- CORRECTION TO THE SPEC. It says "production has zero warehouses and zero
+-- carrier configs", so the backfill may simply CREATE a warehouse named
+-- 'Main Warehouse' per store. That has been false since 2026-09-01:
+-- the-bondi-store has a warehouse named exactly 'Main Warehouse' with a real
+-- address, and warehouses is keyed (store_id, name) — partially, since 000122.
+-- A naive INSERT violates that index; an ON CONFLICT DO NOTHING silently
+-- leaves the stock on the sentinel while the code believes it migrated.
+-- So: find-or-create, and never overwrite an address a merchant has entered.
+
+-- ---------------------------------------------------------------------
+-- 1. Every store holding sentinel stock needs somewhere to put it.
+--
+-- Only for stores with NO live warehouse at all. A store that already has
+-- one — under any name — uses it; creating a second 'Main Warehouse'
+-- alongside the merchant's own is exactly the duplicate this issue exists
+-- to stop.
+--
+-- The address is left blank on purpose: that store has never told us where
+-- it ships from, and the warehouses page is what fills it in. Writing a
+-- plausible-looking placeholder would be a lie that quotes rates.
+-- ---------------------------------------------------------------------
+INSERT INTO warehouses (
+    id, tenant_id, store_id, name, line1, line2, city, region,
+    postal_code, country_code, phone, is_default, priority
+)
+SELECT gen_random_uuid(), s.tenant_id, s.id, 'Main Warehouse',
+       '', '', '', '', '', COALESCE(NULLIF(s.country_code, ''), 'IN'), '',
+       true, 0
+  FROM stores s
+ WHERE EXISTS (
+           SELECT 1
+             FROM variant_stock vs
+             JOIN product_variants pv ON pv.id = vs.variant_id
+            WHERE pv.store_id = s.id
+              AND vs.location_id = '00000000-0000-0000-0000-000000000001'
+       )
+   AND NOT EXISTS (
+           SELECT 1 FROM warehouses w
+            WHERE w.store_id = s.id AND w.archived_at IS NULL
+       );
+
+-- ---------------------------------------------------------------------
+-- 2. Which warehouse each store's sentinel stock lands on.
+--
+-- Repeated as a CTE in each statement below rather than materialised once
+-- into a TEMP TABLE. A temp table created ON COMMIT DROP only survives if
+-- the whole migration runs inside one transaction — true under
+-- golang-migrate, false under `psql -f` in autocommit, which is how a
+-- migration gets applied by hand during an incident. It failed exactly
+-- that way in testing. A repeated CTE has no such dependency.
+--
+-- Precedence matches warehouse.DefaultForStore: the flagged default, then
+-- fill order, then oldest. Deterministic because the answer decides where
+-- a merchant's entire inventory is recorded. Archived warehouses are
+-- excluded — the allocator refuses to fill from them (#528), so
+-- backfilling onto one would park every unit somewhere unsellable.
+-- ---------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------
+-- 3. variant_stock: sentinel rows become real-warehouse rows.
+--
+-- SUMS on conflict rather than overwriting. A variant can legitimately
+-- have BOTH a sentinel row and a real row for the same warehouse: PR 5e
+-- writes real rows and clears the sentinel, but the multi-variant product
+-- save still writes the sentinel, so a variant edited both ways carries
+-- the two. checkout_availability adds them together today (that is the
+-- tolerance), so summing here preserves the total the merchant is already
+-- selling. Overwriting would silently delete stock.
+-- ---------------------------------------------------------------------
+WITH target AS (
+    SELECT DISTINCT ON (w.store_id) w.store_id, w.id AS warehouse_id
+      FROM warehouses w
+     WHERE w.archived_at IS NULL
+     ORDER BY w.store_id, w.is_default DESC, w.priority ASC, w.created_at ASC
+)
+INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+SELECT vs.variant_id, t.warehouse_id, vs.quantity, now()
+  FROM variant_stock vs
+  JOIN product_variants pv ON pv.id = vs.variant_id
+  JOIN target t            ON t.store_id = pv.store_id
+ WHERE vs.location_id = '00000000-0000-0000-0000-000000000001'
+    ON CONFLICT (variant_id, location_id)
+    DO UPDATE SET quantity   = variant_stock.quantity + EXCLUDED.quantity,
+                  updated_at = now();
+
+DELETE FROM variant_stock vs
+ USING product_variants pv
+ WHERE vs.variant_id = pv.id
+   AND vs.location_id = '00000000-0000-0000-0000-000000000001'
+   AND EXISTS (
+           SELECT 1 FROM warehouses w
+            WHERE w.store_id = pv.store_id AND w.archived_at IS NULL
+       );
+
+-- ---------------------------------------------------------------------
+-- 4. stock_holds: live reservations move with the stock.
+--
+-- Deleting them instead would release a shopper's reservation mid-checkout
+-- and let someone else take the units they are paying for. Summing on
+-- conflict for the same reason as above.
+-- ---------------------------------------------------------------------
+WITH target AS (
+    SELECT DISTINCT ON (w.store_id) w.store_id, w.id AS warehouse_id
+      FROM warehouses w
+     WHERE w.archived_at IS NULL
+     ORDER BY w.store_id, w.is_default DESC, w.priority ASC, w.created_at ASC
+)
+INSERT INTO stock_holds (variant_id, location_id, cart_token, qty, expires_at, state)
+SELECT sh.variant_id, t.warehouse_id, sh.cart_token, sh.qty, sh.expires_at, sh.state
+  FROM stock_holds sh
+  JOIN product_variants pv ON pv.id = sh.variant_id
+  JOIN target t            ON t.store_id = pv.store_id
+ WHERE sh.location_id = '00000000-0000-0000-0000-000000000001'
+    ON CONFLICT (cart_token, variant_id, location_id)
+    DO UPDATE SET qty        = stock_holds.qty + EXCLUDED.qty,
+                  expires_at = GREATEST(stock_holds.expires_at, EXCLUDED.expires_at);
+
+DELETE FROM stock_holds sh
+ USING product_variants pv
+ WHERE sh.variant_id = pv.id
+   AND sh.location_id = '00000000-0000-0000-0000-000000000001'
+   AND EXISTS (
+           SELECT 1 FROM warehouses w
+            WHERE w.store_id = pv.store_id AND w.archived_at IS NULL
+       );

--- a/services/marketplace-api/migrations_backfill_sentinel_integration_test.go
+++ b/services/marketplace-api/migrations_backfill_sentinel_integration_test.go
@@ -1,0 +1,294 @@
+//go:build integration
+
+// #177 PR 6 — the sentinel backfill (migration 000123).
+//
+// Tested by executing the migration's own SQL inside a rolled-back
+// transaction, rather than by asserting on a pre-migrated fixture: the
+// thing that can be wrong here is the SQL, and a test that re-implements
+// it would agree with itself.
+//
+// The case that drove these tests is the one the spec gets wrong. It says
+// "production has zero warehouses", so the backfill may simply CREATE a
+// 'Main Warehouse' per store. the-bondi-store has had one — with a real
+// address — since 2026-09-01, and warehouses is keyed (store_id, name).
+package marketplaceapi_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+const sentinel = "00000000-0000-0000-0000-000000000001"
+
+// runBackfill executes migrations/000123 statement by statement.
+func runBackfill(t *testing.T, tx *gorm.DB) {
+	t.Helper()
+	raw, err := os.ReadFile("migrations/000123_backfill_sentinel_stock.up.sql")
+	require.NoError(t, err)
+
+	// Strip comments BEFORE splitting. A prose semicolon inside a comment
+	// ("safe in either order; the reverse is not") otherwise splits a
+	// statement in half, and the fragment fails with a syntax error that
+	// looks nothing like the real cause.
+	body := make([]string, 0)
+	for _, l := range strings.Split(string(raw), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(l), "--") {
+			continue
+		}
+		body = append(body, l)
+	}
+
+	for _, stmt := range strings.Split(strings.Join(body, "\n"), ";") {
+		cleaned := strings.TrimSpace(stmt)
+		if cleaned == "" {
+			continue
+		}
+		require.NoError(t, tx.Exec(cleaned).Error, "statement: %s", cleaned)
+	}
+}
+
+// seedStoreWithSentinelStock creates a store, a product, one variant and
+// qty units on the sentinel — the exact shape of every product in
+// production today.
+func seedStoreWithSentinelStock(t *testing.T, tx *gorm.DB, qty int) (storeID, tenantID, variantID string) {
+	t.Helper()
+	tenantID, storeID = uuid.NewString(), uuid.NewString()
+	require.NoError(t, tx.Exec(
+		`INSERT INTO stores (id, tenant_id, name, slug, status, country_code, currency_code,
+		                     timezone, storefront_customer_portal_secret)
+		 VALUES (?, ?, 'Backfill Store', ?, 'active', 'AU', 'AUD', 'Australia/Sydney', ?)`,
+		storeID, tenantID, "bf-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	productID := uuid.NewString()
+	require.NoError(t, tx.Exec(
+		`INSERT INTO products (id, tenant_id, store_id, title, handle, status, vendor_id, published_at)
+		 VALUES (?, ?, ?, 'Backfill Product', ?, 'active', ?, now())`,
+		productID, tenantID, storeID, "bf-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	variantID = uuid.NewString()
+	require.NoError(t, tx.Exec(
+		`INSERT INTO product_variants (id, product_id, store_id, sku, price, currency_code)
+		 VALUES (?, ?, ?, ?, 10.00, 'AUD')`,
+		variantID, productID, storeID, "BF-"+uuid.NewString()[:8]).Error)
+	require.NoError(t, tx.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, ?, now())`, variantID, sentinel, qty).Error)
+	return storeID, tenantID, variantID
+}
+
+func seedNamedWarehouse(t *testing.T, tx *gorm.DB, tenantID, storeID, name, line1 string) string {
+	t.Helper()
+	id := uuid.NewString()
+	require.NoError(t, tx.Exec(
+		`INSERT INTO warehouses (id, tenant_id, store_id, name, line1, city, region,
+		                         postal_code, country_code, phone, is_default)
+		 VALUES (?, ?, ?, ?, ?, 'Bondi Beach', 'NSW', '2026', 'AU', '+61255500000', true)`,
+		id, tenantID, storeID, name, line1).Error)
+	return id
+}
+
+func stockAt(t *testing.T, tx *gorm.DB, variantID, locationID string) int {
+	t.Helper()
+	var q int
+	require.NoError(t, tx.Raw(
+		`SELECT COALESCE((SELECT quantity FROM variant_stock
+		                   WHERE variant_id = ? AND location_id = ?), -1)`,
+		variantID, locationID).Scan(&q).Error)
+	return q
+}
+
+func liveWarehouses(t *testing.T, tx *gorm.DB, storeID string) []string {
+	t.Helper()
+	var names []string
+	require.NoError(t, tx.Raw(
+		`SELECT name FROM warehouses WHERE store_id = ? AND archived_at IS NULL ORDER BY name`,
+		storeID).Scan(&names).Error)
+	return names
+}
+
+// A store with no warehouse gets one, and its stock moves onto it.
+func TestBackfill_StoreWithNoWarehouseGetsOneAndItsStockMoves(t *testing.T) {
+	tx := testdb.NewTx(t)
+	storeID, _, variantID := seedStoreWithSentinelStock(t, tx, 16)
+
+	runBackfill(t, tx)
+
+	require.Equal(t, []string{"Main Warehouse"}, liveWarehouses(t, tx, storeID))
+	require.Equal(t, -1, stockAt(t, tx, variantID, sentinel), "the sentinel row must be gone")
+
+	var moved int
+	require.NoError(t, tx.Raw(
+		`SELECT vs.quantity FROM variant_stock vs
+		   JOIN warehouses w ON w.id = vs.location_id
+		  WHERE vs.variant_id = ? AND w.store_id = ?`, variantID, storeID).Scan(&moved).Error)
+	require.Equal(t, 16, moved)
+}
+
+// THE test #515 asked for. bondi already has a 'Main Warehouse' with a real
+// address. A naive INSERT violates (store_id, name); an ON CONFLICT DO
+// NOTHING leaves the stock behind while the code believes it migrated.
+func TestBackfill_ExistingMainWarehouseIsReusedNotDuplicated(t *testing.T) {
+	tx := testdb.NewTx(t)
+	storeID, tenantID, variantID := seedStoreWithSentinelStock(t, tx, 16354)
+	existing := seedNamedWarehouse(t, tx, tenantID, storeID, "Main Warehouse", "1 Campbell Parade")
+
+	runBackfill(t, tx)
+
+	require.Equal(t, []string{"Main Warehouse"}, liveWarehouses(t, tx, storeID),
+		"a second 'Main Warehouse' must not be created")
+	require.Equal(t, 16354, stockAt(t, tx, variantID, existing),
+		"the stock must land on the warehouse that already existed")
+	require.Equal(t, -1, stockAt(t, tx, variantID, sentinel))
+
+	// The merchant's address must survive untouched — the backfill's blank
+	// address is for stores that never had one.
+	var line1 string
+	require.NoError(t, tx.Raw(`SELECT line1 FROM warehouses WHERE id = ?`, existing).Scan(&line1).Error)
+	require.Equal(t, "1 Campbell Parade", line1)
+}
+
+// A store whose warehouse is named something else must use THAT one, not
+// gain a second called 'Main Warehouse' beside it.
+func TestBackfill_DifferentlyNamedWarehouseIsUsedAsIs(t *testing.T) {
+	tx := testdb.NewTx(t)
+	storeID, tenantID, variantID := seedStoreWithSentinelStock(t, tx, 40)
+	existing := seedNamedWarehouse(t, tx, tenantID, storeID, "Bondi Depot", "1 Campbell Parade")
+
+	runBackfill(t, tx)
+
+	require.Equal(t, []string{"Bondi Depot"}, liveWarehouses(t, tx, storeID))
+	require.Equal(t, 40, stockAt(t, tx, variantID, existing))
+}
+
+// A variant can carry BOTH a sentinel row and a real row for the same
+// warehouse — 5e clears the sentinel, but the multi-variant product save
+// still writes it. Availability adds them today, so the backfill must sum:
+// overwriting would silently delete stock the merchant is selling.
+func TestBackfill_SentinelAndRealRowAreSummedNotOverwritten(t *testing.T) {
+	tx := testdb.NewTx(t)
+	storeID, tenantID, variantID := seedStoreWithSentinelStock(t, tx, 10)
+	existing := seedNamedWarehouse(t, tx, tenantID, storeID, "Main Warehouse", "1 Campbell Parade")
+	require.NoError(t, tx.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, 5, now())`, variantID, existing).Error)
+
+	runBackfill(t, tx)
+
+	require.Equal(t, 15, stockAt(t, tx, variantID, existing),
+		"10 on the sentinel + 5 already there = 15, the total availability reports today")
+	require.Equal(t, -1, stockAt(t, tx, variantID, sentinel))
+	_ = storeID
+}
+
+// A live cart hold on the sentinel must MOVE, not vanish: deleting it
+// releases a shopper's reservation mid-checkout and lets someone else take
+// the units they are paying for.
+func TestBackfill_LiveHoldsMoveWithTheStock(t *testing.T) {
+	tx := testdb.NewTx(t)
+	storeID, tenantID, variantID := seedStoreWithSentinelStock(t, tx, 10)
+	existing := seedNamedWarehouse(t, tx, tenantID, storeID, "Main Warehouse", "1 Campbell Parade")
+	cart := uuid.NewString()
+	require.NoError(t, tx.Exec(
+		`INSERT INTO stock_holds (variant_id, location_id, cart_token, qty, expires_at, state)
+		 VALUES (?, ?, ?, 3, now() + interval '10 minutes', 'held')`,
+		variantID, sentinel, cart).Error)
+
+	runBackfill(t, tx)
+
+	var qty int
+	require.NoError(t, tx.Raw(
+		`SELECT COALESCE((SELECT qty FROM stock_holds
+		                   WHERE cart_token = ? AND variant_id = ? AND location_id = ?), -1)`,
+		cart, variantID, existing).Scan(&qty).Error)
+	require.Equal(t, 3, qty, "the hold must have moved to the real warehouse")
+
+	var onSentinel int64
+	require.NoError(t, tx.Raw(
+		`SELECT count(*) FROM stock_holds WHERE variant_id = ? AND location_id = ?`,
+		variantID, sentinel).Scan(&onSentinel).Error)
+	require.Zero(t, onSentinel)
+}
+
+// Migrations get re-run in recovery and in fresh environments. A second
+// pass must be a no-op, not a doubling.
+func TestBackfill_IsIdempotent(t *testing.T) {
+	tx := testdb.NewTx(t)
+	storeID, tenantID, variantID := seedStoreWithSentinelStock(t, tx, 16)
+	existing := seedNamedWarehouse(t, tx, tenantID, storeID, "Main Warehouse", "1 Campbell Parade")
+
+	runBackfill(t, tx)
+	runBackfill(t, tx)
+
+	require.Equal(t, 16, stockAt(t, tx, variantID, existing),
+		"a second run must not double the stock")
+	require.Equal(t, []string{"Main Warehouse"}, liveWarehouses(t, tx, storeID))
+}
+
+// An ARCHIVED warehouse is removed as far as the merchant is concerned, and
+// the allocator refuses to fill from it (#528). Backfilling onto one would
+// park every unit somewhere unsellable.
+func TestBackfill_ArchivedWarehouseIsNotATarget(t *testing.T) {
+	tx := testdb.NewTx(t)
+	storeID, tenantID, variantID := seedStoreWithSentinelStock(t, tx, 10)
+	archived := seedNamedWarehouse(t, tx, tenantID, storeID, "Gone", "1 Old Road")
+	require.NoError(t, tx.Exec(
+		`UPDATE warehouses SET archived_at = now(), is_default = false WHERE id = ?`, archived).Error)
+
+	runBackfill(t, tx)
+
+	require.Equal(t, []string{"Main Warehouse"}, liveWarehouses(t, tx, storeID),
+		"a store whose only warehouse is archived must get a live one")
+	require.Equal(t, -1, stockAt(t, tx, variantID, archived),
+		"no stock may be parked on an archived warehouse")
+	require.Equal(t, -1, stockAt(t, tx, variantID, sentinel))
+}
+
+// The case above cannot catch a missing archived_at filter on its own: the
+// warehouse the backfill creates is is_default = true, so it wins the
+// ordering regardless. The filter only earns its keep when an archived row
+// would otherwise SORT FIRST — an older one, at a store that already has a
+// live warehouse so nothing new is created. A mutation proved the gap.
+func TestBackfill_OlderArchivedWarehouseDoesNotWinOverALiveOne(t *testing.T) {
+	tx := testdb.NewTx(t)
+	storeID, tenantID, variantID := seedStoreWithSentinelStock(t, tx, 25)
+
+	archived := seedNamedWarehouse(t, tx, tenantID, storeID, "Old Depot", "1 Old Road")
+	live := seedNamedWarehouse(t, tx, tenantID, storeID, "Current Depot", "2 New Road")
+	// Neither is the default, so the tie-break falls to created_at — and the
+	// archived one is older.
+	require.NoError(t, tx.Exec(
+		`UPDATE warehouses SET is_default = false WHERE store_id = ?`, storeID).Error)
+	require.NoError(t, tx.Exec(
+		`UPDATE warehouses SET archived_at = now(), created_at = now() - interval '30 days'
+		  WHERE id = ?`, archived).Error)
+
+	runBackfill(t, tx)
+
+	require.Equal(t, 25, stockAt(t, tx, variantID, live),
+		"the stock must land on the LIVE warehouse")
+	require.Equal(t, -1, stockAt(t, tx, variantID, archived),
+		"an archived warehouse must never be the backfill target, however it sorts")
+}
+
+// A store with no sentinel stock must not gain a warehouse it never asked
+// for — the backfill is a migration, not a provisioning step.
+func TestBackfill_StoreWithoutSentinelStockIsUntouched(t *testing.T) {
+	tx := testdb.NewTx(t)
+	tenantID, storeID := uuid.NewString(), uuid.NewString()
+	require.NoError(t, tx.Exec(
+		`INSERT INTO stores (id, tenant_id, name, slug, status, country_code, currency_code,
+		                     timezone, storefront_customer_portal_secret)
+		 VALUES (?, ?, 'Quiet Store', ?, 'active', 'AU', 'AUD', 'Australia/Sydney', ?)`,
+		storeID, tenantID, "q-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	runBackfill(t, tx)
+
+	require.Empty(t, liveWarehouses(t, tx, storeID))
+}

--- a/services/marketplace-api/testint_coverage_test.go
+++ b/services/marketplace-api/testint_coverage_test.go
@@ -194,6 +194,16 @@ func testIntPatterns(makefilePath string) ([]string, error) {
 			continue
 		}
 		for _, field := range strings.Fields(strings.TrimSuffix(trimmed, "\\")) {
+			// A bare "." is the service ROOT package. It carries integration
+			// tests as of #177 PR 6 (the sentinel backfill executes its own
+			// migration SQL, which lives beside migrations.go), and the
+			// parser previously recognised only "./"-prefixed patterns — so
+			// the root could never be marked covered however the Makefile
+			// spelled it.
+			if field == "." {
+				patterns = append(patterns, ".")
+				continue
+			}
 			if strings.HasPrefix(field, "./") {
 				patterns = append(patterns, strings.TrimPrefix(field, "./"))
 			}


### PR DESCRIPTION
Refs #177, closes the data half of the contract step. **Migration only — no code changes to the sentinel tolerance, and `DefaultLocationID` is untouched.** See *Why this is only step 1* below.

Every unit in production still sits on `location_id = '00000000-…-0001'`. I re-checked against prod while writing this: **380 rows, 16,354 units, zero at Main Warehouse.** Allocation is structurally correct and economically hollow until this runs.

## The spec is wrong here, and it matters

> production has zero warehouses and zero carrier configs

That was true when the spec was written and false since 2026-09-01. `the-bondi-store` has a warehouse named **exactly `Main Warehouse`**, with a real address, and `warehouses` is keyed `(store_id, name)` — partially, since 000122. The spec has the backfill simply *create* one per store with that name, which against production either violates the index or, with `ON CONFLICT DO NOTHING`, **silently leaves the stock on the sentinel while the code believes it migrated.**

So the migration find-or-creates, and never touches an address a merchant has entered. `TestBackfill_ExistingMainWarehouseIsReusedNotDuplicated` is that case, seeded exactly as bondi is.

## What it does

1. **Creates a warehouse only for stores holding sentinel stock and having no live warehouse at all.** A store that already has one — under *any* name — uses it. The address is left blank deliberately: that store has never said where it ships from, and a plausible-looking placeholder is a lie that quotes rates.
2. **Moves `variant_stock` onto the store's warehouse**, chosen by the same precedence as `warehouse.DefaultForStore` (flagged default, then fill order, then oldest), **excluding archived** — the allocator refuses to fill from those (#528), so backfilling onto one parks every unit somewhere unsellable.
3. **Moves `stock_holds` too.** Deleting them would release a shopper's reservation mid-checkout and let someone else take the units they are paying for.

**Conflicts SUM, they do not overwrite.** A variant can carry both a sentinel row and a real row for the same warehouse — 5e clears the sentinel on edit, but the multi-variant product save still writes it. `checkout_availability` adds them together today, so summing preserves the total the merchant is already selling; overwriting would silently delete stock.

**No temp table.** The first draft materialised the target into `CREATE TEMP TABLE … ON COMMIT DROP`, which only survives if the whole migration runs in one transaction — true under golang-migrate, **false under `psql -f` in autocommit**, which is how a migration gets applied by hand during an incident. It failed exactly that way when I applied it to the dev database. It is a repeated CTE now.

**The down migration refuses to run.** Reversing would mean summing every warehouse row back onto the sentinel, which cannot tell stock this migration moved from a per-warehouse split the merchant made themselves via 5e — a merchant holding 10 in Sydney and 5 in Melbourne would get back 15 in one undifferentiated pile. It raises an exception telling you to restore from a snapshot.

## Why this is only step 1

The spec's expand/contract reasoning still holds: migrations run in the `migrate` initContainer on the **admin** deployment only, while `marketplace-api-storefront` and the sweeper CronJobs roll independently. Removing the sentinel tolerance in the same PR as the backfill risks a storefront pod on the old image reading a location that no longer has rows — every shopper told the item is sold out.

Landing the data move alone is safe in either rollout order: after it there are simply no sentinel rows, and the tolerance never fires. **Step 2** — deleting `DefaultLocationID`, its nine call sites and the tolerance — comes once this is confirmed run in production.

## Tests

**9 integration tests**, executing the migration's own SQL inside a rolled-back transaction rather than asserting against a pre-migrated fixture: the thing that can be wrong here is the SQL, and a test that re-implemented it would only agree with itself.

Four mutations, all caught:

| mutation | caught by |
|---|---|
| no find-or-create guard (the spec's naive INSERT) | 6 tests |
| overwrite instead of summing | `SentinelAndRealRowAreSummedNotOverwritten` |
| archived warehouses accepted as targets | `OlderArchivedWarehouseDoesNotWinOverALiveOne` |
| live holds dropped rather than moved | `LiveHoldsMoveWithTheStock` |

The archived-target mutation **survived the first attempt**: my original test archived the store's only warehouse, so the one the backfill creates is `is_default = true` and wins the ordering regardless. The filter only earns its keep when an archived row would otherwise *sort first* — an older one at a store that already has a live warehouse. That second test is what actually pins it.

## Two guards I tripped

- **`TestEveryIntegrationPackageIsInTheTestIntTarget`** caught that the service ROOT package now has integration tests and `make test-int` never ran it. Added to the Makefile — and the guard's parser only recognised `./`-prefixed patterns, so the root could never be marked covered however it was spelled. Parser extended; removing the entry still fails the guard.
- **`ExpectedSchemaVersion`** bumped to 123.

Applied by hand to the dev database and re-run: idempotent. Full suite — exit 0, 120 packages ok, **3302 PASS / 25 SKIP / 0 FAIL**; `go vet -tags=integration ./...` clean.

## Before merging

This rewrites every stock row in production. Worth taking a Cloud SQL snapshot first — the down migration deliberately will not undo it.