### PR TITLE
Emit an audit event on subscription period and cancellation-flag transitions

### DIFF
--- a/.planning/quick/260905-pta-period-transition-audit/PLAN.md
+++ b/.planning/quick/260905-pta-period-transition-audit/PLAN.md
@@ -1,0 +1,76 @@
+# Emit an audit event on subscription period transitions
+
+Half of #705. The refund half of that issue is deliberately NOT in scope —
+`refund_audit` turned out to be a fraud-control table with "one refund per
+card, ever" semantics enforced at `internal/refund/service.go:128`, so writing
+to it from a webhook would change refund policy rather than add observability.
+That is recorded on the issue with three options; this plan covers only the
+clean half.
+
+## The gap
+
+`internal/billing/dispatch/handlers.go:242` `handleSubscriptionUpdated` mirrors
+`current_period_start`, `current_period_end` and `cancel_at_period_end` from
+Stripe into `store_subscriptions`, and emits nothing. It is a free function
+`func(ctx, tx, raw) error`, so it has no access to `d.emitter` — that is the
+structural reason the original `TODO(P3)` was never done.
+
+Consequence: there is no record of when a billing period rolled, or when
+`cancel_at_period_end` was set or cleared. "This merchant scheduled a
+cancellation and then reversed it" cannot be reconstructed — exactly the
+question a billing dispute produces, and it interacts with #701's save-offer
+path which reverses a scheduled cancellation.
+
+## Design constraint discovered while scoping
+
+The existing `UPDATE` is **blind**: it writes new values without reading the
+old ones. Stripe emits `customer.subscription.updated` for many reasons, so
+emitting unconditionally would produce an event per webhook rather than per
+transition — noise that would make the audit trail less useful, not more.
+
+A transition signal therefore requires reading the prior row inside the same
+transaction, comparing, and emitting only on an actual change.
+
+## Task
+
+1. Convert `handleSubscriptionUpdated` to a method on `*Dispatcher` and change
+   its registration at `dispatcher.go:65` to `d.handleSubscriptionUpdated`.
+   `Handler` is `func(ctx, tx, raw) error` and the dispatcher already binds
+   methods this way (`dispatcher.go:78-81`), so this is a one-line change.
+2. Inside the handler, SELECT the current row for `stripe_customer_id` (id,
+   tenant_id, store_id, current_period_start, cancel_at_period_end) in the same
+   `tx` BEFORE the UPDATE. If no row matches, keep today's behaviour — the
+   UPDATE affects zero rows and the handler returns nil.
+3. After a successful UPDATE, emit via `d.emitter.Emit(nil, audit.Event{...})`
+   ONLY when something actually changed:
+   - `cancel_at_period_end` flipped false -> true, or true -> false. These are
+     distinct actions; a merchant scheduling a cancellation and a merchant
+     reversing one are different events and must not share one action string.
+   - `current_period_start` moved to a later value (a period rolled).
+3. Add the action constants alongside the existing
+   `ActionProAppCancelled = "subscription.pro_app_cancelled"` precedent
+   (`internal/subscription/lifecycle/finalize.go:30`), named in the same
+   `subscription.*` namespace.
+4. `d.emitter` may be nil — `Emitter.Emit` is nil-safe (`emitter.go:126`), but
+   the handler must not panic building the event either.
+
+## Out of scope
+
+- Anything touching `refund_audit`, `handleChargeRefunded`, or refund policy.
+- Backfilling past transitions.
+
+## Done when
+
+- Emits exactly one event when `cancel_at_period_end` flips, with distinct
+  actions for set vs clear
+- Emits when the period rolls forward
+- Emits NOTHING when the webhook carries identical values (the common case)
+- Existing dispatcher tests pass unchanged
+- Unit tests, not integration — `TEST_DATABASE_URL` is unset locally and
+  integration tests skip silently while still printing `ok`
+
+## Constraints
+
+- TDD: test first, watch it fail.
+- One atomic commit, single-line conventional message, NO attribution trailers.
+- `go build ./...`, `go vet`, `go test` green before committing.

