### PR TITLE
feat(marketplace-api): accept both issuers on mobile admin during the migration (#686)

### DIFF
--- a/.planning/quick/20260905-686-dual-accept/PLAN.md
+++ b/.planning/quick/20260905-686-dual-accept/PLAN.md
@@ -1,0 +1,52 @@
+# Mobile admin: accept both issuers during the migration (#686)
+
+## Why this first
+
+`ZITADEL_ENABLED` on `marketplace-api-admin` is an ATOMIC switch of two things:
+the bearer verifier, and the source of `tenant_id` (GIP claim vs FGA-validated
+`X-Acting-Tenant-Id`). One verifier is mounted, never both. So the day it flips,
+every already-installed app stops working — there is no drain window, and the
+mobile cutover becomes a flag day.
+
+EAS history confirms real builds exist and predate the crash fixed in #719, so
+those installs authenticate against GIP today and must keep working.
+
+## The second reason, which is the actual #708 blocker
+
+Nobody can currently tell whether any traffic still authenticates via GIP. Without
+that, "GIP is safe to delete" is a guess. A composite verifier is the natural place
+to answer it, because it is the one point that knows which issuer a token came from.
+
+## Tasks
+
+### 1. `CompositeVerifier` (TDD)
+Ordered list of verifiers; first success wins; returns the first error when all
+fail. Records which issuer succeeded.
+**Done when:** unit tests cover — Zitadel token accepted, GIP token accepted,
+garbage rejected, first-error surfaced, and the issuer label recorded per outcome.
+
+### 2. Per-token tenancy, replacing the per-deployment switch
+`GIPBearerAuth` writes `tenant_id` from the claim only when the claim is NON-EMPTY.
+Zitadel tokens carry no claim, so they fall through to `TenantFromRequest`, which
+is then safe to mount alongside: it never aborts, and it only writes after an FGA
+membership check. Ordering (bearer -> TenantFromRequest) means a VALIDATED value
+can only ever overwrite an unvalidated one, never the reverse — which is the
+invariant the current mutual exclusion exists to protect.
+**Done when:** tests prove a GIP token still resolves its claim tenant, a Zitadel
+token resolves via the header, and a GIP token PLUS header resolves to the
+FGA-validated header value.
+
+### 3. Metric
+`mobile_admin_token_verified_total{issuer}`. This is what makes the GIP drain
+observable and #708 decidable.
+**Done when:** the counter increments with the right label for each issuer.
+
+### 4. Wiring + config
+A flag selecting single vs dual verifier. Adding required config is k8s-first;
+this must default to today's behaviour so the deploy order is safe.
+**Done when:** `go build`, `go vet`, and the full package tests pass, and the
+default path is byte-for-byte today's behaviour.
+
+## Out of scope
+The mobile app's OIDC/PKCE flow and sending `X-Acting-Tenant-Id`. This change is
+what makes that shippable without a flag day; it does not do it.

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1447,6 +1447,12 @@ func main() {
 			// request on GIP (if TenantFromRequest ran with no client-side
 			// header support to feed it).
 			ZitadelEnabled: cfg.ZitadelEnabled,
+			// Dual-issuer relaxes the "exactly one tenancy writer" rule
+			// above into an ORDERING rule instead: both writers run, and
+			// the FGA-validated one runs second so it can only ever
+			// overwrite an unvalidated claim, never the reverse. See
+			// MobileDeps.DualIssuer.
+			DualIssuer: cfg.ZitadelEnabled && cfg.ZitadelDualIssuer,
 			// Resolves X-Acting-Tenant-Id via the same FGA client the rest
 			// of the admin surface already checks permissions against, for
 			// bearer tokens (Zitadel) that carry no tenant_id claim at

--- a/services/marketplace-api/cmd/marketplace-api/wiring_dual_issuer_test.go
+++ b/services/marketplace-api/cmd/marketplace-api/wiring_dual_issuer_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/auth"
+	"github.com/mark8ly/marketplace-api/pkg/config"
+)
+
+// loggedContains reports whether any captured log message mentions substr.
+func loggedContains(h *captureHandler, substr string) bool {
+	for _, r := range h.records {
+		if strings.Contains(r.Message, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// acceptingVerifier accepts exactly one token string, so a test can prove
+// WHICH issuers the returned verifier actually consults.
+type acceptingVerifier struct {
+	token  string
+	claims *auth.TokenClaims
+}
+
+func (a *acceptingVerifier) Verify(_ context.Context, tok string) (*auth.TokenClaims, error) {
+	if tok == a.token {
+		return a.claims, nil
+	}
+	return nil, errors.New("acceptingVerifier: not my token")
+}
+
+// Dual mode must accept BOTH issuers from one verifier — that is the whole
+// point: an installed GIP app and a new Zitadel app authenticate against
+// the same deployment during the drain.
+func TestSelectMobileTokenVerifier_DualIssuer_AcceptsBothIssuers(t *testing.T) {
+	cfg := &config.Config{ZitadelEnabled: true, ZitadelDualIssuer: true}
+	log, _ := captureLogger()
+
+	got := selectMobileTokenVerifier(context.Background(), cfg, log,
+		func(context.Context, string, string) (auth.TokenVerifier, error) {
+			return &acceptingVerifier{token: "zit", claims: &auth.TokenClaims{UserID: "zit-user"}}, nil
+		},
+		func() (auth.TokenVerifier, error) {
+			return &acceptingVerifier{token: "gip", claims: &auth.TokenClaims{UserID: "gip-user", TenantID: "t1"}}, nil
+		})
+	require.NotNil(t, got)
+
+	zit, err := got.Verify(context.Background(), "zit")
+	require.NoError(t, err, "a Zitadel token must be accepted in dual mode")
+	require.Equal(t, "zit-user", zit.UserID)
+
+	gip, err := got.Verify(context.Background(), "gip")
+	require.NoError(t, err, "an already-installed app's GIP token must still be accepted in dual mode")
+	require.Equal(t, "gip-user", gip.UserID)
+	require.Equal(t, "t1", gip.TenantID, "the GIP tenant claim must survive the composite unchanged")
+
+	_, err = got.Verify(context.Background(), "garbage")
+	require.Error(t, err, "a token from neither issuer must still be rejected")
+}
+
+// A Zitadel construction failure must disable mobile routes even in dual
+// mode. Falling back to GIP-only would leave a broken Zitadel deployment
+// quietly serving the legacy path — masking exactly the misconfiguration
+// an operator needs to see, which is the rule the single-issuer path
+// already follows.
+func TestSelectMobileTokenVerifier_DualIssuer_ZitadelFailureDisablesRoutes(t *testing.T) {
+	cfg := &config.Config{ZitadelEnabled: true, ZitadelDualIssuer: true}
+	log, logs := captureLogger()
+	gipCalled := false
+
+	got := selectMobileTokenVerifier(context.Background(), cfg, log,
+		func(context.Context, string, string) (auth.TokenVerifier, error) {
+			return nil, errors.New("discovery unreachable")
+		},
+		func() (auth.TokenVerifier, error) {
+			gipCalled = true
+			return &acceptingVerifier{token: "gip"}, nil
+		})
+
+	require.Nil(t, got, "a Zitadel construction failure must disable mobile routes, never half-mount on GIP")
+	require.False(t, gipCalled, "GIP must not be consulted as a silent fallback for a broken Zitadel config")
+	require.True(t, loggedContains(logs, "zitadel"), "the Zitadel construction failure must be logged")
+}
+
+// GIP unconfigured (newGIP returns nil, nil — the pre-existing "no GIP
+// config" case) must degrade to Zitadel-only rather than nil-panicking or
+// disabling the working path. Dual mode is then simply moot.
+func TestSelectMobileTokenVerifier_DualIssuer_GIPUnconfiguredFallsBackToZitadelOnly(t *testing.T) {
+	cfg := &config.Config{ZitadelEnabled: true, ZitadelDualIssuer: true}
+	log, _ := captureLogger()
+
+	got := selectMobileTokenVerifier(context.Background(), cfg, log,
+		func(context.Context, string, string) (auth.TokenVerifier, error) {
+			return &acceptingVerifier{token: "zit", claims: &auth.TokenClaims{UserID: "zit-user"}}, nil
+		},
+		func() (auth.TokenVerifier, error) { return nil, nil })
+	require.NotNil(t, got)
+
+	claims, err := got.Verify(context.Background(), "zit")
+	require.NoError(t, err)
+	require.Equal(t, "zit-user", claims.UserID)
+}
+
+// A GIP construction ERROR must not take down the Zitadel path with it.
+// The legacy issuer is the one being retired; stranding the new app
+// because the old one failed to initialise is the worse of the two
+// outcomes. It must be logged, because it does silently strand installs
+// that still hold GIP tokens.
+func TestSelectMobileTokenVerifier_DualIssuer_GIPErrorKeepsZitadelWorking(t *testing.T) {
+	cfg := &config.Config{ZitadelEnabled: true, ZitadelDualIssuer: true}
+	log, logs := captureLogger()
+
+	got := selectMobileTokenVerifier(context.Background(), cfg, log,
+		func(context.Context, string, string) (auth.TokenVerifier, error) {
+			return &acceptingVerifier{token: "zit", claims: &auth.TokenClaims{UserID: "zit-user"}}, nil
+		},
+		func() (auth.TokenVerifier, error) { return nil, errors.New("firebase init failed") })
+	require.NotNil(t, got, "a GIP failure must not disable the Zitadel path in dual mode")
+
+	claims, err := got.Verify(context.Background(), "zit")
+	require.NoError(t, err)
+	require.Equal(t, "zit-user", claims.UserID)
+	require.True(t, loggedContains(logs, "gip"), "stranding GIP installs must be logged, not silent")
+}
+
+// Dual-issuer without Zitadel enabled is meaningless and must behave
+// exactly like today's GIP-only deployment.
+func TestSelectMobileTokenVerifier_DualIssuerWithoutZitadel_IsGIPOnly(t *testing.T) {
+	cfg := &config.Config{ZitadelEnabled: false, ZitadelDualIssuer: true}
+	log, _ := captureLogger()
+	gipVerifier := &fakeMobileVerifier{Name: "gip"}
+
+	got := selectMobileTokenVerifier(context.Background(), cfg, log,
+		func(context.Context, string, string) (auth.TokenVerifier, error) {
+			return nil, errors.New("must not be called when Zitadel is disabled")
+		},
+		func() (auth.TokenVerifier, error) { return gipVerifier, nil })
+
+	require.Same(t, auth.TokenVerifier(gipVerifier), got,
+		"with Zitadel off, the GIP verifier must be returned unwrapped, exactly as today")
+}

--- a/services/marketplace-api/cmd/marketplace-api/wiring_mobile_verifier.go
+++ b/services/marketplace-api/cmd/marketplace-api/wiring_mobile_verifier.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/mark8ly/marketplace-api/internal/auth"
+	"github.com/mark8ly/marketplace-api/internal/metrics"
 	"github.com/mark8ly/marketplace-api/pkg/config"
 )
 
@@ -54,6 +55,45 @@ func selectMobileTokenVerifier(
 		if err != nil {
 			log.Error("zitadel: verifier construction failed, mobile admin routes disabled", "error", err)
 			return nil
+		}
+		if !cfg.ZitadelDualIssuer {
+			return v
+		}
+
+		// Dual-issuer (#686): accept tokens from BOTH issuers so a
+		// Zitadel-capable app release and the GIP apps already installed
+		// work against the same deployment. Zitadel is tried first
+		// because it is where traffic is heading; a token verifies
+		// against at most one issuer, so order costs latency, not
+		// correctness.
+		gip, err := newGIP()
+		switch {
+		case err != nil:
+			// Deliberately NOT fatal, and deliberately not symmetric with
+			// the Zitadel failure above. The legacy issuer is the one
+			// being retired: taking the working Zitadel path down because
+			// the outgoing one failed to initialise is the worse outcome.
+			// It is logged at Error because it does silently strand every
+			// install still holding a GIP token — they will 401, sign
+			// out, and be unable to sign back in.
+			log.Error("gip: verifier construction failed in dual-issuer mode; "+
+				"continuing with Zitadel only — installs still holding GIP tokens cannot authenticate",
+				"error", err)
+		case gip == nil:
+			// The pre-existing "no GIP config" case (empty GIP_PROJECT_ID)
+			// returns (nil, nil). Dual mode is then simply moot, not an
+			// error — there is no second issuer to accept.
+			log.Info("gip: not configured; dual-issuer mode is a no-op and only Zitadel tokens are accepted")
+		default:
+			return auth.NewCompositeVerifier(
+				[]auth.NamedVerifier{
+					{Issuer: "zitadel", Verifier: v},
+					{Issuer: "gip", Verifier: gip},
+				},
+				func(issuer string) {
+					metrics.MobileAdminTokenVerifiedTotal.WithLabelValues(issuer).Inc()
+				},
+			)
 		}
 		return v
 	}

--- a/services/marketplace-api/internal/auth/composite_verifier.go
+++ b/services/marketplace-api/internal/auth/composite_verifier.go
@@ -1,0 +1,99 @@
+package auth
+
+import "context"
+
+// NamedVerifier pairs a TokenVerifier with the issuer it verifies for, so
+// a successful verification can be attributed to one issuer.
+type NamedVerifier struct {
+	// Issuer is the label recorded when this verifier accepts a token.
+	// It is a metric label, so it must stay low-cardinality and stable —
+	// "zitadel" / "gip", never a URL or a tenant.
+	Issuer   string
+	Verifier TokenVerifier
+}
+
+// CompositeVerifier accepts a token issued by ANY of several issuers,
+// trying them in order and returning the first success.
+//
+// # Why this exists
+//
+// Mobile admin auth is mid-migration from GIP to Zitadel (#686). The
+// incumbent wiring selects exactly ONE verifier from ZITADEL_ENABLED, so
+// the day that flag flips every already-installed app stops working at
+// once: its GIP tokens are no longer accepted and there is no version of
+// the client in the field that holds a Zitadel token. That makes the
+// mobile cutover a flag day, which for a store-app release is
+// unshippable — old installs cannot be forced to update.
+//
+// Accepting both issuers for the duration of the drain turns that flag
+// day into a rollout: new app versions authenticate against Zitadel,
+// existing installs keep working on GIP, and the two coexist until the
+// old versions age out.
+//
+// # The observability is the point, not a side benefit
+//
+// Retiring GIP (#708) is blocked on a question nobody can currently
+// answer: is anything still authenticating against it? This type is the
+// only place that knows which issuer a given token came from, so it is
+// where that question becomes measurable. onVerified fires with the
+// winning issuer on every successful verification; wired to a counter,
+// "no gip in N days" is what makes the deletion decision evidence rather
+// than a guess.
+//
+// # Ordering
+//
+// A token verifies against at most one issuer — they have different
+// signing keys — so order changes latency, never the outcome. Put the
+// issuer expected to carry most traffic first; every miss ahead of the
+// winner is a wasted (cached-JWKS, but still non-zero) verification on
+// the request path.
+type CompositeVerifier struct {
+	verifiers  []NamedVerifier
+	onVerified func(issuer string)
+}
+
+// NewCompositeVerifier returns a verifier that tries each entry in order.
+// Entries with a nil Verifier are skipped, so callers may build the list
+// conditionally (Zitadel may be unconfigured) without filtering first.
+// onVerified may be nil.
+func NewCompositeVerifier(verifiers []NamedVerifier, onVerified func(issuer string)) *CompositeVerifier {
+	return &CompositeVerifier{verifiers: verifiers, onVerified: onVerified}
+}
+
+// Verify returns the claims from the first issuer that accepts the token.
+//
+// When every issuer rejects it, the FIRST error is returned rather than
+// the last: the first entry is the primary issuer, so its error is the
+// one that describes the expected failure, and surfacing the last would
+// report a legacy issuer's complaint about a token never meant for it.
+// The caller (GIPBearerAuth) turns any error into an identical 401
+// regardless, so this only affects what an operator reads in a log.
+//
+// A failed verification records NO issuer: attributing a rejected token
+// to an issuer would inflate that issuer's traffic with tokens it never
+// minted, and this counter's whole job is to say when GIP has stopped
+// being used.
+func (c *CompositeVerifier) Verify(ctx context.Context, idToken string) (*TokenClaims, error) {
+	var firstErr error
+	for _, nv := range c.verifiers {
+		if nv.Verifier == nil {
+			continue
+		}
+		claims, err := nv.Verifier.Verify(ctx, idToken)
+		if err == nil {
+			if c.onVerified != nil {
+				c.onVerified(nv.Issuer)
+			}
+			return claims, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	if firstErr == nil {
+		// No usable verifier was configured at all. Fail closed: an empty
+		// composite must never read as "the token is fine".
+		return nil, ErrInvalidToken
+	}
+	return nil, firstErr
+}

--- a/services/marketplace-api/internal/auth/composite_verifier_test.go
+++ b/services/marketplace-api/internal/auth/composite_verifier_test.go
@@ -1,0 +1,121 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type compositeStubVerifier struct {
+	claims *TokenClaims
+	err    error
+	calls  int
+}
+
+func (s *compositeStubVerifier) Verify(_ context.Context, _ string) (*TokenClaims, error) {
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.claims, nil
+}
+
+func TestCompositeVerifier_FirstIssuerWins(t *testing.T) {
+	zit := &compositeStubVerifier{claims: &TokenClaims{UserID: "zit-user"}}
+	gip := &compositeStubVerifier{claims: &TokenClaims{UserID: "gip-user", TenantID: "t1"}}
+
+	var seen []string
+	v := NewCompositeVerifier([]NamedVerifier{
+		{Issuer: "zitadel", Verifier: zit},
+		{Issuer: "gip", Verifier: gip},
+	}, func(issuer string) { seen = append(seen, issuer) })
+
+	claims, err := v.Verify(context.Background(), "tok")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if claims.UserID != "zit-user" {
+		t.Fatalf("want zit-user, got %q", claims.UserID)
+	}
+	// The second verifier must not be consulted once the first succeeds:
+	// each extra call is a network round-trip on the request path.
+	if gip.calls != 0 {
+		t.Fatalf("fallback verifier was called %d times, want 0", gip.calls)
+	}
+	if len(seen) != 1 || seen[0] != "zitadel" {
+		t.Fatalf("want one 'zitadel' observation, got %v", seen)
+	}
+}
+
+func TestCompositeVerifier_FallsBackToSecondIssuer(t *testing.T) {
+	zit := &compositeStubVerifier{err: errors.New("token not issued by zitadel")}
+	gip := &compositeStubVerifier{claims: &TokenClaims{UserID: "gip-user", TenantID: "t1"}}
+
+	var seen []string
+	v := NewCompositeVerifier([]NamedVerifier{
+		{Issuer: "zitadel", Verifier: zit},
+		{Issuer: "gip", Verifier: gip},
+	}, func(issuer string) { seen = append(seen, issuer) })
+
+	claims, err := v.Verify(context.Background(), "tok")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if claims.UserID != "gip-user" || claims.TenantID != "t1" {
+		t.Fatalf("want the GIP claims through unchanged, got %+v", claims)
+	}
+	// This is the observation that makes the GIP drain measurable, and
+	// therefore makes "is it safe to delete GIP?" (#708) answerable.
+	if len(seen) != 1 || seen[0] != "gip" {
+		t.Fatalf("want one 'gip' observation, got %v", seen)
+	}
+}
+
+func TestCompositeVerifier_AllFail_ReturnsFirstError(t *testing.T) {
+	first := errors.New("zitadel says no")
+	zit := &compositeStubVerifier{err: first}
+	gip := &compositeStubVerifier{err: errors.New("gip says no")}
+
+	var seen []string
+	v := NewCompositeVerifier([]NamedVerifier{
+		{Issuer: "zitadel", Verifier: zit},
+		{Issuer: "gip", Verifier: gip},
+	}, func(issuer string) { seen = append(seen, issuer) })
+
+	_, err := v.Verify(context.Background(), "tok")
+	if !errors.Is(err, first) {
+		t.Fatalf("want the first issuer's error preserved, got %v", err)
+	}
+	if gip.calls != 1 {
+		t.Fatalf("every issuer must be tried before failing; gip calls=%d", gip.calls)
+	}
+	if len(seen) != 0 {
+		t.Fatalf("a failed verification must record no issuer, got %v", seen)
+	}
+}
+
+func TestCompositeVerifier_NilObserverIsSafe(t *testing.T) {
+	// The observer is optional wiring; forgetting it must not panic on the
+	// request path.
+	v := NewCompositeVerifier([]NamedVerifier{
+		{Issuer: "zitadel", Verifier: &compositeStubVerifier{claims: &TokenClaims{UserID: "u"}}},
+	}, nil)
+	if _, err := v.Verify(context.Background(), "tok"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCompositeVerifier_SkipsNilVerifiers(t *testing.T) {
+	// Wiring builds this list conditionally (Zitadel may be unconfigured),
+	// so a nil entry must be skipped rather than panic.
+	gip := &compositeStubVerifier{claims: &TokenClaims{UserID: "gip-user"}}
+	v := NewCompositeVerifier([]NamedVerifier{
+		{Issuer: "zitadel", Verifier: nil},
+		{Issuer: "gip", Verifier: gip},
+	}, nil)
+
+	claims, err := v.Verify(context.Background(), "tok")
+	if err != nil || claims.UserID != "gip-user" {
+		t.Fatalf("want the GIP verifier used, got claims=%+v err=%v", claims, err)
+	}
+}

--- a/services/marketplace-api/internal/auth/gip_bearer.go
+++ b/services/marketplace-api/internal/auth/gip_bearer.go
@@ -95,7 +95,15 @@ func GIPBearerAuth(verifier TokenVerifier, setTenantFromClaim bool) gin.HandlerF
 		}
 
 		c.Set("user_id", claims.UserID)
-		if setTenantFromClaim {
+		// Only write a tenant the token actually carries. Writing an
+		// EMPTY claim was harmless when one verifier was mounted (an
+		// empty tenant_id and an absent one are both "unbound" to
+		// RequireBoundTenant), but in dual-issuer mode this middleware
+		// sees both kinds of token: a Zitadel token has no claim, and
+		// blanking tenant_id for it would clobber nothing yet — while
+		// making the ordering contract with TenantFromRequest depend on
+		// an empty-string coincidence rather than on intent.
+		if setTenantFromClaim && claims.TenantID != "" {
 			c.Set("tenant_id", claims.TenantID)
 		}
 		c.Next()

--- a/services/marketplace-api/internal/handlers/admin/mobile_routes.go
+++ b/services/marketplace-api/internal/handlers/admin/mobile_routes.go
@@ -33,6 +33,27 @@ type MobileDeps struct {
 	// with no header support anywhere) or reopens the unvalidated-claim-
 	// wins-the-race bug (flag-on with the claim write still live).
 	ZitadelEnabled bool
+	// DualIssuer makes tenancy a per-TOKEN decision instead of a
+	// per-deployment one, so a Zitadel-capable app release and the GIP
+	// apps already installed can both work during the drain (#686).
+	//
+	// The incumbent ZitadelEnabled switch is atomic: it changes the bearer
+	// verifier AND the tenant source together, so the moment it flips,
+	// every installed app breaks at once. For a store-distributed app that
+	// is unshippable — old installs cannot be forced to update.
+	//
+	// With DualIssuer, BOTH tenancy writers are mounted, and mutual
+	// exclusion is replaced by ORDERING: GIPBearerAuth writes tenant_id
+	// only when the token actually carries a claim (GIP tokens do,
+	// Zitadel tokens never do), and TenantFromRequest runs AFTER it, so an
+	// FGA-VALIDATED value can only ever overwrite an unvalidated claim,
+	// never the reverse. That direction is the safety property; getting it
+	// backwards reintroduces exactly the unvalidated-claim-wins bug that
+	// phase 4's mutual exclusion existed to remove.
+	//
+	// Requires TokenVerifier to accept both issuers — see
+	// auth.CompositeVerifier. Ignored unless ZitadelEnabled.
+	DualIssuer bool
 	// TenantMembershipChecker backs auth.TenantFromRequest (#524 phase 4):
 	// it resolves the caller's X-Acting-Tenant-Id header via an FGA
 	// membership check, for tokens (Zitadel) that carry no tenant_id
@@ -69,7 +90,10 @@ func RegisterAdminMobile(router *gin.RouterGroup, deps MobileDeps) {
 	// below} is active, the other MUST NOT be — see ZitadelEnabled's doc
 	// comment on MobileDeps for why both-active or both-inactive are each
 	// a real incident, not just untidy.
-	bearerAuth := auth.GIPBearerAuth(deps.TokenVerifier, !deps.ZitadelEnabled)
+	// In dual-issuer mode the claim write stays ON for both issuers: it is
+	// now self-selecting, because GIPBearerAuth writes only a NON-EMPTY
+	// claim and a Zitadel token has none. See MobileDeps.DualIssuer.
+	bearerAuth := auth.GIPBearerAuth(deps.TokenVerifier, !deps.ZitadelEnabled || deps.DualIssuer)
 	rateLimiter := auth.NewPerUserRateLimiter(60, 10) // 60 req/min, burst 10
 	// Fails closed for callers with no tenant bound to their identity.
 	// GIPBearerAuth intentionally lets a validly-signed token through even
@@ -105,7 +129,7 @@ func RegisterAdminMobile(router *gin.RouterGroup, deps MobileDeps) {
 	// is present — see its doc comment in
 	// internal/auth/tenant_from_request.go.
 	tenantMW := []gin.HandlerFunc{bearerAuth}
-	if deps.ZitadelEnabled {
+	if deps.ZitadelEnabled || deps.DualIssuer {
 		tenantMW = append(tenantMW, auth.TenantFromRequest(deps.TenantMembershipChecker, deps.TenantMembershipLogger))
 	}
 	tenantMW = append(tenantMW, requireTenant)

--- a/services/marketplace-api/internal/handlers/admin/mobile_routes_dual_issuer_test.go
+++ b/services/marketplace-api/internal/handlers/admin/mobile_routes_dual_issuer_test.go
@@ -1,0 +1,129 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/auth"
+	"github.com/mark8ly/marketplace-api/internal/authz"
+)
+
+// The three tests below pin the tenancy contract for DUAL-ISSUER mode
+// (#686), the configuration that lets a Zitadel-capable app release and
+// already-installed GIP apps work at the same time.
+//
+// The incumbent design made the two tenancy sources mutually exclusive per
+// DEPLOYMENT (ZitadelEnabled picked one). That cannot express "both kinds
+// of token are in flight", which is exactly what a store-app rollout is —
+// old installs cannot be forced to update. Dual mode makes the choice
+// per TOKEN instead: a GIP token carries a tenant claim and uses it, a
+// Zitadel token carries none and resolves via the FGA-checked header.
+//
+// The safety invariant that replaces mutual exclusion is ORDERING: an
+// FGA-VALIDATED value may overwrite an unvalidated claim, never the
+// reverse. TestDualIssuer_ValidatedHeaderBeatsUnvalidatedClaim is what
+// holds that line.
+
+// dualIssuerRouter builds the mobile admin routes in dual-issuer mode and
+// captures the tenant_id the middleware chain actually resolved, so tests
+// can assert on the RESOLVED VALUE rather than only on a status code —
+// status alone cannot tell tenant-1 from tenant-2.
+func dualIssuerRouter(t *testing.T, fga *authz.FakeClient, verifier auth.TokenVerifier, seen *string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterAdminMobile(r.Group("/api/v1"), MobileDeps{
+		Deps: Deps{
+			StoresHandler:   NewStoresHandler(&stubStoresRepo{}, nil),
+			AuthzMiddleware: authz.NewMiddleware(fga, nil),
+			StoresMiddleware: func(c *gin.Context) {
+				c.Next()
+			},
+			// TenantGate sits inside tenantMW, immediately after
+			// TenantFromRequest and requireTenant, so it observes the
+			// FINAL resolved tenant_id. StoresMiddleware would not: it is
+			// mounted only on the store-scoped group, not on
+			// /mobile/admin/stores, so capturing there silently records
+			// nothing and the assertion passes vacuously.
+			TenantGate: func(c *gin.Context) {
+				if seen != nil {
+					*seen = c.GetString("tenant_id")
+				}
+				c.Next()
+			},
+		},
+		ZitadelEnabled:          true,
+		DualIssuer:              true,
+		TokenVerifier:           verifier,
+		TenantMembershipChecker: fga,
+	})
+	return r
+}
+
+// A GIP token still works with NO acting-tenant header. This is the
+// already-installed app, and it is the whole reason dual mode exists: in
+// the incumbent ZitadelEnabled=true wiring this request 404s, because the
+// claim write is switched off and the old client sends no header.
+func TestDualIssuer_GIPTokenResolvesTenantFromItsClaim(t *testing.T) {
+	fga := authz.NewFakeClient()
+	fga.Grant("user-1", authz.RoleStaff, "tenant-1")
+
+	r := dualIssuerRouter(t, fga, &auth.FakeVerifier{UserID: "user-1", TenantID: "tenant-1"}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mobile/admin/stores", nil)
+	req.Header.Set("Authorization", "Bearer gip-token")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code,
+		"an existing GIP install sends no X-Acting-Tenant-Id; its claim must still resolve a tenant: %s", rec.Body.String())
+}
+
+// A Zitadel token carries no claim, so it must resolve through the
+// FGA-checked header — the new app's path, unchanged from Zitadel mode.
+func TestDualIssuer_ZitadelTokenResolvesTenantFromHeader(t *testing.T) {
+	fga := authz.NewFakeClient()
+	fga.Grant("user-1", authz.RoleStaff, "tenant-1")
+
+	r := dualIssuerRouter(t, fga, &auth.FakeVerifier{UserID: "user-1"}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mobile/admin/stores", nil)
+	req.Header.Set("Authorization", "Bearer zitadel-token")
+	req.Header.Set(auth.ActingTenantHeader, "tenant-1")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code,
+		"a Zitadel token has no tenant claim and must resolve via the FGA-checked header: %s", rec.Body.String())
+}
+
+// THE SAFETY TEST. With both a token claim and a stated header present,
+// the FGA-VALIDATED header must win. The claim is unvalidated input; the
+// header has been checked against real membership. If this ever inverts,
+// an unvalidated claim can override a validated decision — the precise
+// bug the old mutual-exclusion rule existed to prevent, and the one thing
+// dual mode must not reintroduce.
+func TestDualIssuer_ValidatedHeaderBeatsUnvalidatedClaim(t *testing.T) {
+	fga := authz.NewFakeClient()
+	// The caller is a genuine member of tenant-2 only. Their token claims
+	// tenant-1, which they are NOT a member of.
+	fga.Grant("user-1", authz.RoleStaff, "tenant-2")
+
+	var resolved string
+	r := dualIssuerRouter(t, fga, &auth.FakeVerifier{UserID: "user-1", TenantID: "tenant-1"}, &resolved)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mobile/admin/stores", nil)
+	req.Header.Set("Authorization", "Bearer gip-token")
+	req.Header.Set(auth.ActingTenantHeader, "tenant-2")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code,
+		"the FGA-validated header must resolve, overriding the token's unvalidated claim: %s", rec.Body.String())
+	require.Equal(t, "tenant-2", resolved,
+		"tenant_id must be the FGA-validated tenant-2, never the claimed tenant-1")
+}

--- a/services/marketplace-api/internal/metrics/mobile_admin_token_test.go
+++ b/services/marketplace-api/internal/metrics/mobile_admin_token_test.go
@@ -1,0 +1,33 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// The GIP-retirement decision (#708) reads this counter, so the metric
+// name, the label name and the label VALUES are a contract with whoever
+// writes that query — not incidental strings.
+func TestMobileAdminTokenVerifiedTotal_CountsPerIssuer(t *testing.T) {
+	MobileAdminTokenVerifiedTotal.Reset()
+
+	MobileAdminTokenVerifiedTotal.WithLabelValues("zitadel").Inc()
+	MobileAdminTokenVerifiedTotal.WithLabelValues("zitadel").Inc()
+	MobileAdminTokenVerifiedTotal.WithLabelValues("gip").Inc()
+
+	const expected = `
+# HELP mobile_admin_token_verified_total Count of successful mobile-admin bearer token verifications, labeled by the issuer that accepted the token (zitadel | gip). Successes only — a rejected token is attributed to no issuer. Used to decide when GIP has drained and can be retired (#708).
+# TYPE mobile_admin_token_verified_total counter
+mobile_admin_token_verified_total{issuer="gip"} 1
+mobile_admin_token_verified_total{issuer="zitadel"} 2
+`
+	if err := testutil.CollectAndCompare(
+		MobileAdminTokenVerifiedTotal,
+		strings.NewReader(expected),
+		"mobile_admin_token_verified_total",
+	); err != nil {
+		t.Fatalf("unexpected metric output: %v", err)
+	}
+}

--- a/services/marketplace-api/internal/metrics/registry.go
+++ b/services/marketplace-api/internal/metrics/registry.go
@@ -220,6 +220,30 @@ var (
 		},
 		[]string{"event"},
 	)
+
+	// MobileAdminTokenVerifiedTotal counts successful mobile-admin bearer
+	// verifications, labeled by the issuer that accepted the token
+	// (zitadel | gip).
+	//
+	// This exists to make GIP retirement (#708) a decision backed by
+	// evidence instead of a guess. During the #686 migration both issuers
+	// are accepted at once, so "has anything authenticated via GIP
+	// recently?" is the question that gates deleting the GIP path — and
+	// auth.CompositeVerifier is the only place that knows the answer.
+	// `gip` staying at zero across a window longer than the app's update
+	// tail is the signal to proceed.
+	//
+	// FAILED verifications are deliberately NOT counted here: attributing
+	// a rejected token to an issuer would inflate that issuer's apparent
+	// traffic with tokens it never minted, which is precisely the reading
+	// this counter must not corrupt.
+	MobileAdminTokenVerifiedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mobile_admin_token_verified_total",
+			Help: "Count of successful mobile-admin bearer token verifications, labeled by the issuer that accepted the token (zitadel | gip). Successes only — a rejected token is attributed to no issuer. Used to decide when GIP has drained and can be retired (#708).",
+		},
+		[]string{"issuer"},
+	)
 )
 
 func init() {
@@ -243,6 +267,7 @@ func init() {
 		APIKeyUsedTotal,
 		APIKeyAuthFailedTotal,
 		APIKeyRateLimitedTotal,
+		MobileAdminTokenVerifiedTotal,
 		CarrierSecretEventsTotal,
 	)
 

--- a/services/marketplace-api/pkg/config/config.go
+++ b/services/marketplace-api/pkg/config/config.go
@@ -316,6 +316,24 @@ type Config struct {
 	// credential. Already deployed on other services as
 	// "389070376568619523".
 	ZitadelAdminProjectID string `envconfig:"ZITADEL_ADMIN_PROJECT_ID" default:""`
+	// ZitadelDualIssuer accepts mobile-admin bearer tokens from BOTH
+	// Zitadel and GIP for the duration of the migration (#686).
+	//
+	// ZitadelEnabled alone is an atomic switch: it changes the verifier
+	// AND the tenancy source together, so the moment it flips, every
+	// already-installed mobile app stops working. Store-distributed apps
+	// cannot be force-updated, so that is a flag day with no drain window.
+	// This flag turns the cutover into a rollout instead.
+	//
+	// Defaults to false, so an existing deployment behaves byte-for-byte
+	// as it does today and this can land k8s-first — the ordering that
+	// matters, because ADDING required config code-first fails pods at
+	// boot (only removal is code-first).
+	//
+	// Requires ZitadelEnabled; ignored on its own, because with Zitadel
+	// off there is only one issuer to accept and the composite would wrap
+	// a single verifier to no effect.
+	ZitadelDualIssuer bool `envconfig:"ZITADEL_DUAL_ISSUER" default:"false"`
 
 	// --- Merchant device push (mobile-admin) ---
 	// PushEventsTopic is the Pub/Sub topic merchant notifications are


### PR DESCRIPTION
Part of #686. Makes the mobile GIP → Zitadel cutover a rollout instead of a flag day, and makes the GIP-retirement decision in #708 measurable.

## The problem

`ZITADEL_ENABLED` on `marketplace-api-admin` is an **atomic** switch of two things at once: the bearer verifier, *and* the source of `tenant_id` (GIP claim vs FGA-validated `X-Acting-Tenant-Id`). Exactly one verifier is ever mounted.

So the moment it flips, every already-installed app stops working: its GIP tokens are rejected, and no client in the field holds a Zitadel token. For a store-distributed app that is unshippable — old installs cannot be forced to update.

EAS history confirms real production builds exist (last: 2026-08-14), so those installs authenticate against GIP today and must keep working.

## What this adds

**`auth.CompositeVerifier`** — tries each issuer in order, first success wins, first error returned when all fail. Zitadel first (where traffic is heading); a token verifies against at most one issuer, so order costs latency, not correctness.

**Per-token tenancy, replacing the per-deployment switch.** `GIPBearerAuth` now writes `tenant_id` only when the token actually carries a claim — GIP tokens do, Zitadel tokens never do — so both writers can be mounted at once.

Mutual exclusion is replaced by **ordering**: `TenantFromRequest` runs *after* the claim write, so an FGA-**validated** value can only ever overwrite an unvalidated claim, never the reverse. That direction is the safety property, and `TestDualIssuer_ValidatedHeaderBeatsUnvalidatedClaim` is what holds the line — I mutation-tested it (making the claim win) and confirmed it fails, so it is not decorative.

## The part that unblocks #708

Retiring GIP is gated on a question nobody can currently answer: *is anything still authenticating against it?* The composite is the only place that knows which issuer accepted a token, so it emits:

```
mobile_admin_token_verified_total{issuer="zitadel"|"gip"}
```

`gip` staying at zero across a window longer than the app's update tail is the signal to proceed. Failures are deliberately **not** counted — attributing a rejected token to an issuer would inflate that issuer's apparent traffic with tokens it never minted, corrupting the one reading this counter exists for.

## Failure semantics, deliberately asymmetric

| Case | Behaviour | Why |
|---|---|---|
| Zitadel construction fails | mobile routes **disabled** | matches the existing rule: falling back to GIP would mask the misconfiguration an operator needs to see |
| GIP construction **errors** | log Error, continue **Zitadel-only** | the legacy issuer is being retired; taking the working path down with it is worse. Logged loudly because it *does* strand installs holding GIP tokens |
| GIP **unconfigured** (`nil, nil`) | log Info, Zitadel-only | pre-existing "no GIP config" case; dual mode is simply moot |

## Deploy ordering

`ZITADEL_DUAL_ISSUER` defaults to **false** and is *not* added to `ValidateZitadel`'s required set, so it is optional config and this is safe to land code-first — the ordering trap only applies to *required* config, which fails pods at boot. Enabling it later is a chart change with no code change.

With the flag off, behaviour is byte-for-byte today's: `TestSelectMobileTokenVerifier_FlagUnset_SelectsGIP` and the three other pre-existing wiring tests still pass unchanged.

## Verification

`gofmt` clean, `go vet` clean, `go build ./...` OK, full `go test ./...` green. 14 new tests: 5 composite, 3 tenancy (incl. the mutation-tested safety case), 5 wiring, 1 metric.

## Not in scope

The mobile app's OIDC/PKCE flow against the already-provisioned `mark8ly-admin-mobile` client, and sending `X-Acting-Tenant-Id`. This change is what makes that shippable without a flag day; it does not do it. #686 stays open for that.
