### PR TITLE
fix(admin): stop the product page describing tabs it no longer has, and name option-less variants honestly

### DIFF
--- a/apps/admin/components/products/ProductForm.VariantsWithoutOptions.test.tsx
+++ b/apps/admin/components/products/ProductForm.VariantsWithoutOptions.test.tsx
@@ -133,3 +133,65 @@ describe("ProductForm — editing one option-less variant", () => {
     expect(values.variants?.map((v) => v.price)).toEqual(["999", "120"]);
   });
 });
+
+// The page lost its tabs in #539, but two empty states and both variant
+// section descriptions still described the old layout — pointing at an
+// "Options tab" and an "Otions tab"-era mental model, and calling
+// option-less rows "combinations" when nothing is combined.
+describe("ProductForm — copy for a product whose variants have no options", () => {
+  it("never sends the merchant to a tab", async () => {
+    render(
+      <ProductForm
+        {...baseProps}
+        mode="edit"
+        initialProduct={productWithVariantsButNoOptions()}
+      />,
+    );
+    await screen.findByRole("button", { name: /save changes/i });
+    expect(document.body.textContent).not.toMatch(/\btab\b/i);
+  });
+
+  it("calls them variants, not combinations", async () => {
+    render(
+      <ProductForm
+        {...baseProps}
+        mode="edit"
+        initialProduct={productWithVariantsButNoOptions()}
+      />,
+    );
+    expect(
+      await screen.findByText(/each variant has its own price, stock and SKU/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/each combination/i)).not.toBeInTheDocument();
+  });
+
+  it("warns that adding an option replaces the existing variants", async () => {
+    render(
+      <ProductForm
+        {...baseProps}
+        mode="edit"
+        initialProduct={productWithVariantsButNoOptions()}
+      />,
+    );
+    expect(
+      await screen.findByText(/adding one rebuilds the list above from scratch and replaces them/i),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the combination wording for a product that really has options", async () => {
+    const withOptions = {
+      ...productWithVariantsButNoOptions(),
+      options: [{ id: "o1", name: "Size", values: [{ id: "ov1", value: "S" }, { id: "ov2", value: "M" }] }],
+      variants: [
+        { id: "v1", sku: "S", price: "120", inventory_quantity: 2, option_values: [{ option_name: "Size", value: "S" }] },
+        { id: "v2", sku: "M", price: "120", inventory_quantity: 2, option_values: [{ option_name: "Size", value: "M" }] },
+      ],
+    } as unknown as AdminProduct;
+
+    render(<ProductForm {...baseProps} mode="edit" initialProduct={withOptions} />);
+    expect(
+      await screen.findByText(/each combination has its own price, stock and SKU/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/rebuilds the list above/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/admin/components/products/ProductForm.tsx
+++ b/apps/admin/components/products/ProductForm.tsx
@@ -68,7 +68,7 @@ export interface ProductFormProps {
   initialProduct?: AdminProduct;
   categories: AdminCategory[];
   currencyCode: string;
-  /** ISO 3166-1 alpha-2 code of the store, drives the Tax tab strategy. */
+  /** ISO 3166-1 alpha-2 code of the store, drives the Tax section strategy. */
   storeCountryCode: string;
   canDelete: boolean;
   canArchive: boolean;
@@ -101,6 +101,16 @@ export function ProductForm({
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [discardOpen, setDiscardOpen] = useState(false);
   const hasMultipleVariants = (initialProduct?.variants.length ?? 0) > 1;
+  // Whether this product has real options, as opposed to variants that
+  // simply exist. 8 of the-bondi-store's 12 products have the latter: rows
+  // with prices and SKUs but no product_options at all. Calling those
+  // "combinations" is wrong — there is nothing being combined — and the
+  // consequence of adding an option to them is destructive, so both bits of
+  // copy below adapt on this rather than on variant count alone.
+  const namedOptions = (initialProduct?.options ?? []).filter(
+    (o) => o.name.trim().length > 0,
+  );
+  const hasOptions = namedOptions.length > 0;
   const firstVariant = initialProduct?.variants[0];
 
   // variantId -> warehouseId -> quantity, from the product detail response
@@ -532,9 +542,11 @@ export function ProductForm({
               id="pricing"
               title={hasMultipleVariants ? "Variants" : "Pricing and inventory"}
               description={
-                hasMultipleVariants
-                  ? "Each combination has its own price, stock and SKU."
-                  : "What it costs, and how many you have."
+                !hasMultipleVariants
+                  ? "What it costs, and how many you have."
+                  : hasOptions
+                    ? "Each combination has its own price, stock and SKU."
+                    : "Each variant has its own price, stock and SKU."
               }
             >
               <PricingSection
@@ -554,9 +566,16 @@ export function ProductForm({
               id="options"
               title="Options"
               description={
-                hasMultipleVariants
-                  ? "Size, colour and the like. Changing these regenerates the variants above."
-                  : "Add size, colour or similar to sell this product in several variations."
+                !hasMultipleVariants
+                  ? "Add size, colour or similar to sell this product in several variations."
+                  : hasOptions
+                    ? "Size, colour and the like. Changing these regenerates the variants above."
+                    : // These variants were never built from options, so no
+                      // option value can match them: generateVariants returns
+                      // every existing id in removedIds and Save deletes them.
+                      // Saying so is the difference between an informed choice
+                      // and losing a catalogue.
+                      "These variants have no options. Adding one rebuilds the list above from scratch and replaces them."
               }
             >
               <OptionsTab />

--- a/apps/admin/components/products/form/TaxSection.tsx
+++ b/apps/admin/components/products/form/TaxSection.tsx
@@ -22,7 +22,7 @@ import { TaxTab } from "./TaxTab";
 
 export interface TaxSectionProps {
   /**
-   * Optional: this section renders on the General tab now, so it runs for
+   * Optional: this section renders inline on the product page, so it runs for
    * every product — including callers that never had a country to give.
    * An unknown country falls back to the generic strategy rather than
    * taking the whole form down with it.

--- a/apps/admin/components/products/form/VariantsTab.test.tsx
+++ b/apps/admin/components/products/form/VariantsTab.test.tsx
@@ -37,7 +37,7 @@ function Harness({ variants, onSnapshot }: HarnessProps): ReactElement {
 describe("VariantsTab", () => {
   it("shows empty state when no variants", () => {
     render(<Harness />);
-    expect(screen.getByText(/Add options on the Options tab/i)).toBeInTheDocument();
+    expect(screen.getByText(/Add options below to generate variants/i)).toBeInTheDocument();
   });
 
   const sampleVariants = [

--- a/apps/admin/components/products/form/VariantsTab.tsx
+++ b/apps/admin/components/products/form/VariantsTab.tsx
@@ -41,7 +41,7 @@ export function VariantsTab({
     return (
       <div className="border-t border-[color:var(--ink-100)] py-12 pl-1">
         <p className="font-[family-name:var(--font-serif,'Source_Serif_4',serif)] text-lg text-[color:var(--ink-900)] opacity-80">
-          Add options on the Options tab to generate variants.
+          Add options below to generate variants.
         </p>
       </div>
     );

--- a/apps/admin/components/products/variants/VariantImagePicker.tsx
+++ b/apps/admin/components/products/variants/VariantImagePicker.tsx
@@ -58,7 +58,7 @@ export function VariantImagePicker({
         </div>
       ) : (
         <p className="max-w-[14rem] text-xs text-foreground-tertiary">
-          Upload images on the Media tab to assign them to variants here.
+          Add images in the Media section below, then assign one here.
         </p>
       )}
       {currentMediaId !== null && (

--- a/apps/admin/lib/products/generateVariants.test.ts
+++ b/apps/admin/lib/products/generateVariants.test.ts
@@ -133,3 +133,27 @@ describe("generateVariants", () => {
     expect(result.variants).toHaveLength(500);
   });
 });
+
+// 8 of the-bondi-store's 12 products have variants with no product_options
+// rows. Their variants are keyed by id (`id:<uuid>`, see ProductForm) since
+// there are no option values to compose a key from. Adding a first option
+// therefore matches none of them, and every one is returned for deletion.
+// This is the behaviour the Options section's copy warns about; the test
+// exists so the warning cannot quietly stop being true.
+describe("generateVariants — adding a first option to option-less variants", () => {
+  it("returns every existing variant for removal, because no key can match", () => {
+    const existing = [
+      { id: "v1", key: "id:v1", price: "189", sku: "ROBE-S", stock: 6, weight: 0 },
+      { id: "v2", key: "id:v2", price: "189", sku: "ROBE-M", stock: 4, weight: 0 },
+    ];
+
+    const { variants, removedIds } = generateVariants(
+      [{ name: "Size", values: ["S", "M"] }],
+      existing as never,
+      { price: "189", sku: "", stock: 0, weight: 0 },
+    );
+
+    expect(variants.map((v) => v.key)).toEqual(["Size=S", "Size=M"]);
+    expect(removedIds.sort()).toEqual(["v1", "v2"]);
+  });
+});


### PR DESCRIPTION
Reported from the live page: the Variants section still says *"Add options on the Options tab to generate variants."* There have been no tabs since #539. Reviewing the rest of the page's copy turned up three more problems, one of them not cosmetic.

## 1. Copy pointing at tabs that no longer exist

| where | before | after |
|---|---|---|
| `VariantsTab` empty state | "Add options on the **Options tab** to generate variants." | "Add options **below** to generate variants." |
| `VariantImagePicker` empty state | "Upload images on the **Media tab** to assign them to variants here." | "Add images in the **Media section below**, then assign one here." |

Both now describe the single scrolling page. Two stale code comments (`ProductForm`'s `storeCountryCode` doc, `TaxSection`'s "renders on the General tab now") were corrected in passing.

## 2. "Each combination" is wrong for most of this store's products

The Variants section described itself as *"Each combination has its own price, stock and SKU."* whenever a product had more than one variant.

**8 of the-bondi-store's 12 products have variants but no `product_options` rows at all.** Nothing is being combined — Palm Beach Linen Robe shows `Variant 1` / `Variant 2`, which is precisely what #543 had to introduce because there are no option values to name them with. The copy now adapts:

- has options → "Each combination has its own price, stock and SKU." *(unchanged)*
- variants, no options → "Each variant has its own price, stock and SKU."
- single variant → "What it costs, and how many you have." *(unchanged)*

## 3. The Options section was silent about a destructive action

This is the one worth reading closely. For an option-less product the Options section said:

> "Size, colour and the like. Changing these regenerates the variants above."

That undersells what happens. Those variants are keyed by id (`id:<uuid>`, per #542) because there are no option values to build a key from. Adding a first option produces keys like `Size=S`, which match **none** of them — so `generateVariants` returns every existing variant in `removedIds`, and Save deletes them.

I did not want to write a warning I had not verified, so there is a test proving it:

```
generateVariants — adding a first option to option-less variants
  ✓ returns every existing variant for removal, because no key can match
    variants  → ["Size=S", "Size=M"]
    removedIds → ["v1", "v2"]
```

The copy now says so, only for the products where it is true:

> "These variants have no options. Adding one rebuilds the list above from scratch and replaces them."

This is the same family as #540 — the form holding a loaded gun without saying so. #540 stopped it firing on mount; this makes the remaining, *deliberate* path legible before the merchant takes it.

## Tests

`apps/admin`: **111 files, 882 tests, 0 failures** (877 before; +5 here, and one existing assertion updated to the new string).

New coverage on the option-less product: no occurrence of the word "tab" anywhere in the rendered page, "variant" rather than "combination" wording, the replacement warning present — plus a control case asserting a product that really *does* have options keeps the combination wording and shows no warning.

## Not addressed here

Whether adding an option to an option-less product *should* destroy its variants at all, rather than adopting them into the first option value. That is a behaviour change and a separate decision; this PR only stops the page lying about it.