### PR TITLE
feat(billing): cache the console catalog, fail open, and exercise it in production before the cutover (#328)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/catalog_admin_resolve.go
+++ b/services/marketplace-api/cmd/marketplace-api/catalog_admin_resolve.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/consolecatalog"
+	"github.com/mark8ly/marketplace-api/internal/mode"
+	"github.com/mark8ly/marketplace-api/pkg/config"
+)
+
+// resolveTimeout bounds one Resolve's network work. Same reasoning as
+// checkTimeout in catalog_parity.go: nothing waits on the outcome, so it can
+// be generous, but it must be bounded or a hung console pins this goroutine
+// forever.
+const resolveTimeout = 30 * time.Second
+
+// adminResolveLogMsg is the greppable marker for the evidence this whole file
+// exists to produce. `kubectl logs deploy/mark8ly-marketplace-api-admin |
+// grep 'catalog resolve'` is the check that the console read path works; keep
+// the string stable, things outside this repo grep it.
+const adminResolveLogMsg = "consolecatalog: catalog resolve"
+
+// startAdminCatalogResolve exercises consolecatalog.Cache.Resolve on a ticker
+// (tesserix-home#328 phase B). It returns whether it started a goroutine,
+// which is what the wiring tests assert.
+//
+// # The gap it closes
+//
+// The parallel run (startCatalogParityRun) validates the DATA: it fetches the
+// console catalog directly and diffs it against the compiled one. Nothing has
+// ever exercised the code path phase C will actually serve from — the Cache:
+// its cold start, its TTL refresh, its fail-open to last-known, its fallback
+// to the compiled catalog. A missing credential, a blocked egress or a
+// contract-guard rejection would first surface at the moment serving started
+// depending on it. This ticker runs that path now, in production, while
+// nothing depends on the answer.
+//
+// # Why the admin pod, and not the storefront
+//
+// Because every runtime reader of internal/billing/pricing is admin-side.
+// `go list -deps ./internal/handlers/storefront` has no path to
+// billing/pricing or to this package at all; the readers are
+// internal/handlers/platformadmin (money.go), internal/subscription/planchange
+// (the orchestrator and the downgrade-recheck cron, both wired inside the
+// mode.Admin/mode.Both block in main.go) and internal/reconciliation. The
+// plan catalog is what a MERCHANT pays Mark8ly. The storefront sells a
+// merchant's products to that merchant's customers — a different pricing
+// concept that never touches this catalog. Running this on the storefront
+// would exercise a read path that pod will never take, at the cost of
+// doubling the console's read load. So its absence there is deliberate;
+// please do not "fix" the asymmetry.
+//
+// # It decides nothing
+//
+// The Resolution is logged and discarded. Prices still come from
+// internal/billing/pricing through the existing call sites; phase C is what
+// moves those onto Cache.Resolve. This is phase C's code path being
+// EXERCISED, not taken — so a fault found here costs a log line, not a
+// merchant's plan change.
+//
+// # Why this and the parity monitor both run, on the same pod
+//
+// They look redundant and are not. The monitor fetches DIRECTLY every 15m,
+// so each run re-proves the console is reachable and its data still agrees
+// with the compiled catalog. This resolver goes THROUGH the cache, so most
+// ticks are memory hits and it proves something the monitor cannot: that the
+// caching, degradation and fallback layer phase C will serve from behaves.
+// Deliberately no Diff here — the monitor already does that comparison,
+// against the same console catalog and the same compiled catalog in the same
+// process, so repeating it would add no signal and double console load.
+// Neither call site substitutes for the other; collapsing them loses one of
+// the two properties.
+//
+// # Unconfigured is a supported state, not a degraded one
+//
+// Absent credentials mean one log line, no goroutine, and behaviour identical
+// to before this existed — the same contract as startCatalogParityRun, and
+// for the same reason: enabling and disabling this is a config change, with
+// no code path that behaves differently once it is off.
+func startAdminCatalogResolve(m mode.Mode, cfg *config.Config, log *slog.Logger) bool {
+	// mode.Admin and mode.Both — the modes that mount the handlers and start
+	// the crons which read the plan catalog. Asked through RunsAdmin rather
+	// than by comparing constants so this cannot drift from what is actually
+	// wired. main.go around line 613 records what the sloppy version of a
+	// mode gate costs: the audit emitter was built inside the admin-mode
+	// block, so MODE=storefront pods ran with a nil emitter and silently
+	// dropped every storefront event.
+	if !m.RunsAdmin() {
+		return false
+	}
+
+	cc := consolecatalog.Config{
+		CatalogURL:   cfg.ConsoleCatalogURL,
+		TokenURL:     cfg.ConsoleCatalogTokenURL,
+		ClientID:     cfg.ConsoleCatalogClientID,
+		ClientSecret: cfg.ConsoleCatalogClientSecret,
+		Scope:        cfg.ConsoleCatalogScope,
+		Mode:         cfg.ConsoleCatalogMode,
+	}
+	if !cc.Configured() {
+		log.Info("consolecatalog: cache read-path exercise disabled " +
+			"(no console credentials); prices come from the compiled catalog, as before")
+		return false
+	}
+
+	interval := cfg.ConsoleCatalogInterval
+	if interval <= 0 {
+		interval = 15 * time.Minute
+	}
+
+	// Ticking faster than the cache TTL is intentional and cheap: most ticks
+	// are answered from memory (SourceFresh, no console call), so the console
+	// still sees at most one read per TTL from this resolver, while every
+	// tick republishes its state to the logs. The ticks that DO cross the TTL
+	// are the ones that exercise the fetch.
+	cache := consolecatalog.NewCache(
+		consolecatalog.NewClient(cc, log), cfg.ConsoleCatalogCacheTTL, cc.Mode, log)
+
+	log.Info("consolecatalog: cache read-path exercise enabled",
+		"mode", cc.Mode, "interval", interval.String(),
+		"cache_ttl", cfg.ConsoleCatalogCacheTTL.String())
+
+	go func() {
+		// One resolve immediately. This is the interesting one: an empty
+		// cache means it takes the cold-start path — token, fetch, and on
+		// failure the compiled fallback — which is exactly what a freshly
+		// rolled pod would do at the first plan change after the cutover.
+		resolveOnceAndLog(cache, log)
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for range t.C {
+			resolveOnceAndLog(cache, log)
+		}
+	}()
+	return true
+}
+
+// resolveOnceAndLog performs one Resolve and logs its outcome, which is the
+// entire product of this file. The Resolution is returned only so tests can
+// assert on it; the caller above discards it, because nothing in this process
+// is allowed to act on a price from here yet.
+//
+// Resolve never returns an error — a degradation is reported through Source
+// and Err — so this cannot fail, only report.
+func resolveOnceAndLog(c *consolecatalog.Cache, log *slog.Logger) consolecatalog.Resolution {
+	return resolveWithin(resolveTimeout, c, log)
+}
+
+// resolveWithin is resolveOnceAndLog with the deadline as a parameter, so a
+// test can prove the deadline actually reaches the fetcher without waiting
+// out the production one.
+func resolveWithin(timeout time.Duration, c *consolecatalog.Cache, log *slog.Logger) consolecatalog.Resolution {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	res := c.Resolve(ctx)
+
+	attrs := []any{
+		"source", string(res.Source),
+		"stale", res.Stale,
+		"revision_id", res.Catalog.RevisionID,
+		"prices", len(res.Catalog.Prices),
+		"revision_unexpected", res.RevisionUnexpected,
+	}
+	if res.Err != nil {
+		attrs = append(attrs, "error", res.Err)
+	}
+	if log != nil {
+		// Info for a fresh read, warn for anything else. Every non-fresh
+		// resolve is a rehearsal of a post-cutover degradation, so it should
+		// be findable without knowing to look: after phase C the same line at
+		// warn means a plan change was priced from a stale or compiled
+		// catalog rather than from the console.
+		if res.Source == consolecatalog.SourceFresh {
+			log.Info(adminResolveLogMsg, attrs...)
+		} else {
+			log.Warn(adminResolveLogMsg, attrs...)
+		}
+	}
+	return res
+}

