### PR TITLE
feat(onboarding): lead the homepage and its metadata with the ninety-day offer

### DIFF
--- a/.planning/quick/260902-ndq-homepage-lead-with-offer/PLAN.md
+++ b/.planning/quick/260902-ndq-homepage-lead-with-offer/PLAN.md
@@ -1,0 +1,69 @@
+---
+type: quick
+slug: homepage-lead-with-offer
+branch: feat/homepage-lead-with-offer
+---
+
+# Quick Plan: Homepage leads with the ninety-day offer
+
+## Objective
+
+The ninety-day free trial (vs Shopify's 3 days, Wix/Squarespace's 14) is
+Mark8ly's strongest differentiator, but on the homepage it is tertiary fine
+print *below* the CTAs, and the page `<title>` is brand-led with no offer at
+all. Promote the offer to a hero deck line and front-load it in the metadata,
+without touching the `<h1>` or the design language.
+
+## Context
+
+- `apps/onboarding/app/page.tsx` — `Hero()` (~:305-343), page `metadata` (~:35-47)
+- `mark8ly/.impeccable.md` — paper/ink/moss, serif for display, calm voice,
+  no urgency or scarcity, asymmetric/left-aligned.
+
+## Tasks
+
+### Task 1 — Hero deck line (type: auto)
+
+- Keep the serif `<h1>` byte-identical ("A storefront / worth opening.").
+- Insert between `<h1>` and the descriptive `<p>`:
+  "Ninety days free, no card. And we never take a cut of what you sell."
+- Style with classes already used in the file only: `mt-6 max-w-xl text-xl
+  leading-[1.2] text-foreground`. Sans, not serif — the serif stays reserved
+  for the `<h1>` so the deck supports rather than competes.
+- Trim the tertiary line at :335 to pricing detail only:
+  "Three clear plans after that, from $15 a month, billed yearly."
+- Update the Hero header comment, which claims "Headline carries the offer" —
+  it no longer will; the deck does.
+
+Verify: offer appears exactly once above the fold, no new tokens introduced.
+
+### Task 2 — Homepage metadata (type: auto)
+
+- `title.absolute`: offer-led, brand present, ≤ 60 chars.
+- `description`: ninety days + 0% fees first, ≤ 155 chars.
+- Every claim must already be committed elsewhere in the repo
+  (`app/terms` ninety days free/no card, homepage FAQ 0% transaction fees,
+  Pricing $15/mo billed yearly). No migration claims — the importer is CSV.
+
+Verify: character counts measured, not estimated.
+
+### Task 3 — Typecheck + commit (type: auto)
+
+`npm run check-types -w @mark8ly/onboarding` (i.e. `tsc --noEmit`). No
+`npm install`. Atomic single-line conventional commits.
+
+## Out of scope
+
+- `SITE_JSON_LD` / `SITE_DESCRIPTION` in `lib/seo/site-json-ld.ts` — the CSP
+  hash is content-derived so an edit is safe, but the site-wide description is
+  not the homepage description and changing it would widen the blast radius
+  past this task. Leave it.
+- The `<h1>`, the SEO landing pages, `SeoLanding.tsx`, `Pricing.tsx`.
+
+## Success criteria
+
+- [ ] Offer stated once, prominently, above the CTAs
+- [ ] Fine print keeps only the price detail
+- [ ] Title ≤ 60 chars, description ≤ 155 chars, both offer-led
+- [ ] `tsc --noEmit` clean
+- [ ] Existing e2e heading assertion (`/a storefront worth opening/i`) still passes

