### PR TITLE
fix(httpserver): install the Prometheus middleware so request metrics exist (#624)

### DIFF
--- a/services/marketplace-api/pkg/httpserver/metrics_middleware_test.go
+++ b/services/marketplace-api/pkg/httpserver/metrics_middleware_test.go
@@ -1,0 +1,85 @@
+package httpserver
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/mark8ly/marketplace-api/internal/metrics"
+	"github.com/mark8ly/marketplace-api/internal/mode"
+)
+
+// internal/middleware.Prometheus() existed and populated HTTPRequestsTotal /
+// HTTPRequestDuration, but was installed on NO router — so the service
+// exported no request, latency or error metrics at all, and
+// http_requests_total had zero series in production (mark8ly#624).
+//
+// It belongs here rather than in main.go's two mode branches: this is where
+// every engine already gets its baseline middleware, it runs before any
+// route is registered (gin's Use is not retroactive — the same trap that
+// silently dropped customer ids in storefront/routes.go), and a future
+// engine inherits it instead of forgetting it.
+
+func serveOnce(t *testing.T, r *gin.Engine, method, route, url string) {
+	t.Helper()
+	r.Handle(method, route, func(c *gin.Context) { c.Status(http.StatusOK) })
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(method, url, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("request returned %d, want 200", rec.Code)
+	}
+}
+
+func TestNew_EnginesRecordRequestMetrics(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	e := New("test", mode.Admin, log)
+
+	const route = "/metrics-mw-probe/:id"
+	before := testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues(http.MethodGet, route, "200"))
+
+	serveOnce(t, e.Admin, http.MethodGet, route, "/metrics-mw-probe/abc")
+
+	after := testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues(http.MethodGet, route, "200"))
+	if after != before+1 {
+		t.Errorf("http_requests_total = %v, want %v — Prometheus middleware is not installed on the engine", after, before+1)
+	}
+}
+
+func TestMergedForBoth_RecordsRequestMetrics(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	r := MergedForBoth("test", log)
+
+	const route = "/metrics-mw-merged-probe"
+	before := testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues(http.MethodGet, route, "200"))
+
+	serveOnce(t, r, http.MethodGet, route, route)
+
+	after := testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues(http.MethodGet, route, "200"))
+	if after != before+1 {
+		t.Errorf("http_requests_total = %v, want %v — Prometheus middleware is not installed on the merged engine", after, before+1)
+	}
+}
+
+// The path label must be the ROUTE PATTERN, never the raw URL. Labelling by
+// raw path would give every product handle and order id its own time series
+// and blow up cardinality — the standard way this middleware goes wrong.
+func TestEngine_MetricsPathLabelIsRoutePatternNotRawURL(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	e := New("test", mode.Storefront, log)
+
+	const route = "/metrics-mw-cardinality/:handle"
+	serveOnce(t, e.Storefront, http.MethodGet, route, "/metrics-mw-cardinality/some-unique-handle")
+
+	if got := testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues(http.MethodGet, route, "200")); got < 1 {
+		t.Errorf("no series for the route pattern %q; got %v", route, got)
+	}
+	raw := "/metrics-mw-cardinality/some-unique-handle"
+	if got := testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues(http.MethodGet, raw, "200")); got != 0 {
+		t.Errorf("a series exists for the RAW path %q (%v) — path label must be the route pattern", raw, got)
+	}
+}

--- a/services/marketplace-api/pkg/httpserver/server.go
+++ b/services/marketplace-api/pkg/httpserver/server.go
@@ -34,6 +34,7 @@ func New(env string, m mode.Mode, log *slog.Logger) Engines {
 		r := gin.New()
 		r.Use(gin.Recovery())
 		r.Use(middleware.SecurityHeaders())
+		r.Use(middleware.Prometheus())
 		r.Use(requestLogger(log.With(slog.String("engine", label))))
 		return r
 	}
@@ -59,6 +60,7 @@ func MergedForBoth(env string, log *slog.Logger) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
 	r.Use(middleware.SecurityHeaders())
+	r.Use(middleware.Prometheus())
 	r.Use(requestLogger(log))
 	return r
 }


### PR DESCRIPTION
Follow-up to #624 / #625. Two lines of wiring, three tests.

`internal/middleware.Prometheus()` exists and populates `HTTPRequestsTotal` and `HTTPRequestDuration` — but it was installed on **no router**. Verified against a live pod: `http_requests_total` had **zero series** while the engine was serving traffic. The service exports no request-rate, latency or error-rate metrics at all.

#625 made `/metrics` real. This makes it worth scraping.

## Why `pkg/httpserver` and not `main.go`

`main.go` applies `otelgin` in two places (the `mode.Both` branch and the `mode.Admin, mode.Storefront` branch), so wiring it there means two edits and a standing invitation to forget the third. `pkg/httpserver` is where every engine already gets `gin.Recovery()`, `SecurityHeaders()` and `requestLogger()`:

- one place covers `New()` (both per-mode engines) and `MergedForBoth()` (dev),
- it runs **before any route is registered** — gin's `Use` is not retroactive, which is the exact trap that silently dropped `customer_id` from every order in `storefront/routes.go`,
- it is testable without booting `main`,
- a future engine inherits it rather than omitting it.

## Cardinality — the standard way this goes wrong

The middleware labels by `c.FullPath()`, the **route pattern**, not the raw URL. Labelling by raw path would give every product handle and order id its own time series. `TestEngine_MetricsPathLabelIsRoutePatternNotRawURL` pins that in both directions: a series must exist for `/metrics-mw-cardinality/:handle` and must **not** exist for the concrete URL that produced it.

Unmatched routes already collapse to `"unknown"`, so 404 scans can't inflate cardinality either.

## Tests

All three verified RED first — `http_requests_total = 0, want 1 — Prometheus middleware is not installed on the engine`:

- `TestNew_EnginesRecordRequestMetrics`
- `TestMergedForBoth_RecordsRequestMetrics`
- `TestEngine_MetricsPathLabelIsRoutePatternNotRawURL`

## Note on the base

This branch was initially cut from a stale local ref and rebased onto `origin/main` before opening; the diff is the intended 2 files (+87), with no side effects on #631/#632.

## Test plan

- [x] Three tests verified RED before GREEN
- [x] `go test ./...` — 0 failures
- [x] `go build`, `go vet`, `gofmt` clean
- [x] `scripts/ci/verify-logging-smoke.sh` PASS
- [ ] After deploy: `curl :9090/metrics | grep http_requests_total` returns series labelled by route pattern

## Still outstanding

Nothing scrapes `/metrics` yet — Managed Prometheus is **not** enabled on the cluster (`managedPrometheusConfig: {}`) and no in-cluster Prometheus exists. Values remain readable only by port-forward, which is enough for point-in-time checks (that is how #621's decommission evidence was gathered) but gives no history and no alerting. Choosing a scrape target is a separate, cost-bearing decision.

Refs #624, #625.
