### PR TITLE
Emit audit-log metadata as the JSON string the console actually reads

### DIFF
--- a/.planning/quick/260906-alm-audit-log-metadata/PLAN.md
+++ b/.planning/quick/260906-alm-audit-log-metadata/PLAN.md
@@ -1,0 +1,56 @@
+# Emit audit-log metadata as the string the console actually reads
+
+#313. `/admin/audit-logs` omits `metadata` from every row, so plan changes,
+refund reasons, suspension reason codes and API-key revocations all reach the
+platform console stripped of their detail.
+
+The issue was filed as a question for the console team — object or string? —
+and asked twice on #276 without an answer.
+
+## It did not need an answer; it needed reading the consumer
+
+`tesserix-home` is checked out. Three layers agree, independently:
+
+- `platform-api/internal/modules/audit/internal/domain/entry.go:30` —
+  `Metadata string`, and that struct IS the federation decode target
+  (`service.go:104-125` unmarshals product responses straight into it)
+- `apps/console/lib/audit.ts:196` — `optionalStr(row.metadata, ...)`, which
+  `entry.go`'s own doc comment names as the real contract
+- the console's own writer (`platform/audit/audit.go` `serialiseSummary`)
+  renders compact JSON by hand into that column
+
+So: a string, containing compact JSON. That also answers the "if string, how
+do we flatten?" sub-question — not `k=v`, just the marshalled object.
+
+## The stakes are higher than the issue assumed
+
+#313 treats a wrong guess as a mis-rendered field. It is not.
+`service.go:113` decodes a whole page with one `json.Unmarshal`. An object
+where a string is expected fails that decode, the closure returns an error,
+and mark8ly is recorded as a federation FAILURE — **every** mark8ly audit row
+disappears from the console, not just this field.
+
+Which is also why the current omission was the right holding position.
+
+## Tasks
+
+1. `metadata` on `auditRow`, `omitempty`.
+2. `metadataOf` in `toRow`: `json.Marshal` the jsonb map; "" for an empty or
+   nil map, and "" on a marshal error so one bad row cannot cost the page.
+3. Golden fixture: one row with metadata, one without, pinning both the
+   encoding and the omission.
+
+## Done when
+
+- A row with metadata carries a JSON *string*; the raw bytes are quoted.
+- Empty and nil metadata omit the key entirely — never `"{}"`.
+- Output is byte-stable across calls, so a poller sees no phantom change.
+- The pinned-contract golden test covers both cases.
+
+## Flagged, not decided here
+
+`metadata` carries `customer_email` on two paths (`abandoned_cart_service.go`,
+`checkout_ext.go`). This ships it to the console. That is an HMAC-authenticated
+operator surface which already receives merchant emails in `actor`, so it is
+consistent rather than new — but it is a widening of what leaves this service
+and belongs in the PR description, not in a silent commit.

