### PR TITLE
feat(mobile): send X-Acting-Tenant-Id and stop conflating store id with tenant id (#686)

### DIFF
--- a/apps/mobile-admin/__tests__/acting-tenant-header.test.tsx
+++ b/apps/mobile-admin/__tests__/acting-tenant-header.test.tsx
@@ -1,0 +1,80 @@
+import { createApiClient } from "@repo/mobile-shared/api/client";
+
+// marketplace-api resolves tenancy for a Zitadel token from the
+// X-Acting-Tenant-Id header, FGA-checked against the caller (#686). A GIP
+// token carried a tenant claim and needed none of this; a Zitadel token
+// carries no claim at all, so without the header every request resolves no
+// tenant and is refused 404.
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    headers: { get: () => "application/json" },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response);
+}
+
+function clientWith(actingTenantId: string | null, storeId: string | null = null) {
+  const fetchMock = jest.fn(() => jsonResponse({ data: [] }));
+  global.fetch = fetchMock as unknown as typeof fetch;
+  const client = createApiClient({
+    baseUrl: "https://api.mark8ly.com",
+    getToken: async () => "tok",
+    getStoreId: () => storeId,
+    getActingTenantId: () => actingTenantId,
+  });
+  return { client, fetchMock };
+}
+
+function headersOf(fetchMock: jest.Mock): Record<string, string> {
+  return (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+}
+
+it("sends X-Acting-Tenant-Id when a tenant is known", async () => {
+  const { client, fetchMock } = clientWith("e638b731-6a49-48ce-8fad-80cc1e6213c2");
+  await client.getTenant("/stores");
+
+  expect(headersOf(fetchMock)["X-Acting-Tenant-Id"]).toBe(
+    "e638b731-6a49-48ce-8fad-80cc1e6213c2",
+  );
+});
+
+it("omits the header entirely when no tenant is known", async () => {
+  const { client, fetchMock } = clientWith(null);
+  await client.getTenant("/stores");
+
+  // An empty-string header is NOT the same as an absent one: the server
+  // treats a present-but-empty value as a stated tenant and fails the FGA
+  // check, turning "not resolved yet" into a hard refusal.
+  expect(headersOf(fetchMock)).not.toHaveProperty("X-Acting-Tenant-Id");
+});
+
+// The regression this guards: tenant-store used to write the STORE id into
+// the tenant slot. Sending a store id here would fail every FGA membership
+// check, and the failure surfaces as 404 "no store" — indistinguishable
+// from a genuinely unbound account.
+it("sends the tenant id, never the store id", async () => {
+  const { client, fetchMock } = clientWith("tenant-uuid", "store-uuid");
+  await client.get("/products");
+
+  const headers = headersOf(fetchMock);
+  expect(headers["X-Acting-Tenant-Id"]).toBe("tenant-uuid");
+  expect(headers["X-Acting-Tenant-Id"]).not.toBe("store-uuid");
+});
+
+// Configuration is optional so a GIP build, whose token still carries the
+// claim, is byte-for-byte unchanged.
+it("omits the header when no resolver is configured at all", async () => {
+  const fetchMock = jest.fn(() => jsonResponse({ data: [] }));
+  global.fetch = fetchMock as unknown as typeof fetch;
+  const client = createApiClient({
+    baseUrl: "https://api.mark8ly.com",
+    getToken: async () => "tok",
+    getStoreId: () => null,
+  });
+
+  await client.get("/products");
+  expect(headersOf(fetchMock)).not.toHaveProperty("X-Acting-Tenant-Id");
+});

--- a/apps/mobile-admin/__tests__/tenant-id-not-store-id.test.ts
+++ b/apps/mobile-admin/__tests__/tenant-id-not-store-id.test.ts
@@ -1,0 +1,84 @@
+import { useTenantStore } from "@repo/mobile-shared/stores/tenant-store";
+import { tokenStorage } from "@repo/mobile-shared/auth/token-storage";
+
+jest.mock("expo-secure-store", () => {
+  const mem: Record<string, string> = {};
+  return {
+    __mem: mem,
+    getItemAsync: jest.fn(async (k: string) => mem[k] ?? null),
+    setItemAsync: jest.fn(async (k: string, v: string) => {
+      mem[k] = v;
+    }),
+    deleteItemAsync: jest.fn(async (k: string) => {
+      delete mem[k];
+    }),
+  };
+});
+
+const store = (id: string) => ({
+  id,
+  name: "S",
+  slug: "s",
+  country_code: "IN",
+  currency_code: "INR",
+  status: "active",
+});
+
+const freshLaunch = () =>
+  useTenantStore.setState({ tenantId: null, activeStore: null, stores: [], hydrated: false });
+
+beforeEach(() => {
+  const mem = (jest.requireMock("expo-secure-store") as { __mem: Record<string, string> }).__mem;
+  for (const k of Object.keys(mem)) delete mem[k];
+  freshLaunch();
+});
+
+// THE regression, and it only shows across a restart — which is why it went
+// unnoticed. Selecting a store persisted that STORE's id into the tenant
+// slot; the next cold launch hydrates it as the tenant.
+//
+// Harmless while GIP's token carried the real tenant claim server-side. The
+// moment the client sends X-Acting-Tenant-Id (#686) it states a store id as
+// its tenant, fails every FGA membership check, and is refused 404 "no
+// store" while genuinely being a member — a bug that would look like a
+// backend fault, on the second launch only.
+it("does not persist the store id into the tenant slot", async () => {
+  await tokenStorage.setTenantId("tenant-uuid");
+  useTenantStore.getState().setActiveStore(store("store-uuid"));
+  await Promise.resolve();
+
+  expect(await tokenStorage.getTenantId()).toBe("tenant-uuid");
+});
+
+it("hydrates the real tenant id after a cold launch, not the store id", async () => {
+  await tokenStorage.setTenantId("tenant-uuid");
+  useTenantStore.getState().setActiveStore(store("store-uuid"));
+  await Promise.resolve();
+
+  freshLaunch();
+  await useTenantStore.getState().hydrate();
+
+  expect(useTenantStore.getState().tenantId).toBe("tenant-uuid");
+  expect(useTenantStore.getState().activeStore?.id).toBe("store-uuid");
+});
+
+// A wrong tenant is worse than no tenant: the client then sends a header it
+// believes is correct and gets an unexplained 404, instead of resolving the
+// tenant properly at sign-in.
+it("hydrates a null tenant rather than falling back to the store id", async () => {
+  useTenantStore.getState().setActiveStore(store("store-uuid"));
+  await Promise.resolve();
+
+  freshLaunch();
+  await useTenantStore.getState().hydrate();
+
+  expect(useTenantStore.getState().tenantId).toBeNull();
+});
+
+it("keeps the tenant id in memory when the active store changes", () => {
+  useTenantStore.getState().setTenantId("tenant-uuid");
+  useTenantStore.getState().setActiveStore(store("store-a"));
+  useTenantStore.getState().setActiveStore(store("store-b"));
+
+  expect(useTenantStore.getState().tenantId).toBe("tenant-uuid");
+});

--- a/apps/mobile-admin/__tests__/tenant-store-hydration.test.ts
+++ b/apps/mobile-admin/__tests__/tenant-store-hydration.test.ts
@@ -58,7 +58,18 @@ describe('tenant-store hydration', () => {
     await useTenantStore.getState().hydrate();
 
     expect(useTenantStore.getState().activeStore).toEqual(STORE);
-    expect(useTenantStore.getState().tenantId).toBe(STORE.id);
+    // CHANGED with #686. This previously asserted tenantId === STORE.id,
+    // i.e. it pinned the store-id/tenant-id conflation as intended
+    // behaviour. It was invisible while GIP's token carried the real tenant
+    // claim server-side, but the client now STATES its tenant via
+    // X-Acting-Tenant-Id, and a store id there fails the FGA membership
+    // check and is refused 404 "no store" for a genuine member.
+    //
+    // Selecting a store says nothing about which tenant the user is acting
+    // as; only the sign-in flow learns that, from the login response. So a
+    // cold launch that restores a store must leave the tenant untouched
+    // rather than inventing one.
+    expect(useTenantStore.getState().tenantId).toBeNull();
   });
 
   it('discards a persisted store that no longer matches the schema', async () => {

--- a/apps/mobile-admin/lib/api-client.ts
+++ b/apps/mobile-admin/lib/api-client.ts
@@ -27,6 +27,7 @@ const demoClient = DEMO_MODE ? createDemoApiClient() : null;
 export function useApiClient() {
   const { getToken, refreshToken, signOut } = useAuth();
   const activeStore = useTenantStore((s) => s.activeStore);
+  const tenantId = useTenantStore((s) => s.tenantId);
   const clearActiveStore = useTenantStore((s) => s.clearActiveStore);
   const env = useEnvironment();
   const queryClient = useQueryClient();
@@ -38,6 +39,10 @@ export function useApiClient() {
         getToken,
         refreshToken,
         getStoreId: () => activeStore?.id ?? null,
+        // Tenancy for a Zitadel token, which carries no tenant claim
+        // (#686). Read from the tenant slot, never from activeStore — see
+        // tenant-store.ts for why those must not be conflated.
+        getActingTenantId: () => tenantId ?? null,
         onUnauthorized: async (reason) => {
           // Record WHY before tearing the session down — /login reads this and
           // explains itself instead of bouncing the user with no message.
@@ -56,6 +61,7 @@ export function useApiClient() {
       getToken,
       refreshToken,
       activeStore?.id,
+      tenantId,
       clearActiveStore,
       signOut,
       queryClient,

--- a/packages/mobile-shared/api/client.ts
+++ b/packages/mobile-shared/api/client.ts
@@ -21,6 +21,23 @@ export interface ApiClientConfig {
   refreshToken?: () => Promise<string | null>;
   getStoreId: () => string | null;
   /**
+   * Returns the tenant the caller is acting as, sent as
+   * `X-Acting-Tenant-Id` and validated server-side against FGA membership
+   * (#686).
+   *
+   * A GIP id_token carried a tenant claim, so the server could resolve
+   * tenancy from the token alone. A Zitadel access token carries no such
+   * claim — by design, since FGA membership is a list and only the client
+   * knows which tenant is on screen — so the client has to state it. Omit
+   * this on a GIP build and behaviour is unchanged.
+   *
+   * This is the TENANT id, NOT the active store id. They are different
+   * identifiers, and sending a store id fails every FGA membership check,
+   * surfacing as a 404 that is indistinguishable from an account with no
+   * store at all.
+   */
+  getActingTenantId?: () => string | null;
+  /**
    * Called when the API rejects the (possibly refreshed) token with a
    * 401. The caller normally signs the user out and routes back to /login.
    */
@@ -88,6 +105,14 @@ export function createApiClient(config: ApiClientConfig) {
       Accept: "application/json",
       ...(init.headers ?? {}),
     };
+    // Only when actually known. An empty-string header is NOT equivalent to
+    // an absent one: the server treats a present value as a stated tenant
+    // and fails it against FGA, turning "not resolved yet" into a hard
+    // refusal instead of falling through to the token's own claim.
+    const actingTenantId = config.getActingTenantId?.() ?? null;
+    if (actingTenantId) {
+      headers["X-Acting-Tenant-Id"] = actingTenantId;
+    }
     let body: BodyInit | undefined;
     if (init.formData) {
       body = init.formData;

--- a/packages/mobile-shared/stores/tenant-store.ts
+++ b/packages/mobile-shared/stores/tenant-store.ts
@@ -33,7 +33,17 @@ export const useTenantStore = create<TenantStoreState>((set, get) => ({
     set({ activeStore: store });
     if (store) {
       tokenStorage.setStoreId(store.id).catch(() => undefined);
-      tokenStorage.setTenantId(store.id).catch(() => undefined);
+      // Deliberately NOT setTenantId(store.id). A store id and a tenant id
+      // are different identifiers; writing one into the other's slot was
+      // invisible while GIP's token carried the real tenant claim
+      // server-side, but the client now STATES its tenant via
+      // X-Acting-Tenant-Id (#686). A store id there fails the FGA
+      // membership check and is refused 404 "no store" — while the
+      // merchant genuinely is a member. It only surfaced after a restart,
+      // because this wrote to storage and hydrate() read it back.
+      //
+      // The tenant is set explicitly by the sign-in flow, which is the
+      // only thing that actually learns it (from the login response).
       tokenStorage.setActiveStore(store).catch(() => undefined);
     }
   },
@@ -55,7 +65,11 @@ export const useTenantStore = create<TenantStoreState>((set, get) => ({
       // resolver has to re-decide.
       const restored = activeStore && activeStore.id === storeId ? activeStore : null;
       set({
-        tenantId: tenantId ?? storeId ?? null,
+        // No storeId fallback: a WRONG tenant is worse than none. With a
+        // fallback the client confidently states a store id as its tenant
+        // and gets an unexplained 404; with null it simply has no tenant
+        // yet and the sign-in flow resolves one.
+        tenantId: tenantId ?? null,
         activeStore: restored,
         hydrated: true,
       });


### PR DESCRIPTION
Part of #686. The client half of tenancy: the app can now state which tenant it is acting as, and a latent data bug that would have silently broken it is fixed.

## 1. `X-Acting-Tenant-Id`

marketplace-api resolves tenancy for a Zitadel token from this header, FGA-checked against the caller (#722). A GIP id_token carried a tenant claim so the server could resolve tenancy alone; a Zitadel token carries none — deliberately, since FGA membership is a *list* and only the client knows which tenant is on screen.

`getActingTenantId` is **optional**, so a GIP build is byte-for-byte unchanged.

The header is sent only when a tenant is actually known. An empty-string header is **not** equivalent to an absent one: the server treats a present value as a stated tenant and fails it against FGA, turning "not resolved yet" into a hard refusal instead of falling through to the token's own claim.

## 2. The latent bug this would have tripped over

`setActiveStore` persisted the selected **store's** id into the **tenant** slot, and `hydrate` read it back as the tenant.

It was invisible because GIP's token carried the real tenant claim server-side — and because **it only manifests after a restart**: the write went to secure storage, not to in-memory state. So the first session looked fine and the second silently sent a store id as its tenant, failing every FGA membership check and being refused `404 no_store` while the merchant genuinely *is* a member. On the second launch only, looking exactly like a backend fault.

`hydrate` also no longer falls back to the store id. A **wrong** tenant is worse than none: with a fallback the client confidently states a store id and gets an unexplained 404; with null it simply has no tenant yet and the sign-in flow resolves one.

## A test that pinned the bug

`tenant-store-hydration.test.ts` asserted `tenantId === STORE.id` — it encoded the conflation as intended behaviour. I changed it to assert `null` and left a comment explaining what changed and why, rather than quietly dropping the assertion. Worth a reviewer's eye: if selecting a store *should* imply a tenant, this is the line to argue with.

## Also worth knowing

My first attempt at the regression test **passed immediately** — because it only exercised in-memory state, where the bug does not appear. I rewrote it around a cold launch, watched it fail for the right reason, then fixed the code. Three of the four assertions in that file are meaningless without the `hydrate()` step.

## Verification

Full suite: **127 suites, 1697 tests, all passing.** 7 new tests. `tsc` is clean for these files apart from the repo-wide missing-`@types/jest`/`node` noise that predates this (see #716).

## Next

The OTP screen and the sign-in flow that calls the front door (#732) and stores the returned tokens — this PR gives that flow somewhere correct to put the tenant it learns.
