### PR TITLE
feat(plans): widen the read-only API to Trial so evaluating merchants can complete the webhook loop

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -12,14 +12,9 @@ Webhooks are available on every plan. There is no gating by tier.
 the event name, the aggregate id and a timestamp — deliberately, so no customer
 data is sent to a merchant-supplied URL and a retry can never deliver a stale
 copy of an entity. To act on an event you fetch the entity from the REST API
-using the id. The read-only API is available on **Starter, Studio and Pro**
-(widened to Starter in #585 precisely so every plan that can register a webhook
-can also resolve what it delivers).
-
-On **Trial**, the read-only API is not enabled. Trial webhooks still work as
-pure signals — ping a Slack channel, increment a counter, prompt someone to
-open admin — but a Trial integration cannot fetch the order behind an
-`order.placed` until the store is on a paid plan.
+using the id. The read-only API is available on **every plan, Trial included**
+(#585) — precisely so that any plan able to register a webhook can also resolve
+what it delivers. Write access to the API (`FeatureFullAPI`) remains Pro-only.
 
 **How many endpoints you can register.** Each store may hold a limited number
 of subscriptions, because dispatch fan-out is `outbox rows × matching

--- a/services/marketplace-api/internal/handlers/admin/apikeys_handler.go
+++ b/services/marketplace-api/internal/handlers/admin/apikeys_handler.go
@@ -1,6 +1,6 @@
 // Package admin — apikeys_handler.go: §18.4 enterprise API-key admin
 // endpoints. Mounted under /admin/stores/:storeId/api-keys. Reads (GET)
-// are gated by plangate.RequireFeature(FeatureReadAPI) (Starter+ since
+// are gated by plangate.RequireFeature(FeatureReadAPI) (every plan since
 // #585); writes
 // (POST create/rotate, DELETE revoke) are gated by FeatureFullAPI (Pro).
 // The service layer additionally rejects write-scoped key creation when
@@ -251,9 +251,9 @@ func (h *APIKeysHandler) parseUser(c *gin.Context) (uuid.UUID, bool) {
 }
 
 // RegisterAPIKeys mounts the admin endpoints. List is gated by FeatureReadAPI
-// (Starter+ since #585); create/rotate/revoke are gated by FeatureFullAPI
-// (Pro). Read endpoints under FeatureReadAPI let Starter+ merchants list
-// their keys without upgrading; write endpoints require an explicit Pro plan.
+// (every plan since #585); create/rotate/revoke are gated by FeatureFullAPI
+// (Pro). Read endpoints under FeatureReadAPI let any merchant list their keys
+// without upgrading; write endpoints require an explicit Pro plan.
 func RegisterAPIKeys(storeRoute gin.IRouter, h *APIKeysHandler, fgaMw *authz.Middleware, logger *slog.Logger) {
 	if h == nil || h.resolver == nil {
 		return

--- a/services/marketplace-api/internal/plangate/matrix.go
+++ b/services/marketplace-api/internal/plangate/matrix.go
@@ -145,10 +145,18 @@ var featureMatrix = map[subscription.SubscriptionPlan]planLimits{
 		FeatureReviews:         1,
 		FeatureTickets:         1,
 		FeatureGiftCards:       1,
-		FeatureReadAPI:         Disabled,
-		FeatureFullAPI:         Disabled,
-		FeatureSSO:             Disabled,
-		FeatureUptimeSLA:       Disabled,
+		// #585 (follow-up): widened from Disabled for the same reason
+		// Starter was. Webhooks ship on every plan and deliver only an
+		// event name and an aggregate id, so a Trial merchant evaluating
+		// an integration could receive order.placed and have no way to
+		// resolve it — and would reasonably conclude webhooks are broken
+		// during the exact window we are trying to convert them in.
+		// The read API is consequently no longer a paid differentiator
+		// on any tier; FeatureFullAPI (write) remains Pro-only.
+		FeatureReadAPI:   1,
+		FeatureFullAPI:   Disabled,
+		FeatureSSO:       Disabled,
+		FeatureUptimeSLA: Disabled,
 
 		FeatureStandardEmailSupport: 1,
 		FeaturePriorityEmailSupport: Disabled,

--- a/services/marketplace-api/internal/plangate/matrix_test.go
+++ b/services/marketplace-api/internal/plangate/matrix_test.go
@@ -48,15 +48,16 @@ func TestMatrix_SSO_ProOnly(t *testing.T) {
 	require.True(t, plangate.IsAllowed(subscription.PlanPro, plangate.FeatureSSO))
 }
 
-// TestMatrix_ReadAPI_StarterAndAbove pins the #585 decision. Outbound
-// webhooks are available on every plan and carry a notify-and-fetch payload
-// (event + aggregate id only), so any plan that can register a webhook must
-// also be able to resolve what it points at. Trial is deliberately excluded
-// here — see #585; if Trial ever gains it, extend this test rather than
-// deleting it.
-func TestMatrix_ReadAPI_StarterAndAbove(t *testing.T) {
+// TestMatrix_ReadAPI_EveryPlan pins the #585 decision, now extended to
+// Trial. Outbound webhooks are available on every plan and carry a
+// notify-and-fetch payload (event + aggregate id only), so EVERY plan that
+// can register a webhook must also be able to resolve what it points at.
+// This is the whole matrix on purpose: the read API is deliberately no
+// longer a paid differentiator. Write access (FeatureFullAPI) remains
+// Pro-only — see TestMatrix_FullAPI_ProOnly.
+func TestMatrix_ReadAPI_EveryPlan(t *testing.T) {
 	for _, p := range []subscription.SubscriptionPlan{
-		subscription.PlanStarter, subscription.PlanStudio, subscription.PlanPro,
+		subscription.PlanTrial, subscription.PlanStarter, subscription.PlanStudio, subscription.PlanPro,
 	} {
 		require.True(t, plangate.IsAllowed(p, plangate.FeatureReadAPI),
 			"plan %s can register webhooks, so it must be able to resolve the ids they deliver (#585)", p)


### PR DESCRIPTION
Follow-up to #591, closing the half of #585 that PR deliberately left open.

## Why Trial too

#591 widened `FeatureReadAPI` to Starter. Trial kept `Disabled`, so the original incoherence survived on the one tier where it does the most damage.

Webhooks ship on **every** plan, Trial included, and deliver only an event name plus an aggregate id. A merchant evaluating Mark8ly during their trial could register a webhook, receive `order.placed`, and have no supported way to resolve it — during the exact window we are trying to convert them in. Someone in that position does not conclude "this is a paid feature"; they conclude webhooks are broken.

## Changes

- `plangate/matrix.go` — Trial `FeatureReadAPI: Disabled → 1`, with the reasoning inline
- `TestMatrix_ReadAPI_StarterAndAbove` → **`TestMatrix_ReadAPI_EveryPlan`**, now asserting all four plans. #591 wrote that test saying *"if Trial ever gains it, extend this test rather than deleting it"* — this is that extension
- `docs/webhooks.md` — drops the Trial caveat #591 added; the read API is now documented as available on every plan, with write access (`FeatureFullAPI`) still Pro-only
- `apikeys_handler.go` — two more comments moved from "Starter+" to "every plan"

No pricing-surface changes: Trial is not sold as a plan and has no bullets on any surface.

## What this now means

**The read-only API is no longer a paid differentiator on any tier.** That is the full extent of the #585 Option 1 trade-off, and it should be a conscious position rather than something discovered later:

- **Studio** still differentiates on 5 storefronts, 50 images/product, 50k campaign emails, custom CSS, the 12-month audit log, and 25 vs 10 webhook endpoints (#586)
- **Pro** still gates write access behind `FeatureFullAPI`, plus SSO, unlimited images and forever retention

If the read API should remain a paid line item, this PR is the one to reject — not #591.

## Test plan

- [x] `TestMatrix_ReadAPI_EveryPlan` passes across Trial/Starter/Studio/Pro
- [x] `TestMatrix_FullAPI_ProOnly` still passes — write access did not leak
- [x] `go test ./internal/plangate/` unit + integration, and the full `internal/handlers/admin` integration suite (40.6s) against a real Postgres
- [x] Onboarding unit suite 77/77
- [x] Rebased onto main after #592 merged; `go build ./...`, `gofmt` clean

Refs #585, #591, #562.
