### PR TITLE
docs: implementation plan for break-glass activation (#642)

### DIFF
--- a/docs/superpowers/plans/2026-09-04-break-glass-activation.md
+++ b/docs/superpowers/plans/2026-09-04-break-glass-activation.md
@@ -1,0 +1,724 @@
+# Break-Glass Activation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `SessionIssuer` so the break-glass login and per-tenant SSO routes become reachable, and move break-glass credentials off the decommissioned GCP Secret Manager onto OpenBao.
+
+**Architecture:** auth-bff gains one internal endpoint that mints a session cookie for an already-authenticated principal, on the existing `/internal` group (Bearer service key + rate limit). marketplace-api implements `SessionIssuer` as an HTTP client to it, swaps the break-glass `SecretClient` to an OpenBao adapter, and mounts the two route groups that were written but never registered. No downstream service changes — verified: marketplace-api authenticates on `X-User-Id`/`X-Tenant-Id`, and its Istio policy is mTLS workload-identity with no JWT requirement.
+
+**Tech Stack:** Go 1.26, Gin, `openbao/openbao/api`, AES-256-GCM cookie sessions, bcrypt, TOTP (`pquerna/otp`).
+
+**Spec:** [`docs/superpowers/specs/2026-09-04-break-glass-activation-design.md`](../specs/2026-09-04-break-glass-activation-design.md)
+
+## Global Constraints
+
+- **marketplace-api MUST NEVER sign or encrypt a session cookie.** Cookie cryptography stays in auth-bff. marketplace-api only passes a `Set-Cookie` string through.
+- **`auth_context` is an explicit allow-list**: `staff`, `customer`, `break_glass`. Reject anything else with 400. It must never default to `staff` — a typo would silently mint a full staff session.
+- **No secret value in any log line** — not the password, TOTP secret, session cookie, or service key. Log lengths and outcomes, never contents.
+- **Break-glass login responses stay uniform.** `{"error":"invalid_credentials"}` regardless of which factor failed; forensics goes to the audit log.
+- **bcrypt cost stays 12** (§12.4). **Secret-store write precedes the DB write** in `Bootstrapper`, so a store failure never leaves a `password_hash` referencing a non-existent blob.
+- Repo conventions: single-line commit messages, no signatures, conventional-commit prefixes.
+
+---
+
+### Task 1: `CookieStore.Encode` in auth-bff
+
+Extract the encrypt step from `Save` so a non-HTTP caller can produce a cookie value. `Save` must keep behaving identically.
+
+**Files:**
+- Modify: `auth-bff/internal/session/cookie.go:62-79`
+- Test: `auth-bff/internal/session/cookie_test.go`
+
+**Interfaces:**
+- Produces: `func (cs *CookieStore) Encode(sess *Session) (string, error)` — sets `IssuedAt`, marshals, AES-GCM encrypts, returns the raw cookie value.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestCookieStore_Encode_RoundTrips(t *testing.T) {
+	cs := NewCookieStore(testKeyHex, time.Hour, false)
+	in := &Session{UserID: "u1", TenantID: "t1", AuthContext: "break_glass"}
+
+	value, err := cs.Encode(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if value == "" {
+		t.Fatal("Encode returned an empty cookie value")
+	}
+
+	out, err := cs.LoadFromValue(value)
+	if err != nil {
+		t.Fatalf("LoadFromValue: %v", err)
+	}
+	if out.UserID != "u1" || out.AuthContext != "break_glass" {
+		t.Fatalf("round-trip mismatch: %+v", out)
+	}
+	if in.IssuedAt == 0 {
+		t.Fatal("Encode must stamp IssuedAt, as Save does")
+	}
+}
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: `cd auth-bff && go test ./internal/session/ -run TestCookieStore_Encode -v`
+Expected: FAIL — `cs.Encode undefined`
+
+- [ ] **Step 3: Implement, and make `Save` use it**
+
+```go
+// Encode stamps IssuedAt, marshals and encrypts the session, returning
+// the raw cookie value. Save writes this into an HTTP cookie; internal
+// endpoints that mint a session for another service use it directly.
+func (cs *CookieStore) Encode(sess *Session) (string, error) {
+	sess.IssuedAt = time.Now().Unix()
+
+	data, err := json.Marshal(sess)
+	if err != nil {
+		return "", fmt.Errorf("session: marshal: %w", err)
+	}
+	encrypted, err := crypto.EncryptAESGCM(data, cs.encryptionKey)
+	if err != nil {
+		return "", fmt.Errorf("session: encrypt: %w", err)
+	}
+	return encrypted, nil
+}
+
+func (cs *CookieStore) Save(c *gin.Context, cookieName, cookieDomain string, sess *Session) error {
+	encrypted, err := cs.Encode(sess)
+	if err != nil {
+		return err
+	}
+	maxAgeSeconds := int(cs.maxAge.Seconds())
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie(cookieName, encrypted, maxAgeSeconds, "/", cookieDomain, cs.secure, true)
+	return nil
+}
+```
+
+- [ ] **Step 4: Run the whole session package**
+
+Run: `cd auth-bff && go test ./internal/session/ -v`
+Expected: PASS, including the pre-existing `Save`/`Load` tests — this is a refactor, not a behaviour change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/session/cookie.go internal/session/cookie_test.go
+git commit -m "refactor(session): extract Encode from Save so internal callers can mint a cookie value"
+```
+
+---
+
+### Task 2: `POST /internal/mint-session` in auth-bff
+
+**Files:**
+- Modify: `auth-bff/internal/handlers/internal.go` (register route + handler)
+- Test: `auth-bff/internal/handlers/internal_mint_session_test.go`
+
+**Interfaces:**
+- Consumes: `CookieStore.Encode` from Task 1.
+- Produces: `POST /internal/mint-session` — body `{tenant_id, tenant_slug, user_id, email, auth_context, app_name, cookie_name, ttl_seconds}`, response `{"set_cookie": "<header value>"}`.
+
+**Note:** `cookie_name` is validated with the existing `cfg.IsKnownSessionCookie`, exactly as `SessionExchange` does — that guard already exists and prevents the endpoint being used to mint a cookie under an arbitrary name.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestMintSession_RejectsUnknownAuthContext(t *testing.T) {
+	h, r := newTestInternalHandler(t)
+	_ = h
+	body := `{"tenant_id":"t1","user_id":"u1","auth_context":"root","cookie_name":"mark8ly_session","ttl_seconds":7200}`
+	w := postJSON(r, "/internal/mint-session", body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 for an unknown auth_context, got %d", w.Code)
+	}
+}
+
+func TestMintSession_AcceptsBreakGlassAndSetsNoIdPTokens(t *testing.T) {
+	h, r := newTestInternalHandler(t)
+	body := `{"tenant_id":"t1","tenant_slug":"bondi","user_id":"u1","email":"bg@example.test","auth_context":"break_glass","app_name":"marketplace-admin","cookie_name":"mark8ly_session","ttl_seconds":7200}`
+	w := postJSON(r, "/internal/mint-session", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		SetCookie string `json:"set_cookie"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if !strings.HasPrefix(resp.SetCookie, "mark8ly_session=") {
+		t.Fatalf("set_cookie not a cookie header: %q", resp.SetCookie)
+	}
+
+	value := strings.TrimPrefix(strings.Split(resp.SetCookie, ";")[0], "mark8ly_session=")
+	sess, err := h.sessions.LoadFromValue(value)
+	if err != nil {
+		t.Fatalf("minted cookie does not decrypt: %v", err)
+	}
+	if sess.AuthContext != "break_glass" {
+		t.Fatalf("auth_context = %q, want break_glass", sess.AuthContext)
+	}
+	// The whole point: a break-glass principal has no IdP identity.
+	if sess.AccessToken != "" || sess.IDToken != "" || sess.RefreshToken != "" {
+		t.Fatalf("break-glass session must carry no IdP tokens: %+v", sess)
+	}
+	if sess.ExpiresAt <= time.Now().Unix() {
+		t.Fatal("ExpiresAt must be in the future")
+	}
+}
+
+func TestMintSession_RejectsUnknownCookieName(t *testing.T) {
+	_, r := newTestInternalHandler(t)
+	body := `{"tenant_id":"t1","user_id":"u1","auth_context":"break_glass","cookie_name":"evil_cookie","ttl_seconds":7200}`
+	w := postJSON(r, "/internal/mint-session", body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 for an unknown cookie_name, got %d", w.Code)
+	}
+}
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `cd auth-bff && go test ./internal/handlers/ -run TestMintSession -v`
+Expected: FAIL — route returns 404.
+
+- [ ] **Step 3: Implement**
+
+Register alongside the existing internal routes:
+
+```go
+	internal.POST("/mint-session", h.MintSession)
+```
+
+```go
+// allowedAuthContexts is an explicit allow-list. It must never fall
+// back to "staff": a typo in a caller would otherwise silently mint a
+// full staff session.
+var allowedAuthContexts = map[string]bool{
+	"staff":       true,
+	"customer":    true,
+	"break_glass": true,
+}
+
+// MintSession issues a Mark8ly session cookie for a principal that the
+// CALLER has already authenticated. auth-bff performs no credential
+// check here — the Bearer service key on this route group is what makes
+// that safe.
+//
+// Used by marketplace-api's break-glass login and SSO callback, whose
+// principals have no IdP identity: AccessToken/IDToken/RefreshToken are
+// deliberately left empty, so nothing downstream can mistake this for a
+// federated session.
+func (h *InternalHandler) MintSession(c *gin.Context) {
+	var req struct {
+		TenantID    string `json:"tenant_id" binding:"required"`
+		TenantSlug  string `json:"tenant_slug"`
+		UserID      string `json:"user_id" binding:"required"`
+		Email       string `json:"email"`
+		AuthContext string `json:"auth_context" binding:"required"`
+		AppName     string `json:"app_name"`
+		CookieName  string `json:"cookie_name" binding:"required"`
+		TTLSeconds  int    `json:"ttl_seconds" binding:"required,min=60,max=86400"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "INVALID_REQUEST"})
+		return
+	}
+	if !allowedAuthContexts[req.AuthContext] {
+		slog.Warn("mint-session: rejected auth_context", "auth_context", req.AuthContext)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "INVALID_AUTH_CONTEXT"})
+		return
+	}
+	if !h.cfg.IsKnownSessionCookie(req.CookieName) {
+		slog.Warn("mint-session: unknown cookie name", "cookie_name", req.CookieName)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "INVALID_COOKIE_NAME"})
+		return
+	}
+
+	ttl := time.Duration(req.TTLSeconds) * time.Second
+	csrf, err := crypto.RandomToken(32)
+	if err != nil {
+		slog.Error("mint-session: csrf generation failed", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "MINT_FAILED"})
+		return
+	}
+
+	sess := &session.Session{
+		UserID:      req.UserID,
+		Email:       req.Email,
+		TenantID:    req.TenantID,
+		TenantSlug:  req.TenantSlug,
+		AuthContext: req.AuthContext,
+		AppName:     req.AppName,
+		CSRFToken:   csrf,
+		ExpiresAt:   time.Now().Add(ttl).Unix(),
+		// AccessToken / IDToken / RefreshToken intentionally empty.
+	}
+
+	value, err := h.sessions.Encode(sess)
+	if err != nil {
+		slog.Error("mint-session: encode failed", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "MINT_FAILED"})
+		return
+	}
+
+	ck := &http.Cookie{
+		Name:     req.CookieName,
+		Value:    value,
+		Path:     "/",
+		Domain:   h.cfg.SessionCookieDomain,
+		MaxAge:   int(ttl.Seconds()),
+		Secure:   h.cfg.SecureCookies(),
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
+	slog.Info("mint-session: issued",
+		"auth_context", req.AuthContext, "tenant_id", req.TenantID,
+		"user_id", req.UserID, "ttl_seconds", req.TTLSeconds)
+	c.JSON(http.StatusOK, gin.H{"set_cookie": ck.String()})
+}
+```
+
+> If `crypto.RandomToken` / `cfg.SecureCookies()` / `cfg.SessionCookieDomain` differ in name, use the equivalents already used by `DirectAuthHandler` when it builds a session — match that call site rather than inventing helpers.
+
+- [ ] **Step 4: Run**
+
+Run: `cd auth-bff && go test ./internal/handlers/ -run TestMintSession -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/handlers/internal.go internal/handlers/internal_mint_session_test.go
+git commit -m "feat(internal): mint a session cookie for an already-authenticated principal"
+```
+
+---
+
+### Task 3: `HTTPIssuer` in marketplace-api
+
+**Files:**
+- Create: `services/marketplace-api/internal/authbffclient/http_issuer.go`
+- Test: `services/marketplace-api/internal/authbffclient/http_issuer_test.go`
+
+**Interfaces:**
+- Consumes: `POST /internal/mint-session` from Task 2.
+- Produces: `authbffclient.NewHTTPIssuer(baseURL, serviceKey, cookieName string, slug TenantSlugFunc) *HTTPIssuer`, satisfying `SessionIssuer`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestHTTPIssuer_Issue_SendsBreakGlassContextAndReturnsCookie(t *testing.T) {
+	var gotAuth, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"set_cookie":"mark8ly_session=abc; Path=/; HttpOnly"}`))
+	}))
+	defer srv.Close()
+
+	iss := NewHTTPIssuer(srv.URL, "svc-key", "mark8ly_session",
+		func(context.Context, uuid.UUID) (string, error) { return "bondi", nil })
+
+	tid, uid := uuid.New(), uuid.New()
+	cookie, err := iss.Issue(context.Background(), tid, uid, 2*time.Hour)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if cookie != "mark8ly_session=abc; Path=/; HttpOnly" {
+		t.Fatalf("cookie = %q", cookie)
+	}
+	if gotAuth != "Bearer svc-key" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if !strings.Contains(gotBody, `"auth_context":"break_glass"`) {
+		t.Fatalf("body missing break_glass context: %s", gotBody)
+	}
+	if !strings.Contains(gotBody, `"ttl_seconds":7200`) {
+		t.Fatalf("body missing ttl: %s", gotBody)
+	}
+}
+
+func TestHTTPIssuer_Issue_NonOKIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	iss := NewHTTPIssuer(srv.URL, "wrong", "mark8ly_session",
+		func(context.Context, uuid.UUID) (string, error) { return "bondi", nil })
+
+	if _, err := iss.Issue(context.Background(), uuid.New(), uuid.New(), time.Hour); err == nil {
+		t.Fatal("want an error on 401, got nil")
+	}
+}
+
+func TestHTTPIssuer_SatisfiesSessionIssuer(t *testing.T) {
+	var _ SessionIssuer = (*HTTPIssuer)(nil)
+}
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `cd services/marketplace-api && go test ./internal/authbffclient/ -run TestHTTPIssuer -v`
+Expected: FAIL — `NewHTTPIssuer` undefined.
+
+- [ ] **Step 3: Implement**
+
+```go
+package authbffclient
+
+// TenantSlugFunc resolves a tenant's slug. The minted session carries it
+// so the admin app can render tenant context without a second lookup.
+type TenantSlugFunc func(context.Context, uuid.UUID) (string, error)
+
+// HTTPIssuer mints sessions by calling auth-bff's internal endpoint.
+// It authenticates with the same Bearer service key the rest of the
+// /internal group uses.
+type HTTPIssuer struct {
+	baseURL    string
+	serviceKey string
+	cookieName string
+	slug       TenantSlugFunc
+	client     *http.Client
+}
+
+func NewHTTPIssuer(baseURL, serviceKey, cookieName string, slug TenantSlugFunc) *HTTPIssuer {
+	return &HTTPIssuer{
+		baseURL:    strings.TrimSuffix(baseURL, "/"),
+		serviceKey: serviceKey,
+		cookieName: cookieName,
+		slug:       slug,
+		client:     &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func (h *HTTPIssuer) Issue(ctx context.Context, tenantID, userID uuid.UUID, ttl time.Duration) (string, error) {
+	slug := ""
+	if h.slug != nil {
+		if s, err := h.slug(ctx, tenantID); err == nil {
+			slug = s
+		}
+	}
+
+	payload := map[string]any{
+		"tenant_id":    tenantID.String(),
+		"tenant_slug":  slug,
+		"user_id":      userID.String(),
+		"auth_context": "break_glass",
+		"app_name":     "marketplace-admin",
+		"cookie_name":  h.cookieName,
+		"ttl_seconds":  int(ttl.Seconds()),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("authbffclient: marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.baseURL+"/internal/mint-session", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("authbffclient: new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+h.serviceKey)
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("authbffclient: mint-session: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Never echo the response body — it is auth-bff's and may name
+		// internals. The status is enough to act on.
+		return "", fmt.Errorf("authbffclient: mint-session: status %d", resp.StatusCode)
+	}
+
+	var out struct {
+		SetCookie string `json:"set_cookie"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("authbffclient: decode: %w", err)
+	}
+	if out.SetCookie == "" {
+		return "", errors.New("authbffclient: mint-session returned an empty cookie")
+	}
+	return out.SetCookie, nil
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd services/marketplace-api && go test ./internal/authbffclient/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/authbffclient/http_issuer.go internal/authbffclient/http_issuer_test.go
+git commit -m "feat(authbffclient): implement SessionIssuer against auth-bff mint-session"
+```
+
+---
+
+### Task 4: OpenBao adapter for break-glass secrets
+
+`breakglass.SecretClient` needs two methods; `carriersecrets.BaoClient` already provides both under different names.
+
+**Files:**
+- Create: `services/marketplace-api/internal/breakglass/bao_secret_client.go`
+- Test: `services/marketplace-api/internal/breakglass/bao_secret_client_test.go`
+
+**Interfaces:**
+- Consumes: `carriersecrets.BaoClient.CreateOrAddVersion(ctx, name, payload)` and `.AccessLatest(ctx, name)`.
+- Produces: `breakglass.NewBaoSecretClient(*carriersecrets.BaoClient) SecretClient`, and `BreakGlassSecretName(tenantID uuid.UUID) string` returning `break-glass/<tenant_id>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+type fakeBao struct {
+	saved map[string][]byte
+	err   error
+}
+
+func (f *fakeBao) CreateOrAddVersion(_ context.Context, name string, payload []byte) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.saved == nil {
+		f.saved = map[string][]byte{}
+	}
+	f.saved[name] = payload
+	return nil
+}
+func (f *fakeBao) AccessLatest(_ context.Context, name string) ([]byte, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	b, ok := f.saved[name]
+	if !ok {
+		return nil, fmt.Errorf("not found: %s", name)
+	}
+	return b, nil
+}
+
+func TestBaoSecretClient_RoundTripsABlob(t *testing.T) {
+	f := &fakeBao{}
+	c := NewBaoSecretClientFrom(f)
+	sm := NewSecretManager(c)
+
+	tenant := uuid.New()
+	path := BreakGlassSecretName(tenant)
+	if !strings.HasPrefix(path, "break-glass/") {
+		t.Fatalf("path = %q, want break-glass/<tenant>", path)
+	}
+
+	in := Blob{Password: "pw", TOTPSecret: "totp", GeneratedAt: time.Now().UTC()}
+	if err := sm.Write(context.Background(), path, in); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	out, err := sm.Read(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if out.Password != "pw" || out.TOTPSecret != "totp" {
+		t.Fatalf("round-trip mismatch: %+v", out)
+	}
+}
+
+func TestBaoSecretClient_PropagatesWriteFailure(t *testing.T) {
+	c := NewBaoSecretClientFrom(&fakeBao{err: errors.New("bao down")})
+	if err := NewSecretManager(c).Write(context.Background(), "break-glass/x", Blob{}); err == nil {
+		t.Fatal("a store failure must propagate — Bootstrapper relies on it to skip the DB write")
+	}
+}
+```
+
+> Match `SecretManager`'s real method names when writing this test — read `secret_manager.go` first and use whatever it calls read/write.
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `cd services/marketplace-api && go test ./internal/breakglass/ -run TestBaoSecretClient -v`
+Expected: FAIL — undefined.
+
+- [ ] **Step 3: Implement**
+
+```go
+package breakglass
+
+// baoWriter is the slice of carriersecrets.BaoClient this package needs.
+// Declared as an interface so tests need no live OpenBao.
+type baoWriter interface {
+	CreateOrAddVersion(ctx context.Context, name string, payload []byte) error
+	AccessLatest(ctx context.Context, name string) ([]byte, error)
+}
+
+// BaoSecretClient adapts an OpenBao client to SecretClient.
+//
+// Break-glass credentials used to live in GCP Secret Manager. That
+// backend was decommissioned (milestone 10: secrets deleted, IAM
+// revoked), so this is now the only store — not an alternative to one.
+type BaoSecretClient struct{ bao baoWriter }
+
+func NewBaoSecretClientFrom(b baoWriter) *BaoSecretClient { return &BaoSecretClient{bao: b} }
+
+func (c *BaoSecretClient) AddVersion(ctx context.Context, path string, payload []byte) error {
+	return c.bao.CreateOrAddVersion(ctx, path, payload)
+}
+
+func (c *BaoSecretClient) AccessLatest(ctx context.Context, path string) ([]byte, error) {
+	return c.bao.AccessLatest(ctx, path)
+}
+
+// BreakGlassSecretName is the OpenBao path for a tenant's break-glass
+// blob, mirroring the carrier-secrets convention.
+func BreakGlassSecretName(tenantID uuid.UUID) string {
+	return "break-glass/" + tenantID.String()
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd services/marketplace-api && go test ./internal/breakglass/ -v`
+Expected: PASS, existing break-glass tests included.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/breakglass/bao_secret_client.go internal/breakglass/bao_secret_client_test.go
+git commit -m "feat(breakglass): store credentials in OpenBao instead of the retired GCP Secret Manager"
+```
+
+---
+
+### Task 5: Delete the GCP Secret Manager client
+
+**Files:**
+- Delete: `services/marketplace-api/internal/breakglass/gcp_secret_manager.go`
+- Delete: `services/marketplace-api/internal/breakglass/secret_manager_test.go` cases that construct `GCPSecretClient` (keep the `FakeSecretClient` ones)
+- Modify: `services/marketplace-api/go.mod` if `cloud.google.com/go/secretmanager` becomes unused
+
+- [ ] **Step 1: Confirm nothing else imports it**
+
+Run: `cd services/marketplace-api && grep -rn "GCPSecretClient\|secretmanager" --include=*.go . | grep -v _test.go`
+Expected: only `gcp_secret_manager.go` itself. **If anything else appears, stop and report** — another caller means this is not a clean delete.
+
+- [ ] **Step 2: Delete and tidy**
+
+```bash
+git rm internal/breakglass/gcp_secret_manager.go
+go mod tidy
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `cd services/marketplace-api && go build ./... && go test ./internal/breakglass/ -v`
+Expected: builds clean, tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "chore(breakglass): delete the GCP Secret Manager client for a decommissioned backend"
+```
+
+---
+
+### Task 6: Wire and mount in `main.go`
+
+**Files:**
+- Modify: `services/marketplace-api/cmd/marketplace-api/main.go`
+- Modify: `services/marketplace-api/internal/handlers/admin/routes.go` (if the login route registers there)
+
+- [ ] **Step 1: Build the issuer and the Bao-backed secret manager**
+
+Construct `HTTPIssuer` from config, falling back to `NoopIssuer` when unset so a misconfigured deploy fails loudly at first use rather than serving an unauthenticated route:
+
+```go
+	var bgIssuer authbffclient.SessionIssuer = authbffclient.NoopIssuer{}
+	if cfg.AuthBFFInternalURL != "" && cfg.AuthBFFInternalServiceKey != "" {
+		bgIssuer = authbffclient.NewHTTPIssuer(
+			cfg.AuthBFFInternalURL,
+			cfg.AuthBFFInternalServiceKey,
+			cfg.SessionCookieName,
+			tenantSlugLookup,
+		)
+	} else {
+		log.Warn("break-glass: no auth-bff internal config; login will return 500 until set")
+	}
+```
+
+- [ ] **Step 2: Mount the login route OUTSIDE the store-scoped group**
+
+The handler's own comment is explicit: it must survive `read_only` / `store_closed` subscription states (§12.4). Gate it with `plangate.RequireFeature(FeatureSSO)` — break-glass exists for SSO tenants.
+
+```go
+	bgHandler := admin.NewBreakGlassLoginHandler(admin.BreakGlassDeps{
+		Repo: bgRepo, Secrets: bgSecrets, Audit: bgAudit, Slack: bgSlack,
+		RateLimiter: bgLimiter, IPHMACKey: bgHMACKey,
+		Sessions: bgIssuer, Logger: appLogger,
+	})
+	adminRoot.POST("/break-glass/login",
+		plangate.RequireFeature(plangate.FeatureSSO),
+		bgHandler.Login)
+```
+
+- [ ] **Step 3: Mount the SSO routes**
+
+Same issuer. Register `SSOLoginHandler`'s `Login`, `Callback`, `Logout` on the public group.
+
+- [ ] **Step 4: Prove the routes exist**
+
+Add a route-registration test — an unmounted route is this codebase's recurring silent failure, so assert presence directly:
+
+```go
+func TestBreakGlassLoginRouteIsMounted(t *testing.T) {
+	r := buildTestRouter(t)
+	found := false
+	for _, ri := range r.Routes() {
+		if ri.Method == http.MethodPost && strings.HasSuffix(ri.Path, "/break-glass/login") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("POST /break-glass/login is not registered — the handler exists but is unreachable")
+	}
+}
+```
+
+- [ ] **Step 5: Build, test, commit**
+
+```bash
+cd services/marketplace-api && go build ./... && go test ./... 
+git add -A
+git commit -m "feat(marketplace-api): mount the break-glass login and SSO routes"
+```
+
+---
+
+### Task 7: Config and deployment
+
+**Ordering matters and is the opposite of intuition** for the two directions:
+
+- `AUTH_BFF_INTERNAL_URL` / `AUTH_BFF_INTERNAL_SERVICE_KEY` are **new required-ish config**, so the **cluster change goes first**: add the env vars and the ExternalSecret, then ship the code that reads them. Shipping code first would crashloop on validate.
+- The OpenBao grant needs a `break-glass/*` path policy for the marketplace-api roles. CronJobs inherit the deployment ServiceAccount, so the existing grant machinery applies — what a new path needs is the policy line, not new IAM.
+
+- [ ] **Step 1: tesserix-k8s — add the env vars + secret, chart version bump, merge, confirm synced**
+- [ ] **Step 2: Extend the OpenBao policy to `kv/data/mark8ly/break-glass/*`**
+- [ ] **Step 3: Only then merge the marketplace-api change**
+
+---
+
+### Task 8: Provision accounts and verify end to end
+
+Zero break-glass accounts exist today, so the feature is not real until this runs.
+
+- [ ] **Step 1: Run `Bootstrapper` for each Pro+SSO tenant** — verify the OpenBao blob exists and the DB row references it, and that a store failure leaves **no** DB row.
+- [ ] **Step 2: Confirm the credentials are delivered to their owner out-of-band.** Never paste a password or TOTP secret into a PR, issue, log, or chat.
+- [ ] **Step 3: End-to-end** — a correct password+TOTP returns 200 with `Set-Cookie`; the cookie is accepted by marketplace-api-admin (this is the §4 claim, proven against the live Istio policy rather than the manifest).
+- [ ] **Step 4: Negative** — wrong factor returns the uniform `invalid_credentials`; the lockout path still trips; the Slack alert and `severity=critical` audit event both fire.
+- [ ] **Step 5: Audit `session-exchange` callers** for any that assume a non-empty `access_token`, since break-glass sessions return empty strings there.

--- a/docs/superpowers/specs/2026-09-04-break-glass-activation-design.md
+++ b/docs/superpowers/specs/2026-09-04-break-glass-activation-design.md
@@ -1,0 +1,235 @@
+# Break-glass activation — design
+
+**Status:** proposed
+**Issues:** closes #642 (turn it on), unblocks #404 (write operations)
+**Supersedes the unfinished parts of:** `docs/superpowers/plans/2026-04-18-p13-sso-break-glass.md`
+
+**Goal:** make the break-glass emergency admin login reachable, and mount the
+per-tenant SSO login routes that share its one missing dependency.
+
+---
+
+## 1. What break-glass is for
+
+Pro-tier tenants attach their own SAML/OIDC IdP (P13). When that tenant's SSO
+breaks or is misconfigured, their admins cannot sign in at all. Break-glass is
+one emergency local account per tenant — password **and** TOTP, never SMS —
+that bypasses SSO entirely.
+
+The thing that is down is **the tenant's own IdP**. GIP, auth-bff and the
+cluster are up. This matters: it is the constraint that shapes the whole
+design, and it is narrower than "the IdP is down".
+
+## 2. Verified current state
+
+The code is far more finished than "not built". Verified by reading it, not
+from the plan document:
+
+| Piece | State |
+|---|---|
+| `internal/breakglass/` (~60KB) | credentials, TOTP, lockouts, rotation, audit, Slack, bootstrap — **complete** |
+| `handlers/admin/break_glass_login.go` | **complete**, including a considered fail-closed degradation when the lockout store is unreachable (#457/#468) |
+| `handlers/public/sso_login.go` | login / callback / logout — **complete** |
+| Migrations `000073` (lockouts), `000129` (disable) | applied |
+| `cmd/break-glass-rotation` | exists |
+| Platform **read** path | **already mounted** (`platformadmin.BreakGlassListerFunc`, `main.go:2338`, `:2487`) |
+| `authbffclient.SessionIssuer` | interface + `NoopIssuer` that always errors — **no implementation** |
+| `POST /admin/break-glass/login` | **not mounted** |
+| SSO login routes | **not mounted** |
+| Break-glass accounts provisioned | **zero** |
+
+**One missing dependency gates two features.** `SessionIssuer` is referenced
+only by `break_glass_login.go` and `sso_login.go`. Implementing it unblocks
+both; neither is reachable without it.
+
+## 3. The two constraints
+
+### 3.1 A break-glass session carries no IdP tokens
+
+auth-bff's `session.Session` has `AccessToken` / `IDToken` / `RefreshToken`.
+A break-glass principal never authenticated to any IdP — there is no federated
+assertion to put there. Minting a GIP custom token for a synthetic user was
+rejected: P13's own architecture note says *"we do not invent a second
+token-verification layer"*, and it would add GIP account lifecycle for
+synthetic users to buy nothing this design needs.
+
+So the session ships with those three fields **empty, deliberately**.
+
+### 3.2 Break-glass secrets live in a backend we decommissioned
+
+P13 stores each account's password + TOTP secret in **GCP Secret Manager** at
+`/projects/tesserix-prod/secrets/break-glass-{tenant_id}`.
+
+Milestone 10 retired GCP Secret Manager: the secrets were deleted and the
+service account's IAM revoked. **Turning on break-glass as written would fail
+at first use**, and `Bootstrapper` writes Secret Manager *before* the DB row,
+so provisioning would fail at step one.
+
+This is not optional cleanup — it is a prerequisite.
+
+## 4. Why nothing downstream needs to change
+
+The reason the narrow approach is sufficient, verified against the running
+cluster rather than assumed:
+
+- `marketplace-api` authenticates callers with `auth.HeaderTrustAuth` —
+  it reads **`X-User-Id` / `X-Tenant-Id`** headers, optionally gated by
+  `MARKETPLACE_INTERNAL_AUTH_SECRET`. It does **not** validate GIP tokens on
+  this path.
+- The admin API's Istio policy `allow-marketplace-api-admin-callers` is
+  **mTLS workload-identity** based — a list of SA principals
+  (`.../sa/mark8ly-admin`, `.../sa/mark8ly-auth-bff`, …). It requires **no
+  JWT**. The JWT `RequestAuthentication`s live in `istio-ingress`, on the
+  browser hop.
+- Therefore the admin BFF sets exactly the same headers from a break-glass
+  session as from a normal one.
+
+**The empty IdP token fields never reach a validator.** "Session-cookie trust"
+is not a reduced-capability compromise here; it is complete for the admin
+surface.
+
+## 5. Design
+
+### 5.1 auth-bff — mint a session for an already-authenticated principal
+
+Add one endpoint to the **existing** `/internal` group in
+`internal/handlers/internal.go`, which already carries
+`requireServiceKey()` (Bearer `INTERNAL_SERVICE_KEY`) and `rateLimit()`:
+
+```
+POST /internal/mint-session
+```
+
+Request:
+
+```json
+{ "tenant_id": "...", "tenant_slug": "...", "user_id": "...",
+  "email": "...", "auth_context": "break_glass",
+  "app_name": "marketplace-admin", "ttl_seconds": 7200 }
+```
+
+Response: `{ "set_cookie": "<full Set-Cookie header value>" }`
+
+> **Correction to the code's own comment.** `session_issuer.go` says the
+> endpoint is "expected to be mTLS-gated". The `/internal` group's actual,
+> working pattern is a Bearer service key plus rate limiting. Follow the
+> pattern that exists; introducing a second auth mechanism for one endpoint
+> would be a new thing to get wrong.
+
+**`auth_context` must be allow-listed**, exactly as `IsKnownSessionCookie`
+guards `session-exchange` today. Accept `break_glass` and the existing
+`staff` / `customer`; reject anything else with 400. It must never default to
+`staff` — a typo would silently mint a full staff session.
+
+Cookie cryptography stays in auth-bff. Extract the encrypt step already inside
+`CookieStore.Save` into an exported `Encode(sess *Session) (string, error)`,
+and have both `Save` and this endpoint use it. marketplace-api never signs a
+session cookie.
+
+### 5.2 marketplace-api — implement the issuer
+
+`internal/authbffclient/http_issuer.go`:
+
+```go
+type HTTPIssuer struct {
+    BaseURL    string        // AUTH_BFF_INTERNAL_URL
+    ServiceKey string        // AUTH_BFF_INTERNAL_SERVICE_KEY
+    Client     *http.Client  // timeout 5s
+    TenantSlug func(context.Context, uuid.UUID) (string, error)
+}
+```
+
+`Issue` POSTs to `/internal/mint-session` with `auth_context: "break_glass"`
+and returns the `set_cookie` string. Any non-200 returns an error — the
+handler already maps that to `500 session_mint_failed` without leaking why.
+
+`NoopIssuer` stays the default when config is absent, so a misconfigured
+deploy fails loudly rather than serving an unauthenticated route.
+
+### 5.3 Port break-glass secrets to OpenBao
+
+`breakglass.SecretClient` is a two-method interface:
+
+```go
+AddVersion(ctx, path string, payload []byte) error
+AccessLatest(ctx, path string) ([]byte, error)
+```
+
+`carriersecrets.BaoClient` already offers `CreateOrAddVersion(ctx, name,
+payload)` and `AccessLatest(ctx, name)`. Add
+`internal/breakglass/bao_secret_client.go` — a thin adapter, no new secret
+machinery, reusing the KV v2 mount and Kubernetes auth proven in milestone 10.
+
+Path scheme: `break-glass/{tenant_id}`, mirroring the carrier-secrets
+convention.
+
+`gcp_secret_manager.go` is **deleted**, not left in place. An unused GCP client
+whose IAM has been revoked is a trap for the next reader — the same reasoning
+that deleted the retired ArgoCD Application in tesserix-k8s#938.
+
+### 5.4 Mount the routes
+
+In `main.go`, alongside the already-wired `BreakGlassLister`:
+
+- `POST /admin/break-glass/login` — mounted **outside** the store-scoped
+  `RequireActive` group. The handler comment is explicit about why: it must
+  survive `read_only` / `store_closed` subscription states (§12.4).
+- Gate with `plangate.RequireFeature(FeatureSSO)` — break-glass exists for
+  SSO tenants, so a Starter tenant hitting it should get the same 403 the SSO
+  endpoints give.
+- SSO login / callback / logout routes, now that their issuer exists.
+
+### 5.5 Provision accounts
+
+Use the existing `Bootstrapper` (bcrypt cost 12, Secret-Manager-write-first
+ordering preserved against the Bao adapter). One account per Pro+SSO tenant.
+Zero exist today, so this is the step that makes the feature real rather than
+merely reachable.
+
+## 6. #404 — write operations
+
+Unblocked by the same work. `rotation.go`, migration `000129_break_glass_disable`
+and `cmd/break-glass-rotation` already exist; `platformadmin` write handlers
+need mounting plus the Bao port above. Rotate / disable / clear-lockout are a
+follow-on plan, not this spec's scope.
+
+Note for the 24-hour post-use rotation and 90-day cron: **CronJobs inherit the
+deployment ServiceAccount**, so the OpenBao grant already applies; what a new
+CronJob needs is env vars and the NetworkPolicy pod label, never new IAM.
+
+## 7. Risks
+
+| Risk | Mitigation |
+|---|---|
+| A caller assumes `session-exchange` returns a non-empty `access_token` | Enumerate every caller before mounting. Break-glass sessions return empty strings there. |
+| `auth_context` typo silently mints a staff session | Explicit allow-list, reject-by-default, unit test per accepted value. |
+| Break-glass depends on auth-bff being up | Accepted: the failure being addressed is the *tenant's* IdP, not auth-bff. Stated so nobody assumes wider coverage than exists. |
+| A break-glass session is a full admin session for 2h | Unchanged from P13's design: every login triggers immediate 24h rotation, a `#security-alerts` Slack post, and a `severity=critical` audit event. |
+| Obsolete Terraform | P13 provisions a `break-glass-responders` Google Group + IAM on `/projects/tesserix-prod/secrets/break-glass-*`. Those secrets no longer exist; the IAM policy is dead and should be removed with the GCP client. |
+
+## 8. Deliberately not doing
+
+- **No GIP custom tokens** for break-glass principals (§3.1).
+- **No second token-verification layer** in go-shared or any service — §4
+  shows none is needed.
+- **No mTLS** for the new endpoint; it follows the `/internal` group's
+  existing Bearer pattern.
+- **No change to Istio policy.** Verified unnecessary, not assumed.
+
+## 9. Test plan
+
+- Unit: `HTTPIssuer` maps non-200 to error; `NoopIssuer` still the default
+  when config is absent.
+- Unit: `auth_context` allow-list rejects unknown values; no path defaults to
+  `staff`.
+- Unit: Bao adapter satisfies `SecretClient`; round-trips a `Blob`.
+- Integration: `Bootstrapper` provisions against Bao with the
+  secret-before-DB ordering intact (a Bao failure must leave no DB row).
+- Integration: full login — correct password+TOTP returns 200 with a
+  `Set-Cookie`; wrong either factor returns the uniform
+  `{"error":"invalid_credentials"}`; the existing lockout tests still pass.
+- End-to-end in a real cluster: a break-glass cookie reaches
+  marketplace-api-admin and is accepted, proving §4 against the running Istio
+  policy rather than the manifest.
+- Negative: confirm the route is **absent** before the change and **present**
+  after — an unmounted route is this codebase's recurring silent failure.

--- a/services/marketplace-api/internal/handlers/storefront/cancel_refund_email_integration_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/cancel_refund_email_integration_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+
+package storefront_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
+
+	"github.com/mark8ly/marketplace-api/internal/branding"
+	"github.com/mark8ly/marketplace-api/internal/handlers/storefront"
+	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/internal/orderdoc"
+	"github.com/mark8ly/marketplace-api/internal/orderrefund"
+	"github.com/mark8ly/marketplace-api/internal/outbox"
+	"github.com/mark8ly/marketplace-api/internal/payment"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// recordingMailer captures the orderdoc envelopes a handler dispatches.
+// Both sends are fire-and-forget goroutines, so each call is announced on a
+// buffered channel the test waits on rather than sleeping.
+type recordingMailer struct {
+	refunds       chan orderdoc.DocumentInput
+	cancellations chan orderdoc.DocumentInput
+}
+
+func newRecordingMailer() *recordingMailer {
+	return &recordingMailer{
+		refunds:       make(chan orderdoc.DocumentInput, 4),
+		cancellations: make(chan orderdoc.DocumentInput, 4),
+	}
+}
+
+func (m *recordingMailer) SendRefund(_ context.Context, in orderdoc.DocumentInput) error {
+	m.refunds <- in
+	return nil
+}
+
+func (m *recordingMailer) SendCancellation(_ context.Context, in orderdoc.DocumentInput) error {
+	m.cancellations <- in
+	return nil
+}
+
+// The rest of the Mailer contract is unused by the cancel path.
+func (m *recordingMailer) SendInvoice(context.Context, orderdoc.DocumentInput) error { return nil }
+func (m *recordingMailer) SendReceipt(context.Context, orderdoc.DocumentInput) error { return nil }
+func (m *recordingMailer) SendShipmentDispatched(context.Context, orderdoc.DocumentInput) error {
+	return nil
+}
+
+// A customer who self-cancels a PAID order gets their money back, but until
+// #169 they were told only "your order was cancelled" — no refund
+// confirmation. The admin-initiated refund has always sent one
+// (handlers/admin/orders.go dispatchRefundEmail), so the same customer got a
+// different experience depending on who pressed the button.
+func TestIntegration_SelfCancelPaid_SendsRefundEmailWithRunningTotal(t *testing.T) {
+	env, mailer := setupCancelRefundEmailEnv(t)
+	cust := seedCancelAutoRefundCustomer(t, env.db, env.store)
+	o := seedCancelAutoRefundOrder(t, env.db, env.store, cust,
+		cancelAutoRefundOrderOpts{GrandTotal: "120.00"})
+	seedCancelAutoRefundCapturedTxn(t, env.db, env.store, o.ID, "120.00")
+	seedCancelAutoRefundGatewayConfig(t, env.db, env.store)
+
+	r := buildCancelRouter(env.handler, env.store, cust)
+	if w := cancelAutoRefundRequest(r, env.store.Slug, o.ID.String()); w.Code != http.StatusOK {
+		t.Fatalf("cancel: status %d, body=%s", w.Code, w.Body.String())
+	}
+
+	select {
+	case in := <-mailer.refunds:
+		if !in.RefundAmount.Equal(decimal.RequireFromString("120.00")) {
+			t.Errorf("RefundAmount = %s, want 120.00", in.RefundAmount)
+		}
+		// The running total must reflect THIS refund. The handler loads the
+		// order before refunding, so a naive pass-through would report 0.00
+		// and tell the customer nothing had been refunded yet.
+		if !in.TotalRefunded.Equal(decimal.RequireFromString("120.00")) {
+			t.Errorf("TotalRefunded = %s, want 120.00 — the post-refund total, not the pre-refund row",
+				in.TotalRefunded)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("no refund email dispatched after a paid self-cancel")
+	}
+
+	// This ADDS an email; it does not replace the cancellation one.
+	select {
+	case <-mailer.cancellations:
+	case <-time.After(15 * time.Second):
+		t.Fatal("the cancellation email must still be sent")
+	}
+}
+
+// An unpaid order is never refunded, so it must never claim to be. Telling a
+// customer money came back when none moved is worse than sending nothing.
+func TestIntegration_SelfCancelUnpaid_SendsNoRefundEmail(t *testing.T) {
+	env, mailer := setupCancelRefundEmailEnv(t)
+	cust := seedCancelAutoRefundCustomer(t, env.db, env.store)
+	o := seedCancelAutoRefundOrder(t, env.db, env.store, cust,
+		cancelAutoRefundOrderOpts{GrandTotal: "80.00", PaymentStatus: string(order.PaymentStatusPending)})
+
+	r := buildCancelRouter(env.handler, env.store, cust)
+	if w := cancelAutoRefundRequest(r, env.store.Slug, o.ID.String()); w.Code != http.StatusOK {
+		t.Fatalf("cancel: status %d, body=%s", w.Code, w.Body.String())
+	}
+
+	// Waiting for the cancellation email first proves the handler ran to
+	// completion, so the absent refund email below is a real absence rather
+	// than a race that has not finished yet.
+	select {
+	case <-mailer.cancellations:
+	case <-time.After(15 * time.Second):
+		t.Fatal("the cancellation email must still be sent for an unpaid order")
+	}
+	select {
+	case in := <-mailer.refunds:
+		t.Fatalf("an unpaid self-cancel must not send a refund email; got amount %s", in.RefundAmount)
+	case <-time.After(2 * time.Second):
+	}
+}
+
+// setupCancelRefundEmailEnv mirrors setupCancelAutoRefundEnv but wires a real
+// orderdoc.Service over a recording Mailer, so the email dispatch the other
+// file passes nil for is actually observable.
+func setupCancelRefundEmailEnv(t *testing.T) (*cancelAutoRefundEnv, *recordingMailer) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	db := testdb.NewDB(t, cancelAutoRefundTables...)
+	store := seedCancelAutoRefundStore(t, db)
+
+	orderRepo := order.NewRepository()
+	orderSvc := order.NewService(db, orderRepo, outbox.NewRepository(db))
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	gw := &carFakeGateway{}
+	res := &carFakeRefundResolver{Resolver: orderrefund.NewResolver(db), gw: gw}
+	paySvc := payment.NewService(payment.NewRepository(db))
+	coordinator := orderrefund.NewCoordinator(db, res, paySvc, orderSvc, orderRepo, true)
+
+	mailer := newRecordingMailer()
+	// orderdoc.Service dereferences brandingSvc in buildInput, so a nil here
+	// panics inside the dispatch goroutine rather than failing the test.
+	brandingSvc := branding.NewService(branding.ServiceConfig{
+		DB: db, Repo: branding.NewRepository(), Logger: logger,
+	})
+	docSvc := orderdoc.NewService(db, mailer, orderRepo, brandingSvc, "https://example.test")
+
+	handler := storefront.NewOrderDetailHandler(db, orderRepo, orderSvc, docSvc, logger).
+		WithRefunds(coordinator)
+
+	return &cancelAutoRefundEnv{db: db, handler: handler, store: store}, mailer
+}

--- a/services/marketplace-api/internal/handlers/storefront/order_detail.go
+++ b/services/marketplace-api/internal/handlers/storefront/order_detail.go
@@ -79,6 +79,39 @@ func (h *OrderDetailHandler) WithRefunds(c *orderrefund.Coordinator) *OrderDetai
 	return h
 }
 
+// dispatchRefundEmail fires the refund-issued notification on a detached
+// context, mirroring the admin path's dispatchRefundEmail
+// (handlers/admin/orders.go). Before #169 a customer who self-cancelled a
+// PAID order was refunded but only ever told the order was cancelled — the
+// same customer got a different experience depending on who pressed the
+// button.
+//
+// The order is re-read inside the goroutine rather than reusing the copy the
+// handler loaded before refunding. Two reasons, and the second is the one
+// that bites: the pre-refund row still reports the OLD refunded_amount, and
+// adding res.Amount to it would OVER-report, because res.Amount includes the
+// gift-card slice while orders.refunded_amount counts gateway money only.
+// The admin path sidesteps both by passing its post-refund row.
+func (h *OrderDetailHandler) dispatchRefundEmail(orderID uuid.UUID, refundAmount decimal.Decimal) {
+	if h.docMailer == nil {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		post, _, _, err := h.orderRepo.GetByID(ctx, h.db, orderID)
+		if err != nil {
+			h.logger.Warn("orderdoc: refund email skipped — could not re-read order for the running total",
+				"order_id", orderID, "err", err)
+			return
+		}
+		if err := h.docMailer.SendRefund(ctx, orderID, refundAmount, post.RefundedAmount); err != nil {
+			h.logger.Warn("orderdoc: customer cancel refund email dispatch failed",
+				"order_id", orderID, "err", err)
+		}
+	}()
+}
+
 // storefrontOrderResponse is the customer-facing DTO.
 type storefrontOrderResponse struct {
 	ID            string `json:"id"`
@@ -680,10 +713,21 @@ func (h *OrderDetailHandler) Cancel(c *gin.Context) {
 	// gateway blip leaves the order cancelled + a pending ledger row for the
 	// sweeper, so the customer is never blocked on the cancel response.
 	if h.refunds != nil && o.PaymentStatus == string(order.PaymentStatusPaid) {
-		if _, rerr := h.refunds.Refund(c.Request.Context(), orderrefund.RefundCommand{
+		res, rerr := h.refunds.Refund(c.Request.Context(), orderrefund.RefundCommand{
 			OrderID: orderID, Amount: nil, Reason: "order cancelled", Actor: "customer", ScopeID: "cancel",
-		}); rerr != nil {
+		})
+		switch {
+		case rerr != nil:
+			// A gateway blip leaves a pending ledger row for the sweeper, so
+			// the money has NOT moved yet. Deliberately no refund email here:
+			// telling a customer they have been refunded when the refund is
+			// still queued is worse than telling them nothing (#169).
 			h.logger.Warn("cancel auto-refund deferred", "order_id", orderID, "err", rerr)
+		case res.AlreadyDone:
+			// Idempotent replay of a refund that already happened — the email
+			// went out the first time.
+		case res.Amount.IsPositive():
+			h.dispatchRefundEmail(orderID, res.Amount)
 		}
 	}
 

--- a/services/marketplace-api/internal/payment/razorpay_test.go
+++ b/services/marketplace-api/internal/payment/razorpay_test.go
@@ -19,7 +19,13 @@ func TestRazorpayRefund_SendsIdempotencyHeaderAndNotes(t *testing.T) {
 	var body []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotKey = r.Header.Get("X-Refund-Idempotency")
-		body, _ = io.ReadAll(r.Body)
+		var readErr error
+		// Swallowing this made a read failure look like an assertion failure
+		// on the body below (#169). t.Errorf is safe from a handler
+		// goroutine; t.Fatalf is not.
+		if body, readErr = io.ReadAll(r.Body); readErr != nil {
+			t.Errorf("read request body: %v", readErr)
+		}
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"id":"rfnd_1","status":"processed","amount":5000}`))
 	}))

--- a/services/marketplace-api/internal/payment/stripe.go
+++ b/services/marketplace-api/internal/payment/stripe.go
@@ -232,6 +232,18 @@ func stripeRefundReason(raw string) string {
 
 // RefundPayment creates a refund via POST /v1/refunds.
 func (s *StripeGateway) RefundPayment(ctx context.Context, in RefundInput) (*Refund, error) {
+	// An unconfigured key is a local configuration fault, not a Stripe one.
+	// Sent as empty basic auth it comes back as a bare 401, which reads as
+	// "Stripe rejected our credentials" and sends an operator to the Stripe
+	// dashboard mid-incident instead of to their own config (#169).
+	//
+	// Scoped to the refund path deliberately: that is the surface #164/#169
+	// cover, and the other Stripe calls have their own callers and tests.
+	// The same guard would suit them.
+	if s.apiKey == "" {
+		return nil, fmt.Errorf("stripe: refund payment: no API key configured for this store")
+	}
+
 	amountMinor := toMinorUnits(in.Amount, in.CurrencyCode)
 
 	form := url.Values{}

--- a/services/marketplace-api/internal/payment/stripe_emptykey_test.go
+++ b/services/marketplace-api/internal/payment/stripe_emptykey_test.go
@@ -1,0 +1,47 @@
+package payment
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+// An unconfigured API key must fail LOCALLY, before any request leaves the
+// process (#169).
+//
+// Without this, an empty key is sent as empty basic auth and Stripe answers
+// 401 — so a missing credential is indistinguishable from a revoked or wrong
+// one. During a refund incident that points the operator at Stripe's
+// dashboard instead of at their own configuration, which is the expensive
+// kind of misdirection.
+func TestStripeRefund_EmptyAPIKeyFailsBeforeSendingRequest(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	g := NewStripeGateway("", "secret", "test")
+	g.baseURL = srv.URL
+
+	_, err := g.RefundPayment(context.Background(), RefundInput{
+		ProviderPaymentID: "pi_1",
+		Amount:            decimal.RequireFromString("10.00"),
+		CurrencyCode:      "USD",
+	})
+	if err == nil {
+		t.Fatal("RefundPayment with an empty API key returned nil error")
+	}
+	if called {
+		t.Error("a request reached Stripe despite there being no API key; the guard must short-circuit first")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "api key") {
+		t.Errorf("error = %q, want it to name the missing API key so the operator "+
+			"looks at configuration rather than at Stripe", err)
+	}
+}


### PR DESCRIPTION
Task-by-task plan implementing the design merged in #652. No production code — this is the artifact to disagree with before any is written.

## Eight tasks

1. **`CookieStore.Encode`** in auth-bff — extract the encrypt step from `Save` so a non-HTTP caller can mint a cookie value. Pure refactor; `Save` calls it.
2. **`POST /internal/mint-session`** — on the existing `/internal` group, so it inherits the Bearer service key and rate limiting rather than introducing a second auth mechanism.
3. **`HTTPIssuer`** in marketplace-api — implements `SessionIssuer` against that endpoint.
4. **OpenBao adapter** for break-glass secrets.
5. **Delete the GCP Secret Manager client.**
6. **Mount the routes** — break-glass login and SSO.
7. **Config + deploy ordering.**
8. **Provision accounts and verify end to end.**

## Ordering that is easy to get backwards

Task 7 is cluster-first: `AUTH_BFF_INTERNAL_URL` and the service key are new required config, so the env vars and ExternalSecret must land **before** the code that reads them. Shipping the code first crashloops on validate. (Removing required config is the opposite — code first.)

Task 5 opens with a grep gate rather than a delete: if anything besides `gcp_secret_manager.go` still imports `secretmanager`, **stop and report** — that would mean it is not a clean delete.

## Two things the plan refuses to let slide

**A route that exists but is not mounted is this codebase's recurring silent failure** — it is the entire reason #642 was open. So Task 6 ends with a test that asserts `POST /break-glass/login` is actually in `r.Routes()`, not merely that the handler compiles.

**Task 8 is what makes the feature real.** Zero break-glass accounts exist today; mounting the route changes nothing on its own. It also carries the explicit rule that credentials are delivered out-of-band and never pasted into a PR, issue, log, or chat.

## Global constraints carried into every task

- marketplace-api **never** signs a session cookie — it passes a `Set-Cookie` string through; cryptography stays in auth-bff
- `auth_context` is an explicit allow-list that must never default to `staff` — a typo would silently mint a full staff session
- no secret value in any log line
- break-glass login responses stay uniform (`invalid_credentials`); forensics goes to the audit log
- bcrypt cost 12, and the secret-store write precedes the DB write so a store failure leaves no orphan `password_hash`

## Test plan

- [x] Every task has runnable test code and exact file paths; no placeholders
- [x] Types and signatures are consistent across tasks
- [x] Two tasks carry explicit stop-and-report gates rather than assumptions
- [ ] Review, then execute task-by-task

Refs #642, #404, #652.