### PR TITLE
Stop footer React keys leaking phantom URLs that Google crawls as 404s

### DIFF
--- a/apps/onboarding/components/marketing/Footer.tsx
+++ b/apps/onboarding/components/marketing/Footer.tsx
@@ -118,7 +118,18 @@ function FooterColumn({ title, links }: FooterColumnProps) {
       </h2>
       <ul className="space-y-3">
         {links.map((l) => (
-          <li key={`${l.href}-${l.label}`}>
+          // Key on href alone, NOT `${href}-${label}`. React keys are
+          // serialised into the RSC flight payload embedded in the page,
+          // and Googlebot harvests URL-shaped strings out of it: a key of
+          // "/blog-Journal" was crawled as a real path and returned 404.
+          // Search Console had five of these (#147) — /blog-Journal,
+          // /cookies-Cookies, /refunds-Refunds among them — and every
+          // footer link was generating another one.
+          //
+          // href is already unique within a column, and if it ever does
+          // leak into the payload it resolves to a real page instead of a
+          // phantom 404. Don't reintroduce a composite key here.
+          <li key={l.href}>
             <Link
               href={l.href}
               className="text-[0.9375rem] text-paper-400 hover:text-paper-50"

--- a/apps/onboarding/public/llms.txt
+++ b/apps/onboarding/public/llms.txt
@@ -11,8 +11,18 @@ The project is pre-launch. The marketing site at https://mark8ly.com is the prim
 - [Home](https://mark8ly.com/): The main landing page — product positioning, pricing, how it works, FAQs.
 - [About](https://mark8ly.com/about): Who we are, what we believe, where we're based.
 - [Contact](https://mark8ly.com/contact): Email channels for general support, partnerships, legal, and press.
+- [Help & FAQ](https://mark8ly.com/help): Answers to the questions merchants actually ask — trial, pricing, domains, payments, shipping, inventory, data export.
+- [Integrations](https://mark8ly.com/integrations): What Mark8ly connects to today — payments, shipping, tax, email, and the REST API.
+- [Guides](https://mark8ly.com/guides): How-to guides for new merchants — starting a store, pricing handmade products, accepting UPI, adding your first product, connecting a domain.
 - [Privacy](https://mark8ly.com/privacy): Plain-language privacy policy. We don't sell personal information.
 - [Terms](https://mark8ly.com/terms): Terms of service.
+
+## Comparison pages
+
+- [Shopify alternative](https://mark8ly.com/shopify-alternative): For merchants comparing against Shopify, with no platform transaction fees.
+- [Etsy alternative](https://mark8ly.com/etsy-alternative): For sellers who want their own website rather than a marketplace listing.
+- [Ecommerce for makers](https://mark8ly.com/ecommerce-for-makers): For makers and handmade sellers.
+- [Sell online in India](https://mark8ly.com/sell-online-india): UPI, wallets, and local cards for Indian merchants.
 
 ## Pricing
 
@@ -30,7 +40,9 @@ Indie merchants, small batch makers, boutique brands, and established small-to-m
 
 ## Not indexed
 
-The onboarding funnel (/onboarding/*), the welcome page, and the "coming soon" stubs (blog, help, guides, integrations, legal security page) are intentionally excluded from indexing. They're either funnel destinations or placeholder content.
+The onboarding funnel (/onboarding/*) and the welcome page are intentionally excluded from indexing — they're funnel destinations, not content. The Journal (/blog) is also excluded while it has no articles yet, and the DPA (/dpa) is excluded because it's an auto-accepted contract rather than something anyone should find in search.
+
+Help, Guides, and Integrations were previously "coming soon" stubs and are no longer — they carry real content and are indexed. They're listed under Core pages above.
 
 ## Contact
 

--- a/apps/onboarding/tests/unit/footer-keys.spec.ts
+++ b/apps/onboarding/tests/unit/footer-keys.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Regression guard for GitHub issue #147.
+ *
+ * React keys don't stay in React. In the App Router they are serialised
+ * into the RSC flight payload that ships inside the HTML document, and
+ * Googlebot harvests URL-shaped strings out of that payload and crawls
+ * them. The footer used to key its list items on `${href}-${label}`,
+ * which produced strings like:
+ *
+ *     ["$","li","/blog-Journal",{...,"href":"/blog",...}]
+ *
+ * The href was always correct — but Google crawled the *key*. Search
+ * Console's "Not found (404)" report filled up with phantom paths:
+ * /blog-Journal, /cookies-Cookies, /refunds-Refunds, and every other
+ * footer link was queued to produce one.
+ *
+ * The rule this pins down: a key that a crawler could mistake for a path
+ * must not be built by concatenating an href with anything. Keying on the
+ * href alone is fine — it is unique per column, and if it does leak it
+ * resolves to a real page.
+ */
+const FOOTER_SOURCES: ReadonlyArray<string> = [
+  "components/marketing/Footer.tsx",
+  "components/onboarding/SlimFooter.tsx",
+];
+
+// A key built as `${something}-${somethingElse}` inside a template
+// literal — the exact shape that produced the phantom URLs.
+const COMPOSITE_KEY = /key=\{`[^`]*\$\{[^}]*\}[^`]*-[^`]*\$\{[^}]*\}[^`]*`\}/;
+
+for (const relative of FOOTER_SOURCES) {
+  test(`${relative} does not build a URL-shaped composite React key`, () => {
+    const file = path.join(__dirname, "../..", relative);
+    const source = readFileSync(file, "utf8");
+
+    const offending = source
+      .split("\n")
+      .map((line, i) => ({ line: line.trim(), number: i + 1 }))
+      .filter(({ line }) => COMPOSITE_KEY.test(line));
+
+    expect(
+      offending,
+      `${relative} builds a React key by concatenating interpolated values. ` +
+        "If either half is an href, the key serialises into the RSC payload " +
+        "as a path-shaped string and Googlebot crawls it as a real URL, " +
+        "producing a 404 that never existed (#147). Key on the href alone.",
+    ).toEqual([]);
+  });
+}
+
+test("footer link hrefs are unique, so keying on href alone is safe", () => {
+  const file = path.join(__dirname, "../../components/marketing/Footer.tsx");
+  const source = readFileSync(file, "utf8");
+
+  const hrefs = [...source.matchAll(/\{\s*href:\s*"([^"]+)"/g)].map((m) => m[1]);
+
+  expect(hrefs.length).toBeGreaterThan(0);
+  expect(new Set(hrefs).size).toBe(hrefs.length);
+});


### PR DESCRIPTION
Fixes the actual cause of Search Console's "Not found (404)" report, now that I have the real URLs.

## The five 404s

Pulled from Search Console (Indexing → Pages → Not found (404), 5 affected, first detected 4/14/26):

| URL | Last crawled |
|---|---|
| `https://mark8ly.com/blog-Journal` | Apr 16, 2026 |
| `https://mark8ly.com/refunds-Refunds` | May 30, 2026 |
| `https://mark8ly.com/cookies-Cookies` | Jul 8, 2026 |
| `https://india-store.mark8ly.com/` | May 20, 2026 |
| `https://admin.mark8ly.com/` | Jul 31, 2026 |

The first three share a shape: `{path}-{NavLabel}`. They are **React keys**, not hrefs.

## Root cause

`Footer.tsx` keyed its list items on `` `${l.href}-${l.label}` ``. That's ordinary, correct React — but in the App Router **keys are serialised into the RSC flight payload embedded in the HTML**, and Googlebot harvests URL-shaped strings out of it. Straight from the live homepage:

```
["$","li","/blog-Journal",{"children":["$","$L5",null,{"href":"/blog", ... ,"children":"Journal"}]}]
              ^^^^^^^^^^^^ the key — crawled as a path
```

The `href` was always `/blog` and always correct. Google crawled the key.

**This was ongoing, not historical.** Every footer link was queuing up another phantom 404 — `/guides-Guides` and `/about-About` both 404 right now and simply hadn't been crawled yet. Three had surfaced; there were nine more waiting.

Fixed by keying on `l.href` alone: unique within each column, and if it ever does leak it resolves to a real page instead of a phantom.

## Regression guard

`tests/unit/footer-keys.spec.ts` fails the build on a key built by concatenating interpolated values in either footer, and separately asserts footer hrefs are unique so keying on href alone stays safe.

**Verified the guard actually fails on the old code** — reverted the fix, ran it, watched it fail, restored. A guard that can't fail isn't a guard.

## Also: `llms.txt` was stale

It still told AI crawlers that help, guides and integrations were "coming soon" stubs excluded from indexing. #546 gave all three real content and indexed them. Updated to list them (plus the four comparison pages, which were never there), and rewrote the "Not indexed" section to describe what's actually excluded — the funnel, `/blog` while it has no articles, and `/dpa`.

## The other two 404s — no code change needed

- **`india-store.mark8ly.com`** — a tenant slug that doesn't resolve to an onboarded store. The storefront middleware 404s unknown slugs deliberately (the wildcard-subdomain guard). Working as designed; it'll age out of the report.
- **`admin.mark8ly.com`** — not a routed host (merchant admin is `{slug}-admin.mark8ly.com`). A 404 is honest. Could be a 301 to the marketing site for tidiness, but that's Cloudflare/Istio routing, not this repo.

## Verification

- `tests/unit/footer-keys.spec.ts` — 3 passed, and confirmed failing on the pre-fix code
- 45 unit tests pass across footer-keys, guides, help-integrations-seo, mail-link, csp, journal-signup, journal-unsubscribe

**Not fully verified locally:** `@tesserix/web` is currently absent from `node_modules`, so the four specs importing it error out. Confirmed environmental, not caused by this change — the identical failure reproduces on unmodified `origin/main` in the same worktree (`git stash`, re-run, same errors). CI installs properly and will cover them.

## Note on #147

My earlier comment on that issue guessed the 404s were the Cloudflare `/cdn-cgi/l/email-protection` rewrites. **That was wrong** — none of the five are cdn-cgi URLs. That fix was still worth shipping (it was breaking every "email us" link for real visitors, a UX bug independent of crawling), but it did not address this report. This does.
