### PR TITLE
feat(billing): resolve platform-admin subscription amounts from the console catalog (#328, phase C step 1)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/catalog_serving.go
+++ b/services/marketplace-api/cmd/marketplace-api/catalog_serving.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"log/slog"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/consolecatalog"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/pkg/config"
+)
+
+// newServingCatalogResolver builds the cache the platform console's billing
+// READ routes price from (tesserix-home#328 phase C, step 1), or an
+// explicitly nil interface when the console catalog is unconfigured.
+//
+// # Unconfigured returns a TRUE nil, not a nil pointer in an interface
+//
+// The unconfigured path returns the untyped nil literal rather than a nil
+// *consolecatalog.Cache. A nil pointer assigned into an interface field is a
+// NON-nil interface value, so platformadmin's `r == nil` check would miss it
+// and the first request would call Resolve on a nil *Cache and panic on its
+// mutex. main.go already records this exact trap for tenantTeardownClient
+// (#323); it is the same shape here, with a worse blast radius, because the
+// nil case is the ROLLBACK path — the one that has to work when everything
+// else is broken.
+//
+// # Why this is a second cache, beside startAdminCatalogResolve's
+//
+// The phase-B ticker owns its own Cache and keeps it, deliberately. Its job
+// is to exercise and report on the read path on a fixed schedule whether or
+// not anyone is using the console; this one's job is to answer requests.
+// Sharing one instance would make the ticker's refresh schedule part of the
+// serving path's behaviour and its log lines ambiguous about which cache
+// they describe. The cost of not sharing is one extra console read per pod
+// per cache TTL (6h by default) — see consolecatalog.DefaultTTL for why that
+// interval is generous rather than tight.
+//
+// # It is not gated on mode here
+//
+// Both platformadmin.Register call sites are already inside admin-mode
+// blocks, so a storefront pod never reaches this. The ticker carries its own
+// m.RunsAdmin() gate because it is started from a block that does not
+// otherwise state one.
+func newServingCatalogResolver(cfg *config.Config, log *slog.Logger) platformadmin.CatalogResolver {
+	cc := consolecatalog.Config{
+		CatalogURL:   cfg.ConsoleCatalogURL,
+		TokenURL:     cfg.ConsoleCatalogTokenURL,
+		ClientID:     cfg.ConsoleCatalogClientID,
+		ClientSecret: cfg.ConsoleCatalogClientSecret,
+		Scope:        cfg.ConsoleCatalogScope,
+		Mode:         cfg.ConsoleCatalogMode,
+	}
+	if !cc.Configured() {
+		log.Info("consolecatalog: platform-admin billing amounts come from the compiled " +
+			"catalog (no console credentials); this is the supported rollback state")
+		return nil
+	}
+
+	log.Info("consolecatalog: platform-admin billing amounts resolve from the console catalog",
+		"mode", cc.Mode, "cache_ttl", cfg.ConsoleCatalogCacheTTL.String())
+	return consolecatalog.NewCache(
+		consolecatalog.NewClient(cc, log), cfg.ConsoleCatalogCacheTTL, cc.Mode, log)
+}

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -2335,6 +2335,7 @@ func main() {
 			EstateUsers:           estateUsersClient,
 			EmailSends:            platformadmin.EmailSendListerFunc(emaillog.ListPlatform),
 			BreakGlass:            platformadmin.BreakGlassListerFunc(breakglass.ListPlatform),
+			PriceCatalog:          newServingCatalogResolver(cfg, log),
 		})
 		storefront.RegisterStorefront(r.Group("/api/v1"), storefrontDeps)
 		storefront.RegisterMobileStorefrontSupport(r.Group("/api/v1"), storefrontSupportHandler, storefrontDeps.SlugCache, storefrontCustomerVerifier)
@@ -2482,6 +2483,7 @@ func main() {
 				EstateUsers:           estateUsersClient,
 				EmailSends:            platformadmin.EmailSendListerFunc(emaillog.ListPlatform),
 				BreakGlass:            platformadmin.BreakGlassListerFunc(breakglass.ListPlatform),
+				PriceCatalog:          newServingCatalogResolver(cfg, log),
 			})
 			// Public Delhivery webhook receiver. Mounted on the admin
 			// engine because the merchant-configured URL points at the

