### PR TITLE
Tell the merchant when their migration fast-path request is decided

### DIFF
--- a/.planning/quick/260906-mfp-migration-decision-email/PLAN.md
+++ b/.planning/quick/260906-mfp-migration-decision-email/PLAN.md
@@ -1,0 +1,71 @@
+# Tell the merchant when their migration fast-path request is decided
+
+The last item on #703. Everything else the issue asked for shipped in #711;
+this is the one site left:
+
+```go
+// internal/billing/migration/handler.go:212-214
+// TODO: migration fast-path approval/rejection emails land when the email
+// package and StoreSubscription.email column exist (deferred from P5 scope).
+h.logger.Info("migration fast-path decided; email deferred", ...)
+```
+
+A merchant submits evidence that they have been trading elsewhere, a CSM
+approves or rejects it, and the merchant is never told either way. The
+decision is written and audited; only the notification is missing.
+
+## The stated blocker is gone twice over
+
+The comment defers to "the email package and StoreSubscription.email column".
+Both exist. `internal/email/` has the client, twelve registered templates,
+`ValidateRecipient` and `SkipReason`; `store_subscriptions.email` landed in
+migration 000104 and `expiry_cron.go` reads it. Nothing is blocked.
+
+## Shape: copy expiry_cron.go, do not invent
+
+`ExpiryCron.notifyExpired` is the reference and this follows it exactly:
+chainable `WithEmail(...)` so existing callers compile untouched, a nil mailer
+means send nothing, `ValidateRecipient` before the provider sees the address,
+and skip/sent counters on `BillingEmailsSkippedTotal` / `BillingEmailsSentTotal`.
+
+Best-effort is the whole point: the review row is already committed and the
+audit event already emitted when we get here, so a send failure is logged and
+counted, never returned. The CSM's write must not fail because email is down.
+
+## Two decisions worth recording
+
+**The CSM's notes are NOT sent to the merchant.** `reviewRequest.Notes` is
+required, 3–2000 chars, and written by a CSM for internal review. Putting it
+in merchant-facing mail would publish internal commentary about that merchant
+on the strength of a field nobody wrote with an external reader in mind. The
+rejection email says the decision and how to follow up; if a merchant-facing
+reason is wanted later it needs its own field, deliberately authored.
+
+**Recipient lookup enters as a function, not a DB handle.** `Handler` holds a
+narrow `reviewStore`, not gorm, and that is worth keeping. A
+`RecipientLookup func(ctx, storeID) (email, storeName string)` is supplied by
+main.go as a closure over `conn`. The handler stays testable without a
+database, matching how `reviewStore` already works.
+
+## Tasks
+
+1. `internal/subscription/billing_email.go` — `BillingEmailFor`, the
+   symmetric partner to the existing `StoreNameFor`. Returns "" when there is
+   no row, so `ValidateRecipient` produces the `no_address` skip reason
+   rather than the caller inventing one.
+2. `internal/email/` — two templates, `migration_fast_path_approved` and
+   `migration_fast_path_rejected`: ids in `client.go`, entries in
+   `billingTemplateKeys`, subject + HTML + text in `templates_content.go`.
+   Registering them makes them console-overridable (#717's mechanism).
+3. `internal/billing/migration/handler.go` — `WithEmail(...)`, a
+   `notifyDecision` mirroring `notifyExpired`, replacing the TODO and its log.
+4. `cmd/marketplace-api/main.go` — wire client, lookup closure and counters.
+
+## Done when
+
+- A merchant with a valid billing email gets the right one of two emails on
+  approve and on reject.
+- A handler with no mailer, a store with no email row, and a placeholder
+  `@mark8ly.local` address each send nothing, return 200, and count a skip.
+- A provider failure is logged and counted, and the response is still 200.
+- Existing `NewHandler` callers and tests compile untouched.

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -274,6 +274,25 @@ func (t trialSentCounter) WithTemplate(template string) trial.CounterIncrementer
 	return t.cv.WithLabelValues(template)
 }
 
