### PR TITLE
fix(billing): the purchase page's full-year line showed the one-time setup fee, not the annual add-on price (#650)

### DIFF
--- a/apps/admin/app/(admin)/settings/billing/pro-app-purchase/ProAppPurchaseClient.tsx
+++ b/apps/admin/app/(admin)/settings/billing/pro-app-purchase/ProAppPurchaseClient.tsx
@@ -19,13 +19,20 @@
  *   - After a successful 201, we redirect to the credentials upload page.
  *
  * Proration preview:
- *   - Derived client-side from CurrentPlan.periodEnd (co-termination date)
- *     and amount_due_cents from the purchase response preview shown to the
- *     merchant before submission via a static calculation.
- *   - The annual Pro add-on list price is $2,000/yr (server-side ProrationCents
- *     includes a setup component too — we show `amount_due_cents` from the
- *     actual response AFTER purchase; pre-purchase we show "$2,000/yr" as
- *     the full-year anchor).
+ *   - The co-termination date is CurrentPlan.periodEnd. The amount actually
+ *     charged comes back as `amount_due_cents` on the purchase response, so
+ *     before purchase all this page can honestly show is the list price.
+ *   - Per spec §3.4 the add-on lists at $199/mo — $2,388 for a full year —
+ *     plus a separate one-time, non-refundable $2,000 setup fee. Server-side
+ *     `ProrationCents` charges `(remaining_days / 365) × $2,388 + $2,000` up
+ *     front, so the up-front charge and the full-year figure are legitimately
+ *     different numbers. Conflating them is how the $2,000 setup fee once
+ *     ended up on the full-year line here.
+ *   - The full-year figure is read from SHARED_PRICING_CATALOGUE (generated
+ *     from the Go `pricing.ProAppAnnual` constant) rather than hardcoded, so
+ *     it cannot drift from the billing constants again. The add-on bills in
+ *     USD globally (spec §4.1.2), so the USD row is read explicitly and
+ *     rendered as USD — never relabelled with the merchant's currency.
  *
  * Accessibility:
  *   - Checkbox associated via htmlFor/id.
@@ -44,7 +51,11 @@ import { usePurchaseProApp } from '@/lib/api/subscription/hooks/useProApp'
 import { ApiError } from '@/lib/api/client'
 import { useToast } from '@/components/feedback/Toaster'
 import { subscriptionCopy } from '@/lib/copy/subscription'
-import { Money } from '@repo/ui/subscription'
+import {
+  Money,
+  SHARED_PRICING_CATALOGUE,
+  getAddOnPrice,
+} from '@repo/ui/subscription'
 import { formatBillingDate } from '@/lib/format/date'
 
 // ---------------------------------------------------------------------------
