### PR TITLE
feat(admin): per-warehouse stock for multi-variant products

### DIFF
--- a/apps/admin/components/products/ProductForm.tsx
+++ b/apps/admin/components/products/ProductForm.tsx
@@ -105,6 +105,14 @@ export function ProductForm({
   const hasMultipleVariants = (initialProduct?.variants.length ?? 0) > 1;
   const firstVariant = initialProduct?.variants[0];
 
+  // variantId -> warehouseId -> quantity, from the product detail response
+  // (#177 PR 6). Empty for a store with fewer than two warehouses, which is
+  // exactly when neither tab shows a per-warehouse editor.
+  const stockByVariant: Record<string, Record<string, number>> = {};
+  for (const v of initialProduct?.variants ?? []) {
+    if (v.inventory_by_location) stockByVariant[v.id] = v.inventory_by_location;
+  }
+
   const defaults: ProductFormValues = {
     title: initialProduct?.title ?? "",
     handle: initialProduct?.handle ?? "",
@@ -473,7 +481,13 @@ export function ProductForm({
           )}
           {currentTab === "options" && <OptionsTab />}
           {currentTab === "variants" && (
-            <VariantsTab currencyCode={currencyCode} />
+            <VariantsTab
+              currencyCode={currencyCode}
+              warehouses={warehouses}
+              storeId={storeId}
+              productId={initialProduct?.id}
+              stockByLocation={stockByVariant}
+            />
           )}
           {currentTab === "tax" && (
             <TaxTab storeCountryCode={storeCountryCode} />

--- a/apps/admin/components/products/form/VariantStockByWarehouse.tsx
+++ b/apps/admin/components/products/form/VariantStockByWarehouse.tsx
@@ -13,7 +13,7 @@
 // because the backend conserves the total by clearing the variant's
 // sentinel row in the same transaction — see SetVariantStockByLocationInTx.
 
-import { useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
 import { SENTINEL_LOCATION_ID } from "@/lib/api/marketplace-api";
@@ -27,6 +27,14 @@ interface VariantStockByWarehouseProps {
   warehouses: Warehouse[];
   /** Current breakdown from the product detail response. */
   byLocation: Record<string, number>;
+  /**
+   * Move focus to the first warehouse input on mount. Set when the panel is
+   * opened by a disclosure control: activating it is a deliberate
+   * drill-down, and a keyboard or screen-reader user expects to land
+   * somewhere rather than stay parked on a button whose state silently
+   * changed.
+   */
+  autoFocus?: boolean;
 }
 
 export function VariantStockByWarehouse({
@@ -35,9 +43,15 @@ export function VariantStockByWarehouse({
   variantId,
   warehouses,
   byLocation,
+  autoFocus = false,
 }: VariantStockByWarehouseProps) {
   const router = useRouter();
+  const firstInputRef = useRef<HTMLInputElement>(null);
   const [pending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (autoFocus) firstInputRef.current?.focus();
+  }, [autoFocus]);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
 
@@ -125,7 +139,7 @@ export function VariantStockByWarehouse({
       )}
 
       <ul className="space-y-3">
-        {warehouses.map((w) => (
+        {warehouses.map((w, index) => (
           <li key={w.id} className="flex items-center justify-between gap-4">
             <label
               htmlFor={`stock-${variantId}-${w.id}`}
@@ -135,6 +149,7 @@ export function VariantStockByWarehouse({
               <span className="ml-2 opacity-50">{w.city}</span>
             </label>
             <input
+              ref={index === 0 ? firstInputRef : undefined}
               id={`stock-${variantId}-${w.id}`}
               type="text"
               inputMode="numeric"

--- a/apps/admin/components/products/form/VariantsTab.tsx
+++ b/apps/admin/components/products/form/VariantsTab.tsx
@@ -8,9 +8,15 @@ import {
 import { VariantBulkBar } from "@/components/products/variants/VariantBulkBar";
 import type { ProductFormValues } from "@/lib/validation/product-form";
 import type { AdminMediaResponse } from "@/lib/api/marketplace-api";
+import type { Warehouse } from "@/lib/api/warehouses-api";
 
 export interface VariantsTabProps {
   currencyCode: string;
+  /** Per-warehouse stock (#177 PR 6); fewer than two changes nothing. */
+  warehouses?: Warehouse[];
+  storeId?: string;
+  productId?: string;
+  stockByLocation?: Record<string, Record<string, number>>;
 }
 
 type BulkPatch =
@@ -18,7 +24,13 @@ type BulkPatch =
   | { field: "stock"; value: number }
   | { field: "weight"; value: number };
 
-export function VariantsTab({ currencyCode }: VariantsTabProps) {
+export function VariantsTab({
+  currencyCode,
+  warehouses = [],
+  storeId,
+  productId,
+  stockByLocation = {},
+}: VariantsTabProps) {
   const { control, setValue, getValues } = useFormContext<ProductFormValues>();
   const variants =
     (useWatch({ control, name: "variants" }) as VariantDraft[] | undefined) ?? [];
@@ -54,11 +66,26 @@ export function VariantsTab({ currencyCode }: VariantsTabProps) {
         currencyCode={currencyCode}
         onBulkPatch={handleBulk}
       />
+      {warehouses.length > 1 && (
+        // Two save models in one table is a real inconsistency, so it is
+        // stated rather than disguised: prices and SKUs commit on blur with
+        // the product, warehouse stock has its own Save. A merchant who
+        // expects one Save for everything otherwise files a bug about
+        // stock "not saving".
+        <p className="border-b border-[var(--ink-100)] pb-3 text-xs text-[color:var(--ink-900)]/50">
+          Prices, SKUs and dimensions save with the product. Warehouse stock
+          saves on its own, inside each variant.
+        </p>
+      )}
       <VariantMatrixTable
         variants={variants}
         currencyCode={currencyCode}
         media={media}
         onPatch={handlePatch}
+        warehouses={warehouses}
+        storeId={storeId}
+        productId={productId}
+        stockByLocation={stockByLocation}
       />
     </div>
   );

--- a/apps/admin/components/products/variants/VariantMatrixTable.tsx
+++ b/apps/admin/components/products/variants/VariantMatrixTable.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import type { AdminMediaResponse } from "@/lib/api/marketplace-api";
+import type { Warehouse } from "@/lib/api/warehouses-api";
 import { VariantRow } from "./VariantRow";
 
 export interface VariantDraft {
@@ -24,6 +25,12 @@ export interface VariantMatrixTableProps {
   currencyCode: string;
   media: AdminMediaResponse[];
   onPatch: (key: string, patch: Partial<VariantDraft>) => void;
+  /** Per-warehouse stock (#177 PR 6); fewer than two changes nothing. */
+  warehouses?: Warehouse[];
+  storeId?: string;
+  productId?: string;
+  /** variantId -> warehouseId -> quantity. */
+  stockByLocation?: Record<string, Record<string, number>>;
 }
 
 export function VariantMatrixTable({
@@ -31,6 +38,10 @@ export function VariantMatrixTable({
   currencyCode,
   media,
   onPatch,
+  warehouses = [],
+  storeId,
+  productId,
+  stockByLocation = {},
 }: VariantMatrixTableProps): React.ReactElement {
   const optionNames = React.useMemo<string[]>(() => {
     const first = variants[0];
@@ -84,6 +95,10 @@ export function VariantMatrixTable({
               currencyCode={currencyCode}
               media={media}
               onPatch={(patch) => onPatch(v.key, patch)}
+              warehouses={warehouses}
+              storeId={storeId}
+              productId={productId}
+              stockByLocation={v.id ? stockByLocation[v.id] : undefined}
             />
           ))}
         </tbody>

--- a/apps/admin/components/products/variants/VariantRow.StockSplit.test.tsx
+++ b/apps/admin/components/products/variants/VariantRow.StockSplit.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { Warehouse } from "@/lib/api/warehouses-api";
+import type { VariantDraft } from "./VariantMatrixTable";
+
+vi.mock("@/app/(admin)/products/actions", () => ({
+  saveVariantStockByLocation: vi.fn().mockResolvedValue({ ok: true }),
+}));
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+
+import { VariantRow } from "./VariantRow";
+
+function warehouse(id: string, name: string, city: string): Warehouse {
+  return {
+    id, name, city, line1: "1 Dock Rd", region: "NSW", postal_code: "2026",
+    country_code: "AU", phone: "+61200000000", is_default: false, priority: 0,
+  };
+}
+
+const sydney = warehouse("wh-1", "Main", "Sydney");
+const melbourne = warehouse("wh-2", "Overflow", "Melbourne");
+
+function variant(overrides: Partial<VariantDraft> = {}): VariantDraft {
+  return {
+    id: "var-1",
+    key: "Size=M",
+    price: "10.00",
+    sku: "SKU-1",
+    stock: 12,
+    weight: 1,
+    optionValues: [{ optionName: "Size", value: "M" }],
+    ...overrides,
+  };
+}
+
+function renderRow(props: Partial<React.ComponentProps<typeof VariantRow>> = {}) {
+  render(
+    <table>
+      <tbody>
+        <VariantRow
+          variant={variant()}
+          optionNames={["Size"]}
+          currencyCode="AUD"
+          media={[]}
+          onPatch={vi.fn()}
+          warehouses={[sydney, melbourne]}
+          storeId="store-1"
+          productId="prod-1"
+          stockByLocation={{ "wh-1": 7, "wh-2": 5 }}
+          {...props}
+        />
+      </tbody>
+    </table>,
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+// A store with one warehouse has no split to make, and this table must
+// look exactly as it did before #177.
+describe("VariantRow — one warehouse", () => {
+  it("keeps the plain Stock input", () => {
+    renderRow({ warehouses: [sydney], stockByLocation: { "wh-1": 12 } });
+
+    expect(screen.getByLabelText("Stock")).toHaveValue(12);
+    expect(screen.queryByRole("button", { name: /Expand to edit/ })).toBeNull();
+  });
+
+  it("keeps the plain input for an unsaved variant even with two warehouses", () => {
+    // No id yet: per-warehouse stock saves through the variant PATCH, which
+    // needs one. The split waits until the product is saved.
+    renderRow({ variant: variant({ id: undefined }) });
+
+    expect(screen.getByLabelText("Stock")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Expand to edit/ })).toBeNull();
+  });
+});
+
+describe("VariantRow — the collapsed summary", () => {
+  it("names where the units are, not how many warehouses exist", () => {
+    renderRow();
+
+    // "in 2" told the merchant nothing they could not already see.
+    expect(screen.getByText("Sydney, Melbourne")).toBeInTheDocument();
+    expect(screen.queryByText(/^in 2$/)).toBeNull();
+  });
+
+  it("says 'only' when a variant sits in one location", () => {
+    renderRow({ stockByLocation: { "wh-1": 12 } });
+    expect(screen.getByText("Sydney only")).toBeInTheDocument();
+  });
+
+  it("flags unassigned units, which is the state worth colour", () => {
+    // 12 on the variant, 9 accounted for across warehouses.
+    renderRow({ stockByLocation: { "wh-1": 5, "wh-2": 4 } });
+    expect(screen.getByText("3 unassigned")).toBeInTheDocument();
+  });
+
+  it("truncates beyond two locations rather than overflowing the cell", () => {
+    const brisbane = warehouse("wh-3", "North", "Brisbane");
+    renderRow({
+      warehouses: [sydney, melbourne, brisbane],
+      stockByLocation: { "wh-1": 4, "wh-2": 4, "wh-3": 4 },
+    });
+    expect(screen.getByText("Sydney +2")).toBeInTheDocument();
+  });
+
+  // WCAG 1.4.1 — the amber on the number is never the only carrier of the
+  // unassigned state.
+  it("states the split in the accessible name, not only in colour", () => {
+    renderRow({ stockByLocation: { "wh-1": 5, "wh-2": 4 } });
+
+    expect(
+      screen.getByRole("button", { name: /Stock, 12 units — 3 unassigned/ }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("VariantRow — the disclosure", () => {
+  it("is a real button reporting its state, wired to the panel it controls", async () => {
+    const user = userEvent.setup();
+    renderRow();
+
+    const trigger = screen.getByRole("button", { name: /Expand to edit/ });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger).toHaveAttribute("aria-controls", "stock-panel-var-1");
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(/Stock by warehouse/i)).toBeInTheDocument();
+  });
+
+  it("moves focus into the panel on expand", async () => {
+    const user = userEvent.setup();
+    renderRow();
+
+    await user.click(screen.getByRole("button", { name: /Expand to edit/ }));
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Main/)).toHaveFocus(),
+    );
+  });
+
+  it("opens on Enter from the keyboard", async () => {
+    const user = userEvent.setup();
+    renderRow();
+
+    const trigger = screen.getByRole("button", { name: /Expand to edit/ });
+    trigger.focus();
+    await user.keyboard("{Enter}");
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/apps/admin/components/products/variants/VariantRow.tsx
+++ b/apps/admin/components/products/variants/VariantRow.tsx
@@ -4,6 +4,8 @@ import * as React from "react";
 import type { AdminMediaResponse } from "@/lib/api/marketplace-api";
 import { VariantImagePicker } from "./VariantImagePicker";
 import type { VariantDraft } from "./VariantMatrixTable";
+import { VariantStockByWarehouse } from "@/components/products/form/VariantStockByWarehouse";
+import type { Warehouse } from "@/lib/api/warehouses-api";
 
 export interface VariantRowProps {
   variant: VariantDraft;
@@ -11,6 +13,16 @@ export interface VariantRowProps {
   currencyCode: string;
   media: AdminMediaResponse[];
   onPatch: (patch: Partial<VariantDraft>) => void;
+  /**
+   * Per-warehouse stock (#177 PR 6). With fewer than two warehouses the
+   * Stock cell stays a plain number and this row is byte-for-byte what it
+   * was — a store with one location has no split to make.
+   */
+  warehouses?: Warehouse[];
+  storeId?: string;
+  productId?: string;
+  /** This variant's current breakdown, keyed by warehouse id. */
+  stockByLocation?: Record<string, number>;
 }
 
 function findValue(variant: VariantDraft, optionName: string): string {
@@ -24,7 +36,59 @@ export function VariantRow({
   optionNames,
   media,
   onPatch,
+  warehouses = [],
+  storeId,
+  productId,
+  stockByLocation = {},
 }: VariantRowProps): React.ReactElement {
+  const [splitOpen, setSplitOpen] = React.useState(false);
+  const splitTriggerRef = React.useRef<HTMLButtonElement>(null);
+
+  // The split is offered only when there is a choice to make AND a saved
+  // variant to write against: per-warehouse stock saves through the
+  // variant PATCH, which needs an id. A variant generated but not yet
+  // saved keeps the plain total until the product is saved.
+  const canSplit =
+    warehouses.length > 1 && Boolean(variant.id && storeId && productId);
+
+  // What the collapsed cell says. A count ("in 2") tells the merchant
+  // nothing they cannot already see; WHERE the units are is the thing they
+  // opened the page for, and it doubles as the at-a-glance flag for a
+  // variant stocked in only one place or carrying unassigned units.
+  const assigned = warehouses.reduce(
+    (sum, w) => sum + (stockByLocation[w.id] ?? 0),
+    0,
+  );
+  const unassigned = Math.max(variant.stock - assigned, 0);
+  const stocked = warehouses.filter((w) => (stockByLocation[w.id] ?? 0) > 0);
+
+  let splitSummary: string;
+  if (unassigned > 0) {
+    splitSummary = `${unassigned} unassigned`;
+  } else if (stocked.length === 0) {
+    splitSummary = "Not stocked";
+  } else if (stocked.length === 1) {
+    // "only" carries the signal in words rather than adding a second
+    // colour. Stocking one location is often deliberate, so it is not a
+    // warning — just worth saying.
+    splitSummary = `${stocked[0]!.city || stocked[0]!.name} only`;
+  } else if (stocked.length === 2) {
+    splitSummary = stocked.map((w) => w.city || w.name).join(", ");
+  } else {
+    splitSummary = `${stocked[0]!.city || stocked[0]!.name} +${stocked.length - 1}`;
+  }
+
+  // Colour is reserved for the one state that is a data-hygiene problem.
+  // Vermillion (--signal) stays for destructive/error; unassigned stock is
+  // amber-bronze, matching the same warning the single-variant panel uses.
+  const summaryClass = unassigned > 0
+    ? "text-xs text-[color:var(--warning)]"
+    : "text-xs text-[color:var(--ink-900)]/40";
+
+  // WCAG 1.4.1: colour alone never carries the state, so the accessible
+  // name says it too.
+  const stockLabel =
+    `Stock, ${variant.stock} units — ${splitSummary}. Expand to edit by warehouse.`;
   const [price, setPrice] = React.useState(variant.price);
   const [sku, setSku] = React.useState(variant.sku);
   const [stock, setStock] = React.useState(String(variant.stock));
@@ -85,7 +149,10 @@ export function VariantRow({
     if (!Number.isNaN(n) && n !== variant[field]) onPatch({ [field]: n });
   };
 
+  const totalColumns = optionNames.length + 6;
+
   return (
+    <>
     <tr className="border-b border-[var(--ink-100)]">
       {optionNames.map((name) => (
         <td key={name} className="px-3 py-2 text-sm text-[var(--ink-900)]">
@@ -114,15 +181,59 @@ export function VariantRow({
         />
       </td>
       <td className="px-3 py-2">
-        <input
-          aria-label="Stock"
-          type="number"
-          value={stock}
-          onChange={(e) => setStock(e.target.value)}
-          onBlur={commitStock}
-          style={tabularNum}
-          className="w-20 bg-transparent px-2 py-1 text-sm text-[var(--ink-900)] outline-none focus:ring-2 focus:ring-[var(--moss-700)]"
-        />
+        {canSplit ? (
+          // A disclosure control, not a stunted text field. Every sibling
+          // cell is an input; styling this one to half-resemble one made it
+          // read as broken. Borderless, chevron, serif numeral — closer to
+          // a footnote reference than a form control.
+          <button
+            type="button"
+            aria-expanded={splitOpen}
+            aria-controls={`stock-panel-${variant.id}`}
+            aria-label={stockLabel}
+            ref={splitTriggerRef}
+            onClick={() => {
+              setSplitOpen((open) => {
+                // Collapsing returns focus to this button rather than
+                // dumping the keyboard user at the top of a long table.
+                if (open) {
+                  requestAnimationFrame(() => splitTriggerRef.current?.focus());
+                }
+                return !open;
+              });
+            }}
+            className="group flex flex-col items-start gap-0.5 rounded-md px-2 py-1 text-left hover:bg-[color:var(--ink-900)]/[0.03] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]"
+          >
+            <span className="flex items-center gap-1.5">
+              <span
+                style={tabularNum}
+                className="font-[family-name:var(--font-serif,'Source_Serif_4',serif)] text-sm text-[var(--ink-900)]"
+              >
+                {variant.stock}
+              </span>
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 10 10"
+                aria-hidden="true"
+                className={`text-[color:var(--ink-900)]/40 transition-transform group-hover:text-[color:var(--moss-700)] motion-reduce:transition-none ${splitOpen ? "rotate-180" : ""}`}
+              >
+                <path d="M2 4l3 3 3-3" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </span>
+            <span className={summaryClass}>{splitSummary}</span>
+          </button>
+        ) : (
+          <input
+            aria-label="Stock"
+            type="number"
+            value={stock}
+            onChange={(e) => setStock(e.target.value)}
+            onBlur={commitStock}
+            style={tabularNum}
+            className="w-20 bg-transparent px-2 py-1 text-sm text-[var(--ink-900)] outline-none focus:ring-2 focus:ring-[var(--moss-700)]"
+          />
+        )}
       </td>
       <td className="px-3 py-2">
         <input
@@ -204,5 +315,31 @@ export function VariantRow({
         ) : null}
       </td>
     </tr>
+    {canSplit && splitOpen && (
+      // A full-width sub-row rather than extra columns: the split is a
+      // detail of ONE variant, and widening every row to carry a column per
+      // warehouse would make the common single-warehouse table worse to
+      // serve the uncommon case.
+      <tr className="border-b border-[var(--ink-100)]">
+        <td colSpan={totalColumns} className="px-3 py-6">
+          {/* Constrained rather than full-bleed, on the page's own paper
+              rather than a tinted panel: the design system is hairline
+              rules, not cards, and a full-width filled block in a dense
+              table reads as a layout break rather than detail attached to
+              this row. */}
+          <div id={`stock-panel-${variant.id}`} className="max-w-xl">
+          <VariantStockByWarehouse
+            storeId={storeId!}
+            productId={productId!}
+            variantId={variant.id!}
+            warehouses={warehouses}
+            byLocation={stockByLocation}
+            autoFocus
+          />
+          </div>
+        </td>
+      </tr>
+    )}
+    </>
   );
 }


### PR DESCRIPTION
Refs #177. Closes the gap I flagged when 5e landed: the per-warehouse editor covered single-variant products only. On the real store that is **184 of 227 products covered and 43 not** — every product with sizes or colours. Without this you cannot set up a realistic split-shipment order, which is the thing multi-warehouse exists to do.

## The pattern, and why not the obvious one

The Variants tab is already a dense table — options, price, SKU, stock, weight, L×W×H, image — and scrolls horizontally on narrow viewports. A column per warehouse does not scale past two or three and degrades the common single-warehouse case to serve the uncommon one.

Instead: the Stock cell becomes a **disclosure** showing the total, expanding a sub-row with the same `VariantStockByWarehouse` panel the single-variant page uses. Reusing it is deliberate — a merchant who has split stock on a simple product already knows this control when they meet a variant matrix.

I had a UX review challenge this before building it out, and it rejected the alternatives for concrete reasons worth recording: a **variants × warehouses matrix tab** is the enterprise-dashboard answer this design system lists as an anti-reference, and it splits one product's numbers across two tabs; a **drawer** shows one variant at a time, defeating the actual task ("which variants are low in Melbourne?"); a **modal** implies a weighty decision for a routine adjustment.

## Two things the review caught that I had wrong

**The expanded panel was a filled card.** `bg-[--ink-900]/[0.015]` stretched full-bleed across all eight columns. The system is hairline rules, not bordered cards, and a full-width tinted block inside a dense table reads as a layout break rather than as detail attached to one row. Now `max-w-xl`, on the page's own paper, hairline-separated.

**`"in 2"` was the wrong information.** A warehouse count tells the merchant nothing they cannot already see. The sub-line now names *where*:

| state | reads |
|---|---|
| spread across two | `Sydney, Melbourne` |
| concentrated | `Sydney only` |
| units unaccounted for | `3 unassigned` |
| more than two | `Sydney +2` |

That single change also solved the "how do I spot a lopsided variant without expanding every row" problem, with no new UI.

## Colour, restrained

Amber-bronze (`--warning`) marks **only** the unassigned state — a data-hygiene problem worth flagging. Stocking one location is usually deliberate, so `"only"` carries that in words rather than earning a second colour. Vermillion stays reserved for destructive/error.

Per WCAG 1.4.1 the colour is never the sole carrier: the accessible name reads `"Stock, 12 units — 3 unassigned. Expand to edit by warehouse."`

## The two save models, said out loud

Prices and SKUs commit on blur with the product; warehouse stock has its own Save, because it writes through the variant PATCH that conserves the total. Rather than disguise that, the tab says it once, quietly, only when the store has 2+ warehouses:

> Prices, SKUs and dimensions save with the product. Warehouse stock saves on its own, inside each variant.

## Unchanged for everyone else

A store with **fewer than two warehouses** sees the plain Stock input, exactly as before — pinned by a test. So does an **unsaved variant**: per-warehouse stock writes through the variant PATCH, which needs an id, so the split waits until the product is saved.

## Accessibility

Real `<button>` with `aria-expanded` and `aria-controls`; focus moves into the first warehouse input on expand (activating a disclosure is a deliberate drill-down — a keyboard user should land somewhere, not stay parked on a button whose state silently changed) and returns to the trigger on collapse, so a long table does not lose their place. Chevron rotation is gated behind `motion-reduce`.

## Tests

10 new. Four mutations, each confirmed to compile first:

| mutation | caught by |
|---|---|
| disclosure shown with one warehouse | `keeps the plain Stock input` |
| unassigned units not reported | 2 tests |
| the `"only"` wording dropped | `says 'only' when a variant sits in one location` |
| focus not moved into the panel | `moves focus into the panel on expand` |

Admin suite: **109 files, 852 tests passing**; `tsc --noEmit` clean.

## Still open

Nothing here changes the storefront or the allocator. With this merged, a merchant can finally set up the state needed to test a real split-shipment order: two warehouses, a multi-variant product, stock in both.