### PR TITLE
feat: make customer store membership explicit instead of a side effect (#684)

### DIFF
--- a/apps/storefront/app/auth/google/finish/route.ts
+++ b/apps/storefront/app/auth/google/finish/route.ts
@@ -63,8 +63,10 @@ export async function GET(req: Request): Promise<Response> {
     return errorResponse(req, "return_to_host_mismatch");
   }
 
-  // customerSignIn re-verifies the GIP id_token, mints the per-host
-  // mp_customer_session cookie, and triggers EnsureProfile.
+  // customerSignIn re-verifies the GIP id_token and, if this identity is
+  // already a customer of this store, mints the per-host
+  // mp_customer_session cookie. If it is not, it mints nothing and
+  // returns membership_required with a short-lived join grant instead.
   // The `uid` field is documented as deprecated/ignored.
   const result = await customerSignIn({
     idToken: claims.idToken,
@@ -72,6 +74,18 @@ export async function GET(req: Request): Promise<Response> {
     storeSlug: claims.storeSlug,
   });
   if (!result.ok) {
+    if (result.code === "membership_required") {
+      // Google signed them in fine — they just have no account with this
+      // store. Redirecting to /sign-in?error=... would report a failure
+      // that did not happen; send them to the join screen instead.
+      const isLocalHost =
+        forwardedHost.startsWith("localhost") || forwardedHost.startsWith("127.");
+      const proto =
+        req.headers.get("x-forwarded-proto") ?? (isLocalHost ? "http" : "https");
+      return NextResponse.redirect(`${proto}://${forwardedHost}/join`, {
+        status: 303,
+      });
+    }
     return errorResponse(req, result.code ?? "signin_failed");
   }
 

--- a/apps/storefront/app/auth/idp/finish/route.ts
+++ b/apps/storefront/app/auth/idp/finish/route.ts
@@ -122,12 +122,23 @@ export async function GET(req: Request): Promise<Response> {
     uid: outcome.uid,
     email: outcome.email,
   });
+  const protocol = req.headers.get("x-forwarded-proto") ?? "https";
   if (!result.ok) {
+    if (result.code === "membership_required") {
+      // Google verified them and so did Zitadel; they simply have no
+      // account with THIS store yet. completeCustomerSignIn set the
+      // short-lived join grant and minted no session, so send the browser
+      // to the join screen — bouncing to /sign-in?error=... would read as
+      // a failed sign-in for a sign-in that worked.
+      return NextResponse.redirect(
+        `${protocol}://${forwardedHost}/join`,
+        { status: 303 },
+      );
+    }
     console.error("google idp finish: completeCustomerSignIn failed", result.code);
     return errorRedirect(req, result.code ?? "google_sign_in_unavailable");
   }
 
-  const protocol = req.headers.get("x-forwarded-proto") ?? "https";
   return NextResponse.redirect(`${protocol}://${forwardedHost}${dest}`, {
     status: 303,
   });

--- a/apps/storefront/app/create-account/actions.test.ts
+++ b/apps/storefront/app/create-account/actions.test.ts
@@ -103,7 +103,14 @@ beforeEach(() => {
     json: async () => ({ data: { tenant_id: "tenant-1", id: "store-1" } }),
   } as Response);
 
-  fetchSpy = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  // Default: marketplace-api reports this identity IS a customer of the
+  // store. completeCustomerSignIn now asks before it mints a session
+  // cookie (see @/lib/auth/customer-session), so every test below that
+  // expects a cookie needs a membership to exist. The gate itself is
+  // covered in lib/auth/customer-session.membership.test.ts.
+  fetchSpy = vi
+    .fn()
+    .mockResolvedValue({ ok: true, json: async () => ({ data: { member: true } }) });
   globalThis.fetch = fetchSpy as unknown as typeof fetch;
 });
 

--- a/apps/storefront/app/join/actions.ts
+++ b/apps/storefront/app/join/actions.ts
@@ -1,0 +1,85 @@
+"use server";
+
+// The explicit store join.
+//
+// A Mark8ly login is one platform identity; each store is a separate
+// membership. Signing in at a store the customer has not joined mints no
+// session — it leaves a short-lived join grant and sends them here (see
+// @/lib/auth/join-grant and
+// docs/superpowers/specs/2026-09-05-customer-store-membership-design.md).
+//
+// This action is what turns "I have a login" into "I have an account with
+// this store": it creates the customer_profiles row and nothing else — no
+// new identity, no new credential, no change to any other store the
+// customer belongs to.
+//
+// Every export is async, because Next.js silently strips non-async
+// runtime exports from a `"use server"` module (see
+// @/lib/auth/customer-sign-in-result's header for the time that bit this
+// repo). The join-grant claim shape and its verifier are plain functions
+// and live in @/lib/auth/join-grant accordingly.
+
+import { cookies, headers } from "next/headers";
+import { resolveStoreSlug } from "@/lib/slug";
+import { sanitizeHost } from "@/lib/host";
+import { JOIN_GRANT_COOKIE, verifyJoinGrant } from "@/lib/auth/join-grant";
+import { completeCustomerStoreJoin } from "@/lib/auth/customer-session";
+import type { CustomerSignInResult as Result } from "@/lib/auth/customer-sign-in-result";
+
+const EXPIRED_MESSAGE =
+  "This join request has expired. Please sign in again to join this store.";
+
+/**
+ * joinThisStore creates the membership for the identity carried by the
+ * join-grant cookie, then completes sign-in.
+ *
+ * It takes NO caller-supplied identity: the email and uid come from the
+ * grant this server signed after verifying the credential itself, so a
+ * caller cannot join a store as someone else. The grant is also checked
+ * against the store the request actually arrived at, so a grant issued at
+ * store2 cannot be spent at store3.
+ */
+export async function joinThisStore(): Promise<Result> {
+  const h = await headers();
+  const rawHost = h.get("x-forwarded-host") ?? h.get("host");
+  const cookieHost = sanitizeHost(rawHost);
+  if (!cookieHost) {
+    return {
+      ok: false,
+      code: "invalid_host",
+      message: "Could not validate the host for sign-in. Please try again.",
+    };
+  }
+
+  const storeSlug = await resolveStoreSlug(rawHost);
+  if (!storeSlug) {
+    return {
+      ok: false,
+      code: "store_not_found",
+      message: "Could not resolve this store. Please try again.",
+    };
+  }
+
+  const c = await cookies();
+  const grant = verifyJoinGrant(c.get(JOIN_GRANT_COOKIE)?.value, storeSlug);
+  if (!grant) {
+    // Expired, tampered with, or minted for a different store. All three
+    // recover the same way, and none of them is a password problem.
+    return { ok: false, code: "join_grant_invalid", message: EXPIRED_MESSAGE };
+  }
+
+  return completeCustomerStoreJoin(grant, cookieHost);
+}
+
+/**
+ * pendingJoinEmail reports the address the join screen is about, so the
+ * page can name it. Returns null when there is no usable grant, which the
+ * page renders as "start again" rather than an empty join form.
+ */
+export async function pendingJoinEmail(
+  storeSlug: string,
+): Promise<string | null> {
+  const c = await cookies();
+  const grant = verifyJoinGrant(c.get(JOIN_GRANT_COOKIE)?.value, storeSlug);
+  return grant?.email ?? null;
+}

--- a/apps/storefront/app/join/page.tsx
+++ b/apps/storefront/app/join/page.tsx
@@ -1,0 +1,102 @@
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import Link from "next/link";
+import { resolveStoreSlug } from "@/lib/slug";
+import { fetchStoreBySlug } from "@/lib/api/platform-api";
+import { StorefrontNav } from "@/components/StorefrontNav";
+import { JoinStoreForm } from "@/components/auth/JoinStoreForm";
+import { pendingJoinEmail } from "@/app/join/actions";
+
+export const metadata: Metadata = {
+  title: "Join this store",
+  robots: { index: false, follow: false },
+};
+
+function sanitizeNextPath(next: string | undefined): string {
+  if (!next || !next.startsWith("/")) return "/account";
+  if (next.startsWith("//") || next.includes("\\")) return "/account";
+  return next;
+}
+
+/**
+ * /join — the explicit store join.
+ *
+ * Reached when a customer signed in correctly but has no account with
+ * THIS store. Their Mark8ly login is real and their password was right;
+ * what is missing is a membership, and this page is where they create it.
+ *
+ * The copy has one job beyond consent: it must not let the customer
+ * believe this is a second, separate account. It is not — the password is
+ * shared platform-wide, and saying otherwise here would be a lie the
+ * password-reset flow immediately exposes (see the design doc's "What
+ * this decision does NOT give you").
+ */
+export default async function JoinPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string }>;
+}) {
+  const { next } = await searchParams;
+  const safeNext = sanitizeNextPath(next);
+
+  const h = await headers();
+  const host = h.get("host");
+  const storeSlug = await resolveStoreSlug(host);
+  const store = await fetchStoreBySlug(storeSlug).catch(() => null);
+  const storeName = store?.name ?? "this store";
+
+  const email = await pendingJoinEmail(storeSlug);
+
+  const protocol = h.get("x-forwarded-proto") ?? "https";
+  const origin = host ? `${protocol}://${host}` : "";
+
+  return (
+    <div className="min-h-screen bg-[color:var(--storefront-background,var(--paper-200))]">
+      <StorefrontNav storeName={store?.name} />
+      <main id="main" className="mx-auto max-w-md px-6 py-16 sm:px-8 sm:py-24">
+        <header className="space-y-2">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[color:var(--storefront-text,var(--ink-900))] opacity-55">
+            {store?.name ?? "Store"}
+          </p>
+          <h1 className="font-[family-name:var(--storefront-heading-font,var(--font-source-serif))] text-3xl font-medium text-[color:var(--storefront-text,var(--ink-900))]">
+            Join {storeName}
+          </h1>
+        </header>
+
+        {email ? (
+          <>
+            <div className="mt-4 space-y-3 text-sm leading-6 text-[color:var(--storefront-text,var(--ink-900))] opacity-75">
+              <p>
+                Your Mark8ly login worked. You just don&apos;t have an account
+                with {storeName} yet.
+              </p>
+              <p>
+                Joining creates your account here for{" "}
+                <span className="font-medium opacity-100">{email}</span> so this
+                store can hold your orders, addresses and rewards. You keep the
+                same Mark8ly login and password you already use — nothing new to
+                remember, and stores you&apos;ve already joined are unaffected.
+              </p>
+            </div>
+            <JoinStoreForm
+              storeName={storeName}
+              returnUrl={`${origin}${safeNext}`}
+            />
+          </>
+        ) : (
+          <div className="mt-4 space-y-4">
+            <p className="text-sm leading-6 text-[color:var(--storefront-text,var(--ink-900))] opacity-75">
+              This join request has expired. Sign in again to join {storeName}.
+            </p>
+            <Link
+              href="/sign-in"
+              className="inline-flex h-11 w-full items-center justify-center rounded-md bg-[color:var(--storefront-accent,var(--ink-900))] px-6 text-sm font-medium text-[color:var(--storefront-on-accent,var(--paper-200))] transition-opacity hover:opacity-90"
+            >
+              Back to sign in
+            </Link>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/apps/storefront/app/sign-in/actions.zitadel.test.ts
+++ b/apps/storefront/app/sign-in/actions.zitadel.test.ts
@@ -101,7 +101,14 @@ beforeEach(() => {
     json: async () => ({ data: { tenant_id: "tenant-1", id: "store-1" } }),
   } as Response);
 
-  fetchSpy = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  // Default: marketplace-api reports this identity IS a customer of the
+  // store. completeCustomerSignIn now asks before it mints a session
+  // cookie (see @/lib/auth/customer-session), so every test below that
+  // expects a cookie needs a membership to exist. The gate itself is
+  // covered in lib/auth/customer-session.membership.test.ts.
+  fetchSpy = vi
+    .fn()
+    .mockResolvedValue({ ok: true, json: async () => ({ data: { member: true } }) });
   globalThis.fetch = fetchSpy as unknown as typeof fetch;
 });
 

--- a/apps/storefront/app/sign-in/customer-login-flow.test.ts
+++ b/apps/storefront/app/sign-in/customer-login-flow.test.ts
@@ -160,6 +160,17 @@ function installFetchRouter(handlers: {
       });
     }
 
+    // The membership probe completeCustomerSignIn runs BEFORE it hands a
+    // session cookie to the browser. These traces are about the
+    // credential seams, so the customer is a member throughout; the gate
+    // itself is covered in lib/auth/customer-session.membership.test.ts.
+    if (
+      url.startsWith(`${MARKETPLACE_API_URL}`) &&
+      url.includes("/account/membership")
+    ) {
+      return jsonResponse(200, { data: { member: true } });
+    }
+
     if (url.startsWith(`${MARKETPLACE_API_URL}`) && url.includes("/account")) {
       return jsonResponse(200, {});
     }

--- a/apps/storefront/components/auth/CreateAccountForm.tsx
+++ b/apps/storefront/components/auth/CreateAccountForm.tsx
@@ -63,7 +63,14 @@ async function signUpWithPassword(
     } | null;
     const code = body?.error?.message ?? "UNKNOWN";
     const friendly: Record<string, string> = {
-      EMAIL_EXISTS: "An account with this email already exists. Try signing in instead.",
+      // NOT a dead end, and not necessarily an account with THIS store.
+      // A Mark8ly login is one platform identity used across every store,
+      // so the usual reason for landing here is that the shopper already
+      // has a login and is now at a store they have not joined. Sign-in
+      // is the route to the join screen, so say so plainly rather than
+      // implying they already shop here.
+      EMAIL_EXISTS:
+        "You already have a Mark8ly login for this email. Sign in with it and we'll set up your account with this store.",
       WEAK_PASSWORD: "Password must be at least 6 characters.",
       INVALID_EMAIL: "Please enter a valid email address.",
       TOO_MANY_ATTEMPTS_TRY_LATER:

--- a/apps/storefront/components/auth/CustomerSignInForm.tsx
+++ b/apps/storefront/components/auth/CustomerSignInForm.tsx
@@ -180,6 +180,15 @@ export function CustomerSignInForm({
             });
             return;
           }
+          if (result.code === "membership_required") {
+            // The password was RIGHT — what is missing is an account with
+            // this store. Rendering result.message as a form error next
+            // to the password field would read as a credential failure,
+            // which is the exact misleading-error trap this flow exists
+            // to avoid. Send them to the join screen instead.
+            router.push("/join");
+            return;
+          }
           setError(result.message);
           return;
         }
