### PR TITLE
fix: accept invites through Zitadel instead of creating GIP accounts (#679)

### DIFF
--- a/apps/admin/app/accept-invite/actions.test.ts
+++ b/apps/admin/app/accept-invite/actions.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Issue #679 — the accept-invite server actions, asserted against the
+// bytes they actually put on the wire rather than against a mocked
+// module boundary. The bug being fixed was precisely a payload/endpoint
+// mismatch (a GIP uid written where the Zitadel login path reads an
+// email), so a test that stops at `expect(acceptInvitation).toHaveBeenCalled`
+// would not have caught it.
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    set: vi.fn(),
+    getAll: () => [],
+  }),
+}));
+
+import {
+  acceptInvite,
+  acceptInviteWithZitadel,
+} from "./actions";
+
+const PLATFORM = "http://localhost:8086";
+const ACCEPT_URL = `${PLATFORM}/api/v1/invitations/accept`;
+
+interface Call {
+  url: string;
+  body: Record<string, unknown>;
+}
+
+let calls: Call[] = [];
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Records every request and answers each URL from `handlers`. */
+function installFetch(handlers: Record<string, () => Response>) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : String(input);
+    calls.push({
+      url,
+      body: init?.body ? JSON.parse(init.body as string) : {},
+    });
+    const handler = Object.entries(handlers).find(([u]) => url === u)?.[1];
+    if (!handler) throw new Error(`unexpected fetch to ${url}`);
+    return handler();
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  calls = [];
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("acceptInviteWithZitadel", () => {
+  it("sends password + verified_email and no GIP uid or id_token", async () => {
+    installFetch({
+      [ACCEPT_URL]: () =>
+        jsonResponse(200, { data: { tenant_id: "tenant-1", role: "staff" } }),
+    });
+
+    const result = await acceptInviteWithZitadel({
+      token: "invite-token",
+      email: "staff@example.com",
+      password: "correct-horse-battery",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      tenantId: "tenant-1",
+      signInUrl: "/login/authorize?returnUrl=%2Fdashboard",
+    });
+
+    // Exactly one call, to platform-api's accept endpoint. Nothing to
+    // GIP's Identity Toolkit, nothing to auth-bff's /auth/auto-login.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(ACCEPT_URL);
+    expect(calls[0]!.body).toEqual({
+      token: "invite-token",
+      verified_email: "staff@example.com",
+      password: "correct-horse-battery",
+    });
+    // Spelled out separately: the absence of these keys is the fix.
+    expect(calls[0]!.body).not.toHaveProperty("uid");
+    expect(calls[0]!.body).not.toHaveProperty("id_token");
+  });
+
+  it("lowercases the email so the tuple it writes matches the one login reads", async () => {
+    installFetch({
+      [ACCEPT_URL]: () =>
+        jsonResponse(200, { data: { tenant_id: "tenant-1", role: "staff" } }),
+    });
+
+    await acceptInviteWithZitadel({
+      token: "invite-token",
+      email: "  Staff@Example.COM ",
+      password: "not-a-real-password",
+    });
+
+    expect(calls[0]!.body.verified_email).toBe("staff@example.com");
+  });
+
+  it("surfaces provisioning_failed with platform-api's own actionable message", async () => {
+    installFetch({
+      [ACCEPT_URL]: () =>
+        jsonResponse(500, {
+          error: "provisioning_failed",
+          message:
+            "we couldn't finish setting up your account — please try the invitation link again",
+        }),
+    });
+
+    const result = await acceptInviteWithZitadel({
+      token: "invite-token",
+      email: "staff@example.com",
+      password: "not-a-real-password",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("provisioning_failed");
+    expect(result.message).toContain("invitation link again");
+    expect(result.message).not.toMatch(/something went wrong/i);
+  });
+
+  it("falls back to actionable copy when provisioning_failed carries no message", async () => {
+    installFetch({
+      [ACCEPT_URL]: () => jsonResponse(500, { error: "provisioning_failed" }),
+    });
+
+    const result = await acceptInviteWithZitadel({
+      token: "invite-token",
+      email: "staff@example.com",
+      password: "not-a-real-password",
+    });
+
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("provisioning_failed");
+    // platform-api sent nothing usable; `HTTP 500` must not be what the
+    // invitee reads.
+    expect(result.message).not.toMatch(/^HTTP /);
+    expect(result.message).toMatch(/invitation link again/i);
+  });
+});
+
+describe("acceptInvite (GIP path, unchanged)", () => {
+  it("still sends token + uid + verified_email, and still auto-logs in against GIP", async () => {
+    installFetch({
+      [ACCEPT_URL]: () =>
+        jsonResponse(200, { data: { tenant_id: "tenant-1", role: "staff" } }),
+      "http://localhost:8087/auth/auto-login": () =>
+        jsonResponse(200, {
+          data: { uid: "gip-uid", email: "staff@example.com", tenant_id: "tenant-1" },
+        }),
+    });
+
+    const result = await acceptInvite({
+      token: "invite-token",
+      idToken: "gip-id-token",
+      uid: "gip-uid",
+      verifiedEmail: "staff@example.com",
+    });
+
+    expect(result).toEqual({ ok: true, tenantId: "tenant-1" });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.url).toBe(ACCEPT_URL);
+    // Byte-identical to the pre-#679 payload: no password, no name fields.
+    expect(calls[0]!.body).toEqual({
+      token: "invite-token",
+      uid: "gip-uid",
+      verified_email: "staff@example.com",
+    });
+    expect(calls[1]!.url).toBe("http://localhost:8087/auth/auto-login");
+    expect(calls[1]!.body).toMatchObject({
+      id_token: "gip-id-token",
+      workspace_tenant: "tenant-1",
+    });
+  });
+});

--- a/apps/admin/app/accept-invite/actions.ts
+++ b/apps/admin/app/accept-invite/actions.ts
@@ -1,6 +1,16 @@
 "use server";
 
-// Phase P — accept-invite server action.
+// Phase P — accept-invite server actions.
+//
+// Two actions, one per identity provider, branched on
+// `publicConfig.authProvider` by the form (never here — a server action
+// cannot see which provider the browser rendered against any more
+// cheaply than the caller can):
+//
+//   - acceptInvite            GIP.     Unchanged. Still the fallback.
+//   - acceptInviteWithZitadel Zitadel. See its own doc; issue #679.
+//
+// The GIP flow, described below, is left exactly as it was.
 //
 // The client gets the user to a GIP id_token via one of three paths
 // on the AcceptInviteForm:
@@ -40,12 +50,69 @@ export type AcceptInviteResult =
   | { ok: true; tenantId: string }
   | { ok: false; code: string; message: string };
 
+/**
+ * Where the Zitadel path sends the invitee once the accept succeeded.
+ *
+ * Not a shortcut: /login/authorize is the ONLY way to obtain a Zitadel
+ * `auth_request_id`, and every Zitadel sign-in call in this app
+ * (`signInWithZitadel`, `confirmZitadelTotp`, `finishZitadelGoogleSignIn`)
+ * requires one. Zitadel's login-client model redirects the browser to a
+ * fixed, instance-configured login URI (`/login`), so the accept page
+ * cannot be handed an auth request of its own — it has to hand the
+ * browser to the real login flow. The invitee re-enters the password
+ * they just chose; the alternative is stashing a password somewhere to
+ * replay it, which is not a trade worth making.
+ */
+const ZITADEL_SIGN_IN_URL = `/login/authorize?returnUrl=${encodeURIComponent("/dashboard")}`;
+
+/**
+ * The message shown when platform-api could not finish provisioning the
+ * invitee (Zitadel user, admin project grant, or the FGA tuples).
+ *
+ * Only used when platform-api sent no message of its own. Its message is
+ * preferred because it is written against the failure that actually
+ * happened; this is the floor, not the ceiling. What must never happen
+ * is `provisioning_failed` collapsing into "Something went wrong" —
+ * a half-provisioned teammate is invisible until they try to sign in,
+ * and the invitation is still pending, so "open the link again" is
+ * genuinely the fix.
+ */
+const PROVISIONING_FAILED_FALLBACK =
+  "We couldn't finish setting up your account. Your invite is still valid — open the invitation link again to retry, and contact the person who invited you if it keeps failing.";
+
+export interface AcceptInviteWithZitadelInput {
+  token: string;
+  /** The invitation's email. Normalised to lowercase before it leaves
+   *  this action: every email-keyed FGA tuple is lowercased, and the
+   *  Zitadel login path resolves membership by email, so a
+   *  `Staff@Example.com` sent verbatim would later miss its own
+   *  membership and produce the misleading "no store found". */
+  email: string;
+  password: string;
+}
+
+export type AcceptInviteWithZitadelResult =
+  | { ok: true; tenantId: string; signInUrl: string }
+  | { ok: false; code: string; message: string };
+
 function fail(err: unknown): {
   ok: false;
   code: string;
   message: string;
 } {
   if (err instanceof PlatformApiError || err instanceof AuthBffError) {
+    if (err.code === "provisioning_failed") {
+      // `HTTP 500` is what PlatformApiError synthesizes when the
+      // response carried no `message` — it is a stand-in for the
+      // absence of one, not copy, and must not reach the invitee.
+      const supplied = err.message?.trim() ?? "";
+      const usable = supplied && !/^HTTP \d+$/.test(supplied);
+      return {
+        ok: false,
+        code: err.code,
+        message: usable ? supplied : PROVISIONING_FAILED_FALLBACK,
+      };
+    }
     return { ok: false, code: err.code, message: err.message };
   }
   return {
@@ -53,6 +120,39 @@ function fail(err: unknown): {
     code: "unknown",
     message: err instanceof Error ? err.message : String(err),
   };
+}
+
+/**
+ * acceptInviteWithZitadel is the Zitadel-path counterpart of
+ * `acceptInvite`. Three things it deliberately does NOT do:
+ *
+ *   1. No GIP sign-up. Under Zitadel, platform-api's accept endpoint
+ *      creates the account — that is the whole point of #679. Creating
+ *      a GIP user here is the bug, not the flow.
+ *   2. No `uid`. The invitee has no provider account at this point, so
+ *      there is no id to send; platform-api's Accept no longer requires
+ *      one when a provisioner is wired.
+ *   3. No `autoLogin` / no id_token. auth-bff's /auth/auto-login verifies
+ *      a GIP id_token; there is none on this path. The invitee is sent
+ *      to the real Zitadel login flow instead (see ZITADEL_SIGN_IN_URL).
+ */
+export async function acceptInviteWithZitadel(
+  input: AcceptInviteWithZitadelInput,
+): Promise<AcceptInviteWithZitadelResult> {
+  try {
+    const accepted = await acceptInvitation({
+      token: input.token,
+      verified_email: input.email.trim().toLowerCase(),
+      password: input.password,
+    });
+    return {
+      ok: true,
+      tenantId: accepted.tenant_id,
+      signInUrl: ZITADEL_SIGN_IN_URL,
+    };
+  } catch (err) {
+    return fail(err);
+  }
 }
 
 export async function acceptInvite(

--- a/apps/admin/app/accept-invite/page.tsx
+++ b/apps/admin/app/accept-invite/page.tsx
@@ -3,6 +3,7 @@ import { BrandBar } from "@repo/ui/brand-bar";
 
 import { verifyInvitationToken, PlatformApiError } from "@/lib/api/platform-api";
 import { AcceptInviteForm } from "@/components/auth/AcceptInviteForm";
+import { publicConfig } from "@/lib/config";
 
 export const metadata: Metadata = { title: "Accept invite" };
 
@@ -15,10 +16,15 @@ interface PageProps {
  *
  * Verifies the invitation token server-side and renders either an
  * error message or the AcceptInviteForm with the verified context.
- * The form handles new-account (sign-up) and existing-account
+ * Under GIP the form handles new-account (sign-up) and existing-account
  * (sign-in OR Google) flows then calls the accept server action which
  * writes the FGA role tuple via platform-api and switches the session
  * onto the new tenant.
+ *
+ * Under Zitadel (`publicConfig.authProvider === "zitadel"`) the form
+ * collects a password and hands it to platform-api, which provisions
+ * the Zitadel user, the admin project grant and the FGA tuples, then
+ * sends the invitee into the normal Zitadel login flow. See issue #679.
  */
 export default async function AcceptInvitePage({ searchParams }: PageProps) {
   const { token = "" } = await searchParams;
@@ -54,7 +60,11 @@ export default async function AcceptInvitePage({ searchParams }: PageProps) {
               Accept your {invitation.role} invite with {invitation.email}.
             </p>
           </header>
-          <AcceptInviteForm token={token} invitation={invitation} />
+          <AcceptInviteForm
+            token={token}
+            invitation={invitation}
+            provider={publicConfig.authProvider}
+          />
         </div>
       </main>
     </>

--- a/apps/admin/components/auth/AcceptInviteForm.test.tsx
+++ b/apps/admin/components/auth/AcceptInviteForm.test.tsx
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Issue #679 — pins the provider branch on the accept-invite form:
+//   1. provider="zitadel" routes through acceptInviteWithZitadel with
+//      the password, and touches no GIP helper at all.
+//   2. provider unset keeps the GIP flow byte-for-byte — this is a
+//      branch, not a replacement.
+//   3. provisioning_failed renders as something the invitee can act on.
+//   4. The Google button, which authenticates through GIP end to end,
+//      is absent on the Zitadel path and present otherwise.
+
+const signUp = vi.fn();
+const signInWithPassword = vi.fn();
+const acceptInvite = vi.fn();
+const acceptInviteWithZitadel = vi.fn();
+const push = vi.fn();
+const refresh = vi.fn();
+
+vi.mock("@/lib/gip/signup", () => ({
+  signUp: (...args: unknown[]) => signUp(...args),
+  signInWithPassword: (...args: unknown[]) => signInWithPassword(...args),
+  signInWithGoogle: vi.fn(),
+  GIPError: class GIPError extends Error {
+    code: string;
+    constructor(code: string) {
+      super(code);
+      this.code = code;
+    }
+  },
+}));
+
+vi.mock("@/lib/gip/google-gsi", () => ({
+  getGoogleCredential: vi.fn(),
+}));
+
+vi.mock("@/app/accept-invite/actions", () => ({
+  acceptInvite: (...args: unknown[]) => acceptInvite(...args),
+  acceptInviteWithZitadel: (...args: unknown[]) =>
+    acceptInviteWithZitadel(...args),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, refresh }),
+}));
+
+import { AcceptInviteForm } from "./AcceptInviteForm";
+
+const invitation = {
+  email: "staff@example.com",
+  role: "staff",
+  tenant_slug: "bondi-store",
+  tenant_name: "The Bondi Store",
+} as never;
+
+const assign = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  signUp.mockResolvedValue({ idToken: "gip-id-token", uid: "gip-uid" });
+  signInWithPassword.mockResolvedValue({
+    idToken: "gip-id-token",
+    uid: "gip-uid",
+  });
+  acceptInvite.mockResolvedValue({ ok: true, tenantId: "tenant-1" });
+  acceptInviteWithZitadel.mockResolvedValue({
+    ok: true,
+    tenantId: "tenant-1",
+    signInUrl: "/login/authorize?returnUrl=%2Fdashboard",
+  });
+  assign.mockReset();
+  Object.defineProperty(window, "location", {
+    writable: true,
+    value: { assign, origin: "https://admin.mark8ly.com" },
+  });
+});
+
+async function submitExistingAccount(password = "correct-horse-battery") {
+  await userEvent.type(screen.getByLabelText(/^password$/i), password);
+  await userEvent.click(screen.getByRole("button", { name: /accept invite|sign in and accept/i }));
+}
+
+describe("AcceptInviteForm — Zitadel path", () => {
+  it("sends the password to acceptInviteWithZitadel and never calls GIP", async () => {
+    render(
+      <AcceptInviteForm
+        token="invite-token"
+        invitation={invitation}
+        provider="zitadel"
+      />,
+    );
+
+    await submitExistingAccount();
+
+    await waitFor(() =>
+      expect(acceptInviteWithZitadel).toHaveBeenCalledTimes(1),
+    );
+    expect(acceptInviteWithZitadel).toHaveBeenCalledWith({
+      token: "invite-token",
+      email: "staff@example.com",
+      password: "correct-horse-battery",
+    });
+    // No GIP account creation, no GIP sign-in, and therefore no
+    // id_token for the old accept action to forward.
+    expect(signUp).not.toHaveBeenCalled();
+    expect(signInWithPassword).not.toHaveBeenCalled();
+    expect(acceptInvite).not.toHaveBeenCalled();
+  });
+
+  it("hands the browser to the Zitadel login flow, not router.push", async () => {
+    render(
+      <AcceptInviteForm
+        token="invite-token"
+        invitation={invitation}
+        provider="zitadel"
+      />,
+    );
+
+    await submitExistingAccount();
+
+    await waitFor(() =>
+      expect(assign).toHaveBeenCalledWith("/login/authorize?returnUrl=%2Fdashboard"),
+    );
+    // /login/authorize is a Route Handler that writes cookies and 302s
+    // off-origin — a client-side navigation would never reach it.
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("renders a provisioning_failed message the invitee can act on", async () => {
+    acceptInviteWithZitadel.mockResolvedValue({
+      ok: false,
+      code: "provisioning_failed",
+      message:
+        "we couldn't finish setting up your account — please try the invitation link again",
+    });
+
+    render(
+      <AcceptInviteForm
+        token="invite-token"
+        invitation={invitation}
+        provider="zitadel"
+      />,
+    );
+
+    await submitExistingAccount();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/invitation link again/i);
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it("offers no Google button — that path is GIP end to end", () => {
+    render(
+      <AcceptInviteForm
+        token="invite-token"
+        invitation={invitation}
+        provider="zitadel"
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /continue with google/i }),
+    ).toBeNull();
+  });
+});
+
+describe("AcceptInviteForm — GIP path (unchanged)", () => {
+  it("signs in through GIP and calls the original acceptInvite action", async () => {
+    render(<AcceptInviteForm token="invite-token" invitation={invitation} />);
+
+    await submitExistingAccount();
+
+    await waitFor(() => expect(acceptInvite).toHaveBeenCalledTimes(1));
+    expect(signInWithPassword).toHaveBeenCalledWith(
+      "staff@example.com",
+      "correct-horse-battery",
+    );
+    expect(acceptInvite).toHaveBeenCalledWith({
+      token: "invite-token",
+      idToken: "gip-id-token",
+      uid: "gip-uid",
+      verifiedEmail: "staff@example.com",
+    });
+    expect(acceptInviteWithZitadel).not.toHaveBeenCalled();
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/dashboard"));
+  });
+
+  it("creates a GIP account in create mode", async () => {
+    render(<AcceptInviteForm token="invite-token" invitation={invitation} />);
+
+    await userEvent.click(screen.getByRole("tab", { name: /create an account/i }));
+    await userEvent.type(screen.getByLabelText(/^create password$/i), "pw-123456789");
+    await userEvent.type(
+      screen.getByLabelText(/^confirm password$/i),
+      "pw-123456789",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /create account and join store/i }),
+    );
+
+    await waitFor(() =>
+      expect(signUp).toHaveBeenCalledWith("staff@example.com", "pw-123456789"),
+    );
+    expect(acceptInviteWithZitadel).not.toHaveBeenCalled();
+  });
+
+  it("still offers the Google button", () => {
+    render(<AcceptInviteForm token="invite-token" invitation={invitation} />);
+
+    expect(
+      screen.getByRole("button", { name: /continue with google/i }),
+    ).toBeTruthy();
+  });
+});

--- a/apps/admin/components/auth/AcceptInviteForm.tsx
+++ b/apps/admin/components/auth/AcceptInviteForm.tsx
@@ -18,13 +18,24 @@ import {
   signInWithPassword,
   signUp,
 } from "@/lib/gip/signup";
-import { acceptInvite } from "@/app/accept-invite/actions";
+import {
+  acceptInvite,
+  acceptInviteWithZitadel,
+} from "@/app/accept-invite/actions";
 
 type Mode = "signin" | "create";
 
 interface AcceptInviteFormProps {
   token: string;
   invitation: InvitationVerifyResult;
+  /**
+   * Which identity provider backs this invite. Read defensively, the
+   * same way SignInForm reads it: only the exact literal `"zitadel"`
+   * switches this form onto the Zitadel path — anything else, including
+   * undefined, keeps the GIP flow byte-for-byte. Wired from
+   * `publicConfig.authProvider` by app/accept-invite/page.tsx.
+   */
+  provider?: string;
 }
 
 const baseSchema = z.object({
@@ -37,8 +48,10 @@ type FormValues = z.infer<typeof baseSchema>;
 export function AcceptInviteForm({
   token,
   invitation,
+  provider,
 }: AcceptInviteFormProps) {
   const router = useRouter();
+  const isZitadel = provider === "zitadel";
   const [mode, setMode] = useState<Mode>("signin");
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -78,6 +91,36 @@ export function AcceptInviteForm({
     });
   }
 
+  /**
+   * The Zitadel submit path. platform-api's accept endpoint provisions
+   * the Zitadel user (from this password, when the address has no
+   * account yet), the admin project grant, and both FGA tuples — so
+   * there is nothing for the browser to create first, and no GIP call
+   * of any kind on this path.
+   *
+   * On success the browser is handed to /login/authorize with a
+   * full-page navigation, not router.push: that route is a Route
+   * Handler that writes the PKCE/state cookies and 302s to Zitadel, and
+   * a client-side navigation would never reach it.
+   */
+  function acceptWithZitadel(password: string) {
+    startTransition(async () => {
+      const result = await acceptInviteWithZitadel({
+        token,
+        email: invitation.email,
+        password,
+      });
+      if (!result.ok) {
+        setSubmitError(result.message);
+        return;
+      }
+      setSuccess("Invite accepted. Taking you to sign in…");
+      if (typeof window !== "undefined") {
+        window.location.assign(result.signInUrl);
+      }
+    });
+  }
+
   function onValid(values: FormValues) {
     setSubmitError(null);
     setSuccess(null);
@@ -87,6 +130,11 @@ export function AcceptInviteForm({
         type: "validate",
         message: "Passwords do not match",
       });
+      return;
+    }
+
+    if (isZitadel) {
+      acceptWithZitadel(values.password);
       return;
     }
 
@@ -269,38 +317,56 @@ export function AcceptInviteForm({
             disabled={disabled}
             className="inline-flex h-12 w-full items-center justify-center rounded-md bg-primary px-6 text-base font-medium text-primary-foreground hover:bg-primary-hover disabled:cursor-not-allowed disabled:bg-ink-600"
           >
-            {pending
-              ? mode === "create"
-                ? "Creating account…"
-                : "Signing in…"
-              : mode === "create"
-                ? "Create account and join store"
-                : "Sign in and accept invite"}
+            {submitLabel({ pending, mode, isZitadel })}
           </button>
 
-          <div className="relative py-1">
-            <div
-              className="absolute inset-0 flex items-center"
-              aria-hidden="true"
-            >
-              <div className="w-full border-t border-border-subtle" />
-            </div>
-            <div className="relative flex justify-center">
-              <span className="bg-background px-3 text-xs uppercase tracking-wider text-foreground-tertiary">
-                or
-              </span>
-            </div>
-          </div>
+          {/* Google is deliberately absent on the Zitadel path.
 
-          <button
-            type="button"
-            onClick={handleGoogle}
-            disabled={disabled}
-            className="inline-flex h-11 w-full items-center justify-center gap-3 rounded-md border border-border bg-background-elevated px-6 text-sm font-medium text-foreground hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <GoogleMark />
-            {googlePending ? "Opening Google…" : "Continue with Google"}
-          </button>
+              The button below authenticates through GIP's GSI helper
+              end to end, so leaving it visible after the cutover would
+              silently create a GIP account for the invitee — the exact
+              defect #679 exists to fix, in miniature. Routing it through
+              the Zitadel IDP flow instead is not available here: that
+              flow needs a Zitadel `auth_request_id`, which only
+              /login/authorize can obtain (Zitadel redirects to a fixed
+              login URI), and accept provisions the account from a
+              password rather than from an IDP intent. An invitee who
+              wants Google can use it at /login once this accept has
+              provisioned their account. */}
+          {!isZitadel && (
+            <>
+              <div className="relative py-1">
+                <div
+                  className="absolute inset-0 flex items-center"
+                  aria-hidden="true"
+                >
+                  <div className="w-full border-t border-border-subtle" />
+                </div>
+                <div className="relative flex justify-center">
+                  <span className="bg-background px-3 text-xs uppercase tracking-wider text-foreground-tertiary">
+                    or
+                  </span>
+                </div>
+              </div>
+
+              <button
+                type="button"
+                onClick={handleGoogle}
+                disabled={disabled}
+                className="inline-flex h-11 w-full items-center justify-center gap-3 rounded-md border border-border bg-background-elevated px-6 text-sm font-medium text-foreground hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <GoogleMark />
+                {googlePending ? "Opening Google…" : "Continue with Google"}
+              </button>
+            </>
+          )}
+
+          {isZitadel && (
+            <p className="text-xs leading-5 text-foreground-tertiary">
+              We&apos;ll take you to the sign-in screen once your account is
+              ready.
+            </p>
+          )}
         </div>
       </form>
     </div>
@@ -319,6 +385,33 @@ const modeOptions: Array<{ value: Mode; title: string; body: string }> = [
     body: "First time joining Mark8ly.",
   },
 ];
+
+/**
+ * Submit-button copy. The Zitadel path never signs the invitee in from
+ * this form — it provisions the account and hands the browser to
+ * /login/authorize — so "Sign in and accept invite" would promise
+ * something this button does not do.
+ */
+function submitLabel({
+  pending,
+  mode,
+  isZitadel,
+}: {
+  pending: boolean;
+  mode: Mode;
+  isZitadel: boolean;
+}): string {
+  if (isZitadel) {
+    if (pending) return "Setting up your account…";
+    return mode === "create"
+      ? "Create account and join store"
+      : "Accept invite and continue";
+  }
+  if (pending) return mode === "create" ? "Creating account…" : "Signing in…";
+  return mode === "create"
+    ? "Create account and join store"
+    : "Sign in and accept invite";
+}
 
 function describeAuthError(err: unknown, mode: Mode): string {
   if (err instanceof GIPError) {

--- a/apps/admin/lib/api/platform-api.ts
+++ b/apps/admin/lib/api/platform-api.ts
@@ -492,15 +492,33 @@ export async function verifyInvitationToken(
 }
 
 /**
- * Accepts an invitation by writing the role tuple to FGA. The
- * caller must pass the verified GIP uid + email from the client
- * sign-in flow; platform-api re-checks the email against the
+ * Accepts an invitation by writing the role tuple to FGA.
+ *
+ * GIP path: the caller passes the verified GIP uid + email from the
+ * client sign-in flow; platform-api re-checks the email against the
  * invitation row and rejects on mismatch.
+ *
+ * Zitadel path: there is no `uid` to send — the invitee has no provider
+ * account yet, and creating it is what accept now does (see
+ * services/platform-api/internal/invitation/service.go's AcceptInput).
+ * The caller sends `password` instead, and platform-api provisions the
+ * Zitadel user, the admin project grant, and BOTH FGA tuples
+ * (email-keyed and Zitadel-uid-keyed) before marking the invitation
+ * accepted. `verified_email` is required on both paths and is still
+ * strictly matched against the invitation.
+ *
+ * `uid` stays required-shaped for the GIP caller by convention rather
+ * than by types: JSON.stringify drops undefined keys, so a GIP caller
+ * passing exactly {token, uid, verified_email} still emits a
+ * byte-identical body to the one this function has always sent.
  */
 export async function acceptInvitation(payload: {
   token: string;
-  uid: string;
+  uid?: string;
   verified_email: string;
+  password?: string;
+  first_name?: string;
+  last_name?: string;
 }): Promise<{ tenant_id: string; role: TenantRole }> {
   const res = await fetch(`${PLATFORM_API_URL}/api/v1/invitations/accept`, {
     method: "POST",

--- a/services/platform-api/cmd/server/main.go
+++ b/services/platform-api/cmd/server/main.go
@@ -324,18 +324,29 @@ func main() {
 	// TestMainCallsNewTenantClaimSetterUnconditionally exists to catch.
 	inviteClaims := newTenantClaimSetter(gipAdmin)
 
+	// Zitadel-path staff provisioning for invite-accept. Nil (and every
+	// downstream behaviour byte-identical to before) unless
+	// ZITADEL_ENABLED is true; a misconfiguration panics rather than
+	// quietly provisioning nobody — see newStaffProvisioner's doc.
+	staffProvisioner, provisionerErr := newStaffProvisioner(cfg)
+	if provisionerErr != nil {
+		log.Error("staff provisioner wiring", "err", provisionerErr)
+		panic(provisionerErr)
+	}
+
 	invitationSvc := invitation.NewService(invitation.Config{
-		Repo:       invitation.NewRepository(conn),
-		TenantRepo: tenantRepo,
-		StoreRepo:  storeRepo,
-		FGA:        fga,
-		Sender:     sender,
-		Loader:     templateLoader,
-		EmailFrom:  cfg.EmailFrom,
-		AcceptURL:  acceptURL,
-		Recorder:   invitationRec,
-		Audit:      auditClient,
-		Claims:     inviteClaims,
+		Repo:        invitation.NewRepository(conn),
+		TenantRepo:  tenantRepo,
+		StoreRepo:   storeRepo,
+		FGA:         fga,
+		Sender:      sender,
+		Loader:      templateLoader,
+		EmailFrom:   cfg.EmailFrom,
+		AcceptURL:   acceptURL,
+		Recorder:    invitationRec,
+		Audit:       auditClient,
+		Claims:      inviteClaims,
+		Provisioner: staffProvisioner,
 	})
 	invitationHandler := invitation.NewHandler(invitationSvc)
 

--- a/services/platform-api/cmd/server/provider_wiring.go
+++ b/services/platform-api/cmd/server/provider_wiring.go
@@ -83,6 +83,41 @@ func selectAccountProviders(cfg *config.Config, gipAdmin *gipadmin.AdminClient) 
 	return reset, del, nil
 }
 
+// newStaffProvisioner builds the invitation.StaffProvisioner that
+// invitation.Accept calls to create an invited teammate's Zitadel
+// account and grant them the mark8ly-admin project role.
+//
+// Returns a true nil (never a typed nil — same trap selectAccountProviders
+// documents) when cfg.ZitadelEnabled is false. That nil is what selects
+// the GIP path inside invitation.Service: under GIP the accept form
+// creates the account client-side before calling platform-api, so there
+// is nothing for the server to provision and the behaviour must stay
+// exactly as it was.
+//
+// When Zitadel IS enabled, a configuration problem is a startup failure,
+// not a degraded mode: the caller panics on the returned error, matching
+// selectAccountProviders. Silently wiring nil here would leave invite-
+// accept writing a GIP-shaped tuple into a Zitadel world and produce the
+// precise bug this function exists to fix — an invited teammate who is
+// told "we couldn't find a store for this account" at every sign-in.
+func newStaffProvisioner(cfg *config.Config) (invitation.StaffProvisioner, error) {
+	if !cfg.ZitadelEnabled {
+		return nil, nil
+	}
+	if err := cfg.ValidateZitadel(); err != nil {
+		return nil, err
+	}
+	client, err := zitadeladmin.New(zitadeladmin.Config{
+		BaseURL: cfg.ZitadelIssuer,
+		Token:   cfg.ZitadelLoginClientToken,
+		OrgID:   cfg.ZitadelOrgID,
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+	return zitadeladmin.NewStaffProvisioner(client, cfg.ZitadelAdminProjectID, []string{cfg.ZitadelStaffRoleKey})
+}
+
 // newTenantClaimSetter builds the invitation.TenantClaimSetter that
 // invitation/service.go calls on invite-accept to stamp the tenant_id
 // custom claim onto the invited user.

--- a/services/platform-api/cmd/server/provider_wiring_test.go
+++ b/services/platform-api/cmd/server/provider_wiring_test.go
@@ -143,6 +143,8 @@ func TestSelectAccountProviders_FlagSet_SelectsZitadel(t *testing.T) {
 		ZitadelIssuer:           "https://login.mark8ly.zitadel.cloud",
 		ZitadelLoginClientToken: "pat",
 		ZitadelOrgID:            "339070697432875523",
+		ZitadelAdminProjectID:   "389070376568619523",
+		ZitadelStaffRoleKey:     "mark8ly.staff",
 	}
 
 	reset, del, err := selectAccountProviders(cfg, admin)
@@ -181,5 +183,67 @@ func TestSelectAccountProviders_FlagSet_Misconfigured_FailsClearly(t *testing.T)
 	}
 	if del != nil {
 		t.Fatal("deleter must be nil on misconfiguration, never a silent GIP fallback")
+	}
+}
+
+// --- newStaffProvisioner: invite-accept provisioning selection --------
+
+// zitadelStaffConfig is a fully configured, Zitadel-enabled config.
+func zitadelStaffConfig() *config.Config {
+	return &config.Config{
+		ZitadelEnabled:          true,
+		ZitadelIssuer:           "https://login.mark8ly.zitadel.cloud",
+		ZitadelLoginClientToken: "pat",
+		ZitadelOrgID:            "339070697432875523",
+		ZitadelAdminProjectID:   "389070376568619523",
+		ZitadelStaffRoleKey:     "mark8ly.staff",
+	}
+}
+
+// TestNewStaffProvisioner_FlagUnset_StaysGenuinelyNil pins the GIP path:
+// with ZITADEL_ENABLED unset, invitation.Service must receive a truly nil
+// StaffProvisioner. A non-nil interface wrapping a nil pointer would flip
+// invitation.Accept onto the Zitadel branch and panic on first accept.
+func TestNewStaffProvisioner_FlagUnset_StaysGenuinelyNil(t *testing.T) {
+	p, err := newStaffProvisioner(&config.Config{ZitadelEnabled: false})
+	if err != nil {
+		t.Fatalf("newStaffProvisioner() error = %v, want nil", err)
+	}
+	if p != nil {
+		t.Fatal("provisioner must be a genuinely nil interface when Zitadel is disabled")
+	}
+}
+
+// TestNewStaffProvisioner_FlagSet_BuildsZitadelProvisioner pins that an
+// enabled, fully configured deployment gets the Zitadel provisioner.
+func TestNewStaffProvisioner_FlagSet_BuildsZitadelProvisioner(t *testing.T) {
+	p, err := newStaffProvisioner(zitadelStaffConfig())
+	if err != nil {
+		t.Fatalf("newStaffProvisioner() error = %v, want nil", err)
+	}
+	if _, ok := p.(*zitadeladmin.StaffProvisioner); !ok {
+		t.Fatalf("provisioner = %T, want *zitadeladmin.StaffProvisioner", p)
+	}
+}
+
+// TestNewStaffProvisioner_MissingProjectID_FailsClearly pins that the new
+// REQUIRED variable fails startup rather than provisioning teammates who
+// hold no grant on the admin project and therefore cannot sign in.
+func TestNewStaffProvisioner_MissingProjectID_FailsClearly(t *testing.T) {
+	cfg := zitadelStaffConfig()
+	cfg.ZitadelAdminProjectID = ""
+
+	p, err := newStaffProvisioner(cfg)
+	if err == nil {
+		t.Fatal("newStaffProvisioner() = nil error, want a misconfiguration error")
+	}
+	if !errors.Is(err, config.ErrZitadelNotConfigured) {
+		t.Fatalf("err = %v, want it to wrap config.ErrZitadelNotConfigured", err)
+	}
+	if !strings.Contains(err.Error(), "ZITADEL_ADMIN_PROJECT_ID") {
+		t.Errorf("err = %q, want it to name ZITADEL_ADMIN_PROJECT_ID", err.Error())
+	}
+	if p != nil {
+		t.Fatal("provisioner must be nil on misconfiguration")
 	}
 }

--- a/services/platform-api/internal/invitation/accept_zitadel_test.go
+++ b/services/platform-api/internal/invitation/accept_zitadel_test.go
@@ -1,0 +1,349 @@
+package invitation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mark8ly/platform-api/internal/authz"
+	"github.com/mark8ly/platform-api/internal/tenant"
+	apperrors "github.com/mark8ly/platform-api/pkg/errors"
+)
+
+// fakeProvisioner stands in for *zitadeladmin.StaffProvisioner. It is a
+// TRIPWIRE: it fails the test from inside ProvisionStaff when called
+// with anything other than the invitation's own email, because "we
+// provisioned the wrong address" is precisely the class of bug that
+// produced the production incident behind this code.
+type fakeProvisioner struct {
+	t          *testing.T
+	wantEmail  string
+	returnUID  string
+	err        error
+	calls      int
+	gotEmail   string
+	gotFirst   string
+	gotLast    string
+	gotPasswrd string
+}
+
+func (f *fakeProvisioner) ProvisionStaff(_ context.Context, email, firstName, lastName, password string) (string, error) {
+	f.calls++
+	f.gotEmail, f.gotFirst, f.gotLast, f.gotPasswrd = email, firstName, lastName, password
+	if f.wantEmail != "" && email != f.wantEmail {
+		f.t.Errorf("ProvisionStaff called with email %q, want the INVITATION's email %q — "+
+			"provisioning must never trust a caller-supplied address", email, f.wantEmail)
+	}
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.returnUID, nil
+}
+
+func zitadelAcceptInput() AcceptInput {
+	return AcceptInput{
+		Token:         "tok",
+		VerifiedEmail: "staff@example.com",
+		Password:      "correct-horse-battery-staple",
+		FirstName:     "Sam",
+		LastName:      "Staff",
+	}
+}
+
+// TestAccept_Zitadel_ProvisionsAndWritesBothIdentityKeys is the core
+// regression test for #679. The admin login path resolves membership by
+// EMAIL (apps/admin/app/login/actions.ts resolveWorkspaceTenant, which
+// runs BEFORE authentication) while the bearer-token API path resolves
+// by the Zitadel uid. Writing only one of them breaks the other reader.
+func TestAccept_Zitadel_ProvisionsAndWritesBothIdentityKeys(t *testing.T) {
+	repo := &fakeRepo{inv: pendingInvitation()}
+	fga := authz.NewFake()
+	prov := &fakeProvisioner{t: t, wantEmail: "staff@example.com", returnUID: "zid-1"}
+	claims := &fakeClaimSetter{}
+	svc := NewService(Config{Repo: repo, FGA: fga, Provisioner: prov, Claims: claims})
+
+	res, err := svc.Accept(context.Background(), zitadelAcceptInput())
+	if err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if res.TenantID != "tid-1" || res.Role != "staff" {
+		t.Errorf("result = %+v, want tenant tid-1 role staff", res)
+	}
+	if prov.calls != 1 {
+		t.Fatalf("ProvisionStaff called %d times, want 1", prov.calls)
+	}
+	if prov.gotFirst != "Sam" || prov.gotLast != "Staff" || prov.gotPasswrd != "correct-horse-battery-staple" {
+		t.Errorf("provisioned with (%q, %q, %q), want the submitted profile and password",
+			prov.gotFirst, prov.gotLast, prov.gotPasswrd)
+	}
+	if !fga.HasRole("staff@example.com", authz.RoleStaff, "tid-1") {
+		t.Error("no EMAIL-keyed tuple: the admin login path resolves membership by email and " +
+			"would show \"we couldn't find a store for this account\"")
+	}
+	if !fga.HasRole("zid-1", authz.RoleStaff, "tid-1") {
+		t.Error("no ZITADEL-UID-keyed tuple: the bearer-token API path resolves by the token's sub")
+	}
+	// The Zitadel uid, not the (absent) caller uid, is what gets recorded.
+	if repo.acceptedUID != "zid-1" {
+		t.Errorf("acceptedUID = %q, want the Zitadel uid zid-1", repo.acceptedUID)
+	}
+	// EnsureTenantClaim writes a GIP claim keyed by GIP uid; there is no
+	// GIP uid on this path, so calling it would only log a failure.
+	if claims.calls != 0 {
+		t.Errorf("EnsureTenantClaim called %d times on the Zitadel path, want 0", claims.calls)
+	}
+}
+
+// TestAccept_Zitadel_NoUIDRequired pins that the Zitadel path does not
+// demand a caller-supplied uid: the invitee has no provider account at
+// this point, which is exactly what Accept is about to create.
+func TestAccept_Zitadel_NoUIDRequired(t *testing.T) {
+	svc := NewService(Config{
+		Repo:        &fakeRepo{inv: pendingInvitation()},
+		FGA:         authz.NewFake(),
+		Provisioner: &fakeProvisioner{t: t, returnUID: "zid-1"},
+	})
+	in := zitadelAcceptInput()
+	in.UID = ""
+	if _, err := svc.Accept(context.Background(), in); err != nil {
+		t.Fatalf("Accept without a uid on the Zitadel path: %v", err)
+	}
+}
+
+// TestAccept_Zitadel_ProvisioningFailureAbortsEverything is the
+// half-provisioned-teammate guard. A tuple without a Zitadel account (or
+// without the admin-project grant, which ProvisionStaff also ensures)
+// looks like a working member and cannot sign in.
+func TestAccept_Zitadel_ProvisioningFailureAbortsEverything(t *testing.T) {
+	repo := &fakeRepo{inv: pendingInvitation()}
+	fga := authz.NewFake()
+	prov := &fakeProvisioner{t: t, err: errors.New("zitadel: 503")}
+	svc := NewService(Config{Repo: repo, FGA: fga, Provisioner: prov})
+
+	_, err := svc.Accept(context.Background(), zitadelAcceptInput())
+	if err == nil {
+		t.Fatal("Accept = nil error, want the accept to fail loudly rather than half-provision")
+	}
+	ae, ok := apperrors.As(err)
+	if !ok || ae.Code != "provisioning_failed" {
+		t.Errorf("err = %v, want an apperror coded provisioning_failed the accept form can show", err)
+	}
+	if fga.WriteCallCount() != 0 {
+		t.Errorf("%d FGA writes happened after provisioning failed, want 0 — "+
+			"a tuple with no provider account is the half-provisioned state this guards", fga.WriteCallCount())
+	}
+	if repo.acceptedID != "" {
+		t.Error("invitation was marked accepted despite provisioning failing; the link must stay usable")
+	}
+}
+
+// TestAccept_Zitadel_StoreScopedWritesBothKeys pins that the Phase R
+// store-scoped branch got the same treatment — it writes a store role
+// plus a tenant viewer back-fill, and both need both identity keys.
+func TestAccept_Zitadel_StoreScopedWritesBothKeys(t *testing.T) {
+	inv := pendingInvitation()
+	storeID := "store-1"
+	inv.StoreID = &storeID
+	inv.Role = "manager"
+
+	fga := authz.NewFake()
+	svc := NewService(Config{
+		Repo:        &fakeRepo{inv: inv},
+		FGA:         fga,
+		Provisioner: &fakeProvisioner{t: t, returnUID: "zid-1"},
+	})
+	if _, err := svc.Accept(context.Background(), zitadelAcceptInput()); err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	for _, subject := range []string{"staff@example.com", "zid-1"} {
+		if !fga.HasStoreRole(subject, "manager", "store-1") {
+			t.Errorf("no store manager tuple for %q", subject)
+		}
+		if !fga.HasRole(subject, authz.RoleViewer, "tid-1") {
+			t.Errorf("no tenant viewer back-fill for %q — session mint checks tenant membership", subject)
+		}
+	}
+}
+
+// TestAccept_Zitadel_DerivesProfileNamesFromEmail pins that a missing
+// name does not fail the accept: Zitadel rejects an empty givenName /
+// familyName, and a cosmetic field must never cost a teammate their
+// invitation.
+func TestAccept_Zitadel_DerivesProfileNamesFromEmail(t *testing.T) {
+	prov := &fakeProvisioner{t: t, returnUID: "zid-1"}
+	svc := NewService(Config{
+		Repo:        &fakeRepo{inv: pendingInvitation()},
+		FGA:         authz.NewFake(),
+		Provisioner: prov,
+	})
+	in := zitadelAcceptInput()
+	in.FirstName, in.LastName = "", ""
+	if _, err := svc.Accept(context.Background(), in); err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if prov.gotFirst == "" || prov.gotLast == "" {
+		t.Errorf("derived names = (%q, %q), want both non-empty — Zitadel rejects an empty profile name",
+			prov.gotFirst, prov.gotLast)
+	}
+}
+
+// --- The GIP path must be untouched -----------------------------------
+
+// TestAccept_GIP_UnchangedSingleUIDTuple pins flag-off behaviour: one
+// tuple, keyed by the caller-supplied GIP uid, and the tenant claim
+// still stamped. No email-keyed tuple appears.
+func TestAccept_GIP_UnchangedSingleUIDTuple(t *testing.T) {
+	repo := &fakeRepo{inv: pendingInvitation()}
+	fga := authz.NewFake()
+	claims := &fakeClaimSetter{}
+	svc := NewService(Config{Repo: repo, FGA: fga, Claims: claims})
+
+	if _, err := svc.Accept(context.Background(), acceptInput()); err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if !fga.HasRole("uid-staff", authz.RoleStaff, "tid-1") {
+		t.Error("the GIP uid tuple is missing")
+	}
+	if fga.HasRole("staff@example.com", authz.RoleStaff, "tid-1") {
+		t.Error("the GIP path must NOT start writing an email-keyed tuple")
+	}
+	if fga.WriteCallCount() != 1 {
+		t.Errorf("%d FGA writes, want exactly 1 on the GIP path", fga.WriteCallCount())
+	}
+	if claims.calls != 1 || claims.uid != "uid-staff" {
+		t.Errorf("EnsureTenantClaim called %d times with uid %q, want 1 with uid-staff", claims.calls, claims.uid)
+	}
+	if repo.acceptedUID != "uid-staff" {
+		t.Errorf("acceptedUID = %q, want uid-staff", repo.acceptedUID)
+	}
+}
+
+// TestAccept_GIP_StillRequiresUID pins that relaxing the uid requirement
+// for Zitadel did not relax it for GIP, where a missing uid means an
+// unusable tuple.
+func TestAccept_GIP_StillRequiresUID(t *testing.T) {
+	svc := NewService(Config{Repo: &fakeRepo{inv: pendingInvitation()}, FGA: authz.NewFake()})
+	in := acceptInput()
+	in.UID = ""
+
+	_, err := svc.Accept(context.Background(), in)
+	ae, ok := apperrors.As(err)
+	if !ok || ae.Code != "invalid_input" {
+		t.Fatalf("err = %v, want the unchanged invalid_input rejection", err)
+	}
+}
+
+func TestProfileNames(t *testing.T) {
+	cases := []struct{ first, last, email, wantFirst, wantLast string }{
+		{"Sam", "Staff", "a@b.com", "Sam", "Staff"},
+		{"", "", "jane.doe@example.com", "Jane", "Doe"},
+		{"", "", "jane@example.com", "Jane", "Jane"},
+		{"", "", "jane.van.doe@example.com", "Jane", "Van doe"},
+	}
+	for _, tc := range cases {
+		gotFirst, gotLast := profileNames(tc.first, tc.last, tc.email)
+		if gotFirst != tc.wantFirst || gotLast != tc.wantLast {
+			t.Errorf("profileNames(%q,%q,%q) = (%q,%q), want (%q,%q)",
+				tc.first, tc.last, tc.email, gotFirst, gotLast, tc.wantFirst, tc.wantLast)
+		}
+	}
+}
+
+// --- UpdateMemberRole keeps both identity keys in step ----------------
+
+type roleChangeRepo struct {
+	Repository
+	inv       *Invitation
+	updated   string
+	updateErr error
+}
+
+func (r *roleChangeRepo) FindAcceptedByEmail(_ context.Context, _, _ string) (*Invitation, error) {
+	return r.inv, nil
+}
+
+func (r *roleChangeRepo) UpdateRoleByEmail(_ context.Context, _, _, role string) error {
+	r.updated = role
+	return r.updateErr
+}
+
+type roleChangeTenantRepo struct {
+	tenant.Repository
+}
+
+func (roleChangeTenantRepo) GetByID(_ context.Context, id string) (*tenant.Tenant, error) {
+	return &tenant.Tenant{ID: id, Name: "Bondi", OwnerEmail: "owner@example.com"}, nil
+}
+
+func acceptedStaffInvitation() *Invitation {
+	uid := "zid-1"
+	return &Invitation{
+		ID:               "inv-1",
+		TenantID:         "tid-1",
+		Email:            "staff@example.com",
+		Role:             "staff",
+		Status:           StatusAccepted,
+		AcceptedByUserID: &uid,
+	}
+}
+
+// TestUpdateMemberRole_Zitadel_WritesBothKeys pins that a role change
+// reaches the EMAIL-keyed tuple too. Updating only the uid-keyed one
+// would look correct in the team list and change nothing at sign-in,
+// because the login path resolves membership by email.
+func TestUpdateMemberRole_Zitadel_WritesBothKeys(t *testing.T) {
+	fga := authz.NewFake()
+	ctx := context.Background()
+	// The actor must be an owner to be allowed to change roles.
+	if err := fga.WriteRole(ctx, "owner-uid", authz.RoleOwner, "tid-1"); err != nil {
+		t.Fatalf("seed actor role: %v", err)
+	}
+	svc := NewService(Config{
+		Repo:        &roleChangeRepo{inv: acceptedStaffInvitation()},
+		TenantRepo:  roleChangeTenantRepo{},
+		FGA:         fga,
+		Provisioner: &fakeProvisioner{t: t, returnUID: "zid-1"},
+	})
+
+	if _, err := svc.UpdateMemberRole(ctx, UpdateMemberRoleInput{
+		TenantID:    "tid-1",
+		TargetEmail: "staff@example.com",
+		NewRole:     "admin",
+		ActorUID:    "owner-uid",
+	}); err != nil {
+		t.Fatalf("UpdateMemberRole: %v", err)
+	}
+	if !fga.HasRole("zid-1", authz.RoleAdmin, "tid-1") {
+		t.Error("the uid-keyed tuple was not updated")
+	}
+	if !fga.HasRole("staff@example.com", authz.RoleAdmin, "tid-1") {
+		t.Error("the email-keyed tuple was not updated — the login path would keep reading the old role")
+	}
+}
+
+// TestUpdateMemberRole_GIP_WritesOnlyTheUIDKey pins that the GIP path
+// still writes exactly one tuple.
+func TestUpdateMemberRole_GIP_WritesOnlyTheUIDKey(t *testing.T) {
+	fga := authz.NewFake()
+	ctx := context.Background()
+	if err := fga.WriteRole(ctx, "owner-uid", authz.RoleOwner, "tid-1"); err != nil {
+		t.Fatalf("seed actor role: %v", err)
+	}
+	svc := NewService(Config{
+		Repo:       &roleChangeRepo{inv: acceptedStaffInvitation()},
+		TenantRepo: roleChangeTenantRepo{},
+		FGA:        fga,
+	})
+
+	if _, err := svc.UpdateMemberRole(ctx, UpdateMemberRoleInput{
+		TenantID:    "tid-1",
+		TargetEmail: "staff@example.com",
+		NewRole:     "admin",
+		ActorUID:    "owner-uid",
+	}); err != nil {
+		t.Fatalf("UpdateMemberRole: %v", err)
+	}
+	if fga.HasRole("staff@example.com", authz.RoleAdmin, "tid-1") {
+		t.Error("the GIP path must not start writing an email-keyed tuple")
+	}
+}

--- a/services/platform-api/internal/invitation/handler.go
+++ b/services/platform-api/internal/invitation/handler.go
@@ -155,6 +155,13 @@ type acceptRequest struct {
 	Token         string `json:"token"`
 	UID           string `json:"uid"`
 	VerifiedEmail string `json:"verified_email"`
+	// Zitadel path only — the password to create the invitee's account
+	// with, and the name to put on its profile. All three are ignored
+	// under GIP, where the account exists before this call. See
+	// AcceptInput's doc.
+	Password  string `json:"password,omitempty"`
+	FirstName string `json:"first_name,omitempty"`
+	LastName  string `json:"last_name,omitempty"`
 }
 
 func (h *Handler) accept(c *gin.Context) {
@@ -170,6 +177,9 @@ func (h *Handler) accept(c *gin.Context) {
 		Token:         req.Token,
 		UID:           req.UID,
 		VerifiedEmail: req.VerifiedEmail,
+		Password:      req.Password,
+		FirstName:     req.FirstName,
+		LastName:      req.LastName,
 	})
 	if err != nil {
 		respondError(c, err)

--- a/services/platform-api/internal/invitation/service.go
+++ b/services/platform-api/internal/invitation/service.go
@@ -25,18 +25,19 @@ import (
 // is small enough that the handler/service/repo split is the only
 // layering that matters.
 type Service struct {
-	repo       Repository
-	tenantRepo tenant.Repository
-	storeRepo  store.Repository
-	fga        authz.Client
-	sender     notification.Sender
-	loader     *notification.Loader
-	emailFrom  string
-	acceptURL  func(slug, token string) string
-	expiry     time.Duration
-	recorder   TokenRecorder
-	audit      *audit.Client // optional — emits staff lifecycle events
-	claims     TenantClaimSetter
+	repo        Repository
+	tenantRepo  tenant.Repository
+	storeRepo   store.Repository
+	fga         authz.Client
+	sender      notification.Sender
+	loader      *notification.Loader
+	emailFrom   string
+	acceptURL   func(slug, token string) string
+	expiry      time.Duration
+	recorder    TokenRecorder
+	audit       *audit.Client // optional — emits staff lifecycle events
+	claims      TenantClaimSetter
+	provisioner StaffProvisioner
 }
 
 // TenantClaimSetter writes the tenant_id custom claim onto a GIP user.
@@ -47,6 +48,26 @@ type Service struct {
 // failure here degrades mobile only.
 type TenantClaimSetter interface {
 	EnsureTenantClaim(ctx context.Context, uid, tenantID string) error
+}
+
+// StaffProvisioner makes an invited teammate a usable sign-in identity
+// in the identity provider and returns their provider user id.
+//
+// Non-nil ONLY on the Zitadel path (see cmd/server/provider_wiring.go's
+// newStaffProvisioner). Nil selects the GIP path, whose behaviour is
+// unchanged: GIP accounts are created client-side by the accept form
+// before it ever calls platform-api, so there is nothing to provision
+// server-side and the caller-supplied uid is already a real identity.
+//
+// Satisfied by *zitadeladmin.StaffProvisioner, which creates-or-
+// resolves the Zitadel user AND ensures the mark8ly-admin project
+// grant. Both halves are inside one call deliberately: a teammate with
+// an account but no grant cannot complete the OIDC flow (the project
+// sets projectRoleCheck: true and finalize returns
+// 403 OIDC-foSyH49RvL), so "provisioned" is not a state either half
+// can reach on its own.
+type StaffProvisioner interface {
+	ProvisionStaff(ctx context.Context, email, firstName, lastName, password string) (string, error)
 }
 
 // TokenRecorder is the narrow interface the service calls to publish
@@ -84,6 +105,10 @@ type Config struct {
 	Audit *audit.Client
 	// Claims writes the GIP tenant_id custom claim on accept. Optional.
 	Claims TenantClaimSetter
+	// Provisioner creates the invitee's identity-provider account and
+	// project grant on accept. Nil on the GIP path — see
+	// StaffProvisioner's doc.
+	Provisioner StaffProvisioner
 }
 
 // NewService constructs a Service.
@@ -92,18 +117,19 @@ func NewService(cfg Config) *Service {
 		cfg.Expiry = 72 * time.Hour
 	}
 	return &Service{
-		repo:       cfg.Repo,
-		tenantRepo: cfg.TenantRepo,
-		storeRepo:  cfg.StoreRepo,
-		fga:        cfg.FGA,
-		sender:     cfg.Sender,
-		loader:     cfg.Loader,
-		emailFrom:  cfg.EmailFrom,
-		acceptURL:  cfg.AcceptURL,
-		expiry:     cfg.Expiry,
-		recorder:   cfg.Recorder,
-		audit:      cfg.Audit,
-		claims:     cfg.Claims,
+		repo:        cfg.Repo,
+		tenantRepo:  cfg.TenantRepo,
+		storeRepo:   cfg.StoreRepo,
+		fga:         cfg.FGA,
+		sender:      cfg.Sender,
+		loader:      cfg.Loader,
+		emailFrom:   cfg.EmailFrom,
+		acceptURL:   cfg.AcceptURL,
+		expiry:      cfg.Expiry,
+		recorder:    cfg.Recorder,
+		audit:       cfg.Audit,
+		claims:      cfg.Claims,
+		provisioner: cfg.Provisioner,
 	}
 }
 
@@ -338,10 +364,29 @@ type AcceptInput struct {
 	// UID is the GIP UID of the accepting user. The caller
 	// (admin BFF) has verified the GIP id_token and extracted
 	// the uid + verified email.
+	//
+	// Required on the GIP path. On the Zitadel path it is optional and
+	// unused: the invitee has no provider account yet at this point —
+	// creating one is what Accept does — so there is no id for the
+	// caller to send.
 	UID string
 	// VerifiedEmail is the GIP token's verified email claim.
 	// Must match the invitation's email (case-insensitive).
+	//
+	// On the Zitadel path the caller sends the address the accept form
+	// was opened for; the invitation token itself, single-use and
+	// emailed to that address, is what attests to it.
 	VerifiedEmail string
+	// Password is the password to create the invitee's Zitadel account
+	// with. Zitadel path only, and only consulted when no account
+	// exists for the address yet. Ignored entirely on the GIP path,
+	// where the account already exists before Accept is called.
+	Password string
+	// FirstName / LastName populate the Zitadel profile. Optional —
+	// derived from the email local part when absent (Zitadel rejects
+	// an empty givenName/familyName).
+	FirstName string
+	LastName  string
 }
 
 // AcceptResult is returned on successful accept so the admin BFF
@@ -358,7 +403,14 @@ func (s *Service) Accept(ctx context.Context, in AcceptInput) (*AcceptResult, er
 	token := strings.TrimSpace(in.Token)
 	uid := strings.TrimSpace(in.UID)
 	verifiedEmail := strings.ToLower(strings.TrimSpace(in.VerifiedEmail))
-	if token == "" || uid == "" || verifiedEmail == "" {
+	if token == "" || verifiedEmail == "" {
+		return nil, apperrors.BadRequest("invalid_input", "token, uid, and verified_email are required")
+	}
+	// uid is required on the GIP path only. With a provisioner wired
+	// (Zitadel) the invitee has no provider account yet, so there is no
+	// uid to send — this call is what creates one. The message and code
+	// are unchanged so the GIP path's response is byte-identical.
+	if s.provisioner == nil && uid == "" {
 		return nil, apperrors.BadRequest("invalid_input", "token, uid, and verified_email are required")
 	}
 
@@ -383,6 +435,55 @@ func (s *Service) Accept(ctx context.Context, in AcceptInput) (*AcceptResult, er
 		)
 	}
 
+	// Provision the invitee in the identity provider (Zitadel path
+	// only; s.provisioner is nil under GIP). This runs BEFORE any FGA
+	// write and BEFORE MarkAccepted, and a failure aborts the whole
+	// accept with nothing written.
+	//
+	// That ordering is the point. The failure this exists to prevent is
+	// a HALF-provisioned teammate — tuples but no project grant, or a
+	// grant but no tuples — which is indistinguishable from a working
+	// account until they try to sign in and get "we couldn't find a
+	// store for this account" or a bare 403 from Zitadel's finalize.
+	// Diagnosing one of those took an hour of production archaeology.
+	// An invitation that stays pending and returns an error the accept
+	// form can show is recoverable by clicking the link again; an
+	// account that looks created and cannot sign in is not recoverable
+	// by the merchant at all.
+	subjects := []string{uid}
+	if s.provisioner != nil {
+		first, last := profileNames(in.FirstName, in.LastName, inv.Email)
+		zitadelUID, err := s.provisioner.ProvisionStaff(ctx, inv.Email, first, last, in.Password)
+		if err != nil {
+			return nil, apperrors.Wrap(err, 500, "provisioning_failed",
+				"we couldn't finish setting up your account — please try the invitation link again")
+		}
+		// Both identity keys, deliberately. Three readers disagree on
+		// what a member is keyed by:
+		//
+		//   - admin sign-in (apps/admin/app/login/actions.ts,
+		//     resolveWorkspaceTenant) looks membership up by EMAIL on
+		//     the Zitadel path — it has no uid at tenant-resolution
+		//     time, which runs BEFORE authentication;
+		//   - the bearer-token API path resolves by the Zitadel uid
+		//     (the token's `sub`);
+		//   - this code used to write only the caller-supplied GIP uid,
+		//     which after the Zitadel cutover matches neither.
+		//
+		// Writing one key breaks the other reader: email-only 403s
+		// every API call, uid-only puts the teammate back on "we
+		// couldn't find a store for this account" at the login screen.
+		// Writing both is what the one working owner account
+		// (demo@mark8ly.com) already has, and it needs no change to the
+		// login path — which is why it wins over the tidier
+		// alternative of teaching every reader one canonical key.
+		subjects = []string{inv.Email, zitadelUID}
+		// The Zitadel uid, not the caller's, is what gets recorded as
+		// the accepting user: it is the id the API path sees and the
+		// one UpdateMemberRole later writes tuples for.
+		uid = zitadelUID
+	}
+
 	// Write the FGA role tuple. Phase R branches on scope:
 	// store-scoped invitations write to the store object; tenant-
 	// scoped invitations keep the Phase P tenant-level WriteRole.
@@ -399,18 +500,20 @@ func (s *Service) Accept(ctx context.Context, in AcceptInput) (*AcceptResult, er
 	//
 	// Degraded mode (fga nil) skips — dev-only, never prod.
 	if s.fga != nil {
-		if inv.StoreID != nil && *inv.StoreID != "" {
-			if err := s.fga.WriteRoleObject(ctx, uid, inv.Role, "store", *inv.StoreID); err != nil {
-				return nil, apperrors.Wrap(err, 500, "authz_write_failed", "failed to grant store role")
-			}
-			// Back-fill a tenant viewer so session mint works.
-			if err := s.fga.WriteRole(ctx, uid, authz.RoleViewer, inv.TenantID); err != nil {
-				return nil, apperrors.Wrap(err, 500, "authz_write_failed", "failed to grant tenant viewer")
-			}
-		} else {
-			role := authz.Role(inv.Role)
-			if err := s.fga.WriteRole(ctx, uid, role, inv.TenantID); err != nil {
-				return nil, apperrors.Wrap(err, 500, "authz_write_failed", "failed to grant role")
+		for _, subject := range subjects {
+			if inv.StoreID != nil && *inv.StoreID != "" {
+				if err := s.fga.WriteRoleObject(ctx, subject, inv.Role, "store", *inv.StoreID); err != nil {
+					return nil, apperrors.Wrap(err, 500, "authz_write_failed", "failed to grant store role")
+				}
+				// Back-fill a tenant viewer so session mint works.
+				if err := s.fga.WriteRole(ctx, subject, authz.RoleViewer, inv.TenantID); err != nil {
+					return nil, apperrors.Wrap(err, 500, "authz_write_failed", "failed to grant tenant viewer")
+				}
+			} else {
+				role := authz.Role(inv.Role)
+				if err := s.fga.WriteRole(ctx, subject, role, inv.TenantID); err != nil {
+					return nil, apperrors.Wrap(err, 500, "authz_write_failed", "failed to grant role")
+				}
 			}
 		}
 	}
@@ -425,7 +528,12 @@ func (s *Service) Accept(ctx context.Context, in AcceptInput) (*AcceptResult, er
 	// so a failure here logs (mobile shows its "No store yet" empty
 	// state until the claim lands — e.g. via the backfill CLI) rather
 	// than failing the accept.
-	if s.claims != nil {
+	//
+	// Skipped on the Zitadel path: uid is a Zitadel user id there, and
+	// EnsureTenantClaim writes a GIP custom claim keyed by GIP uid. The
+	// call would resolve nothing, fail, and log a misleading line every
+	// time. The GIP path is untouched.
+	if s.claims != nil && s.provisioner == nil {
 		if err := s.claims.EnsureTenantClaim(ctx, uid, inv.TenantID); err != nil {
 			log.Printf("invitation.Accept: ensure tenant claim for uid %s tenant %s: %v", uid, inv.TenantID, err)
 		}
@@ -556,6 +664,19 @@ func (s *Service) UpdateMemberRole(ctx context.Context, in UpdateMemberRoleInput
 	if s.fga != nil {
 		if err := s.fga.WriteRole(ctx, targetUID, authz.Role(newRole), tenantID); err != nil {
 			return nil, apperrors.Wrap(err, 500, "authz_write_failed", "failed to write new role")
+		}
+		// Zitadel path: Accept wrote BOTH a uid-keyed and an
+		// email-keyed tuple because the login path resolves membership
+		// by email (see Accept's subjects comment). A role change that
+		// updated only the uid-keyed tuple would leave the login path
+		// still reading the OLD role — the change would appear to work
+		// in the team list and do nothing at sign-in. Kept behind the
+		// provisioner nil-check so the GIP path writes exactly the one
+		// tuple it always has.
+		if s.provisioner != nil {
+			if err := s.fga.WriteRole(ctx, targetEmail, authz.Role(newRole), tenantID); err != nil {
+				return nil, apperrors.Wrap(err, 500, "authz_write_failed", "failed to write new role")
+			}
 		}
 	}
 
@@ -751,6 +872,53 @@ func newToken() (string, string, error) {
 	}
 	plain := hex.EncodeToString(buf)
 	return plain, hashToken(plain), nil
+}
+
+// profileNames returns the givenName/familyName to create a Zitadel
+// profile with. Zitadel rejects an empty value for either, so when the
+// accept form did not collect a name we derive one from the email local
+// part rather than failing the accept over a cosmetic field: the user
+// can correct it in their profile, but they cannot un-fail an accept.
+//
+// "jane.doe@x.com" -> ("Jane", "Doe"); "jane@x.com" -> ("Jane", "Jane").
+func profileNames(first, last, email string) (string, string) {
+	first = strings.TrimSpace(first)
+	last = strings.TrimSpace(last)
+	if first != "" && last != "" {
+		return first, last
+	}
+	local := email
+	if at := strings.Index(local, "@"); at > 0 {
+		local = local[:at]
+	}
+	parts := strings.FieldsFunc(local, func(r rune) bool {
+		return r == '.' || r == '_' || r == '-' || r == '+'
+	})
+	derivedFirst, derivedLast := local, local
+	if len(parts) > 0 {
+		derivedFirst = titleCase(parts[0])
+		derivedLast = derivedFirst
+		if len(parts) > 1 {
+			derivedLast = titleCase(strings.Join(parts[1:], " "))
+		}
+	}
+	if first == "" {
+		first = derivedFirst
+	}
+	if last == "" {
+		last = derivedLast
+	}
+	return first, last
+}
+
+// titleCase upper-cases the first rune only. strings.Title is
+// deprecated and golang.org/x/text/cases would be a new dependency for
+// a display-name fallback.
+func titleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
 }
 
 func hashToken(plain string) string {

--- a/services/platform-api/internal/tenant/service.go
+++ b/services/platform-api/internal/tenant/service.go
@@ -59,6 +59,21 @@ func (s *Service) ListMemberTenants(ctx context.Context, uid string) ([]Membersh
 	if uid == "" {
 		return nil, apperrors.BadRequest("invalid_uid", "uid is required")
 	}
+	// The identity key is an EMAIL on the Zitadel sign-in path (see
+	// resolveWorkspaceTenant in apps/admin/app/login/actions.ts: tenant
+	// resolution runs before authentication, when no uid exists yet) and
+	// a provider uid otherwise. FGA tuple subjects are exact strings, and
+	// every email-keyed tuple we write is lowercased — invitation.Create
+	// lowercases the address before it is ever stored. A merchant who
+	// types "Sam@Example.com" into the login form would otherwise miss
+	// their own membership and be told no store exists for the account.
+	//
+	// Only the email form is folded: provider uids ARE case-sensitive
+	// (a GIP uid looks like "6GrzK9LDKHV4Ix2BgtaMnrzunih2"), and none of
+	// them contain "@".
+	if strings.Contains(uid, "@") {
+		uid = strings.ToLower(uid)
+	}
 
 	if s.fga == nil {
 		t, err := s.repo.GetByOwnerUserID(ctx, uid)

--- a/services/platform-api/internal/tenant/service_test.go
+++ b/services/platform-api/internal/tenant/service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"gorm.io/gorm"
 
+	"github.com/mark8ly/platform-api/internal/authz"
 	apperrors "github.com/mark8ly/platform-api/pkg/errors"
 )
 
@@ -295,5 +296,49 @@ func TestService_GetByOwnerUserID_NotFound(t *testing.T) {
 	ae, ok := apperrors.As(err)
 	if !ok || ae.Code != "tenant_not_found" {
 		t.Errorf("expected tenant_not_found, got %v", err)
+	}
+}
+
+// TestListMemberTenants_EmailIdentityKeyIsCaseFolded pins the #679
+// casing footgun: on the Zitadel sign-in path the identity key is the
+// EMAIL the merchant typed, resolved BEFORE authentication, while every
+// email-keyed FGA tuple we write is lowercased. Without folding, typing
+// "Staff@Example.com" reads as a different subject and the merchant is
+// told no store exists for their account.
+func TestListMemberTenants_EmailIdentityKeyIsCaseFolded(t *testing.T) {
+	repo := newFakeRepo()
+	repo.seed(&Tenant{ID: "tid-1", Name: "Bondi"})
+	fga := authz.NewFake()
+	if err := fga.WriteRole(context.Background(), "staff@example.com", authz.RoleStaff, "tid-1"); err != nil {
+		t.Fatalf("seed tuple: %v", err)
+	}
+	svc := NewService(repo, fga)
+
+	got, err := svc.ListMemberTenants(context.Background(), "Staff@Example.COM")
+	if err != nil {
+		t.Fatalf("ListMemberTenants: %v", err)
+	}
+	if len(got) != 1 || got[0].TenantID != "tid-1" {
+		t.Fatalf("memberships = %+v, want the tid-1 membership", got)
+	}
+}
+
+// TestListMemberTenants_UIDIsNotCaseFolded pins the other half: provider
+// uids are case-sensitive and must pass through untouched.
+func TestListMemberTenants_UIDIsNotCaseFolded(t *testing.T) {
+	repo := newFakeRepo()
+	repo.seed(&Tenant{ID: "tid-1", Name: "Bondi"})
+	fga := authz.NewFake()
+	if err := fga.WriteRole(context.Background(), "6GrzK9LDKHV4Ix2BgtaMnrzunih2", authz.RoleStaff, "tid-1"); err != nil {
+		t.Fatalf("seed tuple: %v", err)
+	}
+	svc := NewService(repo, fga)
+
+	got, err := svc.ListMemberTenants(context.Background(), "6GrzK9LDKHV4Ix2BgtaMnrzunih2")
+	if err != nil {
+		t.Fatalf("ListMemberTenants: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("memberships = %+v, want the uid membership preserved verbatim", got)
 	}
 }

--- a/services/platform-api/internal/zitadeladmin/client.go
+++ b/services/platform-api/internal/zitadeladmin/client.go
@@ -222,7 +222,17 @@ func (c *Client) do(ctx context.Context, method, path string, body, out any, sco
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 		id := readZitadelErrorID(respBody)
-		return fmt.Errorf("zitadeladmin: %s %s: status %d: %s: %w", method, logPath, resp.StatusCode, id, classifyError(resp.StatusCode, respBody, id))
+		var parsed zitadelErrorBody
+		_ = json.Unmarshal(respBody, &parsed) // best-effort; a malformed body just leaves the zero value
+		return &apiError{
+			method:   method,
+			logPath:  logPath,
+			status:   resp.StatusCode,
+			id:       id,
+			grpcCode: parsed.Code,
+			message:  parsed.Message,
+			sentinel: classifyError(resp.StatusCode, respBody, id),
+		}
 	}
 	if out == nil {
 		return nil
@@ -231,6 +241,47 @@ func (c *Client) do(ctx context.Context, method, path string, body, out any, sco
 		return fmt.Errorf("zitadeladmin: decode %s %s: %v: %w", method, logPath, err, gipadmin.ErrUnavailable)
 	}
 	return nil
+}
+
+// apiError is the error do() returns for every non-2xx Zitadel response.
+//
+// It exists so a caller can branch on Zitadel's STABLE details[0].id
+// (see readZitadelErrorID and zitadelErrorIDSentinels) without parsing
+// an error string. EnsureHumanUser needs exactly that: "this email is
+// already a Zitadel user" (id V3-DKcYh) is a resolvable condition, not a
+// failure, and it arrives as a 409 that classifyError deliberately maps
+// to the coarse ErrUnavailable — indistinguishable from a real outage if
+// all you have is the sentinel.
+//
+// Error() reproduces byte-for-byte the string do() used to build with
+// fmt.Errorf, and Unwrap returns the same gipadmin sentinel, so every
+// existing errors.Is check downstream (internal/auth/handler.go and
+// service.go branch on six of them) keeps behaving identically.
+type apiError struct {
+	method   string
+	logPath  string
+	status   int
+	id       string
+	grpcCode int
+	message  string
+	sentinel error
+}
+
+func (e *apiError) Error() string {
+	return fmt.Sprintf("zitadeladmin: %s %s: status %d: %s: %v", e.method, e.logPath, e.status, e.id, e.sentinel)
+}
+
+func (e *apiError) Unwrap() error { return e.sentinel }
+
+// errorID returns Zitadel's stable details[0].id for err, or "" when err
+// did not come from a Zitadel response (or carried no id). "" must never
+// be compared against a real id — treat it only as "no id available".
+func errorID(err error) string {
+	var ae *apiError
+	if errors.As(err, &ae) {
+		return ae.id
+	}
+	return ""
 }
 
 // zitadelErrorBody is the Zitadel v2 grpc-gateway error envelope:

--- a/services/platform-api/internal/zitadeladmin/provision.go
+++ b/services/platform-api/internal/zitadeladmin/provision.go
@@ -1,0 +1,299 @@
+package zitadeladmin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/mark8ly/platform-api/internal/gipadmin"
+)
+
+// This file holds the PROVISIONING half of the Zitadel admin client:
+// creating an invited teammate's account and granting them the admin
+// project role. It is separate from client.go's three account
+// operations (password-reset send/confirm, delete) because it has a
+// different caller (internal/invitation) and a different failure
+// posture — see EnsureProjectGrant's doc.
+//
+// Every request shape below was VERIFIED against the live TESSERIX
+// Zitadel instance on 2026-09-04/05 while hand-provisioning the first
+// invited staff member; the exceptions are called out inline.
+//
+// The protojson rules recorded in this package's doc comment apply
+// here too and are load-bearing:
+//
+//   - Oneofs are FLATTENED. Nothing below wraps a variant in a key
+//     named after its oneof.
+//   - Zero values are ELIDED. "isVerified": true must be sent
+//     explicitly; omitting it (or sending the field's zero value)
+//     produces an UNVERIFIED email, and an unverified email makes the
+//     user invisible to resolveUserIDByEmail, which requires
+//     human.email.isVerified. That would turn a successful create into
+//     a user nobody can ever look up again.
+
+// zitadelErrIDUserAlreadyExists is the stable details[0].id Zitadel
+// returns from POST /v2/users/human when a user with that email
+// already exists in the org. VERIFIED live: it arrives as an HTTP 409
+// whose grpc code is 6 (AlreadyExists).
+//
+// classifyError maps that 409 to gipadmin.ErrUnavailable (its default
+// branch — "a wrong guess here reads as something it is not"), which
+// is the right default for the account operations but useless here:
+// "already exists" is the single most common outcome of re-accepting
+// an invitation, and it must resolve to the existing user rather than
+// abort the accept. Hence the id check rather than a status check.
+const zitadelErrIDUserAlreadyExists = "V3-DKcYh"
+
+// ResolveUserIDByEmail is the exported form of resolveUserIDByEmail.
+// Callers outside this package (internal/invitation, via the wiring in
+// cmd/server) need the same email -> user id resolution the password
+// reset path uses, with the same guarantees: scoped to Config.OrgID,
+// requires a VERIFIED email, refuses an ambiguous match rather than
+// picking one (ErrAmbiguousEmail), and returns gipadmin.ErrUserNotFound
+// on zero matches.
+func (c *Client) ResolveUserIDByEmail(ctx context.Context, email string) (string, error) {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return "", fmt.Errorf("zitadeladmin: email is required")
+	}
+	return c.resolveUserIDByEmail(ctx, email)
+}
+
+// HumanUser is the input to EnsureHumanUser.
+type HumanUser struct {
+	Email string
+	// FirstName / LastName populate Zitadel's required profile block.
+	// Callers that have no real name should pass something derived
+	// from the email rather than empty strings — Zitadel rejects an
+	// empty givenName/familyName.
+	FirstName string
+	LastName  string
+	// Password is set with changeRequired=false so the invitee can
+	// sign in immediately with what they just typed. Required when the
+	// user does not already exist.
+	Password string
+}
+
+// EnsureHumanUser creates the invitee's Zitadel account and returns its
+// user id, or returns the id of the account that already exists for
+// that email.
+//
+// The request body is the shape VERIFIED working in production:
+//
+//	POST /v2/users/human
+//	{"organization":{"orgId":…},
+//	 "profile":{"givenName":…,"familyName":…},
+//	 "email":{"email":…,"isVerified":true},
+//	 "password":{"password":…,"changeRequired":false}}
+//
+// isVerified is true deliberately and is NOT a shortcut: the invitation
+// token that got the caller here was emailed to this exact address and
+// is single-use, so possession of it IS proof of control of the
+// mailbox — the same attestation a verification email would produce.
+// It also has to be true for the account to be findable again:
+// resolveUserIDByEmail (and zitadellogin.FindUserByVerifiedEmail in
+// auth-bff) both require human.email.isVerified, so an unverified
+// invitee would be created once and then be unresolvable forever.
+//
+// "Already exists" is resolved, not failed. Re-accepting an invitation,
+// accepting a second invitation to a different tenant with the same
+// address, or a retry after a partial failure all land here, and in
+// every one of those cases the correct outcome is "use the account that
+// is already there" — the caller still needs its id to write the grant
+// and the FGA tuples. The supplied Password is deliberately ignored on
+// that branch: silently resetting an existing merchant's password from
+// an invitation-accept form would be an account takeover primitive.
+func (c *Client) EnsureHumanUser(ctx context.Context, in HumanUser) (string, error) {
+	email := strings.TrimSpace(in.Email)
+	if email == "" {
+		return "", fmt.Errorf("zitadeladmin: email is required")
+	}
+	first := strings.TrimSpace(in.FirstName)
+	last := strings.TrimSpace(in.LastName)
+	if first == "" || last == "" {
+		return "", fmt.Errorf("zitadeladmin: first and last name are required to create a human user")
+	}
+	if in.Password == "" {
+		return "", fmt.Errorf("zitadeladmin: password is required to create a human user")
+	}
+
+	body := map[string]any{
+		"organization": map[string]any{"orgId": c.orgID},
+		"profile": map[string]any{
+			"givenName":  first,
+			"familyName": last,
+		},
+		"email": map[string]any{
+			"email":      email,
+			"isVerified": true,
+		},
+		"password": map[string]any{
+			"password":       in.Password,
+			"changeRequired": false,
+		},
+	}
+	var wire struct {
+		UserID string `json:"userId"`
+	}
+	// The org is carried in the BODY here (organization.orgId), which is
+	// what the verified-working request does; the org header is not sent
+	// so the two cannot disagree about which org the user lands in.
+	err := c.do(ctx, http.MethodPost, "/v2/users/human", body, &wire, false, withLogPath("/v2/users/human"))
+	if err == nil {
+		if wire.UserID == "" {
+			return "", fmt.Errorf("zitadeladmin: create human user returned 2xx without a userId: %w", gipadmin.ErrUnavailable)
+		}
+		return wire.UserID, nil
+	}
+	if errorID(err) != zitadelErrIDUserAlreadyExists {
+		return "", err
+	}
+	// The account is already there — look it up and carry on.
+	existing, resolveErr := c.resolveUserIDByEmail(ctx, email)
+	if resolveErr != nil {
+		return "", fmt.Errorf("zitadeladmin: user already exists but could not be resolved: %w", resolveErr)
+	}
+	return existing, nil
+}
+
+// EnsureProjectGrant gives userID the given roles on projectID, and
+// treats an already-present grant as success.
+//
+//	POST /management/v1/users/{userId}/grants
+//	{"projectId":…,"roleKeys":[…]}   + the x-zitadel-orgid header
+//
+// This call is not optional decoration. The mark8ly-admin project has
+// projectRoleCheck: true (see the zitadel-bootstrap chart values), so a
+// user holding NO role on it cannot complete the OIDC flow at all —
+// finalize returns 403 OIDC-foSyH49RvL. An invited teammate with FGA
+// tuples but no project grant is an account that looks fully created
+// and can never sign in.
+//
+// Idempotency is by tolerating the duplicate rather than by searching
+// first: an extra list call would be a second, UNVERIFIED request shape
+// on the critical path, and a re-accept must not fail merely because
+// the grant survived from the first attempt. The duplicate is detected
+// by grpc code 6 (AlreadyExists) / HTTP 409, with a message-substring
+// safety net. Unlike the create case above there is no live-verified
+// error id for this one, which is exactly why the detection is
+// deliberately broad here and narrow (id-keyed) there.
+func (c *Client) EnsureProjectGrant(ctx context.Context, userID, projectID string, roleKeys []string) error {
+	userID = strings.TrimSpace(userID)
+	projectID = strings.TrimSpace(projectID)
+	if userID == "" {
+		return fmt.Errorf("zitadeladmin: userID is required")
+	}
+	if projectID == "" {
+		return fmt.Errorf("zitadeladmin: projectID is required")
+	}
+	if len(roleKeys) == 0 {
+		return fmt.Errorf("zitadeladmin: at least one role key is required")
+	}
+
+	body := map[string]any{
+		"projectId": projectID,
+		"roleKeys":  roleKeys,
+	}
+	path := fmt.Sprintf("/management/v1/users/%s/grants", url.PathEscape(userID))
+	err := c.do(ctx, http.MethodPost, path, body, nil, true, withLogPath("/management/v1/users/{id}/grants"))
+	if err == nil || isAlreadyExists(err) {
+		return nil
+	}
+	return err
+}
+
+// isAlreadyExists reports whether err is Zitadel refusing to create
+// something that is already there. See EnsureProjectGrant's doc for why
+// this is broader than the id-keyed check EnsureHumanUser uses.
+func isAlreadyExists(err error) bool {
+	var ae *apiError
+	if !errors.As(err, &ae) {
+		return false
+	}
+	if ae.grpcCode == 6 || ae.status == http.StatusConflict {
+		return true
+	}
+	// Both spellings occur in Zitadel's own strings: the human message
+	// ("User grant already exists") and the i18n key it sometimes
+	// surfaces instead ("Errors.UserGrant.AlreadyExists").
+	msg := strings.ToLower(ae.message)
+	return strings.Contains(msg, "already exists") || strings.Contains(msg, "alreadyexists")
+}
+
+// StaffProvisioner binds a Client to the admin project and role key an
+// invited teammate must hold, and performs the whole provisioning step
+// as one call. It satisfies internal/invitation's StaffProvisioner
+// interface; the invitation package deliberately knows nothing about
+// Zitadel projects or role keys, which are deployment config.
+type StaffProvisioner struct {
+	client    *Client
+	projectID string
+	roleKeys  []string
+}
+
+// NewStaffProvisioner constructs a StaffProvisioner. It refuses an
+// empty project id or role set rather than provisioning users that
+// cannot sign in — see EnsureProjectGrant's doc.
+func NewStaffProvisioner(client *Client, projectID string, roleKeys []string) (*StaffProvisioner, error) {
+	if client == nil {
+		return nil, fmt.Errorf("zitadeladmin: client is required")
+	}
+	if strings.TrimSpace(projectID) == "" {
+		return nil, fmt.Errorf("zitadeladmin: admin project id is required")
+	}
+	if len(roleKeys) == 0 {
+		return nil, fmt.Errorf("zitadeladmin: at least one staff role key is required")
+	}
+	return &StaffProvisioner{
+		client:    client,
+		projectID: strings.TrimSpace(projectID),
+		roleKeys:  roleKeys,
+	}, nil
+}
+
+// ProvisionStaff makes email a sign-in-capable identity on the admin
+// project and returns its Zitadel user id.
+//
+// Resolve-first, create-on-miss: an address that already has a Zitadel
+// account (a merchant accepting a second invitation, or anyone
+// re-accepting after a partial failure) needs no password at all, and
+// asking EnsureHumanUser to create it would only reach the same
+// resolution via a wasted 409. password is therefore only consulted
+// when the account genuinely does not exist yet. EnsureHumanUser's own
+// already-exists branch remains the backstop for the race between this
+// lookup and the create.
+//
+// The grant is ensured on EVERY call, including for a pre-existing
+// user: an account created by some other path (storefront signup, an
+// earlier GIP-era migration) has no grant on the admin project, and
+// without one it cannot complete the OIDC flow.
+func (p *StaffProvisioner) ProvisionStaff(ctx context.Context, email, firstName, lastName, password string) (string, error) {
+	userID, err := p.client.ResolveUserIDByEmail(ctx, email)
+	switch {
+	case err == nil:
+		// Existing account — password intentionally unused.
+	case errors.Is(err, gipadmin.ErrUserNotFound):
+		userID, err = p.client.EnsureHumanUser(ctx, HumanUser{
+			Email:     email,
+			FirstName: firstName,
+			LastName:  lastName,
+			Password:  password,
+		})
+		if err != nil {
+			return "", err
+		}
+	default:
+		// Includes ErrAmbiguousEmail: two accounts share this address,
+		// and picking one to grant admin access to is not a decision to
+		// make silently.
+		return "", err
+	}
+
+	if err := p.client.EnsureProjectGrant(ctx, userID, p.projectID, p.roleKeys); err != nil {
+		return "", err
+	}
+	return userID, nil
+}

--- a/services/platform-api/internal/zitadeladmin/provision_test.go
+++ b/services/platform-api/internal/zitadeladmin/provision_test.go
@@ -1,0 +1,362 @@
+package zitadeladmin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/mark8ly/platform-api/internal/gipadmin"
+)
+
+// The handlers below are TRIPWIRES: an unexpected path, method or body
+// shape fails the test from inside the handler rather than being
+// discovered (or not) by an assertion afterwards. This package has been
+// bitten before by a fixture that asserted a request shape the real
+// Zitadel never accepts — see the wrapped-oneof incident in the package
+// doc — so the fake must reject anything the live API would.
+
+func zitadelError(id, message string, grpcCode int) []byte {
+	raw, _ := json.Marshal(map[string]any{
+		"code":    grpcCode,
+		"message": message,
+		"details": []any{map[string]any{"id": id}},
+	})
+	return raw
+}
+
+func decodeBody(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode body %q: %v", raw, err)
+	}
+	return body
+}
+
+func newUser() HumanUser {
+	return HumanUser{
+		Email:     "teammate@example.com",
+		FirstName: "Tea",
+		LastName:  "Mmate",
+		Password:  "correct-horse-battery-staple",
+	}
+}
+
+// TestEnsureHumanUser_SendsTheVerifiedShape pins the exact body verified
+// working in production, including the two protojson traps: no oneof
+// wrapper, and isVerified sent explicitly as true (protojson elides zero
+// values, so an omitted or false isVerified creates a user that
+// resolveUserIDByEmail can then never find again).
+func TestEnsureHumanUser_SendsTheVerifiedShape(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/users/human" || r.Method != http.MethodPost {
+			t.Errorf("unexpected request %s %s, want POST /v2/users/human", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusTeapot)
+			return
+		}
+		body := decodeBody(t, r)
+
+		org, _ := body["organization"].(map[string]any)
+		if org == nil || org["orgId"] != "org-tesserix" {
+			t.Errorf("organization = %v, want {orgId: org-tesserix}", body["organization"])
+		}
+		email, _ := body["email"].(map[string]any)
+		if email == nil || email["email"] != "teammate@example.com" {
+			t.Errorf("email = %v", body["email"])
+		}
+		if email["isVerified"] != true {
+			t.Errorf("email.isVerified = %v, want true sent EXPLICITLY — protojson elides zero values, "+
+				"so an absent isVerified reads as false and the user becomes unresolvable", email["isVerified"])
+		}
+		profile, _ := body["profile"].(map[string]any)
+		if profile == nil || profile["givenName"] != "Tea" || profile["familyName"] != "Mmate" {
+			t.Errorf("profile = %v", body["profile"])
+		}
+		pw, _ := body["password"].(map[string]any)
+		if pw == nil || pw["password"] != "correct-horse-battery-staple" {
+			t.Errorf("password = %v", body["password"])
+		}
+		if pw["changeRequired"] != false {
+			t.Errorf("password.changeRequired = %v, want false so the invitee can sign in with what they just typed", pw["changeRequired"])
+		}
+		// A wrapper key named after a oneof is the exact bug the package
+		// doc records; nothing here has one, and nothing may grow one.
+		for _, forbidden := range []string{"medium", "type", "user"} {
+			if _, ok := body[forbidden]; ok {
+				t.Errorf("body carries a %q wrapper key — Zitadel v2 protojson FLATTENS oneofs", forbidden)
+			}
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"userId":"zid-1","details":{}}`))
+	})
+
+	id, err := c.EnsureHumanUser(context.Background(), newUser())
+	if err != nil {
+		t.Fatalf("EnsureHumanUser: %v", err)
+	}
+	if id != "zid-1" {
+		t.Errorf("id = %q, want zid-1", id)
+	}
+}
+
+// TestEnsureHumanUser_AlreadyExistsResolves pins that the live duplicate
+// error id resolves to the existing account instead of failing the
+// accept. classifyError maps that 409 to ErrUnavailable, so a
+// status/sentinel-based check here would read as an outage.
+func TestEnsureHumanUser_AlreadyExistsResolves(t *testing.T) {
+	var searched bool
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/users/human":
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write(zitadelError(zitadelErrIDUserAlreadyExists, "User already exists", 6))
+		case "/v2/users":
+			searched = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(searchResponse(humanEntry("zid-existing", "teammate@example.com", true)))
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusTeapot)
+		}
+	})
+
+	id, err := c.EnsureHumanUser(context.Background(), newUser())
+	if err != nil {
+		t.Fatalf("EnsureHumanUser: %v", err)
+	}
+	if id != "zid-existing" {
+		t.Errorf("id = %q, want zid-existing", id)
+	}
+	if !searched {
+		t.Error("the already-exists branch must resolve the existing user by email")
+	}
+}
+
+// TestEnsureHumanUser_OtherErrorDoesNotResolve pins that only the
+// duplicate id takes the resolve branch. A different 409 (or any other
+// failure) must propagate — silently resolving one would let an
+// unrelated failure return some other org member's id.
+func TestEnsureHumanUser_OtherErrorDoesNotResolve(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/users/human" {
+			t.Errorf("unexpected request %s %s — a non-duplicate failure must NOT fall through to a search", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(zitadelError("DOMAIN-HuJf6", "Password is too short", 3))
+	})
+
+	if _, err := c.EnsureHumanUser(context.Background(), newUser()); !errors.Is(err, gipadmin.ErrWeakPassword) {
+		t.Fatalf("err = %v, want ErrWeakPassword", err)
+	}
+}
+
+func TestEnsureHumanUser_RefusesIncompleteInput(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("incomplete input must never reach the network (%s %s)", r.Method, r.URL.Path)
+	})
+	for name, in := range map[string]HumanUser{
+		"no email":    {FirstName: "A", LastName: "B", Password: "pw"},
+		"no name":     {Email: "a@b.com", Password: "pw"},
+		"no password": {Email: "a@b.com", FirstName: "A", LastName: "B"},
+	} {
+		if _, err := c.EnsureHumanUser(context.Background(), in); err == nil {
+			t.Errorf("%s: EnsureHumanUser = nil error, want a refusal", name)
+		}
+	}
+}
+
+// TestEnsureProjectGrant_SendsVerifiedShape pins the management-API body
+// and the org header. Without this grant the mark8ly-admin project's
+// projectRoleCheck refuses to finalize the OIDC flow (403 OIDC-foSyH49RvL).
+func TestEnsureProjectGrant_SendsVerifiedShape(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/management/v1/users/zid-1/grants" || r.Method != http.MethodPost {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusTeapot)
+			return
+		}
+		if got := r.Header.Get("x-zitadel-orgid"); got != "org-tesserix" {
+			t.Errorf("x-zitadel-orgid = %q, want org-tesserix", got)
+		}
+		body := decodeBody(t, r)
+		if body["projectId"] != "proj-1" {
+			t.Errorf("projectId = %v, want proj-1", body["projectId"])
+		}
+		roles, _ := body["roleKeys"].([]any)
+		if len(roles) != 1 || roles[0] != "mark8ly.staff" {
+			t.Errorf("roleKeys = %v, want [mark8ly.staff]", body["roleKeys"])
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"userGrantId":"g-1"}`))
+	})
+
+	if err := c.EnsureProjectGrant(context.Background(), "zid-1", "proj-1", []string{"mark8ly.staff"}); err != nil {
+		t.Fatalf("EnsureProjectGrant: %v", err)
+	}
+}
+
+// TestEnsureProjectGrant_AlreadyExistsIsSuccess pins idempotency: a
+// re-accept must not fail because the grant survived the first attempt.
+func TestEnsureProjectGrant_AlreadyExistsIsSuccess(t *testing.T) {
+	for name, respond := range map[string]func(w http.ResponseWriter){
+		"409 + grpc AlreadyExists": func(w http.ResponseWriter) {
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write(zitadelError("COMMAND-XYZ", "User grant already exists", 6))
+		},
+		"message only": func(w http.ResponseWriter) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write(zitadelError("COMMAND-XYZ", "Errors.UserGrant.AlreadyExists", 3))
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) { respond(w) })
+			if err := c.EnsureProjectGrant(context.Background(), "zid-1", "proj-1", []string{"mark8ly.staff"}); err != nil {
+				t.Fatalf("EnsureProjectGrant = %v, want nil (idempotent)", err)
+			}
+		})
+	}
+}
+
+// TestEnsureProjectGrant_RealFailurePropagates pins that idempotency
+// tolerance did not swallow genuine failures — a grant that never lands
+// is an account that can never sign in.
+func TestEnsureProjectGrant_RealFailurePropagates(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write(zitadelError("AUTHZ-1", "No permission", 7))
+	})
+	if err := c.EnsureProjectGrant(context.Background(), "zid-1", "proj-1", []string{"mark8ly.staff"}); err == nil {
+		t.Fatal("EnsureProjectGrant = nil, want the failure to propagate")
+	}
+}
+
+func newTestProvisioner(t *testing.T, handler http.HandlerFunc) *StaffProvisioner {
+	t.Helper()
+	p, err := NewStaffProvisioner(newTestClient(t, handler), "proj-1", []string{"mark8ly.staff"})
+	if err != nil {
+		t.Fatalf("NewStaffProvisioner: %v", err)
+	}
+	return p
+}
+
+// TestProvisionStaff_NewUser pins the create path and, critically, that
+// the grant is ensured too — user-without-grant is one of the two
+// half-provisioned states this whole change exists to make impossible.
+func TestProvisionStaff_NewUser(t *testing.T) {
+	var created, granted bool
+	p := newTestProvisioner(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/users":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(searchResponse()) // no match
+		case "/v2/users/human":
+			created = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"userId":"zid-new"}`))
+		case "/management/v1/users/zid-new/grants":
+			granted = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"userGrantId":"g-1"}`))
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusTeapot)
+		}
+	})
+
+	id, err := p.ProvisionStaff(context.Background(), "teammate@example.com", "Tea", "Mmate", "pw-123456789")
+	if err != nil {
+		t.Fatalf("ProvisionStaff: %v", err)
+	}
+	if id != "zid-new" || !created || !granted {
+		t.Errorf("id=%q created=%v granted=%v, want zid-new/true/true", id, created, granted)
+	}
+}
+
+// TestProvisionStaff_ExistingUserNeedsNoPassword pins resolve-first: an
+// address that already has an account must not attempt a create (the
+// handler fails the test if it does), and must still get the grant —
+// an account made by another path holds no admin-project role.
+func TestProvisionStaff_ExistingUserNeedsNoPassword(t *testing.T) {
+	var granted bool
+	p := newTestProvisioner(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/users":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(searchResponse(humanEntry("zid-existing", "teammate@example.com", true)))
+		case "/management/v1/users/zid-existing/grants":
+			granted = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"userGrantId":"g-1"}`))
+		default:
+			t.Errorf("unexpected request %s %s — an existing user must not be re-created", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusTeapot)
+		}
+	})
+
+	id, err := p.ProvisionStaff(context.Background(), "teammate@example.com", "Tea", "Mmate", "")
+	if err != nil {
+		t.Fatalf("ProvisionStaff: %v", err)
+	}
+	if id != "zid-existing" || !granted {
+		t.Errorf("id=%q granted=%v, want zid-existing/true", id, granted)
+	}
+}
+
+// TestProvisionStaff_GrantFailureFailsTheWholeCall pins that a created
+// user with no grant is reported as a failure, never as success.
+func TestProvisionStaff_GrantFailureFailsTheWholeCall(t *testing.T) {
+	p := newTestProvisioner(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/users":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(searchResponse())
+		case "/v2/users/human":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"userId":"zid-new"}`))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write(zitadelError("X-1", "boom", 13))
+		}
+	})
+
+	if _, err := p.ProvisionStaff(context.Background(), "teammate@example.com", "Tea", "Mmate", "pw-123456789"); err == nil {
+		t.Fatal("ProvisionStaff = nil error, want a failure when the project grant does not land")
+	}
+}
+
+// TestProvisionStaff_AmbiguousEmailRefuses pins that two accounts sharing
+// an address is a refusal, not a coin flip over who gets admin access.
+func TestProvisionStaff_AmbiguousEmailRefuses(t *testing.T) {
+	p := newTestProvisioner(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/users" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(searchResponse(
+			humanEntry("zid-a", "teammate@example.com", true),
+			humanEntry("zid-b", "teammate@example.com", true),
+		))
+	})
+
+	if _, err := p.ProvisionStaff(context.Background(), "teammate@example.com", "Tea", "Mmate", "pw"); !errors.Is(err, ErrAmbiguousEmail) {
+		t.Fatalf("err = %v, want ErrAmbiguousEmail", err)
+	}
+}
+
+func TestNewStaffProvisioner_RefusesEmptyConfig(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {})
+	if _, err := NewStaffProvisioner(c, "", []string{"mark8ly.staff"}); err == nil {
+		t.Error("NewStaffProvisioner with no project id = nil error, want a refusal")
+	}
+	if _, err := NewStaffProvisioner(c, "proj-1", nil); err == nil {
+		t.Error("NewStaffProvisioner with no roles = nil error, want a refusal")
+	}
+}

