### PR TITLE
fix(admin): state the real password policy on reset instead of repeating an 8-character bound

### DIFF
--- a/apps/admin/app/reset-password/actions.test.ts
+++ b/apps/admin/app/reset-password/actions.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// #695: the reset action claimed an 8-character minimum on BOTH providers.
+// Zitadel's real policy is 12 + upper/lower/number/symbol, so an
+// 8-character password was rejected upstream and this action answered
+// "Password must be at least 8 characters." — telling the user to do
+// exactly what they had just done, with no way to discover the real rule.
+const configMock = vi.hoisted(() => ({
+  authProvider: "zitadel" as "gip" | "zitadel",
+}));
+vi.mock("@/lib/config", () => ({ publicConfig: configMock }));
+
+const confirmPasswordReset = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api/platform-api", () => ({ confirmPasswordReset }));
+
+import { confirmPasswordResetAction } from "./actions";
+
+beforeEach(() => {
+  configMock.authProvider = "zitadel";
+  confirmPasswordReset.mockReset();
+  confirmPasswordReset.mockResolvedValue({ ok: true });
+});
+
+describe("confirmPasswordResetAction — password policy", () => {
+  it("rejects an 8-character password WITHOUT repeating '8 characters' back", async () => {
+    const r = await confirmPasswordResetAction("code", "Test123!");
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    // The exact failure from production: the message must not restate the
+    // bound the input already satisfies.
+    expect(r.message).not.toMatch(/at least 8 characters/i);
+    expect(r.message).toMatch(/12/);
+    // and it must never reach the upstream call
+    expect(confirmPasswordReset).not.toHaveBeenCalled();
+  });
+
+  it("names every rule so the user can act on it", async () => {
+    const r = await confirmPasswordResetAction("code", "alllowercaseonly");
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.message).toMatch(/uppercase/i);
+  });
+
+  it("accepts a policy-compliant password and calls upstream", async () => {
+    const r = await confirmPasswordResetAction("code", "Not-A-Real-Password-1!");
+    expect(r.ok).toBe(true);
+    expect(confirmPasswordReset).toHaveBeenCalledWith("code", "Not-A-Real-Password-1!");
+  });
+
+  it("keeps GIP's 8-character rule when the flag is off", async () => {
+    configMock.authProvider = "gip";
+    const ok = await confirmPasswordResetAction("code", "Test123!");
+    expect(ok.ok).toBe(true);
+    const short = await confirmPasswordResetAction("code", "short");
+    expect(short.ok).toBe(false);
+    if (short.ok) return;
+    expect(short.message).toMatch(/at least 8 characters/i);
+  });
+});

--- a/apps/admin/app/reset-password/actions.ts
+++ b/apps/admin/app/reset-password/actions.ts
@@ -6,6 +6,8 @@
 // public resetPassword endpoint on our behalf.
 
 import { confirmPasswordReset } from "@/lib/api/platform-api";
+import { publicConfig } from "@/lib/config";
+import { validateNewPassword } from "@/lib/auth/password-policy";
 
 export type ResetPasswordResult =
   | { ok: true }
@@ -25,12 +27,19 @@ export async function confirmPasswordResetAction(
         "This reset link is missing its code. Request a new one from the forgot-password page.",
     };
   }