+// migrationSkipCounter / migrationSentCounter do the same again for the
+// migration fast-path decision notices (#703).
+//
+// A third near-identical pair rather than reusing the trial ones: each
+// package declares its own CounterIncrementer, and Go requires the return
+// type to match exactly, so trialSentCounter cannot satisfy
+// migration.SentCounter however alike they look.
+type migrationSkipCounter struct{ cv *prometheus.CounterVec }
+
+func (m migrationSkipCounter) WithTemplateReason(template, reason string) migration.CounterIncrementer {
+	return m.cv.WithLabelValues(template, reason)
+}
+
+type migrationSentCounter struct{ cv *prometheus.CounterVec }
+
+func (m migrationSentCounter) WithTemplate(template string) migration.CounterIncrementer {
+	return m.cv.WithLabelValues(template)
+}
+
 // otelServiceName is the OpenTelemetry service.name reported for traces and
 // metrics. Both MODE variants (admin/storefront) run the same binary/image,
 // so they share one logical service name; the MODE is distinguished via
@@ -1192,7 +1211,21 @@ func main() {
 		// left implicit so an operator reading boot logs learns the gate is inert
 		// instead of inferring it from a passing check.
 		log.Warn("migration fast-path: domain-age check NOT enforced — every domain is accepted; eligibility rests on CSM review (#706)")
-		migrationHandler = migration.NewHandler(migrationRepo, migration.UnenforcedDomainAge{}, log).WithAudit(auditEmitter)
+
+		// The recipient lookup is a closure over conn rather than a handle
+		// passed into the handler — see migration.RecipientLookup. Both
+		// halves are total: a missing subscription row yields "", which
+		// ValidateRecipient classifies as no_address, and a missing store
+		// projection yields "your store".
+		migrationRecipient := func(ctx context.Context, storeID uuid.UUID) (string, string) {
+			return subscription.BillingEmailFor(ctx, conn, storeID),
+				subscription.StoreNameFor(ctx, conn, storeID)
+		}
+		migrationHandler = migration.NewHandler(migrationRepo, migration.UnenforcedDomainAge{}, log).
+			WithAudit(auditEmitter).
+			WithEmail(billingEmailClient, migrationRecipient,
+				migrationSentCounter{metrics.BillingEmailsSentTotal},
+				migrationSkipCounter{metrics.BillingEmailsSkippedTotal})
 
 		// P8 — Arbitrage appeal handler (§18.8.1).
 		arbitrageAppealSvc := arbitrage.NewAppealService(conn, arbitrage.NoOpPublisher{}, arbitrage.NopPIILogger{})

--- a/services/marketplace-api/internal/billing/migration/handler.go
+++ b/services/marketplace-api/internal/billing/migration/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/audit"
 	"github.com/mark8ly/marketplace-api/internal/auth"
+	"github.com/mark8ly/marketplace-api/internal/email"
 )
 
 // PriorPlatformValidator is the domain-registration-age check interface. A
@@ -57,12 +58,49 @@ type reviewStore interface {
 	Reject(ctx context.Context, id, reviewerID uuid.UUID, notes string) (*Review, error)
 }
 
+// RecipientLookup resolves the merchant-facing billing address and store name
+// for a store, returning "" for either when it cannot.
+//
+// A function rather than a database handle so the Handler keeps depending on
+// narrow behaviour instead of gorm — the same reason reviewStore exists. The
+// production implementation is a closure over the connection in main.go
+// (subscription.BillingEmailFor + subscription.StoreNameFor); tests supply a
+// literal. It cannot fail: a missing address is "" and is classified by
+// email.ValidateRecipient like any other undeliverable one.
+type RecipientLookup func(ctx context.Context, storeID uuid.UUID) (address, storeName string)
+
+// CounterIncrementer is a one-method counter so tests can stub it.
+type CounterIncrementer interface{ Inc() }
+
+// SentCounter counts decision notices actually delivered, labeled by template.
+// SkipCounter counts those deliberately not sent, labeled by template and
+// reason (see email.SkipReason for the reason vocabulary).
+//
+// Both are declared here rather than imported from the trial package, which
+// declares its own for the same reason: a shared home would make one billing
+// sub-package depend on another purely for a two-line interface.
+type SentCounter interface {
+	WithTemplate(template string) CounterIncrementer
+}
+
+// SkipCounter — see SentCounter.
+type SkipCounter interface {
+	WithTemplateReason(template, reason string) CounterIncrementer
+}
+
 // Handler exposes the fast-path submit and CSM review endpoints.
 type Handler struct {
 	repo      reviewStore
 	validator PriorPlatformValidator
 	logger    *slog.Logger
 	audit     *audit.Emitter // optional — nil-safe, see WithAudit
+
+	// Email is optional in the same way audit is: a Handler built without
+	// WithEmail decides reviews and sends nothing.
+	mailer    email.Client
+	recipient RecipientLookup
+	sent      SentCounter
+	skip      SkipCounter
 }
 
 // NewHandler constructs a Handler. A nil validator falls back to
