### PR TITLE
feat(admin): make New product a short form that redirects into edit

### DIFF
--- a/apps/admin/components/products/ProductForm.ActionBar.test.tsx
+++ b/apps/admin/components/products/ProductForm.ActionBar.test.tsx
@@ -100,10 +100,14 @@ describe("ProductForm — the docked action bar", () => {
     expect(screen.getByRole("button", { name: /delete product/i })).toBeInTheDocument();
   });
 
-  it("labels the action for the mode it is in", () => {
-    render(<ProductForm {...baseProps} mode="create" />);
-    expect(screen.getByRole("button", { name: /create product/i })).toBeInTheDocument();
+  it("does not appear on the create form, which has no scroll to get lost in", () => {
+    const { container } = render(<ProductForm {...baseProps} mode="create" />);
+    // Create is a short form. A bar that exists to answer "did I save"
+    // across a long scroll has nothing to do here, and its two actions are
+    // "Create as draft" / "Create and publish" instead.
+    expect(container.querySelector(".sticky")).toBeNull();
     expect(screen.queryByRole("button", { name: /save changes/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create as draft/i })).toBeInTheDocument();
   });
 });
 

--- a/apps/admin/components/products/ProductForm.CreateForm.test.tsx
+++ b/apps/admin/components/products/ProductForm.CreateForm.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { AdminCategory } from "@/lib/api/marketplace-api";
+
+const createProductAction = vi.fn(async () => ({ ok: true, data: { id: "p1" } }));
+const push = vi.fn();
+
+vi.mock("@/app/(admin)/products/actions", () => ({
+  createProductAction: (...args: unknown[]) => createProductAction(...(args as [])),
+  updateProductAction: vi.fn(),
+  deleteProductAction: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, refresh: vi.fn() }),
+}));
+vi.mock("./form/MediaTab", () => ({
+  MediaTab: () => <div data-testid="media-tab-stub" />,
+}));
+
+import { ProductForm } from "./ProductForm";
+
+const categories: AdminCategory[] = [];
+
+const baseProps = {
+  storeId: "s1",
+  categories,
+  currencyCode: "AUD",
+  storeCountryCode: "AU",
+  canDelete: false,
+  canArchive: false,
+  session: { userId: "u1", tenantId: "t1" },
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+// Create used to render the identical edit page, including a Media section
+// that cannot work before the product exists. It is now a short form: the
+// few things needed to make the product real, then a redirect into edit
+// where the rest has room.
+describe("ProductForm — the create form", () => {
+  it("asks only what is needed to make the product exist", () => {
+    render(<ProductForm {...baseProps} mode="create" />);
+
+    expect(screen.getByText(/^Title$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Categories$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Price/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Stock$/i)).toBeInTheDocument();
+
+    // Handle auto-generates from the title, and description has room on the
+    // edit page. Asking for them here makes the form longer for nothing.
+    expect(screen.queryByText(/^Handle$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Description$/i)).not.toBeInTheDocument();
+  });
+
+  it("omits the sections that need a saved product", () => {
+    render(<ProductForm {...baseProps} mode="create" />);
+    for (const name of [/^Media$/, /^Options$/, /^Shipping$/, /^Tax$/]) {
+      expect(screen.queryByRole("heading", { name })).not.toBeInTheDocument();
+    }
+    // Absent, not disabled: a dropzone that cannot accept a file is a
+    // promise the page cannot keep.
+    expect(screen.queryByTestId("media-tab-stub")).toBeNull();
+  });
+
+  it("has no rail, because there is no scroll to glance across", () => {
+    render(<ProductForm {...baseProps} mode="create" />);
+    expect(screen.queryByRole("complementary")).not.toBeInTheDocument();
+  });
+
+  it("is left-aligned and constrained, never centred", () => {
+    const { container } = render(<ProductForm {...baseProps} mode="create" />);
+    const column = container.querySelector(".max-w-2xl");
+    expect(column).not.toBeNull();
+    // mx-auto would centre it into the generic signup-card look the design
+    // direction rules out; the empty right-hand width is the asymmetric
+    // margin the system asks for.
+    expect(column!.className).not.toMatch(/mx-auto/);
+  });
+
+  // Status is decided by WHICH action the merchant takes, not by a fifth
+  // field asking the same question the submit button is about to answer.
+  it("offers draft and publish as the two actions, with no status field", () => {
+    render(<ProductForm {...baseProps} mode="create" />);
+    expect(screen.getByRole("button", { name: /create as draft/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create and publish/i })).toBeInTheDocument();
+    expect(screen.queryByText(/^Status$/i)).not.toBeInTheDocument();
+  });
+
+  it("creates a draft when the draft action is used", async () => {
+    const user = userEvent.setup();
+    render(<ProductForm {...baseProps} mode="create" />);
+
+    await user.type(screen.getByLabelText(/^Title$/i), "Bondi Beach Cotton Towel");
+    await user.type(screen.getByLabelText(/^Price/i), "75");
+    await user.click(screen.getByRole("button", { name: /create as draft/i }));
+
+    await waitFor(() => expect(createProductAction).toHaveBeenCalled());
+    const values = createProductAction.mock.calls[0]![2] as { status: string };
+    expect(values.status).toBe("draft");
+  });
+
+  it("creates an active product when the publish action is used", async () => {
+    const user = userEvent.setup();
+    render(<ProductForm {...baseProps} mode="create" />);
+
+    await user.type(screen.getByLabelText(/^Title$/i), "Bondi Beach Cotton Towel");
+    await user.type(screen.getByLabelText(/^Price/i), "75");
+    await user.click(screen.getByRole("button", { name: /create and publish/i }));
+
+    await waitFor(() => expect(createProductAction).toHaveBeenCalled());
+    const values = createProductAction.mock.calls[0]![2] as { status: string };
+    expect(values.status).toBe("active");
+  });
+});

--- a/apps/admin/components/products/ProductForm.test.tsx
+++ b/apps/admin/components/products/ProductForm.test.tsx
@@ -32,6 +32,28 @@ const baseProps = {
   session: { userId: "u1", tenantId: "t1" },
 };
 
+// The one-page layout is the EDIT page. Create is deliberately a short
+// form that makes the product exist and redirects into edit, so these
+// structural assertions render edit mode explicitly rather than relying on
+// the default.
+const editProduct = {
+  id: "p1",
+  title: "T",
+  handle: "t",
+  description: "",
+  status: "draft",
+  variants: [],
+  categories: [],
+  options: [],
+  media: [],
+} as unknown as AdminProduct;
+
+function renderEdit() {
+  return render(
+    <ProductForm {...baseProps} mode="edit" initialProduct={editProduct} />,
+  );
+}
+
 // The form was five tabs. It is one scrolling page of hairline-separated
 // sections now: tabs hid whether a section held anything until you clicked
 // it, and the tab bar changed shape between create and edit because Media
@@ -40,7 +62,7 @@ const baseProps = {
 describe("ProductForm — one page, no tabs", () => {
   describe("everything is present without navigating", () => {
     it("renders the core fields on mount", () => {
-      render(<ProductForm {...baseProps} />);
+      renderEdit();
       expect(screen.getByText(/^Title$/i)).toBeInTheDocument();
       expect(screen.getByText(/^Handle$/i)).toBeInTheDocument();
       expect(screen.getByText(/^Description$/i)).toBeInTheDocument();
@@ -56,7 +78,7 @@ describe("ProductForm — one page, no tabs", () => {
     });
 
     it("shows options and shipping without a click", () => {
-      render(<ProductForm {...baseProps} />);
+      renderEdit();
       expect(
         screen.getByRole("button", { name: /add option/i }),
       ).toBeInTheDocument();
@@ -64,7 +86,7 @@ describe("ProductForm — one page, no tabs", () => {
     });
 
     it("names its sections as headings, so the page is navigable by structure", () => {
-      render(<ProductForm {...baseProps} />);
+      renderEdit();
       for (const name of [/^Details$/, /^Options$/, /^Shipping$/]) {
         expect(screen.getByRole("heading", { name })).toBeInTheDocument();
       }

--- a/apps/admin/components/products/ProductForm.tsx
+++ b/apps/admin/components/products/ProductForm.tsx
@@ -54,6 +54,8 @@ import { DetailsSection } from "./form/DetailsSection";
 import { PricingSection } from "./form/PricingSection";
 import { ShippingSection } from "./form/ShippingSection";
 import { ProductRail } from "./form/ProductRail";
+import { Field } from "./form/Field";
+import { ProductCategoriesPicker } from "./ProductCategoriesPicker";
 
 // RHF-side option shape (matches zod + OptionsEditor).
 interface RhfOptionDraft {
@@ -419,6 +421,134 @@ export function ProductForm({
     mode === "create" ? "New product" : (initialProduct?.title ?? "Product");
 
 
+  // --- Create -------------------------------------------------------------
+  // A short form that makes the product exist, then redirects into edit.
+  //
+  // It deliberately does NOT reuse the edit page's furniture. No rail: the
+  // rail holds metadata worth glancing at while scrolling a long page, and
+  // four fields have no scroll to glance across — building one anyway would
+  // be cargo-culting a shape whose justification is absent. No docked action
+  // bar either, for the same reason: that bar exists to answer "did I save"
+  // across a long scroll, and there is no long scroll here.
+  //
+  // max-w-2xl with NO mx-auto. AdminShell already owns the page width; the
+  // empty space to the right is the asymmetric margin this system asks for,
+  // not a mistake to correct by centring. Centring it would land straight on
+  // the generic signup-card look the design direction rules out.
+  //
+  // Media is absent rather than disabled — before the product exists there is
+  // nothing to attach an upload to, and a disabled dropzone is a promise the
+  // page cannot keep.
+  if (mode === "create") {
+    return (
+      <FormProvider {...methods}>
+        <form
+          onSubmit={methods.handleSubmit(onSubmit, onInvalid)}
+          className="flex flex-col gap-8"
+          aria-labelledby="product-form-heading"
+        >
+          <header className="flex flex-col gap-3">
+            <h1
+              id="product-form-heading"
+              className="font-serif text-2xl font-medium leading-tight tracking-tight text-foreground sm:text-3xl"
+            >
+              New product
+            </h1>
+          </header>
+
+          {rootError && (
+            <div
+              role="alert"
+              className="border-y border-[color:var(--danger)]/30 bg-[color:var(--danger)]/[0.06] px-4 py-3 text-sm text-[color:var(--danger)]"
+            >
+              {rootError}
+            </div>
+          )}
+
+          <div className="flex max-w-2xl flex-col gap-10">
+            <ProductSection
+              id="details"
+              title="Details"
+              description="You can add the description, media and options once it exists."
+            >
+              <div className="flex flex-col gap-6">
+                <DetailsSection mode="create" compact />
+                <Field label="Categories" error={methods.formState.errors.categoryIds?.message}>
+                  <ProductCategoriesPicker
+                    allCategories={categories}
+                    selectedIds={methods.watch("categoryIds")}
+                    onChange={(ids: string[]) =>
+                      methods.setValue("categoryIds", ids, { shouldDirty: true })
+                    }
+                    storeId={storeId}
+                  />
+                </Field>
+              </div>
+            </ProductSection>
+
+            <ProductSection
+              id="pricing"
+              title="Pricing and inventory"
+              description="A starting price and count. Both are editable straight after."
+            >
+              <PricingSection
+                mode="create"
+                currencyCode={currencyCode}
+                hasMultipleVariants={false}
+                storeId={storeId}
+              />
+            </ProductSection>
+
+            {/* Status is folded into the two actions rather than asked as a
+                fifth field. The merchant decides it by choosing how to save,
+                and asking twice — once as a select, once implicitly by
+                submitting — is the redundancy this redesign has been removing.
+                Both are inline-sized and flush left, so the page stays
+                asymmetric to its last element instead of resolving into a
+                centred footer. */}
+            <div className="flex flex-wrap items-center gap-4 border-t border-border-subtle pt-8">
+              <button
+                type="submit"
+                disabled={isPending}
+                onClick={() => methods.setValue("status", "draft")}
+                className="inline-flex items-center justify-center rounded-md bg-[color:var(--ink-900)] px-5 py-2 text-sm font-medium text-[color:var(--primary-foreground)] transition-colors hover:bg-[color:var(--moss-700)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isPending ? "Creating…" : "Create as draft"}
+              </button>
+              <button
+                type="submit"
+                disabled={isPending}
+                onClick={() => methods.setValue("status", "active")}
+                className="inline-flex items-center justify-center rounded-md border border-[color:var(--ink-200)] px-5 py-2 text-sm font-medium text-[color:var(--ink-900)] transition-colors hover:border-[color:var(--moss-700)] hover:text-[color:var(--moss-700)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Create and publish
+              </button>
+              <Link
+                href="/products"
+                onClick={handleDiscard}
+                className="text-sm text-foreground-secondary underline-offset-4 transition-colors hover:text-[color:var(--moss-700)] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]"
+              >
+                Cancel
+              </Link>
+            </div>
+          </div>
+        </form>
+
+        <AlertDialog
+          isOpen={discardOpen}
+          onClose={() => setDiscardOpen(false)}
+          title="Discard this product?"
+          message="Nothing has been created yet."
+          type="confirm"
+          confirmLabel="Discard"
+          cancelLabel="Keep editing"
+          onConfirm={confirmDiscard}
+          onCancel={() => setDiscardOpen(false)}
+        />
+      </FormProvider>
+    );
+  }
+
   return (
     <FormProvider {...methods}>
       <form
@@ -498,11 +628,7 @@ export function ProductForm({
               disabled={isPending}
               className="inline-flex items-center justify-center gap-2 rounded-md bg-[color:var(--ink-900)] px-5 py-2 text-sm font-medium text-[color:var(--primary-foreground)] transition-colors hover:bg-[color:var(--moss-700)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {isPending
-                ? "Saving…"
-                : mode === "create"
-                  ? "Create product"
-                  : "Save changes"}
+              {isPending ? "Saving…" : "Save changes"}
             </button>
             <Link
               href="/products"

--- a/apps/admin/components/products/form/DetailsSection.tsx
+++ b/apps/admin/components/products/form/DetailsSection.tsx
@@ -15,23 +15,38 @@ import { Field } from "./Field";
 
 export interface DetailsSectionProps {
   mode: "create" | "edit";
+  /**
+   * Title only. The create form asks for the few things needed to make the
+   * product exist and then redirects into edit, so handle and description
+   * are asked for where there is room for them rather than up front —
+   * handle auto-generates from the title anyway.
+   */
+  compact?: boolean;
 }
 
 const inputClass =
   "w-full rounded-md border border-[color:var(--ink-900)] border-opacity-20 bg-[color:var(--background-elevated,white)] px-3 py-2 text-sm text-[color:var(--ink-900)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]";
 
-export function DetailsSection({ mode }: DetailsSectionProps) {
+export function DetailsSection({ mode, compact = false }: DetailsSectionProps) {
   const { register, formState } = useFormContext<ProductFormValues>();
+
+  const titleField = (
+    <Field label="Title" error={formState.errors.title?.message}>
+      <input
+        type="text"
+        {...register("title")}
+        className={`${inputClass} text-base`}
+      />
+    </Field>
+  );
+
+  if (compact) {
+    return titleField;
+  }
 
   return (
     <div className="flex flex-col gap-6">
-      <Field label="Title" error={formState.errors.title?.message}>
-        <input
-          type="text"
-          {...register("title")}
-          className={`${inputClass} text-base`}
-        />
-      </Field>
+      {titleField}
 
       <Field
         label="Handle"


### PR DESCRIPTION
Change 3 of 3 from the `ux-design-specialist` pass on the product page. #543 did the variant matrix, #547 the docked action bar.

## The problem

"New product" rendered the **identical edit page** — Details, Pricing, Options, Shipping, Tax — including a Media section that cannot work before the product exists. That is why the chrome changed shape between create and edit in the first place: a section that has nothing to attach to is a promise the page cannot keep.

## What create asks for now

Title · Categories · Price · Stock · SKU. That is enough to make the product real; everything else is asked for in edit, where there is room.

- **Handle is dropped** — it auto-generates from the title, and the field's own helper already said so.
- **Description is dropped** — it has room on the edit page the merchant lands on a second later.
- **Media is absent, not disabled.**

`DetailsSection` gains a `compact` prop so the title input stays single-sourced rather than duplicated.

## Layout

**No rail.** The rail holds metadata worth glancing at while scrolling a long page. Four fields have no scroll to glance across, and building one anyway would be cargo-culting a shape whose justification is missing.

**No docked action bar**, unlike #547. That asymmetry is deliberate, not an oversight: the bar exists to answer "did I save" across a long scroll. There is no long scroll here. It is commented in the code so the next person doesn't assume it was forgotten.

**`max-w-2xl` with no `mx-auto`.** `AdminShell` already owns the page width. The empty space to the right is the asymmetric margin the system asks for — centring it would land straight on the generic signup-card look the design direction rules out.

## Status is an action, not a field

```
[ Create as draft ]  [ Create and publish ]  Cancel
```

Rather than a Status select *and* a submit button asking the same question twice. The merchant decides it by choosing how to save. Both actions are inline-sized and flush left, so the page stays asymmetric to its last element instead of resolving into a centred footer.

## Tests

`apps/admin`: **112 files, 891 tests, 0 failures** (884 before; +7 new, 4 existing updated).

Four existing tests asserted the full one-page layout while rendering `mode="create"` — they were really about the *edit* page, and now say so via a `renderEdit()` helper. The action-bar test that checked create's button label now asserts the create form has no sticky bar at all.

New `ProductForm.CreateForm.test.tsx` covers: the field set (and the absence of handle/description), the omitted sections, no rail, `max-w-2xl` without `mx-auto`, both actions present with no Status field, and that each action submits the status it names.

Mutation-tested, since most of those are absence assertions:

| mutant | caught by |
|---|---|
| add `mx-auto` to the column | *is left-aligned and constrained, never centred* |
| publish action sets `draft` | *creates an active product when the publish action is used* |
| render the rail in create | *has no rail* (+2 more) |

## Follow-up, not in this PR

The redirect after create already goes to the edit page via `createProductAction`. Worth a look separately at whether landing there should scroll to Media, since adding photos is the obvious next thing a merchant wants.