--- a/services/marketplace-api/cmd/marketplace-api/catalog_admin_resolve_test.go
+++ b/services/marketplace-api/cmd/marketplace-api/catalog_admin_resolve_test.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/consolecatalog"
+	"github.com/mark8ly/marketplace-api/internal/mode"
+	"github.com/mark8ly/marketplace-api/pkg/config"
+)
+
+// captureHandler collects records so a test can assert on what was logged.
+// The log line IS the deliverable of the resolver, so asserting
+// on it is asserting on the feature, not on an implementation detail.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *captureHandler) all() []slog.Record {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]slog.Record(nil), h.records...)
+}
+
+// find returns the first record whose message contains sub.
+func (h *captureHandler) find(sub string) (slog.Record, bool) {
+	for _, r := range h.all() {
+		if strings.Contains(r.Message, sub) {
+			return r, true
+		}
+	}
+	return slog.Record{}, false
+}
+
+func attrsOf(r slog.Record) map[string]any {
+	out := map[string]any{}
+	r.Attrs(func(a slog.Attr) bool {
+		out[a.Key] = a.Value.Any()
+		return true
+	})
+	return out
+}
+
+func captureLogger() (*slog.Logger, *captureHandler) {
+	h := &captureHandler{}
+	return slog.New(h), h
+}
+
+// fakeFetcher is a consolecatalog.Fetcher whose answer the test controls.
+type fakeFetcher struct {
+	mu  sync.Mutex
+	cat consolecatalog.Catalog
+	err error
+}
+
+func (f *fakeFetcher) Fetch(context.Context) (consolecatalog.Catalog, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.cat, f.err
+}
+
+func (f *fakeFetcher) set(cat consolecatalog.Catalog, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cat, f.err = cat, err
+}
+
+func testCatalog() consolecatalog.Catalog {
+	return consolecatalog.Catalog{
+		Mode:       "test",
+		RevisionID: consolecatalog.SharedRevisionID,
+		Prices: []consolecatalog.Price{
+			{LookupKey: "starter_monthly", Currency: "usd", UnitAmountMinor: 1900},
+		},
+	}
+}
+
+func configuredCfg() *config.Config {
+	return &config.Config{
+		// 127.0.0.1:1 is refused immediately, so the goroutine this starts
+		// cannot sit on a real network call for the length of the test.
+		ConsoleCatalogURL:          "http://127.0.0.1:1/api/v1/billing/catalog",
+		ConsoleCatalogTokenURL:     "http://127.0.0.1:1/oauth/v2/token",
+		ConsoleCatalogClientID:     "id",
+		ConsoleCatalogClientSecret: "secret",
+		ConsoleCatalogMode:         "test",
+		ConsoleCatalogInterval:     time.Hour,
+		ConsoleCatalogCacheTTL:     time.Hour,
+	}
+}
+
+// TestAdminCatalogResolveUnconfigured pins the contract catalog_parity.go
+// states and this file repeats: absent credentials mean no goroutine, no
+// reads, and one clear log line — behaviour identical to before the resolver
+// existed. Enabling it must stay a pure config change.
+func TestAdminCatalogResolveUnconfigured(t *testing.T) {
+	log, h := captureLogger()
+
+	started := startAdminCatalogResolve(mode.Admin, &config.Config{}, log)
+
+	require.False(t, started, "no credentials must mean no goroutine")
+	_, ok := h.find("cache read-path exercise disabled")
+	require.True(t, ok, "unconfigured must say so exactly once, clearly: %v", h.all())
+}
+
+// TestAdminCatalogResolveModeMatrix states the matrix implemented:
+//
+//	admin      -> started (every runtime reader of the plan catalog is here)
+//	storefront -> not started
+//	both       -> started (local dev runs both this and the parity monitor)
+//
+// The storefront case additionally asserts SILENCE rather than a "disabled"
+// line: on the storefront this feature is not disabled, it is not applicable
+// — that pod has no dependency path to internal/billing/pricing at all — and
+// a line claiming otherwise would send someone hunting for credentials that
+// pod is right not to use.
+func TestAdminCatalogResolveModeMatrix(t *testing.T) {
+	for _, tc := range []struct {
+		m    mode.Mode
+		want bool
+	}{
+		{mode.Admin, true},
+		{mode.Storefront, false},
+		{mode.Both, true},
+	} {
+		t.Run(string(tc.m), func(t *testing.T) {
+			log, h := captureLogger()
+
+			got := startAdminCatalogResolve(tc.m, configuredCfg(), log)
+
+			require.Equal(t, tc.want, got)
+			if tc.want {
+				_, ok := h.find("cache read-path exercise enabled")
+				require.True(t, ok, "an enabled resolver must announce itself: %v", h.all())
+			} else {
+				require.Empty(t, h.all(), "a mode that does not run the resolver must log nothing")
+			}
+		})
+	}
+}
+
+// TestResolveOnceLogsFresh is the happy path: a working console read logs at
+// info with the source, revision and price count that make the line evidence
+// rather than noise.
+func TestResolveOnceLogsFresh(t *testing.T) {
+	log, h := captureLogger()
+	f := &fakeFetcher{cat: testCatalog()}
+	cache := consolecatalog.NewCache(f, time.Hour, "test", log)
+
+	res := resolveOnceAndLog(cache, log)
+
+	require.Equal(t, consolecatalog.SourceFresh, res.Source)
+	require.False(t, res.Stale)
+
+	rec, ok := h.find(adminResolveLogMsg)
+	require.True(t, ok, "the resolve must log: %v", h.all())
+	require.Equal(t, slog.LevelInfo, rec.Level)
+
+	a := attrsOf(rec)
+	require.Equal(t, "fresh", a["source"])
+	require.Equal(t, false, a["stale"])
+	require.Equal(t, consolecatalog.SharedRevisionID, a["revision_id"])
+	require.Equal(t, int64(1), a["prices"])
+	require.Equal(t, false, a["revision_unexpected"])
+	require.NotContains(t, a, "error")
+}
+
+// TestResolveOnceLogsColdStartFallback covers the case the cutover most needs
+// to survive: a freshly rolled pod that has never reached the console. It must
+// answer from the compiled catalog, log it, and not panic — a pod that cannot
+// price a plan change is an outage, a pod pricing from the compiled snapshot
+// is not.
+func TestResolveOnceLogsColdStartFallback(t *testing.T) {
+	log, h := captureLogger()
+	f := &fakeFetcher{err: errors.New("dial tcp: connection refused")}
+	cache := consolecatalog.NewCache(f, time.Hour, "test", log)
+
+	res := resolveOnceAndLog(cache, log)
+
+	require.Equal(t, consolecatalog.SourceCompiled, res.Source)
+	require.True(t, res.Stale)
+	require.NotEmpty(t, res.Catalog.Prices, "the compiled fallback must not be empty")
+
+	rec, ok := h.find(adminResolveLogMsg)
+	require.True(t, ok, "a degraded resolve must still log: %v", h.all())
+	require.Equal(t, slog.LevelWarn, rec.Level)
+
+	a := attrsOf(rec)
+	require.Equal(t, "compiled", a["source"])
+	require.Equal(t, true, a["stale"])
+	require.Contains(t, a, "error")
+}
+
+// TestResolveOnceLogsStaleAfterFailedRefresh is the fail-open property seen
+// from the caller's side: once a good catalog has been read, a later console
+// failure must serve that catalog rather than evict it, and must say so.
+func TestResolveOnceLogsStaleAfterFailedRefresh(t *testing.T) {
+	log, _ := captureLogger()
+	f := &fakeFetcher{cat: testCatalog()}
+	// A one-nanosecond TTL expires between the two resolves without the test
+	// having to sleep out a real window.
+	cache := consolecatalog.NewCache(f, time.Nanosecond, "test", log)
+
+	require.Equal(t, consolecatalog.SourceFresh, resolveOnceAndLog(cache, log).Source)
+
+	f.set(consolecatalog.Catalog{}, errors.New("console 503"))
+	log2, h2 := captureLogger()
+	res := resolveOnceAndLog(cache, log2)
+
+	require.Equal(t, consolecatalog.SourceStale, res.Source)
+	require.True(t, res.Stale)
+	require.Equal(t, consolecatalog.SharedRevisionID, res.Catalog.RevisionID,
+		"a failed refresh must not evict the last-known catalog")
+
+	rec, ok := h2.find(adminResolveLogMsg)
+	require.True(t, ok, "a stale resolve must still log: %v", h2.all())
+	require.Equal(t, slog.LevelWarn, rec.Level)
+	require.Equal(t, "stale", attrsOf(rec)["source"])
+}
+
+// TestResolveOnceDoesNotBlockOnAHangingConsole guards the reason resolveTimeout
+// exists. A console that accepts the connection and never answers must not pin
+// the ticker goroutine: the context deadline has to reach the fetcher.
+func TestResolveOnceDoesNotBlockOnAHangingConsole(t *testing.T) {
+	log, h := captureLogger()
+	cache := consolecatalog.NewCache(hangingFetcher{}, time.Hour, "test", log)
+
+	done := make(chan consolecatalog.Resolution, 1)
+	go func() { done <- resolveWithin(100*time.Millisecond, cache, log) }()
+
+	select {
+	case res := <-done:
+		require.Equal(t, consolecatalog.SourceCompiled, res.Source)
+		_, ok := h.find(adminResolveLogMsg)
+		require.True(t, ok)
+	case <-time.After(5 * time.Second):
+		t.Fatal("resolveOnceAndLog blocked on a hanging console")
+	}
+}
+
+// hangingFetcher blocks until the caller's context is done, which is what a
+// console that accepts a connection and never replies looks like from here.
+type hangingFetcher struct{}
+
+func (hangingFetcher) Fetch(ctx context.Context) (consolecatalog.Catalog, error) {
+	<-ctx.Done()
+	return consolecatalog.Catalog{}, ctx.Err()
+}

