### PR TITLE
feat(carriersecrets): add carrier-secrets-backfill to migrate gsm:// references to OpenBao (#319 phase 3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	  go test -tags=integration -p 1 \
 	    . \
 	    ./cmd/backfill-email/... \
+	    ./cmd/carrier-secrets-backfill/... \
 	    ./internal/apikeys/... \
 	    ./internal/arbitrage/... \
 	    ./internal/attestation/... \

--- a/services/marketplace-api/Dockerfile
+++ b/services/marketplace-api/Dockerfile
@@ -26,7 +26,9 @@ RUN go build -trimpath -ldflags="-s -w" \
  && go build -trimpath -ldflags="-s -w" \
       -o /out/stock-hold-sweep-cron ./cmd/stock-hold-sweep-cron \
  && go build -trimpath -ldflags="-s -w" \
-      -o /out/webhook-delivery-prune-cron ./cmd/webhook-delivery-prune-cron
+      -o /out/webhook-delivery-prune-cron ./cmd/webhook-delivery-prune-cron \
+ && go build -trimpath -ldflags="-s -w" \
+      -o /out/carrier-secrets-backfill ./cmd/carrier-secrets-backfill
 
 # ─── migrate ────────────────────────────────────────────────────────────
 # Standalone image used by the K8s Job pattern.
@@ -51,5 +53,12 @@ COPY --from=builder --chown=10001:10001 /out/migrate /usr/local/bin/migrate
 COPY --from=builder --chown=10001:10001 /out/refund-sweep-cron /usr/local/bin/refund-sweep-cron
 COPY --from=builder --chown=10001:10001 /out/stock-hold-sweep-cron /usr/local/bin/stock-hold-sweep-cron
 COPY --from=builder --chown=10001:10001 /out/webhook-delivery-prune-cron /usr/local/bin/webhook-delivery-prune-cron
+# carrier-secrets-backfill is a ONE-OFF migration tool, not a CronJob: it is
+# run by hand as a Job when credentials need moving from GCP Secret Manager to
+# OpenBao (mark8ly#319 phase 3). It defaults to --dry-run and refuses to run
+# unless SHIPPING_SECRET_STORE=bao. Shipped in the image so it runs in-cluster
+# under the real ServiceAccount, rather than from an operator's laptop with
+# production credentials port-forwarded to it.
+COPY --from=builder --chown=10001:10001 /out/carrier-secrets-backfill /usr/local/bin/carrier-secrets-backfill
 EXPOSE 8091
 CMD ["/usr/local/bin/marketplace-api"]

--- a/services/marketplace-api/cmd/carrier-secrets-backfill/backfill.go
+++ b/services/marketplace-api/cmd/carrier-secrets-backfill/backfill.go
@@ -1,0 +1,142 @@
+// Command carrier-secrets-backfill migrates existing gsm:// (GCP Secret
+// Manager) credential references to bao:// (OpenBao) references. This is
+// phase 3 of the OpenBao migration: the admin engine's lazy rewrap
+// (carriersecrets.ChainStore.MaybeRewrap) only fires on save, and is
+// refused outright on the storefront engine by design (no OpenBao write
+// grant there — least privilege). Rows that are never re-saved never
+// migrate on their own; this job is what completes them.
+//
+// THESE ARE LIVE PAYMENT CREDENTIALS IN PRODUCTION. The safety property
+// this job relies on is Backfiller.migrateRow's read-back verification: a
+// row's DB reference is only ever updated after the NEW reference is
+// proven, by an actual read, to resolve to the exact same plaintext the
+// OLD reference resolved to. The old GCP SM secret is never deleted (see
+// Backfiller.migrateRow's doc comment) — a bad migration is recoverable by
+// hand precisely because that old copy is still there and the DB reference
+// pointing at it is only ever swapped after the new one is proven equal.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/mark8ly/marketplace-api/internal/carriersecrets"
+)
+
+// Result summarizes one backfill run.
+type Result struct {
+	Examined int
+	Skipped  int
+	Migrated int
+	Failed   int
+}
+
+// Backfiller drives the gsm:// -> bao:// migration over every row RowStore
+// returns.
+type Backfiller struct {
+	Rows   RowStore
+	Store  carriersecrets.Store
+	DryRun bool
+	Logger *slog.Logger
+}
+
+func (b *Backfiller) logger() *slog.Logger {
+	if b.Logger != nil {
+		return b.Logger
+	}
+	return slog.Default()
+}
+
+// Run walks every row RowStore.FetchAll returns, exactly once, in fetch
+// order. Per row:
+//
+//  1. Skip unless IsGSMRef(row.Ref) — bao://, inline (noop:/aes:), and
+//     empty values are left untouched. This is what makes the job
+//     idempotent: a row already migrated (or never on GCP SM at all)
+//     produces zero writes on a repeat run.
+//  2. In dry-run mode, log what WOULD migrate and count it under
+//     Migrated without touching the Store or the DB.
+//  3. Otherwise call migrateRow, which performs the actual
+//     get/put/verify/update sequence.
+func (b *Backfiller) Run(ctx context.Context) (Result, error) {
+	rows, err := b.Rows.FetchAll(ctx)
+	if err != nil {
+		return Result{}, fmt.Errorf("carrier-secrets-backfill: fetch rows: %w", err)
+	}
+
+	var res Result
+	log := b.logger()
+	for _, row := range rows {
+		res.Examined++
+
+		if !carriersecrets.IsGSMRef(row.Ref) {
+			res.Skipped++
+			continue
+		}
+
+		if b.DryRun {
+			newRef := carriersecrets.FormatBaoReference(row.Scope)
+			log.Info("carrier-secrets-backfill: dry-run would migrate",
+				"table", row.Table, "column", row.Column,
+				"tenant_id", row.Scope.TenantID, "domain", row.Scope.Domain,
+				"provider", row.Scope.Provider, "field", row.Scope.Field,
+				"old_ref", row.Ref, "new_ref", newRef)
+			res.Migrated++
+			continue
+		}
+
+		if err := b.migrateRow(ctx, row); err != nil {
+			res.Failed++
+			log.Error("carrier-secrets-backfill: migration failed — DB reference left unchanged",
+				"table", row.Table, "column", row.Column,
+				"tenant_id", row.Scope.TenantID, "domain", row.Scope.Domain,
+				"provider", row.Scope.Provider, "field", row.Scope.Field,
+				"old_ref_len", len(row.Ref), "err", err)
+			continue
+		}
+		res.Migrated++
+	}
+	return res, nil
+}
+
+// migrateRow performs the get -> put -> verify -> update sequence for one
+// row, in that exact order. It updates the DB reference IF AND ONLY IF the
+// read-back through the newly written reference reproduces, byte for byte,
+// the plaintext read through the old one.
+//
+// This is the safety property that makes the whole operation
+// reversible-by-construction: the old GCP SM secret is never deleted by
+// this job (a later phase's decision, not this one's — see package doc),
+// so as long as the DB reference isn't swapped until the new copy is
+// PROVEN correct, a migration that fails at any step leaves the row
+// exactly as readable as it was before this job ran. Never reorder or skip
+// the verification read — that is what turns "we wrote something to
+// OpenBao" into "we confirmed OpenBao actually has the right value" before
+// the one thing that can't be undone cheaply (the DB write) happens.
+//
+// Never logs plaintext — only references, lengths, and outcomes.
+func (b *Backfiller) migrateRow(ctx context.Context, row Row) error {
+	plaintext, err := b.Store.Get(ctx, row.Ref)
+	if err != nil {
+		return fmt.Errorf("read old reference: %w", err)
+	}
+
+	newRef, err := b.Store.Put(ctx, row.Scope, plaintext)
+	if err != nil {
+		return fmt.Errorf("write new reference: %w", err)
+	}
+
+	verify, err := b.Store.Get(ctx, newRef)
+	if err != nil {
+		return fmt.Errorf("read back new reference for verification: %w", err)
+	}
+	if verify != plaintext {
+		return fmt.Errorf("read-back verification failed: new reference %q does not reproduce the original value — DB reference left unchanged", newRef)
+	}
+
+	if err := b.Rows.UpdateReference(ctx, row, newRef); err != nil {
+		return fmt.Errorf("update db reference: %w", err)
+	}
+	return nil
+}

