### PR TITLE
fix(seo): a checkable Organization identity, and a corrected+sourced UPI cost claim

### DIFF
--- a/apps/onboarding/app/guides/[slug]/page.tsx
+++ b/apps/onboarding/app/guides/[slug]/page.tsx
@@ -46,6 +46,26 @@ function Block({ block }: { block: GuideBlock }) {
           ))}
         </ul>
       );
+    case "sources":
+      // Rendered, not hidden in the JSON-LD. A citation a reader cannot
+      // click is a schema decoration; the point is that someone can
+      // check the claim. Links stay dofollow on purpose \u2014 these are
+      // genuine references to a regulator and a processor, and
+      // nofollowing them would be disowning our own sources.
+      return (
+        <>
+          <h2>Sources</h2>
+          <ul>
+            {block.items.map((source) => (
+              <li key={source.url}>
+                <a href={source.url} target="_blank" rel="noopener noreferrer">
+                  {source.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </>
+      );
     case "p":
     default:
       return <p>{block.text}</p>;
@@ -58,6 +78,15 @@ export default async function GuidePage({ params }: PageProps) {
   if (!guide) notFound();
 
   const url = `${SITE_URL}/guides/${guide.slug}`;
+
+  const citations = guide.blocks
+    .filter((block) => block.type === "sources")
+    .flatMap((block) => block.items)
+    .map((source) => ({
+      "@type": "CreativeWork",
+      name: source.label,
+      url: source.url,
+    }));
 
   // Article JSON-LD — content is first-party, but we still escape `<`
   // in the serialized output as a matter of habit.
@@ -77,6 +106,12 @@ export default async function GuidePage({ params }: PageProps) {
     author: { "@id": ORGANIZATION_ID },
     publisher: { "@id": ORGANIZATION_ID },
     mainEntityOfPage: { "@type": "WebPage", "@id": url },
+    // Mirror any rendered "Sources" list into `citation`, so the
+    // references a reader can see are also the ones a crawler is told
+    // about. Omitted entirely when a guide cites nothing \u2014 an empty
+    // array would assert "we checked and there are none", which is a
+    // different and untrue claim from staying silent.
+    ...(citations.length > 0 ? { citation: citations } : {}),
   };
 
   const otherGuides = GUIDES.filter((g) => g.slug !== guide.slug);

--- a/apps/onboarding/app/guides/guides.ts
+++ b/apps/onboarding/app/guides/guides.ts
@@ -12,7 +12,23 @@
 export type GuideBlock =
   | { type: "p"; text: string }
   | { type: "h2"; text: string }
-  | { type: "ul"; items: ReadonlyArray<string> };
+  | { type: "ul"; items: ReadonlyArray<string> }
+  /**
+   * Outbound citations, rendered as a "Sources" list and mirrored into
+   * the article's JSON-LD `citation`.
+   *
+   * These exist because two of these guides make claims that need
+   * backing rather than asserting — UPI settlement economics above all
+   * (tesserix/mark8ly#594). We publish under an Organization byline, so
+   * a reader has no named expert to weigh; a checkable primary source
+   * is the honest substitute, and it is a stronger signal than a
+   * confident tone. Cite the regulator or the processor's own
+   * documentation, never a secondary summary of one.
+   */
+  | {
+      type: "sources";
+      items: ReadonlyArray<{ label: string; url: string }>;
+    };
 
 export interface Guide {
   slug: string;
@@ -173,7 +189,19 @@ export const GUIDES: ReadonlyArray<Guide> = [
       { type: "h2", text: "What it costs" },
       {
         type: "p",
-        text: "UPI is one of the cheapest ways to take money online — processing is typically around 2%, and often lower than cards. The important thing to watch is whether your commerce platform adds its own fee on top of the processor's rate. That extra percentage is pure margin loss, and on Indian D2C margins it adds up fast. A platform with no per-sale platform fee means UPI costs you only what the processor charges.",
+        text: "UPI is unusual among payment methods: the merchant discount rate on person-to-merchant UPI payments has been nil since January 2020, when Section 10A of the Payment and Settlement Systems Act, 2007 and Section 269SU of the Income-tax Act, 1961 were amended to prohibit charging it. Before that it was capped at 0.30%. On the regulated side, in other words, accepting UPI costs an Indian merchant nothing at all.",
+      },
+      {
+        type: "p",
+        text: "That is not the same as UPI reaching you free, and the difference is where most sellers get confused. Payment gateways charge their own fee on top of the nil MDR, and that is the headline rate you were quoted. Razorpay's published pricing, for example, lists UPI as \u201cZero MDR \u2014 2% platform fee applies\u201d \u2014 the same 2% it charges on cards and wallets. So the roughly 2% you pay on a UPI order is your gateway's fee, not the cost of UPI itself. It is worth knowing which of the two you are being charged, because only one of them is anyone's to negotiate.",
+      },
+      {
+        type: "p",
+        text: "This is no longer a settled zero, either. The Taxation and Other Laws (Amendment) Bill, 2026 amends the Payment and Settlement Systems Act again, replacing the blanket prohibition with a framework under which MDR can be notified above a turnover threshold. Neither the rate nor the threshold has been set, and small merchants and lower-value person-to-merchant payments are expected to stay exempt \u2014 but it is worth watching rather than assuming.",
+      },
+      {
+        type: "p",
+        text: "The number to check on any commerce platform, then, is what it adds on top of your gateway's rate. That extra percentage is pure margin loss, and on Indian D2C margins it adds up fast. A platform with no per-sale fee means a UPI order costs you only what your gateway charges.",
       },
       { type: "h2", text: "Offer UPI, wallets, and cards behind one checkout" },
       {
@@ -200,6 +228,26 @@ export const GUIDES: ReadonlyArray<Guide> = [
       {
         type: "p",
         text: "For the fuller picture on selling to Indian customers — pricing in your own currency, your own domain, and a storefront that looks like a brand — see our guide to selling online in India.",
+      },
+      {
+        type: "sources",
+        items: [
+          {
+            label:
+              "Press Information Bureau \u2014 Cabinet incentive scheme for RuPay debit and low-value BHIM-UPI (P2M), stating the zero-MDR basis in Section 10A of the Payment and Settlement Systems Act, 2007 and Section 269SU of the Income-tax Act, 1961",
+            url: "https://www.pib.gov.in/PressReleasePage.aspx?PRID=1890314&reg=48&lang=2",
+          },
+          {
+            label:
+              "Razorpay \u2014 Pricing, listing UPI as \u201cZero MDR \u2014 2% platform fee applies\u201d",
+            url: "https://razorpay.com/pricing/",
+          },
+          {
+            label:
+              "PRS Legislative Research \u2014 The Taxation and Other Laws (Amendment) Bill, 2026, which amends the Payment and Settlement Systems Act, 2007",
+            url: "https://prsindia.org/billtrack/the-taxation-and-other-laws-amendment-bill-2026",
+          },
+        ],
       },
     ],
   },

--- a/apps/onboarding/app/sell-online-india/page.tsx
+++ b/apps/onboarding/app/sell-online-india/page.tsx
@@ -30,7 +30,7 @@ export default function SellOnlineIndiaPage() {
       intro={[
         "Selling online in India comes down to one thing at the moment of truth: can the customer pay the way they already pay? For most of the country, that's UPI — a quick scan or a tap, no card numbers, no friction. A checkout that treats UPI as an afterthought loses the sale on the last screen.",
         "Mark8ly puts UPI, wallets, and cards behind one clean checkout, so however your customer prefers to pay, they can. It's built in, not bolted on — no region-locked workarounds, no forcing everyone through a single card processor that half your customers don't use.",
-        "And on top of that, we take nothing from your sales. There's no platform fee — you pay only your payment processor's standard rate (around 2% for UPI). For Indian sellers running on real margins, keeping that 2% platform skim in your own pocket is decisive. Ninety days free to start, then ₹999 a month for Starter — or ₹9,599 for the year, which works out at about ₹800 a month.",
+        "And on top of that, we take nothing from your sales. There's no platform fee \u2014 you pay only your payment gateway's rate, around 2%. Worth knowing what that 2% actually is: UPI's own merchant discount rate has been nil since 2020, so it is your gateway's fee rather than a cost of UPI itself. For Indian sellers running on real margins, keeping a platform's extra cut out of that number is decisive. Ninety days free to start, then \u20b9999 a month for Starter \u2014 or \u20b99,599 for the year, which works out at about \u20b9800 a month.",
       ]}
       competitorName="Global platforms"
       comparisonNote="Most global platforms bill in USD and treat local Indian payment methods as a regional add-on rather than the default."
@@ -67,7 +67,7 @@ export default function SellOnlineIndiaPage() {
           heading: "Payments the way India actually pays",
           body: [
             "UPI, wallets, and cards all sit behind one checkout on Mark8ly. There's no separate flow to configure, no method that only works for some customers. Whether someone pays by scanning a QR, tapping a wallet, or entering a card, it's the same clean, single-page checkout — which is what keeps the sale from dropping at the end.",
-            "You pay only your processor's standard rate. We don't add a platform fee on top, so the cost of taking a UPI payment is the cost of the UPI payment — nothing else.",
+            "You pay only your gateway's rate. We don't add a platform fee on top, so what a UPI order costs you is your gateway's fee and nothing else \u2014 UPI itself carries no merchant discount rate.",
           ],
         },
         {
@@ -94,7 +94,7 @@ export default function SellOnlineIndiaPage() {
         {
           question: "What does it cost to sell online in India?",
           answer:
-            "There's no platform fee on your sales — you pay only your payment processor's standard rate, around 2% for UPI. After 90 days free, Starter is ₹999 a month (₹9,599 a year), Studio is ₹2,499 and Pro is ₹6,599.",
+            "There's no platform fee on your sales \u2014 you pay only your payment gateway's rate, typically around 2%. UPI's own merchant discount rate has been nil since 2020, so that 2% is the gateway's fee rather than a cost of UPI itself. After 90 days free, Starter is \u20b9999 a month (\u20b99,599 a year), Studio is \u20b92,499 and Pro is \u20b96,599.",
         },
         {
           question: "Can customers pay with cards and wallets too?",

--- a/apps/onboarding/lib/seo/site-json-ld.ts
+++ b/apps/onboarding/lib/seo/site-json-ld.ts
@@ -33,7 +33,20 @@ const jsonLd = {
       "@type": "Organization",
       "@id": ORGANIZATION_ID,
       name: SITE_NAME,
-      legalName: "Tesserix",
+      legalName: "Tesserix Pty Ltd",
+      // The registration numbers are the point of this block, not
+      // decoration. "Mark8ly" and "the Mark8ly team" are assertions;
+      // an ACN is a fact anyone can check against the ASIC register in
+      // about ten seconds, and an ABN against ABN Lookup. That is the
+      // one Authoritativeness signal available to a company with no
+      // trading history yet (tesserix/mark8ly#594), and it costs us
+      // nothing because both numbers are already published on /privacy,
+      // /terms, /security and /sub-processors. Digits only, unspaced —
+      // that is the form both registers index on.
+      identifier: [
+        { "@type": "PropertyValue", propertyID: "ACN", value: "694070865" },
+        { "@type": "PropertyValue", propertyID: "ABN", value: "59694070865" },
+      ],
       url: SITE_URL,
       // A square mark, not the 1200×630 social card. Google's
       // Organization logo guidance wants a logo image it can crop to
@@ -47,13 +60,17 @@ const jsonLd = {
         "https://instagram.com/mark8ly",
         "https://linkedin.com/company/mark8ly",
       ],
-      // Tesserix is an Australian entity. No specific locality
-      // is emitted here until the legal registration address is
-      // confirmed — fabricating a city to fill the schema shape is
+      // Tesserix is an Australian entity registered in New South
+      // Wales — that much is stated on /privacy, so emitting the region
+      // here is reporting our own published legal text, not guesswork.
+      // Still no locality: /privacy names Sydney as where operations
+      // are *conducted*, which is not the same claim as a registered
+      // office, and fabricating a city to fill the schema shape stays
       // worse than a narrower-but-accurate address.
       address: {
         "@type": "PostalAddress",
         addressCountry: "AU",
+        addressRegion: "NSW",
       },
     },
     {


### PR DESCRIPTION
Rescopes and addresses #594.

## The authorship decision, stated plainly

#594 asked for a **named human author** on the two expertise-dependent guides. The decision was to stay with organisation-level attribution, so **that part of #594 is deliberately not done** — `Article.author` still resolves to an Organization, and the issue's "Done when" is not met. This PR does not pretend otherwise.

What it does instead is take the issue's *other* recommendation, which the authorship decision doesn't block:

> Where guides make specific UPI claims, citing NPCI/RBI or the processor's own documentation is stronger than presenting it as house expertise, and it costs nothing.

## `d1883c4a` — the Organization was an assertion; now it's checkable

`legalName` said `"Tesserix"`. The legal pages say **Tesserix Pty Ltd**, so the schema was both incomplete and inconsistent with `/privacy`, `/terms`, `/security` and `/sub-processors`.

Now `legalName: "Tesserix Pty Ltd"` plus `identifier` carrying **ACN 694070865** and **ABN 59694070865** — already published on those four pages, so nothing new is disclosed. This matters because it is the one Authoritativeness signal available to a company with no trading history: "the Mark8ly team" is a claim, an ACN is a fact anyone can check against ASIC in ten seconds. Audit scored Authoritativeness **30/100**, the weakest of the four.

`addressRegion: "NSW"` added too — `/privacy` states registration in New South Wales, so this reports our own published text. Locality still omitted: `/privacy` names Sydney as where operations are *conducted*, which is not a registered-office claim.

`SITE_JSON_LD` bytes change, which is safe — `middleware.ts:31` computes the CSP hash via `sha256Source(SITE_JSON_LD)` at module load, from the same constant.

## `bb86e62e` — the UPI guide's cost claim was wrong, and contradicted itself

This is the substantive find. The guide said UPI "processing is typically around 2%", then in the *next sentence* warned about platforms adding "its own fee on top of the processor's rate" — when the 2% it had just quoted **is** that fee.

The facts:

- **UPI person-to-merchant MDR has been nil since January 2020**, via Section 10A of the Payment and Settlement Systems Act, 2007 and Section 269SU of the Income-tax Act, 1961. It was capped at 0.30% before.
- The ~2% a seller actually pays is a **gateway fee**. Razorpay's own pricing page lists UPI as "Zero MDR — 2% platform fee applies" — the same 2% it charges on cards and wallets.
- **It is no longer a settled zero.** The Taxation and Other Laws (Amendment) Bill, 2026 amends the PSS Act to allow MDR to be notified above a turnover threshold. Rate and threshold unset; small merchants and lower-value P2M expected to remain exempt.

Rewritten accordingly, and the same error corrected in three places on `/sell-online-india` (intro, section body, and the FAQ answer that feeds FAQPage JSON-LD).

Being right about this is worth more than a byline: it is a distinction most competitor content gets wrong, and it *strengthens* our own pitch rather than weakening it.

## New `sources` block type

`GuideBlock` gains `{ type: "sources"; items: {label, url}[] }`, rendered as a visible "Sources" list and mirrored into `Article.citation`. Links are dofollow on purpose — nofollowing a regulator we cite would be disowning our own source. `citation` is **omitted entirely** when a guide cites nothing, rather than emitted as `[]`, which would assert "we checked and found none".

All three cited URLs were fetched and return 200. NPCI's `/what-we-do/upi/product-overview` returns 403 to non-browser clients so it is **not** cited — an unverifiable citation on a page about credibility is worse than one fewer.

## Verification

```
npm run check-types -w @mark8ly/onboarding  → clean
npm test (apps/onboarding)                  → 85 passed (baseline, no new tests)
npm run build -w @mark8ly/onboarding        → ┌ ○ /   (#607 not regressed)
```

Checked against the **prerendered HTML on disk**, not a dev server — the stale-`next start` trap from #609 does not apply:

- `>Sources<` renders once on the UPI guide; all 3 URLs present as `href`s and inside `"citation"`
- guides with no sources → `"citation"` count **0**
- old "one of the cheapest ways to take money online" string → **0 occurrences**
- Organization `identifier` array present with both ACN and ABN

**Not verified:** production. And no test guards the new `sources` renderer — the existing suite covers it only via the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YB1BFjWgctpHPLb1knCRKH