### PR TITLE
fix(marketplace-api): log refund-sweep row skips so a persistently stuck refund is visible

### DIFF
--- a/services/marketplace-api/cmd/refund-sweep-cron/main.go
+++ b/services/marketplace-api/cmd/refund-sweep-cron/main.go
@@ -53,7 +53,11 @@ func main() {
 	// enabled=true: the sweep is itself the recovery path for the
 	// REFUND_GATEWAY_ENABLED kill switch — a stuck pending row must still be
 	// re-driven so a later flip back to enabled doesn't leave it orphaned.
-	coord := orderrefund.NewCoordinator(conn, res, pay, orders, order.NewRepository(), true)
+	// WithLogger is what makes the sweep's per-row skips visible (#169).
+	// Without it ResumePending drops every skip silently and a persistently
+	// stuck refund looks identical to a clean run reporting resumed=0.
+	coord := orderrefund.NewCoordinator(conn, res, pay, orders, order.NewRepository(), true).
+		WithLogger(log)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()

--- a/services/marketplace-api/internal/orderrefund/coordinator.go
+++ b/services/marketplace-api/internal/orderrefund/coordinator.go
@@ -107,6 +107,12 @@ func (c *Coordinator) logError(msg string, args ...any) {
 	}
 }
 
+func (c *Coordinator) logWarn(msg string, args ...any) {
+	if c.logger != nil {
+		c.logger.Warn(msg, args...)
+	}
+}
+
 // storeCreditRefundID is the provider_refund_id for a refund that moved no
 // gateway money — the gateway portion was already fully returned and this
 // refund is pure store credit. A synthetic id keeps the ledger row uniform
