### PR TITLE
refactor(admin): collapse the variant matrix to four columns with a per-row details disclosure

### DIFF
--- a/apps/admin/components/products/media/MediaCropDialog.test.tsx
+++ b/apps/admin/components/products/media/MediaCropDialog.test.tsx
@@ -72,8 +72,19 @@ describe("MediaCropDialog", () => {
     const onCancel = vi.fn();
     render(<MediaCropDialog sourceUrl="blob:test" onApply={onApply} onCancel={onCancel} />);
     await waitFor(() => expect(screen.getByRole("button", { name: /apply/i })).not.toBeDisabled());
-    fireEvent.keyDown(window, { key: "Enter" });
-    await waitFor(() => expect(onApply).toHaveBeenCalledTimes(1));
+    // The Apply button's disabled state and the window keydown listener are
+    // updated by two different mechanisms: the button is plain render
+    // output, the listener is a passive effect keyed on [pixelCrop]. React
+    // commits the DOM before flushing that effect, so waiting on the button
+    // does not guarantee the listener has re-registered with a non-null
+    // pixelCrop — on a loaded CI runner the keydown lands on the stale
+    // closure and does nothing. Retry the key until it takes; handleApply
+    // sets `busy` synchronously and the handler skips when busy, so a retry
+    // cannot apply twice.
+    await waitFor(() => {
+      fireEvent.keyDown(window, { key: "Enter" });
+      expect(onApply).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("passes sourceMimeType through to cropToBlob", async () => {

--- a/apps/admin/components/products/variants/VariantImagePicker.tsx
+++ b/apps/admin/components/products/variants/VariantImagePicker.tsx
@@ -17,7 +17,12 @@ export function VariantImagePicker({
   const hasMedia = media.length > 0;
 
   return (
-    <div className="flex flex-col gap-3 rounded-md border border-[var(--ink-100)] bg-[var(--background-elevated)] p-4 shadow-[var(--shadow-1)]">
+    // No card. This used to be a floating popover, which needed its own
+    // border, fill and shadow to separate itself from the row underneath.
+    // It now sits inside the row's details disclosure, which already has a
+    // hairline above it — so the wrapper would be a bordered card in a
+    // system whose rule is hairline rules, not cards.
+    <div className="flex flex-col gap-3">
       {hasMedia ? (
         <div
           role="radiogroup"

--- a/apps/admin/components/products/variants/VariantMatrixTable.test.tsx
+++ b/apps/admin/components/products/variants/VariantMatrixTable.test.tsx
@@ -35,7 +35,7 @@ const variants: VariantDraft[] = [
 ];
 
 describe("VariantMatrixTable", () => {
-  it("renders one row per variant with option cells", () => {
+  it("composes every option into a single Variant cell", () => {
     render(
       <VariantMatrixTable
         variants={variants}
@@ -44,10 +44,38 @@ describe("VariantMatrixTable", () => {
         onPatch={() => {}}
       />,
     );
-    expect(screen.getByText("Red")).toBeInTheDocument();
-    expect(screen.getByText("Blue")).toBeInTheDocument();
-    expect(screen.getByText("M")).toBeInTheDocument();
-    expect(screen.getByText("L")).toBeInTheDocument();
+    // Colour and Size used to be two columns. They are now one cell, joined
+    // by the interpunct, in the header's column order.
+    expect(screen.getByText("Red · M")).toBeInTheDocument();
+    expect(screen.getByText("Blue · L")).toBeInTheDocument();
+  });
+
+  it("shows four data columns, not one per option", () => {
+    render(
+      <VariantMatrixTable
+        variants={variants}
+        currencyCode="USD"
+        media={media}
+        onPatch={() => {}}
+      />,
+    );
+    const headers = screen
+      .getAllByRole("columnheader")
+      .map((th) => th.textContent?.trim());
+    expect(headers).toEqual(["Variant", "Price (USD)", "SKU", "Stock", "Details"]);
+  });
+
+  it("keeps weight, dimensions and image out of the row until expanded", () => {
+    render(
+      <VariantMatrixTable
+        variants={variants}
+        currencyCode="USD"
+        media={media}
+        onPatch={() => {}}
+      />,
+    );
+    expect(screen.queryByLabelText("Weight")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Length (cm)")).not.toBeInTheDocument();
   });
 
   it("renders price input populated from variant", () => {

--- a/apps/admin/components/products/variants/VariantMatrixTable.test.tsx
+++ b/apps/admin/components/products/variants/VariantMatrixTable.test.tsx
@@ -62,7 +62,19 @@ describe("VariantMatrixTable", () => {
     const headers = screen
       .getAllByRole("columnheader")
       .map((th) => th.textContent?.trim());
-    expect(headers).toEqual(["Variant", "Price (USD)", "SKU", "Stock", "Details"]);
+    // The price header interpolates a currency symbol via Intl, which
+    // resolves differently depending on the ICU data the runtime ships
+    // with — "Price ($)" on CI, "Price (USD)" on a full-icu local Node.
+    // The column set is what this test is about, so match that shape
+    // rather than pinning an environment-dependent string.
+    expect(headers).toHaveLength(5);
+    expect([headers[0], headers[2], headers[3], headers[4]]).toEqual([
+      "Variant",
+      "SKU",
+      "Stock",
+      "Details",
+    ]);
+    expect(headers[1]).toMatch(/^Price \(/);
   });
 
   it("keeps weight, dimensions and image out of the row until expanded", () => {

--- a/apps/admin/components/products/variants/VariantMatrixTable.tsx
+++ b/apps/admin/components/products/variants/VariantMatrixTable.tsx
@@ -63,34 +63,34 @@ export function VariantMatrixTable({
   }, [currencyCode]);
 
   return (
-    // overflow-x-auto handles narrow viewports (mobile / small split panes),
-    // but on md+ we need overflow-visible so the VariantImagePicker popover
-    // can spill below the row. Otherwise CSS coerces overflow-y to auto and
-    // the absolute popover triggers a vertical scrollbar on the wrapper.
-    <div className="overflow-x-auto md:overflow-visible">
+    // Plain overflow-x-auto. The md:overflow-visible exception existed only
+    // so the image picker's absolutely-positioned popover could spill below
+    // the row; the picker now lives inside the row's details disclosure, so
+    // nothing escapes the wrapper and the exception is gone with it.
+    <div className="overflow-x-auto">
       <table className="w-full border-collapse text-left">
         <thead>
+          {/* Four visible columns, not eight. Every option collapses into
+              one Variant cell, and weight / dimensions / image move behind
+              the per-row details disclosure. Eight columns did not fit a
+              realistic admin width and pushed the table into a horizontal
+              scroll on every product that had options at all. */}
           <tr className="border-b border-[var(--ink-100)] text-xs uppercase tracking-widest text-[var(--ink-500)]">
-            {optionNames.map((name) => (
-              <th key={name} className="px-3 py-2 font-normal">
-                {name}
-              </th>
-            ))}
+            <th className="px-3 py-2 font-normal">Variant</th>
             <th className="px-3 py-2 font-normal">{priceHeader}</th>
             <th className="px-3 py-2 font-normal">SKU</th>
             <th className="px-3 py-2 font-normal">Stock</th>
-            <th className="px-3 py-2 font-normal">Weight (kg)</th>
-            <th className="px-3 py-2 font-normal" title="Length × Width × Height in centimetres">
-              L × W × H (cm)
+            <th className="w-px px-3 py-2 font-normal">
+              <span className="sr-only">Details</span>
             </th>
-            <th className="px-3 py-2 font-normal">Image</th>
           </tr>
         </thead>
         <tbody>
-          {variants.map((v) => (
+          {variants.map((v, index) => (
             <VariantRow
               key={v.key}
               variant={v}
+              index={index}
               optionNames={optionNames}
               currencyCode={currencyCode}
               media={media}

--- a/apps/admin/components/products/variants/VariantRow.test.tsx
+++ b/apps/admin/components/products/variants/VariantRow.test.tsx
@@ -34,13 +34,15 @@ function renderRow(
   override: Partial<VariantDraft> = {},
   onPatch = vi.fn(),
   mediaList: AdminMediaResponse[] = media,
+  optionNames: string[] = ["Color"],
 ) {
   render(
     <table>
       <tbody>
         <VariantRow
           variant={{ ...baseVariant, ...override }}
-          optionNames={["Color"]}
+          index={0}
+          optionNames={optionNames}
           currencyCode="USD"
           media={mediaList}
           onPatch={onPatch}
@@ -51,6 +53,11 @@ function renderRow(
   return onPatch;
 }
 
+/** Weight, dimensions and the image now live behind the row's disclosure. */
+function openDetails(): void {
+  fireEvent.click(screen.getByRole("button", { name: /weight, dimensions and image/i }));
+}
+
 describe("VariantRow", () => {
   it("commits sku on blur and weight on blur, skips no-op change", () => {
     const onPatch = renderRow();
@@ -59,6 +66,7 @@ describe("VariantRow", () => {
     fireEvent.blur(sku);
     expect(onPatch).toHaveBeenCalledWith({ sku: "SKU-2" });
 
+    openDetails();
     const weight = screen.getByLabelText("Weight");
     fireEvent.change(weight, { target: { value: "1.5" } });
     fireEvent.blur(weight);
@@ -76,17 +84,16 @@ describe("VariantRow", () => {
     const stock = screen.getByLabelText("Stock");
     fireEvent.change(stock, { target: { value: "abc" } });
     fireEvent.blur(stock);
+    openDetails();
     const weight = screen.getByLabelText("Weight");
     fireEvent.change(weight, { target: { value: "xyz" } });
     fireEvent.blur(weight);
     expect(onPatch).not.toHaveBeenCalled();
   });
 
-  it("toggles image picker and selecting an image emits variantImageId", () => {
+  it("selecting an image in the details panel emits variantImageId", () => {
     const onPatch = renderRow();
-    const imgBtn = screen.getByRole("button", { name: /variant image/i });
-    fireEvent.click(imgBtn);
-    // Picker lists media thumbnails — click the first media option
+    openDetails();
     const thumb = screen.getByRole("radio", { name: /pic/i });
     fireEvent.click(thumb);
     expect(onPatch).toHaveBeenCalledWith({ variantImageId: "m1" });
@@ -94,7 +101,61 @@ describe("VariantRow", () => {
 
   it("renders current media image when variantImageId matches", () => {
     renderRow({ variantImageId: "m1" });
+    openDetails();
     const img = screen.getByAltText("pic") as HTMLImageElement;
     expect(img.src).toContain("a.jpg");
+  });
+
+  it("names the row by its option values", () => {
+    renderRow();
+    expect(screen.getByText("Red")).toBeInTheDocument();
+  });
+
+  // 8 of the-bondi-store's 12 products have variants with no options at
+  // all. Those rows have nothing to compose a name from, and must still be
+  // tellable apart rather than rendering as blank cells.
+  it("falls back to its position when the variant has no options", () => {
+    render(
+      <table>
+        <tbody>
+          <VariantRow
+            variant={{ ...baseVariant, optionValues: [] }}
+            index={2}
+            optionNames={[]}
+            currencyCode="USD"
+            media={media}
+            onPatch={vi.fn()}
+          />
+        </tbody>
+      </table>,
+    );
+    expect(screen.getByText("Variant 3")).toBeInTheDocument();
+  });
+
+  it("does not invent an option name for an unnamed variant", () => {
+    render(
+      <table>
+        <tbody>
+          <VariantRow
+            variant={{ ...baseVariant, optionValues: [] }}
+            index={0}
+            optionNames={[]}
+            currencyCode="USD"
+            media={media}
+            onPatch={vi.fn()}
+          />
+        </tbody>
+      </table>,
+    );
+    expect(screen.queryByText(/option a/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("—")).not.toBeInTheDocument();
+  });
+
+  it("collapses the details panel again on a second click", () => {
+    renderRow();
+    openDetails();
+    expect(screen.getByLabelText("Weight")).toBeInTheDocument();
+    openDetails();
+    expect(screen.queryByLabelText("Weight")).not.toBeInTheDocument();
   });
 });

--- a/apps/admin/components/products/variants/VariantRow.tsx
+++ b/apps/admin/components/products/variants/VariantRow.tsx
@@ -9,6 +9,8 @@ import type { Warehouse } from "@/lib/api/warehouses-api";
 
 export interface VariantRowProps {
   variant: VariantDraft;
+  /** Row position, used to label variants that have no options to name them. */
+  index: number;
   optionNames: string[];
   currencyCode: string;
   media: AdminMediaResponse[];
@@ -33,6 +35,7 @@ const tabularNum: React.CSSProperties = { fontVariantNumeric: "tabular-nums" };
 
 export function VariantRow({
   variant,
+  index,
   optionNames,
   media,
   onPatch,
@@ -102,7 +105,9 @@ export function VariantRow({
   const [heightCm, setHeightCm] = React.useState(
     variant.heightCm ? String(variant.heightCm) : "",
   );
-  const [pickerOpen, setPickerOpen] = React.useState(false);
+  const [detailsOpen, setDetailsOpen] = React.useState(false);
+  const detailsTriggerRef = React.useRef<HTMLButtonElement>(null);
+  const rowKey = variant.id ?? variant.key;
 
   React.useEffect(() => setPrice(variant.price), [variant.price]);
   React.useEffect(() => setSku(variant.sku), [variant.sku]);
@@ -121,7 +126,14 @@ export function VariantRow({
     [variant.heightCm],
   );
 
-  const currentMedia = media.find((m) => m.id === variant.variantImageId) ?? null;
+  // One Variant cell instead of a column per option. The interpunct is
+  // already this codebase's separator for joined metadata (the product
+  // header joins handle and storefront link the same way), so it is not a
+  // second convention for the same job.
+  const composedName = optionNames
+    .map((name) => findValue(variant, name))
+    .filter((value) => value.length > 0)
+    .join(" · ");
 
   const commitPrice = (): void => {
     if (price !== variant.price) onPatch({ price });
@@ -149,16 +161,31 @@ export function VariantRow({
     if (!Number.isNaN(n) && n !== variant[field]) onPatch({ [field]: n });
   };
 
-  const totalColumns = optionNames.length + 6;
+  // Variant | Price | SKU | Stock | details trigger.
+  const totalColumns = 5;
 
   return (
     <>
     <tr className="border-b border-[var(--ink-100)]">
-      {optionNames.map((name) => (
-        <td key={name} className="px-3 py-2 text-sm text-[var(--ink-900)]">
-          {findValue(variant, name)}
-        </td>
-      ))}
+      <td className="px-3 py-2">
+        {composedName ? (
+          <span className="text-sm text-[var(--ink-900)]">{composedName}</span>
+        ) : (
+          // A variant with no options has nothing to compose a name from.
+          // 8 of the-bondi-store's 12 products are in that state, so this
+          // is a normal row, not an edge case. Its position is the only
+          // honest label available — inventing "Option A" would be
+          // fabricating product data. Muted ink says the system named this
+          // row, the merchant did not, the same register the Tax summary
+          // uses for "the store default applies".
+          <span
+            className="text-sm text-[color:var(--ink-900)]/40"
+            title="No options set for this variant"
+          >
+            Variant {index + 1}
+          </span>
+        )}
+      </td>
       <td className="px-3 py-2">
         <input
           aria-label="Price"
@@ -235,84 +262,41 @@ export function VariantRow({
           />
         )}
       </td>
-      <td className="px-3 py-2">
-        <input
-          aria-label="Weight"
-          type="number"
-          step="0.01"
-          value={weight}
-          onChange={(e) => setWeight(e.target.value)}
-          onBlur={commitWeight}
-          style={tabularNum}
-          className="w-20 bg-transparent px-2 py-1 text-sm text-[var(--ink-900)] outline-none focus:ring-2 focus:ring-[var(--moss-700)]"
-        />
-      </td>
-      <td className="px-3 py-2">
-        <div className="flex items-center gap-1" style={tabularNum}>
-          <input
-            aria-label="Length (cm)"
-            type="number"
-            step="0.01"
-            placeholder="L"
-            value={lengthCm}
-            onChange={(e) => setLengthCm(e.target.value)}
-            onBlur={() => commitDim(lengthCm, "lengthCm")}
-            className="w-14 bg-transparent px-2 py-1 text-sm text-[var(--ink-900)] outline-none focus:ring-2 focus:ring-[var(--moss-700)]"
-          />
-          <span className="text-xs text-[var(--ink-500)]">×</span>
-          <input
-            aria-label="Width (cm)"
-            type="number"
-            step="0.01"
-            placeholder="W"
-            value={widthCm}
-            onChange={(e) => setWidthCm(e.target.value)}
-            onBlur={() => commitDim(widthCm, "widthCm")}
-            className="w-14 bg-transparent px-2 py-1 text-sm text-[var(--ink-900)] outline-none focus:ring-2 focus:ring-[var(--moss-700)]"
-          />
-          <span className="text-xs text-[var(--ink-500)]">×</span>
-          <input
-            aria-label="Height (cm)"
-            type="number"
-            step="0.01"
-            placeholder="H"
-            value={heightCm}
-            onChange={(e) => setHeightCm(e.target.value)}
-            onBlur={() => commitDim(heightCm, "heightCm")}
-            className="w-14 bg-transparent px-2 py-1 text-sm text-[var(--ink-900)] outline-none focus:ring-2 focus:ring-[var(--moss-700)]"
-          />
-        </div>
-      </td>
-      <td className="relative px-3 py-2">
+      <td className="w-px px-3 py-2 text-right">
+        {/* Weight, package dimensions and the image live behind this. They
+            are set once and rarely revisited, unlike price and stock, so
+            they cost four columns of horizontal scroll for nothing. Same
+            borderless ghost treatment as the stock disclosure beside it —
+            nothing draws a box around the trigger. */}
         <button
           type="button"
-          aria-label="Variant image"
-          onClick={() => setPickerOpen((o) => !o)}
-          className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-md border border-[var(--ink-100)] bg-[var(--background-elevated)] text-[var(--ink-500)] focus:outline-none focus:ring-2 focus:ring-[var(--moss-700)]"
+          ref={detailsTriggerRef}
+          aria-expanded={detailsOpen}
+          aria-controls={`variant-details-${rowKey}`}
+          aria-label={`Weight, dimensions and image for ${composedName || `variant ${index + 1}`}`}
+          onClick={() => {
+            setDetailsOpen((open) => {
+              if (open) {
+                requestAnimationFrame(() => detailsTriggerRef.current?.focus());
+              }
+              return !open;
+            });
+          }}
+          className="group inline-flex items-center gap-1.5 rounded-md px-2 py-1 hover:bg-[color:var(--ink-900)]/[0.03] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]"
         >
-          {currentMedia ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={currentMedia.url}
-              alt={currentMedia.alt ?? ""}
-              className="h-full w-full object-cover"
-            />
-          ) : (
-            <span className="text-lg">+</span>
-          )}
+          <span className="text-xs text-[color:var(--ink-900)]/40 group-hover:text-[color:var(--moss-700)]">
+            More
+          </span>
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 10 10"
+            aria-hidden="true"
+            className={`text-[color:var(--ink-900)]/40 transition-transform group-hover:text-[color:var(--moss-700)] motion-reduce:transition-none ${detailsOpen ? "rotate-180" : ""}`}
+          >
+            <path d="M2 4l3 3 3-3" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
         </button>
-        {pickerOpen ? (
-          <div className="absolute right-0 top-12 z-10">
-            <VariantImagePicker
-              media={media}
-              currentMediaId={variant.variantImageId ?? null}
-              onSelect={(id) => {
-                onPatch({ variantImageId: id });
-                setPickerOpen(false);
-              }}
-            />
-          </div>
-        ) : null}
       </td>
     </tr>
     {canSplit && splitOpen && (
@@ -336,6 +320,88 @@ export function VariantRow({
             byLocation={stockByLocation}
             autoFocus
           />
+          </div>
+        </td>
+      </tr>
+    )}
+    {detailsOpen && (
+      // Same sub-row pattern as the stock split, deliberately: one grammar
+      // for row detail, not two. Constrained width, page paper, and the
+      // hairline that ProductSection uses between sections.
+      <tr className="border-b border-[var(--ink-100)]">
+        <td colSpan={totalColumns} className="px-3 py-6">
+          <div
+            id={`variant-details-${rowKey}`}
+            className="flex max-w-xl flex-col gap-6 border-t border-[color:var(--border-subtle)] pt-6"
+          >
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="flex flex-col gap-1.5">
+                <span className="text-xs uppercase tracking-widest text-[var(--ink-500)]">
+                  Weight (kg)
+                </span>
+                <input
+                  aria-label="Weight"
+                  type="number"
+                  step="0.01"
+                  value={weight}
+                  onChange={(e) => setWeight(e.target.value)}
+                  onBlur={commitWeight}
+                  style={tabularNum}
+                  className="w-full rounded-md border border-[var(--ink-100)] bg-[var(--background-elevated)] px-2 py-1.5 text-sm text-[var(--ink-900)] outline-none focus:border-[var(--moss-700)] focus:ring-2 focus:ring-[color:var(--moss-700)]/20"
+                />
+              </label>
+
+              <div className="flex flex-col gap-1.5">
+                <span className="text-xs uppercase tracking-widest text-[var(--ink-500)]">
+                  Package (cm)
+                </span>
+                <div className="flex items-center gap-1" style={tabularNum}>
+                  <input
+                    aria-label="Length (cm)"
+                    type="number"
+                    step="0.01"
+                    placeholder="L"
+                    value={lengthCm}
+                    onChange={(e) => setLengthCm(e.target.value)}
+                    onBlur={() => commitDim(lengthCm, "lengthCm")}
+                    className="w-full min-w-0 rounded-md border border-[var(--ink-100)] bg-[var(--background-elevated)] px-2 py-1.5 text-sm text-[var(--ink-900)] outline-none focus:border-[var(--moss-700)] focus:ring-2 focus:ring-[color:var(--moss-700)]/20"
+                  />
+                  <span className="text-xs text-[var(--ink-500)]">×</span>
+                  <input
+                    aria-label="Width (cm)"
+                    type="number"
+                    step="0.01"
+                    placeholder="W"
+                    value={widthCm}
+                    onChange={(e) => setWidthCm(e.target.value)}
+                    onBlur={() => commitDim(widthCm, "widthCm")}
+                    className="w-full min-w-0 rounded-md border border-[var(--ink-100)] bg-[var(--background-elevated)] px-2 py-1.5 text-sm text-[var(--ink-900)] outline-none focus:border-[var(--moss-700)] focus:ring-2 focus:ring-[color:var(--moss-700)]/20"
+                  />
+                  <span className="text-xs text-[var(--ink-500)]">×</span>
+                  <input
+                    aria-label="Height (cm)"
+                    type="number"
+                    step="0.01"
+                    placeholder="H"
+                    value={heightCm}
+                    onChange={(e) => setHeightCm(e.target.value)}
+                    onBlur={() => commitDim(heightCm, "heightCm")}
+                    className="w-full min-w-0 rounded-md border border-[var(--ink-100)] bg-[var(--background-elevated)] px-2 py-1.5 text-sm text-[var(--ink-900)] outline-none focus:border-[var(--moss-700)] focus:ring-2 focus:ring-[color:var(--moss-700)]/20"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-xs uppercase tracking-widest text-[var(--ink-500)]">
+                Variant image
+              </span>
+              <VariantImagePicker
+                media={media}
+                currentMediaId={variant.variantImageId ?? null}
+                onSelect={(id) => onPatch({ variantImageId: id })}
+              />
+            </div>
           </div>
         </td>
       </tr>


### PR DESCRIPTION
Design direction from the `ux-design-specialist` pass on the product page. This is change 1 of 3 from that review; the rail and the create form are not in this PR.

## Before

Eight columns — `Size | Colour | Price | SKU | Stock | Weight | L×W×H | Image` — inside `overflow-x-auto`. Any product with two options scrolled horizontally at a realistic admin width, so Price and Stock (the two things merchants actually scan for) competed for space with fields that are set once and rarely revisited.

## After

Four data columns plus a disclosure:

```
Variant | Price (A$) | SKU | Stock | More ⌄
```

- **One Variant cell.** Every option value composes into a single cell joined by the interpunct — `Bath · Sand`. That separator is already this codebase's idiom for joined metadata (the product header joins handle and storefront link the same way), so it is not a second convention for the same job. Values are emitted in the header's column order.
- **Weight, package dimensions and image move behind a per-row `More` disclosure.** Same borderless ghost-button treatment as the stock-split trigger beside it — nothing draws a box around the trigger — and the same full-width sub-row pattern for the panel, so there is one grammar for row detail rather than two. The panel uses the `border-t border-border-subtle pt-6` hairline that `ProductSection` uses between sections.

## Variants with no options

8 of the-bondi-store's 12 products have variants but no `product_options` rows. Those rows have nothing to compose a name from and previously rendered with **no identity column at all** — `optionNames` derives from `variants[0].optionValues`, which is empty.

They now fall back to their position, in muted ink:

```
Variant 1     189.00    ROBE-S    6    More ⌄
```

Muted rather than full ink is the whole point: it reads as *the system named this row, you didn't* — the same register the Tax summary uses for "the store default applies". Deliberately **not** an em dash (doesn't distinguish row 2 from row 3) and **not** a synthesised "Option A" (that would be fabricating product data).

## Two things that fall out of this

- `VariantImagePicker` loses its card. It was wrapped in `rounded-md border … bg-elevated … shadow-1`, which it needed as a floating popover to separate itself from the row underneath. Inside the details panel there is already a hairline above it, so the wrapper was a bordered card in a system whose rule is hairline rules, not cards.
- `VariantMatrixTable` loses its `md:overflow-visible` exception. That existed *only* so the picker's absolutely-positioned popover could spill out of the row without the wrapper coercing `overflow-y: auto`. The picker no longer escapes the row, so the plain `overflow-x-auto` is correct again.

## Tests

`apps/admin`: **110 files, 869 tests, 0 failures** (863 on `main`; +6 here).

Updated the five tests that asserted the old column layout, and added coverage for the new behaviour:
- composes option values into one cell
- the header is exactly `Variant | Price | SKU | Stock | Details`
- weight and dimensions are absent from the row until expanded, and collapse again
- an option-less variant renders `Variant 3` at index 2
- an option-less variant renders neither a fabricated option name nor an em dash

## Related

- #542 fixes the key collision that made those same option-less rows write edits into each other. Different files, no conflict; either can merge first.
- The `Variant N` fallback is only reachable at all because #540 (now live on `main-0e37834`) stopped the derivation effect emptying those variants on mount.