### PR TITLE
fix(admin): stop Save stock being a second primary floating mid-page

### DIFF
--- a/apps/admin/components/products/form/VariantStockByWarehouse.test.tsx
+++ b/apps/admin/components/products/form/VariantStockByWarehouse.test.tsx
@@ -137,3 +137,26 @@ describe("VariantStockByWarehouse", () => {
     expect(screen.queryByText("Stock saved.")).toBeNull();
   });
 });
+
+// The product page docks one filled --ink-900 primary under the header
+// ("Save changes"). This panel's own commit must not be a second one:
+// two filled primaries competing for different commits is exactly what
+// "one accent per view" rules out, and a filled button floating at the
+// left margin mid-page is the "dangling in the middle of the page"
+// complaint that moved the form's Save in the first place.
+describe("VariantStockByWarehouse — the save control's weight", () => {
+  it("is a secondary control, not a second filled primary", () => {
+    renderEditor({ "wh-1": 18, "wh-2": 10 });
+    const save = screen.getByRole("button", { name: /save stock/i });
+    expect(save.className).not.toMatch(/bg-\[color:var\(--ink-900\)\]/);
+    expect(save.className).toMatch(/border-\[color:var\(--ink-200\)\]/);
+  });
+
+  it("sits on the status row, right-aligned under the stock inputs", () => {
+    renderEditor({ "wh-1": 18, "wh-2": 10 });
+    const save = screen.getByRole("button", { name: /save stock/i });
+    const row = save.parentElement!;
+    expect(row.className).toMatch(/justify-between/);
+    expect(row.querySelector('[aria-live="polite"]')).not.toBeNull();
+  });
+});

--- a/apps/admin/components/products/form/VariantStockByWarehouse.tsx
+++ b/apps/admin/components/products/form/VariantStockByWarehouse.tsx
@@ -174,28 +174,43 @@ export function VariantStockByWarehouse({
         </span>
       </div>
 
-      <div aria-live="polite">
-        {error && (
-          <div
-            role="alert"
-            className="rounded-md border border-[color:var(--danger)]/25 bg-[color:var(--danger)]/[0.06] px-4 py-2.5 text-sm text-[color:var(--danger)]"
-          >
-            {error}
-          </div>
-        )}
-        {saved && !error && (
-          <p className="text-sm text-[color:var(--moss-700)]">Stock saved.</p>
-        )}
-      </div>
+      {/* Status and the save control share one row, and the button is
+          right-aligned so it sits under the column of stock inputs above
+          rather than floating at the left margin. That alignment is what
+          stops it reading as "dangling in the middle of the page" — the
+          same complaint the product form's own Save had before it was
+          docked under the header.
 
-      <button
-        type="button"
-        onClick={handleSave}
-        disabled={pending}
-        className="rounded-md bg-[color:var(--ink-900)] px-4 py-2 text-sm font-medium text-[color:var(--primary-foreground)] transition-colors hover:bg-[color:var(--moss-700)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-40"
-      >
-        {pending ? "Saving..." : "Save stock"}
-      </button>
+          It is deliberately SECONDARY. The page already has one filled
+          --ink-900 primary, the docked "Save changes". Two filled primaries
+          asking for different commits is precisely the "one accent per
+          view" rule this system sets, and the weaker weight also tells the
+          truth: warehouse stock is a smaller, self-contained commit than
+          saving the product. */}
+      <div className="flex items-center justify-between gap-4">
+        <div aria-live="polite" className="min-w-0">
+          {error && (
+            <div
+              role="alert"
+              className="rounded-md border border-[color:var(--danger)]/25 bg-[color:var(--danger)]/[0.06] px-4 py-2.5 text-sm text-[color:var(--danger)]"
+            >
+              {error}
+            </div>
+          )}
+          {saved && !error && (
+            <p className="text-sm text-[color:var(--moss-700)]">Stock saved.</p>
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={pending}
+          className="shrink-0 rounded-md border border-[color:var(--ink-200)] px-4 py-2 text-sm font-medium text-[color:var(--ink-900)] transition-colors hover:border-[color:var(--moss-700)] hover:text-[color:var(--moss-700)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {pending ? "Saving…" : "Save stock"}
+        </button>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
Reported from the live page: the per-warehouse stock panel's **Save stock** button still dangles in the middle of the page.

#547 docked the *product form's* Save under the header, but it never touched this control — `VariantStockByWarehouse` has its own commit, because warehouse stock saves separately from the product. So the same complaint survived on a different button, and the page ended up with **two filled `--ink-900` primaries** asking for two different commits.

## What changed

**Weight.** Save stock becomes a secondary control — `border-[--ink-200]` with ink text, moss on hover — instead of a filled primary. The docked "Save changes" is now the only filled primary on the page, which is what "one accent per view" asks for. The weaker weight is also honest: warehouse stock is a smaller, self-contained commit than saving the product.

**Position.** It moves onto the same row as the `aria-live` status region, right-aligned, so it sits under the column of stock inputs above it rather than floating at the left margin. That alignment is what stops it reading as adrift — it now has a relationship to something, which the old placement did not.

```
Main Warehouse      Bondi Beach              [ 18 ]
Marrickville Depot  Marrickville             [ 10 ]
─────────────────────────────────────────────────
Total                                            28

Stock saved.                          [ Save stock ]
```

Also swapped `"Saving..."` for `"Saving…"` to match the action bar.

## Tests

`apps/admin`: **111 files, 884 tests, 0 failures** (882 before; +2).

- the save control is not a filled primary, and does carry the secondary border
- it sits on the status row (`justify-between`, with the `aria-live` region as its sibling)

Mutation-checked, since "does not contain a class" is exactly the kind of assertion that passes whether or not the feature works: reverting the button to `bg-[color:var(--ink-900)]` fails *is a secondary control, not a second filled primary*. Restored, 9/9 pass.

## Not changed

The two-save-models split itself — product fields commit with the form, warehouse stock commits here. That is stated in the variants note rather than disguised, and changing it is a behaviour decision, not a styling one.