### PR TITLE
fix(onboarding): provision the merchant in Zitadel so a new store owner can sign in (#685)

### DIFF
--- a/.github/ci/container-images.json
+++ b/.github/ci/container-images.json
@@ -54,7 +54,7 @@
       "dockerfile": "apps/onboarding/Dockerfile",
       "target": "runtime",
       "source_root": "apps/onboarding",
-      "build_args": "NEXT_PUBLIC_GIP_CUSTOMER_TENANT_ID=MP-Customer-39opy",
+      "build_args": "NEXT_PUBLIC_GIP_CUSTOMER_TENANT_ID=MP-Customer-39opy\nNEXT_PUBLIC_AUTH_PROVIDER=zitadel",
       "requires_application_build_secret": true,
       "trivy_ignore_file": ".trivyignore",
       "smoke_port": 4201,

--- a/apps/onboarding/Dockerfile
+++ b/apps/onboarding/Dockerfile
@@ -60,6 +60,17 @@ ARG REUSABLE_PUBLIC_BUILD_ARG_6=""
 ARG REUSABLE_PUBLIC_BUILD_ARG_7=""
 ARG REUSABLE_PUBLIC_BUILD_ARG_8=""
 ARG NEXT_PUBLIC_GIP_CUSTOMER_TENANT_ID=""
+# Which identity provider onboarding creates merchant accounts in (#685).
+# Build-time only, like every NEXT_PUBLIC_* here — a chart env var cannot
+# flip it, because SetPasswordForm is a client component and the value is
+# frozen into the bundle.
+#
+# Defaults to "zitadel" to match apps/admin's own default. The two MUST
+# agree: onboarding creating a GIP account while admin authenticates
+# against Zitadel is exactly the defect #685 reports — the merchant
+# finishes the wizard and is then told "We couldn't find a store for this
+# account. Did you finish onboarding?"
+ARG NEXT_PUBLIC_AUTH_PROVIDER="zitadel"
 ENV NEXT_PUBLIC_GIP_PROJECT_ID=$REUSABLE_PUBLIC_BUILD_ARG_1 \
     NEXT_PUBLIC_GIP_TENANT_ID=$REUSABLE_PUBLIC_BUILD_ARG_2 \
     NEXT_PUBLIC_GIP_CUSTOMER_TENANT_ID=$NEXT_PUBLIC_GIP_CUSTOMER_TENANT_ID \
@@ -67,6 +78,7 @@ ENV NEXT_PUBLIC_GIP_PROJECT_ID=$REUSABLE_PUBLIC_BUILD_ARG_1 \
     NEXT_PUBLIC_GOOGLE_CLIENT_ID=$REUSABLE_PUBLIC_BUILD_ARG_4 \
     NEXT_PUBLIC_MARKETING_URL=$REUSABLE_PUBLIC_BUILD_ARG_6 \
     NEXT_PUBLIC_ADMIN_URL_TEMPLATE=$REUSABLE_PUBLIC_BUILD_ARG_7 \
+    NEXT_PUBLIC_AUTH_PROVIDER=$NEXT_PUBLIC_AUTH_PROVIDER \
     NEXT_TELEMETRY_DISABLED=1
 
 # Pins the Server Action ID hash salt so action IDs stay stable across

--- a/apps/onboarding/app/onboarding/actions.ts
+++ b/apps/onboarding/app/onboarding/actions.ts
@@ -162,6 +162,118 @@ export async function verifyToken(
   }
 }
 