-  if (trimmedPassword.length < 8) {
-    return {
-      ok: false,
-      code: "weak_password",
-      message: "Password must be at least 8 characters.",
-    };
+  // Validate against the provider's ACTUAL policy. Zitadel requires 12
+  // chars plus upper/lower/number/symbol; claiming 8 here produced the
+  // dead end in #695 — the server rejected an 8-character password and
+  // this action answered "must be at least 8 characters", i.e. telling
+  // the user to do what they had just done. GIP's own minimum is 8, so
+  // the old bound stays correct on that path.
+  const policyError = publicConfig.authProvider === "zitadel"
+    ? validateNewPassword(trimmedPassword)
+    : trimmedPassword.length < 8
+      ? "Password must be at least 8 characters."
+      : null;
+  if (policyError) {
+    return { ok: false, code: "weak_password", message: policyError };
   }
 
   const result = await confirmPasswordReset(trimmedCode, trimmedPassword);

--- a/apps/admin/components/auth/ResetPasswordForm.tsx
+++ b/apps/admin/components/auth/ResetPasswordForm.tsx
@@ -15,7 +15,20 @@ import { Input } from "@tesserix/web";
 import { Field } from "@repo/ui/field";
 
 import { confirmPasswordResetAction } from "@/app/reset-password/actions";
+import { publicConfig } from "@/lib/config";
+import {
+  PASSWORD_REQUIREMENTS_TEXT,
+  validateNewPassword,
+} from "@/lib/auth/password-policy";
 import { signInHref } from "@/lib/auth/sign-in-href";
+
+// The 8-char floor is GIP's minimum and stays for that path. Zitadel's
+// real policy (12 + upper/lower/number/symbol) is layered on below via
+// superRefine, gated on the provider — mirroring how AcceptInviteForm
+// avoids tightening the shared GIP schema. #695: this form previously
+// claimed 8 on BOTH paths and then repeated that number when Zitadel
+// rejected an 8-character password, leaving the user no way forward.
+const isZitadel = publicConfig.authProvider === "zitadel";
 
 const schema = z
   .object({
@@ -24,6 +37,13 @@ const schema = z
       .min(8, "At least 8 characters")
       .max(128, "Password is too long"),
     confirm: z.string().min(1, "Please confirm your password"),
+  })
+  .superRefine((v, ctx) => {
+    if (!isZitadel) return;
+    const err = validateNewPassword(v.password);
+    if (err) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: err, path: ["password"] });
+    }
   })
   .refine((v) => v.password === v.confirm, {
     message: "Passwords don't match",
@@ -49,6 +69,7 @@ export function ResetPasswordForm({ oobCode }: ResetPasswordFormProps) {
     register,
     handleSubmit,
     formState: { errors },
+    setError,
   } = useForm<FormValues>({
     resolver: zodResolver(schema),
     mode: "onTouched",
@@ -94,6 +115,16 @@ export function ResetPasswordForm({ oobCode }: ResetPasswordFormProps) {
         }
         return;
       }
+      // A policy rejection belongs on the password field, where the fix
+      // is, not in the generic form-level alert — same handling as
+      // AcceptInviteForm. platform-api answers `password_policy` with the
+      // specific broken rule (#682); `weak_password` is this action's own
+      // pre-check. Client validation and the server can drift, and the
+      // server is authoritative, so render whatever rule it names.
+      if (result.code === "password_policy" || result.code === "weak_password") {
+        setError("password", { type: "server", message: result.message });
+        return;
+      }
       setSubmitError(result.message);
     });
   }
@@ -129,8 +160,9 @@ export function ResetPasswordForm({ oobCode }: ResetPasswordFormProps) {
           Choose a new password.
         </h1>
         <p className="max-w-md text-[15px] leading-relaxed text-foreground-secondary">
-          Use at least 8 characters. We recommend a passphrase you haven&rsquo;t
-          used elsewhere.
+          {isZitadel
+            ? PASSWORD_REQUIREMENTS_TEXT
+            : "Use at least 8 characters. We recommend a passphrase you haven\u2019t used elsewhere."}
         </p>
       </div>
 


### PR DESCRIPTION
Closes #695.

Reproduced in production: requested a reset for a Zitadel account, opened the emailed link, entered `Test123!` — **8 characters** with upper, lower, number and symbol. The page said *"Use at least 8 characters"*, Zitadel rejected it for being under **12**, and the form answered:

> **Please choose a stronger password — at least 8 characters.**

The password was 8 characters. The user is told to do exactly what they just did, with no way to discover the real rule — and someone resetting a password is already locked out.

## Fix

Uses the shared policy module from #682 (`lib/auth/password-policy.ts`) on the Zitadel path:

- helper text states all five requirements **before** the first submit
- client validation matches the real policy
- a policy rejection renders on the **password field** rather than the generic alert, and shows whatever rule the server names — client and server can drift, and the server is authoritative

## GIP path deliberately unchanged

The `min(8)` floor stays, and the 12-char policy is layered on via `superRefine` gated on the provider. GIP's own minimum *is* 8, so tightening it there would lock out legitimate GIP users — the same reasoning #682 applied to `AcceptInviteForm`'s shared schema.

## Verification

Four tests, and I checked they catch the bug rather than assert a constant: reverting the fix fails "rejects an 8-character password WITHOUT repeating '8 characters' back" and "names every rule so the user can act on it", while the GIP and happy-path tests keep passing.

`vitest` 1168 passing, `tsc --noEmit` clean, `npm run build` exit 0, gitleaks clean.

Note the platform-api side already classified these correctly — #682 added the five `COMMA-*` ids to the reset mapping — so this is frontend-only.
