### PR TITLE
feat(seo): a named author on the UPI guide, and founders named on /about

### DIFF
--- a/apps/onboarding/app/about/page.tsx
+++ b/apps/onboarding/app/about/page.tsx
@@ -95,6 +95,84 @@ export default function AboutPage() {
         </div>
       </section>
 
+      {/*
+        Named people, with third-party profiles.
+
+        This page used to say "a small distributed team" and name nobody,
+        while our own parent site listed both founders publicly — so the
+        anonymity was not protecting anything, it was just a dead end for
+        anyone trying to work out who was behind the advice we publish
+        (tesserix/mark8ly#594).
+
+        The ids here are load-bearing: the UPI guide's Person schema uses
+        `@id: https://mark8ly.com/about#mahesh-sangawar`, so removing or
+        renaming that anchor leaves the byline pointing at nothing.
+      */}
+      <section className="border-t border-border-subtle py-20 sm:py-28">
+        <div className="mx-auto grid max-w-6xl gap-12 px-6 lg:grid-cols-[1fr_2fr] lg:gap-16">
+          <div>
+            <p className="eyebrow mb-5">Who&rsquo;s behind it</p>
+          </div>
+          <div className="space-y-10 lg:max-w-xl">
+            <div id="mahesh-sangawar" className="scroll-mt-24">
+              <p className="text-foreground">Mahesh Sangawar</p>
+              <p className="mt-1 text-sm text-foreground-tertiary">
+                Co-founder, Tesserix
+              </p>
+              <p className="mt-3 text-foreground-secondary leading-relaxed">
+                Cloud architect and platform engineer, building multi-tenant
+                SaaS, Kubernetes platforms and developer tooling. Wrote most of
+                Mark8ly&rsquo;s payment integration, including the Razorpay
+                checkout that handles UPI, cards and wallets for merchants
+                selling in India.
+              </p>
+              <p className="mt-3 text-sm">
+                <a
+                  href="https://www.linkedin.com/in/mahesh-sangawar-985a3214/"
+                  className="text-foreground underline decoration-moss-700 decoration-2 underline-offset-4 hover:text-moss-700"
+                >
+                  LinkedIn
+                </a>
+                <span className="text-foreground-tertiary"> · </span>
+                <a
+                  href="https://github.com/mahesh-sangawar"
+                  className="text-foreground underline decoration-moss-700 decoration-2 underline-offset-4 hover:text-moss-700"
+                >
+                  GitHub
+                </a>
+              </p>
+            </div>
+
+            <div id="samyak-rout" className="scroll-mt-24">
+              <p className="text-foreground">Samyak Rout</p>
+              <p className="mt-1 text-sm text-foreground-tertiary">
+                Co-founder, Tesserix
+              </p>
+              <p className="mt-3 text-foreground-secondary leading-relaxed">
+                Full-stack and AI platform engineer, building cloud-native
+                products end to end &mdash; Go services, Next.js apps and the
+                delivery pipelines behind them.
+              </p>
+              <p className="mt-3 text-sm">
+                <a
+                  href="https://www.linkedin.com/in/samyak-r-96551a21/"
+                  className="text-foreground underline decoration-moss-700 decoration-2 underline-offset-4 hover:text-moss-700"
+                >
+                  LinkedIn
+                </a>
+                <span className="text-foreground-tertiary"> · </span>
+                <a
+                  href="https://github.com/sam123ben"
+                  className="text-foreground underline decoration-moss-700 decoration-2 underline-offset-4 hover:text-moss-700"
+                >
+                  GitHub
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <section className="border-t border-border-subtle py-20 sm:py-28">
         <div className="mx-auto grid max-w-6xl gap-12 px-6 lg:grid-cols-[1fr_2fr] lg:gap-16">
           <div>
@@ -102,9 +180,16 @@ export default function AboutPage() {
           </div>
           <div className="space-y-6 text-foreground-secondary leading-relaxed lg:max-w-xl">
             <p>
-              Australia. Remote-first, global by default. We build and
-              support Mark8ly from a small distributed team of engineers,
-              designers, and merchants.
+              Australia. Remote-first, global by default. Mark8ly is a
+              product of{" "}
+              <a
+                href="https://tesserix.app/about"
+                className="text-foreground underline decoration-moss-700 decoration-2 underline-offset-4 hover:text-moss-700"
+              >
+                Tesserix Pty Ltd
+              </a>
+              , a small studio building focused software, with help from
+              designers and merchants along the way.
             </p>
             <p>
               Questions, ideas, or just want to say hello?{" "}

--- a/apps/onboarding/app/guides/[slug]/page.tsx
+++ b/apps/onboarding/app/guides/[slug]/page.tsx
@@ -97,13 +97,27 @@ export default async function GuidePage({ params }: PageProps) {
     description: guide.description,
     datePublished: guide.updated,
     dateModified: guide.updated,
-    // Reference the Organization the root layout already puts on this
-    // page rather than declaring a second one. Google merges same-page
-    // JSON-LD, and the inline copy that used to live here carried no
-    // logo — so the richer node was being shadowed by a poorer duplicate
-    // (tesserix/mark8ly#600). If these guides ever gain a named human
-    // author, only `publisher` keeps the @id.
-    author: { "@id": ORGANIZATION_ID },
+    // `publisher` always references the Organization the root layout
+    // already puts on this page, rather than declaring a second one.
+    // Google merges same-page JSON-LD, and the inline copy that used to
+    // live here carried no logo — so the richer node was being shadowed
+    // by a poorer duplicate (tesserix/mark8ly#600).
+    //
+    // `author` is the Person where the guide names one, and falls back
+    // to the Organization otherwise. Both are emitted in full rather
+    // than as bare @id references, because the Person node exists
+    // nowhere else on the page — an @id pointing at nothing resolves to
+    // nothing, which is worse than no author at all.
+    author: guide.author
+      ? {
+          "@type": "Person",
+          "@id": guide.author.id,
+          name: guide.author.name,
+          jobTitle: guide.author.jobTitle,
+          description: guide.author.bio,
+          sameAs: [...guide.author.sameAs],
+        }
+      : { "@id": ORGANIZATION_ID },
     publisher: { "@id": ORGANIZATION_ID },
     mainEntityOfPage: { "@type": "WebPage", "@id": url },
     // Mirror any rendered "Sources" list into `citation`, so the
@@ -131,6 +145,17 @@ export default async function GuidePage({ params }: PageProps) {
         {guide.blocks.map((block, i) => (
           <Block key={i} block={block} />
         ))}
+
+        {guide.author ? (
+          // Rendered, not schema-only. A byline a reader cannot see is
+          // markup for crawlers; the point of naming someone is that a
+          // person deciding whether to trust this can weigh who wrote it.
+          <p className="mt-10 border-t border-border-subtle pt-6 text-sm text-foreground-secondary">
+            <span className="text-foreground">{guide.author.name}</span>
+            {" — "}
+            {guide.author.bio}
+          </p>
+        ) : null}
 
         <p className="mt-4 text-sm text-foreground-tertiary">
           Last updated{" "}

--- a/apps/onboarding/app/guides/guides.ts
+++ b/apps/onboarding/app/guides/guides.ts
@@ -9,6 +9,9 @@
  * link across to the commercial comparison pages and /onboarding.
  */
 
+import type { Author } from "@/lib/seo/authors";
+import { MAHESH_SANGAWAR } from "@/lib/seo/authors";
+
 export type GuideBlock =
   | { type: "p"; text: string }
   | { type: "h2"; text: string }
@@ -32,6 +35,16 @@ export type GuideBlock =
 
 export interface Guide {
   slug: string;
+  /**
+   * A named human author, for guides whose claims need one.
+   *
+   * Optional on purpose. Product documentation ("how to connect your
+   * domain") is correctly attributed to the Organization, and inventing
+   * a byline for it would add nothing. Set this only where the named
+   * person's experience genuinely covers the subject — see the note in
+   * lib/seo/authors.ts on why a mismatched byline is worse than none.
+   */
+  author?: Author;
   /** <title> — brand suffix is appended by the layout template. */
   title: string;
   description: string;
@@ -168,6 +181,10 @@ export const GUIDES: ReadonlyArray<Guide> = [
   },
   {
     slug: "accept-upi-payments-online",
+    // The one guide here with a named author. The claims below are about
+    // UPI settlement economics and gateway pricing, which is work this
+    // author actually did rather than a topic we read up on.
+    author: MAHESH_SANGAWAR,
     title: "How to Accept UPI Payments on Your Online Store",
     description:
       "A clear guide to accepting UPI payments online in India — how UPI works at checkout, what it costs, and how to offer it alongside cards and wallets without losing the sale.",

--- a/apps/onboarding/lib/seo/authors.ts
+++ b/apps/onboarding/lib/seo/authors.ts
@@ -1,0 +1,43 @@
+/**
+ * Named article authors.
+ *
+ * Most pages here publish under the Organization, which is honest for
+ * product documentation and fine for it. A named byline is reserved for
+ * guides making claims that need a person behind them — and it is only
+ * worth adding where the person's *stated* experience actually covers
+ * the topic (tesserix/mark8ly#594).
+ *
+ * That constraint is the whole point. A byline invites the reader to
+ * check, so a name attached to a subject the bio does not support is
+ * worse than no name at all: the reader clicks through and finds the
+ * mismatch. Every `bio` here must describe work the person did, on the
+ * subject at hand, and `sameAs` must point at third-party-hosted
+ * profiles so the claim is verifiable somewhere we do not control.
+ */
+
+export interface Author {
+  /**
+   * Stable `@id` for the Person node, anchored at /about where the bio
+   * is also rendered — so the identifier resolves to something a reader
+   * and a crawler can both actually fetch.
+   */
+  id: string;
+  name: string;
+  jobTitle: string;
+  /** Rendered under the byline. Must be true and topic-relevant. */
+  bio: string;
+  /** Third-party profiles. This is what makes the byline checkable. */
+  sameAs: ReadonlyArray<string>;
+}
+
+export const MAHESH_SANGAWAR: Author = {
+  id: "https://mark8ly.com/about#mahesh-sangawar",
+  name: "Mahesh Sangawar",
+  jobTitle: "Co-founder, Tesserix",
+  bio: "Co-founder of Tesserix, the studio behind Mark8ly, and the principal author of Mark8ly's payment integration — including the Razorpay checkout that handles UPI, cards and wallets for merchants selling in India.",
+  sameAs: [
+    "https://www.linkedin.com/in/mahesh-sangawar-985a3214/",
+    "https://github.com/mahesh-sangawar",
+    "https://tesserix.app/about",
+  ],
+};

--- a/apps/onboarding/tests/unit/guide-author-anchor.spec.ts
+++ b/apps/onboarding/tests/unit/guide-author-anchor.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { GUIDES } from "../../app/guides/guides";
+
+/**
+ * Regression guard for GitHub issue #594.
+ *
+ * The UPI guide publishes under a named Person whose schema `@id` is
+ * `https://mark8ly.com/about#mahesh-sangawar`. That identifier is only
+ * worth anything if it resolves — the whole argument for a named byline
+ * over an anonymous Organization one is that a reader can go and check
+ * who wrote this. An `@id` pointing at an anchor that does not exist is
+ * a byline that fails exactly the test it was added to pass, and it
+ * fails silently: the page renders, the JSON-LD validates, and nothing
+ * anywhere complains.
+ *
+ * So this pins the coupling in both directions — every named author's
+ * `@id` fragment must exist as an `id=` on /about, and the bio we show
+ * a crawler must be the bio we show a person.
+ */
+function source(relative: string): string {
+  return readFileSync(path.join(__dirname, "../..", relative), "utf8");
+}
+
+const authored = GUIDES.filter((guide) => guide.author !== undefined);
+
+test("at least one guide carries a named author, or this guard is vacuous", () => {
+  expect(authored.length).toBeGreaterThan(0);
+});
+
+for (const guide of authored) {
+  const author = guide.author!;
+
+  test(`${guide.slug}: the author @id resolves to a real anchor on /about (#594)`, () => {
+    const fragment = author.id.split("#")[1];
+    expect(fragment, `${author.id} has no #fragment`).toBeTruthy();
+    expect(
+      source("app/about/page.tsx"),
+      `/about has no element with id="${fragment}"`,
+    ).toContain(`id="${fragment}"`);
+  });
+
+  test(`${guide.slug}: the author is named on /about, not only in schema`, () => {
+    expect(source("app/about/page.tsx")).toContain(author.name);
+  });
+
+  test(`${guide.slug}: the byline is checkable off-site`, () => {
+    // A bio we host is an assertion about ourselves. The point of
+    // sameAs is that at least one profile lives somewhere a reader can
+    // corroborate without taking our word for it.
+    const offsite = author.sameAs.filter(
+      (url) => !url.startsWith("https://mark8ly.com"),
+    );
+    expect(offsite.length).toBeGreaterThan(0);
+    for (const url of author.sameAs) {
+      expect(url).toMatch(/^https:\/\//);
+    }
+  });
+}


### PR DESCRIPTION
Closes #594.

Follows #611, which corrected the UPI guide's facts but left the byline question open. This settles it — and **not** by naming someone on both guides.

## The decision, and why it is split

#594 asked for a named human author on **two** guides. Only one gets it.

**`accept-upi-payments-online` → named.** The author wrote the payments integration this guide describes. Checked before claiming it, not after: `git log` on payment paths shows **116 commits** by Mahesh Sangawar against 26 for the other co-founder, and `services/marketplace-api/internal/payment/razorpay.go` is real code with real tests. The UPI specifics are in there too — `gateway.go:89` carries a first-hand note that `customer_phone` is *mandatory* at some UPI gateways for intent flows, and `razorpay_test.go` exercises a `"method":"upi"` INR webhook. That is lived integration knowledge, which is exactly what the QRG means by Experience.

**`how-to-price-handmade-products` → stays Organization-attributed.** Neither founder's published bio supports it — both are platform/infrastructure engineers, and neither claims to have sold handmade goods. A byline invites the reader to click through and check, so a name over a topic the bio does not cover is *worse* than the honest anonymous byline: the reader checks, and the check fails. #611 already gave that guide the treatment it can actually support — corrected facts and cited sources. If it ever needs Experience signals, that needs a person who has the experience, not a spare name.

This is the part of #594 worth being explicit about: the issue framed the fix as "add a name". The real constraint is that the name has to survive being checked.

## `782296cf` — /about named nobody while our own parent site named everyone

`/about` said "a small distributed team of engineers, designers, and merchants" and named zero individuals — while `tesserix.app/about` has publicly listed both co-founders, with LinkedIn *and* GitHub, the whole time. The codebase contained **zero** references to `tesserix.app`. So the anonymity was not protecting anything; it was a dead end for anyone trying to work out who was behind the advice.

Both founders now named with their real published bios and third-party profiles, and the "Where we're based" copy links to Tesserix Pty Ltd instead of gesturing at a "small distributed team" that the section above now contradicts.

## `3be33661` — the byline itself

New `lib/seo/authors.ts` holds the `Author` type and the one author, with the rule that makes it safe written down: `bio` must describe work the person did *on the subject at hand*, and `sameAs` must point somewhere we do not control.

`Guide.author` is **optional**. Product documentation stays Organization-attributed and should — nobody expects a byline on "how to connect your domain", and `how-to-connect-your-domain.html` still ships `"author":{"@id":"https://mark8ly.com#organization"}`.

`author` is emitted as a **full Person node**, not an `@id` reference. The Person exists nowhere else on the page, so an `@id` would resolve to nothing — which is how the #600 duplicate-Organization bug worked, in reverse. `publisher` keeps the `@id` and stays the Organization.

The bio renders on the page, not only in schema. A byline a reader cannot see is markup for crawlers, which defeats the point.

## The fragile bit, and the guard for it

The Person's `@id` is `https://mark8ly.com/about#mahesh-sangawar`. That only means something if the anchor exists — and if it stops existing, **nothing complains**: the page renders, the JSON-LD validates, and the byline silently fails the exact test it was added to pass.

`tests/unit/guide-author-anchor.spec.ts` pins it: every named author's `@id` fragment must exist as an `id=` on `/about`, the name must appear there, and `sameAs` must include at least one off-site profile.

**Mutation-tested.** Renaming the anchor to `id="mahesh-sangawar-typo"` fails the guard (1 failed, 3 passed); restoring it passes. It is not a test that cannot fail.

## Verification

```
npm run check-types -w @mark8ly/onboarding  → clean
npm test (apps/onboarding)                  → 89 passed (85 baseline + 4 new)
npm run build -w @mark8ly/onboarding        → ┌ ○ /   (#607 not regressed)
```

Against the prerendered HTML on disk:

- UPI guide ships `"author":{"@type":"Person","@id":"…/about#mahesh-sangawar",…}` with all three `sameAs` profiles
- `/about` ships `id="mahesh-sangawar"`
- `how-to-connect-your-domain` still Organization-authored
- `github.com/mahesh-sangawar` returns 200; LinkedIn is not fetched from CI (it blocks non-browser clients), so those two URLs are the one thing here taken on trust rather than checked

**Not verified:** production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YB1BFjWgctpHPLb1knCRKH