--- a/services/marketplace-api/cmd/carrier-secrets-backfill/backfill_test.go
+++ b/services/marketplace-api/cmd/carrier-secrets-backfill/backfill_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/carriersecrets"
+)
+
+const (
+	testProjectID = "test-project"
+	testPrefix    = "mark8ly-test"
+)
+
+// recordingRowStore is a RowStore fake that hands back a fixed set of rows
+// and records every UpdateReference call, so tests can assert "the DB was
+// (or was not) written" directly instead of inferring it from a real
+// database.
+type recordingRowStore struct {
+	rows    []Row
+	updates []recordedUpdate
+}
+
+type recordedUpdate struct {
+	row    Row
+	newRef string
+}
+
+func (f *recordingRowStore) FetchAll(context.Context) ([]Row, error) {
+	return f.rows, nil
+}
+
+func (f *recordingRowStore) UpdateReference(_ context.Context, row Row, newRef string) error {
+	f.updates = append(f.updates, recordedUpdate{row: row, newRef: newRef})
+	return nil
+}
+
+// newTestChainStore builds a ChainStore around two independent FakeClients
+// (bao-primary), exactly the shape internal/carriersecrets/chain_test.go
+// uses, so tests exercise the real routing/Put/Get logic rather than a
+// hand-rolled Store.
+func newTestChainStore() (*carriersecrets.ChainStore, *carriersecrets.FakeClient, *carriersecrets.FakeClient) {
+	bao := carriersecrets.NewFakeClient()
+	gcp := carriersecrets.NewFakeClient()
+	store := carriersecrets.NewChainStore(carriersecrets.ChainConfig{
+		Bao:          bao,
+		GCP:          gcp,
+		Primary:      carriersecrets.BackendBao,
+		GCPProjectID: testProjectID,
+		GCPPrefix:    testPrefix,
+	})
+	return store, bao, gcp
+}
+
+// seedGSMRow writes plaintext into the GCP fake at the resource a gsm://
+// reference for scope would point at, and returns that reference — i.e. it
+// recreates "a row still on GCP SM from before the OpenBao cutover".
+func seedGSMRow(t *testing.T, gcp *carriersecrets.FakeClient, scope carriersecrets.Scope, plaintext string) string {
+	t.Helper()
+	resource := carriersecrets.SecretResource(testProjectID, testPrefix, scope)
+	if err := gcp.CreateOrAddVersion(context.Background(), resource, []byte(plaintext)); err != nil {
+		t.Fatalf("seed gsm secret: %v", err)
+	}
+	return carriersecrets.FormatReference(testProjectID, testPrefix, scope)
+}
+
+func scopeFor(field string) carriersecrets.Scope {
+	return carriersecrets.Scope{TenantID: "tenant-1", Domain: "payment", Provider: "razorpay", Field: field}
+}
+
+// TestBackfill_SkipsNonGSMReferences asserts bao://, inline, and empty
+// values are left completely untouched — no Store call, no DB update —
+// while a genuine gsm:// row in the same batch is still migrated. This is
+// the idempotency property: re-running the backfill after (or alongside)
+// rows already on bao:// must be a no-op for those rows.
+func TestBackfill_SkipsNonGSMReferences(t *testing.T) {
+	store, _, gcp := newTestChainStore()
+	ctx := context.Background()
+
+	gsmScope := scopeFor("api_key")
+	gsmRef := seedGSMRow(t, gcp, gsmScope, "the-plaintext-secret")
+
+	rows := &recordingRowStore{
+		rows: []Row{
+			{Table: "payment_gateway_configs", Column: "api_key_encrypted", ID: "row-1", Ref: gsmRef, Scope: gsmScope},
+			{Table: "payment_gateway_configs", Column: "secret_key_encrypted", ID: "row-1", Ref: carriersecrets.FormatBaoReference(scopeFor("secret_key")), Scope: scopeFor("secret_key")},
+			{Table: "payment_gateway_configs", Column: "webhook_secret_encrypted", ID: "row-1", Ref: "noop:already-inline", Scope: scopeFor("webhook_secret")},
+			{Table: "shipping_carrier_configs", Column: "api_key_encrypted", ID: "row-2", Ref: "", Scope: scopeFor("api_key")},
+		},
+	}
+
+	b := &Backfiller{Rows: rows, Store: store, DryRun: false}
+	res, err := b.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if res.Examined != 4 {
+		t.Fatalf("Examined = %d, want 4", res.Examined)
+	}
+	if res.Skipped != 3 {
+		t.Fatalf("Skipped = %d, want 3 (bao://, inline, empty)", res.Skipped)
+	}
+	if res.Migrated != 1 {
+		t.Fatalf("Migrated = %d, want 1 (the gsm:// row)", res.Migrated)
+	}
+	if res.Failed != 0 {
+		t.Fatalf("Failed = %d, want 0", res.Failed)
+	}
+	if len(rows.updates) != 1 {
+		t.Fatalf("DB updates = %d, want exactly 1 (only the gsm:// row)", len(rows.updates))
+	}
+	if rows.updates[0].row.ID != "row-1" || rows.updates[0].row.Column != "api_key_encrypted" {
+		t.Fatalf("unexpected row updated: %+v", rows.updates[0].row)
+	}
+}
+
+// TestBackfill_DryRunWritesNothing asserts dry-run makes no writes of any
+// kind: not to the underlying secret backend, and not to the DB. It still
+// reports what it would have done.
+func TestBackfill_DryRunWritesNothing(t *testing.T) {
+	store, bao, gcp := newTestChainStore()
+	ctx := context.Background()
+
+	scope := scopeFor("api_key")
+	ref := seedGSMRow(t, gcp, scope, "the-plaintext-secret")
+
+	rows := &recordingRowStore{
+		rows: []Row{{Table: "payment_gateway_configs", Column: "api_key_encrypted", ID: "row-1", Ref: ref, Scope: scope}},
+	}
+
+	b := &Backfiller{Rows: rows, Store: store, DryRun: true}
+	res, err := b.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if res.Examined != 1 || res.Migrated != 1 || res.Skipped != 0 || res.Failed != 0 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if len(rows.updates) != 0 {
+		t.Fatalf("DB updates = %d, want 0 under dry-run", len(rows.updates))
+	}
+	baoPath := carriersecrets.BaoPath(scope)
+	if bao.Has(baoPath) {
+		t.Fatalf("bao path %q was written under dry-run — it must not be", baoPath)
+	}
+}
+
+// mismatchStore wraps a real ChainStore but corrupts the value it just
+// wrote on every Put, so the caller's subsequent verification read sees a
+// different plaintext than what it asked to store. This is the fixture for
+// TestBackfill_VerifiesReadBackBeforeUpdating — the single most important
+// test in this package.
+type mismatchStore struct {
+	inner *carriersecrets.ChainStore
+	bao   *carriersecrets.FakeClient
+}
+
+func (m *mismatchStore) Get(ctx context.Context, ref string) (string, error) {
+	return m.inner.Get(ctx, ref)
+}
+
+func (m *mismatchStore) Put(ctx context.Context, scope carriersecrets.Scope, plaintext string) (string, error) {
+	ref, err := m.inner.Put(ctx, scope, plaintext)
+	if err != nil {
+		return "", err
+	}
+	// Immediately overwrite the value that was just written so a
+	// subsequent Get(ref) returns something other than plaintext —
+	// simulating "the write silently landed wrong" without needing a
+	// real broken backend.
+	path := carriersecrets.BaoPath(scope)
+	if err := m.bao.CreateOrAddVersion(ctx, path, []byte("corrupted-does-not-match-original")); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func (m *mismatchStore) Destroy(ctx context.Context, ref string) error {
+	return m.inner.Destroy(ctx, ref)
+}
+
+var _ carriersecrets.Store = (*mismatchStore)(nil)
+
+// TestBackfill_VerifiesReadBackBeforeUpdating is the safety-critical test:
+// when the read-back through the new reference does not reproduce the
+// original plaintext, the DB must NOT be updated and the row must count as
+// failed, not migrated. This is what makes a migration recoverable — the
+// old gsm:// reference (and the GCP secret behind it) is left exactly as
+// it was.
+func TestBackfill_VerifiesReadBackBeforeUpdating(t *testing.T) {
+	inner, _, gcp := newTestChainStore()
+	bao := carriersecrets.NewFakeClient()
+	// Rebuild inner around the SAME gcp fake but a fresh bao fake so
+	// mismatchStore can corrupt independently of what Put already wrote.
+	inner = carriersecrets.NewChainStore(carriersecrets.ChainConfig{
+		Bao:          bao,
+		GCP:          gcp,
+		Primary:      carriersecrets.BackendBao,
+		GCPProjectID: testProjectID,
+		GCPPrefix:    testPrefix,
+	})
+	store := &mismatchStore{inner: inner, bao: bao}
+
+	ctx := context.Background()
+	scope := scopeFor("api_key")
+	ref := seedGSMRow(t, gcp, scope, "the-plaintext-secret")
+
+	rows := &recordingRowStore{
+		rows: []Row{{Table: "payment_gateway_configs", Column: "api_key_encrypted", ID: "row-1", Ref: ref, Scope: scope}},
+	}
+
+	b := &Backfiller{Rows: rows, Store: store, DryRun: false}
+	res, err := b.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if res.Failed != 1 {
+		t.Fatalf("Failed = %d, want 1", res.Failed)
+	}
+	if res.Migrated != 0 {
+		t.Fatalf("Migrated = %d, want 0 — a verification mismatch must never count as migrated", res.Migrated)
+	}
+	if len(rows.updates) != 0 {
+		t.Fatalf("DB updates = %d, want 0 — the DB must never be updated when read-back verification fails", len(rows.updates))
+	}
+}
+
+func TestRequireBaoPrimary(t *testing.T) {
+	if err := requireBaoPrimary("bao"); err != nil {
+		t.Fatalf("requireBaoPrimary(bao) = %v, want nil", err)
+	}
+	for _, mode := range []string{"gcpsm", "inline", "", "bogus"} {
+		if err := requireBaoPrimary(mode); err == nil {
+			t.Fatalf("requireBaoPrimary(%q) = nil, want an error", mode)
+		}
+	}
+}

--- a/services/marketplace-api/cmd/carrier-secrets-backfill/main.go
+++ b/services/marketplace-api/cmd/carrier-secrets-backfill/main.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"os"
+
+	"github.com/mark8ly/marketplace-api/internal/carriersecrets"
+	"github.com/mark8ly/marketplace-api/internal/crypto"
+	"github.com/mark8ly/marketplace-api/pkg/config"
+	"github.com/mark8ly/marketplace-api/pkg/db"
+)
+
+func main() {
+	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	dryRun := flag.Bool("dry-run", true,
+		"report what would migrate without writing anything to the Store or the DB. "+
+			"Default true — pass -dry-run=false to actually write.")
+	flag.Parse()
+
+	// LoadCarrierSecretJob mirrors cmd/refund-sweep-cron: it reads only
+	// DATABASE_URL / SHIPPING_SECRET_STORE / GCP_PROJECT_ID /
+	// SECRET_NAME_PREFIX / OPENBAO_ADDR / OPENBAO_ROLE / OPENBAO_KV_MOUNT /
+	// ENCRYPTION_MODE / ENCRYPTION_KEY, not the full config.Load() — this
+	// job never touches FGA, internal auth, or customer sessions.
+	cfg, err := config.LoadCarrierSecretJob()
+	if err != nil {
+		log.Error("carrier-secrets-backfill: config load failed", "err", err)
+		os.Exit(1)
+	}
+
+	// Running this job under any mode other than "bao" cannot produce
+	// bao:// references — see requireBaoPrimary's doc comment.
+	if err := requireBaoPrimary(cfg.ShippingSecretStore); err != nil {
+		log.Error("carrier-secrets-backfill: refusing to run", "err", err)
+		os.Exit(1)
+	}
+
+	conn, err := db.Open(cfg.DatabaseURL)
+	if err != nil {
+		log.Error("carrier-secrets-backfill: db open failed", "err", err)
+		os.Exit(1)
+	}
+
+	// Encryptor for legacy inline (noop:/aes:) references the Store may
+	// still need to decode on read — mirrors cmd/refund-sweep-cron and
+	// cmd/marketplace-api's construction exactly.
+	var apiKeyEncryptor crypto.Encryptor
+	switch cfg.EncryptionMode {
+	case "aes":
+		if cfg.EncryptionKey == "" {
+			log.Error("carrier-secrets-backfill: ENCRYPTION_KEY required when ENCRYPTION_MODE=aes")
+			os.Exit(1)
+		}
+		key, decodeErr := crypto.DecodeKey(cfg.EncryptionKey)
+		if decodeErr != nil {
+			log.Error("carrier-secrets-backfill: invalid ENCRYPTION_KEY", "err", decodeErr)
+			os.Exit(1)
+		}
+		enc, aesErr := crypto.NewAESEncryptor(key)
+		if aesErr != nil {
+			log.Error("carrier-secrets-backfill: create AES encryptor failed", "err", aesErr)
+			os.Exit(1)
+		}
+		apiKeyEncryptor = enc
+	default:
+		apiKeyEncryptor = crypto.NewNoopEncryptor()
+	}
+
+	carrierSecretCounter := func(label string, n int64) {
+		log.Info("carriersecrets: metric", "label", label, "count", n)
+	}
+	secretStore, degraded, buildErr := carriersecrets.Build(context.Background(), carriersecrets.BuildParams{
+		Mode:         cfg.ShippingSecretStore,
+		GCPProjectID: cfg.GCPProjectID,
+		SecretPrefix: cfg.SecretNamePrefix,
+		OpenBaoAddr:  cfg.OpenBaoAddr,
+		OpenBaoMount: cfg.OpenBaoKVMount,
+		OpenBaoRole:  cfg.OpenBaoRole,
+		Encryptor:    apiKeyEncryptor,
+		Logger:       log,
+		Counter:      carrierSecretCounter,
+	})
+	if buildErr != nil {
+		log.Error("carrier-secrets-backfill: carrier secret store build failed", "err", buildErr)
+		os.Exit(1)
+	}
+	// A store degraded to InlineStore cannot resolve gsm:// references
+	// (it errors loudly instead) and cannot write bao:// ones either —
+	// running the backfill against it would fail every row. Fatal here,
+	// same reasoning as cmd/refund-sweep-cron.
+	if degraded {
+		log.Error("carrier-secrets-backfill: carrier secret store degraded to inline — refusing to run a backfill that cannot resolve gsm:// or write bao:// references",
+			"shipping_secret_store", cfg.ShippingSecretStore)
+		os.Exit(1)
+	}
+
+	b := &Backfiller{
+		Rows:   newGormRowStore(conn),
+		Store:  secretStore,
+		DryRun: *dryRun,
+		Logger: log,
+	}
+
+	res, err := b.Run(context.Background())
+	if err != nil {
+		log.Error("carrier-secrets-backfill: run failed", "err", err)
+		os.Exit(1)
+	}
+
+	log.Info("carrier-secrets-backfill: done",
+		"dry_run", *dryRun,
+		"examined", res.Examined,
+		"skipped", res.Skipped,
+		"migrated", res.Migrated,
+		"failed", res.Failed)
+
+	if res.Failed > 0 {
+		os.Exit(1)
+	}
+}

