### PR TITLE
Stop recording a registry name match that never happened

### DIFF
--- a/.planning/quick/260906-nm-name-match-honest/PLAN.md
+++ b/.planning/quick/260906-nm-name-match-honest/PLAN.md
@@ -1,0 +1,74 @@
+# Stop recording a name match that never happened
+
+#707. `US`, `CA` and `NZ` are format-only tax validators. All three return the
+merchant's OWN submitted business name as the registry's answer:
+
+    // internal/billing/tax/validators/us.go:42
+    return tax.ValidationResult{Valid: true, RegistryName: req.BusinessName}
+
+`service.go:132` then runs `CompareNames(in.BusinessName, res.RegistryName)` —
+comparing a string with itself — and writes `tax_id_name_match = "matched"`.
+
+So the database records that a registry confirmed the merchant's name, for
+merchants where no registry was ever consulted.
+
+## It is a deliberate workaround, which is why the fix is narrow
+
+`us.go`'s own comment says so:
+
+  "Mirrors BusinessName back so the orchestrator's name-match step writes
+   'matched' trivially; the attestation checkbox is the real integrity gate."
+
+The intent — do not block a US merchant when we have no registry to check
+against — is legitimate and is preserved. What is wrong is the expression: it
+records a positive assertion instead of an absence.
+
+## The honest value already exists
+
+`CompareNames` returns `NameNotChecked` when either side is empty
+(`namematch.go:25-27`), and `store_subscriptions.tax_id_name_match` already
+DEFAULTS to `not_checked` (`internal/subscription/models.go:128`). So the
+correct value is the one the schema was designed around.
+
+Verified nothing gates on it: `tax_id_name_match` is written by `service.go`
+and surfaced, but no code branches on the value. Changing `matched` to
+`not_checked` for these three countries blocks nothing and breaks no flow.
+
+## Task
+
+1. In `us.go`, `ca.go` and `nz.go`, return an empty `RegistryName` instead of
+   echoing `req.BusinessName`. Keep `Valid: true` — these countries should
+   still pass format validation and should still not be blocked.
+2. Rewrite the three comments. Each currently describes the echo as
+   intentional ("mirroring BusinessName as RegistryName"); they should say
+   instead that no registry is consulted, so no name match is asserted, and
+   that the real integrity gate is elsewhere (attestation for US).
+3. Update the two tests that pin the echo — `us_test.go:20` and `ca_test.go:20`
+   assert `RegistryName` equals the submitted name. That assertion encodes the
+   defect. Replace with an assertion that no registry name is returned, so a
+   future re-introduction fails.
+4. Add a test asserting the end state that matters: for a format-only country,
+   the recorded match is `not_checked`, not `matched`.
+
+## Out of scope — needs a product decision, not this change
+
+Whether format-only countries should set `tax_id_validated = true` at all, or
+follow the SEA pattern (`MY/TH/PH/ID/VN` return `Valid: false,
+ManualReviewRequired: true` and enqueue to `seaqueue`). That changes merchant
+flow and needs a queue to route to. Note it on the issue; do not build it.
+
+Also out of scope: NZ's enablement. It is gated off (`NZDisabled` unless
+`NZTaxValidationEnabled`), and it stays that way — this only fixes what it
+would record if enabled.
+
+## Done when
+
+- No format-only validator returns the submitted name as the registry name
+- A format-only validation records `not_checked`
+- Nothing is newly blocked: `Valid: true` unchanged for all three
+- `go build ./...`, `go vet`, `go test ./internal/billing/tax/...` green
+
+## Constraints
+
+- Single atomic commit, single-line conventional message, NO attribution.
+- SHARED CHECKOUT: no checkout/switch/stash/reset beyond this branch.

--- a/services/marketplace-api/internal/billing/tax/name_match_formatonly_test.go
+++ b/services/marketplace-api/internal/billing/tax/name_match_formatonly_test.go
@@ -1,0 +1,55 @@
+package tax_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/tax"
+	"github.com/mark8ly/marketplace-api/internal/billing/tax/validators"
+)
+
+// The format-only validators (US, CA, and NZ when enabled) consult no registry.
+// They must therefore record the name match as "not_checked" rather than
+// "matched" — the value store_subscriptions.tax_id_name_match already defaults
+// to.
+//
+// This pins the END STATE rather than the mechanism: what matters is the value
+// the orchestrator would write, not how the validator expresses it. Before
+// #707 each of these echoed the submitted BusinessName back, so
+// CompareNames compared a string with itself and returned NameMatched —
+// recording that a registry had confirmed the merchant's name when none was
+// ever consulted.
+func TestFormatOnlyValidatorsRecordNotChecked(t *testing.T) {
+	const submitted = "Acme Inc"
+
+	cases := []struct {
+		name    string
+		country string
+		taxID   string
+		v       tax.Validator
+	}{
+		{"US EIN", "US", "12-3456789", validators.NewUS()},
+		{"CA BN", "CA", "123456789", validators.NewCA()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := tc.v.Validate(context.Background(), tax.ValidationRequest{
+				Country: tc.country, TaxID: tc.taxID, BusinessName: submitted,
+			})
+			require.NoError(t, err)
+
+			// Still valid: format-only countries are not blocked. Only the
+			// false name-match assertion was removed.
+			require.True(t, res.Valid, "format check should still pass")
+
+			// This is the line that matters. CompareNames maps an empty
+			// registry name to NameNotChecked; an echo would yield NameMatched.
+			require.Equal(t, tax.NameNotChecked,
+				tax.CompareNames(submitted, res.RegistryName),
+				"a validator that consults no registry must not record a name match")
+		})
+	}
+}

