### PR TITLE
feat(carrier-secrets-backfill): read-only -verify mode to prove credential paths resolve (#621)

### DIFF
--- a/services/marketplace-api/cmd/carrier-secrets-backfill/main.go
+++ b/services/marketplace-api/cmd/carrier-secrets-backfill/main.go
@@ -19,6 +19,11 @@ func main() {
 	dryRun := flag.Bool("dry-run", true,
 		"report what would migrate without writing anything to the Store or the DB. "+
 			"Default true — pass -dry-run=false to actually write.")
+	verify := flag.Bool("verify", false,
+		"read every stored reference through the Store and report whether each "+
+			"resolves, plus a census by reference scheme. Never writes. Used by "+
+			"mark8ly#621 to prove the credential paths were actually exercised "+
+			"before GCP Secret Manager is deleted.")
 	flag.Parse()
 
 	// LoadCarrierSecretJob mirrors cmd/refund-sweep-cron: it reads only
@@ -100,6 +105,23 @@ func main() {
 		Store:  secretStore,
 		DryRun: *dryRun,
 		Logger: log,
+	}
+
+	if *verify {
+		vres, verr := b.Verify(context.Background())
+		if verr != nil {
+			log.Error("carrier-secrets-backfill: verify failed", "err", verr)
+			os.Exit(1)
+		}
+		log.Info("carrier-secrets-backfill: verify done",
+			"examined", vres.Examined,
+			"resolved", vres.Resolved,
+			"failed", vres.Failed,
+			"by_scheme", vres.ByScheme)
+		if vres.Failed > 0 {
+			os.Exit(1)
+		}
+		return
 	}
 
 	res, err := b.Run(context.Background())

--- a/services/marketplace-api/cmd/carrier-secrets-backfill/verify.go
+++ b/services/marketplace-api/cmd/carrier-secrets-backfill/verify.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/mark8ly/marketplace-api/internal/carriersecrets"
+)
+
+// VerifyResult is the census Verify produces.
+type VerifyResult struct {
+	Examined int
+	Resolved int
+	Failed   int
+	// ByScheme counts references by reference prefix: "bao", "gsm",
+	// "inline", "empty", or "unknown". This is the decision input for
+	// mark8ly#621 — a non-zero "gsm" count means GCP Secret Manager is
+	// still serving at least one live credential and must not be deleted.
+	ByScheme map[string]int
+}
+
+// referenceScheme classifies a stored reference by prefix. It never returns
+// any part of the reference itself: an unrecognised value can be a raw
+// pre-encryption credential, so it must not reach logs.
+func referenceScheme(ref string) string {
+	switch {
+	case ref == "":
+		return "empty"
+	case carriersecrets.IsBaoRef(ref):
+		return "bao"
+	case carriersecrets.IsGSMRef(ref):
+		return "gsm"
+	case carriersecrets.IsInlineRef(ref):
+		return "inline"
+	default:
+		return "unknown"
+	}
+}
+
+// Verify reads every stored carrier-credential reference through the real
+// Store and reports whether each one still resolves, plus a census by
+// reference scheme.
+//
+// It exists for mark8ly#621. Retiring GCP Secret Manager rests on the claim
+// that nothing reads gsm:// any more, and the carriersecrets_events_total
+// fallback counter cannot establish that on its own: with every reference
+// already bao://, the counter reads zero whether the credential paths were
+// exercised or never reached at all. Verify supplies the missing half — it
+// drives a real read through each of the credentials in the database, so a
+// zero counter afterwards means "exercised and clean" rather than "not
+// measured".
+//
+// Verify NEVER writes. It calls only Store.Get, never Put or Destroy, and
+// never touches the DB beyond the initial FetchAll. It also never logs a
+// secret value: failures are reported by table/column/id and scheme only.
+func (b *Backfiller) Verify(ctx context.Context) (VerifyResult, error) {
+	rows, err := b.Rows.FetchAll(ctx)
+	if err != nil {
+		return VerifyResult{}, fmt.Errorf("carrier-secrets-backfill: fetch rows: %w", err)
+	}
+
+	res := VerifyResult{ByScheme: make(map[string]int)}
+	log := b.logger()
+
+	for _, row := range rows {
+		res.Examined++
+		scheme := referenceScheme(row.Ref)
+		res.ByScheme[scheme]++
+
+		// An empty column is not a configured credential; dialling a
+		// backend for it would invent a read that production never does.
+		if scheme == "empty" {
+			continue
+		}
+
+		if _, getErr := b.Store.Get(ctx, row.Ref); getErr != nil {
+			res.Failed++
+			log.Error("carrier-secrets-backfill: reference did not resolve",
+				slog.String("table", row.Table),
+				slog.String("column", row.Column),
+				slog.String("id", row.ID),
+				slog.String("scheme", scheme),
+				slog.String("err", getErr.Error()))
+			continue
+		}
+		res.Resolved++
+	}
+
+	return res, nil
+}

--- a/services/marketplace-api/cmd/carrier-secrets-backfill/verify_test.go
+++ b/services/marketplace-api/cmd/carrier-secrets-backfill/verify_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/carriersecrets"
+)
+
+// verifyStore records every Get and fails the ones whose reference is in
+// failFor. Put/Destroy panic: Verify must never write, and a panic makes a
+// regression impossible to miss.
+type verifyStore struct {
+	got     []string
+	failFor map[string]bool
+}
+
+func (s *verifyStore) Get(_ context.Context, ref string) (string, error) {
+	s.got = append(s.got, ref)
+	if s.failFor[ref] {
+		return "", errors.New("backend unavailable")
+	}
+	return "resolved-value", nil
+}
+
+func (s *verifyStore) Put(context.Context, carriersecrets.Scope, string) (string, error) {
+	panic("Verify must never write: Put called")
+}
+
+func (s *verifyStore) Destroy(context.Context, string) error {
+	panic("Verify must never write: Destroy called")
+}
+
+func TestVerify_ResolvesEveryReferenceAndCountsBySchema(t *testing.T) {
+	scope := carriersecrets.Scope{TenantID: "t1", Domain: "payment", Provider: "razorpay", Field: "api_key"}
+	baoRef := carriersecrets.FormatBaoReference(scope)
+	gsmRef := carriersecrets.GSMRefPrefix + "projects/p/secrets/s"
+
+	rows := []Row{
+		{Table: "payment_gateway_configs", Column: "api_key_encrypted", ID: "1", Ref: baoRef, Scope: scope},
+		{Table: "payment_gateway_configs", Column: "secret_key_encrypted", ID: "1", Ref: baoRef, Scope: scope},
+		{Table: "shipping_carrier_configs", Column: "api_key_encrypted", ID: "2", Ref: gsmRef, Scope: scope},
+		{Table: "custom_domains", Column: "cf_api_token_encrypted", ID: "3", Ref: "", Scope: scope},
+	}
+
+	store := &verifyStore{}
+	b := &Backfiller{Rows: &recordingRowStore{rows: rows}, Store: store}
+
+	res, err := b.Verify(context.Background())
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+
+	if res.Examined != 4 {
+		t.Errorf("Examined = %d, want 4", res.Examined)
+	}
+	// The empty reference is not a credential and must not be dialled.
+	if res.Resolved != 3 {
+		t.Errorf("Resolved = %d, want 3", res.Resolved)
+	}
+	if res.Failed != 0 {
+		t.Errorf("Failed = %d, want 0", res.Failed)
+	}
+	if len(store.got) != 3 {
+		t.Errorf("Store.Get called %d times, want 3 (empty ref must not be read)", len(store.got))
+	}
+
+	// The scheme census is the actual decision input for #621: it says
+	// whether any credential is still served by GCP Secret Manager.
+	if res.ByScheme["bao"] != 2 {
+		t.Errorf("ByScheme[bao] = %d, want 2", res.ByScheme["bao"])
+	}
+	if res.ByScheme["gsm"] != 1 {
+		t.Errorf("ByScheme[gsm] = %d, want 1", res.ByScheme["gsm"])
+	}
+	if res.ByScheme["empty"] != 1 {
+		t.Errorf("ByScheme[empty] = %d, want 1", res.ByScheme["empty"])
+	}
+}
+
+func TestVerify_CountsUnresolvableReferences(t *testing.T) {
+	scope := carriersecrets.Scope{TenantID: "t1", Domain: "payment", Provider: "razorpay", Field: "api_key"}
+	badRef := carriersecrets.FormatBaoReference(scope)
+
+	store := &verifyStore{failFor: map[string]bool{badRef: true}}
+	b := &Backfiller{
+		Rows:  &recordingRowStore{rows: []Row{{Table: "payment_gateway_configs", Column: "api_key_encrypted", ID: "1", Ref: badRef, Scope: scope}}},
+		Store: store,
+	}
+
+	res, err := b.Verify(context.Background())
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if res.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", res.Failed)
+	}
+	if res.Resolved != 0 {
+		t.Errorf("Resolved = %d, want 0", res.Resolved)
+	}
+}