@@ -84,6 +122,22 @@ func NewHandler(repo reviewStore, v PriorPlatformValidator, logger *slog.Logger)
 // opted-out wiring.
 func (h *Handler) WithAudit(e *audit.Emitter) *Handler {
 	h.audit = e
+	return h
+}
+
+// WithEmail attaches the transactional client used to tell a merchant their
+// fast-path request was decided, the lookup that finds their address, and the
+// optional delivered/skipped counters.
+//
+// Chainable rather than constructor parameters so existing NewHandler callers
+// compile untouched, mirroring trial.ExpiryCron.WithEmail. A Handler missing
+// either the client or the lookup sends nothing: a CSM's decision must never
+// fail because email is unconfigured.
+func (h *Handler) WithEmail(cl email.Client, lookup RecipientLookup, sent SentCounter, skip SkipCounter) *Handler {
+	h.mailer = cl
+	h.recipient = lookup
+	h.sent = sent
+	h.skip = skip
 	return h
 }
 
@@ -229,12 +283,86 @@ func (h *Handler) Review(c *gin.Context) {
 		},
 	})
 
-	// TODO: migration fast-path approval/rejection emails land when the email
-	// package and StoreSubscription.email column exist (deferred from P5 scope).
-	h.logger.Info("migration fast-path decided; email deferred",
+	h.logger.Info("migration fast-path decided",
 		"review_id", id.String(),
 		"decision", req.Decision,
 		"reviewer_id", reviewerID.String())
 
+	h.notifyDecision(c.Request.Context(), review, req.Decision)
+
 	c.JSON(http.StatusOK, gin.H{"status": statusMap[req.Decision]})
+}
+
+// decisionTemplates maps a decision to the merchant-facing template. Both
+// branches must be present: a decision with no template would silently send
+// nothing, which is the failure this whole change exists to remove.
+var decisionTemplates = map[string]email.TemplateID{
+	"approve": email.TemplateMigrationFastPathApproved,
+	"reject":  email.TemplateMigrationFastPathRejected,
+}
+
+// notifyDecision tells the merchant their fast-path request was approved or
+// rejected. Strictly best-effort: the review row is committed and the audit
+// event emitted before this runs, so every failure here is logged and counted
+// and none is returned. The CSM's write is not undone by a mail outage.
+//
+// The review notes are deliberately absent from the template data. They are
+// authored by a CSM for internal review, and nothing in their validation
+// (required, 3–2000 chars) makes them fit to show the merchant they describe.
+func (h *Handler) notifyDecision(ctx context.Context, review *Review, decision string) {
+	if h.mailer == nil || h.recipient == nil {
+		// Email is not configured for this deployment. The decision itself
+		// has already succeeded.
+		return
+	}
+	template, ok := decisionTemplates[decision]
+	if !ok {
+		// Unreachable: the binding tag admits only approve|reject. Guarded
+		// so a third decision added later fails loudly here rather than
+		// quietly sending nothing.
+		h.logger.Error("migration fast-path: no template for decision",
+			"review_id", review.ID.String(), "decision", decision)
+		return
+	}
+
+	to, storeName := h.recipient(ctx, review.StoreID)
+
+	// Classify before the provider sees the address: the placeholder
+	// billing+<uuid>@mark8ly.local addresses minted at bootstrap would
+	// hard-bounce and cost sender reputation.
+	if err := email.ValidateRecipient(to); err != nil {
+		h.countSkip(template, email.SkipReason(err))
+		h.logger.Warn("migration fast-path decision notice not sent",
+			"review_id", review.ID.String(),
+			"store_id", review.StoreID.String(),
+			"reason", email.SkipReason(err))
+		return
+	}
+
+	if err := h.mailer.Send(ctx, template, to, map[string]any{
+		"store_id":   review.StoreID.String(),
+		"tenant_id":  review.TenantID.String(),
+		"store_name": storeName,
+	}); err != nil {
+		h.countSkip(template, email.SkipReason(err))
+		h.logger.Warn("migration fast-path decision notice not sent",
+			"review_id", review.ID.String(),
+			"store_id", review.StoreID.String(),
+			"reason", email.SkipReason(err),
+			"err", err.Error())
+		return
+	}
+
+	if h.sent != nil {
+		h.sent.WithTemplate(string(template)).Inc()
+	}
+	h.logger.Info("migration fast-path decision notice sent",
+		"review_id", review.ID.String(),
+		"store_id", review.StoreID.String())
+}
+
+func (h *Handler) countSkip(template email.TemplateID, reason string) {
+	if h.skip != nil {
+		h.skip.WithTemplateReason(string(template), reason).Inc()
+	}
 }

