### PR TITLE
refactor(warehouse): retire DefaultLocationID and the sentinel tolerance (#177 PR 6, step 2)

### DIFF
--- a/services/marketplace-api/internal/handlers/admin/variant_stock_by_location_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/variant_stock_by_location_integration_test.go
@@ -16,7 +16,6 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/authz"
-	"github.com/mark8ly/marketplace-api/internal/product"
 )
 
 // seedWarehouseFor inserts a live warehouse for a store.
@@ -29,6 +28,22 @@ func seedStockWarehouse(t *testing.T, db *gorm.DB, tenantID, storeID, name strin
 		 VALUES (?, ?, ?, ?, '1 Dock Rd', 'Mumbai', 'MH', '400001', 'IN', '+912200000000')`,
 		id, tenantID, storeID, name).Error; err != nil {
 		t.Fatalf("seed warehouse: %v", err)
+	}
+	return id
+}
+
+// storeWarehouseID returns the warehouse the store's stock writes resolve
+// to. Product writes create one when the store has none (#177 PR 6), so
+// after seeding a product this always finds a row.
+func storeWarehouseID(t *testing.T, db *gorm.DB, storeID string) string {
+	t.Helper()
+	var id string
+	if err := db.Raw(
+		`SELECT id::text FROM warehouses
+		  WHERE store_id = ? AND archived_at IS NULL
+		  ORDER BY is_default DESC, priority ASC, created_at ASC LIMIT 1`,
+		storeID).Row().Scan(&id); err != nil {
+		t.Fatalf("no warehouse for store %s: %v", storeID, err)
 	}
 	return id
 }
@@ -89,11 +104,12 @@ func TestAPI_VariantStock_PerLocationSaveConservesTheTotal(t *testing.T) {
 	env.fga.Grant(userID, authz.RoleStaff, tenantID)
 
 	productID, variantID := seedProductWithStock(t, env, storeID, tenantID, userID, 10)
-	if got := stockAtLoc(t, env.db, variantID, product.DefaultLocationID); got != 10 {
-		t.Fatalf("precondition: sentinel stock = %d, want 10", got)
+	// Seeding the product created the store's warehouse and put the units
+	// there — the sentinel is gone (#177 PR 6).
+	whA := storeWarehouseID(t, env.db, storeID)
+	if got := stockAtLoc(t, env.db, variantID, whA); got != 10 {
+		t.Fatalf("precondition: warehouse stock = %d, want 10", got)
 	}
-
-	whA := seedStockWarehouse(t, env.db, tenantID, storeID, "Alpha")
 	whB := seedStockWarehouse(t, env.db, tenantID, storeID, "Bravo")
 
 	w := request(t, env.router, http.MethodPatch, variantURL(storeID, productID, variantID),
@@ -103,8 +119,8 @@ func TestAPI_VariantStock_PerLocationSaveConservesTheTotal(t *testing.T) {
 		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
 	}
 
-	if got := stockAtLoc(t, env.db, variantID, product.DefaultLocationID); got != -1 {
-		t.Fatalf("sentinel row survived with %d units — its stock is double-counted", got)
+	if got := stockAtLoc(t, env.db, variantID, retiredSentinelLoc); got != -1 {
+		t.Fatalf("nothing may live on the retired sentinel, found %d", got)
 	}
 	if got := stockAtLoc(t, env.db, variantID, whA); got != 10 {
 		t.Fatalf("warehouse A = %d, want 10", got)
@@ -121,8 +137,11 @@ func TestAPI_VariantStock_PerLocationSaveConservesTheTotal(t *testing.T) {
 	}
 }
 
-// The single-warehouse path must be untouched by this slice.
-func TestAPI_VariantStock_PlainQuantityStillWritesTheSentinel(t *testing.T) {
+// The single-quantity path: one number, written to the store's warehouse.
+// It used to write the sentinel; #177 PR 6 retired that, and a store with
+// no warehouse gets one created rather than falling back to a location
+// that names nothing.
+func TestAPI_VariantStock_PlainQuantityWritesTheStoreWarehouse(t *testing.T) {
 	env := setupTestRouter(t)
 	storeID, tenantID := seedStoreRow(t, env.db, "")
 	userID := uuid.NewString()
@@ -137,8 +156,12 @@ func TestAPI_VariantStock_PlainQuantityStillWritesTheSentinel(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
 	}
-	if got := stockAtLoc(t, env.db, variantID, product.DefaultLocationID); got != 42 {
-		t.Fatalf("sentinel = %d, want 42 — the single-warehouse path must be unchanged", got)
+	wh := storeWarehouseID(t, env.db, storeID)
+	if got := stockAtLoc(t, env.db, variantID, wh); got != 42 {
+		t.Fatalf("warehouse stock = %d, want 42", got)
+	}
+	if got := stockAtLoc(t, env.db, variantID, retiredSentinelLoc); got != -1 {
+		t.Fatalf("nothing may be written to the retired sentinel, found %d", got)
 	}
 }
 
@@ -181,8 +204,8 @@ func TestAPI_VariantStock_AnotherStoresWarehouseIsRefused(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
 	}
-	if got := stockAtLoc(t, env.db, variantID, product.DefaultLocationID); got != 10 {
-		t.Fatalf("a refused save moved stock: sentinel = %d, want 10", got)
+	if got := stockAtLoc(t, env.db, variantID, storeWarehouseID(t, env.db, storeID)); got != 10 {
+		t.Fatalf("a refused save moved stock: warehouse = %d, want 10", got)
 	}
 }
 
@@ -239,8 +262,19 @@ func TestAPI_ProductGet_CarriesThePerLocationBreakdown(t *testing.T) {
 	if len(resp.Variants) == 0 {
 		t.Fatalf("no variants: %s", get.Body.String())
 	}
-	if got := resp.Variants[0].InventoryByLocation[product.DefaultLocationID]; got != 10 {
-		t.Fatalf("sentinel breakdown = %d, want 10 (variant %s): %s",
+	wh := storeWarehouseID(t, env.db, storeID)
+	if got := resp.Variants[0].InventoryByLocation[wh]; got != 10 {
+		t.Fatalf("warehouse breakdown = %d, want 10 (variant %s): %s",
 			got, variantID, get.Body.String())
 	}
+	if _, present := resp.Variants[0].InventoryByLocation[retiredSentinelLoc]; present {
+		t.Fatalf("the retired sentinel must not appear in a breakdown: %s", get.Body.String())
+	}
 }
+
+// retiredSentinelLoc is the location every stock row carried before #177 PR 6
+// moved them onto real warehouses. The production constant is gone;
+// these tests still need the value precisely BECAUSE nothing writes it
+// any more — a straggler row from an old pod or a restored backup must
+// still be swept, and that is what they pin.
+const retiredSentinelLoc = "00000000-0000-0000-0000-000000000001"

--- a/services/marketplace-api/internal/handlers/storefront/cart_holds.go
+++ b/services/marketplace-api/internal/handlers/storefront/cart_holds.go
@@ -10,9 +10,9 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
-	"github.com/mark8ly/marketplace-api/internal/product"
 	"github.com/mark8ly/marketplace-api/internal/stockhold"
 	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
 )
 
 // CartTokenCookie is the first-party cookie carrying the server-minted cart
@@ -103,6 +103,28 @@ func (h *CartHoldsHandler) Place(c *gin.Context) {
 	results := make([]cartHoldItemResult, 0, len(req.Items))
 
 	err := h.db.Transaction(func(tx *gorm.DB) error {
+		// Where this store's stock lives. Read-only on purpose: a shopper
+		// adding to their cart must never create merchant configuration,
+		// so unlike the product write paths this does NOT ensure a
+		// warehouse. A store without one has no stock rows either — every
+		// write path creates one — so there is nothing to hold, and the
+		// items below are reported insufficient rather than held against a
+		// location that names nothing (#177 PR 6 step 2).
+		var holdLocationID string
+		wh, whErr := warehouse.NewRepository().DefaultForStore(c.Request.Context(), tx, storeID)
+		switch {
+		case whErr == nil:
+			holdLocationID = wh.ID
+		case errors.Is(whErr, warehouse.ErrNotFound):
+			// Leave holdLocationID empty and fall through. Returning early
+			// here skipped the per-item ownership check below — which is
+			// the one thing on this unauthenticated surface that stops a
+			// caller probing another store's variants through any store's
+			// slug. A test caught it; the check runs first, always.
+		default:
+			return whErr
+		}
+
 		for _, item := range req.Items {
 			// Ownership check FIRST. This surface is unauthenticated beyond
 			// the shared storefront key, so without it a caller could hold
@@ -118,15 +140,26 @@ func (h *CartHoldsHandler) Place(c *gin.Context) {
 				return errVariantNotInStore
 			}
 
+			if holdLocationID == "" {
+				// The store has no warehouse, so it has no stock rows
+				// either — every write path creates one. Nothing to hold,
+				// and reporting it as insufficient is the truth rather
+				// than holding against a location that names nothing.
+				results = append(results, cartHoldItemResult{
+					VariantID: item.VariantID, Status: "insufficient", Available: 0,
+				})
+				continue
+			}
+
 			err := h.holds.Hold(c.Request.Context(), tx, cartToken, item.VariantID,
-				product.DefaultLocationID, item.Quantity, HoldTTL)
+				holdLocationID, item.Quantity, HoldTTL)
 			switch {
 			case err == nil:
 				results = append(results, cartHoldItemResult{
 					VariantID: item.VariantID, Status: "held", Available: item.Quantity,
 				})
 			case errors.Is(err, stockhold.ErrInsufficientStock):
-				avail, aerr := h.holds.Available(c.Request.Context(), tx, item.VariantID, product.DefaultLocationID, cartToken)
+				avail, aerr := h.holds.Available(c.Request.Context(), tx, item.VariantID, holdLocationID, cartToken)
 				if aerr != nil {
 					return aerr
 				}

--- a/services/marketplace-api/internal/handlers/storefront/cart_holds_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/cart_holds_integration_test.go
@@ -249,8 +249,36 @@ func insertVariantWithStock(t *testing.T, db *gorm.DB, tenantID, storeID string,
 		 VALUES (?, ?, ?, ?, 10.00, 'EUR')`,
 		variantID, productID, storeID, "SKU-"+uuid.NewString()[:8]).Error)
 
