### PR TITLE
feat(auth): storefront customer login through Zitadel, and close the credential oracle (#524)

### DIFF
--- a/apps/admin/lib/auth/auth-bff.ts
+++ b/apps/admin/lib/auth/auth-bff.ts
@@ -8,6 +8,29 @@ import { parseLoginResponse, type LoginOutcome } from "./login-response";
 
 const base = config.authBffUrl;
 
+/**
+ * The shared service-to-service secret auth-bff's Zitadel credential
+ * endpoints require in the X-Internal-Auth header — the same scheme and the
+ * same env var this app already uses for marketplace-api's internal routes
+ * (see lib/api/marketplace-api.ts).
+ *
+ * auth-bff is publicly reachable (auth.mark8ly.com routes to it on any
+ * path) and /auth/zitadel/login answers whether a {login_name, password}
+ * pair is valid against an instance-level login-client PAT, so without this
+ * header the route is a credential oracle over every user in the Zitadel
+ * instance, merchant admins included. This module is imported from server
+ * actions only, so the header costs one line — read from server config,
+ * never a NEXT_PUBLIC_* variable, which would ship the secret to the
+ * browser bundle.
+ *
+ * Read at call time rather than module scope so a value injected after
+ * module evaluation (and a test's stubbed env) is still seen.
+ */
+function internalAuthHeader(): Record<string, string> {
+  const secret = process.env.MARKETPLACE_INTERNAL_AUTH_SECRET ?? "";
+  return secret ? { "X-Internal-Auth": secret } : {};
+}
+
 export class AuthBffError extends Error {
   constructor(
     public status: number,
@@ -383,7 +406,10 @@ interface ZitadelTotpRequest {
 export async function zitadelLogin(
   req: ZitadelLoginRequest,
 ): Promise<LoginOutcome & { setCookies: string[] }> {
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...internalAuthHeader(),
+  };
   if (req.userAgent) headers["User-Agent"] = req.userAgent;
   if (req.forwardedFor) headers["X-Forwarded-For"] = req.forwardedFor;
 
@@ -428,7 +454,10 @@ export async function zitadelLogin(
 export async function zitadelTotp(
   req: ZitadelTotpRequest,
 ): Promise<LoginOutcome & { setCookies: string[] }> {
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...internalAuthHeader(),
+  };
   if (req.userAgent) headers["User-Agent"] = req.userAgent;
   if (req.forwardedFor) headers["X-Forwarded-For"] = req.forwardedFor;
 

--- a/apps/admin/lib/auth/auth-bff.zitadel.test.ts
+++ b/apps/admin/lib/auth/auth-bff.zitadel.test.ts
@@ -240,3 +240,56 @@ describe("zitadelTotp", () => {
     expect(JSON.stringify(err)).not.toContain(totpReq.code);
   });
 });
+
+// The X-Internal-Auth header is what stops auth-bff's publicly reachable
+// /auth/zitadel/{login,totp} from being a credential-validity oracle over
+// every user in the Zitadel instance — the login-client PAT behind them is
+// instance-level, so merchant admins are in scope too. These pin that this
+// server-actions-only client sends it, and never from a NEXT_PUBLIC_*
+// variable (which would ship the secret to the browser bundle).
+describe("internal auth header", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("sends X-Internal-Auth on /auth/zitadel/login", async () => {
+    vi.stubEnv("MARKETPLACE_INTERNAL_AUTH_SECRET", "s3cret-internal");
+    const fetchMock = stubFetch(200, {
+      data: { uid: "u1", email: "merchant@example.com", tenant_id: "tenant-1" },
+    });
+
+    await zitadelLogin(loginReq);
+
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["X-Internal-Auth"]).toBe("s3cret-internal");
+  });
+
+  it("sends X-Internal-Auth on /auth/zitadel/totp", async () => {
+    vi.stubEnv("MARKETPLACE_INTERNAL_AUTH_SECRET", "s3cret-internal");
+    const fetchMock = stubFetch(200, {
+      data: { uid: "u1", email: "merchant@example.com", tenant_id: "tenant-1" },
+    });
+
+    await zitadelTotp(totpReq);
+
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["X-Internal-Auth"]).toBe("s3cret-internal");
+  });
+
+  it("never reads the secret from a NEXT_PUBLIC_ variable", async () => {
+    vi.stubEnv("MARKETPLACE_INTERNAL_AUTH_SECRET", "");
+    vi.stubEnv("NEXT_PUBLIC_MARKETPLACE_INTERNAL_AUTH_SECRET", "leaked");
+    const fetchMock = stubFetch(200, {
+      data: { uid: "u1", email: "merchant@example.com", tenant_id: "tenant-1" },
+    });
+
+    await zitadelLogin(loginReq);
+
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["X-Internal-Auth"]).toBeUndefined();
+    expect(JSON.stringify(init)).not.toContain("leaked");
+  });
+});

--- a/apps/storefront/app/sign-in/actions.ts
+++ b/apps/storefront/app/sign-in/actions.ts
@@ -2,9 +2,14 @@
 
 // Server action for storefront customer sign-in.
 //
-// Customer auth skips auth-bff entirely — auth-bff's auto-login checks
-// OpenFGA tenant membership which customers don't have. Instead we:
-//   1. Verify the GIP id_token signature, project, tenant, and expiry.
+// Customer auth skips auth-bff's merchant gauntlet entirely — auth-bff's
+// auto-login checks OpenFGA tenant membership which customers don't have.
+// Instead we:
+//   1. Verify the credential — under GIP, the Identity Toolkit id_token
+//      (signature, project, tenant, expiry); under Zitadel, the login
+//      name + password via auth-bff's storefront-customer endpoint
+//      (see @/lib/auth/auth-bff-customer). This is the ONLY step that
+//      differs between providers — see the comment on AUTH_PROVIDER below.
 //   2. Set an HMAC-signed `mp_customer_session` cookie.
 //   3. Ensure the customer profile exists in marketplace-api.
 
@@ -14,6 +19,7 @@ import {
   GIPTokenVerificationError,
   verifyGIPIdToken,
 } from "@/lib/gip/verify-id-token";
+import { verifyCustomerCredential } from "@/lib/auth/auth-bff-customer";
 import { sanitizeHost } from "@/lib/host";
 import { platformInternalFetch } from "@/lib/api/server/platformInternal";
 
@@ -23,17 +29,42 @@ const STOREFRONT_KEY = process.env.MARKETPLACE_STOREFRONT_KEY ?? "";
 const GIP_PROJECT_ID = process.env.GIP_PROJECT_ID ?? "";
 const GIP_CUSTOMER_TENANT_ID = process.env.GIP_CUSTOMER_TENANT_ID ?? "";
 
+// Which identity provider verifies the credential in customerSignIn below.
+// Read defensively, matching apps/admin/lib/config.ts's publicConfig.authProvider
+// rule exactly: only the literal string "zitadel" switches the path — unset,
+// empty, or any other value (including "Zitadel" or "true") stays on GIP.
+// NEXT_PUBLIC_-prefixed (not server-only) because CustomerSignInForm, a client
+// component, must branch on the identical value to decide whether to call
+// Identity Toolkit from the browser at all.
+const AUTH_PROVIDER: "gip" | "zitadel" =
+  process.env.NEXT_PUBLIC_AUTH_PROVIDER === "zitadel" ? "zitadel" : "gip";
+
 type Result =
   | { ok: true }
   | { ok: false; code: string; message: string };
 
 interface CustomerSignInInput {
-  idToken: string;
-  /** Deprecated: ignored. The trusted UID comes from the verified idToken. */
-  uid: string;
   storeSlug: string;
-  /** Deprecated: ignored. The trusted email comes from the verified idToken. */
+  /** GIP path only: the verified Identity Toolkit id_token. */
+  idToken?: string;
+  /** Deprecated: ignored. The trusted UID comes from the verified credential. */
+  uid?: string;
+  /** Deprecated: ignored. The trusted email comes from the verified credential. */
   email?: string;
+  /** Zitadel path only: the login name (email) collected by the form. */
+  loginName?: string;
+  /** Zitadel path only: the password collected by the form. Never logged. */
+  password?: string;
+  /**
+   * Zitadel path only: the auth-bff `auth_request_id` for this login
+   * attempt. Obtaining a real one requires an OIDC authorize round-trip
+   * (see apps/admin/app/login/authorize/route.ts for the merchant analog)
+   * that is out of scope for this task — see the phase's progress ledger.
+   * Defaults to "" until that plumbing exists, which auth-bff rejects
+   * with a 400 today, so the Zitadel path is not yet reachable end-to-end
+   * outside tests.
+   */
+  authRequestId?: string;
 }
 
 async function resolveStore(
@@ -149,11 +180,43 @@ export async function customerSignIn(
       };
     }
 
-    const verified = await verifyGIPIdToken(
-      input.idToken,
-      GIP_PROJECT_ID,
-      GIP_CUSTOMER_TENANT_ID,
-    );
+    // The ONLY step that differs between providers: how the credential is
+    // verified and where {uid, email} come from. Everything below this
+    // block — cookie minting, domain scoping, profile/loyalty side
+    // effects — is identical on both paths.
+    let verified: { uid: string; email: string };
+    if (AUTH_PROVIDER === "zitadel") {
+      if (!input.loginName || !input.password) {
+        return {
+          ok: false,
+          code: "invalid_request",
+          message: "Email and password are required.",
+        };
+      }
+      const outcome = await verifyCustomerCredential({
+        authRequestId: input.authRequestId ?? "",
+        loginName: input.loginName,
+        password: input.password,
+      });
+      if (outcome.kind !== "complete") {
+        // Covers `rejected` (wrong credential — collapsed to one outcome,
+        // see auth-bff-customer.ts) as well as `totp_required` and
+        // `handoff`, neither of which the storefront form collects yet.
+        // No cookie is set in any of these cases.
+        return {
+          ok: false,
+          code: "invalid_credentials",
+          message: "Email or password is incorrect.",
+        };
+      }
+      verified = { uid: outcome.uid, email: outcome.email };
+    } else {
+      verified = await verifyGIPIdToken(
+        input.idToken ?? "",
+        GIP_PROJECT_ID,
+        GIP_CUSTOMER_TENANT_ID,
+      );
+    }
 
     // Set the HMAC-signed customer session cookie. The storefront
     // layout decodes and verifies this on every request to hydrate

--- a/apps/storefront/app/sign-in/actions.ts
+++ b/apps/storefront/app/sign-in/actions.ts
@@ -55,16 +55,6 @@ interface CustomerSignInInput {
   loginName?: string;
   /** Zitadel path only: the password collected by the form. Never logged. */
   password?: string;
-  /**
-   * Zitadel path only: the auth-bff `auth_request_id` for this login
-   * attempt. Obtaining a real one requires an OIDC authorize round-trip
-   * (see apps/admin/app/login/authorize/route.ts for the merchant analog)
-   * that is out of scope for this task — see the phase's progress ledger.
-   * Defaults to "" until that plumbing exists, which auth-bff rejects
-   * with a 400 today, so the Zitadel path is not yet reachable end-to-end
-   * outside tests.
-   */
-  authRequestId?: string;
 }
 
 async function resolveStore(
@@ -194,7 +184,6 @@ export async function customerSignIn(
         };
       }
       const outcome = await verifyCustomerCredential({
-        authRequestId: input.authRequestId ?? "",
         loginName: input.loginName,
         password: input.password,
       });

--- a/apps/storefront/app/sign-in/actions.ts
+++ b/apps/storefront/app/sign-in/actions.ts
@@ -187,18 +187,51 @@ export async function customerSignIn(
         loginName: input.loginName,
         password: input.password,
       });
-      if (outcome.kind !== "complete") {
-        // Covers `rejected` (wrong credential — collapsed to one outcome,
-        // see auth-bff-customer.ts) as well as `totp_required` and
-        // `handoff`, neither of which the storefront form collects yet.
-        // No cookie is set in any of these cases.
-        return {
-          ok: false,
-          code: "invalid_credentials",
-          message: "Email or password is incorrect.",
-        };
+      // Each non-"complete" outcome gets its own truthful message. None of
+      // them may render as "email or password is incorrect" — that would
+      // be false for a customer who typed the right password but hit a
+      // factor this endpoint can't finish (totp_required) or can't collect
+      // at all (handoff), and would send them into a retry loop that can
+      // never succeed. No cookie is set for any outcome below.
+      switch (outcome.kind) {
+        case "complete":
+          verified = { uid: outcome.uid, email: outcome.email };
+          break;
+        case "rejected":
+          // The one case this message IS true for: a wrong password or an
+          // unknown login name, collapsed to a single outcome upstream
+          // (see auth-bff-customer.ts) so this response can't be used to
+          // enumerate accounts.
+          return {
+            ok: false,
+            code: "invalid_credentials",
+            message: "Email or password is incorrect.",
+          };
+        case "totp_required":
+          // Zero customers have a second factor enrolled today (per the
+          // phase's progress ledger) — an honest "not supported yet"
+          // message is the correct interim. Building a TOTP entry screen
+          // is real UI work deferred to phase 3c alongside the Google
+          // trampoline.
+          return {
+            ok: false,
+            code: "totp_required",
+            message:
+              "This account needs an authenticator code to finish signing in, and this page can't collect one yet. Please contact support for help.",
+          };
+        case "handoff":
+          // A real, uncollectible factor (passkey, U2F, SMS OTP, recovery
+          // code, ...). The handoff URL is deliberately never surfaced —
+          // it lands the customer in Zitadel's own hosted UI, which mints
+          // no `mp_customer_session`, so following it would not complete
+          // sign-in on this storefront either.
+          return {
+            ok: false,
+            code: "signin_method_unsupported",
+            message:
+              "This account uses a sign-in method this storefront can't complete yet. Please contact support for help signing in.",
+          };
       }
-      verified = { uid: outcome.uid, email: outcome.email };
     } else {
       verified = await verifyGIPIdToken(
         input.idToken ?? "",
@@ -255,10 +288,17 @@ export async function customerSignIn(
         message: "Your sign-in session could not be verified. Please sign in again.",
       };
     }
+    // Anything else — including AuthBffCustomerError, whose .message is
+    // literally "auth-bff customer endpoint error: <code> (status <n>)" —
+    // must never reach the shopper verbatim. That string is meaningless as
+    // UI copy and hands an attacker internal error codes/status for free.
+    // Log the detail server-side and return one generic, actionable
+    // message instead.
+    console.error("customerSignIn failed with an unexpected error", err);
     return {
       ok: false,
       code: "unknown",
-      message: err instanceof Error ? err.message : String(err),
+      message: "Sign-in is temporarily unavailable. Please try again shortly.",
     };
   }
 }

