### PR TITLE
feat(auth-bff): wire the mobile token issuer from config (#686)

### DIFF
--- a/services/auth-bff/cmd/server/main.go
+++ b/services/auth-bff/cmd/server/main.go
@@ -102,7 +102,20 @@ func newZitadelHandlers(cfg *config.Config, zitadelClient *zitadellogin.Client, 
 	if err != nil {
 		return nil, err
 	}
+	// Mobile token issuance (#686). Enabled only when all four values are
+	// present; any missing one leaves the mobile routes refusing with 500
+	// rather than half-configured, because a login that "succeeds" without
+	// a usable token is indistinguishable from a working one until the
+	// first API call 401s.
+	var mobileTokens *zitadellogin.TokenExchanger
+	if cfg.ZitadelAdminClientID != "" && cfg.ZitadelAdminClientSecret != "" &&
+		cfg.ZitadelAdminRedirectURI != "" && cfg.ZitadelAdminProjectID != "" {
+		mobileTokens = zitadellogin.NewTokenExchanger(
+			cfg.ZitadelIssuer, cfg.ZitadelAdminClientID, cfg.ZitadelAdminClientSecret, nil)
+	}
+
 	merchant := zitadellogin.NewHandler(zitadelClient, complete).
+		WithTokenIssuer(mobileTokens, cfg.ZitadelAdminRedirectURI, cfg.ZitadelAdminProjectID).
 		WithHostedLoginBaseURL(cfg.ZitadelIssuer).
 		WithInternalAuth(cfg.MarketplaceInternalAuthSecret).
 		WithReturnURLAllowlist(adminReturnURLs).

--- a/services/auth-bff/cmd/server/mobile_token_wiring_test.go
+++ b/services/auth-bff/cmd/server/mobile_token_wiring_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mark8ly/auth-bff/pkg/config"
+)
+
+// mobileTokenIssuanceEnabled mirrors the guard in main.go. It exists so the
+// "all four or nothing" rule is testable without booting the server.
+func mobileTokenIssuanceEnabled(cfg *config.Config) bool {
+	return cfg.ZitadelAdminClientID != "" && cfg.ZitadelAdminClientSecret != "" &&
+		cfg.ZitadelAdminRedirectURI != "" && cfg.ZitadelAdminProjectID != ""
+}
+
+// Half-configured must mean OFF, not half-on. A login that "succeeds"
+// without a usable token is indistinguishable from a working one until the
+// first API call 401s — from a device, that is the hardest possible failure
+// to diagnose. Refusing at 500 is loud and immediate instead.
+func TestMobileTokenIssuance_RequiresEveryValue(t *testing.T) {
+	full := config.Config{
+		ZitadelAdminClientID:     "id",
+		ZitadelAdminClientSecret: "placeholder",
+		ZitadelAdminRedirectURI:  "https://admin.mark8ly.com/auth/callback",
+		ZitadelAdminProjectID:    "proj",
+	}
+	if !mobileTokenIssuanceEnabled(&full) {
+		t.Fatal("a fully configured deployment must enable mobile token issuance")
+	}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*config.Config)
+	}{
+		{"no client id", func(c *config.Config) { c.ZitadelAdminClientID = "" }},
+		{"no client secret", func(c *config.Config) { c.ZitadelAdminClientSecret = "" }},
+		{"no redirect uri", func(c *config.Config) { c.ZitadelAdminRedirectURI = "" }},
+		{"no project id", func(c *config.Config) { c.ZitadelAdminProjectID = "" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := full
+			tc.mutate(&cfg)
+			if mobileTokenIssuanceEnabled(&cfg) {
+				t.Fatalf("%s must disable mobile token issuance, not half-enable it", tc.name)
+			}
+		})
+	}
+}
+
+// The default deployment (nothing set) must be unchanged from today: mobile
+// token issuance off, web login untouched.
+func TestMobileTokenIssuance_OffByDefault(t *testing.T) {
+	if mobileTokenIssuanceEnabled(&config.Config{}) {
+		t.Fatal("an unconfigured deployment must not enable mobile token issuance")
+	}
+}

