### PR TITLE
feat(admin): stop in-app navigation discarding unsaved edits without asking

### DIFF
--- a/apps/admin/components/products/ProductForm.tsx
+++ b/apps/admin/components/products/ProductForm.tsx
@@ -526,6 +526,8 @@ export function ProductForm({
               <Link
                 href="/products"
                 onClick={handleDiscard}
+                // Owns its own confirmation, as on the edit page.
+                data-unsaved-guard="off"
                 className="text-sm text-foreground-secondary underline-offset-4 transition-colors hover:text-[color:var(--moss-700)] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]"
               >
                 Cancel
@@ -633,6 +635,10 @@ export function ProductForm({
             <Link
               href="/products"
               onClick={handleDiscard}
+              // This link already opens its own styled confirmation, so the
+              // global navigation guard steps aside rather than stacking a
+              // second dialog on the same click.
+              data-unsaved-guard="off"
               className="text-sm text-foreground-secondary underline-offset-4 transition-colors hover:text-[color:var(--moss-700)] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]"
             >
               Discard

--- a/apps/admin/components/shell/AdminShell.tsx
+++ b/apps/admin/components/shell/AdminShell.tsx
@@ -16,6 +16,8 @@ import {
   LogOut,
   ChevronDown,
 } from "lucide-react";
+
+import { UnsavedChangesProvider } from "./UnsavedChangesGuard";
 import {
   Sidebar,
   SidebarContent,
@@ -385,7 +387,11 @@ function AdminShellFrame({
             prose inside pages is constrained by its own max-w-2xl/3xl so
             text measure stays readable. */}
         <main id="main" className="flex-1 px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
-          <div className="mx-auto w-full max-w-6xl">{children}</div>
+          <div className="mx-auto w-full max-w-6xl">
+            {/* Wraps the content, not the chrome, but the click listener is
+                on document — so sidebar and topbar links are guarded too. */}
+            <UnsavedChangesProvider>{children}</UnsavedChangesProvider>
+          </div>
         </main>
       </SidebarInset>
     </>

--- a/apps/admin/components/shell/UnsavedChangesGuard.test.tsx
+++ b/apps/admin/components/shell/UnsavedChangesGuard.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }));
+
+import {
+  UnsavedChangesProvider,
+  useUnsavedNavigationGuard,
+} from "./UnsavedChangesGuard";
+
+/** A form that reports itself dirty, exactly as useUnsavedGuard does. */
+function DirtyForm({ dirty = true, submitting = false }) {
+  useUnsavedNavigationGuard("form-1", dirty, submitting);
+  return <p>form</p>;
+}
+
+function renderWithLinks(form: React.ReactNode, links: React.ReactNode) {
+  return render(
+    <UnsavedChangesProvider>
+      {form}
+      {links}
+    </UnsavedChangesProvider>,
+  );
+}
+
+const dialog = () => screen.queryByText(/leave without saving\?/i);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.history.pushState({}, "", "/products/p1");
+});
+
+// App Router navigation fires no beforeunload, so a sidebar link with a dirty
+// form used to unmount it and discard the edits with no warning at all. That
+// is the silent half this guard exists to close — the loud half (refresh, tab
+// close) stays with beforeunload, whose dialog the browser owns.
+describe("UnsavedChangesGuard", () => {
+  it("intercepts an in-app link while a form is dirty", () => {
+    renderWithLinks(<DirtyForm />, <a href="/orders">Orders</a>);
+    fireEvent.click(screen.getByText("Orders"));
+    expect(dialog()).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("navigates once the merchant confirms", () => {
+    renderWithLinks(<DirtyForm />, <a href="/orders">Orders</a>);
+    fireEvent.click(screen.getByText("Orders"));
+    fireEvent.click(screen.getByRole("button", { name: /^leave$/i }));
+    expect(push).toHaveBeenCalledWith("/orders");
+  });
+
+  it("stays put when they decline, and can still be asked again", () => {
+    renderWithLinks(<DirtyForm />, <a href="/orders">Orders</a>);
+    fireEvent.click(screen.getByText("Orders"));
+    fireEvent.click(screen.getByRole("button", { name: /stay on this page/i }));
+    expect(push).not.toHaveBeenCalled();
+    expect(dialog()).not.toBeInTheDocument();
+
+    // The guard must not disarm itself by asking once.
+    fireEvent.click(screen.getByText("Orders"));
+    expect(dialog()).toBeInTheDocument();
+  });
+
+  it("lets the click through when nothing is dirty", () => {
+    renderWithLinks(<DirtyForm dirty={false} />, <a href="/orders">Orders</a>);
+    fireEvent.click(screen.getByText("Orders"));
+    expect(dialog()).not.toBeInTheDocument();
+  });
+
+  it("lets the click through while the form is submitting", () => {
+    // A save in flight is about to navigate on purpose; asking there would
+    // interrupt the very action the merchant took.
+    renderWithLinks(<DirtyForm submitting />, <a href="/orders">Orders</a>);
+    fireEvent.click(screen.getByText("Orders"));
+    expect(dialog()).not.toBeInTheDocument();
+  });
+
+  it("releases the form's claim when it unmounts", () => {
+    const { rerender } = renderWithLinks(<DirtyForm />, <a href="/orders">Orders</a>);
+    rerender(
+      <UnsavedChangesProvider>
+        <a href="/orders">Orders</a>
+      </UnsavedChangesProvider>,
+    );
+    fireEvent.click(screen.getByText("Orders"));
+    expect(dialog()).not.toBeInTheDocument();
+  });
+
+  // Each of these unmounts nothing, or is already covered by beforeunload.
+  describe("clicks it must not intercept", () => {
+    it("a new-tab link", () => {
+      renderWithLinks(
+        <DirtyForm />,
+        <a href="/orders" target="_blank" rel="noreferrer">Orders</a>,
+      );
+      fireEvent.click(screen.getByText("Orders"));
+      expect(dialog()).not.toBeInTheDocument();
+    });
+
+    it("a cmd/ctrl click", () => {
+      renderWithLinks(<DirtyForm />, <a href="/orders">Orders</a>);
+      fireEvent.click(screen.getByText("Orders"), { metaKey: true });
+      expect(dialog()).not.toBeInTheDocument();
+    });
+
+    it("an external link, which beforeunload already covers", () => {
+      renderWithLinks(
+        <DirtyForm />,
+        <a href="https://example.com/x">Away</a>,
+      );
+      fireEvent.click(screen.getByText("Away"));
+      expect(dialog()).not.toBeInTheDocument();
+    });
+
+    it("an in-page anchor", () => {
+      renderWithLinks(<DirtyForm />, <a href="#media">Media</a>);
+      fireEvent.click(screen.getByText("Media"));
+      expect(dialog()).not.toBeInTheDocument();
+    });
+
+    it("a download link", () => {
+      renderWithLinks(<DirtyForm />, <a href="/invoice.pdf" download>Invoice</a>);
+      fireEvent.click(screen.getByText("Invoice"));
+      expect(dialog()).not.toBeInTheDocument();
+    });
+
+    it("a link back to the page already open", () => {
+      renderWithLinks(<DirtyForm />, <a href="/products/p1">This product</a>);
+      fireEvent.click(screen.getByText("This product"));
+      expect(dialog()).not.toBeInTheDocument();
+    });
+
+    it("an anchor that owns its own confirmation", () => {
+      // ProductForm's Discard already opens a styled dialog of its own.
+      renderWithLinks(
+        <DirtyForm />,
+        <a href="/products" data-unsaved-guard="off">Discard</a>,
+      );
+      fireEvent.click(screen.getByText("Discard"));
+      expect(dialog()).not.toBeInTheDocument();
+    });
+
+    it("a plain button", () => {
+      renderWithLinks(<DirtyForm />, <button type="button">Save</button>);
+      fireEvent.click(screen.getByText("Save"));
+      expect(dialog()).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/admin/components/shell/UnsavedChangesGuard.tsx
+++ b/apps/admin/components/shell/UnsavedChangesGuard.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+// UnsavedChangesGuard — the half of the unsaved-changes story that
+// `beforeunload` cannot cover.
+//
+// There were two guards and between them they protected the wrong things.
+// `beforeunload` fires for refresh, tab close and leaving the site, and its
+// dialog is drawn by the browser — unstyleable by design, and the one people
+// complain about. In-app navigation fires it not at all: App Router
+// transitions the client, so clicking any sidebar link with a dirty form
+// unmounted it and the edits were gone. Loud where it could not be styled,
+// silent where it actually cost work.
+//
+// This closes the silent half. A capture-phase click listener intercepts
+// same-origin link navigations while any form reports itself dirty, and asks
+// with the system's own dialog.
+//
+// Capture phase, deliberately: it has to run before Next's Link handler
+// starts the transition. An anchor that wants to own its own confirmation
+// opts out with data-unsaved-guard="off".
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+
+import { AlertDialog } from "@tesserix/web";
+
+interface UnsavedChangesContextValue {
+  /** Report a form's dirtiness. Keyed so several forms can coexist. */
+  setDirty: (key: string, dirty: boolean) => void;
+}
+
+const UnsavedChangesContext =
+  React.createContext<UnsavedChangesContextValue | null>(null);
+
+/**
+ * Registers this form's dirty state with the navigation guard.
+ *
+ * Safe to call outside the provider — it becomes a no-op, so a form rendered
+ * on its own (a test, a standalone page) behaves exactly as before.
+ */
+export function useUnsavedNavigationGuard(
+  key: string,
+  isDirty: boolean,
+  isSubmitting: boolean,
+): void {
+  const ctx = React.useContext(UnsavedChangesContext);
+  const setDirty = ctx?.setDirty;
+
+  React.useEffect(() => {
+    if (!setDirty) return;
+    setDirty(key, isDirty && !isSubmitting);
+    // Clearing on unmount matters: a form that navigated away is no longer
+    // holding anything, and a stale "dirty" would block every later click.
+    return () => setDirty(key, false);
+  }, [setDirty, key, isDirty, isSubmitting]);
+}
+
+/** True when this click should be left alone rather than intercepted. */
+function isPlainLinkNavigation(e: MouseEvent): HTMLAnchorElement | null {
+  // Anything but an unmodified primary click is the user asking for a new
+  // tab or window, which does not unmount the form.
+  if (e.defaultPrevented) return null;
+  if (e.button !== 0) return null;
+  if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return null;
+
+  const anchor = (e.target as HTMLElement | null)?.closest?.("a");
+  if (!anchor) return null;
+  if (anchor.dataset.unsavedGuard === "off") return null;
+  if (anchor.hasAttribute("download")) return null;
+  if (anchor.target && anchor.target !== "_self") return null;
+
+  const href = anchor.getAttribute("href");
+  if (!href || href.startsWith("#")) return null;
+
+  let url: URL;
+  try {
+    url = new URL(anchor.href, window.location.href);
+  } catch {
+    return null;
+  }
+  // A different origin unloads the document, so beforeunload already asks.
+  if (url.origin !== window.location.origin) return null;
+  // Same page: nothing unmounts.
+  if (url.pathname === window.location.pathname && url.search === window.location.search) {
+    return null;
+  }
+  return anchor;
+}
+
+export function UnsavedChangesProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+  const dirtyRef = React.useRef<Map<string, boolean>>(new Map());
+  const [pendingHref, setPendingHref] = React.useState<string | null>(null);
+
+  const setDirty = React.useCallback((key: string, dirty: boolean) => {
+    if (dirty) dirtyRef.current.set(key, true);
+    else dirtyRef.current.delete(key);
+  }, []);
+
+  React.useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (dirtyRef.current.size === 0) return;
+      const anchor = isPlainLinkNavigation(e);
+      if (!anchor) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+      const url = new URL(anchor.href, window.location.href);
+      setPendingHref(url.pathname + url.search);
+    };
+
+    document.addEventListener("click", onClick, true);
+    return () => document.removeEventListener("click", onClick, true);
+  }, []);
+
+  const value = React.useMemo(() => ({ setDirty }), [setDirty]);
+
+  return (
+    <UnsavedChangesContext.Provider value={value}>
+      {children}
+      <AlertDialog
+        isOpen={pendingHref !== null}
+        onClose={() => setPendingHref(null)}
+        title="Leave without saving?"
+        message="Your unsaved changes will be lost."
+        type="confirm"
+        confirmLabel="Leave"
+        cancelLabel="Stay on this page"
+        onConfirm={() => {
+          const href = pendingHref;
+          // The forms this guard protects unmount on navigation and clear
+          // their own entry, but clearing here too means a confirmed leave
+          // can never be blocked a second time by a form that is slow to
+          // tear down.
+          dirtyRef.current.clear();
+          setPendingHref(null);
+          if (href) router.push(href);
+        }}
+        onCancel={() => setPendingHref(null)}
+      />
+    </UnsavedChangesContext.Provider>
+  );
+}

--- a/apps/admin/lib/hooks/useUnsavedGuard.ts
+++ b/apps/admin/lib/hooks/useUnsavedGuard.ts
@@ -1,13 +1,21 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useId } from "react";
+
+import { useUnsavedNavigationGuard } from "@/components/shell/UnsavedChangesGuard";
 
 /**
- * Attach a `beforeunload` warning when the form has dirty changes so the
- * user doesn't lose work by refreshing / closing the tab / following an
- * external link. App Router client-side navigation doesn't trigger
- * beforeunload — for that, intercept the back / discard click and show a
- * confirm dialog.
+ * Guards unsaved work on both routes out of a page.
+ *
+ * `beforeunload` covers refresh, tab close and leaving the site. Its dialog
+ * is the browser's own and cannot be styled — that is a browser guarantee,
+ * not a choice we get to make here.
+ *
+ * App Router navigation fires no beforeunload at all, so the same dirty
+ * state is also reported to UnsavedChangesProvider, which intercepts
+ * same-origin link clicks and asks with the system's dialog. Without it,
+ * clicking any sidebar link discarded the edits silently — the failure this
+ * hook looked like it was already preventing.
  *
  * @param isDirty true when the form has unsaved edits
  * @param isSubmitting true while a save is in flight (suppresses the
@@ -17,6 +25,10 @@ export function useUnsavedGuard(
   isDirty: boolean,
   isSubmitting: boolean = false,
 ): void {
+  // A stable per-instance key, so two dirty forms on one page each hold
+  // their own entry rather than overwriting one another.
+  useUnsavedNavigationGuard(useId(), isDirty, isSubmitting);
+
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {
       if (!isDirty || isSubmitting) return;


### PR DESCRIPTION
Fixes #548.

## The gap

There were two guards, and between them they covered the wrong half.

| leaving via | before |
|---|---|
| refresh / tab close | Chrome's native "Leave site?" — unstyleable, and the one people complain about |
| the Discard link | the correct styled dialog |
| **any sidebar link** | **nothing; edits silently lost** |

`useUnsavedGuard` attaches `beforeunload`, which App Router navigation never fires — its own docstring says so. `handleDiscard` intercepts exactly one anchor. Every other `<Link>` in `AdminShell` transitioned the client, unmounted the form, and took the edits with it.

## The fix

`UnsavedChangesProvider`, mounted in `AdminShell` around the admin content, installs a **capture-phase** `click` listener on `document` and intercepts same-origin link navigations while any form reports itself dirty — asking with the system's own `AlertDialog` instead.

Capture phase is required, not stylistic: it has to run before Next's `Link` handler starts the transition.

`useUnsavedGuard` now reports into the provider as well as attaching `beforeunload`, so **all four existing call sites are covered with no change to them** — `ProductForm`, `BrandingSettingsClient`, `GeneralSettingsForm`, `CouponForm`. Dirtiness is keyed per form instance via `useId`, so two dirty forms on one page each hold their own claim.

Anchors that already own a confirmation opt out with `data-unsaved-guard="off"` — used on `ProductForm`'s Discard and the create form's Cancel, so neither stacks a second dialog on one click.

## What it deliberately does not touch

`beforeunload` stays for refresh, tab close and cross-origin links. Its dialog **cannot be styled** — browsers ignore custom text by design — so the only lever is whether it arms at all, and dropping it would trade one silent-loss path for two. It does not arm spuriously: the form is clean on mount, which I verified separately.

Browser back/forward is not intercepted. App Router gives no reliable way to block `popstate`, and the reported failure was link navigation. Worth its own issue rather than a half-working guard here.

## Tests

`apps/admin`: **114 files, 908 tests, 0 failures** (894 before; +14).

Coverage is mostly about what it must *not* do, since over-eager interception would be worse than the bug: new-tab links, cmd/ctrl-click, cross-origin, in-page anchors, `download`, a link to the page already open, opted-out anchors, and plain buttons. Plus the positive path, confirm/cancel, re-asking after a decline, clean forms, submitting forms, and releasing the claim on unmount.

Because nearly all of those are absence assertions, they are **mutation-tested** — five ways of breaking the guard, each caught by its intended test:

| mutant | caught by |
|---|---|
| drop the modifier-key check | *a cmd/ctrl click* |
| drop the cross-origin check | *an external link…* |
| ignore `data-unsaved-guard` | *an anchor that owns its own confirmation* |
| ignore `isSubmitting` | *lets the click through while the form is submitting* |
| never clean up on unmount | *releases the form's claim when it unmounts* |

Restored, 14/14 pass.