### PR TITLE
feat(breakglass): rotate/disable/enable/clear-lockout write operations (#404)

### DIFF
--- a/services/marketplace-api/internal/breakglass/models.go
+++ b/services/marketplace-api/internal/breakglass/models.go
@@ -23,6 +23,12 @@ import (
 //     `secret_path`. Neither ever hits this row.
 //   - `rotation_scheduled_at` is set to now()+24h on every successful
 //     login; cleared when the rotator runs.
+//   - `disabled_at` is set only by an explicit operator action (POST
+//     .../disable, #404), never as a side effect of rotation —
+//     ReplaceAfterRotation (rotation.go) does not touch it. The login
+//     handler refuses a disabled account with a response
+//     byte-identical to a wrong-password failure; `disabled_reason` is
+//     for the audit log only and must never reach the HTTP response.
 type Account struct {
 	TenantID            uuid.UUID  `gorm:"column:tenant_id;type:uuid;primaryKey"`
 	SecretPath          string     `gorm:"column:secret_path;not null"`
@@ -32,6 +38,8 @@ type Account struct {
 	LastRotatedAt       time.Time  `gorm:"column:last_rotated_at;not null;default:now()"`
 	LastUsedAt          *time.Time `gorm:"column:last_used_at"`
 	RotationScheduledAt *time.Time `gorm:"column:rotation_scheduled_at"`
+	DisabledAt          *time.Time `gorm:"column:disabled_at"`
+	DisabledReason      *string    `gorm:"column:disabled_reason"`
 	CreatedAt           time.Time  `gorm:"column:created_at;not null;autoCreateTime"`
 	UpdatedAt           time.Time  `gorm:"column:updated_at;not null;autoUpdateTime"`
 }

--- a/services/marketplace-api/internal/breakglass/repository.go
+++ b/services/marketplace-api/internal/breakglass/repository.go
@@ -108,6 +108,77 @@ func (r *Repository) ReplaceAfterRotation(ctx context.Context, tenantID uuid.UUI
 	return nil
 }
 
+// Disable marks tenantID's account disabled with reason (#404). The login
+// handler refuses a disabled account before ever reaching Secret Manager
+// (see break_glass_login.go step 3.5), by reading DisabledAt off the SAME
+// row GetByTenant already fetches — no new query is added to that path.
+// Returns ErrNotFound when the tenant has no account.
+func (r *Repository) Disable(ctx context.Context, tenantID uuid.UUID, reason string) error {
+	now := time.Now().UTC()
+	res := r.ctx(ctx).
+		Model(&Account{}).
+		Where("tenant_id = ?", tenantID).
+		Updates(map[string]any{
+			"disabled_at":     &now,
+			"disabled_reason": reason,
+			"updated_at":      now,
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// Enable clears BOTH disabled_at and disabled_reason, restoring login.
+// A partial clear would leave stale forensic text on an otherwise clean,
+// re-enabled account. Returns ErrNotFound when the tenant has no account.
+//
+// Enable is the ONLY thing that clears disabled_at — rotation
+// (ReplaceAfterRotation, rotation.go) deliberately never touches it, so an
+// operator rotating credentials for an unrelated reason cannot silently
+// re-enable an account someone disabled on purpose.
+func (r *Repository) Enable(ctx context.Context, tenantID uuid.UUID) error {
+	res := r.ctx(ctx).
+		Model(&Account{}).
+		Where("tenant_id = ?", tenantID).
+		Updates(map[string]any{
+			"disabled_at":     nil,
+			"disabled_reason": nil,
+			"updated_at":      time.Now().UTC(),
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ClearIPLock deletes ACTIVE lockout rows (locked_until > now()) for
+// ipHash, returning how many were removed. An expired row is left alone —
+// it is already inert and harmless as forensic history, and deleting it
+// would not change anything IsIPLocked observes.
+//
+// ipHash MUST be computed with the same HMAC key the login path uses
+// (breakglass.HMACIPHash) — a mismatched key hashes to different bytes,
+// so this deletes zero rows while still reporting success.
+func (r *Repository) ClearIPLock(ctx context.Context, ipHash []byte) (int64, error) {
+	if len(ipHash) == 0 {
+		return 0, ErrInvalidCredentials
+	}
+	res := r.ctx(ctx).
+		Where("ip_hash = ? AND locked_until > ?", ipHash, time.Now().UTC()).
+		Delete(&Lockout{})
+	if res.Error != nil {
+		return 0, res.Error
+	}
+	return res.RowsAffected, nil
+}
+
 // FindDueForRotation returns every account that needs a new password
 // right now: either the post-use rotation clock has elapsed, or the
 // 90-day cadence has lapsed.

--- a/services/marketplace-api/internal/breakglass/repository_integration_test.go
+++ b/services/marketplace-api/internal/breakglass/repository_integration_test.go
@@ -1,0 +1,122 @@
+//go:build integration
+
+package breakglass_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// seedRepoAccount is a thin wrapper around seedAccount (defined in
+// platform_list_integration_test.go, same package) so this file reads
+// standalone.
+func seedRepoAccount(t *testing.T, db *gorm.DB, tenantID uuid.UUID) {
+	t.Helper()
+	seedAccount(t, db, tenantID, nil)
+}
+
+// #404: Disable must set both disabled_at and disabled_reason, and Enable
+// must clear BOTH — a partial clear (e.g. leaving disabled_reason behind)
+// would leave stale forensic text sitting on a re-enabled, otherwise-clean
+// account.
+func TestIntegration_Repository_DisableThenEnable_RoundTrips(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := breakglass.NewRepository(db)
+	tenantID := uuid.New()
+	seedRepoAccount(t, db, tenantID)
+
+	require.NoError(t, repo.Disable(context.Background(), tenantID, "compromised laptop"))
+
+	acc, err := repo.GetByTenant(context.Background(), tenantID)
+	require.NoError(t, err)
+	require.NotNil(t, acc.DisabledAt, "Disable must set disabled_at")
+	require.WithinDuration(t, time.Now().UTC(), *acc.DisabledAt, 5*time.Second)
+	require.NotNil(t, acc.DisabledReason)
+	require.Equal(t, "compromised laptop", *acc.DisabledReason)
+
+	require.NoError(t, repo.Enable(context.Background(), tenantID))
+
+	acc, err = repo.GetByTenant(context.Background(), tenantID)
+	require.NoError(t, err)
+	require.Nil(t, acc.DisabledAt, "Enable must clear disabled_at")
+	require.Nil(t, acc.DisabledReason, "Enable must clear disabled_reason too, not just disabled_at")
+}
+
+func TestIntegration_Repository_Disable_UnknownTenantReturnsErrNotFound(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := breakglass.NewRepository(db)
+
+	err := repo.Disable(context.Background(), uuid.New(), "reason")
+	require.ErrorIs(t, err, breakglass.ErrNotFound)
+}
+
+func TestIntegration_Repository_Enable_UnknownTenantReturnsErrNotFound(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := breakglass.NewRepository(db)
+
+	err := repo.Enable(context.Background(), uuid.New())
+	require.ErrorIs(t, err, breakglass.ErrNotFound)
+}
+
+// ClearIPLock must remove only ACTIVE rows (locked_until > now()) for the
+// given ip_hash — an expired row is already inert, and a row for a
+// DIFFERENT ip_hash must survive untouched.
+func TestIntegration_Repository_ClearIPLock_RemovesOnlyActiveRowsForThatHash(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := breakglass.NewRepository(db)
+	now := time.Now().UTC()
+
+	targetHash := breakglass.HMACIPHash([]byte("test-key"), "203.0.113.5")
+	otherHash := breakglass.HMACIPHash([]byte("test-key"), "203.0.113.9")
+
+	// Active lockout for the target hash — must be removed.
+	require.NoError(t, db.Table("break_glass_lockouts").Create(map[string]interface{}{
+		"ip_hash":      targetHash,
+		"tenant_id":    nil,
+		"locked_until": now.Add(1 * time.Hour),
+		"reason":       "3-strike",
+	}).Error)
+	// Expired lockout for the SAME hash — must survive (already inert).
+	require.NoError(t, db.Table("break_glass_lockouts").Create(map[string]interface{}{
+		"ip_hash":      targetHash,
+		"tenant_id":    nil,
+		"locked_until": now.Add(-1 * time.Hour),
+		"reason":       "3-strike",
+	}).Error)
+	// Active lockout for a DIFFERENT hash — must survive.
+	require.NoError(t, db.Table("break_glass_lockouts").Create(map[string]interface{}{
+		"ip_hash":      otherHash,
+		"tenant_id":    nil,
+		"locked_until": now.Add(1 * time.Hour),
+		"reason":       "3-strike",
+	}).Error)
+
+	removed, err := repo.ClearIPLock(context.Background(), targetHash)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, removed, "only the one ACTIVE row for targetHash must be removed")
+
+	locked, err := repo.IsIPLocked(context.Background(), targetHash)
+	require.NoError(t, err)
+	require.False(t, locked, "targetHash must no longer be locked after ClearIPLock")
+
+	stillLocked, err := repo.IsIPLocked(context.Background(), otherHash)
+	require.NoError(t, err)
+	require.True(t, stillLocked, "a different ip_hash's active lockout must not be touched")
+}
+
+func TestIntegration_Repository_ClearIPLock_NoActiveRowsRemovesNothing(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := breakglass.NewRepository(db)
+
+	removed, err := repo.ClearIPLock(context.Background(), breakglass.HMACIPHash([]byte("k"), "198.51.100.1"))
+	require.NoError(t, err)
+	require.EqualValues(t, 0, removed)
+}

--- a/services/marketplace-api/internal/breakglass/rotation_integration_test.go
+++ b/services/marketplace-api/internal/breakglass/rotation_integration_test.go
@@ -1,0 +1,49 @@
+//go:build integration
+
+package breakglass_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// #404: rotating a disabled account's credentials must NOT clear
+// disabled_at. Re-enabling is only ever an explicit, audited act (the
+// enable endpoint) — otherwise an operator rotating for an unrelated
+// reason (e.g. the 90-day cron, or a routine credential refresh) would
+// silently undo someone else's deliberate security decision.
+func TestIntegration_RotateOne_DoesNotReEnableADisabledAccount(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := breakglass.NewRepository(db)
+	secrets := breakglass.NewSecretManager(breakglass.NewFakeSecretClient())
+	rotator := breakglass.NewRotator(repo, secrets, nil, nil)
+
+	tenantID := uuid.New()
+	boot := breakglass.NewBootstrapper(repo, secrets, "test-project")
+	require.NoError(t, boot.Provision(context.Background(), tenantID))
+
+	require.NoError(t, repo.Disable(context.Background(), tenantID, "suspected compromise"))
+
+	before, err := repo.GetByTenant(context.Background(), tenantID)
+	require.NoError(t, err)
+	beforeHash := before.PasswordHash
+
+	require.NoError(t, rotator.RotateOne(context.Background(), tenantID))
+
+	after, err := repo.GetByTenant(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	require.NotNil(t, after.DisabledAt,
+		"RotateOne must NOT clear disabled_at — rotating credentials is not the same act as re-enabling")
+	require.NotNil(t, after.DisabledReason)
+	require.Equal(t, "suspected compromise", *after.DisabledReason,
+		"the disable reason must survive a rotation untouched")
+	require.NotEqual(t, beforeHash, after.PasswordHash,
+		"rotation must still have actually happened — a disabled account is still rotated, just not re-enabled")
+}

--- a/services/marketplace-api/internal/handlers/admin/break_glass_login.go
+++ b/services/marketplace-api/internal/handlers/admin/break_glass_login.go
@@ -119,6 +119,19 @@ func (h *BreakGlassLoginHandler) Login(c *gin.Context) {
 		return
 	}
 
+	// 3.5. Refuse a disabled account with a response BYTE-IDENTICAL to a
+	// wrong-password failure (#404). No new dependency on this path:
+	// DisabledAt is a field on `acc`, the row step 3 already fetched — see
+	// the package constraint that nothing added here may introduce a new
+	// query or service call. Sits BEFORE the Secret Manager fetch (step 4)
+	// so a disabled account is refused even when Secret Manager is
+	// unreachable.
+	if acc.DisabledAt != nil {
+		h.recordFailure(c, ipHash, tenantID, "account_disabled")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_credentials"})
+		return
+	}
+
 	// 4. Fetch blob from Secret Manager. Fetch failure is a 500 (ops
 	// needs to see it, not a security event).
 	blob, err := h.deps.Secrets.Fetch(ctx, acc.SecretPath)

--- a/services/marketplace-api/internal/handlers/admin/break_glass_login_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/break_glass_login_integration_test.go
@@ -1,0 +1,180 @@
+//go:build integration
+
+package admin_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/authbffclient"
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+	"github.com/mark8ly/marketplace-api/internal/handlers/admin"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// alwaysFailSecretClient simulates Secret Manager being completely
+// unreachable — every call returns an error, regardless of path.
+type alwaysFailSecretClient struct{}
+
+func (alwaysFailSecretClient) AddVersion(context.Context, string, []byte) error {
+	return errors.New("secret manager unreachable")
+}
+
+func (alwaysFailSecretClient) AccessLatest(context.Context, string) ([]byte, error) {
+	return nil, errors.New("secret manager unreachable")
+}
+
+// provisionAccount seeds a real break-glass account (via the same
+// Bootstrapper production uses) and returns its plaintext password and
+// TOTP secret so a test can build a genuine login request.
+func provisionAccount(t *testing.T, repo *breakglass.Repository, secrets *breakglass.SecretManager, tenantID uuid.UUID) (password, totpSecret string) {
+	t.Helper()
+	boot := breakglass.NewBootstrapper(repo, secrets, "test-project")
+	require.NoError(t, boot.Provision(context.Background(), tenantID))
+
+	acc, err := repo.GetByTenant(context.Background(), tenantID)
+	require.NoError(t, err)
+	blob, err := secrets.Fetch(context.Background(), acc.SecretPath)
+	require.NoError(t, err)
+	return blob.Password, blob.TOTPSecret
+}
+
+func newLoginRouter(deps admin.BreakGlassDeps) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h := admin.NewBreakGlassLoginHandler(deps)
+	r.POST("/admin/break-glass/login", h.Login)
+	return r
+}
+
+func doLogin(t *testing.T, r *gin.Engine, tenantID uuid.UUID, password, totpCode string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{
+		"tenant_id": tenantID.String(),
+		"password":  password,
+		"totp_code": totpCode,
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/admin/break-glass/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// The single most important test in this series (#404): a caller must not
+// be able to tell a disabled account from a wrong-password attempt — not
+// by status, not by body. Forensics lives in the audit log only.
+func TestIntegration_Login_DisabledAccountIsByteIdenticalToWrongPassword(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := breakglass.NewRepository(db)
+	secrets := breakglass.NewSecretManager(breakglass.NewFakeSecretClient())
+
+	// The disabled tenant's password + TOTP are the REAL, CORRECT ones —
+	// proving this is refused BECAUSE of disabled_at, not because the
+	// credentials happen to be wrong too. A test that used a wrong
+	// password here would still pass with no disable check at all.
+	disabledTenant := uuid.New()
+	disabledPassword, disabledTOTPSecret := provisionAccount(t, repo, secrets, disabledTenant)
+	require.NoError(t, repo.Disable(context.Background(), disabledTenant, "compromised laptop"))
+	disabledTOTPCode, err := breakglass.TOTPCode(disabledTOTPSecret, time.Now())
+	require.NoError(t, err)
+
+	wrongPwTenant := uuid.New()
+	_, totpSecret := provisionAccount(t, repo, secrets, wrongPwTenant)
+	validTOTP, err := breakglass.TOTPCode(totpSecret, time.Now())
+	require.NoError(t, err)
+
+	r := newLoginRouter(admin.BreakGlassDeps{
+		Repo:        repo,
+		Secrets:     secrets,
+		RateLimiter: breakglass.NewLoginRateLimiter(),
+		IPHMACKey:   breakglass.HMACKey("test-hmac-key"),
+		Sessions:    authbffclient.NoopIssuer{},
+	})
+
+	disabledResp := doLogin(t, r, disabledTenant, disabledPassword, disabledTOTPCode)
+	wrongPwResp := doLogin(t, r, wrongPwTenant, "definitely-the-wrong-password", validTOTP)
+
+	require.Equal(t, http.StatusUnauthorized, disabledResp.Code)
+	require.Equal(t, http.StatusUnauthorized, wrongPwResp.Code)
+	require.Equal(t, wrongPwResp.Body.String(), disabledResp.Body.String(),
+		"a disabled account's failure response must be BYTE-IDENTICAL to a wrong-password failure")
+	require.JSONEq(t, `{"error":"invalid_credentials"}`, disabledResp.Body.String())
+}
+
+// The disable check must fire even when Secret Manager is completely
+// unreachable — proving it short-circuits BEFORE the fetch (step 4), not
+// merely produces the same eventual status by another route.
+func TestIntegration_Login_DisabledAccountShortCircuitsBeforeSecretFetch(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := breakglass.NewRepository(db)
+	// Seed with a WORKING secret manager so Provision succeeds...
+	workingSecrets := breakglass.NewSecretManager(breakglass.NewFakeSecretClient())
+	tenantID := uuid.New()
+	_, _ = provisionAccount(t, repo, workingSecrets, tenantID)
+	require.NoError(t, repo.Disable(context.Background(), tenantID, "incident #999"))
+
+	// ...but wire the HANDLER to a secret manager that always fails, so
+	// any code path that reaches step 4 would surface as a 500, not a 401.
+	brokenSecrets := breakglass.NewSecretManager(alwaysFailSecretClient{})
+
+	r := newLoginRouter(admin.BreakGlassDeps{
+		Repo:        repo,
+		Secrets:     brokenSecrets,
+		RateLimiter: breakglass.NewLoginRateLimiter(),
+		IPHMACKey:   breakglass.HMACKey("test-hmac-key"),
+		Sessions:    authbffclient.NoopIssuer{},
+	})
+
+	resp := doLogin(t, r, tenantID, "irrelevant", "000000")
+
+	require.Equal(t, http.StatusUnauthorized, resp.Code,
+		"a disabled account must be refused before Secret Manager is ever touched — "+
+			"a 500 here would mean the check ran AFTER the fetch")
+	require.JSONEq(t, `{"error":"invalid_credentials"}`, resp.Body.String())
+}
+
+// Enable must restore login for an account that was previously disabled.
+func TestIntegration_Login_Enable_RestoresLogin(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := breakglass.NewRepository(db)
+	secrets := breakglass.NewSecretManager(breakglass.NewFakeSecretClient())
+
+	tenantID := uuid.New()
+	password, totpSecret := provisionAccount(t, repo, secrets, tenantID)
+	require.NoError(t, repo.Disable(context.Background(), tenantID, "testing disable"))
+
+	r := newLoginRouter(admin.BreakGlassDeps{
+		Repo:        repo,
+		Secrets:     secrets,
+		RateLimiter: breakglass.NewLoginRateLimiter(),
+		IPHMACKey:   breakglass.HMACKey("test-hmac-key"),
+		Sessions:    authbffclient.StaticIssuer{},
+	})
+
+	code, err := breakglass.TOTPCode(totpSecret, time.Now())
+	require.NoError(t, err)
+
+	disabledResp := doLogin(t, r, tenantID, password, code)
+	require.Equal(t, http.StatusUnauthorized, disabledResp.Code, "must be refused while disabled")
+
+	require.NoError(t, repo.Enable(context.Background(), tenantID))
+
+	// A fresh TOTP code: enough wall-clock may have passed between the two
+	// requests to cross a 30s window boundary.
+	code2, err := breakglass.TOTPCode(totpSecret, time.Now())
+	require.NoError(t, err)
+	enabledResp := doLogin(t, r, tenantID, password, code2)
+	require.Equal(t, http.StatusOK, enabledResp.Code, "Enable must restore login")
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/break_glass_write.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/break_glass_write.go
@@ -1,0 +1,384 @@
+package platformadmin
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+)
+
+// BreakGlassRotator is the subset of *breakglass.Rotator this handler needs
+// for POST /admin/break-glass/:tenantId/rotate. Declared locally, same
+// reason as BreakGlassLister (break_glass.go), so the handler is stubbable.
+type BreakGlassRotator interface {
+	RotateOne(ctx context.Context, tenantID uuid.UUID) error
+}
+
+// BreakGlassWriter is the subset of *breakglass.Repository this handler
+// needs for disable/enable/clear-lockout (#404).
+type BreakGlassWriter interface {
+	Disable(ctx context.Context, tenantID uuid.UUID, reason string) error
+	Enable(ctx context.Context, tenantID uuid.UUID) error
+	ClearIPLock(ctx context.Context, ipHash []byte) (int64, error)
+}
+
+// BreakGlassRateLimiter is the subset of *breakglass.LoginRateLimiter this
+// handler needs to reset the in-process login limiter alongside the
+// durable DB lockout on clear-lockout. Declared as an interface (not the
+// concrete pointer type) so a nil Deps field is a genuine nil interface,
+// never a non-nil interface wrapping a nil pointer — see the nil check in
+// clearLockout.
+type BreakGlassRateLimiter interface {
+	Reset(key string)
+}
+
+// breakGlassAuditFunc records a platform-operator action against a tenant.
+// Alias of lifecycleAuditFunc (tenant_lifecycle.go) for the same reason
+// trialExtendAuditFunc is: Go does not implicitly convert between two
+// distinct named function types even when their underlying signatures
+// match, and this package already has exactly one such adapter
+// (NewOperatorActionAuditFunc) it should keep using.
+type breakGlassAuditFunc = lifecycleAuditFunc
+
+// BreakGlassWriteHandler serves the break-glass write half (#404): rotate,
+// disable, enable, clear-lockout. Split from BreakGlassHandler (the read
+// side, #333) because these routes need write-scoped dependencies
+// (Rotator, Writer, RateLimiter, an IP HMAC key, an audit emitter) that
+// the read route has no use for — see Register (routes.go) for the hard
+// DB+Emitter gate that keeps these four routes unmounted rather than
+// mounted-but-unaudited, the same guarantee TenantLifecycle and
+// TrialExtender already enforce on this surface.
+type BreakGlassWriteHandler struct {
+	db          *gorm.DB
+	writer      BreakGlassWriter
+	rotator     BreakGlassRotator
+	rateLimiter BreakGlassRateLimiter
+	ipHMACKey   breakglass.HMACKey
+	emit        breakGlassAuditFunc
+	logger      *slog.Logger
+}
+
+// NewBreakGlassWriteHandler constructs the handler. rateLimiter may be
+// nil — clearLockout degrades to clearing only the durable DB lock and
+// logs loudly, rather than panicking on a nil interface. emit may be nil,
+// defaulting to a no-op for direct low-level callers; the real audit
+// guarantee lives in Register's mount gate, not here (see
+// NewTenantLifecycleHandler's doc for why that split exists). logger may
+// be nil, substituted with slog.Default().
+func NewBreakGlassWriteHandler(
+	db *gorm.DB,
+	writer BreakGlassWriter,
+	rotator BreakGlassRotator,
+	rateLimiter BreakGlassRateLimiter,
+	ipHMACKey breakglass.HMACKey,
+	emit breakGlassAuditFunc,
+	logger *slog.Logger,
+) *BreakGlassWriteHandler {
+	if emit == nil {
+		emit = func(*gin.Context, uuid.UUID, audit.Event) error { return nil }
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &BreakGlassWriteHandler{
+		db:          db,
+		writer:      writer,
+		rotator:     rotator,
+		rateLimiter: rateLimiter,
+		ipHMACKey:   ipHMACKey,
+		emit:        emit,
+		logger:      logger,
+	}
+}
+
+// Register mounts the four write routes on the supplied group, beside
+// List (break_glass.go).
+func (h *BreakGlassWriteHandler) Register(g *gin.RouterGroup) {
+	g.POST("/admin/break-glass/:tenantId/rotate", h.rotate)
+	g.POST("/admin/break-glass/:tenantId/disable", h.disable)
+	g.POST("/admin/break-glass/:tenantId/enable", h.enable)
+	g.POST("/admin/break-glass/clear-lockout", h.clearLockout)
+}
+
+// breakGlassRLKey MUST stay byte-identical to rlKey in
+// internal/handlers/admin/break_glass_login.go: both shape the same
+// LoginRateLimiter bucket key from an ip_hash, and the login path resets
+// that bucket on a successful login. A key that shapes the hash
+// differently here would mean clear-lockout resets a bucket the login
+// path never reads, leaving the in-memory limiter stuck even though the
+// durable DB lock was cleared.
+func breakGlassRLKey(ipHash []byte) string {
+	n := len(ipHash)
+	if n > 16 {
+		n = 16
+	}
+	return string(ipHash[:n])
+}
+
+func (h *BreakGlassWriteHandler) parseTenantID(c *gin.Context) (uuid.UUID, bool) {
+	id, err := uuid.Parse(strings.TrimSpace(c.Param("tenantId")))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_tenant_id", "message": "tenantId must be a uuid", "field": "tenantId",
+		})
+		return uuid.Nil, false
+	}
+	return id, true
+}
+
+// rotateResponse carries METADATA ONLY. RotateOne (breakglass/rotation.go)
+// writes the new password and TOTP secret directly to Secret Manager and
+// returns only an error — there is no credential value anywhere in this
+// handler for a response to leak, even by mistake.
+type rotateResponse struct {
+	TenantID  string `json:"tenant_id"`
+	RotatedAt string `json:"rotated_at"`
+}
+
+func (h *BreakGlassWriteHandler) rotate(c *gin.Context) {
+	tenantID, ok := h.parseTenantID(c)
+	if !ok {
+		return
+	}
+
+	// RotateOne does not touch disabled_at (see
+	// breakglass.Repository.ReplaceAfterRotation) — a deliberately
+	// disabled account stays disabled through an unrelated rotation.
+	if err := h.rotator.RotateOne(c.Request.Context(), tenantID); err != nil {
+		if errors.Is(err, breakglass.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{
+				"error": "not_found", "message": "no break-glass account for that tenant",
+			})
+			return
+		}
+		h.logger.Error("break-glass: rotate failed", "tenant_id", tenantID.String(), "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "rotate_failed", "message": "could not rotate break-glass credentials",
+		})
+		return
+	}
+
+	rotatedAt := time.Now().UTC()
+	if err := h.emit(c, tenantID, audit.Event{
+		Action:       "break_glass.rotated",
+		ResourceType: "break_glass_account",
+		ResourceID:   tenantID.String(),
+		Metadata: map[string]any{
+			"rotated_at": rotatedAt.Format(time.RFC3339),
+		},
+	}); err != nil {
+		// The rotation already SUCCEEDED. Log loudly; do not fail the
+		// response for an audit-attribution failure alone.
+		h.logger.Error("break-glass: rotate succeeded but was not audited", "tenant_id", tenantID.String(), "err", err)
+	}
+
+	c.JSON(http.StatusOK, rotateResponse{
+		TenantID:  tenantID.String(),
+		RotatedAt: rotatedAt.Format(time.RFC3339),
+	})
+}
+
+type disableRequest struct {
+	Reason string `json:"reason"`
+}
+
+type disableResponse struct {
+	TenantID   string `json:"tenant_id"`
+	DisabledAt string `json:"disabled_at"`
+	Reason     string `json:"reason"`
+}
+
+func (h *BreakGlassWriteHandler) disable(c *gin.Context) {
+	tenantID, ok := h.parseTenantID(c)
+	if !ok {
+		return
+	}
+
+	var req disableRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		// gin's JSON binder returns io.EOF for a completely empty body —
+		// an omitted body is rejected HERE, before the empty-reason check
+		// below, matching tenant_lifecycle.go's handle().
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_request", "message": "request body could not be parsed",
+		})
+		return
+	}
+
+	reason := strings.TrimSpace(req.Reason)
+	if reason == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "reason_required", "message": "reason is required and must not be empty", "field": "reason",
+		})
+		return
+	}
+
+	if err := h.writer.Disable(c.Request.Context(), tenantID, reason); err != nil {
+		h.respondWriterErr(c, "disable", err)
+		return
+	}
+
+	disabledAt := time.Now().UTC()
+	if err := h.emit(c, tenantID, audit.Event{
+		Action:       "break_glass.disabled",
+		ResourceType: "break_glass_account",
+		ResourceID:   tenantID.String(),
+		Metadata: map[string]any{
+			"reason":      reason,
+			"disabled_at": disabledAt.Format(time.RFC3339),
+		},
+	}); err != nil {
+		h.logger.Error("break-glass: disable succeeded but was not audited", "tenant_id", tenantID.String(), "err", err)
+	}
+
+	c.JSON(http.StatusOK, disableResponse{
+		TenantID:   tenantID.String(),
+		DisabledAt: disabledAt.Format(time.RFC3339),
+		Reason:     reason,
+	})
+}
+
+type enableResponse struct {
+	TenantID  string `json:"tenant_id"`
+	EnabledAt string `json:"enabled_at"`
+}
+
+func (h *BreakGlassWriteHandler) enable(c *gin.Context) {
+	tenantID, ok := h.parseTenantID(c)
+	if !ok {
+		return
+	}
+
+	if err := h.writer.Enable(c.Request.Context(), tenantID); err != nil {
+		h.respondWriterErr(c, "enable", err)
+		return
+	}
+
+	enabledAt := time.Now().UTC()
+	if err := h.emit(c, tenantID, audit.Event{
+		Action:       "break_glass.enabled",
+		ResourceType: "break_glass_account",
+		ResourceID:   tenantID.String(),
+		Metadata: map[string]any{
+			"enabled_at": enabledAt.Format(time.RFC3339),
+		},
+	}); err != nil {
+		h.logger.Error("break-glass: enable succeeded but was not audited", "tenant_id", tenantID.String(), "err", err)
+	}
+
+	c.JSON(http.StatusOK, enableResponse{
+		TenantID:  tenantID.String(),
+		EnabledAt: enabledAt.Format(time.RFC3339),
+	})
+}
+
+// clearLockoutRequest carries the plaintext IP — the one place in this
+// handler a raw IP is allowed to exist, in the request body of the
+// operator who already knows it. It is hashed immediately (see
+// clearLockout below) and the plaintext is never stored or logged.
+//
+// TenantID is OPTIONAL and used only for audit attribution:
+// break_glass_lockouts is keyed by ip_hash, not tenant, and its own
+// tenant_id column is nullable (an attempt that never resolved a tenant —
+// see breakglass.Lockout's doc). When the caller does not supply one,
+// EmitOperatorAction (audit.go) cannot attribute the event to a tenant;
+// that failure is logged, not surfaced, matching every other
+// audit-attribution failure on this surface.
+type clearLockoutRequest struct {
+	IP       string `json:"ip"`
+	TenantID string `json:"tenant_id"`
+}
+
+type clearLockoutResponse struct {
+	Removed int64 `json:"removed"`
+}
+
+func (h *BreakGlassWriteHandler) clearLockout(c *gin.Context) {
+	var req clearLockoutRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_request", "message": "request body could not be parsed",
+		})
+		return
+	}
+
+	ip := strings.TrimSpace(req.IP)
+	if ip == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "ip_required", "message": "ip is required", "field": "ip",
+		})
+		return
+	}
+
+	// The SAME key the login path uses (breakglass.HMACIPHash) — a
+	// different key hashes to different bytes, and this endpoint would
+	// silently clear nothing while still reporting success.
+	ipHash := breakglass.HMACIPHash(h.ipHMACKey, ip)
+
+	removed, err := h.writer.ClearIPLock(c.Request.Context(), ipHash)
+	if err != nil {
+		h.logger.Error("break-glass: clear-lockout failed", "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "clear_lockout_failed", "message": "could not clear the lockout",
+		})
+		return
+	}
+
+	// LoginRateLimiter is an in-memory, per-pod map (breakglass/ratelimit.go)
+	// — this Reset only reaches the pod serving THIS request. The admin
+	// deployment runs 1 replica today, so the durable DB row cleared above
+	// is the one that actually matters; a second replica's own in-memory
+	// counter would be untouched by this call. That is current luck, not
+	// design (#404).
+	if h.rateLimiter != nil {
+		h.rateLimiter.Reset(breakGlassRLKey(ipHash))
+	} else {
+		h.logger.Warn("break-glass: clear-lockout has no rate limiter wired; only the durable DB lock was cleared")
+	}
+
+	var tenantID uuid.UUID
+	if parsed, err := uuid.Parse(strings.TrimSpace(req.TenantID)); err == nil {
+		tenantID = parsed
+	}
+
+	// NEVER the raw IP — only the HMAC hash and the row count are
+	// recorded, matching the storage rule break_glass_lockouts.ip_hash
+	// already applies. The audit trail must not become the one place the
+	// plaintext IP survives.
+	if err := h.emit(c, tenantID, audit.Event{
+		Action:       "break_glass.lockout_cleared",
+		ResourceType: "break_glass_lockout",
+		ResourceID:   hex.EncodeToString(ipHash),
+		Metadata: map[string]any{
+			"ip_hash": hex.EncodeToString(ipHash),
+			"removed": removed,
+		},
+	}); err != nil {
+		h.logger.Error("break-glass: clear-lockout succeeded but was not audited", "err", err)
+	}
+
+	c.JSON(http.StatusOK, clearLockoutResponse{Removed: removed})
+}
+
+func (h *BreakGlassWriteHandler) respondWriterErr(c *gin.Context, action string, err error) {
+	if errors.Is(err, breakglass.ErrNotFound) {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "not_found", "message": "no break-glass account for that tenant",
+		})
+		return
+	}
+	h.logger.Error("break-glass: "+action+" failed", "err", err)
+	c.JSON(http.StatusInternalServerError, gin.H{
+		"error": "internal_error", "message": "could not update the break-glass account",
+	})
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/break_glass_write_integration_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/break_glass_write_integration_test.go
@@ -1,0 +1,206 @@
+//go:build integration
+
+package platformadmin_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/authbffclient"
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+	"github.com/mark8ly/marketplace-api/internal/handlers/admin"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// End-to-end proof of #404 test intent 6: clearing a lockout must remove
+// the DURABLE DB row AND reset the in-process LoginRateLimiter that the
+// SAME pod's login path reads — otherwise a previously locked IP still
+// gets refused, only now for a reason nothing on the console can see.
+//
+// Wires the real breakglass.Repository, a real *breakglass.LoginRateLimiter
+// SHARED between the login handler (internal/handlers/admin) and the
+// break-glass write handler (this package) — exactly as main.go must do
+// in production, since two different LoginRateLimiter instances would
+// never observe each other's state.
+func TestIntegration_ClearLockout_RemovesDBRowAndResetsRateLimiterSoALockedIPCanRetry(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := breakglass.NewRepository(db)
+	secrets := breakglass.NewSecretManager(breakglass.NewFakeSecretClient())
+	limiter := breakglass.NewLoginRateLimiter()
+	ipKey := breakglass.HMACKey("shared-hmac-key-for-this-test")
+
+	tenantID := uuid.New()
+	boot := breakglass.NewBootstrapper(repo, secrets, "test-project")
+	require.NoError(t, boot.Provision(context.Background(), tenantID))
+
+	loginHandler := admin.NewBreakGlassLoginHandler(admin.BreakGlassDeps{
+		Repo:        repo,
+		Secrets:     secrets,
+		RateLimiter: limiter,
+		IPHMACKey:   ipKey,
+		Sessions:    authbffclient.StaticIssuer{},
+	})
+	writeHandler := platformadmin.NewBreakGlassWriteHandler(
+		db, repo, breakglass.NewRotator(repo, secrets, nil, nil),
+		limiter, ipKey, nil, nil,
+	)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/admin/break-glass/login", loginHandler.Login)
+	writeHandler.Register(r.Group(""))
+
+	const clientIP = "203.0.113.55"
+
+	// Fail LoginMaxFailures times with the WRONG password from the SAME
+	// IP, tripping both the in-memory limiter and the durable DB lockout.
+	for i := 0; i < breakglass.LoginMaxFailures; i++ {
+		rec := loginFrom(t, r, clientIP, tenantID, "wrong-password", "000000")
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+	}
+
+	ipHash := breakglass.HMACIPHash(ipKey, clientIP)
+	locked, err := repo.IsIPLocked(context.Background(), ipHash)
+	require.NoError(t, err)
+	require.True(t, locked, "the durable lockout must be in effect after LoginMaxFailures failures")
+
+	// The IP is now locked — even a request bearing the RIGHT credentials
+	// is refused with 429, proving the lock (not just wrong creds) is
+	// what's blocking it.
+	acc, err := repo.GetByTenant(context.Background(), tenantID)
+	require.NoError(t, err)
+	blob, err := secrets.Fetch(context.Background(), acc.SecretPath)
+	require.NoError(t, err)
+	validCode, err := breakglass.TOTPCode(blob.TOTPSecret, time.Now())
+	require.NoError(t, err)
+
+	lockedResp := loginFrom(t, r, clientIP, tenantID, blob.Password, validCode)
+	require.Equal(t, http.StatusTooManyRequests, lockedResp.Code,
+		"the IP must be locked out even with correct credentials")
+
+	// Clear the lockout through the write handler.
+	clearBody, err := json.Marshal(map[string]string{"ip": clientIP})
+	require.NoError(t, err)
+	clearReq := httptest.NewRequest(http.MethodPost, "/admin/break-glass/clear-lockout", bytes.NewReader(clearBody))
+	clearReq.Header.Set("Content-Type", "application/json")
+	clearRec := httptest.NewRecorder()
+	r.ServeHTTP(clearRec, clearReq)
+	require.Equal(t, http.StatusOK, clearRec.Code)
+
+	var clearResult struct {
+		Removed int64 `json:"removed"`
+	}
+	require.NoError(t, json.Unmarshal(clearRec.Body.Bytes(), &clearResult))
+	require.GreaterOrEqual(t, clearResult.Removed, int64(1))
+
+	stillLocked, err := repo.IsIPLocked(context.Background(), ipHash)
+	require.NoError(t, err)
+	require.False(t, stillLocked, "the durable DB lockout row must be gone")
+
+	// A fresh TOTP code — time may have moved past the 30s window.
+	freshCode, err := breakglass.TOTPCode(blob.TOTPSecret, time.Now())
+	require.NoError(t, err)
+	retryResp := loginFrom(t, r, clientIP, tenantID, blob.Password, freshCode)
+	require.Equal(t, http.StatusOK, retryResp.Code,
+		"a previously locked IP must be able to log in again after clear-lockout — "+
+			"both the durable lock AND the in-memory limiter must be clear")
+}
+
+// The DB clear alone is not sufficient proof that the in-memory limiter
+// was also reset: IsIPLocked only ever consults the DB on the happy path,
+// so a successful retry above would pass even if the in-memory counter
+// were left untouched. This test isolates the in-memory half: if
+// clear-lockout did NOT reset LoginRateLimiter, the stale failure count
+// (already at LoginMaxFailures) plus one more wrong-password attempt
+// would push RecordFailure's count past the threshold again and
+// IMMEDIATELY re-persist a fresh DB lockout — even though the operator
+// just cleared it moments ago. A properly reset counter leaves that one
+// wrong attempt safely under threshold.
+func TestIntegration_ClearLockout_ResetsInMemoryCounterNotJustTheDBRow(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := breakglass.NewRepository(db)
+	secrets := breakglass.NewSecretManager(breakglass.NewFakeSecretClient())
+	limiter := breakglass.NewLoginRateLimiter()
+	ipKey := breakglass.HMACKey("shared-hmac-key-for-this-test-2")
+
+	tenantID := uuid.New()
+	boot := breakglass.NewBootstrapper(repo, secrets, "test-project")
+	require.NoError(t, boot.Provision(context.Background(), tenantID))
+
+	loginHandler := admin.NewBreakGlassLoginHandler(admin.BreakGlassDeps{
+		Repo:        repo,
+		Secrets:     secrets,
+		RateLimiter: limiter,
+		IPHMACKey:   ipKey,
+		Sessions:    authbffclient.StaticIssuer{},
+	})
+	writeHandler := platformadmin.NewBreakGlassWriteHandler(
+		db, repo, breakglass.NewRotator(repo, secrets, nil, nil),
+		limiter, ipKey, nil, nil,
+	)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/admin/break-glass/login", loginHandler.Login)
+	writeHandler.Register(r.Group(""))
+
+	const clientIP = "203.0.113.66"
+	ipHash := breakglass.HMACIPHash(ipKey, clientIP)
+
+	for i := 0; i < breakglass.LoginMaxFailures; i++ {
+		rec := loginFrom(t, r, clientIP, tenantID, "wrong-password", "000000")
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+	}
+	locked, err := repo.IsIPLocked(context.Background(), ipHash)
+	require.NoError(t, err)
+	require.True(t, locked)
+
+	clearBody, err := json.Marshal(map[string]string{"ip": clientIP})
+	require.NoError(t, err)
+	clearReq := httptest.NewRequest(http.MethodPost, "/admin/break-glass/clear-lockout", bytes.NewReader(clearBody))
+	clearReq.Header.Set("Content-Type", "application/json")
+	clearRec := httptest.NewRecorder()
+	r.ServeHTTP(clearRec, clearReq)
+	require.Equal(t, http.StatusOK, clearRec.Code)
+
+	stillLocked, err := repo.IsIPLocked(context.Background(), ipHash)
+	require.NoError(t, err)
+	require.False(t, stillLocked)
+
+	// ONE more wrong-password attempt, immediately after the clear.
+	rec := loginFrom(t, r, clientIP, tenantID, "still-wrong-password", "000000")
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	relocked, err := repo.IsIPLocked(context.Background(), ipHash)
+	require.NoError(t, err)
+	require.False(t, relocked,
+		"a single wrong attempt right after clear-lockout must NOT immediately "+
+			"re-trigger the hard lockout — that would mean the in-memory "+
+			"failure counter was never actually reset, only the DB row was")
+}
+
+func loginFrom(t *testing.T, r *gin.Engine, clientIP string, tenantID uuid.UUID, password, totpCode string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{
+		"tenant_id": tenantID.String(),
+		"password":  password,
+		"totp_code": totpCode,
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/admin/break-glass/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-For", clientIP)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/break_glass_write_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/break_glass_write_test.go
@@ -1,0 +1,311 @@
+package platformadmin_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+)
+
+// stubBreakGlassRotator records what tenant it was asked to rotate.
+type stubBreakGlassRotator struct {
+	err       error
+	gotTenant uuid.UUID
+	calls     int
+}
+
+func (s *stubBreakGlassRotator) RotateOne(_ context.Context, tenantID uuid.UUID) error {
+	s.calls++
+	s.gotTenant = tenantID
+	return s.err
+}
+
+// stubBreakGlassWriter implements platformadmin.BreakGlassWriter, recording
+// every call so tests can assert what the handler asked it to do.
+type stubBreakGlassWriter struct {
+	mu sync.Mutex
+
+	disableErr error
+	enableErr  error
+	clearErr   error
+	clearN     int64
+
+	disabledTenant uuid.UUID
+	disabledReason string
+	enabledTenant  uuid.UUID
+	gotIPHash      []byte
+}
+
+func (s *stubBreakGlassWriter) Disable(_ context.Context, tenantID uuid.UUID, reason string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.disabledTenant = tenantID
+	s.disabledReason = reason
+	return s.disableErr
+}
+
+func (s *stubBreakGlassWriter) Enable(_ context.Context, tenantID uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.enabledTenant = tenantID
+	return s.enableErr
+}
+
+func (s *stubBreakGlassWriter) ClearIPLock(_ context.Context, ipHash []byte) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.gotIPHash = ipHash
+	return s.clearN, s.clearErr
+}
+
+// fakeRateLimiter records the key it was asked to Reset.
+type fakeRateLimiter struct {
+	mu      sync.Mutex
+	resetOn []string
+}
+
+func (f *fakeRateLimiter) Reset(key string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resetOn = append(f.resetOn, key)
+}
+
+func discardBreakGlassAudit(*gin.Context, uuid.UUID, audit.Event) error { return nil }
+
+func breakGlassWriteRouter(
+	rotator platformadmin.BreakGlassRotator,
+	writer platformadmin.BreakGlassWriter,
+	limiter platformadmin.BreakGlassRateLimiter,
+	ipKey breakglass.HMACKey,
+	emit func(*gin.Context, uuid.UUID, audit.Event) error,
+) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	platformadmin.NewBreakGlassWriteHandler(nil, writer, rotator, limiter, ipKey, emit, nil).Register(r.Group(""))
+	return r
+}
+
+func doPost(r *gin.Engine, path, body string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// The rotate response must carry metadata only — never a credential. This
+// is the handler-side twin of the "RotateOne returns only an error"
+// contract: even if a future change made the response richer by accident,
+// this pins the exact key set the wire is allowed to carry.
+func TestBreakGlassWrite_RotateResponseContainsNoCredentialMaterial(t *testing.T) {
+	tid := uuid.New()
+	rotator := &stubBreakGlassRotator{}
+	r := breakGlassWriteRouter(rotator, &stubBreakGlassWriter{}, nil, breakglass.HMACKey("k"), discardBreakGlassAudit)
+
+	rec := doPost(r, "/admin/break-glass/"+tid.String()+"/rotate", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, tid, rotator.gotTenant, "rotate must call RotateOne for the path tenant")
+
+	body := rec.Body.String()
+	for _, forbidden := range []string{"password", "totp", "secret", "blob"} {
+		require.NotContainsf(t, strings.ToLower(body), forbidden,
+			"rotate response must never contain %q — RotateOne returns only an error", forbidden)
+	}
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &parsed))
+	require.ElementsMatch(t, []string{"tenant_id", "rotated_at"}, keysOf(parsed),
+		"rotate response must carry metadata only")
+}
+
+func TestBreakGlassWrite_RotateNotFoundReturns404(t *testing.T) {
+	rotator := &stubBreakGlassRotator{err: breakglass.ErrNotFound}
+	r := breakGlassWriteRouter(rotator, &stubBreakGlassWriter{}, nil, breakglass.HMACKey("k"), discardBreakGlassAudit)
+
+	rec := doPost(r, "/admin/break-glass/"+uuid.New().String()+"/rotate", "")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// Disable must reject an empty reason (#404) — free text is required, not
+// optional, because an audit row saying WHAT happened without WHY defeats
+// the point of this surface.
+func TestBreakGlassWrite_DisableRejectsEmptyReason(t *testing.T) {
+	writer := &stubBreakGlassWriter{}
+	r := breakGlassWriteRouter(&stubBreakGlassRotator{}, writer, nil, breakglass.HMACKey("k"), discardBreakGlassAudit)
+
+	tid := uuid.New()
+	rec := doPost(r, "/admin/break-glass/"+tid.String()+"/disable", `{"reason":""}`)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, uuid.Nil, writer.disabledTenant, "the writer must never be called with an empty reason")
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "reason_required", body["error"])
+}
+
+func TestBreakGlassWrite_DisableRejectsWhitespaceOnlyReason(t *testing.T) {
+	writer := &stubBreakGlassWriter{}
+	r := breakGlassWriteRouter(&stubBreakGlassRotator{}, writer, nil, breakglass.HMACKey("k"), discardBreakGlassAudit)
+
+	tid := uuid.New()
+	rec := doPost(r, "/admin/break-glass/"+tid.String()+"/disable", `{"reason":"   "}`)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, uuid.Nil, writer.disabledTenant)
+}
+
+func TestBreakGlassWrite_DisableRejectsMissingBody(t *testing.T) {
+	writer := &stubBreakGlassWriter{}
+	r := breakGlassWriteRouter(&stubBreakGlassRotator{}, writer, nil, breakglass.HMACKey("k"), discardBreakGlassAudit)
+
+	tid := uuid.New()
+	rec := doPost(r, "/admin/break-glass/"+tid.String()+"/disable", "")
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestBreakGlassWrite_DisableSucceedsWithReason(t *testing.T) {
+	writer := &stubBreakGlassWriter{}
+	tid := uuid.New()
+	r := breakGlassWriteRouter(&stubBreakGlassRotator{}, writer, nil, breakglass.HMACKey("k"), discardBreakGlassAudit)
+
+	rec := doPost(r, "/admin/break-glass/"+tid.String()+"/disable", `{"reason":"compromised laptop"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, tid, writer.disabledTenant)
+	require.Equal(t, "compromised laptop", writer.disabledReason)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "compromised laptop", body["reason"])
+}
+
+func TestBreakGlassWrite_EnableSucceeds(t *testing.T) {
+	writer := &stubBreakGlassWriter{}
+	tid := uuid.New()
+	r := breakGlassWriteRouter(&stubBreakGlassRotator{}, writer, nil, breakglass.HMACKey("k"), discardBreakGlassAudit)
+
+	rec := doPost(r, "/admin/break-glass/"+tid.String()+"/enable", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, tid, writer.enabledTenant)
+}
+
+func TestBreakGlassWrite_EnableNotFoundReturns404(t *testing.T) {
+	writer := &stubBreakGlassWriter{enableErr: breakglass.ErrNotFound}
+	r := breakGlassWriteRouter(&stubBreakGlassRotator{}, writer, nil, breakglass.HMACKey("k"), discardBreakGlassAudit)
+
+	rec := doPost(r, "/admin/break-glass/"+uuid.New().String()+"/enable", "")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// The IP must be hashed with the SAME key the login path uses — this
+// proves the handler calls breakglass.HMACIPHash rather than some other
+// derivation, by recomputing the expected hash independently and
+// comparing.
+func TestBreakGlassWrite_ClearLockout_HashesWithTheSameKeyTheLoginPathUses(t *testing.T) {
+	key := breakglass.HMACKey("shared-secret-key")
+	writer := &stubBreakGlassWriter{clearN: 2}
+	limiter := &fakeRateLimiter{}
+	r := breakGlassWriteRouter(&stubBreakGlassRotator{}, writer, limiter, key, discardBreakGlassAudit)
+
+	rec := doPost(r, "/admin/break-glass/clear-lockout", `{"ip":"203.0.113.7"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	expectedHash := breakglass.HMACIPHash(key, "203.0.113.7")
+	require.Equal(t, expectedHash, writer.gotIPHash,
+		"clear-lockout must hash the IP with breakglass.HMACIPHash under the SAME key the login path uses")
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.EqualValues(t, 2, body["removed"])
+}
+
+// Clearing the DB lockout alone is not enough — the in-process
+// LoginRateLimiter must also be reset, using the exact key shape the login
+// handler computes (first 16 bytes of the ip_hash), or a previously
+// locked IP served by the SAME pod stays stuck on the in-memory counter
+// even after the durable lock is gone.
+func TestBreakGlassWrite_ClearLockout_ResetsTheRateLimiterWithTheLoginPathKeyShape(t *testing.T) {
+	key := breakglass.HMACKey("shared-secret-key")
+	writer := &stubBreakGlassWriter{clearN: 1}
+	limiter := &fakeRateLimiter{}
+	r := breakGlassWriteRouter(&stubBreakGlassRotator{}, writer, limiter, key, discardBreakGlassAudit)
+
+	rec := doPost(r, "/admin/break-glass/clear-lockout", `{"ip":"198.51.100.9"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	ipHash := breakglass.HMACIPHash(key, "198.51.100.9")
+	wantKey := string(ipHash[:16])
+	require.Equal(t, []string{wantKey}, limiter.resetOn,
+		"the rate limiter must be Reset with the same key shape the login handler's rlKey computes")
+}
+
+func TestBreakGlassWrite_ClearLockout_NilRateLimiterDoesNotPanic(t *testing.T) {
+	writer := &stubBreakGlassWriter{clearN: 1}
+	r := breakGlassWriteRouter(&stubBreakGlassRotator{}, writer, nil, breakglass.HMACKey("k"), discardBreakGlassAudit)
+
+	require.NotPanics(t, func() {
+		rec := doPost(r, "/admin/break-glass/clear-lockout", `{"ip":"192.0.2.1"}`)
+		require.Equal(t, http.StatusOK, rec.Code)
+	})
+}
+
+func TestBreakGlassWrite_ClearLockout_RejectsEmptyIP(t *testing.T) {
+	writer := &stubBreakGlassWriter{}
+	r := breakGlassWriteRouter(&stubBreakGlassRotator{}, writer, nil, breakglass.HMACKey("k"), discardBreakGlassAudit)
+
+	rec := doPost(r, "/admin/break-glass/clear-lockout", `{"ip":""}`)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Nil(t, writer.gotIPHash)
+}
+
+// The audit trail must never carry the raw IP — only its HMAC hash — even
+// though the request body necessarily does.
+func TestBreakGlassWrite_ClearLockout_AuditNeverCarriesRawIP(t *testing.T) {
+	key := breakglass.HMACKey("shared-secret-key")
+	writer := &stubBreakGlassWriter{clearN: 1}
+
+	var captured audit.Event
+	emit := func(_ *gin.Context, _ uuid.UUID, ev audit.Event) error {
+		captured = ev
+		return nil
+	}
+	r := breakGlassWriteRouter(&stubBreakGlassRotator{}, writer, nil, key, emit)
+
+	const rawIP = "203.0.113.42"
+	rec := doPost(r, "/admin/break-glass/clear-lockout", `{"ip":"`+rawIP+`"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	encoded, err := json.Marshal(captured)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), rawIP,
+		"the audit event must never contain the plaintext IP")
+}
+
+func TestBreakGlassWrite_RotateFailsReturns500AndStillLogsNoCredential(t *testing.T) {
+	rotator := &stubBreakGlassRotator{err: errors.New("secret manager unreachable")}
+	r := breakGlassWriteRouter(rotator, &stubBreakGlassWriter{}, nil, breakglass.HMACKey("k"), discardBreakGlassAudit)
+
+	rec := doPost(r, "/admin/break-glass/"+uuid.New().String()+"/rotate", "")
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.NotContains(t, rec.Body.String(), "secret manager unreachable",
+		"the underlying error must not be echoed to the caller")
+}
+
+func TestBreakGlassWrite_InvalidTenantIDReturns400(t *testing.T) {
+	r := breakGlassWriteRouter(&stubBreakGlassRotator{}, &stubBreakGlassWriter{}, nil, breakglass.HMACKey("k"), discardBreakGlassAudit)
+
+	for _, path := range []string{"/rotate", "/disable", "/enable"} {
+		rec := doPost(r, "/admin/break-glass/not-a-uuid"+path, `{"reason":"x"}`)
+		require.Equal(t, http.StatusBadRequest, rec.Code, "path %s", path)
+	}
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
 	"github.com/mark8ly/marketplace-api/internal/stores"
 )
 
@@ -183,6 +184,23 @@ type Deps struct {
 	// route to mount.
 	BreakGlass BreakGlassLister
 
+	// BreakGlassRotator, BreakGlassWriter, BreakGlassRateLimiter and
+	// BreakGlassIPHMACKey together serve the break-glass write endpoints
+	// (#404): POST /admin/break-glass/:tenantId/{rotate,disable,enable}
+	// and POST /admin/break-glass/clear-lockout. Nil BreakGlassRotator or
+	// BreakGlassWriter leaves those four routes unmounted while List
+	// (#333) keeps working — matching OutboxWriter's pattern. Like
+	// OutboxWriter, this ALSO requires DB and Emitter to be non-nil for
+	// the write routes to mount: a write endpoint that cannot be
+	// attributed to an operator should not exist rather than run silently
+	// unaudited (#287, F1). BreakGlassRateLimiter may be nil — the
+	// handler degrades to clearing only the durable DB lock and logs
+	// loudly rather than panicking (see BreakGlassWriteHandler's doc).
+	BreakGlassRotator     BreakGlassRotator
+	BreakGlassWriter      BreakGlassWriter
+	BreakGlassRateLimiter BreakGlassRateLimiter
+	BreakGlassIPHMACKey   breakglass.HMACKey
+
 	// PriceCatalog resolves the plan catalog the two billing read routes
 	// display amounts from (tesserix-home#328 phase C). Unlike every other
 	// optional field in this struct, nil does NOT unmount anything: it
@@ -305,6 +323,24 @@ func Register(g *gin.RouterGroup, deps Deps) {
 
 	if deps.BreakGlass != nil && deps.TenantDirectory != nil {
 		NewBreakGlassHandler(deps.DB, deps.BreakGlass, deps.TenantDirectory, deps.Logger).Register(group)
+	}
+
+	switch {
+	case deps.BreakGlassRotator != nil && deps.BreakGlassWriter != nil && deps.DB != nil && deps.Emitter != nil:
+		NewBreakGlassWriteHandler(
+			deps.DB, deps.BreakGlassWriter, deps.BreakGlassRotator,
+			deps.BreakGlassRateLimiter, deps.BreakGlassIPHMACKey,
+			NewOperatorActionAuditFunc(deps.Emitter), deps.Logger,
+		).Register(group)
+	case deps.BreakGlassRotator != nil || deps.BreakGlassWriter != nil:
+		// A write endpoint that cannot be attributed is worse than not
+		// having it (#287, F1) — not the nil-safe "just degraded" pattern
+		// the read routes above use.
+		if deps.Logger != nil {
+			deps.Logger.Warn("platformadmin: break-glass write routes not mounted — BreakGlassRotator, BreakGlassWriter, DB and Emitter are all required",
+				"rotator_nil", deps.BreakGlassRotator == nil, "writer_nil", deps.BreakGlassWriter == nil,
+				"db_nil", deps.DB == nil, "emitter_nil", deps.Emitter == nil)
+		}
 	}
 
 	if deps.EstateUsers != nil {

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 128
+const ExpectedSchemaVersion uint = 129

--- a/services/marketplace-api/migrations/000129_break_glass_disable.down.sql
+++ b/services/marketplace-api/migrations/000129_break_glass_disable.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE break_glass_accounts
+    DROP COLUMN IF EXISTS disabled_at,
+    DROP COLUMN IF EXISTS disabled_reason;

--- a/services/marketplace-api/migrations/000129_break_glass_disable.up.sql
+++ b/services/marketplace-api/migrations/000129_break_glass_disable.up.sql
@@ -1,0 +1,16 @@
+-- Migration 129: disable/enable columns for break_glass_accounts (#404).
+--
+-- disabled_at marks an emergency account as administratively disabled by a
+-- platform operator via POST /admin/break-glass/:tenantId/disable — distinct
+-- from a normal wrong-password failure or an IP lockout. The login handler
+-- (internal/handlers/admin/break_glass_login.go) refuses a disabled account
+-- with a response BYTE-IDENTICAL to a wrong-password failure
+-- (401 {"error":"invalid_credentials"}); disabled_reason is for forensics in
+-- the audit log only, and must never reach the HTTP response.
+--
+-- Enable (POST .../enable) clears both columns. Rotate (POST .../rotate)
+-- deliberately does NOT touch either column — see internal/breakglass/
+-- rotation.go's ReplaceAfterRotation, which this migration does not change.
+ALTER TABLE break_glass_accounts
+    ADD COLUMN IF NOT EXISTS disabled_at     TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS disabled_reason TEXT;


### PR DESCRIPTION
Implements #404 — rotate, disable/enable, and clear-lockout for the break-glass surface, plus the migration and login-path enforcement they need.

**The routes are deliberately NOT mounted by this PR.** Please read "What this does not do" before merging: break-glass turns out to be entirely unprovisioned, and mounting controls over it would ship buttons that cannot work.

## The constraint that shaped the design

The break-glass login route is deliberately outside the normal auth middleware and must survive a tenant suspension — it is the way in when everything else is broken. **Nothing added to that path may introduce a new dependency.**

The disable check satisfies that by construction: step 3 of `Login` already does `GetByTenant`, so the check reads a field on a row the handler has in hand. No new query, no new service call.

Two properties, both tested:

- **`TestIntegration_Login_DisabledAccountIsByteIdenticalToWrongPassword`** — status and body identical to a wrong-password attempt. The handler's own doc says "forensics lives in the audit log, not the HTTP response"; a caller must not be able to enumerate which accounts are disabled. The reason `account_disabled` goes to the audit trail only.
- **`TestIntegration_Login_DisabledAccountShortCircuitsBeforeSecretFetch`** — the check sits before the Secret Manager call, so a disabled account is refused even when Secret Manager is down.

## What is here

- **Migration `000129`** — `disabled_at`, `disabled_reason` on `break_glass_accounts`.
- **Repository** — `Disable`, `Enable`, `ClearIPLock` (deletes only *active* lock rows, returns the count).
- **Four handlers** — `rotate`, `disable` (reason required), `enable`, `clear-lockout`.
- All four audit through `EmitOperatorAction`; clear-lockout records the number of rows removed and **never the plaintext IP** — the system stores only HMAC hashes, and the audit log should not become the one place the raw IP is kept.

Three properties worth calling out:

**Rotate cannot leak a credential.** It calls the existing `Rotator.RotateOne`, which returns only an `error` and writes the new password and TOTP secret to Secret Manager itself. The response carries metadata only, pinned by `TestBreakGlassWrite_RotateResponseContainsNoCredentialMaterial`.

**Rotate does not re-enable a disabled account** (`TestIntegration_RotateOne_DoesNotReEnableADisabledAccount`). Re-enabling is only ever an explicit, audited act — otherwise rotating for an unrelated reason silently undoes a deliberate security decision.

**Clear-lockout clears BOTH stores.** There are two: the durable `break_glass_lockouts` rows and the in-process `LoginRateLimiter`. Clearing one leaves the other and the operator reports the button as broken. The IP is hashed with the same HMAC key the login path uses, or the hashes would not match and the endpoint would silently clear nothing while reporting success.

Documented in code: `LoginRateLimiter` is an in-memory per-pod map, so the reset reaches only the serving pod. Admin runs 1 replica and the durable DB lock is the one that matters — current luck, not design. **Whoever wires this must share one limiter instance with the login handler**, or the reset clears a map nobody reads.

## What this does not do — and why

The four routes stay unmounted (`BreakGlassRotator`/`BreakGlassWriter` nil in `main.go`), because break-glass is not a live feature:

```
break_glass_accounts rows      : 0
break_glass_lockouts rows      : 0
GCP secrets matching "break"   : none
POST /admin/break-glass/login  : 404 — handler constructed only in tests
SA Secret Manager permission   : secretAccessor only (READ)
```

Verified against production, not just source: `/api/v1/platform/admin/break-glass` and `.../outbox` both return 401 (mounted, auth required) while `/api/v1/admin/break-glass/login` returns 404.

So there is nothing to rotate, nothing to unlock, and rotation would receive a 403 from GCP because `AddVersion` needs write permission the service account no longer holds (mark8ly#621 revoked project-wide `secretmanager.admin`; nothing broke, since rotation was never wired).

Mounting controls over that would ship a surface that looks delivered and cannot work — which is the exact failure #404 and #405 were filed about. The routing code is written and tested; flipping it on is a one-line dependency wiring once the feature is real.

Filed separately: what actually blocks break-glass.

## Test plan

Integration tests are `//go:build integration` and gated on `TEST_DATABASE_URL` — they skip silently and print `ok` without it, so these were run with a real DSN and observed executing:

- [x] `Login_DisabledAccountIsByteIdenticalToWrongPassword` — RED first
- [x] `Login_DisabledAccountShortCircuitsBeforeSecretFetch`
- [x] `RotateOne_DoesNotReEnableADisabledAccount` — RED first
- [x] `RotateResponseContainsNoCredentialMaterial`
- [x] `ClearLockout_RemovesDBRowAndResetsRateLimiterSoALockedIPCanRetry`, `ClearLockout_ResetsInMemoryCounterNotJustTheDBRow`
- [x] `Repository_DisableThenEnable_RoundTrips`, `Enable_UnknownTenantReturnsErrNotFound`
- [x] Disable rejects empty / whitespace-only / missing reason
- [x] All pre-existing break-glass login tests pass unchanged
- [x] `go test ./...` 0 failures; `go build`, `go vet`, `gofmt` clean
- [x] `scripts/ci/verify-logging-smoke.sh` PASS

Refs #260, #333.
