### PR TITLE
feat(platform-api): Zitadel password reset and account deletion (#524 phase 5)

### DIFF
--- a/docs/superpowers/plans/2026-09-04-zitadel-phase5-platform-api.md
+++ b/docs/superpowers/plans/2026-09-04-zitadel-phase5-platform-api.md
@@ -1,0 +1,96 @@
+# Zitadel Phase 5 — `platform-api`'s Account Operations
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `platform-api` perform password reset and account deletion against Zitadel instead of GIP's Identity Toolkit, flag-selected.
+
+**Architecture:** `gipadmin` today is a concrete `*AdminClient` doing five things over GIP's REST API. Three of them — send a password-reset code, reset a password, delete an account — get a Zitadel implementation behind an interface, selected by the same `ZITADEL_ENABLED` flag shape used elsewhere. The other two stay on GIP deliberately.
+
+**Spec:** `docs/superpowers/specs/2026-09-03-zitadel-migration-design.md` (decision D7)
+
+## What is deliberately NOT in scope
+
+**`EnsureTenantClaim` and the `backfill-gip-claims` CLI stay on GIP and are not ported.** D7 says the custom claim is dropped rather than ported, and phase 4 removed its consumer — but **only under the Zitadel flag**. With the flag off, which is today's production, `marketplace-api`'s `gip_bearer.go` still reads `tenant_id` from that claim. `invitation/service.go:429` writes it on invite-accept, and its own comment records the consequence of it not landing: *"mobile shows its 'No store yet' empty state until the claim lands."*
+
+Deleting it now would give every newly-invited merchant a permanent no-store state on mobile. It gets deleted at cutover, once `ZITADEL_ENABLED` is true on marketplace-api — not before. `lookupCustomAttributes` serves only `EnsureTenantClaim`, so it stays too.
+
+## Global Constraints
+
+- **The nil-interface trap is the single biggest hazard here — read `cmd/server/account_wiring.go`'s comment in full before writing any interface.** Assigning a nil `*AdminClient` into an interface yields a **non-nil interface holding a nil pointer**, so a `!= nil` guard passes and the method panics on a nil receiver. That panic lands *after* the teardown transaction commits, gin's Recovery answers 500, and the operator is told `503 upstream_unavailable` for work that already happened. Every new interface in this phase must avoid reintroducing it, and the existing guard pattern must survive.
+- **With the flag unset, behaviour must be byte-identical to `main`.** Phase 4 shipped a revision that violated this and would have bricked a live app; verify by diffing the GIP path, not by reasoning.
+- Password reset and account deletion are destructive, user-visible paths. A failure must not silently succeed, and an unavailable provider must surface as unavailable rather than as "wrong code".
+- No token, secret, password, reset code, or bearer value in any log line.
+- `ZITADEL_ISSUER` and any project id must be `TrimSpace`d **on assignment**, like the other secret-sourced fields — a trailing newline from a mounted secret caused a ~25-hour outage in this codebase before.
+- `go build ./... && go vet ./... && go test -race ./...` must pass in `services/platform-api`.
+
+---
+
+### Task 1: An interface for the account operations
+
+**Files:**
+- Modify: `services/platform-api/internal/auth/service.go` (takes `Admin *gipadmin.AdminClient` concretely today), and its tests
+- Check: `internal/account/service.go:45` already defines `gipDeleter` — reuse that shape rather than inventing a second one
+
+Introduce interfaces covering the three operations to be swapped: send reset code, reset password, delete account. `gipadmin.AdminClient` must satisfy them unchanged — this task adds no behaviour.
+
+**Handle the nil trap explicitly.** Construct the interface value only when a real client exists; never assign a possibly-nil concrete pointer into it. Follow whatever `account_wiring.go` already does, and say in your report how you avoided it.
+
+- [ ] **Step 1: Write the failing tests** — a nil provider is genuinely nil at the interface (a `!= nil` guard sees it as absent, and calling through it never panics); `gipadmin.AdminClient` satisfies the interfaces; existing auth/account behaviour is unchanged.
+- [ ] **Step 2: Run, confirm failure**
+- [ ] **Step 3: Implement**
+- [ ] **Step 4: build, vet, `go test -race ./...`**
+- [ ] **Step 5: Commit** — `refactor(platform-api): put account operations behind an interface`
+
+---
+
+### Task 2: The Zitadel implementation
+
+**Files:**
+- Create: `services/platform-api/internal/zitadeladmin/` (client + tests), or follow whatever package convention this service already uses
+
+Implement the three operations against Zitadel's v2 API. The spec's D7 table gives the mapping:
+
+| GIP today | Zitadel |
+|---|---|
+| `sendOobCode` (PASSWORD_RESET, `returnOobLink`) | `POST /v2/users/{id}/password_reset`, returning the code so we send the mail |
+| `accounts:resetPassword` | `POST /v2/users/{id}/password` with `verificationCode` |
+| `accounts:delete` | `DELETE /v2/users/{id}` |
+
+**Returning the code rather than letting Zitadel send the mail is deliberate** — it preserves today's `returnOobLink=true` behaviour and keeps branding and delivery on the existing `notify` → platform-api path rather than the shared instance's SMTP.
+
+Note the reset flow is **id-based**, not email-based: GIP's `sendOobCode` takes an email, Zitadel's takes a user id. Resolving email → id is part of this task. `POST /v2/users` is a **search** on this instance (verified), which is how auth-bff finds users by email.
+
+Read `services/auth-bff/internal/zitadellogin/client.go` first for the established request/error conventions in this codebase, and follow them.
+
+- [ ] **Step 1: Write the failing tests** against an `httptest` fake: each operation's happy path; a user-not-found; an unavailable provider surfacing as unavailable rather than as a wrong-code/weak-password error; the existing sentinel errors (`ErrUserNotFound`, `ErrWeakPassword`, `ErrTooManyAttempts`, `ErrUnavailable`, `ErrUnauthenticated`) mapping correctly, since `internal/auth/handler.go` already branches on them.
+- [ ] **Step 2: Run, confirm failure**
+- [ ] **Step 3: Implement**
+- [ ] **Step 4: build, vet, `go test -race ./...`**
+- [ ] **Step 5: Commit** — `feat(platform-api): Zitadel account operations`
+
+---
+
+### Task 3: Selection and wiring
+
+**Files:**
+- Modify: `services/platform-api/cmd/server/main.go` (around the `gipAdmin` construction at ~line 243), `cmd/server/account_wiring.go`, `pkg/config`, and tests
+
+Select by flag, defaulting to GIP. Mirror `services/auth-bff/pkg/config`'s `ZITADEL_ENABLED` + `ValidateZitadel()` shape: dependent values required only when enabled, inert when not.
+
+**`EnsureTenantClaim` still needs the GIP client**, so a Zitadel deployment keeps `gipAdmin` alive for that one call. Two concerns with two lifetimes — say clearly in the code which is which, so a later reader does not "tidy up" the GIP client and break invite-accept.
+
+- [ ] **Step 1: Write the failing tests** — flag unset selects GIP and behaviour is unchanged; flag set selects Zitadel for the three operations while `EnsureTenantClaim` still runs against GIP; a misconfigured Zitadel fails clearly rather than silently falling back; the nil-interface guard still behaves when a provider is absent.
+- [ ] **Step 2: Run, confirm failure**
+- [ ] **Step 3: Implement**
+- [ ] **Step 4: build, vet, `go test -race ./...`**
+- [ ] **Step 5: Commit** — `feat(platform-api): select account operations by provider`
+
+---
+
+### Task 4: Documentation
+
+**Files:**
+- Modify: the doc comments or package docs where this service documents auth
+
+- [ ] **Step 1:** Record which operations moved and which did not, and **why `EnsureTenantClaim` is still here** — that it is dead only once `ZITADEL_ENABLED` is true on marketplace-api, and that deleting it sooner gives newly-invited merchants a permanent "No store yet" on mobile. Record that the reset code is returned to us on purpose so mail stays on our own delivery path. Note the nil-interface trap and how the wiring avoids it.
+- [ ] **Step 2: Commit** — `docs(platform-api): record the Zitadel account-operation split`

--- a/services/platform-api/cmd/server/account_wiring.go
+++ b/services/platform-api/cmd/server/account_wiring.go
@@ -9,12 +9,13 @@ import (
 
 	"github.com/mark8ly/platform-api/internal/account"
 	"github.com/mark8ly/platform-api/internal/authz"
-	"github.com/mark8ly/platform-api/internal/gipadmin"
 )
 
 // gipAccountDeleter mirrors internal/account's unexported gipDeleter
 // interface. It exists so this package can hold a TRUE nil interface value
-// when GIP is unconfigured — see newAccountService.
+// when no delete-account provider is configured, and so it is satisfied
+// equally by *gipadmin.AdminClient and *zitadeladmin.Client (#524 phase 5).
+// See newAccountService and selectAccountProviders.
 type gipAccountDeleter interface {
 	DeleteAccount(ctx context.Context, uid string) error
 }
@@ -26,26 +27,29 @@ type gipAccountDeleter interface {
 // (see account_wiring_test.go). This is NOT the general main.go refactor —
 // that is #323.
 //
-// # Why gipAdmin is not passed straight through
+// # gip must already be a genuinely nil-or-real interface value
 //
-// gipAdmin is a CONCRETE *gipadmin.AdminClient; account.NewService's
-// parameter is an INTERFACE. Assigning a nil *AdminClient into an interface
-// produces a NON-NIL interface value holding a nil pointer, so
-// Service.cleanupAfterTeardown's `if s.gip != nil` guard PASSES and
-// DeleteAccount runs on a nil receiver, panicking as it dereferences the
-// client's config.
+// account.NewService's gip parameter is an INTERFACE
+// (gipAccountDeleter/the package-local mirror of internal/account's
+// unexported gipDeleter). Since #524 phase 5 task 3, the caller —
+// selectAccountProviders — is the place that performs the typed-nil guard:
+// it only ever assigns a concrete, non-nil client (gipAdmin OR a
+// *zitadeladmin.Client) into the interface it returns, or leaves it a true
+// nil interface when no provider is configured. newAccountService trusts
+// that and passes gip straight through.
 //
-// That panic lands AFTER the teardown transaction has committed. gin's
-// Recovery answers 500, marketplace-api's tenantlifecycle maps it to
-// ErrUnavailable, and the operator is told `503 upstream_unavailable` — for
-// a tenant that is already destroyed and whose purge was never audited.
-// platform-api deployed without GIP_PROJECT_ID/GIP_TENANT_ID/
-// GIP_WEB_API_KEY is a real configuration; the startup warning above the
-// call site exists because of it.
-//
-// So: declare the interface-typed variable, assign it ONLY inside the
-// non-nil guard, and pass that. Same shape marketplace-api already uses for
-// its TenantTeardown client (cmd/marketplace-api/main.go).
+// Do NOT reintroduce the trap here by accepting a concrete
+// *gipadmin.AdminClient again and assigning it unconditionally — see
+// selectAccountProviders' doc (provider_wiring.go) and
+// TestSelectAccountProviders_FlagUnset_NilGIPStaysGenuinelyNil for why: a
+// nil *AdminClient assigned straight into an interface is a NON-NIL
+// interface holding a nil pointer, so Service.cleanupAfterTeardown's
+// `if s.gip != nil` guard PASSES and DeleteAccount runs on a nil receiver,
+// panicking as it dereferences the client's config — AFTER the teardown
+// transaction has committed. gin's Recovery then answers 500,
+// marketplace-api's tenantlifecycle maps it to ErrUnavailable, and the
+// operator is told `503 upstream_unavailable` for a tenant that is already
+// destroyed and whose purge was never audited.
 //
 // fga needs no such treatment: it is declared in main as `var fga
 // authz.Client`, an interface all the way down, so it is a TRUE nil
@@ -55,7 +59,7 @@ func newAccountService(
 	conn *gorm.DB,
 	repo account.TenantRepo,
 	fga authz.Client,
-	gipAdmin *gipadmin.AdminClient,
+	gip gipAccountDeleter,
 	// enqueue is deliberately an UNNAMED func type: a named type here would
 	// not be assignable to internal/account's named outboxEnqueuer. The
 	// delay parameter is outbox.EnqueueAfter's — see account.outboxEnqueuer
@@ -63,9 +67,5 @@ func newAccountService(
 	enqueue func(tx *gorm.DB, kind string, payload any, delay time.Duration) error,
 	log *slog.Logger,
 ) *account.Service {
-	var gipCleanup gipAccountDeleter
-	if gipAdmin != nil {
-		gipCleanup = gipAdmin
-	}
-	return account.NewService(conn, repo, fga, gipCleanup, enqueue, log)
+	return account.NewService(conn, repo, fga, gip, enqueue, log)
 }

--- a/services/platform-api/cmd/server/invite_claims_wiring_test.go
+++ b/services/platform-api/cmd/server/invite_claims_wiring_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestMainCallsNewTenantClaimSetterUnconditionally is the direct
+// production-wiring test the reviewer's gap called for: it is not enough
+// that newTenantClaimSetter itself guards the typed-nil trap and ignores
+// cfg.ZitadelEnabled by construction — main.go could still stop calling
+// it, or wrap the call in an `if` that skips it under some condition,
+// without any other test noticing.
+//
+// This parses cmd/server/main.go's actual source (not a copy) and asserts
+// TWO things at once:
+//  1. main() calls newTenantClaimSetter exactly once.
+//  2. That call is a TOP-LEVEL statement in main()'s body — found by
+//     scanning main.Body.List directly rather than recursively — so a
+//     call moved inside any if/else/switch block (e.g. gated on
+//     cfg.ZitadelEnabled) is invisible to this scan and fails the test.
+//  3. Its sole argument is the identifier "gipAdmin" — the client kept
+//     alive for EnsureTenantClaim — not some other, Zitadel-conditional
+//     value.
+//
+// Mirrors the AST-parsing approach TestMainSetsEveryInternalHandlersField
+// (internal_wiring_test.go) already uses for the identical reason: proving
+// a fact about main.go's literal wiring that no other test can see.
+func TestMainCallsNewTenantClaimSetterUnconditionally(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse main.go: %v", err)
+	}
+
+	var mainFunc *ast.FuncDecl
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == "main" {
+			mainFunc = fn
+			break
+		}
+	}
+	if mainFunc == nil {
+		t.Fatal("main.go must declare func main")
+	}
+
+	var calls []*ast.CallExpr
+	for _, stmt := range mainFunc.Body.List {
+		var call *ast.CallExpr
+		switch s := stmt.(type) {
+		case *ast.AssignStmt:
+			if len(s.Rhs) == 1 {
+				if c, ok := s.Rhs[0].(*ast.CallExpr); ok {
+					call = c
+				}
+			}
+		case *ast.ExprStmt:
+			if c, ok := s.X.(*ast.CallExpr); ok {
+				call = c
+			}
+		}
+		if call == nil {
+			continue
+		}
+		if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == "newTenantClaimSetter" {
+			calls = append(calls, call)
+		}
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("found %d top-level call(s) to newTenantClaimSetter in main(), want exactly 1. "+
+			"If this is 0, either the call was removed or it was nested inside an if/else/switch "+
+			"(e.g. gated on cfg.ZitadelEnabled) — either way EnsureTenantClaim can silently stop "+
+			"running against GIP, and marketplace-api's flag-off path reading the tenant_id claim "+
+			"breaks for every newly-invited merchant.", len(calls))
+	}
+
+	call := calls[0]
+	if len(call.Args) != 1 {
+		t.Fatalf("newTenantClaimSetter called with %d args, want exactly 1 (gipAdmin)", len(call.Args))
+	}
+	arg, ok := call.Args[0].(*ast.Ident)
+	if !ok || arg.Name != "gipAdmin" {
+		t.Fatalf("newTenantClaimSetter's argument = %#v, want the identifier gipAdmin — "+
+			"EnsureTenantClaim must always run against the GIP client, never a "+
+			"Zitadel-conditional value", call.Args[0])
+	}
+}

--- a/services/platform-api/cmd/server/invite_claims_wiring_test.go
+++ b/services/platform-api/cmd/server/invite_claims_wiring_test.go
@@ -88,3 +88,66 @@ func TestMainCallsNewTenantClaimSetterUnconditionally(t *testing.T) {
 			"Zitadel-conditional value", call.Args[0])
 	}
 }
