### PR TITLE
Honour the Idempotency-Key on the email-template PUT

### DIFF
--- a/.planning/quick/260906-etk-email-template-idempotency/PLAN.md
+++ b/.planning/quick/260906-etk-email-template-idempotency/PLAN.md
@@ -1,0 +1,63 @@
+# Honour the Idempotency-Key on the email-template PUT
+
+#730. tesserix-home's platform-api sends an `Idempotency-Key` on
+`PUT /admin/email-templates/:key` and mark8ly ignores it.
+
+Verified in the caller, not assumed:
+`tesserix-home/platform-api/internal/platform/federation/client.go:203-207`
+returns `ErrIdempotencyKeyRequired` before any HTTP call, so **every**
+federated write already carries the header.
+
+## Why a retry actually costs something
+
+A template upsert is *nearly* idempotent by shape — the same body twice
+yields the same subject, bodies and status. But `version` bumps on every
+UPSERT and a revision row is appended per change, so a retried write inflates
+the counter and records a change nobody made. On this surface the revision
+trail is what stands in for an audit record, which is why a duplicate matters
+more than the identical-looking row suggests.
+
+## Shape: copy billing_trial_extend.go
+
+It is the only route on this surface that honours a key today, and its
+ordering comments record reasoning worth reusing rather than rediscovering:
+
+- header checked FIRST, before the key or the body
+- `Reserve` AFTER all validation and immediately before the write, so a
+  malformed request cannot leave a key claimed with an empty response for the
+  full TTL
+- fail CLOSED on a reserve/lookup error — a caller who cannot be told whether
+  the key was used must not reach a second UPSERT
+- `!claimed` → `Lookup`; a hit replays the stored bytes, a miss is 409
+  `in_progress`
+- `Release` on failure so a corrected retry is not blocked until the TTL
+
+## Two decisions
+
+**The header is REQUIRED, not optional.** Matching trial-extend. Safe
+because the only caller cannot omit it, and because the conformance suite
+never probes this route — `email-templates` is not one of the seventeen
+declarable ids, so no nightly run sends a PUT.
+
+**`tenant_id` is the nil uuid.** `idempotency_keys.tenant_id` is NOT NULL
+(migration 000001) and this registry is estate-wide — a template key belongs
+to the product, not a tenant. The nil uuid is honest; borrowing an unrelated
+id to satisfy the constraint is not.
+
+## Tasks
+
+1. `db *gorm.DB` on the handler and its constructor; `routes.go` passes
+   `deps.DB`. Kept separate from `writable` because unit tests exercise a
+   writable handler with no database.
+2. Header check, scoped key `email_template_upsert:<key>:<header>`,
+   Reserve/Lookup/Complete/Release around the existing write.
+3. Marshal the response once so the stored replay body and the served body
+   are the same bytes.
+
+## Done when
+
+- No header → 400 `idempotency_key_required`, and nothing is written.
+- Same key twice → the second replays the stored body, with no version bump.
+- A different key is a new write and does bump.
+- A key does not replay across template keys.
+- A nil-db handler still serves the write (the unit-test configuration).

--- a/services/marketplace-api/internal/handlers/platformadmin/email_templates.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/email_templates.go
@@ -24,6 +24,7 @@ package platformadmin
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	htmltpl "html/template"
 	"log/slog"
@@ -35,8 +36,11 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+	"github.com/mark8ly/marketplace-api/internal/idempotency"
 )
 
 // EmailTemplateStore is the subset of emailtemplates.Store this handler
@@ -96,6 +100,7 @@ type EmailTemplatesHandler struct {
 	registry EmailTemplateRegistry
 	sender   emailtemplates.TestSender
 	writable bool
+	db       *gorm.DB
 	logger   *slog.Logger
 }
 
