### PR TITLE
docs: design and phase-1 plan for migrating auth from GIP to Zitadel (#524)

### DIFF
--- a/docs/superpowers/plans/2026-09-03-zitadel-phase1-infrastructure.md
+++ b/docs/superpowers/plans/2026-09-03-zitadel-phase1-infrastructure.md
@@ -108,6 +108,33 @@ class ProjectRoleCheckTest(unittest.TestCase):
         self.assertEqual(len(calls), 1)
         self.assertIs(calls[0][2]["projectRoleCheck"], False)
 
+    def test_unmanaged_when_desired_is_none_and_live_is_true(self):
+        """Absent key must not disable a live-true gate. Regression test:
+        AgentGateway, AgentRegistry and Atlantis all have projectRoleCheck on
+        and declare nothing, so a False default would silently disable them."""
+        calls = []
+        bootstrap.reconcile_project_role_check(
+            project_id="9",
+            project_name="AgentGateway",
+            live={"id": "9", "name": "AgentGateway", "projectRoleCheck": True},
+            desired=None,
+            scope={},
+            request=self._recording_request(calls),
+        )
+        self.assertEqual(calls, [])
+
+    def test_unmanaged_when_desired_is_none_and_live_is_absent(self):
+        calls = []
+        bootstrap.reconcile_project_role_check(
+            project_id="9",
+            project_name="AgentGateway",
+            live={"id": "9", "name": "AgentGateway"},
+            desired=None,
+            scope={},
+            request=self._recording_request(calls),
+        )
+        self.assertEqual(calls, [])
+
     def test_raises_on_write_failure(self):
         with self.assertRaises(SystemExit):
             bootstrap.reconcile_project_role_check(
@@ -144,6 +171,13 @@ def reconcile_project_role_check(
     The management API has no partial update for a project: PUT replaces the
     whole resource, so name and roleAssertion are resent unchanged.
     """
+    # An absent key means UNMANAGED, not False. bootstrap.py reconciles
+    # field-by-field so console-set values survive; defaulting to False here
+    # would turn OFF the gate on every platformProject that has it on but does
+    # not declare it (AgentGateway, AgentRegistry and Atlantis all do today).
+    if desired is None:
+        return
+
     current = bool(live.get("projectRoleCheck", False))
     if current == bool(desired):
         return
@@ -172,7 +206,7 @@ Then call it from `reconcile_platform_project`, immediately after the `expectedI
         project_id=project_id,
         project_name=desired["name"],
         live=project,
-        desired=desired.get("projectRoleCheck", False),
+        desired=desired.get("projectRoleCheck"),  # absent => unmanaged, never False
         scope=scope,
     )
 ```

--- a/docs/superpowers/plans/2026-09-03-zitadel-phase1-infrastructure.md
+++ b/docs/superpowers/plans/2026-09-03-zitadel-phase1-infrastructure.md
@@ -1,0 +1,656 @@
+# Zitadel Migration Phase 1 — Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the `mark8ly-admin` and `mark8ly-storefront` Zitadel projects, their OIDC applications, and the credentials and config `auth-bff` will need — with the `restricted` gate reconciled as code, and with zero behaviour change to running mark8ly services.
+
+**Architecture:** All work is declarative config in `tesserix-k8s`, reconciled by the existing `zitadel-bootstrap` CronJob (every 30 min, fails closed on drift). The `zitadel-operator` CRDs are deliberately NOT used here — they issue public PKCE clients only and expose neither `loginVersion` nor `authMethodType`, both of which this design requires. Nothing in this phase is consumed by mark8ly code yet; every new env var is added but unread.
+
+**Tech Stack:** Zitadel v4.15.3 management API, Python 3 (`bootstrap.py`), Helm, ArgoCD, External Secrets Operator, GCP Secret Manager.
+
+**Spec:** `docs/superpowers/specs/2026-09-03-zitadel-migration-design.md` (in the `mark8ly` repo)
+
+## Global Constraints
+
+- **Execution repo is `tesserix-k8s`**, not `mark8ly`. Only this plan's Task 6 touches `mark8ly`.
+- **Branch from `origin/main` after fetching.** `tesserix-k8s` has concurrent sessions; never rewrite someone else's branch.
+- **Every chart change needs a `Chart.yaml` version bump** or `ct lint` fails in CI. Local `helm lint` does not catch this.
+- **`tesserix-k8s` PRs require a review approval** before merge.
+- Zitadel instance: `https://auth.tesserix.app`, v4.15.3. Org `TESSERIX` = `386377229942128837`.
+- **In-cluster calls must send `Host: auth.tesserix.app`** — Zitadel resolves the instance by Host header and answers `Instance not found` otherwise.
+- **`PUT .../oidc_config` is a full replace, not a patch.** Any write must send every field or it silently resets omitted ones (this reset `authMethodType` and broke every hms login for the life of a PR).
+- **protojson elides zero-value fields.** A `false` boolean is absent from responses, not `false`. Never infer "unset" from "absent".
+- New config added to mark8ly charts in this phase MUST be optional and unread. A required env var that code rejects when empty causes a crashloop on merge; tests cannot catch it.
+
+---
+
+### Task 1: Teach `zitadel-bootstrap` to reconcile `projectRoleCheck`
+
+The `restricted` gate is the entire structural guarantee of spec decision D2 — it is what stops a storefront customer authenticating against the admin surface. `bootstrap.py` currently does not manage it, so it would be a hand-set flag that nothing asserts and that silently drifts. This task closes that before the flag is ever set.
+
+**Files:**
+- Modify: `charts/apps/zitadel-bootstrap/files/bootstrap.py` (in `reconcile_platform_project`, after the `expectedId` check at line ~707)
+- Test: `charts/apps/zitadel-bootstrap/files/bootstrap_test.py`
+- Modify: `charts/apps/zitadel-bootstrap/Chart.yaml` (version bump)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `platformProjects[].projectRoleCheck` (bool, optional, default `False`) is honoured by the reconciler. Task 3 sets it to `true` for `mark8ly-admin`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `bootstrap_test.py`. That file is **stdlib `unittest` only** — no pytest, no third-party imports — so match its style exactly.
+
+The third test is the important one: it pins the protojson elision behaviour, which is why this cannot be a naive `live.get("projectRoleCheck") == wanted` comparison. The last test pins idempotency, which the file's own docstring names as the property that matters, since the job runs every 30 minutes against a live instance.
+
+```python
+class ProjectRoleCheckTest(unittest.TestCase):
+    @staticmethod
+    def _recording_request(calls, status=200, payload="{}"):
+        def _request(method, path, body=None, headers=None):
+            calls.append((method, path, body, headers))
+            return status, payload
+        return _request
+
+    def test_enables_when_desired_and_live_key_is_absent(self):
+        """protojson omits projectRoleCheck when false, so absent means OFF."""
+        calls = []
+        bootstrap.reconcile_project_role_check(
+            project_id="1",
+            project_name="mark8ly-admin",
+            live={"id": "1", "name": "mark8ly-admin"},  # no projectRoleCheck key
+            desired=True,
+            scope={},
+            request=self._recording_request(calls),
+        )
+        self.assertEqual(len(calls), 1)
+        method, path, body, _headers = calls[0]
+        self.assertEqual(method, "PUT")
+        self.assertEqual(path, "/management/v1/projects/1")
+        self.assertIs(body["projectRoleCheck"], True)
+        # PUT is a full replace, so name must be resent or it is wiped.
+        self.assertEqual(body["name"], "mark8ly-admin")
+
+    def test_no_write_when_already_correct(self):
+        calls = []
+        bootstrap.reconcile_project_role_check(
+            project_id="1",
+            project_name="mark8ly-admin",
+            live={"id": "1", "name": "mark8ly-admin", "projectRoleCheck": True},
+            desired=True,
+            scope={},
+            request=self._recording_request(calls),
+        )
+        self.assertEqual(calls, [])
+
+    def test_absent_and_not_desired_is_a_no_op(self):
+        calls = []
+        bootstrap.reconcile_project_role_check(
+            project_id="2",
+            project_name="mark8ly-storefront",
+            live={"id": "2", "name": "mark8ly-storefront"},
+            desired=False,
+            scope={},
+            request=self._recording_request(calls),
+        )
+        self.assertEqual(calls, [])
+
+    def test_disables_when_live_is_true_and_not_desired(self):
+        calls = []
+        bootstrap.reconcile_project_role_check(
+            project_id="2",
+            project_name="mark8ly-storefront",
+            live={"id": "2", "name": "mark8ly-storefront", "projectRoleCheck": True},
+            desired=False,
+            scope={},
+            request=self._recording_request(calls),
+        )
+        self.assertEqual(len(calls), 1)
+        self.assertIs(calls[0][2]["projectRoleCheck"], False)
+
+    def test_raises_on_write_failure(self):
+        with self.assertRaises(SystemExit):
+            bootstrap.reconcile_project_role_check(
+                project_id="1",
+                project_name="mark8ly-admin",
+                live={"id": "1", "name": "mark8ly-admin"},
+                desired=True,
+                scope={},
+                request=self._recording_request(
+                    [], status=403, payload='{"message":"nope"}'
+                ),
+            )
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd charts/apps/zitadel-bootstrap/files && python3 bootstrap_test.py`
+Expected: FAIL with `AttributeError: module 'bootstrap' has no attribute 'reconcile_project_role_check'`
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add to `bootstrap.py`, above `reconcile_platform_project`:
+
+```python
+def reconcile_project_role_check(
+    project_id, project_name, live, desired, scope, request=request
+):
+    """Assert a project's "only authorized users can authenticate" gate.
+
+    protojson omits projectRoleCheck from the response when it is false, so an
+    absent key means OFF, not "unset". Comparing with .get(..., False) is what
+    makes absent and false the same thing, deliberately.
+
+    The management API has no partial update for a project: PUT replaces the
+    whole resource, so name and roleAssertion are resent unchanged.
+    """
+    current = bool(live.get("projectRoleCheck", False))
+    if current == bool(desired):
+        return
+
+    body = {
+        "name": project_name,
+        "projectRoleAssertion": bool(live.get("projectRoleAssertion", False)),
+        "projectRoleCheck": bool(desired),
+        "hasProjectCheck": bool(live.get("hasProjectCheck", False)),
+    }
+    status, payload = request(
+        "PUT", f"/management/v1/projects/{project_id}", body, headers=scope
+    )
+    if status != 200:
+        raise SystemExit(
+            f"project {project_name!r} role-check update failed: {status} {payload!r}"
+        )
+```
+
+Then call it from `reconcile_platform_project`, immediately after the `expectedId` mismatch check and before `wanted_apps` is read:
+
+```python
+    project_id = project["id"]
+
+    reconcile_project_role_check(
+        project_id=project_id,
+        project_name=desired["name"],
+        live=project,
+        desired=desired.get("projectRoleCheck", False),
+        scope=scope,
+    )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd charts/apps/zitadel-bootstrap/files && python3 bootstrap_test.py`
+Expected: `OK`, including all pre-existing tests.
+
+Also run the repo suite the way CI does, since `repo-tests.yaml` drives it through pytest:
+
+Run: `python3 -m pytest charts/apps/zitadel-bootstrap/files/bootstrap_test.py -q`
+Expected: all pass.
+
+- [ ] **Step 5: Bump the chart version**
+
+In `charts/apps/zitadel-bootstrap/Chart.yaml`, increment the patch component of `version` (e.g. `0.3.15` → `0.3.16`). CI's `ct lint` fails on an unbumped chart.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add charts/apps/zitadel-bootstrap/files/bootstrap.py \
+        charts/apps/zitadel-bootstrap/files/bootstrap_test.py \
+        charts/apps/zitadel-bootstrap/Chart.yaml
+git commit -m "feat(zitadel-bootstrap): reconcile projectRoleCheck so the restricted gate cannot drift"
+```
+
+---
+
+### Task 2: Create the two projects and commit their IDs
+
+`reconcile_platform_project` deliberately does not create projects — it exits with a message telling you to create one and commit its ID, because a project ID is a JWT audience and a changed one must stop reconciliation rather than silently issue tokens the verifier will reject. So creation is a one-time human step.
+
+**This task is executed by a human with instance credentials, not by an agent.** Its output is two IDs.
+
+**Files:**
+- No file changes in this task. Task 3 consumes the IDs.
+
+**Interfaces:**
+- Consumes: Task 1's reconciler (must be merged first, so the gate is asserted the moment the project exists).
+- Produces: two project IDs, referred to below as `<ADMIN_PROJECT_ID>` and `<STOREFRONT_PROJECT_ID>`.
+
+- [ ] **Step 1: Obtain the instance-admin PAT**
+
+```bash
+PAT=$(kubectl get secret iam-admin-pat -n zitadel -o jsonpath='{.data.pat}' | base64 -d)
+ORG=386377229942128837
+```
+
+- [ ] **Step 2: Create `mark8ly-admin`**
+
+```bash
+curl -s -X POST https://auth.tesserix.app/management/v1/projects \
+  -H "Authorization: Bearer $PAT" -H "x-zitadel-orgid: $ORG" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"mark8ly-admin","projectRoleAssertion":true,"projectRoleCheck":true,"hasProjectCheck":false}'
+```
+
+Expected: `200` with `{"id":"…"}`. Record that id as `<ADMIN_PROJECT_ID>`.
+
+- [ ] **Step 3: Create `mark8ly-storefront`**
+
+```bash
+curl -s -X POST https://auth.tesserix.app/management/v1/projects \
+  -H "Authorization: Bearer $PAT" -H "x-zitadel-orgid: $ORG" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"mark8ly-storefront","projectRoleAssertion":true,"projectRoleCheck":false,"hasProjectCheck":false}'
+```
+
+Expected: `200` with `{"id":"…"}`. Record that id as `<STOREFRONT_PROJECT_ID>`.
+
+- [ ] **Step 4: Verify the gate reads back as expected**
+
+```bash
+curl -s -H "Authorization: Bearer $PAT" -H "x-zitadel-orgid: $ORG" \
+  https://auth.tesserix.app/management/v1/projects/<ADMIN_PROJECT_ID>
+```
+
+Expected: the response contains `"projectRoleCheck": true`.
+
+```bash
+curl -s -H "Authorization: Bearer $PAT" -H "x-zitadel-orgid: $ORG" \
+  https://auth.tesserix.app/management/v1/projects/<STOREFRONT_PROJECT_ID>
+```
+
+Expected: `projectRoleCheck` is **absent** from the response. That is correct and means `false` — protojson elides it. Do not "fix" this.
+
+- [ ] **Step 5: Record the IDs**
+
+Paste both IDs into the PR description for Task 3. They are not secrets; they are JWT audiences and belong in git.
+
+---
+
+### Task 3: Declare the mark8ly projects, roles and applications
+
+**Files:**
+- Modify: `charts/apps/zitadel-bootstrap/values.yaml` (append two entries to `desired.platformProjects`)
+- Modify: `charts/apps/zitadel-bootstrap/Chart.yaml` (version bump)
+
+**Interfaces:**
+- Consumes: Task 1's `projectRoleCheck` support; Task 2's two project IDs.
+- Produces: project role keys `mark8ly.staff` and `mark8ly.customer`, and four OIDC applications. Task 4 grants the login-client machine user; Task 6 consumes the client IDs.
+
+- [ ] **Step 1: Append the two project declarations**
+
+Add to `platformProjects` in `charts/apps/zitadel-bootstrap/values.yaml`, substituting the real IDs from Task 2. `loginBaseUri` points at **our** login page, not Zitadel's hosted UI — that is what makes this a login-client integration. It must be an origin with **no path**: Zitadel appends `/login` itself, and `…/login` produces `…/login/login?authRequest=`.
+
+```yaml
+    - org: TESSERIX
+      name: mark8ly-admin
+      expectedId: "<ADMIN_PROJECT_ID>"
+      # Closed product: a user holding no role here cannot obtain a token for
+      # it at all. This is what keeps storefront customers out of the merchant
+      # admin surface, enforced by Zitadel rather than by our own checks.
+      projectRoleCheck: true
+      roles:
+        - key: mark8ly.staff
+          displayName: Merchant Staff
+          group: mark8ly-access
+      oidcApps:
+        - name: mark8ly-admin-web
+          appType: OIDC_APP_TYPE_WEB
+          authMethodType: OIDC_AUTH_METHOD_TYPE_BASIC
+          loginBaseUri: https://admin.mark8ly.com
+          redirectUris:
+            - https://admin.mark8ly.com/auth/callback
+          postLogoutRedirectUris:
+            - https://admin.mark8ly.com/
+        - name: mark8ly-admin-mobile
+          appType: OIDC_APP_TYPE_NATIVE
+          authMethodType: OIDC_AUTH_METHOD_TYPE_NONE
+          redirectUris:
+            - mark8ly-admin:/auth/callback
+    - org: TESSERIX
+      name: mark8ly-storefront
+      expectedId: "<STOREFRONT_PROJECT_ID>"
+      # Open product: any TESSERIX user may authenticate. This matches the
+      # current open MP-Customer pool; see spec D2 for the accepted risk.
+      projectRoleCheck: false
+      roles:
+        - key: mark8ly.customer
+          displayName: Storefront Customer
+          group: mark8ly-access
+      oidcApps:
+        - name: mark8ly-storefront-web
+          appType: OIDC_APP_TYPE_WEB
+          authMethodType: OIDC_AUTH_METHOD_TYPE_BASIC
+          # Per-tenant subdomains cannot each be a login origin, so login runs
+          # on the one fixed registered origin and bounces back to the store,
+          # reusing the existing /auth/google trampoline shape.
+          loginBaseUri: https://mark8ly.com
+          redirectUris:
+            - https://mark8ly.com/auth/callback
+          postLogoutRedirectUris:
+            - https://mark8ly.com/
+        - name: mark8ly-storefront-mobile
+          appType: OIDC_APP_TYPE_NATIVE
+          authMethodType: OIDC_AUTH_METHOD_TYPE_NONE
+          redirectUris:
+            - mark8ly-storefront:/auth/callback
+```
+
+- [ ] **Step 2: Verify the values file still parses**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('charts/apps/zitadel-bootstrap/values.yaml'))" && echo OK`
+Expected: `OK`
+
+- [ ] **Step 3: Bump the chart version and lint**
+
+Increment `version` in `charts/apps/zitadel-bootstrap/Chart.yaml`.
+
+Run: `helm lint charts/apps/zitadel-bootstrap`
+Expected: `0 chart(s) failed`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add charts/apps/zitadel-bootstrap/values.yaml charts/apps/zitadel-bootstrap/Chart.yaml
+git commit -m "feat(zitadel): declare the mark8ly-admin and mark8ly-storefront projects"
+```
+
+- [ ] **Step 5: After merge, confirm the reconciler ran clean**
+
+The CronJob runs every 30 minutes. The two confidential web applications must exist before the reconciler asserts them, so if the run fails with `application … is missing`, create them once by hand (Task 4 Step 1) and let the next run assert them.
+
+Run: `kubectl -n zitadel logs job/$(kubectl -n zitadel get jobs -o name | grep zitadel-bootstrap | tail -1 | cut -d/ -f2)`
+Expected: completes without `SystemExit`.
+
+---
+
+### Task 4: Mint the `auth-bff` confidential client secret and login-client PAT
+
+Two credentials, both one-time, both outside the reconciler by design — `bootstrap.py`'s own comment records that machine client secrets are deliberately not periodically reconciled.
+
+**This task is executed by a human with instance credentials.**
+
+**Files:**
+- Create: `external-secrets/prod/mark8ly/externalsecret.yaml` — append a new `ExternalSecret` (the file already exists and holds `mark8ly-console-catalog`)
+
+**Interfaces:**
+- Consumes: Task 3's applications.
+- Produces: K8s secret `mark8ly-zitadel` in namespace `mark8ly` with keys `ZITADEL_CLIENT_ID`, `ZITADEL_CLIENT_SECRET`, `ZITADEL_LOGIN_CLIENT_TOKEN`. Task 6 mounts it.
+
+- [ ] **Step 1: Create the two web applications if the reconciler reported them missing**
+
+For each of `mark8ly-admin-web` and `mark8ly-storefront-web`, substituting the project id:
+
+```bash
+curl -s -X POST https://auth.tesserix.app/management/v1/projects/<PROJECT_ID>/apps/oidc \
+  -H "Authorization: Bearer $PAT" -H "x-zitadel-orgid: $ORG" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"mark8ly-admin-web","appType":"OIDC_APP_TYPE_WEB","authMethodType":"OIDC_AUTH_METHOD_TYPE_BASIC","grantTypes":["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"],"responseTypes":["OIDC_RESPONSE_TYPE_CODE"],"accessTokenType":"OIDC_TOKEN_TYPE_JWT","redirectUris":["https://admin.mark8ly.com/auth/callback"],"postLogoutRedirectUris":["https://admin.mark8ly.com/"],"loginVersion":{"loginV2":{"baseUri":"https://admin.mark8ly.com"}}}'
+```
+
+Expected: `200` with `clientId` and `clientSecret`. **The secret is shown once.** Capture both immediately.
+
+- [ ] **Step 2: Create the login-client machine user**
+
+```bash
+curl -s -X POST https://auth.tesserix.app/management/v1/users/machine \
+  -H "Authorization: Bearer $PAT" -H "x-zitadel-orgid: $ORG" \
+  -H "Content-Type: application/json" \
+  -d '{"userName":"mark8ly-login-client","name":"mark8ly login client","description":"Drives the Zitadel Session API v2 for mark8ly auth-bff own login page","accessTokenType":"ACCESS_TOKEN_TYPE_JWT"}'
+```
+
+Expected: `200` with `userId`. Note it as `<LOGIN_CLIENT_USER_ID>`.
+
+- [ ] **Step 3: Grant it `IAM_LOGIN_CLIENT` and mint a PAT**
+
+```bash
+curl -s -X POST https://auth.tesserix.app/admin/v1/members \
+  -H "Authorization: Bearer $PAT" -H "Content-Type: application/json" \
+  -d '{"userId":"<LOGIN_CLIENT_USER_ID>","roles":["IAM_LOGIN_CLIENT"]}'
+
+curl -s -X POST https://auth.tesserix.app/management/v1/users/<LOGIN_CLIENT_USER_ID>/pats \
+  -H "Authorization: Bearer $PAT" -H "x-zitadel-orgid: $ORG" \
+  -H "Content-Type: application/json" -d '{}'
+```
+
+Expected: `200` with `token`. **Shown once.**
+
+> This PAT is instance-level. It can check anyone's password and mint a session for any user of any product on this instance. Zitadel offers no narrower role. Treat it as the most powerful credential mark8ly holds, and never log it.
+
+- [ ] **Step 4: Write all three values to GCP Secret Manager**
+
+```bash
+for pair in \
+  "prod-mark8ly-zitadel-client-id:<CLIENT_ID>" \
+  "prod-mark8ly-zitadel-client-secret:<CLIENT_SECRET>" \
+  "prod-mark8ly-zitadel-login-client-token:<PAT>"; do
+  name="${pair%%:*}"; value="${pair#*:}"
+  gcloud secrets create "$name" --project tesseracthub-480811 --replication-policy=automatic 2>/dev/null || true
+  printf '%s' "$value" | gcloud secrets versions add "$name" --project tesseracthub-480811 --data-file=-
+done
+```
+
+- [ ] **Step 5: Add the ExternalSecret**
+
+Append to `external-secrets/prod/mark8ly/externalsecret.yaml`:
+
+```yaml
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mark8ly-zitadel
+  namespace: mark8ly
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: mark8ly-zitadel
+    creationPolicy: Owner
+  data:
+    - secretKey: ZITADEL_CLIENT_ID
+      remoteRef: {key: prod-mark8ly-zitadel-client-id}
+    - secretKey: ZITADEL_CLIENT_SECRET
+      remoteRef: {key: prod-mark8ly-zitadel-client-secret}
+    - secretKey: ZITADEL_LOGIN_CLIENT_TOKEN
+      remoteRef: {key: prod-mark8ly-zitadel-login-client-token}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add external-secrets/prod/mark8ly/externalsecret.yaml
+git commit -m "feat(mark8ly): provision the Zitadel confidential client and login-client credentials"
+```
+
+- [ ] **Step 7: After merge, verify the secret materialised**
+
+Run: `kubectl get secret mark8ly-zitadel -n mark8ly -o jsonpath='{.data}' | tr ',' '\n' | cut -d'"' -f2`
+Expected: three keys listed. Never print the values.
+
+---
+
+### Task 5: Prove the two projects behave as designed
+
+The `restricted` gate is the reason for this whole topology, and it fails silently if wrong — a user simply gets in when they should not. Assert it against the real instance before any code depends on it.
+
+**This task is executed by a human with instance credentials. It creates and deletes a throwaway user.**
+
+**Files:**
+- Create: `docs/zitadel-mark8ly-verification.md` — record the observed results
+
+**Interfaces:**
+- Consumes: Tasks 2, 3 and 4.
+- Produces: a recorded verification. No code artefacts.
+
+- [ ] **Step 1: Create a throwaway user with a password and no roles**
+
+```bash
+curl -s -X POST https://auth.tesserix.app/v2/users/human \
+  -H "Authorization: Bearer $PAT" -H "Content-Type: application/json" \
+  -d '{"userId":"verify524NoRoleUserAaBb123","organization":{"orgId":"386377229942128837"},"username":"verify524@mark8ly.test","profile":{"givenName":"Verify","familyName":"NoRole"},"email":{"email":"verify524@mark8ly.test","isVerified":true},"password":{"password":"Ver1fy524!Temp#Pass","changeRequired":false}}'
+```
+
+Expected: `200`, and the returned `userId` is **exactly** `verify524NoRoleUserAaBb123`. If Zitadel returned a different, generated id, stop — spec decision D4 does not hold and the later phases must be re-planned.
+
+- [ ] **Step 2: Create a session (password only)**
+
+```bash
+LCT=$(kubectl get secret mark8ly-zitadel -n mark8ly -o jsonpath='{.data.ZITADEL_LOGIN_CLIENT_TOKEN}' | base64 -d)
+curl -s -X POST https://auth.tesserix.app/v2/sessions \
+  -H "Authorization: Bearer $LCT" -H "Content-Type: application/json" \
+  -d '{"checks":{"user":{"loginName":"verify524@mark8ly.test"},"password":{"password":"Ver1fy524!Temp#Pass"}}}'
+```
+
+Expected: `201` with `sessionId` and `sessionToken`. Record both.
+
+Note: the create response omits `factors`. To see what was actually verified you must re-read the session with `GET /v2/sessions/{id}`; expect `password.verifiedAt` to be present.
+
+- [ ] **Step 3: Confirm the admin project REFUSES a user with no role**
+
+```bash
+CID=<mark8ly-admin-web clientId>
+CV=verify524codeverifier1234567890abcdefghijk
+CC=$(python3 -c "import hashlib,base64;print(base64.urlsafe_b64encode(hashlib.sha256('$CV'.encode()).digest()).decode().rstrip('='))")
+LOC=$(curl -s -o /dev/null -D - "https://auth.tesserix.app/oauth/v2/authorize?client_id=$CID&redirect_uri=https%3A%2F%2Fadmin.mark8ly.com%2Fauth%2Fcallback&response_type=code&scope=openid&state=v&code_challenge=$CC&code_challenge_method=S256" | grep -i '^location:' | tr -d '\r' | sed 's/^[Ll]ocation: //')
+AR=$(echo "$LOC" | grep -oE 'authRequest(ID)?=[^&]+' | cut -d= -f2)
+echo "authRequest: $AR"   # must start with V2_ — if not, loginVersion is not set
+
+curl -s -X POST "https://auth.tesserix.app/v2/oidc/auth_requests/$AR" \
+  -H "Authorization: Bearer $LCT" -H "Content-Type: application/json" \
+  -d '{"session":{"sessionId":"<SESSION_ID>","sessionToken":"<SESSION_TOKEN>"}}'
+```
+
+Expected: **`403` with `Errors.User.GrantRequired`**.
+
+If this returns `200`, the restricted gate is not in force. Stop and fix before proceeding — every later phase assumes this refusal.
+
+- [ ] **Step 4: Confirm the storefront project ADMITS the same user**
+
+Repeat Step 3 with the `mark8ly-storefront-web` client id and its redirect URI, using a fresh auth request.
+
+Expected: `200` with a `callbackUrl` containing `?code=`.
+
+- [ ] **Step 5: Delete the throwaway user and verify it is gone**
+
+```bash
+curl -s -X DELETE https://auth.tesserix.app/v2/users/verify524NoRoleUserAaBb123 -H "Authorization: Bearer $PAT"
+curl -s -o /dev/null -w '%{http_code}\n' https://auth.tesserix.app/v2/users/verify524NoRoleUserAaBb123 -H "Authorization: Bearer $PAT"
+```
+
+Expected: `200` then `404`.
+
+- [ ] **Step 6: Record and commit the results**
+
+Write `docs/zitadel-mark8ly-verification.md` with the date, the two project IDs, and the observed status codes from Steps 1, 3, 4 and 5.
+
+```bash
+git add docs/zitadel-mark8ly-verification.md
+git commit -m "docs(zitadel): record the mark8ly project isolation verification"
+```
+
+---
+
+### Task 6: Add unread Zitadel config to the mark8ly charts
+
+Config lands before any code reads it. A required env var whose validation rejects an empty value crashloops the moment it merges, and no test catches that — so every value here is added while nothing consumes it.
+
+**Files:**
+- Modify: `charts/apps/mark8ly-auth-bff/values.yaml` (add a `zitadel:` block alongside the existing `gip:` block)
+- Modify: `charts/apps/mark8ly-auth-bff/templates/deployment.yaml` (add env entries)
+- Modify: `charts/apps/mark8ly-auth-bff/Chart.yaml` (version bump)
+
+**Interfaces:**
+- Consumes: Task 2's project IDs; Task 4's `mark8ly-zitadel` secret.
+- Produces: env vars `ZITADEL_ISSUER`, `ZITADEL_ADMIN_PROJECT_ID`, `ZITADEL_STOREFRONT_PROJECT_ID`, `ZITADEL_CLIENT_ID`, `ZITADEL_CLIENT_SECRET`, `ZITADEL_LOGIN_CLIENT_TOKEN` on the `auth-bff` pod. Phase 2 reads them.
+
+- [ ] **Step 1: Add the values block**
+
+In `charts/apps/mark8ly-auth-bff/values.yaml`, alongside the existing `gip:` block:
+
+```yaml
+# Zitadel identity. Present but UNREAD until phase 2 lands the login client.
+# GIP remains the live provider; nothing here changes behaviour.
+zitadel:
+  issuer: https://auth.tesserix.app
+  adminProjectId: "<ADMIN_PROJECT_ID>"
+  storefrontProjectId: "<STOREFRONT_PROJECT_ID>"
+  # Credentials come from the mark8ly-zitadel ExternalSecret.
+  secretName: mark8ly-zitadel
+```
+
+- [ ] **Step 2: Add the env entries**
+
+In `charts/apps/mark8ly-auth-bff/templates/deployment.yaml`, inside the container's `env:` list:
+
+```yaml
+            - name: ZITADEL_ISSUER
+              value: {{ .Values.zitadel.issuer | quote }}
+            - name: ZITADEL_ADMIN_PROJECT_ID
+              value: {{ .Values.zitadel.adminProjectId | quote }}
+            - name: ZITADEL_STOREFRONT_PROJECT_ID
+              value: {{ .Values.zitadel.storefrontProjectId | quote }}
+            - name: ZITADEL_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.zitadel.secretName }}
+                  key: ZITADEL_CLIENT_ID
+            - name: ZITADEL_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.zitadel.secretName }}
+                  key: ZITADEL_CLIENT_SECRET
+            - name: ZITADEL_LOGIN_CLIENT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.zitadel.secretName }}
+                  key: ZITADEL_LOGIN_CLIENT_TOKEN
+```
+
+- [ ] **Step 3: Render the template and confirm the env vars appear**
+
+Run: `helm template charts/apps/mark8ly-auth-bff | grep -A2 ZITADEL_ISSUER`
+Expected: the rendered env entry with the issuer URL.
+
+- [ ] **Step 4: Lint and bump the chart version**
+
+Increment `version` in `charts/apps/mark8ly-auth-bff/Chart.yaml`.
+
+Run: `helm lint charts/apps/mark8ly-auth-bff`
+Expected: `0 chart(s) failed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charts/apps/mark8ly-auth-bff/values.yaml \
+        charts/apps/mark8ly-auth-bff/templates/deployment.yaml \
+        charts/apps/mark8ly-auth-bff/Chart.yaml
+git commit -m "feat(mark8ly-auth-bff): land Zitadel config ahead of the login client"
+```
+
+- [ ] **Step 6: After merge, confirm the pod still starts**
+
+Run: `kubectl rollout status deploy/mark8ly-auth-bff -n mark8ly --timeout=180s`
+Expected: `successfully rolled out`. The new env vars are present and unread; behaviour is unchanged.
+
+---
+
+## Phase 1 completion criteria
+
+- `zitadel-bootstrap` reconciles `projectRoleCheck` and its CronJob completes clean.
+- `mark8ly-admin` refuses a role-less user at OIDC finalize with `Errors.User.GrantRequired`; `mark8ly-storefront` admits the same user. Both recorded in `docs/zitadel-mark8ly-verification.md`.
+- `POST /v2/users/human` preserves a caller-supplied GIP-shaped `userId` on this instance.
+- `mark8ly-auth-bff` runs with Zitadel config present and unread; GIP remains the live provider.
+
+## Remaining phases
+
+Each becomes its own plan, written after the phase before it lands. Phases 2–5 build behind a disabled flag; phase 6 is the single cutover commit, per spec D5 and hms's "two providers at once is the worst state".
+
+| Phase | Scope |
+|---|---|
+| 2 | `auth-bff` Zitadel login client + `decideSufficiency` (fail-closed, compile-error-to-omit) + archtest, behind a disabled flag |
+| 3 | Frontends post credentials to `auth-bff` instead of calling the GIP SDK; storefront trampoline reshaped for Zitadel |
+| 4 | `marketplace-api` verifier replacement; drop the `tenant_id` custom claim, resolve tenancy from FGA |
+| 5 | `platform-api` `gipadmin` → Zitadel management API; signup via `POST /v2/users/human` |
+| 6 | Cutover: flip the flag, recreate the four password accounts, delete `gipkey`, `usermfa`, both GIP verifiers and all GIP config |

--- a/docs/superpowers/plans/2026-09-03-zitadel-phase1-infrastructure.md
+++ b/docs/superpowers/plans/2026-09-03-zitadel-phase1-infrastructure.md
@@ -35,7 +35,7 @@ The `restricted` gate is the entire structural guarantee of spec decision D2 —
 
 **Interfaces:**
 - Consumes: nothing from earlier tasks.
-- Produces: `platformProjects[].projectRoleCheck` (bool, optional, default `False`) is honoured by the reconciler. Task 3 sets it to `true` for `mark8ly-admin`.
+- Produces: `platformProjects[].projectRoleCheck` (bool, optional) is honoured by the reconciler. **Absent means unmanaged — the reconciler does not touch the flag.** Task 3 declares it explicitly on both mark8ly projects (`true` for `mark8ly-admin`, `false` for `mark8ly-storefront`).
 
 - [ ] **Step 1: Write the failing tests**
 

--- a/docs/superpowers/specs/2026-09-03-zitadel-migration-design.md
+++ b/docs/superpowers/specs/2026-09-03-zitadel-migration-design.md
@@ -1,0 +1,378 @@
+# Migrating mark8ly authentication from GIP to Zitadel
+
+Design for #524. Written 2026-09-03.
+
+Every claim marked **VERIFIED** below was observed against the live instance
+(`auth.tesserix.app`, zitadel v4.15.3) or against production data on
+2026-09-03, not read from documentation. Throwaway users and projects created
+during verification were deleted and confirmed gone.
+
+## Why this is smaller than #524 assumes, and where the risk actually is
+
+#524 lists `autologin`, `deviceguard`, `emailotp`/`loginotp`, `adminhandoff`,
+`session` and MFA/TOTP as needing "a Zitadel equivalent or a deliberate
+decision to drop". **None of them call GIP.** They are our own code sitting
+downstream of a GIP-issued `sub`.
+
+The real GIP surface is:
+
+1. Two independent token verifiers — `auth-bff`'s hand-rolled JWKS verifier
+   (`keyfunc` + `golang-jwt`) and `marketplace-api`'s Firebase Admin SDK
+   verifier (`internal/auth/gip_verifier.go`) for mobile bearer tokens. Only
+   the second reads the `tenant_id` custom claim.
+2. `gipadmin` — five Identity Toolkit REST endpoints.
+3. `gipkey` — deleted outright, see below.
+4. `/auth/me/providers`.
+
+The sibling checkout `tesserix-new/auth-bff` is a different, stale service
+(module `github.com/tesserix/auth-bff`, last commit 2026-04-04) and is **not**
+in scope. All live auth code is `mark8ly/services/auth-bff`.
+
+**There are no users to migrate.** VERIFIED: production GIP holds 13 accounts
+across all mark8ly pools (`MP-Internal-e986p` 5, `MP-Customer-39opy` 4,
+`Platform-9bu14` 3, UAT pools 1). Four carry a password hash. **Zero** have MFA
+enrolled. `mark8ly_marketplace_api` agrees: 5 customer profiles, 11 user
+profiles, 3 orders, 3 stores. `user_mfa` in `mark8ly_platform_api` has **0
+rows**.
+
+So the risk is entirely in the code, not the data — which is what #524 says:
+five defects (#493, #499, #502, #503, #504) shipped with passing tests, all in
+the seams. This design's job is to not add more seams.
+
+**Timing.** This migration is far cheaper now than after the CRM push converts
+leads. Every converted merchant brings passwords, staff accounts and storefront
+customers. The data risk grows; the code risk does not shrink by waiting.
+
+## Decisions
+
+| # | Decision |
+|---|---|
+| D1 | One Zitadel org: `TESSERIX`. No new orgs, no org-per-tenant. |
+| D2 | Two projects: `mark8ly-admin` (`restricted`) and `mark8ly-storefront` (`public`). |
+| D3 | Full login-client model over the OIDC authorization request. Our existing login page is kept. |
+| D4 | GIP UIDs are preserved as Zitadel `userId`. |
+| D5 | No user migration. Recreate the four password accounts by hand. Atomic cutover, no dual-run. |
+| D6 | Delete `usermfa`; use Zitadel TOTP. Keep `deviceguard` and `emailotp`. |
+| D7 | Drop the `tenant_id` custom claim; resolve tenancy from FGA. |
+| D8 | Delete `gipkey` and the server/browser API key split. |
+| D9 | `Platform-9bu14` is out of scope — it is tesserix-home's pool and no mark8ly Go code reads it. |
+
+### D1 — one org, one human, one account
+
+The org is Zitadel's user namespace; projects and apps are not. One org
+therefore means **one human, one user account**. A merchant who also shops is
+the same user with the same `sub`, holding different authority in different
+places. There is no duplicate-email ambiguity because no second account is ever
+created.
+
+This matters because two users sharing an email make login non-deterministic —
+a trap tesserix-home hit in production on 2026-08-19.
+
+`customer_profiles` is unaffected: it is keyed `(store_id, email)` and
+`(store_id, gip_uid)`, so one uid across several stores is already the normal
+case.
+
+### D2 — two projects, because app-level isolation does not exist
+
+VERIFIED: an OIDC application's entire configuration is `accessTokenType,
+allowedOrigins, appType, authMethodType, clientId, clockSkew, grantTypes,
+idTokenUserinfoAssertion, redirectUris, responseTypes`. There is **no field
+restricting which users may authenticate to an application**. The isolation
+boundary is the project.
+
+Today `mp-internal` and `mp-customer` are separate GIP pools, so a storefront
+customer cannot authenticate against the internal surface at all. That property
+is preserved structurally by splitting the projects and setting
+`mark8ly-admin` to `restricted` (`projectRoleCheck: true`), rather than
+behaviourally by relying on our own checks.
+
+| Project | Access | Applications |
+|---|---|---|
+| `mark8ly-admin` | `restricted` | Mark8ly Admin Web (User Agent, `admin.mark8ly.com`), Mark8ly Admin Mobile (Native) |
+| `mark8ly-storefront` | `public` | Mark8ly Storefront Web (User Agent, trampoline origin), Mark8ly Storefront Mobile (Native) |
+
+No onboarding application: onboarding has signup, not login, and signup is a
+server-side management-API call (see D7).
+
+`auth-bff` additionally needs one **confidential** client. The
+`zitadel-operator` issues public PKCE clients only — a confidential client is
+explicitly out of its contract — so that one client is hand-created with a GCP
+Secret Manager handoff, the pattern `zitadel-bootstrap`'s `platformProjects`
+already uses for AgentGateway, AgentRegistry and Atlantis.
+
+Accepted risks, inherited rather than created:
+
+- The login-client PAT is **instance-level**. hms's runbook: it "can check
+  anyone's password and mint a session for anyone... the most powerful
+  credential this application holds." Zitadel offers no narrower role.
+- `mark8ly-storefront` being `public` means any `TESSERIX` user can
+  authenticate to it, including staff of other products. This matches today's
+  open customer pool, so it is not a regression — but it is a decision.
+- A single shared instance means one Zitadel outage signs out every Tesserix
+  product at once.
+
+### D3 — full login-client, because Session-API-only does not enforce the role check
+
+This was the decisive experiment. With a `restricted` project and a user
+holding **no role**:
+
+| Path | Result |
+|---|---|
+| `POST /v2/sessions` (Session API only) | **201, session created.** Password genuinely verified (`password.verifiedAt` set; wrong password → 400 `COMMAND-3M0fs`). The project role check never runs. |
+| `POST /v2/oidc/auth_requests/{id}` (finalize) | **403 `Errors.User.GrantRequired (OIDC-foSyH49RvL)`** |
+| Same, after granting a role (positive control) | **200 + `callbackUrl?code=…`** |
+
+A Session-API-only design would therefore produce a topology that looks
+isolated and is not, with nothing in the API to reveal it. D2's guarantee only
+exists if login goes through the OIDC authorization request.
+
+Flow:
+
+```
+browser --> /oauth/v2/authorize                    [creates V2 auth request]
+        <-- 302 to OUR login page ?authRequest=V2_…
+browser --> existing login UI --POST creds--> auth-bff
+            auth-bff: POST /v2/sessions            [Zitadel verifies password]
+            auth-bff: decideSufficiency(...)       [fail-closed, ours]
+            auth-bff: addTotpCheck if required     [Zitadel TOTP]
+            auth-bff: POST /v2/oidc/auth_requests/{id}   <-- role check enforced HERE
+        <-- callbackUrl?code=…
+auth-bff: exchange code
+          -> FGA CheckMembership (8 retries)  ] unchanged
+          -> deviceguard                      ] unchanged
+          -> email OTP                        ] unchanged
+          -> mint m8_session                  ] unchanged
+```
+
+Everything after the code exchange is today's code. A user can complete Zitadel
+authentication and still not receive an `m8_session` — precisely today's
+semantics, where a valid GIP token must still pass our gates.
+
+**Cost to acknowledge:** this adds a redirect round-trip to storefront customer
+login, where there is none today. Unremarkable for merchant admin; a real
+change for checkout conversion.
+
+**Storefront origin.** VERIFIED: `loginVersion.loginV2.baseUri` is a single
+origin and must carry no path. Per-tenant subdomains cannot each be a login
+origin. This is the problem `apps/onboarding/app/auth/google` already solves for
+Google, whose OAuth client has the same limitation — fixed registered origin at
+`mark8ly.com`, short-lived HMAC exchange code, bounce back to the store's
+`/auth/google/finish`. Storefront login reuses that shape. Custom admin domains
+reuse `adminhandoff` for the same reason.
+
+Note the boundary confusion worth writing down: the **Storefront Web Zitadel
+application's redirect URI physically lives in the onboarding Next.js app**,
+because that is what serves `mark8ly.com`. The Zitadel app boundary is not the
+Next.js app boundary.
+
+### D4 — preserve the subject
+
+VERIFIED: `POST /v2/users/human` accepts a caller-supplied `userId` and stores
+it **verbatim** — a 28-character alphanumeric GIP-shaped id was accepted and
+read back `USER_STATE_ACTIVE`, despite Zitadel's own ids being numeric
+snowflakes. `userId` cannot be changed after creation. VERIFIED: `sub == userId`
+in a real minted token (`mark8ly-catalog-reader`: sub `388414281508455697`).
+
+This matters because OpenFGA's subject is the raw GIP uid concatenated as
+`"user:" + userID`, and the same uid is denormalised into
+`tenants.owner_user_id`, `invitations.invited_by_user_id`,
+`invitations.accepted_by_user_id`, `user_sessions.user_id`, `user_mfa.user_id`
+(PK), live `m8_session` cookies, and the `X-User-Id` header contract between
+`marketplace-api` and `auth-bff`.
+
+The FGA **model** needs no changes at all: `infra/openfga/model.fga` declares a
+bare `type user` with no attributes, and objects are `tenant:<our UUID>` /
+`store:<our UUID>`. Nothing touches a GIP claim shape.
+
+**Required post-condition of the import: assert the returned `userId` equals
+the GIP uid.** If the import ever silently falls back to a generated id the
+failure is not loud — `user_mfa` and `user_sessions` are keyed by that uid, so
+the symptom is un-enrolled MFA and every device re-challenged, not an error.
+
+VERIFIED caveat: caller-supplied ids are **human-users-only** on v4.15.3.
+`POST /v2/users/machine` returns 405, and the management-v1 fallback has no
+`userId` field.
+
+### D5 — no user migration, atomic cutover
+
+Password hashes cannot move: Zitadel's own Firebase guide states it has no
+verifier for Firebase's proprietary modified scrypt, and `zitadel/passwap`
+ships no firebase package (`argon2, bcrypt, drupal7, md5, md5plain, md5salted,
+pbkdf2, phpass, scrypt, sha2`; its `scrypt` is standard scrypt with no salt
+separator or signer key). A custom verifier would mean forking and
+self-building Zitadel.
+
+Just-in-time migration against GIP `accounts:signInWithPassword` is the
+documented way to avoid resets, and was the plan until the row counts came in.
+With four password accounts it is unjustifiable machinery. Recreate them by
+hand.
+
+That removes the only reason for dual-run, so hms's conclusion applies
+unchanged: "Tasks 2-8 are ONE cutover and must merge together ... Two providers
+at once is the worst state."
+
+Federated users have no password and import clean, but the IDP link only works
+if the OAuth client id matches between systems. Passkeys do not transfer unless
+the domain is identical. TOTP is moot — nobody is enrolled.
+
+### D6 — delete `usermfa`, keep `deviceguard` and `emailotp`
+
+VERIFIED: `user_mfa` has 0 rows and 0 enabled; GIP MFA enrolment is 0 across
+all pools. So this decision affects nobody.
+
+Under the login-client model the session API expects TOTP via `addTotpCheck`.
+Keeping our own TOTP would mean two TOTP systems against one session — worse
+than either. Deleting ours also drops AES-GCM secret-at-rest handling and
+server-side PNG QR generation we have no reason to own.
+
+`deviceguard` and `emailotp` stay unchanged: Zitadel has no
+new-device-email-OTP concept, neither calls GIP, and because D4 preserves the
+subject, `user_sessions.user_id` stays valid — known devices stay known and
+nobody is re-challenged at cutover.
+
+**The sufficiency check is the load-bearing new code.** VERIFIED independently
+by hms and tesserix-home against the live instance: under `forceMfa: true`,
+Zitadel **still issues an authorization code for a password-only session**. It
+does not refuse and does not signal a missing factor. MFA enforcement is
+therefore entirely ours.
+
+Required shape, copied from hms rather than reinvented: a pure
+`decideSufficiency(policy, factors, checks)`, fail-closed on every uncertain
+input, with `finalize` unexported and taking an unexported branded type so
+omitting the check is a compile error, plus an archtest pinning the single call
+site.
+
+Four failure modes it must handle, all found in production by others:
+
+- **protojson elides zero-value fields.** A healthy login policy never sends
+  `forceMfa` at all when false. Decode into `map[string]any` with an anchor
+  field, not a struct. (Same elision: `projectRoleCheck` is absent from the
+  project JSON when false — VERIFIED on the HomeChef project — and
+  `POST /v2/sessions` omits `factors` in its create response, so the session
+  must be re-read with `GET` to see what was actually verified.)
+- **`forceMfaLocalOnly`** forces MFA while `forceMfa` reads absent.
+- **Read the policy scoped to the user's org** (`x-zitadel-orgid`), refusing an
+  empty org id rather than falling back. hms #913 was a cross-org MFA bypass
+  from exactly this.
+- **The session token rotates on every TOTP check.** Returning the input token
+  makes finalize fail *after* a correct code, which the user reads as "my code
+  was wrong". The method is `PATCH`; `POST` returns 405.
+
+### D7 — `gipadmin` replacement, and dropping the custom claim
+
+| Today (GIP) | Zitadel |
+|---|---|
+| `sendOobCode` (PASSWORD_RESET, `returnOobLink`) | `POST /v2/users/{id}/password_reset`, returning the code so we send the mail |
+| `accounts:resetPassword` | `POST /v2/users/{id}/password` with `verificationCode` |
+| `accounts:delete` | `DELETE /v2/users/{id}` (VERIFIED) |
+| `accounts:lookup` → `/auth/me/providers` | `GET /v2/users/{id}/authentication_methods` |
+| `customAttributes` read/write | **dropped — see below** |
+
+Returning the code rather than letting Zitadel send the mail preserves today's
+behaviour (`returnOobLink=true`) and keeps branding and delivery on the
+existing `notify` → platform-api path rather than the shared instance's SMTP.
+
+**The `tenant_id` custom claim is dropped, not ported.** Zitadel has user
+metadata, but metadata is not in the token; putting it there needs an Actions
+v2 "complement token" script — a new runtime dependency on a shared instance.
+hms faced the same choice and deliberately minted its own claim instead of
+asking Zitadel for one. Its only consumer is `marketplace-api`'s mobile bearer
+verifier, which will resolve tenancy from FGA exactly as `autologin` already
+does. This deletes the read-modify-write dance that exists only because GIP has
+no partial update for `customAttributes`.
+
+**Signup** is a server-side `POST /v2/users/human` from `platform-api`. No
+browser client, no app registration.
+
+VERIFIED: creating a user via `/v2/users/human` with
+`{"password":{"password":…}}` and then authenticating with that password works.
+This sidesteps hms's management-v1 trap, where sending `password` instead of
+`initialPassword` returns 201 with a `userId` and leaves no usable credential.
+`email.isVerified` must be set deliberately; omitting it leaves the user
+`USER_STATE_INITIAL` and unable to log in.
+
+### D8 — delete `gipkey`
+
+`gipkey` exists only because GIP browser API keys are HTTP-referrer restricted,
+so a verified custom domain must be patched onto the key's `allowedReferrers`
+or the storefront's `signInWithPassword` fails with
+`API_KEY_HTTP_REFERRER_BLOCKED`. Zitadel has no such concept.
+
+Deleting it also retires the `GIP_SERVER_API_KEY` / `GIP_WEB_API_KEY` split
+from #499 and tesserix-k8s#780, and the latent hazard that `auth-bff`'s
+`/auth/me/providers` uses the browser key for a server-side call.
+
+## What is reusable
+
+- `tesserix-home/platform-auth/` — standalone Go module, own `go.mod`, single
+  dependency `go-oidc/v3`, JWKS verification with no introspection. Near
+  drop-in: swap the capability vocabulary, set issuer and project id. Its
+  `middleware.go` is `net/http` and needs re-shaping for Gin.
+- `packages/platform-auth/src/zitadel.ts` — the TS twin, `jose` only.
+- hms's `sufficiency.go` and its login-client HTTP client shape.
+- hms's `docs/runbooks/` and tesserix-home's `RUNBOOK-ZITADEL-IDENTITY.md` —
+  the documented traps are worth more than the code.
+
+Neither repo uses a Zitadel SDK; both hand-roll against generic OIDC libraries
+so they control the wire shape. We do the same. (The Go SDK does not expose
+`UserId` — zitadel/zitadel#8146, closed as not planned — which would otherwise
+block D4.)
+
+## Infrastructure
+
+Existing shared instance, no new infrastructure: `auth.tesserix.app`,
+`zitadel:v4.15.3`, 3 replicas + HPA, CloudNativePG (not Cloud SQL) with mTLS,
+behind a dedicated Istio gateway because Zitadel PATs are opaque rather than
+JWTs and Envoy 401'd every authenticated call.
+
+Two `ZitadelProject` / `ZitadelApplication` claim files under
+`tesserix-k8s/k8s/operators/zitadel/claims/`, plus the hand-created confidential
+client for `auth-bff` and its login-client machine user.
+
+VERIFIED trap: `PUT .../oidc_config` is a **full replace, not a patch**. A
+`loginVersion`-only PUT silently resets `authMethodType` and breaks token
+exchange — the bug that broke every hms login for the life of a PR. Any write to
+an app's OIDC config must send every field.
+
+VERIFIED: per-app `loginVersion.loginV2.baseUri` works on this instance, so we
+are not blocked by the `LOGINV2_REQUIRED` upstream bug (zitadel/zitadel#10722).
+Without `loginVersion` set to V2, `/authorize` redirects to `/ui/login/login`
+(V1) and the v2 API cannot finalize that request.
+
+Chart changes need a `Chart.yaml` version bump or `ct lint` fails.
+
+## Testing
+
+Unit tests are explicitly not the mitigation — every one of the five defects
+this issue cites had them. The mitigation is exercising the real flows:
+
+- `decideSufficiency` — table-driven over absent/false/true `forceMfa`,
+  `forceMfaLocalOnly`, unknown policy, unknown factors. Fail-closed asserted for
+  every uncertain input.
+- An archtest pinning the single `finalize` call site.
+- An end-to-end test that a user with **no role** on `mark8ly-admin` is refused
+  at finalize, and admitted once granted — the D2 guarantee, asserted rather
+  than assumed.
+- A cross-site cookie probe. hms ran app and IdP on different ports of
+  `localhost`, which is same-site, so no test could catch a `SameSite` failure.
+  Dev must use distinct registrable domains.
+- An import post-condition test asserting the returned `userId` equals the GIP
+  uid (D4).
+- Manual walk of the real merchant login path before cutover, including new
+  device → email OTP.
+
+## Open questions
+
+1. **Storefront redirect round-trip.** D3 adds one to customer login. Acceptable
+   for conversion, or worth a storefront-specific mitigation?
+2. **Mobile.** The repo has `apps/mobile-admin`, `apps/mobile-storefront` and
+   `apps/storefront-mobile`. The Native app registrations depend on which are
+   real; needs confirming before the claim files are written.
+3. **`mark8ly-storefront` is `public`**, so any `TESSERIX` user can
+   authenticate to it. Matches today, but should be an explicit acceptance.
+
+## Non-goals
+
+Not an implementation plan and not an estimate. Zitadel Actions are not used.
+No new Zitadel instance. `Platform-9bu14` and tesserix-home's identity model are
+out of scope.

--- a/docs/superpowers/specs/2026-09-03-zitadel-migration-design.md
+++ b/docs/superpowers/specs/2026-09-03-zitadel-migration-design.md
@@ -365,9 +365,13 @@ this issue cites had them. The mitigation is exercising the real flows:
 
 1. **Storefront redirect round-trip.** D3 adds one to customer login. Acceptable
    for conversion, or worth a storefront-specific mitigation?
-2. **Mobile.** The repo has `apps/mobile-admin`, `apps/mobile-storefront` and
-   `apps/storefront-mobile`. The Native app registrations depend on which are
-   real; needs confirming before the claim files are written.
+2. **Mobile — likely resolved.** Of the three candidates, `apps/mobile-admin`
+   (317 TS files, last commit 2026-08-15) and `apps/storefront-mobile` (80
+   files, 2026-08-15) are live; `apps/mobile-storefront` (35 files, last commit
+   2026-05-10) appears abandoned and superseded by `storefront-mobile`. So
+   **two** Native registrations, not three. Confirm before writing the claim
+   files — a wrong guess here registers an app nobody uses, or omits one people
+   do.
 3. **`mark8ly-storefront` is `public`**, so any `TESSERIX` user can
    authenticate to it. Matches today, but should be an explicit acceptance.
 


### PR DESCRIPTION
Design and phase-1 plan for #524. Documents only — no code, no behaviour change.

The spike behind this is written up in two comments on #524. The short version
is that the issue's own scope estimate was wrong in both directions, and the
design says so.

## Smaller than #524 assumed

`autologin`, `deviceguard`, `emailotp`/`loginotp`, `adminhandoff`, `session`
and MFA/TOTP are listed in the issue as needing a Zitadel equivalent. **None of
them call GIP.** They are our own code sitting downstream of a GIP-issued
`sub`. The real GIP surface is two token verifiers, `gipadmin`, `gipkey`, and
one route — and `gipkey` disappears entirely, taking the #499 server/browser
key split with it.

There is also nothing to migrate: production GIP holds 13 accounts across all
mark8ly pools, four with a password, zero with MFA enrolled. So no dual-run, no
JIT password machinery, no reset event — recreate four accounts by hand and cut
over atomically.

## Larger than #524 assumed, in one place

Zitadel does **not** enforce MFA on the login-client path. Under
`forceMfa: true` it still issues an authorization code for a password-only
session, with no refusal and no signal. Found independently by `helivanta`
(hms) and `tesserix-home` against the live instance. MFA enforcement is
entirely application code, and the design specifies hms's fail-closed
`decideSufficiency` with a compile-error-to-omit call site.

## Verified rather than assumed

Every claim marked **VERIFIED** in the spec was observed against
`auth.tesserix.app` (v4.15.3) or production data on 2026-09-03. Throwaway
users and projects were deleted and confirmed gone. The load-bearing ones:

- `POST /v2/users/human` preserves a caller-supplied 28-char GIP-shaped
  `userId` verbatim, and `sub == userId` in a real minted token — so OpenFGA
  tuples and six denormalised columns need no migration.
- A `restricted` project refuses a role-less user at OIDC finalize
  (`Errors.User.GrantRequired`) but **not** at Session-API session creation.
  This killed a simpler design that would have looked isolated and not been.
- An OIDC application has no field restricting who may authenticate; the
  isolation boundary is the project. Hence two projects, not one.

## Decisions

D1 one org (`TESSERIX`) → one human, one account. D2 two projects,
`mark8ly-admin` restricted. D3 full login-client over OIDC, keeping our
existing login page. D4 preserve GIP UIDs. D5 no user migration, atomic
cutover. D6 delete `usermfa` (0 enrolments anywhere), keep `deviceguard` and
`emailotp`. D7 drop the `tenant_id` custom claim. D8 delete `gipkey`.
D9 `Platform-9bu14` out of scope.

## Phasing

Six phases. 2–5 build behind a disabled flag; 6 is the single cutover commit,
honouring D5 without leaving `main` half-migrated for weeks.

Phase 1 (infrastructure) is planned in full and its Task 1 is already
implemented in tesserix-k8s#878. Tasks 2, 4 and 5 are human-executed — they
need instance credentials and mint one-time secrets.

## Note on the plan's own history

Task 1's plan text originally defaulted an undeclared `projectRoleCheck` to
`False`, which would have disabled the authentication gate on three other
products. Two commits here correct the committed plan so a future executor
cannot re-derive the defect. See tesserix-k8s#878 for the fix and its
regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xQ7gJoonbQZmnnbfPD5RE
