### PR TITLE
feat(admin): read platform announcements through the platform API, retiring the shared secret (tesserix-home#152)

### DIFF
--- a/apps/admin/app/api/platform-announcements/route.test.ts
+++ b/apps/admin/app/api/platform-announcements/route.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api/platform-token", () => ({
+  getPlatformToken: vi.fn(async () => "machine-token"),
+}));
+
+import { GET } from "./route";
+
+// The banner's proxy, repointed from apps/web's shared-secret internal route
+// to the platform API (tesserix-home#152).
+//
+// The BROWSER contract is deliberately unchanged — the banner still reads
+// `{ rows }` — so the repoint is invisible on that side. What changes is where
+// the rows come from and how this pod authenticates for them.
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+beforeEach(() => {
+  process.env.TESSERIX_PLATFORM_API_URL = "http://platform-api.tesserix.svc.cluster.local";
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.TESSERIX_PLATFORM_API_URL;
+});
+
+it("calls the platform API with a machine token", async () => {
+  const f = vi.fn().mockResolvedValue(ok({ data: { announcements: [] } }));
+  vi.stubGlobal("fetch", f);
+
+  await GET(new Request("http://localhost/api/platform-announcements") as never);
+
+  const [url, init] = f.mock.calls[0];
+  const u = new URL(String(url));
+  expect(u.host).toBe("platform-api.tesserix.svc.cluster.local");
+  expect(u.pathname).toBe("/v1/announcements");
+  expect(new Headers((init as RequestInit).headers).get("authorization")).toBe("Bearer machine-token");
+  // The shared secret must not travel to a service that ignores it.
+  expect(new Headers((init as RequestInit).headers).get("x-internal-token")).toBeNull();
+});
+
+it("sends no product, because the API takes it from the token's scope", async () => {
+  const f = vi.fn().mockResolvedValue(ok({ data: { announcements: [] } }));
+  vi.stubGlobal("fetch", f);
+
+  await GET(new Request("http://localhost/api/platform-announcements") as never);
+
+  const u = new URL(String(f.mock.calls[0][0]));
+  // A product parameter is now a 400 at the API — it would break the banner
+  // rather than be ignored.
+  expect(u.searchParams.get("product")).toBeNull();
+  expect(u.searchParams.get("tenant_status")).toBe("active");
+});
+
+it("keeps the browser contract: data.announcements is returned as rows", async () => {
+  const f = vi.fn().mockResolvedValue(
+    ok({ data: { announcements: [{ id: "a1", title: "t", body: "b", severity: "info" }] } }),
+  );
+  vi.stubGlobal("fetch", f);
+
+  const res = await GET(new Request("http://localhost/api/platform-announcements") as never);
+  const body = (await res.json()) as { rows: unknown[] };
+
+  // The banner reads `rows`. Returning the envelope through unchanged would
+  // render as "no announcements" rather than as an error.
+  expect(body.rows).toHaveLength(1);
+});
+
+it("degrades to an empty banner rather than failing the page", async () => {
+  // A banner is decoration on someone's admin dashboard. It must never be the
+  // reason the page errors — which is why every failure path answers [].
+  for (const outcome of [
+    { ok: false, status: 503, json: async () => ({}) } as unknown as Response,
+    Promise.reject(new Error("network")) as unknown as Response,
+  ]) {
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(() => Promise.resolve(outcome).catch(() => Promise.reject(new Error("network")))));
+    const res = await GET(new Request("http://localhost/api/platform-announcements") as never);
+    expect((await res.json()).rows).toEqual([]);
+  }
+});
+
+it("answers [] when the token cannot be minted", async () => {
+  const { getPlatformToken } = await import("@/lib/api/platform-token");
+  vi.mocked(getPlatformToken).mockRejectedValueOnce(new Error("no creds"));
+  vi.stubGlobal("fetch", vi.fn());
+
+  const res = await GET(new Request("http://localhost/api/platform-announcements") as never);
+  expect((await res.json()).rows).toEqual([]);
+});

--- a/apps/admin/app/api/platform-announcements/route.ts
+++ b/apps/admin/app/api/platform-announcements/route.ts
@@ -1,38 +1,61 @@
-// Server-side proxy to tesserix-home's /api/internal/platform-announcements.
-// The browser hits THIS route (no token), the route forwards with the
-// shared INTERNAL_API_TOKEN to tesserix. Keeping the proxy here means the
-// token never leaves the pod and the banner client component can stay
-// simple (plain fetch from same origin, credentials inherited).
+// Server-side proxy for the announcements banner.
+//
+// The browser hits THIS route with no credentials; the route calls
+// tesserix-home's platform API with a Zitadel machine token minted in-pod. The
+// token never leaves the pod and the banner client component stays a plain
+// same-origin fetch.
+//
+// # Repointed from apps/web (tesserix-home#152)
+//
+// This used to call `/api/internal/platform-announcements` with the shared
+// INTERNAL_API_TOKEN. It now calls `/v1/announcements`, which takes the
+// PRODUCT from the scope the machine token resolves to rather than from a
+// query parameter — so this proxy can no longer ask about another product's
+// audience, and sending `?product=` would be a 400 rather than a no-op.
+//
+// # The browser contract is unchanged
+//
+// The banner reads `{ rows }`, and it still does. The platform API answers a
+// §4.4 envelope (`{ data: { announcements } }`), which is unwrapped here rather
+// than passed through — forwarding the envelope would leave the banner reading
+// an absent `rows` and rendering "no announcements" instead of erroring.
 
 import { NextResponse, type NextRequest } from "next/server";
 
