### PR TITLE
fix(ci): merge base-image digest bumps on a schedule, since the PAT-gated workflow never runs

### DIFF
--- a/.github/workflows/base-digest-auto-merge.yml
+++ b/.github/workflows/base-digest-auto-merge.yml
@@ -1,0 +1,143 @@
+name: base digest auto-merge
+
+# Auto-merges ONLY the Dependabot docker-ecosystem PRs that bump a pinned
+# ghcr.io/tesserix/base-* digest in a Dockerfile. This is the fix for a real
+# outage path: GHCR keeps just the latest weekly build of each base image, so
+# a pinned digest survives at most one rebuild before it 404s on pull. The
+# intended updater is Dependabot, and dependabot-auto-merge.yml exists to
+# land those PRs automatically — but it requires a DEPENDABOT_PAT secret that
+# does not exist in this repo, so it has never merged anything. A PR
+# triggered BY Dependabot gets a read-only GITHUB_TOKEN with no secret
+# access, which is exactly why that workflow needs a PAT at all. A
+# `schedule`-triggered run is an ordinary run: it gets a full-permission
+# GITHUB_TOKEN with no human credential required, so it can do the merge
+# itself.
+#
+# Scope is intentionally narrow — every one of these must hold or the PR is
+# left alone:
+#   - authored by dependabot[bot] (enforced twice: the PR listing below only
+#     considers that author, and fetch-metadata independently verifies the
+#     PR's user and commit signature)
+#   - a `docker` ecosystem update, per dependabot/fetch-metadata
+#   - every changed file in the PR is a Dockerfile (checked against the PR's
+#     actual file list, not inferred from its title)
+#   - every check run on the PR's head commit has completed, and none failed
+#
+# Anything else — a gomod/npm/github-actions Dependabot PR, or any
+# human-authored PR — is never touched. Runs daily (the upstream rebuild is
+# weekly, so this gives six chances to land a PR before the next prune) and
+# exits quietly when there is nothing to do.
+
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+jobs:
+  discover:
+    name: Find open Dependabot PRs
+    runs-on: ubuntu-latest
+    outputs:
+      prs: ${{ steps.list.outputs.prs }}
+    steps:
+      - name: List open PRs authored by dependabot[bot]
+        id: list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          prs=$(gh pr list --repo "$REPO" --state open --author "dependabot[bot]" --json number --jq '[.[].number]')
+          echo "Open Dependabot PRs: $prs"
+          echo "prs=$prs" >> "$GITHUB_OUTPUT"
+
+  evaluate:
+    name: "PR #${{ matrix.pr }}"
+    needs: discover
+    if: ${{ needs.discover.outputs.prs != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pr: ${{ fromJson(needs.discover.outputs.prs) }}
+    steps:
+      - name: Fetch PR as a synthetic pull_request event
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$REPO/pulls/${{ matrix.pr }}" > pr.json
+          jq -n --slurpfile pr pr.json '{pull_request: $pr[0]}' > event.json
+          echo "path=$PWD/event.json" >> "$GITHUB_OUTPUT"
+
+      # fetch-metadata reads the pull_request event payload, not a live API
+      # call — this repo only triggers it on `pull_request`. A schedule run
+      # has no such payload, so we hand it one built from the PR we just
+      # fetched. It still independently verifies the PR author and the
+      # commit signature, so this is not a way to spoof provenance.
+      - name: Fetch Dependabot metadata
+        id: meta
+        continue-on-error: true
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        env:
+          GITHUB_EVENT_PATH: ${{ steps.pr.outputs.path }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Evaluate eligibility and merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ matrix.pr }}
+          META_OK: ${{ steps.meta.outcome }}
+          ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
+        run: |
+          set -euo pipefail
+
+          skip() {
+            echo "::notice::PR #$PR skipped — $1"
+            exit 0
+          }
+
+          if [ "$META_OK" != "success" ]; then
+            skip "Dependabot metadata could not be verified (not from dependabot[bot], or an unsigned commit)."
+          fi
+
+          if [ "$ECOSYSTEM" != "docker" ]; then
+            skip "not a docker-ecosystem update (ecosystem: '${ECOSYSTEM:-unknown}') — left for a human or the existing PR-triggered workflow."
+          fi
+
+          files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename')
+          non_dockerfile=$(echo "$files" | grep -v -E '(^|/)Dockerfile$' || true)
+          if [ -n "$non_dockerfile" ]; then
+            skip "touches file(s) beyond a Dockerfile: $(echo "$non_dockerfile" | tr '\n' ' ')"
+          fi
+          if [ -z "$files" ]; then
+            skip "reported no changed files — nothing to verify."
+          fi
+
+          sha=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')
+          checks=$(gh api "repos/$REPO/commits/$sha/check-runs" --paginate --jq '.check_runs')
+          others=$(echo "$checks" | jq '[.[] | select(.name | test("auto-merge"; "i") | not)]')
+          total=$(echo "$others" | jq 'length')
+          pending=$(echo "$others" | jq '[.[] | select(.status != "completed")] | length')
+          failed=$(echo "$others" | jq '[.[] | select(.conclusion != null and (.conclusion | IN("success","skipped","neutral") | not))] | length')
+          echo "PR #$PR check runs: total=$total pending=$pending failed=$failed"
+
+          if [ "$failed" -gt 0 ]; then
+            skip "at least one check run failed on the PR head commit."
+          fi
+          if [ "$pending" -gt 0 ]; then
+            skip "check runs are still in progress — will re-check on tomorrow's run."
+          fi
+
+          echo "::notice::PR #$PR is a docker digest bump touching only Dockerfile(s), all checks green — merging."
+          gh pr merge --squash --delete-branch "$PR" --repo "$REPO"
+          echo "::notice::PR #$PR merged."

--- a/.github/workflows/base-digest-auto-merge.yml
+++ b/.github/workflows/base-digest-auto-merge.yml
@@ -15,13 +15,18 @@ name: base digest auto-merge
 #
 # Scope is intentionally narrow — every one of these must hold or the PR is
 # left alone:
-#   - authored by dependabot[bot] (enforced twice: the PR listing below only
-#     considers that author, and fetch-metadata independently verifies the
-#     PR's user and commit signature)
+#   - authored by dependabot[bot] — this is the real provenance boundary: the
+#     PR listing below only ever considers that author, so a human PR is
+#     never even enumerated. fetch-metadata performs its own secondary check
+#     of the PR author and Dependabot's commit metadata format, but that is
+#     a defense-in-depth parse, not the primary guarantee.
 #   - a `docker` ecosystem update, per dependabot/fetch-metadata
 #   - every changed file in the PR is a Dockerfile (checked against the PR's
 #     actual file list, not inferred from its title)
-#   - every check run on the PR's head commit has completed, and none failed
+#   - every check run on the PR's head commit has completed, none failed,
+#     and there is at least one check run — zero check runs means CI has
+#     not started yet, not that nothing needs to run (ci.yml triggers
+#     unconditionally on `pull_request`, no path filter)
 #
 # Anything else — a gomod/npm/github-actions Dependabot PR, or any
 # human-authored PR — is never touched. Runs daily (the upstream rebuild is
@@ -80,8 +85,9 @@ jobs:
       # fetch-metadata reads the pull_request event payload, not a live API
       # call — this repo only triggers it on `pull_request`. A schedule run
       # has no such payload, so we hand it one built from the PR we just
-      # fetched. It still independently verifies the PR author and the
-      # commit signature, so this is not a way to spoof provenance.
+      # fetched. It performs its own author/metadata check on top of this,
+      # but the `discover` job's author filter above is what actually keeps
+      # a human PR out of this matrix in the first place.
       - name: Fetch Dependabot metadata
         id: meta
         continue-on-error: true
@@ -123,19 +129,43 @@ jobs:
             skip "reported no changed files — nothing to verify."
           fi
 
+          # --paginate emits one JSON array PER PAGE, not one merged array —
+          # a bare `--jq '.check_runs'` over multiple pages produces several
+          # separate arrays back to back, which silently breaks any `length`
+          # / arithmetic done on the result. --slurp collects every page
+          # into a single outer array first, so the --jq filter here runs
+          # once over the whole set and flattens it into one true list.
           sha=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')
-          checks=$(gh api "repos/$REPO/commits/$sha/check-runs" --paginate --jq '.check_runs')
+          checks=$(gh api "repos/$REPO/commits/$sha/check-runs" --paginate --slurp --jq '[.[].check_runs] | flatten')
           others=$(echo "$checks" | jq '[.[] | select(.name | test("auto-merge"; "i") | not)]')
           total=$(echo "$others" | jq 'length')
           pending=$(echo "$others" | jq '[.[] | select(.status != "completed")] | length')
           failed=$(echo "$others" | jq '[.[] | select(.conclusion != null and (.conclusion | IN("success","skipped","neutral") | not))] | length')
           echo "PR #$PR check runs: total=$total pending=$pending failed=$failed"
 
+          # A gate that can't parse its own inputs must stop hard, never
+          # fall through to a merge. jq's `length` always yields a plain
+          # non-negative integer for a well-formed array, so anything else
+          # here means the aggregation above is broken — treat that as a
+          # hard failure of the whole job, not a reason to proceed.
+          for name in total pending failed; do
+            value="${!name}"
+            case "$value" in
+              ''|*[!0-9]*)
+                echo "::error::PR #$PR check-run aggregation produced a non-integer $name value: '$value' — refusing to merge."
+                exit 1
+                ;;
+            esac
+          done
+
           if [ "$failed" -gt 0 ]; then
             skip "at least one check run failed on the PR head commit."
           fi
           if [ "$pending" -gt 0 ]; then
             skip "check runs are still in progress — will re-check on tomorrow's run."
