### PR TITLE
docs(mcp-catalog): deployment plan across mark8ly, tesserix-k8s and devai

### DIFF
--- a/docs/superpowers/plans/2026-09-05-mcp-catalog-deployment.md
+++ b/docs/superpowers/plans/2026-09-05-mcp-catalog-deployment.md
@@ -1,0 +1,321 @@
+# `mcp-catalog` Deployment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Get `mcp-catalog` — merged, tested and sitting on `main` since #663 — actually running in the `mark8ly` namespace and answering a `tools/list`.
+
+**Architecture:** The binary already exists. This plan builds the image in CI, provisions its credential, deploys it via a Helm chart and an ArgoCD Application, registers it in the agent registry, and only then wires it into Kargo's promotion chain.
+
+**Tech Stack:** GitHub Actions (mark8ly), Helm + ArgoCD + External Secrets + KEDA (tesserix-k8s), the agentic registry (devai), GCP Secret Manager.
+
+**Spec:** `docs/superpowers/specs/2026-09-04-mark8ly-mcp-connectors-design.md` — this is the deployment half of its step 2. Steps 3–5 (australis ADR amendment, support-tool migration, platform-read) remain out of scope.
+
+**Repos touched:** `mark8ly`, `tesserix-k8s`, `devai`. Three separate PRs, in the order below.
+
+## Global Constraints
+
+- **The Kargo warehouse is the sharp edge.** `kargo-mark8ly` has ONE `Warehouse` named `services` subscribed to exactly **7** images, and Freight forms only when **all** subscribed images share a tag. Adding an 8th subscription before that image is publishing will **stop Freight forming for every other mark8ly service** — admin, auth-bff, marketplace-api, onboarding, otto, platform-api, storefront all stop deploying. This is why the warehouse change is LAST and gated on evidence.
+- **An unreferenced ArgoCD Application manifest fails CI** (`scripts/validate-argocd-apps.py` in tesserix-k8s). A new Application must be wired into the app-of-apps in the same PR that adds it.
+- **Chart changes need a `Chart.yaml` version bump** — `ct lint` fails an unbumped chart, and a local `helm lint` will not catch it.
+- tesserix-k8s requires a **review approval** before merge. Do not expect to self-merge there.
+- The connector gets **its own** key, not the shared gateway's. australis invariant 8: transport identity and data identity must name the same unit.
+- No secret value in any manifest, commit, PR body, or log line. Secrets are referenced by GSM key name only.
+- Every image reference is pulled through the in-region Artifact Registry mirror (`asia-south1-docker.pkg.dev/tesseracthub-480811/ghcr-remote/tesserix/...`), never `ghcr.io` directly — see `docs/artifact-registry-mirror.md`.
+
+## What already exists — verified 2026-09-05, do not re-derive
+
+| Thing | State |
+| --- | --- |
+| `services/mcp` on mark8ly `main` | builds, vets, passes `-race`; `Go (mcp)` CI job green |
+| `services/mcp/Dockerfile` | builds locally; same base digests and non-root handling as otto |
+| Dependabot docker entry for `/services/mcp` | added in #670 |
+| `mark8ly-mcp` (the OLD shared gateway) | still running, on the `slm-support-platform` image. **Leave it alone** — retiring it is spec step 4 |
+| `STOREFRONT_KEY` | k8s secret `mark8ly-marketplace-api-storefront-key`, from GSM `prod-mark8ly-marketplace-api-storefront-key` |
+| Kargo prod stage | currently **Unhealthy** — ArgoCD app `mark8ly-marketplace-api-admin` is Degraded. **Pre-existing and unrelated.** Do not try to fix it here, and do not treat it as caused by this work |
+
+---
+
+### Task 1 (mark8ly): build and publish the image
+
+**Files:**
+- Modify: `.github/ci/container-images.json`
+
+**Interfaces:**
+- Produces: a published image `.../ghcr-remote/tesserix/mark8ly-mcp-catalog:main-<sha7>` on every push to `main`.
+
+- [ ] **Step 1: Read the existing entries and match them**
+
+Read `.github/ci/container-images.json`. The Go services (`mark8ly-platform-api`, `mark8ly-otto`) are the right model: `context` is the service directory, `dockerfile` is that directory's Dockerfile, `requires_application_build_secret` is `false`, and `smoke_path` is a health endpoint.
+
+- [ ] **Step 2: Add the entry**
+
+```json
+{
+  "name": "mark8ly-mcp-catalog",
+  "context": "services/mcp",
+  "dockerfile": "services/mcp/Dockerfile",
+  "target": "runtime",
+  "source_root": "services/mcp",
+  "build_args": "",
+  "requires_application_build_secret": false,
+  "trivy_ignore_file": ".trivyignore",
+  "smoke_port": 8765,
+  "smoke_path": "/healthz"
+}
+```
+
+**Confirm `target` against the Dockerfile before committing** — the plan asserts `runtime`, but read the file's stage names rather than trusting this. Confirm `smoke_port` matches the config default (8765) and that `/healthz` is the path `main.go` actually serves.
+
+- [ ] **Step 3: Run the contract test**
+
+Run: `python3 .github/scripts/test-ci-contract.py`
+Expected: PASS. `test_image_matrix_covers_every_deployable` asserts an exact closed set, so it will fail if the set it expects was not updated too — if it fails, read what it wants rather than deleting the assertion.
+
+- [ ] **Step 4: Build the image locally exactly as CI will**
+
+```bash
+cd services/mcp && docker build --target runtime -t mcp-catalog:ci-check .
+docker run --rm --entrypoint /bin/sh mcp-catalog:ci-check -c 'echo ok' 2>/dev/null || echo "(distroless — no shell, expected)"
+```
+A distroless image has no shell; that is fine and expected. The build succeeding is the assertion.
+
+- [ ] **Step 5: Commit and open the PR**
+
+```bash
+git commit -am "ci(mcp-catalog): build and publish the connector image"
+```
+
+- [ ] **Step 6: THE GATE — confirm the image actually published**
+
+After the PR merges, wait for the `main` CI run and confirm the image exists:
+
+```bash
+gh api "orgs/tesserix/packages/container/mark8ly-mcp-catalog/versions" \
+  --jq '.[]|"\(.name[0:19]) tags=\(.metadata.container.tags|join(","))"' | head -3
+```
+
+**Do not start Task 4 until this returns a `main-<sha7>` tag.** Everything about the Kargo ordering depends on this being true, not assumed.
+
+---
+
+### Task 2 (operator action — NOT an agent task): mint the connector's key
+
+**This task cannot be done by an agent and must not be attempted by one.** It mints a credential.
+
+- [ ] **Step 1: Create the GSM secret**
+
+Create a new secret in GCP project `tesseracthub-480811` named **`prod-mark8ly-mcp-catalog-key`**, containing a freshly generated high-entropy key. It must be a NEW value — do not reuse `prod-support-platform-mark8ly-mcp-key`, which belongs to the shared gateway. Per australis invariant 8, this connector owns its own credential so it can be revoked without touching another product.
+
+- [ ] **Step 2: Record who holds it**
+
+Whoever will call the connector (the engine, or an operator testing it) needs this value. Record where it is held. Do not paste it into an issue, a PR, or a commit.
+
+- [ ] **Step 3: Confirm it is readable by the cluster**
+
+The `gcp-secret-store` ClusterSecretStore must be able to read it. If other `prod-mark8ly-*` secrets sync, this one will too; confirm rather than assume by checking the ExternalSecret goes `SecretSynced` in Task 3's verification step.
+
+---
+
+### Task 3 (tesserix-k8s): the chart and the Application
+
+**Files:**
+- Create: `charts/apps/mark8ly-mcp-catalog/{Chart.yaml,values.yaml}` and `templates/{deployment,service,serviceaccount,externalsecret,keda,pdb,_helpers.tpl}.yaml`
+- Create: `argocd/prod/apps/mark8ly/mcp-catalog.yaml`
+- Modify: whatever wires `argocd/prod/apps/mark8ly/` into the app-of-apps
+
+**Interfaces:**
+- Consumes: the image from Task 1, the GSM secret from Task 2.
+- Produces: `mark8ly-mcp-catalog.mark8ly.svc.cluster.local:8765` serving MCP.
+
+- [ ] **Step 1: Copy the closest sibling and read it properly**
+
+`charts/apps/mark8ly-otto/` is the right model — a single-replica Go service in the same namespace with KEDA, a PDB, a ServiceAccount and an AuthorizationPolicy. Copy its structure. **Read every template before adapting it**; do not rename otto's values blindly.
+
+- [ ] **Step 2: values.yaml**
+
+```yaml
+namespace: mark8ly
+name: mark8ly-mcp-catalog
+image:
+  repository: asia-south1-docker.pkg.dev/tesseracthub-480811/ghcr-remote/tesserix/mark8ly-mcp-catalog
+  tag: "main-REPLACE"   # a REAL published tag from Task 1 step 6; Kargo rewrites it later
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: ghcr-secret
+service:
+  type: ClusterIP
+  port: 8765
+replicaCount: 1
+```
+
+**`tag` must be a real, published tag** — not `main`, not `latest`. Take it from Task 1 step 6's output. The spec forbids resolving a moving tag (D8), and the estate has just spent a day on pruned digests.
+
+- [ ] **Step 3: Deployment env — the config the binary actually reads**
+
+Read `services/mcp/internal/config/config.go` in mark8ly and wire exactly what `Load()` requires. As of this writing that is `STOREFRONT_BASE_URL`, `STOREFRONT_KEY`, `MCP_AUTH_KEY`, and optionally `PORT` and `UPSTREAM_TIMEOUT` — **but read the file, because it refuses to start if a required variable is missing, and a stale plan is not a reason for a CrashLoopBackOff.**
+
+`STOREFRONT_BASE_URL` is `http://mark8ly-marketplace-api-storefront.mark8ly.svc.cluster.local:8080` — no path component, and no trailing slash. `STOREFRONT_KEY` and `MCP_AUTH_KEY` come from secret refs, never literals.
+
+Probes: `/healthz` for liveness, `/readyz` for readiness, on port 8765.
+
+- [ ] **Step 4: ExternalSecret**
+
+Two keys, from two different GSM secrets:
+
+| env | GSM key |
+| --- | --- |
+| `STOREFRONT_KEY` | `prod-mark8ly-marketplace-api-storefront-key` |
+| `MCP_AUTH_KEY` | `prod-mark8ly-mcp-catalog-key` (Task 2) |
+
+Follow `charts/apps/console/templates/externalsecret.yaml` for shape: `ClusterSecretStore` `gcp-secret-store`, `refreshInterval: 1h`, `creationPolicy: Owner`.
+
+**Name the resulting k8s Secret `mark8ly-mcp-catalog-secrets`** — step 9's verification and the Deployment's `secretKeyRef`s both use that name, so picking a different one silently breaks both.
+
+- [ ] **Step 5: Bump the chart version**
+
+`Chart.yaml` starts at `version: 0.1.0`. A new chart needs no bump, but confirm `ct lint` is satisfied — an unbumped or malformed `Chart.yaml` fails CI in a way `helm lint` does not reproduce locally.
+
+- [ ] **Step 6: The ArgoCD Application**
+
+Copy `argocd/prod/apps/mark8ly/otto.yaml`. Keep:
+- the `kargo.akuity.io/authorized-stage: kargo-mark8ly:prod` annotation
+- the `ignoreDifferences` for `/status/terminatingReplicas`
+- automated sync with prune and selfHeal
+
+**Then wire it into the app-of-apps.** An unreferenced Application manifest fails `scripts/validate-argocd-apps.py`. Find how the sibling Applications in `argocd/prod/apps/mark8ly/` are enumerated and add this one the same way.
+
+- [ ] **Step 7: Validate before pushing**
+
+```bash
+helm lint charts/apps/mark8ly-mcp-catalog
+helm template charts/apps/mark8ly-mcp-catalog | head -60
+python3 scripts/validate-argocd-apps.py
+```
+`helm template` must render with no missing values and no secret literals. Grep the output for the string `KEY` and confirm every hit is a `secretKeyRef`, not a value.
+
+- [ ] **Step 8: Commit, PR, and wait for approval**
+
+```bash
+git commit -m "feat(mark8ly): deploy the mcp-catalog connector"
+```
+tesserix-k8s requires a review approval. Do not self-merge.
+
+- [ ] **Step 9: Verify it is actually running**
+
+After ArgoCD syncs:
+
+```bash
+kubectl get externalsecret -n mark8ly mark8ly-mcp-catalog-secrets   # must be SecretSynced
+kubectl get deploy -n mark8ly mark8ly-mcp-catalog                   # must be 1/1
+kubectl logs -n mark8ly deploy/mark8ly-mcp-catalog | tail -20       # must contain NO secret
+```
+
+Then call it. **Three headers are mandatory** — without them you get a 400 that looks like auth and is neither:
+
+```bash
+KEY=$(kubectl get secret -n mark8ly mark8ly-mcp-catalog-secrets -o jsonpath='{.data.MCP_AUTH_KEY}' | base64 -d)
+kubectl run mcpq-$RANDOM -n mark8ly --rm -i --restart=Never --image=curlimages/curl:8.10.1 --quiet --env="K=$KEY" -- sh -c '
+curl -s -m 20 -X POST http://mark8ly-mcp-catalog:8765/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "MCP-Protocol-Version: 2026-07-28" \
+  -H "Mcp-Method: tools/list" \
+  -H "X-MCP-Key: $K" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}"'
+```
+
+**Expected: the five tool names.** `list_store_products`, `get_store_product`, `list_store_categories`, `list_products_by_category`, `get_store_branding`. Anything else — and especially an empty tool list — means stop and diagnose, not proceed. An empty list is exactly the shape of #412.
+
+Then call one tool for real against a live store slug and confirm a projected result comes back with no `null`.
+
+---
+
+### Task 4 (tesserix-k8s): add it to the Kargo warehouse — LAST, and only on evidence
+
+**Do not start this task until Task 1 step 6 has confirmed a published `main-<sha7>` tag, and Task 3 step 9 has confirmed the connector answers a `tools/list`.**
+
+**Files:**
+- Modify: the mark8ly Kargo project values that produce the `services` Warehouse
+
+**Interfaces:**
+- Produces: Kargo promoting `mark8ly-mcp-catalog` alongside the other seven.
+
+- [ ] **Step 1: Understand what you are changing**
+
+There is ONE Warehouse, `services`, in namespace `kargo-mark8ly`, subscribed to 7 images. Freight forms only when **all** subscribed images share a tag. Adding an 8th means no Freight forms until `mark8ly-mcp-catalog` also publishes that tag.
+
+Because the image builds on every push to `main` from Task 1 onward, this is safe **once that is true and only then**. If it is not true, every mark8ly service stops deploying, and the symptom (Freight simply stops appearing) points nowhere near this change.
+
+- [ ] **Step 2: Record the pre-change state**
+
+```bash
+kubectl get freight -n kargo-mark8ly --sort-by=.metadata.creationTimestamp | tail -3
+kubectl get warehouse services -n kargo-mark8ly -o jsonpath='{.spec.subscriptions[*].image.repoURL}' | tr ' ' '\n'
+```
+Write both into the PR. You need to know what "normal" looked like to tell whether you broke it.
+
+- [ ] **Step 3: Add the subscription**
+
+Add `mark8ly-mcp-catalog` to the service list that generates the Warehouse, matching the existing entries.
+
+- [ ] **Step 4: Commit and PR**
+
+```bash
+git commit -m "feat(kargo): promote mcp-catalog alongside the other mark8ly services"
+```
+
+- [ ] **Step 5: THE GATE — confirm Freight still forms**
+
+Kargo polls every 5 minutes. After the PR merges and ArgoCD syncs:
+
+```bash
+kubectl get warehouse services -n kargo-mark8ly -o jsonpath='{.spec.subscriptions[*].image.repoURL}' | tr ' ' '\n' | wc -l   # expect 8
+kubectl get freight -n kargo-mark8ly --sort-by=.metadata.creationTimestamp | tail -3
+```
+
+**A new Freight must appear within ~15 minutes of the next push to `main`.** If none does, the 8th subscription is not resolving and every mark8ly deploy is now blocked — revert this commit immediately rather than debugging forward. That is the whole reason this task is last and separate.
+
+---
+
+### Task 5 (devai): register the connector
+
+**Files:**
+- Create: `architecture/registry-seeds/mcp-servers/mark8ly-mcp-catalog.yaml`
+
+- [ ] **Step 1: Copy the sibling and adapt it**
+
+`architecture/registry-seeds/mcp-servers/mark8ly-mcp.yaml` is the model. Keep `apiVersion: registry.agentic.dev/v1alpha1`, `kind: MCPServer`, the `mcp.tesserix.app/tenant: mark8ly` label, `protocolVersion: '2026-07-28'`, and the `credentialRef` shape.
+
+Changes from the sibling:
+- `name` / `displayName`: `mark8ly-mcp-catalog` / "Mark8ly Catalog MCP"
+- `endpoint` and `remotes[0].url`: `http://mark8ly-mcp-catalog.mark8ly.svc.cluster.local:8765/mcp`
+- `credentialRef.key`: the new key from Task 2, header `X-MCP-Key`
+- `tools`: the five catalog tools, **in the same order `Registry.Names()` returns them** — alphabetical
+- `description`: say plainly that these are read-only catalog reads over a store's public slug, and that nothing here can write
+
+- [ ] **Step 2: Cross-check against what is actually served**
+
+The tool list in the seed and the tool list the server returns must match. mark8ly's `cmd/mcp-catalog/declared_test.go` pins the server side; this seed is the other side of that comparison. If they disagree, one of them is wrong — find out which before committing.
+
+- [ ] **Step 3: Commit and PR**
+
+```bash
+git commit -m "feat(registry): register the mark8ly catalog connector"
+```
+
+Note the seeds are a source of record; **zero `MCPServer` CRs exist in the cluster** and devai's catalog seeds declare a different apiVersion group than the installed CRD. Applying seeds is a separate, pre-existing piece of work — do not take it on here.
+
+---
+
+## Out of scope
+
+- **Retiring the old `mark8ly-mcp` gateway.** Spec step 4, after the support tools migrate. Both run side by side until then; that is the temporary two-pod cost the spec already accounted for.
+- **The Degraded `mark8ly-marketplace-api-admin` Application.** Pre-existing, unrelated, and the reason the Kargo prod stage reads Unhealthy today.
+- **Applying registry seeds as cluster CRs**, and the `registry.solo.io` vs `kagent.dev` apiVersion mismatch.
+- **AgentGateway routing.** The registry record names the in-cluster Service URL. Whether callers go through AgentGateway (ADR-0001 D4) is open question 1 in the spec and is not settled by deploying this.
+- **A `/readyz` that probes the upstream.** It returns a static 200, matching otto. Worth revisiting when something gates on it.
+
+## Open questions
+
+1. **Who calls this first?** Deploying it proves it runs; it does not prove anything consumes it. Identify the first caller before Task 4, because a connector nothing calls is not obviously worth adding to the promotion chain.
+2. **Does the engine reach it directly or via AgentGateway?** Affects whether an AuthorizationPolicy needs to admit a second caller identity.


