### PR TITLE
docs(mcp): mark the connector spec and deployment plan superseded by ADR-0005

### DIFF
--- a/docs/superpowers/plans/2026-09-05-mcp-catalog-deployment.md
+++ b/docs/superpowers/plans/2026-09-05-mcp-catalog-deployment.md
@@ -1,5 +1,54 @@
 # `mcp-catalog` Deployment Implementation Plan
 
+> # ⚠️ SUPERSEDED — DO NOT EXECUTE
+>
+> **Superseded 2026-09-05 by [australis ADR-0005](https://github.com/tesserix/australis/blob/main/docs/adr/0005-mark8ly-catalog-on-the-shared-gateway.md).**
+>
+> This plan stands up a product-owned `mcp-catalog` workload — image, chart, ArgoCD
+> Application, ExternalSecret, mesh policy, Kargo subscription, Registry record.
+> **That workload was never created and will not be.**
+>
+> What actually happened: the five catalog tools ship as tenant tools inside
+> `slm-support-platform/services/mcp-gateway`
+> ([slm-support-platform#23](https://github.com/tesserix/slm-support-platform/pull/23)),
+> served by the existing `mark8ly-mcp` deployment. **Verified live on 2026-09-05** —
+> a `tools/list` against the running gateway returns thirteen mark8ly tools, the
+> original eight plus `list_store_products`, `get_store_product`,
+> `list_store_categories`, `list_products_by_category` and `get_store_branding`.
+>
+> Executing this plan now would build an image nothing runs (mark8ly#687 removed
+> that entry), add an eighth subscription to a Kargo warehouse that must stay at
+> seven, and duplicate tools already being served.
+>
+> ## What is still true, and worth reading
+>
+> These were established by reading the real handlers, and they outlived the plan:
+>
+> - **Pagination is `page`/`page_size`, capped at 100 — never `limit`/`offset`.**
+>   marketplace-api silently ignores the wrong names and returns page 1 forever.
+>   The OpenAPI document says `limit`/`offset` and is wrong.
+> - **List endpoints wrap in `{"data": […]}`; single-resource endpoints return a
+>   bare object.** Unwrapping the wrong one yields an empty result with no error.
+> - **Branding's promotion is `active_promotion`** — singular, top-level, omitted
+>   when absent. Not the plural nested array the spec implies.
+> - **Categories carry no product count**, whatever the spec claims.
+> - **`mark8ly` has ONE Kargo warehouse subscribed to seven images**, and freight
+>   forms only when all seven share a tag. An eighth subscription stalls every
+>   mark8ly deploy.
+> - **A waypoint alone does not admit a caller.** Reaching an MCP server needs a
+>   dedicated ServiceAccount, STRICT `PeerAuthentication`, workload *and*
+>   Service-targeted ALLOW/DENY, plus a NetworkPolicy.
+> - **Calling an MCP server needs more than a key**: `MCP-Protocol-Version`,
+>   `Mcp-Method`, a `Host` header, and a `params._meta` carrying both
+>   `io.modelcontextprotocol/protocolVersion` and
+>   `io.modelcontextprotocol/clientCapabilities`. Miss any and you get an error
+>   that reads like an auth failure and is not one.
+>
+> The design spec it implements
+> (`docs/superpowers/specs/2026-09-04-mark8ly-mcp-connectors-design.md`) is
+> likewise superseded on packaging, though its analysis of *why* the shared image
+> couples four products remains the honest account of the tradeoff ADR-0005 accepts.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Get `mcp-catalog` — merged, tested and sitting on `main` since #663 — actually running in the `mark8ly` namespace and answering a `tools/list`.

--- a/docs/superpowers/specs/2026-09-04-mark8ly-mcp-connectors-design.md
+++ b/docs/superpowers/specs/2026-09-04-mark8ly-mcp-connectors-design.md
@@ -1,5 +1,35 @@
 # mark8ly-owned MCP connectors
 
+> # ⚠️ SUPERSEDED ON PACKAGING — 2026-09-05
+>
+> This spec argues for a **product-owned** connector: mark8ly's own service, image
+> and deployment. [australis ADR-0005](https://github.com/tesserix/australis/blob/main/docs/adr/0005-mark8ly-catalog-on-the-shared-gateway.md)
+> reversed that for the catalog connector, which now ships as tenant tools inside
+> the shared `slm-support-platform/services/mcp-gateway`
+> ([slm-support-platform#23](https://github.com/tesserix/slm-support-platform/pull/23),
+> verified serving live on 2026-09-05).
+>
+> **What this spec got right and still stands:** the finding that `mark8ly-mcp`,
+> `platform-mcp`, `kora-mcp`, `homechef-mcp` and `stockpilot-mcp` all run one
+> shared image, so a change for one tenant rebuilds the executable four others
+> run; that mark8ly's only own agent surface was an OpenAPI document which never
+> produced a single tool; and that the document is wrong about pagination,
+> category product counts, and response envelopes.
+>
+> **What it no longer decides:** D1 (where connectors live), D2/D9 (the
+> `go-shared/mcp` foundation as the runtime for this connector), and D7 (own
+> Deployment and identity). The Go implementation those decisions produced —
+> `services/mcp`, five tools with closed input *and* output schemas — has no
+> consumer. `go-shared/mcp` v1.11.0 remains valid and independently useful.
+>
+> **What survived the reversal:** D4 (read through the product API, never its
+> database), D5's intent (project into a declared shape rather than passing
+> upstream bodies through — now enforced by a projection helper rather than by
+> types), D6 (read-only), and D8 (no `latest`).
+>
+> ADR-0005 records the cost of the reversal honestly: no output schemas, read-only
+> as convention rather than structure, and shared release blast radius.
+
 Design for milestone 9 (MCP: platform agent integration). Written 2026-09-04.
 
 Every claim marked **VERIFIED** was observed against the live cluster, the


### PR DESCRIPTION
Two documents on `main` describe work that will not happen. Left alone they read as live guidance, and the deployment plan in particular is written to be executed task-by-task by an agent.

## What changed

Superseded banners on:

- `docs/superpowers/plans/2026-09-05-mcp-catalog-deployment.md`
- `docs/superpowers/specs/2026-09-04-mark8ly-mcp-connectors-design.md`

Both point at [australis ADR-0005](https://github.com/tesserix/australis/blob/main/docs/adr/0005-mark8ly-catalog-on-the-shared-gateway.md), which reversed the packaging decision. The catalog tools ship as tenant tools inside `slm-support-platform/services/mcp-gateway` (slm-support-platform#23), served by the existing `mark8ly-mcp` deployment.

**Verified live 2026-09-05:** a `tools/list` against the running gateway returns thirteen mark8ly tools — the original eight plus `list_store_products`, `get_store_product`, `list_store_categories`, `list_products_by_category`, `get_store_branding`.

## Why a banner rather than deletion

Executing the plan now would build an image nothing runs (#687 removed that entry), add an eighth subscription to a Kargo warehouse that must stay at seven, and duplicate tools already being served. That is worth a loud warning at the top of the file.

But most of what these documents contain was learned by reading the real handlers, and it outlived the decision. The banners keep it:

- **`page`/`page_size`, capped at 100 — never `limit`/`offset`.** marketplace-api silently ignores the wrong names and returns page 1 forever. The OpenAPI document says `limit`/`offset` and is wrong.
- **List endpoints wrap in `{"data": […]}`; single-resource endpoints return a bare object.** Unwrapping the wrong one gives an empty result with no error.
- **`active_promotion` is singular and top-level**, omitted when absent.
- **Categories carry no product count**, whatever the spec claims.
- **One Kargo warehouse, seven images, freight only when all seven share a tag.**
- **A waypoint alone admits no caller** — a dedicated ServiceAccount, STRICT `PeerAuthentication`, workload *and* Service-targeted ALLOW/DENY, and a NetworkPolicy are all required.
- **Calling an MCP server needs more than a key**: `MCP-Protocol-Version`, `Mcp-Method`, a `Host` header, and a `params._meta` carrying both `io.modelcontextprotocol/protocolVersion` and `io.modelcontextprotocol/clientCapabilities`. Miss any and the error reads like an auth failure and is not one. That cost several attempts to establish.

The spec's banner also separates what it got right from what it no longer decides. Its analysis of *why* one shared image across five tenants couples their releases still stands — ADR-0005 accepts that cost rather than disputing it.

## Not in this PR

`services/mcp` — the superseded Go connector, five tools with closed input *and* output schemas — remains in the tree. #687 stopped it looking deployed by removing its image build, but whether it is deleted or left dormant is still an open call.