+
+// TestMainNeverReassignsGipAdminAfterConstruction closes a gap the
+// previous test leaves open: matching on the argument IDENTIFIER
+// "gipAdmin" would still pass if some other statement — e.g. an
+// `if cfg.ZitadelEnabled { gipAdmin = nil }` inserted ABOVE the
+// newTenantClaimSetter call — reassigned that same variable first. The
+// call-site check alone cannot see that; this one can.
+//
+// So this scans main()'s ENTIRE body (recursively, unlike the top-level-only
+// scan above, specifically so it also sees inside if/else/switch blocks)
+// for every assignment to an identifier named "gipAdmin", and requires
+// there to be EXACTLY ONE: the "gipAdmin = admin" line inside the
+// successful-construction branch. A second assignment anywhere —
+// including one that only fires when ZitadelEnabled is true — fails this
+// test, whatever value it assigns.
+//
+// This is deliberately narrow: it does not understand control flow or
+// prove gipAdmin is non-nil at the newTenantClaimSetter call site (that
+// is requireGIPForTenantClaim's job, enforced at runtime, not this
+// test's). It only proves the variable is never reassigned after its
+// single construction point — cheap, and enough to catch the specific
+// shape of regression described above.
+func TestMainNeverReassignsGipAdminAfterConstruction(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse main.go: %v", err)
+	}
+
+	var mainFunc *ast.FuncDecl
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == "main" {
+			mainFunc = fn
+			break
+		}
+	}
+	if mainFunc == nil {
+		t.Fatal("main.go must declare func main")
+	}
+
+	var assignments []*ast.AssignStmt
+	ast.Inspect(mainFunc.Body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for _, lhs := range assign.Lhs {
+			if ident, ok := lhs.(*ast.Ident); ok && ident.Name == "gipAdmin" {
+				assignments = append(assignments, assign)
+			}
+		}
+		return true
+	})
+
+	if len(assignments) != 1 {
+		t.Fatalf("found %d assignment(s) to gipAdmin in main(), want exactly 1 (its single "+
+			"successful-construction assignment). A second assignment anywhere — including "+
+			"one only reached when ZitadelEnabled is true — can defeat the "+
+			"TestMainCallsNewTenantClaimSetterUnconditionally check above, since that test "+
+			"only looks at the call's argument NAME, not the value gipAdmin holds by the "+
+			"time the call runs.", len(assignments))
+	}
+}

--- a/services/platform-api/cmd/server/main.go
+++ b/services/platform-api/cmd/server/main.go
@@ -230,16 +230,20 @@ func main() {
 	// secret disables it (dev convenience).
 	auditClient := audit.New(cfg.MarketplaceAPIURL, cfg.AuditIngestSecret, log)
 
-	// ─── Password reset (Phase: GIP-aware branded flow) ────────────────
-	// Wires the /internal/auth/password-reset/* endpoints used by the
-	// admin BFF. Requires GIP_PROJECT_ID, GIP_TENANT_ID, and
-	// GIP_WEB_API_KEY. If any are missing the handler is skipped —
-	// dev machines without real GIP credentials fall through to GIP's
-	// default behaviour via auth-bff.
-	var authHandler *auth.Handler
+	// ─── GIP admin client (EnsureTenantClaim) ───────────────────────────
 	// Hoisted: the outbox drainer needs this client to stamp the owner's
 	// tenant_id GIP custom claim after onboarding completes, and the
 	// invitation service needs it to stamp the same claim on accept.
+	//
+	// Its lifetime is governed ENTIRELY by GIP_PROJECT_ID/GIP_TENANT_ID/a
+	// GIP API key being present — NEVER by cfg.ZitadelEnabled. D7 drops
+	// this claim only once ZITADEL_ENABLED is true on marketplace-api too
+	// (a separate service, a separate cutover); until then a Zitadel
+	// deployment of platform-api still needs this client alive for
+	// EnsureTenantClaim, or newly-invited merchants get a permanent "No
+	// store yet" on mobile. See selectAccountProviders' doc below for the
+	// two-concerns-two-lifetimes split this implies — do NOT gate this
+	// construction on the Zitadel flag.
 	var gipAdmin *gipadmin.AdminClient
 	// GIPKey prefers the unrestricted server key and falls back to the
 	// public web key. The web key is referrer-restricted, so admin calls
@@ -253,20 +257,47 @@ func main() {
 		})
 		if adminErr != nil {
 			log.Error("gipadmin: init", "err", adminErr)
-			log.Warn("auth: password reset disabled — gipadmin init failed")
+			log.Warn("gip: tenant-claim client disabled — gipadmin init failed")
 		} else {
 			gipAdmin = admin
-			authSvc := auth.NewService(auth.Config{
-				Admin:             admin,
-				Sender:            sender,
-				Loader:            templateLoader,
-				EmailFrom:         cfg.EmailFrom,
-				SupportEmail:      cfg.EmailFrom,
-				AdminResetBaseURL: cfg.AdminResetBaseURL,
-				Logger:            log,
-			})
-			authHandler = auth.NewHandler(authSvc, log)
-			log.Info("auth: password reset enabled",
+		}
+	} else {
+		log.Warn("gip: tenant-claim client disabled — missing GIP_PROJECT_ID/GIP_TENANT_ID and GIP_SERVER_API_KEY or GIP_WEB_API_KEY")
+	}
+
+	// ─── Password-reset / account-delete provider (#524 phase 5) ───────
+	// Wires the /internal/auth/password-reset/* endpoints used by the
+	// admin BFF, and the deleter behind account.Service. Selected by
+	// ZITADEL_ENABLED, defaulting to GIP — see selectAccountProviders'
+	// doc (provider_wiring.go) for the full reasoning, including why
+	// gipAdmin above is a SEPARATE concern from what this selects.
+	//
+	// A misconfigured-but-enabled Zitadel must fail startup loudly rather
+	// than silently keep serving merchants against GIP; panic here mirrors
+	// every other startup failure in this file.
+	resetProvider, accountDeleter, providerErr := selectAccountProviders(cfg, gipAdmin)
+	if providerErr != nil {
+		log.Error("account provider selection", "err", providerErr)
+		panic(providerErr)
+	}
+
+	var authHandler *auth.Handler
+	if resetProvider != nil {
+		authSvc := auth.NewService(auth.Config{
+			Admin:             resetProvider,
+			Sender:            sender,
+			Loader:            templateLoader,
+			EmailFrom:         cfg.EmailFrom,
+			SupportEmail:      cfg.EmailFrom,
+			AdminResetBaseURL: cfg.AdminResetBaseURL,
+			Logger:            log,
+		})
+		authHandler = auth.NewHandler(authSvc, log)
+		if cfg.ZitadelEnabled {
+			log.Info("auth: password reset enabled (zitadel)",
+				"reset_url", cfg.AdminResetBaseURL)
+		} else {
+			log.Info("auth: password reset enabled (gip)",
 				"project_id", cfg.GIPProjectID,
 				"tenant_id", cfg.GIPTenantID,
 				"reset_url", cfg.AdminResetBaseURL)
@@ -298,23 +329,23 @@ func main() {
 	invitationHandler := invitation.NewHandler(invitationSvc)
 
 	// ─── Account teardown (Task 5) / operator tenant purge (#288) ───────
-	// The operator teardown path (#288) needs neither FGA nor GIP to
-	// function — its cleanup of both is best-effort post-commit — so the
-	// service is constructed unconditionally and its route is mounted
-	// unconditionally below. Only the MERCHANT DeleteAccount route stays
-	// gated: it calls fga.GetRole and gip.DeleteAccount with no internal
-	// nil-check and would panic on first call.
+	// The operator teardown path (#288) needs neither FGA nor an
+	// account-deletion provider to function — its cleanup of both is
+	// best-effort post-commit — so the service is constructed
+	// unconditionally and its route is mounted unconditionally below.
+	// Only the MERCHANT DeleteAccount route stays gated: it calls
+	// fga.GetRole and gip.DeleteAccount with no internal nil-check and
+	// would panic on first call.
 	//
-	// gipAdmin is passed to newAccountService as the CONCRETE pointer on
-	// purpose: it converts a nil one into a true nil interface rather than
-	// a non-nil interface holding a nil pointer, which would defeat
-	// cleanupAfterTeardown's nil guard and panic AFTER the teardown
-	// transaction commits. See newAccountService.
-	accountSvc := newAccountService(conn, tenantRepo, fga, gipAdmin, outbox.EnqueueAfter, log)
+	// accountDeleter already comes from selectAccountProviders as a
+	// genuinely nil-or-real interface value (never a typed nil) — see
+	// that function's doc and newAccountService's doc for the trap this
+	// avoids.
+	accountSvc := newAccountService(conn, tenantRepo, fga, accountDeleter, outbox.EnqueueAfter, log)
 	accountHandler := account.NewHandler(accountSvc)
-	merchantAccountRoutes := fga != nil && gipAdmin != nil
+	merchantAccountRoutes := fga != nil && accountDeleter != nil
 	if !merchantAccountRoutes {
-		log.Warn("account: merchant teardown endpoint disabled — missing OpenFGA store or GIP_PROJECT_ID/GIP_TENANT_ID and a GIP API key; operator teardown (#288) stays mounted")
+		log.Warn("account: merchant teardown endpoint disabled — missing OpenFGA store or an account-deletion provider (GIP_PROJECT_ID/GIP_TENANT_ID/a GIP API key, or ZITADEL_ENABLED); operator teardown (#288) stays mounted")
 	}
 
 	// ─── Outbox drainer ────────────────────────────────────────────────

--- a/services/platform-api/cmd/server/main.go
+++ b/services/platform-api/cmd/server/main.go
@@ -264,6 +264,15 @@ func main() {
 	} else {
 		log.Warn("gip: tenant-claim client disabled — missing GIP_PROJECT_ID/GIP_TENANT_ID and GIP_SERVER_API_KEY or GIP_WEB_API_KEY")
 	}
+	// A Zitadel cutover must not silently drop EnsureTenantClaim's GIP
+	// dependency — see requireGIPForTenantClaim's doc (provider_wiring.go)
+	// for why "we enabled Zitadel, so GIP_* is dead weight" is exactly the
+	// deploy-time mistake this guards against. Panics, matching every
+	// other startup failure in this file.
+	if err := requireGIPForTenantClaim(cfg, gipAdmin); err != nil {
+		log.Error("startup: gip required for tenant claim", "err", err)
+		panic(err)
+	}
 
 	// ─── Password-reset / account-delete provider (#524 phase 5) ───────
 	// Wires the /internal/auth/password-reset/* endpoints used by the

--- a/services/platform-api/cmd/server/main.go
+++ b/services/platform-api/cmd/server/main.go
@@ -306,12 +306,14 @@ func main() {
 		log.Warn("auth: password reset disabled — missing GIP_PROJECT_ID/GIP_TENANT_ID and GIP_SERVER_API_KEY or GIP_WEB_API_KEY")
 	}
 
-	// Assign through a typed interface variable only when non-nil, so the
-	// invitation service's nil check isn't defeated by a typed-nil pointer.
-	var inviteClaims invitation.TenantClaimSetter
-	if gipAdmin != nil {
-		inviteClaims = gipAdmin
-	}
+	// newTenantClaimSetter is called UNCONDITIONALLY, with gipAdmin as its
+	// only argument — see that function's doc (provider_wiring.go) for why
+	// its signature has no access to cfg.ZitadelEnabled at all. Do not
+	// wrap this call in an `if`, and do not change its argument: doing
+	// either would (re)break EnsureTenantClaim under Zitadel, which is the
+	// exact regression cmd/server/main_test.go's
+	// TestMainCallsNewTenantClaimSetterUnconditionally exists to catch.
+	inviteClaims := newTenantClaimSetter(gipAdmin)
 
 	invitationSvc := invitation.NewService(invitation.Config{
 		Repo:       invitation.NewRepository(conn),

--- a/services/platform-api/cmd/server/provider_wiring.go
+++ b/services/platform-api/cmd/server/provider_wiring.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"github.com/mark8ly/platform-api/internal/auth"
+	"github.com/mark8ly/platform-api/internal/gipadmin"
+	"github.com/mark8ly/platform-api/internal/zitadeladmin"
+	"github.com/mark8ly/platform-api/pkg/config"
+)
+
+// selectAccountProviders picks which identity provider backs the three
+// DESTRUCTIVE, user-visible account operations platform-api performs
+// against an IdP: send a password-reset code, redeem one, and delete an
+// account. It exists as a function purely so this selection is testable
+// against production wiring — see provider_wiring_test.go — mirroring
+// newAccountService's reason for existing in account_wiring.go.
+//
+// # Two concerns, two lifetimes — do not conflate them
+//
+// gipAdmin, the parameter, is the SAME *gipadmin.AdminClient main.go
+// already builds (or leaves nil) for EnsureTenantClaim: the tenant_id
+// custom claim written on invite-accept (internal/invitation/service.go)
+// and consumed via marketplace-api's flag-off GIP path. That client's
+// lifetime is governed ENTIRELY by GIP_PROJECT_ID/GIP_TENANT_ID/a GIP API
+// key being present — never by cfg.ZitadelEnabled. A Zitadel deployment
+// still needs it alive; do not remove or gate its construction here or in
+// main.go on the Zitadel flag, or invite-accept breaks (see
+// cmd/server/main.go's gipAdmin construction comment and the phase plan's
+// "What is deliberately NOT in scope" section).
+//
+// This function's job is a SEPARATE, narrower concern: which client
+// backs password-reset and account-delete. When cfg.ZitadelEnabled is
+// false (default), that is the same gipAdmin instance, guarded against
+// the typed-nil trap below. When true, it is a freshly constructed
+// *zitadeladmin.Client instead — gipAdmin is simply not used for these
+// three operations, but the caller must keep it alive regardless for
+// EnsureTenantClaim.
+//
+// # The typed-nil trap
+//
+// gipAdmin is a CONCRETE *gipadmin.AdminClient. Assigning a nil one
+// straight into an interface-typed return value produces a NON-NIL
+// interface holding a nil pointer: a caller's `if reset != nil` guard
+// would pass, and the eventual call would panic on a nil receiver. See
+// cmd/server/account_wiring.go's newAccountService doc for the full
+// incident this mirrors. The interface-typed locals below are assigned
+// ONLY inside the `gipAdmin != nil` guard, exactly like that function and
+// cmd/server/main.go's existing Admin/inviteClaims wiring.
+//
+// # Fail clearly, never fall back silently
+//
+// When cfg.ZitadelEnabled is true but misconfigured, this returns the
+// error from cfg.ValidateZitadel() (or from constructing the Zitadel
+// client) and BOTH return values nil — never the GIP client. A
+// misconfigured Zitadel deployment must fail startup loudly (the caller
+// is expected to panic on a non-nil error, exactly like every other
+// startup failure in cmd/server/main.go), not silently keep serving
+// merchants against GIP while believing it migrated.
+func selectAccountProviders(cfg *config.Config, gipAdmin *gipadmin.AdminClient) (auth.PasswordResetProvider, gipAccountDeleter, error) {
+	if cfg.ZitadelEnabled {
+		if err := cfg.ValidateZitadel(); err != nil {
+			return nil, nil, err
+		}
+		client, err := zitadeladmin.New(zitadeladmin.Config{
+			BaseURL: cfg.ZitadelIssuer,
+			Token:   cfg.ZitadelLoginClientToken,
+			OrgID:   cfg.ZitadelOrgID,
+		}, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		return client, client, nil
+	}
+
+	var reset auth.PasswordResetProvider
+	var del gipAccountDeleter
+	if gipAdmin != nil {
+		reset = gipAdmin
+		del = gipAdmin
+	}
+	return reset, del, nil
+}

--- a/services/platform-api/cmd/server/provider_wiring.go
+++ b/services/platform-api/cmd/server/provider_wiring.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/mark8ly/platform-api/internal/auth"
 	"github.com/mark8ly/platform-api/internal/gipadmin"
+	"github.com/mark8ly/platform-api/internal/invitation"
 	"github.com/mark8ly/platform-api/internal/zitadeladmin"
 	"github.com/mark8ly/platform-api/pkg/config"
 )
@@ -78,4 +79,38 @@ func selectAccountProviders(cfg *config.Config, gipAdmin *gipadmin.AdminClient) 
 		del = gipAdmin
 	}
 	return reset, del, nil
+}
+
+// newTenantClaimSetter builds the invitation.TenantClaimSetter that
+// invitation/service.go calls on invite-accept to stamp the tenant_id
+// custom claim onto the invited user.
+//
+// Deliberately takes ONLY gipAdmin — no *config.Config, no
+// cfg.ZitadelEnabled anywhere in reach — so this is structurally, not
+// just conventionally, independent of the Zitadel flag: there is no
+// config value in scope for a future edit to branch on. EnsureTenantClaim
+// must keep running against GIP regardless of which provider
+// selectAccountProviders chose for password-reset/delete, because
+// marketplace-api's flag-off path still reads the tenant_id claim and
+// invitation/service.go writes it on accept. See selectAccountProviders'
+// doc above for the full two-concerns-two-lifetimes reasoning this
+// mirrors — this function IS the "EnsureTenantClaim" lifetime; that
+// function's return values are the other one.
+//
+// cmd/server/main_test.go's TestMainCallsNewTenantClaimSetterUnconditionally
+// pins the ONE thing this function's own signature cannot prove by
+// itself: that main.go actually calls it as a top-level, unconditional
+// statement rather than nesting it inside an `if` that could be
+// flag-gated later.
+//
+// Guards the typed-nil trap the same way selectAccountProviders does:
+// gipAdmin is a CONCRETE *gipadmin.AdminClient, so the interface-typed
+// local is assigned only inside the `gipAdmin != nil` guard — never a
+// possibly-nil pointer straight into the interface return.
+func newTenantClaimSetter(gipAdmin *gipadmin.AdminClient) invitation.TenantClaimSetter {
+	var claims invitation.TenantClaimSetter
+	if gipAdmin != nil {
+		claims = gipAdmin
+	}
+	return claims
 }

--- a/services/platform-api/cmd/server/provider_wiring.go
+++ b/services/platform-api/cmd/server/provider_wiring.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/mark8ly/platform-api/internal/auth"
 	"github.com/mark8ly/platform-api/internal/gipadmin"
 	"github.com/mark8ly/platform-api/internal/invitation"
@@ -113,4 +115,50 @@ func newTenantClaimSetter(gipAdmin *gipadmin.AdminClient) invitation.TenantClaim
 		claims = gipAdmin
 	}
 	return claims
+}
+
+// requireGIPForTenantClaim is the DEPLOY-time half of the guard
+// newTenantClaimSetter enforces in code. A code review (and
+// TestMainCallsNewTenantClaimSetterUnconditionally) can prove main.go
+// still WIRES gipAdmin into EnsureTenantClaim unconditionally, but neither
+// can stop an operator's config change from pulling the rug out from
+// under it: enabling Zitadel and, as the natural "we've migrated" action,
+// also removing GIP_PROJECT_ID/GIP_TENANT_ID/the GIP key.
+//
+// Without this check, that combination leaves gipAdmin nil,
+// newTenantClaimSetter correctly (per its own guard) returns a true nil
+// invitation.TenantClaimSetter, and EnsureTenantClaim silently no-ops
+// behind cmd/server/main.go's one log.Warn line — invite-accept
+// (internal/invitation/service.go) stops writing the tenant_id custom
+// claim, and every newly-invited merchant gets a permanent "No store yet"
+// on mobile. Nothing fails at startup; it surfaces days later as a
+// support ticket.
+//
+// So: when cfg.ZitadelEnabled is true, gipAdmin must be non-nil — for ANY
+// reason it might not be (missing config, or gipadmin.New itself failing,
+// e.g. ADC unavailable) — or this returns an error the caller is expected
+// to panic on, exactly like config.ValidateZitadel's own missing-value
+// errors and every other startup failure in cmd/server/main.go. A
+// crashloop on a bad rollout is the correct outcome here; a quiet no-op
+// that surfaces as "merchants can't see their store" is not.
+//
+// When cfg.ZitadelEnabled is false this is always nil — flag-off behaviour
+// must stay byte-identical to before this check existed, including dev
+// machines that run with no GIP credentials at all.
+func requireGIPForTenantClaim(cfg *config.Config, gipAdmin *gipadmin.AdminClient) error {
+	if !cfg.ZitadelEnabled {
+		return nil
+	}
+	if gipAdmin != nil {
+		return nil
+	}
+	return fmt.Errorf("gip: ZITADEL_ENABLED=true but the GIP client EnsureTenantClaim " +
+		"depends on is not available (see the preceding log line for whether " +
+		"GIP_PROJECT_ID/GIP_TENANT_ID/a GIP API key are missing, or gipadmin init " +
+		"itself failed). This client is still REQUIRED after a Zitadel cutover here: " +
+		"invite-accept (internal/invitation/service.go) writes the tenant_id custom " +
+		"claim through it, and marketplace-api's flag-off path still reads that claim " +
+		"— dropping GIP_PROJECT_ID/GIP_TENANT_ID/the GIP key is only safe once " +
+		"ZITADEL_ENABLED is ALSO true on marketplace-api, a separate service and a " +
+		"separate cutover. Restore the GIP_* variables, or do not enable Zitadel here yet")
 }