### PR DESCRIPTION
`mcp-catalog` has been merged, tested and sitting on `main` since #663 without running anywhere. This is the plan to change that.

Documentation only — no behaviour changes in this PR.

## The finding that shapes the whole plan

`kargo-mark8ly` has **one** Warehouse named `services`, subscribed to exactly **seven** images, and Freight forms only when **all** subscribed images share a tag.

So adding `mcp-catalog` as an eighth subscription before its image is publishing would **stop Freight forming for every other mark8ly service** — admin, auth-bff, marketplace-api, onboarding, otto, platform-api and storefront would all silently stop deploying, with a symptom (Freight simply stops appearing) that points nowhere near the change that caused it.

That is why the plan is ordered the way it is, and why the Kargo task is last, separate, and gated on evidence rather than on assumption. Freight is currently forming normally (most recent 15 minutes before writing), which is the baseline the plan tells you to record before touching it.

## Five tasks, three repos, one human gate

1. **mark8ly** — add the image to `container-images.json` so CI builds and publishes it. Gated on actually observing a `main-<sha7>` tag in GHCR, not on the PR merging.
2. **Operator, not an agent** — mint `prod-mark8ly-mcp-catalog-key` in GSM. The connector gets its **own** credential rather than reusing the shared gateway's, so it can be revoked without touching another product. The plan says explicitly that an agent must not attempt this.
3. **tesserix-k8s** — Helm chart modelled on `mark8ly-otto`, ExternalSecret for the two keys, and an ArgoCD Application wired into the app-of-apps (an unreferenced Application manifest fails `validate-argocd-apps.py`).
4. **tesserix-k8s** — add the eighth Kargo subscription. Last, and only after tasks 1 and 3 have produced evidence.
5. **devai** — the registry seed, with its tool list cross-checked against what the server actually serves.

