### PR TITLE
chore(ci): allowlist the two unfixable image-size advisories so the audit gate stops blocking every PR

### DIFF
--- a/.github/scripts/test-ci-contract.py
+++ b/.github/scripts/test-ci-contract.py
@@ -10,7 +10,10 @@ ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github/workflows/ci.yml"
 IMAGES = ROOT / ".github/ci/container-images.json"
 CANDIDATE_REF = "29f963da2412a4ba0c755f19697ad0a31d7624b4"
-RELEASE_REF = "v2.2.1"
+# Bumped to v2.3.0 for the `audit_allowlist` input on nextjs-ci.yml (#561).
+# That tag's only change from v2.2.1 is nextjs-ci.yml, so the other four
+# callers move with it purely to keep one ref across the file.
+RELEASE_REF = "v2.3.0"
 
 
 class ReusableCIContract(unittest.TestCase):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           - service: otto
             directory: services/otto
             coverage: 4
-    uses: tesserix/tesserix-workflows/.github/workflows/go-ci.yml@v2.2.1
+    uses: tesserix/tesserix-workflows/.github/workflows/go-ci.yml@v2.3.0
     with:
       working_directory: ${{ matrix.directory }}
       go_version: 1.26.6
@@ -67,7 +67,7 @@ jobs:
 
   nextjs:
     name: Next.js
-    uses: tesserix/tesserix-workflows/.github/workflows/nextjs-ci.yml@v2.2.1
+    uses: tesserix/tesserix-workflows/.github/workflows/nextjs-ci.yml@v2.3.0
     with:
       working_directory: .
       node_version: "22"
@@ -78,12 +78,35 @@ jobs:
         @mark8ly/onboarding
         @repo/ui
         @repo/otto-widget
+      # Two advisories on `image-size`, accepted knowingly (#561).
+      #
+      # There is no version to upgrade to: the advisory range is `<= 2.0.2`
+      # with `first_patched_version: null`, and 2.0.2 is the newest release.
+      # Every published version is affected, so no override or bump exists.
+      #
+      # It reaches this tree only through the mobile apps —
+      # react-native/expo -> metro -> image-size — as bundler tooling. It is
+      # in no web workspace's dependency graph and ships in no web image.
+      # `audit_workspaces` above says as much, but --workspace does not scope
+      # `npm audit`: it walks the hoisted root tree regardless, which is why
+      # this needs an explicit allowlist rather than a narrower list.
+      #
+      # Five other packages (metro, metro-config, metro-transform-worker,
+      # react-native, @react-native/community-cli-plugin) are reported too,
+      # and all six trace back to exactly these two advisories — the gate
+      # tolerates a vulnerability only when EVERY advisory it stems from is
+      # listed, so nothing else is being waved through.
+      #
+      # Remove both ids the moment a patched image-size exists.
+      audit_allowlist: >-
+        GHSA-w3rx-r6r6-pgpr
+        GHSA-5p2g-fcmc-qvqq
     secrets:
       package_read_token: ${{ secrets.GHCR_PAT }}
 
   secrets:
     name: Secrets
-    uses: tesserix/tesserix-workflows/.github/workflows/secret-scan.yml@v2.2.1
+    uses: tesserix/tesserix-workflows/.github/workflows/secret-scan.yml@v2.3.0
 
   integration:
     name: Integration (marketplace-api)
@@ -142,7 +165,7 @@ jobs:
     name: Containers
     if: ${{ github.event_name == 'pull_request' }}
     needs: policy
-    uses: tesserix/tesserix-workflows/.github/workflows/container-ci.yml@v2.2.1
+    uses: tesserix/tesserix-workflows/.github/workflows/container-ci.yml@v2.3.0
     with:
       images: ${{ needs.policy.outputs.images }}
     secrets:
@@ -162,7 +185,7 @@ jobs:
     name: Images
     if: ${{ contains(fromJSON('["push","workflow_dispatch"]'), github.event_name) && github.ref == 'refs/heads/main' }}
     needs: [policy, go, nextjs, secrets]
