### PR TITLE
State in the terms that no GST is charged, rather than implying it is added

### DIFF
--- a/apps/onboarding/app/terms/page.tsx
+++ b/apps/onboarding/app/terms/page.tsx
@@ -101,9 +101,12 @@ export default function TermsOfServicePage() {
           annually and co-terminated with the Pro renewal date.
         </p>
         <p>
-          <strong>Taxes:</strong> plan prices are stated exclusive of GST
-          and other applicable taxes, which we add at invoice where
-          required.
+          <strong>Taxes:</strong> Tesserix Pty Ltd is not currently
+          registered for GST, so no GST is charged on Australian
+          subscriptions and the plan price shown is the total amount
+          payable. Plan prices are otherwise stated exclusive of GST and any
+          other applicable taxes, which we add at invoice where we are
+          required to charge them.
         </p>
         <p>
           <strong>Payment methods:</strong> Mark8ly subscriptions are charged


### PR DESCRIPTION
The last piece of #699. #721 removed the "Plus 10% GST" disclosure from the marketing and admin surfaces; this updates the Terms of Service, which was deliberately left out of that PR because it is published legal copy.

**This is a draft for review by whoever owns the terms.** I have kept it narrow and invented no new commitments — see below.

## What it said

```
Taxes: plan prices are stated exclusive of GST and other applicable taxes,
which we add at invoice where required.
```

That is not *false*. The prices genuinely are GST-exclusive, and "where required" is conditional rather than a promise. But an Australian reader lands on "exclusive of GST … which we add at invoice" and reasonably concludes GST will be added to their bill. It never is, and while Tesserix is unregistered it cannot be.

## What it says now

```
Taxes: Tesserix Pty Ltd is not currently registered for GST, so no GST is
charged on Australian subscriptions and the plan price shown is the total
amount payable. Plan prices are otherwise stated exclusive of GST and any
other applicable taxes, which we add at invoice where we are required to
charge them.
```

Three deliberate properties:

1. **The current position is stated first and plainly** — "not currently registered", "no GST is charged", "the total amount payable". A merchant comparing A$29.00 against a competitor's GST-inclusive figure now has the answer without inference.
2. **The forward-looking clause survives, unchanged in substance.** "Otherwise stated exclusive of … which we add at invoice where we are required to charge them" preserves exactly what the old sentence reserved. When registration happens, the terms already cover charging GST; only the first sentence needs revisiting.
3. **"currently" is load-bearing.** It marks the statement as a present fact rather than a permanent commitment, which matters given registration is expected.

## What I deliberately did NOT do

**No new notice commitment.** My first draft added "we will give notice before that takes effect". I removed it: the terms already carry notice obligations (§8 "announced with reasonable notice", and the terms-update clause at the end), and inventing a fresh, differently-worded promise inside the tax clause would create a second standard to comply with. Aligning with what exists is safer than adding to it.

**No change to the entity, the payment-collection clause, or anything else on the page.** One paragraph.

**No change to `tax_behavior: "exclusive"`** in the price catalogue — see #699. Keeping the Stripe prices tax-exclusive is what makes future registration a configuration change rather than a repricing and subscriber migration.

## Note for the reviewer

I am not a lawyer and this is legal copy. The engineering facts behind it are established and verifiable — Tesserix charges no GST today, and `automatic_tax` is not enabled anywhere in `internal/billing/` — but whether this is the right *wording* is a judgement for whoever owns the terms. Rewrite freely; the point is that the previous sentence implied a charge that does not happen.

One inconsistency spotted while here, already fixed in #721: a Go comment in `reverse_charge_invoice.go` referred to "Mark8ly Pty Ltd". The terms consistently say **Tesserix Pty Ltd**, which is the correct entity.

## Verification

`npm run build` in `apps/onboarding` passes; `/terms` prerenders as static content. Copy-only change — no logic, no imports, no new code paths.

Refs #699.
