### PR TITLE
fix(config): stop requiring GCP_PROJECT_ID for bao mode, drop dead carrier-secret GCP inputs (#621)

### DIFF
--- a/services/marketplace-api/pkg/config/config.go
+++ b/services/marketplace-api/pkg/config/config.go
@@ -255,16 +255,16 @@ type Config struct {
 	// at startup by Validate — a typo here must not silently leave the
 	// wrong backend primary (see ErrShippingSecretStoreUnknown).
 	ShippingSecretStore string `envconfig:"SHIPPING_SECRET_STORE" default:"inline"`
-	// GCPProjectID is the project that hosts the per-tenant carrier
-	// secrets. Required when ShippingSecretStore is "gcpsm" or "bao" —
-	// even bao-primary chains still route legacy gsm:// reads through
-	// GCP Secret Manager. Unused when "inline".
+	// GCPProjectID is the GCP project used by the merchant-push Pub/Sub
+	// publisher (see pushevents.NewPublisher in cmd/marketplace-api).
+	//
+	// It has NOTHING to do with carrier secrets any more: mark8ly#621
+	// removed the GCP Secret Manager backend, and Validate no longer
+	// requires this for any ShippingSecretStore mode. It is still
+	// load-bearing though — push publishing is skipped when it is empty,
+	// and that skip only logs, so removing it from a deployment disables
+	// merchant push silently rather than failing loudly.
 	GCPProjectID string `envconfig:"GCP_PROJECT_ID" default:""`
-	// SecretNamePrefix goes at the head of every per-tenant secret ID,
-	// e.g. "mark8ly-prod", "mark8ly-test". Isolates dev and prod
-	// clusters that share the same GCP project by scoping IAM
-	// bindings via resource.name.startsWith.
-	SecretNamePrefix string `envconfig:"SECRET_NAME_PREFIX" default:"mark8ly-dev"`
 
 	// OpenBaoAddr is the OpenBao API address. Required whenever
 	// ShippingSecretStore != "inline" — ChainStore routes any bao://
@@ -353,13 +353,6 @@ var (
 	// error on the first merchant credential save instead of at boot.
 	ErrOpenBaoKVMountUnsupported = errors.New(
 		"marketplace config: OPENBAO_KV_MOUNT must be \"kv\" when SHIPPING_SECRET_STORE=bao (carriersecrets.BaoPath currently assumes the \"kv\" mount)")
-	// ErrGCPProjectIDRequiredForBao fires when ShippingSecretStore=bao
-	// and GCP_PROJECT_ID is unset. A bao-primary ChainStore still routes
-	// legacy gsm:// reads (and destroys) through GCP Secret Manager, so
-	// GCP_PROJECT_ID is a genuine prerequisite for "bao" mode, not just
-	// "gcpsm" mode.
-	ErrGCPProjectIDRequiredForBao = errors.New(
-		"marketplace config: GCP_PROJECT_ID must be set when SHIPPING_SECRET_STORE=bao (legacy gsm:// rows must still resolve through GCP Secret Manager)")
 )
 
 // Load reads .env (if present) and binds environment variables into Config.
@@ -475,9 +468,6 @@ func (c *Config) validateShippingSecretStore() error {
 	if c.OpenBaoKVMount != "kv" {
 		return fmt.Errorf("%w (got OPENBAO_KV_MOUNT=%q)", ErrOpenBaoKVMountUnsupported, c.OpenBaoKVMount)
 	}
-	if c.GCPProjectID == "" {
-		return ErrGCPProjectIDRequiredForBao
-	}
 	return nil
 }
 
@@ -489,8 +479,6 @@ func (c *Config) validateShippingSecretStore() error {
 type CarrierSecretJobConfig struct {
 	DatabaseURL         string
 	ShippingSecretStore string
-	GCPProjectID        string
-	SecretNamePrefix    string
 	OpenBaoAddr         string
 	OpenBaoRole         string
 	OpenBaoKVMount      string
@@ -511,8 +499,6 @@ type CarrierSecretJobConfig struct {
 type carrierSecretJobEnv struct {
 	DatabaseURL         string `envconfig:"DATABASE_URL" required:"true"`
 	ShippingSecretStore string `envconfig:"SHIPPING_SECRET_STORE" default:"inline"`
-	GCPProjectID        string `envconfig:"GCP_PROJECT_ID" default:""`
-	SecretNamePrefix    string `envconfig:"SECRET_NAME_PREFIX" default:"mark8ly-dev"`
 	OpenBaoAddr         string `envconfig:"OPENBAO_ADDR" default:"http://openbao-active.openbao.svc.cluster.local:8200"`
 	OpenBaoRole         string `envconfig:"OPENBAO_ROLE" default:""`
 	OpenBaoKVMount      string `envconfig:"OPENBAO_KV_MOUNT" default:"kv"`
@@ -554,7 +540,6 @@ func LoadCarrierSecretJob() (*CarrierSecretJobConfig, error) {
 	// copy the (possibly normalised) value back out.
 	validation := &Config{
 		ShippingSecretStore: env.ShippingSecretStore,
-		GCPProjectID:        env.GCPProjectID,
 		OpenBaoAddr:         env.OpenBaoAddr,
 		OpenBaoRole:         env.OpenBaoRole,
 		OpenBaoKVMount:      env.OpenBaoKVMount,
@@ -566,8 +551,6 @@ func LoadCarrierSecretJob() (*CarrierSecretJobConfig, error) {
 	return &CarrierSecretJobConfig{
 		DatabaseURL:         env.DatabaseURL,
 		ShippingSecretStore: validation.ShippingSecretStore,
-		GCPProjectID:        env.GCPProjectID,
-		SecretNamePrefix:    env.SecretNamePrefix,
 		OpenBaoAddr:         env.OpenBaoAddr,
 		OpenBaoRole:         env.OpenBaoRole,
 		OpenBaoKVMount:      env.OpenBaoKVMount,

--- a/services/marketplace-api/pkg/config/config_test.go
+++ b/services/marketplace-api/pkg/config/config_test.go
@@ -237,14 +237,25 @@ func TestConfig_BaoModeRejectsNonKVMount(t *testing.T) {
 // bao mode still routes legacy gsm:// reads/destroys through GCP Secret
 // Manager, so GCP_PROJECT_ID is a genuine prerequisite for "bao" mode too,
 // not just "gcpsm" — selecting bao without it is a startup error.
-func TestConfig_BaoModeRequiresGCPProjectID(t *testing.T) {
+// GCP_PROJECT_ID used to be REQUIRED in bao mode, on the reasoning that a
+// bao-primary ChainStore still routed legacy gsm:// rows through GCP Secret
+// Manager. mark8ly#621 removed the GCP backend entirely, so that reasoning
+// no longer holds and the variable is dead input.
+//
+// This must be asserted before the env var is removed from the k8s
+// deployments, not after: while Validate still demanded it, deleting the
+// variable from the cluster would have crashlooped both engines at boot.
+// That is the #610 failure mode in reverse — adding a required variable
+// means "cluster first, then code", but removing one means "code first,
+// then cluster".
+func TestConfig_BaoModeNoLongerRequiresGCPProjectID(t *testing.T) {
 	baseEnv(t)
 	t.Setenv("SHIPPING_SECRET_STORE", "bao")
 	t.Setenv("OPENBAO_ROLE", "marketplace-api")
 	t.Setenv("GCP_PROJECT_ID", "")
 
-	if _, err := Load(); err == nil {
-		t.Fatal("Load() with SHIPPING_SECRET_STORE=bao and no GCP_PROJECT_ID = nil, want error")
+	if _, err := Load(); err != nil {
+		t.Fatalf("Load() with SHIPPING_SECRET_STORE=bao and no GCP_PROJECT_ID = %v, want nil", err)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #629. **This must land and deploy before the env vars are removed from the cluster** — see the ordering note below.

## The trap this defuses

`Validate()` still carried `ErrGCPProjectIDRequiredForBao`:

```
GCP_PROJECT_ID must be set when SHIPPING_SECRET_STORE=bao
(legacy gsm:// rows must still resolve through GCP Secret Manager)
```

That justification became false in #629, which removed the GCP client entirely. The check outlived its reason.

So the obvious next step — "drop `GCP_PROJECT_ID` from the deployments" — would have **crashlooped both marketplace-api engines at boot**, because the code still demanded a variable it no longer uses.

That is #610 in reverse, and the two directions have opposite orderings:

- **Adding** a required variable → cluster first, then code.
- **Removing** one → **code first, then cluster.** Dropping a config field while the env var is still set is harmless; envconfig simply ignores it.

The new test `TestConfig_BaoModeNoLongerRequiresGCPProjectID` pins this, and its RED output was the outage itself: `Load() ... = marketplace config: GCP_PROJECT_ID must be set when SHIPPING_SECRET_STORE=bao, want nil`. It replaces `TestConfig_BaoModeRequiresGCPProjectID`, which asserted the now-obsolete requirement.

## `GCP_PROJECT_ID` is NOT dead — scope corrected

#621's checklist says to drop `GCP_PROJECT_ID` from the marketplace-api deployments. **Do not.** `cmd/marketplace-api/main.go:634` still uses it for the merchant-push Pub/Sub publisher:

```go
if cfg.GCPProjectID != "" && cfg.PushEventsTopic != "" {
    pushevents.NewPublisher(ctx, cfg.GCPProjectID, cfg.PushEventsTopic, log)
}
```

Both engines publish — `pushEventsTopic: "mp-merchant-push"` is set on the storefront chart as well as admin. And the failure is **silent**: an unset project skips publishing with only a log line, so removing the variable would disable merchant push notifications without any deployment appearing unhealthy. Exactly the kind of quiet degradation that gets discovered weeks later by a merchant who stopped getting order alerts.

So the field stays in `Config`, with its comment retargeted from carrier secrets to Pub/Sub, plus an explicit warning about the silent-skip behaviour.

## Changes

- `ErrGCPProjectIDRequiredForBao` and its validation branch: **removed**.
- `Config.SecretNamePrefix`: **removed** — genuinely dead once the GCP secret-name builder went in #629.
- `CarrierSecretJobConfig`: both `GCPProjectID` and `SecretNamePrefix` **removed**. No job publishes push events, and the carrier store no longer takes GCP inputs at all.
- `Config.GCPProjectID`: **kept**, comment corrected.

## What the k8s change may now do (next PR, not this one)

- Remove `SECRET_NAME_PREFIX` from both deployments and the refund-sweep CronJob — now genuinely unread.
- Remove `GCP_PROJECT_ID` from the **refund-sweep CronJob only**.
- **Keep `GCP_PROJECT_ID` on both deployments** for merchant push.

## Test plan

- [x] `TestConfig_BaoModeNoLongerRequiresGCPProjectID` verified RED before GREEN
- [x] `go test ./...` — 0 failures
- [x] `go build`, `go vet`, `gofmt` clean
- [x] `scripts/ci/verify-logging-smoke.sh` PASS
- [ ] After deploy: both engines Ready, no config-validation panic
- [ ] After deploy: merchant push still publishing (`GCP_PROJECT_ID` still set)

Refs #319, #621.
