### PR TITLE
feat(auth-bff): Zitadel login client with fail-closed MFA, behind a disabled flag (#524)

### DIFF
--- a/docs/superpowers/plans/2026-09-03-zitadel-phase2-login-client.md
+++ b/docs/superpowers/plans/2026-09-03-zitadel-phase2-login-client.md
@@ -1,0 +1,1359 @@
+# Zitadel Migration Phase 2 — auth-bff Login Client Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `auth-bff` a Zitadel login client that authenticates a user against Zitadel's Session API v2 and finalizes an OIDC auth request — with MFA enforced in our own fail-closed code — reachable only when a disabled-by-default flag is set, leaving GIP as the live path.
+
+**Architecture:** `AutoLogin`'s ten steps are split: step 2 (identity) becomes provider-specific, steps 3–10 (FGA membership, MFA gate, deviceguard, email OTP, session mint, registry, audit) become a shared `completeLogin` both providers call. A new `internal/zitadellogin` package ports hms's `loginclient` + `sufficiency` design. Nothing in `apps/` changes — the new endpoints exist but no frontend calls them until phase 3.
+
+**Tech Stack:** Go 1.26, Gin, `net/http` (no Zitadel SDK — both precedent repos hand-roll deliberately), stdlib `testing` with hand-written fakes and `httptest.Server`.
+
+**Spec:** `docs/superpowers/specs/2026-09-03-zitadel-migration-design.md`
+
+## Global Constraints
+
+- **Repo is `mark8ly`; the service is `services/auth-bff`.** The sibling checkout `tesserix-new/auth-bff` is a different, stale service — never touch it.
+- **GIP stays live.** Every change is additive and gated. `AutoLogin`'s existing behaviour and its existing tests must be unchanged at the end of Task 1.
+- **No new test framework.** This service uses hand-written fakes (`gip/fake.go`, `authz/fake.go`) and stdlib `testing`. No gomock, no testify mocks, no cassettes. Fake Zitadel is an `httptest.Server` with inline JSON literals copied from observed responses.
+- **No Zitadel SDK dependency.** `net/http` + `encoding/json` only.
+- **Config must not be required.** Add fields with no `required:"true"` tag; gate wiring in `main.go` with the existing `if cfg.X != "" { ... } else { log.Warn(...) }` idiom. A required env var that rejects empty crashloops the deployment on merge and no test catches it.
+- **Never log a credential.** Session tokens, the login-client PAT, passwords and TOTP codes are all secrets. Error text must not carry Zitadel's `failedAttempts` counter.
+- **Zitadel does not enforce MFA for login clients.** Under `forceMfa: true` it still issues an authorization code for a password-only session. Enforcement is entirely this code's job.
+- Instance: `https://auth.tesserix.app` (v4.15.3). Projects `mark8ly-admin` = `389070376568619523`, `mark8ly-storefront` = `389070377390703107`.
+
+---
+
+### Task 1: Split `AutoLogin` so the post-identity gauntlet is shared
+
+Provider-agnostic today, but entangled with GIP verification. Extracting it first means the Zitadel path is genuinely additive rather than a second copy of the gating that can drift out of sync.
+
+**Files:**
+- Modify: `services/auth-bff/internal/autologin/service.go` (`AutoLogin`, lines ~181-335)
+- Test: `services/auth-bff/internal/autologin/service_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `func (s *Service) completeLogin(ctx context.Context, w http.ResponseWriter, id Identity, req Request) (*Result, error)` and `type Identity struct { UID, Email, TenantID string }`. Task 5 calls `completeLogin` from the Zitadel handler.
+
+- [ ] **Step 1: Write the characterisation test that pins current behaviour**
+
+Add to `service_test.go`. This must pass BEFORE the refactor — it is the proof the refactor changes nothing.
+
+```go
+func TestCompleteLogin_RunsTheSameGauntletAsAutoLogin(t *testing.T) {
+	gipFake := gip.NewFakeVerifier()
+	gipFake.Add("good-token", gip.VerifiedToken{UID: "user-1", Email: "u@e.com", TenantID: "MP-Internal-test"})
+	fgaFake := authz.NewFake()
+	fgaFake.SetMembership("user-1", "tenant-uuid-1")
+
+	svc := newTestService(t, gipFake, fgaFake, fastPolicy)
+
+	viaAutoLogin := httptest.NewRecorder()
+	got, err := svc.AutoLogin(context.Background(), viaAutoLogin, Request{
+		IDToken: "good-token", ExpectedTenantID: "MP-Internal-test", WorkspaceTenant: "tenant-uuid-1",
+	})
+	if err != nil {
+		t.Fatalf("AutoLogin: %v", err)
+	}
+	if got.UID != "user-1" || got.TenantID != "tenant-uuid-1" {
+		t.Fatalf("result = %+v", got)
+	}
+	if len(viaAutoLogin.Result().Cookies()) == 0 {
+		t.Fatal("AutoLogin minted no cookie")
+	}
+}
+```
+
+- [ ] **Step 2: Run it to confirm it passes against today's code**
+
+Run: `cd services/auth-bff && go test ./internal/autologin/ -run TestCompleteLogin_RunsTheSameGauntletAsAutoLogin -v`
+Expected: PASS. If it fails, stop — the test is wrong, not the code.
+
+- [ ] **Step 3: Extract `completeLogin`**
+
+In `service.go`, add above `AutoLogin`:
+
+```go
+// Identity is the outcome of authenticating a user, independent of which
+// provider did it. Everything downstream of this type — membership, MFA,
+// device and OTP gating, session minting — is provider-agnostic and shared
+// between the GIP and Zitadel paths.
+type Identity struct {
+	UID      string
+	Email    string
+	TenantID string
+}
+```
+
+Then change `AutoLogin` so that everything after the `gip.VerifyToken` call and its error mapping becomes a call to `completeLogin`:
+
+```go
+	tok, err := s.gip.VerifyToken(ctx, req.IDToken, req.ExpectedTenantID)
+	if err != nil {
+		if errors.Is(err, gip.ErrTenantMismatch) {
+			return nil, ErrTenantMismatch
+		}
+		return nil, fmt.Errorf("%w: %v", ErrTokenInvalid, err)
+	}
+
+	return s.completeLogin(ctx, w, Identity{
+		UID:      tok.UID,
+		Email:    tok.Email,
+		TenantID: tok.TenantID,
+	}, req)
+}
+
+// completeLogin runs every gate that stands between a verified identity and a
+// minted session: FGA membership (with the outbox-race retry), the MFA gate,
+// new-device evaluation, the email-OTP step-up, then the session cookie,
+// registry row and audit event.
+//
+// It is deliberately provider-agnostic. A Zitadel login that has satisfied its
+// own credential and factor checks arrives here with the same Identity a
+// verified GIP token produces, and is subject to exactly the same gates — so
+// the two providers cannot drift apart in what they enforce after login.
+func (s *Service) completeLogin(ctx context.Context, w http.ResponseWriter, id Identity, req Request) (*Result, error) {
+```
+
+Move the existing body verbatim into `completeLogin`, replacing every `tok.UID` with `id.UID`, `tok.Email` with `id.Email`, and `tok.TenantID` with `id.TenantID`. Change nothing else — no reordering, no new logging, no behaviour change.
+
+- [ ] **Step 4: Run the whole autologin suite**
+
+Run: `cd services/auth-bff && go test ./internal/autologin/ -v`
+Expected: every pre-existing test still passes, unchanged. If any needed editing, the refactor was not behaviour-preserving — revert and redo.
+
+- [ ] **Step 5: Vet and build**
+
+Run: `cd services/auth-bff && go vet ./... && go build ./...`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/auth-bff/internal/autologin/
+git commit -m "refactor(auth-bff): share the post-identity login gauntlet between providers"
+```
+
+---
+
+### Task 2: The Zitadel login client
+
+A direct port of hms's `loginclient`, whose every JSON shape was pinned to observed behaviour against a live v4.15.3 instance rather than to documentation.
+
+**Files:**
+- Create: `services/auth-bff/internal/zitadellogin/client.go`
+- Test: `services/auth-bff/internal/zitadellogin/client_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `func New(baseURL, token string, hc *http.Client) *Client`; methods `AuthRequest(ctx, id) (AuthRequest, error)`, `CreatePasswordSession(ctx, loginName, password string) (Session, error)`, `VerifyTOTP(ctx, s Session, code string) (Session, error)`, `SessionFactors(ctx, sessionID string) (Factors, error)`, `LoginPolicyForOrg(ctx, orgID string) (LoginPolicy, error)`, `InstanceLoginPolicyForDisplay(ctx) (LoginPolicy, error)`; types `Session{ID, Token string}`, `LoginPolicy{ForceMFA, ForceMFALocalOnly bool}`; sentinels `ErrBadCredentials`, `ErrUserNotFound`, `ErrAuthRequestInvalid`, `ErrUnavailable`. Task 3 adds `finalize` and the sufficiency entry points to this same package.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `client_test.go`. The JSON bodies are the literal shapes observed from Zitadel — do not tidy them.
+
+```go
+package zitadellogin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestClient(t *testing.T, h http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "test-pat", srv.Client())
+}
+
+func TestCreatePasswordSessionReturnsSession(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v2/sessions" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-pat" {
+			t.Errorf("Authorization = %q", got)
+		}
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"sessionId":"389070697432875523","sessionToken":"tok-1"}`))
+	})
+	s, err := c.CreatePasswordSession(context.Background(), "a@b.test", "pw")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if s.ID != "389070697432875523" || s.Token != "tok-1" {
+		t.Fatalf("session = %+v", s)
+	}
+}
+
+func TestCreatePasswordSessionMapsWrongPasswordAndHidesAttemptCounter(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"code":3,"message":"Password is invalid (COMMAND-3M0fs)","details":[{"@type":"type.googleapis.com/zitadel.v1.CredentialsCheckError","id":"COMMAND-3M0fs","message":"Password is invalid","failedAttempts":1}]}`))
+	})
+	_, err := c.CreatePasswordSession(context.Background(), "a@b.test", "wrong")
+	if !errors.Is(err, ErrBadCredentials) {
+		t.Fatalf("err = %v, want ErrBadCredentials", err)
+	}
+	if strings.Contains(err.Error(), "failedAttempts") {
+		t.Errorf("error text leaks the attempt counter: %q", err.Error())
+	}
+}
+
+func TestVerifyTOTPUsesPatchAndReturnsTheRotatedToken(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("method = %s, want PATCH (POST returns 405 on this endpoint)", r.Method)
+		}
+		w.Write([]byte(`{"sessionToken":"tok-ROTATED"}`))
+	})
+	got, err := c.VerifyTOTP(context.Background(), Session{ID: "s1", Token: "tok-STALE"}, "123456")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got.Token != "tok-ROTATED" {
+		t.Fatalf("token = %q, want the rotated token from the response, not the input", got.Token)
+	}
+	if got.ID != "s1" {
+		t.Fatalf("id = %q", got.ID)
+	}
+}
+
+func TestLoginPolicyForOrgSetsTheOrgHeader(t *testing.T) {
+	var sawOrg string
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		sawOrg = r.Header.Get("x-zitadel-orgid")
+		w.Write([]byte(`{"policy":{"passwordCheckLifetime":"0s","forceMfa":true}}`))
+	})
+	p, err := c.LoginPolicyForOrg(context.Background(), "org-1")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if sawOrg != "org-1" {
+		t.Errorf("x-zitadel-orgid = %q", sawOrg)
+	}
+	if !p.ForceMFA {
+		t.Error("ForceMFA = false, want true")
+	}
+}
+
+func TestLoginPolicyForOrgRefusesAnEmptyOrgRatherThanReadingUnscoped(t *testing.T) {
+	called := false
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.Write([]byte(`{"policy":{"passwordCheckLifetime":"0s"}}`))
+	})
+	_, err := c.LoginPolicyForOrg(context.Background(), "")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", err)
+	}
+	if called {
+		t.Error("made an unscoped HTTP call; an empty org id must be refused before the request")
+	}
+}
+
+func TestLoginPolicyRejectsAResponseWithoutTheAnchorField(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"policy":{"someOtherThing":true}}`))
+	})
+	_, err := c.LoginPolicyForOrg(context.Background(), "org-1")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable for an unrecognizable policy object", err)
+	}
+}
+
+func TestLoginPolicyTreatsAbsentForceMfaAsFalseNotUnknown(t *testing.T) {
+	// protojson elides zero-value booleans, so a perfectly healthy org that
+	// does not force MFA sends no forceMfa key at all. Treating that as
+	// "unrecognized" handed every ordinary login to the hosted UI in hms.
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"policy":{"passwordCheckLifetime":"0s"}}`))
+	})
+	p, err := c.LoginPolicyForOrg(context.Background(), "org-1")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if p.ForceMFA || p.ForceMFALocalOnly {
+		t.Fatalf("policy = %+v, want both false", p)
+	}
+}
+
+func TestLoginPolicyReadsForceMfaLocalOnlySeparately(t *testing.T) {
+	// These are two distinct fields and mark8ly must keep them distinct: it
+	// has federated (Google/Apple) users, for whom forceMfaLocalOnly does NOT
+	// apply. Folding them together would force MFA on federated logins.
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"policy":{"passwordCheckLifetime":"0s","forceMfaLocalOnly":true}}`))
+	})
+	p, err := c.LoginPolicyForOrg(context.Background(), "org-1")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if p.ForceMFA {
+		t.Error("ForceMFA = true, want false — forceMfa was absent")
+	}
+	if !p.ForceMFALocalOnly {
+		t.Error("ForceMFALocalOnly = false, want true")
+	}
+}
+
+func TestLoginPolicyRefusesARenamedOrRecasedMfaKey(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"policy":{"passwordCheckLifetime":"0s","force_mfa":true}}`))
+	})
+	_, err := c.LoginPolicyForOrg(context.Background(), "org-1")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v; a renamed key must fail closed, not read as absent-therefore-false", err)
+	}
+}
+
+func TestTransportFailureMapsToUnavailable(t *testing.T) {
+	c := New("http://127.0.0.1:1", "pat", &http.Client{})
+	_, err := c.CreatePasswordSession(context.Background(), "a@b.test", "pw")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd services/auth-bff && go test ./internal/zitadellogin/`
+Expected: build failure — the package does not exist yet.
+
+- [ ] **Step 3: Implement the client**
+
+Create `client.go`. Port hms's design; the comments explaining *why* are as important as the code.
+
+```go
+// Package zitadellogin speaks Zitadel's v2 login-client HTTP API so auth-bff
+// can host its own login page instead of redirecting to Zitadel's.
+//
+// Every JSON shape and error mapping here is pinned to what was OBSERVED
+// against a live Zitadel v4.15.3 instance, not to what the documentation says
+// the API should return. Three separate shapes in this API answer 200 or 201
+// while doing something other than what the caller assumes.
+//
+// This package makes NO decision about whether a session is adequate to
+// finalize a login — that is sufficiency.go's job, and Zitadel will happily
+// issue an authorization code for a password-only session even under a
+// forceMfa policy.
+package zitadellogin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	defaultTimeout      = 10 * time.Second
+	maxSuccessBodyBytes = 64 * 1024
+	maxErrorBodyBytes   = 4096
+)
+
+var (
+	ErrBadCredentials     = errors.New("zitadellogin: bad credentials")
+	ErrUserNotFound       = errors.New("zitadellogin: user not found")
+	ErrAuthRequestInvalid = errors.New("zitadellogin: auth request invalid")
+	ErrUnavailable        = errors.New("zitadellogin: zitadel unavailable")
+)
+
+type Client struct {
+	baseURL string
+	token   string
+	hc      *http.Client
+}
+
+// New builds a client. token is the login-client PAT: it authenticates every
+// call in this package, never the end-user session being established. It is
+// instance-level and can mint a session for any user of any product on the
+// shared instance — treat it as the most powerful credential this service
+// holds and never log it.
+func New(baseURL, token string, hc *http.Client) *Client {
+	if hc == nil {
+		hc = &http.Client{Timeout: defaultTimeout}
+	}
+	return &Client{baseURL: strings.TrimSuffix(baseURL, "/"), token: token, hc: hc}
+}
+
+// Session is a Zitadel session. Token is a bearer-equivalent secret for this
+// one session and must never be logged.
+type Session struct {
+	ID    string
+	Token string
+}
+
+// LoginPolicy carries the two MFA fields as SEPARATE values. They are not
+// folded together: forceMfaLocalOnly means "require MFA for local/password
+// users, not federated ones", and mark8ly has federated Google and Apple
+// users for whom that distinction is load-bearing.
+type LoginPolicy struct {
+	ForceMFA          bool
+	ForceMFALocalOnly bool
+}
+
+type Factors struct {
+	Password bool
+	TOTP     bool
+	UserID   string
+	OrgID    string
+}
+
+type AuthRequest struct {
+	ID string
+}
+
+// requestOptions accumulates per-request settings. The option type is
+// func(*requestOptions), NOT func(*http.Request), deliberately: an option that
+// could reach the raw request could set or overwrite any header — including
+// the Authorization header do sets from the PAT. This shape makes that class
+// of bug unrepresentable rather than something a reviewer must keep checking.
+type requestOptions struct {
+	orgID string
+}
+
+type requestOption func(*requestOptions)
+
+func withOrgID(orgID string) requestOption {
+	return func(ro *requestOptions) { ro.orgID = orgID }
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body, out any, notFound error, opts ...requestOption) error {
+	var rdr io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("zitadellogin: marshal %s %s: %w", method, path, err)
+		}
+		rdr = bytes.NewReader(buf)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, rdr)
+	if err != nil {
+		return fmt.Errorf("zitadellogin: build %s %s: %w", method, path, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	var ro requestOptions
+	for _, opt := range opts {
+		opt(&ro)
+	}
+	if ro.orgID != "" {
+		req.Header.Set("x-zitadel-orgid", ro.orgID)
+	}
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("zitadellogin: %s %s: %v: %w", method, path, err, ErrUnavailable)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		id := readZitadelErrorID(resp.Body)
+		switch {
+		case resp.StatusCode == http.StatusBadRequest:
+			return fmt.Errorf("zitadellogin: %s %s: %s: %w", method, path, id, ErrBadCredentials)
+		case resp.StatusCode == http.StatusNotFound:
+			return fmt.Errorf("zitadellogin: %s %s: %s: %w", method, path, id, notFound)
+		default:
+			return fmt.Errorf("zitadellogin: %s %s: status %d: %s: %w", method, path, resp.StatusCode, id, ErrUnavailable)
+		}
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxSuccessBodyBytes)).Decode(out); err != nil {
+		return fmt.Errorf("zitadellogin: decode %s %s: %v: %w", method, path, err, ErrUnavailable)
+	}
+	return nil
+}
+
+// readZitadelErrorID extracts ONLY details[0].id (e.g. "COMMAND-3M0fs"). The
+// raw error body is never surfaced, because that is exactly where Zitadel puts
+// failedAttempts — a counter that must not reach a caller or a log line.
+func readZitadelErrorID(r io.Reader) string {
+	var wire struct {
+		Details []struct {
+			ID string `json:"id"`
+		} `json:"details"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r, maxErrorBodyBytes)).Decode(&wire); err != nil {
+		return "unknown"
+	}
+	if len(wire.Details) == 0 || wire.Details[0].ID == "" {
+		return "unknown"
+	}
+	return wire.Details[0].ID
+}
+
+func (c *Client) AuthRequest(ctx context.Context, id string) (AuthRequest, error) {
+	var wire struct {
+		AuthRequest struct {
+			ID string `json:"id"`
+		} `json:"authRequest"`
+	}
+	err := c.do(ctx, http.MethodGet, "/v2/oidc/auth_requests/"+url.PathEscape(id), nil, &wire, ErrAuthRequestInvalid)
+	if err != nil {
+		return AuthRequest{}, err
+	}
+	return AuthRequest{ID: wire.AuthRequest.ID}, nil
+}
+
+// CreatePasswordSession checks the login name and password in ONE call, so a
+// wrong username and a wrong password take the same code path and the same
+// time. ErrUserNotFound and ErrBadCredentials stay distinct here for logging;
+// collapsing them into one user-facing answer is the handler's job.
+func (c *Client) CreatePasswordSession(ctx context.Context, loginName, password string) (Session, error) {
+	body := map[string]any{
+		"checks": map[string]any{
+			"user":     map[string]any{"loginName": loginName},
+			"password": map[string]any{"password": password},
+		},
+	}
+	var wire struct {
+		SessionID    string `json:"sessionId"`
+		SessionToken string `json:"sessionToken"`
+	}
+	if err := c.do(ctx, http.MethodPost, "/v2/sessions", body, &wire, ErrUserNotFound); err != nil {
+		return Session{}, err
+	}
+	return Session{ID: wire.SessionID, Token: wire.SessionToken}, nil
+}
+
+// VerifyTOTP submits a TOTP code.
+//
+// Two facts, both observed and both easy to get wrong:
+//
+//  1. The method is PATCH. POST to a session id returns 405.
+//  2. The session token ROTATES on every check. The response carries a NEW
+//     sessionToken, and finalize needs the newest one. Returning the input
+//     session keeps the stale token and makes finalize fail AFTER a correct
+//     code, which the user reads as "my code was wrong".
+func (c *Client) VerifyTOTP(ctx context.Context, s Session, code string) (Session, error) {
+	body := map[string]any{
+		"sessionToken": s.Token,
+		"checks":       map[string]any{"totp": map[string]any{"code": code}},
+	}
+	var wire struct {
+		SessionToken string `json:"sessionToken"`
+	}
+	if err := c.do(ctx, http.MethodPatch, "/v2/sessions/"+url.PathEscape(s.ID), body, &wire, ErrBadCredentials); err != nil {
+		return Session{}, err
+	}
+	return Session{ID: s.ID, Token: wire.SessionToken}, nil
+}
+
+// SessionFactors re-reads what Zitadel believes was verified. The create
+// response omits the factors object entirely, so it cannot be trusted to say
+// what was checked — this is the only honest source.
+func (c *Client) SessionFactors(ctx context.Context, sessionID string) (Factors, error) {
+	var wire struct {
+		Session struct {
+			Factors struct {
+				User *struct {
+					ID             string `json:"id"`
+					OrganizationID string `json:"organizationId"`
+				} `json:"user"`
+				Password *struct {
+					VerifiedAt string `json:"verifiedAt"`
+				} `json:"password"`
+				TOTP *struct {
+					VerifiedAt string `json:"verifiedAt"`
+				} `json:"totp"`
+			} `json:"factors"`
+		} `json:"session"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/v2/sessions/"+url.PathEscape(sessionID), nil, &wire, ErrUnavailable); err != nil {
+		return Factors{}, err
+	}
+	f := wire.Session.Factors
+	out := Factors{Password: f.Password != nil, TOTP: f.TOTP != nil}
+	if f.User != nil {
+		out.UserID, out.OrgID = f.User.ID, f.User.OrganizationID
+	}
+	return out, nil
+}
+
+// EnrolledMethodTypes lists a user's registered authentication methods.
+func (c *Client) EnrolledMethodTypes(ctx context.Context, userID string) ([]string, error) {
+	var wire struct {
+		AuthMethodTypes []string `json:"authMethodTypes"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/v2/users/"+url.PathEscape(userID)+"/authentication_methods", nil, &wire, ErrUnavailable); err != nil {
+		return nil, err
+	}
+	return wire.AuthMethodTypes, nil
+}
+
+var mfaPolicyKeys = []string{"forceMfa", "forceMfaLocalOnly"}
+
+// policyAnchorKey proves a 200 really carried a login-policy object.
+//
+// It cannot be one of the MFA booleans: protojson elides zero-value fields, so
+// a healthy org that does not force MFA sends no forceMfa key at all. Treating
+// that absence as "unrecognized" handed every ordinary login to the hosted UI
+// in hms. passwordCheckLifetime is a message-typed field observed present on
+// every real response.
+const policyAnchorKey = "passwordCheckLifetime"
+
+func (c *Client) loginPolicy(ctx context.Context, opts ...requestOption) (LoginPolicy, error) {
+	var wire struct {
+		Policy map[string]any `json:"policy"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/management/v1/policies/login", nil, &wire, ErrUnavailable, opts...); err != nil {
+		return LoginPolicy{}, err
+	}
+	if _, ok := wire.Policy[policyAnchorKey]; !ok {
+		return LoginPolicy{}, fmt.Errorf("zitadellogin: 200 without a recognizable policy object: %w", ErrUnavailable)
+	}
+	for _, key := range mfaPolicyKeys {
+		if err := refuseIfKeyRenamedOrRecased(wire.Policy, key); err != nil {
+			return LoginPolicy{}, err
+		}
+	}
+	forceMFA, err := readMFABool(wire.Policy, "forceMfa")
+	if err != nil {
+		return LoginPolicy{}, err
+	}
+	localOnly, err := readMFABool(wire.Policy, "forceMfaLocalOnly")
+	if err != nil {
+		return LoginPolicy{}, err
+	}
+	return LoginPolicy{ForceMFA: forceMFA, ForceMFALocalOnly: localOnly}, nil
+}
+
+func normalizePolicyKey(key string) string {
+	return strings.ReplaceAll(strings.ToLower(key), "_", "")
+}
+
+// refuseIfKeyRenamedOrRecased fails closed when the API renames or re-cases an
+// MFA field. Without it, force_mfa or ForceMFA would decode as merely absent,
+// therefore false — a silent fail-open on the one field that matters most.
+func refuseIfKeyRenamedOrRecased(policy map[string]any, wantKey string) error {
+	want := normalizePolicyKey(wantKey)
+	for k := range policy {
+		if k != wantKey && normalizePolicyKey(k) == want {
+			return fmt.Errorf("zitadellogin: policy key %q looks like a renamed %q: %w", k, wantKey, ErrUnavailable)
+		}
+	}
+	return nil
+}
+
+func readMFABool(policy map[string]any, key string) (bool, error) {
+	v, ok := policy[key]
+	if !ok {
+		return false, nil // elided zero value: genuinely false
+	}
+	b, ok := v.(bool)
+	if !ok {
+		return false, fmt.Errorf("zitadellogin: policy.%s is %T, not a bool: %w", key, v, ErrUnavailable)
+	}
+	return b, nil
+}
+
+// LoginPolicyForOrg reads the policy of the org the user actually belongs to.
+// It refuses an empty org id rather than falling back to an unscoped read: an
+// unscoped read judges a user in one org by a different org's policy, which is
+// a real, shipped MFA bypass (hms #913).
+func (c *Client) LoginPolicyForOrg(ctx context.Context, orgID string) (LoginPolicy, error) {
+	if orgID == "" {
+		return LoginPolicy{}, fmt.Errorf("zitadellogin: LoginPolicyForOrg with an empty org id, refusing rather than reading unscoped: %w", ErrUnavailable)
+	}
+	return c.loginPolicy(ctx, withOrgID(orgID))
+}
+
+// InstanceLoginPolicyForDisplay reads the unscoped instance policy. It is for
+// display before a user is known and MUST NOT be used for enforcement; an
+// archtest forbids sufficiency.go from referencing it.
+func (c *Client) InstanceLoginPolicyForDisplay(ctx context.Context) (LoginPolicy, error) {
+	return c.loginPolicy(ctx)
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd services/auth-bff && go test ./internal/zitadellogin/ -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Vet and commit**
+
+```bash
+cd services/auth-bff && go vet ./... && gofmt -l internal/zitadellogin/
+git add services/auth-bff/internal/zitadellogin/
+git commit -m "feat(auth-bff): add a Zitadel login client pinned to observed API behaviour"
+```
+
+---
+
+### Task 3: Sufficiency — MFA enforced in our code, fail-closed
+
+Zitadel issues an authorization code for a password-only session **even under `forceMfa: true`**. Verified independently by two repos against the live instance. This task is the only thing standing between that and an MFA bypass.
+
+**Files:**
+- Create: `services/auth-bff/internal/zitadellogin/sufficiency.go`
+- Test: `services/auth-bff/internal/zitadellogin/sufficiency_test.go`
+- Test: `services/auth-bff/internal/zitadellogin/arch_test.go`
+
+**Interfaces:**
+- Consumes: Task 2's `Client`, `Session`, `LoginPolicy`, `Factors`, sentinels.
+- Produces: `type Outcome int` with `OutcomeHandoff` (zero value), `OutcomeComplete`, `OutcomeFactorRequired`; `type Result struct { Outcome Outcome; CallbackURL string; Factors []string }`; `func (c *Client) CompleteIfSufficient(ctx, authRequestID string, s Session, federated bool) (Result, error)`; `func (c *Client) CompleteAfterFactor(ctx, authRequestID string, s Session) (Result, error)`. Task 5's handler consumes both.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `sufficiency_test.go`:
+
+```go
+package zitadellogin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func fakeZitadel(t *testing.T, policyJSON, methodsJSON, factorsJSON string, finalized *atomic.Bool) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/management/v1/policies/login":
+			w.Write([]byte(policyJSON))
+		case strings.HasSuffix(r.URL.Path, "/authentication_methods"):
+			w.Write([]byte(`{"authMethodTypes":` + methodsJSON + `}`))
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v2/oidc/auth_requests/"):
+			finalized.Store(true)
+			w.Write([]byte(`{"callbackUrl":"https://admin.mark8ly.com/auth/callback?code=c&state=s"}`))
+		case strings.HasPrefix(r.URL.Path, "/v2/sessions/"):
+			w.Write([]byte(factorsJSON))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "pat", srv.Client())
+}
+
+const factorsPasswordOnly = `{"session":{"factors":{"user":{"id":"u1","organizationId":"o1"},"password":{"verifiedAt":"2026-09-03T01:00:00Z"}}}}`
+const factorsWithTOTP = `{"session":{"factors":{"user":{"id":"u1","organizationId":"o1"},"password":{"verifiedAt":"2026-09-03T01:00:00Z"},"totp":{"verifiedAt":"2026-09-03T01:01:00Z"}}}}`
+const policyNoMFA = `{"policy":{"passwordCheckLifetime":"0s"}}`
+const policyForceMFA = `{"policy":{"passwordCheckLifetime":"0s","forceMfa":true}}`
+const policyLocalOnly = `{"policy":{"passwordCheckLifetime":"0s","forceMfaLocalOnly":true}}`
+
+func TestPasswordOnlyCompletesWhenNoMFAIsRequired(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadel(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+	res, err := c.CompleteIfSufficient(context.Background(), "V2_1", Session{ID: "s1", Token: "t"}, false)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeComplete || res.CallbackURL == "" {
+		t.Fatalf("result = %+v", res)
+	}
+	if !fin.Load() {
+		t.Error("finalize was not called")
+	}
+}
+
+func TestPasswordOnlyDoesNotCompleteWhenForceMfaIsSet(t *testing.T) {
+	// The whole reason this package exists: Zitadel WOULD issue a code here.
+	var fin atomic.Bool
+	c := fakeZitadel(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsPasswordOnly, &fin)
+	res, err := c.CompleteIfSufficient(context.Background(), "V2_1", Session{ID: "s1", Token: "t"}, false)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeFactorRequired {
+		t.Fatalf("outcome = %v, want OutcomeFactorRequired", res.Outcome)
+	}
+	if fin.Load() {
+		t.Fatal("finalize WAS called for a password-only session under forceMfa — MFA bypass")
+	}
+}
+
+func TestForceMfaLocalOnlyDoesNotApplyToFederatedUsers(t *testing.T) {
+	// forceMfaLocalOnly means "local/password users only". mark8ly has Google
+	// and Apple users; forcing MFA on them would be wrong.
+	var fin atomic.Bool
+	c := fakeZitadel(t, policyLocalOnly, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+	res, err := c.CompleteIfSufficient(context.Background(), "V2_1", Session{ID: "s1", Token: "t"}, true /* federated */)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeComplete {
+		t.Fatalf("outcome = %v, want OutcomeComplete for a federated user", res.Outcome)
+	}
+	_ = fin
+}
+
+func TestForceMfaLocalOnlyDoesApplyToPasswordUsers(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadel(t, policyLocalOnly, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsPasswordOnly, &fin)
+	res, err := c.CompleteIfSufficient(context.Background(), "V2_1", Session{ID: "s1", Token: "t"}, false)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeFactorRequired {
+		t.Fatalf("outcome = %v, want OutcomeFactorRequired", res.Outcome)
+	}
+	if fin.Load() {
+		t.Fatal("finalize was called")
+	}
+}
+
+func TestAnUncollectibleFactorHandsOff(t *testing.T) {
+	// A passkey is a real second factor this login page cannot collect.
+	// Completing anyway would silently skip it.
+	var fin atomic.Bool
+	c := fakeZitadel(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_PASSKEY"]`, factorsPasswordOnly, &fin)
+	res, err := c.CompleteIfSufficient(context.Background(), "V2_1", Session{ID: "s1", Token: "t"}, false)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeHandoff {
+		t.Fatalf("outcome = %v, want OutcomeHandoff", res.Outcome)
+	}
+	if fin.Load() {
+		t.Fatal("finalize was called with an uncollected factor outstanding")
+	}
+}
+
+func TestAnUnreadablePolicyHandsOffRatherThanCompleting(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadel(t, `{"policy":{"nonsense":true}}`, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+	res, err := c.CompleteIfSufficient(context.Background(), "V2_1", Session{ID: "s1", Token: "t"}, false)
+	if err != nil {
+		t.Fatalf("err = %v (a handoff is an outcome, not an error)", err)
+	}
+	if res.Outcome != OutcomeHandoff {
+		t.Fatalf("outcome = %v, want OutcomeHandoff", res.Outcome)
+	}
+	if fin.Load() {
+		t.Fatal("finalize was called despite an unreadable policy")
+	}
+}
+
+func TestZeroValueOutcomeIsHandoff(t *testing.T) {
+	var r Result
+	if r.Outcome != OutcomeHandoff {
+		t.Fatal("the zero value must be OutcomeHandoff so an undecided Result cannot complete a login")
+	}
+}
+
+func TestCompleteAfterFactorRefusesWhenZitadelDoesNotReportTOTP(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadel(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsPasswordOnly, &fin)
+	res, err := c.CompleteAfterFactor(context.Background(), "V2_1", Session{ID: "s1", Token: "t"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome == OutcomeComplete {
+		t.Fatal("completed without Zitadel confirming the TOTP factor")
+	}
+	if fin.Load() {
+		t.Fatal("finalize was called")
+	}
+}
+
+func TestCompleteAfterFactorCompletesWhenTOTPIsConfirmed(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadel(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsWithTOTP, &fin)
+	res, err := c.CompleteAfterFactor(context.Background(), "V2_1", Session{ID: "s1", Token: "t"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeComplete || !fin.Load() {
+		t.Fatalf("result = %+v finalized=%v", res, fin.Load())
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd services/auth-bff && go test ./internal/zitadellogin/ -run 'Complete|Force|Uncollectible|ZeroValue|Password' -v`
+Expected: build failure — `CompleteIfSufficient` does not exist.
+
+- [ ] **Step 3: Implement sufficiency**
+
+Create `sufficiency.go`:
+
+```go
+package zitadellogin
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+)
+
+// Outcome is what to do with a login attempt.
+type Outcome int
+
+const (
+	// OutcomeHandoff is the zero value ON PURPOSE. Any Result built without a
+	// decision lands on "do not complete this login". The opposite default
+	// would cost an MFA bypass; that asymmetry decides which value is zero.
+	OutcomeHandoff Outcome = iota
+	OutcomeComplete
+	OutcomeFactorRequired
+)
+
+type Result struct {
+	Outcome     Outcome
+	CallbackURL string
+	Factors     []string
+}
+
+// sufficient is proof that a session was evaluated by one of this package's
+// two classification paths and found adequate to finalize.
+//
+// It makes "call finalize with no decision at all" a compile error. It does
+// NOT stop someone constructing sufficient{} beside a new check-free function
+// — Go permits that inside the package — which is why an archtest pins both
+// the finalize call site and sufficient{} construction to this file.
+type sufficient struct{}
+
+const (
+	methodPassword = "AUTHENTICATION_METHOD_TYPE_PASSWORD" // not a second factor
+	methodTOTP     = "AUTHENTICATION_METHOD_TYPE_TOTP"     // the one we can collect
+)
+
+// finalize exchanges a session for an authorization code. Unexported and
+// requiring a sufficient witness, so it is unreachable without a decision.
+func (c *Client) finalize(ctx context.Context, authRequestID string, s Session, _ sufficient) (string, error) {
+	body := map[string]any{
+		"session": map[string]any{"sessionId": s.ID, "sessionToken": s.Token},
+	}
+	var wire struct {
+		CallbackURL string `json:"callbackUrl"`
+	}
+	err := c.do(ctx, http.MethodPost, "/v2/oidc/auth_requests/"+url.PathEscape(authRequestID), body, &wire, ErrAuthRequestInvalid)
+	if err != nil {
+		return "", err
+	}
+	if wire.CallbackURL == "" {
+		return "", fmt.Errorf("zitadellogin: finalize returned no callbackUrl: %w", ErrUnavailable)
+	}
+	return wire.CallbackURL, nil
+}
+
+// classifyEnrolledMethods reports whether the user has TOTP enrolled and
+// whether they have any factor this login page cannot collect.
+//
+// Everything that is not PASSWORD or TOTP is uncollectible — an include list,
+// so a factor type we have never seen fails closed into a handoff rather than
+// being silently skipped.
+func (c *Client) classifyEnrolledMethods(ctx context.Context, userID string) (totpEnrolled, uncollectible bool, err error) {
+	types, err := c.EnrolledMethodTypes(ctx, userID)
+	if err != nil {
+		return false, false, err
+	}
+	for _, t := range types {
+		switch t {
+		case methodPassword:
+		case methodTOTP:
+			totpEnrolled = true
+		default:
+			uncollectible = true
+		}
+	}
+	return totpEnrolled, uncollectible, nil
+}
+
+// mfaRequired applies the two policy fields to this user.
+//
+// forceMfa applies to everyone. forceMfaLocalOnly applies only to users
+// authenticating with a local credential — mark8ly has federated Google and
+// Apple users, and forcing MFA on them would be wrong. These are kept separate
+// rather than OR-ed together for exactly that reason.
+func mfaRequired(p LoginPolicy, federated bool) bool {
+	if p.ForceMFA {
+		return true
+	}
+	return p.ForceMFALocalOnly && !federated
+}
+
+// CompleteIfSufficient decides whether a freshly created session may finalize.
+//
+// Zitadel does NOT enforce forceMfa for a login client: it issues an
+// authorization code for a password-only session and signals nothing. Every
+// uncertain input therefore fails closed to OutcomeHandoff, which is a
+// legitimate outcome rather than an error.
+func (c *Client) CompleteIfSufficient(ctx context.Context, authRequestID string, s Session, federated bool) (Result, error) {
+	factors, err := c.SessionFactors(ctx, s.ID)
+	if err != nil || factors.UserID == "" || factors.OrgID == "" {
+		slog.WarnContext(ctx, "zitadel sufficiency: cannot read session subject, handing off", "err", err)
+		return Result{Outcome: OutcomeHandoff}, nil
+	}
+	totpEnrolled, uncollectible, err := c.classifyEnrolledMethods(ctx, factors.UserID)
+	if err != nil {
+		slog.WarnContext(ctx, "zitadel sufficiency: cannot read enrolled methods, handing off", "err", err)
+		return Result{Outcome: OutcomeHandoff}, nil
+	}
+	if uncollectible {
+		return Result{Outcome: OutcomeHandoff}, nil
+	}
+	policy, err := c.LoginPolicyForOrg(ctx, factors.OrgID)
+	if err != nil {
+		slog.WarnContext(ctx, "zitadel sufficiency: cannot read login policy, handing off", "err", err)
+		return Result{Outcome: OutcomeHandoff}, nil
+	}
+	if mfaRequired(policy, federated) && !factors.TOTP {
+		if !totpEnrolled {
+			return Result{Outcome: OutcomeHandoff}, nil
+		}
+		return Result{Outcome: OutcomeFactorRequired, Factors: []string{methodTOTP}}, nil
+	}
+	cb, err := c.finalize(ctx, authRequestID, s, sufficient{})
+	if err != nil {
+		return Result{Outcome: OutcomeHandoff}, err
+	}
+	return Result{Outcome: OutcomeComplete, CallbackURL: cb}, nil
+}
+
+// CompleteAfterFactor finalizes after a TOTP check.
+//
+// It re-reads the factors from Zitadel rather than trusting that VerifyTOTP
+// returned without error, because the caller may be holding a stale session
+// value from before the token rotated.
+func (c *Client) CompleteAfterFactor(ctx context.Context, authRequestID string, s Session) (Result, error) {
+	factors, err := c.SessionFactors(ctx, s.ID)
+	if err != nil {
+		slog.WarnContext(ctx, "zitadel sufficiency: cannot re-read factors after TOTP, handing off", "err", err)
+		return Result{Outcome: OutcomeHandoff}, nil
+	}
+	if !factors.TOTP {
+		return Result{Outcome: OutcomeHandoff}, nil
+	}
+	cb, err := c.finalize(ctx, authRequestID, s, sufficient{})
+	if err != nil {
+		return Result{Outcome: OutcomeHandoff}, err
+	}
+	return Result{Outcome: OutcomeComplete, CallbackURL: cb}, nil
+}
+```
+
+- [ ] **Step 4: Write the archtests**
+
+Create `arch_test.go`. These are the mechanical backstop for the residual gap the witness type cannot close.
+
+```go
+package zitadellogin
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func sourceFiles(t *testing.T) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		out[name] = string(b)
+	}
+	return out
+}
+
+func TestFinalizeIsOnlyCalledFromSufficiency(t *testing.T) {
+	for name, src := range sourceFiles(t) {
+		if name == "sufficiency.go" {
+			continue
+		}
+		if strings.Contains(src, "c.finalize(") || strings.Contains(src, ".finalize(ctx") {
+			t.Errorf("%s calls finalize; the OIDC finalize call must stay behind a sufficiency decision, "+
+				"because Zitadel does not enforce forceMfa for a login client", name)
+		}
+	}
+}
+
+func TestSufficientWitnessIsOnlyConstructedInSufficiency(t *testing.T) {
+	for name, src := range sourceFiles(t) {
+		if name == "sufficiency.go" {
+			continue
+		}
+		if strings.Contains(src, "sufficient{") {
+			t.Errorf("%s constructs the sufficient witness; only sufficiency.go may", name)
+		}
+	}
+}
+
+func TestSufficiencyNeverUsesTheUnscopedDisplayPolicy(t *testing.T) {
+	src := sourceFiles(t)["sufficiency.go"]
+	if strings.Contains(src, "InstanceLoginPolicyForDisplay") {
+		t.Error("sufficiency.go references InstanceLoginPolicyForDisplay; enforcement must read the " +
+			"user's own org policy via LoginPolicyForOrg, or a user in one org is judged by another org's policy")
+	}
+}
+```
+
+- [ ] **Step 5: Run everything**
+
+Run: `cd services/auth-bff && go test ./internal/zitadellogin/ -v`
+Expected: all PASS, including the three archtests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/auth-bff/internal/zitadellogin/
+git commit -m "feat(auth-bff): enforce MFA in fail-closed sufficiency, since Zitadel does not"
+```
+
+---
+
+### Task 4: Config and wiring, disabled by default
+
+**Files:**
+- Modify: `services/auth-bff/pkg/config/config.go`
+- Modify: `services/auth-bff/cmd/server/main.go`
+- Test: `services/auth-bff/pkg/config/config_test.go` (create if absent)
+
+**Interfaces:**
+- Consumes: Task 2's `New`.
+- Produces: `cfg.ZitadelEnabled`, `cfg.ZitadelIssuer`, `cfg.ZitadelLoginClientToken`, `cfg.ZitadelAdminProjectID`, `cfg.ZitadelStorefrontProjectID`; a `*zitadellogin.Client` in `main.go`, nil when disabled. Task 5 consumes the client.
+
+- [ ] **Step 1: Write the failing config test**
+
+```go
+func TestZitadelIsDisabledAndUnrequiredByDefault(t *testing.T) {
+	for _, k := range []string{"ZITADEL_ENABLED", "ZITADEL_ISSUER", "ZITADEL_LOGIN_CLIENT_TOKEN"} {
+		t.Setenv(k, "")
+	}
+	// Only the pre-existing required vars are set.
+	t.Setenv("DATABASE_URL", "postgres://x")
+	t.Setenv("GIP_PROJECT_ID", "p")
+	t.Setenv("GIP_PROJECT_NUMBER", "1")
+	t.Setenv("GIP_WEB_API_KEY", "k")
+	t.Setenv("GIP_INTERNAL_TENANT_ID", "t")
+	t.Setenv("OAUTH_CLIENT_ID", "c")
+	t.Setenv("OAUTH_CLIENT_SECRET", "s")
+	t.Setenv("SESSION_ENCRYPT_KEY", "thirtytwo-bytes-for-testing-only")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load must succeed with no Zitadel config at all: %v", err)
+	}
+	if cfg.ZitadelEnabled {
+		t.Error("ZitadelEnabled must default to false")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd services/auth-bff && go test ./pkg/config/ -run TestZitadelIsDisabled -v`
+Expected: FAIL — field does not exist.
+
+- [ ] **Step 3: Add the config fields**
+
+In `config.go`, alongside the existing GIP fields. **No `required:"true"` on any of them** — a required var that rejects empty crashloops the pod on merge.
+
+```go
+	// Zitadel (#524 phase 2). All optional and unread unless ZitadelEnabled is
+	// set: GIP remains the live provider until the phase 6 cutover.
+	ZitadelEnabled             bool   `envconfig:"ZITADEL_ENABLED" default:"false"`
+	ZitadelIssuer              string `envconfig:"ZITADEL_ISSUER"`
+	ZitadelLoginClientToken    string `envconfig:"ZITADEL_LOGIN_CLIENT_TOKEN"`
+	ZitadelAdminProjectID      string `envconfig:"ZITADEL_ADMIN_PROJECT_ID"`
+	ZitadelStorefrontProjectID string `envconfig:"ZITADEL_STOREFRONT_PROJECT_ID"`
+```
+
+- [ ] **Step 4: Wire it in `main.go`, following the existing optional-collaborator idiom**
+
+After the `autologinSvc` construction block (~line 243):
+
+```go
+	// Zitadel login client (#524 phase 2). Constructed only when explicitly
+	// enabled AND fully configured; nil otherwise, so no route it backs is
+	// mounted. Refusing to boot on partial config is deliberate: a
+	// half-configured login path that fails at request time is worse than a
+	// loud failure here.
+	var zitadelClient *zitadellogin.Client
+	switch {
+	case !cfg.ZitadelEnabled:
+		log.Info("zitadel login disabled; GIP remains the auth provider")
+	case cfg.ZitadelIssuer == "" || cfg.ZitadelLoginClientToken == "":
+		log.Error("zitadel: ZITADEL_ENABLED is set but ZITADEL_ISSUER or ZITADEL_LOGIN_CLIENT_TOKEN is empty")
+		panic("zitadel: enabled but not configured")
+	default:
+		zitadelClient = zitadellogin.New(cfg.ZitadelIssuer, cfg.ZitadelLoginClientToken, nil)
+		log.Info("zitadel login client enabled", "issuer", cfg.ZitadelIssuer)
+	}
+```
+
+`main()` returns nothing and uses `log.Error(...)` followed by `panic(err)` for every startup failure — there are 11 such sites and zero uses of `log.Fatal`/`os.Exit`. The snippet above matches that idiom; do not introduce a new one, and do not change `main`'s signature.
+
+Refusing to boot on partial config is deliberate and is the one place this phase is allowed to be fatal: the flag is opt-in, so a half-configured Zitadel path can only exist if someone set `ZITADEL_ENABLED` and stopped halfway. Failing loudly at boot beats failing per-request at login. This does not contradict the Global Constraint about crashloops — that constraint is about config being required when the feature is *off*, which it is not here.
+
+- [ ] **Step 5: Run the tests and build**
+
+Run: `cd services/auth-bff && go test ./pkg/config/ -v && go build ./...`
+Expected: PASS and clean build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/auth-bff/pkg/config/ services/auth-bff/cmd/server/main.go
+git commit -m "feat(auth-bff): wire the Zitadel login client behind a disabled flag"
+```
+
+---
+
+### Task 5: The login handler
+
+**Files:**
+- Create: `services/auth-bff/internal/zitadellogin/handler.go`
+- Test: `services/auth-bff/internal/zitadellogin/handler_test.go`
+- Modify: `services/auth-bff/cmd/server/main.go` (mount, conditional)
+
+**Interfaces:**
+- Consumes: Task 1's `completeLogin` (via an injected callback so this package does not import `autologin`), Tasks 2-3's `Client`.
+- Produces: `POST /auth/zitadel/login`, `POST /auth/zitadel/totp`.
+
+- [ ] **Step 1: Write the failing handler tests**
+
+```go
+func TestLoginCollapsesUnknownUserAndWrongPasswordIntoOneAnswer(t *testing.T) {
+	// A different status or message for "no such user" is an account-
+	// enumeration oracle. Both must look identical to the browser.
+	for _, body := range []string{
+		`{"code":3,"message":"Password is invalid (COMMAND-3M0fs)","details":[{"id":"COMMAND-3M0fs","failedAttempts":1}]}`,
+		`{"code":5,"message":"User could not be found (QUERY-Dfbg2)","details":[{"id":"QUERY-Dfbg2"}]}`,
+	} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(body, "QUERY") {
+				w.WriteHeader(http.StatusNotFound)
+			} else {
+				w.WriteHeader(http.StatusBadRequest)
+			}
+			w.Write([]byte(body))
+		}))
+		defer srv.Close()
+		h := NewHandler(New(srv.URL, "pat", srv.Client()), nil)
+		rec := httptest.NewRecorder()
+		h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/login",
+			strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x"}`)))
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", rec.Code)
+		}
+		if strings.Contains(rec.Body.String(), "failedAttempts") || strings.Contains(rec.Body.String(), "not be found") {
+			t.Fatalf("response leaks which half failed: %s", rec.Body.String())
+		}
+	}
+}
+```
+
+Add a second test asserting a `OutcomeFactorRequired` result returns a body carrying `totp_required` **and does not mint a session**.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd services/auth-bff && go test ./internal/zitadellogin/ -run TestLogin -v`
+Expected: FAIL — `NewHandler` does not exist.
+
+- [ ] **Step 3: Implement the handler**
+
+`NewHandler(c *Client, complete CompleteFunc) *Handler` where:
+
+```go
+// CompleteFunc runs the shared post-identity gauntlet — membership, MFA gate,
+// device and OTP checks, session mint. It is injected rather than imported so
+// this package stays a Zitadel client and knows nothing about autologin.
+type CompleteFunc func(ctx context.Context, w http.ResponseWriter, uid, email, tenantID string) error
+```
+
+`login` reads `{auth_request_id, login_name, password, workspace_tenant}`, calls `CreatePasswordSession`, then `CompleteIfSufficient`, then switches on `Result.Outcome`:
+- `OutcomeComplete` → call `complete(...)`, return `{"callback_url": …}`
+- `OutcomeFactorRequired` → return `{"totp_required": true, "session_id": …}` with **no session minted**
+- `OutcomeHandoff` → return `{"handoff_url": …}` pointing at the Aurora-branded hosted login
+
+Every credential error — `ErrBadCredentials`, `ErrUserNotFound` — maps to a single `401 {"error":"invalid_credentials"}`. Log which one actually happened; never return it.
+
+- [ ] **Step 4: Mount it conditionally in `main.go`**
+
+```go
+	if zitadelClient != nil {
+		zitadelHandler := zitadellogin.NewHandler(zitadelClient, autologinSvc.CompleteForProvider)
+		zitadelHandler.Register(v1)
+	}
+```
+
+This requires a small exported wrapper on `autologin.Service` around `completeLogin` — add it in this task, not Task 1.
+
+- [ ] **Step 5: Run the full service suite**
+
+Run: `cd services/auth-bff && go test ./... && go vet ./... && go build ./...`
+Expected: everything passes, including all pre-existing tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/auth-bff/
+git commit -m "feat(auth-bff): add the Zitadel login and TOTP endpoints behind the flag"
+```
+
+---
+
+### Task 6: Record the known gaps
+
+**Files:**
+- Create: `services/auth-bff/internal/zitadellogin/README.md`
+
+- [ ] **Step 1: Write it**
+
+Document, with the reasoning, not just the fact:
+
+1. **Zitadel does not enforce MFA for login clients.** Verified against the live instance by two repos. `sufficiency.go` is the enforcement; the archtests are what keep it that way.
+2. **`passwordChangeRequired` is not signalled** to a login client anywhere in this flow — create, read and finalize are byte-identical to a normal user's. Logins that should force a password change silently complete. Open upstream gap; file an issue.
+3. **Handoff targets the Aurora-branded hosted login** (`zitadel-login:v4.15.3-aurora.4`) for factors this page cannot collect: passkeys, U2F, SMS OTP, recovery codes.
+4. **The login-client PAT is instance-level.** It can mint a session for any user of any product on the shared instance. Zitadel offers no narrower role.
+5. **`forceMfaLocalOnly` is NOT folded into `forceMfa`**, unlike hms, because mark8ly has federated Google and Apple users to whom it must not apply.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add services/auth-bff/internal/zitadellogin/README.md
+git commit -m "docs(auth-bff): record the Zitadel login client's known gaps"
+```
+
+---
+
+## Phase 2 completion criteria
+
+- `AutoLogin`'s behaviour and tests are unchanged; both providers share `completeLogin`.
+- `go test ./...` passes in `services/auth-bff`, including three archtests pinning the finalize call site, the witness construction, and the ban on the unscoped policy in enforcement.
+- With `ZITADEL_ENABLED` unset the service boots exactly as today, mounts no Zitadel route, and logs that GIP remains the provider.
+- A password-only session under `forceMfa` returns `OutcomeFactorRequired` and never finalizes.
+- A federated user under `forceMfaLocalOnly` completes.
+
+## Not in this phase
+
+Frontend changes (phase 3), the `marketplace-api` verifier and the `tenant_id` claim (phase 4), `gipadmin` (phase 5), and the cutover itself including deleting `gipkey`, `usermfa` and both GIP verifiers (phase 6).

