### PR TITLE
feat(marketplace-api): add mobile tenant discovery outside the tenant gate (#686)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1420,10 +1420,16 @@ func main() {
 		// then stay unmounted.
 		var teamHandler *admin.TeamHandler
 		var mobileAccountHandler *admin.MobileAccountHandler
+		var myTenantsHandler *admin.MobileMyTenantsHandler
 		if cfg.PlatformAPIURL != "" {
 			teamClient := teamproxy.NewClient(cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 			teamHandler = admin.NewTeamHandler(teamClient, log)
 			mobileAccountHandler = admin.NewMobileAccountHandler(teamClient, log)
+			// Mobile tenant discovery (#686). Shares the platform client
+			// above — no new chart env. Unset platform URL leaves it nil
+			// and the route unmounted, which is the pre-existing shape for
+			// every platform-backed mobile route.
+			myTenantsHandler = admin.NewMobileMyTenantsHandler(teamClient, log)
 		} else {
 			log.Info("team: platform client not configured (MARKETPLACE_PLATFORM_API_URL empty); team + account-deletion routes disabled")
 		}
@@ -1452,7 +1458,8 @@ func main() {
 			// the FGA-validated one runs second so it can only ever
 			// overwrite an unvalidated claim, never the reverse. See
 			// MobileDeps.DualIssuer.
-			DualIssuer: cfg.ZitadelEnabled && cfg.ZitadelDualIssuer,
+			DualIssuer:       cfg.ZitadelEnabled && cfg.ZitadelDualIssuer,
+			MyTenantsHandler: myTenantsHandler,
 			// Resolves X-Acting-Tenant-Id via the same FGA client the rest
 			// of the admin surface already checks permissions against, for
 			// bearer tokens (Zitadel) that carry no tenant_id claim at

--- a/services/marketplace-api/internal/handlers/admin/mobile_my_tenants.go
+++ b/services/marketplace-api/internal/handlers/admin/mobile_my_tenants.go
@@ -1,0 +1,79 @@
+package admin
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/marketplace-api/internal/teamproxy"
+)
+
+// TenantLister is the narrow slice of teamproxy.Client this handler needs.
+type TenantLister interface {
+	ListMyTenants(ctx context.Context, id string) ([]teamproxy.TenantMembership, error)
+}
+
+// MobileMyTenantsHandler serves GET /mobile/admin/me/tenants: the tenants
+// the authenticated caller belongs to.
+//
+// # Why this route exists, and why it is NOT tenant-gated (#686)
+//
+// It is the only mobile admin route mounted outside RequireBoundTenant,
+// and that is the entire point. A GIP token carried a tenant claim, so
+// the client never had to ask. A Zitadel token carries none, tenancy
+// instead comes from the client stating X-Acting-Tenant-Id — and nothing
+// told the client what to put there. Every other route 404s a caller with
+// no bound tenant, so gating this one too would deadlock the flow: you
+// would need a tenant in order to discover your tenant.
+//
+// Authentication is NOT relaxed, only the tenant gate. The identity comes
+// from the verified bearer token's user_id, never from a query parameter
+// or header — otherwise this would be an arbitrary-identity membership
+// lookup, which is exactly the property that keeps platform-api's own
+// (unauthenticated) endpoint in-cluster.
+type MobileMyTenantsHandler struct {
+	lister TenantLister
+	log    *slog.Logger
+}
+
+func NewMobileMyTenantsHandler(lister TenantLister, log *slog.Logger) *MobileMyTenantsHandler {
+	return &MobileMyTenantsHandler{lister: lister, log: log}
+}
+
+// List responds with {"data": [...]}.
+//
+// An upstream failure is 502, deliberately NOT an empty list: the client
+// routes "zero tenants" to the finish-onboarding screen, so degrading a
+// platform-api outage into [] would tell an established merchant they
+// have no store.
+func (h *MobileMyTenantsHandler) List(c *gin.Context) {
+	userID := c.GetString("user_id")
+	if userID == "" {
+		// bearerAuth always sets user_id, so this is unreachable in the
+		// mounted chain; fail closed rather than look up "".
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+			"error": "unauthorized", "message": "bearer token required",
+		})
+		return
+	}
+
+	tenants, err := h.lister.ListMyTenants(c.Request.Context(), userID)
+	if err != nil {
+		if h.log != nil {
+			h.log.Error("mobile: tenant discovery failed", "user_id", userID, "error", err)
+		}
+		c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{
+			"error": "platform_unavailable", "message": "could not look up your stores",
+		})
+		return
+	}
+
+	// Never null: the client parses this with a strict schema, and a null
+	// would fail it where an empty list is a legitimate answer.
+	if tenants == nil {
+		tenants = []teamproxy.TenantMembership{}
+	}
+	c.JSON(http.StatusOK, gin.H{"data": tenants})
+}