--- a/services/auth-bff/pkg/config/config.go
+++ b/services/auth-bff/pkg/config/config.go
@@ -78,6 +78,26 @@ type Config struct {
 	ZitadelAdminProjectID      string `envconfig:"ZITADEL_ADMIN_PROJECT_ID"`
 	ZitadelStorefrontProjectID string `envconfig:"ZITADEL_STOREFRONT_PROJECT_ID"`
 
+	// Mobile token issuance (#686). The mobile login routes exchange the
+	// completed login's authorization code for OAuth tokens, because
+	// marketplace-api verifies a bearer JWT and a native client can use
+	// neither a session cookie nor a callback URL.
+	//
+	// ZITADEL_ADMIN_CLIENT_ID / _SECRET are the mark8ly-admin confidential
+	// client's, and the chart ALREADY injects both — until now nothing read
+	// them (see the correction on #709).
+	//
+	// ZitadelAdminRedirectURI is the one genuinely new value, and it is
+	// deliberately NOT defaulted: it must byte-match the redirect the auth
+	// request is created with or Zitadel refuses the exchange with a
+	// generic invalid_grant, and a hardcoded default would be silently
+	// wrong in any environment that is not production. Empty leaves mobile
+	// token issuance OFF, which is exactly today's behaviour — so this
+	// lands code-first safely and the chart turns it on.
+	ZitadelAdminClientID     string `envconfig:"ZITADEL_ADMIN_CLIENT_ID"`
+	ZitadelAdminClientSecret string `envconfig:"ZITADEL_ADMIN_CLIENT_SECRET"`
+	ZitadelAdminRedirectURI  string `envconfig:"ZITADEL_ADMIN_REDIRECT_URI"`
+
 	// Zitadel IDP-intent return-URL allowlists (internal/zitadellogin's
 	// ReturnURLAllowlist) — the only control preventing an open redirect on
 	// a completed federated sign-in, since Zitadel itself does not validate


### PR DESCRIPTION
Part of #686. Wires the mobile token issuer, which #728 deliberately left inert.

## Found by testing production, not by reading code

With #728 deployed I ran the real end-to-end call:

```
POST https://api.mark8ly.com/api/v1/mobile/admin/auth/login   → 502
```

Chasing it through the logs showed the whole chain working and stopping at exactly one place:

- `api.mark8ly.com` → marketplace-api ✅
- **tenant resolved by email** — it got past the no-tenant 404, so `ListMyTenants` found Mumbai Spice Co ✅
- marketplace-api → auth-bff with valid internal auth (a 500, not a 401) ✅
- auth-bff's mobile route reached ✅
- `zitadellogin: could not create an auth request for mobile login err="no token issuer configured"` ⛔

That last line is #728's documented "inert on deploy" state, not a bug. This PR supplies the wiring.

## Config

`ZITADEL_ADMIN_CLIENT_ID` and `ZITADEL_ADMIN_CLIENT_SECRET` are the mark8ly-admin confidential client's, and **the chart already injects both** — until now nothing read them (see the correction on #709). `ZITADEL_ADMIN_PROJECT_ID` is already set too.

`ZITADEL_ADMIN_REDIRECT_URI` is the one genuinely new value, and it is deliberately **not defaulted**. It must byte-match the redirect the auth request was created with or Zitadel refuses the exchange with a generic `invalid_grant` that names nothing — and a hardcoded default would be silently wrong in any environment that is not production.

## Deploy ordering

Empty config leaves mobile token issuance **off**, which is exactly today's behaviour. So this lands code-first safely, and a chart change turns it on — the right way round, since it is *adding* required config that would otherwise fail pods at boot.

A companion tesserix-k8s PR adds `ZITADEL_ADMIN_REDIRECT_URI: https://admin.mark8ly.com/auth/callback` to the auth-bff chart. **Merge this first**, then the chart.

## All four or nothing

Half-configured means OFF, not half-on. A login that "succeeds" without a usable token is indistinguishable from a working one until the first API call 401s — from a device, the hardest possible failure to diagnose. Refusing at 500 is loud and immediate. Five tests pin that, one per missing value, plus the unconfigured default.

## Verification

`gofmt`/`vet`/`build` clean, full auth-bff suite green. After this deploys I will re-run the production call; the expected answer for a never-seen device is `email_otp_required`, not tokens.
