### PR TITLE
Stop the pricing table selling two features that don't exist

### DIFF
--- a/apps/onboarding/components/marketing/Pricing.tsx
+++ b/apps/onboarding/components/marketing/Pricing.tsx
@@ -43,8 +43,24 @@ interface PlanMeta {
   features: string[]
 }
 
-// Feature list matches spec §9 exactly. Plans gate on these features
-// server-side via plangate; the copy here must not promise more.
+// Every bullet below must be something a merchant on that plan can actually
+// get today. Before adding or restoring one:
+//   1. Find its `plangate.Feature` constant in
+//      services/marketplace-api/internal/plangate/matrix.go, confirm it is
+//      enabled (non-Disabled) for that plan, AND grep for the constant
+//      outside matrix.go and its tests to confirm a real handler enforces
+//      it — a constant that only appears in matrix.go is a hedge for
+//      something unbuilt, not a shipped feature (see
+//      FeatureCustomCodeInjection).
+//   2. Check migrations/ for a later migration that withdrew the feature
+//      while its implementation code stayed behind (see
+//      000121_retire_untested_paypal — a complete gateway offered to
+//      nobody).
+//   3. For a numeric limit (stores, emails, images, retention), confirm the
+//      number is enforced in code, not just asserted in this file.
+// An implementation file existing is NOT evidence a feature is offered.
+// This exact mistake shipped twice on the live page — see #544 — before
+// anyone checked past "the code exists somewhere."
 const PLAN_META: readonly PlanMeta[] = [
   {
     id: 'starter',
@@ -67,7 +83,7 @@ const PLAN_META: readonly PlanMeta[] = [
       '50 images per product',
       '50,000 campaign emails / mo',
       'Custom CSS & fonts',
-      'Read-only API + webhooks',
+      'Read-only API',
       '12-month audit log',
     ],
   },
@@ -79,13 +95,14 @@ const PLAN_META: readonly PlanMeta[] = [
       'Up to 10 stores',
       'Unlimited images',
       'Full read/write API',
-      'Custom code injection',
       'SSO (SAML / OIDC)',
       'Priority support (4h response)',
       'Forever audit retention',
     ],
   },
 ] as const
+
+export { PLAN_META }
 
 // AU prices in the catalogue are GST-exclusive (spec §19.4).
 // Other countries either have no domestic tax or handle via reverse charge.

--- a/apps/onboarding/tests/unit/pricing-copy-truth.spec.ts
+++ b/apps/onboarding/tests/unit/pricing-copy-truth.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+
+// The live pricing table (components/marketing/Pricing.tsx) promised two
+// features that plangate never enabled server-side — see #544:
+//
+//   - "Read-only API + webhooks" (Studio): the read-only API is real
+//     (plangate.FeatureReadAPI -> internal/apikeys/*), but nothing in the
+//     schema stores a merchant-supplied webhook/callback URL, so outbound
+//     webhook delivery cannot exist. webhook_events / stripe_webhook_events
+//     are inbound idempotency tables, not evidence of the feature.
+//   - "Custom code injection" (Pro): plangate.FeatureCustomCodeInjection's
+//     own doc comment in matrix.go says no handler accepts arbitrary
+//     <script> payloads today - it's a forward-compat hedge, referenced
+//     nowhere outside the matrix and its tests.
+//
+// This spec pins the fix so neither claim can silently return. It does not
+// re-verify every other bullet against the server (that audit lives in the
+// #544 investigation) - it only guards the two bullets already proven false
+// plus the basic shape of PLAN_META.
+import { PLAN_META } from "../../components/marketing/Pricing";
+
+function allFeatures(): string[] {
+  return PLAN_META.flatMap((plan) => plan.features);
+}
+
+test.describe("pricing copy must not promise unenforced features (#544)", () => {
+  test("no bullet claims webhooks", () => {
+    const offenders = allFeatures().filter((f) => /webhook/i.test(f));
+    expect(
+      offenders,
+      "Found a pricing bullet mentioning 'webhook'. Outbound webhook " +
+        "delivery does not exist server-side: webhook_events and " +
+        "stripe_webhook_events are inbound idempotency tables, and no " +
+        "column anywhere stores a merchant-supplied callback URL. See " +
+        "issue #544 - narrow this bullet back to what plangate.FeatureReadAPI " +
+        "actually grants ('Read-only API'), don't re-add webhooks.",
+    ).toEqual([]);
+  });
+
+  test("no bullet claims code injection", () => {
+    const offenders = allFeatures().filter((f) => /code injection/i.test(f));
+    expect(
+      offenders,
+      "Found a pricing bullet mentioning 'code injection'. " +
+        "plangate.FeatureCustomCodeInjection's own doc comment " +
+        "(internal/plangate/matrix.go) says no handler accepts arbitrary " +
+        "<script> payloads today - it exists only as a forward-compat hedge " +
+        "and is referenced nowhere outside the matrix and its tests. See " +
+        "issue #544 - do not restore this bullet until a real write handler " +
+        "enforces the feature.",
+    ).toEqual([]);
+  });
+
+  test("every plan has a non-empty, unique feature list", () => {
+    expect(PLAN_META.length).toBeGreaterThan(0);
+    for (const plan of PLAN_META) {
+      expect(plan.features.length, `${plan.id} has no features`).toBeGreaterThan(0);
+      expect(
+        new Set(plan.features).size,
+        `${plan.id} has duplicate feature bullets`,
+      ).toBe(plan.features.length);
+    }
+  });
+});