+// ─── completeOnboardingWithZitadel: set-password submit → tenant ───────
+//
+// The Zitadel-path counterpart of completeOnboarding (issue #685).
+// Three things it deliberately does NOT do:
+//
+//   1. No GIP sign-up. Under Zitadel, platform-api's complete endpoint
+//      creates the merchant's account and the mark8ly-admin project
+//      grant, and writes BOTH FGA owner tuples. Creating a GIP user here
+//      is the bug, not the flow.
+//   2. No `owner_user_id`. The merchant has no provider account at this
+//      point, so there is no id to send; platform-api no longer requires
+//      one when a provisioner is wired.
+//   3. No `autoLogin` / no id_token. auth-bff's /auth/auto-login verifies
+//      a GIP id_token and there is none on this path — see
+//      completeOnboardingWithZitadel's doc for what happens instead.
+//
+// It also skips completeOnboarding's `users.listMemberTenants(uid)`
+// pre-check, which has no uid to look up here. Nothing is lost: that
+// check is a UX affordance, and platform-api's own
+// ensureOwnerEmailAvailable — which runs on Complete, not only on
+// Create — is the enforcement point for "this email already owns a
+// store", backed by the tenants_owner_email_unique index.
+interface CompleteWithZitadelInput {
+  sessionId: string;
+  password: string;
+  /** Free-text name from the form; split into the givenName/familyName
+   *  Zitadel requires. platform-api derives both from the email when
+   *  they arrive empty, so a single-word name is fine. */
+  name: string;
+}
+
+/**
+ * What the merchant does after onboarding on the Zitadel path: they sign
+ * in once, with the password they just chose.
+ *
+ * Not a shortcut, and not an oversight. Zitadel's login-client model
+ * requires an `auth_request_id` to sign a user in, and one can only be
+ * minted by the OIDC flow Zitadel itself starts by redirecting to a
+ * fixed, instance-configured login URI. A page cannot mint one for
+ * itself, which is why apps/admin's accept-invite hands the browser to
+ * `/login/authorize` rather than logging the invitee in directly (#680).
+ *
+ * Onboarding cannot even do that much: the admin lives on a DIFFERENT
+ * origin from this app ({slug}-admin.mark8ly.com), so there is no session
+ * cookie this app could set for it under any scheme. The welcome page's
+ * CTA is the hand-off, and admin's own middleware sends an
+ * unauthenticated visitor to its login page. The alternative — stashing
+ * the password to replay it across an origin boundary — is not a trade
+ * worth making.
+ */
+export async function completeOnboardingWithZitadel(
+  input: CompleteWithZitadelInput,
+): Promise<Result<{ tenantId: string; slug: string }>> {
+  try {
+    const sess = await onboarding.getSession(input.sessionId);
+    const draft = sess.draft ?? {};
+    const businessName = draft.business_name ?? "";
+    const slug = draft.slug ?? "";
+    const countryCode = draft.country_code ?? "";
+    const currencyCode = draft.currency_code ?? "";
+    const timezone = draft.timezone ?? "UTC";
+
+    if (!businessName || !slug || !countryCode || !currencyCode) {
+      return {
+        ok: false,
+        code: "draft_incomplete",
+        message:
+          "We couldn't recover your store details. Please start onboarding again.",
+      };
+    }
+
+    const { firstName, lastName } = splitName(input.name);
+
+    const completion = await onboarding.complete(input.sessionId, {
+      business_name: businessName,
+      slug,
+      // Lowercased before it leaves this action: every email-keyed FGA
+      // tuple is lowercase and the admin login path folds to lower
+      // server-side, so a `Founder@Example.com` sent verbatim would later
+      // miss its own membership and produce the misleading "We couldn't
+      // find a store for this account".
+      owner_email: sess.email.trim().toLowerCase(),
+      country_code: countryCode,
+      currency_code: currencyCode,
+      timezone,
+      password: input.password,
+      first_name: firstName,
+      last_name: lastName,
+    });
+
+    return {
+      ok: true,
+      data: { tenantId: completion.tenant_id, slug: completion.slug },
+    };
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/** Splits a free-text name into the two parts Zitadel's profile needs. A
+ *  single word becomes both, which is what platform-api's own derivation
+ *  does — Zitadel rejects an empty familyName outright. */
+function splitName(name: string): { firstName: string; lastName: string } {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return { firstName: "", lastName: "" };
+  if (parts.length === 1) return { firstName: parts[0]!, lastName: parts[0]! };
+  return {
+    firstName: parts[0]!,
+    lastName: parts.slice(1).join(" "),
+  };
+}
+
 // ─── completeOnboarding: set-password submit → tenant + auto-login ─────
 //
 // Called from the /onboarding/set-password page once the user has either

--- a/apps/onboarding/app/onboarding/set-password/page.tsx
+++ b/apps/onboarding/app/onboarding/set-password/page.tsx
@@ -9,6 +9,7 @@
 import { redirect } from "next/navigation";
 
 import { onboarding } from "@/lib/api/platform-api";
+import { publicConfig } from "@/lib/config";
 import { PostSubmitShell } from "@/components/onboarding/PostSubmitShell";
 import { SetPasswordForm } from "@/components/onboarding/SetPasswordForm";
 
@@ -58,6 +59,7 @@ export default async function SetPasswordPage({ searchParams }: PageProps) {
         sessionId={sessionId}
         email={email}
         businessName={businessName}
+        provider={publicConfig.authProvider}
       />
     </PostSubmitShell>
   );

--- a/apps/onboarding/app/welcome/page.tsx
+++ b/apps/onboarding/app/welcome/page.tsx
@@ -2,10 +2,19 @@ import { AppStoreBadges } from "@repo/ui/app-store-badges";
 
 import { PostSubmitShell } from "@/components/onboarding/PostSubmitShell";
 import { WelcomeCta } from "@/components/onboarding/WelcomeCta";
+import { publicConfig } from "@/lib/config";
 
-// Welcome page shown after successful onboarding + auto-login.
-// The session cookie has already been minted by the time the
-// user lands here, so the primary CTA into admin works immediately.
+// Welcome page shown after successful onboarding.
+//
+// On the GIP path the session cookie has already been minted by the time
+// the user lands here, so the primary CTA into admin works immediately.
+// On the Zitadel path it has NOT: the admin is on a different origin and
+// Zitadel's login-client model has no session this app could mint for
+// it, so the merchant signs in there once with the password they just
+// chose (see completeOnboardingWithZitadel's doc). The copy below must
+// not claim otherwise — telling someone they are signed in and then
+// showing them a login screen is the same class of misleading message
+// #685 exists to remove.
 // The CTA itself is a client component so it can read the freshly
 // onboarded tenant slug from the zustand store and build a per-tenant
 // admin URL — see components/onboarding/WelcomeCta.tsx.
@@ -17,11 +26,16 @@ export const metadata = {
 };
 
 export default function WelcomePage() {
+  const signedIn = publicConfig.authProvider !== "zitadel";
   return (
     <PostSubmitShell
       eyebrow="Store ready"
       title="Your store is open."
-      description="You&rsquo;re signed in. Step into the admin dashboard to add your first product, shape your storefront, and confirm your settings."
+      description={
+        signedIn
+          ? "You\u2019re signed in. Step into the admin dashboard to add your first product, shape your storefront, and confirm your settings."
+          : "Sign in to the admin dashboard with the password you just chose to add your first product, shape your storefront, and confirm your settings."
+      }
     >
       <div className="border-t border-border-subtle pt-10">
         {/* Head start — same 20% the admin checklist opens with, so the
@@ -42,7 +56,7 @@ export default function WelcomePage() {
           </p>
         </div>
 
-        <WelcomeCta />
+        <WelcomeCta signedIn={signedIn} />
 
         <dl className="mt-16 grid gap-10 border-t border-border-subtle pt-10 sm:grid-cols-2">
           <div>
@@ -60,8 +74,8 @@ export default function WelcomePage() {
           </div>
         </dl>
 
-        {/* Highest-intent moment in the funnel: the store exists and they
-            are already signed in. Badges render per configured platform —
+        {/* Highest-intent moment in the funnel: the store exists.
+            Badges render per configured platform —
             see MOBILE_ADMIN_APP_LINKS. */}
         <section className="mt-16 border-t border-border-subtle pt-10">
           <p className="eyebrow mb-3">On your phone</p>

--- a/apps/onboarding/components/onboarding/SetPasswordForm.tsx
+++ b/apps/onboarding/components/onboarding/SetPasswordForm.tsx
@@ -40,13 +40,28 @@ import {
   GIPSignupError,
 } from "@/lib/gip/signup";
 import { getGoogleCredential } from "@/lib/gip/google-gsi";
-import { completeOnboarding } from "@/app/onboarding/actions";
+import {
+  completeOnboarding,
+  completeOnboardingWithZitadel,
+} from "@/app/onboarding/actions";
+import {
+  PASSWORD_REQUIREMENTS_TEXT,
+  validateNewPassword,
+} from "@/lib/auth/password-policy";
 import { useOnboardingStore } from "@/lib/store/onboarding-store";
 
 interface Props {
   sessionId: string;
   email: string;
   businessName: string;
+  /**
+   * Which identity provider backs merchant accounts. Read defensively,
+   * exactly as apps/admin's AcceptInviteForm reads it: only the literal
+   * "zitadel" switches this form onto the Zitadel path — anything else,
+   * including undefined, keeps the GIP flow byte-for-byte. Wired from
+   * `publicConfig.authProvider` by app/onboarding/set-password/page.tsx.
+   */
+  provider?: string;
 }
 
 const schema = z.object({
@@ -59,6 +74,17 @@ const schema = z.object({
     .trim()
     .min(1, "Your name is required")
     .max(80, "Name is too long"),
+  // The shared floor, left exactly as it was: GIP's own minimum is 8 and
+  // the GIP path is not being changed here.
+  //
+  // The real Zitadel policy (12 characters, upper, lower, number,
+  // symbol — see lib/auth/password-policy.ts) is applied on top of this
+  // in onValid, and ONLY on the Zitadel path. Applying it through a
+  // second resolver schema would mean swapping resolvers underneath
+  // react-hook-form on a prop change, a subtlety this form does not need.
+  // A client rule LOOSER than the server's is worse than no rule at all —
+  // it promises an acceptance the server will refuse — which is exactly
+  // what min(8) was doing here (#685).
   password: z
     .string()
     .min(1, "Password is required")
@@ -67,8 +93,9 @@ const schema = z.object({
 
 type FormValues = z.infer<typeof schema>;
 
-export function SetPasswordForm({ sessionId, email }: Props) {
+export function SetPasswordForm({ sessionId, email, provider }: Props) {
   const router = useRouter();
+  const isZitadel = provider === "zitadel";
   const setSubmitted = useOnboardingStore((s) => s.setSubmitted);
   const storedSlug = useOnboardingStore((s) => s.slug);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -88,8 +115,57 @@ export function SetPasswordForm({ sessionId, email }: Props) {
     defaultValues: { name: "", password: "" },
   });
 
+  /**
+   * Finish the wizard on the Zitadel path.
+   *
+   * platform-api's complete endpoint provisions the Zitadel user from
+   * this password, ensures the mark8ly-admin project grant, and writes
+   * both FGA owner tuples — so there is nothing for the browser to create
+   * first, and no GIP call of any kind on this path.
+   *
+   * No auto-login follows. See completeOnboardingWithZitadel's doc for
+   * why: the admin is on a different origin and Zitadel's login-client
+   * model has no session this page could mint. The merchant signs in
+   * once, on the admin, with the password they just chose.
+   */
+  function completeWithZitadel(values: FormValues) {
+    startTransition(async () => {
+      const r = await completeOnboardingWithZitadel({
+        sessionId,
+        password: values.password,
+        name: values.name,
+      });
+      if (!r.ok) {
+        // The server is authoritative on the password policy: the client
+        // copy above and it can drift. When platform-api names the rule
+        // that was broken, put its message on the password field where
+        // the fix is, not in the generic form-level alert.
+        if (r.code === "password_policy") {
+          setError("password", { type: "server", message: r.message });
+          return;
+        }
+        setSubmitError(r.message);
+        return;
+      }
+      if (r.data.slug) {
+        setSubmitted({ email, sessionId, businessName: "", slug: r.data.slug, countryCode: "", currencyCode: "", timezone: "", taxId: "", migrationType: "new", whoisUrl: "", screenshotUrl: "" });
+      }
+      router.push("/welcome");
+    });
+  }
+
   function onValid(values: FormValues) {
     setSubmitError(null);
+
+    if (isZitadel) {
+      const policyError = validateNewPassword(values.password);
+      if (policyError) {
+        setError("password", { type: "validate", message: policyError });
+        return;
+      }
+      completeWithZitadel(values);
+      return;
+    }
 
     startTransition(async () => {
       let uid = "";
@@ -251,13 +327,26 @@ export function SetPasswordForm({ sessionId, email }: Props) {
           <Input
             id="password"
             type="password"
-            placeholder="At least 8 characters"
+            placeholder={
+              isZitadel ? "At least 12 characters" : "At least 8 characters"
+            }
             autoComplete="new-password"
             disabled={disabled}
             aria-invalid={errors.password ? true : undefined}
-            aria-describedby={errors.password ? "password-error" : undefined}
+            aria-describedby={
+              errors.password
+                ? "password-error"
+                : isZitadel
+                  ? "password-requirements"
+                  : undefined
+            }
             {...register("password")}
           />
+          {/* The whole policy, shown BEFORE the first submit. A merchant
+              choosing a password should not have to guess and be
+              corrected one rule at a time — that drip-feed is what the
+              incident behind lib/auth/password-policy.ts was made of.
+              Zitadel path only: the GIP minimum really is 8. */}
           <div className="min-h-[1.125rem]">
             {errors.password ? (
               <p
@@ -267,6 +356,13 @@ export function SetPasswordForm({ sessionId, email }: Props) {
                 className="text-xs text-danger"
               >
                 {errors.password.message}
+              </p>
+            ) : isZitadel ? (
+              <p
+                id="password-requirements"
+                className="text-xs text-foreground-tertiary"
+              >
+                {PASSWORD_REQUIREMENTS_TEXT}
               </p>
             ) : null}
           </div>
@@ -290,7 +386,15 @@ export function SetPasswordForm({ sessionId, email }: Props) {
           {pending ? "Finishing up…" : "Create account"}
         </button>
 
-        <div className="relative py-2">
+        {/* Google is GIP-only here. On the Zitadel path the backend
+            provisions from a PASSWORD rather than an IDP intent, and
+            there is no auto-login to hand a Google credential to — a
+            merchant who wants Google can use it on the admin sign-in page
+            once their account exists. Mirrors what apps/admin's
+            accept-invite form does, for the same two reasons (#680). */}
+        {!isZitadel && (
+          <>
+            <div className="relative py-2">
           <div className="absolute inset-0 flex items-center" aria-hidden="true">
             <div className="w-full border-t border-border-subtle" />
           </div>
@@ -309,7 +413,9 @@ export function SetPasswordForm({ sessionId, email }: Props) {
         >
           <GoogleMark />
           {googlePending ? "Opening Google…" : "Continue with Google"}
-        </button>
+            </button>
+          </>
+        )}
       </form>
     </div>
   );

--- a/apps/onboarding/components/onboarding/WelcomeCta.tsx
+++ b/apps/onboarding/components/onboarding/WelcomeCta.tsx
@@ -27,7 +27,15 @@ const ADMIN_URL_TEMPLATE =
  * leaving the `{slug}` placeholder in place — the subdomain 404 will
  * make the problem obvious rather than silently leaking to localhost.
  */
-export function WelcomeCta() {
+interface WelcomeCtaProps {
+  /** False on the Zitadel path, where no session was minted for the admin
+   *  origin and the merchant signs in there once. Only the button LABEL
+   *  changes — the destination is the same either way, and admin's own
+   *  middleware sends an unauthenticated visitor to its login page. */
+  signedIn?: boolean;
+}
+
+export function WelcomeCta({ signedIn = true }: WelcomeCtaProps) {
   const slug = useOnboardingStore((s) => s.slug);
   const adminUrl = resolveAdminUrl(ADMIN_URL_TEMPLATE, slug);
 
@@ -37,7 +45,7 @@ export function WelcomeCta() {
         href={adminUrl}
         className="inline-flex h-12 items-center rounded-md bg-primary px-6 text-base font-medium text-primary-foreground hover:bg-primary-hover"
       >
-        Open admin dashboard
+        {signedIn ? "Open admin dashboard" : "Sign in to your admin"}
       </a>
       <Link href="/" className="btn-ghost">
         Back to home

--- a/apps/onboarding/lib/api/platform-api.ts
+++ b/apps/onboarding/lib/api/platform-api.ts
@@ -101,11 +101,20 @@ export const onboarding = {
     body: {
       business_name: string;
       slug: string;
-      owner_user_id: string;
+      /** GIP path only. On the Zitadel path the merchant has no provider
+       *  account yet — platform-api's complete endpoint creates it — so
+       *  there is no id to send and the field is omitted entirely. */
+      owner_user_id?: string;
       owner_email: string;
       country_code: string;
       currency_code: string;
       timezone: string;
+      /** Zitadel path only: the password platform-api creates the
+       *  merchant's Zitadel account with. Never sent under GIP, where the
+       *  browser already created the account. */
+      password?: string;
+      first_name?: string;
+      last_name?: string;
     },
   ) =>
     request<CompleteResult>(

--- a/apps/onboarding/lib/auth/password-policy.ts
+++ b/apps/onboarding/lib/auth/password-policy.ts
@@ -1,0 +1,98 @@
+import { z } from "zod";
+
+/**
+ * The password rules Zitadel actually enforces, mirrored here so the
+ * browser can say "no" before the network does.
+ *
+ * # Why this file exists
+ *
+ * A merchant accepted a staff invitation with an eleven-character
+ * password. That form's schema said `min(8)`, so it submitted happily;
+ * Zitadel's policy requires twelve, so provisioning failed, and the
+ * invitee was shown an opaque "we couldn't finish setting up your
+ * account". They retried the same password. Onboarding's set-password
+ * form had the identical `min(8)` and the identical failure ahead of it
+ * (#685) — with no fallback account, since this is the merchant's first.
+ *
+ * A client rule that is LOOSER than the server's is worse than no client
+ * rule at all: it promises an acceptance the server will refuse.
+ *
+ * # Source of truth
+ *
+ * The live instance policy is the authority:
+ * `GET /management/v1/policies/password/complexity`, org
+ * 386377229942128837 — PROBED 2026-09-05:
+ *
+ *     minLength: 12, hasUppercase, hasLowercase, hasNumber, hasSymbol
+ *
+ * These constants are a copy of it, and the ONLY copy on the TypeScript
+ * side — the schema, the helper text under the field, and the tests all
+ * read them from here. Its counterpart is
+ * `services/platform-api/internal/zitadeladmin/password_policy.go`; the
+ * two cannot share a literal across the language boundary, so they share
+ * a comment instead. Change the org policy and both must move.
+ *
+ * The policy is deliberately NOT fetched at runtime. Zitadel remains the
+ * enforcer either way, the server now returns the specific rule that was
+ * broken when the two ever disagree, and an extra round trip on page
+ * load to learn a number that changes approximately never is not a trade
+ * worth making.
+ */
+export const PASSWORD_MIN_LENGTH = 12;
+
+/**
+ * The whole policy in one sentence, shown under the field BEFORE the
+ * first submit. Discoverability is the point: a merchant choosing a
+ * password should not have to guess and be corrected one rule at a time.
+ */
+export const PASSWORD_REQUIREMENTS_TEXT = `At least ${PASSWORD_MIN_LENGTH} characters, with an uppercase letter, a lowercase letter, a number, and a symbol.`;
+
+/**
+ * Every rule reports the SAME message — the full requirements — rather
+ * than the first one that failed. Reporting only "needs a number" invites
+ * the user to add a number and then be told about the symbol, which is
+ * the drip-feed the incident was made of.
+ */
+export const PASSWORD_REQUIREMENTS_MESSAGE = `Password must be at least ${PASSWORD_MIN_LENGTH} characters, with an uppercase letter, a lowercase letter, a number, and a symbol.`;
+
+/**
+ * A symbol is anything that is not a letter or a digit, which is how
+ * Zitadel's `hasSymbol` behaves. Kept broad on purpose: a client rule
+ * narrower than the server's would reject a password Zitadel accepts.
+ */
+const SYMBOL = /[^A-Za-z0-9]/;
+
+/**
+ * Schema for a password the merchant is CHOOSING (it will create, or be
+ * checked against, a Zitadel account).
+ *
+ * Not for the GIP path, whose own minimum is 8 and which this file must
+ * not tighten: the GIP flow is the fallback and stays byte-identical.
+ * See SetPasswordForm for where that branch is made.
+ *
+ * A verbatim copy of apps/admin/lib/auth/password-policy.ts. The two
+ * apps cannot share a module (separate Next builds, no shared auth
+ * package) and the alternative — onboarding silently using a looser
+ * rule than accept-invite — is the exact class of bug this file was
+ * written for. Its Go counterpart is
+ * services/platform-api/internal/zitadeladmin/password_policy.go; all
+ * three move together.
+ */
+export const newPasswordSchema = z
+  .string()
+  .min(PASSWORD_MIN_LENGTH, PASSWORD_REQUIREMENTS_MESSAGE)
+  .regex(/[A-Z]/, PASSWORD_REQUIREMENTS_MESSAGE)
+  .regex(/[a-z]/, PASSWORD_REQUIREMENTS_MESSAGE)
+  .regex(/[0-9]/, PASSWORD_REQUIREMENTS_MESSAGE)
+  .regex(SYMBOL, PASSWORD_REQUIREMENTS_MESSAGE);
+
+/**
+ * Imperative form of the schema, for callers that want a message or
+ * null rather than a Zod result.
+ */
+export function validateNewPassword(password: string): string | null {
+  const result = newPasswordSchema.safeParse(password);
+  return result.success
+    ? null
+    : (result.error.issues[0]?.message ?? PASSWORD_REQUIREMENTS_MESSAGE);
+}

--- a/apps/onboarding/lib/config.ts
+++ b/apps/onboarding/lib/config.ts
@@ -24,6 +24,17 @@ export const config = {
 } as const;
 
 export const publicConfig = {
+  /** Which identity provider backs merchant accounts.
+   *
+   *  Read defensively, exactly as apps/admin reads it: only the literal
+   *  "zitadel" switches onboarding onto the Zitadel path — anything
+   *  else, including undefined, keeps the GIP flow byte-for-byte. Baked
+   *  into the client bundle at build time (see the Dockerfile), because
+   *  SetPasswordForm is a client component and has to branch before it
+   *  ever reaches a server action. */
+  authProvider: (process.env.NEXT_PUBLIC_AUTH_PROVIDER === "zitadel"
+    ? "zitadel"
+    : "gip") as "gip" | "zitadel",
   /** GIP / Firebase project ID. Browser-exposed by design. */
   gipProjectId: process.env.NEXT_PUBLIC_GIP_PROJECT_ID ?? "",
   /** GIP tenant pool for marketplace internal users (admin/onboarding). */

--- a/apps/onboarding/tests/unit/onboarding-zitadel-complete.spec.ts
+++ b/apps/onboarding/tests/unit/onboarding-zitadel-complete.spec.ts
@@ -1,0 +1,214 @@
+import { test, expect } from "@playwright/test";
+
+// Issue #685 — the onboarding completion server actions, asserted
+// against the bytes they actually put on the wire.
+//
+// The bug being fixed was precisely a payload/endpoint mismatch: a GIP
+// uid written where the Zitadel admin login path reads an email. A test
+// that stopped at "the action returned ok" would not have caught it, and
+// neither would one that mocked the platform-api client module — the
+// mismatch lives in the JSON body.
+
+import {
+  completeOnboarding,
+  completeOnboardingWithZitadel,
+} from "../../app/onboarding/actions";
+
+interface RecordedCall {
+  url: string;
+  body: Record<string, unknown>;
+}
+
+const SESSION_ID = "sess-685";
+const SESSION_URL = `http://localhost:8086/api/v1/onboarding/sessions/${SESSION_ID}`;
+const COMPLETE_URL = `${SESSION_URL}/complete`;
+
+// A password that satisfies the live Zitadel policy (12+ characters,
+// upper, lower, number, symbol) while being unmistakably not a real
+// credential.
+const PASSWORD = "Not-A-Real-Password-1!";
+
+const SESSION_BODY = {
+  data: {
+    id: SESSION_ID,
+    // Mixed case on purpose: every email-keyed FGA tuple is lowercase.
+    email: "Founder@Example.test",
+    status: "in_progress",
+    email_verified_at: "2026-09-05T00:00:00Z",
+    draft: {
+      business_name: "Bondi Surf Co",
+      slug: "bondi-surf",
+      country_code: "AU",
+      currency_code: "AUD",
+      timezone: "Australia/Sydney",
+    },
+  },
+};
+
+const COMPLETE_BODY = {
+  data: { tenant_id: "tenant-685", slug: "bondi-surf" },
+};
+
+/**
+ * Replaces global fetch with a router over exact URLs, recording every
+ * request. Any URL without a handler fails the test from inside the
+ * action — which is how "the Zitadel path must never call auth-bff" is
+ * asserted below rather than merely hoped for.
+ */
+function installFetch(
+  handlers: Record<string, () => { status?: number; json: unknown }>,
+): RecordedCall[] {
+  const calls: RecordedCall[] = [];
+  globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({
+      url,
+      body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>,
+    });
+    const handler = handlers[url];
+    if (!handler) throw new Error(`unexpected request to ${url}`);
+    const { status = 200, json } = handler();
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => json,
+      headers: { get: () => null },
+    };
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+test("the Zitadel path sends a password and no owner_user_id", async () => {
+  const calls = installFetch({
+    [SESSION_URL]: () => ({ json: SESSION_BODY }),
+    [COMPLETE_URL]: () => ({ json: COMPLETE_BODY }),
+  });
+
+  const result = await completeOnboardingWithZitadel({
+    sessionId: SESSION_ID,
+    password: PASSWORD,
+    name: "Ada Lovelace",
+  });
+
+  expect(result.ok).toBe(true);
+
+  const complete = calls.find((c) => c.url === COMPLETE_URL);
+  expect(complete, "the complete endpoint was never called").toBeTruthy();
+  // The whole bug in one assertion: no GIP uid may be sent as the owner.
+  expect(complete!.body).not.toHaveProperty("owner_user_id");
+  expect(complete!.body.password).toBe(PASSWORD);
+  expect(complete!.body.first_name).toBe("Ada");
+  expect(complete!.body.last_name).toBe("Lovelace");
+});
+
+test("the Zitadel path lowercases the owner email it sends", async () => {
+  const calls = installFetch({
+    [SESSION_URL]: () => ({ json: SESSION_BODY }),
+    [COMPLETE_URL]: () => ({ json: COMPLETE_BODY }),
+  });
+
+  await completeOnboardingWithZitadel({
+    sessionId: SESSION_ID,
+    password: PASSWORD,
+    name: "Ada Lovelace",
+  });
+
+  // The session carries Founder@Example.test. An email-keyed FGA tuple
+  // written verbatim would never match the login path's lowercased
+  // lookup, and the merchant would be told "We couldn't find a store for
+  // this account" seconds after finishing onboarding.
+  const complete = calls.find((c) => c.url === COMPLETE_URL)!;
+  expect(complete.body.owner_email).toBe("founder@example.test");
+});
+
+test("the Zitadel path never calls auth-bff auto-login", async () => {
+  // Only the two platform-api URLs are routed. auth-bff's /auth/auto-login
+  // verifies a GIP id_token; there is none on this path, and a call to it
+  // would throw here rather than silently 401ing in production.
+  const calls = installFetch({
+    [SESSION_URL]: () => ({ json: SESSION_BODY }),
+    [COMPLETE_URL]: () => ({ json: COMPLETE_BODY }),
+  });
+
+  const result = await completeOnboardingWithZitadel({
+    sessionId: SESSION_ID,
+    password: PASSWORD,
+    name: "Ada Lovelace",
+  });
+
+  expect(result.ok).toBe(true);
+  expect(calls.map((c) => c.url)).toEqual([SESSION_URL, COMPLETE_URL]);
+});
+
+test("a single-word name still fills both Zitadel profile fields", async () => {
+  const calls = installFetch({
+    [SESSION_URL]: () => ({ json: SESSION_BODY }),
+    [COMPLETE_URL]: () => ({ json: COMPLETE_BODY }),
+  });
+
+  await completeOnboardingWithZitadel({
+    sessionId: SESSION_ID,
+    password: PASSWORD,
+    name: "Ada",
+  });
+
+  // Zitadel rejects an empty givenName/familyName outright.
+  const complete = calls.find((c) => c.url === COMPLETE_URL)!;
+  expect(complete.body.first_name).toBe("Ada");
+  expect(complete.body.last_name).toBe("Ada");
+});
+
+test("a password_policy rejection reaches the caller with its own code", async () => {
+  installFetch({
+    [SESSION_URL]: () => ({ json: SESSION_BODY }),
+    [COMPLETE_URL]: () => ({
+      status: 400,
+      json: {
+        error: "password_policy",
+        message:
+          "Password must be at least 12 characters, with an uppercase letter, a lowercase letter, a number, and a symbol.",
+      },
+    }),
+  });
+
+  const result = await completeOnboardingWithZitadel({
+    sessionId: SESSION_ID,
+    password: "short",
+    name: "Ada Lovelace",
+  });
+
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  // The form puts this on the password field, not in a generic alert —
+  // so the code has to survive the round trip intact.
+  expect(result.code).toBe("password_policy");
+  expect(result.message).toContain("12 characters");
+});
+
+test("the GIP path still sends owner_user_id and still calls auth-bff", async () => {
+  const MEMBERSHIPS_URL =
+    "http://localhost:8086/api/v1/users/me/tenants?uid=gip-uid-1";
+  const AUTO_LOGIN_URL = "http://localhost:8087/auth/auto-login";
+
+  const calls = installFetch({
+    [SESSION_URL]: () => ({ json: SESSION_BODY }),
+    [MEMBERSHIPS_URL]: () => ({ json: { data: [] } }),
+    [COMPLETE_URL]: () => ({ json: COMPLETE_BODY }),
+    [AUTO_LOGIN_URL]: () => ({ json: { data: {} } }),
+  });
+
+  const result = await completeOnboarding({
+    sessionId: SESSION_ID,
+    gipUid: "gip-uid-1",
+    gipIdToken: "gip-id-token",
+  });
+
+  expect(result.ok).toBe(true);
+
+  const complete = calls.find((c) => c.url === COMPLETE_URL)!;
+  expect(complete.body.owner_user_id).toBe("gip-uid-1");
+  // And nothing from the Zitadel path leaked into it.
+  expect(complete.body).not.toHaveProperty("password");
+  expect(complete.body).not.toHaveProperty("first_name");
+  expect(calls.some((c) => c.url === AUTO_LOGIN_URL)).toBe(true);
+});

--- a/apps/onboarding/tests/unit/password-policy.spec.ts
+++ b/apps/onboarding/tests/unit/password-policy.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+
+// Issue #685 — the browser-side copy of Zitadel's password policy.
+//
+// The rule this file protects: a client rule LOOSER than the server's is
+// worse than no client rule at all, because it promises an acceptance the
+// server will refuse. Onboarding's set-password form said min(8) while
+// the live org policy requires 12 plus four character classes, so a
+// merchant could submit happily and then be told, opaquely, that their
+// store could not be created.
+
+import {
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_REQUIREMENTS_TEXT,
+  validateNewPassword,
+} from "../../lib/auth/password-policy";
+
+test("the minimum matches the live org policy, not GIP's old floor", () => {
+  expect(PASSWORD_MIN_LENGTH).toBe(12);
+});
+
+test("the requirements text names every rule before the first submit", () => {
+  for (const rule of ["12", "uppercase", "lowercase", "number", "symbol"]) {
+    expect(PASSWORD_REQUIREMENTS_TEXT.toLowerCase()).toContain(rule);
+  }
+});
+
+test("a compliant password is accepted", () => {
+  // Obviously fake, and still satisfies all five rules.
+  expect(validateNewPassword("Not-A-Real-Password-1!")).toBeNull();
+});
+
+test("each rule is enforced, and the message restates the whole policy", () => {
+  const rejected: Record<string, string> = {
+    // Eleven characters — the exact shape of the reported incident.
+    too_short: "Sh0rt-Pass!",
+    no_uppercase: "not-a-real-password-1!",
+    no_lowercase: "NOT-A-REAL-PASSWORD-1!",
+    no_number: "Not-A-Real-Password!!",
+    no_symbol: "NotARealPassword1234",
+  };
+
+  for (const [rule, password] of Object.entries(rejected)) {
+    const message = validateNewPassword(password);
+    expect(message, `${rule} was accepted`).not.toBeNull();
+    // Fixing one rule commonly reveals the next, so every rejection
+    // restates the full policy rather than drip-feeding.
+    expect(message).toContain("12 characters");
+    expect(message).toContain("symbol");
+  }
+});

--- a/services/platform-api/cmd/server/main.go
+++ b/services/platform-api/cmd/server/main.go
@@ -192,6 +192,17 @@ func main() {
 
 	vendorClient := marketplaceapi.NewVendorClient(cfg.MarketplaceAPIURL, cfg.MarketplaceInternalAuthSecret)
 
+	// Zitadel-path owner provisioning for onboarding completion (#685).
+	// Nil (and every downstream behaviour byte-identical to before)
+	// unless ZITADEL_ENABLED is true; a misconfiguration panics rather
+	// than quietly onboarding merchants who can never sign in — see
+	// newOwnerProvisioner's doc.
+	ownerProvisioner, ownerProvErr := newOwnerProvisioner(cfg)
+	if ownerProvErr != nil {
+		log.Error("owner provisioner wiring", "err", ownerProvErr)
+		panic(ownerProvErr)
+	}
+
 	onboardingSvc := onboarding.NewService(onboarding.Config{
 		DB:                    conn,
 		Repo:                  onboarding.NewRepository(conn),
@@ -204,6 +215,7 @@ func main() {
 		StorefrontURLTemplate: cfg.StorefrontBaseURLTemplate,
 		SupportEmail:          cfg.EmailFrom,
 		VendorClient:          vendorClient,
+		Provisioner:           ownerProvisioner,
 	})
 	onboardingHandler := onboarding.NewHandler(onboardingSvc, verifSvc)
 

--- a/services/platform-api/cmd/server/provider_wiring.go
+++ b/services/platform-api/cmd/server/provider_wiring.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mark8ly/platform-api/internal/auth"
 	"github.com/mark8ly/platform-api/internal/gipadmin"
 	"github.com/mark8ly/platform-api/internal/invitation"
+	"github.com/mark8ly/platform-api/internal/onboarding"
 	"github.com/mark8ly/platform-api/internal/zitadeladmin"
 	"github.com/mark8ly/platform-api/pkg/config"
 )
@@ -101,6 +102,55 @@ func selectAccountProviders(cfg *config.Config, gipAdmin *gipadmin.AdminClient) 
 // precise bug this function exists to fix — an invited teammate who is
 // told "we couldn't find a store for this account" at every sign-in.
 func newStaffProvisioner(cfg *config.Config) (invitation.StaffProvisioner, error) {
+	p, err := buildZitadelProvisioner(cfg)
+	if err != nil || p == nil {
+		// Never `return p, err` — p is a CONCRETE pointer, and a nil one
+		// assigned into the interface return would produce a NON-NIL
+		// interface holding nil, which is exactly the GIP-path selector
+		// invitation.Service branches on. See selectAccountProviders'
+		// typed-nil section.
+		return nil, err
+	}
+	return p, nil
+}
+
+// newOwnerProvisioner builds the onboarding.OwnerProvisioner that
+// onboarding.Complete calls to create the MERCHANT's Zitadel account and
+// grant them the mark8ly-admin project role (#685).
+//
+// Same construction, same true-nil discipline, and deliberately the same
+// underlying *zitadeladmin.StaffProvisioner as newStaffProvisioner —
+// including the same role key. The mark8ly-admin project defines exactly
+// one role, mark8ly.staff, and a Zitadel project grant only decides
+// whether the OIDC flow may complete at all; it carries no authority.
+// Authority is the FGA `owner` tuple onboarding writes. Minting a second
+// Zitadel role to express "owner" would duplicate that decision in a
+// place nothing reads.
+//
+// Returns a true nil when cfg.ZitadelEnabled is false, which selects the
+// GIP path inside onboarding.Service: under GIP the set-password form
+// creates the account client-side before calling platform-api, so the
+// server has nothing to provision and the behaviour must stay exactly as
+// it was. A configuration problem when Zitadel IS enabled is a startup
+// failure, not a degraded mode — wiring nil here would leave onboarding
+// writing a GIP-shaped tuple into a Zitadel world and reproduce the
+// precise bug this exists to fix: a merchant told "We couldn't find a
+// store for this account. Did you finish onboarding?" seconds after
+// finishing onboarding.
+func newOwnerProvisioner(cfg *config.Config) (onboarding.OwnerProvisioner, error) {
+	p, err := buildZitadelProvisioner(cfg)
+	if err != nil || p == nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// buildZitadelProvisioner returns the shared Zitadel provisioner, or a
+// nil pointer (and nil error) when Zitadel is not enabled. Both callers
+// above convert that nil pointer into a true nil interface themselves —
+// this function must NOT return an interface, or the typed-nil trap
+// moves in here where it is harder to see.
+func buildZitadelProvisioner(cfg *config.Config) (*zitadeladmin.StaffProvisioner, error) {
 	if !cfg.ZitadelEnabled {
 		return nil, nil
 	}

--- a/services/platform-api/cmd/server/provider_wiring_test.go
+++ b/services/platform-api/cmd/server/provider_wiring_test.go
@@ -247,3 +247,53 @@ func TestNewStaffProvisioner_MissingProjectID_FailsClearly(t *testing.T) {
 		t.Fatal("provisioner must be nil on misconfiguration")
 	}
 }
+
+// --- newOwnerProvisioner: onboarding-completion provisioning (#685) ----
+
+// TestNewOwnerProvisioner_FlagUnset_StaysGenuinelyNil pins the GIP path
+// for onboarding, for the same reason its invite-accept twin above does:
+// a non-nil interface wrapping a nil pointer would flip
+// onboarding.Complete onto the Zitadel branch and panic on the first
+// merchant to finish the wizard.
+func TestNewOwnerProvisioner_FlagUnset_StaysGenuinelyNil(t *testing.T) {
+	p, err := newOwnerProvisioner(&config.Config{ZitadelEnabled: false})
+	if err != nil {
+		t.Fatalf("newOwnerProvisioner() error = %v, want nil", err)
+	}
+	if p != nil {
+		t.Fatal("provisioner must be a genuinely nil interface when Zitadel is disabled")
+	}
+}
+
+// TestNewOwnerProvisioner_FlagSet_BuildsZitadelProvisioner pins that the
+// merchant is provisioned by the SAME type an invited teammate is. The
+// mark8ly-admin project has exactly one role and the grant only gates
+// access to the project; the owner/staff distinction lives in FGA.
+func TestNewOwnerProvisioner_FlagSet_BuildsZitadelProvisioner(t *testing.T) {
+	p, err := newOwnerProvisioner(zitadelStaffConfig())
+	if err != nil {
+		t.Fatalf("newOwnerProvisioner() error = %v, want nil", err)
+	}
+	if _, ok := p.(*zitadeladmin.StaffProvisioner); !ok {
+		t.Fatalf("provisioner = %T, want *zitadeladmin.StaffProvisioner", p)
+	}
+}
+
+// TestNewOwnerProvisioner_MissingProjectID_FailsClearly pins that a
+// misconfigured deployment crashloops rather than onboarding merchants
+// who hold no grant on the admin project and therefore cannot sign in.
+func TestNewOwnerProvisioner_MissingProjectID_FailsClearly(t *testing.T) {
+	cfg := zitadelStaffConfig()
+	cfg.ZitadelAdminProjectID = ""
+
+	p, err := newOwnerProvisioner(cfg)
+	if err == nil {
+		t.Fatal("newOwnerProvisioner() = nil error, want a misconfiguration error")
+	}
+	if !errors.Is(err, config.ErrZitadelNotConfigured) {
+		t.Fatalf("err = %v, want it to wrap config.ErrZitadelNotConfigured", err)
+	}
+	if p != nil {
+		t.Fatal("provisioner must be nil on misconfiguration")
+	}
+}

--- a/services/platform-api/internal/onboarding/complete_zitadel_integration_test.go
+++ b/services/platform-api/internal/onboarding/complete_zitadel_integration_test.go
@@ -1,0 +1,144 @@
+//go:build integration
+
+package onboarding
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/mark8ly/platform-api/internal/authz"
+	"github.com/mark8ly/platform-api/internal/notification"
+	"github.com/mark8ly/platform-api/internal/outbox"
+	"github.com/mark8ly/platform-api/internal/store"
+	"github.com/mark8ly/platform-api/internal/tenant"
+	"github.com/mark8ly/platform-api/pkg/testdb"
+)
+
+// Issue #685 — the committed half of onboarding completion on the
+// Zitadel path, against a real database.
+//
+// What this pins that the unit tests cannot: that a completed onboarding
+// leaves BOTH FGA owner tuples in place — one keyed by the merchant's
+// lowercased email, which is what apps/admin's resolveWorkspaceTenant
+// reads BEFORE authentication, and one keyed by the Zitadel user id,
+// which is what the bearer-token API reads. Writing either one alone
+// produces a merchant who can sign in but gets 403 from every API call,
+// or one who is told "We couldn't find a store for this account. Did you
+// finish onboarding?" at the login screen. Before this fix onboarding
+// wrote a third key — the GIP uid — which matches neither.
+
+type stubOwnerProvisioner struct {
+	uid   string
+	calls int
+	pass  string
+}
+
+func (p *stubOwnerProvisioner) ProvisionStaff(_ context.Context, _, _, _, password string) (string, error) {
+	p.calls++
+	p.pass = password
+	return p.uid, nil
+}
+
+func TestIntegration_Complete_ZitadelWritesBothOwnerTuples(t *testing.T) {
+	db := testdb.NewDB(t,
+		"outbox_events",
+		"verification_tokens",
+		"onboarding_sessions",
+		"stores",
+		"tenants",
+	)
+
+	prov := &stubOwnerProvisioner{uid: "zitadel-user-685"}
+	tenantRepo := tenant.NewRepository(db)
+	onboardingRepo := NewRepository(db)
+	svc := NewService(Config{
+		DB:           db,
+		Repo:         onboardingRepo,
+		TenantRepo:   tenantRepo,
+		StoreRepo:    store.NewRepository(db),
+		Sender:       notification.NoopSender{},
+		EmailFrom:    "noreply@test.local",
+		SupportEmail: "help@test.local",
+		Provisioner:  prov,
+	})
+
+	ctx := context.Background()
+	now := time.Now()
+	sess := &Session{
+		Email:           "founder@zitadel-onboarding.local",
+		Draft:           json.RawMessage(`{}`),
+		Status:          StatusInProgress,
+		EmailVerifiedAt: &now,
+	}
+	if err := onboardingRepo.Create(ctx, sess); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	res, err := svc.Complete(ctx, CompleteRequest{
+		SessionID:    sess.ID,
+		BusinessName: "Zitadel Onboarding Co",
+		Slug:         "zitadel-onboarding",
+		// Deliberately mixed case: the tuple must be lowercased.
+		OwnerEmail:   "Founder@Zitadel-Onboarding.local",
+		CountryCode:  "AU",
+		CurrencyCode: "AUD",
+		Timezone:     "Australia/Sydney",
+		FirstName:    "Ada",
+		LastName:     "Lovelace",
+		Password:     "Not-A-Real-Password-1!",
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if prov.calls != 1 {
+		t.Fatalf("provisioner called %d times, want exactly 1", prov.calls)
+	}
+	if prov.pass != "Not-A-Real-Password-1!" {
+		t.Fatalf("password not forwarded to the provisioner: %q", prov.pass)
+	}
+
+	// The tenant's owner is the ZITADEL uid, not the caller's — it is
+	// the id the bearer API sees and the one later membership writes
+	// key on.
+	tn, err := tenantRepo.GetByID(ctx, res.TenantID)
+	if err != nil {
+		t.Fatalf("tenant lookup: %v", err)
+	}
+	if tn.OwnerUserID != "zitadel-user-685" {
+		t.Errorf("tenant.OwnerUserID = %q, want zitadel-user-685", tn.OwnerUserID)
+	}
+
+	// The GIP tenant_id claim is a GIP-only concept keyed by GIP uid.
+	// Under Zitadel it would resolve nothing and be retried forever, so
+	// no row must be enqueued at all.
+	var claimCount int64
+	if err := db.Model(&outbox.Event{}).Where("kind = ?", GIPClaimOutboxKind).Count(&claimCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if claimCount != 0 {
+		t.Errorf("GIP claim outbox rows = %d, want 0 on the Zitadel path", claimCount)
+	}
+
+	fake := authz.NewFake()
+	d := outbox.NewDrainer(db, slog.New(slog.NewTextHandler(io.Discard, nil)), outbox.Config{})
+	d.Register(FGAOutboxKind, NewFGAOutboxHandler(fake))
+	if err := d.Tick(ctx); err != nil {
+		t.Fatalf("drainer tick: %v", err)
+	}
+
+	// Both readers, both keys.
+	if !fake.HasOwnership("founder@zitadel-onboarding.local", res.TenantID) {
+		t.Error("no email-keyed owner tuple — admin sign-in resolves membership by email and would say 'no store found'")
+	}
+	if !fake.HasOwnership("zitadel-user-685", res.TenantID) {
+		t.Error("no uid-keyed owner tuple — every bearer-token API call would 403")
+	}
+	// And never the pre-fix key.
+	if fake.HasOwnership("Founder@Zitadel-Onboarding.local", res.TenantID) {
+		t.Error("a mixed-case email tuple was written; every email-keyed tuple must be lowercased")
+	}
+}

--- a/services/platform-api/internal/onboarding/complete_zitadel_test.go
+++ b/services/platform-api/internal/onboarding/complete_zitadel_test.go
@@ -1,0 +1,254 @@
+package onboarding
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+
+	apperrors "github.com/mark8ly/platform-api/pkg/errors"
+)
+
+// Issue #685 — the halves of onboarding completion that need no
+// database. Everything here exercises the code that runs BEFORE the
+// completion transaction, which is exactly where the Zitadel
+// provisioning step was added and exactly where its failures must be
+// contained. The full commit path (both FGA tuples, the GIP claim) is
+// covered against a real database in complete_zitadel_integration_test.go.
+
+// fakeSessionRepo serves one verified session and is a tripwire on
+// everything else: the tests below must never reach a write.
+type fakeSessionRepo struct {
+	sess *Session
+	t    *testing.T
+}
+
+func (f *fakeSessionRepo) Create(context.Context, *Session) error {
+	f.t.Fatal("Create called")
+	return nil
+}
+func (f *fakeSessionRepo) GetByID(_ context.Context, id string) (*Session, error) {
+	if f.sess == nil || f.sess.ID != id {
+		return nil, apperrors.NotFound("session_not_found", "no such session")
+	}
+	return f.sess, nil
+}
+func (f *fakeSessionRepo) UpdateDraft(context.Context, string, json.RawMessage) error {
+	f.t.Fatal("UpdateDraft called")
+	return nil
+}
+func (f *fakeSessionRepo) MarkEmailVerified(context.Context, string) error {
+	f.t.Fatal("MarkEmailVerified called")
+	return nil
+}
+func (f *fakeSessionRepo) CompleteInTx(context.Context, *gorm.DB, string, string) error {
+	f.t.Fatal("CompleteInTx called — completion should have aborted before the transaction")
+	return nil
+}
+func (f *fakeSessionRepo) GetFunnel(context.Context, FunnelFilter) (*FunnelStats, error) {
+	f.t.Fatal("GetFunnel called")
+	return nil, nil
+}
+func (f *fakeSessionRepo) ListSessions(context.Context, FunnelFilter) ([]SessionRow, int64, error) {
+	f.t.Fatal("ListSessions called")
+	return nil, 0, nil
+}
+
+// recordingProvisioner captures the arguments Complete passes and
+// answers with a fixed result.
+type recordingProvisioner struct {
+	uid   string
+	err   error
+	calls int
+	email string
+	first string
+	last  string
+	pass  string
+}
+
+func (p *recordingProvisioner) ProvisionStaff(_ context.Context, email, first, last, password string) (string, error) {
+	p.calls++
+	p.email, p.first, p.last, p.pass = email, first, last, password
+	return p.uid, p.err
+}
+
+// policyErr satisfies the passwordPolicyViolation interface the same way
+// *zitadeladmin.policyError does, without importing that package (which
+// this one deliberately does not know about).
+type policyErr struct{}
+
+func (policyErr) Error() string { return "zitadeladmin: password is shorter than the policy minimum" }
+func (policyErr) PasswordPolicyRule() (string, string) {
+	return "too_short", "Password must be at least 12 characters, with an uppercase letter, a lowercase letter, a number, and a symbol."
+}
+
+func verifiedSession(t *testing.T) *Session {
+	t.Helper()
+	now := time.Now()
+	return &Session{
+		ID:              "sess-685",
+		Email:           "founder@example.test",
+		Draft:           json.RawMessage(`{}`),
+		Status:          StatusInProgress,
+		EmailVerifiedAt: &now,
+	}
+}
+
+func zitadelRequest() CompleteRequest {
+	return CompleteRequest{
+		SessionID:    "sess-685",
+		BusinessName: "Bondi Surf Co",
+		Slug:         "bondi-surf",
+		OwnerEmail:   "Founder@Example.test",
+		CountryCode:  "AU",
+		CurrencyCode: "AUD",
+		Timezone:     "Australia/Sydney",
+		FirstName:    "Ada",
+		LastName:     "Lovelace",
+		// Obviously fake, and still satisfies the live policy (12+
+		// chars, upper, lower, number, symbol) so it exercises the real
+		// validation rather than tripping it.
+		Password: "Not-A-Real-Password-1!",
+	}
+}
+
+// The Zitadel path must abort the whole completion when provisioning
+// fails — no tenant, no store, no outbox row. The fake repository above
+// fails the test from inside CompleteInTx if the transaction is ever
+// entered, so this asserts the ordering and not merely the error.
+func TestComplete_ZitadelProvisioningFailureAborts(t *testing.T) {
+	prov := &recordingProvisioner{err: errors.New("zitadel unreachable")}
+	svc := NewService(Config{
+		Repo:        &fakeSessionRepo{sess: verifiedSession(t), t: t},
+		Provisioner: prov,
+	})
+
+	_, err := svc.Complete(context.Background(), zitadelRequest())
+	if err == nil {
+		t.Fatal("expected Complete to fail when provisioning fails")
+	}
+	ae, ok := apperrors.As(err)
+	if !ok {
+		t.Fatalf("expected an AppError, got %T", err)
+	}
+	if ae.Status != 500 || ae.Code != "provisioning_failed" {
+		t.Fatalf("got %d %s, want 500 provisioning_failed", ae.Status, ae.Code)
+	}
+	if prov.calls != 1 {
+		t.Fatalf("provisioner called %d times, want 1", prov.calls)
+	}
+}
+
+// A password the identity provider rejects is the MERCHANT'S input being
+// wrong, so it must come back as 400 with the specific rule named —
+// not the opaque 500 that had an invitee retyping the same password.
+func TestComplete_ZitadelPasswordPolicyRejectionNamesTheRule(t *testing.T) {
+	prov := &recordingProvisioner{err: policyErr{}}
+	svc := NewService(Config{
+		Repo:        &fakeSessionRepo{sess: verifiedSession(t), t: t},
+		Provisioner: prov,
+	})
+
+	_, err := svc.Complete(context.Background(), zitadelRequest())
+	ae, ok := apperrors.As(err)
+	if !ok {
+		t.Fatalf("expected an AppError, got %T (%v)", err, err)
+	}
+	if ae.Status != 400 {
+		t.Fatalf("status = %d, want 400 — a bad password is not a server fault", ae.Status)
+	}
+	if ae.Code != "password_policy" {
+		t.Fatalf("code = %q, want password_policy (the code apps/onboarding branches on)", ae.Code)
+	}
+	if !strings.Contains(ae.Message, "12 characters") {
+		t.Fatalf("message %q does not name the rule that was broken", ae.Message)
+	}
+	if strings.Contains(ae.Message, "Not-A-Real-Password-1!") {
+		t.Fatal("the rejected password was echoed back to the caller")
+	}
+}
+
+// Complete must hand the provisioner a LOWERCASED email. Every
+// email-keyed FGA tuple is lowercase and the login path folds to lower
+// server-side, so a merchant who typed Founder@Example.test would
+// otherwise miss their own membership.
+func TestComplete_ZitadelNormalisesTheEmailItProvisions(t *testing.T) {
+	prov := &recordingProvisioner{err: errors.New("stop here")}
+	svc := NewService(Config{
+		Repo:        &fakeSessionRepo{sess: verifiedSession(t), t: t},
+		Provisioner: prov,
+	})
+
+	_, _ = svc.Complete(context.Background(), zitadelRequest())
+
+	if prov.email != "founder@example.test" {
+		t.Fatalf("provisioned email = %q, want the lowercased address", prov.email)
+	}
+	if prov.first != "Ada" || prov.last != "Lovelace" {
+		t.Fatalf("profile names = %q/%q, want Ada/Lovelace", prov.first, prov.last)
+	}
+	if prov.pass != "Not-A-Real-Password-1!" {
+		t.Fatalf("password was not passed through verbatim: %q", prov.pass)
+	}
+}
+
+// Zitadel rejects an empty givenName/familyName outright, so a merchant
+// who typed no name must still get a derived one rather than a failed
+// signup.
+func TestComplete_ZitadelDerivesNamesFromTheEmail(t *testing.T) {
+	prov := &recordingProvisioner{err: errors.New("stop here")}
+	svc := NewService(Config{
+		Repo:        &fakeSessionRepo{sess: verifiedSession(t), t: t},
+		Provisioner: prov,
+	})
+	req := zitadelRequest()
+	req.FirstName, req.LastName = "", ""
+
+	_, _ = svc.Complete(context.Background(), req)
+
+	if prov.first == "" || prov.last == "" {
+		t.Fatalf("derived names were empty (%q/%q) — Zitadel would reject the create", prov.first, prov.last)
+	}
+}
+
+// owner_user_id is required on the GIP path and must NOT be on the
+// Zitadel path, where the account does not exist yet. The GIP branch's
+// error code and message are pinned because the GIP path is the
+// fallback and its responses must stay byte-identical.
+func TestValidateCompleteRequest_OwnerUserIDRequiredOnlyUnderGIP(t *testing.T) {
+	req := zitadelRequest()
+
+	if err := validateCompleteRequest(req, false); err != nil {
+		t.Fatalf("Zitadel path rejected a request with no owner_user_id: %v", err)
+	}
+
+	err := validateCompleteRequest(req, true)
+	ae, ok := apperrors.As(err)
+	if !ok {
+		t.Fatalf("GIP path accepted a request with no owner_user_id (%v)", err)
+	}
+	if ae.Status != 400 || ae.Code != "invalid_owner" || ae.Message != "owner_user_id is required" {
+		t.Fatalf("GIP-path error changed: %d %s %q", ae.Status, ae.Code, ae.Message)
+	}
+}
+
+// The GIP path must not construct a provisioner call at all. Asserted
+// via the service rather than by reading the code: a nil provisioner is
+// what selects it, and a typed-nil interface would silently pass a
+// `!= nil` guard and panic here instead.
+func TestComplete_GIPPathNeverProvisions(t *testing.T) {
+	svc := NewService(Config{Repo: &fakeSessionRepo{sess: verifiedSession(t), t: t}})
+
+	req := zitadelRequest()
+	req.OwnerUserID = "" // GIP path: the form supplies one; this is the reject case
+	_, err := svc.Complete(context.Background(), req)
+
+	ae, ok := apperrors.As(err)
+	if !ok || ae.Code != "invalid_owner" {
+		t.Fatalf("expected the unchanged GIP validation error, got %v", err)
+	}
+}

--- a/services/platform-api/internal/onboarding/fga_handler.go
+++ b/services/platform-api/internal/onboarding/fga_handler.go
@@ -10,10 +10,15 @@ import (
 )
 
 // NewFGAOutboxHandler returns the outbox handler that ships the
-// onboarding-completion FGA tuples to OpenFGA. Two tuples:
+// onboarding-completion FGA tuples to OpenFGA:
 //
-//  1. user:<uid> owner tenant:<tid>       — Phase D/O
+//  1. user:<subject> owner tenant:<tid>   — Phase D/O, once per subject
 //  2. tenant:<tid> parent store:<sid>     — Phase Q
+//
+// There is ONE subject on the GIP path (the GIP uid) and TWO on the
+// Zitadel path (the owner's lowercased email and their Zitadel user id).
+// See fgaWritePayload.UserIDs for why both keys are required rather than
+// merely convenient.
 //
 // The parent tuple unlocks the `from parent` inheritance in the
 // store type's DSL: tenant owners/admins automatically get
@@ -29,11 +34,24 @@ func NewFGAOutboxHandler(fga authz.Client) outbox.Handler {
 		if err := json.Unmarshal(payload, &p); err != nil {
 			return fmt.Errorf("fga outbox: parse payload: %w", err)
 		}
-		if p.UserID == "" || p.TenantID == "" {
+		// user_ids is the current shape; user_id is what every row
+		// enqueued before #685 carries, and rows pending across the
+		// rollout must still drain. Reading both is what makes this deploy
+		// safe in either order.
+		subjects := p.UserIDs
+		if len(subjects) == 0 && p.UserID != "" {
+			subjects = []string{p.UserID}
+		}
+		if len(subjects) == 0 || p.TenantID == "" {
 			return fmt.Errorf("fga outbox: missing user_id or tenant_id")
 		}
-		if err := fga.WriteOwnership(ctx, p.UserID, p.TenantID); err != nil {
-			return fmt.Errorf("fga outbox: write ownership: %w", err)
+		for _, subject := range subjects {
+			if subject == "" {
+				return fmt.Errorf("fga outbox: empty subject in user_ids")
+			}
+			if err := fga.WriteOwnership(ctx, subject, p.TenantID); err != nil {
+				return fmt.Errorf("fga outbox: write ownership for %q: %w", subject, err)
+			}
 		}
 		// StoreID is optional so pre-Phase-Q outbox rows that were
 		// written without one (and any future tuple-write payloads

--- a/services/platform-api/internal/onboarding/fga_handler_test.go
+++ b/services/platform-api/internal/onboarding/fga_handler_test.go
@@ -90,3 +90,56 @@ func TestFGAOutboxHandler_RejectsMalformedPayload(t *testing.T) {
 		})
 	}
 }
+
+// Issue #685 — the Zitadel path enqueues TWO subjects (the owner's
+// lowercased email and their Zitadel user id) and both must become owner
+// tuples. See fgaWritePayload.UserIDs for why one key is not enough.
+func TestFGAOutboxHandler_WritesEveryZitadelSubject(t *testing.T) {
+	fake := authz.NewFake()
+	handler := NewFGAOutboxHandler(fake)
+
+	payload, _ := json.Marshal(fgaWritePayload{
+		UserIDs:  []string{"founder@example.test", "zitadel-user-685"},
+		UserID:   "zitadel-user-685",
+		TenantID: "tenant-685",
+		StoreID:  "store-685",
+	})
+	if err := handler(context.Background(), payload); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	for _, subject := range []string{"founder@example.test", "zitadel-user-685"} {
+		if !fake.HasOwnership(subject, "tenant-685") {
+			t.Errorf("no ownership tuple for %q", subject)
+		}
+	}
+}
+
+// Rows enqueued by the image running BEFORE #685 carry only `user_id`
+// and are still pending when the new image starts draining. They must
+// keep working, or a rollout strands whichever merchants completed
+// onboarding in the seconds around it.
+func TestFGAOutboxHandler_StillDrainsLegacySingleSubjectRows(t *testing.T) {
+	fake := authz.NewFake()
+	handler := NewFGAOutboxHandler(fake)
+
+	// Written by hand in the pre-#685 shape — no user_ids key at all.
+	payload := []byte(`{"user_id":"gip-uid-legacy","tenant_id":"tenant-legacy"}`)
+	if err := handler(context.Background(), payload); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if !fake.HasOwnership("gip-uid-legacy", "tenant-legacy") {
+		t.Error("legacy single-subject row did not produce an ownership tuple")
+	}
+}
+
+// An empty string in user_ids would write `user:` — a tuple that matches
+// nobody and is invisible to the store's usual queries. Fail loudly so
+// the drainer retries instead.
+func TestFGAOutboxHandler_RejectsEmptySubject(t *testing.T) {
+	handler := NewFGAOutboxHandler(authz.NewFake())
+	payload := []byte(`{"user_ids":["ok@example.test",""],"tenant_id":"t"}`)
+	if err := handler(context.Background(), payload); err == nil {
+		t.Error("expected an error for an empty subject")
+	}
+}

--- a/services/platform-api/internal/onboarding/provisioning_error.go
+++ b/services/platform-api/internal/onboarding/provisioning_error.go
@@ -1,0 +1,92 @@
+package onboarding
+
+import (
+	"errors"
+	"log"
+	"strings"
+
+	apperrors "github.com/mark8ly/platform-api/pkg/errors"
+)
+
+// This file turns an OwnerProvisioner failure into (a) an HTTP answer the
+// merchant can act on and (b) exactly one log line an operator can
+// diagnose from. It is the onboarding twin of
+// internal/invitation/provisioning_error.go, written after the same
+// incident that one records: an 11-character password against a policy
+// that requires 12 produced an opaque 500 and no log line at all, so the
+// person who typed it retried the same password.
+//
+// It is a deliberate copy rather than a shared helper. The two paths
+// share a classification but not a REMEDY — "open the invitation link
+// again" is correct for an invitee and meaningless to a merchant whose
+// wizard session is still open in front of them — and the message is the
+// whole point of the file.
+
+// passwordPolicyViolation is the shape a provisioner error implements
+// when the identity provider rejected the chosen password for breaking a
+// named complexity rule. *zitadeladmin.policyError satisfies it.
+//
+// Declared here as an interface rather than importing zitadeladmin: this
+// package knows nothing about which identity provider is wired (projects,
+// role keys and policy ids are all deployment concerns), and an import
+// would make that false. errors.As against a one-method interface keeps
+// the dependency pointing the right way.
+//
+// The returned message is provider-authored, static text naming the
+// broken rule; it contains no password material.
+type passwordPolicyViolation interface {
+	error
+	PasswordPolicyRule() (rule string, message string)
+}
+
+// passwordPolicyCode is the single machine-readable code every
+// password-complexity rejection is returned under. One code, not five:
+// the browser needs exactly one branch — "put this on the password
+// field" — and the rule-specific detail belongs in the message, which is
+// the part a human reads. It matches the code apps/admin's accept form
+// already branches on, so both wizards behave identically.
+const passwordPolicyCode = "password_policy"
+
+// provisioningError maps a ProvisionStaff failure onto an AppError and
+// logs the cause.
+//
+// A password-complexity rejection is 400, not 500: it is the caller's
+// input that is wrong, and answering 500 tells both the merchant and
+// every dashboard the wrong story about whose fault it is.
+//
+// password is passed in ONLY so redactPassword can guarantee it is not
+// echoed back out of an error string. It is never itself logged.
+func provisioningError(err error, sessionID, email, password string) error {
+	var violation passwordPolicyViolation
+	if errors.As(err, &violation) {
+		rule, message := violation.PasswordPolicyRule()
+		log.Printf("ERROR onboarding.Complete: identity provider rejected the chosen password: "+
+			"session=%s email=%s rule=%s cause=%s",
+			sessionID, email, rule, redactPassword(err.Error(), password))
+		return apperrors.Wrap(err, 400, passwordPolicyCode, message)
+	}
+
+	log.Printf("ERROR onboarding.Complete: owner provisioning failed: session=%s email=%s cause=%s",
+		sessionID, email, redactPassword(err.Error(), password))
+	return apperrors.Wrap(err, 500, "provisioning_failed",
+		"we couldn't finish creating your admin account — nothing was charged or created, please try again")
+}
+
+// redactPassword removes password from s.
+//
+// Belt and braces. No error this package receives is supposed to embed
+// the credential — zitadeladmin's apiError formats only method, path,
+// status, error id and sentinel, and never the request body — but the
+// log line above is the first place in this flow that prints an upstream
+// error verbatim, and "no current code path leaks it" is a property that
+// silently stops holding the moment someone adds %v of a request body to
+// an error string upstream.
+//
+// An empty password redacts nothing: strings.ReplaceAll with an empty
+// old value splices the replacement between every character.
+func redactPassword(s, password string) string {
+	if password == "" {
+		return s
+	}
+	return strings.ReplaceAll(s, password, "[redacted]")
+}

--- a/services/platform-api/internal/onboarding/service.go
+++ b/services/platform-api/internal/onboarding/service.go
@@ -45,6 +45,29 @@ type VendorEnsurer interface {
 //     the tuple is actually visible.
 //
 // Together these close the race window from both ends.
+// OwnerProvisioner makes the onboarding merchant a sign-in-capable
+// identity in the identity provider and returns their provider user id.
+//
+// Non-nil ONLY on the Zitadel path (see cmd/server/provider_wiring.go's
+// newOwnerProvisioner). Nil selects the GIP path, whose behaviour is
+// unchanged: under GIP the set-password form creates the account
+// client-side before it ever calls platform-api, so there is nothing to
+// provision server-side and the caller-supplied owner_user_id is already
+// a real identity.
+//
+// Satisfied by *zitadeladmin.StaffProvisioner — the SAME type
+// internal/invitation uses, and deliberately so. The merchant needs
+// exactly what an invited teammate needs: a Zitadel account and a grant
+// on the mark8ly-admin project, whose projectRoleCheck: true otherwise
+// makes OIDC finalize return 403 OIDC-foSyH49RvL. There is only one role
+// on that project (mark8ly.staff) and it gates PROJECT ACCESS, not
+// authority — the owner/staff distinction lives entirely in FGA, which
+// is why the owner reuses the staff role key here and still gets an FGA
+// `owner` tuple below.
+type OwnerProvisioner interface {
+	ProvisionStaff(ctx context.Context, email, firstName, lastName, password string) (string, error)
+}
+
 type Service struct {
 	db                    *gorm.DB
 	repo                  Repository
@@ -57,6 +80,7 @@ type Service struct {
 	adminURLTemplate      string
 	storefrontURLTemplate string
 	vendorClient          VendorEnsurer
+	provisioner           OwnerProvisioner
 }
 
 // Config holds Service dependencies.
@@ -81,6 +105,10 @@ type Config struct {
 	// A nil VendorClient disables the call (useful for tests that don't
 	// need the vendor path).
 	VendorClient VendorEnsurer
+	// Provisioner creates the owner's identity-provider account and admin
+	// project grant during Complete. Nil on the GIP path — see
+	// OwnerProvisioner's doc.
+	Provisioner OwnerProvisioner
 }
 
 // NewService constructs a Service.
@@ -97,6 +125,7 @@ func NewService(cfg Config) *Service {
 		adminURLTemplate:      cfg.AdminURLTemplate,
 		storefrontURLTemplate: cfg.StorefrontURLTemplate,
 		vendorClient:          cfg.VendorClient,
+		provisioner:           cfg.Provisioner,
 	}
 }
 
@@ -203,8 +232,22 @@ type CompleteRequest struct {
 	SessionID    string `json:"session_id"`
 	BusinessName string `json:"business_name"`
 	Slug         string `json:"slug"`
-	OwnerUserID  string `json:"owner_user_id"` // GIP UID
-	OwnerEmail   string `json:"owner_email"`
+	// OwnerUserID is the GIP UID of the account the set-password form
+	// already created. Required on the GIP path ONLY. On the Zitadel path
+	// the merchant has no provider account at this point — creating one is
+	// what Complete does — so there is no id for the caller to send and
+	// the field is ignored.
+	OwnerUserID string `json:"owner_user_id"`
+	OwnerEmail  string `json:"owner_email"`
+	// Password is the password to create the owner's Zitadel account
+	// with. Zitadel path only, and only consulted when no account exists
+	// for the address yet. Ignored entirely on the GIP path.
+	Password string `json:"password"`
+	// FirstName / LastName populate the Zitadel profile. Optional —
+	// derived from the email local part when absent (Zitadel rejects an
+	// empty givenName/familyName).
+	FirstName    string `json:"first_name"`
+	LastName     string `json:"last_name"`
 	CountryCode  string `json:"country_code"`
 	CurrencyCode string `json:"currency_code"`
 	Timezone     string `json:"timezone"`
@@ -225,9 +268,32 @@ type CompleteResult struct {
 // `from parent` inheritance works for the default store created
 // during onboarding.
 type fgaWritePayload struct {
-	UserID   string `json:"user_id"`
-	TenantID string `json:"tenant_id"`
-	StoreID  string `json:"store_id,omitempty"`
+	// UserID is the single subject the GIP path writes, and is what every
+	// outbox row enqueued before #685 carries. The handler still reads
+	// it, so rows left pending across the rollout drain unchanged.
+	UserID string `json:"user_id"`
+	// UserIDs is the Zitadel path's subject list: the owner's lowercased
+	// EMAIL and their Zitadel user id, both written as owner tuples.
+	//
+	// Two keys because three readers disagree on what a member is keyed
+	// by, exactly as #679/#680 found for invitation accept:
+	//
+	//   - admin sign-in (apps/admin/app/login/actions.ts,
+	//     resolveWorkspaceTenant) looks membership up by EMAIL on the
+	//     Zitadel path — tenant resolution runs BEFORE authentication, so
+	//     at that moment the typed address is the only identifier in
+	//     existence and there is no `sub` to key on;
+	//   - the bearer-token API path resolves by the Zitadel uid;
+	//   - this code used to write only the GIP uid, which after the
+	//     Zitadel cutover matches neither — the bug #685 reports.
+	//
+	// Writing one key breaks the other reader: email-only 403s every API
+	// call, uid-only puts the merchant back on "We couldn't find a store
+	// for this account. Did you finish onboarding?" — the message they
+	// are shown seconds after finishing onboarding.
+	UserIDs  []string `json:"user_ids,omitempty"`
+	TenantID string   `json:"tenant_id"`
+	StoreID  string   `json:"store_id,omitempty"`
 }
 
 // FGAOutboxKind is the dispatch key for FGA membership writes.
@@ -250,7 +316,12 @@ const FGAOutboxKind = "fga.write_membership"
 // After commit (NOT in the tx) we send the welcome email best-effort.
 // Failure to send is logged but does not fail completion.
 func (s *Service) Complete(ctx context.Context, req CompleteRequest) (*CompleteResult, error) {
-	if err := validateCompleteRequest(req); err != nil {
+	// owner_user_id is required on the GIP path only. With a provisioner
+	// wired (Zitadel) the merchant has no provider account yet, so there
+	// is no uid to send — this call is what creates one. The error code
+	// and message are unchanged so the GIP path's response stays
+	// byte-identical.
+	if err := validateCompleteRequest(req, s.provisioner == nil); err != nil {
 		return nil, err
 	}
 
@@ -274,6 +345,41 @@ func (s *Service) Complete(ctx context.Context, req CompleteRequest) (*CompleteR
 		return nil, err
 	}
 
+	// Provision the merchant in the identity provider (Zitadel path only;
+	// s.provisioner is nil under GIP). This runs BEFORE the transaction,
+	// and a failure aborts Complete with no tenant, no store and no
+	// outbox row written.
+	//
+	// That ordering is the point, and it is the same one
+	// invitation.Accept uses. The failure worth preventing is a
+	// HALF-provisioned merchant — a tenant whose owner has no Zitadel
+	// account or no project grant — which looks like a finished signup
+	// right up until the first sign-in fails, and which the merchant
+	// cannot repair themselves. The reverse leak, a Zitadel account
+	// created for a completion that then fails at the DB, IS possible and
+	// is deliberately the cheaper one: ProvisionStaff resolves an
+	// existing account instead of failing, so the retry the merchant is
+	// already going to make lands on the same user, and an account with a
+	// project grant but no tenant cannot sign in to anything.
+	ownerUserID := strings.TrimSpace(req.OwnerUserID)
+	ownerEmail := strings.ToLower(strings.TrimSpace(req.OwnerEmail))
+	// subjects are the FGA tuple keys: one under GIP (the uid the form
+	// already created), two under Zitadel — see fgaWritePayload.UserIDs.
+	subjects := []string{ownerUserID}
+	if s.provisioner != nil {
+		first, last := profileNames(req.FirstName, req.LastName, ownerEmail)
+		zitadelUID, provErr := s.provisioner.ProvisionStaff(ctx, ownerEmail, first, last, req.Password)
+		if provErr != nil {
+			return nil, provisioningError(provErr, req.SessionID, ownerEmail, req.Password)
+		}
+		ownerUserID = zitadelUID
+		// Email first, lowercased: the login path folds to lower
+		// server-side and every email-keyed tuple in the store is
+		// lowercase, so `Founder@Example.com` written verbatim would miss
+		// its own membership.
+		subjects = []string{ownerEmail, zitadelUID}
+	}
+
 	// Phase Q: onboarding creates BOTH a tenant (the company) and a
 	// default store (the first storefront) in the same transaction.
 	// The merchant's "business name" becomes both the tenant.name
@@ -282,11 +388,14 @@ func (s *Service) Complete(ctx context.Context, req CompleteRequest) (*CompleteR
 	// slug + currency + timezone + country — the user-facing
 	// storefront identity.
 	t := &tenant.Tenant{
-		Name:        req.BusinessName,
-		OwnerUserID: req.OwnerUserID,
+		Name: req.BusinessName,
+		// The Zitadel user id on the Zitadel path, not the caller's: it is
+		// the id the bearer API sees and the one every later membership
+		// write keys on.
+		OwnerUserID: ownerUserID,
 		// Store normalized so the row matches what the case-insensitive
 		// uniqueness check and the lower(owner_email) index compare on.
-		OwnerEmail: strings.ToLower(strings.TrimSpace(req.OwnerEmail)),
+		OwnerEmail: ownerEmail,
 		Status:     tenant.StatusActive,
 	}
 	st := &store.Store{
@@ -317,7 +426,8 @@ func (s *Service) Complete(ctx context.Context, req CompleteRequest) (*CompleteR
 		// Phase D outbox event — owner tuple on the tenant. Store-
 		// level tuples come with Phase R (store-level invites).
 		if err := outbox.Enqueue(tx, FGAOutboxKind, fgaWritePayload{
-			UserID:   req.OwnerUserID,
+			UserID:   ownerUserID,
+			UserIDs:  subjects,
 			TenantID: t.ID,
 			StoreID:  st.ID,
 		}); err != nil {
@@ -329,11 +439,20 @@ func (s *Service) Complete(ctx context.Context, req CompleteRequest) (*CompleteR
 		// is refused — which the app renders as a login bounce loop. Rides
 		// the same transaction/outbox as the FGA tuple so it is retried
 		// until it lands rather than silently locking the owner out.
-		if err := outbox.Enqueue(tx, GIPClaimOutboxKind, gipClaimPayload{
-			UserID:   req.OwnerUserID,
-			TenantID: t.ID,
-		}); err != nil {
-			return err
+		//
+		// Skipped on the Zitadel path: ownerUserID is a Zitadel user id
+		// there and EnsureTenantClaim writes a GIP custom claim keyed by
+		// GIP uid. The call would resolve nothing, fail, and be retried by
+		// the drainer forever. The GIP path is untouched. (Mobile admin is
+		// on the same GIP bearer path and is a separate cutover — see
+		// cmd/server/provider_wiring.go's requireGIPForTenantClaim.)
+		if s.provisioner == nil {
+			if err := outbox.Enqueue(tx, GIPClaimOutboxKind, gipClaimPayload{
+				UserID:   ownerUserID,
+				TenantID: t.ID,
+			}); err != nil {
+				return err
+			}
 		}
 		return nil
 	})
@@ -415,8 +534,10 @@ func formatURLTemplate(template, slug string) string {
 	return template
 }
 
-// validateCompleteRequest enforces presence + shape of every required field.
-func validateCompleteRequest(req CompleteRequest) error {
+// validateCompleteRequest enforces presence + shape of every required
+// field. requireOwnerUserID is false on the Zitadel path, where the
+// provider account does not exist yet — see CompleteRequest.OwnerUserID.
+func validateCompleteRequest(req CompleteRequest, requireOwnerUserID bool) error {
 	if req.SessionID == "" {
 		return apperrors.BadRequest("invalid_session", "session_id is required")
 	}
@@ -426,7 +547,7 @@ func validateCompleteRequest(req CompleteRequest) error {
 	if req.Slug == "" {
 		return apperrors.BadRequest("invalid_slug", "slug is required")
 	}
-	if req.OwnerUserID == "" {
+	if requireOwnerUserID && req.OwnerUserID == "" {
 		return apperrors.BadRequest("invalid_owner", "owner_user_id is required")
 	}
 	if req.OwnerEmail == "" || !strings.Contains(req.OwnerEmail, "@") {
@@ -442,4 +563,52 @@ func validateCompleteRequest(req CompleteRequest) error {
 		return apperrors.BadRequest("invalid_timezone", "timezone is required")
 	}
 	return nil
+}
+
+// profileNames resolves the givenName/familyName Zitadel requires,
+// falling back to the email local part when the wizard sent nothing.
+// Zitadel rejects an empty name outright, so "no name" is not an option
+// and a derived one beats a failed signup.
+//
+// Deliberately a copy of internal/invitation's identical helper rather
+// than a shared import: the two packages are independent of each other
+// by design, and a naming heuristic is not worth a new shared package
+// that couples them.
+func profileNames(first, last, email string) (string, string) {
+	first = strings.TrimSpace(first)
+	last = strings.TrimSpace(last)
+	if first != "" && last != "" {
+		return first, last
+	}
+	local := email
+	if at := strings.Index(local, "@"); at > 0 {
+		local = local[:at]
+	}
+	parts := strings.FieldsFunc(local, func(r rune) bool {
+		return r == '.' || r == '_' || r == '-' || r == '+'
+	})
+	derivedFirst, derivedLast := local, local
+	if len(parts) > 0 {
+		derivedFirst = titleCase(parts[0])
+		derivedLast = derivedFirst
+		if len(parts) > 1 {
+			derivedLast = titleCase(strings.Join(parts[1:], " "))
+		}
+	}
+	if first == "" {
+		first = derivedFirst
+	}
+	if last == "" {
+		last = derivedLast
+	}
+	return first, last
+}
+
+// titleCase upper-cases the first rune only.
+func titleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	r := []rune(s)
+	return strings.ToUpper(string(r[0])) + string(r[1:])
 }


### PR DESCRIPTION
Closes #685.

Onboarding was never migrated in the Zitadel cutover. It created **GIP** accounts and recorded the GIP uid as `owner_user_id`, which became the FGA ownership tuple — while admin resolves membership by **email**. A merchant who onboarded could not sign in, and got *"We couldn't find a store for this account. Did you finish onboarding?"* immediately after doing exactly that.

This blocked every new merchant. Same defect as #679, on the acquisition path where there is no fallback account.

## The fix

**platform-api** — `Complete` provisions/resolves the Zitadel user and its project grant *before* the transaction, sets `tenant.owner_user_id` to the Zitadel uid, and enqueues FGA with both subjects: the lowercased **email** (what login reads) and the **Zitadel uid** (what the bearer API reads). Password-policy rejections answer **400 `password_policy`** with the specific rule; anything else is 500 `provisioning_failed`. Both log the cause with the password redacted.

**apps/onboarding** — the set-password step branches on the provider: no GIP call, no uid, no auto-login, 12-char policy validated client-side with the requirements shown before the first submit, and the server's specific rule rendered on the field. The GIP branch is byte-identical when the flag is off.

Reuses `zitadeladmin.StaffProvisioner` and the `mark8ly.staff` role key from #680 — the Zitadel grant only gates project access for OIDC; the real role is the FGA **owner** tuple. There is no owner role on the project and none was invented.

## Rollout safety

Onboarding writes FGA through a transactional outbox rather than inline, so the payload gained a `user_ids` list. The handler still reads the legacy single `user_id`, so rows enqueued before this deploy drain unchanged — verified, since in-flight signups would otherwise strand.

`GIPClaimOutboxKind` is not enqueued on the Zitadel path: it is keyed by GIP uid and would retry forever.

## Post-onboarding sign-in — the honest answer

**The merchant re-enters their password once on the admin.** No session is minted. Accept-invite could hand the browser to `/login/authorize` because it shares an origin; onboarding cannot — the admin is a *different origin* (`{slug}-admin.mark8ly.com`), so there is no cookie this app can set for it, and Zitadel's login-client model has no `auth_request_id` a page can mint for itself. The `/welcome` copy no longer claims "You're signed in" on this path.

## Deploy ordering

platform-api must have `ZITADEL_ENABLED=true` **before** this onboarding image ships. Already true in production (tesserix-k8s#972; its startup log reads `auth: password reset enabled (zitadel)`). If the two ever disagree, `Complete` answers 400 `invalid_owner` — fail-closed and loud rather than silently creating another unusable account.

The provider build arg is now set in `container-images.json` for onboarding as well, so all three apps flip from one file instead of onboarding relying on a Dockerfile default.

## Verification

`gofmt` clean, `go build ./...`, `go test ./...` green (11 unit + 1 integration test). onboarding: 101 tests passing, `tsc --noEmit` clean, `npm run build` exit 0. gitleaks clean over the branch range.

Not yet exercised against a live onboarding run — that is the next step, and worth doing with a store you are happy to discard.
