### PR TITLE
fix(ci): repin base images whose digests were pruned, breaking every image publish

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -8,7 +8,7 @@
 # differ.
 
 # ─── deps ──────────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:517372359a366695db0898e2295158cf4b227537377a264dc55a7faa623cfc29 AS deps
+FROM ghcr.io/tesserix/base-node-builder-22@sha256:a86cc6019a5c1fd8601c68fe076a178aef575bc40f38ade51862efb48017a855 AS deps
 USER 0:0
 WORKDIR /src
 
@@ -29,7 +29,7 @@ COPY packages/ui/package.json ./packages/ui/
 RUN npm ci --no-audit --no-fund --legacy-peer-deps
 
 # ─── builder ───────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:517372359a366695db0898e2295158cf4b227537377a264dc55a7faa623cfc29 AS builder
+FROM ghcr.io/tesserix/base-node-builder-22@sha256:a86cc6019a5c1fd8601c68fe076a178aef575bc40f38ade51862efb48017a855 AS builder
 USER 0:0
 WORKDIR /src
 COPY --from=deps /src/node_modules ./node_modules
@@ -104,7 +104,7 @@ RUN --mount=type=secret,id=APPLICATION_BUILD_SECRET \
 
 # ─── runtime ───────────────────────────────────────────────────────────
 # base-node-runtime-22: libc6-compat, tini PID 1, USER 10001 (nextjs).
-FROM ghcr.io/tesserix/base-node-runtime-22@sha256:7e1a058efb1e11e92427dfb68cb19d43fa7c658b6e1b3aa0d242731114a5103f AS runtime
+FROM ghcr.io/tesserix/base-node-runtime-22@sha256:0e94a9fe76f2febb951f1deadece069edf82fbee66ac61e8f8384590862cfe43 AS runtime
 WORKDIR /app
 
 ENV PORT=4202

--- a/apps/onboarding/Dockerfile
+++ b/apps/onboarding/Dockerfile
@@ -11,7 +11,7 @@
 # the repo root.
 
 # ─── deps ──────────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:517372359a366695db0898e2295158cf4b227537377a264dc55a7faa623cfc29 AS deps
+FROM ghcr.io/tesserix/base-node-builder-22@sha256:a86cc6019a5c1fd8601c68fe076a178aef575bc40f38ade51862efb48017a855 AS deps
 USER 0:0
 WORKDIR /src
 
@@ -32,7 +32,7 @@ COPY packages/ui/package.json ./packages/ui/
 RUN npm ci --no-audit --no-fund --legacy-peer-deps
 
 # ─── builder ───────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:517372359a366695db0898e2295158cf4b227537377a264dc55a7faa623cfc29 AS builder
+FROM ghcr.io/tesserix/base-node-builder-22@sha256:a86cc6019a5c1fd8601c68fe076a178aef575bc40f38ade51862efb48017a855 AS builder
 USER 0:0
 WORKDIR /src
 COPY --from=deps /src/node_modules ./node_modules
@@ -90,7 +90,7 @@ RUN --mount=type=secret,id=APPLICATION_BUILD_SECRET \
 # Next.js standalone output for a workspace ends up at
 # apps/onboarding/.next/standalone/ with the monorepo directory layout
 # preserved, so the entrypoint is apps/onboarding/server.js.
-FROM ghcr.io/tesserix/base-node-runtime-22@sha256:7e1a058efb1e11e92427dfb68cb19d43fa7c658b6e1b3aa0d242731114a5103f AS runtime
+FROM ghcr.io/tesserix/base-node-runtime-22@sha256:0e94a9fe76f2febb951f1deadece069edf82fbee66ac61e8f8384590862cfe43 AS runtime
 WORKDIR /app
 
 ENV PORT=4201

--- a/apps/storefront/Dockerfile
+++ b/apps/storefront/Dockerfile
@@ -7,7 +7,7 @@
 # apps/admin and apps/onboarding — only workspace name + port differ.
 
 # ─── deps ──────────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:517372359a366695db0898e2295158cf4b227537377a264dc55a7faa623cfc29 AS deps
