### PR TITLE
fix(perf): move geo currency off the HTML response so the edge can cache it

### DIFF
--- a/apps/onboarding/app/api/geo-currency/route.ts
+++ b/apps/onboarding/app/api/geo-currency/route.ts
@@ -1,0 +1,33 @@
+import { countryToCurrency } from "@repo/ui/subscription";
+import { NextResponse } from "next/server";
+
+/**
+ * Geo-resolved billing currency, as JSON, for the client to fetch.
+ *
+ * This endpoint exists so the marketing pages can be cached at the
+ * edge. Middleware used to attach `Set-Cookie: mk8_currency` to every
+ * response, which meant Cloudflare could never cache any of them — a
+ * cached response carries its `Set-Cookie` header with it, so serving
+ * one visitor's HTML to another would hand them the first visitor's
+ * currency. Correct, and expensive: every visit to every marketing page
+ * round-tripped to a single pod in Sydney (tesserix/mark8ly#597).
+ *
+ * Moving the geo lookup here confines the per-visitor bit to one small
+ * JSON response that nobody caches, and leaves the HTML identical for
+ * everyone — which is the precondition for caching it.
+ *
+ * Deliberately `force-dynamic` and `no-store`: the entire value of this
+ * route is that it reads a per-request header. A cached response would
+ * report the currency of whoever happened to warm the cache, which is
+ * the exact bug this design removes from the HTML.
+ */
+export const dynamic = "force-dynamic";
+
+export function GET(request: Request): NextResponse {
+  const currency = countryToCurrency(request.headers.get("CF-IPCountry"));
+
+  return NextResponse.json(
+    { currency },
+    { headers: { "cache-control": "private, no-store" } },
+  );
+}

--- a/apps/onboarding/lib/geo/currency.ts
+++ b/apps/onboarding/lib/geo/currency.ts
@@ -1,9 +1,12 @@
 /**
  * Client-side resolution of the geo-localized billing currency.
  *
- * `mk8_currency` is still written by middleware.ts from Cloudflare's
- * `CF-IPCountry` — nothing about who *writes* the cookie changed. What
- * changed is who *reads* it.
+ * `mk8_currency` is now written by the client, from a value it fetches
+ * from `/api/geo-currency`. Middleware used to write it on every
+ * response, which made every marketing page uncacheable at the edge —
+ * a response carrying `Set-Cookie` cannot be shared between visitors
+ * (tesserix/mark8ly#597). The cookie survives as a cache, so the fetch
+ * happens once per visitor rather than once per page view.
  *
  * The marketing landing used to read the cookie in the server component
  * via `await cookies()`. In the App Router that single call opts the
@@ -51,17 +54,47 @@ import {
 export const PRERENDER_CURRENCY: Currency = normalizeCurrency(undefined)
 
 /**
- * Reads `mk8_currency` from `document.cookie`. The cookie is written
- * with `httpOnly: false` precisely so this is possible.
+ * How long a resolved currency stays cached in the cookie. Matches the
+ * 24 hours middleware used, so a visitor who moves country is not stuck
+ * with a stale currency indefinitely.
+ */
+const COOKIE_MAX_AGE_SECONDS = 86_400
+
+/**
+ * Reads `mk8_currency` from `document.cookie`, or `undefined` when the
+ * cookie is absent.
+ *
+ * The distinction matters now that the client is responsible for
+ * fetching the currency: "no cookie yet" means *go and ask*, while a
+ * cookie that happens to say USD means the question is already
+ * answered. Collapsing both to PRERENDER_CURRENCY would re-fetch on
+ * every page view for every American visitor.
  *
  * `normalizeCurrency` still guards the value: geo-targeting can resolve
  * a visitor to a currency the catalogue can't actually price, and
  * showing a USD amount under that label would misquote the price.
  */
