### PR TITLE
feat(plans): widen the read-only API to Starter so every webhook plan can resolve what it delivers

### DIFF
--- a/apps/admin/lib/copy/pricing.ts
+++ b/apps/admin/lib/copy/pricing.ts
@@ -92,6 +92,7 @@ export const pricingCopy = {
         '15,000 campaign emails / mo',
         'Full colour palette & announcement bar',
         'Your own domain',
+        'Read-only API',
       ],
     },
     {

--- a/apps/onboarding/components/marketing/Pricing.tsx
+++ b/apps/onboarding/components/marketing/Pricing.tsx
@@ -72,6 +72,7 @@ const PLAN_META: readonly PlanMeta[] = [
       '15,000 campaign emails / mo',
       'Full colour palette & announcement bar',
       'Your own domain',
+      'Read-only API',
     ],
   },
   {

--- a/apps/onboarding/public/llms-full.txt
+++ b/apps/onboarding/public/llms-full.txt
@@ -38,7 +38,7 @@ Free for ninety days. No card required. Three clear plans after that, from $15 a
 
 Ninety days free to start. After that, three clear plans — no hidden fees, no transaction cuts from Mark8ly, only what your payment processor charges at their standard rate. Change plans any time; upgrades prorate, downgrades take effect at the end of your current period.
 
-- **Starter — $15/month billed yearly, or $19/month billed monthly.** For merchants opening their first store. Up to 2 stores, unlimited products and orders, 15,000 campaign emails/month, full colour palette and announcement bar, your own domain.
+- **Starter — $15/month billed yearly, or $19/month billed monthly.** For merchants opening their first store. Up to 2 stores, unlimited products and orders, 15,000 campaign emails/month, full colour palette and announcement bar, your own domain, read-only API.
 - **Studio — $39/month billed yearly, or $49/month billed monthly.** For stores finding their rhythm. Up to 5 stores, 50 images per product, 50,000 campaign emails/month, custom CSS and fonts, read-only API, 12-month audit log.
 - **Pro — $99/month billed yearly, or $119/month billed monthly.** For mid-market brands at scale. Up to 10 stores, unlimited images, full read/write API, SSO (SAML/OIDC), priority support with 4-hour response, forever audit retention.
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -8,6 +8,19 @@ verify the signature, and what your endpoint needs to handle.
 
 Webhooks are available on every plan. There is no gating by tier.
 
+**Completing the loop needs the read-only API.** A delivery body carries only
+the event name, the aggregate id and a timestamp — deliberately, so no customer
+data is sent to a merchant-supplied URL and a retry can never deliver a stale
+copy of an entity. To act on an event you fetch the entity from the REST API
+using the id. The read-only API is available on **Starter, Studio and Pro**
+(widened to Starter in #585 precisely so every plan that can register a webhook
+can also resolve what it delivers).
+
+On **Trial**, the read-only API is not enabled. Trial webhooks still work as
+pure signals — ping a Slack channel, increment a counter, prompt someone to
+open admin — but a Trial integration cannot fetch the order behind an
+`order.placed` until the store is on a paid plan.
+
 Subscriptions, deliveries, replay and test sends are all managed from
 **Admin → Settings → Webhooks**.
 

--- a/services/marketplace-api/internal/handlers/admin/apikeys_handler.go
+++ b/services/marketplace-api/internal/handlers/admin/apikeys_handler.go
@@ -1,6 +1,7 @@
 // Package admin — apikeys_handler.go: §18.4 enterprise API-key admin
 // endpoints. Mounted under /admin/stores/:storeId/api-keys. Reads (GET)
-// are gated by plangate.RequireFeature(FeatureReadAPI) (Studio+); writes
+// are gated by plangate.RequireFeature(FeatureReadAPI) (Starter+ since
+// #585); writes
 // (POST create/rotate, DELETE revoke) are gated by FeatureFullAPI (Pro).
 // The service layer additionally rejects write-scoped key creation when
 // FeatureFullAPI is not allowed for the resolved plan.
@@ -250,9 +251,9 @@ func (h *APIKeysHandler) parseUser(c *gin.Context) (uuid.UUID, bool) {
 }
 
 // RegisterAPIKeys mounts the admin endpoints. List is gated by FeatureReadAPI
-// (Studio+); create/rotate/revoke are gated by FeatureFullAPI (Pro). Read
-// endpoints under FeatureReadAPI let Studio+ merchants list their keys
-// without upgrading; write endpoints require an explicit Pro plan.
+// (Starter+ since #585); create/rotate/revoke are gated by FeatureFullAPI
+// (Pro). Read endpoints under FeatureReadAPI let Starter+ merchants list
+// their keys without upgrading; write endpoints require an explicit Pro plan.
 func RegisterAPIKeys(storeRoute gin.IRouter, h *APIKeysHandler, fgaMw *authz.Middleware, logger *slog.Logger) {
 	if h == nil || h.resolver == nil {
 		return

--- a/services/marketplace-api/internal/plangate/matrix.go
+++ b/services/marketplace-api/internal/plangate/matrix.go
@@ -165,10 +165,19 @@ var featureMatrix = map[subscription.SubscriptionPlan]planLimits{
 		FeatureReviews:         1,
 		FeatureTickets:         1,
 		FeatureGiftCards:       1,
-		FeatureReadAPI:         Disabled,
-		FeatureFullAPI:         Disabled,
-		FeatureSSO:             Disabled,
-		FeatureUptimeSLA:       Disabled,
+		// #585: widened from Disabled. Outbound webhooks (#562) ship on
+		// every plan and use a notify-and-fetch payload — the delivery
+		// body carries only an event name and an aggregate id, so the
+		// merchant MUST call the read API to resolve it. Leaving this
+		// Disabled on Starter shipped "a doorbell with the door locked":
+		// a Starter merchant could register a webhook, receive
+		// order.placed, and have no supported way to act on it.
+		// Diverges from spec §9, deliberately — see #585 for the
+		// trade-off (the read API stops being a Studio differentiator).
+		FeatureReadAPI:   1,
+		FeatureFullAPI:   Disabled,
+		FeatureSSO:       Disabled,
+		FeatureUptimeSLA: Disabled,
 
 		FeatureStandardEmailSupport: 1,
 		FeaturePriorityEmailSupport: Disabled,

--- a/services/marketplace-api/internal/plangate/matrix_test.go
+++ b/services/marketplace-api/internal/plangate/matrix_test.go
@@ -48,6 +48,21 @@ func TestMatrix_SSO_ProOnly(t *testing.T) {
 	require.True(t, plangate.IsAllowed(subscription.PlanPro, plangate.FeatureSSO))
 }
 
+// TestMatrix_ReadAPI_StarterAndAbove pins the #585 decision. Outbound
+// webhooks are available on every plan and carry a notify-and-fetch payload
+// (event + aggregate id only), so any plan that can register a webhook must
+// also be able to resolve what it points at. Trial is deliberately excluded
+// here — see #585; if Trial ever gains it, extend this test rather than
+// deleting it.
+func TestMatrix_ReadAPI_StarterAndAbove(t *testing.T) {
+	for _, p := range []subscription.SubscriptionPlan{
+		subscription.PlanStarter, subscription.PlanStudio, subscription.PlanPro,
+	} {
+		require.True(t, plangate.IsAllowed(p, plangate.FeatureReadAPI),
+			"plan %s can register webhooks, so it must be able to resolve the ids they deliver (#585)", p)
+	}
+}
+
 func TestMatrix_FullAPI_ProOnly(t *testing.T) {
 	require.True(t, plangate.IsAllowed(subscription.PlanStudio, plangate.FeatureReadAPI))
 	require.False(t, plangate.IsAllowed(subscription.PlanStudio, plangate.FeatureFullAPI))


### PR DESCRIPTION
Closes #585 by taking **Option 1** — widening `FeatureReadAPI` to Starter — which was the issue's own recommendation.

## The incoherence

Outbound webhooks (#562) ship on **every plan** and use a notify-and-fetch payload: the delivery body carries only `event`, `id` and `occurred_at`. That shape is deliberate — no customer PII goes to a merchant-supplied URL, and a retry can never deliver a stale entity. To act on an event you fetch the entity from the read-only API.

The read-only API was Studio+. So a Starter merchant could register a webhook, receive `order.placed` with an aggregate id, and have no supported way to resolve it. The design doc's own words: *"a doorbell with the door locked."* It was flagged during design as something that must land with webhooks, and didn't.

## The trade-off, stated plainly

The read-only API stops being a Studio differentiator. That is the real cost of this option and it is why the issue asked for a decision rather than a fix. Studio still differentiates on 5 storefronts, 50 images/product, 50k campaign emails, custom CSS and the 12-month audit log.

## Changes

- `plangate/matrix.go` — Starter `FeatureReadAPI: Disabled → 1`, with the reasoning inline (it is a deliberate divergence from spec §9, so the next reader doesn't "correct" it back)
- **Both** public pricing surfaces gain a `Read-only API` bullet on Starter, changed together as the issue requires: `apps/onboarding/components/marketing/Pricing.tsx` and `apps/admin/lib/copy/pricing.ts`
- `apps/onboarding/public/llms-full.txt` — the third surface the guard test covers, kept in sync
- `docs/webhooks.md` — states which plans can complete the notify-and-fetch loop
- `apikeys_handler.go` — two comments still said "Studio+"; corrected rather than left to mislead

## Trial is deliberately left out — please confirm

You picked "widen to Starter", so that is exactly what this does. **Trial still has `FeatureReadAPI: Disabled`, so the same doorbell/locked-door problem persists there**, and Trial is arguably where it bites most — it is the evaluation window, and a merchant who concludes webhooks are broken during a trial does not become a customer.

I did not widen Trial because it was outside the decision. `docs/webhooks.md` documents the Trial limitation honestly in the meantime, and `TestMatrix_ReadAPI_StarterAndAbove` names Trial's exclusion so it is a recorded choice rather than an oversight. **Say the word and it is a one-line follow-up.**

## Test plan

- [x] `TestMatrix_ReadAPI_StarterAndAbove` — new; asserts every plan that can register a webhook can resolve what it delivers
- [x] `go test ./internal/plangate/` — all `TestMatrix_*` pass, including the 25-feature parity test
- [x] **`pricing-surfaces-truth.spec.ts` passes** (3/3) — the guard the issue requires
- [x] Full onboarding unit suite: 77 passed
- [x] Admin pricing suite: 20 passed
- [x] `go build ./...`, `gofmt` clean

Refs #585, #562, #564.
