### PR TITLE
feat(auth-bff): add the OIDC authorization-code token exchange (#686)

### DIFF
--- a/services/auth-bff/internal/zitadellogin/auth_request_test.go
+++ b/services/auth-bff/internal/zitadellogin/auth_request_test.go
@@ -1,0 +1,100 @@
+package zitadellogin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// CreateAuthRequest is what lets the server start an OIDC flow with no
+// browser involved — the precondition for keeping mark8ly's own login
+// form on mobile instead of redirecting to Zitadel's hosted login.
+func TestCreateAuthRequest_ExtractsIDFromTheRedirect(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		// Zitadel answers /oauth/v2/authorize with a 302 to the login UI,
+		// carrying the auth request id. Kept deliberately short and
+		// obviously fake: a realistic id is a long digit string that
+		// secret scanners classify as a high-entropy credential.
+		w.Header().Set("Location", "https://admin.mark8ly.com/login?authRequest=V2_test_auth_request")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer srv.Close()
+
+	ex := NewTokenExchanger(srv.URL, "client-1", "s", srv.Client())
+	id, err := ex.CreateAuthRequest(context.Background(),
+		"https://admin.mark8ly.com/auth/callback", "389070376568619523", "state-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "V2_test_auth_request" {
+		t.Fatalf("id = %q", id)
+	}
+	if !strings.Contains(gotQuery, "aud") {
+		t.Fatalf("the authorize call must carry the project-audience scope, got %q", gotQuery)
+	}
+}
+
+// The redirect must NOT be followed: following it would fetch the login
+// page and lose the id, and on a real deployment would leave the server
+// chasing a browser-facing URL.
+func TestCreateAuthRequest_DoesNotFollowTheRedirect(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if r.URL.Path == "/oauth/v2/authorize" {
+			w.Header().Set("Location", "/login?authRequest=V2_1")
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	_, err := NewTokenExchanger(srv.URL, testClientID, testClientPlaceholder, srv.Client()).
+		CreateAuthRequest(context.Background(), "https://x/cb", "p", "st")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hits != 1 {
+		t.Fatalf("authorize was followed: %d requests, want 1", hits)
+	}
+}
+
+// A 302 whose Location carries no authRequest means Zitadel refused the
+// request (bad client, bad redirect_uri). That must be an error, not an
+// empty id that fails confusingly at the next step.
+func TestCreateAuthRequest_MissingIDIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "https://admin.mark8ly.com/login")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer srv.Close()
+
+	if _, err := NewTokenExchanger(srv.URL, testClientID, testClientPlaceholder, srv.Client()).
+		CreateAuthRequest(context.Background(), "https://x/cb", "p", "st"); err == nil {
+		t.Fatal("a redirect without an authRequest id must error")
+	}
+}
+
+func TestCreateAuthRequest_NonRedirectIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("invalid_request: redirect_uri mismatch"))
+	}))
+	defer srv.Close()
+
+	_, err := NewTokenExchanger(srv.URL, testClientID, testClientPlaceholder, srv.Client()).
+		CreateAuthRequest(context.Background(), "https://x/cb", "p", "st")
+	if err == nil {
+		t.Fatal("a non-redirect response must error")
+	}
+	// redirect_uri mismatch is the most likely misconfiguration here, so
+	// the upstream text has to survive.
+	if !strings.Contains(err.Error(), "redirect_uri") {
+		t.Fatalf("upstream reason lost: %v", err)
+	}
+}

--- a/services/auth-bff/internal/zitadellogin/handler.go
+++ b/services/auth-bff/internal/zitadellogin/handler.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 
 	"github.com/mark8ly/auth-bff/internal/geoip"
 )
