### PR TITLE
fix(refund-sweep-cron): wire a carrier secret store so the sweeper can resolve credentials (#166)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -38,7 +38,6 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/audit"
 	"github.com/mark8ly/marketplace-api/internal/auth"
 	"github.com/mark8ly/marketplace-api/internal/authz"
-	"github.com/mark8ly/marketplace-api/internal/bao"
 	"github.com/mark8ly/marketplace-api/internal/billing/appaddon"
 	appcredspkg "github.com/mark8ly/marketplace-api/internal/billing/appcreds"
 	"github.com/mark8ly/marketplace-api/internal/billing/dispatch"
@@ -425,8 +424,6 @@ func main() {
 	// independently of whatever mount the OpenBao client is configured
 	// with, so a mismatch there would otherwise fail every read/write
 	// at runtime instead of at boot).
-	var carrierSecretStore carriersecrets.Store
-	carrierSecretStoreDegraded := false
 	// carrierSecretCounter feeds ChainStore's fallback-read counter and
 	// CachingStore's stale-read counter. There is no existing Prometheus
 	// CounterVec for carriersecrets metrics and this task's file scope
@@ -445,63 +442,28 @@ func main() {
 	carrierSecretCounter := func(label string, n int64) {
 		log.Info("carriersecrets: metric", "label", label, "count", n)
 	}
-	switch cfg.ShippingSecretStore {
-	case "gcpsm", "bao":
-		if cfg.GCPProjectID == "" {
-			log.Error("GCP_PROJECT_ID required when SHIPPING_SECRET_STORE=gcpsm or bao",
-				"shipping_secret_store", cfg.ShippingSecretStore)
-			os.Exit(1)
-		}
-		smClient, smErr := secretmanagerclient.NewClient(context.Background())
-		if smErr != nil {
-			log.Error("carriersecrets: secret manager client init failed — falling back to inline",
-				"err", smErr)
-			carrierSecretStore = carriersecrets.NewInlineStore(apiKeyEncryptor)
-			carrierSecretStoreDegraded = true
-		} else {
-			baoClient, baoErr := bao.New(bao.Config{
-				Address:        cfg.OpenBaoAddr,
-				Mount:          cfg.OpenBaoKVMount,
-				KubernetesRole: cfg.OpenBaoRole,
-			})
-			if baoErr != nil {
-				// bao.New only fails on an empty Address, which never
-				// happens here — OpenBaoAddr always carries a default.
-				// Treated as a boot failure rather than silently
-				// degrading, matching the "misconfiguration is a boot
-				// failure" property required of the mount check above.
-				log.Error("carriersecrets: openbao client init failed", "err", baoErr)
-				os.Exit(1)
-			}
-			primary := carriersecrets.BackendGCP
-			if cfg.ShippingSecretStore == "bao" {
-				primary = carriersecrets.BackendBao
-			}
-			chain := carriersecrets.NewChainStore(carriersecrets.ChainConfig{
-				Bao:          carriersecrets.NewBaoClient(baoClient),
-				GCP:          carriersecrets.NewGCPStore(smClient, cfg.GCPProjectID),
-				Encryptor:    apiKeyEncryptor,
-				Primary:      primary,
-				GCPProjectID: cfg.GCPProjectID,
-				GCPPrefix:    cfg.SecretNamePrefix,
-				Counter:      carrierSecretCounter,
-				Logger:       log,
-			})
-			if cfg.ShippingSecretStore == "bao" {
-				// Caching is bao-only — see the switch's doc comment
-				// above for why "gcpsm" stays uncached.
-				carrierSecretStore = carriersecrets.NewCachingStore(chain, 60*time.Second, time.Now, carrierSecretCounter)
-			} else {
-				carrierSecretStore = chain
-			}
-			log.Info("carriersecrets: chain store online",
-				"primary", primary, "cached", cfg.ShippingSecretStore == "bao",
-				"project_id", cfg.GCPProjectID, "prefix", cfg.SecretNamePrefix,
-				"openbao_addr", cfg.OpenBaoAddr, "openbao_kv_mount", cfg.OpenBaoKVMount)
-		}
-	default: // "inline" — config.Validate already rejected anything else.
-		carrierSecretStore = carriersecrets.NewInlineStore(apiKeyEncryptor)
-		log.Info("carriersecrets: inline store (dev mode)")
+	// The construction itself — the mode switch this comment block
+	// describes — lives in internal/carriersecrets.Build, shared with
+	// cmd/refund-sweep-cron so the two callers cannot drift the way that
+	// produced mark8ly#166 (the cron never got the "bao" mode the API
+	// did, because the switch was duplicated instead of shared). Build
+	// never calls os.Exit; every failure it can't degrade past comes
+	// back as an error, and this is where that decision (exit vs.
+	// continue) is made for the API process specifically.
+	carrierSecretStore, carrierSecretStoreDegraded, buildErr := carriersecrets.Build(context.Background(), carriersecrets.BuildParams{
+		Mode:         cfg.ShippingSecretStore,
+		GCPProjectID: cfg.GCPProjectID,
+		SecretPrefix: cfg.SecretNamePrefix,
+		OpenBaoAddr:  cfg.OpenBaoAddr,
+		OpenBaoMount: cfg.OpenBaoKVMount,
+		OpenBaoRole:  cfg.OpenBaoRole,
+		Encryptor:    apiKeyEncryptor,
+		Logger:       log,
+		Counter:      carrierSecretCounter,
+	})
+	if buildErr != nil {
+		log.Error("carriersecrets: build failed", "err", buildErr, "shipping_secret_store", cfg.ShippingSecretStore)
+		os.Exit(1)
 	}
 	_ = carrierSecretStoreDegraded // readiness wiring is a downstream concern; flag kept in scope so future health-check hooks can read it.
 

--- a/services/marketplace-api/cmd/refund-sweep-cron/main.go
+++ b/services/marketplace-api/cmd/refund-sweep-cron/main.go
@@ -30,14 +30,20 @@ import (
 func main() {
 	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
-	// cfg.Load reads the same SHIPPING_SECRET_STORE / GCP_PROJECT_ID /
-	// SECRET_NAME_PREFIX / OPENBAO_ADDR / OPENBAO_ROLE / OPENBAO_KV_MOUNT
-	// (and ENCRYPTION_MODE / ENCRYPTION_KEY) env vars cmd/marketplace-api
-	// does, through the same pkg/config validation — so a misconfigured
+	// LoadCarrierSecretJob reads only DATABASE_URL / SHIPPING_SECRET_STORE
+	// / GCP_PROJECT_ID / SECRET_NAME_PREFIX / OPENBAO_ADDR / OPENBAO_ROLE
+	// / OPENBAO_KV_MOUNT / ENCRYPTION_MODE / ENCRYPTION_KEY — NOT the full
+	// config.Load(), which requires MARKETPLACE_FGA_API_URL
+	// unconditionally and, outside ENV=dev, the internal-auth and
+	// customer-session secrets too. This job never touches FGA, internal
+	// auth, or customer sessions; loading the full Config would crash-loop
+	// it until its deployment manifest grew settings it never reads, and
+	// would widen the blast radius of secrets it never touches. It DOES
+	// go through the same validateShippingSecretStore() the API uses (see
+	// pkg/config.LoadCarrierSecretJob), so a misconfigured
 	// SHIPPING_SECRET_STORE fails the cron at boot exactly as it would
-	// fail the API, instead of drifting into its own, unvalidated reading
-	// of the same env vars.
-	cfg, err := config.Load()
+	// fail the API.
+	cfg, err := config.LoadCarrierSecretJob()
 	if err != nil {
 		log.Error("refund-sweep-cron: config load failed", "err", err)
 		os.Exit(1)
@@ -105,8 +111,23 @@ func main() {
 		log.Error("refund-sweep-cron: carrier secret store build failed", "err", buildErr, "shipping_secret_store", cfg.ShippingSecretStore)
 		os.Exit(1)
 	}
-	if degraded {
-		log.Warn("refund-sweep-cron: carrier secret store degraded to inline (Secret Manager client init failed)")
+	// carriersecrets.Build degrades to an InlineStore (degraded=true, no
+	// error) when the configured mode is "gcpsm"/"bao" but the Secret
+	// Manager client failed to construct — the API is allowed to run in
+	// that state because an InlineStore still errors loudly on a gsm://
+	// reference rather than passing it through (it just can't be
+	// resolved). But for THIS job, degraded in a non-"inline" mode means
+	// the sweep would run and fail every row needing a gsm:// or bao://
+	// credential — the exact failure mode mark8ly#166 was about. Treat
+	// it as fatal here instead of proceeding to a sweep that cannot
+	// possibly succeed. In "inline" mode, Build never sets degraded=true
+	// (see build.go: the degrade path is only reachable from the
+	// "gcpsm"/"bao" branch), so this check is unreachable there — an
+	// inline configuration never needs a Secret Manager client.
+	if degraded && cfg.ShippingSecretStore != "inline" {
+		log.Error("refund-sweep-cron: carrier secret store degraded to inline, refusing to sweep with a store that cannot resolve gsm:// or bao:// references",
+			"shipping_secret_store", cfg.ShippingSecretStore)
+		os.Exit(1)
 	}
 
 	res := orderrefund.NewResolver(conn).WithSecretStore(secretStore).WithEncryptor(apiKeyEncryptor)

--- a/services/marketplace-api/cmd/refund-sweep-cron/main.go
+++ b/services/marketplace-api/cmd/refund-sweep-cron/main.go
@@ -7,7 +7,8 @@
 //
 // Designed to run as a Cloud Run Job on a Cloud Scheduler trigger (every 5
 // min). Exits non-zero only on infrastructure failures (DB connection,
-// etc.) — a sweep that resumes zero rows is a normal, successful run.
+// carrier secret store construction, etc.) — a sweep that resumes zero
+// rows is a normal, successful run.
 package main
 
 import (
@@ -16,38 +17,99 @@ import (
 	"os"
 	"time"
 
+	"github.com/mark8ly/marketplace-api/internal/carriersecrets"
+	"github.com/mark8ly/marketplace-api/internal/crypto"
 	"github.com/mark8ly/marketplace-api/internal/order"
 	"github.com/mark8ly/marketplace-api/internal/orderrefund"
 	"github.com/mark8ly/marketplace-api/internal/outbox"
 	"github.com/mark8ly/marketplace-api/internal/payment"
+	"github.com/mark8ly/marketplace-api/pkg/config"
 	"github.com/mark8ly/marketplace-api/pkg/db"
 )
 
 func main() {
 	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		log.Error("refund-sweep-cron: DATABASE_URL not set")
+	// cfg.Load reads the same SHIPPING_SECRET_STORE / GCP_PROJECT_ID /
+	// SECRET_NAME_PREFIX / OPENBAO_ADDR / OPENBAO_ROLE / OPENBAO_KV_MOUNT
+	// (and ENCRYPTION_MODE / ENCRYPTION_KEY) env vars cmd/marketplace-api
+	// does, through the same pkg/config validation — so a misconfigured
+	// SHIPPING_SECRET_STORE fails the cron at boot exactly as it would
+	// fail the API, instead of drifting into its own, unvalidated reading
+	// of the same env vars.
+	cfg, err := config.Load()
+	if err != nil {
+		log.Error("refund-sweep-cron: config load failed", "err", err)
 		os.Exit(1)
 	}
 
-	conn, err := db.Open(databaseURL)
+	conn, err := db.Open(cfg.DatabaseURL)
 	if err != nil {
 		log.Error("refund-sweep-cron: db open failed", "err", err)
 		os.Exit(1)
 	}
 
-	// KNOWN GAP: no secret store is wired here, so GatewayFor cannot resolve
-	// the gsm:// credential references on payment_gateway_configs and every
-	// gateway re-drive fails (loudly — see orderrefund.resolveCred). The
-	// sweep still runs and rows stay 'pending' for a later attempt, which is
-	// the same outcome as before, when the raw reference was handed to the
-	// gateway and came back 401. Closing this needs GCP_PROJECT_ID /
-	// SECRET_NAME_PREFIX / SHIPPING_SECRET_STORE in the CronJob env plus
-	// Secret Manager access for its service account (tesserix-k8s), so it is
-	// deliberately out of scope of the API-path fix.
-	res := orderrefund.NewResolver(conn)
+	// API key encryptor — AES-256-GCM in production, noop in dev. Mirrors
+	// cmd/marketplace-api/main.go's construction: the same
+	// ENCRYPTION_MODE/ENCRYPTION_KEY pair backs both the inline-mode
+	// carrier secret store and the Resolver's inline-ciphertext fallback.
+	var apiKeyEncryptor crypto.Encryptor
+	switch cfg.EncryptionMode {
+	case "aes":
+		if cfg.EncryptionKey == "" {
+			log.Error("refund-sweep-cron: ENCRYPTION_KEY required when ENCRYPTION_MODE=aes")
+			os.Exit(1)
+		}
+		key, decodeErr := crypto.DecodeKey(cfg.EncryptionKey)
+		if decodeErr != nil {
+			log.Error("refund-sweep-cron: invalid ENCRYPTION_KEY", "err", decodeErr)
+			os.Exit(1)
+		}
+		enc, aesErr := crypto.NewAESEncryptor(key)
+		if aesErr != nil {
+			log.Error("refund-sweep-cron: create AES encryptor failed", "err", aesErr)
+			os.Exit(1)
+		}
+		apiKeyEncryptor = enc
+	default:
+		apiKeyEncryptor = crypto.NewNoopEncryptor()
+	}
+
+	// Carrier secret store — shares internal/carriersecrets.Build with
+	// cmd/marketplace-api so the two callers can never again drift the
+	// way that produced mark8ly#166: the cron built no store at all
+	// (never called WithSecretStore), so GatewayFor could not resolve
+	// the gsm:// credential references on payment_gateway_configs and
+	// handed the raw reference to the gateway, which 401'd — every
+	// gateway re-drive from the sweeper failed. A store-construction
+	// failure here is fatal (unlike the API, which degrades to inline on
+	// a Secret Manager client failure but still exits on every other
+	// error): resolving credentials is the entire point of this job, so
+	// a build that can't produce a working store must not run a sweep
+	// that will just fail every row's gateway call again.
+	carrierSecretCounter := func(label string, n int64) {
+		log.Info("carriersecrets: metric", "label", label, "count", n)
+	}
+	secretStore, degraded, buildErr := carriersecrets.Build(context.Background(), carriersecrets.BuildParams{
+		Mode:         cfg.ShippingSecretStore,
+		GCPProjectID: cfg.GCPProjectID,
+		SecretPrefix: cfg.SecretNamePrefix,
+		OpenBaoAddr:  cfg.OpenBaoAddr,
+		OpenBaoMount: cfg.OpenBaoKVMount,
+		OpenBaoRole:  cfg.OpenBaoRole,
+		Encryptor:    apiKeyEncryptor,
+		Logger:       log,
+		Counter:      carrierSecretCounter,
+	})
+	if buildErr != nil {
+		log.Error("refund-sweep-cron: carrier secret store build failed", "err", buildErr, "shipping_secret_store", cfg.ShippingSecretStore)
+		os.Exit(1)
+	}
+	if degraded {
+		log.Warn("refund-sweep-cron: carrier secret store degraded to inline (Secret Manager client init failed)")
+	}
+
+	res := orderrefund.NewResolver(conn).WithSecretStore(secretStore).WithEncryptor(apiKeyEncryptor)
 	pay := payment.NewService(payment.NewRepository(conn))
 	orders := order.NewService(conn, order.NewRepository(), outbox.NewRepository(conn))
 	// enabled=true: the sweep is itself the recovery path for the

--- a/services/marketplace-api/internal/carriersecrets/build.go
+++ b/services/marketplace-api/internal/carriersecrets/build.go
@@ -1,0 +1,164 @@
+package carriersecrets
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"time"
+
+	secretmanagerclient "cloud.google.com/go/secretmanager/apiv1"
+
+	"github.com/mark8ly/marketplace-api/internal/bao"
+	"github.com/mark8ly/marketplace-api/internal/crypto"
+)
+
+// cachingTTL is the CachingStore TTL used for "bao" mode. Matches the
+// value both cmd/marketplace-api and cmd/refund-sweep-cron wired inline
+// before this package existed.
+const cachingTTL = 60 * time.Second
+
+// SMClientFactory constructs a GCP Secret Manager client. Overridable in
+// tests so mode selection can be exercised without real GCP credentials or
+// network access — see BuildParams.NewSMClient.
+type SMClientFactory func(ctx context.Context) (*secretmanagerclient.Client, error)
+
+// BaoClientFactory constructs an OpenBao client. Overridable in tests —
+// see BuildParams.NewBaoClient.
+type BaoClientFactory func(cfg bao.Config) (*bao.Client, error)
+
+// BuildParams bundles every knob needed to construct the per-tenant
+// carrier secret Store, independent of how a caller loads its config (this
+// package never imports pkg/config — see the package doc).
+type BuildParams struct {
+	// Mode selects the backend: "inline" | "gcpsm" | "bao". Any other
+	// value is an error — Build never silently coerces an unrecognised
+	// mode to inline.
+	Mode string
+	// GCPProjectID is the GCP project hosting GCP SM secrets. Required
+	// when Mode is "gcpsm" or "bao".
+	GCPProjectID string
+	// SecretPrefix is the cluster identifier prefixed onto every GCP SM
+	// secret ID. Required alongside GCPProjectID.
+	SecretPrefix string
+	// OpenBaoAddr is the OpenBao API address.
+	OpenBaoAddr string
+	// OpenBaoMount is the OpenBao KV v2 mount name.
+	OpenBaoMount string
+	// OpenBaoRole is the Kubernetes auth role the OpenBao client logs in
+	// as.
+	OpenBaoRole string
+	// Encryptor decodes legacy inline (noop:/aes:) values and backs the
+	// "inline" mode store directly.
+	Encryptor crypto.Encryptor
+	// Logger receives the same structured log lines main.go's inline
+	// switch used to emit. Nil installs a discard logger.
+	Logger *slog.Logger
+	// Counter feeds ChainStore's fallback-read counter and CachingStore's
+	// stale-read counter. Nil installs a no-op.
+	Counter CounterFn
+
+	// NewSMClient constructs the GCP Secret Manager client. Defaults to
+	// secretmanagerclient.NewClient. Tests inject a fake (or
+	// error-returning) factory to exercise "gcpsm"/"bao" mode selection
+	// without a real network call.
+	NewSMClient SMClientFactory
+	// NewBaoClient constructs the OpenBao client. Defaults to bao.New.
+	NewBaoClient BaoClientFactory
+}
+
+// Build constructs the Store for p.Mode, preserving every behaviour of the
+// mode switch this replaced in cmd/marketplace-api/main.go:
+//
+//   - "inline": NewInlineStore(p.Encryptor).
+//   - "gcpsm": a ChainStore with Primary: BackendGCP, UNCACHED. Caching
+//     this would add stale-on-error masking to the path nobody asked to
+//     change — see the switch's original doc comment, preserved on the
+//     call site in cmd/marketplace-api/main.go.
+//   - "bao": a ChainStore with Primary: BackendBao, wrapped in a
+//     CachingStore (ttl=60s).
+//   - A GCP Secret Manager client that fails to construct in "gcpsm" or
+//     "bao" mode is NOT an error — it degrades to NewInlineStore and
+//     reports degraded=true, exactly as main.go did.
+//   - Any other failure (missing GCPProjectID, OpenBao client init
+//     failure, unrecognised mode) is a returned error. Build never calls
+//     os.Exit — that decision belongs to each caller, since main.go and
+//     the cron treat it differently (main.go exits; the cron's caller
+//     may choose the same, but that's the caller's call, not this
+//     package's).
+func Build(ctx context.Context, p BuildParams) (Store, bool, error) {
+	logger := p.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	counter := p.Counter
+	if counter == nil {
+		counter = func(string, int64) {}
+	}
+	newSMClient := p.NewSMClient
+	if newSMClient == nil {
+		newSMClient = func(ctx context.Context) (*secretmanagerclient.Client, error) {
+			return secretmanagerclient.NewClient(ctx)
+		}
+	}
+	newBaoClient := p.NewBaoClient
+	if newBaoClient == nil {
+		newBaoClient = bao.New
+	}
+
+	switch p.Mode {
+	case "gcpsm", "bao":
+		if p.GCPProjectID == "" {
+			return nil, false, fmt.Errorf(
+				"carriersecrets: GCP_PROJECT_ID required when SHIPPING_SECRET_STORE=%s", p.Mode)
+		}
+		smClient, smErr := newSMClient(ctx)
+		if smErr != nil {
+			logger.Error("carriersecrets: secret manager client init failed — falling back to inline",
+				"err", smErr)
+			return NewInlineStore(p.Encryptor), true, nil
+		}
+		baoClient, baoErr := newBaoClient(bao.Config{
+			Address:        p.OpenBaoAddr,
+			Mount:          p.OpenBaoMount,
+			KubernetesRole: p.OpenBaoRole,
+		})
+		if baoErr != nil {
+			return nil, false, fmt.Errorf("carriersecrets: openbao client init failed: %w", baoErr)
+		}
+		primary := BackendGCP
+		if p.Mode == "bao" {
+			primary = BackendBao
+		}
+		chain := NewChainStore(ChainConfig{
+			Bao:          NewBaoClient(baoClient),
+			GCP:          NewGCPStore(smClient, p.GCPProjectID),
+			Encryptor:    p.Encryptor,
+			Primary:      primary,
+			GCPProjectID: p.GCPProjectID,
+			GCPPrefix:    p.SecretPrefix,
+			Counter:      counter,
+			Logger:       logger,
+		})
+		var store Store
+		cached := p.Mode == "bao"
+		if cached {
+			// Caching is bao-only — see the doc comment above and on
+			// the call site in cmd/marketplace-api/main.go for why
+			// "gcpsm" stays uncached.
+			store = NewCachingStore(chain, cachingTTL, time.Now, counter)
+		} else {
+			store = chain
+		}
+		logger.Info("carriersecrets: chain store online",
+			"primary", primary, "cached", cached,
+			"project_id", p.GCPProjectID, "prefix", p.SecretPrefix,
+			"openbao_addr", p.OpenBaoAddr, "openbao_kv_mount", p.OpenBaoMount)
+		return store, false, nil
+	case "inline":
+		logger.Info("carriersecrets: inline store (dev mode)")
+		return NewInlineStore(p.Encryptor), false, nil
+	default:
+		return nil, false, fmt.Errorf("carriersecrets: unknown SHIPPING_SECRET_STORE mode %q", p.Mode)
+	}
+}

--- a/services/marketplace-api/internal/carriersecrets/build_test.go
+++ b/services/marketplace-api/internal/carriersecrets/build_test.go
@@ -1,0 +1,170 @@
+package carriersecrets_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	secretmanagerclient "cloud.google.com/go/secretmanager/apiv1"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/mark8ly/marketplace-api/internal/bao"
+	"github.com/mark8ly/marketplace-api/internal/carriersecrets"
+	"github.com/mark8ly/marketplace-api/internal/crypto"
+)
+
+// erroringSMFactory always fails to construct a Secret Manager client,
+// exercising the degrade-to-inline path without any network access.
+func erroringSMFactory(context.Context) (*secretmanagerclient.Client, error) {
+	return nil, errors.New("boom: no secret manager client in tests")
+}
+
+// fakeSMFactory returns a non-nil, unusable-but-constructible client so
+// mode-selection tests can get past the "client init failed" branch without
+// real GCP credentials. It never has AccessLatest/CreateOrAddVersion called
+// on it by these tests — they only assert on the returned Store's
+// concrete type, not on read/write behaviour.
+func fakeSMFactory(ctx context.Context) (*secretmanagerclient.Client, error) {
+	return secretmanagerclient.NewClient(ctx,
+		option.WithoutAuthentication(),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		option.WithEndpoint("127.0.0.1:1"), // never dialed by these tests
+	)
+}
+
+// fakeBaoFactory returns a Client without contacting a real OpenBao server
+// (Token short-circuits Kubernetes auth per bao.Config's doc comment).
+func fakeBaoFactory(cfg bao.Config) (*bao.Client, error) {
+	cfg.Token = "fake-test-token"
+	return bao.New(cfg)
+}
+
+func TestBuild_InlineMode(t *testing.T) {
+	store, degraded, err := carriersecrets.Build(context.Background(), carriersecrets.BuildParams{
+		Mode:      "inline",
+		Encryptor: crypto.NewNoopEncryptor(),
+	})
+	if err != nil {
+		t.Fatalf("Build(inline): %v", err)
+	}
+	if degraded {
+		t.Error("Build(inline) reported degraded=true, want false")
+	}
+	if _, ok := store.(*carriersecrets.InlineStore); !ok {
+		t.Errorf("Build(inline) returned %T, want *carriersecrets.InlineStore", store)
+	}
+}
+
+func TestBuild_UnknownModeErrors(t *testing.T) {
+	store, degraded, err := carriersecrets.Build(context.Background(), carriersecrets.BuildParams{
+		Mode:      "not-a-real-mode",
+		Encryptor: crypto.NewNoopEncryptor(),
+	})
+	if err == nil {
+		t.Fatal("Build(unknown mode) returned nil error, want an error")
+	}
+	if store != nil {
+		t.Errorf("Build(unknown mode) returned a non-nil store %T, want nil (no silent inline fallback)", store)
+	}
+	if degraded {
+		t.Error("Build(unknown mode) reported degraded=true — an unrecognised mode is an error, not a degrade")
+	}
+}
+
+func TestBuild_GCPSMModeRequiresProjectID(t *testing.T) {
+	_, _, err := carriersecrets.Build(context.Background(), carriersecrets.BuildParams{
+		Mode:      "gcpsm",
+		Encryptor: crypto.NewNoopEncryptor(),
+	})
+	if err == nil {
+		t.Fatal("Build(gcpsm, no GCPProjectID) returned nil error, want an error")
+	}
+}
+
+func TestBuild_SMClientFailureDegradesToInline(t *testing.T) {
+	store, degraded, err := carriersecrets.Build(context.Background(), carriersecrets.BuildParams{
+		Mode:         "gcpsm",
+		GCPProjectID: "test-project",
+		Encryptor:    crypto.NewNoopEncryptor(),
+		NewSMClient:  erroringSMFactory,
+	})
+	if err != nil {
+		t.Fatalf("Build(gcpsm, failing SM client) returned an error %v, want degraded fallback instead", err)
+	}
+	if !degraded {
+		t.Error("Build(gcpsm, failing SM client) reported degraded=false, want true")
+	}
+	if _, ok := store.(*carriersecrets.InlineStore); !ok {
+		t.Errorf("Build(gcpsm, failing SM client) returned %T, want *carriersecrets.InlineStore", store)
+	}
+}
+
+func TestBuild_GCPSMIsNotCached(t *testing.T) {
+	store, degraded, err := carriersecrets.Build(context.Background(), carriersecrets.BuildParams{
+		Mode:         "gcpsm",
+		GCPProjectID: "test-project",
+		SecretPrefix: "mark8ly-test",
+		OpenBaoAddr:  "http://127.0.0.1:8200",
+		OpenBaoMount: "kv",
+		OpenBaoRole:  "test-role",
+		Encryptor:    crypto.NewNoopEncryptor(),
+		NewSMClient:  fakeSMFactory,
+		NewBaoClient: fakeBaoFactory,
+	})
+	if err != nil {
+		t.Fatalf("Build(gcpsm): %v", err)
+	}
+	if degraded {
+		t.Error("Build(gcpsm) reported degraded=true, want false")
+	}
+	if _, isCached := store.(*carriersecrets.CachingStore); isCached {
+		t.Errorf("Build(gcpsm) returned a *CachingStore — gcpsm MUST stay uncached (see main.go's doc comment on why)")
+	}
+	if _, isChain := store.(*carriersecrets.ChainStore); !isChain {
+		t.Errorf("Build(gcpsm) returned %T, want *carriersecrets.ChainStore", store)
+	}
+}
+
+func TestBuild_BaoIsCached(t *testing.T) {
+	store, degraded, err := carriersecrets.Build(context.Background(), carriersecrets.BuildParams{
+		Mode:         "bao",
+		GCPProjectID: "test-project",
+		SecretPrefix: "mark8ly-test",
+		OpenBaoAddr:  "http://127.0.0.1:8200",
+		OpenBaoMount: "kv",
+		OpenBaoRole:  "test-role",
+		Encryptor:    crypto.NewNoopEncryptor(),
+		NewSMClient:  fakeSMFactory,
+		NewBaoClient: fakeBaoFactory,
+	})
+	if err != nil {
+		t.Fatalf("Build(bao): %v", err)
+	}
+	if degraded {
+		t.Error("Build(bao) reported degraded=true, want false")
+	}
+	if _, ok := store.(*carriersecrets.CachingStore); !ok {
+		t.Errorf("Build(bao) returned %T, want *carriersecrets.CachingStore", store)
+	}
+}
+
+func TestBuild_BaoClientFailureIsAnError(t *testing.T) {
+	_, _, err := carriersecrets.Build(context.Background(), carriersecrets.BuildParams{
+		Mode:         "bao",
+		GCPProjectID: "test-project",
+		SecretPrefix: "mark8ly-test",
+		OpenBaoAddr:  "http://127.0.0.1:8200",
+		OpenBaoMount: "kv",
+		OpenBaoRole:  "test-role",
+		Encryptor:    crypto.NewNoopEncryptor(),
+		NewSMClient:  fakeSMFactory,
+		NewBaoClient: func(bao.Config) (*bao.Client, error) {
+			return nil, errors.New("boom: openbao client init failed")
+		},
+	})
+	if err == nil {
+		t.Fatal("Build(bao, failing bao client) returned nil error, want an error — never os.Exit, never silent inline")
+	}
+}

--- a/services/marketplace-api/internal/orderrefund/resolver_integration_test.go
+++ b/services/marketplace-api/internal/orderrefund/resolver_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shopspring/decimal"
 	"gorm.io/gorm"
 
+	"github.com/mark8ly/marketplace-api/internal/carriersecrets"
 	"github.com/mark8ly/marketplace-api/internal/crypto"
 	"github.com/mark8ly/marketplace-api/internal/orderrefund"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
@@ -267,5 +268,100 @@ func TestGatewayFor_MissingConfig(t *testing.T) {
 	r := orderrefund.NewResolver(db)
 	if _, err := r.GatewayFor(context.Background(), storeID, "stripe"); err == nil {
 		t.Fatalf("expected error for missing gateway config, got nil")
+	}
+}
+
+// seedGatewayConfigWithRefs inserts a payment_gateway_configs row whose
+// api_key_encrypted/secret_key_encrypted columns hold caller-supplied
+// values verbatim — used to seed real carriersecrets references (e.g.
+// "gsm://...") rather than seedGatewayConfig's plaintext placeholder.
+func seedGatewayConfigWithRefs(t *testing.T, db *gorm.DB, tenantID, storeID uuid.UUID, provider, apiKeyRef, secretKeyRef string) {
+	t.Helper()
+	err := db.Exec(
+		`INSERT INTO payment_gateway_configs (id, tenant_id, store_id, provider, api_key_encrypted, secret_key_encrypted, mode, is_active)
+		 VALUES (gen_random_uuid(), ?, ?, ?, ?, ?, 'test', true)`,
+		tenantID, storeID, provider, apiKeyRef, secretKeyRef,
+	).Error
+	if err != nil {
+		t.Fatalf("seedGatewayConfigWithRefs: %v", err)
+	}
+}
+
+// Pins the mark8ly#166 fix: cmd/refund-sweep-cron built a Resolver via
+// orderrefund.NewResolver(conn) and never called WithSecretStore, so
+// GatewayFor could not resolve the gsm:// references stored on
+// payment_gateway_configs and every gateway re-drive from the sweeper
+// failed. A Resolver WITH a secret store wired — the fix — must resolve a
+// wrapped reference back to the real credential and construct a working
+// gateway.
+func TestGatewayFor_WithSecretStoreResolvesWrappedReference(t *testing.T) {
+	db := testdb.NewDB(t, resolverTruncateTables...)
+	tenantID, storeID := uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+
+	store := carriersecrets.NewFakeStore("tesseracthub-480811", "mark8ly-test", crypto.NewNoopEncryptor())
+	ctx := context.Background()
+	const wantAPIKey = "rzp_test_realapikey123"
+	apiKeyRef, err := store.Put(ctx, carriersecrets.Scope{
+		TenantID: tenantID.String(), Domain: "payment", Provider: "razorpay", Field: "api_key",
+	}, wantAPIKey)
+	if err != nil {
+		t.Fatalf("Put api_key: %v", err)
+	}
+	const wantSecretKey = "rzp_test_realsecretkey456"
+	secretKeyRef, err := store.Put(ctx, carriersecrets.Scope{
+		TenantID: tenantID.String(), Domain: "payment", Provider: "razorpay", Field: "secret_key",
+	}, wantSecretKey)
+	if err != nil {
+		t.Fatalf("Put secret_key: %v", err)
+	}
+	seedGatewayConfigWithRefs(t, db, tenantID, storeID, "razorpay", apiKeyRef, secretKeyRef)
+
+	r := orderrefund.NewResolver(db).WithSecretStore(store)
+	gw, err := r.GatewayFor(ctx, storeID, "razorpay")
+	if err != nil {
+		t.Fatalf("GatewayFor with secret store wired: %v", err)
+	}
+	if gw == nil {
+		t.Fatal("gateway is nil")
+	}
+	if gw.ProviderName() != "razorpay" {
+		t.Errorf("ProviderName() = %q, want razorpay", gw.ProviderName())
+	}
+}
+
+// The other half of the mark8ly#166 pin: a Resolver with NO secret store
+// and NO encryptor wired — exactly how cmd/refund-sweep-cron constructed
+// it before this fix — must fail loudly at GatewayFor instead of handing
+// the raw "gsm://..." reference to the gateway as a credential (which is
+// what produced the 401s in prod).
+func TestGatewayFor_WithoutSecretStoreFailsLoudly(t *testing.T) {
+	db := testdb.NewDB(t, resolverTruncateTables...)
+	tenantID, storeID := uuid.New(), uuid.New()
+	seedStore(t, db, storeID, tenantID)
+
+	store := carriersecrets.NewFakeStore("tesseracthub-480811", "mark8ly-test", crypto.NewNoopEncryptor())
+	ctx := context.Background()
+	apiKeyRef, err := store.Put(ctx, carriersecrets.Scope{
+		TenantID: tenantID.String(), Domain: "payment", Provider: "razorpay", Field: "api_key",
+	}, "rzp_test_realapikey123")
+	if err != nil {
+		t.Fatalf("Put api_key: %v", err)
+	}
+	secretKeyRef, err := store.Put(ctx, carriersecrets.Scope{
+		TenantID: tenantID.String(), Domain: "payment", Provider: "razorpay", Field: "secret_key",
+	}, "rzp_test_realsecretkey456")
+	if err != nil {
+		t.Fatalf("Put secret_key: %v", err)
+	}
+	seedGatewayConfigWithRefs(t, db, tenantID, storeID, "razorpay", apiKeyRef, secretKeyRef)
+
+	r := orderrefund.NewResolver(db) // no WithSecretStore, no WithEncryptor — the bug.
+	gw, err := r.GatewayFor(ctx, storeID, "razorpay")
+	if err == nil {
+		t.Fatal("GatewayFor with no secret store wired: want an error, got a gateway")
+	}
+	if gw != nil {
+		t.Errorf("GatewayFor returned a non-nil gateway on the unwired path, want nil")
 	}
 }

--- a/services/marketplace-api/pkg/config/config.go
+++ b/services/marketplace-api/pkg/config/config.go
@@ -480,3 +480,98 @@ func (c *Config) validateShippingSecretStore() error {
 	}
 	return nil
 }
+
+// CarrierSecretJobConfig is the narrow config surface for a background
+// job that only needs to build a per-tenant carrier secret Store (see
+// internal/carriersecrets.Build) and talk to Postgres — e.g.
+// cmd/refund-sweep-cron — as opposed to the full Config a Gin-serving
+// process like cmd/marketplace-api needs.
+type CarrierSecretJobConfig struct {
+	DatabaseURL         string
+	ShippingSecretStore string
+	GCPProjectID        string
+	SecretNamePrefix    string
+	OpenBaoAddr         string
+	OpenBaoRole         string
+	OpenBaoKVMount      string
+	// EncryptionMode/EncryptionKey stay in scope even though this is a
+	// "secret store" loader, not a full auth surface: the store needs an
+	// Encryptor for "inline" mode and for decoding legacy inline
+	// (noop:/aes:) references under any mode.
+	EncryptionMode string
+	EncryptionKey  string
+}
+
+// carrierSecretJobEnv is the envconfig-tagged struct LoadCarrierSecretJob
+// binds env vars into. Kept separate from Config so envconfig's
+// required-field enforcement only applies to DATABASE_URL, not to
+// Config's MARKETPLACE_FGA_API_URL (required unconditionally) or its
+// prod-only auth secrets (see Validate) — none of which a carrier-secret
+// job has any use for.
+type carrierSecretJobEnv struct {
+	DatabaseURL         string `envconfig:"DATABASE_URL" required:"true"`
+	ShippingSecretStore string `envconfig:"SHIPPING_SECRET_STORE" default:"inline"`
+	GCPProjectID        string `envconfig:"GCP_PROJECT_ID" default:""`
+	SecretNamePrefix    string `envconfig:"SECRET_NAME_PREFIX" default:"mark8ly-dev"`
+	OpenBaoAddr         string `envconfig:"OPENBAO_ADDR" default:"http://openbao-active.openbao.svc.cluster.local:8200"`
+	OpenBaoRole         string `envconfig:"OPENBAO_ROLE" default:""`
+	OpenBaoKVMount      string `envconfig:"OPENBAO_KV_MOUNT" default:"kv"`
+	EncryptionMode      string `envconfig:"ENCRYPTION_MODE" default:""`
+	EncryptionKey       string `envconfig:"ENCRYPTION_KEY" default:""`
+}
+
+// LoadCarrierSecretJob reads .env (if present) and binds only the env
+// vars a carrier-secret-consuming background job needs: DATABASE_URL,
+// SHIPPING_SECRET_STORE, GCP_PROJECT_ID, SECRET_NAME_PREFIX, OPENBAO_ADDR,
+// OPENBAO_ROLE, OPENBAO_KV_MOUNT, ENCRYPTION_MODE, ENCRYPTION_KEY.
+//
+// It deliberately does NOT call Load(): Load's envconfig.Process(Config{})
+// requires MARKETPLACE_FGA_API_URL unconditionally and, outside
+// ENV=dev, MARKETPLACE_INTERNAL_AUTH_SECRET / CUSTOMER_SESSION_SECRET /
+// ENCRYPTION_MODE=aes+ENCRYPTION_KEY (see Validate) — none of which a job
+// that only builds a carrier secret Store and talks to Postgres has any
+// use for. Loading the full Config here would force such a job to boot
+// with settings it never reads, and would widen the blast radius of
+// secrets (the customer session secret, the internal auth secret) it
+// never touches.
+//
+// It DOES reuse Config.validateShippingSecretStore() — the one piece of
+// validation that must never drift between the API and any other caller
+// of internal/carriersecrets.Build — by copying the relevant fields onto
+// a throwaway *Config and invoking that same method, rather than
+// duplicating its logic here.
+func LoadCarrierSecretJob() (*CarrierSecretJobConfig, error) {
+	_ = godotenv.Load() // .env is optional
+
+	var env carrierSecretJobEnv
+	if err := envconfig.Process("", &env); err != nil {
+		return nil, err
+	}
+
+	// validateShippingSecretStore is a method on *Config and also
+	// normalises ShippingSecretStore ("" -> "inline") in place — run it
+	// through a throwaway Config carrying only the fields it reads, then
+	// copy the (possibly normalised) value back out.
+	validation := &Config{
+		ShippingSecretStore: env.ShippingSecretStore,
+		GCPProjectID:        env.GCPProjectID,
+		OpenBaoAddr:         env.OpenBaoAddr,
+		OpenBaoRole:         env.OpenBaoRole,
+		OpenBaoKVMount:      env.OpenBaoKVMount,
+	}
+	if err := validation.validateShippingSecretStore(); err != nil {
+		return nil, err
+	}
+
+	return &CarrierSecretJobConfig{
+		DatabaseURL:         env.DatabaseURL,
+		ShippingSecretStore: validation.ShippingSecretStore,
+		GCPProjectID:        env.GCPProjectID,
+		SecretNamePrefix:    env.SecretNamePrefix,
+		OpenBaoAddr:         env.OpenBaoAddr,
+		OpenBaoRole:         env.OpenBaoRole,
+		OpenBaoKVMount:      env.OpenBaoKVMount,
+		EncryptionMode:      strings.ToLower(strings.TrimSpace(env.EncryptionMode)),
+		EncryptionKey:       strings.TrimSpace(env.EncryptionKey),
+	}, nil
+}

--- a/services/marketplace-api/pkg/config/config_test.go
+++ b/services/marketplace-api/pkg/config/config_test.go
@@ -298,3 +298,85 @@ func TestConfig_ShippingSecretStoreExplicitlyEmptyDefaultsToInline(t *testing.T)
 		t.Errorf("ShippingSecretStore = %q, want inline", cfg.ShippingSecretStore)
 	}
 }
+
+// LoadCarrierSecretJob is the narrow loader for background jobs (e.g.
+// cmd/refund-sweep-cron) that only need to construct a carrier secret
+// Store — it must accept a minimal env with none of Config's unrelated
+// required/prod-only fields set.
+func TestLoadCarrierSecretJob_MinimalEnvSucceeds(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://x/y")
+	os.Unsetenv("MARKETPLACE_FGA_API_URL")
+	os.Unsetenv("SHIPPING_SECRET_STORE")
+	os.Unsetenv("ENV")
+
+	cfg, err := LoadCarrierSecretJob()
+	if err != nil {
+		t.Fatalf("LoadCarrierSecretJob: %v", err)
+	}
+	if cfg.DatabaseURL != "postgres://x/y" {
+		t.Errorf("DatabaseURL = %q, want postgres://x/y", cfg.DatabaseURL)
+	}
+	if cfg.ShippingSecretStore != "inline" {
+		t.Errorf("LoadCarrierSecretJob: ShippingSecretStore = %q, want inline", cfg.ShippingSecretStore)
+	}
+}
+
+// It must NOT require MARKETPLACE_FGA_API_URL — that's the whole point:
+// Load()/Config requires it unconditionally, but a carrier-secret job
+// never touches FGA.
+func TestLoadCarrierSecretJob_DoesNotRequireFGAAPIURL(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://x/y")
+	os.Unsetenv("MARKETPLACE_FGA_API_URL")
+
+	if _, err := LoadCarrierSecretJob(); err != nil {
+		t.Fatalf("LoadCarrierSecretJob() with no MARKETPLACE_FGA_API_URL = %v, want success", err)
+	}
+}
+
+func TestLoadCarrierSecretJob_RequiresDatabaseURL(t *testing.T) {
+	os.Unsetenv("DATABASE_URL")
+
+	if _, err := LoadCarrierSecretJob(); err == nil {
+		t.Fatal("LoadCarrierSecretJob() with no DATABASE_URL = nil, want error")
+	}
+}
+
+// The same validateShippingSecretStore() the full Load() uses must reject
+// an unknown SHIPPING_SECRET_STORE for the narrow loader too — this is
+// the one piece of validation that must never drift between callers.
+func TestLoadCarrierSecretJob_RejectsUnknownShippingSecretStore(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://x/y")
+	t.Setenv("SHIPPING_SECRET_STORE", "totally-bogus")
+
+	if _, err := LoadCarrierSecretJob(); err == nil {
+		t.Fatal("LoadCarrierSecretJob() with SHIPPING_SECRET_STORE=totally-bogus = nil, want error")
+	}
+}
+
+// Same rollback-safety rule Load() enforces: "gcpsm" (and "bao") require
+// OPENBAO_ROLE.
+func TestLoadCarrierSecretJob_GCPSMModeRequiresOpenBaoRole(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://x/y")
+	t.Setenv("SHIPPING_SECRET_STORE", "gcpsm")
+	t.Setenv("GCP_PROJECT_ID", "test-project")
+	t.Setenv("OPENBAO_ROLE", "")
+
+	if _, err := LoadCarrierSecretJob(); err == nil {
+		t.Fatal("LoadCarrierSecretJob() with SHIPPING_SECRET_STORE=gcpsm and no OPENBAO_ROLE = nil, want error")
+	}
+}
+
+func TestLoadCarrierSecretJob_BaoModeSucceedsWithFullSettings(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://x/y")
+	t.Setenv("SHIPPING_SECRET_STORE", "bao")
+	t.Setenv("OPENBAO_ROLE", "refund-sweep-cron")
+	t.Setenv("GCP_PROJECT_ID", "test-project")
+
+	cfg, err := LoadCarrierSecretJob()
+	if err != nil {
+		t.Fatalf("LoadCarrierSecretJob() with SHIPPING_SECRET_STORE=bao and required settings: %v", err)
+	}
+	if cfg.ShippingSecretStore != "bao" {
+		t.Errorf("ShippingSecretStore = %q, want bao", cfg.ShippingSecretStore)
+	}
+}


### PR DESCRIPTION
Fixes #166's blocker: the refund sweeper could not resolve any carrier credential.

**Merge tesserix-k8s#865 FIRST.** That PR adds the env this binary reads at startup; adding it is inert for the currently-deployed binary, whereas merging this first would leave the CronJob without the config it now needs.

## The bug

`cmd/refund-sweep-cron/main.go` called `orderrefund.NewResolver(conn)` and never called the existing `WithSecretStore`. So `GatewayFor` could not resolve the `gsm://` reference on `payment_gateway_configs` — it handed the raw reference string to the payment gateway, which 401s. **Every gateway re-drive from the stuck-refund sweeper failed**, which is a live gate on `REFUND_GATEWAY_ENABLED`.

The file carried a `KNOWN GAP` comment describing this. It is now gone, because it is fixed.

## The root cause was duplication, so the fix is deduplication

`cmd/marketplace-api/main.go` built the store inline through an ~80-line mode switch; the cron built nothing. They drifted because nothing forced them to agree — and phase 2 made it worse by adding a third mode (`bao`) to one side only. Pasting the construction into the cron would have recreated the same drift on a slower fuse.

So this extracts `internal/carriersecrets.Build(ctx, BuildParams) (Store, degraded bool, error)` and has both binaries call it. The builder **returns errors instead of calling `os.Exit`** — which is why the old code could never be tested, and why the two were free to diverge. Callers decide: the API keeps its exact current exit behaviour; the cron treats a build failure as fatal, because running a sweep that cannot resolve credentials is precisely the bug.

## Config: shared validation, not a shared config surface

The cron uses a narrow `config.LoadCarrierSecretJob()` rather than the full `config.Load()`. The full loader requires `MARKETPLACE_FGA_API_URL`, and in non-`dev` environments also the internal-auth and customer-session secrets — none of which a refund sweeper uses. Sharing it wholesale would have crash-looped the CronJob and injected two unrelated secrets into it.

The narrow loader still calls the **same** `validateShippingSecretStore()` the API uses. That is the piece that must not drift; the rest of the API's config surface is not.

## Behaviour preserved exactly

`gcpsm` remains **uncached**. That is load-bearing — caching the default path would add stale-on-error masking, so a GCP Secret Manager outage that surfaces immediately today would instead be hidden behind a stale value. `TestBuild_GCPSMIsNotCached` pins it by asserting on the concrete type, and the reviewer proved that test non-vacuous by inverting the branch and watching it fail.

## Test plan

- [x] `go test ./...` — 98 packages, 0 failures
- [x] `-race` clean on `internal/carriersecrets`, `internal/orderrefund`, `pkg/config`
- [x] `TestGatewayFor_WithSecretStoreResolvesWrappedReference` / `...WithoutSecretStoreFailsLoudly` — both directions, so the fix is pinned by a test that fails without it
- [x] 7 `TestBuild_*` covering mode selection, the degrade-to-inline path, and the uncached/cached invariants
- [x] Behavioural parity of the extraction reviewed branch-by-branch against `origin/main`'s inline switch
- [ ] After both merge: a live CronJob run resolving a real credential

That last box is #166's acceptance criterion. It stays open until the log line exists.

## Known follow-up

The API still uses the full `config.Load()` — correct, it needs all of it. If other job binaries appear, they should use the narrow loader rather than growing their own.

Refs #166, #319.