--- a/services/marketplace-api/internal/billing/migration/handler_email_test.go
+++ b/services/marketplace-api/internal/billing/migration/handler_email_test.go
@@ -1,0 +1,295 @@
+package migration_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/migration"
+	"github.com/mark8ly/marketplace-api/internal/email"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+// sentMail is one captured Send call.
+type sentMail struct {
+	template email.TemplateID
+	to       string
+	data     map[string]any
+}
+
+// fakeMailer records what it was asked to send, and can be made to fail like
+// a provider outage.
+type fakeMailer struct {
+	mu   sync.Mutex
+	sent []sentMail
+	err  error
+}
+
+func (f *fakeMailer) Send(_ context.Context, t email.TemplateID, to string, data map[string]any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sent = append(f.sent, sentMail{template: t, to: to, data: data})
+	return f.err
+}
+
+func (f *fakeMailer) calls() []sentMail {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]sentMail(nil), f.sent...)
+}
+
+// countingCounter records label values instead of touching Prometheus.
+type countingCounter struct {
+	mu     sync.Mutex
+	labels [][]string
+}
+
+func (c *countingCounter) record(vals ...string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.labels = append(c.labels, vals)
+}
+
+func (c *countingCounter) all() [][]string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([][]string(nil), c.labels...)
+}
+
+type incFunc func()
+
+func (f incFunc) Inc() { f() }
+
+type fakeSent struct{ c *countingCounter }
+
+func (f fakeSent) WithTemplate(template string) migration.CounterIncrementer {
+	return incFunc(func() { f.c.record(template) })
+}
+
+type fakeSkip struct{ c *countingCounter }
+
+func (f fakeSkip) WithTemplateReason(template, reason string) migration.CounterIncrementer {
+	return incFunc(func() { f.c.record(template, reason) })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// lookupReturning builds a RecipientLookup that always answers the same way.
+func lookupReturning(addr, name string) migration.RecipientLookup {
+	return func(context.Context, uuid.UUID) (string, string) { return addr, name }
+}
+
+type emailRouterOpts struct {
+	mailer *fakeMailer
+	lookup migration.RecipientLookup
+	sent   *countingCounter
+	skip   *countingCounter
+}
+
+func newReviewRouterWithEmail(store *fakeReviewStore, o emailRouterOpts) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h := migration.NewHandler(store, nil, nil)
+	if o.mailer != nil || o.lookup != nil {
+		var sent migration.SentCounter
+		var skip migration.SkipCounter
+		if o.sent != nil {
+			sent = fakeSent{o.sent}
+		}
+		if o.skip != nil {
+			skip = fakeSkip{o.skip}
+		}
+		h = h.WithEmail(o.mailer, o.lookup, sent, skip)
+	}
+	r.Use(func(c *gin.Context) {
+		c.Set("user_id", validUserID)
+		c.Next()
+	})
+	r.POST("/internal/csm/migration-fast-path/:id/review", h.Review)
+	return r
+}
+
+const csmNotes = "Verified Shopify export CSV — domain age confirmed."
+
+func decide(t *testing.T, r *gin.Engine, decision string) *http.Response {
+	t.Helper()
+	w := doPost(t, r, "/internal/csm/migration-fast-path/"+validReviewID+"/review", map[string]any{
+		"decision": decision,
+		"notes":    csmNotes,
+	})
+	return w.Result()
+}
+
+// ---------------------------------------------------------------------------
+// Delivery
+// ---------------------------------------------------------------------------
+
+func TestReview_Approve_SendsApprovalEmail(t *testing.T) {
+	mailer := &fakeMailer{}
+	sent := &countingCounter{}
+	r := newReviewRouterWithEmail(&fakeReviewStore{}, emailRouterOpts{
+		mailer: mailer,
+		lookup: lookupReturning("merchant@example.com", "Nadia's Ceramics"),
+		sent:   sent,
+	})
+
+	resp := decide(t, r, "approve")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	calls := mailer.calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, email.TemplateMigrationFastPathApproved, calls[0].template)
+	assert.Equal(t, "merchant@example.com", calls[0].to)
+	assert.Equal(t, "Nadia's Ceramics", calls[0].data["store_name"])
+
+	assert.Equal(t, [][]string{{string(email.TemplateMigrationFastPathApproved)}}, sent.all())
+}
+
+func TestReview_Reject_SendsRejectionEmail(t *testing.T) {
+	mailer := &fakeMailer{}
+	r := newReviewRouterWithEmail(&fakeReviewStore{}, emailRouterOpts{
+		mailer: mailer,
+		lookup: lookupReturning("merchant@example.com", "Nadia's Ceramics"),
+	})
+
+	resp := decide(t, r, "reject")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	calls := mailer.calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, email.TemplateMigrationFastPathRejected, calls[0].template)
+}
+
+// The CSM's notes are written for internal review, not for the merchant.
+// Sending them would publish internal commentary about a merchant on the
+// strength of a field nobody authored for an external reader.
+func TestReview_EmailNeverCarriesTheCSMNotes(t *testing.T) {
+	mailer := &fakeMailer{}
+	r := newReviewRouterWithEmail(&fakeReviewStore{}, emailRouterOpts{
+		mailer: mailer,
+		lookup: lookupReturning("merchant@example.com", "Nadia's Ceramics"),
+	})
+
+	decide(t, r, "reject")
+
+	calls := mailer.calls()
+	require.Len(t, calls, 1)
+	for k, v := range calls[0].data {
+		if s, ok := v.(string); ok {
+			assert.NotContains(t, s, csmNotes, "template data %q leaked the CSM notes", k)
+		}
+	}
+	_, hasNotes := calls[0].data["notes"]
+	assert.False(t, hasNotes, "template data must not carry a notes key")
+}
+
+// ---------------------------------------------------------------------------
+// The decision must survive every email failure
+// ---------------------------------------------------------------------------
+
+func TestReview_NoMailerConfigured_StillSucceeds(t *testing.T) {
+	// newReviewRouter builds a handler that never had WithEmail called.
+	r := newReviewRouter(&fakeReviewStore{}, true)
+	resp := decide(t, r, "approve")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestReview_NoBillingEmailOnFile_SkipsWithoutSending(t *testing.T) {
+	mailer := &fakeMailer{}
+	skip := &countingCounter{}
+	r := newReviewRouterWithEmail(&fakeReviewStore{}, emailRouterOpts{
+		mailer: mailer,
+		lookup: lookupReturning("", "your store"),
+		skip:   skip,
+	})
+
+	resp := decide(t, r, "approve")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, mailer.calls(), "provider must not see an empty address")
+
+	recorded := skip.all()
+	require.Len(t, recorded, 1)
+	assert.Equal(t, string(email.TemplateMigrationFastPathApproved), recorded[0][0])
+	assert.Equal(t, email.ReasonNoAddress, recorded[0][1])
+}
+
+// Bootstrap mints placeholder billing+<uuid>@mark8ly.local addresses. Handing
+// one to the provider would hard-bounce and cost sender reputation.
+func TestReview_PlaceholderAddress_SkipsWithoutSending(t *testing.T) {
+	mailer := &fakeMailer{}
+	skip := &countingCounter{}
+	r := newReviewRouterWithEmail(&fakeReviewStore{}, emailRouterOpts{
+		mailer: mailer,
+		lookup: lookupReturning("billing+"+validStoreID+"@mark8ly.local", "your store"),
+		skip:   skip,
+	})
+
+	resp := decide(t, r, "approve")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, mailer.calls())
+
+	recorded := skip.all()
+	require.Len(t, recorded, 1)
+	assert.Equal(t, email.ReasonPlaceholderAddress, recorded[0][1])
+}
+
+func TestReview_ProviderFailure_StillSucceedsAndCountsSkip(t *testing.T) {
+	mailer := &fakeMailer{err: errors.New("smtp: connection refused")}
+	skip := &countingCounter{}
+	sent := &countingCounter{}
+	r := newReviewRouterWithEmail(&fakeReviewStore{}, emailRouterOpts{
+		mailer: mailer,
+		lookup: lookupReturning("merchant@example.com", "Nadia's Ceramics"),
+		sent:   sent,
+		skip:   skip,
+	})
+
+	resp := decide(t, r, "approve")
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "the review is already committed; email must not fail it")
+	assert.Len(t, skip.all(), 1)
+	assert.Empty(t, sent.all(), "a failed send is not a sent email")
+}
+
+// ---------------------------------------------------------------------------
+// No decision, no email
+// ---------------------------------------------------------------------------
+
+func TestReview_RepositoryFailure_SendsNothing(t *testing.T) {
+	mailer := &fakeMailer{}
+	r := newReviewRouterWithEmail(
+		&fakeReviewStore{approveErr: errors.New("db down")},
+		emailRouterOpts{
+			mailer: mailer,
+			lookup: lookupReturning("merchant@example.com", "Nadia's Ceramics"),
+		})
+
+	resp := decide(t, r, "approve")
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Empty(t, mailer.calls(), "nothing was decided, so there is nothing to announce")
+}
+
+func TestReview_NotFound_SendsNothing(t *testing.T) {
+	mailer := &fakeMailer{}
+	r := newReviewRouterWithEmail(
+		&fakeReviewStore{approveErr: migration.ErrNotFound},
+		emailRouterOpts{
+			mailer: mailer,
+			lookup: lookupReturning("merchant@example.com", "Nadia's Ceramics"),
+		})
+
+	resp := decide(t, r, "approve")
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Empty(t, mailer.calls())
+}