--- a/services/marketplace-api/internal/handlers/platformadmin/audit_logs.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/audit_logs.go
@@ -1,6 +1,7 @@
 package platformadmin
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -40,15 +41,26 @@ func (h *AuditLogsHandler) Register(g *gin.RouterGroup) {
 // deliberately absent. Adding fields unilaterally is what the contract exists
 // to prevent.
 //
-// `metadata` is also absent pending the open question on #276: our column is
-// jsonb, the contract's example shows a string. Omission is the one choice
-// that cannot be wrong while it is unresolved.
+// `metadata` is a STRING carrying compact JSON, not an object — settled on
+// #313 by reading the consumer rather than by asking again. All three layers
+// of tesserix-home agree:
+//
+//   - platform-api internal/modules/audit/internal/domain/entry.go —
+//     `Metadata string`, and that struct is the federation decode target
+//   - apps/console/lib/audit.ts — `optionalStr(row.metadata, ...)`
+//   - the console's own audit writer renders compact JSON into the column
+//
+// The cost of the other choice is not a mis-rendered field. platform-api
+// decodes an entire page with one json.Unmarshal, so an object where a string
+// is expected fails that decode and mark8ly is reported as a federation
+// FAILURE — every mark8ly row disappears from the console at once.
 type auditRow struct {
 	ID        string `json:"id"`
 	Actor     string `json:"actor"`
 	Action    string `json:"action"`
 	Timestamp string `json:"timestamp"`
 	Target    string `json:"target,omitempty"`
+	Metadata  string `json:"metadata,omitempty"`
 }
 
 type pagination struct {
@@ -105,7 +117,33 @@ func toRow(e audit.Entry) auditRow {
 		Action:    e.Action,
 		Timestamp: e.CreatedAt.UTC().Format(time.RFC3339),
 		Target:    targetOf(e),
+		Metadata:  metadataOf(e),
 	}
+}
+
+// metadataOf renders the jsonb blob as the compact JSON string the consumer
+// reads, or "" to omit the field.
+//
+// "" for an empty map as well as a nil one: "this event carried no detail"
+// and "this event carried a detail object containing nothing" are the same
+// fact to a reader, and the contract marks the field optional. Sending "{}"
+// would put a literal empty-braces string in front of an operator.
+//
+// A marshal failure also yields "" rather than propagating. Metadata is
+// loaded from jsonb so it should always re-marshal, but this runs per row on
+// a page: one unserialisable value must cost that row its detail, never the
+// whole page its rows.
+func metadataOf(e audit.Entry) string {
+	if len(e.Metadata) == 0 {
+		return ""
+	}
+	// encoding/json sorts map keys, so the output is byte-stable across calls
+	// and a poller does not see a phantom change on an unchanged row.
+	encoded, err := json.Marshal(e.Metadata)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
 }
 
 // actorOf resolves the single "who did it" string the contract asks for.

--- a/services/marketplace-api/internal/handlers/platformadmin/audit_logs_metadata_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/audit_logs_metadata_test.go
@@ -1,0 +1,158 @@
+package platformadmin_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+)
+
+// The consumer is tesserix-home/platform-api. Three layers agree that
+// `metadata` is a STRING carrying compact JSON, not an object:
+//
+//   - internal/modules/audit/internal/domain/entry.go — Metadata string, and
+//     that struct IS the federation decode target
+//   - apps/console/lib/audit.ts:196 — optionalStr(row.metadata, ...)
+//   - the console's own writer renders compact JSON by hand into the column
+//
+// Getting this wrong is not cosmetic. The consumer decodes a whole page with
+// one json.Unmarshal, so an object where a string is expected fails the
+// decode, and mark8ly becomes a federation FAILURE — every mark8ly audit row
+// vanishes from the console, not just this field. See #313.
+
+func metadataRouter(t *testing.T, entries []audit.Entry) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	repo := &stubRepo{result: audit.ListResult{Total: int64(len(entries)), Entries: entries}}
+	r := gin.New()
+	platformadmin.NewAuditLogsHandler(nil, repo, nil).Register(r.Group(""))
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/audit-logs", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	return rec
+}
+
+// rawRows decodes data[] without imposing a type on metadata, so the test can
+// assert what the field actually IS on the wire.
+func rawRows(t *testing.T, rec *httptest.ResponseRecorder) []map[string]json.RawMessage {
+	t.Helper()
+	var body struct {
+		Data []map[string]json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	return body.Data
+}
+
+func entryWithMetadata(m audit.Metadata) audit.Entry {
+	return audit.Entry{
+		ID:           uuid.MustParse("3f2504e0-4f89-11d3-9a0c-0305e82c3301"),
+		TenantID:     uuid.New(),
+		ActorType:    audit.ActorOperator,
+		Action:       "subscription.plan_changed",
+		ResourceType: "subscription",
+		CreatedAt:    time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC),
+		Metadata:     m,
+	}
+}
+
+// The whole point of #313: metadata is a JSON string, never an object.
+func TestMetadataIsAJSONStringNotAnObject(t *testing.T) {
+	rec := metadataRouter(t, []audit.Entry{
+		entryWithMetadata(audit.Metadata{"plan": "pro", "previous_plan": "starter"}),
+	})
+
+	rows := rawRows(t, rec)
+	require.Len(t, rows, 1)
+	raw, ok := rows[0]["metadata"]
+	require.True(t, ok, "metadata must be present when the entry has some")
+
+	// A string on the wire — it unmarshals into a string, and the raw bytes
+	// are quoted rather than starting a JSON object.
+	var s string
+	require.NoError(t, json.Unmarshal(raw, &s),
+		"metadata must decode as a string; an object here breaks the consumer's whole page")
+	assert.Equal(t, byte('"'), raw[0])
+
+	// And its CONTENT is the compact JSON of the stored map.
+	var round map[string]any
+	require.NoError(t, json.Unmarshal([]byte(s), &round))
+	assert.Equal(t, map[string]any{"plan": "pro", "previous_plan": "starter"}, round)
+	assert.NotContains(t, s, " ", "compact, not indented")
+}
+
+// Empty and absent metadata must be OMITTED, not sent as "{}". "No metadata"
+// and "metadata containing nothing" are different facts, and the contract
+// marks the field optional.
+func TestEmptyMetadataIsOmittedNotEmptyObjectString(t *testing.T) {
+	for name, m := range map[string]audit.Metadata{
+		"nil":   nil,
+		"empty": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rows := rawRows(t, metadataRouter(t, []audit.Entry{entryWithMetadata(m)}))
+			require.Len(t, rows, 1)
+			_, present := rows[0]["metadata"]
+			assert.False(t, present, "metadata must be omitted, not sent as an empty string or {}")
+		})
+	}
+}
+
+// Key order must be stable, or every poll shows a diff for rows that did not
+// change. encoding/json sorts map keys; this pins that we depend on it.
+func TestMetadataKeyOrderIsDeterministic(t *testing.T) {
+	m := audit.Metadata{"zebra": 1, "alpha": 2, "middle": 3}
+	first := rawRows(t, metadataRouter(t, []audit.Entry{entryWithMetadata(m)}))[0]["metadata"]
+	for range 5 {
+		got := rawRows(t, metadataRouter(t, []audit.Entry{entryWithMetadata(m)}))[0]["metadata"]
+		assert.JSONEq(t, string(first), string(got))
+		assert.Equal(t, string(first), string(got), "byte-identical, so a poller sees no phantom change")
+	}
+	var s string
+	require.NoError(t, json.Unmarshal(first, &s))
+	assert.Equal(t, `{"alpha":2,"middle":3,"zebra":1}`, s)
+}
+
+// Nested values survive: the column is jsonb and some rows carry structure.
+func TestMetadataPreservesNestedValues(t *testing.T) {
+	rows := rawRows(t, metadataRouter(t, []audit.Entry{
+		entryWithMetadata(audit.Metadata{
+			"refund": map[string]any{"amount": 1250, "currency": "aud"},
+			"items":  []any{"a", "b"},
+		}),
+	}))
+	var s string
+	require.NoError(t, json.Unmarshal(rows[0]["metadata"], &s))
+
+	var round map[string]any
+	require.NoError(t, json.Unmarshal([]byte(s), &round))
+	assert.Equal(t, float64(1250), round["refund"].(map[string]any)["amount"])
+	assert.Equal(t, []any{"a", "b"}, round["items"])
+}
+
+// One unserialisable row must not take the page down with it: the rest of the
+// rows still render, and the offender simply has no metadata.
+func TestUnserialisableMetadataOmitsTheFieldAndKeepsThePage(t *testing.T) {
+	bad := entryWithMetadata(audit.Metadata{"ch": make(chan int)})
+	good := entryWithMetadata(audit.Metadata{"plan": "pro"})
+	good.ID = uuid.MustParse("3f2504e0-4f89-11d3-9a0c-0305e82c3302")
+
+	rows := rawRows(t, metadataRouter(t, []audit.Entry{bad, good}))
+	require.Len(t, rows, 2, "a bad row must not truncate the page")
+
+	_, present := rows[0]["metadata"]
+	assert.False(t, present, "unserialisable metadata is dropped, not partially emitted")
+
+	var s string
+	require.NoError(t, json.Unmarshal(rows[1]["metadata"], &s))
+	assert.JSONEq(t, `{"plan":"pro"}`, s)
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/audit_logs_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/audit_logs_test.go
@@ -76,6 +76,9 @@ func TestAuditLogsMatchesPinnedContract(t *testing.T) {
 				Action:          "tenant.suspended",
 				ResourceType:    "tenant",
 				CreatedAt:       time.Date(2026, 8, 22, 9, 0, 0, 0, time.UTC),
+				// One row carries metadata and one does not, so the golden
+				// file pins both the string encoding and the omission (#313).
+				Metadata: audit.Metadata{"reason_code": "abuse"},
 			},
 		},
 	}}

