### PR TITLE
docs(billing): consolecatalog is on the serving path — its header still claimed it changed no behaviour

### DIFF
--- a/services/marketplace-api/internal/billing/consolecatalog/catalog.go
+++ b/services/marketplace-api/internal/billing/consolecatalog/catalog.go
@@ -4,12 +4,13 @@
 //
 // # Why this exists
 //
-// The console is becoming the single place a price is maintained. Until
-// marketplace-api reads from it, a price changed in the console updates
-// Stripe while this service keeps serving the hardcoded Go amount — a
+// The console is the single place a price is maintained. Before
+// marketplace-api read from it, a price changed in the console updated
+// Stripe while this service kept serving the hardcoded Go amount — a
 // divergence on the SERVING side that the console's parity check is
 // structurally blind to, because that check compares the console's catalog
-// to Stripe and both of those would be correct.
+// to Stripe and both of those would be correct. Closing that divergence is
+// what this package was built for, and #632 closed it.
 //
 // # The invariant that shapes every decision here
 //
@@ -21,12 +22,23 @@
 // not a nicety; it is the entire reason reading the console at all is
 // acceptable.
 //
-// # This package changes no behaviour yet
+// # The cutover has happened — this package is on the serving path
 //
-// Slice one runs both sources and logs their differences. Prices continue
-// to come from the compiled catalog. The cutover happens separately, once
-// the difference count is durably zero — the same evidence pattern the
-// console's parity check established.
+// This header used to read "this package changes no behaviour yet", which
+// was true of slice one and false from #632 onward. Since then the platform
+// console's billing read routes resolve their amounts through Cache.Resolve
+// here (see cmd/marketplace-api/catalog_serving.go), so a fault in this
+// package is a fault in what an operator is shown, not just in a log line.
+//
+// The compiled catalog in internal/billing/pricing did not go away: it is
+// the fallback Resolve serves from when the console is unconfigured or
+// unreachable, and it is now GENERATED from the console by cmd/gencatalog
+// (#648) rather than hand-maintained. The Monitor's comparison therefore
+// answers a narrower question than it once did — no longer "did someone
+// forget to update the Go map", but "did the console move without the
+// fallback being regenerated". A difference is reported to Prometheus as
+// well as logged (#328 gap 3), because a difference nothing watches is a
+// difference nobody acts on.
 package consolecatalog
 
 import "time"


### PR DESCRIPTION
`internal/billing/consolecatalog`'s package doc still carried this section:

> **# This package changes no behaviour yet**
>
> Slice one runs both sources and logs their differences. Prices continue to come
> from the compiled catalog. The cutover happens separately, once the difference
> count is durably zero.

True of slice one. **False since #632**, when platform-admin billing amounts began
resolving through `Cache.Resolve` in this package.

A package whose header says it does nothing, while sitting on the path that decides
what an operator is shown, is the comment most likely to mislead someone reading it
under pressure. It was flagged during #648 and deferred as out of scope for a
byte-identity change; this is that follow-up.

## What the header now says

- the cutover **has** happened, and a fault here is a fault in what an operator is
  shown, not just in a log line — pointing at `cmd/marketplace-api/catalog_serving.go`
- the compiled catalog did not go away: it is the fallback `Resolve` serves from when
  the console is unconfigured or unreachable, and since #648 it is **generated** from
  the console by `cmd/gencatalog` rather than hand-maintained
- the Monitor's comparison therefore answers a narrower question than it once did —
  no longer "did someone forget to update the Go map", but "did the console move
  without the fallback being regenerated"
- a difference now reaches Prometheus as well as the log (#328 gap 3, PR #654),
  because a difference nothing watches is a difference nobody acts on

The intro's "is becoming … Until marketplace-api reads from it" is likewise put in the
past tense, since it does.

Comment-only. No code, no behaviour.

## Test plan

- [x] `go build ./...` — exit 0
- [x] `go vet ./internal/billing/consolecatalog/...` — clean

Found while auditing which docs this session's work had left stale.