--- a/services/marketplace-api/internal/billing/consolecatalog/compare.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/compare.go
@@ -24,6 +24,25 @@ type rowKey struct {
 type row struct {
 	amountMinor int64
 	taxBehavior string
+	// plan, period and tier are compared as well as keyed on, and that is
+	// deliberate rather than redundant.
+	//
+	// `rowKey` is (lookup_key, currency) because that is what identifies an
+	// amount on both sides. These three are the fields the SERVING lookup
+	// keys on: `platformadmin`'s price index finds a row by (plan, period,
+	// tier, currency), because a subscription row carries those and never a
+	// Stripe lookup_key. Before they were compared here, `differences=0`
+	// evidenced the amounts while saying nothing about the three fields the
+	// cutover reads by -- so the check that gates the cutover did not cover
+	// the path the cutover creates.
+	//
+	// Verified identical across all 42 lookup keys on 2026-09-03, so adding
+	// them reports nothing new today. That is the point: the guard is being
+	// put in place while it is known to pass, so a later divergence is a
+	// signal rather than a discovery.
+	plan   string
+	period string
+	tier   string
 }
 
 // Diff compares the console's catalog against the compiled one and returns
@@ -53,6 +72,24 @@ func Diff(console Catalog, compiled []pricing.PriceDescriptor) []Difference {
 		if !sameTaxBehavior(l.taxBehavior, r.taxBehavior) {
 			diffs = append(diffs, Difference{k.lookupKey, k.currency,
 				fmt.Sprintf("tax_behavior: compiled=%q console=%q", r.taxBehavior, l.taxBehavior)})
+			continue
+		}
+		// Reported one field at a time, worst-first like the checks above, so
+		// a report names the specific field rather than dumping both rows and
+		// leaving a reader to spot the difference.
+		if l.plan != r.plan {
+			diffs = append(diffs, Difference{k.lookupKey, k.currency,
+				fmt.Sprintf("plan: compiled=%q console=%q", r.plan, l.plan)})
+			continue
+		}
+		if l.period != r.period {
+			diffs = append(diffs, Difference{k.lookupKey, k.currency,
+				fmt.Sprintf("period: compiled=%q console=%q", r.period, l.period)})
+			continue
+		}
+		if l.tier != r.tier {
+			diffs = append(diffs, Difference{k.lookupKey, k.currency,
+				fmt.Sprintf("tier: compiled=%q console=%q", r.tier, l.tier)})
 		}
 	}
 	for k, r := range right {
@@ -74,7 +111,15 @@ func Diff(console Catalog, compiled []pricing.PriceDescriptor) []Difference {
 func consoleRows(c Catalog) map[rowKey]row {
 	out := make(map[rowKey]row, len(c.Prices))
 	for _, p := range c.Prices {
-		out[rowKey{p.LookupKey, strings.ToLower(p.Currency)}] = row{p.UnitAmountMinor, p.TaxBehavior}
+		out[rowKey{p.LookupKey, strings.ToLower(p.Currency)}] = row{
+			amountMinor: p.UnitAmountMinor,
+			taxBehavior: p.TaxBehavior,
+			// Lower-folded on both sides so a case difference alone cannot
+			// report a divergence. The serving index folds the same way.
+			plan:   strings.ToLower(strings.TrimSpace(p.Plan)),
+			period: strings.ToLower(strings.TrimSpace(p.Period)),
+			tier:   strings.ToLower(strings.TrimSpace(p.Tier)),
+		}
 	}
 	return out
 }
@@ -97,7 +142,13 @@ func compiledRows(descriptors []pricing.PriceDescriptor) map[rowKey]row {
 			if amt.Currency == "" {
 				continue
 			}
-			out[rowKey{d.LookupKey, strings.ToLower(cur)}] = row{amt.UnitAmountMinor, amt.TaxBehavior}
+			out[rowKey{d.LookupKey, strings.ToLower(cur)}] = row{
+				amountMinor: amt.UnitAmountMinor,
+				taxBehavior: amt.TaxBehavior,
+				plan:        strings.ToLower(strings.TrimSpace(string(d.Plan))),
+				period:      strings.ToLower(strings.TrimSpace(string(d.Period))),
+				tier:        strings.ToLower(strings.TrimSpace(string(d.Tier))),
+			}
 		}
 	}
 	return out

--- a/services/marketplace-api/internal/billing/consolecatalog/compare_test.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/compare_test.go
@@ -85,8 +85,13 @@ func TestDiff_ComparesEveryCurrencyOfADevelopedPrice(t *testing.T) {
 		LookupKey: "mark8ly_starter_monthly_developed_v1",
 	}}
 	console := consolecatalog.Catalog{Prices: []consolecatalog.Price{
-		{LookupKey: "mark8ly_starter_monthly_developed_v1", Currency: "usd", UnitAmountMinor: 1900, Tier: "developed"},
-		{LookupKey: "mark8ly_starter_monthly_developed_v1", Currency: "gbp", UnitAmountMinor: 9999, Tier: "developed"},
+		// Plan and Period are set because a real console row always carries
+		// them -- they are NOT NULL in the console's own schema. A fixture
+		// omitting them is not a response the console can produce, and since
+		// Diff now compares those fields it would report a difference this
+		// test is not about.
+		{LookupKey: "mark8ly_starter_monthly_developed_v1", Plan: "starter", Period: "monthly", Currency: "usd", UnitAmountMinor: 1900, Tier: "developed"},
+		{LookupKey: "mark8ly_starter_monthly_developed_v1", Plan: "starter", Period: "monthly", Currency: "gbp", UnitAmountMinor: 9999, Tier: "developed"},
 	}}
 
 	diffs := consolecatalog.Diff(console, compiled)
@@ -138,4 +143,85 @@ func TestDiff_IdenticalSourcesProduceNoDifferences(t *testing.T) {
 	}
 	require.NotEmpty(t, prices, "a vacuous comparison would prove nothing")
 	require.Empty(t, consolecatalog.Diff(consolecatalog.Catalog{Prices: prices}, compiled))
+}
+
+// plan, period and tier are compared, because they are what the SERVING
+// lookup keys on.
+//
+// `rowKey` is (lookup_key, currency), so before these fields were compared a
+// console row could carry a different plan, period or tier from the compiled
+// descriptor with the same lookup key and `differences=0` would still be
+// reported. That mattered once tesserix-home#328's cutover landed:
+// `platformadmin`'s price index finds a row by (plan, period, tier,
+// currency) -- a subscription row carries those and never a Stripe lookup
+// key -- so the check that gates the cutover would not have covered the path
+// the cutover creates.
+//
+// The three are verified identical across all 42 lookup keys in production
+// (2026-09-03), so this reports nothing today. The guard exists so a later
+// divergence is a signal rather than a discovery -- and the failure it
+// prevents is quiet: a tier mismatch would strip the amount from a
+// subscription's display rather than show a wrong number.
+func TestDiff_ComparesTheFieldsTheServingLookupKeysOn(t *testing.T) {
+	compiled := []pricing.PriceDescriptor{{
+		Plan: "starter", Period: "monthly", Tier: pricing.TierDeveloped,
+		Currency:  "usd",
+		Baseline:  pricing.Amount{Currency: "usd", UnitAmountMinor: 1900},
+		Options:   map[string]pricing.Amount{"usd": {Currency: "usd", UnitAmountMinor: 1900}},
+		LookupKey: "mark8ly_starter_monthly_developed_v1",
+	}}
+
+	base := consolecatalog.Price{
+		LookupKey: "mark8ly_starter_monthly_developed_v1",
+		Plan:      "starter", Period: "monthly", Tier: "developed",
+		Currency: "usd", UnitAmountMinor: 1900,
+	}
+
+	// The control: identical on all three, and the amount agrees, so nothing
+	// is reported. Without this a later change could make Diff report
+	// everything and the three cases below would still "pass".
+	require.Empty(t,
+		consolecatalog.Diff(consolecatalog.Catalog{Prices: []consolecatalog.Price{base}}, compiled),
+		"an agreeing row must report nothing")
+
+	for _, tc := range []struct {
+		field  string
+		mutate func(consolecatalog.Price) consolecatalog.Price
+	}{
+		{"plan", func(p consolecatalog.Price) consolecatalog.Price { p.Plan = "pro"; return p }},
+		{"period", func(p consolecatalog.Price) consolecatalog.Price { p.Period = "annual"; return p }},
+		{"tier", func(p consolecatalog.Price) consolecatalog.Price { p.Tier = "ppp"; return p }},
+	} {
+		t.Run(tc.field, func(t *testing.T) {
+			diffs := consolecatalog.Diff(
+				consolecatalog.Catalog{Prices: []consolecatalog.Price{tc.mutate(base)}}, compiled)
+			require.Len(t, diffs, 1, "%s must be compared, not merely carried", tc.field)
+			require.Contains(t, diffs[0].Detail, tc.field+":",
+				"the report must name the field that differs, not just that something did")
+		})
+	}
+}
+
+// Case alone is not a divergence.
+//
+// The console stores these lower-cased and the compiled catalog's types are
+// Go string constants; if either side ever changes case, comparing raw would
+// report all 78 rows as divergent, the count would never reach zero, and the
+// evidence this whole package produces would be worthless. Same reasoning as
+// sameTaxBehavior, one field over.
+func TestDiff_FieldCaseAloneIsNotADivergence(t *testing.T) {
+	compiled := []pricing.PriceDescriptor{{
+		Plan: "starter", Period: "monthly", Tier: pricing.TierDeveloped,
+		Currency:  "usd",
+		Baseline:  pricing.Amount{Currency: "usd", UnitAmountMinor: 1900},
+		Options:   map[string]pricing.Amount{"usd": {Currency: "usd", UnitAmountMinor: 1900}},
+		LookupKey: "mark8ly_starter_monthly_developed_v1",
+	}}
+	console := consolecatalog.Catalog{Prices: []consolecatalog.Price{{
+		LookupKey: "mark8ly_starter_monthly_developed_v1",
+		Plan:      "Starter", Period: " MONTHLY ", Tier: "Developed",
+		Currency: "usd", UnitAmountMinor: 1900,
+	}}}
+
+	require.Empty(t, consolecatalog.Diff(console, compiled))
 }

--- a/services/marketplace-api/internal/billing/consolecatalog/lookup.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/lookup.go
@@ -1,0 +1,104 @@
+package consolecatalog
+
+import "strings"
+
+// priceKey identifies one row of the flattened catalog.
+//
+// Four fields, not the lookup_key, because that is the vocabulary a caller
+// actually holds: a subscription row carries plan, period, price_tier and
+// billing_currency, and never a Stripe lookup_key. Diff keys on
+// (lookup_key, currency) instead, which is right for ITS job — comparing two
+// catalogs row for row — and useless for answering "what does this merchant
+// pay".
+//
+// Every field is normalised to lower case here. The console's own schema
+// already constrains three of them (apps/web/db/migrations/0032_plan_catalog.sql:
+// period CHECK IN ('monthly','annual'), tier CHECK IN ('developed','ppp'),
+// currency CHECK lowercase ISO 4217), so normalising is belt and braces on
+// that side — but the CALLER's currency comes from a char(3) database column
+// of unspecified case, and matching it against a lowercase catalog key
+// without folding is how a real merchant's amount silently disappears from
+// the console.
+type priceKey struct {
+	plan     string
+	period   string
+	tier     string
+	currency string
+}
+
+func newPriceKey(plan, period, tier, currency string) priceKey {
+	return priceKey{
+		plan:     fold(plan),
+		period:   fold(period),
+		tier:     fold(tier),
+		currency: fold(currency),
+	}
+}
+
+func fold(v string) string { return strings.ToLower(strings.TrimSpace(v)) }
+
+// PriceIndex answers "the price for (plan, period, tier, currency)" over one
+// catalog.
+//
+// It is built once and queried many times because that is how the callers
+// use it: a console page renders up to 500 subscription rows, and a linear
+// scan of 78 prices per row is work nobody needs to do. Building it is also
+// the point at which unusable rows are dropped once, rather than being
+// re-examined at every lookup — see Index.
+type PriceIndex struct {
+	byKey map[priceKey]Price
+}
+
+// Index builds a PriceIndex over the catalog's prices.
+//
+// Rows with an empty currency are SKIPPED rather than indexed. That is the
+// same rule compiledRows and CompiledCatalog apply, for the same reason: a
+// row that names no currency names no price, and indexing it would let a
+// lookup return an amount of zero for a currency the catalog has nothing to
+// say about. The console cannot produce such a row (plan_catalog_amounts
+// constrains currency to lowercase ISO 4217), but CompiledCatalog projects
+// from a map that IS pre-populated with zero-value entries, so the guard has
+// to live on this side of the boundary too.
+//
+// A duplicate key keeps the FIRST row. Neither source is expected to produce
+// one — the console's schema is UNIQUE (revision_id, source, lookup_key) with
+// one amount per currency — so this only decides what happens if that ever
+// stops being true, and "keep what you first saw" is at least stable across
+// calls where last-write-wins over a slice would not be.
+func (c Catalog) Index() PriceIndex {
+	ix := PriceIndex{byKey: make(map[priceKey]Price, len(c.Prices))}
+	for _, p := range c.Prices {
+		if fold(p.Currency) == "" {
+			continue
+		}
+		k := newPriceKey(p.Plan, p.Period, p.Tier, p.Currency)
+		if _, dup := ix.byKey[k]; dup {
+			continue
+		}
+		ix.byKey[k] = p
+	}
+	return ix
+}
+
+// Len reports how many usable prices the index holds. Zero means the index
+// can price nothing at all, which a caller must be able to tell apart from
+// "this particular combination is unpriced".
+func (ix PriceIndex) Len() int { return len(ix.byKey) }
+
+// Find returns the price for one (plan, period, tier, currency), matching
+// case-insensitively on all four.
+//
+// ok=false means the catalog has no such row, and the returned Price is then
+// the zero value — an amount of 0 in no currency, which a caller must not
+// report as a price. There is deliberately no way to get ok=true out of this
+// without a row that was actually indexed: absence is reported by the bool,
+// never by a zero amount. That property is the whole reason Find returns
+// (Price, bool) rather than an amount, and the reason Index drops rows with
+// an empty currency instead of storing them.
+func (ix PriceIndex) Find(plan, period, tier, currency string) (Price, bool) {
+	p, ok := ix.byKey[newPriceKey(plan, period, tier, currency)]
+	if !ok {
+		return Price{}, false
+	}
+	return p, true
+}