+	// Stock lives at the store's warehouse, not at a sentinel location.
+	// #177 PR 6 retired the sentinel: every write path resolves a real
+	// warehouse, and cart holds are placed against it. Seeding the old way
+	// here would test a state production can no longer be in.
+	locationID := ensureTestWarehouse(t, db, tenantID, storeID)
 	require.NoError(t, db.Exec(
 		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
-		 VALUES (?, '00000000-0000-0000-0000-000000000001', ?, now())`, variantID, qty).Error)
+		 VALUES (?, ?, ?, now())`, variantID, locationID, qty).Error)
 	return variantID
+}
+
+// ensureTestWarehouse returns the store's warehouse, creating one if it has
+// none — the same find-or-create the product write paths do.
+func ensureTestWarehouse(t *testing.T, db *gorm.DB, tenantID, storeID string) string {
+	t.Helper()
+	var existing string
+	err := db.Raw(
+		`SELECT id::text FROM warehouses
+		  WHERE store_id = ? AND archived_at IS NULL
+		  ORDER BY is_default DESC, priority ASC, created_at ASC LIMIT 1`,
+		storeID).Row().Scan(&existing)
+	if err == nil && existing != "" {
+		return existing
+	}
+	id := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO warehouses (id, tenant_id, store_id, name, line1, city, region,
+		                         postal_code, country_code, phone, is_default)
+		 VALUES (?, ?, ?, 'Main Warehouse', '1 Dock Rd', 'Mumbai', 'MH', '400001', 'IN',
+		         '+912200000000', true)`,
+		id, tenantID, storeID).Error)
+	return id
 }

--- a/services/marketplace-api/internal/handlers/storefront/checkout_allocation_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_allocation_integration_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
-	"github.com/mark8ly/marketplace-api/internal/product"
+	"github.com/mark8ly/marketplace-api/internal/allocation"
 	"github.com/mark8ly/marketplace-api/internal/stockhold"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
@@ -74,32 +74,37 @@ func stockUnitsAt(t *testing.T, db *gorm.DB, variantID, locationID string) int {
 	return q
 }
 
-// THE load-bearing test. Production has zero warehouses; if this regresses,
-// every checkout fails.
-func TestCommitStock_StoreWithNoWarehousesBehavesExactlyAsBefore(t *testing.T) {
+// Replaces TestCommitStock_StoreWithNoWarehousesBehavesExactlyAsBefore,
+// which pinned the pre-#177 fallback: hold and decrement at a sentinel
+// location, write no allocations. That path is gone.
+//
+// Every store that holds stock now has a warehouse — product writes
+// resolve one, creating it if the store had none, and migration 000123
+// moved the existing rows. So a store with no warehouse has no products,
+// and a checkout against one is a broken invariant rather than a normal
+// case. It must fail LOUDLY: holding stock at a location that names
+// nothing is exactly what made allocation economically hollow.
+func TestCommitStock_StoreWithNoWarehousesFailsLoudlyInsteadOfUsingASentinel(t *testing.T) {
 	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
 		"variant_stock", "product_variants", "products", "stores")
 	storeID, variantID := seedAvailStore(t, db)
+	orphan := uuid.NewString()
 	require.NoError(t, db.Exec(
 		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
-		 VALUES (?, ?, 5, now())`, variantID, product.DefaultLocationID).Error)
+		 VALUES (?, ?, 5, now())`, variantID, orphan).Error)
 
 	lines := []stockLine{{VariantID: variantID, Quantity: 2}}
 	orderID, _ := seedOrderWithItems(t, db, storeID, lines)
-	cart := uuid.NewString()
 
-	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
-		return commitStock(context.Background(), tx, stockhold.NewRepository(), cart, orderID, storeID, lines)
-	}))
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
+			orderID, storeID, lines)
+	})
+	require.Error(t, err, "a store with no warehouse cannot allocate, and must say so")
+	require.ErrorIs(t, err, allocation.ErrNoWarehouse)
 
-	require.Equal(t, 3, stockUnitsAt(t, db, variantID, product.DefaultLocationID),
-		"the sentinel row must still be the one decremented")
-
-	var allocations int64
-	require.NoError(t, db.Raw(
-		`SELECT count(*) FROM order_allocations WHERE order_id = ?`, orderID).Scan(&allocations).Error)
-	require.Zero(t, allocations,
-		"a store with no warehouses has nothing to allocate against — order_allocations.warehouse_id is NOT NULL")
+	require.Equal(t, 5, stockUnitsAt(t, db, variantID, orphan),
+		"a failed checkout must move no stock")
 }
 
 func TestCommitStock_AllocatesAcrossWarehousesAndRecordsThem(t *testing.T) {
@@ -197,30 +202,6 @@ func TestCommitStock_UnfillableOrderFailsAndTakesNoStock(t *testing.T) {
 // the backfill, plus a real row written by per-location stock editing. One
 // assignment against that warehouse must produce a hold in EACH location,
 // adding up to the assignment.
-func TestCommitStock_AssignmentSpanningTwoStorageLocationsHoldsInBoth(t *testing.T) {
-	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
-		"variant_stock", "product_variants", "products", "stores")
-	storeID, variantID := seedAvailStore(t, db)
-	whA := seedWarehouseRow(t, db, storeID, "A")
-	require.NoError(t, db.Exec(
-		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
-		 VALUES (?, ?, 3, now()), (?, ?, 4, now())`,
-		variantID, product.DefaultLocationID, variantID, whA).Error)
-
-	lines := []stockLine{{VariantID: variantID, Quantity: 5}}
-	orderID, _ := seedOrderWithItems(t, db, storeID, lines)
-
-	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
-		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
-			orderID, storeID, lines)
-	}))
-
-	// 5 units drawn from a 3 + 4 breakdown: the sentinel is exhausted and the
-	// remainder comes from the real row.
-	require.Equal(t, 0, stockUnitsAt(t, db, variantID, product.DefaultLocationID))
-	require.Equal(t, 2, stockUnitsAt(t, db, variantID, whA))
-}
-
 // seedAvailVariant creates one more product+variant for an existing store,
 // for tests that need two distinct variants.
 func seedAvailVariant(t *testing.T, db *gorm.DB, storeID string) string {
@@ -370,41 +351,23 @@ func TestCommitStock_ContinuePolicyWithNoStorageSucceedsOnAllocationPath(t *test
 // A continue-policy variant whose warehouse's units span TWO storage
 // locations (the sentinel row plus a real one). Both must be decremented,
 // not just the first one the breakdown happens to list.
-func TestCommitStock_ContinuePolicyDecrementsAcrossMultipleStorageLocations(t *testing.T) {
-	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
-		"variant_stock", "product_variants", "products", "stores")
-	storeID, variantID := seedAvailStore(t, db)
-	whA := seedWarehouseRow(t, db, storeID, "A")
-	require.NoError(t, db.Exec(
-		`UPDATE product_variants SET inventory_policy = 'continue' WHERE id = ?`, variantID).Error)
-	require.NoError(t, db.Exec(
-		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
-		 VALUES (?, ?, 1, now()), (?, ?, 1, now())`,
-		variantID, product.DefaultLocationID, variantID, whA).Error)
+// REMOVED: TestCommitStock_ContinuePolicyDecrementsAcrossMultipleStorageLocations.
+//
+// It pinned a 'continue' variant's decrement spanning TWO storage rows
+// behind ONE warehouse — the sentinel row plus a real row. That state
+// cannot occur after #177 PR 6: every variant_stock row's location_id is
+// now a warehouse id, so a warehouse is backed by exactly one row.
+//
+// Deliberately not rewritten as "spreads across two warehouses". The
+// allocator does not do that for a sell-past-zero variant — it fills from
+// the first warehouse and lets it go past zero — so the rewrite asserted
+// behaviour that has never existed and failed, which is how it was caught.
+// TestCommitStock_ContinuePolicyWithNoStorageSucceedsOnAllocationPath
+// still covers the sell-past-zero path itself.
 
-	// 2 units requested against two locations holding 1 each: whichever
-	// sorts first can only cover 1, so the second MUST be touched too, or
-	// this fails regardless of storage order.
-	lines := []stockLine{{VariantID: variantID, Quantity: 2}}
-	orderID, _ := seedOrderWithItems(t, db, storeID, lines)
-
-	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
-		return commitStock(context.Background(), tx, stockhold.NewRepository(), uuid.NewString(),
-			orderID, storeID, lines)
-	}))
-
-	require.Equal(t, 0, stockUnitsAt(t, db, variantID, product.DefaultLocationID),
-		"the sentinel location must be decremented, not left untouched")
-	require.Equal(t, 0, stockUnitsAt(t, db, variantID, whA),
-		"the real warehouse location must be decremented too")
-}
-
-// FIX 1 (final review): the storage draw must track units already consumed
-// by EARLIER assignments in this call, not restart from the full breakdown
-// snapshot for every assignment. Two lines of the same variant, both filled
-// at one warehouse whose units span the sentinel row and a real row —
-// breakdown [sentinel:3, A:4], lines of 2 and 3 — must total 3 at the
-// sentinel and 2 at A, not 5 at a location that only holds 3.
+// at ONE warehouse — lines of 2 and 3 against a warehouse holding 5 —
+// must draw 5 in total, not double-count the breakdown and try to take
+// more than the row holds.
 func TestCommitStock_TwoLinesFilledAtSameWarehouseDoNotDoubleCountTheBreakdown(t *testing.T) {
 	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
 		"variant_stock", "product_variants", "products", "stores")
@@ -412,8 +375,7 @@ func TestCommitStock_TwoLinesFilledAtSameWarehouseDoNotDoubleCountTheBreakdown(t
 	whA := seedWarehouseRow(t, db, storeID, "A")
 	require.NoError(t, db.Exec(
 		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
-		 VALUES (?, ?, 3, now()), (?, ?, 4, now())`,
-		variantID, product.DefaultLocationID, variantID, whA).Error)
+		 VALUES (?, ?, 5, now())`, variantID, whA).Error)
 
 	lines := []stockLine{{VariantID: variantID, Quantity: 2}, {VariantID: variantID, Quantity: 3}}
 	orderID, itemIDs := seedOrderWithItems(t, db, storeID, lines)
@@ -423,10 +385,8 @@ func TestCommitStock_TwoLinesFilledAtSameWarehouseDoNotDoubleCountTheBreakdown(t
 			orderID, storeID, lines)
 	}), "a cart the store can fully fill must not see out_of_stock")
 
-	require.Equal(t, 0, stockUnitsAt(t, db, variantID, product.DefaultLocationID),
-		"3 units at the sentinel, fully drawn across both lines")
-	require.Equal(t, 2, stockUnitsAt(t, db, variantID, whA),
-		"4 units at A, only the 2 units the sentinel could not cover")
+	require.Equal(t, 0, stockUnitsAt(t, db, variantID, whA),
+		"5 units at A, fully drawn across both lines")
 
 	var total int64
 	require.NoError(t, db.Raw(
@@ -443,33 +403,37 @@ func TestCommitStock_TwoLinesFilledAtSameWarehouseDoNotDoubleCountTheBreakdown(t
 // fires and the checkout 500s instead of succeeding.
 //
 // The stale hold is manufactured the way it happens in production: a
-// cart-add hold succeeds against the sentinel while it still has stock, and
+// cart-add hold succeeds against warehouse B while it still has stock, and
 // by checkout time an admin has corrected that count to zero — the hold
-// still exists, but the sentinel no longer has anything to give, so the
-// warehouse allocation plan must fill entirely from the real row instead.
+// still exists, but B no longer has anything to give, so the allocation
+// plan must fill entirely from A instead.
 func TestCommitStock_StaleCartHoldAtAnUnusedLocationIsReleasedNotDoubleCommitted(t *testing.T) {
 	db := testdb.NewDB(t, "order_allocations", "stock_holds", "order_items", "orders",
 		"variant_stock", "product_variants", "products", "stores")
 	storeID, variantID := seedAvailStore(t, db)
 	whA := seedWarehouseRow(t, db, storeID, "A")
+	whB := seedWarehouseRow(t, db, storeID, "B")
+	// A is filled first, so B is the one the plan will not need.
+	require.NoError(t, db.Exec(`UPDATE warehouses SET priority = 0 WHERE id = ?`, whA).Error)
+	require.NoError(t, db.Exec(`UPDATE warehouses SET priority = 1 WHERE id = ?`, whB).Error)
 	require.NoError(t, db.Exec(
 		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
 		 VALUES (?, ?, 2, now()), (?, ?, 5, now())`,
-		variantID, product.DefaultLocationID, variantID, whA).Error)
+		variantID, whB, variantID, whA).Error)
 
 	cart := uuid.NewString()
 	holds := stockhold.NewRepository()
 
 	// The cart-add hold, placed while the sentinel still had stock.
 	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