### PR DESCRIPTION
The last piece of evidence #621 needs before deleting anything. Read-only.

## The problem with "the counter is zero"

Every carrier-credential reference is already `bao://`. So **no amount of production traffic can move** `carriersecrets_events_total{event="gsm_fallback_read"}`. That makes a zero reading ambiguous in the worst possible way:

- the credential paths were exercised and none touched GCP — *safe to delete*
- the credential paths were never reached at all — *proves nothing*

Both render as `0`. #608 made the counter real and #625 made it scrapable, but neither can distinguish those two cases, and #621 deletes six live merchant credentials' backend on the difference.

`-verify` supplies the missing half: it drives a real `Store.Get` through every reference in the database, so a zero counter *afterwards* means "exercised and clean" rather than "not measured".

## Why not just hit the API instead

The obvious alternative — call `GET /storefront/stores/{slug}/payment-methods` — has three problems this avoids:

- it sits behind `RequireStorefrontKey`, so verifying would mean extracting and replaying a shared secret;
- `POST /shipping-rates` quotes against the **live carrier API**, an outward-facing third-party call;
- the refund-sweep cron resolves credentials but can also take **real financial actions**.

`-verify` reaches the same `ChainStore.Get` those paths reach — which is exactly the level the counter instruments — with none of that blast radius.

