### PR TITLE
test(product,onboarding): pin the OptionValueInUse reachability asymmetry and the reserved onboarding statuses

### DIFF
--- a/services/marketplace-api/internal/product/service_aggregate.go
+++ b/services/marketplace-api/internal/product/service_aggregate.go
@@ -90,6 +90,18 @@ func (s *Service) UpdateAggregate(ctx context.Context, req UpdateAggregateReques
 	} else {
 		desiredOptions = optionSpecsFromExisting(existing.Options)
 	}
+	// ValidateMatrix runs ONLY when the caller supplies variants. That is
+	// what makes the OptionValueInUse guard in applyOptionsDiff live rather
+	// than dead code (#400): an options-only edit — req.Options set,
+	// req.Variants nil, which is the ordinary shape when an admin edits the
+	// Options section without touching the variant list — reaches
+	// applyOptionsDiff with no prior validation, so the guard is the sole
+	// thing standing between the request and deleting an option value a
+	// stored variant still references.
+	//
+	// When variants ARE supplied, ValidateMatrix rejects that same scenario
+	// first, on a different error, and the guard never sees it. Both halves
+	// of that asymmetry are pinned by tests in service_aggregate_test.go.
 	if req.Variants != nil {
 		// Force currency on every incoming variant.
 		vars := *req.Variants

--- a/services/marketplace-api/internal/product/service_aggregate_test.go
+++ b/services/marketplace-api/internal/product/service_aggregate_test.go
@@ -277,3 +277,80 @@ func TestIntegration_ProductService_UpdateAggregate_OptionValueInUseRejected(t *
 		t.Fatalf("option value count = %d, want 2 (unchanged after rollback)", valueCount)
 	}
 }
