### PR TITLE
Record Stripe Radar early fraud warnings instead of discarding them

### DIFF
--- a/.planning/quick/260906-fw-fraud-warnings/PLAN.md
+++ b/.planning/quick/260906-fw-fraud-warnings/PLAN.md
@@ -1,0 +1,84 @@
+# Record Stripe Radar early fraud warnings
+
+Half of #704. `internal/billing/dispatch/handlers.go`'s `handleFraudWarning`
+is `return nil`. `radar.early_fraud_warning` is subscribed
+(`dispatcher.go:75`) and in the allowed-event list (`pkg/config/config.go:135`),
+so Stripe delivers these and we acknowledge them — and discard them. Its
+comment claims "audit-only in P2"; no audit row is written either.
+
+Stripe telling us a charge is likely fraudulent is about the strongest signal
+we get, and it currently reaches nothing.
+
+## The arbitrage half is NOT in scope — deliberately
+
+#704 also covers `arbitrage_flag` being unreachable (the only `recordArbitrage`
+caller passes `IPCountry: ""`, and `Evaluate` returns `ReasonIPUnknown` without
+one). Threading the real IP country through is tractable — capture via
+`arbitrage.CFIPCountryFromGin` at checkout-session creation, carry it in the
+Stripe session metadata, read it back in `handleCheckoutSessionCompleted`.
+
+**We are not doing it yet, and the reason is not technical.** Enabling
+flagging would mark merchant accounts while:
+
+- **tesserix-home#144 ("Subscription arbitrage appeals queue") is UNBUILT** —
+  there is no operator queue to review a flag
+- `arbitrage_flag` is already exposed on the merchant's own subscription
+  response (`internal/handlers/admin/subscription.go:98`), so a merchant can
+  see they are flagged
+- the quarterly cron only clears flags for stores on an allowlist
+
+Flagging people who can see it, with no review queue and no appeals path, is
+worse than not flagging. That half waits for tesserix-home#144.
+
+## Task
+
+1. Convert `handleFraudWarning` to a `*Dispatcher` method (as a free function
+   it has no `d.emitter` — the same structural reason the other P2 handlers
+   were never finished) and update its registration.
+2. Parse the `radar.early_fraud_warning` payload: `id`, `charge`,
+   `payment_intent`, `fraud_type`, `actionable`.
+3. **Attribution needs a Stripe lookup.** The payload carries a charge id, not
+   a customer, and `audit.Event` requires a `TenantID`. There is no local
+   charge -> store mapping (`refund_audit.stripe_charge_id` exists only for
+   refunds). Add a narrow, **nil-safe** charge-getter dependency to the
+   Dispatcher — mirroring how `refunds` was added — backed by the existing
+   `billingstripe.GetCharge` (`internal/billing/stripe/refund.go:71`). From the
+   charge's customer, resolve `store_subscriptions` in the same `tx`, exactly
+   as `handleChargeRefunded` does.
+4. Emit an audit event with a new `subscription.*` action, Severity **Warning**
+   (Stripe suspects fraud — this must be findable), metadata carrying the
+   warning id, charge id, `fraud_type` and `actionable`.
+5. **The signal must survive failed attribution.** If the getter is nil, the
+   Stripe lookup fails, or no subscription matches, do NOT silently return nil:
+   log at Error with the warning and charge ids, and still increment the
+   counter below. An unattributable fraud warning is still a fraud warning.
+6. Add a Prometheus counter (follow `metrics/registry.go`'s existing
+   `CounterVec` pattern and register it) so this is alertable. #704's own
+   argument is that a warning arriving is an **event**, better served by
+   alerting than by a boolean column — the counter is what makes that possible.
+   Label it so attributed and unattributed warnings are distinguishable.
+
+## Do NOT
+
+- touch `internal/arbitrage`, `recordArbitrage`, or `IPCountry` — see above
+- write `arbitrage_flag`
+- block or fail the webhook on a fraud warning: this is observational
+
+## Done when
+
+- An attributable warning emits exactly one Warning-severity audit event and
+  counts
+- A warning we cannot attribute still logs at Error and counts, and returns nil
+- A nil charge-getter does not panic
+- Tests genuinely execute. Existing tests in `internal/billing/dispatch` are
+  ALL `//go:build integration`, so an untagged run compiles none of them and
+  `TEST_DATABASE_URL` is unset locally — they would skip while printing `ok`.
+  Follow `charge_refunded_audit.go`'s shape: put the decision in a pure helper
+  and unit-test that.
+
+## Constraints
+
+- TDD: test first, watch it fail.
+- One atomic commit, single-line conventional message, NO attribution trailers.
+- SHARED CHECKOUT: never checkout/switch/stash/reset. Only add + commit.
+- `go build ./...`, `go vet` (including `-tags integration`), `go test` green.

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1926,6 +1926,12 @@ func main() {
 		// invoice.finalized for validated tax IDs in reverse-charge jurisdictions.
 		dispatcher.WithReverseChargeAnnotator(billingStripeClient)
 
+		// #704: radar.early_fraud_warning carries a charge id and no customer,
+		// so attributing a Radar fraud warning to a store needs a live Stripe
+		// charge lookup. A nil client (no billing key) leaves the getter unset
+		// and every warning is recorded as unattributed rather than dropped.
+		dispatcher.WithChargeGetter(billingStripeClient)
+
 		// P8 §18.8: wire arbitrage recorder into the checkout webhook handler.
 		// KeyLoader + Hasher use Secret Manager when ARBITRAGE_HMAC_SECRET_PATH
 		// is set; omit gracefully in local dev (recorder stays nil → no-op).

--- a/services/marketplace-api/internal/billing/dispatch/dispatcher.go
+++ b/services/marketplace-api/internal/billing/dispatch/dispatcher.go
@@ -55,7 +55,14 @@ type Dispatcher struct {
 	// in the Stripe Dashboard (see handleChargeRefunded). Read-only — nothing
 	// here ever writes that fraud-control table. Nil-safe: a nil repo makes
 	// every refund look externally initiated.
-	refunds  refund.Repository
+	refunds refund.Repository
+	// charges resolves a Stripe charge id to its customer so a
+	// radar.early_fraud_warning can be attributed to a store. That event
+	// carries a charge id and no customer, and there is no local
+	// charge→store mapping, so this Stripe read is the only attribution
+	// path (#704). Read-only. Nil-safe: a nil getter makes every fraud
+	// warning unattributed — logged and counted, never dropped.
+	charges  ChargeGetter
 	skip     SkipCounter // nil-safe: skipped-send counting is optional
 	sent     SentCounter // nil-safe: delivered-send counting is optional
 	handlers map[string]Handler
@@ -80,7 +87,10 @@ func New(em *audit.Emitter) *Dispatcher {
 	d.handlers["charge.refunded"] = d.handleChargeRefunded
 	d.handlers["payment_method.attached"] = handlePaymentMethodAttached
 	d.handlers["payment_method.detached"] = handlePaymentMethodDetached
-	d.handlers["radar.early_fraud_warning"] = handleFraudWarning
+	// radar.early_fraud_warning is a method for the same reason
+	// charge.refunded is: it emits through d.emitter, and it needs d.charges
+	// to attribute the charge to a store (#704).
+	d.handlers["radar.early_fraud_warning"] = d.handleFraudWarning
 	// Methods — state mutations routed through statemachine.Transition.
 	d.handlers["checkout.session.completed"] = d.handleCheckoutSessionCompleted
 	d.handlers["customer.subscription.deleted"] = d.handleSubscriptionDeleted
@@ -94,6 +104,41 @@ func New(em *audit.Emitter) *Dispatcher {
 // check per spec §18.8. Recorder may be nil (skips the check).
 func (d *Dispatcher) WithRecorder(r *arbitrage.Recorder) *Dispatcher {
 	d.recorder = r
+	return d
+}
+
+// ChargeGetter reads a single Stripe charge. Narrow by design: the only
+// caller is the fraud-warning handler, and the only field it needs is the
+// charge's customer.
+type ChargeGetter interface {
+	GetCharge(ctx context.Context, id string) (*billingstripe.Charge, error)
+}
+
+// stripeChargeGetterAdapter wraps the package-level billingstripe.GetCharge
+// helper into the ChargeGetter interface, mirroring
+// stripeInvoiceUpdaterAdapter.
+type stripeChargeGetterAdapter struct {
+	client *billingstripe.Client
+}
+
+func (a *stripeChargeGetterAdapter) GetCharge(ctx context.Context, id string) (*billingstripe.Charge, error) {
+	return billingstripe.GetCharge(ctx, a.client, id)
+}
+
+// WithChargeGetter wires the Stripe charge lookup used to attribute
+// radar.early_fraud_warning events to a store. A nil client leaves the getter
+// unset, which downgrades every fraud warning to unattributed rather than
+// panicking. Tests use withChargeGetter with a stub directly.
+func (d *Dispatcher) WithChargeGetter(client *billingstripe.Client) *Dispatcher {
+	if client == nil {
+		return d
+	}
+	return d.withChargeGetter(&stripeChargeGetterAdapter{client: client})
+}
+
+// withChargeGetter is the test seam for WithChargeGetter.
+func (d *Dispatcher) withChargeGetter(g ChargeGetter) *Dispatcher {
+	d.charges = g
 	return d
 }
 

--- a/services/marketplace-api/internal/billing/dispatch/fraud_warning.go
+++ b/services/marketplace-api/internal/billing/dispatch/fraud_warning.go
@@ -1,0 +1,268 @@
+package dispatch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/metrics"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// ActionFraudWarningReceived records that Stripe Radar told us a charge is
+// probably fraudulent (an "early fraud warning" — the issuer has reported the
+// card as fraudulently used, usually days before any chargeback lands).
+//
+// It is deliberately NOT subscription.refunded_externally or any existing
+// action: nothing has happened to the subscription. This is Stripe's opinion
+// about a charge, and it is the earliest warning we ever get that a store may
+// be a fraud liability. Severity is Warning for the same reason a Dashboard
+// refund is — ops must be able to find it — and never Critical, because the
+// warning is a signal to investigate, not a confirmed loss.
+const ActionFraudWarningReceived = "subscription.fraud_warning_received"
+
+// Attribution outcomes for fraud_warnings_total's reason label and the Error
+// log that accompanies a failure. The vocabulary is closed and small so
+// dashboards can reference fixed values.
+const (
+	fraudAttrOK              = "ok"
+	fraudAttrMalformed       = "malformed_payload"
+	fraudAttrNoChargeID      = "no_charge_id"
+	fraudAttrNoChargeGetter  = "no_charge_getter"
+	fraudAttrLookupFailed    = "charge_lookup_failed"
+	fraudAttrNoCustomer      = "no_customer"
+	fraudAttrNoSubscription  = "no_subscription"
+	fraudAttrSubLookupFailed = "subscription_lookup_failed"
+)
+
+// fraudWarningPayload is the slice of a radar.early_fraud_warning event we
+// record. Stripe sends no customer and no metadata on this object, which is
+// why attribution needs a separate charge lookup.
+type fraudWarningPayload struct {
+	WarningID       string
+	ChargeID        string
+	PaymentIntentID string
+	// FraudType is Stripe's closed vocabulary: card_never_received,
+	// fraudulent_card_application, made_with_counterfeit_card,
+	// made_with_lost_card, made_with_stolen_card, misc,
+	// unauthorized_use_of_card.
+	FraudType string
+	// Actionable is Stripe's own judgement that refunding the charge would
+	// still avoid a dispute. It drives what ops should do first, so it is
+	// both a metric label and audit metadata.
+	Actionable bool
+}
+
+// fraudWarningContext carries the identifiers an emitted event needs. They
+// come from the store_subscriptions row matched on the charge's customer, so
+// they are only meaningful when attribution succeeded.
+type fraudWarningContext struct {
+	SubscriptionID uuid.UUID
+	TenantID       uuid.UUID
+	StoreID        uuid.UUID
+}
+
+// stripeRef decodes a Stripe reference field that is a bare id string when
+// unexpanded and a full object when expanded, and null when absent. Getting
+// this wrong on `charge` would cost us the only attribution key the event has.
+type stripeRef string
+
+func (r *stripeRef) UnmarshalJSON(b []byte) error {
+	if string(b) == "null" {
+		*r = ""
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		*r = stripeRef(s)
+		return nil
+	}
+	var obj struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(b, &obj); err != nil {
+		return err
+	}
+	*r = stripeRef(obj.ID)
+	return nil
+}
+
+// parseFraudWarning extracts the recorded fields from a
+// radar.early_fraud_warning event body.
+func parseFraudWarning(raw []byte) (fraudWarningPayload, error) {
+	var e struct {
+		Data struct {
+			Object struct {
+				ID            string    `json:"id"`
+				Charge        stripeRef `json:"charge"`
+				PaymentIntent stripeRef `json:"payment_intent"`
+				FraudType     string    `json:"fraud_type"`
+				Actionable    bool      `json:"actionable"`
+			} `json:"object"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &e); err != nil {
+		return fraudWarningPayload{}, fmt.Errorf("dispatch: unmarshal radar.early_fraud_warning: %w", err)
+	}
+	obj := e.Data.Object
+	return fraudWarningPayload{
+		WarningID:       obj.ID,
+		ChargeID:        string(obj.Charge),
+		PaymentIntentID: string(obj.PaymentIntent),
+		FraudType:       obj.FraudType,
+		Actionable:      obj.Actionable,
+	}, nil
+}
+
+// decideFraudWarningEvent returns the audit event a radar.early_fraud_warning
+// webhook should produce, or ok=false when it should produce none. It is pure
+// so the whole decision is unit-testable without a database or a Stripe
+// client — the handler around it is a thin shell.
+//
+// attributed is false when the warning could not be tied to a store. No event
+// is emitted then, because audit.Event is tenant-scoped and a tenant-less row
+// would be unreadable in every audit surface we have. The Error log and the
+// counter carry that case instead — it is not dropped, just not audited.
+func decideFraudWarningEvent(p fraudWarningPayload, fc fraudWarningContext, attributed bool) (audit.Event, bool) {
+	if !attributed {
+		return audit.Event{}, false
+	}
+	return audit.Event{
+		Action:         ActionFraudWarningReceived,
+		ResourceType:   "subscription",
+		ResourceID:     fc.SubscriptionID.String(),
+		Severity:       audit.SeverityWarning,
+		TenantID:       fc.TenantID,
+		StoreID:        fc.StoreID,
+		ForceActorType: audit.ActorSystem,
+		Metadata: map[string]any{
+			"reason":                        "radar.early_fraud_warning",
+			"stripe_early_fraud_warning_id": p.WarningID,
+			"stripe_charge_id":              p.ChargeID,
+			"stripe_payment_intent_id":      p.PaymentIntentID,
+			"fraud_type":                    p.FraudType,
+			"actionable":                    p.Actionable,
+			"store_id":                      fc.StoreID.String(),
+		},
+	}, true
+}
+
+// fraudWarningLabels maps an attribution outcome onto the three
+// fraud_warnings_total label values. Pure, so the label vocabulary is
+// testable without a registry.
+func fraudWarningLabels(p fraudWarningPayload, attributed bool, reason string) (attribution, reasonLabel, actionable string) {
+	attribution = "unattributed"
+	if attributed {
+		attribution = "attributed"
+	}
+	return attribution, reason, strconv.FormatBool(p.Actionable)
+}
+
+// attributeFraudWarning resolves the store behind a fraud warning.
+//
+// The event carries a charge id and no customer, and there is no local
+// charge→store mapping (refund_audit.stripe_charge_id covers refunds only),
+// so this costs one Stripe read. Every failure mode returns ok=false with a
+// reason rather than an error: the caller must never fail the webhook over
+// attribution.
+func (d *Dispatcher) attributeFraudWarning(ctx context.Context, tx *gorm.DB, p fraudWarningPayload) (fraudWarningContext, bool, string) {
+	if p.ChargeID == "" {
+		return fraudWarningContext{}, false, fraudAttrNoChargeID
+	}
+	if d.charges == nil {
+		// No Stripe billing client wired (local dev, or a deployment with no
+		// billing key). Nothing to look up.
+		return fraudWarningContext{}, false, fraudAttrNoChargeGetter
+	}
+
+	ch, err := d.charges.GetCharge(ctx, p.ChargeID)
+	if err != nil {
+		return fraudWarningContext{}, false, fraudAttrLookupFailed
+	}
+	if ch == nil || ch.CustomerID == "" {
+		// A one-off charge with no customer attached: nothing to join on.
+		return fraudWarningContext{}, false, fraudAttrNoCustomer
+	}
+
+	// Resolve inside the webhook transaction, exactly as handleChargeRefunded
+	// does, so the read sees the same snapshot as the rest of the event.
+	var sub subscription.StoreSubscription
+	switch err := tx.WithContext(ctx).Where("stripe_customer_id = ?", ch.CustomerID).First(&sub).Error; {
+	case err == nil:
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return fraudWarningContext{}, false, fraudAttrNoSubscription
+	default:
+		return fraudWarningContext{}, false, fraudAttrSubLookupFailed
+	}
+
+	return fraudWarningContext{
+		SubscriptionID: sub.ID,
+		TenantID:       sub.TenantID,
+		StoreID:        sub.StoreID,
+	}, true, fraudAttrOK
+}
+
+// handleFraudWarning records a Stripe Radar early fraud warning (#704). It
+// used to be `return nil` with a comment claiming it was "audit-only in P2" —
+// no audit row was written either, so the strongest fraud signal Stripe gives
+// us reached nothing at all.
+//
+// It writes no columns. In particular it does NOT set arbitrage_flag: that is
+// the other half of #704 and is deliberately deferred until the operator
+// appeals queue (tesserix-home#144) exists, because arbitrage_flag is visible
+// to the merchant on their own subscription response and flagging someone who
+// can see it with no review path is worse than not flagging.
+//
+// It is a method (not the free function it used to be) purely so it can reach
+// d.emitter and d.charges, exactly as handleChargeRefunded became one.
+//
+// It never returns an error. A fraud warning is observational: failing the
+// webhook would make Stripe retry an event that cannot succeed any better on
+// the second attempt, and would push the store's whole webhook stream into
+// retry behind it.
+func (d *Dispatcher) handleFraudWarning(ctx context.Context, tx *gorm.DB, raw []byte) error {
+	p, err := parseFraudWarning(raw)
+	if err != nil {
+		// Still counted: a warning we could not even parse is a warning we
+		// received, and silence here would look identical to no fraud.
+		slog.Default().Error("dispatch: radar.early_fraud_warning payload unparseable; warning recorded only as a metric",
+			"error", err)
+		countFraudWarning(fraudWarningPayload{}, false, fraudAttrMalformed)
+		return nil
+	}
+
+	fc, attributed, reason := d.attributeFraudWarning(ctx, tx, p)
+	if !attributed {
+		// Never silent. An unattributable fraud warning is still a fraud
+		// warning, and the ids below are enough to finish the attribution by
+		// hand in the Stripe Dashboard.
+		slog.Default().Error("dispatch: could not attribute Stripe early fraud warning to a store; no audit event emitted",
+			"stripe_early_fraud_warning_id", p.WarningID,
+			"stripe_charge_id", p.ChargeID,
+			"fraud_type", p.FraudType,
+			"actionable", p.Actionable,
+			"reason", reason)
+	}
+
+	if ev, ok := decideFraudWarningEvent(p, fc, attributed); ok {
+		// d.emitter may be nil — Emitter.Emit is nil-receiver-safe.
+		d.emitter.Emit(nil, ev)
+	}
+	countFraudWarning(p, attributed, reason)
+	return nil
+}
+
+// countFraudWarning increments the fraud warning counter. Split out so the
+// handler reads as one decision per line and so the label mapping stays in
+// fraudWarningLabels.
+func countFraudWarning(p fraudWarningPayload, attributed bool, reason string) {
+	attribution, reasonLabel, actionable := fraudWarningLabels(p, attributed, reason)
+	metrics.FraudWarningsTotal.WithLabelValues(attribution, reasonLabel, actionable).Inc()
+}

--- a/services/marketplace-api/internal/billing/dispatch/fraud_warning_test.go
+++ b/services/marketplace-api/internal/billing/dispatch/fraud_warning_test.go
@@ -1,0 +1,351 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
+	"github.com/mark8ly/marketplace-api/internal/metrics"
+)
+
+func TestParseFraudWarning(t *testing.T) {
+	raw := []byte(`{
+      "type": "radar.early_fraud_warning.created",
+      "data": {
+        "object": {
+          "id": "issfr_123",
+          "object": "radar.early_fraud_warning",
+          "charge": "ch_123",
+          "payment_intent": "pi_123",
+          "fraud_type": "made_with_stolen_card",
+          "actionable": true,
+          "livemode": true
+        }
+      }
+    }`)
+
+	p, err := parseFraudWarning(raw)
+	if err != nil {
+		t.Fatalf("parseFraudWarning: %v", err)
+	}
+	if p.WarningID != "issfr_123" {
+		t.Errorf("WarningID = %q, want issfr_123", p.WarningID)
+	}
+	if p.ChargeID != "ch_123" {
+		t.Errorf("ChargeID = %q, want ch_123", p.ChargeID)
+	}
+	if p.PaymentIntentID != "pi_123" {
+		t.Errorf("PaymentIntentID = %q, want pi_123", p.PaymentIntentID)
+	}
+	if p.FraudType != "made_with_stolen_card" {
+		t.Errorf("FraudType = %q, want made_with_stolen_card", p.FraudType)
+	}
+	if !p.Actionable {
+		t.Error("Actionable = false, want true")
+	}
+}
+
+func TestParseFraudWarning_ExpandedRefs(t *testing.T) {
+	// charge and payment_intent are string ids when unexpanded, but Stripe
+	// sends full objects when the endpoint or webhook is configured to
+	// expand them. Both shapes must yield the same id.
+	raw := []byte(`{
+      "data": {
+        "object": {
+          "id": "issfr_9",
+          "charge": {"id": "ch_9", "object": "charge", "amount": 100},
+          "payment_intent": {"id": "pi_9", "object": "payment_intent"},
+          "fraud_type": "misc",
+          "actionable": false
+        }
+      }
+    }`)
+
+	p, err := parseFraudWarning(raw)
+	if err != nil {
+		t.Fatalf("parseFraudWarning: %v", err)
+	}
+	if p.ChargeID != "ch_9" {
+		t.Errorf("ChargeID = %q, want ch_9", p.ChargeID)
+	}
+	if p.PaymentIntentID != "pi_9" {
+		t.Errorf("PaymentIntentID = %q, want pi_9", p.PaymentIntentID)
+	}
+	if p.Actionable {
+		t.Error("Actionable = true, want false")
+	}
+}
+
+func TestParseFraudWarning_NullRefs(t *testing.T) {
+	raw := []byte(`{"data":{"object":{"id":"issfr_1","charge":null,"payment_intent":null,"fraud_type":"misc"}}}`)
+	p, err := parseFraudWarning(raw)
+	if err != nil {
+		t.Fatalf("parseFraudWarning: %v", err)
+	}
+	if p.ChargeID != "" || p.PaymentIntentID != "" {
+		t.Errorf("null refs should decode to empty, got %q / %q", p.ChargeID, p.PaymentIntentID)
+	}
+}
+
+func TestParseFraudWarning_Malformed(t *testing.T) {
+	if _, err := parseFraudWarning([]byte(`{`)); err == nil {
+		t.Fatal("expected an error for malformed JSON")
+	}
+}
+
+func newFraudCtx() fraudWarningContext {
+	return fraudWarningContext{
+		SubscriptionID: uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		TenantID:       uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+		StoreID:        uuid.MustParse("33333333-3333-3333-3333-333333333333"),
+	}
+}
+
+func sampleFraudPayload() fraudWarningPayload {
+	return fraudWarningPayload{
+		WarningID:       "issfr_123",
+		ChargeID:        "ch_123",
+		PaymentIntentID: "pi_123",
+		FraudType:       "made_with_stolen_card",
+		Actionable:      true,
+	}
+}
+
+func TestDecideFraudWarningEvent_Emits(t *testing.T) {
+	fc := newFraudCtx()
+	ev, ok := decideFraudWarningEvent(sampleFraudPayload(), fc, true)
+	if !ok {
+		t.Fatal("expected an event for an attributed fraud warning")
+	}
+	if ev.Action != ActionFraudWarningReceived {
+		t.Errorf("Action = %q, want %q", ev.Action, ActionFraudWarningReceived)
+	}
+	if ev.Severity != audit.SeverityWarning {
+		t.Errorf("Severity = %q, want %q", ev.Severity, audit.SeverityWarning)
+	}
+	if ev.ResourceType != "subscription" {
+		t.Errorf("ResourceType = %q, want subscription", ev.ResourceType)
+	}
+	if ev.ResourceID != fc.SubscriptionID.String() {
+		t.Errorf("ResourceID = %q, want %q", ev.ResourceID, fc.SubscriptionID)
+	}
+	if ev.TenantID != fc.TenantID || ev.StoreID != fc.StoreID {
+		t.Errorf("tenant/store not carried through: %v %v", ev.TenantID, ev.StoreID)
+	}
+	if ev.ForceActorType != audit.ActorSystem {
+		t.Errorf("ForceActorType = %q, want system", ev.ForceActorType)
+	}
+	if ev.Metadata["stripe_early_fraud_warning_id"] != "issfr_123" {
+		t.Errorf("metadata warning id = %v", ev.Metadata["stripe_early_fraud_warning_id"])
+	}
+	if ev.Metadata["stripe_charge_id"] != "ch_123" {
+		t.Errorf("metadata charge id = %v", ev.Metadata["stripe_charge_id"])
+	}
+	if ev.Metadata["stripe_payment_intent_id"] != "pi_123" {
+		t.Errorf("metadata payment intent id = %v", ev.Metadata["stripe_payment_intent_id"])
+	}
+	if ev.Metadata["fraud_type"] != "made_with_stolen_card" {
+		t.Errorf("metadata fraud_type = %v", ev.Metadata["fraud_type"])
+	}
+	if ev.Metadata["actionable"] != true {
+		t.Errorf("metadata actionable = %v", ev.Metadata["actionable"])
+	}
+}
+
+func TestDecideFraudWarningEvent_NoEventWhenUnattributed(t *testing.T) {
+	// audit.Event requires a TenantID; an unattributable warning has none.
+	// It must not produce a tenant-less row — the Error log and the counter
+	// carry that signal instead.
+	if _, ok := decideFraudWarningEvent(sampleFraudPayload(), fraudWarningContext{}, false); ok {
+		t.Fatal("expected no audit event when the warning could not be attributed")
+	}
+}
+
+func TestFraudWarningLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		actionable     bool
+		attributed     bool
+		reason         string
+		wantAttr       string
+		wantReason     string
+		wantActionable string
+	}{
+		{
+			name: "attributed actionable", actionable: true, attributed: true, reason: fraudAttrOK,
+			wantAttr: "attributed", wantReason: fraudAttrOK, wantActionable: "true",
+		},
+		{
+			name: "attributed not actionable", actionable: false, attributed: true, reason: fraudAttrOK,
+			wantAttr: "attributed", wantReason: fraudAttrOK, wantActionable: "false",
+		},
+		{
+			name: "unattributed", actionable: true, attributed: false, reason: fraudAttrNoChargeGetter,
+			wantAttr: "unattributed", wantReason: fraudAttrNoChargeGetter, wantActionable: "true",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := sampleFraudPayload()
+			p.Actionable = tc.actionable
+			attr, reason, actionable := fraudWarningLabels(p, tc.attributed, tc.reason)
+			if attr != tc.wantAttr {
+				t.Errorf("attribution = %q, want %q", attr, tc.wantAttr)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
+			}
+			if actionable != tc.wantActionable {
+				t.Errorf("actionable = %q, want %q", actionable, tc.wantActionable)
+			}
+		})
+	}
+}
+
+// stubChargeGetter implements ChargeGetter without a Stripe client.
+type stubChargeGetter struct {
+	charge *billingstripe.Charge
+	err    error
+	calls  []string
+}
+
+func (s *stubChargeGetter) GetCharge(_ context.Context, id string) (*billingstripe.Charge, error) {
+	s.calls = append(s.calls, id)
+	return s.charge, s.err
+}
+
+func TestAttributeFraudWarning_NilGetterDoesNotPanic(t *testing.T) {
+	// Production wiring may omit WithChargeGetter (no Stripe billing key).
+	// The warning is then unattributable, but nothing may panic and the
+	// reason must say why. tx is nil here precisely because this path must
+	// return before touching the database.
+	d := New(nil)
+	_, ok, reason := d.attributeFraudWarning(context.Background(), nil, sampleFraudPayload())
+	if ok {
+		t.Fatal("expected attribution to fail with no charge getter")
+	}
+	if reason != fraudAttrNoChargeGetter {
+		t.Errorf("reason = %q, want %q", reason, fraudAttrNoChargeGetter)
+	}
+}
+
+func TestAttributeFraudWarning_NoChargeID(t *testing.T) {
+	getter := &stubChargeGetter{}
+	d := New(nil).withChargeGetter(getter)
+	p := sampleFraudPayload()
+	p.ChargeID = ""
+	_, ok, reason := d.attributeFraudWarning(context.Background(), nil, p)
+	if ok {
+		t.Fatal("expected attribution to fail with no charge id")
+	}
+	if reason != fraudAttrNoChargeID {
+		t.Errorf("reason = %q, want %q", reason, fraudAttrNoChargeID)
+	}
+	if len(getter.calls) != 0 {
+		t.Errorf("must not call Stripe without a charge id, got %v", getter.calls)
+	}
+}
+
+func TestAttributeFraudWarning_LookupFailure(t *testing.T) {
+	// A Stripe outage must not swallow the warning: attribution fails, the
+	// caller still logs and counts.
+	d := New(nil).withChargeGetter(&stubChargeGetter{err: errors.New("stripe down")})
+	_, ok, reason := d.attributeFraudWarning(context.Background(), nil, sampleFraudPayload())
+	if ok {
+		t.Fatal("expected attribution to fail when the Stripe lookup errors")
+	}
+	if reason != fraudAttrLookupFailed {
+		t.Errorf("reason = %q, want %q", reason, fraudAttrLookupFailed)
+	}
+}
+
+func TestAttributeFraudWarning_ChargeWithoutCustomer(t *testing.T) {
+	// A one-off charge carries no customer, so there is nothing to join
+	// store_subscriptions on. Must not reach the database.
+	getter := &stubChargeGetter{charge: &billingstripe.Charge{ID: "ch_123"}}
+	d := New(nil).withChargeGetter(getter)
+	_, ok, reason := d.attributeFraudWarning(context.Background(), nil, sampleFraudPayload())
+	if ok {
+		t.Fatal("expected attribution to fail for a charge with no customer")
+	}
+	if reason != fraudAttrNoCustomer {
+		t.Errorf("reason = %q, want %q", reason, fraudAttrNoCustomer)
+	}
+	if len(getter.calls) != 1 || getter.calls[0] != "ch_123" {
+		t.Errorf("charge lookup calls = %v, want [ch_123]", getter.calls)
+	}
+}
+
+func TestAttributeFraudWarning_NilChargeIsNotACustomer(t *testing.T) {
+	// A getter returning (nil, nil) must be treated as "no customer", not
+	// dereferenced.
+	d := New(nil).withChargeGetter(&stubChargeGetter{})
+	_, ok, reason := d.attributeFraudWarning(context.Background(), nil, sampleFraudPayload())
+	if ok {
+		t.Fatal("expected attribution to fail for a nil charge")
+	}
+	if reason != fraudAttrNoCustomer {
+		t.Errorf("reason = %q, want %q", reason, fraudAttrNoCustomer)
+	}
+}
+
+func TestHandleFraudWarning_UnattributedReturnsNil(t *testing.T) {
+	// The webhook is never failed by a fraud warning: it is observational.
+	// With no charge getter this runs end to end without touching tx.
+	d := New(nil)
+	raw := []byte(`{"data":{"object":{"id":"issfr_1","charge":"ch_1","fraud_type":"misc","actionable":true}}}`)
+	if err := d.handleFraudWarning(context.Background(), nil, raw); err != nil {
+		t.Fatalf("handleFraudWarning = %v, want nil", err)
+	}
+}
+
+func TestHandleFraudWarning_MalformedReturnsNil(t *testing.T) {
+	d := New(nil)
+	if err := d.handleFraudWarning(context.Background(), nil, []byte(`{`)); err != nil {
+		t.Fatalf("handleFraudWarning = %v, want nil", err)
+	}
+}
+
+func TestFraudWarningHandlerIsRegistered(t *testing.T) {
+	if _, ok := New(nil).handlers["radar.early_fraud_warning"]; !ok {
+		t.Fatal("radar.early_fraud_warning must stay registered")
+	}
+}
+
+func TestHandleFraudWarning_CountsEvenWhenUnattributed(t *testing.T) {
+	// The whole point of #704's counter is that it fires on EVERY warning.
+	// If it only counted attributed ones it would read healthiest exactly
+	// when the Stripe lookup path is broken.
+	labels := []string{"unattributed", fraudAttrNoChargeGetter, "true"}
+	before := testutil.ToFloat64(metrics.FraudWarningsTotal.WithLabelValues(labels...))
+
+	d := New(nil)
+	raw := []byte(`{"data":{"object":{"id":"issfr_1","charge":"ch_1","fraud_type":"misc","actionable":true}}}`)
+	if err := d.handleFraudWarning(context.Background(), nil, raw); err != nil {
+		t.Fatalf("handleFraudWarning = %v, want nil", err)
+	}
+
+	after := testutil.ToFloat64(metrics.FraudWarningsTotal.WithLabelValues(labels...))
+	if after != before+1 {
+		t.Errorf("fraud_warnings_total{unattributed} = %v, want %v", after, before+1)
+	}
+}
+
+func TestHandleFraudWarning_MalformedStillCounts(t *testing.T) {
+	labels := []string{"unattributed", fraudAttrMalformed, "false"}
+	before := testutil.ToFloat64(metrics.FraudWarningsTotal.WithLabelValues(labels...))
+
+	if err := New(nil).handleFraudWarning(context.Background(), nil, []byte(`{`)); err != nil {
+		t.Fatalf("handleFraudWarning = %v, want nil", err)
+	}
+
+	after := testutil.ToFloat64(metrics.FraudWarningsTotal.WithLabelValues(labels...))
+	if after != before+1 {
+		t.Errorf("fraud_warnings_total{malformed_payload} = %v, want %v", after, before+1)
+	}
+}

--- a/services/marketplace-api/internal/billing/dispatch/handlers.go
+++ b/services/marketplace-api/internal/billing/dispatch/handlers.go
@@ -926,10 +926,6 @@ func handlePaymentMethodAttached(ctx context.Context, tx *gorm.DB, raw []byte) e
 // default_payment_method=null which clears the flag in handleCustomerUpdated.
 func handlePaymentMethodDetached(ctx context.Context, tx *gorm.DB, raw []byte) error { return nil }
 
-// handleFraudWarning is audit-only in P2.
-// TODO(P3): flag account for manual review via arbitrage_flag column.
-func handleFraudWarning(ctx context.Context, tx *gorm.DB, raw []byte) error { return nil }
-
 // extractCustomerID parses the customer ID from a standard Stripe event
 // payload that wraps the object under data.object.customer.
 func extractCustomerID(raw []byte) (string, error) {

--- a/services/marketplace-api/internal/billing/stripe/refund.go
+++ b/services/marketplace-api/internal/billing/stripe/refund.go
@@ -64,6 +64,11 @@ type Charge struct {
 	Status          string `json:"status"`
 	Created         int64  `json:"created"` // Unix timestamp — authoritative for 14-day gate
 	CardFingerprint string `json:"card_fingerprint,omitempty"`
+	// CustomerID is the Stripe customer the charge belongs to, empty for a
+	// one-off charge with no customer attached. It is the ONLY way to
+	// attribute a radar.early_fraud_warning to a store: that event carries a
+	// charge id and nothing else, and there is no local charge→store map.
+	CustomerID string `json:"customer_id,omitempty"`
 }
 
 // GetCharge retrieves a Stripe Charge by ID.
@@ -119,6 +124,9 @@ func mapCharge(ch *sdk.Charge) *Charge {
 		Currency: string(ch.Currency),
 		Status:   string(ch.Status),
 		Created:  ch.Created,
+	}
+	if ch.Customer != nil {
+		out.CustomerID = ch.Customer.ID
 	}
 	// Extract card fingerprint from payment_method_details.card.fingerprint (§8 pattern D).
 	if ch.PaymentMethodDetails != nil && ch.PaymentMethodDetails.Card != nil {

--- a/services/marketplace-api/internal/metrics/registry.go
+++ b/services/marketplace-api/internal/metrics/registry.go
@@ -221,6 +221,33 @@ var (
 		[]string{"event"},
 	)
 
+	// FraudWarningsTotal counts radar.early_fraud_warning webhook events
+	// received from Stripe Radar, labeled by whether the warning could be
+	// attributed to a store (attributed | unattributed), the reason
+	// attribution ended that way (ok | malformed_payload | no_charge_id |
+	// no_charge_getter | charge_lookup_failed | no_customer |
+	// no_subscription | subscription_lookup_failed), and whether Stripe
+	// marked the warning actionable (true | false).
+	//
+	// A fraud warning is an EVENT, not a state, which is why #704 is served
+	// by this counter and an audit row rather than by a boolean column: the
+	// thing ops needs is to be told one arrived, promptly, not to be able to
+	// query later that one once did.
+	//
+	// Unattributed warnings are counted deliberately. Attribution needs a
+	// live Stripe charge lookup, so it fails on a Stripe outage, on a
+	// one-off charge, and whenever no billing key is configured — and a
+	// warning we cannot pin to a store is still a warning. Dropping those
+	// would make the counter read healthiest exactly when the lookup path
+	// is broken.
+	FraudWarningsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mark8ly_subscription_fraud_warnings_total",
+			Help: "Count of Stripe Radar early fraud warnings received, labeled by attribution (attributed | unattributed), the reason attribution resolved that way, and whether Stripe marked the warning actionable. Unattributed warnings are counted too — attribution requires a live Stripe lookup that can fail independently of the warning.",
+		},
+		[]string{"attribution", "reason", "actionable"},
+	)
+
 	// MobileAdminTokenVerifiedTotal counts successful mobile-admin bearer
 	// verifications, labeled by the issuer that accepted the token
 	// (zitadel | gip).
@@ -269,6 +296,7 @@ func init() {
 		APIKeyRateLimitedTotal,
 		MobileAdminTokenVerifiedTotal,
 		CarrierSecretEventsTotal,
+		FraudWarningsTotal,
 	)
 
 	// Pre-declare every carriersecrets event series at 0.


### PR DESCRIPTION
Half of #704. `radar.early_fraud_warning` is subscribed (`dispatcher.go:75`) and in the allowed-event list, so Stripe delivers these and we return 200 — into a handler whose entire body was `return nil`. Its comment claimed "audit-only in P2"; no audit row was written either.

Stripe telling us a charge is likely fraudulent is among the strongest signals we get, and it reached nothing.

## The arbitrage half is deliberately NOT here

#704 also covers `arbitrage_flag` being unreachable. I traced a clean fix — capture `CF-IPCountry` via the existing `arbitrage.CFIPCountryFromGin` at checkout-session creation, carry it in the Stripe session metadata, read it back in `handleCheckoutSessionCompleted`. No new column, no new table.

**It is not shipped, for non-technical reasons.** Enabling it starts flagging real merchant accounts while tesserix-home#144 ("Subscription arbitrage appeals queue") is unbuilt, `arbitrage_flag` is already visible to the merchant on their own subscription response (`handlers/admin/subscription.go:98`), and the quarterly cron only clears flags for allowlisted stores. Flagging people who can see it, with no review queue and no appeals path, is worse than not flagging.

Full reasoning on the issue. Sequence: tesserix-home#144 -> thread the IP country -> flags mean something.

## What this does

- `handleFraudWarning` is now a `*Dispatcher` method. As a free function it had no `d.emitter` — the same structural reason the other P2 handlers were never finished.
- New action `subscription.fraud_warning_received`, Severity **Warning**, metadata carrying warning id, charge id, payment-intent id, `fraud_type` and `actionable`.
- New counter `mark8ly_subscription_fraud_warnings_total`, labelled `attribution` / `reason` / `actionable`. #704's own argument is that a warning arriving is an **event**, better served by alerting than a boolean column — the counter is what makes that possible, and the estate's alerting stack is proven (tesserix-k8s `subscription-observability`).

## Attribution needed a Stripe lookup, and a struct change

The payload carries a **charge id, not a customer**, and `audit.Event` requires a `TenantID`. There is no local charge -> store mapping — `refund_audit.stripe_charge_id` exists only for refunds. So the Dispatcher gained a narrow, nil-safe `ChargeGetter`, mirroring how the `refunds` repository was added in #725.

Worth a reviewer's eye: **`billingstripe.Charge` did not expose the customer at all**, so `GetCharge` as it stood could not have attributed anything. `CustomerID` was added, mapped nil-safely. Additive only — existing refund callers are unaffected and `internal/billing/...` and `internal/refund` tests pass.

The payload's `charge`/`payment_intent` go through a small `stripeRef` type accepting a bare id, an expanded object, or `null`. Getting `charge` wrong would cost the only attribution key the event carries.

## The property that matters most

**The signal survives failed attribution.** Nil getter, failed Stripe lookup, charge without a customer, or no matching subscription — each logs at **Error** with the warning and charge ids and the specific reason, still increments the counter, and returns nil. A malformed payload does the same. The webhook is never failed; this is observational.

Silently returning nil is how the original bug existed, so the new code cannot do it.

**One decision worth confirming:** an unattributed warning emits **no audit event**. `audit.Event` is tenant-scoped, and a `uuid.Nil` tenant would produce a row invisible in every audit surface — worse than no row, because it looks recorded. The Error log plus the labelled counter carry that case instead. If you would rather have a tenant-less row as well, it is a small change to `decideFraudWarningEvent`.

## Testing

Every pre-existing test in `internal/billing/dispatch` is `//go:build integration`, so an untagged run compiles none of them and `TEST_DATABASE_URL` is unset locally — they would skip while still printing `ok`. All new tests are untagged and genuinely execute: **30 passing in the package**, verified with `-v`, including two that assert the real counter moves via `prometheus/testutil`.

Covered: parsing (bare id, expanded object, null refs, malformed), the emit/suppress decision, every attribution failure mode, and that the handler is actually registered.

Rebased onto current `main` after #731 landed — both touch `main.go`. Verified after rebasing that #731's 12 `emailtemplates` references are intact and the build, vet (including `-tags integration`) and tests are clean.

Refs #704.
