### PR TITLE
fix(ci): dependabot missed services/mcp, and the test that should have caught it couldn't

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,6 +78,11 @@ updates:
       interval: weekly
     open-pull-requests-limit: 2
   - package-ecosystem: docker
+    directory: /services/mcp
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+  - package-ecosystem: docker
     directory: /services/otto
     schedule:
       interval: weekly

--- a/.github/scripts/test-ci-contract.py
+++ b/.github/scripts/test-ci-contract.py
@@ -195,20 +195,40 @@ class ReusableCIContract(unittest.TestCase):
                 self.assertNotIn("ARG REUSABLE_BUILD_SECRET_FP", contents)
 
     def test_dependabot_tracks_every_pinned_dockerfile(self) -> None:
+        # Discover every Dockerfile on disk rather than hardcoding a
+        # directory list — a hardcoded list can never fail when a new
+        # Dockerfile is added, which is exactly how /services/mcp went
+        # untracked and its base pins silently rotted. node_modules and
+        # vendor trees are excluded because a Dockerfile shipped by a
+        # third-party dependency is not ours to add to dependabot.yml.
+        dockerfiles = [
+            path
+            for path in ROOT.rglob("Dockerfile")
+            if "node_modules" not in path.parts and "vendor" not in path.parts
+        ]
+        self.assertTrue(dockerfiles, "no Dockerfiles found — discovery is broken")
+
         config = (ROOT / ".github/dependabot.yml").read_text()
-        for directory in (
-            "/services/platform-api",
-            "/services/auth-bff",
-            "/services/marketplace-api",
-            "/services/otto",
-            "/apps/onboarding",
-            "/apps/admin",
-            "/apps/storefront",
-        ):
-            self.assertRegex(
-                config,
-                rf"package-ecosystem:\s*docker\s+directory:\s*{re.escape(directory)}\b",
-            )
+
+        # Only Dockerfiles that pin a company-owned ghcr.io/tesserix/base-*
+        # image are in scope: that pin is the exact thing that goes stale
+        # when GHCR prunes old digests, and it is the property this test
+        # protects. A Dockerfile with no such pin has nothing for
+        # Dependabot's docker ecosystem to refresh.
+        for path in dockerfiles:
+            contents = path.read_text()
+            if not re.search(r"^FROM\s+ghcr\.io/tesserix/base-", contents, re.MULTILINE):
+                continue
+            directory = "/" + str(path.parent.relative_to(ROOT))
+            with self.subTest(directory=directory):
+                self.assertRegex(
+                    config,
+                    rf"package-ecosystem:\s*docker\s+directory:\s*{re.escape(directory)}\b",
+                    f"{directory} pins a ghcr.io/tesserix/base- image but has no "
+                    f"`package-ecosystem: docker` entry for it in "
+                    f".github/dependabot.yml — add one so its base image pin "
+                    f"gets refreshed automatically.",
+                )
 
     def test_secret_baseline_is_redacted_and_fingerprint_specific(self) -> None:
         findings = json.loads((ROOT / ".gitleaks-baseline.json").read_text())


### PR DESCRIPTION
Yesterday every image publish in this repo failed at once. This closes the path that let it happen.

## What happened, and why it will happen again without this

The pinned base-image digests had been **pruned**. GHCR retention keeps 3 versions per package; `tesserix/base-docker-images` rebuilds weekly (Saturdays 03:00 UTC); a pin older than about three rebuilds stops resolving:

```
ERROR: failed to solve: ghcr.io/tesserix/base-go-builder@sha256:4ec5ce5894…: not found
```

#665 repinned and unblocked it. It did not close the recurrence path.

The safeguard is meant to be Dependabot — `base-image-refresh.yml` says so in as many words: *"Base images remain pinned until the Docker Dependabot update PR passes CI."* The upstream dispatch is only a notification; Dependabot is what actually resolves each new digest and opens the auditable PR.

## Two defects

**1. `services/mcp` had no Dependabot docker entry.** Eight Dockerfiles pin a `ghcr.io/tesserix/base-` image; only seven had entries. `services/mcp` was added recently and missed, so its pins would never be refreshed and would rot exactly as the others did — the same outage, on a delay.

**2. The test that should have caught that could not.** `test_dependabot_tracks_every_pinned_dockerfile` iterated a **hardcoded list of seven directory strings**. It never looked at the filesystem, so adding a Dockerfile could not fail it. The name promised a property the code did not enforce.

## The fix

The test now discovers every `Dockerfile` on disk, filters to those actually pinning a `ghcr.io/tesserix/base-` image (that is the property being protected — an unpinned Dockerfile has nothing to rot), and requires a `package-ecosystem: docker` entry for each. Its failure message names the directory and says what to add:

```
/services/mcp pins a ghcr.io/tesserix/base- image but has no
`package-ecosystem: docker` entry for it in .github/dependabot.yml —
add one so its base image pin gets refreshed automatically.
```

And the missing `/services/mcp` entry is added, matching its siblings.

## Proven to have teeth, both ways

A gate that passes because it inspected an empty list looks identical to one that works, so both directions were checked:

- **Before adding the entry**, the rewritten test **fails**, naming `/services/mcp`.
- **Removing a different directory's entry** (`/services/otto`) also fails, naming that one — so the discovery is general, not tuned to the single case being fixed.
- With everything in place, all 6 tests pass. The 5 pre-existing tests are unmodified.

Only `.github/scripts/test-ci-contract.py` and `.github/dependabot.yml` change. No Dockerfile, workflow, or service code is touched.

## Still open, and outside this repo

This closes the *coverage* half. The other half is timing: with weekly rebuilds against 3-version retention, a Dependabot PR that sits unmerged for three weeks still ends in a pruned pin. Raising retention on the base packages, or narrowing the rebuild cadence, is a change in `tesserix/base-docker-images` or its GHCR package settings.
