### PR TITLE
Stop the migration fast path claiming a domain-age check it does not run

### DIFF
--- a/.planning/quick/260906-da-domain-age-honest/PLAN.md
+++ b/.planning/quick/260906-da-domain-age-honest/PLAN.md
@@ -1,0 +1,72 @@
+# Stop the migration fast path claiming a domain-age check it does not run
+
+#706. `internal/billing/migration/handler.go:112` gates the fast path on
+`ValidateWhoisAge(ctx, domain, 90)`, rejecting with `whois_too_young`. That
+rejection can never fire: production wires `NoOpValidator{}`
+(`cmd/marketplace-api/main.go`), whose `ValidateWhoisAge` returns `nil`
+unconditionally, and **no WHOIS or RDAP implementation exists anywhere** in the
+repo.
+
+So the system presents a substantive eligibility gate — "this merchant has
+genuinely been operating elsewhere for 90+ days" — and enforces nothing.
+
+## What is actually protecting this
+
+The human CSM review at `POST /internal/csm/migration-fast-path/:id/review`.
+That is a real control and this change does not touch it. The problem is that
+the system reports the automated check as passed, so reviewer attention is
+being spent on a check the reviewer may reasonably assume already happened.
+
+## The decision
+
+#706 offered implement-or-drop. Taking neither wholesale:
+
+- **Not implementing RDAP here.** It is real work with an external dependency,
+  and registrar privacy proxies mean the result needs a third state
+  (verified / too-new / undeterminable) with undeterminable routed to a human
+  — which is what already happens today for everything. Worth doing, but it
+  should be its own change, decided on its own merits.
+- **Not deleting the interface.** It is the correct seam for a real validator.
+
+What ships now is honesty: the code should say plainly that domain age is NOT
+verified, and it must be impossible to wire the no-op without noticing.
+
+## Task
+
+1. **Rename `NoOpValidator` to state what it does** — something like
+   `UnenforcedDomainAge`. "NoOp" describes the implementation; the new name
+   must describe the CONSEQUENCE, so `main.go`'s wiring line reads as an
+   admission rather than a placeholder. Update the doc comment to say the
+   90-day gate is not enforced and eligibility rests entirely on CSM review.
+2. **Log loudly at startup** when it is wired — Warn or Error, naming the
+   consequence, so an operator reading boot logs learns the gate is inert.
+   This is #706's explicit ask: an unimplemented validator must be impossible
+   to wire silently.
+3. **Correct the misattributed comment.** `handler.go:20` says "TODO: wire
+   P7's tax-ID package when it lands." The tax-ID package now EXISTS
+   (`internal/billing/tax/`) and is irrelevant — it validates tax
+   identifiers, not domain registration age. Anyone following that comment is
+   sent to the wrong place. Say what is actually needed: a WHOIS/RDAP lookup.
+4. Keep `PriorPlatformValidator` and the `handler.go:112` call site unchanged,
+   so a real validator drops in without touching the handler.
+
+## Out of scope
+
+- Implementing RDAP/WHOIS.
+- Any migration or new column. Recording "was the age verified?" on the review
+  row so a CSM sees it is the substantive follow-up, and needs its own change.
+- The CSM review flow itself.
+
+## Done when
+
+- Nothing in the tree claims a domain-age check is enforced
+- Production logs the consequence at startup
+- No behaviour change: the same requests are accepted, the same CSM review
+  decides them
+- `go build ./...`, `go vet`, `go test` green; existing migration tests pass
+  unchanged
+
+## Constraints
+
+- Single atomic commit, single-line conventional message, NO attribution.
+- SHARED CHECKOUT: no checkout/switch/stash/reset beyond this branch.

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1185,7 +1185,14 @@ func main() {
 			log.Error("marketplace-api: customer erasure executor could not be built", "err", err)
 			os.Exit(1)
 		}
-		migrationHandler = migration.NewHandler(migrationRepo, migration.NoOpValidator{}, log).WithAudit(auditEmitter)
+		// #706: the fast path's 90-day domain-age gate is NOT enforced. No WHOIS
+		// or RDAP lookup exists, so UnenforcedDomainAge accepts every domain and
+		// eligibility rests entirely on the CSM review at
+		// POST /internal/csm/migration-fast-path/:id/review. Logged rather than
+		// left implicit so an operator reading boot logs learns the gate is inert
+		// instead of inferring it from a passing check.
+		log.Warn("migration fast-path: domain-age check NOT enforced — every domain is accepted; eligibility rests on CSM review (#706)")
+		migrationHandler = migration.NewHandler(migrationRepo, migration.UnenforcedDomainAge{}, log).WithAudit(auditEmitter)
 
 		// P8 — Arbitrage appeal handler (§18.8.1).
 		arbitrageAppealSvc := arbitrage.NewAppealService(conn, arbitrage.NoOpPublisher{}, arbitrage.NopPIILogger{})

--- a/services/marketplace-api/internal/billing/migration/handler.go
+++ b/services/marketplace-api/internal/billing/migration/handler.go
@@ -13,21 +13,40 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/auth"
 )
 
-// PriorPlatformValidator is the WHOIS-age check interface. P7 will ship a
-// concrete implementation backed by the tax-ID registry; until then
-// NoOpValidator passes every request.
+// PriorPlatformValidator is the domain-registration-age check interface. A
+// real implementation needs a WHOIS or RDAP lookup; RDAP is the better target,
+// being the IETF successor with structured JSON and more predictable rate
+// limits than scraping WHOIS text.
 //