--- a/services/marketplace-api/cmd/marketplace-api/catalog_parity.go
+++ b/services/marketplace-api/cmd/marketplace-api/catalog_parity.go
@@ -31,6 +31,26 @@ const checkTimeout = 30 * time.Second
 // the console one bad deploy away from the payment path even when cached.
 // On its own ticker it cannot, whatever it does.
 //
+// # Why this fetches directly and NOT through consolecatalog.Cache
+//
+// Deliberate, and revisited when the cache landed (tesserix-home#328). This
+// monitor's output is evidence of two things: that the console's data agrees
+// with the compiled catalog, and that the console is reachable from this
+// service every interval. Routing it through the Cache would destroy the
+// second: with a 6h TTL and a 15m interval, ~23 of every 24 checks would be
+// answered from memory and would re-compare bytes already compared, while a
+// console that went down would keep producing "parity clean" until the TTL
+// expired. A monitor that reports healthy through an outage is worse than no
+// monitor.
+//
+// The cache is exercised instead by startAdminCatalogResolve in
+// catalog_admin_resolve.go, which runs on this same pod and has the opposite
+// job: it proves the READ PATH — token, fetch, cache, fail-open, compiled
+// fallback — works, which is what phase C will serve from. Two jobs, two
+// call sites on one pod, neither substituting for the other. When phase C
+// moves serving onto the Cache, that is where the cached read belongs; this
+// monitor should keep reading directly for as long as it exists.
+//
 // # Unconfigured is a supported state, not a degraded one
 //
 // Absent credentials mean no goroutine, no reads, and behaviour identical to

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1004,6 +1004,20 @@ func main() {
 		// invariant. Unconfigured, nothing is started at all.
 		startCatalogParityRun(cfg, log)
 
+		// tesserix-home#328 phase B — exercise the Cache's READ PATH.
+		//
+		// Sits beside the parity run because both belong on the pod that
+		// reads the plan catalog, and does a deliberately different job: the
+		// monitor above fetches directly to evidence reachability and data
+		// agreement, this one resolves through the cache to exercise what
+		// phase C will serve from (platformadmin/money.go, planchange,
+		// reconciliation — all admin-side). It logs and discards; prices
+		// still come from the compiled catalog. It carries its own
+		// m.RunsAdmin() gate rather than relying on this block, so the mode
+		// contract is stated and tested in one place.
+		// See catalog_admin_resolve.go.
+		startAdminCatalogResolve(m, cfg, log)
+
 		subscriptionSvc := subscription.NewService(subscription.ServiceConfig{
 			DB:     conn,
 			Repo:   subscriptionRepo,

--- a/services/marketplace-api/internal/billing/consolecatalog/cache.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/cache.go
@@ -1,0 +1,351 @@
+package consolecatalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+)
+
+// Source names which of the three tiers answered a Resolve.
+//
+// It is part of the result rather than only a log line because the caller
+// has to be able to act on it: the question the cutover must be able to
+// answer continuously is "how often did this service price from something
+// other than a fresh console read", and a degradation nobody can count is a
+// degradation nobody notices.
+type Source string
+
+const (
+	// SourceFresh — a cached catalog younger than the TTL, or one just
+	// fetched successfully.
+	SourceFresh Source = "fresh"
+	// SourceStale — a previously fetched catalog now past its TTL, served
+	// because the refresh failed. Fail-open: a price from last week is
+	// enormously better than no price on a checkout path.
+	SourceStale Source = "stale"
+	// SourceCompiled — internal/billing/pricing, the snapshot baked into the
+	// binary. This is what makes a cold start during a console outage
+	// survivable: a pod that has never reached the console still holds a
+	// complete, correct catalog.
+	SourceCompiled Source = "compiled"
+)
+
+// DefaultTTL is deliberately long. The catalog changes a few times a year,
+// so a stale window measured in hours costs nothing and keeps the console
+// far away from anything a customer waits on. Shortening this does not make
+// prices more correct; it only multiplies the number of requests that can
+// discover the console is down.
+const DefaultTTL = 6 * time.Hour
+
+// SharedRevisionID is the revision BOTH the console's test and live
+// publications named when the two were last verified identical: on
+// 2026-09-03 each served 78 rows with a symmetric difference of 0.
+//
+// That equivalence is load-bearing evidence, not trivia. It is the whole
+// reason mark8ly's test-mode comparison is accepted as evidence for live,
+// and why no separate live-mode observation window was required
+// (tesserix-home#328).
+//
+// The premise expires the moment the console can publish to live
+// independently of test — which is exactly what tesserix-home#327 phase P2b
+// enables. So it is asserted here rather than remembered: a catalog naming
+// any other revision means the verification above no longer covers what is
+// running, and someone must re-verify the two modes before leaning on
+// test-mode evidence again.
+//
+// Reading a different revision is NOT itself proof that the modes diverged —
+// a legitimate republish moves the id too. It only proves the check is
+// stale, which is why it is reported and not refused.
+const SharedRevisionID = "00000000-0000-0000-0000-000000000001"
+
+// Resolution is one answer from the Cache, plus everything a caller needs to
+// know about how much to trust it.
+type Resolution struct {
+	Catalog Catalog
+	// Source names which tier answered. Never empty.
+	Source Source
+	// Stale is true whenever Source is not SourceFresh. Redundant with
+	// Source by construction, and deliberately so: the one question every
+	// caller asks is "is this current", and answering it should not require
+	// knowing the tier vocabulary.
+	Stale bool
+	// FetchedAt is when the served catalog was read from the console. Zero
+	// for SourceCompiled, which was never read from anywhere.
+	FetchedAt time.Time
+	// Err is the console read error that forced the degradation, nil when
+	// Source is SourceFresh. It is carried, not returned, because Resolve
+	// does not fail — Source already says what happened, and an error return
+	// would tempt a caller into treating a degraded answer as no answer.
+	Err error
+	// RevisionUnexpected reports that the served catalog names a revision
+	// other than SharedRevisionID — see that constant for why anyone cares.
+	// Always false for SourceCompiled, which has no console revision to check.
+	RevisionUnexpected bool
+}
+
+// Cache resolves the plan catalog through fresh -> last-known -> compiled.
+//
+// # The property this type exists to hold
+//
+// A failed refresh must never evict a good value. Every degradation path
+// below either returns what was already held or falls through to the
+// compiled catalog; none of them writes. An outage degrades to stale, never
+// to empty.
+//
+// # Where this sits relative to Client
+//
+// Client already retains its last body and ETag so it can answer a 304 with
+// a real catalog. That retention solves a different problem — the console
+// sends Cache-Control: no-cache with an ETag, so every read revalidates and
+// a 304 carries no body — and it only survives a SUCCESSFUL round trip.
+// This cache sits above it and covers the cases Client deliberately does
+// not: no round trip at all (fresh hit inside the TTL), a round trip that
+// failed (stale), and a process that has never had one (compiled). Neither
+// layer duplicates the other, and this one never inspects ETags.
+//
+// # It resolves nothing on its own
+//
+// Nothing wires this to serving yet. Prices still come from
+// internal/billing/pricing via the existing call sites; this type is built
+// and tested first so the cutover is one deliberate change rather than a
+// cutover plus an untested cache.
+type Cache struct {
+	fetcher Fetcher
+	ttl     time.Duration
+	mode    string
+	logger  *slog.Logger
+	// now is injectable so TTL expiry is testable without sleeping. Tests
+	// that sleep to cross a boundary are slow and flaky in equal measure.
+	now func() time.Time
+
+	// group collapses concurrent misses into one console call. Without it a
+	// pod that wakes up with an expired entry aims its whole in-flight
+	// request set at the console at once — the exact stampede that turns a
+	// slow console into a failed one.
+	group singleflight.Group
+
+	mu       sync.RWMutex
+	cached   Catalog
+	cachedAt time.Time
+	have     bool
+}
+
+// NewCache builds a Cache. A ttl of zero or less takes DefaultTTL; mode is
+// the mode the caller configured, used by the contract guard below.
+func NewCache(f Fetcher, ttl time.Duration, mode string, logger *slog.Logger) *Cache {
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	return &Cache{fetcher: f, ttl: ttl, mode: mode, logger: logger, now: time.Now}
+}
+
+// Resolve returns the best catalog available, never an error.
+//
+// The tiers are tried in order and the first that can answer wins:
+//
+//  1. fresh    — a cached catalog younger than the TTL; no console call
+//  2. stale    — the last good catalog, when the refresh failed
+//  3. compiled — internal/billing/pricing, when nothing was ever cached
+//
+// Every fallback is logged, because a service silently pricing from a
+// week-old catalog is indistinguishable from a healthy one until someone
+// looks at the amounts.
+func (c *Cache) Resolve(ctx context.Context) Resolution {
+	if res, ok := c.fresh(); ok {
+		return res
+	}
+
+	// singleflight.Do, not DoChan: the waiters want the same answer, and a
+	// caller whose ctx is cancelled mid-flight still gets a usable
+	// resolution below rather than an error, so there is nothing to select
+	// on. `shared` is ignored — which goroutine actually made the call is
+	// not information any caller acts on.
+	v, err, _ := c.group.Do("refresh", func() (any, error) {
+		// Re-check under the flight: while this goroutine was queueing, the
+		// previous flight may have refreshed the entry. Without this the
+		// first waiter after a successful refresh issues a second,
+		// pointless console call.
+		if res, ok := c.fresh(); ok {
+			return res, nil
+		}
+		return c.refresh(ctx)
+	})
+	if err == nil {
+		return v.(Resolution)
+	}
+
+	// From here the console did not answer. Nothing below writes to the
+	// cache: a failed read must not be able to change what is held.
+	if res, ok := c.lastKnown(err); ok {
+		c.warn("consolecatalog: console read failed; serving the last-known catalog",
+			"error", err, "age", c.now().Sub(res.FetchedAt).String(),
+			"revision_id", res.Catalog.RevisionID)
+		return res
+	}
+
+	// Cold start during an outage. ErrNotPublished lands here too, and that
+	// is correct: "this mode has never been published" is a reason to price
+	// from the compiled snapshot, never a reason to hold zero prices. It is
+	// carried on Err distinctly from ErrUnavailable so the two remain
+	// tellable apart by whoever reads the logs.
+	c.warn("consolecatalog: no console catalog available; falling back to the compiled catalog",
+		"error", err, "not_published", errors.Is(err, ErrNotPublished))
+	return Resolution{
+		Catalog: CompiledCatalog(c.mode),
+		Source:  SourceCompiled,
+		Stale:   true,
+		Err:     err,
+	}
+}
+
+// fresh returns the cached catalog when it is still inside the TTL.
+func (c *Cache) fresh() (Resolution, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if !c.have || c.now().Sub(c.cachedAt) >= c.ttl {
+		return Resolution{}, false
+	}
+	return Resolution{
+		Catalog:            c.cached,
+		Source:             SourceFresh,
+		FetchedAt:          c.cachedAt,
+		RevisionUnexpected: c.cached.RevisionID != SharedRevisionID,
+	}, true
+}
+
+// lastKnown returns the cached catalog regardless of age, for use when the
+// refresh failed.
+func (c *Cache) lastKnown(cause error) (Resolution, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if !c.have {
+		return Resolution{}, false
+	}
+	return Resolution{
+		Catalog:            c.cached,
+		Source:             SourceStale,
+		Stale:              true,
+		FetchedAt:          c.cachedAt,
+		Err:                cause,
+		RevisionUnexpected: c.cached.RevisionID != SharedRevisionID,
+	}, true
+}
+
+// refresh reads the console and, only on success, replaces what is held.
+func (c *Cache) refresh(ctx context.Context) (Resolution, error) {
+	cat, err := c.fetcher.Fetch(ctx)
+	if err != nil {
+		return Resolution{}, err
+	}
+	if err := c.guard(cat); err != nil {
+		// A catalog that fails the contract guard is not stored. Treating a
+		// wrong-mode response as good would silently overwrite correct
+		// prices with another mode's, which is worse than any outage this
+		// package is designed to survive.
+		return Resolution{}, err
+	}
+
+	now := c.now()
+	c.mu.Lock()
+	c.cached, c.cachedAt, c.have = cat, now, true
+	c.mu.Unlock()
+
+	res := Resolution{
+		Catalog:            cat,
+		Source:             SourceFresh,
+		FetchedAt:          now,
+		RevisionUnexpected: cat.RevisionID != SharedRevisionID,
+	}
+	if res.RevisionUnexpected {
+		c.warn("consolecatalog: catalog revision is not the one the test-for-live "+
+			"equivalence was verified against; that verification is now stale and "+
+			"must be redone before test-mode evidence is used for live "+
+			"(tesserix-home#328; #327 P2b is what lets the modes diverge)",
+			"revision_id", cat.RevisionID, "verified_revision_id", SharedRevisionID,
+			"mode", cat.Mode)
+	}
+	return res, nil
+}
+
+// guard rejects a response that contradicts the configured mode.
+//
+// The service reads exactly one mode and asks for it by query parameter, so
+// a response labelled another one means the console answered a question
+// nobody asked. Refusing keeps the failure loud and bounded — the caller
+// degrades to stale or compiled — instead of quietly pricing live customers
+// from the test catalog or the reverse. This does NOT reach across modes to
+// compare them: one process reads one mode, and cross-mode comparison is the
+// console's job, not this service's.
+func (c *Cache) guard(cat Catalog) error {
+	if c.mode != "" && cat.Mode != "" && cat.Mode != c.mode {
+		return fmt.Errorf("%w: console answered mode %q for a %q request",
+			ErrUnavailable, cat.Mode, c.mode)
+	}
+	return nil
+}
+
+func (c *Cache) warn(msg string, args ...any) {
+	if c.logger != nil {
+		c.logger.Warn(msg, args...)
+	}
+}
+
+// compiledRevisionID marks a catalog as having come from the binary rather
+// than from any console publication. It is not a uuid on purpose: anything
+// that logs or compares a revision should be unable to mistake this for one
+// the console issued.
+const compiledRevisionID = "compiled"
+
+// CompiledCatalog projects internal/billing/pricing into the console's
+// Catalog shape, so the fallback tier answers with the same type as the
+// other two and callers need no second code path.
+//
+// It flattens descriptors one row per currency, exactly as compare.go's
+// compiledRows does and for the same two reasons: a developed-tier
+// descriptor is one Price object carrying seven currencies, and Options is
+// pre-populated with zero-value entries for currencies that have no price,
+// which must be skipped rather than emitted as an amount of zero. Getting
+// that wrong here would hand a checkout a price of nothing.
+func CompiledCatalog(mode string) Catalog {
+	descriptors := pricing.AllDescriptors()
+	out := Catalog{
+		Mode:       mode,
+		RevisionID: compiledRevisionID,
+		Prices:     make([]Price, 0, len(descriptors)),
+	}
+	for _, d := range descriptors {
+		for cur, amt := range d.Options {
+			if amt.Currency == "" {
+				continue
+			}
+			out.Prices = append(out.Prices, Price{
+				LookupKey:       d.LookupKey,
+				Plan:            string(d.Plan),
+				Period:          string(d.Period),
+				Tier:            string(d.Tier),
+				Currency:        cur,
+				UnitAmountMinor: amt.UnitAmountMinor,
+				TaxBehavior:     amt.TaxBehavior,
+			})
+		}
+	}
+	// Map iteration order is random, so without this two calls in the same
+	// process return the same prices in a different order. Sorted, the
+	// fallback catalog is byte-comparable between calls and a test that
+	// compares two projections is not flaky.
+	sort.Slice(out.Prices, func(i, j int) bool {
+		if out.Prices[i].LookupKey != out.Prices[j].LookupKey {
+			return out.Prices[i].LookupKey < out.Prices[j].LookupKey
+		}
+		return out.Prices[i].Currency < out.Prices[j].Currency
+	})
+	return out
+}

--- a/services/marketplace-api/internal/billing/consolecatalog/cache_test.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/cache_test.go
@@ -1,0 +1,443 @@
+package consolecatalog
+
+// These tests are in the package rather than consolecatalog_test so they can
+// drive the cache's injected clock. TTL expiry tested by sleeping would make
+// the suite both slow and flaky, and the fail-open behaviour is exactly the
+// thing that must not be tested approximately.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+)
+
+// fakeClock is a hand-advanced clock. Every test moves time explicitly, so
+// no test depends on how long it took to run.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newClock() *fakeClock {
+	return &fakeClock{t: time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// fakeFetcher answers with whatever the test currently wants and counts
+// calls, so "did not touch the console" is an assertion and not an
+// assumption.
+type fakeFetcher struct {
+	mu      sync.Mutex
+	calls   int32
+	catalog Catalog
+	err     error
+	// before runs inside Fetch, used to widen the window the single-flight
+	// test needs to observe concurrent misses.
+	before func()
+}
+
+func (f *fakeFetcher) Fetch(context.Context) (Catalog, error) {
+	atomic.AddInt32(&f.calls, 1)
+	if f.before != nil {
+		f.before()
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.catalog, f.err
+}
+
+func (f *fakeFetcher) set(cat Catalog, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.catalog, f.err = cat, err
+}
+
+func (f *fakeFetcher) count() int32 { return atomic.LoadInt32(&f.calls) }
+
+const testTTL = time.Hour
+
+// consoleCatalog builds a minimal well-formed console response. The contents
+// do not matter to the cache — it never inspects an amount — so one row is
+// enough to tell two catalogs apart.
+func consoleCatalog(mode, revision string, amount int64) Catalog {
+	return Catalog{
+		Mode:        mode,
+		RevisionID:  revision,
+		PublishedAt: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+		Prices: []Price{{
+			LookupKey:       "starter_monthly_developed",
+			Plan:            "starter",
+			Period:          "monthly",
+			Tier:            "developed",
+			Currency:        "usd",
+			UnitAmountMinor: amount,
+		}},
+	}
+}
+
+func newTestCache(f Fetcher, clock *fakeClock, mode string) *Cache {
+	c := NewCache(f, testTTL, mode, nil)
+	c.now = clock.now
+	return c
+}
+
+func TestCacheResolveTiers(t *testing.T) {
+	catalogA := consoleCatalog("test", SharedRevisionID, 1900)
+	catalogB := consoleCatalog("test", SharedRevisionID, 2100)
+
+	tests := []struct {
+		name string
+		// prime, when set, is fetched and cached before the case's own
+		// setup runs — it is how a case distinguishes "nothing was ever
+		// cached" from "a good value is held".
+		prime      *Catalog
+		advance    time.Duration
+		then       Catalog
+		thenErr    error
+		wantSource Source
+		wantStale  bool
+		wantAmount int64 // 0 means "expect the compiled catalog instead"
+		wantErrIs  error
+		// wantExtraCalls counts console reads AFTER priming.
+		wantExtraCalls int32
+	}{
+		{
+			name:           "fresh inside the TTL never touches the console",
+			prime:          &catalogA,
+			advance:        testTTL - time.Minute,
+			thenErr:        ErrUnavailable, // would fail if it were called
+			wantSource:     SourceFresh,
+			wantAmount:     1900,
+			wantExtraCalls: 0,
+		},
+		{
+			name:           "expired and the console answers returns the new value",
+			prime:          &catalogA,
+			advance:        testTTL,
+			then:           catalogB,
+			wantSource:     SourceFresh,
+			wantAmount:     2100,
+			wantExtraCalls: 1,
+		},
+		{
+			// The fail-open property, and the reason this package exists:
+			// an outage must degrade to a stale price, never to no price.
+			name:           "expired and the console is down returns the last-known value, flagged stale",
+			prime:          &catalogA,
+			advance:        testTTL,
+			thenErr:        ErrUnavailable,
+			wantSource:     SourceStale,
+			wantStale:      true,
+			wantAmount:     1900,
+			wantErrIs:      ErrUnavailable,
+			wantExtraCalls: 1,
+		},
+		{
+			// A cold pod during a console outage must not itself be the
+			// outage. The compiled snapshot ships in the binary for exactly
+			// this moment.
+			name:           "cold start with the console down falls back to the compiled catalog",
+			advance:        0,
+			thenErr:        ErrUnavailable,
+			wantSource:     SourceCompiled,
+			wantStale:      true,
+			wantErrIs:      ErrUnavailable,
+			wantExtraCalls: 1,
+		},
+		{
+			// 404 means "this mode was never published", which is a reason
+			// to price from the binary — never a reason to hold zero
+			// prices. It must also stay distinguishable from ErrUnavailable.
+			name:           "cold start with an unpublished mode falls back to the compiled catalog",
+			thenErr:        ErrNotPublished,
+			wantSource:     SourceCompiled,
+			wantStale:      true,
+			wantErrIs:      ErrNotPublished,
+			wantExtraCalls: 1,
+		},
+		{
+			name:           "an unpublished mode does not evict a good value",
+			prime:          &catalogA,
+			advance:        testTTL,
+			thenErr:        ErrNotPublished,
+			wantSource:     SourceStale,
+			wantStale:      true,
+			wantAmount:     1900,
+			wantErrIs:      ErrNotPublished,
+			wantExtraCalls: 1,
+		},
+		{
+			// The mode guard. A response labelled another mode is refused
+			// rather than stored: overwriting correct prices with the other
+			// mode's is worse than any outage this cache survives.
+			name:           "a wrong-mode response is refused and does not evict a good value",
+			prime:          &catalogA,
+			advance:        testTTL,
+			then:           consoleCatalog("live", SharedRevisionID, 9900),
+			wantSource:     SourceStale,
+			wantStale:      true,
+			wantAmount:     1900,
+			wantErrIs:      ErrUnavailable,
+			wantExtraCalls: 1,
+		},
+		{
+			name:           "a wrong-mode response on a cold start falls back to the compiled catalog",
+			then:           consoleCatalog("live", SharedRevisionID, 9900),
+			wantSource:     SourceCompiled,
+			wantStale:      true,
+			wantErrIs:      ErrUnavailable,
+			wantExtraCalls: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := newClock()
+			f := &fakeFetcher{}
+			c := newTestCache(f, clock, "test")
+
+			if tc.prime != nil {
+				f.set(*tc.prime, nil)
+				primed := c.Resolve(context.Background())
+				require.Equal(t, SourceFresh, primed.Source, "priming must succeed")
+				require.Equal(t, int32(1), f.count())
+			}
+			base := f.count()
+
+			f.set(tc.then, tc.thenErr)
+			clock.advance(tc.advance)
+
+			res := c.Resolve(context.Background())
+
+			require.Equal(t, tc.wantSource, res.Source)
+			require.Equal(t, tc.wantStale, res.Stale)
+			require.Equal(t, tc.wantExtraCalls, f.count()-base, "console reads after priming")
+
+			if tc.wantErrIs != nil {
+				require.ErrorIs(t, res.Err, tc.wantErrIs)
+			} else {
+				require.NoError(t, res.Err)
+			}
+
+			if tc.wantAmount != 0 {
+				require.Len(t, res.Catalog.Prices, 1)
+				require.Equal(t, tc.wantAmount, res.Catalog.Prices[0].UnitAmountMinor)
+				return
+			}
+
+			// The compiled tier must answer with a COMPLETE catalog, not a
+			// token one: a fallback that returns three prices would be an
+			// outage wearing a success's clothing. Zero differences against
+			// the compiled descriptors is the strongest available statement
+			// of that.
+			require.NotEmpty(t, res.Catalog.Prices)
+			require.Empty(t, Diff(res.Catalog, pricing.AllDescriptors()))
+		})
+	}
+}
+
+// The revision guard. It reports, and does not refuse: a republish moves the
+// id legitimately. What it asserts is that the test-for-live equivalence
+// verified on 2026-09-03 still covers what is running.
+func TestCacheRevisionGuard(t *testing.T) {
+	tests := []struct {
+		name     string
+		revision string
+		want     bool
+	}{
+		{"the verified shared revision is expected", SharedRevisionID, false},
+		{"any other revision is reported", "11111111-1111-1111-1111-111111111111", true},
+		{"an absent revision is reported", "", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := newClock()
+			f := &fakeFetcher{}
+			f.set(consoleCatalog("test", tc.revision, 1900), nil)
+			c := newTestCache(f, clock, "test")
+
+			fresh := c.Resolve(context.Background())
+			require.Equal(t, SourceFresh, fresh.Source)
+			require.Equal(t, tc.want, fresh.RevisionUnexpected)
+
+			// It must survive into the degraded answer too — a stale price
+			// carrying an unverified revision is exactly the combination
+			// someone needs to see.
+			clock.advance(testTTL)
+			f.set(Catalog{}, ErrUnavailable)
+			stale := c.Resolve(context.Background())
+			require.Equal(t, SourceStale, stale.Source)
+			require.Equal(t, tc.want, stale.RevisionUnexpected)
+		})
+	}
+}
+
+// The compiled tier never claims a console revision, so nothing can mistake
+// the binary's snapshot for a publication.
+func TestCompiledResolutionCarriesNoConsoleRevision(t *testing.T) {
+	f := &fakeFetcher{}
+	f.set(Catalog{}, ErrUnavailable)
+	c := newTestCache(f, newClock(), "test")
+
+	res := c.Resolve(context.Background())
+	require.Equal(t, SourceCompiled, res.Source)
+	require.False(t, res.RevisionUnexpected)
+	require.Equal(t, compiledRevisionID, res.Catalog.RevisionID)
+	require.Equal(t, "test", res.Catalog.Mode)
+	require.True(t, res.FetchedAt.IsZero(), "the compiled catalog was never fetched from anywhere")
+}
+
+func TestCompiledCatalogIsCompleteAndOrdered(t *testing.T) {
+	a := CompiledCatalog("test")
+	b := CompiledCatalog("test")
+
+	require.NotEmpty(t, a.Prices)
+	require.Equal(t, a.Prices, b.Prices, "two projections must agree despite map iteration order")
+	require.Empty(t, Diff(a, pricing.AllDescriptors()))
+	for _, p := range a.Prices {
+		require.NotZero(t, p.UnitAmountMinor, "a zero amount would price a checkout at nothing: %+v", p)
+		require.NotEmpty(t, p.Currency)
+		require.NotEmpty(t, p.LookupKey)
+	}
+}
+
+// A stampede must reach the console once. Without single-flight, a pod whose
+// entry has just expired aims its whole in-flight request set at the console
+// at the same instant.
+func TestCacheConcurrentMissesCollapseToOneCall(t *testing.T) {
+	const goroutines = 64
+
+	release := make(chan struct{})
+	f := &fakeFetcher{before: func() { <-release }}
+	f.set(consoleCatalog("test", SharedRevisionID, 1900), nil)
+	c := newTestCache(f, newClock(), "test")
+
+	var start, done sync.WaitGroup
+	start.Add(goroutines)
+	done.Add(goroutines)
+	results := make([]Resolution, goroutines)
+	for i := range results {
+		go func(i int) {
+			defer done.Done()
+			start.Done()
+			results[i] = c.Resolve(context.Background())
+		}(i)
+	}
+	start.Wait()
+	close(release)
+	done.Wait()
+
+	require.Equal(t, int32(1), f.count(), "concurrent misses must not stampede the console")
+	for i, res := range results {
+		require.Equal(t, SourceFresh, res.Source, "goroutine %d", i)
+		require.Len(t, res.Catalog.Prices, 1, "goroutine %d", i)
+	}
+}
+
+// Concurrent readers of a warm cache, for -race. The refresher runs
+// alongside them so the read lock and the write lock are actually contended.
+func TestCacheConcurrentReadersAndRefresh(t *testing.T) {
+	clock := newClock()
+	f := &fakeFetcher{}
+	f.set(consoleCatalog("test", SharedRevisionID, 1900), nil)
+	c := newTestCache(f, clock, "test")
+	require.Equal(t, SourceFresh, c.Resolve(context.Background()).Source)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				res := c.Resolve(context.Background())
+				// Whatever the tier, a resolution always carries prices.
+				// There is no path through this cache that answers nothing.
+				require.NotEmpty(t, res.Catalog.Prices)
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < 10; j++ {
+			clock.advance(testTTL)
+			c.Resolve(context.Background())
+		}
+	}()
+	wg.Wait()
+}
+
+// The distinction the whole package rests on: "we could not ask" and "there
+// are no prices" must never converge, at any tier.
+func TestCacheNeverAnswersWithNoPrices(t *testing.T) {
+	for _, err := range []error{ErrUnavailable, ErrNotPublished, errors.New("some transport failure")} {
+		f := &fakeFetcher{}
+		f.set(Catalog{}, err)
+		c := newTestCache(f, newClock(), "test")
+
+		res := c.Resolve(context.Background())
+		require.NotEmpty(t, res.Catalog.Prices, "error %v produced an empty catalog", err)
+	}
+}
+
+// The compiled fallback must be COMPLETE, not merely non-empty.
+//
+// SourceCompiled is what a cold-start pod serves during a console outage, on
+// the checkout path. A fallback that is present but missing currencies would
+// be worse than the compiled map this service serves today: checkout would
+// break for exactly the countries whose rows were dropped, and every other
+// test here would still pass because they only assert that prices came back.
+//
+// The numbers are the console's own, measured against production on
+// 2026-09-03: the published catalog holds 42 prices which flatten to 78
+// (lookup_key, currency) rows -- the same 42/78 relationship
+// `catalog.go` documents for the console's response shape. Pinning them here
+// asserts that the compiled projection covers the published catalog exactly,
+// so a descriptor or a currency lost from `pricing` fails here rather than
+// during an outage.
+//
+// If a deliberate catalog change moves these numbers, the console's
+// published catalog has to move with them -- that is the point, not an
+// inconvenience: the two are meant to agree, and `Diff` is what proves they
+// still do.
+func TestCompiledCatalogCoversThePublishedCatalog(t *testing.T) {
+	for _, mode := range []string{"test", "live"} {
+		t.Run(mode, func(t *testing.T) {
+			cat := CompiledCatalog(mode)
+
+			keys := make(map[string]struct{}, len(cat.Prices))
+			for _, p := range cat.Prices {
+				keys[p.LookupKey] = struct{}{}
+			}
+
+			require.Equal(t, 78, len(cat.Prices),
+				"compiled fallback must flatten to the same 78 (lookup_key, currency) rows the console publishes")
+			require.Equal(t, 42, len(keys),
+				"compiled fallback must carry all 42 lookup keys the console publishes")
+
+			// Mode travels with the answer even on the tier that never read
+			// the console, so a caller logging the resolution cannot report a
+			// live-mode degradation as a test-mode one.
+			require.Equal(t, mode, cat.Mode)
+		})
+	}
+}

--- a/services/marketplace-api/pkg/config/config.go
+++ b/services/marketplace-api/pkg/config/config.go
@@ -119,6 +119,13 @@ type Config struct {
 	ConsoleCatalogScope    string        `envconfig:"CONSOLE_CATALOG_SCOPE" default:""`
 	ConsoleCatalogMode     string        `envconfig:"CONSOLE_CATALOG_MODE" default:"test"`
 	ConsoleCatalogInterval time.Duration `envconfig:"CONSOLE_CATALOG_INTERVAL" default:"15m"`
+	// How long a fetched catalog stays fresh before the cache tries the
+	// console again. Generous on purpose: the catalog changes a few times a
+	// year, so a long TTL costs no correctness and keeps the console off
+	// anything a customer waits on. A short TTL would not make prices more
+	// current — it would only multiply the reads that can discover an
+	// outage. Zero or negative takes consolecatalog.DefaultTTL.
+	ConsoleCatalogCacheTTL time.Duration `envconfig:"CONSOLE_CATALOG_CACHE_TTL" default:"6h"`
 
 	// RESEND_WEBHOOK_SECRET verifies inbound provider delivery events
 	// (#348B). Empty leaves the endpoint mounted but inert: it answers 503


### PR DESCRIPTION
Phases A and B of tesserix/tesserix-home#328 — *marketplace-api reads the plan catalog from the console, cached and fail-open*.

**This changes no prices.** Nothing here is wired to serving; the compiled `internal/billing/pricing` catalog remains the only source of a served amount. The cutover is a separate, deliberate change (phase C), and this PR exists so that when it happens the machinery underneath it has already been running in production.

## Why this is two phases and not one

The cutover puts a network read behind pricing. §P's constraint is that nothing on a customer payment path may depend on the console being reachable — so the read must be cached, fail open to last-known, and fall back to a baked snapshot on a cold start. `consolecatalog`'s package doc has described that cache since the package was created and called it "the entire reason reading the console at all is acceptable".

**It did not exist.** The package had a `Client` (which deliberately "returns an error rather than degrading: how to degrade is the cache layer's decision") and a `Monitor` that logs. So the cutover would have introduced the network dependency *and* its only mitigation in the same change, with the mitigation never having run anywhere.

## A — the cache (`bafeffc6`)

`Cache.Resolve(ctx) Resolution` never returns an error. It resolves through three tiers and says which one answered:

1. `SourceFresh` — cached inside TTL, zero console calls
2. `SourceStale` — the console read failed; serve last-known, `Stale=true`, the cause carried on `Err`
3. `SourceCompiled` — nothing ever cached; project `internal/billing/pricing`

Tier 3 is the "baked snapshot" the design asks for, and it is the compiled catalog that ships in the binary today — not a second snapshot format to keep in sync.

The property everything else rests on: **no failure path writes to the cache.** A failed refresh is structurally incapable of evicting a good value, and no path returns an empty catalog. `ErrUnavailable` and `ErrNotPublished` stay distinct and neither is ever cached as "no prices" — conflating "we could not ask" with "there are no prices" would leave the service pricing nothing at all.

Also: single-flight so concurrent misses cannot stampede the console (`golang.org/x/sync` was already a direct dependency — nothing added); `sync.RWMutex`, tested under `-race`; injected clock so TTL expiry is tested without sleeping; `CONSOLE_CATALOG_CACHE_TTL`, default 6h, because this data changes a few times a year.

**The compiled fallback is pinned as complete, not merely non-empty.** It must flatten to the same **78 (lookup_key, currency) rows across 42 lookup keys** the console publishes. A fallback that is present but missing currencies would be worse than today's behaviour — it would break exactly the countries whose rows were dropped — and every other test in the file would still pass, because they only assert that prices came back. Verified by mutation: dropping one row fails the test with `expected: 78, actual: 77`.

## B — exercise it in production first (`3e3219d9`)

A ticker on the **admin** pod calls `Resolve` and logs which tier answered, plus staleness, revision and price count. That is phase C's exact code path — token exchange, fetch, cache, degradation — running before serving depends on it, so a broken credential or config surfaces as a log line instead of in a merchant's plan change.

It deliberately does **not** re-run the Diff. The parity monitor beside it already does that, and fetches *directly* every 15m rather than through the cache — on purpose: the monitor's job is to evidence console reachability and data agreement, and a cached monitor would keep reporting `parity clean` straight through an outage until the TTL expired. Two jobs, two call sites, both documented so nobody collapses them.

## This corrects gap 2 of the issue

#328's status block says the cutover needs "the **storefront's** fetch, cache and fail-open behaviour on the checkout hot path". There is no such path:

```
$ go list -deps ./internal/handlers/storefront | grep -E "billing/pricing|billing/stripe|consolecatalog"
(no matches)

$ go list -deps ./internal/handlers/platformadmin | grep billing/pricing
github.com/mark8ly/marketplace-api/internal/billing/pricing
```

Every caller of the three runtime readers is admin-side or a CLI — `platformadmin/money.go`, `subscription/planchange` (orchestrator + downgrade-recheck cron, wired at `main.go:1020` inside the admin gate opened at line 710), `reconciliation/reconciler.go`, and `cmd/billing-bootstrap`.

The plan catalog is what a **merchant pays Mark8ly**; the storefront sells that merchant's products to their customers. Different concept, and "checkout" means different things on the two sides. So the resolver runs on admin, where the readers actually are — and the file records the dependency evidence so the asymmetry does not get "fixed" later.

Consequence worth stating: the cutover is **better** covered than the issue claimed. Its readers live on the pod that has been reporting `parity clean differences=0` for a week. Full correction posted on tesserix-home#328.

## MODE matrix

| MODE | parity monitor | cache resolver |
|---|---|---|
| admin | yes | yes |
| storefront | no | no, and logs nothing |
| both | yes | yes |

The storefront logs *nothing* rather than "disabled (no credentials)": on that pod the feature is not disabled, it is inapplicable, and a credentials line would send someone hunting for credentials that pod is right not to have.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l`, and `go test -race -count=1 ./...` across the whole module — **zero failures**, rebased onto `f5d3e84d` (which also touched `pkg/config`, so the gates were re-run after the rebase).

Test coverage of the properties that matter: fresh hit makes no console call; expired + console down returns last-known and flags it stale; cold start + console down returns a complete compiled catalog rather than an error or an empty one; `ErrNotPublished` neither cached as empty nor evicting a good value; concurrent readers under `-race` collapse to one console call; the mode matrix; a hanging console hits the deadline instead of blocking.

## Not in this PR

- **Phase C**, the cutover itself — moving `platformadmin/money.go`, `planchange` and `reconciliation` onto `Resolve`. It should follow once this has run in production for a while, which is the entire point of B.
- **Negative-result backoff** and **rate-limiting the degraded-resolve warn**. Both are inert at a 6h TTL on a ticker and both become real once `Resolve` sits on a request path; they belong with phase C, where the call frequency is decided.
- **Gap 3** — the evidence trail is still logs, not a queryable table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vwnnQQ2pfJJ58QjTkfPTB