--- a/services/marketplace-api/internal/billing/consolecatalog/lookup_test.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/lookup_test.go
@@ -1,0 +1,117 @@
+package consolecatalog_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/consolecatalog"
+)
+
+func TestIndexFindMatchesOnAllFourFields(t *testing.T) {
+	ix := consolecatalog.Catalog{Prices: []consolecatalog.Price{
+		{LookupKey: "a", Plan: "starter", Period: "monthly", Tier: "developed",
+			Currency: "gbp", UnitAmountMinor: 1500},
+		{LookupKey: "b", Plan: "starter", Period: "annual", Tier: "developed",
+			Currency: "gbp", UnitAmountMinor: 15000},
+		{LookupKey: "c", Plan: "starter", Period: "monthly", Tier: "ppp",
+			Currency: "inr", UnitAmountMinor: 99900},
+	}}.Index()
+
+	require.Equal(t, 3, ix.Len())
+
+	p, ok := ix.Find("starter", "monthly", "developed", "gbp")
+	require.True(t, ok)
+	require.Equal(t, int64(1500), p.UnitAmountMinor)
+
+	p, ok = ix.Find("starter", "annual", "developed", "gbp")
+	require.True(t, ok)
+	require.Equal(t, int64(15000), p.UnitAmountMinor)
+
+	p, ok = ix.Find("starter", "monthly", "ppp", "inr")
+	require.True(t, ok)
+	require.Equal(t, int64(99900), p.UnitAmountMinor)
+}
+
+// TestIndexFindFoldsCase covers the case mismatch that actually happens in
+// production: the catalog's keys are lowercase (the console's schema
+// constrains currency to lowercase ISO 4217) while the caller's currency
+// comes from a char(3) column of unspecified case.
+func TestIndexFindFoldsCase(t *testing.T) {
+	ix := consolecatalog.Catalog{Prices: []consolecatalog.Price{
+		{Plan: "starter", Period: "monthly", Tier: "developed",
+			Currency: "gbp", UnitAmountMinor: 1500},
+	}}.Index()
+
+	for _, cur := range []string{"gbp", "GBP", "GbP", "  gbp  "} {
+		_, ok := ix.Find("STARTER", " Monthly ", "Developed", cur)
+		require.True(t, ok, "currency %q must match the lowercase catalog key", cur)
+	}
+}
+
+// TestIndexFindMissReturnsZeroValueAndFalse is the property every caller
+// depends on: absence is reported by the bool, and the Price that comes back
+// with it is the zero value — so a caller that ignores the bool cannot get a
+// plausible-looking amount, only an obviously empty one.
+func TestIndexFindMissReturnsZeroValueAndFalse(t *testing.T) {
+	ix := consolecatalog.Catalog{Prices: []consolecatalog.Price{
+		{Plan: "starter", Period: "monthly", Tier: "developed",
+			Currency: "gbp", UnitAmountMinor: 1500},
+	}}.Index()
+
+	p, ok := ix.Find("starter", "monthly", "developed", "usd")
+	require.False(t, ok)
+	require.Equal(t, consolecatalog.Price{}, p)
+}
+
+// TestIndexSkipsRowsWithNoCurrency pins the guard that keeps a catalog GAP
+// from becoming an amount of zero. CompiledCatalog already drops these, and
+// the console cannot publish one, so this pins the index's own refusal
+// rather than either source's behaviour.
+func TestIndexSkipsRowsWithNoCurrency(t *testing.T) {
+	ix := consolecatalog.Catalog{Prices: []consolecatalog.Price{
+		{Plan: "starter", Period: "monthly", Tier: "developed", Currency: ""},
+		{Plan: "starter", Period: "monthly", Tier: "developed", Currency: "   "},
+	}}.Index()
+
+	require.Equal(t, 0, ix.Len(), "a row naming no currency names no price")
+
+	_, ok := ix.Find("starter", "monthly", "developed", "")
+	require.False(t, ok)
+}
+
+// TestIndexKeepsFirstOnDuplicateKey pins the tie-break so it is a decision
+// rather than an accident of map iteration. Neither source is expected to
+// produce a duplicate; this only says what happens if one ever does.
+func TestIndexKeepsFirstOnDuplicateKey(t *testing.T) {
+	ix := consolecatalog.Catalog{Prices: []consolecatalog.Price{
+		{LookupKey: "first", Plan: "starter", Period: "monthly", Tier: "developed",
+			Currency: "gbp", UnitAmountMinor: 1500},
+		{LookupKey: "second", Plan: "starter", Period: "monthly", Tier: "developed",
+			Currency: "GBP", UnitAmountMinor: 9999},
+	}}.Index()
+
+	require.Equal(t, 1, ix.Len())
+	p, ok := ix.Find("starter", "monthly", "developed", "gbp")
+	require.True(t, ok)
+	require.Equal(t, "first", p.LookupKey)
+}
+
+// TestCompiledCatalogIndexesEveryPublishedRow ties the fallback tier to the
+// shape the console publishes: 42 lookup keys flatten to 78 (lookup_key,
+// currency) rows, and every one of them must be reachable by
+// (plan, period, tier, currency) — otherwise the rollback path would price
+// some combinations and silently drop others.
+func TestCompiledCatalogIndexesEveryPublishedRow(t *testing.T) {
+	cat := consolecatalog.CompiledCatalog("test")
+	ix := cat.Index()
+
+	require.Equal(t, len(cat.Prices), ix.Len(),
+		"every compiled row must be reachable by plan/period/tier/currency")
+
+	for _, p := range cat.Prices {
+		got, ok := ix.Find(p.Plan, p.Period, p.Tier, p.Currency)
+		require.True(t, ok, "no index entry for %+v", p)
+		require.Equal(t, p.UnitAmountMinor, got.UnitAmountMinor)
+	}
+}

--- a/services/marketplace-api/internal/billing/consolecatalog/parity_test.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/parity_test.go
@@ -36,8 +36,14 @@ func matchingCatalog() consolecatalog.Catalog {
 			if amt.Currency == "" {
 				continue
 			}
+			// Plan, Period and Tier are carried because a real console row
+			// always carries them (NOT NULL in the console schema) and Diff
+			// compares them: they are the fields the SERVING lookup keys on,
+			// so leaving them out of the "matching" fixture would make this
+			// test assert agreement over a response the console cannot send.
 			prices = append(prices, consolecatalog.Price{
 				LookupKey: d.LookupKey, Currency: cur,
+				Plan: string(d.Plan), Period: string(d.Period), Tier: string(d.Tier),
 				UnitAmountMinor: amt.UnitAmountMinor, TaxBehavior: amt.TaxBehavior,
 			})
 		}

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions.go
@@ -99,11 +99,21 @@ type BillingSubscriptionsHandler struct {
 	dir    TenantDirectory
 	db     *gorm.DB
 	logger *slog.Logger
+	// catalog and fallbackLog mirror BillingTrialsHandler exactly — the two
+	// surfaces must not disagree about what a plan costs, so they price
+	// from the same resolver through the same helper (tesserix-home#328).
+	catalog     CatalogResolver
+	fallbackLog *catalogFallbackLog
 }
 
 // NewBillingSubscriptionsHandler constructs the handler. logger may be nil.