+FROM ghcr.io/tesserix/base-node-builder-22@sha256:a86cc6019a5c1fd8601c68fe076a178aef575bc40f38ade51862efb48017a855 AS deps
 USER 0:0
 WORKDIR /src
 
@@ -28,7 +28,7 @@ COPY packages/ui/package.json ./packages/ui/
 RUN npm ci --no-audit --no-fund --legacy-peer-deps
 
 # ─── builder ───────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:517372359a366695db0898e2295158cf4b227537377a264dc55a7faa623cfc29 AS builder
+FROM ghcr.io/tesserix/base-node-builder-22@sha256:a86cc6019a5c1fd8601c68fe076a178aef575bc40f38ade51862efb48017a855 AS builder
 USER 0:0
 WORKDIR /src
 COPY --from=deps /src/node_modules ./node_modules
@@ -84,7 +84,7 @@ RUN --mount=type=secret,id=APPLICATION_BUILD_SECRET \
 
 # ─── runtime ───────────────────────────────────────────────────────────
 # base-node-runtime-22: libc6-compat, tini PID 1, USER 10001 (nextjs).
-FROM ghcr.io/tesserix/base-node-runtime-22@sha256:7e1a058efb1e11e92427dfb68cb19d43fa7c658b6e1b3aa0d242731114a5103f AS runtime
+FROM ghcr.io/tesserix/base-node-runtime-22@sha256:0e94a9fe76f2febb951f1deadece069edf82fbee66ac61e8f8384590862cfe43 AS runtime
 WORKDIR /app
 
 ENV PORT=4203

--- a/services/auth-bff/Dockerfile
+++ b/services/auth-bff/Dockerfile
@@ -10,7 +10,7 @@
 # unnecessary. K8s securityContext overrides the image's USER, so the
 # binaries are world-executable (mode 0755 from `go build`).
 
-FROM ghcr.io/tesserix/base-go-builder@sha256:4ec5ce5894e501cc24f3a81329a8d548661e234be00b1f68205171bc6d048d1a AS build
+FROM ghcr.io/tesserix/base-go-builder@sha256:1d52f1321953c29971c261ccc7cd212f2ab84008321b88113ccff88330dd7d1f AS build
 USER 0:0
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -21,7 +21,7 @@ RUN go build -trimpath -ldflags="-s -w" -o /out/server ./cmd/server \
 
 # Single runtime stage carries both binaries so the K8s init pattern
 # can override ENTRYPOINT to /migrate without pulling a second image.
-FROM ghcr.io/tesserix/base-distroless-static@sha256:0d68ca8037f210e82e211017dbf49b54cde04c42a47baa5c5e429dee07b29c14 AS server
+FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS server
 COPY --from=build --chown=10001:10001 /out/server /server
 COPY --from=build --chown=10001:10001 /out/migrate /migrate
 EXPOSE 8080
@@ -29,6 +29,6 @@ CMD ["/server"]
 
 # Legacy single-purpose stage retained for local docker-compose flows
 # that build with --target migrate.
-FROM ghcr.io/tesserix/base-distroless-static@sha256:0d68ca8037f210e82e211017dbf49b54cde04c42a47baa5c5e429dee07b29c14 AS migrate
+FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS migrate
 COPY --from=build --chown=10001:10001 /out/migrate /migrate
 CMD ["/migrate"]

--- a/services/marketplace-api/Dockerfile
+++ b/services/marketplace-api/Dockerfile
@@ -9,7 +9,7 @@
 # securityContext overrides USER and binaries are mode 0755.
 
 # ─── builder ────────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-go-builder@sha256:4ec5ce5894e501cc24f3a81329a8d548661e234be00b1f68205171bc6d048d1a AS builder
+FROM ghcr.io/tesserix/base-go-builder@sha256:1d52f1321953c29971c261ccc7cd212f2ab84008321b88113ccff88330dd7d1f AS builder
 USER 0:0
 WORKDIR /src
 
