### PR TITLE
SEO & growth: fix two live 404 bugs, index /help + /integrations, publish guides and Journal capture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/handlers/webhooks/... \
 	    ./internal/idempotency/... \
 	    ./internal/inbox/... \
+	    ./internal/journal/... \
 	    ./internal/notification/... \
 	    ./internal/order/... \
 	    ./internal/orderrefund/... \

--- a/apps/admin/app/pricing/layout.tsx
+++ b/apps/admin/app/pricing/layout.tsx
@@ -8,6 +8,8 @@
 import type { ReactNode } from 'react'
 import Link from 'next/link'
 
+import { MailLink } from '@repo/ui/mail-link'
+
 interface PricingLayoutProps {
   children: ReactNode
 }
@@ -48,12 +50,12 @@ export default function PricingLayout({ children }: PricingLayoutProps) {
         style={{ color: 'var(--ink-600)' }}
       >
         <nav aria-label="Footer" className="flex gap-6 text-sm">
-          <a
-            href="mailto:hello@mark8ly.com"
+          <MailLink
+            email="hello@mark8ly.com"
             className="hover:text-[var(--moss-700)] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--moss-700)] rounded-sm"
           >
             Contact
-          </a>
+          </MailLink>
           <Link
             href="/privacy"
             className="hover:text-[var(--moss-700)] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--moss-700)] rounded-sm"

--- a/apps/onboarding/.env.example
+++ b/apps/onboarding/.env.example
@@ -5,6 +5,11 @@ PORT=4201
 # These never reach the browser.
 PLATFORM_API_URL=http://localhost:8086
 AUTH_BFF_URL=http://localhost:8087
+# marketplace-api base URL — used by the /api/journal-subscribe route only
+# (issue #153, the Journal "coming soon" page). Not PLATFORM_API_URL: that
+# points at platform-api, a different service. Matches the env var name
+# and default port apps/admin/lib/api/marketplace-api.ts already uses.
+MARKETPLACE_API_URL=http://localhost:8088
 
 # Browser-exposed (NEXT_PUBLIC_*).
 # All three are public by design — they identify the GIP project but

--- a/apps/onboarding/app/acceptable-use/page.tsx
+++ b/apps/onboarding/app/acceptable-use/page.tsx
@@ -1,3 +1,4 @@
+import { MailLink } from "@repo/ui/mail-link";
 import {
   MarketingPage,
   PageHero,
@@ -72,7 +73,7 @@ export default function AcceptableUsePage() {
         <p>
           If your account is suspended or terminated and you believe we got
           it wrong, email{" "}
-          <a href="mailto:legal@mark8ly.com">legal@mark8ly.com</a> within 30
+          <MailLink email="legal@mark8ly.com" /> within 30
           days. Include your store name, the action we took, and why you think
           it was incorrect. We respond within 10 business days.
         </p>
@@ -81,7 +82,7 @@ export default function AcceptableUsePage() {
         <p>
           If you see a Mark8ly-hosted store that looks like it violates this
           policy — counterfeit goods, phishing, IP infringement, fraud — email{" "}
-          <a href="mailto:abuse@mark8ly.com">abuse@mark8ly.com</a>. Include
+          <MailLink email="abuse@mark8ly.com" />. Include
           the store URL and a description of the issue.
         </p>
 

--- a/apps/onboarding/app/api/journal-subscribe/route.ts
+++ b/apps/onboarding/app/api/journal-subscribe/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+
+import { config } from "@/lib/config";
+
+// Server-side proxy for the Journal "coming soon" page's email capture
+// (#153). The browser never calls marketplace-api directly — it only ever
+// sees this route, which forwards to marketplace-api's public, tenant-free
+// /api/v1/journal/subscribe endpoint using the server-only
+// MARKETPLACE_API_URL (see lib/config.ts for why not PLATFORM_API_URL).
+export const dynamic = "force-dynamic";
+
+interface JournalSubscribeResponse {
+  ok: boolean;
+  message?: string;
+}
+
+function jsonResponse(body: JournalSubscribeResponse, status: number): NextResponse {
+  return NextResponse.json(body, { status });
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  let email: unknown;
+  try {
+    const parsed = (await request.json()) as { email?: unknown };
+    email = parsed.email;
+  } catch {
+    return jsonResponse(
+      { ok: false, message: "Enter a valid email address." },
+      400,
+    );
+  }
+
+  if (typeof email !== "string" || email.trim() === "") {
+    return jsonResponse(
+      { ok: false, message: "Enter a valid email address." },
+      400,
+    );
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${config.marketplaceApiUrl}/api/v1/journal/subscribe`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+      cache: "no-store",
+    });
+  } catch (error: unknown) {
+    // marketplace-api unreachable (network error, DNS, connection refused).
+    // The visitor gets a plain, human message — never a stack trace, and
+    // never a silent no-op that looks like success.
+    console.error("journal-subscribe: marketplace-api unreachable", error);
+    return jsonResponse(
+      {
+        ok: false,
+        message:
+          "We couldn't save that just now — please try again in a moment.",
+      },
+      502,
+    );
+  }
+
+  if (upstream.status === 429) {
+    return jsonResponse(
+      { ok: false, message: "Too many attempts. Please try again shortly." },
+      429,
+    );
+  }
+
+  if (!upstream.ok) {
+    // Anything else (400 validation_failed, or a 5xx marketplace-api
+    // itself couldn't recover from) reads the same to a visitor: the
+    // address they typed didn't go through. marketplace-api's own logs
+    // carry the real detail server-side.
+    return jsonResponse(
+      { ok: false, message: "That doesn't look like a valid email address." },
+      upstream.status >= 500 ? 502 : 400,
+    );
+  }
+
+  return jsonResponse({ ok: true }, 200);
+}

--- a/apps/onboarding/app/blog/page.tsx
+++ b/apps/onboarding/app/blog/page.tsx
@@ -1,4 +1,5 @@
 import { MarketingStub } from "@/components/marketing/primitives";
+import { JournalSignupForm } from "@/components/marketing/JournalSignupForm";
 
 export const metadata = {
   title: "Journal",
@@ -10,9 +11,11 @@ export default function BlogPage() {
     <MarketingStub
       eyebrow="Journal"
       title={<>Writing, coming soon.</>}
-      body="We&rsquo;re preparing a small, quiet journal about what we&rsquo;re building and the merchants we&rsquo;re building it for. No content for content&rsquo;s sake — only things worth your time. Check back, or email us to be notified when the first piece goes up."
+      body="We&rsquo;re preparing a small, quiet journal about what we&rsquo;re building and the merchants we&rsquo;re building it for. No content for content&rsquo;s sake — only things worth your time. Check back, or leave your email below to hear when the first piece goes up."
       primaryCta={{ href: "/onboarding", label: "Open your store" }}
       secondaryCta={{ href: "/contact", label: "Get in touch" }}
-    />
+    >
+      <JournalSignupForm />
+    </MarketingStub>
   );
 }

--- a/apps/onboarding/app/contact/page.tsx
+++ b/apps/onboarding/app/contact/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { MailLink } from "@repo/ui/mail-link";
 import { MarketingPage, PageHero } from "@/components/marketing/primitives";
 
 export const metadata = {
@@ -42,12 +43,10 @@ export default function ContactPage() {
                   {channel.description}
                 </dd>
                 <dd className="mt-4">
-                  <a
-                    href={`mailto:${channel.email}`}
+                  <MailLink
+                    email={channel.email}
                     className="text-foreground underline decoration-moss-700 decoration-2 underline-offset-4 hover:text-moss-700"
-                  >
-                    {channel.email}
-                  </a>
+                  />
                 </dd>
               </div>
             ))}
@@ -68,12 +67,10 @@ export default function ContactPage() {
             </p>
             <p>
               If you&rsquo;re local and want to meet, email{" "}
-              <a
-                href="mailto:hello@mark8ly.com"
+              <MailLink
+                email="hello@mark8ly.com"
                 className="text-foreground underline decoration-moss-700 decoration-2 underline-offset-4 hover:text-moss-700"
-              >
-                hello@mark8ly.com
-              </a>
+              />
               .
             </p>
           </div>

--- a/apps/onboarding/app/cookies/page.tsx
+++ b/apps/onboarding/app/cookies/page.tsx
@@ -1,3 +1,4 @@
+import { MailLink } from "@repo/ui/mail-link";
 import {
   MarketingPage,
   PageHero,
@@ -111,7 +112,7 @@ export default function CookiePolicyPage() {
         <h2>6. Contact</h2>
         <p>
           Questions about cookies: email{" "}
-          <a href="mailto:privacy@mark8ly.com">privacy@mark8ly.com</a>.
+          <MailLink email="privacy@mark8ly.com" />.
         </p>
 
         <h2>7. About Tesserix</h2>

--- a/apps/onboarding/app/delete-account/page.tsx
+++ b/apps/onboarding/app/delete-account/page.tsx
@@ -1,3 +1,4 @@
+import { MailLink } from "@repo/ui/mail-link";
 import { MarketingPage, PageHero, Prose } from "@/components/marketing/primitives";
 
 export const metadata = {
@@ -100,7 +101,7 @@ export default function DeleteAccountPage() {
         <p>
           If you&rsquo;ve lost access to your account and can&rsquo;t use either
           self-service option above, email{" "}
-          <a href="mailto:privacy@mark8ly.com">privacy@mark8ly.com</a> from the
+          <MailLink email="privacy@mark8ly.com" /> from the
           address on your account and ask us to delete it. We&rsquo;ll verify
           you own the account and complete the deletion for you.
         </p>

--- a/apps/onboarding/app/dpa/page.tsx
+++ b/apps/onboarding/app/dpa/page.tsx
@@ -1,3 +1,4 @@
+import { MailLink } from "@repo/ui/mail-link";
 import {
   MarketingPage,
   PageHero,
@@ -120,7 +121,7 @@ export default function DpaPage() {
           engaging a new sub-processor or materially changing how an
           existing one is used. The Controller may object within those
           fourteen days by emailing{" "}
-          <a href="mailto:privacy@mark8ly.com">privacy@mark8ly.com</a>; if
+          <MailLink email="privacy@mark8ly.com" />; if
           the parties cannot agree on an alternative, the Controller may
           terminate the affected part of the service without penalty.
         </p>
@@ -133,7 +134,7 @@ export default function DpaPage() {
           measures, taking into account the nature of the Processing. Most
           requests are servable by the Controller through the admin
           dashboard; for those that are not, email{" "}
-          <a href="mailto:privacy@mark8ly.com">privacy@mark8ly.com</a>.
+          <MailLink email="privacy@mark8ly.com" />.
         </p>
 
         <h2>7. Breach notification</h2>
@@ -204,7 +205,7 @@ export default function DpaPage() {
         <h2>13. Annex III — SCCs completion details</h2>
         <ul>
           <li><strong>Data exporter:</strong> the Controller (merchant account holder) as identified in the Mark8ly account record.</li>
-          <li><strong>Data importer:</strong> Tesserix Pty Ltd (ACN 694 070 865), New South Wales, Australia. Contact: <a href="mailto:dpo@mark8ly.com">dpo@mark8ly.com</a>.</li>
+          <li><strong>Data importer:</strong> Tesserix Pty Ltd (ACN 694 070 865), New South Wales, Australia. Contact: <MailLink email="dpo@mark8ly.com" />.</li>
           <li><strong>Module:</strong> Module Two — Transfer Controller to Processor.</li>
           <li><strong>Clause 7 (Docking):</strong> optional, not used.</li>
           <li><strong>Clause 9 (Sub-processors):</strong> General written authorisation, 14 days&rsquo; notice — see section 5.</li>
@@ -235,15 +236,15 @@ export default function DpaPage() {
         <ul>
           <li>
             <strong>Data Protection Officer:</strong>{" "}
-            <a href="mailto:dpo@mark8ly.com">dpo@mark8ly.com</a>
+            <MailLink email="dpo@mark8ly.com" />
           </li>
           <li>
             <strong>Privacy:</strong>{" "}
-            <a href="mailto:privacy@mark8ly.com">privacy@mark8ly.com</a>
+            <MailLink email="privacy@mark8ly.com" />
           </li>
           <li>
             <strong>Legal:</strong>{" "}
-            <a href="mailto:legal@mark8ly.com">legal@mark8ly.com</a>
+            <MailLink email="legal@mark8ly.com" />
           </li>
         </ul>
       </Prose>

--- a/apps/onboarding/app/guides/guides.ts
+++ b/apps/onboarding/app/guides/guides.ts
@@ -203,6 +203,125 @@ export const GUIDES: ReadonlyArray<Guide> = [
       },
     ],
   },
+  {
+    slug: "how-to-add-your-first-product",
+    title: "How to Add Your First Product to Your Online Store",
+    description:
+      "A walkthrough of adding your first product in the Mark8ly admin — the fields that matter, when variants are worth the extra step, and what draft vs active actually controls.",
+    eyebrow: "Guide",
+    heading: "How to add your first product",
+    lede: "The product form has more fields than any one product needs. Here's the order to fill them in, what's actually required, and what you can safely leave for later.",
+    updated: "2026-09-02",
+    readingMinutes: 6,
+    blocks: [
+      {
+        type: "p",
+        text: "A product listing only needs three things to save: a title, a price, and a stock count. Everything else on the form exists to handle products that are more complicated than yours might be. Here's what to fill in, in the order the form asks for it, and which parts you can ignore on day one.",
+      },
+      { type: "h2", text: "1. Open a new product" },
+      {
+        type: "p",
+        text: "From Products in the admin sidebar, click New product. That opens a blank form at a URL like /products/new — nothing is saved yet, so there's no harm in clicking around before you commit to anything.",
+      },
+      { type: "h2", text: "2. Details: title, handle, description" },
+      {
+        type: "p",
+        text: "Title is the only field on the whole form that's required by name. Handle — the part of the URL after /products/ — is optional and gets generated from the title automatically if you leave it blank, so don't overthink it unless you need a specific slug. Description sits below and shows up on the product page under the title; it's optional too, but an empty one looks unfinished to a shopper, so it's worth a paragraph even at this stage.",
+      },
+      { type: "h2", text: "3. Pricing and inventory" },
+      {
+        type: "p",
+        text: "For a plain product with no variants, this section is three fields: price, stock, and SKU. Price needs a number like 19.99 — the form will reject anything else. Stock defaults to 0, and there's an \"Always in stock\" checkbox for products you don't want to run out on the storefront (digital goods, made-to-order pieces); stock still counts down on each order, it just never blocks a sale. SKU is optional — leave it blank and one gets generated from the handle.",
+      },
+      {
+        type: "p",
+        text: "If your store has more than one warehouse, per-warehouse stock only appears once the product exists — you'll set the overall stock number here first, then split it by location after saving.",
+      },
+      { type: "h2", text: "4. Options — only if this product comes in more than one version" },
+      {
+        type: "p",
+        text: "Skip this section entirely if you're selling one version of one thing. If you're not — a T-shirt in three sizes, a candle in four scents — add an option (Size, Colour, whatever applies) and list its values. The moment you do, the Pricing and inventory section above turns into a variant table: one row per combination, each with its own price, stock, and SKU. Add a second option and the table fills in every combination automatically. There's no obligation to price every variant the same — that's the whole point of breaking it out.",
+      },
+      { type: "h2", text: "5. Shipping" },
+      {
+        type: "p",
+        text: "Weight and dimensions here are what carrier rates get calculated from at checkout. If you skip this, the storefront falls back to a default envelope for the rate quote — fine for a quick test, worth fixing before you take real orders, because a wrong quote either loses you money on every sale or overcharges a customer who then doesn't come back.",
+      },
+      { type: "h2", text: "6. Categories and tax" },
+      {
+        type: "p",
+        text: "Categories live in the right-hand rail and control where the product shows up when someone browses your storefront rather than searching it directly — worth setting even with only a handful of products, since \"browse everything\" stops being a real navigation option past about a dozen items. Tax fields below the main form adapt to your store's country; if you're not sure what applies, leave the default and revisit it with an accountant rather than guessing.",
+      },
+      { type: "h2", text: "7. Draft vs active — and photos" },
+      {
+        type: "p",
+        text: "Every new product starts as a draft, set in the Status field in the same right-hand rail. A draft is saved but not visible on your storefront — switch it to Active when you're ready for customers to see it. One thing to know before you save: photos aren't on the create form at all. A product needs to exist first before you can attach media to it, so the Media section only appears once you've saved the product for the first time and are editing it. Save with the basics, then come straight back in to add photos before switching it to Active — a product page without a photo is not one you want live.",
+      },
+      {
+        type: "p",
+        text: "That's the whole flow: title, price, stock, save. Everything else — variants, shipping weights, categories — is there for when a product needs it, not before. Once your first product is live, adding the next one is the same three fields again.",
+      },
+    ],
+  },
+  {
+    slug: "how-to-connect-your-domain",
+    title: "How to Connect Your Domain to Your Storefront",
+    description:
+      "A step-by-step guide to pointing your own domain at your Mark8ly storefront — the DNS records to add, how ownership and SSL get verified, and how long it actually takes.",
+    eyebrow: "Guide",
+    heading: "How to connect your domain",
+    lede: "A store on your own domain looks like a business. A store on someone else's subdomain looks like a trial. Here's exactly what to add at your DNS provider, and what each record is actually for.",
+    updated: "2026-09-02",
+    readingMinutes: 6,
+    blocks: [
+      {
+        type: "p",
+        text: "Connecting a domain is a DNS change, not a code change — you're telling the internet that your domain now points at your storefront. It takes a few minutes to set up and, depending on your DNS provider, anywhere from a few minutes to a couple of days to take effect. Here's the whole process, record by record.",
+      },
+      { type: "h2", text: "1. Start from Settings → Domains" },
+      {
+        type: "p",
+        text: "In the admin, go to Settings, then Domains, and use Add a custom domain. You'll be asked for the domain itself and which of two setup methods to use: manual, where you add DNS records yourself, or Cloudflare, where an API token lets the platform create them for you automatically. Manual works with any registrar and is what most people use; Cloudflare is faster if that's already where your domain's DNS is hosted.",
+      },
+      { type: "h2", text: "2. Prove you own the domain" },
+      {
+        type: "p",
+        text: "The first record is a TXT record, with a name and value generated specifically for your domain and shown on screen after you add it. Only someone with access to your DNS settings can publish a TXT record, which is exactly why it's used as proof of ownership before anything else happens. You can remove it once verification succeeds — it's not needed after that.",
+      },
+      { type: "h2", text: "3. Route traffic to your storefront" },
+      {
+        type: "p",
+        text: "This is the record that actually makes the domain work, and there are two ways to do it — pick the one your DNS provider supports for your situation. The Domains screen shows the exact value for each, with a copy button; copy from there rather than retyping from anywhere else, including this page — these values are the kind of thing that can change, and the screen is always current:",
+      },
+      {
+        type: "ul",
+        items: [
+          "Option A — an A record at your domain, pointing to the IP address shown on the Domains screen. Use this for an apex domain (example.com rather than shop.example.com) — most DNS providers don't allow a CNAME at the apex.",
+          "Option B — a CNAME record at your domain, pointing to edge.mark8ly.com. Cleaner if you're using a subdomain and your provider supports it.",
+        ],
+      },
+      { type: "h2", text: "4. Let SSL provision itself" },
+      {
+        type: "p",
+        text: "A third record — a CNAME from _acme-challenge.yourdomain.com to _acme-challenge.yourdomain.com.acme.mark8ly.com — delegates certificate issuance back to Mark8ly. It's how you get a free, auto-renewing SSL certificate without ever handing over your DNS credentials. Add it once alongside the routing record; you won't need to touch it again after that.",
+      },
+      { type: "h2", text: "5. Optional: a branded admin subdomain" },
+      {
+        type: "p",
+        text: "If you'd also like admin.yourdomain.com to work as a branded URL for your admin dashboard, add one more A record — admin.yourdomain.com pointing to the same IP address as the storefront record — and it's active alongside the rest. Skip this if the default admin URL is fine; it changes nothing about the storefront.",
+      },
+      { type: "h2", text: "6. Verify, and be patient with DNS" },
+      {
+        type: "p",
+        text: "Once the records are added, click Verify. DNS changes can take up to 48 hours to propagate fully, though most providers are faster — a tool like dnschecker.org will tell you whether your records have gone live before you try verifying again. If verification fails, the error tells you what it found: a missing CNAME, an unproven TXT record, or a routing record pointing somewhere other than what's expected. Fix the specific thing it names and verify again — there's no need to redo records that already checked out.",
+      },
+      { type: "h2", text: "7. What \"active\" looks like" },
+      {
+        type: "p",
+        text: "Once DNS verification succeeds, the domain's status moves to active and SSL certificate provisioning starts automatically — that can take a few minutes on its own, and a refresh action on the domain's card shows you when the certificate is live. From that point, your storefront answers on your own domain with a valid certificate, and you're done. No further DNS maintenance is needed unless you change registrars or move the domain elsewhere.",
+      },
+    ],
+  },
 ];
 
 export function getGuide(slug: string): Guide | undefined {

--- a/apps/onboarding/app/help/page.tsx
+++ b/apps/onboarding/app/help/page.tsx
@@ -1,18 +1,252 @@
-import { MarketingStub } from "@/components/marketing/primitives";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { FaqAccordion, type FaqItem } from "@repo/ui/faq-accordion";
 
-export const metadata = {
-  title: "Help",
-  robots: { index: false, follow: true },
+import { MarketingPage, PageHero } from "@/components/marketing/primitives";
+
+/* ============================================================
+   Help — grouped FAQ covering the questions a merchant evaluating
+   or newly onboarded onto Mark8ly actually asks. Every answer is
+   grounded in what the product does today (see the category
+   comments below for the source); nothing here promises a
+   feature that hasn't shipped.
+
+   Rendered as the same asymmetric eyebrow-plus-content sections
+   used on /about, with a FaqAccordion per category so the page
+   reads as one continuous, scannable list rather than a wall of
+   text. FAQPage JSON-LD is emitted from the flattened category
+   list, following the pattern already used by SeoLanding for the
+   comparison landing pages (see components/marketing/SeoLanding.tsx).
+   ============================================================ */
+
+export const metadata: Metadata = {
+  title: "Help & FAQ",
+  description:
+    "Answers to the questions merchants actually ask about Mark8ly: the 90-day trial, pricing and fees, custom domains, payments, shipping, inventory, and taking your data with you.",
+  alternates: { canonical: "/help" },
+  openGraph: {
+    title: "Help & FAQ · Mark8ly",
+    description:
+      "Getting started, the trial, pricing, payments, shipping, and data ownership — answered plainly, no ticket queue required.",
+    url: "/help",
+  },
+};
+
+interface FaqCategory {
+  eyebrow: string;
+  heading: string;
+  items: ReadonlyArray<FaqItem>;
+}
+
+// Source for each category, so future edits stay grounded rather than
+// drifting into marketing copy. A file existing under internal/ is NOT
+// enough on its own — check what's actually reachable by a merchant
+// today (supported-country arrays, plangate feature gates, whether a
+// component is ever rendered) before repeating a claim from here:
+//  - Trial/pricing: components/marketing/Pricing.tsx, app/page.tsx FAQ
+//  - Payments: services/marketplace-api/internal/payment (stripe.go,
+//    razorpay.go) and migrations/000121_retire_untested_paypal.up.sql,
+//    which removed 'paypal' from every country's payment_providers array
+//    and deactivated existing configs — PayPal is NOT offered today even
+//    though paypal.go still exists.
+//  - Shipping: services/marketplace-api/internal/shipping (delhivery.go,
+//    ninjavan.go, shipengine.go), gated per-country by
+//    supported_countries.shipping_carriers (migrations/000090).
+//  - Inventory/warehouses: PR #538 (per-warehouse stock for
+//    multi-variant products); migrations/000122 and 000123 confirm every
+//    store has a real warehouse to hold that stock.
+//  - Otto (services/otto) is NOT included here: its storefront wrapper,
+//    apps/storefront/components/OttoSupportChat.tsx, is never imported
+//    by any page, and its tenantId is hardcoded to "mark8ly" rather than
+//    the merchant's own store — so it isn't something a merchant gets
+//    today.
+const CATEGORIES: ReadonlyArray<FaqCategory> = [
+  {
+    eyebrow: "Getting started",
+    heading: "Opening a store",
+    items: [
+      {
+        question: "I'm not technical. Can I actually do this myself?",
+        answer:
+          "Yes — that's the point of Mark8ly. If you can write an email, you can set up a store: add products, connect a payment processor, and pick a domain, all from the admin. Most merchants have a working store open by the end of the afternoon.",
+      },
+      {
+        question: "Do I need a credit card to start?",
+        answer:
+          "No. The 90-day trial starts with just an email and doesn't ask for a card. You'll only be asked to choose a plan once the trial is ending, or earlier if you decide to upgrade.",
+      },
+    ],
+  },
+  {
+    eyebrow: "Trial & billing",
+    heading: "The 90 days, and after",
+    items: [
+      {
+        question: "What's included in the free trial?",
+        answer:
+          "The full product — unlimited products and orders, your own domain, payments, shipping, and the admin, exactly as a paying merchant sees it. Nothing is watermarked or feature-limited during the 90 days.",
+      },
+      {
+        question: "What happens when the trial ends?",
+        answer:
+          "You choose one of three plans — Starter, Studio, or Pro — starting at $15 a month billed yearly, or $19 a month billed monthly. There's no auto-upgrade and no surprise charge: if you haven't picked a plan, your store simply won't take new orders until you do.",
+      },
+      {
+        question: "Can I cancel or change plans later?",
+        answer:
+          "Any time. Upgrades take effect immediately and prorate; downgrades take effect at the end of the current billing period. Cancelling doesn't lock your data — see data ownership below.",
+      },
+    ],
+  },
+  {
+    eyebrow: "Pricing & fees",
+    heading: "What Mark8ly actually charges",
+    items: [
+      {
+        question: "Does Mark8ly take a cut of my sales?",
+        answer:
+          "No. We don't add a platform transaction fee on any plan. You pay only your payment processor's standard rate — roughly 2% for UPI and 2–3% for cards — and that's the entire cost of taking a payment.",
+      },
+      {
+        question: "What's the difference between Starter, Studio, and Pro?",
+        answer:
+          "All three include unlimited products and orders. Starter covers up to 2 stores. Studio adds up to 5 stores, custom CSS and fonts, a read-only API, and a 12-month audit log. Pro adds up to 10 stores, a full read/write API, SSO, and priority support.",
+      },
+    ],
+  },
+  {
+    eyebrow: "Domains",
+    heading: "Your own address",
+    items: [
+      {
+        question: "Can I use my own domain?",
+        answer:
+          "Yes, on every plan — it's included, not an add-on. Connect a domain you already own from Settings → Domains, or buy one during onboarding. Customers land on your brand, never a Mark8ly subdomain.",
+      },
+    ],
+  },
+  {
+    eyebrow: "Payments",
+    heading: "Getting paid, including UPI",
+    items: [
+      {
+        question: "Which payment processors do you support?",
+        answer:
+          "Stripe for cards internationally, and Razorpay for merchants selling in India — which covers UPI, wallets, and local cards, not just international cards. You connect one from Settings → Payments; customers never leave your storefront to pay.",
+      },
+      {
+        question: "Can I accept UPI payments if I'm selling in India?",
+        answer:
+          "Yes. Razorpay is a first-class processor in Mark8ly, so UPI, popular wallets, and net banking are available alongside cards for Indian customers, at Razorpay's standard rates — Mark8ly adds nothing on top.",
+      },
+    ],
+  },
+  {
+    eyebrow: "Products & inventory",
+    heading: "Catalogue and stock",
+    items: [
+      {
+        question: "Is there a limit on how many products I can list?",
+        answer:
+          "No. Every plan includes unlimited products, variants, and orders. What differs between plans is how many separate storefronts you can run, not how big any one of them can grow.",
+      },
+      {
+        question: "Can I track stock across more than one warehouse?",
+        answer:
+          "Yes. Stock is tracked per warehouse, including for products with multiple variants — so a product with several sizes or colours can show accurate, location-specific availability rather than one blended number.",
+      },
+    ],
+  },
+  {
+    eyebrow: "Shipping",
+    heading: "Getting orders to customers",
+    items: [
+      {
+        question: "What shipping carriers can I use?",
+        answer:
+          "Delhivery for domestic shipping within India, NinjaVan for Southeast Asia, and ShipEngine for broader coverage — which connects carriers like USPS, UPS, FedEx, and DHL through a single integration. Live rates are calculated at checkout based on the carriers you've connected.",
+      },
+    ],
+  },
+  {
+    eyebrow: "Data ownership",
+    heading: "Nothing is locked in",
+    items: [
+      {
+        question: "What happens to my data if I decide to leave?",
+        answer:
+          "It's yours. Export your products, customers, and orders in one click, at any time, whether or not you're cancelling. We'd rather earn a renewal than make leaving painful.",
+      },
+    ],
+  },
+];
+
+const faqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: CATEGORIES.flatMap((category) =>
+    category.items.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: { "@type": "Answer", text: item.answer },
+    })),
+  ),
 };
 
 export default function HelpPage() {
   return (
-    <MarketingStub
-      eyebrow="Help"
-      title={<>Answers are on the way.</>}
-      body="Our full help centre is being written alongside the product. In the meantime, the best way to get help is to email us directly — a real person reads every message."
-      primaryCta={{ href: "/onboarding", label: "Open your store" }}
-      secondaryCta={{ href: "/contact", label: "Email us" }}
-    />
+    <MarketingPage>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+
+      <PageHero
+        eyebrow="Help"
+        title={<>Answers, plainly.</>}
+        lede="The questions merchants actually ask, grouped by topic. If yours isn't here, a real person reads every message we get."
+      />
+
+      {CATEGORIES.map((category) => (
+        <section
+          key={category.heading}
+          className="border-t border-border-subtle py-16 sm:py-20"
+        >
+          <div className="mx-auto grid max-w-6xl gap-8 px-6 lg:grid-cols-[1fr_2fr] lg:gap-16">
+            <div className="lg:sticky lg:top-32 lg:self-start">
+              <p className="eyebrow mb-5">{category.eyebrow}</p>
+              <h2 className="font-serif text-2xl font-medium leading-[1.1] tracking-[-0.015em] text-foreground">
+                {category.heading}
+              </h2>
+            </div>
+            <FaqAccordion
+              items={[...category.items]}
+              className="border-t border-border-subtle"
+            />
+          </div>
+        </section>
+      ))}
+
+      <section className="border-t border-border-subtle py-20 sm:py-24">
+        <div className="mx-auto max-w-6xl px-6">
+          <p className="max-w-xl text-lg leading-[1.55] text-foreground-secondary">
+            Still stuck, or asking something we haven&rsquo;t covered? Email
+            us — we&rsquo;re a small team and we read every message
+            ourselves.
+          </p>
+          <div className="mt-10 flex flex-wrap items-center gap-x-8 gap-y-4">
+            <Link
+              href="/onboarding"
+              className="inline-flex h-12 items-center rounded-md bg-primary px-6 text-base font-medium text-primary-foreground hover:bg-primary-hover"
+            >
+              Open your store
+            </Link>
+            <Link href="/contact" className="btn-ghost">
+              Contact us
+            </Link>
+          </div>
+        </div>
+      </section>
+    </MarketingPage>
   );
 }

--- a/apps/onboarding/app/integrations/page.tsx
+++ b/apps/onboarding/app/integrations/page.tsx
@@ -1,18 +1,240 @@
-import { MarketingStub } from "@/components/marketing/primitives";
+import type { Metadata } from "next";
+import Link from "next/link";
 
-export const metadata = {
+import { MarketingPage, PageHero } from "@/components/marketing/primitives";
+
+/* ============================================================
+   Integrations — an honest list of what Mark8ly connects to
+   today, grouped by function. Every entry below is confirmed
+   reachable by a merchant right now — not just present as code —
+   see the comment above each group for exactly how that was
+   checked. Nothing here is aspirational — if something is
+   genuinely on the roadmap it belongs in a labelled "in progress"
+   group, not folded in as if it already works.
+
+   PayPal is deliberately absent even though
+   internal/payment/paypal.go exists: migrations/
+   000121_retire_untested_paypal.up.sql removed 'paypal' from
+   every country's supported_countries.payment_providers and
+   deactivated any existing configs, specifically because the
+   gateway had never been run against a real PayPal account. Its
+   code being present is not evidence it's offered — don't infer
+   availability from an internal/ file existing without checking
+   what's actually enabled for merchants (supported-country
+   arrays, plangate feature gates, whether a component is ever
+   rendered).
+   ============================================================ */
+
+export const metadata: Metadata = {
   title: "Integrations",
-  robots: { index: false, follow: true },
+  description:
+    "What Mark8ly actually connects to: Stripe and Razorpay for payments, Delhivery, NinjaVan, and ShipEngine for shipping, TaxJar for tax, and SendGrid or Resend for email.",
+  alternates: { canonical: "/integrations" },
+  openGraph: {
+    title: "Integrations · Mark8ly",
+    description:
+      "A small, considered set of integrations — payments, shipping, tax, and email — each one honestly described, nothing implied that isn't live.",
+    url: "/integrations",
+  },
 };
+
+interface Integration {
+  name: string;
+  description: string;
+}
+
+interface IntegrationGroup {
+  eyebrow: string;
+  heading: string;
+  intro: string;
+  items: ReadonlyArray<Integration>;
+}
+
+// services/marketplace-api/internal/payment (stripe.go, razorpay.go) —
+// cross-checked against supported_countries.payment_providers as seeded
+// by migrations/000090 and left standing after 000100 and 000121. PayPal
+// (paypal.go) is intentionally excluded: see the file-level comment above.
+const PAYMENTS: IntegrationGroup = {
+  eyebrow: "Payments",
+  heading: "Getting paid",
+  intro:
+    "Connect one processor per store from Settings → Payments. Mark8ly never touches the money or adds a fee on top — you pay only the processor's own rate.",
+  items: [
+    {
+      name: "Stripe",
+      description:
+        "Cards and wallets for merchants selling internationally. The default choice outside India.",
+    },
+    {
+      name: "Razorpay",
+      description:
+        "Cards, UPI, wallets, and net banking for merchants selling in India — a full local payment stack, not just a card gateway.",
+    },
+  ],
+};
+
+// services/marketplace-api/internal/shipping (delhivery.go, ninjavan.go,
+// shipengine.go), cross-checked against
+// supported_countries.shipping_carriers (migrations/000090; untouched by
+// any later migration) — Delhivery for India, NinjaVan for the Southeast
+// Asian countries in the seed, ShipEngine everywhere else in it.
+const SHIPPING: IntegrationGroup = {
+  eyebrow: "Shipping",
+  heading: "Getting orders out the door",
+  intro:
+    "Connected carriers appear as live rates at checkout and generate tracking numbers automatically once you fulfil an order.",
+  items: [
+    {
+      name: "Delhivery",
+      description:
+        "Domestic carrier for shipments within India, including rate calculation and label generation.",
+    },
+    {
+      name: "NinjaVan",
+      description: "Regional carrier for shipments within Southeast Asia.",
+    },
+    {
+      name: "ShipEngine",
+      description:
+        "A carrier aggregator that brings USPS, UPS, FedEx, DHL, and others in through a single connection — useful for merchants shipping outside India and Southeast Asia.",
+    },
+  ],
+};
+
+// services/marketplace-api/internal/tax (taxjar.go), cross-checked
+// against supported_countries.tax_strategy (migrations/000090) — 'taxjar'
+// only for the US row; India runs its own GST calculator, everyone else a
+// flat rate, so TaxJar is not claimed for those.
+const TAX: IntegrationGroup = {
+  eyebrow: "Tax",
+  heading: "Sales tax, calculated for you",
+  intro:
+    "Tax is calculated automatically at checkout based on where you and your customer are.",
+  items: [
+    {
+      name: "TaxJar",
+      description:
+        "Automatic US sales tax calculation by jurisdiction. India uses a built-in calculator instead, since GST doesn't need a third party.",
+    },
+  ],
+};
+
+// services/marketplace-api/internal/email (sendgrid.go, resend.go,
+// fallback.go) — providers.go wires both into NewFromConfig's
+// FallbackSender chain unconditionally, not behind a plan or country
+// gate.
+const EMAIL: IntegrationGroup = {
+  eyebrow: "Email",
+  heading: "Order and account email",
+  intro:
+    "Transactional email — order confirmations, shipping updates, password resets — and campaign email both run through the same connected provider.",
+  items: [
+    {
+      name: "SendGrid",
+      description:
+        "The default provider for transactional and campaign email.",
+    },
+    {
+      name: "Resend",
+      description:
+        "An alternative provider; Mark8ly automatically falls back to it if the primary provider has an outage, so a delivery failure doesn't mean a lost order confirmation.",
+    },
+  ],
+};
+
+// internal/plangate/matrix.go's FeatureReadAPI / FeatureFullAPI, wired to
+// real handlers in internal/handlers/admin/apikeys_handler.go (Studio gets
+// read-only key scopes, Pro gets full read/write). Pricing.tsx additionally
+// advertises "webhooks" (Studio) and "custom code injection" (Pro) — both
+// left off here because they don't check out: no merchant-facing outbound
+// webhook subscription exists anywhere in the codebase (internal/outbox is
+// an internal event-bus pattern, not something a merchant configures), and
+// matrix.go's own comment on FeatureCustomCodeInjection calls it "reserved
+// for the future... no handler accepts arbitrary <script> payloads today."
+const DEVELOPER: IntegrationGroup = {
+  eyebrow: "Build on Mark8ly",
+  heading: "For everything else",
+  intro:
+    "If the integration you need isn't on this list yet, you can often build it yourself.",
+  items: [
+    {
+      name: "REST API",
+      description:
+        "Read-only API access on Studio; full read/write access on Pro — enough to sync orders and inventory with tools we don't connect to directly.",
+    },
+  ],
+};
+
+const GROUPS: ReadonlyArray<IntegrationGroup> = [
+  PAYMENTS,
+  SHIPPING,
+  TAX,
+  EMAIL,
+  DEVELOPER,
+];
 
 export default function IntegrationsPage() {
   return (
-    <MarketingStub
-      eyebrow="Integrations"
-      title={<>A small, considered set.</>}
-      body="We&rsquo;re picking integrations the way an editor picks a list of recommended tools — only the ones we&rsquo;d use ourselves. Payment processors, shipping carriers, analytics, and email tools are all in progress. The full list will appear here as each one lands."
-      primaryCta={{ href: "/onboarding", label: "Open your store" }}
-      secondaryCta={{ href: "/contact", label: "Suggest one" }}
-    />
+    <MarketingPage>
+      <PageHero
+        eyebrow="Integrations"
+        title={<>A small, considered set.</>}
+        lede="We pick integrations the way an editor picks recommended tools — only the ones that earn their place. Here's exactly what's live today."
+      />
+
+      {GROUPS.map((group) => (
+        <section
+          key={group.heading}
+          className="border-t border-border-subtle py-16 sm:py-20"
+        >
+          <div className="mx-auto grid max-w-6xl gap-8 px-6 lg:grid-cols-[1fr_2fr] lg:gap-16">
+            <div className="lg:sticky lg:top-32 lg:self-start">
+              <p className="eyebrow mb-5">{group.eyebrow}</p>
+              <h2 className="font-serif text-2xl font-medium leading-[1.1] tracking-[-0.015em] text-foreground">
+                {group.heading}
+              </h2>
+              <p className="mt-4 max-w-sm text-foreground-secondary leading-relaxed">
+                {group.intro}
+              </p>
+            </div>
+            <ul className="space-y-8 border-t border-border-subtle pt-8">
+              {group.items.map((item) => (
+                <li
+                  key={item.name}
+                  className="border-t border-border-subtle pt-8 first:border-t-0 first:pt-0"
+                >
+                  <p className="font-serif text-xl text-foreground">
+                    {item.name}
+                  </p>
+                  <p className="mt-2 max-w-xl text-foreground-secondary leading-relaxed">
+                    {item.description}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      ))}
+
+      <section className="border-t border-border-subtle py-20 sm:py-24">
+        <div className="mx-auto max-w-6xl px-6">
+          <p className="max-w-xl text-lg leading-[1.55] text-foreground-secondary">
+            Using something that isn&rsquo;t here? Tell us — partnerships and
+            provider requests both come to a real inbox.
+          </p>
+          <div className="mt-10 flex flex-wrap items-center gap-x-8 gap-y-4">
+            <Link
+              href="/onboarding"
+              className="inline-flex h-12 items-center rounded-md bg-primary px-6 text-base font-medium text-primary-foreground hover:bg-primary-hover"
+            >
+              Open your store
+            </Link>
+            <Link href="/contact" className="btn-ghost">
+              Suggest one
+            </Link>
+          </div>
+        </div>
+      </section>
+    </MarketingPage>
   );
 }

--- a/apps/onboarding/app/legal/page.tsx
+++ b/apps/onboarding/app/legal/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { MailLink } from "@repo/ui/mail-link";
 import {
   MarketingPage,
   PageHero,
@@ -101,12 +102,10 @@ export default function LegalHubPage() {
             </p>
             <p className="mt-3">
               Questions?{" "}
-              <a
-                href="mailto:legal@mark8ly.com"
+              <MailLink
+                email="legal@mark8ly.com"
                 className="text-foreground underline decoration-moss-700 decoration-2 underline-offset-4 hover:text-moss-700"
-              >
-                legal@mark8ly.com
-              </a>
+              />
             </p>
           </div>
         </div>

--- a/apps/onboarding/app/privacy/page.tsx
+++ b/apps/onboarding/app/privacy/page.tsx
@@ -1,3 +1,4 @@
+import { MailLink } from "@repo/ui/mail-link";
 import {
   MarketingPage,
   PageHero,
@@ -39,9 +40,9 @@ export default function PrivacyPolicyPage() {
         </p>
         <p>
           <strong>Contact:</strong>{" "}
-          <a href="mailto:privacy@mark8ly.com">privacy@mark8ly.com</a> ·{" "}
+          <MailLink email="privacy@mark8ly.com" /> ·{" "}
           <strong>Data Protection Officer:</strong>{" "}
-          <a href="mailto:dpo@mark8ly.com">dpo@mark8ly.com</a>
+          <MailLink email="dpo@mark8ly.com" />
         </p>
 
         <h2>2. Information we collect</h2>
@@ -218,7 +219,7 @@ export default function PrivacyPolicyPage() {
         </ul>
         <p>
           To exercise your rights, email{" "}
-          <a href="mailto:privacy@mark8ly.com">privacy@mark8ly.com</a>. We
+          <MailLink email="privacy@mark8ly.com" />. We
           respond within 30 days.
         </p>
 
@@ -248,7 +249,7 @@ export default function PrivacyPolicyPage() {
             correction, erasure, grievance redressal, and nomination, per
             the Digital Personal Data Protection Act, 2023. Our grievance
             officer is reachable at{" "}
-            <a href="mailto:dpo@mark8ly.com">dpo@mark8ly.com</a>.
+            <MailLink email="dpo@mark8ly.com" />.
           </li>
         </ul>
 
@@ -281,7 +282,7 @@ export default function PrivacyPolicyPage() {
           Mark8ly is not directed to children under 16. We do not knowingly
           collect personal information from children under 16. If you
           believe we&rsquo;ve received such information, email{" "}
-          <a href="mailto:privacy@mark8ly.com">privacy@mark8ly.com</a> and
+          <MailLink email="privacy@mark8ly.com" /> and
           we will delete it.
         </p>
 
@@ -296,15 +297,15 @@ export default function PrivacyPolicyPage() {
         <ul>
           <li>
             <strong>General privacy:</strong>{" "}
-            <a href="mailto:privacy@mark8ly.com">privacy@mark8ly.com</a>
+            <MailLink email="privacy@mark8ly.com" />
           </li>
           <li>
             <strong>Data Protection Officer / grievance officer (India):</strong>{" "}
-            <a href="mailto:dpo@mark8ly.com">dpo@mark8ly.com</a>
+            <MailLink email="dpo@mark8ly.com" />
           </li>
           <li>
             <strong>Legal:</strong>{" "}
-            <a href="mailto:legal@mark8ly.com">legal@mark8ly.com</a>
+            <MailLink email="legal@mark8ly.com" />
           </li>
         </ul>
 

--- a/apps/onboarding/app/refunds/page.tsx
+++ b/apps/onboarding/app/refunds/page.tsx
@@ -1,3 +1,4 @@
+import { MailLink } from "@repo/ui/mail-link";
 import {
   MarketingPage,
   PageHero,
@@ -39,7 +40,7 @@ export default function RefundsPolicyPage() {
         <p>
           After your first paid charge, you have fourteen days to request a
           full refund — no questions asked. Email{" "}
-          <a href="mailto:support@mark8ly.com">support@mark8ly.com</a> with
+          <MailLink email="support@mark8ly.com" /> with
           your store name and the invoice number. Typical turnaround is five
           business days; funds reappear on the original payment method.
         </p>
@@ -85,7 +86,7 @@ export default function RefundsPolicyPage() {
 
         <h2>7. How to request a refund</h2>
         <ol style={{ listStyleType: "decimal", paddingLeft: "1.5rem" }}>
-          <li>Email <a href="mailto:support@mark8ly.com">support@mark8ly.com</a></li>
+          <li>Email <MailLink email="support@mark8ly.com" /></li>
           <li>Include your store name and the invoice number</li>
           <li>Tell us briefly what happened</li>
         </ol>
@@ -99,11 +100,11 @@ export default function RefundsPolicyPage() {
         <ul>
           <li>
             <strong>Billing or refund questions:</strong>{" "}
-            <a href="mailto:support@mark8ly.com">support@mark8ly.com</a>
+            <MailLink email="support@mark8ly.com" />
           </li>
           <li>
             <strong>Legal:</strong>{" "}
-            <a href="mailto:legal@mark8ly.com">legal@mark8ly.com</a>
+            <MailLink email="legal@mark8ly.com" />
           </li>
         </ul>
 

--- a/apps/onboarding/app/security/page.tsx
+++ b/apps/onboarding/app/security/page.tsx
@@ -1,3 +1,4 @@
+import { MailLink } from "@repo/ui/mail-link";
 import {
   MarketingPage,
   PageHero,
@@ -84,7 +85,7 @@ export default function SecurityPage() {
         <p>
           If you think you&rsquo;ve found a security vulnerability, please
           tell us. Email{" "}
-          <a href="mailto:security@mark8ly.com">security@mark8ly.com</a> with
+          <MailLink email="security@mark8ly.com" /> with
           a description, reproduction steps, and — if you know — the impact.
         </p>
         <ul>
@@ -130,15 +131,15 @@ export default function SecurityPage() {
         <ul>
           <li>
             <strong>Vulnerability reports:</strong>{" "}
-            <a href="mailto:security@mark8ly.com">security@mark8ly.com</a>
+            <MailLink email="security@mark8ly.com" />
           </li>
           <li>
             <strong>Privacy &amp; DPA:</strong>{" "}
-            <a href="mailto:privacy@mark8ly.com">privacy@mark8ly.com</a>
+            <MailLink email="privacy@mark8ly.com" />
           </li>
           <li>
             <strong>General legal:</strong>{" "}
-            <a href="mailto:legal@mark8ly.com">legal@mark8ly.com</a>
+            <MailLink email="legal@mark8ly.com" />
           </li>
         </ul>
 

--- a/apps/onboarding/app/sitemap.ts
+++ b/apps/onboarding/app/sitemap.ts
@@ -37,6 +37,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.7,
     },
+    {
+      url: `${SITE_URL}/help`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
+      url: `${SITE_URL}/integrations`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
   ];
 
   // SEO landing pages — high-intent comparison/alternative

--- a/apps/onboarding/app/sub-processors/page.tsx
+++ b/apps/onboarding/app/sub-processors/page.tsx
@@ -1,3 +1,4 @@
+import { MailLink } from "@repo/ui/mail-link";
 import {
   MarketingPage,
   PageHero,
@@ -166,7 +167,7 @@ export default function SubProcessorsPage() {
           or materially changing how an existing one is used. Merchants who
           have signed our Data Processing Addendum may subscribe to change
           notifications by emailing{" "}
-          <a href="mailto:privacy@mark8ly.com">privacy@mark8ly.com</a> with
+          <MailLink email="privacy@mark8ly.com" /> with
           the subject line &ldquo;sub-processor updates&rdquo;.
         </p>
         <p>
@@ -179,11 +180,11 @@ export default function SubProcessorsPage() {
         <ul>
           <li>
             <strong>Privacy / DPA questions:</strong>{" "}
-            <a href="mailto:privacy@mark8ly.com">privacy@mark8ly.com</a>
+            <MailLink email="privacy@mark8ly.com" />
           </li>
           <li>
             <strong>Data protection officer:</strong>{" "}
-            <a href="mailto:dpo@mark8ly.com">dpo@mark8ly.com</a>
+            <MailLink email="dpo@mark8ly.com" />
           </li>
         </ul>
 

--- a/apps/onboarding/app/terms/page.tsx
+++ b/apps/onboarding/app/terms/page.tsx
@@ -1,3 +1,4 @@
+import { MailLink } from "@repo/ui/mail-link";
 import {
   MarketingPage,
   PageHero,
@@ -167,7 +168,7 @@ export default function TermsOfServicePage() {
         <p>
           If you believe content on a Mark8ly-hosted store infringes your
           copyright, send a notice to{" "}
-          <a href="mailto:legal@mark8ly.com">legal@mark8ly.com</a> including:
+          <MailLink email="legal@mark8ly.com" /> including:
         </p>
         <ul>
           <li>your contact details</li>
@@ -318,19 +319,19 @@ export default function TermsOfServicePage() {
         <ul>
           <li>
             <strong>Legal questions:</strong>{" "}
-            <a href="mailto:legal@mark8ly.com">legal@mark8ly.com</a>
+            <MailLink email="legal@mark8ly.com" />
           </li>
           <li>
             <strong>Billing and refunds:</strong>{" "}
-            <a href="mailto:support@mark8ly.com">support@mark8ly.com</a>
+            <MailLink email="support@mark8ly.com" />
           </li>
           <li>
             <strong>Privacy:</strong>{" "}
-            <a href="mailto:privacy@mark8ly.com">privacy@mark8ly.com</a>
+            <MailLink email="privacy@mark8ly.com" />
           </li>
           <li>
             <strong>Security:</strong>{" "}
-            <a href="mailto:security@mark8ly.com">security@mark8ly.com</a>
+            <MailLink email="security@mark8ly.com" />
           </li>
         </ul>
 

--- a/apps/onboarding/components/marketing/Footer.tsx
+++ b/apps/onboarding/components/marketing/Footer.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { MailLink } from "@repo/ui/mail-link";
+
 interface FooterColumnProps {
   title: string;
   links: Array<{ href: string; label: string }>;
@@ -92,12 +94,10 @@ export function Footer() {
             <p className="text-sm text-paper-500">
               © {currentYear} mark8ly · A Tesserix product
             </p>
-            <a
-              href="mailto:hello@mark8ly.com"
+            <MailLink
+              email="hello@mark8ly.com"
               className="inline-flex h-11 items-center text-sm text-paper-400 hover:text-paper-50"
-            >
-              hello@mark8ly.com
-            </a>
+            />
           </div>
           {/* Operator disclosure. Named here so a merchant can match the entity
               on their invoice and settlement to the product they signed up to. */}

--- a/apps/onboarding/components/marketing/JournalSignupFields.tsx
+++ b/apps/onboarding/components/marketing/JournalSignupFields.tsx
@@ -1,0 +1,67 @@
+import { Input, Label } from "@tesserix/web";
+
+export type JournalSignupStatus = "idle" | "submitting" | "success" | "error";
+
+interface JournalSignupFieldsProps {
+  status: JournalSignupStatus;
+  email: string;
+  errorMessage: string | null;
+  onEmailChange: (value: string) => void;
+}
+
+/**
+ * Presentational half of JournalSignupForm — pure props in, markup out, no
+ * hooks. Split out so the label/aria wiring can be exercised with
+ * `renderToStaticMarkup` in tests (see tests/unit/journal-signup-fields.spec.tsx,
+ * which loads this file's real JSX via tests/unit/helpers/load-tsx.ts —
+ * the same trick tests/unit/mail-link.spec.tsx uses for MailLink, needed
+ * because this app's Playwright-based unit tests intercept ordinary JSX
+ * with their own pragma).
+ */
+export function JournalSignupFields({
+  status,
+  email,
+  errorMessage,
+  onEmailChange,
+}: JournalSignupFieldsProps) {
+  const disabled = status === "submitting" || status === "success";
+  const hasError = status === "error" && Boolean(errorMessage);
+
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor="journal-email" className="text-foreground">
+        Email address
+      </Label>
+      <Input
+        id="journal-email"
+        type="email"
+        inputMode="email"
+        autoComplete="email"
+        placeholder="you@example.com"
+        value={email}
+        disabled={disabled}
+        required
+        aria-invalid={hasError ? true : undefined}
+        aria-describedby={hasError ? "journal-email-error" : undefined}
+        onChange={(e) => onEmailChange(e.target.value)}
+      />
+      <div className="min-h-[1.125rem]">
+        {hasError ? (
+          <p
+            id="journal-email-error"
+            role="alert"
+            aria-live="polite"
+            className="text-xs text-danger"
+          >
+            {errorMessage}
+          </p>
+        ) : null}
+        {status === "success" ? (
+          <p role="status" aria-live="polite" className="text-xs text-moss-700">
+            You&rsquo;re on the list — we&rsquo;ll email you when the first piece goes up.
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/onboarding/components/marketing/JournalSignupForm.tsx
+++ b/apps/onboarding/components/marketing/JournalSignupForm.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+// JournalSignupForm — #153: "Notify me when the first piece goes up" on
+// the /blog "coming soon" page.
+//
+// Posts to this app's own /api/journal-subscribe route (never
+// marketplace-api directly — see lib/api/journal-signup.ts). Idempotent
+// resubmission and rate limiting are enforced server-side; this component
+// only needs to render the four states plainly: idle, submitting,
+// success, error.
+
+import { useState } from "react";
+
+import { subscribeToJournal } from "@/lib/api/journal-signup";
+
+import { JournalSignupFields, type JournalSignupStatus } from "./JournalSignupFields";
+
+export function JournalSignupForm() {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<JournalSignupStatus>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const disabled = status === "submitting" || status === "success";
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (disabled) return;
+
+    setStatus("submitting");
+    setErrorMessage(null);
+
+    const result = await subscribeToJournal(email);
+
+    if (result.ok) {
+      setStatus("success");
+      return;
+    }
+
+    setStatus("error");
+    setErrorMessage(result.message);
+  }
+
+  return (
+    <form
+      onSubmit={(e) => {
+        void handleSubmit(e);
+      }}
+      noValidate
+      className="mt-10 max-w-sm border-t border-border-subtle pt-8"
+    >
+      <p className="mb-4 text-sm font-medium text-foreground">
+        Notify me when the first piece goes up
+      </p>
+      <JournalSignupFields
+        status={status}
+        email={email}
+        errorMessage={errorMessage}
+        onEmailChange={setEmail}
+      />
+      <button
+        type="submit"
+        disabled={disabled}
+        className="mt-4 inline-flex h-11 items-center rounded-md bg-primary px-6 text-sm font-medium text-primary-foreground hover:bg-primary-hover disabled:cursor-not-allowed disabled:bg-ink-600"
+      >
+        {status === "submitting"
+          ? "Sending…"
+          : status === "success"
+            ? "Subscribed"
+            : "Notify me"}
+      </button>
+    </form>
+  );
+}

--- a/apps/onboarding/components/marketing/primitives.tsx
+++ b/apps/onboarding/components/marketing/primitives.tsx
@@ -111,6 +111,10 @@ interface MarketingStubProps {
     href: string;
     label: string;
   };
+  /** Optional content rendered below the CTA row — e.g. the Journal
+   *  page's email capture form (#153). Most stub pages have no need for
+   *  this and can omit it entirely. */
+  children?: ReactNode;
 }
 
 export function MarketingStub({
@@ -119,6 +123,7 @@ export function MarketingStub({
   body,
   primaryCta,
   secondaryCta,
+  children,
 }: MarketingStubProps) {
   return (
     <MarketingPage>
@@ -149,6 +154,8 @@ export function MarketingStub({
               )}
             </div>
           )}
+
+          {children}
         </div>
       </section>
     </MarketingPage>

--- a/apps/onboarding/components/onboarding/SlimFooter.tsx
+++ b/apps/onboarding/components/onboarding/SlimFooter.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { MailLink } from "@repo/ui/mail-link";
+
 /**
  * Thin footer used by the onboarding flow and post-submit
  * pages. Pure type, a single row, hairline top border. No card
@@ -11,12 +13,10 @@ export function SlimFooter() {
       <div className="mx-auto flex max-w-6xl flex-col gap-3 px-6 py-5 text-sm text-foreground-secondary sm:flex-row sm:items-center sm:justify-between">
         <p>
           Need help?{" "}
-          <a
-            href="mailto:hello@mark8ly.com"
+          <MailLink
+            email="hello@mark8ly.com"
             className="font-medium text-foreground underline decoration-moss-700 decoration-2 underline-offset-4 hover:text-moss-700"
-          >
-            hello@mark8ly.com
-          </a>
+          />
         </p>
 
         <div className="flex flex-wrap items-center gap-x-6 gap-y-2">

--- a/apps/onboarding/lib/api/journal-signup.ts
+++ b/apps/onboarding/lib/api/journal-signup.ts
@@ -1,0 +1,40 @@
+// Browser-side helper for the Journal email capture form (#153). Calls
+// this app's own /api/journal-subscribe route — never marketplace-api
+// directly, since that route is the only thing allowed to hold
+// MARKETPLACE_API_URL.
+
+export type SubscribeResult = { ok: true } | { ok: false; message: string };
+
+/**
+ * Submits an email to the Journal "coming soon" capture point. Never
+ * throws — network failures and non-2xx responses both come back as
+ * `{ ok: false, message }` so the caller can render the error inline
+ * without a try/catch.
+ */
+export async function subscribeToJournal(email: string): Promise<SubscribeResult> {
+  try {
+    const res = await fetch("/api/journal-subscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+
+    const body = (await res.json().catch(() => ({}))) as { message?: string };
+
+    if (!res.ok) {
+      return {
+        ok: false,
+        message: body.message ?? "Something went wrong. Please try again.",
+      };
+    }
+
+    return { ok: true };
+  } catch {
+    // fetch() itself rejected — offline, or the app server is unreachable.
+    return {
+      ok: false,
+      message:
+        "We couldn't reach the server. Check your connection and try again.",
+    };
+  }
+}

--- a/apps/onboarding/lib/config.ts
+++ b/apps/onboarding/lib/config.ts
@@ -15,6 +15,12 @@ export const config = {
   platformApiUrl: process.env.PLATFORM_API_URL ?? "http://localhost:8086",
   /** Server-side auth-bff base URL. Only used from server actions / server components. */
   authBffUrl: process.env.AUTH_BFF_URL ?? "http://localhost:8087",
+  /** Server-side marketplace-api base URL. Only used by /api/journal-subscribe
+   *  (#153). Deliberately not platformApiUrl above — that points at the
+   *  separate platform-api service. Name and default port match
+   *  apps/admin/lib/api/marketplace-api.ts, which already talks to
+   *  marketplace-api from a Next.js server. */
+  marketplaceApiUrl: process.env.MARKETPLACE_API_URL ?? "http://localhost:8088",
 } as const;
 
 export const publicConfig = {

--- a/apps/onboarding/tests/unit/guides.spec.ts
+++ b/apps/onboarding/tests/unit/guides.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+// guides.ts is the single source of truth for /guides (the index),
+// /guides/[slug] (the article), and sitemap.ts. There's no DOM harness in
+// this unit-test config (see playwright.unit.config.ts), so "renders at
+// /guides/<slug>" and "appears on the index" are proven against the data
+// both pages actually render from — generateStaticParams for the article
+// route, and the GUIDES array itself for the index — rather than by
+// mounting a component.
+import { GUIDES, getGuide } from "../../app/guides/guides";
+import { generateStaticParams } from "../../app/guides/[slug]/page";
+
+const NEW_SLUGS = ["how-to-add-your-first-product", "how-to-connect-your-domain"];
+
+test.describe("guides content", () => {
+  for (const slug of NEW_SLUGS) {
+    test(`${slug} is present in GUIDES`, () => {
+      expect(getGuide(slug)).toBeDefined();
+    });
+
+    test(`${slug} generates a static param for its article route`, () => {
+      const params = generateStaticParams();
+      expect(params).toContainEqual({ slug });
+    });
+
+    test(`${slug} appears on the /guides index (GUIDES array)`, () => {
+      expect(GUIDES.some((g) => g.slug === slug)).toBe(true);
+    });
+  }
+
+  test("every slug is unique", () => {
+    const slugs = GUIDES.map((g) => g.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  test("every title is unique (guards against copy-paste drift)", () => {
+    const titles = GUIDES.map((g) => g.title);
+    expect(new Set(titles).size).toBe(titles.length);
+  });
+
+  test("every description is unique (guards against copy-paste drift)", () => {
+    const descriptions = GUIDES.map((g) => g.description);
+    expect(new Set(descriptions).size).toBe(descriptions.length);
+  });
+
+  test("every guide has a non-empty blocks array", () => {
+    for (const guide of GUIDES) {
+      expect(guide.blocks.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every guide has a valid ISO `updated` date", () => {
+    for (const guide of GUIDES) {
+      expect(guide.updated).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(Number.isNaN(new Date(guide.updated).getTime())).toBe(false);
+    }
+  });
+
+  test("no guide's title duplicates the brand name (layout appends it)", () => {
+    for (const guide of GUIDES) {
+      expect(guide.title.toLowerCase()).not.toContain("mark8ly");
+    }
+  });
+});

--- a/apps/onboarding/tests/unit/help-integrations-seo.spec.ts
+++ b/apps/onboarding/tests/unit/help-integrations-seo.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from "@playwright/test";
+
+import HelpPage, { metadata as helpMetadata } from "../../app/help/page";
+import { metadata as integrationsMetadata } from "../../app/integrations/page";
+import sitemap from "../../app/sitemap";
+
+/**
+ * Issue #149 — /help and /integrations were reported by Search Console as
+ * excluded by a noindex tag. They're now real content, so this locks in
+ * that both are indexable, carry distinct metadata, and are listed in the
+ * sitemap — plus that the /help FAQPage JSON-LD is well-formed.
+ */
+
+test.describe("metadata no longer sets noindex", () => {
+  for (const [name, metadata] of [
+    ["/help", helpMetadata],
+    ["/integrations", integrationsMetadata],
+  ] as const) {
+    test(`${name} metadata does not set robots index: false`, () => {
+      const robots = metadata.robots as
+        | { index?: boolean }
+        | string
+        | undefined;
+      if (robots && typeof robots === "object") {
+        expect(robots.index).not.toBe(false);
+      } else {
+        expect(robots).toBeUndefined();
+      }
+    });
+
+    test(`${name} has a non-empty title and description`, () => {
+      expect(String(metadata.title ?? "").length).toBeGreaterThan(0);
+      expect(String(metadata.description ?? "").length).toBeGreaterThan(0);
+    });
+  }
+
+  test("/help and /integrations have distinct titles and descriptions", () => {
+    expect(helpMetadata.title).not.toEqual(integrationsMetadata.title);
+    expect(helpMetadata.description).not.toEqual(
+      integrationsMetadata.description,
+    );
+  });
+
+  test("/help and /integrations declare canonical URLs and OpenGraph blocks", () => {
+    for (const metadata of [helpMetadata, integrationsMetadata]) {
+      expect(metadata.alternates?.canonical).toBeTruthy();
+      expect(metadata.openGraph?.title).toBeTruthy();
+      expect(metadata.openGraph?.description).toBeTruthy();
+    }
+  });
+});
+
+test.describe("sitemap", () => {
+  test("includes /help and /integrations", () => {
+    const urls = sitemap().map((entry) => entry.url);
+    expect(urls).toContain("https://mark8ly.com/help");
+    expect(urls).toContain("https://mark8ly.com/integrations");
+  });
+
+  test("still excludes noindexed and funnel-only routes", () => {
+    const urls = sitemap().map((entry) => entry.url);
+    for (const excluded of [
+      "https://mark8ly.com/blog",
+      "https://mark8ly.com/dpa",
+      "https://mark8ly.com/onboarding",
+      "https://mark8ly.com/welcome",
+    ]) {
+      expect(urls).not.toContain(excluded);
+    }
+  });
+});
+
+test.describe("/help FAQPage JSON-LD", () => {
+  test("renders valid JSON with a non-empty FAQPage mainEntity", () => {
+    const element = HelpPage();
+
+    // The <script type="application/ld+json"> is the first child of the
+    // MarketingPage tree. Rather than pull in a renderer, walk the plain
+    // React element tree — server components return ordinary element
+    // objects, no DOM involved — to find it and parse its content.
+    const script = findJsonLdScript(element);
+    expect(script).not.toBeNull();
+
+    const parsed = JSON.parse(script as string);
+    expect(parsed["@type"]).toBe("FAQPage");
+    expect(Array.isArray(parsed.mainEntity)).toBe(true);
+    expect(parsed.mainEntity.length).toBeGreaterThan(0);
+
+    for (const entry of parsed.mainEntity) {
+      expect(entry["@type"]).toBe("Question");
+      expect(typeof entry.name).toBe("string");
+      expect(entry.name.length).toBeGreaterThan(0);
+      expect(entry.acceptedAnswer["@type"]).toBe("Answer");
+      expect(typeof entry.acceptedAnswer.text).toBe("string");
+      expect(entry.acceptedAnswer.text.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// Minimal recursive walk over a React element tree looking for the
+// dangerouslySetInnerHTML payload of a <script type="application/ld+json">.
+// Works without a DOM because JSX is just nested plain objects until a
+// renderer processes it.
+function findJsonLdScript(node: unknown): string | null {
+  if (node === null || node === undefined || typeof node !== "object") {
+    return null;
+  }
+  const el = node as {
+    type?: unknown;
+    props?: {
+      type?: string;
+      dangerouslySetInnerHTML?: { __html?: string };
+      children?: unknown;
+    };
+  };
+
+  if (el.type === "script" && el.props?.type === "application/ld+json") {
+    return el.props.dangerouslySetInnerHTML?.__html ?? null;
+  }
+
+  const children = el.props?.children;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      const found = findJsonLdScript(child);
+      if (found) return found;
+    }
+  } else if (children) {
+    const found = findJsonLdScript(children);
+    if (found) return found;
+  }
+
+  return null;
+}

--- a/apps/onboarding/tests/unit/helpers/load-tsx.ts
+++ b/apps/onboarding/tests/unit/helpers/load-tsx.ts
@@ -1,0 +1,55 @@
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
+/**
+ * Loads a named export from a real `.tsx` source file, with its JSX
+ * compiled by the TypeScript compiler API rather than Playwright's own
+ * transform.
+ *
+ * tests/unit runs under @playwright/test as plain Node (see
+ * ../../playwright.unit.config.ts). That runner instruments every
+ * non-node_modules `.ts`/`.tsx` file it loads with its own JSX
+ * transform, whose `jsx-runtime` is Playwright's own (built for its
+ * ARIA-snapshot matchers) rather than React's — importing a component
+ * directly would silently swap in Playwright's `jsx()` and produce inert
+ * `{__pw_type: "jsx", ...}` objects instead of real React elements,
+ * which `react-dom/server`'s `renderToStaticMarkup` then rejects with
+ * "Objects are not valid as a React child". Transpiling the source
+ * ourselves into plain CommonJS leaves no JSX syntax for Playwright's
+ * loader to intercept.
+ *
+ * Factored out of tests/unit/mail-link.spec.ts, which had the original,
+ * single-use version of this loader — pulled into a shared helper now
+ * that journal-signup-fields.spec.tsx needs the same trick.
+ */
+export function loadTsxExport<T>(
+  sourcePath: string,
+  exportName: string,
+  outputDir: string,
+): T {
+  const source = readFileSync(sourcePath, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      jsx: ts.JsxEmit.ReactJSX,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+    fileName: path.basename(sourcePath),
+  });
+
+  // Written next to the calling spec (outputDir, its __dirname) rather
+  // than os.tmpdir() so the generated file's `require("react/jsx-
+  // runtime")` resolves via the normal node_modules ancestor walk.
+  const base = path.basename(sourcePath, path.extname(sourcePath));
+  const generatedPath = path.join(outputDir, `.${base}.generated.cjs`);
+  writeFileSync(generatedPath, outputText);
+  try {
+    delete require.cache[require.resolve(generatedPath)];
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require(generatedPath)[exportName] as T;
+  } finally {
+    rmSync(generatedPath, { force: true });
+  }
+}

--- a/apps/onboarding/tests/unit/journal-signup-fields.spec.tsx
+++ b/apps/onboarding/tests/unit/journal-signup-fields.spec.tsx
@@ -1,0 +1,112 @@
+import { expect, test } from "@playwright/test";
+import path from "node:path";
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { loadTsxExport } from "./helpers/load-tsx";
+import type { JournalSignupStatus } from "../../components/marketing/JournalSignupFields";
+
+/**
+ * See tests/unit/helpers/load-tsx.ts for why JournalSignupFields' real
+ * JSX source is loaded this way rather than imported directly.
+ */
+type JournalSignupFieldsProps = {
+  status: JournalSignupStatus;
+  email: string;
+  errorMessage: string | null;
+  onEmailChange: (value: string) => void;
+};
+
+const JournalSignupFields = loadTsxExport<(props: JournalSignupFieldsProps) => ReactNode>(
+  path.join(__dirname, "../../components/marketing/JournalSignupFields.tsx"),
+  "JournalSignupFields",
+  __dirname,
+);
+
+function noop() {
+  // JournalSignupFields requires onEmailChange; static rendering never
+  // fires it.
+}
+
+test("the email input has a real <label> associated via htmlFor/id", () => {
+  const html = renderToStaticMarkup(
+    createElement(JournalSignupFields, {
+      status: "idle",
+      email: "",
+      errorMessage: null,
+      onEmailChange: noop,
+    }),
+  );
+
+  expect(html).toContain('for="journal-email"');
+  expect(html).toContain('id="journal-email"');
+  expect(html).toContain('type="email"');
+});
+
+test("idle state renders no error and no aria-describedby", () => {
+  const html = renderToStaticMarkup(
+    createElement(JournalSignupFields, {
+      status: "idle",
+      email: "",
+      errorMessage: null,
+      onEmailChange: noop,
+    }),
+  );
+
+  expect(html).not.toContain("aria-describedby");
+  expect(html).not.toContain('role="alert"');
+});
+
+test("error state wires aria-describedby on the input to the error message's id", () => {
+  const html = renderToStaticMarkup(
+    createElement(JournalSignupFields, {
+      status: "error",
+      email: "not-an-email",
+      errorMessage: "That doesn't look like a valid email address.",
+      onEmailChange: noop,
+    }),
+  );
+
+  expect(html).toContain('aria-describedby="journal-email-error"');
+  expect(html).toContain('id="journal-email-error"');
+  expect(html).toContain('role="alert"');
+  expect(html).toContain("That doesn&#x27;t look like a valid email address.");
+  // The input itself must be marked invalid for assistive tech.
+  expect(html).toContain('aria-invalid="true"');
+});
+
+test("success state announces a calm, specific message via role=status", () => {
+  const html = renderToStaticMarkup(
+    createElement(JournalSignupFields, {
+      status: "success",
+      email: "ada@example.com",
+      errorMessage: null,
+      onEmailChange: noop,
+    }),
+  );
+
+  expect(html).toContain('role="status"');
+  expect(html).toContain("we’ll email you when the first piece goes up");
+});
+
+test("submitting and success states disable the input", () => {
+  const submitting = renderToStaticMarkup(
+    createElement(JournalSignupFields, {
+      status: "submitting",
+      email: "ada@example.com",
+      errorMessage: null,
+      onEmailChange: noop,
+    }),
+  );
+  const success = renderToStaticMarkup(
+    createElement(JournalSignupFields, {
+      status: "success",
+      email: "ada@example.com",
+      errorMessage: null,
+      onEmailChange: noop,
+    }),
+  );
+
+  expect(submitting).toContain('disabled=""');
+  expect(success).toContain('disabled=""');
+});

--- a/apps/onboarding/tests/unit/journal-signup.spec.ts
+++ b/apps/onboarding/tests/unit/journal-signup.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+
+import { subscribeToJournal } from "../../lib/api/journal-signup";
+
+interface StubbedResponse {
+  ok: boolean;
+  status?: number;
+  json?: unknown;
+}
+
+/**
+ * Replace global fetch with a queue of canned responses, recording every
+ * request. Mirrors the stubFetch helper in gip-signup.spec.ts.
+ */
+function stubFetch(responses: StubbedResponse[]): { url: string; body: unknown }[] {
+  const calls: { url: string; body: unknown }[] = [];
+  let i = 0;
+
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    const next = responses[i++];
+    if (!next) throw new Error(`unexpected fetch call #${i}: ${url}`);
+    calls.push({ url: String(url), body: JSON.parse(String(init?.body ?? "{}")) });
+    return {
+      ok: next.ok,
+      status: next.status ?? (next.ok ? 200 : 500),
+      json: async () => next.json ?? {},
+    };
+  }) as unknown as typeof fetch;
+
+  return calls;
+}
+
+test("posts to the app's own /api/journal-subscribe route, never marketplace-api directly", async () => {
+  const calls = stubFetch([{ ok: true, json: { ok: true } }]);
+
+  const result = await subscribeToJournal("ada@example.com");
+
+  expect(result).toEqual({ ok: true });
+  expect(calls).toHaveLength(1);
+  const [call] = calls;
+  expect(call?.url).toBe("/api/journal-subscribe");
+  expect(call?.body).toEqual({ email: "ada@example.com" });
+});
+
+test("success path: resolves ok:true on a 200 response", async () => {
+  stubFetch([{ ok: true, json: { ok: true } }]);
+
+  const result = await subscribeToJournal("ada@example.com");
+
+  expect(result.ok).toBe(true);
+});
+
+test("error path: surfaces the server's message on a non-2xx response", async () => {
+  stubFetch([
+    { ok: false, status: 400, json: { ok: false, message: "That doesn't look like a valid email address." } },
+  ]);
+
+  const result = await subscribeToJournal("not-an-email");
+
+  expect(result).toEqual({
+    ok: false,
+    message: "That doesn't look like a valid email address.",
+  });
+});
+
+test("error path: falls back to a generic message when the response body has none", async () => {
+  stubFetch([{ ok: false, status: 500, json: {} }]);
+
+  const result = await subscribeToJournal("ada@example.com");
+
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.message).toBe("Something went wrong. Please try again.");
+  }
+});
+
+test("error path: a network failure (fetch rejects) never throws, and returns a human message", async () => {
+  globalThis.fetch = (async () => {
+    throw new Error("network down");
+  }) as unknown as typeof fetch;
+
+  const result = await subscribeToJournal("ada@example.com");
+
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.message).toContain("couldn't reach the server");
+  }
+});