--- a/services/platform-api/cmd/server/provider_wiring_test.go
+++ b/services/platform-api/cmd/server/provider_wiring_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/mark8ly/platform-api/internal/gipadmin"
@@ -37,6 +38,48 @@ func TestNewTenantClaimSetter_NilGIPStaysGenuinelyNil(t *testing.T) {
 	if claims != nil {
 		t.Fatal("claims must be a genuinely nil interface when gipAdmin is nil, " +
 			"not a non-nil interface wrapping a nil *gipadmin.AdminClient")
+	}
+}
+
+// --- requireGIPForTenantClaim: the deploy-time half of the same guard ---
+
+// TestRequireGIPForTenantClaim_FlagOff_NeverRequired pins flag-off
+// byte-identical behaviour: today's production (ZITADEL_ENABLED unset)
+// runs fine with GIP unconfigured (dev without real GIP credentials), and
+// this new check must not turn that into a startup failure.
+func TestRequireGIPForTenantClaim_FlagOff_NeverRequired(t *testing.T) {
+	cfg := &config.Config{ZitadelEnabled: false}
+	if err := requireGIPForTenantClaim(cfg, nil); err != nil {
+		t.Fatalf("requireGIPForTenantClaim() with the flag off = %v, want nil", err)
+	}
+}
+
+// TestRequireGIPForTenantClaim_FlagOn_MissingGIP_FailsClearly is the
+// regression test for the deploy-time gap: enabling Zitadel while also
+// dropping GIP_PROJECT_ID/GIP_TENANT_ID/the GIP key (the "we've migrated"
+// operator action) must fail startup loudly, not leave EnsureTenantClaim
+// silently no-op-ing behind a log.Warn.
+func TestRequireGIPForTenantClaim_FlagOn_MissingGIP_FailsClearly(t *testing.T) {
+	cfg := &config.Config{ZitadelEnabled: true}
+	err := requireGIPForTenantClaim(cfg, nil)
+	if err == nil {
+		t.Fatal("requireGIPForTenantClaim() = nil, want an error when gipAdmin is nil and Zitadel is enabled")
+	}
+	for _, want := range []string{"EnsureTenantClaim", "marketplace-api"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %q, want it to mention %q so an operator understands why", err.Error(), want)
+		}
+	}
+}
+
+// TestRequireGIPForTenantClaim_FlagOn_GIPPresent_Boots pins that a
+// correctly configured Zitadel-enabled deployment (GIP client built
+// successfully) boots without this new check getting in the way.
+func TestRequireGIPForTenantClaim_FlagOn_GIPPresent_Boots(t *testing.T) {
+	cfg := &config.Config{ZitadelEnabled: true}
+	admin := &gipadmin.AdminClient{}
+	if err := requireGIPForTenantClaim(cfg, admin); err != nil {
+		t.Fatalf("requireGIPForTenantClaim() with gipAdmin present = %v, want nil", err)
 	}
 }
 

--- a/services/platform-api/cmd/server/provider_wiring_test.go
+++ b/services/platform-api/cmd/server/provider_wiring_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mark8ly/platform-api/internal/gipadmin"
+	"github.com/mark8ly/platform-api/internal/zitadeladmin"
+	"github.com/mark8ly/platform-api/pkg/config"
+)
+
+// TestSelectAccountProviders_FlagUnset_SelectsGIP pins that with
+// ZITADEL_ENABLED unset (production today), the reset-provider and
+// deleter handed to auth.Service and the account teardown service are
+// exactly the gipAdmin client already built for EnsureTenantClaim — no
+// new behaviour on the GIP path.
+func TestSelectAccountProviders_FlagUnset_SelectsGIP(t *testing.T) {
+	admin := &gipadmin.AdminClient{}
+	cfg := &config.Config{ZitadelEnabled: false}
+
+	reset, del, err := selectAccountProviders(cfg, admin)
+	if err != nil {
+		t.Fatalf("selectAccountProviders() error = %v, want nil", err)
+	}
+	if reset != admin {
+		t.Fatalf("reset provider = %v, want the gipAdmin client %v", reset, admin)
+	}
+	if del != admin {
+		t.Fatalf("deleter = %v, want the gipAdmin client %v", del, admin)
+	}
+}
+
+// TestSelectAccountProviders_FlagUnset_NilGIPStaysGenuinelyNil is the
+// typed-nil regression test: this is what makes the test suite fail first
+// against a naive implementation that assigns a possibly-nil
+// *gipadmin.AdminClient straight into the interface return values.
+//
+// gipAdmin is declared as a nil *gipadmin.AdminClient (the "GIP
+// unconfigured" case in cmd/server/main.go) with NO New() call — a typed
+// nil pointer needs no working credentials to construct.
+func TestSelectAccountProviders_FlagUnset_NilGIPStaysGenuinelyNil(t *testing.T) {
+	var admin *gipadmin.AdminClient // nil concrete pointer
+	cfg := &config.Config{ZitadelEnabled: false}
+
+	reset, del, err := selectAccountProviders(cfg, admin)
+	if err != nil {
+		t.Fatalf("selectAccountProviders() error = %v, want nil", err)
+	}
+	if reset != nil {
+		t.Fatal("reset provider must be a genuinely nil interface when gipAdmin is nil, " +
+			"not a non-nil interface wrapping a nil *gipadmin.AdminClient")
+	}
+	if del != nil {
+		t.Fatal("deleter must be a genuinely nil interface when gipAdmin is nil, " +
+			"not a non-nil interface wrapping a nil *gipadmin.AdminClient")
+	}
+}
+
+// TestSelectAccountProviders_FlagSet_SelectsZitadel pins that a fully
+// configured, enabled Zitadel deployment gets a *zitadeladmin.Client for
+// BOTH the reset provider and the deleter — and NOT the gipAdmin instance,
+// even though gipAdmin is passed in (it must still be alive for
+// EnsureTenantClaim elsewhere, but it must not be what this function
+// returns once Zitadel is selected).
+func TestSelectAccountProviders_FlagSet_SelectsZitadel(t *testing.T) {
+	admin := &gipadmin.AdminClient{}
+	cfg := &config.Config{
+		ZitadelEnabled:          true,
+		ZitadelIssuer:           "https://login.mark8ly.zitadel.cloud",
+		ZitadelLoginClientToken: "pat",
+		ZitadelOrgID:            "339070697432875523",
+	}
+
+	reset, del, err := selectAccountProviders(cfg, admin)
+	if err != nil {
+		t.Fatalf("selectAccountProviders() error = %v, want nil", err)
+	}
+	if _, ok := reset.(*zitadeladmin.Client); !ok {
+		t.Fatalf("reset provider = %T, want *zitadeladmin.Client", reset)
+	}
+	if _, ok := del.(*zitadeladmin.Client); !ok {
+		t.Fatalf("deleter = %T, want *zitadeladmin.Client", del)
+	}
+}
+
+// TestSelectAccountProviders_FlagSet_Misconfigured_FailsClearly pins that a
+// misconfigured Zitadel deployment refuses with an error wrapping
+// config.ErrZitadelNotConfigured, rather than silently falling back to
+// GIP — the deleter/reset provider must both come back nil so nothing
+// downstream can mistake this for "GIP selected".
+func TestSelectAccountProviders_FlagSet_Misconfigured_FailsClearly(t *testing.T) {
+	admin := &gipadmin.AdminClient{}
+	cfg := &config.Config{
+		ZitadelEnabled: true,
+		// ZitadelIssuer, ZitadelLoginClientToken, ZitadelOrgID all unset.
+	}
+
+	reset, del, err := selectAccountProviders(cfg, admin)
+	if err == nil {
+		t.Fatal("selectAccountProviders() error = nil, want a misconfiguration error")
+	}
+	if !errors.Is(err, config.ErrZitadelNotConfigured) {
+		t.Fatalf("err = %v, want it to wrap config.ErrZitadelNotConfigured", err)
+	}
+	if reset != nil {
+		t.Fatal("reset provider must be nil on misconfiguration, never a silent GIP fallback")
+	}
+	if del != nil {
+		t.Fatal("deleter must be nil on misconfiguration, never a silent GIP fallback")
+	}
+}

--- a/services/platform-api/cmd/server/provider_wiring_test.go
+++ b/services/platform-api/cmd/server/provider_wiring_test.go
@@ -9,6 +9,37 @@ import (
 	"github.com/mark8ly/platform-api/pkg/config"
 )
 
+// --- newTenantClaimSetter: EnsureTenantClaim always runs against GIP ----
+
+// TestNewTenantClaimSetter_UsesGIPAdmin pins that a real gipAdmin client
+// is returned as-is — this is the client invitation/service.go calls
+// EnsureTenantClaim through on invite-accept, and it must be GIP
+// regardless of ZITADEL_ENABLED (marketplace-api's flag-off path still
+// reads the tenant_id claim written this way).
+func TestNewTenantClaimSetter_UsesGIPAdmin(t *testing.T) {
+	admin := &gipadmin.AdminClient{}
+
+	claims := newTenantClaimSetter(admin)
+
+	if claims != admin {
+		t.Fatalf("claims = %v, want the gipAdmin client %v", claims, admin)
+	}
+}
+
+// TestNewTenantClaimSetter_NilGIPStaysGenuinelyNil is the typed-nil
+// regression test for this function, mirroring
+// TestSelectAccountProviders_FlagUnset_NilGIPStaysGenuinelyNil.
+func TestNewTenantClaimSetter_NilGIPStaysGenuinelyNil(t *testing.T) {
+	var admin *gipadmin.AdminClient // nil concrete pointer
+
+	claims := newTenantClaimSetter(admin)
+
+	if claims != nil {
+		t.Fatal("claims must be a genuinely nil interface when gipAdmin is nil, " +
+			"not a non-nil interface wrapping a nil *gipadmin.AdminClient")
+	}
+}
+
 // TestSelectAccountProviders_FlagUnset_SelectsGIP pins that with
 // ZITADEL_ENABLED unset (production today), the reset-provider and
 // deleter handed to auth.Service and the account teardown service are

--- a/services/platform-api/internal/auth/service.go
+++ b/services/platform-api/internal/auth/service.go
@@ -30,9 +30,35 @@ import (
 	"github.com/mark8ly/platform-api/internal/notification"
 )
 