@@ -57,8 +68,14 @@ interface ProAppPurchaseClientProps {
 
 const copy = subscriptionCopy.proApp.purchase
 
-/** Annual White-label App add-on price in cents (used for the next-year line). */
-const ANNUAL_ADDON_PRICE_CENTS = 200000
+/**
+ * Full-year White-label App add-on list price, in USD cents, for the
+ * next-year line. Derived from the shared catalogue rather than written
+ * here: the same figure lives in Go as `pricing.ProAppAnnual` and
+ * `appaddon.AppAnnualCents`, and a third hand-maintained copy is exactly
+ * what drifted before.
+ */
+const { price: proAppUsdPrice } = getAddOnPrice(SHARED_PRICING_CATALOGUE.proApp, 'USD')
 
 /** RHF form schema — only the acknowledgement checkbox. */
 const formSchema = z.object({
@@ -129,10 +146,9 @@ function AlreadyActiveState() {
 
 interface ProrationPreviewCardProps {
   renewalAt: string | null
-  currency: string
 }
 
-function ProrationPreviewCard({ renewalAt, currency }: ProrationPreviewCardProps) {
+function ProrationPreviewCard({ renewalAt }: ProrationPreviewCardProps) {
   const formattedRenewal = formatBillingDate(renewalAt)
 
   return (
@@ -154,7 +170,7 @@ function ProrationPreviewCard({ renewalAt, currency }: ProrationPreviewCardProps
         <p>
           Next full-year charge:{' '}
           <span className="font-medium text-[var(--ink-900)]">
-            <Money amount={ANNUAL_ADDON_PRICE_CENTS} currency={currency} />
+            <Money amount={proAppUsdPrice.annual} currency="USD" />
           </span>
           {renewalAt && (
             <> on {formattedRenewal}</>
@@ -173,10 +189,9 @@ function ProrationPreviewCard({ renewalAt, currency }: ProrationPreviewCardProps
 interface PurchaseFormProps {
   storeId: string
   renewalAt: string | null
-  currency: string
 }
 
-function PurchaseForm({ storeId, renewalAt, currency }: PurchaseFormProps) {
+function PurchaseForm({ storeId, renewalAt }: PurchaseFormProps) {
   const router = useRouter()
   const { toast } = useToast()
   const mutation = usePurchaseProApp(storeId)
@@ -231,7 +246,7 @@ function PurchaseForm({ storeId, renewalAt, currency }: PurchaseFormProps) {
       aria-label={copy.heading}
       className="max-w-2xl space-y-6"
     >
-      <ProrationPreviewCard renewalAt={renewalAt} currency={currency} />
+      <ProrationPreviewCard renewalAt={renewalAt} />
 
       {/* Apple 4.2.6 acknowledgement */}
       <div className="space-y-1">
@@ -321,10 +336,6 @@ export function ProAppPurchaseClient({ storeId }: ProAppPurchaseClientProps) {
   }
 
   return (
-    <PurchaseForm
-      storeId={storeId}
-      renewalAt={plan.periodEnd}
-      currency={plan.billingCurrency}
-    />
+    <PurchaseForm storeId={storeId} renewalAt={plan.periodEnd} />
   )
 }

--- a/apps/admin/tests/unit/app/settings/billing/pro-app-purchase/ProAppPurchaseClient.test.tsx
+++ b/apps/admin/tests/unit/app/settings/billing/pro-app-purchase/ProAppPurchaseClient.test.tsx
@@ -79,8 +79,12 @@ vi.mock('@/lib/api/subscription/hooks/useBilling', () => ({
   useCurrentPlan: (...args: unknown[]) => mockUseCurrentPlan(...args),
 }))
 
-// Money component stub — renders amount/100 formatted simply
-vi.mock('@repo/ui/subscription', () => ({
+// Money component stub — renders amount/100 formatted simply.
+// Everything else (SHARED_PRICING_CATALOGUE, getAddOnPrice) stays REAL: the
+// component reads the add-on's full-year price out of the generated
+// catalogue, so stubbing it would make the price assertions vacuous.
+vi.mock('@repo/ui/subscription', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@repo/ui/subscription')>()),
   Money: ({ amount, currency }: { amount: number; currency: string }) => (
     <span>{currency.toUpperCase()} {(amount / 100).toFixed(2)}</span>
   ),
@@ -194,6 +198,36 @@ describe('ProAppPurchaseClient', () => {
     expect(screen.getByRole('form', { name: /add the white-label app/i })).toBeInTheDocument()
     expect(screen.getByRole('checkbox')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /add to plan/i })).toBeInTheDocument()
+  })
+
+  it('next full-year charge is the $2,388 add-on list price, not the $2,000 setup fee', () => {
+    mockUseCurrentPlan.mockReturnValue({
+      data: makePlan(),
+      isLoading: false,
+      isError: false,
+    })
+    renderComponent()
+
+    // $199/mo x 12 = $2,388/yr (spec 3.4), matching pricing.ProAppAnnual and
+    // appaddon.AppAnnualCents. $2,000 is the ONE-TIME setup fee and must
+    // never appear on this line.
+    expect(screen.getByText(/next full-year charge/i)).toBeInTheDocument()
+    expect(screen.getByText('USD 2388.00')).toBeInTheDocument()
+    expect(screen.queryByText('USD 2000.00')).not.toBeInTheDocument()
+  })
+
+  it('full-year charge stays in USD for a non-USD merchant (add-on bills in USD globally)', () => {
+    mockUseCurrentPlan.mockReturnValue({
+      data: makePlan({ billingCurrency: 'INR' }),
+      isLoading: false,
+      isError: false,
+    })
+    renderComponent()
+
+    // Spec 4.1.2: the add-on is billed in USD everywhere, so the USD amount
+    // must not be relabelled with the merchant's billing currency.
+    expect(screen.getByText('USD 2388.00')).toBeInTheDocument()
+    expect(screen.queryByText(/^INR /)).not.toBeInTheDocument()
   })
 
   it('acknowledgement checkbox controls submit button state', async () => {

--- a/services/marketplace-api/internal/billing/pricing/proapp_parity_test.go
+++ b/services/marketplace-api/internal/billing/pricing/proapp_parity_test.go
@@ -1,0 +1,58 @@
+package pricing_test
+
+// The Pro+App add-on's annual price is written down twice in Go, in packages
+// that have no relationship to each other:
+//
+//   - pricing.ProAppAnnual  — the DISPLAY figure, from which
+//     cmd/genpricing generates the TypeScript catalogue the admin and
+//     onboarding apps render.
+//   - appaddon.AppAnnualCents — the BILLING figure, which appaddon.ProrationCents
+//     multiplies by the remaining fraction of the anchor year to compute the
+//     amount actually invoiced.
+//
+// Nothing imported one from the other and nothing asserted they agreed, so a
+// third hand-written copy in the admin purchase page was free to disagree with
+// both (tesserix/mark8ly#650) and did. Reconciling the copies removes that
+// third one; this test closes the drift between the two that remain.
+//
+// This lives in the EXTERNAL test package `pricing_test` on purpose. `pricing`
+// and `appaddon` import each other in neither direction today, and asserting
+// the two constants agree must not be what creates that edge. An external test
+// package is never imported by anything, so it can depend on both packages
+// without any possibility of an import cycle — and it stays cycle-proof even
+// if a future change makes one of the two packages import the other.
+
+import (
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/appaddon"
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProAppAnnualMatchesBillingConstant pins the display figure to the figure
+// that is actually charged. If these ever diverge, a merchant is quoted one
+// number on the pricing page and invoiced another.
+func TestProAppAnnualMatchesBillingConstant(t *testing.T) {
+	require.Equal(t, appaddon.AppAnnualCents, pricing.ProAppAnnual.UnitAmountMinor,
+		"pricing.ProAppAnnual (displayed) must equal appaddon.AppAnnualCents (billed)")
+}
+
+// TestProAppMonthlyTimesTwelveIsAnnual pins the internal consistency of the
+// display pair: spec §3.4 defines the annual figure as twelve monthly charges
+// ($199 × 12 = $2,388) — there is no annual discount on the add-on.
+func TestProAppMonthlyTimesTwelveIsAnnual(t *testing.T) {
+	require.Equal(t, pricing.ProAppAnnual.UnitAmountMinor, pricing.ProAppMonthly.UnitAmountMinor*12,
+		"spec §3.4: the add-on's annual price is exactly 12 × the monthly price, with no annual discount")
+	require.Equal(t, pricing.ProAppMonthly.Currency, pricing.ProAppAnnual.Currency,
+		"both add-on amounts are denominated in the same currency (spec §4.1.2: USD only)")
+}
+
+// TestProAppAnnualIsNotTheSetupFee guards the specific confusion behind #650:
+// $2,000 is the ONE-TIME setup charge, not a full year of add-on fees. The two
+// are added together by appaddon.ProrationCents at purchase, which is why a
+// purchase-time total and a full-year price are legitimately different numbers.
+func TestProAppAnnualIsNotTheSetupFee(t *testing.T) {
+	require.NotEqual(t, appaddon.SetupFeeCents, pricing.ProAppAnnual.UnitAmountMinor,
+		"the annual add-on price must never be the one-time setup fee")
+}


### PR DESCRIPTION
The Pro+App purchase page — the last screen before a merchant commits — rendered:

> Next full-year charge: **$2,000.00** on {renewal date}.

$2,000 is not the annual price. It is exactly `SetupFeeCents`, the **one-time**
non-refundable setup charge. The annual price is **$2,388** ($199 × 12).

## Three copies, one wrong

| where | value |
|---|---|
| `pricing/display_extras.go` — `ProAppAnnual` | 238800 ($2,388) — marketing + admin `/pricing` |
| `appaddon/proration.go` — `AppAnnualCents` | 2388_00 ($2,388) — what Stripe is actually invoiced |
| `ProAppPurchaseClient.tsx` — `ANNUAL_ADDON_PRICE_CENTS` | **200000 ($2,000)** — the purchase page |

Nothing related them: no import path between `pricing` and `appaddon` in either
direction, no shared constant, no test.

**The spec settles which is wrong.** `2026-04-17-subscription-model-design.md` §3.4:
*"The **$199/mo + $2,000 non-refundable setup**"*. The two Go constants are right; the
TypeScript one conflated the setup fee with the annual price, and its own doc comment
asserted "$2,000/yr" as fact.

## Blast radius: none

`store_subscriptions` in production has **0 rows**, and `has_white_label_app_add_on` is
true on **0**. Nobody has ever been shown this figure at purchase, because nobody has
reached purchase. A latent defect, not an incident — no remediation needed.

## The fix removes the third copy rather than correcting it

Changing `200000` to `238800` would leave a third hand-maintained copy free to drift
again. The generated catalogue already carries the right number, so the page now derives it:

```ts
const { price: proAppUsdPrice } = getAddOnPrice(SHARED_PRICING_CATALOGUE.proApp, 'USD')
…
<Money amount={proAppUsdPrice.annual} currency="USD" />
```

Same call shape `PricingClient.tsx:296` already uses. Three copies become two, and the
two survivors are now related by a test.

## A second bug on the same line

The old code rendered a USD-denominated amount labelled with the merchant's
`billingCurrency` — so an INR merchant was shown **"₹2,000"**: wrong number *and* wrong
currency. The add-on bills in USD globally (spec §4.1.2), which is why `PricingClient`
renders `currency="USD"` literally. This now does the same, and the dead `currency`
prop is dropped from `ProrationPreviewCard`/`PurchaseForm`.

## Tests

**Go** — `proapp_parity_test.go`, external `package pricing_test` importing both (neither
package imports the other; an external test package is never imported, so it cannot
cycle even if that changes later). Asserts display == billed, `ProAppMonthly × 12 ==
ProAppAnnual`, and `ProAppAnnual != SetupFeeCents` — the last guarding this exact confusion.

Mutation-proven:
```
AppAnnualCents → 2400_00 : expected 240000 / actual 238800
ProAppMonthly  → 19000   : expected 238800 / actual 228000
```

**Frontend** — the existing test mocked `@repo/ui/subscription` with **only** `Money`, so
the catalogue import would have been `undefined` and any price assertion vacuous. The
mock now spreads `importOriginal()` and stubs only `Money`. Two new tests: the line shows
`USD 2388.00` and never `USD 2000.00`, and stays USD for an INR merchant. Reverting the
component to `amount={200000}` fails both.

## What this does NOT claim

**No renewal path was found.** `AppAnnualCents` has one non-test consumer —
`ProrationCents`, called only from the one-off purchase invoice. `HasWhiteLabelAppAddOn`
appears in the purchase handler, `plangate`, refunds, cancellation finalisation, the
status loader, the model and the flag-flipping webhook; nothing schedules a recurring
add-on charge. Two of us looked independently.

So the page still states a future charge whose implementation cannot be located. This
commit makes the **number** agree with the spec and the billing constants; it asserts
nothing about billing behaviour, and touches no charging logic. That question stays open
on #650.

## Test plan

- [x] `go build ./...` — exit 0
- [x] `go test -race -count=1 ./...` — exit 0, 99 ok, zero FAIL
- [x] `npm run check-types` (`tsc --noEmit`) — exit 0
- [x] `npm test` — 130 files, 1119 tests, all pass
- [x] `npm run build` (`next build`) — compiled; run because this adds a new `@repo/ui`
      import to a client component, which typecheck alone would not catch
- [x] Both Go mutations and the frontend mutation shown failing, then restored

Refs #650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vwnnQQ2pfJJ58QjTkfPTB