@@ -105,16 +110,23 @@ type EmailTemplatesHandler struct {
 // mounted and answering 503 not_configured, matching how a missing
 // MARKETPLACE_PLATFORM_ADMIN_SECRET leaves this whole surface mounted but
 // inert rather than absent. writable gates the PUT; see Register.
+//
+// db backs Idempotency-Key replay on the PUT (#730). It is a separate
+// parameter from writable even though production derives both from the same
+// deps.DB, because the unit tests exercise a writable handler with no
+// database: a nil db there means the write happens but is not replayable,
+// which is the same nil-db handling BillingTrialExtendHandler has.
 func NewEmailTemplatesHandler(
 	store EmailTemplateStore,
 	registry EmailTemplateRegistry,
 	sender emailtemplates.TestSender,
 	writable bool,
+	db *gorm.DB,
 	logger *slog.Logger,
 ) *EmailTemplatesHandler {
 	return &EmailTemplatesHandler{
 		store: store, registry: registry, sender: sender,
-		writable: writable, logger: logger,
+		writable: writable, db: db, logger: logger,
 	}
 }
 
@@ -286,6 +298,20 @@ type upsertRequest struct {
 // does NOT keep is the attribution source: updated_by comes from the
 // SIGNED operator id on the request, never from the body.
 func (h *EmailTemplatesHandler) Upsert(c *gin.Context) {
+	// Checked FIRST, before the key or the body. platform-api's
+	// federation.Client refuses to make a write without this header
+	// (client.go:203), so every real caller already sends one; a request
+	// that arrives without it is malformed, and saying so plainly beats a
+	// validation error that sends the caller fixing the wrong thing.
+	idemKey := strings.TrimSpace(c.GetHeader("Idempotency-Key"))
+	if idemKey == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "idempotency_key_required",
+			"message": "the Idempotency-Key header is required for this endpoint",
+		})
+		return
+	}
+
 	key := strings.TrimSpace(c.Param("key"))
 	if key == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -356,6 +382,55 @@ func (h *EmailTemplatesHandler) Upsert(c *gin.Context) {
 		return
 	}
 