--- a/.planning/quick/260902-ndq-homepage-lead-with-offer/SUMMARY.md
+++ b/.planning/quick/260902-ndq-homepage-lead-with-offer/SUMMARY.md
@@ -1,0 +1,102 @@
+---
+type: quick
+slug: homepage-lead-with-offer
+branch: feat/homepage-lead-with-offer
+commit: 2a59230c
+files-modified:
+  - apps/onboarding/app/page.tsx
+completed: 2026-09-02
+---
+
+# Quick Summary: Homepage leads with the ninety-day offer
+
+The ninety-day free trial and the 0% platform fee now lead the homepage and
+its SERP entry instead of sitting as tertiary fine print below the CTAs. The
+serif `<h1>` is untouched; a sans deck line beneath it carries the offer, and
+the fine print below the CTAs keeps price detail only, so the offer is stated
+exactly once.
+
+## What changed
+
+**`apps/onboarding/app/page.tsx` — `Hero()`**
+
+New deck line between the `<h1>` and the descriptive paragraph:
+
+```
+mt-6 max-w-xl text-xl leading-[1.2] text-foreground
+"Ninety days free, no card. And we never take a cut of what you sell."
+```
+
+Every class was already in use in this file (`text-xl` at :972, `leading-[1.2]`
+at :972, `mt-6`, `text-foreground`) — no new colours, sizes, or spacing values.
+Sans rather than serif: `.impeccable.md` reserves Source Serif 4 for display,
+and a serif deck under a serif headline would compete rather than support. The
+descriptive paragraph moved `mt-8` → `mt-6` so the headline/deck/body read as
+one block, with the CTAs' `mt-10` still opening the next beat.
+
+The Hero header comment claimed "Headline carries the offer" — the drift the
+task named. Rewritten to describe what the code now does.
+
+**Copy, before → after**
+
+| Slot | Before | After |
+| --- | --- | --- |
+| Deck (new) | — | Ninety days free, no card. And we never take a cut of what you sell. |
+| Below CTAs | Free for ninety days. No card required. Three clear plans after that, from $15 a month, billed yearly. | Three clear plans after that, from $15 a month, billed yearly. |
+| `title.absolute` | Mark8ly — quiet commerce for people who make things (51 ch) | Ninety days free, 0% platform fees — Mark8ly commerce (53 ch) |
+| `description` | Mark8ly is an editorial commerce platform for independent merchants. Open a storefront in an afternoon, keep every sale — no platform transaction fees — and ship a store that looks considered from day one. Ninety days free, no card required. (238 ch) | Ninety days free, no card, and 0% platform fees on your sales. An editorial commerce platform for independent merchants — open a store in an afternoon. (151 ch) |
+
+Title and description lengths were measured with `node -e`, not estimated: 53
+and 151, inside the ~60 / ~155 render budgets. The brand name stays in the
+title, so the description spends its budget on the offer and the category
+rather than repeating "Mark8ly". "0% **platform** fees" rather than a bare
+"0% fees" — the merchant still pays their payment processor's standard rate,
+and the unqualified phrasing would be a claim the repo does not support.
+
+## Claims audit
+
+Every claim was already committed elsewhere in the repo before this change:
+
+- ninety days free, no card — `app/terms/page.tsx:87`, `app/refunds/page.tsx:21`
+- no platform cut on sales — homepage FAQ (`page.tsx:1128`, "No added
+  transaction fees from Mark8ly, ever") and `page.tsx:412`
+- $15 a month billed yearly — existing USD annual equivalent, unchanged
+
+No new claims invented. No migration/importer claim made anywhere.
+
+## Not changed (deliberately)
+
+- **`lib/seo/site-json-ld.ts`** — left alone. Editing `SITE_DESCRIPTION` is
+  safe (the CSP hash is computed from `SITE_JSON_LD` at module load in
+  `middleware.ts:31`, so it follows the content), but that string is the
+  *site-wide* description consumed by the Organization and WebSite graphs on
+  every route, not the homepage description. Rewriting it to lead with a
+  trial offer would push page-specific marketing copy into site-wide
+  structured data. No consistency gain worth that.
+- **The `<h1>`** — byte-identical, per the task and to keep the existing e2e
+  assertion `getByRole("heading", { name: /a storefront worth opening/i })`
+  in `tests/e2e/golden-path.spec.ts:25` passing.
+- **`app/opengraph-image.tsx:14`** — its `alt` still reads "Mark8ly — quiet
+  commerce for people who make things" because it describes the OG image,
+  which visually renders that tagline. Changing the alt without regenerating
+  the image would make the alt wrong.
+
+## Verification
+
+| Command | Result |
+| --- | --- |
+| `npm run check-types -w @mark8ly/onboarding` (`tsc --noEmit`) | Pass, no output |
+| `npm run lint -w @mark8ly/onboarding` | Runs, but it is a **stub** — the script body is `echo 'lint stub — migrate to ESLint flat config (next lint removed in Next 16)'`. It lints nothing. |
+| `node -e` character counts on title/description | 53 and 151 |
+| `git diff --diff-filter=D HEAD~1 HEAD` | No deletions |
+
+No `npm install` was run and none was needed.
+
+Not run: `next build` and the Playwright e2e suite. The e2e specs need a dev
+server, and the only homepage assertion is on the unchanged `<h1>`. The change
+is JSX text and two string literals in an already-typechecking file.
+
+## Self-Check: PASSED
+
+- `apps/onboarding/app/page.tsx` — exists, modified
+- commit `2a59230c` — present in `git log`

--- a/apps/onboarding/app/page.tsx
+++ b/apps/onboarding/app/page.tsx
@@ -34,13 +34,20 @@ const SITE_URL = "https://mark8ly.com";
 
 export const metadata: Metadata = {
   title: {
-    absolute: "Mark8ly — quiet commerce for people who make things",
+    // Offer-led, not brand-led: the ninety days and the 0% platform fee are
+    // what differentiate us in a SERP (Shopify gives three days, Wix and
+    // Squarespace fourteen), and a brand tagline spends the whole ~60-char
+    // budget saying nothing a searcher can act on. 53 chars, so Google
+    // renders it whole.
+    absolute: "Ninety days free, 0% platform fees — Mark8ly commerce",
   },
+  // 151 chars — under the ~155 Google renders. Offer first, category second;
+  // "platform fees" rather than a bare "0% fees" because the merchant still
+  // pays their payment processor's standard rate.
   description:
-    "Mark8ly is an editorial commerce platform for independent merchants. " +
-    "Open a storefront in an afternoon, keep every sale — no platform " +
-    "transaction fees — and ship a store that looks considered from day one. " +
-    "Ninety days free, no card required.",
+    "Ninety days free, no card, and 0% platform fees on your sales. " +
+    "An editorial commerce platform for independent merchants — " +
+    "open a store in an afternoon.",
   alternates: {
     canonical: "/",
   },
@@ -299,7 +306,10 @@ export default async function HomePage() {
    ------------------------------------------------------------
    Asymmetric: copy left, single editorial moment right. No
    floating badges, no fake browser chrome, no metric strip.
-   Headline carries the offer; everything else gets out of the way.
+   Headline carries the brand, the deck line under it carries the
+   offer; everything else gets out of the way. The offer is stated
+   once, above the CTAs — the line below them keeps price detail only,
+   so nothing repeats.
    ============================================================ */
 
 function Hero() {
@@ -312,7 +322,11 @@ function Hero() {
             <br />
             worth opening.
           </h1>
-          <p className="mt-8 max-w-xl text-lg leading-[1.55] text-foreground-secondary">
+          <p className="mt-6 max-w-xl text-xl leading-[1.2] text-foreground">
+            Ninety days free, no card. And we never take a cut of what you
+            sell.
+          </p>
+          <p className="mt-6 max-w-xl text-lg leading-[1.55] text-foreground-secondary">
             Mark8ly is a quiet, considered commerce platform for people who
             actually make things. Set up in an afternoon. Keep your margins.
             Sell on a storefront that doesn&rsquo;t look like everyone
@@ -332,8 +346,7 @@ function Hero() {
           </div>
 
           <p className="mt-8 text-sm text-foreground-tertiary">
-            Free for ninety days. No card required. Three clear plans after
-            that, from $15 a month, billed yearly.
+            Three clear plans after that, from $15 a month, billed yearly.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Why

The ninety-day free trial is Mark8ly's strongest differentiator — Shopify gives three days, Wix and Squarespace fourteen — and the homepage rendered it as `text-sm text-foreground-tertiary` fine print *below* the CTAs. The `Hero()` header comment already said "Headline carries the offer; everything else gets out of the way", so this is closing a drift between the file's stated intent and what it does.

This matters now because an outreach campaign to the CRM's stage-`new` Mark8ly leads points every message at this page, and the page did not repeat the promise the message makes.

## What changed

**Hero** — the serif `<h1>` is untouched. A deck line goes between it and the descriptive paragraph:

> Ninety days free, no card. And we never take a cut of what you sell.

Styled `mt-6 max-w-xl text-xl leading-[1.2] text-foreground` — every class already used elsewhere in the file, no new tokens. Sans rather than serif: `.impeccable.md` reserves Source Serif 4 for display, and a serif deck would compete with the headline. The body paragraph moves `mt-8` → `mt-6` so headline/deck/body read as one block; the CTAs keep `mt-10` to open the next beat.

The tertiary line below the CTAs drops the duplicated offer and keeps only price detail. Net: the offer is stated once, high, and nothing repeats.

**Metadata** — was brand-led (`Mark8ly — quiet commerce for people who make things`), which spends the whole title budget on something a searcher cannot act on.

- title: `Ninety days free, 0% platform fees — Mark8ly commerce` (53 chars)
- description: offer first, category second (151 chars)

Both measured, not estimated.

## Claims

Every claim traces to existing copy — nothing new is asserted:

| Claim | Source |
|---|---|
| Ninety days, no card | `app/terms/page.tsx:87`, `app/refunds/page.tsx:21` |
| 0% platform fees | homepage FAQ, `page.tsx:1128` |
| From $15/mo billed yearly | unchanged; USD annual equivalent in `pricing-data.ts` |

"0% **platform** fees" rather than a bare "0% fees" — the merchant still pays their payment processor's standard rate, and the unqualified phrasing would claim something the service does not support. Same standard as #564.

`SITE_DESCRIPTION` is deliberately **not** touched. Editing it is CSP-safe (`middleware.ts:31` derives the hash via `sha256Source(SITE_JSON_LD)` at load), but that string feeds the Organization and WebSite graphs on every route, and leading site-wide structured data with a trial offer is a wider blast radius than the consistency gain.

## Verification

- `npm run check-types -w @mark8ly/onboarding` (`tsc --noEmit`) — passes, run independently of the change author.
- `npm run lint -w @mark8ly/onboarding` is a **stub** (`echo 'lint stub — migrate to ESLint flat config'`). It lints nothing. Flagging it as an existing gap rather than a gate this PR passed.
- No `npm install`.
- The only homepage e2e assertion is `getByRole("heading", { name: /a storefront worth opening/i })` (`tests/e2e/golden-path.spec.ts:25`) against the unchanged `<h1>`, so it still holds.

## Follow-up, not in this PR

`app/opengraph-image.tsx:14` still has `alt = "Mark8ly — quiet commerce for people who make things"`. That is correct today because the OG image visually renders that tagline — changing the alt without regenerating the image would make the alt wrong. The social card therefore still leads with the brand while the page leads with the offer. Worth a follow-up that regenerates the image and the alt together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YB1BFjWgctpHPLb1knCRKH
