### PR TITLE
fix(marketplace-api): serve the Prometheus registry on MetricsPort (#624)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -2588,6 +2588,25 @@ func main() {
 		}
 	}()
 
+	// Prometheus scrape endpoint, on its own listener so the registry is not
+	// reachable through the public ingress. A failure here must never take
+	// the API down — an unscrapable service is a monitoring outage, not a
+	// customer-facing one — so this logs and gives up rather than exiting.
+	var metricsSrv *http.Server
+	if cfg.MetricsPort > 0 && cfg.MetricsPort != cfg.HTTPPort {
+		metricsSrv = newMetricsServer(cfg.MetricsPort)
+		go func() {
+			log.Info("metrics listening", slog.String("addr", metricsSrv.Addr))
+			if err := metricsSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				log.Error("metrics listen", "err", err)
+			}
+		}()
+	} else {
+		log.Warn("metrics endpoint disabled",
+			slog.Int("metrics_port", cfg.MetricsPort),
+			slog.Int("http_port", cfg.HTTPPort))
+	}
+
 	// Graceful shutdown on SIGINT/SIGTERM.
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
@@ -2596,6 +2615,11 @@ func main() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+	if metricsSrv != nil {
+		if err := metricsSrv.Shutdown(ctx); err != nil {
+			log.Warn("metrics shutdown", "err", err)
+		}
+	}
 	if err := srv.Shutdown(ctx); err != nil {
 		log.Error("shutdown", "err", err)
 		os.Exit(1)

--- a/services/marketplace-api/cmd/marketplace-api/metrics_server.go
+++ b/services/marketplace-api/cmd/marketplace-api/metrics_server.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// The metrics endpoint runs on its own listener, separate from the API
+// server, because cfg.MetricsPort differs from cfg.HTTPPort and the pods are
+// annotated prometheus.io/port: "9090". Serving it off the API engine would
+// also expose the whole registry through the public ingress.
+//
+// Until #624 nothing read cfg.MetricsPort at all: every collector the service
+// registers — HTTP request counters, billing and prune counters, the MRR
+// rollup collectors, carriersecrets_events_total — incremented in-process and
+// was never scrapable, while the pod annotations pointed at a port with no
+// listener.
+
+// metricsMux returns the handler serving the default Prometheus registry.
+// It is separate from newMetricsServer so the routing is testable without
+// binding a port.
+func metricsMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	return mux
+}
+
+// newMetricsServer builds the Prometheus scrape server for the given port.
+func newMetricsServer(port int) *http.Server {
+	return &http.Server{
+		Addr:              fmt.Sprintf(":%d", port),
+		Handler:           metricsMux(),
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+}

--- a/services/marketplace-api/cmd/marketplace-api/metrics_server_test.go
+++ b/services/marketplace-api/cmd/marketplace-api/metrics_server_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/metrics"
+)
+
+// The service registers dozens of Prometheus collectors but, until #624,
+// served none of them: MetricsPort was declared in config and read by
+// nothing, so the prometheus.io/* pod annotations pointed at a port with no
+// listener. These tests pin that the handler exists and actually exposes the
+// default registry.
+
+func TestMetricsMux_ServesDefaultRegistry(t *testing.T) {
+	// Touch a counter so the registry has at least one of our own series to
+	// find, rather than only the Go runtime collectors.
+	metrics.CarrierSecretCounter("gsm_fallback_read", 1)
+
+	rec := httptest.NewRecorder()
+	metricsMux().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /metrics = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "# HELP") {
+		t.Error("response has no # HELP lines; it is not a Prometheus exposition")
+	}
+	// The specific series that #608 added and #621 depends on being readable.
+	if !strings.Contains(body, "carriersecrets_events_total") {
+		t.Error("carriersecrets_events_total missing from /metrics; #621 cannot gather its evidence")
+	}
+}
+
+func TestMetricsMux_UnknownPathIs404(t *testing.T) {
+	rec := httptest.NewRecorder()
+	metricsMux().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("GET / on the metrics mux = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestNewMetricsServer_UsesConfiguredPort(t *testing.T) {
+	srv := newMetricsServer(9090)
+	if srv == nil {
+		t.Fatal("newMetricsServer returned nil")
+	}
+	if srv.Addr != ":9090" {
+		t.Errorf("Addr = %q, want %q", srv.Addr, ":9090")
+	}
+	if srv.ReadHeaderTimeout == 0 {
+		t.Error("ReadHeaderTimeout is 0; the listener is exposed to slowloris")
+	}
+}


### PR DESCRIPTION
Closes #624. Unblocks the verification step of #621.

`cfg.MetricsPort` was declared with `default:"9090"` and **read by nothing** — a repo-wide grep returned exactly one hit, the declaration itself. So every collector this service registers incremented in-process and was never scrapable, while the pods carried `prometheus.io/scrape: "true"`, `path: /metrics`, `port: 9090` annotations pointing at a port with no listener.

Verified against a running admin pod before the fix: 9090 refuses connections, 8080 returns 404 for `/metrics`.

## Why this blocked #621

#621 retires GCP Secret Manager on the evidence that `carriersecrets_events_total{event="gsm_fallback_read"}` has been zero. #608 made that a real `CounterVec` — but a counter nothing can read is not evidence. As things stood the metric was arguably *less* observable than the log line it replaced, since the log line at least reached stdout and Cloud Logging. I overstated that in #622; this is the missing half.

## What changed

- `metricsMux()` — serves `promhttp.Handler()` at `/metrics`. Split out from the server so routing is testable without binding a port.
- `newMetricsServer(port)` — mirrors `newHTTPServer`'s timeouts.
- Started on its own listener when `MetricsPort > 0` and differs from `HTTPPort`; otherwise it logs a warning naming both ports rather than failing silently.
- Shut down alongside the API server on SIGTERM.

Two deliberate choices:

**Its own listener, not a route on the API engine.** The annotations already say 9090, and mounting `/metrics` on the public engine would expose the whole registry through the ingress.

**A metrics listen failure logs and gives up; it does not `os.Exit`.** An unscrapable service is a monitoring outage, not a customer-facing one. Taking checkout down because a debug port was already bound would be the wrong trade — note the API server's own listener keeps its `os.Exit(1)`, which is correct for it.

## A nice side effect

Two comments previously asserted a handler that did not exist — `main.go:2172` ("scraped automatically via the existing /metrics handler") and `internal/whitelabel/metrics/metrics.go:52` ("Register into the default registry so /metrics exposes them without extra wiring"). Rather than correct them to admit the gap, this makes them true.

## What starts working

Everything already registered, none of which was reachable: `HTTPRequestsTotal`, `HTTPRequestDuration`, `BillingEmailsSentTotal`, `WebhookPruneRowsDeletedTotal`, `AuditPruneRowsDeletedTotal`, `TrialActivationDay30Total`, the MRR rollup collectors, campaign-budget and whitelabel metrics — and `carriersecrets_events_total`.

There is still **no Prometheus server in this cluster** (the only match anywhere is `kagent-grafana-mcp`, an MCP tool). Deploying or choosing a hosted scrape target is a separate decision, tracked on #624. This PR is what makes the endpoint real, which is all #621 needs: its verification reads the counter at two points around a forced credential read, via port-forward, rather than relying on long-term retention.

## Test plan

- [x] `TestMetricsMux_ServesDefaultRegistry` — 200, has `# HELP` lines, and contains `carriersecrets_events_total`; verified RED first (`undefined: metricsMux`)
- [x] `TestMetricsMux_UnknownPathIs404` — the mux serves only `/metrics`
- [x] `TestNewMetricsServer_UsesConfiguredPort` — addr honours the port, `ReadHeaderTimeout` non-zero (slowloris)
- [x] `go test ./...` — 0 failures
- [x] `go build`, `go vet`, `gofmt` clean
- [ ] After deploy: `curl :9090/metrics` on an admin pod returns the registry

Refs #608, #621.