+          fi
+          if [ "$total" -eq 0 ]; then
+            skip "no check runs found yet — CI has not started (ci.yml triggers on every pull_request with no path filter, so this means 'not yet', never 'none will run'); will re-check on tomorrow's run."
           fi
 
           echo "::notice::PR #$PR is a docker digest bump touching only Dockerfile(s), all checks green — merging."

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -36,7 +36,7 @@ jobs:
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::DEPENDABOT_PAT not set — skipping auto-merge."
+            echo "::warning::DEPENDABOT_PAT not set — this workflow no-ops for every PR. Base-image digest bumps are instead auto-merged by base-digest-auto-merge.yml; anything else (gomod/npm/github-actions) needs a human to merge it."
           fi
 
       # Build gate: wait for every other check run on this PR's head commit to


### PR DESCRIPTION
Closes the path that broke every image publish on 2026-09-04, and will otherwise break it again next Saturday.

## Why this keeps happening

Established by inspection, not inference:

- `ghcr.io/tesserix/base-go-builder` was created 2026-04-19 and has rebuilt weekly since, yet holds only **3 versions, all from the single 2026-09-04 05:41 build** — one index plus two per-arch manifests. Every earlier digest is gone. GHCR keeps only the current build, so **a pinned digest survives at most one weekly rebuild** (Saturdays 03:00 UTC).
- Nothing in `tesserix/base-docker-images` deletes package versions. The pruning is a GitHub-side behaviour we do not control, so the fix has to be on the consumer side.
- mark8ly's `base-image-refresh.yml` is only a guard — it validates and prints notices, and never bumps a digest.
- The intended updater is Dependabot, and `dependabot-auto-merge.yml` exists to merge those PRs. **It is gated on a `DEPENDABOT_PAT` secret that does not exist in this repo** (12 Actions secrets, none named that). It has never merged anything; it logs a notice and skips.