--- a/services/platform-api/pkg/config/config.go
+++ b/services/platform-api/pkg/config/config.go
@@ -134,6 +134,27 @@ type Config struct {
 	// required because the login-client token is instance-level and the
 	// shared Zitadel instance hosts other products' orgs too.
 	ZitadelOrgID string `envconfig:"ZITADEL_ORG_ID"`
+
+	// ZitadelAdminProjectID is the Zitadel project id of the merchant
+	// admin app (mark8ly-admin). Invitation accept must create a project
+	// grant on it for every invited teammate: that project has
+	// projectRoleCheck: true, so a user holding no role on it cannot
+	// complete the OIDC flow at all (finalize returns
+	// 403 OIDC-foSyH49RvL) no matter how correct their FGA tuples are.
+	//
+	// REQUIRED whenever ZitadelEnabled is true (see ValidateZitadel).
+	// There is deliberately no default: the id is instance-specific, and
+	// baking the production one into the binary would make a
+	// staging/replacement instance silently grant roles on a project
+	// that isn't the one it is serving.
+	ZitadelAdminProjectID string `envconfig:"ZITADEL_ADMIN_PROJECT_ID"`
+
+	// ZitadelStaffRoleKey is the role key granted on
+	// ZitadelAdminProjectID. It defaults to the one role the
+	// mark8ly-admin project declares in the zitadel-bootstrap chart, so
+	// no deployment has to set it; it is configurable only so a future
+	// role split does not require a code change to roll out.
+	ZitadelStaffRoleKey string `envconfig:"ZITADEL_STAFF_ROLE_KEY" default:"mark8ly.staff"`
 }
 
 // GIPKey returns the API key to use for server-side GIP calls: the
