### PR TITLE
Stop the public pricing surfaces advertising limits the service never enforced

### DIFF
--- a/apps/admin/lib/copy/pricing.ts
+++ b/apps/admin/lib/copy/pricing.ts
@@ -61,7 +61,24 @@ export const pricingCopy = {
   disclosureTemplate: (currency: string) =>
     `Prices shown in ${currency}. Annual billing bills upfront; monthly bills each month.`,
 
-  /** The three public plans. Backend uses starter / studio / pro. */
+  /**
+   * The three public plans. Backend uses starter / studio / pro.
+   *
+   * Every bullet must be something plangate actually grants on that plan.
+   * #413 caught this page quoting prices the billing catalog would not
+   * charge; #418 fixed the prices and left these feature bullets alone,
+   * and they turned out to describe a different product entirely —
+   * invented product/order/staff caps, wrong storefront counts in both
+   * directions, and "dedicated infrastructure" / "SLA-backed uptime" on a
+   * shared Cloud SQL micro instance (#564).
+   *
+   * Before adding a bullet: find its Feature constant in
+   * services/marketplace-api/internal/plangate/matrix.go, confirm it is
+   * enabled for that plan, and confirm a real handler enforces it. A
+   * numeric limit must be a number the code enforces, not one invented
+   * here. This page is public and indexed — pricing-copy.test.ts pins the
+   * counts against the matrix so a divergence fails the build.
+   */
   plans: [
     {
       id: 'starter' as const,
@@ -70,12 +87,11 @@ export const pricingCopy = {
       cta: 'Start free trial',
       ctaHref: '/signup?plan=starter',
       features: [
-        '1 storefront',
-        'Up to 100 products',
-        '500 orders / month',
-        '2 staff accounts',
-        'Standard analytics',
-        'Community support',
+        'Up to 2 storefronts',
+        'Unlimited products & orders',
+        '15,000 campaign emails / mo',
+        'Full colour palette & announcement bar',
+        'Your own domain',
       ],
     },
     {
@@ -85,14 +101,12 @@ export const pricingCopy = {
       cta: 'Start free trial',
       ctaHref: '/signup?plan=studio',
       features: [
-        '3 storefronts',
-        'Unlimited products',
-        '5,000 orders / month',
-        '10 staff accounts',
-        'Advanced analytics',
-        'Priority email support',
-        'Custom domain',
-        'Discount codes',
+        'Up to 5 storefronts',
+        '50 images per product',
+        '50,000 campaign emails / mo',
+        'Custom CSS & fonts',
+        'Read-only API',
+        '12-month audit log',
       ],
     },
     {
@@ -102,15 +116,12 @@ export const pricingCopy = {
       cta: 'Start a conversation',
       ctaHref: '/admin/settings/billing/pro-contact',
       features: [
-        'Unlimited storefronts',
-        'Unlimited everything',
-        'Dedicated infrastructure',
-        'SLA-backed uptime',
-        'Custom contract',
-        'Named account manager',
-        'Enterprise SSO',
-        'Audit log retention',
-        'Advanced fraud tooling',
+        'Up to 10 storefronts',
+        'Unlimited images',
+        'Full read/write API',
+        'SSO (SAML / OIDC)',
+        'Priority support (4h response)',
+        'Forever audit retention',
       ],
     },
   ] satisfies PlanCopyItem[],

--- a/apps/onboarding/public/llms-full.txt
+++ b/apps/onboarding/public/llms-full.txt
@@ -39,8 +39,8 @@ Free for ninety days. No card required. Three clear plans after that, from $15 a
 Ninety days free to start. After that, three clear plans — no hidden fees, no transaction cuts from Mark8ly, only what your payment processor charges at their standard rate. Change plans any time; upgrades prorate, downgrades take effect at the end of your current period.
 
 - **Starter — $15/month billed yearly, or $19/month billed monthly.** For merchants opening their first store. Up to 2 stores, unlimited products and orders, 15,000 campaign emails/month, full colour palette and announcement bar, your own domain.
-- **Studio — $39/month billed yearly, or $49/month billed monthly.** For stores finding their rhythm. Up to 5 stores, 50 images per product, 50,000 campaign emails/month, custom CSS and fonts, read-only API and webhooks, 12-month audit log.
-- **Pro — $99/month billed yearly, or $119/month billed monthly.** For mid-market brands at scale. Up to 10 stores, unlimited images, full read/write API, custom code injection, SSO (SAML/OIDC), priority support with 4-hour response, forever audit retention.
+- **Studio — $39/month billed yearly, or $49/month billed monthly.** For stores finding their rhythm. Up to 5 stores, 50 images per product, 50,000 campaign emails/month, custom CSS and fonts, read-only API, 12-month audit log.
+- **Pro — $99/month billed yearly, or $119/month billed monthly.** For mid-market brands at scale. Up to 10 stores, unlimited images, full read/write API, SSO (SAML/OIDC), priority support with 4-hour response, forever audit retention.
 
 **White-label App add-on** (Pro only): publish a branded iOS and Android app for your storefront. Billed annually and co-terminated with your Pro renewal.
 

--- a/apps/onboarding/tests/unit/pricing-surfaces-truth.spec.ts
+++ b/apps/onboarding/tests/unit/pricing-surfaces-truth.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Cross-surface guard for GitHub issue #564.
+ *
+ * Plan copy lives in three places and they drifted apart:
+ *
+ *   apps/onboarding/components/marketing/Pricing.tsx   → mark8ly.com/#pricing
+ *   apps/admin/lib/copy/pricing.ts                     → admin.mark8ly.com/pricing (public, indexed)
+ *   apps/onboarding/public/llms-full.txt               → mark8ly.com/llms-full.txt
+ *
+ * #413 caught the admin page quoting prices the billing catalog would not
+ * charge. #418 fixed the prices and left the feature bullets, which turned
+ * out to describe a different product: invented product/order/staff caps,
+ * storefront counts wrong in both directions, and "dedicated
+ * infrastructure" / "SLA-backed uptime" on a shared Cloud SQL micro.
+ *
+ * The authority is the Go plan matrix, not any of the copy files. These
+ * tests read it directly so the copy cannot drift from what is actually
+ * enforced without failing the build.
+ */
+const REPO_ROOT = path.join(__dirname, "../../../..");
+
+function read(rel: string): string {
+  return readFileSync(path.join(REPO_ROOT, rel), "utf8");
+}
+
+/**
+ * Strips comments from TypeScript sources before scanning. What ships to a
+ * customer is the string literals, not the commentary — and the comments in
+ * these very files name the removed claims in order to explain why they were
+ * removed. Scanning raw source would make documenting the fix trip the guard
+ * that enforces it.
+ */
+function copyOnly(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+}
+
+/**
+ * Pulls `FeatureStores: N` out of each plan block in the Go matrix. The
+ * blocks appear in declaration order: Trial, Starter, Studio, Pro.
+ */
+function storeLimitsFromMatrix(): Record<string, number> {
+  const src = read("services/marketplace-api/internal/plangate/matrix.go");
+  const order = ["trial", "starter", "studio", "pro"];
+  const found = [...src.matchAll(/FeatureStores:\s*(\d+)/g)].map((m) =>
+    Number(m[1]),
+  );
+  expect(
+    found.length,
+    "expected four FeatureStores entries in matrix.go (trial/starter/studio/pro) — " +
+      "if the matrix was restructured, this parser needs updating rather than deleting",
+  ).toBe(order.length);
+  return Object.fromEntries(order.map((k, i) => [k, found[i]!]));
+}
+
+test("public pricing copy quotes the storefront counts plangate enforces", () => {
+  const limits = storeLimitsFromMatrix();
+  const surfaces: ReadonlyArray<[string, string]> = [
+    ["onboarding", read("apps/onboarding/components/marketing/Pricing.tsx")],
+    ["admin", read("apps/admin/lib/copy/pricing.ts")],
+  ];
+
+  for (const [name, src] of surfaces) {
+    for (const [plan, n] of Object.entries(limits)) {
+      if (plan === "trial") continue; // not sold as a plan
+      expect(
+        src,
+        `${name} pricing copy should quote "Up to ${n} storefronts/stores" for ${plan} ` +
+          `(plangate FeatureStores = ${n}). A count that disagrees with the matrix is a ` +
+          `promise the product will not keep — see #564.`,
+      ).toMatch(new RegExp(`Up to ${n} store`));
+    }
+  }
+});
+
+/**
+ * Limits that exist only in marketing copy. Each of these was on the live
+ * admin page against a service that enforces no such cap — a merchant
+ * hitting the advertised number would find nothing there.
+ */
+const INVENTED_LIMITS: ReadonlyArray<RegExp> = [
+  /Up to \d+ products/i,
+  /\d[\d,]* orders \/ month/i,
+  /\d+ staff accounts/i,
+  /Unlimited storefronts/i,
+  /Dedicated infrastructure/i,
+  /SLA-backed uptime/i,
+  /Advanced fraud tooling/i,
+];
+
+test("no pricing surface advertises a limit or capability the service lacks", () => {
+  const surfaces: ReadonlyArray<[string, string]> = [
+    ["onboarding Pricing.tsx", copyOnly(read("apps/onboarding/components/marketing/Pricing.tsx"))],
+    ["admin lib/copy/pricing.ts", copyOnly(read("apps/admin/lib/copy/pricing.ts"))],
+    ["llms-full.txt", read("apps/onboarding/public/llms-full.txt")],
+  ];
+
+  for (const [name, src] of surfaces) {
+    for (const pattern of INVENTED_LIMITS) {
+      expect(
+        src,
+        `${name} advertises "${pattern.source}", which nothing in ` +
+          `marketplace-api enforces or provides (#564). There is no product, ` +
+          `order or staff cap in the schema, FeatureStores caps Pro at 10 rather ` +
+          `than unlimited, and the cluster is a shared Cloud SQL micro instance.`,
+      ).not.toMatch(pattern);
+    }
+  }
+});
+
+test("no pricing surface still sells webhooks or custom code injection (#544)", () => {
+  const surfaces: ReadonlyArray<[string, string]> = [
+    ["onboarding Pricing.tsx", copyOnly(read("apps/onboarding/components/marketing/Pricing.tsx"))],
+    ["admin lib/copy/pricing.ts", copyOnly(read("apps/admin/lib/copy/pricing.ts"))],
+    ["llms-full.txt", read("apps/onboarding/public/llms-full.txt")],
+  ];
+
+  for (const [name, src] of surfaces) {
+    for (const claim of [/webhook/i, /code injection/i]) {
+      expect(
+        src,
+        `${name} still advertises ${claim.source}. Neither exists server-side: ` +
+          `no column stores a merchant callback URL, and FeatureCustomCodeInjection ` +
+          `is a forward-compat hedge no handler reads (#544). Outbound webhooks are ` +
+          `tracked in #562 — restore the copy when they ship, not before.`,
+      ).not.toMatch(claim);
+    }
+  }
+});


### PR DESCRIPTION
Closes #564. Finishes the job #560 started and #418 half-finished.

## What was live

`admin.mark8ly.com/pricing` is a **public, indexed** page — its own layout says *"Public pricing layout — no admin shell, no tenant extraction"* — and it described a different product from `mark8ly.com`.

| Claim on admin `/pricing` | Reality |
|---|---|
| Starter: **1 storefront** | `FeatureStores` = **2** |
| Studio: **3 storefronts** | **5** |
| Pro: **Unlimited storefronts** | **10** |
| Starter: **Up to 100 products** | No product cap exists |
| Starter: **500 orders / month** | No order cap exists |
| Studio: **5,000 orders / month** | No order cap exists |
| **2 / 10 staff accounts** | No staff cap exists |
| Pro: **Dedicated infrastructure** | Shared Cloud SQL `db-f1-micro` |
| Pro: **SLA-backed uptime** | `FeatureUptimeSLA` enforced by nothing; no SLA infrastructure |
| Pro: **Advanced fraud tooling** | No fraud module in the service |

The storefront counts were wrong in **both directions**. Starter and Studio understated what a merchant gets; Pro advertised unlimited against a matrix that caps it at 10 — so a Pro merchant opening an 11th store hits a wall the page told them wasn't there.

`Dedicated infrastructure` and `SLA-backed uptime` are the two I'd flag hardest: those are claims a customer could rely on contractually, made on a shared micro instance.

## How it survived

#413 caught this exact page quoting **prices** the billing catalog wouldn't charge. #418 fixed the prices by sourcing them from the catalog — and left the feature bullets as hand-written copy. Nobody audited the other column.

Meanwhile `llms-full.txt` still carried both #544 claims — "read-only API and webhooks" and "custom code injection" — because #560 fixed `PLAN_META` and missed it. **Those were still live** at `mark8ly.com/llms-full.txt`, served to AI crawlers.

Three sources of plan copy, none agreeing.

## Fix

Both surfaces now carry the audited list from #560, which was verified bullet-by-bullet against `plangate/matrix.go` and the schema.

**`tests/unit/pricing-surfaces-truth.spec.ts`** is the part meant to outlast this PR. It parses `FeatureStores` out of `matrix.go` and asserts both TypeScript surfaces quote those numbers — so the authority is the Go matrix, not any copy file. It also fails on invented limits (product/order/staff caps, "unlimited storefronts", "dedicated infrastructure", "SLA-backed uptime", "fraud tooling") and on webhooks / code injection across all three surfaces.

Verified it fails on the pre-fix copy: reinstated `Unlimited storefronts` + `Dedicated infrastructure`, watched both tests fail, restored.

It strips comments before scanning, so documenting *why* a claim was removed doesn't trip the guard enforcing its removal.

## Verification

- `apps/onboarding`: **77 passed**, `tsc --noEmit` clean
- `apps/admin`: `tsc --noEmit` clean
- Admin's vitest can't run in this worktree (`ERR_MODULE_NOT_FOUND`) — confirmed pre-existing by stashing to unmodified `origin/main` and reproducing. CI covers it.

## Left alone, deliberately

Admin still sells Pro as *"Start a conversation"* → `/admin/settings/billing/pro-contact`, while the marketing site sells it self-serve at $99/month. That's a **sales-process** difference rather than a false capability claim, and `pro-contact` is a real implemented flow — so I haven't touched it. Worth a decision, but not a correctness fix.

## Follow-up

Consolidating three copies onto one source. #305 does that for **prices** via a console snapshot; nothing covers **feature bullets**. Until something does, the new test is what keeps them from drifting apart again.
