### PR TITLE
chore(images): move the Next.js apps to the Node 24 LTS bases

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -8,7 +8,7 @@
 # differ.
 
 # ─── deps ──────────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:a86cc6019a5c1fd8601c68fe076a178aef575bc40f38ade51862efb48017a855 AS deps
+FROM ghcr.io/tesserix/base-node-builder-24@sha256:c5b173e90d748e60496f7b7be877e767226867c974cf322bec634f04beb45819 AS deps
 USER 0:0
 WORKDIR /src
 
@@ -29,7 +29,7 @@ COPY packages/ui/package.json ./packages/ui/
 RUN npm ci --no-audit --no-fund --legacy-peer-deps
 
 # ─── builder ───────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:a86cc6019a5c1fd8601c68fe076a178aef575bc40f38ade51862efb48017a855 AS builder
+FROM ghcr.io/tesserix/base-node-builder-24@sha256:c5b173e90d748e60496f7b7be877e767226867c974cf322bec634f04beb45819 AS builder
 USER 0:0
 WORKDIR /src
 COPY --from=deps /src/node_modules ./node_modules
@@ -103,8 +103,8 @@ RUN --mount=type=secret,id=APPLICATION_BUILD_SECRET \
     npm run build --workspace=@mark8ly/admin
 
 # ─── runtime ───────────────────────────────────────────────────────────
-# base-node-runtime-22: libc6-compat, tini PID 1, USER 10001 (nextjs).
-FROM ghcr.io/tesserix/base-node-runtime-22@sha256:0e94a9fe76f2febb951f1deadece069edf82fbee66ac61e8f8384590862cfe43 AS runtime
+# base-node-runtime-24: libc6-compat, tini PID 1, USER 10001 (nextjs).
+FROM ghcr.io/tesserix/base-node-runtime-24@sha256:6e503bc4b951eeb065b9ff8c4a0d53bfd240b9e974709c79b56f163b9d70b683 AS runtime
 WORKDIR /app
 
 ENV PORT=4202
@@ -114,5 +114,5 @@ COPY --from=builder --chown=10001:10001 /src/apps/admin/.next/static ./apps/admi
 COPY --from=builder --chown=10001:10001 /src/apps/admin/public ./apps/admin/public
 
 EXPOSE 4202
-# base-node-runtime-22's ENTRYPOINT is already `tini --`.
+# base-node-runtime-24's ENTRYPOINT is already `tini --`.
 CMD ["node", "apps/admin/server.js"]

--- a/apps/onboarding/Dockerfile
+++ b/apps/onboarding/Dockerfile
@@ -11,7 +11,7 @@
 # the repo root.
 
 # ─── deps ──────────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:a86cc6019a5c1fd8601c68fe076a178aef575bc40f38ade51862efb48017a855 AS deps
+FROM ghcr.io/tesserix/base-node-builder-24@sha256:c5b173e90d748e60496f7b7be877e767226867c974cf322bec634f04beb45819 AS deps
 USER 0:0
 WORKDIR /src
 
@@ -32,7 +32,7 @@ COPY packages/ui/package.json ./packages/ui/
 RUN npm ci --no-audit --no-fund --legacy-peer-deps
 
 # ─── builder ───────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:a86cc6019a5c1fd8601c68fe076a178aef575bc40f38ade51862efb48017a855 AS builder
+FROM ghcr.io/tesserix/base-node-builder-24@sha256:c5b173e90d748e60496f7b7be877e767226867c974cf322bec634f04beb45819 AS builder
 USER 0:0
 WORKDIR /src
 COPY --from=deps /src/node_modules ./node_modules
@@ -86,11 +86,11 @@ RUN --mount=type=secret,id=APPLICATION_BUILD_SECRET \
     npm run build --workspace=@mark8ly/onboarding
 
 # ─── runtime ───────────────────────────────────────────────────────────
-# base-node-runtime-22: libc6-compat, tini PID 1, USER 10001 (nextjs).
+# base-node-runtime-24: libc6-compat, tini PID 1, USER 10001 (nextjs).
 # Next.js standalone output for a workspace ends up at
 # apps/onboarding/.next/standalone/ with the monorepo directory layout
 # preserved, so the entrypoint is apps/onboarding/server.js.
-FROM ghcr.io/tesserix/base-node-runtime-22@sha256:0e94a9fe76f2febb951f1deadece069edf82fbee66ac61e8f8384590862cfe43 AS runtime
+FROM ghcr.io/tesserix/base-node-runtime-24@sha256:6e503bc4b951eeb065b9ff8c4a0d53bfd240b9e974709c79b56f163b9d70b683 AS runtime
 WORKDIR /app
 
 ENV PORT=4201
@@ -100,5 +100,5 @@ COPY --from=builder --chown=10001:10001 /src/apps/onboarding/.next/static ./apps
 COPY --from=builder --chown=10001:10001 /src/apps/onboarding/public ./apps/onboarding/public
 
 EXPOSE 4201
-# base-node-runtime-22's ENTRYPOINT is already `tini --`.
+# base-node-runtime-24's ENTRYPOINT is already `tini --`.
 CMD ["node", "apps/onboarding/server.js"]

