### PR TITLE
feat(billing): a catalog parity difference must arrive somewhere, not just a log (#328 gap 3)

### DIFF
--- a/.planning/quick/260904-pm1-parity-metrics/PLAN.md
+++ b/.planning/quick/260904-pm1-parity-metrics/PLAN.md
@@ -1,0 +1,124 @@
+---
+id: 260904-pm1
+slug: parity-metrics
+date: 2026-09-04
+issue: tesserix-home#328 (gap 3)
+kind: quick
+---
+
+# Make a catalog parity difference something that is noticed
+
+## Gap 3 as filed, and why the answer is not a table
+
+tesserix-home#328's third gap says:
+
+> *"The evidence trail is logs, not a table. The monitor calls `slog` and persists
+> nothing … Judging 'durably zero' will mean a log query over a window, and pod
+> restarts do not reset the underlying data but do reset what `kubectl logs` can show."*
+
+That was written while "durably zero" was a **cutover gate** — a decision someone was
+going to make once, by looking. The cutover shipped (#631, #632), so the question the
+table was for is answered and will not be asked again.
+
+The ongoing need is different, and measuring it changes the answer:
+
+| | state |
+|---|---|
+| `consolecatalog` exports a Prometheus metric | **no** — the package imports only `log/slog` |
+| any alert rule mentions catalog or pricing | **no** — `tesserix-k8s/k8s/cluster/prometheus/rules/` has cnpg, subscription, white_label_app, and nothing else |
+| evidence is durable | yes — Cloud Logging retains it; only `kubectl logs` is truncated by restarts |
+
+So the real defect is not that the evidence is hard to query. **It is that a parity
+difference in production would be written to a log that nothing watches.** A table
+would not fix that: a table also has to be looked at, and nobody is looking.
+
+What is needed is for a difference to *arrive somewhere*. That is a metric and an
+alert, and the repo already has the pattern — `internal/campaignbudget/metrics.go`
+declares metrics and `main.go:962` registers them with
+`prometheus.DefaultRegisterer`.
+
+## Why this matters more since #648
+
+Before, `catalog.go` was hand-maintained and the parity check caught a human forgetting
+to update it. Since #648 the fallback is **generated from the console**, so a
+difference now means something narrower and more surprising: the console moved and
+nobody regenerated, or someone hand-edited a generated file. Both are exactly the
+kind of thing that goes unnoticed for weeks — the catalog keeps working, because the
+console is authoritative and the fallback is only consulted when the console is
+unreachable. **The failure is silent until the day it is load-bearing.**
+
+## The distinction that must survive into the metrics
+
+`Result.Compared` is separate from `Result.Differences` for a reason the package states:
+
+> *"A failed read must not look like agreement: reporting zero differences when the
+> console could not be reached would make an outage indistinguishable from a clean run."*
+
+A naive single gauge re-creates that defect precisely. If the monitor stops being able
+to reach the console, `differences` stays at its last value — or worse, is never set
+and reads as absent-or-zero — and the alert stays quiet forever. **A monitor that has
+stopped checking must not look like a monitor that keeps finding nothing.**
+
+So the metrics must make "we compared and found nothing" distinguishable from "we did
+not compare", and the alerting must fire on the second as well as the first.
+
+## Tasks
+
+### T1 — Metrics on the parity monitor
+
+`internal/billing/consolecatalog/metrics.go`, following `campaignbudget/metrics.go`'s
+shape, registered from `cmd/marketplace-api/main.go` beside the existing
+`campaignbudget.MustRegisterMetrics`.
+
+At minimum the monitor must express:
+
+- how many differences the **last completed comparison** found
+- when a comparison last **completed successfully** — the staleness signal, and the
+  half that keeps a dead monitor from reading as a clean one
+- that a comparison **failed** (console unreachable, bad read), counted separately
+  from finding differences
+
+Do not add a metric whose only reading is "0" in every state that matters; each one
+must have a state where it is the thing that tells you.
+
+`Monitor.Check`/`report` currently take a `*slog.Logger` and nothing else. Keep logging
+exactly as it is — the log line is still the human-readable evidence and #328's
+"clean runs log at info so the evidence trail is visible" reasoning still holds. The
+metrics are added beside it, not instead.
+
+### T2 — The alert rule
+
+A `PrometheusRule` in `tesserix-k8s/k8s/cluster/prometheus/rules/`, added to that
+directory's `kustomization.yaml`, following `subscription.yaml`'s shape (it has a
+`subscription_test.yaml` beside it — check whether that is a promtool unit test and
+match the convention if so).
+
+Two alerts, not one:
+
+1. **Differences found** — the catalog and the fallback disagree.
+2. **No successful comparison in N hours** — the monitor is not running, or cannot
+   reach the console. Without this, silence is ambiguous and the first alert is
+   unreliable by construction.
+
+Pick N from the real interval: the monitor runs every 15m in production
+(`consolecatalog: parallel run enabled interval=15m0s`), so N should tolerate a
+restart and a deploy without crying wolf. Say in the rule's annotation what an
+operator should DO, not just what happened — a difference means regenerate
+`catalog_data.go` from the console (`gencatalog -source=console`) and work out why it
+drifted.
+
+## Out of scope
+
+- A persisted table. Argued above.
+- Changing the comparison itself, the cache, or anything on the serving path.
+- Console-side parity (`plan_catalog_parity_runs`) — a different comparison, already
+  queryable.
+
+## Verification
+
+```
+cd services/marketplace-api && go build ./... && go test -race -count=1 ./...
+```
+
+For the rule, whatever `promtool` invocation the existing rules are checked with — find
+it before inventing one.

--- a/services/marketplace-api/cmd/marketplace-api/catalog_parity.go
+++ b/services/marketplace-api/cmd/marketplace-api/catalog_parity.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/mark8ly/marketplace-api/internal/billing/consolecatalog"
 	"github.com/mark8ly/marketplace-api/pkg/config"
 )
@@ -76,6 +78,18 @@ func startCatalogParityRun(cfg *config.Config, log *slog.Logger) {
 	if interval <= 0 {
 		interval = 15 * time.Minute
 	}
+
+	// Registered here rather than beside campaignbudget.MustRegisterMetrics in
+	// main.go, and specifically AFTER the credentials gate above. A registered
+	// gauge publishes zero at once, and a "last successful comparison" of zero
+	// reads as 1970 — so registering on a pod where the parallel run is
+	// switched off would keep the staleness alert firing against a deployment
+	// doing exactly what it is configured to do. Absent series say "not
+	// enabled here"; present-and-stale says "enabled and not working".
+	//
+	// Safe to call once: this function has a single call site, in main.go's
+	// admin-mode block.
+	consolecatalog.MustRegisterMetrics(prometheus.DefaultRegisterer)
 
 	monitor := consolecatalog.NewMonitor(consolecatalog.NewClient(cc, log), interval, log)
 	log.Info("consolecatalog: parallel run enabled",

--- a/services/marketplace-api/internal/billing/consolecatalog/metrics.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/metrics.go
@@ -1,0 +1,89 @@
+package consolecatalog
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Prometheus metrics for the parity monitor (tesserix-home#328 gap 3).
+//
+// # Why metrics and not a table
+//
+// Before this file the monitor's only output was a log line, and nothing
+// watched it. A parity difference in production was therefore written
+// somewhere durable and never read. A persisted table would have had the same
+// defect — a table also has to be looked at. What was missing is a difference
+// ARRIVING somewhere, which is a metric plus an alert.
+//
+// This matters more since the compiled fallback became GENERATED from the
+// console (#648): a difference now means the console moved and nobody
+// regenerated, or someone hand-edited a generated file. Neither is visible in
+// day-to-day behaviour, because the fallback is only consulted when the
+// console is unreachable. The failure is silent until the day it is
+// load-bearing.
+//
+// # The distinction these three metrics exist to preserve
+//
+// Result.Compared is deliberately separate from Result.Differences, because
+// "a failed read must not look like agreement". A single gauge would re-create
+// that defect exactly: if the monitor stopped reaching the console,
+// ParityDifferences would hold its last value — or never be set, and read as
+// zero — and would say "fine" forever. A monitor that has STOPPED CHECKING
+// must not look like a monitor that KEEPS FINDING NOTHING.
+//
+// So the three are read together, and each has a state where it is the one
+// that tells you:
+//
+//   - ParityDifferences > 0            → the catalog and the fallback disagree.
+//   - LastSuccessTimestamp stale       → nothing has been compared lately, so
+//     ParityDifferences describes the past and means nothing about now. This
+//     is the half that keeps a dead monitor from reading as a clean one.
+//   - CheckFailuresTotal rising        → the monitor IS running and is failing
+//     its reads. It separates "cannot reach the console" from "not running at
+//     all", which the stale timestamp alone cannot tell apart.
+//
+// Deliberately absent: a "checks succeeded" counter. Its every reading is
+// already implied by the timestamp advancing, and it would be zero in exactly
+// the states that matter.
+var (
+	// ParityDifferences is how many differences the LAST COMPLETED comparison
+	// found. It is not touched by a failed read, so its value always describes
+	// a real comparison — read it together with LastSuccessTimestamp, which
+	// says when that comparison was.
+	ParityDifferences = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "mark8ly_catalog_parity_differences",
+			Help: "Differences the last completed console/compiled catalog comparison found. Only meaningful alongside mark8ly_catalog_parity_last_success_timestamp_seconds — a failed read leaves this at its previous value.",
+		},
+	)
+	// LastSuccessTimestamp is when a comparison last COMPLETED — i.e. the
+	// console was read and the two sources were compared. A failed read must
+	// never advance it; that is what makes silence detectable.
+	LastSuccessTimestamp = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "mark8ly_catalog_parity_last_success_timestamp_seconds",
+			Help: "Unix time of the last COMPLETED console/compiled catalog comparison. Never advanced by a failed read, so staleness means the monitor is dead or cannot reach the console.",
+		},
+	)
+	// CheckFailuresTotal counts comparisons that could not be made because the
+	// console read failed. Counted separately from finding differences: an
+	// outage is not a disagreement.
+	CheckFailuresTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "mark8ly_catalog_parity_check_failures_total",
+			Help: "Comparisons abandoned because the console catalog could not be read. Counted separately from differences found — an unreachable console is not a disagreement.",
+		},
+	)
+)
+
+// MustRegisterMetrics registers the parity monitor's metrics with reg.
+// Panics on duplicate registration — call once at startup.
+//
+// Called from startCatalogParityRun AFTER the credentials gate, not
+// unconditionally from main. Registering a gauge publishes it at zero
+// immediately, and a LastSuccessTimestamp of zero reads as "last compared in
+// 1970" — so registering on a pod where the parallel run is switched off
+// would make the staleness alert fire forever on a deployment that is
+// behaving exactly as configured. Absent series mean "not enabled here";
+// present-but-stale means "enabled and not working", which is the thing worth
+// paging about.
+func MustRegisterMetrics(reg prometheus.Registerer) {
+	reg.MustRegister(ParityDifferences, LastSuccessTimestamp, CheckFailuresTotal)
+}