-export function readCurrencyCookie(): Currency {
-  if (typeof document === 'undefined') return PRERENDER_CURRENCY
+export function readCurrencyCookie(): Currency | undefined {
+  if (typeof document === 'undefined') return undefined
   const match = document.cookie.match(
     new RegExp(`(?:^|;\\s*)${CURRENCY_COOKIE_NAME}=([^;]*)`),
   )
-  return normalizeCurrency(match ? decodeURIComponent(match[1]!) : undefined)
+  if (!match) return undefined
+  return normalizeCurrency(decodeURIComponent(match[1]!))
+}
+
+/**
+ * Caches a resolved currency so later page views skip the fetch.
+ *
+ * Not `httpOnly` — it cannot be, since the code that reads it is this
+ * module. Not `secure` either, because localhost is served over http
+ * and a `secure` cookie would silently never be set in development,
+ * making every local page view re-fetch.
+ */
+export function writeCurrencyCookie(currency: Currency): void {
+  if (typeof document === 'undefined') return
+  const secure = window.location.protocol === 'https:' ? '; secure' : ''
+  document.cookie =
+    `${CURRENCY_COOKIE_NAME}=${encodeURIComponent(currency)}` +
+    `; path=/; max-age=${COOKIE_MAX_AGE_SECONDS}; samesite=lax${secure}`
 }

--- a/apps/onboarding/lib/geo/use-geo-currency.ts
+++ b/apps/onboarding/lib/geo/use-geo-currency.ts
@@ -10,18 +10,49 @@
 import { useEffect, useState } from 'react'
 import type { Currency } from '@repo/ui/subscription'
 
-import { PRERENDER_CURRENCY, readCurrencyCookie } from './currency'
+import {
+  PRERENDER_CURRENCY,
+  readCurrencyCookie,
+  writeCurrencyCookie,
+} from './currency'
 
 /**
  * Returns PRERENDER_CURRENCY for the server render and the first client
  * render — they must agree or React reports a hydration mismatch — then
  * the visitor's real currency once mounted.
+ *
+ * The cookie is checked first and only missed on a visitor's first page
+ * view, when we ask `/api/geo-currency` and cache the answer. A failed
+ * fetch is swallowed on purpose: the page is already showing valid USD
+ * pricing, so the correct behaviour on a network error is to leave it
+ * alone rather than surface an error about a currency label.
  */
 export function useGeoCurrency(): Currency {
   const [currency, setCurrency] = useState<Currency>(PRERENDER_CURRENCY)
 
   useEffect(() => {
-    setCurrency(readCurrencyCookie())
+    const cached = readCurrencyCookie()
+    if (cached) {
+      setCurrency(cached)
+      return
+    }
+
+    // Guards against setting state after unmount, and against a slow
+    // response arriving once the visitor has navigated away.
+    const controller = new AbortController()
+
+    fetch('/api/geo-currency', { signal: controller.signal })
+      .then((response) => (response.ok ? response.json() : null))
+      .then((body: { currency?: Currency } | null) => {
+        if (!body?.currency) return
+        writeCurrencyCookie(body.currency)
+        setCurrency(body.currency)
+      })
+      .catch(() => {
+        // Offline, blocked, or aborted. USD stands.
+      })
+
+    return () => controller.abort()
   }, [])
 
   return currency

--- a/apps/onboarding/middleware.ts
+++ b/apps/onboarding/middleware.ts
@@ -1,5 +1,4 @@
 import { type NextRequest, NextResponse } from 'next/server'
-import { CURRENCY_COOKIE_NAME, countryToCurrency } from '@repo/ui/subscription'
 import { SITE_JSON_LD } from './lib/seo/site-json-ld'
 import {
   buildCsp,
@@ -10,22 +9,36 @@ import {
 } from './lib/security/csp'
 
 /**
- * Onboarding middleware — sets the `mk8_currency` cookie on every
- * request so the marketing landing (`/#pricing`) can render geo-
- * localized prices without an extra round-trip. Mirrors the admin
- * app's `/pricing` middleware using the same shared country→currency
- * map, so both surfaces show the same currency for a given visitor.
+ * Onboarding middleware — sets the Content-Security-Policy, and
+ * deliberately nothing else.
  *
- * Cloudflare injects `CF-IPCountry` at the edge. Local dev lacks it —
- * the fallback to USD keeps the page rendering.
+ * It used to also write an `mk8_currency` cookie on every response,
+ * resolved from Cloudflare's `CF-IPCountry`, so the pricing section
+ * could render geo-localized prices without an extra round-trip.
  *
- * We set the cookie on every response rather than only on `/` because
- * marketing visitors hit various routes (/, /about, /guides, ...) and
- * the landing's pricing section needs the cookie regardless of their
- * entry point. Overhead is one header + one cookie write per request.
+ * That cookie is why nothing here was ever cacheable. A response
+ * carrying `Set-Cookie` cannot be shared between visitors — a cached
+ * copy would hand the next visitor the first visitor's currency — so
+ * Cloudflare reported `cf-cache-status: DYNAMIC` for every marketing
+ * page, and every visit paid a full origin round-trip to one pod in
+ * Sydney (tesserix/mark8ly#597).
+ *
+ * It had also stopped earning its keep. Since #607 nothing on the
+ * server reads the cookie: `/` prerenders at PRERENDER_CURRENCY and the
+ * currency-bearing islands correct themselves on mount, reading
+ * `document.cookie` from the client. Middleware was making the whole
+ * site uncacheable to write a value only client JS consumed.
+ *
+ * So the geo lookup moved to `app/api/geo-currency/route.ts`, which the
+ * client fetches once and then caches in the cookie itself. The HTML is
+ * now byte-identical for every visitor, which is what makes an edge
+ * Cache Rule safe.
+ *
+ * NOTE: removing the cookie makes caching *safe*, not automatic —
+ * Cloudflare does not cache HTML without a Cache Rule. If the marketing
+ * pages still report DYNAMIC, that rule is the missing half, and it
+ * must exclude `/api/*` so this endpoint stays per-request.
  */
-const COOKIE_MAX_AGE = 86_400 // 24 hours
-
 // The layout's JSON-LD is a constant, so its hash is computed once per
 // worker rather than per request.
 const jsonLdHash = sha256Source(SITE_JSON_LD)
@@ -45,24 +58,12 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
 
   const response = NextResponse.next({ request: { headers } })
   response.headers.set('Content-Security-Policy', csp)
-  const countryCode = request.headers.get('CF-IPCountry')
-  const currency = countryToCurrency(countryCode)
-  const isProduction = process.env.NODE_ENV === 'production'
-
-  response.cookies.set(CURRENCY_COOKIE_NAME, currency, {
-    maxAge: COOKIE_MAX_AGE,
-    path: '/',
-    sameSite: 'lax',
-    secure: isProduction,
-    httpOnly: false,
-  })
 
   return response
 }
 
 export const config = {
-  // Skip Next internals + static assets. Run on every user-facing
-  // route so the cookie is present on every page the pricing section
-  // might appear on.
+  // Skip Next internals + static assets. Runs on every user-facing
+  // route because every one of them needs the CSP header.
   matcher: ['/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)'],
 }

--- a/apps/onboarding/tests/unit/middleware-sets-no-cookie.spec.ts
+++ b/apps/onboarding/tests/unit/middleware-sets-no-cookie.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Regression guard for GitHub issue #597.
+ *
+ * Middleware runs on every user-facing route. Any `Set-Cookie` it
+ * attaches travels with the response, and a response carrying
+ * `Set-Cookie` cannot be shared between visitors — so Cloudflare will
+ * not cache it, and every marketing page reverts to a full origin
+ * round-trip to a single pod in Sydney.
+ *
+ * That is exactly what used to happen: middleware wrote `mk8_currency`
+ * from `CF-IPCountry` on every response, and `cf-cache-status` was
+ * `DYNAMIC` site-wide as a result. The geo lookup now lives in
+ * /api/geo-currency, which the client fetches and caches itself.
+ *
+ * This regression is invisible without a guard. Adding a cookie back
+ * breaks no test, renders correctly, and passes review — it just
+ * quietly makes the site uncacheable again, and the only symptom is a
+ * latency number nobody is watching.
+ */
+function source(relative: string): string {
+  return readFileSync(path.join(__dirname, "../..", relative), "utf8");
+}
+
+/** Comments name the removed cookie in order to explain it, so scanning
+ *  raw source would trip the guard on its own documentation. */
+function codeOnly(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+test("middleware attaches no cookie to any response (#597)", () => {
+  const code = codeOnly(source("middleware.ts"));
+  expect(code).not.toContain("cookies.set");
+  expect(code.toLowerCase()).not.toContain("set-cookie");
+});
+
+test("the geo endpoint stays per-request, never cached (#597)", () => {
+  const code = source("app/api/geo-currency/route.ts");
+  // If this response were ever cached it would report the currency of
+  // whoever warmed the cache — the same bug, moved rather than fixed.
+  expect(code).toContain('export const dynamic = "force-dynamic"');
+  expect(code).toContain("no-store");
+});


### PR DESCRIPTION
Addresses the remaining half of #597. **Does not close it** — the code change makes edge caching *safe*, but a Cloudflare Cache Rule is still needed to make it *happen*. See "What is still required" below.

## The issue named the wrong cause, twice

#597 blamed fonts and missing preconnects. #607 established the real cause was one `cookies()` call, and fixed it. Measured on production after that landed:

| | Before | After #607 |
|---|---|---|
| Mobile LCP | 3.27s | **2.9s** |
| Perf score | — | 94 |

Better, but 2.9s is still outside Google's "good" band (≤2.5s), and `server-response-time` is 300ms because **`cf-cache-status: DYNAMIC`** — Cloudflare caches none of it.

The reason is `Set-Cookie`. Middleware wrote `mk8_currency` from `CF-IPCountry` on **every** response, and a response carrying `Set-Cookie` cannot be shared between visitors: a cached copy hands the next visitor the first visitor's currency. So Cloudflare correctly refused, and every visit to every marketing page — not just `/` — paid a full origin round-trip to one pod in Sydney. From India, where `/sell-online-india` and the UPI guide are aimed, that is materially worse than the ~355ms I measure from Australia.

## The cookie had already stopped earning it

This is the part that makes the fix cheap. I checked every reader of `mk8_currency`: since #607, **nothing on the server touches it**. `/` prerenders at `PRERENDER_CURRENCY` and the currency islands correct themselves on mount via `readCurrencyCookie()` on `document.cookie`.

Middleware was making the entire site uncacheable in order to write a value only client JS consumed.

## What changed

**`app/api/geo-currency/route.ts`** — new. Returns `{currency}` from `CF-IPCountry`. `force-dynamic` and `private, no-store`, because a cached copy of *this* would report the currency of whoever warmed it — the same bug relocated rather than fixed.

**`middleware.ts`** — no longer writes any cookie. It now sets CSP and nothing else.

**`lib/geo/currency.ts`** — `readCurrencyCookie()` now returns `Currency | undefined`. The distinction is load-bearing: "no cookie yet" means *go ask*, whereas a cookie saying USD means the question is answered. Collapsing both to `PRERENDER_CURRENCY` would re-fetch on every page view for every American visitor. Adds `writeCurrencyCookie()`, deliberately not `secure` on http so local development doesn't silently re-fetch forever.

**`lib/geo/use-geo-currency.ts`** — cookie first, fetch only on a visitor's first page view, then cache. `AbortController` on unmount. A failed fetch is swallowed on purpose: the page is already showing valid USD pricing, so the right response to a network error is to leave it alone, not to surface an error about a currency label.

No visible change: the USD→local swap already happened post-hydration before this PR.

## The guard, and why it matters more than usual

`tests/unit/middleware-sets-no-cookie.spec.ts` asserts middleware attaches no cookie and the endpoint stays uncached.

This regression is **invisible without a guard**. Re-adding a cookie to middleware breaks no test, renders correctly, and passes review — it just quietly makes the whole site uncacheable again, and the only symptom is a latency number nobody is watching.

**Mutation-tested:** inserting `response.cookies.set('x','y')` fails the guard (1 failed, 1 passed); removing it passes.

## Verification

```
npm run check-types -w @mark8ly/onboarding  → clean
npm test (apps/onboarding)                  → 91 passed (89 baseline + 2 new)
npm run build -w @mark8ly/onboarding        → ┌ ○ /   and  ƒ /api/geo-currency
```

Against a real `next start` (killed by PID first — Next renames itself to `next-server`, which is how a stale server faked a result during #609):

- `/` ships **0** `Set-Cookie` headers, `Cache-Control: s-maxage=31536000`
- `/api/geo-currency` → `CF-IPCountry: IN` gives `{"currency":"INR"}`, `AU` gives `{"currency":"AUD"}`, absent gives `{"currency":"USD"}`
- endpoint returns `cache-control: private, no-store`
- CSP already allows the call — `connect-src 'self'` — checked before relying on it

## What is still required (not code)

Cloudflare **does not cache HTML by default**, so this alone will not flip `cf-cache-status` to `HIT`. A Cache Rule is needed on the marketing routes, and it **must exclude `/api/*`** so the geo endpoint stays per-request. That rule was unsafe before this PR and is safe after it — which is the actual sequencing here.

Leaving #597 open until that rule exists and production measures `HIT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YB1BFjWgctpHPLb1knCRKH