### PR TITLE
chore(deps): take @tesserix/web 2.4.2, which fixes the AlertDialog scrim and confirm colour

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -27,7 +27,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.99.1",
     "@tesserix/otto-widget": "^0.6.0",
-    "@tesserix/web": "^1.7.1",
+    "@tesserix/web": "^2.4.2",
     "@tiptap/extension-link": "^3.22.3",
     "@tiptap/extension-underline": "^3.22.3",
     "@tiptap/pm": "^3.22.3",

--- a/apps/onboarding/package.json
+++ b/apps/onboarding/package.json
@@ -16,7 +16,7 @@
     "@openpanel/nextjs": "^1.5.1",
     "@repo/ui": "*",
     "@tailwindcss/postcss": "^4.2.2",
-    "@tesserix/web": "^1.7.1",
+    "@tesserix/web": "^2.4.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^13.1.0",

--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -18,7 +18,7 @@
     "@repo/ui": "*",
     "@tailwindcss/postcss": "^4.2.2",
     "@tesserix/otto-widget": "^0.6.0",
-    "@tesserix/web": "^1.7.1",
+    "@tesserix/web": "^2.4.2",
     "next": "^16.2.11",
     "postcss": "^8.5.8",
     "react": "19.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.99.1",
         "@tesserix/otto-widget": "^0.6.0",
-        "@tesserix/web": "^1.7.1",
+        "@tesserix/web": "^2.4.2",
         "@tiptap/extension-link": "^3.22.3",
         "@tiptap/extension-underline": "^3.22.3",
         "@tiptap/pm": "^3.22.3",
