### PR TITLE
fix(admin): stop the page entrance animation trapping modal overlays

### DIFF
--- a/apps/admin/components/layout/AdminPage.NoContainingBlock.test.tsx
+++ b/apps/admin/components/layout/AdminPage.NoContainingBlock.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { AdminPage } from "./AdminPage";
+
+// A `position: fixed` element is positioned against the VIEWPORT only while
+// no ancestor establishes a containing block. Any ancestor with a transform
+// takes that job over, and `inset-0` then covers that ancestor's box.
+//
+// AdminPage's entrance animation used `animation-fill-mode: both`, which
+// keeps the ANIMATED value applied for as long as the page is mounted.
+// fadeInUp ends on `transform: none`, but an animated `none` computes to
+// the identity matrix(1, 0, 0, 1, 0, 0) — still a transform. Every modal
+// rendered inside a page therefore drew its scrim as a grey rectangle over
+// the content column, leaving the sidebar and header bright. Measured live:
+// 1152x448 at (512, 113) in a 1920x779 viewport.
+//
+// `backwards` reverts to the natural style when the animation ends, which
+// is visually identical here and leaves no containing block behind.
+describe("AdminPage — entrance animation", () => {
+  it("does not use fill-mode `both`, which would trap fixed-position children", () => {
+    const { container } = render(
+      <AdminPage title="Warehouses">
+        <p>content</p>
+      </AdminPage>,
+    );
+
+    const root = container.firstElementChild;
+    expect(root).not.toBeNull();
+    const cls = root!.className;
+
+    expect(cls).toContain("animate-[fadeInUp");
+    expect(cls).not.toMatch(/fadeInUp[^\]]*_both\]/);
+    expect(cls).toMatch(/fadeInUp[^\]]*_backwards\]/);
+  });
+
+  it("still renders its children and title", () => {
+    render(
+      <AdminPage title="Warehouses">
+        <p>content</p>
+      </AdminPage>,
+    );
+    expect(screen.getByText("Warehouses")).toBeInTheDocument();
+    expect(screen.getByText("content")).toBeInTheDocument();
+  });
+});

--- a/apps/admin/components/layout/AdminPage.tsx
+++ b/apps/admin/components/layout/AdminPage.tsx
@@ -65,8 +65,23 @@ export function AdminPage({
   // The entrance animation smooths the skeleton→content swap on route
   // changes (M3 "emphasized decelerate" feel via ease-out-expo). Guarded
   // by motion-safe; prefers-reduced-motion users get an instant swap.
+  //
+  // fill-mode is `backwards`, NOT `both`, and that is load-bearing.
+  // fadeInUp ends on `transform: none`, but `both` keeps the ANIMATED
+  // value applied for as long as the page is mounted — and an animated
+  // `none` computes to the identity matrix(1, 0, 0, 1, 0, 0), which is
+  // still a transform. A transformed ancestor becomes the containing
+  // block for every `position: fixed` descendant, so `inset-0` stopped
+  // meaning "the viewport" and started meaning "this div": modal scrims
+  // rendered as a grey rectangle over the content column while the
+  // sidebar and header stayed bright. Measured on the live page: the
+  // overlay was 1152x448 at (512, 113) inside a 1920x779 viewport.
+  //
+  // `backwards` reverts to the element's natural style once the animation
+  // finishes — opacity 1, no transform — which is visually identical to
+  // the final keyframe and leaves no containing block behind.
   return (
-    <div className="space-y-10 motion-safe:animate-[fadeInUp_0.35s_var(--ease-out)_both]">
+    <div className="space-y-10 motion-safe:animate-[fadeInUp_0.35s_var(--ease-out)_backwards]">
       <header className="space-y-4">
         <div className="flex flex-wrap items-end justify-between gap-x-6 gap-y-4">
           <div className="min-w-0 flex-1 space-y-3">


### PR DESCRIPTION
You reported the confirm dialog on **Shipping** rendering its scrim as a grey rectangle over the content column, while the **product edit** discard dialog looked correct. Same component, different result — and the difference is the page wrapper, not the dialog.

## Cause

`AdminPage` wraps every page in:

```
motion-safe:animate-[fadeInUp_0.35s_var(--ease-out)_both]
```

`fadeInUp` ends on `transform: none`, which looks harmless. But `animation-fill-mode: both` keeps the **animated** value applied for as long as the page is mounted, and an animated `none` computes to the identity `matrix(1, 0, 0, 1, 0, 0)` — still a transform.

A transformed ancestor becomes the **containing block** for every `position: fixed` descendant. So the dialog's `inset-0` stopped meaning "the viewport" and started meaning "this div". Measured on the live page:

```
viewport      1920 x 779  at (0, 0)
overlay rect  1152 x 448  at (512, 113)
```

The product edit page renders a plain `<main>` rather than `AdminPage`, which is why its dialog was unaffected — and why this looked like a dialog bug when it is a page-wrapper bug.

## Fix

`both` → `backwards`. The animation reverts to the element's natural style once it finishes — `opacity: 1`, no transform — which is **visually identical** to the final keyframe here, and leaves no containing block behind. The entrance animation is unchanged.

Every modal inside every `AdminPage` is fixed by this, not just the warehouses one.

## Tests

`AdminPage.NoContainingBlock.test.tsx` asserts the class carries `backwards` and not `both`, with the reasoning in the file so the next person to touch the animation knows why. Mutation-tested: putting `both` back fails it.

Admin suite: **108 files, 842 tests passing**; `tsc --noEmit` clean.

## Relationship to tesserix/design-system#46

That PR portals `AlertDialog` to `document.body`, which fixes this class of bug for **any** consumer regardless of what their ancestors do — a dialog should not be breakable by a decorative animation three levels up. It is still the right fix and worth landing.

This one is complementary and lands immediately: it removes an unnecessary containing block from the admin, and does not wait on a design-system release (merge → changeset version PR → npm publish → version bump here). That release chain is why the dialog is still broken in production despite #46 existing.