### PR TITLE
fix(admin): pin the OIDC redirect_uri to the canonical login origin

### DIFF
--- a/apps/admin/app/login/authorize/route.test.ts
+++ b/apps/admin/app/login/authorize/route.test.ts
@@ -45,3 +45,47 @@ describe("GET /login/authorize — provider gate", () => {
     expect(location).toContain("https://auth.tesserix.app/oauth/v2/authorize");
   });
 });
+
+describe("GET /login/authorize — redirect_uri is pinned to the canonical origin", () => {
+  // Production incident (#524): the post-accept handoff in accept-invite
+  // jumps straight to this route on the host the invitation link opened —
+  // a {slug}-admin host — skipping the canonical bounce /login performs.
+  // redirect_uri was built from that host, and Zitadel refused it with
+  // "The requested redirect_uri is missing in the client configuration",
+  // because the admin OIDC app registers exactly one callback.
+  function slugHostRequest(): NextRequest {
+    return new NextRequest(
+      "https://the-bondi-store-admin.mark8ly.com/login/authorize?returnUrl=%2Fdashboard",
+      {
+        headers: {
+          host: "the-bondi-store-admin.mark8ly.com",
+          "x-forwarded-host": "the-bondi-store-admin.mark8ly.com",
+          "x-forwarded-proto": "https",
+        },
+      },
+    );
+  }
+
+  it("uses the canonical origin even when the request arrives on a slug host", async () => {
+    vi.stubEnv("NEXT_PUBLIC_ADMIN_LOGIN_ORIGIN", "https://admin.mark8ly.com");
+    const res = await GET(slugHostRequest());
+    const redirectUri = new URL(
+      res.headers.get("location") ?? "",
+    ).searchParams.get("redirect_uri");
+    expect(redirectUri).toBe("https://admin.mark8ly.com/auth/callback");
+    expect(redirectUri).not.toContain("the-bondi-store-admin");
+  });
+
+  it("falls back to the request origin when no canonical origin is configured", async () => {
+    // Dev/preview: same-origin is the only sane default, and matches how
+    // middleware.ts treats an unset NEXT_PUBLIC_ADMIN_LOGIN_ORIGIN.
+    vi.stubEnv("NEXT_PUBLIC_ADMIN_LOGIN_ORIGIN", "");
+    const res = await GET(slugHostRequest());
+    const redirectUri = new URL(
+      res.headers.get("location") ?? "",
+    ).searchParams.get("redirect_uri");
+    expect(redirectUri).toBe(
+      "https://the-bondi-store-admin.mark8ly.com/auth/callback",
+    );
+  });
+});

--- a/apps/admin/app/login/authorize/route.ts
+++ b/apps/admin/app/login/authorize/route.ts
@@ -54,6 +54,28 @@ export async function GET(req: NextRequest): Promise<Response> {
     ? `${forwardedProto ?? "https"}://${forwardedHost}`
     : new URL(req.url).origin;
 
+  // redirect_uri MUST be the canonical login origin, never the host this
+  // request happened to arrive on. Zitadel matches redirect_uri against an
+  // exact registered list, and the admin OIDC app registers exactly one:
+  // https://admin.mark8ly.com/auth/callback.
+  //
+  // Reaching here on a {slug}-admin host is not hypothetical. /login bounces
+  // unauthenticated traffic to the canonical origin first, so the normal path
+  // is already canonical — but the post-accept handoff in accept-invite jumps
+  // straight to THIS route on whatever host the invitation link opened, which
+  // skips that normalisation. In production that produced:
+  //
+  //   {"error":"invalid_request","error_description":"The requested
+  //    redirect_uri is missing in the client configuration."}
+  //
+  // Registering every {slug}-admin callback instead would mean a Zitadel
+  // change per merchant before their admin could log in — the same
+  // does-not-scale trap as the auth-bff return-URL allowlist. The callback
+  // lands on the canonical host and then forwards to returnUrl, so a slug
+  // destination still works; only the OIDC hop is pinned.
+  const canonicalOrigin =
+    process.env.NEXT_PUBLIC_ADMIN_LOGIN_ORIGIN || externalOrigin;
+
   // Re-sanitize even though /login already did: this route is itself
   // a public GET endpoint and must not trust a returnUrl handed to it
   // directly.
@@ -67,7 +89,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   const authorizeUrl = buildZitadelAuthorizeUrl({
     issuer,
     clientId,
-    redirectUri: `${externalOrigin}/auth/callback`,
+    redirectUri: `${canonicalOrigin}/auth/callback`,
     state,
     codeChallenge: challenge,
   });


### PR DESCRIPTION
Signing in after accepting a staff invitation failed at Zitadel with:

```json
{"error":"invalid_request","error_description":"The requested redirect_uri is missing in the client configuration."}
```

## Cause

`/login/authorize` built `redirect_uri` from the host the request arrived on (`x-forwarded-host`). The admin OIDC app registers exactly one callback:

```
redirectUris: ['https://admin.mark8ly.com/auth/callback']
```

`/login` bounces unauthenticated traffic to the canonical origin first, so the ordinary path was already canonical and this never surfaced. The post-accept handoff jumps straight to **this** route on whatever host the invitation link opened — a `{slug}-admin` host — skipping that normalisation, so it asked Zitadel for `https://the-bondi-store-admin.mark8ly.com/auth/callback`, which is not registered.

## Fix

Pin `redirect_uri` to `NEXT_PUBLIC_ADMIN_LOGIN_ORIGIN`, falling back to the request origin when unset (dev/preview, matching how `middleware.ts` already treats it). The callback lands on the canonical host and then forwards to `returnUrl`, so a slug destination still works — only the OIDC hop is pinned.

## Why not register the slug hosts

That would need a Zitadel change per merchant before their admin could log in — the same does-not-scale trap as the auth-bff return-URL allowlist, which already has to enumerate `{slug}-admin` hosts by hand.

## Verification

Two tests, and I checked they actually catch the bug rather than assert a constant: reverting the one-line change fails "uses the canonical origin even when the request arrives on a slug host" and leaves the fallback test passing.

`vitest` green, `tsc --noEmit` clean, `npm run build` exit 0, gitleaks clean over the branch range.