@@ -154,46 +154,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "apps/admin/node_modules/@tesserix/web": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@tesserix/web/-/web-1.8.1.tgz",
-      "integrity": "sha512-15g+i/0kfdhtRnpvegQX9v4mjGcIZtQcSurdKrcRr9DZ+7cOsSHBk5u8nxfoKoofcwccWFJgjqWH1odT03l+ug==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-avatar": "^1.1.3",
-        "@radix-ui/react-checkbox": "^1.3.3",
-        "@radix-ui/react-dropdown-menu": "^2.1.16",
-        "@radix-ui/react-menubar": "^1.1.16",
-        "@radix-ui/react-navigation-menu": "^1.2.14",
-        "@radix-ui/react-progress": "^1.1.8",
-        "@radix-ui/react-radio-group": "^1.3.8",
-        "@radix-ui/react-scroll-area": "^1.2.10",
-        "@radix-ui/react-select": "^2.1.7",
-        "@radix-ui/react-slider": "^1.3.6",
-        "@radix-ui/react-slot": "^1.2.4",
-        "@radix-ui/react-switch": "^1.2.6",
-        "@radix-ui/react-tooltip": "^1.1.8",
-        "@tesserix/hooks": "1.0.0",
-        "@tesserix/tokens": "1.0.0",
-        "@tesserix/utils": "1.0.0",
-        "class-variance-authority": "^0.7.0",
-        "clsx": "^2.1.0",
-        "date-fns": "^4.1.0",
-        "react-day-picker": "^9.13.2",
-        "tailwind-merge": "^3.4.0"
-      },
-      "peerDependencies": {
-        "framer-motion": "^11.0.0 || ^12.0.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "tailwindcss": "^4.1.0"
-      },
-      "peerDependenciesMeta": {
-        "framer-motion": {
-          "optional": true
-        }
       }
     },
     "apps/admin/node_modules/balanced-match": {
@@ -4475,7 +4435,7 @@
         "@openpanel/nextjs": "^1.5.1",
         "@repo/ui": "*",
         "@tailwindcss/postcss": "^4.2.2",
-        "@tesserix/web": "^1.7.1",
+        "@tesserix/web": "^2.4.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^13.1.0",
@@ -4564,46 +4524,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "apps/onboarding/node_modules/@tesserix/web": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@tesserix/web/-/web-1.8.1.tgz",
-      "integrity": "sha512-15g+i/0kfdhtRnpvegQX9v4mjGcIZtQcSurdKrcRr9DZ+7cOsSHBk5u8nxfoKoofcwccWFJgjqWH1odT03l+ug==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-avatar": "^1.1.3",
-        "@radix-ui/react-checkbox": "^1.3.3",
-        "@radix-ui/react-dropdown-menu": "^2.1.16",
-        "@radix-ui/react-menubar": "^1.1.16",
-        "@radix-ui/react-navigation-menu": "^1.2.14",
-        "@radix-ui/react-progress": "^1.1.8",
-        "@radix-ui/react-radio-group": "^1.3.8",
-        "@radix-ui/react-scroll-area": "^1.2.10",
-        "@radix-ui/react-select": "^2.1.7",
-        "@radix-ui/react-slider": "^1.3.6",
-        "@radix-ui/react-slot": "^1.2.4",
-        "@radix-ui/react-switch": "^1.2.6",
-        "@radix-ui/react-tooltip": "^1.1.8",
-        "@tesserix/hooks": "1.0.0",
-        "@tesserix/tokens": "1.0.0",
-        "@tesserix/utils": "1.0.0",
-        "class-variance-authority": "^0.7.0",
-        "clsx": "^2.1.0",
-        "date-fns": "^4.1.0",
-        "react-day-picker": "^9.13.2",
-        "tailwind-merge": "^3.4.0"
-      },
-      "peerDependencies": {
-        "framer-motion": "^11.0.0 || ^12.0.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "tailwindcss": "^4.1.0"
-      },
-      "peerDependenciesMeta": {
-        "framer-motion": {
-          "optional": true
-        }
       }
     },
     "apps/onboarding/node_modules/@types/node": {
@@ -4832,7 +4752,7 @@
         "@repo/ui": "*",
         "@tailwindcss/postcss": "^4.2.2",
         "@tesserix/otto-widget": "^0.6.0",
-        "@tesserix/web": "^1.7.1",
+        "@tesserix/web": "^2.4.2",
         "next": "^16.2.11",
         "postcss": "^8.5.8",
         "react": "19.2.7",
@@ -5736,46 +5656,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "apps/storefront/node_modules/@tesserix/web": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@tesserix/web/-/web-1.8.1.tgz",
-      "integrity": "sha512-15g+i/0kfdhtRnpvegQX9v4mjGcIZtQcSurdKrcRr9DZ+7cOsSHBk5u8nxfoKoofcwccWFJgjqWH1odT03l+ug==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-avatar": "^1.1.3",
-        "@radix-ui/react-checkbox": "^1.3.3",
-        "@radix-ui/react-dropdown-menu": "^2.1.16",
-        "@radix-ui/react-menubar": "^1.1.16",
-        "@radix-ui/react-navigation-menu": "^1.2.14",
-        "@radix-ui/react-progress": "^1.1.8",
-        "@radix-ui/react-radio-group": "^1.3.8",
-        "@radix-ui/react-scroll-area": "^1.2.10",
-        "@radix-ui/react-select": "^2.1.7",
-        "@radix-ui/react-slider": "^1.3.6",
-        "@radix-ui/react-slot": "^1.2.4",
-        "@radix-ui/react-switch": "^1.2.6",
-        "@radix-ui/react-tooltip": "^1.1.8",
-        "@tesserix/hooks": "1.0.0",
-        "@tesserix/tokens": "1.0.0",
-        "@tesserix/utils": "1.0.0",
-        "class-variance-authority": "^0.7.0",
-        "clsx": "^2.1.0",
-        "date-fns": "^4.1.0",
-        "react-day-picker": "^9.13.2",
-        "tailwind-merge": "^3.4.0"
-      },
-      "peerDependencies": {
-        "framer-motion": "^11.0.0 || ^12.0.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "tailwindcss": "^4.1.0"
-      },
-      "peerDependenciesMeta": {
-        "framer-motion": {
-          "optional": true
-        }
       }
     },
     "apps/storefront/node_modules/@types/node": {
@@ -16492,13 +16372,13 @@
       }
     },
     "node_modules/@tesserix/icons": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tesserix/icons/-/icons-1.0.0.tgz",