--- a/services/auth-bff/cmd/server/main.go
+++ b/services/auth-bff/cmd/server/main.go
@@ -259,8 +259,11 @@ func main() {
 		zitadelClient = zitadellogin.New(cfg.ZitadelIssuer, cfg.ZitadelLoginClientToken, nil)
 		log.Info("zitadel login client enabled", "issuer", cfg.ZitadelIssuer)
 	}
-	// Task 5 (wiring) will use zitadelClient to mount routes.
-	_ = zitadelClient
+	var zitadelHandler *zitadellogin.Handler
+	if zitadelClient != nil {
+		zitadelHandler = zitadellogin.NewHandler(zitadelClient, autologinSvc.CompleteForProvider).
+			WithHostedLoginBaseURL(cfg.ZitadelIssuer)
+	}
 
 	// ─── Session introspection + logout ────────────────────────────────
 	sessionHandler := session.NewHandler(sessions, fgaClient).
@@ -294,6 +297,9 @@ func main() {
 	adminHandoffHandler.Register(v1)
 	if otpHandler != nil {
 		otpHandler.Register(v1)
+	}
+	if zitadelHandler != nil {
+		zitadelHandler.Register(v1)
 	}
 
 	// /api/v1 surface consumed by marketplace-api's account handler,

--- a/services/auth-bff/cmd/server/main.go
+++ b/services/auth-bff/cmd/server/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/mark8ly/auth-bff/internal/session"
 	"github.com/mark8ly/auth-bff/internal/usermfa"
 	"github.com/mark8ly/auth-bff/internal/usersessions"
+	"github.com/mark8ly/auth-bff/internal/zitadellogin"
 	"github.com/mark8ly/auth-bff/pkg/config"
 	"github.com/mark8ly/auth-bff/pkg/httpserver"
 	"github.com/mark8ly/auth-bff/pkg/logger"
@@ -241,6 +242,25 @@ func main() {
 		Logger:   log,
 	})
 	autologinHandler := autologin.NewHandler(autologinSvc)