--- a/services/marketplace-api/internal/handlers/admin/mobile_my_tenants_test.go
+++ b/services/marketplace-api/internal/handlers/admin/mobile_my_tenants_test.go
@@ -1,0 +1,154 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/auth"
+	"github.com/mark8ly/marketplace-api/internal/authz"
+	"github.com/mark8ly/marketplace-api/internal/teamproxy"
+)
+
+type fakeTenantLister struct {
+	got    string
+	result []teamproxy.TenantMembership
+	err    error
+}
+
+func (f *fakeTenantLister) ListMyTenants(_ context.Context, id string) ([]teamproxy.TenantMembership, error) {
+	f.got = id
+	return f.result, f.err
+}
+
+// THE test for this route. Every other mobile admin route is behind
+// RequireBoundTenant, which 404s a caller with no tenant. This one MUST
+// NOT be — it is how a Zitadel-authenticated client discovers the tenant
+// it will then send as X-Acting-Tenant-Id. Gate it and the mobile Zitadel
+// flow deadlocks: no tenant, therefore no way to learn the tenant.
+func TestMobileMyTenants_IsReachableWithoutABoundTenant(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	lister := &fakeTenantLister{result: []teamproxy.TenantMembership{
+		{TenantID: "e638b731", Name: "Mumbai Spice Co", Role: "owner"},
+	}}
+
+	RegisterAdminMobile(r.Group("/api/v1"), MobileDeps{
+		Deps: Deps{
+			AuthzMiddleware:  authz.NewMiddleware(authz.NewFakeClient(), nil),
+			StoresMiddleware: func(c *gin.Context) { c.Next() },
+		},
+		ZitadelEnabled: true,
+		DualIssuer:     true,
+		// No tenant claim, and NO X-Acting-Tenant-Id on the request:
+		// exactly the state a client is in immediately after signing in.
+		TokenVerifier:           &auth.FakeVerifier{UserID: "389396765696066342"},
+		TenantMembershipChecker: authz.NewFakeClient(),
+		MyTenantsHandler:        NewMobileMyTenantsHandler(lister, nil),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mobile/admin/me/tenants", nil)
+	req.Header.Set("Authorization", "Bearer zitadel-token")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code,
+		"tenant discovery must not require a tenant, or the Zitadel mobile flow can never start: %s", rec.Body.String())
+
+	var body struct {
+		Data []teamproxy.TenantMembership `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Data, 1)
+	require.Equal(t, "e638b731", body.Data[0].TenantID)
+
+	// The identity must come from the VERIFIED token, never from anything
+	// the caller supplies — this endpoint would otherwise be an
+	// arbitrary-identity membership lookup.
+	require.Equal(t, "389396765696066342", lister.got)
+}
+
+// Authentication is still required: it is only the TENANT gate that is
+// lifted, not the bearer check.
+func TestMobileMyTenants_StillRequiresAValidToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	RegisterAdminMobile(r.Group("/api/v1"), MobileDeps{
+		Deps: Deps{
+			AuthzMiddleware:  authz.NewMiddleware(authz.NewFakeClient(), nil),
+			StoresMiddleware: func(c *gin.Context) { c.Next() },
+		},
+		ZitadelEnabled:   true,
+		DualIssuer:       true,
+		TokenVerifier:    &auth.FakeVerifier{Err: auth.ErrInvalidToken},
+		MyTenantsHandler: NewMobileMyTenantsHandler(&fakeTenantLister{}, nil),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mobile/admin/me/tenants", nil)
+	req.Header.Set("Authorization", "Bearer nope")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// A user with no memberships gets 200 + [], not 404. The client shows
+// "finish onboarding", which is a different screen from "something broke".
+func TestMobileMyTenants_ZeroTenantsIsAnEmptyList(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	RegisterAdminMobile(r.Group("/api/v1"), MobileDeps{
+		Deps: Deps{
+			AuthzMiddleware:  authz.NewMiddleware(authz.NewFakeClient(), nil),
+			StoresMiddleware: func(c *gin.Context) { c.Next() },
+		},
+		ZitadelEnabled:   true,
+		DualIssuer:       true,
+		TokenVerifier:    &auth.FakeVerifier{UserID: "u-new"},
+		MyTenantsHandler: NewMobileMyTenantsHandler(&fakeTenantLister{result: nil}, nil),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mobile/admin/me/tenants", nil)
+	req.Header.Set("Authorization", "Bearer t")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"data":[]}`, rec.Body.String(),
+		"zero tenants must serialise as [], never null — the client's schema rejects null")
+}
+
+// platform-api being down must not read as "you have no stores", which
+// would send a legitimate merchant to the onboarding screen.
+func TestMobileMyTenants_PlatformFailureIsNotAnEmptyList(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	RegisterAdminMobile(r.Group("/api/v1"), MobileDeps{
+		Deps: Deps{
+			AuthzMiddleware:  authz.NewMiddleware(authz.NewFakeClient(), nil),
+			StoresMiddleware: func(c *gin.Context) { c.Next() },
+		},
+		ZitadelEnabled:   true,
+		DualIssuer:       true,
+		TokenVerifier:    &auth.FakeVerifier{UserID: "u-1"},
+		MyTenantsHandler: NewMobileMyTenantsHandler(&fakeTenantLister{err: errors.New("platform down")}, nil),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mobile/admin/me/tenants", nil)
+	req.Header.Set("Authorization", "Bearer t")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadGateway, rec.Code,
+		"an upstream failure must be distinguishable from an empty membership list")
+}

--- a/services/marketplace-api/internal/handlers/admin/mobile_routes.go
+++ b/services/marketplace-api/internal/handlers/admin/mobile_routes.go
@@ -54,6 +54,11 @@ type MobileDeps struct {
 	// Requires TokenVerifier to accept both issuers — see
 	// auth.CompositeVerifier. Ignored unless ZitadelEnabled.
 	DualIssuer bool
+	// MyTenantsHandler serves the ONE mobile admin route mounted outside
+	// the tenant gate — see its doc comment for why that is required
+	// rather than an oversight. Nil leaves the route unmounted, which
+	// disables Zitadel tenant discovery on mobile.
+	MyTenantsHandler *MobileMyTenantsHandler
 	// TenantMembershipChecker backs auth.TenantFromRequest (#524 phase 4):
 	// it resolves the caller's X-Acting-Tenant-Id header via an FGA
 	// membership check, for tokens (Zitadel) that carry no tenant_id
@@ -154,6 +159,18 @@ func RegisterAdminMobile(router *gin.RouterGroup, deps MobileDeps) {
 	if deps.MobileAccountHandler != nil {
 		acct := router.Group("/mobile/admin/account", tenantMW...)
 		acct.DELETE("", deps.MobileAccountHandler.Delete)
+	}
+
+	// Tenant discovery — the ONLY mobile admin route mounted WITHOUT
+	// requireTenant, and deliberately so: it is how a Zitadel-authenticated
+	// client learns the tenant it will then send as X-Acting-Tenant-Id.
+	// Gating it would deadlock that flow (a tenant would be needed to
+	// discover the tenant). Authentication still applies — bearerAuth and
+	// the per-user rate limiter are both here; only the tenant gate is
+	// absent. Do NOT "tidy" this onto tenantMW.
+	if deps.MyTenantsHandler != nil {
+		me := router.Group("/mobile/admin/me", bearerAuth, rateLimiter)
+		me.GET("/tenants", deps.MyTenantsHandler.List)
 	}
 
 	// Tenant-wide routes

--- a/services/marketplace-api/internal/handlers/admin/route_parity_test.go
+++ b/services/marketplace-api/internal/handlers/admin/route_parity_test.go
@@ -115,7 +115,9 @@ var mobileOnlySubtrees = map[string]string{
 	"/stores/:storeId/team":        "staff/invite management proxied to platform-api; web admin calls platform-api directly rather than through this service",
 }
 
-var mobileOnlyRoutes = map[string]string{}
+var mobileOnlyRoutes = map[string]string{
+	"GET /me/tenants": "Zitadel tenant discovery (#686): mobile is the only surface that must ask the API which tenants it belongs to, because a Zitadel token carries no tenant claim and every other mobile route is tenant-gated. The web admin resolves the same thing server-side in its own BFF (resolveWorkspaceTenant) by calling platform-api directly, so mirroring it here would add an unused route. It is also the one mobile route deliberately mounted OUTSIDE requireTenant — see MobileMyTenantsHandler",
+}
 
 // ---------------------------------------------------------------------------
 

--- a/services/marketplace-api/internal/teamproxy/client.go
+++ b/services/marketplace-api/internal/teamproxy/client.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -184,4 +185,52 @@ func (c *Client) UpdateMemberRole(ctx context.Context, tenantID, email, newRole,
 		return nil, err
 	}
 	return &res, nil
+}
+
+// TenantMembership is one tenant the caller has a role on, as returned by
+// platform-api's GET /api/v1/users/me/tenants.
+type TenantMembership struct {
+	TenantID string `json:"tenant_id"`
+	Name     string `json:"name"`
+	Role     string `json:"role"`
+}
+
+// ListMyTenants returns every tenant the given identity has a role on.
+//
+// # Why this is on the mobile critical path (#686)
+//
+// After a Zitadel sign-in the mobile app knows who the user is and
+// nothing else. Zitadel mints no tenant claim (unlike GIP), every mobile
+// admin route is behind RequireBoundTenant, and the stores response
+// carries no tenant id — so without this lookup the client has no value
+// to put in X-Acting-Tenant-Id and cannot make a single successful call.
+// This is the mobile equivalent of the web's resolveWorkspaceTenant.
+//
+// # Why it goes through marketplace-api rather than being called directly
+//
+// platform-api mounts this on its PUBLIC /api/v1 group with no
+// authentication — it takes the identity as a query parameter, because
+// its only caller so far is the admin BFF passing a uid from an already
+// validated session. A device calling it directly would be an
+// unauthenticated membership lookup for any identity. Routing it through
+// marketplace-api keeps that endpoint in-cluster and lets the caller's
+// identity come from a VERIFIED bearer token instead of a query string.
+//
+// # Identity key
+//
+// id may be a provider uid OR an email: platform-api resolves either,
+// because mark8ly writes both email- and uid-keyed FGA tuples for the
+// same human. It is passed through verbatim — platform-api owns the
+// email lowercasing, and provider uids are case-sensitive.
+//
+// An empty result is not an error: a signed-in user who has not onboarded
+// genuinely has zero tenants, and the client shows a different screen for
+// that than for a failed lookup.
+func (c *Client) ListMyTenants(ctx context.Context, id string) ([]TenantMembership, error) {
+	var out []TenantMembership
+	path := "/api/v1/users/me/tenants?uid=" + url.QueryEscape(id)
+	if err := c.do(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }

--- a/services/marketplace-api/internal/teamproxy/my_tenants_test.go
+++ b/services/marketplace-api/internal/teamproxy/my_tenants_test.go
@@ -1,0 +1,88 @@
+package teamproxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ListMyTenants is the mobile app's ONLY route to a tenant id after a
+// Zitadel sign-in (#686): every mobile admin route is tenant-gated, and a
+// Zitadel token carries no tenant claim, so without this the client has
+// nothing to put in X-Acting-Tenant-Id.
+func TestListMyTenants_CallsPublicRouteWithUID(t *testing.T) {
+	var gotPath, gotQuery, gotInternalAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query().Get("uid")
+		gotInternalAuth = r.Header.Get("X-Internal-Auth")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"tenant_id":"t-1","name":"Mumbai Spice Co","role":"owner"}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "s3cret", srv.Client())
+	got, err := c.ListMyTenants(context.Background(), "389396765696066342")
+	require.NoError(t, err)
+
+	// platform-api mounts listMyTenants on the PUBLIC /api/v1 group, not
+	// the /internal one, so the path must not be guessed from the
+	// /internal/* siblings on this client.
+	require.Equal(t, "/api/v1/users/me/tenants", gotPath)
+	require.Equal(t, "389396765696066342", gotQuery)
+	// Harmless on a public route, but the client sends it uniformly and
+	// platform-api ignores it there.
+	require.Equal(t, "s3cret", gotInternalAuth)
+
+	require.Len(t, got, 1)
+	require.Equal(t, "t-1", got[0].TenantID)
+	require.Equal(t, "Mumbai Spice Co", got[0].Name)
+	require.Equal(t, "owner", got[0].Role)
+}
+
+// Zero tenants is a legitimate answer (a signed-in user who has not
+// onboarded), and must be an empty list rather than an error — the client
+// distinguishes "no stores yet" from "lookup failed" and shows very
+// different screens.
+func TestListMyTenants_EmptyListIsNotAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	got, err := NewClient(srv.URL, "", srv.Client()).ListMyTenants(context.Background(), "uid")
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+// An email is a valid identity key here: platform-api's ListMemberTenants
+// resolves either an email- or a uid-keyed FGA tuple, and mark8ly writes
+// BOTH for the same human. The client must pass it through untouched —
+// platform-api owns the lowercasing.
+func TestListMyTenants_PassesEmailKeyThroughUnchanged(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query().Get("uid")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	_, err := NewClient(srv.URL, "", srv.Client()).ListMyTenants(context.Background(), "Demo+India@Mark8ly.com")
+	require.NoError(t, err)
+	require.Equal(t, "Demo+India@Mark8ly.com", gotQuery)
+}
+
+func TestListMyTenants_PlatformErrorSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal","message":"boom"}`))
+	}))
+	defer srv.Close()
+
+	_, err := NewClient(srv.URL, "", srv.Client()).ListMyTenants(context.Background(), "uid")
+	require.Error(t, err)
+}