-const TESSERIX_INTERNAL_URL =
-  process.env.TESSERIX_INTERNAL_URL ?? "https://tesserix.app";
-const INTERNAL_API_TOKEN = process.env.INTERNAL_API_TOKEN ?? "";
+import { getPlatformToken } from "@/lib/api/platform-token";
+
+const TESSERIX_PLATFORM_API_URL =
+  process.env.TESSERIX_PLATFORM_API_URL ?? "http://platform-api.tesserix.svc.cluster.local";
+
+// The lifecycle status the banner asks on behalf of.
+//
+// Hard-coded `active`, exactly as before the repoint: this proxy serves the
+// admin shell's banner, and a merchant reading it is in an active tenant by
+// definition. A suspended tenant does not reach this page.
+const TENANT_STATUS = "active";
+
+/** An empty banner. Never an error — see the comment on the catch below. */
+function empty() {
+  return NextResponse.json({ rows: [] });
+}
 
 export async function GET(_req: NextRequest) {
-  if (!INTERNAL_API_TOKEN) {
-    return NextResponse.json({ rows: [] });
-  }
   try {
-    const url = new URL(
-      `${TESSERIX_INTERNAL_URL}/api/internal/platform-announcements`,
-    );
-    url.searchParams.set("product", "mark8ly");
-    url.searchParams.set("tenant_status", "active");
+    const url = new URL(`${TESSERIX_PLATFORM_API_URL}/v1/announcements`);
+    url.searchParams.set("tenant_status", TENANT_STATUS);
 
     const res = await fetch(url.toString(), {
-      // X-Internal-Token, not Authorization Bearer — istio-ingress at
-      // tesserix.app intercepts Authorization for JWT validation.
-      headers: { "X-Internal-Token": INTERNAL_API_TOKEN.trim() },
+      headers: { Authorization: `Bearer ${await getPlatformToken()}` },
       cache: "no-store",
     });
-    if (!res.ok) {
-      return NextResponse.json({ rows: [] });
-    }
-    const body = await res.json();
-    return NextResponse.json(body);
+    if (!res.ok) return empty();
+
+    const body = (await res.json()) as { data?: { announcements?: unknown[] } };
+    return NextResponse.json({ rows: body.data?.announcements ?? [] });
   } catch {
-    return NextResponse.json({ rows: [] });
+    // A banner is decoration on someone's dashboard. It must never be the
+    // reason the page fails, so every failure — an unmintable token included —
+    // degrades to no banner rather than propagating.
+    return empty();
   }
 }

--- a/apps/admin/lib/api/tesserix.ts
+++ b/apps/admin/lib/api/tesserix.ts
@@ -1,16 +1,18 @@
 // tesserix-home client. Used from the merchant admin to file platform support
 // tickets and read active platform announcements.
 //
-// TWO CHANNELS, and the split is temporary (tesserix-home#152):
+// ONE CHANNEL now (tesserix-home#152). Everything here goes to the PLATFORM
+// API over the in-cluster ClusterIP, authenticated with a Zitadel machine
+// token. That token identifies mark8ly, and the API scopes every read and
+// write to the product it resolves to — so this client cannot reach another
+// product's queue even if it asked.
 //
-//   TICKETS go to the PLATFORM API over the in-cluster ClusterIP, authenticated
-//   with a Zitadel machine token. That token identifies mark8ly, and the API
-//   scopes every read and write to the product it resolves to — so this client
-//   can no longer reach another product's queue even if it asked.
-//
-//   ANNOUNCEMENTS still go to apps/web's /api/internal/* with the shared
-//   INTERNAL_API_TOKEN, because the platform API has no announcements module
-//   yet. They move when it does; until then apps/web cannot be retired.
+// THE SHARED SECRET IS GONE from this file. `INTERNAL_API_TOKEN` and
+// `X-Internal-Token` are no longer used by the admin app at all: the tickets
+// calls moved first, and the announcements client that remained here had no
+// callers — the banner reaches announcements through its own proxy in
+// app/api/platform-announcements/route.ts, which also now speaks to the
+// platform API.
 //
 // The mark8ly admin server remains the trusted caller in both: it forwards the
 // merchant's identity (tenantId, name, email, userId) from its own
@@ -20,12 +22,7 @@
 
 import { getPlatformToken } from "./platform-token";
 
-const TESSERIX_INTERNAL_URL =
-  process.env.TESSERIX_INTERNAL_URL ?? "https://tesserix.app";
 
