### PR TITLE
feat(marketplace-api): add the public mobile sign-in front door (#686)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/arbitrage"
 	"github.com/mark8ly/marketplace-api/internal/audit"
 	"github.com/mark8ly/marketplace-api/internal/auth"
+	"github.com/mark8ly/marketplace-api/internal/authbffclient"
 	"github.com/mark8ly/marketplace-api/internal/authz"
 	"github.com/mark8ly/marketplace-api/internal/billing/appaddon"
 	appcredspkg "github.com/mark8ly/marketplace-api/internal/billing/appcreds"
@@ -1421,6 +1422,7 @@ func main() {
 		var teamHandler *admin.TeamHandler
 		var mobileAccountHandler *admin.MobileAccountHandler
 		var myTenantsHandler *admin.MobileMyTenantsHandler
+		var mobileLoginHandler *admin.MobileLoginHandler
 		if cfg.PlatformAPIURL != "" {
 			teamClient := teamproxy.NewClient(cfg.PlatformAPIURL, cfg.PlatformAPISecret, nil)
 			teamHandler = admin.NewTeamHandler(teamClient, log)
@@ -1430,6 +1432,19 @@ func main() {
 			// and the route unmounted, which is the pre-existing shape for
 			// every platform-backed mobile route.
 			myTenantsHandler = admin.NewMobileMyTenantsHandler(teamClient, log)
+			// Public mobile sign-in (#686). Needs auth-bff as well as the
+			// platform client; both env vars already exist on this
+			// deployment, so no chart change. Unset AUTH_BFF_URL leaves it
+			// nil and the route unmounted.
+			if cfg.AuthBFFURL != "" {
+				mobileLoginHandler = admin.NewMobileLoginHandler(
+					teamClient,
+					authbffclient.NewMobileLoginClient(cfg.AuthBFFURL, cfg.InternalAuthSecret, nil),
+					log,
+				)
+			} else {
+				log.Info("mobile login: AUTH_BFF_URL empty; mobile sign-in route disabled")
+			}
 		} else {
 			log.Info("team: platform client not configured (MARKETPLACE_PLATFORM_API_URL empty); team + account-deletion routes disabled")
 		}
@@ -1460,6 +1475,7 @@ func main() {
 			// MobileDeps.DualIssuer.
 			DualIssuer:       cfg.ZitadelEnabled && cfg.ZitadelDualIssuer,
 			MyTenantsHandler: myTenantsHandler,
+			LoginHandler:     mobileLoginHandler,
 			// Resolves X-Acting-Tenant-Id via the same FGA client the rest
 			// of the admin surface already checks permissions against, for
 			// bearer tokens (Zitadel) that carry no tenant_id claim at

--- a/services/marketplace-api/internal/authbffclient/mobile_login.go
+++ b/services/marketplace-api/internal/authbffclient/mobile_login.go
@@ -1,0 +1,166 @@
+package authbffclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ErrInvalidCredentials is auth-bff's enumeration-safe rejection: a wrong
+// password and a non-existent account produce this identical error, and
+// callers must not try to tell them apart.
+var ErrInvalidCredentials = errors.New("authbffclient: invalid credentials")
+
+// MobileLoginClient calls auth-bff's mobile login routes.
+//
+// # Why marketplace-api proxies this rather than the app calling auth-bff
+//
+// auth-bff is internet-reachable at auth.mark8ly.com, and the ONLY thing
+// protecting /auth/zitadel/login from credential stuffing is the
+// X-Internal-Auth secret that its trusted server-side callers hold. A
+// device cannot hold that secret. Exposing an unauthenticated login route
+// on auth-bff would remove that protection for every surface at once.
+//
+// marketplace-api is already the app's public backend, already holds the
+// same secret (MARKETPLACE_INTERNAL_AUTH_SECRET — the identical GCP secret
+// auth-bff checks against), and already has a per-user rate limiter. So
+// the public front door lives there and auth-bff keeps its gate.
+type MobileLoginClient struct {
+	baseURL string
+	secret  string
+	http    *http.Client
+}
+
+func NewMobileLoginClient(baseURL, secret string, httpClient *http.Client) *MobileLoginClient {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 15 * time.Second}
+	}
+	return &MobileLoginClient{baseURL: baseURL, secret: secret, http: httpClient}
+}
+
+// LoginResult carries every outcome auth-bff can report. Exactly one of
+// {tokens present, EmailOTPRequired, TOTPRequired} is true on success.
+type LoginResult struct {
+	UID          string
+	Email        string
+	TenantID     string
+	AccessToken  string
+	RefreshToken string
+	TokenType    string
+	ExpiresIn    int
+
+	// EmailOTPRequired is the COMMON first-login case on mobile, not an
+	// edge case: a fresh install is by definition an unrecognised device.
+	EmailOTPRequired bool
+	MFARequired      bool
+
+	TOTPRequired bool
+	SessionID    string
+	SessionToken string
+}
+
+type loginWire struct {
+	Data *struct {
+		UID              string `json:"uid"`
+		Email            string `json:"email"`
+		TenantID         string `json:"tenant_id"`
+		AccessToken      string `json:"access_token"`
+		RefreshToken     string `json:"refresh_token"`
+		TokenType        string `json:"token_type"`
+		ExpiresIn        int    `json:"expires_in"`
+		EmailOTPRequired bool   `json:"email_otp_required"`
+		MFARequired      bool   `json:"mfa_required"`
+	} `json:"data"`
+	TOTPRequired bool   `json:"totp_required"`
+	SessionID    string `json:"session_id"`
+	SessionToken string `json:"session_token"`
+}
+
+// Login posts credentials to auth-bff's mobile route.
+//
+// auth_request_id is deliberately NOT sent: auth-bff mints one for the
+// mobile route, because a native client has no browser redirect through
+// /oauth/v2/authorize to obtain one.
+//
+// A step-up (email OTP or TOTP) is a normal successful outcome, not an
+// error — treating it as failure is what produced the silent redirect loop
+// in #493, where every layer logged success and the user saw nothing.
+func (c *MobileLoginClient) Login(ctx context.Context, email, password, workspaceTenant string) (LoginResult, error) {
+	return c.post(ctx, "/auth/zitadel/mobile/login", map[string]any{
+		"login_name":       email,
+		"password":         password,
+		"workspace_tenant": workspaceTenant,
+	})
+}
+
+// VerifyTOTP completes a login that stopped at the TOTP gate.
+func (c *MobileLoginClient) VerifyTOTP(ctx context.Context, authRequestID, email, sessionID, sessionToken, code, workspaceTenant string) (LoginResult, error) {
+	return c.post(ctx, "/auth/zitadel/mobile/totp", map[string]any{
+		"auth_request_id":  authRequestID,
+		"login_name":       email,
+		"session_id":       sessionID,
+		"session_token":    sessionToken,
+		"code":             code,
+		"workspace_tenant": workspaceTenant,
+	})
+}
+
+func (c *MobileLoginClient) post(ctx context.Context, path string, body map[string]any) (LoginResult, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return LoginResult{}, fmt.Errorf("authbffclient: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(b))
+	if err != nil {
+		return LoginResult{}, fmt.Errorf("authbffclient: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.secret != "" {
+		req.Header.Set("X-Internal-Auth", c.secret)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return LoginResult{}, fmt.Errorf("authbffclient: %w", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		// Preserved as a distinct error so the handler can answer 401
+		// rather than flattening it into an upstream failure — a merchant
+		// typing the wrong password must not be told the service is down.
+		return LoginResult{}, ErrInvalidCredentials
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return LoginResult{}, fmt.Errorf("authbffclient: auth-bff returned %d: %s", resp.StatusCode, string(raw))
+	}
+
+	var wire loginWire
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		return LoginResult{}, fmt.Errorf("authbffclient: decode: %w", err)
+	}
+
+	out := LoginResult{
+		TOTPRequired: wire.TOTPRequired,
+		SessionID:    wire.SessionID,
+		SessionToken: wire.SessionToken,
+	}
+	if wire.Data != nil {
+		out.UID = wire.Data.UID
+		out.Email = wire.Data.Email
+		out.TenantID = wire.Data.TenantID
+		out.AccessToken = wire.Data.AccessToken
+		out.RefreshToken = wire.Data.RefreshToken
+		out.TokenType = wire.Data.TokenType
+		out.ExpiresIn = wire.Data.ExpiresIn
+		out.EmailOTPRequired = wire.Data.EmailOTPRequired
+		out.MFARequired = wire.Data.MFARequired
+	}
+	return out, nil
+}

--- a/services/marketplace-api/internal/authbffclient/mobile_login_test.go
+++ b/services/marketplace-api/internal/authbffclient/mobile_login_test.go
@@ -1,0 +1,101 @@
+package authbffclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMobileLogin_PostsToAuthBFFWithInternalAuth(t *testing.T) {
+	var gotPath, gotSecret string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotSecret = r.Header.Get("X-Internal-Auth")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = w.Write([]byte(`{"data":{"uid":"u1","email":"a@b.test","tenant_id":"t1","access_token":"AT","refresh_token":"RT","token_type":"Bearer","expires_in":3599}}`))
+	}))
+	defer srv.Close()
+
+	got, err := NewMobileLoginClient(srv.URL, "s3cret", srv.Client()).
+		Login(context.Background(), "a@b.test", "pw", "t1")
+	require.NoError(t, err)
+
+	require.Equal(t, "/auth/zitadel/mobile/login", gotPath)
+	// auth-bff's login route is internet-reachable at auth.mark8ly.com and
+	// its ONLY protection is this header. Dropping it would turn the proxy
+	// into an open credential oracle.
+	require.Equal(t, "s3cret", gotSecret)
+	require.Equal(t, "a@b.test", gotBody["login_name"])
+	require.Equal(t, "t1", gotBody["workspace_tenant"])
+	// auth_request_id is deliberately absent — auth-bff mints it for the
+	// mobile route, because a native client has no browser redirect.
+	require.NotContains(t, gotBody, "auth_request_id")
+
+	require.Equal(t, "AT", got.AccessToken)
+	require.Equal(t, "RT", got.RefreshToken)
+	require.Equal(t, "t1", got.TenantID)
+	require.False(t, got.EmailOTPRequired)
+}
+
+// A fresh install is always an unrecognised device, so this is the normal
+// first-login path. It must surface as a step-up, NOT as a failure and not
+// as a login with empty tokens.
+func TestMobileLogin_EmailOTPRequiredSurfacesAsAStepUp(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"uid":"u1","email":"a@b.test","tenant_id":"t1","email_otp_required":true,"mfa_required":false}}`))
+	}))
+	defer srv.Close()
+
+	got, err := NewMobileLoginClient(srv.URL, "", srv.Client()).
+		Login(context.Background(), "a@b.test", "pw", "t1")
+	require.NoError(t, err, "a step-up is a normal outcome, not an error")
+	require.True(t, got.EmailOTPRequired)
+	require.Empty(t, got.AccessToken, "no token may be issued while a step-up is outstanding")
+}
+
+func TestMobileLogin_TOTPRequiredCarriesTheSessionHandles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"totp_required":true,"session_id":"sid","session_token":"stok"}`))
+	}))
+	defer srv.Close()
+
+	got, err := NewMobileLoginClient(srv.URL, "", srv.Client()).
+		Login(context.Background(), "a@b.test", "pw", "t1")
+	require.NoError(t, err)
+	require.True(t, got.TOTPRequired)
+	// The client needs these to complete the second step.
+	require.Equal(t, "sid", got.SessionID)
+	require.Equal(t, "stok", got.SessionToken)
+}
+
+// Bad credentials must stay a 401 with auth-bff's enumeration-safe body,
+// not be flattened into a generic 502.
+func TestMobileLogin_InvalidCredentialsSurfacesAsUnauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_credentials"}`))
+	}))
+	defer srv.Close()
+
+	_, err := NewMobileLoginClient(srv.URL, "", srv.Client()).
+		Login(context.Background(), "a@b.test", "bad", "t1")
+	require.ErrorIs(t, err, ErrInvalidCredentials)
+}
+
+func TestMobileLogin_UpstreamFailureIsDistinctFromBadCredentials(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := NewMobileLoginClient(srv.URL, "", srv.Client()).
+		Login(context.Background(), "a@b.test", "pw", "t1")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrInvalidCredentials,
+		"an auth-bff outage must never read as 'wrong password'")
+}