### PR DESCRIPTION
Part of #686. Closes the gap that made the dual-issuer verifier (#722) unusable by a real client.

## The gap

With a Zitadel token the mobile app **cannot discover its own tenant**, so it can never populate `X-Acting-Tenant-Id`:

- every mobile admin route sits behind `RequireBoundTenant` — including `/mobile/admin/stores`. You need a tenant to ask what your tenants are.
- the `Store` schema carries no `tenant_id`, so the stores list could not tell it either.
- `packages/mobile-shared/stores/tenant-store.ts` currently does `setTenantId(store.id)` — it stores the **store** id as the tenant id. Harmless today because GIP's claim supplies the real tenant server-side, but it means the client has no correct value to send.
- platform-api's `GET /api/v1/users/me/tenants` is on its **public, unauthenticated** group and takes the identity as a query parameter, so a device must not call it.
- `internal/authz` exposes only `Check`/`CheckMembership`/`GetRole` — no "list tenants for this user".

The GIP path never needed any of this: the claim carried exactly one tenant. Zitadel mints none, which is why `X-Acting-Tenant-Id` exists — but nothing gave the client a value to put in it.

## What this adds

`GET /api/v1/mobile/admin/me/tenants` on marketplace-api, proxying platform-api's `listMyTenants` with the uid from the **verified bearer token**, reusing the existing `teamproxy` client and `PlatformAPISecret` (no new chart env).

