### PR TITLE
perf(onboarding): prerender the marketing homepage instead of rendering it per request

### DIFF
--- a/apps/onboarding/app/page.tsx
+++ b/apps/onboarding/app/page.tsx
@@ -1,16 +1,11 @@
-import type { ReactNode } from "react";
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
-import { cookies } from "next/headers";
 import { FaqAccordion } from "@repo/ui/faq-accordion";
 import { MOBILE_ADMIN_APP_LINKS } from "@repo/ui/app-store-badges";
 import {
-  CURRENCY_COOKIE_NAME,
-  Money,
   SHARED_PRICING_CATALOGUE,
   getPlanPrice,
-  normalizeCurrency,
   type Currency,
   type PlanId,
   type SharedPlan,
@@ -19,6 +14,8 @@ import {
 import { Header } from "@/components/marketing/Header";
 import { Footer } from "@/components/marketing/Footer";
 import { Pricing } from "@/components/marketing/Pricing";
+import { Comparison } from "@/components/marketing/Comparison";
+import { PRERENDER_CURRENCY } from "@/lib/geo/currency";
 
 const SITE_URL = "https://mark8ly.com";
 
@@ -111,7 +108,7 @@ function describeMobileApp(): {
  * Resolves a plan's price alongside the currency it is actually
  * denominated in. `getPlanPrice` silently falls back to USD for an
  * unlisted currency, which would otherwise let us label a USD amount
- * with the visitor's currency code — a wrong price in the schema.
+ * with the requested currency's code — a wrong price in the schema.
  */
 function resolvePricedPlan(
   plan: SharedPlan,
@@ -125,6 +122,20 @@ function resolvePricedPlan(
   };
 }
 
+/**
+ * The schema currency is fixed at PRERENDER_CURRENCY rather than the
+ * visitor's, and that is the honest description of what this page is:
+ * `/` is statically prerendered, so there is exactly one HTML document
+ * and it can only carry one price.
+ *
+ * Nothing is lost. The dynamic render this replaced resolved crawlers to
+ * their own egress location, which meant the "localised" structured data
+ * was one fixed currency (AUD, from the Sydney pod) in practice — it just
+ * cost full edge caching to produce. A fixed, USD-denominated graph that
+ * matches the prerendered visible prices satisfies Google's
+ * structured-data-must-match-visible-content rule for the document the
+ * crawler actually receives.
+ */
 function buildHomeJsonLd(currency: Currency) {
   const pricedPlans = SHARED_PRICING_CATALOGUE.plans.map((plan) => ({
     id: plan.id,
@@ -248,24 +259,24 @@ function buildHomeJsonLd(currency: Currency) {
 /**
  * Marketing landing page.
  *
- * Server Component. The only client island on the page is the
- * FAQ accordion, imported from @repo/ui. Everything else is
- * static markup so the JS bundle on the highest-traffic page
- * stays close to zero.
+ * Server Component, and deliberately a statically prerendered one:
+ * it touches no request-scoped API, so Next can emit it at build
+ * time and Cloudflare can cache it at the edge. Anything that
+ * needs the visitor (currency, today) belongs in a client island —
+ * see lib/geo/currency.ts. Adding a `cookies()`, `headers()`, or
+ * `searchParams` read here silently costs every visitor a
+ * round-trip to a single pod in Sydney (#597).
+ *
+ * The client islands are the FAQ accordion, the Pricing section,
+ * and the Comparison table. Everything else is static markup so
+ * the JS bundle on the highest-traffic page stays close to zero.
  *
  * Layout philosophy: editorial, left-aligned, asymmetric. No
  * card grids. No icon tiles above headings. No hero metric
  * strips. The serif (Source Serif 4) carries the weight; one
  * moss accent does the work color used to do.
  */
-export default async function HomePage() {
-  // Geo-localized currency — middleware sets `mk8_currency` from
-  // CF-IPCountry. Fallback is USD so the page always renders.
-  const cookieStore = await cookies();
-  const currency = normalizeCurrency(
-    cookieStore.get(CURRENCY_COOKIE_NAME)?.value,
-  );
-
+export default function HomePage() {
   return (
     <div className="bg-background text-foreground">
       <script
@@ -274,7 +285,7 @@ export default async function HomePage() {
         // input reaches this. `<` is escaped as a matter of habit,
         // matching app/guides/[slug]/page.tsx.
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify(buildHomeJsonLd(currency)).replace(
+          __html: JSON.stringify(buildHomeJsonLd(PRERENDER_CURRENCY)).replace(
             /</g,
             "\\u003c",
           ),
@@ -288,8 +299,8 @@ export default async function HomePage() {
         <Tour />
         <Manifesto />
         <Features />
-        <Pricing currency={currency} catalogue={SHARED_PRICING_CATALOGUE} />
-        <Comparison currency={currency} />
+        <Pricing catalogue={SHARED_PRICING_CATALOGUE} />
+        <Comparison />
         <HowItWorks />
         <SetupSavings />
         <Faq />
@@ -589,358 +600,12 @@ function FeaturePlate({ kicker, index, src, alt }: FeaturePlateProps) {
    ============================================================ */
 
 /* ============================================================
-   Comparison — quiet, factual table that puts Mark8ly next to
-   the names readers have already weighed: Shopify, BigCommerce,
-   Wix, Squarespace.
-
-   Cadence: every "Starting price" cell shows the *annual-billed
-   monthly equivalent* — the same cadence the Pricing section
-   above defaults to. Without this, an AUD merchant saw A$23 in
-   Pricing and A$29 in Comparison for the same plan, which read
-   as a typo. Now both speak the same number.
-
-   Mark8ly's Starter tracks the SHARED_PRICING_CATALOGUE (single
-   source of truth with /admin/pricing). Competitor prices come
-   from each platform's published per-country pricing page,
-   verified against the live page where possible:
-     - Shopify Basic AUD A$42 — shopify.com/au/pricing
-     - Shopify Basic INR ₹1,499 — shopify.com/in/pricing
-     - BigCommerce Standard USD $22 — bigcommerce.com (USD only globally)
-   Where a platform doesn't publish a price in the visitor's
-   currency (BigCommerce globally, Wix/Squarespace outside the
-   US in our data set), the cell shows their USD rate with a
-   "(USD)" tag so the merchant sees what they'd actually be
-   charged. We deliberately keep the data set small and honest:
-   only currencies we've verified, USD fallback for the rest.
-
-   Editorial, not a SaaS bake-off — hairline rules between rows,
-   no shaded card, Mark8ly column carries a single moss accent
-   so the eye finds it without shouting.
+   Comparison — rendered by the client island at
+   components/marketing/Comparison.tsx. It left this file when
+   `/` was made statically prerenderable (#597): its price cells
+   resolve the visitor's currency after mount rather than from a
+   server-side cookie read.
    ============================================================ */
-
-interface CompareRow {
-  label: string;
-  mark8ly: string;
-  shopify: string;
-  bigcommerce: string;
-  wix: string;
-  squarespace: string;
-}
-
-// Feature rows (currency-agnostic). The Starting-price row is
-// rendered separately and pulls from COMPETITOR_STARTING_PRICES
-// + the shared catalogue.
-const COMPARISON_ROWS: readonly CompareRow[] = [
-  {
-    label: "Free to try",
-    mark8ly: "90 days",
-    shopify: "3 days",
-    bigcommerce: "15 days",
-    wix: "14 days",
-    squarespace: "14 days",
-  },
-  {
-    label: "Platform fee per sale",
-    mark8ly: "None",
-    shopify: "2%, unless you use Shopify Payments",
-    bigcommerce: "None",
-    wix: "None",
-    squarespace: "None",
-  },
-  {
-    label: "Default storefront design",
-    mark8ly: "Editorial, designer-led",
-    shopify: "Generic templates",
-    bigcommerce: "Functional templates",
-    wix: "Drag-and-drop builder",
-    squarespace: "Designer themes",
-  },
-  {
-    label: "Use your own domain",
-    mark8ly: "Included",
-    shopify: "Bring your own",
-    bigcommerce: "Bring your own",
-    wix: "First year included",
-    squarespace: "First year included",
-  },
-  {
-    label: "Local payments (UPI, wallets)",
-    mark8ly: "Built in",
-    shopify: "Limited by region",
-    bigcommerce: "Limited by region",
-    wix: "Limited by region",
-    squarespace: "Mostly Stripe / PayPal",
-  },
-  {
-    label: "Take your data when you leave",
-    mark8ly: "One click, any time",
-    shopify: "CSV export",
-    bigcommerce: "CSV export",
-    wix: "Partial",
-    squarespace: "Partial",
-  },
-];
-
-type CompetitorId = "shopify" | "bigcommerce" | "wix" | "squarespace";
-
-// Annual-billed monthly equivalent (the price each platform leads
-// with on their own pricing page, "$X/mo billed yearly"). Pre-
-// formatted strings preserve each platform's own grouping and
-// symbol convention. Currencies not in a competitor's map fall back
-// to its USD entry with a "(USD)" tag in the renderer below — that's
-// honest about platforms that don't localize for that currency.
-const COMPETITOR_STARTING_PRICES: Record<
-  CompetitorId,
-  Partial<Record<Currency, string>>
-> = {
-  shopify: {
-    // Shopify Basic, "$X/mo billed yearly" rate from each region.
-    USD: "$29",
-    AUD: "A$42", // shopify.com/au/pricing
-    INR: "₹1,499", // shopify.com/in/pricing
-    GBP: "£19",
-    EUR: "€27",
-  },
-  bigcommerce: {
-    // Standard plan annual-billed: $29 monthly with "save 25%" → $22/mo.
-    // BigCommerce publishes USD only globally — every other currency
-    // hits the USD-tagged fallback.
-    USD: "$22",
-  },
-  wix: {
-    // Core plan with ecommerce, annual billing.
-    USD: "$29",
-  },
-  squarespace: {
-    // Basic Commerce, annual billing.
-    USD: "$27",
-  },
-};
-
-function competitorStartingPrice(
-  id: CompetitorId,
-  currency: Currency,
-): string {
-  const map = COMPETITOR_STARTING_PRICES[id];
-  const localized = map[currency];
-  if (localized) return `${localized} / mo`;
-  // Platform doesn't publish a price in this currency — they bill
-  // in USD. Tag it so a non-US merchant knows what they'd actually pay.
-  const usd = map.USD!;
-  return currency === "USD" ? `${usd} / mo` : `${usd} / mo (USD)`;
-}
-
-interface ComparisonProps {
-  currency: Currency;
-}
-
-function Comparison({ currency }: ComparisonProps) {
-  const competitorHeaderClass =
-    "px-4 py-4 text-left align-bottom font-sans text-[0.9375rem] font-medium text-foreground-secondary";
-  const competitorCellClass =
-    "px-4 py-5 align-top text-foreground-tertiary";
-
-  // Mark8ly's Starter price tracks the shared pricing catalogue,
-  // and we deliberately use the annual-billed monthly equivalent so
-  // the number matches what the Pricing section shows on its default
-  // (annual) toggle. Without this, the same plan reads as A$23 in
-  // Pricing and A$29 in Comparison — same plan, different cadence,
-  // looks like a typo.
-  const starter = SHARED_PRICING_CATALOGUE.plans.find((p) => p.id === "starter");
-  const resolvedStarter = starter ? getPlanPrice(starter, currency) : null;
-  const mark8lyStarterAnnualMonthly = resolvedStarter?.price.annualMonthlyEquivalent ?? null;
-  // MUST render this — never the raw `currency` prop — for the same
-  // reason as the Pricing section: when `currency` has no row, the
-  // fallback amount is denominated in USD, and labelling it with the
-  // visitor's raw currency code would misquote the price.
-  const mark8lyStarterCurrency = resolvedStarter?.currency ?? currency;
-
-  return (
-    <section
-      id="compare"
-      aria-labelledby="compare-heading"
-      className="border-t border-border-subtle py-16 sm:py-24"
-    >
-      <div className="mx-auto max-w-6xl px-6">
-        <div className="mb-12 grid gap-8 lg:grid-cols-[1fr_2fr] lg:gap-16">
-          <div>
-            <p className="eyebrow mb-5">How we compare</p>
-            <h2
-              id="compare-heading"
-              className="font-serif text-4xl font-medium leading-[1.05] tracking-[-0.02em] text-foreground"
-            >
-              Side by side,
-              <br />
-              no spin.
-            </h2>
-          </div>
-          <p className="max-w-xl self-end text-base leading-relaxed text-foreground-secondary">
-            We&rsquo;re not the only commerce platform on the table. Here&rsquo;s
-            how Mark8ly lines up against the names you&rsquo;ve probably
-            already looked at &mdash; the things that show up on the bill,
-            and the things that show up on the storefront. Starting prices
-            show each platform&rsquo;s annual-billed rate in {currency} where
-            they publish one, the same cadence as the Pricing section above.
-          </p>
-        </div>
-
-        <div className="-mx-6 overflow-x-auto px-6 sm:mx-0 sm:px-0">
-          <table className="w-full min-w-[760px] border-collapse text-sm">
-            <caption className="sr-only">
-              How Mark8ly compares with Shopify, BigCommerce, Wix and
-              Squarespace on price, trial length, fees, design and data
-              portability. Prices shown in {currency}.
-            </caption>
-            <thead>
-              <tr className="border-b border-border">
-                <th
-                  scope="col"
-                  className="py-4 pr-6 text-left align-bottom"
-                >
-                  <span className="eyebrow">Feature</span>
-                </th>
-                <th
-                  scope="col"
-                  className="px-4 py-4 text-left align-bottom"
-                >
-                  <span className="font-serif text-lg font-medium text-foreground">
-                    Mark8ly
-                  </span>
-                </th>
-                <th scope="col" className={competitorHeaderClass}>
-                  Shopify
-                </th>
-                <th scope="col" className={competitorHeaderClass}>
-                  BigCommerce
-                </th>
-                <th scope="col" className={competitorHeaderClass}>
-                  Wix
-                </th>
-                <th scope="col" className={competitorHeaderClass}>
-                  Squarespace
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {/* Starting price — geo-localized row, rendered specially. */}
-              <tr className="border-b border-border-subtle">
-                <th
-                  scope="row"
-                  className="py-5 pr-6 text-left align-top font-normal text-foreground-secondary"
-                >
-                  Starting price
-                </th>
-                <td className="px-4 py-5 align-top">
-                  <span className="block border-l-2 border-moss-700 pl-3 font-medium text-foreground">
-                    {mark8lyStarterAnnualMonthly !== null ? (
-                      <>
-                        <Money
-                          amount={mark8lyStarterAnnualMonthly}
-                          currency={mark8lyStarterCurrency}
-                          showCents={false}
-                        />
-                        <span className="text-foreground-tertiary"> / mo</span>
-                      </>
-                    ) : (
-                      "—"
-                    )}
-                  </span>
-                </td>
-                <td className={competitorCellClass}>
-                  {competitorStartingPrice("shopify", currency)}
-                </td>
-                <td className={competitorCellClass}>
-                  {competitorStartingPrice("bigcommerce", currency)}
-                </td>
-                <td className={competitorCellClass}>
-                  {competitorStartingPrice("wix", currency)}
-                </td>
-                <td className={competitorCellClass}>
-                  {competitorStartingPrice("squarespace", currency)}
-                </td>
-              </tr>
-
-              {/* Feature rows — currency-agnostic. */}
-              {COMPARISON_ROWS.map((row) => (
-                <tr
-                  key={row.label}
-                  className="border-b border-border-subtle"
-                >
-                  <th
-                    scope="row"
-                    className="py-5 pr-6 text-left align-top font-normal text-foreground-secondary"
-                  >
-                    {row.label}
-                  </th>
-                  <td className="px-4 py-5 align-top">
-                    <span className="block border-l-2 border-moss-700 pl-3 font-medium text-foreground">
-                      {row.mark8ly}
-                    </span>
-                  </td>
-                  <td className={competitorCellClass}>{row.shopify}</td>
-                  <td className={competitorCellClass}>{row.bigcommerce}</td>
-                  <td className={competitorCellClass}>{row.wix}</td>
-                  <td className={competitorCellClass}>{row.squarespace}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        <p className="mt-8 max-w-3xl text-sm text-foreground-tertiary">
-          Starting prices show each platform&rsquo;s cheapest paid plan
-          billed yearly &mdash; Shopify Basic, BigCommerce Standard, Wix
-          Core, Squarespace Basic Commerce. Where a platform doesn&rsquo;t
-          publish a price in your currency (BigCommerce globally; Wix and
-          Squarespace outside the US in our verified data), we show the USD
-          rate and tag it so you know what you&rsquo;d actually be charged.
-          Payment processor fees &mdash; around 2&ndash;3% for cards, closer
-          to 1% for UPI &mdash; apply on every platform. That&rsquo;s your
-          bank, not us; the line above is what the platform itself adds on
-          top.
-        </p>
-
-        <p className="mt-8 max-w-3xl text-base leading-relaxed text-foreground-secondary">
-          Weighing a specific platform? Read the full comparisons:{" "}
-          <ComparisonLink href="/shopify-alternative">
-            Mark8ly vs Shopify
-          </ComparisonLink>
-          ,{" "}
-          <ComparisonLink href="/etsy-alternative">
-            the Etsy alternative
-          </ComparisonLink>
-          , our{" "}
-          <ComparisonLink href="/ecommerce-for-makers">
-            guide for makers
-          </ComparisonLink>
-          , or{" "}
-          <ComparisonLink href="/sell-online-india">
-            selling online in India
-          </ComparisonLink>
-          .
-        </p>
-      </div>
-    </section>
-  );
-}
-
-/* Inline editorial link — moss underline, matches the Prose link style. */
-function ComparisonLink({
-  href,
-  children,
-}: {
-  href: string;
-  children: ReactNode;
-}) {
-  return (
-    <Link
-      href={href}
-      className="text-foreground underline decoration-moss-700 decoration-2 underline-offset-4 hover:text-moss-700"
-    >
-      {children}
-    </Link>
-  );
-}
 
 /* ============================================================
    How it works — three steps, numbered, left-aligned, narrow

--- a/apps/onboarding/components/marketing/Comparison.tsx
+++ b/apps/onboarding/components/marketing/Comparison.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+/**
+ * Marketing /#compare section.
+ *
+ * A client island purely so the currency-bearing cells can resolve the
+ * visitor's `mk8_currency` cookie after mount. It was inline in
+ * app/page.tsx and rendered on the server until doing so forced the
+ * whole route dynamic (#597) — see lib/geo/currency.ts for the TTFB
+ * numbers that motivated the split.
+ *
+ * The markup still server-renders at build time in PRERENDER_CURRENCY,
+ * so crawlers and the first paint get the full table; only the six
+ * price cells and the two "in {currency}" sentences change on mount.
+ * Splitting those into six micro-islands would keep a few kB out of the
+ * bundle at the cost of scattering one table across several files, and
+ * this section is well below the fold where bundle size is not the
+ * constraint.
+ */
+
+import type { ReactNode } from "react";
+import Link from "next/link";
+import {
+  Money,
+  getPlanPrice,
+  SHARED_PRICING_CATALOGUE,
+  type Currency,
+} from "@repo/ui/subscription";
+
+import { useGeoCurrency } from "@/lib/geo/use-geo-currency";
+
+/* ============================================================
+   Comparison — quiet, factual table that puts Mark8ly next to
+   the names readers have already weighed: Shopify, BigCommerce,
+   Wix, Squarespace.
+
+   Cadence: every "Starting price" cell shows the *annual-billed
+   monthly equivalent* — the same cadence the Pricing section
+   above defaults to. Without this, an AUD merchant saw A$23 in
+   Pricing and A$29 in Comparison for the same plan, which read
+   as a typo. Now both speak the same number.
+
+   Mark8ly's Starter tracks the SHARED_PRICING_CATALOGUE (single
+   source of truth with /admin/pricing). Competitor prices come
+   from each platform's published per-country pricing page,
+   verified against the live page where possible:
+     - Shopify Basic AUD A$42 — shopify.com/au/pricing
+     - Shopify Basic INR ₹1,499 — shopify.com/in/pricing
+     - BigCommerce Standard USD $22 — bigcommerce.com (USD only globally)
+   Where a platform doesn't publish a price in the visitor's
+   currency (BigCommerce globally, Wix/Squarespace outside the
+   US in our data set), the cell shows their USD rate with a
+   "(USD)" tag so the merchant sees what they'd actually be
+   charged. We deliberately keep the data set small and honest:
+   only currencies we've verified, USD fallback for the rest.
+
+   Editorial, not a SaaS bake-off — hairline rules between rows,
+   no shaded card, Mark8ly column carries a single moss accent
+   so the eye finds it without shouting.
+   ============================================================ */
+
+interface CompareRow {
+  label: string;
+  mark8ly: string;
+  shopify: string;
+  bigcommerce: string;
+  wix: string;
+  squarespace: string;
+}
+
+// Feature rows (currency-agnostic). The Starting-price row is
+// rendered separately and pulls from COMPETITOR_STARTING_PRICES
+// + the shared catalogue.
+const COMPARISON_ROWS: readonly CompareRow[] = [
+  {
+    label: "Free to try",
+    mark8ly: "90 days",
+    shopify: "3 days",
+    bigcommerce: "15 days",
+    wix: "14 days",
+    squarespace: "14 days",
+  },
+  {
+    label: "Platform fee per sale",
+    mark8ly: "None",
+    shopify: "2%, unless you use Shopify Payments",
+    bigcommerce: "None",
+    wix: "None",
+    squarespace: "None",
+  },
+  {
+    label: "Default storefront design",
+    mark8ly: "Editorial, designer-led",
+    shopify: "Generic templates",
+    bigcommerce: "Functional templates",
+    wix: "Drag-and-drop builder",
+    squarespace: "Designer themes",
+  },
+  {
+    label: "Use your own domain",
+    mark8ly: "Included",
+    shopify: "Bring your own",
+    bigcommerce: "Bring your own",
+    wix: "First year included",
+    squarespace: "First year included",
+  },
+  {
+    label: "Local payments (UPI, wallets)",
+    mark8ly: "Built in",
+    shopify: "Limited by region",
+    bigcommerce: "Limited by region",
+    wix: "Limited by region",
+    squarespace: "Mostly Stripe / PayPal",
+  },
+  {
+    label: "Take your data when you leave",
+    mark8ly: "One click, any time",
+    shopify: "CSV export",
+    bigcommerce: "CSV export",
+    wix: "Partial",
+    squarespace: "Partial",
+  },
+];
+
+type CompetitorId = "shopify" | "bigcommerce" | "wix" | "squarespace";
+
+// Annual-billed monthly equivalent (the price each platform leads
+// with on their own pricing page, "$X/mo billed yearly"). Pre-
+// formatted strings preserve each platform's own grouping and
+// symbol convention. Currencies not in a competitor's map fall back
+// to its USD entry with a "(USD)" tag in the renderer below — that's
+// honest about platforms that don't localize for that currency.
+const COMPETITOR_STARTING_PRICES: Record<
+  CompetitorId,
+  Partial<Record<Currency, string>>
+> = {
+  shopify: {
+    // Shopify Basic, "$X/mo billed yearly" rate from each region.
+    USD: "$29",
+    AUD: "A$42", // shopify.com/au/pricing
+    INR: "₹1,499", // shopify.com/in/pricing
+    GBP: "£19",
+    EUR: "€27",
+  },
+  bigcommerce: {
+    // Standard plan annual-billed: $29 monthly with "save 25%" → $22/mo.
+    // BigCommerce publishes USD only globally — every other currency
+    // hits the USD-tagged fallback.
+    USD: "$22",
+  },
+  wix: {
+    // Core plan with ecommerce, annual billing.
+    USD: "$29",
+  },
+  squarespace: {
+    // Basic Commerce, annual billing.
+    USD: "$27",
+  },
+};
+
+function competitorStartingPrice(
+  id: CompetitorId,
+  currency: Currency,
+): string {
+  const map = COMPETITOR_STARTING_PRICES[id];
+  const localized = map[currency];
+  if (localized) return `${localized} / mo`;
+  // Platform doesn't publish a price in this currency — they bill
+  // in USD. Tag it so a non-US merchant knows what they'd actually pay.
+  const usd = map.USD!;
+  return currency === "USD" ? `${usd} / mo` : `${usd} / mo (USD)`;
+}
+
+export function Comparison() {
+  // Resolved on the client for the same reason as the Pricing section:
+  // reading `mk8_currency` on the server made the entire marketing route
+  // dynamic and uncacheable at the edge. See lib/geo/currency.ts.
+  const currency = useGeoCurrency();
+
+  const competitorHeaderClass =
+    "px-4 py-4 text-left align-bottom font-sans text-[0.9375rem] font-medium text-foreground-secondary";
+  const competitorCellClass =
+    "px-4 py-5 align-top text-foreground-tertiary";
+
+  // Mark8ly's Starter price tracks the shared pricing catalogue,
+  // and we deliberately use the annual-billed monthly equivalent so
+  // the number matches what the Pricing section shows on its default
+  // (annual) toggle. Without this, the same plan reads as A$23 in
+  // Pricing and A$29 in Comparison — same plan, different cadence,
+  // looks like a typo.
+  const starter = SHARED_PRICING_CATALOGUE.plans.find((p) => p.id === "starter");
+  const resolvedStarter = starter ? getPlanPrice(starter, currency) : null;
+  const mark8lyStarterAnnualMonthly = resolvedStarter?.price.annualMonthlyEquivalent ?? null;
+  // MUST render this — never the raw cookie value — for the same
+  // reason as the Pricing section: when `currency` has no row, the
+  // fallback amount is denominated in USD, and labelling it with the
+  // visitor's raw currency code would misquote the price.
+  const mark8lyStarterCurrency = resolvedStarter?.currency ?? currency;
+
+  return (
+    <section
+      id="compare"
+      aria-labelledby="compare-heading"
+      className="border-t border-border-subtle py-16 sm:py-24"
+    >
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="mb-12 grid gap-8 lg:grid-cols-[1fr_2fr] lg:gap-16">
+          <div>
+            <p className="eyebrow mb-5">How we compare</p>
+            <h2
+              id="compare-heading"
+              className="font-serif text-4xl font-medium leading-[1.05] tracking-[-0.02em] text-foreground"
+            >
+              Side by side,
+              <br />
+              no spin.
+            </h2>
+          </div>
+          <p className="max-w-xl self-end text-base leading-relaxed text-foreground-secondary">
+            We&rsquo;re not the only commerce platform on the table. Here&rsquo;s
+            how Mark8ly lines up against the names you&rsquo;ve probably
+            already looked at &mdash; the things that show up on the bill,
+            and the things that show up on the storefront. Starting prices
+            show each platform&rsquo;s annual-billed rate in {currency} where
+            they publish one, the same cadence as the Pricing section above.
+          </p>
+        </div>
+
+        <div className="-mx-6 overflow-x-auto px-6 sm:mx-0 sm:px-0">
+          <table className="w-full min-w-[760px] border-collapse text-sm">
+            <caption className="sr-only">
+              How Mark8ly compares with Shopify, BigCommerce, Wix and
+              Squarespace on price, trial length, fees, design and data
+              portability. Prices shown in {currency}.
+            </caption>
+            <thead>
+              <tr className="border-b border-border">
+                <th
+                  scope="col"
+                  className="py-4 pr-6 text-left align-bottom"
+                >
+                  <span className="eyebrow">Feature</span>
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-4 text-left align-bottom"
+                >
+                  <span className="font-serif text-lg font-medium text-foreground">
+                    Mark8ly
+                  </span>
+                </th>
+                <th scope="col" className={competitorHeaderClass}>
+                  Shopify
+                </th>
+                <th scope="col" className={competitorHeaderClass}>
+                  BigCommerce
+                </th>
+                <th scope="col" className={competitorHeaderClass}>
+                  Wix
+                </th>
+                <th scope="col" className={competitorHeaderClass}>
+                  Squarespace
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {/* Starting price — geo-localized row, rendered specially. */}
+              <tr className="border-b border-border-subtle">
+                <th
+                  scope="row"
+                  className="py-5 pr-6 text-left align-top font-normal text-foreground-secondary"
+                >
+                  Starting price
+                </th>
+                <td className="px-4 py-5 align-top">
+                  <span className="block border-l-2 border-moss-700 pl-3 font-medium text-foreground">
+                    {mark8lyStarterAnnualMonthly !== null ? (
+                      <>
+                        <Money
+                          amount={mark8lyStarterAnnualMonthly}
+                          currency={mark8lyStarterCurrency}
+                          showCents={false}
+                        />
+                        <span className="text-foreground-tertiary"> / mo</span>
+                      </>
+                    ) : (
+                      "—"
+                    )}
+                  </span>
+                </td>
+                <td className={competitorCellClass}>
+                  {competitorStartingPrice("shopify", currency)}
+                </td>
+                <td className={competitorCellClass}>
+                  {competitorStartingPrice("bigcommerce", currency)}
+                </td>
+                <td className={competitorCellClass}>
+                  {competitorStartingPrice("wix", currency)}
+                </td>
+                <td className={competitorCellClass}>
+                  {competitorStartingPrice("squarespace", currency)}
+                </td>
+              </tr>
+
+              {/* Feature rows — currency-agnostic. */}
+              {COMPARISON_ROWS.map((row) => (
+                <tr
+                  key={row.label}
+                  className="border-b border-border-subtle"
+                >
+                  <th
+                    scope="row"
+                    className="py-5 pr-6 text-left align-top font-normal text-foreground-secondary"
+                  >
+                    {row.label}
+                  </th>
+                  <td className="px-4 py-5 align-top">
+                    <span className="block border-l-2 border-moss-700 pl-3 font-medium text-foreground">
+                      {row.mark8ly}
+                    </span>
+                  </td>
+                  <td className={competitorCellClass}>{row.shopify}</td>
+                  <td className={competitorCellClass}>{row.bigcommerce}</td>
+                  <td className={competitorCellClass}>{row.wix}</td>
+                  <td className={competitorCellClass}>{row.squarespace}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <p className="mt-8 max-w-3xl text-sm text-foreground-tertiary">
+          Starting prices show each platform&rsquo;s cheapest paid plan
+          billed yearly &mdash; Shopify Basic, BigCommerce Standard, Wix
+          Core, Squarespace Basic Commerce. Where a platform doesn&rsquo;t
+          publish a price in your currency (BigCommerce globally; Wix and
+          Squarespace outside the US in our verified data), we show the USD
+          rate and tag it so you know what you&rsquo;d actually be charged.
+          Payment processor fees &mdash; around 2&ndash;3% for cards, closer
+          to 1% for UPI &mdash; apply on every platform. That&rsquo;s your
+          bank, not us; the line above is what the platform itself adds on
+          top.
+        </p>
+
+        <p className="mt-8 max-w-3xl text-base leading-relaxed text-foreground-secondary">
+          Weighing a specific platform? Read the full comparisons:{" "}
+          <ComparisonLink href="/shopify-alternative">
+            Mark8ly vs Shopify
+          </ComparisonLink>
+          ,{" "}
+          <ComparisonLink href="/etsy-alternative">
+            the Etsy alternative
+          </ComparisonLink>
+          , our{" "}
+          <ComparisonLink href="/ecommerce-for-makers">
+            guide for makers
+          </ComparisonLink>
+          , or{" "}
+          <ComparisonLink href="/sell-online-india">
+            selling online in India
+          </ComparisonLink>
+          .
+        </p>
+      </div>
+    </section>
+  );
+}
+
+/* Inline editorial link — moss underline, matches the Prose link style. */
+function ComparisonLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      className="text-foreground underline decoration-moss-700 decoration-2 underline-offset-4 hover:text-moss-700"
+    >
+      {children}
+    </Link>
+  );
+}

--- a/apps/onboarding/components/marketing/Pricing.tsx
+++ b/apps/onboarding/components/marketing/Pricing.tsx
@@ -3,8 +3,9 @@
 /**
  * Marketing /#pricing section.
  *
- * Client island (only for the monthly/annual toggle state). All
- * pricing data is static at build-time via SHARED_PRICING_CATALOGUE.
+ * Client island for the monthly/annual toggle state and for resolving
+ * the visitor's currency from the `mk8_currency` cookie. All pricing
+ * data is static at build-time via SHARED_PRICING_CATALOGUE.
  *
  * Design rules per mark8ly/.impeccable.md:
  *  - Paper / Ink / Moss only; no other decorative colours.
@@ -29,8 +30,9 @@ import {
   type SharedPricingCatalogue,
 } from '@repo/ui/subscription'
 
+import { useGeoCurrency } from '@/lib/geo/use-geo-currency'
+
 interface PricingProps {
-  currency: Currency
   catalogue: SharedPricingCatalogue
 }
 
@@ -168,7 +170,12 @@ function TogglePill({
   )
 }
 
-export function Pricing({ currency, catalogue }: PricingProps) {
+export function Pricing({ catalogue }: PricingProps) {
+  // Resolved on the client, not handed down from the server: reading the
+  // cookie in the page's server component made the whole marketing route
+  // dynamic and uncacheable at the edge. See lib/geo/currency.ts for the
+  // measurements and the accepted first-paint flash.
+  const currency = useGeoCurrency()
   const [period, setPeriod] = useState<BillingPeriod>('annual')
   const plans = catalogue.plans
   // The add-on always bills in USD globally (spec §4.1.2) regardless of the
@@ -178,7 +185,7 @@ export function Pricing({ currency, catalogue }: PricingProps) {
   const { price: proApp } = getAddOnPrice(catalogue.proApp, 'USD')
   const showUsdBilledNote = currency !== 'USD'
   // Page-level "prices shown in X" / GST copy MUST use the currency actually
-  // resolved for the plans below, not the raw `currency` prop — otherwise a
+  // resolved for the plans below, not the raw cookie value — otherwise a
   // visitor whose currency has no row would read "Prices shown in THB." over
   // amounts that are actually in USD. Every priceable currency has a row on
   // every plan (see PRICEABLE_CURRENCIES), so any plan resolves the same way;
@@ -223,7 +230,7 @@ export function Pricing({ currency, catalogue }: PricingProps) {
             const plan = plans.find((p) => p.id === meta.id)!
             // `resolvedCurrency` is what MUST be rendered — when `currency`
             // has no row on this plan, getPlanPrice falls back to USD, and
-            // rendering the visitor's raw `currency` would label that USD
+            // rendering the visitor's raw currency would label that USD
             // amount with a currency it isn't priced in.
             const { price, currency: resolvedCurrency } = getPlanPrice(plan, currency)
             const headline =

--- a/apps/onboarding/lib/geo/currency.ts
+++ b/apps/onboarding/lib/geo/currency.ts
@@ -1,0 +1,67 @@
+/**
+ * Client-side resolution of the geo-localized billing currency.
+ *
+ * `mk8_currency` is still written by middleware.ts from Cloudflare's
+ * `CF-IPCountry` — nothing about who *writes* the cookie changed. What
+ * changed is who *reads* it.
+ *
+ * The marketing landing used to read the cookie in the server component
+ * via `await cookies()`. In the App Router that single call opts the
+ * whole route out of static generation: Next marks `/` dynamic, emits
+ * `cache-control: private, no-store`, and Cloudflare reports
+ * `cf-cache-status: DYNAMIC`. Every visit then round-trips to one pod in
+ * Sydney — measured TTFB 380–460ms, worse from India, plus cold-start
+ * risk on `minScale: 0`. Under Lighthouse mobile throttling that TTFB
+ * was 1,380ms of a 3.27s LCP, the single largest term.
+ *
+ * The trade wasn't even paying for itself: geo-resolution defaults to
+ * the crawler's own location, so the "crawlable localised pricing" the
+ * dynamic render bought was one fixed currency anyway.
+ *
+ * So the page prerenders in PRERENDER_CURRENCY and the currency-bearing
+ * islands correct themselves on mount. A real visitor outside the US
+ * sees a brief flash of USD before the swap. That is a deliberate,
+ * accepted trade: a loading skeleton or hidden prices would cost more
+ * LCP than the flash does, and would hide the prices from crawlers that
+ * don't run effects.
+ */
+
+import {
+  CURRENCY_COOKIE_NAME,
+  normalizeCurrency,
+  type Currency,
+} from '@repo/ui/subscription'
+
+/**
+ * The currency baked into the prerendered HTML — what crawlers, AI
+ * answer engines, and the first paint all see.
+ *
+ * USD because `pricing-data.ts` guarantees a USD row on every plan and
+ * add-on; every other currency is an optional row. Anchoring the static
+ * render to a currency that could be missing would put `getPlanPrice`
+ * on its USD fallback path and risk labelling a USD amount with another
+ * currency's code.
+ *
+ * This module is deliberately NOT `'use client'` and deliberately holds
+ * no React hooks: `app/page.tsx` reads PRERENDER_CURRENCY on the server
+ * to pick the JSON-LD currency, and Next refuses to pull a module that
+ * imports `useState` into a Server Component graph at all. The hook
+ * lives next door in use-geo-currency.ts.
+ */
+export const PRERENDER_CURRENCY: Currency = normalizeCurrency(undefined)
+
+/**
+ * Reads `mk8_currency` from `document.cookie`. The cookie is written
+ * with `httpOnly: false` precisely so this is possible.
+ *
+ * `normalizeCurrency` still guards the value: geo-targeting can resolve
+ * a visitor to a currency the catalogue can't actually price, and
+ * showing a USD amount under that label would misquote the price.
+ */
+export function readCurrencyCookie(): Currency {
+  if (typeof document === 'undefined') return PRERENDER_CURRENCY
+  const match = document.cookie.match(
+    new RegExp(`(?:^|;\\s*)${CURRENCY_COOKIE_NAME}=([^;]*)`),
+  )
+  return normalizeCurrency(match ? decodeURIComponent(match[1]!) : undefined)
+}

--- a/apps/onboarding/lib/geo/use-geo-currency.ts
+++ b/apps/onboarding/lib/geo/use-geo-currency.ts
@@ -1,0 +1,28 @@
+'use client'
+
+/**
+ * The client half of lib/geo/currency.ts — kept separate because that
+ * module is imported by `app/page.tsx` on the server, and Next rejects
+ * a Server Component graph that reaches a module importing `useState`,
+ * even when the server only reads a constant from it.
+ */
+
+import { useEffect, useState } from 'react'
+import type { Currency } from '@repo/ui/subscription'
+
+import { PRERENDER_CURRENCY, readCurrencyCookie } from './currency'
+
+/**
+ * Returns PRERENDER_CURRENCY for the server render and the first client
+ * render — they must agree or React reports a hydration mismatch — then
+ * the visitor's real currency once mounted.
+ */
+export function useGeoCurrency(): Currency {
+  const [currency, setCurrency] = useState<Currency>(PRERENDER_CURRENCY)
+
+  useEffect(() => {
+    setCurrency(readCurrencyCookie())
+  }, [])
+
+  return currency
+}

--- a/apps/onboarding/tests/unit/homepage-static-render.spec.ts
+++ b/apps/onboarding/tests/unit/homepage-static-render.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Regression guard for GitHub issue #597.
+ *
+ * `app/page.tsx` used to call `await cookies()` to read `mk8_currency`
+ * for geo-localised pricing. In the App Router one request-scoped read
+ * opts the entire route out of static generation: Next marks `/`
+ * dynamic, emits `cache-control: private, no-store`, and Cloudflare
+ * reports `cf-cache-status: DYNAMIC`. Every visit to the highest-traffic
+ * page then round-trips to a single pod in Sydney — measured TTFB
+ * 380–460ms, 1,380ms of a 3.27s LCP under Lighthouse mobile throttling,
+ * plus cold-start risk on `minScale: 0`.
+ *
+ * The failure mode is silent: the page renders correctly, the tests pass,
+ * and the only symptom is a `ƒ` instead of a `○` in the build's route
+ * table. Nothing about the code looks wrong. So this guard names the APIs
+ * that cause it rather than waiting for someone to read the route table.
+ *
+ * The definitive check remains `npm run build -w @mark8ly/onboarding`:
+ * `/` must be listed `○ (Static)`. This test is the cheap early warning.
+ */
+const REPO_ROOT = path.join(__dirname, "../../../..");
+const HOMEPAGE = "apps/onboarding/app/page.tsx";
+const LAYOUT = "apps/onboarding/app/layout.tsx";
+
+function read(rel: string): string {
+  return readFileSync(path.join(REPO_ROOT, rel), "utf8");
+}
+
+/**
+ * Comments are stripped before scanning for the same reason as
+ * pricing-surfaces-truth.spec.ts: the comments in these files name the
+ * banned APIs in order to explain why they are banned, and scanning raw
+ * source would make documenting the fix trip the guard enforcing it.
+ */
+function codeOnly(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+// Every App Router API that forces a dynamic render. `searchParams` is
+// included because awaiting it in a page has the same effect even though
+// it arrives as a prop rather than an import.
+const DYNAMIC_APIS: ReadonlyArray<[string, RegExp]> = [
+  ["cookies()", /\bcookies\s*\(/],
+  ["headers()", /\bheaders\s*\(/],
+  ["draftMode()", /\bdraftMode\s*\(/],
+  ["connection()", /\bconnection\s*\(/],
+  ["unstable_noStore()", /\bunstable_noStore\s*\(/],
+  ["searchParams", /\bsearchParams\b/],
+  ["export const dynamic", /export\s+const\s+dynamic\b/],
+  ["export const revalidate = 0", /export\s+const\s+revalidate\s*=\s*0\b/],
+];
+
+for (const file of [HOMEPAGE, LAYOUT]) {
+  test(`${file} uses no request-scoped API that would make / dynamic (#597)`, () => {
+    const src = codeOnly(read(file));
+    for (const [name, pattern] of DYNAMIC_APIS) {
+      expect(
+        pattern.test(src),
+        `${file} references ${name}, which opts / out of static generation. ` +
+          "Anything that depends on the visitor belongs in a client island — " +
+          "see apps/onboarding/lib/geo/use-geo-currency.ts for the currency case.",
+      ).toBe(false);
+    }
+  });
+}
+
+test("the currency-bearing marketing sections are client islands (#597)", () => {
+  // These two render prices in the visitor's currency. They can only do
+  // that without the server reading a cookie if they resolve it after
+  // mount, which requires the client boundary.
+  const islands = [
+    "apps/onboarding/components/marketing/Pricing.tsx",
+    "apps/onboarding/components/marketing/Comparison.tsx",
+  ];
+
+  for (const rel of islands) {
+    const src = read(rel);
+    expect(
+      /^\s*(['"])use client\1/.test(src),
+      `${rel} must open with a "use client" directive — it calls useGeoCurrency()`,
+    ).toBe(true);
+    expect(src, `${rel} should resolve currency via useGeoCurrency()`).toContain(
+      "useGeoCurrency",
+    );
+  }
+});
+
+test("the homepage JSON-LD is pinned to the prerendered currency (#597)", () => {
+  const src = codeOnly(read(HOMEPAGE));
+  // Only one HTML document is prerendered, so the structured data can
+  // only honestly carry one currency — and it must be the same one the
+  // visible prices in that document are denominated in.
+  expect(src).toContain("buildHomeJsonLd(PRERENDER_CURRENCY)");
+});


### PR DESCRIPTION
Addresses #597, but not the way that issue describes it — the diagnosis changed after measurement.

## The real cause

`app/page.tsx:264` called `await cookies()` to read `mk8_currency` for geo-localised pricing. In the App Router that makes the whole route dynamic, so Next emitted:

```
cache-control: private, no-cache, no-store, max-age=0, must-revalidate
cf-cache-status: DYNAMIC
```

Every visit to the marketing homepage rendered React on a single GKE pod in Sydney. Measured TTFB ~380–460ms, worse from India, plus cold-start exposure from `minScale: 0`. Under Lighthouse mobile throttling that TTFB was **1,380ms of a 3.27s LCP** — the dominant term by a wide margin.

The issue's original advice (preconnect fonts, split the 20.3 KB blocking stylesheet) is real but marginal beside this. Worth noting it also could not have worked as written: the fonts are same-origin `next/font` assets, so `preconnect` does nothing, and the LCP element is a **text** node with `display: swap`, which paints in the fallback face immediately.

And the trade-off was not paying for itself. Crawlable pricing is AUD-only regardless, because geo-resolution defaults there for bots — so the dynamic render taxed every human visitor while still not serving the crawlers it existed for.

## The proof

```
before:  ┌ ƒ /          after:  ┌ ○ /
                                ○  (Static)  prerendered as static content
```

That single character is the whole change. API routes correctly remain `ƒ`.

## What changed

- **`lib/geo/currency.ts`** (new) — `PRERENDER_CURRENCY` + `readCurrencyCookie()`. No `'use client'`, no hooks, because `page.tsx` reads the constant on the server.
- **`lib/geo/use-geo-currency.ts`** (new, client) — `useGeoCurrency()`. Initial state is `PRERENDER_CURRENCY` so server HTML and first client render agree; an effect swaps in the cookie value.
- **`app/page.tsx`** — no `cookies()`, no longer `async`, JSON-LD built from `PRERENDER_CURRENCY`.
- **`components/marketing/Pricing.tsx`** — `currency` prop dropped, calls the hook. Already a client component.
- **`components/marketing/Comparison.tsx`** (new, client) — `Comparison` was a *server* component defined inline in `page.tsx` and had to cross the client boundary. Markup, copy, competitor prices and comments moved verbatim.

`resolvePricedPlan` (`page.tsx:111-120`) is untouched — it still returns the currency a price is actually denominated in, so the schema can never label a USD amount with someone else's currency code.

The two-file split for the hook is not stylistic: putting `PRERENDER_CURRENCY` beside `useState` in one module made the build fail with *"You're importing a module that depends on 'useState' into a React Server Component module."* Next bans the module, not the call. Worth knowing before anyone consolidates them.

## A regression test that fails for the right reason

`tests/unit/homepage-static-render.spec.ts` scans for `cookies()`/`headers()`/`draftMode()`/`searchParams`/`export const dynamic` in the page and layout, and asserts both currency islands are client components using the hook.

Verified it goes RED: reintroducing `await cookies()` gives `1 failed / 3 passed`, green again on restore.

This failure mode is invisible in review — the page renders correctly, every test passes, and the only symptom is one character in a build table. A source-level guard seemed proportionate.

## Verification

```
npm run build -w @mark8ly/onboarding        → ┌ ○ /
npm run check-types -w @mark8ly/onboarding  → clean
npm test (apps/onboarding)                  → 81 passed (77 pre-existing + 4 new)
```

Prerendered `.next/server/app/index.html` contains `<h1>A storefront<br/>worth opening.</h1>` (so `tests/e2e/golden-path.spec.ts:25` still holds), 14 × `"priceCurrency":"USD"` in the JSON-LD derived from `SHARED_PRICING_CATALOGUE`, and the full comparison table. The e2e suite was not run — it needs Postgres, platform-api and auth-bff running.

`npm run lint` is a stub that lints nothing; not reported as a gate.

## What this does NOT fix, stated plainly

**`cf-cache-status` will probably still not reach `HIT`.** `middleware.ts` sets `Set-Cookie: mk8_currency` on every response including `/` (matcher at line 67), and Cloudflare will not cache a response carrying `Set-Cookie`.

That is not merely a config oversight — caching such a response would be a **correctness bug**: an Indian visitor could receive a cached response that sets them to AUD. So "add a Cache Rule to ignore cookies" is the wrong reflex; the cookie has to stop riding on the cacheable document first.

The origin-side win is real and independent of that: `/` now serves prebuilt HTML with no React render and no cookie read per request. Whether that alone moves TTFB enough is worth measuring after deploy rather than predicting.

The follow-up decision — narrow the middleware matcher and set the currency another way, versus a Cloudflare Cache Rule that strips `Set-Cookie` — is left open deliberately. It needs a call about where geo detection should live, which is bigger than this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YB1BFjWgctpHPLb1knCRKH