+
+	// ─── Zitadel login client (#524 phase 2) ────────────────────────────
+	// Constructed only when explicitly enabled AND fully configured; nil
+	// otherwise, so no route it backs is mounted. Refusing to boot on
+	// partial config is deliberate: a half-configured login path that fails
+	// at request time is worse than a loud failure here.
+	var zitadelClient *zitadellogin.Client
+	switch {
+	case !cfg.ZitadelEnabled:
+		log.Info("zitadel login disabled; GIP remains the auth provider")
+	case cfg.ZitadelIssuer == "" || cfg.ZitadelLoginClientToken == "":
+		log.Error("zitadel: ZITADEL_ENABLED is set but ZITADEL_ISSUER or ZITADEL_LOGIN_CLIENT_TOKEN is empty")
+		panic("zitadel: enabled but not configured")
+	default:
+		zitadelClient = zitadellogin.New(cfg.ZitadelIssuer, cfg.ZitadelLoginClientToken, nil)
+		log.Info("zitadel login client enabled", "issuer", cfg.ZitadelIssuer)
+	}
+	// Task 5 (wiring) will use zitadelClient to mount routes.
+	_ = zitadelClient
 
 	// ─── Session introspection + logout ────────────────────────────────
 	sessionHandler := session.NewHandler(sessions, fgaClient).

--- a/services/auth-bff/internal/autologin/service.go
+++ b/services/auth-bff/internal/autologin/service.go
@@ -175,6 +175,16 @@ var (
 	ErrChallengeSendFail = errors.New("autologin: failed to send sign-in code")
 )
 
+// Identity is the outcome of authenticating a user, independent of which
+// provider did it. Everything downstream of this type — membership, MFA,
+// device and OTP gating, session minting — is provider-agnostic and shared
+// between the GIP and Zitadel paths.
+type Identity struct {
+	UID      string
+	Email    string
+	TenantID string
+}
+
 // AutoLogin verifies the ID token, confirms tenant membership (with retry
 // to close the auth-bug #2 race window), mints a session cookie onto the
 // response, and returns the result.
@@ -194,8 +204,25 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 		}
 	}
 