--- a/services/marketplace-api/internal/billing/consolecatalog/metrics_test.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/metrics_test.go
@@ -1,0 +1,108 @@
+package consolecatalog_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/consolecatalog"
+)
+
+// The metrics exist so a parity difference ARRIVES somewhere instead of being
+// written to a log nothing watches (tesserix-home#328 gap 3). These tests pin
+// the one property that makes them worth having: a monitor that has stopped
+// checking must not read like a monitor that keeps finding nothing.
+
+// snapshot is what the three metrics say right now.
+type snapshot struct {
+	differences float64
+	lastSuccess float64
+	failures    float64
+}
+
+func readMetrics() snapshot {
+	return snapshot{
+		differences: testutil.ToFloat64(consolecatalog.ParityDifferences),
+		lastSuccess: testutil.ToFloat64(consolecatalog.LastSuccessTimestamp),
+		failures:    testutil.ToFloat64(consolecatalog.CheckFailuresTotal),
+	}
+}
+
+// alwaysCheck builds a monitor whose interval never suppresses a refetch, so
+// each Check is a real attempt.
+func alwaysCheck(f consolecatalog.Fetcher) *consolecatalog.Monitor {
+	return consolecatalog.NewMonitor(f, time.Nanosecond, nil)
+}
+
+func TestMetrics_ACleanComparisonRecordsZeroDifferencesAndStampsTheTime(t *testing.T) {
+	before := readMetrics()
+	m := alwaysCheck(&stubFetcher{catalog: matchingCatalog()})
+
+	m.Check(context.Background())
+
+	got := readMetrics()
+	require.Zero(t, got.differences)
+	require.Greater(t, got.lastSuccess, before.lastSuccess,
+		"a completed comparison must advance the success timestamp — it is the only "+
+			"evidence that the zero above describes now rather than last week")
+	require.Equal(t, before.failures, got.failures,
+		"a clean comparison is not a failure")
+}
+
+func TestMetrics_ADifferenceIsCounted(t *testing.T) {
+	c := matchingCatalog()
+	c.Prices[0].UnitAmountMinor += 1
+	m := alwaysCheck(&stubFetcher{catalog: c})
+
+	m.Check(context.Background())
+
+	require.Equal(t, float64(1), readMetrics().differences)
+}
+
+// THE test. It is the metrics-side statement of the invariant Result.Compared
+// exists for: "a failed read must not look like agreement".
+//
+// Both collapsed implementations fail here:
+//
+//   - stamping LastSuccessTimestamp on a failed read too — then a monitor that
+//     can no longer reach the console goes on looking freshly-checked forever,
+//     and the staleness alert never fires. Caught by the timestamp assertion.
+//   - Set(0) on ParityDifferences when a read fails — then an outage reports
+//     exactly what agreement reports, which is the original defect with extra
+//     steps. Caught by the differences assertion, which requires the value
+//     from the last REAL comparison to survive.
+func TestMetrics_AFailedReadIsDistinguishableFromACleanRun(t *testing.T) {
+	// First a real comparison that finds something, so "differences" holds a
+	// value a collapse would have to destroy.
+	diverged := matchingCatalog()
+	diverged.Prices[0].UnitAmountMinor += 1
+	m := alwaysCheck(&stubFetcher{catalog: diverged})
+	m.Check(context.Background())
+
+	afterCompare := readMetrics()
+	require.Equal(t, float64(1), afterCompare.differences)
+
+	// Now the console goes away. Sleep first so a wrongly-stamped timestamp
+	// is unmistakably different rather than a rounding coincidence.
+	time.Sleep(5 * time.Millisecond)
+	failing := alwaysCheck(&stubFetcher{err: errors.New("console 503")})
+	res := failing.Check(context.Background())
+	require.False(t, res.Compared)
+
+	got := readMetrics()
+	require.Equal(t, afterCompare.lastSuccess, got.lastSuccess,
+		"a failed read must NOT advance the last-success timestamp: if it does, a "+
+			"monitor that has stopped checking is indistinguishable from one that "+
+			"keeps finding nothing, and the staleness alert can never fire")
+	require.Equal(t, afterCompare.differences, got.differences,
+		"a failed read must NOT rewrite the difference count: reporting zero because "+
+			"the console was unreachable is exactly the outage-looks-like-agreement "+
+			"defect Result.Compared exists to prevent")
+	require.Equal(t, afterCompare.failures+1, got.failures,
+		"the failure must be counted somewhere — it is what separates 'running and "+
+			"cannot reach the console' from 'not running at all'")
+}