--- a/services/marketplace-api/cmd/carrier-secrets-backfill/mode.go
+++ b/services/marketplace-api/cmd/carrier-secrets-backfill/mode.go
@@ -1,0 +1,19 @@
+package main
+
+import "fmt"
+
+// requireBaoPrimary refuses to run the backfill unless mode is exactly
+// "bao". Running it under any other mode would not produce bao://
+// references: under "gcpsm" every migrated row's Put writes back to GCP SM,
+// "migrating" gsm:// to gsm:// — a pointless write against live payment
+// credentials that still leaves the row unmigrated. Under "inline" there is
+// no per-tenant reference to migrate at all. The only mode where this job's
+// purpose (gsm:// -> bao://) is even meaningful is "bao".
+func requireBaoPrimary(mode string) error {
+	if mode != "bao" {
+		return fmt.Errorf(
+			"carrier-secrets-backfill: refusing to run — SHIPPING_SECRET_STORE=%q, must be %q (running under any other mode cannot produce bao:// references)",
+			mode, "bao")
+	}
+	return nil
+}

--- a/services/marketplace-api/cmd/carrier-secrets-backfill/rowstore.go
+++ b/services/marketplace-api/cmd/carrier-secrets-backfill/rowstore.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/carriersecrets"
+)
+
+// Row is one migratable credential slot: a single (table, column) cell
+// whose value carriersecrets.Scope maps 1:1 to one secret. Multiple Rows
+// can share the same ID (a payment_gateway_configs row with all three of
+// api_key/secret_key/webhook_secret populated becomes three Rows).
+type Row struct {
+	// Table and Column name the DB cell this Row was read from and will be
+	// written back to. Both are always one of the fixed literals this
+	// package produces — never derived from external input — so passing
+	// Column into a dynamic gorm Update is safe.
+	Table  string
+	Column string
+	// ID is the row's primary key, as its canonical string form.
+	ID string
+	// Scope is the (tenant, domain, provider, field) tuple this cell
+	// resolves to — see the per-table *Rows functions below for exactly
+	// how each table's columns map onto it.
+	Scope carriersecrets.Scope
+	// Ref is the cell's current value: "", a bao:// or gsm:// reference,
+	// or legacy inline ciphertext. The backfill only acts on gsm:// values
+	// — see Backfiller.Run.
+	Ref string
+}
+
+// RowStore is the DB access surface the backfill needs. Production wires
+// gormRowStore against the real schema; tests use a recording fake so
+// dry-run and verification-failure behaviour can be asserted without a
+// database.
+type RowStore interface {
+	// FetchAll returns every migratable credential cell across all four
+	// tracked tables, regardless of what Ref currently holds — the
+	// gsm://-only filter is Backfiller.Run's job, not the fetch's, so
+	// unit tests can feed it a mix of bao:///inline/empty/gsm:// rows and
+	// assert on the skip behaviour directly.
+	FetchAll(ctx context.Context) ([]Row, error)
+	// UpdateReference persists newRef into row's own (table, column, id).
+	// Callers MUST have already verified newRef round-trips to the same
+	// plaintext as row.Ref before calling this — see Backfiller.migrateRow.
+	UpdateReference(ctx context.Context, row Row, newRef string) error
+}
+
+// gormRowStore implements RowStore against the live marketplace-api schema.
+type gormRowStore struct {
+	db *gorm.DB
+}
+
+func newGormRowStore(db *gorm.DB) *gormRowStore { return &gormRowStore{db: db} }
+
+// ─────────────────────────────────────────────────────────────────────────
+// payment_gateway_configs — internal/handlers/admin/settings.go:551-558
+// writes api_key/secret_key/webhook_secret under Domain "payment" with the
+// row's own `provider` column as Scope.Provider.
+// ─────────────────────────────────────────────────────────────────────────
+
+type paymentGatewayConfigRow struct {
+	ID                     uuid.UUID `gorm:"column:id"`
+	TenantID               uuid.UUID `gorm:"column:tenant_id"`
+	Provider               string    `gorm:"column:provider"`
+	APIKeyEncrypted        string    `gorm:"column:api_key_encrypted"`
+	SecretKeyEncrypted     string    `gorm:"column:secret_key_encrypted"`
+	WebhookSecretEncrypted string    `gorm:"column:webhook_secret_encrypted"`
+}
+
+func (paymentGatewayConfigRow) TableName() string { return "payment_gateway_configs" }
+
+// paymentRows derives the three migratable cells of one
+// payment_gateway_configs row. Kept as a pure function (no DB, no Store) so
+// the scope mapping can be unit-tested directly against BaoPath.
+func paymentRows(r paymentGatewayConfigRow) []Row {
+	id := r.ID.String()
+	tenant := r.TenantID.String()
+	scope := func(field string) carriersecrets.Scope {
+		return carriersecrets.Scope{TenantID: tenant, Domain: "payment", Provider: r.Provider, Field: field}
+	}
+	return []Row{
+		{Table: "payment_gateway_configs", Column: "api_key_encrypted", ID: id, Ref: r.APIKeyEncrypted, Scope: scope("api_key")},
+		{Table: "payment_gateway_configs", Column: "secret_key_encrypted", ID: id, Ref: r.SecretKeyEncrypted, Scope: scope("secret_key")},
+		{Table: "payment_gateway_configs", Column: "webhook_secret_encrypted", ID: id, Ref: r.WebhookSecretEncrypted, Scope: scope("webhook_secret")},
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// shipping_carrier_configs — internal/handlers/admin/settings.go:~718-725
+// (ShippingSettingsHandler.putCredential) writes api_key/secret_key under
+// Domain "shipping" with the row's own `provider` column (NOT `carrier` —
+// confirmed against internal/shipping/repository.go's CarrierConfig and
+// internal/handlers/storefront/shipping_rates.go's carrierConfigRow, both
+// of which tag the same table's provider column as `provider`).
+// ─────────────────────────────────────────────────────────────────────────
+
+type shippingCarrierConfigRow struct {
+	ID                 uuid.UUID `gorm:"column:id"`
+	TenantID           uuid.UUID `gorm:"column:tenant_id"`
+	Provider           string    `gorm:"column:provider"`
+	APIKeyEncrypted    string    `gorm:"column:api_key_encrypted"`
+	SecretKeyEncrypted string    `gorm:"column:secret_key_encrypted"`
+}
+
+func (shippingCarrierConfigRow) TableName() string { return "shipping_carrier_configs" }
+
+func shippingRows(r shippingCarrierConfigRow) []Row {
+	id := r.ID.String()
+	tenant := r.TenantID.String()
+	scope := func(field string) carriersecrets.Scope {
+		return carriersecrets.Scope{TenantID: tenant, Domain: "shipping", Provider: r.Provider, Field: field}
+	}
+	return []Row{
+		{Table: "shipping_carrier_configs", Column: "api_key_encrypted", ID: id, Ref: r.APIKeyEncrypted, Scope: scope("api_key")},
+		{Table: "shipping_carrier_configs", Column: "secret_key_encrypted", ID: id, Ref: r.SecretKeyEncrypted, Scope: scope("secret_key")},
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// tax_provider_configs — internal/handlers/admin/settings.go:~1440-1447
+// (TaxSettingsHandler.putCredential) writes api_key under Domain "tax" with
+// the row's own `provider` column.
+// ─────────────────────────────────────────────────────────────────────────
+
+type taxProviderConfigRow struct {
+	ID              uuid.UUID `gorm:"column:id"`
+	TenantID        uuid.UUID `gorm:"column:tenant_id"`
+	Provider        string    `gorm:"column:provider"`
+	APIKeyEncrypted string    `gorm:"column:api_key_encrypted"`
+}
+
+func (taxProviderConfigRow) TableName() string { return "tax_provider_configs" }
+
+func taxRows(r taxProviderConfigRow) []Row {
+	id := r.ID.String()
+	tenant := r.TenantID.String()
+	return []Row{
+		{
+			Table: "tax_provider_configs", Column: "api_key_encrypted", ID: id, Ref: r.APIKeyEncrypted,
+			Scope: carriersecrets.Scope{TenantID: tenant, Domain: "tax", Provider: r.Provider, Field: "api_key"},
+		},
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// custom_domains — internal/domain/service.go:150-155 (scopeForCFToken)
+// writes cf_api_token_encrypted under Domain "platform", Provider fixed to
+// "cloudflare", and Field set to the row's own FQDN (the `domain` column) —
+// NOT a fixed field name, since a tenant can register multiple custom
+// domains and each needs its own secret slot.
+// ─────────────────────────────────────────────────────────────────────────
+
+type customDomainRow struct {
+	ID                  uuid.UUID `gorm:"column:id"`
+	TenantID            uuid.UUID `gorm:"column:tenant_id"`
+	Domain              string    `gorm:"column:domain"`
+	CFAPITokenEncrypted string    `gorm:"column:cf_api_token_encrypted"`
+}
+
+func (customDomainRow) TableName() string { return "custom_domains" }
+
+func domainRows(r customDomainRow) []Row {
+	return []Row{
+		{
+			Table: "custom_domains", Column: "cf_api_token_encrypted", ID: r.ID.String(), Ref: r.CFAPITokenEncrypted,
+			Scope: carriersecrets.Scope{TenantID: r.TenantID.String(), Domain: "platform", Provider: "cloudflare", Field: r.Domain},
+		},
+	}
+}
+
+// FetchAll queries all four tracked tables and flattens every row into its
+// migratable cells.
+func (g *gormRowStore) FetchAll(ctx context.Context) ([]Row, error) {
+	var out []Row
+
+	var payments []paymentGatewayConfigRow
+	if err := g.db.WithContext(ctx).Find(&payments).Error; err != nil {
+		return nil, fmt.Errorf("query payment_gateway_configs: %w", err)
+	}
+	for _, r := range payments {
+		out = append(out, paymentRows(r)...)
+	}
+
+	var shipping []shippingCarrierConfigRow
+	if err := g.db.WithContext(ctx).Find(&shipping).Error; err != nil {
+		return nil, fmt.Errorf("query shipping_carrier_configs: %w", err)
+	}
+	for _, r := range shipping {
+		out = append(out, shippingRows(r)...)
+	}
+
+	var tax []taxProviderConfigRow
+	if err := g.db.WithContext(ctx).Find(&tax).Error; err != nil {
+		return nil, fmt.Errorf("query tax_provider_configs: %w", err)
+	}
+	for _, r := range tax {
+		out = append(out, taxRows(r)...)
+	}
+
+	var domains []customDomainRow
+	if err := g.db.WithContext(ctx).Find(&domains).Error; err != nil {
+		return nil, fmt.Errorf("query custom_domains: %w", err)
+	}
+	for _, r := range domains {
+		out = append(out, domainRows(r)...)
+	}
+
+	return out, nil
+}
+
+// UpdateReference writes newRef into row's own cell. Column is always one
+// of this package's fixed literals (never external input), so passing it
+// into gorm's dynamic Update is safe.
+func (g *gormRowStore) UpdateReference(ctx context.Context, row Row, newRef string) error {
+	res := g.db.WithContext(ctx).Table(row.Table).Where("id = ?", row.ID).Update(row.Column, newRef)
+	if res.Error != nil {
+		return fmt.Errorf("update %s.%s for id %s: %w", row.Table, row.Column, row.ID, res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("update %s.%s for id %s: no rows affected (row deleted since it was fetched?)", row.Table, row.Column, row.ID)
+	}
+	return nil
+}

--- a/services/marketplace-api/cmd/carrier-secrets-backfill/rowstore_integration_test.go
+++ b/services/marketplace-api/cmd/carrier-secrets-backfill/rowstore_integration_test.go
@@ -1,0 +1,168 @@
+//go:build integration
+
+// Proves gormRowStore's SQL actually matches the live schema — the unit
+// tests in rowstore_test.go exercise the pure Scope-mapping functions
+// (paymentRows/shippingRows/taxRows/domainRows) against hand-built structs,
+// but never touch a real payment_gateway_configs/shipping_carrier_configs/
+// tax_provider_configs/custom_domains table. This is exactly the class of
+// gap that produced the earlier `carrier` vs `provider` column mistake:
+// a struct tag can be wrong and every unit test still passes, because the
+// unit tests build the struct value directly instead of scanning it out of
+// Postgres.
+//
+// Gated on TEST_DATABASE_URL, matching this service's established
+// integration-test convention (see pkg/testdb and internal/arbitrage's
+// openIntegrationDB). Missing it skips loudly rather than passing silently.
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/carriersecrets"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+func openIntegrationDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set — skipping integration test")
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() {
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			sqlDB.Close()
+		}
+	})
+	return db
+}
+
+// TestGormRowStore_FetchAllAndUpdateReference_RealSchema seeds one row in
+// each of the four tracked tables with a gsm:// reference, fetches through
+// gormRowStore, confirms the Scope each row produces resolves to the
+// expected BaoPath, then updates the reference and confirms it round-trips
+// back out of the real table.
+func TestGormRowStore_FetchAllAndUpdateReference_RealSchema(t *testing.T) {
+	db := openIntegrationDB(t)
+	ctx := context.Background()
+
+	tenantID := uuid.New()
+	storeID := uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
+
+	paymentID := uuid.New()
+	if err := db.Exec(
+		`INSERT INTO payment_gateway_configs (id, tenant_id, store_id, provider, api_key_encrypted)
+		 VALUES (?, ?, ?, 'razorpay', 'gsm://projects/p/secrets/payment-key')`,
+		paymentID, tenantID, storeID,
+	).Error; err != nil {
+		t.Fatalf("seed payment_gateway_configs: %v", err)
+	}
+	t.Cleanup(func() { db.Exec("DELETE FROM payment_gateway_configs WHERE id = ?", paymentID) })
+
+	shippingID := uuid.New()
+	if err := db.Exec(
+		`INSERT INTO shipping_carrier_configs (id, tenant_id, store_id, provider, api_key_encrypted)
+		 VALUES (?, ?, ?, 'delhivery', 'gsm://projects/p/secrets/shipping-key')`,
+		shippingID, tenantID, storeID,
+	).Error; err != nil {
+		t.Fatalf("seed shipping_carrier_configs: %v", err)
+	}
+	t.Cleanup(func() { db.Exec("DELETE FROM shipping_carrier_configs WHERE id = ?", shippingID) })
+
+	taxID := uuid.New()
+	if err := db.Exec(
+		`INSERT INTO tax_provider_configs (id, tenant_id, store_id, provider, api_key_encrypted)
+		 VALUES (?, ?, ?, 'taxjar', 'gsm://projects/p/secrets/tax-key')`,
+		taxID, tenantID, storeID,
+	).Error; err != nil {
+		t.Fatalf("seed tax_provider_configs: %v", err)
+	}
+	t.Cleanup(func() { db.Exec("DELETE FROM tax_provider_configs WHERE id = ?", taxID) })
+
+	domainID := uuid.New()
+	fqdn := "backfill-test-" + storeID.String()[:8] + ".example.com"
+	if err := db.Exec(
+		`INSERT INTO custom_domains (id, tenant_id, store_id, domain, cf_api_token_encrypted)
+		 VALUES (?, ?, ?, ?, 'gsm://projects/p/secrets/cf-token')`,
+		domainID, tenantID, storeID, fqdn,
+	).Error; err != nil {
+		t.Fatalf("seed custom_domains: %v", err)
+	}
+	t.Cleanup(func() { db.Exec("DELETE FROM custom_domains WHERE id = ?", domainID) })
+
+	store := newGormRowStore(db)
+	rows, err := store.FetchAll(ctx)
+	if err != nil {
+		t.Fatalf("FetchAll: %v", err)
+	}
+
+	find := func(table, id string) *Row {
+		for i := range rows {
+			if rows[i].Table == table && rows[i].ID == id {
+				return &rows[i]
+			}
+		}
+		return nil
+	}
+
+	paymentRow := find("payment_gateway_configs", paymentID.String())
+	if paymentRow == nil {
+		t.Fatal("seeded payment_gateway_configs row not found by FetchAll")
+	}
+	wantPaymentScope := carriersecrets.Scope{TenantID: tenantID.String(), Domain: "payment", Provider: "razorpay", Field: "api_key"}
+	if paymentRow.Scope != wantPaymentScope {
+		t.Fatalf("payment scope = %+v, want %+v", paymentRow.Scope, wantPaymentScope)
+	}
+
+	shippingRow := find("shipping_carrier_configs", shippingID.String())
+	if shippingRow == nil {
+		t.Fatal("seeded shipping_carrier_configs row not found by FetchAll")
+	}
+	wantShippingScope := carriersecrets.Scope{TenantID: tenantID.String(), Domain: "shipping", Provider: "delhivery", Field: "api_key"}
+	if shippingRow.Scope != wantShippingScope {
+		t.Fatalf("shipping scope = %+v, want %+v — if Provider is empty, the real column is not named `provider`", shippingRow.Scope, wantShippingScope)
+	}
+
+	taxRow := find("tax_provider_configs", taxID.String())
+	if taxRow == nil {
+		t.Fatal("seeded tax_provider_configs row not found by FetchAll")
+	}
+	wantTaxScope := carriersecrets.Scope{TenantID: tenantID.String(), Domain: "tax", Provider: "taxjar", Field: "api_key"}
+	if taxRow.Scope != wantTaxScope {
+		t.Fatalf("tax scope = %+v, want %+v", taxRow.Scope, wantTaxScope)
+	}
+
+	domainRow := find("custom_domains", domainID.String())
+	if domainRow == nil {
+		t.Fatal("seeded custom_domains row not found by FetchAll")
+	}
+	wantDomainScope := carriersecrets.Scope{TenantID: tenantID.String(), Domain: "platform", Provider: "cloudflare", Field: fqdn}
+	if domainRow.Scope != wantDomainScope {
+		t.Fatalf("domain scope = %+v, want %+v", domainRow.Scope, wantDomainScope)
+	}
+
+	// UpdateReference round-trip: write a bao:// reference into the real
+	// row and confirm it reads back.
+	newRef := carriersecrets.FormatBaoReference(domainRow.Scope)
+	if err := store.UpdateReference(ctx, *domainRow, newRef); err != nil {
+		t.Fatalf("UpdateReference: %v", err)
+	}
+	var gotRef string
+	if err := db.Raw("SELECT cf_api_token_encrypted FROM custom_domains WHERE id = ?", domainID).Scan(&gotRef).Error; err != nil {
+		t.Fatalf("read back cf_api_token_encrypted: %v", err)
+	}
+	if gotRef != newRef {
+		t.Fatalf("cf_api_token_encrypted after UpdateReference = %q, want %q", gotRef, newRef)
+	}
+}

--- a/services/marketplace-api/cmd/carrier-secrets-backfill/rowstore_test.go
+++ b/services/marketplace-api/cmd/carrier-secrets-backfill/rowstore_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/carriersecrets"
+)
+
+// TestPaymentRows_ScopeMapping pins Domain "payment" with the row's own
+// provider column, and Field literals api_key/secret_key/webhook_secret —
+// see internal/handlers/admin/settings.go:551-558.
+func TestPaymentRows_ScopeMapping(t *testing.T) {
+	id := uuid.New()
+	tenant := uuid.New()
+	row := paymentGatewayConfigRow{
+		ID:                     id,
+		TenantID:               tenant,
+		Provider:               "razorpay",
+		APIKeyEncrypted:        "gsm://projects/p/secrets/x",
+		SecretKeyEncrypted:     "gsm://projects/p/secrets/y",
+		WebhookSecretEncrypted: "gsm://projects/p/secrets/z",
+	}
+	got := paymentRows(row)
+	if len(got) != 3 {
+		t.Fatalf("len(paymentRows) = %d, want 3", len(got))
+	}
+	wantFields := []string{"api_key", "secret_key", "webhook_secret"}
+	for i, field := range wantFields {
+		wantScope := carriersecrets.Scope{TenantID: tenant.String(), Domain: "payment", Provider: "razorpay", Field: field}
+		if got[i].Scope != wantScope {
+			t.Fatalf("row %d scope = %+v, want %+v", i, got[i].Scope, wantScope)
+		}
+		wantPath := "kv/mark8ly/marketplace-api/tenants/" + tenant.String() + "/payment/razorpay/" + field
+		if gotPath := carriersecrets.BaoPath(got[i].Scope); gotPath != wantPath {
+			t.Fatalf("BaoPath(%+v) = %q, want %q", got[i].Scope, gotPath, wantPath)
+		}
+		if got[i].Table != "payment_gateway_configs" {
+			t.Fatalf("row %d table = %q, want payment_gateway_configs", i, got[i].Table)
+		}
+	}
+}
+
+// TestShippingRows_ScopeMapping pins Domain "shipping" with the row's own
+// `provider` column (confirmed NOT `carrier` against
+// internal/shipping/repository.go's CarrierConfig struct).
+func TestShippingRows_ScopeMapping(t *testing.T) {
+	id := uuid.New()
+	tenant := uuid.New()
+	row := shippingCarrierConfigRow{
+		ID:                 id,
+		TenantID:           tenant,
+		Provider:           "delhivery",
+		APIKeyEncrypted:    "gsm://projects/p/secrets/x",
+		SecretKeyEncrypted: "gsm://projects/p/secrets/y",
+	}
+	got := shippingRows(row)
+	if len(got) != 2 {
+		t.Fatalf("len(shippingRows) = %d, want 2", len(got))
+	}
+	wantFields := []string{"api_key", "secret_key"}
+	for i, field := range wantFields {
+		wantScope := carriersecrets.Scope{TenantID: tenant.String(), Domain: "shipping", Provider: "delhivery", Field: field}
+		if got[i].Scope != wantScope {
+			t.Fatalf("row %d scope = %+v, want %+v", i, got[i].Scope, wantScope)
+		}
+		wantPath := "kv/mark8ly/marketplace-api/tenants/" + tenant.String() + "/shipping/delhivery/" + field
+		if gotPath := carriersecrets.BaoPath(got[i].Scope); gotPath != wantPath {
+			t.Fatalf("BaoPath(%+v) = %q, want %q", got[i].Scope, gotPath, wantPath)
+		}
+		if got[i].Table != "shipping_carrier_configs" {
+			t.Fatalf("row %d table = %q, want shipping_carrier_configs", i, got[i].Table)
+		}
+	}
+}
+
+// TestTaxRows_ScopeMapping pins Domain "tax", Field "api_key", provider
+// from the row's own `provider` column.
+func TestTaxRows_ScopeMapping(t *testing.T) {
+	id := uuid.New()
+	tenant := uuid.New()
+	row := taxProviderConfigRow{
+		ID:              id,
+		TenantID:        tenant,
+		Provider:        "taxjar",
+		APIKeyEncrypted: "gsm://projects/p/secrets/x",
+	}
+	got := taxRows(row)
+	if len(got) != 1 {
+		t.Fatalf("len(taxRows) = %d, want 1", len(got))
+	}
+	wantScope := carriersecrets.Scope{TenantID: tenant.String(), Domain: "tax", Provider: "taxjar", Field: "api_key"}
+	if got[0].Scope != wantScope {
+		t.Fatalf("scope = %+v, want %+v", got[0].Scope, wantScope)
+	}
+	wantPath := "kv/mark8ly/marketplace-api/tenants/" + tenant.String() + "/tax/taxjar/api_key"
+	if gotPath := carriersecrets.BaoPath(got[0].Scope); gotPath != wantPath {
+		t.Fatalf("BaoPath = %q, want %q", gotPath, wantPath)
+	}
+	if got[0].Table != "tax_provider_configs" {
+		t.Fatalf("table = %q, want tax_provider_configs", got[0].Table)
+	}
+}
+
+// TestDomainRows_ScopeMapping is the trap case: Domain "platform", Provider
+// fixed "cloudflare", and Field is the row's FQDN — NOT a fixed field name
+// — per internal/domain/service.go's scopeForCFToken (150-155). Also pins
+// the exact sanitized BaoPath: BaoPath lower-cases and replaces every
+// non-alnum/_/- character (the FQDN's dots) with '_'.
+func TestDomainRows_ScopeMapping(t *testing.T) {
+	id := uuid.New()
+	tenant := uuid.New()
+	fqdn := "shop.example.com"
+	row := customDomainRow{
+		ID:                  id,
+		TenantID:            tenant,
+		Domain:              fqdn,
+		CFAPITokenEncrypted: "gsm://projects/p/secrets/x",
+	}
+	got := domainRows(row)
+	if len(got) != 1 {
+		t.Fatalf("len(domainRows) = %d, want 1", len(got))
+	}
+	wantScope := carriersecrets.Scope{TenantID: tenant.String(), Domain: "platform", Provider: "cloudflare", Field: fqdn}
+	if got[0].Scope != wantScope {
+		t.Fatalf("scope = %+v, want %+v", got[0].Scope, wantScope)
+	}
+	// FQDN dots are sanitized to underscores in the KV path.
+	wantPath := "kv/mark8ly/marketplace-api/tenants/" + tenant.String() + "/platform/cloudflare/shop_example_com"
+	if gotPath := carriersecrets.BaoPath(got[0].Scope); gotPath != wantPath {
+		t.Fatalf("BaoPath = %q, want %q", gotPath, wantPath)
+	}
+	if got[0].Table != "custom_domains" || got[0].Column != "cf_api_token_encrypted" {
+		t.Fatalf("table/column = %q/%q, want custom_domains/cf_api_token_encrypted", got[0].Table, got[0].Column)
+	}
+}


### PR DESCRIPTION
Phase 3 of mark8ly#319: a one-off tool that migrates existing `gsm://` credential references to OpenBao.

The admin engine now writes `bao://`, but existing rows never migrate on their own — lazy rewrap only fires on save, and is refused on the storefront by design (read-only role). This closes that gap.

## Dry-run against production, already executed

```
examined=6  skipped=4  would-migrate=2  failed=0

payment_gateway_configs.webhook_secret_encrypted
  gsm://…-payment-stripe-webhook_secret
  → bao://kv/mark8ly/marketplace-api/tenants/8c302556-…/payment/stripe/webhook_secret

shipping_carrier_configs.api_key_encrypted
  gsm://…-shipping-shipengine-api_key
  → bao://kv/mark8ly/marketplace-api/tenants/8c302556-…/shipping/shipengine/api_key
```

Only two rows need migrating; the rest are already `bao://` or empty. `provider=shipengine` was resolved from real data, which validates the mapping rather than just asserting it.

## Safety properties

**Read-back before commit.** Per row: read plaintext from GCP → write to OpenBao → **read the new reference back and assert the plaintext matches** → only then update the database. A mismatch leaves the row pointing at the working GCP reference and counts as a failure. That makes a bad migration reversible by construction.

**The GCP secret is never deleted.** Retiring GCP Secret Manager is phase 5's decision, gated on #608. Until then the old value survives, so a wrong migration is recoverable by restoring the old reference.

**Dry-run is the default.** Writing requires an explicit `-dry-run=false`.

**Refuses to run unless the mode is `bao`.** Under `gcpsm` it would "migrate" `gsm://` to `gsm://` — pointless writes against live payment credentials.

**Never logs plaintext.** References, lengths and counts only.

## The Scope mapping, confirmed against the write paths and the DDL

| Table | Domain | Provider | Field |
| --- | --- | --- | --- |
| `payment_gateway_configs` | `payment` | row's `provider` | `api_key` / `secret_key` / `webhook_secret` |
| `shipping_carrier_configs` | `shipping` | row's `provider` | `api_key` / `secret_key` |
| `tax_provider_configs` | `tax` | row's `provider` | `api_key` |
| `custom_domains` | `platform` | fixed `cloudflare` | **the row's FQDN** |

Two traps worth naming, because either would have written a live credential to a path nothing reads:
- `custom_domains` keys on the FQDN, not a fixed field name.
- `shipping_carrier_configs` uses `provider`, not `carrier` — an earlier probe of mine assumed `carrier` and failed with `column does not exist`.

A schema sweep for `%_encrypted` / `%token_ref%` / `%key_ref%` columns confirmed no credential-reference column exists outside these four tables.

## Also in this PR

The binary is added to the Dockerfile. A `cmd/` binary that is not in the runtime image cannot be run as a Job — mark8ly#587 demonstrated exactly that, and the tool is deliberately built to run **in-cluster under the real ServiceAccount** rather than from an operator's laptop with production credentials port-forwarded to it.

## Test plan

- [x] `go test ./...` — 99 packages, 0 failures
- [x] Four safety-critical tests each verified RED before GREEN, including that a failed read-back does NOT update the database
- [x] Scope-mapping tests per table, including the `custom_domains` FQDN case
- [x] Dry-run executed against production (above) — no writes
- [x] `go build`, `go vet`, `gofmt` clean
- [ ] After merge and promotion: run as a Job with `-dry-run=false`, then verify both references became `bao://` and both values read back correctly

Refs #319.
