### PR TITLE
fix(storefront): correct the PublicBrandingResponse exposure comment and pin it with a test

### DIFF
--- a/services/marketplace-api/internal/handlers/storefront/branding.go
+++ b/services/marketplace-api/internal/handlers/storefront/branding.go
@@ -38,8 +38,21 @@ type ActivePromotionResponse struct {
 	Link       *string `json:"link,omitempty"`
 }
 
-// PublicBrandingResponse is the public wire DTO — excludes custom_css
-// and admin-only fields.
+// PublicBrandingResponse is the public wire DTO for the storefront.
+//
+// Relative to branding.StoreBranding it withholds the row's identifiers
+// and timestamps (ID, TenantID, StoreID, CreatedAt, UpdatedAt) and
+// ReturnPolicy, which only the admin DTO carries
+// (handlers/admin/branding.go).
+//
+// It DOES carry custom_css. That is deliberate: the field is
+// merchant-authored styling for the merchant's own storefront, so the
+// storefront cannot render the store without it (apps/storefront types it
+// and sanitises at render time). An earlier version of this comment
+// claimed custom_css was excluded while the struct below included it —
+// the comment was wrong, not the struct (#694). Keep this list in step
+// with the fields; a reader auditing what the public endpoint exposes
+// will trust it.
 type PublicBrandingResponse struct {
 	LogoURL            *string                  `json:"logo_url,omitempty"`
 	FaviconURL         *string                  `json:"favicon_url,omitempty"`

--- a/services/marketplace-api/internal/handlers/storefront/branding_exposure_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/branding_exposure_test.go
@@ -1,0 +1,67 @@
+package storefront
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/branding"
+)
+
+// TestPublicBrandingExposureIsExactlyWhatTheCommentClaims pins the boundary
+// PublicBrandingResponse's doc comment describes.
+//
+// #694: that comment claimed custom_css was excluded while the struct
+// included it. Nothing failed, because a comment cannot fail — and a reader
+// auditing what the public branding endpoint exposes reads the comment, not
+// the 36-field struct. This test makes the claim executable, so the next
+// person who adds a field to StoreBranding has to decide, explicitly,
+// whether it is public.
+//
+// Adding a field to StoreBranding without adding it here is the failure this
+// catches. If you are here because it failed: decide whether the new field is
+// public. If it is, add it to PublicBrandingResponse. If it is not, add it to
+// withheld below AND to the doc comment.
+func TestPublicBrandingExposureIsExactlyWhatTheCommentClaims(t *testing.T) {
+	// Withheld from the storefront. Identifiers and timestamps, plus
+	// ReturnPolicy, which only the admin DTO carries.
+	withheld := map[string]struct{}{
+		"ID":        {},
+		"TenantID":  {},
+		"StoreID":   {},
+		"CreatedAt": {},
+		"UpdatedAt": {},
+
+		"ReturnPolicy": {},
+	}
+
+	public := map[string]struct{}{}
+	pt := reflect.TypeOf(PublicBrandingResponse{})
+	for i := 0; i < pt.NumField(); i++ {
+		public[pt.Field(i).Name] = struct{}{}
+	}
+
+	mt := reflect.TypeOf(branding.StoreBranding{})
+	for i := 0; i < mt.NumField(); i++ {
+		name := mt.Field(i).Name
+		_, isPublic := public[name]
+		_, isWithheld := withheld[name]
+
+		switch {
+		case isPublic && isWithheld:
+			t.Errorf("StoreBranding.%s is listed as withheld but IS on PublicBrandingResponse", name)
+		case !isPublic && !isWithheld:
+			t.Errorf(
+				"StoreBranding.%s reaches neither PublicBrandingResponse nor the withheld list — "+
+					"decide whether it is public and record the decision in both places",
+				name,
+			)
+		}
+	}
+
+	// The specific regression: custom_css is public on purpose. If someone
+	// makes it non-public they must change the doc comment too, and this
+	// says so at the point of failure.
+	if _, ok := public["CustomCSS"]; !ok {
+		t.Error("CustomCSS is no longer on PublicBrandingResponse — update the doc comment, which states it IS carried")
+	}
+}


### PR DESCRIPTION
Closes #694.

`PublicBrandingResponse`'s doc comment said:

> excludes custom_css and admin-only fields

The struct declares `CustomCSS` and `toPublicBrandingResponse` populates it, so
half that sentence was false.

**The code was right; the comment was wrong.** `custom_css` is merchant-authored
styling for the merchant's own storefront — `apps/storefront` types it and
sanitises at render time, and the store cannot render its own branding without
it. Nothing here changes what the endpoint returns.

### What it actually withholds

Checked by diffing the struct against `branding.StoreBranding` rather than
trusting the comment: `ID`, `TenantID`, `StoreID`, `CreatedAt`, `UpdatedAt`, and
`ReturnPolicy` — the last carried only by the admin DTO
(`handlers/admin/branding.go:94`). So the "admin-only fields" half was true; only
the `custom_css` clause was false.

### Why a test and not just a comment

The bug here is not the wrong words, it is that **a comment cannot fail**. A
reader auditing what the public branding endpoint exposes reads two lines of
prose, not a 36-field struct — that is exactly how this went unnoticed, and
fixing only the prose leaves the same trap for the next field.

`TestPublicBrandingExposureIsExactlyWhatTheCommentClaims` makes the claim
executable: every `StoreBranding` field must appear either on
`PublicBrandingResponse` or on an explicit withheld list. A field added to the
model and silently omitted from the DTO now fails with a message telling the
author to record the decision in both places, and a field moved onto the public
DTO while still listed as withheld fails too.

I verified the test is not vacuous by dropping `ReturnPolicy` from the withheld
list and confirming it fails:

```
--- FAIL: TestPublicBrandingExposureIsExactlyWhatTheCommentClaims
    StoreBranding.ReturnPolicy reaches neither PublicBrandingResponse nor the
    withheld list — decide whether it is public and record the decision in both places
```

### Verification

- `go build ./...` and `go vet ./internal/handlers/storefront/` — clean
- `go test ./internal/handlers/storefront/ -run TestPublicBrandingExposure` — ok
- Test proven to fail on drift, then restored (above)

### One thing I did not decide

`ReturnPolicy` is the only non-identifier field withheld from the storefront. A
store's return policy is plausibly customer-facing, so this may be an oversight
rather than a choice — but it predates this issue and changing it would alter
the endpoint's payload, so I recorded the current behaviour rather than
silently changing it. Worth a look by whoever owns the branding surface.