-func NewBillingSubscriptionsHandler(subs SubscriptionLister, dir TenantDirectory, db *gorm.DB, logger *slog.Logger) *BillingSubscriptionsHandler {
-	return &BillingSubscriptionsHandler{subs: subs, dir: dir, db: db, logger: logger}
+// catalog may be nil, which prices from the compiled catalog — see
+// compiledPriceCatalog for why that is the cutover's kill switch.
+func NewBillingSubscriptionsHandler(subs SubscriptionLister, dir TenantDirectory, db *gorm.DB, catalog CatalogResolver, logger *slog.Logger) *BillingSubscriptionsHandler {
+	return &BillingSubscriptionsHandler{
+		subs: subs, dir: dir, db: db, logger: logger,
+		catalog: catalog, fallbackLog: newCatalogFallbackLog(),
+	}
 }
 
 // Register mounts the route on the supplied group.
@@ -175,11 +185,15 @@ func (h *BillingSubscriptionsHandler) list(c *gin.Context) {
 		return
 	}
 
+	// Resolved ONCE for the whole page, off the request's context — never
+	// context.Background(). See the matching comment in billing_trials.go.
+	pc := resolvePriceCatalog(ctx, h.catalog, h.fallbackLog, h.logger)
+
 	// Allocate before appending: a nil slice marshals to {}, which defeats a
 	// caller's `?? []`.
 	out := make([]subscriptionRow, 0, len(rows))
 	for _, r := range rows {
-		out = append(out, toSubscriptionRow(r, names))
+		out = append(out, toSubscriptionRow(r, names, pc))
 	}
 
 	c.JSON(http.StatusOK, billingSubscriptionsResponse{
@@ -235,7 +249,7 @@ func (h *BillingSubscriptionsHandler) lookupTenantNames(ctx context.Context, row
 	return names, nil
 }
 
-func toSubscriptionRow(r subscription.StoreSubscription, names map[string]string) subscriptionRow {
+func toSubscriptionRow(r subscription.StoreSubscription, names map[string]string, pc priceCatalog) subscriptionRow {
 	tenantID := r.TenantID.String()
 	row := subscriptionRow{
 		TenantID:          tenantID,
@@ -247,7 +261,7 @@ func toSubscriptionRow(r subscription.StoreSubscription, names map[string]string
 		CancelAtPeriodEnd: r.CancelAtPeriodEnd,
 	}
 
-	if m, ok := resolveMoney(string(r.Plan), string(r.SubscriptionPeriod), r.BillingCurrency, r.PriceTier); ok {
+	if m, ok := pc.resolveMoney(string(r.Plan), string(r.SubscriptionPeriod), r.BillingCurrency, r.PriceTier); ok {
 		row.Amount = &m
 	}
 

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_subscriptions_test.go
@@ -45,7 +45,8 @@ func billingSubscriptionsRouter(t *testing.T, subs platformadmin.SubscriptionLis
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	platformadmin.NewBillingSubscriptionsHandler(subs, dir, nil, nil).Register(r.Group(""))
+	// nil CatalogResolver: compiled catalog, the rollback state.
+	platformadmin.NewBillingSubscriptionsHandler(subs, dir, nil, nil, nil).Register(r.Group(""))
 	return r
 }
 

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_trials.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_trials.go
@@ -61,6 +61,15 @@ type BillingTrialsHandler struct {
 	dir    TenantDirectory
 	db     *gorm.DB
 	logger *slog.Logger
+	// catalog resolves the plan catalog each response is priced from
+	// (tesserix-home#328 phase C). Nil prices from the compiled catalog —
+	// see compiledPriceCatalog for why that nil is the cutover's kill
+	// switch and not a degraded state.
+	catalog CatalogResolver
+	// fallbackLog throttles the warning that a page was priced from a
+	// non-fresh catalog. Per handler, not per package, so the interval is
+	// testable without global state.
+	fallbackLog *catalogFallbackLog
 	// now is overridable in tests; production uses time.Now. The single
 	// instant it returns is used for BOTH the query window and every row's
 	// days_remaining — two clocks in one response is a defect this project
@@ -74,11 +83,14 @@ type BillingTrialsHandler struct {
 // clock so the fixture's TrialEndsAt values and the resulting
 // days_remaining stay deterministic, mirroring the clock parameter pattern
 // used by trial.NewExpiryCron and friends.
-func NewBillingTrialsHandler(trials TrialLister, dir TenantDirectory, db *gorm.DB, clock func() time.Time, logger *slog.Logger) *BillingTrialsHandler {
+func NewBillingTrialsHandler(trials TrialLister, dir TenantDirectory, db *gorm.DB, clock func() time.Time, catalog CatalogResolver, logger *slog.Logger) *BillingTrialsHandler {
 	if clock == nil {
 		clock = time.Now
 	}
-	return &BillingTrialsHandler{trials: trials, dir: dir, db: db, logger: logger, now: clock}
+	return &BillingTrialsHandler{
+		trials: trials, dir: dir, db: db, logger: logger, now: clock,
+		catalog: catalog, fallbackLog: newCatalogFallbackLog(),
+	}
 }
 
 // Register mounts the route on the supplied group.
@@ -148,12 +160,18 @@ func (h *BillingTrialsHandler) list(c *gin.Context) {
 		return
 	}
 
+	// Resolved ONCE for the whole page, off the request's context — never
+	// context.Background(): a client that has gone away must be able to
+	// cancel the console read this may perform, like every other upstream
+	// call on this path.
+	pc := resolvePriceCatalog(ctx, h.catalog, h.fallbackLog, h.logger)
+
 	// Allocate before appending: a nil slice marshals to {}, which defeats a
 	// caller's `?? []` and crashes their page precisely when there is no
 	// data — same reasoning as toTenantRow's caller in entities_tenants.go.
 	out := make([]trialRow, 0, len(rows))
 	for _, r := range rows {
-		out = append(out, toTrialRow(r, names, asOf))
+		out = append(out, toTrialRow(r, names, asOf, pc))
 	}
 
 	c.JSON(http.StatusOK, billingTrialsResponse{
@@ -208,7 +226,7 @@ func (h *BillingTrialsHandler) lookupTenantNames(ctx context.Context, rows []tri
 	return names, nil
 }
 
-func toTrialRow(r trial.ExpiringRow, names map[string]string, asOf time.Time) trialRow {
+func toTrialRow(r trial.ExpiringRow, names map[string]string, asOf time.Time, pc priceCatalog) trialRow {
 	row := trialRow{
 		TenantID:      r.TenantID,
 		TenantName:    names[r.TenantID],
@@ -226,7 +244,7 @@ func toTrialRow(r trial.ExpiringRow, names map[string]string, asOf time.Time) tr
 		StripeManaged:       r.StripeManaged,
 	}
 
-	if m, ok := resolveMoney(r.Plan, r.Period, r.BillingCurrency, r.PriceTier); ok {
+	if m, ok := pc.resolveMoney(r.Plan, r.Period, r.BillingCurrency, r.PriceTier); ok {
 		row.Amount = &m
 	}
 

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_trials_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_trials_test.go
@@ -98,7 +98,9 @@ func billingTrialsRouterAt(t *testing.T, trials platformadmin.TrialLister, dir p
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	platformadmin.NewBillingTrialsHandler(trials, dir, nil, func() time.Time { return asOf }, nil).Register(r.Group(""))
+	// nil CatalogResolver: these tests pin the compiled-catalog
+	// (rollback) behaviour, which is what an unconfigured console gives.
+	platformadmin.NewBillingTrialsHandler(trials, dir, nil, func() time.Time { return asOf }, nil, nil).Register(r.Group(""))
 	return r
 }
 

--- a/services/marketplace-api/internal/handlers/platformadmin/money.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/money.go
@@ -1,9 +1,13 @@
 package platformadmin
 
 import (
+	"context"
+	"log/slog"
 	"strings"
+	"sync"
+	"time"
 
-	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+	"github.com/mark8ly/marketplace-api/internal/billing/consolecatalog"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 )
 
@@ -14,6 +18,83 @@ type money struct {
 	Currency string `json:"currency"`
 }
 
+// CatalogResolver is the subset of *consolecatalog.Cache this package needs:
+// one call that always answers. Declared here as a local interface for the
+// same reason TenantDirectory and TenantLifecycle are — this package stays
+// testable without building a console client — and typed to return the
+// Resolution rather than a bare Catalog because the SOURCE is what the
+// fallback logging below reports.
+//
+// Resolve returns no error by contract (see consolecatalog.Cache.Resolve): a
+// degradation is reported through Source and Err, never by failing.
+type CatalogResolver interface {
+	Resolve(ctx context.Context) consolecatalog.Resolution
+}
+
+// priceCatalog is the catalog ONE RESPONSE is priced from.
+//
+// Resolved once per request and then queried per row. Resolving per row
+// would be correct but wasteful — a 500-row page would call Resolve 500
+// times — and, worse, a TTL expiry midway through a page could price the
+// top of the response from one catalog and the bottom from another. One
+// response quotes one catalog.
+type priceCatalog struct {
+	prices consolecatalog.PriceIndex
+}
+
+// compiledPriceCatalog prices from internal/billing/pricing, projected into
+// the console's row shape.
+//
+// # This is the kill switch, and it is config, not code
+//
+// When CONSOLE_CATALOG_* is unconfigured, main.go passes a nil
+// CatalogResolver, resolvePriceCatalog lands here, and this surface prices
+// exactly as it did before the cutover (tesserix-home#328 phase C). Unsetting
+// the console credentials therefore reverts the cutover with a rollout, not
+// a revert — the same contract startCatalogParityRun and
+// startAdminCatalogResolve already state for phases A and B.
+//
+// The mode argument to CompiledCatalog only labels Catalog.Mode, which
+// nothing in this file reads; the compiled amounts are the same either way,
+// so there is no mode to pass and none is invented.
+func compiledPriceCatalog() priceCatalog {
+	return priceCatalog{prices: consolecatalog.CompiledCatalog("").Index()}
+}
+
+// resolvePriceCatalog resolves the catalog for one request.
+//
+// Three ways in, and all three end at a usable catalog:
+//
+//   - r == nil — the console catalog is unconfigured. Compiled. See
+//     compiledPriceCatalog: this is the deliberate rollback path, and it must
+//     never be a panic or an empty answer.
+//   - r.Resolve — fresh, stale or compiled, decided inside the cache. It
+//     cannot fail; a degradation arrives as Source/Err on the Resolution.
+//   - a resolution carrying no usable prices — compiled. Nothing in the cache
+//     is supposed to produce this (a never-published mode is a 404, which the
+//     cache already answers with the compiled catalog), but an empty index
+//     silently strips the amount from every row on the page, which looks
+//     exactly like "these merchants have no prices". Falling back costs one
+//     projection and removes that failure mode entirely.
+func resolvePriceCatalog(ctx context.Context, r CatalogResolver, fb *catalogFallbackLog, log *slog.Logger) priceCatalog {
+	if r == nil {
+		return compiledPriceCatalog()
+	}
+
+	res := r.Resolve(ctx)
+	fb.note(log, res)
+
+	ix := res.Catalog.Index()
+	if ix.Len() == 0 {
+		if log != nil {
+			log.Warn("platformadmin: resolved catalog holds no usable prices; pricing from the compiled catalog",
+				"source", string(res.Source), "revision_id", res.Catalog.RevisionID)
+		}
+		return compiledPriceCatalog()
+	}
+	return priceCatalog{prices: ix}
+}
+
 // resolveMoney returns the catalog price for a subscription's plan, period
 // and currency, or ok=false when no price can be determined.
 //
@@ -21,42 +102,123 @@ type money struct {
 //   - billing_currency is NULL (the merchant never chose one), or
 //   - the plan has no price at all — the catalog excludes `trial` and
 //     `marketplace` by design ("no Price objects"), or
-//   - the catalog has no entry for that plan/period/currency combination.
+//   - the catalog has no entry for that plan/period/tier/currency combination.
 //
 // Callers OMIT the amount key entirely in that case. Never null, never 0,
 // never a guessed currency: a number the system cannot determine must not
 // be reported as a number.
 //
-// Deliberately does NOT use pricing.MustGet, which panics on a miss. A
-// console read must not panic on an unpriced combination. This calls the
-// same two lookups MustGet wraps, minus the panic.
-func resolveMoney(plan, period string, billingCurrency *string, tier subscription.PriceTier) (money, bool) {
+// Cannot panic. That was true when this called pricing.LookupPPPOption
+// directly (and deliberately not pricing.MustGet, which panics on a miss),
+// and it stays true through a map lookup that reports absence with a bool.
+//
+// # An absent price can never surface as amount=0
+//
+// PriceIndex.Find returns (Price, bool) and this returns early on
+// ok=false, so the only amount that can reach the wire is one that came off
+// a row the index actually holds. Index in turn refuses to store a row with
+// no currency, which is the specific shape the compiled catalog's
+// pre-populated Options map produces for a gap. The property the previous
+// implementation held with an `amt.Currency != ""` guard therefore holds
+// here by construction, on both sources: a missing price yields ok=false,
+// never an amount of zero.
+func (pc priceCatalog) resolveMoney(plan, period string, billingCurrency *string, tier subscription.PriceTier) (money, bool) {
 	if billingCurrency == nil || strings.TrimSpace(*billingCurrency) == "" {
 		return money{}, false
 	}
-	// Catalog keys are lowercase ISO 4217; the column is char(3) of
-	// unspecified case; the wire contract is uppercase.
-	cur := strings.ToLower(strings.TrimSpace(*billingCurrency))
 
-	p, per := pricing.Plan(plan), pricing.Period(period)
-
+	// Only PriceTierPPP looks up a PPP price; ANY other value — including an
+	// unexpected or empty one — looks up a developed price. That is the
+	// branch structure this replaced, preserved exactly, so a row whose
+	// price_tier column is somehow not one of the two still resolves the way
+	// it does today rather than losing its amount.
+	t := subscription.PriceTierDeveloped
 	if tier == subscription.PriceTierPPP {
-		if amt, ok := pricing.LookupPPPOption(p, per, cur); ok {
-			return money{Amount: amt.UnitAmountMinor, Currency: strings.ToUpper(amt.Currency)}, true
-		}
+		t = subscription.PriceTierPPP
+	}
+
+	// Find folds case on all four fields, so the char(3) billing_currency
+	// column's case does not matter here; the wire contract's uppercase is
+	// applied below, to the CATALOG's currency rather than to the caller's,
+	// so the response quotes the currency the price is actually in.
+	p, ok := pc.prices.Find(plan, period, string(t), *billingCurrency)
+	if !ok {
 		return money{}, false
 	}
+	return money{Amount: p.UnitAmountMinor, Currency: strings.ToUpper(p.Currency)}, true
+}
 
-	if opts, ok := pricing.DevelopedCurrencyOptions(p, per); ok {
-		// DevelopedCurrencyOptions' Options map is pre-populated with a
-		// zero-value Amount for every developed currency, even one the
-		// catalog has no price for (see catalog.go's init: opts[c] =
-		// byPeriod[c]). Map presence alone is not proof of a real price —
-		// require a non-empty Currency too, or a catalog gap silently
-		// resolves as amount=0.
-		if amt, present := opts[cur]; present && amt.Currency != "" {
-			return money{Amount: amt.UnitAmountMinor, Currency: strings.ToUpper(amt.Currency)}, true
-		}
+// catalogFallbackLogInterval bounds how often one handler reports that it
+// priced a response from a non-fresh catalog.
+const catalogFallbackLogInterval = 5 * time.Minute
+
+// catalogFallbackLog throttles the "this page was priced from a stale or
+// compiled catalog" warning.
+//
+// # Why not simply warn per request
+//
+// Because this is a request path. A console operator refreshing a list
+// during a console-catalog outage would produce one warn line per refresh
+// for as long as the outage lasted, which buries the first line — the one
+// that actually says when the degradation started — under the noise of
+// someone hitting F5. Phase A flagged unrate-limited warn-per-resolve as
+// exactly the thing not to ship into phase C.
+//
+// # Why not simply drop it
+//
+// Because a stale amount displayed is indistinguishable from a correct one
+// until someone compares it to Stripe. startAdminCatalogResolve's ticker
+// does report the same kind of degradation every 15m, but it resolves
+// through its OWN cache instance — a fresh read there is not evidence about
+// the cache THIS surface served from, so the request path has to be able to
+// speak for itself.
+//
+// So: at most one line per interval per handler, carrying how many
+// resolutions it stands for. The first degradation after a quiet period is
+// always logged immediately; the storm behind it is counted, not printed.
+type catalogFallbackLog struct {
+	mu         sync.Mutex
+	lastLogged time.Time
+	suppressed int
+	// now is injectable so the interval is testable without sleeping.
+	now func() time.Time
+}
+
+func newCatalogFallbackLog() *catalogFallbackLog {
+	return &catalogFallbackLog{now: time.Now}
+}
+
+// note records one resolution, logging at most one line per interval.
+//
+// Nil-safe on both the receiver and the logger: a handler constructed
+// without either still serves, because observability must not be able to
+// take down the surface it observes.
+func (l *catalogFallbackLog) note(log *slog.Logger, res consolecatalog.Resolution) {
+	if l == nil || log == nil || res.Source == consolecatalog.SourceFresh {
+		return
 	}
-	return money{}, false
+
+	l.mu.Lock()
+	now := l.now()
+	if !l.lastLogged.IsZero() && now.Sub(l.lastLogged) < catalogFallbackLogInterval {
+		l.suppressed++
+		l.mu.Unlock()
+		return
+	}
+	suppressed := l.suppressed
+	l.suppressed = 0
+	l.lastLogged = now
+	l.mu.Unlock()
+
+	attrs := []any{
+		"source", string(res.Source),
+		"revision_id", res.Catalog.RevisionID,
+		"prices", len(res.Catalog.Prices),
+		"suppressed_since_last_line", suppressed,
+		"interval", catalogFallbackLogInterval.String(),
+	}
+	if res.Err != nil {
+		attrs = append(attrs, "error", res.Err)
+	}
+	log.Warn("platformadmin: billing amounts priced from a non-fresh catalog", attrs...)
 }

--- a/services/marketplace-api/internal/handlers/platformadmin/money_console_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/money_console_test.go
@@ -1,0 +1,412 @@
+package platformadmin
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/consolecatalog"
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+	"github.com/mark8ly/marketplace-api/internal/billing/trial"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/internal/tenantdirectory"
+)
+
+// resolveMoney prices from the compiled catalog, which is exactly what an
+// unconfigured console gives this surface (see compiledPriceCatalog: the nil
+// CatalogResolver is the cutover's kill switch).
+//
+// It exists so money_test.go — every rule this helper has to honour, written
+// before the console was involved at all — keeps testing the ROLLBACK path
+// unchanged, byte for byte, after the cutover. If those assertions ever stop
+// holding, the config change that reverts tesserix-home#328 phase C no
+// longer restores today's behaviour, which is the thing the kill switch is
+// for.
+func resolveMoney(plan, period string, billingCurrency *string, tier subscription.PriceTier) (money, bool) {
+	return compiledPriceCatalog().resolveMoney(plan, period, billingCurrency, tier)
+}
+
+// stubResolver is a CatalogResolver returning a fixed Resolution, recording
+// the context it was handed.
+type stubResolver struct {
+	res     consolecatalog.Resolution
+	gotCtx  context.Context
+	callCnt int
+}
+
+func (s *stubResolver) Resolve(ctx context.Context) consolecatalog.Resolution {
+	s.gotCtx = ctx
+	s.callCnt++
+	return s.res
+}
+
+func freshResolution(prices ...consolecatalog.Price) consolecatalog.Resolution {
+	return consolecatalog.Resolution{
+		Catalog: consolecatalog.Catalog{
+			Mode:       "test",
+			RevisionID: consolecatalog.SharedRevisionID,
+			Prices:     prices,
+		},
+		Source:    consolecatalog.SourceFresh,
+		FetchedAt: time.Now(),
+	}
+}
+
+// consoleRowsFromCompiled flattens the compiled catalog into the row shape
+// the console publishes.
+//
+// Deliberately written out here rather than calling
+// consolecatalog.CompiledCatalog: that function is the FALLBACK this cutover
+// falls back TO, so using it to build the "console" side of a comparison
+// would compare a thing to itself. This walks pricing.AllDescriptors by a
+// separate route, so a test that says "the console and the compiled catalog
+// agree" is comparing two independently produced row sets.
+func consoleRowsFromCompiled(t *testing.T) []consolecatalog.Price {
+	t.Helper()
+	var out []consolecatalog.Price
+	for _, d := range pricing.AllDescriptors() {
+		for cur, amt := range d.Options {
+			// A zero-value Amount is a catalog GAP, not a price of zero —
+			// pricing's Options map is pre-populated for every developed
+			// currency. The console has no such row to publish.
+			if amt.Currency == "" {
+				continue
+			}
+			out = append(out, consolecatalog.Price{
+				LookupKey:       d.LookupKey,
+				Plan:            string(d.Plan),
+				Period:          string(d.Period),
+				Tier:            string(d.Tier),
+				Currency:        cur,
+				UnitAmountMinor: amt.UnitAmountMinor,
+				TaxBehavior:     amt.TaxBehavior,
+			})
+		}
+	}
+	require.NotEmpty(t, out)
+	return out
+}
+
+// moneyCase is one (plan, period, currency, tier) question, covering exactly
+// the combinations money_test.go asserts on plus the two unpriced plans.
+type moneyCase struct {
+	plan, period, currency string
+	tier                   subscription.PriceTier
+}
+
+func moneyCases() []moneyCase {
+	return []moneyCase{
+		{"starter", "monthly", "gbp", subscription.PriceTierDeveloped},
+		{"starter", "monthly", "usd", subscription.PriceTierDeveloped},
+		{"starter", "monthly", "inr", subscription.PriceTierPPP},
+		{"starter", "annual", "gbp", subscription.PriceTierDeveloped},
+		{"studio", "monthly", "eur", subscription.PriceTierDeveloped},
+		{"pro", "annual", "vnd", subscription.PriceTierPPP},
+		{"trial", "monthly", "usd", subscription.PriceTierDeveloped},
+		{"marketplace", "monthly", "usd", subscription.PriceTierDeveloped},
+		{"nonexistent", "monthly", "usd", subscription.PriceTierDeveloped},
+		{"starter", "monthly", "zzz", subscription.PriceTierDeveloped},
+		// inr has no developed-tier price: asking for one must miss rather
+		// than fall through to the PPP row that does exist for it.
+		{"starter", "monthly", "inr", subscription.PriceTierDeveloped},
+	}
+}
+
+// TestConsoleCatalogAgreesWithCompiled is the cutover's core claim: for
+// every question this surface asks, a console catalog and the compiled
+// catalog return the same answer — including the same ok=false.
+//
+// The parity monitor already reports differences=0, but it compares
+// (lookup_key, currency) AMOUNTS. It says nothing about whether this
+// package's plan/period/tier/currency lookup finds the same row, which is
+// the part the cutover actually depends on.
+func TestConsoleCatalogAgreesWithCompiled(t *testing.T) {
+	console := priceCatalog{prices: consolecatalog.Catalog{
+		Prices: consoleRowsFromCompiled(t),
+	}.Index()}
+	compiled := compiledPriceCatalog()
+
+	for _, tc := range moneyCases() {
+		cur := tc.currency
+		wantMoney, wantOK := compiled.resolveMoney(tc.plan, tc.period, &cur, tc.tier)
+		gotMoney, gotOK := console.resolveMoney(tc.plan, tc.period, &cur, tc.tier)
+
+		require.Equal(t, wantOK, gotOK, "ok differs for %+v", tc)
+		require.Equal(t, wantMoney, gotMoney, "money differs for %+v", tc)
+	}
+}
+
+// TestConsoleCatalogResolvesKnownAmounts pins the amounts money_test.go
+// pins, resolved through the CONSOLE path rather than the compiled one, so a
+// change that silently made the console path return nothing at all could not
+// pass by agreeing with an equally broken compiled path.
+func TestConsoleCatalogResolvesKnownAmounts(t *testing.T) {
+	console := priceCatalog{prices: consolecatalog.Catalog{
+		Prices: consoleRowsFromCompiled(t),
+	}.Index()}
+
+	gbp := "gbp"
+	m, ok := console.resolveMoney("starter", "monthly", &gbp, subscription.PriceTierDeveloped)
+	require.True(t, ok)
+	require.Equal(t, money{Amount: 1500, Currency: "GBP"}, m)
+
+	inr := "inr"
+	m, ok = console.resolveMoney("starter", "monthly", &inr, subscription.PriceTierPPP)
+	require.True(t, ok)
+	require.Equal(t, money{Amount: 99900, Currency: "INR"}, m)
+}
+
+// TestConsoleCatalogMissingEntryIsNotZero is the property the previous
+// implementation held with an `amt.Currency != ""` guard: a combination the
+// catalog has no row for resolves as ok=false, never as amount=0. A console
+// row set is built from real rows, so the zero-value-placeholder mechanism
+// does not exist there — but "absent resolves to zero" must be impossible
+// regardless of which source is answering.
+func TestConsoleCatalogMissingEntryIsNotZero(t *testing.T) {
+	// One plan/period/tier, one currency. Every other question is a miss.
+	console := priceCatalog{prices: consolecatalog.Catalog{Prices: []consolecatalog.Price{
+		{LookupKey: "k", Plan: "starter", Period: "monthly", Tier: "developed",
+			Currency: "gbp", UnitAmountMinor: 1500},
+	}}.Index()}
+
+	for _, tc := range []moneyCase{
+		{"starter", "monthly", "usd", subscription.PriceTierDeveloped}, // currency absent
+		{"starter", "annual", "gbp", subscription.PriceTierDeveloped},  // period absent
+		{"studio", "monthly", "gbp", subscription.PriceTierDeveloped},  // plan absent
+		{"starter", "monthly", "gbp", subscription.PriceTierPPP},       // tier absent
+	} {
+		cur := tc.currency
+		m, ok := console.resolveMoney(tc.plan, tc.period, &cur, tc.tier)
+		require.False(t, ok, "%+v must miss", tc)
+		require.Equal(t, money{}, m, "%+v must not resolve to an amount at all", tc)
+		require.Zero(t, m.Amount, "%+v must never surface as amount=0", tc)
+	}
+}
+
+// TestConsoleCatalogCaseHandling walks the three cases the wire contract
+// spans in one go: the catalog key is lowercase, the DB's char(3) column is
+// of unspecified case, and the response must be uppercase.
+func TestConsoleCatalogCaseHandling(t *testing.T) {
+	console := priceCatalog{prices: consolecatalog.Catalog{Prices: []consolecatalog.Price{
+		// Lowercase, as plan_catalog_amounts' currency CHECK constrains it.
+		{LookupKey: "k", Plan: "starter", Period: "monthly", Tier: "developed",
+			Currency: "gbp", UnitAmountMinor: 1500},
+	}}.Index()}
+
+	for _, dbValue := range []string{"gbp", "GBP", "GbP", " gbp "} {
+		v := dbValue
+		m, ok := console.resolveMoney("starter", "monthly", &v, subscription.PriceTierDeveloped)
+		require.True(t, ok, "billing_currency %q must resolve", dbValue)
+		require.Equal(t, "GBP", m.Currency, "the wire contract is uppercase")
+		require.Equal(t, int64(1500), m.Amount)
+	}
+
+	// A console that ever published an uppercase currency must still be
+	// found: the fold is applied to both sides of the comparison, not only
+	// to the caller's value.
+	upperConsole := priceCatalog{prices: consolecatalog.Catalog{Prices: []consolecatalog.Price{
+		{LookupKey: "k", Plan: "Starter", Period: "Monthly", Tier: "Developed",
+			Currency: "GBP", UnitAmountMinor: 1500},
+	}}.Index()}
+	cur := "gbp"
+	m, ok := upperConsole.resolveMoney("starter", "monthly", &cur, subscription.PriceTierDeveloped)
+	require.True(t, ok)
+	require.Equal(t, money{Amount: 1500, Currency: "GBP"}, m)
+}
+
+// TestResolvePriceCatalogNilResolverIsCompiled pins the kill switch: no
+// resolver at all must price exactly as the compiled catalog does, with no
+// panic and no empty answer.
+func TestResolvePriceCatalogNilResolverIsCompiled(t *testing.T) {
+	var pc priceCatalog
+	require.NotPanics(t, func() {
+		pc = resolvePriceCatalog(context.Background(), nil, nil, nil)
+	})
+
+	gbp := "gbp"
+	m, ok := pc.resolveMoney("starter", "monthly", &gbp, subscription.PriceTierDeveloped)
+	require.True(t, ok, "the rollback path must still be able to price")
+	require.Equal(t, money{Amount: 1500, Currency: "GBP"}, m)
+}
+
+// TestResolvePriceCatalogFailedResolverStillPrices covers the cache's own
+// fallback reaching this package: Resolve never errors, it answers with the
+// compiled catalog and Source=compiled. This surface must price from it
+// normally.
+func TestResolvePriceCatalogFailedResolverStillPrices(t *testing.T) {
+	r := &stubResolver{res: consolecatalog.Resolution{
+		Catalog: consolecatalog.CompiledCatalog("test"),
+		Source:  consolecatalog.SourceCompiled,
+		Stale:   true,
+		Err:     errors.New("console unreachable"),
+	}}
+
+	pc := resolvePriceCatalog(context.Background(), r, newCatalogFallbackLog(), slog.Default())
+
+	gbp := "gbp"
+	m, ok := pc.resolveMoney("starter", "monthly", &gbp, subscription.PriceTierDeveloped)
+	require.True(t, ok)
+	require.Equal(t, money{Amount: 1500, Currency: "GBP"}, m)
+}
+
+// TestResolvePriceCatalogEmptyCatalogFallsBackToCompiled: a resolution that
+// carries no usable prices would strip the amount from every row on the
+// page, which reads as "these merchants have no price" rather than as a
+// fault. Fall back rather than serve that.
+func TestResolvePriceCatalogEmptyCatalogFallsBackToCompiled(t *testing.T) {
+	r := &stubResolver{res: freshResolution()}
+
+	pc := resolvePriceCatalog(context.Background(), r, newCatalogFallbackLog(), slog.Default())
+
+	gbp := "gbp"
+	m, ok := pc.resolveMoney("starter", "monthly", &gbp, subscription.PriceTierDeveloped)
+	require.True(t, ok, "an empty resolution must not leave the surface unable to price")
+	require.Equal(t, money{Amount: 1500, Currency: "GBP"}, m)
+}
+
+// TestResolvePriceCatalogPassesCallerContext proves the caller's context
+// reaches Resolve — the console read has to be cancellable by the request
+// that triggered it.
+func TestResolvePriceCatalogPassesCallerContext(t *testing.T) {
+	r := &stubResolver{res: freshResolution(consolecatalog.Price{
+		LookupKey: "k", Plan: "starter", Period: "monthly", Tier: "developed",
+		Currency: "gbp", UnitAmountMinor: 1500,
+	})}
+
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "caller")
+
+	resolvePriceCatalog(ctx, r, newCatalogFallbackLog(), nil)
+
+	require.Equal(t, 1, r.callCnt)
+	require.Equal(t, "caller", r.gotCtx.Value(ctxKey{}), "Resolve must get the caller's context")
+}
+
+// stubTrialLister returns a fixed page of trials.
+type stubTrialLister struct{ rows []trial.ExpiringRow }
+
+func (s stubTrialLister) ListExpiring(_ context.Context, _ *gorm.DB, _ time.Time, _ time.Duration, _, _ int, _ trial.ListOptions) ([]trial.ExpiringRow, int64, error) {
+	return s.rows, int64(len(s.rows)), nil
+}
+
+// TestBillingTrialsUsesRequestContextAndResolvesOncePerPage pins the two
+// wiring properties the row-level helpers cannot: the handler hands Resolve
+// the REQUEST's context (not context.Background(), which would leave a
+// console read running after the client hung up), and it resolves ONCE for
+// the page rather than once per row — a page priced from two different
+// catalogs is a page that can contradict itself.
+func TestBillingTrialsUsesRequestContextAndResolvesOncePerPage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	usd := "usd"
+	rows := make([]trial.ExpiringRow, 0, 3)
+	for i := 0; i < 3; i++ {
+		rows = append(rows, trial.ExpiringRow{
+			TenantID: "t", StoreID: "s", TrialEndsAt: time.Now().Add(48 * time.Hour),
+			Plan: "starter", Period: "monthly", BillingCurrency: &usd,
+			PriceTier: subscription.PriceTierDeveloped, Status: "trialing",
+		})
+	}
+
+	r := &stubResolver{res: freshResolution(consolecatalog.Price{
+		LookupKey: "k", Plan: "starter", Period: "monthly", Tier: "developed",
+		Currency: "usd", UnitAmountMinor: 4242,
+	})}
+
+	// The page has rows, so lookupTenantNames DOES call the directory; a nil
+	// one would panic. The stub returns no tenants, which only means the
+	// rows carry no tenant_name — irrelevant to what this test asserts.
+	h := NewBillingTrialsHandler(stubTrialLister{rows: rows}, stubDirectory{}, nil, time.Now, r, nil)
+
+	engine := gin.New()
+	h.Register(engine.Group(""))
+
+	type ctxKey struct{}
+	req := httptest.NewRequest(http.MethodGet, "/admin/billing/trials", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxKey{}, "request"))
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 1, r.callCnt, "one page must resolve the catalog exactly once")
+	require.Equal(t, "request", r.gotCtx.Value(ctxKey{}),
+		"the console read must run on the request's context, never context.Background()")
+	require.Contains(t, w.Body.String(), `"amount":4242`,
+		"the page must be priced from the console catalog, not the compiled one")
+}
+
+// TestCatalogFallbackLogThrottles pins the observability decision: the first
+// degradation is reported immediately, the storm behind it is counted rather
+// than printed, and a fresh resolution is never reported at all.
+func TestCatalogFallbackLogThrottles(t *testing.T) {
+	var lines []string
+	log := slog.New(slog.NewTextHandler(&lineWriter{&lines}, nil))
+
+	now := time.Now()
+	fb := newCatalogFallbackLog()
+	fb.now = func() time.Time { return now }
+
+	stale := consolecatalog.Resolution{
+		Catalog: consolecatalog.Catalog{RevisionID: "r"},
+		Source:  consolecatalog.SourceStale, Stale: true,
+		Err: errors.New("console unreachable"),
+	}
+
+	fb.note(log, stale)
+	require.Len(t, lines, 1, "the first degradation must be reported immediately")
+
+	for i := 0; i < 20; i++ {
+		fb.note(log, stale)
+	}
+	require.Len(t, lines, 1, "a refresh storm must not produce a line per request")
+
+	now = now.Add(catalogFallbackLogInterval + time.Second)
+	fb.note(log, stale)
+	require.Len(t, lines, 2)
+	require.Contains(t, lines[1], "suppressed_since_last_line=20",
+		"the second line must account for what it stands for")
+
+	fb.note(log, freshResolution())
+	require.Len(t, lines, 2, "a fresh resolution is not a degradation and must be silent")
+}
+
+// TestCatalogFallbackLogNilSafe: observability must not be able to take down
+// the surface it observes.
+func TestCatalogFallbackLogNilSafe(t *testing.T) {
+	var nilLog *catalogFallbackLog
+	require.NotPanics(t, func() {
+		nilLog.note(slog.Default(), consolecatalog.Resolution{Source: consolecatalog.SourceStale})
+		newCatalogFallbackLog().note(nil, consolecatalog.Resolution{Source: consolecatalog.SourceStale})
+	})
+}
+
+// stubDirectory answers the tenant-name lookup with nothing.
+type stubDirectory struct{}
+
+func (stubDirectory) List(context.Context, tenantdirectory.ListParams) (*tenantdirectory.ListResult, error) {
+	return &tenantdirectory.ListResult{}, nil
+}
+
+func (stubDirectory) Get(context.Context, string) (*tenantdirectory.TenantDetail, error) {
+	return nil, errors.New("not used")
+}
+
+func (stubDirectory) FindByOwnerEmail(context.Context, string) (*tenantdirectory.Tenant, error) {
+	return nil, errors.New("not used")
+}
+
+type lineWriter struct{ lines *[]string }
+
+func (w *lineWriter) Write(p []byte) (int, error) {
+	*w.lines = append(*w.lines, strings.TrimRight(string(p), "\n"))
+	return len(p), nil
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -172,6 +172,15 @@ type Deps struct {
 	// Trials/AllSubscriptions pattern above: both must be non-nil for the
 	// route to mount.
 	BreakGlass BreakGlassLister
+
+	// PriceCatalog resolves the plan catalog the two billing read routes
+	// display amounts from (tesserix-home#328 phase C). Unlike every other
+	// optional field in this struct, nil does NOT unmount anything: it
+	// prices from the catalog compiled into internal/billing/pricing, which
+	// is what those routes did before the cutover. That is the rollback —
+	// unsetting CONSOLE_CATALOG_* in the chart reverts this surface to the
+	// compiled amounts without a code change. See compiledPriceCatalog.
+	PriceCatalog CatalogResolver
 }
 
 // TenantGateInvalidator drops a tenant's cached admin-gate status. Declared
@@ -255,11 +264,11 @@ func Register(g *gin.RouterGroup, deps Deps) {
 	}
 
 	if deps.Trials != nil && deps.TenantDirectory != nil {
-		NewBillingTrialsHandler(deps.Trials, deps.TenantDirectory, deps.DB, nil, deps.Logger).Register(group)
+		NewBillingTrialsHandler(deps.Trials, deps.TenantDirectory, deps.DB, nil, deps.PriceCatalog, deps.Logger).Register(group)
 	}
 
 	if deps.AllSubscriptions != nil && deps.TenantDirectory != nil {
-		NewBillingSubscriptionsHandler(deps.AllSubscriptions, deps.TenantDirectory, deps.DB, deps.Logger).Register(group)
+		NewBillingSubscriptionsHandler(deps.AllSubscriptions, deps.TenantDirectory, deps.DB, deps.PriceCatalog, deps.Logger).Register(group)
 	}
 
 	if deps.Tickets != nil {


### PR DESCRIPTION
Phase C **step 1 of 3** of tesserix/tesserix-home#328. Moves the first of the three runtime readers off the compiled catalog and onto the console's, through the cache #631 added.

## Why this reader first

The three readers have very different blast radii:

| reader | what a wrong answer does |
|---|---|
| **`platformadmin/money.go`** ← this PR | displays a wrong amount to a platform operator |
| `subscription/planchange` | **charges** on it — via an unattended downgrade cron |
| `reconciliation` | reconciles against it |

So the display-only reader goes first: it puts `Resolve` on a real request path, in production, where a wrong answer is visible and harmless — before anything that moves money depends on it. tesserix-home#327's own analysis names `planchange`'s unattended cron as where a pricing fault "would rot longest"; that one goes last, on its own.

## Prerequisite already in production

#631's cache is live on the admin pod and verified today:

```
consolecatalog: catalog resolve  source=fresh stale=false prices=78 revision_unexpected=false   05:02:35
consolecatalog: catalog resolve  source=fresh stale=false prices=78 revision_unexpected=false   05:17:35
```

The second tick is the meaningful one — `source=fresh` at a 6h TTL means it was served from cache, so both the fetch path and the caching work.

## The change

`resolveMoney` becomes a method on a `priceCatalog` resolved **once per request** — a TTL expiry mid-page could otherwise price the top and bottom of one response from two different catalogs. `consolecatalog` gains `Catalog.Index()` / `PriceIndex.Find(plan, period, tier, currency)`, keyed on the four fields the caller actually holds: a subscription row carries plan/period/price_tier/billing_currency and **never** a Stripe `lookup_key`.

Behaviour preserved exactly, per `money.go`'s existing contract:

- `ok=false` stays a normal outcome; callers omit the amount key. Never null, never 0, never a guessed currency.
- Only `PriceTierPPP` looks up a PPP row; **any** other value including empty looks up a developed row — so a row whose `price_tier` is unexpected keeps today's answer instead of losing its amount.
- Case: catalog keys lowercase, `char(3)` column of unspecified case, wire uppercase. Uppercase is applied to the **catalog's** currency, not the caller's, so the response quotes the currency the price is actually in.
- No panics. `pricing.MustGet` was avoided before for this reason and nothing reintroduces it.

**The zero-amount property now holds by construction.** The old code needed an `amt.Currency != ""` guard because `DevelopedCurrencyOptions`' map is pre-populated with zero-value entries for currencies with no price — map presence was not proof of a price. Now `Find` returns `(Price{}, false)` on a miss and `Index` refuses to store a currency-less row, so no amount can reach the wire that did not come off a real row.

## Rollback is config, not code

`CONSOLE_CATALOG_*` unconfigured → the resolver is nil → compiled catalog → behaviour identical to today. Unsetting the console config reverts this cutover with no deploy of new code.

Three independent paths all end at a usable catalog: a nil resolver, `Resolve` (which cannot fail), and a resolution carrying **zero usable prices** — that last one matters, because an empty index would silently strip the amount from every row and read as "these merchants have no price". The nil is an untyped nil literal rather than a nil `*Cache` in an interface, so the rollback path cannot panic.

## `differences=0` now covers what the cutover actually reads

Found while reviewing, and worth stating plainly: **the parity monitor diffed on `(lookup_key, currency)` only.** `plan`, `period` and `tier` were carried but never compared — so the check that gates this cutover did not cover the three fields the new serving lookup keys on. A tier mismatch would have produced a silent, uncompared divergence.

Verified against production first (2026-09-03) — all 42 lookup keys agree on plan, period *and* tier between the console and the compiled catalog:

```
diff <(console: lookup_key|plan|period|tier)  <(compiled: same)
→ identical, 42 rows
```

`Diff` now compares them, lower-folded on both sides so case alone cannot report a divergence (the same reasoning `sameTaxBehavior` already applies one field over). It reports nothing today — that is the point: the guard goes in while it is known to pass, so a later divergence is a signal rather than a discovery.

Two test fixtures were building console rows without those fields and started failing. They were **unfaithful**: those columns are `NOT NULL` in the console schema, so a row without them is not a response the console can send. Fixed rather than tolerated.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l` clean, `go test -race -count=1 ./...` — **zero failures across the module**.

`money_test.go` is **unchanged**. A shim points its ten tests at the compiled path, so they now pin the *rollback* behaviour byte-for-byte. The new console-vs-compiled agreement test builds its console fixture from an independent flattening of `pricing.AllDescriptors` rather than from `CompiledCatalog`, so it is not comparing a thing to itself.

**Mutation-tested rather than assumed:**

- `Find` returning a zero-value price with `ok=true` on a miss → fails 6 tests, including the pre-existing `TestResolveMoney_TrialPlanHasNoPrice` and `TestBillingTrialsMatchesContract`. The original contract is genuinely enforced, not merely restated.
- Removing the empty-catalog fallback → fails `TestResolvePriceCatalogEmptyCatalogFallsBackToCompiled`.

## Observability

Non-fresh resolutions warn on first occurrence, then count within a 5-minute window rather than printing — an operator refreshing during an outage would otherwise bury the one line saying when degradation began. Fresh resolutions are silent. Not dropped entirely, because the phase-B ticker resolves through its own `Cache` instance, so its `source=fresh` is not evidence about the cache this surface served from.

## Known, deliberate

- **Two cache instances** on the admin pod — the phase-B ticker's and this serving one. Costs one extra console read per pod per 6h TTL. Consolidating is worth considering in step 2 or 3; doing it here would have changed a signature that phase B's tests pin, for no behavioural gain.
- The 5-minute throttle is a judgement call, not a measured one.

## Next

Step 2 (`reconciliation`) and step 3 (`planchange`, including the unattended downgrade cron) — separately, and after this has run in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vwnnQQ2pfJJ58QjTkfPTB