## What it does

- Reads every reference via `Store.Get` and reports `examined / resolved / failed`.
- Reports a census `by_scheme`: `bao | gsm | inline | empty | unknown`. A non-zero `gsm` count is a direct, independent statement that GCP Secret Manager still serves a live credential.
- **Never writes.** Only `Store.Get`; no `Put`, no `Destroy`, no DB write beyond the initial `FetchAll`.
- Never logs a secret. Failures are reported by table/column/id and scheme. `referenceScheme` deliberately returns no part of the reference, since an unrecognised value can be a raw pre-encryption credential.
- Skips empty columns rather than dialling a backend for them — an empty column is not a configured credential, and reading it would invent a read production never performs.

## Tests

- `TestVerify_ResolvesEveryReferenceAndCountsBySchema` — mixed `bao`/`gsm`/empty rows; asserts the scheme census, and that the empty reference is **not** read.
- `TestVerify_CountsUnresolvableReferences` — a failing backend counts as `failed`, not `resolved`.
- The fake store **panics** on `Put`/`Destroy`, so a future change that makes verification write cannot pass silently.

Both verified RED first (`b.Verify undefined`).

## Test plan

- [x] `go test ./...` — 0 failures
- [x] `go build`, `go vet`, `gofmt` clean
- [x] `scripts/ci/verify-logging-smoke.sh` — PASS
- [ ] In-cluster: `carrier-secrets-backfill -verify` reports `failed=0` and `by_scheme` with **`gsm` absent**
- [ ] Counter re-read afterwards still shows `gsm_fallback_read 0`

Those last two together are the actual gate on #621's deletion step.

Refs #608, #621, #624.