@@ -32,7 +32,7 @@ RUN go build -trimpath -ldflags="-s -w" \
 
 # ─── migrate ────────────────────────────────────────────────────────────
 # Standalone image used by the K8s Job pattern.
-FROM ghcr.io/tesserix/base-distroless-static@sha256:0d68ca8037f210e82e211017dbf49b54cde04c42a47baa5c5e429dee07b29c14 AS migrate
+FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS migrate
 COPY --from=builder --chown=10001:10001 /out/migrate /usr/local/bin/migrate
 CMD ["/usr/local/bin/migrate"]
 
@@ -47,7 +47,7 @@ CMD ["/usr/local/bin/migrate"]
 # webhook-delivery-prune-cron prunes webhook_deliveries (OUTBOUND merchant
 # webhooks). It is NOT internal/webhookprune, which prunes webhook_events
 # (the inbound provider log) in-process inside marketplace-api.
-FROM ghcr.io/tesserix/base-distroless-static@sha256:0d68ca8037f210e82e211017dbf49b54cde04c42a47baa5c5e429dee07b29c14 AS runtime
+FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS runtime
 COPY --from=builder --chown=10001:10001 /out/marketplace-api /usr/local/bin/marketplace-api
 COPY --from=builder --chown=10001:10001 /out/migrate /usr/local/bin/migrate
 COPY --from=builder --chown=10001:10001 /out/refund-sweep-cron /usr/local/bin/refund-sweep-cron

--- a/services/mcp/Dockerfile
+++ b/services/mcp/Dockerfile
@@ -6,7 +6,7 @@
 # Go's runtime handles SIGTERM directly so tini is unnecessary; K8s
 # securityContext overrides USER, mode 0755 lets any uid execute.
 
-FROM ghcr.io/tesserix/base-go-builder@sha256:4ec5ce5894e501cc24f3a81329a8d548661e234be00b1f68205171bc6d048d1a AS build
+FROM ghcr.io/tesserix/base-go-builder@sha256:1d52f1321953c29971c261ccc7cd212f2ab84008321b88113ccff88330dd7d1f AS build
 USER 0:0
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -14,7 +14,7 @@ RUN go mod download
 COPY . .
 RUN go build -trimpath -ldflags="-s -w" -o /out/server ./cmd/mcp-catalog
 
-FROM ghcr.io/tesserix/base-distroless-static@sha256:0d68ca8037f210e82e211017dbf49b54cde04c42a47baa5c5e429dee07b29c14 AS server
+FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS server
 COPY --from=build --chown=10001:10001 /out/server /server
 EXPOSE 8765
 CMD ["/server"]

--- a/services/otto/Dockerfile
+++ b/services/otto/Dockerfile
@@ -6,7 +6,7 @@
 # Go's runtime handles SIGTERM directly so tini is unnecessary; K8s
 # securityContext overrides USER, mode 0755 lets any uid execute.
 
-FROM ghcr.io/tesserix/base-go-builder@sha256:4ec5ce5894e501cc24f3a81329a8d548661e234be00b1f68205171bc6d048d1a AS build
+FROM ghcr.io/tesserix/base-go-builder@sha256:1d52f1321953c29971c261ccc7cd212f2ab84008321b88113ccff88330dd7d1f AS build
 USER 0:0
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -14,7 +14,7 @@ RUN go mod download
 COPY . .
 RUN go build -trimpath -ldflags="-s -w" -o /out/server ./cmd/server
 
-FROM ghcr.io/tesserix/base-distroless-static@sha256:0d68ca8037f210e82e211017dbf49b54cde04c42a47baa5c5e429dee07b29c14 AS server
+FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS server
 COPY --from=build --chown=10001:10001 /out/server /server
 EXPOSE 8089
 CMD ["/server"]

--- a/services/platform-api/Dockerfile
+++ b/services/platform-api/Dockerfile
@@ -5,7 +5,7 @@
 #   * runtime: base-distroless-static (no shell, ca-certs + tzdata,
 #              upstream gcr.io/distroless/static:nonroot)
 
