### PR TITLE
fix(carriersecrets): make secret path segment encoding injective (#606)

### DIFF
--- a/services/marketplace-api/cmd/carrier-secrets-backfill/rowstore_test.go
+++ b/services/marketplace-api/cmd/carrier-secrets-backfill/rowstore_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -32,7 +33,8 @@ func TestPaymentRows_ScopeMapping(t *testing.T) {
 		if got[i].Scope != wantScope {
 			t.Fatalf("row %d scope = %+v, want %+v", i, got[i].Scope, wantScope)
 		}
-		wantPath := "kv/mark8ly/marketplace-api/tenants/" + tenant.String() + "/payment/razorpay/" + field
+		// encodeSegment escapes a literal '_' to "__" to stay injective (#606).
+		wantPath := "kv/mark8ly/marketplace-api/tenants/" + tenant.String() + "/payment/razorpay/" + strings.ReplaceAll(field, "_", "__")
 		if gotPath := carriersecrets.BaoPath(got[i].Scope); gotPath != wantPath {
 			t.Fatalf("BaoPath(%+v) = %q, want %q", got[i].Scope, gotPath, wantPath)
 		}
@@ -65,7 +67,8 @@ func TestShippingRows_ScopeMapping(t *testing.T) {
 		if got[i].Scope != wantScope {
 			t.Fatalf("row %d scope = %+v, want %+v", i, got[i].Scope, wantScope)
 		}
-		wantPath := "kv/mark8ly/marketplace-api/tenants/" + tenant.String() + "/shipping/delhivery/" + field
+		// encodeSegment escapes a literal '_' to "__" to stay injective (#606).
+		wantPath := "kv/mark8ly/marketplace-api/tenants/" + tenant.String() + "/shipping/delhivery/" + strings.ReplaceAll(field, "_", "__")
 		if gotPath := carriersecrets.BaoPath(got[i].Scope); gotPath != wantPath {
 			t.Fatalf("BaoPath(%+v) = %q, want %q", got[i].Scope, gotPath, wantPath)
 		}
@@ -94,7 +97,8 @@ func TestTaxRows_ScopeMapping(t *testing.T) {
 	if got[0].Scope != wantScope {
 		t.Fatalf("scope = %+v, want %+v", got[0].Scope, wantScope)
 	}
-	wantPath := "kv/mark8ly/marketplace-api/tenants/" + tenant.String() + "/tax/taxjar/api_key"
+	// encodeSegment escapes a literal '_' to "__" to stay injective (#606).
+	wantPath := "kv/mark8ly/marketplace-api/tenants/" + tenant.String() + "/tax/taxjar/api__key"
 	if gotPath := carriersecrets.BaoPath(got[0].Scope); gotPath != wantPath {
 		t.Fatalf("BaoPath = %q, want %q", gotPath, wantPath)
 	}
@@ -126,8 +130,10 @@ func TestDomainRows_ScopeMapping(t *testing.T) {
 	if got[0].Scope != wantScope {
 		t.Fatalf("scope = %+v, want %+v", got[0].Scope, wantScope)
 	}
-	// FQDN dots are sanitized to underscores in the KV path.
-	wantPath := "kv/mark8ly/marketplace-api/tenants/" + tenant.String() + "/platform/cloudflare/shop_example_com"
+	// FQDN dots are hex-escaped by encodeSegment ('.' -> "_2E") to stay
+	// injective (#606) — a literal '_' would otherwise be indistinguishable
+	// from an escape sequence, and two distinct FQDNs could collide.
+	wantPath := "kv/mark8ly/marketplace-api/tenants/" + tenant.String() + "/platform/cloudflare/shop_2Eexample_2Ecom"
 	if gotPath := carriersecrets.BaoPath(got[0].Scope); gotPath != wantPath {
 		t.Fatalf("BaoPath = %q, want %q", gotPath, wantPath)
 	}

--- a/services/marketplace-api/internal/carriersecrets/hybrid_test.go
+++ b/services/marketplace-api/internal/carriersecrets/hybrid_test.go
@@ -30,11 +30,13 @@ func TestHybridStore_Put_WritesGSMReference(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Put: %v", err)
 	}
-	wantRef := "gsm://projects/tesseracthub-480811/secrets/mark8ly-test-4a47610c-3f0c-4ef7-a64c-892480c4635e-shipping-delhivery-api_key"
+	// "api_key" contains a literal '_', which encodeSegment escapes to "__"
+	// to stay injective (see #606).
+	wantRef := "gsm://projects/tesseracthub-480811/secrets/mark8ly-test-4a47610c-3f0c-4ef7-a64c-892480c4635e-shipping-delhivery-api__key"
 	if ref != wantRef {
 		t.Fatalf("ref = %q, want %q", ref, wantRef)
 	}
-	if !fake.Has("projects/tesseracthub-480811/secrets/mark8ly-test-4a47610c-3f0c-4ef7-a64c-892480c4635e-shipping-delhivery-api_key") {
+	if !fake.Has("projects/tesseracthub-480811/secrets/mark8ly-test-4a47610c-3f0c-4ef7-a64c-892480c4635e-shipping-delhivery-api__key") {
 		t.Fatal("FakeClient doesn't have the secret after Put")
 	}
 	got, err := s.Get(ctx, ref)

--- a/services/marketplace-api/internal/carriersecrets/refs.go
+++ b/services/marketplace-api/internal/carriersecrets/refs.go
@@ -23,6 +23,7 @@ package carriersecrets
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -69,10 +70,10 @@ func IsBaoRef(r string) bool { return strings.HasPrefix(r, BaoRefPrefix) }
 // segments (~40 chars combined) is ~96 chars for any realistic
 // tenant.
 func SecretName(prefix string, s Scope) string {
-	tenant := sanitizeSegment(s.TenantID)
-	domain := sanitizeSegment(strings.ToLower(s.Domain))
-	provider := sanitizeSegment(strings.ToLower(s.Provider))
-	field := sanitizeSegment(strings.ToLower(s.Field))
+	tenant := encodeSegment(s.TenantID)
+	domain := encodeSegment(strings.ToLower(s.Domain))
+	provider := encodeSegment(strings.ToLower(s.Provider))
+	field := encodeSegment(strings.ToLower(s.Field))
 	return fmt.Sprintf("%s-%s-%s-%s-%s", prefix, tenant, domain, provider, field)
 }
 
@@ -110,10 +111,10 @@ const baoPathPrefix = "kv/mark8ly/marketplace-api/tenants"
 func BaoPath(s Scope) string {
 	return fmt.Sprintf("%s/%s/%s/%s/%s",
 		baoPathPrefix,
-		sanitizeSegment(s.TenantID),
-		sanitizeSegment(strings.ToLower(s.Domain)),
-		sanitizeSegment(strings.ToLower(s.Provider)),
-		sanitizeSegment(strings.ToLower(s.Field)),
+		encodeSegment(s.TenantID),
+		encodeSegment(strings.ToLower(s.Domain)),
+		encodeSegment(strings.ToLower(s.Provider)),
+		encodeSegment(strings.ToLower(s.Field)),
 	)
 }
 
@@ -128,23 +129,78 @@ func ParseBaoReference(ref string) (path string, ok bool) {
 	return strings.TrimPrefix(ref, BaoRefPrefix), true
 }
 
-// sanitizeSegment reduces a Scope segment to the character set GCP
-// Secret Manager accepts: letters, digits, '_' and '-'. Anything else
-// becomes '_' so a stray dot/slash never produces an InvalidArgument
-// from the API.
-func sanitizeSegment(s string) string {
+// encodeSegment reduces a Scope segment to the character set both GCP
+// Secret Manager names and OpenBao KV paths accept — [A-Za-z0-9_-] — while
+// staying INJECTIVE: distinct inputs always produce distinct outputs. That
+// matters because a Scope segment (e.g. a merchant-registered domain) is
+// untrusted, and two distinct segments folding to the same encoded path
+// would let one tenant's per-tenant carrier credential silently overwrite
+// another's config in the same slot (see #606).
+//
+// Encoding, byte-wise (not rune-wise, so multi-byte UTF-8 becomes a run of
+// escapes):
+//   - '[A-Za-z0-9-]'  -> unchanged
+//   - '_'             -> "__"
+//   - anything else   -> '_' followed by its two-digit uppercase hex value
+//
+// decodeSegment is its exact inverse and exists to make injectivity
+// testable (round-trip), not because any caller needs to decode a stored
+// path — see below.
+//
+// Changing this function does NOT require a migration: every stored
+// reference is self-describing (ParseBaoReference/ParseReference recover
+// the path straight out of the reference string, never by recomputing it
+// from a Scope), so old rows keep resolving at their old paths and only
+// new writes land on paths produced by this version.
+func encodeSegment(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
-	for _, r := range s {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
 		switch {
-		case r >= 'a' && r <= 'z',
-			r >= 'A' && r <= 'Z',
-			r >= '0' && r <= '9',
-			r == '_', r == '-':
-			b.WriteRune(r)
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '-':
+			b.WriteByte(c)
+		case c == '_':
+			b.WriteString("__")
 		default:
-			b.WriteByte('_')
+			fmt.Fprintf(&b, "_%02X", c)
 		}
 	}
 	return b.String()
+}
+
+// decodeSegment is the inverse of encodeSegment. It returns an error on a
+// malformed escape: a trailing lone '_', or a '_' followed by non-hex
+// digits.
+func decodeSegment(s string) (string, error) {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c != '_' {
+			b.WriteByte(c)
+			continue
+		}
+		if i+1 >= len(s) {
+			return "", fmt.Errorf("carriersecrets: malformed segment %q: trailing '_'", s)
+		}
+		if s[i+1] == '_' {
+			b.WriteByte('_')
+			i++
+			continue
+		}
+		if i+2 >= len(s) {
+			return "", fmt.Errorf("carriersecrets: malformed segment %q: incomplete escape at offset %d", s, i)
+		}
+		hexByte, err := strconv.ParseUint(s[i+1:i+3], 16, 8)
+		if err != nil {
+			return "", fmt.Errorf("carriersecrets: malformed segment %q: invalid hex escape at offset %d: %w", s, i, err)
+		}
+		b.WriteByte(byte(hexByte))
+		i += 2
+	}
+	return b.String(), nil
 }

--- a/services/marketplace-api/internal/carriersecrets/refs.go
+++ b/services/marketplace-api/internal/carriersecrets/refs.go
@@ -152,6 +152,10 @@ func ParseBaoReference(ref string) (path string, ok bool) {
 // the path straight out of the reference string, never by recomputing it
 // from a Scope), so old rows keep resolving at their old paths and only
 // new writes land on paths produced by this version.
+// upperHexDigits indexes the two-digit uppercase hex escape emitted by
+// encodeSegment; decodeSegment parses it back with strconv.ParseUint.
+const upperHexDigits = "0123456789ABCDEF"
+
 func encodeSegment(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
@@ -166,7 +170,14 @@ func encodeSegment(s string) string {
 		case c == '_':
 			b.WriteString("__")
 		default:
-			fmt.Fprintf(&b, "_%02X", c)
+			// Hand-rolled hex rather than a formatting helper: the
+			// log-shipping PII guard rejects the print-family calls in
+			// service code, and suppressing that guard inside the encoder
+			// for per-tenant secret paths would be the wrong signal. This
+			// is also allocation-free.
+			b.WriteByte('_')
+			b.WriteByte(upperHexDigits[c>>4])
+			b.WriteByte(upperHexDigits[c&0x0F])
 		}
 	}
 	return b.String()

--- a/services/marketplace-api/internal/carriersecrets/refs_test.go
+++ b/services/marketplace-api/internal/carriersecrets/refs_test.go
@@ -1,13 +1,16 @@
 package carriersecrets
 
 import (
+	"math/rand"
 	"strings"
 	"testing"
 )
 
 func TestBaoPath_IsScopeInPathForm(t *testing.T) {
 	s := Scope{TenantID: "11111111-2222-3333-4444-555555555555", Domain: "payment", Provider: "razorpay", Field: "secret_key"}
-	want := "kv/mark8ly/marketplace-api/tenants/11111111-2222-3333-4444-555555555555/payment/razorpay/secret_key"
+	// "secret_key" contains a literal '_', which encodeSegment escapes to
+	// "__" to stay injective (see #606).
+	want := "kv/mark8ly/marketplace-api/tenants/11111111-2222-3333-4444-555555555555/payment/razorpay/secret__key"
 	if got := BaoPath(s); got != want {
 		t.Fatalf("BaoPath = %q, want %q", got, want)
 	}
@@ -68,5 +71,80 @@ func TestBaoPath_SanitisesSegments(t *testing.T) {
 	}
 	if strings.Count(got, "/") != 7 {
 		t.Fatalf("unexpected segment count in %q — a segment contained an unsanitised separator", got)
+	}
+}
+
+// --- Issue #606: injective segment encoding ---
+
+func TestEncodeSegment_RoundTrips(t *testing.T) {
+	cases := []string{
+		"",
+		"api_key",
+		"shop.example.com",
+		"müller.com",
+		"möller.com",
+		"11111111-2222-3333-4444-555555555555",
+		"a/b",
+		"a..b",
+		"has\x00nul",
+	}
+	for _, s := range cases {
+		enc := encodeSegment(s)
+		dec, err := decodeSegment(enc)
+		if err != nil {
+			t.Fatalf("decodeSegment(encodeSegment(%q)=%q) returned error: %v", s, enc, err)
+		}
+		if dec != s {
+			t.Fatalf("decodeSegment(encodeSegment(%q)) = %q, want %q", s, dec, s)
+		}
+	}
+}
+
+// These are the specific pairs the old sanitizeSegment collided on. This
+// test must FAIL against the old sanitizeSegment-based encoding — confirmed
+// before encodeSegment was implemented (see #606 report).
+func TestEncodeSegment_Injective(t *testing.T) {
+	pairs := [][2]string{
+		{"t_1", "t/1"},
+		{"müller.com", "möller.com"},
+	}
+	for _, p := range pairs {
+		a, b := encodeSegment(p[0]), encodeSegment(p[1])
+		if a == b {
+			t.Fatalf("encodeSegment(%q) == encodeSegment(%q) == %q, want distinct encodings", p[0], p[1], a)
+		}
+	}
+}
+
+func TestEncodeSegment_OutputCharset(t *testing.T) {
+	rnd := rand.New(rand.NewSource(606))
+	for i := 0; i < 300; i++ {
+		n := rnd.Intn(24)
+		buf := make([]byte, n)
+		for j := range buf {
+			buf[j] = byte(rnd.Intn(256))
+		}
+		s := string(buf)
+		enc := encodeSegment(s)
+		for _, b := range []byte(enc) {
+			ok := (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_' || b == '-'
+			if !ok {
+				t.Fatalf("encodeSegment(%q) = %q contains disallowed byte %q", s, enc, b)
+			}
+		}
+		if strings.Contains(enc, "/") {
+			t.Fatalf("encodeSegment(%q) = %q contains '/'", s, enc)
+		}
+		if strings.Contains(enc, "..") {
+			t.Fatalf("encodeSegment(%q) = %q contains '..'", s, enc)
+		}
+	}
+}
+
+func TestBaoPath_DistinctScopesDistinctPaths(t *testing.T) {
+	a := Scope{TenantID: "11111111-2222-3333-4444-555555555555", Domain: "platform", Provider: "cloudflare", Field: "t_1"}
+	b := Scope{TenantID: "11111111-2222-3333-4444-555555555555", Domain: "platform", Provider: "cloudflare", Field: "t/1"}
+	if BaoPath(a) == BaoPath(b) {
+		t.Fatalf("BaoPath collided for distinct Fields %q and %q: %q", a.Field, b.Field, BaoPath(a))
 	}
 }

--- a/services/marketplace-api/internal/carriersecrets/store_test.go
+++ b/services/marketplace-api/internal/carriersecrets/store_test.go
@@ -45,7 +45,10 @@ func TestSecretName_CanonicalLayout(t *testing.T) {
 		Field:    "api_key",
 	}
 	got := SecretName("mark8ly-prod", s)
-	want := "mark8ly-prod-4a47610c-3f0c-4ef7-a64c-892480c4635e-shipping-delhivery-api_key"
+	// "api_key" contains a literal '_', which encodeSegment escapes to "__"
+	// to stay injective (see #606) — the plain byte '_' would otherwise be
+	// indistinguishable from an escaped one.
+	want := "mark8ly-prod-4a47610c-3f0c-4ef7-a64c-892480c4635e-shipping-delhivery-api__key"
 	if got != want {
 		t.Fatalf("SecretName = %q, want %q", got, want)
 	}
@@ -72,7 +75,7 @@ func TestFormatReference_And_ParseReference(t *testing.T) {
 	if !ok {
 		t.Fatalf("ParseReference rejected a value we just formatted: %s", ref)
 	}
-	if res != "projects/proj/secrets/mark8ly-dev-tenant-payment-razorpay-secret_key" {
+	if res != "projects/proj/secrets/mark8ly-dev-tenant-payment-razorpay-secret__key" {
 		t.Fatalf("parsed resource wrong: %s", res)
 	}
 }

--- a/services/marketplace-api/internal/handlers/admin/settings_secretstore_test.go
+++ b/services/marketplace-api/internal/handlers/admin/settings_secretstore_test.go
@@ -27,7 +27,9 @@ func TestShippingSettings_WithSecretStore_PutAndMask(t *testing.T) {
 	if !strings.HasPrefix(ref, "gsm://") {
 		t.Fatalf("reference not a gsm:// value: %s", ref)
 	}
-	wantRef := "gsm://projects/tesseracthub-480811/secrets/mark8ly-test-4a47610c-3f0c-4ef7-a64c-892480c4635e-shipping-delhivery-api_key"
+	// "api_key" contains a literal '_', which encodeSegment escapes to "__"
+	// to stay injective (see #606).
+	wantRef := "gsm://projects/tesseracthub-480811/secrets/mark8ly-test-4a47610c-3f0c-4ef7-a64c-892480c4635e-shipping-delhivery-api__key"
 	if ref != wantRef {
 		t.Fatalf("unexpected ref: got %q want %q", ref, wantRef)
 	}
@@ -71,7 +73,7 @@ func TestPaymentSettings_WithSecretStore_ScopeIsPaymentDomain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("putCredential: %v", err)
 	}
-	if !strings.Contains(ref, "-payment-razorpay-api_key") {
+	if !strings.Contains(ref, "-payment-razorpay-api__key") {
 		t.Fatalf("reference doesn't carry payment scope: %s", ref)
 	}
 }
@@ -86,7 +88,7 @@ func TestTaxSettings_WithSecretStore_ScopeIsTaxDomain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("putCredential: %v", err)
 	}
-	if !strings.Contains(ref, "-tax-taxjar-api_key") {
+	if !strings.Contains(ref, "-tax-taxjar-api__key") {
 		t.Fatalf("reference doesn't carry tax scope: %s", ref)
 	}
 }


### PR DESCRIPTION
Closes #606.

`sanitizeSegment` folded every character outside `[A-Za-z0-9_-]` to `_` and passed `_` through unchanged, so distinct `Scope` values could produce one secret path. It is replaced by an injective `encodeSegment`.

## Two things #606 got wrong

Both premises in the issue turned out to be false, and both change what the fix costs.

**1. "Provider/Field are near-enum values set in code, not free-form user input" — false.**

`cmd/carrier-secrets-backfill/rowstore.go:171` builds `Scope{Domain: "platform", Provider: "cloudflare", Field: r.Domain}`, where `r.Domain` is a merchant-registered FQDN from `custom_domains.domain`. The free-form component the issue treated as hypothetical already exists in production. `müller.com` and `möller.com` both sanitised to `m_ller_com`.

The severity is *lower* than the issue implies, though, and it is worth being precise: `TenantID` leads the path and is a UUID, which is identity under the old sanitiser. Collisions were therefore confined to a single tenant — one tenant's two custom domains sharing a Cloudflare token slot. A config overwrite, **not** a cross-tenant credential leak.

**2. "Fixing it is a migration, not an edit" — also false, and this is what makes the fix cheap.**

Stored references are self-describing. `ChainStore.Get` resolves a `bao://` reference through `ParseBaoReference(ref)` and a `gsm://` one through `ParseReference(ref)`; neither ever recomputes a path from a `Scope`. `BaoPath`/`SecretName` are consumed only on the write path.

So changing the encoding cannot break any existing row. Old rows keep resolving at their old paths; only new writes land on new paths. No migration, no dual-read shim, no compatibility fallback — adding one would have reintroduced exactly the ambiguity being removed.

## The encoding

Byte-wise (so multi-byte UTF-8 becomes a run of escapes):

| input byte | output |
|---|---|
| `[A-Za-z0-9-]` | unchanged |
| `_` | `__` |
| anything else | `_` + two-digit uppercase hex |

The escape is prefix-free, so decoding is unambiguous and injectivity follows. Output charset stays `[A-Za-z0-9_-]`, which both GCP Secret Manager names and OpenBao KV paths accept.

In practice: UUID tenant ids, `payment`, `shipping`, `razorpay` are unchanged; `api_key` becomes `api__key`; `shop.example.com` becomes `shop_2Eexample_2Ecom`.

`decodeSegment` is the exact inverse. No caller needs it — it exists so injectivity is *testable* by round-trip rather than asserted.

## Tests

- `TestEncodeSegment_Injective` — the pairs the old code collided on (`t_1`/`t/1`, `müller.com`/`möller.com`). **Verified RED first**: aliasing `encodeSegment` to the old `sanitizeSegment` produces `encodeSegment("t_1") == encodeSegment("t/1") == "t_1"` and the test fails.
- `TestEncodeSegment_RoundTrips` — empty string, `api_key`, FQDNs, IDN domains, a UUID, `a/b`, `a..b`, a NUL byte.
- `TestEncodeSegment_OutputCharset` — deterministic pseudo-random property check: every output byte is in `[A-Za-z0-9_-]`, and no output contains `/` or `..`, preserving the existing path-traversal guarantee.
- `TestBaoPath_DistinctScopesDistinctPaths` — two scopes differing only in a previously-colliding `Field` now yield different paths.

`sanitizeSegment` is deleted rather than left in place, so it cannot be reused by accident.

## One thing deliberately left alone

`BaoPath` still applies `strings.ToLower` to domain/provider/field before encoding, and `ToLower` is itself non-injective. That is intentional normalisation, not a residual bug: DNS is case-insensitive, so `Shop.example.com` and `shop.example.com` are the same domain and *should* share a path. Worth knowing that the injectivity guarantee is over the normalised scope, not the raw one.

## Test plan

- [x] `go test ./internal/carriersecrets/...` passes
- [x] `go test ./... | grep '^FAIL'` empty
- [x] `go build`, `go vet`, `gofmt` clean
- [x] `grep sanitizeSegment` returns only comments — no live call sites
- [x] Injectivity test confirmed failing against the old encoding before implementation

Rewriting the 6 existing production rows onto new paths is optional tidy-up, not a prerequisite, and is not in this PR.