-// Still used by ANNOUNCEMENTS, which have no platform-api counterpart yet and
-// so remain on apps/web's shared-secret channel (tesserix-home#152 step 3).
-const INTERNAL_API_TOKEN = process.env.INTERNAL_API_TOKEN ?? "";
 
 const PRODUCT_ID = "mark8ly";
 
@@ -37,16 +34,6 @@ const PRODUCT_ID = "mark8ly";
 const PLATFORM_API_URL =
   process.env.TESSERIX_PLATFORM_API_URL ?? "http://platform-api.tesserix.svc.cluster.local";
 
-function authHeaders(): Record<string, string> {
-  // ANNOUNCEMENTS ONLY. X-Internal-Token rather than Authorization Bearer —
-  // the istio-ingress at tesserix.app has a RequestAuthentication policy that
-  // parses Authorization Bearer as JWT and rejects our opaque shared-secret
-  // token. A custom header bypasses that path.
-  return {
-    "Content-Type": "application/json",
-    "X-Internal-Token": INTERNAL_API_TOKEN.trim(),
-  };
-}
 
 // Headers for the platform API: a Zitadel machine token.
 //
@@ -103,17 +90,20 @@ export interface PlatformTicket {
   updated_at: string;
 }
 
+// One announcement as the PLATFORM API returns it (tesserix-home#152).
+//
+// Narrower than the old apps/web row, and deliberately so on that side:
+// `audience_filter` names the other products a broadcast targets,
+// `created_by` identifies staff to a merchant, and `is_published` is always
+// true for anything this endpoint returns. Declaring them here would promise
+// fields every response omits.
 export interface PlatformAnnouncement {
   id: string;
   title: string;
   body: string;
   severity: string;
-  audience_filter: Record<string, unknown>;
   starts_at: string;
   ends_at: string | null;
-  is_published: boolean;
-  created_at: string;
-  updated_at: string;
 }
 
 export interface FilePlatformTicketInput {
@@ -280,29 +270,6 @@ export async function replyToPlatformTicket(
   }
 }
 
-export async function listActivePlatformAnnouncements(
-  tenantStatus: string = "active",
-): Promise<PlatformAnnouncement[]> {
-  if (!INTERNAL_API_TOKEN) return [];
-
-  try {
-    const url = new URL(
-      `${TESSERIX_INTERNAL_URL}/api/internal/platform-announcements`,
-    );
-    url.searchParams.set("product", PRODUCT_ID);
-    url.searchParams.set("tenant_status", tenantStatus);
-
-    const res = await fetch(url.toString(), {
-      headers: authHeaders(),
-      cache: "no-store",
-    });
-    if (!res.ok) return [];
-    const body = (await res.json()) as { rows: PlatformAnnouncement[] };
-    return body.rows ?? [];
-  } catch {
-    return [];
-  }
-}
 
 function messageForCode(code: string, status: number): string {
   switch (code) {


### PR DESCRIPTION
The last mark8ly caller of apps/web's internal channel. After this, **the admin app does not use the shared secret at all.**

Requires no new configuration: `TESSERIX_PLATFORM_*` and the token minter already landed with the tickets repoint, and `read-announcements` is already granted to `mark8ly-catalog-reader`.

## The live caller was the proxy, not the client

`lib/api/tesserix.ts` had a `listActivePlatformAnnouncements` — and **nothing called it**. The banner fetches its own same-origin proxy at `app/api/platform-announcements/route.ts`, which called apps/web directly.

So this repoints the proxy and **deletes the client as dead code**. Checked before changing either; repointing the unused one would have looked like progress and moved no traffic.

## The browser contract is deliberately unchanged

The banner reads `{ rows }` and still does. The platform API answers a §4.4 envelope, unwrapped here rather than forwarded — passing the envelope through would leave the banner reading an absent `rows` and rendering *"no announcements"* instead of erroring, which is the failure mode that hides itself.

## No product parameter

The old call sent `?product=mark8ly`. The platform API takes the product from the scope the machine token resolves to, and **rejects an unknown parameter with 400** — so sending it would break the banner rather than be ignored.

## Failure stays invisible

Every failure path answers `[]`: a non-2xx, a network error, and an unmintable token. A banner is decoration on someone's dashboard and must never be the reason the page fails. Tested, including the token path.

## What this removes

`authHeaders()`, `INTERNAL_API_TOKEN` and `TESSERIX_INTERNAL_URL` are all unreferenced in `tesserix.ts` once the dead client goes, so they are deleted. `INTERNAL_API_TOKEN` now survives in the admin app only inside comments explaining what replaced it.

The `PlatformAnnouncement` type is narrowed to what the API returns — `audience_filter`, `is_published`, `created_at` and `updated_at` are gone, since the API omits the first two deliberately and never sent the rest.

The chart still mounts `INTERNAL_API_TOKEN`; removing it is a separate change and safe to do once this has run for a while.

## Testing

5 new tests on the proxy, 43 passing across `lib/api` and this route. Typecheck clean.

## After this

apps/web's `/api/internal/platform-announcements` has **no caller**. It should not be deleted on that basis alone — confirm zero traffic over a real window first, alongside the four ticket routes.