+	return s.completeLogin(ctx, w, Identity{
+		UID:      tok.UID,
+		Email:    tok.Email,
+		TenantID: tok.TenantID,
+	}, req)
+}
+
+// completeLogin runs every gate that stands between a verified identity and a
+// minted session: FGA membership (with the outbox-race retry), the MFA gate,
+// new-device evaluation, the email-OTP step-up, then the session cookie,
+// registry row and audit event.
+//
+// It is deliberately provider-agnostic. A Zitadel login that has satisfied its
+// own credential and factor checks arrives here with the same Identity a
+// verified GIP token produces, and is subject to exactly the same gates — so
+// the two providers cannot drift apart in what they enforce after login.
+func (s *Service) completeLogin(ctx context.Context, w http.ResponseWriter, id Identity, req Request) (*Result, error) {
 	// Step 2: check FGA membership with retry. THE BUG-FIX LOOP.
-	if err := s.checkMembershipWithRetry(ctx, tok.UID, req.WorkspaceTenant); err != nil {
+	if err := s.checkMembershipWithRetry(ctx, id.UID, req.WorkspaceTenant); err != nil {
 		return nil, err
 	}
 
@@ -206,22 +233,22 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 	// the GIP token, and flag MFARequired on the result so the handler
 	// can respond with the right HTTP shape.
 	if s.mfa != nil {
-		enabled, err := s.mfa.IsEnabled(ctx, tok.UID)
+		enabled, err := s.mfa.IsEnabled(ctx, id.UID)
 		if err != nil && s.logger != nil {
 			s.logger.Warn("autologin: mfa status check failed — treating as disabled",
-				"err", err, "user_id", tok.UID)
+				"err", err, "user_id", id.UID)
 		}
 		if enabled {
 			if err := s.sessions.MintPending(w, session.Pending{
-				UID:      tok.UID,
-				Email:    tok.Email,
+				UID:      id.UID,
+				Email:    id.Email,
 				TenantID: req.WorkspaceTenant,
 			}); err != nil {
 				return nil, fmt.Errorf("%w: %w", ErrSessionMintFail, err)
 			}
 			return &Result{
-				UID:         tok.UID,
-				Email:       tok.Email,
+				UID:         id.UID,
+				Email:       id.Email,
 				TenantID:    req.WorkspaceTenant,
 				MFARequired: true,
 			}, nil
@@ -243,8 +270,8 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 	newDevice := false
 	if s.devices != nil {
 		isNew, err := s.devices.Evaluate(ctx, deviceguard.Login{
-			UserID:      tok.UID,
-			Email:       tok.Email,
+			UserID:      id.UID,
+			Email:       id.Email,
 			Fingerprint: fingerprint,
 			Device:      device,
 			IPAddress:   req.IPAddress,
@@ -252,7 +279,7 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 			At:          time.Now().UTC(),
 		})
 		if err != nil && s.logger != nil {
-			s.logger.Warn("deviceguard: evaluate failed", "err", err, "user_id", tok.UID)
+			s.logger.Warn("deviceguard: evaluate failed", "err", err, "user_id", id.UID)
 		}
 		newDevice = isNew
 	}
@@ -261,16 +288,16 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 	// email before it gets a session. This is what makes signing in on a
 	// second device safe rather than merely possible.
 	if newDevice && s.emailOTP != nil {
-		if err := s.emailOTP.IssueChallenge(ctx, tok.Email, req.IPAddress); err != nil {
+		if err := s.emailOTP.IssueChallenge(ctx, id.Email, req.IPAddress); err != nil {
 			if s.logger != nil {
 				s.logger.Error("autologin: challenge send failed",
-					"err", err, "user_id", tok.UID, "tenant_id", req.WorkspaceTenant)
+					"err", err, "user_id", id.UID, "tenant_id", req.WorkspaceTenant)
 			}
 			return nil, fmt.Errorf("%w: %w", ErrChallengeSendFail, err)
 		}
 		if err := s.sessions.MintPending(w, session.Pending{
-			UID:         tok.UID,
-			Email:       tok.Email,
+			UID:         id.UID,
+			Email:       id.Email,
 			TenantID:    req.WorkspaceTenant,
 			Fingerprint: fingerprint,
 			Device:      device,
@@ -279,8 +306,8 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 			return nil, fmt.Errorf("%w: %w", ErrSessionMintFail, err)
 		}
 		return &Result{
-			UID:              tok.UID,
-			Email:            tok.Email,
+			UID:              id.UID,
+			Email:            id.Email,
 			TenantID:         req.WorkspaceTenant,
 			EmailOTPRequired: true,
 		}, nil
@@ -288,8 +315,8 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 
 	// Step 3: mint the session cookie.
 	if err := s.sessions.Mint(w, session.Session{
-		UID:      tok.UID,
-		Email:    tok.Email,
+		UID:      id.UID,
+		Email:    id.Email,
 		TenantID: req.WorkspaceTenant,
 	}); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrSessionMintFail, err)
@@ -300,14 +327,14 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 	// login — the user is already authenticated and the cookie is set.
 	if s.registry != nil {
 		if _, err := s.registry.Create(ctx, usersessions.CreateParams{
-			UserID:      tok.UID,
+			UserID:      id.UID,
 			TenantID:    req.WorkspaceTenant,
 			Device:      device,
 			IPAddress:   req.IPAddress,
 			UserAgent:   req.UserAgent,
 			Fingerprint: fingerprint,
 		}); err != nil && s.logger != nil {
-			s.logger.Warn("usersessions: create failed", "err", err, "user_id", tok.UID)
+			s.logger.Warn("usersessions: create failed", "err", err, "user_id", id.UID)
 		}
 	}
 
@@ -318,18 +345,18 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 		TenantID:     req.WorkspaceTenant,
 		Action:       "user.signed_in",
 		ResourceType: "user",
-		ResourceID:   tok.UID,
+		ResourceID:   id.UID,
 		ActorType:    "user",
-		ActorUserID:  tok.UID,
-		ActorEmail:   tok.Email,
+		ActorUserID:  id.UID,
+		ActorEmail:   id.Email,
 		IPAddress:    req.IPAddress,
 		UserAgent:    req.UserAgent,
 		Metadata:     map[string]any{"device": req.Device, "method": "auto_login"},
 	})
 
 	return &Result{
-		UID:      tok.UID,
-		Email:    tok.Email,
+		UID:      id.UID,
+		Email:    id.Email,
 		TenantID: req.WorkspaceTenant,
 	}, nil
 }

--- a/services/auth-bff/internal/autologin/service.go
+++ b/services/auth-bff/internal/autologin/service.go
@@ -225,8 +225,8 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 // GIP path. Passing these empty is not an option: deviceguard fingerprints
 // the user agent, and Fingerprint("") is a constant every user would share —
 // silently collapsing new-device detection for every Zitadel login.
-func (s *Service) CompleteForProvider(ctx context.Context, w http.ResponseWriter, lc zitadellogin.LoginContext) error {
-	_, err := s.completeLogin(ctx, w, Identity{
+func (s *Service) CompleteForProvider(ctx context.Context, w http.ResponseWriter, lc zitadellogin.LoginContext) (zitadellogin.CompleteResult, error) {
+	res, err := s.completeLogin(ctx, w, Identity{
 		UID:      lc.UID,
 		Email:    lc.Email,
 		TenantID: lc.TenantID,
@@ -237,7 +237,13 @@ func (s *Service) CompleteForProvider(ctx context.Context, w http.ResponseWriter
 		UserAgent:       lc.UserAgent,
 		Country:         lc.Country,
 	})
-	return err
+	if err != nil {
+		return zitadellogin.CompleteResult{}, err
+	}
+	return zitadellogin.CompleteResult{
+		MFARequired:      res.MFARequired,
+		EmailOTPRequired: res.EmailOTPRequired,
+	}, nil
 }
 
 // completeLogin runs every gate that stands between a verified identity and a

--- a/services/auth-bff/internal/autologin/service.go
+++ b/services/auth-bff/internal/autologin/service.go
@@ -184,6 +184,20 @@ type Identity struct {
 	UID      string
 	Email    string
 	TenantID string
+	// Provider labels the audit event's "method" field with who actually
+	// authenticated this login. Empty means GIP/AutoLogin's own default
+	// ("auto_login") applies; CompleteForProvider sets this explicitly so a
+	// Zitadel login is not misattributed to GIP in the audit trail.
+	Provider string
+}
+
+// auditMethod returns the audit event's "method" label for id, defaulting to
+// "auto_login" (the GIP path's historical value) when no provider is set.
+func auditMethod(id Identity) string {
+	if id.Provider == "" {
+		return "auto_login"
+	}
+	return id.Provider
 }
 
 // AutoLogin verifies the ID token, confirms tenant membership (with retry
@@ -230,6 +244,7 @@ func (s *Service) CompleteForProvider(ctx context.Context, w http.ResponseWriter
 		UID:      lc.UID,
 		Email:    lc.Email,
 		TenantID: lc.TenantID,
+		Provider: "zitadel",
 	}, Request{
 		WorkspaceTenant: lc.TenantID,
 		Device:          lc.Device,
@@ -386,7 +401,7 @@ func (s *Service) completeLogin(ctx context.Context, w http.ResponseWriter, id I
 		ActorEmail:   id.Email,
 		IPAddress:    req.IPAddress,
 		UserAgent:    req.UserAgent,
-		Metadata:     map[string]any{"device": req.Device, "method": "auto_login"},
+		Metadata:     map[string]any{"device": req.Device, "method": auditMethod(id)},
 	})
 
 	return &Result{

--- a/services/auth-bff/internal/autologin/service.go
+++ b/services/auth-bff/internal/autologin/service.go
@@ -211,6 +211,27 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 	}, req)
 }
 
+// CompleteForProvider is the exported entry point for a provider other than
+// GIP — currently Zitadel — that has already established a verified identity
+// by its own means (password + sufficiency checks) and just needs to run the
+// shared gauntlet: FGA membership, the MFA gate, deviceguard, the email-OTP
+// step-up, session minting.
+//
+// It is a thin wrapper around completeLogin so that gauntlet has exactly one
+// implementation regardless of which provider authenticated the user. It
+// takes only the fields a provider-agnostic caller can supply — device,
+// IP and user-agent metadata are unavailable to a Zitadel-authenticated
+// request through this path and are left zero, same as an empty Request
+// field would leave them for AutoLogin.
+func (s *Service) CompleteForProvider(ctx context.Context, w http.ResponseWriter, uid, email, tenantID string) error {
+	_, err := s.completeLogin(ctx, w, Identity{
+		UID:      uid,
+		Email:    email,
+		TenantID: tenantID,
+	}, Request{WorkspaceTenant: tenantID})
+	return err
+}
+
 // completeLogin runs every gate that stands between a verified identity and a
 // minted session: FGA membership (with the outbox-race retry), the MFA gate,
 // new-device evaluation, the email-OTP step-up, then the session cookie,

--- a/services/auth-bff/internal/autologin/service.go
+++ b/services/auth-bff/internal/autologin/service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mark8ly/auth-bff/internal/gip"
 	"github.com/mark8ly/auth-bff/internal/session"
 	"github.com/mark8ly/auth-bff/internal/usersessions"
+	"github.com/mark8ly/auth-bff/internal/zitadellogin"
 )
 
 // MFAStatusChecker is the narrow interface autologin needs from the
@@ -218,17 +219,24 @@ func (s *Service) AutoLogin(ctx context.Context, w http.ResponseWriter, req Requ
 // step-up, session minting.
 //
 // It is a thin wrapper around completeLogin so that gauntlet has exactly one
-// implementation regardless of which provider authenticated the user. It
-// takes only the fields a provider-agnostic caller can supply — device,
-// IP and user-agent metadata are unavailable to a Zitadel-authenticated
-// request through this path and are left zero, same as an empty Request
-// field would leave them for AutoLogin.
-func (s *Service) CompleteForProvider(ctx context.Context, w http.ResponseWriter, uid, email, tenantID string) error {
+// implementation regardless of which provider authenticated the user, and it
+// maps zitadellogin.LoginContext onto Request field-for-field so UserAgent,
+// IPAddress, Device and Country reach completeLogin exactly as they do on the
+// GIP path. Passing these empty is not an option: deviceguard fingerprints
+// the user agent, and Fingerprint("") is a constant every user would share —
+// silently collapsing new-device detection for every Zitadel login.
+func (s *Service) CompleteForProvider(ctx context.Context, w http.ResponseWriter, lc zitadellogin.LoginContext) error {
 	_, err := s.completeLogin(ctx, w, Identity{
-		UID:      uid,
-		Email:    email,
-		TenantID: tenantID,
-	}, Request{WorkspaceTenant: tenantID})
+		UID:      lc.UID,
+		Email:    lc.Email,
+		TenantID: lc.TenantID,
+	}, Request{
+		WorkspaceTenant: lc.TenantID,
+		Device:          lc.Device,
+		IPAddress:       lc.IPAddress,
+		UserAgent:       lc.UserAgent,
+		Country:         lc.Country,
+	})
 	return err
 }
 

--- a/services/auth-bff/internal/autologin/service_test.go
+++ b/services/auth-bff/internal/autologin/service_test.go
@@ -369,7 +369,7 @@ func TestCompleteForProvider_RunsTheSameGauntletAsCompleteLogin(t *testing.T) {
 	svc := newTestService(t, gipFake, fgaFake, fastPolicy)
 
 	rec := httptest.NewRecorder()
-	err := svc.CompleteForProvider(context.Background(), rec, zitadellogin.LoginContext{
+	_, err := svc.CompleteForProvider(context.Background(), rec, zitadellogin.LoginContext{
 		UID:       "user-z1",
 		Email:     "z@e.com",
 		TenantID:  "tenant-uuid-1",
@@ -393,7 +393,7 @@ func TestCompleteForProvider_PropagatesMembershipFailure(t *testing.T) {
 	svc := newTestService(t, gipFake, fgaFake, fastPolicy)
 
 	rec := httptest.NewRecorder()
-	err := svc.CompleteForProvider(context.Background(), rec, zitadellogin.LoginContext{
+	_, err := svc.CompleteForProvider(context.Background(), rec, zitadellogin.LoginContext{
 		UID:      "user-z2",
 		Email:    "z2@e.com",
 		TenantID: "tenant-uuid-1",

--- a/services/auth-bff/internal/autologin/service_test.go
+++ b/services/auth-bff/internal/autologin/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mark8ly/auth-bff/internal/authz"
 	"github.com/mark8ly/auth-bff/internal/gip"
 	"github.com/mark8ly/auth-bff/internal/session"
+	"github.com/mark8ly/auth-bff/internal/zitadellogin"
 )
 
 const testKey = "0123456789abcdef0123456789abcdef" // 32 bytes for AES-256
@@ -368,7 +369,15 @@ func TestCompleteForProvider_RunsTheSameGauntletAsCompleteLogin(t *testing.T) {
 	svc := newTestService(t, gipFake, fgaFake, fastPolicy)
 
 	rec := httptest.NewRecorder()
-	err := svc.CompleteForProvider(context.Background(), rec, "user-z1", "z@e.com", "tenant-uuid-1")
+	err := svc.CompleteForProvider(context.Background(), rec, zitadellogin.LoginContext{
+		UID:       "user-z1",
+		Email:     "z@e.com",
+		TenantID:  "tenant-uuid-1",
+		UserAgent: "ZitadelTestAgent/1.0",
+		IPAddress: "203.0.113.7",
+		Device:    "Browser",
+		Country:   "IN",
+	})
 	if err != nil {
 		t.Fatalf("CompleteForProvider: %v", err)
 	}
@@ -384,7 +393,11 @@ func TestCompleteForProvider_PropagatesMembershipFailure(t *testing.T) {
 	svc := newTestService(t, gipFake, fgaFake, fastPolicy)
 
 	rec := httptest.NewRecorder()
-	err := svc.CompleteForProvider(context.Background(), rec, "user-z2", "z2@e.com", "tenant-uuid-1")
+	err := svc.CompleteForProvider(context.Background(), rec, zitadellogin.LoginContext{
+		UID:      "user-z2",
+		Email:    "z2@e.com",
+		TenantID: "tenant-uuid-1",
+	})
 	if !errors.Is(err, ErrNotMember) {
 		t.Fatalf("err = %v, want ErrNotMember", err)
 	}

--- a/services/auth-bff/internal/autologin/service_test.go
+++ b/services/auth-bff/internal/autologin/service_test.go
@@ -359,3 +359,33 @@ func TestCompleteLogin_RunsTheSameGauntletAsAutoLogin(t *testing.T) {
 		t.Fatal("AutoLogin minted no cookie")
 	}
 }
+
+func TestCompleteForProvider_RunsTheSameGauntletAsCompleteLogin(t *testing.T) {
+	gipFake := gip.NewFakeVerifier()
+	fgaFake := authz.NewFake()
+	fgaFake.SetMembership("user-z1", "tenant-uuid-1")
+
+	svc := newTestService(t, gipFake, fgaFake, fastPolicy)
+
+	rec := httptest.NewRecorder()
+	err := svc.CompleteForProvider(context.Background(), rec, "user-z1", "z@e.com", "tenant-uuid-1")
+	if err != nil {
+		t.Fatalf("CompleteForProvider: %v", err)
+	}
+	if len(rec.Result().Cookies()) == 0 {
+		t.Fatal("CompleteForProvider minted no cookie")
+	}
+}
+
+func TestCompleteForProvider_PropagatesMembershipFailure(t *testing.T) {
+	gipFake := gip.NewFakeVerifier()
+	fgaFake := authz.NewFake() // no membership set
+
+	svc := newTestService(t, gipFake, fgaFake, fastPolicy)
+
+	rec := httptest.NewRecorder()
+	err := svc.CompleteForProvider(context.Background(), rec, "user-z2", "z2@e.com", "tenant-uuid-1")
+	if !errors.Is(err, ErrNotMember) {
+		t.Fatalf("err = %v, want ErrNotMember", err)
+	}
+}

--- a/services/auth-bff/internal/autologin/service_test.go
+++ b/services/auth-bff/internal/autologin/service_test.go
@@ -336,3 +336,26 @@ func TestAutoLogin_NilFGAClient_ReportsUnreachableNotPanic(t *testing.T) {
 		}
 	}
 }
+
+func TestCompleteLogin_RunsTheSameGauntletAsAutoLogin(t *testing.T) {
+	gipFake := gip.NewFakeVerifier()
+	gipFake.Add("good-token", gip.VerifiedToken{UID: "user-1", Email: "u@e.com", TenantID: "MP-Internal-test"})
+	fgaFake := authz.NewFake()
+	fgaFake.SetMembership("user-1", "tenant-uuid-1")
+
+	svc := newTestService(t, gipFake, fgaFake, fastPolicy)
+
+	viaAutoLogin := httptest.NewRecorder()
+	got, err := svc.AutoLogin(context.Background(), viaAutoLogin, Request{
+		IDToken: "good-token", ExpectedTenantID: "MP-Internal-test", WorkspaceTenant: "tenant-uuid-1",
+	})
+	if err != nil {
+		t.Fatalf("AutoLogin: %v", err)
+	}
+	if got.UID != "user-1" || got.TenantID != "tenant-uuid-1" {
+		t.Fatalf("result = %+v", got)
+	}
+	if len(viaAutoLogin.Result().Cookies()) == 0 {
+		t.Fatal("AutoLogin minted no cookie")
+	}
+}

--- a/services/auth-bff/internal/autologin/service_test.go
+++ b/services/auth-bff/internal/autologin/service_test.go
@@ -2,12 +2,15 @@ package autologin
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/mark8ly/auth-bff/internal/audit"
 	"github.com/mark8ly/auth-bff/internal/authz"
 	"github.com/mark8ly/auth-bff/internal/gip"
 	"github.com/mark8ly/auth-bff/internal/session"
@@ -400,5 +403,101 @@ func TestCompleteForProvider_PropagatesMembershipFailure(t *testing.T) {
 	})
 	if !errors.Is(err, ErrNotMember) {
 		t.Fatalf("err = %v, want ErrNotMember", err)
+	}
+}
+
+// TestCompleteForProviderLabelsTheAuditEventAsZitadel pins the fix for the
+// audit "method" field: every login used to record "auto_login", even a
+// Zitadel one, which misattributed the login method in the audit trail.
+// CompleteForProvider must now carry "zitadel" through, while the GIP path
+// (AutoLogin) keeps its historical "auto_login" label.
+func TestCompleteForProviderLabelsTheAuditEventAsZitadel(t *testing.T) {
+	events := make(chan audit.Event, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ev audit.Event
+		if err := json.NewDecoder(r.Body).Decode(&ev); err != nil {
+			t.Errorf("decode audit event: %v", err)
+		}
+		events <- ev
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	gipFake := gip.NewFakeVerifier()
+	fgaFake := authz.NewFake()
+	fgaFake.SetMembership("user-z3", "tenant-uuid-1")
+
+	sm, err := session.NewManager(session.Config{
+		CookieName: "m8_test", Domain: "localhost", Secure: false, EncryptKey: testKey,
+	})
+	if err != nil {
+		t.Fatalf("session manager: %v", err)
+	}
+	svc := NewService(Config{
+		GIP: gipFake, FGA: fgaFake, Sessions: sm, Policy: fastPolicy,
+		Audit: audit.New(srv.URL, "", nil),
+	})
+
+	rec := httptest.NewRecorder()
+	if _, err := svc.CompleteForProvider(context.Background(), rec, zitadellogin.LoginContext{
+		UID: "user-z3", Email: "z3@e.com", TenantID: "tenant-uuid-1",
+	}); err != nil {
+		t.Fatalf("CompleteForProvider: %v", err)
+	}
+
+	select {
+	case ev := <-events:
+		if got, _ := ev.Metadata["method"].(string); got != "zitadel" {
+			t.Fatalf("audit event metadata.method = %q, want %q", got, "zitadel")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the audit event")
+	}
+}
+
+// TestAutoLoginLabelsTheAuditEventAsAutoLogin proves the GIP path's audit
+// label is unchanged by the fix above.
+func TestAutoLoginLabelsTheAuditEventAsAutoLogin(t *testing.T) {
+	events := make(chan audit.Event, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ev audit.Event
+		if err := json.NewDecoder(r.Body).Decode(&ev); err != nil {
+			t.Errorf("decode audit event: %v", err)
+		}
+		events <- ev
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	gipFake := gip.NewFakeVerifier()
+	gipFake.Add("good-token", gip.VerifiedToken{UID: "user-g1", Email: "g@e.com", TenantID: "MP-Internal-test"})
+	fgaFake := authz.NewFake()
+	fgaFake.SetMembership("user-g1", "tenant-uuid-1")
+
+	sm, err := session.NewManager(session.Config{
+		CookieName: "m8_test", Domain: "localhost", Secure: false, EncryptKey: testKey,
+	})
+	if err != nil {
+		t.Fatalf("session manager: %v", err)
+	}
+	svc := NewService(Config{
+		GIP: gipFake, FGA: fgaFake, Sessions: sm, Policy: fastPolicy,
+		Audit: audit.New(srv.URL, "", nil),
+	})
+
+	rec := httptest.NewRecorder()
+	if _, err := svc.AutoLogin(context.Background(), rec, Request{
+		IDToken: "good-token", ExpectedTenantID: "MP-Internal-test", WorkspaceTenant: "tenant-uuid-1",
+	}); err != nil {
+		t.Fatalf("AutoLogin: %v", err)
+	}
+
+	select {
+	case ev := <-events:
+		if got, _ := ev.Metadata["method"].(string); got != "auto_login" {
+			t.Fatalf("audit event metadata.method = %q, want %q", got, "auto_login")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the audit event")
 	}
 }

--- a/services/auth-bff/internal/zitadellogin/README.md
+++ b/services/auth-bff/internal/zitadellogin/README.md
@@ -1,0 +1,129 @@
+# Zitadel Login Client
+
+This package implements Zitadel's v2 login-client HTTP API so auth-bff can host its own login page instead of redirecting to Zitadel's managed UI. It is a narrow, purpose-built client that speaks only the shapes observed against a live Zitadel v4.15.3 instance.
+
+## Known Gaps and Unusual Design Choices
+
+### 1. Zitadel Does Not Enforce MFA for Login Clients
+
+**The issue:** Under a `forceMfa: true` login policy, Zitadel's v2 API still issues an OIDC authorization code for a password-only session. It does not refuse the request, it does not signal "more factors required"—it succeeds silently. This has been verified against live v4.15.3 instances by two independent teams.
+
+**Why this matters:** A password-only login would normally violate an MFA policy. Zitadel's server makes no attempt to enforce this at the API boundary, which means this package **must** enforce it on the client side—or MFA gets silently bypassed.
+
+**How we prevent it:** The `sufficiency.go` file contains all MFA enforcement logic. Every path to finalize a session goes through a sufficiency decision in `CompleteIfSufficient` or `CompleteAfterFactor`, which checks the policy, compares it against what factors the user has verified, and either blocks the login (returning `OutcomeFactorRequired` or `OutcomeHandoff`) or permits it. The `finalize` function itself is unexported and requires a `sufficient` witness type that can only be constructed in `sufficiency.go`.
+
+This design makes "call finalize without a decision" a compile error. It does not stop *all* mistakes—see the blind spot below—but it makes the most obvious bypass (a direct finalize call) impossible.
+
+### 2. The Architecture Tests Have a Known Blind Spot
+
+Three architecture tests police the MFA enforcement boundary:
+
+- `TestFinalizeIsOnlyCalledFromSufficiency` — checks that no file other than `sufficiency.go` calls `finalize`
+- `TestSufficientWitnessIsOnlyConstructedInSufficiency` — checks that `sufficient{}` is constructed only in `sufficiency.go`
+- `TestSufficiencyNeverUsesTheUnscopedDisplayPolicy` — checks that `sufficiency.go` never calls `InstanceLoginPolicyForDisplay`
+
+**The blind spot:** These tests check *which file* performs an action, not *how the decision was reached*. They verify file-level facts via string search; they do not perform semantic analysis.
+
+A future contributor could add a helper function inside `sufficiency.go` itself that constructs a `sufficient{}` witness and calls `finalize` while skipping the core sufficiency checks (`mfaRequired`, `classifyEnrolledMethods`, `SessionFactors`). Such a function might be named `bypassMFA`, `trustDeviceComplete`, or `adminFinalizeLogin`. It would pass all three tests because it lives in the right file and constructs the witness there—yet it would be exactly the MFA bypass the tests are meant to prevent.
+
+**Why we accepted this gap:** Closing it properly requires abstract-syntax-tree (AST) or call-graph analysis that can validate the *decision path*, not just the *file*. That was judged disproportionate to the risk. The package is small and changes rarely; the tests catch the obvious mistakes.
+
+**Mitigation—required action for future editors:** Any new code path to `finalize` is a decision about MFA enforcement, not a refactor. Before adding a new helper that leads to `finalize`, treat it as a policy decision: review it carefully, document why the shortcut is sound, and consider whether a new architecture-level test should pin the decision logic itself (not just the file). Treat any suggestion to add a "trusted device" mode, "admin bypass", or "skip MFA" feature as requiring design review and test changes, never as a code-only change.
+
+### 3. Password Change Requirement Is Not Signalled
+
+**The issue:** When a user logs in via a password that Zitadel has marked as requiring a change, the session create, session read, and finalize endpoints return byte-identical responses to a normal login. No flag, no error, no alert—just a successful login that actually requires a password change before the user can proceed.
+
+This is an upstream gap in Zitadel; it is not a bug in this package. However, it is load-bearing: if Zitadel later adds a `passwordChangeRequired` flag to the session or factors object, this package will silently ignore it until the handler is updated to check it and respond with `OutcomeHandoff` instead of `OutcomeComplete`.
+
+**Current behaviour:** A user whose password is expired or flagged for change will complete the login and receive an authorization code. The browser will exchange that code for an auth token and be logged in—with a password that should not have allowed it. This is a known gap in the hosted Zitadel UI as well and should be filed as an upstream issue if it hasn't been already.
+
+### 4. Handoff Targets the Aurora-Branded Hosted Login
+
+**The design:** When this login page cannot (or should not) complete a login on its own, it hands off to Zitadel's managed login UI. The factors this package can collect are:
+
+- PASSWORD (via plaintext submission to `/zitadel/login`)
+- TOTP (via 6-digit code submission to `/zitadel/totp`)
+
+Everything else is uncollectible: passkeys, U2F security keys, SMS OTP, recovery codes, SAML, OIDC federation (unless Zitadel adds those to this API). This login page is deliberately narrow.
+
+**Include-list design:** The `classifyEnrolledMethods` function maintains an include-list of known, collectible method types. If Zitadel's API returns a method type we have never seen before—`AUTHENTICATION_METHOD_TYPE_WEBAUTHN` or `AUTHENTICATION_METHOD_TYPE_SMS`, for example—the function treats it as uncollectible and triggers a handoff. An unknown method type fails closed to `OutcomeHandoff` rather than being silently skipped.
+
+**Hosted login URL:** The handoff target is built by `Handler.handoffURL` using `hostedLoginBaseURL`. It must point to the Aurora-branded v4.15.3+ Zitadel instance (the URL scheme is `/ui/v2/login/login?authRequestID=...`). If `hostedLoginBaseURL` is not configured, the handoff still succeeds but returns an empty `handoff_url`; the auth request itself is preserved and logged.
+
+### 5. The Login-Client PAT Is Instance-Level
+
+**The credential:** Every request in this package is authenticated with a Personal Access Token (PAT) that is instance-level in Zitadel. It can:
+
+- Check any user's password (via `CreatePasswordSession`)
+- Verify any user's TOTP code (via `VerifyTOTP`)
+- Read any user's enrolled authentication methods
+- Mint a session for any user of any product on the shared instance
+- Read login policies of any organization
+
+Zitadel offers no narrower role that still permits these operations. This is the most powerful credential auth-bff holds.
+
+**Handling the PAT:** The token is passed to `New` and stored in the `Client` struct. It is automatically added to every request's `Authorization: Bearer` header by the `do` method. **Never log the token.** When debugging, never print the client or the struct that holds it. When tests need to validate auth, assert on the header key, not the token value.
+
+### 6. `forceMfaLocalOnly` Is Not Folded Into `forceMfa`
+
+**The separation:** The `LoginPolicy` struct carries two boolean fields: `ForceMFA` and `ForceMFALocalOnly`. They are not combined with a logical OR; they are kept separate.
+
+- `ForceMFA`: Require MFA for all login methods (password, federated, etc.).
+- `ForceMFALocalOnly`: Require MFA for password/local users only. Do not require it for federated logins (Google, Apple, etc.).
+
+**Why this matters for mark8ly:** The mark8ly instance has federated Google and Apple identity providers. Some organizations want password users to use MFA but do not want to force it on Google/Apple federated users (who often have their own MFA via Google Account or Apple ID).
+
+**Comparison to hms:** The hms service (which uses Zitadel) folded these two fields into a single policy decision. That was safe for hms because hms has no federated IdPs—all users are local/password. For mark8ly, folding them would silently force MFA on federated logins, which violates the organization's intent.
+
+The `mfaRequired` function applies both policies correctly:
+
+```go
+if p.ForceMFA {
+    return true // MFA required for everyone
+}
+return p.ForceMFALocalOnly && !federated // MFA required for local users only
+```
+
+If `federated` is true and `ForceMFALocalOnly` is true, MFA is not required.
+
+### 7. LoginContext Carries Request-Scoped Metadata for a Reason
+
+**The purpose:** `LoginContext` is the handoff type between this package (Zitadel-specific) and the shared post-identity gauntlet (provider-agnostic). It carries:
+
+- `UID`, `Email`, `TenantID`: Identity facts
+- `UserAgent`, `IPAddress`, `Device`, `Country`: Client metadata
+
+The request-scoped fields exist because of a narrow near-miss during development.
+
+**The near-miss:** An earlier iteration passed only `UID`, `Email`, and `TenantID` to the gauntlet, leaving the client metadata empty. The shared code includes `deviceguard.Fingerprint("")`, which builds a device fingerprint from the user agent. Passing an empty string produces a constant—every Zitadel user would have the same fingerprint. This would have silently broken device-change detection: the first Zitadel login would be flagged as "new device", but every subsequent login from anywhere would look like the same familiar device.
+
+This bug would have shipped silently—no failing test, no error log—because `Fingerprint("")` is a valid input that returns a constant output.
+
+**The fix:** `LoginContext.UserAgent` must always be populated from `r.UserAgent()`. `IPAddress`, `Device`, and `Country` follow the same pattern that the existing `autologin` handler uses for GIP logins, ensuring the two providers see the same metadata.
+
+Anything added to this boundary must carry the request-scoped fields. Fields built from credential checks (user ID, email, tenant ID) can be populated after authentication; fields built from the HTTP request must be captured at the request boundary.
+
+### 8. Two Open Follow-Ups
+
+#### 8a. Missing End-to-End Coverage for Device Metadata
+
+Only `UserAgent` has a handler-level pinning test (checking that it flows into the response when certain conditions are met). The fields `IPAddress`, `Device`, and `Country` are not proven end-to-end from a real HTTP request. They are extracted and passed correctly by inspection, but a test that exercises a full login flow (or a fixture that mocks a real request) and verifies these fields reach the gauntlet would be prudent. This is low-risk because the code is small and the pattern is clear, but it closes a gap.
+
+#### 8b. Device Label Heuristic Is Duplicated
+
+The `deviceFromUA` function in this package is byte-identical to a function of the same name in `internal/autologin/handler.go`. Both extract a short device label (e.g. "iPhone", "Windows", "Browser") from a User-Agent header. The label is used only for display and audit log context; it never flows into security decisions. 
+
+Because the duplication is presentation-only and unlikely to evolve differently, it is low-severity. However, before either copy diverges—or before a third consumer adds a third copy—the function should be extracted to a shared package (e.g. `internal/useragent/`) with appropriate placement in the codebase hierarchy. When you refactor this, treat it as a pure consolidation: no behavior change, copy the comments, run all handler tests from both packages.
+
+---
+
+## Testing and Validation
+
+The three architecture tests (`TestFinalizeIsOnlyCalledFromSufficiency`, `TestSufficientWitnessIsOnlyConstructedInSufficiency`, `TestSufficiencyNeverUsesTheUnscopedDisplayPolicy`) are not unit tests in the traditional sense. They are code-inspection tests that verify file-level invariants. They catch the obvious mistakes but accept the blind spot described in section 2.
+
+When writing new tests or modifying `sufficiency.go`:
+
+1. Run `go test ./...` to ensure all tests pass, including the architecture tests.
+2. Any new path to `finalize` is a design decision. Document it and consider whether an architecture test should be updated to pin the decision logic itself.
+3. Do not treat a passing architecture test as proof that MFA enforcement is sound. Read the code.

--- a/services/auth-bff/internal/zitadellogin/README.md
+++ b/services/auth-bff/internal/zitadellogin/README.md
@@ -116,6 +116,31 @@ The `deviceFromUA` function in this package is byte-identical to a function of t
 
 Because the duplication is presentation-only and unlikely to evolve differently, it is low-severity. However, before either copy diverges—or before a third consumer adds a third copy—the function should be extracted to a shared package (e.g. `internal/useragent/`) with appropriate placement in the codebase hierarchy. When you refactor this, treat it as a pure consolidation: no behavior change, copy the comments, run all handler tests from both packages.
 
+### 9. `login_name` on `/zitadel/totp` Was Client-Supplied and Unverified (FIXED)
+
+**The issue:** `handler.go`'s `totp` read `login_name` from the request body and passed it straight through to `finishComplete`, which used it as `LoginContext.Email`. On `/zitadel/login` that string is verified, because `CreatePasswordSession` checks it against the password in the same call. On `/zitadel/totp` nothing checks it against anything — the password check already happened on the prior `/zitadel/login` call, against a session the caller submitting `/zitadel/totp` may not even own.
+
+**Consequence:** anyone with valid credentials of their own could POST an arbitrary `login_name` to `/zitadel/totp` and receive a session cookie carrying that address, an audit event attributing the login to it, and — when the login looked like a new device — a mark8ly-branded sign-in code mailed to an address of their choosing. UID and FGA membership were unaffected (this is spoofing and unsolicited mail, not privilege escalation), but it was still a real defect.
+
+**The fix:** `Client.UserEmail` (in `client.go`) reads a user's email directly from Zitadel via `GET /v2/users/{id}`, keyed off the user id `SessionFactors` already returns. `finishComplete` now resolves the email this way on BOTH `/zitadel/login` and `/zitadel/totp`, so there is one source of truth regardless of which step is finishing the login. `login_name` from the request body is used for exactly one thing anywhere in this package: the credential check inside `CreatePasswordSession`.
+
+### 10. `CompleteForProvider` Discarded the Step-Up State (FIXED)
+
+**The issue:** `autologin.Service.CompleteForProvider` called `s.completeLogin` and threw away its `*Result`, keeping only the error. When auth-bff's own MFA gate or the new-device email-OTP gate fired inside the gauntlet, `completeLogin` minted a *pending* cookie (not a real session) and returned a nil error — so `finishComplete` would answer `200 {"callback_url": ...}`, telling the browser the login had finished while a step-up was still outstanding. The GIP path (`autologin/handler.go`) surfaces `MFARequired`/`EmailOTPRequired` correctly; the Zitadel path had no way to.
+
+**The fix:** `CompleteFunc` now returns `(CompleteResult, error)` instead of just `error`. `CompleteResult{MFARequired, EmailOTPRequired}` propagates out of `completeLogin` through `CompleteForProvider` to the handler. `finishComplete` checks these flags before answering: if either is set, it responds with the same `{"data": {"uid", "email", "tenant_id", "mfa_required", "email_otp_required"}}` shape the GIP handler uses for the same two cases — never `callback_url` — so the two providers cannot silently diverge in what they tell the browser.
+
+---
+
+## Deliberately Deferred Items
+
+These are known gaps, tracked here so a future reader recognizes them as accepted rather than missed. None block this branch; all are candidates for the phase-3 rewrite of this package's client contract.
+
+1. **The Zitadel `session_token` rides in the `/zitadel/login` JSON response body** when a factor is still required (`OutcomeFactorRequired`). This is bounded today — using it still requires the instance-level login-client PAT, which only this service holds — but the response contract for this endpoint is being rewritten in phase 3, and the token should move into the encrypted pending cookie at that point instead of the JSON body.
+2. **All gauntlet errors collapse to `500 internal_error` on the Zitadel path.** `autologin.ErrNotMember` (should be 403), `ErrFGAUnreachable` (503), and email-OTP rate-limiting (429) are all indistinguishable from a generic internal error until phase 3 gives this package a client shaped to carry that distinction to the handler.
+3. **`Identity.TenantID` is written by every caller and read by none.** Both `AutoLogin` and `CompleteForProvider` populate it, but nothing downstream consumes the field from `Identity` — `completeLogin` uses `req.WorkspaceTenant` instead. Not a bug (WorkspaceTenant is the correct value to use), but a bit of dead weight worth resolving when this type is next touched.
+4. **`arch_test.go` looks up `sufficiency.go` by filename**, not by content or symbol. Renaming that file — for any reason, including an unrelated refactor — would make `TestSufficientWitnessIsOnlyConstructedInSufficiency` and `TestSufficiencyNeverUsesTheUnscopedDisplayPolicy` pass vacuously (nothing named `sufficiency.go` would exist, so the `for` loop / lookup finds nothing to check). Treat any rename of that file as requiring a matching update to `arch_test.go` in the same change.
+
 ---
 
 ## Testing and Validation

--- a/services/auth-bff/internal/zitadellogin/arch_test.go
+++ b/services/auth-bff/internal/zitadellogin/arch_test.go
@@ -1,0 +1,60 @@
+package zitadellogin
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func sourceFiles(t *testing.T) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		out[name] = string(b)
+	}
+	return out
+}
+
+func TestFinalizeIsOnlyCalledFromSufficiency(t *testing.T) {
+	for name, src := range sourceFiles(t) {
+		if name == "sufficiency.go" {
+			continue
+		}
+		if strings.Contains(src, "c.finalize(") || strings.Contains(src, ".finalize(ctx") {
+			t.Errorf("%s calls finalize; the OIDC finalize call must stay behind a sufficiency decision, "+
+				"because Zitadel does not enforce forceMfa for a login client", name)
+		}
+	}
+}
+
+func TestSufficientWitnessIsOnlyConstructedInSufficiency(t *testing.T) {
+	for name, src := range sourceFiles(t) {
+		if name == "sufficiency.go" {
+			continue
+		}
+		if strings.Contains(src, "sufficient{") {
+			t.Errorf("%s constructs the sufficient witness; only sufficiency.go may", name)
+		}
+	}
+}
+
+func TestSufficiencyNeverUsesTheUnscopedDisplayPolicy(t *testing.T) {
+	src := sourceFiles(t)["sufficiency.go"]
+	if strings.Contains(src, "InstanceLoginPolicyForDisplay") {
+		t.Error("sufficiency.go references InstanceLoginPolicyForDisplay; enforcement must read the " +
+			"user's own org policy via LoginPolicyForOrg, or a user in one org is judged by another org's policy")
+	}
+}

--- a/services/auth-bff/internal/zitadellogin/client.go
+++ b/services/auth-bff/internal/zitadellogin/client.go
@@ -265,6 +265,32 @@ func (c *Client) EnrolledMethodTypes(ctx context.Context, userID string) ([]stri
 	return wire.AuthMethodTypes, nil
 }
 
+// UserEmail fetches a user's email address by user id.
+//
+// This is the ONLY email the handler should trust for a Zitadel-authenticated
+// session: it comes from Zitadel's own record of who the session's factors
+// belong to, not from anything the caller typed into a request body. Reading
+// it here — rather than trusting a client-supplied login_name on the TOTP
+// step — is what makes a spoofed login_name on /zitadel/totp inert.
+func (c *Client) UserEmail(ctx context.Context, userID string) (string, error) {
+	var wire struct {
+		User struct {
+			Human *struct {
+				Email struct {
+					Email string `json:"email"`
+				} `json:"email"`
+			} `json:"human"`
+		} `json:"user"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/v2/users/"+url.PathEscape(userID), nil, &wire, ErrUserNotFound); err != nil {
+		return "", err
+	}
+	if wire.User.Human == nil {
+		return "", fmt.Errorf("zitadellogin: user has no human profile, cannot resolve email: %w", ErrUnavailable)
+	}
+	return wire.User.Human.Email.Email, nil
+}
+
 var mfaPolicyKeys = []string{"forceMfa", "forceMfaLocalOnly"}
 
 // policyAnchorKey proves a 200 really carried a login-policy object.

--- a/services/auth-bff/internal/zitadellogin/client.go
+++ b/services/auth-bff/internal/zitadellogin/client.go
@@ -1,0 +1,350 @@
+// Package zitadellogin speaks Zitadel's v2 login-client HTTP API so auth-bff
+// can host its own login page instead of redirecting to Zitadel's.
+//
+// Every JSON shape and error mapping here is pinned to what was OBSERVED
+// against a live Zitadel v4.15.3 instance, not to what the documentation says
+// the API should return. Three separate shapes in this API answer 200 or 201
+// while doing something other than what the caller assumes.
+//
+// This package makes NO decision about whether a session is adequate to
+// finalize a login — that is sufficiency.go's job, and Zitadel will happily
+// issue an authorization code for a password-only session even under a
+// forceMfa policy.
+package zitadellogin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	defaultTimeout      = 10 * time.Second
+	maxSuccessBodyBytes = 64 * 1024
+	maxErrorBodyBytes   = 4096
+)
+
+var (
+	ErrBadCredentials     = errors.New("zitadellogin: bad credentials")
+	ErrUserNotFound       = errors.New("zitadellogin: user not found")
+	ErrAuthRequestInvalid = errors.New("zitadellogin: auth request invalid")
+	ErrUnavailable        = errors.New("zitadellogin: zitadel unavailable")
+)
+
+type Client struct {
+	baseURL string
+	token   string
+	hc      *http.Client
+}
+
+// New builds a client. token is the login-client PAT: it authenticates every
+// call in this package, never the end-user session being established. It is
+// instance-level and can mint a session for any user of any product on the
+// shared instance — treat it as the most powerful credential this service
+// holds and never log it.
+func New(baseURL, token string, hc *http.Client) *Client {
+	if hc == nil {
+		hc = &http.Client{Timeout: defaultTimeout}
+	}
+	return &Client{baseURL: strings.TrimSuffix(baseURL, "/"), token: token, hc: hc}
+}
+
+// Session is a Zitadel session. Token is a bearer-equivalent secret for this
+// one session and must never be logged.
+type Session struct {
+	ID    string
+	Token string
+}
+
+// LoginPolicy carries the two MFA fields as SEPARATE values. They are not
+// folded together: forceMfaLocalOnly means "require MFA for local/password
+// users, not federated ones", and mark8ly has federated Google and Apple
+// users for whom that distinction is load-bearing.
+type LoginPolicy struct {
+	ForceMFA          bool
+	ForceMFALocalOnly bool
+}
+
+type Factors struct {
+	Password bool
+	TOTP     bool
+	UserID   string
+	OrgID    string
+}
+
+type AuthRequest struct {
+	ID string
+}
+
+// requestOptions accumulates per-request settings. The option type is
+// func(*requestOptions), NOT func(*http.Request), deliberately: an option that
+// could reach the raw request could set or overwrite any header — including
+// the Authorization header do sets from the PAT. This shape makes that class
+// of bug unrepresentable rather than something a reviewer must keep checking.
+type requestOptions struct {
+	orgID string
+}
+
+type requestOption func(*requestOptions)
+
+func withOrgID(orgID string) requestOption {
+	return func(ro *requestOptions) { ro.orgID = orgID }
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body, out any, notFound error, opts ...requestOption) error {
+	var rdr io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("zitadellogin: marshal %s %s: %w", method, path, err)
+		}
+		rdr = bytes.NewReader(buf)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, rdr)
+	if err != nil {
+		return fmt.Errorf("zitadellogin: build %s %s: %w", method, path, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	var ro requestOptions
+	for _, opt := range opts {
+		opt(&ro)
+	}
+	if ro.orgID != "" {
+		req.Header.Set("x-zitadel-orgid", ro.orgID)
+	}
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("zitadellogin: %s %s: %v: %w", method, path, err, ErrUnavailable)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		id := readZitadelErrorID(resp.Body)
+		switch {
+		case resp.StatusCode == http.StatusBadRequest:
+			return fmt.Errorf("zitadellogin: %s %s: %s: %w", method, path, id, ErrBadCredentials)
+		case resp.StatusCode == http.StatusNotFound:
+			return fmt.Errorf("zitadellogin: %s %s: %s: %w", method, path, id, notFound)
+		default:
+			return fmt.Errorf("zitadellogin: %s %s: status %d: %s: %w", method, path, resp.StatusCode, id, ErrUnavailable)
+		}
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxSuccessBodyBytes)).Decode(out); err != nil {
+		return fmt.Errorf("zitadellogin: decode %s %s: %v: %w", method, path, err, ErrUnavailable)
+	}
+	return nil
+}
+
+// readZitadelErrorID extracts ONLY details[0].id (e.g. "COMMAND-3M0fs"). The
+// raw error body is never surfaced, because that is exactly where Zitadel puts
+// failedAttempts — a counter that must not reach a caller or a log line.
+func readZitadelErrorID(r io.Reader) string {
+	var wire struct {
+		Details []struct {
+			ID string `json:"id"`
+		} `json:"details"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r, maxErrorBodyBytes)).Decode(&wire); err != nil {
+		return "unknown"
+	}
+	if len(wire.Details) == 0 || wire.Details[0].ID == "" {
+		return "unknown"
+	}
+	return wire.Details[0].ID
+}
+
+func (c *Client) AuthRequest(ctx context.Context, id string) (AuthRequest, error) {
+	var wire struct {
+		AuthRequest struct {
+			ID string `json:"id"`
+		} `json:"authRequest"`
+	}
+	err := c.do(ctx, http.MethodGet, "/v2/oidc/auth_requests/"+url.PathEscape(id), nil, &wire, ErrAuthRequestInvalid)
+	if err != nil {
+		return AuthRequest{}, err
+	}
+	return AuthRequest{ID: wire.AuthRequest.ID}, nil
+}
+
+// CreatePasswordSession checks the login name and password in ONE call, so a
+// wrong username and a wrong password take the same code path and the same
+// time. ErrUserNotFound and ErrBadCredentials stay distinct here for logging;
+// collapsing them into one user-facing answer is the handler's job.
+func (c *Client) CreatePasswordSession(ctx context.Context, loginName, password string) (Session, error) {
+	body := map[string]any{
+		"checks": map[string]any{
+			"user":     map[string]any{"loginName": loginName},
+			"password": map[string]any{"password": password},
+		},
+	}
+	var wire struct {
+		SessionID    string `json:"sessionId"`
+		SessionToken string `json:"sessionToken"`
+	}
+	if err := c.do(ctx, http.MethodPost, "/v2/sessions", body, &wire, ErrUserNotFound); err != nil {
+		return Session{}, err
+	}
+	return Session{ID: wire.SessionID, Token: wire.SessionToken}, nil
+}
+
+// VerifyTOTP submits a TOTP code.
+//
+// Two facts, both observed and both easy to get wrong:
+//
+//  1. The method is PATCH. POST to a session id returns 405.
+//  2. The session token ROTATES on every check. The response carries a NEW
+//     sessionToken, and finalize needs the newest one. Returning the input
+//     session keeps the stale token and makes finalize fail AFTER a correct
+//     code, which the user reads as "my code was wrong".
+func (c *Client) VerifyTOTP(ctx context.Context, s Session, code string) (Session, error) {
+	body := map[string]any{
+		"sessionToken": s.Token,
+		"checks":       map[string]any{"totp": map[string]any{"code": code}},
+	}
+	var wire struct {
+		SessionToken string `json:"sessionToken"`
+	}
+	if err := c.do(ctx, http.MethodPatch, "/v2/sessions/"+url.PathEscape(s.ID), body, &wire, ErrBadCredentials); err != nil {
+		return Session{}, err
+	}
+	return Session{ID: s.ID, Token: wire.SessionToken}, nil
+}
+
+// SessionFactors re-reads what Zitadel believes was verified. The create
+// response omits the factors object entirely, so it cannot be trusted to say
+// what was checked — this is the only honest source.
+func (c *Client) SessionFactors(ctx context.Context, sessionID string) (Factors, error) {
+	var wire struct {
+		Session struct {
+			Factors struct {
+				User *struct {
+					ID             string `json:"id"`
+					OrganizationID string `json:"organizationId"`
+				} `json:"user"`
+				Password *struct {
+					VerifiedAt string `json:"verifiedAt"`
+				} `json:"password"`
+				TOTP *struct {
+					VerifiedAt string `json:"verifiedAt"`
+				} `json:"totp"`
+			} `json:"factors"`
+		} `json:"session"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/v2/sessions/"+url.PathEscape(sessionID), nil, &wire, ErrUnavailable); err != nil {
+		return Factors{}, err
+	}
+	f := wire.Session.Factors
+	out := Factors{Password: f.Password != nil, TOTP: f.TOTP != nil}
+	if f.User != nil {
+		out.UserID, out.OrgID = f.User.ID, f.User.OrganizationID
+	}
+	return out, nil
+}
+
+// EnrolledMethodTypes lists a user's registered authentication methods.
+func (c *Client) EnrolledMethodTypes(ctx context.Context, userID string) ([]string, error) {
+	var wire struct {
+		AuthMethodTypes []string `json:"authMethodTypes"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/v2/users/"+url.PathEscape(userID)+"/authentication_methods", nil, &wire, ErrUnavailable); err != nil {
+		return nil, err
+	}
+	return wire.AuthMethodTypes, nil
+}
+
+var mfaPolicyKeys = []string{"forceMfa", "forceMfaLocalOnly"}
+
+// policyAnchorKey proves a 200 really carried a login-policy object.
+//
+// It cannot be one of the MFA booleans: protojson elides zero-value fields, so
+// a healthy org that does not force MFA sends no forceMfa key at all. Treating
+// that absence as "unrecognized" handed every ordinary login to the hosted UI
+// in hms. passwordCheckLifetime is a message-typed field observed present on
+// every real response.
+const policyAnchorKey = "passwordCheckLifetime"
+
+func (c *Client) loginPolicy(ctx context.Context, opts ...requestOption) (LoginPolicy, error) {
+	var wire struct {
+		Policy map[string]any `json:"policy"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/management/v1/policies/login", nil, &wire, ErrUnavailable, opts...); err != nil {
+		return LoginPolicy{}, err
+	}
+	if _, ok := wire.Policy[policyAnchorKey]; !ok {
+		return LoginPolicy{}, fmt.Errorf("zitadellogin: 200 without a recognizable policy object: %w", ErrUnavailable)
+	}
+	for _, key := range mfaPolicyKeys {
+		if err := refuseIfKeyRenamedOrRecased(wire.Policy, key); err != nil {
+			return LoginPolicy{}, err
+		}
+	}
+	forceMFA, err := readMFABool(wire.Policy, "forceMfa")
+	if err != nil {
+		return LoginPolicy{}, err
+	}
+	localOnly, err := readMFABool(wire.Policy, "forceMfaLocalOnly")
+	if err != nil {
+		return LoginPolicy{}, err
+	}
+	return LoginPolicy{ForceMFA: forceMFA, ForceMFALocalOnly: localOnly}, nil
+}
+
+func normalizePolicyKey(key string) string {
+	return strings.ReplaceAll(strings.ToLower(key), "_", "")
+}
+
+// refuseIfKeyRenamedOrRecased fails closed when the API renames or re-cases an
+// MFA field. Without it, force_mfa or ForceMFA would decode as merely absent,
+// therefore false — a silent fail-open on the one field that matters most.
+func refuseIfKeyRenamedOrRecased(policy map[string]any, wantKey string) error {
+	want := normalizePolicyKey(wantKey)
+	for k := range policy {
+		if k != wantKey && normalizePolicyKey(k) == want {
+			return fmt.Errorf("zitadellogin: policy key %q looks like a renamed %q: %w", k, wantKey, ErrUnavailable)
+		}
+	}
+	return nil
+}
+
+func readMFABool(policy map[string]any, key string) (bool, error) {
+	v, ok := policy[key]
+	if !ok {
+		return false, nil // elided zero value: genuinely false
+	}
+	b, ok := v.(bool)
+	if !ok {
+		return false, fmt.Errorf("zitadellogin: policy.%s is %T, not a bool: %w", key, v, ErrUnavailable)
+	}
+	return b, nil
+}
+
+// LoginPolicyForOrg reads the policy of the org the user actually belongs to.
+// It refuses an empty org id rather than falling back to an unscoped read: an
+// unscoped read judges a user in one org by a different org's policy, which is
+// a real, shipped MFA bypass (hms #913).
+func (c *Client) LoginPolicyForOrg(ctx context.Context, orgID string) (LoginPolicy, error) {
+	if orgID == "" {
+		return LoginPolicy{}, fmt.Errorf("zitadellogin: LoginPolicyForOrg with an empty org id, refusing rather than reading unscoped: %w", ErrUnavailable)
+	}
+	return c.loginPolicy(ctx, withOrgID(orgID))
+}
+
+// InstanceLoginPolicyForDisplay reads the unscoped instance policy. It is for
+// display before a user is known and MUST NOT be used for enforcement; an
+// archtest forbids sufficiency.go from referencing it.
+func (c *Client) InstanceLoginPolicyForDisplay(ctx context.Context) (LoginPolicy, error) {
+	return c.loginPolicy(ctx)
+}

--- a/services/auth-bff/internal/zitadellogin/client_test.go
+++ b/services/auth-bff/internal/zitadellogin/client_test.go
@@ -1,0 +1,166 @@
+package zitadellogin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestClient(t *testing.T, h http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "test-pat", srv.Client())
+}
+
+func TestCreatePasswordSessionReturnsSession(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v2/sessions" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-pat" {
+			t.Errorf("Authorization = %q", got)
+		}
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"sessionId":"389070697432875523","sessionToken":"tok-1"}`))
+	})
+	s, err := c.CreatePasswordSession(context.Background(), "a@b.test", "pw")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if s.ID != "389070697432875523" || s.Token != "tok-1" {
+		t.Fatalf("session = %+v", s)
+	}
+}
+
+func TestCreatePasswordSessionMapsWrongPasswordAndHidesAttemptCounter(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"code":3,"message":"Password is invalid (COMMAND-3M0fs)","details":[{"@type":"type.googleapis.com/zitadel.v1.CredentialsCheckError","id":"COMMAND-3M0fs","message":"Password is invalid","failedAttempts":1}]}`))
+	})
+	_, err := c.CreatePasswordSession(context.Background(), "a@b.test", "wrong")
+	if !errors.Is(err, ErrBadCredentials) {
+		t.Fatalf("err = %v, want ErrBadCredentials", err)
+	}
+	if strings.Contains(err.Error(), "failedAttempts") {
+		t.Errorf("error text leaks the attempt counter: %q", err.Error())
+	}
+}
+
+func TestVerifyTOTPUsesPatchAndReturnsTheRotatedToken(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("method = %s, want PATCH (POST returns 405 on this endpoint)", r.Method)
+		}
+		w.Write([]byte(`{"sessionToken":"tok-ROTATED"}`))
+	})
+	got, err := c.VerifyTOTP(context.Background(), Session{ID: "s1", Token: "tok-STALE"}, "123456")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got.Token != "tok-ROTATED" {
+		t.Fatalf("token = %q, want the rotated token from the response, not the input", got.Token)
+	}
+	if got.ID != "s1" {
+		t.Fatalf("id = %q", got.ID)
+	}
+}
+
+func TestLoginPolicyForOrgSetsTheOrgHeader(t *testing.T) {
+	var sawOrg string
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		sawOrg = r.Header.Get("x-zitadel-orgid")
+		w.Write([]byte(`{"policy":{"passwordCheckLifetime":"0s","forceMfa":true}}`))
+	})
+	p, err := c.LoginPolicyForOrg(context.Background(), "org-1")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if sawOrg != "org-1" {
+		t.Errorf("x-zitadel-orgid = %q", sawOrg)
+	}
+	if !p.ForceMFA {
+		t.Error("ForceMFA = false, want true")
+	}
+}
+
+func TestLoginPolicyForOrgRefusesAnEmptyOrgRatherThanReadingUnscoped(t *testing.T) {
+	called := false
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.Write([]byte(`{"policy":{"passwordCheckLifetime":"0s"}}`))
+	})
+	_, err := c.LoginPolicyForOrg(context.Background(), "")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", err)
+	}
+	if called {
+		t.Error("made an unscoped HTTP call; an empty org id must be refused before the request")
+	}
+}
+
+func TestLoginPolicyRejectsAResponseWithoutTheAnchorField(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"policy":{"someOtherThing":true}}`))
+	})
+	_, err := c.LoginPolicyForOrg(context.Background(), "org-1")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable for an unrecognizable policy object", err)
+	}
+}
+
+func TestLoginPolicyTreatsAbsentForceMfaAsFalseNotUnknown(t *testing.T) {
+	// protojson elides zero-value booleans, so a perfectly healthy org that
+	// does not force MFA sends no forceMfa key at all. Treating that as
+	// "unrecognized" handed every ordinary login to the hosted UI in hms.
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"policy":{"passwordCheckLifetime":"0s"}}`))
+	})
+	p, err := c.LoginPolicyForOrg(context.Background(), "org-1")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if p.ForceMFA || p.ForceMFALocalOnly {
+		t.Fatalf("policy = %+v, want both false", p)
+	}
+}
+
+func TestLoginPolicyReadsForceMfaLocalOnlySeparately(t *testing.T) {
+	// These are two distinct fields and mark8ly must keep them distinct: it
+	// has federated (Google/Apple) users, for whom forceMfaLocalOnly does NOT
+	// apply. Folding them together would force MFA on federated logins.
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"policy":{"passwordCheckLifetime":"0s","forceMfaLocalOnly":true}}`))
+	})
+	p, err := c.LoginPolicyForOrg(context.Background(), "org-1")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if p.ForceMFA {
+		t.Error("ForceMFA = true, want false — forceMfa was absent")
+	}
+	if !p.ForceMFALocalOnly {
+		t.Error("ForceMFALocalOnly = false, want true")
+	}
+}
+
+func TestLoginPolicyRefusesARenamedOrRecasedMfaKey(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"policy":{"passwordCheckLifetime":"0s","force_mfa":true}}`))
+	})
+	_, err := c.LoginPolicyForOrg(context.Background(), "org-1")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v; a renamed key must fail closed, not read as absent-therefore-false", err)
+	}
+}
+
+func TestTransportFailureMapsToUnavailable(t *testing.T) {
+	c := New("http://127.0.0.1:1", "pat", &http.Client{})
+	_, err := c.CreatePasswordSession(context.Background(), "a@b.test", "pw")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", err)
+	}
+}

--- a/services/auth-bff/internal/zitadellogin/client_test.go
+++ b/services/auth-bff/internal/zitadellogin/client_test.go
@@ -164,3 +164,56 @@ func TestTransportFailureMapsToUnavailable(t *testing.T) {
 		t.Fatalf("err = %v, want ErrUnavailable", err)
 	}
 }
+
+func TestUserEmailReadsTheHumanEmail(t *testing.T) {
+	var gotPath string
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Write([]byte(`{"user":{"human":{"email":{"email":"real-owner@mark8ly.com","isVerified":true}}}}`))
+	})
+	email, err := c.UserEmail(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if email != "real-owner@mark8ly.com" {
+		t.Fatalf("email = %q", email)
+	}
+	if gotPath != "/v2/users/u1" {
+		t.Fatalf("path = %q, want /v2/users/u1", gotPath)
+	}
+}
+
+func TestUserEmailEscapesTheUserID(t *testing.T) {
+	var gotPath string
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		w.Write([]byte(`{"user":{"human":{"email":{"email":"a@b.test"}}}}`))
+	})
+	if _, err := c.UserEmail(context.Background(), "u/1"); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if gotPath != "/v2/users/u%2F1" {
+		t.Fatalf("path = %q, want the id path-escaped", gotPath)
+	}
+}
+
+func TestUserEmailMapsNotFound(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"code":5,"message":"User could not be found (QUERY-Dfbg2)","details":[{"id":"QUERY-Dfbg2"}]}`))
+	})
+	_, err := c.UserEmail(context.Background(), "missing")
+	if !errors.Is(err, ErrUserNotFound) {
+		t.Fatalf("err = %v, want ErrUserNotFound", err)
+	}
+}
+
+func TestUserEmailRefusesAMachineUserWithNoHumanProfile(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"user":{"machine":{"name":"svc-account"}}}`))
+	})
+	_, err := c.UserEmail(context.Background(), "svc-1")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable for a user with no human.email", err)
+	}
+}

--- a/services/auth-bff/internal/zitadellogin/handler.go
+++ b/services/auth-bff/internal/zitadellogin/handler.go
@@ -41,11 +41,25 @@ type LoginContext struct {
 	Country   string
 }
 
+// CompleteResult is what CompleteFunc reports back about the shared
+// post-identity gauntlet, beyond a plain error. Without this, CompleteFunc
+// had no way to say "a step-up is still outstanding" — the handler would
+// answer 200 with a callback_url while the browser still owed an MFA code or
+// an email-OTP, telling it the login was finished when it was not.
+type CompleteResult struct {
+	// MFARequired is true when the gauntlet minted only a pending cookie
+	// pending a TOTP code via POST /auth/mfa-challenge.
+	MFARequired bool
+	// EmailOTPRequired is true when the gauntlet minted only a pending
+	// cookie pending a mailed code via POST /auth/otp/verify.
+	EmailOTPRequired bool
+}
+
 // CompleteFunc runs the shared post-identity gauntlet — FGA membership, the
 // MFA gate, deviceguard, the email-OTP step-up, session minting. It is
 // injected rather than imported so this package stays a Zitadel client and
 // knows nothing about autologin.
-type CompleteFunc func(ctx context.Context, w http.ResponseWriter, lc LoginContext) error
+type CompleteFunc func(ctx context.Context, w http.ResponseWriter, lc LoginContext) (CompleteResult, error)
 
 // Handler is the HTTP layer over Client: it owns request/response shapes and
 // the outcome switch, and defers every credential and sufficiency decision to
@@ -199,7 +213,7 @@ func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 	// Password login through this page is never a federated (Google/Apple)
 	// identity — those never present a password to us at all.
 	res, err := h.c.CompleteIfSufficient(ctx, req.AuthRequestID, sess, false)
-	h.respondOutcome(w, r, res, err, req.AuthRequestID, sess, req.LoginName, req.WorkspaceTenant)
+	h.respondOutcome(w, r, res, err, req.AuthRequestID, sess, req.WorkspaceTenant)
 }
 
 // totp reads {auth_request_id, login_name, session_id, session_token, code,
@@ -225,8 +239,15 @@ func (h *Handler) totp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// req.LoginName is NOT used from here on. On this step it is an
+	// unverified claim from the request body — the password check that
+	// verified login_name happened on the earlier /zitadel/login call, on a
+	// session this caller may not even own. finishComplete resolves the
+	// real subject's email from Zitadel via SessionFactors + UserEmail
+	// instead, so a caller cannot walk away with a session cookie, an audit
+	// event, or a mailed sign-in code addressed to an email of their choice.
 	res, err := h.c.CompleteAfterFactor(ctx, req.AuthRequestID, sess)
-	h.respondOutcome(w, r, res, err, req.AuthRequestID, sess, req.LoginName, req.WorkspaceTenant)
+	h.respondOutcome(w, r, res, err, req.AuthRequestID, sess, req.WorkspaceTenant)
 }
 
 // respondOutcome is shared by login and totp: both end at CompleteIfSufficient
@@ -238,7 +259,6 @@ func (h *Handler) respondOutcome(
 	resErr error,
 	authRequestID string,
 	sess Session,
-	loginName string,
 	workspaceTenant string,
 ) {
 	ctx := r.Context()
@@ -253,7 +273,7 @@ func (h *Handler) respondOutcome(
 			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
 			return
 		}
-		h.finishComplete(w, r, res, sess, loginName, workspaceTenant)
+		h.finishComplete(w, r, res, sess, workspaceTenant)
 
 	case OutcomeFactorRequired:
 		// No session minted here — this IS the MFA gate. Minting now would
@@ -286,15 +306,27 @@ func (h *Handler) respondOutcome(
 
 // finishComplete resolves the subject of the now-sufficient session and runs
 // the shared post-identity gauntlet via the injected CompleteFunc.
-func (h *Handler) finishComplete(w http.ResponseWriter, r *http.Request, res Result, sess Session, loginName, workspaceTenant string) {
+func (h *Handler) finishComplete(w http.ResponseWriter, r *http.Request, res Result, sess Session, workspaceTenant string) {
 	ctx := r.Context()
-	// Result carries no subject — re-read it. Zitadel's login_name is the
-	// only identifier this package has for "email"; mark8ly logs in by
-	// email, so the value the caller submitted to /zitadel/login is used
-	// as-is rather than guessed at again here.
+	// Result carries no subject — re-read it.
 	factors, err := h.c.SessionFactors(ctx, sess.ID)
 	if err != nil || factors.UserID == "" {
 		slog.ErrorContext(ctx, "zitadellogin: could not resolve session subject after a sufficient decision", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+		return
+	}
+
+	// The email MUST come from Zitadel's own record of this session's
+	// subject, never from a request body. login_name on /zitadel/login is
+	// verified because it is checked against the password in the same call;
+	// login_name on /zitadel/totp is NOT verified against anything — a
+	// caller who owns valid credentials of their own could submit any
+	// address there and, without this resolution, walk away with a session
+	// cookie, an audit event, and a new-device sign-in email addressed to a
+	// victim of their choosing.
+	email, err := h.c.UserEmail(ctx, factors.UserID)
+	if err != nil {
+		slog.ErrorContext(ctx, "zitadellogin: could not resolve the verified email for session subject", "err", err, "user_id", factors.UserID)
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
 		return
 	}
@@ -304,10 +336,30 @@ func (h *Handler) finishComplete(w http.ResponseWriter, r *http.Request, res Res
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
 		return
 	}
-	lc := h.loginContext(r, factors.UserID, loginName, workspaceTenant)
-	if err := h.complete(ctx, w, lc); err != nil {
+	lc := h.loginContext(r, factors.UserID, email, workspaceTenant)
+	cr, err := h.complete(ctx, w, lc)
+	if err != nil {
 		slog.ErrorContext(ctx, "zitadellogin: post-identity gauntlet failed", "err", err, "user_id", factors.UserID)
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+		return
+	}
+
+	// A step-up (MFA or email-OTP) is still outstanding: the gauntlet minted
+	// only a pending cookie, not a real session. Answering with callback_url
+	// here would tell the browser the login finished when it did not — the
+	// exact defect this branch exists to prevent. Mirror the shape
+	// autologin's own GIP handler uses for the same two cases so the two
+	// providers answer identically.
+	if cr.MFARequired || cr.EmailOTPRequired {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"data": map[string]any{
+				"uid":                factors.UserID,
+				"email":              email,
+				"tenant_id":          workspaceTenant,
+				"mfa_required":       cr.MFARequired,
+				"email_otp_required": cr.EmailOTPRequired,
+			},
+		})
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"callback_url": res.CallbackURL})

--- a/services/auth-bff/internal/zitadellogin/handler.go
+++ b/services/auth-bff/internal/zitadellogin/handler.go
@@ -1,0 +1,285 @@
+package zitadellogin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// maxRequestBodyBytes bounds request decoding, matching the defensive limits
+// already used for Zitadel's own responses in client.go.
+const maxRequestBodyBytes = 8 * 1024
+
+// CompleteFunc runs the shared post-identity gauntlet — FGA membership, the
+// MFA gate, deviceguard, the email-OTP step-up, session minting. It is
+// injected rather than imported so this package stays a Zitadel client and
+// knows nothing about autologin.
+type CompleteFunc func(ctx context.Context, w http.ResponseWriter, uid, email, tenantID string) error
+
+// Handler is the HTTP layer over Client: it owns request/response shapes and
+// the outcome switch, and defers every credential and sufficiency decision to
+// the client and sufficiency packages respectively.
+type Handler struct {
+	c        *Client
+	complete CompleteFunc
+
+	// hostedLoginBaseURL is the Zitadel instance's own login UI (the
+	// Aurora-branded hosted login), used ONLY as the OutcomeHandoff target
+	// for factors this page cannot collect (passkeys, U2F, SMS OTP,
+	// recovery codes). Optional: set via WithHostedLoginBaseURL. When
+	// unset, a handoff still answers 200 with an empty handoff_url and the
+	// auth_request_id, and logs a warning — the auth request itself is not
+	// lost, only the convenience redirect.
+	hostedLoginBaseURL string
+}
+
+// NewHandler constructs a Handler. complete may be nil in tests that never
+// exercise OutcomeComplete.
+func NewHandler(c *Client, complete CompleteFunc) *Handler {
+	return &Handler{c: c, complete: complete}
+}
+
+// WithHostedLoginBaseURL sets the Zitadel instance base URL used to build the
+// OutcomeHandoff redirect target. Mirrors the optional-config builder idiom
+// used elsewhere in this service (e.g. session.Handler.WithRegistry).
+func (h *Handler) WithHostedLoginBaseURL(baseURL string) *Handler {
+	h.hostedLoginBaseURL = strings.TrimSuffix(baseURL, "/")
+	return h
+}
+
+// Register mounts the Zitadel login routes onto the given gin.RouterGroup.
+// The handlers are plain net/http (gin.WrapF) rather than gin.HandlerFunc:
+// this package has no dependency on gin beyond mounting, and stays testable
+// with httptest alone.
+func (h *Handler) Register(r *gin.RouterGroup) {
+	r.POST("/zitadel/login", gin.WrapF(h.login))
+	r.POST("/zitadel/totp", gin.WrapF(h.totp))
+}
+
+type loginRequest struct {
+	AuthRequestID   string `json:"auth_request_id"`
+	LoginName       string `json:"login_name"`
+	Password        string `json:"password"`
+	WorkspaceTenant string `json:"workspace_tenant"`
+}
+
+type totpRequest struct {
+	AuthRequestID   string `json:"auth_request_id"`
+	LoginName       string `json:"login_name"`
+	SessionID       string `json:"session_id"`
+	SessionToken    string `json:"session_token"`
+	Code            string `json:"code"`
+	WorkspaceTenant string `json:"workspace_tenant"`
+}
+
+// login reads {auth_request_id, login_name, password, workspace_tenant},
+// creates a Zitadel password session, and asks sufficiency.go whether that
+// session may finalize.
+func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req loginRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		return
+	}
+	if req.AuthRequestID == "" || req.LoginName == "" || req.Password == "" || req.WorkspaceTenant == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		return
+	}
+
+	// A wrong username and a wrong password take the same code path in
+	// CreatePasswordSession and must take the same one here: a different
+	// answer for "no such user" is an account-enumeration oracle.
+	sess, err := h.c.CreatePasswordSession(ctx, req.LoginName, req.Password)
+	if err != nil {
+		h.respondSessionCreateError(ctx, w, err)
+		return
+	}
+
+	// Password login through this page is never a federated (Google/Apple)
+	// identity — those never present a password to us at all.
+	res, err := h.c.CompleteIfSufficient(ctx, req.AuthRequestID, sess, false)
+	h.respondOutcome(ctx, w, res, err, req.AuthRequestID, sess, req.LoginName, req.WorkspaceTenant)
+}
+
+// totp reads {auth_request_id, login_name, session_id, session_token, code,
+// workspace_tenant}, submits the TOTP code against the session opened by
+// login, and re-asks sufficiency.go whether the session may now finalize.
+func (h *Handler) totp(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req totpRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		return
+	}
+	if req.AuthRequestID == "" || req.LoginName == "" || req.SessionID == "" || req.SessionToken == "" ||
+		req.Code == "" || req.WorkspaceTenant == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		return
+	}
+
+	sess, err := h.c.VerifyTOTP(ctx, Session{ID: req.SessionID, Token: req.SessionToken}, req.Code)
+	if err != nil {
+		h.respondTOTPVerifyError(ctx, w, err)
+		return
+	}
+
+	res, err := h.c.CompleteAfterFactor(ctx, req.AuthRequestID, sess)
+	h.respondOutcome(ctx, w, res, err, req.AuthRequestID, sess, req.LoginName, req.WorkspaceTenant)
+}
+
+// respondOutcome is shared by login and totp: both end at CompleteIfSufficient
+// / CompleteAfterFactor and switch on the same three outcomes.
+func (h *Handler) respondOutcome(
+	ctx context.Context,
+	w http.ResponseWriter,
+	res Result,
+	resErr error,
+	authRequestID string,
+	sess Session,
+	loginName string,
+	workspaceTenant string,
+) {
+	switch res.Outcome {
+	case OutcomeComplete:
+		if resErr != nil {
+			// Not reachable per CompleteIfSufficient/CompleteAfterFactor's
+			// contract — OutcomeComplete is only ever returned with a nil
+			// error — but refuse to complete a login on an outcome/error
+			// mismatch rather than trust an incoherent result.
+			slog.ErrorContext(ctx, "zitadellogin: OutcomeComplete carried a non-nil error, refusing to complete", "err", resErr)
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+			return
+		}
+		h.finishComplete(ctx, w, res, sess, loginName, workspaceTenant)
+
+	case OutcomeFactorRequired:
+		// No session minted here — this IS the MFA gate. Minting now would
+		// defeat the entire reason this package exists.
+		writeJSON(w, http.StatusOK, map[string]any{
+			"totp_required": true,
+			"session_id":    sess.ID,
+			"session_token": sess.Token,
+		})
+
+	default: // OutcomeHandoff, including the zero value.
+		if resErr != nil {
+			// finalize() ran, Zitadel returned a positive decision, and the
+			// exchange itself failed — a real error, not routine
+			// uncertainty. Distinguished from the nil-error case below so
+			// an operator can tell "policy was unreadable" apart from
+			// "we decided to finalize and it broke".
+			slog.ErrorContext(ctx, "zitadellogin: handoff after a failed finalize (positive decision, exchange failed)",
+				"err", resErr, "auth_request_id", authRequestID)
+		} else {
+			slog.InfoContext(ctx, "zitadellogin: handoff (uncollectible factor or unreadable policy/session)",
+				"auth_request_id", authRequestID)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"handoff_url":     h.handoffURL(authRequestID),
+			"auth_request_id": authRequestID,
+		})
+	}
+}
+
+// finishComplete resolves the subject of the now-sufficient session and runs
+// the shared post-identity gauntlet via the injected CompleteFunc.
+func (h *Handler) finishComplete(ctx context.Context, w http.ResponseWriter, res Result, sess Session, loginName, workspaceTenant string) {
+	// Result carries no subject — re-read it. Zitadel's login_name is the
+	// only identifier this package has for "email"; mark8ly logs in by
+	// email, so the value the caller submitted to /zitadel/login is used
+	// as-is rather than guessed at again here.
+	factors, err := h.c.SessionFactors(ctx, sess.ID)
+	if err != nil || factors.UserID == "" {
+		slog.ErrorContext(ctx, "zitadellogin: could not resolve session subject after a sufficient decision", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+		return
+	}
+
+	if h.complete == nil {
+		slog.ErrorContext(ctx, "zitadellogin: no CompleteFunc configured")
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+		return
+	}
+	if err := h.complete(ctx, w, factors.UserID, loginName, workspaceTenant); err != nil {
+		slog.ErrorContext(ctx, "zitadellogin: post-identity gauntlet failed", "err", err, "user_id", factors.UserID)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"callback_url": res.CallbackURL})
+}
+
+// respondSessionCreateError maps CreatePasswordSession's errors.
+//
+// ErrBadCredentials and ErrUserNotFound MUST produce the identical response —
+// collapsing them is the entire point of this function. Which one actually
+// happened is logged for operators, never returned to the caller.
+func (h *Handler) respondSessionCreateError(ctx context.Context, w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrBadCredentials):
+		slog.WarnContext(ctx, "zitadellogin: login rejected: bad credentials")
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "invalid_credentials"})
+	case errors.Is(err, ErrUserNotFound):
+		slog.WarnContext(ctx, "zitadellogin: login rejected: user not found")
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "invalid_credentials"})
+	case errors.Is(err, ErrUnavailable):
+		slog.ErrorContext(ctx, "zitadellogin: zitadel unavailable creating session", "err", err)
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "zitadel_unavailable"})
+	default:
+		slog.ErrorContext(ctx, "zitadellogin: unexpected error creating session", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+	}
+}
+
+// respondTOTPVerifyError maps VerifyTOTP's errors. Unlike the login step,
+// there is no enumeration concern here — the account is already established
+// — but the wrong-code case still must never echo Zitadel's error body.
+func (h *Handler) respondTOTPVerifyError(ctx context.Context, w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrBadCredentials):
+		slog.WarnContext(ctx, "zitadellogin: totp rejected: bad code")
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "invalid_totp"})
+	case errors.Is(err, ErrUserNotFound):
+		// The session itself vanished/expired between steps.
+		slog.WarnContext(ctx, "zitadellogin: totp rejected: session not found")
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "invalid_totp"})
+	case errors.Is(err, ErrUnavailable):
+		slog.ErrorContext(ctx, "zitadellogin: zitadel unavailable verifying totp", "err", err)
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "zitadel_unavailable"})
+	default:
+		slog.ErrorContext(ctx, "zitadellogin: unexpected error verifying totp", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+	}
+}
+
+// handoffURL builds the Aurora-branded hosted login's continuation URL for an
+// auth request this page decided it cannot (or should not) finish itself.
+// Returns "" when no hosted login base URL was configured; the caller still
+// gets auth_request_id back and is not stranded.
+func (h *Handler) handoffURL(authRequestID string) string {
+	if h.hostedLoginBaseURL == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/ui/v2/login/login?authRequestID=%s", h.hostedLoginBaseURL, url.QueryEscape(authRequestID))
+}
+
+func decodeJSON(r *http.Request, v any) error {
+	defer r.Body.Close()
+	return json.NewDecoder(io.LimitReader(r.Body, maxRequestBodyBytes)).Decode(v)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v map[string]any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/services/auth-bff/internal/zitadellogin/handler.go
+++ b/services/auth-bff/internal/zitadellogin/handler.go
@@ -12,17 +12,40 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/auth-bff/internal/geoip"
 )
 
 // maxRequestBodyBytes bounds request decoding, matching the defensive limits
 // already used for Zitadel's own responses in client.go.
 const maxRequestBodyBytes = 8 * 1024
 
+// LoginContext is everything the shared post-identity gauntlet needs beyond
+// the identity itself. It exists because deviceguard fingerprints the user
+// agent and the email-OTP limiter keys on the client IP: passing these empty
+// silently disables both, since Fingerprint("") is a constant every user
+// would share — the first Zitadel login would look like a new device, and
+// every one after it, from anywhere, would look like the same familiar one.
+type LoginContext struct {
+	UID      string
+	Email    string
+	TenantID string
+	// UserAgent, IPAddress, Device and Country are best-effort client
+	// metadata, populated the same way autologin's own handler populates
+	// them for a GIP login (see Handler.loginContext below) so the two
+	// providers cannot silently diverge in what deviceguard, the email-OTP
+	// limiter, the session registry and audit events see.
+	UserAgent string
+	IPAddress string
+	Device    string
+	Country   string
+}
+
 // CompleteFunc runs the shared post-identity gauntlet — FGA membership, the
 // MFA gate, deviceguard, the email-OTP step-up, session minting. It is
 // injected rather than imported so this package stays a Zitadel client and
 // knows nothing about autologin.
-type CompleteFunc func(ctx context.Context, w http.ResponseWriter, uid, email, tenantID string) error
+type CompleteFunc func(ctx context.Context, w http.ResponseWriter, lc LoginContext) error
 
 // Handler is the HTTP layer over Client: it owns request/response shapes and
 // the outcome switch, and defers every credential and sufficiency decision to
@@ -56,12 +79,80 @@ func (h *Handler) WithHostedLoginBaseURL(baseURL string) *Handler {
 }
 
 // Register mounts the Zitadel login routes onto the given gin.RouterGroup.
-// The handlers are plain net/http (gin.WrapF) rather than gin.HandlerFunc:
-// this package has no dependency on gin beyond mounting, and stays testable
-// with httptest alone.
+// The handlers themselves are plain net/http funcs so this package's tests
+// stay httptest-only; the two routing closures below are the ONLY place gin
+// is touched, and exist solely to carry gin.Context.ClientIP() — the same
+// trusted-proxy-aware IP resolution autologin's handler uses via c.ClientIP()
+// — into the request context, since a plain http.Request has no equivalent.
 func (h *Handler) Register(r *gin.RouterGroup) {
-	r.POST("/zitadel/login", gin.WrapF(h.login))
-	r.POST("/zitadel/totp", gin.WrapF(h.totp))
+	r.POST("/zitadel/login", func(c *gin.Context) {
+		h.login(c.Writer, withClientIP(c.Request, c.ClientIP()))
+	})
+	r.POST("/zitadel/totp", func(c *gin.Context) {
+		h.totp(c.Writer, withClientIP(c.Request, c.ClientIP()))
+	})
+}
+
+type contextKey int
+
+const clientIPContextKey contextKey = iota
+
+// withClientIP attaches a pre-resolved client IP to the request context. Kept
+// as context plumbing (rather than widening login/totp's signature) so those
+// handlers stay plain (http.ResponseWriter, *http.Request) funcs that tests
+// can call directly, exactly like the existing handler tests do.
+func withClientIP(r *http.Request, ip string) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), clientIPContextKey, ip))
+}
+
+// clientIPFromContext reads back the IP withClientIP attached. Returns "" for
+// a request built directly by a test rather than routed through Register —
+// same behaviour as an untested field, never a panic.
+func clientIPFromContext(ctx context.Context) string {
+	ip, _ := ctx.Value(clientIPContextKey).(string)
+	return ip
+}
+
+// deviceFromUA produces the same short device label autologin's handler
+// derives from a User-Agent (see internal/autologin/handler.go). Duplicated
+// rather than imported: this package must not depend on autologin, and the
+// label is a small, self-contained, presentation-only heuristic.
+func deviceFromUA(ua string) string {
+	ua = strings.ToLower(ua)
+	switch {
+	case ua == "":
+		return "Unknown device"
+	case strings.Contains(ua, "iphone"):
+		return "iPhone"
+	case strings.Contains(ua, "ipad"):
+		return "iPad"
+	case strings.Contains(ua, "android"):
+		return "Android"
+	case strings.Contains(ua, "mac os x"), strings.Contains(ua, "macintosh"):
+		return "Mac"
+	case strings.Contains(ua, "windows"):
+		return "Windows"
+	case strings.Contains(ua, "linux"):
+		return "Linux"
+	default:
+		return "Browser"
+	}
+}
+
+// loginContext assembles the client metadata half of LoginContext from the
+// inbound request, the same way autologin's handler assembles autologin.
+// Request's Device/IPAddress/UserAgent/Country fields for a GIP login.
+func (h *Handler) loginContext(r *http.Request, uid, email, tenantID string) LoginContext {
+	ua := r.UserAgent()
+	return LoginContext{
+		UID:       uid,
+		Email:     email,
+		TenantID:  tenantID,
+		UserAgent: ua,
+		IPAddress: clientIPFromContext(r.Context()),
+		Device:    deviceFromUA(ua),
+		Country:   geoip.CountryFromHeaders(r.Header),
+	}
 }
 
 type loginRequest struct {
@@ -108,7 +199,7 @@ func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 	// Password login through this page is never a federated (Google/Apple)
 	// identity — those never present a password to us at all.
 	res, err := h.c.CompleteIfSufficient(ctx, req.AuthRequestID, sess, false)
-	h.respondOutcome(ctx, w, res, err, req.AuthRequestID, sess, req.LoginName, req.WorkspaceTenant)
+	h.respondOutcome(w, r, res, err, req.AuthRequestID, sess, req.LoginName, req.WorkspaceTenant)
 }
 
 // totp reads {auth_request_id, login_name, session_id, session_token, code,
@@ -135,14 +226,14 @@ func (h *Handler) totp(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res, err := h.c.CompleteAfterFactor(ctx, req.AuthRequestID, sess)
-	h.respondOutcome(ctx, w, res, err, req.AuthRequestID, sess, req.LoginName, req.WorkspaceTenant)
+	h.respondOutcome(w, r, res, err, req.AuthRequestID, sess, req.LoginName, req.WorkspaceTenant)
 }
 
 // respondOutcome is shared by login and totp: both end at CompleteIfSufficient
 // / CompleteAfterFactor and switch on the same three outcomes.
 func (h *Handler) respondOutcome(
-	ctx context.Context,
 	w http.ResponseWriter,
+	r *http.Request,
 	res Result,
 	resErr error,
 	authRequestID string,
@@ -150,6 +241,7 @@ func (h *Handler) respondOutcome(
 	loginName string,
 	workspaceTenant string,
 ) {
+	ctx := r.Context()
 	switch res.Outcome {
 	case OutcomeComplete:
 		if resErr != nil {
@@ -161,7 +253,7 @@ func (h *Handler) respondOutcome(
 			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
 			return
 		}
-		h.finishComplete(ctx, w, res, sess, loginName, workspaceTenant)
+		h.finishComplete(w, r, res, sess, loginName, workspaceTenant)
 
 	case OutcomeFactorRequired:
 		// No session minted here — this IS the MFA gate. Minting now would
@@ -194,7 +286,8 @@ func (h *Handler) respondOutcome(
 
 // finishComplete resolves the subject of the now-sufficient session and runs
 // the shared post-identity gauntlet via the injected CompleteFunc.
-func (h *Handler) finishComplete(ctx context.Context, w http.ResponseWriter, res Result, sess Session, loginName, workspaceTenant string) {
+func (h *Handler) finishComplete(w http.ResponseWriter, r *http.Request, res Result, sess Session, loginName, workspaceTenant string) {
+	ctx := r.Context()
 	// Result carries no subject — re-read it. Zitadel's login_name is the
 	// only identifier this package has for "email"; mark8ly logs in by
 	// email, so the value the caller submitted to /zitadel/login is used
@@ -211,7 +304,8 @@ func (h *Handler) finishComplete(ctx context.Context, w http.ResponseWriter, res
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
 		return
 	}
-	if err := h.complete(ctx, w, factors.UserID, loginName, workspaceTenant); err != nil {
+	lc := h.loginContext(r, factors.UserID, loginName, workspaceTenant)
+	if err := h.complete(ctx, w, lc); err != nil {
 		slog.ErrorContext(ctx, "zitadellogin: post-identity gauntlet failed", "err", err, "user_id", factors.UserID)
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
 		return

--- a/services/auth-bff/internal/zitadellogin/handler_test.go
+++ b/services/auth-bff/internal/zitadellogin/handler_test.go
@@ -55,6 +55,10 @@ func fakeZitadelHandler(t *testing.T, policyJSON, methodsJSON, factorsJSON strin
 			w.Write([]byte(policyJSON))
 		case strings.HasSuffix(r.URL.Path, "/authentication_methods"):
 			w.Write([]byte(`{"authMethodTypes":` + methodsJSON + `}`))
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v2/users/"):
+			// UserEmail: the fixed handler resolves email from Zitadel, not
+			// from the request body, so every handler test needs this.
+			w.Write([]byte(`{"user":{"human":{"email":{"email":"a@b.test"}}}}`))
 		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v2/oidc/auth_requests/"):
 			finalized.Store(true)
 			w.Write([]byte(`{"callbackUrl":"https://admin.mark8ly.com/auth/callback?code=c&state=s"}`))
@@ -76,9 +80,9 @@ func TestLoginFactorRequiredDoesNotMintSession(t *testing.T) {
 	c := fakeZitadelHandler(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsPasswordOnly, &fin)
 
 	completeCalled := false
-	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) error {
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) (CompleteResult, error) {
 		completeCalled = true
-		return nil
+		return CompleteResult{}, nil
 	})
 
 	rec := httptest.NewRecorder()
@@ -108,9 +112,9 @@ func TestLoginCompleteCallsCompleteAndReturnsCallbackURL(t *testing.T) {
 	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
 
 	var gotUID, gotEmail, gotTenant string
-	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) error {
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) (CompleteResult, error) {
 		gotUID, gotEmail, gotTenant = lc.UID, lc.Email, lc.TenantID
-		return nil
+		return CompleteResult{}, nil
 	})
 
 	rec := httptest.NewRecorder()
@@ -139,9 +143,9 @@ func TestLoginHandoffReturnsHandoffURLAndDoesNotCallComplete(t *testing.T) {
 	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_U2F"]`, factorsPasswordOnly, &fin)
 
 	completeCalled := false
