### PR TITLE
feat(webhooks): cap subscriptions per store with per-plan plangate limits

### DIFF
--- a/apps/admin/lib/copy/pricing.ts
+++ b/apps/admin/lib/copy/pricing.ts
@@ -93,6 +93,7 @@ export const pricingCopy = {
         'Full colour palette & announcement bar',
         'Your own domain',
         'Read-only API',
+        '10 webhook endpoints',
       ],
     },
     {
@@ -107,6 +108,7 @@ export const pricingCopy = {
         '50,000 campaign emails / mo',
         'Custom CSS & fonts',
         'Read-only API',
+        '25 webhook endpoints',
         '12-month audit log',
       ],
     },
@@ -120,6 +122,7 @@ export const pricingCopy = {
         'Up to 10 storefronts',
         'Unlimited images',
         'Full read/write API',
+        '100 webhook endpoints',
         'SSO (SAML / OIDC)',
         'Priority support (4h response)',
         'Forever audit retention',

--- a/apps/onboarding/components/marketing/Pricing.tsx
+++ b/apps/onboarding/components/marketing/Pricing.tsx
@@ -73,6 +73,7 @@ const PLAN_META: readonly PlanMeta[] = [
       'Full colour palette & announcement bar',
       'Your own domain',
       'Read-only API',
+      '10 webhook endpoints',
     ],
   },
   {
@@ -85,6 +86,7 @@ const PLAN_META: readonly PlanMeta[] = [
       '50,000 campaign emails / mo',
       'Custom CSS & fonts',
       'Read-only API',
+      '25 webhook endpoints',
       '12-month audit log',
     ],
   },
