### PR TITLE
fix(admin): render the product's values in the server HTML instead of after hydration

### DIFF
--- a/apps/admin/components/products/ProductForm.ServerMarkup.test.tsx
+++ b/apps/admin/components/products/ProductForm.ServerMarkup.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+
+import type { AdminCategory, AdminProduct } from "@/lib/api/marketplace-api";
+
+vi.mock("@/app/(admin)/products/actions", () => ({
+  createProductAction: vi.fn(),
+  updateProductAction: vi.fn(),
+  deleteProductAction: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+vi.mock("./form/MediaTab", () => ({
+  MediaTab: () => <div data-testid="media-tab-stub" />,
+}));
+
+import { ProductForm } from "./ProductForm";
+
+const categories: AdminCategory[] = [];
+
+const baseProps = {
+  storeId: "s1",
+  categories,
+  currencyCode: "AUD",
+  storeCountryCode: "AU",
+  canDelete: false,
+  canArchive: false,
+  session: { userId: "u1", tenantId: "t1" },
+};
+
+function product(): AdminProduct {
+  return {
+    id: "p1",
+    title: "Bondi Beach Cotton Towel",
+    handle: "bondi-beach-cotton-towel",
+    description: "Turkish cotton, woven flat-weave.",
+    status: "active",
+    categories: [],
+    options: [],
+    media: [],
+    variants: [
+      {
+        id: "v1",
+        sku: "TBS-BBCT-100X180CM",
+        price: "75",
+        inventory_quantity: 28,
+        option_values: [],
+        weight_grams: 620,
+      },
+    ],
+  } as unknown as AdminProduct;
+}
+
+// The page is a server component that already holds the product, but the
+// form is a client component driven by react-hook-form. register() returns
+// only { name, onChange, onBlur, ref } — no value, no defaultValue — so the
+// server HTML shipped EMPTY inputs and the values appeared only once the
+// client hydrated and RHF wrote them through its refs.
+//
+// The visible result was a form that looked like a product with no data, or
+// a failed load: heading and breadcrumb correct immediately, Title blank and
+// Handle showing its placeholder for a beat on every load.
+//
+// renderToString is the honest test for this: it is the server pass, with no
+// hydration to paper over the gap.
+describe("ProductForm — server-rendered markup", () => {
+  const html = () =>
+    renderToString(
+      <ProductForm {...baseProps} mode="edit" initialProduct={product()} />,
+    );
+
+  it("carries the product's values before any hydration", () => {
+    const markup = html();
+    expect(markup).toContain('value="Bondi Beach Cotton Towel"');
+    expect(markup).toContain('value="bondi-beach-cotton-towel"');
+    expect(markup).toContain('value="75"');
+    expect(markup).toContain('value="TBS-BBCT-100X180CM"');
+    expect(markup).toContain('value="28"');
+  });
+
+  it("renders the description into the textarea, not as an empty box", () => {
+    expect(html()).toContain("Turkish cotton, woven flat-weave.");
+  });
+
+  it("carries shipping values too", () => {
+    // 620g -> 0.62kg, set on the form's defaults.
+    expect(html()).toContain('value="0.62"');
+  });
+});

--- a/apps/admin/components/products/form/DetailsSection.tsx
+++ b/apps/admin/components/products/form/DetailsSection.tsx
@@ -13,6 +13,17 @@ import { useFormContext } from "react-hook-form";
 import type { ProductFormValues } from "@/lib/validation/product-form";
 import { Field } from "./Field";
 
+// RHF's register() returns only { name, onChange, onBlur, ref } — no value
+// and no defaultValue — so a server-rendered form emits EMPTY inputs and the
+// values appear only once the client has hydrated and RHF has written them
+// through its refs. On the product page that showed as a real flash: the
+// heading and breadcrumb (plain JSX) were correct immediately while Title sat
+// empty and Handle showed its placeholder, which reads exactly like a product
+// with no data — or a failed load.
+//
+// Passing defaultValue puts the value in the server HTML. It affects nothing
+// after hydration: RHF owns the input imperatively from then on, and a later
+// reset() sets .value directly rather than consulting the attribute.
 export interface DetailsSectionProps {
   mode: "create" | "edit";
   /**
@@ -28,13 +39,14 @@ const inputClass =
   "w-full rounded-md border border-[color:var(--ink-900)] border-opacity-20 bg-[color:var(--background-elevated,white)] px-3 py-2 text-sm text-[color:var(--ink-900)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]";
 
 export function DetailsSection({ mode, compact = false }: DetailsSectionProps) {
-  const { register, formState } = useFormContext<ProductFormValues>();
+  const { register, formState, getValues } = useFormContext<ProductFormValues>();
 
   const titleField = (
     <Field label="Title" error={formState.errors.title?.message}>
       <input
         type="text"
         {...register("title")}
+          defaultValue={getValues("title")}
         className={`${inputClass} text-base`}
       />
     </Field>
@@ -60,6 +72,7 @@ export function DetailsSection({ mode, compact = false }: DetailsSectionProps) {
         <input
           type="text"
           {...register("handle")}
+          defaultValue={getValues("handle")}
           placeholder="linen-shirt"
           className={inputClass}
         />
@@ -72,6 +85,7 @@ export function DetailsSection({ mode, compact = false }: DetailsSectionProps) {
       >
         <textarea
           {...register("description")}
+          defaultValue={getValues("description")}
           rows={6}
           className={`${inputClass} resize-vertical`}
         />

--- a/apps/admin/components/products/form/PricingSection.tsx
+++ b/apps/admin/components/products/form/PricingSection.tsx
@@ -22,6 +22,17 @@ import { Field } from "./Field";
 import { VariantsTab } from "./VariantsTab";
 import { VariantStockByWarehouse } from "./VariantStockByWarehouse";
 
+// RHF's register() returns only { name, onChange, onBlur, ref } — no value
+// and no defaultValue — so a server-rendered form emits EMPTY inputs and the
+// values appear only once the client has hydrated and RHF has written them
+// through its refs. On the product page that showed as a real flash: the
+// heading and breadcrumb (plain JSX) were correct immediately while Title sat
+// empty and Handle showed its placeholder, which reads exactly like a product
+// with no data — or a failed load.
+//
+// Passing defaultValue puts the value in the server HTML. It affects nothing
+// after hydration: RHF owns the input imperatively from then on, and a later
+// reset() sets .value directly rather than consulting the attribute.
 export interface PricingSectionProps {
   mode: "create" | "edit";
   currencyCode: string;
@@ -51,7 +62,7 @@ export function PricingSection({
   stockByLocation = {},
   stockByVariant = {},
 }: PricingSectionProps) {
-  const { register, formState, watch } = useFormContext<ProductFormValues>();
+  const { register, formState, watch, getValues } = useFormContext<ProductFormValues>();
 
   // With options defined, the variants themselves carry price and stock —
   // the table IS this section.
@@ -86,6 +97,7 @@ export function PricingSection({
             inputMode="decimal"
             placeholder="19.99"
             {...register("price")}
+            defaultValue={getValues("price")}
             className={inputClass}
           />
         </Field>
@@ -96,6 +108,7 @@ export function PricingSection({
               inputMode="numeric"
               placeholder="0"
               {...register("inventoryQuantity")}
+              defaultValue={getValues("inventoryQuantity")}
               className={inputClass}
             />
           </Field>
@@ -105,6 +118,7 @@ export function PricingSection({
             type="text"
             placeholder="Auto-generated from handle"
             {...register("sku")}
+            defaultValue={getValues("sku")}
             className={inputClass}
           />
         </Field>

--- a/apps/admin/components/products/form/ShippingSection.tsx
+++ b/apps/admin/components/products/form/ShippingSection.tsx
@@ -22,8 +22,19 @@ import { Field } from "./Field";
 const inputClass =
   "w-full rounded-md border border-[color:var(--ink-900)] border-opacity-20 bg-[color:var(--background-elevated,white)] px-3 py-2 text-sm text-[color:var(--ink-900)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]";
 
+// RHF's register() returns only { name, onChange, onBlur, ref } — no value
+// and no defaultValue — so a server-rendered form emits EMPTY inputs and the
+// values appear only once the client has hydrated and RHF has written them
+// through its refs. On the product page that showed as a real flash: the
+// heading and breadcrumb (plain JSX) were correct immediately while Title sat
+// empty and Handle showed its placeholder, which reads exactly like a product
+// with no data — or a failed load.
+//
+// Passing defaultValue puts the value in the server HTML. It affects nothing
+// after hydration: RHF owns the input imperatively from then on, and a later
+// reset() sets .value directly rather than consulting the attribute.
 export function ShippingSection() {
-  const { register, formState, watch } = useFormContext<ProductFormValues>();
+  const { register, formState, watch, getValues } = useFormContext<ProductFormValues>();
 
   // Blank, whitespace, unparseable or non-positive all mean "no usable
   // weight" — each ends up as the store's fallback at checkout.
@@ -38,17 +49,18 @@ export function ShippingSection() {
             inputMode="decimal"
             placeholder="0.5"
             {...register("weightKg")}
+            defaultValue={getValues("weightKg")}
             className={inputClass}
           />
         </Field>
         <Field label="Length (cm)" error={formState.errors.lengthCm?.message}>
-          <input type="text" inputMode="decimal" {...register("lengthCm")} className={inputClass} />
+          <input type="text" inputMode="decimal" {...register("lengthCm")} defaultValue={getValues("lengthCm")} className={inputClass} />
         </Field>
         <Field label="Width (cm)" error={formState.errors.widthCm?.message}>
-          <input type="text" inputMode="decimal" {...register("widthCm")} className={inputClass} />
+          <input type="text" inputMode="decimal" {...register("widthCm")} defaultValue={getValues("widthCm")} className={inputClass} />
         </Field>
         <Field label="Height (cm)" error={formState.errors.heightCm?.message}>
-          <input type="text" inputMode="decimal" {...register("heightCm")} className={inputClass} />
+          <input type="text" inputMode="decimal" {...register("heightCm")} defaultValue={getValues("heightCm")} className={inputClass} />
         </Field>
       </div>
 


### PR DESCRIPTION
Fixes #549.

## The flash

Loading `/products/<id>` painted an **empty** form for a beat: Title blank, Handle showing its placeholder (`linen-shirt`), Description empty, then everything appeared. It happened on every load. It reads exactly like a product with no data, or a failed fetch — and on a slow connection a merchant who starts typing into that apparently-empty Title has it overwritten when the real value lands.

I filed #549 as a symptom report because I had not confirmed a cause. This is the cause.

## Why

The page is a **server component** that already holds the product:

```tsx
const [product, categories, warehouses] = await Promise.all([...]);
return <ProductForm mode="edit" initialProduct={product} … />
```

But the form is a client component driven by react-hook-form, and `register()` returns only `{ name, onChange, onBlur, ref }` — **no `value`, no `defaultValue`**. So the server-rendered HTML contains genuinely empty inputs, and RHF writes the values imperatively through its refs once the client has hydrated.

That is why the heading and breadcrumb were correct immediately: they are plain JSX. Only the registered inputs lagged. Not a race, not a slow fetch — the data was always there, it simply never reached the markup.

## The fix

Pass `defaultValue` alongside `register` on the nine registered inputs in `DetailsSection`, `PricingSection` and `ShippingSection`, sourced from `getValues()` — which during the server pass returns the form's `defaultValues`, i.e. the product.

It changes nothing after hydration: RHF owns the input imperatively from that point, and a later `reset()` sets `.value` directly rather than consulting the attribute.

## Tests

`apps/admin`: **113 files, 894 tests, 0 failures** (891 before; +3).

New `ProductForm.ServerMarkup.test.tsx` uses `renderToString` — the actual server pass, with no hydration to paper over the gap — and asserts the markup carries the title, handle, price, SKU, stock, description and weight.

**Verified against the pre-fix state**, since a test that cannot fail proves nothing here: stripping every `defaultValue` back out fails all three cases, and restoring them passes 3/3. That is also what confirms the diagnosis rather than merely asserting it.

## Scope

Only the inputs that visibly flashed. `Status` and `Categories` are `@tesserix/web` `Select` / `ProductCategoriesPicker` driven by `watch()`, which is a different mechanism — they were not part of the reported symptom and are left alone.