### PR TITLE
Apply the save-offer discount, or stop claiming it

### DIFF
--- a/.planning/quick/260905-so-save-offer-honest-discount/PLAN.md
+++ b/.planning/quick/260905-so-save-offer-honest-discount/PLAN.md
@@ -1,0 +1,77 @@
+# Make the save offer apply a discount, or stop claiming one
+
+Half of #701. `internal/subscription/cancel/service.go:126-155` reverses a
+scheduled cancellation and returns:
+
+    SaveOfferMsg: "Save offer accepted. A 20% discount applies to your next billing cycle."
+
+while the discount itself is only a log line. The merchant takes an action they
+would not otherwise have taken — un-cancelling — in reliance on a statement
+returned to them as settled fact, and is then billed full price.
+
+## The blocker, established before planning
+
+**`promo_codes` is never written in production.** `promo.Repository.Create`
+exists with zero production callers; no migration seeds a code, and no admin or
+platform endpoint creates one. Both `ApplyPromo` and `ValidateForSaveOffer`
+begin with `repo.GetByCode`, so today they can only return not-found.
+
+That is not a reason to defer this. The user's decision (#701) is:
+**reverse the cancellation, but never claim a discount that was not applied.**
+With no code present the merchant gets an honest message; when promo
+provisioning lands, the same code path starts applying the discount with no
+further change.
+
+## Task
+
+In `internal/subscription/cancel`:
+
+1. Give `Service` an optional promo dependency — narrow interface, not the
+   concrete `*promo.Service`, so tests can stub it. It must be **nil-safe**:
+   a Service constructed without it behaves as today minus the false claim.
+   Check for an import cycle before choosing where the interface lives
+   (`promo` must not import `cancel`).
+2. In `acceptSaveOffer`, after the `cancel_scheduled -> active` transition
+   succeeds, attempt the discount: `ValidateForSaveOffer` then `ApplyPromo`.
+3. **The message must follow what actually happened.** Only return the "a 20%
+   discount applies" wording when `ApplyPromo` succeeded. Otherwise return a
+   message that states the reversal alone and claims no discount. Do not
+   invent a "pending" state — either it applied or it did not.
+4. **A failed or impossible discount must NOT fail the reversal.** The merchant
+   asked to un-cancel; that succeeded and is the more important half. Log the
+   reason and carry on.
+5. The promo code the save offer uses: a documented package constant, since
+   nothing today can create it. `promo_codes` has
+   `CHECK (char_length(code) >= 12)`, so the constant must satisfy that.
+   State in its comment that provisioning a code with this exact string is what
+   switches the discount on, and that until then the path is a no-op by design.
+
+## Out of scope, deliberately
+
+- **The win-back email** (`lifecycle/winback.go`). Its "20% off six months" is
+  **baked into the template subject and body** (`email/templates_content.go:57,111,219`),
+  not driven by the `promo` data key that gets passed. Fixing it means editing
+  marketing copy or attaching a real code — a product decision, not the same
+  mechanical change. Report it; do not touch it here.
+- **Creating promo codes.** No provisioning path exists (see blocker). Out of
+  scope and tracked separately.
+- Anything in `internal/promo` itself. `ValidateForSaveOffer` and `ApplyPromo`
+  are already correct; they have never been called.
+
+## Done when
+
+- Discount applied  -> reversal happens AND the message says a discount applies
+- Discount fails / no promo dep / no code -> reversal STILL happens, message
+  claims no discount, no error surfaced to the merchant
+- A promo failure never leaves the subscription cancel_scheduled
+- Tests genuinely execute — check whether this package's existing tests are
+  integration-tagged or gate on TEST_DATABASE_URL (unset locally, they skip
+  silently while printing `ok`). Factor the message decision into a pure
+  helper if that is what it takes to get real coverage.
+
+## Constraints
+
+- TDD: test first, watch it fail.
+- One atomic commit, single-line conventional message, NO attribution trailers.
+- SHARED CHECKOUT: never run checkout/switch/stash/reset. Only add + commit.
+- `go build ./...`, `go vet`, `go test` green before committing.

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1164,7 +1164,7 @@ func main() {
 		refundHandler := admin.NewRefundHandler(conn, refundSvc, log).WithAudit(auditEmitter)
 
 		// P11 — Cancel handler (merchant-initiated cancellation + save-offer §15).
-		cancelSvc := cancel.NewService(conn, subscriptionRepo, auditEmitter, log)
+		cancelSvc := cancel.NewService(conn, subscriptionRepo, auditEmitter, log).WithPromo(promoSvc)
 		cancelHandler := cancel.NewHandler(cancelSvc, log)
 
 		// P5 — Migration fast-path submit handler.

--- a/services/marketplace-api/internal/subscription/cancel/handler.go
+++ b/services/marketplace-api/internal/subscription/cancel/handler.go
@@ -26,7 +26,7 @@ type cancelRequest struct {
 	// SurveyReason is the optional exit-survey reason from the merchant.
 	SurveyReason string `json:"survey_reason"`
 	// AcceptSaveOffer true triggers the save-offer reversal branch:
-	// cancel_scheduled → active (prospective discount deferred to P10).
+	// cancel_scheduled → active, with a best-effort prospective discount.
 	AcceptSaveOffer bool `json:"accept_save_offer"`
 }
 

--- a/services/marketplace-api/internal/subscription/cancel/save_offer.go
+++ b/services/marketplace-api/internal/subscription/cancel/save_offer.go
@@ -1,0 +1,126 @@
+package cancel
+
+import (
+	"context"
+
+	"github.com/mark8ly/marketplace-api/internal/promo"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// SaveOfferPromoCode is the promo code the cancellation save offer redeems.
+//
+// Provisioning a promo_codes row whose code is exactly this string is what
+// switches the save-offer discount on. Nothing in the product creates promo
+// codes today (promo.Repository.Create has no production caller and no
+// migration seeds a row), so until such a row exists this path is a deliberate
+// no-op: the reversal still happens and the merchant is simply not told about a
+// discount that was not applied (#701).
+//
+// The promo_codes table carries CHECK (char_length(code) >= 12), so any
+// replacement for this constant must be at least 12 characters or it could
+// never be provisioned.
+const SaveOfferPromoCode = "SAVEOFFER20OFF6MONTHS"
+
+const (
+	saveOfferMsgDiscountApplied = "Save offer accepted. A 20% discount applies to your next billing cycle."
+	saveOfferMsgReversalOnly    = "Save offer accepted. Your subscription stays active and will not be cancelled."
+)
+
+// PromoApplier is the narrow slice of promo.Service the save offer needs.
+// Declared here (rather than depending on *promo.Service) so the dependency is
+// optional and stubbable; promo does not import this package, so there is no
+// import cycle.
+type PromoApplier interface {
+	ValidateForSaveOffer(ctx context.Context, in promo.ApplyInput) (promo.ApplyOutput, error)
+	ApplyPromo(ctx context.Context, in promo.ApplyInput) (promo.ApplyOutput, error)
+}
+
+// WithPromo returns a copy of the Service that attempts the save-offer discount
+// through p. A Service without one behaves exactly as before, minus the false
+// discount claim. Passing a nil applier leaves the Service unchanged.
+func (s *Service) WithPromo(p PromoApplier) *Service {
+	if s == nil || p == nil {
+		return s
+	}
+	cp := *s
+	cp.promo = p
+	return &cp
+}
+
+// SaveOfferMessage returns the merchant-facing message for an accepted save
+// offer. It claims the discount only when one was actually applied — the
+// merchant un-cancels in reliance on this sentence, so it must never describe a
+// discount that does not exist (#701).
+func SaveOfferMessage(discountApplied bool) string {
+	if discountApplied {
+		return saveOfferMsgDiscountApplied
+	}
+	return saveOfferMsgReversalOnly
+}
+
+// saveOfferOutput builds the response for a completed save-offer reversal. The
+// status is active either way: whether the discount applied has no bearing on
+// the reversal, which has already been committed by the time this is called.
+func saveOfferOutput(discountApplied bool) Output {
+	return Output{
+		Status:       string(subscription.StatusActive),
+		SaveOfferMsg: SaveOfferMessage(discountApplied),
+	}
+}
+
+// applySaveOfferDiscount attempts to attach the save-offer discount and reports
+// whether it was actually applied.
+//
+// It deliberately returns no error. The merchant asked to un-cancel and that
+// has already succeeded; a discount that cannot be applied must never fail the
+// reversal or surface an error to them. Every failure path is logged and
+// reported as "not applied", which the message then reflects honestly.
+func (s *Service) applySaveOfferDiscount(ctx context.Context, in Input, sub *subscription.StoreSubscription) bool {
+	if s.promo == nil {
+		s.logger.Info("cancel: save offer accepted without a promo service — no discount applied",
+			"store_id", in.StoreID, "tenant_id", in.TenantID)
+		return false
+	}
+	if sub == nil {
+		s.logger.Warn("cancel: save offer accepted with no subscription loaded — no discount applied",
+			"store_id", in.StoreID, "tenant_id", in.TenantID)
+		return false
+	}
+
+	applyIn := promo.ApplyInput{
+		TenantID:             in.TenantID,
+		StoreID:              in.StoreID,
+		SubscriptionID:       sub.ID,
+		Code:                 SaveOfferPromoCode,
+		MerchantEmail:        derefString(sub.Email),
+		Plan:                 sub.Plan,
+		Period:               sub.SubscriptionPeriod,
+		BasePriceMinor:       0, // floor validation keys off plan + currency; mirrors admin.PromoHandler.
+		Currency:             derefString(sub.BillingCurrency),
+		StripeSubscriptionID: derefString(sub.StripeSubscriptionID),
+		Actor:                in.Actor,
+	}
+
+	if _, err := s.promo.ValidateForSaveOffer(ctx, applyIn); err != nil {
+		s.logger.Info("cancel: save-offer discount not available — reversal stands, no discount claimed",
+			"store_id", in.StoreID, "tenant_id", in.TenantID, "code", SaveOfferPromoCode, "err", err)
+		return false
+	}
+
+	if _, err := s.promo.ApplyPromo(ctx, applyIn); err != nil {
+		s.logger.Warn("cancel: save-offer discount failed to apply — reversal stands, no discount claimed",
+			"store_id", in.StoreID, "tenant_id", in.TenantID, "code", SaveOfferPromoCode, "err", err)
+		return false
+	}
+
+	s.logger.Info("cancel: save-offer discount applied",
+		"store_id", in.StoreID, "tenant_id", in.TenantID, "code", SaveOfferPromoCode)
+	return true
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/services/marketplace-api/internal/subscription/cancel/save_offer_test.go
+++ b/services/marketplace-api/internal/subscription/cancel/save_offer_test.go
@@ -1,0 +1,154 @@
+package cancel
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/promo"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// stubPromo is a PromoApplier double. Each call records its input so tests can
+// assert the save offer redeems the documented package constant.
+type stubPromo struct {
+	validateOut promo.ApplyOutput
+	validateErr error
+	applyOut    promo.ApplyOutput
+	applyErr    error
+
+	validateCalls []promo.ApplyInput
+	applyCalls    []promo.ApplyInput
+}
+
+func (s *stubPromo) ValidateForSaveOffer(_ context.Context, in promo.ApplyInput) (promo.ApplyOutput, error) {
+	s.validateCalls = append(s.validateCalls, in)
+	return s.validateOut, s.validateErr
+}
+
+func (s *stubPromo) ApplyPromo(_ context.Context, in promo.ApplyInput) (promo.ApplyOutput, error) {
+	s.applyCalls = append(s.applyCalls, in)
+	return s.applyOut, s.applyErr
+}
+
+func testService(p PromoApplier) *Service {
+	return (&Service{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}).WithPromo(p)
+}
+
+func testSub() *subscription.StoreSubscription {
+	email := "merchant@example.com"
+	stripeSub := "sub_123"
+	currency := "aud"
+	return &subscription.StoreSubscription{
+		ID:                   uuid.New(),
+		TenantID:             uuid.New(),
+		StoreID:              uuid.New(),
+		Email:                &email,
+		StripeSubscriptionID: &stripeSub,
+		BillingCurrency:      &currency,
+		Status:               subscription.StatusCancelScheduled,
+	}
+}
+
+func testInput(sub *subscription.StoreSubscription) Input {
+	return Input{
+		TenantID:        sub.TenantID,
+		StoreID:         sub.StoreID,
+		Actor:           "user:" + uuid.NewString(),
+		AcceptSaveOffer: true,
+	}
+}
+
+// TestSaveOfferPromoCode_SatisfiesLengthCheck guards the promo_codes
+// CHECK (char_length(code) >= 12) constraint: a shorter constant could never be
+// provisioned, so the discount could never be switched on.
+func TestSaveOfferPromoCode_SatisfiesLengthCheck(t *testing.T) {
+	require.GreaterOrEqual(t, len(SaveOfferPromoCode), 12,
+		"promo_codes CHECK (char_length(code) >= 12) — a shorter code cannot be provisioned")
+}
+
+// TestSaveOfferMessage_ClaimsDiscountOnlyWhenApplied is the core of #701: the
+// merchant must never be told a discount applies when none was applied.
+func TestSaveOfferMessage_ClaimsDiscountOnlyWhenApplied(t *testing.T) {
+	applied := SaveOfferMessage(true)
+	require.Contains(t, applied, "20%", "an applied discount must be stated")
+
+	notApplied := SaveOfferMessage(false)
+	require.NotContains(t, notApplied, "20%")
+	require.NotContains(t, strings.ToLower(notApplied), "discount",
+		"a discount that was not applied must not be claimed in any form")
+	require.NotEmpty(t, notApplied, "the reversal itself must still be confirmed")
+}
+
+// TestSaveOfferOutput_AlwaysActive proves a promo failure can never leave the
+// merchant looking cancel_scheduled: the output status is active either way.
+func TestSaveOfferOutput_AlwaysActive(t *testing.T) {
+	for _, applied := range []bool{true, false} {
+		out := saveOfferOutput(applied)
+		require.Equal(t, string(subscription.StatusActive), out.Status)
+		require.Empty(t, out.CancelsAt, "an un-cancelled subscription has no cancellation date")
+		require.Equal(t, SaveOfferMessage(applied), out.SaveOfferMsg)
+	}
+}
+
+func TestApplySaveOfferDiscount_AppliedWhenPromoSucceeds(t *testing.T) {
+	sub := testSub()
+	stub := &stubPromo{}
+	svc := testService(stub)
+
+	require.True(t, svc.applySaveOfferDiscount(context.Background(), testInput(sub), sub))
+	require.Len(t, stub.validateCalls, 1)
+	require.Len(t, stub.applyCalls, 1)
+	require.Equal(t, SaveOfferPromoCode, stub.applyCalls[0].Code)
+	require.Equal(t, "merchant@example.com", stub.applyCalls[0].MerchantEmail)
+	require.Equal(t, "sub_123", stub.applyCalls[0].StripeSubscriptionID)
+	require.Equal(t, "aud", stub.applyCalls[0].Currency)
+	require.Equal(t, sub.ID, stub.applyCalls[0].SubscriptionID)
+}
+
+func TestApplySaveOfferDiscount_NotAppliedWhenValidationRejects(t *testing.T) {
+	sub := testSub()
+	// The live behaviour today: no promo_codes row exists, so validation is a
+	// uniform invalid-or-expired rejection.
+	stub := &stubPromo{validateErr: promo.ErrInvalidOrExpired}
+	svc := testService(stub)
+
+	require.False(t, svc.applySaveOfferDiscount(context.Background(), testInput(sub), sub))
+	require.Empty(t, stub.applyCalls, "a rejected code must never be applied")
+}
+
+func TestApplySaveOfferDiscount_NotAppliedWhenApplyFails(t *testing.T) {
+	sub := testSub()
+	stub := &stubPromo{applyErr: errors.New("stripe: coupon attach failed")}
+	svc := testService(stub)
+
+	require.False(t, svc.applySaveOfferDiscount(context.Background(), testInput(sub), sub))
+	require.Len(t, stub.applyCalls, 1)
+}
+
+func TestApplySaveOfferDiscount_NilPromoDependencyIsSafe(t *testing.T) {
+	sub := testSub()
+	svc := testService(nil)
+
+	require.NotPanics(t, func() {
+		require.False(t, svc.applySaveOfferDiscount(context.Background(), testInput(sub), sub))
+	})
+}
+
+// TestApplySaveOfferDiscount_NilSubscriptionIsSafe covers the defensive path:
+// a missing subscription must not panic mid-reversal.
+func TestApplySaveOfferDiscount_NilSubscriptionIsSafe(t *testing.T) {
+	stub := &stubPromo{}
+	svc := testService(stub)
+
+	require.NotPanics(t, func() {
+		require.False(t, svc.applySaveOfferDiscount(context.Background(), Input{}, nil))
+	})
+	require.Empty(t, stub.validateCalls)
+}

--- a/services/marketplace-api/internal/subscription/cancel/service.go
+++ b/services/marketplace-api/internal/subscription/cancel/service.go
@@ -47,6 +47,9 @@ type Service struct {
 	repo    subscription.Repository
 	emitter *audit.Emitter
 	logger  *slog.Logger
+	// promo is optional. When nil the save offer reverses the cancellation and
+	// claims no discount; see WithPromo in save_offer.go.
+	promo PromoApplier
 }
 
 // NewService constructs a cancel.Service.
@@ -58,9 +61,9 @@ func NewService(db *gorm.DB, repo subscription.Repository, emitter *audit.Emitte
 //
 // Save-offer branch (§15.1):
 //   - AcceptSaveOffer=true AND status=cancel_scheduled → transition back to active.
-//     The discount (20%-off-6-months) is prospective-only and is NOT applied here —
-//     P10's promo service owns that; P11 only drives the state transition and emits
-//     the audit event with a note so P10 can wire it later.
+//     The discount (20%-off-6-months) is prospective-only. It is attempted after
+//     the transition via the optional promo dependency, and the response claims a
+//     discount only when one was actually applied (#701).
 //   - AcceptSaveOffer=false (or no offer presented) → transition active → cancel_scheduled
 //     setting cancel_at_period_end=true. The subscription expires at Stripe's
 //     current_period_end; we do NOT call Stripe here because Stripe already has
@@ -122,7 +125,8 @@ func (s *Service) scheduleCancellation(ctx context.Context, in Input, sub *subsc
 }
 
 // acceptSaveOffer reverts cancel_scheduled → active (prospective save-offer path).
-// The actual promo/discount is NOT applied here; P10 owns that wiring.
+// The discount is best-effort: it is attempted only after the reversal has been
+// committed, and a failure downgrades the message rather than failing the call.
 func (s *Service) acceptSaveOffer(ctx context.Context, in Input, sub *subscription.StoreSubscription) (Output, error) {
 	if sub.Status != subscription.StatusCancelScheduled {
 		return Output{}, fmt.Errorf("%w: must be cancel_scheduled to accept save offer, got %s", ErrSaveOfferAlreadyAccepted, sub.Status)
@@ -142,17 +146,17 @@ func (s *Service) acceptSaveOffer(ctx context.Context, in Input, sub *subscripti
 		return Output{}, fmt.Errorf("cancel: save-offer transition: %w", err)
 	}
 
-	// NOTE: P10 promo service would be called here to attach a prospective-only
-	// discount (20%-off-6-months). Until P10 is wired, log intent.
-	s.logger.Info("cancel: save offer accepted — would apply prospective promo (P10 not yet wired)",
+	// The reversal is committed. Attempt the prospective-only discount; whether
+	// it lands only changes what we tell the merchant, never the reversal.
+	discountApplied := s.applySaveOfferDiscount(ctx, in, sub)
+
+	s.logger.Info("cancel: save offer accepted",
 		"store_id", in.StoreID,
 		"tenant_id", in.TenantID,
-		"actor", in.Actor)
+		"actor", in.Actor,
+		"discount_applied", discountApplied)
 
-	return Output{
-		Status:       string(subscription.StatusActive),
-		SaveOfferMsg: "Save offer accepted. A 20% discount applies to your next billing cycle.",
-	}, nil
+	return saveOfferOutput(discountApplied), nil
 }
 
 // IsCancellableStatus reports whether a subscription in the given status may be


### PR DESCRIPTION
Half of #701. `acceptSaveOffer` reversed a scheduled cancellation and told the merchant:

    "Save offer accepted. A 20% discount applies to your next billing cycle."

while the discount itself was only a log line. The merchant took an action they would not otherwise have taken — un-cancelling — in reliance on a statement returned as settled fact, and was then billed full price.

Now the message follows what actually happened.

## The blocker, and why it did not stop this

**`promo_codes` is never written in production.** `promo.Repository.Create` has zero production callers, no migration seeds a code, no endpoint creates one — filed as its own issue, since it also means the live `POST /apply-promo` endpoint can never succeed.

So wiring the discount cannot make it apply *today*. That turns out not to matter, because the harm was never the missing discount — it was the false claim. The chosen shape (agreed on #701) is: **reverse the cancellation, but never claim a discount that was not applied.** With no code present the merchant gets an honest message; when provisioning lands, the same path starts applying the discount with no further change.

## What changed

- `PromoApplier` — a narrow interface (`ValidateForSaveOffer`, `ApplyPromo`) declared in `cancel`, so tests can stub it. No import cycle: `promo` imports `internal/subscription`, never `subscription/cancel`.
- `WithPromo` returns a **copy** of the Service rather than mutating, and `NewService`'s signature is unchanged, so existing callers compile untouched.
- `SaveOfferMessage(bool)` and `saveOfferOutput(bool)` are pure and unit-testable. There is deliberately **no "pending discount" state** — either it applied or it did not.
- `applySaveOfferDiscount` **returns no error by signature**, so it is structurally impossible for a promo failure to fail the reversal. That is the property that matters most: the merchant asked to un-cancel, that half succeeded, and a discount problem must never undo it.
- `SaveOfferPromoCode = "SAVEOFFER20OFF6MONTHS"` — 21 chars, satisfying `promo_codes`' `CHECK (char_length(code) >= 12)`. Its comment states that provisioning a row with exactly this string is what switches the discount on, and that until then the path is a deliberate no-op rather than an oversight.

## Not in scope

**The win-back email.** Its "20% off six months" is baked into the template subject and body, not driven by the `promo` data key that `winback.go` passes — that value is inert. Fixing it means editing marketing copy or attaching a real code, which is a product decision. Filed separately.

**Promo-code provisioning**, for the reasons above — and because adding a local create path would entrench a second source of truth against tesserix-home#521, which made the console the owner of promo definitions.

## Testing

The `cancel` package has no `//go:build integration` files and no `TEST_DATABASE_URL` gate, so its tests genuinely run — worth stating, because several neighbouring packages skip silently while still printing `ok`.

**13 tests pass**, 8 of them new, verified with `-v`: the message claims a discount only when applied; output is always `active` so a promo outcome cannot affect reported state; validation rejection never reaches `ApplyPromo`; and nil-promo and nil-subscription are both safe.

`go build ./...`, `go vet` (including `-tags integration`) and `go test` all clean.

## Note on how this branch was built

The implementation was first committed on a branch that still carried #705's commits (since merged as `abddae3e`), and whose `main.go` predated the #686 work now in `main`. Taking that file wholesale would have **reverted `MyTenantsHandler`**. This branch was rebuilt on current `origin/main` with only the single `WithPromo` line applied to `main.go`; the #686 references are verified intact (3, matching `origin/main`).

## One thing for a reviewer

`applySaveOfferDiscount` passes `BasePriceMinor: 0`, mirroring the existing `internal/handlers/admin/promo.go:99`, which carries a "populated in future" comment. Floor validation keys off plan and currency, so this is consistent with the only other call site rather than a new shortcut — but if that placeholder is wrong it is wrong in both, and belongs to its own fix.

Refs #701.
