### PR TITLE
Audit refunds issued outside the admin API

### DIFF
--- a/.planning/quick/260905-rae-refund-audit-event/PLAN.md
+++ b/.planning/quick/260905-rae-refund-audit-event/PLAN.md
@@ -1,0 +1,92 @@
+# Emit an audit event for externally-initiated refunds
+
+The remaining half of #705. `handleChargeRefunded` (`internal/billing/dispatch/handlers.go:841`)
+is `return nil`, so a refund issued from the Stripe Dashboard leaves **no trace
+at all** — no audit row, no log. Refunds issued through our own admin API are
+fully recorded; the ones least likely to be recorded are the ones most likely
+to need explaining later.
+
+## The chosen option, and why not the other two
+
+#705 proposed writing a `refund_audit` row. **We are not doing that.**
+`refund_audit` is a fraud-control table, not a log: migration 000062 puts a
+UNIQUE index on `card_fingerprint`, and `internal/refund/service.go:128-137`
+reads it before issuing a refund and REJECTS one when that card already has a
+row. Writing from the webhook would make a Dashboard refund silently consume
+that card's only allowed refund, causing the next legitimate admin refund to be
+rejected as fraud. The issue asked for observability; that would have changed
+refund policy.
+
+The user chose: **emit an audit event only.** No `refund_audit` write, no
+coupling to the fraud guard.
+
+## Design points already established — do not re-derive
+
+- **Redelivery is already deduped.** `internal/handlers/webhooks/stripe.go:94`
+  does an idempotent insert keyed on the Stripe `event_id`. The handler needs
+  no redelivery guard of its own.
+- **Our own refunds also fire this webhook.** `refund.Service` calls Stripe's
+  `Refunds.Create`, so Stripe sends `charge.refunded` back for refunds we
+  issued and already audited via `EmitRefundIssued`
+  (`internal/audit/refund_events.go:29`, action `subscription.refund_issued`).
+  Without a discriminator this handler would double-audit every admin refund.
+- **The discriminator is `refund_audit.stripe_refund_id`.** Our refunds are
+  recorded there with their Stripe refund id; a Dashboard refund is not. A
+  READ against that table is safe — it is the WRITE that carries fraud-guard
+  meaning.
+- `handleChargeRefunded` is a free function today, so it has no `d.emitter`.
+  It must become a `*Dispatcher` method, exactly as `handleSubscriptionUpdated`
+  did; registration at `dispatcher.go` becomes `d.handleChargeRefunded`.
+
+## Task
+
+1. Add `ExistsByStripeRefundID(ctx, db, refundID) (bool, error)` to
+   `internal/refund`'s repository interface and its gorm implementation,
+   alongside the existing `ExistsByCardFingerprint` / `ExistsByStore`.
+   Read-only.
+2. Convert `handleChargeRefunded` to a `*Dispatcher` method and register it as
+   such.
+3. Parse the `charge.refunded` payload for: charge id, customer,
+   `amount_refunded`, `currency`, and the nested `refunds.data[].id`.
+4. Resolve `customer` -> `store_subscriptions` (tenant_id, store_id) in the
+   same `tx`, mirroring `handleSubscriptionUpdated`'s pre-state SELECT. A
+   missing row is NOT an error — return nil and emit nothing, matching
+   today's behaviour for a customer we never provisioned.
+5. If ANY of the payload's refund ids already exists in `refund_audit`, this
+   refund is ours and is already audited: return nil, emit nothing.
+6. Otherwise emit via `d.emitter.Emit(nil, audit.Event{...})` with a NEW action
+   in the `subscription.*` namespace distinct from `subscription.refund_issued`
+   — this is an externally-initiated refund, and conflating the two would
+   destroy the only signal that says "this did not come through our controls".
+   Follow the field shape used at `lifecycle/finalize.go:88-99`. Metadata
+   should carry the charge id, refund id(s), amount and currency.
+7. `d.emitter` may be nil (`emitter.go:126` is nil-safe) — do not panic
+   building the event either.
+
+## Worth stating in the code
+
+`refund/service.go:80` refuses to refund a subscription holding the Pro+App
+add-on (`ErrProAppNotRefundable`). That guard lives ONLY in the admin path, so
+a Dashboard refund bypasses it entirely. This event is the only thing that
+would ever reveal that having happened. Say so where the action is defined.
+
+## Out of scope
+
+- Any write to `refund_audit`, and any change to the fraud guard.
+- Any change to `refund.Service` or the admin refund path.
+
+## Done when
+
+- A Dashboard-initiated refund emits exactly one event with the new action
+- A refund we issued (its id present in `refund_audit`) emits NOTHING
+- An unknown customer emits nothing and returns nil
+- A nil emitter does not panic
+- Unit tests, genuinely executing — the existing dispatch tests are
+  `//go:build integration` and `TEST_DATABASE_URL` is unset locally, so they
+  compile out entirely. Factor the decision into a pure helper if needed.
+
+## Constraints
+
+- TDD: test first, watch it fail.
+- One atomic commit, single-line conventional message, NO attribution trailers.
+- `go build ./...`, `go vet`, `go test` green before committing.