So: Dependabot opens the digest PR → nothing merges it → Saturday's rebuild prunes the pin → every image build fails. #665 repinned by hand; #670 made sure every Dockerfile has a Dependabot entry. Neither closes the merge gap.

## Why a scheduled workflow rather than adding the PAT

Workflow runs triggered **by** Dependabot get a read-only `GITHUB_TOKEN` and no access to secrets — that restriction is the entire reason the existing workflow needs a PAT. A `schedule`-triggered run is an ordinary run with full `GITHUB_TOKEN` permissions, so it can merge with **no long-lived credential to create, store or rotate**.

Daily cadence against a weekly rebuild gives six chances to land each bump before a pin can rot.

## Deliberately narrow

It merges a PR only when **all** of these hold:

- authored by `dependabot[bot]` (filtered at enumeration, from GitHub's authoritative field — not the title)
- **docker** ecosystem, read from `dependabot/fetch-metadata`, not inferred from the branch or title
- **every** changed file is a Dockerfile — a PR touching a Dockerfile *and* a lockfile or workflow is rejected
- every check run has concluded and none failed

A gomod, npm or github-actions bump does not qualify. A human PR is never enumerated. All four cases were walked through explicitly.

## Two Critical defects found in review, both fixed

Review reproduced both by execution rather than reading, which is the only reason they were caught:

**1. `--paginate` was silently defeating the gate.** `gh api --paginate --jq '.check_runs'` emits a *separate array per page*. With two pages, `pending` became the literal string `"0\n1"`; `[ "$pending" -gt 0 ]` threw `integer expression expected`, which is **falsy**, so execution fell through to merge — able to ignore an actively **failed** check. Now aggregated with `--slurp` + `[.[].check_runs] | flatten`, and every numeric value is validated against `^[0-9]+$` and `exit 1`s loudly rather than evaluating false.

**2. Zero check runs counted as green**, merging code CI had never run on. A scheduled snapshot is not the sibling workflow's polling `pull_request` trigger, so a PR opened shortly before the run was a live weekly race. Zero now means **not ready → skip** (exit 0, not a red job); tomorrow's run picks it up.

Verified afterwards against synthetic two-page payloads: counts aggregate correctly across pages, a failure on page 2 is seen, a non-integer fails loudly, and zero-total skips before any merge call. All four gates run strictly before `gh pr merge`.

## Also here

`dependabot-auto-merge.yml`'s missing-PAT `::notice::` becomes a `::warning::` naming the consequence and pointing at this workflow. Its behaviour is otherwise untouched — a notice is invisible in practice, which is how this went unnoticed for months.

## Still open, and outside this repo

This closes the merge window. It does not change the retention that makes the window matter: raising retention on the base packages, or slowing the rebuild cadence, is a change in `tesserix/base-docker-images` or its GHCR settings.