--- a/apps/storefront/app/sign-in/actions.zitadel.test.ts
+++ b/apps/storefront/app/sign-in/actions.zitadel.test.ts
@@ -1,0 +1,370 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// customerSignIn's AUTH_PROVIDER flag is read once, at module-evaluation
+// time. To exercise both the GIP-default and the Zitadel branch in the
+// same file we reset the module registry and dynamically re-import
+// "./actions" per test, after setting process.env for that test — a
+// plain top-level import would freeze whichever value was set first.
+
+const cookieStore: Record<string, string> = {};
+const cookiesSetSpy = vi.fn(
+  (opts: { name: string; value: string; domain?: string }) => {
+    cookieStore[opts.name] = opts.value;
+  },
+);
+const cookiesDeleteSpy = vi.fn((name: string) => {
+  delete cookieStore[name];
+});
+
+let headerMap: Map<string, string>;
+
+const HOST = "shop.mark8ly.com";
+const SUBMITTED_PASSWORD = "correct-horse-battery-staple";
+
+vi.mock("next/headers", () => ({
+  headers: async () => ({
+    get: (key: string) => headerMap.get(key.toLowerCase()) ?? null,
+  }),
+  cookies: async () => ({
+    set: cookiesSetSpy,
+    get: (name: string) =>
+      cookieStore[name] !== undefined ? { value: cookieStore[name] } : undefined,
+    delete: cookiesDeleteSpy,
+  }),
+}));
+
+vi.mock("@/lib/gip/verify-id-token", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/gip/verify-id-token")
+  >("@/lib/gip/verify-id-token");
+  return { ...actual, verifyGIPIdToken: vi.fn() };
+});
+
+vi.mock("@/lib/auth/auth-bff-customer", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/auth/auth-bff-customer")
+  >("@/lib/auth/auth-bff-customer");
+  return { ...actual, verifyCustomerCredential: vi.fn() };
+});
+
+vi.mock("@/lib/api/server/platformInternal", () => ({
+  platformInternalFetch: vi.fn(),
+}));
+
+import {
+  GIPTokenVerificationError,
+  verifyGIPIdToken,
+} from "@/lib/gip/verify-id-token";
+import { verifyCustomerCredential } from "@/lib/auth/auth-bff-customer";
+import { platformInternalFetch } from "@/lib/api/server/platformInternal";
+
+const verifyGIPIdTokenMock = vi.mocked(verifyGIPIdToken);
+const verifyCustomerCredentialMock = vi.mocked(verifyCustomerCredential);
+const platformInternalFetchMock = vi.mocked(platformInternalFetch);
+
+const originalFetch = globalThis.fetch;
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+async function loadActions() {
+  return await import("./actions");
+}
+
+/** Decodes the base64 payload half of an encodeSession cookie value
+ *  (`<base64-payload>.<hex-signature>`) without needing the HMAC key. */
+function decodeCookiePayload(cookieValue: string): Record<string, unknown> {
+  const payload = cookieValue.slice(0, cookieValue.lastIndexOf("."));
+  return JSON.parse(Buffer.from(payload, "base64").toString());
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  delete process.env.NEXT_PUBLIC_AUTH_PROVIDER;
+
+  headerMap = new Map([["host", HOST]]);
+  for (const key of Object.keys(cookieStore)) delete cookieStore[key];
+  cookiesSetSpy.mockClear();
+  cookiesDeleteSpy.mockClear();
+
+  verifyGIPIdTokenMock.mockReset();
+  verifyCustomerCredentialMock.mockReset();
+
+  platformInternalFetchMock.mockReset();
+  platformInternalFetchMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({ data: { tenant_id: "tenant-1", id: "store-1" } }),
+  } as Response);
+
+  fetchSpy = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete process.env.NEXT_PUBLIC_AUTH_PROVIDER;
+  vi.clearAllMocks();
+});
+
+describe("customerSignIn — provider branch", () => {
+  it("flag unset: calls verifyGIPIdToken and not the Zitadel client", async () => {
+    verifyGIPIdTokenMock.mockResolvedValue({
+      uid: "u-gip",
+      email: "gip@example.com",
+      tenantId: "t",
+    });
+    const { customerSignIn } = await loadActions();
+
+    const result = await customerSignIn({
+      idToken: "id-token",
+      uid: "ignored",
+      storeSlug: "shop",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(verifyGIPIdTokenMock).toHaveBeenCalledTimes(1);
+    expect(verifyCustomerCredentialMock).not.toHaveBeenCalled();
+  });
+
+  it('flag "zitadel": calls the Zitadel client and not verifyGIPIdToken', async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "zitadel";
+    verifyCustomerCredentialMock.mockResolvedValue({
+      kind: "complete",
+      uid: "u-zit",
+      email: "zit@example.com",
+    });
+    const { customerSignIn } = await loadActions();
+
+    const result = await customerSignIn({
+      loginName: "zit@example.com",
+      password: SUBMITTED_PASSWORD,
+      storeSlug: "shop",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(verifyCustomerCredentialMock).toHaveBeenCalledTimes(1);
+    expect(verifyGIPIdTokenMock).not.toHaveBeenCalled();
+  });
+
+  it('an unrecognised flag value (e.g. "Zitadel") stays on the GIP path', async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "Zitadel"; // wrong case — must not match
+    verifyGIPIdTokenMock.mockResolvedValue({
+      uid: "u-gip",
+      email: "gip@example.com",
+      tenantId: "t",
+    });
+    const { customerSignIn } = await loadActions();
+
+    const result = await customerSignIn({
+      idToken: "id-token",
+      uid: "ignored",
+      storeSlug: "shop",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(verifyGIPIdTokenMock).toHaveBeenCalledTimes(1);
+    expect(verifyCustomerCredentialMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("customerSignIn — per-store cookie isolation (domain: cookieHost)", () => {
+  it("GIP path: the session cookie's domain equals the resolved request host", async () => {
+    verifyGIPIdTokenMock.mockResolvedValue({
+      uid: "u1",
+      email: "e1@example.com",
+      tenantId: "t",
+    });
+    const { customerSignIn } = await loadActions();
+
+    await customerSignIn({ idToken: "tok", uid: "ignored", storeSlug: "shop" });
+
+    expect(cookiesSetSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "mp_customer_session", domain: HOST }),
+    );
+  });
+
+  it("Zitadel path: the session cookie's domain equals the resolved request host", async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "zitadel";
+    verifyCustomerCredentialMock.mockResolvedValue({
+      kind: "complete",
+      uid: "u2",
+      email: "e2@example.com",
+    });
+    const { customerSignIn } = await loadActions();
+
+    await customerSignIn({
+      loginName: "e2@example.com",
+      password: SUBMITTED_PASSWORD,
+      storeSlug: "shop",
+    });
+
+    expect(cookiesSetSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "mp_customer_session", domain: HOST }),
+    );
+  });
+});
+
+describe("customerSignIn — failed verification sets no cookie", () => {
+  it("GIP: a token verification failure sets no cookie", async () => {
+    verifyGIPIdTokenMock.mockRejectedValue(
+      new GIPTokenVerificationError("bad token"),
+    );
+    const { customerSignIn } = await loadActions();
+
+    const result = await customerSignIn({
+      idToken: "bad",
+      uid: "ignored",
+      storeSlug: "shop",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(cookiesSetSpy).not.toHaveBeenCalled();
+  });
+
+  it("Zitadel: a rejected credential sets no cookie", async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "zitadel";
+    verifyCustomerCredentialMock.mockResolvedValue({ kind: "rejected" });
+    const { customerSignIn } = await loadActions();
+
+    const result = await customerSignIn({
+      loginName: "e@x.com",
+      password: "wrong-password",
+      storeSlug: "shop",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(cookiesSetSpy).not.toHaveBeenCalled();
+  });
+
+  it("Zitadel: a totp_required outcome (uncollected by this form) sets no cookie", async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "zitadel";
+    verifyCustomerCredentialMock.mockResolvedValue({
+      kind: "totp_required",
+      sessionId: "s1",
+      sessionToken: "tok1",
+    });
+    const { customerSignIn } = await loadActions();
+
+    const result = await customerSignIn({
+      loginName: "e@x.com",
+      password: SUBMITTED_PASSWORD,
+      storeSlug: "shop",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(cookiesSetSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("customerSignIn — uid/email come from the verification result", () => {
+  it("GIP: the session is built from verifyGIPIdToken's result, not client-supplied uid/email", async () => {
+    verifyGIPIdTokenMock.mockResolvedValue({
+      uid: "trusted-uid",
+      email: "trusted@example.com",
+      tenantId: "t",
+    });
+    const { customerSignIn } = await loadActions();
+
+    await customerSignIn({
+      idToken: "tok",
+      uid: "attacker-supplied-uid",
+      email: "attacker@evil.com",
+      storeSlug: "shop",
+    });
+
+    const setCall = cookiesSetSpy.mock.calls[0]![0] as { value: string };
+    const decoded = decodeCookiePayload(setCall.value);
+    expect(decoded.uid).toBe("trusted-uid");
+    expect(decoded.email).toBe("trusted@example.com");
+  });
+
+  it("Zitadel: the session is built from verifyCustomerCredential's result, not client-supplied loginName", async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "zitadel";
+    verifyCustomerCredentialMock.mockResolvedValue({
+      kind: "complete",
+      uid: "trusted-zit-uid",
+      email: "trusted-zit@example.com",
+    });
+    const { customerSignIn } = await loadActions();
+
+    await customerSignIn({
+      loginName: "attacker@evil.com",
+      password: SUBMITTED_PASSWORD,
+      storeSlug: "shop",
+    });
+
+    const setCall = cookiesSetSpy.mock.calls[0]![0] as { value: string };
+    const decoded = decodeCookiePayload(setCall.value);
+    expect(decoded.uid).toBe("trusted-zit-uid");
+    expect(decoded.email).toBe("trusted-zit@example.com");
+  });
+});
+
+describe("customerSignIn — profile and loyalty side effects", () => {
+  it("fire on the GIP path", async () => {
+    verifyGIPIdTokenMock.mockResolvedValue({
+      uid: "u1",
+      email: "e1@example.com",
+      tenantId: "t",
+    });
+    const { customerSignIn } = await loadActions();
+
+    await customerSignIn({ idToken: "tok", uid: "ignored", storeSlug: "shop" });
+
+    const paths = fetchSpy.mock.calls.map((c) => String(c[0]));
+    expect(paths.some((p) => p.includes("/account"))).toBe(true);
+    expect(paths.some((p) => p.includes("/loyalty/enroll"))).toBe(true);
+  });
+
+  it("fire on the Zitadel path", async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "zitadel";
+    verifyCustomerCredentialMock.mockResolvedValue({
+      kind: "complete",
+      uid: "u2",
+      email: "e2@example.com",
+    });
+    const { customerSignIn } = await loadActions();
+
+    await customerSignIn({
+      loginName: "e2@example.com",
+      password: SUBMITTED_PASSWORD,
+      storeSlug: "shop",
+    });
+
+    const paths = fetchSpy.mock.calls.map((c) => String(c[0]));
+    expect(paths.some((p) => p.includes("/account"))).toBe(true);
+    expect(paths.some((p) => p.includes("/loyalty/enroll"))).toBe(true);
+  });
+});
+
+describe("customerSignIn — password never leaks", () => {
+  it("a thrown verification error never carries the submitted password", async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "zitadel";
+    verifyCustomerCredentialMock.mockRejectedValue(
+      new Error(
+        "auth-bff customer endpoint error: zitadel_unavailable (status 503)",
+      ),
+    );
+    const { customerSignIn } = await loadActions();
+
+    const result = await customerSignIn({
+      loginName: "e@x.com",
+      password: SUBMITTED_PASSWORD,
+      storeSlug: "shop",
+    });
+
+    expect(JSON.stringify(result)).not.toContain(SUBMITTED_PASSWORD);
+  });
+
+  it("a rejected outcome's result value never carries the submitted password", async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "zitadel";
+    verifyCustomerCredentialMock.mockResolvedValue({ kind: "rejected" });
+    const { customerSignIn } = await loadActions();
+
+    const result = await customerSignIn({
+      loginName: "e@x.com",
+      password: SUBMITTED_PASSWORD,
+      storeSlug: "shop",
+    });
+
+    expect(JSON.stringify(result)).not.toContain(SUBMITTED_PASSWORD);
+  });
+});

--- a/apps/storefront/app/sign-in/actions.zitadel.test.ts
+++ b/apps/storefront/app/sign-in/actions.zitadel.test.ts
@@ -55,7 +55,10 @@ import {
   GIPTokenVerificationError,
   verifyGIPIdToken,
 } from "@/lib/gip/verify-id-token";
-import { verifyCustomerCredential } from "@/lib/auth/auth-bff-customer";
+import {
+  AuthBffCustomerError,
+  verifyCustomerCredential,
+} from "@/lib/auth/auth-bff-customer";
 import { platformInternalFetch } from "@/lib/api/server/platformInternal";
 
 const verifyGIPIdTokenMock = vi.mocked(verifyGIPIdToken);
@@ -251,6 +254,94 @@ describe("customerSignIn — failed verification sets no cookie", () => {
 
     expect(result.ok).toBe(false);
     expect(cookiesSetSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("customerSignIn — truthful messages for outcomes other than a wrong credential", () => {
+  it("a wrong password still produces the credential message (the useful signal isn't flattened away)", async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "zitadel";
+    verifyCustomerCredentialMock.mockResolvedValue({ kind: "rejected" });
+    const { customerSignIn } = await loadActions();
+
+    const result = await customerSignIn({
+      loginName: "e@x.com",
+      password: "wrong-password",
+      storeSlug: "shop",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      code: "invalid_credentials",
+      message: "Email or password is incorrect.",
+    });
+  });
+
+  it('a "totp_required" outcome does NOT say the password is incorrect, and has its own message', async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "zitadel";
+    verifyCustomerCredentialMock.mockResolvedValue({
+      kind: "totp_required",
+      sessionId: "s1",
+      sessionToken: "tok1",
+    });
+    const { customerSignIn } = await loadActions();
+
+    const result = await customerSignIn({
+      loginName: "e@x.com",
+      password: SUBMITTED_PASSWORD,
+      storeSlug: "shop",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).not.toBe("Email or password is incorrect.");
+      expect(result.message.toLowerCase()).toContain("authenticator");
+    }
+  });
+
+  it('a "handoff" outcome does NOT say the password is incorrect, does not surface the handoff URL, and has its own message', async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "zitadel";
+    verifyCustomerCredentialMock.mockResolvedValue({
+      kind: "handoff",
+      handoffUrl: "https://zitadel.example/ui/v2/login/login",
+    });
+    const { customerSignIn } = await loadActions();
+
+    const result = await customerSignIn({
+      loginName: "e@x.com",
+      password: SUBMITTED_PASSWORD,
+      storeSlug: "shop",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).not.toBe("Email or password is incorrect.");
+      expect(result.message).not.toContain("zitadel.example");
+      expect(result.message.toLowerCase()).toContain("sign-in method");
+    }
+  });
+
+  it("an AuthBffCustomerError produces a generic message with no internal detail", async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "zitadel";
+    verifyCustomerCredentialMock.mockRejectedValue(
+      new AuthBffCustomerError(503, "zitadel_unavailable"),
+    );
+    const { customerSignIn } = await loadActions();
+
+    const result = await customerSignIn({
+      loginName: "e@x.com",
+      password: SUBMITTED_PASSWORD,
+      storeSlug: "shop",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe(
+        "Sign-in is temporarily unavailable. Please try again shortly.",
+      );
+      expect(result.message).not.toContain("503");
+      expect(result.message).not.toContain("zitadel_unavailable");
+      expect(result.message.toLowerCase()).not.toContain("auth-bff");
+    }
   });
 });
 

--- a/apps/storefront/app/sign-in/customer-login-flow.test.ts
+++ b/apps/storefront/app/sign-in/customer-login-flow.test.ts
@@ -1,0 +1,372 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createPublicKey,
+  createSign,
+  generateKeyPairSync,
+} from "node:crypto";
+
+// This file is the trace, not a per-file review. Phase 3a's six tasks each
+// passed their own review and the feature was still unreachable end to
+// end — a flag computed and never passed, a route built and never called.
+// None of that shows up in a diff of any single file; it only shows up by
+// walking the seams a real request walks.
+//
+// So unlike app/sign-in/actions.zitadel.test.ts (which mocks
+// verifyGIPIdToken and verifyCustomerCredential directly to drive
+// customerSignIn's branches in isolation), this file mocks only:
+//   - the network boundary (global fetch)
+//   - next/headers (a Next.js server-action runtime seam vitest has no
+//     substitute for — there is no request to read headers/cookies from
+//     outside a real Next.js server)
+//
+// customerSignIn, verifyCustomerCredential, verifyGIPIdToken, and
+// encodeSession all run for real. A password submitted by the caller
+// really goes over an HTTP request body to auth-bff; a GIP id_token is a
+// real RS256-signed JWT verified against a real RSA keypair served back
+// through the mocked fetch as if it were Google's certs endpoint.
+
+const HOST = "shop.mark8ly.com";
+const AUTH_BFF_URL = "http://localhost:8087";
+const PLATFORM_API_URL = "http://localhost:8086";
+const MARKETPLACE_API_URL = "http://localhost:8088";
+const CERTS_URL =
+  "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com";
+
+const GIP_PROJECT_ID = "test-project";
+const GIP_CUSTOMER_TENANT_ID = "test-customer-tenant";
+
+// --- next/headers: the one module boundary that is genuinely unavoidable
+// here (no real Next.js request exists under vitest to read headers/
+// cookies from). Backed by a plain in-memory store so cookies.set / .get /
+// .delete behave like the real API customerSignIn calls.
+const cookieStore: Record<string, string> = {};
+const cookiesSetSpy = vi.fn(
+  (opts: { name: string; value: string; domain?: string }) => {
+    cookieStore[opts.name] = opts.value;
+  },
+);
+let headerMap: Map<string, string>;
+
+vi.mock("next/headers", () => ({
+  headers: async () => ({
+    get: (key: string) => headerMap.get(key.toLowerCase()) ?? null,
+  }),
+  cookies: async () => ({
+    set: cookiesSetSpy,
+    get: (name: string) =>
+      cookieStore[name] !== undefined ? { value: cookieStore[name] } : undefined,
+    delete: (name: string) => {
+      delete cookieStore[name];
+    },
+  }),
+}));
+
+/** Generates a real RSA keypair and a real RS256-signed GIP-shaped id_token,
+ *  plus the "Google certs" document verifyGIPIdToken would fetch to check
+ *  it. Nothing here is a stub of the verification logic — it is the same
+ *  signature math verify-id-token.ts performs, run backwards. */
+function makeSignedGIPToken(claims: {
+  uid: string;
+  email: string;
+  projectId: string;
+  tenantId: string;
+}): { idToken: string; certsBody: Record<string, string> } {
+  const { publicKey, privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+  });
+  const kid = "test-kid";
+  const header = { alg: "RS256", kid };
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    aud: claims.projectId,
+    iss: `https://securetoken.google.com/${claims.projectId}`,
+    sub: claims.uid,
+    email: claims.email,
+    email_verified: true,
+    iat: now,
+    exp: now + 3600,
+    firebase: { tenant: claims.tenantId },
+  };
+  const b64url = (o: unknown) =>
+    Buffer.from(JSON.stringify(o)).toString("base64url");
+  const signingInput = `${b64url(header)}.${b64url(payload)}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer.sign(privateKey).toString("base64url");
+
+  const pubPem = publicKey.export({ type: "spki", format: "pem" }) as string;
+  return {
+    idToken: `${signingInput}.${signature}`,
+    certsBody: { [kid]: pubPem },
+  };
+}
+
+/** Decodes the base64 payload half of an encodeSession cookie value
+ *  (`<base64-payload>.<hex-signature>`) without needing the HMAC key. */
+function decodeCookiePayload(cookieValue: string): Record<string, unknown> {
+  const payload = cookieValue.slice(0, cookieValue.lastIndexOf("."));
+  return JSON.parse(Buffer.from(payload, "base64").toString());
+}
+
+async function loadActions() {
+  return await import("./actions");
+}
+
+const originalFetch = globalThis.fetch;
+let fetchMock: ReturnType<typeof vi.fn>;
+/** URLs requested, in order — used to assert both presence and absence
+ *  of specific network hops (e.g. "the certs URL was never requested"). */
+let requestedUrls: string[];
+
+/** A fetch stand-in that routes each known URL to its real-service shape
+ *  and throws on anything unexpected, so a wrong-branch call surfaces
+ *  loudly instead of silently returning `undefined`-shaped JSON. */
+function installFetchRouter(handlers: {
+  certs?: () => { status: number; body: unknown };
+  customerLogin?: (body: {
+    login_name: string;
+    password: string;
+  }) => { status: number; body: unknown };
+}) {
+  fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    requestedUrls.push(url);
+
+    if (url === CERTS_URL) {
+      const { status, body } = handlers.certs
+        ? handlers.certs()
+        : { status: 500, body: {} };
+      return jsonResponse(status, body);
+    }
+
+    if (url === `${AUTH_BFF_URL}/auth/customer/login`) {
+      const submitted = JSON.parse(String(init?.body)) as {
+        login_name: string;
+        password: string;
+      };
+      const { status, body } = handlers.customerLogin
+        ? handlers.customerLogin(submitted)
+        : { status: 500, body: {} };
+      return jsonResponse(status, body);
+    }
+
+    if (
+      url === `${PLATFORM_API_URL}/internal/stores/by-slug/shop` ||
+      url.startsWith(`${PLATFORM_API_URL}/internal/stores/by-slug/`)
+    ) {
+      return jsonResponse(200, {
+        data: { tenant_id: "tenant-1", id: "store-1" },
+      });
+    }
+
+    if (url.startsWith(`${MARKETPLACE_API_URL}`) && url.includes("/account")) {
+      return jsonResponse(200, {});
+    }
+
+    if (
+      url.startsWith(`${MARKETPLACE_API_URL}`) &&
+      url.includes("/loyalty/enroll")
+    ) {
+      return jsonResponse(200, {});
+    }
+
+    throw new Error(`unexpected fetch to unmocked URL: ${url}`);
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null } as unknown as Headers,
+    json: async () => body,
+  } as Response;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  delete process.env.NEXT_PUBLIC_AUTH_PROVIDER;
+  process.env.GIP_PROJECT_ID = GIP_PROJECT_ID;
+  process.env.GIP_CUSTOMER_TENANT_ID = GIP_CUSTOMER_TENANT_ID;
+  process.env.AUTH_BFF_URL = AUTH_BFF_URL;
+  process.env.PLATFORM_API_URL = PLATFORM_API_URL;
+  process.env.MARKETPLACE_API_URL = MARKETPLACE_API_URL;
+
+  headerMap = new Map([["host", HOST]]);
+  for (const key of Object.keys(cookieStore)) delete cookieStore[key];
+  cookiesSetSpy.mockClear();
+  requestedUrls = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete process.env.NEXT_PUBLIC_AUTH_PROVIDER;
+  vi.clearAllMocks();
+});
+
+describe("customer login flow — Zitadel provider, every seam traversed", () => {
+  it("password sign-in reaches verifyCustomerCredential, skips verifyGIPIdToken, mints a session from auth-bff's identity, scopes the cookie to the host, and fires profile/loyalty side effects", async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "zitadel";
+    installFetchRouter({
+      customerLogin: (submitted) => {
+        // Seam 1: the credential that reaches auth-bff over the wire is
+        // exactly what the caller submitted — proof verifyCustomerCredential
+        // was actually invoked with it, not a mock standing in for it.
+        expect(submitted).toEqual({
+          login_name: "customer@example.com",
+          password: "correct horse battery staple",
+        });
+        return {
+          status: 200,
+          body: { data: { uid: "zit-uid-1", email: "trusted@example.com" } },
+        };
+      },
+    });
+
+    const { customerSignIn } = await loadActions();
+    const result = await customerSignIn({
+      storeSlug: "shop",
+      loginName: "customer@example.com",
+      password: "correct horse battery staple",
+      // A client-supplied uid/email must never win — proven by seam 3 below.
+      uid: "attacker-supplied-uid",
+      email: "attacker@evil.com",
+    });
+
+    expect(result.ok).toBe(true);
+
+    // Seam 1 (call-shape): the auth-bff customer login endpoint was hit
+    // exactly once — this is verifyCustomerCredential actually running.
+    const loginCalls = requestedUrls.filter(
+      (u) => u === `${AUTH_BFF_URL}/auth/customer/login`,
+    );
+    expect(loginCalls).toHaveLength(1);
+
+    // Seam 2: verifyGIPIdToken was never reached. If it had been, it would
+    // have needed to fetch Google's certs to verify a signature — that
+    // fetch never happened.
+    expect(requestedUrls).not.toContain(CERTS_URL);
+
+    // Seam 3: encodeSession was fed auth-bff's identity, not the
+    // client-supplied uid/email above.
+    expect(cookiesSetSpy).toHaveBeenCalledTimes(1);
+    const cookieCall = cookiesSetSpy.mock.calls[0]![0] as {
+      name: string;
+      value: string;
+      domain?: string;
+    };
+    expect(cookieCall.name).toBe("mp_customer_session");
+    const decoded = decodeCookiePayload(cookieCall.value);
+    expect(decoded.uid).toBe("zit-uid-1");
+    expect(decoded.email).toBe("trusted@example.com");
+
+    // Seam 4: the cookie is scoped to the resolved request host.
+    expect(cookieCall.domain).toBe(HOST);
+
+    // Seam 5: profile + loyalty side effects fired.
+    expect(requestedUrls.some((u) => u.includes("/account"))).toBe(true);
+    expect(requestedUrls.some((u) => u.includes("/loyalty/enroll"))).toBe(
+      true,
+    );
+  });
+});
+
+describe("customer login flow — GIP provider (flag unset), mirror trace", () => {
+  it("id_token sign-in reaches verifyGIPIdToken, never touches the Zitadel client, mints a session from the verified token, and still scopes the cookie to the host", async () => {
+    // AUTH_PROVIDER stays "gip" — NEXT_PUBLIC_AUTH_PROVIDER unset, per
+    // beforeEach.
+    const { idToken, certsBody } = makeSignedGIPToken({
+      uid: "gip-uid-1",
+      email: "gip-trusted@example.com",
+      projectId: GIP_PROJECT_ID,
+      tenantId: GIP_CUSTOMER_TENANT_ID,
+    });
+    installFetchRouter({
+      certs: () => ({ status: 200, body: certsBody }),
+    });
+
+    const { customerSignIn } = await loadActions();
+    const result = await customerSignIn({
+      storeSlug: "shop",
+      idToken,
+      uid: "attacker-supplied-uid",
+      email: "attacker@evil.com",
+    });
+
+    expect(result.ok).toBe(true);
+
+    // The certs fetch is verifyGIPIdToken's own real network hop — proof
+    // it, not a stand-in, actually verified the signature.
+    expect(requestedUrls).toContain(CERTS_URL);
+
+    // The Zitadel client's endpoint was never called.
+    expect(requestedUrls).not.toContain(`${AUTH_BFF_URL}/auth/customer/login`);
+
+    expect(cookiesSetSpy).toHaveBeenCalledTimes(1);
+    const cookieCall = cookiesSetSpy.mock.calls[0]![0] as {
+      name: string;
+      value: string;
+      domain?: string;
+    };
+    const decoded = decodeCookiePayload(cookieCall.value);
+    expect(decoded.uid).toBe("gip-uid-1");
+    expect(decoded.email).toBe("gip-trusted@example.com");
+    expect(cookieCall.domain).toBe(HOST);
+  });
+});
+
+describe("customer login flow — the GIP branch is genuinely unreachable under the Zitadel flag", () => {
+  // The previous phase's failure would NOT have been caught by an assertion
+  // that merely reads "verifyGIPIdToken was not called this time" — that is
+  // also true if the branch were reached but happened to no-op, or if the
+  // call recorder itself were wired to nothing. What distinguishes "did not
+  // run" from "could not have produced this outcome" is a poison pill: rig
+  // the GIP path so that if it executes at all, it fails in a specific,
+  // detectable way that could never coincidentally match the Zitadel
+  // path's success. No idToken is supplied, and GIP_PROJECT_ID /
+  // GIP_CUSTOMER_TENANT_ID are deliberately left as they are — verifyGIPIdToken
+  // rejects an empty idToken before doing anything else (see
+  // verify-id-token.ts's very first check), and customerSignIn's catch
+  // block turns that into a specific, distinguishable error shape
+  // (ok:false, code:"invalid_token") that a successful Zitadel result can
+  // never equal. A passing Zitadel result here is proof the GIP branch's
+  // code never ran — not merely proof a spy sitting on it wasn't tripped.
+  it("succeeds via the Zitadel branch even though the GIP branch would fail immediately and distinctly if entered", async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "zitadel";
+    installFetchRouter({
+      customerLogin: () => ({
+        status: 200,
+        body: { data: { uid: "zit-uid-2", email: "zit2@example.com" } },
+      }),
+    });
+
+    const { customerSignIn } = await loadActions();
+    const result = await customerSignIn({
+      storeSlug: "shop",
+      loginName: "zit2@example.com",
+      password: "another-correct-password",
+      // No idToken at all — if the GIP branch ran, verifyGIPIdToken would
+      // throw GIPTokenVerificationError("missing verification
+      // configuration") synchronously, before any network call, and
+      // customerSignIn's catch block maps that specific error type to
+      // { ok: false, code: "invalid_token" }.
+    });
+
+    // This is the trap springing (or not): ok:true, with the Zitadel
+    // identity, is reachable ONLY if the GIP branch's throw never
+    // happened — i.e. the GIP branch's code was never entered, not just
+    // "not observed to have been entered".
+    expect(result).toMatchObject({ ok: true });
+    if (result.ok) {
+      // no message/code fields on success — nothing further to assert
+      // beyond ok:true itself, which is already the discriminant.
+    }
+    expect(requestedUrls).not.toContain(CERTS_URL);
+
+    const cookieCall = cookiesSetSpy.mock.calls[0]![0] as { value: string };
+    const decoded = decodeCookiePayload(cookieCall.value);
+    expect(decoded.uid).toBe("zit-uid-2");
+  });
+});

--- a/apps/storefront/components/auth/CustomerSignInForm.tsx
+++ b/apps/storefront/components/auth/CustomerSignInForm.tsx
@@ -8,6 +8,14 @@ import { customerSignIn } from "@/app/sign-in/actions";
 const TRAMPOLINE_BASE =
   process.env.NEXT_PUBLIC_MARK8LY_AUTH_URL ?? "https://mark8ly.com";
 
+// Matches apps/storefront/app/sign-in/actions.ts's AUTH_PROVIDER rule
+// exactly (see that file for the full rationale): only the literal string
+// "zitadel" switches this form off the GIP/Identity Toolkit path. Both
+// reads must agree, since the server action rejects a Zitadel-shaped
+// payload sent while the flag says GIP and vice versa.
+const AUTH_PROVIDER: "gip" | "zitadel" =
+  process.env.NEXT_PUBLIC_AUTH_PROVIDER === "zitadel" ? "zitadel" : "gip";
+
 interface GipConfig {
   apiKey: string;
   tenantId: string;
@@ -111,17 +119,30 @@ export function CustomerSignInForm({
 
     startTransition(async () => {
       try {
-        const gipResult = await signInWithPassword(
-          email.trim(),
-          password,
-          gipConfig,
-        );
+        let result: Awaited<ReturnType<typeof customerSignIn>>;
 
-        const result = await customerSignIn({
-          idToken: gipResult.idToken,
-          uid: gipResult.uid,
-          storeSlug,
-        });
+        if (AUTH_PROVIDER === "zitadel") {
+          // Under Zitadel the browser never talks to Identity Toolkit —
+          // the password goes straight to the server action, which calls
+          // auth-bff's storefront-customer credential endpoint itself.
+          result = await customerSignIn({
+            loginName: email.trim(),
+            password,
+            storeSlug,
+          });
+        } else {
+          const gipResult = await signInWithPassword(
+            email.trim(),
+            password,
+            gipConfig,
+          );
+
+          result = await customerSignIn({
+            idToken: gipResult.idToken,
+            uid: gipResult.uid,
+            storeSlug,
+          });
+        }
 
         if (!result.ok) {
           setError(result.message);

--- a/apps/storefront/lib/auth/auth-bff-customer.test.ts
+++ b/apps/storefront/lib/auth/auth-bff-customer.test.ts
@@ -24,7 +24,6 @@ afterEach(() => {
 
 describe("verifyCustomerCredential", () => {
   const loginArgs = {
-    authRequestId: "ar-1",
     loginName: "customer@example.com",
     password: SECRET_PASSWORD,
   };
@@ -41,7 +40,6 @@ describe("verifyCustomerCredential", () => {
     expect(url).toBe("http://localhost:8087/auth/customer/login");
     const parsedBody = JSON.parse(init.body as string);
     expect(parsedBody).toEqual({
-      auth_request_id: "ar-1",
       login_name: "customer@example.com",
       password: SECRET_PASSWORD,
     });
@@ -77,16 +75,14 @@ describe("verifyCustomerCredential", () => {
 
   it("maps a handoff response to the handoff outcome", async () => {
     stubFetch(200, {
-      handoff_url: "https://zitadel.example.com/ui/v2/login/login?authRequestID=ar-1",
-      auth_request_id: "ar-1",
+      handoff_url: "https://zitadel.example.com/ui/v2/login/login",
     });
 
     const outcome = await verifyCustomerCredential(loginArgs);
 
     expect(outcome).toEqual({
       kind: "handoff",
-      handoffUrl: "https://zitadel.example.com/ui/v2/login/login?authRequestID=ar-1",
-      authRequestId: "ar-1",
+      handoffUrl: "https://zitadel.example.com/ui/v2/login/login",
     });
   });
 
@@ -152,7 +148,6 @@ describe("verifyCustomerCredential", () => {
 
 describe("verifyCustomerTotp", () => {
   const totpArgs = {
-    authRequestId: "ar-1",
     sessionId: "sess-1",
     sessionToken: "sess-token-1",
     code: "123456",
@@ -170,7 +165,6 @@ describe("verifyCustomerTotp", () => {
     expect(url).toBe("http://localhost:8087/auth/customer/totp");
     const parsedBody = JSON.parse(init.body as string);
     expect(parsedBody).toEqual({
-      auth_request_id: "ar-1",
       session_id: "sess-1",
       session_token: "sess-token-1",
       code: "123456",

--- a/apps/storefront/lib/auth/auth-bff-customer.test.ts
+++ b/apps/storefront/lib/auth/auth-bff-customer.test.ts
@@ -199,3 +199,65 @@ describe("verifyCustomerTotp", () => {
     );
   });
 });
+
+// The X-Internal-Auth header is what stops auth-bff's publicly reachable
+// /auth/customer/{login,totp} from being a credential-validity oracle over
+// every user in the Zitadel instance. These pin that this server-side-only
+// client actually sends it, and that it never comes from a NEXT_PUBLIC_*
+// variable (which would ship the secret to the browser bundle).
+describe("internal auth header", () => {
+  const loginArgs = {
+    loginName: "customer@example.com",
+    password: SECRET_PASSWORD,
+  };
+  const totpArgs = {
+    sessionId: "s1",
+    sessionToken: "tok-1",
+    code: "123456",
+  };
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("sends X-Internal-Auth on /auth/customer/login", async () => {
+    vi.stubEnv("MARKETPLACE_INTERNAL_AUTH_SECRET", "s3cret-internal");
+    const fetchMock = stubFetch(200, {
+      data: { uid: "u1", email: "customer@example.com" },
+    });
+
+    await verifyCustomerCredential(loginArgs);
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["X-Internal-Auth"]).toBe("s3cret-internal");
+  });
+
+  it("sends X-Internal-Auth on /auth/customer/totp", async () => {
+    vi.stubEnv("MARKETPLACE_INTERNAL_AUTH_SECRET", "s3cret-internal");
+    const fetchMock = stubFetch(200, {
+      data: { uid: "u1", email: "customer@example.com" },
+    });
+
+    await verifyCustomerTotp(totpArgs);
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["X-Internal-Auth"]).toBe("s3cret-internal");
+  });
+
+  it("never reads the secret from a NEXT_PUBLIC_ variable", async () => {
+    vi.stubEnv("MARKETPLACE_INTERNAL_AUTH_SECRET", "");
+    vi.stubEnv("NEXT_PUBLIC_MARKETPLACE_INTERNAL_AUTH_SECRET", "leaked");
+    const fetchMock = stubFetch(200, {
+      data: { uid: "u1", email: "customer@example.com" },
+    });
+
+    await verifyCustomerCredential(loginArgs);
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["X-Internal-Auth"]).toBeUndefined();
+    expect(JSON.stringify(init)).not.toContain("leaked");
+  });
+});

--- a/apps/storefront/lib/auth/auth-bff-customer.test.ts
+++ b/apps/storefront/lib/auth/auth-bff-customer.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AuthBffCustomerError,
+  verifyCustomerCredential,
+  verifyCustomerTotp,
+} from "./auth-bff-customer";
+
+const SECRET_PASSWORD = "correct-horse-battery-staple";
+
+function stubFetch(status: number, body: unknown) {
+  const res = new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+  const fn = vi.fn().mockResolvedValue(res);
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("verifyCustomerCredential", () => {
+  const loginArgs = {
+    authRequestId: "ar-1",
+    loginName: "customer@example.com",
+    password: SECRET_PASSWORD,
+  };
+
+  it("sends the exact snake_case wire fields for /auth/customer/login", async () => {
+    const fetchMock = stubFetch(200, {
+      data: { uid: "u1", email: "customer@example.com" },
+    });
+
+    await verifyCustomerCredential(loginArgs);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("http://localhost:8087/auth/customer/login");
+    const parsedBody = JSON.parse(init.body as string);
+    expect(parsedBody).toEqual({
+      auth_request_id: "ar-1",
+      login_name: "customer@example.com",
+      password: SECRET_PASSWORD,
+    });
+  });
+
+  it("maps a 2xx identity response to the completed outcome", async () => {
+    stubFetch(200, { data: { uid: "u1", email: "customer@example.com" } });
+
+    const outcome = await verifyCustomerCredential(loginArgs);
+
+    expect(outcome).toEqual({
+      kind: "complete",
+      uid: "u1",
+      email: "customer@example.com",
+    });
+  });
+
+  it("maps a totp_required response to the factor-required outcome", async () => {
+    stubFetch(200, {
+      totp_required: true,
+      session_id: "sess-1",
+      session_token: "sess-token-1",
+    });
+
+    const outcome = await verifyCustomerCredential(loginArgs);
+
+    expect(outcome).toEqual({
+      kind: "totp_required",
+      sessionId: "sess-1",
+      sessionToken: "sess-token-1",
+    });
+  });
+
+  it("maps a handoff response to the handoff outcome", async () => {
+    stubFetch(200, {
+      handoff_url: "https://zitadel.example.com/ui/v2/login/login?authRequestID=ar-1",
+      auth_request_id: "ar-1",
+    });
+
+    const outcome = await verifyCustomerCredential(loginArgs);
+
+    expect(outcome).toEqual({
+      kind: "handoff",
+      handoffUrl: "https://zitadel.example.com/ui/v2/login/login?authRequestID=ar-1",
+      authRequestId: "ar-1",
+    });
+  });
+
+  it("collapses a 401 to the single rejected outcome regardless of which error auth-bff logged internally", async () => {
+    stubFetch(401, { error: "invalid_credentials" });
+
+    const outcome = await verifyCustomerCredential(loginArgs);
+
+    expect(outcome).toEqual({ kind: "rejected" });
+  });
+
+  it("does not distinguish a 401 by response body content (no enumeration oracle)", async () => {
+    // Same status, arbitrary/different error body — must still collapse
+    // to the identical outcome as the canonical invalid_credentials case.
+    stubFetch(401, { error: "user_not_found_but_should_never_say_so" });
+
+    const outcome = await verifyCustomerCredential(loginArgs);
+
+    expect(outcome).toEqual({ kind: "rejected" });
+  });
+
+  it("throws a distinguishable error on a 5xx, not the credential-rejection outcome", async () => {
+    stubFetch(503, { error: "zitadel_unavailable" });
+
+    await expect(verifyCustomerCredential(loginArgs)).rejects.toBeInstanceOf(
+      AuthBffCustomerError,
+    );
+    await expect(verifyCustomerCredential(loginArgs)).rejects.toMatchObject({
+      status: 503,
+    });
+  });
+
+  it("throws a distinguishable error on a transport failure", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    vi.stubGlobal("fetch", fn);
+
+    const rejection = verifyCustomerCredential(loginArgs);
+    await expect(rejection).rejects.toBeInstanceOf(AuthBffCustomerError);
+    await expect(rejection).rejects.toMatchObject({ status: 0 });
+  });
+
+  it("never lets the password appear in a thrown error", async () => {
+    stubFetch(500, { error: "internal_error" });
+
+    try {
+      await verifyCustomerCredential(loginArgs);
+      throw new Error("expected verifyCustomerCredential to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AuthBffCustomerError);
+      const serialised = JSON.stringify(err) + String((err as Error).message) + String((err as Error).stack);
+      expect(serialised).not.toContain(SECRET_PASSWORD);
+    }
+  });
+
+  it("never lets the password appear in a rejection outcome value", async () => {
+    stubFetch(401, { error: "invalid_credentials" });
+
+    const outcome = await verifyCustomerCredential(loginArgs);
+
+    expect(JSON.stringify(outcome)).not.toContain(SECRET_PASSWORD);
+  });
+});
+
+describe("verifyCustomerTotp", () => {
+  const totpArgs = {
+    authRequestId: "ar-1",
+    sessionId: "sess-1",
+    sessionToken: "sess-token-1",
+    code: "123456",
+  };
+
+  it("sends the exact snake_case wire fields for /auth/customer/totp", async () => {
+    const fetchMock = stubFetch(200, {
+      data: { uid: "u1", email: "customer@example.com" },
+    });
+
+    await verifyCustomerTotp(totpArgs);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("http://localhost:8087/auth/customer/totp");
+    const parsedBody = JSON.parse(init.body as string);
+    expect(parsedBody).toEqual({
+      auth_request_id: "ar-1",
+      session_id: "sess-1",
+      session_token: "sess-token-1",
+      code: "123456",
+    });
+  });
+
+  it("maps a 2xx identity response to the completed outcome", async () => {
+    stubFetch(200, { data: { uid: "u1", email: "customer@example.com" } });
+
+    const outcome = await verifyCustomerTotp(totpArgs);
+
+    expect(outcome).toEqual({
+      kind: "complete",
+      uid: "u1",
+      email: "customer@example.com",
+    });
+  });
+
+  it("collapses a 401 (bad code or vanished session) to the single rejected outcome", async () => {
+    stubFetch(401, { error: "invalid_totp" });
+
+    const outcome = await verifyCustomerTotp(totpArgs);
+
+    expect(outcome).toEqual({ kind: "rejected" });
+  });
+
+  it("throws a distinguishable error on a 5xx", async () => {
+    stubFetch(503, { error: "zitadel_unavailable" });
+
+    await expect(verifyCustomerTotp(totpArgs)).rejects.toBeInstanceOf(
+      AuthBffCustomerError,
+    );
+  });
+});

--- a/apps/storefront/lib/auth/auth-bff-customer.ts
+++ b/apps/storefront/lib/auth/auth-bff-customer.ts
@@ -38,6 +38,28 @@
 const AUTH_BFF_URL = process.env.AUTH_BFF_URL ?? "http://localhost:8087";
 
 /**
+ * The shared service-to-service secret auth-bff's Zitadel credential
+ * endpoints require in the X-Internal-Auth header — the same scheme and the
+ * same env var this app already uses for marketplace-api's internal routes
+ * (see app/api/internal/orders/[id]/invoice/route.ts).
+ *
+ * auth-bff is publicly reachable (auth.mark8ly.com routes to it on any
+ * path) and /auth/customer/login answers whether a {login_name, password}
+ * pair is valid, so without this header those routes are a credential
+ * oracle over every user in the Zitadel instance. This module is
+ * server-side only, so the header costs one line — read from server config,
+ * never a NEXT_PUBLIC_* variable, which would ship the secret to the
+ * browser bundle.
+ *
+ * Read at call time rather than module scope so a value injected after
+ * module evaluation (and a test's stubbed env) is still seen.
+ */
+function internalAuthHeader(): Record<string, string> {
+  const secret = process.env.MARKETPLACE_INTERNAL_AUTH_SECRET ?? "";
+  return secret ? { "X-Internal-Auth": secret } : {};
+}
+
+/**
  * Outcome union mirroring the endpoint's four possible shapes. Modeled on
  * apps/admin/lib/auth/login-response.ts's LoginOutcome so the merchant and
  * customer login paths read alike, but intentionally NOT shared code —
@@ -136,7 +158,7 @@ async function postToCustomerEndpoint(
   try {
     return await fetch(`${AUTH_BFF_URL}${path}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...internalAuthHeader() },
       body: JSON.stringify(body),
       cache: "no-store",
     });

--- a/apps/storefront/lib/auth/auth-bff-customer.ts
+++ b/apps/storefront/lib/auth/auth-bff-customer.ts
@@ -1,0 +1,206 @@
+// Server-side client for auth-bff's storefront customer credential
+// endpoints (POST /auth/customer/login and POST /auth/customer/totp).
+//
+// SERVER-SIDE ONLY. AUTH_BFF_URL is server config (never a NEXT_PUBLIC_*
+// variable) because the customer endpoint sits behind auth-bff's own
+// Zitadel login-client PAT (see services/auth-bff/pkg/config/config.go's
+// ZITADEL_LOGIN_CLIENT_TOKEN) — that token is used server-to-server between
+// auth-bff and Zitadel and must never be reachable from a value the browser
+// bundle can read. This module must only be imported from a server action
+// or route handler (see apps/storefront/app/sign-in/actions.ts, the eventual
+// caller), never from client components.
+//
+// Shape reference: services/auth-bff/internal/zitadellogin/customer_handler.go
+//   POST /auth/customer/login  <- {auth_request_id, login_name, password}
+//   POST /auth/customer/totp   <- {auth_request_id, session_id, session_token, code}
+//   200 complete   -> {"data": {"uid": string, "email": string}}
+//   200 factor-req -> {"totp_required": true, "session_id": string, "session_token": string}
+//   200 handoff    -> {"handoff_url": string, "auth_request_id": string}
+//   401 rejected   -> {"error": "invalid_credentials"} or {"error": "invalid_totp"}
+//   503/5xx        -> {"error": "zitadel_unavailable" | "internal_error" | ...}
+//
+// The 401 case is deliberately collapsed to ONE outcome on the wire —
+// CustomerHandler.respondSessionCreateError returns the identical
+// {"error":"invalid_credentials"} whether the password was wrong or the
+// account doesn't exist, because a different answer would be an
+// account-enumeration oracle on a public storefront. This client must not
+// reintroduce that distinction: every 401 maps to the same `rejected`
+// outcome below, with no further detail. A 5xx or a transport failure is a
+// DIFFERENT, distinguishable case (AuthBffCustomerError, thrown rather than
+// returned) so the UI can tell "wrong credentials" from "auth is down".
+
+const AUTH_BFF_URL = process.env.AUTH_BFF_URL ?? "http://localhost:8087";
+
+/**
+ * Outcome union mirroring the endpoint's four possible shapes. Modeled on
+ * apps/admin/lib/auth/login-response.ts's LoginOutcome so the merchant and
+ * customer login paths read alike, but intentionally NOT shared code —
+ * these are separate apps and the customer path has one fewer step-up type
+ * (no usermfa/email-OTP gate; Storefront customers never go through that
+ * gauntlet, see the file comment on customer_handler.go) and no session
+ * cookie / tenant id (the customer endpoint mints no session; the caller,
+ * apps/storefront/app/sign-in/actions.ts, does that itself).
+ */
+export type CustomerAuthOutcome =
+  | { kind: "complete"; uid: string; email: string }
+  | { kind: "totp_required"; sessionId: string; sessionToken: string }
+  | { kind: "handoff"; handoffUrl: string; authRequestId: string }
+  | { kind: "rejected" };
+
+/**
+ * Thrown for anything that is NOT one of the endpoint's normal outcomes:
+ * a 5xx from auth-bff, a malformed 2xx body, or a transport-level failure
+ * (fetch rejecting outright). Deliberately distinct from the `rejected`
+ * union member above so callers can tell "the credential was wrong" from
+ * "we couldn't find out" and avoid, e.g., telling a customer their
+ * password is wrong when auth-bff is actually down.
+ *
+ * `message` is always a fixed, static string — never built from the
+ * request body or the raw response body — so a password can never end up
+ * in a thrown error.
+ */
+export class AuthBffCustomerError extends Error {
+  constructor(
+    public status: number,
+    public code: string,
+  ) {
+    super(`auth-bff customer endpoint error: ${code} (status ${status})`);
+    this.name = "AuthBffCustomerError";
+  }
+}
+
+interface VerifyCustomerCredentialArgs {
+  authRequestId: string;
+  loginName: string;
+  password: string;
+}
+
+interface VerifyCustomerTotpArgs {
+  authRequestId: string;
+  sessionId: string;
+  sessionToken: string;
+  code: string;
+}
+
+/** Narrow, structurally-typed shapes for the bodies we read fields off of.
+ *  Never logged or embedded in an error — see AuthBffCustomerError above. */
+type CustomerLoginBody =
+  | { data: { uid: string; email: string } }
+  | { totp_required: true; session_id: string; session_token: string }
+  | { handoff_url: string; auth_request_id: string };
+
+/**
+ * verifyCustomerCredential submits {auth_request_id, login_name, password}
+ * to POST /auth/customer/login and returns the resulting outcome.
+ *
+ * Never call this from a client component or route that ships to the
+ * browser — see the file header.
+ */
+export async function verifyCustomerCredential(
+  args: VerifyCustomerCredentialArgs,
+): Promise<CustomerAuthOutcome> {
+  const res = await postToCustomerEndpoint("/auth/customer/login", {
+    auth_request_id: args.authRequestId,
+    login_name: args.loginName,
+    password: args.password,
+  });
+  return parseCustomerOutcome(res);
+}
+
+/**
+ * verifyCustomerTotp submits {auth_request_id, session_id, session_token,
+ * code} to POST /auth/customer/totp and returns the resulting outcome.
+ *
+ * Never call this from a client component or route that ships to the
+ * browser — see the file header.
+ */
+export async function verifyCustomerTotp(
+  args: VerifyCustomerTotpArgs,
+): Promise<CustomerAuthOutcome> {
+  const res = await postToCustomerEndpoint("/auth/customer/totp", {
+    auth_request_id: args.authRequestId,
+    session_id: args.sessionId,
+    session_token: args.sessionToken,
+    code: args.code,
+  });
+  return parseCustomerOutcome(res);
+}
+
+/** Shared POST + transport-failure handling for both endpoints. */
+async function postToCustomerEndpoint(
+  path: string,
+  body: Record<string, string>,
+): Promise<Response> {
+  try {
+    return await fetch(`${AUTH_BFF_URL}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      cache: "no-store",
+    });
+  } catch {
+    // A network-level failure (fetch rejects). Deliberately no cause/detail
+    // from the caught error is included — it could theoretically echo
+    // request internals — and the request body (which may hold the
+    // password) is never referenced here.
+    throw new AuthBffCustomerError(0, "network_error");
+  }
+}
+
+/** Shared response parsing for both endpoints: 401 -> the single
+ *  `rejected` outcome, other non-2xx -> AuthBffCustomerError, 2xx ->
+ *  the matching outcome by shape. */
+async function parseCustomerOutcome(
+  res: Response,
+): Promise<CustomerAuthOutcome> {
+  if (res.status === 401) {
+    // Both ErrBadCredentials and ErrUserNotFound (login) and both a wrong
+    // TOTP code and a vanished session (totp) arrive here as the identical
+    // {"error": "invalid_credentials"} / {"error": "invalid_totp"} body.
+    // Collapse to one outcome with no further detail — do not read the
+    // `error` field and do not distinguish by it.
+    return { kind: "rejected" };
+  }
+
+  if (!res.ok) {
+    let code = `http_${res.status}`;
+    try {
+      const errBody = (await res.json()) as { error?: string };
+      if (typeof errBody.error === "string" && errBody.error) {
+        code = errBody.error;
+      }
+    } catch {
+      // Non-JSON error body — keep the http_<status> fallback code.
+    }
+    throw new AuthBffCustomerError(res.status, code);
+  }
+
+  let body: CustomerLoginBody;
+  try {
+    body = (await res.json()) as CustomerLoginBody;
+  } catch {
+    throw new AuthBffCustomerError(res.status, "invalid_response_body");
+  }
+
+  if ("totp_required" in body && body.totp_required === true) {
+    return {
+      kind: "totp_required",
+      sessionId: body.session_id,
+      sessionToken: body.session_token,
+    };
+  }
+
+  if ("handoff_url" in body && typeof body.handoff_url === "string") {
+    return {
+      kind: "handoff",
+      handoffUrl: body.handoff_url,
+      authRequestId: body.auth_request_id,
+    };
+  }
+
+  if ("data" in body && body.data && typeof body.data.uid === "string") {
+    return { kind: "complete", uid: body.data.uid, email: body.data.email };
+  }
+
+  throw new AuthBffCustomerError(res.status, "unrecognised_response_shape");
+}

--- a/apps/storefront/lib/auth/auth-bff-customer.ts
+++ b/apps/storefront/lib/auth/auth-bff-customer.ts
@@ -11,13 +11,19 @@
 // caller), never from client components.
 //
 // Shape reference: services/auth-bff/internal/zitadellogin/customer_handler.go
-//   POST /auth/customer/login  <- {auth_request_id, login_name, password}
-//   POST /auth/customer/totp   <- {auth_request_id, session_id, session_token, code}
+//   POST /auth/customer/login  <- {login_name, password}
+//   POST /auth/customer/totp   <- {session_id, session_token, code}
 //   200 complete   -> {"data": {"uid": string, "email": string}}
 //   200 factor-req -> {"totp_required": true, "session_id": string, "session_token": string}
-//   200 handoff    -> {"handoff_url": string, "auth_request_id": string}
+//   200 handoff    -> {"handoff_url": string}
 //   401 rejected   -> {"error": "invalid_credentials"} or {"error": "invalid_totp"}
 //   503/5xx        -> {"error": "zitadel_unavailable" | "internal_error" | ...}
+//
+// Neither endpoint takes an auth_request_id: the customer path makes a
+// sufficiency decision and returns an identity — it never finalizes, so it
+// never obtains (or needs) an OIDC authorization code. See
+// services/auth-bff/internal/zitadellogin/sufficiency.go's DecideSufficiency
+// / DecideAfterFactor and the file comment on customer_handler.go.
 //
 // The 401 case is deliberately collapsed to ONE outcome on the wire —
 // CustomerHandler.respondSessionCreateError returns the identical
@@ -44,7 +50,7 @@ const AUTH_BFF_URL = process.env.AUTH_BFF_URL ?? "http://localhost:8087";
 export type CustomerAuthOutcome =
   | { kind: "complete"; uid: string; email: string }
   | { kind: "totp_required"; sessionId: string; sessionToken: string }
-  | { kind: "handoff"; handoffUrl: string; authRequestId: string }
+  | { kind: "handoff"; handoffUrl: string }
   | { kind: "rejected" };
 
 /**
@@ -70,13 +76,11 @@ export class AuthBffCustomerError extends Error {
 }
 
 interface VerifyCustomerCredentialArgs {
-  authRequestId: string;
   loginName: string;
   password: string;
 }
 
 interface VerifyCustomerTotpArgs {
-  authRequestId: string;
   sessionId: string;
   sessionToken: string;
   code: string;
@@ -87,11 +91,11 @@ interface VerifyCustomerTotpArgs {
 type CustomerLoginBody =
   | { data: { uid: string; email: string } }
   | { totp_required: true; session_id: string; session_token: string }
-  | { handoff_url: string; auth_request_id: string };
+  | { handoff_url: string };
 
 /**
- * verifyCustomerCredential submits {auth_request_id, login_name, password}
- * to POST /auth/customer/login and returns the resulting outcome.
+ * verifyCustomerCredential submits {login_name, password} to
+ * POST /auth/customer/login and returns the resulting outcome.
  *
  * Never call this from a client component or route that ships to the
  * browser — see the file header.
@@ -100,7 +104,6 @@ export async function verifyCustomerCredential(
   args: VerifyCustomerCredentialArgs,
 ): Promise<CustomerAuthOutcome> {
   const res = await postToCustomerEndpoint("/auth/customer/login", {
-    auth_request_id: args.authRequestId,
     login_name: args.loginName,
     password: args.password,
   });
@@ -108,8 +111,8 @@ export async function verifyCustomerCredential(
 }
 
 /**
- * verifyCustomerTotp submits {auth_request_id, session_id, session_token,
- * code} to POST /auth/customer/totp and returns the resulting outcome.
+ * verifyCustomerTotp submits {session_id, session_token, code} to
+ * POST /auth/customer/totp and returns the resulting outcome.
  *
  * Never call this from a client component or route that ships to the
  * browser — see the file header.
@@ -118,7 +121,6 @@ export async function verifyCustomerTotp(
   args: VerifyCustomerTotpArgs,
 ): Promise<CustomerAuthOutcome> {
   const res = await postToCustomerEndpoint("/auth/customer/totp", {
-    auth_request_id: args.authRequestId,
     session_id: args.sessionId,
     session_token: args.sessionToken,
     code: args.code,
@@ -191,11 +193,7 @@ async function parseCustomerOutcome(
   }
 
   if ("handoff_url" in body && typeof body.handoff_url === "string") {
-    return {
-      kind: "handoff",
-      handoffUrl: body.handoff_url,
-      authRequestId: body.auth_request_id,
-    };
+    return { kind: "handoff", handoffUrl: body.handoff_url };
   }
 
   if ("data" in body && body.data && typeof body.data.uid === "string") {

--- a/apps/storefront/vitest.config.ts
+++ b/apps/storefront/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     globals: false,
     include: [
       "lib/**/*.{test,spec}.{ts,tsx}",
-      "app/api/**/*.{test,spec}.{ts,tsx}",
+      "app/**/*.{test,spec}.{ts,tsx}",
     ],
     exclude: ["**/node_modules/**", "**/tests/e2e/**", "**/.next/**"],
   },

--- a/docs/superpowers/plans/2026-09-03-zitadel-phase3b-customer-login.md
+++ b/docs/superpowers/plans/2026-09-03-zitadel-phase3b-customer-login.md
@@ -1,0 +1,255 @@
+# Zitadel Migration Phase 3b — Storefront Customer Password Login
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a storefront customer sign in with a password against Zitadel instead of Google Identity Platform, behind a flag that is off by default, without changing what mints their session or how it is scoped.
+
+**Architecture:** `auth-bff` gains a customer endpoint that verifies a credential against Zitadel and returns `{uid, email}` — it mints nothing, touches no cookie, and never enters the merchant gauntlet (spec D11). The storefront keeps resolving the host and store, minting `mp_customer_session` in its own HMAC format scoped to the exact host, and driving profile and loyalty enrolment. Only the "verify the token" step moves.
+
+**Tech Stack:** Go 1.26 (auth-bff), Next.js App Router server actions (storefront), stdlib `testing` with `httptest`, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-09-03-zitadel-migration-design.md` — D10, and **D11 which supersedes D10's framing**.
+
+## Scope — read this before starting
+
+**In scope:** storefront customer **password** sign-in.
+
+**Explicitly NOT in scope, and deferred to phase 3c:** the Google sign-in trampoline at `apps/onboarding/app/auth/google`. Zitadel's federated-IdP flow is shaped differently from GIP's `signInWithIdp`, the trampoline carries its own HMAC exchange-code protocol and host-matching defences, and the onboarding app's CSP allowlists `accounts.google.com/gsi/client` by host with **no `strict-dynamic`** — so any replacement script origin needs an explicit CSP change. Bundling that with password login would produce one branch nobody can review well.
+
+Also not in scope: deleting any GIP code (phase 6), and customer new-device detection or email OTP (spec D11 records why).
+
+## Global Constraints
+
+- **GIP stays live and default.** Every change is additive and flag-gated. Existing storefront tests must pass unedited.
+- **`auth-bff` must not mint a customer cookie.** It returns an identity. The storefront mints `mp_customer_session` exactly as it does today, scoped to the exact request host so one store's session cannot be sent to another. Do not "improve" this by centralising cookie minting.
+- **The customer endpoint must not call `completeLogin`, `CompleteForProvider`, or OpenFGA.** If a task seems to need them, stop and report BLOCKED — that would reintroduce the weaker-second-path cost D11 exists to avoid.
+- **The login-client PAT is instance-level** and must never reach a customer-facing app. It stays in `auth-bff`; that is the whole reason this endpoint exists.
+- **Reuse `internal/zitadellogin`.** Its client, sufficiency decision, witness type and archtests are merged and reviewed. The customer path uses them; it does not fork them. The three archtests scan every non-test file in that package, so anything added there must still satisfy them.
+- **Never log a credential** — password, session token, PAT.
+- Instance: `https://auth.tesserix.app`. Storefront project `mark8ly-storefront` = `389070377390703107`, `access.mode: public`.
+
+---
+
+### Task 1: The customer verification endpoint
+
+**Files:**
+- Create: `services/auth-bff/internal/zitadellogin/customer_handler.go`
+- Test: `services/auth-bff/internal/zitadellogin/customer_handler_test.go`
+
+**Interfaces:**
+- Consumes: the merged `Client` (`CreatePasswordSession`, `VerifyTOTP`, `UserEmail`), `CompleteIfSufficient`, `CompleteAfterFactor`.
+- Produces: `func NewCustomerHandler(c *Client) *CustomerHandler` and `Register(r *gin.RouterGroup)` mounting `POST /customer/login` and `POST /customer/totp`. Task 2 mounts it; Task 3 calls it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Mirror `handler_test.go`'s style — `httptest.Server` fake Zitadel, inline JSON literals copied from observed responses.
+
+Cover:
+- a successful password login returns `200 {"data": {"uid": …, "email": …}}` and **sets no cookie** — assert `rec.Result().Cookies()` is empty, because this is the property that distinguishes the customer path
+- `ErrBadCredentials` and `ErrUserNotFound` produce an **identical** `401 {"error":"invalid_credentials"}` — a different answer for "no such user" is an account-enumeration oracle on a public storefront
+- a `totp_required` outcome returns the session for the UI and still sets no cookie
+- a handoff outcome returns the hosted-login URL
+- neither the password nor the Zitadel session token appears in any error body
+- the email is resolved from Zitadel via `UserEmail`, **not** taken from the request body — the same defect fixed on the merchant path in phase 2
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd services/auth-bff && go test ./internal/zitadellogin/`
+Expected: build failure — `NewCustomerHandler` undefined.
+
+- [ ] **Step 3: Implement**
+
+`login` reads `{auth_request_id, login_name, password}`. It calls `CreatePasswordSession`, then `CompleteIfSufficient` with `federated: false`, then on `OutcomeComplete` resolves the user via `SessionFactors` + `UserEmail` and returns the identity. On `OutcomeFactorRequired` it returns the session so the caller can collect a code. On `OutcomeHandoff` it returns the hosted-login URL.
+
+It **mints no session, sets no cookie, and calls nothing in `internal/autologin`.** Add a file-level comment saying so and why, citing D11 — the next reader's instinct will be to "finish" it by minting something.
+
+`totp` mirrors the merchant path: `VerifyTOTP`, then `CompleteAfterFactor`, then the same identity response.
+
+- [ ] **Step 4: Run the tests and the archtests**
+
+Run: `cd services/auth-bff && go test ./internal/zitadellogin/ -v`
+Expected: all pass, **including the three archtests** — the new file must not call `finalize` or construct `sufficient{}`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/auth-bff/internal/zitadellogin/
+git commit -m "feat(auth-bff): verify a storefront customer credential and return an identity"
+```
+
+---
+
+### Task 2: Mount it
+
+**Files:**
+- Modify: `services/auth-bff/cmd/server/main.go`
+
+**Interfaces:**
+- Consumes: Task 1's `NewCustomerHandler`.
+- Produces: `POST /auth/customer/login` and `POST /auth/customer/totp`, live only when the Zitadel client is configured.
+
+- [ ] **Step 1: Mount conditionally**
+
+In the route block (~line 294-302), following the existing `if zitadelHandler != nil { zitadelHandler.Register(v1) }` idiom exactly:
+
+```go
+	if zitadelClient != nil {
+		zitadellogin.NewCustomerHandler(zitadelClient).Register(v1)
+	}
+```
+
+Do not introduce a second flag. The existing `ZITADEL_ENABLED` gate already governs whether the client exists.
+
+- [ ] **Step 2: Verify**
+
+Run: `cd services/auth-bff && go build ./... && go vet ./... && go test ./...`
+Expected: clean, all packages green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add services/auth-bff/cmd/server/main.go
+git commit -m "feat(auth-bff): mount the customer login routes behind the existing flag"
+```
+
+---
+
+### Task 3: Storefront client for the endpoint
+
+**Files:**
+- Create: `apps/storefront/lib/auth/auth-bff-customer.ts`
+- Test: `apps/storefront/lib/auth/auth-bff-customer.test.ts`
+
+**Interfaces:**
+- Produces: `verifyCustomerCredential({authRequestId, loginName, password})` and `verifyCustomerTotp({...})`, each returning a discriminated union mirroring the endpoint's outcomes. Task 4 consumes them.
+
+- [ ] **Step 1: Write the failing tests**
+
+Mock `fetch`. Assert the snake_case wire fields, that a 401 maps to a single `invalid_credentials` outcome regardless of which underlying error occurred, and that **the password never appears in a thrown error or rejection value**.
+
+- [ ] **Step 2: Run to verify they fail, then implement**
+
+Follow whatever conventions `apps/storefront/lib` already uses for outbound HTTP — read a sibling first. The `auth-bff` base URL is server-side config; this must only ever be called from a server action, never the browser.
+
+- [ ] **Step 3: Verify and commit**
+
+Run: `cd apps/storefront && npx vitest run lib/auth/ && npx tsc --noEmit`
+
+```bash
+git add apps/storefront/lib/auth/
+git commit -m "feat(storefront): client for auth-bff's customer credential check"
+```
+
+---
+
+### Task 4: Branch `customerSignIn` on the provider
+
+**Files:**
+- Modify: `apps/storefront/app/sign-in/actions.ts`
+- Modify: `apps/storefront/components/auth/CustomerSignInForm.tsx`
+- Test: `apps/storefront/app/sign-in/actions.zitadel.test.ts`
+
+**Interfaces:**
+- Consumes: Task 3's client.
+- Produces: no new exports; `customerSignIn` gains a Zitadel branch.
+
+- [ ] **Step 1: Understand what must NOT change**
+
+Read `customerSignIn` end to end first. Under Zitadel, **only** the `verifyGIPIdToken` step is replaced. Everything else stays byte-for-byte: `sanitizeHost`, `resolveStore`, `encodeSession`, the cookie set with `domain: cookieHost` and its exact-host comment, `ensureCustomerProfile`, `ensureLoyaltyEnrollment`.
+
+- [ ] **Step 2: Write the failing tests**
+
+Assert:
+- with the flag unset, `customerSignIn` calls `verifyGIPIdToken` and not the new client
+- with the flag on, it calls the new client and **not** `verifyGIPIdToken`
+- **in both cases the cookie is set with `domain` equal to the resolved request host** — the per-store isolation property, asserted directly rather than assumed
+- a failed verification sets no cookie
+- the form posts the password to the server action rather than to Zitadel from the browser
+
+- [ ] **Step 3: Implement the branch**
+
+Add a `NEXT_PUBLIC_AUTH_PROVIDER`-style flag read, defaulting to GIP, matching how `apps/admin` does it — check that implementation and use the same defaulting rule, where anything other than the literal `"zitadel"` means GIP.
+
+Under Zitadel the form collects the password and posts it to the server action; the browser no longer calls Identity Toolkit.
+
+- [ ] **Step 4: Verify**
+
+Run: `cd apps/storefront && npx vitest run && npx tsc --noEmit && npm run build`
+Expected: clean, and every pre-existing storefront test passes unedited.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/storefront/
+git commit -m "feat(storefront): sign customers in through auth-bff when the flag selects Zitadel"
+```
+
+---
+
+### Task 5: Prove the flow is reachable end to end
+
+**This task exists because of what happened in phase 3a.** Six tasks each passed their own review, and the feature was still unreachable: a flag was computed and never passed, a callback route was built and never called, and both were invisible in every individual diff. A per-task review sees a diff; a missing connection appears in no diff. This task is the check that would have caught it, run before the final review rather than after.
+
+**Files:**
+- Create: `apps/storefront/app/sign-in/customer-login-flow.test.ts`
+
+- [ ] **Step 1: Write an integration test that traverses every seam**
+
+With the flag on, and with only the network boundary mocked, assert in one test that a customer password sign-in:
+
+1. reaches `verifyCustomerCredential` with the submitted credential
+2. does **not** call `verifyGIPIdToken`
+3. results in `encodeSession` being called with the uid and email that came back from `auth-bff` — not from any client-supplied field
+4. sets `mp_customer_session` with `domain` equal to the resolved request host
+5. triggers the profile and loyalty side effects
+
+Each assertion pins one seam. If any step is wired to nothing, this test fails — which is exactly the failure mode a per-file review cannot see.
+
+- [ ] **Step 2: Write the same test for the flag unset**, asserting the GIP path is traversed instead and the Zitadel client is never called.
+
+- [ ] **Step 3: Verify and commit**
+
+Run: `cd apps/storefront && npx vitest run`
+
+```bash
+git add apps/storefront/app/sign-in/
+git commit -m "test(storefront): pin the customer login flow end to end for both providers"
+```
+
+---
+
+### Task 6: Record what this phase did not do
+
+**Files:**
+- Modify: `services/auth-bff/internal/zitadellogin/README.md`
+
+- [ ] **Step 1: Add a customer-path section**
+
+Record, with reasoning:
+1. The customer endpoint verifies and returns an identity. It mints nothing and never enters the merchant gauntlet (D11). The next reader's instinct will be to "finish" it; say why that would be wrong.
+2. `mp_customer_session` is minted by the storefront, in a different format from `m8_session`, scoped to the exact host so one store's session cannot reach another. The two share a key *name* and nothing else.
+3. Storefront customers get no new-device detection and no email-OTP step-up, because they have neither today. Adding them is a product decision, not a migration detail.
+4. The Google trampoline is untouched and is phase 3c — with the CSP host-allowlist constraint noted, since there is no `strict-dynamic`.
+5. `packages/ui/src/auth/exchange-code.ts` still has no `kind` pin while its two siblings do, and all three share `SESSION_ENCRYPT_KEY`. Carried from phase 3a; it sits on the trampoline path this phase deliberately did not touch.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add services/auth-bff/internal/zitadellogin/README.md
+git commit -m "docs(auth-bff): record the customer path's boundaries and what 3b deferred"
+```
+
+---
+
+## Phase 3b completion criteria
+
+- With the flag unset, storefront login behaves exactly as today and every pre-existing test passes unedited.
+- The customer endpoint mints no cookie, calls no OpenFGA, and touches nothing in `internal/autologin` — asserted by tests, not by inspection.
+- `mp_customer_session` is still minted by the storefront, still scoped to the exact request host, on both providers.
+- Unknown-user and wrong-password are indistinguishable to the caller.
+- Task 5's end-to-end tests pass for both providers.
+- The three `zitadellogin` archtests still pass with the new file present.
+
+## Not in this phase
+
+The Google trampoline (3c), `marketplace-api`'s verifier and the `tenant_id` claim (4), `gipadmin` (5), and the cutover (6).

--- a/docs/superpowers/specs/2026-09-03-zitadel-migration-design.md
+++ b/docs/superpowers/specs/2026-09-03-zitadel-migration-design.md
@@ -57,6 +57,50 @@ customers. The data risk grows; the code risk does not shrink by waiting.
 | D8 | Delete `gipkey` and the server/browser API key split. |
 | D9 | `Platform-9bu14` is out of scope — it is tesserix-home's pool and no mark8ly Go code reads it. |
 | D10 | Storefront customers get a separate `auth-bff` login path that skips the OpenFGA membership check. |
+| D11 | That customer path returns an identity and mints nothing; it does not run the merchant gauntlet at all. |
+
+### D11 — the customer path verifies credentials and returns an identity, nothing more
+
+D10 said the customer path would "skip the membership check". Reading the code
+made a simpler and safer shape available, and this supersedes that framing.
+
+**What `auth-bff` will do for a customer:** drive Zitadel's Session API to check
+the credential, apply the fail-closed sufficiency decision, and return
+`{uid, email}`. That is all. It does **not** call `completeLogin`, mint a cookie,
+or touch OpenFGA.
+
+**What the storefront keeps doing, exactly as today:** resolve the host, resolve
+the store, mint `mp_customer_session`, and drive the profile and loyalty side
+effects. VERIFIED by reading `apps/storefront/app/sign-in/actions.ts` — `auth-bff`
+would replace only the "verify the token" step; every other step already lives
+there and works.
+
+Three reasons this beats a membership-skipping variant of `completeLogin`:
+
+- **No weaker path inside the gating service.** A customer request never enters
+  the merchant gauntlet, so there is no second code path through it that
+  deliberately bypasses a gate — the thing D10 correctly called out as the cost.
+- **The cookie formats are incompatible anyway.** `auth-bff` mints an AES-GCM
+  encrypted blob scoped to `.mark8ly.com`; the storefront mints an HMAC-signed
+  base64 payload scoped to the **exact host**, so that "store-a's session can't be
+  sent to store-b". They share the `SESSION_ENCRYPT_KEY` *name* and nothing else.
+  Having `auth-bff` mint the customer cookie would mean either a third cookie
+  format or giving up the per-store host scoping.
+- **`auth-bff` has no notion of which surface a request is for.** All routes sit on
+  one flat `/auth` group. Keeping the customer endpoint to "verify and return"
+  means that plumbing stays a route prefix rather than becoming a mode that alters
+  what the gauntlet does.
+
+**Accepted consequence, decided rather than defaulted:** storefront login gets no
+new-device detection and no email-OTP step-up, because it has neither today.
+Routing customers through `completeLogin` would add both — a security improvement
+and new friction on the shopper conversion path. That is a product decision, and it
+should be made deliberately rather than arriving as a side effect of a migration.
+It remains available later.
+
+The PAT is still why this lives in `auth-bff` at all: the storefront cannot drive
+Zitadel's Session API without the instance-level login-client credential, which
+must not be deployed into a customer-facing app.
 
 ### D10 — customers need their own path, because they are not FGA members
 

--- a/services/auth-bff/cmd/server/main.go
+++ b/services/auth-bff/cmd/server/main.go
@@ -302,7 +302,9 @@ func main() {
 		zitadelHandler.Register(v1)
 	}
 	if zitadelClient != nil {
-		zitadellogin.NewCustomerHandler(zitadelClient).Register(v1)
+		zitadellogin.NewCustomerHandler(zitadelClient).
+			WithHostedLoginBaseURL(cfg.ZitadelIssuer).
+			Register(v1)
 	}
 
 	// /api/v1 surface consumed by marketplace-api's account handler,

--- a/services/auth-bff/cmd/server/main.go
+++ b/services/auth-bff/cmd/server/main.go
@@ -248,21 +248,30 @@ func main() {
 	// otherwise, so no route it backs is mounted. Refusing to boot on
 	// partial config is deliberate: a half-configured login path that fails
 	// at request time is worse than a loud failure here.
+	//
+	// MARKETPLACE_INTERNAL_AUTH_SECRET is part of "fully configured": the
+	// four Zitadel credential routes are gated on that shared header (see
+	// internal/zitadellogin/internal_auth.go), and mounting them without it
+	// would publish an unauthenticated credential-validity oracle.
+	// cfg.ValidateZitadel owns that list.
 	var zitadelClient *zitadellogin.Client
 	switch {
 	case !cfg.ZitadelEnabled:
 		log.Info("zitadel login disabled; GIP remains the auth provider")
-	case cfg.ZitadelIssuer == "" || cfg.ZitadelLoginClientToken == "":
-		log.Error("zitadel: ZITADEL_ENABLED is set but ZITADEL_ISSUER or ZITADEL_LOGIN_CLIENT_TOKEN is empty")
-		panic("zitadel: enabled but not configured")
 	default:
+		if err := cfg.ValidateZitadel(); err != nil {
+			// err names the missing variables, never their values.
+			log.Error("zitadel: refusing to start", "err", err)
+			panic(err)
+		}
 		zitadelClient = zitadellogin.New(cfg.ZitadelIssuer, cfg.ZitadelLoginClientToken, nil)
 		log.Info("zitadel login client enabled", "issuer", cfg.ZitadelIssuer)
 	}
 	var zitadelHandler *zitadellogin.Handler
 	if zitadelClient != nil {
 		zitadelHandler = zitadellogin.NewHandler(zitadelClient, autologinSvc.CompleteForProvider).
-			WithHostedLoginBaseURL(cfg.ZitadelIssuer)
+			WithHostedLoginBaseURL(cfg.ZitadelIssuer).
+			WithInternalAuth(cfg.MarketplaceInternalAuthSecret)
 	}
 
 	// ─── Session introspection + logout ────────────────────────────────
@@ -304,6 +313,7 @@ func main() {
 	if zitadelClient != nil {
 		zitadellogin.NewCustomerHandler(zitadelClient).
 			WithHostedLoginBaseURL(cfg.ZitadelIssuer).
+			WithInternalAuth(cfg.MarketplaceInternalAuthSecret).
 			Register(v1)
 	}
 

--- a/services/auth-bff/cmd/server/main.go
+++ b/services/auth-bff/cmd/server/main.go
@@ -301,6 +301,9 @@ func main() {
 	if zitadelHandler != nil {
 		zitadelHandler.Register(v1)
 	}
+	if zitadelClient != nil {
+		zitadellogin.NewCustomerHandler(zitadelClient).Register(v1)
+	}
 
 	// /api/v1 surface consumed by marketplace-api's account handler,
 	// which proxies admin UI requests through to us. Kept separate from

--- a/services/auth-bff/internal/internalauth/internalauth.go
+++ b/services/auth-bff/internal/internalauth/internalauth.go
@@ -1,0 +1,35 @@
+// Package internalauth holds the one shared-secret scheme auth-bff uses to
+// authenticate server-to-server callers.
+//
+// The scheme predates this package: internal/audit and internal/notify send
+// the secret as an X-Internal-Auth header on outbound calls, and
+// internal/session's /internal/users handler validates the same header on
+// the way in. This package is that inbound check, lifted out so every route
+// that needs it compares the same way instead of growing its own copy.
+//
+// The secret itself is never logged, echoed, or included in any error.
+package internalauth
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+)
+
+// Header is the request header carrying the shared internal secret.
+const Header = "X-Internal-Auth"
+
+// Equal reports whether the presented secret matches the expected one, in
+// constant time. An empty value on either side never matches, so a caller
+// that sends no header is rejected exactly like one that sends a wrong
+// value.
+//
+// Both sides are hashed first so the comparison is over fixed-length inputs
+// and the length of the configured secret does not leak through timing.
+func Equal(got, want string) bool {
+	if got == "" || want == "" {
+		return false
+	}
+	gotSum := sha256.Sum256([]byte(got))
+	wantSum := sha256.Sum256([]byte(want))
+	return subtle.ConstantTimeCompare(gotSum[:], wantSum[:]) == 1
+}

--- a/services/auth-bff/internal/internalauth/internalauth_test.go
+++ b/services/auth-bff/internal/internalauth/internalauth_test.go
@@ -1,0 +1,33 @@
+package internalauth
+
+import "testing"
+
+func TestEqual(t *testing.T) {
+	const want = "s3cret-internal"
+	cases := []struct {
+		name string
+		got  string
+		want string
+		ok   bool
+	}{
+		{"exact match", want, want, true},
+		{"missing header", "", want, false},
+		{"wrong value", "nope", want, false},
+		{"prefix of the secret", want[:4], want, false},
+		{"unconfigured expectation never matches", want, "", false},
+		{"both empty", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Equal(tc.got, tc.want); got != tc.ok {
+				t.Fatalf("Equal(%q, %q) = %v, want %v", tc.got, tc.want, got, tc.ok)
+			}
+		})
+	}
+}
+
+func TestHeaderNameMatchesTheEstablishedScheme(t *testing.T) {
+	if Header != "X-Internal-Auth" {
+		t.Fatalf("Header = %q; internal/audit and internal/notify send X-Internal-Auth", Header)
+	}
+}

--- a/services/auth-bff/internal/session/internal_users.go
+++ b/services/auth-bff/internal/session/internal_users.go
@@ -2,12 +2,12 @@ package session
 
 import (
 	"context"
-	"crypto/sha256"
-	"crypto/subtle"
 	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/auth-bff/internal/internalauth"
 )
 
 // UserEraser is what /internal/users/:id needs from downstream state
@@ -66,7 +66,7 @@ func (h *InternalUsersHandler) deleteUser(c *gin.Context) {
 		})
 		return
 	}
-	if !constantTimeEqual(c.GetHeader("X-Internal-Auth"), h.secret) {
+	if !internalauth.Equal(c.GetHeader(internalauth.Header), h.secret) {
 		c.JSON(http.StatusUnauthorized, gin.H{
 			"error":   "unauthorized",
 			"message": "missing or invalid internal auth",
@@ -111,13 +111,4 @@ func (h *InternalUsersHandler) deleteUser(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"data": gin.H{"user_id": userID, "erased": true},
 	})
-}
-
-func constantTimeEqual(got, want string) bool {
-	if got == "" || want == "" {
-		return false
-	}
-	gotSum := sha256.Sum256([]byte(got))
-	wantSum := sha256.Sum256([]byte(want))
-	return subtle.ConstantTimeCompare(gotSum[:], wantSum[:]) == 1
 }

--- a/services/auth-bff/internal/zitadellogin/README.md
+++ b/services/auth-bff/internal/zitadellogin/README.md
@@ -143,6 +143,60 @@ These are known gaps, tracked here so a future reader recognizes them as accepte
 
 ---
 
+## The Storefront Customer Path
+
+This package also contains `customer_handler.go`, which handles login for the **storefront** (end-customer purchases). It is deliberately incomplete compared to `handler.go` (the merchant admin path) and operates under a different contract.
+
+### Why the Customer Endpoint Mints No Session and Touches No OpenFGA
+
+**The design:** The customer endpoint verifies a credential against Zitadel and returns `{uid, email}`. It stops there. It mints no cookie, calls nothing in `internal/autologin`, and touches no OpenFGA. The storefront's existing sign-in action (see `apps/storefront/app/sign-in/actions.ts`) handles everything else: resolving the store, minting the `mp_customer_session` cookie, and driving profile side effects.
+
+**Why it cannot be "completed" by centralizing session minting here:** The storefront's `mp_customer_session` cookie is minted in a different format from `m8_session` and is scoped to the exact request host — a customer signed in on one store's subdomain (e.g. `store1.mark8ly.com`) must never be handed a session usable on another store's subdomain (e.g. `store2.mark8ly.com`). Minting the session here would require either:
+- Adding a third session format to this package (beside `m8_session` and `mp_customer_session`), or
+- Having this auth-bff package know about individual store subdomains, violating the separation of concerns between a centralized auth service and store-specific frontend logic.
+
+Both destroy the per-store isolation the storefront's own minting code provides for free. The current design is simpler and safer: auth-bff verifies the identity; the storefront applies the store-scoped isolation.
+
+### The Customer Path Never Calls Finalize
+
+**The design:** The customer path's `login` and `totp` handlers call `DecideSufficiency` and `DecideAfterFactor` from `sufficiency.go`. These methods evaluate whether a session meets the MFA policy and return a decision — `OutcomeComplete`, `OutcomeFactorRequired`, or `OutcomeHandoff` — but they never call the unexported `finalize` function. On `OutcomeComplete`, the customer handler returns `{uid, email}`. No `finalize` call. No authorization code.
+
+**Why no authorization code:** An authorization code is a handle to complete an OIDC flow that requires an `auth_request_id` from an earlier OIDC authorize round trip. The storefront never performs that round trip — it already has an identity from the password/TOTP verification and jumps straight to minting its own session. Asking for an authorization code would be asking for something the storefront has no way to use.
+
+**Why the decision logic is not duplicated:** The merchant path (`Handler`) and customer path (`CustomerHandler`) share the same decision functions in `sufficiency.go`. `CompleteIfSufficient` and `CompleteAfterFactor` in that file call `DecideSufficiency` and `DecideAfterFactor` respectively and then call `finalize` — so they apply the same MFA enforcement with one decision path. Having two separate decision paths, even if they started identical, is how one drifts into a bypass without anyone noticing. By keeping the decision in one place and having one caller path through `finalize` and another skip it, the enforcement stays single-source-of-truth.
+
+### KNOWN LIMITATION — Customers with a Second Factor Cannot Complete Sign-In on This Path
+
+**The issue:** A customer whose Zitadel account has enrolled a second factor (TOTP, passkey, U2F, SMS OTP, recovery code) cannot complete the sign-in flow on the storefront.
+
+**TOTP case:** If the customer has TOTP enrolled, the endpoint returns `{"totp_required": true, "session_id": "...", "session_token": "..."}` and the storefront would need a code-entry screen to submit the TOTP token to `/customer/totp`. No such screen exists today, so the flow stops with a browser message saying "TOTP entry not supported here."
+
+**Other second factors (passkey, U2F, SMS OTP, recovery code):** The `classifyEnrolledMethods` function maintains an include-list of known, collectible method types. PASSWORD and TOTP are in it; everything else is treated as uncollectible. When a customer has enrolled a method outside this list, the endpoint returns `{"handoff_url": "..."}` pointing to Zitadel's managed login UI. If no hosted login base URL is configured, it returns `{"error": "signin_unavailable"}` (a 503) rather than leaving the customer hung with a dead link.
+
+**Why these are honest dead ends, not oversights:** As of this writing, **zero customers have a second factor enrolled**. Building a TOTP entry screen is real UI work that belongs with the Google trampoline phase (3c) when that work is planned. Before this fix, both conditions rendered as the identical error message — "Email or password is incorrect" — which incorrectly told a customer with a correct password that it was wrong. Now the messages are honest: "We require an extra verification step we don't support here" for TOTP, and "Complete your sign-in in our full login UI" for other methods.
+
+### KNOWN LIMITATION — Network Timing May Still Distinguish a Wrong Password from an Unknown User
+
+**The limitation:** The customer endpoint returns byte-identical responses for a user-not-found error and a bad-credentials error: both produce `401 {"error": "invalid_credentials"}`. This is asserted by tests. However, Zitadel's internal password hashing happens on different code paths — roughly 0.7 seconds was observed in a sibling project for the correct-username-wrong-password case, while the user-not-found path is faster.
+
+**Why this is not ours to fix:** This storefront is a public website that anyone can probe. The endpoint's response symmetry is correct. Zitadel's latency asymmetry is Zitadel's problem, not this package's. If the consumer of this data wants to mitigate timing attacks from the browser side, they can use a client-side artificial delay before rendering the error, but this endpoint alone cannot close that gap without making legitimate requests artificially slow. Do not interpret the identical response bodies as proof of protection against timing attacks; they are necessary but not sufficient.
+
+### The Google Trampoline Is Phase 3c
+
+**The design:** The onboarding wizard (where merchants start) and the storefront (where customers purchase) both use Google Sign-In. When a user signs in with Google, the sign-in token comes from Google's Identity Services JavaScript SDK (`accounts.google.com/gsi/client`). To bounce that token from the multi-tenant mark8ly.com trampoline back to a tenant's own subdomain (e.g. `mystore.mark8ly.com`), the token is wrapped in an HMAC-signed exchange code and sent to the target store's `/auth/google/finish` handler.
+
+**Constraint that makes it its own phase:** The onboarding app's Content-Security-Policy allowlists `accounts.google.com/gsi/client` by host with no `strict-dynamic`. Any replacement or supplementary script origin needs an explicit CSP change, which requires coordination across multiple deployments. Additionally, the exchange-code protocol carries its own HMAC-based authentication and host-matching defenses. This phase (3b) touches only the Zitadel customer login path and leaves the Google trampoline untouched. Replacing or securing that integration is phase 3c.
+
+### Carried from Phase 3a: `exchange-code.ts` Has No `kind` Field
+
+**The issue:** The file `packages/ui/src/auth/exchange-code.ts` mints and verifies HMAC-signed exchange codes used by the Google trampoline. It has two sibling files that also mint and verify codes for different purposes. All three use `SESSION_ENCRYPT_KEY` as their signing key. However, unlike its two siblings, `exchange-code.ts` has no `kind` field to distinguish its intended purpose — a code minted for one purpose will pass the HMAC signature check when validated by another purpose's verifier, because they share the same key and the payload structure is compatible.
+
+**Example of the risk:** If a code minted for "Google sign-in on the storefront" and a code minted for "password-reset confirmation" both use the same key and are both JSON payloads, an attacker could swap them and potentially complete the wrong action (if the receiving handler doesn't validate the intent strictly enough).
+
+**Why it is not fixed in this phase:** This came to light in phase 3a and remains open. It lives on the Google trampoline path, which is explicitly not touched by this phase. When the trampoline integration is revisited in phase 3c, this gap should be closed by adding a `kind` field to `ExchangeCodeClaims` and validating it strictly in every verifier.
+
+---
+
 ## Testing and Validation
 
 The three architecture tests (`TestFinalizeIsOnlyCalledFromSufficiency`, `TestSufficientWitnessIsOnlyConstructedInSufficiency`, `TestSufficiencyNeverUsesTheUnscopedDisplayPolicy`) are not unit tests in the traditional sense. They are code-inspection tests that verify file-level invariants. They catch the obvious mistakes but accept the blind spot described in section 2.

--- a/services/auth-bff/internal/zitadellogin/customer_handler.go
+++ b/services/auth-bff/internal/zitadellogin/customer_handler.go
@@ -201,8 +201,22 @@ func (h *CustomerHandler) respondOutcome(
 		} else {
 			slog.InfoContext(ctx, "zitadellogin(customer): handoff (uncollectible factor or unreadable policy/session)")
 		}
+		// A customer who reaches this branch has a real, uncollectible
+		// factor (a passkey, U2F, SMS OTP, recovery code, ...) — see
+		// classifyEnrolledMethods — and handoff is the only door out. If no
+		// hosted login base URL is configured, handoffURL() returns "", and
+		// silently returning that string would be a 200 with nowhere to go:
+		// the customer would be stuck with no way to finish signing in. Fail
+		// loudly instead of leaving that empty, so the storefront can render
+		// "sign-in is unavailable" rather than a dead handoff link.
+		handoffURL := h.handoffURL()
+		if handoffURL == "" {
+			slog.ErrorContext(ctx, "zitadellogin(customer): handoff has no hosted login base URL configured; customer has no way to complete sign-in")
+			writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "signin_unavailable"})
+			return
+		}
 		writeJSON(w, http.StatusOK, map[string]any{
-			"handoff_url": h.handoffURL(),
+			"handoff_url": handoffURL,
 		})
 	}
 }

--- a/services/auth-bff/internal/zitadellogin/customer_handler.go
+++ b/services/auth-bff/internal/zitadellogin/customer_handler.go
@@ -29,15 +29,20 @@
 // else it does today — resolving the host, resolving the store, minting the
 // cookie, driving profile/loyalty side effects. Only the "verify the
 // credential" step moves to Zitadel.
+//
+// It follows from this that the customer path must never finalize: an OIDC
+// authorization code is not an identity, and obtaining a genuine one needs
+// an auth_request_id from an OIDC authorize round trip the storefront does
+// not have. So login/totp below call sufficiency.go's decision-only
+// DecideSufficiency / DecideAfterFactor, never CompleteIfSufficient /
+// CompleteAfterFactor, and take no auth_request_id at all.
 package zitadellogin
 
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -81,23 +86,27 @@ func (h *CustomerHandler) Register(r *gin.RouterGroup) {
 	})
 }
 
+// Neither request shape carries an auth_request_id: the customer path makes
+// a sufficiency decision and returns an identity (see DecideSufficiency /
+// DecideAfterFactor in sufficiency.go and spec D11) — it never finalizes, so
+// it has no use for an OIDC authorization-request id. A caller that sends
+// one anyway (e.g. a client still carrying the auth_request_id plumbing
+// removed from the storefront in this same change) has it silently ignored:
+// decodeJSON does not reject unknown fields.
 type customerLoginRequest struct {
-	AuthRequestID string `json:"auth_request_id"`
-	LoginName     string `json:"login_name"`
-	Password      string `json:"password"`
+	LoginName string `json:"login_name"`
+	Password  string `json:"password"`
 }
 
 type customerTOTPRequest struct {
-	AuthRequestID string `json:"auth_request_id"`
-	SessionID     string `json:"session_id"`
-	SessionToken  string `json:"session_token"`
-	Code          string `json:"code"`
+	SessionID    string `json:"session_id"`
+	SessionToken string `json:"session_token"`
+	Code         string `json:"code"`
 }
 
-// login reads {auth_request_id, login_name, password}, creates a Zitadel
-// password session, and asks sufficiency.go whether that session may
-// finalize. It never mints a session or sets a cookie — see the file
-// comment.
+// login reads {login_name, password}, creates a Zitadel password session,
+// and asks sufficiency.go whether that session is sufficient. It never
+// mints a session, sets a cookie, or finalizes — see the file comment.
 func (h *CustomerHandler) login(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -106,7 +115,7 @@ func (h *CustomerHandler) login(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
 		return
 	}
-	if req.AuthRequestID == "" || req.LoginName == "" || req.Password == "" {
+	if req.LoginName == "" || req.Password == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
 		return
 	}
@@ -123,13 +132,13 @@ func (h *CustomerHandler) login(w http.ResponseWriter, r *http.Request) {
 
 	// Password login through this endpoint is never a federated
 	// (Google/Apple) identity — those never present a password to us at all.
-	res, err := h.c.CompleteIfSufficient(ctx, req.AuthRequestID, sess, false)
-	h.respondOutcome(ctx, w, res, err, req.AuthRequestID, sess)
+	res, err := h.c.DecideSufficiency(ctx, sess, false)
+	h.respondOutcome(ctx, w, res, err, sess)
 }
 
-// totp reads {auth_request_id, session_id, session_token, code}, submits the
-// TOTP code against the session opened by login, and re-asks sufficiency.go
-// whether the session may now finalize.
+// totp reads {session_id, session_token, code}, submits the TOTP code
+// against the session opened by login, and re-asks sufficiency.go whether
+// the session is now sufficient.
 func (h *CustomerHandler) totp(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -138,7 +147,7 @@ func (h *CustomerHandler) totp(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
 		return
 	}
-	if req.AuthRequestID == "" || req.SessionID == "" || req.SessionToken == "" || req.Code == "" {
+	if req.SessionID == "" || req.SessionToken == "" || req.Code == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
 		return
 	}
@@ -149,26 +158,27 @@ func (h *CustomerHandler) totp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := h.c.CompleteAfterFactor(ctx, req.AuthRequestID, sess)
-	h.respondOutcome(ctx, w, res, err, req.AuthRequestID, sess)
+	res, err := h.c.DecideAfterFactor(ctx, sess)
+	h.respondOutcome(ctx, w, res, err, sess)
 }
 
-// respondOutcome is shared by login and totp: both end at
-// CompleteIfSufficient / CompleteAfterFactor and switch on the same three
-// outcomes as Handler.respondOutcome, but OutcomeComplete here resolves and
-// returns an identity instead of running the post-identity gauntlet.
+// respondOutcome is shared by login and totp: both end at DecideSufficiency
+// / DecideAfterFactor and switch on the same three outcomes as
+// Handler.respondOutcome, but OutcomeComplete here resolves and returns an
+// identity instead of finalizing — the decision functions never call
+// finalize, so there is no callback URL to hand back and no
+// "handoff after a failed finalize" case to report.
 func (h *CustomerHandler) respondOutcome(
 	ctx context.Context,
 	w http.ResponseWriter,
 	res Result,
 	resErr error,
-	authRequestID string,
 	sess Session,
 ) {
 	switch res.Outcome {
 	case OutcomeComplete:
 		if resErr != nil {
-			// Not reachable per CompleteIfSufficient/CompleteAfterFactor's
+			// Not reachable per DecideSufficiency/DecideAfterFactor's
 			// contract, but refuse to report success on an outcome/error
 			// mismatch rather than trust an incoherent result.
 			slog.ErrorContext(ctx, "zitadellogin(customer): OutcomeComplete carried a non-nil error, refusing to complete", "err", resErr)
@@ -187,15 +197,12 @@ func (h *CustomerHandler) respondOutcome(
 
 	default: // OutcomeHandoff, including the zero value.
 		if resErr != nil {
-			slog.ErrorContext(ctx, "zitadellogin(customer): handoff after a failed finalize (positive decision, exchange failed)",
-				"err", resErr, "auth_request_id", authRequestID)
+			slog.ErrorContext(ctx, "zitadellogin(customer): handoff after a decision error", "err", resErr)
 		} else {
-			slog.InfoContext(ctx, "zitadellogin(customer): handoff (uncollectible factor or unreadable policy/session)",
-				"auth_request_id", authRequestID)
+			slog.InfoContext(ctx, "zitadellogin(customer): handoff (uncollectible factor or unreadable policy/session)")
 		}
 		writeJSON(w, http.StatusOK, map[string]any{
-			"handoff_url":     h.handoffURL(authRequestID),
-			"auth_request_id": authRequestID,
+			"handoff_url": h.handoffURL(),
 		})
 	}
 }
@@ -278,13 +285,16 @@ func (h *CustomerHandler) respondTOTPVerifyError(ctx context.Context, w http.Res
 	}
 }
 
-// handoffURL builds the Aurora-branded hosted login's continuation URL for an
-// auth request this endpoint decided it cannot (or should not) finish
-// itself. Mirrors Handler.handoffURL. Returns "" when no hosted login base
-// URL was configured; the caller still gets auth_request_id back.
-func (h *CustomerHandler) handoffURL(authRequestID string) string {
+// handoffURL builds the Aurora-branded hosted login's landing URL for a
+// login this endpoint decided it cannot (or should not) finish itself.
+// Unlike Handler.handoffURL on the merchant path, there is no
+// authRequestID to append — the customer path never has a genuine one (see
+// the file comment) — so this is a bare landing URL, not a continuation of
+// a specific auth request. Returns "" when no hosted login base URL was
+// configured.
+func (h *CustomerHandler) handoffURL() string {
 	if h.hostedLoginBaseURL == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s/ui/v2/login/login?authRequestID=%s", h.hostedLoginBaseURL, url.QueryEscape(authRequestID))
+	return h.hostedLoginBaseURL + "/ui/v2/login/login"
 }

--- a/services/auth-bff/internal/zitadellogin/customer_handler.go
+++ b/services/auth-bff/internal/zitadellogin/customer_handler.go
@@ -1,0 +1,290 @@
+// This file implements the STOREFRONT CUSTOMER login path. It looks
+// unfinished compared to Handler (handler.go): it mints no session, sets no
+// cookie, and calls nothing in internal/autologin. That is deliberate — see
+// spec D11 (docs/superpowers/specs/2026-09-03-zitadel-migration-design.md).
+//
+// D11 supersedes an earlier framing (D10) that said the customer path would
+// "skip the membership check". Reading the code made a simpler and safer
+// shape available: rather than reuse the merchant gauntlet minus a check,
+// this endpoint verifies the credential against Zitadel and returns
+// {uid, email}. Full stop.
+//
+// Why not "finish" it by minting a session here too:
+//
+//   - Storefront customers are deliberately not OpenFGA members. Running them
+//     through the merchant gauntlet would mean either adding a bypass flag to
+//     that gauntlet (a second, weaker path baked into the trusted one) or
+//     giving customers FGA tuples they have no reason to hold.
+//   - The storefront mints its own `mp_customer_session` cookie, in its own
+//     HMAC format, scoped to the exact request host — a customer signed in on
+//     one store's subdomain must never be handed a session usable on another
+//     store. Minting a cookie here would either introduce a THIRD session
+//     format (alongside `m8_session` and `mp_customer_session`) or require
+//     this package to know the request host of a storefront it has no
+//     business knowing about. Either destroys the per-store isolation the
+//     storefront's own minting code already gives for free.
+//
+// So: this handler verifies and returns. The storefront's existing sign-in
+// action (apps/storefront/app/sign-in/actions.ts) keeps doing everything
+// else it does today — resolving the host, resolving the store, minting the
+// cookie, driving profile/loyalty side effects. Only the "verify the
+// credential" step moves to Zitadel.
+package zitadellogin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CustomerHandler is the HTTP layer over Client for storefront customers. It
+// shares Client and the sufficiency decision with Handler, but never touches
+// CompleteFunc, session cookies, or internal/autologin — see the file
+// comment above.
+type CustomerHandler struct {
+	c *Client
+
+	// hostedLoginBaseURL mirrors Handler.hostedLoginBaseURL: the Zitadel
+	// instance's own login UI, used ONLY as the OutcomeHandoff target for
+	// factors this endpoint cannot collect. Optional: set via
+	// WithHostedLoginBaseURL.
+	hostedLoginBaseURL string
+}
+
+// NewCustomerHandler constructs a CustomerHandler.
+func NewCustomerHandler(c *Client) *CustomerHandler {
+	return &CustomerHandler{c: c}
+}
+
+// WithHostedLoginBaseURL sets the Zitadel instance base URL used to build the
+// OutcomeHandoff redirect target. Mirrors Handler.WithHostedLoginBaseURL.
+func (h *CustomerHandler) WithHostedLoginBaseURL(baseURL string) *CustomerHandler {
+	h.hostedLoginBaseURL = strings.TrimSuffix(baseURL, "/")
+	return h
+}
+
+// Register mounts the customer login routes onto the given gin.RouterGroup.
+// Like Handler.Register, the handlers are plain net/http funcs; gin is only
+// used to route, matching this package's existing style.
+func (h *CustomerHandler) Register(r *gin.RouterGroup) {
+	r.POST("/customer/login", func(c *gin.Context) {
+		h.login(c.Writer, c.Request)
+	})
+	r.POST("/customer/totp", func(c *gin.Context) {
+		h.totp(c.Writer, c.Request)
+	})
+}
+
+type customerLoginRequest struct {
+	AuthRequestID string `json:"auth_request_id"`
+	LoginName     string `json:"login_name"`
+	Password      string `json:"password"`
+}
+
+type customerTOTPRequest struct {
+	AuthRequestID string `json:"auth_request_id"`
+	SessionID     string `json:"session_id"`
+	SessionToken  string `json:"session_token"`
+	Code          string `json:"code"`
+}
+
+// login reads {auth_request_id, login_name, password}, creates a Zitadel
+// password session, and asks sufficiency.go whether that session may
+// finalize. It never mints a session or sets a cookie — see the file
+// comment.
+func (h *CustomerHandler) login(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req customerLoginRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		return
+	}
+	if req.AuthRequestID == "" || req.LoginName == "" || req.Password == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		return
+	}
+
+	// A wrong username and a wrong password take the same code path in
+	// CreatePasswordSession and must take the same one here: a different
+	// answer for "no such user" is an account-enumeration oracle on a public
+	// storefront that anyone can probe.
+	sess, err := h.c.CreatePasswordSession(ctx, req.LoginName, req.Password)
+	if err != nil {
+		h.respondSessionCreateError(ctx, w, err)
+		return
+	}
+
+	// Password login through this endpoint is never a federated
+	// (Google/Apple) identity — those never present a password to us at all.
+	res, err := h.c.CompleteIfSufficient(ctx, req.AuthRequestID, sess, false)
+	h.respondOutcome(ctx, w, res, err, req.AuthRequestID, sess)
+}
+
+// totp reads {auth_request_id, session_id, session_token, code}, submits the
+// TOTP code against the session opened by login, and re-asks sufficiency.go
+// whether the session may now finalize.
+func (h *CustomerHandler) totp(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req customerTOTPRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		return
+	}
+	if req.AuthRequestID == "" || req.SessionID == "" || req.SessionToken == "" || req.Code == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		return
+	}
+
+	sess, err := h.c.VerifyTOTP(ctx, Session{ID: req.SessionID, Token: req.SessionToken}, req.Code)
+	if err != nil {
+		h.respondTOTPVerifyError(ctx, w, err)
+		return
+	}
+
+	res, err := h.c.CompleteAfterFactor(ctx, req.AuthRequestID, sess)
+	h.respondOutcome(ctx, w, res, err, req.AuthRequestID, sess)
+}
+
+// respondOutcome is shared by login and totp: both end at
+// CompleteIfSufficient / CompleteAfterFactor and switch on the same three
+// outcomes as Handler.respondOutcome, but OutcomeComplete here resolves and
+// returns an identity instead of running the post-identity gauntlet.
+func (h *CustomerHandler) respondOutcome(
+	ctx context.Context,
+	w http.ResponseWriter,
+	res Result,
+	resErr error,
+	authRequestID string,
+	sess Session,
+) {
+	switch res.Outcome {
+	case OutcomeComplete:
+		if resErr != nil {
+			// Not reachable per CompleteIfSufficient/CompleteAfterFactor's
+			// contract, but refuse to report success on an outcome/error
+			// mismatch rather than trust an incoherent result.
+			slog.ErrorContext(ctx, "zitadellogin(customer): OutcomeComplete carried a non-nil error, refusing to complete", "err", resErr)
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+			return
+		}
+		h.finishComplete(ctx, w, sess)
+
+	case OutcomeFactorRequired:
+		// No session minted here — this IS the MFA gate.
+		writeJSON(w, http.StatusOK, map[string]any{
+			"totp_required": true,
+			"session_id":    sess.ID,
+			"session_token": sess.Token,
+		})
+
+	default: // OutcomeHandoff, including the zero value.
+		if resErr != nil {
+			slog.ErrorContext(ctx, "zitadellogin(customer): handoff after a failed finalize (positive decision, exchange failed)",
+				"err", resErr, "auth_request_id", authRequestID)
+		} else {
+			slog.InfoContext(ctx, "zitadellogin(customer): handoff (uncollectible factor or unreadable policy/session)",
+				"auth_request_id", authRequestID)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"handoff_url":     h.handoffURL(authRequestID),
+			"auth_request_id": authRequestID,
+		})
+	}
+}
+
+// finishComplete resolves the subject of the now-sufficient session and
+// returns {uid, email}. It does not mint a session, set a cookie, or call
+// anything in internal/autologin — see the file comment.
+func (h *CustomerHandler) finishComplete(ctx context.Context, w http.ResponseWriter, sess Session) {
+	// Result carries no subject — re-read it.
+	factors, err := h.c.SessionFactors(ctx, sess.ID)
+	if err != nil || factors.UserID == "" {
+		slog.ErrorContext(ctx, "zitadellogin(customer): could not resolve session subject after a sufficient decision", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+		return
+	}
+
+	// The email MUST come from Zitadel's own record of this session's
+	// subject, never from a request body — the same defect fixed on the
+	// merchant path in phase 2. A caller with valid credentials of their own
+	// could otherwise submit an arbitrary login_name and walk away with an
+	// identity response addressed to a victim's email of their choosing.
+	email, err := h.c.UserEmail(ctx, factors.UserID)
+	if err != nil {
+		slog.ErrorContext(ctx, "zitadellogin(customer): could not resolve the verified email for session subject", "err", err, "user_id", factors.UserID)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": map[string]any{
+			"uid":   factors.UserID,
+			"email": email,
+		},
+	})
+}
+
+// respondSessionCreateError maps CreatePasswordSession's errors.
+//
+// ErrBadCredentials and ErrUserNotFound MUST produce the identical response —
+// collapsing them is the entire point of this function, and it matters more
+// here than on the merchant path: this endpoint is reachable by anyone on a
+// public storefront, so a different answer for "no such user" is a live
+// account-enumeration oracle. Which one actually happened is logged for
+// operators, never returned to the caller.
+func (h *CustomerHandler) respondSessionCreateError(ctx context.Context, w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrBadCredentials):
+		slog.WarnContext(ctx, "zitadellogin(customer): login rejected: bad credentials")
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "invalid_credentials"})
+	case errors.Is(err, ErrUserNotFound):
+		slog.WarnContext(ctx, "zitadellogin(customer): login rejected: user not found")
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "invalid_credentials"})
+	case errors.Is(err, ErrUnavailable):
+		slog.ErrorContext(ctx, "zitadellogin(customer): zitadel unavailable creating session", "err", err)
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "zitadel_unavailable"})
+	default:
+		slog.ErrorContext(ctx, "zitadellogin(customer): unexpected error creating session", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+	}
+}
+
+// respondTOTPVerifyError maps VerifyTOTP's errors. Unlike the login step,
+// there is no enumeration concern here — the account is already established
+// — but the wrong-code case still must never echo Zitadel's error body.
+func (h *CustomerHandler) respondTOTPVerifyError(ctx context.Context, w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrBadCredentials):
+		slog.WarnContext(ctx, "zitadellogin(customer): totp rejected: bad code")
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "invalid_totp"})
+	case errors.Is(err, ErrUserNotFound):
+		// The session itself vanished/expired between steps.
+		slog.WarnContext(ctx, "zitadellogin(customer): totp rejected: session not found")
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "invalid_totp"})
+	case errors.Is(err, ErrUnavailable):
+		slog.ErrorContext(ctx, "zitadellogin(customer): zitadel unavailable verifying totp", "err", err)
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "zitadel_unavailable"})
+	default:
+		slog.ErrorContext(ctx, "zitadellogin(customer): unexpected error verifying totp", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+	}
+}
+
+// handoffURL builds the Aurora-branded hosted login's continuation URL for an
+// auth request this endpoint decided it cannot (or should not) finish
+// itself. Mirrors Handler.handoffURL. Returns "" when no hosted login base
+// URL was configured; the caller still gets auth_request_id back.
+func (h *CustomerHandler) handoffURL(authRequestID string) string {
+	if h.hostedLoginBaseURL == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/ui/v2/login/login?authRequestID=%s", h.hostedLoginBaseURL, url.QueryEscape(authRequestID))
+}

--- a/services/auth-bff/internal/zitadellogin/customer_handler.go
+++ b/services/auth-bff/internal/zitadellogin/customer_handler.go
@@ -60,6 +60,11 @@ type CustomerHandler struct {
 	// factors this endpoint cannot collect. Optional: set via
 	// WithHostedLoginBaseURL.
 	hostedLoginBaseURL string
+
+	// internalAuthSecret is the expected X-Internal-Auth value. See
+	// internal_auth.go: empty means unchecked, and the boot guard in
+	// config.ValidateZitadel is what stops that reaching production.
+	internalAuthSecret string
 }
 
 // NewCustomerHandler constructs a CustomerHandler.
@@ -71,6 +76,15 @@ func NewCustomerHandler(c *Client) *CustomerHandler {
 // OutcomeHandoff redirect target. Mirrors Handler.WithHostedLoginBaseURL.
 func (h *CustomerHandler) WithHostedLoginBaseURL(baseURL string) *CustomerHandler {
 	h.hostedLoginBaseURL = strings.TrimSuffix(baseURL, "/")
+	return h
+}
+
+// WithInternalAuth requires every request to /auth/customer/{login,totp} to
+// present secret in the X-Internal-Auth header. The storefront calls these
+// from a server action only, so this costs it one header. See
+// internal_auth.go.
+func (h *CustomerHandler) WithInternalAuth(secret string) *CustomerHandler {
+	h.internalAuthSecret = secret
 	return h
 }
 
@@ -110,6 +124,14 @@ type customerTOTPRequest struct {
 func (h *CustomerHandler) login(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	// First, before the body is even read: an unauthenticated caller must
+	// never reach CreatePasswordSession, or this endpoint tells them
+	// whether a credential is valid.
+	if !internalAuthorized(r, h.internalAuthSecret) {
+		writeUnauthorized(w)
+		return
+	}
+
 	var req customerLoginRequest
 	if err := decodeJSON(r, &req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
@@ -141,6 +163,12 @@ func (h *CustomerHandler) login(w http.ResponseWriter, r *http.Request) {
 // the session is now sufficient.
 func (h *CustomerHandler) totp(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+
+	// See login: reject before any Zitadel call.
+	if !internalAuthorized(r, h.internalAuthSecret) {
+		writeUnauthorized(w)
+		return
+	}
 
 	var req customerTOTPRequest
 	if err := decodeJSON(r, &req); err != nil {

--- a/services/auth-bff/internal/zitadellogin/customer_handler_test.go
+++ b/services/auth-bff/internal/zitadellogin/customer_handler_test.go
@@ -51,8 +51,8 @@ func TestCustomerLoginSetsNoCookie(t *testing.T) {
 	if data["email"] != "a@b.test" {
 		t.Fatalf("data.email = %v, want a@b.test", data["email"])
 	}
-	if !fin.Load() {
-		t.Fatal("finalize was not called for a sufficient session")
+	if fin.Load() {
+		t.Fatal("finalize was called — the customer path must decide and stop, never finalize (spec D11)")
 	}
 }
 
@@ -148,7 +148,7 @@ func TestCustomerLoginHandoffReturnsHostedLoginURL(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 	got, _ := body["handoff_url"].(string)
-	if !strings.HasPrefix(got, "https://login.mark8ly.zitadel.cloud/ui/v2/login/login?authRequestID=") {
+	if got != "https://login.mark8ly.zitadel.cloud/ui/v2/login/login" {
 		t.Fatalf("handoff_url = %q", got)
 	}
 	if fin.Load() {
@@ -210,8 +210,8 @@ func TestCustomerTotpCompleteReturnsIdentityAndSetsNoCookie(t *testing.T) {
 	if data == nil || data["uid"] != "u1" || data["email"] != "a@b.test" {
 		t.Fatalf("body = %v, want data.{uid: u1, email: a@b.test}", body)
 	}
-	if !fin.Load() {
-		t.Fatal("finalize was not called after a successful TOTP check")
+	if fin.Load() {
+		t.Fatal("finalize was called — the customer path must decide and stop, never finalize (spec D11)")
 	}
 }
 
@@ -269,7 +269,36 @@ func TestCustomerTotpRejectsMissingFields(t *testing.T) {
 
 func TestCustomerHandoffURLEmptyWithoutConfiguredBase(t *testing.T) {
 	h := NewCustomerHandler(New("http://unused.invalid", "pat", nil))
-	if got := h.handoffURL("V2_1"); got != "" {
+	if got := h.handoffURL(); got != "" {
 		t.Fatalf("handoffURL = %q, want empty when no base configured", got)
+	}
+}
+
+// TestCustomerEndpointsIgnoreAuthRequestID pins that a caller who still
+// sends auth_request_id (e.g. a client not yet updated) gets it silently
+// ignored rather than rejected — the field carries no meaning on this path
+// and decodeJSON does not reject unknown fields.
+func TestCustomerEndpointsIgnoreAuthRequestID(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelCustomer(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+	h := NewCustomerHandler(c)
+
+	rec := httptest.NewRecorder()
+	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/customer/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s — a stray auth_request_id must not cause a 400", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := body["auth_request_id"]; ok {
+		t.Fatalf("body = %v, must not echo auth_request_id back", body)
+	}
+	data, _ := body["data"].(map[string]any)
+	if data == nil || data["uid"] != "u1" {
+		t.Fatalf("body = %v, want data.uid = u1", body)
 	}
 }

--- a/services/auth-bff/internal/zitadellogin/customer_handler_test.go
+++ b/services/auth-bff/internal/zitadellogin/customer_handler_test.go
@@ -1,0 +1,275 @@
+package zitadellogin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// fakeZitadelCustomer wires the same routes fakeZitadelHandler does
+// (handler_test.go), reused here so the customer path tests need no fixture
+// duplication.
+func fakeZitadelCustomer(t *testing.T, policyJSON, methodsJSON, factorsJSON string, finalized *atomic.Bool) *Client {
+	t.Helper()
+	return fakeZitadelHandler(t, policyJSON, methodsJSON, factorsJSON, finalized)
+}
+
+// TestCustomerLoginSetsNoCookie pins the property that distinguishes this
+// endpoint from the merchant path: a successful login returns an identity
+// but mints no session and sets no cookie. The storefront mints
+// mp_customer_session itself, scoped to the exact request host.
+func TestCustomerLoginSetsNoCookie(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelCustomer(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+	h := NewCustomerHandler(c)
+
+	rec := httptest.NewRecorder()
+	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/customer/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if cookies := rec.Result().Cookies(); len(cookies) != 0 {
+		t.Fatalf("cookies = %v, want none — the customer endpoint must never mint a session cookie", cookies)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	data, _ := body["data"].(map[string]any)
+	if data == nil {
+		t.Fatalf("body = %v, want data.{uid,email}", body)
+	}
+	if data["uid"] != "u1" {
+		t.Fatalf("data.uid = %v, want u1", data["uid"])
+	}
+	if data["email"] != "a@b.test" {
+		t.Fatalf("data.email = %v, want a@b.test", data["email"])
+	}
+	if !fin.Load() {
+		t.Fatal("finalize was not called for a sufficient session")
+	}
+}
+
+// TestCustomerLoginCollapsesUnknownUserAndWrongPasswordIntoOneAnswer mirrors
+// TestLoginCollapsesUnknownUserAndWrongPasswordIntoOneAnswer for the merchant
+// path (handler_test.go) — the enumeration concern is sharper here because
+// this endpoint is reachable by anyone on a public storefront.
+func TestCustomerLoginCollapsesUnknownUserAndWrongPasswordIntoOneAnswer(t *testing.T) {
+	var responses []string
+	for _, body := range []string{
+		`{"code":3,"message":"Password is invalid (COMMAND-3M0fs)","details":[{"id":"COMMAND-3M0fs","failedAttempts":1}]}`,
+		`{"code":5,"message":"User could not be found (QUERY-Dfbg2)","details":[{"id":"QUERY-Dfbg2"}]}`,
+	} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(body, "QUERY") {
+				w.WriteHeader(http.StatusNotFound)
+			} else {
+				w.WriteHeader(http.StatusBadRequest)
+			}
+			w.Write([]byte(body))
+		}))
+		defer srv.Close()
+		h := NewCustomerHandler(New(srv.URL, "pat", srv.Client()))
+		rec := httptest.NewRecorder()
+		h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/customer/login",
+			strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x"}`)))
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", rec.Code)
+		}
+		if strings.Contains(rec.Body.String(), "failedAttempts") || strings.Contains(rec.Body.String(), "not be found") {
+			t.Fatalf("response leaks which half failed: %s", rec.Body.String())
+		}
+		if len(rec.Result().Cookies()) != 0 {
+			t.Fatalf("cookies set on a rejected login: %v", rec.Result().Cookies())
+		}
+		responses = append(responses, rec.Body.String())
+	}
+	if responses[0] != responses[1] {
+		t.Fatalf("responses differ: %q vs %q — this is an account-enumeration oracle", responses[0], responses[1])
+	}
+}
+
+// TestCustomerLoginFactorRequiredSetsNoCookie mirrors
+// TestLoginFactorRequiredDoesNotMintSession: an outcome that still needs a
+// TOTP code must not mint anything either.
+func TestCustomerLoginFactorRequiredSetsNoCookie(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelCustomer(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsPasswordOnly, &fin)
+	h := NewCustomerHandler(c)
+
+	rec := httptest.NewRecorder()
+	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/customer/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if len(rec.Result().Cookies()) != 0 {
+		t.Fatalf("cookies = %v, want none for totp_required", rec.Result().Cookies())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["totp_required"] != true {
+		t.Fatalf("body = %v, want totp_required: true", body)
+	}
+	if body["session_id"] != "s1" || body["session_token"] != "tok-1" {
+		t.Fatalf("body = %v, want the session returned for the caller to collect a code", body)
+	}
+	if fin.Load() {
+		t.Fatal("finalize was called for OutcomeFactorRequired")
+	}
+}
+
+// TestCustomerLoginHandoffReturnsHostedLoginURL mirrors
+// TestLoginHandoffReturnsHandoffURLAndDoesNotCallComplete.
+func TestCustomerLoginHandoffReturnsHostedLoginURL(t *testing.T) {
+	var fin atomic.Bool
+	// Unrecognised factor type -> uncollectible -> OutcomeHandoff.
+	c := fakeZitadelCustomer(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_U2F"]`, factorsPasswordOnly, &fin)
+	h := NewCustomerHandler(c).WithHostedLoginBaseURL("https://login.mark8ly.zitadel.cloud")
+
+	rec := httptest.NewRecorder()
+	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/customer/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got, _ := body["handoff_url"].(string)
+	if !strings.HasPrefix(got, "https://login.mark8ly.zitadel.cloud/ui/v2/login/login?authRequestID=") {
+		t.Fatalf("handoff_url = %q", got)
+	}
+	if fin.Load() {
+		t.Fatal("finalize was called for OutcomeHandoff")
+	}
+	if len(rec.Result().Cookies()) != 0 {
+		t.Fatalf("cookies set on a handoff: %v", rec.Result().Cookies())
+	}
+}
+
+// TestCustomerTotpWrongCodeReturns401WithoutLeakingZitadelBody mirrors
+// TestTotpWrongCodeReturns401WithoutLeakingZitadelBody.
+func TestCustomerTotpWrongCodeReturns401WithoutLeakingZitadelBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"code":3,"message":"Invalid code (COMMAND-Sfeg2)","details":[{"id":"COMMAND-Sfeg2","failedAttempts":2}]}`))
+	}))
+	defer srv.Close()
+	h := NewCustomerHandler(New(srv.URL, "pat", srv.Client()))
+
+	rec := httptest.NewRecorder()
+	h.totp(rec, httptest.NewRequest(http.MethodPost, "/auth/customer/totp",
+		strings.NewReader(`{"auth_request_id":"V2_1","session_id":"s1","session_token":"tok-1","code":"000000"}`)))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401, body = %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "failedAttempts") {
+		t.Fatalf("response leaks the attempt counter: %s", rec.Body.String())
+	}
+	if len(rec.Result().Cookies()) != 0 {
+		t.Fatalf("cookies set on a rejected totp: %v", rec.Result().Cookies())
+	}
+}
+
+// TestCustomerTotpCompleteReturnsIdentityAndSetsNoCookie exercises the full
+// totp completion path and re-checks the no-cookie property there too.
+func TestCustomerTotpCompleteReturnsIdentityAndSetsNoCookie(t *testing.T) {
+	var fin atomic.Bool
+	factorsWithTOTP := `{"session":{"factors":{"user":{"id":"u1","organizationId":"o1"},"password":{"verifiedAt":"2026-09-03T01:00:00Z"},"totp":{"verifiedAt":"2026-09-03T01:01:00Z"}}}}`
+	c := fakeZitadelCustomer(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsWithTOTP, &fin)
+	h := NewCustomerHandler(c)
+
+	rec := httptest.NewRecorder()
+	h.totp(rec, httptest.NewRequest(http.MethodPost, "/auth/customer/totp",
+		strings.NewReader(`{"auth_request_id":"V2_1","session_id":"s1","session_token":"tok-1","code":"123456"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if len(rec.Result().Cookies()) != 0 {
+		t.Fatalf("cookies = %v, want none after totp completion", rec.Result().Cookies())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	data, _ := body["data"].(map[string]any)
+	if data == nil || data["uid"] != "u1" || data["email"] != "a@b.test" {
+		t.Fatalf("body = %v, want data.{uid: u1, email: a@b.test}", body)
+	}
+	if !fin.Load() {
+		t.Fatal("finalize was not called after a successful TOTP check")
+	}
+}
+
+// TestCustomerLoginResolvesEmailFromZitadelNotRequestBody mirrors
+// TestTotpIgnoresAClientSuppliedLoginNameAndResolvesTheRealUser: the email in
+// the response must come from Client.UserEmail, never from the submitted
+// login_name — the same defect fixed on the merchant path in phase 2, and
+// worse here since login_name is the only per-request text this endpoint
+// takes from an anonymous caller.
+func TestCustomerLoginResolvesEmailFromZitadelNotRequestBody(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelCustomer(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+	h := NewCustomerHandler(c)
+
+	rec := httptest.NewRecorder()
+	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/customer/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"attacker-chosen@evil.test","password":"x"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	data, _ := body["data"].(map[string]any)
+	if data == nil {
+		t.Fatalf("body = %v, want data", body)
+	}
+	if data["email"] == "attacker-chosen@evil.test" {
+		t.Fatalf("data.email = %v — the submitted login_name reached the response instead of the Zitadel-resolved email", data["email"])
+	}
+	if data["email"] != "a@b.test" {
+		t.Fatalf("data.email = %v, want the email resolved from Zitadel (a@b.test)", data["email"])
+	}
+}
+
+func TestCustomerLoginRejectsMissingFields(t *testing.T) {
+	h := NewCustomerHandler(New("http://unused.invalid", "pat", nil))
+	rec := httptest.NewRecorder()
+	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/customer/login", strings.NewReader(`{}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestCustomerTotpRejectsMissingFields(t *testing.T) {
+	h := NewCustomerHandler(New("http://unused.invalid", "pat", nil))
+	rec := httptest.NewRecorder()
+	h.totp(rec, httptest.NewRequest(http.MethodPost, "/auth/customer/totp", strings.NewReader(`{}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestCustomerHandoffURLEmptyWithoutConfiguredBase(t *testing.T) {
+	h := NewCustomerHandler(New("http://unused.invalid", "pat", nil))
+	if got := h.handoffURL("V2_1"); got != "" {
+		t.Fatalf("handoffURL = %q, want empty when no base configured", got)
+	}
+}

--- a/services/auth-bff/internal/zitadellogin/customer_handler_test.go
+++ b/services/auth-bff/internal/zitadellogin/customer_handler_test.go
@@ -159,6 +159,40 @@ func TestCustomerLoginHandoffReturnsHostedLoginURL(t *testing.T) {
 	}
 }
 
+// TestCustomerLoginHandoffWithNoBaseConfiguredFailsLoudlyNotSilently pins the
+// fix for the gap where an unconfigured hosted login base URL produced a 200
+// with an empty handoff_url: a customer with an uncollectible factor (a
+// passkey, U2F, SMS OTP, recovery code, ...) and nowhere to go. That must
+// never come back as a silent empty string — it must be a distinguishable
+// error the storefront can render as "sign-in is unavailable".
+func TestCustomerLoginHandoffWithNoBaseConfiguredFailsLoudlyNotSilently(t *testing.T) {
+	var fin atomic.Bool
+	// Unrecognised factor type -> uncollectible -> OutcomeHandoff.
+	c := fakeZitadelCustomer(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_U2F"]`, factorsPasswordOnly, &fin)
+	h := NewCustomerHandler(c) // no WithHostedLoginBaseURL
+
+	rec := httptest.NewRecorder()
+	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/customer/login",
+		strings.NewReader(`{"login_name":"a@b.test","password":"x"}`)))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503, body = %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := body["handoff_url"]; ok {
+		t.Fatalf("body = %v, must not carry an empty handoff_url", body)
+	}
+	if body["error"] != "signin_unavailable" {
+		t.Fatalf("body = %v, want error: signin_unavailable", body)
+	}
+	if fin.Load() {
+		t.Fatal("finalize was called for OutcomeHandoff")
+	}
+}
+
 // TestCustomerTotpWrongCodeReturns401WithoutLeakingZitadelBody mirrors
 // TestTotpWrongCodeReturns401WithoutLeakingZitadelBody.
 func TestCustomerTotpWrongCodeReturns401WithoutLeakingZitadelBody(t *testing.T) {

--- a/services/auth-bff/internal/zitadellogin/handler.go
+++ b/services/auth-bff/internal/zitadellogin/handler.go
@@ -76,6 +76,11 @@ type Handler struct {
 	// auth_request_id, and logs a warning — the auth request itself is not
 	// lost, only the convenience redirect.
 	hostedLoginBaseURL string
+
+	// internalAuthSecret is the expected X-Internal-Auth value. See
+	// internal_auth.go: empty means unchecked, and the boot guard in
+	// config.ValidateZitadel is what stops that reaching production.
+	internalAuthSecret string
 }
 
 // NewHandler constructs a Handler. complete may be nil in tests that never
@@ -89,6 +94,14 @@ func NewHandler(c *Client, complete CompleteFunc) *Handler {
 // used elsewhere in this service (e.g. session.Handler.WithRegistry).
 func (h *Handler) WithHostedLoginBaseURL(baseURL string) *Handler {
 	h.hostedLoginBaseURL = strings.TrimSuffix(baseURL, "/")
+	return h
+}
+
+// WithInternalAuth requires every request to /auth/zitadel/{login,totp} to
+// present secret in the X-Internal-Auth header. Both callers are
+// server-side, so this costs them one header. See internal_auth.go.
+func (h *Handler) WithInternalAuth(secret string) *Handler {
+	h.internalAuthSecret = secret
 	return h
 }
 
@@ -191,6 +204,14 @@ type totpRequest struct {
 func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	// First, before the body is even read: an unauthenticated caller must
+	// never reach CreatePasswordSession, or this endpoint tells them
+	// whether a credential is valid.
+	if !internalAuthorized(r, h.internalAuthSecret) {
+		writeUnauthorized(w)
+		return
+	}
+
 	var req loginRequest
 	if err := decodeJSON(r, &req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
@@ -221,6 +242,12 @@ func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 // login, and re-asks sufficiency.go whether the session may now finalize.
 func (h *Handler) totp(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+
+	// See login: reject before any Zitadel call.
+	if !internalAuthorized(r, h.internalAuthSecret) {
+		writeUnauthorized(w)
+		return
+	}
 
 	var req totpRequest
 	if err := decodeJSON(r, &req); err != nil {

--- a/services/auth-bff/internal/zitadellogin/internal_auth.go
+++ b/services/auth-bff/internal/zitadellogin/internal_auth.go
@@ -1,0 +1,48 @@
+package zitadellogin
+
+import (
+	"net/http"
+
+	"github.com/mark8ly/auth-bff/internal/internalauth"
+)
+
+// Both /auth/zitadel/{login,totp} and /auth/customer/{login,totp} take a
+// {login_name, password} pair and answer whether it is valid. auth-bff is
+// publicly reachable (the mark8ly-wildcard VirtualService routes
+// auth.mark8ly.com on any path to it), the login-client PAT behind
+// CreatePasswordSession is instance-level rather than org-scoped, and
+// nothing in this service rate-limits. Left open, these four routes are a
+// credential-validity oracle over every user in the Zitadel instance,
+// merchant admins included.
+//
+// Every caller is server-side — apps/admin and apps/storefront reach them
+// from server actions, never from the browser — so the fix is the same
+// shared-secret scheme internal/session's /internal/users handler already
+// uses inbound and internal/audit + internal/notify already use outbound:
+// an X-Internal-Auth header compared in constant time
+// (internal/internalauth).
+//
+// An empty secret here means "unchecked", NOT "reject everything": the
+// guard is enforced at boot instead, where config.Config.ValidateZitadel
+// refuses to start a Zitadel-enabled auth-bff whose internal secret is
+// unset. A per-request 503 would let a misconfigured deploy come up and
+// only fail when someone tried to log in; panicking at boot means the
+// routes can never be mounted unauthenticated in the first place.
+
+// internalAuthorized reports whether the request presented the shared
+// internal secret. A handler configured with no secret (tests, and only
+// tests — see the boot guard above) accepts everything.
+func internalAuthorized(r *http.Request, secret string) bool {
+	if secret == "" {
+		return true
+	}
+	return internalauth.Equal(r.Header.Get(internalauth.Header), secret)
+}
+
+// writeUnauthorized emits the single response used for BOTH a missing and a
+// wrong header. They must stay indistinguishable: a caller that can tell
+// "no header" from "wrong header" apart learns whether a secret is
+// configured at all.
+func writeUnauthorized(w http.ResponseWriter) {
+	writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
+}

--- a/services/auth-bff/internal/zitadellogin/internal_auth_test.go
+++ b/services/auth-bff/internal/zitadellogin/internal_auth_test.go
@@ -1,0 +1,205 @@
+package zitadellogin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mark8ly/auth-bff/internal/internalauth"
+)
+
+const testInternalSecret = "s3cret-internal"
+
+// unreachableZitadel returns a Client whose every call fails the test. The
+// point of the header check is that an unauthenticated caller never causes a
+// credential check at all: if CreatePasswordSession (POST /v2/sessions) or
+// any other Zitadel call is reached, the endpoint still worked as an oracle
+// no matter what status it eventually returned.
+func unreachableZitadel(t *testing.T) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("Zitadel was called (%s %s) for a request that failed internal auth; "+
+			"the credential check must not happen for an unauthenticated caller", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "pat", srv.Client())
+}
+
+func postJSON(t *testing.T, path, body, secret string) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	if secret != "" {
+		r.Header.Set(internalauth.Header, secret)
+	}
+	return r
+}
+
+// endpoint names one of the four guarded routes so every case below runs
+// against all of them rather than only the two added by this branch: the
+// merchant routes are as publicly reachable as the customer ones.
+type endpoint struct {
+	name string
+	path string
+	body string
+	// call invokes the handler under test with the given secret configured.
+	call func(t *testing.T, c *Client, rec *httptest.ResponseRecorder, r *http.Request)
+}
+
+func guardedEndpoints() []endpoint {
+	merchantComplete := func(ctx context.Context, w http.ResponseWriter, lc LoginContext) (CompleteResult, error) {
+		return CompleteResult{}, nil
+	}
+	return []endpoint{
+		{
+			name: "zitadel/login",
+			path: "/auth/zitadel/login",
+			body: `{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`,
+			call: func(t *testing.T, c *Client, rec *httptest.ResponseRecorder, r *http.Request) {
+				NewHandler(c, merchantComplete).WithInternalAuth(testInternalSecret).login(rec, r)
+			},
+		},
+		{
+			name: "zitadel/totp",
+			path: "/auth/zitadel/totp",
+			body: `{"auth_request_id":"V2_1","login_name":"a@b.test","session_id":"s1","session_token":"tok-1","code":"123456","workspace_tenant":"t1"}`,
+			call: func(t *testing.T, c *Client, rec *httptest.ResponseRecorder, r *http.Request) {
+				NewHandler(c, merchantComplete).WithInternalAuth(testInternalSecret).totp(rec, r)
+			},
+		},
+		{
+			name: "customer/login",
+			path: "/auth/customer/login",
+			body: `{"login_name":"a@b.test","password":"x"}`,
+			call: func(t *testing.T, c *Client, rec *httptest.ResponseRecorder, r *http.Request) {
+				NewCustomerHandler(c).WithInternalAuth(testInternalSecret).login(rec, r)
+			},
+		},
+		{
+			name: "customer/totp",
+			path: "/auth/customer/totp",
+			body: `{"session_id":"s1","session_token":"tok-1","code":"123456"}`,
+			call: func(t *testing.T, c *Client, rec *httptest.ResponseRecorder, r *http.Request) {
+				NewCustomerHandler(c).WithInternalAuth(testInternalSecret).totp(rec, r)
+			},
+		},
+	}
+}
+
+// TestGuardedEndpointsRejectMissingAndWrongSecretIdentically is the core of
+// the fix: all four credential endpoints answer the same 401 with the same
+// body whether the header is absent or wrong, and neither case reaches
+// Zitadel.
+func TestGuardedEndpointsRejectMissingAndWrongSecretIdentically(t *testing.T) {
+	for _, ep := range guardedEndpoints() {
+		t.Run(ep.name, func(t *testing.T) {
+			c := unreachableZitadel(t)
+
+			missingRec := httptest.NewRecorder()
+			ep.call(t, c, missingRec, postJSON(t, ep.path, ep.body, ""))
+
+			wrongRec := httptest.NewRecorder()
+			ep.call(t, c, wrongRec, postJSON(t, ep.path, ep.body, "not-the-secret"))
+
+			if missingRec.Code != http.StatusUnauthorized {
+				t.Errorf("missing header: status = %d, want 401 (body %s)", missingRec.Code, missingRec.Body.String())
+			}
+			if wrongRec.Code != http.StatusUnauthorized {
+				t.Errorf("wrong header: status = %d, want 401 (body %s)", wrongRec.Code, wrongRec.Body.String())
+			}
+			if missingRec.Code != wrongRec.Code || missingRec.Body.String() != wrongRec.Body.String() {
+				t.Errorf("missing (%d %s) and wrong (%d %s) headers must be indistinguishable",
+					missingRec.Code, missingRec.Body.String(), wrongRec.Code, wrongRec.Body.String())
+			}
+			if got := strings.TrimSpace(missingRec.Body.String()); got != `{"error":"unauthorized"}` {
+				t.Errorf("body = %s, want {\"error\":\"unauthorized\"}", got)
+			}
+		})
+	}
+}
+
+// TestGuardedEndpointsRejectBeforeReadingTheBody pins that the guard runs
+// ahead of request decoding too: a caller with no secret must not be able to
+// tell a malformed body from a well-formed one.
+func TestGuardedEndpointsRejectBeforeReadingTheBody(t *testing.T) {
+	for _, ep := range guardedEndpoints() {
+		t.Run(ep.name, func(t *testing.T) {
+			c := unreachableZitadel(t)
+			rec := httptest.NewRecorder()
+			ep.call(t, c, rec, postJSON(t, ep.path, `not json at all`, ""))
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401 — auth must be decided before the body is parsed", rec.Code)
+			}
+		})
+	}
+}
+
+// TestGuardedEndpointsAcceptTheCorrectSecret proves the guard does not
+// simply close the routes: with the right header they reach Zitadel and
+// behave exactly as before.
+func TestGuardedEndpointsAcceptTheCorrectSecret(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelHandler(t, policyNoMFA,
+		`["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+
+	for _, ep := range guardedEndpoints() {
+		t.Run(ep.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			ep.call(t, c, rec, postJSON(t, ep.path, ep.body, testInternalSecret))
+			// The assertion is deliberately "not the guard's answer"
+			// rather than a specific status: what each endpoint returns
+			// past the guard depends on the Zitadel fixture (this one has
+			// no hosted-login base URL, so a handoff outcome legitimately
+			// answers 503) and is already pinned by handler_test.go and
+			// customer_handler_test.go.
+			if rec.Code == http.StatusUnauthorized {
+				t.Fatalf("status = 401 with the correct header; body = %s", rec.Body.String())
+			}
+			if strings.Contains(rec.Body.String(), `"unauthorized"`) {
+				t.Fatalf("body = %s, want anything but the guard's rejection", rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestHandlersWithoutAConfiguredSecretStayOpen documents the deliberate
+// shape of the check: an unset secret means "unchecked", because the guard
+// that must never be bypassed lives at boot (config.ValidateZitadel), not
+// here. Without this, every pre-existing handler test would have to be
+// rewritten to carry a header.
+func TestHandlersWithoutAConfiguredSecretStayOpen(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelHandler(t, policyNoMFA,
+		`["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+
+	rec := httptest.NewRecorder()
+	NewCustomerHandler(c).login(rec, postJSON(t, "/auth/customer/login", `{"login_name":"a@b.test","password":"x"}`, ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestInternalAuthorizedIsExactAndRejectsEmptyPresentedSecret(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+		want   bool
+	}{
+		{"exact", testInternalSecret, true},
+		{"empty", "", false},
+		{"prefix", testInternalSecret[:5], false},
+		{"suffix-extended", testInternalSecret + "x", false},
+		{"case-changed", strings.ToUpper(testInternalSecret), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := postJSON(t, "/auth/customer/login", `{}`, tc.header)
+			if got := internalAuthorized(r, testInternalSecret); got != tc.want {
+				t.Fatalf("internalAuthorized = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/services/auth-bff/internal/zitadellogin/sufficiency.go
+++ b/services/auth-bff/internal/zitadellogin/sufficiency.go
@@ -95,13 +95,22 @@ func mfaRequired(p LoginPolicy, federated bool) bool {
 	return p.ForceMFALocalOnly && !federated
 }
 
-// CompleteIfSufficient decides whether a freshly created session may finalize.
+// DecideSufficiency runs the same evaluation CompleteIfSufficient does —
+// SessionFactors, classifyEnrolledMethods, LoginPolicyForOrg, mfaRequired —
+// and stops there: it never calls finalize and never constructs the
+// sufficient{} witness, so it cannot obtain an OIDC authorization code.
+//
+// This is what the storefront customer path calls (see customer_handler.go
+// and spec D11): a sufficiency decision and, on OutcomeComplete, an identity
+// — never a callback URL. CompleteIfSufficient below is this function plus
+// finalize, and is the only thing that changed to make that split: the
+// decision logic itself is not duplicated anywhere.
 //
 // Zitadel does NOT enforce forceMfa for a login client: it issues an
 // authorization code for a password-only session and signals nothing. Every
 // uncertain input therefore fails closed to OutcomeHandoff, which is a
 // legitimate outcome rather than an error.
-func (c *Client) CompleteIfSufficient(ctx context.Context, authRequestID string, s Session, federated bool) (Result, error) {
+func (c *Client) DecideSufficiency(ctx context.Context, s Session, federated bool) (Result, error) {
 	factors, err := c.SessionFactors(ctx, s.ID)
 	if err != nil || factors.UserID == "" || factors.OrgID == "" {
 		slog.WarnContext(ctx, "zitadel sufficiency: cannot read session subject, handing off", "err", err)
@@ -126,6 +135,17 @@ func (c *Client) CompleteIfSufficient(ctx context.Context, authRequestID string,
 		}
 		return Result{Outcome: OutcomeFactorRequired, Factors: []string{methodTOTP}}, nil
 	}
+	return Result{Outcome: OutcomeComplete}, nil
+}
+
+// CompleteIfSufficient decides whether a freshly created session may finalize,
+// and finalizes it when it may. It is DecideSufficiency plus the finalize
+// call — the merchant path's behavior is unchanged by this split.
+func (c *Client) CompleteIfSufficient(ctx context.Context, authRequestID string, s Session, federated bool) (Result, error) {
+	res, err := c.DecideSufficiency(ctx, s, federated)
+	if err != nil || res.Outcome != OutcomeComplete {
+		return res, err
+	}
 	cb, err := c.finalize(ctx, authRequestID, s, sufficient{})
 	if err != nil {
 		return Result{Outcome: OutcomeHandoff}, err
@@ -133,12 +153,16 @@ func (c *Client) CompleteIfSufficient(ctx context.Context, authRequestID string,
 	return Result{Outcome: OutcomeComplete, CallbackURL: cb}, nil
 }
 
-// CompleteAfterFactor finalizes after a TOTP check.
+// DecideAfterFactor is CompleteAfterFactor's decision half: it re-reads the
+// session's factors after a TOTP check and reports whether TOTP is now
+// confirmed, without finalizing. Used by the storefront customer path's
+// /customer/totp step for the same reason DecideSufficiency exists — see its
+// doc comment.
 //
 // It re-reads the factors from Zitadel rather than trusting that VerifyTOTP
 // returned without error, because the caller may be holding a stale session
 // value from before the token rotated.
-func (c *Client) CompleteAfterFactor(ctx context.Context, authRequestID string, s Session) (Result, error) {
+func (c *Client) DecideAfterFactor(ctx context.Context, s Session) (Result, error) {
 	factors, err := c.SessionFactors(ctx, s.ID)
 	if err != nil {
 		slog.WarnContext(ctx, "zitadel sufficiency: cannot re-read factors after TOTP, handing off", "err", err)
@@ -146,6 +170,17 @@ func (c *Client) CompleteAfterFactor(ctx context.Context, authRequestID string, 
 	}
 	if !factors.TOTP {
 		return Result{Outcome: OutcomeHandoff}, nil
+	}
+	return Result{Outcome: OutcomeComplete}, nil
+}
+
+// CompleteAfterFactor finalizes after a TOTP check. It is DecideAfterFactor
+// plus the finalize call — the merchant path's behavior is unchanged by this
+// split.
+func (c *Client) CompleteAfterFactor(ctx context.Context, authRequestID string, s Session) (Result, error) {
+	res, err := c.DecideAfterFactor(ctx, s)
+	if err != nil || res.Outcome != OutcomeComplete {
+		return res, err
 	}
 	cb, err := c.finalize(ctx, authRequestID, s, sufficient{})
 	if err != nil {

--- a/services/auth-bff/internal/zitadellogin/sufficiency_test.go
+++ b/services/auth-bff/internal/zitadellogin/sufficiency_test.go
@@ -170,3 +170,108 @@ func TestCompleteAfterFactorCompletesWhenTOTPIsConfirmed(t *testing.T) {
 		t.Fatalf("result = %+v finalized=%v", res, fin.Load())
 	}
 }
+
+// --- DecideSufficiency / DecideAfterFactor: the customer path's decision-only
+// functions must never finalize, no matter what the input is. ---
+
+// fakeZitadelNoFinalize serves the same fixtures as fakeZitadel but fails the
+// test outright if the finalize endpoint is ever hit — the strongest
+// assertion available that a code path never obtains an OIDC authorization
+// code, stronger than merely checking a bool afterward.
+func fakeZitadelNoFinalize(t *testing.T, policyJSON, methodsJSON, factorsJSON string) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/management/v1/policies/login":
+			w.Write([]byte(policyJSON))
+		case strings.HasSuffix(r.URL.Path, "/authentication_methods"):
+			w.Write([]byte(`{"authMethodTypes":` + methodsJSON + `}`))
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v2/oidc/auth_requests/"):
+			t.Fatalf("finalize endpoint was called: %s %s — a decision-only function must never finalize", r.Method, r.URL.Path)
+		case strings.HasPrefix(r.URL.Path, "/v2/sessions/"):
+			w.Write([]byte(factorsJSON))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "pat", srv.Client())
+}
+
+func TestDecideSufficiencyCompletesWithoutFinalizingOrACallbackURL(t *testing.T) {
+	c := fakeZitadelNoFinalize(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly)
+	res, err := c.DecideSufficiency(context.Background(), Session{ID: "s1", Token: "t"}, false)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeComplete {
+		t.Fatalf("outcome = %v, want OutcomeComplete", res.Outcome)
+	}
+	if res.CallbackURL != "" {
+		t.Fatalf("CallbackURL = %q, want empty — a decision-only function must never carry one", res.CallbackURL)
+	}
+}
+
+func TestDecideSufficiencyStillRequiresMfaWhenForced(t *testing.T) {
+	// The MFA guarantee must survive the split: a password-only session
+	// under forceMfa must still land on OutcomeFactorRequired, never
+	// OutcomeComplete, from the decision-only function too.
+	c := fakeZitadelNoFinalize(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsPasswordOnly)
+	res, err := c.DecideSufficiency(context.Background(), Session{ID: "s1", Token: "t"}, false)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeFactorRequired {
+		t.Fatalf("outcome = %v, want OutcomeFactorRequired", res.Outcome)
+	}
+}
+
+func TestDecideSufficiencyFailsClosedOnEveryUncertainInput(t *testing.T) {
+	cases := []struct {
+		name        string
+		policyJSON  string
+		methodsJSON string
+		factorsJSON string
+	}{
+		{"unreadable policy", `{"policy":{"nonsense":true}}`, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly},
+		{"uncollectible factor", policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_PASSKEY"]`, factorsPasswordOnly},
+		{"unreadable session subject", policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, `{"session":{"factors":{}}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fakeZitadelNoFinalize(t, tc.policyJSON, tc.methodsJSON, tc.factorsJSON)
+			res, err := c.DecideSufficiency(context.Background(), Session{ID: "s1", Token: "t"}, false)
+			if err != nil {
+				t.Fatalf("err = %v (a handoff is an outcome, not an error)", err)
+			}
+			if res.Outcome != OutcomeHandoff {
+				t.Fatalf("outcome = %v, want OutcomeHandoff", res.Outcome)
+			}
+		})
+	}
+}
+
+func TestDecideAfterFactorCompletesWithoutFinalizingOrACallbackURL(t *testing.T) {
+	c := fakeZitadelNoFinalize(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsWithTOTP)
+	res, err := c.DecideAfterFactor(context.Background(), Session{ID: "s1", Token: "t"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeComplete {
+		t.Fatalf("outcome = %v, want OutcomeComplete", res.Outcome)
+	}
+	if res.CallbackURL != "" {
+		t.Fatalf("CallbackURL = %q, want empty — a decision-only function must never carry one", res.CallbackURL)
+	}
+}
+
+func TestDecideAfterFactorFailsClosedWhenTOTPIsNotConfirmed(t *testing.T) {
+	c := fakeZitadelNoFinalize(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsPasswordOnly)
+	res, err := c.DecideAfterFactor(context.Background(), Session{ID: "s1", Token: "t"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeHandoff {
+		t.Fatalf("outcome = %v, want OutcomeHandoff", res.Outcome)
+	}
+}

--- a/services/auth-bff/pkg/config/config.go
+++ b/services/auth-bff/pkg/config/config.go
@@ -2,6 +2,10 @@
 package config
 
 import (
+	"errors"
+	"fmt"
+	"strings"
+
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
 )
@@ -84,4 +88,43 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+// ErrZitadelNotConfigured is returned by ValidateZitadel when ZITADEL_ENABLED
+// is set but a value the Zitadel login path cannot run safely without is
+// missing. Wrapped errors carry the NAME of the missing variable only —
+// never its value.
+var ErrZitadelNotConfigured = errors.New("zitadel: enabled but not configured")
+
+// ValidateZitadel reports whether the Zitadel login path may be mounted.
+//
+// It returns nil when Zitadel is disabled: nothing is mounted, so nothing
+// needs configuring. When it is enabled, every field below is mandatory and
+// a missing one is a boot failure, not a request-time one.
+//
+// MarketplaceInternalAuthSecret is in that list because /auth/zitadel/login
+// and /auth/customer/login answer whether a {login_name, password} pair is
+// valid, auth-bff is publicly reachable, and the login-client PAT behind
+// them is instance-level. Without the shared secret those routes are an
+// unauthenticated credential oracle over every user in the instance. A
+// silently-unauthenticated auth endpoint is exactly what the header check
+// exists to prevent, so refusing to boot is the only safe answer.
+func (c *Config) ValidateZitadel() error {
+	if !c.ZitadelEnabled {
+		return nil
+	}
+	var missing []string
+	if c.ZitadelIssuer == "" {
+		missing = append(missing, "ZITADEL_ISSUER")
+	}
+	if c.ZitadelLoginClientToken == "" {
+		missing = append(missing, "ZITADEL_LOGIN_CLIENT_TOKEN")
+	}
+	if c.MarketplaceInternalAuthSecret == "" {
+		missing = append(missing, "MARKETPLACE_INTERNAL_AUTH_SECRET")
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%w: missing %s", ErrZitadelNotConfigured, strings.Join(missing, ", "))
 }

--- a/services/auth-bff/pkg/config/validate_zitadel_test.go
+++ b/services/auth-bff/pkg/config/validate_zitadel_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func zitadelReadyConfig() Config {
+	return Config{
+		ZitadelEnabled:                true,
+		ZitadelIssuer:                 "https://login.mark8ly.zitadel.cloud",
+		ZitadelLoginClientToken:       "pat",
+		MarketplaceInternalAuthSecret: "s3cret-internal",
+	}
+}
+
+// TestValidateZitadelRefusesWithoutTheInternalSecret is the boot guard for
+// the credential-oracle fix: /auth/zitadel/login and /auth/customer/login
+// answer whether a {login_name, password} pair is valid, auth-bff is
+// publicly reachable, and the header check that gates them is a no-op when
+// the secret is empty. Booting in that state would publish exactly the
+// endpoint the header exists to prevent.
+func TestValidateZitadelRefusesWithoutTheInternalSecret(t *testing.T) {
+	cfg := zitadelReadyConfig()
+	cfg.MarketplaceInternalAuthSecret = ""
+
+	err := cfg.ValidateZitadel()
+	if err == nil {
+		t.Fatal("ValidateZitadel = nil; a Zitadel-enabled auth-bff with no internal secret must refuse to start")
+	}
+	if !errors.Is(err, ErrZitadelNotConfigured) {
+		t.Fatalf("err = %v, want it to wrap ErrZitadelNotConfigured", err)
+	}
+	if !strings.Contains(err.Error(), "MARKETPLACE_INTERNAL_AUTH_SECRET") {
+		t.Fatalf("err = %v, want it to name the missing variable", err)
+	}
+}
+
+func TestValidateZitadelRefusesOnEachMissingValue(t *testing.T) {
+	cases := []struct {
+		name string
+		mut  func(*Config)
+		want string
+	}{
+		{"issuer", func(c *Config) { c.ZitadelIssuer = "" }, "ZITADEL_ISSUER"},
+		{"login client token", func(c *Config) { c.ZitadelLoginClientToken = "" }, "ZITADEL_LOGIN_CLIENT_TOKEN"},
+		{"internal secret", func(c *Config) { c.MarketplaceInternalAuthSecret = "" }, "MARKETPLACE_INTERNAL_AUTH_SECRET"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := zitadelReadyConfig()
+			tc.mut(&cfg)
+			err := cfg.ValidateZitadel()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want an error naming %s", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidateZitadelNeverEchoesASecretValue: the error is logged and
+// panicked on at boot, so it must name variables, never their contents.
+func TestValidateZitadelNeverEchoesASecretValue(t *testing.T) {
+	cfg := zitadelReadyConfig()
+	cfg.ZitadelIssuer = ""
+	err := cfg.ValidateZitadel()
+	if err == nil {
+		t.Fatal("want an error")
+	}
+	for _, secret := range []string{cfg.ZitadelLoginClientToken, cfg.MarketplaceInternalAuthSecret} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("err = %v leaks a configured secret value", err)
+		}
+	}
+}
+
+func TestValidateZitadelPassesWhenFullyConfigured(t *testing.T) {
+	cfg := zitadelReadyConfig()
+	if err := cfg.ValidateZitadel(); err != nil {
+		t.Fatalf("ValidateZitadel = %v, want nil", err)
+	}
+}
+
+// TestValidateZitadelIgnoresEverythingWhenDisabled pins that this change
+// does not touch the GIP path: with ZITADEL_ENABLED unset (production
+// today), no Zitadel route is mounted and nothing new is required to boot.
+func TestValidateZitadelIgnoresEverythingWhenDisabled(t *testing.T) {
+	cfg := Config{ZitadelEnabled: false}
+	if err := cfg.ValidateZitadel(); err != nil {
+		t.Fatalf("ValidateZitadel = %v, want nil when Zitadel is disabled", err)
+	}
+}


### PR DESCRIPTION
Phase 3b of #524: the **storefront customer** login path to Zitadel. Behind `NEXT_PUBLIC_AUTH_PROVIDER=zitadel`; with the flag unset every byte of the GIP path is unchanged.

## The customer path is deliberately not the merchant path

Merchant login runs a gauntlet: OpenFGA tenant-membership check, `projectRoleCheck`, deviceguard, session minting. Shoppers have none of that — no tenant, no FGA tuples, no roles. Running them through it would fail every time.

So `/auth/customer/login` **verifies and returns an identity, and mints nothing.** It never calls `finalize`, never issues an authorization code, never needs an `auth_request_id` (which would require an OIDC round trip the storefront doesn't have). The storefront mints its own cookie, scoped to the exact host so store-a's session can't be replayed at store-b.

## Security fix included

The final whole-branch review found that both `/auth/customer/login` (this branch) **and `/auth/zitadel/login` (merged in phase 2)** were unauthenticated credential-validity oracles. Verified against the live cluster: `mark8ly-wildcard` routes `authority: auth.mark8ly.com` on *any* path to auth-bff via Cloudflare → Istio. `CreatePasswordSession` is not org-scoped and the PAT is instance-level, so this was an oracle over every user in the instance, merchant admins included. Not exploitable today only because both mount solely under `ZITADEL_ENABLED`, which production does not set.

Fixed by reusing the service's **existing** internal-caller scheme rather than inventing one — `X-Internal-Auth` + `MARKETPLACE_INTERNAL_AUTH_SECRET`, SHA-256 then `subtle.ConstantTimeCompare`, extracted into `internal/internalauth` so `session` and `zitadellogin` share one copy. The guard is the first statement of all four handlers, before the body is read. Missing and wrong secrets get byte-identical 401s.

**No k8s change is needed:** all three deployments already carry that secret — auth-bff validates with it, admin and storefront send it. That is what reusing the existing pattern bought.

A boot guard (`ValidateZitadel`) makes the secret mandatory when `ZITADEL_ENABLED`, and returns `nil` immediately when it isn't — so today's GIP-only boot cannot crashloop.

## Testing

auth-bff 16 packages green; storefront 119 tests (was 116); admin 1036 tests. No pre-existing test was edited — both apps' Zitadel test files went 14 → 17 `it()` blocks, purely additive.

The guard test uses an `unreachableZitadel` fixture that **fails the test if Zitadel is contacted at all**, so it proves the request never gets that far rather than merely asserting a 401. The seam test was mutation-tested: flipping the provider ternary fails both Zitadel tests.

## Known, deferred

- `/auth/zitadel/login` still never validates `auth_request_id` — closed to the public now, still worth fixing.
- No rate limiting anywhere in auth-bff; `CreatePasswordSession` remains instance-wide, not org-scoped.
- The Google button is still shown on the storefront under the Zitadel flag (phase 3c).

Closes nothing on its own — #524 continues at phase 3c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xQ7gJoonbQZmnnbfPD5RE