+	// Namespaced so a key can never replay across template keys or across
+	// endpoints: idempotency_keys.key is a bare primary key shared by the
+	// whole service, and the caller's raw header is theirs to choose.
+	scopedKey := "email_template_upsert:" + key + ":" + idemKey
+
+	// Reserved AFTER every validation above and immediately before the
+	// write, for the reason billing_trial_extend.go records: validation is
+	// deterministic, so two callers with the same key either both pass it
+	// or both fail it, and only then race. Reserving earlier would let a
+	// malformed request leave the key claimed with an empty response for
+	// the full TTL — turning a typo into a key that answers 409 for a day.
+	if h.db != nil {
+		claimed, err := idempotency.Reserve(c.Request.Context(), h.db, scopedKey,
+			estateWideTenant, time.Now().UTC(), idempotency.DefaultTTL)
+		if err != nil {
+			// Fail CLOSED. A caller that cannot be told whether this key was
+			// already used must not be let through to a second UPSERT, which
+			// would bump the version again and append a second revision row
+			// recording a change nobody made.
+			h.logError("platform email template idempotency reserve failed", err)
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"error": "unavailable", "message": "could not verify idempotency key",
+			})
+			return
+		}
+		if !claimed {
+			stored, ok, err := idempotency.Lookup(c.Request.Context(), h.db, scopedKey)
+			if err != nil {
+				h.logError("platform email template idempotency lookup failed", err)
+				c.JSON(http.StatusServiceUnavailable, gin.H{
+					"error": "unavailable", "message": "could not verify idempotency key",
+				})
+				return
+			}
+			if ok {
+				// A replay: the stored bytes verbatim, with no second UPSERT,
+				// no version bump and no extra revision row.
+				c.Data(http.StatusOK, "application/json; charset=utf-8", stored)
+				return
+			}
+			// Reserved but not completed — another caller, or another pod
+			// handling the same retry, is still doing the work.
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "in_progress", "message": "a request with this Idempotency-Key is already in flight",
+			})
+			return
+		}
+	}
+
 	saved, err := h.store.Upsert(c.Request.Context(), emailtemplates.UpsertInput{
 		Key:        key,
 		Subject:    req.Subject,
@@ -367,6 +442,9 @@ func (h *EmailTemplatesHandler) Upsert(c *gin.Context) {
 		Capability: strings.TrimSpace(c.GetString(CtxCapability)),
 	})
 	if err != nil {
+		// Release the reservation so a corrected retry with the same key is
+		// not answered 409 in_progress until the TTL expires.
+		h.releaseReservation(c, scopedKey)
 		h.logError("platform email template write failed", err)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "internal_error", "message": "could not save the template",
@@ -388,12 +466,54 @@ func (h *EmailTemplatesHandler) Upsert(c *gin.Context) {
 		h.registry.Invalidate(key)
 	}
 
-	c.JSON(http.StatusOK, gin.H{"data": emailTemplateDetail{
+	body, err := json.Marshal(gin.H{"data": emailTemplateDetail{
 		emailTemplateRow: h.storedRow(saved),
 		HTMLBody:         saved.HTMLBody,
 		TextBody:         saved.TextBody,
 		Variables:        variablesOrEmpty(saved.Variables),
 	}})
+	if err != nil {
+		// The write SUCCEEDED, so this is not a failed request — but the
+		// caller cannot be given a body and the key must not be left
+		// claimed with an empty response.
+		h.releaseReservation(c, scopedKey)
+		h.logError("platform email template response encode failed", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "internal_error", "message": "the template was saved but the response could not be encoded",
+		})
+		return
+	}
+
+	// Completed AFTER the write, so a retry replays the same body. A failure
+	// here is logged, not returned: the template is saved and the caller must
+	// be told so. The cost is that a retry would write again — strictly better
+	// than reporting a failure for a write that happened.
+	if h.db != nil {
+		if err := idempotency.Complete(c.Request.Context(), h.db, scopedKey, body); err != nil {
+			h.logError("platform email template idempotency complete failed", err)
+		}
+	}
+
+	c.Data(http.StatusOK, "application/json; charset=utf-8", body)
+}
+
+// estateWideTenant is the tenant_id recorded against an email-template
+// reservation. idempotency_keys.tenant_id is NOT NULL (migration 000001) and
+// this registry is estate-wide — a template key belongs to the product, not
+// to a tenant — so the nil uuid is the honest value rather than borrowing an
+// unrelated id to satisfy the constraint.
+var estateWideTenant = uuid.Nil.String()
+
+// releaseReservation drops a claim whose work did not complete. Best-effort:
+// the caller is already being given an error, and the reservation expires on
+// its own TTL regardless.
+func (h *EmailTemplatesHandler) releaseReservation(c *gin.Context, scopedKey string) {
+	if h.db == nil {
+		return
+	}
+	if err := idempotency.Release(c.Request.Context(), h.db, scopedKey); err != nil {
+		h.logError("platform email template idempotency release failed", err)
+	}
 }
 
 // testSendRequest is the test-send wire shape. `to` is required: the

--- a/services/marketplace-api/internal/handlers/platformadmin/email_templates_idempotency_integration_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/email_templates_idempotency_integration_test.go
@@ -1,0 +1,119 @@
+//go:build integration
+
+package platformadmin_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// The acceptance criterion for #730: the SAME key replays the stored body
+// and performs NO second UPSERT, while a DIFFERENT key is a new write.
+//
+// Counting the store's Upsert calls is what distinguishes real idempotency
+// from a coincidentally identical response — the retry hazard here is not a
+// wrong body, it is the version bump and the extra revision row a second
+// UPSERT would leave behind.
+func putRouter(t *testing.T, store platformadmin.EmailTemplateStore) *gin.Engine {
+	t.Helper()
+	db := testdb.NewDB(t, "idempotency_keys")
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	g := r.Group("", func(c *gin.Context) {
+		c.Set(platformadmin.CtxOperatorID, testOperatorID)
+		c.Set(platformadmin.CtxCapability, "platform.email_templates.write")
+	})
+	platformadmin.NewEmailTemplatesHandler(store, newStubRegistry(nil), nil, true, db, nil).Register(g)
+	return r
+}
+
+func putWithKey(r *gin.Engine, idemKey string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPut,
+		"/admin/email-templates/orderdoc_invoice", strings.NewReader(validPut))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", idemKey)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestUpsertIsIdempotentPerKey(t *testing.T) {
+	store := newStubTemplateStore(fixtureRow("orderdoc_invoice", emailtemplates.StatusPublished))
+	r := putRouter(t, store)
+
+	first := putWithKey(r, "key-1")
+	require.Equal(t, http.StatusOK, first.Code, first.Body.String())
+	firstVersion := decodeData(t, first)["version"]
+
+	replay := putWithKey(r, "key-1")
+	require.Equal(t, http.StatusOK, replay.Code)
+
+	assert.JSONEq(t, first.Body.String(), replay.Body.String(),
+		"a retry must replay the stored body verbatim")
+	assert.Equal(t, firstVersion, decodeData(t, replay)["version"],
+		"the version must NOT bump on a replay — that is the whole defect")
+
+	// A different key is a genuinely new write, and does bump.
+	fresh := putWithKey(r, "key-2")
+	require.Equal(t, http.StatusOK, fresh.Code)
+	assert.NotEqual(t, firstVersion, decodeData(t, fresh)["version"],
+		"a new key is a new write, not a replay")
+}
+
+// The stored response must be the exact bytes the first caller received —
+// not a re-render, which could drift as the row changes underneath.
+func TestReplayReturnsTheStoredBytesNotAFreshRead(t *testing.T) {
+	store := newStubTemplateStore(fixtureRow("orderdoc_invoice", emailtemplates.StatusPublished))
+	r := putRouter(t, store)
+
+	first := putWithKey(r, "key-1")
+	require.Equal(t, http.StatusOK, first.Code)
+
+	// Move the row on underneath, the way another operator's edit would.
+	other := putWithKey(r, "key-other")
+	require.Equal(t, http.StatusOK, other.Code)
+
+	replay := putWithKey(r, "key-1")
+	assert.JSONEq(t, first.Body.String(), replay.Body.String(),
+		"the replay answers the original request, not the current row")
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(replay.Body.Bytes(), &body))
+	assert.Contains(t, replay.Header().Get("Content-Type"), "application/json")
+}
+
+// A key scoped to one template must not replay against another. Without
+// namespacing, idempotency_keys.key is a bare service-wide primary key and
+// the same header would silently skip the second template's write.
+func TestKeysDoNotReplayAcrossTemplateKeys(t *testing.T) {
+	store := newStubTemplateStore(
+		fixtureRow("orderdoc_invoice", emailtemplates.StatusPublished),
+		fixtureRow("giftcard_delivery", emailtemplates.StatusPublished),
+	)
+	r := putRouter(t, store)
+
+	require.Equal(t, http.StatusOK, putWithKey(r, "shared-key").Code)
+
+	req := httptest.NewRequest(http.MethodPut,
+		"/admin/email-templates/giftcard_delivery", strings.NewReader(validPut))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", "shared-key")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "giftcard_delivery", decodeData(t, rec)["key"],
+		"the second template must be written, not answered with the first's response")
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/email_templates_idempotency_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/email_templates_idempotency_test.go
@@ -1,0 +1,83 @@
+package platformadmin_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+)
+
+// #730. tesserix-home's platform-api sends an Idempotency-Key on every
+// federated write — federation.Client refuses to make one without it
+// (client.go:203, ErrIdempotencyKeyRequired) — and this handler ignored it.
+//
+// A template upsert is NEARLY idempotent by shape: the same body applied
+// twice yields the same subject, bodies and status. But `version` bumps on
+// every UPSERT and a revision row is appended per change, so a retried write
+// inflates the counter and records a change nobody made. That revision trail
+// is what stands in for an audit record on this surface, which is why a
+// duplicate matters more here than the identical-looking row suggests.
+
+func TestUpsertRequiresAnIdempotencyKey(t *testing.T) {
+	store := newStubTemplateStore(fixtureRow("orderdoc_invoice", emailtemplates.StatusPublished))
+	rec := doWithoutIdempotencyKey(t,
+		templateRouter(store, newStubRegistry(nil), nil, true),
+		http.MethodPut, "/admin/email-templates/orderdoc_invoice", validPut)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code,
+		"a write that cannot be retried safely must refuse to start")
+	require.Equal(t, "idempotency_key_required", errorCode(t, rec))
+	require.Nil(t, store.gotUpsert, "nothing may be written without a key")
+}
+
+// The requirement is checked BEFORE the body is parsed, so a caller missing
+// the header gets that one clear reason rather than a validation error that
+// sends them fixing the wrong thing.
+func TestMissingIdempotencyKeyIsReportedBeforeBodyValidation(t *testing.T) {
+	store := newStubTemplateStore(fixtureRow("orderdoc_invoice", emailtemplates.StatusPublished))
+	rec := doWithoutIdempotencyKey(t,
+		templateRouter(store, newStubRegistry(nil), nil, true),
+		http.MethodPut, "/admin/email-templates/orderdoc_invoice", `{"status":"nonsense"}`)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "idempotency_key_required", errorCode(t, rec))
+}
+
+// A whitespace-only header is not a key. Accepting one would scope every
+// caller's replay to the same blank string.
+func TestBlankIdempotencyKeyIsRejected(t *testing.T) {
+	store := newStubTemplateStore(fixtureRow("orderdoc_invoice", emailtemplates.StatusPublished))
+	r := templateRouter(store, newStubRegistry(nil), nil, true)
+
+	req := httptest.NewRequest(http.MethodPut,
+		"/admin/email-templates/orderdoc_invoice", strings.NewReader(validPut))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", "   ")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "idempotency_key_required", errorCode(t, rec))
+}
+
+// Without a database the handler cannot record or replay a key, and it must
+// still serve the write rather than refusing it — mirroring how
+// BillingTrialExtendHandler treats a nil db. This is the unit-test
+// configuration; replay itself needs a real table and is proven in the
+// integration test.
+//
+// Production never reaches this branch: routes.go mounts the PUT only when
+// deps.DB is non-nil, and passes that same handle here.
+func TestUpsertWithoutADatabaseStillWrites(t *testing.T) {
+	store := newStubTemplateStore(fixtureRow("orderdoc_invoice", emailtemplates.StatusPublished))
+	rec := do(t, templateRouter(store, newStubRegistry(nil), nil, true),
+		http.MethodPut, "/admin/email-templates/orderdoc_invoice", validPut)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.NotNil(t, store.gotUpsert, "the write must still happen")
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/email_templates_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/email_templates_test.go
@@ -144,11 +144,24 @@ func templateRouter(
 		c.Set(platformadmin.CtxOperatorID, testOperatorID)
 		c.Set(platformadmin.CtxCapability, "platform.email_templates.write")
 	})