-	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) error {
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) (CompleteResult, error) {
 		completeCalled = true
-		return nil
+		return CompleteResult{}, nil
 	}).WithHostedLoginBaseURL("https://login.mark8ly.zitadel.cloud")
 
 	rec := httptest.NewRecorder()
@@ -193,9 +197,9 @@ func TestTotpCompleteCallsCompleteAndReturnsCallbackURL(t *testing.T) {
 	c := fakeZitadelHandler(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsWithTOTP, &fin)
 
 	completeCalled := false
-	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) error {
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) (CompleteResult, error) {
 		completeCalled = true
-		return nil
+		return CompleteResult{}, nil
 	})
 
 	rec := httptest.NewRecorder()
@@ -237,9 +241,9 @@ func TestLoginPassesTheUserAgentThroughSoDeviceguardStillWorks(t *testing.T) {
 
 	const wantUA = "Mark8lyZitadelLoginTest/1.0 (distinctive-ua)"
 	var got LoginContext
-	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) error {
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) (CompleteResult, error) {
 		got = lc
-		return nil
+		return CompleteResult{}, nil
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/auth/zitadel/login",

--- a/services/auth-bff/internal/zitadellogin/handler_test.go
+++ b/services/auth-bff/internal/zitadellogin/handler_test.go
@@ -1,0 +1,234 @@
+package zitadellogin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestLoginCollapsesUnknownUserAndWrongPasswordIntoOneAnswer(t *testing.T) {
+	// A different status or message for "no such user" is an account-
+	// enumeration oracle. Both must look identical to the browser.
+	for _, body := range []string{
+		`{"code":3,"message":"Password is invalid (COMMAND-3M0fs)","details":[{"id":"COMMAND-3M0fs","failedAttempts":1}]}`,
+		`{"code":5,"message":"User could not be found (QUERY-Dfbg2)","details":[{"id":"QUERY-Dfbg2"}]}`,
+	} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(body, "QUERY") {
+				w.WriteHeader(http.StatusNotFound)
+			} else {
+				w.WriteHeader(http.StatusBadRequest)
+			}
+			w.Write([]byte(body))
+		}))
+		defer srv.Close()
+		h := NewHandler(New(srv.URL, "pat", srv.Client()), nil)
+		rec := httptest.NewRecorder()
+		h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/login",
+			strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`)))
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", rec.Code)
+		}
+		if strings.Contains(rec.Body.String(), "failedAttempts") || strings.Contains(rec.Body.String(), "not be found") {
+			t.Fatalf("response leaks which half failed: %s", rec.Body.String())
+		}
+	}
+}
+
+// fakeZitadelHandler wires the same routes fakeZitadel (sufficiency_test.go)
+// wires, plus /v2/sessions for CreatePasswordSession and PATCH for VerifyTOTP,
+// so handler tests can drive the full login/totp path against one fake.
+func fakeZitadelHandler(t *testing.T, policyJSON, methodsJSON, factorsJSON string, finalized *atomic.Bool) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sessions":
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"sessionId":"s1","sessionToken":"tok-1"}`))
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/v2/sessions/"):
+			w.Write([]byte(`{"sessionToken":"tok-2"}`))
+		case r.URL.Path == "/management/v1/policies/login":
+			w.Write([]byte(policyJSON))
+		case strings.HasSuffix(r.URL.Path, "/authentication_methods"):
+			w.Write([]byte(`{"authMethodTypes":` + methodsJSON + `}`))
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v2/oidc/auth_requests/"):
+			finalized.Store(true)
+			w.Write([]byte(`{"callbackUrl":"https://admin.mark8ly.com/auth/callback?code=c&state=s"}`))
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v2/sessions/"):
+			w.Write([]byte(factorsJSON))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "pat", srv.Client())
+}
+
+// factorsPasswordOnly, policyNoMFA and policyForceMFA are shared with
+// sufficiency_test.go.
+
+func TestLoginFactorRequiredDoesNotMintSession(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelHandler(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsPasswordOnly, &fin)
+
+	completeCalled := false
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, uid, email, tenantID string) error {
+		completeCalled = true
+		return nil
+	})
+
+	rec := httptest.NewRecorder()
+	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["totp_required"] != true {
+		t.Fatalf("body = %v, want totp_required: true", body)
+	}
+	if completeCalled {
+		t.Fatal("complete() was called for OutcomeFactorRequired — a session must not be minted at the MFA gate")
+	}
+	if fin.Load() {
+		t.Fatal("finalize was called for OutcomeFactorRequired")
+	}
+}
+
+func TestLoginCompleteCallsCompleteAndReturnsCallbackURL(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+
+	var gotUID, gotEmail, gotTenant string
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, uid, email, tenantID string) error {
+		gotUID, gotEmail, gotTenant = uid, email, tenantID
+		return nil
+	})
+
+	rec := httptest.NewRecorder()
+	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["callback_url"] != "https://admin.mark8ly.com/auth/callback?code=c&state=s" {
+		t.Fatalf("body = %v", body)
+	}
+	if gotUID != "u1" || gotEmail != "a@b.test" || gotTenant != "t1" {
+		t.Fatalf("complete called with uid=%q email=%q tenant=%q", gotUID, gotEmail, gotTenant)
+	}
+}
+
+func TestLoginHandoffReturnsHandoffURLAndDoesNotCallComplete(t *testing.T) {
+	var fin atomic.Bool
+	// Unrecognised factor type -> uncollectible -> OutcomeHandoff with a nil
+	// error (ordinary uncertainty, not a finalize failure).
+	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_U2F"]`, factorsPasswordOnly, &fin)
+
+	completeCalled := false
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, uid, email, tenantID string) error {
+		completeCalled = true
+		return nil
+	}).WithHostedLoginBaseURL("https://login.mark8ly.zitadel.cloud")
+
+	rec := httptest.NewRecorder()
+	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got, _ := body["handoff_url"].(string)
+	if !strings.HasPrefix(got, "https://login.mark8ly.zitadel.cloud/ui/v2/login/login?authRequestID=") {
+		t.Fatalf("handoff_url = %q", got)
+	}
+	if completeCalled {
+		t.Fatal("complete() was called for OutcomeHandoff")
+	}
+	if fin.Load() {
+		t.Fatal("finalize was called for OutcomeHandoff")
+	}
+}
+
+func TestTotpWrongCodeReturns401WithoutLeakingZitadelBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"code":3,"message":"Invalid code (COMMAND-Sfeg2)","details":[{"id":"COMMAND-Sfeg2","failedAttempts":2}]}`))
+	}))
+	defer srv.Close()
+	h := NewHandler(New(srv.URL, "pat", srv.Client()), nil)
+
+	rec := httptest.NewRecorder()
+	h.totp(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/totp",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","session_id":"s1","session_token":"tok-1","code":"000000","workspace_tenant":"t1"}`)))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401, body = %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "failedAttempts") {
+		t.Fatalf("response leaks the attempt counter: %s", rec.Body.String())
+	}
+}
+
+func TestTotpCompleteCallsCompleteAndReturnsCallbackURL(t *testing.T) {
+	var fin atomic.Bool
+	factorsWithTOTP := `{"session":{"factors":{"user":{"id":"u1","organizationId":"o1"},"password":{"verifiedAt":"2026-09-03T01:00:00Z"},"totp":{"verifiedAt":"2026-09-03T01:01:00Z"}}}}`
+	c := fakeZitadelHandler(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsWithTOTP, &fin)
+
+	completeCalled := false
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, uid, email, tenantID string) error {
+		completeCalled = true
+		return nil
+	})
+
+	rec := httptest.NewRecorder()
+	h.totp(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/totp",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","session_id":"s1","session_token":"tok-1","code":"123456","workspace_tenant":"t1"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if !completeCalled {
+		t.Fatal("complete() was not called after a successful TOTP check")
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["callback_url"] == "" {
+		t.Fatalf("body = %v", body)
+	}
+}
+
+func TestLoginRejectsMissingFields(t *testing.T) {
+	h := NewHandler(New("http://unused.invalid", "pat", nil), nil)
+	rec := httptest.NewRecorder()
+	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/login", strings.NewReader(`{}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandoffURLEmptyWithoutConfiguredBase(t *testing.T) {
+	h := NewHandler(New("http://unused.invalid", "pat", nil), nil)
+	if got := h.handoffURL("V2_1"); got != "" {
+		t.Fatalf("handoffURL = %q, want empty when no base configured", got)
+	}
+}

--- a/services/auth-bff/internal/zitadellogin/handler_test.go
+++ b/services/auth-bff/internal/zitadellogin/handler_test.go
@@ -76,7 +76,7 @@ func TestLoginFactorRequiredDoesNotMintSession(t *testing.T) {
 	c := fakeZitadelHandler(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsPasswordOnly, &fin)
 
 	completeCalled := false
-	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, uid, email, tenantID string) error {
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) error {
 		completeCalled = true
 		return nil
 	})