--- a/services/marketplace-api/internal/billing/dispatch/charge_refunded_audit.go
+++ b/services/marketplace-api/internal/billing/dispatch/charge_refunded_audit.go
@@ -1,0 +1,132 @@
+package dispatch
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+)
+
+// ActionRefundedExternally records a refund that reached Stripe WITHOUT going
+// through our admin refund API — in practice, one issued from the Stripe
+// Dashboard.
+//
+// It is deliberately NOT subscription.refund_issued. That action means "a
+// refund passed our controls": the 14-day cooling-off gate, the card
+// fingerprint fraud guard, and the Pro+App guard at
+// internal/refund/service.go:80 (ErrProAppNotRefundable), which refuses to
+// refund a subscription still holding the white-label app add-on. None of
+// those guards exist on the Dashboard path — a Dashboard refund bypasses all
+// three, including the Pro+App refusal, and this event is the only thing that
+// would ever reveal that it happened. Collapsing the two actions into one
+// would destroy exactly that signal.
+const ActionRefundedExternally = "subscription.refunded_externally"
+
+// chargeRefundedPayload is the slice of a charge.refunded event we audit.
+type chargeRefundedPayload struct {
+	ChargeID       string
+	Customer       string
+	AmountRefunded int64
+	Currency       string
+	// RefundIDs are the Stripe refund ids from the charge's expanded refunds
+	// list. May be empty: Stripe omits the expanded list on some replays.
+	RefundIDs []string
+}
+
+// externalRefundContext carries the identifiers an emitted event needs. They
+// come from the store_subscriptions row matched on stripe_customer_id, so
+// they are only meaningful when that row was found.
+type externalRefundContext struct {
+	SubscriptionID uuid.UUID
+	TenantID       uuid.UUID
+	StoreID        uuid.UUID
+}
+
+// parseChargeRefunded extracts the audited fields from a charge.refunded
+// event body. A missing refunds list is not an error.
+func parseChargeRefunded(raw []byte) (chargeRefundedPayload, error) {
+	var e struct {
+		Data struct {
+			Object struct {
+				ID             string `json:"id"`
+				Customer       string `json:"customer"`
+				AmountRefunded int64  `json:"amount_refunded"`
+				Currency       string `json:"currency"`
+				Refunds        struct {
+					Data []struct {
+						ID string `json:"id"`
+					} `json:"data"`
+				} `json:"refunds"`
+			} `json:"object"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &e); err != nil {
+		return chargeRefundedPayload{}, fmt.Errorf("dispatch: unmarshal charge.refunded: %w", err)
+	}
+	obj := e.Data.Object
+	p := chargeRefundedPayload{
+		ChargeID:       obj.ID,
+		Customer:       obj.Customer,
+		AmountRefunded: obj.AmountRefunded,
+		Currency:       obj.Currency,
+	}
+	for _, r := range obj.Refunds.Data {
+		if r.ID != "" {
+			p.RefundIDs = append(p.RefundIDs, r.ID)
+		}
+	}
+	return p, nil
+}
+
+// decideExternalRefundEvent returns the audit event a charge.refunded webhook
+// should produce, or ok=false when it should produce none. It is pure so the
+// whole decision is unit-testable without a database — the handler around it
+// is a thin shell.
+//
+// ours is true when at least one of the payload's refund ids is already
+// recorded in refund_audit, which means refund.Service issued it and
+// EmitRefundIssued already audited it. Our own refunds fire this same webhook
+// back at us, so without that discriminator every admin refund would be
+// audited twice.
+func decideExternalRefundEvent(p chargeRefundedPayload, ours bool, rc externalRefundContext) (audit.Event, bool) {
+	if ours {
+		return audit.Event{}, false
+	}
+
+	// Copy the ids so the event does not alias the parsed payload's slice.
+	refundIDs := make([]string, len(p.RefundIDs))
+	copy(refundIDs, p.RefundIDs)
+
+	return audit.Event{
+		Action:       ActionRefundedExternally,
+		ResourceType: "subscription",
+		ResourceID:   rc.SubscriptionID.String(),
+		// Warning, not Info: a refund that skipped our guards is something
+		// ops should be able to find, not routine bookkeeping.
+		Severity:       audit.SeverityWarning,
+		TenantID:       rc.TenantID,
+		StoreID:        rc.StoreID,
+		ForceActorType: audit.ActorSystem,
+		Metadata: map[string]any{
+			"reason":                "charge.refunded",
+			"stripe_charge_id":      p.ChargeID,
+			"stripe_customer_id":    p.Customer,
+			"stripe_refund_ids":     refundIDs,
+			"amount_refunded_minor": p.AmountRefunded,
+			"currency":              p.Currency,
+			"store_id":              rc.StoreID.String(),
+		},
+	}, true
+}
+
+// emitExternalRefund emits the decided event, if any.
+//
+// d.emitter may be nil — Emitter.Emit is nil-receiver-safe, and nothing here
+// dereferences it, so the whole path is a no-op in that wiring.
+func (d *Dispatcher) emitExternalRefund(p chargeRefundedPayload, ours bool, rc externalRefundContext) {
+	if ev, ok := decideExternalRefundEvent(p, ours, rc); ok {
+		d.emitter.Emit(nil, ev)
+	}
+}

--- a/services/marketplace-api/internal/billing/dispatch/charge_refunded_audit_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/charge_refunded_audit_test.go
@@ -1,0 +1,257 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/refund"
+)
+
+func TestParseChargeRefunded(t *testing.T) {
+	raw := []byte(`{
+      "type": "charge.refunded",
+      "data": {
+        "object": {
+          "id": "ch_123",
+          "object": "charge",
+          "customer": "cus_123",
+          "amount": 9900,
+          "amount_refunded": 9900,
+          "currency": "aud",
+          "refunds": {
+            "object": "list",
+            "data": [
+              {"id": "re_1", "object": "refund"},
+              {"id": "re_2", "object": "refund"}
+            ]
+          }
+        }
+      }
+    }`)
+
+	p, err := parseChargeRefunded(raw)
+	if err != nil {
+		t.Fatalf("parseChargeRefunded: %v", err)
+	}
+	if p.ChargeID != "ch_123" {
+		t.Errorf("ChargeID = %q, want ch_123", p.ChargeID)
+	}
+	if p.Customer != "cus_123" {
+		t.Errorf("Customer = %q, want cus_123", p.Customer)
+	}
+	if p.AmountRefunded != 9900 {
+		t.Errorf("AmountRefunded = %d, want 9900", p.AmountRefunded)
+	}
+	if p.Currency != "aud" {
+		t.Errorf("Currency = %q, want aud", p.Currency)
+	}
+	if len(p.RefundIDs) != 2 || p.RefundIDs[0] != "re_1" || p.RefundIDs[1] != "re_2" {
+		t.Errorf("RefundIDs = %v, want [re_1 re_2]", p.RefundIDs)
+	}
+}
+
+func TestParseChargeRefunded_MissingRefundsList(t *testing.T) {
+	// Some replays omit the expanded refunds list entirely. That must not be
+	// an error: an unknown refund id simply cannot be matched against
+	// refund_audit, and the event is still worth recording.
+	raw := []byte(`{"data":{"object":{"id":"ch_1","customer":"cus_1","amount_refunded":100,"currency":"usd"}}}`)
+	p, err := parseChargeRefunded(raw)
+	if err != nil {
+		t.Fatalf("parseChargeRefunded: %v", err)
+	}
+	if len(p.RefundIDs) != 0 {
+		t.Errorf("RefundIDs = %v, want empty", p.RefundIDs)
+	}
+	if p.ChargeID != "ch_1" {
+		t.Errorf("ChargeID = %q, want ch_1", p.ChargeID)
+	}
+}
+
+func TestParseChargeRefunded_Malformed(t *testing.T) {
+	if _, err := parseChargeRefunded([]byte(`{`)); err == nil {
+		t.Fatal("expected an error for malformed JSON")
+	}
+}
+
+func newRefundCtx() externalRefundContext {
+	return externalRefundContext{
+		SubscriptionID: uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		TenantID:       uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+		StoreID:        uuid.MustParse("33333333-3333-3333-3333-333333333333"),
+	}
+}
+
+func samplePayload() chargeRefundedPayload {
+	return chargeRefundedPayload{
+		ChargeID:       "ch_123",
+		Customer:       "cus_123",
+		AmountRefunded: 9900,
+		Currency:       "aud",
+		RefundIDs:      []string{"re_1"},
+	}
+}
+
+func TestDecideExternalRefundEvent_Emits(t *testing.T) {
+	rc := newRefundCtx()
+	ev, ok := decideExternalRefundEvent(samplePayload(), false, rc)
+	if !ok {
+		t.Fatal("expected an event for a refund we did not issue")
+	}
+	if ev.Action != ActionRefundedExternally {
+		t.Errorf("Action = %q, want %q", ev.Action, ActionRefundedExternally)
+	}
+	if ev.Action == "subscription.refund_issued" {
+		t.Error("must not reuse the admin-path action")
+	}
+	if ev.ResourceType != "subscription" {
+		t.Errorf("ResourceType = %q, want subscription", ev.ResourceType)
+	}
+	if ev.ResourceID != rc.SubscriptionID.String() {
+		t.Errorf("ResourceID = %q, want %q", ev.ResourceID, rc.SubscriptionID)
+	}
+	if ev.TenantID != rc.TenantID || ev.StoreID != rc.StoreID {
+		t.Errorf("tenant/store not carried through: %v %v", ev.TenantID, ev.StoreID)
+	}
+	if ev.Metadata["stripe_charge_id"] != "ch_123" {
+		t.Errorf("metadata stripe_charge_id = %v", ev.Metadata["stripe_charge_id"])
+	}
+	if ev.Metadata["stripe_customer_id"] != "cus_123" {
+		t.Errorf("metadata stripe_customer_id = %v", ev.Metadata["stripe_customer_id"])
+	}
+	if ev.Metadata["amount_refunded_minor"] != int64(9900) {
+		t.Errorf("metadata amount_refunded_minor = %v", ev.Metadata["amount_refunded_minor"])
+	}
+	if ev.Metadata["currency"] != "aud" {
+		t.Errorf("metadata currency = %v", ev.Metadata["currency"])
+	}
+	ids, _ := ev.Metadata["stripe_refund_ids"].([]string)
+	if len(ids) != 1 || ids[0] != "re_1" {
+		t.Errorf("metadata stripe_refund_ids = %v", ev.Metadata["stripe_refund_ids"])
+	}
+}
+
+func TestDecideExternalRefundEvent_SuppressedWhenOurs(t *testing.T) {
+	// The refund id is already in refund_audit, so refund.Service issued it
+	// and EmitRefundIssued already recorded it. Emitting here would
+	// double-audit every admin refund.
+	if _, ok := decideExternalRefundEvent(samplePayload(), true, newRefundCtx()); ok {
+		t.Fatal("expected no event for a refund we issued ourselves")
+	}
+}
+
+func TestDecideExternalRefundEvent_NoRefundIDsStillEmits(t *testing.T) {
+	p := samplePayload()
+	p.RefundIDs = nil
+	ev, ok := decideExternalRefundEvent(p, false, newRefundCtx())
+	if !ok {
+		t.Fatal("expected an event even when the payload carries no refund ids")
+	}
+	if ids, _ := ev.Metadata["stripe_refund_ids"].([]string); len(ids) != 0 {
+		t.Errorf("stripe_refund_ids = %v, want empty", ids)
+	}
+}
+
+func TestEmitExternalRefund_NilEmitterDoesNotPanic(t *testing.T) {
+	// Production wiring may pass a nil *audit.Emitter. Emit is nil-safe, and
+	// building the event must not panic either.
+	var d *Dispatcher = New(nil)
+	d.emitExternalRefund(samplePayload(), false, newRefundCtx())
+}
+
+// stubRefundRepo implements refund.Repository over an in-memory id set so
+// refundIsOurs can be tested without a database. Only the read used by
+// handleChargeRefunded is meaningful; the write path must never be reached.
+type stubRefundRepo struct {
+	known map[string]bool
+	err   error
+	calls []string
+}
+
+func (s *stubRefundRepo) Create(context.Context, *gorm.DB, *refund.RefundAudit) error {
+	panic("charge.refunded must never write refund_audit")
+}
+
+func (s *stubRefundRepo) ExistsByCardFingerprint(context.Context, *gorm.DB, string) (bool, error) {
+	panic("unexpected fingerprint lookup")
+}
+
+func (s *stubRefundRepo) ExistsByStore(context.Context, *gorm.DB, string) (bool, error) {
+	panic("unexpected store lookup")
+}
+
+func (s *stubRefundRepo) ExistsByStripeRefundID(_ context.Context, _ *gorm.DB, id string) (bool, error) {
+	s.calls = append(s.calls, id)
+	if s.err != nil {
+		return false, s.err
+	}
+	return s.known[id], nil
+}
+
+func TestRefundIsOurs(t *testing.T) {
+	tests := []struct {
+		name      string
+		known     map[string]bool
+		ids       []string
+		want      bool
+		wantCalls int
+	}{
+		{name: "no ids", ids: nil, want: false, wantCalls: 0},
+		{name: "unknown id", known: map[string]bool{}, ids: []string{"re_x"}, want: false, wantCalls: 1},
+		{name: "known id", known: map[string]bool{"re_1": true}, ids: []string{"re_1"}, want: true, wantCalls: 1},
+		{
+			name:  "short-circuits on the first match",
+			known: map[string]bool{"re_1": true},
+			ids:   []string{"re_1", "re_2"},
+			want:  true, wantCalls: 1,
+		},
+		{
+			name:  "checks every id before concluding it is external",
+			known: map[string]bool{},
+			ids:   []string{"re_1", "re_2"},
+			want:  false, wantCalls: 2,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &stubRefundRepo{known: tc.known}
+			d := New(nil)
+			d.refunds = repo
+			got, err := d.refundIsOurs(context.Background(), nil, tc.ids)
+			if err != nil {
+				t.Fatalf("refundIsOurs: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("refundIsOurs = %v, want %v", got, tc.want)
+			}
+			if len(repo.calls) != tc.wantCalls {
+				t.Errorf("lookups = %v, want %d", repo.calls, tc.wantCalls)
+			}
+		})
+	}
+}
+
+func TestRefundIsOurs_NilRepo(t *testing.T) {
+	d := New(nil)
+	d.refunds = nil
+	got, err := d.refundIsOurs(context.Background(), nil, []string{"re_1"})
+	if err != nil {
+		t.Fatalf("refundIsOurs: %v", err)
+	}
+	if got {
+		t.Error("a nil repo must make the refund look externally initiated, not ours")
+	}
+}
+
+func TestRefundIsOurs_LookupErrorPropagates(t *testing.T) {
+	// A failed lookup must NOT be swallowed into "not ours" — that would
+	// double-audit an admin refund.
+	d := New(nil)
+	d.refunds = &stubRefundRepo{err: errors.New("boom")}
+	if _, err := d.refundIsOurs(context.Background(), nil, []string{"re_1"}); err == nil {
+		t.Fatal("expected the lookup error to propagate")
+	}
+}

--- a/services/marketplace-api/internal/billing/dispatch/dispatcher.go
+++ b/services/marketplace-api/internal/billing/dispatch/dispatcher.go
@@ -16,6 +16,7 @@ import (
 	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
 	"github.com/mark8ly/marketplace-api/internal/email"
 	"github.com/mark8ly/marketplace-api/internal/metrics"
+	"github.com/mark8ly/marketplace-api/internal/refund"
 	"github.com/mark8ly/marketplace-api/internal/subscription/statemachine"
 	"github.com/mark8ly/marketplace-api/internal/webhookevents"
 )
@@ -49,7 +50,12 @@ type Dispatcher struct {
 	// tx is long gone by then and this is the only usable handle. Nil
 	// disables the trial-billed email entirely — there is no way to make it
 	// at-most-once without a claim store.
-	db       *gorm.DB
+	db *gorm.DB
+	// refunds reads refund_audit to tell a refund we issued from one issued
+	// in the Stripe Dashboard (see handleChargeRefunded). Read-only — nothing
+	// here ever writes that fraud-control table. Nil-safe: a nil repo makes
+	// every refund look externally initiated.
+	refunds  refund.Repository
 	skip     SkipCounter // nil-safe: skipped-send counting is optional
 	sent     SentCounter // nil-safe: delivered-send counting is optional
 	handlers map[string]Handler
@@ -59,7 +65,7 @@ type Dispatcher struct {
 // tests that opt out of audit emission — Emitter.EmitStateTransition is a
 // no-op on a nil receiver.
 func New(em *audit.Emitter) *Dispatcher {
-	d := &Dispatcher{emitter: em, handlers: map[string]Handler{}}
+	d := &Dispatcher{emitter: em, refunds: refund.NewRepository(), handlers: map[string]Handler{}}
 	// Side-effect-only handlers that don't advance status. Most are free
 	// functions; customer.subscription.updated is a method because it emits
 	// a period/cancel-flag transition event through d.emitter (#705).
@@ -71,7 +77,7 @@ func New(em *audit.Emitter) *Dispatcher {
 	// when metadata.kind matches. Errors in either stage bail the chain.
 	d.handlers["invoice.paid"] = chain(d.handleInvoicePaid, appaddon.HandleInvoicePaidForAppAddOn)
 	d.handlers["customer.updated"] = handleCustomerUpdated
-	d.handlers["charge.refunded"] = handleChargeRefunded
+	d.handlers["charge.refunded"] = d.handleChargeRefunded
 	d.handlers["payment_method.attached"] = handlePaymentMethodAttached
 	d.handlers["payment_method.detached"] = handlePaymentMethodDetached
 	d.handlers["radar.early_fraud_warning"] = handleFraudWarning

--- a/services/marketplace-api/internal/billing/dispatch/handlers.go
+++ b/services/marketplace-api/internal/billing/dispatch/handlers.go
@@ -836,9 +836,83 @@ func handleCustomerUpdated(ctx context.Context, tx *gorm.DB, raw []byte) error {
 	return nil
 }
 
-// handleChargeRefunded is audit-only in P2.
-// TODO(P3): create refund record in billing ledger.
-func handleChargeRefunded(ctx context.Context, tx *gorm.DB, raw []byte) error { return nil }
+// handleChargeRefunded audits a refund that did NOT come through our admin
+// refund API (#705). It used to be `return nil`, so a refund issued from the
+// Stripe Dashboard left no trace anywhere.
+//
+// It writes nothing. In particular it does NOT create a refund_audit row:
+// that table is a fraud control with a unique index on card_fingerprint that
+// Service.IssueRefund reads before allowing a refund, so a webhook write
+// would silently consume a card's one allowed refund and cause the next
+// legitimate admin refund to be rejected. The issue asked for observability,
+// not a policy change.
+//
+// Discriminating our own refunds. refund.Service calls Stripe's
+// Refunds.Create, so Stripe sends charge.refunded back for refunds we issued
+// and already audited as subscription.refund_issued. Those refunds have their
+// Stripe id in refund_audit.stripe_refund_id; a Dashboard refund does not.
+// The READ below is the discriminator — without it every admin refund would
+// be audited twice.
+//
+// It is a method (not the free function it used to be) purely so it can reach
+// d.emitter, exactly as handleSubscriptionUpdated became one.
+//
+// Redelivery needs no guard here: internal/handlers/webhooks/stripe.go dedupes
+// on the Stripe event_id before the dispatcher is ever reached.
+func (d *Dispatcher) handleChargeRefunded(ctx context.Context, tx *gorm.DB, raw []byte) error {
+	p, err := parseChargeRefunded(raw)
+	if err != nil {
+		return err
+	}
+	if p.Customer == "" {
+		// Replays and non-subscription charges may carry no customer; there
+		// is nothing to attribute the refund to.
+		return nil
+	}
+
+	// Resolve the customer inside the same transaction, mirroring
+	// handleSubscriptionUpdated's pre-state read. A missing row is NOT an
+	// error: it is a customer we never provisioned (test-mode noise), and
+	// today's behaviour for one is to do nothing and return nil.
+	var sub subscription.StoreSubscription
+	switch err := tx.WithContext(ctx).Where("stripe_customer_id = ?", p.Customer).First(&sub).Error; {
+	case err == nil:
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return nil
+	default:
+		return fmt.Errorf("dispatch: charge.refunded lookup: %w", err)
+	}
+
+	ours, err := d.refundIsOurs(ctx, tx, p.RefundIDs)
+	if err != nil {
+		return err
+	}
+
+	d.emitExternalRefund(p, ours, externalRefundContext{
+		SubscriptionID: sub.ID,
+		TenantID:       sub.TenantID,
+		StoreID:        sub.StoreID,
+	})
+	return nil
+}
+
+// refundIsOurs reports whether any of the payload's refund ids is already
+// recorded in refund_audit — i.e. we issued this refund ourselves.
+func (d *Dispatcher) refundIsOurs(ctx context.Context, tx *gorm.DB, refundIDs []string) (bool, error) {
+	if d.refunds == nil {
+		return false, nil
+	}
+	for _, id := range refundIDs {
+		exists, err := d.refunds.ExistsByStripeRefundID(ctx, tx, id)
+		if err != nil {
+			return false, fmt.Errorf("dispatch: charge.refunded refund_audit lookup: %w", err)
+		}
+		if exists {
+			return true, nil
+		}
+	}
+	return false, nil
+}
 
 // handlePaymentMethodAttached is intentionally a no-op. has_default_payment_method
 // is mirrored from customer.updated, which Stripe emits whenever

--- a/services/marketplace-api/internal/refund/repository.go
+++ b/services/marketplace-api/internal/refund/repository.go
@@ -18,6 +18,17 @@ type Repository interface {
 
 	// ExistsByStore returns true when any refund row exists for the given store.
 	ExistsByStore(ctx context.Context, db *gorm.DB, storeID string) (bool, error)
+
+	// ExistsByStripeRefundID returns true when the given Stripe refund id is
+	// already recorded here — i.e. WE issued that refund through the admin
+	// API and it is already audited as subscription.refund_issued.
+	//
+	// This is read-only on purpose. A row in refund_audit is a fraud control
+	// (migration 062's unique index on card_fingerprint, enforced by
+	// Service.IssueRefund), not a log line; writing one from a webhook would
+	// consume a card's single allowed refund. Reading one carries no such
+	// meaning, which is why the charge.refunded audit handler may use it.
+	ExistsByStripeRefundID(ctx context.Context, db *gorm.DB, refundID string) (bool, error)
 }
 
 type gormRepository struct{}
@@ -50,6 +61,20 @@ func (gormRepository) ExistsByStore(ctx context.Context, db *gorm.DB, storeID st
 		Limit(1).
 		Count(&count).Error; err != nil {
 		return false, fmt.Errorf("refund: exists by store: %w", err)
+	}
+	return count > 0, nil
+}
+
+func (gormRepository) ExistsByStripeRefundID(ctx context.Context, db *gorm.DB, refundID string) (bool, error) {
+	if refundID == "" {
+		return false, nil
+	}
+	var count int64
+	if err := db.WithContext(ctx).Model(&RefundAudit{}).
+		Where("stripe_refund_id = ?", refundID).
+		Limit(1).
+		Count(&count).Error; err != nil {
+		return false, fmt.Errorf("refund: exists by stripe refund id: %w", err)
 	}
 	return count > 0, nil
 }


### PR DESCRIPTION
Closes the remaining half of #705. A refund issued from the Stripe Dashboard left **no trace at all** — no audit row, no log — while refunds issued through our own admin API were fully recorded. The refunds least likely to be recorded were the ones most likely to need explaining later.

## Why an audit event and not a `refund_audit` row

#705 proposed writing a `refund_audit` row, "reusing `refund.Service`'s existing shape". That table is a **fraud control**, not a log: migration 000062 puts a UNIQUE index on `card_fingerprint`, and `internal/refund/service.go:128-137` reads it before issuing a refund and rejects one when that card already has a row.

Writing from the webhook would make a Dashboard refund silently consume that card's only allowed refund, so the next legitimate admin refund would be rejected as fraud. The issue asked for observability; that change would have altered refund **policy**. Options recorded on #705; this is option 1.

Reading the table is safe — it is only the write that carries fraud meaning.

## The part #705 did not anticipate: our own refunds fire this webhook

`refund.Service` calls Stripe's `Refunds.Create`, so Stripe sends `charge.refunded` straight back for refunds we just audited as `subscription.refund_issued`. Emitting unconditionally would double-audit **every** admin refund.

The discriminator is `refund_audit.stripe_refund_id`: our refunds are recorded there with their Stripe id, a Dashboard refund is not. New read-only `ExistsByStripeRefundID` on the refund repository, alongside the existing `ExistsByCardFingerprint`/`ExistsByStore`.

`refundIsOurs` **propagates** a lookup error rather than defaulting to "not ours" — defaulting would turn a transient DB error into a duplicate audit of a legitimate admin refund.

## Why a distinct action

`subscription.refunded_externally`, deliberately not reusing `subscription.refund_issued`. Conflating them destroys the only signal that says *this refund did not come through our controls*, which is the entire point.

Severity is `Warning`, not `Info` — a refund that skipped our guards should be findable, not routine bookkeeping.

That matters more than the missing-record complaint the issue was filed about: **`refund/service.go:80` refuses to refund a subscription holding the Pro+App add-on (`ErrProAppNotRefundable`), and that guard exists only in the admin path.** A Dashboard refund bypasses it entirely, along with the cooling-off gate and the fingerprint check. This event is the only thing that would ever reveal that happened. The action's doc comment says so.

## Mechanics

- `handleChargeRefunded` becomes a `*Dispatcher` method — as a free function it had no `d.emitter`, which is the structural reason the original `TODO(P3)` was never done. Same conversion `handleSubscriptionUpdated` had.
- Customer resolved against `store_subscriptions` inside the same `tx`. `ErrRecordNotFound` returns nil with no event and no error — preserving today's behaviour for a customer we never provisioned.
- **No redelivery guard**, deliberately: ingress already does an idempotent insert keyed on the Stripe `event_id` (`internal/handlers/webhooks/stripe.go:94`).
- `d.emitter` and the repository are both nil-safe.

## Testing

Pre-existing tests in `internal/billing/dispatch` are all `//go:build integration`, so an untagged run compiles none of them and `TEST_DATABASE_URL` is unset locally — they would skip while still printing `ok`. Every new test is untagged and genuinely executes: **13 passing**, verified with `-v`.

Covered: payload parsing (including a missing `refunds` list and malformed JSON), the emit/suppress decision, nil-emitter safety, and `refundIsOurs` across no-ids / unknown / known / short-circuit / checks-every-id, plus nil-repo and error-propagation.

The test's `stubRefundRepo` has a `Create` that **panics**, so a future change that starts writing `refund_audit` from this path fails the suite loudly rather than quietly re-introducing the fraud-guard coupling.

**Not covered by an executing test**, stated plainly: the DB-touching branches of `handleChargeRefunded` — the unknown-customer path and the tx-scoped subscription SELECT. Only the decision logic around them is unit-tested. CI's integration job is what exercises those.

`go build ./...`, `go vet` (including `-tags integration`, so the integration files still compile against the new method signature) and `go test` all clean.

Refs #705.
