### PR TITLE
Let journal subscribers erase themselves — the art.17 path #546's erasure exclusion promised

### DIFF
--- a/apps/onboarding/app/api/journal-unsubscribe/route.ts
+++ b/apps/onboarding/app/api/journal-unsubscribe/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from "next/server";
+
+import { config } from "@/lib/config";
+
+// Server-side proxy for the Journal unsubscribe page's erasure request —
+// the counterpart to app/api/journal-subscribe/route.ts. The browser
+// never calls marketplace-api directly — it only ever sees this route,
+// which forwards to marketplace-api's public, tenant-free
+// /api/v1/journal/unsubscribe endpoint using the server-only
+// MARKETPLACE_API_URL (see lib/config.ts).
+export const dynamic = "force-dynamic";
+
+interface JournalUnsubscribeResponse {
+  ok: boolean;
+  message?: string;
+}
+
+function jsonResponse(
+  body: JournalUnsubscribeResponse,
+  status: number,
+): NextResponse {
+  return NextResponse.json(body, { status });
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  let token: unknown;
+  try {
+    const parsed = (await request.json()) as { token?: unknown };
+    token = parsed.token;
+  } catch {
+    return jsonResponse(
+      { ok: false, message: "That unsubscribe link looks incomplete." },
+      400,
+    );
+  }
+
+  if (typeof token !== "string" || token.trim() === "") {
+    return jsonResponse(
+      { ok: false, message: "That unsubscribe link looks incomplete." },
+      400,
+    );
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(
+      `${config.marketplaceApiUrl}/api/v1/journal/unsubscribe`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+        cache: "no-store",
+      },
+    );
+  } catch (error: unknown) {
+    // marketplace-api unreachable (network error, DNS, connection refused).
+    // The visitor gets a plain, human message — never a stack trace, and
+    // never a silent no-op that looks like success.
+    console.error("journal-unsubscribe: marketplace-api unreachable", error);
+    return jsonResponse(
+      {
+        ok: false,
+        message:
+          "We couldn't reach the server just now — please try again in a moment.",
+      },
+      502,
+    );
+  }
+
+  if (upstream.status === 429) {
+    return jsonResponse(
+      { ok: false, message: "Too many attempts. Please try again shortly." },
+      429,
+    );
+  }
+
+  if (!upstream.ok) {
+    // marketplace-api's /journal/unsubscribe always returns 200 for a
+    // syntactically valid request, whether or not the token was
+    // recognised — see internal/handlers/public/journal_unsubscribe.go.
+    // A non-2xx here means something actually broke upstream, not "bad
+    // token", so this is the one place that's allowed to read as a real
+    // failure to the visitor.
+    return jsonResponse(
+      { ok: false, message: "Something went wrong. Please try again." },
+      upstream.status >= 500 ? 502 : 400,
+    );
+  }
+
+  return jsonResponse({ ok: true }, 200);
+}

--- a/apps/onboarding/app/journal/unsubscribe/page.tsx
+++ b/apps/onboarding/app/journal/unsubscribe/page.tsx
@@ -1,0 +1,58 @@
+import { Suspense } from "react";
+import { MailLink } from "@repo/ui/mail-link";
+
+import {
+  MarketingPage,
+  PageHero,
+  Prose,
+} from "@/components/marketing/primitives";
+import { JournalUnsubscribeConfirm } from "@/components/marketing/JournalUnsubscribeConfirm";
+import { JournalUnsubscribeTokenReader } from "@/components/marketing/JournalUnsubscribeTokenReader";
+
+// Never indexed — this is a private action page reached only via a
+// per-subscriber emailed link, not a destination anyone should land on
+// from search.
+export const metadata = {
+  title: "Unsubscribe",
+  robots: { index: false, follow: false },
+  alternates: { canonical: "/journal/unsubscribe" },
+};
+
+// Rendered per request so the CSP nonce reaches the client component's
+// script tags — same reasoning as app/onboarding/verify/page.tsx.
+export const dynamic = "force-dynamic";
+
+export default function JournalUnsubscribePage() {
+  return (
+    <MarketingPage>
+      <PageHero
+        eyebrow="Journal"
+        title={<>Unsubscribe.</>}
+        lede="Stop receiving Journal emails and remove your address from our marketing list."
+      />
+
+      <Prose>
+        {/* JournalUnsubscribeTokenReader reads ?token= via useSearchParams
+            (client-only), so it's wrapped in Suspense — same pattern as
+            VerifyMagicLink on /onboarding/verify. See
+            JournalUnsubscribeConfirm.tsx for why confirmation requires an
+            explicit click and never fires from a mount/effect. */}
+        <Suspense
+          fallback={<p className="text-foreground-secondary">Loading…</p>}
+        >
+          <JournalUnsubscribeTokenReader>
+            {(token) => <JournalUnsubscribeConfirm token={token} />}
+          </JournalUnsubscribeTokenReader>
+        </Suspense>
+
+        <h2>Deleted the email already?</h2>
+        <p>
+          If you no longer have the unsubscribe link, we can&rsquo;t look up
+          your address by token — email <MailLink email="privacy@mark8ly.com" />{" "}
+          from the address you subscribed with and we&rsquo;ll remove it by
+          hand.
+        </p>
+      </Prose>
+    </MarketingPage>
+  );
+}