-		return holds.Hold(context.Background(), tx, cart, variantID, product.DefaultLocationID, 2, time.Hour)
+		return holds.Hold(context.Background(), tx, cart, variantID, whB, 2, time.Hour)
 	}))
 
 	// An admin corrects the count between cart-add and checkout. The hold
 	// row is untouched — it still says 2 units held at the sentinel.
 	require.NoError(t, db.Exec(
 		`UPDATE variant_stock SET quantity = 0 WHERE variant_id = ? AND location_id = ?`,
-		variantID, product.DefaultLocationID).Error)
+		variantID, whB).Error)
 
 	lines := []stockLine{{VariantID: variantID, Quantity: 2}}
 	orderID, itemIDs := seedOrderWithItems(t, db, storeID, lines)
@@ -478,7 +442,7 @@ func TestCommitStock_StaleCartHoldAtAnUnusedLocationIsReleasedNotDoubleCommitted
 		return commitStock(context.Background(), tx, holds, cart, orderID, storeID, lines)
 	}), "the stale sentinel hold must be released, not decremented a second time")
 
-	require.Equal(t, 0, stockUnitsAt(t, db, variantID, product.DefaultLocationID),
+	require.Equal(t, 0, stockUnitsAt(t, db, variantID, whB),
 		"the sentinel had nothing left and must stay at zero, not go negative")
 	require.Equal(t, 3, stockUnitsAt(t, db, variantID, whA),
 		"the whole order must be filled from A, the only location with real stock")
@@ -486,7 +450,7 @@ func TestCommitStock_StaleCartHoldAtAnUnusedLocationIsReleasedNotDoubleCommitted
 	var state string
 	require.NoError(t, db.Raw(
 		`SELECT state FROM stock_holds WHERE cart_token = ? AND location_id = ?`,
-		cart, product.DefaultLocationID).Row().Scan(&state))
+		cart, whB).Row().Scan(&state))
 	require.Equal(t, "released", state, "the stale hold must be released, not left held or committed")
 
 	var allocWarehouse string