+// PasswordResetProvider is the subset of gipadmin.AdminClient the
+// password-reset flow needs: mint a reset code, then redeem one. Defined
+// as an interface — rather than depending on the concrete
+// *gipadmin.AdminClient type here — so a later provider (e.g. Zitadel,
+// #524 Phase 5) can satisfy the same contract without this package
+// changing.
+//
+// Construct the interface value ONLY when a real, non-nil client
+// exists — never assign a possibly-nil *gipadmin.AdminClient straight
+// into Config.Admin. Doing so would produce a non-nil interface value
+// wrapping a nil pointer (the "typed nil" trap documented in
+// cmd/server/account_wiring.go): every method below unconditionally
+// dereferences the client's config, so a caller's `!= nil` guard would
+// be defeated and the eventual call would panic. cmd/server/main.go
+// already follows the safe pattern: it only calls auth.NewService
+// inside the branch where gipadmin.New succeeded, so Admin here is
+// always a genuine, non-nil client.
+type PasswordResetProvider interface {
+	SendPasswordResetOobCode(ctx context.Context, email string) (string, error)
+	ResetPassword(ctx context.Context, oobCode, newPassword string) error
+}
+
+// Compile-time proof that *gipadmin.AdminClient satisfies
+// PasswordResetProvider unchanged — this task adds no behaviour to it.
+var _ PasswordResetProvider = (*gipadmin.AdminClient)(nil)
+
 // Config bundles the dependencies and tunables for Service.
 type Config struct {
-	Admin  *gipadmin.AdminClient
+	Admin  PasswordResetProvider
 	Sender notification.Sender
 	// Loader is the DB-backed template loader (embedded fallback). May
 	// be nil during boot races; nil falls through to embedded rendering.

--- a/services/platform-api/internal/auth/service_test.go
+++ b/services/platform-api/internal/auth/service_test.go
@@ -1,0 +1,184 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/mark8ly/platform-api/internal/gipadmin"
+	"github.com/mark8ly/platform-api/internal/notification"
+)
+
+// fakeProvider is an in-memory double for PasswordResetProvider.
+type fakeProvider struct {
+	sendCode  string
+	sendErr   error
+	resetErr  error
+	sentEmail string
+	resetOob  string
+	resetPass string
+}
+
+func (f *fakeProvider) SendPasswordResetOobCode(ctx context.Context, email string) (string, error) {
+	f.sentEmail = email
+	if f.sendErr != nil {
+		return "", f.sendErr
+	}
+	return f.sendCode, nil
+}
+
+func (f *fakeProvider) ResetPassword(ctx context.Context, oobCode, newPassword string) error {
+	f.resetOob = oobCode
+	f.resetPass = newPassword
+	return f.resetErr
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newTestService(admin PasswordResetProvider) *Service {
+	return NewService(Config{
+		Admin:             admin,
+		Sender:            notification.NoopSender{},
+		EmailFrom:         "noreply@mark8ly.com",
+		SupportEmail:      "support@mark8ly.com",
+		AdminResetBaseURL: "https://admin.mark8ly.com",
+		Logger:            testLogger(),
+	})
+}
+
+// --- Regression test for the typed-nil interface trap ------------------
+
+// TestPasswordResetProvider_GuardedConstructionStaysGenuinelyNil is the
+// regression test for the incident documented in
+// cmd/server/account_wiring.go: assigning a possibly-nil concrete
+// *gipadmin.AdminClient into an interface produces a NON-NIL interface
+// value wrapping a nil pointer, so a `!= nil` guard is defeated and a
+// later call panics on the nil receiver.
+//
+// This proves the correct pattern (construct the interface value only
+// inside the non-nil guard, exactly like cmd/server/main.go's Admin
+// wiring and account_wiring.go's gipCleanup wiring) leaves the interface
+// genuinely nil when no real client exists, so a `!= nil` guard sees it
+// as absent and nothing ever calls through it.
+//
+// MUTATION: assign the nil *gipadmin.AdminClient straight into the
+// interface-typed variable (skip the "admin != nil" guard) and this test
+// fails, because "naive" would then also report != nil.
+func TestPasswordResetProvider_GuardedConstructionStaysGenuinelyNil(t *testing.T) {
+	var admin *gipadmin.AdminClient // nil concrete pointer — "unconfigured" case
+
+	// The WRONG way: demonstrates the trap. A nil *gipadmin.AdminClient
+	// assigned directly into the interface is NOT a nil interface.
+	var naive PasswordResetProvider = admin
+	if naive == nil {
+		t.Fatal("sanity check failed: assigning a nil *AdminClient into an interface " +
+			"was expected to produce a non-nil interface (the well-known typed-nil trap) " +
+			"— if this now reports nil, the language/runtime assumption behind the guarded " +
+			"pattern below no longer holds")
+	}
+
+	// The RIGHT way: exactly what cmd/server/main.go and
+	// cmd/server/account_wiring.go already do — construct the
+	// interface-typed value ONLY inside the non-nil guard.
+	var guarded PasswordResetProvider
+	if admin != nil {
+		guarded = admin
+	}
+	if guarded != nil {
+		t.Fatal("guarded construction must leave the interface genuinely nil " +
+			"when no real client exists, so callers' `!= nil` checks see it as absent")
+	}
+
+	// And genuinely absent means callers never dispatch through it. We
+	// don't call a method on `guarded` here — doing so would panic
+	// regardless of nil-ness, because there is no concrete type to
+	// dispatch to. The guard's entire job is making sure that call site
+	// is never reached, which `guarded != nil` above proves.
+}
+
+// TestNewService_AdminSetOnlyWhenRealClientExists documents that Config.Admin
+// must be populated with a genuinely non-nil PasswordResetProvider — never a
+// possibly-nil *gipadmin.AdminClient assigned straight through — mirroring
+// how cmd/server/main.go only calls auth.NewService inside the branch where
+// gipadmin.New succeeded.
+func TestNewService_AdminSetOnlyWhenRealClientExists(t *testing.T) {
+	fake := &fakeProvider{sendCode: "oob-abc"}
+	svc := newTestService(fake)
+
+	if err := svc.RequestPasswordReset(context.Background(), "merchant@example.com"); err != nil {
+		t.Fatalf("RequestPasswordReset: %v", err)
+	}
+	if fake.sentEmail != "merchant@example.com" {
+		t.Fatalf("sentEmail = %q, want %q", fake.sentEmail, "merchant@example.com")
+	}
+}
+
+// --- Existing behaviour, unchanged --------------------------------------
+
+func TestRequestPasswordReset_UnknownEmailSuppressesEnumeration(t *testing.T) {
+	fake := &fakeProvider{sendErr: gipadmin.ErrUserNotFound}
+	svc := newTestService(fake)
+
+	if err := svc.RequestPasswordReset(context.Background(), "nobody@example.com"); err != nil {
+		t.Fatalf("RequestPasswordReset with unknown email must return nil, got: %v", err)
+	}
+}
+
+func TestRequestPasswordReset_UpstreamErrorPropagates(t *testing.T) {
+	wantErr := errors.New("boom")
+	fake := &fakeProvider{sendErr: wantErr}
+	svc := newTestService(fake)
+
+	err := svc.RequestPasswordReset(context.Background(), "merchant@example.com")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+}
+
+func TestRequestPasswordReset_EmptyEmailRejected(t *testing.T) {
+	svc := newTestService(&fakeProvider{})
+
+	if err := svc.RequestPasswordReset(context.Background(), "   "); err == nil {
+		t.Fatal("expected error for empty email")
+	}
+}
+
+func TestConfirmPasswordReset_DelegatesToProvider(t *testing.T) {
+	fake := &fakeProvider{}
+	svc := newTestService(fake)
+
+	if err := svc.ConfirmPasswordReset(context.Background(), " oob-xyz ", "correct horse battery staple"); err != nil {
+		t.Fatalf("ConfirmPasswordReset: %v", err)
+	}
+	if fake.resetOob != "oob-xyz" {
+		t.Fatalf("resetOob = %q, want %q", fake.resetOob, "oob-xyz")
+	}
+	if fake.resetPass != "correct horse battery staple" {
+		t.Fatalf("resetPass = %q", fake.resetPass)
+	}
+}
+
+func TestConfirmPasswordReset_WeakPasswordRejectedBeforeProvider(t *testing.T) {
+	fake := &fakeProvider{}
+	svc := newTestService(fake)
+
+	err := svc.ConfirmPasswordReset(context.Background(), "oob-xyz", "short")
+	if !errors.Is(err, gipadmin.ErrWeakPassword) {
+		t.Fatalf("err = %v, want ErrWeakPassword", err)
+	}
+	if fake.resetOob != "" {
+		t.Fatal("provider must not be called when the password fails the local length check")
+	}
+}
+
+func TestConfirmPasswordReset_MissingOobCodeRejected(t *testing.T) {
+	svc := newTestService(&fakeProvider{})
+
+	if err := svc.ConfirmPasswordReset(context.Background(), "  ", "correct horse battery staple"); err == nil {
+		t.Fatal("expected error for empty oob code")
+	}
+}

--- a/services/platform-api/internal/gipadmin/password_reset_provider_test.go
+++ b/services/platform-api/internal/gipadmin/password_reset_provider_test.go
@@ -1,0 +1,66 @@
+package gipadmin
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// passwordResetProviderShape mirrors internal/auth.PasswordResetProvider's
+// method set. It is redeclared locally, rather than importing internal/auth,
+// because internal/auth imports gipadmin — importing auth back from a
+// gipadmin_test file (compiled as part of package gipadmin) would be a
+// import cycle. auth/service.go itself carries the compile-time assertion
+// (`var _ PasswordResetProvider = (*gipadmin.AdminClient)(nil)`) proving
+// *AdminClient satisfies the real interface; this test additionally proves
+// the methods are reachable through dispatch, not just structurally
+// matching, by driving both calls through a variable of this shape against
+// a real HTTP round trip.
+type passwordResetProviderShape interface {
+	SendPasswordResetOobCode(ctx context.Context, email string) (string, error)
+	ResetPassword(ctx context.Context, oobCode, newPassword string) error
+}
+
+// TestAdminClient_SatisfiesPasswordResetProviderShape proves
+// *AdminClient's SendPasswordResetOobCode and ResetPassword are reachable
+// through an interface value — i.e. dynamic dispatch actually reaches the
+// real HTTP-calling methods — not merely that the method set matches.
+func TestAdminClient_SatisfiesPasswordResetProviderShape(t *testing.T) {
+	var sendHit, resetHit bool
+
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "accounts:sendOobCode"):
+			sendHit = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"oobCode":"oob-reachable"}`))
+		case strings.HasSuffix(r.URL.Path, "accounts:resetPassword"):
+			resetHit = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	})
+
+	var provider passwordResetProviderShape = c
+
+	code, err := provider.SendPasswordResetOobCode(context.Background(), "merchant@example.com")
+	if err != nil {
+		t.Fatalf("SendPasswordResetOobCode through interface: %v", err)
+	}
+	if code != "oob-reachable" {
+		t.Fatalf("code = %q, want %q", code, "oob-reachable")
+	}
+	if !sendHit {
+		t.Fatal("SendPasswordResetOobCode dispatched through the interface never reached the HTTP layer")
+	}
+
+	if err := provider.ResetPassword(context.Background(), "oob-reachable", "correct horse battery staple"); err != nil {
+		t.Fatalf("ResetPassword through interface: %v", err)
+	}
+	if !resetHit {
+		t.Fatal("ResetPassword dispatched through the interface never reached the HTTP layer")
+	}
+}

--- a/services/platform-api/internal/zitadeladmin/client.go
+++ b/services/platform-api/internal/zitadeladmin/client.go
@@ -25,14 +25,32 @@
 // Modelled directly on services/auth-bff/internal/zitadellogin/client.go:
 // same requestOptions/do() shape, same withLogPath convention to keep
 // caller-supplied ids out of error strings, same error-body extraction
-// approach. Every JSON shape below is the DOCUMENTED Zitadel v2
-// UserService shape; none of the password-reset or delete request/response
-// bodies were independently re-verified against a live instance while
-// writing this package (unlike zitadellogin's FindUserByVerifiedEmail and
-// LinkIDPToUser, which carry their own "Verified 2026-09-04" notes). Only
-// D7's own table entry for DELETE /v2/users/{id} is marked VERIFIED in the
-// spec. Treat the exact error-body field names below as best-effort until
-// exercised against the real instance.
+// approach (readZitadelErrorID mirrors that package's readZitadelError).
+//
+// VERIFIED 2026-09-04 against the live TESSERIX Zitadel instance: a
+// throwaway user was created, driven through the full password_reset ->
+// password round trip, and deleted.
+//
+//   - POST /v2/users/{id}/password_reset with {"returnCode":{}} returns 200
+//     with {"details":…, "verificationCode":"<6 chars>"} — Zitadel hands
+//     back the code and sends no notification of its own, exactly matching
+//     D7's "return the code so we send the mail".
+//   - POST /v2/users/{id}/password with
+//     {"newPassword":{"password":…},"verificationCode":…} returns 200 on a
+//     real, correct code.
+//   - Error bodies carry a STABLE id at details[0].id, distinct from the
+//     grpc code and from the message text: user-not-found is
+//     COMMAND-SAF4f (404, code 5); a wrong/expired verification code is
+//     COMMAND-2M9fs (400, code 9, message "Code not found"); a request
+//     missing the password field is COMMAND-G8dh3 (400, code 9, message
+//     "Password not found"). The last two share both HTTP status and grpc
+//     code and differ in message by one word — classifyError keys off
+//     details[0].id first for exactly this reason; see its doc.
+//
+// DELETE /v2/users/{id} was separately marked VERIFIED in the D7 spec
+// table. Everything else in this file (the /v2/users search shape, and any
+// error id not in the table above) remains best-effort against the
+// documented Zitadel v2 UserService shape, not independently re-verified.
 package zitadeladmin
 
 import (
@@ -172,7 +190,8 @@ func (c *Client) do(ctx context.Context, method, path string, body, out any, sco
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
-		return fmt.Errorf("zitadeladmin: %s %s: status %d: %w", method, logPath, resp.StatusCode, classifyError(resp.StatusCode, respBody))
+		id := readZitadelErrorID(respBody)
+		return fmt.Errorf("zitadeladmin: %s %s: status %d: %s: %w", method, logPath, resp.StatusCode, id, classifyError(resp.StatusCode, respBody, id))
 	}
 	if out == nil {
 		return nil
@@ -183,25 +202,74 @@ func (c *Client) do(ctx context.Context, method, path string, body, out any, sco
 	return nil
 }
 
-// zitadelErrorBody is the documented Zitadel v2 grpc-gateway error
-// envelope: {"code": <grpc status code>, "message": "..."}.
+// zitadelErrorBody is the Zitadel v2 grpc-gateway error envelope:
+// {"code": <grpc status code>, "message": "...", "details": [{"id": "..."}]}.
 type zitadelErrorBody struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
+	Details []struct {
+		ID string `json:"id"`
+	} `json:"details"`
+}
+
+// readZitadelErrorID extracts ONLY details[0].id from a Zitadel error
+// body, mirroring services/auth-bff/internal/zitadellogin/client.go's
+// readZitadelError (that function also returns the grpc code; this
+// package doesn't currently need it separately, so classifyError re-parses
+// the body itself for code+message). Returns "" when absent or
+// undecodable — the caller must never treat "" as if it were a real,
+// unrecognized id, only as "no id available, fall back to the coarser
+// mapping".
+func readZitadelErrorID(body []byte) string {
+	var e zitadelErrorBody
+	if err := json.Unmarshal(body, &e); err != nil {
+		return ""
+	}
+	if len(e.Details) > 0 {
+		return e.Details[0].ID
+	}
+	return ""
+}
+
+// zitadelErrorIDSentinels maps a Zitadel error's stable details[0].id to
+// the gipadmin sentinel it means, for ids VERIFIED live on 2026-09-04
+// against the TESSERIX instance (see this file's package doc). This is
+// the PRIMARY mapping — classifyError only falls back to HTTP status +
+// message-substring matching when the id is absent or not in this table.
+//
+// COMMAND-2M9fs and COMMAND-G8dh3 are both 400s with grpc code 9 and
+// messages that differ by a single word ("Code not found" vs "Password
+// not found") — text matching alone cannot reliably tell a wrong/expired
+// verification code apart from a malformed request missing the password
+// field, and getting that distinction wrong is exactly the silent
+// degradation this package exists to avoid: a malformed request must never
+// read as "your reset code is invalid" to the merchant. COMMAND-G8dh3
+// therefore maps to ErrUnavailable (a server-side request-shape bug on our
+// end, not a bad code), never to ErrInvalidOobCode.
+var zitadelErrorIDSentinels = map[string]error{
+	"COMMAND-SAF4f": gipadmin.ErrUserNotFound,   // "User could not be found" (404, code 5)
+	"COMMAND-2M9fs": gipadmin.ErrInvalidOobCode, // "Code not found" (400, code 9)
+	"COMMAND-G8dh3": gipadmin.ErrUnavailable,    // "Password not found" (400, code 9) -- malformed request, NOT an invalid code
 }
 
 // classifyError maps an HTTP status + Zitadel error body to one of
-// gipadmin's sentinels. Status code drives the coarse mapping (404 -> not
-// found, 401/403 -> unauthenticated, 429 -> too many attempts); within a
-// 400 the message is inspected because Zitadel's password endpoint can
-// 400 for two very different reasons (an invalid/expired verification code
-// vs. a policy-rejected password) that must NOT collapse into one sentinel
-// — see the CONTRACT note in this file's package doc. A 400 that matches
-// neither known shape maps to ErrUnavailable rather than guessing: a wrong
-// guess here reads as "wrong code" or "weak password" to the merchant when
-// it is neither, which is exactly the silent-degradation failure mode this
-// package exists to avoid.
-func classifyError(status int, body []byte) error {
+// gipadmin's sentinels. id (from readZitadelErrorID) is checked first
+// against zitadelErrorIDSentinels; it is the reliable signal because it is
+// stable and distinguishes cases the message text alone cannot (see that
+// map's doc). When id is absent or not one seen live, this falls back to
+// the coarser HTTP-status mapping (404 -> not found, 401/403 ->
+// unauthenticated, 429 -> too many attempts) and, within an unrecognized
+// 400, a message-substring safety net. A 400 that matches neither the id
+// table nor a known substring maps to ErrUnavailable rather than guessing:
+// a wrong guess here reads as "wrong code" or "weak password" to the
+// merchant when it is neither.
+func classifyError(status int, body []byte, id string) error {
+	if id != "" {
+		if sentinel, ok := zitadelErrorIDSentinels[id]; ok {
+			return sentinel
+		}
+	}
+
 	var e zitadelErrorBody
 	_ = json.Unmarshal(body, &e) // best-effort; a malformed body just yields Message == ""
 	msg := strings.ToLower(e.Message)
@@ -218,8 +286,13 @@ func classifyError(status int, body []byte) error {
 		case strings.Contains(msg, "password") &&
 			(strings.Contains(msg, "weak") || strings.Contains(msg, "polic") || strings.Contains(msg, "complexity")):
 			return gipadmin.ErrWeakPassword
-		case strings.Contains(msg, "code") &&
+		case strings.Contains(msg, "code") && !strings.Contains(msg, "password") &&
 			(strings.Contains(msg, "invalid") || strings.Contains(msg, "expired") || strings.Contains(msg, "not found")):
+			// "not found" is included for the real observed message ("Code
+			// not found"), but only when "password" is absent — the
+			// COMMAND-G8dh3 case ("Password not found") must never match
+			// here. This is now a SAFETY NET behind the id table above,
+			// not the primary signal.
 			return gipadmin.ErrInvalidOobCode
 		default:
 			return gipadmin.ErrUnavailable

--- a/services/platform-api/internal/zitadeladmin/client.go
+++ b/services/platform-api/internal/zitadeladmin/client.go
@@ -1,0 +1,417 @@
+// Package zitadeladmin is the Zitadel v2-API implementation of the three
+// account operations platform-api performs against an identity provider:
+// send a password-reset code, redeem it, and delete an account. It exists
+// to satisfy the interfaces defined in internal/auth (PasswordResetProvider)
+// and internal/account (the unexported gipDeleter shape) — see D7 in
+// docs/superpowers/specs/2026-09-03-zitadel-migration-design.md for the
+// mapping this package implements.
+//
+// # Errors are gipadmin's sentinels, not new ones
+//
+// internal/auth/handler.go and internal/auth/service.go already branch with
+// errors.Is against gipadmin.ErrUserNotFound, ErrInvalidOobCode,
+// ErrWeakPassword, ErrUnauthenticated, ErrTooManyAttempts and ErrUnavailable.
+// This package returns those SAME sentinel values (imported directly from
+// gipadmin, not redeclared) rather than inventing a parallel set — the
+// alternative would silently break every errors.Is check downstream the
+// moment this provider is selected: a rate limit would read as a generic
+// 500, a weak password would read as a server error, and so on, with no
+// compiler or test signal pointing at why. Depending on gipadmin here for
+// its sentinels only, not its behaviour, is deliberate: gipadmin itself is
+// untouched by this package.
+//
+// # Request/response conventions
+//
+// Modelled directly on services/auth-bff/internal/zitadellogin/client.go:
+// same requestOptions/do() shape, same withLogPath convention to keep
+// caller-supplied ids out of error strings, same error-body extraction
+// approach. Every JSON shape below is the DOCUMENTED Zitadel v2
+// UserService shape; none of the password-reset or delete request/response
+// bodies were independently re-verified against a live instance while
+// writing this package (unlike zitadellogin's FindUserByVerifiedEmail and
+// LinkIDPToUser, which carry their own "Verified 2026-09-04" notes). Only
+// D7's own table entry for DELETE /v2/users/{id} is marked VERIFIED in the
+// spec. Treat the exact error-body field names below as best-effort until
+// exercised against the real instance.
+package zitadeladmin
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/mark8ly/platform-api/internal/gipadmin"
+)
+
+const (
+	defaultTimeout      = 15 * time.Second
+	maxSuccessBodyBytes = 64 * 1024
+	maxErrorBodyBytes   = 4096
+)
+
+// ErrAmbiguousEmail is returned when an email search matches more than one
+// Zitadel user. It is NOT one of the sentinels internal/auth/handler.go
+// branches on, and that is deliberate: an ambiguous match is a data
+// integrity problem, not a missing user, a bad code, a weak password, or an
+// unreachable upstream. Falling through handler.go's switch to its default
+// case (500, logged) is the honest outcome — telling the caller "not found"
+// would be false, and "unavailable" would misdirect anyone investigating
+// the log line toward a network problem that doesn't exist. See
+// resolveUserIDByEmail's doc for why this refuses rather than picking one.
+var ErrAmbiguousEmail = errors.New("zitadeladmin: more than one user matched the email")
+
+// Config holds the values needed to construct a Client.
+type Config struct {
+	// BaseURL is the Zitadel instance origin, e.g. "https://auth.tesserix.app".
+	BaseURL string
+	// Token is the service-user/login-client personal access token used to
+	// authenticate every call in this package. It is instance-level and
+	// must never be logged.
+	Token string
+	// OrgID scopes the email->user-id search (see resolveUserIDByEmail).
+	// D1 in the migration spec fixes exactly one org, TESSERIX, for this
+	// whole instance, but the instance is shared with other products (the
+	// package doc on services/auth-bff/internal/zitadellogin/client.go
+	// notes the same PAT can mint sessions for "any user of any product on
+	// the shared instance") — so an unscoped search could still match a
+	// same-address user belonging to a different product's org. Required;
+	// New refuses an empty value rather than searching instance-wide, the
+	// same refusal zitadellogin.FindUserByVerifiedEmail makes.
+	OrgID string
+}
+
+// Client is a thin Zitadel v2 API client for the three account operations
+// platform-api performs against an identity provider.
+type Client struct {
+	baseURL string
+	token   string
+	orgID   string
+	hc      *http.Client
+}
+
+// New constructs a Client. hc may be nil, in which case a client with
+// defaultTimeout is used.
+func New(cfg Config, hc *http.Client) (*Client, error) {
+	if cfg.BaseURL == "" {
+		return nil, fmt.Errorf("zitadeladmin: BaseURL is required")
+	}
+	if cfg.Token == "" {
+		return nil, fmt.Errorf("zitadeladmin: Token is required")
+	}
+	if cfg.OrgID == "" {
+		return nil, fmt.Errorf("zitadeladmin: OrgID is required")
+	}
+	if hc == nil {
+		hc = &http.Client{Timeout: defaultTimeout}
+	}
+	return &Client{
+		baseURL: strings.TrimSuffix(cfg.BaseURL, "/"),
+		token:   cfg.Token,
+		orgID:   cfg.OrgID,
+		hc:      hc,
+	}, nil
+}
+
+// requestOptions accumulates per-request settings, mirroring
+// zitadellogin's shape and its reasoning: an option type over *http.Request
+// itself could clobber the Authorization header set from the token.
+type requestOptions struct {
+	// logPath replaces path in every error/log string do() builds, WITHOUT
+	// affecting the actual HTTP request. Defaults to path. Used to keep a
+	// caller-supplied Zitadel user id out of logs — see withLogPath.
+	logPath string
+}
+
+type requestOption func(*requestOptions)
+
+func withLogPath(label string) requestOption {
+	return func(ro *requestOptions) { ro.logPath = label }
+}
+
+// do performs one HTTP round trip and maps a non-2xx response to one of
+// gipadmin's sentinel errors via classifyError. out may be nil when the
+// caller doesn't need the response body decoded.
+func (c *Client) do(ctx context.Context, method, path string, body, out any, scopeToOrg bool, opts ...requestOption) error {
+	ro := requestOptions{logPath: path}
+	for _, opt := range opts {
+		opt(&ro)
+	}
+	logPath := ro.logPath
+
+	var rdr io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("zitadeladmin: marshal %s %s: %w", method, logPath, err)
+		}
+		rdr = bytes.NewReader(raw)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, rdr)
+	if err != nil {
+		return fmt.Errorf("zitadeladmin: build %s %s: %w", method, logPath, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+	if scopeToOrg {
+		req.Header.Set("x-zitadel-orgid", c.orgID)
+	}
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("zitadeladmin: %s %s: %v: %w", method, logPath, err, gipadmin.ErrUnavailable)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		return fmt.Errorf("zitadeladmin: %s %s: status %d: %w", method, logPath, resp.StatusCode, classifyError(resp.StatusCode, respBody))
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxSuccessBodyBytes)).Decode(out); err != nil {
+		return fmt.Errorf("zitadeladmin: decode %s %s: %v: %w", method, logPath, err, gipadmin.ErrUnavailable)
+	}
+	return nil
+}
+
+// zitadelErrorBody is the documented Zitadel v2 grpc-gateway error
+// envelope: {"code": <grpc status code>, "message": "..."}.
+type zitadelErrorBody struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// classifyError maps an HTTP status + Zitadel error body to one of
+// gipadmin's sentinels. Status code drives the coarse mapping (404 -> not
+// found, 401/403 -> unauthenticated, 429 -> too many attempts); within a
+// 400 the message is inspected because Zitadel's password endpoint can
+// 400 for two very different reasons (an invalid/expired verification code
+// vs. a policy-rejected password) that must NOT collapse into one sentinel
+// — see the CONTRACT note in this file's package doc. A 400 that matches
+// neither known shape maps to ErrUnavailable rather than guessing: a wrong
+// guess here reads as "wrong code" or "weak password" to the merchant when
+// it is neither, which is exactly the silent-degradation failure mode this
+// package exists to avoid.
+func classifyError(status int, body []byte) error {
+	var e zitadelErrorBody
+	_ = json.Unmarshal(body, &e) // best-effort; a malformed body just yields Message == ""
+	msg := strings.ToLower(e.Message)
+
+	switch status {
+	case http.StatusNotFound:
+		return gipadmin.ErrUserNotFound
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return gipadmin.ErrUnauthenticated
+	case http.StatusTooManyRequests:
+		return gipadmin.ErrTooManyAttempts
+	case http.StatusBadRequest:
+		switch {
+		case strings.Contains(msg, "password") &&
+			(strings.Contains(msg, "weak") || strings.Contains(msg, "polic") || strings.Contains(msg, "complexity")):
+			return gipadmin.ErrWeakPassword
+		case strings.Contains(msg, "code") &&
+			(strings.Contains(msg, "invalid") || strings.Contains(msg, "expired") || strings.Contains(msg, "not found")):
+			return gipadmin.ErrInvalidOobCode
+		default:
+			return gipadmin.ErrUnavailable
+		}
+	default:
+		return gipadmin.ErrUnavailable
+	}
+}
+
+// compositeCode packs a Zitadel user id together with the verification
+// code Zitadel hands back from POST /v2/users/{id}/password_reset.
+//
+// Why this exists: Zitadel's confirm call, POST /v2/users/{id}/password,
+// needs BOTH the user id and the verification code. GIP's oobCode alone is
+// proof of possession and needs no accompanying user id. But
+// auth.PasswordResetProvider's interface — frozen by task 1 — is a plain
+// string out of SendPasswordResetOobCode and a plain string in on
+// ResetPassword's oobCode parameter, with no room for a second field. That
+// string is also NOT free-form: auth.Service.buildResetURL appends it,
+// unescaped, straight into a URL query value
+// ("...?oobCode=" + oobCode). So whatever this package returns from
+// SendPasswordResetOobCode must itself already be a single, URL-safe
+// string carrying both pieces.
+//
+// Base64 (URL alphabet, unpadded) over a small JSON envelope is used
+// rather than a delimited string like "userID:code": RawURLEncoding's
+// alphabet (letters, digits, '-', '_') is a strict subset of characters
+// valid in an unescaped URL query value, whereas neither a Zitadel user id
+// nor a verification code is documented to exclude ':' — a delimited join
+// could be ambiguous to split back apart.
+type compositeCode struct {
+	UserID string `json:"u"`
+	Code   string `json:"c"`
+}
+
+func encodeCompositeCode(userID, code string) string {
+	// compositeCode's fields are plain strings; json.Marshal cannot fail
+	// on this input.
+	raw, _ := json.Marshal(compositeCode{UserID: userID, Code: code})
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+// decodeCompositeCode reverses encodeCompositeCode. Any failure — bad
+// base64, bad JSON, or a missing field — maps to gipadmin.ErrInvalidOobCode:
+// from the caller's perspective a malformed reset code and an
+// expired/redeemed one are the same outcome, "this link doesn't work,
+// request a new one," and handler.go already renders that as 410 Gone.
+func decodeCompositeCode(s string) (userID, code string, err error) {
+	raw, decErr := base64.RawURLEncoding.DecodeString(s)
+	if decErr != nil {
+		return "", "", fmt.Errorf("zitadeladmin: decode reset code: %w", gipadmin.ErrInvalidOobCode)
+	}
+	var cc compositeCode
+	if jsonErr := json.Unmarshal(raw, &cc); jsonErr != nil || cc.UserID == "" || cc.Code == "" {
+		return "", "", fmt.Errorf("zitadeladmin: malformed reset code: %w", gipadmin.ErrInvalidOobCode)
+	}
+	return cc.UserID, cc.Code, nil
+}
+
+// resolveUserIDByEmail searches for a Zitadel user by email, scoped to
+// Config.OrgID, and returns exactly the sole matching user id.
+//
+// Zero matches maps to gipadmin.ErrUserNotFound: RequestPasswordReset in
+// internal/auth/service.go already does
+// `errors.Is(err, gipadmin.ErrUserNotFound)` to suppress account
+// enumeration, and this keeps that behaviour working unchanged with this
+// provider swapped in.
+//
+// More than one match is a REFUSAL, not a "pick the first one": which user
+// a search returns first for an ambiguous query is unspecified ordering,
+// and silently acting on one of several matches for a destructive,
+// user-visible operation like password reset is exactly the kind of
+// decision this function must not make on a caller's behalf — mirrors
+// zitadellogin.FindUserByVerifiedEmail's ErrAmbiguousEmailMatch for the
+// identical reason. See ErrAmbiguousEmail's doc for why it is not one of
+// gipadmin's sentinels.
+//
+// Matching requires BOTH a case-insensitive email match AND
+// human.email.isVerified — the same pair zitadellogin.FindUserByVerifiedEmail
+// uses. D7's own note that "email.isVerified must be set deliberately" for
+// every user this system creates (signup and admin-invite alike) means
+// every legitimate account already satisfies this; requiring it defends
+// against redeeming a password reset against an email Zitadel itself has
+// not attested to.
+func (c *Client) resolveUserIDByEmail(ctx context.Context, email string) (string, error) {
+	body := map[string]any{
+		"queries": []any{
+			map[string]any{
+				"emailQuery": map[string]any{
+					"emailAddress": email,
+					"method":       "TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE",
+				},
+			},
+		},
+	}
+	var wire struct {
+		Result []struct {
+			UserID string `json:"userId"`
+			Human  *struct {
+				Email struct {
+					Email      string `json:"email"`
+					IsVerified bool   `json:"isVerified"`
+				} `json:"email"`
+			} `json:"human"`
+		} `json:"result"`
+	}
+	if err := c.do(ctx, http.MethodPost, "/v2/users", body, &wire, true, withLogPath("/v2/users (search)")); err != nil {
+		return "", err
+	}
+
+	var matches []string
+	for _, u := range wire.Result {
+		if u.Human != nil && strings.EqualFold(u.Human.Email.Email, email) && u.Human.Email.IsVerified {
+			matches = append(matches, u.UserID)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return "", gipadmin.ErrUserNotFound
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("zitadeladmin: %d users matched the email: %w", len(matches), ErrAmbiguousEmail)
+	}
+}
+
+// SendPasswordResetOobCode resolves email to a Zitadel user id, then asks
+// Zitadel to mint a password-reset verification code WITHOUT sending its
+// own notification (the "returnCode" medium — see D7: this preserves
+// today's GIP returnOobLink=true behaviour and keeps branding/delivery on
+// platform-api's own notify path). The returned string packs the user id
+// and code together; see compositeCode's doc. It is opaque to every other
+// caller and must be passed back to ResetPassword unmodified.
+func (c *Client) SendPasswordResetOobCode(ctx context.Context, email string) (string, error) {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return "", fmt.Errorf("zitadeladmin: email is required")
+	}
+
+	userID, err := c.resolveUserIDByEmail(ctx, email)
+	if err != nil {
+		return "", err
+	}
+
+	var wire struct {
+		VerificationCode string `json:"verificationCode"`
+	}
+	path := fmt.Sprintf("/v2/users/%s/password_reset", url.PathEscape(userID))
+	body := map[string]any{
+		"medium": map[string]any{
+			"returnCode": map[string]any{},
+		},
+	}
+	if err := c.do(ctx, http.MethodPost, path, body, &wire, false, withLogPath("/v2/users/{id}/password_reset")); err != nil {
+		return "", err
+	}
+	if wire.VerificationCode == "" {
+		return "", fmt.Errorf("zitadeladmin: password_reset 2xx without a verificationCode: %w", gipadmin.ErrUnavailable)
+	}
+	return encodeCompositeCode(userID, wire.VerificationCode), nil
+}
+
+// ResetPassword decodes oobCode back into the user id + verification code
+// SendPasswordResetOobCode packed together, then submits the new password
+// to Zitadel. A malformed oobCode never reaches the network — it maps
+// straight to gipadmin.ErrInvalidOobCode, same as a code Zitadel itself
+// rejects as invalid or expired.
+func (c *Client) ResetPassword(ctx context.Context, oobCode, newPassword string) error {
+	userID, code, err := decodeCompositeCode(strings.TrimSpace(oobCode))
+	if err != nil {
+		return err
+	}
+	path := fmt.Sprintf("/v2/users/%s/password", url.PathEscape(userID))
+	body := map[string]any{
+		"newPassword":      map[string]any{"password": newPassword},
+		"verificationCode": code,
+	}
+	return c.do(ctx, http.MethodPost, path, body, nil, false, withLogPath("/v2/users/{id}/password"))
+}
+
+// DeleteAccount removes the Zitadel user identified by uid. Idempotent:
+// gipadmin.ErrUserNotFound (a 404) is treated as success, mirroring
+// gipadmin.AdminClient.DeleteAccount's own doc — account deletion is
+// retried and the user may already be gone.
+func (c *Client) DeleteAccount(ctx context.Context, uid string) error {
+	if uid == "" {
+		return fmt.Errorf("zitadeladmin: uid is required")
+	}
+	path := fmt.Sprintf("/v2/users/%s", url.PathEscape(uid))
+	err := c.do(ctx, http.MethodDelete, path, nil, nil, false, withLogPath("/v2/users/{id}"))
+	if errors.Is(err, gipadmin.ErrUserNotFound) {
+		return nil
+	}
+	return err
+}

--- a/services/platform-api/internal/zitadeladmin/client.go
+++ b/services/platform-api/internal/zitadeladmin/client.go
@@ -31,6 +31,23 @@
 // throwaway user was created, driven through the full password_reset ->
 // password round trip, and deleted.
 //
+//   - Zitadel v2's protojson wire format flattens a oneof to its chosen
+//     variant's field name directly, UN-NESTED — there is no wrapper key
+//     named after the oneof itself. resolveUserIDByEmail's "emailQuery"
+//     and the confirm call's "verificationCode" (both below) get this
+//     right by construction. POST /v2/users/{id}/password_reset's "medium"
+//     oneof is the same rule: the body is {"returnCode":{}} AT THE TOP
+//     LEVEL, never {"medium":{"returnCode":{}}}. The wrapped form was
+//     tried and VERIFIED WRONG: it returns 200 with NO verificationCode
+//     (response keys == ["details"] only), and worse, Zitadel silently
+//     falls back to sending ITS OWN unbranded reset email in that case —
+//     the merchant gets an email nobody wrote AND this call still fails
+//     with nothing to return. An earlier revision of this file sent the
+//     wrapped form while this very doc comment already recorded the
+//     correct one; the fixture in password_reset_test.go asserted the
+//     wrapped shape too, so nothing caught it. If a future oneof field is
+//     added to this package, send it un-nested and prove it with a test
+//     that asserts the TOP-LEVEL key, not a wrapper.
 //   - POST /v2/users/{id}/password_reset with {"returnCode":{}} returns 200
 //     with {"details":…, "verificationCode":"<6 chars>"} — Zitadel hands
 //     back the code and sends no notification of its own, exactly matching
@@ -39,13 +56,19 @@
 //     {"newPassword":{"password":…},"verificationCode":…} returns 200 on a
 //     real, correct code.
 //   - Error bodies carry a STABLE id at details[0].id, distinct from the
-//     grpc code and from the message text: user-not-found is
-//     COMMAND-SAF4f (404, code 5); a wrong/expired verification code is
-//     COMMAND-2M9fs (400, code 9, message "Code not found"); a request
-//     missing the password field is COMMAND-G8dh3 (400, code 9, message
-//     "Password not found"). The last two share both HTTP status and grpc
-//     code and differ in message by one word — classifyError keys off
-//     details[0].id first for exactly this reason; see its doc.
+//     grpc code and from the message text, and NOT under one consistent
+//     prefix — do not assume "COMMAND-" is the only shape:
+//     user-not-found is COMMAND-SAF4f (404, code 5); a wrong/expired
+//     verification code is COMMAND-2M9fs (400, code 9, message "Code not
+//     found"); a request missing the password field is COMMAND-G8dh3
+//     (400, code 9, message "Password not found") — these two share both
+//     HTTP status and grpc code and differ in message by one word; a
+//     too-short password is DOMAIN-HuJf6 (400, code 3, message "Password
+//     is too short") — a message that hits none of classifyError's
+//     substring fallbacks, so relying on message text alone for this case
+//     would have surfaced as ErrUnavailable ("identity service
+//     unreachable") instead of ErrWeakPassword. classifyError keys off
+//     details[0].id first for exactly these reasons; see its doc.
 //
 // DELETE /v2/users/{id} was separately marked VERIFIED in the D7 spec
 // table, and re-confirmed in the same round trip.
@@ -245,6 +268,9 @@ func readZitadelErrorID(body []byte) string {
 // the PRIMARY mapping — classifyError only falls back to HTTP status +
 // message-substring matching when the id is absent or not in this table.
 //
+// Ids do NOT share a single prefix ("COMMAND-" and "DOMAIN-" both occur
+// live) — never assume one when adding a new entry.
+//
 // COMMAND-2M9fs and COMMAND-G8dh3 are both 400s with grpc code 9 and
 // messages that differ by a single word ("Code not found" vs "Password
 // not found") — text matching alone cannot reliably tell a wrong/expired
@@ -258,6 +284,7 @@ var zitadelErrorIDSentinels = map[string]error{
 	"COMMAND-SAF4f": gipadmin.ErrUserNotFound,   // "User could not be found" (404, code 5)
 	"COMMAND-2M9fs": gipadmin.ErrInvalidOobCode, // "Code not found" (400, code 9)
 	"COMMAND-G8dh3": gipadmin.ErrUnavailable,    // "Password not found" (400, code 9) -- malformed request, NOT an invalid code
+	"DOMAIN-HuJf6":  gipadmin.ErrWeakPassword,   // "Password is too short" (400, code 3)
 }
 
 // classifyError maps an HTTP status + Zitadel error body to one of
@@ -434,6 +461,18 @@ func (c *Client) resolveUserIDByEmail(ctx context.Context, email string) (string
 // platform-api's own notify path). The returned string packs the user id
 // and code together; see compositeCode's doc. It is opaque to every other
 // caller and must be passed back to ResetPassword unmodified.
+//
+// The request body's "returnCode" key is sent at the TOP LEVEL, not
+// wrapped under a "medium" key. medium is a protojson oneof, and Zitadel
+// v2's protojson wire format flattens oneofs to their chosen variant's
+// field name directly — resolveUserIDByEmail's un-nested "emailQuery" and
+// this function's own un-nested "verificationCode" on the confirm call
+// already get this right. A body wrapping it in "medium" was tried and
+// VERIFIED WRONG live: it returns 200 with no verificationCode (body keys
+// == ["details"] only) — worse than an error, because Zitadel silently
+// falls back to sending ITS OWN unbranded reset notification and hands
+// this package nothing, so the merchant gets an email nobody wrote AND
+// this call then fails upstream with no code to return.
 func (c *Client) SendPasswordResetOobCode(ctx context.Context, email string) (string, error) {
 	email = strings.TrimSpace(email)
 	if email == "" {
@@ -450,9 +489,7 @@ func (c *Client) SendPasswordResetOobCode(ctx context.Context, email string) (st
 	}
 	path := fmt.Sprintf("/v2/users/%s/password_reset", url.PathEscape(userID))
 	body := map[string]any{
-		"medium": map[string]any{
-			"returnCode": map[string]any{},
-		},
+		"returnCode": map[string]any{},
 	}
 	if err := c.do(ctx, http.MethodPost, path, body, &wire, false, withLogPath("/v2/users/{id}/password_reset")); err != nil {
 		return "", err

--- a/services/platform-api/internal/zitadeladmin/client.go
+++ b/services/platform-api/internal/zitadeladmin/client.go
@@ -48,9 +48,17 @@
 //     details[0].id first for exactly this reason; see its doc.
 //
 // DELETE /v2/users/{id} was separately marked VERIFIED in the D7 spec
-// table. Everything else in this file (the /v2/users search shape, and any
-// error id not in the table above) remains best-effort against the
-// documented Zitadel v2 UserService shape, not independently re-verified.
+// table, and re-confirmed in the same round trip.
+//
+// The /v2/users search shape was also probed live on 2026-09-04: POST
+// /v2/users with {"queries":[{"emailQuery":{"emailAddress":...,
+// "method":"TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE"}}]} returns matches under
+// "result". A ZERO-match search omits "result" entirely rather than
+// returning an empty array — protojson elides empty values — which decodes
+// to a nil slice here, so the len()==0 path below is the correct one to
+// rely on. Do not rewrite it to test for the key's presence.
+//
+// What remains best-effort: any error id not in the table above.
 package zitadeladmin
 
 import (

--- a/services/platform-api/internal/zitadeladmin/config_test.go
+++ b/services/platform-api/internal/zitadeladmin/config_test.go
@@ -1,0 +1,31 @@
+package zitadeladmin
+
+import "testing"
+
+func TestNew_RejectsMissingConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{"empty BaseURL", Config{Token: "t", OrgID: "o"}},
+		{"empty Token", Config{BaseURL: "https://auth.example.com", OrgID: "o"}},
+		{"empty OrgID", Config{BaseURL: "https://auth.example.com", Token: "t"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := New(tc.cfg, nil); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestNew_TrimsTrailingSlashFromBaseURL(t *testing.T) {
+	c, err := New(Config{BaseURL: "https://auth.example.com/", Token: "t", OrgID: "o"}, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if c.baseURL != "https://auth.example.com" {
+		t.Errorf("baseURL = %q", c.baseURL)
+	}
+}

--- a/services/platform-api/internal/zitadeladmin/contract_test.go
+++ b/services/platform-api/internal/zitadeladmin/contract_test.go
@@ -3,6 +3,7 @@ package zitadeladmin
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -25,17 +26,24 @@ type gipDeleterShape interface {
 }
 
 func TestClient_SatisfiesPasswordResetProviderShape(t *testing.T) {
+	// sendHit and resetHit are each set from their OWN request path, not
+	// from a shared branch: a shared "any POST" branch would leave both
+	// true even if only one of the two calls under test actually ran,
+	// silently weakening the two separate assertions below to one.
 	var sendHit, resetHit bool
 	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v2/users":
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(searchResponse(humanEntry("user-1", "merchant@example.com", true)))
-		case r.Method == http.MethodPost:
-			sendHit = sendHit || true
-			resetHit = resetHit || true
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/password_reset"):
+			sendHit = true
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"verificationCode":"code-1"}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/password"):
+			resetHit = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}

--- a/services/platform-api/internal/zitadeladmin/contract_test.go
+++ b/services/platform-api/internal/zitadeladmin/contract_test.go
@@ -1,0 +1,78 @@
+package zitadeladmin
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// passwordResetProviderShape mirrors internal/auth.PasswordResetProvider's
+// method set. Redeclared locally, following gipadmin's own
+// password_reset_provider_test.go convention, rather than importing
+// internal/auth directly: this proves *Client's methods are reachable
+// through dynamic dispatch, which is the property that actually matters,
+// without taking on a dependency from the provider package back up to the
+// consumer package.
+type passwordResetProviderShape interface {
+	SendPasswordResetOobCode(ctx context.Context, email string) (string, error)
+	ResetPassword(ctx context.Context, oobCode, newPassword string) error
+}
+
+// gipDeleterShape mirrors internal/account's unexported gipDeleter
+// interface (DeleteAccount(ctx, uid) error).
+type gipDeleterShape interface {
+	DeleteAccount(ctx context.Context, uid string) error
+}
+
+func TestClient_SatisfiesPasswordResetProviderShape(t *testing.T) {
+	var sendHit, resetHit bool
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/users":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(searchResponse(humanEntry("user-1", "merchant@example.com", true)))
+		case r.Method == http.MethodPost:
+			sendHit = sendHit || true
+			resetHit = resetHit || true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"verificationCode":"code-1"}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	var provider passwordResetProviderShape = c
+	oobCode, err := provider.SendPasswordResetOobCode(context.Background(), "merchant@example.com")
+	if err != nil {
+		t.Fatalf("SendPasswordResetOobCode via interface: %v", err)
+	}
+	if !sendHit {
+		t.Error("expected the password_reset endpoint to be hit")
+	}
+
+	// ResetPassword against the same fake server, which answers every POST
+	// with 200, proving dispatch reaches the real method.
+	if err := provider.ResetPassword(context.Background(), oobCode, "correct horse battery staple"); err != nil {
+		t.Fatalf("ResetPassword via interface: %v", err)
+	}
+	if !resetHit {
+		t.Error("expected dispatch to reach ResetPassword's HTTP call")
+	}
+}
+
+func TestClient_SatisfiesGipDeleterShape(t *testing.T) {
+	var hit bool
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	var deleter gipDeleterShape = c
+	if err := deleter.DeleteAccount(context.Background(), "user-1"); err != nil {
+		t.Fatalf("DeleteAccount via interface: %v", err)
+	}
+	if !hit {
+		t.Error("expected dispatch to reach DeleteAccount's HTTP call")
+	}
+}

--- a/services/platform-api/internal/zitadeladmin/delete_test.go
+++ b/services/platform-api/internal/zitadeladmin/delete_test.go
@@ -1,0 +1,57 @@
+package zitadeladmin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mark8ly/platform-api/internal/gipadmin"
+)
+
+func TestDeleteAccount_SucceedsOn200(t *testing.T) {
+	var gotMethod, gotPath string
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	if err := c.DeleteAccount(context.Background(), "user-1"); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method = %s, want DELETE", gotMethod)
+	}
+	if !strings.HasSuffix(gotPath, "/v2/users/user-1") {
+		t.Errorf("path = %s", gotPath)
+	}
+}
+
+func TestDeleteAccount_IdempotentOnNotFound(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"code":5,"message":"User not found"}`))
+	})
+	if err := c.DeleteAccount(context.Background(), "user-1"); err != nil {
+		t.Fatalf("expected nil on not-found (idempotent delete), got %v", err)
+	}
+}
+
+func TestDeleteAccount_RejectsEmptyUID(t *testing.T) {
+	c := &Client{}
+	if err := c.DeleteAccount(context.Background(), ""); err == nil {
+		t.Fatal("expected error for empty uid")
+	}
+}
+
+func TestDeleteAccount_UnavailableSurfacesAsUnavailable(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"code":14,"message":"backend unavailable"}`))
+	})
+	err := c.DeleteAccount(context.Background(), "user-1")
+	if !errors.Is(err, gipadmin.ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", err)
+	}
+}

--- a/services/platform-api/internal/zitadeladmin/error_id_mapping_test.go
+++ b/services/platform-api/internal/zitadeladmin/error_id_mapping_test.go
@@ -40,6 +40,17 @@ func TestErrorIDMapping_VerifiedLiveIDs(t *testing.T) {
 			body:   `{"code":9,"message":"Password not found","details":[{"@type":"...","id":"COMMAND-G8dh3"}]}`,
 			want:   gipadmin.ErrUnavailable,
 		},
+		{
+			// Different id prefix ("DOMAIN-" not "COMMAND-") and a message
+			// ("Password is too short") that hits none of classifyError's
+			// substring fallbacks (no "weak"/"polic"/"complexity") — this
+			// case only works via the id table, proving the fallback text
+			// match alone would have missed it.
+			name:   "DOMAIN-HuJf6 too-short password maps to ErrWeakPassword",
+			status: http.StatusBadRequest,
+			body:   `{"code":3,"message":"Password is too short","details":[{"@type":"...","id":"DOMAIN-HuJf6"}]}`,
+			want:   gipadmin.ErrWeakPassword,
+		},
 	}
 
 	for _, tc := range cases {
@@ -96,6 +107,17 @@ func TestErrorIDMapping_EndToEndThroughResetPassword(t *testing.T) {
 		}
 		if !errors.Is(err, gipadmin.ErrUnavailable) {
 			t.Fatalf("err = %v, want ErrUnavailable", err)
+		}
+	})
+
+	t.Run("too-short password maps to ErrWeakPassword via id, not message text", func(t *testing.T) {
+		c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"code":3,"message":"Password is too short","details":[{"id":"DOMAIN-HuJf6"}]}`))
+		})
+		err := c.ResetPassword(context.Background(), encodeCompositeCode("user-1", "code"), "a")
+		if !errors.Is(err, gipadmin.ErrWeakPassword) {
+			t.Fatalf("err = %v, want ErrWeakPassword", err)
 		}
 	})
 }