@@ -108,8 +108,8 @@ func TestLoginCompleteCallsCompleteAndReturnsCallbackURL(t *testing.T) {
 	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
 
 	var gotUID, gotEmail, gotTenant string
-	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, uid, email, tenantID string) error {
-		gotUID, gotEmail, gotTenant = uid, email, tenantID
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) error {
+		gotUID, gotEmail, gotTenant = lc.UID, lc.Email, lc.TenantID
 		return nil
 	})
 
@@ -139,7 +139,7 @@ func TestLoginHandoffReturnsHandoffURLAndDoesNotCallComplete(t *testing.T) {
 	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_U2F"]`, factorsPasswordOnly, &fin)
 
 	completeCalled := false
-	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, uid, email, tenantID string) error {
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) error {
 		completeCalled = true
 		return nil
 	}).WithHostedLoginBaseURL("https://login.mark8ly.zitadel.cloud")
@@ -193,7 +193,7 @@ func TestTotpCompleteCallsCompleteAndReturnsCallbackURL(t *testing.T) {
 	c := fakeZitadelHandler(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsWithTOTP, &fin)
 
 	completeCalled := false
-	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, uid, email, tenantID string) error {
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) error {
 		completeCalled = true
 		return nil
 	})
@@ -223,6 +223,38 @@ func TestLoginRejectsMissingFields(t *testing.T) {
 	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/login", strings.NewReader(`{}`)))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestLoginPassesTheUserAgentThroughSoDeviceguardStillWorks pins the fix for
+// a critical, invisible-to-tests defect: an earlier CompleteFunc shape had no
+// way to carry request metadata to completeLogin at all, so
+// deviceguard.Fingerprint would have hashed "" for every Zitadel login —
+// a CONSTANT every user shares, silently collapsing new-device detection.
+func TestLoginPassesTheUserAgentThroughSoDeviceguardStillWorks(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+
+	const wantUA = "Mark8lyZitadelLoginTest/1.0 (distinctive-ua)"
+	var got LoginContext
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) error {
+		got = lc
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/zitadel/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`))
+	req.Header.Set("User-Agent", wantUA)
+
+	rec := httptest.NewRecorder()
+	h.login(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got.UserAgent != wantUA {
+		t.Fatalf("LoginContext.UserAgent = %q, want %q — deviceguard fingerprints this; "+
+			"empty would collapse every Zitadel user onto one fingerprint", got.UserAgent, wantUA)
 	}
 }
 

--- a/services/auth-bff/internal/zitadellogin/handler_test.go
+++ b/services/auth-bff/internal/zitadellogin/handler_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	"github.com/gin-gonic/gin"
 )
 
 func TestLoginCollapsesUnknownUserAndWrongPasswordIntoOneAnswer(t *testing.T) {
@@ -266,5 +268,147 @@ func TestHandoffURLEmptyWithoutConfiguredBase(t *testing.T) {
 	h := NewHandler(New("http://unused.invalid", "pat", nil), nil)
 	if got := h.handoffURL("V2_1"); got != "" {
 		t.Fatalf("handoffURL = %q, want empty when no base configured", got)
+	}
+}
+
+// TestTotpIgnoresAClientSuppliedLoginNameAndResolvesTheRealUser pins the fix
+// for a spoofing defect: login_name on /zitadel/totp is never checked against
+// anything (the password check that verifies login_name happens on the
+// earlier /zitadel/login call, against a session this caller might not even
+// own). Without resolving the email from Zitadel, anyone with valid
+// credentials of their own could submit an arbitrary login_name here and walk
+// away with a session cookie, an audit event, and a mailed sign-in code
+// addressed to a victim's email of their choosing.
+func TestTotpIgnoresAClientSuppliedLoginNameAndResolvesTheRealUser(t *testing.T) {
+	var fin atomic.Bool
+	factorsWithTOTP := `{"session":{"factors":{"user":{"id":"u1","organizationId":"o1"},"password":{"verifiedAt":"2026-09-03T01:00:00Z"},"totp":{"verifiedAt":"2026-09-03T01:01:00Z"}}}}`
+	c := fakeZitadelHandler(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsWithTOTP, &fin)
+
+	var got LoginContext
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) (CompleteResult, error) {
+		got = lc
+		return CompleteResult{}, nil
+	})
+
+	rec := httptest.NewRecorder()
+	h.totp(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/totp",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"attacker-chosen@evil.test","session_id":"s1","session_token":"tok-1","code":"123456","workspace_tenant":"t1"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got.Email == "attacker-chosen@evil.test" {
+		t.Fatalf("LoginContext.Email = %q — a client-supplied, unverified login_name reached the gauntlet on the TOTP step", got.Email)
+	}
+	if got.Email != "a@b.test" {
+		t.Fatalf("LoginContext.Email = %q, want the email resolved from Zitadel (a@b.test), regardless of what login_name was submitted", got.Email)
+	}
+}
+
+// TestLoginCompleteWithMFARequiredDoesNotReturnCallbackURL pins the fix for
+// CompleteForProvider discarding the step-up state: if auth-bff's own MFA
+// gate fires inside the gauntlet, the response must say so instead of
+// answering with a callback_url that would tell the browser the login is
+// finished while a step-up is still outstanding.
+func TestLoginCompleteWithMFARequiredDoesNotReturnCallbackURL(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) (CompleteResult, error) {
+		return CompleteResult{MFARequired: true}, nil
+	})
+
+	rec := httptest.NewRecorder()
+	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := body["callback_url"]; ok {
+		t.Fatalf("body = %v carries callback_url while auth-bff's own MFA step-up is outstanding", body)
+	}
+	data, _ := body["data"].(map[string]any)
+	if data == nil || data["mfa_required"] != true {
+		t.Fatalf("body = %v, want data.mfa_required = true", body)
+	}
+	if data["email_otp_required"] != false {
+		t.Fatalf("body = %v, want data.email_otp_required = false", body)
+	}
+}
+
+// TestLoginCompleteWithEmailOTPRequiredDoesNotReturnCallbackURL is the
+// email-OTP twin of the MFA case above: a new-device challenge must also
+// suppress callback_url, not just MFA.
+func TestLoginCompleteWithEmailOTPRequiredDoesNotReturnCallbackURL(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) (CompleteResult, error) {
+		return CompleteResult{EmailOTPRequired: true}, nil
+	})
+
+	rec := httptest.NewRecorder()
+	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := body["callback_url"]; ok {
+		t.Fatalf("body = %v carries callback_url while the email-OTP step-up is outstanding", body)
+	}
+	data, _ := body["data"].(map[string]any)
+	if data == nil || data["email_otp_required"] != true {
+		t.Fatalf("body = %v, want data.email_otp_required = true", body)
+	}
+	if data["mfa_required"] != false {
+		t.Fatalf("body = %v, want data.mfa_required = false", body)
+	}
+}
+
+// TestRegisterResolvesTheGinClientIPIntoLoginContext exercises the actual
+// Register -> withClientIP plumbing through a real gin router, rather than
+// calling h.login/h.totp directly as every other test in this file does. No
+// prior test routed through Register, so a break in that wiring (IPAddress
+// silently landing as "") would have gone unnoticed — the same shape of gap
+// as the Fingerprint("") defect this phase already found and fixed.
+func TestRegisterResolvesTheGinClientIPIntoLoginContext(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+
+	var gotIP string
+	h := NewHandler(c, func(ctx context.Context, w http.ResponseWriter, lc LoginContext) (CompleteResult, error) {
+		gotIP = lc.IPAddress
+		return CompleteResult{}, nil
+	})
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h.Register(r.Group("/auth"))
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/zitadel/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`))
+	req.Header.Set("X-Forwarded-For", "203.0.113.42")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if gotIP == "" {
+		t.Fatal("IPAddress reaching CompleteFunc is empty — the Register -> withClientIP plumbing is broken; " +
+			"the email-OTP limiter would key on a constant for every Zitadel login")
+	}
+	if gotIP != "203.0.113.42" {
+		t.Fatalf("IPAddress = %q, want the gin-resolved client IP from X-Forwarded-For", gotIP)
 	}
 }

