### PR TITLE
fix(metrics): pre-declare carriersecrets event series so zero is affirmative (#621)

### DIFF
--- a/services/marketplace-api/internal/metrics/registry.go
+++ b/services/marketplace-api/internal/metrics/registry.go
@@ -245,6 +245,29 @@ func init() {
 		APIKeyRateLimitedTotal,
 		CarrierSecretEventsTotal,
 	)
+
+	// Pre-declare every carriersecrets event series at 0.
+	//
+	// A CounterVec exports nothing for a label value it has never
+	// observed, which makes an absent series ambiguous: "wired and
+	// genuinely zero" is indistinguishable from "never wired, or the code
+	// path is unreachable". mark8ly#621 retires GCP Secret Manager on the
+	// strength of gsm_fallback_read reading zero, so that ambiguity must
+	// not sit under the decision — an affirmative 0 also proves the sink
+	// reaches the exported registry.
+	for _, event := range carrierSecretEvents {
+		CarrierSecretEventsTotal.WithLabelValues(event).Add(0)
+	}
+}
+
+// carrierSecretEvents lists every event value the carriersecrets package
+// fires. Kept here rather than imported from carriersecrets so this package
+// stays free of a dependency on its consumer; the values are asserted
+// against the carriersecrets constants in TestCarrierSecretEvents_MatchConstants.
+var carrierSecretEvents = []string{
+	"gsm_fallback_read",
+	"stale_read",
+	"rewrap_failed",
 }
 
 // CarrierSecretCounter is the single carriersecrets.CounterFn-shaped sink

--- a/services/marketplace-api/internal/metrics/registry_test.go
+++ b/services/marketplace-api/internal/metrics/registry_test.go
@@ -3,10 +3,81 @@ package metrics_test
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 
+	"github.com/mark8ly/marketplace-api/internal/carriersecrets"
 	"github.com/mark8ly/marketplace-api/internal/metrics"
 )
+
+// TestCarrierSecretSeries_ZeroInitialised pins that all three event series
+// exist on /metrics before anything has fired.
+//
+// A CounterVec exports nothing for a label value it has never observed, so
+// an absent series is ambiguous: "wired and genuinely zero" and "never
+// wired, or the code path is unreachable" look identical to a scraper.
+// mark8ly#621 retires GCP Secret Manager on the strength of
+// gsm_fallback_read reading zero, and that is precisely the ambiguity that
+// must not sit under the decision. Pre-declaring the label values turns the
+// evidence from "no series" into an affirmative 0.
+//
+// This must NOT assert via WithLabelValues, which creates the child on
+// access and would make the assertion vacuous. Counting collected series is
+// the real check.
+func TestCarrierSecretSeries_ZeroInitialised(t *testing.T) {
+	const wantSeries = 3 // gsm_fallback_read, stale_read, rewrap_failed
+
+	if got := testutil.CollectAndCount(metrics.CarrierSecretEventsTotal); got != wantSeries {
+		t.Errorf("carriersecrets_events_total exports %d series, want %d; "+
+			"an unexported label value reads as absent rather than zero on /metrics", got, wantSeries)
+	}
+}
+
+// TestCarrierSecretEvents_MatchConstants guards the one real risk created by
+// pre-declaring the event series: the string list in registry.go is a copy of
+// the carriersecrets constants, and a rename on one side would silently leave
+// the renamed event unexported again — reintroducing exactly the
+// absent-vs-zero ambiguity the zero-init exists to remove.
+//
+// The list is deliberately not imported from carriersecrets (this package
+// should not depend on its consumer), so it is pinned by test instead.
+func TestCarrierSecretEvents_MatchConstants(t *testing.T) {
+	want := map[string]bool{
+		carriersecrets.FallbackReadMetric: true,
+		carriersecrets.StaleReadMetric:    true,
+		carriersecrets.RewrapFailedMetric: true,
+	}
+
+	ch := make(chan prometheus.Metric, 16)
+	metrics.CarrierSecretEventsTotal.Collect(ch)
+	close(ch)
+
+	got := map[string]bool{}
+	for m := range ch {
+		var d dto.Metric
+		if err := m.Write(&d); err != nil {
+			t.Fatalf("write metric: %v", err)
+		}
+		for _, lp := range d.Label {
+			if lp.GetName() == "event" {
+				got[lp.GetValue()] = true
+			}
+		}
+	}
+
+	for event := range want {
+		if !got[event] {
+			t.Errorf("carriersecrets constant %q has no pre-declared series; "+
+				"the list in registry.go has drifted from the constants", event)
+		}
+	}
+	for event := range got {
+		if !want[event] {
+			t.Errorf("pre-declared series %q matches no carriersecrets constant", event)
+		}
+	}
+}
 
 // TestCarrierSecretCounter_IncrementsRegisteredMetric verifies the shared
 // sink wired into all three carriersecrets binaries (cmd/marketplace-api,


### PR DESCRIPTION
Last piece of instrumentation before #621 can delete anything.

## The gap

With #625 merged, `/metrics` is finally served — verified on the promoted pod: `HTTP 200`, 50 `# HELP` lines. But `carriersecrets_events_total` had **no series at all**.

A `CounterVec` exports nothing for a label value it has never observed. So on a real scrape, these two are indistinguishable:

- the counter is wired and the value is genuinely zero — *delete GCP, it is unused*
- the counter was never wired, or the code path is unreachable — *do not delete anything*

They call for opposite actions. #621 retires GCP Secret Manager on the strength of `gsm_fallback_read` reading zero, so shipping that ambiguity underneath the decision would undo the point of #608 and #625.

Pre-declaring each label value at 0 turns "no series" into an affirmative `0`, which additionally proves the sink reaches the exported registry — end to end, in production, not just in a unit test.

## Changes

- `init()` now calls `CarrierSecretEventsTotal.WithLabelValues(event).Add(0)` for all three event values.
- `carrierSecretEvents` holds that list. It is deliberately **not** imported from `carriersecrets` — this package should not depend on its own consumer — so the duplication is pinned by test instead.

## Tests

- `TestCarrierSecretSeries_ZeroInitialised` — asserts three series are collected. **Verified RED first**: `exports 0 series, want 3`.

  It counts collected series rather than reading `WithLabelValues(...)`, because `WithLabelValues` *creates* the child on access — an assertion written that way passes vacuously against the unfixed code and would have been worse than no test.

- `TestCarrierSecretEvents_MatchConstants` — guards the one risk the copied list introduces: a rename on either side would silently leave that event unexported again, quietly restoring the absent-vs-zero ambiguity. Compares the collected `event` label values against `carriersecrets.FallbackReadMetric` / `StaleReadMetric` / `RewrapFailedMetric` in both directions.

## Test plan

- [x] Zero-init test verified RED before GREEN
- [x] `go test ./...` — 0 failures
- [x] `go build`, `go vet`, `gofmt` clean
- [x] `scripts/ci/verify-logging-smoke.sh` — PASS (run locally after #623 tripped it)
- [ ] After deploy: `curl :9090/metrics | grep carriersecrets_events_total` shows all three series at 0

## After this

#621's verification becomes executable and honest: read the three series, force a credential read through each production path, re-read, and confirm `gsm_fallback_read` is still `0` — an observed zero on a series known to exist, rather than an absence that could mean anything.

Refs #608, #621, #624.