--- a/services/marketplace-api/internal/handlers/admin/mobile_auth_login.go
+++ b/services/marketplace-api/internal/handlers/admin/mobile_auth_login.go
@@ -1,0 +1,150 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/marketplace-api/internal/authbffclient"
+	"github.com/mark8ly/marketplace-api/internal/teamproxy"
+)
+
+// MobileLoginBackend is the slice of authbffclient.MobileLoginClient this
+// handler needs.
+type MobileLoginBackend interface {
+	Login(ctx context.Context, email, password, workspaceTenant string) (authbffclient.LoginResult, error)
+}
+
+// MobileLoginHandler is the app's public front door for signing in.
+//
+// # Why the front door is here and not on auth-bff
+//
+// The app keeps mark8ly's own login form rather than being sent to
+// Zitadel's hosted login, so credentials have to reach a public endpoint.
+// auth-bff is internet-reachable at auth.mark8ly.com and the ONLY thing
+// protecting its login route from credential stuffing is the
+// X-Internal-Auth secret its trusted server-side callers hold — which a
+// device cannot hold. Adding an unauthenticated route there would remove
+// that protection for every surface at once.
+//
+// marketplace-api is already the app's public backend, already holds the
+// identical secret, and already has IP rate limiting. So the public
+// surface lives here and auth-bff keeps its gate.
+//
+// # Why it resolves the tenant first
+//
+// auth-bff requires a workspace_tenant, and the client cannot know one: a
+// Zitadel token carries no tenant claim, and tenant discovery itself needs
+// a token. So the tenant is resolved from the EMAIL before authenticating
+// — exactly what the web does in resolveWorkspaceTenant, and why
+// platform-api's lookup accepts an email as well as a uid.
+type MobileLoginHandler struct {
+	lister  TenantLister
+	backend MobileLoginBackend
+	log     *slog.Logger
+}
+
+func NewMobileLoginHandler(lister TenantLister, backend MobileLoginBackend, log *slog.Logger) *MobileLoginHandler {
+	return &MobileLoginHandler{lister: lister, backend: backend, log: log}
+}
+
+type mobileLoginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+// Login authenticates and, on success, returns bearer tokens.
+//
+// A step-up (email OTP or TOTP) is a SUCCESSFUL outcome reported in the
+// body, not an error. Treating it as failure is what produced the silent
+// redirect loop in #493, where every layer logged 200 and the user was
+// bounced back to the login screen with nothing shown.
+func (h *MobileLoginHandler) Login(c *gin.Context) {
+	var req mobileLoginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "message": "email and password are required"})
+		return
+	}
+	email := strings.TrimSpace(req.Email)
+	if email == "" || req.Password == "" {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "message": "email and password are required"})
+		return
+	}
+
+	tenants, err := h.lister.ListMyTenants(c.Request.Context(), email)
+	if err != nil {
+		h.logError("mobile login: tenant lookup failed", err)
+		c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{"error": "platform_unavailable", "message": "could not look up your stores"})
+		return
+	}
+	if len(tenants) == 0 {
+		// Refused WITHOUT sending the password anywhere: there is no
+		// workspace_tenant to authenticate against, so probing the
+		// credential would be exposure for no result.
+		//
+		// This does reveal that an address has no membership. It is the
+		// same signal the web sign-in already gives, and the alternative
+		// (authenticate, then refuse) would check credentials for
+		// arbitrary addresses on an unauthenticated endpoint.
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
+			"error":   "no_store",
+			"message": "We couldn't find a store for this account. Did you finish onboarding?",
+		})
+		return
+	}
+
+	// Authenticate against the first membership. The full list is returned
+	// so a merchant on more than one tenant can switch, rather than being
+	// silently pinned to whichever one happened to sort first.
+	primary := tenants[0].TenantID
+
+	res, err := h.backend.Login(c.Request.Context(), email, req.Password, primary)
+	switch {
+	case errors.Is(err, authbffclient.ErrInvalidCredentials):
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid_credentials", "message": "Couldn't sign you in. Check your details and try again."})
+		return
+	case err != nil:
+		// Deliberately NOT 401: a merchant typing a correct password
+		// during an auth-bff outage would otherwise retry forever.
+		h.logError("mobile login: auth-bff call failed", err)
+		c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{"error": "auth_unavailable", "message": "Sign-in is temporarily unavailable. Try again shortly."})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": mobileLoginResponse(res, tenants)})
+}
+
+func mobileLoginResponse(res authbffclient.LoginResult, tenants []teamproxy.TenantMembership) gin.H {
+	out := gin.H{
+		"uid":                res.UID,
+		"email":              res.Email,
+		"tenant_id":          res.TenantID,
+		"tenants":            tenants,
+		"email_otp_required": res.EmailOTPRequired,
+		"mfa_required":       res.MFARequired,
+		"totp_required":      res.TOTPRequired,
+	}
+	// Tokens are present only when no step-up is outstanding; auth-bff
+	// guarantees that, and this mirrors it rather than re-deciding.
+	if res.AccessToken != "" {
+		out["access_token"] = res.AccessToken
+		out["refresh_token"] = res.RefreshToken
+		out["token_type"] = res.TokenType
+		out["expires_in"] = res.ExpiresIn
+	}
+	if res.TOTPRequired {
+		out["session_id"] = res.SessionID
+		out["session_token"] = res.SessionToken
+	}
+	return out
+}
+
+func (h *MobileLoginHandler) logError(msg string, err error) {
+	if h.log != nil {
+		h.log.Error(msg, "error", err)
+	}
+}

