### PR TITLE
fix(onboarding): treat a replayed verification link as success when the session is already verified

### DIFF
--- a/services/platform-api/internal/onboarding/handler.go
+++ b/services/platform-api/internal/onboarding/handler.go
@@ -2,6 +2,7 @@ package onboarding
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -117,6 +118,24 @@ func (h *Handler) verifyAndMarkSession(c *gin.Context) {
 	}
 	res, err := h.verifSvc.VerifyToken(c.Request.Context(), req.Token)
 	if err != nil {
+		// A replayed link is not a failure when the first open worked.
+		// Mail clients and security scanners prefetch URLs and users
+		// double-click, so a second open is ordinary traffic — and the
+		// failure page it used to render offers "Start over", which would
+		// discard a session that had already progressed (#710).
+		//
+		// Success here is narrow on purpose: the token must be consumed AND
+		// still unexpired (ResolveReplay enforces that), and the session it
+		// belongs to must ALREADY be verified. A consumed token whose
+		// session is not verified is a genuinely dead link and still fails.
+		if replay, ok := h.resolveVerifiedReplay(c, req.Token, err); ok {
+			c.JSON(http.StatusOK, gin.H{"data": gin.H{
+				"verified":   true,
+				"session_id": replay.SessionID,
+				"email":      replay.Email,
+			}})
+			return
+		}
 		respondError(c, err)
 		return
 	}
@@ -129,6 +148,33 @@ func (h *Handler) verifyAndMarkSession(c *gin.Context) {
 		"session_id": res.SessionID,
 		"email":      res.Email,
 	}})