**It is the only mobile admin route mounted outside `requireTenant`, and that is the point.** Gating it deadlocks the flow: you would need a tenant in order to discover your tenant. Authentication is not relaxed — `bearerAuth` and the per-user rate limiter both still apply; only the tenant gate is absent. `TestMobileMyTenants_IsReachableWithoutABoundTenant` pins that, and the doc comment says loudly not to "tidy" it onto `tenantMW`.

Routing it through marketplace-api rather than calling platform-api from the device is what keeps that unauthenticated endpoint in-cluster: the identity comes from a verified token instead of a query string.

## Details worth the review

- **Identity key.** The id is passed through verbatim, because platform-api's `ListMemberTenants` resolves either an email- or a uid-keyed FGA tuple and mark8ly writes both for the same human. It owns the email lowercasing; provider uids are case-sensitive. Covered by `TestListMyTenants_PassesEmailKeyThroughUnchanged`.
- **Zero tenants is `200 {"data":[]}`**, never 404 or null — the client routes that to "finish onboarding", a different screen from a failure, and its Zod schema rejects null.
- **An upstream failure is `502`, deliberately not an empty list.** Degrading a platform-api outage into `[]` would tell an established merchant they have no store.
- **Path.** platform-api mounts this on the public `/api/v1` group, not the `/internal` one its siblings on this client use, so the path is asserted in a test rather than inferred.

## Route parity

The repo's `TestAdminRouteParity` caught this immediately and refused a one-sided route. Declared deliberate in `mobileOnlyRoutes` with a reason: the web admin resolves the same thing server-side in its own BFF (`resolveWorkspaceTenant`), so mirroring it would add an unused route. Good guard — it did exactly its job.

## Verification

`gofmt` clean, `go vet` clean, `go build ./...` OK, full `go test ./...` green. 8 new tests: 4 on the teamproxy client, 4 on the route (reachable without a tenant, still requires a token, empty list, upstream failure).

## Next

The app side: OIDC/PKCE against the already-provisioned `mark8ly-admin-mobile` client (verified `accessTokenType: JWT`, so `ZitadelVerifier` can verify it), then calling this endpoint on sign-in and sending `X-Acting-Tenant-Id`. Also worth fixing there: `tenant-store.ts` conflating store id with tenant id.