@@ -96,6 +98,7 @@ const PLAN_META: readonly PlanMeta[] = [
       'Up to 10 stores',
       'Unlimited images',
       'Full read/write API',
+      '100 webhook endpoints',
       'SSO (SAML / OIDC)',
       'Priority support (4h response)',
       'Forever audit retention',

--- a/apps/onboarding/public/llms-full.txt
+++ b/apps/onboarding/public/llms-full.txt
@@ -38,9 +38,9 @@ Free for ninety days. No card required. Three clear plans after that, from $15 a
 
 Ninety days free to start. After that, three clear plans — no hidden fees, no transaction cuts from Mark8ly, only what your payment processor charges at their standard rate. Change plans any time; upgrades prorate, downgrades take effect at the end of your current period.
 
-- **Starter — $15/month billed yearly, or $19/month billed monthly.** For merchants opening their first store. Up to 2 stores, unlimited products and orders, 15,000 campaign emails/month, full colour palette and announcement bar, your own domain, read-only API.
-- **Studio — $39/month billed yearly, or $49/month billed monthly.** For stores finding their rhythm. Up to 5 stores, 50 images per product, 50,000 campaign emails/month, custom CSS and fonts, read-only API, 12-month audit log.
-- **Pro — $99/month billed yearly, or $119/month billed monthly.** For mid-market brands at scale. Up to 10 stores, unlimited images, full read/write API, SSO (SAML/OIDC), priority support with 4-hour response, forever audit retention.
+- **Starter — $15/month billed yearly, or $19/month billed monthly.** For merchants opening their first store. Up to 2 stores, unlimited products and orders, 15,000 campaign emails/month, full colour palette and announcement bar, your own domain, read-only API, 10 webhook endpoints.
+- **Studio — $39/month billed yearly, or $49/month billed monthly.** For stores finding their rhythm. Up to 5 stores, 50 images per product, 50,000 campaign emails/month, custom CSS and fonts, read-only API, 25 webhook endpoints, 12-month audit log.
+- **Pro — $99/month billed yearly, or $119/month billed monthly.** For mid-market brands at scale. Up to 10 stores, unlimited images, full read/write API, 100 webhook endpoints, SSO (SAML/OIDC), priority support with 4-hour response, forever audit retention.
 
 **White-label App add-on** (Pro only): publish a branded iOS and Android app for your storefront. Billed annually and co-terminated with your Pro renewal.
 

--- a/apps/onboarding/tests/unit/pricing-copy-truth.spec.ts
+++ b/apps/onboarding/tests/unit/pricing-copy-truth.spec.ts
@@ -4,10 +4,15 @@ import { test, expect } from "@playwright/test";
 // features that plangate never enabled server-side — see #544:
 //
 //   - "Read-only API + webhooks" (Studio): the read-only API is real
-//     (plangate.FeatureReadAPI -> internal/apikeys/*), but nothing in the
-//     schema stores a merchant-supplied webhook/callback URL, so outbound
-//     webhook delivery cannot exist. webhook_events / stripe_webhook_events
-//     are inbound idempotency tables, not evidence of the feature.
+//     (plangate.FeatureReadAPI -> internal/apikeys/*), and outbound webhooks
+//     BECAME real in #562 — webhook_subscriptions.url stores exactly the
+//     merchant-supplied callback URL this guard was originally written to
+//     say did not exist. The blanket "no bullet may say webhook" assertion
+//     was therefore stale and has been replaced (#586) by one that lets the
+//     claim exist but pins the NUMBER to plangate's
+//     FeatureWebhookSubscriptions, so the copy cannot drift from the cap the
+//     server actually enforces. Its sibling guard in
+//     pricing-surfaces-truth.spec.ts already retired the same assertion.
 //   - "Custom code injection" (Pro): plangate.FeatureCustomCodeInjection's
 //     own doc comment in matrix.go says no handler accepts arbitrary
 //     <script> payloads today - it's a forward-compat hedge, referenced
@@ -17,6 +22,8 @@ import { test, expect } from "@playwright/test";
 // re-verify every other bullet against the server (that audit lives in the
 // #544 investigation) - it only guards the two bullets already proven false
 // plus the basic shape of PLAN_META.
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { PLAN_META } from "../../components/marketing/Pricing";
 
 function allFeatures(): string[] {
@@ -24,17 +31,42 @@ function allFeatures(): string[] {
 }
 
 test.describe("pricing copy must not promise unenforced features (#544)", () => {
-  test("no bullet claims webhooks", () => {
-    const offenders = allFeatures().filter((f) => /webhook/i.test(f));
+  test("any webhook bullet quotes the cap plangate enforces (#586)", () => {
+    const src = readFileSync(
+      path.join(__dirname, "../../../..", "services/marketplace-api/internal/plangate/matrix.go"),
+      "utf8",
+    );
+    // Blocks appear in declaration order: trial, starter, studio, pro.
+    // Trial is not sold as a plan, so only the last three are asserted.
+    const caps = [...src.matchAll(/FeatureWebhookSubscriptions:\s*(\d+)/g)].map((m) =>
+      Number(m[1]),
+    );
     expect(
-      offenders,
-      "Found a pricing bullet mentioning 'webhook'. Outbound webhook " +
-        "delivery does not exist server-side: webhook_events and " +
-        "stripe_webhook_events are inbound idempotency tables, and no " +
-        "column anywhere stores a merchant-supplied callback URL. See " +
-        "issue #544 - narrow this bullet back to what plangate.FeatureReadAPI " +
-        "actually grants ('Read-only API'), don't re-add webhooks.",
-    ).toEqual([]);
+      caps.length,
+      "expected four FeatureWebhookSubscriptions entries in matrix.go " +
+        "(trial/starter/studio/pro) — if the matrix was restructured, update " +
+        "this parser rather than deleting the assertion",
+    ).toBe(4);
+    const byPlan: Record<string, number> = {
+      starter: caps[1]!,
+      studio: caps[2]!,
+      pro: caps[3]!,
+    };
+
+    for (const plan of PLAN_META) {
+      const bullets = plan.features.filter((f) => /webhook/i.test(f));
+      // A plan need not advertise the cap — but if it does, the number must
+      // be the one the server enforces at creation.
+      for (const bullet of bullets) {
+        const n = Number(bullet.match(/(\d+)/)?.[1]);
+        expect(
+          n,
+          `${plan.id} advertises "${bullet}" but plangate enforces ` +
+            `${byPlan[plan.id]} webhook subscriptions per store. A count that ` +
+            `disagrees with the matrix is a promise the product will not keep.`,
+        ).toBe(byPlan[plan.id]);
+      }
+    }
   });
 
   test("no bullet claims code injection", () => {

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -21,6 +21,28 @@ pure signals — ping a Slack channel, increment a counter, prompt someone to
 open admin — but a Trial integration cannot fetch the order behind an
 `order.placed` until the store is on a paid plan.
 
+**How many endpoints you can register.** Each store may hold a limited number
+of subscriptions, because dispatch fan-out is `outbox rows × matching
+subscriptions` — every subscription multiplies the delivery rows and outbound
+HTTP attempts a single event produces.
+
+| Plan | Webhook endpoints per store |
+| --- | --- |
+| Trial | 5 |
+| Starter | 10 |
+| Studio | 25 |
+| Pro | 100 |
+
+The cap is checked when you create a subscription; going over it returns a
+`400` with `webhook_subscription_limit_reached`, naming your current count and
+limit. **Disabled subscriptions still count** — a disabled row is one you can
+re-enable, so parking endpoints in the disabled state does not free a slot.
+Delete what you no longer need.
+
+A plan downgrade never deletes subscriptions you already have. A store that
+ends up over the cap keeps every existing endpoint working, but cannot create
+a new one until it is back under the limit.
+
 Subscriptions, deliveries, replay and test sends are all managed from
 **Admin → Settings → Webhooks**.
 

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -885,11 +885,19 @@ func main() {
 		// wrappers over the same conn/ssrfguard, so nothing needs sharing
 		// between the HTTP surface and the background loops.
 		webhooksGuard := ssrfguard.New(nil)
+		// The shared planResolver (B2) is constructed further down, after
+		// subscriptionRepo. PlanResolver is stateless — just a *gorm.DB and
+		// a subscription.Repository — so building a second one here costs
+		// nothing and keeps the per-store webhook subscription cap (#586)
+		// an explicit, non-nil constructor argument rather than a setter
+		// that could be forgotten.
+		webhooksPlanResolver := plangate.NewPlanResolver(conn, subscription.NewRepository())
 		webhooksHandler := admin.NewWebhooksHandler(
 			webhook.NewSubscriptionRepo(conn),
 			webhook.NewDeliveryRepo(conn),
 			webhooksGuard,
 			webhook.NewSender(webhooksGuard, nil),
+			webhooksPlanResolver,
 			log,
 		)
 

--- a/services/marketplace-api/internal/handlers/admin/products_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/products_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/handlers/admin"
 	"github.com/mark8ly/marketplace-api/internal/media"
 	"github.com/mark8ly/marketplace-api/internal/outbox"
+	"github.com/mark8ly/marketplace-api/internal/plangate"
 	"github.com/mark8ly/marketplace-api/internal/product"
 	"github.com/mark8ly/marketplace-api/internal/promo"
 	"github.com/mark8ly/marketplace-api/internal/stores"
@@ -145,6 +146,11 @@ func setupTestRouter(t *testing.T) *testEnv {
 		webhook.NewDeliveryRepo(db),
 		whGuard,
 		webhook.NewSender(whGuard, nil),
+		// Real resolver so the per-store subscription cap (#586) is
+		// exercised by the handler tests rather than bypassed. Seeded
+		// stores have no subscription row, so Resolve falls back to
+		// PlanTrial — a cap of 5.
+		plangate.NewPlanResolver(db, subscription.NewRepository()),
 		nil,
 	)
 

--- a/services/marketplace-api/internal/handlers/admin/webhooks.go
+++ b/services/marketplace-api/internal/handlers/admin/webhooks.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/mark8ly/marketplace-api/internal/outbox"
+	"github.com/mark8ly/marketplace-api/internal/plangate"
 	"github.com/mark8ly/marketplace-api/internal/webhook"
 	"github.com/mark8ly/marketplace-api/internal/webhook/ssrfguard"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
@@ -67,12 +68,17 @@ type WebhooksHandler struct {
 	deliveries *webhook.DeliveryRepo
 	guard      *ssrfguard.Guard
 	sender     *webhook.Sender
+	resolver   *plangate.PlanResolver
 	logger     *slog.Logger
 }
 
-// NewWebhooksHandler constructs a WebhooksHandler.
-func NewWebhooksHandler(subs *webhook.SubscriptionRepo, deliveries *webhook.DeliveryRepo, guard *ssrfguard.Guard, sender *webhook.Sender, logger *slog.Logger) *WebhooksHandler {
-	return &WebhooksHandler{subs: subs, deliveries: deliveries, guard: guard, sender: sender, logger: logger}
+// NewWebhooksHandler constructs a WebhooksHandler. resolver is an explicit
+// parameter rather than an optional setter because it enforces the per-store
+// subscription cap (#586) — a nil resolver disables that cap, and a limit
+// that silently does not apply is worse than no limit at all. Create logs
+// loudly and fails closed if it is ever nil.
+func NewWebhooksHandler(subs *webhook.SubscriptionRepo, deliveries *webhook.DeliveryRepo, guard *ssrfguard.Guard, sender *webhook.Sender, resolver *plangate.PlanResolver, logger *slog.Logger) *WebhooksHandler {
+	return &WebhooksHandler{subs: subs, deliveries: deliveries, guard: guard, sender: sender, resolver: resolver, logger: logger}
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -240,6 +246,50 @@ func (h *WebhooksHandler) ownedSubscription(c *gin.Context, tenantID, storeID uu
 // and the event-type check before ever generating a secret or touching the
 // database, and returns the secret exactly once — it never leaves the
 // server again after this response (Subscription.Secret is json:"-").
+// withinSubscriptionCap reports whether the store may create one more
+// subscription, writing the error response itself when it may not. Fails
+// CLOSED on a nil resolver or a count error: the cap protects shared
+// database capacity, so "we could not check" must not mean "allow".
+func (h *WebhooksHandler) withinSubscriptionCap(c *gin.Context, tenantID, storeID uuid.UUID) bool {
+	if h.resolver == nil {
+		// Wiring bug, not a merchant error. Loud, and closed.
+		if h.logger != nil {
+			h.logger.Error("webhooks: no plan resolver wired, cannot enforce subscription cap",
+				"tenant_id", tenantID, "store_id", storeID)
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "internal_error",
+			"message": "Webhook subscription limits are unavailable. Please try again later.",
+		})
+		return false
+	}
+
+	ctx := c.Request.Context()
+	plan := h.resolver.Resolve(ctx, tenantID, storeID)
+	limit := plangate.Limit(plan, plangate.FeatureWebhookSubscriptions)
+
+	count, err := h.subs.CountForStore(ctx, tenantID, storeID)
+	if err != nil {
+		RespondErr(c, err, h.logger)
+		return false
+	}
+
+	if count >= limit {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "webhook_subscription_limit_reached",
+			"message": fmt.Sprintf(
+				"This store has %d of %d webhook subscriptions allowed on the %s plan. Delete one, or upgrade for a higher limit.",
+				count, limit, plan),
+			"limit":   limit,
+			"current": count,
+			"plan":    string(plan),
+			"feature": string(plangate.FeatureWebhookSubscriptions),
+		})
+		return false
+	}
+	return true
+}
+
 func (h *WebhooksHandler) Create(c *gin.Context) {
 	tenantID, storeID, ok := h.scope(c)
 	if !ok {
@@ -257,6 +307,16 @@ func (h *WebhooksHandler) Create(c *gin.Context) {
 	}
 	if verr := validateEventTypes(req.EventTypes); verr != nil {
 		RespondErr(c, verr, h.logger)
+		return
+	}
+
+	// Per-store subscription cap (#586). Dispatch fan-out is
+	// `outbox rows × matching subscriptions`, so an unbounded count turns
+	// one order.placed into an unbounded number of delivery rows and
+	// outbound HTTP attempts. Enforced here, at creation, only — a
+	// downgrade never deletes a merchant's existing subscriptions, the same
+	// contract FeatureImagesPerProduct has.
+	if !h.withinSubscriptionCap(c, tenantID, storeID) {
 		return
 	}
 

--- a/services/marketplace-api/internal/handlers/admin/webhooks_test.go
+++ b/services/marketplace-api/internal/handlers/admin/webhooks_test.go
@@ -5,6 +5,7 @@ package admin_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"testing"
@@ -359,5 +360,98 @@ func TestTestSend_ReportsFailureWithoutServerError(t *testing.T) {
 	}
 	if data["error"] == nil || data["error"] == "" {
 		t.Fatalf("expected an error message, got %s", tw.Body.String())
+	}
+}
+
+// TestCreateWebhook_EnforcesPerStoreCap pins the #586 cap. Dispatch fan-out
+// is `outbox rows × matching subscriptions`, so an unbounded subscription
+// count turns one order.placed into an unbounded number of delivery rows and
+// outbound HTTP attempts against a shared db-f1-micro. A seeded store has no
+// subscription row, so PlanResolver falls back to PlanTrial — a cap of 5.
+func TestCreateWebhook_EnforcesPerStoreCap(t *testing.T) {
+	env, storeID, tenantID, userID := webhookOwnerEnv(t)
+
+	const trialCap = 5
+	for i := 0; i < trialCap; i++ {
+		w := request(t, env.router, http.MethodPost, webhooksURL(storeID),
+			webhookCreateBody(fmt.Sprintf("https://public.example.com/hooks/%d", i), []string{"order.placed"}),
+			authHeaders(userID, tenantID))
+		if w.Code != http.StatusCreated {
+			t.Fatalf("create #%d: status = %d, body = %s (all %d should fit under the cap)",
+				i+1, w.Code, w.Body.String(), trialCap)
+		}
+	}
+
+	// The one past the cap must be refused with a 400 the merchant can act
+	// on — naming the limit, the current count and the plan.
+	w := request(t, env.router, http.MethodPost, webhooksURL(storeID),
+		webhookCreateBody("https://public.example.com/hooks/over", []string{"order.placed"}),
+		authHeaders(userID, tenantID))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("create past cap: status = %d, want 400, body = %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if resp["error"] != "webhook_subscription_limit_reached" {
+		t.Fatalf("error code = %v, want webhook_subscription_limit_reached (body = %s)", resp["error"], w.Body.String())
+	}
+	if got := resp["limit"]; got != float64(trialCap) {
+		t.Fatalf("limit = %v, want %d — the response must name the cap so the UI can explain it", got, trialCap)
+	}
+	if got := resp["current"]; got != float64(trialCap) {
+		t.Fatalf("current = %v, want %d", got, trialCap)
+	}
+	if msg, _ := resp["message"].(string); msg == "" {
+		t.Fatal("expected a human-readable message a merchant can act on")
+	}
+
+	// The refusal must not have written a row.
+	subs := webhook.NewSubscriptionRepo(env.db)
+	n, err := subs.CountForStore(context.Background(), uuid.MustParse(tenantID), uuid.MustParse(storeID))
+	if err != nil {
+		t.Fatalf("CountForStore: %v", err)
+	}
+	if n != trialCap {
+		t.Fatalf("subscription count = %d, want %d — a rejected create must not persist", n, trialCap)
+	}
+}
+
+// TestCreateWebhook_DisabledSubscriptionsCountTowardCap closes the obvious
+// way around the cap: parking subscriptions in the disabled state. A disabled
+// row is still a row the merchant can flip back on, so it must count.
+func TestCreateWebhook_DisabledSubscriptionsCountTowardCap(t *testing.T) {
+	env, storeID, tenantID, userID := webhookOwnerEnv(t)
+
+	const trialCap = 5
+	var firstID string
+	for i := 0; i < trialCap; i++ {
+		w := request(t, env.router, http.MethodPost, webhooksURL(storeID),
+			webhookCreateBody(fmt.Sprintf("https://public.example.com/hooks/%d", i), []string{"order.placed"}),
+			authHeaders(userID, tenantID))
+		if w.Code != http.StatusCreated {
+			t.Fatalf("create #%d: status = %d, body = %s", i+1, w.Code, w.Body.String())
+		}
+		if i == 0 {
+			first := dataObject(t, w.Body.Bytes())
+			firstID, _ = first["id"].(string)
+		}
+	}
+
+	// Disable one — this must NOT free a slot.
+	pw := request(t, env.router, http.MethodPatch, webhooksURL(storeID)+"/"+firstID,
+		map[string]any{"enabled": false}, authHeaders(userID, tenantID))
+	if pw.Code != http.StatusOK {
+		t.Fatalf("disable: status = %d, body = %s", pw.Code, pw.Body.String())
+	}
+
+	w := request(t, env.router, http.MethodPost, webhooksURL(storeID),
+		webhookCreateBody("https://public.example.com/hooks/after-disable", []string{"order.placed"}),
+		authHeaders(userID, tenantID))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("create after disabling one: status = %d, want 400 — disabling must not free a slot (body = %s)",
+			w.Code, w.Body.String())
 	}
 }

--- a/services/marketplace-api/internal/plangate/matrix.go
+++ b/services/marketplace-api/internal/plangate/matrix.go
@@ -21,6 +21,14 @@ const (
 	FeatureAuditRetentionDays     Feature = "audit_retention_days"
 	FeatureCampaignEmailsPerMonth Feature = "campaign_emails_per_month"
 	FeatureTransactionalEmails    Feature = "transactional_emails"
+	// FeatureWebhookSubscriptions caps outbound webhook subscriptions per
+	// STORE (not per tenant) — #586. Dispatch fan-out is
+	// `outbox rows × matching subscriptions`, so an unbounded count turns
+	// one order.placed into an unbounded number of delivery rows and
+	// outbound HTTP attempts against a shared db-f1-micro. Enforced at
+	// creation only, mirroring FeatureImagesPerProduct: a downgrade does
+	// not delete a merchant's existing subscriptions.
+	FeatureWebhookSubscriptions Feature = "webhook_subscriptions"
 
 	// Storefront.
 	FeatureCustomDomain     Feature = "custom_domain"
@@ -74,6 +82,7 @@ var allFeatures = []Feature{
 	FeatureAuditRetentionDays,
 	FeatureCampaignEmailsPerMonth,
 	FeatureTransactionalEmails,
+	FeatureWebhookSubscriptions,
 	FeatureCustomDomain,
 	FeatureFullColorPalette,
 	FeatureAnnouncementBar,
@@ -120,6 +129,7 @@ var featureMatrix = map[subscription.SubscriptionPlan]planLimits{
 		FeatureAuditRetentionDays:     90,
 		FeatureCampaignEmailsPerMonth: 5_000,
 		FeatureTransactionalEmails:    Unlimited, // ∞ with 100k/mo fair-use (§9)
+		FeatureWebhookSubscriptions:   5,
 
 		FeatureCustomDomain:        1,
 		FeatureFullColorPalette:    1,
@@ -150,6 +160,7 @@ var featureMatrix = map[subscription.SubscriptionPlan]planLimits{
 		FeatureAuditRetentionDays:     90,
 		FeatureCampaignEmailsPerMonth: 15_000,
 		FeatureTransactionalEmails:    Unlimited,
+		FeatureWebhookSubscriptions:   10,
 
 		FeatureCustomDomain:        1,
 		FeatureFullColorPalette:    1,
@@ -189,6 +200,7 @@ var featureMatrix = map[subscription.SubscriptionPlan]planLimits{
 		FeatureAuditRetentionDays:     365,
 		FeatureCampaignEmailsPerMonth: 50_000,
 		FeatureTransactionalEmails:    Unlimited,
+		FeatureWebhookSubscriptions:   25,
 
 		FeatureCustomDomain:        1,
 		FeatureFullColorPalette:    1,
@@ -219,6 +231,11 @@ var featureMatrix = map[subscription.SubscriptionPlan]planLimits{
 		FeatureAuditRetentionDays:     Unlimited, // "Forever" (§9)
 		FeatureCampaignEmailsPerMonth: Negotiated,
 		FeatureTransactionalEmails:    Negotiated, // "Negotiated ceiling" (§9)
+		// 100, deliberately under the ~132 subscriptions that overflowed
+		// Postgres's 65535-parameter limit in the original fan-out outage
+		// (#562 chunked the insert; this keeps even the top tier away from
+		// the region that broke it).
+		FeatureWebhookSubscriptions: 100,
 
 		FeatureCustomDomain:        1,
 		FeatureFullColorPalette:    1,

--- a/services/marketplace-api/internal/plangate/matrix_test.go
+++ b/services/marketplace-api/internal/plangate/matrix_test.go
@@ -63,6 +63,37 @@ func TestMatrix_ReadAPI_StarterAndAbove(t *testing.T) {
 	}
 }
 
+// TestMatrix_WebhookSubscriptions pins the #586 ladder. The cap exists
+// because dispatch fan-out is `outbox rows × matching subscriptions` on a
+// shared db-f1-micro; it is not merely an anti-abuse number. Pro's 100 is
+// deliberately below the ~132 subscriptions that overflowed Postgres's
+// 65535-parameter limit in the original outage, so no tier can reach the
+// region that broke dispatch even though #562's chunking already fixed it.
+func TestMatrix_WebhookSubscriptions(t *testing.T) {
+	for _, tc := range []struct {
+		plan subscription.SubscriptionPlan
+		want int
+	}{
+		{subscription.PlanTrial, 5},
+		{subscription.PlanStarter, 10},
+		{subscription.PlanStudio, 25},
+		{subscription.PlanPro, 100},
+	} {
+		require.Equal(t, tc.want, plangate.Limit(tc.plan, plangate.FeatureWebhookSubscriptions),
+			"webhook subscription cap for %s", tc.plan)
+	}
+
+	// No tier may be Unlimited: fan-out cost is unbounded in the number of
+	// subscriptions, so "no cap" is the failure mode this feature exists to
+	// prevent. Guard against a well-meaning future edit.
+	for _, p := range []subscription.SubscriptionPlan{
+		subscription.PlanTrial, subscription.PlanStarter, subscription.PlanStudio, subscription.PlanPro,
+	} {
+		require.NotEqual(t, plangate.Unlimited, plangate.Limit(p, plangate.FeatureWebhookSubscriptions),
+			"plan %s must keep a finite webhook subscription cap (#586)", p)
+	}
+}
+
 func TestMatrix_FullAPI_ProOnly(t *testing.T) {
 	require.True(t, plangate.IsAllowed(subscription.PlanStudio, plangate.FeatureReadAPI))
 	require.False(t, plangate.IsAllowed(subscription.PlanStudio, plangate.FeatureFullAPI))
@@ -113,7 +144,7 @@ func TestAllFeatureLimits_EveryFeaturePresentForEveryPlan(t *testing.T) {
 // feature list stays aligned with the spec §9 count. Bumping the count
 // should be deliberate — update this assertion when a new Feature lands.
 func TestAllFeatures_IncludesAllConstants(t *testing.T) {
-	require.Equal(t, 25, len(plangate.AllFeatures()),
+	require.Equal(t, 26, len(plangate.AllFeatures()),
 		"expected 25 feature constants per §9 — update this count if new ones are added")
 }
 

--- a/services/marketplace-api/internal/webhook/subscription_repo.go
+++ b/services/marketplace-api/internal/webhook/subscription_repo.go
@@ -43,6 +43,21 @@ func (r *SubscriptionRepo) ListForStore(ctx context.Context, tenantID, storeID u
 	return out, nil
 }
 
+// CountForStore returns how many subscriptions a store currently holds,
+// enabled or not. Disabled rows count: they are still a row a merchant can
+// flip back on, so excluding them would let a store sit permanently over
+// its plan cap by parking subscriptions in the disabled state.
+func (r *SubscriptionRepo) CountForStore(ctx context.Context, tenantID, storeID uuid.UUID) (int, error) {
+	var n int64
+	err := r.db.WithContext(ctx).Model(&Subscription{}).
+		Where("tenant_id = ? AND store_id = ?", tenantID, storeID).
+		Count(&n).Error
+	if err != nil {
+		return 0, fmt.Errorf("webhook: count subscriptions: %w", err)
+	}
+	return int(n), nil
+}
+
 // Update persists url/event_types/enabled/disabled_reason/disabled_at for a
 // subscription the caller has already verified belongs to their tenant and
 // store — this method itself does not re-check ownership, matching ByID.


### PR DESCRIPTION
Closes #586 by taking the **plangate route** with per-plan limits, consistent with how `FeatureStores` and `FeatureImagesPerProduct` work.

## The limits

| Plan | Subscriptions per store |
| --- | --- |
| Trial | 5 |
| Starter | 10 |
| Studio | 25 |
| Pro | 100 |

Pro's 100 is deliberately **below** the ~132 subscriptions that overflowed Postgres's 65535-parameter limit in the original fan-out outage. #562's chunking already fixed that failure, but keeping every tier short of the region that broke dispatch means the cap does not depend on the chunking holding.

## Why a cap at all

Fan-out is `outbox rows × matching subscriptions`. Chunking changed the *failure shape* — a merchant now degrades their own dispatch throughput rather than every tenant's — but it is not a limit. One `order.placed` on an uncapped store still becomes an unbounded number of delivery rows and outbound HTTP attempts against a shared `db-f1-micro` with a 5-connection pool per pod.

## Enforcement, and what it deliberately does not do

Enforced at **creation only**, mirroring `FeatureImagesPerProduct`: a plan downgrade never deletes a merchant's existing subscriptions. A store that ends up over its cap keeps every endpoint working but cannot add another. Only `FeatureStores` gets the `planchange` preflight/downgrade treatment, and extending that machinery here would be a much larger change than this issue asked for — `docs/webhooks.md` states the behaviour plainly instead.

Over the cap returns a `400 webhook_subscription_limit_reached` naming `limit`, `current` and `plan`, so the UI can explain the situation rather than showing a generic failure.

**Disabled subscriptions count.** A disabled row is one the merchant can flip back on, so excluding them would let a store sit permanently over its cap by parking endpoints in the disabled state. There is a test for exactly this.

**Fails closed.** A nil resolver or a failed count refuses the create rather than allowing it — the cap protects shared database capacity, so "could not check" must not mean "allow". `resolver` is an explicit constructor argument, not an optional setter, so it cannot be silently forgotten.

## A stale guard, repaired rather than deleted

`apps/onboarding/tests/unit/pricing-copy-truth.spec.ts` asserted **no pricing bullet may mention "webhook"**, on the stated grounds that "no column anywhere stores a merchant-supplied callback URL". That premise died with #562 — `webhook_subscriptions.url` is exactly that column. Its sibling guard in `pricing-surfaces-truth.spec.ts` had already retired the same assertion; this one was missed.

Rather than delete it, I converted it into a live truth guard: a webhook bullet is now allowed, but its **number must match `FeatureWebhookSubscriptions` in the Go matrix**. I verified it fails correctly by editing a bullet to `40` — it reports `studio advertises "40 webhook endpoints" but plangate enforces 25`.

## Test plan

- [x] `TestCreateWebhook_EnforcesPerStoreCap` — 5 creates succeed, the 6th is a 400 with `limit`/`current`/`plan`, and the rejected create persists no row
- [x] `TestCreateWebhook_DisabledSubscriptionsCountTowardCap` — disabling does not free a slot
- [x] **Both verified RED** with enforcement disabled (6th create returned 201), GREEN with it
- [x] `TestMatrix_WebhookSubscriptions` — pins the ladder, and asserts no tier is `Unlimited`
- [x] Feature-parity test updated 25 → 26
- [x] Full integration suites: `internal/handlers/admin` (43.9s), `internal/webhook`, `internal/plangate` — all `ok`, run with `TEST_DATABASE_URL` against a real Postgres
- [x] Onboarding unit suite 77/77 (including the rewritten guard); admin pricing 20/20
- [x] `go build ./...`, `go vet`, `gofmt` clean

## Note

All three public surfaces carry the number, per the decision to make this a visible product lever: both pricing surfaces and `llms-full.txt`.

Refs #586, #562.
