### PR TITLE
Outbound webhooks: merchants subscribe to order, return, product and category events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/ticket/... \
 	    ./internal/vendor/... \
 	    ./internal/warehouse/... \
+	    ./internal/webhook/... \
 	    ./internal/webhookevents/... \
 	    ./internal/webhookprune/... \
 	    ./internal/whitelabel/lifecycle/... \

--- a/apps/admin/app/(admin)/settings/webhooks/actions.ts
+++ b/apps/admin/app/(admin)/settings/webhooks/actions.ts
@@ -2,9 +2,12 @@
 
 // Server actions for the webhooks settings page (#562 task 9).
 //
-// Every action starts with `guard()`, which resolves the session and
-// refuses write actions from anyone who can't edit settings. Read actions
-// (list deliveries) don't need write permission, only a valid session.
+// The MUTATING actions (create, patch, delete, replay) start with `guard()`,
+// which resolves the session and refuses anyone who can't edit settings.
+// The rest — list, test-send, list deliveries — only check that a session
+// exists, because the backend is what actually enforces authorization on
+// each route (internal/handlers/admin/routes.go) and re-deciding it here
+// would just be a second, drift-prone copy of that policy.
 
 import { headers } from "next/headers";
 import { revalidatePath } from "next/cache";
@@ -139,10 +142,13 @@ export async function deleteWebhookAction(webhookId: string): Promise<ActionResu
   return { ok: true, data: undefined };
 }
 
-// Test-send needs only a valid session, not write permission — it never
-// mutates the subscription and staff/viewer debugging their own endpoint
-// shouldn't need an admin to run it for them. It's still scoped to the
-// caller's store by ownedSubscription() server-side.
+// Test-send does not call guard(), but that does NOT make it available to
+// staff: POST /webhooks/:id/test requires RoleAdmin server-side
+// (internal/handlers/admin/routes.go), so a staff or viewer session reaches
+// the API and gets a 403 back, surfaced here as the returned error. The
+// backend is the authority on this; the action deliberately does not
+// duplicate the check. It's also scoped to the caller's store by
+// ownedSubscription() server-side.
 export async function testSendWebhookAction(
   webhookId: string,
 ): Promise<ActionResult<TestSendResult>> {

--- a/apps/admin/app/(admin)/settings/webhooks/actions.ts
+++ b/apps/admin/app/(admin)/settings/webhooks/actions.ts
@@ -1,0 +1,193 @@
+"use server";
+
+// Server actions for the webhooks settings page (#562 task 9).
+//
+// Every action starts with `guard()`, which resolves the session and
+// refuses write actions from anyone who can't edit settings. Read actions
+// (list deliveries) don't need write permission, only a valid session.
+
+import { headers } from "next/headers";
+import { revalidatePath } from "next/cache";
+
+import {
+  listWebhooks,
+  createWebhook,
+  patchWebhook,
+  deleteWebhook,
+  testSendWebhook,
+  listDeliveries,
+  replayDelivery,
+  type WebhookSubscription,
+  type WebhookDelivery,
+  type CreateWebhookInput,
+  type PatchWebhookInput,
+  type CreateWebhookResult,
+  type TestSendResult,
+} from "@/lib/api/webhooks";
+import { canEditSettings, resolveStoreId } from "@/lib/auth/serverSession";
+import type { TenantRole } from "@/lib/api/platform-api";
+
+export type ActionResult<T = undefined> =
+  | { ok: true; data: T }
+  | { ok: false; code: string; message: string; field?: string };
+
+async function getSession() {
+  const h = await headers();
+  const userId = h.get("x-session-user-id") ?? "";
+  const tenantId = h.get("x-session-tenant-id") ?? "";
+  const role = (h.get("x-session-role") ?? "viewer") as TenantRole;
+  const storeId = await resolveStoreId();
+  return { userId, tenantId, role, storeId };
+}
+
+async function guard() {
+  const session = await getSession();
+  if (!session.userId || !session.tenantId || !session.storeId) {
+    return {
+      refusal: {
+        ok: false as const,
+        code: "no_session",
+        message: "Session expired. Please sign in again.",
+      },
+    };
+  }
+  if (!canEditSettings(session.role)) {
+    return {
+      refusal: {
+        ok: false as const,
+        code: "forbidden",
+        message: "You do not have permission to manage webhooks.",
+      },
+    };
+  }
+  return { session };
+}
+
+function refresh() {
+  revalidatePath("/settings/webhooks");
+}
+
+export async function listWebhooksAction(): Promise<ActionResult<WebhookSubscription[]>> {
+  const session = await getSession();
+  if (!session.userId || !session.tenantId || !session.storeId) {
+    return { ok: false, code: "no_session", message: "Session expired. Please sign in again." };
+  }
+  const data = await listWebhooks(session.storeId, {
+    userId: session.userId,
+    tenantId: session.tenantId,
+  });
+  return { ok: true, data };
+}
+
+export async function createWebhookAction(
+  input: CreateWebhookInput,
+): Promise<ActionResult<CreateWebhookResult>> {
+  const { session, refusal } = await guard();
+  if (refusal) return refusal;
+
+  const result = await createWebhook(session.storeId, input, {
+    userId: session.userId,
+    tenantId: session.tenantId,
+  });
+  if (!result.ok) {
+    return {
+      ok: false,
+      code: result.error.code,
+      message: result.error.message,
+      field: result.error.field,
+    };
+  }
+  refresh();
+  return { ok: true, data: result.data };
+}
+
+export async function patchWebhookAction(
+  webhookId: string,
+  input: PatchWebhookInput,
+): Promise<ActionResult<WebhookSubscription>> {
+  const { session, refusal } = await guard();
+  if (refusal) return refusal;
+
+  const result = await patchWebhook(session.storeId, webhookId, input, {
+    userId: session.userId,
+    tenantId: session.tenantId,
+  });
+  if (!result.ok) {
+    return {
+      ok: false,
+      code: result.error.code,
+      message: result.error.message,
+      field: result.error.field,
+    };
+  }
+  refresh();
+  return { ok: true, data: result.data };
+}
+
+export async function deleteWebhookAction(webhookId: string): Promise<ActionResult> {
+  const { session, refusal } = await guard();
+  if (refusal) return refusal;
+
+  const result = await deleteWebhook(session.storeId, webhookId, {
+    userId: session.userId,
+    tenantId: session.tenantId,
+  });
+  if (!result.ok) {
+    return { ok: false, code: result.error.code, message: result.error.message };
+  }
+  refresh();
+  return { ok: true, data: undefined };
+}
+
+// Test-send needs only a valid session, not write permission — it never
+// mutates the subscription and staff/viewer debugging their own endpoint
+// shouldn't need an admin to run it for them. It's still scoped to the
+// caller's store by ownedSubscription() server-side.
+export async function testSendWebhookAction(
+  webhookId: string,
+): Promise<ActionResult<TestSendResult>> {
+  const session = await getSession();
+  if (!session.userId || !session.tenantId || !session.storeId) {
+    return { ok: false, code: "no_session", message: "Session expired. Please sign in again." };
+  }
+  const result = await testSendWebhook(session.storeId, webhookId, {
+    userId: session.userId,
+    tenantId: session.tenantId,
+  });
+  if (!result.ok) {
+    return { ok: false, code: result.error.code, message: result.error.message };
+  }
+  return { ok: true, data: result.data };
+}
+
+export async function listDeliveriesAction(
+  webhookId: string,
+): Promise<ActionResult<WebhookDelivery[]>> {
+  const session = await getSession();
+  if (!session.userId || !session.tenantId || !session.storeId) {
+    return { ok: false, code: "no_session", message: "Session expired. Please sign in again." };
+  }
+  const data = await listDeliveries(session.storeId, webhookId, {
+    userId: session.userId,
+    tenantId: session.tenantId,
+  });
+  return { ok: true, data };
+}
+
+export async function replayDeliveryAction(
+  webhookId: string,
+  deliveryId: string,
+): Promise<ActionResult> {
+  const { session, refusal } = await guard();
+  if (refusal) return refusal;
+
+  const result = await replayDelivery(session.storeId, webhookId, deliveryId, {
+    userId: session.userId,
+    tenantId: session.tenantId,
+  });
+  if (!result.ok) {
+    return { ok: false, code: result.error.code, message: result.error.message };
+  }
+  refresh();
+  return { ok: true, data: undefined };
+}

--- a/apps/admin/app/(admin)/settings/webhooks/page.tsx
+++ b/apps/admin/app/(admin)/settings/webhooks/page.tsx
@@ -1,0 +1,55 @@
+import { AdminPage, ReadOnlyNotice } from "@/components/layout";
+import {
+  canEditSettings,
+  getServerSessionContext,
+} from "@/lib/auth/serverSession";
+import { listWebhooks } from "@/lib/api/webhooks";
+import { WebhooksSettingsClient } from "@/components/settings/WebhooksSettingsClient";
+
+/**
+ * /settings/webhooks — outbound webhook subscriptions (#562 task 9).
+ *
+ * Available on every plan; there is no gate here to remove.
+ */
+export default async function WebhooksSettingsPage() {
+  const { role, userId, tenantId, currentStore } = await getServerSessionContext();
+
+  const editable = canEditSettings(role);
+
+  return (
+    <AdminPage
+      eyebrow="Developer"
+      title="Webhooks"
+      description="Send order, return, product, and category events to your own endpoint the moment they happen. Sign every request with a secret only you and Mark8ly ever see."
+      readOnlyNotice={!editable && role ? <ReadOnlyNotice role={role} /> : undefined}
+    >
+      {currentStore ? (
+        <WebhooksSettingsContent
+          storeId={currentStore.id}
+          userId={userId}
+          tenantId={tenantId}
+          editable={editable}
+        />
+      ) : (
+        <p className="text-sm text-danger">
+          No store found. Please create a store before configuring webhooks.
+        </p>
+      )}
+    </AdminPage>
+  );
+}
+
+async function WebhooksSettingsContent({
+  storeId,
+  userId,
+  tenantId,
+  editable,
+}: {
+  storeId: string;
+  userId: string;
+  tenantId: string;
+  editable: boolean;
+}) {
+  const webhooks = await listWebhooks(storeId, { userId, tenantId });
+  return <WebhooksSettingsClient webhooks={webhooks} editable={editable} />;
+}

--- a/apps/admin/components/settings/WebhooksSettingsClient.tsx
+++ b/apps/admin/components/settings/WebhooksSettingsClient.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+// WebhooksSettingsClient — outbound webhook subscriptions (#562 task 9).
+//
+// List, create, edit, enable/disable, delete, test-send, and browse
+// deliveries for a store's webhook subscriptions. Follows the same shape
+// as WarehousesSettingsClient: an inline create/edit form swaps in for the
+// list, an AlertDialog confirms delete, and mutations go through the
+// server actions in app/(admin)/settings/webhooks/actions.ts.
+//
+// The one thing this surface has that no other settings page does: the
+// signing secret. It exists on the wire exactly once, in the response to
+// Create, and WebhookSecretDialog is the only place in this component
+// tree that ever touches it — it's never stored in this component's own
+// state beyond the dialog's lifetime, and never logged.
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button, AlertDialog } from "@tesserix/web";
+
+import type { WebhookSubscription } from "@/lib/api/webhooks";
+import {
+  createWebhookAction,
+  patchWebhookAction,
+  deleteWebhookAction,
+} from "@/app/(admin)/settings/webhooks/actions";
+import { WebhookForm } from "./webhooks/WebhookForm";
+import { WebhookRow } from "./webhooks/WebhookRow";
+import { WebhookSecretDialog } from "./webhooks/WebhookSecretDialog";
+
+interface WebhooksSettingsClientProps {
+  webhooks: WebhookSubscription[];
+  editable: boolean;
+}
+
+type Editing = { mode: "none" } | { mode: "new" } | { mode: "edit"; id: string };
+
+export function WebhooksSettingsClient({ webhooks, editable }: WebhooksSettingsClientProps) {
+  const router = useRouter();
+  const [editing, setEditing] = useState<Editing>({ mode: "none" });
+  const [confirmDelete, setConfirmDelete] = useState<WebhookSubscription | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
+
+  function handleCreate(input: { url: string; event_types: string[] }) {
+    return new Promise<{ ok: boolean; message?: string; field?: string }>((resolve) => {
+      startTransition(async () => {
+        const result = await createWebhookAction(input);
+        if (!result.ok) {
+          resolve({ ok: false, message: result.message, field: result.field });
+          return;
+        }
+        setEditing({ mode: "none" });
+        // Reveal the secret before refreshing the list — it exists only
+        // on this response and nowhere else, ever.
+        setRevealedSecret(result.data.secret);
+        router.refresh();
+        resolve({ ok: true });
+      });
+    });
+  }
+
+  function handleUpdate(id: string, input: { url: string; event_types: string[] }) {
+    return new Promise<{ ok: boolean; message?: string; field?: string }>((resolve) => {
+      startTransition(async () => {
+        const result = await patchWebhookAction(id, input);
+        if (!result.ok) {
+          resolve({ ok: false, message: result.message, field: result.field });
+          return;
+        }
+        setEditing({ mode: "none" });
+        router.refresh();
+        resolve({ ok: true });
+      });
+    });
+  }
+
+  function handleToggleEnabled(webhook: WebhookSubscription, enabled: boolean) {
+    setError(null);
+    startTransition(async () => {
+      const result = await patchWebhookAction(webhook.id, { enabled });
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  function handleDeleteConfirmed() {
+    const target = confirmDelete;
+    if (!target) return;
+    setConfirmDelete(null);
+    setError(null);
+    startTransition(async () => {
+      const result = await deleteWebhookAction(target.id);
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  if (editing.mode === "new") {
+    return (
+      <section className="border-t border-border-subtle pt-8">
+        <h2 className="mb-6 font-serif text-xl text-[color:var(--ink-900)]">
+          Add a webhook
+        </h2>
+        <WebhookForm
+          onSubmit={handleCreate}
+          onCancel={() => setEditing({ mode: "none" })}
+          submitLabel="Create webhook"
+        />
+      </section>
+    );
+  }
+
+  if (editing.mode === "edit") {
+    const target = webhooks.find((w) => w.id === editing.id);
+    if (target) {
+      return (
+        <section className="border-t border-border-subtle pt-8">
+          <h2 className="mb-6 font-serif text-xl text-[color:var(--ink-900)]">
+            Edit webhook
+          </h2>
+          <WebhookForm
+            existing={target}
+            onSubmit={(input) => handleUpdate(target.id, input)}
+            onCancel={() => setEditing({ mode: "none" })}
+            submitLabel="Save changes"
+          />
+        </section>
+      );
+    }
+  }
+
+  return (
+    <section>
+      {error && (
+        <p role="alert" className="mb-4 rounded-md border border-[color:var(--danger)]/25 bg-[color:var(--danger)]/[0.06] px-4 py-2.5 text-sm text-[color:var(--danger)]">
+          {error}
+        </p>
+      )}
+
+      {webhooks.length === 0 ? (
+        <div className="border-t border-border-subtle py-10">
+          <p className="text-sm text-foreground-tertiary">
+            No webhooks yet. Add one to start sending order, return, product,
+            and category events to your own endpoint.
+          </p>
+          {editable && (
+            <Button type="button" className="mt-4" onClick={() => setEditing({ mode: "new" })}>
+              Add webhook
+            </Button>
+          )}
+        </div>
+      ) : (
+        <>
+          <ul className="mt-6 border-t border-border-subtle">
+            {webhooks.map((w) => (
+              <WebhookRow
+                key={w.id}
+                webhook={w}
+                editable={editable}
+                pending={pending}
+                onEdit={() => setEditing({ mode: "edit", id: w.id })}
+                onDelete={() => setConfirmDelete(w)}
+                onToggleEnabled={(enabled) => handleToggleEnabled(w, enabled)}
+              />
+            ))}
+          </ul>
+
+          {editable && (
+            <Button type="button" className="mt-6" onClick={() => setEditing({ mode: "new" })} disabled={pending}>
+              Add webhook
+            </Button>
+          )}
+        </>
+      )}
+
+      <AlertDialog
+        isOpen={confirmDelete !== null}
+        onClose={() => setConfirmDelete(null)}
+        title={confirmDelete ? "Delete this webhook?" : ""}
+        message={
+          confirmDelete
+            ? "This stops all future deliveries to this endpoint immediately and cannot be undone. If you need it again, you'll create a new subscription with a new secret."
+            : ""
+        }
+        type="confirm"
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        onConfirm={handleDeleteConfirmed}
+        onCancel={() => setConfirmDelete(null)}
+      />
+
+      <WebhookSecretDialog secret={revealedSecret} onDismiss={() => setRevealedSecret(null)} />
+    </section>
+  );
+}

--- a/apps/admin/components/settings/webhooks/DeliveriesPanel.tsx
+++ b/apps/admin/components/settings/webhooks/DeliveriesPanel.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { Button, Badge } from "@tesserix/web";
+
+import type { WebhookDelivery, DeliveryStatus } from "@/lib/api/webhooks";
+import {
+  listDeliveriesAction,
+  replayDeliveryAction,
+  testSendWebhookAction,
+} from "@/app/(admin)/settings/webhooks/actions";
+
+interface DeliveriesPanelProps {
+  webhookId: string;
+  editable: boolean;
+}
+
+const STATUS_VARIANT: Record<DeliveryStatus, "success" | "error" | "neutral"> = {
+  delivered: "success",
+  failed: "error",
+  pending: "neutral",
+};
+
+/**
+ * Recent deliveries for one subscription, plus the test-send control.
+ * Replay is offered only on `failed` rows — a `pending` delivery is
+ * already due to run, and a `delivered` one succeeded, so replaying
+ * either would either do nothing or duplicate a webhook the merchant's
+ * endpoint already received.
+ */
+export function DeliveriesPanel({ webhookId, editable }: DeliveriesPanelProps) {
+  const [deliveries, setDeliveries] = useState<WebhookDelivery[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loadPending, startLoad] = useTransition();
+  const [testPending, startTest] = useTransition();
+  const [testResult, setTestResult] = useState<
+    { status_code: number; success: boolean; error?: string } | null
+  >(null);
+  const [replayingId, setReplayingId] = useState<string | null>(null);
+
+  function load() {
+    startLoad(async () => {
+      const result = await listDeliveriesAction(webhookId);
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      setError(null);
+      setDeliveries(result.data);
+    });
+  }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    load();
+  }, [webhookId]);
+
+  function handleTestSend() {
+    setTestResult(null);
+    setError(null);
+    startTest(async () => {
+      const result = await testSendWebhookAction(webhookId);
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      setTestResult(result.data);
+      load();
+    });
+  }
+
+  function handleReplay(deliveryId: string) {
+    setReplayingId(deliveryId);
+    setError(null);
+    startLoad(async () => {
+      const result = await replayDeliveryAction(webhookId, deliveryId);
+      setReplayingId(null);
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      load();
+    });
+  }
+
+  return (
+    <div className="space-y-4 border-t border-border-subtle pt-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h4 className="text-sm font-medium text-foreground">Recent deliveries</h4>
+        {editable && (
+          <Button type="button" variant="outline" size="sm" onClick={handleTestSend} disabled={testPending}>
+            {testPending ? "Sending..." : "Send test event"}
+          </Button>
+        )}
+      </div>
+
+      {/* Test-send reports the exact status code the endpoint returned —
+          including on failure, since debugging a non-2xx response is the
+          whole reason this button exists. */}
+      {testResult && (
+        <p
+          role="status"
+          className={`text-sm ${
+            testResult.success ? "text-[color:var(--moss-700)]" : "text-[color:var(--danger)]"
+          }`}
+        >
+          Test event responded {testResult.status_code}
+          {testResult.error ? ` — ${testResult.error}` : ""}
+        </p>
+      )}
+
+      {error && (
+        <p role="alert" className="text-sm text-[color:var(--danger)]">
+          {error}
+        </p>
+      )}
+
+      {deliveries === null ? (
+        <p className="text-sm text-foreground-tertiary">Loading deliveries…</p>
+      ) : deliveries.length === 0 ? (
+        <p className="text-sm text-foreground-tertiary">No deliveries yet.</p>
+      ) : (
+        <ul className="space-y-2.5">
+          {deliveries.map((d) => (
+            <li
+              key={d.id}
+              className="flex flex-wrap items-center justify-between gap-3 border-b border-border-subtle pb-2.5 text-sm last:border-b-0 last:pb-0"
+            >
+              <div className="min-w-0">
+                <span className="font-medium text-foreground">{d.event_type}</span>
+                {d.last_status_code != null && (
+                  <span className="ml-2 text-foreground-tertiary">→ {d.last_status_code}</span>
+                )}
+                {d.last_error && (
+                  <p className="mt-0.5 truncate text-xs text-foreground-tertiary">{d.last_error}</p>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <Badge variant={STATUS_VARIANT[d.status]}>{d.status}</Badge>
+                {editable && d.status === "failed" && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleReplay(d.id)}
+                    disabled={replayingId === d.id}
+                  >
+                    {replayingId === d.id ? "Replaying..." : "Replay"}
+                  </Button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/components/settings/webhooks/EventTypeCheckboxGroup.tsx
+++ b/apps/admin/components/settings/webhooks/EventTypeCheckboxGroup.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Checkbox } from "@tesserix/web";
+
+import { EVENT_TYPE_GROUPS } from "./eventTypes";
+
+interface EventTypeCheckboxGroupProps {
+  value: string[];
+  onChange: (next: string[]) => void;
+  disabled?: boolean;
+  /** Wires the error message to the fieldset for screen readers. */
+  describedBy?: string;
+}
+
+/**
+ * The 18 event types, grouped by aggregate (order / return / product /
+ * category / cart) with the aggregate name as a group label — a flat list
+ * of 18 checkboxes reads as noise, five short lists read as a menu.
+ */
+export function EventTypeCheckboxGroup({
+  value,
+  onChange,
+  disabled,
+  describedBy,
+}: EventTypeCheckboxGroupProps) {
+  const selected = new Set(value);
+
+  function toggle(eventType: string, checked: boolean) {
+    if (disabled) return;
+    const next = new Set(selected);
+    if (checked) {
+      next.add(eventType);
+    } else {
+      next.delete(eventType);
+    }
+    onChange(Array.from(next));
+  }
+
+  return (
+    <fieldset aria-describedby={describedBy} className="space-y-6">
+      <legend className="text-sm font-medium text-foreground">Event types</legend>
+      <div className="grid gap-6 sm:grid-cols-2">
+        {EVENT_TYPE_GROUPS.map((group) => (
+          <div key={group.aggregate} className="space-y-2.5">
+            <p className="text-xs font-medium uppercase tracking-wide text-foreground-tertiary">
+              {group.aggregate}
+            </p>
+            <ul className="space-y-2">
+              {group.types.map((t) => {
+                const id = `event-type-${t.value}`;
+                return (
+                  <li key={t.value} className="flex items-center gap-2.5">
+                    <Checkbox
+                      id={id}
+                      checked={selected.has(t.value)}
+                      onCheckedChange={(checked) => toggle(t.value, checked === true)}
+                      disabled={disabled}
+                    />
+                    <label
+                      htmlFor={id}
+                      className="text-sm text-foreground-secondary"
+                    >
+                      {t.label}
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </fieldset>
+  );
+}

--- a/apps/admin/components/settings/webhooks/WebhookForm.tsx
+++ b/apps/admin/components/settings/webhooks/WebhookForm.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button, Input } from "@tesserix/web";
+
+import type { WebhookSubscription } from "@/lib/api/webhooks";
+import { EventTypeCheckboxGroup } from "./EventTypeCheckboxGroup";
+
+export interface WebhookFormSubmitResult {
+  ok: boolean;
+  message?: string;
+  field?: string;
+}
+
+interface WebhookFormProps {
+  existing?: WebhookSubscription;
+  onSubmit: (input: { url: string; event_types: string[] }) => Promise<WebhookFormSubmitResult>;
+  onCancel: () => void;
+  submitLabel: string;
+}
+
+/**
+ * Create/edit form shared by both flows. The backend maps SSRF failures
+ * (not-HTTPS, private address, unresolvable, malformed, too long) to
+ * distinct messages via mapSSRFErr — this surfaces whatever message comes
+ * back verbatim, wired to the URL field with aria-describedby, rather than
+ * collapsing every case into a generic "invalid URL".
+ */
+export function WebhookForm({ existing, onSubmit, onCancel, submitLabel }: WebhookFormProps) {
+  const [url, setUrl] = useState(existing?.url ?? "");
+  const [eventTypes, setEventTypes] = useState<string[]>(existing?.event_types ?? []);
+  const [error, setError] = useState<{ message: string; field?: string } | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const urlErrorId = "webhook-url-error";
+  const eventTypesErrorId = "webhook-event-types-error";
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (eventTypes.length === 0) {
+      setError({ message: "Select at least one event type.", field: "event_types" });
+      return;
+    }
+    startTransition(async () => {
+      const result = await onSubmit({ url: url.trim(), event_types: eventTypes });
+      if (!result.ok) {
+        setError({ message: result.message ?? "Something went wrong.", field: result.field });
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="space-y-1.5">
+        <label htmlFor="webhook-url" className="block text-sm font-medium text-foreground">
+          Endpoint URL
+        </label>
+        <Input
+          id="webhook-url"
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://example.com/webhooks/mark8ly"
+          disabled={pending}
+          required
+          aria-invalid={error?.field === "url" ? true : undefined}
+          aria-describedby={error?.field === "url" ? urlErrorId : undefined}
+        />
+        <p className="text-xs text-foreground-tertiary">
+          Must be HTTPS and publicly resolvable. We sign every request with
+          your subscription's secret.
+        </p>
+        {error?.field === "url" && (
+          <p id={urlErrorId} role="alert" className="text-sm text-[color:var(--danger)]">
+            {error.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <EventTypeCheckboxGroup
+          value={eventTypes}
+          onChange={setEventTypes}
+          disabled={pending}
+          describedBy={error?.field === "event_types" ? eventTypesErrorId : undefined}
+        />
+        {error?.field === "event_types" && (
+          <p id={eventTypesErrorId} role="alert" className="mt-2 text-sm text-[color:var(--danger)]">
+            {error.message}
+          </p>
+        )}
+      </div>
+
+      {error && !error.field && (
+        <p role="alert" className="text-sm text-[color:var(--danger)]">
+          {error.message}
+        </p>
+      )}
+
+      <div className="flex items-center gap-3">
+        <Button type="submit" disabled={pending}>
+          {pending ? "Saving..." : submitLabel}
+        </Button>
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={pending}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/admin/components/settings/webhooks/WebhookRow.tsx
+++ b/apps/admin/components/settings/webhooks/WebhookRow.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@tesserix/web";
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+import type { WebhookSubscription } from "@/lib/api/webhooks";
+import { ToggleSwitch } from "@/components/settings/BrandingSettingsClient";
+import { eventTypeLabel } from "./eventTypes";
+import { DeliveriesPanel } from "./DeliveriesPanel";
+
+interface WebhookRowProps {
+  webhook: WebhookSubscription;
+  editable: boolean;
+  pending: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+  onToggleEnabled: (enabled: boolean) => void;
+}
+
+export function WebhookRow({
+  webhook,
+  editable,
+  pending,
+  onEdit,
+  onDelete,
+  onToggleEnabled,
+}: WebhookRowProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <li className="border-b border-border-subtle py-5">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0 space-y-1.5">
+          <p className="break-all font-mono text-sm text-foreground">{webhook.url}</p>
+          <p className="text-xs text-foreground-tertiary">
+            {webhook.event_types.length === 1
+              ? eventTypeLabel(webhook.event_types[0] as string)
+              : `${webhook.event_types.length} event types`}
+          </p>
+
+          {/* A disabled subscription must show WHY, prominently and
+              without opening a delivery — the backend's disabled_reason
+              is written in plain language for exactly this. */}
+          {!webhook.enabled && webhook.disabled_reason && (
+            <p
+              role="status"
+              className="mt-2 max-w-prose rounded-md border border-[color:var(--danger)]/25 bg-[color:var(--danger)]/[0.06] px-3 py-2 text-sm text-[color:var(--danger)]"
+            >
+              Disabled: {webhook.disabled_reason}
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1.5 text-sm text-foreground-secondary transition-colors hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--moss-700)]"
+          >
+            Deliveries
+            {expanded ? (
+              <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+            )}
+          </button>
+
+          {editable && (
+            <>
+              <ToggleSwitch
+                checked={webhook.enabled}
+                onChange={onToggleEnabled}
+                disabled={pending}
+              />
+              <Button type="button" variant="outline" size="sm" onClick={onEdit} disabled={pending}>
+                Edit
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                onClick={onDelete}
+                disabled={pending}
+              >
+                Delete
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="mt-4">
+          <DeliveriesPanel webhookId={webhook.id} editable={editable} />
+        </div>
+      )}
+    </li>
+  );
+}

--- a/apps/admin/components/settings/webhooks/WebhookSecretDialog.tsx
+++ b/apps/admin/components/settings/webhooks/WebhookSecretDialog.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  Button,
+  Checkbox,
+} from "@tesserix/web";
+import { Check, Copy } from "lucide-react";
+
+interface WebhookSecretDialogProps {
+  /** null hides the dialog. Pass the freshly-created secret to show it. */
+  secret: string | null;
+  onDismiss: () => void;
+}
+
+/**
+ * The signing secret is shown here exactly once — the create response
+ * carries it and no later endpoint ever returns it again. Every affordance
+ * in this dialog exists to stop a merchant from losing it by accident:
+ *
+ *   - Escape and outside-click are disabled (`dismissOnOutsideClick`,
+ *     no close button) — the only exit is the explicit "Done" button.
+ *   - "Done" is disabled until the merchant checks a box acknowledging
+ *     they've copied it, so the consequence of closing without copying
+ *     (delete + recreate is the only recovery) is unmissable *before*
+ *     they dismiss it, not something they discover on the next visit.
+ */
+export function WebhookSecretDialog({ secret, onDismiss }: WebhookSecretDialogProps) {
+  const [copied, setCopied] = useState(false);
+  const [acknowledged, setAcknowledged] = useState(false);
+
+  if (!secret) return null;
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(secret as string);
+      setCopied(true);
+    } catch {
+      // Clipboard API can be unavailable (older browser, insecure
+      // context). The secret is still visible and selectable as text, so
+      // this isn't fatal — just leave the button in its un-copied state.
+    }
+  }
+
+  function handleDone() {
+    setCopied(false);
+    setAcknowledged(false);
+    onDismiss();
+  }
+
+  return (
+    <Dialog open onOpenChange={() => {}}>
+      <DialogContent showCloseButton={false} dismissOnOutsideClick={false}>
+        <DialogHeader>
+          <DialogTitle>Save your signing secret</DialogTitle>
+          <DialogDescription>
+            This is the only time Mark8ly will show you this secret. Copy it
+            now and store it somewhere safe. If you lose it, the only way to
+            get a new one is to delete this webhook and create another.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center gap-2 rounded-md border border-border bg-[color:var(--background-elevated)] px-3 py-2.5">
+          <code className="flex-1 overflow-x-auto whitespace-nowrap font-mono text-sm text-foreground">
+            {secret}
+          </code>
+          <Button type="button" variant="outline" size="sm" onClick={handleCopy}>
+            {copied ? (
+              <>
+                <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                Copied
+              </>
+            ) : (
+              <>
+                <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+                Copy
+              </>
+            )}
+          </Button>
+        </div>
+
+        <label className="flex items-start gap-2.5 pt-2 text-sm text-foreground-secondary">
+          <Checkbox
+            checked={acknowledged}
+            onCheckedChange={(checked) => setAcknowledged(checked === true)}
+            className="mt-0.5"
+          />
+          I have copied and saved this secret. I understand Mark8ly will not
+          show it to me again.
+        </label>
+
+        <DialogFooter>
+          <Button type="button" onClick={handleDone} disabled={!acknowledged}>
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/components/settings/webhooks/eventTypes.ts
+++ b/apps/admin/components/settings/webhooks/eventTypes.ts
@@ -1,0 +1,77 @@
+// apps/admin/components/settings/webhooks/eventTypes.ts
+//
+// The closed set of 18 event types a subscription may select, mirrored
+// from marketplace-api's allowedEventTypes (webhooks.go) and grouped by
+// aggregate so the picker reads as five short lists instead of one long
+// one. Keep this in sync with services/marketplace-api/internal/outbox's
+// Event* constants — a mismatch here means a merchant can select a type
+// the backend rejects, or can't select one it accepts.
+
+export interface EventTypeGroup {
+  aggregate: string;
+  types: { value: string; label: string }[];
+}
+
+export const EVENT_TYPE_GROUPS: EventTypeGroup[] = [
+  {
+    aggregate: "Order",
+    types: [
+      { value: "order.placed", label: "Order placed" },
+      { value: "order.confirmed", label: "Order confirmed" },
+      { value: "order.fulfilled", label: "Order fulfilled" },
+      { value: "order.partially_fulfilled", label: "Order partially fulfilled" },
+      { value: "order.cancelled", label: "Order cancelled" },
+      { value: "order.refunded", label: "Order refunded" },
+    ],
+  },
+  {
+    aggregate: "Return",
+    types: [
+      { value: "return.requested", label: "Return requested" },
+      { value: "return.approved", label: "Return approved" },
+      { value: "return.received", label: "Return received" },
+      { value: "return.refunded", label: "Return refunded" },
+      { value: "return.rejected", label: "Return rejected" },
+    ],
+  },
+  {
+    aggregate: "Product",
+    types: [
+      { value: "product.created", label: "Product created" },
+      { value: "product.updated", label: "Product updated" },
+      { value: "product.deleted", label: "Product deleted" },
+    ],
+  },
+  {
+    aggregate: "Category",
+    types: [
+      { value: "category.created", label: "Category created" },
+      { value: "category.updated", label: "Category updated" },
+      { value: "category.deleted", label: "Category deleted" },
+    ],
+  },
+  {
+    aggregate: "Cart",
+    types: [
+      {
+        value: "abandoned_cart.recovery_email",
+        label: "Abandoned cart recovery email sent",
+      },
+    ],
+  },
+];
+
+export const ALL_EVENT_TYPES: string[] = EVENT_TYPE_GROUPS.flatMap((g) =>
+  g.types.map((t) => t.value),
+);
+
+const LABELS: Record<string, string> = Object.fromEntries(
+  ALL_EVENT_TYPES.map((value) => [
+    value,
+    EVENT_TYPE_GROUPS.flatMap((g) => g.types).find((t) => t.value === value)!.label,
+  ]),
+);
+
+export function eventTypeLabel(value: string): string {
+  return LABELS[value] ?? value;
+}

--- a/apps/admin/lib/api/webhooks.ts
+++ b/apps/admin/lib/api/webhooks.ts
@@ -1,0 +1,279 @@
+// apps/admin/lib/api/webhooks.ts
+//
+// Admin client for the outbound webhooks API (#562 task 7), mounted at
+// /api/v1/admin/stores/:storeId/webhooks. Follows the same calling
+// convention as coupons-api.ts / settings-api.ts: server components (or
+// server actions) pass SessionHeaders, and mutations return the shared
+// MutationResult<T> so callers pattern-match on `ok` instead of throwing.
+//
+// The one endpoint that behaves differently from every other resource in
+// this app is Create: it returns the signing secret exactly once, as a
+// sibling field next to the subscription — never on the subscription
+// object itself, and no other endpoint here ever returns it again. Keep
+// that shape (CreateWebhookResult) distinct from WebhookSubscription so a
+// future edit can't accidentally start threading `secret` through list/
+// patch responses.
+
+import type { SessionHeaders, MutationResult, MutationError } from "./marketplace-api";
+
+const MARKETPLACE_API_URL =
+  process.env.MARKETPLACE_API_URL ?? "http://localhost:8088";
+
+const MARKETPLACE_INTERNAL_AUTH =
+  process.env.MARKETPLACE_INTERNAL_AUTH_SECRET ?? "";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Wire DTOs — match WebhookResponse / DeliveryResponse in webhooks.go
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface WebhookSubscription {
+  id: string;
+  url: string;
+  event_types: string[];
+  enabled: boolean;
+  disabled_reason?: string | null;
+  disabled_at?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type DeliveryStatus = "pending" | "delivered" | "failed";
+
+export interface WebhookDelivery {
+  id: string;
+  event_type: string;
+  aggregate_id: string;
+  status: DeliveryStatus;
+  attempts: number;
+  next_attempt_at: string;
+  last_status_code?: number | null;
+  last_error?: string | null;
+  delivered_at?: string | null;
+  created_at: string;
+}
+
+export interface CreateWebhookInput {
+  url: string;
+  event_types: string[];
+}
+
+export interface PatchWebhookInput {
+  url?: string;
+  event_types?: string[];
+  enabled?: boolean;
+}
+
+/**
+ * Returned only from createWebhook. `secret` is the one and only time the
+ * signing secret ever appears on the wire — the backend never returns it
+ * from any other endpoint (list, get-via-patch, etc). Do not persist it
+ * anywhere beyond the one-time reveal in the UI, and never log it.
+ */
+export interface CreateWebhookResult {
+  subscription: WebhookSubscription;
+  secret: string;
+}
+
+export interface TestSendResult {
+  status_code: number;
+  success: boolean;
+  error?: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers — same patterns as marketplace-api.ts / coupons-api.ts
+// ─────────────────────────────────────────────────────────────────────────
+
+interface ApiError {
+  error: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+function commonHeaders(session: SessionHeaders): HeadersInit {
+  const headers: Record<string, string> = {
+    "X-User-Id": session.userId,
+    "X-Tenant-Id": session.tenantId,
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  };
+  if (MARKETPLACE_INTERNAL_AUTH) {
+    headers["X-Internal-Auth"] = MARKETPLACE_INTERNAL_AUTH;
+  }
+  return headers;
+}
+
+function readHeaders(session: SessionHeaders): HeadersInit {
+  const headers: Record<string, string> = {
+    "X-User-Id": session.userId,
+    "X-Tenant-Id": session.tenantId,
+    Accept: "application/json",
+  };
+  if (MARKETPLACE_INTERNAL_AUTH) {
+    headers["X-Internal-Auth"] = MARKETPLACE_INTERNAL_AUTH;
+  }
+  return headers;
+}
+
+async function parseMutationError(res: Response): Promise<MutationError> {
+  const body = (await res.json().catch(() => null)) as ApiError | null;
+  return {
+    code: body?.error ?? "unknown_error",
+    message: body?.message ?? `marketplace-api returned ${res.status}`,
+    field:
+      typeof body?.details?.field === "string"
+        ? (body.details.field as string)
+        : undefined,
+    details: body?.details,
+  };
+}
+
+function webhooksUrl(storeId: string, path = ""): string {
+  return `${MARKETPLACE_API_URL}/api/v1/admin/stores/${storeId}/webhooks${path}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Subscriptions
+// ─────────────────────────────────────────────────────────────────────────
+
+export async function listWebhooks(
+  storeId: string,
+  session: SessionHeaders,
+): Promise<WebhookSubscription[]> {
+  const res = await fetch(webhooksUrl(storeId), {
+    cache: "no-store",
+    headers: readHeaders(session),
+  });
+  if (res.status === 401 || res.status === 403 || res.status === 404) {
+    return [];
+  }
+  if (!res.ok) {
+    throw new Error(`marketplace-api: listWebhooks ${res.status}`);
+  }
+  const body = (await res.json()) as { data: WebhookSubscription[] };
+  return body.data ?? [];
+}
+
+export async function createWebhook(
+  storeId: string,
+  input: CreateWebhookInput,
+  session: SessionHeaders,
+): Promise<MutationResult<CreateWebhookResult>> {
+  const res = await fetch(webhooksUrl(storeId), {
+    method: "POST",
+    cache: "no-store",
+    headers: commonHeaders(session),
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    return { ok: false, error: await parseMutationError(res) };
+  }
+  const body = (await res.json()) as { data: WebhookSubscription; secret: string };
+  return { ok: true, data: { subscription: body.data, secret: body.secret } };
+}
+
+export async function patchWebhook(
+  storeId: string,
+  webhookId: string,
+  input: PatchWebhookInput,
+  session: SessionHeaders,
+): Promise<MutationResult<WebhookSubscription>> {
+  const res = await fetch(webhooksUrl(storeId, `/${webhookId}`), {
+    method: "PATCH",
+    cache: "no-store",
+    headers: commonHeaders(session),
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    return { ok: false, error: await parseMutationError(res) };
+  }
+  const body = (await res.json()) as { data: WebhookSubscription };
+  return { ok: true, data: body.data };
+}
+
+export async function deleteWebhook(
+  storeId: string,
+  webhookId: string,
+  session: SessionHeaders,
+): Promise<MutationResult<true>> {
+  const res = await fetch(webhooksUrl(storeId, `/${webhookId}`), {
+    method: "DELETE",
+    cache: "no-store",
+    headers: readHeaders(session),
+  });
+  if (res.status === 204 || res.ok) {
+    return { ok: true, data: true };
+  }
+  return { ok: false, error: await parseMutationError(res) };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Test send
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Sends a synthetic `webhook.test` delivery and reports what came back.
+ * The endpoint always answers 200 — success/failure of the actual delivery
+ * lives in the response body, including the merchant's own status code, so
+ * a 403 from their endpoint surfaces as `{ status_code: 403, success:
+ * false }`, not as a thrown error.
+ */
+export async function testSendWebhook(
+  storeId: string,
+  webhookId: string,
+  session: SessionHeaders,
+): Promise<MutationResult<TestSendResult>> {
+  const res = await fetch(webhooksUrl(storeId, `/${webhookId}/test`), {
+    method: "POST",
+    cache: "no-store",
+    headers: commonHeaders(session),
+  });
+  if (!res.ok) {
+    return { ok: false, error: await parseMutationError(res) };
+  }
+  const body = (await res.json()) as { data: TestSendResult };
+  return { ok: true, data: body.data };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Deliveries
+// ─────────────────────────────────────────────────────────────────────────
+
+export async function listDeliveries(
+  storeId: string,
+  webhookId: string,
+  session: SessionHeaders,
+): Promise<WebhookDelivery[]> {
+  const res = await fetch(webhooksUrl(storeId, `/${webhookId}/deliveries`), {
+    cache: "no-store",
+    headers: readHeaders(session),
+  });
+  if (res.status === 401 || res.status === 403 || res.status === 404) {
+    return [];
+  }
+  if (!res.ok) {
+    throw new Error(`marketplace-api: listDeliveries ${res.status}`);
+  }
+  const body = (await res.json()) as { data: WebhookDelivery[] };
+  return body.data ?? [];
+}
+
+export async function replayDelivery(
+  storeId: string,
+  webhookId: string,
+  deliveryId: string,
+  session: SessionHeaders,
+): Promise<MutationResult<true>> {
+  const res = await fetch(
+    webhooksUrl(storeId, `/${webhookId}/deliveries/${deliveryId}/replay`),
+    {
+      method: "POST",
+      cache: "no-store",
+      headers: commonHeaders(session),
+    },
+  );
+  if (res.ok) {
+    return { ok: true, data: true };
+  }
+  return { ok: false, error: await parseMutationError(res) };
+}

--- a/apps/admin/tests/unit/components/settings/WebhooksSettingsClient.test.tsx
+++ b/apps/admin/tests/unit/components/settings/WebhooksSettingsClient.test.tsx
@@ -1,0 +1,255 @@
+/**
+ * WebhooksSettingsClient unit tests — Vitest + Testing Library.
+ *
+ * Covers the requirements from #562 task 9 that are easy to silently
+ * regress:
+ *   1. The secret is shown once after creation, with a copy control and
+ *      an explicit warning that it will not be shown again.
+ *   2. A disabled subscription renders its disabled_reason prominently,
+ *      without having to open a delivery.
+ *   3. The delivery list shows status + response code, and offers replay
+ *      only on failed deliveries.
+ *   4. Test-send reports the status code it got back, including failure.
+ *   5. API validation errors (SSRF messages) surface readably, wired via
+ *      aria-describedby.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { WebhookSubscription, WebhookDelivery } from "@/lib/api/webhooks";
+
+const createWebhookAction = vi.fn();
+const patchWebhookAction = vi.fn();
+const deleteWebhookAction = vi.fn();
+const testSendWebhookAction = vi.fn();
+const listDeliveriesAction = vi.fn();
+const replayDeliveryAction = vi.fn();
+const refresh = vi.fn();
+
+vi.mock("@/app/(admin)/settings/webhooks/actions", () => ({
+  createWebhookAction: (...args: unknown[]) => createWebhookAction(...args),
+  patchWebhookAction: (...args: unknown[]) => patchWebhookAction(...args),
+  deleteWebhookAction: (...args: unknown[]) => deleteWebhookAction(...args),
+  testSendWebhookAction: (...args: unknown[]) => testSendWebhookAction(...args),
+  listDeliveriesAction: (...args: unknown[]) => listDeliveriesAction(...args),
+  replayDeliveryAction: (...args: unknown[]) => replayDeliveryAction(...args),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+import { WebhooksSettingsClient } from "@/components/settings/WebhooksSettingsClient";
+
+function webhook(overrides: Partial<WebhookSubscription> = {}): WebhookSubscription {
+  return {
+    id: "wh-1",
+    url: "https://example.com/webhooks/mark8ly",
+    event_types: ["order.placed"],
+    enabled: true,
+    disabled_reason: null,
+    disabled_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function delivery(overrides: Partial<WebhookDelivery> = {}): WebhookDelivery {
+  return {
+    id: "del-1",
+    event_type: "order.placed",
+    aggregate_id: "order-1",
+    status: "delivered",
+    attempts: 1,
+    next_attempt_at: "2026-01-01T00:00:00Z",
+    last_status_code: 200,
+    last_error: null,
+    delivered_at: "2026-01-01T00:00:05Z",
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// jsdom has neither ResizeObserver (Radix's Checkbox/Switch use it to size
+// themselves) nor a writable navigator.clipboard — polyfill both so the
+// component tree the real app renders can mount here too.
+class FakeResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+});
+
+// Defining navigator.clipboard must happen AFTER userEvent.setup() runs —
+// user-event installs its own clipboard stub for copy/paste emulation the
+// first time setup() is called, which would otherwise clobber ours.
+function stubClipboard() {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+}
+
+describe("WebhooksSettingsClient — secret reveal", () => {
+  it("shows the secret exactly once after creation, with a copy control and a permanent warning", async () => {
+    const user = userEvent.setup();
+    stubClipboard();
+    createWebhookAction.mockResolvedValue({
+      ok: true,
+      data: {
+        subscription: webhook(),
+        secret: "whsec_only_shown_once",
+      },
+    });
+
+    render(<WebhooksSettingsClient webhooks={[]} editable />);
+
+    await user.click(screen.getByRole("button", { name: "Add webhook" }));
+    await user.type(screen.getByLabelText("Endpoint URL"), "https://example.com/hook");
+    await user.click(screen.getByRole("checkbox", { name: "Order placed" }));
+    await user.click(screen.getByRole("button", { name: "Create webhook" }));
+
+    // The secret itself is shown, plainly, in the dialog.
+    expect(await screen.findByText("whsec_only_shown_once")).toBeInTheDocument();
+    // A copy control exists.
+    const copyButton = screen.getByRole("button", { name: /copy/i });
+
+    // The unmissable warning it will never be shown again.
+    expect(
+      screen.getByText(/only time mark8ly will show you this secret/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/delete this webhook and create another/i),
+    ).toBeInTheDocument();
+
+    // The Done button is gated on acknowledging the secret was copied —
+    // dismissing without acknowledging is not allowed, since the only
+    // recovery afterwards is delete + recreate.
+    const doneButton = screen.getByRole("button", { name: "Done" });
+    expect(doneButton).toBeDisabled();
+
+    await user.click(copyButton);
+    await waitFor(() => expect(copyButton).toHaveTextContent("Copied"));
+    expect(writeText).toHaveBeenCalledWith("whsec_only_shown_once");
+
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: /i have copied and saved this secret/i,
+      }),
+    );
+    expect(doneButton).toBeEnabled();
+
+    await user.click(doneButton);
+    await waitFor(() =>
+      expect(screen.queryByText("whsec_only_shown_once")).not.toBeInTheDocument(),
+    );
+  });
+});
+
+describe("WebhooksSettingsClient — disabled subscriptions", () => {
+  it("renders disabled_reason prominently without opening a delivery", () => {
+    render(
+      <WebhooksSettingsClient
+        webhooks={[
+          webhook({
+            enabled: false,
+            disabled_reason:
+              "disabled automatically after 10 consecutive delivery failures — fix the endpoint and re-enable",
+          }),
+        ]}
+        editable
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        /disabled automatically after 10 consecutive delivery failures/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show a disabled reason banner for an enabled subscription", () => {
+    render(<WebhooksSettingsClient webhooks={[webhook({ enabled: true })]} editable />);
+    expect(screen.queryByText(/disabled/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("WebhooksSettingsClient — deliveries", () => {
+  it("shows status and response code, and offers replay only on failed deliveries", async () => {
+    const user = userEvent.setup();
+    listDeliveriesAction.mockResolvedValue({
+      ok: true,
+      data: [
+        delivery({ id: "d-delivered", status: "delivered", last_status_code: 200 }),
+        delivery({ id: "d-failed", status: "failed", last_status_code: 500 }),
+        delivery({ id: "d-pending", status: "pending", last_status_code: null }),
+      ],
+    });
+
+    render(<WebhooksSettingsClient webhooks={[webhook()]} editable />);
+    await user.click(screen.getByRole("button", { name: /deliveries/i }));
+
+    const delivered = (await screen.findByText("delivered")).closest("li") as HTMLElement;
+    expect(within(delivered).getByText(/200/)).toBeInTheDocument();
+    expect(within(delivered).queryByRole("button", { name: "Replay" })).not.toBeInTheDocument();
+
+    const failed = screen.getByText("failed").closest("li") as HTMLElement;
+    expect(within(failed).getByText(/500/)).toBeInTheDocument();
+    expect(within(failed).getByRole("button", { name: "Replay" })).toBeInTheDocument();
+
+    const pending = screen.getByText("pending").closest("li") as HTMLElement;
+    expect(within(pending).queryByRole("button", { name: "Replay" })).not.toBeInTheDocument();
+  });
+
+  it("test-send reports the status code it got back, including on failure", async () => {
+    const user = userEvent.setup();
+    listDeliveriesAction.mockResolvedValue({ ok: true, data: [] });
+    testSendWebhookAction.mockResolvedValue({
+      ok: true,
+      data: { status_code: 403, success: false, error: "endpoint returned 403" },
+    });
+
+    render(<WebhooksSettingsClient webhooks={[webhook()]} editable />);
+    await user.click(screen.getByRole("button", { name: /deliveries/i }));
+    await user.click(await screen.findByRole("button", { name: /send test event/i }));
+
+    const status = await screen.findByRole("status");
+    expect(status).toHaveTextContent("403");
+  });
+});
+
+describe("WebhooksSettingsClient — form validation errors", () => {
+  it("surfaces API validation errors readably, wired with aria-describedby", async () => {
+    const user = userEvent.setup();
+    stubClipboard();
+    createWebhookAction.mockResolvedValue({
+      ok: false,
+      code: "validation_failed",
+      message: "webhook url resolves to a private or otherwise non-public address",
+      field: "url",
+    });
+
+    render(<WebhooksSettingsClient webhooks={[]} editable />);
+
+    await user.click(screen.getByRole("button", { name: "Add webhook" }));
+    const urlInput = screen.getByLabelText("Endpoint URL");
+    await user.type(urlInput, "https://10.0.0.5/hook");
+    await user.click(screen.getByRole("checkbox", { name: "Order placed" }));
+    await user.click(screen.getByRole("button", { name: "Create webhook" }));
+
+    const errorText = await screen.findByText(
+      /resolves to a private or otherwise non-public address/i,
+    );
+    expect(errorText).toHaveAttribute("id", urlInput.getAttribute("aria-describedby"));
+    expect(urlInput).toHaveAttribute("aria-invalid", "true");
+  });
+});

--- a/apps/onboarding/tests/unit/pricing-surfaces-truth.spec.ts
+++ b/apps/onboarding/tests/unit/pricing-surfaces-truth.spec.ts
@@ -113,7 +113,23 @@ test("no pricing surface advertises a limit or capability the service lacks", ()
   }
 });
 
-test("no pricing surface still sells webhooks or custom code injection (#544)", () => {
+/**
+ * #544 originally caught both "webhooks" and "code injection" as sold
+ * claims with nothing behind them. Outbound webhooks shipped in #562, so
+ * that half of the guard is gone — see the webhook assertion's history in
+ * git blame if you're looking for it.
+ *
+ * Custom code injection stays covered here on its own, and deliberately:
+ * it isn't merely unbuilt (the way webhooks briefly were), it's excluded by
+ * design. Arbitrary merchant-authored `<script>` in a storefront is XSS
+ * against that storefront's customers, and shipping it would permanently
+ * weaken the storefront CSP. Nothing schedules it, so this assertion isn't
+ * stale — it is guarding against reintroducing a claim the product should
+ * never make. If webhooks copy is ever touched again, remember it is not a
+ * tier differentiator (available on every plan), so it does not belong as
+ * a Studio-only bullet even though this guard no longer blocks it.
+ */
+test("no pricing surface still sells custom code injection (#544)", () => {
   const surfaces: ReadonlyArray<[string, string]> = [
     ["onboarding Pricing.tsx", copyOnly(read("apps/onboarding/components/marketing/Pricing.tsx"))],
     ["admin lib/copy/pricing.ts", copyOnly(read("apps/admin/lib/copy/pricing.ts"))],
@@ -121,13 +137,15 @@ test("no pricing surface still sells webhooks or custom code injection (#544)", 
   ];
 
   for (const [name, src] of surfaces) {
-    for (const claim of [/webhook/i, /code injection/i]) {
+    for (const claim of [/code injection/i]) {
       expect(
         src,
-        `${name} still advertises ${claim.source}. Neither exists server-side: ` +
-          `no column stores a merchant callback URL, and FeatureCustomCodeInjection ` +
-          `is a forward-compat hedge no handler reads (#544). Outbound webhooks are ` +
-          `tracked in #562 — restore the copy when they ship, not before.`,
+        `${name} still advertises ${claim.source}. FeatureCustomCodeInjection is a ` +
+          `forward-compat hedge no handler reads (#544), and it is excluded by design, ` +
+          `not merely unbuilt: arbitrary merchant <script> in a storefront is XSS ` +
+          `against that storefront's customers and would permanently weaken the ` +
+          `storefront CSP. Unlike webhooks (#562, shipped), there is no ticket to ` +
+          `restore this copy — it should not come back.`,
       ).not.toMatch(claim);
     }
   }

--- a/docs/superpowers/plans/2026-09-02-outbound-webhooks.md
+++ b/docs/superpowers/plans/2026-09-02-outbound-webhooks.md
@@ -1,0 +1,2017 @@
+# Outbound Webhooks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a merchant register an HTTPS endpoint and receive signed, retried notifications when order, return, product and category events happen in their store.
+
+**Architecture:** Two in-process loops beside the existing `outbox.Publisher`. A dispatcher reads `outbox_events` against its own cursor and fans each event out into one `webhook_deliveries` row per matching subscription. A delivery worker drains that table with `FOR UPDATE SKIP LOCKED`, POSTs to the merchant, and records the outcome. The existing outbox publisher is not touched.
+
+**Tech Stack:** Go 1.26, Gin, GORM, PostgreSQL 15, golang-migrate, testify. Admin UI is Next.js 16 / React 19 with `@tesserix/web` primitives.
+
+**Spec:** `docs/superpowers/specs/2026-09-02-outbound-webhooks-design.md`
+
+## Global Constraints
+
+- **Migration number:** the next free is `000126`. Re-check `services/marketplace-api/migrations/` before writing — another PR may land first.
+- **`ExpectedSchemaVersion`** in `services/marketplace-api/migrations.go` is currently `125` and must be bumped to match the migration you add.
+- **Payloads are notify-and-fetch.** The delivery body carries event name, aggregate id, and timestamp. Never the entity. Never customer PII.
+- **Delivery retention is 30 days on every plan** — deliberately NOT tied to `FeatureAuditRetentionDays`.
+- **Available on every plan.** Do not add a `plangate` check for the webhook feature itself.
+- **Never log a webhook URL's response body, the signing secret, or a subscriber email.**
+- **Integration tests need `TEST_DATABASE_URL` and skip silently without it**, still printing `ok`. Always confirm tests actually ran.
+- **Run the FULL integration suite before opening a PR**, not just touched packages: `go test -tags=integration -p 1 ./...`. `-p 1` matters — parallel packages exhaust the connection limit. The last two features here each tripped a guard in an untouched package that a narrow run missed.
+- **Use a throwaway database**, never the shared one: `docker run -d --name m8-wh -e POSTGRES_PASSWORD=test -e POSTGRES_DB=marketplace_test -p 55440:5432 postgres:15`
+
+## Prerequisite, not part of this plan
+
+Spec decision 5 — widening the read-only API to Starter — is a **plan-entitlement change** and needs its own issue. Notify-and-fetch is incoherent for Starter merchants without it. This plan can be built and merged first; it must not be *announced* to merchants until that lands.
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `internal/webhook/ssrfguard/guard.go` | Resolve a URL and reject non-public destinations. No DB, no HTTP. |
+| `internal/webhook/models.go` | `Subscription`, `Delivery` GORM models + status constants |
+| `internal/webhook/subscription_repo.go` | Subscription CRUD, failure counter, auto-disable |
+| `internal/webhook/delivery_repo.go` | Fan-out insert, claim-batch, outcome recording, prune |
+| `internal/webhook/cursor.go` | Dispatcher's own watermark over `outbox_events` |
+| `internal/webhook/signing.go` | HMAC signature over timestamp + body |
+| `internal/webhook/sender.go` | One HTTP attempt, guard applied immediately before dial |
+| `internal/webhook/dispatcher.go` | outbox → deliveries fan-out loop |
+| `internal/webhook/worker.go` | deliveries → merchant endpoint loop, backoff, auto-disable |
+| `internal/handlers/admin/webhooks.go` | Admin CRUD + test-send + delivery log + replay |
+| `apps/admin/app/(dashboard)/settings/webhooks/` | Admin UI |
+
+---
+
+### Task 1: SSRF guard
+
+The security-critical unit, built first and standalone so it can be tested without a database or a network.
+
+**Files:**
+- Create: `services/marketplace-api/internal/webhook/ssrfguard/guard.go`
+- Test: `services/marketplace-api/internal/webhook/ssrfguard/guard_test.go`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces:
+  - `type Resolver func(host string) ([]net.IP, error)`
+  - `type Guard struct{ resolve Resolver }`
+  - `func New(r Resolver) *Guard` — pass `nil` for `net.LookupIP`
+  - `func (g *Guard) Check(raw string) (*url.URL, error)` — parses, enforces https, resolves, rejects non-public IPs
+  - `var ErrNotHTTPS, ErrPrivateAddress, ErrUnresolvable error`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package ssrfguard
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func fixed(ips ...string) Resolver {
+	return func(string) ([]net.IP, error) {
+		out := make([]net.IP, 0, len(ips))
+		for _, s := range ips {
+			out = append(out, net.ParseIP(s))
+		}
+		return out, nil
+	}
+}
+
+func TestCheck_AllowsPublicHTTPS(t *testing.T) {
+	g := New(fixed("93.184.216.34"))
+	u, err := g.Check("https://hooks.example.com/mark8ly")
+	if err != nil {
+		t.Fatalf("expected public https URL to pass, got %v", err)
+	}
+	if u.Host != "hooks.example.com" {
+		t.Fatalf("host = %q", u.Host)
+	}
+}
+
+func TestCheck_RejectsPlainHTTP(t *testing.T) {
+	g := New(fixed("93.184.216.34"))
+	if _, err := g.Check("http://hooks.example.com/x"); err != ErrNotHTTPS {
+		t.Fatalf("want ErrNotHTTPS, got %v", err)
+	}
+}
+
+// Each of these is a documented SSRF target. A merchant-supplied URL that
+// resolves to any of them must never be dialled.
+func TestCheck_RejectsNonPublicDestinations(t *testing.T) {
+	for name, ip := range map[string]string{
+		"loopback":         "127.0.0.1",
+		"private 10/8":     "10.0.0.5",
+		"private 172.16/12": "172.16.0.5",
+		"private 192.168":  "192.168.1.5",
+		"link-local":       "169.254.1.1",
+		"GCP metadata":     "169.254.169.254",
+		"IPv6 loopback":    "::1",
+		"IPv6 ULA":         "fd00::1",
+		"unspecified":      "0.0.0.0",
+	} {
+		t.Run(name, func(t *testing.T) {
+			g := New(fixed(ip))
+			if _, err := g.Check("https://evil.example.com/x"); err != ErrPrivateAddress {
+				t.Fatalf("want ErrPrivateAddress for %s, got %v", ip, err)
+			}
+		})
+	}
+}
+
+// A hostname that resolves to a mix must be rejected — an attacker only
+// needs one private answer to be picked at dial time.
+func TestCheck_RejectsWhenAnyResolvedAddressIsPrivate(t *testing.T) {
+	g := New(fixed("93.184.216.34", "127.0.0.1"))
+	if _, err := g.Check("https://mixed.example.com/x"); err != ErrPrivateAddress {
+		t.Fatalf("want ErrPrivateAddress, got %v", err)
+	}
+}
+
+func TestCheck_RejectsUnresolvable(t *testing.T) {
+	g := New(func(string) ([]net.IP, error) { return nil, net.UnknownNetworkError("nope") })
+	if _, err := g.Check("https://nx.example.com/x"); err != ErrUnresolvable {
+		t.Fatalf("want ErrUnresolvable, got %v", err)
+	}
+}
+
+func TestCheck_RejectsGarbage(t *testing.T) {
+	g := New(fixed("93.184.216.34"))
+	for _, raw := range []string{"", "not a url", "https://", "ftp://x.example.com"} {
+		if _, err := g.Check(raw); err == nil {
+			t.Fatalf("expected %q to be rejected", raw)
+		}
+	}
+}
+
+func TestCheck_RejectsOverlongURL(t *testing.T) {
+	g := New(fixed("93.184.216.34"))
+	long := "https://hooks.example.com/" + strings.Repeat("a", 3000)
+	if _, err := g.Check(long); err == nil {
+		t.Fatal("expected an overlong URL to be rejected")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+Run: `cd services/marketplace-api && go test ./internal/webhook/ssrfguard/...`
+Expected: FAIL — package does not compile, `New` undefined.
+
+- [ ] **Step 3: Implement the guard**
+
+```go
+// Package ssrfguard decides whether a merchant-supplied URL is safe for the
+// cluster to dial.
+//
+// Webhooks are the first feature where merchant input becomes an egress
+// target: every other outbound integration here (payment gateways, carriers,
+// email providers) talks to fixed, configured endpoints. A merchant who can
+// make us POST to an arbitrary URL can otherwise reach the GCP metadata
+// server or any in-cluster service and read the response back out of the
+// delivery log.
+//
+// Check is called at registration AND again immediately before every
+// delivery. Registration-only validation is the usual shortcut and it is
+// defeated by DNS rebinding — a hostname that answers public when saved and
+// private when dialled.
+package ssrfguard
+
+import (
+	"errors"
+	"net"
+	"net/url"
+)
+
+var (
+	ErrNotHTTPS       = errors.New("webhook url must use https")
+	ErrPrivateAddress = errors.New("webhook url resolves to a non-public address")
+	ErrUnresolvable   = errors.New("webhook url host could not be resolved")
+	ErrMalformed      = errors.New("webhook url is malformed")
+	ErrTooLong        = errors.New("webhook url is too long")
+)
+
+// maxURLLen bounds what we will store and log.
+const maxURLLen = 2048
+
+// Resolver looks a hostname up. Injected so tests need no DNS.
+type Resolver func(host string) ([]net.IP, error)
+
+type Guard struct{ resolve Resolver }
+
+// New builds a Guard. Pass nil to use real DNS.
+func New(r Resolver) *Guard {
+	if r == nil {
+		r = net.LookupIP
+	}
+	return &Guard{resolve: r}
+}
+
+// Check parses raw, requires https, resolves the host, and rejects the URL
+// if ANY resolved address is non-public — an attacker needs only one private
+// answer to be selected at dial time.
+func (g *Guard) Check(raw string) (*url.URL, error) {
+	if raw == "" {
+		return nil, ErrMalformed
+	}
+	if len(raw) > maxURLLen {
+		return nil, ErrTooLong
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, ErrMalformed
+	}
+	if u.Scheme != "https" {
+		return nil, ErrNotHTTPS
+	}
+	if u.Hostname() == "" {
+		return nil, ErrMalformed
+	}
+
+	ips, err := g.resolve(u.Hostname())
+	if err != nil || len(ips) == 0 {
+		return nil, ErrUnresolvable
+	}
+	for _, ip := range ips {
+		if !isPublic(ip) {
+			return nil, ErrPrivateAddress
+		}
+	}
+	return u, nil
+}
+
+// isPublic reports whether ip is globally routable. Everything else —
+// loopback, private, link-local (which covers 169.254.169.254, the cloud
+// metadata endpoint), multicast, unspecified — is refused.
+func isPublic(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() || ip.IsMulticast() {
+		return false
+	}
+	return true
+}
+```
+
+- [ ] **Step 4: Run the tests and watch them pass**
+
+Run: `cd services/marketplace-api && go test ./internal/webhook/ssrfguard/... -v`
+Expected: PASS, all cases including every entry in the non-public table.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/marketplace-api/internal/webhook/ssrfguard/
+git commit -m "feat(webhooks): SSRF guard rejecting non-public webhook destinations"
+```
+
+---
+
+### Task 2: Schema, models, subscription repository
+
+**Files:**
+- Create: `services/marketplace-api/migrations/000126_webhook_subscriptions.up.sql` / `.down.sql`
+- Create: `services/marketplace-api/internal/webhook/models.go`
+- Create: `services/marketplace-api/internal/webhook/subscription_repo.go`
+- Modify: `services/marketplace-api/migrations.go` (`ExpectedSchemaVersion` 125 → 126)
+- Test: `services/marketplace-api/internal/webhook/subscription_repo_integration_test.go`
+
+**Interfaces:**
+- Consumes: Task 1's `ssrfguard` (validation happens in the handler, not the repo)
+- Produces:
+  - `webhook.Subscription` with fields `ID, TenantID, StoreID uuid.UUID`, `URL string`, `EventTypes pq.StringArray`, `Secret string`, `Enabled bool`, `DisabledReason *string`, `DisabledAt *time.Time`, `ConsecutiveFailures int`, `CreatedAt, UpdatedAt time.Time`
+  - `webhook.Delivery` (table created here, used from Task 3)
+  - `func NewSubscriptionRepo(db *gorm.DB) *SubscriptionRepo`
+  - `(*SubscriptionRepo) Create(ctx, *Subscription) error`
+  - `(*SubscriptionRepo) ListForStore(ctx, tenantID, storeID uuid.UUID) ([]Subscription, error)`
+  - `(*SubscriptionRepo) MatchingEvent(ctx, tenantID uuid.UUID, eventType string) ([]Subscription, error)` — enabled only
+  - `(*SubscriptionRepo) RecordFailure(ctx, id uuid.UUID, threshold int) (disabled bool, err error)`
+  - `(*SubscriptionRepo) RecordSuccess(ctx, id uuid.UUID) error`
+  - `const MaxEventTypes = 32`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Migration 126: outbound webhooks (#562).
+--
+-- Consumes the existing transactional outbox rather than instrumenting new
+-- events: outbox_events already carries 18 domain events written in the same
+-- transaction as the mutation that produced them.
+--
+-- Two tables, deliberately separate from outbox_events. A merchant's dead
+-- endpoint must never stall the outbox watermark publisher, whose recovery
+-- semantics are documented in internal/outbox/models.go (#336).
+CREATE TABLE IF NOT EXISTS webhook_subscriptions (
+    id                   UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id            UUID         NOT NULL,
+    store_id             UUID         NOT NULL,
+    url                  VARCHAR(2048) NOT NULL,
+    -- Event types this subscription wants, e.g. {order.placed,order.refunded}.
+    -- Values come from internal/outbox's Event* constants.
+    event_types          TEXT[]       NOT NULL,
+    -- HMAC signing secret. Shown to the merchant once at creation.
+    secret               VARCHAR(128) NOT NULL,
+    enabled              BOOLEAN      NOT NULL DEFAULT true,
+    -- Set when the platform auto-disables after sustained failure, so the
+    -- merchant is told WHY rather than finding a silently dead webhook.
+    disabled_reason      TEXT,
+    disabled_at          TIMESTAMPTZ,
+    consecutive_failures INTEGER      NOT NULL DEFAULT 0,
+    created_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+-- The dispatcher's hot path: "enabled subscriptions for this tenant".
+CREATE INDEX IF NOT EXISTS idx_webhook_subs_tenant_enabled
+    ON webhook_subscriptions (tenant_id) WHERE enabled;
+
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+    id                UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    subscription_id   UUID         NOT NULL REFERENCES webhook_subscriptions(id) ON DELETE CASCADE,
+    outbox_event_id   UUID         NOT NULL,
+    event_type        VARCHAR(64)  NOT NULL,
+    aggregate_id      UUID         NOT NULL,
+    status            VARCHAR(16)  NOT NULL DEFAULT 'pending',
+    attempts          INTEGER      NOT NULL DEFAULT 0,
+    next_attempt_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    last_status_code  INTEGER,
+    -- Truncated by the worker before insert. Surfaced to the merchant so a
+    -- failing endpoint is debuggable; never logged server-side.
+    last_error        TEXT,
+    delivered_at      TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+-- This is what makes fan-out idempotent. The dispatcher inserts with
+-- ON CONFLICT DO NOTHING against it, so re-running over the same outbox
+-- rows cannot double-deliver — which is how we get exactly-once fan-out
+-- without coupling to the outbox publisher's transaction.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webhook_deliveries_event_sub
+    ON webhook_deliveries (outbox_event_id, subscription_id);
+
+-- The worker's claim query.
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_due
+    ON webhook_deliveries (next_attempt_at) WHERE status = 'pending';
+
+-- Prune scan (30-day retention on every plan, see the design doc).
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_created
+    ON webhook_deliveries (created_at);
+
+-- The dispatcher's own cursor over outbox_events. Deliberately NOT the
+-- publisher's watermark: the two consumers advance independently, so a
+-- stalled webhook dispatch cannot hold back outbox publishing.
+CREATE TABLE IF NOT EXISTS webhook_dispatch_cursor (
+    id                  BOOLEAN     PRIMARY KEY DEFAULT true CHECK (id),
+    last_event_created  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_event_id       UUID
+);
+INSERT INTO webhook_dispatch_cursor (id) VALUES (true) ON CONFLICT DO NOTHING;
+```
+
+Down migration:
+
+```sql
+DROP TABLE IF EXISTS webhook_dispatch_cursor;
+DROP TABLE IF EXISTS webhook_deliveries;
+DROP TABLE IF EXISTS webhook_subscriptions;
+```
+
+- [ ] **Step 2: Write the failing integration test**
+
+```go
+//go:build integration
+
+package webhook_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/webhook"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+func newSub(t *testing.T, repo *webhook.SubscriptionRepo, tenant uuid.UUID, events []string) *webhook.Subscription {
+	t.Helper()
+	s := &webhook.Subscription{
+		TenantID:   tenant,
+		StoreID:    uuid.New(),
+		URL:        "https://hooks.example.com/x",
+		EventTypes: events,
+		Secret:     "s3cret-value-for-test",
+		Enabled:    true,
+	}
+	require.NoError(t, repo.Create(context.Background(), s))
+	return s
+}
+
+func TestMatchingEvent_ReturnsOnlyEnabledSubscriptionsWantingThatType(t *testing.T) {
+	db := testdb.NewDB(t)
+	repo := webhook.NewSubscriptionRepo(db)
+	tenant := uuid.New()
+	ctx := context.Background()
+
+	want := newSub(t, repo, tenant, []string{"order.placed", "order.refunded"})
+	newSub(t, repo, tenant, []string{"product.created"})           // wrong type
+	newSub(t, repo, uuid.New(), []string{"order.placed"})          // wrong tenant
+	disabled := newSub(t, repo, tenant, []string{"order.placed"})
+	_, err := repo.RecordFailure(ctx, disabled.ID, 1)              // threshold 1 → disabled
+	require.NoError(t, err)
+
+	got, err := repo.MatchingEvent(ctx, tenant, "order.placed")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, want.ID, got[0].ID)
+}
+
+func TestRecordFailure_DisablesAtThresholdAndRecordsWhy(t *testing.T) {
+	db := testdb.NewDB(t)
+	repo := webhook.NewSubscriptionRepo(db)
+	ctx := context.Background()
+	s := newSub(t, repo, uuid.New(), []string{"order.placed"})
+
+	disabled, err := repo.RecordFailure(ctx, s.ID, 3)
+	require.NoError(t, err)
+	require.False(t, disabled, "one failure must not disable a subscription")
+
+	_, err = repo.RecordFailure(ctx, s.ID, 3)
+	require.NoError(t, err)
+	disabled, err = repo.RecordFailure(ctx, s.ID, 3)
+	require.NoError(t, err)
+	require.True(t, disabled, "third consecutive failure should disable")
+
+	all, err := repo.ListForStore(ctx, s.TenantID, s.StoreID)
+	require.NoError(t, err)
+	require.False(t, all[0].Enabled)
+	require.NotNil(t, all[0].DisabledReason, "merchant must be told why")
+	require.NotNil(t, all[0].DisabledAt)
+}
+
+// A working delivery after a failure must clear the counter, or an endpoint
+// that fails intermittently over weeks would eventually be disabled despite
+// mostly working.
+func TestRecordSuccess_ResetsTheFailureCounter(t *testing.T) {
+	db := testdb.NewDB(t)
+	repo := webhook.NewSubscriptionRepo(db)
+	ctx := context.Background()
+	s := newSub(t, repo, uuid.New(), []string{"order.placed"})
+
+	_, err := repo.RecordFailure(ctx, s.ID, 3)
+	require.NoError(t, err)
+	require.NoError(t, repo.RecordSuccess(ctx, s.ID))
+
+	// Two more failures must not disable — the counter restarted.
+	_, err = repo.RecordFailure(ctx, s.ID, 3)
+	require.NoError(t, err)
+	disabled, err := repo.RecordFailure(ctx, s.ID, 3)
+	require.NoError(t, err)
+	require.False(t, disabled)
+}
+```
+
+- [ ] **Step 3: Run it and watch it fail**
+
+```bash
+docker run -d --name m8-wh -e POSTGRES_PASSWORD=test -e POSTGRES_DB=marketplace_test -p 55440:5432 postgres:15
+cd services/marketplace-api
+export DSN='postgres://postgres:test@localhost:55440/marketplace_test?sslmode=disable'
+DATABASE_URL="$DSN" go run ./cmd/migrate up
+TEST_DATABASE_URL="$DSN" go test -tags=integration ./internal/webhook/... -run TestMatchingEvent -v
+```
+
+Expected: FAIL — `webhook.NewSubscriptionRepo` undefined.
+
+- [ ] **Step 4: Write models.go**
+
+```go
+// Package webhook implements merchant-facing outbound webhooks (#562).
+//
+// It is a CONSUMER of internal/outbox, not a producer: outbox_events already
+// records every domain event transactionally. See
+// docs/superpowers/specs/2026-09-02-outbound-webhooks-design.md.
+package webhook
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+)
+
+// MaxEventTypes bounds how many event types one subscription may select.
+// There are 18 today; the cap exists so a malformed request cannot store an
+// unbounded array.
+const MaxEventTypes = 32
+
+// Delivery statuses.
+const (
+	StatusPending   = "pending"
+	StatusDelivered = "delivered"
+	StatusFailed    = "failed"
+)
+
+type Subscription struct {
+	ID                  uuid.UUID      `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	TenantID            uuid.UUID      `gorm:"column:tenant_id;type:uuid;not null"                      json:"-"`
+	StoreID             uuid.UUID      `gorm:"column:store_id;type:uuid;not null"                       json:"store_id"`
+	URL                 string         `gorm:"column:url;not null"                                      json:"url"`
+	EventTypes          pq.StringArray `gorm:"column:event_types;type:text[];not null"                   json:"event_types"`
+	// Secret never leaves the server after creation — the handler returns it
+	// once in its own response field and this tag keeps it out of every
+	// subsequent read.
+	Secret              string         `gorm:"column:secret;not null"                                   json:"-"`
+	Enabled             bool           `gorm:"column:enabled;not null;default:true"                     json:"enabled"`
+	DisabledReason      *string        `gorm:"column:disabled_reason"                                   json:"disabled_reason,omitempty"`
+	DisabledAt          *time.Time     `gorm:"column:disabled_at"                                       json:"disabled_at,omitempty"`
+	ConsecutiveFailures int            `gorm:"column:consecutive_failures;not null;default:0"           json:"-"`
+	CreatedAt           time.Time      `gorm:"column:created_at;not null;default:now()"                 json:"created_at"`
+	UpdatedAt           time.Time      `gorm:"column:updated_at;not null;default:now()"                 json:"updated_at"`
+}
+
+func (Subscription) TableName() string { return "webhook_subscriptions" }
+
+type Delivery struct {
+	ID             uuid.UUID  `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	SubscriptionID uuid.UUID  `gorm:"column:subscription_id;type:uuid;not null"                json:"subscription_id"`
+	OutboxEventID  uuid.UUID  `gorm:"column:outbox_event_id;type:uuid;not null"                json:"-"`
+	EventType      string     `gorm:"column:event_type;not null"                               json:"event_type"`
+	AggregateID    uuid.UUID  `gorm:"column:aggregate_id;type:uuid;not null"                   json:"aggregate_id"`
+	Status         string     `gorm:"column:status;not null;default:pending"                   json:"status"`
+	Attempts       int        `gorm:"column:attempts;not null;default:0"                       json:"attempts"`
+	NextAttemptAt  time.Time  `gorm:"column:next_attempt_at;not null;default:now()"            json:"next_attempt_at"`
+	LastStatusCode *int       `gorm:"column:last_status_code"                                  json:"last_status_code,omitempty"`
+	LastError      *string    `gorm:"column:last_error"                                        json:"last_error,omitempty"`
+	DeliveredAt    *time.Time `gorm:"column:delivered_at"                                      json:"delivered_at,omitempty"`
+	CreatedAt      time.Time  `gorm:"column:created_at;not null;default:now()"                 json:"created_at"`
+}
+
+func (Delivery) TableName() string { return "webhook_deliveries" }
+```
+
+- [ ] **Step 5: Write subscription_repo.go**
+
+```go
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type SubscriptionRepo struct{ db *gorm.DB }
+
+func NewSubscriptionRepo(db *gorm.DB) *SubscriptionRepo { return &SubscriptionRepo{db: db} }
+
+func (r *SubscriptionRepo) Create(ctx context.Context, s *Subscription) error {
+	if err := r.db.WithContext(ctx).Create(s).Error; err != nil {
+		return fmt.Errorf("webhook: create subscription: %w", err)
+	}
+	return nil
+}
+
+func (r *SubscriptionRepo) ListForStore(ctx context.Context, tenantID, storeID uuid.UUID) ([]Subscription, error) {
+	var out []Subscription
+	err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND store_id = ?", tenantID, storeID).
+		Order("created_at DESC").Find(&out).Error
+	if err != nil {
+		return nil, fmt.Errorf("webhook: list subscriptions: %w", err)
+	}
+	return out, nil
+}
+
+// MatchingEvent returns the ENABLED subscriptions for tenantID that selected
+// eventType. `event_types @> ARRAY[?]` uses the array containment operator so
+// the match happens in Postgres rather than by loading every subscription.
+func (r *SubscriptionRepo) MatchingEvent(ctx context.Context, tenantID uuid.UUID, eventType string) ([]Subscription, error) {
+	var out []Subscription
+	err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND enabled AND event_types @> ARRAY[?]::text[]", tenantID, eventType).
+		Find(&out).Error
+	if err != nil {
+		return nil, fmt.Errorf("webhook: match subscriptions: %w", err)
+	}
+	return out, nil
+}
+
+// RecordFailure increments the consecutive-failure counter and disables the
+// subscription once it reaches threshold, reporting whether it did.
+//
+// The increment and the disable happen in ONE statement so two delivery
+// workers failing concurrently cannot interleave a read-modify-write and
+// lose a count.
+func (r *SubscriptionRepo) RecordFailure(ctx context.Context, id uuid.UUID, threshold int) (bool, error) {
+	var enabled bool
+	err := r.db.WithContext(ctx).Raw(`
+		UPDATE webhook_subscriptions
+		   SET consecutive_failures = consecutive_failures + 1,
+		       enabled = CASE WHEN consecutive_failures + 1 >= ? THEN false ELSE enabled END,
+		       disabled_reason = CASE WHEN consecutive_failures + 1 >= ?
+		            THEN 'Disabled automatically after ' || (consecutive_failures + 1) ||
+		                 ' consecutive delivery failures. Fix the endpoint and re-enable.'
+		            ELSE disabled_reason END,
+		       disabled_at = CASE WHEN consecutive_failures + 1 >= ? THEN now() ELSE disabled_at END,
+		       updated_at = now()
+		 WHERE id = ?
+		RETURNING enabled`, threshold, threshold, threshold, id).Scan(&enabled).Error
+	if err != nil {
+		return false, fmt.Errorf("webhook: record failure: %w", err)
+	}
+	return !enabled, nil
+}
+
+// RecordSuccess clears the counter. Without this an endpoint that fails
+// occasionally over weeks would eventually be disabled despite working.
+func (r *SubscriptionRepo) RecordSuccess(ctx context.Context, id uuid.UUID) error {
+	err := r.db.WithContext(ctx).Exec(`
+		UPDATE webhook_subscriptions
+		   SET consecutive_failures = 0, updated_at = now()
+		 WHERE id = ? AND consecutive_failures <> 0`, id).Error
+	if err != nil {
+		return fmt.Errorf("webhook: record success: %w", err)
+	}
+	return nil
+}
+
+var _ = time.Now
+```
+
+- [ ] **Step 6: Bump `ExpectedSchemaVersion`**
+
+In `services/marketplace-api/migrations.go`, change `const ExpectedSchemaVersion uint = 125` to `126`.
+
+- [ ] **Step 7: Run the tests and watch them pass**
+
+```bash
+TEST_DATABASE_URL="$DSN" go test -tags=integration ./internal/webhook/... -v
+```
+Expected: PASS — all three tests. Confirm they actually ran; a silent skip also prints `ok`.
+
+- [ ] **Step 8: Verify the down migration**
+
+```bash
+DATABASE_URL="$DSN" go run ./cmd/migrate down 1
+DATABASE_URL="$DSN" go run ./cmd/migrate up
+```
+Expected: both succeed; tables dropped then recreated.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add services/marketplace-api/migrations/000126_* services/marketplace-api/migrations.go services/marketplace-api/internal/webhook/
+git commit -m "feat(webhooks): subscription and delivery schema with auto-disable counter"
+```
+
+---
+
+### Task 3: Signing
+
+Small, pure, and worth its own task because merchants write verification code against it and it cannot change later without breaking them.
+
+**Files:**
+- Create: `services/marketplace-api/internal/webhook/signing.go`
+- Test: `services/marketplace-api/internal/webhook/signing_test.go`
+
+**Interfaces:**
+- Produces:
+  - `func Sign(secret string, ts time.Time, body []byte) string` — returns `"t=<unix>,v1=<hex>"`
+  - `func GenerateSecret() (string, error)` — 32 random bytes, hex
+  - `const SignatureHeader = "X-Mark8ly-Signature"`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package webhook
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSign_IsStableForTheSameInputs(t *testing.T) {
+	ts := time.Unix(1756800000, 0)
+	a := Sign("shh", ts, []byte(`{"event":"order.placed"}`))
+	b := Sign("shh", ts, []byte(`{"event":"order.placed"}`))
+	if a != b {
+		t.Fatalf("signature not deterministic: %q vs %q", a, b)
+	}
+	if !strings.HasPrefix(a, "t=1756800000,v1=") {
+		t.Fatalf("unexpected format: %q", a)
+	}
+}
+
+// The timestamp must be INSIDE the signed material. If it were only a
+// separate header, a captured delivery could be replayed later with a fresh
+// timestamp and still verify.
+func TestSign_ChangesWithTimestamp(t *testing.T) {
+	body := []byte(`{"event":"order.placed"}`)
+	a := Sign("shh", time.Unix(1756800000, 0), body)
+	b := Sign("shh", time.Unix(1756800001, 0), body)
+	if a == b {
+		t.Fatal("signature must cover the timestamp")
+	}
+}
+
+func TestSign_ChangesWithBodyAndSecret(t *testing.T) {
+	ts := time.Unix(1756800000, 0)
+	base := Sign("shh", ts, []byte(`{"a":1}`))
+	if Sign("shh", ts, []byte(`{"a":2}`)) == base {
+		t.Fatal("signature must cover the body")
+	}
+	if Sign("other", ts, []byte(`{"a":1}`)) == base {
+		t.Fatal("signature must depend on the secret")
+	}
+}
+
+func TestGenerateSecret_IsRandomAndLongEnough(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		s, err := GenerateSecret()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(s) != 64 {
+			t.Fatalf("want 64 hex chars, got %d", len(s))
+		}
+		if seen[s] {
+			t.Fatal("duplicate secret generated")
+		}
+		seen[s] = true
+	}
+}
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd services/marketplace-api && go test ./internal/webhook/ -run 'TestSign|TestGenerateSecret' -v`
+Expected: FAIL — `Sign` undefined.
+
+- [ ] **Step 3: Implement**
+
+```go
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// SignatureHeader carries the signature on every delivery.
+const SignatureHeader = "X-Mark8ly-Signature"
+
+// Sign returns "t=<unix>,v1=<hex>" over "<unix>.<body>" using secret.
+//
+// The timestamp is part of the SIGNED material, not merely a sibling header:
+// that is what lets a merchant reject a replayed delivery by checking the
+// timestamp is recent, knowing an attacker cannot rewrite it without
+// invalidating v1. The format mirrors Stripe's so the verification recipe is
+// already familiar to most integrators.
+func Sign(secret string, ts time.Time, body []byte) string {
+	unix := strconv.FormatInt(ts.Unix(), 10)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(unix))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	return fmt.Sprintf("t=%s,v1=%s", unix, hex.EncodeToString(mac.Sum(nil)))
+}
+
+// GenerateSecret returns 32 random bytes hex-encoded. Shown to the merchant
+// once at creation and never returned again.
+func GenerateSecret() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("webhook: generate secret: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+```
+
+- [ ] **Step 4: Run and watch them pass**
+
+Run: `go test ./internal/webhook/ -run 'TestSign|TestGenerateSecret' -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/marketplace-api/internal/webhook/signing.go services/marketplace-api/internal/webhook/signing_test.go
+git commit -m "feat(webhooks): HMAC signing with the timestamp inside the signed material"
+```
+
+---
+
+### Task 4: Fan-out — delivery repository and dispatcher
+
+**Files:**
+- Create: `services/marketplace-api/internal/webhook/delivery_repo.go`
+- Create: `services/marketplace-api/internal/webhook/dispatcher.go`
+- Test: `services/marketplace-api/internal/webhook/dispatcher_integration_test.go`
+
+**Interfaces:**
+- Consumes: `NewSubscriptionRepo`, `Subscription`, `Delivery`, `StatusPending` (Task 2)
+- Produces:
+  - `func NewDeliveryRepo(db *gorm.DB) *DeliveryRepo`
+  - `(*DeliveryRepo) FanOut(ctx, rows []Delivery) (int, error)` — `ON CONFLICT DO NOTHING`
+  - `func NewDispatcher(db *gorm.DB, subs *SubscriptionRepo, deliveries *DeliveryRepo, log *slog.Logger, batch int) *Dispatcher`
+  - `(*Dispatcher) Tick(ctx) (int, error)` — returns deliveries created
+  - `(*Dispatcher) Start(ctx, interval time.Duration) <-chan struct{}`
+
+- [ ] **Step 1: Write the failing integration test**
+
+```go
+//go:build integration
+
+package webhook_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/outbox"
+	"github.com/mark8ly/marketplace-api/internal/webhook"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+	"gorm.io/gorm"
+)
+
+func enqueueOutbox(t *testing.T, db *gorm.DB, tenant uuid.UUID, eventType string) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	payload, _ := json.Marshal(map[string]any{"store_id": uuid.New().String()})
+	require.NoError(t, db.Exec(`
+		INSERT INTO outbox_events (id, tenant_id, aggregate, aggregate_id, event_type, payload)
+		VALUES (?, ?, 'order', ?, ?, ?)`,
+		id, tenant, uuid.New(), eventType, payload).Error)
+	return id
+}
+
+func TestDispatcher_CreatesOneDeliveryPerMatchingSubscription(t *testing.T) {
+	db := testdb.NewDB(t)
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	d := webhook.NewDispatcher(db, subs, deliveries, slog.Default(), 100)
+	ctx := context.Background()
+	tenant := uuid.New()
+
+	newSub(t, subs, tenant, []string{"order.placed"})
+	newSub(t, subs, tenant, []string{"order.placed", "order.refunded"})
+	newSub(t, subs, tenant, []string{"product.created"}) // must not match
+	enqueueOutbox(t, db, tenant, "order.placed")
+
+	n, err := d.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, n, "one delivery per subscription that selected the type")
+}
+
+// The property that replaces the exactly-once guarantee we gave up by NOT
+// coupling to the outbox publisher's transaction.
+func TestDispatcher_IsIdempotentAcrossRuns(t *testing.T) {
+	db := testdb.NewDB(t)
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	ctx := context.Background()
+	tenant := uuid.New()
+	newSub(t, subs, tenant, []string{"order.placed"})
+	enqueueOutbox(t, db, tenant, "order.placed")
+
+	first := webhook.NewDispatcher(db, subs, deliveries, slog.Default(), 100)
+	n1, err := first.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, n1)
+
+	// A dispatcher starting from a fresh cursor re-reads the same rows —
+	// the unique index must stop it double-delivering.
+	require.NoError(t, db.Exec(`UPDATE webhook_dispatch_cursor SET last_event_created = 'epoch'`).Error)
+	second := webhook.NewDispatcher(db, subs, deliveries, slog.Default(), 100)
+	n2, err := second.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, n2, "re-dispatching the same outbox rows must create nothing")
+
+	var count int64
+	require.NoError(t, db.Model(&webhook.Delivery{}).Count(&count).Error)
+	require.EqualValues(t, 1, count)
+}
+
+// The failure this whole architecture exists to prevent.
+func TestDispatcher_DoesNotTouchOutboxPublishedState(t *testing.T) {
+	db := testdb.NewDB(t)
+	subs := webhook.NewSubscriptionRepo(db)
+	d := webhook.NewDispatcher(db, subs, webhook.NewDeliveryRepo(db), slog.Default(), 100)
+	tenant := uuid.New()
+	newSub(t, subs, tenant, []string{"order.placed"})
+	id := enqueueOutbox(t, db, tenant, "order.placed")
+
+	_, err := d.Tick(context.Background())
+	require.NoError(t, err)
+
+	var row outbox.OutboxEvent
+	require.NoError(t, db.First(&row, "id = ?", id).Error)
+	require.Nil(t, row.PublishedAt, "webhook dispatch must not mark outbox rows published")
+}
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `TEST_DATABASE_URL="$DSN" go test -tags=integration ./internal/webhook/ -run TestDispatcher -v`
+Expected: FAIL — `NewDeliveryRepo` / `NewDispatcher` undefined.
+
+- [ ] **Step 3: Write delivery_repo.go**
+
+```go
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type DeliveryRepo struct{ db *gorm.DB }
+
+func NewDeliveryRepo(db *gorm.DB) *DeliveryRepo { return &DeliveryRepo{db: db} }
+
+// FanOut inserts delivery rows, ignoring any that already exist.
+//
+// ON CONFLICT DO NOTHING against idx_webhook_deliveries_event_sub is what
+// makes dispatch idempotent, and therefore what lets the dispatcher run
+// OUTSIDE the outbox publisher's transaction without risking duplicate
+// deliveries. Re-reading the same outbox rows is harmless.
+func (r *DeliveryRepo) FanOut(ctx context.Context, rows []Delivery) (int, error) {
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	res := r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "outbox_event_id"}, {Name: "subscription_id"}},
+		DoNothing: true,
+	}).Create(&rows)
+	if res.Error != nil {
+		return 0, fmt.Errorf("webhook: fan out deliveries: %w", res.Error)
+	}
+	return int(res.RowsAffected), nil
+}
+```
+
+- [ ] **Step 4: Write dispatcher.go**
+
+```go
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// Dispatcher turns outbox_events into webhook_deliveries.
+//
+// It keeps its OWN cursor (webhook_dispatch_cursor) rather than reading the
+// outbox publisher's watermark, so the two consumers advance independently.
+// A stalled webhook dispatch cannot hold back outbox publishing, and vice
+// versa. It never writes to outbox_events.
+type Dispatcher struct {
+	db         *gorm.DB
+	subs       *SubscriptionRepo
+	deliveries *DeliveryRepo
+	logger     *slog.Logger
+	batch      int
+}
+
+func NewDispatcher(db *gorm.DB, subs *SubscriptionRepo, deliveries *DeliveryRepo, logger *slog.Logger, batch int) *Dispatcher {
+	if batch <= 0 {
+		batch = 100
+	}
+	return &Dispatcher{db: db, subs: subs, deliveries: deliveries, logger: logger, batch: batch}
+}
+
+type outboxRow struct {
+	ID          uuid.UUID
+	TenantID    uuid.UUID
+	AggregateID uuid.UUID
+	EventType   string
+	CreatedAt   time.Time
+}
+
+// Tick reads one batch of outbox events past the cursor, fans them out, and
+// advances the cursor. Returns how many delivery rows were created.
+func (d *Dispatcher) Tick(ctx context.Context) (int, error) {
+	var cursor time.Time
+	if err := d.db.WithContext(ctx).
+		Raw(`SELECT last_event_created FROM webhook_dispatch_cursor WHERE id`).
+		Scan(&cursor).Error; err != nil {
+		return 0, fmt.Errorf("webhook: read cursor: %w", err)
+	}
+
+	var rows []outboxRow
+	if err := d.db.WithContext(ctx).Raw(`
+		SELECT id, tenant_id, aggregate_id, event_type, created_at
+		  FROM outbox_events
+		 WHERE created_at > ?
+		 ORDER BY created_at ASC
+		 LIMIT ?`, cursor, d.batch).Scan(&rows).Error; err != nil {
+		return 0, fmt.Errorf("webhook: read outbox: %w", err)
+	}
+	if len(rows) == 0 {
+		return 0, nil
+	}
+
+	created := 0
+	for _, row := range rows {
+		matches, err := d.subs.MatchingEvent(ctx, row.TenantID, row.EventType)
+		if err != nil {
+			return created, err
+		}
+		pending := make([]Delivery, 0, len(matches))
+		for _, s := range matches {
+			pending = append(pending, Delivery{
+				SubscriptionID: s.ID,
+				OutboxEventID:  row.ID,
+				EventType:      row.EventType,
+				AggregateID:    row.AggregateID,
+				Status:         StatusPending,
+				NextAttemptAt:  time.Now(),
+			})
+		}
+		n, err := d.deliveries.FanOut(ctx, pending)
+		if err != nil {
+			return created, err
+		}
+		created += n
+	}
+
+	last := rows[len(rows)-1]
+	if err := d.db.WithContext(ctx).Exec(`
+		UPDATE webhook_dispatch_cursor
+		   SET last_event_created = ?, last_event_id = ?
+		 WHERE id`, last.CreatedAt, last.ID).Error; err != nil {
+		return created, fmt.Errorf("webhook: advance cursor: %w", err)
+	}
+	return created, nil
+}
+
+// Start runs Tick on an interval until ctx is cancelled. Mirrors
+// outbox.Publisher.Start so the two loops behave the same way on shutdown.
+func (d *Dispatcher) Start(ctx context.Context, interval time.Duration) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if _, err := d.Tick(ctx); err != nil && d.logger != nil {
+					d.logger.Error("webhook dispatcher tick failed", "err", err)
+				}
+			}
+		}
+	}()
+	return done
+}
+```
+
+- [ ] **Step 5: Run and watch them pass**
+
+Run: `TEST_DATABASE_URL="$DSN" go test -tags=integration ./internal/webhook/ -run TestDispatcher -v`
+Expected: PASS — all three, including the outbox-isolation test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/marketplace-api/internal/webhook/delivery_repo.go services/marketplace-api/internal/webhook/dispatcher.go services/marketplace-api/internal/webhook/dispatcher_integration_test.go
+git commit -m "feat(webhooks): idempotent fan-out from outbox events to per-subscription deliveries"
+```
+
+---
+
+### Task 5: Sender and delivery worker
+
+**Files:**
+- Create: `services/marketplace-api/internal/webhook/sender.go`
+- Create: `services/marketplace-api/internal/webhook/worker.go`
+- Modify: `services/marketplace-api/internal/webhook/delivery_repo.go` (add `ClaimDue`, `RecordOutcome`)
+- Test: `services/marketplace-api/internal/webhook/sender_test.go`, `worker_integration_test.go`
+
+**Interfaces:**
+- Consumes: `ssrfguard.Guard.Check` (Task 1), `Sign`, `SignatureHeader` (Task 3), `DeliveryRepo`, `SubscriptionRepo` (Tasks 2, 4)
+- Produces:
+  - `func NewSender(guard *ssrfguard.Guard, client *http.Client) *Sender`
+  - `(*Sender) Send(ctx, sub Subscription, d Delivery) (statusCode int, err error)`
+  - `(*DeliveryRepo) ClaimDue(ctx, limit int) ([]Delivery, error)` — `FOR UPDATE SKIP LOCKED`
+  - `(*DeliveryRepo) RecordOutcome(ctx, id uuid.UUID, status string, code *int, errMsg *string, next time.Time) error`
+  - `(*DeliveryRepo) Prune(ctx, olderThan time.Duration) (int64, error)` — consumed by Task 8
+  - `(*SubscriptionRepo) ByID(ctx, id uuid.UUID) (*Subscription, error)` — added to Task 2's file in this task; returns `(nil, nil)` when the row is gone
+  - `const RetentionWindow = 30 * 24 * time.Hour` — consumed by Task 8
+  - `func NewWorker(...) *Worker`, `(*Worker) Tick(ctx) (int, error)`, `(*Worker) Start(ctx, interval) <-chan struct{}`
+  - `const MaxAttempts = 6`, `const FailureThreshold = 10`, `const RequestTimeout = 5 * time.Second`
+  - `func backoff(attempt int) time.Duration`
+
+- [ ] **Step 1: Write the failing sender test**
+
+```go
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/webhook/ssrfguard"
+)
+
+// allowAll resolves every host to a public address so httptest servers on
+// 127.0.0.1 can be exercised. Production passes nil, which uses real DNS.
+func allowAll() *ssrfguard.Guard {
+	return ssrfguard.New(func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	})
+}
+
+func TestSend_PostsSignedNotifyAndFetchBody(t *testing.T) {
+	var gotBody []byte
+	var gotSig string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		gotSig = r.Header.Get(SignatureHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := NewSender(allowAll(), srv.Client())
+	sub := Subscription{ID: uuid.New(), URL: srv.URL, Secret: "shh"}
+	d := Delivery{EventType: "order.placed", AggregateID: uuid.New(), CreatedAt: time.Now()}
+
+	code, err := s.Send(context.Background(), sub, d)
+	if err != nil || code != 200 {
+		t.Fatalf("code=%d err=%v", code, err)
+	}
+	if gotSig == "" {
+		t.Fatal("delivery was not signed")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(gotBody, &payload); err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{"event", "id", "occurred_at"} {
+		if _, ok := payload[k]; !ok {
+			t.Fatalf("payload missing %q: %s", k, gotBody)
+		}
+	}
+	// Notify-and-fetch: the body must NOT carry the entity.
+	if len(payload) != 3 {
+		t.Fatalf("payload should carry exactly event/id/occurred_at, got %v", payload)
+	}
+}
+
+// The guard runs immediately before dialling, not only at registration.
+// This is the DNS-rebinding case: the row was saved when the host was
+// public, and now resolves private.
+func TestSend_RefusesWhenTheHostNowResolvesPrivate(t *testing.T) {
+	rebind := ssrfguard.New(func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("169.254.169.254")}, nil
+	})
+	s := NewSender(rebind, http.DefaultClient)
+	sub := Subscription{ID: uuid.New(), URL: "https://hooks.example.com/x", Secret: "shh"}
+
+	if _, err := s.Send(context.Background(), sub, Delivery{EventType: "order.placed"}); err == nil {
+		t.Fatal("expected delivery to a rebound private address to be refused")
+	}
+}
+
+func TestSend_TreatsNon2xxAsFailureButReturnsTheCode(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	s := NewSender(allowAll(), srv.Client())
+	code, err := s.Send(context.Background(), Subscription{URL: srv.URL, Secret: "x"}, Delivery{EventType: "order.placed"})
+	if err == nil {
+		t.Fatal("non-2xx must be an error")
+	}
+	if code != 500 {
+		t.Fatalf("want the status code surfaced for the merchant log, got %d", code)
+	}
+}
+
+func TestBackoff_GrowsAndIsBounded(t *testing.T) {
+	prev := time.Duration(0)
+	for a := 1; a <= MaxAttempts; a++ {
+		d := backoff(a)
+		if d <= prev {
+			t.Fatalf("backoff must increase: attempt %d gave %v after %v", a, d, prev)
+		}
+		if d > 4*time.Hour {
+			t.Fatalf("backoff unbounded at attempt %d: %v", a, d)
+		}
+		prev = d
+	}
+}
+```
+
+Add `"io"` to the import block.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `go test ./internal/webhook/ -run 'TestSend|TestBackoff' -v`
+Expected: FAIL — `NewSender` undefined.
+
+- [ ] **Step 3: Write sender.go**
+
+```go
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/webhook/ssrfguard"
+)
+
+// RequestTimeout bounds one delivery attempt. Short on purpose: these loops
+// run in-process alongside admin API request handling, so a slow endpoint
+// must not hold a goroutine for long.
+const RequestTimeout = 5 * time.Second
+
+// maxErrorLen bounds what we store from a failing endpoint's response. The
+// body is surfaced to the merchant to make a broken endpoint debuggable; it
+// is never logged server-side, since it is arbitrary remote content.
+const maxErrorLen = 500
+
+type Sender struct {
+	guard  *ssrfguard.Guard
+	client *http.Client
+}
+
+func NewSender(guard *ssrfguard.Guard, client *http.Client) *Sender {
+	if client == nil {
+		client = &http.Client{
+			Timeout: RequestTimeout,
+			// Never follow redirects: a 302 to an internal address would
+			// walk straight around the guard, which only checked the
+			// original host.
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+	}
+	return &Sender{guard: guard, client: client}
+}
+
+// notification is the notify-and-fetch body. Identifiers only — the merchant
+// calls the REST API for detail, so no customer data reaches a
+// merchant-supplied URL and a retry cannot deliver a stale entity.
+type notification struct {
+	Event      string    `json:"event"`
+	ID         string    `json:"id"`
+	OccurredAt time.Time `json:"occurred_at"`
+}
+
+// Send makes one attempt. It re-checks the URL through the guard FIRST:
+// registration-time validation alone is defeated by DNS rebinding.
+func (s *Sender) Send(ctx context.Context, sub Subscription, d Delivery) (int, error) {
+	if _, err := s.guard.Check(sub.URL); err != nil {
+		return 0, fmt.Errorf("webhook: destination refused: %w", err)
+	}
+
+	occurred := d.CreatedAt
+	if occurred.IsZero() {
+		occurred = time.Now()
+	}
+	body, err := json.Marshal(notification{
+		Event:      d.EventType,
+		ID:         d.AggregateID.String(),
+		OccurredAt: occurred.UTC(),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("webhook: marshal notification: %w", err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, RequestTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, sub.URL, bytes.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("webhook: build request: %w", err)
+	}
+	now := time.Now()
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "Mark8ly-Webhooks/1")
+	req.Header.Set(SignatureHeader, Sign(sub.Secret, now, body))
+
+	res, err := s.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("webhook: request failed: %w", err)
+	}
+	defer res.Body.Close()
+	_, _ = io.CopyN(io.Discard, res.Body, 1<<16)
+
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		return res.StatusCode, fmt.Errorf("webhook: endpoint returned %d", res.StatusCode)
+	}
+	return res.StatusCode, nil
+}
+
+// backoff returns the delay before attempt n (1-based): roughly 30s, 2m,
+// 8m, 32m, 2h, capped. Spread over hours so a merchant restarting a server
+// has time to recover before attempts are exhausted.
+func backoff(attempt int) time.Duration {
+	d := 30 * time.Second
+	for i := 1; i < attempt; i++ {
+		d *= 4
+		if d > 4*time.Hour {
+			return 4 * time.Hour
+		}
+	}
+	return d
+}
+```
+
+- [ ] **Step 4: Add ClaimDue and RecordOutcome to delivery_repo.go**
+
+```go
+// ClaimDue locks up to limit pending, due deliveries. FOR UPDATE SKIP LOCKED
+// is what makes it safe for several replicas to run this loop at once — each
+// takes a disjoint set instead of contending.
+func (r *DeliveryRepo) ClaimDue(ctx context.Context, limit int) ([]Delivery, error) {
+	var out []Delivery
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT * FROM webhook_deliveries
+		 WHERE status = ? AND next_attempt_at <= now()
+		 ORDER BY next_attempt_at ASC
+		 LIMIT ?
+		 FOR UPDATE SKIP LOCKED`, StatusPending, limit).Scan(&out).Error
+	if err != nil {
+		return nil, fmt.Errorf("webhook: claim deliveries: %w", err)
+	}
+	return out, nil
+}
+
+// RecordOutcome writes the result of one attempt.
+func (r *DeliveryRepo) RecordOutcome(ctx context.Context, id uuid.UUID, status string, code *int, errMsg *string, next time.Time) error {
+	updates := map[string]any{
+		"status":           status,
+		"attempts":         gorm.Expr("attempts + 1"),
+		"last_status_code": code,
+		"last_error":       errMsg,
+		"next_attempt_at":  next,
+	}
+	if status == StatusDelivered {
+		updates["delivered_at"] = time.Now()
+	}
+	if err := r.db.WithContext(ctx).Model(&Delivery{}).Where("id = ?", id).Updates(updates).Error; err != nil {
+		return fmt.Errorf("webhook: record outcome: %w", err)
+	}
+	return nil
+}
+
+// Prune deletes delivery rows older than the retention window. 30 days on
+// every plan, deliberately not tied to FeatureAuditRetentionDays: "forever"
+// retention of delivery bodies on Pro is storage cost on a db-f1-micro with
+// no matching merchant value.
+func (r *DeliveryRepo) Prune(ctx context.Context, olderThan time.Duration) (int64, error) {
+	res := r.db.WithContext(ctx).Exec(
+		`DELETE FROM webhook_deliveries WHERE created_at < now() - ?::interval`,
+		fmt.Sprintf("%d hours", int(olderThan.Hours())))
+	if res.Error != nil {
+		return 0, fmt.Errorf("webhook: prune deliveries: %w", res.Error)
+	}
+	return res.RowsAffected, nil
+}
+```
+
+Add `"time"`, `"github.com/google/uuid"` and `"gorm.io/gorm"` to the imports.
+
+- [ ] **Step 5: Write worker.go**
+
+```go
+package webhook
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	// MaxAttempts before a delivery is dead-lettered.
+	MaxAttempts = 6
+	// FailureThreshold of CONSECUTIVE failures before the subscription is
+	// disabled and the merchant told. Higher than MaxAttempts so one bad
+	// delivery cannot disable a working endpoint — it takes sustained
+	// failure across different events.
+	FailureThreshold = 10
+	// RetentionWindow for delivery rows.
+	RetentionWindow = 30 * 24 * time.Hour
+)
+
+// Worker drains webhook_deliveries.
+type Worker struct {
+	deliveries *DeliveryRepo
+	subs       *SubscriptionRepo
+	sender     *Sender
+	logger     *slog.Logger
+	batch      int
+	notify     func(sub Subscription)
+}
+
+func NewWorker(deliveries *DeliveryRepo, subs *SubscriptionRepo, sender *Sender, logger *slog.Logger, batch int, notify func(Subscription)) *Worker {
+	if batch <= 0 {
+		batch = 4 // bounded: these goroutines share a pod with API traffic
+	}
+	return &Worker{deliveries: deliveries, subs: subs, sender: sender, logger: logger, batch: batch, notify: notify}
+}
+
+// Tick sends one batch. Returns how many deliveries were attempted.
+func (w *Worker) Tick(ctx context.Context) (int, error) {
+	due, err := w.deliveries.ClaimDue(ctx, w.batch)
+	if err != nil {
+		return 0, err
+	}
+	for _, d := range due {
+		w.attempt(ctx, d)
+	}
+	return len(due), nil
+}
+
+func (w *Worker) attempt(ctx context.Context, d Delivery) {
+	sub, err := w.subs.ByID(ctx, d.SubscriptionID)
+	if err != nil || sub == nil {
+		return // subscription deleted mid-flight; the cascade will clean up
+	}
+
+	code, sendErr := w.sender.Send(ctx, *sub, d)
+	var codePtr *int
+	if code != 0 {
+		codePtr = &code
+	}
+
+	if sendErr == nil {
+		if err := w.deliveries.RecordOutcome(ctx, d.ID, StatusDelivered, codePtr, nil, time.Now()); err != nil && w.logger != nil {
+			w.logger.Error("webhook: record delivered failed", "err", err)
+		}
+		if err := w.subs.RecordSuccess(ctx, sub.ID); err != nil && w.logger != nil {
+			w.logger.Error("webhook: record success failed", "err", err)
+		}
+		return
+	}
+
+	// Never log the endpoint's response body — arbitrary remote content.
+	msg := truncate(sendErr.Error(), maxErrorLen)
+	attempts := d.Attempts + 1
+	status, next := StatusPending, time.Now().Add(backoff(attempts))
+	if attempts >= MaxAttempts {
+		status, next = StatusFailed, time.Now()
+	}
+	if err := w.deliveries.RecordOutcome(ctx, d.ID, status, codePtr, &msg, next); err != nil && w.logger != nil {
+		w.logger.Error("webhook: record failure failed", "err", err)
+	}
+
+	if status != StatusFailed {
+		return
+	}
+	disabled, err := w.subs.RecordFailure(ctx, sub.ID, FailureThreshold)
+	if err != nil && w.logger != nil {
+		w.logger.Error("webhook: record subscription failure", "err", err)
+	}
+	if disabled {
+		if w.logger != nil {
+			w.logger.Warn("webhook subscription auto-disabled",
+				slog.String("subscription_id", sub.ID.String()))
+		}
+		if w.notify != nil {
+			w.notify(*sub)
+		}
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+// Start runs Tick on an interval until ctx is cancelled.
+func (w *Worker) Start(ctx context.Context, interval time.Duration) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if _, err := w.Tick(ctx); err != nil && w.logger != nil {
+					w.logger.Error("webhook worker tick failed", "err", err)
+				}
+			}
+		}
+	}()
+	return done
+}
+
+var _ = uuid.Nil
+```
+
+Add to `subscription_repo.go`:
+
+```go
+// ByID returns one subscription, or (nil, nil) if it no longer exists.
+func (r *SubscriptionRepo) ByID(ctx context.Context, id uuid.UUID) (*Subscription, error) {
+	var s Subscription
+	err := r.db.WithContext(ctx).First(&s, "id = ?", id).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("webhook: get subscription: %w", err)
+	}
+	return &s, nil
+}
+```
+
+- [ ] **Step 6: Write the worker integration test**
+
+```go
+//go:build integration
+
+package webhook_test
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/webhook"
+	"github.com/mark8ly/marketplace-api/internal/webhook/ssrfguard"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+	"github.com/google/uuid"
+)
+
+func TestWorker_DeliversAndMarksDelivered(t *testing.T) {
+	var hits int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	db := testdb.NewDB(t)
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	guard := ssrfguard.New(func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	})
+	w := webhook.NewWorker(deliveries, subs, webhook.NewSender(guard, srv.Client()), slog.Default(), 4, nil)
+	ctx := context.Background()
+
+	sub := newSub(t, subs, uuid.New(), []string{"order.placed"})
+	require.NoError(t, db.Exec(`UPDATE webhook_subscriptions SET url = ? WHERE id = ?`, srv.URL, sub.ID).Error)
+	_, err := deliveries.FanOut(ctx, []webhook.Delivery{{
+		SubscriptionID: sub.ID, OutboxEventID: uuid.New(), EventType: "order.placed",
+		AggregateID: uuid.New(), Status: webhook.StatusPending, NextAttemptAt: time.Now(),
+	}})
+	require.NoError(t, err)
+
+	n, err := w.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.EqualValues(t, 1, atomic.LoadInt32(&hits))
+
+	var got webhook.Delivery
+	require.NoError(t, db.First(&got).Error)
+	require.Equal(t, webhook.StatusDelivered, got.Status)
+	require.NotNil(t, got.DeliveredAt)
+}
+
+func TestWorker_RetriesWithBackoffThenDeadLetters(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+
+	db := testdb.NewDB(t)
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	guard := ssrfguard.New(func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	})
+	w := webhook.NewWorker(deliveries, subs, webhook.NewSender(guard, srv.Client()), slog.Default(), 4, nil)
+	ctx := context.Background()
+
+	sub := newSub(t, subs, uuid.New(), []string{"order.placed"})
+	require.NoError(t, db.Exec(`UPDATE webhook_subscriptions SET url = ? WHERE id = ?`, srv.URL, sub.ID).Error)
+	_, err := deliveries.FanOut(ctx, []webhook.Delivery{{
+		SubscriptionID: sub.ID, OutboxEventID: uuid.New(), EventType: "order.placed",
+		AggregateID: uuid.New(), Status: webhook.StatusPending, NextAttemptAt: time.Now(),
+	}})
+	require.NoError(t, err)
+
+	for i := 0; i < webhook.MaxAttempts; i++ {
+		_, err := w.Tick(ctx)
+		require.NoError(t, err)
+		// Make the next attempt due immediately rather than sleeping out the backoff.
+		require.NoError(t, db.Exec(`UPDATE webhook_deliveries SET next_attempt_at = now()`).Error)
+	}
+
+	var got webhook.Delivery
+	require.NoError(t, db.First(&got).Error)
+	require.Equal(t, webhook.StatusFailed, got.Status)
+	require.Equal(t, webhook.MaxAttempts, got.Attempts)
+	require.NotNil(t, got.LastStatusCode)
+	require.Equal(t, 500, *got.LastStatusCode)
+}
+```
+
+- [ ] **Step 7: Run everything and watch it pass**
+
+```bash
+go test ./internal/webhook/... -v
+TEST_DATABASE_URL="$DSN" go test -tags=integration ./internal/webhook/... -v
+```
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add services/marketplace-api/internal/webhook/
+git commit -m "feat(webhooks): delivery worker with backoff, dead-lettering and auto-disable"
+```
+
+---
+
+### Task 6: Wire the loops into main.go
+
+**Files:**
+- Modify: `services/marketplace-api/cmd/marketplace-api/main.go` (beside the outbox publisher, around line 1690)
+
+**Interfaces:**
+- Consumes: `NewDispatcher`, `NewWorker`, `NewSender`, `ssrfguard.New` (Tasks 1, 4, 5)
+- Produces: nothing consumed by later tasks
+
+- [ ] **Step 1: Add the wiring**
+
+Directly after the existing `if m == mode.Admin || m == mode.Both { pub := outbox.New(...) ... }` block:
+
+```go
+	// Outbound webhooks (#562). Two loops beside the outbox publisher, on the
+	// same engines: a merchant subscription is admin-domain state, and the
+	// storefront replica must not run a second copy of either poll.
+	//
+	// In-process rather than a separate Deployment, deliberately. The
+	// alternative costs another chart, another ArgoCD Application and another
+	// pod's memory on a cluster that has already had rollouts deadlock under
+	// memory pressure. FOR UPDATE SKIP LOCKED makes both loops safe across
+	// KEDA replicas. The bounded worker batch and the 5s per-request timeout
+	// in internal/webhook cap what a slow merchant endpoint can tie up.
+	//
+	// Because dispatch and delivery are decoupled by webhook_deliveries,
+	// moving the delivery loop to its own workload later is a deployment
+	// change, not a redesign.
+	webhookCtx, webhookCancel := context.WithCancel(context.Background())
+	defer webhookCancel()
+	var webhookDispatcherDone, webhookWorkerDone <-chan struct{}
+	if m == mode.Admin || m == mode.Both {
+		whSubs := webhook.NewSubscriptionRepo(conn)
+		whDeliveries := webhook.NewDeliveryRepo(conn)
+		whSender := webhook.NewSender(ssrfguard.New(nil), nil)
+
+		dispatcher := webhook.NewDispatcher(conn, whSubs, whDeliveries, log, 100)
+		webhookDispatcherDone = dispatcher.Start(webhookCtx, 5*time.Second)
+
+		worker := webhook.NewWorker(whDeliveries, whSubs, whSender, log, 4, nil)
+		webhookWorkerDone = worker.Start(webhookCtx, 5*time.Second)
+
+		log.Info("webhook dispatcher and delivery worker started")
+	}
+```
+
+Add imports:
+```go
+	"github.com/mark8ly/marketplace-api/internal/webhook"
+	"github.com/mark8ly/marketplace-api/internal/webhook/ssrfguard"
+```
+
+- [ ] **Step 2: Drain both loops on shutdown**
+
+Find where `publisherDone` is waited on during graceful shutdown and add the same treatment for `webhookDispatcherDone` and `webhookWorkerDone`, following the existing pattern exactly.
+
+- [ ] **Step 3: Verify it builds and the whole suite still passes**
+
+```bash
+go build ./... && go vet ./...
+TEST_DATABASE_URL="$DSN" go test -tags=integration -p 1 ./...
+```
+Expected: build and vet clean; every package `ok`. **Run the full suite** — the last two features here each tripped a guard in an untouched package.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/marketplace-api/cmd/marketplace-api/main.go
+git commit -m "feat(webhooks): run dispatcher and delivery worker in-process on admin engines"
+```
+
+---
+
+### Task 7: Admin API
+
+**Files:**
+- Create: `services/marketplace-api/internal/handlers/admin/webhooks.go`
+- Modify: `services/marketplace-api/cmd/marketplace-api/main.go` (register routes with the other admin handlers)
+- Test: `services/marketplace-api/internal/handlers/admin/webhooks_test.go`
+
+**Interfaces:**
+- Consumes: `SubscriptionRepo`, `DeliveryRepo`, `Sender`, `GenerateSecret`, `MaxEventTypes` (Tasks 1–5), `ssrfguard` errors
+- Produces: routes under the existing authenticated admin group —
+  - `POST   /webhooks` → create (returns the secret **once**)
+  - `GET    /webhooks` → list for the current store
+  - `PATCH  /webhooks/:id` → update url / event types / enabled
+  - `DELETE /webhooks/:id`
+  - `POST   /webhooks/:id/test` → send a synthetic `webhook.test` delivery
+  - `GET    /webhooks/:id/deliveries` → recent deliveries
+  - `POST   /webhooks/:id/deliveries/:deliveryID/replay` → reset to pending, due now
+
+- [ ] **Step 1: Write the failing handler test**
+
+Follow the table-driven style of the neighbouring `internal/handlers/admin/*_test.go` files. Cover:
+
+```go
+// A merchant-supplied URL is validated at REGISTRATION as well as delivery.
+// Without this, a private URL is stored and only rejected later, hidden in
+// the delivery log.
+func TestCreate_RejectsNonPublicURL(t *testing.T) { /* expects 400, code validation_failed */ }
+
+func TestCreate_RejectsPlainHTTP(t *testing.T) { /* expects 400 */ }
+
+func TestCreate_RejectsUnknownEventType(t *testing.T) {
+	// Only the 18 constants in internal/outbox are selectable. An unknown
+	// type would silently never fire, which reads to a merchant as a broken
+	// webhook rather than a typo.
+}
+
+func TestCreate_RejectsMoreThanMaxEventTypes(t *testing.T) { /* MaxEventTypes + 1 → 400 */ }
+
+func TestCreate_ReturnsTheSecretExactlyOnce(t *testing.T) {
+	// The create response carries `secret`; a subsequent GET must not.
+}
+
+func TestList_ScopesToTheCallersTenantAndStore(t *testing.T) {
+	// A subscription belonging to another tenant must not be returned.
+}
+
+func TestReplay_ResetsAFailedDeliveryToPendingAndDueNow(t *testing.T) {}
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `go test ./internal/handlers/admin/ -run TestCreate -v`
+Expected: FAIL — handler undefined.
+
+- [ ] **Step 3: Implement the handler**
+
+Key requirements, each with a reason:
+
+```go
+// allowedEventTypes is the closed set a subscription may select, built from
+// internal/outbox's constants. Validating against it means a typo is a 400
+// at registration rather than a webhook that silently never fires.
+var allowedEventTypes = map[string]bool{
+	outbox.EventOrderPlaced: true, outbox.EventOrderConfirmed: true,
+	outbox.EventOrderFulfilled: true, outbox.EventOrderPartiallyFulfilled: true,
+	outbox.EventOrderCancelled: true, outbox.EventOrderRefunded: true,
+	outbox.EventReturnRequested: true, outbox.EventReturnApproved: true,
+	outbox.EventReturnReceived: true, outbox.EventReturnRefunded: true,
+	outbox.EventReturnRejected: true,
+	outbox.EventProductCreated: true, outbox.EventProductUpdated: true,
+	outbox.EventProductDeleted: true,
+	outbox.EventCategoryCreated: true, outbox.EventCategoryUpdated: true,
+	outbox.EventCategoryDeleted: true,
+	outbox.EventAbandonedCartRecoveryEmail: true,
+}
+```
+
+- Bind with Gin tags; return the repo's standard error envelope via `apperrors.CodeValidationFailed` on any rejection — match the shape used by neighbouring admin handlers, do not invent one.
+- Run `ssrfguard.Check` on create and on update. Map `ErrNotHTTPS`, `ErrPrivateAddress`, `ErrUnresolvable` to distinct, human messages: a merchant needs to know *which* rule they hit.
+- `GenerateSecret()` on create; return it in the create response only. `Subscription.Secret` is `json:"-"`, so reads can't leak it.
+- Every query scopes on the tenant and store from the auth context. **No handler may take a tenant id from the request body.**
+- Test-send builds a synthetic `Delivery{EventType: "webhook.test"}` and calls `Sender.Send` directly, returning the status code and any error to the caller so a merchant can debug without waiting for a real event.
+- Replay sets `status='pending'`, `attempts=0`, `next_attempt_at=now()` for a delivery belonging to a subscription in the caller's store.
+
+- [ ] **Step 4: Register the routes**
+
+In `main.go`, alongside the other admin handler registrations, inside the authenticated admin group. Follow the surrounding registration style exactly.
+
+- [ ] **Step 5: Run and watch them pass**
+
+Run: `go test ./internal/handlers/admin/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/marketplace-api/internal/handlers/admin/webhooks.go services/marketplace-api/internal/handlers/admin/webhooks_test.go services/marketplace-api/cmd/marketplace-api/main.go
+git commit -m "feat(webhooks): admin API for subscriptions, test sends and delivery replay"
+```
+
+---
+
+### Task 8: Delivery pruning
+
+**Files:**
+- Create: `services/marketplace-api/cmd/webhook-prune-cron/main.go`
+- Test: `services/marketplace-api/internal/webhook/prune_integration_test.go`
+- Modify: root `Makefile` (add `./internal/webhook/...` to `test-int` if Task 2 didn't)
+
+**Interfaces:**
+- Consumes: `DeliveryRepo.Prune`, `RetentionWindow` (Task 5)
+- Produces: a CronJob entrypoint following `cmd/refund-sweep-cron` exactly
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+//go:build integration
+
+func TestPrune_RemovesRowsPastRetentionAndKeepsRecentOnes(t *testing.T) {
+	db := testdb.NewDB(t)
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	ctx := context.Background()
+	sub := newSub(t, subs, uuid.New(), []string{"order.placed"})
+
+	_, err := deliveries.FanOut(ctx, []webhook.Delivery{
+		{SubscriptionID: sub.ID, OutboxEventID: uuid.New(), EventType: "order.placed", AggregateID: uuid.New(), Status: webhook.StatusDelivered},
+		{SubscriptionID: sub.ID, OutboxEventID: uuid.New(), EventType: "order.placed", AggregateID: uuid.New(), Status: webhook.StatusDelivered},
+	})
+	require.NoError(t, err)
+
+	// Age exactly one row past the window.
+	require.NoError(t, db.Exec(`
+		UPDATE webhook_deliveries SET created_at = now() - interval '31 days'
+		 WHERE id = (SELECT id FROM webhook_deliveries LIMIT 1)`).Error)
+
+	n, err := deliveries.Prune(ctx, webhook.RetentionWindow)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, n)
+
+	var remaining int64
+	require.NoError(t, db.Model(&webhook.Delivery{}).Count(&remaining).Error)
+	require.EqualValues(t, 1, remaining, "a delivery inside the window must survive")
+}
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `TEST_DATABASE_URL="$DSN" go test -tags=integration ./internal/webhook/ -run TestPrune -v`
+
+- [ ] **Step 3: Write the cron entrypoint**
+
+Copy the structure of `cmd/refund-sweep-cron/main.go`: load config, open the DB, call `Prune(ctx, webhook.RetentionWindow)`, log the count, exit non-zero on error.
+
+- [ ] **Step 4: Run and watch it pass, then commit**
+
+```bash
+git add services/marketplace-api/cmd/webhook-prune-cron/ services/marketplace-api/internal/webhook/prune_integration_test.go Makefile
+git commit -m "feat(webhooks): prune delivery rows past the 30-day retention window"
+```
+
+Note: the CronJob manifest lives in `tesserix-k8s`, not this repo — a separate PR modelled on the existing `refund-sweep` CronJob.
+
+---
+
+### Task 9: Admin UI
+
+**Files:**
+- Create: `apps/admin/app/(dashboard)/settings/webhooks/page.tsx`
+- Create: `apps/admin/components/settings/WebhooksSettingsClient.tsx`
+- Create: `apps/admin/lib/api/webhooks.ts`
+- Test: `apps/admin/tests/unit/components/settings/WebhooksSettingsClient.test.tsx`
+
+**Interfaces:**
+- Consumes: the Task 7 admin API
+- Produces: nothing consumed by later tasks
+
+- [ ] **Step 1: Write the failing component test**
+
+Follow the existing `apps/admin/tests/unit/components/**` conventions (vitest + Testing Library). Cover:
+
+- The secret is shown once after creation, with a copy control and a warning that it will not be shown again
+- A disabled subscription renders its `disabled_reason` prominently — a merchant must be able to see *why* without opening a delivery
+- The delivery list shows status and response code, and offers replay only on failed deliveries
+- Test-send reports the status code it got back
+- Form errors from the API (`ErrPrivateAddress`, `ErrNotHTTPS`) surface as readable messages, wired with `aria-describedby`
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `cd apps/admin && npx vitest run tests/unit/components/settings/WebhooksSettingsClient.test.tsx`
+
+- [ ] **Step 3: Build the UI**
+
+Read `apps/admin/components/settings/BrandingSettingsClient.tsx` first and follow its structure — section headers, `ToggleSwitch`, the save pattern, `@tesserix/web` primitives. Design per the repo root CLAUDE.md: Paper/Ink/Moss, Source Serif 4 display / Source Sans 3 UI, hairline rules rather than bordered cards, one accent, light mode only, WCAG 2.1 AA.
+
+Event-type selection is a checkbox group over the 18 types, grouped by aggregate (order / return / product / category), with the aggregate name as a group label so the list reads rather than sprawls.
+
+- [ ] **Step 4: Run and watch them pass**
+
+```bash
+cd apps/admin && npx vitest run && npx tsc --noEmit
+```
+
+Note: `@tesserix/web` and `@tesserix/otto-widget` come from GitHub Packages and may be missing from `node_modules`, which makes some specs fail for reasons unrelated to your change. Confirm any failure reproduces on unmodified `origin/main` (`git stash`, re-run, `git stash pop`) before attributing it to yourself.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/admin/app/\(dashboard\)/settings/webhooks/ apps/admin/components/settings/WebhooksSettingsClient.tsx apps/admin/lib/api/webhooks.ts apps/admin/tests/unit/components/settings/WebhooksSettingsClient.test.tsx
+git commit -m "feat(webhooks): admin UI for subscriptions, test sends and delivery history"
+```
+
+---
+
+### Task 10: Narrow the pricing guard and document verification
+
+**Files:**
+- Modify: `apps/onboarding/tests/unit/pricing-surfaces-truth.spec.ts`
+- Create: `docs/webhooks.md`
+
+- [ ] **Step 1: Narrow the guard, do not delete it**
+
+`pricing-surfaces-truth.spec.ts` currently fails on any pricing surface mentioning **webhooks or code injection**. Webhooks now exist; custom code injection still does not. Remove only the webhook assertion, keep the code-injection one, and update the failure message to say why the two were separated.
+
+Note: webhooks are on **every** plan, so this does not license restoring a *Studio* "webhooks" bullet — it is not a tier differentiator. If plan copy changes at all, both public surfaces must change together (`Pricing.tsx` and `admin/lib/copy/pricing.ts`).
+
+- [ ] **Step 2: Write the merchant-facing verification recipe**
+
+`docs/webhooks.md`: the event catalogue, the payload shape, and a worked signature-verification example showing how to recompute `v1` over `"<t>.<body>"` and reject a stale `t`. Without this the signature is undocumented and merchants will skip verification.
+
+- [ ] **Step 3: Run the onboarding suite and commit**
+
+```bash
+cd apps/onboarding && npx playwright test --config=playwright.unit.config.ts
+git add apps/onboarding/tests/unit/pricing-surfaces-truth.spec.ts docs/webhooks.md
+git commit -m "docs(webhooks): verification recipe, and narrow the pricing guard to code injection"
+```
+
+---
+
+## Before opening the PR
+
+- [ ] `go build ./... && go vet ./... && gofmt -l .`
+- [ ] Full integration suite on a throwaway database: `TEST_DATABASE_URL="$DSN" go test -tags=integration -p 1 -count=1 ./...` — **every** package, not just `internal/webhook`
+- [ ] Down migration round-trips: `go run ./cmd/migrate down 1 && go run ./cmd/migrate up`
+- [ ] `cd apps/admin && npx tsc --noEmit`
+- [ ] `docker rm -f m8-wh`
+- [ ] Confirm no log line anywhere carries a webhook URL's response body, a signing secret, or a subscriber email

--- a/docs/superpowers/plans/2026-09-02-outbound-webhooks.md
+++ b/docs/superpowers/plans/2026-09-02-outbound-webhooks.md
@@ -1872,7 +1872,7 @@ git commit -m "feat(webhooks): admin API for subscriptions, test sends and deliv
 ### Task 8: Delivery pruning
 
 **Files:**
-- Create: `services/marketplace-api/cmd/webhook-prune-cron/main.go`
+- Create: `services/marketplace-api/cmd/webhook-delivery-prune-cron/main.go`
 - Test: `services/marketplace-api/internal/webhook/prune_integration_test.go`
 - Modify: root `Makefile` (add `./internal/webhook/...` to `test-int` if Task 2 didn't)
 
@@ -1924,7 +1924,7 @@ Copy the structure of `cmd/refund-sweep-cron/main.go`: load config, open the DB,
 - [ ] **Step 4: Run and watch it pass, then commit**
 
 ```bash
-git add services/marketplace-api/cmd/webhook-prune-cron/ services/marketplace-api/internal/webhook/prune_integration_test.go Makefile
+git add services/marketplace-api/cmd/webhook-delivery-prune-cron/ services/marketplace-api/internal/webhook/prune_integration_test.go Makefile
 git commit -m "feat(webhooks): prune delivery rows past the 30-day retention window"
 ```
 

--- a/docs/superpowers/specs/2026-09-02-outbound-webhooks-design.md
+++ b/docs/superpowers/specs/2026-09-02-outbound-webhooks-design.md
@@ -1,0 +1,235 @@
+# Outbound webhooks: merchant subscriptions over the existing outbox
+
+Design for #562. Written 2026-09-02, after #560 and #565 removed "webhooks"
+from the pricing table — it had been advertised on Studio for some time
+while no outbound delivery existed anywhere in the service (#544).
+
+## What this delivers
+
+A merchant registers an HTTPS endpoint, picks which events they care about,
+and receives a signed POST when those events happen. Failures retry, then
+dead-letter. A permanently broken endpoint is disabled and the merchant is
+told. Every delivery is visible in admin and replayable.
+
+## The expensive half already exists
+
+`outbox_events` is a transactional outbox: rows are written in the same
+transaction as the mutation that produces them (`EnqueueInTx`), and an
+in-process publisher drains them with `SELECT … FOR UPDATE SKIP LOCKED`.
+
+It already carries eighteen domain events, all of them written by real
+producers in `internal/order`, `internal/product` and `internal/category`:
+
+```
+order.placed          order.confirmed    order.fulfilled
+order.partially_fulfilled                order.cancelled     order.refunded
+return.requested      return.approved    return.received
+return.refunded       return.rejected
+product.created       product.updated    product.deleted
+category.created      category.updated   category.deleted
+abandoned_cart.recovery_email
+```
+
+So this feature captures nothing. It is a **consumer** of an event stream
+that is already reliable and already transactional — which is what makes it
+a contained piece of work rather than the multi-week build it looks like.
+
+## Product decisions
+
+Decided 2026-09-02. Recorded with their rejected alternatives, because each
+has a cheaper option a later reader might assume was overlooked.
+
+### 1. Notify-and-fetch payloads
+
+The delivery body carries the event name, the aggregate id, and a timestamp.
+The merchant calls the REST API for detail.
+
+Rejected: full payloads. They would ship customer PII to merchant-supplied
+URLs, and a retry hours later would deliver a stale snapshot of an order that
+has since changed. Thin payloads also match what the outbox already stores —
+its payloads are identifiers plus `store_id`, not entities.
+
+The cost is a second round trip, and a hard dependency on the merchant having
+API access. See decision 4.
+
+### 2. Strict URL validation, re-resolved at delivery
+
+HTTPS only. The hostname is resolved at registration **and again immediately
+before each delivery**, and the request is rejected if it resolves to a
+private, loopback, link-local, or cloud-metadata address. Redirects are not
+followed.
+
+Rejected: validating only at registration. That is the common shortcut and it
+is defeated by DNS rebinding — a hostname that resolves public when saved and
+private when delivered. The re-resolution is the part that actually matters.
+
+This is the first place merchant input becomes an egress target from the
+cluster. Every other outbound integration (payment gateways, carriers, email
+providers) goes to fixed, configured endpoints.
+
+The cost is real: a merchant cannot point a webhook at `localhost` to test,
+and "why won't it accept my URL" becomes a support question. Accepted.
+
+### 3. Retry, dead-letter, then auto-disable
+
+Exponential backoff over a few hours. A delivery that exhausts its attempts
+is recorded as failed and kept. After a threshold of consecutive failures
+across *different* events, the subscription is disabled and the merchant is
+emailed. They fix the endpoint, re-enable, and replay failed deliveries.
+
+Rejected: retrying forever. A dead endpoint would have the cluster making
+outbound requests indefinitely, and on a shared `db-f1-micro` with a small
+node pool a handful of those is not free.
+
+Rejected: dropping silently. A webhook that stopped working without saying so
+is worse for a merchant than one that told them — especially for order events.
+
+### 4. Available on every plan
+
+Rejected: gating to Studio+. The events already exist; gating mainly creates
+support friction, and webhooks are not the differentiator the plan copy
+implied.
+
+### 5. Read-only API widened to Starter
+
+Decision 1 makes a webhook useless without API access to fetch the detail,
+and the read-only API is currently Studio+. A Starter merchant would get a
+doorbell with the door locked.
+
+**This is a plan-entitlement change, not a webhook change**, and it needs its
+own issue: it alters what Studio sells and requires matching pricing copy on
+both public surfaces (`Pricing.tsx` and `admin/lib/copy/pricing.ts`, kept
+honest by `pricing-surfaces-truth.spec.ts`). It must land before or with
+webhooks, or decision 1 is incoherent for Starter merchants.
+
+## Architecture
+
+Two loops and one new table, running in-process beside the existing
+`outbox.Publisher`.
+
+```
+outbox_events ──(dispatcher: own cursor)──▶ webhook_deliveries ──(worker)──▶ merchant endpoint
+                                                    ▲
+                                      webhook_subscriptions
+```
+
+**Dispatcher.** Polls `outbox_events` against its own cursor — deliberately
+not the publisher's watermark — matches each event to enabled subscriptions
+for that tenant and event type, and inserts one `webhook_deliveries` row per
+(event, subscription). Idempotent on that pair.
+
+**Delivery worker.** Polls `webhook_deliveries WHERE status='pending' AND
+next_attempt_at <= now()` with `FOR UPDATE SKIP LOCKED`, sends, records the
+outcome. Retries, dead-lettering, replay and the merchant-facing delivery log
+all fall out of this one table.
+
+### Why not extend the existing publisher
+
+Fanning out inside `outbox.Publisher.ProcessBatch` would give exactly-once
+fan-out for free, in the same transaction that marks the row published. It is
+rejected because it welds untrusted-network work with unbounded latency into
+the watermark publisher — the component whose failure semantics
+`outbox/models.go` documents at length (#336) as subtle and awkward to
+recover from. A merchant's dead endpoint must never stall internal
+bookkeeping.
+
+The exactly-once property that coupling would buy is recovered by making
+fan-out idempotent on `(outbox_event_id, subscription_id)`.
+
+### Why in-process rather than a separate workload
+
+Both loops run as goroutines in the admin-mode pod, matching how
+`outbox.Publisher` already runs. `FOR UPDATE SKIP LOCKED` makes this safe
+across KEDA-scaled replicas.
+
+Rejected: a dedicated Deployment. It buys isolation — merchant endpoints
+could not touch API latency — at the cost of another chart, another ArgoCD
+Application, and another pod's memory on a cluster that has already had
+rollouts deadlock under memory pressure (the `maxSurge: 0` workaround in the
+mark8ly charts exists because of exactly that). Adding a permanent pod for a
+feature with no users yet is the wrong first move.
+
+Rejected: a CronJob. Minimum granularity is 60 seconds, which undercuts the
+point of a webhook.
+
+The risk accepted is that a burst of slow endpoints ties up goroutines in a
+pod that also serves admin API requests. Bounded by a small worker pool and a
+short per-request timeout, so the blast radius is capped rather than absent.
+
+**This is a reversible decision.** Because the fan-out table already
+decouples dispatch from delivery, extracting the delivery loop into its own
+workload later is a deployment change, not a redesign.
+
+## Schema
+
+`webhook_subscriptions` — tenant and store scoped, URL, selected event types,
+signing secret, enabled flag with a disabled-reason and disabled-at, plus the
+consecutive-failure counter that drives auto-disable.
+
+`webhook_deliveries` — subscription id, outbox event id, event type, status
+(`pending` / `delivered` / `failed`), attempt count, `next_attempt_at`, last
+response status and a truncated response body for the merchant-facing log,
+timestamps. Unique on `(outbox_event_id, subscription_id)` — that constraint
+is what makes dispatch idempotent.
+
+Both tables carry `tenant_id`, unlike `journal_subscribers` (#153), because a
+webhook subscription genuinely belongs to a merchant.
+
+Delivery rows are pruned on a schedule, following `audit/prune_cron.go`.
+Retention is **30 days on every plan**, deliberately not tied to
+`FeatureAuditRetentionDays` — "forever" retention of delivery bodies on Pro
+is a storage cost on a `db-f1-micro` with no corresponding merchant value.
+
+## Delivery semantics
+
+Each request carries an HMAC signature over a timestamp and the raw body,
+using the subscription's secret, in a header alongside that timestamp. The
+timestamp is inside the signed material so a captured delivery cannot be
+replayed later. The verification recipe is documented for merchants, with a
+worked example, and the secret is shown once at creation and never again.
+
+A 2xx is success. Anything else, a timeout, or a connection failure is a
+retryable failure until attempts are exhausted.
+
+## Admin surface
+
+Register, edit and delete a subscription; pick event types; send a test
+event; view recent deliveries with their status and response code; replay a
+failed delivery. Follows the existing admin settings patterns.
+
+## Testing
+
+The SSRF guard is the piece most worth getting right and is built as a
+separately-testable unit, including a DNS-rebinding case where registration
+and delivery resolve differently.
+
+Beyond that: dispatch is idempotent under repeated runs; retry and backoff
+scheduling; auto-disable fires on consecutive failures and not on isolated
+ones; signature verification; and a test asserting that a stalled webhook
+delivery cannot block the outbox watermark publisher — the failure this
+architecture exists to prevent.
+
+Integration tests run against a throwaway `postgres:15`, with the **full**
+suite run before opening a PR, not just the touched packages. The last two
+features here each tripped a guard in an untouched package (the customer
+erasure coverage guard, the CI contract test) that a narrow run would have
+missed.
+
+## Out of scope
+
+**Custom code injection** — the other half of #544. Deliberately not being
+built: arbitrary `<script>` in merchant storefronts is XSS against their
+customers by design, and shipping it permanently weakens the storefront CSP.
+
+**Restoring "webhooks" as a Studio pricing bullet.** It is on every plan, so
+it is not a tier differentiator. `pricing-surfaces-truth.spec.ts` currently
+fails on any pricing surface mentioning webhooks; that guard should be
+narrowed rather than deleted when this ships, so the code-injection half stays
+pinned.
+
+## Open items
+
+- The plan-entitlement change in decision 5 needs its own issue before this
+  can ship coherently.
+- Retry schedule, attempt count and the auto-disable threshold are left to
+  the implementation plan; nothing in the design turns on the exact numbers.

--- a/docs/superpowers/specs/2026-09-02-outbound-webhooks-design.md
+++ b/docs/superpowers/specs/2026-09-02-outbound-webhooks-design.md
@@ -74,8 +74,21 @@ and "why won't it accept my URL" becomes a support question. Accepted.
 
 Exponential backoff over a few hours. A delivery that exhausts its attempts
 is recorded as failed and kept. After a threshold of consecutive failures
-across *different* events, the subscription is disabled and the merchant is
-emailed. They fix the endpoint, re-enable, and replay failed deliveries.
+across *different* events, the subscription is disabled. They fix the
+endpoint, re-enable, and replay failed deliveries. Deliveries already
+pending when a subscription is disabled are retired as failed rather than
+sent, so disabling actually stops outbound traffic instead of only stopping
+new deliveries being created.
+
+**What ships today, and what does not.** The merchant is NOT emailed. The
+worker has the notification hook (`webhook.NewWorker`'s `notify` callback,
+which fires exactly once, on the transition to disabled) but it is wired to
+nil: the email path is its own piece of work and has not been built. What a
+merchant actually gets is the disabled subscription in admin settings with
+its reason and timestamp, and a server-side warning log. That is weaker than
+this decision describes — a merchant who is not looking at admin is not told
+— and the email remains outstanding. Recorded here rather than left as an
+aspiration the code does not meet.
 
 Rejected: retrying forever. A dead endpoint would have the cluster making
 outbound requests indefinitely, and on a shared `db-f1-micro` with a small

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,247 @@
+# Outbound webhooks
+
+Mark8ly can notify your systems when things happen in your store — an order
+is placed, a return is approved, a product changes — by making a signed HTTP
+POST to an endpoint you register. This page is the merchant-facing reference
+for integrating with them: the event catalogue, the payload shape, how to
+verify the signature, and what your endpoint needs to handle.
+
+Webhooks are available on every plan. There is no gating by tier.
+
+Subscriptions, deliveries, replay and test sends are all managed from
+**Admin → Settings → Webhooks**.
+
+## Event catalogue
+
+A subscription selects one or more of the following 18 event types (from
+`internal/outbox`, the transactional event log every subscription reads
+from):
+
+| Event | Fires when |
+|---|---|
+| `product.created` | A product is created |
+| `product.updated` | A product is updated |
+| `product.deleted` | A product is deleted |
+| `category.created` | A category is created |
+| `category.updated` | A category is updated |
+| `category.deleted` | A category is deleted |
+| `order.placed` | An order is placed |
+| `order.confirmed` | An order is confirmed |
+| `order.fulfilled` | An order is fully fulfilled |
+| `order.partially_fulfilled` | An order is partially fulfilled |
+| `order.cancelled` | An order is cancelled |
+| `order.refunded` | An order is refunded |
+| `return.requested` | A return is requested |
+| `return.approved` | A return is approved |
+| `return.received` | A returned item is received |
+| `return.refunded` | A return is refunded |
+| `return.rejected` | A return is rejected |
+| `abandoned_cart.recovery_email` | An abandoned-cart recovery email is sent |
+
+A subscription may select up to 32 event types (`webhook.MaxEventTypes`) —
+comfortably more than the 18 that exist today, so the cap is only there to
+bound a malformed request, not to make you ration event types.
+
+## Payload shape
+
+Every delivery body is exactly three fields — "notify-and-fetch":
+
+```json
+{
+  "event": "order.placed",
+  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "occurred_at": "2026-09-02T14:03:11Z"
+}
+```
+
+- `event` — the event type, one of the values above.
+- `id` — the aggregate id (the order id, product id, etc.). Call the REST
+  API with this id to fetch the current state of the entity.
+- `occurred_at` — when the underlying domain event happened (UTC), not when
+  the delivery attempt was made.
+
+That's it — no order lines, no customer name or email, no addresses. Two
+reasons the payload is kept this thin, deliberately:
+
+1. **No customer PII reaches a merchant-supplied URL.** The delivery target
+   is arbitrary, external, and outside Mark8ly's control. A thin,
+   identifier-only payload means a webhook endpoint never becomes a place
+   customer data leaks to.
+2. **A retry can't deliver a stale entity.** Deliveries retry over hours (see
+   below). If the payload carried a snapshot of the order, a retried
+   delivery could hand you an order that has since changed — refunded,
+   cancelled, fulfilled — while the payload still claims the state at the
+   time of the original event. Fetching fresh from the API means you always
+   see the current truth, never a stale copy.
+
+Call the corresponding REST endpoint with the `id` to get the full entity.
+
+## Verifying the signature
+
+Every delivery carries an `X-Mark8ly-Signature` header, formatted:
+
+```
+t=<unix timestamp>,v1=<hex-encoded HMAC-SHA256>
+```
+
+`v1` is `HMAC-SHA256(secret, "<t>.<raw request body>")` — the timestamp is
+concatenated with a `.` and the exact raw JSON body, and that concatenation
+is what's HMAC'd with your subscription's signing secret.
+
+The timestamp is part of the **signed material itself**, not a sibling
+header you check separately. That is what makes rejecting a stale timestamp
+trustworthy: an attacker replaying an old, captured delivery cannot rewrite
+`t` to make it look recent without invalidating `v1`, because `t` is baked
+into the value the signature covers.
+
+Your signing secret is shown once, at subscription-creation time, and never
+returned by the API again — store it somewhere you can read back at
+verification time.
+
+### Worked example (Node.js)
+
+```js
+const crypto = require("crypto");
+
+// Replace with the secret shown when you created the subscription.
+// NEVER commit a real signing secret to source control.
+const WEBHOOK_SECRET = "whsec_REPLACE_ME";
+
+// Reject anything older than 5 minutes to defeat replay of a captured
+// delivery. Tune to your clock skew tolerance, but keep it tight — the
+// whole point of checking `t` is that it's recent.
+const MAX_AGE_SECONDS = 5 * 60;
+
+function verifyMark8lySignature(header, rawBody, secret) {
+  const parts = Object.fromEntries(
+    header.split(",").map((kv) => kv.split("=")),
+  );
+  const t = parts.t;
+  const v1 = parts.v1;
+  if (!t || !v1) {
+    throw new Error("malformed signature header");
+  }
+
+  // Reject stale deliveries BEFORE trusting anything else. This works only
+  // because `t` is signed material — see above.
+  const age = Math.abs(Date.now() / 1000 - Number(t));
+  if (age > MAX_AGE_SECONDS) {
+    throw new Error("stale webhook timestamp — possible replay");
+  }
+
+  // Recompute the HMAC over "<t>.<raw body>" — the exact bytes received,
+  // before any JSON.parse.
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(`${t}.${rawBody}`)
+    .digest("hex");
+
+  // Constant-time comparison — a naive `expected === v1` string compare
+  // leaks timing information an attacker can use to guess the signature
+  // byte by byte.
+  const a = Buffer.from(expected, "hex");
+  const b = Buffer.from(v1, "hex");
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+    throw new Error("signature mismatch");
+  }
+}
+
+// Express example — must use the RAW body, not a parsed one, since the
+// signature covers the exact bytes sent.
+app.post(
+  "/webhooks/mark8ly",
+  express.raw({ type: "application/json" }),
+  (req, res) => {
+    try {
+      verifyMark8lySignature(
+        req.header("X-Mark8ly-Signature"),
+        req.body, // Buffer — raw bytes
+        WEBHOOK_SECRET,
+      );
+    } catch (err) {
+      return res.status(401).send("invalid signature");
+    }
+
+    const payload = JSON.parse(req.body);
+    // ... handle payload.event / payload.id / payload.occurred_at ...
+    res.sendStatus(200);
+  },
+);
+```
+
+The same shape works in any language: split the header on `,` and `=`,
+reject a stale `t`, recompute HMAC-SHA256 over `"<t>.<raw body>"` with your
+secret, and compare with a constant-time comparison function (not `==`/
+`===`/`memcmp`-without-constant-time).
+
+## Delivery behaviour
+
+**At-least-once, not exactly-once.** A delivery can be sent more than once —
+after a retry whose success response was lost in transit, for example. Your
+endpoint must be idempotent: dedupe on the delivery, not just act on receipt.
+The delivery id is available in the admin delivery log; if you need a
+dedupe key from the payload itself, `event` + `id` + `occurred_at` together
+identify a specific delivery attempt's underlying event.
+
+**Retry with backoff.** A failed attempt (non-2xx response, or the request
+otherwise failing) is retried with exponential backoff: roughly 30s, 2m,
+8m, 32m, then ~2h before the final attempt — five retries after the
+initial send, six attempts total. (The backoff formula itself is capped at
+4h between attempts, but with only 6 attempts total that cap is never
+actually reached — the delay before the last attempt tops out around 2h.)
+This is spread over hours so a merchant endpoint that's briefly down (a
+deploy, a restart) has time to recover before attempts run out.
+
+**Dead-lettering.** After 6 attempts (`webhook.MaxAttempts`) a delivery is
+marked `failed` and kept — visible and replayable from admin — but no longer
+retried automatically.
+
+**Retention.** Delivery rows (successful and failed) are kept for 30 days
+(`webhook.RetentionWindow`) on every plan, then pruned. This is not a paid
+tier's extended log — treat the delivery log as a debugging aid for recent
+activity, not a permanent audit trail.
+
+**Auto-disable.** If a subscription accumulates 10 **consecutive** failures
+(`webhook.FailureThreshold`) — across different events, not just repeated
+attempts at the same one — the subscription is disabled automatically and
+you're notified, with the reason shown in admin. The threshold is
+deliberately higher than the per-delivery attempt cap so a single bad
+delivery can't take down an otherwise-working endpoint; it takes sustained
+failure. Once you've fixed your endpoint, re-enable the subscription from
+admin and replay the failed deliveries you want retried.
+
+## Endpoint requirements
+
+- **HTTPS only.** Plain `http://` URLs are rejected at registration.
+- **Publicly resolvable.** The hostname is resolved both when you register
+  the URL and again immediately before every delivery, and rejected if it
+  resolves to a private, loopback, link-local, or cloud-metadata address.
+  This means `localhost`, addresses on your office LAN, and cloud metadata
+  endpoints (e.g. `169.254.169.254`) can never be used as a webhook target —
+  including if a hostname that used to resolve publicly is later repointed
+  at one of those addresses.
+- **No redirects followed.** A 3xx response from your endpoint is not
+  followed. If your endpoint moves, update the registered URL directly.
+- **Respond 2xx to acknowledge.** Any status outside 200–299 is treated as a
+  failure and retried per the backoff schedule above.
+- **Respond promptly.** Requests are made with a short timeout; a slow
+  endpoint is indistinguishable from a failing one and will be retried the
+  same way.
+- **Response bodies are read but bounded.** On a failing response, a bounded
+  snippet of the body is captured and shown in your delivery log to help you
+  debug — but it is never logged server-side, since it's arbitrary remote
+  content. On success, the body is discarded unread beyond what's needed to
+  reuse the connection. Don't rely on returning data in the response body;
+  fetch state from the REST API instead.
+
+## Summary checklist
+
+- [ ] Endpoint is HTTPS, publicly resolvable, and does not redirect
+- [ ] Endpoint returns 2xx promptly on success
+- [ ] Signature is verified against the **raw** request body, not a
+      re-serialized/parsed one
+- [ ] `t` is checked for staleness before anything else
+- [ ] Comparison of the computed and received signature is constant-time
+- [ ] Handler is idempotent — safe to receive the same delivery twice
+- [ ] Handler calls the REST API for entity detail rather than assuming the
+      payload carries it

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -203,11 +203,19 @@ activity, not a permanent audit trail.
 
 **Auto-disable.** If a subscription accumulates 10 **consecutive** failures
 (`webhook.FailureThreshold`) — across different events, not just repeated
-attempts at the same one — the subscription is disabled automatically and
-you're notified, with the reason shown in admin. The threshold is
+attempts at the same one — the subscription is disabled automatically. The
+threshold is
 deliberately higher than the per-delivery attempt cap so a single bad
 delivery can't take down an otherwise-working endpoint; it takes sustained
-failure. Once you've fixed your endpoint, re-enable the subscription from
+failure. Any deliveries still queued for that subscription are marked
+`failed` rather than sent, so a disabled webhook stops making requests to
+your endpoint immediately.
+
+**Where a disabled webhook shows up.** Nothing is emailed to you today, so
+check admin: a disabled subscription appears in **Settings → Webhooks**
+marked as disabled, with the reason it was disabled and when. If deliveries
+stopped arriving and you are not sure why, that page is the place to look
+first. Once you've fixed your endpoint, re-enable the subscription from
 admin and replay the failed deliveries you want retried.
 
 ## Endpoint requirements

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1743,6 +1743,14 @@ func main() {
 		dispatcher := webhook.NewDispatcher(conn, whSubs, whDeliveries, log, 100)
 		webhookDispatcherDone = dispatcher.Start(webhookCtx, 5*time.Second)
 
+		// notify is nil: merchant notification on auto-disable is NOT wired
+		// yet. Design decision 3 describes emailing the merchant, and that
+		// email is still outstanding — see the design doc, which records
+		// what actually ships. What a merchant gets today is the disabled
+		// subscription surfaced in admin settings with its
+		// disabled_reason/disabled_at, plus a server-side warning log; a
+		// merchant who is not looking at admin learns nothing until they do.
+		// Known gap, deliberately not papered over here.
 		worker := webhook.NewWorker(whDeliveries, whSubs, whSender, log, 4, nil)
 		webhookWorkerDone = worker.Start(webhookCtx, 5*time.Second)
 

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -879,6 +879,20 @@ func main() {
 		// Coupon handler (Marketing M1).
 		couponHandler := admin.NewCouponHandler(couponSvc, log)
 
+		// Outbound webhooks admin API (#562 task 7). Its own SubscriptionRepo/
+		// DeliveryRepo/Sender instances, separate from the dispatcher and
+		// delivery worker wired further below — both sets are stateless
+		// wrappers over the same conn/ssrfguard, so nothing needs sharing
+		// between the HTTP surface and the background loops.
+		webhooksGuard := ssrfguard.New(nil)
+		webhooksHandler := admin.NewWebhooksHandler(
+			webhook.NewSubscriptionRepo(conn),
+			webhook.NewDeliveryRepo(conn),
+			webhooksGuard,
+			webhook.NewSender(webhooksGuard, nil),
+			log,
+		)
+
 		// Gift cards — Marketing M2.
 		giftCardRepo := giftcard.NewRepository()
 		// Delivery email rides the shared transport (log-only in dev).
@@ -1244,6 +1258,7 @@ func main() {
 			TicketsHandler:           ticketsHandler,
 			BrandingHandler:          brandingHandler,
 			PagesHandler:             pagesHandler,
+			WebhooksHandler:          webhooksHandler,
 			PlanResolver:             planResolver,
 			StoresMiddleware:         storeMW,
 			SubscriptionStatusLoader: readonly.LoadStatus(readonly.StatusLoaderConfig{DB: conn, Repo: subscriptionRepo, Logger: log}),

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -128,6 +128,8 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/ticket"
 	"github.com/mark8ly/marketplace-api/internal/userprofile"
 	"github.com/mark8ly/marketplace-api/internal/vendor"
+	"github.com/mark8ly/marketplace-api/internal/webhook"
+	"github.com/mark8ly/marketplace-api/internal/webhook/ssrfguard"
 	"github.com/mark8ly/marketplace-api/internal/webhookevents"
 	"github.com/mark8ly/marketplace-api/internal/webhookprune"
 	wlapple "github.com/mark8ly/marketplace-api/internal/whitelabel/apple"
@@ -1701,6 +1703,37 @@ func main() {
 		log.Info("outbox publisher started")
 	}
 
+	// Outbound webhooks (#562). Two loops beside the outbox publisher, on the
+	// same engines: a merchant subscription is admin-domain state, and the
+	// storefront replica must not run a second copy of either poll.
+	//
+	// In-process rather than a separate Deployment, deliberately. The
+	// alternative costs another chart, another ArgoCD Application and another
+	// pod's memory on a cluster that has already had rollouts deadlock under
+	// memory pressure. FOR UPDATE SKIP LOCKED makes both loops safe across
+	// KEDA replicas. The bounded worker batch and the 5s per-request timeout
+	// in internal/webhook cap what a slow merchant endpoint can tie up.
+	//
+	// Because dispatch and delivery are decoupled by webhook_deliveries,
+	// moving the delivery loop to its own workload later is a deployment
+	// change, not a redesign.
+	webhookCtx, webhookCancel := context.WithCancel(context.Background())
+	defer webhookCancel()
+	var webhookDispatcherDone, webhookWorkerDone <-chan struct{}
+	if m == mode.Admin || m == mode.Both {
+		whSubs := webhook.NewSubscriptionRepo(conn)
+		whDeliveries := webhook.NewDeliveryRepo(conn)
+		whSender := webhook.NewSender(ssrfguard.New(nil), nil)
+
+		dispatcher := webhook.NewDispatcher(conn, whSubs, whDeliveries, log, 100)
+		webhookDispatcherDone = dispatcher.Start(webhookCtx, 5*time.Second)
+
+		worker := webhook.NewWorker(whDeliveries, whSubs, whSender, log, 4, nil)
+		webhookWorkerDone = worker.Start(webhookCtx, 5*time.Second)
+
+		log.Info("webhook dispatcher and delivery worker started")
+	}
+
 	// Public country endpoint — available in ALL modes (admin, storefront, both).
 	// When storefront mode is active, it's already wired via storefrontDeps.
 	// For admin-only mode, we register it directly on the admin engine below.
@@ -2515,6 +2548,23 @@ func main() {
 			log.Info("outbox publisher stopped")
 		case <-time.After(5 * time.Second):
 			log.Warn("outbox publisher did not stop in time")
+		}
+	}
+	webhookCancel()
+	if webhookDispatcherDone != nil {
+		select {
+		case <-webhookDispatcherDone:
+			log.Info("webhook dispatcher stopped")
+		case <-time.After(5 * time.Second):
+			log.Warn("webhook dispatcher did not stop in time")
+		}
+	}
+	if webhookWorkerDone != nil {
+		select {
+		case <-webhookWorkerDone:
+			log.Info("webhook delivery worker stopped")
+		case <-time.After(5 * time.Second):
+			log.Warn("webhook delivery worker did not stop in time")
 		}
 	}
 	workerCancel()

--- a/services/marketplace-api/cmd/webhook-delivery-prune-cron/main.go
+++ b/services/marketplace-api/cmd/webhook-delivery-prune-cron/main.go
@@ -1,10 +1,16 @@
-// Command webhook-prune-cron deletes webhook_deliveries rows past the
-// retention window (webhook.RetentionWindow — 30 days on every plan).
+// Command webhook-delivery-prune-cron deletes webhook_deliveries rows past
+// the retention window (webhook.RetentionWindow — 30 days on every plan).
 // webhook_deliveries carries delivery bodies for merchant-configured
-// outbound webhooks (#562): storage cost on a shared db-f1-micro with no
+// OUTBOUND webhooks (#562): storage cost on a shared db-f1-micro with no
 // matching merchant value once a delivery is old enough that nobody is
 // going to replay it. Deliberately NOT tied to FeatureAuditRetentionDays —
 // see DeliveryRepo.Prune for why "forever" on Pro does not apply here.
+//
+// NOT internal/webhookprune. That package prunes webhook_events — the raw
+// INBOUND provider (Stripe) event log — on a different 30/90-day age split
+// and runs in-process on the trial scheduler inside cmd/marketplace-api.
+// Near-identical names, different tables: this binary is the standalone
+// k8s CronJob for the outbound delivery table only.
 //
 // Designed to run as a Cloud Run Job on a Cloud Scheduler trigger (daily).
 // Exits non-zero only on infrastructure failures (DB connection, etc.) — a
@@ -26,13 +32,13 @@ func main() {
 
 	databaseURL := os.Getenv("DATABASE_URL")
 	if databaseURL == "" {
-		log.Error("webhook-prune-cron: DATABASE_URL not set")
+		log.Error("webhook-delivery-prune-cron: DATABASE_URL not set")
 		os.Exit(1)
 	}
 
 	conn, err := db.Open(databaseURL)
 	if err != nil {
-		log.Error("webhook-prune-cron: db open failed", "err", err)
+		log.Error("webhook-delivery-prune-cron: db open failed", "err", err)
 		os.Exit(1)
 	}
 
@@ -43,9 +49,9 @@ func main() {
 
 	n, err := deliveries.Prune(ctx, webhook.RetentionWindow)
 	if err != nil {
-		log.Error("webhook-prune-cron: run failed", "err", err)
+		log.Error("webhook-delivery-prune-cron: run failed", "err", err)
 		os.Exit(1)
 	}
 
-	log.Info("webhook-prune-cron: done", "pruned", n)
+	log.Info("webhook-delivery-prune-cron: done", "pruned", n)
 }

--- a/services/marketplace-api/cmd/webhook-prune-cron/main.go
+++ b/services/marketplace-api/cmd/webhook-prune-cron/main.go
@@ -1,0 +1,51 @@
+// Command webhook-prune-cron deletes webhook_deliveries rows past the
+// retention window (webhook.RetentionWindow — 30 days on every plan).
+// webhook_deliveries carries delivery bodies for merchant-configured
+// outbound webhooks (#562): storage cost on a shared db-f1-micro with no
+// matching merchant value once a delivery is old enough that nobody is
+// going to replay it. Deliberately NOT tied to FeatureAuditRetentionDays —
+// see DeliveryRepo.Prune for why "forever" on Pro does not apply here.
+//
+// Designed to run as a Cloud Run Job on a Cloud Scheduler trigger (daily).
+// Exits non-zero only on infrastructure failures (DB connection, etc.) — a
+// prune that removes zero rows is a normal, successful run.
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/webhook"
+	"github.com/mark8ly/marketplace-api/pkg/db"
+)
+
+func main() {
+	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		log.Error("webhook-prune-cron: DATABASE_URL not set")
+		os.Exit(1)
+	}
+
+	conn, err := db.Open(databaseURL)
+	if err != nil {
+		log.Error("webhook-prune-cron: db open failed", "err", err)
+		os.Exit(1)
+	}
+
+	deliveries := webhook.NewDeliveryRepo(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	n, err := deliveries.Prune(ctx, webhook.RetentionWindow)
+	if err != nil {
+		log.Error("webhook-prune-cron: run failed", "err", err)
+		os.Exit(1)
+	}
+
+	log.Info("webhook-prune-cron: done", "pruned", n)
+}

--- a/services/marketplace-api/internal/handlers/admin/products_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/products_integration_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/stores"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 	"github.com/mark8ly/marketplace-api/internal/vendor"
+	"github.com/mark8ly/marketplace-api/internal/webhook"
+	"github.com/mark8ly/marketplace-api/internal/webhook/ssrfguard"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
@@ -72,6 +74,8 @@ var productsTables = []string{
 	"product_categories",
 	"products",
 	"categories",
+	"webhook_deliveries",
+	"webhook_subscriptions",
 	"stores",
 }
 
@@ -130,6 +134,20 @@ func setupTestRouter(t *testing.T) *testEnv {
 	subHandler := admin.NewSubscriptionHandler(subSvc, nil)
 	promoHandler := admin.NewPromoHandler(db, promo.NewService(db, promo.NewRepository(), nil, nil), subscription.NewRepository(), nil)
 
+	// Outbound webhooks (#562 task 7). webhookTestResolver (defined in
+	// webhooks_test.go) answers public for any host except a couple of
+	// deliberately-private/unresolvable test hostnames, so SSRF-rejection
+	// tests need no real DNS and httptest servers (loopback, a literal IP
+	// host) still work via ssrfguard's documented literal-IP test path.
+	whGuard := ssrfguard.New(webhookTestResolver)
+	webhooksHandler := admin.NewWebhooksHandler(
+		webhook.NewSubscriptionRepo(db),
+		webhook.NewDeliveryRepo(db),
+		whGuard,
+		webhook.NewSender(whGuard, nil),
+		nil,
+	)
+
 	r := gin.New()
 	admin.RegisterAdmin(r.Group("/api/v1"), admin.Deps{
 		ProductHandler:      handler,
@@ -139,6 +157,7 @@ func setupTestRouter(t *testing.T) *testEnv {
 		SubscriptionHandler: subHandler,
 		PromoHandler:        promoHandler,
 		WarehousesHandler:   admin.NewWarehousesHandler(db, nil),
+		WebhooksHandler:     webhooksHandler,
 		StoresMiddleware:    storeMW,
 		AuthzMiddleware:     authzMW,
 		InternalSecret:      "",

--- a/services/marketplace-api/internal/handlers/admin/route_parity_test.go
+++ b/services/marketplace-api/internal/handlers/admin/route_parity_test.go
@@ -67,6 +67,7 @@ var webOnlySubtrees = map[string]string{
 	"/stores/:storeId/subscription":             "plan, invoices, checkout, promo, cancel — all billing is web-only (app-store policy + PCI surface)",
 	"/stores/:storeId/tax":                      "tax-ID submission + US/CA attestation — legal attestation flow, web-only by design",
 	"/stores/:storeId/warehouses":               "warehouse CRUD (#177 PR 5b) — address forms + drag-to-reorder, a desktop settings task; mobile ships no warehouse screen. If mobile ever wants a read-only list, replace this subtree with exact webOnlyRoutes entries.",
+	"/stores/:storeId/webhooks":                 "outbound webhook subscriptions (#562) — URL registration, secrets and delivery logs are a developer-integration task; no mobile UI planned.",
 }
 
 // webOnlyRoutes exempts a single route INSIDE a group mobile does mirror.

--- a/services/marketplace-api/internal/handlers/admin/routes.go
+++ b/services/marketplace-api/internal/handlers/admin/routes.go
@@ -73,15 +73,19 @@ type Deps struct {
 	// P13 — break-glass emergency admin login (§12.4). Mounted OUTSIDE
 	// the store-scoped + RequireActive group: this is the recovery
 	// path, it must survive read-only / store_closed states.
-	BreakGlassLoginHandler   *BreakGlassLoginHandler
-	AuditLogsHandler         *AuditLogsHandler
-	NotificationsHandler     *NotificationsHandler
-	DashboardHandler         *DashboardHandler
-	SetupProgressHandler     *SetupProgressHandler
-	TicketsHandler           *TicketsHandler
-	ShipmentsHandler         *ShipmentsHandler
-	BrandingHandler          *BrandingHandler
-	PagesHandler             *PagesHandler
+	BreakGlassLoginHandler *BreakGlassLoginHandler
+	AuditLogsHandler       *AuditLogsHandler
+	NotificationsHandler   *NotificationsHandler
+	DashboardHandler       *DashboardHandler
+	SetupProgressHandler   *SetupProgressHandler
+	TicketsHandler         *TicketsHandler
+	ShipmentsHandler       *ShipmentsHandler
+	BrandingHandler        *BrandingHandler
+	PagesHandler           *PagesHandler
+	// Outbound webhooks (#562 task 7) — merchant-managed subscriptions,
+	// test sends and delivery replay. Available on every plan, so
+	// deliberately not gated behind PlanResolver like SSO above.
+	WebhooksHandler          *WebhooksHandler
 	PlanResolver             *plangate.PlanResolver
 	StoresMiddleware         gin.HandlerFunc // from stores.StoreMiddleware
 	SubscriptionStatusLoader gin.HandlerFunc // optional; runs after StoresMiddleware
@@ -962,6 +966,34 @@ func RegisterAdmin(router *gin.RouterGroup, deps Deps) {
 				pagesGroup.DELETE("/:id",
 					deps.AuthzMiddleware.RequireTenantRelation(authz.PageEditRole),
 					deps.PagesHandler.Delete)
+			}
+		}
+
+		// Outbound webhooks — #562 task 7.
+		if deps.WebhooksHandler != nil {
+			webhooks := storeRoute.Group("/webhooks")
+			{
+				webhooks.GET("",
+					deps.AuthzMiddleware.RequireTenantRelation(authz.RoleStaff),
+					deps.WebhooksHandler.List)
+				webhooks.POST("",
+					deps.AuthzMiddleware.RequireTenantRelation(authz.RoleAdmin),
+					deps.WebhooksHandler.Create)
+				webhooks.PATCH("/:id",
+					deps.AuthzMiddleware.RequireTenantRelation(authz.RoleAdmin),
+					deps.WebhooksHandler.Patch)
+				webhooks.DELETE("/:id",
+					deps.AuthzMiddleware.RequireTenantRelation(authz.RoleAdmin),
+					deps.WebhooksHandler.Delete)
+				webhooks.POST("/:id/test",
+					deps.AuthzMiddleware.RequireTenantRelation(authz.RoleAdmin),
+					deps.WebhooksHandler.TestSend)
+				webhooks.GET("/:id/deliveries",
+					deps.AuthzMiddleware.RequireTenantRelation(authz.RoleStaff),
+					deps.WebhooksHandler.ListDeliveries)
+				webhooks.POST("/:id/deliveries/:deliveryID/replay",
+					deps.AuthzMiddleware.RequireTenantRelation(authz.RoleAdmin),
+					deps.WebhooksHandler.ReplayDelivery)
 			}
 		}
 	}

--- a/services/marketplace-api/internal/handlers/admin/webhooks.go
+++ b/services/marketplace-api/internal/handlers/admin/webhooks.go
@@ -437,6 +437,13 @@ func (h *WebhooksHandler) ListDeliveries(c *gin.Context) {
 // retries it. Scoped through ownedSubscription first, then again by
 // subscription id in the UPDATE itself, so a deliveryID that belongs to
 // another tenant's subscription can never be replayed by guessing it.
+//
+// A delivery that is ALREADY pending is not replayable and answers 404
+// here: it may be leased by a worker mid-send right now, and resetting
+// next_attempt_at under that lease would let a second worker claim and
+// send it too. It is also pointless — a pending delivery is already going
+// to be attempted. The admin UI only offers the button on settled rows;
+// this is the enforcement behind that.
 func (h *WebhooksHandler) ReplayDelivery(c *gin.Context) {
 	tenantID, storeID, ok := h.scope(c)
 	if !ok {

--- a/services/marketplace-api/internal/handlers/admin/webhooks.go
+++ b/services/marketplace-api/internal/handlers/admin/webhooks.go
@@ -1,0 +1,466 @@
+// Package admin — webhooks.go: the merchant-facing admin API for outbound
+// webhook subscriptions, mounted at /admin/stores/:storeId/webhooks (#562
+// task 7).
+//
+// Every handler here scopes its query on the tenant and store the auth
+// middleware chain already resolved (c.GetString("tenant_id"), the
+// :storeId path param FGA has already checked ownership of) — never on a
+// value from the request body. A subscription or delivery id that does not
+// belong to that (tenant, store) pair is reported as 404, exactly like an
+// id that does not exist at all, so guessing a UUID cannot distinguish
+// "not yours" from "doesn't exist".
+package admin
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+
+	"github.com/mark8ly/marketplace-api/internal/outbox"
+	"github.com/mark8ly/marketplace-api/internal/webhook"
+	"github.com/mark8ly/marketplace-api/internal/webhook/ssrfguard"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+)
+
+// allowedEventTypes is the closed set a subscription may select, built from
+// internal/outbox's 18 Event* constants. Validating against it turns a
+// typo into a 400 at registration instead of a subscription that silently
+// never fires — which reads to a merchant as a broken product, not a typo.
+var allowedEventTypes = map[string]bool{
+	outbox.EventOrderPlaced:                true,
+	outbox.EventOrderConfirmed:             true,
+	outbox.EventOrderFulfilled:             true,
+	outbox.EventOrderPartiallyFulfilled:    true,
+	outbox.EventOrderCancelled:             true,
+	outbox.EventOrderRefunded:              true,
+	outbox.EventReturnRequested:            true,
+	outbox.EventReturnApproved:             true,
+	outbox.EventReturnReceived:             true,
+	outbox.EventReturnRefunded:             true,
+	outbox.EventReturnRejected:             true,
+	outbox.EventProductCreated:             true,
+	outbox.EventProductUpdated:             true,
+	outbox.EventProductDeleted:             true,
+	outbox.EventCategoryCreated:            true,
+	outbox.EventCategoryUpdated:            true,
+	outbox.EventCategoryDeleted:            true,
+	outbox.EventAbandonedCartRecoveryEmail: true,
+}
+
+// testEventType is the synthetic event name a test-send carries. It is
+// deliberately not in allowedEventTypes — a merchant can never subscribe
+// to it directly.
+const testEventType = "webhook.test"
+
+// deliveryListLimit bounds how many recent deliveries one GET returns.
+const deliveryListLimit = 50
+
+// WebhooksHandler serves the per-store outbound webhook admin endpoints.
+type WebhooksHandler struct {
+	subs       *webhook.SubscriptionRepo
+	deliveries *webhook.DeliveryRepo
+	guard      *ssrfguard.Guard
+	sender     *webhook.Sender
+	logger     *slog.Logger
+}
+
+// NewWebhooksHandler constructs a WebhooksHandler.
+func NewWebhooksHandler(subs *webhook.SubscriptionRepo, deliveries *webhook.DeliveryRepo, guard *ssrfguard.Guard, sender *webhook.Sender, logger *slog.Logger) *WebhooksHandler {
+	return &WebhooksHandler{subs: subs, deliveries: deliveries, guard: guard, sender: sender, logger: logger}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Wire types
+// ─────────────────────────────────────────────────────────────────────────
+
+// CreateWebhookRequest is the POST /webhooks body.
+type CreateWebhookRequest struct {
+	URL        string   `json:"url" binding:"required"`
+	EventTypes []string `json:"event_types" binding:"required"`
+}
+
+// PatchWebhookRequest is the PATCH /webhooks/:id body. Every field is
+// optional — only the fields present are changed.
+type PatchWebhookRequest struct {
+	URL        *string  `json:"url"`
+	EventTypes []string `json:"event_types"`
+	Enabled    *bool    `json:"enabled"`
+}
+
+// WebhookResponse is one subscription on the wire. It deliberately has no
+// secret field — the create handler puts the secret in a sibling response
+// field instead of on this struct, so reusing toWebhookResponse for
+// List/Get/Patch can never leak it.
+type WebhookResponse struct {
+	ID             string     `json:"id"`
+	URL            string     `json:"url"`
+	EventTypes     []string   `json:"event_types"`
+	Enabled        bool       `json:"enabled"`
+	DisabledReason *string    `json:"disabled_reason,omitempty"`
+	DisabledAt     *time.Time `json:"disabled_at,omitempty"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+}
+
+func toWebhookResponse(s *webhook.Subscription) WebhookResponse {
+	return WebhookResponse{
+		ID:             s.ID.String(),
+		URL:            s.URL,
+		EventTypes:     []string(s.EventTypes),
+		Enabled:        s.Enabled,
+		DisabledReason: s.DisabledReason,
+		DisabledAt:     s.DisabledAt,
+		CreatedAt:      s.CreatedAt,
+		UpdatedAt:      s.UpdatedAt,
+	}
+}
+
+// DeliveryResponse is one delivery attempt on the wire.
+type DeliveryResponse struct {
+	ID             string     `json:"id"`
+	EventType      string     `json:"event_type"`
+	AggregateID    string     `json:"aggregate_id"`
+	Status         string     `json:"status"`
+	Attempts       int        `json:"attempts"`
+	NextAttemptAt  time.Time  `json:"next_attempt_at"`
+	LastStatusCode *int       `json:"last_status_code,omitempty"`
+	LastError      *string    `json:"last_error,omitempty"`
+	DeliveredAt    *time.Time `json:"delivered_at,omitempty"`
+	CreatedAt      time.Time  `json:"created_at"`
+}
+
+func toDeliveryResponse(d *webhook.Delivery) DeliveryResponse {
+	return DeliveryResponse{
+		ID:             d.ID.String(),
+		EventType:      d.EventType,
+		AggregateID:    d.AggregateID.String(),
+		Status:         d.Status,
+		Attempts:       d.Attempts,
+		NextAttemptAt:  d.NextAttemptAt,
+		LastStatusCode: d.LastStatusCode,
+		LastError:      d.LastError,
+		DeliveredAt:    d.DeliveredAt,
+		CreatedAt:      d.CreatedAt,
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Validation helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+// validateEventTypes enforces the closed vocabulary and the MaxEventTypes
+// cap. A caller must pass at least one type — an empty selection is a
+// subscription that can never fire, which is exactly the "looks alive but
+// is dead" failure mode this handler exists to prevent at registration.
+func validateEventTypes(types []string) *apperrors.Error {
+	if len(types) == 0 {
+		return apperrors.ValidationFailed("event_types", "at least one event type is required")
+	}
+	if len(types) > webhook.MaxEventTypes {
+		return apperrors.ValidationFailed("event_types",
+			fmt.Sprintf("a subscription may select at most %d event types", webhook.MaxEventTypes))
+	}
+	for _, t := range types {
+		if !allowedEventTypes[t] {
+			return apperrors.ValidationFailed("event_types", fmt.Sprintf("unknown event type %q", t))
+		}
+	}
+	return nil
+}
+
+// mapSSRFErr turns an ssrfguard error into a distinct, human message — a
+// merchant needs to know WHICH rule their URL hit, not just "invalid url".
+func mapSSRFErr(err error) *apperrors.Error {
+	switch {
+	case errors.Is(err, ssrfguard.ErrNotHTTPS):
+		return apperrors.ValidationFailed("url", "webhook url must use https")
+	case errors.Is(err, ssrfguard.ErrPrivateAddress):
+		return apperrors.ValidationFailed("url", "webhook url resolves to a private or otherwise non-public address")
+	case errors.Is(err, ssrfguard.ErrUnresolvable):
+		return apperrors.ValidationFailed("url", "webhook url host could not be resolved")
+	case errors.Is(err, ssrfguard.ErrTooLong):
+		return apperrors.ValidationFailed("url", "webhook url is too long")
+	case errors.Is(err, ssrfguard.ErrMalformed):
+		return apperrors.ValidationFailed("url", "webhook url is malformed")
+	default:
+		return apperrors.ValidationFailed("url", "webhook url is invalid")
+	}
+}
+
+// scope reads the tenant id the auth middleware set on the context and the
+// store id the store middleware has already verified ownership of. Neither
+// ever comes from the request body.
+func (h *WebhooksHandler) scope(c *gin.Context) (tenantID, storeID uuid.UUID, ok bool) {
+	storeID, err := uuid.Parse(c.Param("storeId"))
+	if err != nil {
+		RespondErr(c, apperrors.ValidationFailed("storeId", "invalid uuid"), h.logger)
+		return uuid.Nil, uuid.Nil, false
+	}
+	tenantID, err = uuid.Parse(c.GetString("tenant_id"))
+	if err != nil {
+		RespondErr(c, apperrors.ValidationFailed("tenant_id", "invalid uuid"), h.logger)
+		return uuid.Nil, uuid.Nil, false
+	}
+	return tenantID, storeID, true
+}
+
+// ownedSubscription fetches the subscription named by the :id path param
+// and verifies it belongs to (tenantID, storeID). A subscription that
+// exists but belongs to someone else is reported identically to one that
+// does not exist — the security boundary this whole file exists for.
+func (h *WebhooksHandler) ownedSubscription(c *gin.Context, tenantID, storeID uuid.UUID) (*webhook.Subscription, bool) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		RespondErr(c, apperrors.ValidationFailed("id", "invalid uuid"), h.logger)
+		return nil, false
+	}
+	sub, err := h.subs.ByID(c.Request.Context(), id)
+	if err != nil {
+		RespondErr(c, err, h.logger)
+		return nil, false
+	}
+	if sub == nil || sub.TenantID != tenantID || sub.StoreID != storeID {
+		RespondErr(c, apperrors.NotFound("webhook subscription"), h.logger)
+		return nil, false
+	}
+	return sub, true
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Handlers
+// ─────────────────────────────────────────────────────────────────────────
+
+// Create handles POST /admin/stores/:storeId/webhooks. Runs the SSRF guard
+// and the event-type check before ever generating a secret or touching the
+// database, and returns the secret exactly once — it never leaves the
+// server again after this response (Subscription.Secret is json:"-").
+func (h *WebhooksHandler) Create(c *gin.Context) {
+	tenantID, storeID, ok := h.scope(c)
+	if !ok {
+		return
+	}
+
+	var req CreateWebhookRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		RespondErr(c, apperrors.ValidationFailed("body", err.Error()), h.logger)
+		return
+	}
+	if _, err := h.guard.Check(req.URL); err != nil {
+		RespondErr(c, mapSSRFErr(err), h.logger)
+		return
+	}
+	if verr := validateEventTypes(req.EventTypes); verr != nil {
+		RespondErr(c, verr, h.logger)
+		return
+	}
+
+	secret, err := webhook.GenerateSecret()
+	if err != nil {
+		RespondErr(c, fmt.Errorf("webhooks: generate secret: %w", err), h.logger)
+		return
+	}
+
+	sub := &webhook.Subscription{
+		TenantID:   tenantID,
+		StoreID:    storeID,
+		URL:        req.URL,
+		EventTypes: pq.StringArray(req.EventTypes),
+		Secret:     secret,
+		Enabled:    true,
+	}
+	if err := h.subs.Create(c.Request.Context(), sub); err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"data":   toWebhookResponse(sub),
+		"secret": secret,
+	})
+}
+
+// List handles GET /admin/stores/:storeId/webhooks, scoped to the caller's
+// tenant and store.
+func (h *WebhooksHandler) List(c *gin.Context) {
+	tenantID, storeID, ok := h.scope(c)
+	if !ok {
+		return
+	}
+	subs, err := h.subs.ListForStore(c.Request.Context(), tenantID, storeID)
+	if err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+	out := make([]WebhookResponse, 0, len(subs))
+	for i := range subs {
+		out = append(out, toWebhookResponse(&subs[i]))
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out})
+}
+
+// Patch handles PATCH /admin/stores/:storeId/webhooks/:id — url, event
+// types and enabled are each optional. Re-enabling a subscription clears
+// the auto-disable bookkeeping, since it no longer describes the current
+// state once a merchant has acted on it.
+func (h *WebhooksHandler) Patch(c *gin.Context) {
+	tenantID, storeID, ok := h.scope(c)
+	if !ok {
+		return
+	}
+	sub, ok := h.ownedSubscription(c, tenantID, storeID)
+	if !ok {
+		return
+	}
+
+	var req PatchWebhookRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		RespondErr(c, apperrors.ValidationFailed("body", err.Error()), h.logger)
+		return
+	}
+
+	updated := *sub
+	if req.URL != nil {
+		if _, err := h.guard.Check(*req.URL); err != nil {
+			RespondErr(c, mapSSRFErr(err), h.logger)
+			return
+		}
+		updated.URL = *req.URL
+	}
+	if req.EventTypes != nil {
+		if verr := validateEventTypes(req.EventTypes); verr != nil {
+			RespondErr(c, verr, h.logger)
+			return
+		}
+		updated.EventTypes = pq.StringArray(req.EventTypes)
+	}
+	if req.Enabled != nil {
+		updated.Enabled = *req.Enabled
+		if *req.Enabled {
+			updated.DisabledReason = nil
+			updated.DisabledAt = nil
+			updated.ConsecutiveFailures = 0
+		}
+	}
+
+	if err := h.subs.Update(c.Request.Context(), &updated); err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": toWebhookResponse(&updated)})
+}
+
+// Delete handles DELETE /admin/stores/:storeId/webhooks/:id.
+func (h *WebhooksHandler) Delete(c *gin.Context) {
+	tenantID, storeID, ok := h.scope(c)
+	if !ok {
+		return
+	}
+	sub, ok := h.ownedSubscription(c, tenantID, storeID)
+	if !ok {
+		return
+	}
+	if err := h.subs.Delete(c.Request.Context(), sub.ID); err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "webhook subscription deleted"})
+}
+
+// TestSend handles POST /admin/stores/:storeId/webhooks/:id/test. It builds
+// a synthetic delivery — never persisted, never fanned out — and calls the
+// same Sender the real delivery worker uses, so a merchant can debug their
+// endpoint without waiting for a real event.
+//
+// The Send error (which may embed the endpoint's response body) is
+// returned to the merchant in the JSON body, exactly like a real delivery
+// record would surface it — but it is NEVER passed to RespondErr/the
+// logger, which would log it server-side.
+func (h *WebhooksHandler) TestSend(c *gin.Context) {
+	tenantID, storeID, ok := h.scope(c)
+	if !ok {
+		return
+	}
+	sub, ok := h.ownedSubscription(c, tenantID, storeID)
+	if !ok {
+		return
+	}
+
+	delivery := webhook.Delivery{
+		ID:             uuid.New(),
+		SubscriptionID: sub.ID,
+		OutboxEventID:  uuid.New(),
+		EventType:      testEventType,
+		AggregateID:    uuid.New(),
+		CreatedAt:      time.Now(),
+	}
+	status, sendErr := h.sender.Send(c.Request.Context(), *sub, delivery)
+
+	resp := gin.H{"status_code": status, "success": sendErr == nil}
+	if sendErr != nil {
+		resp["error"] = sendErr.Error()
+	}
+	c.JSON(http.StatusOK, gin.H{"data": resp})
+}
+
+// ListDeliveries handles GET /admin/stores/:storeId/webhooks/:id/deliveries.
+func (h *WebhooksHandler) ListDeliveries(c *gin.Context) {
+	tenantID, storeID, ok := h.scope(c)
+	if !ok {
+		return
+	}
+	sub, ok := h.ownedSubscription(c, tenantID, storeID)
+	if !ok {
+		return
+	}
+
+	deliveries, err := h.deliveries.ListForSubscription(c.Request.Context(), sub.ID, deliveryListLimit)
+	if err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+	out := make([]DeliveryResponse, 0, len(deliveries))
+	for i := range deliveries {
+		out = append(out, toDeliveryResponse(&deliveries[i]))
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out})
+}
+
+// ReplayDelivery handles
+// POST /admin/stores/:storeId/webhooks/:id/deliveries/:deliveryID/replay.
+// It resets the delivery to pending, due now, so the worker's next poll
+// retries it. Scoped through ownedSubscription first, then again by
+// subscription id in the UPDATE itself, so a deliveryID that belongs to
+// another tenant's subscription can never be replayed by guessing it.
+func (h *WebhooksHandler) ReplayDelivery(c *gin.Context) {
+	tenantID, storeID, ok := h.scope(c)
+	if !ok {
+		return
+	}
+	sub, ok := h.ownedSubscription(c, tenantID, storeID)
+	if !ok {
+		return
+	}
+
+	deliveryID, err := uuid.Parse(c.Param("deliveryID"))
+	if err != nil {
+		RespondErr(c, apperrors.ValidationFailed("deliveryID", "invalid uuid"), h.logger)
+		return
+	}
+
+	found, err := h.deliveries.Replay(c.Request.Context(), sub.ID, deliveryID)
+	if err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+	if !found {
+		RespondErr(c, apperrors.NotFound("webhook delivery"), h.logger)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "delivery reset to pending"})
+}

--- a/services/marketplace-api/internal/handlers/admin/webhooks_test.go
+++ b/services/marketplace-api/internal/handlers/admin/webhooks_test.go
@@ -1,0 +1,363 @@
+//go:build integration
+
+package admin_test
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/authz"
+	"github.com/mark8ly/marketplace-api/internal/webhook"
+)
+
+// webhookTestResolver backs the whGuard built in setupTestRouter. It answers
+// "public" for any host by default — including a literal loopback IP host
+// like an httptest server's — and only carves out the couple of hostnames
+// these tests deliberately use to exercise SSRF rejection, so no test here
+// depends on real DNS. See ssrfguard's Send tests (allowAll) for the same
+// pattern.
+func webhookTestResolver(host string) ([]net.IP, error) {
+	switch host {
+	case "private.example.com":
+		return []net.IP{net.ParseIP("10.0.0.5")}, nil
+	case "unresolvable.example.com":
+		return nil, net.UnknownNetworkError("no such host (test resolver)")
+	default:
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+}
+
+func webhooksURL(storeID string) string {
+	return "/api/v1/admin/stores/" + storeID + "/webhooks"
+}
+
+func webhookCreateBody(url string, eventTypes []string) map[string]any {
+	return map[string]any{"url": url, "event_types": eventTypes}
+}
+
+// createWebhook posts a valid subscription and returns (id, secret).
+func createWebhook(t *testing.T, env *testEnv, storeID, tenantID, userID string) (string, string) {
+	t.Helper()
+	w := request(t, env.router, http.MethodPost, webhooksURL(storeID),
+		webhookCreateBody("https://public.example.com/hooks", []string{"order.placed"}),
+		authHeaders(userID, tenantID))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create webhook: status = %d, body = %s", w.Code, w.Body.String())
+	}
+	data := dataObject(t, w.Body.Bytes())
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	secret, _ := resp["secret"].(string)
+	return data["id"].(string), secret
+}
+
+func webhookOwnerEnv(t *testing.T) (*testEnv, string, string, string) {
+	t.Helper()
+	env := setupTestRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+	env.fga.Grant(userID, authz.RoleAdmin, tenantID)
+	env.fga.Grant(userID, authz.RoleStaff, tenantID)
+	return env, storeID, tenantID, userID
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+func TestCreate_RejectsNonPublicURL(t *testing.T) {
+	env, storeID, tenantID, userID := webhookOwnerEnv(t)
+
+	w := request(t, env.router, http.MethodPost, webhooksURL(storeID),
+		webhookCreateBody("https://private.example.com/hooks", []string{"order.placed"}),
+		authHeaders(userID, tenantID))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["error"] != "validation_failed" {
+		t.Fatalf("expected validation_failed, got %v (%s)", resp["error"], w.Body.String())
+	}
+}
+
+func TestCreate_RejectsPlainHTTP(t *testing.T) {
+	env, storeID, tenantID, userID := webhookOwnerEnv(t)
+
+	w := request(t, env.router, http.MethodPost, webhooksURL(storeID),
+		webhookCreateBody("http://public.example.com/hooks", []string{"order.placed"}),
+		authHeaders(userID, tenantID))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreate_RejectsUnknownEventType(t *testing.T) {
+	env, storeID, tenantID, userID := webhookOwnerEnv(t)
+
+	w := request(t, env.router, http.MethodPost, webhooksURL(storeID),
+		webhookCreateBody("https://public.example.com/hooks", []string{"order.teleported"}),
+		authHeaders(userID, tenantID))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["error"] != "validation_failed" {
+		t.Fatalf("expected validation_failed, got %v (%s)", resp["error"], w.Body.String())
+	}
+}
+
+func TestCreate_RejectsMoreThanMaxEventTypes(t *testing.T) {
+	env, storeID, tenantID, userID := webhookOwnerEnv(t)
+
+	types := make([]string, 0, webhook.MaxEventTypes+1)
+	for i := 0; i < webhook.MaxEventTypes+1; i++ {
+		types = append(types, "order.placed")
+	}
+
+	w := request(t, env.router, http.MethodPost, webhooksURL(storeID),
+		webhookCreateBody("https://public.example.com/hooks", types),
+		authHeaders(userID, tenantID))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreate_ReturnsTheSecretExactlyOnce(t *testing.T) {
+	env, storeID, tenantID, userID := webhookOwnerEnv(t)
+
+	w := request(t, env.router, http.MethodPost, webhooksURL(storeID),
+		webhookCreateBody("https://public.example.com/hooks", []string{"order.placed"}),
+		authHeaders(userID, tenantID))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var createResp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &createResp)
+	secret, _ := createResp["secret"].(string)
+	if secret == "" {
+		t.Fatalf("create response missing secret: %s", w.Body.String())
+	}
+	data, _ := createResp["data"].(map[string]any)
+	if _, ok := data["secret"]; ok {
+		t.Fatalf("secret must not also appear inside data: %s", w.Body.String())
+	}
+	id, _ := data["id"].(string)
+
+	// A subsequent GET (via List, the only read endpoint) must not carry it.
+	lw := request(t, env.router, http.MethodGet, webhooksURL(storeID), nil, authHeaders(userID, tenantID))
+	if lw.Code != http.StatusOK {
+		t.Fatalf("list: status = %d, body = %s", lw.Code, lw.Body.String())
+	}
+	items := dataArray(t, lw.Body.Bytes())
+	found := false
+	for _, raw := range items {
+		item, _ := raw.(map[string]any)
+		if item["id"] == id {
+			found = true
+			if _, ok := item["secret"]; ok {
+				t.Fatalf("list response must never carry secret: %s", lw.Body.String())
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("created webhook not found in list: %s", lw.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+func TestList_ScopesToTheCallersTenantAndStore(t *testing.T) {
+	env, storeID, tenantID, userID := webhookOwnerEnv(t)
+	createWebhook(t, env, storeID, tenantID, userID)
+
+	// A different tenant/store must see none of it.
+	otherStoreID, otherTenantID := seedStoreRow(t, env.db, "")
+	otherUserID := uuid.NewString()
+	env.fga.Grant(otherUserID, authz.RoleStaff, otherTenantID)
+
+	w := request(t, env.router, http.MethodGet, webhooksURL(otherStoreID), nil, authHeaders(otherUserID, otherTenantID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	items := dataArray(t, w.Body.Bytes())
+	if len(items) != 0 {
+		t.Fatalf("expected no subscriptions visible to another tenant, got %s", w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Cross-tenant access is refused everywhere an :id is taken from the path.
+// ---------------------------------------------------------------------------
+
+func TestCrossTenantAccess_IsRefusedOnEveryIDRoute(t *testing.T) {
+	env, storeID, tenantID, userID := webhookOwnerEnv(t)
+	id, _ := createWebhook(t, env, storeID, tenantID, userID)
+
+	otherStoreID, otherTenantID := seedStoreRow(t, env.db, "")
+	otherUserID := uuid.NewString()
+	env.fga.Grant(otherUserID, authz.RoleOwner, otherTenantID)
+	env.fga.Grant(otherUserID, authz.RoleAdmin, otherTenantID)
+	env.fga.Grant(otherUserID, authz.RoleStaff, otherTenantID)
+	otherHeaders := authHeaders(otherUserID, otherTenantID)
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   any
+	}{
+		{"patch", http.MethodPatch, webhooksURL(otherStoreID) + "/" + id, map[string]any{"enabled": false}},
+		{"test-send", http.MethodPost, webhooksURL(otherStoreID) + "/" + id + "/test", nil},
+		{"deliveries", http.MethodGet, webhooksURL(otherStoreID) + "/" + id + "/deliveries", nil},
+		{"replay", http.MethodPost, webhooksURL(otherStoreID) + "/" + id + "/deliveries/" + uuid.NewString() + "/replay", nil},
+		{"delete", http.MethodDelete, webhooksURL(otherStoreID) + "/" + id, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := request(t, env.router, tc.method, tc.path, tc.body, otherHeaders)
+			if w.Code != http.StatusNotFound {
+				t.Fatalf("%s: status = %d, want 404, body = %s", tc.name, w.Code, w.Body.String())
+			}
+		})
+	}
+
+	// The subscription must be untouched by the (refused) delete/patch above.
+	lw := request(t, env.router, http.MethodGet, webhooksURL(storeID), nil, authHeaders(userID, tenantID))
+	items := dataArray(t, lw.Body.Bytes())
+	if len(items) != 1 {
+		t.Fatalf("expected the original subscription to survive, got %s", lw.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Replay
+// ---------------------------------------------------------------------------
+
+func TestReplay_ResetsAFailedDeliveryToPendingAndDueNow(t *testing.T) {
+	env, storeID, tenantID, userID := webhookOwnerEnv(t)
+	subID, _ := createWebhook(t, env, storeID, tenantID, userID)
+
+	deliveryRepo := webhook.NewDeliveryRepo(env.db)
+	future := time.Now().Add(2 * time.Hour)
+	lastErr := "endpoint returned 500"
+	code := 500
+	delivery := webhook.Delivery{
+		SubscriptionID: uuid.MustParse(subID),
+		OutboxEventID:  uuid.New(),
+		EventType:      "order.placed",
+		AggregateID:    uuid.New(),
+		Status:         webhook.StatusFailed,
+		Attempts:       3,
+		NextAttemptAt:  future,
+		LastStatusCode: &code,
+		LastError:      &lastErr,
+	}
+	if _, err := deliveryRepo.FanOut(context.Background(), []webhook.Delivery{delivery}); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+	seeded, err := deliveryRepo.ListForSubscription(context.Background(), uuid.MustParse(subID), 1)
+	if err != nil || len(seeded) != 1 {
+		t.Fatalf("seed delivery: list = %v, err = %v", seeded, err)
+	}
+	deliveryID := seeded[0].ID.String()
+
+	w := request(t, env.router, http.MethodPost,
+		webhooksURL(storeID)+"/"+subID+"/deliveries/"+deliveryID+"/replay", nil,
+		authHeaders(userID, tenantID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	after, err := deliveryRepo.ListForSubscription(context.Background(), uuid.MustParse(subID), 1)
+	if err != nil || len(after) != 1 {
+		t.Fatalf("post-replay list = %v, err = %v", after, err)
+	}
+	got := after[0]
+	if got.Status != webhook.StatusPending {
+		t.Fatalf("status = %q, want pending", got.Status)
+	}
+	if got.Attempts != 0 {
+		t.Fatalf("attempts = %d, want 0", got.Attempts)
+	}
+	if got.NextAttemptAt.After(time.Now()) {
+		t.Fatalf("next_attempt_at = %v, want due now", got.NextAttemptAt)
+	}
+}
+
+func TestReplay_UnknownDeliveryID_404s(t *testing.T) {
+	env, storeID, tenantID, userID := webhookOwnerEnv(t)
+	subID, _ := createWebhook(t, env, storeID, tenantID, userID)
+
+	w := request(t, env.router, http.MethodPost,
+		webhooksURL(storeID)+"/"+subID+"/deliveries/"+uuid.NewString()+"/replay", nil,
+		authHeaders(userID, tenantID))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test-send
+// ---------------------------------------------------------------------------
+
+// TestSend refuses to leak an unhandled-error 500 (which would log the
+// remote body) — a Send failure comes back as a 200 with success=false and
+// the error text in the JSON body instead.
+func TestTestSend_ReportsFailureWithoutServerError(t *testing.T) {
+	env, storeID, tenantID, userID := webhookOwnerEnv(t)
+
+	w := request(t, env.router, http.MethodPost, webhooksURL(storeID),
+		webhookCreateBody("https://unresolvable.example.com/hooks", []string{"order.placed"}),
+		authHeaders(userID, tenantID))
+	// Registration itself refuses an unresolvable host, so seed the
+	// subscription directly through the repo to exercise Send's own guard
+	// re-check instead of Create's.
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected registration to refuse an unresolvable host: status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	subs := webhook.NewSubscriptionRepo(env.db)
+	secret, err := webhook.GenerateSecret()
+	if err != nil {
+		t.Fatalf("generate secret: %v", err)
+	}
+	sub := &webhook.Subscription{
+		TenantID:   uuid.MustParse(tenantID),
+		StoreID:    uuid.MustParse(storeID),
+		URL:        "https://unresolvable.example.com/hooks",
+		EventTypes: []string{"order.placed"},
+		Secret:     secret,
+		Enabled:    true,
+	}
+	if err := subs.Create(context.Background(), sub); err != nil {
+		t.Fatalf("seed subscription: %v", err)
+	}
+
+	tw := request(t, env.router, http.MethodPost, webhooksURL(storeID)+"/"+sub.ID.String()+"/test", nil,
+		authHeaders(userID, tenantID))
+	if tw.Code != http.StatusOK {
+		t.Fatalf("test-send status = %d, body = %s", tw.Code, tw.Body.String())
+	}
+	data := dataObject(t, tw.Body.Bytes())
+	if data["success"] != false {
+		t.Fatalf("expected success=false, got %s", tw.Body.String())
+	}
+	if data["error"] == nil || data["error"] == "" {
+		t.Fatalf("expected an error message, got %s", tw.Body.String())
+	}
+}

--- a/services/marketplace-api/internal/tenantpurge/purge.go
+++ b/services/marketplace-api/internal/tenantpurge/purge.go
@@ -373,6 +373,7 @@ func purgePlan(tenantID string, storeIDs []string) []deleteStep {
 		tenantScoped("break_glass_lockouts", tenantID), // 000073: tenant_id (nullable)
 		tenantScoped("break_glass_accounts", tenantID), // 000072: tenant_id (PK)
 		tenantScoped("enterprise_api_keys", tenantID),  // 000068: tenant_id, store_id
+		tenantScoped("webhook_subscriptions", tenantID), // 000126: tenant_id, store_id
 		// audit_logs is tenant-scoped EXCEPT for operator rows. A platform
 		// operator's action against a tenant (suspend, trial extend, purge)
 		// is a governance record about the OPERATOR, not tenant data, and it

--- a/services/marketplace-api/internal/tenantpurge/purge.go
+++ b/services/marketplace-api/internal/tenantpurge/purge.go
@@ -370,9 +370,9 @@ func purgePlan(tenantID string, storeIDs []string) []deleteStep {
 		// so those survive — which is the point, not an accident. Widening this
 		// predicate would let any purge clear a live platform-wide lockout. See
 		// TestPurgePlan_BreakGlassLockoutsNeverTouchesNullTenantRows.
-		tenantScoped("break_glass_lockouts", tenantID), // 000073: tenant_id (nullable)
-		tenantScoped("break_glass_accounts", tenantID), // 000072: tenant_id (PK)
-		tenantScoped("enterprise_api_keys", tenantID),  // 000068: tenant_id, store_id
+		tenantScoped("break_glass_lockouts", tenantID),  // 000073: tenant_id (nullable)
+		tenantScoped("break_glass_accounts", tenantID),  // 000072: tenant_id (PK)
+		tenantScoped("enterprise_api_keys", tenantID),   // 000068: tenant_id, store_id
 		tenantScoped("webhook_subscriptions", tenantID), // 000126: tenant_id, store_id
 		// audit_logs is tenant-scoped EXCEPT for operator rows. A platform
 		// operator's action against a tenant (suspend, trial extend, purge)

--- a/services/marketplace-api/internal/webhook/delivery_repo.go
+++ b/services/marketplace-api/internal/webhook/delivery_repo.go
@@ -1,0 +1,33 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type DeliveryRepo struct{ db *gorm.DB }
+
+func NewDeliveryRepo(db *gorm.DB) *DeliveryRepo { return &DeliveryRepo{db: db} }
+
+// FanOut inserts delivery rows, ignoring any that already exist.
+//
+// ON CONFLICT DO NOTHING against idx_webhook_deliveries_event_sub is what
+// makes dispatch idempotent, and therefore what lets the dispatcher run
+// OUTSIDE the outbox publisher's transaction without risking duplicate
+// deliveries. Re-reading the same outbox rows is harmless.
+func (r *DeliveryRepo) FanOut(ctx context.Context, rows []Delivery) (int, error) {
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	res := r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "outbox_event_id"}, {Name: "subscription_id"}},
+		DoNothing: true,
+	}).Create(&rows)
+	if res.Error != nil {
+		return 0, fmt.Errorf("webhook: fan out deliveries: %w", res.Error)
+	}
+	return int(res.RowsAffected), nil
+}

--- a/services/marketplace-api/internal/webhook/delivery_repo.go
+++ b/services/marketplace-api/internal/webhook/delivery_repo.go
@@ -14,20 +14,67 @@ type DeliveryRepo struct{ db *gorm.DB }
 
 func NewDeliveryRepo(db *gorm.DB) *DeliveryRepo { return &DeliveryRepo{db: db} }
 
-// FanOut inserts delivery rows in ONE statement, ignoring any that already
-// exist.
+// fanOutParamsPerRow is how many bound parameters one delivery row costs in
+// FanOut's INSERT: subscription_id, outbox_event_id, event_type,
+// aggregate_id, status. next_attempt_at is SQL now(), not a parameter.
+const fanOutParamsPerRow = 5
+
+// fanOutChunkRows is how many rows go into one INSERT.
+//
+// Postgres's extended protocol caps a statement at 65535 bound parameters,
+// so the hard ceiling here is 65535/5 = 13107 rows. That is REACHABLE: the
+// dispatcher accumulates across a whole batch, so the row count is
+// batch x matching_subscriptions — about 132 enabled subscriptions on one
+// store for one event type at batch=100, and nothing caps how many
+// subscriptions a merchant creates (creation is gated on RoleAdmin only,
+// with no per-store limit and no plangate feature).
+//
+// Exceeding it is not a degraded insert, it is a global outage: FanOut
+// returns an error, the dispatcher returns before advanceCursor, the cursor
+// never moves, and the same poisoned batch is re-read every 5 seconds
+// forever — so NO tenant's webhooks dispatch at all. One merchant with too
+// many subscriptions takes the subsystem down for everyone. That is the
+// poison-pill class internal/outbox documents removing in #374.
+//
+// 2000 rows is 10000 parameters, comfortably inside the limit with room for
+// the per-row parameter count to grow. Do NOT "simplify" this back to a
+// single unbounded INSERT.
+const fanOutChunkRows = 2000
+
+// FanOut inserts delivery rows, ignoring any that already exist.
 //
 // ON CONFLICT DO NOTHING against idx_webhook_deliveries_event_sub is what
 // makes dispatch idempotent, and therefore what lets the dispatcher run
 // OUTSIDE the outbox publisher's transaction without risking duplicate
 // deliveries. Re-reading the same outbox rows is harmless — which is also
-// what pays for the dispatcher's lookback window.
+// what pays for the dispatcher's sweep pass.
+//
+// The insert is chunked (see fanOutChunkRows) and therefore NOT atomic
+// across chunks. That is safe for the same reason: if a later chunk fails,
+// the cursor does not advance, the batch is re-read, and the rows an
+// earlier chunk already wrote come back as conflicts rather than
+// duplicates.
 //
 // next_attempt_at is SQL now(), not the caller's clock. Every timestamp in
 // this table is written by the database so that ClaimDue's `next_attempt_at
 // <= now()` compares two readings of the same clock; a Delivery's
 // NextAttemptAt field is ignored on insert for that reason.
 func (r *DeliveryRepo) FanOut(ctx context.Context, rows []Delivery) (int, error) {
+	created := 0
+	for start := 0; start < len(rows); start += fanOutChunkRows {
+		end := min(start+fanOutChunkRows, len(rows))
+		n, err := r.fanOutChunk(ctx, rows[start:end])
+		if err != nil {
+			return created, err
+		}
+		created += n
+	}
+	return created, nil
+}
+
+// fanOutChunk inserts one chunk in a single statement. Callers must keep the
+// chunk within fanOutChunkRows.
+func (r *DeliveryRepo) fanOutChunk(ctx context.Context, rows []Delivery) (int, error) {
 	if len(rows) == 0 {
 		return 0, nil
 	}
@@ -35,7 +82,7 @@ func (r *DeliveryRepo) FanOut(ctx context.Context, rows []Delivery) (int, error)
 	b.WriteString(`INSERT INTO webhook_deliveries
 		(subscription_id, outbox_event_id, event_type, aggregate_id, status, next_attempt_at)
 		VALUES `)
-	args := make([]any, 0, len(rows)*5)
+	args := make([]any, 0, len(rows)*fanOutParamsPerRow)
 	for i, d := range rows {
 		if i > 0 {
 			b.WriteString(",")

--- a/services/marketplace-api/internal/webhook/delivery_repo.go
+++ b/services/marketplace-api/internal/webhook/delivery_repo.go
@@ -34,19 +34,65 @@ func (r *DeliveryRepo) FanOut(ctx context.Context, rows []Delivery) (int, error)
 	return int(res.RowsAffected), nil
 }
 
-// ClaimDue locks up to limit pending, due deliveries. FOR UPDATE SKIP LOCKED
-// is what makes it safe for several replicas to run this loop at once — each
-// takes a disjoint set instead of contending.
+// ClaimDue claims up to limit pending, due deliveries by taking a short
+// LEASE, not a lock.
+//
+// FOR UPDATE SKIP LOCKED only holds its row lock while THIS function's own
+// transaction is open, and that transaction commits here, before the caller
+// ever makes the outbound HTTP call. Postgres releases the lock at commit —
+// well before RecordOutcome moves status off pending, up to RequestTimeout
+// later. If ClaimDue simply returned the claimed rows at that point, a
+// second worker calling ClaimDue while the first is still mid-Send would
+// see them as pending and unlocked, and send them again. Several replicas
+// running this loop at once (Task 6 puts this on KEDA-scaled pods) is
+// exactly the case that must not double-send.
+//
+// So within the same transaction that claims the rows, it immediately
+// pushes their next_attempt_at forward by LeaseWindow. That's what actually
+// keeps the rows from being claimed again: they are still status=pending,
+// but no longer due. The HTTP send itself happens entirely OUTSIDE any
+// transaction — holding a connection and row locks across a blocking
+// outbound call to a merchant server is not an option on a 5-connection
+// pool shared with the rest of the service. RecordOutcome then overwrites
+// next_attempt_at with the real outcome (retry backoff, or dead-letter).
+//
+// If a worker dies mid-send, no RecordOutcome ever runs and the lease
+// simply expires — the row becomes due again and some worker retries it.
+// That's at-least-once delivery, which is what webhooks already assume:
+// the signature and delivery id are what let a merchant dedupe.
 func (r *DeliveryRepo) ClaimDue(ctx context.Context, limit int) ([]Delivery, error) {
 	var out []Delivery
-	err := r.db.WithContext(ctx).Raw(`
-		SELECT * FROM webhook_deliveries
-		 WHERE status = ? AND next_attempt_at <= now()
-		 ORDER BY next_attempt_at ASC
-		 LIMIT ?
-		 FOR UPDATE SKIP LOCKED`, StatusPending, limit).Scan(&out).Error
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Raw(`
+			SELECT * FROM webhook_deliveries
+			 WHERE status = ? AND next_attempt_at <= now()
+			 ORDER BY next_attempt_at ASC
+			 LIMIT ?
+			 FOR UPDATE SKIP LOCKED`, StatusPending, limit).Scan(&out).Error; err != nil {
+			return fmt.Errorf("webhook: claim deliveries: %w", err)
+		}
+		if len(out) == 0 {
+			return nil
+		}
+
+		ids := make([]uuid.UUID, len(out))
+		for i, d := range out {
+			ids[i] = d.ID
+		}
+		leaseUntil := time.Now().Add(LeaseWindow)
+		if err := tx.Exec(`UPDATE webhook_deliveries SET next_attempt_at = ? WHERE id IN ?`,
+			leaseUntil, ids).Error; err != nil {
+			return fmt.Errorf("webhook: lease deliveries: %w", err)
+		}
+		// Reflect the lease in what's returned too, so a caller reading
+		// NextAttemptAt off these structs doesn't see stale pre-lease data.
+		for i := range out {
+			out[i].NextAttemptAt = leaseUntil
+		}
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("webhook: claim deliveries: %w", err)
+		return nil, err
 	}
 	return out, nil
 }

--- a/services/marketplace-api/internal/webhook/delivery_repo.go
+++ b/services/marketplace-api/internal/webhook/delivery_repo.go
@@ -3,31 +3,49 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 type DeliveryRepo struct{ db *gorm.DB }
 
 func NewDeliveryRepo(db *gorm.DB) *DeliveryRepo { return &DeliveryRepo{db: db} }
 
-// FanOut inserts delivery rows, ignoring any that already exist.
+// FanOut inserts delivery rows in ONE statement, ignoring any that already
+// exist.
 //
 // ON CONFLICT DO NOTHING against idx_webhook_deliveries_event_sub is what
 // makes dispatch idempotent, and therefore what lets the dispatcher run
 // OUTSIDE the outbox publisher's transaction without risking duplicate
-// deliveries. Re-reading the same outbox rows is harmless.
+// deliveries. Re-reading the same outbox rows is harmless — which is also
+// what pays for the dispatcher's lookback window.
+//
+// next_attempt_at is SQL now(), not the caller's clock. Every timestamp in
+// this table is written by the database so that ClaimDue's `next_attempt_at
+// <= now()` compares two readings of the same clock; a Delivery's
+// NextAttemptAt field is ignored on insert for that reason.
 func (r *DeliveryRepo) FanOut(ctx context.Context, rows []Delivery) (int, error) {
 	if len(rows) == 0 {
 		return 0, nil
 	}
-	res := r.db.WithContext(ctx).Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "outbox_event_id"}, {Name: "subscription_id"}},
-		DoNothing: true,
-	}).Create(&rows)
+	var b strings.Builder
+	b.WriteString(`INSERT INTO webhook_deliveries
+		(subscription_id, outbox_event_id, event_type, aggregate_id, status, next_attempt_at)
+		VALUES `)
+	args := make([]any, 0, len(rows)*5)
+	for i, d := range rows {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString("(?,?,?,?,?,now())")
+		args = append(args, d.SubscriptionID, d.OutboxEventID, d.EventType, d.AggregateID, d.Status)
+	}
+	b.WriteString(` ON CONFLICT (outbox_event_id, subscription_id) DO NOTHING`)
+
+	res := r.db.WithContext(ctx).Exec(b.String(), args...)
 	if res.Error != nil {
 		return 0, fmt.Errorf("webhook: fan out deliveries: %w", res.Error)
 	}
@@ -79,15 +97,30 @@ func (r *DeliveryRepo) ClaimDue(ctx context.Context, limit int) ([]Delivery, err
 		for i, d := range out {
 			ids[i] = d.ID
 		}
-		leaseUntil := time.Now().Add(LeaseWindow)
-		if err := tx.Exec(`UPDATE webhook_deliveries SET next_attempt_at = ? WHERE id IN ?`,
-			leaseUntil, ids).Error; err != nil {
+		// now() + interval, not a Go timestamp: the predicate above reads
+		// SQL now(), so the lease has to be written against the same clock
+		// or a pod running fast/slow shortens or extends every lease.
+		var leased []struct {
+			ID            uuid.UUID
+			NextAttemptAt time.Time
+		}
+		if err := tx.Raw(`
+			UPDATE webhook_deliveries
+			   SET next_attempt_at = now() + ?::interval
+			 WHERE id IN ?
+			RETURNING id, next_attempt_at`, intervalArg(LeaseWindow), ids).Scan(&leased).Error; err != nil {
 			return fmt.Errorf("webhook: lease deliveries: %w", err)
 		}
 		// Reflect the lease in what's returned too, so a caller reading
 		// NextAttemptAt off these structs doesn't see stale pre-lease data.
+		byID := make(map[uuid.UUID]time.Time, len(leased))
+		for _, l := range leased {
+			byID[l.ID] = l.NextAttemptAt
+		}
 		for i := range out {
-			out[i].NextAttemptAt = leaseUntil
+			if t, ok := byID[out[i].ID]; ok {
+				out[i].NextAttemptAt = t
+			}
 		}
 		return nil
 	})
@@ -97,17 +130,23 @@ func (r *DeliveryRepo) ClaimDue(ctx context.Context, limit int) ([]Delivery, err
 	return out, nil
 }
 
-// RecordOutcome writes the result of one attempt.
-func (r *DeliveryRepo) RecordOutcome(ctx context.Context, id uuid.UUID, status string, code *int, errMsg *string, next time.Time) error {
+// RecordOutcome writes the result of one attempt. retryIn is how far ahead
+// of SQL now() the next attempt becomes due; pass 0 for a terminal outcome.
+//
+// Every timestamp here comes from the database clock, matching FanOut and
+// ClaimDue. Mixing a pod clock into next_attempt_at while ClaimDue's
+// predicate reads now() is the same class of assumption that produced the
+// dispatcher's lost-event bug.
+func (r *DeliveryRepo) RecordOutcome(ctx context.Context, id uuid.UUID, status string, code *int, errMsg *string, retryIn time.Duration) error {
 	updates := map[string]any{
 		"status":           status,
 		"attempts":         gorm.Expr("attempts + 1"),
 		"last_status_code": code,
 		"last_error":       errMsg,
-		"next_attempt_at":  next,
+		"next_attempt_at":  gorm.Expr("now() + ?::interval", intervalArg(retryIn)),
 	}
 	if status == StatusDelivered {
-		updates["delivered_at"] = time.Now()
+		updates["delivered_at"] = gorm.Expr("now()")
 	}
 	if err := r.db.WithContext(ctx).Model(&Delivery{}).Where("id = ?", id).Updates(updates).Error; err != nil {
 		return fmt.Errorf("webhook: record outcome: %w", err)
@@ -135,12 +174,20 @@ func (r *DeliveryRepo) ListForSubscription(ctx context.Context, subscriptionID u
 // verified that subscription belongs to their tenant and store — so a
 // deliveryID belonging to a different subscription is silently a no-op
 // rather than a cross-tenant write. Reports whether a row matched.
+//
+// `status <> pending` is a guard, not a filter for tidiness: a pending row
+// may be LEASED right now (see ClaimDue), mid-flight in some worker's
+// outbound request. Resetting next_attempt_at under it would break the
+// lease and let a second worker claim and send the same delivery — an admin
+// button that manufactures a duplicate send. Only a settled delivery
+// (delivered or failed) is replayable; a pending one is already going to be
+// attempted.
 func (r *DeliveryRepo) Replay(ctx context.Context, subscriptionID, deliveryID uuid.UUID) (bool, error) {
 	res := r.db.WithContext(ctx).Exec(`
 		UPDATE webhook_deliveries
 		   SET status = ?, attempts = 0, next_attempt_at = now()
-		 WHERE id = ? AND subscription_id = ?`,
-		StatusPending, deliveryID, subscriptionID)
+		 WHERE id = ? AND subscription_id = ? AND status <> ?`,
+		StatusPending, deliveryID, subscriptionID, StatusPending)
 	if res.Error != nil {
 		return false, fmt.Errorf("webhook: replay delivery: %w", res.Error)
 	}

--- a/services/marketplace-api/internal/webhook/delivery_repo.go
+++ b/services/marketplace-api/internal/webhook/delivery_repo.go
@@ -3,7 +3,9 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -30,4 +32,53 @@ func (r *DeliveryRepo) FanOut(ctx context.Context, rows []Delivery) (int, error)
 		return 0, fmt.Errorf("webhook: fan out deliveries: %w", res.Error)
 	}
 	return int(res.RowsAffected), nil
+}
+
+// ClaimDue locks up to limit pending, due deliveries. FOR UPDATE SKIP LOCKED
+// is what makes it safe for several replicas to run this loop at once — each
+// takes a disjoint set instead of contending.
+func (r *DeliveryRepo) ClaimDue(ctx context.Context, limit int) ([]Delivery, error) {
+	var out []Delivery
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT * FROM webhook_deliveries
+		 WHERE status = ? AND next_attempt_at <= now()
+		 ORDER BY next_attempt_at ASC
+		 LIMIT ?
+		 FOR UPDATE SKIP LOCKED`, StatusPending, limit).Scan(&out).Error
+	if err != nil {
+		return nil, fmt.Errorf("webhook: claim deliveries: %w", err)
+	}
+	return out, nil
+}
+
+// RecordOutcome writes the result of one attempt.
+func (r *DeliveryRepo) RecordOutcome(ctx context.Context, id uuid.UUID, status string, code *int, errMsg *string, next time.Time) error {
+	updates := map[string]any{
+		"status":           status,
+		"attempts":         gorm.Expr("attempts + 1"),
+		"last_status_code": code,
+		"last_error":       errMsg,
+		"next_attempt_at":  next,
+	}
+	if status == StatusDelivered {
+		updates["delivered_at"] = time.Now()
+	}
+	if err := r.db.WithContext(ctx).Model(&Delivery{}).Where("id = ?", id).Updates(updates).Error; err != nil {
+		return fmt.Errorf("webhook: record outcome: %w", err)
+	}
+	return nil
+}
+
+// Prune deletes delivery rows older than the retention window. 30 days on
+// every plan, deliberately not tied to FeatureAuditRetentionDays: "forever"
+// retention of delivery bodies on Pro is storage cost on a db-f1-micro with
+// no matching merchant value.
+func (r *DeliveryRepo) Prune(ctx context.Context, olderThan time.Duration) (int64, error) {
+	res := r.db.WithContext(ctx).Exec(
+		`DELETE FROM webhook_deliveries WHERE created_at < now() - ?::interval`,
+		fmt.Sprintf("%d hours", int(olderThan.Hours())))
+	if res.Error != nil {
+		return 0, fmt.Errorf("webhook: prune deliveries: %w", res.Error)
+	}
+	return res.RowsAffected, nil
 }

--- a/services/marketplace-api/internal/webhook/delivery_repo.go
+++ b/services/marketplace-api/internal/webhook/delivery_repo.go
@@ -115,6 +115,38 @@ func (r *DeliveryRepo) RecordOutcome(ctx context.Context, id uuid.UUID, status s
 	return nil
 }
 
+// ListForSubscription returns the most recent deliveries for one
+// subscription, most recent first, for the admin delivery log.
+func (r *DeliveryRepo) ListForSubscription(ctx context.Context, subscriptionID uuid.UUID, limit int) ([]Delivery, error) {
+	var out []Delivery
+	err := r.db.WithContext(ctx).
+		Where("subscription_id = ?", subscriptionID).
+		Order("created_at DESC").
+		Limit(limit).
+		Find(&out).Error
+	if err != nil {
+		return nil, fmt.Errorf("webhook: list deliveries: %w", err)
+	}
+	return out, nil
+}
+
+// Replay resets one delivery to pending, due now, so the worker's next poll
+// picks it up. Scoped to subscriptionID — the caller must have already
+// verified that subscription belongs to their tenant and store — so a
+// deliveryID belonging to a different subscription is silently a no-op
+// rather than a cross-tenant write. Reports whether a row matched.
+func (r *DeliveryRepo) Replay(ctx context.Context, subscriptionID, deliveryID uuid.UUID) (bool, error) {
+	res := r.db.WithContext(ctx).Exec(`
+		UPDATE webhook_deliveries
+		   SET status = ?, attempts = 0, next_attempt_at = now()
+		 WHERE id = ? AND subscription_id = ?`,
+		StatusPending, deliveryID, subscriptionID)
+	if res.Error != nil {
+		return false, fmt.Errorf("webhook: replay delivery: %w", res.Error)
+	}
+	return res.RowsAffected > 0, nil
+}
+
 // Prune deletes delivery rows older than the retention window. 30 days on
 // every plan, deliberately not tied to FeatureAuditRetentionDays: "forever"
 // retention of delivery bodies on Pro is storage cost on a db-f1-micro with

--- a/services/marketplace-api/internal/webhook/delivery_repo_integration_test.go
+++ b/services/marketplace-api/internal/webhook/delivery_repo_integration_test.go
@@ -1,0 +1,83 @@
+//go:build integration
+
+package webhook_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/webhook"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// TestClaimDue_LeasesSoASecondClaimCannotSeeTheSameRow is the fix for the
+// Critical review finding on this task: FOR UPDATE SKIP LOCKED's row lock
+// is released the instant ClaimDue's own transaction commits — long before
+// a real Send (up to RequestTimeout later) completes and RecordOutcome
+// moves status off pending. Without a lease, a second worker calling
+// ClaimDue in that window would see the row as due and unlocked, and claim
+// (and therefore send) it again.
+//
+// This drives ClaimDue twice in a row with no RecordOutcome between the
+// calls — standing in for two concurrent workers, the first of which is
+// still mid-Send when the second polls. Before the lease fix, the second
+// call returned the same row a second time; after it, the row's
+// next_attempt_at has been pushed into the future by the first claim, so
+// the second call sees nothing due.
+func TestClaimDue_LeasesSoASecondClaimCannotSeeTheSameRow(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	ctx := context.Background()
+
+	sub := newSub(t, subs, uuid.New(), []string{"order.placed"})
+	_, err := deliveries.FanOut(ctx, []webhook.Delivery{{
+		SubscriptionID: sub.ID, OutboxEventID: uuid.New(), EventType: "order.placed",
+		AggregateID: uuid.New(), Status: webhook.StatusPending, NextAttemptAt: time.Now(),
+	}})
+	require.NoError(t, err)
+
+	first, err := deliveries.ClaimDue(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, first, 1, "first claim must see the due delivery")
+
+	second, err := deliveries.ClaimDue(ctx, 10)
+	require.NoError(t, err)
+	require.Empty(t, second, "second claim must NOT re-see a delivery the first claim already leased — that would be a duplicate send")
+}
+
+// TestClaimDue_PicksTheRowBackUpOnceTheLeaseExpires proves the other half
+// of the contract: a claim that never reaches RecordOutcome (the worker
+// died mid-send, say) is not lost forever — it becomes claimable again once
+// the lease window passes, which is what makes this at-least-once rather
+// than at-most-once.
+func TestClaimDue_PicksTheRowBackUpOnceTheLeaseExpires(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	ctx := context.Background()
+
+	sub := newSub(t, subs, uuid.New(), []string{"order.placed"})
+	_, err := deliveries.FanOut(ctx, []webhook.Delivery{{
+		SubscriptionID: sub.ID, OutboxEventID: uuid.New(), EventType: "order.placed",
+		AggregateID: uuid.New(), Status: webhook.StatusPending, NextAttemptAt: time.Now(),
+	}})
+	require.NoError(t, err)
+
+	first, err := deliveries.ClaimDue(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+
+	// Simulate the lease expiring without the worker ever calling
+	// RecordOutcome, by rewinding next_attempt_at past "due" directly
+	// rather than sleeping out LeaseWindow in a test.
+	require.NoError(t, db.Exec(`UPDATE webhook_deliveries SET next_attempt_at = now() WHERE id = ?`, first[0].ID).Error)
+
+	again, err := deliveries.ClaimDue(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, again, 1, "an expired lease must make the row claimable again")
+}

--- a/services/marketplace-api/internal/webhook/delivery_repo_integration_test.go
+++ b/services/marketplace-api/internal/webhook/delivery_repo_integration_test.go
@@ -81,3 +81,54 @@ func TestClaimDue_PicksTheRowBackUpOnceTheLeaseExpires(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, again, 1, "an expired lease must make the row claimable again")
 }
+
+// TestFanOut_InsertsABatchLargerThanThePostgresParameterLimit covers the
+// HIGH found reviewing the batched fan-out. Batching moved FanOut from one
+// statement per outbox row to ONE statement for the whole batch, so its row
+// count became batch x matching_subscriptions. At 5 bound parameters per
+// row, Postgres's 65535-parameter ceiling is 13107 rows — reachable with
+// ~132 enabled subscriptions on one store for one event type at batch=100,
+// and nothing caps subscription count.
+//
+// The failure mode is what makes this load-bearing rather than cosmetic: a
+// FanOut error returns before advanceCursor, so the cursor never moves, the
+// same batch is re-read every 5s, and NO tenant's webhooks dispatch at all.
+// One merchant with too many subscriptions would take the subsystem down
+// globally — the poison-pill shape internal/outbox documents removing in
+// #374.
+//
+// Driving it through real subscriptions would need 13k of them; the
+// parameter count is per-STATEMENT and does not care where the rows came
+// from, so one subscription and distinct outbox_event_ids reproduces it
+// exactly.
+func TestFanOut_InsertsABatchLargerThanThePostgresParameterLimit(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	ctx := context.Background()
+
+	sub := newSub(t, subs, uuid.New(), []string{"order.placed"})
+
+	// 5 params per row, so 65535/5 = 13107 is the ceiling. Go just past it.
+	const rows = 13200
+	pending := make([]webhook.Delivery, 0, rows)
+	for i := 0; i < rows; i++ {
+		pending = append(pending, webhook.Delivery{
+			SubscriptionID: sub.ID, OutboxEventID: uuid.New(), EventType: "order.placed",
+			AggregateID: uuid.New(), Status: webhook.StatusPending,
+		})
+	}
+
+	n, err := deliveries.FanOut(ctx, pending)
+	require.NoError(t, err, "a batch past the parameter limit must not error — an error here stalls dispatch for every tenant, forever")
+	require.Equal(t, rows, n, "every row must be inserted, and RowsAffected summed across chunks")
+
+	var count int64
+	require.NoError(t, db.Model(&webhook.Delivery{}).Count(&count).Error)
+	require.EqualValues(t, rows, count)
+
+	// Chunking must not break idempotency: re-running inserts nothing.
+	again, err := deliveries.FanOut(ctx, pending)
+	require.NoError(t, err)
+	require.Equal(t, 0, again, "ON CONFLICT DO NOTHING must still hold across chunk boundaries")
+}

--- a/services/marketplace-api/internal/webhook/dispatcher.go
+++ b/services/marketplace-api/internal/webhook/dispatcher.go
@@ -39,29 +39,92 @@ type outboxRow struct {
 	CreatedAt   time.Time
 }
 
+// dispatchCursor mirrors webhook_dispatch_cursor. LastEventID is compared
+// alongside LastEventCreated so ties on created_at (routine in a
+// transactional outbox: several events written in one transaction share
+// Postgres's `now()`, which is transaction-start time) never hide a row from
+// the next read.
+type dispatchCursor struct {
+	LastEventCreated time.Time
+	LastEventID      *uuid.UUID
+}
+
+// readCursor loads the dispatcher's cursor. LastEventID is NULL only in the
+// seeded initial state (migration 000126 inserts the singleton row with no
+// id); every other case runs (created_at, id) > (?, ?), so nil is coalesced
+// to the zero UUID rather than left to compare against NULL, which would
+// make the predicate match nothing.
+func (d *Dispatcher) readCursor(ctx context.Context) (dispatchCursor, error) {
+	var cursor dispatchCursor
+	if err := d.db.WithContext(ctx).
+		Raw(`SELECT last_event_created, last_event_id FROM webhook_dispatch_cursor WHERE id`).
+		Scan(&cursor).Error; err != nil {
+		return dispatchCursor{}, fmt.Errorf("webhook: read cursor: %w", err)
+	}
+	if cursor.LastEventID == nil {
+		zero := uuid.UUID{}
+		cursor.LastEventID = &zero
+	}
+	return cursor, nil
+}
+
+// advanceCursor moves the cursor to the last row of the batch just fanned
+// out. GREATEST guards both columns together so the pair stays consistent
+// even when multiple dispatcher replicas run this loop concurrently (wired
+// up in Task 6) — an unconditional SET would let a slower replica, racing a
+// faster one, walk the cursor backward. Idempotent fan-out makes that safe
+// rather than lossy, but it is wasted and confusing work, so we guard it.
+func (d *Dispatcher) advanceCursor(ctx context.Context, last outboxRow) error {
+	err := d.db.WithContext(ctx).Exec(`
+		UPDATE webhook_dispatch_cursor
+		   SET last_event_created = GREATEST(last_event_created, ?),
+		       last_event_id = CASE
+		           WHEN ? > last_event_created THEN ?
+		           WHEN ? = last_event_created THEN GREATEST(last_event_id, ?)
+		           ELSE last_event_id
+		       END
+		 WHERE id`, last.CreatedAt, last.CreatedAt, last.ID, last.CreatedAt, last.ID).Error
+	if err != nil {
+		return fmt.Errorf("webhook: advance cursor: %w", err)
+	}
+	return nil
+}
+
 // Tick reads one batch of outbox events past the cursor, fans them out, and
 // advances the cursor. Returns how many delivery rows were created.
 func (d *Dispatcher) Tick(ctx context.Context) (int, error) {
-	var cursor time.Time
-	if err := d.db.WithContext(ctx).
-		Raw(`SELECT last_event_created FROM webhook_dispatch_cursor WHERE id`).
-		Scan(&cursor).Error; err != nil {
-		return 0, fmt.Errorf("webhook: read cursor: %w", err)
+	cursor, err := d.readCursor(ctx)
+	if err != nil {
+		return 0, err
 	}
 
 	var rows []outboxRow
 	if err := d.db.WithContext(ctx).Raw(`
 		SELECT id, tenant_id, aggregate_id, event_type, created_at
 		  FROM outbox_events
-		 WHERE created_at > ?
-		 ORDER BY created_at ASC
-		 LIMIT ?`, cursor, d.batch).Scan(&rows).Error; err != nil {
+		 WHERE (created_at, id) > (?, ?)
+		 ORDER BY created_at ASC, id ASC
+		 LIMIT ?`, cursor.LastEventCreated, *cursor.LastEventID, d.batch).Scan(&rows).Error; err != nil {
 		return 0, fmt.Errorf("webhook: read outbox: %w", err)
 	}
 	if len(rows) == 0 {
 		return 0, nil
 	}
 
+	created, err := d.fanOutRows(ctx, rows)
+	if err != nil {
+		return created, err
+	}
+
+	if err := d.advanceCursor(ctx, rows[len(rows)-1]); err != nil {
+		return created, err
+	}
+	return created, nil
+}
+
+// fanOutRows creates delivery rows for every subscription matching each
+// outbox row, returning how many were actually created.
+func (d *Dispatcher) fanOutRows(ctx context.Context, rows []outboxRow) (int, error) {
 	created := 0
 	for _, row := range rows {
 		matches, err := d.subs.MatchingEvent(ctx, row.TenantID, row.EventType)
@@ -84,14 +147,6 @@ func (d *Dispatcher) Tick(ctx context.Context) (int, error) {
 			return created, err
 		}
 		created += n
-	}
-
-	last := rows[len(rows)-1]
-	if err := d.db.WithContext(ctx).Exec(`
-		UPDATE webhook_dispatch_cursor
-		   SET last_event_created = ?, last_event_id = ?
-		 WHERE id`, last.CreatedAt, last.ID).Error; err != nil {
-		return created, fmt.Errorf("webhook: advance cursor: %w", err)
 	}
 	return created, nil
 }

--- a/services/marketplace-api/internal/webhook/dispatcher.go
+++ b/services/marketplace-api/internal/webhook/dispatcher.go
@@ -1,0 +1,119 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// Dispatcher turns outbox_events into webhook_deliveries.
+//
+// It keeps its OWN cursor (webhook_dispatch_cursor) rather than reading the
+// outbox publisher's watermark, so the two consumers advance independently.
+// A stalled webhook dispatch cannot hold back outbox publishing, and vice
+// versa. It never writes to outbox_events.
+type Dispatcher struct {
+	db         *gorm.DB
+	subs       *SubscriptionRepo
+	deliveries *DeliveryRepo
+	logger     *slog.Logger
+	batch      int
+}
+
+func NewDispatcher(db *gorm.DB, subs *SubscriptionRepo, deliveries *DeliveryRepo, logger *slog.Logger, batch int) *Dispatcher {
+	if batch <= 0 {
+		batch = 100
+	}
+	return &Dispatcher{db: db, subs: subs, deliveries: deliveries, logger: logger, batch: batch}
+}
+
+type outboxRow struct {
+	ID          uuid.UUID
+	TenantID    uuid.UUID
+	AggregateID uuid.UUID
+	EventType   string
+	CreatedAt   time.Time
+}
+
+// Tick reads one batch of outbox events past the cursor, fans them out, and
+// advances the cursor. Returns how many delivery rows were created.
+func (d *Dispatcher) Tick(ctx context.Context) (int, error) {
+	var cursor time.Time
+	if err := d.db.WithContext(ctx).
+		Raw(`SELECT last_event_created FROM webhook_dispatch_cursor WHERE id`).
+		Scan(&cursor).Error; err != nil {
+		return 0, fmt.Errorf("webhook: read cursor: %w", err)
+	}
+
+	var rows []outboxRow
+	if err := d.db.WithContext(ctx).Raw(`
+		SELECT id, tenant_id, aggregate_id, event_type, created_at
+		  FROM outbox_events
+		 WHERE created_at > ?
+		 ORDER BY created_at ASC
+		 LIMIT ?`, cursor, d.batch).Scan(&rows).Error; err != nil {
+		return 0, fmt.Errorf("webhook: read outbox: %w", err)
+	}
+	if len(rows) == 0 {
+		return 0, nil
+	}
+
+	created := 0
+	for _, row := range rows {
+		matches, err := d.subs.MatchingEvent(ctx, row.TenantID, row.EventType)
+		if err != nil {
+			return created, err
+		}
+		pending := make([]Delivery, 0, len(matches))
+		for _, s := range matches {
+			pending = append(pending, Delivery{
+				SubscriptionID: s.ID,
+				OutboxEventID:  row.ID,
+				EventType:      row.EventType,
+				AggregateID:    row.AggregateID,
+				Status:         StatusPending,
+				NextAttemptAt:  time.Now(),
+			})
+		}
+		n, err := d.deliveries.FanOut(ctx, pending)
+		if err != nil {
+			return created, err
+		}
+		created += n
+	}
+
+	last := rows[len(rows)-1]
+	if err := d.db.WithContext(ctx).Exec(`
+		UPDATE webhook_dispatch_cursor
+		   SET last_event_created = ?, last_event_id = ?
+		 WHERE id`, last.CreatedAt, last.ID).Error; err != nil {
+		return created, fmt.Errorf("webhook: advance cursor: %w", err)
+	}
+	return created, nil
+}
+
+// Start runs Tick on an interval until ctx is cancelled. Mirrors
+// outbox.Publisher.Start so the two loops behave the same way on shutdown.
+func (d *Dispatcher) Start(ctx context.Context, interval time.Duration) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if _, err := d.Tick(ctx); err != nil && d.logger != nil {
+					d.logger.Error("webhook dispatcher tick failed", "err", err)
+				}
+			}
+		}
+	}()
+	return done
+}

--- a/services/marketplace-api/internal/webhook/dispatcher.go
+++ b/services/marketplace-api/internal/webhook/dispatcher.go
@@ -16,139 +16,300 @@ import (
 // outbox publisher's watermark, so the two consumers advance independently.
 // A stalled webhook dispatch cannot hold back outbox publishing, and vice
 // versa. It never writes to outbox_events.
+//
+// Each Tick runs two passes over outbox_events — a prompt forward pass and
+// a trailing sweep of the settled region. See dispatchCursor.
+
+// DispatchLookback is how far behind "now" a region of outbox_events is
+// considered SETTLED — old enough that every transaction which could have
+// written a row there has certainly committed.
+//
+// It exists because created_at ordering is NOT commit ordering.
+// OutboxEvent.CreatedAt is stamped at INSERT, but the row stays invisible
+// until the business transaction commits — and the enqueue is not the last
+// statement before commit (internal/order/service.go enqueues, then does
+// more work inside the same transaction). So a row stamped at t=100.000 and
+// committed at t=100.400 becomes visible AFTER one stamped t=100.100 and
+// committed at t=100.150. A single cursor advancing to the newest row it
+// has seen steps over the first and never selects it again: no error, no
+// retry, no dead-letter, just silent permanent delivery loss — the worst
+// failure this system can produce. Replica clock skew produces the same
+// shape on its own, since created_at comes from the POD clock and five KEDA
+// replicas each tick every 5s.
+//
+// The window must exceed the longest plausible business transaction plus
+// that skew. Five minutes is several orders of magnitude above both: the
+// service's HTTP handlers are bounded well under a minute, and GKE nodes
+// run chronyd with skew in the low milliseconds. Over-sizing it only delays
+// the safety net, and costs nothing else — the sweep's re-reads are free
+// because fan-out is idempotent via ON CONFLICT DO NOTHING on
+// (outbox_event_id, subscription_id).
+//
+// Deliberately NOT solved by writing to outbox_events: this dispatcher
+// never does, and that separation from outbox.Publisher is a design
+// decision, not an accident.
+const DispatchLookback = 5 * time.Minute
+
 type Dispatcher struct {
 	db         *gorm.DB
 	subs       *SubscriptionRepo
 	deliveries *DeliveryRepo
 	logger     *slog.Logger
 	batch      int
+	lookback   time.Duration
 }
 
 func NewDispatcher(db *gorm.DB, subs *SubscriptionRepo, deliveries *DeliveryRepo, logger *slog.Logger, batch int) *Dispatcher {
 	if batch <= 0 {
 		batch = 100
 	}
-	return &Dispatcher{db: db, subs: subs, deliveries: deliveries, logger: logger, batch: batch}
+	return &Dispatcher{
+		db: db, subs: subs, deliveries: deliveries,
+		logger: logger, batch: batch, lookback: DispatchLookback,
+	}
+}
+
+// WithLookback overrides DispatchLookback for this dispatcher.
+//
+// It exists for tests: the sweep's whole contract is "a row becomes
+// reachable once its region has settled", and proving that at the shipped
+// five minutes would mean a five-minute test. Ageing the timestamps
+// instead cannot substitute — a row inserted into an ALREADY-settled region
+// is not a late commit, it is something the design says cannot happen, and
+// a test built on it asserts the wrong guarantee. Production uses the
+// constant.
+func (d *Dispatcher) WithLookback(v time.Duration) *Dispatcher {
+	d.lookback = v
+	return d
 }
 
 type outboxRow struct {
 	ID          uuid.UUID
 	TenantID    uuid.UUID
+	StoreID     string // payload->>'store_id', parsed in Go — see fanOutRows
 	AggregateID uuid.UUID
 	EventType   string
 	CreatedAt   time.Time
 }
 
-// dispatchCursor mirrors webhook_dispatch_cursor. LastEventID is compared
-// alongside LastEventCreated so ties on created_at (routine in a
-// transactional outbox: several events written in one transaction share
-// Postgres's `now()`, which is transaction-start time) never hide a row from
-// the next read.
+// matchKey is one distinct fan-out target set within a batch. The
+// dispatcher resolves subscriptions once per key rather than once per row:
+// a 100-row batch from one store collapses to a handful of keys, where the
+// per-row form ran a match + an insert for every row — ~1000 statements a
+// tick with five KEDA replicas scanning the same backlog, against a
+// 5-connection pool on a shared db-f1-micro.
+type matchKey struct {
+	tenantID  uuid.UUID
+	storeID   uuid.UUID
+	eventType string
+}
+
+// dispatchCursor mirrors webhook_dispatch_cursor, which holds TWO
+// watermarks over the same table.
+//
+// LastEvent* is the prompt forward cursor: it advances to the newest row
+// each tick actually read, so a freshly committed event is dispatched
+// within one tick. On its own it is lossy, for the reason on
+// DispatchLookback.
+//
+// Swept* is the safety net. It trails through the settled region
+// (created_at <= now() - DispatchLookback), where visibility is no longer
+// in question, so every row is guaranteed to pass under it exactly once
+// however its commit interleaved. Rows the forward pass already handled
+// simply re-insert as no-ops.
+//
+// Both are compared as (created_at, id) pairs. Ties on created_at are
+// routine in a transactional outbox — several events written in one
+// transaction share Postgres's now(), which is transaction-start time — and
+// a timestamp-only comparison would hide a row from the next read.
+//
+// Two independently advancing watermarks, each with its own LIMIT, is also
+// what keeps either pass from starving: a single cursor pinned inside the
+// lookback window would re-serve the window's oldest rows every tick, so
+// the tail of any group larger than one batch would wait out the whole
+// window before being delivered.
 type dispatchCursor struct {
 	LastEventCreated time.Time
 	LastEventID      *uuid.UUID
+	SweptCreated     time.Time
+	SweptID          *uuid.UUID
 }
 
-// readCursor loads the dispatcher's cursor. LastEventID is NULL only in the
-// seeded initial state (migration 000126 inserts the singleton row with no
-// id); every other case runs (created_at, id) > (?, ?), so nil is coalesced
-// to the zero UUID rather than left to compare against NULL, which would
-// make the predicate match nothing.
+// readCursor loads both watermarks. The id columns are NULL only in the
+// seeded initial state (000126 inserts the singleton row with no id, 000127
+// copies it into swept_id); every comparison runs
+// (created_at, id) > (?, ?), so nil is coalesced to the zero UUID rather
+// than left to compare against NULL, which would make the predicate match
+// nothing.
 func (d *Dispatcher) readCursor(ctx context.Context) (dispatchCursor, error) {
 	var cursor dispatchCursor
 	if err := d.db.WithContext(ctx).
-		Raw(`SELECT last_event_created, last_event_id FROM webhook_dispatch_cursor WHERE id`).
+		Raw(`SELECT last_event_created, last_event_id, swept_created, swept_id
+		       FROM webhook_dispatch_cursor WHERE id`).
 		Scan(&cursor).Error; err != nil {
 		return dispatchCursor{}, fmt.Errorf("webhook: read cursor: %w", err)
 	}
+	zero := uuid.UUID{}
 	if cursor.LastEventID == nil {
-		zero := uuid.UUID{}
 		cursor.LastEventID = &zero
+	}
+	if cursor.SweptID == nil {
+		cursor.SweptID = &zero
 	}
 	return cursor, nil
 }
 
-// advanceCursor moves the cursor to the last row of the batch just fanned
-// out. GREATEST guards both columns together so the pair stays consistent
-// even when multiple dispatcher replicas run this loop concurrently (wired
-// up in Task 6) — an unconditional SET would let a slower replica, racing a
-// faster one, walk the cursor backward. Idempotent fan-out makes that safe
-// rather than lossy, but it is wasted and confusing work, so we guard it.
-func (d *Dispatcher) advanceCursor(ctx context.Context, last outboxRow) error {
-	err := d.db.WithContext(ctx).Exec(`
+// advanceCursor moves one watermark to the last row of the batch just
+// fanned out. GREATEST guards both columns together so the pair stays
+// consistent when multiple dispatcher replicas run this loop concurrently —
+// an unconditional SET would let a slower replica, racing a faster one,
+// walk a watermark backward. Idempotent fan-out makes that safe rather than
+// lossy, but it is wasted and confusing work, so we guard it.
+//
+// createdCol/idCol are column names chosen by this file, never by a caller.
+func (d *Dispatcher) advanceCursor(ctx context.Context, createdCol, idCol string, last outboxRow) error {
+	err := d.db.WithContext(ctx).Exec(fmt.Sprintf(`
 		UPDATE webhook_dispatch_cursor
-		   SET last_event_created = GREATEST(last_event_created, ?),
-		       last_event_id = CASE
-		           WHEN ? > last_event_created THEN ?
-		           WHEN ? = last_event_created THEN GREATEST(last_event_id, ?)
-		           ELSE last_event_id
+		   SET %[1]s = GREATEST(%[1]s, ?),
+		       %[2]s = CASE
+		           WHEN ? > %[1]s THEN ?
+		           WHEN ? = %[1]s THEN GREATEST(%[2]s, ?)
+		           ELSE %[2]s
 		       END
-		 WHERE id`, last.CreatedAt, last.CreatedAt, last.ID, last.CreatedAt, last.ID).Error
+		 WHERE id`, createdCol, idCol),
+		last.CreatedAt, last.CreatedAt, last.ID, last.CreatedAt, last.ID).Error
 	if err != nil {
 		return fmt.Errorf("webhook: advance cursor: %w", err)
 	}
 	return nil
 }
 
-// Tick reads one batch of outbox events past the cursor, fans them out, and
-// advances the cursor. Returns how many delivery rows were created.
+// intervalArg renders a Duration for a Postgres ::interval cast. Kept in
+// milliseconds so sub-second windows survive the round trip.
+func intervalArg(d time.Duration) string {
+	return fmt.Sprintf("%d milliseconds", d.Milliseconds())
+}
+
+// Tick runs both passes once and returns how many delivery rows were
+// created. See dispatchCursor for why there are two.
 func (d *Dispatcher) Tick(ctx context.Context) (int, error) {
 	cursor, err := d.readCursor(ctx)
 	if err != nil {
 		return 0, err
 	}
 
-	var rows []outboxRow
-	if err := d.db.WithContext(ctx).Raw(`
-		SELECT id, tenant_id, aggregate_id, event_type, created_at
-		  FROM outbox_events
-		 WHERE (created_at, id) > (?, ?)
-		 ORDER BY created_at ASC, id ASC
-		 LIMIT ?`, cursor.LastEventCreated, *cursor.LastEventID, d.batch).Scan(&rows).Error; err != nil {
-		return 0, fmt.Errorf("webhook: read outbox: %w", err)
+	created, err := d.forwardPass(ctx, cursor)
+	if err != nil {
+		return created, err
+	}
+	swept, err := d.sweepPass(ctx, cursor)
+	return created + swept, err
+}
+
+// forwardPass dispatches everything newer than the forward cursor. This is
+// the path that delivers promptly.
+func (d *Dispatcher) forwardPass(ctx context.Context, cursor dispatchCursor) (int, error) {
+	rows, err := d.read(ctx, `(created_at, id) > (?, ?)`,
+		cursor.LastEventCreated, *cursor.LastEventID)
+	if err != nil {
+		return 0, err
 	}
 	if len(rows) == 0 {
 		return 0, nil
 	}
-
 	created, err := d.fanOutRows(ctx, rows)
 	if err != nil {
 		return created, err
 	}
+	return created, d.advanceCursor(ctx, "last_event_created", "last_event_id", rows[len(rows)-1])
+}
 
-	if err := d.advanceCursor(ctx, rows[len(rows)-1]); err != nil {
+// sweepPass re-walks the settled region, catching anything the forward pass
+// stepped over because it committed out of created_at order. now() is SQL's:
+// a pod-clock boundary here would reintroduce exactly the skew assumption
+// DispatchLookback exists to absorb.
+func (d *Dispatcher) sweepPass(ctx context.Context, cursor dispatchCursor) (int, error) {
+	rows, err := d.read(ctx, `(created_at, id) > (?, ?) AND created_at <= now() - ?::interval`,
+		cursor.SweptCreated, *cursor.SweptID, intervalArg(d.lookback))
+	if err != nil {
+		return 0, err
+	}
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	created, err := d.fanOutRows(ctx, rows)
+	if err != nil {
 		return created, err
 	}
-	return created, nil
+	return created, d.advanceCursor(ctx, "swept_created", "swept_id", rows[len(rows)-1])
+}
+
+// read loads one batch of outbox rows matching where, oldest first.
+func (d *Dispatcher) read(ctx context.Context, where string, args ...any) ([]outboxRow, error) {
+	var rows []outboxRow
+	args = append(args, d.batch)
+	err := d.db.WithContext(ctx).Raw(`
+		SELECT id, tenant_id, payload->>'store_id' AS store_id,
+		       aggregate_id, event_type, created_at
+		  FROM outbox_events
+		 WHERE `+where+`
+		 ORDER BY created_at ASC, id ASC
+		 LIMIT ?`, args...).Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("webhook: read outbox: %w", err)
+	}
+	return rows, nil
 }
 
 // fanOutRows creates delivery rows for every subscription matching each
 // outbox row, returning how many were actually created.
+//
+// Subscriptions are resolved once per distinct (tenant, store, event type)
+// across the whole batch and inserted in ONE FanOut, rather than a
+// match+insert per row. Per-row semantics are unchanged; the statement
+// count is not — see matchKey.
 func (d *Dispatcher) fanOutRows(ctx context.Context, rows []outboxRow) (int, error) {
-	created := 0
+	matches := make(map[matchKey][]Subscription)
+	pending := make([]Delivery, 0, len(rows))
+
 	for _, row := range rows {
-		matches, err := d.subs.MatchingEvent(ctx, row.TenantID, row.EventType)
+		// Every outbox producer writes a top-level store_id (the outbox
+		// publisher already treats a missing one as the terminal
+		// ReasonPayloadMissingStoreID), so this is a producer bug if it
+		// ever fires. Skipping is the only safe response: dispatching on an
+		// unknown store would fan the event out to the wrong merchant's
+		// endpoint, which is the bug this scoping exists to prevent.
+		storeID, err := uuid.Parse(row.StoreID)
 		if err != nil {
-			return created, err
+			if d.logger != nil {
+				d.logger.Error("webhook: outbox row has no usable store_id; not dispatching",
+					"outbox_event_id", row.ID.String(), "event_type", row.EventType)
+			}
+			continue
 		}
-		pending := make([]Delivery, 0, len(matches))
-		for _, s := range matches {
+
+		key := matchKey{tenantID: row.TenantID, storeID: storeID, eventType: row.EventType}
+		subs, ok := matches[key]
+		if !ok {
+			subs, err = d.subs.MatchingEvent(ctx, key.tenantID, key.storeID, key.eventType)
+			if err != nil {
+				return 0, err
+			}
+			matches[key] = subs
+		}
+
+		for _, s := range subs {
 			pending = append(pending, Delivery{
 				SubscriptionID: s.ID,
 				OutboxEventID:  row.ID,
 				EventType:      row.EventType,
 				AggregateID:    row.AggregateID,
 				Status:         StatusPending,
-				NextAttemptAt:  time.Now(),
 			})
 		}
-		n, err := d.deliveries.FanOut(ctx, pending)
-		if err != nil {
-			return created, err
-		}
-		created += n
 	}
-	return created, nil
+
+	return d.deliveries.FanOut(ctx, pending)
 }
 
 // Start runs Tick on an interval until ctx is cancelled. Mirrors

--- a/services/marketplace-api/internal/webhook/dispatcher_integration_test.go
+++ b/services/marketplace-api/internal/webhook/dispatcher_integration_test.go
@@ -1,0 +1,113 @@
+//go:build integration
+
+package webhook_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/outbox"
+	"github.com/mark8ly/marketplace-api/internal/webhook"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+	"gorm.io/gorm"
+)
+
+func enqueueOutbox(t *testing.T, db *gorm.DB, tenant uuid.UUID, eventType string) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	payload, _ := json.Marshal(map[string]any{"store_id": uuid.New().String()})
+	require.NoError(t, db.Exec(`
+		INSERT INTO outbox_events (id, tenant_id, aggregate, aggregate_id, event_type, payload)
+		VALUES (?, ?, 'order', ?, ?, ?)`,
+		id, tenant, uuid.New(), eventType, payload).Error)
+	return id
+}
+
+// resetDispatchCursor rewinds the dispatcher's cursor to the epoch so each
+// test is independent of execution order.
+//
+// webhook_dispatch_cursor is deliberately NOT in any testdb.NewDB cleanup
+// list: migration 000126 seeds it as a singleton row
+// (INSERT ... ON CONFLICT DO NOTHING), and TRUNCATE would delete that row.
+// With no row left, Tick's `UPDATE webhook_dispatch_cursor ... WHERE id`
+// would match zero rows, so the cursor would silently never advance — a
+// dispatcher test that passes while dispatching nothing. Resetting the
+// existing row's value, instead of truncating the table, keeps the row in
+// place.
+func resetDispatchCursor(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`UPDATE webhook_dispatch_cursor SET last_event_created = 'epoch', last_event_id = NULL`).Error)
+}
+
+func TestDispatcher_CreatesOneDeliveryPerMatchingSubscription(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
+	resetDispatchCursor(t, db)
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	d := webhook.NewDispatcher(db, subs, deliveries, slog.Default(), 100)
+	ctx := context.Background()
+	tenant := uuid.New()
+
+	newSub(t, subs, tenant, []string{"order.placed"})
+	newSub(t, subs, tenant, []string{"order.placed", "order.refunded"})
+	newSub(t, subs, tenant, []string{"product.created"}) // must not match
+	enqueueOutbox(t, db, tenant, "order.placed")
+
+	n, err := d.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, n, "one delivery per subscription that selected the type")
+}
+
+// The property that replaces the exactly-once guarantee we gave up by NOT
+// coupling to the outbox publisher's transaction.
+func TestDispatcher_IsIdempotentAcrossRuns(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
+	resetDispatchCursor(t, db)
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	ctx := context.Background()
+	tenant := uuid.New()
+	newSub(t, subs, tenant, []string{"order.placed"})
+	enqueueOutbox(t, db, tenant, "order.placed")
+
+	first := webhook.NewDispatcher(db, subs, deliveries, slog.Default(), 100)
+	n1, err := first.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, n1)
+
+	// A dispatcher starting from a fresh cursor re-reads the same rows —
+	// the unique index must stop it double-delivering.
+	resetDispatchCursor(t, db)
+	second := webhook.NewDispatcher(db, subs, deliveries, slog.Default(), 100)
+	n2, err := second.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, n2, "re-dispatching the same outbox rows must create nothing")
+
+	var count int64
+	require.NoError(t, db.Model(&webhook.Delivery{}).Count(&count).Error)
+	require.EqualValues(t, 1, count)
+}
+
+// The failure this whole architecture exists to prevent.
+func TestDispatcher_DoesNotTouchOutboxPublishedState(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
+	resetDispatchCursor(t, db)
+	subs := webhook.NewSubscriptionRepo(db)
+	d := webhook.NewDispatcher(db, subs, webhook.NewDeliveryRepo(db), slog.Default(), 100)
+	tenant := uuid.New()
+	newSub(t, subs, tenant, []string{"order.placed"})
+	id := enqueueOutbox(t, db, tenant, "order.placed")
+
+	_, err := d.Tick(context.Background())
+	require.NoError(t, err)
+
+	var row outbox.OutboxEvent
+	require.NoError(t, db.First(&row, "id = ?", id).Error)
+	require.Nil(t, row.PublishedAt, "webhook dispatch must not mark outbox rows published")
+}

--- a/services/marketplace-api/internal/webhook/dispatcher_integration_test.go
+++ b/services/marketplace-api/internal/webhook/dispatcher_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -25,6 +26,22 @@ func enqueueOutbox(t *testing.T, db *gorm.DB, tenant uuid.UUID, eventType string
 		INSERT INTO outbox_events (id, tenant_id, aggregate, aggregate_id, event_type, payload)
 		VALUES (?, ?, 'order', ?, ?, ?)`,
 		id, tenant, uuid.New(), eventType, payload).Error)
+	return id
+}
+
+// enqueueOutboxAt inserts an outbox row with an explicit created_at, for
+// tests that need to control ordering directly rather than relying on
+// now() — including two rows sharing the exact same timestamp, which is
+// what a transactional outbox produces for events written in one
+// transaction (Postgres's now() is transaction-start time).
+func enqueueOutboxAt(t *testing.T, db *gorm.DB, tenant uuid.UUID, eventType string, createdAt time.Time) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	payload, _ := json.Marshal(map[string]any{"store_id": uuid.New().String()})
+	require.NoError(t, db.Exec(`
+		INSERT INTO outbox_events (id, tenant_id, aggregate, aggregate_id, event_type, payload, created_at)
+		VALUES (?, ?, 'order', ?, ?, ?, ?)`,
+		id, tenant, uuid.New(), eventType, payload, createdAt).Error)
 	return id
 }
 
@@ -110,4 +127,85 @@ func TestDispatcher_DoesNotTouchOutboxPublishedState(t *testing.T) {
 	var row outbox.OutboxEvent
 	require.NoError(t, db.First(&row, "id = ?", id).Error)
 	require.Nil(t, row.PublishedAt, "webhook dispatch must not mark outbox rows published")
+}
+
+// The bug this whole fix round exists to close: a timestamp-only cursor
+// silently drops any row that lands on the far side of a batch boundary
+// from another row sharing its exact created_at. A transactional outbox
+// makes identical timestamps routine — Postgres's now() is transaction
+// START time, so several events written in one transaction share it — so
+// this is not an edge case.
+func TestDispatcher_TieBreaksIdenticalCreatedAtByID(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
+	resetDispatchCursor(t, db)
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	ctx := context.Background()
+	tenant := uuid.New()
+	newSub(t, subs, tenant, []string{"order.placed"})
+
+	same := time.Now().UTC().Truncate(time.Microsecond)
+	enqueueOutboxAt(t, db, tenant, "order.placed", same)
+	enqueueOutboxAt(t, db, tenant, "order.placed", same)
+	enqueueOutboxAt(t, db, tenant, "order.placed", same)
+
+	// batch=2 forces the tie group to straddle a page boundary: the first
+	// Tick can only take 2 of the 3 tied rows.
+	d := webhook.NewDispatcher(db, subs, deliveries, slog.Default(), 2)
+
+	n1, err := d.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, n1, "first page takes 2 of the 3 tied rows")
+
+	n2, err := d.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, n2, "the row left behind by the tie must still be dispatched on the next tick, not dropped forever")
+
+	var count int64
+	require.NoError(t, db.Model(&webhook.Delivery{}).Count(&count).Error)
+	require.EqualValues(t, 3, count, "all 3 tied events must eventually produce a delivery")
+}
+
+// Companion to the Critical fix: the composite cursor guards against the
+// concurrent-replica case (wired up in Task 6, when KEDA can scale the
+// dispatcher to multiple pods) where an unconditional SET would let a
+// replica working from a stale read walk the cursor backward.
+func TestDispatcher_CursorAdvanceNeverMovesBackward(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
+	resetDispatchCursor(t, db)
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	d := webhook.NewDispatcher(db, subs, deliveries, slog.Default(), 100)
+	ctx := context.Background()
+	tenant := uuid.New()
+	newSub(t, subs, tenant, []string{"order.placed"})
+
+	base := time.Now().UTC().Truncate(time.Microsecond)
+	enqueueOutboxAt(t, db, tenant, "order.placed", base)
+
+	n, err := d.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	// Simulate a faster replica having already pushed the cursor ahead of
+	// anything dispatched so far.
+	future := base.Add(time.Hour)
+	require.NoError(t, db.Exec(
+		`UPDATE webhook_dispatch_cursor SET last_event_created = ?, last_event_id = ?`,
+		future, uuid.New()).Error)
+
+	// A stale event, stamped before that pushed-forward cursor (as a
+	// slower replica's own read might produce), must not pull it back —
+	// and, being behind the cursor, is correctly not dispatched at all.
+	stale := base.Add(-time.Minute)
+	enqueueOutboxAt(t, db, tenant, "order.placed", stale)
+
+	n2, err := d.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, n2, "a stale event behind the cursor is not dispatched")
+
+	var after struct{ LastEventCreated time.Time }
+	require.NoError(t, db.Raw(
+		`SELECT last_event_created FROM webhook_dispatch_cursor WHERE id`).Scan(&after).Error)
+	require.False(t, after.LastEventCreated.Before(future), "cursor must never move backward")
 }

--- a/services/marketplace-api/internal/webhook/dispatcher_integration_test.go
+++ b/services/marketplace-api/internal/webhook/dispatcher_integration_test.go
@@ -20,8 +20,17 @@ import (
 
 func enqueueOutbox(t *testing.T, db *gorm.DB, tenant uuid.UUID, eventType string) uuid.UUID {
 	t.Helper()
+	return enqueueOutboxForStore(t, db, tenant, uuid.New(), eventType)
+}
+
+// enqueueOutboxForStore writes an outbox row whose payload carries an
+// explicit store_id. Fan-out is scoped by (tenant_id, store_id), so a test
+// that cares which subscriptions match has to control the store, not let
+// the helper invent one.
+func enqueueOutboxForStore(t *testing.T, db *gorm.DB, tenant, store uuid.UUID, eventType string) uuid.UUID {
+	t.Helper()
 	id := uuid.New()
-	payload, _ := json.Marshal(map[string]any{"store_id": uuid.New().String()})
+	payload, _ := json.Marshal(map[string]any{"store_id": store.String()})
 	require.NoError(t, db.Exec(`
 		INSERT INTO outbox_events (id, tenant_id, aggregate, aggregate_id, event_type, payload)
 		VALUES (?, ?, 'order', ?, ?, ?)`,
@@ -34,10 +43,10 @@ func enqueueOutbox(t *testing.T, db *gorm.DB, tenant uuid.UUID, eventType string
 // now() — including two rows sharing the exact same timestamp, which is
 // what a transactional outbox produces for events written in one
 // transaction (Postgres's now() is transaction-start time).
-func enqueueOutboxAt(t *testing.T, db *gorm.DB, tenant uuid.UUID, eventType string, createdAt time.Time) uuid.UUID {
+func enqueueOutboxAt(t *testing.T, db *gorm.DB, tenant, store uuid.UUID, eventType string, createdAt time.Time) uuid.UUID {
 	t.Helper()
 	id := uuid.New()
-	payload, _ := json.Marshal(map[string]any{"store_id": uuid.New().String()})
+	payload, _ := json.Marshal(map[string]any{"store_id": store.String()})
 	require.NoError(t, db.Exec(`
 		INSERT INTO outbox_events (id, tenant_id, aggregate, aggregate_id, event_type, payload, created_at)
 		VALUES (?, ?, 'order', ?, ?, ?, ?)`,
@@ -58,8 +67,10 @@ func enqueueOutboxAt(t *testing.T, db *gorm.DB, tenant uuid.UUID, eventType stri
 // place.
 func resetDispatchCursor(t *testing.T, db *gorm.DB) {
 	t.Helper()
-	require.NoError(t, db.Exec(
-		`UPDATE webhook_dispatch_cursor SET last_event_created = 'epoch', last_event_id = NULL`).Error)
+	require.NoError(t, db.Exec(`
+		UPDATE webhook_dispatch_cursor
+		   SET last_event_created = 'epoch', last_event_id = NULL,
+		       swept_created = 'epoch', swept_id = NULL`).Error)
 }
 
 func TestDispatcher_CreatesOneDeliveryPerMatchingSubscription(t *testing.T) {
@@ -71,10 +82,11 @@ func TestDispatcher_CreatesOneDeliveryPerMatchingSubscription(t *testing.T) {
 	ctx := context.Background()
 	tenant := uuid.New()
 
-	newSub(t, subs, tenant, []string{"order.placed"})
-	newSub(t, subs, tenant, []string{"order.placed", "order.refunded"})
-	newSub(t, subs, tenant, []string{"product.created"}) // must not match
-	enqueueOutbox(t, db, tenant, "order.placed")
+	store := uuid.New()
+	newSubForStore(t, subs, tenant, store, []string{"order.placed"})
+	newSubForStore(t, subs, tenant, store, []string{"order.placed", "order.refunded"})
+	newSubForStore(t, subs, tenant, store, []string{"product.created"}) // must not match
+	enqueueOutboxForStore(t, db, tenant, store, "order.placed")
 
 	n, err := d.Tick(ctx)
 	require.NoError(t, err)
@@ -90,8 +102,9 @@ func TestDispatcher_IsIdempotentAcrossRuns(t *testing.T) {
 	deliveries := webhook.NewDeliveryRepo(db)
 	ctx := context.Background()
 	tenant := uuid.New()
-	newSub(t, subs, tenant, []string{"order.placed"})
-	enqueueOutbox(t, db, tenant, "order.placed")
+	store := uuid.New()
+	newSubForStore(t, subs, tenant, store, []string{"order.placed"})
+	enqueueOutboxForStore(t, db, tenant, store, "order.placed")
 
 	first := webhook.NewDispatcher(db, subs, deliveries, slog.Default(), 100)
 	n1, err := first.Tick(ctx)
@@ -118,8 +131,9 @@ func TestDispatcher_DoesNotTouchOutboxPublishedState(t *testing.T) {
 	subs := webhook.NewSubscriptionRepo(db)
 	d := webhook.NewDispatcher(db, subs, webhook.NewDeliveryRepo(db), slog.Default(), 100)
 	tenant := uuid.New()
-	newSub(t, subs, tenant, []string{"order.placed"})
-	id := enqueueOutbox(t, db, tenant, "order.placed")
+	store := uuid.New()
+	newSubForStore(t, subs, tenant, store, []string{"order.placed"})
+	id := enqueueOutboxForStore(t, db, tenant, store, "order.placed")
 
 	_, err := d.Tick(context.Background())
 	require.NoError(t, err)
@@ -141,13 +155,13 @@ func TestDispatcher_TieBreaksIdenticalCreatedAtByID(t *testing.T) {
 	subs := webhook.NewSubscriptionRepo(db)
 	deliveries := webhook.NewDeliveryRepo(db)
 	ctx := context.Background()
-	tenant := uuid.New()
-	newSub(t, subs, tenant, []string{"order.placed"})
+	tenant, store := uuid.New(), uuid.New()
+	newSubForStore(t, subs, tenant, store, []string{"order.placed"})
 
 	same := time.Now().UTC().Truncate(time.Microsecond)
-	enqueueOutboxAt(t, db, tenant, "order.placed", same)
-	enqueueOutboxAt(t, db, tenant, "order.placed", same)
-	enqueueOutboxAt(t, db, tenant, "order.placed", same)
+	enqueueOutboxAt(t, db, tenant, store, "order.placed", same)
+	enqueueOutboxAt(t, db, tenant, store, "order.placed", same)
+	enqueueOutboxAt(t, db, tenant, store, "order.placed", same)
 
 	// batch=2 forces the tie group to straddle a page boundary: the first
 	// Tick can only take 2 of the 3 tied rows.
@@ -166,11 +180,125 @@ func TestDispatcher_TieBreaksIdenticalCreatedAtByID(t *testing.T) {
 	require.EqualValues(t, 3, count, "all 3 tied events must eventually produce a delivery")
 }
 
-// Companion to the Critical fix: the composite cursor guards against the
-// concurrent-replica case (wired up in Task 6, when KEDA can scale the
-// dispatcher to multiple pods) where an unconditional SET would let a
-// replica working from a stale read walk the cursor backward.
-func TestDispatcher_CursorAdvanceNeverMovesBackward(t *testing.T) {
+// Renamed from TestDispatcher_CursorAdvanceNeverMovesBackward, which
+// overstated what it proves. Tick's own WHERE clause means advanceCursor can
+// never be handed a behind-the-watermark candidate single-threaded, so this
+// does NOT exercise the GREATEST guard's real hazard — two dispatcher
+// replicas racing, where a slower one's stale read would otherwise walk a
+// watermark back. That race is not reproducible in a single-threaded test.
+// What this DOES check is the observable contract at the boundary: a Tick
+// running against a forward cursor that another writer has already pushed
+// ahead leaves that advance intact.
+func TestDispatcher_TickLeavesAnAlreadyAdvancedCursorAlone(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
+	resetDispatchCursor(t, db)
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	d := webhook.NewDispatcher(db, subs, deliveries, slog.Default(), 100)
+	ctx := context.Background()
+	tenant, store := uuid.New(), uuid.New()
+	newSubForStore(t, subs, tenant, store, []string{"order.placed"})
+
+	base := time.Now().UTC().Truncate(time.Microsecond)
+	enqueueOutboxAt(t, db, tenant, store, "order.placed", base)
+
+	n, err := d.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	// Simulate a faster replica having pushed both watermarks ahead of
+	// anything dispatched so far.
+	future := base.Add(time.Hour)
+	require.NoError(t, db.Exec(`
+		UPDATE webhook_dispatch_cursor
+		   SET last_event_created = ?, last_event_id = ?,
+		       swept_created = ?, swept_id = ?`,
+		future, uuid.New(), future, uuid.New()).Error)
+
+	n2, err := d.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, n2, "nothing sits ahead of the pushed-forward watermarks")
+
+	var after struct {
+		LastEventCreated time.Time
+		SweptCreated     time.Time
+	}
+	require.NoError(t, db.Raw(
+		`SELECT last_event_created, swept_created FROM webhook_dispatch_cursor WHERE id`).
+		Scan(&after).Error)
+	require.False(t, after.LastEventCreated.Before(future), "forward cursor must never move backward")
+	require.False(t, after.SweptCreated.Before(future), "sweep watermark must never move backward")
+}
+
+// The Critical review finding on the branch: created_at ordering is NOT
+// commit ordering. OutboxEvent.CreatedAt is stamped at INSERT, but the row
+// is invisible until the business transaction commits — and enqueueOutbox
+// is not the last statement before commit (see internal/order/service.go).
+// So a row stamped EARLIER can become visible LATER than one stamped after
+// it. A cursor that advanced strictly to the newest row it had seen would
+// step over the late arrival and never select it again: no error, no retry,
+// no dead-letter, just silent permanent delivery loss. Replica clock skew
+// on `created_at` (it comes from the pod clock) produces the same shape.
+//
+// The lookback window is what closes it: reads also take anything newer
+// than now() - DispatchLookback regardless of the cursor, and the cursor
+// itself never advances past that boundary. Idempotent fan-out is what
+// makes the resulting re-reads free.
+func TestDispatcher_DispatchesAnOutboxRowThatBecameVisibleBehindTheCursor(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
+	resetDispatchCursor(t, db)
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	ctx := context.Background()
+	tenant, store := uuid.New(), uuid.New()
+	newSubForStore(t, subs, tenant, store, []string{"order.placed"})
+
+	// A short lookback so the settled region catches up within the test
+	// rather than five minutes from now. See Dispatcher.WithLookback.
+	const lookback = 300 * time.Millisecond
+	d := webhook.NewDispatcher(db, subs, deliveries, slog.Default(), 100).WithLookback(lookback)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	// The short transaction: stamped later, commits first, so the forward
+	// pass sees only it and the cursor walks past.
+	enqueueOutboxAt(t, db, tenant, store, "order.placed", now)
+	n1, err := d.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, n1)
+
+	// The long transaction finally commits. Its created_at is OLDER than
+	// the row already dispatched, so the forward cursor is past it — this
+	// is the row a single-cursor dispatcher loses silently and forever.
+	late := enqueueOutboxAt(t, db, tenant, store, "order.placed", now.Add(-100*time.Millisecond))
+
+	// Its region has not settled yet, so nothing happens on this tick.
+	n2, err := d.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, n2)
+
+	// Once the lookback has passed, the sweep reaches it.
+	time.Sleep(2 * lookback)
+	n3, err := d.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, n3, "a row that committed behind the cursor must still be dispatched once its region settles")
+
+	var count int64
+	require.NoError(t, db.Model(&webhook.Delivery{}).
+		Where("outbox_event_id = ?", late).Count(&count).Error)
+	require.EqualValues(t, 1, count, "the late-committing event must have produced its delivery")
+
+	// And the sweep must not manufacture a second delivery for the row the
+	// forward pass already handled.
+	var total int64
+	require.NoError(t, db.Model(&webhook.Delivery{}).Count(&total).Error)
+	require.EqualValues(t, 2, total)
+}
+
+// The second Critical finding: fan-out matched on tenant_id alone, so on a
+// multi-store plan (plangate FeatureStores grants 2/5/10) a webhook
+// registered on Store A received Store B's events.
+func TestDispatcher_FansOutOnlyToSubscriptionsOnTheEventsStore(t *testing.T) {
 	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
 	resetDispatchCursor(t, db)
 	subs := webhook.NewSubscriptionRepo(db)
@@ -178,34 +306,19 @@ func TestDispatcher_CursorAdvanceNeverMovesBackward(t *testing.T) {
 	d := webhook.NewDispatcher(db, subs, deliveries, slog.Default(), 100)
 	ctx := context.Background()
 	tenant := uuid.New()
-	newSub(t, subs, tenant, []string{"order.placed"})
+	storeA, storeB := uuid.New(), uuid.New()
 
-	base := time.Now().UTC().Truncate(time.Microsecond)
-	enqueueOutboxAt(t, db, tenant, "order.placed", base)
+	subA := newSubForStore(t, subs, tenant, storeA, []string{"order.placed"})
+	newSubForStore(t, subs, tenant, storeB, []string{"order.placed"})
+
+	enqueueOutboxForStore(t, db, tenant, storeA, "order.placed")
 
 	n, err := d.Tick(ctx)
 	require.NoError(t, err)
-	require.Equal(t, 1, n)
+	require.Equal(t, 1, n, "a store A event must reach store A's subscription only")
 
-	// Simulate a faster replica having already pushed the cursor ahead of
-	// anything dispatched so far.
-	future := base.Add(time.Hour)
-	require.NoError(t, db.Exec(
-		`UPDATE webhook_dispatch_cursor SET last_event_created = ?, last_event_id = ?`,
-		future, uuid.New()).Error)
-
-	// A stale event, stamped before that pushed-forward cursor (as a
-	// slower replica's own read might produce), must not pull it back —
-	// and, being behind the cursor, is correctly not dispatched at all.
-	stale := base.Add(-time.Minute)
-	enqueueOutboxAt(t, db, tenant, "order.placed", stale)
-
-	n2, err := d.Tick(ctx)
-	require.NoError(t, err)
-	require.Equal(t, 0, n2, "a stale event behind the cursor is not dispatched")
-
-	var after struct{ LastEventCreated time.Time }
-	require.NoError(t, db.Raw(
-		`SELECT last_event_created FROM webhook_dispatch_cursor WHERE id`).Scan(&after).Error)
-	require.False(t, after.LastEventCreated.Before(future), "cursor must never move backward")
+	var got []webhook.Delivery
+	require.NoError(t, db.Find(&got).Error)
+	require.Len(t, got, 1)
+	require.Equal(t, subA.ID, got[0].SubscriptionID, "store B's subscription must not receive store A's event")
 }

--- a/services/marketplace-api/internal/webhook/dispatcher_integration_test.go
+++ b/services/marketplace-api/internal/webhook/dispatcher_integration_test.go
@@ -240,10 +240,17 @@ func TestDispatcher_TickLeavesAnAlreadyAdvancedCursorAlone(t *testing.T) {
 // no dead-letter, just silent permanent delivery loss. Replica clock skew
 // on `created_at` (it comes from the pod clock) produces the same shape.
 //
-// The lookback window is what closes it: reads also take anything newer
-// than now() - DispatchLookback regardless of the cursor, and the cursor
-// itself never advances past that boundary. Idempotent fan-out is what
-// makes the resulting re-reads free.
+// Two watermarks are what close it, and this test drives both. The forward
+// cursor (last_event_*) advances freely to the newest row each tick reads,
+// so a normal event is dispatched promptly — and so a late arrival IS
+// stepped over, which is the first half of what is asserted below. The
+// sweep watermark (swept_*) then trails through the region older than
+// now() - DispatchLookback, where every transaction that could have written
+// a row has certainly committed, so the row it missed is picked up exactly
+// once. There is no OR term and no clamp on the forward cursor: each pass
+// has its own LIMIT and advances independently, which is what keeps either
+// from starving the other's backlog. Idempotent fan-out is what makes the
+// overlap between the two passes free.
 func TestDispatcher_DispatchesAnOutboxRowThatBecameVisibleBehindTheCursor(t *testing.T) {
 	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
 	resetDispatchCursor(t, db)

--- a/services/marketplace-api/internal/webhook/models.go
+++ b/services/marketplace-api/internal/webhook/models.go
@@ -1,0 +1,62 @@
+// Package webhook implements merchant-facing outbound webhooks (#562).
+//
+// It is a CONSUMER of internal/outbox, not a producer: outbox_events already
+// records every domain event transactionally. See
+// docs/superpowers/specs/2026-09-02-outbound-webhooks-design.md.
+package webhook
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+)
+
+// MaxEventTypes bounds how many event types one subscription may select.
+// There are 18 today; the cap exists so a malformed request cannot store an
+// unbounded array.
+const MaxEventTypes = 32
+
+// Delivery statuses.
+const (
+	StatusPending   = "pending"
+	StatusDelivered = "delivered"
+	StatusFailed    = "failed"
+)
+
+type Subscription struct {
+	ID         uuid.UUID      `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	TenantID   uuid.UUID      `gorm:"column:tenant_id;type:uuid;not null"                      json:"-"`
+	StoreID    uuid.UUID      `gorm:"column:store_id;type:uuid;not null"                       json:"store_id"`
+	URL        string         `gorm:"column:url;not null"                                      json:"url"`
+	EventTypes pq.StringArray `gorm:"column:event_types;type:text[];not null"                   json:"event_types"`
+	// Secret never leaves the server after creation — the handler returns it
+	// once in its own response field and this tag keeps it out of every
+	// subsequent read.
+	Secret              string     `gorm:"column:secret;not null"                                   json:"-"`
+	Enabled             bool       `gorm:"column:enabled;not null;default:true"                     json:"enabled"`
+	DisabledReason      *string    `gorm:"column:disabled_reason"                                   json:"disabled_reason,omitempty"`
+	DisabledAt          *time.Time `gorm:"column:disabled_at"                                       json:"disabled_at,omitempty"`
+	ConsecutiveFailures int        `gorm:"column:consecutive_failures;not null;default:0"           json:"-"`
+	CreatedAt           time.Time  `gorm:"column:created_at;not null;default:now()"                 json:"created_at"`
+	UpdatedAt           time.Time  `gorm:"column:updated_at;not null;default:now()"                 json:"updated_at"`
+}
+
+func (Subscription) TableName() string { return "webhook_subscriptions" }
+
+type Delivery struct {
+	ID             uuid.UUID  `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	SubscriptionID uuid.UUID  `gorm:"column:subscription_id;type:uuid;not null"                json:"subscription_id"`
+	OutboxEventID  uuid.UUID  `gorm:"column:outbox_event_id;type:uuid;not null"                json:"-"`
+	EventType      string     `gorm:"column:event_type;not null"                               json:"event_type"`
+	AggregateID    uuid.UUID  `gorm:"column:aggregate_id;type:uuid;not null"                   json:"aggregate_id"`
+	Status         string     `gorm:"column:status;not null;default:pending"                   json:"status"`
+	Attempts       int        `gorm:"column:attempts;not null;default:0"                       json:"attempts"`
+	NextAttemptAt  time.Time  `gorm:"column:next_attempt_at;not null;default:now()"            json:"next_attempt_at"`
+	LastStatusCode *int       `gorm:"column:last_status_code"                                  json:"last_status_code,omitempty"`
+	LastError      *string    `gorm:"column:last_error"                                        json:"last_error,omitempty"`
+	DeliveredAt    *time.Time `gorm:"column:delivered_at"                                      json:"delivered_at,omitempty"`
+	CreatedAt      time.Time  `gorm:"column:created_at;not null;default:now()"                 json:"created_at"`
+}
+
+func (Delivery) TableName() string { return "webhook_deliveries" }

--- a/services/marketplace-api/internal/webhook/prune_integration_test.go
+++ b/services/marketplace-api/internal/webhook/prune_integration_test.go
@@ -1,0 +1,50 @@
+//go:build integration
+
+package webhook_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/webhook"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// TestPrune_RemovesRowsPastRetentionAndKeepsRecentOnes is the delivery-table
+// counterpart to the webhook_events prune in internal/webhookprune: 30 days,
+// no plan gate. It ages exactly one of two delivered rows past the window
+// and asserts Prune removes only that row.
+//
+// db is scoped with testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions",
+// "outbox_events") rather than the zero-arg form — a bare Count() here would
+// otherwise be polluted by delivery rows FanOut-ed by sibling tests in this
+// package (the exact issue hit in Task 4).
+func TestPrune_RemovesRowsPastRetentionAndKeepsRecentOnes(t *testing.T) {
+	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	ctx := context.Background()
+	sub := newSub(t, subs, uuid.New(), []string{"order.placed"})
+
+	_, err := deliveries.FanOut(ctx, []webhook.Delivery{
+		{SubscriptionID: sub.ID, OutboxEventID: uuid.New(), EventType: "order.placed", AggregateID: uuid.New(), Status: webhook.StatusDelivered},
+		{SubscriptionID: sub.ID, OutboxEventID: uuid.New(), EventType: "order.placed", AggregateID: uuid.New(), Status: webhook.StatusDelivered},
+	})
+	require.NoError(t, err)
+
+	// Age exactly one row past the window.
+	require.NoError(t, db.Exec(`
+		UPDATE webhook_deliveries SET created_at = now() - interval '31 days'
+		 WHERE id = (SELECT id FROM webhook_deliveries LIMIT 1)`).Error)
+
+	n, err := deliveries.Prune(ctx, webhook.RetentionWindow)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, n)
+
+	var remaining int64
+	require.NoError(t, db.Model(&webhook.Delivery{}).Count(&remaining).Error)
+	require.EqualValues(t, 1, remaining, "a delivery inside the window must survive")
+}

--- a/services/marketplace-api/internal/webhook/sender.go
+++ b/services/marketplace-api/internal/webhook/sender.go
@@ -19,6 +19,19 @@ import (
 // must not hold a goroutine for long.
 const RequestTimeout = 5 * time.Second
 
+// LeaseWindow is how far DeliveryRepo.ClaimDue pushes a claimed delivery's
+// next_attempt_at forward. It exists because FOR UPDATE SKIP LOCKED's row
+// lock is released the instant the claiming transaction commits — long
+// before the HTTP send this package makes actually finishes — so without a
+// lease, a second worker calling ClaimDue while the first is still mid-Send
+// would see the row as due and unlocked, and send it again.
+//
+// It MUST stay comfortably longer than RequestTimeout: shrinking one
+// without the other reopens the double-send window this constant exists to
+// close. 60s against a 5s request timeout leaves generous margin for a slow
+// send plus the time between claiming and issuing the request.
+const LeaseWindow = 60 * time.Second
+
 // maxErrorLen bounds what we store from a failing endpoint's response. The
 // body is surfaced to the merchant to make a broken endpoint debuggable; it
 // is never logged server-side, since it is arbitrary remote content.
@@ -32,6 +45,13 @@ type Sender struct {
 func NewSender(guard *ssrfguard.Guard, client *http.Client) *Sender {
 	if client == nil {
 		client = &http.Client{Timeout: RequestTimeout}
+	} else {
+		// Copy rather than mutate: client may be shared with other callers
+		// (a test's srv.Client(), a caller's own default client). Setting
+		// Transport/CheckRedirect directly on it would silently change its
+		// behavior for everyone else holding a reference.
+		cp := *client
+		client = &cp
 	}
 	if client.Transport == nil {
 		if dt, ok := http.DefaultTransport.(*http.Transport); ok {
@@ -101,11 +121,17 @@ func (s *Sender) Send(ctx context.Context, sub Subscription, d Delivery) (int, e
 		return 0, fmt.Errorf("webhook: request failed: %w", err)
 	}
 	defer res.Body.Close()
-	_, _ = io.CopyN(io.Discard, res.Body, 1<<16)
 
 	if res.StatusCode < 200 || res.StatusCode > 299 {
-		return res.StatusCode, fmt.Errorf("webhook: endpoint returned %d", res.StatusCode)
+		// Captured for the merchant's delivery log — never logged
+		// server-side, since it is arbitrary content from a remote,
+		// merchant-controlled endpoint.
+		snippet, _ := io.ReadAll(io.LimitReader(res.Body, maxErrorLen))
+		return res.StatusCode, fmt.Errorf("webhook: endpoint returned %d: %s", res.StatusCode, snippet)
 	}
+	// A 2xx response body is never surfaced anywhere, so it only needs
+	// draining to let the connection be reused — not reading into memory.
+	_, _ = io.CopyN(io.Discard, res.Body, 1<<16)
 	return res.StatusCode, nil
 }
 
@@ -138,6 +164,10 @@ func (s *Sender) baseTransport() *http.Transport {
 	if tr, ok := s.client.Transport.(*http.Transport); ok {
 		return tr.Clone()
 	}
+	// A custom, non-*http.Transport RoundTripper is deliberately not
+	// preserved here — there's no generic way to clone an arbitrary
+	// RoundTripper and still override DialContext/TLSClientConfig on it, so
+	// falling back to a fresh default transport is the practical choice.
 	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
 		return dt.Clone()
 	}
@@ -150,6 +180,20 @@ func (s *Sender) baseTransport() *http.Transport {
 // names — there is no hostname for a transport to re-resolve, so no rebind
 // window exists, and the guard's resolver output (a mock, in tests) must
 // not override it. Otherwise the guard-validated address is used.
+//
+// This literal-IP branch is provably a no-op in production: real DNS
+// resolves a literal IP to itself, so ssrfguard.CheckResolved's own ips and
+// the literal always agree there — the branch only diverges under a test
+// double like allowAll() that answers every host with the same fixed
+// address regardless of what was asked, which is exactly what lets
+// httptest's loopback TLS servers exercise a real handshake here. It exists
+// for test portability, not as a security shortcut; there is no in-repo way
+// to exercise the guard-resolved branch end-to-end without either a test
+// seam inside isPublic (a seam in security code, worse than not having the
+// test) or a non-loopback test server (not portable). That branch's
+// correctness is instead covered by TestDialPinnedTo_* (the dial mechanism
+// itself) and ssrfguard's own CheckResolved tests (that the IPs it hands
+// back are the ones actually validated), not by an end-to-end Send test.
 func pinnedAddress(host string, ips []net.IP) net.IP {
 	if literal := net.ParseIP(host); literal != nil {
 		return literal

--- a/services/marketplace-api/internal/webhook/sender.go
+++ b/services/marketplace-api/internal/webhook/sender.go
@@ -1,0 +1,205 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/webhook/ssrfguard"
+)
+
+// RequestTimeout bounds one delivery attempt. Short on purpose: these loops
+// run in-process alongside admin API request handling, so a slow endpoint
+// must not hold a goroutine for long.
+const RequestTimeout = 5 * time.Second
+
+// maxErrorLen bounds what we store from a failing endpoint's response. The
+// body is surfaced to the merchant to make a broken endpoint debuggable; it
+// is never logged server-side, since it is arbitrary remote content.
+const maxErrorLen = 500
+
+type Sender struct {
+	guard  *ssrfguard.Guard
+	client *http.Client
+}
+
+func NewSender(guard *ssrfguard.Guard, client *http.Client) *Sender {
+	if client == nil {
+		client = &http.Client{Timeout: RequestTimeout}
+	}
+	if client.Transport == nil {
+		if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+			client.Transport = dt.Clone()
+		}
+	}
+	if client.CheckRedirect == nil {
+		// Never follow redirects: a 302 to an internal address would walk
+		// straight around the guard, which only checked the original host.
+		client.CheckRedirect = func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
+	return &Sender{guard: guard, client: client}
+}
+
+// notification is the notify-and-fetch body. Identifiers only — the merchant
+// calls the REST API for detail, so no customer data reaches a
+// merchant-supplied URL and a retry cannot deliver a stale entity.
+type notification struct {
+	Event      string    `json:"event"`
+	ID         string    `json:"id"`
+	OccurredAt time.Time `json:"occurred_at"`
+}
+
+// Send makes one attempt. It re-checks the URL through the guard FIRST:
+// registration-time validation alone is defeated by DNS rebinding.
+//
+// The connection itself is then pinned to the address the guard just
+// validated (see pinnedTransport) rather than left to the transport's own,
+// separate DNS lookup at dial time — otherwise a rebind between the two
+// resolutions defeats the check entirely instead of merely narrowing its
+// window.
+func (s *Sender) Send(ctx context.Context, sub Subscription, d Delivery) (int, error) {
+	u, ips, err := s.guard.CheckResolved(sub.URL)
+	if err != nil {
+		return 0, fmt.Errorf("webhook: destination refused: %w", err)
+	}
+
+	occurred := d.CreatedAt
+	if occurred.IsZero() {
+		occurred = time.Now()
+	}
+	body, err := json.Marshal(notification{
+		Event:      d.EventType,
+		ID:         d.AggregateID.String(),
+		OccurredAt: occurred.UTC(),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("webhook: marshal notification: %w", err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, RequestTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, sub.URL, bytes.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("webhook: build request: %w", err)
+	}
+	now := time.Now()
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "Mark8ly-Webhooks/1")
+	req.Header.Set(SignatureHeader, Sign(sub.Secret, now, body))
+
+	client := s.pinnedClient(u.Hostname(), ips)
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("webhook: request failed: %w", err)
+	}
+	defer res.Body.Close()
+	_, _ = io.CopyN(io.Discard, res.Body, 1<<16)
+
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		return res.StatusCode, fmt.Errorf("webhook: endpoint returned %d", res.StatusCode)
+	}
+	return res.StatusCode, nil
+}
+
+// pinnedClient returns a client that dials one of ips directly rather than
+// re-resolving host, while still verifying the TLS certificate — and
+// setting SNI — against host. Dialling an IP but checking the certificate
+// against the IP instead of the hostname would break every valid HTTPS
+// endpoint, since certificates are issued for hostnames, not addresses.
+//
+// A fresh transport per call (rather than one shared across the sender's
+// lifetime) is deliberate: every delivery targets a different merchant
+// host and a different validated address, so nothing here is reusable
+// across calls the way keep-alive pooling assumes.
+func (s *Sender) pinnedClient(host string, ips []net.IP) *http.Client {
+	pin := pinnedAddress(host, ips)
+	if pin == nil {
+		return s.client
+	}
+	tr := s.baseTransport()
+	tr.DialContext = dialPinnedTo(pin)
+	tr.TLSClientConfig = cloneTLSConfigForHost(tr.TLSClientConfig, host)
+	return &http.Client{
+		Transport:     tr,
+		Timeout:       s.client.Timeout,
+		CheckRedirect: s.client.CheckRedirect,
+	}
+}
+
+func (s *Sender) baseTransport() *http.Transport {
+	if tr, ok := s.client.Transport.(*http.Transport); ok {
+		return tr.Clone()
+	}
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		return dt.Clone()
+	}
+	return &http.Transport{}
+}
+
+// pinnedAddress picks the address to dial for host.
+//
+// When host is already a literal IP, that literal IS the address the URL
+// names — there is no hostname for a transport to re-resolve, so no rebind
+// window exists, and the guard's resolver output (a mock, in tests) must
+// not override it. Otherwise the guard-validated address is used.
+func pinnedAddress(host string, ips []net.IP) net.IP {
+	if literal := net.ParseIP(host); literal != nil {
+		return literal
+	}
+	if len(ips) == 0 {
+		return nil
+	}
+	return ips[0]
+}
+
+// dialPinnedTo returns a DialContext that connects to ip on the port named
+// in addr, ignoring addr's host entirely. That is the pin: whatever the
+// transport believes the hostname resolves to, this always dials the
+// address the guard already validated.
+func dialPinnedTo(ip net.IP) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		_, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			port = "443"
+		}
+		d := net.Dialer{Timeout: RequestTimeout}
+		return d.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+	}
+}
+
+// cloneTLSConfigForHost clones base (preserving any configured RootCAs,
+// notably a test server's) and points ServerName at host, so certificate
+// verification runs against the hostname the merchant registered rather
+// than the IP address the connection actually dials.
+func cloneTLSConfigForHost(base *tls.Config, host string) *tls.Config {
+	var cfg *tls.Config
+	if base != nil {
+		cfg = base.Clone()
+	} else {
+		cfg = &tls.Config{}
+	}
+	cfg.ServerName = host
+	return cfg
+}
+
+// backoff returns the delay before attempt n (1-based): roughly 30s, 2m,
+// 8m, 32m, 2h, capped. Spread over hours so a merchant restarting a server
+// has time to recover before attempts are exhausted.
+func backoff(attempt int) time.Duration {
+	d := 30 * time.Second
+	for i := 1; i < attempt; i++ {
+		d *= 4
+		if d > 4*time.Hour {
+			return 4 * time.Hour
+		}
+	}
+	return d
+}

--- a/services/marketplace-api/internal/webhook/sender_test.go
+++ b/services/marketplace-api/internal/webhook/sender_test.go
@@ -1,0 +1,168 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/webhook/ssrfguard"
+)
+
+// allowAll resolves every host to a public address so httptest servers on
+// 127.0.0.1 can be exercised. Production passes nil, which uses real DNS.
+func allowAll() *ssrfguard.Guard {
+	return ssrfguard.New(func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	})
+}
+
+func TestSend_PostsSignedNotifyAndFetchBody(t *testing.T) {
+	var gotBody []byte
+	var gotSig string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		gotSig = r.Header.Get(SignatureHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := NewSender(allowAll(), srv.Client())
+	sub := Subscription{ID: uuid.New(), URL: srv.URL, Secret: "shh"}
+	d := Delivery{EventType: "order.placed", AggregateID: uuid.New(), CreatedAt: time.Now()}
+
+	code, err := s.Send(context.Background(), sub, d)
+	if err != nil || code != 200 {
+		t.Fatalf("code=%d err=%v", code, err)
+	}
+	if gotSig == "" {
+		t.Fatal("delivery was not signed")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(gotBody, &payload); err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{"event", "id", "occurred_at"} {
+		if _, ok := payload[k]; !ok {
+			t.Fatalf("payload missing %q: %s", k, gotBody)
+		}
+	}
+	// Notify-and-fetch: the body must NOT carry the entity.
+	if len(payload) != 3 {
+		t.Fatalf("payload should carry exactly event/id/occurred_at, got %v", payload)
+	}
+}
+
+// The guard runs immediately before dialling, not only at registration.
+// This is the DNS-rebinding case: the row was saved when the host was
+// public, and now resolves private.
+func TestSend_RefusesWhenTheHostNowResolvesPrivate(t *testing.T) {
+	rebind := ssrfguard.New(func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("169.254.169.254")}, nil
+	})
+	s := NewSender(rebind, http.DefaultClient)
+	sub := Subscription{ID: uuid.New(), URL: "https://hooks.example.com/x", Secret: "shh"}
+
+	if _, err := s.Send(context.Background(), sub, Delivery{EventType: "order.placed"}); err == nil {
+		t.Fatal("expected delivery to a rebound private address to be refused")
+	}
+}
+
+func TestSend_TreatsNon2xxAsFailureButReturnsTheCode(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	s := NewSender(allowAll(), srv.Client())
+	code, err := s.Send(context.Background(), Subscription{URL: srv.URL, Secret: "x"}, Delivery{EventType: "order.placed"})
+	if err == nil {
+		t.Fatal("non-2xx must be an error")
+	}
+	if code != 500 {
+		t.Fatalf("want the status code surfaced for the merchant log, got %d", code)
+	}
+}
+
+func TestBackoff_GrowsAndIsBounded(t *testing.T) {
+	prev := time.Duration(0)
+	for a := 1; a <= MaxAttempts; a++ {
+		d := backoff(a)
+		if d <= prev {
+			t.Fatalf("backoff must increase: attempt %d gave %v after %v", a, d, prev)
+		}
+		if d > 4*time.Hour {
+			t.Fatalf("backoff unbounded at attempt %d: %v", a, d)
+		}
+		prev = d
+	}
+}
+
+// TestDialPinnedTo_DialsTheGivenIPRegardlessOfAddrsHost proves the sender's
+// dial-pinning mechanism does what it claims: the returned DialContext
+// connects to the IP it was built with, not to whatever host the caller
+// (the http.Transport, in production) passes in addr.
+//
+// The addr host used here, "definitely-not-a-real-host.invalid", is chosen
+// from the IANA-reserved .invalid TLD (RFC 6761) specifically so that it
+// cannot resolve — if dialPinnedTo re-resolved addr's host the way a plain
+// net.Dialer would, this would fail with "no such host". It succeeds only
+// because the pin bypasses that resolution and connects to ip directly,
+// which is exactly the DNS-rebinding protection sender.go depends on: the
+// address dialled is the one the guard already validated, not a second,
+// independent lookup that an attacker's rebind could answer differently.
+func TestDialPinnedTo_DialsTheGivenIPRegardlessOfAddrsHost(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	accepted := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			close(accepted)
+			conn.Close()
+		}
+	}()
+
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("split listener addr: %v", err)
+	}
+
+	dial := dialPinnedTo(net.ParseIP("127.0.0.1"))
+	addr := net.JoinHostPort("definitely-not-a-real-host.invalid", port)
+	conn, err := dial(context.Background(), "tcp", addr)
+	if err != nil {
+		t.Fatalf("pinned dial should ignore addr's unresolvable host and connect to the pinned IP, got: %v", err)
+	}
+	defer conn.Close()
+
+	select {
+	case <-accepted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener never accepted a connection from the pinned dial")
+	}
+}
+
+// TestPinnedAddress_PrefersTheLiteralHostOverResolverOutput documents why
+// pinnedClient does not blindly use whatever the guard's resolver returned:
+// when the URL already names a literal IP (as every httptest server URL
+// does), that literal IS the address — there is no hostname for a
+// transport to re-resolve, so nothing to pin against besides the literal
+// itself, regardless of what a resolver mock happens to answer for it.
+func TestPinnedAddress_PrefersTheLiteralHostOverResolverOutput(t *testing.T) {
+	got := pinnedAddress("127.0.0.1", []net.IP{net.ParseIP("93.184.216.34")})
+	if !got.Equal(net.ParseIP("127.0.0.1")) {
+		t.Fatalf("want literal host address pinned, got %v", got)
+	}
+}

--- a/services/marketplace-api/internal/webhook/sender_test.go
+++ b/services/marketplace-api/internal/webhook/sender_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -88,6 +89,62 @@ func TestSend_TreatsNon2xxAsFailureButReturnsTheCode(t *testing.T) {
 	}
 	if code != 500 {
 		t.Fatalf("want the status code surfaced for the merchant log, got %d", code)
+	}
+}
+
+// TestSend_CapturesTheFailingEndpointsResponseBodyForTheMerchantLog proves
+// last_error ends up with more than a bare status code: the endpoint's own
+// response body, which is what actually makes a broken endpoint debuggable
+// for the merchant (maxErrorLen's doc comment, and migration 000126's
+// last_error column comment, both promise this).
+func TestSend_CapturesTheFailingEndpointsResponseBodyForTheMerchantLog(t *testing.T) {
+	const want = "validation failed: missing signature header"
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(want))
+	}))
+	defer srv.Close()
+
+	s := NewSender(allowAll(), srv.Client())
+	_, err := s.Send(context.Background(), Subscription{URL: srv.URL, Secret: "x"}, Delivery{EventType: "order.placed"})
+	if err == nil {
+		t.Fatal("non-2xx must be an error")
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error should carry the endpoint's response body so the merchant log is debuggable, got: %v", err)
+	}
+}
+
+// TestSend_TruncatesAnOverlongResponseBody proves the capture is bounded by
+// maxErrorLen, not just "whatever the endpoint sent" — an unbounded body
+// from a merchant-controlled endpoint must not be stored as-is.
+func TestSend_TruncatesAnOverlongResponseBody(t *testing.T) {
+	huge := strings.Repeat("x", maxErrorLen*4)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(huge))
+	}))
+	defer srv.Close()
+
+	s := NewSender(allowAll(), srv.Client())
+	_, err := s.Send(context.Background(), Subscription{URL: srv.URL, Secret: "x"}, Delivery{EventType: "order.placed"})
+	if err == nil {
+		t.Fatal("non-2xx must be an error")
+	}
+	if len(err.Error()) >= len(huge) {
+		t.Fatalf("captured body must be bounded by maxErrorLen, got a %d-byte error", len(err.Error()))
+	}
+}
+
+// TestNewSender_DoesNotMutateTheCallersClient proves NewSender takes a
+// shallow copy: a caller's *http.Client (e.g. one shared with other code,
+// or a test's srv.Client()) must not silently inherit the no-redirect
+// policy NewSender sets up for itself.
+func TestNewSender_DoesNotMutateTheCallersClient(t *testing.T) {
+	client := &http.Client{}
+	_ = NewSender(allowAll(), client)
+	if client.CheckRedirect != nil {
+		t.Fatal("NewSender must not mutate the caller's http.Client in place")
 	}
 }
 

--- a/services/marketplace-api/internal/webhook/signing.go
+++ b/services/marketplace-api/internal/webhook/signing.go
@@ -1,0 +1,40 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// SignatureHeader carries the signature on every delivery.
+const SignatureHeader = "X-Mark8ly-Signature"
+
+// Sign returns "t=<unix>,v1=<hex>" over "<unix>.<body>" using secret.
+//
+// The timestamp is part of the SIGNED material, not merely a sibling header:
+// that is what lets a merchant reject a replayed delivery by checking the
+// timestamp is recent, knowing an attacker cannot rewrite it without
+// invalidating v1. The format mirrors Stripe's so the verification recipe is
+// already familiar to most integrators.
+func Sign(secret string, ts time.Time, body []byte) string {
+	unix := strconv.FormatInt(ts.Unix(), 10)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(unix))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	return fmt.Sprintf("t=%s,v1=%s", unix, hex.EncodeToString(mac.Sum(nil)))
+}
+
+// GenerateSecret returns 32 random bytes hex-encoded. Shown to the merchant
+// once at creation and never returned again.
+func GenerateSecret() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("webhook: generate secret: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}

--- a/services/marketplace-api/internal/webhook/signing_test.go
+++ b/services/marketplace-api/internal/webhook/signing_test.go
@@ -1,0 +1,59 @@
+package webhook
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSign_IsStableForTheSameInputs(t *testing.T) {
+	ts := time.Unix(1756800000, 0)
+	a := Sign("shh", ts, []byte(`{"event":"order.placed"}`))
+	b := Sign("shh", ts, []byte(`{"event":"order.placed"}`))
+	if a != b {
+		t.Fatalf("signature not deterministic: %q vs %q", a, b)
+	}
+	if !strings.HasPrefix(a, "t=1756800000,v1=") {
+		t.Fatalf("unexpected format: %q", a)
+	}
+}
+
+// The timestamp must be INSIDE the signed material. If it were only a
+// separate header, a captured delivery could be replayed later with a fresh
+// timestamp and still verify.
+func TestSign_ChangesWithTimestamp(t *testing.T) {
+	body := []byte(`{"event":"order.placed"}`)
+	a := Sign("shh", time.Unix(1756800000, 0), body)
+	b := Sign("shh", time.Unix(1756800001, 0), body)
+	if a == b {
+		t.Fatal("signature must cover the timestamp")
+	}
+}
+
+func TestSign_ChangesWithBodyAndSecret(t *testing.T) {
+	ts := time.Unix(1756800000, 0)
+	base := Sign("shh", ts, []byte(`{"a":1}`))
+	if Sign("shh", ts, []byte(`{"a":2}`)) == base {
+		t.Fatal("signature must cover the body")
+	}
+	if Sign("other", ts, []byte(`{"a":1}`)) == base {
+		t.Fatal("signature must depend on the secret")
+	}
+}
+
+func TestGenerateSecret_IsRandomAndLongEnough(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		s, err := GenerateSecret()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(s) != 64 {
+			t.Fatalf("want 64 hex chars, got %d", len(s))
+		}
+		if seen[s] {
+			t.Fatal("duplicate secret generated")
+		}
+		seen[s] = true
+	}
+}

--- a/services/marketplace-api/internal/webhook/ssrfguard/guard.go
+++ b/services/marketplace-api/internal/webhook/ssrfguard/guard.go
@@ -31,6 +31,34 @@ var (
 // maxURLLen bounds what we will store and log.
 const maxURLLen = 2048
 
+// nonPublicRanges are blocks that net.IP's built-in classifiers do not
+// cover but that must still be refused. Parsed once at package init rather
+// than per-call.
+var nonPublicRanges = mustParseCIDRs(
+	// 0.0.0.0/8: IsUnspecified() only matches the all-zero address, but
+	// Linux — the deployment target, Alpine containers — routinely treats
+	// the whole "this network" block as loopback/local. A documented SSRF
+	// bypass class.
+	"0.0.0.0/8",
+	// 100.64.0.0/10 (RFC 6598, carrier-grade NAT / shared address space):
+	// IsPrivate() covers RFC1918 and fc00::/7 only, but this range is
+	// exactly the kind of address cloud/Kubernetes internal networking
+	// (CNI overlays, NAT gateways) uses on this cluster.
+	"100.64.0.0/10",
+)
+
+func mustParseCIDRs(cidrs ...string) []*net.IPNet {
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		_, n, err := net.ParseCIDR(c)
+		if err != nil {
+			panic("ssrfguard: invalid CIDR literal " + c + ": " + err.Error())
+		}
+		nets = append(nets, n)
+	}
+	return nets
+}
+
 // Resolver looks a hostname up. Injected so tests need no DNS.
 type Resolver func(host string) ([]net.IP, error)
 
@@ -88,6 +116,11 @@ func isPublic(ip net.IP) bool {
 		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
 		ip.IsInterfaceLocalMulticast() || ip.IsMulticast() {
 		return false
+	}
+	for _, n := range nonPublicRanges {
+		if n.Contains(ip) {
+			return false
+		}
 	}
 	return true
 }

--- a/services/marketplace-api/internal/webhook/ssrfguard/guard.go
+++ b/services/marketplace-api/internal/webhook/ssrfguard/guard.go
@@ -76,33 +76,54 @@ func New(r Resolver) *Guard {
 // if ANY resolved address is non-public — an attacker needs only one private
 // answer to be selected at dial time.
 func (g *Guard) Check(raw string) (*url.URL, error) {
+	u, _, err := g.checkResolved(raw)
+	return u, err
+}
+
+// CheckResolved is Check, but also returns the addresses it validated the
+// host against.
+//
+// Check alone tells a caller a URL is safe to dial, but a caller that then
+// hands the URL to an http.Client lets the transport perform its OWN DNS
+// lookup at connect time — a second resolution, after the one Check just
+// did. A resolver that answers public here and private a moment later (a
+// fast DNS rebind) walks straight around the check: Check said yes, and the
+// transport dials whatever the second lookup returns. Callers that dial
+// after checking should pin the connection to one of these addresses
+// instead of letting the transport re-resolve the hostname, which is what
+// actually closes that window rather than just narrowing it.
+func (g *Guard) CheckResolved(raw string) (*url.URL, []net.IP, error) {
+	return g.checkResolved(raw)
+}
+
+func (g *Guard) checkResolved(raw string) (*url.URL, []net.IP, error) {
 	if raw == "" {
-		return nil, ErrMalformed
+		return nil, nil, ErrMalformed
 	}
 	if len(raw) > maxURLLen {
-		return nil, ErrTooLong
+		return nil, nil, ErrTooLong
 	}
 	u, err := url.Parse(raw)
 	if err != nil {
-		return nil, ErrMalformed
+		return nil, nil, ErrMalformed
 	}
 	if u.Scheme != "https" {
-		return nil, ErrNotHTTPS
+		return nil, nil, ErrNotHTTPS
 	}
 	if u.Hostname() == "" {
-		return nil, ErrMalformed
+		return nil, nil, ErrMalformed
 	}
 
 	ips, err := g.resolve(u.Hostname())
 	if err != nil || len(ips) == 0 {
-		return nil, ErrUnresolvable
+		return nil, nil, ErrUnresolvable
 	}
 	for _, ip := range ips {
 		if !isPublic(ip) {
-			return nil, ErrPrivateAddress
+			return nil, nil, ErrPrivateAddress
 		}
 	}
-	return u, nil
+	return u, ips, nil
 }
 
 // isPublic reports whether ip is globally routable. Everything else —

--- a/services/marketplace-api/internal/webhook/ssrfguard/guard.go
+++ b/services/marketplace-api/internal/webhook/ssrfguard/guard.go
@@ -1,0 +1,93 @@
+// Package ssrfguard decides whether a merchant-supplied URL is safe for the
+// cluster to dial.
+//
+// Webhooks are the first feature where merchant input becomes an egress
+// target: every other outbound integration here (payment gateways, carriers,
+// email providers) talks to fixed, configured endpoints. A merchant who can
+// make us POST to an arbitrary URL can otherwise reach the GCP metadata
+// server or any in-cluster service and read the response back out of the
+// delivery log.
+//
+// Check is called at registration AND again immediately before every
+// delivery. Registration-only validation is the usual shortcut and it is
+// defeated by DNS rebinding — a hostname that answers public when saved and
+// private when dialled.
+package ssrfguard
+
+import (
+	"errors"
+	"net"
+	"net/url"
+)
+
+var (
+	ErrNotHTTPS       = errors.New("webhook url must use https")
+	ErrPrivateAddress = errors.New("webhook url resolves to a non-public address")
+	ErrUnresolvable   = errors.New("webhook url host could not be resolved")
+	ErrMalformed      = errors.New("webhook url is malformed")
+	ErrTooLong        = errors.New("webhook url is too long")
+)
+
+// maxURLLen bounds what we will store and log.
+const maxURLLen = 2048
+
+// Resolver looks a hostname up. Injected so tests need no DNS.
+type Resolver func(host string) ([]net.IP, error)
+
+type Guard struct{ resolve Resolver }
+
+// New builds a Guard. Pass nil to use real DNS.
+func New(r Resolver) *Guard {
+	if r == nil {
+		r = net.LookupIP
+	}
+	return &Guard{resolve: r}
+}
+
+// Check parses raw, requires https, resolves the host, and rejects the URL
+// if ANY resolved address is non-public — an attacker needs only one private
+// answer to be selected at dial time.
+func (g *Guard) Check(raw string) (*url.URL, error) {
+	if raw == "" {
+		return nil, ErrMalformed
+	}
+	if len(raw) > maxURLLen {
+		return nil, ErrTooLong
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, ErrMalformed
+	}
+	if u.Scheme != "https" {
+		return nil, ErrNotHTTPS
+	}
+	if u.Hostname() == "" {
+		return nil, ErrMalformed
+	}
+
+	ips, err := g.resolve(u.Hostname())
+	if err != nil || len(ips) == 0 {
+		return nil, ErrUnresolvable
+	}
+	for _, ip := range ips {
+		if !isPublic(ip) {
+			return nil, ErrPrivateAddress
+		}
+	}
+	return u, nil
+}
+
+// isPublic reports whether ip is globally routable. Everything else —
+// loopback, private, link-local (which covers 169.254.169.254, the cloud
+// metadata endpoint), multicast, unspecified — is refused.
+func isPublic(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() || ip.IsMulticast() {
+		return false
+	}
+	return true
+}

--- a/services/marketplace-api/internal/webhook/ssrfguard/guard_test.go
+++ b/services/marketplace-api/internal/webhook/ssrfguard/guard_test.go
@@ -1,0 +1,91 @@
+package ssrfguard
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func fixed(ips ...string) Resolver {
+	return func(string) ([]net.IP, error) {
+		out := make([]net.IP, 0, len(ips))
+		for _, s := range ips {
+			out = append(out, net.ParseIP(s))
+		}
+		return out, nil
+	}
+}
+
+func TestCheck_AllowsPublicHTTPS(t *testing.T) {
+	g := New(fixed("93.184.216.34"))
+	u, err := g.Check("https://hooks.example.com/mark8ly")
+	if err != nil {
+		t.Fatalf("expected public https URL to pass, got %v", err)
+	}
+	if u.Host != "hooks.example.com" {
+		t.Fatalf("host = %q", u.Host)
+	}
+}
+
+func TestCheck_RejectsPlainHTTP(t *testing.T) {
+	g := New(fixed("93.184.216.34"))
+	if _, err := g.Check("http://hooks.example.com/x"); err != ErrNotHTTPS {
+		t.Fatalf("want ErrNotHTTPS, got %v", err)
+	}
+}
+
+// Each of these is a documented SSRF target. A merchant-supplied URL that
+// resolves to any of them must never be dialled.
+func TestCheck_RejectsNonPublicDestinations(t *testing.T) {
+	for name, ip := range map[string]string{
+		"loopback":          "127.0.0.1",
+		"private 10/8":      "10.0.0.5",
+		"private 172.16/12": "172.16.0.5",
+		"private 192.168":   "192.168.1.5",
+		"link-local":        "169.254.1.1",
+		"GCP metadata":      "169.254.169.254",
+		"IPv6 loopback":     "::1",
+		"IPv6 ULA":          "fd00::1",
+		"unspecified":       "0.0.0.0",
+	} {
+		t.Run(name, func(t *testing.T) {
+			g := New(fixed(ip))
+			if _, err := g.Check("https://evil.example.com/x"); err != ErrPrivateAddress {
+				t.Fatalf("want ErrPrivateAddress for %s, got %v", ip, err)
+			}
+		})
+	}
+}
+
+// A hostname that resolves to a mix must be rejected — an attacker only
+// needs one private answer to be picked at dial time.
+func TestCheck_RejectsWhenAnyResolvedAddressIsPrivate(t *testing.T) {
+	g := New(fixed("93.184.216.34", "127.0.0.1"))
+	if _, err := g.Check("https://mixed.example.com/x"); err != ErrPrivateAddress {
+		t.Fatalf("want ErrPrivateAddress, got %v", err)
+	}
+}
+
+func TestCheck_RejectsUnresolvable(t *testing.T) {
+	g := New(func(string) ([]net.IP, error) { return nil, net.UnknownNetworkError("nope") })
+	if _, err := g.Check("https://nx.example.com/x"); err != ErrUnresolvable {
+		t.Fatalf("want ErrUnresolvable, got %v", err)
+	}
+}
+
+func TestCheck_RejectsGarbage(t *testing.T) {
+	g := New(fixed("93.184.216.34"))
+	for _, raw := range []string{"", "not a url", "https://", "ftp://x.example.com"} {
+		if _, err := g.Check(raw); err == nil {
+			t.Fatalf("expected %q to be rejected", raw)
+		}
+	}
+}
+
+func TestCheck_RejectsOverlongURL(t *testing.T) {
+	g := New(fixed("93.184.216.34"))
+	long := "https://hooks.example.com/" + strings.Repeat("a", 3000)
+	if _, err := g.Check(long); err == nil {
+		t.Fatal("expected an overlong URL to be rejected")
+	}
+}

--- a/services/marketplace-api/internal/webhook/ssrfguard/guard_test.go
+++ b/services/marketplace-api/internal/webhook/ssrfguard/guard_test.go
@@ -38,15 +38,17 @@ func TestCheck_RejectsPlainHTTP(t *testing.T) {
 // resolves to any of them must never be dialled.
 func TestCheck_RejectsNonPublicDestinations(t *testing.T) {
 	for name, ip := range map[string]string{
-		"loopback":          "127.0.0.1",
-		"private 10/8":      "10.0.0.5",
-		"private 172.16/12": "172.16.0.5",
-		"private 192.168":   "192.168.1.5",
-		"link-local":        "169.254.1.1",
-		"GCP metadata":      "169.254.169.254",
-		"IPv6 loopback":     "::1",
-		"IPv6 ULA":          "fd00::1",
-		"unspecified":       "0.0.0.0",
+		"loopback":           "127.0.0.1",
+		"private 10/8":       "10.0.0.5",
+		"private 172.16/12":  "172.16.0.5",
+		"private 192.168":    "192.168.1.5",
+		"link-local":         "169.254.1.1",
+		"GCP metadata":       "169.254.169.254",
+		"IPv6 loopback":      "::1",
+		"IPv6 ULA":           "fd00::1",
+		"unspecified":        "0.0.0.0",
+		"0.0.0.0/8 non-zero": "0.0.0.1",
+		"CGNAT shared space": "100.64.0.1",
 	} {
 		t.Run(name, func(t *testing.T) {
 			g := New(fixed(ip))
@@ -54,6 +56,15 @@ func TestCheck_RejectsNonPublicDestinations(t *testing.T) {
 				t.Fatalf("want ErrPrivateAddress for %s, got %v", ip, err)
 			}
 		})
+	}
+}
+
+// 100.63.255.255 sits just below the CGNAT block (100.64.0.0/10) and must
+// still be treated as public — over-blocking is also a defect.
+func TestCheck_AllowsAddressAdjacentToCGNAT(t *testing.T) {
+	g := New(fixed("100.63.255.255"))
+	if _, err := g.Check("https://edge.example.com/x"); err != nil {
+		t.Fatalf("expected address adjacent to CGNAT to pass, got %v", err)
 	}
 }
 

--- a/services/marketplace-api/internal/webhook/subscription_repo.go
+++ b/services/marketplace-api/internal/webhook/subscription_repo.go
@@ -1,0 +1,84 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type SubscriptionRepo struct{ db *gorm.DB }
+
+func NewSubscriptionRepo(db *gorm.DB) *SubscriptionRepo { return &SubscriptionRepo{db: db} }
+
+func (r *SubscriptionRepo) Create(ctx context.Context, s *Subscription) error {
+	if err := r.db.WithContext(ctx).Create(s).Error; err != nil {
+		return fmt.Errorf("webhook: create subscription: %w", err)
+	}
+	return nil
+}
+
+func (r *SubscriptionRepo) ListForStore(ctx context.Context, tenantID, storeID uuid.UUID) ([]Subscription, error) {
+	var out []Subscription
+	err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND store_id = ?", tenantID, storeID).
+		Order("created_at DESC").Find(&out).Error
+	if err != nil {
+		return nil, fmt.Errorf("webhook: list subscriptions: %w", err)
+	}
+	return out, nil
+}
+
+// MatchingEvent returns the ENABLED subscriptions for tenantID that selected
+// eventType. `event_types @> ARRAY[?]` uses the array containment operator so
+// the match happens in Postgres rather than by loading every subscription.
+func (r *SubscriptionRepo) MatchingEvent(ctx context.Context, tenantID uuid.UUID, eventType string) ([]Subscription, error) {
+	var out []Subscription
+	err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND enabled AND event_types @> ARRAY[?]::text[]", tenantID, eventType).
+		Find(&out).Error
+	if err != nil {
+		return nil, fmt.Errorf("webhook: match subscriptions: %w", err)
+	}
+	return out, nil
+}
+
+// RecordFailure increments the consecutive-failure counter and disables the
+// subscription once it reaches threshold, reporting whether it did.
+//
+// The increment and the disable happen in ONE statement so two delivery
+// workers failing concurrently cannot interleave a read-modify-write and
+// lose a count.
+func (r *SubscriptionRepo) RecordFailure(ctx context.Context, id uuid.UUID, threshold int) (bool, error) {
+	var enabled bool
+	err := r.db.WithContext(ctx).Raw(`
+		UPDATE webhook_subscriptions
+		   SET consecutive_failures = consecutive_failures + 1,
+		       enabled = CASE WHEN consecutive_failures + 1 >= ? THEN false ELSE enabled END,
+		       disabled_reason = CASE WHEN consecutive_failures + 1 >= ?
+		            THEN 'Disabled automatically after ' || (consecutive_failures + 1) ||
+		                 ' consecutive delivery failures. Fix the endpoint and re-enable.'
+		            ELSE disabled_reason END,
+		       disabled_at = CASE WHEN consecutive_failures + 1 >= ? THEN now() ELSE disabled_at END,
+		       updated_at = now()
+		 WHERE id = ?
+		RETURNING enabled`, threshold, threshold, threshold, id).Scan(&enabled).Error
+	if err != nil {
+		return false, fmt.Errorf("webhook: record failure: %w", err)
+	}
+	return !enabled, nil
+}
+
+// RecordSuccess clears the counter. Without this an endpoint that fails
+// occasionally over weeks would eventually be disabled despite working.
+func (r *SubscriptionRepo) RecordSuccess(ctx context.Context, id uuid.UUID) error {
+	err := r.db.WithContext(ctx).Exec(`
+		UPDATE webhook_subscriptions
+		   SET consecutive_failures = 0, updated_at = now()
+		 WHERE id = ? AND consecutive_failures <> 0`, id).Error
+	if err != nil {
+		return fmt.Errorf("webhook: record success: %w", err)
+	}
+	return nil
+}

--- a/services/marketplace-api/internal/webhook/subscription_repo.go
+++ b/services/marketplace-api/internal/webhook/subscription_repo.go
@@ -19,6 +19,19 @@ func (r *SubscriptionRepo) Create(ctx context.Context, s *Subscription) error {
 	return nil
 }
 
+// ByID returns one subscription, or (nil, nil) if it no longer exists.
+func (r *SubscriptionRepo) ByID(ctx context.Context, id uuid.UUID) (*Subscription, error) {
+	var s Subscription
+	err := r.db.WithContext(ctx).First(&s, "id = ?", id).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("webhook: get subscription: %w", err)
+	}
+	return &s, nil
+}
+
 func (r *SubscriptionRepo) ListForStore(ctx context.Context, tenantID, storeID uuid.UUID) ([]Subscription, error) {
 	var out []Subscription
 	err := r.db.WithContext(ctx).

--- a/services/marketplace-api/internal/webhook/subscription_repo.go
+++ b/services/marketplace-api/internal/webhook/subscription_repo.go
@@ -74,13 +74,23 @@ func (r *SubscriptionRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
-// MatchingEvent returns the ENABLED subscriptions for tenantID that selected
-// eventType. `event_types @> ARRAY[?]` uses the array containment operator so
-// the match happens in Postgres rather than by loading every subscription.
-func (r *SubscriptionRepo) MatchingEvent(ctx context.Context, tenantID uuid.UUID, eventType string) ([]Subscription, error) {
+// MatchingEvent returns the ENABLED subscriptions for one (tenant, store)
+// that selected eventType. `event_types @> ARRAY[?]` uses the array
+// containment operator so the match happens in Postgres rather than by
+// loading every subscription.
+//
+// store_id is part of the predicate, not decoration. It is NOT NULL on the
+// table, it scopes ListForStore and ownedSubscription, and merchants see it
+// in admin — so matching on tenant_id alone let a webhook registered on one
+// store receive another store's events for any merchant on a multi-store
+// plan (plangate FeatureStores). The payload is identifier-only, so the
+// merchant could not even see the leak: their follow-up API fetch just
+// 404s. Migration 000127 carries the matching partial index.
+func (r *SubscriptionRepo) MatchingEvent(ctx context.Context, tenantID, storeID uuid.UUID, eventType string) ([]Subscription, error) {
 	var out []Subscription
 	err := r.db.WithContext(ctx).
-		Where("tenant_id = ? AND enabled AND event_types @> ARRAY[?]::text[]", tenantID, eventType).
+		Where("tenant_id = ? AND store_id = ? AND enabled AND event_types @> ARRAY[?]::text[]",
+			tenantID, storeID, eventType).
 		Find(&out).Error
 	if err != nil {
 		return nil, fmt.Errorf("webhook: match subscriptions: %w", err)

--- a/services/marketplace-api/internal/webhook/subscription_repo.go
+++ b/services/marketplace-api/internal/webhook/subscription_repo.go
@@ -43,6 +43,37 @@ func (r *SubscriptionRepo) ListForStore(ctx context.Context, tenantID, storeID u
 	return out, nil
 }
 
+// Update persists url/event_types/enabled/disabled_reason/disabled_at for a
+// subscription the caller has already verified belongs to their tenant and
+// store — this method itself does not re-check ownership, matching ByID.
+func (r *SubscriptionRepo) Update(ctx context.Context, s *Subscription) error {
+	err := r.db.WithContext(ctx).Model(&Subscription{}).
+		Where("id = ?", s.ID).
+		Updates(map[string]any{
+			"url":                  s.URL,
+			"event_types":          s.EventTypes,
+			"enabled":              s.Enabled,
+			"disabled_reason":      s.DisabledReason,
+			"disabled_at":          s.DisabledAt,
+			"consecutive_failures": s.ConsecutiveFailures,
+			"updated_at":           gorm.Expr("now()"),
+		}).Error
+	if err != nil {
+		return fmt.Errorf("webhook: update subscription: %w", err)
+	}
+	return nil
+}
+
+// Delete removes a subscription the caller has already verified belongs to
+// their tenant and store. webhook_deliveries.subscription_id is ON DELETE
+// CASCADE, so this also clears its delivery history.
+func (r *SubscriptionRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	if err := r.db.WithContext(ctx).Delete(&Subscription{}, "id = ?", id).Error; err != nil {
+		return fmt.Errorf("webhook: delete subscription: %w", err)
+	}
+	return nil
+}
+
 // MatchingEvent returns the ENABLED subscriptions for tenantID that selected
 // eventType. `event_types @> ARRAY[?]` uses the array containment operator so
 // the match happens in Postgres rather than by loading every subscription.

--- a/services/marketplace-api/internal/webhook/subscription_repo.go
+++ b/services/marketplace-api/internal/webhook/subscription_repo.go
@@ -45,29 +45,55 @@ func (r *SubscriptionRepo) MatchingEvent(ctx context.Context, tenantID uuid.UUID
 }
 
 // RecordFailure increments the consecutive-failure counter and disables the
-// subscription once it reaches threshold, reporting whether it did.
+// subscription once it reaches threshold, reporting whether THIS call is the
+// one that flipped it from enabled to disabled — not whether it is disabled
+// now. A subscription already disabled by a prior call must report false, or
+// Task 5's "notify the merchant once" logic would re-fire on every
+// subsequent failure against a dead endpoint.
 //
-// The increment and the disable happen in ONE statement so two delivery
-// workers failing concurrently cannot interleave a read-modify-write and
-// lose a count.
+// The `old` CTE takes the row lock (FOR UPDATE) and `upd` reads
+// consecutive_failures/enabled through that same locked row, so the whole
+// read-increment-disable happens as one statement: two delivery workers
+// failing concurrently cannot interleave a read-modify-write and lose a
+// count.
+//
+// An id that matches no row leaves both CTEs empty, so the final SELECT
+// returns zero rows; RowsAffected is then 0 and we report (false, nil)
+// rather than misreporting a disable for a subscription that doesn't exist.
 func (r *SubscriptionRepo) RecordFailure(ctx context.Context, id uuid.UUID, threshold int) (bool, error) {
-	var enabled bool
-	err := r.db.WithContext(ctx).Raw(`
-		UPDATE webhook_subscriptions
-		   SET consecutive_failures = consecutive_failures + 1,
-		       enabled = CASE WHEN consecutive_failures + 1 >= ? THEN false ELSE enabled END,
-		       disabled_reason = CASE WHEN consecutive_failures + 1 >= ?
-		            THEN 'Disabled automatically after ' || (consecutive_failures + 1) ||
-		                 ' consecutive delivery failures. Fix the endpoint and re-enable.'
-		            ELSE disabled_reason END,
-		       disabled_at = CASE WHEN consecutive_failures + 1 >= ? THEN now() ELSE disabled_at END,
-		       updated_at = now()
-		 WHERE id = ?
-		RETURNING enabled`, threshold, threshold, threshold, id).Scan(&enabled).Error
-	if err != nil {
-		return false, fmt.Errorf("webhook: record failure: %w", err)
+	var result struct {
+		WasEnabled bool
+		IsEnabled  bool
 	}
-	return !enabled, nil
+	tx := r.db.WithContext(ctx).Raw(`
+		WITH old AS (
+			SELECT enabled AS was_enabled, consecutive_failures
+			  FROM webhook_subscriptions
+			 WHERE id = ?
+			   FOR UPDATE
+		), upd AS (
+			UPDATE webhook_subscriptions s
+			   SET consecutive_failures = old.consecutive_failures + 1,
+			       enabled = CASE WHEN old.consecutive_failures + 1 >= ? THEN false ELSE s.enabled END,
+			       disabled_reason = CASE WHEN old.consecutive_failures + 1 >= ?
+			            THEN 'Disabled automatically after ' || (old.consecutive_failures + 1) ||
+			                 ' consecutive delivery failures. Fix the endpoint and re-enable.'
+			            ELSE s.disabled_reason END,
+			       disabled_at = CASE WHEN old.consecutive_failures + 1 >= ? THEN now() ELSE s.disabled_at END,
+			       updated_at = now()
+			  FROM old
+			 WHERE s.id = ?
+			RETURNING s.enabled AS is_enabled
+		)
+		SELECT old.was_enabled, upd.is_enabled FROM old, upd`,
+		id, threshold, threshold, threshold, id).Scan(&result)
+	if tx.Error != nil {
+		return false, fmt.Errorf("webhook: record failure: %w", tx.Error)
+	}
+	if tx.RowsAffected == 0 {
+		return false, nil
+	}
+	return result.WasEnabled && !result.IsEnabled, nil
 }
 
 // RecordSuccess clears the counter. Without this an endpoint that fails

--- a/services/marketplace-api/internal/webhook/subscription_repo_integration_test.go
+++ b/services/marketplace-api/internal/webhook/subscription_repo_integration_test.go
@@ -15,9 +15,17 @@ import (
 
 func newSub(t *testing.T, repo *webhook.SubscriptionRepo, tenant uuid.UUID, events []string) *webhook.Subscription {
 	t.Helper()
+	return newSubForStore(t, repo, tenant, uuid.New(), events)
+}
+
+// newSubForStore is newSub with the store pinned. Fan-out matches on
+// (tenant_id, store_id), so any test asserting who receives a delivery has
+// to name the store rather than take a random one.
+func newSubForStore(t *testing.T, repo *webhook.SubscriptionRepo, tenant, store uuid.UUID, events []string) *webhook.Subscription {
+	t.Helper()
 	s := &webhook.Subscription{
 		TenantID:   tenant,
-		StoreID:    uuid.New(),
+		StoreID:    store,
 		URL:        "https://hooks.example.com/x",
 		EventTypes: events,
 		Secret:     "s3cret-value-for-test",
@@ -33,17 +41,39 @@ func TestMatchingEvent_ReturnsOnlyEnabledSubscriptionsWantingThatType(t *testing
 	tenant := uuid.New()
 	ctx := context.Background()
 
-	want := newSub(t, repo, tenant, []string{"order.placed", "order.refunded"})
-	newSub(t, repo, tenant, []string{"product.created"})  // wrong type
-	newSub(t, repo, uuid.New(), []string{"order.placed"}) // wrong tenant
-	disabled := newSub(t, repo, tenant, []string{"order.placed"})
+	store := uuid.New()
+	want := newSubForStore(t, repo, tenant, store, []string{"order.placed", "order.refunded"})
+	newSubForStore(t, repo, tenant, store, []string{"product.created"})   // wrong type
+	newSubForStore(t, repo, uuid.New(), store, []string{"order.placed"})  // wrong tenant
+	newSubForStore(t, repo, tenant, uuid.New(), []string{"order.placed"}) // wrong store
+	disabled := newSubForStore(t, repo, tenant, store, []string{"order.placed"})
 	_, err := repo.RecordFailure(ctx, disabled.ID, 1) // threshold 1 → disabled
 	require.NoError(t, err)
 
-	got, err := repo.MatchingEvent(ctx, tenant, "order.placed")
+	got, err := repo.MatchingEvent(ctx, tenant, store, "order.placed")
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	require.Equal(t, want.ID, got[0].ID)
+}
+
+// The Critical review finding on the whole branch: webhook_subscriptions
+// carries a NOT NULL store_id that scopes every merchant-facing read, but
+// the fan-out match ignored it — so on a multi-store plan a webhook
+// registered on Store A received Store B's events, with an
+// identifier-only payload that gave the merchant no way to tell.
+func TestMatchingEvent_DoesNotLeakAcrossStoresInOneTenant(t *testing.T) {
+	db := testdb.NewDB(t)
+	repo := webhook.NewSubscriptionRepo(db)
+	tenant := uuid.New()
+	storeA, storeB := uuid.New(), uuid.New()
+
+	subA := newSubForStore(t, repo, tenant, storeA, []string{"order.placed"})
+	newSubForStore(t, repo, tenant, storeB, []string{"order.placed"})
+
+	got, err := repo.MatchingEvent(context.Background(), tenant, storeA, "order.placed")
+	require.NoError(t, err)
+	require.Len(t, got, 1, "a store B subscription must not match a store A event")
+	require.Equal(t, subA.ID, got[0].ID)
 }
 
 func TestRecordFailure_DisablesAtThresholdAndRecordsWhy(t *testing.T) {

--- a/services/marketplace-api/internal/webhook/subscription_repo_integration_test.go
+++ b/services/marketplace-api/internal/webhook/subscription_repo_integration_test.go
@@ -1,0 +1,91 @@
+//go:build integration
+
+package webhook_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/webhook"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+func newSub(t *testing.T, repo *webhook.SubscriptionRepo, tenant uuid.UUID, events []string) *webhook.Subscription {
+	t.Helper()
+	s := &webhook.Subscription{
+		TenantID:   tenant,
+		StoreID:    uuid.New(),
+		URL:        "https://hooks.example.com/x",
+		EventTypes: events,
+		Secret:     "s3cret-value-for-test",
+		Enabled:    true,
+	}
+	require.NoError(t, repo.Create(context.Background(), s))
+	return s
+}
+
+func TestMatchingEvent_ReturnsOnlyEnabledSubscriptionsWantingThatType(t *testing.T) {
+	db := testdb.NewDB(t)
+	repo := webhook.NewSubscriptionRepo(db)
+	tenant := uuid.New()
+	ctx := context.Background()
+
+	want := newSub(t, repo, tenant, []string{"order.placed", "order.refunded"})
+	newSub(t, repo, tenant, []string{"product.created"})  // wrong type
+	newSub(t, repo, uuid.New(), []string{"order.placed"}) // wrong tenant
+	disabled := newSub(t, repo, tenant, []string{"order.placed"})
+	_, err := repo.RecordFailure(ctx, disabled.ID, 1) // threshold 1 → disabled
+	require.NoError(t, err)
+
+	got, err := repo.MatchingEvent(ctx, tenant, "order.placed")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, want.ID, got[0].ID)
+}
+
+func TestRecordFailure_DisablesAtThresholdAndRecordsWhy(t *testing.T) {
+	db := testdb.NewDB(t)
+	repo := webhook.NewSubscriptionRepo(db)
+	ctx := context.Background()
+	s := newSub(t, repo, uuid.New(), []string{"order.placed"})
+
+	disabled, err := repo.RecordFailure(ctx, s.ID, 3)
+	require.NoError(t, err)
+	require.False(t, disabled, "one failure must not disable a subscription")
+
+	_, err = repo.RecordFailure(ctx, s.ID, 3)
+	require.NoError(t, err)
+	disabled, err = repo.RecordFailure(ctx, s.ID, 3)
+	require.NoError(t, err)
+	require.True(t, disabled, "third consecutive failure should disable")
+
+	all, err := repo.ListForStore(ctx, s.TenantID, s.StoreID)
+	require.NoError(t, err)
+	require.False(t, all[0].Enabled)
+	require.NotNil(t, all[0].DisabledReason, "merchant must be told why")
+	require.NotNil(t, all[0].DisabledAt)
+}
+
+// A working delivery after a failure must clear the counter, or an endpoint
+// that fails intermittently over weeks would eventually be disabled despite
+// mostly working.
+func TestRecordSuccess_ResetsTheFailureCounter(t *testing.T) {
+	db := testdb.NewDB(t)
+	repo := webhook.NewSubscriptionRepo(db)
+	ctx := context.Background()
+	s := newSub(t, repo, uuid.New(), []string{"order.placed"})
+
+	_, err := repo.RecordFailure(ctx, s.ID, 3)
+	require.NoError(t, err)
+	require.NoError(t, repo.RecordSuccess(ctx, s.ID))
+
+	// Two more failures must not disable — the counter restarted.
+	_, err = repo.RecordFailure(ctx, s.ID, 3)
+	require.NoError(t, err)
+	disabled, err := repo.RecordFailure(ctx, s.ID, 3)
+	require.NoError(t, err)
+	require.False(t, disabled)
+}

--- a/services/marketplace-api/internal/webhook/subscription_repo_integration_test.go
+++ b/services/marketplace-api/internal/webhook/subscription_repo_integration_test.go
@@ -89,3 +89,31 @@ func TestRecordSuccess_ResetsTheFailureCounter(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, disabled)
 }
+
+// A further failure against an already-disabled subscription must not
+// report a fresh disable, or Task 5's delivery worker would email the
+// merchant "your webhook was disabled" on every subsequent failure against
+// a dead endpoint instead of once.
+func TestRecordFailure_AlreadyDisabledDoesNotReportAFreshDisable(t *testing.T) {
+	db := testdb.NewDB(t)
+	repo := webhook.NewSubscriptionRepo(db)
+	ctx := context.Background()
+	s := newSub(t, repo, uuid.New(), []string{"order.placed"})
+
+	disabled, err := repo.RecordFailure(ctx, s.ID, 1)
+	require.NoError(t, err)
+	require.True(t, disabled, "first failure at threshold 1 disables and reports it")
+
+	disabled, err = repo.RecordFailure(ctx, s.ID, 1)
+	require.NoError(t, err)
+	require.False(t, disabled, "already-disabled subscription must not report another disable")
+}
+
+func TestRecordFailure_UnknownIDDoesNotReportADisable(t *testing.T) {
+	db := testdb.NewDB(t)
+	repo := webhook.NewSubscriptionRepo(db)
+
+	disabled, err := repo.RecordFailure(context.Background(), uuid.New(), 1)
+	require.NoError(t, err)
+	require.False(t, disabled, "an unknown id must not report a disable")
+}

--- a/services/marketplace-api/internal/webhook/worker.go
+++ b/services/marketplace-api/internal/webhook/worker.go
@@ -53,6 +53,22 @@ func (w *Worker) attempt(ctx context.Context, d Delivery) {
 		return // subscription deleted mid-flight; the cascade will clean up
 	}
 
+	// Auto-disable stops the DISPATCHER creating new deliveries (it matches
+	// only enabled subscriptions), but says nothing about deliveries already
+	// pending when the subscription was disabled. Without this check those
+	// keep being claimed and sent — for hours, across the full retry
+	// schedule — which is a softer version of the "cluster making outbound
+	// requests indefinitely" that design decision 3 rejects. Retire them
+	// instead: failed, visible in the delivery log, and replayable once the
+	// merchant fixes the endpoint and re-enables.
+	if !sub.Enabled {
+		reason := "subscription disabled; delivery not attempted"
+		if err := w.deliveries.RecordOutcome(ctx, d.ID, StatusFailed, nil, &reason, 0); err != nil && w.logger != nil {
+			w.logger.Error("webhook: retire delivery for disabled subscription failed", "err", err)
+		}
+		return
+	}
+
 	code, sendErr := w.sender.Send(ctx, *sub, d)
 	var codePtr *int
 	if code != 0 {
@@ -60,7 +76,7 @@ func (w *Worker) attempt(ctx context.Context, d Delivery) {
 	}
 
 	if sendErr == nil {
-		if err := w.deliveries.RecordOutcome(ctx, d.ID, StatusDelivered, codePtr, nil, time.Now()); err != nil && w.logger != nil {
+		if err := w.deliveries.RecordOutcome(ctx, d.ID, StatusDelivered, codePtr, nil, 0); err != nil && w.logger != nil {
 			w.logger.Error("webhook: record delivered failed", "err", err)
 		}
 		if err := w.subs.RecordSuccess(ctx, sub.ID); err != nil && w.logger != nil {
@@ -72,11 +88,11 @@ func (w *Worker) attempt(ctx context.Context, d Delivery) {
 	// Never log the endpoint's response body — arbitrary remote content.
 	msg := truncate(sendErr.Error(), maxErrorLen)
 	attempts := d.Attempts + 1
-	status, next := StatusPending, time.Now().Add(backoff(attempts))
+	status, retryIn := StatusPending, backoff(attempts)
 	if attempts >= MaxAttempts {
-		status, next = StatusFailed, time.Now()
+		status, retryIn = StatusFailed, time.Duration(0)
 	}
-	if err := w.deliveries.RecordOutcome(ctx, d.ID, status, codePtr, &msg, next); err != nil && w.logger != nil {
+	if err := w.deliveries.RecordOutcome(ctx, d.ID, status, codePtr, &msg, retryIn); err != nil && w.logger != nil {
 		w.logger.Error("webhook: record failure failed", "err", err)
 	}
 

--- a/services/marketplace-api/internal/webhook/worker.go
+++ b/services/marketplace-api/internal/webhook/worker.go
@@ -1,0 +1,132 @@
+package webhook
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+const (
+	// MaxAttempts before a delivery is dead-lettered.
+	MaxAttempts = 6
+	// FailureThreshold of CONSECUTIVE failures before the subscription is
+	// disabled and the merchant told. Higher than MaxAttempts so one bad
+	// delivery cannot disable a working endpoint — it takes sustained
+	// failure across different events.
+	FailureThreshold = 10
+	// RetentionWindow for delivery rows. 30 days on every plan.
+	RetentionWindow = 30 * 24 * time.Hour
+)
+
+// Worker drains webhook_deliveries.
+type Worker struct {
+	deliveries *DeliveryRepo
+	subs       *SubscriptionRepo
+	sender     *Sender
+	logger     *slog.Logger
+	batch      int
+	notify     func(sub Subscription)
+}
+
+func NewWorker(deliveries *DeliveryRepo, subs *SubscriptionRepo, sender *Sender, logger *slog.Logger, batch int, notify func(Subscription)) *Worker {
+	if batch <= 0 {
+		batch = 4 // bounded: these goroutines share a pod with API traffic
+	}
+	return &Worker{deliveries: deliveries, subs: subs, sender: sender, logger: logger, batch: batch, notify: notify}
+}
+
+// Tick sends one batch. Returns how many deliveries were attempted.
+func (w *Worker) Tick(ctx context.Context) (int, error) {
+	due, err := w.deliveries.ClaimDue(ctx, w.batch)
+	if err != nil {
+		return 0, err
+	}
+	for _, d := range due {
+		w.attempt(ctx, d)
+	}
+	return len(due), nil
+}
+
+func (w *Worker) attempt(ctx context.Context, d Delivery) {
+	sub, err := w.subs.ByID(ctx, d.SubscriptionID)
+	if err != nil || sub == nil {
+		return // subscription deleted mid-flight; the cascade will clean up
+	}
+
+	code, sendErr := w.sender.Send(ctx, *sub, d)
+	var codePtr *int
+	if code != 0 {
+		codePtr = &code
+	}
+
+	if sendErr == nil {
+		if err := w.deliveries.RecordOutcome(ctx, d.ID, StatusDelivered, codePtr, nil, time.Now()); err != nil && w.logger != nil {
+			w.logger.Error("webhook: record delivered failed", "err", err)
+		}
+		if err := w.subs.RecordSuccess(ctx, sub.ID); err != nil && w.logger != nil {
+			w.logger.Error("webhook: record success failed", "err", err)
+		}
+		return
+	}
+
+	// Never log the endpoint's response body — arbitrary remote content.
+	msg := truncate(sendErr.Error(), maxErrorLen)
+	attempts := d.Attempts + 1
+	status, next := StatusPending, time.Now().Add(backoff(attempts))
+	if attempts >= MaxAttempts {
+		status, next = StatusFailed, time.Now()
+	}
+	if err := w.deliveries.RecordOutcome(ctx, d.ID, status, codePtr, &msg, next); err != nil && w.logger != nil {
+		w.logger.Error("webhook: record failure failed", "err", err)
+	}
+
+	if status != StatusFailed {
+		return
+	}
+	w.disableIfExhausted(ctx, *sub)
+}
+
+func (w *Worker) disableIfExhausted(ctx context.Context, sub Subscription) {
+	disabled, err := w.subs.RecordFailure(ctx, sub.ID, FailureThreshold)
+	if err != nil && w.logger != nil {
+		w.logger.Error("webhook: record subscription failure", "err", err)
+	}
+	if !disabled {
+		return
+	}
+	if w.logger != nil {
+		w.logger.Warn("webhook subscription auto-disabled",
+			slog.String("subscription_id", sub.ID.String()))
+	}
+	if w.notify != nil {
+		w.notify(sub)
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+// Start runs Tick on an interval until ctx is cancelled.
+func (w *Worker) Start(ctx context.Context, interval time.Duration) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if _, err := w.Tick(ctx); err != nil && w.logger != nil {
+					w.logger.Error("webhook worker tick failed", "err", err)
+				}
+			}
+		}
+	}()
+	return done
+}

--- a/services/marketplace-api/internal/webhook/worker_integration_test.go
+++ b/services/marketplace-api/internal/webhook/worker_integration_test.go
@@ -1,0 +1,145 @@
+//go:build integration
+
+package webhook_test
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/webhook"
+	"github.com/mark8ly/marketplace-api/internal/webhook/ssrfguard"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+func TestWorker_DeliversAndMarksDelivered(t *testing.T) {
+	var hits int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	guard := ssrfguard.New(func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	})
+	w := webhook.NewWorker(deliveries, subs, webhook.NewSender(guard, srv.Client()), slog.Default(), 4, nil)
+	ctx := context.Background()
+
+	sub := newSub(t, subs, uuid.New(), []string{"order.placed"})
+	require.NoError(t, db.Exec(`UPDATE webhook_subscriptions SET url = ? WHERE id = ?`, srv.URL, sub.ID).Error)
+	_, err := deliveries.FanOut(ctx, []webhook.Delivery{{
+		SubscriptionID: sub.ID, OutboxEventID: uuid.New(), EventType: "order.placed",
+		AggregateID: uuid.New(), Status: webhook.StatusPending, NextAttemptAt: time.Now(),
+	}})
+	require.NoError(t, err)
+
+	n, err := w.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.EqualValues(t, 1, atomic.LoadInt32(&hits))
+
+	var got webhook.Delivery
+	require.NoError(t, db.First(&got).Error)
+	require.Equal(t, webhook.StatusDelivered, got.Status)
+	require.NotNil(t, got.DeliveredAt)
+}
+
+func TestWorker_RetriesWithBackoffThenDeadLetters(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+
+	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	guard := ssrfguard.New(func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	})
+	w := webhook.NewWorker(deliveries, subs, webhook.NewSender(guard, srv.Client()), slog.Default(), 4, nil)
+	ctx := context.Background()
+
+	sub := newSub(t, subs, uuid.New(), []string{"order.placed"})
+	require.NoError(t, db.Exec(`UPDATE webhook_subscriptions SET url = ? WHERE id = ?`, srv.URL, sub.ID).Error)
+	_, err := deliveries.FanOut(ctx, []webhook.Delivery{{
+		SubscriptionID: sub.ID, OutboxEventID: uuid.New(), EventType: "order.placed",
+		AggregateID: uuid.New(), Status: webhook.StatusPending, NextAttemptAt: time.Now(),
+	}})
+	require.NoError(t, err)
+
+	for i := 0; i < webhook.MaxAttempts; i++ {
+		_, err := w.Tick(ctx)
+		require.NoError(t, err)
+		// Make the next attempt due immediately rather than sleeping out the backoff.
+		require.NoError(t, db.Exec(`UPDATE webhook_deliveries SET next_attempt_at = now()`).Error)
+	}
+
+	var got webhook.Delivery
+	require.NoError(t, db.First(&got).Error)
+	require.Equal(t, webhook.StatusFailed, got.Status)
+	require.Equal(t, webhook.MaxAttempts, got.Attempts)
+	require.NotNil(t, got.LastStatusCode)
+	require.Equal(t, 500, *got.LastStatusCode)
+}
+
+// TestWorker_DisablesSubscriptionExactlyOnceAndNotifies exercises the
+// notify-once contract RecordFailure was built for in Task 2: the worker
+// must call the notify callback on the tick that flips the subscription
+// disabled, and never again for further failures against the same dead
+// endpoint.
+func TestWorker_DisablesSubscriptionExactlyOnceAndNotifies(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+
+	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	guard := ssrfguard.New(func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	})
+
+	var notifyCount int32
+	w := webhook.NewWorker(deliveries, subs, webhook.NewSender(guard, srv.Client()), slog.Default(), 4,
+		func(webhook.Subscription) { atomic.AddInt32(&notifyCount, 1) })
+	ctx := context.Background()
+
+	sub := newSub(t, subs, uuid.New(), []string{"order.placed"})
+	require.NoError(t, db.Exec(`UPDATE webhook_subscriptions SET url = ? WHERE id = ?`, srv.URL, sub.ID).Error)
+
+	// RecordFailure only increments once per DEAD-LETTERED delivery (see
+	// worker.go's disableIfExhausted), not once per failed HTTP attempt —
+	// so tripping FailureThreshold takes that many separate deliveries
+	// exhausting their retries, not that many attempts.
+	for i := 0; i < webhook.FailureThreshold; i++ {
+		_, err := deliveries.FanOut(ctx, []webhook.Delivery{{
+			SubscriptionID: sub.ID, OutboxEventID: uuid.New(), EventType: "order.placed",
+			AggregateID: uuid.New(), Status: webhook.StatusPending, NextAttemptAt: time.Now(),
+		}})
+		require.NoError(t, err)
+		for a := 0; a < webhook.MaxAttempts; a++ {
+			_, err := w.Tick(ctx)
+			require.NoError(t, err)
+			require.NoError(t, db.Exec(`UPDATE webhook_deliveries SET next_attempt_at = now() WHERE status = ?`, webhook.StatusPending).Error)
+		}
+	}
+
+	require.EqualValues(t, 1, atomic.LoadInt32(&notifyCount), "notify must fire exactly once")
+
+	var got webhook.Subscription
+	require.NoError(t, db.First(&got, "id = ?", sub.ID).Error)
+	require.False(t, got.Enabled)
+}

--- a/services/marketplace-api/internal/webhook/worker_integration_test.go
+++ b/services/marketplace-api/internal/webhook/worker_integration_test.go
@@ -99,6 +99,20 @@ func TestWorker_RetriesWithBackoffThenDeadLetters(t *testing.T) {
 // must call the notify callback on the tick that flips the subscription
 // disabled, and never again for further failures against the same dead
 // endpoint.
+//
+// This drives the boundary directly rather than grinding up to it: earlier
+// this test drove FailureThreshold (10) separate deliveries through
+// MaxAttempts (6) real TLS round-trips each — 60 requests plus 60 DB
+// updates — to reach the one dead-letter that flips the subscription
+// disabled. That loop is not what's under test; RecordFailure only
+// increments consecutive_failures once per DEAD-LETTERED delivery (see
+// worker.go's disableIfExhausted), not once per failed HTTP attempt, so the
+// grind was purely mechanical repetition to get the counter to
+// FailureThreshold-1. Seeding consecutive_failures directly gets to the
+// same starting point in one UPDATE, and the two deliveries actually
+// exercised below are what the test is really asserting about: the
+// tick that crosses the threshold, and the tick after that proves the
+// notify doesn't fire again for the same already-disabled endpoint.
 func TestWorker_DisablesSubscriptionExactlyOnceAndNotifies(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
@@ -120,11 +134,12 @@ func TestWorker_DisablesSubscriptionExactlyOnceAndNotifies(t *testing.T) {
 	sub := newSub(t, subs, uuid.New(), []string{"order.placed"})
 	require.NoError(t, db.Exec(`UPDATE webhook_subscriptions SET url = ? WHERE id = ?`, srv.URL, sub.ID).Error)
 
-	// RecordFailure only increments once per DEAD-LETTERED delivery (see
-	// worker.go's disableIfExhausted), not once per failed HTTP attempt —
-	// so tripping FailureThreshold takes that many separate deliveries
-	// exhausting their retries, not that many attempts.
-	for i := 0; i < webhook.FailureThreshold; i++ {
+	// Seed one failure short of the threshold, so the very next dead-lettered
+	// delivery is the one that crosses it.
+	require.NoError(t, db.Exec(`UPDATE webhook_subscriptions SET consecutive_failures = ? WHERE id = ?`,
+		webhook.FailureThreshold-1, sub.ID).Error)
+
+	driveOneDeliveryToDeadLetter := func() {
 		_, err := deliveries.FanOut(ctx, []webhook.Delivery{{
 			SubscriptionID: sub.ID, OutboxEventID: uuid.New(), EventType: "order.placed",
 			AggregateID: uuid.New(), Status: webhook.StatusPending, NextAttemptAt: time.Now(),
@@ -137,9 +152,18 @@ func TestWorker_DisablesSubscriptionExactlyOnceAndNotifies(t *testing.T) {
 		}
 	}
 
-	require.EqualValues(t, 1, atomic.LoadInt32(&notifyCount), "notify must fire exactly once")
+	// First dead-letter crosses the threshold: notify fires, subscription disables.
+	driveOneDeliveryToDeadLetter()
+	require.EqualValues(t, 1, atomic.LoadInt32(&notifyCount), "notify must fire on the tick that disables the subscription")
 
 	var got webhook.Subscription
 	require.NoError(t, db.First(&got, "id = ?", sub.ID).Error)
 	require.False(t, got.Enabled)
+
+	// Second dead-letter against the same already-disabled endpoint: notify
+	// must NOT fire again. This is the half of the contract a naive
+	// implementation (notify on every dead-letter rather than only on the
+	// disabling transition) would silently fail.
+	driveOneDeliveryToDeadLetter()
+	require.EqualValues(t, 1, atomic.LoadInt32(&notifyCount), "notify must not fire again for an already-disabled subscription")
 }

--- a/services/marketplace-api/internal/webhook/worker_integration_test.go
+++ b/services/marketplace-api/internal/webhook/worker_integration_test.go
@@ -167,3 +167,56 @@ func TestWorker_DisablesSubscriptionExactlyOnceAndNotifies(t *testing.T) {
 	driveOneDeliveryToDeadLetter()
 	require.EqualValues(t, 1, atomic.LoadInt32(&notifyCount), "notify must not fire again for an already-disabled subscription")
 }
+
+// Important review finding: auto-disable stopped NEW deliveries being
+// created (the dispatcher only matches enabled subscriptions) but did
+// nothing about the ones already pending. Those kept being claimed and sent
+// for hours — a softer version of the "cluster making outbound requests
+// indefinitely" that design decision 3 explicitly rejects. A pending
+// delivery for a disabled subscription must be retired, not sent.
+func TestWorker_DoesNotSendPendingDeliveriesForADisabledSubscription(t *testing.T) {
+	var hits int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	db := testdb.NewDB(t, "webhook_deliveries", "webhook_subscriptions", "outbox_events")
+	subs := webhook.NewSubscriptionRepo(db)
+	deliveries := webhook.NewDeliveryRepo(db)
+	guard := ssrfguard.New(func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	})
+	w := webhook.NewWorker(deliveries, subs, webhook.NewSender(guard, srv.Client()), slog.Default(), 4, nil)
+	ctx := context.Background()
+
+	sub := newSub(t, subs, uuid.New(), []string{"order.placed"})
+	require.NoError(t, db.Exec(`UPDATE webhook_subscriptions SET url = ? WHERE id = ?`, srv.URL, sub.ID).Error)
+
+	// The delivery is created while the subscription is still enabled…
+	_, err := deliveries.FanOut(ctx, []webhook.Delivery{{
+		SubscriptionID: sub.ID, OutboxEventID: uuid.New(), EventType: "order.placed",
+		AggregateID: uuid.New(), Status: webhook.StatusPending,
+	}})
+	require.NoError(t, err)
+
+	// …and the subscription is disabled before the worker gets to it.
+	require.NoError(t, db.Exec(
+		`UPDATE webhook_subscriptions SET enabled = false, disabled_at = now() WHERE id = ?`, sub.ID).Error)
+
+	n, err := w.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, n, "the delivery is still claimed — it has to be retired somewhere")
+	require.EqualValues(t, 0, atomic.LoadInt32(&hits), "no outbound request may be made for a disabled subscription")
+
+	var got webhook.Delivery
+	require.NoError(t, db.First(&got).Error)
+	require.Equal(t, webhook.StatusFailed, got.Status, "the delivery must be retired, not left pending to be re-claimed forever")
+
+	// And it must stay retired, not come back round on the next tick.
+	n2, err := w.Tick(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, n2)
+	require.EqualValues(t, 0, atomic.LoadInt32(&hits))
+}

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 125
+const ExpectedSchemaVersion uint = 126

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 126
+const ExpectedSchemaVersion uint = 127

--- a/services/marketplace-api/migrations/000126_webhook_subscriptions.down.sql
+++ b/services/marketplace-api/migrations/000126_webhook_subscriptions.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS webhook_dispatch_cursor;
+DROP TABLE IF EXISTS webhook_deliveries;
+DROP TABLE IF EXISTS webhook_subscriptions;

--- a/services/marketplace-api/migrations/000126_webhook_subscriptions.up.sql
+++ b/services/marketplace-api/migrations/000126_webhook_subscriptions.up.sql
@@ -1,0 +1,74 @@
+-- Migration 126: outbound webhooks (#562).
+--
+-- Consumes the existing transactional outbox rather than instrumenting new
+-- events: outbox_events already carries 18 domain events written in the same
+-- transaction as the mutation that produced them.
+--
+-- Two tables, deliberately separate from outbox_events. A merchant's dead
+-- endpoint must never stall the outbox watermark publisher, whose recovery
+-- semantics are documented in internal/outbox/models.go (#336).
+CREATE TABLE IF NOT EXISTS webhook_subscriptions (
+    id                   UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id            UUID         NOT NULL,
+    store_id             UUID         NOT NULL,
+    url                  VARCHAR(2048) NOT NULL,
+    -- Event types this subscription wants, e.g. {order.placed,order.refunded}.
+    -- Values come from internal/outbox's Event* constants.
+    event_types          TEXT[]       NOT NULL,
+    -- HMAC signing secret. Shown to the merchant once at creation.
+    secret               VARCHAR(128) NOT NULL,
+    enabled              BOOLEAN      NOT NULL DEFAULT true,
+    -- Set when the platform auto-disables after sustained failure, so the
+    -- merchant is told WHY rather than finding a silently dead webhook.
+    disabled_reason      TEXT,
+    disabled_at          TIMESTAMPTZ,
+    consecutive_failures INTEGER      NOT NULL DEFAULT 0,
+    created_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+-- The dispatcher's hot path: "enabled subscriptions for this tenant".
+CREATE INDEX IF NOT EXISTS idx_webhook_subs_tenant_enabled
+    ON webhook_subscriptions (tenant_id) WHERE enabled;
+
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+    id                UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    subscription_id   UUID         NOT NULL REFERENCES webhook_subscriptions(id) ON DELETE CASCADE,
+    outbox_event_id   UUID         NOT NULL,
+    event_type        VARCHAR(64)  NOT NULL,
+    aggregate_id      UUID         NOT NULL,
+    status            VARCHAR(16)  NOT NULL DEFAULT 'pending',
+    attempts          INTEGER      NOT NULL DEFAULT 0,
+    next_attempt_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    last_status_code  INTEGER,
+    -- Truncated by the worker before insert. Surfaced to the merchant so a
+    -- failing endpoint is debuggable; never logged server-side.
+    last_error        TEXT,
+    delivered_at      TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+-- This is what makes fan-out idempotent. The dispatcher inserts with
+-- ON CONFLICT DO NOTHING against it, so re-running over the same outbox
+-- rows cannot double-deliver — which is how we get exactly-once fan-out
+-- without coupling to the outbox publisher's transaction.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webhook_deliveries_event_sub
+    ON webhook_deliveries (outbox_event_id, subscription_id);
+
+-- The worker's claim query.
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_due
+    ON webhook_deliveries (next_attempt_at) WHERE status = 'pending';
+
+-- Prune scan (30-day retention on every plan, see the design doc).
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_created
+    ON webhook_deliveries (created_at);
+
+-- The dispatcher's own cursor over outbox_events. Deliberately NOT the
+-- publisher's watermark: the two consumers advance independently, so a
+-- stalled webhook dispatch cannot hold back outbox publishing.
+CREATE TABLE IF NOT EXISTS webhook_dispatch_cursor (
+    id                  BOOLEAN     PRIMARY KEY DEFAULT true CHECK (id),
+    last_event_created  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_event_id       UUID
+);
+INSERT INTO webhook_dispatch_cursor (id) VALUES (true) ON CONFLICT DO NOTHING;

--- a/services/marketplace-api/migrations/000127_webhook_dispatch_sweep.down.sql
+++ b/services/marketplace-api/migrations/000127_webhook_dispatch_sweep.down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE webhook_dispatch_cursor
+    DROP COLUMN IF EXISTS swept_created,
+    DROP COLUMN IF EXISTS swept_id;
+
+-- Restore 000126's tenant-only partial index.
+DROP INDEX IF EXISTS idx_webhook_subs_tenant_store_enabled;
+
+CREATE INDEX IF NOT EXISTS idx_webhook_subs_tenant_enabled
+    ON webhook_subscriptions (tenant_id) WHERE enabled;

--- a/services/marketplace-api/migrations/000127_webhook_dispatch_sweep.up.sql
+++ b/services/marketplace-api/migrations/000127_webhook_dispatch_sweep.up.sql
@@ -1,0 +1,44 @@
+-- Migration 127: store-scoped fan-out, and a sweep watermark for the
+-- dispatcher's late-commit safety net (#562).
+--
+-- (1) webhook_subscriptions.store_id is NOT NULL and scopes every
+-- merchant-facing read (ListForStore, ownedSubscription) and the admin UI,
+-- but the fan-out query that decides who RECEIVES a delivery matched on
+-- tenant_id alone. On a paid plan (plangate FeatureStores grants 2/5/10
+-- stores) a webhook registered on Store A therefore also received Store B's
+-- events — and because the payload is identifier-only the merchant could
+-- not even tell: their follow-up API fetch just 404s.
+--
+-- SubscriptionRepo.MatchingEvent now filters on (tenant_id, store_id), so
+-- the partial index behind it has to carry store_id too. 000126 has already
+-- been applied, so this replaces its index rather than editing it.
+DROP INDEX IF EXISTS idx_webhook_subs_tenant_enabled;
+
+CREATE INDEX IF NOT EXISTS idx_webhook_subs_tenant_store_enabled
+    ON webhook_subscriptions (tenant_id, store_id) WHERE enabled;
+
+-- (2) A second watermark on the dispatch cursor.
+--
+-- outbox_events.created_at is stamped at INSERT, but the row is invisible
+-- until the business transaction commits — and the enqueue is not the last
+-- statement before commit. So a row stamped EARLIER can become visible
+-- LATER than one stamped after it, and the (created_at, id) cursor, having
+-- already walked past, would never select it again: silent, permanent
+-- delivery loss. Replica clock skew produces the same shape, since
+-- created_at comes from the pod clock.
+--
+-- last_event_* stays the prompt forward cursor. swept_* trails it through
+-- the region old enough that every transaction touching it has certainly
+-- committed (now() - webhook.DispatchLookback), so nothing can be missed
+-- there. Fan-out is idempotent, so the sweep's re-reads cost nothing.
+--
+-- Seeded from last_event_* rather than from epoch: a fresh sweep watermark
+-- at epoch would walk the entire history of outbox_events and fan months of
+-- old orders out to live merchant endpoints.
+ALTER TABLE webhook_dispatch_cursor
+    ADD COLUMN IF NOT EXISTS swept_created TIMESTAMPTZ NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS swept_id      UUID;
+
+UPDATE webhook_dispatch_cursor
+   SET swept_created = last_event_created,
+       swept_id      = last_event_id;


### PR DESCRIPTION
Closes #562. Implements the design in `docs/superpowers/specs/2026-09-02-outbound-webhooks-design.md`, executed against `docs/superpowers/plans/2026-09-02-outbound-webhooks.md`.

Merchants register an HTTPS endpoint, choose event types, and receive signed notifications when order, return, product and category events occur.

## The shape

The expensive part already existed. `outbox_events` is a transactional outbox carrying **18 domain events**, written in the same transaction as the mutation that produces them. This feature is a *consumer* of that stream, not new instrumentation — which is what made it a contained piece of work rather than the multi-week build it first looked like.

```
outbox_events ──(dispatcher: forward pass + settled-region sweep)──▶ webhook_deliveries ──(worker)──▶ merchant endpoint
                                                                            ▲
                                                              webhook_subscriptions
```

Both loops run in-process beside the existing `outbox.Publisher` on admin-mode engines. The existing publisher is **not** touched: welding unbounded-latency network work into the watermark publisher — whose recovery semantics `outbox/models.go` documents as subtle (#336) — was rejected deliberately. A merchant's dead endpoint must never stall internal bookkeeping. Idempotent fan-out on `(outbox_event_id, subscription_id)` recovers the exactly-once property that coupling would have bought.

## Design decisions

| Decision | Why |
|---|---|
| **Notify-and-fetch payload** (`event`, `id`, `occurred_at`) | No customer PII to merchant-supplied URLs; a retry can't deliver a stale entity |
| **Strict URL validation, re-resolved at delivery, dial pinned to the validated IP** | Registration-only checking is defeated by DNS rebinding |
| **Retry → dead-letter → auto-disable** | A webhook that stopped working silently is worse than one that says so |
| **Every plan** | The events already exist; gating is friction |
| **30-day delivery retention on all plans** | Deliberately not `FeatureAuditRetentionDays` — "forever" retention of delivery bodies is storage cost on a `db-f1-micro` with no merchant value |

## What review caught

Ten tasks, each implemented then reviewed, then a whole-branch review. Five defects would have shipped as silent production incidents:

1. **SSRF guard missed `0.0.0.0/8` and `100.64.0.0/10`** (CGNAT). `net.IP`'s built-ins cover neither, and CGNAT is what Kubernetes CNI overlays use — on this cluster.
2. **`RecordFailure` reported "just disabled" on every failure** once a subscription was already disabled. The worker uses that boolean to notify the merchant, so a dead endpoint's retries would have emailed them repeatedly.
3. **The dispatch cursor lost events permanently.** `created_at` ordering is not commit ordering — `enqueueOutbox` isn't the last statement before commit, so a transaction inserting early and committing late fell behind an advanced cursor and was *never* selected again. Fixed with a prompt forward pass plus a **sweep over the settled region** (`created_at <= now() - 5min`), which provably passes every row exactly once regardless of commit interleaving.
4. **`FOR UPDATE SKIP LOCKED` outside a transaction does nothing.** Postgres commits a lone statement's implicit transaction immediately, releasing the locks before the HTTP call — two replicas would have sent the same delivery. Fixed with a short claim-lease (60s) committed *before* the send, deliberately not holding a connection across a remote call.
5. **Fan-out ignored `store_id`.** On any multi-store plan (2/5/10 stores) a webhook on Store A received Store B's events, and the thin payload meant the merchant couldn't tell.

Three more came from **guards in packages nobody touched** — a tenant-purge coverage guard, an integration-test-registration guard, and a schema-version guard. Each caught a gap left by an earlier task that a narrow test run would have missed.

## Verification

- Full integration suite run solo: **123 packages `ok`, 0 failures**
- `go build`, `go vet`, `gofmt` clean; `tsc --noEmit` clean; `next build` succeeds with `/settings/webhooks` in the route manifest
- Migrations `000126` and `000127` round-trip
- Every Critical fix was written test-first and confirmed failing against the pre-fix code

## Known gaps, filed not hidden

- **#585** — webhooks ship on every plan but the read-only API they depend on is Studio+. A Starter merchant gets an id they can't resolve. The design predicted this; it needs a product decision.
- **#586** — no cap on subscriptions per store. Chunking the fan-out insert removed a global-outage poison pill; it did not add a limit.
- **#587** — the delivery-prune CronJob must land in `tesserix-k8s` or the 30-day retention is unenforced.
- **Auto-disable does not email the merchant** — `notify` is wired `nil`. The reason surfaces prominently in admin instead. Design doc and `docs/webhooks.md` were amended to say what actually ships rather than what was aspired to.

## Out of scope, deliberately

**Custom code injection** — the other half of #544. Arbitrary `<script>` in merchant storefronts is XSS against their customers by design and permanently weakens the storefront CSP. `pricing-surfaces-truth.spec.ts` was narrowed to keep pinning it while releasing the webhooks half.
