### PR TITLE
fix(admin): give option-less variants unique keys so editing one row stops overwriting all of them

### DIFF
--- a/apps/admin/components/products/ProductForm.VariantsWithoutOptions.test.tsx
+++ b/apps/admin/components/products/ProductForm.VariantsWithoutOptions.test.tsx
@@ -99,3 +99,37 @@ describe("ProductForm — a product whose variants have no options", () => {
     expect(values.variants ?? []).toHaveLength(2);
   });
 });
+
+// With no options there are no option-value pairs to compose a key from,
+// so buildVariantKey returned "" for EVERY variant of these products. The
+// key is both the React list key and the identity VariantsTab.handlePatch
+// matches on (`v.key === key`), so a single "" shared by every row means
+// editing one row's price wrote that price into all of them — silently,
+// and on exactly the products that were already the most broken.
+describe("ProductForm — editing one option-less variant", () => {
+  it("does not write the edit into every other variant", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProductForm
+        {...baseProps}
+        mode="edit"
+        initialProduct={productWithVariantsButNoOptions()}
+      />,
+    );
+
+    const prices = await screen.findAllByLabelText("Price");
+    expect(prices).toHaveLength(2);
+
+    await user.clear(prices[0]!);
+    await user.type(prices[0]!, "999");
+    await user.tab();
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+    await waitFor(() => expect(updateProductAction).toHaveBeenCalled());
+
+    const values = updateProductAction.mock.calls[0]![3] as {
+      variants?: Array<{ price: string }>;
+    };
+    expect(values.variants?.map((v) => v.price)).toEqual(["999", "120"]);
+  });
+});

--- a/apps/admin/components/products/ProductForm.tsx
+++ b/apps/admin/components/products/ProductForm.tsx
@@ -151,7 +151,12 @@ export function ProductForm({
       );
       return {
         id: v.id,
-        key: buildVariantKey(pairs),
+        // With no options there is nothing to compose a key from and
+        // buildVariantKey returns "" for every variant alike. The key is
+        // both the React list key and the identity handlePatch matches on,
+        // so a shared "" made editing one row write into all of them. Fall
+        // back to the variant's own id, which is unique and stable.
+        key: pairs.length > 0 ? buildVariantKey(pairs) : `id:${v.id}`,
         price: v.price,
         sku: v.sku,
         stock: v.inventory_quantity,


### PR DESCRIPTION
## The bug

`buildVariantKey` returns `""` when there are no option-value pairs to compose from. Every variant of an option-less product therefore hydrated with the **same** key:

```ts
// ProductForm.tsx
key: buildVariantKey(pairs),   // pairs === [] → "" for all of them
```

That key is doing two jobs at once, and both break:

1. It is the React list key — hence `Encountered two children with the same key, \`\`` in the console.
2. It is the identity `VariantsTab.handlePatch` matches on:

```ts
current.map((v) => (v.key === key ? { ...v, ...patch } : v))
```

So editing **one** row's price wrote that price into **every** row of the product. Silently, with no error, on exactly the products that were already the most broken.

## Scope

8 of the-bondi-store's 12 products have variants but no `product_options` rows — the shape a seeded catalogue arrives in. `Palm Beach Linen Robe` (`a28defe3-…`) is the reproduction case.

This is the second half of the same seam as #540. #540 stopped the derivation effect from staging those variants for deletion on mount; it did not make them safely editable, because as soon as the matrix rendered, any edit fanned out across all rows.

## The fix

Fall back to the variant's own id, which is unique and stable:

```ts
key: pairs.length > 0 ? buildVariantKey(pairs) : `id:${v.id}`,
```

`buildVariantKey` itself is unchanged — `""` is still the correct canonical key for "no options" everywhere it is used to *match* option combinations (`generateVariants`). Only the hydration site, which needs row identity rather than a combination key, takes the fallback.

## Test

Added to `ProductForm.VariantsWithoutOptions.test.tsx`, alongside the two #540 cases. It fails on `main`:

```
AssertionError: expected [ '999', '999' ] to deeply equal [ '999', '120' ]
```

and passes here.

## Verification

- `npx vitest run` in `apps/admin` — **110 files, 864 tests, 0 failures** (863 before; the +1 is this test).
- React's duplicate-key warning is gone from the test output.

## Note

Not yet visible in production: `main-0e37834d` (#540) has still not rolled out to the admin pods, which remain on `main-4b22e7c`. Until it does, opening one of these 8 products and pressing Save still deletes its variants.