### PR TITLE
fix(storefront): quote and charge shipping per fulfilling warehouse (#541)

### DIFF
--- a/services/marketplace-api/internal/handlers/storefront/checkout_ext.go
+++ b/services/marketplace-api/internal/handlers/storefront/checkout_ext.go
@@ -65,6 +65,11 @@ type CheckoutExtHandler struct {
 	// it here costs nothing, matching the other shipping-adjacent
 	// handlers' warehouseRepo field.
 	warehouseRepo *warehouse.Repository
+	// carrierFactory, when set, substitutes a stub Carrier without
+	// standing up a live provider or an HTTPS test server — mirrors
+	// (*ShipmentsHandler).WithCarrierFactory in internal/handlers/admin.
+	// Production code never sets this.
+	carrierFactory func(provider string) (shipping.Carrier, bool)
 }
 
 // NewCheckoutExtHandler constructs a CheckoutExtHandler.
@@ -99,6 +104,14 @@ func (h *CheckoutExtHandler) WithSecretStore(s carriersecrets.Store) *CheckoutEx
 // checkouts fire in-app notifications to the merchant. Nil-safe.
 func (h *CheckoutExtHandler) WithNotifier(n *notification.Service) *CheckoutExtHandler {
 	h.notify = n
+	return h
+}
+
+// WithCarrierFactory lets tests substitute a stub Carrier without
+// requiring a live provider or an HTTPS test server. Returns the receiver
+// for chaining. Production code never sets this.
+func (h *CheckoutExtHandler) WithCarrierFactory(fn func(provider string) (shipping.Carrier, bool)) *CheckoutExtHandler {
+	h.carrierFactory = fn
 	return h
 }
 
@@ -851,6 +864,57 @@ func (h *CheckoutExtHandler) Checkout(c *gin.Context) {
 // Internal helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
+// variantShipRow is the per-variant weight/dimensions projection used to
+// build carrier parcel data — both for the legacy single-origin rate
+// request below and for the split-origin path's per-warehouse parcels
+// (checkoutItemsToOriginLines).
+type variantShipRow struct {
+	ID          string
+	WeightGrams *int
+	LengthCM    *decimal.Decimal
+	WidthCM     *decimal.Decimal
+	HeightCM    *decimal.Decimal
+}
+
+// checkoutItemsToOriginLines adapts checkout request items to
+// originLineItem for buildOriginGroups, resolving each item's parcel data
+// from shipByVariant the same way the legacy single-origin parcel loop
+// below does. Returns errMissingVariantID for any item with a nil or
+// empty VariantID — checkout_lowstock.go and stockLinesFromItems treat
+// that as a legitimate unstocked/custom line, but #541 requires falling
+// back to the single-origin path entirely when it happens, rather than
+// guess which warehouse (if any) ships it.
+func checkoutItemsToOriginLines(
+	items []CheckoutItemRequest,
+	shipByVariant map[string]variantShipRow,
+	defaultParcelWeightGrams int,
+) ([]originLineItem, error) {
+	lines := make([]originLineItem, 0, len(items))
+	for _, it := range items {
+		if it.VariantID == nil || *it.VariantID == "" {
+			return nil, errMissingVariantID
+		}
+		p := shipping.ParcelItem{WeightGrams: parcelWeightGrams(nil, defaultParcelWeightGrams)}
+		if vs, ok := shipByVariant[*it.VariantID]; ok {
+			p.WeightGrams = parcelWeightGrams(vs.WeightGrams, defaultParcelWeightGrams)
+			if vs.LengthCM != nil {
+				f, _ := vs.LengthCM.Float64()
+				p.LengthCM = f
+			}
+			if vs.WidthCM != nil {
+				f, _ := vs.WidthCM.Float64()
+				p.WidthCM = f
+			}
+			if vs.HeightCM != nil {
+				f, _ := vs.HeightCM.Float64()
+				p.HeightCM = f
+			}
+		}
+		lines = append(lines, originLineItem{VariantID: *it.VariantID, Quantity: it.Quantity, Parcel: p})
+	}
+	return lines, nil
+}
+
 // calculateShipping resolves the carrier config and gets the rate for the
 // selected service. Returns the final price including handling fee plus
 // the resolved carrier provider name so the order can persist what the
@@ -897,6 +961,15 @@ func (h *CheckoutExtHandler) calculateShipping(
 		return decimal.Zero, "", fmt.Errorf("carrier init: %w", err)
 	}
 
+	// Allow tests to substitute a stub Carrier without a live provider or
+	// an HTTPS test server. Nil override → use the resolved production
+	// carrier.
+	if h.carrierFactory != nil {
+		if c2, ok := h.carrierFactory(cfg.Provider); ok {
+			carrier = c2
+		}
+	}
+
 	// Fetch per-variant weight + dims so the carrier rate request gets
 	// real numbers. Without this every shipment looks like a 0-gram
 	// envelope to ShipEngine, which Australia Post rejects with
@@ -906,13 +979,6 @@ func (h *CheckoutExtHandler) calculateShipping(
 		if it.VariantID != nil && *it.VariantID != "" {
 			variantIDs = append(variantIDs, *it.VariantID)
 		}
-	}
-	type variantShipRow struct {
-		ID          string
-		WeightGrams *int
-		LengthCM    *decimal.Decimal
-		WidthCM     *decimal.Decimal
-		HeightCM    *decimal.Decimal
 	}
 	shipByVariant := map[string]variantShipRow{}
 	if len(variantIDs) > 0 {
@@ -925,6 +991,47 @@ func (h *CheckoutExtHandler) calculateShipping(
 			for _, r := range rows {
 				shipByVariant[r.ID] = r
 			}
+		}
+	}
+
+	// Attempt to price this order per fulfilling warehouse (#541), so the
+	// amount actually charged matches what GetRates quoted for the same
+	// cart. Falls back to the single-origin computation below — unchanged
+	// from before #541 — whenever the split cannot be computed; see
+	// buildOriginGroups for the exact conditions.
+	if lineItems, splitErr := checkoutItemsToOriginLines(req.Items, shipByVariant, cfg.DefaultParcelWeightGrams); splitErr != nil {
+		if h.logger != nil {
+			h.logger.Warn("checkout: split-origin shipping unavailable, using single origin",
+				"store_id", store.ID, "reason", splitErr.Error())
+		}
+	} else if groups, gErr := buildOriginGroups(ctx, h.db, h.warehouseRepo, store.ID, lineItems); gErr != nil {
+		if h.logger != nil {
+			h.logger.Warn("checkout: split-origin shipping unavailable, using single origin",
+				"store_id", store.ID, "reason", gErr.Error())
+		}
+	} else if len(groups) > 1 {
+		toAddr := shipping.Address{
+			Line1:       req.ShippingAddress.Line1,
+			City:        req.ShippingAddress.City,
+			Region:      derefString(req.ShippingAddress.Region),
+			PostalCode:  derefString(req.ShippingAddress.PostalCode),
+			CountryCode: req.ShippingAddress.CountryCode,
+		}
+		combined, sErr := quoteSplitOrigins(ctx, carrier, toAddr, store.CurrencyCode, groups)
+		if sErr != nil {
+			return decimal.Zero, "", fmt.Errorf("carrier.GetRates (split origin): %w", sErr)
+		}
+		if price, ok := selectShippingPrice(combined, req.ShippingService, cfg.HandlingFee, cfg.FreeShippingMin, req.Subtotal); ok {
+			return price, cfg.Provider, nil
+		}
+		// Empty intersection: no (carrier, service) pair can ship every
+		// parcel of this order. Falling through to the single-origin
+		// computation below — rather than charging zero — is the safer
+		// failure: this order still needs a price, and a same-origin
+		// best-effort one beats a free ride.
+		if h.logger != nil {
+			h.logger.Warn("checkout: split-origin quote had an empty intersection, using single origin",
+				"store_id", store.ID)
 		}
 	}
 

--- a/services/marketplace-api/internal/handlers/storefront/shipping_origins.go
+++ b/services/marketplace-api/internal/handlers/storefront/shipping_origins.go
@@ -1,0 +1,362 @@
+// Package storefront — shipping_origins.go: groups a checkout/rate
+// request's items by the warehouse(s) that will actually fulfill them,
+// and combines a per-origin carrier quote into one answer (#541).
+//
+// Before this file, both the rates quote (shipping_rates.go) and the
+// checkout charge (checkout_ext.go) priced from ONE fixed origin — the
+// carrier config's linked warehouse — no matter where the stock backing
+// the order actually sat. Since multi-warehouse shipped (#177), one
+// variant's stock can span warehouses, so allocation can split an order
+// into several physical parcels from several origins. Pricing that as one
+// parcel from one origin under-quotes it; the merchant absorbed the
+// difference.
+//
+// buildOriginGroups reuses the SAME allocation machinery checkout_stock.go
+// uses to actually place stock at commit time (storeWarehousesInFillOrder,
+// loadAvailability, allocation.Plan), so the quote and the eventual
+// placement can never disagree about which warehouse ships what.
+package storefront
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/allocation"
+	"github.com/mark8ly/marketplace-api/internal/shipping"
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
+)
+
+// errMissingVariantID means a rate/checkout request carried an item with
+// no variant_id (the field is deliberately not binding:"required" — an
+// unstocked or custom line is otherwise legitimate). Splitting requires
+// knowing which variant each line is, so a request with any such item
+// falls back to the single-origin path entirely rather than guess.
+var errMissingVariantID = errors.New("storefront: shipping origin split requires variant_id on every item")
+
+// errNoWarehousesToSplit means the store has no live warehouse to
+// allocate from. checkout_stock.go documents why a store with stock has
+// always resolved one since #177 PR 6 — this is the defensive read for
+// when that is ever false, not the expected case.
+var errNoWarehousesToSplit = errors.New("storefront: store has no warehouses to split shipping origins across")
+
+// quoteCartTokenSentinel stands in for "no cart" when reading availability
+// for a quote or charge preview — see buildOriginGroups's loadAvailability
+// call for why this can't just be "".
+const quoteCartTokenSentinel = "00000000-0000-0000-0000-000000000000"
+
+// originLineItem is one request line reduced to what origin-splitting
+// needs: which variant, how many units, and the parcel data to report for
+// whichever warehouse(s) end up shipping it. Parcel.Quantity is ignored —
+// Quantity above is the source of truth, since one line's units can end
+// up split across more than one resulting parcel.
+type originLineItem struct {
+	VariantID string
+	Quantity  int
+	Parcel    shipping.ParcelItem
+}
+
+// originGroup is one fulfilling origin and the parcels it ships.
+type originGroup struct {
+	Address shipping.Address
+	Parcels []shipping.ParcelItem
+}
+
+// buildOriginGroups groups items by the warehouse(s) allocation.Plan says
+// will actually fulfil them, resolving each warehouse's address.
+//
+// It returns an error whenever the split cannot be computed. Every caller
+// treats that as "fall back to the existing single-origin quote/charge" —
+// never as a reason to fail the request, or to price it wrong — matching
+// #541's fallback list: a missing variant_id, no warehouses, an
+// availability read failure, or allocation.Plan being unable to fill the
+// cart (CannotFillError or any other error).
+//
+// db is read-only here (h.db, no transaction): a quote or a charge preview
+// must never take the locks or side effects commitStock's hold placement
+// does.
+func buildOriginGroups(
+	ctx context.Context,
+	db *gorm.DB,
+	warehouseRepo *warehouse.Repository,
+	storeID string,
+	items []originLineItem,
+) ([]originGroup, error) {
+	if len(items) == 0 {
+		return nil, nil
+	}
+	for _, it := range items {
+		if it.VariantID == "" {
+			return nil, errMissingVariantID
+		}
+	}
+
+	warehouses, err := storeWarehousesInFillOrder(ctx, db, storeID)
+	if err != nil {
+		return nil, err
+	}
+	if len(warehouses) == 0 {
+		return nil, errNoWarehousesToSplit
+	}
+
+	variantIDs := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, it := range items {
+		vid := strings.ToLower(it.VariantID)
+		if _, ok := seen[vid]; ok {
+			continue
+		}
+		seen[vid] = struct{}{}
+		variantIDs = append(variantIDs, vid)
+	}
+
+	// A quote or charge preview happens before THIS attempt has placed any
+	// hold of its own, so there is nothing of the caller's own to exclude
+	// — every live hold from every cart should be subtracted, which is
+	// the conservative reading: a shopper who has not reserved anything
+	// must not be quoted stock that competing carts are already holding.
+	//
+	// The obvious way to express "exclude nothing" is an empty cartToken,
+	// since loadAvailability's exclusion is `sh.cart_token <> ?` and no
+	// real hold can have an empty token. But stock_holds.cart_token is a
+	// uuid column, and Postgres rejects "" as a uuid outright — the query
+	// errors before it can exclude anything. quoteCartTokenSentinel is a
+	// valid-shaped uuid instead, chosen so no real cart can ever hold it:
+	// production cart tokens are always either parsed from a client
+	// cookie (checked with uuid.Parse — this value would parse, but no
+	// client is ever issued it) or freshly minted via uuid.NewString(),
+	// which cannot collide with an all-zero id.
+	avail, _, err := loadAvailability(ctx, db, quoteCartTokenSentinel, warehouses, variantIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	allocLines := make([]allocation.Line, 0, len(items))
+	for _, it := range items {
+		allocLines = append(allocLines, allocation.Line{
+			VariantID: strings.ToLower(it.VariantID),
+			Quantity:  it.Quantity,
+		})
+	}
+
+	assignments, err := allocation.Plan(warehouses, avail, allocLines)
+	if err != nil {
+		// Covers allocation.CannotFillError along with everything else
+		// Plan can return (ErrNoWarehouse, ErrInvalidInput) — #541's
+		// fallback list treats all of them the same way.
+		return nil, err
+	}
+
+	return groupAssignmentsByWarehouse(ctx, db, warehouseRepo, items, assignments)
+}
+
+// groupAssignmentsByWarehouse turns Plan's flat assignment list back into
+// per-warehouse parcels, resolves each warehouse's address, and returns
+// the groups sorted by warehouse id for a deterministic response.
+func groupAssignmentsByWarehouse(
+	ctx context.Context,
+	db *gorm.DB,
+	warehouseRepo *warehouse.Repository,
+	items []originLineItem,
+	assignments []allocation.Assignment,
+) ([]originGroup, error) {
+	// Per-variant queue of items still owed units, in request order. An
+	// assignment for a variant draws from these queues front to back —
+	// the same principle recordAllocations (checkout_stock.go) uses to
+	// attribute a flat assignment list back to individual lines.
+	type pending struct {
+		itemIdx   int
+		remaining int
+	}
+	queues := map[string][]*pending{}
+	for i, it := range items {
+		vid := strings.ToLower(it.VariantID)
+		queues[vid] = append(queues[vid], &pending{itemIdx: i, remaining: it.Quantity})
+	}
+
+	parcelsByWarehouse := map[string][]shipping.ParcelItem{}
+	order := make([]string, 0, 2)
+	for _, a := range assignments {
+		if _, ok := parcelsByWarehouse[a.WarehouseID]; !ok {
+			order = append(order, a.WarehouseID)
+			parcelsByWarehouse[a.WarehouseID] = nil
+		}
+		want := a.Quantity
+		for _, p := range queues[a.VariantID] {
+			if want == 0 {
+				break
+			}
+			if p.remaining == 0 {
+				continue
+			}
+			take := min(want, p.remaining)
+			p.remaining -= take
+			want -= take
+
+			parcel := items[p.itemIdx].Parcel
+			parcel.Quantity = take
+			parcelsByWarehouse[a.WarehouseID] = append(parcelsByWarehouse[a.WarehouseID], parcel)
+		}
+		if want > 0 {
+			// Plan assigned units of a variant that this item's queue
+			// does not account for — a bug in this pairing logic, not a
+			// data problem (mirrors recordAllocations's identical guard
+			// in checkout_stock.go). Fail loudly rather than silently
+			// drop units from the quote.
+			return nil, fmt.Errorf(
+				"storefront: cannot attribute %d units of variant %s at warehouse %s to any line",
+				want, a.VariantID, a.WarehouseID)
+		}
+	}
+
+	sort.Strings(order)
+	groups := make([]originGroup, 0, len(order))
+	for _, whID := range order {
+		wh, err := warehouseRepo.ByID(ctx, db, whID)
+		if err != nil {
+			return nil, fmt.Errorf("storefront: resolve origin warehouse %s: %w", whID, err)
+		}
+		groups = append(groups, originGroup{
+			Address: shipping.Address{
+				Name:        wh.Name,
+				Line1:       wh.Line1,
+				Line2:       wh.Line2,
+				City:        wh.City,
+				Region:      wh.Region,
+				PostalCode:  wh.PostalCode,
+				CountryCode: wh.CountryCode,
+				Phone:       wh.Phone,
+			},
+			Parcels: parcelsByWarehouse[whID],
+		})
+	}
+	return groups, nil
+}
+
+// quoteSplitOrigins calls carrier.GetRates once per origin group — a
+// separate carrier call per fulfilling warehouse, each with that
+// warehouse's own address and only the parcels it ships — then combines
+// the per-group results with combineOriginRates.
+func quoteSplitOrigins(
+	ctx context.Context,
+	carrier shipping.Carrier,
+	toAddr shipping.Address,
+	currencyCode string,
+	groups []originGroup,
+) ([]shipping.Rate, error) {
+	perGroup := make([][]shipping.Rate, 0, len(groups))
+	for _, g := range groups {
+		rates, err := carrier.GetRates(ctx, shipping.RateRequest{
+			FromAddress:  g.Address,
+			ToAddress:    toAddr,
+			Items:        g.Parcels,
+			CurrencyCode: currencyCode,
+		})
+		if err != nil {
+			return nil, err
+		}
+		perGroup = append(perGroup, rates)
+	}
+	return combineOriginRates(perGroup), nil
+}
+
+// combineOriginRates applies the decided combine rule (#541):
+//
+//   - Only (carrier, service) pairs quoted by EVERY origin group are
+//     offered — the intersection. A service only one origin can provide
+//     cannot ship the whole order, so including it would under-quote,
+//     which is the bug being fixed.
+//   - price sums across groups.
+//   - estimated_days takes the MAX across groups — the order is not
+//     complete until the last parcel lands.
+//
+// An empty intersection, or no groups at all, yields no rates rather than
+// a price that silently excludes a parcel.
+func combineOriginRates(perGroup [][]shipping.Rate) []shipping.Rate {
+	if len(perGroup) == 0 {
+		return nil
+	}
+
+	type key struct{ carrier, service string }
+	groupsOffering := map[key]int{}
+	price := map[key]decimal.Decimal{}
+	days := map[key]int{}
+	currency := map[key]string{}
+	var order []key
+
+	for _, rates := range perGroup {
+		// A single group listing the same (carrier, service) twice must
+		// not be double-counted into the sum or the "every group" count.
+		countedThisGroup := map[key]bool{}
+		for _, r := range rates {
+			k := key{r.Carrier, r.Service}
+			if countedThisGroup[k] {
+				continue
+			}
+			countedThisGroup[k] = true
+
+			if groupsOffering[k] == 0 {
+				order = append(order, k)
+				price[k] = r.Price
+				days[k] = r.EstimatedDays
+				currency[k] = r.CurrencyCode
+			} else {
+				price[k] = price[k].Add(r.Price)
+				if r.EstimatedDays > days[k] {
+					days[k] = r.EstimatedDays
+				}
+			}
+			groupsOffering[k]++
+		}
+	}
+
+	result := make([]shipping.Rate, 0, len(order))
+	for _, k := range order {
+		if groupsOffering[k] != len(perGroup) {
+			continue // not offered by every origin group
+		}
+		result = append(result, shipping.Rate{
+			Carrier:       k.carrier,
+			Service:       k.service,
+			Price:         price[k],
+			CurrencyCode:  currency[k],
+			EstimatedDays: days[k],
+		})
+	}
+	return result
+}
+
+// selectShippingPrice picks the rate matching service (case-insensitively),
+// falling back to the first rate when none match — mirroring the
+// long-standing inline logic in (*CheckoutExtHandler).calculateShipping —
+// applies the handling fee once, and zeroes the price when the
+// free-shipping threshold is met. ok is false only when rates is empty,
+// so the caller can fall back rather than charge nothing for an order
+// that has a real cost.
+func selectShippingPrice(
+	rates []shipping.Rate,
+	service string,
+	handlingFee decimal.Decimal,
+	freeShippingMin *decimal.Decimal,
+	subtotal decimal.Decimal,
+) (price decimal.Decimal, ok bool) {
+	if len(rates) == 0 {
+		return decimal.Zero, false
+	}
+	chosen := rates[0]
+	for _, r := range rates {
+		if strings.EqualFold(r.Service, service) {
+			chosen = r
+			break
+		}
+	}
+	if freeShippingMin != nil && !freeShippingMin.IsZero() && subtotal.GreaterThanOrEqual(*freeShippingMin) {
+		return decimal.Zero, true
+	}
+	return chosen.Price.Add(handlingFee), true
+}

--- a/services/marketplace-api/internal/handlers/storefront/shipping_rates.go
+++ b/services/marketplace-api/internal/handlers/storefront/shipping_rates.go
@@ -31,6 +31,11 @@ type ShippingRatesHandler struct {
 	// read half) to the store-level warehouses row. Stateless, so
 	// constructing it here costs nothing.
 	warehouseRepo *warehouse.Repository
+	// carrierFactory, when set, substitutes a stub Carrier without
+	// standing up a live provider or an HTTPS test server — mirrors
+	// (*ShipmentsHandler).WithCarrierFactory in internal/handlers/admin.
+	// Production code never sets this.
+	carrierFactory func(provider string) (shipping.Carrier, bool)
 }
 
 // NewShippingRatesHandler constructs a ShippingRatesHandler.
@@ -43,6 +48,14 @@ func NewShippingRatesHandler(db *gorm.DB, enc crypto.Encryptor, logger *slog.Log
 // rows on read. Chainable.
 func (h *ShippingRatesHandler) WithSecretStore(s carriersecrets.Store) *ShippingRatesHandler {
 	h.secretStore = s
+	return h
+}
+
+// WithCarrierFactory lets tests substitute a stub Carrier without
+// requiring a live provider or an HTTPS test server. Returns the receiver
+// for chaining. Production code never sets this.
+func (h *ShippingRatesHandler) WithCarrierFactory(fn func(provider string) (shipping.Carrier, bool)) *ShippingRatesHandler {
+	h.carrierFactory = fn
 	return h
 }
 
@@ -91,6 +104,11 @@ type shippingRateResponse struct {
 	Price         string `json:"price"`
 	CurrencyCode  string `json:"currency_code"`
 	EstimatedDays int    `json:"estimated_days"`
+	// ShipmentCount is additive (#541): the number of parcels/origins
+	// this quote combines. Omitted (zero value) on the single-origin
+	// path, which is unchanged from before #541 — existing storefront
+	// clients that ignore this field keep working.
+	ShipmentCount int `json:"shipment_count,omitempty"`
 }
 
 // carrierConfigRow mirrors the shipping_carrier_configs table for direct
@@ -149,6 +167,31 @@ func parcelWeightGrams(variantWeight *int, configured int) int {
 }
 
 func (carrierConfigRow) TableName() string { return "shipping_carrier_configs" }
+
+// rateItemsToOriginLines adapts the wire request items to originLineItem
+// for buildOriginGroups. Returns errMissingVariantID for any item with no
+// variant_id — shippingRateItemRequest.VariantID deliberately has no
+// binding:"required" tag, so this is a real, expected input shape, not a
+// validation bug.
+func rateItemsToOriginLines(items []shippingRateItemRequest) ([]originLineItem, error) {
+	lines := make([]originLineItem, 0, len(items))
+	for _, it := range items {
+		if it.VariantID == "" {
+			return nil, errMissingVariantID
+		}
+		lines = append(lines, originLineItem{
+			VariantID: it.VariantID,
+			Quantity:  it.Quantity,
+			Parcel: shipping.ParcelItem{
+				WeightGrams: it.WeightGrams,
+				LengthCM:    it.LengthCM,
+				WidthCM:     it.WidthCM,
+				HeightCM:    it.HeightCM,
+			},
+		})
+	}
+	return lines, nil
+}
 
 // GetRates handles POST /storefront/stores/:storeSlug/shipping-rates.
 func (h *ShippingRatesHandler) GetRates(c *gin.Context) {
@@ -252,6 +295,68 @@ func (h *ShippingRatesHandler) GetRates(c *gin.Context) {
 			"error":   "internal",
 			"message": "internal server error",
 		})
+		return
+	}
+
+	// Allow tests to substitute a stub Carrier without a live provider or
+	// an HTTPS test server. Nil override → use the resolved production
+	// carrier.
+	if h.carrierFactory != nil {
+		if c2, ok := h.carrierFactory(cfg.Provider); ok {
+			carrier = c2
+		}
+	}
+
+	// Attempt to quote per fulfilling warehouse (#541): a variant's stock
+	// can span warehouses since #177, and pricing from one fixed origin
+	// under-quotes an order that will actually ship as more than one
+	// parcel. Falls back to the single-origin path below — unchanged from
+	// before #541 — whenever the split cannot be computed; see
+	// buildOriginGroups for the exact conditions.
+	if lineItems, splitErr := rateItemsToOriginLines(req.Items); splitErr != nil {
+		if h.logger != nil {
+			h.logger.Info("shipping_rates: split-origin quote unavailable, using single origin",
+				"store_id", store.ID, "reason", splitErr.Error())
+		}
+	} else if groups, gErr := buildOriginGroups(ctx, h.db, h.warehouseRepo, store.ID, lineItems); gErr != nil {
+		if h.logger != nil {
+			h.logger.Info("shipping_rates: split-origin quote unavailable, using single origin",
+				"store_id", store.ID, "reason", gErr.Error())
+		}
+	} else if len(groups) > 1 {
+		toAddr := shipping.Address{
+			Line1:       req.ShipTo.Line1,
+			City:        req.ShipTo.City,
+			Region:      req.ShipTo.Region,
+			PostalCode:  req.ShipTo.PostalCode,
+			CountryCode: req.ShipTo.CountryCode,
+		}
+		combined, ferr := quoteSplitOrigins(ctx, carrier, toAddr, store.CurrencyCode, groups)
+		if ferr != nil {
+			if h.logger != nil {
+				h.logger.Error("shipping_rates: carrier.GetRates failed (split origin)",
+					"provider", cfg.Provider,
+					"err", ferr)
+			}
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error":   "internal",
+				"message": "unable to calculate shipping rates",
+			})
+			return
+		}
+
+		result := make([]shippingRateResponse, 0, len(combined))
+		for _, r := range combined {
+			result = append(result, shippingRateResponse{
+				Service:       r.Service,
+				Carrier:       r.Carrier,
+				Price:         r.Price.Add(cfg.HandlingFee).StringFixed(2),
+				CurrencyCode:  r.CurrencyCode,
+				EstimatedDays: r.EstimatedDays,
+				ShipmentCount: len(groups),
+			})
+		}
+		c.JSON(http.StatusOK, gin.H{"data": result})
 		return
 	}
 