@@ -181,6 +202,12 @@ func Load() (*Config, error) {
 	cfg.ZitadelIssuer = strings.TrimSpace(cfg.ZitadelIssuer)
 	cfg.ZitadelLoginClientToken = strings.TrimSpace(cfg.ZitadelLoginClientToken)
 	cfg.ZitadelOrgID = strings.TrimSpace(cfg.ZitadelOrgID)
+	// Both go into JSON request bodies Zitadel matches EXACTLY (a project
+	// id and a role key); a trailing newline from a mounted secret or a
+	// heredoc-written ConfigMap would produce a 404 on the project or a
+	// grant carrying a role nobody holds.
+	cfg.ZitadelAdminProjectID = strings.TrimSpace(cfg.ZitadelAdminProjectID)
+	cfg.ZitadelStaffRoleKey = strings.TrimSpace(cfg.ZitadelStaffRoleKey)
 	return &cfg, nil
 }
 
@@ -214,6 +241,23 @@ func (c *Config) ValidateZitadel() error {
 	}
 	if c.ZitadelOrgID == "" {
 		missing = append(missing, "ZITADEL_ORG_ID")
+	}
+	// DEPLOY ORDER: this is a NEW required variable. The chart must set
+	// ZITADEL_ADMIN_PROJECT_ID before a build carrying it reaches a
+	// deployment that already has ZITADEL_ENABLED=true, or platform-api
+	// refuses to boot. It is required rather than optional because the
+	// alternative — accepting an invitation and skipping the project
+	// grant — produces exactly the failure this variable exists to
+	// prevent: a teammate who looks provisioned and cannot sign in.
+	// Refusing at startup surfaces that in the rollout; skipping the
+	// grant surfaces it days later as a support ticket.
+	if c.ZitadelAdminProjectID == "" {
+		missing = append(missing, "ZITADEL_ADMIN_PROJECT_ID")
+	}
+	// ZitadelStaffRoleKey is NOT listed: it carries a default, so it can
+	// only be empty if an operator explicitly set it to the empty string.
+	if c.ZitadelStaffRoleKey == "" {
+		missing = append(missing, "ZITADEL_STAFF_ROLE_KEY")
 	}
 	if len(missing) == 0 {
 		return nil

--- a/services/platform-api/pkg/config/validate_zitadel_test.go
+++ b/services/platform-api/pkg/config/validate_zitadel_test.go
@@ -11,6 +11,8 @@ func validZitadelConfig() Config {
 		ZitadelIssuer:           "https://login.mark8ly.zitadel.cloud",
 		ZitadelLoginClientToken: "pat",
 		ZitadelOrgID:            "339070697432875523",
+		ZitadelAdminProjectID:   "389070376568619523",
+		ZitadelStaffRoleKey:     "mark8ly.staff",
 	}
 }
 
