### PR TITLE
docs(mcp): mark8ly should own its MCP connectors, and the foundation for that is go-shared v1.10.0

### DIFF
--- a/docs/superpowers/plans/2026-09-04-mcp-foundation-go-shared.md
+++ b/docs/superpowers/plans/2026-09-04-mcp-foundation-go-shared.md
@@ -1,0 +1,1239 @@
+# `go-shared/mcp` Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `go-shared/mcp` — the domain-free, SDK-free foundation every mark8ly and tesserix-home MCP server will be built on — as a go-shared minor release.
+
+**Architecture:** Five small packages under `mcp/`. `schema` derives closed JSON Schema from Go types. The `mcp` root registers tools through a generic function whose signature makes an untyped tool unrepresentable. `upstream` is an HTTP client with exactly one exported method, `Get`. `auth` verifies `X-MCP-Key`, failing closed. `observe` emits per-tool metrics that distinguish a dead server from a failing one. Nothing here imports an MCP SDK, a protocol type, or any product package.
+
+**Tech Stack:** Go 1.26, `reflect`, `crypto/subtle`, `net/http`, `github.com/prometheus/client_golang`, `github.com/stretchr/testify` (all already in `go-shared/go.mod` — this plan adds **no** new dependency).
+
+**Spec:** `docs/superpowers/specs/2026-09-04-mark8ly-mcp-connectors-design.md` (in the `mark8ly` repo; decisions D2, D5, D6, D9 are the ones this plan implements)
+
+## Global Constraints
+
+- **Repository: `go-shared`, not `mark8ly`.** Every path below is relative to the `go-shared` checkout (`../go-shared` from mark8ly). Branch from `origin/main`.
+- **No new module dependency.** `go.mod` must be unchanged by this plan. If a task seems to need a dependency, stop and raise it — D9 exists to keep this surface small.
+- **No MCP SDK import, anywhere.** Not in code, not in tests. (D9)
+- **No product package import.** Nothing from `mark8ly`, `tesserix-home`, or any service. (D2)
+- **Read-only.** No package here may issue an HTTP method other than GET. (D6)
+- **Closed schemas.** Every derived object schema sets `additionalProperties: false`. (D5)
+- **Go 1.26**, matching `go-shared/go.mod`.
+- `go build ./... && go vet ./... && go test -race ./...` must pass at the end of every task.
+- Commit messages: single-line subject, conventional-commit prefix, no body.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `mcp/doc.go` | Package doc: what the foundation is, and why the SDK is absent (D9) |
+| `mcp/schema/schema.go` | Go type → closed JSON Schema |
+| `mcp/schema/schema_test.go` | Derivation, closedness, unsupported-type rejection |
+| `mcp/tool.go` | `Tool`, `Registry`, generic `Register` — D5's structural enforcement |
+| `mcp/tool_test.go` | Registration, duplicate rejection, untyped-output rejection |
+| `mcp/upstream/client.go` | GET-only HTTP client, deadline, three distinct failure modes |
+| `mcp/upstream/client_test.go` | Happy path, 404, 5xx, timeout, and the method-set assertion (D6) |
+| `mcp/auth/key.go` | `X-MCP-Key` verification, fail-closed, constant-time |
+| `mcp/auth/key_test.go` | Accept, reject, empty-expected-key, timing-safe comparison |
+| `mcp/observe/metrics.go` | Per-tool latency + outcome counters |
+| `mcp/observe/metrics_test.go` | Registration, outcome labelling |
+| `mcp/boundaries_test.go` | D2 and D9 asserted against the real import graph |
+
+---
+
+### Task 1: `mcp/schema` — closed JSON Schema from Go types
+
+**Files:**
+- Create: `mcp/schema/schema.go`
+- Test: `mcp/schema/schema_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `schema.For(v any) (map[string]any, error)` — returns a JSON Schema
+  object for `v`'s type. Object schemas always carry
+  `"additionalProperties": false`. Returns an error for channels, funcs, maps
+  with non-string keys, and `interface{}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type product struct {
+	Handle string  `json:"handle" desc:"URL-safe product slug"`
+	Title  string  `json:"title"`
+	Price  float64 `json:"price"`
+	Tags   []string `json:"tags"`
+	Note   *string `json:"note,omitempty"`
+	hidden string  //nolint:unused // unexported fields must not appear
+}
+
+func TestFor_StructIsClosedAndDescribed(t *testing.T) {
+	s, err := For(product{})
+	require.NoError(t, err)
+
+	assert.Equal(t, "object", s["type"])
+	// A closed schema is the whole point of D5 — an agent must not receive
+	// fields nobody declared.
+	assert.Equal(t, false, s["additionalProperties"])
+
+	props := s["properties"].(map[string]any)
+	assert.Equal(t, "string", props["handle"].(map[string]any)["type"])
+	assert.Equal(t, "URL-safe product slug", props["handle"].(map[string]any)["description"])
+	assert.Equal(t, "number", props["price"].(map[string]any)["type"])
+	assert.Equal(t, "array", props["tags"].(map[string]any)["type"])
+	assert.Equal(t, "string", props["tags"].(map[string]any)["items"].(map[string]any)["type"])
+
+	assert.NotContains(t, props, "hidden", "unexported fields must never be exposed")
+
+	// omitempty and pointers mean optional; everything else is required.
+	assert.ElementsMatch(t, []any{"handle", "title", "price", "tags"}, s["required"])
+}
+
+func TestFor_RejectsUntypedInterface(t *testing.T) {
+	var v any
+	_, err := For(v)
+	require.Error(t, err, "an interface carries no schema, so it cannot be closed")
+}
+
+func TestFor_RejectsUnsupportedKind(t *testing.T) {
+	_, err := For(make(chan int))
+	require.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ../go-shared && go test ./mcp/schema/ -run TestFor -v`
+Expected: FAIL — `no required module provides package .../mcp/schema` (the package does not exist yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// Package schema derives closed JSON Schema documents from Go types.
+//
+// "Closed" means every object schema carries additionalProperties:false. That
+// is not a stylistic preference: a tool result an agent may cite has to be a
+// declared shape, and a schema that permits unknown fields permits an
+// undeclared one to reach a model. See the design's D5.
+package schema
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// For derives a JSON Schema object for v's type.
+func For(v any) (map[string]any, error) {
+	t := reflect.TypeOf(v)
+	if t == nil {
+		return nil, fmt.Errorf("schema: cannot derive a schema from an untyped nil or interface")
+	}
+	return forType(t)
+}
+
+func forType(t reflect.Type) (map[string]any, error) {
+	switch t.Kind() {
+	case reflect.Pointer:
+		return forType(t.Elem())
+	case reflect.String:
+		return map[string]any{"type": "string"}, nil
+	case reflect.Bool:
+		return map[string]any{"type": "boolean"}, nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return map[string]any{"type": "integer"}, nil
+	case reflect.Float32, reflect.Float64:
+		return map[string]any{"type": "number"}, nil
+	case reflect.Slice, reflect.Array:
+		items, err := forType(t.Elem())
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"type": "array", "items": items}, nil
+	case reflect.Struct:
+		return forStruct(t)
+	default:
+		return nil, fmt.Errorf("schema: unsupported kind %s for type %s", t.Kind(), t)
+	}
+}
+
+func forStruct(t reflect.Type) (map[string]any, error) {
+	props := map[string]any{}
+	var required []any
+
+	for i := range t.NumField() {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		name, opts, ok := jsonName(f)
+		if !ok {
+			continue
+		}
+		sub, err := forType(f.Type)
+		if err != nil {
+			return nil, fmt.Errorf("field %s: %w", f.Name, err)
+		}
+		if d := f.Tag.Get("desc"); d != "" {
+			sub["description"] = d
+		}
+		props[name] = sub
+
+		if !opts.omitempty && f.Type.Kind() != reflect.Pointer {
+			required = append(required, name)
+		}
+	}
+
+	s := map[string]any{
+		"type":                 "object",
+		"properties":           props,
+		"additionalProperties": false,
+	}
+	if len(required) > 0 {
+		s["required"] = required
+	}
+	return s, nil
+}
+
+type fieldOpts struct{ omitempty bool }
+
+func jsonName(f reflect.StructField) (string, fieldOpts, bool) {
+	tag := f.Tag.Get("json")
+	if tag == "-" {
+		return "", fieldOpts{}, false
+	}
+	parts := strings.Split(tag, ",")
+	name := parts[0]
+	if name == "" {
+		name = f.Name
+	}
+	var o fieldOpts
+	for _, p := range parts[1:] {
+		if p == "omitempty" {
+			o.omitempty = true
+		}
+	}
+	return name, o, true
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ../go-shared && go test -race ./mcp/schema/ -v`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ../go-shared
+git add mcp/schema/
+git commit -m "feat(mcp): derive closed JSON Schema from Go types"
+```
+
+---
+
+### Task 2: `mcp` root — a registry that cannot hold an untyped tool
+
+**Files:**
+- Create: `mcp/tool.go`, `mcp/doc.go`
+- Test: `mcp/tool_test.go`
+
+**Interfaces:**
+- Consumes: `schema.For` from Task 1.
+- Produces:
+  - `type Tool struct { Name, Description string; InputSchema, OutputSchema map[string]any; Invoke func(context.Context, json.RawMessage) (any, error) }`
+  - `func NewRegistry() *Registry`
+  - `func Register[In, Out any](r *Registry, name, description string, h func(context.Context, In) (Out, error)) error`
+  - `func (r *Registry) Tools() []Tool` — sorted by name, safe for concurrent use.
+  - `func (r *Registry) Names() []string` — sorted; used by the declared-vs-served CI test.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type listIn struct {
+	StoreSlug string `json:"store_slug" desc:"Public store slug"`
+}
+
+type listOut struct {
+	Found bool     `json:"found"`
+	Items []string `json:"items"`
+}
+
+func listHandler(_ context.Context, in listIn) (listOut, error) {
+	return listOut{Found: true, Items: []string{in.StoreSlug}}, nil
+}
+
+func TestRegister_DerivesBothSchemas(t *testing.T) {
+	r := NewRegistry()
+	require.NoError(t, Register(r, "list_store_products", "List products.", listHandler))
+
+	tools := r.Tools()
+	require.Len(t, tools, 1)
+
+	// D5: BOTH schemas exist. A tool with an input schema and no output schema
+	// is exactly the thing OpenAPI ingestion produced, and the reason it was
+	// rejected.
+	require.NotNil(t, tools[0].InputSchema)
+	require.NotNil(t, tools[0].OutputSchema)
+	assert.Equal(t, false, tools[0].OutputSchema["additionalProperties"])
+}
+
+func TestRegister_RejectsUntypedOutput(t *testing.T) {
+	r := NewRegistry()
+	err := Register(r, "bad", "Untyped.", func(_ context.Context, _ listIn) (any, error) {
+		return nil, nil
+	})
+	require.Error(t, err, "an `any` result cannot be closed, so it cannot be cited")
+}
+
+func TestRegister_RejectsDuplicateName(t *testing.T) {
+	r := NewRegistry()
+	require.NoError(t, Register(r, "dup", "First.", listHandler))
+	require.Error(t, Register(r, "dup", "Second.", listHandler))
+}
+
+func TestInvoke_DecodesAndReturnsTypedResult(t *testing.T) {
+	r := NewRegistry()
+	require.NoError(t, Register(r, "list_store_products", "List products.", listHandler))
+
+	out, err := r.Tools()[0].Invoke(context.Background(), json.RawMessage(`{"store_slug":"bondi"}`))
+	require.NoError(t, err)
+	assert.Equal(t, listOut{Found: true, Items: []string{"bondi"}}, out)
+}
+
+func TestInvoke_RejectsUnknownInputField(t *testing.T) {
+	r := NewRegistry()
+	require.NoError(t, Register(r, "list_store_products", "List products.", listHandler))
+
+	_, err := r.Tools()[0].Invoke(context.Background(), json.RawMessage(`{"store_id":"7"}`))
+	require.Error(t, err, "input is a closed schema; an undeclared field is a caller error")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ../go-shared && go test ./mcp/ -v`
+Expected: FAIL — package `mcp` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`mcp/doc.go`:
+
+```go
+// Package mcp is the foundation every Tesserix MCP connector is built on:
+// tool registration with closed input and output schemas, a GET-only upstream
+// client, key verification, and per-tool metrics.
+//
+// # What is deliberately NOT here
+//
+// There is no MCP SDK import, and no protocol type, anywhere in this package
+// tree. The binding to a specific SDK and protocol version lives in the
+// consuming service.
+//
+// Two reasons. Every Go service in the estate imports go-shared, so an SDK
+// dependency here enters ~30 module graphs whether those services serve MCP or
+// not. And the protocol is where the movement is — the estate's registry
+// records pin protocolVersion 2026-07-28 — so a protocol revision would
+// otherwise force a go-shared release affecting every service to change
+// something only MCP servers care about.
+//
+// boundaries_test.go enforces both halves of that. See the design's D9.
+package mcp
+```
+
+`mcp/tool.go`:
+
+```go
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"sync"
+
+	"github.com/tesserix/go-shared/mcp/schema"
+)
+
+// Tool is a registered, fully-described tool.
+type Tool struct {
+	Name         string
+	Description  string
+	InputSchema  map[string]any
+	OutputSchema map[string]any
+	Invoke       func(context.Context, json.RawMessage) (any, error)
+}
+
+// Registry holds the tools a server serves. Safe for concurrent use.
+type Registry struct {
+	mu    sync.RWMutex
+	tools map[string]Tool
+}
+
+// NewRegistry returns an empty Registry.
+func NewRegistry() *Registry {
+	return &Registry{tools: map[string]Tool{}}
+}
+
+// Register adds a tool, deriving both schemas from the handler's own signature.
+//
+// The generic signature is the enforcement of D5, not a convenience: there is
+// no way to call this without an input type and an output type, so a tool
+// cannot exist without both. The only remaining hole is naming `any` as the
+// output, which is rejected below.
+func Register[In, Out any](r *Registry, name, description string, h func(context.Context, In) (Out, error)) error {
+	if name == "" {
+		return fmt.Errorf("mcp: tool name must not be empty")
+	}
+	if description == "" {
+		return fmt.Errorf("mcp: tool %q must carry a description — it is what the model reads", name)
+	}
+
+	var out Out
+	if reflect.TypeOf(&out).Elem().Kind() == reflect.Interface {
+		return fmt.Errorf("mcp: tool %q declares an interface result; an untyped result cannot be closed or cited", name)
+	}
+
+	var in In
+	inSchema, err := schema.For(in)
+	if err != nil {
+		return fmt.Errorf("mcp: tool %q input: %w", name, err)
+	}
+	outSchema, err := schema.For(out)
+	if err != nil {
+		return fmt.Errorf("mcp: tool %q output: %w", name, err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.tools[name]; exists {
+		return fmt.Errorf("mcp: tool %q is already registered", name)
+	}
+
+	r.tools[name] = Tool{
+		Name:         name,
+		Description:  description,
+		InputSchema:  inSchema,
+		OutputSchema: outSchema,
+		Invoke: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			var args In
+			dec := json.NewDecoder(bytes.NewReader(raw))
+			// The input schema is closed, so the decoder must be too —
+			// otherwise a caller can pass a field the schema forbids and be
+			// silently ignored rather than corrected.
+			dec.DisallowUnknownFields()
+			if len(raw) > 0 {
+				if err := dec.Decode(&args); err != nil {
+					return nil, fmt.Errorf("mcp: tool %q arguments: %w", name, err)
+				}
+			}
+			return h(ctx, args)
+		},
+	}
+	return nil
+}
+
+// Tools returns every registered tool, sorted by name.
+func (r *Registry) Tools() []Tool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]Tool, 0, len(r.tools))
+	for _, t := range r.tools {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// Names returns registered tool names, sorted. The declared-vs-served check
+// compares this against the registry record.
+func (r *Registry) Names() []string {
+	tools := r.Tools()
+	names := make([]string, len(tools))
+	for i, t := range tools {
+		names[i] = t.Name
+	}
+	return names
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ../go-shared && go test -race ./mcp/ -v`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ../go-shared
+git add mcp/doc.go mcp/tool.go mcp/tool_test.go
+git commit -m "feat(mcp): a tool cannot be registered without both schemas"
+```
+
+---
+
+### Task 3: `mcp/upstream` — a client with no write verb
+
+**Files:**
+- Create: `mcp/upstream/client.go`
+- Test: `mcp/upstream/client_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `func New(baseURL string, opts ...Option) (*Client, error)`
+  - `func WithHeader(k, v string) Option`, `func WithTimeout(d time.Duration) Option`, `func WithHTTPClient(c *http.Client) Option`
+  - `func (c *Client) Get(ctx context.Context, path string, params url.Values, out any) error`
+  - Sentinels: `ErrNotFound`, `ErrUnavailable`, `ErrDeadlineExceeded`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package upstream
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type result struct {
+	Handle string `json:"handle"`
+}
+
+func TestGet_HappyPathSendsHeadersAndParams(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "secret", r.Header.Get("X-Storefront-Key"))
+		assert.Equal(t, "20", r.URL.Query().Get("limit"))
+		assert.Equal(t, "/api/v1/storefront/stores/bondi/products", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"handle":"mug"}`))
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL, WithHeader("X-Storefront-Key", "secret"))
+	require.NoError(t, err)
+
+	var got result
+	require.NoError(t, c.Get(context.Background(),
+		"/api/v1/storefront/stores/bondi/products", url.Values{"limit": {"20"}}, &got))
+	assert.Equal(t, "mug", got.Handle)
+}
+
+func TestGet_404IsNotFoundNotUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL)
+	require.NoError(t, err)
+
+	var got result
+	err = c.Get(context.Background(), "/missing", nil, &got)
+	// These must stay distinct: "this store does not exist" and "we could not
+	// ask" lead to different agent behaviour.
+	require.ErrorIs(t, err, ErrNotFound)
+	assert.NotErrorIs(t, err, ErrUnavailable)
+}
+
+func TestGet_5xxIsUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL)
+	require.NoError(t, err)
+
+	var got result
+	require.ErrorIs(t, c.Get(context.Background(), "/x", nil, &got), ErrUnavailable)
+}
+
+func TestGet_TimeoutIsDeadlineExceeded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(150 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL, WithTimeout(20*time.Millisecond))
+	require.NoError(t, err)
+
+	var got result
+	require.ErrorIs(t, c.Get(context.Background(), "/slow", nil, &got), ErrDeadlineExceeded)
+}
+
+// D6, asserted structurally rather than by review. If someone adds Post, this
+// fails — which is the entire point: a write must not be something an author
+// merely remembers not to do.
+func TestClient_ExposesOnlyGet(t *testing.T) {
+	var methods []string
+	ct := reflect.TypeOf(&Client{})
+	for i := range ct.NumMethod() {
+		methods = append(methods, ct.Method(i).Name)
+	}
+	assert.Equal(t, []string{"Get"}, methods,
+		"the upstream client must be incapable of expressing a write")
+}
+
+var _ = errors.Is
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ../go-shared && go test ./mcp/upstream/ -v`
+Expected: FAIL — package does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// Package upstream is the only way a connector reaches a product API.
+//
+// It exposes exactly one verb. That is D6 made structural: a connector cannot
+// perform a write because there is no method that issues one, not because an
+// author remembered to avoid it.
+package upstream
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Failure modes a caller must be able to tell apart. A missing store and an
+// unreachable API produce very different agent behaviour: one is an answer,
+// the other must degrade to a document-only reply with disclosure.
+var (
+	ErrNotFound         = errors.New("upstream: not found")
+	ErrUnavailable      = errors.New("upstream: unavailable")
+	ErrDeadlineExceeded = errors.New("upstream: deadline exceeded")
+)
+
+const defaultTimeout = 400 * time.Millisecond
+
+// Client performs GET requests against one product API.
+type Client struct {
+	base    *url.URL
+	headers map[string]string
+	http    *http.Client
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithHeader adds a header sent on every request — the credential path.
+func WithHeader(k, v string) Option {
+	return func(c *Client) { c.headers[k] = v }
+}
+
+// WithTimeout overrides the per-request deadline. Defaults to 400ms, the
+// per-tool budget the engine contracts for.
+func WithTimeout(d time.Duration) Option {
+	return func(c *Client) { c.http.Timeout = d }
+}
+
+// WithHTTPClient replaces the underlying client. The timeout is preserved.
+func WithHTTPClient(h *http.Client) Option {
+	return func(c *Client) {
+		t := c.http.Timeout
+		c.http = h
+		if c.http.Timeout == 0 {
+			c.http.Timeout = t
+		}
+	}
+}
+
+// New returns a Client rooted at baseURL.
+func New(baseURL string, opts ...Option) (*Client, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("upstream: base URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("upstream: base URL %q must be absolute", baseURL)
+	}
+	c := &Client{
+		base:    u,
+		headers: map[string]string{},
+		http:    &http.Client{Timeout: defaultTimeout},
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c, nil
+}
+
+// Get fetches path and decodes the JSON body into out.
+func (c *Client) Get(ctx context.Context, path string, params url.Values, out any) error {
+	ref := &url.URL{Path: path}
+	if params != nil {
+		ref.RawQuery = params.Encode()
+	}
+	target := c.base.ResolveReference(ref)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.String(), nil)
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrUnavailable, err)
+	}
+	req.Header.Set("Accept", "application/json")
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || isTimeout(err) {
+			return fmt.Errorf("%w: %s", ErrDeadlineExceeded, err)
+		}
+		return fmt.Errorf("%w: %s", ErrUnavailable, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
+		return ErrNotFound
+	case resp.StatusCode >= 400:
+		// Everything else — including a 4xx that means our credential is
+		// wrong — is "we could not ask". It must never be reported as an
+		// empty catalogue.
+		return fmt.Errorf("%w: status %d", ErrUnavailable, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("%w: reading body: %s", ErrUnavailable, err)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("%w: decoding body: %s", ErrUnavailable, err)
+	}
+	return nil
+}
+
+func isTimeout(err error) bool {
+	var ne net.Error
+	if errors.As(err, &ne) {
+		return ne.Timeout()
+	}
+	return strings.Contains(err.Error(), "Client.Timeout")
+}
+```
+
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ../go-shared && go test -race ./mcp/upstream/ -v`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ../go-shared
+git add mcp/upstream/
+git commit -m "feat(mcp): a GET-only upstream client that cannot express a write"
+```
+
+---
+
+### Task 4: `mcp/auth` — fail-closed key verification
+
+**Files:**
+- Create: `mcp/auth/key.go`
+- Test: `mcp/auth/key_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `func RequireKey(expected string, next http.Handler) http.Handler` —
+  wraps a handler, requiring header `X-MCP-Key`. Header name exported as
+  `const HeaderName = "X-MCP-Key"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ok() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func do(t *testing.T, h http.Handler, key string) int {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	if key != "" {
+		req.Header.Set(HeaderName, key)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec.Code
+}
+
+func TestRequireKey_AcceptsMatching(t *testing.T) {
+	assert.Equal(t, http.StatusOK, do(t, RequireKey("s3cret", ok()), "s3cret"))
+}
+
+func TestRequireKey_RejectsWrongAndMissing(t *testing.T) {
+	h := RequireKey("s3cret", ok())
+	assert.Equal(t, http.StatusUnauthorized, do(t, h, "wrong"))
+	assert.Equal(t, http.StatusUnauthorized, do(t, h, ""))
+}
+
+// The case that matters most: an unset secret must not become an open door.
+// A missing ExternalSecret is a deployment mistake, and the safe reading of it
+// is "nobody may call", never "everybody may".
+func TestRequireKey_EmptyExpectedFailsClosed(t *testing.T) {
+	h := RequireKey("", ok())
+	assert.Equal(t, http.StatusUnauthorized, do(t, h, ""))
+	assert.Equal(t, http.StatusUnauthorized, do(t, h, "anything"))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ../go-shared && go test ./mcp/auth/ -v`
+Expected: FAIL — package does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// Package auth verifies the shared key a connector is called with.
+package auth
+
+import (
+	"crypto/subtle"
+	"net/http"
+)
+
+// HeaderName is the header every product MCP server in the estate is called
+// with; the registry records name it in their credentialRef.
+const HeaderName = "X-MCP-Key"
+
+// RequireKey wraps next, rejecting any request whose HeaderName does not match
+// expected.
+//
+// An empty expected key rejects everything. That is deliberate: the key comes
+// from a mounted secret, and an absent secret means the deployment is
+// misconfigured — serving an open endpoint would turn a configuration mistake
+// into an exposure.
+func RequireKey(expected string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if expected == "" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		got := r.Header.Get(HeaderName)
+		if subtle.ConstantTimeCompare([]byte(got), []byte(expected)) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ../go-shared && go test -race ./mcp/auth/ -v`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ../go-shared
+git add mcp/auth/
+git commit -m "feat(mcp): verify the connector key, failing closed on an unset secret"
+```
+
+---
+
+### Task 5: `mcp/observe` — metrics that distinguish dead from failing
+
+**Files:**
+- Create: `mcp/observe/metrics.go`
+- Test: `mcp/observe/metrics_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `type Outcome string` with `OutcomeOK`, `OutcomeNotFound`, `OutcomeUnavailable`, `OutcomeDeadline`, `OutcomeInvalidInput`
+  - `func NewToolMetrics(reg prometheus.Registerer, service string) (*ToolMetrics, error)`
+  - `func (m *ToolMetrics) Observe(tool string, outcome Outcome, d time.Duration)`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package observe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObserve_CountsPerToolAndOutcome(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m, err := NewToolMetrics(reg, "mcp-catalog")
+	require.NoError(t, err)
+
+	m.Observe("list_store_products", OutcomeOK, 12*time.Millisecond)
+	m.Observe("list_store_products", OutcomeUnavailable, 8*time.Millisecond)
+	m.Observe("get_store_product", OutcomeNotFound, 3*time.Millisecond)
+
+	require.Equal(t, 1.0, testutil.ToFloat64(
+		m.calls.WithLabelValues("list_store_products", string(OutcomeOK))))
+	require.Equal(t, 1.0, testutil.ToFloat64(
+		m.calls.WithLabelValues("list_store_products", string(OutcomeUnavailable))))
+	require.Equal(t, 1.0, testutil.ToFloat64(
+		m.calls.WithLabelValues("get_store_product", string(OutcomeNotFound))))
+}
+
+// Registering twice against one registry is a startup bug, and it must be an
+// error rather than a panic in a library ~30 services import.
+func TestNewToolMetrics_DuplicateRegistrationIsAnError(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	_, err := NewToolMetrics(reg, "mcp-catalog")
+	require.NoError(t, err)
+	_, err = NewToolMetrics(reg, "mcp-catalog")
+	require.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ../go-shared && go test ./mcp/observe/ -v`
+Expected: FAIL — package does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// Package observe carries a connector's per-tool metrics.
+//
+// Outcome is a label rather than separate metrics because the distinction that
+// matters is between a server that has STOPPED SERVING and one that KEEPS
+// FAILING — and both are invisible if success and failure share a counter.
+package observe
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Outcome is the controlled vocabulary for how a tool call ended.
+type Outcome string
+
+const (
+	OutcomeOK           Outcome = "ok"
+	OutcomeNotFound     Outcome = "not_found"
+	OutcomeUnavailable  Outcome = "unavailable"
+	OutcomeDeadline     Outcome = "deadline"
+	OutcomeInvalidInput Outcome = "invalid_input"
+)
+
+// ToolMetrics records tool call counts and latency.
+type ToolMetrics struct {
+	calls    *prometheus.CounterVec
+	duration *prometheus.HistogramVec
+}
+
+// NewToolMetrics registers the metrics on reg.
+func NewToolMetrics(reg prometheus.Registerer, service string) (*ToolMetrics, error) {
+	labels := prometheus.Labels{"service": service}
+
+	calls := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name:        "tesserix_mcp_tool_calls_total",
+		Help:        "Tool calls by tool and outcome. Read outcome!=ok against outcome=ok — a tool that only fails and a tool nobody calls look identical in a single total.",
+		ConstLabels: labels,
+	}, []string{"tool", "outcome"})
+
+	duration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "tesserix_mcp_tool_duration_seconds",
+		Help: "Tool call latency. The engine budgets 400ms p99 per tool; this is how you know whether that contract holds.",
+		// Bucketed around the 400ms contract rather than Prometheus defaults.
+		Buckets:     []float64{0.01, 0.025, 0.05, 0.1, 0.2, 0.4, 0.8, 2},
+		ConstLabels: labels,
+	}, []string{"tool", "outcome"})
+
+	if err := reg.Register(calls); err != nil {
+		return nil, err
+	}
+	if err := reg.Register(duration); err != nil {
+		return nil, err
+	}
+	return &ToolMetrics{calls: calls, duration: duration}, nil
+}
+
+// Observe records one completed tool call.
+func (m *ToolMetrics) Observe(tool string, outcome Outcome, d time.Duration) {
+	m.calls.WithLabelValues(tool, string(outcome)).Inc()
+	m.duration.WithLabelValues(tool, string(outcome)).Observe(d.Seconds())
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ../go-shared && go test -race ./mcp/observe/ -v`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ../go-shared
+git add mcp/observe/
+git commit -m "feat(mcp): per-tool call and latency metrics"
+```
+
+---
+
+### Task 6: The boundaries, asserted against the real import graph
+
+**Files:**
+- Create: `mcp/boundaries_test.go`
+
+**Interfaces:**
+- Consumes: every package from Tasks 1–5 (by import path only).
+- Produces: nothing importable. This task's deliverable is a gate.
+
+- [ ] **Step 1: Write the failing test**
+
+The obvious tool for this is `golang.org/x/tools/go/packages`, but it is not a
+dependency and the Global Constraints forbid adding one to enforce a rule about
+dependencies. Shell out to the toolchain instead:
+
+```go
+package mcp_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// deps returns the full transitive import list of the mcp package tree, as the
+// toolchain itself computes it. Shelling out to `go list` avoids adding
+// golang.org/x/tools as a dependency purely to enforce a rule about
+// dependencies.
+func deps(t *testing.T) []string {
+	t.Helper()
+	out, err := exec.Command("go", "list", "-deps", "./...").Output()
+	require.NoError(t, err, "go list must succeed")
+	return strings.Fields(string(out))
+}
+
+// D9: the SDK binding lives in the consuming service, never here. If this
+// fails, a protocol bump has just become a go-shared release for ~30 services.
+func TestFoundationImportsNoMCPSDK(t *testing.T) {
+	banned := []string{
+		"modelcontextprotocol",
+		"mcp-go",
+		"mark3labs",
+	}
+	for _, dep := range deps(t) {
+		for _, b := range banned {
+			require.NotContains(t, dep, b,
+				"go-shared/mcp must not import an MCP SDK (D9); found %s", dep)
+		}
+	}
+}
+
+// D2: the foundation is domain-free. A product import here would make every
+// service that imports go-shared depend on one product's model.
+func TestFoundationImportsNoProductPackage(t *testing.T) {
+	banned := []string{
+		"github.com/mark8ly/",
+		"github.com/tesserix/tesserix-home",
+		"github.com/tesserix/australis",
+	}
+	for _, dep := range deps(t) {
+		for _, b := range banned {
+			require.NotContains(t, dep, b,
+				"go-shared/mcp must not import a product package (D2); found %s", dep)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Prove the gate has teeth before trusting it. Adding a real product import would
+only produce a module-resolution error, which tests the toolchain rather than
+the assertion — so mutate the assertion's own input instead. Temporarily add a
+package the foundation genuinely does import to the banned list in
+`TestFoundationImportsNoMCPSDK`:
+
+```go
+	banned := []string{
+		"modelcontextprotocol",
+		"mcp-go",
+		"mark3labs",
+		"prometheus", // TEMPORARY — mcp/observe really does import this
+	}
+```
+
+Run: `cd ../go-shared && go test ./mcp/ -run TestFoundationImportsNoMCPSDK -v`
+Expected: FAIL, naming the prometheus dependency. That proves `go list -deps`
+is returning a real graph and the assertion reads it correctly — a test that
+passes because it inspected an empty list would look identical to a passing
+gate.
+
+Remove that line again and confirm it returns to PASS.
+
+- [ ] **Step 3: Run the tests to verify they pass**
+
+Run: `cd ../go-shared && go test -race ./mcp/... -v`
+Expected: PASS — every test from Tasks 1–5 plus both boundary tests.
+
+- [ ] **Step 4: Full module verification**
+
+Run: `cd ../go-shared && go build ./... && go vet ./... && go test -race ./...`
+Expected: all pass. Confirm `git diff --stat origin/main -- go.mod go.sum` is
+**empty** — this plan adds no dependency.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ../go-shared
+git add mcp/boundaries_test.go
+git commit -m "test(mcp): keep the foundation free of SDKs and product packages"
+```
+
+---
+
+### Task 7: Release the foundation
+
+**Files:**
+- Modify: none — this task produces a tag and a PR.
+
+**Interfaces:**
+- Consumes: Tasks 1–6.
+- Produces: a `go-shared` minor version consumable as
+  `github.com/tesserix/go-shared/mcp`. mark8ly's `mcp-catalog` plan starts here.
+
+- [ ] **Step 1: Push the branch and open the PR**
+
+`gh` writes must be direct Bash commands, never inside a script, and the PR
+must be created from the main checkout rather than a worktree.
+
+```bash
+cd ../go-shared
+git push -u origin feat/mcp-foundation
+gh pr create -R tesserix/go-shared -B main -H feat/mcp-foundation \
+  --title "feat(mcp): the connector foundation — closed schemas, GET-only upstream, fail-closed auth" \
+  --body-file /tmp/mcp-foundation-pr.md
+```
+
+Write `/tmp/mcp-foundation-pr.md` first with a quoted heredoc (`<<'BODY'`) so
+backticks survive. It must state: no new dependency; the four structural
+guarantees (both schemas required, GET-only, fail-closed key, SDK-free); and
+that no service consumes it yet, so the blast radius of this release is zero.
+
+- [ ] **Step 2: Confirm CI is green**
+
+The repo's workflow runs `go build`, `go vet`, `go test -race -coverprofile`
+and a non-blocking `gofmt` report. Before pushing, run `gofmt -l mcp/` locally
+and fix anything it lists — the format job is non-blocking precisely because of
+a pre-existing backlog, and new files must not add to it.
+
+- [ ] **Step 3: Merge, then tag**
+
+After the PR merges, tag the release. The current tag is `v1.9.1`; this is a new
+package with no change to existing ones, so it is a **minor** bump.
+
+```bash
+cd ../go-shared
+git checkout main && git pull --ff-only
+git tag v1.10.0
+git push origin v1.10.0
+```
+
+- [ ] **Step 4: Verify it is consumable**
+
+```bash
+cd /tmp && rm -rf mcpcheck && mkdir mcpcheck && cd mcpcheck
+go mod init check
+GOPROXY=direct go get github.com/tesserix/go-shared@v1.10.0
+```
+Expected: resolves. This is the only proof that the tag is real and fetchable —
+a merged PR is not a released library.
+
+---
+
+## What this plan deliberately does NOT do
+
+- **No mark8ly changes.** `mcp-catalog` is a separate plan, blocked on the SDK
+  decision (spec open question 2). Nothing here depends on that decision, which
+  is why this half can ship first.
+- **No `gofmt` backlog cleanup** across the rest of go-shared. Tempting while
+  here; unrelated, and it would bury this diff.
+- **No transport, no server, no protocol handling.** By D9.
+- **No registry record or Kubernetes manifest.** Those belong to the connector,
+  not the foundation.
+
+## Self-review notes
+
+Checked against the spec: D5 is Task 2 (generic `Register` plus the interface-
+output rejection), D6 is Task 3 (`TestClient_ExposesOnlyGet`), D9 is Tasks 2 and
+6 (`doc.go` plus the import-graph gate), D2's domain-freedom is Task 6. The
+spec's "schema registry / upstream / auth / observe" four-part foundation maps
+to Tasks 1+2 / 3 / 4 / 5 respectively.
+
+Two spec items are intentionally out of this plan's scope and belong to the
+connector plan: the **declared-vs-served** CI check (needs a registry record and
+a running server) and the **projection tests against recorded marketplace-api
+responses** (needs the catalog domain package). `Registry.Names()` is built here
+so the first of those has something to compare against.

--- a/docs/superpowers/plans/2026-09-04-mcp-foundation-go-shared.md
+++ b/docs/superpowers/plans/2026-09-04-mcp-foundation-go-shared.md
@@ -1237,3 +1237,70 @@ connector plan: the **declared-vs-served** CI check (needs a registry record and
 a running server) and the **projection tests against recorded marketplace-api
 responses** (needs the catalog domain package). `Registry.Names()` is built here
 so the first of those has something to compare against.
+
+---
+
+## Executed 2026-09-04 — what actually shipped
+
+This plan was executed and is complete. `go-shared` **v1.10.0** carries `mcp/`
+(PR tesserix/go-shared#6, merged as `cf68da3`). Verified consumable:
+`go get github.com/tesserix/go-shared@v1.10.0` resolves from a clean module.
+
+**The released package contains materially more than the seven tasks above**,
+because reviews found real defects and because API additions were free before
+the tag and permanently expensive after it. Read this section, not just the
+tasks, to know what v1.10.0 actually is.
+
+### Two Criticals the plan did not anticipate, both found by executing the code
+
+- **A redirect leaked the credential.** `http.Client` follows redirects and Go's
+  stdlib only strips `Authorization`/`Cookie` cross-host, so headers added via
+  `WithHeader` — the documented credential path — reached whatever host
+  `Location` named, that host's JSON was decoded into the tool result, and `Get`
+  returned `nil`. It also bypassed the path-traversal guard entirely. Fixed with
+  `CheckRedirect` returning `http.ErrUseLastResponse`, applied *after* the option
+  loop so a caller-supplied client cannot reopen it.
+- **Embedded structs made the derived schema disagree with the wire in both
+  directions.** For `struct{ Page; Slug string }`, the schema declared a required
+  object property `Page` while `encoding/json` marshals `{"limit":…,"slug":…}` —
+  so every result violated its own `additionalProperties:false`, and the decoder
+  accepted what the schema forbade while rejecting what it required. Fixed by
+  flattening as `encoding/json` promotes, and erroring at registration on
+  embedded pointers, embedded interfaces and name collisions.
+
+### API additions made before tagging
+
+Not in the task list; added because nothing consumed the package yet.
+
+- `observe.OutcomeFor(err) Outcome` — the missing seam. `upstream`'s three
+  sentinels and `observe`'s outcome labels were a 1:1 mapping that existed
+  nowhere, so every connector would have written its own `switch` and the
+  estate's dashboards would have stopped being comparable.
+- `mcp.ErrInvalidArguments` — so a bad-arguments call is distinguishable from a
+  failed handler without string-matching. `Invoke` also now rejects trailing
+  JSON garbage.
+- `observe.OutcomeError` — a catch-all, because an open `Outcome` type with an
+  incomplete closed set invites five connectors to invent `"error"`,
+  `"internal"` and `"failed"`.
+- `Registry.Get(name)` — serving `tools/call` via `Tools()` would have
+  deep-copied every other tool's schemas on every request.
+- `NewToolMetrics(reg, service, opts ...Option)` with a bucket override.
+
+### Behaviour worth knowing before you build on it
+
+- **`WithHTTPClient` now always overrides the supplied client's `Timeout`** with
+  the connector's budget, so option order cannot change the effective deadline.
+  `WithHTTPClient(clientWith30s)` alone yields 400ms. The caller's client is
+  never mutated.
+- **The input schema's `required` is NOT enforced at decode time.** Go cannot
+  distinguish an absent field from a zero value without decoding to a map first;
+  handlers must treat zero values as possibly-absent. Documented on `Register`.
+- **The import gate covers test files** (`go list -deps -test ./...`), and
+  enforces only the import half of D9 — the absence of protocol *types* is a
+  design rule held by review, since no import check can see a hand-written
+  struct that mirrors a protocol shape.
+
+### Known follow-up
+
+One schema collision error message names the field's type where it means the
+parent type. Right diagnosis, wrong noun.

--- a/docs/superpowers/specs/2026-09-04-mark8ly-mcp-connectors-design.md
+++ b/docs/superpowers/specs/2026-09-04-mark8ly-mcp-connectors-design.md
@@ -1,0 +1,349 @@
+# mark8ly-owned MCP connectors
+
+Design for milestone 9 (MCP: platform agent integration). Written 2026-09-04.
+
+Every claim marked **VERIFIED** was observed against the live cluster, the
+running registry seeds, or the repos in this workspace on 2026-09-04 — not read
+from documentation.
+
+## The problem is ownership, not wiring
+
+mark8ly appears to have an MCP integration. It does not have one it owns.
+
+**VERIFIED.** `mark8ly-mcp` runs in the `mark8ly` namespace (113d old, Healthy),
+but its image is
+`asia-south1-docker.pkg.dev/.../tesserix/slm-support-platform/mcp-gateway`, and
+the chart that deploys it (`charts/apps/mcp-gateway` in `tesserix-k8s`) says so
+in its own values file: *"one shared image for every tenant."* The eight tools
+it serves — `get_order`, `list_returns`, `list_recent_orders`,
+`check_payment_status`, `create_refund_request`, `create_support_ticket`,
+`search_knowledge_base`, `lookup_conversation` — are implemented in
+`slm-support-platform`, a repository not present in this workspace. mark8ly is
+differentiated from homechef, platform and stockpilot by a `tenant` Helm
+parameter.
+
+mark8ly's entire own contribution to its agent surface is one 187-line
+hand-written OpenAPI document,
+`services/marketplace-api/internal/handlers/storefront/openapi.go`, ingested at
+gateway startup. **VERIFIED: it has never produced a single tool.** #412
+recorded the cause (a URL missing both `:8080` and the `/api/v1` prefix); that
+URL is now corrected on `origin/main` and the spec returns **200** from inside
+the cluster, but the registry record for `mark8ly-mcp` lists only the eight
+gateway-native tools and none of the spec's five operations. The catalog surface
+the spec was written to enable has never existed.
+
+This is the shape australis names as its two principal failure modes: the
+**god-server** ("a god-server accumulates unrelated scopes, and scopes are the
+unit of authorisation") and the shared failure domain that its invariant 1
+exists to prevent. One image change ships four products at once.
+
+## What already exists, and is worth keeping
+
+The estate has more MCP infrastructure than mark8ly uses, and it is already
+shaped the way australis specifies.
+
+| Thing | State | Where |
+| --- | --- | --- |
+| AgentGateway | **running** — incl. a dedicated `agentgateway-mcp` | ns `agentgateway-system` |
+| MCP CRDs | `mcpservers.kagent.dev`, `remotemcpservers.kagent.dev` installed | cluster-wide |
+| Registry | `agentic-registry` — a catalog, explicitly never a proxy | its own repo |
+| Registry seeds | 31 catalog + 12 product records, incl. `mark8ly-mcp.yaml` | `devai/architecture/registry-seeds/mcp-servers/` |
+| Hub implementation | registry-driven discovery, SSRF guard, identity terminated at hub | `devai/src/devai/mcphub/` |
+| Label vocabulary | `mcp.tesserix.app/tenant`, `.../class` — already on mark8ly's ArgoCD app | estate-wide |
+
+**VERIFIED: zero `MCPServer` custom resources exist estate-wide**, and devai's
+catalog seeds declare `registry.solo.io/v1alpha1` while the installed CRD group
+is `kagent.dev`. The seeds are a source of record that has never been applied to
+the cluster. That is out of scope here (see Non-goals) but it means a seed is
+today a *document*, not a deployed object — so this design treats the registry
+record as the reviewable contract it is, and does not depend on the CR existing.
+
+The per-product runtime split is already correct: `homechef-mcp.homechef.svc`,
+`mark8ly-mcp.mark8ly.svc`, each with its own key
+(`product-mcp-upstream-keys` / `MARK8LY_MCP_KEY`, header `X-MCP-Key`). Ownership
+of the *process* is already mark8ly's. Only the *source* is misplaced.
+
+## Decisions
+
+| # | Decision |
+|---|---|
+| D1 | mark8ly's MCP servers live in `mark8ly`, not in australis. ADR-0001 D1 is amended, not ignored. |
+| D2 | A reusable `services/mcp/internal/mcp` foundation; each server is a thin domain package over it. |
+| D3 | `catalog` is the first server. Support and platform-read follow, in that order. |
+| D4 | Tools read through marketplace-api's storefront HTTP surface, never the database directly. |
+| D5 | Every tool declares closed input **and** output schemas. No pass-through of upstream JSON. |
+| D6 | Read-only in v1, enforced structurally: the foundation cannot express a non-GET upstream call. |
+| D7 | One server per bounded domain, one Deployment, one ServiceAccount, one key. |
+| D8 | Registration is a reviewed registry record with a pinned image digest. No `latest`, ever. |
+
+### D1 — the servers live here, and the ADR is amended
+
+australis ADR-0001 D1 says connectors are built from australis
+(`servers/mark8ly/catalog`, `servers/mark8ly/orders` are named in its layout).
+**VERIFIED: australis has no code — `servers/` contains one README, and the repo
+describes itself as "design / pre-implementation".** Making mark8ly's first
+connector the first thing ever built there means inheriting a repo with no CI,
+no images and no runtime, to solve a problem that is about which repo the *tools*
+live in, not which repo the *design* lives in.
+
+australis's own D5 argues the same way: *"Co-locating the code must not transfer
+ownership of the domain knowledge in it. The person who knows that
+`daily_log_summary` must exclude soft-deleted entries is the person who reviews
+changes to it."* The person who knows a mark8ly refund must file a return in
+`requested` state and never move money is here.
+
+What matters about australis is its **contract**, not its address — closed
+schemas, read-only v1, `credentialRef` only, digest pins, AgentGateway
+invocation, one server per bounded domain. Every one of those is satisfiable
+here, and this design satisfies all of them.
+
+**This divergence must be recorded as an amendment on ADR-0001**, or the next
+reader will find D1, see mark8ly, and "fix" it back. That amendment is a
+deliverable of this work, not an afterthought.
+
+### D2 — a foundation, because three servers are coming
+
+The point of this design is not one catalog server. It is that the second and
+third servers cost days rather than weeks. So the split is:
+
+```
+services/mcp/
+├─ internal/mcp/          the foundation — transport, auth, schema registry,
+│                         upstream client, observability. Domain-free.
+├─ internal/catalog/      server #1 — 5 tools over the storefront read surface
+├─ cmd/mcp-catalog/       one binary, one image, one Deployment
+└─ (later) internal/support/, internal/platformread/ + their own cmd/ + images
+```
+
+One Go module, many binaries — the same "monorepo of source, polyrepo of
+artifacts" rule australis states, applied at the directory level rather than the
+repository level. A change under `internal/catalog/` builds and ships only
+`mcp-catalog`.
+
+The foundation owns exactly five things, and nothing domain-specific:
+
+1. **Transport** — streamable HTTP on `:8765/mcp`, matching the port and path
+   every product server in the registry already uses.
+2. **Inbound auth** — `X-MCP-Key` against a per-server secret, fail-closed.
+3. **Schema registry** — a tool is registered with its input *and* output Go
+   types; JSON Schema is derived from them, so a tool cannot exist without both.
+4. **Upstream client** — a GET-only HTTP client (D6) with a per-call deadline.
+5. **Observability** — per-tool latency, outcome and upstream-failure metrics.
+
+`internal/mcp` may not import any `internal/<domain>` package. Enforced by a
+test, not convention — the same shape as australis's invariant 2.
+
+### D3 — catalog first, because nothing there can regress
+
+Three candidate surfaces; the ordering is a risk argument.
+
+**Catalog is first because it is provably dead.** Its five operations have never
+registered as tools, so there is no behaviour to preserve, no consumer to break,
+and any outcome is an improvement. It is the cheapest possible first exercise of
+an unproven pattern, and australis's own layout names `catalog` as mark8ly's
+first connector.
+
+**Support is second.** Its eight tools are live, in production, and answering
+real customer questions. Migrating them off the shared image is a
+behaviour-identical rewrite — the right second task, and the wrong first one.
+
+**platform-read is last**, and deliberately so. It is cross-tenant by
+construction (#408, #411), and its auth question (#409 — the admin surface is
+HMAC-signed per request with a single-use nonce, which a static header cannot
+express) is the hardest decision in the milestone. Two of #409's three options
+become unnecessary if invocation goes through AgentGateway, so deciding it before
+the pattern exists risks deciding it twice.
+
+### D4 — read through marketplace-api, never the database
+
+The catalog tools call marketplace-api's storefront engine over HTTP with
+`X-Storefront-Key`, the same credential the gateway is already configured with.
+
+The alternative — querying `marketplace_db` directly — is rejected. Published
+filtering, tenant scoping and store-slug resolution are business rules that live
+in marketplace-api's handlers. A second reader of those tables would duplicate
+them, and would drift the first time one changes. One data owner.
+
+The cost is an in-cluster HTTP hop, which is comfortably inside the 400 ms budget
+australis sets. If a future tool cannot meet that budget, australis's own answer
+applies: pre-materialise the aggregate on marketplace-api's side and have the
+tool read the materialised row. The model never does arithmetic.
+
+### D5 — closed output schemas are the whole point
+
+australis invariant 4: *"Every tool declares closed input and output schemas — an
+untyped result cannot be cited."*
+
+This is precisely what the OpenAPI-ingestion approach cannot deliver, and the
+reason fixing #412 in place was rejected. The spec describes operations'
+*inputs*; the gateway derives a tool whose output is whatever the endpoint
+returned. A grounded answer with a citation needs a typed, stable result.
+
+So each tool defines a Go result struct, and the tool returns *that* — never the
+upstream body. Fields marketplace-api returns that an agent has no business
+seeing (internal ids, cost prices, inventory internals) are dropped by
+construction, because they are absent from the struct rather than removed by a
+filter someone must remember to update.
+
+This is also the projection boundary #411 asks for, arriving early: an operation
+is exposed because someone opted it in, and a field is exposed because someone
+typed it.
+
+### D6 — read-only, structurally
+
+The foundation's upstream client exposes `Get(ctx, path, params, &out)` and
+nothing else. There is no method that issues a POST, PUT, PATCH or DELETE.
+
+This is deliberately stronger than a review rule. #408 asks that the generator be
+"incapable of emitting a non-GET operation ... rather than relying on an author
+to leave them out". The same reasoning applies to the server: a write is not
+something an author must remember to avoid, it is something the code cannot
+express. A test asserts the client's method set.
+
+When writes eventually arrive (`create_refund_request` is a write, and it is in
+the support server's scope), they arrive as a deliberate, separately reviewed
+capability on that server — not as a quiet widening of this one.
+
+### D7 — one server, one deployment, one identity
+
+Per australis invariants 7 and 8: `mcp-catalog` gets its own image, its own
+`Deployment` and KEDA `ScaledObject` (min 1, max 5 — no scale-to-zero, because a
+cold start does not fit a 400 ms budget), its own ServiceAccount, and its own
+`X-MCP-Key`. Transport identity and data identity name the same unit.
+
+**Cost, stated honestly.** Until the support tools migrate (D3, step 2), mark8ly
+runs two MCP pods: the existing shared `mark8ly-mcp` and the new `mcp-catalog`.
+Against this project's "minimize GCP costs" constraint that is a real, temporary
++1 pod. It is temporary rather than additive: when support migrates, the shared
+pod is deleted and mark8ly runs only servers it owns.
+
+### D8 — no `latest`, on either axis
+
+australis ADR-0001 D3 forbids resolving `latest` at request time and requires
+pinning both `registry_digest` and `artifact_digest`.
+
+mark8ly's deploy chain already agrees on the image axis: Kargo writes a concrete
+`main-<sha7>` tag into the ArgoCD Application's Helm parameter. This design adds
+the other half — the registry record for `mark8ly-mcp-catalog` names the pinned
+image digest and the tool list, and is reviewed when either changes. A tool
+appearing in the server but not the record is a review failure, and a test in CI
+compares the two.
+
+That test is the direct answer to #412's real ask ("assert the tools actually
+register"), generalised: the failure there was not a typo, it was that **nothing
+compared what was declared against what was served.**
+
+## Architecture
+
+```
+agent ──► AgentGateway ──► mcp-catalog :8765/mcp        (X-MCP-Key, fail-closed)
+                                │
+                                │  tool call: input struct ─► validated
+                                ▼
+                     internal/catalog  ──► internal/mcp upstream client (GET-only)
+                                                    │  X-Storefront-Key, 400ms deadline
+                                                    ▼
+                       marketplace-api-storefront :8080/api/v1/storefront/...
+                                                    │
+                                                    ▼
+                              projected into a closed result struct ─► agent
+```
+
+### The five tools
+
+Derived from the existing spec's operations, renamed to MCP tool conventions and
+given result types. Store scoping is by **slug**, never by `store_id` — the slug
+is the public identifier, and accepting an internal id would invite
+cross-store probing.
+
+| Tool | Upstream | Result carries |
+| --- | --- | --- |
+| `list_store_products` | `GET /storefront/stores/{slug}/products` | handle, title, price + currency, short description, availability |
+| `get_store_product` | `GET /storefront/stores/{slug}/products/{handle}` | the above + images, variants, in-stock state |
+| `list_store_categories` | `GET /storefront/stores/{slug}/categories` | slug, name, product count |
+| `list_products_by_category` | `GET /storefront/stores/{slug}/categories/{slug}/products` | as `list_store_products` |
+| `get_store_branding` | `GET /storefront/stores/{slug}/branding` | display name, logo URL, primary colour, active promotions |
+
+`limit` is clamped server-side to the spec's stated max of 100 regardless of what
+the agent asks for, and a rejected value is an error, not a silent clamp — an
+agent that believes it received 500 products and received 100 will summarise a
+catalogue it never saw.
+
+### Error handling
+
+Three outcomes, kept distinct for the same reason the parity monitor keeps
+"compared" separate from "differences":
+
+- **Not found** (unknown store slug, handle or category) — a typed empty result
+  with an explicit `found: false`, never an empty list. An empty list reads as
+  "this store sells nothing", which is a plausible-looking wrong answer.
+- **Upstream unavailable** — an MCP error. The agent degrades to a
+  document-only answer with disclosure, per australis. It must never be
+  reported as an empty or partial catalogue.
+- **Deadline exceeded** — surfaced as unavailable, and counted separately in
+  metrics so a slow upstream is distinguishable from a down one.
+
+No tool returns a partially-populated result. A projection that could not be
+completed is a failure, not a degraded success.
+
+## Testing
+
+- **Schema conformance** — every registered tool has both an input and an output
+  schema, asserted by walking the registry. A tool registered without one fails
+  the suite; it cannot reach production.
+- **Read-only, structurally** — a test asserts the upstream client's exported
+  method set contains no write verb.
+- **Foundation isolation** — a test asserts `internal/mcp` imports no
+  `internal/<domain>` package.
+- **Declared-vs-served** — CI compares the server's tool list against the
+  registry record. This is #412's lesson, made permanent.
+- **Upstream contract** — the projection is tested against recorded real
+  marketplace-api storefront responses, so a field rename upstream fails here
+  rather than silently emptying a result. This replaces the existing spec's
+  drift tests, which go away with the spec.
+- **`go build ./... && go vet ./... && go test -race ./...`** must pass in
+  `services/mcp`, and the service is added to `.github/workflows/ci.yml`'s Go
+  matrix (`service: mcp`, `directory: services/mcp`). The existing floors range
+  from 4 to 31, which is not a precedent to copy — a greenfield service with a
+  five-tool surface starts at **60** and the number goes up, never down.
+
+## Sequencing
+
+1. Foundation + `mcp-catalog`, deployed alongside the existing shared gateway.
+   Prove the pattern end to end: a real agent lists a real store's products.
+2. Amend australis ADR-0001 with D1's reasoning.
+3. Migrate the eight support tools to `internal/support` + `cmd/mcp-support`,
+   behaviour-identical. Delete the shared `mark8ly-mcp` deployment. Cost returns
+   to where it started.
+4. Only then take up platform-read (#408, #409, #411), with AgentGateway
+   invocation as the starting assumption for the auth question.
+
+Steps 1–3 are independently shippable and each leaves the system working.
+
+## Non-goals
+
+- Applying the registry seeds as cluster CRs, or reconciling devai's
+  `registry.solo.io` seeds with the installed `kagent.dev` CRD group. Real, and
+  a separate piece of work.
+- Changing the shared `charts/apps/mcp-gateway` chart. mark8ly stops using it
+  rather than modifying something three other products depend on.
+- Anything on the storefront's own request path. No customer-facing behaviour
+  changes.
+- Writes, MFA, or agent-initiated actions of any kind.
+- Migrating homechef, platform or stockpilot. If this pattern is good they will
+  want it; that is their decision, not this design's.
+
+## Open questions
+
+1. **Does AgentGateway front these servers today, or do callers dial the Service
+   directly?** The registry records name the in-cluster Service URL, and D4 of
+   ADR-0001 forbids direct pod-to-pod. Worth establishing before step 4, because
+   it is most of #409's answer.
+2. **Which Go MCP SDK.** mark8ly has none today (VERIFIED: no MCP dependency in
+   any `go.mod`). The official `modelcontextprotocol/go-sdk` is the default
+   assumption; the protocol version the estate speaks is `2026-07-28` per the
+   registry records, and the SDK must support it.
+3. **Is `search_knowledge_base` mark8ly's at all?** It appears in both the
+   mark8ly and homechef records with the same name. If it is genuinely shared
+   infrastructure it should not migrate in step 3 — it is not a mark8ly bounded
+   domain.

--- a/docs/superpowers/specs/2026-09-04-mark8ly-mcp-connectors-design.md
+++ b/docs/superpowers/specs/2026-09-04-mark8ly-mcp-connectors-design.md
@@ -68,13 +68,14 @@ of the *process* is already mark8ly's. Only the *source* is misplaced.
 | # | Decision |
 |---|---|
 | D1 | mark8ly's MCP servers live in `mark8ly`, not in australis. ADR-0001 D1 is amended, not ignored. |
-| D2 | A reusable `services/mcp/internal/mcp` foundation; each server is a thin domain package over it. |
+| D2 | The reusable foundation is `go-shared/mcp`, from day one. Each server is a thin domain package over it. |
 | D3 | `catalog` is the first server. Support and platform-read follow, in that order. |
 | D4 | Tools read through marketplace-api's storefront HTTP surface, never the database directly. |
 | D5 | Every tool declares closed input **and** output schemas. No pass-through of upstream JSON. |
 | D6 | Read-only in v1, enforced structurally: the foundation cannot express a non-GET upstream call. |
 | D7 | One server per bounded domain, one Deployment, one ServiceAccount, one key. |
 | D8 | Registration is a reviewed registry record with a pinned image digest. No `latest`, ever. |
+| D9 | `go-shared/mcp` carries no MCP SDK dependency. The protocol binding stays in the consuming service. |
 
 ### D1 — the servers live here, and the ADR is amended
 
@@ -101,37 +102,51 @@ here, and this design satisfies all of them.
 reader will find D1, see mark8ly, and "fix" it back. That amendment is a
 deliverable of this work, not an afterthought.
 
-### D2 — a foundation, because three servers are coming
+### D2 — the foundation is `go-shared/mcp`, from day one
 
 The point of this design is not one catalog server. It is that the second and
-third servers cost days rather than weeks. So the split is:
+third servers — and tesserix-home's — cost days rather than weeks.
+
+**VERIFIED: tesserix-home has the identical problem.** Its `platform-mcp` record
+points at `platform-mcp.support-platform.svc.cluster.local`, i.e. it runs in the
+`support-platform` namespace on the same shared `slm-support-platform` image. It
+does not own its tools either, and it has no MCP code of its own. A second
+consumer is not hypothetical; it already exists and is already broken.
+
+So the foundation goes straight into `go-shared` rather than being built in
+mark8ly and extracted later. **VERIFIED: go-shared is at v1.9.1 and already
+holds 25 packages of exactly this character** — `httpclient`, `serviceclient`,
+`middleware`, `metrics`, `signature`, `authz`. An `mcp` package is not a foreign
+body there.
 
 ```
-services/mcp/
-├─ internal/mcp/          the foundation — transport, auth, schema registry,
-│                         upstream client, observability. Domain-free.
-├─ internal/catalog/      server #1 — 5 tools over the storefront read surface
-├─ cmd/mcp-catalog/       one binary, one image, one Deployment
+go-shared/mcp/                   the foundation — domain-free AND SDK-free
+├─ schema/                       Go type -> JSON Schema; a tool cannot register
+│                                without BOTH an input and an output type
+├─ upstream/                     GET-only HTTP client, per-call deadline (D6)
+├─ auth/                         X-MCP-Key verification, fail-closed
+└─ observe/                      per-tool latency, outcome, upstream-failure metrics
+
+mark8ly services/mcp/
+├─ internal/server/              binds go-shared/mcp to the MCP SDK + transport
+├─ internal/catalog/             server #1 — 5 tools over the storefront reads
+├─ cmd/mcp-catalog/              one binary, one image, one Deployment
 └─ (later) internal/support/, internal/platformread/ + their own cmd/ + images
 ```
 
-One Go module, many binaries — the same "monorepo of source, polyrepo of
-artifacts" rule australis states, applied at the directory level rather than the
-repository level. A change under `internal/catalog/` builds and ships only
-`mcp-catalog`.
+`go-shared/mcp` may not import any product package, and this is asserted by a
+test in go-shared rather than left to convention — the same shape as australis's
+invariant 2.
 
-The foundation owns exactly five things, and nothing domain-specific:
+**The cost of choosing day one over extract-later, stated plainly.** The
+foundation's API will churn most in its first weeks, and every churn is now a
+go-shared release plus a bump in mark8ly — a two-repo loop before the first
+server works, inside a library every Go service in the estate imports. That was
+weighed and accepted: the counter-argument is that an extraction deferred until
+a second consumer appears is an extraction that frequently never happens, and
+here the second consumer demonstrably already exists.
 
-1. **Transport** — streamable HTTP on `:8765/mcp`, matching the port and path
-   every product server in the registry already uses.
-2. **Inbound auth** — `X-MCP-Key` against a per-server secret, fail-closed.
-3. **Schema registry** — a tool is registered with its input *and* output Go
-   types; JSON Schema is derived from them, so a tool cannot exist without both.
-4. **Upstream client** — a GET-only HTTP client (D6) with a per-call deadline.
-5. **Observability** — per-tool latency, outcome and upstream-failure metrics.
-
-`internal/mcp` may not import any `internal/<domain>` package. Enforced by a
-test, not convention — the same shape as australis's invariant 2.
+D9 exists to keep that cost bounded.
 
 ### D3 — catalog first, because nothing there can regress
 
@@ -233,6 +248,31 @@ That test is the direct answer to #412's real ask ("assert the tools actually
 register"), generalised: the failure there was not a typo, it was that **nothing
 compared what was declared against what was served.**
 
+### D9 — the SDK dependency stays out of go-shared
+
+`go-shared/mcp` contains no MCP SDK import, and no protocol types. It carries the
+schema registry, the GET-only upstream client, key verification and metrics —
+all of which are plain Go over the standard library and go-shared's existing
+dependencies. The binding to a specific MCP SDK and protocol version lives in
+the consuming service, at `services/mcp/internal/server`.
+
+Two reasons, and the second is the load-bearing one.
+
+**Supply chain.** Every Go service in the estate imports go-shared. An SDK
+dependency there enters ~30 services' module graphs whether they serve MCP or
+not, and each becomes a surface for the CVE bumps this repo already deals with
+routinely.
+
+**Churn lands in the wrong place.** The protocol is where the movement is — the
+estate's registry records pin `protocolVersion: '2026-07-28'`, and a protocol
+revision would otherwise force a go-shared release affecting every service, to
+change something only MCP servers care about. Keeping the binding in the service
+means a protocol bump is a mark8ly change; only genuine foundation improvements
+become go-shared releases. That is what keeps D2's accepted two-repo cost from
+compounding.
+
+A test in go-shared asserts the `mcp` package's import graph contains no MCP SDK.
+
 ## Architecture
 
 ```
@@ -240,7 +280,7 @@ agent ──► AgentGateway ──► mcp-catalog :8765/mcp        (X-MCP-Key, 
                                 │
                                 │  tool call: input struct ─► validated
                                 ▼
-                     internal/catalog  ──► internal/mcp upstream client (GET-only)
+                     internal/catalog  ──► go-shared/mcp upstream (GET-only)
                                                     │  X-Storefront-Key, 400ms deadline
                                                     ▼
                        marketplace-api-storefront :8080/api/v1/storefront/...
@@ -293,8 +333,8 @@ completed is a failure, not a degraded success.
   the suite; it cannot reach production.
 - **Read-only, structurally** — a test asserts the upstream client's exported
   method set contains no write verb.
-- **Foundation isolation** — a test asserts `internal/mcp` imports no
-  `internal/<domain>` package.
+- **Foundation isolation** — two tests, both in go-shared: `mcp` imports no
+  product package, and its import graph contains no MCP SDK (D9).
 - **Declared-vs-served** — CI compares the server's tool list against the
   registry record. This is #412's lesson, made permanent.
 - **Upstream contract** — the projection is tested against recorded real
@@ -309,16 +349,21 @@ completed is a failure, not a degraded success.
 
 ## Sequencing
 
-1. Foundation + `mcp-catalog`, deployed alongside the existing shared gateway.
-   Prove the pattern end to end: a real agent lists a real store's products.
-2. Amend australis ADR-0001 with D1's reasoning.
-3. Migrate the eight support tools to `internal/support` + `cmd/mcp-support`,
+1. `go-shared/mcp` — schema registry, GET-only upstream client, key auth,
+   metrics — released as a go-shared minor version. No mark8ly change yet.
+2. `mcp-catalog` in mark8ly against it, deployed alongside the existing shared
+   gateway. Prove the pattern end to end: a real agent lists a real store's
+   products.
+3. Amend australis ADR-0001 with D1's reasoning.
+4. Migrate the eight support tools to `internal/support` + `cmd/mcp-support`,
    behaviour-identical. Delete the shared `mark8ly-mcp` deployment. Cost returns
    to where it started.
-4. Only then take up platform-read (#408, #409, #411), with AgentGateway
+5. Only then take up platform-read (#408, #409, #411), with AgentGateway
    invocation as the starting assumption for the auth question.
 
-Steps 1–3 are independently shippable and each leaves the system working.
+Steps 1–4 are independently shippable and each leaves the system working.
+tesserix-home's `platform-mcp` is a separate consumer of step 1's output and is
+not sequenced here — it is that repo's decision, informed by a filed issue.
 
 ## Non-goals
 
@@ -341,8 +386,9 @@ Steps 1–3 are independently shippable and each leaves the system working.
    it is most of #409's answer.
 2. **Which Go MCP SDK.** mark8ly has none today (VERIFIED: no MCP dependency in
    any `go.mod`). The official `modelcontextprotocol/go-sdk` is the default
-   assumption; the protocol version the estate speaks is `2026-07-28` per the
-   registry records, and the SDK must support it.
+   assumption, and it must support `2026-07-28` — the protocol version every
+   product record in the registry pins. Under D9 this is a mark8ly decision
+   rather than a go-shared one, so it blocks step 2, not step 1.
 3. **Is `search_knowledge_base` mark8ly's at all?** It appears in both the
    mark8ly and homechef records with the same name. If it is genuinely shared
    infrastructure it should not migrate in step 3 — it is not a mark8ly bounded


### PR DESCRIPTION
The design and plan behind `go-shared` **v1.10.0**, plus an honest record of what that release actually contains. Documentation only — no code in this repo changes.

## The finding that started it

mark8ly appears to have an MCP integration. It does not have one it owns.

`mark8ly-mcp` runs in the `mark8ly` namespace, but its image is `slm-support-platform/mcp-gateway`, and that chart's own values file says *"one shared image for every tenant."* The eight tools it serves — `get_order`, `create_refund_request`, `create_support_ticket` and the rest — are implemented in `slm-support-platform`, a repo not checked out in this workspace. mark8ly is differentiated from homechef, platform and stockpilot by a `tenant` Helm parameter. One image change ships four products at once.

mark8ly's entire own contribution is a 187-line hand-written OpenAPI document, and **it has never produced a single tool**. #412 recorded the cause; the URL is now fixed on main and the spec returns 200 in-cluster, but the registry record for `mark8ly-mcp` still lists only the eight gateway-native tools. The catalog surface that spec was written to enable has never existed.

tesserix-home's `platform-mcp` has the identical problem, from the `support-platform` namespace.

## What the spec settles

Nine decisions (D1–D9). The load-bearing ones:

- **Connectors live in mark8ly**, not australis — whose `servers/` directory holds one README and whose repo describes itself as pre-implementation. ADR-0001 D1 needs an amendment recording why, or the next reader will "fix" this back.
- **The foundation is `go-shared/mcp`**, from day one rather than extracted later, because a second consumer already exists and is already broken.
- **The MCP SDK stays out of go-shared.** Every Go service imports it; an SDK there enters ~30 module graphs, and the protocol is where the movement is — a revision would otherwise become a go-shared release for services that serve no MCP at all.
- **Catalog first, support second, platform-read last** — the catalog surface is the only one where nothing works today, so it is the cheapest first exercise of an unproven pattern. platform-read is last because it is cross-tenant and carries the unresolved HMAC question.

## Read the plan's last section, not just its tasks

`2026-09-04-mcp-foundation-go-shared.md` ends with **"Executed 2026-09-04 — what actually shipped"**, because v1.10.0 contains materially more than the seven tasks describe. Two Criticals were found by *executing* the code rather than reading it — a redirect that handed the product-API credential to whatever host `Location` named, and embedded structs producing schemas that disagreed with the wire in both directions. Several API additions were also made before tagging, since they were free then and permanently expensive after.

Anyone building the `mcp-catalog` connector should read that section first.

## What this does not do

No code changes here. The connector itself is a separate plan, blocked on choosing a Go MCP SDK that speaks `2026-07-28` — the protocol version every product record in the registry pins.