--- a/services/marketplace-api/internal/handlers/admin/mobile_auth_login_test.go
+++ b/services/marketplace-api/internal/handlers/admin/mobile_auth_login_test.go
@@ -1,0 +1,170 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/auth"
+	"github.com/mark8ly/marketplace-api/internal/authbffclient"
+	"github.com/mark8ly/marketplace-api/internal/authz"
+	"github.com/mark8ly/marketplace-api/internal/teamproxy"
+)
+
+type fakeLoginBackend struct {
+	gotEmail, gotTenant string
+	result              authbffclient.LoginResult
+	err                 error
+}
+
+func (f *fakeLoginBackend) Login(_ context.Context, email, _, workspaceTenant string) (authbffclient.LoginResult, error) {
+	f.gotEmail, f.gotTenant = email, workspaceTenant
+	return f.result, f.err
+}
+
+func loginRouter(t *testing.T, lister TenantLister, backend MobileLoginBackend) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterAdminMobile(r.Group("/api/v1"), MobileDeps{
+		Deps: Deps{
+			AuthzMiddleware:  authz.NewMiddleware(authz.NewFakeClient(), nil),
+			StoresMiddleware: func(c *gin.Context) { c.Next() },
+		},
+		ZitadelEnabled: true,
+		DualIssuer:     true,
+		// RegisterAdminMobile disables the whole group without a verifier,
+		// so the login route needs one mounted even though it does not use
+		// it — signing in would be pointless with no authenticated route.
+		TokenVerifier: &auth.FakeVerifier{UserID: "unused"},
+		LoginHandler:  NewMobileLoginHandler(lister, backend, nil),
+	})
+	return r
+}
+
+func post(t *testing.T, r *gin.Engine, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/mobile/admin/auth/login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// The login route must be reachable with NO Authorization header — it is
+// how a client gets one. Every other mobile route requires a bearer token.
+func TestMobileLogin_NeedsNoBearerToken(t *testing.T) {
+	lister := &fakeTenantLister{result: []teamproxy.TenantMembership{{TenantID: "t-1", Name: "Mumbai Spice Co", Role: "owner"}}}
+	backend := &fakeLoginBackend{result: authbffclient.LoginResult{
+		UID: "u1", Email: "a@b.test", TenantID: "t-1", AccessToken: "AT", RefreshToken: "RT", ExpiresIn: 3599,
+	}}
+
+	rec := post(t, loginRouter(t, lister, backend), `{"email":"a@b.test","password":"pw"}`)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var body struct {
+		Data struct {
+			AccessToken string                       `json:"access_token"`
+			TenantID    string                       `json:"tenant_id"`
+			Tenants     []teamproxy.TenantMembership `json:"tenants"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "AT", body.Data.AccessToken)
+	require.Equal(t, "t-1", body.Data.TenantID)
+
+	// The tenant is resolved server-side from the EMAIL before
+	// authenticating — the client cannot know it yet, and this mirrors the
+	// web's resolveWorkspaceTenant.
+	require.Equal(t, "t-1", backend.gotTenant)
+	require.Equal(t, "a@b.test", backend.gotEmail)
+
+	// Every membership comes back so the client can offer a switcher
+	// rather than being silently pinned to whichever one we picked.
+	require.Len(t, body.Data.Tenants, 1)
+}
+
+// A merchant on two tenants must not be silently pinned: we pick one to
+// authenticate with, but the full list is returned.
+func TestMobileLogin_MultipleTenantsAllReturned(t *testing.T) {
+	lister := &fakeTenantLister{result: []teamproxy.TenantMembership{
+		{TenantID: "t-1", Name: "A", Role: "owner"},
+		{TenantID: "t-2", Name: "B", Role: "staff"},
+	}}
+	backend := &fakeLoginBackend{result: authbffclient.LoginResult{AccessToken: "AT", TenantID: "t-1"}}
+
+	rec := post(t, loginRouter(t, lister, backend), `{"email":"a@b.test","password":"pw"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data struct {
+			Tenants []teamproxy.TenantMembership `json:"tenants"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Data.Tenants, 2)
+}
+
+// Zero tenants must NOT reach auth-bff at all: there is no workspace_tenant
+// to authenticate against, and probing credentials for an address with no
+// membership is needless exposure.
+func TestMobileLogin_NoTenantsIsRefusedWithoutTouchingCredentials(t *testing.T) {
+	backend := &fakeLoginBackend{}
+	rec := post(t, loginRouter(t, &fakeTenantLister{result: nil}, backend), `{"email":"nobody@b.test","password":"pw"}`)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Empty(t, backend.gotEmail, "credentials must not be sent when there is no tenant to log into")
+}
+
+// A step-up is a normal outcome and must be reported as one, with no
+// tokens. This is the COMMON first-login path on a fresh install.
+func TestMobileLogin_EmailOTPRequiredIsReportedNotFailed(t *testing.T) {
+	lister := &fakeTenantLister{result: []teamproxy.TenantMembership{{TenantID: "t-1"}}}
+	backend := &fakeLoginBackend{result: authbffclient.LoginResult{
+		UID: "u1", Email: "a@b.test", TenantID: "t-1", EmailOTPRequired: true,
+	}}
+
+	rec := post(t, loginRouter(t, lister, backend), `{"email":"a@b.test","password":"pw"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Data struct {
+			EmailOTPRequired bool   `json:"email_otp_required"`
+			AccessToken      string `json:"access_token"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.True(t, body.Data.EmailOTPRequired)
+	require.Empty(t, body.Data.AccessToken)
+}
+
+func TestMobileLogin_BadCredentialsIs401(t *testing.T) {
+	lister := &fakeTenantLister{result: []teamproxy.TenantMembership{{TenantID: "t-1"}}}
+	backend := &fakeLoginBackend{err: authbffclient.ErrInvalidCredentials}
+
+	rec := post(t, loginRouter(t, lister, backend), `{"email":"a@b.test","password":"bad"}`)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// An auth-bff outage must not be reported as a wrong password: the
+// merchant would keep retrying a correct credential forever.
+func TestMobileLogin_UpstreamFailureIs502Not401(t *testing.T) {
+	lister := &fakeTenantLister{result: []teamproxy.TenantMembership{{TenantID: "t-1"}}}
+	backend := &fakeLoginBackend{err: errors.New("auth-bff down")}
+
+	rec := post(t, loginRouter(t, lister, backend), `{"email":"a@b.test","password":"pw"}`)
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+func TestMobileLogin_MissingFieldsIs400(t *testing.T) {
+	r := loginRouter(t, &fakeTenantLister{}, &fakeLoginBackend{})
+	require.Equal(t, http.StatusBadRequest, post(t, r, `{"email":"a@b.test"}`).Code)
+	require.Equal(t, http.StatusBadRequest, post(t, r, `{"password":"pw"}`).Code)
+}

--- a/services/marketplace-api/internal/handlers/admin/mobile_routes.go
+++ b/services/marketplace-api/internal/handlers/admin/mobile_routes.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/auth"
 	"github.com/mark8ly/marketplace-api/internal/authz"
+	"github.com/mark8ly/marketplace-api/internal/ratelimit"
 )
 
 // MobileDeps extends Deps with the mobile-specific bearer token verifier.
@@ -59,6 +60,10 @@ type MobileDeps struct {
 	// rather than an oversight. Nil leaves the route unmounted, which
 	// disables Zitadel tenant discovery on mobile.
 	MyTenantsHandler *MobileMyTenantsHandler
+	// LoginHandler serves the app's public sign-in route — the only mobile
+	// route mounted with NO bearer auth at all, because it is how a client
+	// obtains one. Nil leaves it unmounted.
+	LoginHandler *MobileLoginHandler
 	// TenantMembershipChecker backs auth.TenantFromRequest (#524 phase 4):
 	// it resolves the caller's X-Acting-Tenant-Id header via an FGA
 	// membership check, for tokens (Zitadel) that carry no tenant_id
@@ -159,6 +164,16 @@ func RegisterAdminMobile(router *gin.RouterGroup, deps MobileDeps) {
 	if deps.MobileAccountHandler != nil {
 		acct := router.Group("/mobile/admin/account", tenantMW...)
 		acct.DELETE("", deps.MobileAccountHandler.Delete)
+	}
+
+	// Sign-in — mounted with NO bearer auth, because it is what produces a
+	// bearer token. IP rate limiting stands in for the per-user limiter
+	// used everywhere else: there is no user yet, and this is the one
+	// mobile route an unauthenticated caller can reach, so it is the only
+	// credential-stuffing surface in this group.
+	if deps.LoginHandler != nil {
+		a := router.Group("/mobile/admin/auth", ratelimit.PerIP(0.5, 10))
+		a.POST("/login", deps.LoginHandler.Login)
 	}
 
 	// Tenant discovery — the ONLY mobile admin route mounted WITHOUT

--- a/services/marketplace-api/internal/handlers/admin/route_parity_test.go
+++ b/services/marketplace-api/internal/handlers/admin/route_parity_test.go
@@ -116,7 +116,8 @@ var mobileOnlySubtrees = map[string]string{
 }
 
 var mobileOnlyRoutes = map[string]string{
-	"GET /me/tenants": "Zitadel tenant discovery (#686): mobile is the only surface that must ask the API which tenants it belongs to, because a Zitadel token carries no tenant claim and every other mobile route is tenant-gated. The web admin resolves the same thing server-side in its own BFF (resolveWorkspaceTenant) by calling platform-api directly, so mirroring it here would add an unused route. It is also the one mobile route deliberately mounted OUTSIDE requireTenant — see MobileMyTenantsHandler",
+	"POST /auth/login": "mobile sign-in (#686): the app posts to marketplace-api because auth-bff is internet-reachable and its login route's only protection is the X-Internal-Auth secret, which a device cannot hold. The web admin has no equivalent — its Next.js server holds that secret and calls auth-bff directly. This is also the only mobile route mounted with NO bearer auth, since it is what produces a bearer token",
+	"GET /me/tenants":  "Zitadel tenant discovery (#686): mobile is the only surface that must ask the API which tenants it belongs to, because a Zitadel token carries no tenant claim and every other mobile route is tenant-gated. The web admin resolves the same thing server-side in its own BFF (resolveWorkspaceTenant) by calling platform-api directly, so mirroring it here would add an unused route. It is also the one mobile route deliberately mounted OUTSIDE requireTenant — see MobileMyTenantsHandler",
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #686. The app's public sign-in route, so mark8ly keeps its own login form on mobile.

**Depends on #728 at runtime** (not at compile time): it calls auth-bff's `/auth/zitadel/mobile/login`, which #728 adds. Deploy auth-bff first. Until then the route answers 502, not a wrong-password error.

## Why the front door is here and not on auth-bff

auth-bff is internet-reachable at `auth.mark8ly.com`, and the **only** thing protecting `/auth/zitadel/login` from credential stuffing is the `X-Internal-Auth` secret its trusted server-side callers hold. A device cannot hold that secret, and adding an unauthenticated route to auth-bff would remove that protection for every surface at once.

marketplace-api is already the app's public backend, already holds the identical secret (`MARKETPLACE_INTERNAL_AUTH_SECRET` — the same GCP secret auth-bff checks), and already has IP rate limiting. So the public surface lives here and auth-bff keeps its gate.

**No chart change:** `AUTH_BFF_URL` and the secret are already on this deployment. An empty `AUTH_BFF_URL` leaves the route unmounted.

## Why it resolves the tenant before authenticating

auth-bff requires a `workspace_tenant`, and the client cannot know one — a Zitadel token carries no tenant claim, and tenant discovery itself needs a token. So the tenant is resolved from the **email** first, via the `ListMyTenants` added in #724. That is exactly what the web does in `resolveWorkspaceTenant`, and why platform-api's lookup accepts an email as well as a uid.

A merchant on several tenants is authenticated against the first but gets the **full list** back, so the client can offer a switcher instead of being silently pinned to whichever sorted first.

## Failure semantics

| Case | Response | Why |
|---|---|---|
| No tenants for that email | `404 no_store`, **password never sent** | there is no tenant to authenticate against, so probing the credential is exposure for no result |
| Bad credentials | `401` | auth-bff's enumeration-safe rejection, preserved |
| auth-bff unreachable | **`502`, never 401** | a merchant typing a *correct* password during an outage would otherwise retry forever |
| Email OTP / TOTP required | `200` with the step-up flags and **no tokens** | a step-up is a normal outcome, not a failure |

That last row is the one I care most about. A fresh install is always an unrecognised device, so **email OTP is the common first-login path, not an edge case** — and treating it as failure is exactly what produced #493, where every layer logged 200 and the user was bounced back to the login screen with nothing shown.

The `404 no_store` does reveal that an address has no membership. That is the same signal the web sign-in already gives, and the alternative — authenticate first, then refuse — means checking credentials for arbitrary addresses on an unauthenticated endpoint. Called out explicitly in the code so it is a decision, not an accident.

## Rate limiting

`ratelimit.PerIP(0.5, 10)` — the per-user limiter used everywhere else needs a `user_id`, and there is no user yet. This is the only mobile route an unauthenticated caller can reach, so it is the group's only credential-stuffing surface.

## Route parity

`TestAdminRouteParity` caught this too and I declared it deliberate with a reason: the web admin has no equivalent, because its Next.js server holds the internal-auth secret and calls auth-bff directly.

## Verification

12 new tests (5 client, 7 handler). `gofmt`/`vet`/`build` clean, full `go test ./...` green.

One test initially passed for the wrong reason — `NoTenants` expected 404 and got a *routing* 404, because `RegisterAdminMobile` disables the whole group without a `TokenVerifier`. Fixed so it exercises the real path.

## Next

The app: the OTP screen, posting the code, storing tokens, and sending `X-Acting-Tenant-Id`. Also `tenant-store.ts` stores the **store** id as the tenant id, which becomes wrong as soon as the client populates that header.
