### PR TITLE
fix(carriersecrets): real Prometheus counter, and count failed gsm:// reads (#608)

### DIFF
--- a/services/marketplace-api/cmd/carrier-secrets-backfill/main.go
+++ b/services/marketplace-api/cmd/carrier-secrets-backfill/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/carriersecrets"
 	"github.com/mark8ly/marketplace-api/internal/crypto"
+	"github.com/mark8ly/marketplace-api/internal/metrics"
 	"github.com/mark8ly/marketplace-api/pkg/config"
 	"github.com/mark8ly/marketplace-api/pkg/db"
 )
@@ -69,9 +70,6 @@ func main() {
 		apiKeyEncryptor = crypto.NewNoopEncryptor()
 	}
 
-	carrierSecretCounter := func(label string, n int64) {
-		log.Info("carriersecrets: metric", "label", label, "count", n)
-	}
 	secretStore, degraded, buildErr := carriersecrets.Build(context.Background(), carriersecrets.BuildParams{
 		Mode:         cfg.ShippingSecretStore,
 		GCPProjectID: cfg.GCPProjectID,
@@ -81,7 +79,7 @@ func main() {
 		OpenBaoRole:  cfg.OpenBaoRole,
 		Encryptor:    apiKeyEncryptor,
 		Logger:       log,
-		Counter:      carrierSecretCounter,
+		Counter:      metrics.CarrierSecretCounter,
 	})
 	if buildErr != nil {
 		log.Error("carrier-secrets-backfill: carrier secret store build failed", "err", buildErr)

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -424,24 +424,6 @@ func main() {
 	// independently of whatever mount the OpenBao client is configured
 	// with, so a mismatch there would otherwise fail every read/write
 	// at runtime instead of at boot).
-	// carrierSecretCounter feeds ChainStore's fallback-read counter and
-	// CachingStore's stale-read counter. There is no existing Prometheus
-	// CounterVec for carriersecrets metrics and this task's file scope
-	// (main.go / pkg/config) doesn't extend to adding one in
-	// internal/metrics, so this is a logging sink rather than a silent
-	// nil — grep logs for "carriersecrets: metric" to watch these two
-	// counters until a real CounterVec lands.
-	//
-	// IMPORTANT — phase-2 placeholder only, tracked separately as a
-	// blocker: a log line has no aggregation, no retention guarantee,
-	// and is vulnerable to sampling/log-loss across pods. A REAL metric
-	// (a Prometheus CounterVec) is REQUIRED before FallbackReadMetric
-	// can be trusted for the "zero for N days" decision that gates
-	// decommissioning GCP Secret Manager. Do not treat this closure as
-	// sufficient evidence for that decision.
-	carrierSecretCounter := func(label string, n int64) {
-		log.Info("carriersecrets: metric", "label", label, "count", n)
-	}
 	// The construction itself — the mode switch this comment block
 	// describes — lives in internal/carriersecrets.Build, shared with
 	// cmd/refund-sweep-cron so the two callers cannot drift the way that
@@ -459,7 +441,7 @@ func main() {
 		OpenBaoRole:  cfg.OpenBaoRole,
 		Encryptor:    apiKeyEncryptor,
 		Logger:       log,
-		Counter:      carrierSecretCounter,
+		Counter:      metrics.CarrierSecretCounter,
 	})
 	if buildErr != nil {
 		log.Error("carriersecrets: build failed", "err", buildErr, "shipping_secret_store", cfg.ShippingSecretStore)

--- a/services/marketplace-api/cmd/refund-sweep-cron/main.go
+++ b/services/marketplace-api/cmd/refund-sweep-cron/main.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/carriersecrets"
 	"github.com/mark8ly/marketplace-api/internal/crypto"
+	"github.com/mark8ly/marketplace-api/internal/metrics"
 	"github.com/mark8ly/marketplace-api/internal/order"
 	"github.com/mark8ly/marketplace-api/internal/orderrefund"
 	"github.com/mark8ly/marketplace-api/internal/outbox"
@@ -93,9 +94,6 @@ func main() {
 	// error): resolving credentials is the entire point of this job, so
 	// a build that can't produce a working store must not run a sweep
 	// that will just fail every row's gateway call again.
-	carrierSecretCounter := func(label string, n int64) {
-		log.Info("carriersecrets: metric", "label", label, "count", n)
-	}
 	secretStore, degraded, buildErr := carriersecrets.Build(context.Background(), carriersecrets.BuildParams{
 		Mode:         cfg.ShippingSecretStore,
 		GCPProjectID: cfg.GCPProjectID,
@@ -105,7 +103,7 @@ func main() {
 		OpenBaoRole:  cfg.OpenBaoRole,
 		Encryptor:    apiKeyEncryptor,
 		Logger:       log,
-		Counter:      carrierSecretCounter,
+		Counter:      metrics.CarrierSecretCounter,
 	})
 	if buildErr != nil {
 		log.Error("refund-sweep-cron: carrier secret store build failed", "err", buildErr, "shipping_secret_store", cfg.ShippingSecretStore)

--- a/services/marketplace-api/internal/carriersecrets/cache.go
+++ b/services/marketplace-api/internal/carriersecrets/cache.go
@@ -11,7 +11,7 @@ import (
 // failed. This is the only signal that OpenBao (or GCP SM) had a blip
 // that checkout/shipping-rates/payment-webhook rode out on a cached
 // credential instead of failing outright.
-const StaleReadMetric = "carriersecrets_stale_read"
+const StaleReadMetric = "stale_read"
 
 // cacheEntry holds one cached reference's plaintext and the clock time it
 // was fetched at.

--- a/services/marketplace-api/internal/carriersecrets/chain.go
+++ b/services/marketplace-api/internal/carriersecrets/chain.go
@@ -44,7 +44,7 @@ const (
 // reference that is still being read as gsm:// keeps firing this counter
 // at least that often — "durably zero" still means "no gsm:// reads
 // happened", just observed at a coarser cadence than raw request volume.
-const FallbackReadMetric = "carriersecrets_gsm_fallback_read"
+const FallbackReadMetric = "gsm_fallback_read"
 
 // RewrapFailedMetric is the label passed to CounterFn when
 // ChainStore.MaybeRewrap's write fails. The storefront engine holds no
@@ -54,7 +54,7 @@ const FallbackReadMetric = "carriersecrets_gsm_fallback_read"
 // row — this counter, together with the once-per-process log line at the
 // forbidden transition, is what makes that failure VISIBLE instead of a
 // silent no-op with a failing round-trip on every read.
-const RewrapFailedMetric = "carriersecrets_rewrap_failed"
+const RewrapFailedMetric = "rewrap_failed"
 
 // CounterFn is the metric injection hook, called with (label, increment)
 // once per event. Kept generic — like webhookprune.CounterFn — so this
@@ -213,12 +213,17 @@ func (c *ChainStore) Get(ctx context.Context, reference string) (string, error) 
 		return string(data), nil
 	case IsGSMRef(reference):
 		resource, _ := ParseReference(reference)
+		// Count the ATTEMPT, not the success: a failing gsm:// read is
+		// still a live dependency on GCP Secret Manager, and that
+		// dependency must be visible even when the read errors out — a
+		// broken GCP path must never look identical to "no gsm:// reads
+		// happened" in the fallback counter.
+		if c.primary == BackendBao {
+			c.counter(FallbackReadMetric, 1)
+		}
 		data, err := c.gcp.AccessLatest(ctx, resource)
 		if err != nil {
 			return "", fmt.Errorf("carriersecrets: get %s: %w", resource, err)
-		}
-		if c.primary == BackendBao {
-			c.counter(FallbackReadMetric, 1)
 		}
 		return string(data), nil
 	case IsInlineRef(reference):

--- a/services/marketplace-api/internal/carriersecrets/chain_test.go
+++ b/services/marketplace-api/internal/carriersecrets/chain_test.go
@@ -378,6 +378,55 @@ func TestChainStore_GSMReadIncrementsFallbackCounter(t *testing.T) {
 	}
 }
 
+// TestChainStore_FallbackCounterFiresOnFailedGSMRead: a gsm:// read that
+// ERRORS is still a live dependency on GCP Secret Manager — that dependency
+// must be counted even though the read never returns plaintext. Before the
+// fix, ChainStore.Get only incremented the counter AFTER c.gcp.AccessLatest
+// succeeded, so a broken GCP path (down, misconfigured, revoked creds) was
+// invisible to the fallback counter — making a fully-broken GCP dependency
+// look identical to a fully-migrated one, exactly the confusion that could
+// wrongly justify decommissioning a backend still in use.
+func TestChainStore_FallbackCounterFiresOnFailedGSMRead(t *testing.T) {
+	scope := testScope()
+	bao := newRecordingClient()
+	gsmErr := errors.New("gcp secret manager: permission denied")
+	gcp := &erroringClient{err: gsmErr}
+	resource := SecretResource(testProjectID, testPrefix, scope)
+
+	var gotLabel string
+	var gotIncrement int64
+	calls := 0
+	store := NewChainStore(ChainConfig{
+		Bao:          bao,
+		GCP:          gcp,
+		Primary:      BackendBao,
+		GCPProjectID: testProjectID,
+		GCPPrefix:    testPrefix,
+		Counter: func(label string, increment int64) {
+			calls++
+			gotLabel = label
+			gotIncrement = increment
+		},
+	})
+
+	_, err := store.Get(context.Background(), GSMRefPrefix+resource)
+	if err == nil {
+		t.Fatal("Get() error = nil, want error — GCP Secret Manager is down")
+	}
+	if !errors.Is(err, gsmErr) {
+		t.Errorf("Get() error = %v, want it to wrap %v", err, gsmErr)
+	}
+	if calls != 1 {
+		t.Fatalf("counter called %d times, want 1 — a FAILED gsm:// read is still a live GCP SM dependency and must be counted", calls)
+	}
+	if gotLabel != FallbackReadMetric {
+		t.Errorf("counter label = %q, want %q", gotLabel, FallbackReadMetric)
+	}
+	if gotIncrement != 1 {
+		t.Errorf("counter increment = %d, want 1", gotIncrement)
+	}
+}
+
 // TestChainStore_BaoReadDoesNotIncrementFallbackCounter: reading a bao://
 // row must NOT increment the fallback counter.
 func TestChainStore_BaoReadDoesNotIncrementFallbackCounter(t *testing.T) {

--- a/services/marketplace-api/internal/metrics/registry.go
+++ b/services/marketplace-api/internal/metrics/registry.go
@@ -201,6 +201,25 @@ var (
 		},
 		[]string{"tier"},
 	)
+
+	// CarrierSecretEventsTotal counts carriersecrets fall-through-read and
+	// rewrap-failure events, labeled by event
+	// (gsm_fallback_read | stale_read | rewrap_failed). It counts ONLY
+	// reads that fell through to a backend client call — a CachingStore
+	// hit never reaches this counter, so its magnitude under-counts true
+	// credential-read volume by roughly the cache hit ratio. That does
+	// NOT weaken the "zero for N days" decommission signal
+	// gsm_fallback_read exists for: every reference still reaches the
+	// inner store at least once per cache TTL (a miss or an expiry), so a
+	// reference still being read as gsm:// keeps firing this counter at
+	// that coarser cadence regardless of cache hits.
+	CarrierSecretEventsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "carriersecrets_events_total",
+			Help: "Count of carriersecrets fall-through-read and rewrap-failure events, labeled by event (gsm_fallback_read | stale_read | rewrap_failed). Counts fall-through reads only, not all credential reads — CachingStore sits above this counter, so the magnitude under-counts true read volume by the cache hit ratio; the zero/non-zero property still holds because each reference reaches the inner store at least once per cache TTL.",
+		},
+		[]string{"event"},
+	)
 )
 
 func init() {
@@ -224,5 +243,16 @@ func init() {
 		APIKeyUsedTotal,
 		APIKeyAuthFailedTotal,
 		APIKeyRateLimitedTotal,
+		CarrierSecretEventsTotal,
 	)
+}
+
+// CarrierSecretCounter is the single carriersecrets.CounterFn-shaped sink
+// wired into every production Store construction (cmd/marketplace-api,
+// cmd/refund-sweep-cron, cmd/carrier-secrets-backfill). Centralizing it
+// here means the three binaries can never again drift the way that
+// produced mark8ly#166 — each hand-rolling its own counter closure instead
+// of sharing one.
+func CarrierSecretCounter(event string, n int64) {
+	CarrierSecretEventsTotal.WithLabelValues(event).Add(float64(n))
 }

--- a/services/marketplace-api/internal/metrics/registry_test.go
+++ b/services/marketplace-api/internal/metrics/registry_test.go
@@ -1,0 +1,27 @@
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/mark8ly/marketplace-api/internal/metrics"
+)
+
+// TestCarrierSecretCounter_IncrementsRegisteredMetric verifies the shared
+// sink wired into all three carriersecrets binaries (cmd/marketplace-api,
+// cmd/refund-sweep-cron, cmd/carrier-secrets-backfill) actually increments
+// the registered CarrierSecretEventsTotal CounterVec, for each of the three
+// event values the carriersecrets package fires.
+func TestCarrierSecretCounter_IncrementsRegisteredMetric(t *testing.T) {
+	for _, event := range []string{"gsm_fallback_read", "stale_read", "rewrap_failed"} {
+		before := testutil.ToFloat64(metrics.CarrierSecretEventsTotal.WithLabelValues(event))
+
+		metrics.CarrierSecretCounter(event, 1)
+
+		after := testutil.ToFloat64(metrics.CarrierSecretEventsTotal.WithLabelValues(event))
+		if after != before+1 {
+			t.Errorf("event %q: counter = %v, want %v", event, after, before+1)
+		}
+	}
+}


### PR DESCRIPTION
Closes #608. Unblocks the first checkbox on #621 (retire GCP Secret Manager).

## Why this is not just plumbing

The decommission decision rests on one claim: *the GCP fallback counter has been zero for N days*. Until now that counter was a `log.Info` closure. A dropped log line and a genuine zero are indistinguishable and mean opposite things, so the decision would have rested on a log grep.

## It also fixes a real bug

`ChainStore.Get` incremented the fallback counter **only after a successful read**:

```go
data, err := c.gcp.AccessLatest(ctx, resource)
if err != nil {
    return "", fmt.Errorf(...)   // returned BEFORE counting
}
if c.primary == BackendBao {
    c.counter(FallbackReadMetric, 1)
}
```

A **failing** `gsm://` read is still a live dependency on GCP Secret Manager. Under the old ordering it was invisible — so an environment whose GCP path is *broken* looked identical to one that had fully migrated. That is precisely the confusion that could justify deleting a backend still in use.

The increment now fires on the attempt. `TestChainStore_FallbackCounterFiresOnFailedGSMRead` pins it: verified RED (`counter called 0 times, want 1`) against the old ordering, GREEN after.

## The metric

`carriersecrets_events_total{event="gsm_fallback_read" | "stale_read" | "rewrap_failed"}`

The Help text states the two things a reader would otherwise get wrong: it counts **fall-through reads, not all credential reads**, and `CachingStore` sits **above** the counter so the magnitude under-counts by the cache hit ratio. The zero/non-zero property — the only part #621 depends on — still holds, because each reference reaches the inner store at least once per cache TTL.

The label constants lost their redundant `carriersecrets_` prefix so the metric reads cleanly rather than as `event="carriersecrets_gsm_fallback_read"`.

## One shared sink, not three closures

`metrics.CarrierSecretCounter` is now used by all three binaries that construct a store — `marketplace-api`, `refund-sweep-cron` and `carrier-secrets-backfill`.

That is deliberate rather than tidiness: #166 was caused by exactly this shape, where `main.go` and the cron each built their own store construction and drifted, so the cron never received a mode the API had. Three hand-rolled counter closures would drift the same way.

## Test plan

- [x] `go test ./...` — 0 failures
- [x] `TestChainStore_FallbackCounterFiresOnFailedGSMRead` verified RED before GREEN
- [x] Metric registered and increments through the shared sink for all three event values
- [x] All three binaries confirmed on `metrics.CarrierSecretCounter`; no ad-hoc closures remain
- [x] `go build`, `go vet`, `gofmt` clean

## What this enables

#621 can now proceed on evidence:

```
increase(carriersecrets_events_total{event="gsm_fallback_read"}[30d]) == 0
```

All credential references are already `bao://`, so this should sit at zero from here. Watching it stay there is what makes the deletion safe.

Refs #608, #621, #319.
