### PR TITLE
fix(storefront,payment): refund email on paid self-cancel, fail fast on unconfigured Stripe key (#169)

### DIFF
--- a/services/marketplace-api/internal/handlers/storefront/cancel_refund_email_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/cancel_refund_email_integration_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+
+package storefront_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
+
+	"github.com/mark8ly/marketplace-api/internal/branding"
+	"github.com/mark8ly/marketplace-api/internal/handlers/storefront"
+	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/internal/orderdoc"
+	"github.com/mark8ly/marketplace-api/internal/orderrefund"
+	"github.com/mark8ly/marketplace-api/internal/outbox"
+	"github.com/mark8ly/marketplace-api/internal/payment"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// recordingMailer captures the orderdoc envelopes a handler dispatches.
+// Both sends are fire-and-forget goroutines, so each call is announced on a
+// buffered channel the test waits on rather than sleeping.
+type recordingMailer struct {
+	refunds       chan orderdoc.DocumentInput
+	cancellations chan orderdoc.DocumentInput
+}
+
+func newRecordingMailer() *recordingMailer {
+	return &recordingMailer{
+		refunds:       make(chan orderdoc.DocumentInput, 4),
+		cancellations: make(chan orderdoc.DocumentInput, 4),
+	}
+}
+
+func (m *recordingMailer) SendRefund(_ context.Context, in orderdoc.DocumentInput) error {
+	m.refunds <- in
+	return nil
+}
+
+func (m *recordingMailer) SendCancellation(_ context.Context, in orderdoc.DocumentInput) error {
+	m.cancellations <- in
+	return nil
+}
+
+// The rest of the Mailer contract is unused by the cancel path.
+func (m *recordingMailer) SendInvoice(context.Context, orderdoc.DocumentInput) error { return nil }
+func (m *recordingMailer) SendReceipt(context.Context, orderdoc.DocumentInput) error { return nil }
+func (m *recordingMailer) SendShipmentDispatched(context.Context, orderdoc.DocumentInput) error {
+	return nil
+}
+
+// A customer who self-cancels a PAID order gets their money back, but until
+// #169 they were told only "your order was cancelled" — no refund
+// confirmation. The admin-initiated refund has always sent one
+// (handlers/admin/orders.go dispatchRefundEmail), so the same customer got a
+// different experience depending on who pressed the button.
+func TestIntegration_SelfCancelPaid_SendsRefundEmailWithRunningTotal(t *testing.T) {
+	env, mailer := setupCancelRefundEmailEnv(t)
+	cust := seedCancelAutoRefundCustomer(t, env.db, env.store)
+	o := seedCancelAutoRefundOrder(t, env.db, env.store, cust,
+		cancelAutoRefundOrderOpts{GrandTotal: "120.00"})
+	seedCancelAutoRefundCapturedTxn(t, env.db, env.store, o.ID, "120.00")
+	seedCancelAutoRefundGatewayConfig(t, env.db, env.store)
+
+	r := buildCancelRouter(env.handler, env.store, cust)
+	if w := cancelAutoRefundRequest(r, env.store.Slug, o.ID.String()); w.Code != http.StatusOK {
+		t.Fatalf("cancel: status %d, body=%s", w.Code, w.Body.String())
+	}
+
+	select {
+	case in := <-mailer.refunds:
+		if !in.RefundAmount.Equal(decimal.RequireFromString("120.00")) {
+			t.Errorf("RefundAmount = %s, want 120.00", in.RefundAmount)
+		}
+		// The running total must reflect THIS refund. The handler loads the
+		// order before refunding, so a naive pass-through would report 0.00
+		// and tell the customer nothing had been refunded yet.
+		if !in.TotalRefunded.Equal(decimal.RequireFromString("120.00")) {
+			t.Errorf("TotalRefunded = %s, want 120.00 — the post-refund total, not the pre-refund row",
+				in.TotalRefunded)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("no refund email dispatched after a paid self-cancel")
+	}
+
+	// This ADDS an email; it does not replace the cancellation one.
+	select {
+	case <-mailer.cancellations:
+	case <-time.After(15 * time.Second):
+		t.Fatal("the cancellation email must still be sent")
+	}
+}
+
+// An unpaid order is never refunded, so it must never claim to be. Telling a
+// customer money came back when none moved is worse than sending nothing.
+func TestIntegration_SelfCancelUnpaid_SendsNoRefundEmail(t *testing.T) {
+	env, mailer := setupCancelRefundEmailEnv(t)
+	cust := seedCancelAutoRefundCustomer(t, env.db, env.store)
+	o := seedCancelAutoRefundOrder(t, env.db, env.store, cust,
+		cancelAutoRefundOrderOpts{GrandTotal: "80.00", PaymentStatus: string(order.PaymentStatusPending)})
+
+	r := buildCancelRouter(env.handler, env.store, cust)
+	if w := cancelAutoRefundRequest(r, env.store.Slug, o.ID.String()); w.Code != http.StatusOK {
+		t.Fatalf("cancel: status %d, body=%s", w.Code, w.Body.String())
+	}
+
+	// Waiting for the cancellation email first proves the handler ran to
+	// completion, so the absent refund email below is a real absence rather
+	// than a race that has not finished yet.
+	select {
+	case <-mailer.cancellations:
+	case <-time.After(15 * time.Second):
+		t.Fatal("the cancellation email must still be sent for an unpaid order")
+	}
+	select {
+	case in := <-mailer.refunds:
+		t.Fatalf("an unpaid self-cancel must not send a refund email; got amount %s", in.RefundAmount)
+	case <-time.After(2 * time.Second):
+	}
+}
+
+// setupCancelRefundEmailEnv mirrors setupCancelAutoRefundEnv but wires a real
+// orderdoc.Service over a recording Mailer, so the email dispatch the other
+// file passes nil for is actually observable.
+func setupCancelRefundEmailEnv(t *testing.T) (*cancelAutoRefundEnv, *recordingMailer) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	db := testdb.NewDB(t, cancelAutoRefundTables...)
+	store := seedCancelAutoRefundStore(t, db)
+
+	orderRepo := order.NewRepository()
+	orderSvc := order.NewService(db, orderRepo, outbox.NewRepository(db))
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	gw := &carFakeGateway{}
+	res := &carFakeRefundResolver{Resolver: orderrefund.NewResolver(db), gw: gw}
+	paySvc := payment.NewService(payment.NewRepository(db))
+	coordinator := orderrefund.NewCoordinator(db, res, paySvc, orderSvc, orderRepo, true)
+
+	mailer := newRecordingMailer()
+	// orderdoc.Service dereferences brandingSvc in buildInput, so a nil here
+	// panics inside the dispatch goroutine rather than failing the test.
+	brandingSvc := branding.NewService(branding.ServiceConfig{
+		DB: db, Repo: branding.NewRepository(), Logger: logger,
+	})
+	docSvc := orderdoc.NewService(db, mailer, orderRepo, brandingSvc, "https://example.test")
+
+	handler := storefront.NewOrderDetailHandler(db, orderRepo, orderSvc, docSvc, logger).
+		WithRefunds(coordinator)
+
+	return &cancelAutoRefundEnv{db: db, handler: handler, store: store}, mailer
+}

--- a/services/marketplace-api/internal/handlers/storefront/order_detail.go
+++ b/services/marketplace-api/internal/handlers/storefront/order_detail.go
@@ -79,6 +79,39 @@ func (h *OrderDetailHandler) WithRefunds(c *orderrefund.Coordinator) *OrderDetai
 	return h
 }
 