--- a/services/marketplace-api/internal/billing/consolecatalog/parity.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/parity.go
@@ -79,6 +79,11 @@ func (m *Monitor) Check(ctx context.Context) Result {
 	res := Result{}
 	if err != nil {
 		res.Err = err
+		// Counted, but ParityDifferences and LastSuccessTimestamp are left
+		// untouched: Result.Compared's whole reason for existing is that a
+		// failed read must not look like agreement, and the metrics have to
+		// carry that same distinction or they re-create the defect.
+		CheckFailuresTotal.Inc()
 		m.warn("consolecatalog: could not read the console catalog; comparison skipped", "error", err)
 	} else {
 		diffs := Diff(catalog, pricing.AllDescriptors())
@@ -90,6 +95,11 @@ func (m *Monitor) Check(ctx context.Context) Result {
 		} else {
 			res.Sample = diffs
 		}
+		// Set the count first and stamp the time second, so a scrape landing
+		// between the two reads a stale timestamp beside a fresh count rather
+		// than a fresh timestamp vouching for a count not yet written.
+		ParityDifferences.Set(float64(res.Differences))
+		LastSuccessTimestamp.SetToCurrentTime()
 		m.report(res)
 	}
 


### PR DESCRIPTION
Closes the last open item on tesserix-home#328 — but not the way gap 3 asks for, and
the reasoning is the point.

## Gap 3 asks for a table. Measuring the system says otherwise

Gap 3 was written while "durably zero" was a **cutover gate** — a decision someone was
going to make once, by looking. The cutover shipped (#631, #632) and is verified in
production. That question will not be asked again.

What is true now:

| | state |
|---|---|
| `consolecatalog` exports a Prometheus metric | **no** — imports only `log/slog` |
| any alert rule mentions catalog or pricing | **no** |
| the evidence is durable | **yes** — Cloud Logging keeps it; only `kubectl logs` truncates |

So the defect is not that evidence is hard to query. **A parity difference would be
written to a log that nothing watches**, and a table would not fix that — a table also
has to be looked at.

Since #648 this matters more, not less: the fallback is now *generated* from the
console, so a difference means the console moved without regeneration, or someone
hand-edited a generated file. Both stay invisible for weeks, because the fallback only
gets consulted when the console is unreachable. **The failure is silent until the day
it is load-bearing.**

## The metrics, and where each one is the one that tells you

| metric | the state where it is decisive |
|---|---|
| `mark8ly_catalog_parity_differences` | >0 → console and `catalog_data.go` disagree |
| `mark8ly_catalog_parity_last_success_timestamp_seconds` | stale → nothing compared lately, so the gauge above describes the past |
| `mark8ly_catalog_parity_check_failures_total` | rising → the monitor **is** running and its reads are failing — separates "cannot reach the console" from "not running at all", which a stale timestamp alone cannot |

No "checks succeeded" counter: every reading of it is already implied by the timestamp
advancing, and it would sit at 0 in exactly the states that matter.

## The distinction this exists to preserve

`Result.Compared` is separate from `Result.Differences` because *"a failed read must
not look like agreement: reporting zero differences when the console could not be
reached would make an outage indistinguishable from a clean run."*

A single naive gauge re-creates that defect: a monitor that stops reaching the console
holds its last value and reads "fine" forever. **A monitor that has stopped checking
must not look like one that keeps finding nothing.**

So a failed read increments only the failure counter — it does **not** touch
`differences` and does **not** stamp `last_success`. `TestMetrics_AFailedReadIsDistinguishableFromACleanRun`
pins it, and both collapses were shown to fail it before being reverted:

```
stamp last_success on failure too  → expected: 1.7884871619e+09 / actual: 1.7884871620e+09
Set(0) on differences on failure   → expected: 1 / actual: 0
```

## One deliberate deviation from the plan

The plan said register in `main.go` beside `campaignbudget.MustRegisterMetrics`.
Registration happens inside `startCatalogParityRun`, **after the credentials gate**,
because a registered gauge publishes 0 immediately — and a `last_success` of 0 reads as
"last compared in 1970". Registering on a pod where the parallel run is switched off
would make the staleness alert fire forever against a deployment behaving exactly as
configured.

Absent series now mean "not enabled here"; present-and-stale means "enabled and not
working". Single call site, so `MustRegister` cannot double-fire.

Logging is byte-for-byte unchanged — gap 3's own reasoning that a clean run logs at
info "so the evidence trail is visible" still holds.

## Alerts

In tesserix-k8s (companion PR): `CatalogParityDifference` and `CatalogParityStale`.
Two alerts, not one — without the second, silence is ambiguous and the first is
unreliable by construction.

## Test plan

- [x] `go build ./...` — exit 0
- [x] `go test -race -count=1 ./...` — exit 0, 159 packages, zero FAIL
- [x] The collapse test shown failing against both naive implementations, then passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vwnnQQ2pfJJ58QjTkfPTB