### PR TITLE
fix(admin): stop opening a product staging its variants for deletion

### DIFF
--- a/apps/admin/components/products/ProductForm.VariantsWithoutOptions.test.tsx
+++ b/apps/admin/components/products/ProductForm.VariantsWithoutOptions.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { AdminCategory, AdminProduct } from "@/lib/api/marketplace-api";
+
+const updateProductAction = vi.fn(async () => ({ ok: true, data: { id: "p1" } }));
+
+vi.mock("@/app/(admin)/products/actions", () => ({
+  createProductAction: vi.fn(async () => ({ ok: true, data: { id: "p1" } })),
+  updateProductAction: (...args: unknown[]) => updateProductAction(...(args as [])),
+  deleteProductAction: vi.fn(async () => ({ ok: true })),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+vi.mock("./form/MediaTab", () => ({
+  MediaTab: () => <div data-testid="media-tab-stub" />,
+}));
+
+import { ProductForm } from "./ProductForm";
+
+const categories: AdminCategory[] = [];
+
+// A product with variants but NO options. This is not hypothetical: 8 of
+// the-bondi-store's 12 products are in exactly this state, and it is the
+// shape seeded catalogues arrive in.
+function productWithVariantsButNoOptions(): AdminProduct {
+  return {
+    id: "p1",
+    title: "Palm Beach Linen Robe",
+    handle: "palm-beach-linen-robe",
+    description: "",
+    status: "active",
+    categories: [],
+    options: [],
+    media: [],
+    variants: [
+      { id: "v1", sku: "ROBE-S", price: "120", inventory_quantity: 20, option_values: [] },
+      { id: "v2", sku: "ROBE-M", price: "120", inventory_quantity: 20, option_values: [] },
+    ],
+  } as unknown as AdminProduct;
+}
+
+const baseProps = {
+  storeId: "s1",
+  categories,
+  currencyCode: "AUD",
+  storeCountryCode: "AU",
+  canDelete: false,
+  canArchive: false,
+  session: { userId: "u1", tenantId: "t1" },
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+// generateVariants([], existing) returns every existing variant id as
+// removedIds — correct when a merchant DELETES their last option, and
+// catastrophic when it fires on mount for a product that simply never had
+// options. The deletion is staged into removed_variant_ids, which
+// updateProductAction forwards as-is, so pressing Save destroys every
+// variant of the product.
+describe("ProductForm — a product whose variants have no options", () => {
+  it("does not stage its variants for deletion on mount", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProductForm
+        {...baseProps}
+        mode="edit"
+        initialProduct={productWithVariantsButNoOptions()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+    await waitFor(() => expect(updateProductAction).toHaveBeenCalled());
+
+    const values = updateProductAction.mock.calls[0]![3] as {
+      removed_variant_ids?: string[];
+    };
+    expect(values.removed_variant_ids ?? []).toEqual([]);
+  });
+
+  it("keeps the variants themselves rather than emptying the form", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProductForm
+        {...baseProps}
+        mode="edit"
+        initialProduct={productWithVariantsButNoOptions()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+    await waitFor(() => expect(updateProductAction).toHaveBeenCalled());
+
+    const values = updateProductAction.mock.calls[0]![3] as {
+      variants?: unknown[];
+    };
+    expect(values.variants ?? []).toHaveLength(2);
+  });
+});

--- a/apps/admin/components/products/ProductForm.tsx
+++ b/apps/admin/components/products/ProductForm.tsx
@@ -210,8 +210,26 @@ export function ProductForm({
     );
   }, [options]);
 
+  // Skips the FIRST run. On mount, options and variants are both hydrated
+  // from the server and already agree with each other — there is nothing
+  // to derive, and deriving anyway is destructive: generateVariants with
+  // zero options returns every existing variant id as `removedIds`, which
+  // is correct when a merchant deletes their last option and catastrophic
+  // when the product simply never had options.
+  //
+  // 8 of the-bondi-store's 12 products are in that state (variants, no
+  // option rows — the shape a seeded catalogue arrives in). Opening one
+  // emptied the variants list and staged every variant for deletion;
+  // pressing Save destroyed them. The form looked like it was showing an
+  // empty state and was in fact holding a loaded gun.
+  const derivationHasRun = useRef(false);
+
   useEffect(() => {
     if (!options) return;
+    if (!derivationHasRun.current) {
+      derivationHasRun.current = true;
+      return;
+    }
 
     // Adapt RHF options -> generateVariants OptionDraft (values: string[]).
     const adapted: GenOptionDraft[] = options

--- a/apps/admin/components/products/form/ProductRail.tsx
+++ b/apps/admin/components/products/form/ProductRail.tsx
@@ -37,7 +37,12 @@ export function ProductRail({ categories, storeId, actions }: ProductRailProps) 
   const { formState, watch, setValue } = useFormContext<ProductFormValues>();
 
   return (
-    <aside className="lg:sticky lg:top-8 lg:self-start">
+    // A hairline down the left edge is what makes this read as a COLUMN
+    // rather than controls floating in whitespace. Without it the sticky
+    // Save button appears to dangle in the middle of the page as the long
+    // left column scrolls past it — the elements were right, the boundary
+    // was missing. Hairline rather than a card, per the system.
+    <aside className="lg:sticky lg:top-8 lg:self-start lg:border-l lg:border-border-subtle lg:pl-8">
       <div className="flex flex-col gap-6">
         <Field label="Status" error={formState.errors.status?.message}>
           <Select
@@ -69,6 +74,9 @@ export function ProductRail({ categories, storeId, actions }: ProductRailProps) 
         </Field>
 
         <div className="border-t border-border-subtle pt-6">{actions}</div>
+        <p className="text-xs text-[color:var(--ink-900)]/40">
+          Changes apply when you save.
+        </p>
       </div>
     </aside>
   );


### PR DESCRIPTION
**Data-loss bug, found while verifying multi-warehouse on the live store.** Not introduced by the form restructure — it predates it — but the restructure is what made me look.

## What happens

Open a product that has variants but **no options**, press **Save changes**, and every variant of that product is deleted.

The chain:

1. The options→variants derivation effect runs on mount.
2. `generateVariants([], existingVariants, …)` returns `{ variants: [], removedIds: [every existing variant id] }`. That is **correct** when a merchant deletes their last option — the variants should go with it.
3. On mount it is not an edit. The effect writes `variants: []` and stages `removed_variant_ids: ['v1','v2', …]`.
4. `updateProductAction` forwards `removed_variant_ids` as-is.
5. Save destroys them.

The form looked like it was showing an empty state — *"Add options on the Options tab to generate variants"* — and was in fact **holding a loaded gun**. The merchant sees a product that appears to have no variants and does the most natural thing available.

## How reachable

Not hypothetical. **8 of the-bondi-store's 12 products are in exactly this state** — variants with no `product_options` rows, which is the shape a seeded catalogue arrives in. I hit it opening `Palm Beach Linen Robe` (2 variants, empty Variants tab) while checking whether the multi-variant stock editor was reachable.

## Fix

Skip the derivation on its **first** run. On mount, options and variants are both hydrated from the server and already agree with each other — there is nothing to derive. Every later run is a genuine edit, so deleting the last option still removes its variants exactly as before.

One `useRef`, three lines. The narrow fix is the right one here: the derivation is correct, it was simply being asked a question on mount that only makes sense after an edit.

## Tests

Two, both failing before the change — they assert on what reaches `updateProductAction`, because that is where the damage is done rather than in what the screen shows:

- `does not stage its variants for deletion on mount` — was `['v1','v2']`, now `[]`
- `keeps the variants themselves rather than emptying the form` — was 0 variants, now 2

Mutation-tested: restoring the mount-time derivation (with the ref still referenced so it compiles) fails both, plus 0 of the pre-existing suite — which is itself worth noting, because **nothing in 863 existing tests covered this**. The infinite-loop test nearby presets options, so it never exercised the empty-options path.

## Also in this PR — the rail

You flagged the Save button dangling mid-page. It was: the sticky rail had no left boundary, so as the long left column scrolled past, the controls read as floating in whitespace rather than as a column.

Added a hairline down the rail's left edge (`lg:border-l` + padding) — a rule, not a card, per the system — plus a quiet "Changes apply when you save" line under the actions. The elements were right; the boundary was missing.

Admin suite: **110 files, 863 tests passing**; `tsc --noEmit` clean.

## Worth a follow-up

Those 8 products still cannot have their variants **edited** — price, SKU and stock are unreachable without options, and the per-warehouse editor with them. This PR stops the destruction; it does not make the variants editable. That needs its own decision: either the matrix renders option-less variants as plain rows, or those products get real options.