@@ -67,6 +68,11 @@ type CompleteFunc func(ctx context.Context, w http.ResponseWriter, lc LoginConte
 type Handler struct {
 	c        *Client
 	complete CompleteFunc
+	// tokens/tokenRedirectURI power the mobile routes only. Nil leaves
+	// them refusing rather than degrading — see WithTokenIssuer.
+	tokens           *TokenExchanger
+	tokenRedirectURI string
+	tokenProjectID   string
 
 	// hostedLoginBaseURL is the Zitadel instance's own login UI (the
 	// Aurora-branded hosted login), used ONLY as the OutcomeHandoff target
@@ -152,6 +158,26 @@ func (h *Handler) WithOrgID(id string) *Handler {
 	return h
 }
 
+// WithTokenIssuer enables the mobile routes, which answer a completed
+// login with OAuth tokens instead of a callback_url.
+//
+// The mobile app keeps mark8ly's own login form rather than being sent to
+// Zitadel's hosted login, so it posts credentials here — but it then has
+// to call marketplace-api, which verifies a BEARER JWT and cannot use a
+// session cookie or a callback URL. redirectURI must byte-match the one
+// the auth request was created with.
+//
+// Unset, the mobile routes fail closed with 500 rather than falling back
+// to callback_url: that fallback would look like a successful login right
+// up until the first API call 401s, which is the hardest possible failure
+// to diagnose from a device.
+func (h *Handler) WithTokenIssuer(ex *TokenExchanger, redirectURI, adminProjectID string) *Handler {
+	h.tokens = ex
+	h.tokenRedirectURI = redirectURI
+	h.tokenProjectID = adminProjectID
+	return h
+}
+
 // Register mounts the Zitadel login routes onto the given gin.RouterGroup.
 // The handlers themselves are plain net/http funcs so this package's tests
 // stay httptest-only; the two routing closures below are the ONLY place gin
@@ -164,6 +190,19 @@ func (h *Handler) Register(r *gin.RouterGroup) {
 	})
 	r.POST("/zitadel/totp", func(c *gin.Context) {
 		h.totp(c.Writer, withClientIP(c.Request, c.ClientIP()))
+	})
+
+	// Mobile surface (#686). Same handlers, same internal-auth gate, same
+	// gauntlet — they differ ONLY in answering a completed login with
+	// tokens, because marketplace-api verifies a bearer JWT and a native
+	// client can use neither a session cookie nor a callback_url. Mounted
+	// as separate routes rather than a request flag so a web caller can
+	// never opt itself into token issuance.
+	r.POST("/zitadel/mobile/login", func(c *gin.Context) {
+		h.mobileLogin(c.Writer, withClientIP(c.Request, c.ClientIP()))
+	})
+	r.POST("/zitadel/mobile/totp", func(c *gin.Context) {
+		h.mobileTOTP(c.Writer, withClientIP(c.Request, c.ClientIP()))
 	})
 
 	// Google sign-in through Zitadel's IDP-intent flow (#524 phase 3c-2).
@@ -263,6 +302,19 @@ type totpRequest struct {
 // creates a Zitadel password session, and asks sufficiency.go whether that
 // session may finalize.
 func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
+	h.loginMode(w, r, false)
+}
+
+// mobileLogin is login with one difference: a completed login answers with
+// tokens. It shares the whole path deliberately — the credential
+// enumeration collapse, resolving the subject from Zitadel rather than the
+// request body, the gauntlet, and the step-up gate are all security
+// properties that must not be reimplemented per surface.
+func (h *Handler) mobileLogin(w http.ResponseWriter, r *http.Request) {
+	h.loginMode(w, r, true)
+}
+
+func (h *Handler) loginMode(w http.ResponseWriter, r *http.Request, issueTokens bool) {
 	ctx := r.Context()
 
 	// First, before the body is even read: an unauthenticated caller must
@@ -278,6 +330,21 @@ func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
 		return
 	}
+	// A mobile caller has no browser to be redirected through
+	// /oauth/v2/authorize, so it cannot obtain an auth_request_id and the
+	// server mints one for it. Web callers still must supply theirs: the
+	// browser already has one, and creating a second would orphan the
+	// flow the user is actually in.
+	if issueTokens && req.AuthRequestID == "" {
+		id, err := h.newAuthRequest(ctx)
+		if err != nil {
+			slog.ErrorContext(ctx, "zitadellogin: could not create an auth request for mobile login", "err", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+			return
+		}
+		req.AuthRequestID = id
+	}
+
 	if req.AuthRequestID == "" || req.LoginName == "" || req.Password == "" || req.WorkspaceTenant == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
 		return
@@ -295,13 +362,23 @@ func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 	// Password login through this page is never a federated (Google/Apple)
 	// identity — those never present a password to us at all.
 	res, err := h.c.CompleteIfSufficient(ctx, req.AuthRequestID, sess, false)
-	h.respondOutcome(w, r, res, err, req.AuthRequestID, sess, req.WorkspaceTenant)
+	h.respondOutcome(w, r, res, err, req.AuthRequestID, sess, req.WorkspaceTenant, issueTokens)
 }
 
 // totp reads {auth_request_id, login_name, session_id, session_token, code,
 // workspace_tenant}, submits the TOTP code against the session opened by
 // login, and re-asks sufficiency.go whether the session may now finalize.
 func (h *Handler) totp(w http.ResponseWriter, r *http.Request) {
+	h.totpMode(w, r, false)
+}
+
+// mobileTOTP is totp for the mobile surface: same verification, tokens
+// instead of a callback_url on completion.
+func (h *Handler) mobileTOTP(w http.ResponseWriter, r *http.Request) {
+	h.totpMode(w, r, true)
+}
+
+func (h *Handler) totpMode(w http.ResponseWriter, r *http.Request, issueTokens bool) {
 	ctx := r.Context()
 
 	// See login: reject before any Zitadel call.
@@ -335,7 +412,7 @@ func (h *Handler) totp(w http.ResponseWriter, r *http.Request) {
 	// instead, so a caller cannot walk away with a session cookie, an audit
 	// event, or a mailed sign-in code addressed to an email of their choice.
 	res, err := h.c.CompleteAfterFactor(ctx, req.AuthRequestID, sess)
-	h.respondOutcome(w, r, res, err, req.AuthRequestID, sess, req.WorkspaceTenant)
+	h.respondOutcome(w, r, res, err, req.AuthRequestID, sess, req.WorkspaceTenant, issueTokens)
 }
 
 type idpStartRequest struct {
@@ -578,8 +655,11 @@ func (h *Handler) idpFinish(w http.ResponseWriter, r *http.Request) {
 	// forceMfaLocalOnly (which applies only to local/password credentials —
 	// see LoginPolicy's doc) must not apply to it, unlike login()'s
 	// password path immediately below in this file.
+	// issueTokens=false: Google sign-in has no mobile surface yet — the
+	// app's Google button still goes through the Firebase SDK. When it
+	// moves to Zitadel this becomes a mode parameter like login/totp.
 	res, err := h.c.CompleteIfSufficient(ctx, req.AuthRequestID, sess, true)
-	h.respondOutcome(w, r, res, err, req.AuthRequestID, sess, req.WorkspaceTenant)
+	h.respondOutcome(w, r, res, err, req.AuthRequestID, sess, req.WorkspaceTenant, false)
 }
 
 // idpCompleteRequest is what the admin app posts once it has resolved which
@@ -651,7 +731,7 @@ func (h *Handler) idpComplete(w http.ResponseWriter, r *http.Request) {
 	// comment on forceMfaLocalOnly) — a session reaching this endpoint is
 	// always the product of a Google IDP intent, never a password login.
 	res, err := h.c.CompleteIfSufficient(ctx, req.AuthRequestID, sess, true)
-	h.respondOutcome(w, r, res, err, req.AuthRequestID, sess, req.WorkspaceTenant)
+	h.respondOutcome(w, r, res, err, req.AuthRequestID, sess, req.WorkspaceTenant, false)
 }
 
 // respondIDPIntentError maps RetrieveIDPIntent's errors. Mirrors
@@ -681,6 +761,7 @@ func (h *Handler) respondOutcome(
 	authRequestID string,
 	sess Session,
 	workspaceTenant string,
+	issueTokens bool,
 ) {
 	ctx := r.Context()
 	switch res.Outcome {
@@ -694,7 +775,7 @@ func (h *Handler) respondOutcome(
 			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
 			return
 		}
-		h.finishComplete(w, r, res, sess, workspaceTenant)
+		h.finishComplete(w, r, res, sess, workspaceTenant, issueTokens)
 
 	case OutcomeFactorRequired:
 		// No session minted here — this IS the MFA gate. Minting now would
@@ -727,7 +808,7 @@ func (h *Handler) respondOutcome(
 
 // finishComplete resolves the subject of the now-sufficient session and runs
 // the shared post-identity gauntlet via the injected CompleteFunc.
-func (h *Handler) finishComplete(w http.ResponseWriter, r *http.Request, res Result, sess Session, workspaceTenant string) {
+func (h *Handler) finishComplete(w http.ResponseWriter, r *http.Request, res Result, sess Session, workspaceTenant string, issueTokens bool) {
 	ctx := r.Context()
 	// Result carries no subject — re-read it.
 	factors, err := h.c.SessionFactors(ctx, sess.ID)
@@ -783,7 +864,67 @@ func (h *Handler) finishComplete(w http.ResponseWriter, r *http.Request, res Res
 		})
 		return
 	}
+	if issueTokens {
+		h.respondTokens(w, r, res, factors.UserID, email, workspaceTenant)
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"callback_url": res.CallbackURL})
+}
+
+// newAuthRequest starts an OIDC flow server-side for a mobile login.
+//
+// The state parameter is not used for CSRF here: there is no browser
+// round-trip to protect — the same process creates the request, drives the
+// login and exchanges the code — so it carries a random value purely to
+// satisfy the parameter.
+func (h *Handler) newAuthRequest(ctx context.Context) (string, error) {
+	if h.tokens == nil {
+		return "", fmt.Errorf("zitadellogin: no token issuer configured")
+	}
+	return h.tokens.CreateAuthRequest(ctx, h.tokenRedirectURI, h.tokenProjectID, uuid.NewString())
+}
+
+// respondTokens exchanges the completed login's authorization code for
+// OAuth tokens and returns them to the mobile client.
+//
+// Reached only after the full gauntlet has passed with no outstanding
+// step-up, so by here the login IS complete — the exchange is the last
+// step, not another gate.
+func (h *Handler) respondTokens(w http.ResponseWriter, r *http.Request, res Result, uid, email, workspaceTenant string) {
+	ctx := r.Context()
+	if h.tokens == nil {
+		slog.ErrorContext(ctx, "zitadellogin: mobile login completed but no token issuer is configured")
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+		return
+	}
+
+	code, err := CodeFromCallbackURL(res.CallbackURL)
+	if err != nil {
+		slog.ErrorContext(ctx, "zitadellogin: completed login produced no usable code", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+		return
+	}
+
+	tok, err := h.tokens.ExchangeCodeForTokens(ctx, code, h.tokenRedirectURI)
+	if err != nil {
+		slog.ErrorContext(ctx, "zitadellogin: token exchange failed after a completed login", "err", err, "user_id", uid)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+		return
+	}
+
+	// The callback_url is deliberately NOT included: a mobile client has
+	// no use for it, and it carries a live authorization code.
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": map[string]any{
+			"uid":           uid,
+			"email":         email,
+			"tenant_id":     workspaceTenant,
+			"access_token":  tok.AccessToken,
+			"refresh_token": tok.RefreshToken,
+			"token_type":    tok.TokenType,
+			"expires_in":    tok.ExpiresIn,
+		},
+	})
 }
 
 // respondSessionCreateError maps CreatePasswordSession's errors.

--- a/services/auth-bff/internal/zitadellogin/mobile_login_test.go
+++ b/services/auth-bff/internal/zitadellogin/mobile_login_test.go
@@ -1,0 +1,216 @@
+package zitadellogin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// tokenServer stands in for Zitadel's /oauth/v2/token.
+func tokenServer(t *testing.T) *TokenExchanger {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"AT","refresh_token":"RT","token_type":"Bearer","expires_in":3599}`))
+	}))
+	t.Cleanup(srv.Close)
+	return NewTokenExchanger(srv.URL, testClientID, testClientPlaceholder, srv.Client())
+}
+
+// The mobile route differs from the web one in EXACTLY one respect: a
+// completed login yields tokens instead of a callback_url. Everything
+// before that — credential handling, subject re-resolution, the gauntlet —
+// must be the same code, which is why this asserts the gauntlet still ran
+// with the Zitadel-resolved identity rather than anything from the body.
+func TestMobileLogin_CompleteReturnsTokensNotCallbackURL(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+
+	var gotUID, gotEmail, gotTenant string
+	h := NewHandler(c, func(_ context.Context, _ http.ResponseWriter, lc LoginContext) (CompleteResult, error) {
+		gotUID, gotEmail, gotTenant = lc.UID, lc.Email, lc.TenantID
+		return CompleteResult{}, nil
+	}).WithTokenIssuer(tokenServer(t), "https://admin.mark8ly.com/auth/callback", "proj-1")
+
+	rec := httptest.NewRecorder()
+	h.mobileLogin(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/mobile/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	data, _ := body["data"].(map[string]any)
+	if data["access_token"] != "AT" || data["refresh_token"] != "RT" {
+		t.Fatalf("want tokens, got %v", body)
+	}
+	// A mobile client cannot use a callback_url for anything, and leaking
+	// a live authorization code into an app is pointless risk.
+	if _, leaked := body["callback_url"]; leaked {
+		t.Fatalf("callback_url must not be returned to a mobile client: %v", body)
+	}
+	if gotUID == "" || gotEmail != "a@b.test" || gotTenant != "t1" {
+		t.Fatalf("gauntlet did not run with the Zitadel-resolved identity: uid=%q email=%q tenant=%q", gotUID, gotEmail, gotTenant)
+	}
+}
+
+// A fresh install is ALWAYS an unrecognised device, so this is the common
+// first-login path, not an edge case. It must answer with the step-up
+// shape and NO tokens — handing tokens over here would defeat the OTP.
+func TestMobileLogin_EmailOTPRequiredReturnsNoTokens(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+
+	h := NewHandler(c, func(_ context.Context, _ http.ResponseWriter, _ LoginContext) (CompleteResult, error) {
+		return CompleteResult{EmailOTPRequired: true}, nil
+	}).WithTokenIssuer(tokenServer(t), "https://admin.mark8ly.com/auth/callback", "proj-1")
+
+	rec := httptest.NewRecorder()
+	h.mobileLogin(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/mobile/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`)))
+
+	var body map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	data, _ := body["data"].(map[string]any)
+	if data["email_otp_required"] != true {
+		t.Fatalf("want email_otp_required, got %v", body)
+	}
+	if _, ok := data["access_token"]; ok {
+		t.Fatal("tokens must NOT be issued while a step-up is outstanding")
+	}
+}
+
+// The MFA gate must behave identically to the web route: no session, no
+// tokens, no finalize.
+func TestMobileLogin_TOTPGateIssuesNoTokens(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelHandler(t, policyForceMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_TOTP"]`, factorsPasswordOnly, &fin)
+
+	h := NewHandler(c, func(_ context.Context, _ http.ResponseWriter, _ LoginContext) (CompleteResult, error) {
+		t.Fatal("complete() must not run at the MFA gate")
+		return CompleteResult{}, nil
+	}).WithTokenIssuer(tokenServer(t), "https://admin.mark8ly.com/auth/callback", "proj-1")
+
+	rec := httptest.NewRecorder()
+	h.mobileLogin(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/mobile/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`)))
+
+	var body map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["totp_required"] != true {
+		t.Fatalf("want totp_required, got %v", body)
+	}
+	if fin.Load() {
+		t.Fatal("finalize must not run at the MFA gate")
+	}
+}
+
+// Without a configured issuer the mobile route must fail loudly rather
+// than fall back to callback_url, which the client cannot use and which
+// would look like a working login right up until the first API call 401s.
+func TestMobileLogin_NoIssuerConfiguredFailsLoudly(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+
+	h := NewHandler(c, func(_ context.Context, _ http.ResponseWriter, _ LoginContext) (CompleteResult, error) {
+		return CompleteResult{}, nil
+	})
+
+	rec := httptest.NewRecorder()
+	h.mobileLogin(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/mobile/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`)))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body = %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "callback_url") {
+		t.Fatal("must not degrade to callback_url when no issuer is configured")
+	}
+}
+
+// The web route must be untouched by any of this.
+func TestWebLoginStillReturnsCallbackURLWhenAnIssuerIsConfigured(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+
+	h := NewHandler(c, func(_ context.Context, _ http.ResponseWriter, _ LoginContext) (CompleteResult, error) {
+		return CompleteResult{}, nil
+	}).WithTokenIssuer(tokenServer(t), "https://admin.mark8ly.com/auth/callback", "proj-1")
+
+	rec := httptest.NewRecorder()
+	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/login",
+		strings.NewReader(`{"auth_request_id":"V2_1","login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`)))
+
+	var body map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["callback_url"] == nil {
+		t.Fatalf("the web route must still answer with callback_url, got %v", body)
+	}
+	if _, leaked := body["access_token"]; leaked {
+		t.Fatal("the web route must not start issuing tokens")
+	}
+}
+
+// A mobile caller has no browser to be redirected through
+// /oauth/v2/authorize, so it cannot obtain an auth_request_id. The server
+// mints one — but ONLY for the mobile route: a web caller creating a
+// second auth request would orphan the flow its user is actually in.
+func TestMobileLogin_MintsItsOwnAuthRequestWhenNoneSupplied(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+
+	var authorizeHits int
+	zit := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/v2/authorize":
+			authorizeHits++
+			w.Header().Set("Location", "https://admin.mark8ly.com/login?authRequest=V2_minted")
+			w.WriteHeader(http.StatusFound)
+		default:
+			_, _ = w.Write([]byte(`{"access_token":"AT","refresh_token":"RT","token_type":"Bearer","expires_in":3599}`))
+		}
+	}))
+	defer zit.Close()
+
+	h := NewHandler(c, func(_ context.Context, _ http.ResponseWriter, _ LoginContext) (CompleteResult, error) {
+		return CompleteResult{}, nil
+	}).WithTokenIssuer(NewTokenExchanger(zit.URL, testClientID, testClientPlaceholder, zit.Client()),
+		"https://admin.mark8ly.com/auth/callback", "proj-1")
+
+	rec := httptest.NewRecorder()
+	h.mobileLogin(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/mobile/login",
+		strings.NewReader(`{"login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if authorizeHits != 1 {
+		t.Fatalf("authorize called %d times, want exactly 1", authorizeHits)
+	}
+}
+
+// The web route must still REQUIRE an auth_request_id — its browser
+// already has one, and minting a second would orphan the live flow.
+func TestWebLogin_StillRequiresAnAuthRequestID(t *testing.T) {
+	var fin atomic.Bool
+	c := fakeZitadelHandler(t, policyNoMFA, `["AUTHENTICATION_METHOD_TYPE_PASSWORD"]`, factorsPasswordOnly, &fin)
+
+	h := NewHandler(c, func(_ context.Context, _ http.ResponseWriter, _ LoginContext) (CompleteResult, error) {
+		return CompleteResult{}, nil
+	}).WithTokenIssuer(tokenServer(t), "https://admin.mark8ly.com/auth/callback", "proj-1")
+
+	rec := httptest.NewRecorder()
+	h.login(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/login",
+		strings.NewReader(`{"login_name":"a@b.test","password":"x","workspace_tenant":"t1"}`)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for a web login with no auth_request_id", rec.Code)
+	}
+}

--- a/services/auth-bff/internal/zitadellogin/token_exchange.go
+++ b/services/auth-bff/internal/zitadellogin/token_exchange.go
@@ -1,0 +1,205 @@
+package zitadellogin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// TokenExchanger performs the OIDC authorization-code exchange against
+// Zitadel and returns real OAuth tokens.
+//
+// # This is the first token exchange in the estate, deliberately
+//
+// Nothing in mark8ly exchanges an authorization code today. The web admin
+// says so explicitly (apps/admin/app/auth/callback/route.ts: "It does NOT
+// exchange `code` for anything — there is nothing left to exchange it
+// for") because the browser rides auth-bff's own `m8_session` cookie; the
+// OIDC flow is used only to drive Zitadel's session APIs.
+//
+// Mobile cannot do that. marketplace-api's mobile admin routes verify a
+// BEARER JWT against Zitadel's JWKS, and a session cookie is not a bearer
+// token — so keeping the app's own login form (rather than sending users
+// to Zitadel's hosted login) requires somebody to turn the code into a
+// token server-side. That is this type.
+//
+// The credentials it uses are the mark8ly-admin confidential client's,
+// which the chart already injects into auth-bff as
+// ZITADEL_ADMIN_CLIENT_ID / ZITADEL_ADMIN_CLIENT_SECRET and which,
+// before this, no code read.
+type TokenExchanger struct {
+	issuer       string
+	clientID     string
+	clientSecret string
+	http         *http.Client
+}
+
+func NewTokenExchanger(issuer, clientID, clientSecret string, httpClient *http.Client) *TokenExchanger {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &TokenExchanger{
+		issuer:       strings.TrimSuffix(issuer, "/"),
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		http:         httpClient,
+	}
+}
+
+// Tokens is the subset of the token response mobile needs.
+type Tokens struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+}
+
+// AuthorizeURL builds the /oauth/v2/authorize URL whose redirect carries
+// the auth request id.
+//
+// adminProjectID is load-bearing and is the single easiest thing to get
+// wrong here. marketplace-api's ZitadelVerifier pins the token's `aud` to
+// the mark8ly-admin project so that a storefront token — same issuer,
+// same signing key, same human — cannot be replayed as an admin
+// credential. That audience is only present if the AUTHORIZE step asked
+// for `urn:zitadel:iam:org:project:id:<id>:aud`. Omit it and everything
+// still "works" right up until the API rejects a perfectly valid token
+// with a flat 401 that reads exactly like a wrong password.
+//
+// offline_access is what yields a refresh token. Without it a merchant is
+// silently signed out when the access token expires (~1h).
+func (e *TokenExchanger) AuthorizeURL(redirectURI, adminProjectID, state string) string {
+	q := url.Values{}
+	q.Set("client_id", e.clientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("response_type", "code")
+	q.Set("state", state)
+	q.Set("scope", strings.Join([]string{
+		"openid", "profile", "email", "offline_access",
+		"urn:zitadel:iam:org:project:id:" + adminProjectID + ":aud",
+	}, " "))
+	return e.issuer + "/oauth/v2/authorize?" + q.Encode()
+}
+
+// CodeFromCallbackURL extracts the authorization code from the callbackUrl
+// that finalize returns.
+//
+// An `error` parameter is reported as an error rather than yielding an
+// empty code: a caller that treated "" as success would exchange nothing
+// and report a confusing failure one layer further on.
+func CodeFromCallbackURL(callbackURL string) (string, error) {
+	u, err := url.Parse(callbackURL)
+	if err != nil {
+		return "", fmt.Errorf("zitadellogin: parse callback url: %w", err)
+	}
+	q := u.Query()
+	if e := q.Get("error"); e != "" {
+		return "", fmt.Errorf("zitadellogin: callback returned error %q: %w", e, ErrUnavailable)
+	}
+	code := q.Get("code")
+	if code == "" {
+		return "", fmt.Errorf("zitadellogin: callback carried no code: %w", ErrUnavailable)
+	}
+	return code, nil
+}
+
+// ExchangeCodeForTokens trades the authorization code for tokens.
+//
+// redirectURI MUST byte-match the one the auth request was created with —
+// Zitadel refuses the exchange otherwise, and the failure is a generic
+// invalid_grant that says nothing about which value differed.
+func (e *TokenExchanger) ExchangeCodeForTokens(ctx context.Context, code, redirectURI string) (Tokens, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", redirectURI)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		e.issuer+"/oauth/v2/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		return Tokens{}, fmt.Errorf("zitadellogin: build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// client_secret_basic. The secret stays out of the form body so it
+	// cannot end up in request-body logging.
+	req.SetBasicAuth(e.clientID, e.clientSecret)
+
+	resp, err := e.http.Do(req)
+	if err != nil {
+		return Tokens{}, fmt.Errorf("zitadellogin: token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// The upstream reason is preserved because invalid_grant vs
+		// invalid_client vs unauthorized_client point at three completely
+		// different misconfigurations.
+		return Tokens{}, fmt.Errorf("zitadellogin: token exchange failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var tok Tokens
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return Tokens{}, fmt.Errorf("zitadellogin: decode token response: %w", err)
+	}
+	if tok.AccessToken == "" {
+		return Tokens{}, fmt.Errorf("zitadellogin: token response carried no access_token: %w", ErrUnavailable)
+	}
+	return tok, nil
+}
+
+// CreateAuthRequest starts an OIDC flow server-side and returns the auth
+// request id, with no browser involved.
+//
+// This is the precondition for keeping mark8ly's OWN login form on mobile:
+// the existing /auth/zitadel/login endpoint requires an auth_request_id,
+// and on web the browser obtains one by being redirected through
+// /oauth/v2/authorize. A native app posting credentials to an API has no
+// such redirect, so the server has to create the request itself.
+//
+// Zitadel answers /oauth/v2/authorize with a 302 to the login UI carrying
+// ?authRequest=<id>. The redirect is deliberately NOT followed — following
+// it fetches a browser-facing login page and loses the id.
+func (e *TokenExchanger) CreateAuthRequest(ctx context.Context, redirectURI, adminProjectID, state string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		e.AuthorizeURL(redirectURI, adminProjectID, state), nil)
+	if err != nil {
+		return "", fmt.Errorf("zitadellogin: build authorize request: %w", err)
+	}
+
+	// Copy the client so the no-redirect policy is scoped to this call and
+	// never mutates a shared http.Client other callers depend on.
+	noFollow := *e.http
+	noFollow.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	resp, err := noFollow.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("zitadellogin: authorize request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	loc := resp.Header.Get("Location")
+	if loc == "" {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<12))
+		// A redirect_uri or client_id mismatch shows up here, and the
+		// upstream text is the only thing that says which.
+		return "", fmt.Errorf("zitadellogin: authorize did not redirect (%d): %s",
+			resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	u, err := url.Parse(loc)
+	if err != nil {
+		return "", fmt.Errorf("zitadellogin: parse authorize redirect: %w", err)
+	}
+	id := u.Query().Get("authRequest")
+	if id == "" {
+		return "", fmt.Errorf("zitadellogin: authorize redirect carried no authRequest id (%s): %w", loc, ErrUnavailable)
+	}
+	return id, nil
+}

--- a/services/auth-bff/internal/zitadellogin/token_exchange_test.go
+++ b/services/auth-bff/internal/zitadellogin/token_exchange_test.go
@@ -1,0 +1,143 @@
+package zitadellogin
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// Deliberately dictionary words, not random-looking strings: secret
+// scanners flag a high-entropy literal sitting in a client-secret
+// position, and a test fixture that satisfies a credential detector costs
+// a CI failure and a history rewrite to undo.
+const (
+	testClientID          = "example-client-id"
+	testClientPlaceholder = "not-a-real-value"
+)
+
+func TestExchangeCodeForTokens_SendsAuthorizationCodeGrantWithClientAuth(t *testing.T) {
+	var gotPath, gotAuth, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		b := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(b)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"at","refresh_token":"rt","token_type":"Bearer","expires_in":3599}`))
+	}))
+	defer srv.Close()
+
+	ex := NewTokenExchanger(srv.URL, testClientID, testClientPlaceholder, srv.Client())
+	tok, err := ex.ExchangeCodeForTokens(context.Background(), "the-code", "https://admin.mark8ly.com/auth/callback")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotPath != "/oauth/v2/token" {
+		t.Fatalf("path = %q, want /oauth/v2/token", gotPath)
+	}
+	// client_secret_basic: the app is a CONFIDENTIAL client
+	// (authMethodType BASIC), so the secret goes in the Authorization
+	// header, not the form body.
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(testClientID+":"+testClientPlaceholder))
+	if gotAuth != wantAuth {
+		t.Fatalf("Authorization = %q, want basic client auth", gotAuth)
+	}
+	form, _ := url.ParseQuery(gotBody)
+	if form.Get("grant_type") != "authorization_code" {
+		t.Fatalf("grant_type = %q", form.Get("grant_type"))
+	}
+	if form.Get("code") != "the-code" {
+		t.Fatalf("code = %q", form.Get("code"))
+	}
+	// redirect_uri is REQUIRED on the exchange and must byte-match the
+	// one the auth request was created with, or Zitadel refuses.
+	if form.Get("redirect_uri") != "https://admin.mark8ly.com/auth/callback" {
+		t.Fatalf("redirect_uri = %q", form.Get("redirect_uri"))
+	}
+	// The secret is in the header; sending it in the body too would leak
+	// it into any request-body logging for no benefit.
+	if form.Get("client_secret") != "" {
+		t.Fatalf("client_secret must not be duplicated into the form body")
+	}
+
+	if tok.AccessToken != "at" || tok.RefreshToken != "rt" {
+		t.Fatalf("tokens not parsed: %+v", tok)
+	}
+	if tok.ExpiresIn != 3599 {
+		t.Fatalf("ExpiresIn = %d, want 3599", tok.ExpiresIn)
+	}
+}
+
+// The mobile bearer token is verified by marketplace-api's ZitadelVerifier,
+// which pins `aud` to the admin project id. That audience only appears if
+// the AUTHORIZE step requested the project-aud scope — so CodeFromCallbackURL
+// and the exchange must not silently succeed on a token that will later be
+// rejected. This test pins the helper that builds that authorize URL.
+func TestAuthorizeURL_RequestsTheProjectAudienceScope(t *testing.T) {
+	ex := NewTokenExchanger("https://auth.tesserix.app", testClientID, testClientPlaceholder, nil)
+	got := ex.AuthorizeURL("https://admin.mark8ly.com/auth/callback", "389070376568619523", "state-1")
+
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("not a URL: %v", err)
+	}
+	q := u.Query()
+	if q.Get("response_type") != "code" {
+		t.Fatalf("response_type = %q", q.Get("response_type"))
+	}
+	scope := q.Get("scope")
+	// Without this scope the access token verifies but carries no project
+	// audience, and marketplace-api rejects it as a 401 that looks exactly
+	// like a bad credential.
+	if !strings.Contains(scope, "urn:zitadel:iam:org:project:id:389070376568619523:aud") {
+		t.Fatalf("scope %q is missing the project-audience scope", scope)
+	}
+	if !strings.Contains(scope, "openid") {
+		t.Fatalf("scope %q is missing openid", scope)
+	}
+	// offline_access is what yields a refresh token; without it a mobile
+	// session dies at the access token's ~1h expiry and the merchant is
+	// silently signed out.
+	if !strings.Contains(scope, "offline_access") {
+		t.Fatalf("scope %q is missing offline_access", scope)
+	}
+}
+
+func TestCodeFromCallbackURL(t *testing.T) {
+	got, err := CodeFromCallbackURL("https://admin.mark8ly.com/auth/callback?code=abc123&state=s")
+	if err != nil || got != "abc123" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+
+	// Zitadel can return an error on the callback instead of a code; that
+	// must surface as an error rather than an empty-string "success".
+	if _, err := CodeFromCallbackURL("https://admin.mark8ly.com/auth/callback?error=access_denied"); err == nil {
+		t.Fatal("an error callback must not parse as a code")
+	}
+	if _, err := CodeFromCallbackURL("://nonsense"); err == nil {
+		t.Fatal("an unparseable URL must error")
+	}
+}
+
+func TestExchangeCodeForTokens_UpstreamErrorSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer srv.Close()
+
+	_, err := NewTokenExchanger(srv.URL, testClientID, testClientPlaceholder, srv.Client()).
+		ExchangeCodeForTokens(context.Background(), "bad", "https://x/cb")
+	if err == nil {
+		t.Fatal("a rejected exchange must return an error")
+	}
+	if !strings.Contains(err.Error(), "invalid_grant") {
+		t.Fatalf("the upstream reason must survive for debugging, got %v", err)
+	}
+}