--- a/apps/onboarding/app/privacy/page.tsx
+++ b/apps/onboarding/app/privacy/page.tsx
@@ -183,6 +183,12 @@ export default function PrivacyPolicyPage() {
             <strong>Backups:</strong> rotated on a schedule not exceeding 90
             days; deletion propagates on the next rotation.
           </li>
+          <li>
+            <strong>Journal subscribers:</strong> if you&rsquo;ve given us
+            your email to hear about new Journal posts, we keep it until
+            you unsubscribe using the link in any Journal email, or ask us
+            to remove it directly.
+          </li>
         </ul>
         <p>
           You may request earlier deletion under section 8.

--- a/apps/onboarding/components/marketing/JournalUnsubscribeConfirm.tsx
+++ b/apps/onboarding/components/marketing/JournalUnsubscribeConfirm.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+// JournalUnsubscribeConfirm — the erasure counterpart to
+// JournalSignupForm (#153's email capture). Renders the confirm screen
+// for /journal/unsubscribe?token=...
+//
+// CRITICAL: this component must NEVER submit the unsubscribe request on
+// mount, in a useEffect, or from anything other than a direct click on
+// the confirm button below. Email clients and security scanners
+// routinely prefetch links in the body of an email — including this
+// one — before a human ever opens it. If loading this page were enough
+// to unsubscribe someone, every prefetch would silently unsubscribe a
+// person who never clicked anything. Do NOT "simplify" this into a
+// useEffect that fires on mount; that reintroduces exactly this bug.
+// See tests/unit/journal-unsubscribe-confirm.spec.tsx, which asserts
+// the API is never called just from rendering this component.
+
+import { useState } from "react";
+
+// Relative import (not the usual "@/lib/api/..." alias) so this
+// component's own source can be loaded directly by
+// tests/unit/journal-unsubscribe-confirm.spec.tsx via loadTsxExport
+// (tests/unit/helpers/load-tsx.ts) — that loader's plain `require()` of
+// the transpiled output has no tsconfig "paths" resolution, so an
+// alias import would fail only inside that test, not in the real build.
+import { unsubscribeFromJournal } from "../../lib/api/journal-unsubscribe";
+
+import {
+  JournalUnsubscribeFields,
+  type JournalUnsubscribeStatus,
+} from "./JournalUnsubscribeFields";
+
+interface JournalUnsubscribeConfirmProps {
+  /** The `?token=` query param, or null/blank if absent. */
+  token: string | null;
+}
+
+export function JournalUnsubscribeConfirm({
+  token,
+}: JournalUnsubscribeConfirmProps) {
+  const [status, setStatus] = useState<JournalUnsubscribeStatus>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const trimmedToken = token?.trim() ?? "";
+
+  if (trimmedToken === "") {
+    return (
+      <p className="text-foreground-secondary">
+        This unsubscribe link looks incomplete — it&rsquo;s missing its token.
+        If you copied the link by hand, try clicking it directly from the email
+        instead. Otherwise, get in touch at{" "}
+        <a
+          href="/contact"
+          className="underline decoration-moss-700 decoration-2 underline-offset-4 hover:text-moss-700"
+        >
+          /contact
+        </a>{" "}
+        and we&rsquo;ll remove your address by hand.
+      </p>
+    );
+  }
+
+  async function handleConfirm() {
+    // Guarded so a second click while a request is in flight (or after
+    // it already succeeded) can't fire a duplicate request — the button
+    // is also disabled in those states, but this keeps the handler
+    // itself safe regardless of how it's invoked.
+    if (status === "submitting" || status === "done") return;
+
+    setStatus("submitting");
+    setErrorMessage(null);
+
+    const result = await unsubscribeFromJournal(trimmedToken);
+
+    if (result.ok) {
+      setStatus("done");
+      return;
+    }
+
+    setStatus("error");
+    setErrorMessage(result.message);
+  }
+
+  return (
+    <JournalUnsubscribeFields
+      status={status}
+      errorMessage={errorMessage}
+      onConfirm={() => {
+        void handleConfirm();
+      }}
+    />
+  );
+}

--- a/apps/onboarding/components/marketing/JournalUnsubscribeFields.tsx
+++ b/apps/onboarding/components/marketing/JournalUnsubscribeFields.tsx
@@ -1,0 +1,62 @@
+export type JournalUnsubscribeStatus = "idle" | "submitting" | "done" | "error";
+
+interface JournalUnsubscribeFieldsProps {
+  status: JournalUnsubscribeStatus;
+  errorMessage: string | null;
+  onConfirm: () => void;
+}
+
+/**
+ * Presentational half of JournalUnsubscribeConfirm — pure props in,
+ * markup out, no hooks, no fetch. Split out for the same reason
+ * JournalSignupFields is: it can be exercised with
+ * `renderToStaticMarkup` in tests (see
+ * tests/unit/journal-unsubscribe-fields.spec.tsx) without needing a DOM
+ * or a click simulator.
+ *
+ * The button here is the ONLY thing that ever triggers onConfirm — see
+ * JournalUnsubscribeConfirm.tsx for why nothing in this feature may ever
+ * call the unsubscribe API from a mount/render/effect.
+ */
+export function JournalUnsubscribeFields({
+  status,
+  errorMessage,
+  onConfirm,
+}: JournalUnsubscribeFieldsProps) {
+  const disabled = status === "submitting" || status === "done";
+
+  const label =
+    status === "submitting"
+      ? "Unsubscribing…"
+      : status === "done"
+        ? "Unsubscribed"
+        : status === "error"
+          ? "Try again"
+          : "Confirm unsubscribe";
+
+  return (
+    <div>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onConfirm}
+        className="inline-flex h-11 items-center rounded-md bg-primary px-6 text-sm font-medium text-primary-foreground hover:bg-primary-hover disabled:cursor-not-allowed disabled:bg-ink-600"
+      >
+        {label}
+      </button>
+      <div className="mt-4 min-h-[1.125rem]">
+        {status === "error" && errorMessage ? (
+          <p role="alert" aria-live="polite" className="text-sm text-danger">
+            {errorMessage}
+          </p>
+        ) : null}
+        {status === "done" ? (
+          <p role="status" aria-live="polite" className="text-sm text-moss-700">
+            You&rsquo;ve been unsubscribed. That address is no longer on our
+            Journal list.
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/onboarding/components/marketing/JournalUnsubscribeTokenReader.tsx
+++ b/apps/onboarding/components/marketing/JournalUnsubscribeTokenReader.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useSearchParams } from "next/navigation";
+
+interface JournalUnsubscribeTokenReaderProps {
+  children: (token: string | null) => ReactNode;
+}
+
+/**
+ * Thin client-only wrapper around useSearchParams, kept separate from
+ * JournalUnsubscribeConfirm so that component stays a plain
+ * props-in/markup-out client component with no next/navigation
+ * dependency — easier to unit-test (see
+ * tests/unit/journal-unsubscribe-confirm.spec.tsx) and reusable if this
+ * page ever needs a second consumer of the token.
+ *
+ * Must be rendered inside a <Suspense> boundary — useSearchParams
+ * requires one during static rendering (same reasoning as
+ * app/onboarding/verify/page.tsx's use of VerifyMagicLink).
+ */
+export function JournalUnsubscribeTokenReader({
+  children,
+}: JournalUnsubscribeTokenReaderProps) {
+  const searchParams = useSearchParams();
+  return <>{children(searchParams.get("token"))}</>;
+}

--- a/apps/onboarding/lib/api/journal-unsubscribe.ts
+++ b/apps/onboarding/lib/api/journal-unsubscribe.ts
@@ -1,0 +1,47 @@
+// Browser-side helper for the Journal unsubscribe page (erasure
+// counterpart to #153's email capture — see lib/api/journal-signup.ts).
+// Calls this app's own /api/journal-unsubscribe route — never
+// marketplace-api directly, for the same reason subscribeToJournal
+// doesn't: only a server route is allowed to hold MARKETPLACE_API_URL.
+
+export type UnsubscribeResult = { ok: true } | { ok: false; message: string };
+
+/**
+ * Submits an unsubscribe token. Never throws — network failures and
+ * non-2xx responses both come back as `{ ok: false, message }` so the
+ * caller can render the error inline without a try/catch.
+ *
+ * A 200 here does not mean the token was recognised — marketplace-api's
+ * /journal/unsubscribe deliberately returns 200 for an unknown, already-
+ * used, or malformed token too, so a bearer-token guess can't be used to
+ * enumerate valid addresses. This function just forwards that response.
+ */
+export async function unsubscribeFromJournal(
+  token: string,
+): Promise<UnsubscribeResult> {
+  try {
+    const res = await fetch("/api/journal-unsubscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+
+    const body = (await res.json().catch(() => ({}))) as { message?: string };
+
+    if (!res.ok) {
+      return {
+        ok: false,
+        message: body.message ?? "Something went wrong. Please try again.",
+      };
+    }
+
+    return { ok: true };
+  } catch {
+    // fetch() itself rejected — offline, or the app server is unreachable.
+    return {
+      ok: false,
+      message:
+        "We couldn't reach the server. Check your connection and try again.",
+    };
+  }
+}

--- a/apps/onboarding/tests/unit/journal-unsubscribe-confirm.spec.tsx
+++ b/apps/onboarding/tests/unit/journal-unsubscribe-confirm.spec.tsx
@@ -1,0 +1,136 @@
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+import path from "node:path";
+import ts from "typescript";
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { loadTsxExport } from "./helpers/load-tsx";
+
+/**
+ * JournalUnsubscribeConfirm is a "use client" component, but
+ * renderToStaticMarkup happily renders it server-side too (no effects
+ * run, hooks just resolve their initial state) — see
+ * tests/unit/helpers/load-tsx.ts for why the real .tsx source is loaded
+ * this way instead of a plain import.
+ */
+type JournalUnsubscribeConfirmProps = { token: string | null };
+
+const componentsMarketingDir = path.join(
+  __dirname,
+  "../../components/marketing",
+);
+const fieldsSourcePath = path.join(
+  componentsMarketingDir,
+  "JournalUnsubscribeFields.tsx",
+);
+const confirmSourcePath = path.join(
+  componentsMarketingDir,
+  "JournalUnsubscribeConfirm.tsx",
+);
+
+/**
+ * JournalUnsubscribeConfirm's compiled output does `require("./JournalUnsubscribeFields")` —
+ * a *sibling* .tsx file, not a package. loadTsxExport handles loading a
+ * single leaf component (see its own doc comment for why Playwright's
+ * built-in JSX transform can't be trusted), but it deletes its generated
+ * file immediately after requiring it, so it can't double as a
+ * resolvable sibling module for another generated file's `require()`.
+ *
+ * Node's module resolution tries the exact ".js" extension before ever
+ * consulting Playwright's ".tsx" loader hook, so writing a real,
+ * non-hidden "JournalUnsubscribeFields.js" next to the source (rather
+ * than loadTsxExport's hidden, load-and-delete ".*.generated.cjs")
+ * makes plain `require("./JournalUnsubscribeFields")` resolve to our
+ * transpiled shim instead of tripping Playwright's own JSX pragma. It's
+ * removed again immediately after loadTsxExport has finished requiring
+ * Confirm below — by then Node has already loaded and cached it.
+ */
+function writeFieldsShim(): () => void {
+  const shimPath = path.join(
+    componentsMarketingDir,
+    "JournalUnsubscribeFields.js",
+  );
+  const source = readFileSync(fieldsSourcePath, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      jsx: ts.JsxEmit.ReactJSX,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+    fileName: "JournalUnsubscribeFields.tsx",
+  });
+  writeFileSync(shimPath, outputText);
+  return () => rmSync(shimPath, { force: true });
+}
+
+const removeFieldsShim = writeFieldsShim();
+let JournalUnsubscribeConfirm: (
+  props: JournalUnsubscribeConfirmProps,
+) => ReactNode;
+try {
+  JournalUnsubscribeConfirm = loadTsxExport<
+    (props: JournalUnsubscribeConfirmProps) => ReactNode
+  >(confirmSourcePath, "JournalUnsubscribeConfirm", componentsMarketingDir);
+} finally {
+  removeFieldsShim();
+}
+
+function stubFetchCounter(): { calls: number } {
+  const counter = { calls: 0 };
+  globalThis.fetch = (async () => {
+    counter.calls += 1;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    };
+  }) as unknown as typeof fetch;
+  return counter;
+}
+
+// THE prefetch-hazard guard: mail clients and security scanners prefetch
+// links, including this one. If rendering (or mounting) this component
+// ever called the unsubscribe API on its own, a prefetch would silently
+// unsubscribe someone who never clicked anything. This must only ever
+// happen from a real click on the confirm button — never a useEffect, a
+// render-time call, or any other form of "run this automatically".
+test("rendering the confirm screen never calls the unsubscribe API on its own", () => {
+  const counter = stubFetchCounter();
+
+  renderToStaticMarkup(
+    createElement(JournalUnsubscribeConfirm, { token: "a".repeat(64) }),
+  );
+
+  expect(counter.calls).toBe(0);
+});
+
+test("renders a confirm button rather than auto-submitting when a token is present", () => {
+  const counter = stubFetchCounter();
+
+  const html = renderToStaticMarkup(
+    createElement(JournalUnsubscribeConfirm, { token: "a".repeat(64) }),
+  );
+
+  expect(html).toContain("<button");
+  expect(counter.calls).toBe(0);
+});
+
+test("a missing token renders a message pointing at /contact instead of a confirm button", () => {
+  const html = renderToStaticMarkup(
+    createElement(JournalUnsubscribeConfirm, { token: null }),
+  );
+
+  expect(html).not.toContain("<button");
+  expect(html).toContain("/contact");
+});
+
+test("a blank token is treated the same as a missing one", () => {
+  const html = renderToStaticMarkup(
+    createElement(JournalUnsubscribeConfirm, { token: "   " }),
+  );
+
+  expect(html).not.toContain("<button");
+  expect(html).toContain("/contact");
+});

--- a/apps/onboarding/tests/unit/journal-unsubscribe-fields.spec.tsx
+++ b/apps/onboarding/tests/unit/journal-unsubscribe-fields.spec.tsx
@@ -1,0 +1,98 @@
+import { expect, test } from "@playwright/test";
+import path from "node:path";
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { loadTsxExport } from "./helpers/load-tsx";
+import type { JournalUnsubscribeStatus } from "../../components/marketing/JournalUnsubscribeFields";
+
+/**
+ * See tests/unit/helpers/load-tsx.ts for why JournalUnsubscribeFields'
+ * real JSX source is loaded this way rather than imported directly.
+ */
+type JournalUnsubscribeFieldsProps = {
+  status: JournalUnsubscribeStatus;
+  errorMessage: string | null;
+  onConfirm: () => void;
+};
+
+const JournalUnsubscribeFields = loadTsxExport<
+  (props: JournalUnsubscribeFieldsProps) => ReactNode
+>(
+  path.join(
+    __dirname,
+    "../../components/marketing/JournalUnsubscribeFields.tsx",
+  ),
+  "JournalUnsubscribeFields",
+  __dirname,
+);
+
+function noop() {
+  // Static rendering never fires onConfirm.
+}
+
+test("idle state renders a Confirm button that is not disabled", () => {
+  const html = renderToStaticMarkup(
+    createElement(JournalUnsubscribeFields, {
+      status: "idle",
+      errorMessage: null,
+      onConfirm: noop,
+    }),
+  );
+
+  expect(html).toContain("<button");
+  expect(html).not.toContain("disabled=");
+  expect(html.toLowerCase()).toContain("unsubscribe");
+});
+
+test("idle state renders no error and no status region", () => {
+  const html = renderToStaticMarkup(
+    createElement(JournalUnsubscribeFields, {
+      status: "idle",
+      errorMessage: null,
+      onConfirm: noop,
+    }),
+  );
+
+  expect(html).not.toContain('role="alert"');
+  expect(html).not.toContain('role="status"');
+});
+
+test("submitting state disables the button and shows an in-progress label", () => {
+  const html = renderToStaticMarkup(
+    createElement(JournalUnsubscribeFields, {
+      status: "submitting",
+      errorMessage: null,
+      onConfirm: noop,
+    }),
+  );
+
+  expect(html).toContain('disabled=""');
+});
+
+test("done state announces success via role=status and disables the button", () => {
+  const html = renderToStaticMarkup(
+    createElement(JournalUnsubscribeFields, {
+      status: "done",
+      errorMessage: null,
+      onConfirm: noop,
+    }),
+  );
+
+  expect(html).toContain('role="status"');
+  expect(html).toContain('disabled=""');
+});
+
+test("error state announces the message via role=alert and re-enables the button", () => {
+  const html = renderToStaticMarkup(
+    createElement(JournalUnsubscribeFields, {
+      status: "error",
+      errorMessage: "Something went wrong. Please try again.",
+      onConfirm: noop,
+    }),
+  );
+
+  expect(html).toContain('role="alert"');
+  expect(html).toContain("Something went wrong. Please try again.");
+  expect(html).not.toContain('disabled=""');
+});

--- a/apps/onboarding/tests/unit/journal-unsubscribe.spec.ts
+++ b/apps/onboarding/tests/unit/journal-unsubscribe.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "@playwright/test";
+
+import { unsubscribeFromJournal } from "../../lib/api/journal-unsubscribe";
+
+interface StubbedResponse {
+  ok: boolean;
+  status?: number;
+  json?: unknown;
+}
+
+/**
+ * Replace global fetch with a queue of canned responses, recording every
+ * request. Mirrors the stubFetch helper in journal-signup.spec.ts.
+ */
+function stubFetch(
+  responses: StubbedResponse[],
+): { url: string; body: unknown }[] {
+  const calls: { url: string; body: unknown }[] = [];
+  let i = 0;
+
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    const next = responses[i++];
+    if (!next) throw new Error(`unexpected fetch call #${i}: ${url}`);
+    calls.push({
+      url: String(url),
+      body: JSON.parse(String(init?.body ?? "{}")),
+    });
+    return {
+      ok: next.ok,
+      status: next.status ?? (next.ok ? 200 : 500),
+      json: async () => next.json ?? {},
+    };
+  }) as unknown as typeof fetch;
+
+  return calls;
+}
+
+test("posts to the app's own /api/journal-unsubscribe route, never marketplace-api directly", async () => {
+  const calls = stubFetch([{ ok: true, json: { ok: true } }]);
+
+  const result = await unsubscribeFromJournal("a".repeat(64));
+
+  expect(result).toEqual({ ok: true });
+  expect(calls).toHaveLength(1);
+  const [call] = calls;
+  expect(call?.url).toBe("/api/journal-unsubscribe");
+  expect(call?.body).toEqual({ token: "a".repeat(64) });
+});
+
+test("success path: resolves ok:true on a 200 response, even for an unrecognised token (non-enumerable)", async () => {
+  stubFetch([{ ok: true, json: { ok: true } }]);
+
+  const result = await unsubscribeFromJournal("unknown-token");
+
+  expect(result.ok).toBe(true);
+});
+
+test("error path: surfaces the server's message on a non-2xx response", async () => {
+  stubFetch([
+    {
+      ok: false,
+      status: 502,
+      json: { ok: false, message: "We couldn't reach the server just now." },
+    },
+  ]);
+
+  const result = await unsubscribeFromJournal("a".repeat(64));
+
+  expect(result).toEqual({
+    ok: false,
+    message: "We couldn't reach the server just now.",
+  });
+});
+
+test("error path: falls back to a generic message when the response body has none", async () => {
+  stubFetch([{ ok: false, status: 500, json: {} }]);
+
+  const result = await unsubscribeFromJournal("a".repeat(64));
+
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.message).toBe("Something went wrong. Please try again.");
+  }
+});
+
+test("error path: a network failure (fetch rejects) never throws, and returns a human message", async () => {
+  globalThis.fetch = (async () => {
+    throw new Error("network down");
+  }) as unknown as typeof fetch;
+
+  const result = await unsubscribeFromJournal("a".repeat(64));
+
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.message).toContain("couldn't reach the server");
+  }
+});

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -317,6 +317,12 @@ func main() {
 	// tenant-free record is not on mode.Storefront.
 	journalSubscribeHandler := public.NewJournalSubscribeHandler(
 		journal.NewRepository(conn), journal.NewRateLimiter(), log)
+	// Erasure counterpart to journalSubscribeHandler (migration 000125)
+	// — a separate journal.RateLimiter instance rather than sharing
+	// journalSubscribeHandler's, so a burst against one endpoint can't
+	// lock a subscriber out of the other.
+	journalUnsubscribeHandler := public.NewJournalUnsubscribeHandler(
+		journal.NewRepository(conn), journal.NewRateLimiter(), log)
 
 	// ─── Email templates loader (B1f) ───────────────────────────────────
 	// DB-backed templates with embedded fallback. tesserix-home authors
@@ -2229,8 +2235,9 @@ func main() {
 		storefront.RegisterStorefront(r.Group("/api/v1"), storefrontDeps)
 		storefront.RegisterMobileStorefrontSupport(r.Group("/api/v1"), storefrontSupportHandler, storefrontDeps.SlugCache, storefrontCustomerVerifier)
 		public.RegisterPublic(r.Group("/api/v1"), public.PublicDeps{
-			DelhiveryWebhookHandler: delhiveryWebhookHandler,
-			JournalSubscribeHandler: journalSubscribeHandler,
+			DelhiveryWebhookHandler:   delhiveryWebhookHandler,
+			JournalSubscribeHandler:   journalSubscribeHandler,
+			JournalUnsubscribeHandler: journalUnsubscribeHandler,
 		})
 		if brandingSeeder != nil {
 			brandingSeeder.Register(r.Group("/api/v1/test"))
@@ -2378,8 +2385,9 @@ func main() {
 			// handler shares shipments/secrets wiring with the admin
 			// ShipmentsHandler.
 			public.RegisterPublic(engine.Group("/api/v1"), public.PublicDeps{
-				DelhiveryWebhookHandler: delhiveryWebhookHandler,
-				JournalSubscribeHandler: journalSubscribeHandler,
+				DelhiveryWebhookHandler:   delhiveryWebhookHandler,
+				JournalSubscribeHandler:   journalSubscribeHandler,
+				JournalUnsubscribeHandler: journalUnsubscribeHandler,
 			})
 			if countryPublicHandler != nil {
 				engine.GET("/api/v1/public/supported-countries", countryPublicHandler.ListSupported)

--- a/services/marketplace-api/internal/handlers/public/journal_unsubscribe.go
+++ b/services/marketplace-api/internal/handlers/public/journal_unsubscribe.go
@@ -1,0 +1,88 @@
+package public
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/marketplace-api/internal/journal"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+)
+
+// journalUnsubscriber is the slice of *journal.Repository this handler
+// needs. Accepting the interface (rather than the concrete type) keeps
+// the handler testable without a database.
+type journalUnsubscriber interface {
+	Unsubscribe(token string) error
+}
+
+// journalUnsubscribeInput is the JSON binding struct for the public
+// unsubscribe endpoint. No `binding:"required"` on Token: a missing or
+// empty token is handled the same as any other unrecognised token (see
+// Unsubscribe below), not rejected with a 400 — a 400 vs 200 split would
+// itself be a (weak) signal for an attacker probing for well-formed vs.
+// malformed tokens.
+type journalUnsubscribeInput struct {
+	Token string `json:"token"`
+}
+
+// JournalUnsubscribeHandler serves the public, tenant-free erasure path
+// for a Journal subscriber (#153) — the mechanism that makes good on the
+// customererasure declaredExclusions promise that these addresses "still
+// carry an art.17 right, exercised against the platform" even though the
+// table has no store_id/tenant_id for a merchant-scoped erasure to reach.
+type JournalUnsubscribeHandler struct {
+	repo    journalUnsubscriber
+	limiter *journal.RateLimiter
+	logger  *slog.Logger
+}
+
+// NewJournalUnsubscribeHandler constructs a JournalUnsubscribeHandler.
+func NewJournalUnsubscribeHandler(repo journalUnsubscriber, limiter *journal.RateLimiter, logger *slog.Logger) *JournalUnsubscribeHandler {
+	return &JournalUnsubscribeHandler{repo: repo, limiter: limiter, logger: logger}
+}
+
+// Unsubscribe handles POST /journal/unsubscribe. Anonymous by design —
+// the token itself, mailed to the subscriber out of band, is the only
+// credential required.
+//
+// Always returns 200, whether the token matched a row, matched nothing,
+// was already used, or was malformed/empty — the response must never
+// reveal whether a given token (or, transitively, an email address) was
+// ever valid. The only path that deviates is a genuine backend failure
+// (db unreachable, etc.), which surfaces as a 500 exactly like the
+// sibling Subscribe handler, since that failure mode carries no
+// enumeration signal about any particular token.
+func (h *JournalUnsubscribeHandler) Unsubscribe(c *gin.Context) {
+	if h.limiter != nil && !h.limiter.Allow(c.ClientIP()) {
+		c.AbortWithStatusJSON(http.StatusTooManyRequests, journalErrEnvelope(
+			apperrors.CodeRateLimited, "too many requests, please try again later"))
+		return
+	}
+
+	var req journalUnsubscribeInput
+	// A body that fails to bind (missing/non-string token, malformed
+	// JSON) or a token that isn't even the right shape is treated
+	// exactly like an unrecognised token: 200, no repository call at
+	// all — so a malformed token never even reaches the database, let
+	// alone gets logged. (The repository re-checks the length itself
+	// as defense in depth for any other caller.) Never log req.Token
+	// or any derived email.
+	if err := c.ShouldBindJSON(&req); err != nil ||
+		len(req.Token) != journal.UnsubscribeTokenLength {
+		c.JSON(http.StatusOK, gin.H{"unsubscribed": true})
+		return
+	}
+
+	if err := h.repo.Unsubscribe(req.Token); err != nil {
+		if h.logger != nil {
+			h.logger.Error("journal unsubscribe failed", slog.String("err", err.Error()))
+		}
+		c.AbortWithStatusJSON(http.StatusInternalServerError, journalErrEnvelope(
+			"internal", "internal server error"))
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"unsubscribed": true})
+}

--- a/services/marketplace-api/internal/handlers/public/journal_unsubscribe_test.go
+++ b/services/marketplace-api/internal/handlers/public/journal_unsubscribe_test.go
@@ -1,0 +1,133 @@
+package public
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/journal"
+)
+
+// fakeJournalUnsubscriber records every Unsubscribe call so tests can
+// assert on what token reached the repository without a database.
+type fakeJournalUnsubscriber struct {
+	calls []string
+	err   error
+}
+
+func (f *fakeJournalUnsubscriber) Unsubscribe(token string) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.calls = append(f.calls, token)
+	return nil
+}
+
+func newJournalUnsubscribeTestRouter(repo *fakeJournalUnsubscriber, limiter *journal.RateLimiter) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	h := NewJournalUnsubscribeHandler(repo, limiter, slog.Default())
+	r := gin.New()
+	r.POST("/api/v1/journal/unsubscribe", h.Unsubscribe)
+	return r
+}
+
+func postJournalUnsubscribe(r *gin.Engine, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/journal/unsubscribe", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestJournalUnsubscribe_ValidTokenSucceeds(t *testing.T) {
+	repo := &fakeJournalUnsubscriber{}
+	r := newJournalUnsubscribeTestRouter(repo, journal.NewRateLimiter())
+
+	// build a 64-char hex-looking token
+	tok := ""
+	for len(tok) < 64 {
+		tok += "0123456789abcdef"
+	}
+	tok = tok[:64]
+
+	w := postJournalUnsubscribe(r, `{"token":"`+tok+`"}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.JSONEq(t, `{"unsubscribed":true}`, w.Body.String())
+	require.Equal(t, []string{tok}, repo.calls)
+}
+
+func TestJournalUnsubscribe_UnknownTokenStillReturns200(t *testing.T) {
+	repo := &fakeJournalUnsubscriber{}
+	r := newJournalUnsubscribeTestRouter(repo, journal.NewRateLimiter())
+
+	w := postJournalUnsubscribe(r, `{"token":"0000000000000000000000000000000000000000000000000000000000000000"}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.JSONEq(t, `{"unsubscribed":true}`, w.Body.String())
+}
+
+func TestJournalUnsubscribe_MalformedTokenReturns200WithoutTouchingRepo(t *testing.T) {
+	repo := &fakeJournalUnsubscriber{}
+	r := newJournalUnsubscribeTestRouter(repo, journal.NewRateLimiter())
+
+	w := postJournalUnsubscribe(r, `{"token":"not-a-real-token"}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.JSONEq(t, `{"unsubscribed":true}`, w.Body.String())
+}
+
+func TestJournalUnsubscribe_EmptyTokenReturns200WithoutTouchingRepo(t *testing.T) {
+	repo := &fakeJournalUnsubscriber{}
+	r := newJournalUnsubscribeTestRouter(repo, journal.NewRateLimiter())
+
+	w := postJournalUnsubscribe(r, `{}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.JSONEq(t, `{"unsubscribed":true}`, w.Body.String())
+	require.Empty(t, repo.calls, "an empty token must never reach the repository")
+}
+
+func TestJournalUnsubscribe_UsingTheSameTokenTwiceBothReturn200(t *testing.T) {
+	repo := &fakeJournalUnsubscriber{}
+	r := newJournalUnsubscribeTestRouter(repo, journal.NewRateLimiter())
+
+	body := `{"token":"1111111111111111111111111111111111111111111111111111111111111111"}`
+	first := postJournalUnsubscribe(r, body)
+	second := postJournalUnsubscribe(r, body)
+
+	require.Equal(t, http.StatusOK, first.Code)
+	require.Equal(t, http.StatusOK, second.Code)
+}
+
+func TestJournalUnsubscribe_RepositoryErrorReturns500WithoutLeakingDetail(t *testing.T) {
+	repo := &fakeJournalUnsubscriber{err: assertError("db is down")}
+	r := newJournalUnsubscribeTestRouter(repo, journal.NewRateLimiter())
+
+	w := postJournalUnsubscribe(r, `{"token":"2222222222222222222222222222222222222222222222222222222222222222"}`)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.JSONEq(t, `{"error":"internal","message":"internal server error"}`, w.Body.String())
+}
+
+func TestJournalUnsubscribe_RateLimitedAfterMaxRequestsFromSameIP(t *testing.T) {
+	repo := &fakeJournalUnsubscriber{}
+	limiter := journal.NewRateLimiter()
+	r := newJournalUnsubscribeTestRouter(repo, limiter)
+
+	body := `{"token":"3333333333333333333333333333333333333333333333333333333333333333"}`
+	var last *httptest.ResponseRecorder
+	for i := 0; i < journal.SubscribeRateMax; i++ {
+		last = postJournalUnsubscribe(r, body)
+		require.Equal(t, http.StatusOK, last.Code)
+	}
+
+	blocked := postJournalUnsubscribe(r, body)
+	require.Equal(t, http.StatusTooManyRequests, blocked.Code)
+	require.JSONEq(t, `{"error":"rate_limited","message":"too many requests, please try again later"}`, blocked.Body.String())
+}

--- a/services/marketplace-api/internal/handlers/public/routes.go
+++ b/services/marketplace-api/internal/handlers/public/routes.go
@@ -23,6 +23,10 @@ type PublicDeps struct {
 	// soon" page's email capture (#153). Nil-safe, like the others —
 	// absent in test builds that don't wire a DB.
 	JournalSubscribeHandler *JournalSubscribeHandler
+	// JournalUnsubscribeHandler is the erasure counterpart to
+	// JournalSubscribeHandler: it deletes a subscriber row by bearer
+	// token (migration 000125). Nil-safe, like the others.
+	JournalUnsubscribeHandler *JournalUnsubscribeHandler
 }
 
 // RegisterPublic mounts all public (unauthenticated) routes onto the given
@@ -54,5 +58,10 @@ func RegisterPublic(router *gin.RouterGroup, deps PublicDeps) {
 		// share — is the one genuinely tenant-free public surface this
 		// router exposes.
 		router.POST("/journal/subscribe", deps.JournalSubscribeHandler.Subscribe)
+	}
+	if deps.JournalUnsubscribeHandler != nil {
+		// Same tenant-free group, same reasoning as subscribe above:
+		// an unsubscribe token has no tenant to route through either.
+		router.POST("/journal/unsubscribe", deps.JournalUnsubscribeHandler.Unsubscribe)
 	}
 }

--- a/services/marketplace-api/internal/journal/models.go
+++ b/services/marketplace-api/internal/journal/models.go
@@ -32,6 +32,12 @@ type Subscriber struct {
 	Email     string    `gorm:"column:email;type:varchar(254);not null" json:"email"`
 	Source    string    `gorm:"column:source;type:varchar(40);not null;default:journal" json:"source"`
 	CreatedAt time.Time `gorm:"column:created_at;not null;default:now()" json:"created_at"`
+	// UnsubscribeToken is the bearer credential mailed to the
+	// subscriber (out of band — this service never sends the
+	// confirmation email itself) that authorises deleting this row via
+	// POST /journal/unsubscribe. Never serialized to JSON: it must
+	// never come back in any API response after creation.
+	UnsubscribeToken string `gorm:"column:unsubscribe_token;type:char(64);not null" json:"-"`
 }
 
 // TableName pins the GORM table name explicitly rather than relying on

--- a/services/marketplace-api/internal/journal/repository.go
+++ b/services/marketplace-api/internal/journal/repository.go
@@ -20,13 +20,50 @@ func NewRepository(db *gorm.DB) *Repository {
 // NOTHING against the unique index on email — so callers (and, in turn,
 // the HTTP handler) can treat every syntactically valid submission as
 // success without ever learning whether the address was already present.
+//
+// A fresh unsubscribe_token is generated for every call, but ON CONFLICT
+// DO NOTHING means it is only ever *stored* on the first insert for a
+// given email. Deliberately NOT re-issued on a repeat subscribe: an
+// unsubscribe link already sitting in someone's inbox from an earlier
+// email embeds the original token, and rotating it here would silently
+// break that link the next time the same address re-subscribes. The
+// generated-but-discarded token on a conflicting call is harmless — it
+// is never persisted or returned to the caller.
 func (r *Repository) Subscribe(email, source string) error {
+	token, err := GenerateUnsubscribeToken()
+	if err != nil {
+		return err
+	}
+
 	sub := &Subscriber{
-		Email:  NormalizeEmail(email),
-		Source: source,
+		Email:            NormalizeEmail(email),
+		Source:           source,
+		UnsubscribeToken: token,
 	}
 	return r.db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "email"}},
 		DoNothing: true,
 	}).Create(sub).Error
