### PR TITLE
fix(marketing): make the H1 tell the same story as the title

### DIFF
--- a/apps/onboarding/app/page.tsx
+++ b/apps/onboarding/app/page.tsx
@@ -354,20 +354,42 @@ function Hero() {
     <section className="relative overflow-hidden">
       <div className="mx-auto max-w-6xl px-6 pb-16 pt-16 lg:pb-24 lg:pt-20">
         <div className="max-w-3xl">
+          {/*
+            The H1 carries the offer as well as the brand line.
+
+            The <title> was rewritten to lead with the offer (#570), but
+            the H1 was not — so the page told two different stories
+            depending on how you arrived (tesserix/mark8ly#599). Someone
+            coming from search passes through the title first. Someone
+            tapping a link in an Instagram DM never sees the title at
+            all, and lands straight on the H1 — and that is the primary
+            acquisition channel, so it is the majority arrival path.
+
+            "A storefront worth opening" is a comparison claim: it only
+            lands against an implicit alternative, which a seller
+            currently taking orders in DMs does not have. It is kept,
+            because it is the brand line and it works on the migrator,
+            but it no longer stands alone.
+          */}
           <h1 className="font-serif text-5xl font-medium leading-[1.02] tracking-[-0.025em] text-foreground">
-            A storefront
+            A storefront worth opening.
             <br />
-            worth opening.
+            {/* nbsp keeps "ninety days." together: at 390px the serif
+                wraps to four lines and would otherwise orphan "days."
+                on a line of its own. text-wrap:balance does not help —
+                the explicit <br> splits the heading into two separate
+                balancing blocks, and measuring showed no effect. */}
+            Free for ninety&nbsp;days.
           </h1>
           <p className="mt-6 max-w-xl text-xl leading-[1.2] text-foreground">
-            Ninety days free, no card. And we never take a cut of what you
-            sell.
+            No card to start, and we never take a cut of what you sell.
           </p>
           <p className="mt-6 max-w-xl text-lg leading-[1.55] text-foreground-secondary">
             Mark8ly is a quiet, considered commerce platform for people who
-            actually make things. Set up in an afternoon. Keep your margins.
-            Sell on a storefront that doesn&rsquo;t look like everyone
-            else&rsquo;s.
+            actually make things. If you&rsquo;re taking orders through
+            Instagram DMs and a link in your bio today, this is the step
+            after that. Set up in an afternoon. Keep your margins. Sell on a
+            storefront that doesn&rsquo;t look like everyone else&rsquo;s.
           </p>
 
           <div className="mt-10 flex flex-wrap items-center gap-x-8 gap-y-4">

--- a/apps/onboarding/tests/e2e/golden-path.spec.ts
+++ b/apps/onboarding/tests/e2e/golden-path.spec.ts
@@ -22,7 +22,15 @@ test("golden path: landing → form → magic link → welcome", async ({
   // 1. Landing page renders and the primary CTA goes to /onboarding.
   await page.goto("/");
   await expect(
-    page.getByRole("heading", { name: /a storefront worth opening/i }),
+    // Pins both halves of the H1. The offer half is the point of
+    // tesserix/mark8ly#599: the <title> leads with the offer, so an H1
+    // that leads only with the brand line tells a different story to
+    // anyone who arrives without passing through a SERP.
+    page.getByRole("heading", {
+      // \s+ rather than a literal space: the markup uses &nbsp; to stop
+      // "days." orphaning on mobile, and a literal space would not match it.
+      name: /a storefront worth opening\.\s*free for ninety\s+days\./i,
+    }),
   ).toBeVisible();
 
   // 2. Onboarding form.


### PR DESCRIPTION
Closes #599.

## The mismatch

#570 rewrote the `<title>` to lead with the offer — `Ninety days free, 0% platform fees — Mark8ly commerce`. The H1 was not rewritten, and still read **"A storefront worth opening."**

Which story a visitor got depended entirely on how they arrived. From search, you pass through the title first, so the offer lands. **From an Instagram DM you never see the title at all** — you tap a link and land straight on the H1. That is the primary acquisition channel, so it is the majority arrival path.

And "a storefront worth opening" is a *comparison* claim: it only lands against an implicit alternative. A seller currently taking orders in DMs has no comparison set — they are asking "can I actually do this" and "what will it cost me".

## What changed

The H1 now carries both:

> A storefront worth opening.
> Free for ninety days.

The brand line is **kept**, not demoted — it works on the migrator, and it is the line the whole identity rests on. It just no longer stands alone. The deck drops the now-duplicated "ninety days free" and carries what the H1 doesn't: *"No card to start, and we never take a cut of what you sell."*

The body paragraph also gains one sentence naming the arrival context — *"If you're taking orders through Instagram DMs and a link in your bio today, this is the step after that."* #599 noted that **"Instagram", "DM" and "Linktree" appear nowhere on the homepage**, so the page never spoke back to the visitor it was written for. One sentence, no repositioning, migrator copy untouched.

Brand voice holds: no urgency, no hype, no countdown. This is sequence, not tone.

## Typography — measured, not eyeballed

Rendered at 390×844 (iPhone 13) and 1440×900, with `next start` on the production build.

**Desktop:** three lines, the offer on its own line. Reads as intended.

**Mobile:** the first attempt orphaned **"days."** onto a line by itself in the primary serif heading. Given the brand leans on Source Serif 4 for exactly this, that is not acceptable.

`text-wrap: balance` was tried first and **measured to do nothing** — the explicit `<br>` splits the heading into two separate balancing blocks. It was removed rather than shipped as a dead class. The fix is a `&nbsp;` binding "ninety days." together, which resolves the orphan at the same 184px height and leaves desktop untouched (it fits on one line there regardless).

No horizontal overflow at either width, and the deck stays fully above the fold (ends y=394 of 844).

## Verification

```
npm run check-types -w @mark8ly/onboarding  → clean
npm test (apps/onboarding)                  → 91 passed
npm run build -w @mark8ly/onboarding        → ┌ ○ /   (still static)
```

`tests/e2e/golden-path.spec.ts` asserted the old H1 and is updated to pin **both** halves — the offer half is the actual regression guard for this issue. Its regex uses `\s+` rather than a literal space, because a literal space would not match the `&nbsp;`; the built HTML's accessible name was extracted and the regex tested against it directly rather than assumed:

```
accessible name: "A storefront worth opening. Free for ninety days."
e2e regex matches: true
```

## Not done here

#599 also raised two things outside its own "Done when", left deliberately:

- **The five-competitor comparison table on the homepage** is migrator content, and the migrator is already served by four dedicated comparison pages. Removing it is a positioning decision, not a defect fix.
- **The FAQ's "I'm not technical. Can I still use this?"** sits at position 5 of 6 — the most persona-relevant question, nearly last.

Both are worth doing; neither should ride along unannounced in a copy fix.

The issue asks for an A/B test once there is traffic. There is not yet, so this ships on reasoning. Leading indicator to watch in OpenPanel: homepage → `/onboarding` click rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YB1BFjWgctpHPLb1knCRKH