### PR TITLE
fix(marketplace-api): build webhook-delivery-prune-cron into the runtime image

### DIFF
--- a/services/marketplace-api/Dockerfile
+++ b/services/marketplace-api/Dockerfile
@@ -24,7 +24,9 @@ RUN go build -trimpath -ldflags="-s -w" \
  && go build -trimpath -ldflags="-s -w" \
       -o /out/refund-sweep-cron ./cmd/refund-sweep-cron \
  && go build -trimpath -ldflags="-s -w" \
-      -o /out/stock-hold-sweep-cron ./cmd/stock-hold-sweep-cron
+      -o /out/stock-hold-sweep-cron ./cmd/stock-hold-sweep-cron \
+ && go build -trimpath -ldflags="-s -w" \
+      -o /out/webhook-delivery-prune-cron ./cmd/webhook-delivery-prune-cron
 
 # ─── migrate ────────────────────────────────────────────────────────────
 # Standalone image used by the K8s Job pattern.
@@ -34,14 +36,20 @@ CMD ["/usr/local/bin/migrate"]
 
 # ─── runtime ────────────────────────────────────────────────────────────
 # Runtime image carries every binary — server (default ENTRYPOINT), the
-# migrate CLI at /usr/local/bin/migrate, the refund-sweep-cron and the
-# stock-hold-sweep-cron — so the Helm init container and the CronJobs can
-# override ENTRYPOINT and run migrations / the stuck-refund sweeper / the
-# expired-hold sweeper from the same image.
+# migrate CLI at /usr/local/bin/migrate, the refund-sweep-cron, the
+# stock-hold-sweep-cron and the webhook-delivery-prune-cron — so the Helm
+# init container and the CronJobs can override ENTRYPOINT and run
+# migrations / the stuck-refund sweeper / the expired-hold sweeper / the
+# outbound-delivery pruner from the same image.
+#
+# webhook-delivery-prune-cron prunes webhook_deliveries (OUTBOUND merchant
+# webhooks). It is NOT internal/webhookprune, which prunes webhook_events
+# (the inbound provider log) in-process inside marketplace-api.
 FROM ghcr.io/tesserix/base-distroless-static@sha256:0d68ca8037f210e82e211017dbf49b54cde04c42a47baa5c5e429dee07b29c14 AS runtime
 COPY --from=builder --chown=10001:10001 /out/marketplace-api /usr/local/bin/marketplace-api
 COPY --from=builder --chown=10001:10001 /out/migrate /usr/local/bin/migrate
 COPY --from=builder --chown=10001:10001 /out/refund-sweep-cron /usr/local/bin/refund-sweep-cron
 COPY --from=builder --chown=10001:10001 /out/stock-hold-sweep-cron /usr/local/bin/stock-hold-sweep-cron
+COPY --from=builder --chown=10001:10001 /out/webhook-delivery-prune-cron /usr/local/bin/webhook-delivery-prune-cron
 EXPOSE 8091
 CMD ["/usr/local/bin/marketplace-api"]


### PR DESCRIPTION
Part 1 of 2 for #587.

## The gap

#562 added `services/marketplace-api/cmd/webhook-delivery-prune-cron` and `DeliveryRepo.Prune`, both tested. The Dockerfile was never updated, so the binary **is not in the runtime image** — it builds only `marketplace-api`, `migrate`, `refund-sweep-cron` and `stock-hold-sweep-cron`.

#587 asks for a CronJob in `tesserix-k8s`. Shipped against today's image, that CronJob would CrashLoop on a missing entrypoint. This PR closes the half of the gap that lives in this repo.

## Changes

- Build `webhook-delivery-prune-cron` in the builder stage
- `COPY` it into the runtime stage alongside the other cron binaries
- Extend the runtime-stage comment, including an explicit note that this is **not** `internal/webhookprune` (which prunes `webhook_events`, the inbound provider log, in-process). Two jobs, near-identical names, different tables — the mix-up #562 renamed the binary to prevent.

## Test plan

- [x] `go build ./cmd/webhook-delivery-prune-cron` succeeds
- [ ] CI image build succeeds and the runtime image contains `/usr/local/bin/webhook-delivery-prune-cron`

## Merge order

**This must merge and be promoted by Kargo before** the `tesserix-k8s` CronJob PR (tesserix-k8s: `feat/587-webhook-delivery-prune-cronjob`) is merged. Reverse the order and the CronJob CrashLoops until the next promotion.

Refs #587, #562.