@@ -210,6 +219,11 @@ export function CustomerSignInForm({
       });
 
       if (!result.ok) {
+        if (result.code === "membership_required") {
+          // Correct password, correct code — no account with this store.
+          router.push("/join");
+          return;
+        }
         if (isTotpRequiredResult(result)) {
           // A FRESH challenge, not a wrong code — Zitadel handed back a
           // new sessionId/sessionToken pair. Update the held challenge

--- a/apps/storefront/components/auth/JoinStoreForm.tsx
+++ b/apps/storefront/components/auth/JoinStoreForm.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { joinThisStore } from "@/app/join/actions";
+
+interface JoinStoreFormProps {
+  storeName: string;
+  returnUrl: string;
+}
+
+/**
+ * The consent step for joining a store. Deliberately has no inputs — the
+ * identity comes from the server-signed join grant, never from anything
+ * this component could send.
+ */
+export function JoinStoreForm({ storeName, returnUrl }: JoinStoreFormProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function handleJoin() {
+    setError(null);
+    startTransition(async () => {
+      const result = await joinThisStore();
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      router.push(returnUrl);
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="mt-8 space-y-5">
+      {error && (
+        <p
+          role="alert"
+          aria-live="polite"
+          className="text-sm text-[color:var(--storefront-danger)]"
+        >
+          {error}
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={handleJoin}
+        disabled={pending}
+        className="w-full rounded-md bg-[color:var(--storefront-accent,var(--ink-900))] px-6 py-3 text-sm font-medium text-[color:var(--storefront-on-accent,var(--paper-200))] transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--storefront-accent,var(--moss-700))]"
+      >
+        {pending ? "Joining..." : `Join ${storeName}`}
+      </button>
+
+      <p className="text-center text-xs text-[color:var(--storefront-text,var(--ink-900))] opacity-60">
+        Changed your mind?{" "}
+        <Link
+          href="/"
+          className="text-[color:var(--storefront-accent,var(--moss-700))] underline underline-offset-4"
+        >
+          Keep browsing
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/apps/storefront/lib/auth/customer-session.membership.test.ts
+++ b/apps/storefront/lib/auth/customer-session.membership.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The store-membership gate, end to end through the real
+// completeCustomerSignIn / completeCustomerStoreJoin tail.
+//
+// The bug these guard: a customer who signed up at store1 could sign in
+// at store2 and silently acquire an account there, because a valid
+// credential was treated as permission to be at any store. See
+// docs/superpowers/specs/2026-09-05-customer-store-membership-design.md.
+//
+// The invariant asserted below is not "a row is absent" but "no session
+// cookie is ever handed to the browser for a store the customer has not
+// joined, and the only call that creates a membership is the one the
+// customer explicitly asked for".
+
+const cookieStore: Record<string, string> = {};
+const cookiesSetSpy = vi.fn(
+  (opts: { name: string; value: string; domain?: string; maxAge?: number }) => {
+    cookieStore[opts.name] = opts.value;
+  },
+);
+const cookiesDeleteSpy = vi.fn((name: string) => {
+  delete cookieStore[name];
+});
+
+const HOST = "store-two.mark8ly.com";
+let headerMap: Map<string, string>;
+
+vi.mock("next/headers", () => ({
+  headers: async () => ({
+    get: (key: string) => headerMap.get(key.toLowerCase()) ?? null,
+  }),
+  cookies: async () => ({
+    set: cookiesSetSpy,
+    get: (name: string) =>
+      cookieStore[name] !== undefined ? { value: cookieStore[name] } : undefined,
+    delete: cookiesDeleteSpy,
+  }),
+}));
+
+vi.mock("@/lib/api/server/platformInternal", () => ({
+  platformInternalFetch: vi.fn(),
+}));
+
+vi.mock("@/lib/slug", () => ({ resolveStoreSlug: vi.fn() }));
+
+import { resolveStoreSlug } from "@/lib/slug";
+import { JOIN_GRANT_COOKIE, verifyJoinGrant } from "@/lib/auth/join-grant";
+
+const resolveStoreSlugMock = vi.mocked(resolveStoreSlug);
+
+const STORE = { tenant_id: "tenant-2", store_id: "store-2" };
+const STORE_SLUG = "store-two";
+const VERIFIED = { uid: "uid-1", email: "shopper@example.com" };
+
+const originalFetch = globalThis.fetch;
+let calls: { url: string; method: string }[];
+
+/** Routes the marketplace-api calls completeCustomerSignIn makes.
+ *  `member` decides what the membership probe reports; `joinStatus`
+ *  decides how the explicit join responds. */
+function installFetch(opts: {
+  member: boolean | "unavailable";
+  joinStatus?: number;
+  joinError?: string;
+}) {
+  calls = [];
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({ url, method: init?.method ?? "GET" });
+
+    if (url.includes("/account/membership")) {
+      if (opts.member === "unavailable") {
+        return jsonResponse(503, {});
+      }
+      return jsonResponse(200, { data: { member: opts.member } });
+    }
+    if (url.includes("/account/join")) {
+      const status = opts.joinStatus ?? 200;
+      return jsonResponse(
+        status,
+        status === 200 ? { data: {} } : { error: opts.joinError },
+      );
+    }
+    if (url.includes("/loyalty/enroll")) return jsonResponse(200, {});
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as unknown as typeof fetch;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+async function loadSession() {
+  return await import("@/lib/auth/customer-session");
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  headerMap = new Map([["host", HOST]]);
+  for (const key of Object.keys(cookieStore)) delete cookieStore[key];
+  cookiesSetSpy.mockClear();
+  cookiesDeleteSpy.mockClear();
+  resolveStoreSlugMock.mockReset();
+  resolveStoreSlugMock.mockResolvedValue(STORE_SLUG);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("completeCustomerSignIn — a verified credential is not a membership", () => {
+  it("mints no session at a store the customer has not joined, and offers the join instead", async () => {
+    installFetch({ member: false });
+    const { completeCustomerSignIn } = await loadSession();
+
+    const result = await completeCustomerSignIn(STORE, HOST, STORE_SLUG, VERIFIED);
+
+    expect(result).toMatchObject({ ok: false, code: "membership_required" });
+    expect(cookieStore["mp_customer_session"]).toBeUndefined();
+    expect(
+      cookiesSetSpy.mock.calls.some(
+        (c) => c[0].name === "mp_customer_session",
+      ),
+    ).toBe(false);
+  });
+
+  it("never creates the membership on the sign-in path — only the probe is called", async () => {
+    installFetch({ member: false });
+    const { completeCustomerSignIn } = await loadSession();
+
+    await completeCustomerSignIn(STORE, HOST, STORE_SLUG, VERIFIED);
+
+    const joinCalls = calls.filter((c) => c.url.includes("/account/join"));
+    expect(joinCalls).toEqual([]);
+    // Nor may it fall back to the old "poke /account so the middleware
+    // upserts a row" trick, which is what made membership incidental.
+    const accountPokes = calls.filter(
+      (c) => c.url.includes("/account") && !c.url.includes("/account/membership"),
+    );
+    expect(accountPokes).toEqual([]);
+  });
+
+  it("does not run the loyalty side effects for a non-member", async () => {
+    installFetch({ member: false });
+    const { completeCustomerSignIn } = await loadSession();
+
+    await completeCustomerSignIn(STORE, HOST, STORE_SLUG, VERIFIED);
+
+    expect(calls.some((c) => c.url.includes("/loyalty/enroll"))).toBe(false);
+  });
+
+  it("issues a short-lived, host-scoped join grant carrying the verified identity", async () => {
+    installFetch({ member: false });
+    const { completeCustomerSignIn } = await loadSession();
+
+    await completeCustomerSignIn(STORE, HOST, STORE_SLUG, VERIFIED);
+
+    const grantCall = cookiesSetSpy.mock.calls.find(
+      (c) => c[0].name === JOIN_GRANT_COOKIE,
+    );
+    expect(grantCall).toBeDefined();
+    expect(grantCall![0]).toMatchObject({ domain: HOST, maxAge: 600 });
+
+    const claims = verifyJoinGrant(grantCall![0].value, STORE_SLUG);
+    expect(claims).toMatchObject({
+      uid: VERIFIED.uid,
+      email: VERIFIED.email,
+      store_id: STORE.store_id,
+    });
+  });
+
+  it("the copy never implies a wrong password", async () => {
+    installFetch({ member: false });
+    const { completeCustomerSignIn } = await loadSession();
+
+    const result = await completeCustomerSignIn(STORE, HOST, STORE_SLUG, VERIFIED);
+
+    if (result.ok) throw new Error("expected the gate to refuse");
+    const message = result.message.toLowerCase();
+    for (const forbidden of ["password", "incorrect", "credentials"]) {
+      expect(message).not.toContain(forbidden);
+    }
+  });
+
+  it("fails closed when the membership check is unavailable — no session, no silent sign-in", async () => {
+    installFetch({ member: "unavailable" });
+    const { completeCustomerSignIn } = await loadSession();
+
+    const result = await completeCustomerSignIn(STORE, HOST, STORE_SLUG, VERIFIED);
+
+    expect(result).toMatchObject({ ok: false, code: "membership_unavailable" });
+    expect(cookieStore["mp_customer_session"]).toBeUndefined();
+    expect(cookieStore[JOIN_GRANT_COOKIE]).toBeUndefined();
+  });
+
+  it("signs an existing member in exactly as before", async () => {
+    installFetch({ member: true });
+    const { completeCustomerSignIn } = await loadSession();
+
+    const result = await completeCustomerSignIn(STORE, HOST, STORE_SLUG, VERIFIED);
+
+    expect(result).toEqual({ ok: true });
+    expect(cookiesSetSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "mp_customer_session", domain: HOST }),
+    );
+    expect(calls.some((c) => c.url.includes("/loyalty/enroll"))).toBe(true);
+    // An existing member is looked up, never re-created.
+    expect(calls.some((c) => c.url.includes("/account/join"))).toBe(false);
+  });
+});
+
+describe("joinThisStore — the explicit join", () => {
+  async function primeGrant() {
+    installFetch({ member: false });
+    const { completeCustomerSignIn } = await loadSession();
+    await completeCustomerSignIn(STORE, HOST, STORE_SLUG, VERIFIED);
+  }
+
+  it("creates the membership and only then mints the session", async () => {
+    await primeGrant();
+    installFetch({ member: false, joinStatus: 200 });
+    const { joinThisStore } = await import("@/app/join/actions");
+
+    const result = await joinThisStore();
+
+    expect(result).toEqual({ ok: true });
+    const joinIndex = calls.findIndex((c) => c.url.includes("/account/join"));
+    expect(joinIndex).toBeGreaterThanOrEqual(0);
+    expect(calls[joinIndex]!.method).toBe("POST");
+    expect(cookiesSetSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "mp_customer_session", domain: HOST }),
+    );
+    expect(cookiesDeleteSpy).toHaveBeenCalledWith(JOIN_GRANT_COOKIE);
+  });
+
+  it("refuses without a grant — a join is never reachable from an unverified request", async () => {
+    installFetch({ member: false });
+    const { joinThisStore } = await import("@/app/join/actions");
+
+    const result = await joinThisStore();
+
+    expect(result).toMatchObject({ ok: false, code: "join_grant_invalid" });
+    expect(calls.some((c) => c.url.includes("/account/join"))).toBe(false);
+    expect(cookieStore["mp_customer_session"]).toBeUndefined();
+  });
+
+  it("refuses a grant minted for a different store", async () => {
+    await primeGrant();
+    installFetch({ member: false });
+    // Same browser, same grant cookie, but the request now resolves to a
+    // third store. Without the store check the grant would join it.
+    resolveStoreSlugMock.mockResolvedValue("store-three");
+    const { joinThisStore } = await import("@/app/join/actions");
+
+    const result = await joinThisStore();
+
+    expect(result).toMatchObject({ ok: false, code: "join_grant_invalid" });
+    expect(calls.some((c) => c.url.includes("/account/join"))).toBe(false);
+  });
+
+  it("surfaces a blocked customer without minting a session", async () => {
+    await primeGrant();
+    installFetch({ member: false, joinStatus: 403, joinError: "account_blocked" });
+    const { joinThisStore } = await import("@/app/join/actions");
+
+    const result = await joinThisStore();
+
+    expect(result).toMatchObject({ ok: false, code: "account_blocked" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message.toLowerCase()).not.toContain("try again");
+    }
+    expect(
+      cookiesSetSpy.mock.calls.some((c) => c[0].name === "mp_customer_session"),
+    ).toBe(false);
+  });
+
+  it("mints no session when the join call fails", async () => {
+    await primeGrant();
+    installFetch({ member: false, joinStatus: 500 });
+    const { joinThisStore } = await import("@/app/join/actions");
+
+    const result = await joinThisStore();
+
+    expect(result).toMatchObject({ ok: false, code: "join_failed" });
+    expect(
+      cookiesSetSpy.mock.calls.some((c) => c[0].name === "mp_customer_session"),
+    ).toBe(false);
+  });
+});

--- a/apps/storefront/lib/auth/customer-session.ts
+++ b/apps/storefront/lib/auth/customer-session.ts
@@ -15,16 +15,24 @@
 // them in apps/storefront's vitest-covered path (components/** is not
 // covered — see @/lib/auth/provider's file header).
 //
-// completeCustomerSignIn stays the ONLY place that mints
-// `mp_customer_session` — apps/storefront/app/sign-in/actions.ts's
-// customerSignIn and confirmCustomerTotp, and
-// apps/storefront/app/auth/idp/finish/route.ts (the Zitadel Google
-// finish route), all call this same function rather than each minting
-// their own cookie. A second cookie-minting path would drift from this
-// one the same way a second copy of this function's logic would.
+// issueCustomerSession stays the ONLY place that mints
+// `mp_customer_session`, and only completeCustomerSignIn and
+// completeCustomerStoreJoin (both below) call it —
+// apps/storefront/app/sign-in/actions.ts's customerSignIn and
+// confirmCustomerTotp, app/create-account/actions.ts's
+// verifyCustomerEmail, app/join/actions.ts's joinThisStore, and
+// app/auth/idp/finish/route.ts (the Zitadel Google finish route) all go
+// through those two rather than each minting their own cookie. A second
+// cookie-minting path would drift from this one the same way a second
+// copy of this function's logic would.
 
 import { cookies } from "next/headers";
-import { encodeSession } from "@/lib/session";
+import { encodeSession, SESSION_TTL_SECONDS } from "@/lib/session";
+import {
+  JOIN_GRANT_COOKIE,
+  JOIN_GRANT_TTL_SECONDS,
+  signJoinGrant,
+} from "@/lib/auth/join-grant";
 import { platformInternalFetch } from "@/lib/api/server/platformInternal";
 import type { CustomerSignInResult as Result } from "@/lib/auth/customer-sign-in-result";
 
@@ -57,15 +65,33 @@ export async function resolveStore(
   }
 }
 
-// Best-effort: register the customer profile in marketplace-api so
-// they show up in the merchant's customer list and can place orders.
-// We call the web storefront /account endpoint (GET) with the session
-// cookie — the OptionalCustomerAuth middleware automatically calls
-// EnsureProfile when it sees a valid session cookie.
-async function ensureCustomerProfile(
+// Asks marketplace-api whether this verified identity has already joined
+// this store. The freshly minted cookie value is sent as a header on a
+// server-to-server call — it is NOT handed to the browser unless this
+// comes back a member, which is the entire point: a session must never be
+// minted at a store the customer has not joined.
+//
+// This replaced a "best-effort" GET /account whose only purpose was the
+// side effect on the other end: marketplace-api's session middleware used
+// to CREATE the customer_profiles row when it saw a valid cookie. That is
+// exactly the bug in
+// docs/superpowers/specs/2026-09-05-customer-store-membership-design.md —
+// browsing store2 with a store1 password made you a customer of store2.
+// The middleware is read-only now, and creation lives behind the explicit
+// join below.
+//
+// Fails CLOSED: an unreachable or unparseable API means we cannot show
+// that the customer belongs here, so we do not mint a session. The caller
+// turns that into a plain "try again shortly", never a silent sign-in.
+type MembershipCheck =
+  | { kind: "member" }
+  | { kind: "not_member" }
+  | { kind: "unavailable" };
+
+async function checkStoreMembership(
   storeSlug: string,
   cookieValue: string,
-): Promise<void> {
+): Promise<MembershipCheck> {
   try {
     const headers: Record<string, string> = {
       Accept: "application/json",
@@ -73,20 +99,72 @@ async function ensureCustomerProfile(
     };
     if (STOREFRONT_KEY) headers["X-Storefront-Key"] = STOREFRONT_KEY;
 
-    await fetch(
-      `${MARKETPLACE_API_URL}/api/v1/storefront/stores/${encodeURIComponent(storeSlug)}/account`,
-      {
-        method: "GET",
-        headers,
-        cache: "no-store",
-      },
+    const res = await fetch(
+      `${MARKETPLACE_API_URL}/api/v1/storefront/stores/${encodeURIComponent(storeSlug)}/account/membership`,
+      { method: "GET", headers, cache: "no-store" },
     );
-    // The GET /account call triggers OptionalCustomerAuth middleware
-    // which calls EnsureProfile. We don't care about the response —
-    // the side effect (profile creation) is what matters.
+    if (!res.ok) return { kind: "unavailable" };
+    const body = (await res.json()) as { data?: { member?: boolean } };
+    if (typeof body.data?.member !== "boolean") return { kind: "unavailable" };
+    return body.data.member ? { kind: "member" } : { kind: "not_member" };
   } catch {
-    // silent — customer can still browse
+    return { kind: "unavailable" };
   }
+}
+
+/**
+ * joinStoreWithSession creates the customer_profiles membership row for
+ * an identity this server has verified. It is the ONLY thing in this app
+ * that asks marketplace-api to create a membership, and it runs only
+ * after the customer explicitly accepted the join.
+ *
+ * Authenticates with the same signed session value the join is about, so
+ * marketplace-api creates the membership for the identity IN that
+ * credential — never for an email a caller supplied.
+ */
+async function joinStoreWithSession(
+  storeSlug: string,
+  cookieValue: string,
+): Promise<{ ok: true } | { ok: false; code: string; message: string }> {
+  let res: Response;
+  try {
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      Cookie: `mp_customer_session=${cookieValue}`,
+    };
+    if (STOREFRONT_KEY) headers["X-Storefront-Key"] = STOREFRONT_KEY;
+
+    res = await fetch(
+      `${MARKETPLACE_API_URL}/api/v1/storefront/stores/${encodeURIComponent(storeSlug)}/account/join`,
+      { method: "POST", headers, body: "{}", cache: "no-store" },
+    );
+  } catch {
+    return {
+      ok: false,
+      code: "join_unavailable",
+      message: "We couldn't finish setting up your account here. Please try again shortly.",
+    };
+  }
+
+  if (res.ok) return { ok: true };
+
+  const body = (await res.json().catch(() => null)) as {
+    error?: string;
+  } | null;
+  if (body?.error === "account_blocked") {
+    return {
+      ok: false,
+      code: "account_blocked",
+      message:
+        "This store has suspended your account, so it can't be reopened here. Please contact the store if you think that's a mistake.",
+    };
+  }
+  return {
+    ok: false,
+    code: "join_failed",
+    message: "We couldn't finish setting up your account here. Please try again shortly.",
+  };
 }
 
 // Best-effort: auto-enroll the customer in the store's loyalty program.
@@ -126,16 +204,24 @@ async function ensureLoyaltyEnrollment(
 
 /**
  * completeCustomerSignIn is the tail shared by every path that ends in a
- * verified {uid, email}: minting the HMAC-signed session cookie scoped to
- * the resolved host, the best-effort profile and loyalty side effects, and
- * burning the referral cookie. apps/storefront/app/sign-in/actions.ts's
- * customerSignIn (password/id-token path) and confirmCustomerTotp
- * (authenticator-code path), and apps/storefront/app/auth/idp/finish/
- * route.ts (the Zitadel Google finish route, which resolves a
- * {uid, email} from auth-bff's idp/finish endpoint rather than from a
- * password/id-token) all call this instead of each carrying their own
- * copy — a second copy of this tail would drift the moment one path
- * changed and the other didn't.
+ * verified {uid, email}: apps/storefront/app/sign-in/actions.ts's
+ * customerSignIn (password/id-token) and confirmCustomerTotp
+ * (authenticator code), apps/storefront/app/create-account/actions.ts's
+ * verifyCustomerEmail, and apps/storefront/app/auth/idp/finish/route.ts
+ * (the Zitadel Google finish route) all call this instead of each
+ * carrying their own copy.
+ *
+ * A verified credential is NOT on its own permission to be here. One
+ * Mark8ly login works platform-wide; each store is a membership the
+ * customer joins deliberately. So this function checks membership BEFORE
+ * the cookie reaches the browser:
+ *
+ *   member      -> mint the session, run the loyalty/referral side effects
+ *   not a member-> mint NOTHING; issue a short-lived join grant cookie and
+ *                  return `membership_required` so the caller can offer
+ *                  the join. The copy must never imply a wrong password —
+ *                  the password was right.
+ *   unavailable -> mint NOTHING. Fail closed and say so.
  */
 export async function completeCustomerSignIn(
   store: { tenant_id: string; store_id: string },
@@ -143,9 +229,8 @@ export async function completeCustomerSignIn(
   storeSlug: string,
   verified: { uid: string; email: string },
 ): Promise<Result> {
-  // Set the HMAC-signed customer session cookie. The storefront
-  // layout decodes and verifies this on every request to hydrate
-  // the authenticated state.
+  // Minted, but deliberately not handed to the browser yet — it is first
+  // used as the server-to-server credential for the membership check.
   const cookieValue = encodeSession({
     uid: verified.uid,
     email: verified.email,
@@ -154,7 +239,98 @@ export async function completeCustomerSignIn(
     tenant_id: store.tenant_id,
   });
 
+  const membership = await checkStoreMembership(storeSlug, cookieValue);
   const c = await cookies();
+
+  if (membership.kind === "unavailable") {
+    return {
+      ok: false,
+      code: "membership_unavailable",
+      message: "Sign-in is temporarily unavailable. Please try again shortly.",
+    };
+  }
+
+  if (membership.kind === "not_member") {
+    // No session cookie. The grant below authorises the join and nothing
+    // else, and expires in minutes.
+    c.set({
+      name: JOIN_GRANT_COOKIE,
+      value: signJoinGrant({
+        uid: verified.uid,
+        email: verified.email,
+        store_slug: storeSlug,
+        store_id: store.store_id,
+        tenant_id: store.tenant_id,
+      }),
+      path: "/",
+      domain: cookieHost,
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      maxAge: JOIN_GRANT_TTL_SECONDS,
+    });
+    return {
+      ok: false,
+      code: "membership_required",
+      message:
+        "Your Mark8ly login works here — you just don't have an account with this store yet.",
+    };
+  }
+
+  issueCustomerSession(c, cookieValue, cookieHost);
+  await runPostSignInSideEffects(c, storeSlug, verified.email);
+  return { ok: true };
+}
+
+/**
+ * completeCustomerStoreJoin creates the membership for an identity this
+ * server verified minutes ago (carried by a join grant), then completes
+ * sign-in exactly as completeCustomerSignIn's member branch does.
+ *
+ * The order matters and is the invariant this whole feature rests on: the
+ * membership row is created FIRST, by an explicit request the customer
+ * made, and only then does a session cookie exist.
+ */
+export async function completeCustomerStoreJoin(
+  grant: {
+    uid: string;
+    email: string;
+    store_slug: string;
+    store_id: string;
+    tenant_id: string;
+  },
+  cookieHost: string,
+): Promise<Result> {
+  const cookieValue = encodeSession({
+    uid: grant.uid,
+    email: grant.email,
+    store_slug: grant.store_slug,
+    store_id: grant.store_id,
+    tenant_id: grant.tenant_id,
+  });
+
+  const joined = await joinStoreWithSession(grant.store_slug, cookieValue);
+  if (!joined.ok) {
+    return { ok: false, code: joined.code, message: joined.message };
+  }
+
+  const c = await cookies();
+  issueCustomerSession(c, cookieValue, cookieHost);
+  // The grant has done its job; leaving it set would keep a second
+  // credential alive for no reason.
+  c.delete(JOIN_GRANT_COOKIE);
+  await runPostSignInSideEffects(c, grant.store_slug, grant.email);
+  return { ok: true };
+}
+
+type CookieJar = Awaited<ReturnType<typeof cookies>>;
+
+/** The single place `mp_customer_session` is handed to a browser. */
+function issueCustomerSession(
+  c: CookieJar,
+  cookieValue: string,
+  cookieHost: string,
+): void {
   c.set({
     name: "mp_customer_session",
     value: cookieValue,
@@ -163,24 +339,22 @@ export async function completeCustomerSignIn(
     httpOnly: true,
     secure: true,
     sameSite: "lax",
-    maxAge: 60 * 60 * 24 * 30, // 30 days
+    maxAge: SESSION_TTL_SECONDS,
   });
+}
 
-  // Best-effort profile registration — pass the freshly minted cookie
-  // so marketplace-api's OptionalCustomerAuth can validate it and call
-  // EnsureProfile.
-  await ensureCustomerProfile(storeSlug, cookieValue);
-
-  // Auto-enroll in loyalty (idempotent — signup bonus awarded once).
-  // Reads the mp_referral cookie captured by middleware on a prior
-  // page hit, so referral attribution survives the GIP signup dance.
+/** Loyalty auto-enrolment and referral burn — run once a session exists
+ *  and the customer is a member of this store. */
+async function runPostSignInSideEffects(
+  c: CookieJar,
+  storeSlug: string,
+  email: string,
+): Promise<void> {
   const referralCode = c.get("mp_referral")?.value;
-  await ensureLoyaltyEnrollment(storeSlug, verified.email, referralCode);
+  await ensureLoyaltyEnrollment(storeSlug, email, referralCode);
   if (referralCode) {
     // Burn the cookie so the same invite link can't be replayed by
     // the same browser for another account.
     c.delete("mp_referral");
   }
-
-  return { ok: true };
 }

--- a/apps/storefront/lib/auth/customer-signup-messages.ts
+++ b/apps/storefront/lib/auth/customer-signup-messages.ts
@@ -9,8 +9,15 @@
 //
 // Two codes carry the phase brief's sharpest constraint:
 //   - email_taken is PERMANENT for that address (a verified account
-//     already owns it) — the message must be actionable (sign in instead,
-//     or contact support) and must never suggest retrying registration.
+//     already owns it) — the message must be actionable and must never
+//     suggest retrying registration. What it must ALSO not do is imply
+//     the shopper already has an account with THIS store. A Mark8ly login
+//     is one platform identity across every storefront, so the ordinary
+//     way to reach this code is a real customer of store1 registering at
+//     store2. That shopper should be routed to sign-in, which detects the
+//     missing membership and offers the join
+//     (docs/superpowers/specs/2026-09-05-customer-store-membership-design.md),
+//     not told they are already set up here.
 //   - verification_email_failed is the OPPOSITE: register rolled the new
 //     account back, so the address is free again and retrying genuinely
 //     works — the message must say so, not read like a dead end.
@@ -22,7 +29,7 @@
 // string to the shopper.
 const MESSAGES: Record<string, string> = {
   email_taken:
-    "An account with this email address already exists. Sign in instead, or contact support if you believe this is a mistake.",
+    "You already have a Mark8ly login for this email. Sign in with it and we'll set up your account with this store.",
   email_ambiguous:
     "We found more than one account for this email and can't tell which one to use. Please contact support for help.",
   weak_password:

--- a/apps/storefront/lib/auth/join-grant.test.ts
+++ b/apps/storefront/lib/auth/join-grant.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { encodeSession } from "@/lib/session";
+import {
+  JOIN_GRANT_TTL_SECONDS,
+  signJoinGrant,
+  verifyJoinGrant,
+} from "@/lib/auth/join-grant";
+
+const CLAIMS = {
+  uid: "uid-1",
+  email: "shopper@example.com",
+  store_slug: "store-two",
+  store_id: "store-2",
+  tenant_id: "tenant-2",
+};
+
+describe("join grant", () => {
+  it("round-trips the identity it was signed for", () => {
+    expect(verifyJoinGrant(signJoinGrant(CLAIMS), "store-two")).toEqual(CLAIMS);
+  });
+
+  it("rejects a grant spent at a different store", () => {
+    // A grant is minted at the store where the membership gate refused.
+    // Without this check it would authorise a join anywhere.
+    expect(verifyJoinGrant(signJoinGrant(CLAIMS), "store-three")).toBeNull();
+  });
+
+  it("rejects a tampered payload", () => {
+    const grant = signJoinGrant(CLAIMS);
+    const sig = grant.slice(grant.lastIndexOf(".") + 1);
+    const forged = Buffer.from(
+      JSON.stringify({
+        ...CLAIMS,
+        email: "victim@example.com",
+        purpose: "customer-store-join-grant:v1",
+        exp: Math.floor(Date.now() / 1000) + 600,
+      }),
+    ).toString("base64");
+    expect(verifyJoinGrant(`${forged}.${sig}`, "store-two")).toBeNull();
+  });
+
+  it("rejects an expired grant", () => {
+    expect(verifyJoinGrant(signJoinGrant(CLAIMS, -1), "store-two")).toBeNull();
+  });
+
+  it("expires in minutes, not the session's 30 days", () => {
+    expect(JOIN_GRANT_TTL_SECONDS).toBeLessThanOrEqual(15 * 60);
+  });
+
+  it("refuses a session cookie replayed as a join grant", () => {
+    // Both are signed with SESSION_ENCRYPT_KEY, so the signature alone
+    // would verify; the purpose tag is what keeps the two apart.
+    const session = encodeSession({
+      uid: CLAIMS.uid,
+      email: CLAIMS.email,
+      store_slug: CLAIMS.store_slug,
+      store_id: CLAIMS.store_id,
+      tenant_id: CLAIMS.tenant_id,
+    });
+    expect(verifyJoinGrant(session, "store-two")).toBeNull();
+  });
+
+  it("rejects junk without throwing", () => {
+    for (const junk of ["", "no-dot", "a.b", undefined, null]) {
+      expect(verifyJoinGrant(junk as string, "store-two")).toBeNull();
+    }
+  });
+});

--- a/apps/storefront/lib/auth/join-grant.ts
+++ b/apps/storefront/lib/auth/join-grant.ts
@@ -1,0 +1,141 @@
+// The short-lived, HMAC-signed grant that carries a verified customer
+// identity from "you signed in correctly, but you have no account with
+// THIS store" to the join screen.
+//
+// WHY THIS EXISTS AT ALL. A Mark8ly login is one platform identity;
+// access to a store is a separate membership the customer joins
+// deliberately (docs/superpowers/specs/2026-09-05-customer-store-membership-design.md).
+// So completeCustomerSignIn must NOT hand the browser an
+// `mp_customer_session` cookie for a store the customer has not joined —
+// that cookie is exactly the thing the whole gate is about. But joining
+// still has to prove who is joining, and the only party that verified the
+// credential is this server, one request ago.
+//
+// The grant closes that gap: it is a session-shaped claim set, signed the
+// same way and scoped to the same host, but issued under its own purpose
+// tag, with a 10-minute lifetime, under its own cookie name — and it
+// authorises exactly one thing (creating the membership), never a
+// customer session. The real session is minted only after the join
+// succeeds, by the same completeCustomerSignIn tail every other path
+// uses.
+//
+// It is deliberately a COOKIE rather than a value returned to the client:
+// the Google/OIDC finish routes reach the join screen through a browser
+// redirect, and putting a bearer-ish credential in a URL puts it in
+// access logs, referrers, and history. HttpOnly keeps it out of page
+// scripts too.
+//
+// Reuses SESSION_ENCRYPT_KEY (see lib/session.ts and
+// lib/auth/pending-signup-token.ts) rather than provisioning a second
+// secret. Cross-protocol confusion is prevented by the purpose tag inside
+// the signed payload: a session cookie's payload has no `purpose` field,
+// and verifyJoinGrant rejects any payload whose purpose is not exactly
+// this module's, so a grant can never be replayed as a session and a
+// session can never be replayed as a grant.
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const DEV_SESSION_KEY = "dev-session-key-min-32-bytes!!!";
+
+const GRANT_PURPOSE = "customer-store-join-grant:v1";
+
+/** The customer has ten minutes to accept the join before signing in
+ *  again. Short because the grant stands in for a freshly verified
+ *  credential, and a credential check that old should be redone. */
+export const JOIN_GRANT_TTL_SECONDS = 10 * 60;
+
+export const JOIN_GRANT_COOKIE = "mp_join_grant";
+
+export interface JoinGrantClaims {
+  uid: string;
+  email: string;
+  store_slug: string;
+  store_id: string;
+  tenant_id: string;
+}
+
+interface SignedJoinGrant extends JoinGrantClaims {
+  purpose: string;
+  exp: number;
+}
+
+function grantKey(): string {
+  const key = process.env.SESSION_ENCRYPT_KEY;
+  if (key) return key;
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("SESSION_ENCRYPT_KEY is required in production");
+  }
+  return DEV_SESSION_KEY;
+}
+
+function sign(payload: string): string {
+  return createHmac("sha256", grantKey()).update(payload).digest("hex");
+}
+
+/** signJoinGrant encodes and signs a grant for the identity THIS server
+ *  just verified. Never called with values a client supplied. */
+export function signJoinGrant(
+  claims: JoinGrantClaims,
+  ttlSeconds: number = JOIN_GRANT_TTL_SECONDS,
+): string {
+  const body: SignedJoinGrant = {
+    ...claims,
+    purpose: GRANT_PURPOSE,
+    exp: Math.floor(Date.now() / 1000) + ttlSeconds,
+  };
+  const payload = Buffer.from(JSON.stringify(body)).toString("base64");
+  return `${payload}.${sign(payload)}`;
+}
+
+/**
+ * verifyJoinGrant returns the claims a grant carries, or null if the
+ * value is malformed, tampered with, expired, not a join grant, or not
+ * for the store named by `expectedStoreSlug`.
+ *
+ * The store check is not decorative: without it a grant minted at store2
+ * — where the customer legitimately failed the membership gate — would
+ * authorise a join at store3.
+ */
+export function verifyJoinGrant(
+  value: string | undefined | null,
+  expectedStoreSlug: string,
+): JoinGrantClaims | null {
+  if (typeof value !== "string" || !value) return null;
+
+  const dotIndex = value.lastIndexOf(".");
+  if (dotIndex < 0) return null;
+  const payload = value.slice(0, dotIndex);
+  const sig = value.slice(dotIndex + 1);
+
+  const expected = sign(payload);
+  if (sig.length !== expected.length) return null;
+  try {
+    if (!timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) return null;
+  } catch {
+    return null;
+  }
+
+  let parsed: Partial<SignedJoinGrant>;
+  try {
+    parsed = JSON.parse(
+      Buffer.from(payload, "base64").toString(),
+    ) as Partial<SignedJoinGrant>;
+  } catch {
+    return null;
+  }
+
+  if (parsed.purpose !== GRANT_PURPOSE) return null;
+  if (typeof parsed.exp !== "number") return null;
+  if (Math.floor(Date.now() / 1000) > parsed.exp) return null;
+  if (!parsed.uid || !parsed.email) return null;
+  if (!parsed.store_slug || parsed.store_slug !== expectedStoreSlug) return null;
+  if (!parsed.store_id || !parsed.tenant_id) return null;
+
+  return {
+    uid: parsed.uid,
+    email: parsed.email,
+    store_slug: parsed.store_slug,
+    store_id: parsed.store_id,
+    tenant_id: parsed.tenant_id,
+  };
+}

--- a/services/marketplace-api/internal/customer/models.go
+++ b/services/marketplace-api/internal/customer/models.go
@@ -1,6 +1,9 @@
 // Package customer provides the domain model, repository, and service
-// for customer profiles and addresses. Profiles are auto-created on
-// first authenticated storefront request (see Service.EnsureProfile).
+// for customer profiles and addresses. A profile IS the customer's
+// membership of one store: UNIQUE (store_id, email). It is created only
+// by an explicit join (Service.JoinStore) — never as a side effect of an
+// authenticated request, which is what session paths use
+// Service.LookupProfile for.
 package customer
 
 import (

--- a/services/marketplace-api/internal/customer/repository.go
+++ b/services/marketplace-api/internal/customer/repository.go
@@ -21,6 +21,12 @@ type Repository interface {
 	// UpsertProfile inserts a profile or updates gip_uid+updated_at on conflict(store_id, email).
 	UpsertProfile(ctx context.Context, p *CustomerProfile) (*CustomerProfile, error)
 
+	// GetProfileByEmail returns the membership row for (store_id, email),
+	// or ErrNotFound when this identity has not joined this store. This is
+	// the read half of the membership model: every session-path caller
+	// uses it, and none of them may fall back to creating a row.
+	GetProfileByEmail(ctx context.Context, storeID uuid.UUID, email string) (*CustomerProfile, error)
+
 	// GetProfileByGipUID returns the profile for (store_id, gip_uid). ErrNotFound on miss.
 	GetProfileByGipUID(ctx context.Context, storeID uuid.UUID, gipUID string) (*CustomerProfile, error)
 
@@ -112,6 +118,20 @@ func (r *gormRepo) UpsertProfile(ctx context.Context, p *CustomerProfile) (*Cust
 		return nil, fmt.Errorf("customer: reload after upsert: %w", err)
 	}
 	return &fresh, nil
+}
+
+func (r *gormRepo) GetProfileByEmail(ctx context.Context, storeID uuid.UUID, email string) (*CustomerProfile, error) {
+	var p CustomerProfile
+	err := r.db.WithContext(ctx).
+		Where("store_id = ? AND email = ?", storeID, strings.TrimSpace(strings.ToLower(email))).
+		First(&p).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("customer: get by email: %w", err)
+	}
+	return &p, nil
 }
 
 func (r *gormRepo) GetProfileByGipUID(ctx context.Context, storeID uuid.UUID, gipUID string) (*CustomerProfile, error) {

--- a/services/marketplace-api/internal/customer/service.go
+++ b/services/marketplace-api/internal/customer/service.go
@@ -2,6 +2,7 @@ package customer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -14,8 +15,8 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/audit"
 )
 
-// EnsureProfileInput is the input for profile auto-creation.
-type EnsureProfileInput struct {
+// JoinStoreInput is the input for creating a store membership.
+type JoinStoreInput struct {
 	StoreID   uuid.UUID
 	TenantID  uuid.UUID
 	GipUID    string
@@ -44,23 +45,64 @@ func (s *Service) WithAudit(e *audit.Emitter) *Service {
 	return s
 }
 
+// ErrBlocked is returned by JoinStore when a membership row already
+// exists for (store_id, email) but the merchant has blocked it. Joining
+// must never resurrect or reset a blocked customer, so the join is
+// refused outright rather than upserted over.
+var ErrBlocked = errors.New("customer: membership is blocked")
+
 // signupFreshness is how recently a profile must have been created for
-// EnsureProfile to treat the upsert as a fresh signup. The repo reload
+// JoinStore to treat the upsert as a fresh signup. The repo reload
 // happens within milliseconds of the insert, so 2s comfortably covers
 // jitter without false-positive-ing on rapid re-logins.
 const signupFreshness = 2 * time.Second
 
-// EnsureProfile upserts a customer profile on first authenticated request.
+// LookupProfile returns the membership row for (store_id, email), or
+// ErrNotFound when this identity has not joined this store.
+//
+// This is the ONLY customer-profile call any session path may make. A
+// Mark8ly login is platform-wide, but access to a store is a distinct
+// membership the customer has to join deliberately; before this existed,
+// the session path called the creating upsert below and every
+// authenticated request at any store minted a membership as a side
+// effect (see docs/superpowers/specs/2026-09-05-customer-store-membership-design.md).
+func (s *Service) LookupProfile(ctx context.Context, storeID uuid.UUID, email string) (*CustomerProfile, error) {
+	email = strings.TrimSpace(strings.ToLower(email))
+	if email == "" {
+		return nil, ErrNotFound
+	}
+	return s.repo.GetProfileByEmail(ctx, storeID, email)
+}
+
+// JoinStore creates the customer's membership of a store: the
+// customer_profiles row keyed on (store_id, email), and nothing else —
+// no new identity, no new credential. It is reached ONLY from an
+// explicit join (the storefront /account/join endpoint and the mobile
+// /account/register endpoint), never from a session or browsing path.
+//
 // Uses INSERT ON CONFLICT (store_id, email) DO UPDATE SET gip_uid = EXCLUDED.gip_uid
-// so concurrent first-logins are safe.
+// so a double-submitted join is safe. The conflict branch deliberately
+// touches only gip_uid/updated_at, so re-joining can never reset status,
+// block_reason, tags, or notes; a blocked membership is additionally
+// refused up front with ErrBlocked rather than relying on that.
 //
 // Returns the existing or newly created profile. When called from a
 // gin handler (c may be nil for non-HTTP callers) and the upsert
 // inserted a new row, emits a customer.signed_up audit event.
-func (s *Service) EnsureProfile(ctx context.Context, input EnsureProfileInput, c *gin.Context) (*CustomerProfile, error) {
+func (s *Service) JoinStore(ctx context.Context, input JoinStoreInput, c *gin.Context) (*CustomerProfile, error) {
 	email := strings.TrimSpace(strings.ToLower(input.Email))
 	if email == "" {
-		return nil, fmt.Errorf("customer: email is required for profile auto-creation")
+		return nil, fmt.Errorf("customer: email is required to join a store")
+	}
+
+	// Refuse before writing anything: a merchant who blocked this
+	// customer must not have that undone by the customer re-joining.
+	existing, err := s.repo.GetProfileByEmail(ctx, input.StoreID, email)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return nil, fmt.Errorf("customer: join store: %w", err)
+	}
+	if existing != nil && existing.Status == StatusBlocked {
+		return nil, ErrBlocked
 	}
 
 	profile := &CustomerProfile{
@@ -77,10 +119,10 @@ func (s *Service) EnsureProfile(ctx context.Context, input EnsureProfileInput, c
 
 	result, err := s.repo.UpsertProfile(ctx, profile)
 	if err != nil {
-		return nil, fmt.Errorf("customer: ensure profile: %w", err)
+		return nil, fmt.Errorf("customer: join store: %w", err)
 	}
 
-	s.logger.Info("customer profile ensured",
+	s.logger.Info("customer joined store",
 		"store_id", input.StoreID,
 		"email", email,
 		"profile_id", result.ID,

--- a/services/marketplace-api/internal/customer/service_join_test.go
+++ b/services/marketplace-api/internal/customer/service_join_test.go
@@ -1,0 +1,102 @@
+package customer
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// fakeRepo embeds Repository so only the methods a test actually reaches
+// need implementing; anything else panics loudly rather than silently
+// returning a zero value.
+type fakeRepo struct {
+	Repository
+	existing  *CustomerProfile
+	lookupErr error
+	upserted  *CustomerProfile
+}
+
+func (f *fakeRepo) GetProfileByEmail(_ context.Context, _ uuid.UUID, _ string) (*CustomerProfile, error) {
+	if f.lookupErr != nil {
+		return nil, f.lookupErr
+	}
+	if f.existing == nil {
+		return nil, ErrNotFound
+	}
+	return f.existing, nil
+}
+
+func (f *fakeRepo) UpsertProfile(_ context.Context, p *CustomerProfile) (*CustomerProfile, error) {
+	f.upserted = p
+	return p, nil
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestJoinStoreCreatesMembership(t *testing.T) {
+	repo := &fakeRepo{}
+	svc := NewService(nil, repo, testLogger())
+
+	got, err := svc.JoinStore(context.Background(), JoinStoreInput{
+		Email: "  Shopper@Example.COM ",
+	}, nil)
+	if err != nil {
+		t.Fatalf("JoinStore: %v", err)
+	}
+	if repo.upserted == nil {
+		t.Fatal("expected an upsert — JoinStore is the path that creates a membership")
+	}
+	if got.Email != "shopper@example.com" {
+		t.Fatalf("email not normalised: %q", got.Email)
+	}
+	if got.Status != StatusActive {
+		t.Fatalf("status: %q", got.Status)
+	}
+}
+
+func TestJoinStoreRefusesBlockedMembershipWithoutWriting(t *testing.T) {
+	reason := "chargeback fraud"
+	repo := &fakeRepo{existing: &CustomerProfile{
+		Email:       "blocked@example.com",
+		Status:      StatusBlocked,
+		BlockReason: &reason,
+	}}
+	svc := NewService(nil, repo, testLogger())
+
+	_, err := svc.JoinStore(context.Background(), JoinStoreInput{
+		Email: "blocked@example.com",
+	}, nil)
+	if !errors.Is(err, ErrBlocked) {
+		t.Fatalf("want ErrBlocked, got %v", err)
+	}
+	// The point of the check: a blocked customer must not be able to
+	// reset their own state by re-joining.
+	if repo.upserted != nil {
+		t.Fatal("blocked membership was written to — joining must not resurrect a blocked customer")
+	}
+}
+
+func TestLookupProfileNeverWrites(t *testing.T) {
+	repo := &fakeRepo{existing: &CustomerProfile{Email: "member@example.com"}}
+	svc := NewService(nil, repo, testLogger())
+
+	if _, err := svc.LookupProfile(context.Background(), uuid.Nil, "member@example.com"); err != nil {
+		t.Fatalf("LookupProfile: %v", err)
+	}
+	if repo.upserted != nil {
+		t.Fatal("LookupProfile wrote a row — the session path must be read-only")
+	}
+}
+
+func TestLookupProfileEmptyEmailIsNotFound(t *testing.T) {
+	svc := NewService(nil, &fakeRepo{}, testLogger())
+	if _, err := svc.LookupProfile(context.Background(), uuid.Nil, "   "); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+}

--- a/services/marketplace-api/internal/handlers/storefront/customer_account.go
+++ b/services/marketplace-api/internal/handlers/storefront/customer_account.go
@@ -20,7 +20,7 @@ import (
 type CustomerAccountHandler struct {
 	db          *gorm.DB
 	repo        customer.Repository
-	customerSvc *customer.Service
+	customerSvc CustomerProfileService
 	logger      *slog.Logger
 }
 
@@ -28,7 +28,7 @@ type CustomerAccountHandler struct {
 func NewCustomerAccountHandler(
 	db *gorm.DB,
 	repo customer.Repository,
-	customerSvc *customer.Service,
+	customerSvc CustomerProfileService,
 	logger *slog.Logger,
 ) *CustomerAccountHandler {
 	return &CustomerAccountHandler{

--- a/services/marketplace-api/internal/handlers/storefront/customer_join.go
+++ b/services/marketplace-api/internal/handlers/storefront/customer_join.go
@@ -1,0 +1,151 @@
+// Package storefront — customer_join.go: the explicit store join.
+//
+// A Mark8ly customer has ONE platform login and a distinct membership per
+// store. The membership record is the customer_profiles row keyed on
+// (store_id, email). This file holds the only storefront path that
+// creates one, and it runs solely when the customer asked for it.
+//
+// Everything else — the session middleware, browsing, an authenticated
+// API call, checkout — is read-only with respect to membership. Before
+// this existed, the session middleware upserted the row on ANY
+// authenticated request, so signing in at store2 with a store1 password
+// silently made you a customer of store2. See
+// docs/superpowers/specs/2026-09-05-customer-store-membership-design.md.
+package storefront
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/customer"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+)
+
+// joinRequest carries the optional display name the customer supplied on
+// the join screen. The identity (email + uid) is NEVER taken from the
+// body — it comes from the verified session/bearer credential on the
+// context, so a caller cannot join a store on someone else's behalf.
+type joinRequest struct {
+	FirstName *string `json:"first_name" binding:"omitempty,max=200"`
+	LastName  *string `json:"last_name" binding:"omitempty,max=200"`
+}
+
+// Membership handles GET /storefront/stores/:storeSlug/account/membership.
+//
+// Reports whether the verified identity on this request has joined this
+// store. The storefront calls it with a freshly minted (but not yet
+// issued) session cookie so it can decide whether to hand that cookie to
+// the browser at all — a session must never be minted at a store the
+// customer has not joined.
+func (h *CustomerAccountHandler) Membership(c *gin.Context) {
+	email := c.GetString(CustomerIdentityEmailKey)
+	profile, ok := c.Get(CustomerProfileKey)
+	if !ok {
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{
+			"member":  false,
+			"blocked": false,
+			"email":   email,
+		}})
+		return
+	}
+	p, _ := profile.(*customer.CustomerProfile)
+	if p == nil {
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{
+			"member":  false,
+			"blocked": false,
+			"email":   email,
+		}})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{
+		"member":  true,
+		"blocked": p.Status == customer.StatusBlocked,
+		"email":   p.Email,
+	}})
+}
+
+// Join handles POST /storefront/stores/:storeSlug/account/join.
+//
+// Creates the customer_profiles row for the verified identity and this
+// store, and nothing else: no new identity, no new credential, no change
+// to any store the customer already belongs to. Idempotent — a customer
+// who is already a member gets 200 and their existing profile back.
+func (h *CustomerAccountHandler) Join(c *gin.Context) {
+	email := c.GetString(CustomerIdentityEmailKey)
+	uid := c.GetString(CustomerIdentityUIDKey)
+	if email == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error":   "unauthorized",
+			"message": "Authentication required. Please sign in.",
+		})
+		return
+	}
+
+	store, storeID, tenantID, ok := joinStoreIDs(c)
+	if !ok {
+		return
+	}
+
+	var req joinRequest
+	// Body is optional — a join with no name is perfectly valid.
+	_ = c.ShouldBindJSON(&req)
+
+	profile, err := h.customerSvc.JoinStore(c.Request.Context(), customer.JoinStoreInput{
+		StoreID:   storeID,
+		TenantID:  tenantID,
+		GipUID:    uid,
+		Email:     email,
+		FirstName: derefString(req.FirstName),
+		LastName:  derefString(req.LastName),
+	}, c)
+	if err != nil {
+		if errors.Is(err, customer.ErrBlocked) {
+			// The merchant blocked this customer. Joining must not
+			// resurrect them, and the message must not read as a
+			// retryable glitch.
+			c.JSON(http.StatusForbidden, gin.H{
+				"error":   "account_blocked",
+				"message": "This store has suspended your account, so it can't be reopened here. Please contact the store if you think that's a mistake.",
+			})
+			return
+		}
+		h.logger.Error("failed to join store",
+			"error", err,
+			"email_masked", maskEmailForLog(email),
+			"store_id", store.ID,
+		)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "internal",
+			"message": "We couldn't set up your account with this store. Please try again in a moment.",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": mapProfileToResponse(profile)})
+}
+
+// joinStoreIDs pulls the resolved store off the context and parses its
+// ids. Responds 404 and reports false when anything is missing — the same
+// no-existence-leak shape the rest of the storefront uses.
+func joinStoreIDs(c *gin.Context) (*stores.Store, uuid.UUID, uuid.UUID, bool) {
+	storeVal, _ := c.Get("store")
+	store, _ := storeVal.(*stores.Store)
+	if store == nil {
+		respondNotFound(c)
+		return nil, uuid.Nil, uuid.Nil, false
+	}
+	storeID, err := uuid.Parse(store.ID)
+	if err != nil {
+		respondNotFound(c)
+		return nil, uuid.Nil, uuid.Nil, false
+	}
+	tenantID, err := uuid.Parse(store.TenantID)
+	if err != nil {
+		respondNotFound(c)
+		return nil, uuid.Nil, uuid.Nil, false
+	}
+	return store, storeID, tenantID, true
+}

--- a/services/marketplace-api/internal/handlers/storefront/customer_membership_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/customer_membership_test.go
@@ -1,0 +1,379 @@
+package storefront
+
+// Adversarial coverage for the store-membership gate.
+//
+// The bug this guards against is that membership creation used to be a
+// SIDE EFFECT nobody had to ask for: OptionalCustomerAuth called the
+// creating upsert on every authenticated request, so a customer of store1
+// who so much as loaded a page at store2 became a customer of store2.
+//
+// So the tests below do not assert "no row afterwards" — a fixture can
+// pin a shape the real path never produces. They make the create path
+// itself a TRIPWIRE: the fake service fails the test from INSIDE
+// JoinStore. Delete the gate, wire the session path back to the creating
+// call, and these tests fail on the call, not on an inference about it.
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/customer"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+)
+
+const testSessionSecret = "membership-test-cookie-secret"
+
+var (
+	testStoreID  = uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	testTenantID = uuid.MustParse("22222222-2222-2222-2222-222222222222")
+)
+
+func membershipTestStore() *stores.Store {
+	return &stores.Store{
+		ID:       testStoreID.String(),
+		TenantID: testTenantID.String(),
+		Slug:     "store-two",
+		Status:   stores.StatusActive,
+	}
+}
+
+// tripwireService is a CustomerProfileService whose write path fails the
+// test. `member` is the membership LookupProfile reports, or nil for
+// "this identity has not joined this store".
+type tripwireService struct {
+	t         *testing.T
+	member    *customer.CustomerProfile
+	allowJoin bool
+	joinErr   error
+	joins     int
+}
+
+func (f *tripwireService) LookupProfile(_ context.Context, _ uuid.UUID, _ string) (*customer.CustomerProfile, error) {
+	if f.member == nil {
+		return nil, customer.ErrNotFound
+	}
+	return f.member, nil
+}
+
+func (f *tripwireService) JoinStore(_ context.Context, in customer.JoinStoreInput, _ *gin.Context) (*customer.CustomerProfile, error) {
+	f.joins++
+	if !f.allowJoin {
+		f.t.Errorf(
+			"membership was created on a path that must never create one: JoinStore called for %q at store %s",
+			in.Email, in.StoreID,
+		)
+		return nil, customer.ErrNotFound
+	}
+	if f.joinErr != nil {
+		return nil, f.joinErr
+	}
+	return &customer.CustomerProfile{
+		ID:      uuid.New(),
+		StoreID: in.StoreID,
+		Email:   in.Email,
+		Status:  customer.StatusActive,
+	}, nil
+}
+
+// signedCookie builds a valid mp_customer_session value scoped to store.
+func signedCookie(t *testing.T, store *stores.Store, email string) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"uid":        "zitadel-uid-1",
+		"email":      email,
+		"store_slug": store.Slug,
+		"store_id":   store.ID,
+		"tenant_id":  store.TenantID,
+		"exp":        time.Now().Add(time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	b64 := base64.StdEncoding.EncodeToString(payload)
+	mac := hmac.New(sha256.New, []byte(testSessionSecret))
+	mac.Write([]byte(b64))
+	return b64 + "." + hex.EncodeToString(mac.Sum(nil))
+}
+
+func membershipTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// sessionRouter wires the real session chain: store context, then the
+// read-only customer auth middleware.
+func sessionRouter(t *testing.T, svc CustomerProfileService, tail ...gin.HandlerFunc) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	store := membershipTestStore()
+	r.Use(func(c *gin.Context) { c.Set("store", store); c.Next() })
+	r.Use(OptionalCustomerAuth(testSessionSecret, svc, membershipTestLogger()))
+	handlers := append(tail, func(c *gin.Context) {
+		_, hasProfile := c.Get(CustomerProfileKey)
+		c.JSON(http.StatusOK, gin.H{
+			"member":   hasProfile,
+			"identity": c.GetString(CustomerIdentityEmailKey),
+		})
+	})
+	r.GET("/s/:storeSlug/anything", handlers...)
+	return r
+}
+
+func doAuthedGet(t *testing.T, r *gin.Engine, cookie string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/s/store-two/anything", nil)
+	req.AddCookie(&http.Cookie{Name: "mp_customer_session", Value: cookie})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// TestSessionPathNeverCreatesMembership is THE regression test for
+// docs/superpowers/specs/2026-09-05-customer-store-membership-design.md.
+// An authenticated customer with no membership at this store makes an
+// ordinary authenticated request; the fake fails the test from inside
+// JoinStore if the request creates one.
+func TestSessionPathNeverCreatesMembership(t *testing.T) {
+	svc := &tripwireService{t: t} // member == nil: joined store1, not store2
+	r := sessionRouter(t, svc)
+
+	w := doAuthedGet(t, r, signedCookie(t, membershipTestStore(), "shopper@example.com"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code: %d body: %s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Member   bool   `json:"member"`
+		Identity string `json:"identity"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Member {
+		t.Fatal("a non-member resolved to a member — the session path minted a membership")
+	}
+	if body.Identity != "shopper@example.com" {
+		t.Fatalf("identity should still be carried for the join offer, got %q", body.Identity)
+	}
+	if svc.joins != 0 {
+		t.Fatalf("JoinStore called %d times from the session path", svc.joins)
+	}
+}
+
+func TestSessionPathResolvesAnExistingMembership(t *testing.T) {
+	svc := &tripwireService{t: t, member: &customer.CustomerProfile{
+		ID:      uuid.New(),
+		StoreID: testStoreID,
+		Email:   "member@example.com",
+		Status:  customer.StatusActive,
+	}}
+	r := sessionRouter(t, svc)
+
+	w := doAuthedGet(t, r, signedCookie(t, membershipTestStore(), "member@example.com"))
+
+	var body struct {
+		Member bool `json:"member"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if !body.Member {
+		t.Fatal("an existing member was not resolved — the gate must not lock out real customers")
+	}
+	if svc.joins != 0 {
+		t.Fatal("an existing member must be looked up, not re-created")
+	}
+}
+
+// The misleading-error failure mode: a customer with a perfectly good
+// password must never be told their credentials are wrong.
+func TestRequireCustomerAuthOffersTheJoinInsteadOfBlamingThePassword(t *testing.T) {
+	svc := &tripwireService{t: t}
+	r := sessionRouter(t, svc, RequireCustomerAuth())
+
+	w := doAuthedGet(t, r, signedCookie(t, membershipTestStore(), "shopper@example.com"))
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403 for an authenticated non-member, got %d: %s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Error        string `json:"error"`
+		Message      string `json:"message"`
+		JoinRequired bool   `json:"join_required"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error != "membership_required" || !body.JoinRequired {
+		t.Fatalf("response does not identify a joinable state: %s", w.Body.String())
+	}
+	for _, forbidden := range []string{"password", "incorrect", "Sign in again"} {
+		if containsFold(body.Message, forbidden) {
+			t.Fatalf("copy implies a credential problem (%q): %q", forbidden, body.Message)
+		}
+	}
+	if !containsFold(body.Message, "join") {
+		t.Fatalf("copy is not actionable — it never offers the join: %q", body.Message)
+	}
+}
+
+func TestRequireCustomerAuthStill401sAGuest(t *testing.T) {
+	svc := &tripwireService{t: t}
+	r := sessionRouter(t, svc, RequireCustomerAuth())
+
+	req := httptest.NewRequest(http.MethodGet, "/s/store-two/anything", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401 for a request with no credential, got %d", w.Code)
+	}
+}
+
+func TestRequireCustomerIdentityAdmitsAnAuthenticatedNonMember(t *testing.T) {
+	svc := &tripwireService{t: t}
+	r := sessionRouter(t, svc, RequireCustomerIdentity())
+
+	w := doAuthedGet(t, r, signedCookie(t, membershipTestStore(), "shopper@example.com"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("the join guard rejected the exact customer it exists for: %d %s", w.Code, w.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/s/store-two/anything", nil)
+	guest := httptest.NewRecorder()
+	r.ServeHTTP(guest, req)
+	if guest.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401 for an unauthenticated join attempt, got %d", guest.Code)
+	}
+}
+
+// joinRouter wires the real join endpoint behind the real guards.
+func joinRouter(t *testing.T, svc *tripwireService) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	store := membershipTestStore()
+	h := NewCustomerAccountHandler(nil, nil, svc, membershipTestLogger())
+	r.Use(func(c *gin.Context) { c.Set("store", store); c.Next() })
+	r.Use(OptionalCustomerAuth(testSessionSecret, svc, membershipTestLogger()))
+	r.POST("/s/:storeSlug/account/join", RequireCustomerIdentity(), h.Join)
+	return r
+}
+
+func postJoin(t *testing.T, r *gin.Engine, cookie string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/s/store-two/account/join", nil)
+	if cookie != "" {
+		req.AddCookie(&http.Cookie{Name: "mp_customer_session", Value: cookie})
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestJoinCreatesTheMembershipForTheVerifiedIdentity(t *testing.T) {
+	svc := &tripwireService{t: t, allowJoin: true}
+	r := joinRouter(t, svc)
+
+	w := postJoin(t, r, signedCookie(t, membershipTestStore(), "shopper@example.com"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("code: %d body: %s", w.Code, w.Body.String())
+	}
+	if svc.joins != 1 {
+		t.Fatalf("expected exactly one join, got %d", svc.joins)
+	}
+}
+
+func TestJoinRejectsAnUnauthenticatedCaller(t *testing.T) {
+	svc := &tripwireService{t: t} // JoinStore trips the test if reached
+	r := joinRouter(t, svc)
+
+	w := postJoin(t, r, "")
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestJoinSurfacesABlockedMembershipAsBlocked(t *testing.T) {
+	svc := &tripwireService{t: t, allowJoin: true, joinErr: customer.ErrBlocked}
+	r := joinRouter(t, svc)
+
+	w := postJoin(t, r, signedCookie(t, membershipTestStore(), "blocked@example.com"))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403 for a blocked customer, got %d: %s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if body.Error != "account_blocked" {
+		t.Fatalf("want account_blocked, got %s", w.Body.String())
+	}
+	if containsFold(body.Message, "try again") {
+		t.Fatalf("blocked copy must not read as retryable: %q", body.Message)
+	}
+}
+
+// TestMobileSessionPathNeverCreatesMembership is the same tripwire for
+// the bearer path. A gate applied only to the web storefront would leave
+// the mobile apps under apps/ minting memberships silently.
+func TestMobileSessionPathNeverCreatesMembership(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &tripwireService{t: t}
+	store := membershipTestStore()
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("store", store)
+		// What a verified Bearer token leaves behind.
+		c.Set(CustomerGipUIDKey, "gip-uid-1")
+		c.Set(CustomerEmailKey, "shopper@example.com")
+		c.Next()
+	})
+	r.GET("/m/:storeSlug/anything",
+		mobileCustomerProfileMW(svc, membershipTestLogger()),
+		func(c *gin.Context) {
+			_, hasProfile := c.Get(CustomerProfileKey)
+			c.JSON(http.StatusOK, gin.H{
+				"member":   hasProfile,
+				"identity": c.GetString(CustomerIdentityEmailKey),
+			})
+		})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/m/store-two/anything", nil))
+
+	var body struct {
+		Member   bool   `json:"member"`
+		Identity string `json:"identity"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Member {
+		t.Fatal("the mobile bearer path resolved a non-member as a member")
+	}
+	if body.Identity != "shopper@example.com" {
+		t.Fatalf("mobile identity not carried through for the join: %q", body.Identity)
+	}
+	if svc.joins != 0 {
+		t.Fatalf("JoinStore called %d times from the mobile session path", svc.joins)
+	}
+}
+
+func containsFold(haystack, needle string) bool {
+	return strings.Contains(strings.ToLower(haystack), strings.ToLower(needle))
+}

--- a/services/marketplace-api/internal/handlers/storefront/middleware.go
+++ b/services/marketplace-api/internal/handlers/storefront/middleware.go
@@ -87,12 +87,44 @@ func respondNotFound(c *gin.Context) {
 }
 
 // customerContextKey values set by OptionalCustomerAuth.
+//
+// Two tiers, and the difference is the whole point of the membership
+// model. The IDENTITY keys mean "this request carries a credential this
+// storefront verified" — a Mark8ly login is platform-wide, so that says
+// nothing about whether the customer belongs to THIS store. The PROFILE
+// keys mean "this identity has joined this store", and they are set only
+// when a customer_profiles row already exists. No middleware may create
+// that row; see CustomerProfileService.
 const (
 	CustomerProfileIDKey = "customer_profile_id"
 	CustomerEmailKey     = "customer_email"
 	CustomerGipUIDKey    = "customer_gip_uid"
 	CustomerProfileKey   = "customer_profile"
+
+	// CustomerIdentityEmailKey / CustomerIdentityUIDKey carry the
+	// verified identity even when it has no membership here, so
+	// RequireCustomerAuth can tell "not signed in" apart from "signed in
+	// but not a member of this store" and the join endpoint has an
+	// authenticated subject to create the membership for.
+	CustomerIdentityEmailKey = "customer_identity_email"
+	CustomerIdentityUIDKey   = "customer_identity_uid"
 )
+
+// CustomerProfileService is the customer-profile surface the storefront
+// handlers depend on. It models the one *customer.Service main.go builds,
+// so both the read-only session middleware and the write-side join
+// handler take the same value.
+//
+// LookupProfile is read-only. JoinStore CREATES a membership.
+// OptionalCustomerAuth and mobileCustomerProfileMW must never call
+// JoinStore: a customer must not acquire a membership of a store by
+// browsing it, which is exactly the bug this interface's split exists to
+// prevent (docs/superpowers/specs/2026-09-05-customer-store-membership-design.md).
+// TestSessionPathNeverCreatesMembership fails loudly if that is undone.
+type CustomerProfileService interface {
+	LookupProfile(ctx context.Context, storeID uuid.UUID, email string) (*customer.CustomerProfile, error)
+	JoinStore(ctx context.Context, in customer.JoinStoreInput, c *gin.Context) (*customer.CustomerProfile, error)
+}
 
 // sessionClaims represents the decoded auth-bff session cookie payload.
 type sessionClaims struct {
@@ -108,12 +140,18 @@ type sessionClaims struct {
 }
 
 // OptionalCustomerAuth reads the auth-bff session cookie, validates its
-// HMAC signature, and if valid, upserts a customer_profiles row via
-// Service.EnsureProfile and sets customer context on gin.
+// HMAC signature and store scope, and sets customer context on gin.
+//
+// It is READ-ONLY with respect to membership. A valid cookie sets the
+// identity keys; the profile keys follow only if this identity has
+// already joined this store. An authenticated customer with no
+// membership here resolves to "not a member" — never to a freshly minted
+// row. Creation lives behind the explicit join
+// (CustomerAccountHandler.Join).
 //
 // If the cookie is missing, invalid, or expired, the request continues
 // as a guest (no customer context). This middleware never aborts.
-func OptionalCustomerAuth(secret string, customerSvc *customer.Service, logger *slog.Logger) gin.HandlerFunc {
+func OptionalCustomerAuth(secret string, customerSvc CustomerProfileService, logger *slog.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if secret == "" {
 			c.Next()
@@ -169,26 +207,24 @@ func OptionalCustomerAuth(secret string, customerSvc *customer.Service, logger *
 			c.Next()
 			return
 		}
-		tenantID, err := uuid.Parse(store.TenantID)
-		if err != nil {
-			c.Next()
-			return
-		}
 
-		profile, err := customerSvc.EnsureProfile(c.Request.Context(), customer.EnsureProfileInput{
-			StoreID:   storeID,
-			TenantID:  tenantID,
-			GipUID:    claims.UIDOrGipUID(),
-			Email:     claims.Email,
-			FirstName: claims.FirstName,
-			LastName:  claims.LastName,
-		}, c)
+		// The credential is verified and scoped to this store, so the
+		// identity is trustworthy from here on — independently of whether
+		// it has a membership.
+		c.Set(CustomerIdentityEmailKey, claims.Email)
+		c.Set(CustomerIdentityUIDKey, claims.UIDOrGipUID())
+
+		profile, err := customerSvc.LookupProfile(c.Request.Context(), storeID, claims.Email)
 		if err != nil {
-			logger.Error("failed to ensure customer profile",
-				"error", err,
-				"email", claims.Email,
-				"store_id", store.ID,
-			)
+			if !errors.Is(err, customer.ErrNotFound) {
+				logger.Error("failed to look up customer membership",
+					"error", err,
+					"store_id", store.ID,
+				)
+			}
+			// Not a member of this store (or the lookup failed): continue
+			// with identity only. RequireCustomerAuth turns that into an
+			// actionable 403 on the routes that need a membership.
 			c.Next()
 			return
 		}
@@ -198,6 +234,23 @@ func OptionalCustomerAuth(secret string, customerSvc *customer.Service, logger *
 		c.Set(CustomerGipUIDKey, claims.GipUID)
 		c.Set(CustomerProfileKey, profile)
 
+		c.Next()
+	}
+}
+
+// RequireCustomerIdentity aborts with 401 unless the request carries a
+// verified customer identity. It deliberately does NOT require a
+// membership — it is the guard for the join endpoint, which exists
+// precisely for authenticated customers who have not joined yet.
+func RequireCustomerIdentity() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.GetString(CustomerIdentityEmailKey) == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, map[string]any{
+				"error":   "unauthorized",
+				"message": "Authentication required. Please sign in.",
+			})
+			return
+		}
 		c.Next()
 	}
 }
@@ -283,6 +336,18 @@ func RequireCustomerAuth() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		profileID, exists := c.Get(CustomerProfileIDKey)
 		if !exists || profileID == "" {
+			// Signed in, but not a customer of THIS store. Say so
+			// truthfully and offer the fix: a generic 401 here would tell
+			// a customer with a perfectly good password to "sign in"
+			// again, which can never succeed.
+			if c.GetString(CustomerIdentityEmailKey) != "" {
+				c.AbortWithStatusJSON(http.StatusForbidden, map[string]any{
+					"error":         "membership_required",
+					"message":       "Your Mark8ly login works here, but you don't have an account with this store yet. Join the store to continue.",
+					"join_required": true,
+				})
+				return
+			}
 			c.AbortWithStatusJSON(http.StatusUnauthorized, map[string]any{
 				"error":   "unauthorized",
 				"message": "Authentication required. Please sign in.",

--- a/services/marketplace-api/internal/handlers/storefront/mobile_routes.go
+++ b/services/marketplace-api/internal/handlers/storefront/mobile_routes.go
@@ -4,6 +4,7 @@
 package storefront
 
 import (
+	"errors"
 	"log/slog"
 
 	"github.com/gin-gonic/gin"
@@ -125,6 +126,20 @@ func RegisterMobileStorefront(router *gin.RouterGroup, deps MobileDeps) {
 		customerMW := mobileCustomerProfileMW(deps.CustomerService, deps.Logger)
 		requireCustomer := RequireCustomerAuth()
 
+		// Identity-only group: authenticated, but membership NOT required.
+		// /account/register is this app's explicit join, so it must be
+		// reachable by exactly the customer RequireCustomerAuth turns
+		// away — mounting it behind requireCustomer would make joining a
+		// store impossible for anyone who hasn't already joined it.
+		identity := group.Group("", requireAuth, customerMW, RequireCustomerIdentity())
+		if deps.CustomerAccountHandler != nil {
+			identity.POST("/account/register", deps.CustomerAccountHandler.Register)
+			// Membership probe — lets the app tell "you have a Mark8ly
+			// login but no account with this store" apart from "your
+			// password is wrong" instead of guessing from a 403 body.
+			identity.GET("/account/membership", deps.CustomerAccountHandler.Membership)
+		}
+
 		authed := group.Group("", requireAuth, customerMW, requireCustomer)
 		{
 			// Checkout — authenticated.
@@ -144,7 +159,6 @@ func RegisterMobileStorefront(router *gin.RouterGroup, deps MobileDeps) {
 
 			// Customer account.
 			if deps.CustomerAccountHandler != nil {
-				authed.POST("/account/register", deps.CustomerAccountHandler.Register)
 				// check-email is POST (not GET) so the email PII doesn't land
 				// in query-string access logs. See mobile_stubs.go for body shape.
 				authed.POST("/account/check-email", deps.CustomerAccountHandler.CheckEmail)
@@ -219,11 +233,19 @@ func RegisterMobileStorefront(router *gin.RouterGroup, deps MobileDeps) {
 	}
 }
 
-// mobileCustomerProfileMW resolves the GIP UID from context (set by
-// GIPBearerAuth) into a customer profile via EnsureProfile. This bridges
-// the Bearer token auth to the same customer context keys used by the
-// cookie-based web storefront.
-func mobileCustomerProfileMW(customerSvc *customer.Service, logger *slog.Logger) gin.HandlerFunc {
+// mobileCustomerProfileMW resolves the verified Bearer identity (set by
+// MobileCustomerAuth / GIPBearerAuth) into this store's membership. It
+// bridges Bearer auth to the same customer context keys the cookie-based
+// web storefront uses — INCLUDING the read-only membership rule.
+//
+// It looks the membership up; it never creates one. A bearer token is a
+// platform-wide Mark8ly login, so a customer of store1 presenting it at
+// store2 is authenticated but not a member there, and gets identity keys
+// only. The mobile app's explicit join is POST /account/register
+// (CustomerAccountHandler.Register). Gating only the web storefront would
+// have left this path minting memberships silently — see
+// docs/superpowers/specs/2026-09-05-customer-store-membership-design.md.
+func mobileCustomerProfileMW(customerSvc CustomerProfileService, logger *slog.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		gipUID := c.GetString(CustomerGipUIDKey)
 		email := c.GetString(CustomerEmailKey)
@@ -249,23 +271,16 @@ func mobileCustomerProfileMW(customerSvc *customer.Service, logger *slog.Logger)
 			c.Next()
 			return
 		}
-		tenantID, err := uuid.Parse(store.TenantID)
-		if err != nil {
-			c.Next()
-			return
-		}
 
-		profile, err := customerSvc.EnsureProfile(c.Request.Context(), customer.EnsureProfileInput{
-			StoreID:  storeID,
-			TenantID: tenantID,
-			GipUID:   gipUID,
-			Email:    email,
-		}, c)
+		c.Set(CustomerIdentityEmailKey, email)
+		c.Set(CustomerIdentityUIDKey, gipUID)
+
+		profile, err := customerSvc.LookupProfile(c.Request.Context(), storeID, email)
 		if err != nil {
-			if logger != nil {
-				logger.Error("mobile: failed to ensure customer profile",
+			if logger != nil && !errors.Is(err, customer.ErrNotFound) {
+				logger.Error("mobile: failed to look up customer membership",
 					"error", err,
-					"email", email,
+					"email_masked", maskEmailForLog(email),
 					"store_id", store.ID,
 				)
 			}

--- a/services/marketplace-api/internal/handlers/storefront/mobile_stubs.go
+++ b/services/marketplace-api/internal/handlers/storefront/mobile_stubs.go
@@ -4,6 +4,7 @@
 package storefront
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -154,11 +155,15 @@ type registerRequest struct {
 }
 
 // Register handles POST /mobile/storefront/stores/:storeSlug/account/register.
-// Reads gip_uid + email from Bearer context, optional name from body, calls
-// EnsureProfile, returns profile.
+//
+// This is the mobile app's EXPLICIT JOIN: the one mobile path that
+// creates a customer_profiles row, and it runs only because the customer
+// asked for it. The identity comes from the verified Bearer credential on
+// the context, never from the body. See customer_join.go's header for why
+// nothing else on this surface may create a membership.
 func (h *CustomerAccountHandler) Register(c *gin.Context) {
-	gipUID := c.GetString(CustomerGipUIDKey)
-	email := c.GetString(CustomerEmailKey)
+	gipUID := c.GetString(CustomerIdentityUIDKey)
+	email := c.GetString(CustomerIdentityEmailKey)
 	if gipUID == "" || email == "" {
 		c.JSON(http.StatusUnauthorized, gin.H{
 			"error":   "unauthorized",
@@ -199,7 +204,7 @@ func (h *CustomerAccountHandler) Register(c *gin.Context) {
 		lastName = strings.TrimSpace(*req.LastName)
 	}
 
-	profile, err := h.customerSvc.EnsureProfile(c.Request.Context(), customer.EnsureProfileInput{
+	profile, err := h.customerSvc.JoinStore(c.Request.Context(), customer.JoinStoreInput{
 		StoreID:   storeID,
 		TenantID:  tenantID,
 		GipUID:    gipUID,
@@ -208,6 +213,15 @@ func (h *CustomerAccountHandler) Register(c *gin.Context) {
 		LastName:  lastName,
 	}, c)
 	if err != nil {
+		if errors.Is(err, customer.ErrBlocked) {
+			// Blocked by the merchant. Re-registering must not reopen the
+			// account, and the copy must not read as a retryable glitch.
+			c.JSON(http.StatusForbidden, gin.H{
+				"error":   "account_blocked",
+				"message": "This store has suspended your account, so it can't be reopened here. Please contact the store if you think that's a mistake.",
+			})
+			return
+		}
 		h.logger.Error("failed to register customer profile",
 			"error", err,
 			"email_masked", maskEmailForLog(email),
@@ -215,7 +229,7 @@ func (h *CustomerAccountHandler) Register(c *gin.Context) {
 		)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error":   "internal",
-			"message": "Failed to register profile",
+			"message": "We couldn't set up your account with this store. Please try again in a moment.",
 		})
 		return
 	}

--- a/services/marketplace-api/internal/handlers/storefront/routes.go
+++ b/services/marketplace-api/internal/handlers/storefront/routes.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/mark8ly/marketplace-api/internal/customer"
 	"github.com/mark8ly/marketplace-api/internal/customerportal"
 	"github.com/mark8ly/marketplace-api/internal/ratelimit"
 	"github.com/mark8ly/marketplace-api/internal/stores"
@@ -33,7 +32,7 @@ type Deps struct {
 	CountryHandler         CountryLister // optional — set when country handler is wired
 	// C1 customer auth.
 	CustomerAccountHandler *CustomerAccountHandler
-	CustomerService        *customer.Service
+	CustomerService        CustomerProfileService
 	CustomerSessionSecret  string
 	// Customer notification bell.
 	CustomerNotificationsHandler *CustomerNotificationsHandler
@@ -237,6 +236,18 @@ func RegisterStorefront(router *gin.RouterGroup, deps Deps) {
 					deps.LoyaltyHandler.Redeem)
 			}
 		}
+	}
+
+	// Membership routes — authenticated identity required, membership
+	// NOT required. These are the two endpoints that exist precisely for
+	// a customer RequireCustomerAuth turns away: the join itself, and the
+	// probe the storefront runs BEFORE it hands a session cookie to the
+	// browser. Mounting either behind RequireCustomerAuth would make
+	// joining a store impossible for anyone who has not already joined.
+	if deps.CustomerAccountHandler != nil {
+		membership := group.Group("/account", RequireCustomerIdentity())
+		membership.GET("/membership", deps.CustomerAccountHandler.Membership)
+		membership.POST("/join", deps.CustomerAccountHandler.Join)
 	}
 
 	// C1 — Customer account routes (auth required).


### PR DESCRIPTION
Implements the decision recorded in #684's spec (`docs/superpowers/specs/2026-09-05-customer-store-membership-design.md`).

A customer who signed up at store1 could sign in at store2 and silently acquire an account there. **One platform identity, explicit per-store membership** — `customer_profiles` already was the membership record; the change is that a row is created deliberately, never incidentally.

## The crux

`EnsureProfile` is gone, split into `LookupProfile` (read-only) and `JoinStore` (creates). `UpsertProfile` is now reachable from `JoinStore` alone.

This mattered because `EnsureProfile` ran from storefront middleware on **any** authenticated request — gating only sign-in would have changed nothing, since a customer would have browsed into a membership. The storefront's own `ensureCustomerProfile()` poke (a bare `GET /account` so the middleware would upsert) is deleted; that call *was* the client half of the bug.

An authenticated non-member now gets **403 `membership_required`**, not a 401 — with a test asserting the copy contains no "password" / "incorrect" / "sign in again". Getting that wrong is the misleading-error failure this repo keeps hitting.

## A design element the spec didn't anticipate

Refusing to mint a session at an unjoined store removes the very credential the join needs. Hence a short-lived HttpOnly `mp_join_grant` cookie (own purpose tag over `SESSION_ENCRYPT_KEY`, bound to the store it was minted at, and a session cookie replayed as a grant is rejected), and the join being a page rather than an inline button.

Sign-in **fails closed**: an unreachable membership API returns `membership_unavailable`, never a silent sign-in.

## Edge cases — decided with evidence, not assumption

- **Guest checkout: no membership, no code change.** Verified in production — all 3 orders have `customer_id IS NULL` and none has a matching profile, so guest checkout already creates none. Minting one would mean writing a row from a self-asserted unverified email, which is the same "membership as a side effect" this removes.
- **Blocked customers: refused, never reset.** `ErrBlocked` before any write, and the `ON CONFLICT` branch touches only `gip_uid`/`updated_at`, so status/block_reason/tags/notes cannot be clobbered even if that check were bypassed.
- **Admin-created customers: do not exist.** The admin routes expose no create, so a merchant cannot manufacture a membership.
- **Existing data: re-verified live** — 5 profiles, 1 store, 5 emails, 0 blocked, no email on more than one store. No migration.

## Correction to the brief

`RegisterMobileStorefront` is **not mounted** — only the support-chat group is. So the mobile bearer path was latent rather than live, and my framing of it as actively creating memberships was wrong. Fixed regardless, since the mobile app calls those routes and someone will wire them. Mobile's `POST /account/register` already was an explicit join and was reused rather than duplicated; it moved to an identity-only group, since post-gate `RequireCustomerAuth` would have 403'd every first-time joiner.

## Verification

`gofmt` clean, `go build ./...`, `go test ./...` green. Storefront: `tsc --noEmit` clean, `vitest` 285 passing, `npm run build` exit 0 with `/join` in the route manifest. gitleaks clean.

The tripwire is `TestSessionPathNeverCreatesMembership` (+ the mobile twin): the fake calls `t.Errorf` **from inside `JoinStore`**, so re-wiring a session path to the creating call fails on the call itself rather than on an assertion afterwards.

## Not addressed, by design

The spec is explicit that this does not give separate credentials: the password stays shared across stores, and register still discloses that an address has a platform login. Both are coherent under a platform-identity model. True credential separation would need an org per store — a different and much larger piece of work.
