### PR TITLE
feat(marketing): give each comparison page substance only it can carry

### DIFF
--- a/apps/onboarding/app/ecommerce-for-makers/page.tsx
+++ b/apps/onboarding/app/ecommerce-for-makers/page.tsx
@@ -73,8 +73,19 @@ export default function EcommerceForMakersPage() {
         {
           heading: "Margins that survive the sale",
           body: [
-            "When you make things by hand, every percentage point matters. Mark8ly adds nothing to your sales — no platform fee, no per-order surcharge. Your processor takes their standard rate (about 2% for UPI, 2–3% for cards) and that's it.",
+            "When you make things by hand, every percentage point matters. Mark8ly adds nothing to your sales — no platform fee, no per-order surcharge. Your gateway takes its standard rate (about 2% for UPI, 2–3% for cards) and that's it.",
             "The Starter plan is priced for a first shop and still carries unlimited products and orders — list a considered range or a deep archive, it costs the same. What you gain further up is more storefronts, more images per product, and deeper API access.",
+          ],
+        },
+        {
+          heading: "What a maker's storefront needs that a generic one doesn't",
+          body: [
+            "Most storefront software is built around a catalogue: many products, many variants, consistent stock, photography shot to a template. Handmade work is the opposite of nearly all of that, and the mismatch shows up as daily friction rather than as a missing feature.",
+            "A maker often has one of a thing. Not low stock \u2014 one. A platform that treats a sold-out listing as an error state, or pushes you to restock, is describing a business you are not running. Made-to-order work has the reverse problem: no stock number is meaningful, and what the buyer needs to know is how long it will take.",
+            "Variants are physical rather than a dropdown. Ring sizes, timber grain, dye lots and glaze results are not interchangeable options behind one photograph \u2014 the variation is frequently the reason someone is buying. A storefront that hides it behind a swatch is hiding the work.",
+            "Photography is doing the job a customer's hands would do. Texture, scale and colour accuracy carry the sale, which is why generous, uncropped images matter more here than in most categories, and why a template that squeezes everything into a uniform square costs real money.",
+            "And postage is genuinely hard: one-off dimensions, fragile pieces, and a real risk of quoting a flat rate that quietly eats the margin on the heaviest item.",
+            "None of this is exotic. It is just a different shape of business from the one most ecommerce software was designed around, and it is the shape we built for.",
           ],
         },
         {

--- a/apps/onboarding/app/etsy-alternative/page.tsx
+++ b/apps/onboarding/app/etsy-alternative/page.tsx
@@ -78,6 +78,35 @@ export default function EtsyAlternativePage() {
           ],
         },
         {
+          heading: "What Etsy actually costs, on one order",
+          body: [
+            "Etsy's fees are individually small and collectively not. The listing fee is twenty cents, the transaction fee is 6.5%, and payment processing in the US is 3% plus twenty-five cents. The detail that catches people out is that the 6.5% applies to the total order including shipping \u2014 so charging the buyer for postage also increases what Etsy takes.",
+            "Here is a $53 order: a $45 item with $8 of shipping.",
+          ],
+          breakdown: {
+            caption: "A $53 order \u2014 a $45 item plus $8 shipping, US seller",
+            rows: [
+              { label: "Listing fee", amount: "$0.20", note: "per listing, renewed every four months or on each sale" },
+              { label: "Transaction fee", amount: "$3.45", note: "6.5% of $53 \u2014 charged on the shipping too" },
+              { label: "Payment processing", amount: "$1.84", note: "3% + $0.25, US rate" },
+            ],
+            total: { label: "Etsy keeps", amount: "$5.49", note: "10.4% of the order, before any advertising" },
+            source: {
+              label: "Etsy's published seller fees",
+              url: "https://www.etsy.com/legal/fees/",
+            },
+          },
+        },
+        {
+          heading: "And that is the version without Offsite Ads",
+          body: [
+            "Offsite Ads add 15% of the order on any sale that follows an Etsy-placed ad. On the same $53 order that is a further $7.95, taking the total to $13.44 \u2014 just over a quarter of the order.",
+            "The part worth reading carefully: opting out is only available while your shop is under $10,000 of sales in a rolling twelve months. Cross that line once and enrolment becomes permanent for the life of the shop, at a reduced 12% rate capped at $100 per order. It does not lapse if your sales later fall back below the threshold.",
+            "None of this makes Etsy a bad place to sell. It has demand you would otherwise have to go and find, and for many makers that trade is worth it. But it is a marketplace fee, and it scales with your success rather than with anything it costs Etsy to serve you.",
+            "On Mark8ly there is no listing fee, no transaction fee, and no advertising levy. You pay your payment processor \u2014 on that same $53 order, around $1.84, essentially identical to Etsy's own processing charge \u2014 and nothing else. The $3.65 difference per order is the whole of it. At forty orders a month that is roughly $146 you keep, against $15 a month for Starter billed yearly.",
+          ],
+        },
+        {
           heading: "Run it alongside Etsy, or instead of it",
           body: [
             "You don't have to leave Etsy on day one. Many sellers open a Mark8ly shop as the home base they own, and point their best customers there over time. If you can write an email, you can have it live in an afternoon, with real humans to help.",

--- a/apps/onboarding/app/guides/guides.ts
+++ b/apps/onboarding/app/guides/guides.ts
@@ -111,7 +111,7 @@ export const GUIDES: ReadonlyArray<Guide> = [
       { type: "h2", text: "4. Get paid properly" },
       {
         type: "p",
-        text: "Make sure checkout supports how your customers actually pay — cards, and where relevant local methods like UPI or wallets. The cost of taking money is your payment processor's fee (roughly 2% for UPI, 2–3% for cards). Watch for platforms that add their own percentage on top of that; over a year, that skim is real money out of a small margin.",
+        text: "Make sure checkout supports how your customers actually pay — cards, and where relevant local methods like UPI or wallets. The cost of taking money is your payment gateway's fee (roughly 2% for UPI, 2–3% for cards — UPI's own merchant discount rate is nil, so that 2% is the gateway's charge rather than a cost of UPI). Watch for platforms that add their own percentage on top of that; over a year, that skim is real money out of a small margin.",
       },
       { type: "h2", text: "5. Tell people — then keep the ones who buy" },
       {

--- a/apps/onboarding/app/help/page.tsx
+++ b/apps/onboarding/app/help/page.tsx
@@ -105,7 +105,7 @@ const CATEGORIES: ReadonlyArray<FaqCategory> = [
       {
         question: "Does Mark8ly take a cut of my sales?",
         answer:
-          "No. We don't add a platform transaction fee on any plan. You pay only your payment processor's standard rate — roughly 2% for UPI and 2–3% for cards — and that's the entire cost of taking a payment.",
+          "No. We don't add a platform transaction fee on any plan. You pay only your payment gateway's standard rate — roughly 2% for UPI and 2–3% for cards — and that's the entire cost of taking a payment.",
       },
       {
         question: "What's the difference between Starter, Studio, and Pro?",

--- a/apps/onboarding/app/page.tsx
+++ b/apps/onboarding/app/page.tsx
@@ -856,7 +856,7 @@ const faqItems = [
   {
     question: "What does Mark8ly take from each sale?",
     answer:
-      "Nothing. Your payment processor charges their standard fee (around 2% for UPI, 2–3% for cards). We don't add anything on top of that.",
+      "Nothing. Your payment gateway charges its standard fee (around 2% for UPI, 2–3% for cards). We don't add anything on top of that.",
   },
   {
     question: "Is there a limit on products?",

--- a/apps/onboarding/app/sell-online-india/page.tsx
+++ b/apps/onboarding/app/sell-online-india/page.tsx
@@ -78,6 +78,35 @@ export default function SellOnlineIndiaPage() {
           ],
         },
         {
+          heading: "The GST and gateway maths nobody puts on the pricing page",
+          body: [
+            "Two things make selling online in India cost more than the headline rate suggests, and neither appears in most comparisons.",
+            "The first is that Shopify Payments is not available in India \u2014 Stripe, which powers it, has not launched here. Indian merchants therefore have to use a third-party gateway such as Razorpay, which is precisely the case where Shopify Basic adds its 2% platform fee. On a Shopify store in India that 2% is not an avoidable option; it is unavoidable, and it sits on top of your gateway's own rate.",
+            "The second is GST. Payment gateway fees attract 18% GST, so a quoted 2% gateway rate costs 2.36% once tax is applied. If you are GST-registered you can generally claim that back as input tax credit, but it is still cash out of the account first, and it is rarely mentioned when a rate is quoted at you.",
+          ],
+          breakdown: {
+            caption: "\u20b91,00,000 of monthly sales, Shopify Basic with a third-party gateway",
+            rows: [
+              { label: "Shopify platform fee", amount: "\u20b92,000", note: "2%, unavoidable \u2014 Shopify Payments is not available in India" },
+              { label: "Gateway fee", amount: "\u20b92,000", note: "around 2%, varies by method and provider" },
+              { label: "GST on the gateway fee", amount: "\u20b9360", note: "18%, reclaimable as input credit if you are registered" },
+            ],
+            total: { label: "Before the subscription", amount: "\u20b94,360", note: "The \u20b92,000 platform fee is the half that buys you nothing." },
+            source: {
+              label: "Shopify's published pricing",
+              url: "https://www.shopify.com/pricing",
+            },
+          },
+        },
+        {
+          heading: "UPI itself costs nothing, and that surprises people",
+          body: [
+            "The merchant discount rate on person-to-merchant UPI payments has been nil since January 2020, under Section 10A of the Payment and Settlement Systems Act, 2007 and Section 269SU of the Income-tax Act, 1961. Accepting UPI is not, in the regulated sense, a cost at all.",
+            "What you pay is your gateway's own fee. Razorpay's published pricing states it plainly \u2014 \u201cZero MDR \u2014 2% platform fee applies\u201d \u2014 the same 2% it charges on cards and wallets. Knowing which of the two you are being charged is worth something, because only one of them is anyone's to negotiate.",
+            "Worth watching: the Taxation and Other Laws (Amendment) Bill, 2026 amended the Act to allow MDR to be notified above a turnover threshold. Neither the rate nor the threshold has been set, and smaller merchants are expected to remain exempt, but it is no longer a settled zero.",
+          ],
+        },
+        {
           heading: "Start today, keep everything",
           body: [
             "You don't need a developer. If you can write an email, you can open a store and be selling by the end of the afternoon — and real humans answer when you get stuck.",

--- a/apps/onboarding/app/shopify-alternative/page.tsx
+++ b/apps/onboarding/app/shopify-alternative/page.tsx
@@ -28,8 +28,8 @@ export default function ShopifyAlternativePage() {
       }
       lede="Mark8ly is a quiet, considered commerce platform with no platform transaction fees, a storefront that looks designed rather than templated, and ninety days to try it before you pay anything."
       intro={[
-        "If you're searching for a Shopify alternative, it's usually for one of two reasons: the fees, or the sameness. Shopify Basic starts around $29 a month and, unless you route every sale through Shopify Payments, adds a 2% platform fee on top of your processor's cut. On thin margins — which is most independent commerce — that 2% is the difference between a good month and a flat one.",
-        "Mark8ly takes nothing from your sales. Your payment processor charges their standard rate (roughly 2% for UPI, 2–3% for cards) and that's the entire cost of taking money. We don't add a platform fee, ever. You keep what you earn, which is the whole point of running your own shop.",
+        "If you're searching for a Shopify alternative, it's usually for one of two reasons: the fees, or the sameness. Shopify Basic is $39 a month, or $29 if you pay yearly, and — unless you route every sale through Shopify Payments — adds a 2% platform fee on top of your gateway's cut. On thin margins — which is most independent commerce — that 2% is the difference between a good month and a flat one.",
+        "Mark8ly takes nothing from your sales. Your payment gateway charges its standard rate (roughly 2% for UPI, 2–3% for cards) and that's the entire cost of taking money. We don't add a platform fee, ever. You keep what you earn, which is the whole point of running your own shop.",
         "The second reason is how Shopify stores look. Most run a handful of the same themes, so a thousand shops share one silhouette. Mark8ly ships one editorial storefront designed by people who've actually sold things — quiet typography, generous whitespace, real attention to product pages — so your shop reads as yours from the first visit.",
       ]}
       competitorName="Shopify"
@@ -78,6 +78,34 @@ export default function ShopifyAlternativePage() {
           ],
         },
         {
+          heading: "What the 2% costs, at real volumes",
+          body: [
+            "Shopify Basic is $39 a month, or $29 if you pay for the year up front. On top of the subscription, Basic adds a 2% fee to every sale unless you route payments through Shopify Payments \u2014 that is a platform fee, charged on top of whatever your payment processor already takes.",
+            "Whether you can avoid it depends entirely on where you are. If Shopify Payments is available to you and you are happy to use it, the 2% disappears. If it is not \u2014 and it is not available in India, among other markets \u2014 the 2% is simply part of the price.",
+          ],
+          breakdown: {
+            caption: "Monthly cost on Shopify Basic with a third-party gateway, by sales volume",
+            rows: [
+              { label: "$2,000 a month in sales", amount: "$79", note: "$39 subscription + $40 platform fee" },
+              { label: "$5,000 a month in sales", amount: "$139", note: "$39 subscription + $100 platform fee" },
+              { label: "$10,000 a month in sales", amount: "$239", note: "$39 subscription + $200 platform fee" },
+              { label: "$20,000 a month in sales", amount: "$439", note: "$39 subscription + $400 platform fee" },
+            ],
+            total: { label: "Mark8ly, at every one of those volumes", amount: "$15", note: "Starter billed yearly. No platform fee, at any volume." },
+            source: {
+              label: "Shopify's published pricing",
+              url: "https://www.shopify.com/pricing",
+            },
+          },
+        },
+        {
+          heading: "Why a percentage is the wrong shape for a fee",
+          body: [
+            "The figures above exclude payment processing on both sides, because both platforms pass that through and it roughly cancels out. What does not cancel is the 2%: it grows with your revenue while the cost of serving you does not. Doubling your sales does not double what a storefront costs to run.",
+            "That is why our pricing is a flat monthly fee and stays one. A good month should be a good month, rather than an invoice that grows to match.",
+          ],
+        },
+        {
           heading: "Switching is low-drama",
           body: [
             "You don't need to be technical to move. If you can write an email, you can open a store on Mark8ly and have it live by the end of the afternoon. When you get stuck, real people answer real messages — no ticket carousel.",
@@ -89,12 +117,12 @@ export default function ShopifyAlternativePage() {
         {
           question: "Does Mark8ly really charge no transaction fees?",
           answer:
-            "Correct. Mark8ly adds nothing to your sales. You pay only your payment processor's standard rate — around 2% for UPI and 2–3% for cards. There is no platform fee on top, on any plan.",
+            "Correct. Mark8ly adds nothing to your sales. You pay only your payment gateway's standard rate — around 2% for UPI and 2–3% for cards. There is no platform fee on top, on any plan.",
         },
         {
           question: "How does the price compare to Shopify?",
           answer:
-            "Plans start at $15 a month billed yearly after a 90-day free trial, with no added transaction fees. Shopify Basic starts around $29 a month with a 3-day trial and a 2% platform fee unless you use Shopify Payments.",
+            "Plans start at $15 a month billed yearly after a 90-day free trial, with no added transaction fees. Shopify Basic is $39 a month ($29 billed yearly) with a 3-day trial, and adds a 2% platform fee unless you use Shopify Payments.",
         },
         {
           question: "Can I use my own domain?",

--- a/apps/onboarding/components/marketing/SeoLanding.tsx
+++ b/apps/onboarding/components/marketing/SeoLanding.tsx
@@ -25,10 +25,46 @@ export interface SeoComparisonRow {
   them: string;
 }
 
+export interface SeoBreakdownRow {
+  label: string;
+  amount: string;
+  /** What the figure applies to, where that is not obvious. */
+  note?: string;
+}
+
+/**
+ * A worked cost example.
+ *
+ * These pages were ~850 words each, and roughly 700 of those were the
+ * same fee philosophy with the competitor's name swapped in
+ * (tesserix/mark8ly#602). Shared boilerplate across near-identical
+ * pages is a low-quality-content marker, and more to the point it is
+ * not useful: "we don't take a cut" is a claim, whereas arithmetic a
+ * seller can check against their own last order is evidence.
+ *
+ * `source` is required, not optional. Every number here is a claim
+ * about somebody else's pricing, and an uncited one is worth less than
+ * no number at all — it invites a reader to assume we picked whichever
+ * figure flattered us.
+ */
+export interface SeoBreakdown {
+  /** Names the example, e.g. "A $53 order — a $45 item plus $8 shipping". */
+  caption: string;
+  rows: ReadonlyArray<SeoBreakdownRow>;
+  total: SeoBreakdownRow;
+  source: { label: string; url: string };
+}
+
 export interface SeoSection {
   heading: string;
   /** One or more body paragraphs. */
   body: ReadonlyArray<string>;
+  /**
+   * Optional worked figures, rendered after the body. Use this for
+   * something that would be *wrong* on the sibling pages — Etsy's
+   * per-order fees do not belong on the Shopify page.
+   */
+  breakdown?: SeoBreakdown;
 }
 
 export interface SeoLandingProps {
@@ -47,6 +83,71 @@ export interface SeoLandingProps {
   faq: ReadonlyArray<FaqItem>;
   ctaHeading: ReactNode;
   ctaBody: string;
+}
+
+/**
+ * Worked figures. Hairline rules rather than a bordered card, per the
+ * design context — and a real <table> because this is tabular data, so
+ * a screen reader should be able to navigate it as one.
+ *
+ * `tabular-nums` matters here specifically: the whole point is that the
+ * amounts line up so a reader can add them and check our total.
+ */
+function Breakdown({ breakdown }: { breakdown: SeoBreakdown }) {
+  return (
+    <div className="mt-8 max-w-2xl overflow-x-auto">
+      <table className="w-full border-collapse text-left text-sm">
+        <caption className="mb-4 text-left text-sm text-foreground">
+          {breakdown.caption}
+        </caption>
+        <tbody>
+          {breakdown.rows.map((row) => (
+            <tr key={row.label} className="border-t border-border-subtle">
+              <th
+                scope="row"
+                className="py-3 pr-6 font-normal text-foreground-secondary"
+              >
+                {row.label}
+                {row.note ? (
+                  <span className="block text-foreground-tertiary">
+                    {row.note}
+                  </span>
+                ) : null}
+              </th>
+              <td className="py-3 text-right tabular-nums text-foreground-secondary">
+                {row.amount}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr className="border-t border-border">
+            <th scope="row" className="py-3 pr-6 text-left text-foreground">
+              {breakdown.total.label}
+              {breakdown.total.note ? (
+                <span className="block font-normal text-foreground-tertiary">
+                  {breakdown.total.note}
+                </span>
+              ) : null}
+            </th>
+            <td className="py-3 text-right tabular-nums text-foreground">
+              {breakdown.total.amount}
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+      <p className="mt-4 text-sm text-foreground-tertiary">
+        Figures from{" "}
+        <a
+          href={breakdown.source.url}
+          className="text-foreground underline decoration-moss-700 decoration-2 underline-offset-4 hover:text-moss-700"
+        >
+          {breakdown.source.label}
+        </a>
+        . Rates change — check before relying on them.
+      </p>
+    </div>
+  );
 }
 
 export function SeoLanding({
@@ -203,6 +304,10 @@ export function SeoLanding({
                       {paragraph}
                     </p>
                   ))}
+
+                  {section.breakdown ? (
+                    <Breakdown breakdown={section.breakdown} />
+                  ) : null}
                 </div>
               </article>
             ))}


### PR DESCRIPTION
Closes #602.

The four comparison pages were ~850 words each, of which roughly 150–200 were page-specific. The rest was the same fee philosophy with the competitor's name swapped. #602's test for a fix is the right one: **each page must carry a block that would be wrong to copy onto its siblings.**

## What each page got

**`/etsy-alternative` — worked fee math on one order.** A $53 order (a $45 item plus $8 shipping): $0.20 listing + $3.45 transaction + $1.84 processing = **$5.49, or 10.4%**. The detail sellers miss is that the 6.5% applies to the total *including shipping*, so charging for postage raises what Etsy takes.

A second section covers Offsite Ads: +15% ($7.95) takes the same order to **$13.44 — just over a quarter**. And the part worth reading twice: opting out is only possible under $10,000 of trailing-twelve-month sales. Cross it once and enrolment is permanent for the life of the shop at 12%, capped at $100/order, and it does **not** lapse if sales later fall back.

The page says plainly that this does not make Etsy a bad place to sell — it has demand you would otherwise have to find. It is a marketplace fee that scales with your success rather than with what it costs to serve you.

**`/shopify-alternative` — the 2% at four volumes.** $79 / $139 / $239 / $439 a month at $2k / $5k / $10k / $20k of sales, against $15 flat. Also states honestly that the 2% *disappears* if you can use Shopify Payments — the fee is conditional, and pretending otherwise would be the kind of claim this PR exists to remove.

**`/sell-online-india` — the two things nobody puts on a pricing page.** Shopify Payments **is not available in India** (Stripe hasn't launched there), so Indian merchants must use a third-party gateway — which is exactly the case that triggers Shopify's 2%. There it is not an avoidable option. Plus **18% GST on gateway fees**, so a quoted 2% costs 2.36% in cash before input credit. Worked at ₹1,00,000/month: ₹2,000 + ₹2,000 + ₹360 = **₹4,360**, of which the ₹2,000 platform fee buys nothing.

**`/ecommerce-for-makers` — why generic storefront software fits badly.** One-of-a-thing stock that is not an error state; made-to-order where no stock number is meaningful; variants that are physical (ring sizes, timber grain, dye lots) rather than a dropdown, where the variation is often *why* someone is buying; photography doing the job the customer's hands would do; and postage on one-off dimensions.

None of these four blocks would be true on another of the pages. That is the test.

## New: a cited worked-cost table

`SeoSection` gains an optional `breakdown` — caption, rows, total, and a **required** `source`.

Required, not optional, on purpose: every figure here is a claim about someone else's pricing, and an uncited one is worth less than no number at all, because it invites the reader to assume we picked whichever figure flattered us. Rendered as a real `<table>` with `<caption>` and row headers (it is tabular data, so it should be navigable as such), hairline rules rather than a card, and `tabular-nums` so a reader can add the column and check our total.

## Two stale claims fixed while in here

Not strictly #602, but both were wrong and adjacent:

- **`$29 a month` for Shopify Basic was the annual rate presented as the headline.** It is $39 monthly, $29 billed yearly. This *understated* a competitor and weakened our own comparison.
- **Six places still called the ~2% "your payment processor's rate for UPI".** #611 established that UPI's own MDR is nil and the 2% is the *gateway's* fee; only two surfaces were corrected then. The other six (`/`, `/help`, the guides, and two spots on `/shopify-alternative`) now say gateway.

## Verification

```
npm run check-types -w @mark8ly/onboarding  → clean
npm test (apps/onboarding)                  → 91 passed
npm run build -w @mark8ly/onboarding        → compiled
```

Word counts from the built HTML, against #602's own baseline (these include shared nav/footer, so the body gain is proportionally larger):

| Page | Before | After |
|---|---:|---:|
| `/shopify-alternative` | 872 | 1,175 |
| `/etsy-alternative` | 840 | 1,212 |
| `/sell-online-india` | 829 | 1,289 |
| `/ecommerce-for-makers` | 863 | 1,123 |

Every table's arithmetic was recomputed by hand rather than trusted: 6.5% × $53 = $3.445; 3% × $53 + $0.25 = $1.84; sum $5.49 = 10.36% of $53; +15% ($7.95) = $13.44 = 25.4%. Shopify and GST rows likewise.

Rendered and screenshotted at 1000px — no horizontal overflow, totals aligned, source link on-brand.

## Honest limits

- **These are still ~1,200 words, not the ~2,500 #153 claimed.** Length was never the bar; distinctiveness was, and #602's "Done when" is about content that would be wrong on a sibling page.
- **This does not fix the structural problem #602 names.** "shopify alternative" and "etsy alternative" SERPs are dominated by affiliate listicles, and a single-vendor page is the wrong page type for those head terms. This makes the pages better at the bottom-funnel modifiers they can actually win.
- **`etsy.com/legal/fees/` returns 403 to non-browser clients**, so CI cannot verify that link. It resolves normally in a browser and is Etsy's own authoritative page, so it is cited anyway — but it will not survive an automated link check.
- Rates change. Every table says so, next to its source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YB1BFjWgctpHPLb1knCRKH