--- a/services/platform-api/internal/zitadeladmin/error_id_mapping_test.go
+++ b/services/platform-api/internal/zitadeladmin/error_id_mapping_test.go
@@ -1,0 +1,122 @@
+package zitadeladmin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/mark8ly/platform-api/internal/gipadmin"
+)
+
+// TestErrorIDMapping_VerifiedLiveIDs proves classifyError keys off the
+// stable details[0].id first, using the exact error bodies observed live
+// against the TESSERIX Zitadel instance on 2026-09-04 (see the package
+// doc). This is the discrimination message-text matching alone cannot
+// make reliably: COMMAND-2M9fs and COMMAND-G8dh3 share both HTTP status
+// (400) and grpc code (9), and their messages differ by one word.
+func TestErrorIDMapping_VerifiedLiveIDs(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   error
+	}{
+		{
+			name:   "COMMAND-SAF4f user not found",
+			status: http.StatusNotFound,
+			body:   `{"code":5,"message":"User could not be found","details":[{"@type":"...","id":"COMMAND-SAF4f"}]}`,
+			want:   gipadmin.ErrUserNotFound,
+		},
+		{
+			name:   "COMMAND-2M9fs wrong or expired verification code",
+			status: http.StatusBadRequest,
+			body:   `{"code":9,"message":"Code not found","details":[{"@type":"...","id":"COMMAND-2M9fs"}]}`,
+			want:   gipadmin.ErrInvalidOobCode,
+		},
+		{
+			name:   "COMMAND-G8dh3 missing password field is NOT an invalid code",
+			status: http.StatusBadRequest,
+			body:   `{"code":9,"message":"Password not found","details":[{"@type":"...","id":"COMMAND-G8dh3"}]}`,
+			want:   gipadmin.ErrUnavailable,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id := readZitadelErrorID([]byte(tc.body))
+			got := classifyError(tc.status, []byte(tc.body), id)
+			if !errors.Is(got, tc.want) {
+				t.Fatalf("classifyError = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestErrorIDMapping_CommandG8dh3NeverMapsToInvalidOobCode is the specific
+// discrimination the task called out: a malformed-request error, despite
+// sharing status/grpc-code with a genuine bad verification code, must
+// never be mistaken for one.
+func TestErrorIDMapping_CommandG8dh3NeverMapsToInvalidOobCode(t *testing.T) {
+	body := []byte(`{"code":9,"message":"Password not found","details":[{"id":"COMMAND-G8dh3"}]}`)
+	id := readZitadelErrorID(body)
+	got := classifyError(http.StatusBadRequest, body, id)
+	if errors.Is(got, gipadmin.ErrInvalidOobCode) {
+		t.Fatalf("classifyError = %v, must not match ErrInvalidOobCode", got)
+	}
+	if !errors.Is(got, gipadmin.ErrUnavailable) {
+		t.Fatalf("classifyError = %v, want ErrUnavailable", got)
+	}
+}
+
+// TestErrorIDMapping_EndToEndThroughResetPassword drives the same
+// COMMAND-2M9fs / COMMAND-G8dh3 distinction through the real
+// ResetPassword call (not just classifyError directly), proving the id is
+// actually read off the wire and threaded through do().
+func TestErrorIDMapping_EndToEndThroughResetPassword(t *testing.T) {
+	t.Run("wrong code maps to ErrInvalidOobCode", func(t *testing.T) {
+		c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"code":9,"message":"Code not found","details":[{"id":"COMMAND-2M9fs"}]}`))
+		})
+		err := c.ResetPassword(context.Background(), encodeCompositeCode("user-1", "wrong-code"), "correct horse battery staple")
+		if !errors.Is(err, gipadmin.ErrInvalidOobCode) {
+			t.Fatalf("err = %v, want ErrInvalidOobCode", err)
+		}
+	})
+
+	t.Run("malformed request maps to ErrUnavailable, not ErrInvalidOobCode", func(t *testing.T) {
+		c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"code":9,"message":"Password not found","details":[{"id":"COMMAND-G8dh3"}]}`))
+		})
+		err := c.ResetPassword(context.Background(), encodeCompositeCode("user-1", "code"), "correct horse battery staple")
+		if errors.Is(err, gipadmin.ErrInvalidOobCode) {
+			t.Fatalf("err = %v, must not match ErrInvalidOobCode", err)
+		}
+		if !errors.Is(err, gipadmin.ErrUnavailable) {
+			t.Fatalf("err = %v, want ErrUnavailable", err)
+		}
+	})
+}
+
+// TestReadZitadelErrorID covers the extractor directly: present, absent,
+// and undecodable bodies.
+func TestReadZitadelErrorID(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"present", `{"code":5,"message":"x","details":[{"id":"COMMAND-SAF4f"}]}`, "COMMAND-SAF4f"},
+		{"no details", `{"code":5,"message":"x"}`, ""},
+		{"not json", `not even json`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := readZitadelErrorID([]byte(tc.body)); got != tc.want {
+				t.Errorf("readZitadelErrorID = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/services/platform-api/internal/zitadeladmin/helpers_test.go
+++ b/services/platform-api/internal/zitadeladmin/helpers_test.go
@@ -1,0 +1,26 @@
+package zitadeladmin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newTestClient builds a Client wired to an httptest server running
+// handler. The server is closed automatically via t.Cleanup.
+func newTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	c, err := New(Config{
+		BaseURL: srv.URL,
+		Token:   "test-pat-thirtytwo-bytes-for-testing-only",
+		OrgID:   "org-tesserix",
+	}, srv.Client())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}

--- a/services/platform-api/internal/zitadeladmin/password_reset_test.go
+++ b/services/platform-api/internal/zitadeladmin/password_reset_test.go
@@ -1,0 +1,148 @@
+package zitadeladmin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mark8ly/platform-api/internal/gipadmin"
+)
+
+// TestSendPasswordResetOobCode_HappyPath drives the full email->id->code
+// flow: the search hit resolves an id, the password_reset call is made
+// against that id's path with the "returnCode" medium (so Zitadel does not
+// send its own notification — see D7), and the returned code is opaque but
+// decodes back to the same id and code.
+func TestSendPasswordResetOobCode_HappyPath(t *testing.T) {
+	var resetPath string
+	var resetBody map[string]any
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/users":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(searchResponse(humanEntry("user-42", "merchant@example.com", true)))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/password_reset"):
+			resetPath = r.URL.Path
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &resetBody)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"verificationCode":"code-abc"}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	oobCode, err := c.SendPasswordResetOobCode(context.Background(), "merchant@example.com")
+	if err != nil {
+		t.Fatalf("SendPasswordResetOobCode: %v", err)
+	}
+	if oobCode == "" {
+		t.Fatal("expected non-empty oobCode")
+	}
+	if resetPath != "/v2/users/user-42/password_reset" {
+		t.Errorf("resetPath = %q", resetPath)
+	}
+	medium, ok := resetBody["medium"].(map[string]any)
+	if !ok {
+		t.Fatalf("medium = %v", resetBody["medium"])
+	}
+	if _, ok := medium["returnCode"]; !ok {
+		t.Errorf("expected medium.returnCode, got %v", medium)
+	}
+
+	userID, code, err := decodeCompositeCode(oobCode)
+	if err != nil {
+		t.Fatalf("decodeCompositeCode: %v", err)
+	}
+	if userID != "user-42" || code != "code-abc" {
+		t.Errorf("userID=%q code=%q, want user-42/code-abc", userID, code)
+	}
+}
+
+func TestSendPasswordResetOobCode_UnknownEmailMapsToUserNotFound(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(searchResponse())
+	})
+
+	_, err := c.SendPasswordResetOobCode(context.Background(), "nobody@example.com")
+	if !errors.Is(err, gipadmin.ErrUserNotFound) {
+		t.Fatalf("err = %v, want ErrUserNotFound", err)
+	}
+}
+
+// TestResetPassword_HappyPath proves the composite code round-trips: it
+// decodes back to the id embedded in the URL path and the code embedded in
+// the request body, alongside the new password.
+func TestResetPassword_HappyPath(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	oobCode := encodeCompositeCode("user-42", "code-abc")
+	if err := c.ResetPassword(context.Background(), oobCode, "correct horse battery staple"); err != nil {
+		t.Fatalf("ResetPassword: %v", err)
+	}
+	if gotPath != "/v2/users/user-42/password" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotBody["verificationCode"] != "code-abc" {
+		t.Errorf("verificationCode = %v", gotBody["verificationCode"])
+	}
+	np, ok := gotBody["newPassword"].(map[string]any)
+	if !ok || np["password"] != "correct horse battery staple" {
+		t.Errorf("newPassword = %v", gotBody["newPassword"])
+	}
+}
+
+func TestResetPassword_MalformedCodeNeverHitsNetwork(t *testing.T) {
+	called := false
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := c.ResetPassword(context.Background(), "not-a-real-code", "correct horse battery staple")
+	if !errors.Is(err, gipadmin.ErrInvalidOobCode) {
+		t.Fatalf("err = %v, want ErrInvalidOobCode", err)
+	}
+	if called {
+		t.Error("expected no network call for an undecodable oobCode")
+	}
+}
+
+func TestResetPassword_UpstreamInvalidCodeMapsToSentinel(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"code":3,"message":"verification code is invalid or expired"}`))
+	})
+
+	oobCode := encodeCompositeCode("user-42", "stale-code")
+	err := c.ResetPassword(context.Background(), oobCode, "correct horse battery staple")
+	if !errors.Is(err, gipadmin.ErrInvalidOobCode) {
+		t.Fatalf("err = %v, want ErrInvalidOobCode", err)
+	}
+}
+
+func TestResetPassword_UpstreamWeakPasswordMapsToSentinel(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"code":3,"message":"password does not meet the complexity policy"}`))
+	})
+
+	oobCode := encodeCompositeCode("user-42", "code-abc")
+	err := c.ResetPassword(context.Background(), oobCode, "weak")
+	if !errors.Is(err, gipadmin.ErrWeakPassword) {
+		t.Fatalf("err = %v, want ErrWeakPassword", err)
+	}
+}