--- a/services/marketplace-api/internal/handlers/storefront/shipping_split_origin_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/shipping_split_origin_integration_test.go
@@ -1,0 +1,464 @@
+//go:build integration
+
+// Package storefront — coverage for #541: shipping-rate quotes and the
+// checkout charge must price per fulfilling warehouse, not from one fixed
+// origin, once allocation.Plan splits an order's stock across warehouses.
+//
+// In-package (not storefront_test) so these can drive
+// (*ShippingRatesHandler).GetRates and (*CheckoutExtHandler).calculateShipping
+// directly, and inject a stub Carrier via WithCarrierFactory — the same
+// pattern (*ShipmentsHandler).WithCarrierFactory uses in
+// internal/handlers/admin — so no test hits a live carrier or spins up an
+// HTTPS server.
+package storefront
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/country"
+	"github.com/mark8ly/marketplace-api/internal/crypto"
+	"github.com/mark8ly/marketplace-api/internal/shipping"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/internal/warehouse"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+var splitOriginTables = []string{
+	"stock_holds",
+	"variant_stock",
+	"product_variants",
+	"products",
+	"warehouses",
+	"shipping_carrier_configs",
+	"stores",
+}
+
+// splitOriginCarrier is a stub shipping.Carrier whose GetRates answer is
+// driven entirely by ratesFor, keyed on the FromAddress.Line1 the caller
+// passed in — which is exactly what lets a test tell "was this the whA
+// call or the whB call" apart without a real HTTP round trip.
+type splitOriginCarrier struct {
+	mu       sync.Mutex
+	calls    []shipping.RateRequest
+	ratesFor map[string][]shipping.Rate // keyed by FromAddress.Line1
+	err      error
+}
+
+func (c *splitOriginCarrier) GetRates(_ context.Context, in shipping.RateRequest) ([]shipping.Rate, error) {
+	c.mu.Lock()
+	c.calls = append(c.calls, in)
+	c.mu.Unlock()
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.ratesFor[in.FromAddress.Line1], nil
+}
+func (c *splitOriginCarrier) CreateShipment(context.Context, shipping.ShipmentRequest) (*shipping.Shipment, error) {
+	return nil, nil
+}
+func (c *splitOriginCarrier) GetTracking(context.Context, string) (*shipping.Tracking, error) {
+	return nil, nil
+}
+func (c *splitOriginCarrier) CancelShipment(context.Context, string) error { return nil }
+func (c *splitOriginCarrier) ProviderName() string                         { return "delhivery" }
+func (c *splitOriginCarrier) SupportedCountries() []string                 { return []string{"SO"} }
+
+func (c *splitOriginCarrier) callCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.calls)
+}
+
+func (c *splitOriginCarrier) fromAddresses() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, 0, len(c.calls))
+	for _, call := range c.calls {
+		out = append(out, call.FromAddress.Line1)
+	}
+	return out
+}
+
+func seedSplitOriginCountry(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`INSERT INTO supported_countries
+		    (country_code, name, currency_code, region, payment_providers, shipping_carriers, tax_strategy)
+		 VALUES ('SO', 'Split Origin Test Land', 'USD', 'test', '{}', '{delhivery}', 'flat')
+		 ON CONFLICT (country_code) DO NOTHING`).Error)
+	t.Cleanup(func() {
+		db.Exec(`DELETE FROM supported_countries WHERE country_code = 'SO'`)
+	})
+}
+
+func seedSplitOriginStore(t *testing.T, db *gorm.DB) *stores.Store {
+	t.Helper()
+	seedSplitOriginCountry(t, db)
+	storeID := uuid.NewString()
+	s := &stores.Store{
+		ID:           storeID,
+		TenantID:     uuid.NewString(),
+		Slug:         "split-" + storeID[:8],
+		Name:         "Split Origin Test Store",
+		CountryCode:  "SO",
+		CurrencyCode: "USD",
+		Timezone:     "UTC",
+		Status:       stores.StatusActive,
+		SyncedAt:     time.Now(),
+	}
+	require.NoError(t, db.Create(s).Error)
+	return s
+}
+
+func seedSplitOriginWarehouse(t *testing.T, db *gorm.DB, tenantID, storeID, name string, priority int, isDefault bool) warehouse.Warehouse {
+	t.Helper()
+	wh, err := warehouse.NewRepository().Upsert(context.Background(), db, warehouse.Warehouse{
+		TenantID:    tenantID,
+		StoreID:     storeID,
+		Name:        name,
+		Line1:       name + " Line1",
+		City:        name + " City",
+		Region:      "RG",
+		PostalCode:  "00000",
+		CountryCode: "SO",
+		Phone:       "+10000000000",
+		IsDefault:   isDefault,
+		Priority:    priority,
+	})
+	require.NoError(t, err)
+	return wh
+}
+
+func seedSplitOriginCarrierConfig(t *testing.T, db *gorm.DB, storeID, tenantID, warehouseID string) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`INSERT INTO shipping_carrier_configs
+		    (id, tenant_id, store_id, provider, api_key_encrypted, mode, is_active, warehouse_id)
+		 VALUES (?, ?, ?, 'delhivery', 'test-key', 'test', true, ?)`,
+		uuid.NewString(), tenantID, storeID, warehouseID).Error)
+}
+
+func seedSplitOriginVariant(t *testing.T, db *gorm.DB, tenantID, storeID string) string {
+	t.Helper()
+	productID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO products (id, tenant_id, store_id, title, handle, status, vendor_id, published_at)
+		 VALUES (?, ?, ?, 'Split Origin Widget', ?, 'active', ?, now())`,
+		productID, tenantID, storeID, "split-"+uuid.NewString()[:8], uuid.NewString()).Error)
+
+	variantID := uuid.NewString()
+	require.NoError(t, db.Exec(
+		`INSERT INTO product_variants (id, product_id, store_id, sku, price, currency_code, weight_grams)
+		 VALUES (?, ?, ?, ?, 10.00, 'USD', 100)`,
+		variantID, productID, storeID, "SKU-"+uuid.NewString()[:8]).Error)
+	return variantID
+}
+
+func seedSplitOriginStock(t *testing.T, db *gorm.DB, variantID, locationID string, qty int) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`INSERT INTO variant_stock (variant_id, location_id, quantity, updated_at)
+		 VALUES (?, ?, ?, now())`, variantID, locationID, qty).Error)
+}
+
+// splitOriginRig bundles everything a GetRates test needs.
+type splitOriginRig struct {
+	router    *gin.Engine
+	db        *gorm.DB
+	store     *stores.Store
+	carrier   *splitOriginCarrier
+	whA, whB  warehouse.Warehouse
+	variantID string
+}
+
+// setupSplitOriginRig seeds a store with TWO warehouses and one variant,
+// wires ShippingRatesHandler to the stub carrier, and returns everything
+// a test needs to drive it. cfgWarehouse selects which warehouse the
+// carrier config (and therefore the single-origin fallback) links to.
+func setupSplitOriginRig(t *testing.T, stockA, stockB int, cfgWarehouse string) *splitOriginRig {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	db := testdb.NewDB(t, splitOriginTables...)
+
+	store := seedSplitOriginStore(t, db)
+	whA := seedSplitOriginWarehouse(t, db, store.TenantID, store.ID, "WH Alpha", 1, true)
+	whB := seedSplitOriginWarehouse(t, db, store.TenantID, store.ID, "WH Beta", 2, false)
+	variantID := seedSplitOriginVariant(t, db, store.TenantID, store.ID)
+	if stockA > 0 {
+		seedSplitOriginStock(t, db, variantID, whA.ID, stockA)
+	}
+	if stockB > 0 {
+		seedSplitOriginStock(t, db, variantID, whB.ID, stockB)
+	}
+	linked := whA.ID
+	if cfgWarehouse == whB.ID {
+		linked = whB.ID
+	}
+	seedSplitOriginCarrierConfig(t, db, store.ID, store.TenantID, linked)
+
+	carrier := &splitOriginCarrier{}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	h := NewShippingRatesHandler(db, crypto.NewNoopEncryptor(), logger).WithCarrierFactory(func(string) (shipping.Carrier, bool) {
+		return carrier, true
+	})
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("store", store)
+		c.Next()
+	})
+	r.POST("/rates", h.GetRates)
+
+	return &splitOriginRig{router: r, db: db, store: store, carrier: carrier, whA: whA, whB: whB, variantID: variantID}
+}
+
+func (rig *splitOriginRig) postRates(t *testing.T, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/rates", strings.NewReader(string(b)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	rig.router.ServeHTTP(rec, req)
+	return rec
+}
+
+func rateRequestBody(variantID string, qty int) map[string]any {
+	return map[string]any{
+		"items": []map[string]any{{
+			"product_id":   "prod-1",
+			"variant_id":   variantID,
+			"quantity":     qty,
+			"weight_grams": 100,
+		}},
+		"ship_to": map[string]any{
+			"line1":        "1 Buyer St",
+			"city":         "Buyer City",
+			"country_code": "SO",
+		},
+	}
+}
+
+// TestGetRates_SplitOriginSumsPricesAndReportsShipmentCount is the
+// acceptance test for #541: a variant split across two warehouses must
+// produce two carrier calls from different origins, a combined price
+// that SUMS both origins' rate, and an additive shipment_count.
+func TestGetRates_SplitOriginSumsPricesAndReportsShipmentCount(t *testing.T) {
+	rig := setupSplitOriginRig(t, 3, 4, "")
+	rig.carrier.ratesFor = map[string][]shipping.Rate{
+		rig.whA.Line1: {{Carrier: "delhivery", Service: "Standard", Price: decimal.NewFromInt(5), CurrencyCode: "USD", EstimatedDays: 1}},
+		rig.whB.Line1: {{Carrier: "delhivery", Service: "Standard", Price: decimal.NewFromInt(7), CurrencyCode: "USD", EstimatedDays: 2}},
+	}
+
+	// Requesting 5 units against 3@whA + 4@whB forces allocation.Plan to
+	// split: 3 from whA (higher priority, filled first), 2 from whB.
+	rec := rig.postRates(t, rateRequestBody(rig.variantID, 5))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	require.Equal(t, 2, rig.carrier.callCount(), "must call the carrier once per fulfilling warehouse")
+	addrs := rig.carrier.fromAddresses()
+	require.ElementsMatch(t, []string{rig.whA.Line1, rig.whB.Line1}, addrs, "each call's FromAddress must be a different origin")
+
+	var parsed struct {
+		Data []map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &parsed))
+	require.Len(t, parsed.Data, 1)
+	require.Equal(t, "12.00", parsed.Data[0]["price"], "price must be the SUM of both origins' rate")
+	require.Equal(t, float64(2), parsed.Data[0]["estimated_days"], "estimated_days must be the MAX across origins")
+	require.Equal(t, float64(2), parsed.Data[0]["shipment_count"])
+}
+
+// TestGetRates_SingleWarehouseUnchanged is the regression guard for the
+// overwhelmingly common case: a store with only one warehouse must see
+// EXACTLY one carrier call and a response with no shipment_count field at
+// all — identical to the pre-#541 behaviour.
+func TestGetRates_SingleWarehouseUnchanged(t *testing.T) {
+	rig := setupSplitOriginRig(t, 5, 0, "")
+	rig.carrier.ratesFor = map[string][]shipping.Rate{
+		rig.whA.Line1: {{Carrier: "delhivery", Service: "Standard", Price: decimal.NewFromInt(5), CurrencyCode: "USD", EstimatedDays: 1}},
+	}
+
+	rec := rig.postRates(t, rateRequestBody(rig.variantID, 3))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	require.Equal(t, 1, rig.carrier.callCount(), "a single-warehouse store must make exactly one carrier call")
+	require.Equal(t, []string{rig.whA.Line1}, rig.carrier.fromAddresses())
+
+	var parsed struct {
+		Data []map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &parsed))
+	require.Len(t, parsed.Data, 1)
+	require.Equal(t, "5.00", parsed.Data[0]["price"])
+	_, hasShipmentCount := parsed.Data[0]["shipment_count"]
+	require.False(t, hasShipmentCount, "shipment_count must be omitted on the single-origin path")
+}
+
+// TestGetRates_ServiceMissingFromOneOriginIsExcluded pins the intersection
+// rule: a service only one origin can provide cannot ship the whole
+// order, so it must not appear in the combined result.
+func TestGetRates_ServiceMissingFromOneOriginIsExcluded(t *testing.T) {
+	rig := setupSplitOriginRig(t, 3, 4, "")
+	rig.carrier.ratesFor = map[string][]shipping.Rate{
+		rig.whA.Line1: {
+			{Carrier: "delhivery", Service: "Standard", Price: decimal.NewFromInt(5), CurrencyCode: "USD", EstimatedDays: 1},
+			{Carrier: "delhivery", Service: "Express", Price: decimal.NewFromInt(9), CurrencyCode: "USD", EstimatedDays: 1},
+		},
+		rig.whB.Line1: {
+			{Carrier: "delhivery", Service: "Standard", Price: decimal.NewFromInt(7), CurrencyCode: "USD", EstimatedDays: 2},
+		},
+	}
+
+	rec := rig.postRates(t, rateRequestBody(rig.variantID, 5))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var parsed struct {
+		Data []map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &parsed))
+	require.Len(t, parsed.Data, 1, "only the service present in EVERY origin group may be offered")
+	require.Equal(t, "Standard", parsed.Data[0]["service"])
+}
+
+// TestGetRates_EstimatedDaysIsMaxAcrossOrigins pins the days rule
+// separately from the price rule.
+func TestGetRates_EstimatedDaysIsMaxAcrossOrigins(t *testing.T) {
+	rig := setupSplitOriginRig(t, 3, 4, "")
+	rig.carrier.ratesFor = map[string][]shipping.Rate{
+		rig.whA.Line1: {{Carrier: "delhivery", Service: "Standard", Price: decimal.NewFromInt(1), CurrencyCode: "USD", EstimatedDays: 2}},
+		rig.whB.Line1: {{Carrier: "delhivery", Service: "Standard", Price: decimal.NewFromInt(1), CurrencyCode: "USD", EstimatedDays: 5}},
+	}
+
+	rec := rig.postRates(t, rateRequestBody(rig.variantID, 5))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var parsed struct {
+		Data []map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &parsed))
+	require.Len(t, parsed.Data, 1)
+	require.Equal(t, float64(5), parsed.Data[0]["estimated_days"], "estimated_days must be the slowest origin's, not the fastest's")
+}
+
+// TestGetRates_FallsBackWhenVariantIDMissing covers #541's first fallback
+// condition: any item without a variant_id must use the single-origin
+// path entirely, even though the store has two warehouses.
+func TestGetRates_FallsBackWhenVariantIDMissing(t *testing.T) {
+	rig := setupSplitOriginRig(t, 3, 4, "")
+	rig.carrier.ratesFor = map[string][]shipping.Rate{
+		rig.whA.Line1: {{Carrier: "delhivery", Service: "Standard", Price: decimal.NewFromInt(5), CurrencyCode: "USD", EstimatedDays: 1}},
+	}
+
+	body := map[string]any{
+		"items": []map[string]any{{
+			"product_id":   "prod-1",
+			"quantity":     1,
+			"weight_grams": 100,
+			// variant_id deliberately omitted
+		}},
+		"ship_to": map[string]any{
+			"line1": "1 Buyer St", "city": "Buyer City", "country_code": "SO",
+		},
+	}
+	rec := rig.postRates(t, body)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	require.Equal(t, 1, rig.carrier.callCount(), "a missing variant_id must fall back to a single carrier call")
+	require.Equal(t, []string{rig.whA.Line1}, rig.carrier.fromAddresses(), "the fallback call must use the carrier config's linked warehouse")
+
+	var parsed struct {
+		Data []map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &parsed))
+	require.Len(t, parsed.Data, 1)
+	_, hasShipmentCount := parsed.Data[0]["shipment_count"]
+	require.False(t, hasShipmentCount)
+}
+
+// TestGetRates_FallsBackWhenPlanCannotFill covers the CannotFillError
+// fallback condition: a cart asking for more units than every warehouse
+// holds combined must still return a quote, from the single-origin path.
+func TestGetRates_FallsBackWhenPlanCannotFill(t *testing.T) {
+	rig := setupSplitOriginRig(t, 1, 2, "") // only 3 units exist across both warehouses
+	rig.carrier.ratesFor = map[string][]shipping.Rate{
+		rig.whA.Line1: {{Carrier: "delhivery", Service: "Standard", Price: decimal.NewFromInt(5), CurrencyCode: "USD", EstimatedDays: 1}},
+	}
+
+	rec := rig.postRates(t, rateRequestBody(rig.variantID, 10)) // more than the 3 available
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	require.Equal(t, 1, rig.carrier.callCount(), "a cart allocation.Plan cannot fill must fall back to a single carrier call")
+	require.Equal(t, []string{rig.whA.Line1}, rig.carrier.fromAddresses())
+}
+
+// TestCalculateShipping_MatchesGetRatesQuoteForSameSplitCart is the point
+// of #541: the checkout charge and the rates quote must never disagree
+// about a split cart's price. Before this fix, checkout_ext.go priced
+// from ONE fixed origin while (once fixed) GetRates priced from the
+// warehouses that actually fulfil the cart — so a merchant could quote
+// one number and charge another for the identical cart.
+func TestCalculateShipping_MatchesGetRatesQuoteForSameSplitCart(t *testing.T) {
+	rig := setupSplitOriginRig(t, 3, 4, "")
+	rig.carrier.ratesFor = map[string][]shipping.Rate{
+		rig.whA.Line1: {{Carrier: "delhivery", Service: "Standard", Price: decimal.NewFromInt(5), CurrencyCode: "USD", EstimatedDays: 1}},
+		rig.whB.Line1: {{Carrier: "delhivery", Service: "Standard", Price: decimal.NewFromInt(7), CurrencyCode: "USD", EstimatedDays: 2}},
+	}
+
+	// What the rates endpoint quotes for this cart.
+	rec := rig.postRates(t, rateRequestBody(rig.variantID, 5))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var parsed struct {
+		Data []map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &parsed))
+	require.Len(t, parsed.Data, 1)
+	quotedPrice := parsed.Data[0]["price"].(string)
+	require.Equal(t, "12.00", quotedPrice, "sanity: this is the split-origin sum, not a single origin's rate")
+
+	// What checkout charges for the SAME cart, same service.
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	ceh := NewCheckoutExtHandler(rig.db, nil, nil, nil, crypto.NewNoopEncryptor(), logger).
+		WithCarrierFactory(func(string) (shipping.Carrier, bool) { return rig.carrier, true })
+
+	variantID := rig.variantID
+	req := CheckoutExtRequest{
+		Items: []CheckoutItemRequest{{
+			VariantID:     &variantID,
+			TitleSnapshot: "Split Origin Widget",
+			SKUSnapshot:   "SKU-1",
+			UnitPrice:     decimal.NewFromInt(10),
+			Quantity:      5,
+			LineTotal:     decimal.NewFromInt(50),
+			CurrencyCode:  "USD",
+		}},
+		ShippingAddress: CheckoutAddressRequest{
+			Name: "Buyer", Line1: "1 Buyer St", City: "Buyer City", CountryCode: "SO",
+		},
+		ShippingService: "Standard",
+		Subtotal:        decimal.NewFromInt(50),
+	}
+	sc := &country.SupportedCountry{ShippingCarriers: pq.StringArray{"delhivery"}}
+
+	price, provider, err := ceh.calculateShipping(context.Background(), rig.store, sc, req)
+	require.NoError(t, err)
+	require.Equal(t, "delhivery", provider)
+	require.Equal(t, quotedPrice, price.StringFixed(2),
+		"checkout must charge exactly what GetRates quoted for the same split cart")
+}


### PR DESCRIPTION
Closes #541.

Checkout priced shipping from **one fixed origin** — the carrier config's linked warehouse (`cfg.WarehouseID`) — regardless of where the stock actually sat. Since multi-warehouse landed (#177) a variant's stock can span warehouses, so allocation produces several shipments while the quote charged for one parcel from one place. The merchant absorbed the difference, and the gap grows with the distance between warehouses.

`checkout_ext.go` duplicated the same assumption inline, so **both paths are fixed here**. Fixing only the quote would leave the quote disagreeing with the charge, which is worse than today's consistent-but-wrong behaviour.

## Approach: reuse the allocation machinery, don't re-derive it

`buildOriginGroups` calls the same helpers commit-time allocation uses — `storeWarehousesInFillOrder`, `loadAvailability`, `allocation.Plan` — then groups assignments by warehouse. The quote and the eventual shipments therefore agree **by construction** rather than by two implementations happening to match.

## The combine rule

- **Services: intersection.** Only `(carrier, service)` pairs offered by *every* origin are returned. A service available from one origin cannot ship the whole order, so quoting it would under-quote — the bug being fixed. Empty intersection returns no rates rather than a wrong price.
- **Price: summed** across origins, handling fee applied once.
- **`estimated_days`: max** across origins — the order isn't complete until the last parcel lands.

`combineOriginRates` also guards against one group listing the same service twice, so a duplicate can't inflate the sum or fake the "offered by every origin" count.

## Response

Unchanged shape and fields, plus additive `shipment_count` (omitempty). Clients that ignore it are unaffected.

## The single-warehouse path is untouched

This mattered more than the fix: every store today takes that path and it is currently correct, so a regression there would hit *all* stores rather than only multi-warehouse ones.

It is guaranteed structurally, not by a flag — the split branch is `else if len(groups) > 1`, so a single origin falls **through** to the original code, byte for byte. `TestGetRates_SingleWarehouseUnchanged` pins it: exactly one carrier call, `shipment_count` omitted.

## Fallbacks never fail a quote

Falls back to the single-origin path, logging at INFO, when: any item lacks `variant_id` (deliberately not `binding:"required"` — unstocked/custom lines are legitimate), no warehouses exist, availability can't load, or `Plan` returns `CannotFillError`. A split that can't be computed must never turn into a 5xx.

## A defect in my brief, caught by implementation

The brief said to pass `""` as `cartToken` when reading availability. That is wrong: `stock_holds.cart_token` is a Postgres **`uuid`** column (migration `000115_stock_holds.up.sql:16`), so binding `""` raises `invalid input syntax for type uuid: ""` — and via the fallback rules above that error would have **silently disabled the entire feature**, leaving every split order still under-quoted while all tests looked green.

It is implemented with a nil-UUID sentinel instead, documented at the call site. Same intent — the token only excludes *the caller's own* holds, so a value no cart can have subtracts every live hold, which is the conservative choice for a customer who has reserved nothing yet.

## Test plan

All 7 new tests are `//go:build integration` and were run against a real Postgres (`TEST_DATABASE_URL`, `-tags=integration -p 1 -count=1`), confirmed executing rather than skipping — these tests print `ok` and prove nothing if the DSN is unset:

- [x] `TestGetRates_SplitOriginSumsPricesAndReportsShipmentCount` — two origins, two carrier calls from different `FromAddress`, summed price, `shipment_count: 2`
- [x] `TestGetRates_SingleWarehouseUnchanged` — one carrier call, response identical to today
- [x] `TestGetRates_ServiceMissingFromOneOriginIsExcluded`
- [x] `TestGetRates_EstimatedDaysIsMaxAcrossOrigins`
- [x] `TestGetRates_FallsBackWhenVariantIDMissing` — 200, single origin
- [x] `TestGetRates_FallsBackWhenPlanCannotFill`
- [x] `TestCalculateShipping_MatchesGetRatesQuoteForSameSplitCart` — **the charge equals the quote for the same split cart**, which is the actual point of the issue
- [x] `go test ./...` 0 failures; `go build`, `go vet`, `gofmt` clean
- [x] `scripts/ci/verify-logging-smoke.sh` PASS
- [x] No credential handling added — `shipping_origins.go` touches no API key or secret reference

Refs #177, #541.