-    uses: tesserix/tesserix-workflows/.github/workflows/container-release.yml@v2.2.1
+    uses: tesserix/tesserix-workflows/.github/workflows/container-release.yml@v2.3.0
     with:
       namespace: tesserix
       images: ${{ needs.policy.outputs.images }}


### PR DESCRIPTION
Unblocks #561. Consumes `tesserix-workflows` **v2.3.0**, which adds the optional `audit_allowlist` input.

## Why the merge upstream was not enough

mark8ly pins the reusable workflows by tag. Merging the fix in `tesserix-workflows` changed nothing here while `ci.yml` still said `@v2.2.1` — the same shape of silent non-effect as the rest of #561. All five pins move to `v2.3.0`; the only file that changed between the tags is `nextjs-ci.yml`, so the other four are a no-op and move together for consistency.

## The allowlist

```yaml
audit_allowlist: >-
  GHSA-w3rx-r6r6-pgpr
  GHSA-5p2g-fcmc-qvqq
```

Both are `image-size`, and both are **unfixable**: the advisory range is `<= 2.0.2` with `first_patched_version: null`, and 2.0.2 is the newest release. There is no version to upgrade to and no override to write.

It reaches this tree only through the mobile apps — `react-native`/`expo` → `metro` → `image-size` — as bundler tooling. It is in no web workspace's dependency graph and ships in no web image. `audit_workspaces` already says that, but `--workspace` does not scope `npm audit`; verified twice:

```
$ npm audit --audit-level=high --omit=dev --workspace=@mark8ly/admin …   → 6 high
$ cd apps/admin && npm audit --audit-level=high --omit=dev               → 6 high
```

which is why an explicit allowlist is needed rather than a narrower workspace list.

## Only these two, and nothing else, is being accepted

Six packages are reported — `image-size`, `metro`, `metro-config`, `metro-transform-worker`, `react-native`, `@react-native/community-cli-plugin`. I replicated the gate's rule locally (a vulnerability passes only when **every** advisory it stems from is allowlisted) and walked each one's `via` chain:

```
@react-native/community-cli-plugin  stems from [GHSA-5p2g-fcmc-qvqq, GHSA-w3rx-r6r6-pgpr] -> tolerated
image-size                          stems from [GHSA-5p2g-fcmc-qvqq, GHSA-w3rx-r6r6-pgpr] -> tolerated
metro                               stems from [GHSA-5p2g-fcmc-qvqq, GHSA-w3rx-r6r6-pgpr] -> tolerated
metro-config                        stems from [GHSA-5p2g-fcmc-qvqq, GHSA-w3rx-r6r6-pgpr] -> tolerated
metro-transform-worker              stems from [GHSA-5p2g-fcmc-qvqq, GHSA-w3rx-r6r6-pgpr] -> tolerated
react-native                        stems from [GHSA-5p2g-fcmc-qvqq, GHSA-w3rx-r6r6-pgpr] -> tolerated

predicted gate result: PASS
```

All six trace back to exactly these two advisories. If any of those packages later picks up an *unrelated* advisory, the gate fails again — which is the property the upstream input was designed around, and the reason this is an allowlist of advisory ids rather than package names.

The gate keeps its teeth: it would still have caught the browserslist advisory that blocked everything this morning (#545), which **is** reachable from the web workspaces.

## Why this matters beyond merges

The audit gate blocks **deploys**, not just PRs. `Images` declares `needs: [policy, go, nextjs, secrets]`, so a red `nextjs` skips the container build entirely:

```
failure  Next.js / Next.js quality
skipped  Images
skipped  Containers
```

Three commits are on `main` and not in production behind this, including #559 (`@tesserix/web@2.4.2` — the AlertDialog portal fix and the destructive-coloured confirm button). Admin-merging past the gate got code onto `main` but never into a running pod.

## Removal condition

Delete both ids the moment a patched `image-size` ships. The comment in `ci.yml` says so, next to the reasoning, so the next person does not have to reconstruct why they are there.