@@ -37,6 +39,8 @@ func TestValidateZitadel_RefusesOnEachMissingValue(t *testing.T) {
 		{"issuer", func(c *Config) { c.ZitadelIssuer = "" }, "ZITADEL_ISSUER"},
 		{"login client token", func(c *Config) { c.ZitadelLoginClientToken = "" }, "ZITADEL_LOGIN_CLIENT_TOKEN"},
 		{"org id", func(c *Config) { c.ZitadelOrgID = "" }, "ZITADEL_ORG_ID"},
+		{"admin project id", func(c *Config) { c.ZitadelAdminProjectID = "" }, "ZITADEL_ADMIN_PROJECT_ID"},
+		{"staff role key", func(c *Config) { c.ZitadelStaffRoleKey = "" }, "ZITADEL_STAFF_ROLE_KEY"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #679.

`accept-invite` was never migrated off GIP. After the provider flip (#664) every teammate invited to a mark8ly store got a **GIP** account and could not sign in.

## What was actually broken

`AcceptInviteForm.tsx` called `signUp` from `@/lib/gip/signup`, and the accept action auto-logged in against `publicConfig.gipTenantId`. So accepting an invite produced:

```
user:6GrzK9LDKHV4Ix2BgtaMnrzunih2 -- staff     <- GIP-format uid
```

The Zitadel login path resolves membership by **email**, so that tuple was invisible to it and the invitee got *"We couldn't find a store for this account"* — before authentication, since `resolveWorkspaceTenant` runs ahead of `zitadelLogin`. Past that, the missing Zitadel **project grant** would have returned `403 OIDC-foSyH49RvL` at OIDC finalize, because `mark8ly-admin` has `projectRoleCheck: true`.

Making one staff member work by hand needed a project grant plus two FGA tuples. Nothing provisioned any of it.

## The fix

**platform-api** — on accept with Zitadel enabled: resolve-or-create the Zitadel user, ensure the project grant, and write **both** an email-keyed and a Zitadel-uid-keyed FGA tuple. Provisioning failure aborts the accept rather than half-completing, because a teammate with a tuple and no grant is precisely the failure this fixes.

**admin** — the Zitadel path sends `{token, verified_email, password}` and never a GIP `id_token` or `uid`; the GIP branch is byte-identical when the flag is off.

## Why both tuple keys

Three readers use three different keys: accept wrote a GIP uid, login reads **email**, the bearer API reads the **Zitadel uid** (`sub`). A single key forces one of the readers to change, and `resolveWorkspaceTenant` runs *before* authentication — at that moment the typed address is the only identifier in existence, so there is no `sub` to key on. Writing both is what the working owner account already has.

## Two bugs found while fixing this, neither in the original scope

- **Email casing.** `signInWithZitadel` passes whatever the merchant typed, while every email-keyed tuple is lowercased — `Staff@Example.com` would have missed its own membership with the same misleading message. Now folded server-side, and only for keys containing `@`, since provider uids are case-sensitive.
- **`UpdateMemberRole` had the identical defect** — it wrote only the uid-keyed tuple, so a role change displayed correctly in the team list and changed nothing at sign-in.

## Deploy ordering — k8s first

This adds `ZITADEL_ADMIN_PROJECT_ID` as **required** under `ValidateZitadel`. **tesserix-k8s#972 must be deployed before this image**, or platform-api refuses to boot. That PR also fixes a related gap it uncovered: platform-api had *no* `ZITADEL_*` config at all, so password reset and account deletion were still talking to GIP for users who exist only in Zitadel.

## Known behaviour change

After accepting, the invitee is redirected to `/login/authorize` and re-enters the password they just set. Zitadel's login-client model redirects to a fixed instance-configured login URI, so the accept page cannot mint the `auth_request_id` a direct sign-in needs; the alternative was stashing the password to replay it. The Google button is hidden on the Zitadel path for the same reason plus the backend provisioning from a password rather than an IDP intent — an invitee wanting Google uses it at `/login` once provisioned.

## Verification

`gofmt` clean, `go build ./...` and `go test ./...` green in services/platform-api (20 new tests, fakes are tripwires that fail from inside the handler on unexpected calls). `vitest` 1131 passing, `tsc --noEmit` clean, `npm run build` exit 0 in apps/admin.

Not yet exercised end-to-end against a live invite — that is the next step once #972 is deployed.