-	platformadmin.NewEmailTemplatesHandler(store, registry, sender, writable, nil).Register(g)
+	platformadmin.NewEmailTemplatesHandler(store, registry, sender, writable, nil, nil).Register(g)
 	return r
 }
 
+// do sends an Idempotency-Key by default, because the PUT requires one
+// (#730) and every other assertion in this file is about something else.
+// Use doWithoutIdempotencyKey for the case that tests the requirement.
 func do(t *testing.T, r *gin.Engine, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	return doHeaders(t, r, method, path, body, true)
+}
+
+func doWithoutIdempotencyKey(t *testing.T, r *gin.Engine, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	return doHeaders(t, r, method, path, body, false)
+}
+
+func doHeaders(t *testing.T, r *gin.Engine, method, path, body string, withIdempotencyKey bool) *httptest.ResponseRecorder {
 	t.Helper()
 	var req *http.Request
 	if body == "" {
@@ -156,6 +169,9 @@ func do(t *testing.T, r *gin.Engine, method, path, body string) *httptest.Respon
 	} else {
 		req = httptest.NewRequest(method, path, strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
+	}
+	if withIdempotencyKey {
+		req.Header.Set("Idempotency-Key", "test-key-"+method+"-"+path)
 	}
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -393,7 +393,7 @@ func Register(g *gin.RouterGroup, deps Deps) {
 		// still cannot be reached.
 		NewEmailTemplatesHandler(
 			deps.EmailTemplates, deps.EmailTemplateRegistry,
-			deps.EmailTemplateTestSender, deps.DB != nil, deps.Logger,
+			deps.EmailTemplateTestSender, deps.DB != nil, deps.DB, deps.Logger,
 		).Register(group)
 		if deps.DB == nil && deps.Logger != nil {
 			deps.Logger.Warn("platformadmin: email template write route not mounted — DB is required to record the change against an operator")


### PR DESCRIPTION
Closes #730.

`PUT /admin/email-templates/:key` was sent an `Idempotency-Key` on every call and ignored it. It now honours one, following the trials-extend implementation the issue points at.

## The caller side is not an assumption

`tesserix-home/platform-api/internal/platform/federation/client.go:203-207` returns `ErrIdempotencyKeyRequired` *before* any HTTP call, so every federated write already carries the header. That is what makes requiring it server-side safe rather than a gamble.

## Why a retry actually costs something

A template upsert is *nearly* idempotent by shape — the same body twice yields the same subject, bodies and status. But `version` bumps on every UPSERT and a revision row is appended per change, so a retried write inflates the counter and records a change nobody made. On this surface that revision trail is what stands in for an audit record, which is why a duplicate matters more than the identical-looking row suggests.

## Shape

`billing_trial_extend.go` is the only route on this surface that honours a key today, and its ordering carries reasoning worth reusing rather than rediscovering:

- header checked **first**, before the key or the body — so a caller missing it gets that one reason instead of a validation error that sends them fixing the wrong thing
- `Reserve` **after** all validation and immediately before the write, so a malformed request cannot leave a key claimed with an empty response for the full TTL
- fail **closed** on a reserve/lookup error: a caller who cannot be told whether the key was already used must not reach a second UPSERT
- `!claimed` → `Lookup`; a hit replays the stored bytes verbatim, a miss is `409 in_progress`
- `Release` on write failure, so a corrected retry is not answered 409 until the TTL expires

The response is marshalled once and both stored and served, so a replay returns the exact bytes the first caller got rather than a re-render that could drift as the row changes underneath.

## Three decisions worth flagging

**The header is required, not optional.** Matching trial-extend. Safe on two counts: the only caller cannot omit it (above), and the nightly conformance suite never probes this route — `email-templates` is not one of the seventeen declarable ids in `admin-conformance.json`, so no run sends a PUT here.

**`tenant_id` is the nil uuid.** `idempotency_keys.tenant_id` is `NOT NULL` (migration 000001) and this registry is estate-wide — a template key belongs to the product, not to a tenant. The nil uuid is the honest value; borrowing an unrelated id to satisfy the constraint is not. (Note trial-extend puts a *store* id in that column, which is its own looseness — not touched here.)

**`db` is a separate constructor parameter from `writable`**, even though production derives both from `deps.DB`. The unit tests exercise a writable handler with no database, and a nil db there means the write happens but is not replayable — the same nil-db handling `BillingTrialExtendHandler` already has. Production never takes that branch: `routes.go` mounts the PUT only when `deps.DB` is non-nil.

## Tests

Four unit tests for the header contract: missing header is a 400 that writes nothing, the requirement is reported before body validation, a whitespace-only header is not a key, and a nil-db handler still serves the write.

Three integration tests (`//go:build integration`) for replay itself, which needs a real `idempotency_keys` table: the same key replays with **no version bump** — asserting the version is what distinguishes real idempotency from a coincidentally identical response — a different key is a new write that does bump, a replay answers the original request even after the row moved underneath, and a key does not replay across template keys.

`gofmt`, `go build`, `go vet` (both tag sets) and the full unit suite are clean. Integration tests were **not** run locally — another session is active in this workspace and the test database is shared — so CI's `Integration (marketplace-api)` job is the gate on those.