--- a/services/marketplace-api/internal/email/client.go
+++ b/services/marketplace-api/internal/email/client.go
@@ -34,6 +34,14 @@ const (
 	// to reactivate.
 	TemplateTrialExpired TemplateID = "trial_expired"
 
+	// Migration fast-path decisions (#703). A merchant submits evidence of
+	// trading on a prior platform and a CSM approves or rejects it; these
+	// two close that loop. The CSM's review notes are NOT rendered into
+	// either template — they are written for internal review, not for the
+	// merchant. See migration.Handler.notifyDecision.
+	TemplateMigrationFastPathApproved TemplateID = "migration_fast_path_approved"
+	TemplateMigrationFastPathRejected TemplateID = "migration_fast_path_rejected"
+
 	// Day-30 post-expiry win-back promo. Lived in the lifecycle package
 	// until #381; moved here so the billing catalog is complete in one
 	// place and the email package can register its fallback without

--- a/services/marketplace-api/internal/email/templates.go
+++ b/services/marketplace-api/internal/email/templates.go
@@ -31,6 +31,8 @@ var billingTemplateKeys = []TemplateID{
 	TemplateDunningDay5,
 	TemplateDunningDay7,
 	TemplateWinBack,
+	TemplateMigrationFastPathApproved,
+	TemplateMigrationFastPathRejected,
 }
 
 // BillingTemplateKeys returns a copy of the catalog. A copy, so a caller

--- a/services/marketplace-api/internal/email/templates_content.go
+++ b/services/marketplace-api/internal/email/templates_content.go
@@ -55,6 +55,9 @@ var billingSubjects = map[TemplateID]string{
 	TemplateTrialStartedBilled:    `Your {{.plan}} plan for {{.store_name}} is active`,
 	TemplateTrialExpired:          `Your {{.store_name}} trial has ended`,
 	TemplateWinBack:               `Come back to Mark8ly — 20% off six months`,
+
+	TemplateMigrationFastPathApproved: `Your migration request for {{.store_name}} is approved`,
+	TemplateMigrationFastPathRejected: `We could not approve the migration request for {{.store_name}}`,
 }
 
 // --- HTML fragments -------------------------------------------------
@@ -109,6 +112,15 @@ var billingHTMLFragments = map[TemplateID]string{
 	TemplateWinBack: `<h1 ` + h1 + `>Your store is still here</h1>
 <p><strong>{{.store_name}}</strong> has been closed for a month. Everything — products, orders, settings — is exactly as you left it.</p>
 <p>If you want to pick it back up, we will take <strong>20% off your first six months</strong>.</p>`,
+
+	TemplateMigrationFastPathApproved: `<h1 ` + h1 + `>Your migration request is approved</h1>
+<p>We reviewed the evidence you sent for <strong>{{.store_name}}</strong> and approved your migration request. Nothing further is needed from you.</p>
+<p>You can see the current state of your plan any time in your Mark8ly billing settings.</p>`,
+
+	TemplateMigrationFastPathRejected: `<h1 ` + h1 + `>We could not approve your migration request</h1>
+<p>We reviewed the evidence you sent for <strong>{{.store_name}}</strong> and were not able to approve the migration request this time.</p>
+<p>Your store is unaffected — this changes nothing about your current plan, and you can submit a new request with different evidence.</p>
+<p>If you would like to know more about this decision, reply to this email and our team will go through it with you.</p>`,
 }
 
 // --- text fragments -------------------------------------------------
@@ -217,6 +229,24 @@ Mark8ly`,
 {{.store_name}} has been closed for a month. Everything — products, orders, settings — is exactly as you left it.
 
 If you want to pick it back up, we will take 20% off your first six months.
+
+Mark8ly`,
+
+	TemplateMigrationFastPathApproved: `Your migration request is approved
+
+We reviewed the evidence you sent for {{.store_name}} and approved your migration request. Nothing further is needed from you.
+
+You can see the current state of your plan any time in your Mark8ly billing settings.
+
+Mark8ly`,
+
+	TemplateMigrationFastPathRejected: `We could not approve your migration request
+
+We reviewed the evidence you sent for {{.store_name}} and were not able to approve the migration request this time.
+
+Your store is unaffected — this changes nothing about your current plan, and you can submit a new request with different evidence.
+
+If you would like to know more about this decision, reply to this email and our team will go through it with you.
 
 Mark8ly`,
 }