--- a/services/marketplace-api/internal/billing/tax/validators/ca.go
+++ b/services/marketplace-api/internal/billing/tax/validators/ca.go
@@ -22,7 +22,10 @@ func NewCA() *CAValidator { return &CAValidator{} }
 // Country returns ISO-3166 alpha-2.
 func (v *CAValidator) Country() string { return "CA" }
 
-// Validate checks BN shape only, mirroring BusinessName as RegistryName.
+// Validate checks BN shape only. No CRA registry lookup exists, so no registry
+// name is returned and the name match records as "not_checked" (#707). It
+// previously echoed the submitted name back, which wrote "matched" for a check
+// that never ran.
 func (v *CAValidator) Validate(_ context.Context, req tax.ValidationRequest) (tax.ValidationResult, error) {
 	if req.Country != "CA" {
 		return tax.ValidationResult{}, tax.ErrInvalidFormat
@@ -32,7 +35,8 @@ func (v *CAValidator) Validate(_ context.Context, req tax.ValidationRequest) (ta
 		return tax.ValidationResult{}, tax.ErrInvalidFormat
 	}
 	return tax.ValidationResult{
-		Valid:        true,
-		RegistryName: req.BusinessName,
+		Valid: true,
+		// Deliberately empty — see the doc comment (#707).
+		RegistryName: "",
 	}, nil
 }

--- a/services/marketplace-api/internal/billing/tax/validators/ca_test.go
+++ b/services/marketplace-api/internal/billing/tax/validators/ca_test.go
@@ -17,7 +17,8 @@ func TestCA_BN_ValidFormatAccepted(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, res.Valid)
-	require.Equal(t, "Acme Canada Inc", res.RegistryName)
+	// No CRA registry is consulted — see the US equivalent (#707).
+	require.Empty(t, res.RegistryName)
 }
 
 func TestCA_BN_WithRTSuffixAccepted(t *testing.T) {

--- a/services/marketplace-api/internal/billing/tax/validators/nz.go
+++ b/services/marketplace-api/internal/billing/tax/validators/nz.go
@@ -37,7 +37,12 @@ func NewNZ(client *http.Client, baseURL string) *NZValidator {
 // Country returns ISO-3166 alpha-2.
 func (v *NZValidator) Country() string { return "NZ" }
 
-// Validate currently format-checks only; mirrors BusinessName as RegistryName.
+// Validate currently format-checks only. No IRD lookup exists, so no registry
+// name is returned and the name match records as "not_checked" (#707).
+//
+// This path is unreachable in production today — NZDisabled is bound unless
+// NZTaxValidationEnabled — but it must not assert a match if it is ever
+// enabled.
 // TODO(counsel §20.3): wire IRD lookup once legal sign-off lands.
 func (v *NZValidator) Validate(_ context.Context, req tax.ValidationRequest) (tax.ValidationResult, error) {
 	if req.Country != "NZ" {
@@ -46,7 +51,8 @@ func (v *NZValidator) Validate(_ context.Context, req tax.ValidationRequest) (ta
 	if !nzIRDRegex.MatchString(req.TaxID) {
 		return tax.ValidationResult{}, tax.ErrInvalidFormat
 	}
-	return tax.ValidationResult{Valid: true, RegistryName: req.BusinessName}, nil
+	// RegistryName deliberately empty: no registry was consulted (#707).
+	return tax.ValidationResult{Valid: true, RegistryName: ""}, nil
 }
 
 // NZDisabled is wired by Registry when NZ_TAX_VALIDATION_ENABLED=false. The

--- a/services/marketplace-api/internal/billing/tax/validators/us.go
+++ b/services/marketplace-api/internal/billing/tax/validators/us.go
@@ -27,9 +27,16 @@ func NewUS() *USValidator { return &USValidator{} }
 // Country returns ISO-3166 alpha-2.
 func (v *USValidator) Country() string { return "US" }
 
-// Validate checks EIN shape only. Mirrors BusinessName back so the orchestrator's
-// name-match step writes "matched" trivially; the attestation checkbox is the
-// real integrity gate.
+// Validate checks EIN shape only. There is no US registry lookup, so NO
+// registry name is returned and the orchestrator records the name match as
+// "not_checked" (#707).
+//
+// It previously echoed req.BusinessName back, which made CompareNames compare
+// a string with itself and write "matched" — recording that a registry had
+// confirmed the name when none was consulted. Passing format validation is
+// still correct; asserting a match that never happened was not.
+//
+// The attestation checkbox remains the real integrity gate for US merchants.
 func (v *USValidator) Validate(_ context.Context, req tax.ValidationRequest) (tax.ValidationResult, error) {
 	if req.Country != "US" {
 		return tax.ValidationResult{}, tax.ErrInvalidFormat
@@ -38,7 +45,9 @@ func (v *USValidator) Validate(_ context.Context, req tax.ValidationRequest) (ta
 		return tax.ValidationResult{}, tax.ErrInvalidFormat
 	}
 	return tax.ValidationResult{
-		Valid:        true,
-		RegistryName: req.BusinessName,
+		Valid: true,
+		// Deliberately empty: no registry was consulted. CompareNames maps an
+		// empty registry name to NameNotChecked (#707).
+		RegistryName: "",
 	}, nil
 }

--- a/services/marketplace-api/internal/billing/tax/validators/us_test.go
+++ b/services/marketplace-api/internal/billing/tax/validators/us_test.go
@@ -17,7 +17,10 @@ func TestUS_EIN_ValidFormatAccepted(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, res.Valid)
-	require.Equal(t, "Acme Inc", res.RegistryName)
+	// No US registry is consulted, so no registry name may be returned. If this
+	// ever echoes the submitted name again, CompareNames compares a string with
+	// itself and records a "matched" that never happened (#707).
+	require.Empty(t, res.RegistryName)
 }
 
 func TestUS_EIN_NoDashAlsoAccepted(t *testing.T) {


### PR DESCRIPTION
#707. The `US`, `CA` and `NZ` tax validators are format-only — no registry is consulted — yet all three returned the merchant's **own submitted business name** as the registry's answer:

```go
// internal/billing/tax/validators/us.go, before
return tax.ValidationResult{Valid: true, RegistryName: req.BusinessName}
```

`service.go:132` then runs `CompareNames(in.BusinessName, res.RegistryName)` — comparing a string with itself — and writes `tax_id_name_match = "matched"`.

So the database recorded that a registry had confirmed the merchant's name, for every merchant where no registry was ever consulted.

## It was deliberate, which is why the fix is narrow

`us.go`'s own comment said so:

> *"Mirrors BusinessName back so the orchestrator's name-match step writes 'matched' trivially; the attestation checkbox is the real integrity gate."*

The **intent** is legitimate and is preserved: do not block a US merchant when there is no registry to check against. `Valid: true` is unchanged for all three, so nothing is newly rejected. What was wrong is the expression — it recorded a positive assertion where the truth is an absence.

That is the same defect shape as #706's domain-age gate: a check that reports success without testing anything. An absent check should look absent.

## The honest value already existed

`CompareNames` returns `NameNotChecked` when either side is empty (`namematch.go:25-27`), and `store_subscriptions.tax_id_name_match` already **defaults** to `not_checked` (`internal/subscription/models.go:128`). The schema was designed around exactly this case; the validators were routing around it.

So the change is: return an empty `RegistryName`. The orchestrator then records the truth with no other edit.

## Safety

`tax_id_name_match` is **written and surfaced, never branched on** — verified across the service. Changing `matched` to `not_checked` for these three countries blocks nothing and alters no flow. Neither US nor CA is in `ReverseChargeCountries` (`reverse_charge_invoice.go:15-20`), so no tax position rested on the false match either.

## Testing

Two existing assertions **encoded the defect** — `us_test.go:20` and `ca_test.go:20` asserted `RegistryName` equalled the submitted name. Replaced with `require.Empty`, so a re-introduction fails rather than passes.

Added `TestFormatOnlyValidatorsRecordNotChecked`, which pins the **end state** rather than the mechanism: what the orchestrator would record, not how the validator expresses it.

I verified it is a real gate rather than a tautology — temporarily restoring the echo makes it fail with *"a validator that consults no registry must not record a name match"*, and it passes again once reverted.

`go build ./...`, `go vet`, and the tax and subscription suites are clean.

## Deliberately out of scope

**Whether format-only countries should set `tax_id_validated = true` at all.** The SEA validators (`MY/TH/PH/ID/VN`) take the honest alternative — `Valid: false, ManualReviewRequired: true`, enqueued to `seaqueue`. Applying that to US and CA would change merchant flow and needs a queue to route to, so it is a product decision rather than a correctness fix. Noted on the issue.

**NZ's enablement.** It stays gated off (`NZDisabled` unless `NZTaxValidationEnabled`); this only fixes what it would record if ever switched on — which matters, because NZ *is* in `ReverseChargeCountries`, so a false name match there would sit under a real tax position.

Refs #707, #706.