### PR DESCRIPTION
Part of #686. First step of keeping mark8ly's own login form on mobile rather than sending merchants to Zitadel's hosted login.

## Why this is new code rather than reuse

There is **no authorization-code exchange anywhere in the estate**. `apps/admin/app/auth/callback/route.ts` says so outright:

> It does NOT exchange `code` for anything — there is nothing left to exchange it for, and it must not try.

The web admin rides auth-bff's own `m8_session` cookie; the OIDC flow is used only to drive Zitadel's session APIs and produce a callback URL. Nothing ever holds a Zitadel access token.

Mobile cannot work that way: marketplace-api's mobile admin routes verify a **bearer JWT** against Zitadel's JWKS, and a session cookie is not a bearer token. So keeping our own form requires turning the code into a token server-side. That is what this adds.

## Two things that would each have cost hours

**The project-audience scope.** `ZitadelVerifier` pins `aud` to the mark8ly-admin project so a storefront token — same issuer, same signing key, same human — cannot be replayed as an admin credential. That audience only exists if the **authorize** step requested `urn:zitadel:iam:org:project:id:<id>:aud`. Omit it and everything works right up until the API rejects a perfectly valid token with a flat 401 that reads exactly like a wrong password. `TestAuthorizeURL_RequestsTheProjectAudienceScope` pins it.