+}
+
+// Unsubscribe deletes the subscriber row whose unsubscribe_token matches
+// token, outright. This is an erasure, not a soft-delete: it is what
+// makes good on the customererasure declaredExclusions promise that a
+// Journal address "still carries an art.17 right, exercised against the
+// platform" — the address must stop being held, not gain an
+// unsubscribed_at flag while the row (and email) lives on.
+//
+// A token that matches no row deletes zero rows and returns nil, exactly
+// like a token that matches one — the caller cannot distinguish "unknown
+// token" from "already unsubscribed" from "just unsubscribed" by the
+// return value alone, which is what makes the HTTP layer's uniform 200
+// response non-enumerable. The length check below is a cheap short
+// circuit for the common "empty or obviously-wrong-shaped token" case;
+// it is not a correctness requirement, since a well-formed-but-unknown
+// token also just deletes zero rows.
+func (r *Repository) Unsubscribe(token string) error {
+	if len(token) != UnsubscribeTokenLength {
+		return nil
+	}
+	return r.db.Where("unsubscribe_token = ?", token).Delete(&Subscriber{}).Error
 }

--- a/services/marketplace-api/internal/journal/repository_integration_test.go
+++ b/services/marketplace-api/internal/journal/repository_integration_test.go
@@ -68,3 +68,85 @@ func TestSubscribe_NormalizesBeforeInsert(t *testing.T) {
 	).Scan(&count).Error)
 	require.EqualValues(t, 1, count)
 }
