### PR TITLE
refactor(admin): dock the product form's actions under the header instead of floating them in the rail

### DIFF
--- a/apps/admin/components/products/ProductForm.ActionBar.test.tsx
+++ b/apps/admin/components/products/ProductForm.ActionBar.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import type { AdminCategory, AdminProduct } from "@/lib/api/marketplace-api";
+
+vi.mock("@/app/(admin)/products/actions", () => ({
+  createProductAction: vi.fn(async () => ({ ok: true, data: { id: "p1" } })),
+  updateProductAction: vi.fn(async () => ({ ok: true, data: { id: "p1" } })),
+  deleteProductAction: vi.fn(async () => ({ ok: true })),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+vi.mock("./form/MediaTab", () => ({
+  MediaTab: () => <div data-testid="media-tab-stub" />,
+}));
+
+import { ProductForm } from "./ProductForm";
+
+const categories: AdminCategory[] = [];
+
+const baseProps = {
+  storeId: "s1",
+  categories,
+  currencyCode: "AUD",
+  storeCountryCode: "AU",
+  canDelete: false,
+  canArchive: false,
+  session: { userId: "u1", tenantId: "t1" },
+};
+
+function product(): AdminProduct {
+  return {
+    id: "p1",
+    title: "Bondi Beach Cotton Towel",
+    handle: "bondi-beach-cotton-towel",
+    description: "",
+    status: "active",
+    categories: [],
+    options: [],
+    media: [],
+    variants: [
+      { id: "v1", sku: "A", price: "49", inventory_quantity: 28, option_values: [] },
+    ],
+  } as unknown as AdminProduct;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+// Save moved out of the rail and into a bar docked under the page header.
+// The rail is `self-start`, so it is a short box floating beside a long
+// scrolling column — which is why Save read as "dangling in the middle of
+// the page". The bar is the anchor; these tests keep it from drifting back.
+describe("ProductForm — the docked action bar", () => {
+  it("offers exactly one save control, not one per column", () => {
+    render(<ProductForm {...baseProps} mode="edit" initialProduct={product()} />);
+    expect(screen.getAllByRole("button", { name: /save changes/i })).toHaveLength(1);
+  });
+
+  it("docks to the shell's published topbar height rather than to top-0", () => {
+    const { container } = render(
+      <ProductForm {...baseProps} mode="edit" initialProduct={product()} />,
+    );
+    const bar = container.querySelector(".sticky");
+    expect(bar).not.toBeNull();
+    // AdminShell's own topbar is `sticky top-0 z-30`. A bar at top-0 would
+    // slide underneath it, so this must dock to --admin-topbar-h, which
+    // AdminShell publishes on the ancestor of both the topbar and <main>.
+    expect(bar!.className).toContain("top-[var(--admin-topbar-h)]");
+    expect(bar!.className).not.toContain("top-0");
+  });
+
+  it("keeps the bar flat — no shadow, no backdrop blur", () => {
+    const { container } = render(
+      <ProductForm {...baseProps} mode="edit" initialProduct={product()} />,
+    );
+    const bar = container.querySelector(".sticky")!;
+    // Elevation and blur are what turn a docked bar into dashboard chrome.
+    // The system's cue for "docked" is a single hairline.
+    expect(bar.className).not.toMatch(/shadow-|backdrop-blur/);
+    expect(bar.className).toContain("border-b");
+  });
+
+  it("carries Discard, and Delete only when the user may delete", () => {
+    const { unmount } = render(
+      <ProductForm {...baseProps} mode="edit" initialProduct={product()} />,
+    );
+    expect(screen.getByRole("link", { name: /discard/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /delete product/i })).not.toBeInTheDocument();
+    unmount();
+
+    render(
+      <ProductForm
+        {...baseProps}
+        canDelete
+        mode="edit"
+        initialProduct={product()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /delete product/i })).toBeInTheDocument();
+  });
+
+  it("labels the action for the mode it is in", () => {
+    render(<ProductForm {...baseProps} mode="create" />);
+    expect(screen.getByRole("button", { name: /create product/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /save changes/i })).not.toBeInTheDocument();
+  });
+});
+
+// The rail's remaining job is metadata a merchant glances at, not actions.
+describe("ProductForm — the rail", () => {
+  it("holds status and categories and no longer holds the actions", () => {
+    render(<ProductForm {...baseProps} canDelete mode="edit" initialProduct={product()} />);
+    const rail = screen.getByRole("complementary");
+    expect(rail).toBeInTheDocument();
+    expect(rail.querySelector("button[type=submit]")).toBeNull();
+    expect(rail.textContent).not.toMatch(/discard/i);
+    expect(rail.textContent).not.toMatch(/delete/i);
+  });
+
+  it("is not sticky and draws no vertical rule", () => {
+    render(<ProductForm {...baseProps} mode="edit" initialProduct={product()} />);
+    const rail = screen.getByRole("complementary");
+    // --border-subtle is --paper-300 on a --paper-200 page: ~2% luminance at
+    // 1px, so this rule rendered as nothing at all in production while still
+    // reading as sidebar-panel chrome in the markup.
+    expect(rail.className).not.toMatch(/border-l/);
+    expect(rail.className).not.toMatch(/sticky|self-start/);
+  });
+});

--- a/apps/admin/components/products/ProductForm.tsx
+++ b/apps/admin/components/products/ProductForm.tsx
@@ -461,6 +461,63 @@ export function ProductForm({
           </div>
         )}
 
+        {/* The docked action bar.
+            Save used to live in the rail. The merchant's report was that it
+            "dangled in the middle of the page", and that was an anchoring
+            problem, not a boundary one — the rail is `self-start`, so it is a
+            short box floating beside a long column, and no amount of border
+            fixes that. Here Save has a fixed home: it stays put under the
+            topbar at every scroll position.
+
+            Flat --background, one hairline underneath, no shadow and no
+            backdrop-blur. The bar is part of the page rather than floating
+            above it, which is what keeps it from reading as dashboard chrome.
+
+            top is --admin-topbar-h, published by AdminShell on the ancestor of
+            both its own sticky topbar and <main>. The topbar is `sticky top-0
+            z-30`, so a bar at top-0 would slide underneath it; docking to the
+            shared variable means the two cannot drift apart. z-20 sits below
+            the topbar deliberately — they abut rather than overlap.
+
+            The negative margins let the hairline run the full content width
+            while the controls stay on the page's own left edge. */}
+        <div className="sticky top-[var(--admin-topbar-h)] z-20 -mx-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 border-b border-border-subtle bg-background px-4 py-3 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
+          <div className="flex items-center gap-4">
+            <button
+              type="submit"
+              disabled={isPending}
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-[color:var(--ink-900)] px-5 py-2 text-sm font-medium text-[color:var(--primary-foreground)] transition-colors hover:bg-[color:var(--moss-700)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isPending
+                ? "Saving…"
+                : mode === "create"
+                  ? "Create product"
+                  : "Save changes"}
+            </button>
+            <Link
+              href="/products"
+              onClick={handleDiscard}
+              className="text-sm text-foreground-secondary underline-offset-4 transition-colors hover:text-[color:var(--moss-700)] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]"
+            >
+              Discard
+            </Link>
+            <span className="hidden text-xs text-[color:var(--ink-900)]/40 sm:inline">
+              Changes apply when you save.
+            </span>
+          </div>
+          {mode === "edit" && canDelete && initialProduct && (
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={isPending}
+              className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm text-foreground-secondary transition-colors hover:text-[color:var(--danger)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label="Delete product"
+            >
+              <Trash2 className="h-4 w-4" aria-hidden="true" /> Delete
+            </button>
+          )}
+        </div>
+
         <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_18rem] lg:gap-14">
           <div className="flex flex-col gap-10">
             <ProductSection
@@ -533,49 +590,7 @@ export function ProductForm({
             <TaxSection storeCountryCode={storeCountryCode} />
           </div>
 
-          <ProductRail
-            categories={categories}
-            storeId={storeId}
-            actions={
-              // Stacked in the rail rather than a footer row: on a
-              // scrolling page a bottom-anchored Save is a journey, and
-              // the merchant's most common question ("did that save?")
-              // should never require one.
-              <div className="flex flex-col gap-3">
-                <button
-                  type="submit"
-                  disabled={isPending}
-                  className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-[color:var(--ink-900)] px-5 py-2 text-sm font-medium text-[color:var(--primary-foreground)] transition-colors hover:bg-[color:var(--moss-700)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {isPending
-                    ? "Saving…"
-                    : mode === "create"
-                      ? "Create product"
-                      : "Save changes"}
-                </button>
-                <div className="flex items-center justify-between">
-                  <Link
-                    href="/products"
-                    onClick={handleDiscard}
-                    className="text-sm text-foreground-secondary underline-offset-4 transition-colors hover:text-[color:var(--moss-700)] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]"
-                  >
-                    Discard
-                  </Link>
-                  {mode === "edit" && canDelete && initialProduct && (
-                    <button
-                      type="button"
-                      onClick={handleDelete}
-                      disabled={isPending}
-                      className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm text-foreground-secondary transition-colors hover:text-[color:var(--danger)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-50"
-                      aria-label="Delete product"
-                    >
-                      <Trash2 className="h-4 w-4" aria-hidden="true" /> Delete
-                    </button>
-                  )}
-                </div>
-              </div>
-            }
-          />
+          <ProductRail categories={categories} storeId={storeId} />
         </div>
       </form>
 

--- a/apps/admin/components/products/form/ProductRail.tsx
+++ b/apps/admin/components/products/form/ProductRail.tsx
@@ -1,17 +1,22 @@
 "use client";
 
-// ProductRail — status, categories and the actions, kept in view.
+// ProductRail — the product's metadata: status and categories.
 //
-// These were spread across the top of the General tab and a footer at the
-// bottom of the form. On a scrolling page that means a merchant editing a
-// long description has to travel to publish or save. The rail is the one
-// piece of chrome that earns being sticky: it is the answer to "is this
-// live, and have I saved it".
+// It used to carry Save / Discard / Delete as well, and to be sticky with a
+// hairline down its left edge. Both are gone. Save now lives in a docked
+// action bar under the page header (see ProductForm), which is what actually
+// answers "have I saved this" at any scroll position. A border around a
+// floating control only frames the float; it does not anchor it.
 //
-// Asymmetric by design — a narrow rail beside a wider column, not a
-// centred form.
+// The rule went with it. `self-start` sized this box to its own content, so
+// the border was ~450px tall beside a 2000px column — a stub, not a boundary.
+// It was also invisible in practice: --border-subtle is --paper-300 on a
+// --paper-200 page, roughly 2% luminance at 1px, so it rendered as nothing at
+// all in production. The column already reads as metadata through width
+// asymmetry and the grid gap, which is the editorial convention regardless —
+// magazines divide with whitespace, not rules. A vertical rule is the visual
+// grammar of a sidebar panel, which this system lists as an anti-reference.
 
-import type { ReactNode } from "react";
 import { useFormContext } from "react-hook-form";
 import {
   Select,
@@ -29,55 +34,41 @@ import { Field } from "./Field";
 export interface ProductRailProps {
   categories: AdminCategory[];
   storeId?: string;
-  /** Save / delete / discard, composed by the form. */
-  actions: ReactNode;
 }
 
-export function ProductRail({ categories, storeId, actions }: ProductRailProps) {
+export function ProductRail({ categories, storeId }: ProductRailProps) {
   const { formState, watch, setValue } = useFormContext<ProductFormValues>();
 
   return (
-    // A hairline down the left edge is what makes this read as a COLUMN
-    // rather than controls floating in whitespace. Without it the sticky
-    // Save button appears to dangle in the middle of the page as the long
-    // left column scrolls past it — the elements were right, the boundary
-    // was missing. Hairline rather than a card, per the system.
-    <aside className="lg:sticky lg:top-8 lg:self-start lg:border-l lg:border-border-subtle lg:pl-8">
-      <div className="flex flex-col gap-6">
-        <Field label="Status" error={formState.errors.status?.message}>
-          <Select
-            value={watch("status")}
-            onValueChange={(value) =>
-              setValue("status", value as ProductFormValues["status"], {
-                shouldDirty: true,
-              })
-            }
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="draft">Draft</SelectItem>
-              <SelectItem value="active">Active</SelectItem>
-              <SelectItem value="archived">Archived</SelectItem>
-            </SelectContent>
-          </Select>
-        </Field>
+    <aside className="flex flex-col gap-6">
+      <Field label="Status" error={formState.errors.status?.message}>
+        <Select
+          value={watch("status")}
+          onValueChange={(value) =>
+            setValue("status", value as ProductFormValues["status"], {
+              shouldDirty: true,
+            })
+          }
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="draft">Draft</SelectItem>
+            <SelectItem value="active">Active</SelectItem>
+            <SelectItem value="archived">Archived</SelectItem>
+          </SelectContent>
+        </Select>
+      </Field>
 
-        <Field label="Categories" error={formState.errors.categoryIds?.message}>
-          <ProductCategoriesPicker
-            allCategories={categories}
-            selectedIds={watch("categoryIds")}
-            onChange={(ids) => setValue("categoryIds", ids, { shouldDirty: true })}
-            storeId={storeId}
-          />
-        </Field>
-
-        <div className="border-t border-border-subtle pt-6">{actions}</div>
-        <p className="text-xs text-[color:var(--ink-900)]/40">
-          Changes apply when you save.
-        </p>
-      </div>
+      <Field label="Categories" error={formState.errors.categoryIds?.message}>
+        <ProductCategoriesPicker
+          allCategories={categories}
+          selectedIds={watch("categoryIds")}
+          onChange={(ids) => setValue("categoryIds", ids, { shouldDirty: true })}
+          storeId={storeId}
+        />
+      </Field>
     </aside>
   );
 }

--- a/apps/admin/components/shell/AdminShell.tsx
+++ b/apps/admin/components/shell/AdminShell.tsx
@@ -294,7 +294,11 @@ function AdminShellFrame({
         </SidebarFooter>
       </Sidebar>
 
-      <SidebarInset className="relative bg-background">
+      {/* --admin-topbar-h is published here, on the ancestor of BOTH the
+          topbar and <main>, so page content can dock beneath the sticky
+          topbar without hardcoding its height. The topbar consumes it too,
+          which is what keeps the two from drifting apart. */}
+      <SidebarInset className="relative bg-background [--admin-topbar-h:4.5rem]">
         <header className="sticky top-0 z-30 border-b border-border-subtle bg-background">
           <button
             type="button"
@@ -308,7 +312,7 @@ function AdminShellFrame({
               <ChevronLeft className="h-4 w-4" aria-hidden="true" />
             )}
           </button>
-          <div className="flex h-[4.5rem] items-center justify-between px-5 sm:px-7">
+          <div className="flex h-[var(--admin-topbar-h)] items-center justify-between px-5 sm:px-7">
             <div className="flex items-center gap-3">
               <SidebarTrigger className="-ml-1 md:hidden" />
               {/* Compact section indicator only — the page body owns


### PR DESCRIPTION
Change 1 of 3 from the `ux-design-specialist` pass on the product page. #543 shipped change 2 (the variant matrix); the create form is still to come.

## The report, and why the last fix missed

The merchant's words were that Save "dangled in the middle of the page". I responded by adding `lg:border-l lg:border-border-subtle lg:pl-8` to the rail, to give the column a boundary.

That was the wrong diagnosis, and I confirmed it in production before writing this:

- **The border was invisible.** `--border-subtle` is `--paper-300` (`#ECEAE3`) on a `--paper-200` (`#F7F6F2`) page — roughly 2% luminance at 1px. It rendered as nothing at all. The complaint was never addressed.
- **Even visible, it was the wrong tool.** The rail is `self-start`, so its box is only as tall as its content (~450px) beside a column that scrolls for thousands. The rule would have ended partway down the page — a stub, not a boundary.
- **A border cannot fix an anchoring problem.** "Dangling" is about Save having no fixed, predictable home. Framing a floating control just gives the float a picture frame.

## What this does

Save, Discard and Delete move out of the rail into a bar docked directly under the page header:

- Flat `bg-background`, a single `border-b`, **no shadow and no `backdrop-blur`**. The bar is part of the page rather than floating over it, which is what keeps it from reading as dashboard chrome.
- Negative margins (`-mx-4 sm:-mx-6 lg:-mx-8`) let the hairline span the content width while the controls stay on the page's own left edge.
- "Changes apply when you save." moves with the actions, where it is actually relevant.

The rail keeps Status and Categories, loses the border, and loses `sticky`/`self-start` — those only existed to hold up the border. The two-column grid already reads as content-plus-metadata through width asymmetry and the `lg:gap-14`, which is the editorial convention regardless: magazines divide with whitespace, not rules. A vertical rule is the visual grammar of the sidebar panels this system lists as an anti-reference.

## The topbar collision, checked rather than assumed

`AdminShell` renders its own `sticky top-0 z-30` topbar above `<main>`, so a bar at `top-0` would slide **underneath** it.

Rather than hardcode `4.5rem` in the form where it would silently drift, `AdminShell` now publishes the height as a custom property on `SidebarInset` — the ancestor of both the topbar and `<main>` — and consumes it itself:

```tsx
<SidebarInset className="... [--admin-topbar-h:4.5rem]">
  <header className="sticky top-0 z-30 ...">
    <div className="flex h-[var(--admin-topbar-h)] ...">
```

The form docks to the same variable (`top-[var(--admin-topbar-h)] z-20`), so the two cannot drift apart. `z-20` sits below the topbar deliberately — they abut rather than overlap.

## Tests

`apps/admin`: **111 files, 877 tests, 0 failures** (870 before; +7 here).

New `ProductForm.ActionBar.test.tsx` covers: exactly one save control on the page, docking to `--admin-topbar-h` and never `top-0`, no shadow/blur on the bar, Discard always present with Delete gated on `canDelete`, mode-appropriate labels, and a rail that carries neither actions nor a vertical rule.

Because several of these are absence assertions — the kind that can pass whether or not the feature works — I mutation-checked them. Three mutants, each caught by its intended test:

| mutant | caught by |
|---|---|
| dock at `top-0` | *docks to the shell's published topbar height* |
| rail regains `border-l` + `sticky` | *is not sticky and draws no vertical rule* |
| a second Save added back in the rail | *offers exactly one save control* (+2 more) |

## Not in this PR

- The create form (change 3).
- The unsaved-changes gap: navigating away via a sidebar link with unsaved edits still drops them silently, because only the Discard link is intercepted. `beforeunload` covers refresh/tab-close and cannot be styled. Needs a product decision.