--- a/services/platform-api/internal/zitadeladmin/password_reset_test.go
+++ b/services/platform-api/internal/zitadeladmin/password_reset_test.go
@@ -14,9 +14,18 @@ import (
 
 // TestSendPasswordResetOobCode_HappyPath drives the full email->id->code
 // flow: the search hit resolves an id, the password_reset call is made
-// against that id's path with the "returnCode" medium (so Zitadel does not
-// send its own notification — see D7), and the returned code is opaque but
-// decodes back to the same id and code.
+// against that id's path with a TOP-LEVEL "returnCode" key (so Zitadel
+// does not send its own notification — see D7), and the returned code is
+// opaque but decodes back to the same id and code.
+//
+// The assertion on the request body is the load-bearing part of this
+// test: an earlier revision sent {"medium":{"returnCode":{}}} (medium is a
+// protojson oneof, and Zitadel v2 flattens oneofs to their variant's field
+// name UN-NESTED) and this test's fixture asserted that same wrapped shape
+// back, so it passed against a body that was verified WRONG live — Zitadel
+// answers 200 with no verificationCode for the wrapped form and silently
+// sends its own unbranded email instead. Asserting the top-level key here
+// is what would have caught it.
 func TestSendPasswordResetOobCode_HappyPath(t *testing.T) {
 	var resetPath string
 	var resetBody map[string]any
@@ -46,12 +55,11 @@ func TestSendPasswordResetOobCode_HappyPath(t *testing.T) {
 	if resetPath != "/v2/users/user-42/password_reset" {
 		t.Errorf("resetPath = %q", resetPath)
 	}
-	medium, ok := resetBody["medium"].(map[string]any)
-	if !ok {
-		t.Fatalf("medium = %v", resetBody["medium"])
+	if _, ok := resetBody["returnCode"]; !ok {
+		t.Errorf("expected top-level returnCode key, got %v", resetBody)
 	}
-	if _, ok := medium["returnCode"]; !ok {
-		t.Errorf("expected medium.returnCode, got %v", medium)
+	if _, wrapped := resetBody["medium"]; wrapped {
+		t.Errorf("returnCode must NOT be wrapped under a %q key: %v", "medium", resetBody)
 	}
 
 	userID, code, err := decodeCompositeCode(oobCode)

--- a/services/platform-api/internal/zitadeladmin/resolve_test.go
+++ b/services/platform-api/internal/zitadeladmin/resolve_test.go
@@ -1,0 +1,110 @@
+package zitadeladmin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/mark8ly/platform-api/internal/gipadmin"
+)
+
+func searchResponse(entries ...map[string]any) []byte {
+	body := map[string]any{"result": entries}
+	raw, _ := json.Marshal(body)
+	return raw
+}
+
+func humanEntry(userID, email string, verified bool) map[string]any {
+	return map[string]any{
+		"userId": userID,
+		"human": map[string]any{
+			"email": map[string]any{
+				"email":      email,
+				"isVerified": verified,
+			},
+		},
+	}
+}
+
+func TestResolveUserIDByEmail_Found(t *testing.T) {
+	var gotOrgHeader string
+	var gotBody map[string]any
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotOrgHeader = r.Header.Get("x-zitadel-orgid")
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(searchResponse(humanEntry("user-1", "merchant@example.com", true)))
+	})
+
+	id, err := c.resolveUserIDByEmail(context.Background(), "Merchant@Example.com")
+	if err != nil {
+		t.Fatalf("resolveUserIDByEmail: %v", err)
+	}
+	if id != "user-1" {
+		t.Errorf("id = %q, want user-1", id)
+	}
+	if gotOrgHeader != "org-tesserix" {
+		t.Errorf("x-zitadel-orgid = %q, want org-tesserix", gotOrgHeader)
+	}
+	q, ok := gotBody["queries"].([]any)
+	if !ok || len(q) != 1 {
+		t.Fatalf("queries = %v", gotBody["queries"])
+	}
+}
+
+func TestResolveUserIDByEmail_NotFound(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(searchResponse())
+	})
+
+	_, err := c.resolveUserIDByEmail(context.Background(), "nobody@example.com")
+	if !errors.Is(err, gipadmin.ErrUserNotFound) {
+		t.Fatalf("err = %v, want ErrUserNotFound", err)
+	}
+}
+
+func TestResolveUserIDByEmail_UnverifiedEmailDoesNotMatch(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(searchResponse(humanEntry("user-1", "merchant@example.com", false)))
+	})
+
+	_, err := c.resolveUserIDByEmail(context.Background(), "merchant@example.com")
+	if !errors.Is(err, gipadmin.ErrUserNotFound) {
+		t.Fatalf("err = %v, want ErrUserNotFound for an unverified-email match", err)
+	}
+}
+
+// An ambiguous match must not silently pick one. This is the explicit
+// scenario called out in the task brief.
+func TestResolveUserIDByEmail_AmbiguousRefuses(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(searchResponse(
+			humanEntry("user-1", "merchant@example.com", true),
+			humanEntry("user-2", "merchant@example.com", true),
+		))
+	})
+
+	_, err := c.resolveUserIDByEmail(context.Background(), "merchant@example.com")
+	if !errors.Is(err, ErrAmbiguousEmail) {
+		t.Fatalf("err = %v, want ErrAmbiguousEmail", err)
+	}
+	// Ambiguity is NOT one of gipadmin's sentinels: it must fall through
+	// internal/auth/handler.go's switch to the generic 500 default rather
+	// than being reported as "not found" (false) or "unavailable"
+	// (misdirecting anyone reading the log).
+	for _, sentinel := range []error{
+		gipadmin.ErrUserNotFound, gipadmin.ErrInvalidOobCode, gipadmin.ErrWeakPassword,
+		gipadmin.ErrUnauthenticated, gipadmin.ErrTooManyAttempts, gipadmin.ErrUnavailable,
+	} {
+		if errors.Is(err, sentinel) {
+			t.Errorf("ambiguous-match error unexpectedly matches sentinel %v", sentinel)
+		}
+	}
+}