--- a/apps/onboarding/tests/unit/mail-link.spec.ts
+++ b/apps/onboarding/tests/unit/mail-link.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from "@playwright/test";
+import { readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ts from "typescript";
+
+/**
+ * MailLink is the fix for GitHub issue #147: Cloudflare's email
+ * obfuscation rewrites `mailto:` anchors into a `/cdn-cgi/l/email-
+ * protection` path that 404s on mark8ly.com. Wrapping the anchor in
+ * `<!--email_off--> ... <!--email_on-->` opts it out of that rewrite.
+ *
+ * WHY THIS FILE COMPILES MailLink.tsx BY HAND
+ * --------------------------------------------
+ * These tests run under `tests/unit`, which is plain Node via
+ * @playwright/test rather than a browser — see playwright.unit.config.ts.
+ * That runner instruments every non-node_modules .ts/.tsx file it loads
+ * with its own JSX transform, and that transform's `jsx-runtime` is
+ * Playwright's own (built for its ARIA-snapshot matchers), not React's —
+ * requiring MailLink.tsx directly would silently swap in Playwright's
+ * `jsx()` and produce inert `{__pw_type: "jsx", ...}` objects instead of
+ * real React elements. To exercise the actual component with real
+ * react-dom, we transpile its source ourselves (via the TypeScript
+ * compiler API, already a dependency) into plain CommonJS with no JSX
+ * syntax left for Playwright's loader to intercept, write it to a
+ * throwaway file, `require` it, then delete it.
+ */
+const MAIL_LINK_SOURCE_PATH = path.join(
+  __dirname,
+  "../../../../packages/ui/src/mail-link.tsx",
+);
+
+function loadMailLink(): (props: {
+  email: string;
+  className?: string;
+  children?: ReactNode;
+}) => ReactNode {
+  const source = readFileSync(MAIL_LINK_SOURCE_PATH, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      jsx: ts.JsxEmit.ReactJSX,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+    fileName: "MailLink.tsx",
+  });
+
+  // Written next to this spec (not os.tmpdir()) so the generated file's
+  // `require("react/jsx-runtime")` resolves via the normal node_modules
+  // ancestor walk.
+  const generatedPath = path.join(__dirname, ".mail-link.generated.cjs");
+  writeFileSync(generatedPath, outputText);
+  try {
+    delete require.cache[require.resolve(generatedPath)];
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require(generatedPath).MailLink;
+  } finally {
+    rmSync(generatedPath, { force: true });
+  }
+}
+
+const MailLink = loadMailLink();
+
+test("renders an anchor whose href is mailto:<email>", () => {
+  const html = renderToStaticMarkup(
+    createElement(MailLink, { email: "hello@mark8ly.com" }),
+  );
+  expect(html).toContain('href="mailto:hello@mark8ly.com"');
+});
+
+test("wraps the anchor in the Cloudflare email_off/email_on opt-out markers", () => {
+  const html = renderToStaticMarkup(
+    createElement(MailLink, { email: "hello@mark8ly.com" }),
+  );
+
+  const offIndex = html.indexOf("<!--email_off-->");
+  const anchorIndex = html.indexOf("<a href=");
+  const onIndex = html.indexOf("<!--email_on-->");
+
+  expect(offIndex).toBeGreaterThan(-1);
+  expect(onIndex).toBeGreaterThan(-1);
+  // The markers must actually surround the anchor, not just appear
+  // somewhere in the output.
+  expect(offIndex).toBeLessThan(anchorIndex);
+  expect(anchorIndex).toBeLessThan(onIndex);
+});
+
+test("falls back to the email address when no children are given", () => {
+  const html = renderToStaticMarkup(
+    createElement(MailLink, { email: "hello@mark8ly.com" }),
+  );
+  expect(html).toContain(">hello@mark8ly.com</a>");
+});
+
+test("renders explicit children instead of the email address", () => {
+  const html = renderToStaticMarkup(
+    createElement(MailLink, { email: "hello@mark8ly.com" }, "Say hello"),
+  );
+  expect(html).toContain(">Say hello</a>");
+  expect(html).not.toContain(">hello@mark8ly.com</a>");
+});
+
+/**
+ * Regression guard: nothing in apps/onboarding should ever ship a raw
+ * `<a href="mailto:` anchor again — every one of them must be rendered
+ * through MailLink, or Cloudflare's obfuscation 404s it. Scans .tsx source
+ * under app/ and components/, skipping MailLink.tsx itself (the string
+ * lives inside the component's own implementation, which is expected).
+ */
+test("no page ships a bare mailto anchor outside MailLink", () => {
+  const appRoot = path.join(__dirname, "..", "..");
+  const scanDirs = ["app", "components"];
+  const offenders: string[] = [];
+
+  const bareMailtoAnchor = /<a\s[^>]*href\s*=\s*(\{`?mailto:|"mailto:)/;
+
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      const stats = statSync(full);
+      if (stats.isDirectory()) {
+        if (entry === "node_modules" || entry.startsWith(".")) continue;
+        walk(full);
+        continue;
+      }
+      if (!entry.endsWith(".tsx")) continue;
+      if (path.basename(full) === "MailLink.tsx") continue;
+
+      const contents = readFileSync(full, "utf8");
+      if (bareMailtoAnchor.test(contents)) {
+        offenders.push(path.relative(appRoot, full));
+      }
+    }
+  }
+
+  for (const dir of scanDirs) {
+    walk(path.join(appRoot, dir));
+  }
+
+  expect(offenders).toEqual([]);
+});

--- a/apps/storefront/lib/host-policy.test.ts
+++ b/apps/storefront/lib/host-policy.test.ts
@@ -15,11 +15,41 @@ describe("classifyStorefrontHost", () => {
   });
 
   it("treats apex + reserved subdomains as marketing (not storefront)", () => {
-    expect(classifyStorefrontHost("mark8ly.com")).toEqual({ kind: "marketing" });
-    expect(classifyStorefrontHost("www.mark8ly.com")).toEqual({ kind: "marketing" });
-    expect(classifyStorefrontHost("api.mark8ly.com")).toEqual({ kind: "marketing" });
-    expect(classifyStorefrontHost("admin.mark8ly.com")).toEqual({ kind: "marketing" });
-    expect(classifyStorefrontHost("identity.mark8ly.com")).toEqual({ kind: "marketing" });
+    // The apex is already canonical, so it has nowhere to redirect to.
+    expect(classifyStorefrontHost("mark8ly.com")).toEqual({
+      kind: "marketing",
+      redirectTo: null,
+    });
+    // Platform hosts have their own VirtualServices — a hit here is
+    // routing drift, and we'd rather it stay visible than be redirected.
+    expect(classifyStorefrontHost("api.mark8ly.com")).toEqual({
+      kind: "marketing",
+      redirectTo: null,
+    });
+    expect(classifyStorefrontHost("admin.mark8ly.com")).toEqual({
+      kind: "marketing",
+      redirectTo: null,
+    });
+    expect(classifyStorefrontHost("identity.mark8ly.com")).toEqual({
+      kind: "marketing",
+      redirectTo: null,
+    });
+  });
+
+  it("sends www to the apex of its own TLD (#147 soft-404 fix)", () => {
+    // www.mark8ly.com landed on the storefront pod and rendered a
+    // "Store not found" body under a 200 — a soft 404 on the brand's
+    // front door. It must 301 to the apex instead.
+    expect(classifyStorefrontHost("www.mark8ly.com")).toEqual({
+      kind: "marketing",
+      redirectTo: "mark8ly.com",
+    });
+    // Non-prod hosts redirect within their own environment, never
+    // across to production.
+    expect(classifyStorefrontHost("www.mark8ly.dev")).toEqual({
+      kind: "marketing",
+      redirectTo: "mark8ly.dev",
+    });
   });
 
   it("recognises custom domains as needing API resolution", () => {
@@ -51,9 +81,20 @@ describe("classifyStorefrontHost", () => {
   it("treats localhost as marketing for dev iteration — REGRESSION GUARD", () => {
     // Local dev points at localhost:port; the storefront page-level code
     // falls back to DEFAULT_STORE_SLUG. We don't want middleware to 404
-    // here or `npm run dev` breaks.
-    expect(classifyStorefrontHost("localhost")).toEqual({ kind: "marketing" });
-    expect(classifyStorefrontHost("localhost:4203")).toEqual({ kind: "marketing" });
+    // here or `npm run dev` breaks — and `redirectTo: null` keeps it from
+    // bouncing the developer out to the production marketing site.
+    expect(classifyStorefrontHost("localhost")).toEqual({
+      kind: "marketing",
+      redirectTo: null,
+    });
+    expect(classifyStorefrontHost("localhost:4203")).toEqual({
+      kind: "marketing",
+      redirectTo: null,
+    });
+    expect(classifyStorefrontHost("127.0.0.1")).toEqual({
+      kind: "marketing",
+      redirectTo: null,
+    });
   });
 
   it("recognises the UAT slug subdomain pattern and returns the canonical slug", () => {
@@ -74,10 +115,22 @@ describe("classifyStorefrontHost", () => {
     // The bare UAT canonical hosts (uat, admin-uat, onboarding-uat,
     // uat-landing) are NOT tenant slugs — each has its own VirtualService
     // routing to a different service.
-    expect(classifyStorefrontHost("uat.mark8ly.com")).toEqual({ kind: "marketing" });
-    expect(classifyStorefrontHost("admin-uat.mark8ly.com")).toEqual({ kind: "marketing" });
-    expect(classifyStorefrontHost("onboarding-uat.mark8ly.com")).toEqual({ kind: "marketing" });
-    expect(classifyStorefrontHost("uat-landing.mark8ly.com")).toEqual({ kind: "marketing" });
+    expect(classifyStorefrontHost("uat.mark8ly.com")).toEqual({
+      kind: "marketing",
+      redirectTo: null,
+    });
+    expect(classifyStorefrontHost("admin-uat.mark8ly.com")).toEqual({
+      kind: "marketing",
+      redirectTo: null,
+    });
+    expect(classifyStorefrontHost("onboarding-uat.mark8ly.com")).toEqual({
+      kind: "marketing",
+      redirectTo: null,
+    });
+    expect(classifyStorefrontHost("uat-landing.mark8ly.com")).toEqual({
+      kind: "marketing",
+      redirectTo: null,
+    });
   });
 
   it("rejects UAT admin-shaped hosts that hit storefront in error", () => {

--- a/apps/storefront/lib/host-policy.ts
+++ b/apps/storefront/lib/host-policy.ts
@@ -4,11 +4,22 @@
 // {slug}.mark8ly.com URL shape. The mark8ly.com / www.mark8ly.com
 // apex is reserved for marketing (a different app) — if a request
 // for it ever lands on the storefront pod (Istio config drift,
-// dev shortcut, …) we 404 instead of silently rendering DEFAULT_STORE
-// content under the wrong brand.
+// dev shortcut, …) we must not silently render DEFAULT_STORE content
+// under the wrong brand.
+//
+// `www` is the one marketing host that gets special treatment. It is a
+// real, public, brand-owned hostname that people type and Google crawls,
+// and in prod it currently lands here rather than on the marketing app.
+// Serving it a "Store not found" body with a 200 makes it a soft 404 on
+// the brand's own front door (#147). So `www` carries the canonical apex
+// to 301 to; every other marketing host carries `null` and is passed
+// through unchanged, because a hit on `api.` or `admin.` is routing
+// drift we'd rather surface than paper over with a redirect.
 
 export type StorefrontHostClassification =
-  | { kind: "marketing" } // mark8ly.com / www.mark8ly.com — not a store
+  // mark8ly.com / www.mark8ly.com / api. / admin. — not a store.
+  // `redirectTo` is the apex host to 301 to, or null to pass through.
+  | { kind: "marketing"; redirectTo: string | null }
   | { kind: "slug"; slug: string } // {slug}.mark8ly.com
   | { kind: "custom"; domain: string } // off-mark8ly host — resolve via API
   | { kind: "unknown" };
@@ -39,7 +50,11 @@ export function classifyStorefrontHost(
   const host = hostHeader.split(":")[0]?.toLowerCase() ?? "";
   if (!host) return { kind: "unknown" };
 
-  if (host === "localhost" || host === "127.0.0.1") return { kind: "marketing" };
+  // Local dev serves the storefront straight off localhost — never
+  // bounce a developer out to the production marketing site.
+  if (host === "localhost" || host === "127.0.0.1") {
+    return { kind: "marketing", redirectTo: null };
+  }
 
   const parts = host.split(".");
   if (parts.length < 2) return { kind: "unknown" };
@@ -48,11 +63,17 @@ export function classifyStorefrontHost(
   if (MARK8LY_TLDS.has(tld)) {
     if (parts.length === 2) {
       // Bare apex — mark8ly.com itself. Marketing site, not storefront.
-      return { kind: "marketing" };
+      // No redirect target: it IS the canonical host, and pointing it at
+      // itself would loop.
+      return { kind: "marketing", redirectTo: null };
     }
     const first = parts[0] ?? "";
     if (!first) return { kind: "unknown" };
-    if (RESERVED_SUBDOMAINS.has(first)) return { kind: "marketing" };
+    if (RESERVED_SUBDOMAINS.has(first)) {
+      // `www.<tld>` is the public brand alias — send it to the apex of
+      // its own TLD so mark8ly.dev / lvh.me dev hosts stay in their env.
+      return { kind: "marketing", redirectTo: first === "www" ? tld : null };
+    }
     if (first.endsWith("-admin")) return { kind: "unknown" }; // admin host hit storefront pod
     if (first.endsWith("-admin-uat")) return { kind: "unknown" }; // UAT admin host hit storefront pod
     // UAT mirror: `{slug}-uat.mark8ly.com` is the UAT analog of prod's

--- a/apps/storefront/middleware.ts
+++ b/apps/storefront/middleware.ts
@@ -66,9 +66,23 @@ async function handleRequest(
   // mark8ly.com / www.mark8ly.com / api.mark8ly.com / admin.mark8ly.com:
   // not storefront surfaces. Marketing site is a separate app — Istio
   // routes those hosts elsewhere in prod, so a hit here means config
-  // drift. 404 cleanly instead of rendering DEFAULT_STORE under the
-  // wrong brand.
+  // drift.
+  //
+  // `www` is the case that actually reaches us in prod, and letting it
+  // fall through rendered a "Store not found" body under a 200 — a soft
+  // 404 on the brand's front door, which Google reports as an indexing
+  // error (#147). Send it to the apex instead: a 301 is the correct
+  // answer for a brand alias and consolidates link authority onto the
+  // canonical host. Other marketing hosts keep passing through, so
+  // genuine routing drift stays visible rather than being redirected away.
   if (hostKind.kind === "marketing") {
+    if (hostKind.redirectTo) {
+      const target = new URL(req.nextUrl);
+      target.host = hostKind.redirectTo;
+      target.protocol = "https:";
+      target.port = "";
+      return NextResponse.redirect(target, 301);
+    }
     return passthrough(req, nonce, csp);
   }
 

--- a/packages/ui/src/mail-link.tsx
+++ b/packages/ui/src/mail-link.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+
+/* ============================================================
+   MailLink — the only way a `mailto:` anchor should be rendered
+   on any Mark8ly surface. See GitHub issue #147.
+
+   Cloudflare's "Email Address Obfuscation" feature rewrites every
+   literal `mailto:` link in the *served* HTML into
+   `<a href="/cdn-cgi/l/email-protection#...">`. On mark8ly.com that
+   path 404s — the Cloudflare Tunnel forwards /cdn-cgi straight to
+   the Next.js origin, which has no such route. That means:
+
+     1. Googlebot crawls a 404 off every legal/contact page (the GSC
+        "Not found (404)" report).
+     2. Worse: a real visitor clicking the address gets a 404 page
+        instead of their mail client. Live UX bug, not just SEO.
+
+   Cloudflare's obfuscation officially honours an opt-out marker:
+   anything between the literal HTML comments `<!--email_off-->`
+   and `<!--email_on-->` is left untouched. React can't render bare
+   comment nodes, so we emit them as the innerHTML of invisible
+   `<span>` wrappers either side of the anchor. Do NOT delete these
+   spans as "dead markup" — they are the entire fix.
+
+   Lives in @repo/ui because the bug is a property of the Cloudflare
+   edge, not of any one app: it applies to every public surface we
+   serve through that edge. Consumers today are the onboarding
+   marketing site and admin's public /pricing page.
+
+   Do not render a raw `mailto:` anchor anywhere else; always go
+   through this component instead.
+   ============================================================ */
+
+interface MailLinkProps {
+  email: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+export function MailLink({ email, className, children }: MailLinkProps) {
+  return (
+    <>
+      <span aria-hidden dangerouslySetInnerHTML={{ __html: "<!--email_off-->" }} />
+      <a href={`mailto:${email}`} className={className}>
+        {children ?? email}
+      </a>
+      <span aria-hidden dangerouslySetInnerHTML={{ __html: "<!--email_on-->" }} />
+    </>
+  );
+}

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -84,6 +84,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/handlers/webhooks"
 	"github.com/mark8ly/marketplace-api/internal/health"
 	"github.com/mark8ly/marketplace-api/internal/ipprivacy"
+	"github.com/mark8ly/marketplace-api/internal/journal"
 	"github.com/mark8ly/marketplace-api/internal/k8sprov"
 	"github.com/mark8ly/marketplace-api/internal/loyalty"
 	"github.com/mark8ly/marketplace-api/internal/media"
@@ -305,6 +306,17 @@ func main() {
 		log.Error("db open", "err", err)
 		os.Exit(1)
 	}
+
+	// Journal "coming soon" page email capture (#153). Built here,
+	// unconditionally, rather than inside the admin-only wiring block
+	// below: unlike delhiveryWebhookHandler it has no admin-specific
+	// dependency (shipments, carrier secrets) — it only needs the DB
+	// connection every mode already has. Mounted via RegisterPublic on
+	// the same two engines (mode.Both, mode.Admin) as the rest of the
+	// public group; see internal/handlers/public/routes.go for why a
+	// tenant-free record is not on mode.Storefront.
+	journalSubscribeHandler := public.NewJournalSubscribeHandler(
+		journal.NewRepository(conn), journal.NewRateLimiter(), log)
 
 	// ─── Email templates loader (B1f) ───────────────────────────────────
 	// DB-backed templates with embedded fallback. tesserix-home authors
@@ -2218,6 +2230,7 @@ func main() {
 		storefront.RegisterMobileStorefrontSupport(r.Group("/api/v1"), storefrontSupportHandler, storefrontDeps.SlugCache, storefrontCustomerVerifier)
 		public.RegisterPublic(r.Group("/api/v1"), public.PublicDeps{
 			DelhiveryWebhookHandler: delhiveryWebhookHandler,
+			JournalSubscribeHandler: journalSubscribeHandler,
 		})
 		if brandingSeeder != nil {
 			brandingSeeder.Register(r.Group("/api/v1/test"))
@@ -2366,6 +2379,7 @@ func main() {
 			// ShipmentsHandler.
 			public.RegisterPublic(engine.Group("/api/v1"), public.PublicDeps{
 				DelhiveryWebhookHandler: delhiveryWebhookHandler,
+				JournalSubscribeHandler: journalSubscribeHandler,
 			})
 			if countryPublicHandler != nil {
 				engine.GET("/api/v1/public/supported-countries", countryPublicHandler.ListSupported)

--- a/services/marketplace-api/internal/customererasure/coverage_integration_test.go
+++ b/services/marketplace-api/internal/customererasure/coverage_integration_test.go
@@ -55,6 +55,7 @@ var declaredExclusions = map[string]string{
 	"tenant_sso_user_mappings":  "merchant SSO identity, not a customer",
 	"promo_redemptions":         "subscription promo-code redemption (§7). Its `email` is the MERCHANT's billing address — promo.Service writes normaliseEmail(in.MerchantEmail) (internal/promo/service.go:156) and the row references a subscription_id, not an order. Anonymising it during a customer erasure would rewrite a merchant's own billing record",
 	"customer_erasure_requests": "the request itself — its own status and receipt are the evidence the erasure happened, and destroying it would destroy the proof",
+	"journal_subscribers":       "mark8ly.com marketing-list signup (#153), not a merchant's customer. The table carries no store_id and no tenant_id by design — a subscriber belongs to the platform, not to any store — so a store-scoped erasure plan has no key to reach it by, and erasing on a customer's request would delete a platform subscription that customer may never have made. NOT a statement that these addresses are unerasable: they are personal data and still carry an art.17 right, exercised against the platform rather than through a merchant's store-scoped flow",
 }
 
 // TestErasurePlan_CoversEveryCustomerLinkedTable fails when a table exists

--- a/services/marketplace-api/internal/handlers/public/journal_subscribe.go
+++ b/services/marketplace-api/internal/handlers/public/journal_subscribe.go
@@ -1,0 +1,75 @@
+package public
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/marketplace-api/internal/journal"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+)
+
+// journalSubscriber is the slice of *journal.Repository this handler
+// needs. Accepting the interface (rather than the concrete type) keeps
+// the handler testable without a database.
+type journalSubscriber interface {
+	Subscribe(email, source string) error
+}
+
+// JournalSubscribeHandler serves the public, tenant-free Journal email
+// capture endpoint behind "Notify me when the first piece goes up" on
+// mark8ly.com/blog (#153). It is mounted by RegisterPublic rather than
+// under the tenant-scoped storefront/admin route groups — see
+// migrations/000124_journal_subscribers.up.sql for why a Journal
+// subscriber has no tenant_id to route through in the first place.
+type JournalSubscribeHandler struct {
+	repo    journalSubscriber
+	limiter *journal.RateLimiter
+	logger  *slog.Logger
+}
+
+// NewJournalSubscribeHandler constructs a JournalSubscribeHandler.
+func NewJournalSubscribeHandler(repo journalSubscriber, limiter *journal.RateLimiter, logger *slog.Logger) *JournalSubscribeHandler {
+	return &JournalSubscribeHandler{repo: repo, limiter: limiter, logger: logger}
+}
+
+// Subscribe handles POST /journal/subscribe. Anonymous and unauthenticated
+// by design — it is called from the onboarding app's server on behalf of
+// an anonymous visitor of the public marketing site, never from a
+// logged-in session. Rate limited by client IP since it is a public,
+// unauthenticated write endpoint that will be scraped and spammed.
+//
+// Always returns 200 for a syntactically valid email — including one
+// that is already subscribed — so the response never leaks whether an
+// address was previously seen (see #153 requirements).
+func (h *JournalSubscribeHandler) Subscribe(c *gin.Context) {
+	if h.limiter != nil && !h.limiter.Allow(c.ClientIP()) {
+		c.AbortWithStatusJSON(http.StatusTooManyRequests, journalErrEnvelope(
+			apperrors.CodeRateLimited, "too many requests, please try again later"))
+		return
+	}
+
+	var req journal.SubscribeInput
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, journalErrEnvelope(
+			apperrors.CodeValidationFailed, "a valid email address is required"))
+		return
+	}
+
+	if err := h.repo.Subscribe(req.Email, journal.SourceJournal); err != nil {
+		if h.logger != nil {
+			h.logger.Error("journal subscribe failed",
+				slog.String("err", err.Error()))
+		}
+		c.AbortWithStatusJSON(http.StatusInternalServerError, journalErrEnvelope(
+			"internal", "internal server error"))
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"subscribed": true})
+}
+
+func journalErrEnvelope(code apperrors.Code, msg string) gin.H {
+	return gin.H{"error": string(code), "message": msg}
+}

--- a/services/marketplace-api/internal/handlers/public/journal_subscribe_test.go
+++ b/services/marketplace-api/internal/handlers/public/journal_subscribe_test.go
@@ -1,0 +1,142 @@
+package public
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/journal"
+)
+
+// fakeJournalRepo records every Subscribe call so tests can assert on
+// normalization and idempotency without a database.
+type fakeJournalRepo struct {
+	calls []string
+	err   error
+}
+
+func (f *fakeJournalRepo) Subscribe(email, source string) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.calls = append(f.calls, email+"|"+source)
+	return nil
+}
+
+func newJournalTestRouter(repo *fakeJournalRepo, limiter *journal.RateLimiter) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	h := NewJournalSubscribeHandler(repo, limiter, slog.Default())
+	r := gin.New()
+	r.POST("/api/v1/journal/subscribe", h.Subscribe)
+	return r
+}
+
+func postJournalSubscribe(r *gin.Engine, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/journal/subscribe", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestJournalSubscribe_ValidEmailSucceeds(t *testing.T) {
+	repo := &fakeJournalRepo{}
+	r := newJournalTestRouter(repo, journal.NewRateLimiter())
+
+	w := postJournalSubscribe(r, `{"email":"Ada@Example.COM"}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.JSONEq(t, `{"subscribed":true}`, w.Body.String())
+	// Normalization (trim + lowercase) happens in the repository layer
+	// (see journal.NormalizeEmail and repository_integration_test.go) —
+	// the handler's job is just to pass the validated email through with
+	// the right source.
+	require.Equal(t, []string{"Ada@Example.COM|journal"}, repo.calls)
+}
+
+func TestJournalSubscribe_MalformedEmailRejected(t *testing.T) {
+	repo := &fakeJournalRepo{}
+	r := newJournalTestRouter(repo, journal.NewRateLimiter())
+
+	w := postJournalSubscribe(r, `{"email":"not-an-email"}`)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.JSONEq(t, `{"error":"validation_failed","message":"a valid email address is required"}`, w.Body.String())
+	require.Empty(t, repo.calls, "malformed input must never reach the repository")
+}
+
+func TestJournalSubscribe_MissingEmailRejected(t *testing.T) {
+	repo := &fakeJournalRepo{}
+	r := newJournalTestRouter(repo, journal.NewRateLimiter())
+
+	w := postJournalSubscribe(r, `{}`)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Empty(t, repo.calls)
+}
+
+func TestJournalSubscribe_OversizedEmailRejected(t *testing.T) {
+	repo := &fakeJournalRepo{}
+	r := newJournalTestRouter(repo, journal.NewRateLimiter())
+
+	longLocal := make([]byte, journal.MaxEmailLength)
+	for i := range longLocal {
+		longLocal[i] = 'a'
+	}
+	body := `{"email":"` + string(longLocal) + `@example.com"}`
+
+	w := postJournalSubscribe(r, body)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Empty(t, repo.calls, "an absurdly long email must be rejected before it reaches storage")
+}
+
+// Idempotency at the handler layer: two identical submissions both
+// return 200. The "one row" guarantee itself is proven by the
+// repository's ON CONFLICT DO NOTHING (see repository_integration_test.go);
+// this test proves the handler never turns a duplicate into a 409/500.
+func TestJournalSubscribe_ResubmittingSameEmailStillReturns200(t *testing.T) {
+	repo := &fakeJournalRepo{}
+	r := newJournalTestRouter(repo, journal.NewRateLimiter())
+
+	first := postJournalSubscribe(r, `{"email":"ada@example.com"}`)
+	second := postJournalSubscribe(r, `{"email":"ada@example.com"}`)
+
+	require.Equal(t, http.StatusOK, first.Code)
+	require.Equal(t, http.StatusOK, second.Code)
+}
+
+func TestJournalSubscribe_RepositoryErrorReturns500WithoutLeakingDetail(t *testing.T) {
+	repo := &fakeJournalRepo{err: assertError("db is down")}
+	r := newJournalTestRouter(repo, journal.NewRateLimiter())
+
+	w := postJournalSubscribe(r, `{"email":"ada@example.com"}`)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.JSONEq(t, `{"error":"internal","message":"internal server error"}`, w.Body.String())
+}
+
+func TestJournalSubscribe_RateLimitedAfterMaxRequestsFromSameIP(t *testing.T) {
+	repo := &fakeJournalRepo{}
+	limiter := journal.NewRateLimiter()
+	r := newJournalTestRouter(repo, limiter)
+
+	var last *httptest.ResponseRecorder
+	for i := 0; i < journal.SubscribeRateMax; i++ {
+		last = postJournalSubscribe(r, `{"email":"ada@example.com"}`)
+		require.Equal(t, http.StatusOK, last.Code)
+	}
+
+	blocked := postJournalSubscribe(r, `{"email":"ada@example.com"}`)
+	require.Equal(t, http.StatusTooManyRequests, blocked.Code)
+	require.JSONEq(t, `{"error":"rate_limited","message":"too many requests, please try again later"}`, blocked.Body.String())
+}
+
+type assertError string
+
+func (e assertError) Error() string { return string(e) }

--- a/services/marketplace-api/internal/handlers/public/routes.go
+++ b/services/marketplace-api/internal/handlers/public/routes.go
@@ -19,6 +19,10 @@ type PublicDeps struct {
 	// Delhivery. Nil-safe — when absent the route is simply not
 	// mounted, which keeps merchants on polling-only.
 	DelhiveryWebhookHandler *DelhiveryWebhookHandler
+	// JournalSubscribeHandler serves the mark8ly.com Journal "coming
+	// soon" page's email capture (#153). Nil-safe, like the others —
+	// absent in test builds that don't wire a DB.
+	JournalSubscribeHandler *JournalSubscribeHandler
 }
 
 // RegisterPublic mounts all public (unauthenticated) routes onto the given
@@ -40,5 +44,15 @@ func RegisterPublic(router *gin.RouterGroup, deps PublicDeps) {
 		// putting shipping webhooks on a separate root keeps both
 		// surfaces working without either cannibalising the other.
 		router.POST("/carrier-webhooks/delhivery", deps.DelhiveryWebhookHandler.Handle)
+	}
+	if deps.JournalSubscribeHandler != nil {
+		// Deliberately NOT under /storefront or /admin: a journal
+		// subscriber is a platform-level marketing record with no
+		// tenant_id (see migrations/000124), so it has no business
+		// behind TenantMiddleware or any per-tenant route group. This
+		// group — the same one SSO and the Delhivery webhook already
+		// share — is the one genuinely tenant-free public surface this
+		// router exposes.
+		router.POST("/journal/subscribe", deps.JournalSubscribeHandler.Subscribe)
 	}
 }

--- a/services/marketplace-api/internal/journal/models.go
+++ b/services/marketplace-api/internal/journal/models.go
@@ -1,0 +1,54 @@
+// Package journal provides the domain model and repository behind
+// mark8ly.com's marketing-site email capture (#153). The first caller is
+// the Journal "coming soon" page's "Notify me when the first piece goes
+// up" field; the table's `source` column lets other capture points reuse
+// it later without a new migration.
+//
+// Subscribers are a platform-level record with no tenant_id — see
+// migrations/000124_journal_subscribers.up.sql for why this table sits
+// outside the tenant model that every other table in this service uses.
+package journal
+
+import (
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SourceJournal identifies signups captured from the /blog "coming soon"
+// page. A named constant rather than a literal at the call site, so a
+// second capture point can define its own SourceXxx and reuse this same
+// table with no migration required.
+const SourceJournal = "journal"
+
+// MaxEmailLength matches the journal_subscribers.email column width
+// (migration 000124) and RFC 5321's practical mailbox length ceiling.
+const MaxEmailLength = 254
+
+// Subscriber maps to the journal_subscribers table.
+type Subscriber struct {
+	ID        uuid.UUID `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	Email     string    `gorm:"column:email;type:varchar(254);not null" json:"email"`
+	Source    string    `gorm:"column:source;type:varchar(40);not null;default:journal" json:"source"`
+	CreatedAt time.Time `gorm:"column:created_at;not null;default:now()" json:"created_at"`
+}
+
+// TableName pins the GORM table name explicitly rather than relying on
+// pluralization inference.
+func (Subscriber) TableName() string { return "journal_subscribers" }
+
+// SubscribeInput is the JSON binding struct for the public subscribe
+// endpoint. The `email` binding tag rejects malformed or oversized input
+// at the HTTP boundary before it ever reaches the repository; NormalizeEmail
+// is applied afterward so storage matches the unique index's assumptions.
+type SubscribeInput struct {
+	Email string `json:"email" binding:"required,email,max=254"`
+}
+
+// NormalizeEmail trims surrounding whitespace and lowercases the address
+// so that "Foo@Bar.com" and "foo@bar.com" collide on the unique email
+// index instead of creating two rows for the same mailbox.
+func NormalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}

--- a/services/marketplace-api/internal/journal/models_test.go
+++ b/services/marketplace-api/internal/journal/models_test.go
@@ -1,0 +1,25 @@
+package journal_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/journal"
+)
+
+func TestNormalizeEmail_TrimsAndLowercases(t *testing.T) {
+	require.Equal(t, "ada@example.com", journal.NormalizeEmail("  Ada@Example.COM  "))
+}
+
+func TestNormalizeEmail_AlreadyNormalizedIsUnchanged(t *testing.T) {
+	require.Equal(t, "ada@example.com", journal.NormalizeEmail("ada@example.com"))
+}
+
+func TestNormalizeEmail_EmptyStringStaysEmpty(t *testing.T) {
+	require.Equal(t, "", journal.NormalizeEmail("   "))
+}
+
+func TestSubscriber_TableName(t *testing.T) {
+	require.Equal(t, "journal_subscribers", journal.Subscriber{}.TableName())
+}

--- a/services/marketplace-api/internal/journal/ratelimit.go
+++ b/services/marketplace-api/internal/journal/ratelimit.go
@@ -1,0 +1,60 @@
+package journal
+
+import (
+	"sync"
+	"time"
+)
+
+// SubscribeRateWindow is the sliding-window length used for per-IP
+// counting on the public journal subscribe endpoint.
+const SubscribeRateWindow = 10 * time.Minute
+
+// SubscribeRateMax is the number of requests a single IP may make inside
+// SubscribeRateWindow before Allow starts returning false.
+const SubscribeRateMax = 5
+
+// RateLimiter is an in-memory sliding-window counter keyed by client IP.
+// It follows the same shape as internal/breakglass.LoginRateLimiter, but
+// lives in this package rather than importing that one: breakglass is an
+// auth-lockout concern with its own constants and semantics (a hard,
+// DB-persisted lockout on the Nth failure), and reaching into it from a
+// public, unauthenticated marketing endpoint would be a stranger coupling
+// than duplicating the ~20 lines of sliding-window bookkeeping here.
+//
+// Deliberately not shared/Redis-backed, for the same reason breakglass
+// isn't: single-process is good enough for this traffic shape, and a
+// horizontal-scale swap lands behind the same Allow(key) interface.
+type RateLimiter struct {
+	mu       sync.Mutex
+	attempts map[string][]time.Time
+}
+
+// NewRateLimiter returns an empty RateLimiter.
+func NewRateLimiter() *RateLimiter {
+	return &RateLimiter{attempts: map[string][]time.Time{}}
+}
+
+// Allow records an attempt for key (the client IP) and reports whether
+// it is within SubscribeRateMax for the current window.
+func (l *RateLimiter) Allow(key string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := time.Now()
+	cutoff := now.Add(-SubscribeRateWindow)
+
+	bucket := l.attempts[key]
+	fresh := bucket[:0]
+	for _, t := range bucket {
+		if t.After(cutoff) {
+			fresh = append(fresh, t)
+		}
+	}
+	if len(fresh) >= SubscribeRateMax {
+		l.attempts[key] = fresh
+		return false
+	}
+	fresh = append(fresh, now)
+	l.attempts[key] = fresh
+	return true
+}

--- a/services/marketplace-api/internal/journal/ratelimit_test.go
+++ b/services/marketplace-api/internal/journal/ratelimit_test.go
@@ -1,0 +1,34 @@
+package journal_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/journal"
+)
+
+func TestRateLimiter_AllowsUpToMaxWithinWindow(t *testing.T) {
+	l := journal.NewRateLimiter()
+	for i := 0; i < journal.SubscribeRateMax; i++ {
+		require.True(t, l.Allow("1.2.3.4"), "attempt %d should be allowed", i+1)
+	}
+}
+
+func TestRateLimiter_BlocksOnceMaxExceeded(t *testing.T) {
+	l := journal.NewRateLimiter()
+	for i := 0; i < journal.SubscribeRateMax; i++ {
+		require.True(t, l.Allow("1.2.3.4"))
+	}
+	require.False(t, l.Allow("1.2.3.4"), "the request beyond the max must be blocked")
+}
+
+func TestRateLimiter_KeysAreIndependent(t *testing.T) {
+	l := journal.NewRateLimiter()
+	for i := 0; i < journal.SubscribeRateMax; i++ {
+		require.True(t, l.Allow("1.2.3.4"))
+	}
+	require.False(t, l.Allow("1.2.3.4"))
+	// A different client IP has its own, untouched bucket.
+	require.True(t, l.Allow("5.6.7.8"))
+}

--- a/services/marketplace-api/internal/journal/repository.go
+++ b/services/marketplace-api/internal/journal/repository.go
@@ -1,0 +1,32 @@
+package journal
+
+import (
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Repository provides data access for journal subscribers.
+type Repository struct {
+	db *gorm.DB
+}
+
+// NewRepository constructs a Repository.
+func NewRepository(db *gorm.DB) *Repository {
+	return &Repository{db: db}
+}
+
+// Subscribe inserts a subscriber, normalizing the email first. Re-
+// subscribing an address that already exists is a no-op — ON CONFLICT DO
+// NOTHING against the unique index on email — so callers (and, in turn,
+// the HTTP handler) can treat every syntactically valid submission as
+// success without ever learning whether the address was already present.
+func (r *Repository) Subscribe(email, source string) error {
+	sub := &Subscriber{
+		Email:  NormalizeEmail(email),
+		Source: source,
+	}
+	return r.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "email"}},
+		DoNothing: true,
+	}).Create(sub).Error
+}

--- a/services/marketplace-api/internal/journal/repository_integration_test.go
+++ b/services/marketplace-api/internal/journal/repository_integration_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+
+package journal_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/journal"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// journal_subscribers has no tenant_id and no FK into stores/tenants — it
+// is a platform-level marketing table (see migrations/000124's comment) —
+// so unlike most repository integration tests here, there is no
+// testdb.SeedStore fixture to set up first.
+
+func TestSubscribe_InsertsANewRow(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := journal.NewRepository(tx)
+
+	email := uuid.New().String() + "@example.com"
+	require.NoError(t, repo.Subscribe(email, journal.SourceJournal))
+
+	var count int64
+	require.NoError(t, tx.Raw(
+		`SELECT count(*) FROM journal_subscribers WHERE email = ?`, email,
+	).Scan(&count).Error)
+	require.EqualValues(t, 1, count)
+}
+
+// The core requirement: submitting the same email twice must succeed both
+// times and leave exactly one row — never a 500, never a duplicate.
+func TestSubscribe_SameEmailTwiceYieldsOneRow(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := journal.NewRepository(tx)
+
+	email := uuid.New().String() + "@example.com"
+
+	require.NoError(t, repo.Subscribe(email, journal.SourceJournal))
+	require.NoError(t, repo.Subscribe(email, journal.SourceJournal), "resubscribing must not error")
+
+	var count int64
+	require.NoError(t, tx.Raw(
+		`SELECT count(*) FROM journal_subscribers WHERE email = ?`, email,
+	).Scan(&count).Error)
+	require.EqualValues(t, 1, count, "double submit must not create a duplicate row")
+}
+
+// Case variants and surrounding whitespace must collapse to the same
+// normalised row, since the unique index is on the normalised value.
+func TestSubscribe_NormalizesBeforeInsert(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := journal.NewRepository(tx)
+
+	raw := uuid.New().String()
+	mixedCase := "  " + raw + "@Example.COM  "
+	normalized := raw + "@example.com"
+
+	require.NoError(t, repo.Subscribe(mixedCase, journal.SourceJournal))
+	require.NoError(t, repo.Subscribe(normalized, journal.SourceJournal))
+
+	var count int64
+	require.NoError(t, tx.Raw(
+		`SELECT count(*) FROM journal_subscribers WHERE email = ?`, normalized,
+	).Scan(&count).Error)
+	require.EqualValues(t, 1, count)
+}

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 123
+const ExpectedSchemaVersion uint = 124

--- a/services/marketplace-api/migrations/000124_journal_subscribers.down.sql
+++ b/services/marketplace-api/migrations/000124_journal_subscribers.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS journal_subscribers;

--- a/services/marketplace-api/migrations/000124_journal_subscribers.up.sql
+++ b/services/marketplace-api/migrations/000124_journal_subscribers.up.sql
@@ -1,0 +1,33 @@
+-- Migration 124: journal_subscribers — mark8ly.com marketing-site email
+-- capture (#153), starting with the Journal "coming soon" page's
+-- "Notify me when the first piece goes up" field.
+--
+-- This table intentionally carries NO tenant_id. Every other table in
+-- this service is scoped to a merchant tenant (X-Tenant-ID header,
+-- TenantMiddleware, TenantRepository[T]) — a Journal subscriber belongs
+-- to mark8ly.com itself, not to any merchant's store. Bolting on a fake
+-- tenant id here would misrepresent a platform-level marketing record as
+-- tenant data. See internal/handlers/public/journal_subscribe.go for the
+-- handler, which is mounted outside TenantMiddleware for the same reason.
+--
+-- gen_random_uuid() needs no extension: it is core in PostgreSQL 13+
+-- (see migration 000058's comment on gen_random_bytes, which is the
+-- pgcrypto function that DOES need one — this table uses neither).
+CREATE TABLE IF NOT EXISTS journal_subscribers (
+    id         UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Stored normalised (trimmed + lowercased) by the repository so the
+    -- unique index below actually catches "Foo@Bar.com" vs "foo@bar.com".
+    email      VARCHAR(254) NOT NULL,
+    -- Capture point, e.g. 'journal'. Lets this same table serve other
+    -- marketing capture points later (a footer newsletter field, a
+    -- waitlist, etc.) without another migration.
+    source     VARCHAR(40)  NOT NULL DEFAULT 'journal',
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+-- One row per email, full stop. A double submit from the same capture
+-- point — or a resubmission from a second one later — must not create a
+-- duplicate. The repository inserts with ON CONFLICT DO NOTHING against
+-- this index, which is also what makes the endpoint idempotent.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_journal_subscribers_email
+    ON journal_subscribers (email);


### PR DESCRIPTION
Works milestone 6 (**SEO & growth**). Audited every open issue against the live site first, which changed the shape of the work: #151 and #152 turned out to be fully built and shipped already, while the audit surfaced two live bugs nobody had a ticket for.

## What was actually broken

### `www.mark8ly.com` served a soft 404 (`651cda1`)

```
$ curl -s -o /dev/null -w '%{http_code}' https://www.mark8ly.com/
200
$ curl -s https://www.mark8ly.com/ | grep -o '<title>[^<]*</title>'
<title>Store not found</title>
```

**HTTP 200 with an error body**, on the brand's own `www` hostname. `www` routes to the storefront app; `host-policy.ts` classified it as `marketing` correctly, but the middleware comment said *"404 cleanly instead of rendering DEFAULT_STORE under the wrong brand"* while the code beneath it called `passthrough()`. Comment and behaviour had drifted.

It also meant `www.mark8ly.com/robots.txt` served the storefront's robots, advertising `Sitemap: https://default.mark8ly.com/sitemap.xml` — a host whose root is a hard 404.

Now `301`s to the apex of its own TLD. A redirect beats a 404 here: `www` is a real brand alias people type and link, and a 301 consolidates authority onto the canonical apex. Deliberately narrow — the apex itself and platform hosts (`api.`, `admin.`, `uat.`) still pass through so genuine routing drift stays visible, and local dev hosts are never bounced to production.

### Every email address on the site linked to a 404 (`7a4f628`)

Cloudflare's Email Address Obfuscation rewrites `mailto:` into `/cdn-cgi/l/email-protection#...`, and that path 404s here — the Tunnel forwards `/cdn-cgi` straight to the Next.js origin. ~39 anchors across every legal and contact page.

**This was a UX bug before it was an SEO bug:** anyone clicking any email address on the marketing site got a 404 instead of their mail client.

Fixed with a `MailLink` component wrapping each anchor in `<!--email_off-->` / `<!--email_on-->`, the opt-out markers Cloudflare honours. It lives in `@repo/ui` because the bug belongs to the edge rather than any one app — admin's public `/pricing` page had it too. A source-scan test fails the build if a bare `mailto:` anchor is reintroduced.

## Milestone issues

**#149 — `noindex` pages.** The two excluded pages are `/help` and `/integrations`, both thin stubs. Rather than just dropping the tag and handing Google two soft-404 candidates, both got real content first: `/help` is a grouped FAQ with `FAQPage` JSON-LD, `/integrations` is the real integration list traced to the code behind each entry. Both now indexed and in `sitemap.xml`. `/blog`, `/dpa` and the funnel pages stay `noindex`, documented on the issue.

**#153 — two guides + Journal capture.** `how-to-add-your-first-product` and `how-to-connect-your-domain` published, both fact-checked against the actual admin flows. Journal capture is a full vertical slice: a `journal_subscribers` table with **no `tenant_id`** (a subscriber belongs to mark8ly.com, not a merchant), a tenant-free public endpoint that is idempotent and IP-rate-limited and never leaks whether an address was already subscribed, a server-only Next.js proxy, and an accessible form.

**#147, #150** — commented with evidence, left open pending the exact URLs from Search Console. **#151, #152** — verified live and closed.

## Verification

- **Migrations run clean on a fresh database.** Spun a throwaway `postgres:15`, applied all 124 from zero, ran the integration tests against it, then verified the down-migration drops the table and re-up succeeds.
- **Integration tests genuinely pass**, including the double-submit-yields-one-row idempotency test. Worth stating explicitly: they were *failing* when first written because the shared test DB is stuck at schema 119 — this repo's integration tests skip silently and still print `ok` without `TEST_DATABASE_URL`, so "passing" needed proving, not assuming.
- `go build ./...`, `go vet ./...` clean. 54 onboarding unit tests and 81 storefront unit tests pass. `tsc --noEmit` clean for both apps.
- **Not verified: the production build.** `npm install` fails in this worktree on `@tesserix/otto-widget` (GitHub Packages, needs `NODE_AUTH_TOKEN`), so `next build` can't run locally. CI covers it.

## Before merging

⚠️ **`MARKETPLACE_API_URL` must be set on the onboarding deployment** in `tesserix-k8s`, pointing at the marketplace-api **admin** service — the new endpoint is mounted on `mode.Both` and `mode.Admin`, not `mode.Storefront`. Without it the var defaults to `localhost:8088` and the form fails closed with a polite "couldn't save that just now" message. Graceful, but the feature is dead until the env var lands.

Optional: turning off Email Address Obfuscation in Cloudflare → Scrape Shield removes the `/cdn-cgi` root cause outright. The code fix doesn't depend on it and stays correct either way.

## Related

Opened #544 separately — the audit found the **live pricing table advertises two features that don't exist**: "webhooks" on Studio (no outbound webhook delivery exists anywhere in the service) and "custom code injection" on Pro (the plangate flag's own comment calls it a forward-compat hedge with no handler behind it). Both are line items next to a price. Not fixed here because it's a product-copy decision, not SEO work.

Three claims were also cut from the new pages for the same reason — PayPal (removed platform-wide by migration `000121`, though `paypal.go` still exists) and Otto live chat (imported by no page, and its `tenantId` is hardcoded to `"mark8ly"`).