## Verification is by calling it, not by observing a green sync

The plan's acceptance is a real `tools/list` against the running Service returning the five expected tool names — and it flags that **three headers are mandatory** (`MCP-Protocol-Version`, `Mcp-Method`, `X-MCP-Key`), because without them you get a 400 that looks like an auth failure and is neither. That cost a debugging cycle earlier in this work.

It also says plainly that an **empty tool list means stop**, since that is precisely the shape of #412 — a connector that looked healthy for months while serving nothing.

## Deliberately excluded, with reasons

- **Retiring the old `mark8ly-mcp` gateway** — spec step 4, after the support tools migrate. Both run side by side until then; the spec already accounted for that temporary second pod.
- **The Degraded `mark8ly-marketplace-api-admin` Application** — pre-existing and unrelated. It is why the Kargo prod stage currently reads Unhealthy, and the plan says not to treat that as caused by this work.
- **Applying registry seeds as cluster CRs** — zero `MCPServer` CRs exist estate-wide and devai's catalog seeds declare a different apiVersion group than the installed CRD. Separate, pre-existing work.
- **AgentGateway routing** — spec open question 1, not settled by deploying this.

## Open questions the plan asks before task 4

**Who calls this first?** Deploying proves it runs; it does not prove anything consumes it. A connector nothing calls is not obviously worth adding to the promotion chain, and that is worth settling before taking the Kargo risk.

Spec: `docs/superpowers/specs/2026-09-04-mark8ly-mcp-connectors-design.md`