--- a/services/auth-bff/internal/zitadellogin/sufficiency.go
+++ b/services/auth-bff/internal/zitadellogin/sufficiency.go
@@ -1,0 +1,155 @@
+package zitadellogin
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+)
+
+// Outcome is what to do with a login attempt.
+type Outcome int
+
+const (
+	// OutcomeHandoff is the zero value ON PURPOSE. Any Result built without a
+	// decision lands on "do not complete this login". The opposite default
+	// would cost an MFA bypass; that asymmetry decides which value is zero.
+	OutcomeHandoff Outcome = iota
+	OutcomeComplete
+	OutcomeFactorRequired
+)
+
+type Result struct {
+	Outcome     Outcome
+	CallbackURL string
+	Factors     []string
+}
+
+// sufficient is proof that a session was evaluated by one of this package's
+// two classification paths and found adequate to finalize.
+//
+// It makes "call finalize with no decision at all" a compile error. It does
+// NOT stop someone constructing sufficient{} beside a new check-free function
+// — Go permits that inside the package — which is why an archtest pins both
+// the finalize call site and sufficient{} construction to this file.
+type sufficient struct{}
+
+const (
+	methodPassword = "AUTHENTICATION_METHOD_TYPE_PASSWORD" // not a second factor
+	methodTOTP     = "AUTHENTICATION_METHOD_TYPE_TOTP"     // the one we can collect
+)
+
+// finalize exchanges a session for an authorization code. Unexported and
+// requiring a sufficient witness, so it is unreachable without a decision.
+func (c *Client) finalize(ctx context.Context, authRequestID string, s Session, _ sufficient) (string, error) {
+	body := map[string]any{
+		"session": map[string]any{"sessionId": s.ID, "sessionToken": s.Token},
+	}
+	var wire struct {
+		CallbackURL string `json:"callbackUrl"`
+	}
+	err := c.do(ctx, http.MethodPost, "/v2/oidc/auth_requests/"+url.PathEscape(authRequestID), body, &wire, ErrAuthRequestInvalid)
+	if err != nil {
+		return "", err
+	}
+	if wire.CallbackURL == "" {
+		return "", fmt.Errorf("zitadellogin: finalize returned no callbackUrl: %w", ErrUnavailable)
+	}
+	return wire.CallbackURL, nil
+}
+
+// classifyEnrolledMethods reports whether the user has TOTP enrolled and
+// whether they have any factor this login page cannot collect.
+//
+// Everything that is not PASSWORD or TOTP is uncollectible — an include list,
+// so a factor type we have never seen fails closed into a handoff rather than
+// being silently skipped.
+func (c *Client) classifyEnrolledMethods(ctx context.Context, userID string) (totpEnrolled, uncollectible bool, err error) {
+	types, err := c.EnrolledMethodTypes(ctx, userID)
+	if err != nil {
+		return false, false, err
+	}
+	for _, t := range types {
+		switch t {
+		case methodPassword:
+		case methodTOTP:
+			totpEnrolled = true
+		default:
+			uncollectible = true
+		}
+	}
+	return totpEnrolled, uncollectible, nil
+}
+
+// mfaRequired applies the two policy fields to this user.
+//
+// forceMfa applies to everyone. forceMfaLocalOnly applies only to users
+// authenticating with a local credential — mark8ly has federated Google and
+// Apple users, and forcing MFA on them would be wrong. These are kept separate
+// rather than OR-ed together for exactly that reason.
+func mfaRequired(p LoginPolicy, federated bool) bool {
+	if p.ForceMFA {
+		return true
+	}
+	return p.ForceMFALocalOnly && !federated
+}
+
+// CompleteIfSufficient decides whether a freshly created session may finalize.
+//
+// Zitadel does NOT enforce forceMfa for a login client: it issues an
+// authorization code for a password-only session and signals nothing. Every
+// uncertain input therefore fails closed to OutcomeHandoff, which is a
+// legitimate outcome rather than an error.
+func (c *Client) CompleteIfSufficient(ctx context.Context, authRequestID string, s Session, federated bool) (Result, error) {
+	factors, err := c.SessionFactors(ctx, s.ID)
+	if err != nil || factors.UserID == "" || factors.OrgID == "" {
+		slog.WarnContext(ctx, "zitadel sufficiency: cannot read session subject, handing off", "err", err)
+		return Result{Outcome: OutcomeHandoff}, nil
+	}
+	totpEnrolled, uncollectible, err := c.classifyEnrolledMethods(ctx, factors.UserID)
+	if err != nil {
+		slog.WarnContext(ctx, "zitadel sufficiency: cannot read enrolled methods, handing off", "err", err)
+		return Result{Outcome: OutcomeHandoff}, nil
+	}
+	if uncollectible {
+		return Result{Outcome: OutcomeHandoff}, nil
+	}
+	policy, err := c.LoginPolicyForOrg(ctx, factors.OrgID)
+	if err != nil {
+		slog.WarnContext(ctx, "zitadel sufficiency: cannot read login policy, handing off", "err", err)
+		return Result{Outcome: OutcomeHandoff}, nil
+	}
+	if mfaRequired(policy, federated) && !factors.TOTP {
+		if !totpEnrolled {
+			return Result{Outcome: OutcomeHandoff}, nil
+		}
+		return Result{Outcome: OutcomeFactorRequired, Factors: []string{methodTOTP}}, nil
+	}
+	cb, err := c.finalize(ctx, authRequestID, s, sufficient{})
+	if err != nil {
+		return Result{Outcome: OutcomeHandoff}, err
+	}
+	return Result{Outcome: OutcomeComplete, CallbackURL: cb}, nil
+}
+
+// CompleteAfterFactor finalizes after a TOTP check.
+//
+// It re-reads the factors from Zitadel rather than trusting that VerifyTOTP
+// returned without error, because the caller may be holding a stale session
+// value from before the token rotated.
+func (c *Client) CompleteAfterFactor(ctx context.Context, authRequestID string, s Session) (Result, error) {
+	factors, err := c.SessionFactors(ctx, s.ID)
+	if err != nil {
+		slog.WarnContext(ctx, "zitadel sufficiency: cannot re-read factors after TOTP, handing off", "err", err)
+		return Result{Outcome: OutcomeHandoff}, nil
+	}
+	if !factors.TOTP {
+		return Result{Outcome: OutcomeHandoff}, nil
+	}
+	cb, err := c.finalize(ctx, authRequestID, s, sufficient{})
+	if err != nil {
+		return Result{Outcome: OutcomeHandoff}, err
+	}
+	return Result{Outcome: OutcomeComplete, CallbackURL: cb}, nil
+}

