### PR TITLE
docs: break-glass activation design (#642)

### DIFF
--- a/docs/superpowers/specs/2026-09-04-break-glass-activation-design.md
+++ b/docs/superpowers/specs/2026-09-04-break-glass-activation-design.md
@@ -1,0 +1,235 @@
+# Break-glass activation — design
+
+**Status:** proposed
+**Issues:** closes #642 (turn it on), unblocks #404 (write operations)
+**Supersedes the unfinished parts of:** `docs/superpowers/plans/2026-04-18-p13-sso-break-glass.md`
+
+**Goal:** make the break-glass emergency admin login reachable, and mount the
+per-tenant SSO login routes that share its one missing dependency.
+
+---
+
+## 1. What break-glass is for
+
+Pro-tier tenants attach their own SAML/OIDC IdP (P13). When that tenant's SSO
+breaks or is misconfigured, their admins cannot sign in at all. Break-glass is
+one emergency local account per tenant — password **and** TOTP, never SMS —
+that bypasses SSO entirely.
+
+The thing that is down is **the tenant's own IdP**. GIP, auth-bff and the
+cluster are up. This matters: it is the constraint that shapes the whole
+design, and it is narrower than "the IdP is down".
+
+## 2. Verified current state
+
+The code is far more finished than "not built". Verified by reading it, not
+from the plan document:
+
+| Piece | State |
+|---|---|
+| `internal/breakglass/` (~60KB) | credentials, TOTP, lockouts, rotation, audit, Slack, bootstrap — **complete** |
+| `handlers/admin/break_glass_login.go` | **complete**, including a considered fail-closed degradation when the lockout store is unreachable (#457/#468) |
+| `handlers/public/sso_login.go` | login / callback / logout — **complete** |
+| Migrations `000073` (lockouts), `000129` (disable) | applied |
+| `cmd/break-glass-rotation` | exists |
+| Platform **read** path | **already mounted** (`platformadmin.BreakGlassListerFunc`, `main.go:2338`, `:2487`) |
+| `authbffclient.SessionIssuer` | interface + `NoopIssuer` that always errors — **no implementation** |
+| `POST /admin/break-glass/login` | **not mounted** |
+| SSO login routes | **not mounted** |
+| Break-glass accounts provisioned | **zero** |
+
+**One missing dependency gates two features.** `SessionIssuer` is referenced
+only by `break_glass_login.go` and `sso_login.go`. Implementing it unblocks
+both; neither is reachable without it.
+
+## 3. The two constraints
+
+### 3.1 A break-glass session carries no IdP tokens
+
+auth-bff's `session.Session` has `AccessToken` / `IDToken` / `RefreshToken`.
+A break-glass principal never authenticated to any IdP — there is no federated
+assertion to put there. Minting a GIP custom token for a synthetic user was
+rejected: P13's own architecture note says *"we do not invent a second
+token-verification layer"*, and it would add GIP account lifecycle for
+synthetic users to buy nothing this design needs.
+
+So the session ships with those three fields **empty, deliberately**.
+
+### 3.2 Break-glass secrets live in a backend we decommissioned
+
+P13 stores each account's password + TOTP secret in **GCP Secret Manager** at
+`/projects/tesserix-prod/secrets/break-glass-{tenant_id}`.
+
+Milestone 10 retired GCP Secret Manager: the secrets were deleted and the
+service account's IAM revoked. **Turning on break-glass as written would fail
+at first use**, and `Bootstrapper` writes Secret Manager *before* the DB row,
+so provisioning would fail at step one.
+
+This is not optional cleanup — it is a prerequisite.
+
+## 4. Why nothing downstream needs to change
+
+The reason the narrow approach is sufficient, verified against the running
+cluster rather than assumed:
+
+- `marketplace-api` authenticates callers with `auth.HeaderTrustAuth` —
+  it reads **`X-User-Id` / `X-Tenant-Id`** headers, optionally gated by
+  `MARKETPLACE_INTERNAL_AUTH_SECRET`. It does **not** validate GIP tokens on
+  this path.
+- The admin API's Istio policy `allow-marketplace-api-admin-callers` is
+  **mTLS workload-identity** based — a list of SA principals
+  (`.../sa/mark8ly-admin`, `.../sa/mark8ly-auth-bff`, …). It requires **no
+  JWT**. The JWT `RequestAuthentication`s live in `istio-ingress`, on the
+  browser hop.
+- Therefore the admin BFF sets exactly the same headers from a break-glass
+  session as from a normal one.
+
+**The empty IdP token fields never reach a validator.** "Session-cookie trust"
+is not a reduced-capability compromise here; it is complete for the admin
+surface.
+
+## 5. Design
+
+### 5.1 auth-bff — mint a session for an already-authenticated principal
+
+Add one endpoint to the **existing** `/internal` group in
+`internal/handlers/internal.go`, which already carries
+`requireServiceKey()` (Bearer `INTERNAL_SERVICE_KEY`) and `rateLimit()`:
+
+```
+POST /internal/mint-session
+```
+
+Request:
+
+```json
+{ "tenant_id": "...", "tenant_slug": "...", "user_id": "...",
+  "email": "...", "auth_context": "break_glass",
+  "app_name": "marketplace-admin", "ttl_seconds": 7200 }
+```
+
+Response: `{ "set_cookie": "<full Set-Cookie header value>" }`
+
+> **Correction to the code's own comment.** `session_issuer.go` says the
+> endpoint is "expected to be mTLS-gated". The `/internal` group's actual,
+> working pattern is a Bearer service key plus rate limiting. Follow the
+> pattern that exists; introducing a second auth mechanism for one endpoint
+> would be a new thing to get wrong.
+
+**`auth_context` must be allow-listed**, exactly as `IsKnownSessionCookie`
+guards `session-exchange` today. Accept `break_glass` and the existing
+`staff` / `customer`; reject anything else with 400. It must never default to
+`staff` — a typo would silently mint a full staff session.
+
+Cookie cryptography stays in auth-bff. Extract the encrypt step already inside
+`CookieStore.Save` into an exported `Encode(sess *Session) (string, error)`,
+and have both `Save` and this endpoint use it. marketplace-api never signs a
+session cookie.
+
+### 5.2 marketplace-api — implement the issuer
+
+`internal/authbffclient/http_issuer.go`:
+
+```go
+type HTTPIssuer struct {
+    BaseURL    string        // AUTH_BFF_INTERNAL_URL
+    ServiceKey string        // AUTH_BFF_INTERNAL_SERVICE_KEY
+    Client     *http.Client  // timeout 5s
+    TenantSlug func(context.Context, uuid.UUID) (string, error)
+}
+```
+
+`Issue` POSTs to `/internal/mint-session` with `auth_context: "break_glass"`
+and returns the `set_cookie` string. Any non-200 returns an error — the
+handler already maps that to `500 session_mint_failed` without leaking why.
+
+`NoopIssuer` stays the default when config is absent, so a misconfigured
+deploy fails loudly rather than serving an unauthenticated route.
+
+### 5.3 Port break-glass secrets to OpenBao
+
+`breakglass.SecretClient` is a two-method interface:
+
+```go
+AddVersion(ctx, path string, payload []byte) error
+AccessLatest(ctx, path string) ([]byte, error)
+```
+
+`carriersecrets.BaoClient` already offers `CreateOrAddVersion(ctx, name,
+payload)` and `AccessLatest(ctx, name)`. Add
+`internal/breakglass/bao_secret_client.go` — a thin adapter, no new secret
+machinery, reusing the KV v2 mount and Kubernetes auth proven in milestone 10.
+
+Path scheme: `break-glass/{tenant_id}`, mirroring the carrier-secrets
+convention.
+
+`gcp_secret_manager.go` is **deleted**, not left in place. An unused GCP client
+whose IAM has been revoked is a trap for the next reader — the same reasoning
+that deleted the retired ArgoCD Application in tesserix-k8s#938.
+
+### 5.4 Mount the routes
+
+In `main.go`, alongside the already-wired `BreakGlassLister`:
+
+- `POST /admin/break-glass/login` — mounted **outside** the store-scoped
+  `RequireActive` group. The handler comment is explicit about why: it must
+  survive `read_only` / `store_closed` subscription states (§12.4).
+- Gate with `plangate.RequireFeature(FeatureSSO)` — break-glass exists for
+  SSO tenants, so a Starter tenant hitting it should get the same 403 the SSO
+  endpoints give.
+- SSO login / callback / logout routes, now that their issuer exists.
+
+### 5.5 Provision accounts
+
+Use the existing `Bootstrapper` (bcrypt cost 12, Secret-Manager-write-first
+ordering preserved against the Bao adapter). One account per Pro+SSO tenant.
+Zero exist today, so this is the step that makes the feature real rather than
+merely reachable.
+
+## 6. #404 — write operations
+
+Unblocked by the same work. `rotation.go`, migration `000129_break_glass_disable`
+and `cmd/break-glass-rotation` already exist; `platformadmin` write handlers
+need mounting plus the Bao port above. Rotate / disable / clear-lockout are a
+follow-on plan, not this spec's scope.
+
+Note for the 24-hour post-use rotation and 90-day cron: **CronJobs inherit the
+deployment ServiceAccount**, so the OpenBao grant already applies; what a new
+CronJob needs is env vars and the NetworkPolicy pod label, never new IAM.
+
+## 7. Risks
+
+| Risk | Mitigation |
+|---|---|
+| A caller assumes `session-exchange` returns a non-empty `access_token` | Enumerate every caller before mounting. Break-glass sessions return empty strings there. |
+| `auth_context` typo silently mints a staff session | Explicit allow-list, reject-by-default, unit test per accepted value. |
+| Break-glass depends on auth-bff being up | Accepted: the failure being addressed is the *tenant's* IdP, not auth-bff. Stated so nobody assumes wider coverage than exists. |
+| A break-glass session is a full admin session for 2h | Unchanged from P13's design: every login triggers immediate 24h rotation, a `#security-alerts` Slack post, and a `severity=critical` audit event. |
+| Obsolete Terraform | P13 provisions a `break-glass-responders` Google Group + IAM on `/projects/tesserix-prod/secrets/break-glass-*`. Those secrets no longer exist; the IAM policy is dead and should be removed with the GCP client. |
+
+## 8. Deliberately not doing
+
+- **No GIP custom tokens** for break-glass principals (§3.1).
+- **No second token-verification layer** in go-shared or any service — §4
+  shows none is needed.
+- **No mTLS** for the new endpoint; it follows the `/internal` group's
+  existing Bearer pattern.
+- **No change to Istio policy.** Verified unnecessary, not assumed.
+
+## 9. Test plan
+
+- Unit: `HTTPIssuer` maps non-200 to error; `NoopIssuer` still the default
+  when config is absent.
+- Unit: `auth_context` allow-list rejects unknown values; no path defaults to
+  `staff`.
+- Unit: Bao adapter satisfies `SecretClient`; round-trips a `Blob`.
+- Integration: `Bootstrapper` provisions against Bao with the
+  secret-before-DB ordering intact (a Bao failure must leave no DB row).
+- Integration: full login — correct password+TOTP returns 200 with a
+  `Set-Cookie`; wrong either factor returns the uniform
+  `{"error":"invalid_credentials"}`; the existing lockout tests still pass.
+- End-to-end in a real cluster: a break-glass cookie reaches
+  marketplace-api-admin and is accepted, proving §4 against the running Istio
+  policy rather than the manifest.
+- Negative: confirm the route is **absent** before the change and **present**
+  after — an unmounted route is this codebase's recurring silent failure.

--- a/services/marketplace-api/internal/handlers/storefront/cancel_refund_email_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/cancel_refund_email_integration_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+
+package storefront_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
+
+	"github.com/mark8ly/marketplace-api/internal/branding"
+	"github.com/mark8ly/marketplace-api/internal/handlers/storefront"
+	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/internal/orderdoc"
+	"github.com/mark8ly/marketplace-api/internal/orderrefund"
+	"github.com/mark8ly/marketplace-api/internal/outbox"
+	"github.com/mark8ly/marketplace-api/internal/payment"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// recordingMailer captures the orderdoc envelopes a handler dispatches.
+// Both sends are fire-and-forget goroutines, so each call is announced on a
+// buffered channel the test waits on rather than sleeping.
+type recordingMailer struct {
+	refunds       chan orderdoc.DocumentInput
+	cancellations chan orderdoc.DocumentInput
+}
+
+func newRecordingMailer() *recordingMailer {
+	return &recordingMailer{
+		refunds:       make(chan orderdoc.DocumentInput, 4),
+		cancellations: make(chan orderdoc.DocumentInput, 4),
+	}
+}
+
+func (m *recordingMailer) SendRefund(_ context.Context, in orderdoc.DocumentInput) error {
+	m.refunds <- in
+	return nil
+}
+
+func (m *recordingMailer) SendCancellation(_ context.Context, in orderdoc.DocumentInput) error {
+	m.cancellations <- in
+	return nil
+}
+
+// The rest of the Mailer contract is unused by the cancel path.
+func (m *recordingMailer) SendInvoice(context.Context, orderdoc.DocumentInput) error { return nil }
+func (m *recordingMailer) SendReceipt(context.Context, orderdoc.DocumentInput) error { return nil }
+func (m *recordingMailer) SendShipmentDispatched(context.Context, orderdoc.DocumentInput) error {
+	return nil
+}
+
+// A customer who self-cancels a PAID order gets their money back, but until
+// #169 they were told only "your order was cancelled" — no refund
+// confirmation. The admin-initiated refund has always sent one
+// (handlers/admin/orders.go dispatchRefundEmail), so the same customer got a
+// different experience depending on who pressed the button.
+func TestIntegration_SelfCancelPaid_SendsRefundEmailWithRunningTotal(t *testing.T) {
+	env, mailer := setupCancelRefundEmailEnv(t)
+	cust := seedCancelAutoRefundCustomer(t, env.db, env.store)
+	o := seedCancelAutoRefundOrder(t, env.db, env.store, cust,
+		cancelAutoRefundOrderOpts{GrandTotal: "120.00"})
+	seedCancelAutoRefundCapturedTxn(t, env.db, env.store, o.ID, "120.00")
+	seedCancelAutoRefundGatewayConfig(t, env.db, env.store)
+
+	r := buildCancelRouter(env.handler, env.store, cust)
+	if w := cancelAutoRefundRequest(r, env.store.Slug, o.ID.String()); w.Code != http.StatusOK {
+		t.Fatalf("cancel: status %d, body=%s", w.Code, w.Body.String())
+	}
+
+	select {
+	case in := <-mailer.refunds:
+		if !in.RefundAmount.Equal(decimal.RequireFromString("120.00")) {
+			t.Errorf("RefundAmount = %s, want 120.00", in.RefundAmount)
+		}
+		// The running total must reflect THIS refund. The handler loads the
+		// order before refunding, so a naive pass-through would report 0.00
+		// and tell the customer nothing had been refunded yet.
+		if !in.TotalRefunded.Equal(decimal.RequireFromString("120.00")) {
+			t.Errorf("TotalRefunded = %s, want 120.00 — the post-refund total, not the pre-refund row",
+				in.TotalRefunded)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("no refund email dispatched after a paid self-cancel")
+	}
+
+	// This ADDS an email; it does not replace the cancellation one.
+	select {
+	case <-mailer.cancellations:
+	case <-time.After(15 * time.Second):
+		t.Fatal("the cancellation email must still be sent")
+	}
+}
+
+// An unpaid order is never refunded, so it must never claim to be. Telling a
+// customer money came back when none moved is worse than sending nothing.
+func TestIntegration_SelfCancelUnpaid_SendsNoRefundEmail(t *testing.T) {
+	env, mailer := setupCancelRefundEmailEnv(t)
+	cust := seedCancelAutoRefundCustomer(t, env.db, env.store)
+	o := seedCancelAutoRefundOrder(t, env.db, env.store, cust,
+		cancelAutoRefundOrderOpts{GrandTotal: "80.00", PaymentStatus: string(order.PaymentStatusPending)})
+
+	r := buildCancelRouter(env.handler, env.store, cust)
+	if w := cancelAutoRefundRequest(r, env.store.Slug, o.ID.String()); w.Code != http.StatusOK {
+		t.Fatalf("cancel: status %d, body=%s", w.Code, w.Body.String())
+	}
+
+	// Waiting for the cancellation email first proves the handler ran to
+	// completion, so the absent refund email below is a real absence rather
+	// than a race that has not finished yet.
+	select {
+	case <-mailer.cancellations:
+	case <-time.After(15 * time.Second):
+		t.Fatal("the cancellation email must still be sent for an unpaid order")
+	}
+	select {
+	case in := <-mailer.refunds:
+		t.Fatalf("an unpaid self-cancel must not send a refund email; got amount %s", in.RefundAmount)
+	case <-time.After(2 * time.Second):
+	}
+}
+
+// setupCancelRefundEmailEnv mirrors setupCancelAutoRefundEnv but wires a real
+// orderdoc.Service over a recording Mailer, so the email dispatch the other
+// file passes nil for is actually observable.
+func setupCancelRefundEmailEnv(t *testing.T) (*cancelAutoRefundEnv, *recordingMailer) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	db := testdb.NewDB(t, cancelAutoRefundTables...)
+	store := seedCancelAutoRefundStore(t, db)
+
+	orderRepo := order.NewRepository()
+	orderSvc := order.NewService(db, orderRepo, outbox.NewRepository(db))
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	gw := &carFakeGateway{}
+	res := &carFakeRefundResolver{Resolver: orderrefund.NewResolver(db), gw: gw}
+	paySvc := payment.NewService(payment.NewRepository(db))
+	coordinator := orderrefund.NewCoordinator(db, res, paySvc, orderSvc, orderRepo, true)
+
+	mailer := newRecordingMailer()
+	// orderdoc.Service dereferences brandingSvc in buildInput, so a nil here
+	// panics inside the dispatch goroutine rather than failing the test.
+	brandingSvc := branding.NewService(branding.ServiceConfig{
+		DB: db, Repo: branding.NewRepository(), Logger: logger,
+	})
+	docSvc := orderdoc.NewService(db, mailer, orderRepo, brandingSvc, "https://example.test")
+
+	handler := storefront.NewOrderDetailHandler(db, orderRepo, orderSvc, docSvc, logger).
+		WithRefunds(coordinator)
+
+	return &cancelAutoRefundEnv{db: db, handler: handler, store: store}, mailer
+}

--- a/services/marketplace-api/internal/handlers/storefront/order_detail.go
+++ b/services/marketplace-api/internal/handlers/storefront/order_detail.go
@@ -79,6 +79,39 @@ func (h *OrderDetailHandler) WithRefunds(c *orderrefund.Coordinator) *OrderDetai
 	return h
 }
 
+// dispatchRefundEmail fires the refund-issued notification on a detached
+// context, mirroring the admin path's dispatchRefundEmail
+// (handlers/admin/orders.go). Before #169 a customer who self-cancelled a
+// PAID order was refunded but only ever told the order was cancelled — the
+// same customer got a different experience depending on who pressed the
+// button.
+//
+// The order is re-read inside the goroutine rather than reusing the copy the
+// handler loaded before refunding. Two reasons, and the second is the one
+// that bites: the pre-refund row still reports the OLD refunded_amount, and
+// adding res.Amount to it would OVER-report, because res.Amount includes the
+// gift-card slice while orders.refunded_amount counts gateway money only.
+// The admin path sidesteps both by passing its post-refund row.
+func (h *OrderDetailHandler) dispatchRefundEmail(orderID uuid.UUID, refundAmount decimal.Decimal) {
+	if h.docMailer == nil {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		post, _, _, err := h.orderRepo.GetByID(ctx, h.db, orderID)
+		if err != nil {
+			h.logger.Warn("orderdoc: refund email skipped — could not re-read order for the running total",
+				"order_id", orderID, "err", err)
+			return
+		}
+		if err := h.docMailer.SendRefund(ctx, orderID, refundAmount, post.RefundedAmount); err != nil {
+			h.logger.Warn("orderdoc: customer cancel refund email dispatch failed",
+				"order_id", orderID, "err", err)
+		}
+	}()
+}
+
 // storefrontOrderResponse is the customer-facing DTO.
 type storefrontOrderResponse struct {
 	ID            string `json:"id"`
@@ -680,10 +713,21 @@ func (h *OrderDetailHandler) Cancel(c *gin.Context) {
 	// gateway blip leaves the order cancelled + a pending ledger row for the
 	// sweeper, so the customer is never blocked on the cancel response.
 	if h.refunds != nil && o.PaymentStatus == string(order.PaymentStatusPaid) {
-		if _, rerr := h.refunds.Refund(c.Request.Context(), orderrefund.RefundCommand{
+		res, rerr := h.refunds.Refund(c.Request.Context(), orderrefund.RefundCommand{
 			OrderID: orderID, Amount: nil, Reason: "order cancelled", Actor: "customer", ScopeID: "cancel",
-		}); rerr != nil {
+		})
+		switch {
+		case rerr != nil:
+			// A gateway blip leaves a pending ledger row for the sweeper, so
+			// the money has NOT moved yet. Deliberately no refund email here:
+			// telling a customer they have been refunded when the refund is
+			// still queued is worse than telling them nothing (#169).
 			h.logger.Warn("cancel auto-refund deferred", "order_id", orderID, "err", rerr)
+		case res.AlreadyDone:
+			// Idempotent replay of a refund that already happened — the email
+			// went out the first time.
+		case res.Amount.IsPositive():
+			h.dispatchRefundEmail(orderID, res.Amount)
 		}
 	}
 

--- a/services/marketplace-api/internal/payment/razorpay_test.go
+++ b/services/marketplace-api/internal/payment/razorpay_test.go
@@ -19,7 +19,13 @@ func TestRazorpayRefund_SendsIdempotencyHeaderAndNotes(t *testing.T) {
 	var body []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotKey = r.Header.Get("X-Refund-Idempotency")
-		body, _ = io.ReadAll(r.Body)
+		var readErr error
+		// Swallowing this made a read failure look like an assertion failure
+		// on the body below (#169). t.Errorf is safe from a handler
+		// goroutine; t.Fatalf is not.
+		if body, readErr = io.ReadAll(r.Body); readErr != nil {
+			t.Errorf("read request body: %v", readErr)
+		}
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"id":"rfnd_1","status":"processed","amount":5000}`))
 	}))

--- a/services/marketplace-api/internal/payment/stripe.go
+++ b/services/marketplace-api/internal/payment/stripe.go
@@ -232,6 +232,18 @@ func stripeRefundReason(raw string) string {
 
 // RefundPayment creates a refund via POST /v1/refunds.
 func (s *StripeGateway) RefundPayment(ctx context.Context, in RefundInput) (*Refund, error) {
+	// An unconfigured key is a local configuration fault, not a Stripe one.
+	// Sent as empty basic auth it comes back as a bare 401, which reads as
+	// "Stripe rejected our credentials" and sends an operator to the Stripe
+	// dashboard mid-incident instead of to their own config (#169).
+	//
+	// Scoped to the refund path deliberately: that is the surface #164/#169
+	// cover, and the other Stripe calls have their own callers and tests.
+	// The same guard would suit them.
+	if s.apiKey == "" {
+		return nil, fmt.Errorf("stripe: refund payment: no API key configured for this store")
+	}
+
 	amountMinor := toMinorUnits(in.Amount, in.CurrencyCode)
 
 	form := url.Values{}

--- a/services/marketplace-api/internal/payment/stripe_emptykey_test.go
+++ b/services/marketplace-api/internal/payment/stripe_emptykey_test.go
@@ -1,0 +1,47 @@
+package payment
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+// An unconfigured API key must fail LOCALLY, before any request leaves the
+// process (#169).
+//
+// Without this, an empty key is sent as empty basic auth and Stripe answers
+// 401 — so a missing credential is indistinguishable from a revoked or wrong
+// one. During a refund incident that points the operator at Stripe's
+// dashboard instead of at their own configuration, which is the expensive
+// kind of misdirection.
+func TestStripeRefund_EmptyAPIKeyFailsBeforeSendingRequest(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	g := NewStripeGateway("", "secret", "test")
+	g.baseURL = srv.URL
+
+	_, err := g.RefundPayment(context.Background(), RefundInput{
+		ProviderPaymentID: "pi_1",
+		Amount:            decimal.RequireFromString("10.00"),
+		CurrencyCode:      "USD",
+	})
+	if err == nil {
+		t.Fatal("RefundPayment with an empty API key returned nil error")
+	}
+	if called {
+		t.Error("a request reached Stripe despite there being no API key; the guard must short-circuit first")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "api key") {
+		t.Errorf("error = %q, want it to name the missing API key so the operator "+
+			"looks at configuration rather than at Stripe", err)
+	}
+}


### PR DESCRIPTION
Design spec for turning break-glass on. No code — this is the artifact to review before implementation.

## The blocker is one stub, and it gates two features

`authbffclient.SessionIssuer` has only a `NoopIssuer` that always errors. It is referenced by exactly two files: `break_glass_login.go` and `sso_login.go`. **Neither route is mounted**, and implementing the issuer unblocks both.

The rest is more finished than "not built" suggests — ~60KB of `breakglass/` (credentials, TOTP, lockouts, rotation, audit, Slack), a complete login handler, applied migrations, and the platform **read** path already mounted at `main.go:2338`.

## Two findings that change the shape of the work

**1. Break-glass secrets live in a backend we just decommissioned.** P13 stores each account's password + TOTP in **GCP Secret Manager**, which milestone 10 retired — secrets deleted, IAM revoked. `Bootstrapper` writes Secret Manager *before* the DB row, so provisioning would fail at step one. Porting to OpenBao is a prerequisite, not cleanup. It is a small port: `breakglass.SecretClient` is a 2-method interface and `carriersecrets.BaoClient` already provides both.

**2. Nothing downstream needs to change** — verified against the running cluster, not assumed:
- `marketplace-api` authenticates with `auth.HeaderTrustAuth` (`X-User-Id`/`X-Tenant-Id`), not GIP token validation
- the admin API's Istio policy `allow-marketplace-api-admin-callers` is **mTLS workload-identity** based and requires no JWT; the JWT `RequestAuthentication`s live at `istio-ingress`, on the browser hop

So a break-glass session's deliberately-empty IdP token fields never reach a validator. Session-cookie trust is **complete for the admin surface**, not a reduced-capability compromise.

## Corrections to earlier assumptions

- `session_issuer.go`'s comment says the endpoint should be **mTLS-gated**. auth-bff's actual `/internal` group uses a Bearer service key plus rate limiting. The spec follows the pattern that exists rather than adding a second auth mechanism for one endpoint.
- Break-glass is for **the tenant's own SSO being broken**, not "the IdP is down". GIP and auth-bff are up. Narrower than it sounds, and it is what rules out minting a GIP custom token.
- P13's Terraform provisions a `break-glass-responders` group + IAM on GCP SM secrets that no longer exist — dead policy to remove.

## Sharp edge called out

`auth_context` must be explicitly allow-listed and never default to `staff`; a typo would silently mint a full staff session. And every caller of `session-exchange` needs auditing for an assumed non-empty `access_token` before this is mounted.

Refs #642, #404.