### PR TITLE
ci: unblock every PR — allowlist two image-size advisories with no upgrade path

### DIFF
--- a/.github/scripts/audit-gate.py
+++ b/.github/scripts/audit-gate.py
@@ -24,6 +24,29 @@ ALLOWLIST = {
     # them anyway. Proper bump blocked by the monorepo multi-version lockfile
     # (can't regen locally). Time-boxed: drop when eslint deps are refreshed.
     "GHSA-mh99-v99m-4gvg",
+    # image-size DoS via infinite loops in the ICNS (GHSA-w3rx-r6r6-pgpr) and
+    # JXL/HEIF (GHSA-5p2g-fcmc-qvqq) parsers. Reaches us only as a BUILD-TIME
+    # dependency of the React Native bundler:
+    #   apps/mobile-* -> react-native -> @react-native/community-cli-plugin
+    #                 -> metro -> image-size
+    # metro uses it to measure image assets while bundling, on a developer's
+    # machine or in the mobile build job. It is not present in any deployed web
+    # service image, and nothing in production feeds untrusted ICNS/JXL/HEIF
+    # through it, so there is no production exposure to a parser DoS here.
+    #
+    # NOT time-boxed to an upgrade, because there is nothing to upgrade to:
+    # both advisories list `image-size <= 2.0.2` affected with first patched
+    # version NONE, and 2.0.2 is the latest published release. An `overrides`
+    # pin therefore cannot fix it either — clearing this needs image-size to
+    # ship a fix, then metro, then react-native.
+    #
+    # Left un-allowlisted, these block EVERY pr in the repo: main went red on a
+    # completely unchanged lockfile when npm's audit feed picked the advisories
+    # up (they were published 2026-06-10; the gate started failing 2026-09-02).
+    # Revisit when react-native is next bumped — drop these two ids, re-run the
+    # gate, and see whether the chain has been patched upstream.
+    "GHSA-w3rx-r6r6-pgpr",
+    "GHSA-5p2g-fcmc-qvqq",
 }
 
 


### PR DESCRIPTION
`main` is red and every PR is blocked. This unblocks them without weakening the gate for anything else.

## What happened

The "Audit production dependencies" step started failing on an **unchanged lockfile**. It passed at 04:10 on `73d445c6` and failed at 04:15 on `6212052c` — and `image-size@1.2.1`, `metro@0.81.5` and `react-native@0.76.9` are byte-identical across both commits, all `dev=false`. `npm audit` queries the live advisory feed, so no commit caused this; npm picked the advisories up (they were published 2026-06-10).

I initially suspected #559, which was the commit in that window. It isn't implicated — it only bumped `@tesserix/web`, and the lockfile entries for the affected packages are unchanged.

## Why it can't be fixed by upgrading

```
GHSA-w3rx-r6r6-pgpr  image-size <= 2.0.2  → first patched version: NONE
GHSA-5p2g-fcmc-qvqq  image-size <= 2.0.2  → first patched version: NONE
```

`2.0.2` is the latest published release and is itself affected. So `npm audit fix`, `--force`, and an `overrides` pin all have nothing to point at. Clearing it upstream needs `image-size` to ship a fix, then `metro`, then `react-native` — the whole chain — while every PR in the repo stays blocked.

## Why allowlisting is defensible here

The reach is build-time only:

```
apps/mobile-* → react-native → @react-native/community-cli-plugin → metro → image-size
```

metro uses `image-size` to measure image assets **while bundling**, on a developer's machine or in the mobile build job. It is not present in any deployed web service image, and nothing in production feeds untrusted ICNS/JXL/HEIF through it. A parser DoS there does not describe a production risk.

## Why this doesn't blanket-exempt React Native

`audit-gate.py` tolerates a vulnerability only when its **entire** advisory set is a subset of `ALLOWLIST`, and fails closed when it can't attribute one. So if `metro` or `react-native` later picks up an unrelated advisory, the set stops being a subset and the gate fails again.

Verified rather than assumed — I injected a hypothetical unrelated critical into the audit JSON:

```
BLOCKING high/critical vulnerabilities:
  critical: metro ['GHSA-5p2g-fcmc-qvqq', 'GHSA-fake-rce-0001', 'GHSA-w3rx-r6r6-pgpr']
  high: react-native [...]
  exit=1
```

Still blocks, and propagates to every dependent. That is the property worth keeping, and it survives.

## Verification

Against real `npm audit --omit=dev --json` output from this repo:

- **Before:** 7 blocking high-severity vulns, all resolving to exactly those two GHSAs, exit 1
- **After:** all 7 allowlisted, exit 0
- **With an unrelated advisory injected:** exit 1

## Note on the alternative

The other option was scoping the audit to exclude the React Native apps. That's blunter — it would hide *every* future advisory in those apps, not just these two. The allowlist is advisory-specific and self-expiring in the sense that anything new re-breaks the build, so it keeps more coverage.

The comment records what would need to happen to remove these ids: bump react-native, drop them, re-run.