--- a/services/marketplace-api/internal/billing/dispatch/dispatcher.go
+++ b/services/marketplace-api/internal/billing/dispatch/dispatcher.go
@@ -60,8 +60,10 @@ type Dispatcher struct {
 // no-op on a nil receiver.
 func New(em *audit.Emitter) *Dispatcher {
 	d := &Dispatcher{emitter: em, handlers: map[string]Handler{}}
-	// Free functions — side-effect-only handlers that don't advance status.
-	d.handlers["customer.subscription.updated"] = handleSubscriptionUpdated
+	// Side-effect-only handlers that don't advance status. Most are free
+	// functions; customer.subscription.updated is a method because it emits
+	// a period/cancel-flag transition event through d.emitter (#705).
+	d.handlers["customer.subscription.updated"] = d.handleSubscriptionUpdated
 	// invoice.paid runs a chain: the generic handler first (stamps
 	// first_charge_at, clears hosted_invoice_url, emits trial-billed
 	// confirmation email if this is the first charge), then the P15

--- a/services/marketplace-api/internal/billing/dispatch/handlers.go
+++ b/services/marketplace-api/internal/billing/dispatch/handlers.go
@@ -236,10 +236,22 @@ func HandleCheckoutSessionCompletedForTesting(ctx context.Context, tx *gorm.DB, 
 	return d.handleCheckoutSessionCompleted(ctx, tx, raw)
 }
 
-// handleSubscriptionUpdated refreshes period boundaries and cancel_at_period_end.
+// handleSubscriptionUpdated refreshes period boundaries and cancel_at_period_end,
+// and emits an audit event when one of those values actually TRANSITIONS.
 //
-// TODO(P3): emit audit event on period transition.
-func handleSubscriptionUpdated(ctx context.Context, tx *gorm.DB, raw []byte) error {
+// Why it reads the row first (#705). The UPDATE below is blind: it writes the
+// payload's values without looking at what was there. Stripe emits
+// customer.subscription.updated for many reasons, most of which change none of
+// the three columns we mirror, so emitting on every delivery would produce one
+// event per webhook rather than one per transition — noise that makes the
+// audit trail worse. The pre-state is therefore read inside the SAME
+// transaction, immediately before the UPDATE, and compared afterwards; see
+// decidePeriodTransitions for the rule.
+//
+// It is a method (not the free function it used to be) purely so it can reach
+// d.emitter — that structural fact is why the original TODO(P3) sat here
+// unimplemented.
+func (d *Dispatcher) handleSubscriptionUpdated(ctx context.Context, tx *gorm.DB, raw []byte) error {
 	var e struct {
 		Data struct {
 			Object struct {
@@ -267,6 +279,34 @@ func handleSubscriptionUpdated(ctx context.Context, tx *gorm.DB, raw []byte) err
 		ts := time.Unix(obj.CurrentPeriodEnd, 0).UTC()
 		periodEnd = &ts
 	}
+	// Pre-state, inside the same locked transaction as the UPDATE below. A
+	// missing row is NOT an error here: today's behaviour is that the UPDATE
+	// touches zero rows and the handler returns nil (test-mode noise, a
+	// customer we never provisioned), and that is preserved — we simply have
+	// no before-state to compare and emit nothing.
+	var before subscriptionPeriodState
+	var pc periodTransitionContext
+	haveBefore := false
+	var prior subscription.StoreSubscription
+	switch err := tx.WithContext(ctx).Where("stripe_customer_id = ?", obj.Customer).First(&prior).Error; {
+	case err == nil:
+		haveBefore = true
+		before = subscriptionPeriodState{
+			PeriodStart:       prior.CurrentPeriodStart,
+			CancelAtPeriodEnd: prior.CancelAtPeriodEnd,
+		}
+		pc = periodTransitionContext{
+			Customer:       obj.Customer,
+			SubscriptionID: prior.ID,
+			TenantID:       prior.TenantID,
+			StoreID:        prior.StoreID,
+		}
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		// Fall through to the UPDATE, which will affect zero rows.
+	default:
+		return fmt.Errorf("dispatch: subscription.updated lookup: %w", err)
+	}
+
 	res := tx.WithContext(ctx).Exec(
 		`UPDATE store_subscriptions
          SET current_period_start = ?,
@@ -278,6 +318,13 @@ func handleSubscriptionUpdated(ctx context.Context, tx *gorm.DB, raw []byte) err
 	)
 	if res.Error != nil {
 		return fmt.Errorf("dispatch: subscription update: %w", res.Error)
+	}
+
+	if haveBefore {
+		d.emitPeriodTransitions(pc, before, subscriptionPeriodState{
+			PeriodStart:       periodStart,
+			CancelAtPeriodEnd: obj.CancelAtPeriodEnd,
+		})
 	}
 	return nil
 }

--- a/services/marketplace-api/internal/billing/dispatch/subscription_updated_audit.go
+++ b/services/marketplace-api/internal/billing/dispatch/subscription_updated_audit.go
@@ -1,0 +1,124 @@
+package dispatch
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+)
+
+// Audit actions emitted by customer.subscription.updated, in the same
+// subscription.* namespace as lifecycle.ActionProAppCancelled.
+//
+// Scheduling a cancellation and reversing one are DELIBERATELY separate
+// actions. They are opposite merchant intents, and #701's save offer works by
+// reversing a scheduled cancellation — an audit trail that collapsed the two
+// into one action could not answer "did this merchant cancel and then stay?",
+// which is the question a billing dispute actually asks.
+const (
+	// ActionCancellationScheduled: cancel_at_period_end went false -> true.
+	ActionCancellationScheduled = "subscription.cancellation_scheduled"
+	// ActionCancellationReversed: cancel_at_period_end went true -> false.
+	ActionCancellationReversed = "subscription.cancellation_reversed"
+	// ActionPeriodRolled: current_period_start advanced to a later value.
+	ActionPeriodRolled = "subscription.period_rolled"
+)
+
+// subscriptionPeriodState is the slice of a subscription row that
+// customer.subscription.updated can change and that we audit. It is used for
+// both sides of the comparison: the row as it stood before the UPDATE, and
+// the values the Stripe payload carries.
+type subscriptionPeriodState struct {
+	PeriodStart       *time.Time
+	CancelAtPeriodEnd bool
+}
+
+// periodTransitionContext carries the identifiers an emitted event needs.
+// These come from the pre-UPDATE row, so they are only meaningful when that
+// row was found.
+type periodTransitionContext struct {
+	Customer       string
+	SubscriptionID uuid.UUID
+	TenantID       uuid.UUID
+	StoreID        uuid.UUID
+}
+
+// decidePeriodTransitions returns the audit actions a customer.subscription.updated
+// webhook should produce, given the row before the UPDATE and the values the
+// webhook carries. It is pure so the whole decision is unit-testable without
+// a database — the handler around it is a thin shell.
+//
+// It returns nil when nothing we audit actually changed. That is the common
+// case: Stripe emits customer.subscription.updated for many reasons, so
+// emitting unconditionally would produce one event per webhook rather than
+// one per transition, which would make the audit trail noisier and less
+// useful, not more.
+func decidePeriodTransitions(before, after subscriptionPeriodState) []string {
+	var actions []string
+
+	if before.CancelAtPeriodEnd != after.CancelAtPeriodEnd {
+		if after.CancelAtPeriodEnd {
+			actions = append(actions, ActionCancellationScheduled)
+		} else {
+			actions = append(actions, ActionCancellationReversed)
+		}
+	}
+
+	// A period rolls only when the payload carries a start that is strictly
+	// later than the one we held. An absent start (Stripe omits the field on
+	// some replays) and a start that moves backwards are both treated as "no
+	// roll" rather than as transitions.
+	//
+	// nil -> a value counts as a roll: it is the first billing period this
+	// subscription has ever had a start for, which happens once in its life
+	// and is worth a row.
+	if after.PeriodStart != nil &&
+		(before.PeriodStart == nil || after.PeriodStart.After(*before.PeriodStart)) {
+		actions = append(actions, ActionPeriodRolled)
+	}
+
+	return actions
+}
+
+// emitPeriodTransitions emits one audit event per decided transition.
+//
+// d.emitter may be nil — Emitter.Emit is nil-receiver-safe, and nothing here
+// dereferences it, so the whole path is a no-op in that wiring.
+func (d *Dispatcher) emitPeriodTransitions(pc periodTransitionContext, before, after subscriptionPeriodState) {
+	for _, action := range decidePeriodTransitions(before, after) {
+		severity := audit.SeverityInfo
+		if action == ActionCancellationScheduled {
+			// A merchant on their way out is worth surfacing above the
+			// routine period roll.
+			severity = audit.SeverityWarning
+		}
+		d.emitter.Emit(nil, audit.Event{
+			Action:         action,
+			ResourceType:   "subscription",
+			ResourceID:     pc.SubscriptionID.String(),
+			Severity:       severity,
+			TenantID:       pc.TenantID,
+			StoreID:        pc.StoreID,
+			ForceActorType: audit.ActorSystem,
+			Metadata: map[string]any{
+				"reason":                      "customer.subscription.updated",
+				"stripe_customer_id":          pc.Customer,
+				"store_id":                    pc.StoreID.String(),
+				"cancel_at_period_end_before": before.CancelAtPeriodEnd,
+				"cancel_at_period_end_after":  after.CancelAtPeriodEnd,
+				"current_period_start_before": formatPeriod(before.PeriodStart),
+				"current_period_start_after":  formatPeriod(after.PeriodStart),
+			},
+		})
+	}
+}
+
+// formatPeriod renders a nullable period boundary for audit metadata. A nil
+// boundary becomes "" rather than a typed nil, so the JSON blob stays flat.
+func formatPeriod(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}

--- a/services/marketplace-api/internal/billing/dispatch/subscription_updated_audit_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/subscription_updated_audit_test.go
@@ -1,0 +1,111 @@
+package dispatch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func ts(t *testing.T, s string) *time.Time {
+	t.Helper()
+	v, err := time.Parse(time.RFC3339, s)
+	require.NoError(t, err)
+	return &v
+}
+
+// TestDecidePeriodTransitions covers the whole decision surface of
+// customer.subscription.updated: the two cancel-flag directions, a rolled
+// billing period, and — the case that matters most — a webhook that carries
+// identical values and must emit nothing.
+func TestDecidePeriodTransitions(t *testing.T) {
+	jan := ts(t, "2026-01-01T00:00:00Z")
+	feb := ts(t, "2026-02-01T00:00:00Z")
+
+	cases := []struct {
+		name   string
+		before subscriptionPeriodState
+		after  subscriptionPeriodState
+		want   []string
+	}{
+		{
+			name:   "cancel flag set schedules a cancellation",
+			before: subscriptionPeriodState{PeriodStart: jan, CancelAtPeriodEnd: false},
+			after:  subscriptionPeriodState{PeriodStart: jan, CancelAtPeriodEnd: true},
+			want:   []string{ActionCancellationScheduled},
+		},
+		{
+			name:   "cancel flag cleared reverses a cancellation",
+			before: subscriptionPeriodState{PeriodStart: jan, CancelAtPeriodEnd: true},
+			after:  subscriptionPeriodState{PeriodStart: jan, CancelAtPeriodEnd: false},
+			want:   []string{ActionCancellationReversed},
+		},
+		{
+			name:   "period start moving forward rolls the period",
+			before: subscriptionPeriodState{PeriodStart: jan},
+			after:  subscriptionPeriodState{PeriodStart: feb},
+			want:   []string{ActionPeriodRolled},
+		},
+		{
+			name:   "first period start ever recorded rolls the period",
+			before: subscriptionPeriodState{PeriodStart: nil},
+			after:  subscriptionPeriodState{PeriodStart: jan},
+			want:   []string{ActionPeriodRolled},
+		},
+		{
+			name:   "identical values emit nothing",
+			before: subscriptionPeriodState{PeriodStart: jan, CancelAtPeriodEnd: true},
+			after:  subscriptionPeriodState{PeriodStart: jan, CancelAtPeriodEnd: true},
+			want:   nil,
+		},
+		{
+			name:   "absent period start in the payload emits nothing",
+			before: subscriptionPeriodState{PeriodStart: jan},
+			after:  subscriptionPeriodState{PeriodStart: nil},
+			want:   nil,
+		},
+		{
+			name:   "period start moving backwards emits nothing",
+			before: subscriptionPeriodState{PeriodStart: feb},
+			after:  subscriptionPeriodState{PeriodStart: jan},
+			want:   nil,
+		},
+		{
+			name:   "a roll and a cancellation in one webhook emit both, cancel first",
+			before: subscriptionPeriodState{PeriodStart: jan, CancelAtPeriodEnd: false},
+			after:  subscriptionPeriodState{PeriodStart: feb, CancelAtPeriodEnd: true},
+			want:   []string{ActionCancellationScheduled, ActionPeriodRolled},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, decidePeriodTransitions(tc.before, tc.after))
+		})
+	}
+}
+
+// TestPeriodTransitionActionsAreDistinct pins the requirement that scheduling
+// a cancellation and reversing one never collapse into a single action string
+// — the reversal is exactly what #701's save offer produces, and an audit
+// trail that cannot tell the two apart is useless for a billing dispute.
+func TestPeriodTransitionActionsAreDistinct(t *testing.T) {
+	require.NotEqual(t, ActionCancellationScheduled, ActionCancellationReversed)
+	require.Equal(t, "subscription.cancellation_scheduled", ActionCancellationScheduled)
+	require.Equal(t, "subscription.cancellation_reversed", ActionCancellationReversed)
+	require.Equal(t, "subscription.period_rolled", ActionPeriodRolled)
+}
+
+// TestPeriodTransitionEvent_NilEmitterSafe proves the event is constructed and
+// handed to a nil *audit.Emitter without panicking — d.emitter is nil in every
+// test wiring and in any deployment that opts out of auditing.
+func TestPeriodTransitionEvent_NilEmitterSafe(t *testing.T) {
+	d := &Dispatcher{emitter: nil}
+	require.NotPanics(t, func() {
+		d.emitPeriodTransitions(
+			periodTransitionContext{Customer: "cus_123"},
+			subscriptionPeriodState{PeriodStart: nil, CancelAtPeriodEnd: false},
+			subscriptionPeriodState{PeriodStart: ts(t, "2026-01-01T00:00:00Z"), CancelAtPeriodEnd: true},
+		)
+	})
+}


### PR DESCRIPTION
Half of #705 — the clean half. There is now a record of when a billing period rolls and when a merchant schedules or reverses a cancellation.

## Why only half

#705 also asks for Stripe-Dashboard-initiated refunds to be written to `refund_audit`. **That is deliberately not here.** `refund_audit` turned out to be a fraud-control table, not a log: migration `000062` puts a UNIQUE index on `card_fingerprint`, and `internal/refund/service.go:128-137` checks it before issuing a refund and rejects one when the card already has a row.

So a webhook writing there would make a Dashboard refund silently consume that card's only allowed refund, causing the next legitimate admin refund to be rejected as fraud. The issue wants observability; that change would alter refund policy. Three options are recorded on #705; that half stays open pending a choice.

## The design point the issue missed

The existing `UPDATE` in `handleSubscriptionUpdated` is **blind** — it writes new values without reading the old ones. Stripe emits `customer.subscription.updated` for many reasons, so emitting unconditionally would produce one event per webhook rather than one per transition. That is noise, and it would make the audit trail less useful rather than more.

This reads the prior row in the same transaction and emits only on a real change.

## What changed

- `handleSubscriptionUpdated` is now a method on `*Dispatcher`. It was a free function, which is the structural reason the original `TODO(P3)` was never done — a free function has no `d.emitter`. `Handler` is `func(ctx, tx, raw) error` and the dispatcher already binds methods, so registration is a one-line change.
- New `subscription_updated_audit.go` holds three distinct actions — `subscription.cancellation_scheduled`, `subscription.cancellation_reversed`, `subscription.period_rolled` — plus `decidePeriodTransitions(before, after)`, a pure function with no DB and no Dispatcher, which is the unit-testable seam.
- Scheduling a cancellation and reversing one are **separate actions**, not one flag-changed event. That distinction is the point: it is what makes "did this merchant cancel and then reverse?" answerable, and it is what #701's save-offer path needs.

Behaviour preserved exactly: same UPDATE, same error wrapping, same missing-customer and unmarshal errors. A webhook for an unknown customer still updates zero rows, returns nil, and emits nothing.

## Judgement calls worth a reviewer's eye

- **`nil` -> a value counts as a roll.** The first period start ever recorded is treated as a transition. It happens once per subscription, so it is not a noise source, but the action reads `period_rolled` for what is really "period established". Easy to silence if you would rather.
- **An absent `current_period_start`, and one moving backwards, both emit nothing** — Stripe omits the field on some replays, and an out-of-order delivery must not manufacture a roll.
- **One webhook can emit two events** (cancel flag plus roll) rather than one merged event.

## Testing

Every pre-existing test file in this package is `//go:build integration`, so an untagged `go test` runs none of them, and `TEST_DATABASE_URL` is unset locally — they would skip silently and still print `ok`. The new tests are untagged and genuinely execute:

- `TestDecidePeriodTransitions` — 8 subtests including **identical values emit nothing** (the common case, and the one that matters most), absent start, backwards start, and roll + cancel together
- `TestPeriodTransitionActionsAreDistinct` — pins scheduled != reversed
- `TestPeriodTransitionEvent_NilEmitterSafe` — no panic on a nil emitter

**Not proven by an executing test:** the "no matching row" path needs a real database. It is guarded by an explicit flag rather than by inference and `go vet -tags integration` passes, but treat it as reviewed rather than proven until CI's integration job runs.

`go build ./...`, `go vet` (including `-tags integration`), `go test -count=1`, and `gofmt -l` all clean.

Refs #705.