-// TODO: wire P7's tax-ID package when it lands.
+// Whatever implements this must have THREE outcomes, not two: verified,
+// too-new, and undeterminable. Registrar privacy proxies obscure the
+// registration date for a large share of domains, and an undeterminable
+// result must route to human review rather than passing (#706).
+//
+// A previous comment here said "wire P7's tax-ID package when it lands". That
+// was misattributed: the tax-ID package now exists (internal/billing/tax) and
+// is unrelated — it validates tax identifiers, not domain age. Following it
+// leads nowhere.
 type PriorPlatformValidator interface {
 	ValidateWhoisAge(ctx context.Context, domain string, minAgeDays int) error
 }
 
-// NoOpValidator is the default implementation that passes every WHOIS check.
-// It is used until P7 ships the real validator.
-type NoOpValidator struct{}
+// UnenforcedDomainAge accepts every domain, whatever its registration date.
+//
+// Named for its CONSEQUENCE rather than its implementation. It was previously
+// called NoOpValidator, which reads as a harmless placeholder at the wiring
+// site; it is not. With this bound, the 90-day check in Submit cannot reject
+// anything, so a merchant may register a domain today, submit it as
+// whois_domain evidence, and reach a pending review.
+//
+// That is survivable ONLY because the CSM review is the real control. What it
+// must not do is look automated: a reviewer who assumes the age was checked is
+// spending attention on a guarantee nobody made. Callers wiring this are
+// expected to log the fact — see cmd/marketplace-api/main.go.
+type UnenforcedDomainAge struct{}
 
-// ValidateWhoisAge always returns nil (passes every domain).
-func (NoOpValidator) ValidateWhoisAge(context.Context, string, int) error { return nil }
+// ValidateWhoisAge always returns nil: no domain is ever rejected for age.
+func (UnenforcedDomainAge) ValidateWhoisAge(context.Context, string, int) error { return nil }
 
 // reviewStore is the narrow data-access interface the Handler needs.
 // *Repository satisfies it automatically. Defined here so handler tests can
@@ -46,11 +65,12 @@ type Handler struct {
 	audit     *audit.Emitter // optional — nil-safe, see WithAudit
 }
 
-// NewHandler constructs a Handler. If v is nil the NoOpValidator is used.
+// NewHandler constructs a Handler. A nil validator falls back to
+// UnenforcedDomainAge, which accepts every domain — see its doc comment.
 // If logger is nil slog.Default() is used.
 func NewHandler(repo reviewStore, v PriorPlatformValidator, logger *slog.Logger) *Handler {
 	if v == nil {
-		v = NoOpValidator{}
+		v = UnenforcedDomainAge{}
 	}
 	if logger == nil {
 		logger = slog.Default()


### PR DESCRIPTION
#706. The migration fast path gates on `ValidateWhoisAge(ctx, domain, 90)` and rejects with `whois_too_young`. That rejection **can never fire**: production wires a validator that returns `nil` unconditionally, and no WHOIS or RDAP implementation exists anywhere in the repo.

So the system presented a substantive eligibility gate — "this merchant has been operating elsewhere for 90+ days" — and enforced nothing.

## Why not implement RDAP here

#706 framed it as implement-or-drop. This does neither wholesale, deliberately.

**Not implementing.** A real lookup is worth doing, but it is its own change: an external dependency in a request path, and registrar privacy proxies mean the result needs a **third** outcome — verified / too-new / undeterminable — with undeterminable routed to a human. That is a design decision that deserves its own review, not a rider on a comment fix.

**Not deleting the interface.** It is the right seam; a real validator should drop in without touching the handler, and it now does.

What ships is honesty. The human CSM review at `POST /internal/csm/migration-fast-path/:id/review` is and remains the real control — untouched here. The problem was never that a human decides; it is that the system reported an automated check as passed, so **reviewer attention was being spent on a guarantee nobody had made.**

## What changed

**`NoOpValidator` -> `UnenforcedDomainAge`.** "NoOp" names the implementation and reads as a harmless placeholder at the wiring site. The new name states the consequence, so `main.go`'s line reads as an admission rather than a stub. Its doc comment now spells out that a merchant may register a domain today, submit it as evidence, and reach a pending review — survivable only because a human decides, and dangerous only if it looks automated.

**A startup warning.** #706's explicit ask was that an unimplemented validator must be impossible to wire silently:

```
migration fast-path: domain-age check NOT enforced — every domain is
accepted; eligibility rests on CSM review (#706)
```

**A misattributed comment corrected.** The interface said *"TODO: wire P7's tax-ID package when it lands."* The tax-ID package now **exists** (`internal/billing/tax/`) and is irrelevant — it validates tax identifiers, not domain registration age. Anyone following that comment is sent somewhere that cannot help. It now says what is actually needed, including the three-outcome requirement, so whoever implements it does not rediscover the privacy-proxy problem late.

## No behaviour change, and that is checkable

The only non-comment edits in the diff are the rename itself:

```
-type NoOpValidator struct{}
+type UnenforcedDomainAge struct{}
-func (NoOpValidator) ValidateWhoisAge(...) error { return nil }
+func (UnenforcedDomainAge) ValidateWhoisAge(...) error { return nil }
-		v = NoOpValidator{}
+		v = UnenforcedDomainAge{}
```

The `handler.go:112` call site is untouched. The same requests are accepted, and the same CSM review decides them. All 18 existing migration tests pass **unchanged** — no assertion was adjusted to fit.

`go build ./...`, `go vet` (including `-tags integration`) clean.

## The follow-up worth doing next

`migration_fast_path_reviews` records `whois_domain` but **nothing recording whether the age was verified**. So a CSM sees a pending request with a domain and no indication the check did not run. Surfacing that on the review row is the change that actually improves the control — it needs a migration, so it is not here, but it is the natural next step and more valuable than RDAP.

Refs #706.