--- a/services/platform-api/internal/zitadeladmin/resolve_test.go
+++ b/services/platform-api/internal/zitadeladmin/resolve_test.go
@@ -12,7 +12,16 @@ import (
 )
 
 func searchResponse(entries ...map[string]any) []byte {
-	body := map[string]any{"result": entries}
+	// A zero-match search on the real instance OMITS "result" entirely
+	// rather than returning an empty array — protojson elides empty
+	// values (verified live 2026-09-04, see the package doc). Reproducing
+	// that exactly matters: a regression that started keying off the
+	// key's presence instead of len() would pass against a `{"result":[]}`
+	// fixture and fail in production.
+	body := map[string]any{"details": map[string]any{}}
+	if len(entries) > 0 {
+		body["result"] = entries
+	}
 	raw, _ := json.Marshal(body)
 	return raw
 }

--- a/services/platform-api/internal/zitadeladmin/sentinel_mapping_test.go
+++ b/services/platform-api/internal/zitadeladmin/sentinel_mapping_test.go
@@ -1,0 +1,158 @@
+package zitadeladmin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/mark8ly/platform-api/internal/gipadmin"
+)
+
+// TestSentinelMapping_MatchesHandlerContract is the test that proves the
+// contract in the task brief: every sentinel internal/auth/handler.go
+// branches on with errors.Is (ErrUserNotFound, ErrInvalidOobCode,
+// ErrWeakPassword, ErrUnauthenticated, ErrTooManyAttempts, ErrUnavailable)
+// is reachable through this package's own error paths, asserted against
+// the SAME gipadmin.Err* values handler.go checks — not a locally
+// redeclared lookalike.
+func TestSentinelMapping_MatchesHandlerContract(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   error
+		via    func(c *Client) error
+	}{
+		{
+			name:   "too many attempts on password reset request",
+			status: http.StatusTooManyRequests,
+			body:   `{"code":8,"message":"rate limit exceeded"}`,
+			want:   gipadmin.ErrTooManyAttempts,
+			via: func(c *Client) error {
+				_, err := c.SendPasswordResetOobCode(context.Background(), "merchant@example.com")
+				return err
+			},
+		},
+		{
+			name:   "unauthenticated on password reset request (401)",
+			status: http.StatusUnauthorized,
+			body:   `{"code":16,"message":"invalid PAT"}`,
+			want:   gipadmin.ErrUnauthenticated,
+			via: func(c *Client) error {
+				_, err := c.SendPasswordResetOobCode(context.Background(), "merchant@example.com")
+				return err
+			},
+		},
+		{
+			name:   "unauthenticated on password reset request (403)",
+			status: http.StatusForbidden,
+			body:   `{"code":7,"message":"permission denied"}`,
+			want:   gipadmin.ErrUnauthenticated,
+			via: func(c *Client) error {
+				_, err := c.SendPasswordResetOobCode(context.Background(), "merchant@example.com")
+				return err
+			},
+		},
+		{
+			name:   "unavailable on 5xx during password reset request",
+			status: http.StatusBadGateway,
+			body:   `{"code":14,"message":"upstream failure"}`,
+			want:   gipadmin.ErrUnavailable,
+			via: func(c *Client) error {
+				_, err := c.SendPasswordResetOobCode(context.Background(), "merchant@example.com")
+				return err
+			},
+		},
+		{
+			name:   "invalid code on confirm",
+			status: http.StatusBadRequest,
+			body:   `{"code":3,"message":"the verification code is invalid or expired"}`,
+			want:   gipadmin.ErrInvalidOobCode,
+			via: func(c *Client) error {
+				return c.ResetPassword(context.Background(), encodeCompositeCode("user-1", "code"), "correct horse battery staple")
+			},
+		},
+		{
+			name:   "weak password on confirm",
+			status: http.StatusBadRequest,
+			body:   `{"code":3,"message":"password fails the complexity policy"}`,
+			want:   gipadmin.ErrWeakPassword,
+			via: func(c *Client) error {
+				return c.ResetPassword(context.Background(), encodeCompositeCode("user-1", "code"), "weak")
+			},
+		},
+		{
+			name:   "user not found on delete",
+			status: http.StatusNotFound,
+			body:   `{"code":5,"message":"User not found"}`,
+			want:   nil, // DeleteAccount treats not-found as success (idempotent)
+			via: func(c *Client) error {
+				return c.DeleteAccount(context.Background(), "user-1")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				// Password-reset-request cases hit the search endpoint
+				// first; answer it with exactly one match so the flow
+				// reaches the call under test.
+				if r.URL.Path == "/v2/users" {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(searchResponse(humanEntry("user-1", "merchant@example.com", true)))
+					return
+				}
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			})
+
+			err := tc.via(c)
+			if tc.want == nil {
+				if err != nil {
+					t.Fatalf("err = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("err = %v, want errors.Is match for %v", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestUpstreamUnavailable_DoesNotSurfaceAsCredentialError is the explicit
+// constraint from the task brief: an unreachable/failing upstream must
+// read as unavailable, never as "wrong code" or "weak password" — the two
+// sentinels a destructive password-reset confirm could otherwise be
+// mistaken for.
+func TestUpstreamUnavailable_DoesNotSurfaceAsCredentialError(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`not even json`))
+	})
+
+	err := c.ResetPassword(context.Background(), encodeCompositeCode("user-1", "code"), "correct horse battery staple")
+	if !errors.Is(err, gipadmin.ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", err)
+	}
+	if errors.Is(err, gipadmin.ErrInvalidOobCode) || errors.Is(err, gipadmin.ErrWeakPassword) {
+		t.Fatalf("err = %v must not also match a credential sentinel", err)
+	}
+}
+
+// TestNetworkFailureMapsToUnavailable proves a genuinely unreachable
+// upstream (server closed, not just a bad status) also maps to
+// ErrUnavailable, since network transport errors take a different path
+// through do() than a non-2xx status.
+func TestNetworkFailureMapsToUnavailable(t *testing.T) {
+	c, err := New(Config{BaseURL: "http://127.0.0.1:1", Token: "t", OrgID: "o"}, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	derr := c.DeleteAccount(context.Background(), "user-1")
+	if !errors.Is(derr, gipadmin.ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", derr)
+	}
+}

--- a/services/platform-api/internal/zitadeladmin/sentinel_mapping_test.go
+++ b/services/platform-api/internal/zitadeladmin/sentinel_mapping_test.go
@@ -16,6 +16,11 @@ import (
 // is reachable through this package's own error paths, asserted against
 // the SAME gipadmin.Err* values handler.go checks — not a locally
 // redeclared lookalike.
+//
+// These bodies deliberately carry NO details[0].id, exercising
+// classifyError's status+message FALLBACK path (see error_id_mapping_test.go
+// for the primary, id-keyed path using the ids verified live on
+// 2026-09-04). Both paths must reach the right sentinel independently.
 func TestSentinelMapping_MatchesHandlerContract(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/services/platform-api/pkg/config/config.go
+++ b/services/platform-api/pkg/config/config.go
@@ -2,6 +2,8 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/joho/godotenv"
@@ -103,6 +105,26 @@ type Config struct {
 	// GIPKey below. Relaxing the web key instead is not an option —
 	// it is public by construction.
 	GIPServerAPIKey string `envconfig:"GIP_SERVER_API_KEY"`
+
+	// Zitadel (#524 phase 5). All optional and unread unless
+	// ZitadelEnabled is set — mirrors services/auth-bff/pkg/config's
+	// ZITADEL_ENABLED shape. GIP remains the default provider for the
+	// three account operations (password-reset send/confirm, delete)
+	// until this flag flips.
+	//
+	// EnsureTenantClaim (the tenant_id custom claim written on invite
+	// accept and read by onboarding) is DELIBERATELY NOT gated by this
+	// flag — it always runs against GIP via the gipAdmin client built
+	// from GIPProjectID/GIPTenantID/GIPKey() above, independent of
+	// ZitadelEnabled. See cmd/server/provider_wiring.go.
+	ZitadelEnabled          bool   `envconfig:"ZITADEL_ENABLED" default:"false"`
+	ZitadelIssuer           string `envconfig:"ZITADEL_ISSUER"`
+	ZitadelLoginClientToken string `envconfig:"ZITADEL_LOGIN_CLIENT_TOKEN"`
+	// ZitadelOrgID scopes the email->user-id search
+	// (zitadeladmin.Client.resolveUserIDByEmail) to the merchant org —
+	// required because the login-client token is instance-level and the
+	// shared Zitadel instance hosts other products' orgs too.
+	ZitadelOrgID string `envconfig:"ZITADEL_ORG_ID"`
 }
 
 // GIPKey returns the API key to use for server-side GIP calls: the
@@ -141,5 +163,51 @@ func Load() (*Config, error) {
 	// with "invalid header field value".
 	cfg.SendGridAPIKey = strings.TrimSpace(cfg.SendGridAPIKey)
 	cfg.ResendAPIKey = strings.TrimSpace(cfg.ResendAPIKey)
+	// ZitadelIssuer becomes an HTTP request base URL and ZitadelOrgID is
+	// sent as a header value verbatim — a trailing newline from a mounted
+	// secret broke exactly this shape elsewhere in this codebase for
+	// ~25 hours before TrimSpace-on-assignment became the standing rule.
+	// ZitadelLoginClientToken is a bearer credential; trim it for the same
+	// reason SendGridAPIKey/ResendAPIKey are trimmed above.
+	cfg.ZitadelIssuer = strings.TrimSpace(cfg.ZitadelIssuer)
+	cfg.ZitadelLoginClientToken = strings.TrimSpace(cfg.ZitadelLoginClientToken)
+	cfg.ZitadelOrgID = strings.TrimSpace(cfg.ZitadelOrgID)
 	return &cfg, nil
+}
+
+// ErrZitadelNotConfigured is returned by ValidateZitadel when ZITADEL_ENABLED
+// is set but a value the Zitadel account-operations path cannot run safely
+// without is missing. Wrapped errors carry the NAME of the missing variable
+// only — never its value.
+var ErrZitadelNotConfigured = errors.New("zitadel: enabled but not configured")
+
+// ValidateZitadel reports whether platform-api may select Zitadel for its
+// three account operations (password-reset send, password-reset confirm,
+// delete account).
+//
+// It returns nil when Zitadel is disabled: GIP stays the provider and
+// nothing new is required to boot. When it is enabled, every field below is
+// mandatory and a missing one must fail startup loudly (see
+// cmd/server/provider_wiring.go) rather than silently falling back to GIP —
+// a misconfigured Zitadel deployment must never look like a working one.
+//
+// Mirrors services/auth-bff/pkg/config's ValidateZitadel shape.
+func (c *Config) ValidateZitadel() error {
+	if !c.ZitadelEnabled {
+		return nil
+	}
+	var missing []string
+	if c.ZitadelIssuer == "" {
+		missing = append(missing, "ZITADEL_ISSUER")
+	}
+	if c.ZitadelLoginClientToken == "" {
+		missing = append(missing, "ZITADEL_LOGIN_CLIENT_TOKEN")
+	}
+	if c.ZitadelOrgID == "" {
+		missing = append(missing, "ZITADEL_ORG_ID")
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%w: missing %s", ErrZitadelNotConfigured, strings.Join(missing, ", "))
 }

--- a/services/platform-api/pkg/config/config.go
+++ b/services/platform-api/pkg/config/config.go
@@ -117,6 +117,15 @@ type Config struct {
 	// flag — it always runs against GIP via the gipAdmin client built
 	// from GIPProjectID/GIPTenantID/GIPKey() above, independent of
 	// ZitadelEnabled. See cmd/server/provider_wiring.go.
+	//
+	// Deployment ordering: ZitadelIssuer, ZitadelLoginClientToken, and
+	// ZitadelOrgID must all be set — and land whitespace-clean, per the
+	// TrimSpace-on-assignment note in Load() below — BEFORE ZitadelEnabled
+	// is flipped to true. ValidateZitadel enforces this at startup (it
+	// panics rather than falling back to GIP silently), but the flag
+	// itself defaults to false, so merging this config change alone
+	// changes nothing; only a deliberate, later flip of ZITADEL_ENABLED
+	// activates the Zitadel path.
 	ZitadelEnabled          bool   `envconfig:"ZITADEL_ENABLED" default:"false"`
 	ZitadelIssuer           string `envconfig:"ZITADEL_ISSUER"`
 	ZitadelLoginClientToken string `envconfig:"ZITADEL_LOGIN_CLIENT_TOKEN"`

--- a/services/platform-api/pkg/config/config_test.go
+++ b/services/platform-api/pkg/config/config_test.go
@@ -15,6 +15,7 @@ func clearAll(t *testing.T) {
 		"ENV", "HTTP_PORT", "DATABASE_URL",
 		"FGA_API_URL", "FGA_STORE_ID",
 		"SENDGRID_API_KEY", "EMAIL_FROM", "GCS_BUCKET",
+		"ZITADEL_ENABLED", "ZITADEL_ISSUER", "ZITADEL_LOGIN_CLIENT_TOKEN", "ZITADEL_ORG_ID",
 	} {
 		os.Unsetenv(k)
 	}
@@ -47,6 +48,33 @@ func TestLoad_FailsWhenRequiredFieldMissing(t *testing.T) {
 	_, err := Load()
 	if err == nil {
 		t.Error("Load() should fail when DATABASE_URL is unset (envconfig required)")
+	}
+}
+
+// TestLoad_TrimsZitadelSecretFields is the regression test for the
+// trailing-newline outage this codebase already had once: a mounted
+// GCP Secret Manager value with a trailing LF must not survive into
+// ZitadelIssuer (used as an HTTP request base URL), ZitadelLoginClientToken
+// (a bearer credential), or ZitadelOrgID (sent as a header value).
+func TestLoad_TrimsZitadelSecretFields(t *testing.T) {
+	clearAll(t)
+	t.Setenv("DATABASE_URL", "postgres://test/test")
+	t.Setenv("ZITADEL_ISSUER", "https://login.mark8ly.zitadel.cloud\n")
+	t.Setenv("ZITADEL_LOGIN_CLIENT_TOKEN", "  pat-token \n")
+	t.Setenv("ZITADEL_ORG_ID", "339070697432875523\n")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.ZitadelIssuer != "https://login.mark8ly.zitadel.cloud" {
+		t.Errorf("ZitadelIssuer = %q, want trimmed", cfg.ZitadelIssuer)
+	}
+	if cfg.ZitadelLoginClientToken != "pat-token" {
+		t.Errorf("ZitadelLoginClientToken = %q, want trimmed", cfg.ZitadelLoginClientToken)
+	}
+	if cfg.ZitadelOrgID != "339070697432875523" {
+		t.Errorf("ZitadelOrgID = %q, want trimmed", cfg.ZitadelOrgID)
 	}
 }
 

--- a/services/platform-api/pkg/config/validate_zitadel_test.go
+++ b/services/platform-api/pkg/config/validate_zitadel_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"errors"
+	"testing"
+)
+
+func validZitadelConfig() Config {
+	return Config{
+		ZitadelEnabled:          true,
+		ZitadelIssuer:           "https://login.mark8ly.zitadel.cloud",
+		ZitadelLoginClientToken: "pat",
+		ZitadelOrgID:            "339070697432875523",
+	}
+}
+
+func TestValidateZitadel_DisabledIsAlwaysNil(t *testing.T) {
+	cfg := Config{ZitadelEnabled: false}
+	if err := cfg.ValidateZitadel(); err != nil {
+		t.Fatalf("ValidateZitadel() with the flag off = %v, want nil", err)
+	}
+}
+
+func TestValidateZitadel_FullyConfiguredPasses(t *testing.T) {
+	cfg := validZitadelConfig()
+	if err := cfg.ValidateZitadel(); err != nil {
+		t.Fatalf("ValidateZitadel() = %v, want nil", err)
+	}
+}
+
+func TestValidateZitadel_RefusesOnEachMissingValue(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*Config)
+		wantSub string
+	}{
+		{"issuer", func(c *Config) { c.ZitadelIssuer = "" }, "ZITADEL_ISSUER"},
+		{"login client token", func(c *Config) { c.ZitadelLoginClientToken = "" }, "ZITADEL_LOGIN_CLIENT_TOKEN"},
+		{"org id", func(c *Config) { c.ZitadelOrgID = "" }, "ZITADEL_ORG_ID"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validZitadelConfig()
+			tc.mutate(&cfg)
+			err := cfg.ValidateZitadel()
+			if err == nil {
+				t.Fatalf("ValidateZitadel() = nil, want an error mentioning %s", tc.wantSub)
+			}
+			if !errors.Is(err, ErrZitadelNotConfigured) {
+				t.Fatalf("err = %v, want it to wrap ErrZitadelNotConfigured", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Phase 5 of #524. `platform-api` can now send password-reset codes, reset passwords, and delete accounts against Zitadel instead of GIP's Identity Toolkit — behind interfaces, selected by `ZITADEL_ENABLED`, defaulting to GIP.

**With the flag unset — today's production — behaviour is identical to `main`.** Verified by diffing the GIP path directly; the only deltas are log strings.

## What moved, and what deliberately didn't

Three operations moved. **`EnsureTenantClaim` and `cmd/backfill-gip-claims` stayed on GIP on purpose.**

Decision D7 drops the custom claim, and phase 4 removed its consumer — but only *under the Zitadel flag*. With the flag off, `marketplace-api`'s `gip_bearer.go` still reads `tenant_id` from that claim, and `invitation/service.go` writes it on invite-accept. Its own comment records the failure mode: *"mobile shows its 'No store yet' empty state until the claim lands."* Deleting these before `ZITADEL_ENABLED` is true **on marketplace-api** gives every newly-invited merchant a permanent no-store state on mobile.

So a Zitadel-selected `platform-api` still keeps the GIP client alive for that one call — two concerns with two lifetimes, stated at every touch point so nobody "tidies up" the apparently-unused client.

## The reset code comes back to us on purpose

`POST /v2/users/{id}/password_reset` with `{"returnCode":{}}` returns a 6-character `verificationCode` and Zitadel sends nothing. That preserves today's `returnOobLink=true` behaviour and keeps branding and delivery on our own `notify` path rather than the shared instance's SMTP.

## Two blocking defects the reviews caught

**The reset body had the wrong shape, behind a green test.** It sent `{"medium":{"returnCode":{}}}`. Zitadel v2 is protojson, so **oneofs are flattened** — the correct form is `{"returnCode":{}}` at top level. Probed live:

```
{"returnCode":{}}             -> 200, verificationCode returned
{"medium":{"returnCode":{}}}  -> 200, NO code
```

The wrapped form doesn't error. Zitadel reads it as "no return medium requested", sends **its own unbranded reset email**, returns nothing, and we then 502 — so the user gets mail we didn't write *and* a failure. The test asserted the wrapped shape, so the fixture encoded the defect. It now asserts the top-level key **and** that `medium` is absent.

**The tenant-claim invariant was guarded against code edits but not the deploy.** An operator flipping `ZITADEL_ENABLED=true` would reasonably delete the now-"dead" `GIP_*` variables — which silently nils the claim setter behind one log warning, with nothing failing at startup. There is now a startup guard that refuses to boot in that state, with an error explaining *why* and pointing at marketplace-api's dependency.

## Error mapping is keyed on stable ids, not message text

Verified live 2026-09-04: `COMMAND-SAF4f` user not found (404), `COMMAND-2M9fs` wrong/expired code (400, grpc 9), `COMMAND-G8dh3` missing password field (400, grpc 9), `DOMAIN-HuJf6` password too short (400, grpc 3).

Note the middle two share grpc code 9 and their messages differ by one word — "Code not found" vs "Password not found" — so text matching cannot reliably tell a wrong reset code from a malformed request. And the prefix varies (`DOMAIN-`, not only `COMMAND-`).

The errors returned are the **`gipadmin` sentinels themselves**, because `auth/handler.go` and `service.go` branch on those exact values with `errors.Is`. A separate sentinel set would compile, pass its own tests, and silently turn a rate-limit into a 500.

## Deploy ordering

1. Set `ZITADEL_ISSUER`, `ZITADEL_LOGIN_CLIENT_TOKEN`, `ZITADEL_ORG_ID` — all three, whitespace-clean. They are trimmed on assignment; a trailing newline from a mounted secret caused a ~25-hour outage in this codebase before. A missing one crashloops, which is intended.
2. **Keep every `GIP_*` variable set.** That is what holds the tenant-claim path open, and the new startup guard now enforces it.
3. Flip `ZITADEL_ENABLED` on **auth-bff before platform-api** — otherwise `actorUID` can still be a GIP uid, and `DELETE /v2/users/<gip-uid>` 404s, which the idempotent-delete path treats as success.

Merging is safe regardless: the flag defaults false and the Zitadel values are unread while it is off.

## Known, not fixed

- A cross-service flag skew can make account deletion appear to succeed against a uid Zitadel does not know (see ordering step 3). Documented; the ordering is the mitigation.
- In-flight reset links cross a flag flip as 410 Gone in either direction — worth a support note.

## Testing

`go build`, `go vet`, `go test -race ./...` — all `platform-api` packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xQ7gJoonbQZmnnbfPD5RE