+
+// The erasure path this whole feature exists for: subscribe, then
+// unsubscribe by the token that Subscribe generated, and the row must be
+// entirely gone — not soft-deleted, not flagged, gone.
+func TestSubscribeThenUnsubscribe_RowIsGone(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := journal.NewRepository(tx)
+
+	email := uuid.New().String() + "@example.com"
+	require.NoError(t, repo.Subscribe(email, journal.SourceJournal))
+
+	var token string
+	require.NoError(t, tx.Raw(
+		`SELECT unsubscribe_token FROM journal_subscribers WHERE email = ?`, email,
+	).Scan(&token).Error)
+	require.Len(t, token, journal.UnsubscribeTokenLength, "Subscribe must have generated a token")
+
+	require.NoError(t, repo.Unsubscribe(token))
+
+	var count int64
+	require.NoError(t, tx.Raw(
+		`SELECT count(*) FROM journal_subscribers WHERE email = ?`, email,
+	).Scan(&count).Error)
+	require.EqualValues(t, 0, count, "the row must be deleted outright, not merely flagged")
+}
+
+// Using an already-used (or otherwise unknown) token a second time must
+// be a safe no-op: no error, and nothing left to delete the second time
+// around.
+func TestUnsubscribe_UsingTheSameTokenTwiceIsSafe(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := journal.NewRepository(tx)
+
+	email := uuid.New().String() + "@example.com"
+	require.NoError(t, repo.Subscribe(email, journal.SourceJournal))
+
+	var token string
+	require.NoError(t, tx.Raw(
+		`SELECT unsubscribe_token FROM journal_subscribers WHERE email = ?`, email,
+	).Scan(&token).Error)
+
+	require.NoError(t, repo.Unsubscribe(token))
+	require.NoError(t, repo.Unsubscribe(token), "unsubscribing with an already-used token must not error")
+}
+
+// An unrecognised token must be a safe no-op too, never an error — the
+// HTTP layer relies on this to respond identically to every kind of
+// token it's handed.
+func TestUnsubscribe_UnknownTokenIsSafeNoOp(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := journal.NewRepository(tx)
+
+	unknown := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"[:journal.UnsubscribeTokenLength]
+	require.Len(t, unknown, journal.UnsubscribeTokenLength)
+	require.NoError(t, repo.Unsubscribe(unknown))
+}
+
+// The core "don't break links already sitting in inboxes" requirement:
+// re-subscribing an address that already exists must not rotate its
+// unsubscribe_token.
+func TestSubscribe_RepeatSubscribeDoesNotRotateExistingToken(t *testing.T) {
+	tx := testdb.NewTx(t)
+	repo := journal.NewRepository(tx)
+
+	email := uuid.New().String() + "@example.com"
+	require.NoError(t, repo.Subscribe(email, journal.SourceJournal))
+
+	var originalToken string
+	require.NoError(t, tx.Raw(
+		`SELECT unsubscribe_token FROM journal_subscribers WHERE email = ?`, email,
+	).Scan(&originalToken).Error)
+
+	require.NoError(t, repo.Subscribe(email, journal.SourceJournal), "resubscribing must not error")
+
+	var tokenAfterResubscribe string
+	require.NoError(t, tx.Raw(
+		`SELECT unsubscribe_token FROM journal_subscribers WHERE email = ?`, email,
+	).Scan(&tokenAfterResubscribe).Error)
+
+	require.Equal(t, originalToken, tokenAfterResubscribe,
+		"a repeat subscribe must not invalidate an unsubscribe link already sent for this address")
+}

