### PR TITLE
Trial email honesty and a Pro+App teardown guard

### DIFF
--- a/.planning/quick/260905-tpg-trial-and-proapp-guards/PLAN.md
+++ b/.planning/quick/260905-tpg-trial-and-proapp-guards/PLAN.md
@@ -1,0 +1,101 @@
+# Trial email honesty + Pro+App teardown guard
+
+Three small, independent fixes found while triaging the billing backlog
+(#702, #703). Each one closes a place where the code claims something it
+does not do. None of them requires Stripe, the console, or a working
+subscription — that is why they were selected.
+
+## Background that shaped the scope
+
+#703 was filed claiming merchants are charged after a 90-day trial with no
+warning. That is **false**: `internal/subscription/dunning/trial_reminders.go`
+sends T-15/T-10/T-7/T-3/T-1 reminders, payment-method-aware, and is scheduled
+at `cmd/marketplace-api/main.go:2138` (09:30 UTC daily, deduped by the
+`trial_reminders` table). The issue has been corrected.
+
+What remains is narrower, and one part of the original scope is now a
+deletion rather than an addition.
+
+---
+
+## Task 1 — remove the banner cron's phantom email ladder
+
+`internal/billing/trial/banner_cron.go` carries `bannerTarget.template` with
+values `trial_day_60` / `trial_day_75` / `trial_day_85`. **No such TemplateID
+has ever existed.** On a 90-day trial those land at T-30, T-15 and T-5, so
+wiring them would duplicate `no_pm_t_minus_15` and fire a third mail between
+the existing T-7 and T-3.
+
+The banner cron's real job — advancing `trial_banner_state` for the in-app
+banner — works and is untouched here.
+
+- Delete the `template` field from `bannerTarget` and its three values.
+- Replace the "email deferred / when StoreSubscription gets email+store_name
+  columns" comments with a short note that trial email is owned by
+  `dunning/trial_reminders.go`, pointing at it.
+- Keep the `logger.Info` on banner advance, minus the `template` key.
+
+**Done when:** no reference to a non-existent template remains, the package
+builds, and existing banner-cron tests still pass unchanged. No behaviour
+change — this is the commit that stops the next reader rebuilding a duplicate
+ladder.
+
+## Task 2 — send a trial-expired notice
+
+`internal/billing/trial/expiry_cron.go` transitions a cardless trial to
+`expired` and logs "email deferred". Nothing tells the merchant it happened.
+T-1 warned them it would; nothing confirms it did or says what state their
+store is in now.
+
+- Add `TemplateTrialExpired TemplateID = "trial_expired"` to
+  `internal/email/client.go`, append it to `billingTemplateKeys`
+  (`internal/email/templates.go`), and add subject/HTML/text entries to
+  `templates_content.go`. Use only variables the lint test supplies —
+  `store_name` at minimum.
+- Send it from `expiry_cron.go` on a successful transition, following
+  `dunning/trial_reminders.go`'s pattern: recipient from `row.Email`,
+  store name via `subscription.StoreNameFor`, `email.ValidateRecipient`
+  semantics, skip counter on `ErrUndeliverable`, sent counter on success.
+- The cron must keep working when the email client is nil (mirror how other
+  crons treat an unconfigured client) — do not make email a hard dependency
+  of trial expiry.
+- Dedup: a store must not receive two expiry notices. The transition itself
+  is CAS-guarded (`ErrCASConflict` path), so send only on `err == nil`.
+
+**Done when:** the template lints, a unit test proves the mail is sent once
+on a successful expiry and not at all on a CAS conflict, and expiry still
+succeeds with a nil email client.
+
+## Task 3 — refuse to seed a Pro+App teardown with no app identifiers
+
+`internal/whitelabel/lifecycle/pro_app_cancelled_consumer.go` accepts an
+event and inserts a `white_label_app_state` row. The Advancer then skips
+`pullApps` when `AppleAppID` is empty (`advancer.go:186`) and
+`archiveFirebase` when `FirebaseProjectID` is empty (`:201`).
+
+So an event with blank identifiers walks the state machine to
+`credentials_purged`, pulls nothing, and **reports the teardown complete
+while the app stays live**. Worse than today's honest no-op.
+
+Nothing in the estate currently produces those identifiers (see #702) — so
+this task does not wire the consumer. It makes the hole loud.
+
+- Extend the existing `TenantID`/`StoreID` validation in `Handle` to reject
+  an event carrying none of `AppleAppID`, `GooglePackage`,
+  `FirebaseProjectID`, with a distinct sentinel error.
+- Reject when all three are empty. Do not require all three — a store may
+  legitimately have Apple but no Firebase.
+
+**Done when:** a unit test proves an all-empty event returns the sentinel and
+writes no row, and an event with any one identifier still inserts as before.
+
+---
+
+## Constraints
+
+- TDD: test first, watch it fail, then implement.
+- One atomic commit per task, single-line conventional-commit message.
+- `go build ./...` and `go test ./...` green in `services/marketplace-api`
+  before each commit.
+- No behaviour change beyond what each task states. In particular Task 1 is
+  pure deletion and Task 3 adds a guard, not a wiring.

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -259,6 +259,20 @@ func (d dispatchSentCounter) WithTemplate(template string) dispatch.CounterIncre
 	return d.cv.WithLabelValues(template)
 }
 
+// trialSkipCounter / trialSentCounter do the same for the trial_expired
+// notice emitted by the trial expiry cron.
+type trialSkipCounter struct{ cv *prometheus.CounterVec }
+
+func (t trialSkipCounter) WithTemplateReason(template, reason string) trial.CounterIncrementer {
+	return t.cv.WithLabelValues(template, reason)
+}
+
+type trialSentCounter struct{ cv *prometheus.CounterVec }
+
+func (t trialSentCounter) WithTemplate(template string) trial.CounterIncrementer {
+	return t.cv.WithLabelValues(template)
+}
+
 // otelServiceName is the OpenTelemetry service.name reported for traces and
 // metrics. Both MODE variants (admin/storefront) run the same binary/image,
 // so they share one logical service name; the MODE is distinguished via
@@ -1969,7 +1983,13 @@ func main() {
 		log.Error("register trial banner cron", "err", err)
 	}
 
-	expiryCron := trial.NewExpiryCron(conn, auditEmitter, log, nil)
+	// billingEmailClient, not dunningEmailClient: the latter is declared
+	// further down, after this cron is built. Same underlying template
+	// client either way.
+	expiryCron := trial.NewExpiryCron(conn, auditEmitter, log, nil).
+		WithEmail(billingEmailClient,
+			trialSentCounter{metrics.BillingEmailsSentTotal},
+			trialSkipCounter{metrics.BillingEmailsSkippedTotal})
 	if _, err := trialScheduler.AddFunc(trial.ExpirySpec, func() {
 		if err := expiryCron.Run(workerCtx); err != nil {
 			log.Error("trial expiry cron failed", "err", err)

--- a/services/marketplace-api/internal/billing/trial/banner_cron.go
+++ b/services/marketplace-api/internal/billing/trial/banner_cron.go
@@ -16,24 +16,24 @@ import (
 const BannerSpec = "0 9 * * *"
 
 type bannerTarget struct {
-	day      int
-	state    string
-	template string // template name for the deferred email (see TODO below)
+	day   int
+	state string
 }
 
 // bannerTargets defines the three thresholds at which trial banner state advances.
 var bannerTargets = []bannerTarget{
-	{60, "day_60", "trial_day_60"},
-	{75, "day_75", "trial_day_75"},
-	{85, "day_85", "trial_day_85"},
+	{60, "day_60"},
+	{75, "day_75"},
+	{85, "day_85"},
 }
 
 // BannerCron scans trialing stores at days 60, 75, and 85 of their trial and
 // advances the trial_banner_state column so the storefront/admin can surface
 // the appropriate urgency banner.
 //
-// Email delivery is deferred until StoreSubscription gains email/store_name
-// columns (planned for P8 or later).
+// This cron drives the in-app banner only. Trial email is owned by
+// internal/subscription/dunning/trial_reminders.go, which sends the
+// T-15/T-10/T-7/T-3/T-1 ladder.
 type BannerCron struct {
 	db     *gorm.DB
 	logger *slog.Logger
@@ -108,14 +108,12 @@ func (c *BannerCron) processOne(ctx context.Context, row *subscription.StoreSubs
 		if res.RowsAffected == 0 {
 			return nil // another pod won the race
 		}
-		// TODO: trial lifecycle emails land when StoreSubscription gets email/store_name
-		// columns (deferred from P5 scope). For now, log the intent so ops can see trial
-		// banner advancement in structured logs.
-		c.logger.Info("trial banner advanced; email deferred",
+		// No email is sent here — dunning/trial_reminders.go owns trial mail.
+		// Log the advance so ops can see banner state changes in structured logs.
+		c.logger.Info("trial banner advanced",
 			"store_id", row.StoreID.String(),
 			"tenant_id", row.TenantID.String(),
 			"banner_state", t.state,
-			"template", t.template,
 			"day", t.day)
 		return nil
 	})

--- a/services/marketplace-api/internal/billing/trial/expiry_cron.go
+++ b/services/marketplace-api/internal/billing/trial/expiry_cron.go
@@ -9,6 +9,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/email"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 	"github.com/mark8ly/marketplace-api/internal/subscription/statemachine"
 )
@@ -28,6 +29,25 @@ type ExpiryCron struct {
 	emitter *audit.Emitter
 	logger  *slog.Logger
 	clock   func() time.Time
+	mailer  email.Client
+	sent    SentCounter
+	skip    SkipCounter
+}
+
+// CounterIncrementer is a one-method counter so tests can stub it.
+type CounterIncrementer interface{ Inc() }
+
+// SentCounter counts expiry notices actually delivered, labeled by template.
+// Declared here rather than imported from the dunning package, which already
+// imports this one.
+type SentCounter interface {
+	WithTemplate(template string) CounterIncrementer
+}
+
+// SkipCounter counts expiry notices deliberately not sent, labeled by
+// template and reason (see email.SkipReason for the reason vocabulary).
+type SkipCounter interface {
+	WithTemplateReason(template, reason string) CounterIncrementer
 }
 
 // NewExpiryCron constructs an ExpiryCron. If clock is nil, time.Now().UTC() is
@@ -40,6 +60,20 @@ func NewExpiryCron(db *gorm.DB, em *audit.Emitter, logger *slog.Logger, clock fu
 		logger = slog.Default()
 	}
 	return &ExpiryCron{db: db, emitter: em, logger: logger, clock: clock}
+}
+
+// WithEmail attaches the transactional email client used for the
+// trial-expired notice, plus the optional delivered/skipped counters.
+//
+// Chainable rather than a constructor parameter so the existing callers —
+// main.go and five integration tests — compile untouched. A cron with no
+// client simply sends nothing: trial expiry must never fail because email
+// is unconfigured.
+func (c *ExpiryCron) WithEmail(cl email.Client, sent SentCounter, skip SkipCounter) *ExpiryCron {
+	c.mailer = cl
+	c.sent = sent
+	c.skip = skip
+	return c
 }
 
 // Run selects all trialing stores without a card whose effective trial end
@@ -67,7 +101,7 @@ func (c *ExpiryCron) Run(ctx context.Context) error {
 }
 
 func (c *ExpiryCron) expireOne(ctx context.Context, row *subscription.StoreSubscription) {
-	err := statemachine.Transition(ctx, statemachine.TransitionInput{
+	c.afterTransition(ctx, row, statemachine.Transition(ctx, statemachine.TransitionInput{
 		DB:       c.db,
 		Emitter:  c.emitter,
 		TenantID: row.TenantID,
@@ -76,21 +110,87 @@ func (c *ExpiryCron) expireOne(ctx context.Context, row *subscription.StoreSubsc
 		To:       subscription.StatusExpired,
 		Actor:    "system:cron:trial_expiry",
 		Reason:   "trial_ended_no_card",
-	})
+	}))
+}
+
+// afterTransition decides what follows the state-machine call. Split out from
+// expireOne so the email decision is testable without a database.
+func (c *ExpiryCron) afterTransition(ctx context.Context, row *subscription.StoreSubscription, err error) {
 	switch {
 	case err == nil:
-		// TODO: trial expiry email deferred — see banner cron comment.
-		// TODO: trial lifecycle emails land when StoreSubscription gets email/store_name
-		// columns (deferred from P5 scope). For now, log intent for ops visibility.
-		c.logger.Info("trial expired; email deferred",
+		c.logger.Info("trial expired",
 			"store_id", row.StoreID.String(),
-			"tenant_id", row.TenantID.String(),
-			"template", "trial_expired")
+			"tenant_id", row.TenantID.String())
+		c.notifyExpired(ctx, row)
 	case errors.Is(err, statemachine.ErrCASConflict):
 		// Another writer moved it — likely a last-second webhook from card-add.
-		// Intended behaviour; no email, no error log.
+		// That store did NOT expire, so it gets no notice, and no error log.
 	default:
 		c.logger.Error("trial expiry: transition failed",
 			"store_id", row.StoreID.String(), "err", err)
 	}
+}
+
+// notifyExpired tells the merchant their trial has ended. It is best-effort:
+// the transition has already been committed, so a send failure is logged and
+// counted, never returned.
+func (c *ExpiryCron) notifyExpired(ctx context.Context, row *subscription.StoreSubscription) {
+	if c.mailer == nil {
+		// Email is not configured for this deployment (and is not wired in
+		// the integration tests). Expiry itself has already succeeded.
+		return
+	}
+
+	to := ""
+	if row.Email != nil {
+		to = *row.Email
+	}
+	// Classify before handing the address to the provider: the placeholder
+	// billing+<uuid>@mark8ly.local addresses minted at bootstrap would
+	// hard-bounce and cost sender reputation.
+	if err := email.ValidateRecipient(to); err != nil {
+		c.countSkip(email.SkipReason(err))
+		c.logger.Warn("trial expiry notice not sent",
+			"store_id", row.StoreID.String(),
+			"tenant_id", row.TenantID.String(),
+			"reason", email.SkipReason(err))
+		return
+	}
+
+	if err := c.mailer.Send(ctx, email.TemplateTrialExpired, to, map[string]any{
+		"store_id":   row.StoreID.String(),
+		"tenant_id":  row.TenantID.String(),
+		"store_name": c.storeName(ctx, row),
+	}); err != nil {
+		c.countSkip(email.SkipReason(err))
+		c.logger.Warn("trial expiry notice not sent",
+			"store_id", row.StoreID.String(),
+			"tenant_id", row.TenantID.String(),
+			"reason", email.SkipReason(err),
+			"err", err.Error())
+		return
+	}
+
+	if c.sent != nil {
+		c.sent.WithTemplate(string(email.TemplateTrialExpired)).Inc()
+	}
+	c.logger.Info("trial expiry notice sent",
+		"store_id", row.StoreID.String(),
+		"tenant_id", row.TenantID.String())
+}
+
+func (c *ExpiryCron) countSkip(reason string) {
+	if c.skip != nil {
+		c.skip.WithTemplateReason(string(email.TemplateTrialExpired), reason).Inc()
+	}
+}
+
+// storeName resolves the merchant-facing store name, tolerating a cron built
+// without a database handle (unit tests) by falling back to the same generic
+// wording subscription.StoreNameFor uses when the lookup misses.
+func (c *ExpiryCron) storeName(ctx context.Context, row *subscription.StoreSubscription) string {
+	if c.db == nil {
+		return "your store"
+	}
+	return subscription.StoreNameFor(ctx, c.db, row.StoreID)
 }

--- a/services/marketplace-api/internal/billing/trial/expiry_email_test.go
+++ b/services/marketplace-api/internal/billing/trial/expiry_email_test.go
@@ -1,0 +1,194 @@
+package trial
+
+// expiry_email_test.go — pure unit tests for the trial-expired notice.
+//
+// These deliberately need no database. Every other test in this package is
+// an integration test gated on TEST_DATABASE_URL, which means it skips
+// silently when the DSN is absent; the email decision is small enough to
+// exercise directly, so it is tested where it always runs.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/internal/subscription/statemachine"
+)
+
+type recordedSend struct {
+	template email.TemplateID
+	to       string
+	data     map[string]any
+}
+
+type fakeEmailClient struct {
+	sends []recordedSend
+	err   error
+}
+
+func (f *fakeEmailClient) Send(_ context.Context, template email.TemplateID, to string, data map[string]any) error {
+	f.sends = append(f.sends, recordedSend{template: template, to: to, data: data})
+	return f.err
+}
+
+type stubCounter struct{ n *int }
+
+func (s stubCounter) Inc() { *s.n++ }
+
+type stubSentCounter struct {
+	labels []string
+	n      int
+}
+
+func (s *stubSentCounter) WithTemplate(template string) CounterIncrementer {
+	s.labels = append(s.labels, template)
+	return stubCounter{n: &s.n}
+}
+
+type stubSkipCounter struct {
+	labels [][2]string
+	n      int
+}
+
+func (s *stubSkipCounter) WithTemplateReason(template, reason string) CounterIncrementer {
+	s.labels = append(s.labels, [2]string{template, reason})
+	return stubCounter{n: &s.n}
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func expiredRow(addr *string) *subscription.StoreSubscription {
+	return &subscription.StoreSubscription{
+		TenantID: uuid.New(),
+		StoreID:  uuid.New(),
+		Email:    addr,
+	}
+}
+
+func strptr(s string) *string { return &s }
+
+func TestAfterTransition_SendsTrialExpiredOnSuccess(t *testing.T) {
+	mailer := &fakeEmailClient{}
+	sent := &stubSentCounter{}
+	skipped := &stubSkipCounter{}
+	cron := NewExpiryCron(nil, nil, quietLogger(), nil).WithEmail(mailer, sent, skipped)
+
+	row := expiredRow(strptr("merchant@example.com"))
+	cron.afterTransition(context.Background(), row, nil)
+
+	if len(mailer.sends) != 1 {
+		t.Fatalf("sends = %d, want exactly 1", len(mailer.sends))
+	}
+	got := mailer.sends[0]
+	if got.template != email.TemplateTrialExpired {
+		t.Errorf("template = %q, want %q", got.template, email.TemplateTrialExpired)
+	}
+	if got.to != "merchant@example.com" {
+		t.Errorf("to = %q, want merchant@example.com", got.to)
+	}
+	if _, ok := got.data["store_name"]; !ok {
+		t.Error("data is missing store_name")
+	}
+	if got.data["store_id"] != row.StoreID.String() {
+		t.Errorf("data store_id = %v, want %s", got.data["store_id"], row.StoreID)
+	}
+	if sent.n != 1 {
+		t.Errorf("sent counter = %d, want 1", sent.n)
+	}
+	if skipped.n != 0 {
+		t.Errorf("skip counter = %d, want 0", skipped.n)
+	}
+}
+
+func TestAfterTransition_NoMailOnCASConflict(t *testing.T) {
+	mailer := &fakeEmailClient{}
+	cron := NewExpiryCron(nil, nil, quietLogger(), nil).WithEmail(mailer, nil, nil)
+
+	cron.afterTransition(context.Background(), expiredRow(strptr("merchant@example.com")),
+		statemachine.ErrCASConflict)
+
+	if len(mailer.sends) != 0 {
+		t.Fatalf("sends = %d, want 0 — the store did not expire", len(mailer.sends))
+	}
+}
+
+func TestAfterTransition_NoMailOnTransitionFailure(t *testing.T) {
+	mailer := &fakeEmailClient{}
+	cron := NewExpiryCron(nil, nil, quietLogger(), nil).WithEmail(mailer, nil, nil)
+
+	cron.afterTransition(context.Background(), expiredRow(strptr("merchant@example.com")),
+		errors.New("boom"))
+
+	if len(mailer.sends) != 0 {
+		t.Fatalf("sends = %d, want 0", len(mailer.sends))
+	}
+}
+
+func TestAfterTransition_NilEmailClientIsANoOp(t *testing.T) {
+	cron := NewExpiryCron(nil, nil, quietLogger(), nil)
+
+	// Must not panic: trial expiry never depends on email being configured.
+	cron.afterTransition(context.Background(), expiredRow(strptr("merchant@example.com")), nil)
+}
+
+func TestAfterTransition_MissingRecipientIsNotSent(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		addr   *string
+		reason string
+	}{
+		{"nil email", nil, email.ReasonNoAddress},
+		{"empty email", strptr(""), email.ReasonNoAddress},
+		{"placeholder email", strptr("billing+x@mark8ly.local"), email.ReasonPlaceholderAddress},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mailer := &fakeEmailClient{}
+			skipped := &stubSkipCounter{}
+			sent := &stubSentCounter{}
+			cron := NewExpiryCron(nil, nil, quietLogger(), nil).WithEmail(mailer, sent, skipped)
+
+			cron.afterTransition(context.Background(), expiredRow(tc.addr), nil)
+
+			if len(mailer.sends) != 0 {
+				t.Fatalf("sends = %d, want 0 — no deliverable address", len(mailer.sends))
+			}
+			if sent.n != 0 {
+				t.Errorf("sent counter = %d, want 0", sent.n)
+			}
+			if skipped.n != 1 {
+				t.Fatalf("skip counter = %d, want 1", skipped.n)
+			}
+			want := [2]string{string(email.TemplateTrialExpired), tc.reason}
+			if skipped.labels[0] != want {
+				t.Errorf("skip labels = %v, want %v", skipped.labels[0], want)
+			}
+		})
+	}
+}
+
+func TestAfterTransition_SendFailureIsCountedAsSkipped(t *testing.T) {
+	mailer := &fakeEmailClient{err: errors.New("transport down")}
+	sent := &stubSentCounter{}
+	skipped := &stubSkipCounter{}
+	cron := NewExpiryCron(nil, nil, quietLogger(), nil).WithEmail(mailer, sent, skipped)
+
+	cron.afterTransition(context.Background(), expiredRow(strptr("merchant@example.com")), nil)
+
+	if len(mailer.sends) != 1 {
+		t.Fatalf("sends = %d, want 1 attempt", len(mailer.sends))
+	}
+	if sent.n != 0 {
+		t.Errorf("sent counter = %d, want 0 — the send failed", sent.n)
+	}
+	if skipped.n != 1 {
+		t.Errorf("skip counter = %d, want 1", skipped.n)
+	}
+}

--- a/services/marketplace-api/internal/email/client.go
+++ b/services/marketplace-api/internal/email/client.go
@@ -28,6 +28,12 @@ const (
 	// confirms the chosen plan is now active.
 	TemplateTrialStartedBilled TemplateID = "trial_started_billed"
 
+	// Sent by the trial expiry cron once a cardless trial has actually
+	// ended and the store has moved to "expired". The T-1 reminder warned
+	// the merchant it would happen; this confirms that it did and says how
+	// to reactivate.
+	TemplateTrialExpired TemplateID = "trial_expired"
+
 	// Day-30 post-expiry win-back promo. Lived in the lifecycle package
 	// until #381; moved here so the billing catalog is complete in one
 	// place and the email package can register its fallback without

--- a/services/marketplace-api/internal/email/templates.go
+++ b/services/marketplace-api/internal/email/templates.go
@@ -26,6 +26,7 @@ var billingTemplateKeys = []TemplateID{
 	TemplateTrialNoPMT1,
 	TemplateTrialHasPMT1,
 	TemplateTrialStartedBilled,
+	TemplateTrialExpired,
 	TemplatePaymentActionReminder,
 	TemplateDunningDay5,
 	TemplateDunningDay7,

--- a/services/marketplace-api/internal/email/templates_content.go
+++ b/services/marketplace-api/internal/email/templates_content.go
@@ -1,6 +1,6 @@
 package email
 
-// templates_content.go — embedded fallback copy for the eleven billing
+// templates_content.go — embedded fallback copy for the twelve billing
 // templates (#381).
 //
 // These are FALLBACKS. The authoritative copy, once an operator writes one,
@@ -53,6 +53,7 @@ var billingSubjects = map[TemplateID]string{
 	TemplateTrialNoPMT1:           `Your {{.store_name}} trial ends tomorrow`,
 	TemplateTrialHasPMT1:          `Your {{.plan}} plan for {{.store_name}} starts tomorrow`,
 	TemplateTrialStartedBilled:    `Your {{.plan}} plan for {{.store_name}} is active`,
+	TemplateTrialExpired:          `Your {{.store_name}} trial has ended`,
 	TemplateWinBack:               `Come back to Mark8ly — 20% off six months`,
 }
 
@@ -99,6 +100,11 @@ var billingHTMLFragments = map[TemplateID]string{
 	TemplateTrialStartedBilled: `<h1 ` + h1 + `>Your {{.plan}} plan is active</h1>
 <p>Thank you — the first payment for <strong>{{.store_name}}</strong> went through and your <strong>{{.plan}}</strong> plan is now active, billed {{.period}}.</p>
 <p>Your receipt is in your billing settings.</p>`,
+
+	TemplateTrialExpired: `<h1 ` + h1 + `>Your trial has ended</h1>
+<p>The free trial for <strong>{{.store_name}}</strong> ended today. No payment method was added, so the store is not on a paid plan and the storefront has stopped serving customers.</p>
+<p>Nothing has been deleted. Your products, orders and settings are exactly as you left them.</p>
+<p>To reopen the store, add a payment method and choose a plan in your Mark8ly billing settings — it comes back straight away.</p>`,
 
 	TemplateWinBack: `<h1 ` + h1 + `>Your store is still here</h1>
 <p><strong>{{.store_name}}</strong> has been closed for a month. Everything — products, orders, settings — is exactly as you left it.</p>
@@ -193,6 +199,16 @@ Mark8ly`,
 Thank you — the first payment for {{.store_name}} went through and your {{.plan}} plan is now active, billed {{.period}}.
 
 Your receipt is in your billing settings.
+
+Mark8ly`,
+
+	TemplateTrialExpired: `Your trial has ended
+
+The free trial for {{.store_name}} ended today. No payment method was added, so the store is not on a paid plan and the storefront has stopped serving customers.
+
+Nothing has been deleted. Your products, orders and settings are exactly as you left them.
+
+To reopen the store, add a payment method and choose a plan in your Mark8ly billing settings — it comes back straight away.
 
 Mark8ly`,
 

--- a/services/marketplace-api/internal/email/templates_test.go
+++ b/services/marketplace-api/internal/email/templates_test.go
@@ -32,8 +32,8 @@ func TestRegisterFallbacks_EveryKeyRenders(t *testing.T) {
 	email.RegisterFallbacks(loader)
 
 	keys := email.BillingTemplateKeys()
-	if len(keys) != 11 {
-		t.Fatalf("BillingTemplateKeys() has %d keys, want 11", len(keys))
+	if len(keys) != 12 {
+		t.Fatalf("BillingTemplateKeys() has %d keys, want 12", len(keys))
 	}
 
 	for _, key := range keys {

--- a/services/marketplace-api/internal/whitelabel/lifecycle/pro_app_cancelled_consumer.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/pro_app_cancelled_consumer.go
@@ -22,6 +22,25 @@ type ProAppCancelledEvent struct {
 	MerchantInitiatedImmediate bool
 }
 
+// ErrNoAppIdentifiers is returned when an event names neither an Apple
+// app, a Google package, nor a Firebase project.
+//
+// Seeding such a row would be actively harmful rather than merely
+// useless. The advancer skips pullApps when AppleAppID is empty and
+// archiveFirebase when FirebaseProjectID is empty (advancer.go), so a
+// row with all three blank walks the whole state machine to
+// credentials_purged without touching a single store listing. The
+// merchant's app stays live and downloadable while the platform records
+// a completed teardown — a silent false success nobody goes looking for.
+// A teardown that fails loudly at seed time is strictly better: it
+// leaves the honest no-op we have today and surfaces the missing
+// identifiers to whoever emitted the event.
+//
+// Only an event with none of the three is refused. A store may
+// legitimately ship on Apple with no Firebase project (or any other
+// partial combination), and those must still seed.
+var ErrNoAppIdentifiers = errors.New("lifecycle/consumer: event carries no AppleAppID, GooglePackage or FirebaseProjectID")
+
 // ProAppCancelledConsumer seeds a white_label_app_state row when the
 // subscription package emits the pro_app_cancelled event.
 //
@@ -46,13 +65,28 @@ func NewProAppCancelledConsumer(db *gorm.DB, clock Clock) *ProAppCancelledConsum
 	return &ProAppCancelledConsumer{db: db, clock: clock}
 }
 
+// validateEvent rejects events that cannot produce a meaningful
+// teardown. See ErrNoAppIdentifiers for why a blank-identifier event is
+// worse than no event at all.
+func validateEvent(ev ProAppCancelledEvent) error {
+	if ev.TenantID == uuid.Nil || ev.StoreID == uuid.Nil {
+		return errors.New("lifecycle/consumer: TenantID and StoreID are required")
+	}
+	if ev.AppleAppID == "" && ev.GooglePackage == "" && ev.FirebaseProjectID == "" {
+		return ErrNoAppIdentifiers
+	}
+	return nil
+}
+
 // Handle inserts (or updates, if one already exists) a state row for
 // the store. Idempotent under replay: a second Handle call for the
 // same storeID is a no-op (ON CONFLICT DO NOTHING via unique index on
 // store_id).
 func (c *ProAppCancelledConsumer) Handle(ctx context.Context, ev ProAppCancelledEvent) error {
-	if ev.TenantID == uuid.Nil || ev.StoreID == uuid.Nil {
-		return errors.New("lifecycle/consumer: TenantID and StoreID are required")
+	// Validation runs before any SQL: a refused event must leave no row
+	// behind for the advancer to pick up.
+	if err := validateEvent(ev); err != nil {
+		return err
 	}
 
 	now := c.clock().UTC()

--- a/services/marketplace-api/internal/whitelabel/lifecycle/pro_app_cancelled_consumer_integration_test.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/pro_app_cancelled_consumer_integration_test.go
@@ -99,3 +99,34 @@ func TestConsumer_RejectsMissingIDs(t *testing.T) {
 		}
 	}
 }
+
+func TestConsumer_FirebaseOnly_StillSeeds(t *testing.T) {
+	// A store may have a Firebase project and no Apple listing. The
+	// no-identifier guard must not reject a partial-but-real event.
+	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
+	c := lifecycle.NewProAppCancelledConsumer(db, nil)
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	require.NoError(t, c.Handle(context.Background(), lifecycle.ProAppCancelledEvent{
+		TenantID: tenantID, StoreID: storeID, FirebaseProjectID: "fb-x",
+	}))
+
+	var row lifecycle.Row
+	require.NoError(t, db.Where("store_id=?", storeID).First(&row).Error)
+	require.Equal(t, "fb-x", row.FirebaseProjectID)
+}
+
+func TestConsumer_NoIdentifiers_WritesNoRow(t *testing.T) {
+	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
+	c := lifecycle.NewProAppCancelledConsumer(db, nil)
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	err := c.Handle(context.Background(), lifecycle.ProAppCancelledEvent{
+		TenantID: tenantID, StoreID: storeID,
+	})
+	require.ErrorIs(t, err, lifecycle.ErrNoAppIdentifiers)
+
+	var count int64
+	db.Model(&lifecycle.Row{}).Where("store_id=?", storeID).Count(&count)
+	require.Zero(t, count, "a refused event must leave no row for the advancer")
+}

--- a/services/marketplace-api/internal/whitelabel/lifecycle/pro_app_cancelled_consumer_test.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/pro_app_cancelled_consumer_test.go
@@ -1,0 +1,98 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// These are pure unit tests: they never touch a database. The validation
+// they cover runs before any SQL is issued, which is precisely the
+// property being asserted — a rejected event must leave no row behind.
+
+func TestValidateEvent_RejectsEventWithNoAppIdentifiers(t *testing.T) {
+	err := validateEvent(ProAppCancelledEvent{
+		TenantID: uuid.New(),
+		StoreID:  uuid.New(),
+	})
+	if !errors.Is(err, ErrNoAppIdentifiers) {
+		t.Fatalf("validateEvent(no identifiers) = %v; want ErrNoAppIdentifiers", err)
+	}
+}
+
+func TestValidateEvent_AcceptsAnySingleIdentifier(t *testing.T) {
+	base := ProAppCancelledEvent{TenantID: uuid.New(), StoreID: uuid.New()}
+
+	cases := map[string]ProAppCancelledEvent{
+		"apple only": func() ProAppCancelledEvent {
+			ev := base
+			ev.AppleAppID = "1234567890"
+			return ev
+		}(),
+		"google only": func() ProAppCancelledEvent {
+			ev := base
+			ev.GooglePackage = "com.example.store"
+			return ev
+		}(),
+		"firebase only": func() ProAppCancelledEvent {
+			ev := base
+			ev.FirebaseProjectID = "fb-store-1"
+			return ev
+		}(),
+	}
+
+	for name, ev := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := validateEvent(ev); err != nil {
+				t.Fatalf("validateEvent(%s) = %v; want nil — a store may hold one platform without the others", name, err)
+			}
+		})
+	}
+}
+
+func TestValidateEvent_StillRequiresTenantAndStore(t *testing.T) {
+	cases := map[string]ProAppCancelledEvent{
+		"missing tenant": {TenantID: uuid.Nil, StoreID: uuid.New(), AppleAppID: "a1"},
+		"missing store":  {TenantID: uuid.New(), StoreID: uuid.Nil, AppleAppID: "a1"},
+	}
+
+	for name, ev := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := validateEvent(ev)
+			if err == nil {
+				t.Fatalf("validateEvent(%s) = nil; want error", name)
+			}
+			if errors.Is(err, ErrNoAppIdentifiers) {
+				t.Fatalf("validateEvent(%s) returned ErrNoAppIdentifiers; identifier presence is a separate failure", name)
+			}
+		})
+	}
+}
+
+// Handle is given a nil *gorm.DB on purpose: if validation did not return
+// before the insert, the call would panic on the nil handle. A clean
+// sentinel return is proof that no write was attempted.
+func TestHandle_RejectsBeforeTouchingTheDatabase(t *testing.T) {
+	c := NewProAppCancelledConsumer(nil, nil)
+
+	err := c.Handle(context.Background(), ProAppCancelledEvent{
+		TenantID: uuid.New(),
+		StoreID:  uuid.New(),
+	})
+	if !errors.Is(err, ErrNoAppIdentifiers) {
+		t.Fatalf("Handle(no identifiers) = %v; want ErrNoAppIdentifiers", err)
+	}
+}
+
+func TestHandle_RejectsMissingIDsBeforeTouchingTheDatabase(t *testing.T) {
+	c := NewProAppCancelledConsumer(nil, nil)
+
+	if err := c.Handle(context.Background(), ProAppCancelledEvent{StoreID: uuid.New(), AppleAppID: "a1"}); err == nil {
+		t.Fatal("Handle(missing tenant) = nil; want error")
+	}
+	if err := c.Handle(context.Background(), ProAppCancelledEvent{TenantID: uuid.New(), AppleAppID: "a1"}); err == nil {
+		t.Fatal("Handle(missing store) = nil; want error")
+	}
+}


### PR DESCRIPTION
Three small fixes from the billing backlog triage. Each closes a place where the code claimed something it did not do. None needs Stripe, the console, or a working subscription — that is why they were picked up first.

## Why the scope is what it is

#703 was filed claiming merchants are charged after a 90-day trial with no warning. **That was wrong**, and the issue has been corrected. `internal/subscription/dunning/trial_reminders.go` already sends T-15/T-10/T-7/T-3/T-1 reminders, payment-method-aware, and is scheduled at `cmd/marketplace-api/main.go:2138`. So one part of the original scope became a deletion rather than an addition.

## The three commits

**`refactor(trial)` — drop the banner cron's phantom template ladder**

`bannerTarget.template` held `trial_day_60` / `trial_day_75` / `trial_day_85`. No such `TemplateID` has ever existed, and on a 90-day trial those land at T-30/T-15/T-5 — wiring them would have duplicated `no_pm_t_minus_15` and fired a third mail between the existing T-7 and T-3. Deleted the field and repointed the stale comments at the cron that actually owns trial mail. Pure refactor: state machine, CAS update, advisory lock and thresholds are byte-identical.

**`fix(whitelabel)` — refuse to seed a Pro+App teardown with no app identifiers**

The advancer skips `pullApps` when `AppleAppID` is empty and `archiveFirebase` when `FirebaseProjectID` is empty. So an event with all three blank walks the state machine to `credentials_purged` having torn nothing down — the merchant's app stays live while the platform records a completed teardown. `Handle` now returns `ErrNoAppIdentifiers` before any SQL when all three are missing. Partial events (Apple-only, Firebase-only) still seed, since a store may legitimately ship on one platform.

This does **not** wire the consumer. Nothing in the estate produces those identifiers yet (#702) — this makes that hole loud instead of silent.

**`feat(trial)` — tell a merchant when their trial has expired**

The expiry cron transitioned a cardless trial to `expired` and only logged "email deferred". T-1 warned them it would happen; nothing confirmed it did. Adds the `trial_expired` template and sends it on a successful transition.

Attached via a chainable `WithEmail(...)` rather than a constructor change, so all six existing `NewExpiryCron` callers compile untouched and send nothing. A cron with no client is a no-op — trial expiry must never fail because email is unconfigured. Sent only on `err == nil`; a `ErrCASConflict` means a last-second card-add won and that store did not expire, so it gets no mail.

Wired with `billingEmailClient` (line 683) rather than `dunningEmailClient`, which is declared after the expiry cron is constructed.

## Testing

The existing `internal/billing/trial/` and `internal/whitelabel/lifecycle/` suites are integration tests requiring `TEST_DATABASE_URL`, which **skip silently and still print `ok`**. Every new test here is therefore a pure unit test that genuinely executes:

- `expiry_email_test.go` — sends exactly one notice on success; none on CAS conflict, transition failure, nil client, or missing/placeholder recipient; send failure counted as a skip
- `pro_app_cancelled_consumer_test.go` — all-empty event returns the sentinel; each single-identifier case still inserts; tenant/store validation unchanged. "No row written" is proved by calling `Handle` with a nil `*gorm.DB` — it panics if validation does not return first

Integration-tagged tests were also added for the real insert path, but they were **not executed** in this session and should not be counted until CI runs them.

`go build ./...`, `go vet` (including `-tags integration`), and `go test -count=1 ./...` are clean across the service.

Refs #702, #703.
