### PR TITLE
Stop promising a Pro+App renewal charge that never happens

### DIFF
--- a/apps/admin/app/(admin)/settings/billing/pro-app-purchase/ProAppPurchaseClient.tsx
+++ b/apps/admin/app/(admin)/settings/billing/pro-app-purchase/ProAppPurchaseClient.tsx
@@ -25,14 +25,24 @@
  *   - Per spec §3.4 the add-on lists at $199/mo — $2,388 for a full year —
  *     plus a separate one-time, non-refundable $2,000 setup fee. Server-side
  *     `ProrationCents` charges `(remaining_days / 365) × $2,388 + $2,000` up
- *     front, so the up-front charge and the full-year figure are legitimately
- *     different numbers. Conflating them is how the $2,000 setup fee once
- *     ended up on the full-year line here.
- *   - The full-year figure is read from SHARED_PRICING_CATALOGUE (generated
- *     from the Go `pricing.ProAppAnnual` constant) rather than hardcoded, so
- *     it cannot drift from the billing constants again. The add-on bills in
- *     USD globally (spec §4.1.2), so the USD row is read explicitly and
- *     rendered as USD — never relabelled with the merchant's currency.
+ *     front.
+ *   - THE ADD-ON DOES NOT RECUR (#650). It is charged once and never re-billed:
+ *     the purchase creates a single one-off Stripe invoice, the webhook flips
+ *     `has_white_label_app_add_on`, and nothing reads that flag for billing
+ *     again. There is no Stripe Price object for the add-on in any account,
+ *     and none is needed.
+ *
+ *     This page used to show a "Next full-year charge: $2,388 on <date>" line,
+ *     which promised a charge no code produces. Do not reinstate it without a
+ *     recurring subscription item to back it.
+ *
+ *     `ProrationCents`' own doc still describes the add-on as "bundling into
+ *     the next invoice", which reads as though something recurs. It does not —
+ *     the proration exists only to align a mid-year purchase with the Pro
+ *     anchor date.
+ *   - The add-on bills in USD globally (spec §4.1.2), so the USD row is read
+ *     explicitly and rendered as USD — never relabelled with the merchant's
+ *     currency.
  *
  * Accessibility:
  *   - Checkbox associated via htmlFor/id.
@@ -51,11 +61,6 @@ import { usePurchaseProApp } from '@/lib/api/subscription/hooks/useProApp'
 import { ApiError } from '@/lib/api/client'
 import { useToast } from '@/components/feedback/Toaster'
 import { subscriptionCopy } from '@/lib/copy/subscription'
-import {
-  Money,
-  SHARED_PRICING_CATALOGUE,
-  getAddOnPrice,
-} from '@repo/ui/subscription'
 import { formatBillingDate } from '@/lib/format/date'
 
 // ---------------------------------------------------------------------------
@@ -68,14 +73,15 @@ interface ProAppPurchaseClientProps {
 
 const copy = subscriptionCopy.proApp.purchase
 
-/**
- * Full-year White-label App add-on list price, in USD cents, for the
- * next-year line. Derived from the shared catalogue rather than written
- * here: the same figure lives in Go as `pricing.ProAppAnnual` and
- * `appaddon.AppAnnualCents`, and a third hand-maintained copy is exactly
- * what drifted before.
+/*
+ * The full-year list price is deliberately NOT read here any more (#650). The
+ * add-on is a one-time purchase, so this page has no recurring figure to show;
+ * it previously pulled `pricing.ProAppAnnual` from the shared catalogue to
+ * render a "next full-year charge" line that no billing code produced.
+ *
+ * The Go-side constants and their parity test (`proapp_parity_test.go`) still
+ * stand — they pin the displayed and charged figures for the one-off invoice.
  */
-const { price: proAppUsdPrice } = getAddOnPrice(SHARED_PRICING_CATALOGUE.proApp, 'USD')
 
 /** RHF form schema — only the acknowledgement checkbox. */
 const formSchema = z.object({
@@ -168,14 +174,9 @@ function ProrationPreviewCard({ renewalAt }: ProrationPreviewCardProps) {
           </p>
         )}
         <p>
-          Next full-year charge:{' '}
-          <span className="font-medium text-[var(--ink-900)]">
-            <Money amount={proAppUsdPrice.annual} currency="USD" />
-          </span>
-          {renewalAt && (
-            <> on {formattedRenewal}</>
-          )}
-          .
+          This is a{' '}
+          <span className="font-medium text-[var(--ink-900)]">one-time charge</span>.
+          The add-on does not renew and you will not be billed for it again.
         </p>
       </div>
     </div>

--- a/apps/admin/tests/unit/app/settings/billing/pro-app-purchase/ProAppPurchaseClient.test.tsx
+++ b/apps/admin/tests/unit/app/settings/billing/pro-app-purchase/ProAppPurchaseClient.test.tsx
@@ -80,9 +80,11 @@ vi.mock('@/lib/api/subscription/hooks/useBilling', () => ({
 }))
 
 // Money component stub — renders amount/100 formatted simply.
-// Everything else (SHARED_PRICING_CATALOGUE, getAddOnPrice) stays REAL: the
-// component reads the add-on's full-year price out of the generated
-// catalogue, so stubbing it would make the price assertions vacuous.
+// Everything else (SHARED_PRICING_CATALOGUE, getAddOnPrice) stays REAL. The
+// component no longer reads a full-year price (#650 — the add-on does not
+// recur), but the stub is kept unstubbed-around so that if a price is ever
+// rendered here again it shows up in these assertions rather than being
+// silently mocked away.
 vi.mock('@repo/ui/subscription', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@repo/ui/subscription')>()),
   Money: ({ amount, currency }: { amount: number; currency: string }) => (
@@ -200,7 +202,15 @@ describe('ProAppPurchaseClient', () => {
     expect(screen.getByRole('button', { name: /add to plan/i })).toBeInTheDocument()
   })
 
-  it('next full-year charge is the $2,388 add-on list price, not the $2,000 setup fee', () => {
+  // #650: the add-on is a ONE-TIME purchase. It is charged once — a prorated
+  // year plus the $2,000 setup fee — and never re-billed: there is no Stripe
+  // Price object for it, no subscription item, and nothing reads
+  // has_white_label_app_add_on for billing after the webhook sets it.
+  //
+  // This page used to render "Next full-year charge: $2,388 on <date>",
+  // promising a charge no code produces. These tests are the gate against
+  // reinstating it without a recurring subscription item to back it.
+  it('states the charge is one-time and does not renew', () => {
     mockUseCurrentPlan.mockReturnValue({
       data: makePlan(),
       isLoading: false,
@@ -208,26 +218,28 @@ describe('ProAppPurchaseClient', () => {
     })
     renderComponent()
 
-    // $199/mo x 12 = $2,388/yr (spec 3.4), matching pricing.ProAppAnnual and
-    // appaddon.AppAnnualCents. $2,000 is the ONE-TIME setup fee and must
-    // never appear on this line.
-    expect(screen.getByText(/next full-year charge/i)).toBeInTheDocument()
-    expect(screen.getByText('USD 2388.00')).toBeInTheDocument()
-    expect(screen.queryByText('USD 2000.00')).not.toBeInTheDocument()
+    expect(screen.getByText(/one-time charge/i)).toBeInTheDocument()
+    expect(screen.getByText(/does not renew/i)).toBeInTheDocument()
   })
 
-  it('full-year charge stays in USD for a non-USD merchant (add-on bills in USD globally)', () => {
-    mockUseCurrentPlan.mockReturnValue({
-      data: makePlan({ billingCurrency: 'INR' }),
-      isLoading: false,
-      isError: false,
-    })
-    renderComponent()
+  it('promises no recurring charge, for any merchant currency', () => {
+    for (const billingCurrency of ['USD', 'INR'] as const) {
+      mockUseCurrentPlan.mockReturnValue({
+        data: makePlan({ billingCurrency }),
+        isLoading: false,
+        isError: false,
+      })
+      const { unmount } = renderComponent()
 
-    // Spec 4.1.2: the add-on is billed in USD everywhere, so the USD amount
-    // must not be relabelled with the merchant's billing currency.
-    expect(screen.getByText('USD 2388.00')).toBeInTheDocument()
-    expect(screen.queryByText(/^INR /)).not.toBeInTheDocument()
+      // No recurring-charge wording, and no amount rendered as one. The
+      // proration preview still describes the up-front charge; what must not
+      // appear is a future one.
+      expect(screen.queryByText(/next full-year charge/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/renews|renewal charge|per year|\/yr/i)).not.toBeInTheDocument()
+      expect(screen.queryByText('USD 2388.00')).not.toBeInTheDocument()
+
+      unmount()
+    }
   })
 
   it('acknowledgement checkbox controls submit button state', async () => {


### PR DESCRIPTION
#650, per the decision recorded there: **the Pro+App add-on is a one-time purchase.** Charged once — a prorated year plus the $2,000 setup fee — and never re-billed.

The purchase page said otherwise. On the last screen before a merchant commits, it rendered:

    Next full-year charge: $2,388.00 on <renewal date>

That charge does not exist. The purchase creates a single one-off Stripe invoice, the webhook flips `has_white_label_app_add_on`, and nothing reads that flag for billing again. There is no Stripe Price object for the add-on in **either** Stripe account, no subscription item, and no recurring path anywhere in the tree.

## What changed

The line is replaced with a plain statement that the charge is one-time and the add-on does not renew. The proration preview above it is untouched — it describes the up-front charge, which is real.

The now-unused `Money` / `SHARED_PRICING_CATALOGUE` / `getAddOnPrice` imports and the `proAppUsdPrice` constant are removed, with a comment recording why the page no longer reads a full-year figure.

## Two comments corrected, because they are what would cause a regression

The file's own doc block explained the full-year figure as a deliberate, drift-proof read from the shared catalogue — good reasoning for a number that should be displayed, and now misleading. It states plainly that the add-on does not recur and that the line must not be reinstated without a recurring subscription item to back it.

It also flags something that will otherwise send the next reader in circles: **`ProrationCents`' own doc says the add-on "co-terminates on the same day as the upcoming renewal, bundling into the next invoice"** — which reads as though something recurs. Nothing does; the proration exists only to align a mid-year purchase with the Pro anchor date. That sentence is the reason this looked like a missing feature rather than an incorrect claim, and it is worth correcting in `appaddon` separately.

## Tests

Two existing tests **pinned the removed line** — "next full-year charge is the $2,388 add-on list price" and "full-year charge stays in USD for a non-USD merchant". They encoded the defect, so they are replaced rather than deleted:

- one asserting the page states a one-time, non-renewing charge
- one asserting **no** recurring-charge wording or amount appears, for both a USD and a non-USD merchant

I verified these are a real gate, not a tautology: reinstating the old line makes both fail (`2 failed | 19 passed`), and reverting returns all 21 to green.

`npm run build` in `apps/admin` passes — worth stating, because this change deletes imports, and an unused-import or dangling-reference error is exactly the class of failure unit tests do not catch.

## Unchanged

`proapp_parity_test.go` from #656 still earns its place. It pins `pricing.ProAppAnnual == appaddon.AppAnnualCents` and guards the annual figure against being confused with the $2,000 setup fee — both still the displayed and charged figures for the one-off invoice. Only the *recurring* claim is gone.

Refs #650.