--- a/services/marketplace-api/internal/journal/token.go
+++ b/services/marketplace-api/internal/journal/token.go
@@ -1,0 +1,33 @@
+package journal
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+)
+
+// UnsubscribeTokenLength is the fixed length of a hex-encoded unsubscribe
+// token: 32 random bytes at 2 hex characters each. Matches the
+// journal_subscribers.unsubscribe_token CHAR(64) column added by
+// migration 000125.
+const UnsubscribeTokenLength = 64
+
+// unsubscribeTokenBytes is the amount of entropy fed into GenerateUnsubscribeToken,
+// before hex encoding. 32 bytes (256 bits) is comfortably beyond brute-force
+// range for a bearer credential with no other rate limiting than the
+// unsubscribe endpoint's own IP-based limiter.
+const unsubscribeTokenBytes = 32
+
+// GenerateUnsubscribeToken returns a cryptographically random, hex-encoded
+// bearer token that authorises deleting exactly one journal_subscribers
+// row. It is generated with crypto/rand — never derived from the
+// subscriber's email or any other value the server already holds, since a
+// derived token would be computable by anyone who later learns (or
+// guesses) the address it protects.
+func GenerateUnsubscribeToken() (string, error) {
+	buf := make([]byte, unsubscribeTokenBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("journal: generate unsubscribe token: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}

--- a/services/marketplace-api/internal/journal/token_test.go
+++ b/services/marketplace-api/internal/journal/token_test.go
@@ -1,0 +1,51 @@
+package journal_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/journal"
+)
+
+// GenerateUnsubscribeToken must produce a bearer credential that is both
+// unguessable and correctly shaped for the unsubscribe_token CHAR(64)
+// column (migration 000125): 32 random bytes, hex-encoded.
+func TestGenerateUnsubscribeToken_HasExpectedLength(t *testing.T) {
+	token, err := journal.GenerateUnsubscribeToken()
+	require.NoError(t, err)
+	require.Len(t, token, journal.UnsubscribeTokenLength)
+}
+
+func TestGenerateUnsubscribeToken_IsHexEncoded(t *testing.T) {
+	token, err := journal.GenerateUnsubscribeToken()
+	require.NoError(t, err)
+	require.Regexp(t, "^[0-9a-f]{64}$", token)
+}
+
+// The whole point of a bearer token is that it cannot be guessed. A
+// large sample of generated tokens must never collide, and must not
+// exhibit the kind of low-order-byte patterning a weak PRNG would leak.
+func TestGenerateUnsubscribeToken_IsUniqueAcrossManyCalls(t *testing.T) {
+	const n = 5000
+	seen := make(map[string]struct{}, n)
+	for i := 0; i < n; i++ {
+		token, err := journal.GenerateUnsubscribeToken()
+		require.NoError(t, err)
+		_, dup := seen[token]
+		require.False(t, dup, "generated a duplicate token within %d calls", n)
+		seen[token] = struct{}{}
+	}
+}
+
+// GenerateUnsubscribeToken must not derive the token from the email it
+// will be attached to — the token is the ONLY credential authorising
+// deletion, and an address-derived token would be guessable by anyone
+// who knows (or can enumerate) the subscriber's email.
+func TestGenerateUnsubscribeToken_DoesNotAcceptOrDeriveFromEmail(t *testing.T) {
+	tokenA, err := journal.GenerateUnsubscribeToken()
+	require.NoError(t, err)
+	tokenB, err := journal.GenerateUnsubscribeToken()
+	require.NoError(t, err)
+	require.NotEqual(t, tokenA, tokenB)
+}

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 124
+const ExpectedSchemaVersion uint = 125

--- a/services/marketplace-api/migrations/000125_journal_subscribers_unsubscribe_token.down.sql
+++ b/services/marketplace-api/migrations/000125_journal_subscribers_unsubscribe_token.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_journal_subscribers_unsubscribe_token;
+ALTER TABLE journal_subscribers DROP COLUMN IF EXISTS unsubscribe_token;

--- a/services/marketplace-api/migrations/000125_journal_subscribers_unsubscribe_token.up.sql
+++ b/services/marketplace-api/migrations/000125_journal_subscribers_unsubscribe_token.up.sql
@@ -1,0 +1,31 @@
+-- Migration 125: journal_subscribers.unsubscribe_token — the erasure
+-- mechanism promised by the customererasure declaredExclusions entry for
+-- this table (internal/customererasure/coverage_integration_test.go):
+-- a Journal subscriber has no store_id/tenant_id to route a store-scoped
+-- erasure through, so the art.17 right is exercised directly against the
+-- platform via a bearer token mailed to the subscriber, not through a
+-- merchant's flow. See internal/handlers/public/journal_unsubscribe.go.
+--
+-- pgcrypto's gen_random_bytes is already available — migration 000058
+-- ran `CREATE EXTENSION IF NOT EXISTS pgcrypto` for the exact same
+-- "backfill a random secret, then drop the default" shape used there for
+-- stores.storefront_customer_portal_secret. Reusing that precedent here
+-- rather than generating tokens in application code for the backfill
+-- keeps this migration a single, self-contained SQL file: it backfills
+-- the (in practice zero, but must-be-correct-regardless) existing rows
+-- in the same statement that adds the NOT NULL column, with no separate
+-- Go backfill step required. Every *new* row after this migration still
+-- gets its token from journal.GenerateUnsubscribeToken (crypto/rand) in
+-- Go — the DEFAULT below exists purely to satisfy NOT NULL for rows that
+-- predate this column, which is why it is dropped immediately after.
+ALTER TABLE journal_subscribers
+    ADD COLUMN unsubscribe_token CHAR(64) NOT NULL
+        DEFAULT encode(gen_random_bytes(32), 'hex');
+
+ALTER TABLE journal_subscribers ALTER COLUMN unsubscribe_token DROP DEFAULT;
+
+-- The token is looked up by exact match on unsubscribe — a unique index
+-- both enforces "one bearer credential authorises exactly one row" and
+-- makes that lookup an index seek rather than a sequential scan.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_journal_subscribers_unsubscribe_token
+    ON journal_subscribers (unsubscribe_token);


### PR DESCRIPTION
Makes good on a promise #546 left outstanding.

## Why

#546 added the `journal_subscribers` table. It tripped the repo's GDPR guard, `TestErasurePlan_CoversEveryCustomerLinkedTable`, because it holds an `email` with no declared disposition. That was resolved by adding a `declaredExclusions` entry — correctly, since the table carries no `store_id` or `tenant_id` and a store-scoped erasure plan structurally has no key to reach it by.

The justification ended:

> **NOT a statement that these addresses are unerasable: they are personal data and still carry an art.17 right, exercised against the platform rather than through a merchant's store-scoped flow.**

That was true in principle and **unimplemented in practice** — there was no unsubscribe link, no erasure endpoint, no way for a subscriber to get their address out of the table. This PR builds the mechanism the exclusion claims exists. The exclusion text is unchanged.

## What's here

**Unsubscribe token** (`000125`) — 32 bytes from `crypto/rand`, hex-encoded, unique, `NOT NULL`. Never derived from the email: a derived token would be computable by anyone who later learns or guesses the address it protects. Backfilled via `gen_random_bytes` (pgcrypto, already present from `000058`) before the default is dropped, so the column is `NOT NULL` from the start and CI's fresh-DB migration run is clean.

**`POST /api/v1/journal/unsubscribe`** — mounted in the same tenant-free `public.RegisterPublic` group as subscribe.

- **Deletes the row outright.** An erasure, not an `unsubscribed_at` flag — the whole point is that the address stops being held, and a soft-delete that keeps the email would fail the promise while appearing to satisfy it.
- **Idempotent and non-enumerable.** Unknown, malformed, already-used and valid tokens all return the same `200`. The repository returns `nil` for all of them, so the HTTP layer has nothing to leak even by accident.
- IP rate-limited via the existing `journal.RateLimiter`. Never logs the token or the email.

**A repeat subscribe does not rotate the token.** `ON CONFLICT DO NOTHING` means the token is only stored on first insert. This is deliberate and commented: rotating would silently break an unsubscribe link already sitting in someone's inbox. There's an integration test pinning it.

**The confirm page does not unsubscribe on load.** Mail clients and security scanners prefetch links. An auto-submit on mount would unsubscribe people who never clicked — so the page renders a confirm button and only ever acts on a real click. This is the single most important behavioural detail here, and it's guarded by a test that fails if rendering alone ever calls the API:

```
test("rendering the confirm screen never calls the unsubscribe API on its own", ...)
  expect(counter.calls).toBe(0)
```

**The no-token path is documented**, mirroring `/delete-account` §5: someone who deleted the email is pointed at `privacy@mark8ly.com`. Plus a Journal-subscriber line in the privacy policy.

## Verification

Independently re-run, not taken on trust:

- Throwaway `postgres:15`, all **125** migrations applied from zero
- **Full** integration suite — `go test -tags=integration -p 1 -count=1 ./...` — every package `ok`, zero failures. Notably `internal/customererasure` still passes, so the guard is satisfied honestly rather than silenced
- Down-migration verified: column and index dropped, confirmed absent via `information_schema`, then re-applied clean
- `go build ./...`, `go vet ./...` clean
- `npx tsc --noEmit` clean; `npx playwright test` — **68 passed**

Running the whole suite rather than just the touched packages is a direct response to #546, where the narrower scope missed the erasure guard and CI caught it.

Not verified locally: `next build` — `npm install` fails in a worktree on `@tesserix/otto-widget` (GitHub Packages token). CI covers it.

## Note on scope

No email is sent yet — the Journal has no articles. This ships the mechanism so that the moment the first piece goes out, the unsubscribe link has something real behind it, rather than the table quietly accumulating addresses with no way out. The token is ready to embed in `List-Unsubscribe` headers when campaign sending for the Journal is built.