--- a/services/marketplace-api/internal/handlers/platformadmin/testdata/audit_logs_response.json
+++ b/services/marketplace-api/internal/handlers/platformadmin/testdata/audit_logs_response.json
@@ -12,7 +12,8 @@
       "actor": "op_7f3a",
       "action": "tenant.suspended",
       "timestamp": "2026-08-22T09:00:00Z",
-      "target": "tenant"
+      "target": "tenant",
+      "metadata": "{\"reason_code\":\"abuse\"}"
     }
   ],
   "pagination": {


### PR DESCRIPTION
Closes #313.

`/admin/audit-logs` omitted `metadata` from every row, so plan changes, refund reasons, suspension reason codes and API-key revocations all reached the platform console stripped of their detail.

## It did not need an answer — it needed reading the consumer

#313 was filed as a question for the console team (object or string?), and asked twice on #276 without one. `tesserix-home` is checked out in this workspace, and three layers of it agree independently:

| Layer | Evidence |
|---|---|
| `platform-api/internal/modules/audit/internal/domain/entry.go:30` | `Metadata string` — and this struct **is** the federation decode target (`service.go:104-125` unmarshals product responses straight into it) |
| `apps/console/lib/audit.ts:196` | `optionalStr(row.metadata, ...)` — which `entry.go`'s own doc comment names as the real contract |
| `platform-api/internal/platform/audit/audit.go` | the console's own writer renders compact JSON by hand into that column |

So: **a string carrying compact JSON.** That settles the "if string, how do we flatten?" sub-question too — not `k=v` pairs, just the marshalled object.

## The stakes are higher than the issue assumed

The issue treats a wrong guess as a mis-rendered field. It isn't. `service.go:113` decodes an entire page with one `json.Unmarshal`. An object where a string is expected fails that decode, the closure returns an error, and mark8ly is recorded as a **federation failure** — every mark8ly audit row vanishes from the console at once, not just this field.

Which is also why the previous omission was the correct holding position, and worth saying explicitly so nobody "fixes" it back the other way.

## The change

Three lines of behaviour, as the issue predicted:

- `Metadata string \`json:"metadata,omitempty"\`` on `auditRow`
- `metadataOf` in `toRow` — `json.Marshal` of the jsonb map
- the golden fixture gains one row with metadata and keeps one without, pinning both the encoding and the omission

Two deliberate choices in `metadataOf`:

- **Empty and nil both yield `""`, never `"{}"`.** "No detail" and "a detail object containing nothing" are the same fact to a reader, and `"{}"` would put literal empty braces in front of an operator. This matches the console's own `serialiseSummary`, which writes NULL rather than `{}` for the same reason.
- **A marshal error yields `""` rather than propagating.** This runs per row on a page; one unserialisable value should cost that row its detail, never the page its rows. Tested.

## Tests

Six new tests: that the field is a *string* and not an object (asserting on raw bytes, since that is the whole point), that empty/nil omit rather than emit `"{}"`, that output is byte-stable across calls so a poller sees no phantom change on an unchanged row, that nested jsonb survives the round trip, and that one bad row does not truncate the page.

`go build`, `go vet`, `gofmt` and the full unit suite are clean. Integration tests not run locally — another session is active in this workspace and the test DB is shared — so CI is the gate there.

## One thing to flag before merge

This widens what leaves the service. `metadata` carries `customer_email` on two paths (`internal/order/abandoned_cart_service.go:131`, `internal/handlers/storefront/checkout_ext.go:729`), so those addresses will now reach the console.

I don't think that's a blocker: the console is an HMAC-authenticated operator surface that already receives merchant emails in the `actor` field, and audit detail is what it's for. But it is a real change in data flow rather than a pure formatting fix, and it should be a decision rather than a side effect. If you'd rather it were redacted, that's a follow-up — say so and I'll add a key-level filter.