--- a/services/marketplace-api/internal/handlers/storefront/checkout_availability.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_availability.go
@@ -8,7 +8,6 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/allocation"
-	"github.com/mark8ly/marketplace-api/internal/product"
 )
 
 // stockAt is units of a variant available at one physical storage location.
@@ -18,18 +17,15 @@ type stockAt struct {
 }
 
 // storageLocations records, per variant and warehouse, WHERE the units
-// backing that warehouse's availability actually sit — possibly in more
-// than one place while the sentinel and real rows coexist.
+// backing that warehouse's availability actually sit.
 //
-// It exists because of the expand phase: until PR 6 backfills
-// variant_stock.location_id, units sit at product.DefaultLocationID while
-// allocation reasons about real warehouse ids. A hold must be placed against
-// the location(s) the rows actually have, or it locks nothing. A single
-// warehouse can be backed by MORE than one storage location even before the
-// backfill completes: PR 5 adds per-location stock editing, which can write
-// a real warehouse-id row while the sentinel row for that same variant still
-// exists. After the backfill every warehouse has exactly one contributing
-// location and this collapses to the obvious case.
+// It exists because a hold must be placed against the location(s) the rows
+// actually have, or it locks nothing. It was written for the expand phase,
+// when units sat on a sentinel location while allocation reasoned about
+// real warehouse ids and one warehouse could be backed by two rows. After
+// #177 PR 6 that collapses to the obvious case — one warehouse, one row —
+// and the indirection is kept because it is what makes a hold target a
+// real location rather than the warehouse's id by assumption.
 type storageLocations map[string]map[string][]stockAt
 
 // loadAvailability builds the snapshot allocation.Plan reasons over.
@@ -78,10 +74,11 @@ func loadAvailability(
 		return nil, nil, fmt.Errorf("storefront: load availability: %w", err)
 	}
 
