### PR TITLE
fix(admin): pass the Zitadel issuer and client id as build args

### DIFF
--- a/.github/ci/container-images.json
+++ b/.github/ci/container-images.json
@@ -66,7 +66,7 @@
       "dockerfile": "apps/admin/Dockerfile",
       "target": "runtime",
       "source_root": "apps/admin",
-      "build_args": "NEXT_PUBLIC_APPLE_SERVICES_ID=com.mark8ly.admin.web\nNEXT_PUBLIC_AUTH_PROVIDER=zitadel",
+      "build_args": "NEXT_PUBLIC_APPLE_SERVICES_ID=com.mark8ly.admin.web\nNEXT_PUBLIC_AUTH_PROVIDER=zitadel\nNEXT_PUBLIC_ZITADEL_ISSUER=https://auth.tesserix.app\nNEXT_PUBLIC_ZITADEL_ADMIN_CLIENT_ID=389070493069606927",
       "requires_application_build_secret": true,
       "trivy_ignore_file": ".trivyignore",
       "smoke_port": 4202,

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -61,6 +61,14 @@ ARG NEXT_PUBLIC_APPLE_SERVICES_ID=""
 # Build-time only — see apps/storefront/Dockerfile for why a chart env
 # var cannot flip this.
 ARG NEXT_PUBLIC_AUTH_PROVIDER="zitadel"
+# The Zitadel login-client flow needs these IN THE BUNDLE: /login/authorize
+# mints the PKCE redirect from them and 500s "zitadel_misconfigured"
+# without them. Both are NEXT_PUBLIC_* and therefore build-time only —
+# a chart env var cannot supply them. The client id is public by design
+# (it ships in the browser for PKCE); the client SECRET stays server-side
+# in auth-bff and is not here.
+ARG NEXT_PUBLIC_ZITADEL_ISSUER=""
+ARG NEXT_PUBLIC_ZITADEL_ADMIN_CLIENT_ID=""
 ENV NEXT_PUBLIC_GIP_PROJECT_ID=$REUSABLE_PUBLIC_BUILD_ARG_1 \
     NEXT_PUBLIC_GIP_TENANT_ID=$REUSABLE_PUBLIC_BUILD_ARG_2 \
     NEXT_PUBLIC_GIP_API_KEY=$REUSABLE_PUBLIC_BUILD_ARG_3 \
@@ -70,6 +78,8 @@ ENV NEXT_PUBLIC_GIP_PROJECT_ID=$REUSABLE_PUBLIC_BUILD_ARG_1 \
     NEXT_PUBLIC_ADMIN_LOGIN_ORIGIN=$REUSABLE_PUBLIC_BUILD_ARG_8 \
     NEXT_PUBLIC_APPLE_SERVICES_ID=$NEXT_PUBLIC_APPLE_SERVICES_ID \
     NEXT_PUBLIC_AUTH_PROVIDER=$NEXT_PUBLIC_AUTH_PROVIDER \
+    NEXT_PUBLIC_ZITADEL_ISSUER=$NEXT_PUBLIC_ZITADEL_ISSUER \
+    NEXT_PUBLIC_ZITADEL_ADMIN_CLIENT_ID=$NEXT_PUBLIC_ZITADEL_ADMIN_CLIENT_ID \
     NEXT_TELEMETRY_DISABLED=1
 
 # Server Action IDs are hashed with this key as the salt (Next.js wires


### PR DESCRIPTION
Admin sign-in is currently returning `zitadel_misconfigured` in production. This fixes it.

## What broke

The provider flip (#664) is live and working — `/login` correctly redirects to `/login/authorize`, the Zitadel path. But that route needs two more values:

```
const issuer   = process.env.NEXT_PUBLIC_ZITADEL_ISSUER ?? "";
const clientId = process.env.NEXT_PUBLIC_ZITADEL_ADMIN_CLIENT_ID ?? "";
if (!issuer || !clientId) return new NextResponse("zitadel_misconfigured", { status: 500 });
```

Both are `NEXT_PUBLIC_*`, so they are inlined at **build** time and were absent from the admin image — the same defect class as the provider flag itself, in its two siblings. I fixed the flag and did not sweep for the rest, which is how this reached production.

The route failing loudly rather than redirecting is what made it a 30-second diagnosis instead of an infinite redirect loop; that guard did its job.

## The fix

Adds both as named build args on the admin image:

- `NEXT_PUBLIC_ZITADEL_ISSUER=https://auth.tesserix.app`
- `NEXT_PUBLIC_ZITADEL_ADMIN_CLIENT_ID=389070493069606927` — verified equal to the `ZITADEL_ADMIN_CLIENT_ID` auth-bff uses. Client ids are public by design (this one ships in the browser for PKCE); the client **secret** stays server-side in auth-bff and is not added here.

## Scope check — done properly this time

I swept every `NEXT_PUBLIC_*` both apps read against their Dockerfiles:

- **storefront: nothing missing for this flow.** It needs no `NEXT_PUBLIC_ZITADEL_*` at all — it calls auth-bff server-side.
- **admin: two others are absent but deliberate** — `NEXT_PUBLIC_ADMIN_LOCALE` and `NEXT_PUBLIC_MARKETPLACE_API_URL` both have defaults, and the latter is documented in-code as "always unset in prod".

So these two are the complete set for the Zitadel login path.
