### PR TITLE
feat(admin): file, read and reply to platform tickets through tesserix-home's platform API (tesserix-home#152)

### DIFF
--- a/apps/admin/lib/api/platform-token.test.ts
+++ b/apps/admin/lib/api/platform-token.test.ts
@@ -9,10 +9,10 @@ import { __resetPlatformTokenCache, getPlatformToken } from "./platform-token";
 // expiry works perfectly until the hour it does not.
 
 const ENV = {
-  PLATFORM_OIDC_ISSUER: "https://auth.tesserix.app",
-  PLATFORM_OIDC_PROJECT_ID: "386377618200461939",
-  PLATFORM_OIDC_CLIENT_ID: "mark8ly-catalog-reader",
-  PLATFORM_OIDC_CLIENT_SECRET: "s3cret",
+  TESSERIX_PLATFORM_OIDC_ISSUER: "https://auth.tesserix.app",
+  TESSERIX_PLATFORM_OIDC_PROJECT_ID: "386377618200461939",
+  TESSERIX_PLATFORM_OIDC_CLIENT_ID: "mark8ly-catalog-reader",
+  TESSERIX_PLATFORM_OIDC_CLIENT_SECRET: "s3cret",
 };
 
 function tokenResponse(expiresIn = 3600, token = "tok-1") {
@@ -123,9 +123,9 @@ describe("caching", () => {
 
 describe("configuration", () => {
   it("refuses with a message naming what is missing", async () => {
-    delete process.env.PLATFORM_OIDC_CLIENT_SECRET;
+    delete process.env.TESSERIX_PLATFORM_OIDC_CLIENT_SECRET;
     vi.stubGlobal("fetch", vi.fn());
 
-    await expect(getPlatformToken()).rejects.toThrow(/PLATFORM_OIDC_CLIENT_SECRET/);
+    await expect(getPlatformToken()).rejects.toThrow(/TESSERIX_PLATFORM_OIDC_CLIENT_SECRET/);
   });
 });

--- a/apps/admin/lib/api/platform-token.test.ts
+++ b/apps/admin/lib/api/platform-token.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetPlatformTokenCache, getPlatformToken } from "./platform-token";
+
+// The machine token mark8ly presents to tesserix-home's platform API.
+//
+// Worth testing rather than trusting because two of its failure modes are
+// silent: a token minted WITHOUT the roles scope verifies against the JWKS and
+// still answers 401 (it carries no roles claim), and a cache that ignores
+// expiry works perfectly until the hour it does not.
+
+const ENV = {
+  PLATFORM_OIDC_ISSUER: "https://auth.tesserix.app",
+  PLATFORM_OIDC_PROJECT_ID: "386377618200461939",
+  PLATFORM_OIDC_CLIENT_ID: "mark8ly-catalog-reader",
+  PLATFORM_OIDC_CLIENT_SECRET: "s3cret",
+};
+
+function tokenResponse(expiresIn = 3600, token = "tok-1") {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ access_token: token, expires_in: expiresIn }),
+    text: async () => "",
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  __resetPlatformTokenCache();
+  Object.assign(process.env, ENV);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  for (const k of Object.keys(ENV)) delete process.env[k];
+});
+
+describe("minting", () => {
+  it("asks for the roles scope, without which the token 401s at the API", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(tokenResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getPlatformToken();
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://auth.tesserix.app/oauth/v2/token");
+    const body = String((init as RequestInit).body);
+    expect(body).toContain("grant_type=client_credentials");
+    // The two scopes that matter. Measured against production during #152:
+    // the audience scope alone yields a token with NO roles claim, which the
+    // API refuses with 401 — indistinguishable from a bad credential.
+    expect(decodeURIComponent(body)).toContain(
+      "urn:zitadel:iam:org:project:id:386377618200461939:aud",
+    );
+    expect(decodeURIComponent(body)).toContain("urn:zitadel:iam:org:projects:roles");
+  });
+
+  it("authenticates the client rather than putting the secret in the body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(tokenResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getPlatformToken();
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const auth = new Headers(init.headers).get("authorization") ?? "";
+    expect(auth.startsWith("Basic ")).toBe(true);
+    expect(String(init.body)).not.toContain("s3cret");
+  });
+});
+
+describe("caching", () => {
+  it("reuses a live token instead of minting per request", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(tokenResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const a = await getPlatformToken();
+    const b = await getPlatformToken();
+
+    expect(a).toBe(b);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-mints BEFORE expiry rather than at it", async () => {
+    // A token that is valid when checked can still be expired when it
+    // arrives. The skew is what stops a support page failing for one
+    // merchant every hour.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(tokenResponse(3600, "tok-1"))
+      .mockResolvedValueOnce(tokenResponse(3600, "tok-2"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await getPlatformToken()).toBe("tok-1");
+    // Just inside the refresh skew — still short of the real expiry.
+    vi.advanceTimersByTime((3600 - 30) * 1000);
+    expect(await getPlatformToken()).toBe("tok-2");
+  });
+
+  it("does not stampede when several requests arrive together", async () => {
+    // The support page fetches list and announcements at once; a cold cache
+    // must mint once, not once per caller.
+    const fetchMock = vi.fn().mockResolvedValue(tokenResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await Promise.all([getPlatformToken(), getPlatformToken(), getPlatformToken()]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache a failure", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 503, text: async () => "upstream" } as unknown as Response)
+      .mockResolvedValueOnce(tokenResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getPlatformToken()).rejects.toThrow();
+    // A transient mint failure must not poison the cache for the next caller.
+    await expect(getPlatformToken()).resolves.toBe("tok-1");
+  });
+});
+
+describe("configuration", () => {
+  it("refuses with a message naming what is missing", async () => {
+    delete process.env.PLATFORM_OIDC_CLIENT_SECRET;
+    vi.stubGlobal("fetch", vi.fn());
+
+    await expect(getPlatformToken()).rejects.toThrow(/PLATFORM_OIDC_CLIENT_SECRET/);
+  });
+});

--- a/apps/admin/lib/api/platform-token.ts
+++ b/apps/admin/lib/api/platform-token.ts
@@ -86,10 +86,10 @@ export async function getPlatformToken(): Promise<string> {
 }
 
 async function mint(): Promise<CachedToken> {
-  const issuer = required("PLATFORM_OIDC_ISSUER").replace(/\/+$/, "");
-  const projectId = required("PLATFORM_OIDC_PROJECT_ID");
-  const clientId = required("PLATFORM_OIDC_CLIENT_ID");
-  const clientSecret = required("PLATFORM_OIDC_CLIENT_SECRET");
+  const issuer = required("TESSERIX_PLATFORM_OIDC_ISSUER").replace(/\/+$/, "");
+  const projectId = required("TESSERIX_PLATFORM_OIDC_PROJECT_ID");
+  const clientId = required("TESSERIX_PLATFORM_OIDC_CLIENT_ID");
+  const clientSecret = required("TESSERIX_PLATFORM_OIDC_CLIENT_SECRET");
 
   const body = new URLSearchParams({
     grant_type: "client_credentials",

--- a/apps/admin/lib/api/platform-token.ts
+++ b/apps/admin/lib/api/platform-token.ts
@@ -1,0 +1,140 @@
+// The machine token mark8ly presents to tesserix-home's platform API.
+//
+// # Why this exists at all
+//
+// The admin server used to authenticate to tesserix-home with a SHARED SECRET
+// (`X-Internal-Token: $INTERNAL_API_TOKEN`), one bearer for every caller. The
+// platform API verifies Zitadel machine tokens instead, and scopes what a
+// caller may reach from the identity in that token — so the shared secret has
+// no equivalent there and this is what replaces it (tesserix-home#152).
+//
+// # Authorization: Bearer, not a custom header
+//
+// tesserix.ts uses `X-Internal-Token` because the istio-ingress in front of
+// the PUBLIC tesserix.app parses `Authorization: Bearer` as a JWT and rejects
+// an opaque token. That constraint does not apply here: the platform API has
+// no public path, and this calls it over the in-cluster ClusterIP, which never
+// passes through that ingress. Verified from a pod in this namespace during
+// the #152 rollout — Bearer answers 200, no token answers 401.
+//
+// Do not "restore" the custom header on the strength of the comment in
+// tesserix.ts. It is true of a different URL.
+
+const TOKEN_PATH = "/oauth/v2/token";
+
+// Re-mint this many seconds BEFORE the token actually expires.
+//
+// A token that is valid when checked can still be expired when it arrives.
+// Without the skew a merchant's support page fails once an hour, at a
+// different minute each time, which is the shape of bug nobody reproduces.
+const REFRESH_SKEW_SECONDS = 60;
+
+interface CachedToken {
+  token: string;
+  /** Epoch ms at which this token should stop being handed out. */
+  expiresAt: number;
+}
+
+let cached: CachedToken | null = null;
+// The in-flight mint, shared by concurrent callers.
+//
+// The support page fetches a listing and the announcements banner at once. On
+// a cold cache both would mint, and the second would race the first into the
+// cache for no gain. One promise, awaited by everyone.
+let inFlight: Promise<string> | null = null;
+
+/** Test seam. Not exported from the module's public surface by convention. */
+export function __resetPlatformTokenCache(): void {
+  cached = null;
+  inFlight = null;
+}
+
+function required(name: string): string {
+  const value = (process.env[name] ?? "").trim();
+  if (!value) {
+    // Named, because the alternative failure is a 401 from the API and an hour
+    // spent looking at the credential rather than at the missing variable.
+    throw new Error(`platform token: ${name} is not set`);
+  }
+  return value;
+}
+
+/**
+ * A valid access token for the platform API, minted or reused.
+ *
+ * Throws rather than returning null: every caller needs a token to do anything
+ * at all, and a null would be threaded through four call sites as a second
+ * failure mode that means the same thing.
+ */
+export async function getPlatformToken(): Promise<string> {
+  if (cached && Date.now() < cached.expiresAt) return cached.token;
+  if (inFlight) return inFlight;
+
+  inFlight = mint()
+    .then((minted) => {
+      cached = minted;
+      return minted.token;
+    })
+    .finally(() => {
+      // Cleared on BOTH paths. Leaving a rejected promise here would serve the
+      // same failure to every later caller, turning one upstream blip into a
+      // permanently broken support surface.
+      inFlight = null;
+    });
+
+  return inFlight;
+}
+
+async function mint(): Promise<CachedToken> {
+  const issuer = required("PLATFORM_OIDC_ISSUER").replace(/\/+$/, "");
+  const projectId = required("PLATFORM_OIDC_PROJECT_ID");
+  const clientId = required("PLATFORM_OIDC_CLIENT_ID");
+  const clientSecret = required("PLATFORM_OIDC_CLIENT_SECRET");
+
+  const body = new URLSearchParams({
+    grant_type: "client_credentials",
+    // BOTH scopes are load-bearing, measured against production Zitadel.
+    //
+    // The audience scope alone mints a token with NO roles claim, which the
+    // platform API refuses with 401 — indistinguishable from a bad credential,
+    // so it reads as "my secret is wrong" rather than "my scope is wrong".
+    // The roles scope alone gets the wrong audience. Only the pair works.
+    scope: [
+      "openid",
+      `urn:zitadel:iam:org:project:id:${projectId}:aud`,
+      "urn:zitadel:iam:org:projects:roles",
+    ].join(" "),
+  });
+
+  const response = await fetch(`${issuer}${TOKEN_PATH}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      // Client authentication in the header rather than the body, so the
+      // secret does not end up in a logged request body.
+      Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`,
+    },
+    body,
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    // The status and nothing from the body: an error body from a token
+    // endpoint can echo request parameters back, and this is logged.
+    throw new Error(`platform token: mint failed with HTTP ${response.status}`);
+  }
+
+  const payload = (await response.json()) as { access_token?: string; expires_in?: number };
+  if (!payload.access_token) {
+    throw new Error("platform token: response carried no access_token");
+  }
+
+  // Default to a short life when the server does not say. Erring short costs
+  // an extra mint; erring long serves an expired token.
+  const lifetime = typeof payload.expires_in === "number" ? payload.expires_in : 300;
+
+  return {
+    token: payload.access_token,
+    expiresAt: Date.now() + Math.max(lifetime - REFRESH_SKEW_SECONDS, 0) * 1000,
+  };
+}

--- a/apps/admin/lib/api/tesserix-tickets.test.ts
+++ b/apps/admin/lib/api/tesserix-tickets.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./platform-token", () => ({
+  getPlatformToken: vi.fn(async () => "machine-token"),
+  __resetPlatformTokenCache: () => {},
+}));
+
+import {
+  filePlatformTicket,
+  getMyPlatformTicket,
+  listMyPlatformTickets,
+  replyToPlatformTicket,
+} from "./tesserix";
+
+// The four calls repointed from apps/web's shared-secret /api/internal/* to
+// tesserix-home's platform API (tesserix-home#152).
+//
+// These assert the REQUEST as much as the response, because the failures that
+// matter here are silent on this side: a missing tenant reads another
+// merchant's queue on the old API and is refused on the new one, and a reply
+// with no author is recorded as the support team rather than the merchant.
+
+const TENANT = "8c302556-b647-4824-8ce4-73f547ca456e";
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+function lastCall(m: ReturnType<typeof vi.fn>) {
+  const [url, init] = m.mock.calls[m.mock.calls.length - 1];
+  return {
+    url: new URL(String(url)),
+    init: init as RequestInit,
+    body: init && (init as RequestInit).body ? JSON.parse(String((init as RequestInit).body)) : null,
+    headers: new Headers((init as RequestInit)?.headers),
+  };
+}
+
+beforeEach(() => {
+  process.env.PLATFORM_API_URL = "http://platform-api.tesserix.svc.cluster.local";
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.PLATFORM_API_URL;
+});
+
+describe("every ticket call", () => {
+  it("goes to the platform API with a Bearer token, not the shared secret", async () => {
+    const f = vi.fn().mockResolvedValue(ok({ data: { tickets: [] } }));
+    vi.stubGlobal("fetch", f);
+
+    await listMyPlatformTickets(TENANT);
+
+    const { url, headers } = lastCall(f);
+    expect(url.host).toBe("platform-api.tesserix.svc.cluster.local");
+    expect(url.pathname).toBe("/v1/tickets");
+    expect(headers.get("authorization")).toBe("Bearer machine-token");
+    // The old channel's header must be gone: sending both would leave the
+    // shared secret in flight to a service that ignores it.
+    expect(headers.get("x-internal-token")).toBeNull();
+  });
+});
+
+describe("listing", () => {
+  it("names the tenant, without which the API refuses", async () => {
+    const f = vi.fn().mockResolvedValue(ok({ data: { tickets: [{ id: "t1" }] } }));
+    vi.stubGlobal("fetch", f);
+
+    const rows = await listMyPlatformTickets(TENANT);
+
+    expect(lastCall(f).url.searchParams.get("tenant")).toBe(TENANT);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("reads data.tickets, not the old rows key", async () => {
+    // The envelope changed shape. Reading the old key returns [] on every
+    // call, which renders as "no tickets" rather than as an error.
+    const f = vi.fn().mockResolvedValue(ok({ data: { tickets: [{ id: "t1" }, { id: "t2" }] } }));
+    vi.stubGlobal("fetch", f);
+
+    expect(await listMyPlatformTickets(TENANT)).toHaveLength(2);
+  });
+
+  it("returns nothing when no tenant is known, without calling out", async () => {
+    const f = vi.fn();
+    vi.stubGlobal("fetch", f);
+
+    expect(await listMyPlatformTickets("")).toEqual([]);
+    expect(f).not.toHaveBeenCalled();
+  });
+});
+
+describe("detail", () => {
+  it("names the tenant and reads the envelope's data", async () => {
+    const f = vi.fn().mockResolvedValue(
+      ok({ data: { ticket: { id: "t1" }, replies: [{ id: "r1" }] } }),
+    );
+    vi.stubGlobal("fetch", f);
+
+    const got = await getMyPlatformTicket(TENANT, "t1");
+
+    expect(lastCall(f).url.pathname).toBe("/v1/tickets/t1");
+    expect(lastCall(f).url.searchParams.get("tenant")).toBe(TENANT);
+    expect(got?.ticket.id).toBe("t1");
+    expect(got?.replies).toHaveLength(1);
+  });
+});
+
+describe("filing", () => {
+  it("sends the platform API's snake_case contract and no product", async () => {
+    const f = vi.fn().mockResolvedValue(ok({ data: { ticket: { id: "new" } } }));
+    vi.stubGlobal("fetch", f);
+
+    await filePlatformTicket({
+      tenantId: TENANT,
+      subject: "Payouts delayed",
+      description: "Three pending",
+      priority: "high",
+      submittedByName: "Priya",
+      submittedByEmail: "p@example.com",
+      submittedByUserId: "uid-1",
+    });
+
+    const { url, body } = lastCall(f);
+    expect(url.pathname).toBe("/v1/tickets");
+    expect(body).toMatchObject({
+      tenant_id: TENANT,
+      subject: "Payouts delayed",
+      priority: "high",
+      submitted_by_name: "Priya",
+      submitted_by_email: "p@example.com",
+      submitted_by_user_id: "uid-1",
+    });
+    // The product comes from the caller's SCOPE on the server. Sending one
+    // would be a field the API does not read and a claim it does not honour.
+    expect(body).not.toHaveProperty("productId");
+    expect(body).not.toHaveProperty("product_id");
+  });
+});
+
+describe("replying", () => {
+  it("carries the merchant's identity, which is what stops it being filed as the platform", async () => {
+    const f = vi.fn().mockResolvedValue(ok({ data: { reply: { id: "r1" } } }));
+    vi.stubGlobal("fetch", f);
+
+    await replyToPlatformTicket({
+      tenantId: TENANT,
+      ticketId: "t1",
+      content: "Any update?",
+      authorName: "Priya",
+      authorEmail: "p@example.com",
+      authorUserId: "uid-1",
+    });
+
+    const { url, body } = lastCall(f);
+    expect(url.pathname).toBe("/v1/tickets/t1/replies");
+    expect(body).toMatchObject({
+      tenant_id: TENANT,
+      content: "Any update?",
+      author_name: "Priya",
+      author_email: "p@example.com",
+      author_user_id: "uid-1",
+    });
+  });
+
+  it("surfaces the API's own refusal message rather than a bare status", async () => {
+    const f = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: async () => ({ error: { code: "VALIDATION", message: "a merchant author needs a name" } }),
+    } as unknown as Response);
+    vi.stubGlobal("fetch", f);
+
+    const res = await replyToPlatformTicket({
+      tenantId: TENANT, ticketId: "t1", content: "hi", authorName: "",
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      // The envelope nests error as an OBJECT; the old API returned a string.
+      // Reading the old shape loses every message the API took care to write.
+      expect(res.error.message).toContain("merchant author needs a name");
+    }
+  });
+});

--- a/apps/admin/lib/api/tesserix-tickets.test.ts
+++ b/apps/admin/lib/api/tesserix-tickets.test.ts
@@ -37,11 +37,11 @@ function lastCall(m: ReturnType<typeof vi.fn>) {
 }
 
 beforeEach(() => {
-  process.env.PLATFORM_API_URL = "http://platform-api.tesserix.svc.cluster.local";
+  process.env.TESSERIX_PLATFORM_API_URL = "http://platform-api.tesserix.svc.cluster.local";
 });
 afterEach(() => {
   vi.unstubAllGlobals();
-  delete process.env.PLATFORM_API_URL;
+  delete process.env.TESSERIX_PLATFORM_API_URL;
 });
 
 describe("every ticket call", () => {

--- a/apps/admin/lib/api/tesserix.ts
+++ b/apps/admin/lib/api/tesserix.ts
@@ -1,29 +1,79 @@
-// tesserix-home internal API client. Used from the merchant admin to
-// file platform support tickets and read active platform announcements.
+// tesserix-home client. Used from the merchant admin to file platform support
+// tickets and read active platform announcements.
 //
-// The tesserix-home /api/internal/* endpoints are bearer-authenticated
-// with a shared secret (INTERNAL_API_TOKEN) that lives in both pods'
-// envs (provisioned via the GSM-backed ExternalSecret in each chart).
-// The mark8ly admin server is the trusted caller — it forwards the
+// TWO CHANNELS, and the split is temporary (tesserix-home#152):
+//
+//   TICKETS go to the PLATFORM API over the in-cluster ClusterIP, authenticated
+//   with a Zitadel machine token. That token identifies mark8ly, and the API
+//   scopes every read and write to the product it resolves to — so this client
+//   can no longer reach another product's queue even if it asked.
+//
+//   ANNOUNCEMENTS still go to apps/web's /api/internal/* with the shared
+//   INTERNAL_API_TOKEN, because the platform API has no announcements module
+//   yet. They move when it does; until then apps/web cannot be retired.
+//
+// The mark8ly admin server remains the trusted caller in both: it forwards the
 // merchant's identity (tenantId, name, email, userId) from its own
-// authenticated session, not from client input.
+// authenticated session, not from client input. What changed is that the
+// platform API now VERIFIES the product half of that claim rather than taking
+// it on trust, and records a merchant's reply as the merchant.
+
+import { getPlatformToken } from "./platform-token";
 
 const TESSERIX_INTERNAL_URL =
   process.env.TESSERIX_INTERNAL_URL ?? "https://tesserix.app";
 
+// Still used by ANNOUNCEMENTS, which have no platform-api counterpart yet and
+// so remain on apps/web's shared-secret channel (tesserix-home#152 step 3).
 const INTERNAL_API_TOKEN = process.env.INTERNAL_API_TOKEN ?? "";
 
 const PRODUCT_ID = "mark8ly";
 
+// The platform API, reached over the in-cluster ClusterIP.
+//
+// NOT tesserix.app: the platform API has no public path and no VirtualService.
+// Its address is a Service in another namespace, which this pod can reach —
+// verified from this namespace during the #152 rollout.
+const PLATFORM_API_URL =
+  process.env.PLATFORM_API_URL ?? "http://platform-api.tesserix.svc.cluster.local";
+
 function authHeaders(): Record<string, string> {
-  // X-Internal-Token rather than Authorization Bearer — the
-  // istio-ingress at tesserix.app has a RequestAuthentication policy
-  // that parses Authorization Bearer as JWT and rejects our opaque
-  // shared-secret token. A custom header bypasses that path.
+  // ANNOUNCEMENTS ONLY. X-Internal-Token rather than Authorization Bearer —
+  // the istio-ingress at tesserix.app has a RequestAuthentication policy that
+  // parses Authorization Bearer as JWT and rejects our opaque shared-secret
+  // token. A custom header bypasses that path.
   return {
     "Content-Type": "application/json",
     "X-Internal-Token": INTERNAL_API_TOKEN.trim(),
   };
+}
+
+// Headers for the platform API: a Zitadel machine token.
+//
+// Bearer is correct HERE even though the comment above says otherwise for
+// tesserix.app. That constraint belongs to the public ingress, and this call
+// never passes through it. Do not "fix" this to X-Internal-Token.
+async function platformHeaders(): Promise<Record<string, string>> {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${await getPlatformToken()}`,
+  };
+}
+
+// The platform API answers §4.4 envelopes: { success, data, meta } on success
+// and { error: { code, message } } on refusal. apps/web answered bare bodies
+// and a STRING error, so both shapes are read here — the string form until
+// announcements move, the object form for everything else.
+function refusalOf(body: Record<string, unknown> | null, status: number): { code: string; message: string } {
+  const err = body?.error;
+  if (err && typeof err === "object") {
+    const o = err as { code?: string; message?: string };
+    // The API's own message, which names what it declined. Falling back to a
+    // status here would discard the one thing the caller can act on.
+    return { code: o.code ?? `http_${status}`, message: o.message ?? messageForCode(o.code ?? "", status) };
+  }
+  const code = typeof err === "string" ? err : `http_${status}`;
+  return { code, message: messageForCode(code, status) };
 }
 
 // Discriminated result type so callers branch cleanly on success/failure
@@ -45,7 +95,9 @@ export interface PlatformTicket {
   priority: string;
   submitted_by_name: string;
   submitted_by_email: string;
-  submitted_by_user_id: string | null;
+  // submitted_by_user_id is deliberately ABSENT, matching the platform API's
+  // wire shape. It was declared here and never rendered; keeping it would
+  // promise a field every response now omits.
   resolved_at: string | null;
   created_at: string;
   updated_at: string;
@@ -74,17 +126,6 @@ export interface FilePlatformTicketInput {
   submittedByUserId?: string;
 }
 
-function configError(): Result<never> {
-  return {
-    ok: false,
-    error: {
-      code: "not_configured",
-      message:
-        "Platform support is not configured for this environment (missing INTERNAL_API_TOKEN).",
-    },
-  };
-}
-
 async function readJsonSafely(res: Response): Promise<Record<string, unknown> | null> {
   try {
     return (await res.json()) as Record<string, unknown>;
@@ -96,40 +137,29 @@ async function readJsonSafely(res: Response): Promise<Record<string, unknown> | 
 export async function filePlatformTicket(
   input: FilePlatformTicketInput,
 ): Promise<Result<PlatformTicket>> {
-  if (!INTERNAL_API_TOKEN) return configError();
-
   try {
-    const res = await fetch(
-      `${TESSERIX_INTERNAL_URL}/api/internal/platform-tickets`,
-      {
-        method: "POST",
-        headers: authHeaders(),
-        cache: "no-store",
-        body: JSON.stringify({
-          productId: PRODUCT_ID,
-          tenantId: input.tenantId,
-          subject: input.subject,
-          description: input.description,
-          priority: input.priority,
-          submittedByName: input.submittedByName,
-          submittedByEmail: input.submittedByEmail,
-          submittedByUserId: input.submittedByUserId,
-        }),
-      },
-    );
+    const res = await fetch(`${PLATFORM_API_URL}/v1/tickets`, {
+      method: "POST",
+      headers: await platformHeaders(),
+      cache: "no-store",
+      body: JSON.stringify({
+        // No product. The platform API takes it from the SCOPE this machine
+        // token resolves to, so a product sent here would be ignored at best
+        // and a claim to file into another product's queue at worst.
+        tenant_id: input.tenantId,
+        subject: input.subject,
+        description: input.description,
+        priority: input.priority,
+        submitted_by_name: input.submittedByName,
+        submitted_by_email: input.submittedByEmail,
+        submitted_by_user_id: input.submittedByUserId,
+      }),
+    });
     if (!res.ok) {
-      const body = await readJsonSafely(res);
-      const code = typeof body?.error === "string" ? body.error : `http_${res.status}`;
-      return {
-        ok: false,
-        error: {
-          code,
-          message: messageForCode(code, res.status),
-        },
-      };
+      return { ok: false, error: refusalOf(await readJsonSafely(res), res.status) };
     }
-    const body = (await res.json()) as { ticket: PlatformTicket };
-    return { ok: true, data: body.ticket };
+    const body = (await res.json()) as { data: { ticket: PlatformTicket } };
+    return { ok: true, data: body.data.ticket };
   } catch (err) {
     return {
       ok: false,
@@ -144,22 +174,22 @@ export async function filePlatformTicket(
 export async function listMyPlatformTickets(
   tenantId: string,
 ): Promise<PlatformTicket[]> {
-  if (!INTERNAL_API_TOKEN || !tenantId) return [];
+  // No tenant, no call. The platform API refuses a product caller that names
+  // none, so asking would be a guaranteed 422 — and on the OLD API the same
+  // omission returned every tenant's tickets, which is the bug this replaces.
+  if (!tenantId) return [];
 
   try {
-    const url = new URL(
-      `${TESSERIX_INTERNAL_URL}/api/internal/platform-tickets`,
-    );
-    url.searchParams.set("product", PRODUCT_ID);
-    url.searchParams.set("tenant_id", tenantId);
+    const url = new URL(`${PLATFORM_API_URL}/v1/tickets`);
+    url.searchParams.set("tenant", tenantId);
 
     const res = await fetch(url.toString(), {
-      headers: authHeaders(),
+      headers: await platformHeaders(),
       cache: "no-store",
     });
     if (!res.ok) return [];
-    const body = (await res.json()) as { rows: PlatformTicket[] };
-    return body.rows ?? [];
+    const body = (await res.json()) as { data?: { tickets?: PlatformTicket[] } };
+    return body.data?.tickets ?? [];
   } catch {
     return [];
   }
@@ -171,7 +201,7 @@ export interface PlatformTicketReply {
   author_type: "merchant" | "platform_admin";
   author_name: string;
   author_email: string | null;
-  author_user_id: string | null;
+  // Absent for the same reason as submitted_by_user_id above.
   content: string;
   created_at: string;
 }
@@ -185,21 +215,22 @@ export async function getMyPlatformTicket(
   tenantId: string,
   ticketId: string,
 ): Promise<PlatformTicketWithThread | null> {
-  if (!INTERNAL_API_TOKEN || !tenantId || !ticketId) return null;
+  if (!tenantId || !ticketId) return null;
 
   try {
-    const url = new URL(
-      `${TESSERIX_INTERNAL_URL}/api/internal/platform-tickets/${ticketId}`,
-    );
-    url.searchParams.set("product", PRODUCT_ID);
-    url.searchParams.set("tenant_id", tenantId);
+    const url = new URL(`${PLATFORM_API_URL}/v1/tickets/${ticketId}`);
+    url.searchParams.set("tenant", tenantId);
 
     const res = await fetch(url.toString(), {
-      headers: authHeaders(),
+      headers: await platformHeaders(),
       cache: "no-store",
     });
+    // A ticket outside this tenant answers 404, exactly as one that does not
+    // exist — so this null covers both, and deliberately cannot tell them
+    // apart. That non-disclosure is the API's, not an accident here.
     if (!res.ok) return null;
-    return (await res.json()) as PlatformTicketWithThread;
+    const body = (await res.json()) as { data: PlatformTicketWithThread };
+    return body.data;
   } catch {
     return null;
   }
@@ -217,38 +248,27 @@ export interface ReplyInput {
 export async function replyToPlatformTicket(
   input: ReplyInput,
 ): Promise<Result<PlatformTicketReply>> {
-  if (!INTERNAL_API_TOKEN) return configError();
-
   try {
-    const res = await fetch(
-      `${TESSERIX_INTERNAL_URL}/api/internal/platform-tickets/${input.ticketId}/replies`,
-      {
-        method: "POST",
-        headers: authHeaders(),
-        cache: "no-store",
-        body: JSON.stringify({
-          productId: PRODUCT_ID,
-          tenantId: input.tenantId,
-          content: input.content,
-          authorName: input.authorName,
-          authorEmail: input.authorEmail,
-          authorUserId: input.authorUserId,
-        }),
-      },
-    );
+    const res = await fetch(`${PLATFORM_API_URL}/v1/tickets/${input.ticketId}/replies`, {
+      method: "POST",
+      headers: await platformHeaders(),
+      cache: "no-store",
+      body: JSON.stringify({
+        tenant_id: input.tenantId,
+        content: input.content,
+        // The MERCHANT's identity, and the reason it is required: without it
+        // the platform API refuses rather than recording the reply as the
+        // support team, which is what it did before tesserix-home#568.
+        author_name: input.authorName,
+        author_email: input.authorEmail,
+        author_user_id: input.authorUserId,
+      }),
+    });
     if (!res.ok) {
-      const body = await readJsonSafely(res);
-      const code = typeof body?.error === "string" ? body.error : `http_${res.status}`;
-      return {
-        ok: false,
-        error: {
-          code,
-          message: messageForCode(code, res.status),
-        },
-      };
+      return { ok: false, error: refusalOf(await readJsonSafely(res), res.status) };
     }
-    const body = (await res.json()) as { reply: PlatformTicketReply };
-    return { ok: true, data: body.reply };
+    const body = (await res.json()) as { data: { reply: PlatformTicketReply } };
+    return { ok: true, data: body.data.reply };
   } catch (err) {
     return {
       ok: false,

--- a/apps/admin/lib/api/tesserix.ts
+++ b/apps/admin/lib/api/tesserix.ts
@@ -35,7 +35,7 @@ const PRODUCT_ID = "mark8ly";
 // Its address is a Service in another namespace, which this pod can reach —
 // verified from this namespace during the #152 rollout.
 const PLATFORM_API_URL =
-  process.env.PLATFORM_API_URL ?? "http://platform-api.tesserix.svc.cluster.local";
+  process.env.TESSERIX_PLATFORM_API_URL ?? "http://platform-api.tesserix.svc.cluster.local";
 
 function authHeaders(): Record<string, string> {
   // ANNOUNCEMENTS ONLY. X-Internal-Token rather than Authorization Bearer —


### PR DESCRIPTION
Phase 6b of tesserix-home#152. Repoints the merchant admin's **four ticket calls** from apps/web's shared-secret `/api/internal/*` to tesserix-home's platform API.

**Merge tesserix-k8s#970 FIRST and let it roll out.** This code mints a Zitadel token and refuses without the credentials that PR provides; landing this first breaks the merchant support surface until the chart follows.

## What moves, and what does not

| Call | Now |
|---|---|
| `filePlatformTicket` | `POST /v1/tickets` |
| `listMyPlatformTickets` | `GET /v1/tickets?tenant=` |
| `getMyPlatformTicket` | `GET /v1/tickets/{id}?tenant=` |
| `replyToPlatformTicket` | `POST /v1/tickets/{id}/replies` |
| **announcements** | **unchanged** — apps/web, shared secret |

Announcements stay because the platform API has **no announcements module**. Until one exists, apps/web cannot be retired and this client speaks to two backends. The header comment says so, rather than leaving the next reader to infer it from the one call that looks out of place.

## Three things that are not a URL swap

**The product is no longer sent.** It came from the request body before; the platform API takes it from the scope the machine token resolves to. A product field here would be a claim the API does not honour — and the ability to make that claim is the leak #152 exists to close.

**The tenant is now mandatory.** `listMyPlatformTickets("")` returns without calling out. On the old API that same omission returned **every tenant's tickets**; on the new one it is a refusal. Worth stating because the behaviour changed in the safe direction and silently.

**A reply carries the merchant's identity.** `author_name` is required and the API refuses without it. Before tesserix-home#568 a machine's reply was recorded as the support team; the fields are what make the reply the merchant's.

## Two response-shape changes

The platform API answers §4.4 envelopes — `{ success, data, meta }` — where apps/web answered bare bodies. `data.tickets`, not `rows`; `data.ticket`; `data.reply`. Reading the old key would have returned `[]` on every call and rendered as *"no tickets"* rather than as an error, so these are asserted in tests rather than eyeballed.

Refusals also nest: `{ error: { code, message } }` versus the old `{ error: "string" }`. `refusalOf` reads **both**, since announcements still return the old shape — and it prefers the API's own message, which names what it declined.

`submitted_by_user_id` and `author_user_id` are dropped from the types: the platform API deliberately omits them, and nothing in this app ever rendered them (checked, not assumed).

## `Authorization: Bearer`, despite the comment saying otherwise

`tesserix.ts` explains that `X-Internal-Token` exists because the istio-ingress at `tesserix.app` parses `Authorization: Bearer` as a JWT and rejects opaque tokens. **That constraint belongs to the public ingress**, and these calls go to an in-cluster ClusterIP that never passes through it. Verified from a pod in the `mark8ly` namespace: `200` with a Bearer token, `401` without.

Both comments now say which URL they are about, so the next person does not "restore" the custom header.

## The token minter

New: `lib/api/platform-token.ts`. mark8ly had no TypeScript client-credentials helper — the only existing one is Go, in `services/marketplace-api/internal/billing/consolecatalog/client.go`.

Two failure modes it is built around, both silent:

- **Scope.** A token minted with the audience scope alone carries no roles claim and is refused with **401**, indistinguishable from a bad credential. Both scopes are required and asserted in a test.
- **Expiry.** A token valid when checked can be expired when it arrives. It re-mints 60s early, so the support page does not fail for one merchant an hour.

It also shares one in-flight mint across concurrent callers (the support page fetches a listing and the banner together), and clears that promise on failure so one upstream blip does not poison the cache.

## Testing

15 new tests. Typecheck clean; the `lib/api` suite passes 38/38.

Mutants, each restored and re-run: removing the refresh skew, and leaving the in-flight promise set on failure — both caught.

The env-var rename in this branch has its own commit and its own reason: `PLATFORM_API_URL` was already taken in that container by mark8ly's own platform-api, which drives middleware tenant resolution. See tesserix-k8s#970.