+
+// The OptionValueInUse guard is reachable from exactly ONE of the two paths
+// into applyOptionsDiff, and that asymmetry is load-bearing (#400).
+//
+// UpdateAggregate only runs ValidateMatrix when req.Variants != nil. So:
+//
+//   - options-only edit  -> no ValidateMatrix, the guard is the sole
+//     enforcement, and it fires. Covered by
+//     TestIntegration_ProductService_UpdateAggregate_OptionValueInUseRejected
+//     above, which sends Options and no Variants.
+//   - variants supplied  -> ValidateMatrix rejects the same scenario first,
+//     on a different error, so the guard never sees it.
+//
+// This test pins the second half. Without it, someone reading "the guard
+// catches option-value removal" would reasonably assume it catches it on
+// every path, and moving or relaxing ValidateMatrix would silently change
+// which error a caller gets — or whether they get one at all.
+func TestIntegration_ProductService_UpdateAggregate_VariantsSuppliedPreemptsTheInUseGuard(t *testing.T) {
+	tx := testdb.NewTx(t)
+	storeID, tenantID, _ := seedStore(t, tx)
+	svc := buildService(tx, media.NewFakeUploader())
+	ctx := context.Background()
+
+	agg, err := svc.Create(ctx, product.CreateRequest{
+		StoreID: storeID, TenantID: tenantID, Title: "Simple",
+		Options: []product.OptionSpec{
+			{Name: "Size", Values: []product.OptionValueSpec{{Value: "S"}, {Value: "M"}}},
+		},
+		Variants: []product.VariantInput{
+			{SKU: "S-1", Price: decimal.NewFromInt(10), CurrencyCode: "USD", InitialStock: 1,
+				OptionValues: []product.OptionValueRef{{OptionName: "Size", Value: "S"}}},
+			{SKU: "S-2", Price: decimal.NewFromInt(11), CurrencyCode: "USD", InitialStock: 1,
+				OptionValues: []product.OptionValueRef{{OptionName: "Size", Value: "M"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Same removal as the options-only test — drop Size=S while a stored
+	// variant still references it — but this time the caller also supplies
+	// the variant list, naming a value the desired options no longer have.
+	newOptions := []product.OptionSpec{
+		{Name: "Size", Values: []product.OptionValueSpec{{Value: "M"}}},
+	}
+	newVariants := []product.VariantInput{
+		{SKU: "S-1", Price: decimal.NewFromInt(10), CurrencyCode: "USD",
+			OptionValues: []product.OptionValueRef{{OptionName: "Size", Value: "S"}}},
+		{SKU: "S-2", Price: decimal.NewFromInt(11), CurrencyCode: "USD",
+			OptionValues: []product.OptionValueRef{{OptionName: "Size", Value: "M"}}},
+	}
+
+	_, err = svc.UpdateAggregate(ctx, product.UpdateAggregateRequest{
+		ID: agg.Product.ID, StoreID: storeID, TenantID: tenantID,
+		Options:  &newOptions,
+		Variants: &newVariants,
+	})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	// The point of the test: rejected, but NOT by the in-use guard.
+	if errors.Is(err, apperrors.ErrOptionValueInUse) {
+		t.Fatalf("expected ValidateMatrix to preempt the guard, but got ErrOptionValueInUse: %v", err)
+	}
+
+	// Nothing was written — the rejection happens before any DB work.
+	var valueCount int64
+	if err := tx.Raw(`
+		SELECT count(*) FROM product_option_values v
+		JOIN product_options o ON o.id = v.option_id
+		WHERE o.product_id = ?`, agg.Product.ID).Scan(&valueCount).Error; err != nil {
+		t.Fatalf("count values: %v", err)
+	}
+	if valueCount != 2 {
+		t.Fatalf("option value count = %d, want 2 (unchanged)", valueCount)
+	}
+}

--- a/services/platform-api/internal/onboarding/models.go
+++ b/services/platform-api/internal/onboarding/models.go
@@ -12,8 +12,26 @@
 //	  ↓
 //	complete   →  spawns tenant + outbox FGA write, status="completed"
 //
-// At any point a session may transition to status="abandoned" (browser close)
-// or "expired" (gc).
+// Those three — in_progress, verifying, completed — are the ONLY statuses
+// this package ever writes.
+//
+// "abandoned" and "expired" are declared below and permitted by the
+// migration's CHECK constraint, but nothing writes them: there is no gc,
+// cron, sweep or reaper for onboarding sessions anywhere in the workspace.
+// Every session in production is in_progress, verifying or completed.
+//
+// This comment used to claim "at any point a session may transition to
+// status='abandoned' (browser close) or 'expired' (gc)", which described a
+// lifecycle the code does not implement. #283 nearly built an abandoned-
+// session counter on `status = 'abandoned'`; it would have returned zero for
+// every window, forever, and read as a data problem rather than a missing
+// feature. It instead derives abandonment from `last_activity_at` (idle >24h,
+// not completed) and keeps the stored status and the derived flag as separate
+// fields on the wire, so the gap stays visible.
+//
+// If a gc is wanted for its own sake (#322 option 2), the constants are here
+// and the constraint already permits them — but the derived flag and the
+// stored status would then need to agree during the transition.
 //
 // The completion handler is the bug-fix landing point for auth-bug #2 and #3
 // from docs/planning/auth-bugs.md. It writes both the tenant row and the
@@ -48,6 +66,10 @@ type Session struct {
 func (Session) TableName() string { return "onboarding_sessions" }
 
 // Status constants. Match the CHECK constraint in the migration.
+//
+// StatusExpired and StatusAbandoned are RESERVED: permitted by the
+// constraint, referenced by no writer. See the package doc above before
+// building anything that reads for them.
 const (
 	StatusInProgress = "in_progress"
 	StatusVerifying  = "verifying"

--- a/services/platform-api/internal/onboarding/reserved_statuses_test.go
+++ b/services/platform-api/internal/onboarding/reserved_statuses_test.go
@@ -1,0 +1,81 @@
+package onboarding
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The package doc states that "abandoned" and "expired" are reserved and
+// never written. That claim is the whole point of #322: the doc previously
+// described a lifecycle the code did not implement, and #283 nearly built an
+// abandoned-session counter on `status = 'abandoned'` that would have
+// returned zero for every window, forever.
+//
+// A comment cannot enforce itself. This test does: the moment code starts
+// using either constant, it fails and points at the doc that must change with
+// it. It is deliberately a source scan rather than a behavioural test —
+// "nothing anywhere uses this value" is a property of the package, not of any
+// one call.
+//
+// It walks the AST rather than the file text, and that distinction is
+// load-bearing: funnel.go's AbandonedAfter carries a comment explaining that
+// `status = 'abandoned'` returns zero forever and why the funnel derives
+// abandonment from idle time instead (#283). A text scan flags that comment —
+// the very documentation this issue exists to encourage. Identifiers are what
+// matter; prose about them is the opposite of a violation.
+func TestReservedStatusesAreNeverUsedInCode(t *testing.T) {
+	// models.go declares the constants; that is the one legitimate use.
+	const declarationFile = "models.go"
+
+	reserved := map[string]struct{}{
+		"StatusExpired":   {},
+		"StatusAbandoned": {},
+	}
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
+		name := fi.Name()
+		return !strings.HasSuffix(name, "_test.go") && name != declarationFile
+	}, 0) // no parser.ParseComments — comments are not code.
+	if err != nil {
+		t.Fatalf("parse package: %v", err)
+	}
+
+	for _, pkg := range pkgs {
+		for path, file := range pkg.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				id, ok := n.(*ast.Ident)
+				if !ok {
+					return true
+				}
+				if _, isReserved := reserved[id.Name]; !isReserved {
+					return true
+				}
+				t.Errorf(
+					"%s:%d uses %s, but the package doc says that status is reserved and never written.\n"+
+						"If a gc now writes it (#322 option 2), update the package doc in %s and this test together — "+
+						"and check anything deriving abandonment from last_activity_at (#283) still agrees.",
+					path, fset.Position(id.Pos()).Line, id.Name, declarationFile,
+				)
+				return true
+			})
+		}
+	}
+}
+
+// Guards the other half: the constants must keep existing, because the
+// migration's CHECK constraint permits them and #283's wire contract talks
+// about them. Deleting them without a migration would be the opposite
+// mistake.
+func TestReservedStatusesStillDeclared(t *testing.T) {
+	if StatusExpired != "expired" {
+		t.Errorf("StatusExpired = %q, want %q", StatusExpired, "expired")
+	}
+	if StatusAbandoned != "abandoned" {
+		t.Errorf("StatusAbandoned = %q, want %q", StatusAbandoned, "abandoned")
+	}
+}


### PR DESCRIPTION
Closes #400 and #322. Both asked for the same thing: make the code say what is actually true, and stop a comment being the only thing holding a claim up.

---

# #400 — OptionValueInUse reachability

## The issue's suggested test already exists

#400 asks for "a test that exercises the options-only path". `TestIntegration_ProductService_UpdateAggregate_OptionValueInUseRejected` already does exactly that — it sends `Options` with no `Variants`. That half is covered; the issue is stale on it.

## What was untested is the other half

The issue's real content is an **asymmetry**: `UpdateAggregate` runs `ValidateMatrix` only when `req.Variants != nil`, so

- **options-only** → no `ValidateMatrix`; the guard is the sole enforcement and it fires
- **variants supplied** → `ValidateMatrix` rejects the same scenario first, on a different error, and the guard never sees it

Nothing pinned the second half. `TestIntegration_ProductService_UpdateAggregate_VariantsSuppliedPreemptsTheInUseGuard` performs the *identical* removal — drop `Size=S` while a stored variant references it — but with the variant list also supplied, and asserts the error is **not** `ErrOptionValueInUse`.

Without it, someone reading "the guard catches option-value removal" would reasonably assume it catches it on every path, and moving or relaxing `ValidateMatrix` would silently change which error a caller gets.

Plus the comment #400 asks for, at the `req.Variants != nil` branch, spelling out why the guard is live rather than dead code.

**No behaviour change.**

### Mutation-tested

Deleting the `ValidateMatrix` call from the variants path:

```
--- FAIL: ..._VariantsSuppliedPreemptsTheInUseGuard
    expected ValidateMatrix to preempt the guard, but got ErrOptionValueInUse:
    option value "S" on "Size" is still referenced by a surviving variant
```

The asymmetry demonstrated rather than asserted. Restored: both pass.

```
TEST_DATABASE_URL=postgres://dev:dev@192.168.1.110:5432/marketplace_db?sslmode=disable
=== RUN   ..._OptionValueInUseRejected                --- PASS
=== RUN   ..._VariantsSuppliedPreemptsTheInUseGuard   --- PASS
ok  github.com/mark8ly/marketplace-api/internal/product
```

Real `=== RUN` lines, so these did not silently skip on a missing DSN.

---

# #322 — reserved onboarding statuses

Takes the issue's own recommendation (option 1): correct the doc, keep the constants.

The package doc claimed *"at any point a session may transition to status='abandoned' (browser close) or 'expired' (gc)"*. Nothing writes either, and no gc exists. #283 nearly built an abandoned-session counter on `status = 'abandoned'` — it would have returned zero for every window, forever, and read as a data problem rather than a missing feature.

The doc now says they are reserved and unwritten, records why, and points at option 2 if a gc is ever wanted. The constants gain a RESERVED note at their declaration.

## And a guard, because a comment cannot enforce itself

`TestReservedStatusesAreNeverUsedInCode` walks the package AST and fails if either constant is used in code, naming file, line, and the doc that must change with it.

**The AST rather than the file text, and that distinction is the interesting part.** My first version scanned raw text and immediately failed — on `funnel.go`, whose `AbandonedAfter` carries a comment explaining that `status = 'abandoned'` returns zero forever and why the funnel derives abandonment from idle time instead. That comment is #283's documentation of this exact hazard: precisely what the issue wants people to write. A test that punishes it is worse than no test. Identifiers are code; prose about them is not.

Verified both directions:

| mutant | result |
|---|---|
| a function in `repository.go` returning `StatusAbandoned` | ✗ `repository.go:117 uses StatusAbandoned…` |
| a new comment in `funnel.go` mentioning both constants | ✓ passes |

A second test pins the constants' values, since deleting them would be the opposite mistake — the migration's CHECK constraint permits them and #283's wire contract names them.

---

## Verification

- `go vet -tags=integration ./...` — marketplace-api, clean
- `go vet ./...` — platform-api, clean
- `go test ./internal/onboarding/...` — ok
- integration tests above against the LAN DSN with `-count=1`

## Note

CI will fail at **Audit production dependencies** for the reason in #561 — an unfixable `image-size` advisory reaching the tree only through `apps/mobile-admin`. Unrelated to this PR; it blocks everything until the gate is corrected.