+// dispatchRefundEmail fires the refund-issued notification on a detached
+// context, mirroring the admin path's dispatchRefundEmail
+// (handlers/admin/orders.go). Before #169 a customer who self-cancelled a
+// PAID order was refunded but only ever told the order was cancelled — the
+// same customer got a different experience depending on who pressed the
+// button.
+//
+// The order is re-read inside the goroutine rather than reusing the copy the
+// handler loaded before refunding. Two reasons, and the second is the one
+// that bites: the pre-refund row still reports the OLD refunded_amount, and
+// adding res.Amount to it would OVER-report, because res.Amount includes the
+// gift-card slice while orders.refunded_amount counts gateway money only.
+// The admin path sidesteps both by passing its post-refund row.
+func (h *OrderDetailHandler) dispatchRefundEmail(orderID uuid.UUID, refundAmount decimal.Decimal) {
+	if h.docMailer == nil {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		post, _, _, err := h.orderRepo.GetByID(ctx, h.db, orderID)
+		if err != nil {
+			h.logger.Warn("orderdoc: refund email skipped — could not re-read order for the running total",
+				"order_id", orderID, "err", err)
+			return
+		}
+		if err := h.docMailer.SendRefund(ctx, orderID, refundAmount, post.RefundedAmount); err != nil {
+			h.logger.Warn("orderdoc: customer cancel refund email dispatch failed",
+				"order_id", orderID, "err", err)
+		}
+	}()
+}
+
 // storefrontOrderResponse is the customer-facing DTO.
 type storefrontOrderResponse struct {
 	ID            string `json:"id"`
@@ -680,10 +713,21 @@ func (h *OrderDetailHandler) Cancel(c *gin.Context) {
 	// gateway blip leaves the order cancelled + a pending ledger row for the
 	// sweeper, so the customer is never blocked on the cancel response.
 	if h.refunds != nil && o.PaymentStatus == string(order.PaymentStatusPaid) {
-		if _, rerr := h.refunds.Refund(c.Request.Context(), orderrefund.RefundCommand{
+		res, rerr := h.refunds.Refund(c.Request.Context(), orderrefund.RefundCommand{
 			OrderID: orderID, Amount: nil, Reason: "order cancelled", Actor: "customer", ScopeID: "cancel",
-		}); rerr != nil {
+		})
+		switch {
+		case rerr != nil:
+			// A gateway blip leaves a pending ledger row for the sweeper, so
+			// the money has NOT moved yet. Deliberately no refund email here:
+			// telling a customer they have been refunded when the refund is
+			// still queued is worse than telling them nothing (#169).
 			h.logger.Warn("cancel auto-refund deferred", "order_id", orderID, "err", rerr)
+		case res.AlreadyDone:
+			// Idempotent replay of a refund that already happened — the email
+			// went out the first time.
+		case res.Amount.IsPositive():
+			h.dispatchRefundEmail(orderID, res.Amount)
 		}
 	}
 

--- a/services/marketplace-api/internal/payment/razorpay_test.go
+++ b/services/marketplace-api/internal/payment/razorpay_test.go
@@ -19,7 +19,13 @@ func TestRazorpayRefund_SendsIdempotencyHeaderAndNotes(t *testing.T) {
 	var body []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotKey = r.Header.Get("X-Refund-Idempotency")
-		body, _ = io.ReadAll(r.Body)
+		var readErr error
+		// Swallowing this made a read failure look like an assertion failure
+		// on the body below (#169). t.Errorf is safe from a handler
+		// goroutine; t.Fatalf is not.
+		if body, readErr = io.ReadAll(r.Body); readErr != nil {
+			t.Errorf("read request body: %v", readErr)
+		}
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"id":"rfnd_1","status":"processed","amount":5000}`))
 	}))

--- a/services/marketplace-api/internal/payment/stripe.go
+++ b/services/marketplace-api/internal/payment/stripe.go
@@ -232,6 +232,18 @@ func stripeRefundReason(raw string) string {
 
 // RefundPayment creates a refund via POST /v1/refunds.
 func (s *StripeGateway) RefundPayment(ctx context.Context, in RefundInput) (*Refund, error) {
+	// An unconfigured key is a local configuration fault, not a Stripe one.
+	// Sent as empty basic auth it comes back as a bare 401, which reads as
+	// "Stripe rejected our credentials" and sends an operator to the Stripe
+	// dashboard mid-incident instead of to their own config (#169).
+	//
+	// Scoped to the refund path deliberately: that is the surface #164/#169
+	// cover, and the other Stripe calls have their own callers and tests.
+	// The same guard would suit them.
+	if s.apiKey == "" {
+		return nil, fmt.Errorf("stripe: refund payment: no API key configured for this store")
+	}
+
 	amountMinor := toMinorUnits(in.Amount, in.CurrencyCode)
 
 	form := url.Values{}

--- a/services/marketplace-api/internal/payment/stripe_emptykey_test.go
+++ b/services/marketplace-api/internal/payment/stripe_emptykey_test.go
@@ -1,0 +1,47 @@
+package payment
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+// An unconfigured API key must fail LOCALLY, before any request leaves the
+// process (#169).
+//
+// Without this, an empty key is sent as empty basic auth and Stripe answers
+// 401 — so a missing credential is indistinguishable from a revoked or wrong
+// one. During a refund incident that points the operator at Stripe's
+// dashboard instead of at their own configuration, which is the expensive
+// kind of misdirection.
+func TestStripeRefund_EmptyAPIKeyFailsBeforeSendingRequest(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	g := NewStripeGateway("", "secret", "test")
+	g.baseURL = srv.URL
+
+	_, err := g.RefundPayment(context.Background(), RefundInput{
+		ProviderPaymentID: "pi_1",
+		Amount:            decimal.RequireFromString("10.00"),
+		CurrencyCode:      "USD",
+	})
+	if err == nil {
+		t.Fatal("RefundPayment with an empty API key returned nil error")
+	}
+	if called {
+		t.Error("a request reached Stripe despite there being no API key; the guard must short-circuit first")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "api key") {
+		t.Errorf("error = %q, want it to name the missing API key so the operator "+
+			"looks at configuration rather than at Stripe", err)
+	}
+}


### PR DESCRIPTION
Closes #169 — the remaining three bullets. The sweeper skip-logging bullet landed earlier in the session (`Coordinator.ResumePending` now logs every skip site).

## 1. A paid self-cancel now sends a refund email

A customer who self-cancels a **paid** order is auto-refunded, but was told only *"your order was cancelled"*. The admin-initiated refund has always sent a refund confirmation (`handlers/admin/orders.go dispatchRefundEmail`), so the same customer got a different experience depending on who pressed the button.

The email fires only when money actually moved:

```go
switch {
case rerr != nil:      // gateway blip → pending ledger row for the sweeper
case res.AlreadyDone:  // idempotent replay; the first call already mailed
case res.Amount.IsPositive():
    h.dispatchRefundEmail(orderID, res.Amount)
}
```

The `rerr` branch matters: a gateway failure leaves a pending row for the sweeper, so the money has **not** moved yet. Telling a customer they have been refunded while the refund is still queued is worse than telling them nothing.

### The running total is re-read, not computed

The handler loads the order *before* refunding, so its `RefundedAmount` is stale. The obvious fix — adding `res.Amount` to it — is wrong: `res.Amount` includes the gift-card slice, while `orders.refunded_amount` counts **gateway money only**, so the customer would be told a larger total than was actually returned to their card. The admin path sidesteps this by passing its post-refund row; this re-reads the order inside the dispatch goroutine for the same reason.

`TestIntegration_SelfCancelPaid_SendsRefundEmailWithRunningTotal` asserts `TotalRefunded = 120.00` specifically — a naive pass-through reports `0.00` and tells the customer nothing has been refunded.

## 2. An unconfigured Stripe key fails locally

`RefundPayment` sent an empty API key as empty basic auth and Stripe answered `401`, surfacing as:

```
stripe: gateway responded 401:
```

A missing credential was therefore indistinguishable from a revoked or wrong one — and mid-incident that sends an operator to the Stripe dashboard instead of to their own configuration. It now fails before the request leaves the process, naming the API key.

Scoped to the refund path deliberately: that is the surface #164/#169 cover. The comment notes the same guard would suit the other three Stripe calls.

## 3. razorpay_test no longer swallows a read error

`body, _ = io.ReadAll(r.Body)` meant a read failure surfaced as a confusing assertion failure on the body. It now reports the real cause. `t.Errorf` rather than `t.Fatalf`, because the handler runs on its own goroutine.

## Deliberately not done

The **multi-partial limitation** — the payment-status machine has no `partially_refunded → partially_refunded` transition, so two *separate* partial refunds on one order are unsupported. #169 defers this itself ("fine today; revisit if multi-step partials become a requirement"), and it is a state-machine change rather than polish.

## Test plan

Integration tests are `//go:build integration` and gated on `TEST_DATABASE_URL` — they skip silently and print `ok` without it, so these were run with a real DSN and observed executing:

- [x] `SelfCancelPaid_SendsRefundEmailWithRunningTotal` — verified RED (`no refund email dispatched after a paid self-cancel`), asserts both amount and running total, and that the cancellation email still goes out
- [x] `SelfCancelUnpaid_SendsNoRefundEmail` — waits for the cancellation email first, so the absent refund email is a real absence rather than an unfinished race
- [x] `StripeRefund_EmptyAPIKeyFailsBeforeSendingRequest` — verified RED; asserts no request reaches the server and the error names the key
- [x] The three pre-existing `TestCancelAutoRefund_*` tests pass unchanged
- [x] `go test ./...` 0 failures; `go build`, `go vet`, `gofmt` clean
- [x] `scripts/ci/verify-logging-smoke.sh` PASS

One incidental finding, not fixed here: `orderdoc.Service` dereferences `brandingSvc` in `buildInput`, so a nil branding service panics inside the dispatch goroutine rather than degrading. Production always wires one; the test now does too.

Refs #164.