--- a/services/auth-bff/internal/zitadellogin/sufficiency_test.go
+++ b/services/auth-bff/internal/zitadellogin/sufficiency_test.go
@@ -1,0 +1,163 @@
+package zitadellogin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func fakeZitadel(t *testing.T, policyJSON, methodsJSON, factorsJSON string, finalized *atomic.Bool) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/management/v1/policies/login":
+			w.Write([]byte(policyJSON))
+		case strings.HasSuffix(r.URL.Path, "/authentication_methods"):
+			w.Write([]byte(`{"authMethodTypes":` + methodsJSON + `}`))
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v2/oidc/auth_requests/"):
+			finalized.Store(true)
+			w.Write([]byte(`{"callbackUrl":"https://admin.mark8ly.com/auth/callback?code=c&state=s"}`))
+		case strings.HasPrefix(r.URL.Path, "/v2/sessions/"):
+			w.Write([]byte(factorsJSON))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "pat", srv.Client())
+}
+
+const factorsPasswordOnly = `{"session":{"factors":{"user":{"id":"u1","organizationId":"o1"},"password":{"verifiedAt":"2026-09-03T01:00:00Z"}}}}`
+const factorsWithTOTP = `{"session":{"factors":{"user":{"id":"u1","organizationId":"o1"},"password":{"verifiedAt":"2026-09-03T01:00:00Z"},"totp":{"verifiedAt":"2026-09-03T01:01:00Z"}}}}`
+const policyNoMFA = `{"policy":{"passwordCheckLifetime":"0s"}}`
+const policyForceMFA = `{"policy":{"passwordCheckLifetime":"0s","forceMfa":true}}`
+const policyLocalOnly = `{"policy":{"passwordCheckLifetime":"0s","forceMfaLocalOnly":true}}`
+
+func TestPasswordOnlyCompletesWhenNoMFAIsRequired(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadel(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+	res, err := c.CompleteIfSufficient(context.Background(), "V2_1", Session{ID: "s1", Token: "t"}, false)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeComplete || res.CallbackURL == "" {
+		t.Fatalf("result = %+v", res)
+	}
+	if !fin.Load() {
+		t.Error("finalize was not called")
+	}
+}
+
+func TestPasswordOnlyDoesNotCompleteWhenForceMfaIsSet(t *testing.T) {
+	// The whole reason this package exists: Zitadel WOULD issue a code here.
+	var fin atomic.Bool
+	c := fakeZitadel(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsPasswordOnly, &fin)
+	res, err := c.CompleteIfSufficient(context.Background(), "V2_1", Session{ID: "s1", Token: "t"}, false)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeFactorRequired {
+		t.Fatalf("outcome = %v, want OutcomeFactorRequired", res.Outcome)
+	}
+	if fin.Load() {
+		t.Fatal("finalize WAS called for a password-only session under forceMfa — MFA bypass")
+	}
+}
+
+func TestForceMfaLocalOnlyDoesNotApplyToFederatedUsers(t *testing.T) {
+	// forceMfaLocalOnly means "local/password users only". mark8ly has Google
+	// and Apple users; forcing MFA on them would be wrong.
+	var fin atomic.Bool
+	c := fakeZitadel(t, policyLocalOnly, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+	res, err := c.CompleteIfSufficient(context.Background(), "V2_1", Session{ID: "s1", Token: "t"}, true /* federated */)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeComplete {
+		t.Fatalf("outcome = %v, want OutcomeComplete for a federated user", res.Outcome)
+	}
+}
+
+func TestForceMfaLocalOnlyDoesApplyToPasswordUsers(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadel(t, policyLocalOnly, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsPasswordOnly, &fin)
+	res, err := c.CompleteIfSufficient(context.Background(), "V2_1", Session{ID: "s1", Token: "t"}, false)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeFactorRequired {
+		t.Fatalf("outcome = %v, want OutcomeFactorRequired", res.Outcome)
+	}
+	if fin.Load() {
+		t.Fatal("finalize was called")
+	}
+}
+
+func TestAnUncollectibleFactorHandsOff(t *testing.T) {
+	// A passkey is a real second factor this login page cannot collect.
+	// Completing anyway would silently skip it.
+	var fin atomic.Bool
+	c := fakeZitadel(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_PASSKEY"]`, factorsPasswordOnly, &fin)
+	res, err := c.CompleteIfSufficient(context.Background(), "V2_1", Session{ID: "s1", Token: "t"}, false)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeHandoff {
+		t.Fatalf("outcome = %v, want OutcomeHandoff", res.Outcome)
+	}
+	if fin.Load() {
+		t.Fatal("finalize was called with an uncollected factor outstanding")
+	}
+}
+
+func TestAnUnreadablePolicyHandsOffRatherThanCompleting(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadel(t, `{"policy":{"nonsense":true}}`, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+	res, err := c.CompleteIfSufficient(context.Background(), "V2_1", Session{ID: "s1", Token: "t"}, false)
+	if err != nil {
+		t.Fatalf("err = %v (a handoff is an outcome, not an error)", err)
+	}
+	if res.Outcome != OutcomeHandoff {
+		t.Fatalf("outcome = %v, want OutcomeHandoff", res.Outcome)
+	}
+	if fin.Load() {
+		t.Fatal("finalize was called despite an unreadable policy")
+	}
+}
+
+func TestZeroValueOutcomeIsHandoff(t *testing.T) {
+	var r Result
+	if r.Outcome != OutcomeHandoff {
+		t.Fatal("the zero value must be OutcomeHandoff so an undecided Result cannot complete a login")
+	}
+}
+
+func TestCompleteAfterFactorRefusesWhenZitadelDoesNotReportTOTP(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadel(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsPasswordOnly, &fin)
+	res, err := c.CompleteAfterFactor(context.Background(), "V2_1", Session{ID: "s1", Token: "t"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome == OutcomeComplete {
+		t.Fatal("completed without Zitadel confirming the TOTP factor")
+	}
+	if fin.Load() {
+		t.Fatal("finalize was called")
+	}
+}
+
+func TestCompleteAfterFactorCompletesWhenTOTPIsConfirmed(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadel(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsWithTOTP, &fin)
+	res, err := c.CompleteAfterFactor(context.Background(), "V2_1", Session{ID: "s1", Token: "t"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeComplete || !fin.Load() {
+		t.Fatalf("result = %+v finalized=%v", res, fin.Load())
+	}
+}

--- a/services/auth-bff/internal/zitadellogin/sufficiency_test.go
+++ b/services/auth-bff/internal/zitadellogin/sufficiency_test.go
@@ -32,6 +32,15 @@ func fakeZitadel(t *testing.T, policyJSON, methodsJSON, factorsJSON string, fina
 
 const factorsPasswordOnly = `{"session":{"factors":{"user":{"id":"u1","organizationId":"o1"},"password":{"verifiedAt":"2026-09-03T01:00:00Z"}}}}`
 const factorsWithTOTP = `{"session":{"factors":{"user":{"id":"u1","organizationId":"o1"},"password":{"verifiedAt":"2026-09-03T01:00:00Z"},"totp":{"verifiedAt":"2026-09-03T01:01:00Z"}}}}`
+
+// The lifetime value in these fixtures is deliberately trivial. The anchor check
+// is presence-only (client.go: `if _, ok := wire.Policy[policyAnchorKey]`), so the
+// duration never matters to any assertion here.
+//
+// Do not "improve" it to a realistic duration: GitGuardian's Generic Password
+// detector treats that key followed by a longer value as a hardcoded password and
+// fails CI. Eight fixtures tripped it once already, and so did the comment that
+// first explained this, by quoting the value verbatim.
 const policyNoMFA = `{"policy":{"passwordCheckLifetime":"0s"}}`
 const policyForceMFA = `{"policy":{"passwordCheckLifetime":"0s","forceMfa":true}}`
 const policyLocalOnly = `{"policy":{"passwordCheckLifetime":"0s","forceMfaLocalOnly":true}}`

--- a/services/auth-bff/pkg/config/config.go
+++ b/services/auth-bff/pkg/config/config.go
@@ -65,6 +65,14 @@ type Config struct {
 	// code hash, so a database leak alone does not yield usable codes.
 	// Must be at least 16 bytes. Empty disables the email-OTP gate.
 	EmailOTPPepper string `envconfig:"EMAIL_OTP_PEPPER"`
+
+	// Zitadel (#524 phase 2). All optional and unread unless ZitadelEnabled is
+	// set: GIP remains the live provider until the phase 6 cutover.
+	ZitadelEnabled             bool   `envconfig:"ZITADEL_ENABLED" default:"false"`
+	ZitadelIssuer              string `envconfig:"ZITADEL_ISSUER"`
+	ZitadelLoginClientToken    string `envconfig:"ZITADEL_LOGIN_CLIENT_TOKEN"`
+	ZitadelAdminProjectID      string `envconfig:"ZITADEL_ADMIN_PROJECT_ID"`
+	ZitadelStorefrontProjectID string `envconfig:"ZITADEL_STOREFRONT_PROJECT_ID"`
 }
 
 // Load reads .env (if present) and binds environment variables.

--- a/services/auth-bff/pkg/config/config_test.go
+++ b/services/auth-bff/pkg/config/config_test.go
@@ -17,6 +17,8 @@ func clearAll(t *testing.T) {
 		"OAUTH_CLIENT_ID", "OAUTH_CLIENT_SECRET",
 		"SESSION_COOKIE_NAME", "SESSION_COOKIE_DOMAIN", "SESSION_ENCRYPT_KEY",
 		"FGA_API_URL", "FGA_STORE_ID",
+		"ZITADEL_ENABLED", "ZITADEL_ISSUER", "ZITADEL_LOGIN_CLIENT_TOKEN",
+		"ZITADEL_ADMIN_PROJECT_ID", "ZITADEL_STOREFRONT_PROJECT_ID",
 	} {
 		os.Unsetenv(k)
 	}
@@ -86,5 +88,28 @@ func TestLoad_AppliesDefaultsForOptionalFields(t *testing.T) {
 	}
 	if cfg.SessionCookieName != "m8_session" {
 		t.Errorf("SessionCookieName default = %q, want %q", cfg.SessionCookieName, "m8_session")
+	}
+}
+
+func TestZitadelIsDisabledAndUnrequiredByDefault(t *testing.T) {
+	for _, k := range []string{"ZITADEL_ENABLED", "ZITADEL_ISSUER", "ZITADEL_LOGIN_CLIENT_TOKEN", "ZITADEL_ADMIN_PROJECT_ID", "ZITADEL_STOREFRONT_PROJECT_ID"} {
+		os.Unsetenv(k)
+	}
+	// Only the pre-existing required vars are set.
+	t.Setenv("DATABASE_URL", "postgres://x")
+	t.Setenv("GIP_PROJECT_ID", "p")
+	t.Setenv("GIP_PROJECT_NUMBER", "1")
+	t.Setenv("GIP_WEB_API_KEY", "k")
+	t.Setenv("GIP_INTERNAL_TENANT_ID", "t")
+	t.Setenv("OAUTH_CLIENT_ID", "c")
+	t.Setenv("OAUTH_CLIENT_SECRET", "s")
+	t.Setenv("SESSION_ENCRYPT_KEY", "thirtytwo-bytes-for-testing-only")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load must succeed with no Zitadel config at all: %v", err)
+	}
+	if cfg.ZitadelEnabled {
+		t.Error("ZitadelEnabled must default to false")
 	}
 }


### PR DESCRIPTION
Phase 2 of the GIP → Zitadel migration (#524). Adds a Zitadel login client to
`auth-bff` **behind a flag that is off by default**. GIP remains the live auth
provider and nothing about today's login behaviour changes on merge.

Follows the design in `docs/superpowers/specs/2026-09-03-zitadel-migration-design.md`
and the plan in `docs/superpowers/plans/2026-09-03-zitadel-phase2-login-client.md`,
both included here.

## Why this exists in the shape it does

**Zitadel does not enforce MFA for a login client.** Under a `forceMfa: true`
policy it still issues an OIDC authorization code for a password-only session —
no refusal, no signal. Verified against the live v4.15.3 instance by two
independent teams. Every MFA guarantee therefore lives in `sufficiency.go`, and
`finalize` is unexported behind a witness type so calling it without a decision
is a compile error. Three archtests back that up; I mutation-tested all three
(injecting a witness construction, a `finalize` call, and an unscoped policy read)
and each failed with the right message.

## What changed

1. **`AutoLogin` split** (`internal/autologin`) — nine provider-agnostic gates
   (FGA membership + retry, MFA gate, deviceguard, email-OTP step-up, session
   mint, registry row, audit) moved into a shared `completeLogin`, so both
   providers run the *same* gauntlet rather than two copies that can drift.
   **All 19 pre-existing tests pass unedited** — that was the acceptance criterion.
2. **`internal/zitadellogin`** — Session API v2 client, fail-closed sufficiency,
   HTTP handler, and a README recording the package's known gaps.
3. **Config + wiring** — five optional fields, `ZITADEL_ENABLED` defaulting to
   false, client constructed only when explicitly enabled and fully configured.

## Reviewer notes

**The disabled path is the safety property.** With `ZITADEL_ENABLED` unset: no
field carries `required:"true"`, no route is mounted, no client is constructed,
and startup logs that GIP remains the provider. The one deliberate fatal is a
half-configured opt-in (enabled but no issuer/token), which panics at boot rather
than failing per-request at login.

**Three findings from the final review, all fixed in this branch — worth your eyes:**

1. **`login_name` was client-supplied and unverified on `/zitadel/totp`.** Someone
   with valid credentials of their own could have passed `login_name:
   victim@example.com` and received a session cookie carrying that email, an audit
   event attributing the action to it, and a mark8ly-branded sign-in code mailed
   to an address they chose. UID and FGA were unaffected, so spoofing rather than
   escalation. Now the email is resolved from Zitadel on both paths and
   `login_name` is used only as the password-check credential.
2. **The step-up flags were being discarded.** `CompleteForProvider` dropped
   `MFARequired`/`EmailOTPRequired`, so the browser was told `200 {callback_url}`
   while auth-bff still expected a second factor. Both now propagate, with the
   same response shape the GIP handler uses.
3. **`LoginContext` exists because of a caught regression.** An earlier iteration
   passed only uid/email/tenant to the shared gauntlet. `deviceguard.Fingerprint("")`
   is a constant, so every Zitadel user would have shared one device fingerprint —
   new-device detection silently dead, with no failing test and no error log.

## Deliberately deferred (all recorded in the package README)

- The Zitadel `session_token` is returned in the login JSON body when a factor is
  required. Bounded — the Session API also needs the instance PAT — and phase 3
  rewrites this response contract; it should move into the encrypted pending
  cookie then.
- Gauntlet errors collapse to `500` on the Zitadel path; 403/503/429 are
  indistinguishable until phase 3's client exists.
- `deviceFromUA` is byte-identical-duplicated with `internal/autologin`. Display
  label only — the security signal is `Fingerprint(UserAgent)` — but it should be
  extracted before the copies drift.
- The archtests check *which file* calls `finalize`, not how the decision was
  reached, so a bypass helper added inside `sufficiency.go` itself would pass.
  Closing that needs AST analysis; documented rather than solved.

## Testing

`go build ./... && go vet ./... && go test ./...` green across all packages,
including `-race`. `internal/zitadellogin` carries client, sufficiency, handler
and architecture tests; the security properties are asserted directly — that a
password-only session under `forceMfa` never finalizes, that unknown-user and
wrong-password return identical 401s, that `failedAttempts` never reaches an
error string, and that an empty org id is refused before any HTTP call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xQ7gJoonbQZmnnbfPD5RE
