### PR TITLE
fix(seo): state India prices as literal text so crawlers can read them

### DIFF
--- a/apps/onboarding/app/sell-online-india/page.tsx
+++ b/apps/onboarding/app/sell-online-india/page.tsx
@@ -30,7 +30,7 @@ export default function SellOnlineIndiaPage() {
       intro={[
         "Selling online in India comes down to one thing at the moment of truth: can the customer pay the way they already pay? For most of the country, that's UPI — a quick scan or a tap, no card numbers, no friction. A checkout that treats UPI as an afterthought loses the sale on the last screen.",
         "Mark8ly puts UPI, wallets, and cards behind one clean checkout, so however your customer prefers to pay, they can. It's built in, not bolted on — no region-locked workarounds, no forcing everyone through a single card processor that half your customers don't use.",
-        "And on top of that, we take nothing from your sales. There's no platform fee — you pay only your payment processor's standard rate (around 2% for UPI). For Indian sellers running on real margins, keeping that 2% platform skim in your own pocket is decisive. Ninety days free to start, then plans from ₹ equivalent pricing shown in your own currency.",
+        "And on top of that, we take nothing from your sales. There's no platform fee — you pay only your payment processor's standard rate (around 2% for UPI). For Indian sellers running on real margins, keeping that 2% platform skim in your own pocket is decisive. Ninety days free to start, then ₹999 a month for Starter — or ₹9,599 for the year, which works out at about ₹800 a month.",
       ]}
       competitorName="Global platforms"
       comparisonNote="Most global platforms bill in USD and treat local Indian payment methods as a regional add-on rather than the default."
@@ -94,7 +94,7 @@ export default function SellOnlineIndiaPage() {
         {
           question: "What does it cost to sell online in India?",
           answer:
-            "There's no platform fee on your sales — you pay only your payment processor's standard rate, around 2% for UPI. Plans start after 90 days free, priced in your own currency.",
+            "There's no platform fee on your sales — you pay only your payment processor's standard rate, around 2% for UPI. After 90 days free, Starter is ₹999 a month (₹9,599 a year), Studio is ₹2,499 and Pro is ₹6,599.",
         },
         {
           question: "Can customers pay with cards and wallets too?",


### PR DESCRIPTION
Closes #598.

## What was wrong

`/sell-online-india` never stated the India price in server-rendered HTML. Searching the raw response for `₹999`, `INR`, `rupee`, `PPP` and `purchasing power` returned nothing. The only `₹` in the entire document was a dangling symbol with no number attached:

> "...Ninety days free to start, then plans from **₹ equivalent pricing shown in your own currency**."

The FAQ answer to *"What does it cost to sell online in India?"* had the same hole — it said prices were "priced in your own currency", which is a deferral rather than an answer.

The actual figures were resolved client-side from the currency cookie, so they existed only after hydration and never reached a crawler.

## Why it mattered

₹999/month is the reason the India motion is credible at all — roughly a fifth of what Shopify charges there. But:

- **No crawler ever saw it.** The page ranked for India intent while being silent on the one number that wins the click.
- **The FAQ answer was unquotable.** A model asked "what does Mark8ly cost in India" could not cite us, because we had not said anything. That answer is also emitted into `FAQPage` JSON-LD via the shared `faq` prop, so the gap was duplicated into structured data.

This got *more* valuable this week, not less: the Cloudflare edge was returning 403 to every AI crawler (#595, now resolved), so there is finally something on the other side to read it.

## What changed

Two strings in `app/sell-online-india/page.tsx`:

**Body copy** — `"plans from ₹ equivalent pricing shown in your own currency"` → `"₹999 a month for Starter — or ₹9,599 for the year, which works out at about ₹800 a month."`

**FAQ answer** — `"Plans start after 90 days free, priced in your own currency."` → `"After 90 days free, Starter is ₹999 a month (₹9,599 a year), Studio is ₹2,499 and Pro is ₹6,599."`

The FAQ change is the one that matters most — it lands in the `FAQPage` JSON-LD as well as the visible accordion, so the citable version now contains real figures.

## On hardcoding prices into prose

Every figure is verified against `packages/ui/src/subscription/pricing-data.ts`:

```
starter  INR ₹999/mo   ₹9,599/yr
studio   INR ₹2,499/mo ₹23,999/yr
pro      INR ₹6,599/mo ₹65,999/yr
```

This is deliberately a copy of the catalogue rather than a read from it, and that is a real trade-off worth naming: #564 was about public pricing surfaces advertising things the service does not actually grant, and hardcoded prose is exactly how that recurs. **If INR pricing changes, this page must change with it.**

The alternative — rendering these from `SHARED_PRICING_CATALOGUE` server-side — is better and worth doing if this pattern spreads. It is more than this issue needs, and `SeoLanding` currently takes plain strings, so it would mean changing the component's contract for all four landing pages.

Safe to hardcode `₹` here specifically because **`SeoLanding` does not render the currency-switching pricing table** — verified. A non-Indian visitor sees no contradicting figures on this page.

## Verification

```
npm run check-types -w @mark8ly/onboarding    # tsc --noEmit, clean
```

After deploy:

```
curl -s -A "Googlebot/2.1" https://mark8ly.com/sell-online-india | grep -c '₹999'   # expect ≥ 2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YB1BFjWgctpHPLb1knCRKH