--- a/apps/storefront/Dockerfile
+++ b/apps/storefront/Dockerfile
@@ -7,7 +7,7 @@
 # apps/admin and apps/onboarding — only workspace name + port differ.
 
 # ─── deps ──────────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:a86cc6019a5c1fd8601c68fe076a178aef575bc40f38ade51862efb48017a855 AS deps
+FROM ghcr.io/tesserix/base-node-builder-24@sha256:c5b173e90d748e60496f7b7be877e767226867c974cf322bec634f04beb45819 AS deps
 USER 0:0
 WORKDIR /src
 
@@ -28,7 +28,7 @@ COPY packages/ui/package.json ./packages/ui/
 RUN npm ci --no-audit --no-fund --legacy-peer-deps
 
 # ─── builder ───────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-22@sha256:a86cc6019a5c1fd8601c68fe076a178aef575bc40f38ade51862efb48017a855 AS builder
+FROM ghcr.io/tesserix/base-node-builder-24@sha256:c5b173e90d748e60496f7b7be877e767226867c974cf322bec634f04beb45819 AS builder
 USER 0:0
 WORKDIR /src
 COPY --from=deps /src/node_modules ./node_modules
@@ -83,8 +83,8 @@ RUN --mount=type=secret,id=APPLICATION_BUILD_SECRET \
     npm run build --workspace=@mark8ly/storefront
 
 # ─── runtime ───────────────────────────────────────────────────────────
-# base-node-runtime-22: libc6-compat, tini PID 1, USER 10001 (nextjs).
-FROM ghcr.io/tesserix/base-node-runtime-22@sha256:0e94a9fe76f2febb951f1deadece069edf82fbee66ac61e8f8384590862cfe43 AS runtime
+# base-node-runtime-24: libc6-compat, tini PID 1, USER 10001 (nextjs).
+FROM ghcr.io/tesserix/base-node-runtime-24@sha256:6e503bc4b951eeb065b9ff8c4a0d53bfd240b9e974709c79b56f163b9d70b683 AS runtime
 WORKDIR /app
 
 ENV PORT=4203
@@ -94,5 +94,5 @@ COPY --from=builder --chown=10001:10001 /src/apps/storefront/.next/static ./apps
 COPY --from=builder --chown=10001:10001 /src/apps/storefront/public ./apps/storefront/public
 
 EXPOSE 4203
-# base-node-runtime-22's ENTRYPOINT is already `tini --`.
+# base-node-runtime-24's ENTRYPOINT is already `tini --`.
 CMD ["node", "apps/storefront/server.js"]

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "5.9.2"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "packageManager": "npm@10.9.3",
   "workspaces": [


### PR DESCRIPTION
Moves the three Next.js apps from the Node 22 base images to the Node 24 ones.

## Why now

**Node 22 is in Maintenance LTS** — security and critical fixes only, EOL 30 April 2027. **Node 24 is the Active LTS line**, EOL 30 April 2028: a year more runway, and still receiving ordinary fixes rather than only critical ones. Node 26 is Current and enters LTS in October 2026, so 24 is the settled choice rather than the leading edge.

The `base-node-builder-24` / `base-node-runtime-24` images already exist in GHCR alongside the 22s, built from the same upstream run (`sha-f34eae5db88b`, `20260904`). No node-26 bases exist yet, so 24 is also the only forward move currently available.

## What changed

- `apps/admin`, `apps/onboarding`, `apps/storefront` — builder and runtime `FROM` digests, plus the six comments that named the `-22` images, so nothing in the file still claims a base it no longer uses.
- Root `package.json` — the engines floor from `>=22` to `>=24`, so the intent is recorded rather than merely implied. Nothing was pinning 22: there is no `.nvmrc` and no `node-version` in any workflow, so `>=22` was already satisfied by 24.

## Verified by building, not by reasoning

A runtime major bump is only proven by a build, so all three images were built locally from this branch, with CI's own context and target (`context: .`, `--target runtime`):

| image | build | `node --version` in the runtime image |
| --- | --- | --- |
| `mark8ly-onboarding` | ✅ | `v24.20.0` |
| `mark8ly-admin` | ✅ | `v24.20.0` |
| `mark8ly-storefront` | ✅ | `v24.20.0` |

That last column matters: it confirms the running image really is Node 24, rather than a renamed tag that still ships 22.

`.github/scripts/test-ci-contract.py` passes 6/6, so the immutable-base and Dependabot-coverage guards still hold.

Note the app builds mount `APPLICATION_BUILD_SECRET` for `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY`; the Dockerfiles tolerate its absence (warning, random per-build key), so the local builds ran without it. CI supplies the real one.

## Deliberately not in this PR

`tesserix-k8s/services.yaml` carries `defaults.nodeVersion: "22"`. Nothing in the deploy path reads it — its own header says it is consumed by Terraform, tesserix-home's release UI, and go-shared's dispatch — so this change does not break it, but that entry is now inaccurate and wants a follow-up in that repo. The workspace `CLAUDE.md` says "Node.js 22 (all Next.js apps)" for the same reason, and additionally points at `tesserix-infra/services.yaml`, which no longer exists.

The `node:22-alpine` reference in `mark8ly-marketplace-api-admin`'s chart is an upstream docker.io helper image in a Go service and is unrelated to these bases.

Follows #665, which repinned the base digests after the old ones were pruned.
