### PR TITLE
fix(invitations): tell the invitee which password rule Zitadel rejected

### DIFF
--- a/apps/admin/app/accept-invite/actions.test.ts
+++ b/apps/admin/app/accept-invite/actions.test.ts
@@ -131,6 +131,31 @@ describe("acceptInviteWithZitadel", () => {
     expect(result.message).not.toMatch(/something went wrong/i);
   });
 
+  it("passes a 400 password_policy through with the rule-specific message", async () => {
+    // platform-api now distinguishes "the password broke rule X" (400,
+    // the caller's input) from "provisioning failed" (500, our fault).
+    // The message names the rule, so it must reach the invitee verbatim.
+    installFetch({
+      [ACCEPT_URL]: () =>
+        jsonResponse(400, {
+          error: "password_policy",
+          message:
+            "That password is too short — it needs at least 12 characters.",
+        }),
+    });
+
+    const result = await acceptInviteWithZitadel({
+      token: "invite-token",
+      email: "staff@example.com",
+      password: "not-a-real-password",
+    });
+
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("password_policy");
+    expect(result.message).toContain("12 characters");
+    expect(result.message).not.toMatch(/invitation link again/i);
+  });
+
   it("falls back to actionable copy when provisioning_failed carries no message", async () => {
     installFetch({
       [ACCEPT_URL]: () => jsonResponse(500, { error: "provisioning_failed" }),

--- a/apps/admin/components/auth/AcceptInviteForm.test.tsx
+++ b/apps/admin/components/auth/AcceptInviteForm.test.tsx
@@ -76,7 +76,7 @@ beforeEach(() => {
   });
 });
 
-async function submitExistingAccount(password = "correct-horse-battery") {
+async function submitExistingAccount(password = "Not-A-Real-Password-1!") {
   await userEvent.type(screen.getByLabelText(/^password$/i), password);
   await userEvent.click(screen.getByRole("button", { name: /accept invite|sign in and accept/i }));
 }
@@ -99,7 +99,7 @@ describe("AcceptInviteForm — Zitadel path", () => {
     expect(acceptInviteWithZitadel).toHaveBeenCalledWith({
       token: "invite-token",
       email: "staff@example.com",
-      password: "correct-horse-battery",
+      password: "Not-A-Real-Password-1!",
     });
     // No GIP account creation, no GIP sign-in, and therefore no
     // id_token for the old accept action to forward.
@@ -150,6 +150,70 @@ describe("AcceptInviteForm — Zitadel path", () => {
     expect(assign).not.toHaveBeenCalled();
   });
 
+  // The exact password from the production incident: eleven characters,
+  // which the old `min(8)` schema accepted and Zitadel's 12-character
+  // policy then rejected with a message that explained nothing.
+  it("rejects the 11-character password that failed in production, before submitting", async () => {
+    render(
+      <AcceptInviteForm
+        token="invite-token"
+        invitation={invitation}
+        provider="zitadel"
+      />,
+    );
+
+    await submitExistingAccount("Test@123_01");
+
+    expect(
+      await screen.findByText(/at least 12 characters/i),
+    ).toBeTruthy();
+    // The whole point: it never reaches the server.
+    expect(acceptInviteWithZitadel).not.toHaveBeenCalled();
+  });
+
+  it("shows the full requirements before the first submit", () => {
+    render(
+      <AcceptInviteForm
+        token="invite-token"
+        invitation={invitation}
+        provider="zitadel"
+      />,
+    );
+
+    const hint = screen.getByText(/at least 12 characters/i);
+    expect(hint).toBeTruthy();
+    expect(hint.textContent).toMatch(/uppercase/i);
+    expect(hint.textContent).toMatch(/lowercase/i);
+    expect(hint.textContent).toMatch(/number/i);
+    expect(hint.textContent).toMatch(/symbol/i);
+  });
+
+  it("renders the server's specific policy error on the password field", async () => {
+    // Client validation and the server's policy can drift; the server is
+    // authoritative, so its message has to be renderable even for a
+    // password the client accepted.
+    acceptInviteWithZitadel.mockResolvedValue({
+      ok: false,
+      code: "password_policy",
+      message: "That password needs a symbol, for example ! ? @ or #.",
+    });
+
+    render(
+      <AcceptInviteForm
+        token="invite-token"
+        invitation={invitation}
+        provider="zitadel"
+      />,
+    );
+
+    await submitExistingAccount();
+
+    const error = await screen.findByRole("alert");
+    expect(error).toHaveTextContent(/needs a symbol/i);
+    expect(error.id).toBe("invite-password-error");
+    expect(assign).not.toHaveBeenCalled();
+  });
+
   it("offers no Google button — that path is GIP end to end", () => {
     render(
       <AcceptInviteForm
@@ -174,7 +238,7 @@ describe("AcceptInviteForm — GIP path (unchanged)", () => {
     await waitFor(() => expect(acceptInvite).toHaveBeenCalledTimes(1));
     expect(signInWithPassword).toHaveBeenCalledWith(
       "staff@example.com",
-      "correct-horse-battery",
+      "Not-A-Real-Password-1!",
     );
     expect(acceptInvite).toHaveBeenCalledWith({
       token: "invite-token",
@@ -190,19 +254,31 @@ describe("AcceptInviteForm — GIP path (unchanged)", () => {
     render(<AcceptInviteForm token="invite-token" invitation={invitation} />);
 
     await userEvent.click(screen.getByRole("tab", { name: /create an account/i }));
-    await userEvent.type(screen.getByLabelText(/^create password$/i), "pw-123456789");
+    await userEvent.type(screen.getByLabelText(/^create password$/i), "Also-Not-A-Real-Password-2!");
     await userEvent.type(
       screen.getByLabelText(/^confirm password$/i),
-      "pw-123456789",
+      "Also-Not-A-Real-Password-2!",
     );
     await userEvent.click(
       screen.getByRole("button", { name: /create account and join store/i }),
     );
 
     await waitFor(() =>
-      expect(signUp).toHaveBeenCalledWith("staff@example.com", "pw-123456789"),
+      expect(signUp).toHaveBeenCalledWith("staff@example.com", "Also-Not-A-Real-Password-2!"),
     );
     expect(acceptInviteWithZitadel).not.toHaveBeenCalled();
+  });
+
+  it("does not hold an existing GIP sign-in password to the Zitadel policy", async () => {
+    // GIP's own minimum is 8. A user whose password was set under that
+    // rule must still be able to sign in and accept — they cannot change
+    // it from this form.
+    render(<AcceptInviteForm token="invite-token" invitation={invitation} />);
+
+    await submitExistingAccount("gip-old8");
+
+    await waitFor(() => expect(signInWithPassword).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText(/at least 12 characters/i)).toBeNull();
   });
 
   it("still offers the Google button", () => {

--- a/apps/admin/components/auth/AcceptInviteForm.tsx
+++ b/apps/admin/components/auth/AcceptInviteForm.tsx
@@ -22,6 +22,11 @@ import {
   acceptInvite,
   acceptInviteWithZitadel,
 } from "@/app/accept-invite/actions";
+import {
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_REQUIREMENTS_TEXT,
+  validateNewPassword,
+} from "@/lib/auth/password-policy";
 
 type Mode = "signin" | "create";
 
@@ -38,6 +43,23 @@ interface AcceptInviteFormProps {
   provider?: string;
 }
 
+/**
+ * The shared floor, left exactly as it was: GIP's own minimum is 8, and
+ * the GIP path is not being changed here.
+ *
+ * The real Zitadel policy (12 characters, upper, lower, number, symbol —
+ * see lib/auth/password-policy.ts) is applied on top of this in onValid,
+ * and ONLY on the Zitadel path. Two reasons it lives there rather than
+ * in a second resolver schema:
+ *
+ *   - the rule is provider-specific, and swapping resolvers underneath
+ *     react-hook-form on a prop change is a subtlety this form does not
+ *     need;
+ *   - on the GIP path the password may be an EXISTING credential being
+ *     recalled, set when the minimum was 8. Holding it to the Zitadel
+ *     policy would lock a legitimate user out of their own invitation
+ *     over a password they cannot change from this form.
+ */
 const baseSchema = z.object({
   password: z.string().min(8, "Password must be at least 8 characters"),
   confirmPassword: z.string().optional(),
@@ -111,6 +133,15 @@ export function AcceptInviteForm({
         password,
       });
       if (!result.ok) {
+        // The server is authoritative on the password policy: client
+        // validation is a copy of it and the two can drift. When
+        // platform-api names the rule that was broken, put its message
+        // on the password field where the fix is, not in the generic
+        // form-level alert.
+        if (result.code === "password_policy") {
+          setError("password", { type: "server", message: result.message });
+          return;
+        }
         setSubmitError(result.message);
         return;
       }
@@ -124,6 +155,15 @@ export function AcceptInviteForm({
   function onValid(values: FormValues) {
     setSubmitError(null);
     setSuccess(null);
+
+    // Zitadel path only — see baseSchema's doc.
+    if (isZitadel) {
+      const policyError = validateNewPassword(values.password);
+      if (policyError) {
+        setError("password", { type: "validate", message: policyError });
+        return;
+      }
+    }
 
     if (mode === "create" && values.password !== values.confirmPassword) {
       setError("confirmPassword", {
@@ -257,20 +297,39 @@ export function AcceptInviteForm({
           />
         </Field>
 
+        {/* The requirements are shown as a hint BEFORE the first
+            submit, not only as an error after one. A merchant choosing a
+            password should not have to guess it and be corrected — that
+            guessing loop is what the eleven-character password ran into.
+            Field renders the error in the hint's place once there is
+            one, so the two never stack. */}
         <Field
           id="invite-password"
           label={mode === "create" ? "Create password" : "Password"}
           error={errors.password?.message}
+          hint={isZitadel ? PASSWORD_REQUIREMENTS_TEXT : undefined}
         >
           <Input
             id="invite-password"
             type="password"
-            placeholder="At least 8 characters"
+            placeholder={
+              isZitadel
+                ? `At least ${PASSWORD_MIN_LENGTH} characters`
+                : "At least 8 characters"
+            }
             disabled={disabled}
-            autoComplete={mode === "create" ? "new-password" : "current-password"}
+            autoComplete={
+              isZitadel || mode === "create"
+                ? "new-password"
+                : "current-password"
+            }
             aria-invalid={errors.password ? true : undefined}
             aria-describedby={
-              errors.password ? "invite-password-error" : undefined
+              errors.password
+                ? "invite-password-error"
+                : isZitadel
+                  ? "invite-password-hint"
+                  : undefined
             }
             {...register("password")}
           />

--- a/apps/admin/lib/auth/password-policy.test.ts
+++ b/apps/admin/lib/auth/password-policy.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_REQUIREMENTS_TEXT,
+  validateNewPassword,
+} from "./password-policy";
+
+describe("password policy", () => {
+  it("matches the live Zitadel org policy probed 2026-09-05", () => {
+    expect(PASSWORD_MIN_LENGTH).toBe(12);
+  });
+
+  it("rejects Test@123_01 — the exact password that failed in production", () => {
+    // Eleven characters. The old schema said min(8) and let it through;
+    // Zitadel requires twelve and the invitee was told only that we
+    // "couldn't finish setting up your account".
+    expect("Test@123_01".length).toBe(11);
+    const message = validateNewPassword("Test@123_01");
+    expect(message).not.toBeNull();
+    expect(message).toMatch(/12 characters/);
+  });
+
+  it("names every requirement up front rather than one rule at a time", () => {
+    for (const password of [
+      "short1A!", // too short
+      "nouppercase1!", // no uppercase
+      "NOLOWERCASE1!", // no lowercase
+      "NoNumbersHere!", // no number
+      "NoSymbolsHere12", // no symbol
+    ]) {
+      const message = validateNewPassword(password);
+      expect(message, password).not.toBeNull();
+      expect(message, password).toMatch(/uppercase/i);
+      expect(message, password).toMatch(/lowercase/i);
+      expect(message, password).toMatch(/number/i);
+      expect(message, password).toMatch(/symbol/i);
+      expect(message, password).toMatch(/12 characters/);
+    }
+  });
+
+  it("accepts a password that satisfies all five rules", () => {
+    expect(validateNewPassword("Not-A-Real-Password-1!")).toBeNull();
+    expect(validateNewPassword("Still-Not-A-Real-Password-3!")).toBeNull();
+  });
+
+  it("counts any non-alphanumeric character as a symbol, as Zitadel does", () => {
+    // A client rule narrower than the server's would reject a password
+    // Zitadel accepts — the mirror image of the bug being fixed.
+    for (const symbol of ["!", "@", "#", "_", "-", " ", "€", "§"]) {
+      expect(validateNewPassword(`Abcdefghij1${symbol}`), symbol).toBeNull();
+    }
+  });
+
+  it("states the whole policy in the helper text shown under the field", () => {
+    expect(PASSWORD_REQUIREMENTS_TEXT).toMatch(/12 characters/);
+    expect(PASSWORD_REQUIREMENTS_TEXT).toMatch(/uppercase/i);
+    expect(PASSWORD_REQUIREMENTS_TEXT).toMatch(/lowercase/i);
+    expect(PASSWORD_REQUIREMENTS_TEXT).toMatch(/number/i);
+    expect(PASSWORD_REQUIREMENTS_TEXT).toMatch(/symbol/i);
+  });
+});

--- a/apps/admin/lib/auth/password-policy.ts
+++ b/apps/admin/lib/auth/password-policy.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+
+/**
+ * The password rules Zitadel actually enforces, mirrored here so the
+ * browser can say "no" before the network does.
+ *
+ * # Why this file exists
+ *
+ * A merchant accepted a staff invitation with `Test@123_01` — eleven
+ * characters. This form's schema said `min(8)`, so it submitted happily;
+ * Zitadel's policy requires twelve, so provisioning failed, and the
+ * invitee was shown "we couldn't finish setting up your account — please
+ * try the invitation link again". They retried the same password.
+ *
+ * A client rule that is LOOSER than the server's is worse than no client
+ * rule at all: it promises an acceptance the server will refuse.
+ *
+ * # Source of truth
+ *
+ * The live instance policy is the authority:
+ * `GET /management/v1/policies/password/complexity`, org
+ * 386377229942128837 — PROBED 2026-09-05:
+ *
+ *     minLength: 12, hasUppercase, hasLowercase, hasNumber, hasSymbol
+ *
+ * These constants are a copy of it, and the ONLY copy on the TypeScript
+ * side — the schema, the helper text under the field, and the tests all
+ * read them from here. Its counterpart is
+ * `services/platform-api/internal/zitadeladmin/password_policy.go`; the
+ * two cannot share a literal across the language boundary, so they share
+ * a comment instead. Change the org policy and both must move.
+ *
+ * The policy is deliberately NOT fetched at runtime. Zitadel remains the
+ * enforcer either way, the server now returns the specific rule that was
+ * broken when the two ever disagree, and an extra round trip on page
+ * load to learn a number that changes approximately never is not a trade
+ * worth making.
+ */
+export const PASSWORD_MIN_LENGTH = 12;
+
+/**
+ * The whole policy in one sentence, shown under the field BEFORE the
+ * first submit. Discoverability is the point: a merchant choosing a
+ * password should not have to guess and be corrected one rule at a time.
+ */
+export const PASSWORD_REQUIREMENTS_TEXT = `At least ${PASSWORD_MIN_LENGTH} characters, with an uppercase letter, a lowercase letter, a number, and a symbol.`;
+
+/**
+ * Every rule reports the SAME message — the full requirements — rather
+ * than the first one that failed. Reporting only "needs a number" invites
+ * the user to add a number and then be told about the symbol, which is
+ * the drip-feed the incident was made of.
+ */
+export const PASSWORD_REQUIREMENTS_MESSAGE = `Password must be at least ${PASSWORD_MIN_LENGTH} characters, with an uppercase letter, a lowercase letter, a number, and a symbol.`;
+
+/**
+ * A symbol is anything that is not a letter or a digit, which is how
+ * Zitadel's `hasSymbol` behaves. Kept broad on purpose: a client rule
+ * narrower than the server's would reject a password Zitadel accepts.
+ */
+const SYMBOL = /[^A-Za-z0-9]/;
+
+/**
+ * Schema for a password the invitee is CHOOSING (it will create, or be
+ * checked against, a Zitadel account).
+ *
+ * Not for a password being typed to sign in to an existing GIP account:
+ * GIP's own minimum is 8, and holding a legacy 8-character password to
+ * this standard would lock a legitimate user out of their own invite.
+ * See AcceptInviteForm for where that branch is made.
+ */
+export const newPasswordSchema = z
+  .string()
+  .min(PASSWORD_MIN_LENGTH, PASSWORD_REQUIREMENTS_MESSAGE)
+  .regex(/[A-Z]/, PASSWORD_REQUIREMENTS_MESSAGE)
+  .regex(/[a-z]/, PASSWORD_REQUIREMENTS_MESSAGE)
+  .regex(/[0-9]/, PASSWORD_REQUIREMENTS_MESSAGE)
+  .regex(SYMBOL, PASSWORD_REQUIREMENTS_MESSAGE);
+
+/**
+ * Imperative form of the schema, for callers that want a message or
+ * null rather than a Zod result.
+ */
+export function validateNewPassword(password: string): string | null {
+  const result = newPasswordSchema.safeParse(password);
+  return result.success
+    ? null
+    : (result.error.issues[0]?.message ?? PASSWORD_REQUIREMENTS_MESSAGE);
+}

--- a/services/platform-api/internal/invitation/provisioning_error.go
+++ b/services/platform-api/internal/invitation/provisioning_error.go
@@ -1,0 +1,95 @@
+package invitation
+
+import (
+	"errors"
+	"log"
+	"strings"
+
+	apperrors "github.com/mark8ly/platform-api/pkg/errors"
+)
+
+// This file turns a StaffProvisioner failure into (a) an HTTP answer the
+// invitee can act on and (b) exactly one log line an operator can
+// diagnose from.
+//
+// Both halves are a fix for the same production incident: a merchant
+// accepted a staff invitation with an 11-character password, Zitadel's
+// policy requires 12, and the accept endpoint answered 500
+// provisioning_failed with the copy "we couldn't finish setting up your
+// account — please try the invitation link again". That message is a
+// lie in this case (nothing about retrying the LINK helps) and the
+// server logged nothing at all, so the real cause had to be found by
+// replaying platform-api's own Zitadel call by hand.
+
+// passwordPolicyViolation is the shape a provisioner error implements
+// when the identity provider rejected the chosen password for breaking a
+// named complexity rule. *zitadeladmin.policyError satisfies it.
+//
+// It is declared HERE, as an interface, rather than importing
+// zitadeladmin: this package deliberately knows nothing about which
+// identity provider is wired (see StaffProvisioner's doc — projects,
+// role keys and now policy ids are all deployment concerns), and an
+// import would make that false. errors.As against a one-method
+// interface keeps the dependency pointing the right way.
+//
+// The returned message is provider-authored, static text naming the
+// broken rule; it contains no password material.
+type passwordPolicyViolation interface {
+	error
+	PasswordPolicyRule() (rule string, message string)
+}
+
+// passwordPolicyCode is the single machine-readable code every
+// password-complexity rejection is returned under.
+//
+// One code, not five: the browser needs exactly one branch — "put this
+// on the password field" — and the rule-specific detail belongs in the
+// message, which is the part a human reads. The rule name is not lost,
+// it goes to the log line below where an operator can aggregate on it.
+const passwordPolicyCode = "password_policy"
+
+// provisioningError maps a ProvisionStaff failure onto an AppError and
+// logs the cause.
+//
+// A password-complexity rejection is 400, not 500: it is the caller's
+// input that is wrong, and answering 500 tells both the invitee and
+// every dashboard the wrong story about whose fault it is.
+//
+// password is passed in ONLY so redactPassword can guarantee it is not
+// echoed back out of an error string. It is never itself logged; see
+// that function's doc.
+func provisioningError(err error, invitationID, tenantID, password string) error {
+	var violation passwordPolicyViolation
+	if errors.As(err, &violation) {
+		rule, message := violation.PasswordPolicyRule()
+		log.Printf("ERROR invitation.Accept: identity provider rejected the chosen password: "+
+			"invitation=%s tenant=%s rule=%s cause=%s",
+			invitationID, tenantID, rule, redactPassword(err.Error(), password))
+		return apperrors.Wrap(err, 400, passwordPolicyCode, message)
+	}
+
+	log.Printf("ERROR invitation.Accept: staff provisioning failed: invitation=%s tenant=%s cause=%s",
+		invitationID, tenantID, redactPassword(err.Error(), password))
+	return apperrors.Wrap(err, 500, "provisioning_failed",
+		"we couldn't finish setting up your account — please try the invitation link again")
+}
+
+// redactPassword removes password from s.
+//
+// Belt and braces. No error this package receives is supposed to embed
+// the credential — zitadeladmin's apiError formats only method, path,
+// status, error id and sentinel, and never the request body — but the
+// log line above is the first place in this flow that prints an upstream
+// error verbatim, and "no current code path leaks it" is a property that
+// silently stops holding the moment someone adds %v of a request body to
+// an error string upstream. The check costs one string scan per failed
+// accept.
+//
+// An empty password redacts nothing: strings.ReplaceAll with an empty
+// old value splices the replacement between every character.
+func redactPassword(s, password string) string {
+	if password == "" {
+		return s
+	}
+	return strings.ReplaceAll(s, password, "[redacted]")
+}

--- a/services/platform-api/internal/invitation/provisioning_error_test.go
+++ b/services/platform-api/internal/invitation/provisioning_error_test.go
@@ -1,0 +1,208 @@
+package invitation
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/mark8ly/platform-api/internal/authz"
+	apperrors "github.com/mark8ly/platform-api/pkg/errors"
+)
+
+// fakePolicyErr stands in for *zitadeladmin.policyError: an error that
+// names the password rule the identity provider rejected. It is
+// deliberately built from the interface this package declares rather
+// than by importing zitadeladmin — if that import ever becomes necessary
+// the layering has slipped, and this test would keep compiling only
+// because it never had one.
+type fakePolicyErr struct {
+	rule    string
+	message string
+	// cause is what the provider's own error string looked like. The
+	// production shape carries no credential; a test can therefore only
+	// prove redaction works by planting one here.
+	cause string
+}
+
+func (e *fakePolicyErr) Error() string { return e.cause }
+func (e *fakePolicyErr) PasswordPolicyRule() (string, string) {
+	return e.rule, e.message
+}
+
+// captureLog redirects the standard logger for the duration of fn and
+// returns everything written to it.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOut := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	})
+	fn()
+	return buf.String()
+}
+
+// TestProvisioningError_PolicyViolationIsA400WithTheRuleNamed is the
+// user-visible half of the fix. A password the merchant can correct must
+// not be reported as a server fault, and the message must say which rule
+// they broke — the old copy ("try the invitation link again") sent the
+// invitee round the same loop with the same password.
+func TestProvisioningError_PolicyViolationIsA400WithTheRuleNamed(t *testing.T) {
+	err := &fakePolicyErr{
+		rule:    "too_short",
+		message: "That password is too short — it needs at least 12 characters.",
+		cause:   "zitadeladmin: password policy violation too_short (COMMA-HuJf6)",
+	}
+
+	var got error
+	_ = captureLog(t, func() {
+		got = provisioningError(err, "inv-1", "tid-1", "Test@123_01")
+	})
+
+	ae, ok := apperrors.As(got)
+	if !ok {
+		t.Fatalf("provisioningError = %v, want an AppError", got)
+	}
+	if ae.Status != 400 {
+		t.Errorf("status = %d, want 400 — a policy violation is the caller's input, not a server fault", ae.Status)
+	}
+	if ae.Code != "password_policy" {
+		t.Errorf("code = %q, want password_policy (distinct from provisioning_failed)", ae.Code)
+	}
+	if ae.Message != err.message {
+		t.Errorf("message = %q, want the rule-specific text %q", ae.Message, err.message)
+	}
+	if !errors.Is(got, err) {
+		t.Error("the underlying provider error must stay in the chain")
+	}
+}
+
+// TestProvisioningError_NonPolicyFailureStaysA500 pins that everything
+// that is genuinely a server fault keeps its old code, status and copy.
+func TestProvisioningError_NonPolicyFailureStaysA500(t *testing.T) {
+	var got error
+	out := captureLog(t, func() {
+		got = provisioningError(errors.New("zitadeladmin: POST /v2/users/human: status 503"), "inv-1", "tid-1", "Test@123_01")
+	})
+
+	ae, ok := apperrors.As(got)
+	if !ok {
+		t.Fatalf("provisioningError = %v, want an AppError", got)
+	}
+	if ae.Status != 500 || ae.Code != "provisioning_failed" {
+		t.Errorf("got %d/%s, want 500/provisioning_failed", ae.Status, ae.Code)
+	}
+	if !strings.Contains(out, "status 503") {
+		t.Errorf("log = %q, want it to carry the underlying cause — the incident's second half was that this logged nothing", out)
+	}
+}
+
+// TestProvisioningError_LogsTheCauseAtError is the operability half of
+// the fix: the reason diagnosing this took twenty minutes is that
+// provisioning_failed logged nothing at all.
+func TestProvisioningError_LogsTheCauseAtError(t *testing.T) {
+	err := &fakePolicyErr{
+		rule:    "no_symbol",
+		message: "That password needs a symbol.",
+		cause:   "zitadeladmin: password policy violation no_symbol (COMMA-ZDLwA)",
+	}
+	out := captureLog(t, func() {
+		_ = provisioningError(err, "inv-42", "tid-7", "Test@123_01")
+	})
+
+	for _, want := range []string{"ERROR", "COMMA-ZDLwA", "no_symbol", "inv-42", "tid-7"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log = %q, want it to contain %q", out, want)
+		}
+	}
+}
+
+// TestProvisioningError_NeverLogsThePassword is the non-negotiable one.
+// Both branches are exercised with a cause string that embeds the
+// credential, which is what a careless upstream %v of a request body
+// would produce.
+func TestProvisioningError_NeverLogsThePassword(t *testing.T) {
+	const password = "Test@123_01"
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "policy violation",
+			err: &fakePolicyErr{
+				rule:    "too_short",
+				message: "That password is too short.",
+				cause:   `create human user: body {"password":{"password":"` + password + `"}}`,
+			},
+		},
+		{
+			name: "generic failure",
+			err:  errors.New(`POST /v2/users/human body {"password":{"password":"` + password + `"}}: status 400`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := captureLog(t, func() {
+				_ = provisioningError(tc.err, "inv-1", "tid-1", password)
+			})
+			if strings.Contains(out, password) {
+				t.Fatalf("the chosen password leaked into the log: %q", out)
+			}
+			if !strings.Contains(out, "[redacted]") {
+				t.Errorf("log = %q, want the credential replaced by [redacted]", out)
+			}
+		})
+	}
+}
+
+// TestRedactPassword_EmptyPasswordIsANoOp guards the sharp edge in
+// strings.ReplaceAll: an empty old value splices the replacement between
+// every character, which would turn a clean log line into noise.
+func TestRedactPassword_EmptyPasswordIsANoOp(t *testing.T) {
+	const s = "status 503"
+	if got := redactPassword(s, ""); got != s {
+		t.Errorf("redactPassword(%q, \"\") = %q, want it unchanged", s, got)
+	}
+}
+
+// TestAccept_Zitadel_PasswordPolicyFailureSurfacesAs400 drives the whole
+// thing through Accept, proving the classification survives the real
+// call path and that nothing is half-provisioned on the way out.
+func TestAccept_Zitadel_PasswordPolicyFailureSurfacesAs400(t *testing.T) {
+	repo := &fakeRepo{inv: pendingInvitation()}
+	fga := authz.NewFake()
+	prov := &fakeProvisioner{t: t, err: &fakePolicyErr{
+		rule:    "too_short",
+		message: "That password is too short — it needs at least 12 characters.",
+		cause:   "zitadeladmin: password policy violation too_short (COMMA-HuJf6)",
+	}}
+	svc := NewService(Config{Repo: repo, FGA: fga, Provisioner: prov})
+
+	var err error
+	out := captureLog(t, func() {
+		_, err = svc.Accept(context.Background(), zitadelAcceptInput())
+	})
+
+	ae, ok := apperrors.As(err)
+	if !ok || ae.Status != 400 || ae.Code != "password_policy" {
+		t.Fatalf("err = %v, want a 400 password_policy AppError", err)
+	}
+	if !strings.Contains(ae.Message, "12 characters") {
+		t.Errorf("message = %q, want it to name the rule the invitee broke", ae.Message)
+	}
+	if strings.Contains(out, zitadelAcceptInput().Password) {
+		t.Error("the submitted password reached the log")
+	}
+	if fga.WriteCallCount() != 0 || repo.acceptedID != "" {
+		t.Error("a rejected password must leave the invitation pending and write no tuples")
+	}
+}

--- a/services/platform-api/internal/invitation/service.go
+++ b/services/platform-api/internal/invitation/service.go
@@ -455,8 +455,7 @@ func (s *Service) Accept(ctx context.Context, in AcceptInput) (*AcceptResult, er
 		first, last := profileNames(in.FirstName, in.LastName, inv.Email)
 		zitadelUID, err := s.provisioner.ProvisionStaff(ctx, inv.Email, first, last, in.Password)
 		if err != nil {
-			return nil, apperrors.Wrap(err, 500, "provisioning_failed",
-				"we couldn't finish setting up your account — please try the invitation link again")
+			return nil, provisioningError(err, inv.ID, inv.TenantID, in.Password)
 		}
 		// Both identity keys, deliberately. Three readers disagree on
 		// what a member is keyed by:

--- a/services/platform-api/internal/zitadeladmin/client.go
+++ b/services/platform-api/internal/zitadeladmin/client.go
@@ -336,6 +336,22 @@ var zitadelErrorIDSentinels = map[string]error{
 	"COMMAND-2M9fs": gipadmin.ErrInvalidOobCode, // "Code not found" (400, code 9)
 	"COMMAND-G8dh3": gipadmin.ErrUnavailable,    // "Password not found" (400, code 9) -- malformed request, NOT an invalid code
 	"DOMAIN-HuJf6":  gipadmin.ErrWeakPassword,   // "Password is too short" (400, code 3)
+
+	// The five password-complexity ids POST /v2/users/human returns, each
+	// PROBED live on 2026-09-05 (see password_policy.go, which additionally
+	// maps them to the individual RULE broken so the invitee can be told
+	// what to change). They are listed here too so the COARSE sentinel is
+	// right for every caller — including ResetPassword, which hits the same
+	// policy and would otherwise fall through to ErrUnavailable ("identity
+	// service unreachable") for a password the merchant simply mistyped.
+	//
+	// COMMA-HuJf6 is NOT DOMAIN-HuJf6 above. Same suffix, different Zitadel
+	// command, matched whole — never by suffix.
+	"COMMA-HuJf6": gipadmin.ErrWeakPassword, // too short
+	"COMMA-VoaRj": gipadmin.ErrWeakPassword, // no uppercase
+	"COMMA-co3Xw": gipadmin.ErrWeakPassword, // no lowercase
+	"COMMA-ZBv4H": gipadmin.ErrWeakPassword, // no number
+	"COMMA-ZDLwA": gipadmin.ErrWeakPassword, // no symbol
 }
 
 // classifyError maps an HTTP status + Zitadel error body to one of

--- a/services/platform-api/internal/zitadeladmin/password_policy.go
+++ b/services/platform-api/internal/zitadeladmin/password_policy.go
@@ -1,0 +1,161 @@
+package zitadeladmin
+
+import (
+	"errors"
+	"fmt"
+)
+
+// This file classifies Zitadel's password-complexity rejections down to
+// the individual RULE that was broken, so the merchant who typed the
+// password is told what to change instead of "we couldn't finish setting
+// up your account".
+//
+// The incident: an invitee chose an 11-character password. Zitadel's
+// policy requires 12. EnsureHumanUser returned an opaque error, the
+// accept handler answered 500 provisioning_failed, and nothing was
+// logged — so the invitee retried the same password and the cause had to
+// be found by replaying the Zitadel call by hand.
+//
+// # The live policy
+//
+// GET /management/v1/policies/password/complexity for org
+// 386377229942128837, PROBED 2026-09-05:
+//
+//	minLength: 12, hasUppercase: true, hasLowercase: true,
+//	hasNumber: true, hasSymbol: true
+//
+// That instance policy is the AUTHORITY; the constants below are a copy
+// kept for message text and for the browser-side pre-check in
+// apps/admin/lib/auth/password-policy.ts. Deliberately NOT fetched at
+// request time: an extra Zitadel round trip on the accept path buys
+// nothing — Zitadel still enforces the real policy, and this code's job
+// is only to explain the rejection it already received. If the org
+// policy is ever changed, update these two files together.
+//
+// # Ids are matched WHOLE, never by suffix
+//
+// COMMA-HuJf6 (too short, from POST /v2/users/human) and DOMAIN-HuJf6
+// (too short, already in zitadelErrorIDSentinels for the reset path)
+// share a suffix and are different errors from different Zitadel
+// commands. Everything here keys off the FULL id, the same discipline
+// this package's doc comment records for COMMAND-2M9fs vs COMMAND-G8dh3.
+const (
+	// PasswordMinLength mirrors the live policy's minLength.
+	PasswordMinLength = 12
+)
+
+// The five password-complexity sentinels, one per rule the live policy
+// enforces. A caller branches on these with errors.Is; each one is also
+// reachable as gipadmin.ErrWeakPassword (see policyError.Unwrap) so the
+// existing coarse checks in internal/auth keep working unchanged.
+var (
+	ErrPasswordTooShort    = errors.New("zitadeladmin: password is shorter than the policy minimum")
+	ErrPasswordNoUppercase = errors.New("zitadeladmin: password has no uppercase letter")
+	ErrPasswordNoLowercase = errors.New("zitadeladmin: password has no lowercase letter")
+	ErrPasswordNoNumber    = errors.New("zitadeladmin: password has no number")
+	ErrPasswordNoSymbol    = errors.New("zitadeladmin: password has no symbol")
+)
+
+// PasswordPolicyRuleCode is the machine-readable name of a broken rule.
+// It travels into logs so a support question ("why did this invite
+// fail?") is answerable from one line.
+type PasswordPolicyRuleCode = string
+
+const (
+	RuleTooShort    PasswordPolicyRuleCode = "too_short"
+	RuleNoUppercase PasswordPolicyRuleCode = "no_uppercase"
+	RuleNoLowercase PasswordPolicyRuleCode = "no_lowercase"
+	RuleNoNumber    PasswordPolicyRuleCode = "no_number"
+	RuleNoSymbol    PasswordPolicyRuleCode = "no_symbol"
+)
+
+// passwordPolicyRule is one row of the id table.
+type passwordPolicyRule struct {
+	rule     PasswordPolicyRuleCode
+	sentinel error
+	// message is shown to the person who typed the password. It names
+	// the rule that was actually broken AND restates the full policy,
+	// because fixing one rule commonly reveals the next.
+	message string
+}
+
+// passwordRequirementsSuffix is appended to every rule message so the
+// invitee can satisfy the whole policy in one more attempt rather than
+// discovering it a rule at a time.
+const passwordRequirementsSuffix = " Passwords need at least 12 characters and must include an uppercase letter, a lowercase letter, a number, and a symbol."
+
+// zitadelPasswordPolicyIDs maps Zitadel's stable details[0].id from
+// POST /v2/users/human to the rule it means. Every id here was PROBED
+// live against the TESSERIX instance on 2026-09-05 by submitting a
+// password that broke exactly one rule.
+//
+// Keys are FULL ids. Do not shorten them to suffixes and do not add a
+// prefix-insensitive lookup: DOMAIN-HuJf6 is a different error that ends
+// in the same five characters as COMMA-HuJf6.
+var zitadelPasswordPolicyIDs = map[string]passwordPolicyRule{
+	"COMMA-HuJf6": {RuleTooShort, ErrPasswordTooShort,
+		fmt.Sprintf("That password is too short — it needs at least %d characters.", PasswordMinLength) + passwordRequirementsSuffix},
+	"COMMA-VoaRj": {RuleNoUppercase, ErrPasswordNoUppercase,
+		"That password needs an uppercase letter." + passwordRequirementsSuffix},
+	"COMMA-co3Xw": {RuleNoLowercase, ErrPasswordNoLowercase,
+		"That password needs a lowercase letter." + passwordRequirementsSuffix},
+	"COMMA-ZBv4H": {RuleNoNumber, ErrPasswordNoNumber,
+		"That password needs a number." + passwordRequirementsSuffix},
+	"COMMA-ZDLwA": {RuleNoSymbol, ErrPasswordNoSymbol,
+		"That password needs a symbol, for example ! ? @ or #." + passwordRequirementsSuffix},
+}
+
+// policyError is the error EnsureHumanUser returns when Zitadel rejected
+// the supplied password for breaking one named complexity rule.
+//
+// It carries NO password material — only the Zitadel error id, the rule
+// name, and static message text — so it is safe to log whole. That is
+// deliberate: the reason this classification exists is that the original
+// failure logged nothing, and the fix must not swap one hazard (silence)
+// for another (a credential in Cloud Logging).
+//
+// Unwrap returns BOTH the transport error (whose own chain ends at
+// gipadmin.ErrWeakPassword, see zitadelErrorIDSentinels) and the
+// rule-specific sentinel, so errors.Is matches either granularity.
+type policyError struct {
+	errorID string
+	rule    passwordPolicyRule
+	cause   error
+}
+
+func (e *policyError) Error() string {
+	return fmt.Sprintf("zitadeladmin: password policy violation %s (%s): %v", e.rule.rule, e.errorID, e.cause)
+}
+
+func (e *policyError) Unwrap() []error { return []error{e.cause, e.rule.sentinel} }
+
+// PasswordPolicyRule reports the broken rule and the message to show the
+// person who typed the password.
+//
+// The method — rather than an exported struct — is what lets callers
+// outside this package detect the condition WITHOUT importing
+// zitadeladmin: internal/invitation declares a one-method interface of
+// this shape and errors.As against it, keeping the invitation package
+// free of any identity-provider import (it only ever holds a
+// StaffProvisioner interface today, and that stays true).
+func (e *policyError) PasswordPolicyRule() (PasswordPolicyRuleCode, string) {
+	return e.rule.rule, e.rule.message
+}
+
+// asPasswordPolicyError wraps err with its rule classification when err
+// is a Zitadel password-complexity rejection, and returns err untouched
+// otherwise. Keyed strictly on the whole error id.
+func asPasswordPolicyError(err error) error {
+	if err == nil {
+		return nil
+	}
+	id := errorID(err)
+	if id == "" {
+		return err
+	}
+	rule, ok := zitadelPasswordPolicyIDs[id]
+	if !ok {
+		return err
+	}
+	return &policyError{errorID: id, rule: rule, cause: err}
+}

--- a/services/platform-api/internal/zitadeladmin/password_policy_test.go
+++ b/services/platform-api/internal/zitadeladmin/password_policy_test.go
@@ -1,0 +1,170 @@
+package zitadeladmin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mark8ly/platform-api/internal/gipadmin"
+)
+
+// policyBody builds the error envelope POST /v2/users/human returns for a
+// complexity rejection, in the shape probed live on 2026-09-05.
+func policyBody(id string) string {
+	return `{"code":3,"message":"Errors.User.PasswordComplexityPolicy.NotSatisfied","details":[{"@type":"...","id":"` + id + `"}]}`
+}
+
+// TestPasswordPolicy_EachIDMapsToItsOwnRule is the core of the fix: all
+// five live ids must resolve to DIFFERENT rules and DIFFERENT messages.
+// Collapsing any two would put the merchant back where the incident
+// started — told to change something that was not what they got wrong.
+func TestPasswordPolicy_EachIDMapsToItsOwnRule(t *testing.T) {
+	cases := []struct {
+		id       string
+		wantRule string
+		sentinel error
+		// wantIn is a fragment the message must name, so a future edit
+		// cannot quietly swap two rows' text.
+		wantIn string
+	}{
+		{"COMMA-HuJf6", RuleTooShort, ErrPasswordTooShort, "too short"},
+		{"COMMA-VoaRj", RuleNoUppercase, ErrPasswordNoUppercase, "uppercase"},
+		{"COMMA-co3Xw", RuleNoLowercase, ErrPasswordNoLowercase, "lowercase"},
+		{"COMMA-ZBv4H", RuleNoNumber, ErrPasswordNoNumber, "number"},
+		{"COMMA-ZDLwA", RuleNoSymbol, ErrPasswordNoSymbol, "symbol"},
+	}
+
+	seenRules := map[string]string{}
+	seenMessages := map[string]string{}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(policyBody(tc.id)))
+			})
+			_, err := c.EnsureHumanUser(context.Background(), HumanUser{
+				Email: "invitee@example.com", FirstName: "In", LastName: "Vitee", Password: "Test@123_01",
+			})
+			if err == nil {
+				t.Fatal("EnsureHumanUser = nil error, want a password policy rejection")
+			}
+			if !errors.Is(err, tc.sentinel) {
+				t.Fatalf("err = %v, want sentinel %v", err, tc.sentinel)
+			}
+			// The coarse sentinel must still match, or internal/auth's
+			// existing ErrWeakPassword branches stop firing.
+			if !errors.Is(err, gipadmin.ErrWeakPassword) {
+				t.Errorf("err = %v, must also match gipadmin.ErrWeakPassword", err)
+			}
+
+			var v interface {
+				PasswordPolicyRule() (string, string)
+			}
+			if !errors.As(err, &v) {
+				t.Fatalf("err = %v, want it to expose PasswordPolicyRule", err)
+			}
+			rule, message := v.PasswordPolicyRule()
+			if rule != tc.wantRule {
+				t.Errorf("rule = %q, want %q", rule, tc.wantRule)
+			}
+			if !strings.Contains(strings.ToLower(message), tc.wantIn) {
+				t.Errorf("message = %q, want it to name %q", message, tc.wantIn)
+			}
+			if prev, ok := seenRules[rule]; ok {
+				t.Errorf("rule %q already produced by %s — ids must not collapse", rule, prev)
+			}
+			seenRules[rule] = tc.id
+			if prev, ok := seenMessages[message]; ok {
+				t.Errorf("message already produced by %s — each rule needs its own text", prev)
+			}
+			seenMessages[message] = tc.id
+
+			// The classified error must never carry the password.
+			if strings.Contains(err.Error(), "Test@123_01") {
+				t.Errorf("err.Error() = %q contains the password", err.Error())
+			}
+		})
+	}
+}
+
+// TestPasswordPolicy_SuffixCollisionDoesNotCrossMap is the discipline
+// this package's docs already demand, applied to the new table:
+// COMMA-HuJf6 and DOMAIN-HuJf6 share a five-character suffix and are
+// different errors from different Zitadel commands. Matching on the
+// suffix would make either one impersonate the other.
+func TestPasswordPolicy_SuffixCollisionDoesNotCrossMap(t *testing.T) {
+	t.Run("DOMAIN-HuJf6 is not classified as a COMMA rule", func(t *testing.T) {
+		if _, ok := zitadelPasswordPolicyIDs["DOMAIN-HuJf6"]; ok {
+			t.Fatal("DOMAIN-HuJf6 must not be in the COMMA-keyed policy table")
+		}
+		c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"code":3,"message":"Password is too short","details":[{"id":"DOMAIN-HuJf6"}]}`))
+		})
+		_, err := c.EnsureHumanUser(context.Background(), HumanUser{
+			Email: "a@example.com", FirstName: "A", LastName: "B", Password: "short",
+		})
+		var v interface {
+			PasswordPolicyRule() (string, string)
+		}
+		if errors.As(err, &v) {
+			rule, _ := v.PasswordPolicyRule()
+			t.Fatalf("DOMAIN-HuJf6 was classified as rule %q via suffix matching", rule)
+		}
+		// It keeps its long-standing coarse meaning.
+		if !errors.Is(err, gipadmin.ErrWeakPassword) {
+			t.Errorf("err = %v, want gipadmin.ErrWeakPassword", err)
+		}
+	})
+
+	t.Run("COMMA-HuJf6 does not answer to the DOMAIN sentinel path", func(t *testing.T) {
+		// Both map to ErrWeakPassword by design; what must differ is that
+		// only the COMMA id carries a rule classification.
+		got := asPasswordPolicyError(&apiError{id: "DOMAIN-HuJf6", sentinel: gipadmin.ErrWeakPassword})
+		var v interface {
+			PasswordPolicyRule() (string, string)
+		}
+		if errors.As(got, &v) {
+			t.Fatal("asPasswordPolicyError classified DOMAIN-HuJf6")
+		}
+		got = asPasswordPolicyError(&apiError{id: "COMMA-HuJf6", sentinel: gipadmin.ErrWeakPassword})
+		if !errors.As(got, &v) {
+			t.Fatal("asPasswordPolicyError did not classify COMMA-HuJf6")
+		}
+	})
+}
+
+// TestPasswordPolicy_UnrelatedErrorsPassThroughUnchanged pins that the
+// new wrapper is inert for everything else — an already-exists 409 in
+// particular still resolves to the existing user rather than being
+// converted into a user-facing password complaint.
+func TestPasswordPolicy_UnrelatedErrorsPassThroughUnchanged(t *testing.T) {
+	for _, id := range []string{"", "V3-DKcYh", "COMMAND-SAF4f", "COMMA-notreal"} {
+		in := &apiError{id: id, sentinel: gipadmin.ErrUnavailable}
+		if got := asPasswordPolicyError(in); got != error(in) {
+			t.Errorf("asPasswordPolicyError(id=%q) rewrapped an unrelated error: %v", id, got)
+		}
+	}
+	if asPasswordPolicyError(nil) != nil {
+		t.Error("asPasswordPolicyError(nil) must stay nil")
+	}
+	plain := errors.New("dial tcp: connection refused")
+	if got := asPasswordPolicyError(plain); got != plain {
+		t.Errorf("asPasswordPolicyError rewrapped a non-Zitadel error: %v", got)
+	}
+}
+
+// TestPasswordPolicy_MinLengthMatchesLivePolicy guards the copied
+// constant against drifting away from the message that quotes it.
+func TestPasswordPolicy_MinLengthMatchesLivePolicy(t *testing.T) {
+	if PasswordMinLength != 12 {
+		t.Fatalf("PasswordMinLength = %d, want 12 (live org policy minLength, probed 2026-09-05)", PasswordMinLength)
+	}
+	_, msg := (&policyError{rule: zitadelPasswordPolicyIDs["COMMA-HuJf6"]}).PasswordPolicyRule()
+	if !strings.Contains(msg, "12") {
+		t.Errorf("too-short message %q does not quote the minimum length", msg)
+	}
+}

--- a/services/platform-api/internal/zitadeladmin/provision.go
+++ b/services/platform-api/internal/zitadeladmin/provision.go
@@ -149,7 +149,13 @@ func (c *Client) EnsureHumanUser(ctx context.Context, in HumanUser) (string, err
 		return wire.UserID, nil
 	}
 	if errorID(err) != zitadelErrIDUserAlreadyExists {
-		return "", err
+		// A password-complexity rejection is the CALLER'S input being
+		// wrong, not a server fault, and is by far the most common way
+		// this call fails in practice. asPasswordPolicyError attaches
+		// which rule was broken (see password_policy.go) so the accept
+		// handler can answer 400 with text naming it; every other error
+		// passes through untouched.
+		return "", asPasswordPolicyError(err)
 	}
 	// The account is already there — look it up and carry on.
 	existing, resolveErr := c.resolveUserIDByEmail(ctx, email)


### PR DESCRIPTION
A merchant accepting a staff invitation chose `Test@123_01`, and got:

> "we couldn't finish setting up your account — please try the invitation link again"

The password is 11 characters; Zitadel's policy requires 12. Nothing said so, so the natural response is to retry the same password. Nothing was logged server-side either — diagnosing it meant replaying platform-api's own Zitadel call by hand with its token.

## The live policy, and the ids it returns

`GET /management/v1/policies/password/complexity` (org `386377229942128837`): `minLength 12`, uppercase, lowercase, number and symbol all required.

Each id below was confirmed by an actual probe against production, not read from docs:

| Violation | id |
|---|---|
| too short | `COMMA-HuJf6` |
| no uppercase | `COMMA-VoaRj` |
| no lowercase | `COMMA-co3Xw` |
| no number | `COMMA-ZBv4H` |
| no symbol | `COMMA-ZDLwA` |

Matching is on the **full** id: `COMMA-HuJf6` and `DOMAIN-HuJf6` are different errors that share a suffix, and `DOMAIN-HuJf6` is already used elsewhere for weak passwords.

## Changes

- **platform-api** — five sentinels behind a full-id table; a policy violation is now the caller's fault and answers **400 `password_policy`** naming the broken rule, instead of an opaque 500. Both branches log at ERROR with invitation id, tenant id, rule and cause, with the password redacted. The same ids were added to the reset-password mapping, so a mistyped reset stops reporting as "identity service unreachable".
- **admin** — the requirements are shown as persistent helper text *before* the first submit, validated client-side on the Zitadel path, and the server's specific rule is rendered on the password field when the copies drift.

## What was deliberately not changed

The brief told me to replace the form's `z.string().min(8)`. That schema is **shared with the GIP path**, where the field is often an existing 8-character credential being recalled — tightening it to 12 would have locked legitimate GIP users out of their own invitations, and would have modified the GIP path this work is supposed to leave alone. So `min(8)` is byte-identical and the Zitadel policy is layered on in `onValid`, gated on the provider.

## Verification

`gofmt` clean, `go build ./...` and `go test ./...` green in services/platform-api. `vitest` 1157 passing, `tsc --noEmit` clean, `npm run build` exit 0 in apps/admin. `gitleaks` clean over the branch range — checked before pushing, having twice had fixture literals fail this repo's scanners.

Tests cover each id mapping to its own message, that the `COMMA-`/`DOMAIN-` suffix collision does not cross-map, that the password is never logged, and that an 11-character password like the real failing one is rejected client-side.