-	// Which warehouse a stock row belongs to. Sentinel rows have no real
-	// warehouse of their own, so they answer for the store's FIRST warehouse
-	// in fill order — the one a single-warehouse store ships everything from
-	// anyway. Real rows answer for themselves.
+	// Which warehouse a stock row belongs to. Every row answers for itself
+	// now: the sentinel tolerance that mapped location-less rows onto the
+	// store's first warehouse was removed in #177 PR 6 step 2, once
+	// migration 000123 had moved production's units onto real warehouses
+	// and every write path resolved one.
 	byWarehouse := make(map[string]string, len(warehouses))
 	for _, w := range warehouses {
 		byWarehouse[w.ID] = w.ID
@@ -89,9 +86,7 @@ func loadAvailability(
 
 	for _, r := range rows {
 		warehouseID := r.LocationID
-		if r.LocationID == product.DefaultLocationID {
-			warehouseID = warehouses[0].ID
-		} else if _, known := byWarehouse[r.LocationID]; !known {
+		if _, known := byWarehouse[r.LocationID]; !known {
 			// Stock at a location that is not one of this store's warehouses
 			// — another store's row cannot appear here (variantIDs are this
 			// order's), so this is a warehouse deleted out from under its
@@ -112,10 +107,11 @@ func loadAvailability(
 			storage[r.VariantID] = map[string][]stockAt{}
 		}
 		avail[r.VariantID][warehouseID] += r.Available
-		// Append rather than overwrite: the sentinel row and a real
-		// warehouse-id row can both back the same warehouse (PR 5 writes
-		// real rows before PR 6 backfills the sentinel away), and a hold
-		// must be able to target every location the units actually sit at.
+		// Append rather than overwrite. One warehouse is normally backed by
+		// one row, but the shape is kept: a hold must be able to target
+		// every location the units actually sit at, and collapsing to a
+		// single row here would silently drop the second if that ever
+		// stops being true.
 		storage[r.VariantID][warehouseID] = append(
 			storage[r.VariantID][warehouseID],
 			stockAt{LocationID: r.LocationID, Units: r.Available},

--- a/services/marketplace-api/internal/handlers/storefront/checkout_availability_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_availability_integration_test.go
@@ -25,7 +25,6 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/allocation"
-	"github.com/mark8ly/marketplace-api/internal/product"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
@@ -66,24 +65,34 @@ func seedWarehouseRow(t *testing.T, db *gorm.DB, storeID, name string) string {
 	return id
 }
 
-func TestLoadAvailability_SentinelStockIsReportedAgainstTheFirstWarehouse(t *testing.T) {
+// The inverse of the test this replaces. Availability used to map a
+// sentinel row onto the store's FIRST warehouse, because every unit in
+// production lived there and the allocator could not otherwise see them.
+// #177 PR 6 removed that: migration 000123 moved the units onto real
+// warehouses, and every write path now resolves one, so a sentinel row is
+// simply a location this store does not have.
+//
+// Pinned rather than deleted, because the failure it guards against is
+// silent. A straggler row — written by a pod still on the old image during
+// the rollout, or restored from a backup — must contribute NOTHING rather
+// than quietly reappear as sellable stock at whichever warehouse happens
+// to sort first.
+func TestLoadAvailability_SentinelStockNoLongerCountsAsAnything(t *testing.T) {
 	db := testdb.NewTx(t)
 	storeID, variantID := seedAvailStore(t, db)
 	whID := seedWarehouseRow(t, db, storeID, "Main")
 
-	// Stock still lives at the sentinel — PR 6 has not backfilled yet.
 	require.NoError(t, db.Exec(
 		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
-		 VALUES (?, ?, 7, now())`, variantID, product.DefaultLocationID).Error)
+		 VALUES (?, ?, 7, now())`, variantID, retiredSentinelForTest).Error)
 
 	warehouses := []allocation.Warehouse{{ID: whID}}
 	avail, storage, err := loadAvailability(context.Background(), db, uuid.NewString(), warehouses, []string{variantID})
 	require.NoError(t, err)
 
-	require.Equal(t, 7, avail.At(variantID, whID),
-		"sentinel-stored units must be visible against the store's warehouse before the backfill")
-	require.Equal(t, []stockAt{{LocationID: product.DefaultLocationID, Units: 7}}, storage[variantID][whID],
-		"a hold must target the location the units are actually stored at")
+	require.Zero(t, avail.At(variantID, whID),
+		"a sentinel row is a location this store does not have; it must not be sellable")
+	require.Empty(t, storage[variantID][whID])
 }
 
 func TestLoadAvailability_RealWarehouseStockIsReportedAgainstItself(t *testing.T) {
@@ -117,14 +126,14 @@ func TestLoadAvailability_ExcludesTheCallingCartsOwnHolds(t *testing.T) {
 	whID := seedWarehouseRow(t, db, storeID, "Main")
 	require.NoError(t, db.Exec(
 		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
-		 VALUES (?, ?, 10, now())`, variantID, product.DefaultLocationID).Error)
+		 VALUES (?, ?, 10, now())`, variantID, whID).Error)
 
 	mine, theirs := uuid.NewString(), uuid.NewString()
 	require.NoError(t, db.Exec(
 		`INSERT INTO stock_holds (variant_id, location_id, cart_token, qty, expires_at, state)
 		 VALUES (?, ?, ?, 4, ?, 'held'), (?, ?, ?, 3, ?, 'held')`,
-		variantID, product.DefaultLocationID, mine, time.Now().Add(time.Hour),
-		variantID, product.DefaultLocationID, theirs, time.Now().Add(time.Hour)).Error)
+		variantID, whID, mine, time.Now().Add(time.Hour),
+		variantID, whID, theirs, time.Now().Add(time.Hour)).Error)
 
 	warehouses := []allocation.Warehouse{{ID: whID}}
 	avail, _, err := loadAvailability(context.Background(), db, mine, warehouses, []string{variantID})
@@ -140,11 +149,11 @@ func TestLoadAvailability_ExpiredHoldsDoNotReduceAvailability(t *testing.T) {
 	whID := seedWarehouseRow(t, db, storeID, "Main")
 	require.NoError(t, db.Exec(
 		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
-		 VALUES (?, ?, 5, now())`, variantID, product.DefaultLocationID).Error)
+		 VALUES (?, ?, 5, now())`, variantID, whID).Error)
 	require.NoError(t, db.Exec(
 		`INSERT INTO stock_holds (variant_id, location_id, cart_token, qty, expires_at, state)
 		 VALUES (?, ?, ?, 5, ?, 'held')`,
-		variantID, product.DefaultLocationID, uuid.NewString(), time.Now().Add(-time.Minute)).Error)
+		variantID, whID, uuid.NewString(), time.Now().Add(-time.Minute)).Error)
 
 	avail, _, err := loadAvailability(context.Background(), db, uuid.NewString(),
 		[]allocation.Warehouse{{ID: whID}}, []string{variantID})
@@ -176,32 +185,9 @@ func TestLoadAvailability_VariantWithNoStockRowsIsAbsent(t *testing.T) {
 // still exists. Availability must sum across both, and the storage
 // breakdown must name both locations — collapsing to one would under-lock a
 // hold.
-func TestLoadAvailability_MixedSentinelAndRealStockForSameWarehouseIsSummedAndBothLocationsRecorded(t *testing.T) {
-	db := testdb.NewTx(t)
-	storeID, variantID := seedAvailStore(t, db)
-	whID := seedWarehouseRow(t, db, storeID, "Main")
-
-	require.NoError(t, db.Exec(
-		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
-		 VALUES (?, ?, 3, now()), (?, ?, 4, now())`,
-		variantID, product.DefaultLocationID, variantID, whID).Error)
-
-	avail, storage, err := loadAvailability(context.Background(), db, uuid.NewString(),
-		[]allocation.Warehouse{{ID: whID}}, []string{variantID})
-	require.NoError(t, err)
-
-	require.Equal(t, 7, avail.At(variantID, whID),
-		"3 sentinel-stored plus 4 stored directly at the warehouse")
-	require.Equal(t, []stockAt{
-		{LocationID: product.DefaultLocationID, Units: 3},
-		{LocationID: whID, Units: 4},
-	}, storage[variantID][whID],
-		"a hold must be able to target both locations the units actually sit at")
-}
-
-// Stock at a location that is neither the sentinel nor one of the store's
-// warehouses (a warehouse deleted out from under its stock) must contribute
-// nothing — not error, not appear in the total.
+// Stock at a location that is not one of the store's warehouses (a
+// warehouse deleted out from under its stock) must contribute nothing —
+// not error, not appear in the total.
 func TestLoadAvailability_StockAtUnknownLocationContributesNothing(t *testing.T) {
 	db := testdb.NewTx(t)
 	storeID, variantID := seedAvailStore(t, db)
@@ -219,3 +205,9 @@ func TestLoadAvailability_StockAtUnknownLocationContributesNothing(t *testing.T)
 	require.Equal(t, 0, avail.At(variantID, whID))
 	require.Empty(t, storage[variantID])
 }
+
+// retiredSentinelForTest is the location every stock row used to carry,
+// before #177 PR 6 moved them onto real warehouses. Declared here rather
+// than imported: the production constant is gone, and a test that needs
+// the value needs it precisely BECAUSE nothing writes it any more.
+const retiredSentinelForTest = "00000000-0000-0000-0000-000000000001"

--- a/services/marketplace-api/internal/handlers/storefront/checkout_stock.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_stock.go
@@ -12,7 +12,6 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/allocation"
-	"github.com/mark8ly/marketplace-api/internal/product"
 	"github.com/mark8ly/marketplace-api/internal/stockhold"
 )
 
@@ -77,17 +76,19 @@ func commitStock(
 		return err
 	}
 
-	// A store with NO warehouses keeps the pre-#177 behaviour exactly:
-	// hold and decrement at the sentinel location, write no allocations.
-	// This is not a tidy fallback — production has zero warehouse rows, so
-	// it is the only path that currently runs, and allocation.Plan would
-	// return ErrNoWarehouse for every checkout if it ran unconditionally.
+	// Every store that holds stock has a warehouse. Product writes resolve
+	// one — creating it if the store had none — and migration 000123 moved
+	// the existing rows onto real warehouses, so the sentinel path this
+	// used to fall back to is gone (#177 PR 6 step 2).
+	//
+	// A store with no warehouse therefore has no products, and nothing to
+	// check out. If that is ever false, allocation.Plan returns
+	// ErrNoWarehouse and the checkout fails loudly — which is the right
+	// answer: silently holding stock at a location that names nothing is
+	// what made allocation economically hollow in the first place.
 	warehouses, err := storeWarehousesInFillOrder(ctx, tx, storeID)
 	if err != nil {
 		return err
-	}
-	if len(warehouses) == 0 {
-		return commitStockAtSentinel(ctx, tx, holds, cartToken, lines, policies)
 	}
 
 	avail, storage, err := loadAvailability(ctx, tx, cartToken, warehouses, variantIDsOf(lines))
@@ -209,7 +210,7 @@ func commitStock(
 	}
 	// Release any cart-time hold whose (variant, location) is not part of
 	// this plan BEFORE placing the plan's holds and BEFORE Commit runs.
-	// cart_holds.go places holds at product.DefaultLocationID; a placement
+	// cart_holds.go places holds at the store default warehouse; a placement
 	// plan is free to target a different warehouse, and holds.Commit
 	// decrements EVERY live hold this cart owns regardless of whether it
 	// matches. Left in place, a stale cart-add hold gets decremented a
@@ -252,55 +253,6 @@ func commitStock(
 	// its order_item_id without threading ids through the checkout request.
 	if err := recordAllocations(ctx, tx, orderID, assignments, lines); err != nil {
 		return err
-	}
-
-	// One Commit for the whole cart: it decrements every live hold this cart
-	// holds and flips them to 'committed' in the same transaction.
-	return holds.Commit(ctx, tx, cartToken)
-}
-
-// commitStockAtSentinel is the pre-#177 behaviour, moved here verbatim: hold
-// and decrement everything at the single sentinel location, and write no
-// order_allocations rows. This is the ONLY path production exercises today
-// — there are zero warehouse rows — so its body must stay provably
-// unchanged rather than be re-implemented alongside the allocation path.
-func commitStockAtSentinel(
-	ctx context.Context,
-	tx *gorm.DB,
-	holds *stockhold.Repository,
-	cartToken string,
-	lines []stockLine,
-	policies map[string]string,
-) error {
-	for _, line := range lines {
-		if policies[line.VariantID] == inventoryPolicyContinue {
-			// Sell past zero on purpose. No hold, no gate — and the
-			// decrement is clamped, because variant_stock carries a
-			// non-negative CHECK (#231) that cannot be policy-aware: the
-			// policy lives on product_variants, and a CHECK cannot read
-			// another table.
-			//
-			// The consequence, stated rather than hidden: how far a
-			// 'continue' variant is oversold is NOT tracked. The orders
-			// are the record of what was sold; this column stops at zero.
-			if err := tx.WithContext(ctx).Exec(
-				`UPDATE variant_stock
-				    SET quantity = GREATEST(quantity - ?, 0), updated_at = now()
-				  WHERE variant_id = ? AND location_id = ?`,
-				line.Quantity, line.VariantID, product.DefaultLocationID).Error; err != nil {
-				return fmt.Errorf("storefront: decrement continue-policy variant: %w", err)
-			}
-			continue
-		}
-
-		err := holds.Hold(ctx, tx, cartToken, line.VariantID,
-			product.DefaultLocationID, line.Quantity, HoldTTL)
-		if errors.Is(err, stockhold.ErrInsufficientStock) {
-			return outOfStockError{VariantID: line.VariantID}
-		}
-		if err != nil {
-			return err
-		}
 	}
 
 	// One Commit for the whole cart: it decrements every live hold this cart

--- a/services/marketplace-api/internal/product/repository_variants.go
+++ b/services/marketplace-api/internal/product/repository_variants.go
@@ -178,7 +178,7 @@ func (r *gormRepository) UpdateVariantStockInTx(ctx context.Context, tx *gorm.DB
 //
 // # Why the sentinel has to go
 //
-// Until PR 6's backfill runs, a variant's units live on DefaultLocationID.
+// Until PR 6's backfill ran, a variant's units lived on the sentinel.
 // checkout_availability.go attributes a sentinel row to the store's FIRST
 // warehouse and SUMS it with any real row for that same warehouse:
 //
@@ -216,7 +216,7 @@ func (r *gormRepository) SetVariantStockByLocationInTx(
 	slices.Sort(locations)
 
 	for _, locationID := range locations {
-		if locationID == DefaultLocationID {
+		if locationID == retiredSentinelLocationID {
 			// The sentinel is not a place a merchant can choose. Accepting
 			// it here would write the row this method exists to remove.
 			return fmt.Errorf("product: set stock by location: sentinel is not a warehouse")
@@ -228,7 +228,7 @@ func (r *gormRepository) SetVariantStockByLocationInTx(
 
 	if err := tx.WithContext(ctx).Exec(
 		`DELETE FROM variant_stock WHERE variant_id = ? AND location_id = ?`,
-		variantID, DefaultLocationID).Error; err != nil {
+		variantID, retiredSentinelLocationID).Error; err != nil {
 		return fmt.Errorf("product: set stock by location: clear sentinel: %w", err)
 	}
 	return nil
@@ -269,3 +269,15 @@ func (r *gormRepository) StockByLocationForVariants(
 	}
 	return out, nil
 }
+
+// retiredSentinelLocationID is the location every stock row used to carry:
+// the old DefaultLocationID, deleted in #177 PR 6 step 2.
+//
+// It survives as a value, not as a destination. Nothing writes it any more
+// — migration 000123 moved production's 16,354 units onto real warehouses,
+// and every write now resolves the store's warehouse instead. It is kept
+// so the two guards above can still recognise a straggler: a row written
+// by a pod still on the old image during the rollout window, or by a
+// restored backup. Sweeping one costs a DELETE that matches nothing in the
+// normal case.
+const retiredSentinelLocationID = "00000000-0000-0000-0000-000000000001"

--- a/services/marketplace-api/internal/product/service.go
+++ b/services/marketplace-api/internal/product/service.go
@@ -41,10 +41,6 @@ import (
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 )
 
-// DefaultLocationID is the slice-1 single-warehouse location used for
-// variant_stock seeding. Multi-warehouse lands in a later slice.
-const DefaultLocationID = "00000000-0000-0000-0000-000000000001"
-
 // Service orchestrates product mutations and their outbox events.
 type Service struct {
 	db                 *gorm.DB
@@ -339,10 +335,16 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (*Aggregate, er
 		if err := s.repo.CreateAggregateInTx(ctx, tx, agg); err != nil {
 			return err
 		}
-		// Seed per-variant stock at the default location.
+		// Seed per-variant stock at the store's warehouse, creating one if
+		// the store has none. Stock has to live somewhere real — that is
+		// what retired the sentinel (#177 PR 6).
+		locationID, err := s.stockLocationFor(ctx, tx, req.TenantID, req.StoreID)
+		if err != nil {
+			return err
+		}
 		for i := range agg.Variants {
 			if err := s.repo.UpdateVariantStockInTx(ctx, tx,
-				agg.Variants[i].ID, DefaultLocationID, req.Variants[i].InitialStock); err != nil {
+				agg.Variants[i].ID, locationID, req.Variants[i].InitialStock); err != nil {
 				return err
 			}
 		}

--- a/services/marketplace-api/internal/product/service_aggregate.go
+++ b/services/marketplace-api/internal/product/service_aggregate.go
@@ -196,7 +196,15 @@ func (s *Service) UpdateAggregate(ctx context.Context, req UpdateAggregateReques
 			newVariants = added
 		}
 
-		// 4. Seed stock for newly added variants.
+		// 4. Seed stock for newly added variants, at the store's warehouse.
+		var stockLocationID string
+		if len(newVariants) > 0 {
+			var locErr error
+			stockLocationID, locErr = s.stockLocationFor(ctx, tx, req.TenantID, req.StoreID)
+			if locErr != nil {
+				return locErr
+			}
+		}
 		for i := range newVariants {
 			// Find the matching input by generated ID to read InitialStock.
 			if req.Variants == nil {
@@ -205,7 +213,7 @@ func (s *Service) UpdateAggregate(ctx context.Context, req UpdateAggregateReques
 			for _, in := range *req.Variants {
 				if in.ID == "" && newVariants[i].SKU == in.SKU {
 					if err := s.repo.UpdateVariantStockInTx(ctx, tx,
-						newVariants[i].ID, DefaultLocationID, in.InitialStock); err != nil {
+						newVariants[i].ID, stockLocationID, in.InitialStock); err != nil {
 						return err
 					}
 					break
@@ -237,6 +245,16 @@ func (s *Service) UpdateAggregate(ctx context.Context, req UpdateAggregateReques
 			for _, nv := range newVariants {
 				newByID[nv.ID] = struct{}{}
 			}
+			// Resolved once for the loop below. Step 4 may have resolved it
+			// already; EnsureDefaultForStore is idempotent, so asking twice
+			// costs a lookup rather than a second warehouse.
+			if stockLocationID == "" {
+				var locErr error
+				stockLocationID, locErr = s.stockLocationFor(ctx, tx, req.TenantID, req.StoreID)
+				if locErr != nil {
+					return locErr
+				}
+			}
 			for _, in := range *req.Variants {
 				var matched *Variant
 				if in.ID != "" {
@@ -259,7 +277,7 @@ func (s *Service) UpdateAggregate(ctx context.Context, req UpdateAggregateReques
 					continue
 				}
 				if err := s.repo.UpdateVariantStockInTx(ctx, tx,
-					matched.ID, DefaultLocationID, in.InitialStock); err != nil {
+					matched.ID, stockLocationID, in.InitialStock); err != nil {
 					return err
 				}
 			}

--- a/services/marketplace-api/internal/product/service_copy.go
+++ b/services/marketplace-api/internal/product/service_copy.go
@@ -210,10 +210,16 @@ func (s *Service) Copy(ctx context.Context, req CopyRequest) (*Aggregate, error)
 			return err
 		}
 
-		// 4d. Seed variant_stock rows at quantity 0 in target store.
+		// 4d. Seed variant_stock rows at quantity 0 in the TARGET store's
+		// warehouse — the copy's stock belongs to the store it landed in,
+		// not the one it came from.
+		copyLocationID, err := s.stockLocationFor(ctx, tx, newAgg.Product.TenantID, newAgg.Product.StoreID)
+		if err != nil {
+			return err
+		}
 		for i := range newAgg.Variants {
 			if err := s.repo.UpdateVariantStockInTx(ctx, tx,
-				newAgg.Variants[i].ID, DefaultLocationID, 0); err != nil {
+				newAgg.Variants[i].ID, copyLocationID, 0); err != nil {
 				return err
 			}
 		}

--- a/services/marketplace-api/internal/product/service_variant_patch.go
+++ b/services/marketplace-api/internal/product/service_variant_patch.go
@@ -141,9 +141,15 @@ func (s *Service) UpdateVariantBasics(ctx context.Context, req UpdateVariantBasi
 				return err
 			}
 		case req.InventoryQuantity != nil:
-			// The single-warehouse path, unchanged. A store with one
-			// warehouse must behave exactly as it did before this slice.
-			if err := s.repo.UpdateVariantStockInTx(ctx, tx, req.VariantID, DefaultLocationID, *req.InventoryQuantity); err != nil {
+			// The single-warehouse path: one number, written to the store's
+			// warehouse. It used to write the sentinel; #177 PR 6 retired
+			// that, so the units now sit somewhere the allocator can fill
+			// from.
+			locationID, locErr := s.stockLocationFor(ctx, tx, req.TenantID, req.StoreID)
+			if locErr != nil {
+				return locErr
+			}
+			if err := s.repo.UpdateVariantStockInTx(ctx, tx, req.VariantID, locationID, *req.InventoryQuantity); err != nil {
 				return err
 			}
 		}
@@ -184,4 +190,31 @@ func (s *Service) liveWarehouseIDs(ctx context.Context, storeID string) (map[str
 // the per-warehouse editor (#177 PR 5e).
 func (s *Service) StockByLocation(ctx context.Context, variantIDs []string) (map[string]map[string]int, error) {
 	return s.repo.StockByLocationForVariants(ctx, s.db, variantIDs)
+}
+
+// stockLocationFor resolves where a store's stock rows live, creating the
+// store's warehouse if it has none (#177 PR 6 step 2).
+//
+// This replaced DefaultLocationID, the sentinel every stock write used to
+// target. The sentinel named nothing: the allocator could only tolerate
+// those rows, never fill from them, so allocation was structurally correct
+// and economically hollow. Migration 000123 moved the existing 16,354
+// units onto real warehouses; this keeps every NEW write there too.
+//
+// Runs in the caller's transaction so the warehouse and the stock row that
+// needs it commit together.
+func (s *Service) stockLocationFor(ctx context.Context, tx *gorm.DB, tenantID, storeID string) (string, error) {
+	countryCode := ""
+	if store, err := s.storesRepo.GetByIDForTenant(ctx, storeID, tenantID); err == nil {
+		countryCode = store.CountryCode
+	}
+	// A store row that cannot be read is not fatal here: the country code
+	// only seeds the warehouse's country, and the merchant corrects the
+	// address on the warehouses page regardless. Failing the product save
+	// over it would be a worse trade.
+	wh, err := warehouse.NewRepository().EnsureDefaultForStore(ctx, tx, tenantID, storeID, countryCode)
+	if err != nil {
+		return "", err
+	}
+	return wh.ID, nil
 }

--- a/services/marketplace-api/internal/product/stock_by_location_integration_test.go
+++ b/services/marketplace-api/internal/product/stock_by_location_integration_test.go
@@ -59,7 +59,7 @@ func TestSetVariantStockByLocation_WritesRealRowsAndClearsTheSentinel(t *testing
 	variantID := agg.Variants[0].ID
 
 	// The pre-5e world: everything on the sentinel.
-	require.NoError(t, repo.UpdateVariantStockInTx(ctx, tx, variantID, product.DefaultLocationID, 10))
+	require.NoError(t, repo.UpdateVariantStockInTx(ctx, tx, variantID, retiredSentinel, 10))
 
 	whA := seedWarehouseRowForStock(t, tx, tenantID, storeID, "Alpha")
 	whB := seedWarehouseRowForStock(t, tx, tenantID, storeID, "Bravo")
@@ -70,7 +70,7 @@ func TestSetVariantStockByLocation_WritesRealRowsAndClearsTheSentinel(t *testing
 	var sentinel int64
 	require.NoError(t, tx.Raw(
 		`SELECT count(*) FROM variant_stock WHERE variant_id = ? AND location_id = ?`,
-		variantID, product.DefaultLocationID).Scan(&sentinel).Error)
+		variantID, retiredSentinel).Scan(&sentinel).Error)
 	require.Zero(t, sentinel,
 		"the sentinel row must be gone — left behind it is summed with the real row for the same warehouse and the merchant's stock doubles")
 
@@ -89,7 +89,7 @@ func TestSetVariantStockByLocation_InventoryQuantityIsTheTotal(t *testing.T) {
 	agg := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
 	require.NoError(t, repo.CreateAggregateInTx(ctx, tx, agg))
 	variantID := agg.Variants[0].ID
-	require.NoError(t, repo.UpdateVariantStockInTx(ctx, tx, variantID, product.DefaultLocationID, 10))
+	require.NoError(t, repo.UpdateVariantStockInTx(ctx, tx, variantID, retiredSentinel, 10))
 
 	whA := seedWarehouseRowForStock(t, tx, tenantID, storeID, "Alpha")
 	whB := seedWarehouseRowForStock(t, tx, tenantID, storeID, "Bravo")
@@ -142,7 +142,7 @@ func TestSetVariantStockByLocation_IsIdempotent(t *testing.T) {
 	agg := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
 	require.NoError(t, repo.CreateAggregateInTx(ctx, tx, agg))
 	variantID := agg.Variants[0].ID
-	require.NoError(t, repo.UpdateVariantStockInTx(ctx, tx, variantID, product.DefaultLocationID, 10))
+	require.NoError(t, repo.UpdateVariantStockInTx(ctx, tx, variantID, retiredSentinel, 10))
 
 	whA := seedWarehouseRowForStock(t, tx, tenantID, storeID, "Alpha")
 	for range 2 {
@@ -171,13 +171,13 @@ func TestSetVariantStockByLocation_RefusesTheSentinelAsALocation(t *testing.T) {
 	agg := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
 	require.NoError(t, repo.CreateAggregateInTx(ctx, tx, agg))
 	variantID := agg.Variants[0].ID
-	require.NoError(t, repo.UpdateVariantStockInTx(ctx, tx, variantID, product.DefaultLocationID, 10))
+	require.NoError(t, repo.UpdateVariantStockInTx(ctx, tx, variantID, retiredSentinel, 10))
 
 	err := repo.SetVariantStockByLocationInTx(ctx, tx, variantID,
-		map[string]int{product.DefaultLocationID: 99})
+		map[string]int{retiredSentinel: 99})
 	require.Error(t, err)
 
-	require.Equal(t, 10, stockAtLocation(t, tx, variantID, product.DefaultLocationID),
+	require.Equal(t, 10, stockAtLocation(t, tx, variantID, retiredSentinel),
 		"a refused call must not have touched the stock")
 }
 
@@ -192,10 +192,17 @@ func TestSetVariantStockByLocation_EmptyMapChangesNothing(t *testing.T) {
 	agg := minimalAggregate(storeID, tenantID, vendorID, "linen-shirt", "LINEN-1")
 	require.NoError(t, repo.CreateAggregateInTx(ctx, tx, agg))
 	variantID := agg.Variants[0].ID
-	require.NoError(t, repo.UpdateVariantStockInTx(ctx, tx, variantID, product.DefaultLocationID, 10))
+	require.NoError(t, repo.UpdateVariantStockInTx(ctx, tx, variantID, retiredSentinel, 10))
 
 	require.NoError(t, repo.SetVariantStockByLocationInTx(ctx, tx, variantID, map[string]int{}))
 
-	require.Equal(t, 10, stockAtLocation(t, tx, variantID, product.DefaultLocationID),
+	require.Equal(t, 10, stockAtLocation(t, tx, variantID, retiredSentinel),
 		"an empty request must not have cleared the sentinel")
 }
+
+// retiredSentinel is the location every stock row carried before #177 PR 6
+// moved them onto real warehouses. The production constant is gone;
+// these tests still need the value precisely BECAUSE nothing writes it
+// any more — a straggler row from an old pod or a restored backup must
+// still be swept, and that is what they pin.
+const retiredSentinel = "00000000-0000-0000-0000-000000000001"

--- a/services/marketplace-api/internal/warehouse/crud_integration_test.go
+++ b/services/marketplace-api/internal/warehouse/crud_integration_test.go
@@ -212,3 +212,101 @@ func TestUpdateByID_IgnoresAnotherStoresWarehouse(t *testing.T) {
 	require.NoError(t, db.Raw(`SELECT name FROM warehouses WHERE id = ?`, mine.ID).Scan(&name).Error)
 	require.Equal(t, "Mine", name, "another store's warehouse must be untouched")
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// #177 PR 6 step 2 — the invariant that lets DefaultLocationID go.
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestEnsureDefaultForStore_CreatesOneWhenTheStoreHasNone(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	got, err := repo.EnsureDefaultForStore(ctx, db, tenantID, storeID, "au")
+	require.NoError(t, err)
+	require.Equal(t, "Main Warehouse", got.Name)
+	require.True(t, got.IsDefault)
+	require.Equal(t, "AU", got.CountryCode, "country code is normalised to upper case")
+
+	// Blank on purpose: inventing an address would quote rates from a
+	// place that does not exist.
+	require.Empty(t, got.Line1)
+	require.Empty(t, got.City)
+}
+
+func TestEnsureDefaultForStore_ReusesTheExistingDefault(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	made, err := repo.Create(ctx, db, sample(tenantID, storeID, "Bondi Depot"))
+	require.NoError(t, err)
+	require.NoError(t, repo.SetDefault(ctx, db, storeID, made.ID))
+
+	got, err := repo.EnsureDefaultForStore(ctx, db, tenantID, storeID, "AU")
+	require.NoError(t, err)
+	require.Equal(t, made.ID, got.ID, "an existing warehouse must be reused, never duplicated")
+
+	all, err := repo.List(ctx, db, storeID, true)
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+}
+
+// A store whose only warehouse is ARCHIVED has, as far as everything else
+// is concerned, no warehouse — the allocator refuses to fill from it
+// (#528). It must get a live one rather than have stock parked somewhere
+// unsellable.
+func TestEnsureDefaultForStore_ArchivedOnlyStoreGetsALiveOne(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	old, err := repo.Create(ctx, db, sample(tenantID, storeID, "Gone"))
+	require.NoError(t, err)
+	require.NoError(t, repo.Archive(ctx, db, old.ID))
+
+	got, err := repo.EnsureDefaultForStore(ctx, db, tenantID, storeID, "AU")
+	require.NoError(t, err)
+	require.NotEqual(t, old.ID, got.ID)
+	require.Equal(t, "Main Warehouse", got.Name)
+}
+
+// Called twice it must settle on one row — this runs on every stock write.
+func TestEnsureDefaultForStore_IsIdempotent(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	first, err := repo.EnsureDefaultForStore(ctx, db, tenantID, storeID, "AU")
+	require.NoError(t, err)
+	second, err := repo.EnsureDefaultForStore(ctx, db, tenantID, storeID, "AU")
+	require.NoError(t, err)
+	require.Equal(t, first.ID, second.ID)
+
+	all, err := repo.List(ctx, db, storeID, true)
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+}
+
+// An ARCHIVED 'Main Warehouse' must not block creating a live one — that is
+// what 000122's partial unique index buys, and a merchant who archived
+// theirs would otherwise be unable to save a product with stock.
+func TestEnsureDefaultForStore_ArchivedMainWarehouseNameIsNotAConflict(t *testing.T) {
+	db := testdb.NewDB(t, "warehouses")
+	repo := warehouse.NewRepository()
+	ctx := context.Background()
+	tenantID, storeID := seedStore(t, db)
+
+	old, err := repo.Create(ctx, db, sample(tenantID, storeID, "Main Warehouse"))
+	require.NoError(t, err)
+	require.NoError(t, repo.Archive(ctx, db, old.ID))
+
+	got, err := repo.EnsureDefaultForStore(ctx, db, tenantID, storeID, "AU")
+	require.NoError(t, err)
+	require.NotEqual(t, old.ID, got.ID)
+	require.Equal(t, "Main Warehouse", got.Name)
+}

--- a/services/marketplace-api/internal/warehouse/repository.go
+++ b/services/marketplace-api/internal/warehouse/repository.go
@@ -573,3 +573,53 @@ func (r *Repository) UnitsHeld(ctx context.Context, db *gorm.DB, id string) (int
 	}
 	return *total, nil
 }
+
+// EnsureDefaultForStore returns the store's default warehouse, creating one
+// if the store has none (#177 PR 6 step 2).
+//
+// This is the invariant that lets DefaultLocationID go: any store that
+// holds stock has somewhere real to hold it. Before, a store with no
+// warehouse wrote to a sentinel location that named nothing, and the
+// allocator could only tolerate those rows rather than fill from them.
+//
+// The address is left blank on purpose — the same choice migration 000123
+// made. The store has not said where it ships from, and inventing a
+// plausible address would produce a warehouse that quotes rates from a
+// place that does not exist. The warehouses page is what fills it in, and
+// shipping readiness already reports a warehouse with no address as a
+// blocker.
+//
+// Runs in the caller's *gorm.DB so the warehouse and the stock row that
+// needs it land in one transaction: a warehouse created for a stock write
+// that then failed would be a row nothing references.
+func (r *Repository) EnsureDefaultForStore(
+	ctx context.Context, db *gorm.DB, tenantID, storeID, countryCode string,
+) (Warehouse, error) {
+	existing, err := r.DefaultForStore(ctx, db, storeID)
+	if err == nil {
+		return existing, nil
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return Warehouse{}, err
+	}
+
+	created, err := r.Create(ctx, db, Warehouse{
+		TenantID:    tenantID,
+		StoreID:     storeID,
+		Name:        "Main Warehouse",
+		CountryCode: strings.ToUpper(strings.TrimSpace(countryCode)),
+		IsDefault:   true,
+	})
+	if err == nil {
+		return created, nil
+	}
+	if errors.Is(err, ErrNameTaken) {
+		// Two concurrent stock writes for a store with no warehouse race
+		// here, and the partial unique index makes exactly one of them
+		// lose. The loser's answer is the winner's row, not an error —
+		// otherwise a merchant's product save fails for a reason that has
+		// nothing to do with their product.
+		return r.DefaultForStore(ctx, db, storeID)
+	}
+	return Warehouse{}, err
+}


### PR DESCRIPTION
Refs #177. The contract half, and the last of the slice. Step 1 (#535) moved production's 16,354 units onto real warehouses — **verified: 380 rows at bondi's `Main Warehouse`, zero on the sentinel, schema at 123.** This deletes the constant those rows used to carry, its call sites, and the read-time tolerance that existed to cope with them.

## The invariant that makes it possible

`warehouse.EnsureDefaultForStore` — find-or-create, the same shape migration 000123 used. **Any store that holds stock has somewhere real to hold it.** Every product-side write now resolves it:

| call site | was | now |
|---|---|---|
| create product with initial stock | sentinel | store's warehouse |
| update aggregate — new variants | sentinel | store's warehouse |
| update aggregate — changed stock | sentinel | store's warehouse |
| copy product to another store | sentinel | **target** store's warehouse |
| single-quantity variant PATCH | sentinel | store's warehouse |

The created warehouse has a **blank address**, deliberately, exactly as the migration did: the store has not said where it ships from, and inventing one produces a warehouse that quotes rates from a place that does not exist. Shipping readiness already reports that as a blocker.

A concurrent-write race is handled rather than surfaced — two stock writes for a warehouse-less store both try to create, the partial unique index makes one lose, and the loser's answer is the winner's row. A merchant's product save should not fail for a reason that has nothing to do with their product.

## The storefront side

- **Availability's sentinel branch is gone.** A sentinel row is now simply a location the store does not have, and contributes nothing.
- **`commitStockAtSentinel` is deleted.** A store with no warehouse has no products, so a checkout against one is a broken invariant, not a normal case — it now fails loudly via `ErrNoWarehouse` rather than silently holding stock at a location that names nothing.
- **Cart holds resolve the store's warehouse read-only.** Unlike the write paths this does **not** ensure one: a shopper adding to their cart must never create merchant configuration. A store without a warehouse has no stock rows either, so its items are reported insufficient.

**I verified the invariant against production before relying on it**, rather than assuming: the only store with variants (bondi, 380) has exactly one live warehouse; the other two stores have neither products nor warehouses.

## A bug the tests caught in my own change

My first cut of the cart-hold path returned early when the store had no warehouse — **skipping the per-item ownership check**. That check is the only thing on this unauthenticated surface stopping a caller probing any store's variants through any store's slug. `TestCartHolds_RefusesAVariantFromAnotherStore` failed immediately. The check now always runs first, and the mutation that reinstates the early return fails that test.

## Test migration

`go vet -tags=integration` surfaced 36 references encoding the old contract. Each was a decision, not a find-and-replace:

**Replaced with the new contract:**
- `StoreWithNoWarehousesBehavesExactlyAsBefore` → `...FailsLoudlyInsteadOfUsingASentinel`. It was described in the file as "THE load-bearing test" because production had zero warehouses; that premise is now false.
- `SentinelStockIsReportedAgainstTheFirstWarehouse` → `SentinelStockNoLongerCountsAsAnything`. Kept rather than deleted: a straggler row from a restored backup must contribute **nothing**, and that failure would otherwise be silent.

**Rewritten, because the bug survives even though its old setup does not:**
- `TwoLinesFilledAtSameWarehouseDoNotDoubleCountTheBreakdown` — now one warehouse holding 5.
- `StaleCartHoldAtAnUnusedLocationIsReleasedNotDoubleCommitted` — the unused location is a second real warehouse. This one guards a genuine double-decrement and had to survive.

**Deleted, with the reason recorded in the file:**
- `AssignmentSpanningTwoStorageLocationsHoldsInBoth` and `MixedSentinelAndRealStockForSameWarehouseIsSummedAndBothLocationsRecorded` — both needed one warehouse backed by two storage rows, which cannot occur now that every `location_id` **is** a warehouse id.
- `ContinuePolicyDecrementsAcrossMultipleStorageLocations` — same premise. **I first tried to rewrite it as "spreads across two warehouses" and it failed**: the allocator fills a sell-past-zero variant from the first warehouse and lets it go past zero. Rather than weaken the assertion to match, I removed it and left a note; `ContinuePolicyWithNoStorageSucceedsOnAllocationPath` still covers that path.

Two mutations, each confirmed to compile: `EnsureDefaultForStore` ignoring `archived_at` fails 2 tests; the cart-hold early return fails the ownership test.

Full suite — exit 0, 120 packages ok, **3304 PASS / 25 SKIP / 0 FAIL**. `go vet -tags=integration ./...` clean. No migration.

## Rollout

Safe in either order, and the window it might have opened is already closed: both `marketplace-api-admin` and `marketplace-api-storefront` are on `main-cf9dbe8`, i.e. past the backfill. Old pods placing cart holds at a sentinel that no longer holds stock is the hazard step 1 opened; this closes it rather than widening it.