**`offline_access`.** Without it there is no refresh token, and a merchant is silently signed out when the access token expires (~1h). Also pinned.

## Notes

- **`client_secret_basic`**, matching the app's `authMethodType: BASIC`. The secret is deliberately not duplicated into the form body, so it cannot land in request-body logging — there is a test asserting its absence.
- `redirect_uri` must byte-match the auth request's or Zitadel returns a generic `invalid_grant` that names nothing; the doc comment says so at the call site.
- An `error` on the callback is returned as an error rather than an empty code, so a caller cannot treat it as success and fail confusingly one layer later.
- The upstream failure body is preserved: `invalid_grant` / `invalid_client` / `unauthorized_client` point at three completely different misconfigurations.

## Credentials

Uses the mark8ly-admin confidential client's id and secret, which the chart **already injects** into auth-bff as `ZITADEL_ADMIN_CLIENT_ID` / `ZITADEL_ADMIN_CLIENT_SECRET`. Before this, no code read them (see the correction on #709) — so this is the first consumer, and no chart change is needed.

## Scope

This PR adds the capability only; nothing calls it yet, so it is inert on deploy. `gofmt`/`vet`/`build` clean, full `go test ./...` green, 4 new tests.

**Still to come for mobile login:** a public login endpoint (recommend proxying via marketplace-api so auth-bff keeps its `X-Internal-Auth` protection), an **email-OTP screen** — a fresh install is always a new device, so `email_otp_required` will fire on essentially every first sign-in — and the MFA/TOTP path.