-      "integrity": "sha512-Wm1m0msdyebreMy3T1uFpCVbbXvCEHHfcyfonzpPU8zDWyUvCO0MkpfpvI3Heg3N36vuHB1i81gOQsraUngFIA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tesserix/icons/-/icons-1.1.0.tgz",
+      "integrity": "sha512-7RNs5k2sicOVUiSnd0XLSCiGbKkKLfW0nA7L2eImxtVjmY/WEK4R+22CiRX0JeRkGB5XnR44bCVcE1bT5CH9yw==",
       "license": "MIT",
       "peerDependencies": {
-        "lucide-react": "^0.469.0",
-        "lucide-react-native": "^0.469.0",
+        "lucide-react": "^0.469.0 || ^1.0.0",
+        "lucide-react-native": "^0.469.0 || ^1.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-native": ">=0.70.0",
         "react-native-svg": ">=13.0.0"
@@ -16559,6 +16439,51 @@
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tesserix/web": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@tesserix/web/-/web-2.4.2.tgz",
+      "integrity": "sha512-uVuK+9PF66fpUPUpPZc9BOMpUNbuGBwKL3j4P3U8BkCG/+TlydapblogQqmdUMzTK13L8VPoY6+FUThZUYSXAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-avatar": "^1.1.3",
+        "@radix-ui/react-checkbox": "^1.3.3",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-menubar": "^1.1.16",
+        "@radix-ui/react-navigation-menu": "^1.2.14",
+        "@radix-ui/react-progress": "^1.1.8",
+        "@radix-ui/react-radio-group": "^1.3.8",
+        "@radix-ui/react-scroll-area": "^1.2.10",
+        "@radix-ui/react-select": "^2.1.7",
+        "@radix-ui/react-slider": "^1.3.6",
+        "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
+        "@radix-ui/react-tooltip": "^1.1.8",
+        "@tesserix/hooks": "1.0.0",
+        "@tesserix/icons": "1.1.0",
+        "@tesserix/tokens": "1.0.0",
+        "@tesserix/utils": "1.0.0",
+        "class-variance-authority": "^0.7.0",
+        "clsx": "^2.1.0",
+        "date-fns": "^4.1.0",
+        "react-day-picker": "^9.13.2",
+        "tailwind-merge": "^3.4.0"
+      },
+      "peerDependencies": {
+        "framer-motion": "^11.0.0 || ^12.0.0",
+        "lucide-react": "^0.469.0 || ^1.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "tailwindcss": "^4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "framer-motion": {
+          "optional": true
+        },
+        "lucide-react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@testing-library/dom": {


### PR DESCRIPTION
Unblocked by design-system#48. **2.4.2 widens the peer range to `lucide-react: '^0.469.0 || ^1.0.0'`**, which is what stopped mark8ly (on 1.14.0) taking any 2.x — 2.4.1 pinned `^0.469.0` and blew up with `Named export 'Github' not found` at module evaluation.

`@tesserix/web` **1.8.1 → 2.4.2** across admin, storefront and onboarding.

## What this actually ships

The AlertDialog fix that has been stuck since 29 August:

- **The scrim is portalled to `document.body`.** It used `position: fixed` without a portal, so any ancestor establishing a containing block captured it. In this admin every page carries `animate-[fadeInUp…]` with `animation-fill-mode: both`, leaving an identity `transform` for as long as the page is mounted — the overlay rendered as a grey rectangle over the content column instead of the viewport.
- **`type="confirm"` uses `bg-destructive` rather than `bg-warning`.** The confirm button is **amber-bronze in production today**; this is what makes it oxblood. Visible on the product page's discard dialog.

## The 2.0.0 breaking change does not apply

It renamed the auth surface (`Aurora*` → `Auth*`, `--aurora-*` → `--auth-*`). mark8ly imports none of it — the only "aurora" strings here are its own storefront theme presets. The peer range was the sole obstacle.

## Lockfile

Deliberately a **targeted** install rather than a regeneration. Deleting `package-lock.json` and rebuilding produced **888 changed entries** — 453 unrelated version bumps across babel, playwright and others — which is not something a design-system bump should smuggle in. Keeping the lockfile and installing gives **5**:

| entry | before | after |
|---|---|---|
| `node_modules/@tesserix/web` | *(absent)* | **2.4.2** |
| `apps/{admin,storefront,onboarding}/node_modules/@tesserix/web` | 1.8.1 | *(removed)* |
| `node_modules/@tesserix/icons` | 1.0.0 | 1.1.0 |

Note it now **hoists to the root** instead of sitting in three per-workspace copies — the exact shape that broke the container builds in #555.

## Verification

Last time I validated a dependency change with `npm install` and the test suites, and it broke the container builds. This time, in order:

```
rm -rf node_modules && npm ci --legacy-peer-deps      → added 2444 packages
apps/admin typecheck                                  → clean
apps/admin        → 114 files, 908 tests, 0 failures
apps/storefront   → 81 tests, 0 failures
apps/onboarding   → 71 tests, 0 failures

docker build --target builder -f apps/admin/Dockerfile .   → DONE
docker run … node -p "require('@tesserix/web/package.json').version"  → 2.4.2
docker run … ls apps/admin/.next/standalone/apps/admin/server.js      → server.js
```

The container build is the one that mattered and the one I previously skipped.