### PR DESCRIPTION
Closes #544.

The pricing table on mark8ly.com advertised two features on paid tiers that do not exist. Both are now removed, and every other bullet was audited the same way.

## The two false claims

| Bullet | Plan | Reality | Action |
|---|---|---|---|
| `Read-only API + webhooks` | Studio | Read-only API is real (`FeatureReadAPI` → `internal/apikeys/*`). **Webhooks are not** — only `webhook_events` / `stripe_webhook_events` exist, both inbound idempotency, and **no column anywhere stores a merchant-supplied callback URL**, which outbound delivery requires | Narrowed to `Read-only API` |
| `Custom code injection` | Pro | `matrix.go:31-36` says it itself: "No handler accepts arbitrary `<script>` payloads today, so the gate is a forward-compat hedge." Referenced nowhere outside the matrix and its tests | Removed |

Distinct from `FeatureCustomCSS`, which **is** real — so Studio's "Custom CSS & fonts" is accurate and stays.

## Every other bullet, audited

Two were already wrong and nobody had checked the rest, so all fifteen were traced to their enforcement.

| Bullet | Verified against | Verdict |
|---|---|---|
| Up to 2/5/10 stores | `FeatureStores`; enforced in `subscription/planchange/{cron,preflight,downgrade}.go` | Keep |
| Unlimited products & orders | No count cap exists anywhere in `internal/products` or the admin handlers — independently re-checked, since "no cap exists" is a negative claim | Keep |
| 15,000 / 50,000 campaign emails / mo | `FeatureCampaignEmailsPerMonth`; enforced in `campaignbudget/{ramp,recompute,preflight}.go` | Keep |
| Full colour palette & announcement bar | Real fields in `handlers/admin/branding.go`, unrestricted | Keep |
| Your own domain | `handlers/admin/domains.go` + migrations `000014/32/34`, ungated — works on Starter | Keep |
| 50 images / Unlimited images | `FeatureImagesPerProduct`; enforced in `handlers/admin/media.go` | Keep |
| Custom CSS & fonts | `FeatureCustomCSS`; `custom_css` rendered via `MerchantCSS` | Keep |
| 12-month / Forever audit log | `FeatureAuditRetentionDays`; enforced in `audit/prune_cron.go` | Keep |
| Full read/write API | `FeatureFullAPI` gates create/rotate/revoke in `apikeys/service.go` | Keep |
| SSO (SAML / OIDC) | `FeatureSSO` → `sso_config.go`, `sso_login.go`, `internal/sso/*`, migrations `000070/71` | Keep |
| Priority support (4h response) | `FeaturePriorityEmailSupport` is real and Pro-only, but the **4h SLA is an operational commitment no code measures** | Left as-is, flagged |

The one bullet I can't verify from the codebase is the 4h response SLA — it's an ops promise rather than a code feature. Flagging rather than silently keeping or removing it: worth confirming someone actually intends to meet it.

## Guard

The old comment claimed *"the copy here must not promise more"* — while the copy promised more. Replaced with a 3-step checklist a future editor can actually follow (matrix enforcement, migration withdrawal, numeric-limit verification), because the failure mode is specific and repeatable: **an implementation file existing is not evidence a feature is offered.** `000121_retire_untested_paypal` is the worked example — a complete 483-line gateway offered to nobody.

`tests/unit/pricing-copy-truth.spec.ts` pins both removed claims so they can't silently return, with failure messages that explain why rather than just asserting a string is absent.

## Verification

`npx tsc --noEmit` clean; `npx playwright test --config=playwright.unit.config.ts` → **74 passed**.

## Note

This removes the copy rather than building the features. Whether webhooks and a code-injection surface get built is a separate decision — but the page shouldn't sell them in the meantime.
