### PR TITLE
ci: adopt nextjs-ci v2.3.0 and allowlist the two unfixable image-size advisories

### DIFF
--- a/.github/scripts/test-ci-contract.py
+++ b/.github/scripts/test-ci-contract.py
@@ -10,7 +10,7 @@ ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github/workflows/ci.yml"
 IMAGES = ROOT / ".github/ci/container-images.json"
 CANDIDATE_REF = "29f963da2412a4ba0c755f19697ad0a31d7624b4"
-RELEASE_REF = "v2.2.1"
+RELEASE_REF = "v2.3.0"
 
 
 class ReusableCIContract(unittest.TestCase):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           - service: otto
             directory: services/otto
             coverage: 4
-    uses: tesserix/tesserix-workflows/.github/workflows/go-ci.yml@v2.2.1
+    uses: tesserix/tesserix-workflows/.github/workflows/go-ci.yml@v2.3.0
     with:
       working_directory: ${{ matrix.directory }}
       go_version: 1.26.6
@@ -109,7 +109,7 @@ jobs:
 
   secrets:
     name: Secrets
-    uses: tesserix/tesserix-workflows/.github/workflows/secret-scan.yml@v2.2.1
+    uses: tesserix/tesserix-workflows/.github/workflows/secret-scan.yml@v2.3.0
 
   integration:
     name: Integration (marketplace-api)
@@ -168,7 +168,7 @@ jobs:
     name: Containers
     if: ${{ github.event_name == 'pull_request' }}
     needs: policy
-    uses: tesserix/tesserix-workflows/.github/workflows/container-ci.yml@v2.2.1
+    uses: tesserix/tesserix-workflows/.github/workflows/container-ci.yml@v2.3.0
     with:
       images: ${{ needs.policy.outputs.images }}
     secrets:
@@ -188,7 +188,7 @@ jobs:
     name: Images
     if: ${{ contains(fromJSON('["push","workflow_dispatch"]'), github.event_name) && github.ref == 'refs/heads/main' }}
     needs: [policy, go, nextjs, secrets]
-    uses: tesserix/tesserix-workflows/.github/workflows/container-release.yml@v2.2.1
+    uses: tesserix/tesserix-workflows/.github/workflows/container-release.yml@v2.3.0
     with:
       namespace: tesserix
       images: ${{ needs.policy.outputs.images }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
   nextjs:
     name: Next.js
-    uses: tesserix/tesserix-workflows/.github/workflows/nextjs-ci.yml@v2.2.1
+    uses: tesserix/tesserix-workflows/.github/workflows/nextjs-ci.yml@v2.3.0
     with:
       working_directory: .
       node_version: "22"
@@ -78,6 +78,32 @@ jobs:
         @mark8ly/onboarding
         @repo/ui
         @repo/otto-widget
+      # image-size DoS in the ICNS (GHSA-w3rx-r6r6-pgpr) and JXL/HEIF
+      # (GHSA-5p2g-fcmc-qvqq) parsers. Build-time only:
+      #   apps/mobile-* -> react-native -> @react-native/community-cli-plugin
+      #                 -> metro -> image-size
+      # metro measures image assets while bundling; the package is in no
+      # deployed service image and nothing in production feeds it untrusted
+      # ICNS/JXL/HEIF, so there is no production exposure to a parser DoS.
+      #
+      # Nothing to upgrade to: both advisories list `image-size <= 2.0.2`
+      # affected with first patched version NONE, and 2.0.2 is the latest
+      # release — so `npm audit fix`, `--force` and an `overrides` pin all
+      # have nothing to point at. Left un-allowlisted these blocked EVERY PR
+      # in the repo (main went red on an unchanged lockfile when npm's feed
+      # picked them up on 2026-09-02; they were published 2026-06-10).
+      #
+      # audit_workspaces above does NOT exclude these — `npm audit
+      # --workspace=` still audits the hoisted root tree, so react-native
+      # surfaces even though the mobile apps are not listed.
+      #
+      # The gate tolerates a vulnerability only when its COMPLETE advisory
+      # set is listed, so metro/react-native picking up anything unrelated
+      # still fails. Revisit on the next react-native bump: drop these two
+      # ids and see whether the chain has been patched upstream.
+      audit_allowlist: >-
+        GHSA-w3rx-r6r6-pgpr
+        GHSA-5p2g-fcmc-qvqq
     secrets:
       package_read_token: ${{ secrets.GHCR_PAT }}
 


### PR DESCRIPTION
Unblocks the repo. `main` is red and no PR can go green.

## What broke

The "Audit production dependencies" step started failing on an **unchanged lockfile** — passed at 04:10 on `73d445c6`, failed at 04:15 on `6212052c`, with `image-size@1.2.1`, `metro@0.81.5` and `react-native@0.76.9` byte-identical across both and all `dev=false`. `npm audit` queries the live advisory feed, so no commit caused it; npm picked up two advisories published 2026-06-10.

(I initially suspected #559, which merged in that window. It isn't implicated — it only bumped `@tesserix/web`.)

## Why it can't be fixed by upgrading

```
GHSA-w3rx-r6r6-pgpr   image-size <= 2.0.2  → first patched version: NONE
GHSA-5p2g-fcmc-qvqq   image-size <= 2.0.2  → first patched version: NONE
```

`2.0.2` is the latest published release and is itself affected, so `npm audit fix`, `--force` and an `overrides` pin all have nothing to point at. Clearing it upstream needs `image-size` → `metro` → `react-native` to each ship a release, with the repo blocked throughout.

## Why the existing scoping didn't already handle it

`audit_workspaces` already excludes the mobile apps, and it makes no difference. Reproduced with the exact command the workflow runs:

```
$ npm audit --audit-level=high --omit=dev --workspace=@mark8ly/admin \
    --workspace=@mark8ly/storefront --workspace=@mark8ly/onboarding \
    --workspace=@repo/ui --workspace=@repo/otto-widget
6 high severity vulnerabilities
```

`npm audit --workspace=` still audits the **hoisted root tree**, so react-native surfaces regardless. That scoping is ineffective for hoisted transitive dependencies — worth knowing independently of this change.

## The fix

`tesserix-workflows#7` added an optional `audit_allowlist` to `nextjs-ci.yml`, released as **v2.3.0**. This adopts it and lists the two ids with the reasoning inline.

The reach is build-time only — `apps/mobile-* → react-native → @react-native/community-cli-plugin → metro → image-size`, where metro measures image assets while bundling. The package is in no deployed service image, and nothing in production feeds it untrusted ICNS/JXL/HEIF.

**This does not blanket-exempt react-native.** The gate tolerates a vulnerability only when its *complete* advisory set is allowlisted, and fails closed on anything it can't attribute. If metro or react-native later picks up an unrelated advisory, the set stops being a subset and the gate fails again — verified upstream by injecting a hypothetical critical into the audit JSON and confirming it still blocked and propagated to every dependent.

## Verified locally

Against real `npm audit --json` output from this repo, using the gate extracted from the committed workflow:

```
OK   allowlisted exit=0    all 7 vulns tolerated
OK   unrelated   exit=1    injected critical still blocks
OK   empty       exit=1    no allowlist behaves exactly as before
OK   malformed   exit=1    a package name is rejected, only GHSA/CVE ids accepted
OK   stale       exit=0    passes but reports entries matching nothing
```

## Also worth fixing, separately

`audit_workspaces` lists **`@repo/otto-widget`**, which resolves to no workspace in this repo — no package.json declares that name. Harmless today (npm ignores it) but misleading. Left alone here to keep this PR to the unblock.