+}
+
+// resolveVerifiedReplay reports whether verifyErr is a consumed-token error
+// for a link whose session is already verified — i.e. a harmless replay of a
+// link that worked. Returns the session tuple to answer with when so.
+//
+// Any doubt resolves to false, so the caller falls through to the original
+// error: an unrelated error, a token that resolves to nothing, or a session
+// that is not actually verified all keep the failure page. This only ever
+// converts a failure into a success, never the reverse, so being strict here
+// costs a user nothing beyond the page they would have seen anyway.
+func (h *Handler) resolveVerifiedReplay(c *gin.Context, token string, verifyErr error) (*verification.VerifyResult, bool) {
+	var ae *apperrors.AppError
+	if !errors.As(verifyErr, &ae) || ae.Code != verification.ErrCodeTokenConsumed {
+		return nil, false
+	}
+
+	replay, err := h.verifSvc.ResolveReplay(c.Request.Context(), token)
+	if err != nil {
+		return nil, false
+	}
+
+	sess, err := h.svc.Get(c.Request.Context(), replay.SessionID)
+	if err != nil || sess == nil || sess.EmailVerifiedAt == nil {
+		return nil, false
+	}
+	return replay, true
 }
 
 func (h *Handler) completeSession(c *gin.Context) {

--- a/services/platform-api/internal/onboarding/verify_replay_handler_test.go
+++ b/services/platform-api/internal/onboarding/verify_replay_handler_test.go
@@ -1,0 +1,133 @@
+package onboarding
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/platform-api/internal/notification"
+	"github.com/mark8ly/platform-api/internal/verification"
+	apperrors "github.com/mark8ly/platform-api/pkg/errors"
+)
+
+// replaySessionRepo is a Repository whose only interesting behaviour is
+// GetByID; the rest satisfy the interface.
+type replaySessionRepo struct{ sess *Session }
+
+func (r *replaySessionRepo) Create(context.Context, *Session) error { return nil }
+func (r *replaySessionRepo) GetByID(_ context.Context, id string) (*Session, error) {
+	if r.sess == nil || r.sess.ID != id {
+		return nil, apperrors.NotFound("session_not_found", "no such session")
+	}
+	return r.sess, nil
+}
+func (r *replaySessionRepo) UpdateDraft(context.Context, string, json.RawMessage) error { return nil }
+func (r *replaySessionRepo) MarkEmailVerified(context.Context, string) error            { return nil }
+func (r *replaySessionRepo) CompleteInTx(context.Context, *gorm.DB, string, string) error {
+	return nil
+}
+func (r *replaySessionRepo) GetFunnel(context.Context, FunnelFilter) (*FunnelStats, error) {
+	return &FunnelStats{}, nil
+}
+func (r *replaySessionRepo) ListSessions(context.Context, FunnelFilter) ([]SessionRow, int64, error) {
+	return nil, 0, nil
+}
+
+// replayTokenRepo serves one already-consumed, unexpired token.
+type replayTokenRepo struct{ tok *verification.Token }
+
+func (r *replayTokenRepo) Create(context.Context, *verification.Token) error { return nil }
+func (r *replayTokenRepo) GetByHash(_ context.Context, hash string) (*verification.Token, error) {
+	if r.tok == nil || r.tok.CodeHash != hash {
+		return nil, apperrors.NotFound("token_not_found", "verification link is invalid or expired")
+	}
+	return r.tok, nil
+}
+func (r *replayTokenRepo) MarkConsumed(context.Context, string) error         { return nil }
+func (r *replayTokenRepo) InvalidateForSession(context.Context, string) error { return nil }
+
+type noopSender struct{}
+
+func (noopSender) Send(context.Context, notification.Email) error { return nil }
+
+// postVerify drives the real route with a consumed token, for a session in
+// the given verified state, and returns the response.
+func postVerify(t *testing.T, sessionVerified bool) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	// Mint the token the way the service does: the stored value is the
+	// hex SHA-256 of the raw token, so the test can build the pair itself
+	// without exporting production helpers just for a test.
+	raw := "replay-token-fixture-not-a-real-credential"
+	sum := sha256.Sum256([]byte(raw))
+	hash := hex.EncodeToString(sum[:])
+	now := time.Now()
+	tokRepo := &replayTokenRepo{tok: &verification.Token{
+		ID: "tok-1", SessionID: "sess-1", Email: "user@example.com",
+		CodeHash: hash, ExpiresAt: now.Add(verification.TokenLifetime), ConsumedAt: &now,
+	}}
+
+	sess := &Session{ID: "sess-1", Email: "user@example.com"}
+	if sessionVerified {
+		sess.EmailVerifiedAt = &now
+	}
+
+	h := NewHandler(
+		NewService(Config{Repo: &replaySessionRepo{sess: sess}}),
+		verification.NewService(tokRepo, verification.Config{
+			Sender: noopSender{}, EmailFrom: "n@m.com",
+			SupportEmail: "h@m.com", VerifyURLBase: "https://o.test",
+		}),
+	)
+
+	r := gin.New()
+	h.Register(r.Group(""))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/onboarding/verify-token",
+		strings.NewReader(`{"token":"`+raw+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// #710: opening a verification link a second time rendered a failure page
+// ("We couldn't verify your link") with a "Start over" button that would
+// discard a session which had already progressed. Mail scanners and users
+// both replay links, so this is ordinary traffic, not misuse.
+func TestReplayOfAConsumedLinkSucceedsWhenTheSessionIsVerified(t *testing.T) {
+	rec := postVerify(t, true)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data struct {
+			Verified  bool   `json:"verified"`
+			SessionID string `json:"session_id"`
+			Email     string `json:"email"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.True(t, body.Data.Verified)
+	require.Equal(t, "sess-1", body.Data.SessionID)
+	require.Equal(t, "user@example.com", body.Data.Email)
+}
+
+// The boundary. A consumed token whose session was never verified is a
+// genuinely dead link and must keep failing — otherwise this change would
+// hand a session id and email to anyone replaying a spent token.
+func TestReplayStillFailsWhenTheSessionIsNotVerified(t *testing.T) {
+	rec := postVerify(t, false)
+	require.NotEqual(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "token_consumed")
+}

--- a/services/platform-api/internal/verification/replay_test.go
+++ b/services/platform-api/internal/verification/replay_test.go
@@ -1,0 +1,122 @@
+package verification
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	apperrors "github.com/mark8ly/platform-api/pkg/errors"
+)
+
+// issueAndConsume returns a token that has been through VerifyToken once,
+// i.e. exactly the state a replayed magic link is in.
+func issueAndConsume(t *testing.T, repo *fakeRepo) string {
+	t.Helper()
+	// The raw token is only recoverable from the emailed link, so mint one
+	// directly and store it in the state SendMagicLink + VerifyToken leave
+	// behind: present, unexpired, already consumed.
+	raw, hash, err := generateToken()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	now := time.Now()
+	repo.tokens[hash] = &Token{
+		ID:         "tok-replay",
+		SessionID:  "sess-1",
+		Email:      "user@example.com",
+		CodeHash:   hash,
+		ExpiresAt:  now.Add(TokenLifetime),
+		ConsumedAt: &now,
+	}
+	return raw
+}
+
+func TestResolveReplay_ReturnsSessionForAConsumedTokenStillInDate(t *testing.T) {
+	repo := newFakeRepo()
+	svc := newService(repo, &captureSender{})
+	raw := issueAndConsume(t, repo)
+
+	res, err := svc.ResolveReplay(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("ResolveReplay: %v", err)
+	}
+	if res.SessionID != "sess-1" || res.Email != "user@example.com" {
+		t.Errorf("got %+v, want sess-1/user@example.com", res)
+	}
+}
+
+// The boundary the issue did not ask for, and the reason this method
+// enforces expiry: without it a spent 10-minute credential would answer
+// with a session id and email forever, to anyone who later found the URL
+// in a log, a browser history, or a scanner cache.
+func TestResolveReplay_RefusesAConsumedTokenPastItsExpiry(t *testing.T) {
+	repo := newFakeRepo()
+	svc := newService(repo, &captureSender{})
+	raw, hash, err := generateToken()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	consumed := time.Now().Add(-2 * TokenLifetime)
+	repo.tokens[hash] = &Token{
+		ID:         "tok-old",
+		SessionID:  "sess-1",
+		Email:      "user@example.com",
+		CodeHash:   hash,
+		ExpiresAt:  time.Now().Add(-TokenLifetime), // already lapsed
+		ConsumedAt: &consumed,
+	}
+
+	_, err = svc.ResolveReplay(context.Background(), raw)
+	var ae *apperrors.AppError
+	if !errors.As(err, &ae) || ae.Code != "token_expired" {
+		t.Fatalf("err = %v, want token_expired", err)
+	}
+}
+
+func TestResolveReplay_RefusesATokenThatWasNeverConsumed(t *testing.T) {
+	repo := newFakeRepo()
+	svc := newService(repo, &captureSender{})
+	raw, hash, err := generateToken()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	repo.tokens[hash] = &Token{
+		ID: "tok-fresh", SessionID: "sess-1", Email: "user@example.com",
+		CodeHash: hash, ExpiresAt: time.Now().Add(TokenLifetime),
+	}
+
+	if _, err := svc.ResolveReplay(context.Background(), raw); err == nil {
+		t.Fatal("want error for an unconsumed token, got nil")
+	}
+}
+
+func TestResolveReplay_NeverMutates(t *testing.T) {
+	repo := newFakeRepo()
+	svc := newService(repo, &captureSender{})
+	raw := issueAndConsume(t, repo)
+
+	before := *repo.tokens[hashToken(raw)]
+	if _, err := svc.ResolveReplay(context.Background(), raw); err != nil {
+		t.Fatalf("ResolveReplay: %v", err)
+	}
+	after := *repo.tokens[hashToken(raw)]
+
+	if !before.ConsumedAt.Equal(*after.ConsumedAt) || !before.ExpiresAt.Equal(after.ExpiresAt) {
+		t.Error("ResolveReplay mutated the token; it must be read-only")
+	}
+}
+
+func TestVerifyTokenStillRefusesAReplay(t *testing.T) {
+	// ResolveReplay is additive. VerifyToken itself must keep failing on a
+	// consumed token, so nothing can be verified twice.
+	repo := newFakeRepo()
+	svc := newService(repo, &captureSender{})
+	raw := issueAndConsume(t, repo)
+
+	_, err := svc.VerifyToken(context.Background(), raw)
+	var ae *apperrors.AppError
+	if !errors.As(err, &ae) || ae.Code != ErrCodeTokenConsumed {
+		t.Fatalf("err = %v, want %s", err, ErrCodeTokenConsumed)
+	}
+}

--- a/services/platform-api/internal/verification/service.go
+++ b/services/platform-api/internal/verification/service.go
@@ -210,6 +210,48 @@ func (s *Service) VerifyToken(ctx context.Context, token string) (*VerifyResult,
 	}, nil
 }
 
+// ErrCodeTokenConsumed is the AppError code VerifyToken returns for a link
+// that has already been used. Named so callers can recognise a replay
+// without string-matching at each call site.
+const ErrCodeTokenConsumed = "token_consumed"
+
+// ResolveReplay returns the (sessionID, email) behind a token that has
+// ALREADY been consumed but is still inside its lifetime.
+//
+// It exists so a caller can tell a *replayed* link apart from a dead one.
+// Opening a verification link twice is ordinary: mail clients and security
+// scanners prefetch URLs, and users double-click. The second open must not
+// be presented as a failure when the first one succeeded (#710).
+//
+// It deliberately still enforces expiry, which the issue did not ask for.
+// Without that, a consumed token would resolve to a session id and email
+// FOREVER — turning a spent, 10-minute credential into a permanent one that
+// answers questions about an onboarding session to anyone who later finds it
+// in a log, a browser history, or a mail scanner's cache. Honouring
+// ExpiresAt keeps the replay window the same window the token always had.
+//
+// Returns the same errors as VerifyToken, plus a NotFound-equivalent when the
+// token was never consumed (the caller should use VerifyToken for that case).
+// It NEVER consumes, marks, or mutates anything.
+func (s *Service) ResolveReplay(ctx context.Context, token string) (*VerifyResult, error) {
+	if token == "" {
+		return nil, apperrors.BadRequest("invalid_token", "token is required")
+	}
+
+	tok, err := s.repo.GetByHash(ctx, hashToken(token))
+	if err != nil {
+		return nil, err
+	}
+	if tok.ConsumedAt == nil {
+		return nil, apperrors.BadRequest("token_not_consumed", "this token has not been used")
+	}
+	if time.Now().After(tok.ExpiresAt) {
+		return nil, apperrors.BadRequest("token_expired", "this verification link has expired; please request a new one")
+	}
+
+	return &VerifyResult{SessionID: tok.SessionID, Email: tok.Email}, nil
+}
+
 // generateToken returns a (token, hash) pair where:
 //   - token is 32 random bytes base64url-encoded (URL-safe, ~43 chars)
 //   - hash is the SHA-256 of the token, hex-encoded for DB storage


### PR DESCRIPTION
Closes #710.

Opening a verification link twice rendered *"We couldn't verify your link —
token_consumed"* next to a **"Start over"** button that would have discarded a
session which had already progressed. The first open had succeeded and nothing
was wrong.

As the issue says, this needs no careless user: mail clients and security
scanners prefetch URLs, and people double-click. It is ordinary traffic being
presented as a failure, beside a destructive button.

### Behaviour

A replay now succeeds — but narrowly. All three must hold:

1. the failure is specifically `token_consumed` (any other error falls through
   unchanged);
2. the token is consumed **and still inside its 10-minute lifetime**; and
3. the session it belongs to is **already verified**.

A consumed token whose session was never verified is a genuinely dead link and
still fails, which is the case that keeps this from being a way to fish for
session data with a spent token.

### One thing I added that the issue did not ask for

The issue's suggested check was "consumed **but** session verified". Implemented
literally, a consumed token would resolve to a session id and email **forever** —
turning a spent, deliberately short-lived credential into a permanent one that
answers questions to anyone who later finds the URL in a log, a browser history,
or a scanner's cache.

So `ResolveReplay` still enforces `ExpiresAt`. The replay window stays exactly
the window the token always had (`TokenLifetime` = 10 minutes), which comfortably
covers the real scenario — the report's own replay was **34 seconds** later —
without creating a credential that outlives its own expiry. Flagging it because
it is a deliberate deviation from the issue text, not an oversight.

### Shape

- `verification.ResolveReplay` — read-only lookup of a consumed-but-unexpired
  token. It never consumes, marks, or mutates anything, and there is a test
  asserting exactly that.
- `verification.ErrCodeTokenConsumed` — so callers recognise a replay without
  string-matching at each site.
- `onboarding.resolveVerifiedReplay` — the decision, kept out of the handler
  body. Any doubt resolves to *false* and falls through to the original error,
  so it can only ever turn a failure into a success, never the reverse.

`VerifyToken` is untouched and still refuses a consumed token, so nothing can be
verified twice; there is a test pinning that too. The success payload is
byte-identical to a first-time verification, so `apps/onboarding` needs no
change.

### Verification

- `go build ./...`, `go vet`, `gofmt` — clean
- `go test ./internal/onboarding/ ./internal/verification/` — ok
- 7 new tests: replay succeeds; **replay past expiry refused**; unconsumed token
  refused; ResolveReplay never mutates; VerifyToken still refuses a replay;
  handler replay succeeds when verified; **handler replay still fails when the
  session is not verified**
- Non-vacuity proven: disabling the handler branch makes
  `TestReplayOfAConsumedLinkSucceedsWhenTheSessionIsVerified` fail, then restored