@@ -509,14 +515,21 @@ func (c *Coordinator) ResumePending(ctx context.Context, olderThan time.Duration
 		row := rows[i]
 		oid, err := uuid.Parse(row.OrderID)
 		if err != nil {
+			c.logWarn("refund sweep: skipped row, unparseable order_id",
+				"refund_id", row.ID, "order_id", row.OrderID, "err", err)
 			continue
 		}
 		o, _, _, err := c.orderRepo.GetByID(ctx, c.db, oid)
 		if err != nil || o == nil {
+			c.logWarn("refund sweep: skipped row, order not loadable",
+				"refund_id", row.ID, "order_id", oid, "missing", o == nil, "err", err)
 			continue
 		}
 		gw, err := c.res.GatewayFor(ctx, o.StoreID, row.Provider)
 		if err != nil {
+			c.logWarn("refund sweep: skipped row, no gateway for store/provider",
+				"refund_id", row.ID, "order_id", oid, "store_id", o.StoreID,
+				"provider", row.Provider, "err", err)
 			continue
 		}
 
@@ -526,6 +539,8 @@ func (c *Coordinator) ResumePending(ctx context.Context, olderThan time.Duration
 		// for more than it captured.
 		split, err := c.resumeSplit(ctx, o, row)
 		if err != nil {
+			c.logWarn("refund sweep: skipped row, could not re-derive gateway/credit split",
+				"refund_id", row.ID, "order_id", oid, "err", err)
 			continue
 		}
 
@@ -540,9 +555,16 @@ func (c *Coordinator) ResumePending(ctx context.Context, olderThan time.Duration
 				// 'failed' so subsequent sweeps skip it (the claim query only
 				// selects 'pending'). Transient failures are left pending to
 				// retry on the next sweep.
-				if payment.IsPermanentGatewayError(rErr) {
+				permanent := payment.IsPermanentGatewayError(rErr)
+				if permanent {
 					_ = c.pay.MarkRefundFailed(ctx, c.db, row.ID)
 				}
+				// Permanent rows are logged once and never re-read (the claim
+				// query selects only 'pending'); a transient row logs on every
+				// sweep, which is what makes a persistently-stuck refund visible.
+				c.logWarn("refund sweep: gateway refund failed",
+					"refund_id", row.ID, "order_id", oid, "provider", row.Provider,
+					"permanent", permanent, "err", rErr)
 				continue
 			}
 			providerRefundID = ref.ProviderRefundID
@@ -587,6 +609,11 @@ func (c *Coordinator) ResumePending(ctx context.Context, olderThan time.Duration
 			c.returnGiftCardPortion(ctx, tx, locked, row.Reason)
 			return nil
 		}); err != nil {
+			// The gateway may already have moved money here — the row stays
+			// 'pending' and the next sweep re-drives it under the same
+			// idempotency key, so this logs until it resolves.
+			c.logWarn("refund sweep: finalize transaction failed, row left pending",
+				"refund_id", row.ID, "order_id", oid, "err", err)
 			continue
 		}
 		if finalized {

--- a/services/marketplace-api/internal/orderrefund/sweeper_integration_test.go
+++ b/services/marketplace-api/internal/orderrefund/sweeper_integration_test.go
@@ -3,8 +3,11 @@
 package orderrefund_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -190,5 +193,72 @@ func TestResumePending_DoubleRun_BumpsOnce(t *testing.T) {
 	o := getOrder(t, db, orderID)
 	if !o.RefundedAmount.Equal(decimal.RequireFromString("100.00")) {
 		t.Fatalf("refunded_amount = %s, want 100.00 (must not be double-bumped by the second run)", o.RefundedAmount)
+	}
+}
+
+// TestResumePending_LogsSkippedRow pins the observability contract from #169:
+// a row the sweep cannot re-drive must leave a log line naming the refund and
+// the reason. Before this, every skip was a bare `continue` — a persistently
+// stuck refund was indistinguishable from a clean run reporting resumed=0,
+// which is exactly how one goes unnoticed for weeks.
+//
+// The gateway-failure path is used because it is the skip an operator is most
+// likely to actually hit (the sweeper CronJob has no secret store wired, so
+// every gsm:// credential re-drive fails there today).
+func TestResumePending_LogsSkippedRow(t *testing.T) {
+	db := testdb.NewDB(t, coordinatorTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedPaidOrder(t, db, orderID, storeID, tenantID, "100.00", "0")
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider: "stripe", ProviderPaymentID: "pi_x", Amount: "100.00", Status: "captured",
+	})
+	seedGatewayConfig(t, db, tenantID, storeID, "stripe", true)
+
+	wantKey := "refund_" + orderID.String() + "_cancel"
+	seedPendingRefundTxn(t, db, tenantID, storeID, orderID, wantKey, "pi_x", "stripe", "100.00", time.Now().Add(-1*time.Hour))
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	gw := &fakeGateway{refundErr: errors.New("gateway: still down")}
+	c := newCoordinator(db, gw, true).WithLogger(log)
+
+	if _, err := c.ResumePending(context.Background(), 0, 200); err != nil {
+		t.Fatalf("ResumePending: %v", err)
+	}
+
+	out := buf.String()
+	if out == "" {
+		t.Fatal("sweep skipped a row but logged nothing — a stuck refund would be invisible")
+	}
+	for _, want := range []string{"gateway refund failed", orderID.String(), "gateway: still down"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log missing %q\ngot: %s", want, out)
+		}
+	}
+}
+
+// TestResumePending_NilLoggerDoesNotPanic guards the nil-safety of the log
+// helpers: WithLogger is optional and callers that skip it (any test, and any
+// future caller) must still be able to run a sweep that skips rows.
+func TestResumePending_NilLoggerDoesNotPanic(t *testing.T) {
+	db := testdb.NewDB(t, coordinatorTruncateTables...)
+	tenantID, storeID, orderID := uuid.New(), uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+	seedPaidOrder(t, db, orderID, storeID, tenantID, "100.00", "0")
+	seedPaymentTxn(t, db, tenantID, storeID, orderID, seedPaymentTxnOpts{
+		Provider: "stripe", ProviderPaymentID: "pi_x", Amount: "100.00", Status: "captured",
+	})
+	seedGatewayConfig(t, db, tenantID, storeID, "stripe", true)
+
+	wantKey := "refund_" + orderID.String() + "_cancel"
+	seedPendingRefundTxn(t, db, tenantID, storeID, orderID, wantKey, "pi_x", "stripe", "100.00", time.Now().Add(-1*time.Hour))
+
+	gw := &fakeGateway{refundErr: errors.New("gateway: still down")}
+	c := newCoordinator(db, gw, true) // deliberately no WithLogger
+
+	if _, err := c.ResumePending(context.Background(), 0, 200); err != nil {
+		t.Fatalf("ResumePending with nil logger: %v", err)
 	}
 }


### PR DESCRIPTION
Closes the first bullet of #169. The other three bullets in that issue (auto-cancel refund email, multi-partial limitation, test polish) are untouched and stay open.

## Problem

`Coordinator.ResumePending` — the never-lost guarantee for refunds — skipped rows with a bare `continue` at six sites: unparseable `order_id`, order not loadable, no gateway for store/provider, split re-derivation failure, gateway refund failure, and finalize-transaction failure.

A sweep that skipped every row reported `resumed=0`, which is byte-identical to a clean run with nothing to do. A persistently stuck refund — money owed to a customer — was invisible.

**Second, larger half of the bug:** `cmd/refund-sweep-cron/main.go` never called `WithLogger`. That binary is the *only* production caller of `ResumePending`, so even the pre-existing `logError` path was writing to a nil logger. Adding log lines without wiring this would have changed nothing at runtime.

This is not hypothetical. That same binary carries a documented KNOWN GAP — no secret store is wired, so every `gsm://` credential re-drive fails there today. With this change that failure finally says so in the logs instead of presenting as a clean `resumed=0`.

## Changes

- `logWarn` helper beside the existing nil-safe `logError`
- Each of the six skip sites logs `refund_id`, `order_id` and the cause; the gateway path also logs whether the error was classified permanent
- `cmd/refund-sweep-cron` attaches the logger it already builds

## Test plan

- [x] `TestResumePending_LogsSkippedRow` — new; asserts a skipped row logs the refund, order and cause. **Verified RED against pre-fix `coordinator.go`** (`sweep skipped a row but logged nothing`), GREEN after.
- [x] `TestResumePending_NilLoggerDoesNotPanic` — new; `WithLogger` stays optional
- [x] Existing four `TestResumePending_*` still pass
- [x] Full sweeper suite green: `TEST_DATABASE_URL=postgres://dev:dev@192.168.1.110:5432/marketplace_db go test -tags=integration -p 1 -count=1 -run TestResumePending ./internal/orderrefund/` — 6/6 PASS with real `=== RUN` lines
- [x] `go build ./...`, `go vet`, `gofmt` clean

## Note for review

Log volume: the sweep runs every 5 minutes over up to 200 rows. While the secret-store gap above is open, a store with stuck refunds will emit one warn per row per sweep. That is the intended signal, but flag it if you would rather it were rate-limited or dropped to debug for the transient cases.

Refs #169, #164.