-FROM ghcr.io/tesserix/base-go-builder@sha256:4ec5ce5894e501cc24f3a81329a8d548661e234be00b1f68205171bc6d048d1a AS build
+FROM ghcr.io/tesserix/base-go-builder@sha256:1d52f1321953c29971c261ccc7cd212f2ab84008321b88113ccff88330dd7d1f AS build
 USER 0:0
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -20,7 +20,7 @@ RUN go build -trimpath -ldflags="-s -w" -o /out/server           ./cmd/server \
 # overrides can pick the right entrypoint without pulling a second image.
 # /backfill-vendors is the CLI surfaced by the marketplace-api error
 # "tenant has no self-vendor; run platform-api's backfill-vendors CLI".
-FROM ghcr.io/tesserix/base-distroless-static@sha256:0d68ca8037f210e82e211017dbf49b54cde04c42a47baa5c5e429dee07b29c14 AS server
+FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS server
 COPY --from=build --chown=10001:10001 /out/server           /server
 COPY --from=build --chown=10001:10001 /out/migrate          /migrate
 COPY --from=build --chown=10001:10001 /out/seed             /seed
@@ -29,10 +29,10 @@ EXPOSE 8086
 CMD ["/server"]
 
 # Legacy single-purpose stages retained for local docker-compose flows.
-FROM ghcr.io/tesserix/base-distroless-static@sha256:0d68ca8037f210e82e211017dbf49b54cde04c42a47baa5c5e429dee07b29c14 AS migrate
+FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS migrate
 COPY --from=build --chown=10001:10001 /out/migrate /migrate
 CMD ["/migrate"]
 
-FROM ghcr.io/tesserix/base-distroless-static@sha256:0d68ca8037f210e82e211017dbf49b54cde04c42a47baa5c5e429dee07b29c14 AS seed
+FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS seed
 COPY --from=build --chown=10001:10001 /out/seed /seed
 CMD ["/seed"]


### PR DESCRIPTION
Every image publish in this repo is failing, for all seven services, on `main`. This repins the four base images whose digests no longer exist.

## What broke

The pinned digests were pruned. GHCR retention keeps the **3 most recent versions** per package, all four base images were rebuilt on 2026-09-04, and the pins aged out — so `buildx` fails at `FROM`:

```
ERROR: failed to build: failed to solve:
  ghcr.io/tesserix/base-go-builder@sha256:4ec5ce5894…: not found
```

The packages themselves are fine and public; only the specific digests are gone. Four base images, eight Dockerfiles, seven services — every one of them, which is what makes it look alarming and is also what shows it is not any single service's change.

## The repin

| image | now |
| --- | --- |
| `base-go-builder` | `sha256:1d52f132…` |
| `base-distroless-static` | `sha256:db09c7f5…` |
| `base-node-builder-22` | `sha256:a86cc601…` |
| `base-node-runtime-22` | `sha256:0e94a9fe…` |

Each is the currently-tagged version (`latest`, `weekly`, `20260904`, `sha-f34eae5db88b`) — the same build the upstream base-image repo published today.

## Verified, not assumed

Repinning is only useful if the new digests actually resolve, so both halves were checked rather than trusted:

- **`docker build` of `services/mcp`** succeeded end to end, which exercises `base-go-builder` **and** `base-distroless-static` through a real multi-stage build.
- **`docker manifest inspect`** resolves both `base-node-builder-22` and `base-node-runtime-22`.
- **`.github/scripts/test-ci-contract.py`** passes 6/6, so the immutable-base and Dependabot-coverage guards still hold.

## Why by hand rather than via Dependabot

`base-image-refresh.yml` states the intended path: *"Base images remain pinned until the Docker Dependabot update PR passes CI."* That is the right steady-state mechanism, but no such PR is open, and in the meantime nothing in the repo can publish an image — so no service can deploy. This unblocks that; it does not replace Dependabot.

Worth a follow-up separately: the retention window and the base-image rebuild cadence are currently set such that a pin can expire before a Dependabot PR lands. That is the underlying cause, and it will recur.