--- a/services/marketplace-api/internal/email/templates_test.go
+++ b/services/marketplace-api/internal/email/templates_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // sampleVars covers every field any billing template references, so one
-// map renders all eleven. Extra keys are harmless.
+// map renders them all. Extra keys are harmless.
 func sampleVars() map[string]any {
 	return map[string]any{
 		"store_id":           "11111111-2222-3333-4444-555555555555",
@@ -32,8 +32,8 @@ func TestRegisterFallbacks_EveryKeyRenders(t *testing.T) {
 	email.RegisterFallbacks(loader)
 
 	keys := email.BillingTemplateKeys()
-	if len(keys) != 12 {
-		t.Fatalf("BillingTemplateKeys() has %d keys, want 12", len(keys))
+	if len(keys) != 14 {
+		t.Fatalf("BillingTemplateKeys() has %d keys, want 14", len(keys))
 	}
 
 	for _, key := range keys {

--- a/services/marketplace-api/internal/subscription/billing_email.go
+++ b/services/marketplace-api/internal/subscription/billing_email.go
@@ -1,0 +1,32 @@
+package subscription
+
+// billing_email.go — the merchant's billing address for transactional mail.
+//
+// The symmetric partner to StoreNameFor: a caller holding only a store id and
+// no StoreSubscription row (the migration fast-path handler, which addresses
+// a review by id) needs both the address and the name to send.
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// BillingEmailFor returns the store's billing email, or "" when there is no
+// subscription row, no address on it, or the lookup fails.
+//
+// Never returns an error, and "" is deliberately not special-cased into a
+// sentinel: every caller passes the result to email.ValidateRecipient, which
+// classifies "" as ReasonNoAddress. One place decides what is undeliverable,
+// and it is not this function.
+func BillingEmailFor(ctx context.Context, db *gorm.DB, storeID uuid.UUID) string {
+	var addr string
+	err := db.WithContext(ctx).
+		Raw(`SELECT email FROM store_subscriptions WHERE store_id = ?`, storeID).
+		Scan(&addr).Error
+	if err != nil {
+		return ""
+	}
+	return addr
+}


### PR DESCRIPTION
Closes #703.

The last item on that issue. Everything else it asked for shipped in #711; this is the site that was left:

```go
// internal/billing/migration/handler.go:212-214
// TODO: migration fast-path approval/rejection emails land when the email
// package and StoreSubscription.email column exist (deferred from P5 scope).
h.logger.Info("migration fast-path decided; email deferred", ...)
```

A merchant submits evidence that they have been trading on another platform, a CSM approves or rejects it, and the merchant is never told either way. The decision was already written and audited — only the notification was missing.

Both halves of the stated blocker have existed for a while: `internal/email/` has the client, the registered catalog, `ValidateRecipient` and `SkipReason`, and `store_subscriptions.email` landed in migration 000104, where `expiry_cron.go` already reads it.

## Shape

`ExpiryCron.notifyExpired` is the reference and this follows it rather than inventing a second convention: chainable `WithEmail(...)` so existing `NewHandler` callers compile untouched, a nil mailer means send nothing, `ValidateRecipient` runs before the provider sees an address, and skip/sent land on `BillingEmailsSkippedTotal` / `BillingEmailsSentTotal`.

Best-effort is the point. The review row is committed and the audit event emitted before `notifyDecision` runs, so every failure is logged and counted and none is returned. A CSM's write does not fail because email is down.

## Two decisions worth flagging

**The CSM's review notes are not sent to the merchant.** `reviewRequest.Notes` is required, 3–2000 chars, and written by a CSM for internal review. Rendering it into merchant-facing mail would publish internal commentary about a merchant on the strength of a field nobody authored for an external reader. The rejection email states the decision and invites a reply; a merchant-facing reason, if wanted, needs its own deliberately-authored field. `TestReview_EmailNeverCarriesTheCSMNotes` pins this.

**Recipient lookup enters as a function, not a DB handle.** `Handler` depends on the narrow `reviewStore`, not gorm, and that is worth keeping. `RecipientLookup` is supplied by main.go as a closure over `conn`; tests pass a literal. New `subscription.BillingEmailFor` is the symmetric partner to the existing `StoreNameFor` — it returns `""` rather than a sentinel, so `ValidateRecipient` remains the single place that decides what is undeliverable.

## Tests

Nine new unit tests covering delivery on both decisions, and the four ways this must not break a decision that already happened: no mailer configured, no billing email on file, a placeholder `@mark8ly.local` address, and a provider outage — each returns 200, sends nothing to the provider, and counts the right skip reason. Two more assert that a repository failure or a not-found review sends nothing at all.

`go build`, `go vet`, `gofmt` and the full unit suite are clean. Integration tests were **not** run locally — another session is active in this workspace and the test database is shared — so CI's `Integration (marketplace-api)` job is the gate on those, as it was for #711.

## Notes

- Rebased onto #734 (the #706 domain-age work), which landed in the same two files while this was in progress. Both changes are present: the boot-time `log.Warn` about the unenforced gate and `UnenforcedDomainAge` are intact alongside the new wiring.
- The two new templates are registered but not seeded, exactly like the existing twelve — so they are subject to #717 in the same way and are not made worse by it.
- Left alone deliberately: the stale `"Route wiring is deferred to Task 15"` comment at `handler.go:162`. #706 called it out but #734 did not remove it; it is unrelated to this change and did not seem worth mixing in.
