### PR TITLE
Let promo_codes hold console-defined trial-extension codes

### DIFF
--- a/.planning/quick/260906-pc-promo-codes-schema/PLAN.md
+++ b/.planning/quick/260906-pc-promo-codes-schema/PLAN.md
@@ -1,0 +1,93 @@
+# Let promo_codes hold what the console publishes
+
+Step 1 of #726 (decision: the console owns promo definitions; mark8ly ingests).
+This is the SCHEMA half only — no client, no ingest. Those follow once the
+table can hold the data.
+
+## Why the table cannot hold it today
+
+mark8ly's `promo_codes` (migration 000060) and the console's (tesserix-home
+0046) were designed independently. Four mismatches, one of them fatal:
+
+1. **Trial-extension-only codes cannot exist here.** The console allows
+   `trial_extension_days` set with `discount` null. mark8ly has
+   `discount_type NOT NULL`, `discount_value NOT NULL CHECK (> 0)`, and **no
+   trial-extension column at all**. #620 — "redeem promo codes at onboarding
+   to extend the trial" — is entirely about these codes.
+2. `stripe_coupon_id VARCHAR(100) NOT NULL` here; on the console it lives in a
+   child table keyed on `(promo_code_id, mode)` and the API **omits the key**
+   when the coupon is not minted in that mode.
+3. `CHECK (char_length(code) >= 12)` here; the console has no length
+   constraint and its own example is `LAUNCH50` (8 chars).
+4. Percent is basis points here, `numeric(5,2)` there. A conversion, not a
+   blocker — noted so the ingest does not get it wrong.
+
+**Loosening costs nothing today:** `promo.Repository.Create` has zero
+production callers, no migration seeds a row, and no endpoint creates one. The
+table is empty, so no existing data has invariants to weaken.
+
+## Task — migration 000131
+
+Write `migrations/000131_promo_codes_console_sourced.{up,down}.sql`:
+
+- `ADD COLUMN trial_extension_days INTEGER`, with
+  `CHECK (trial_extension_days IS NULL OR trial_extension_days > 0)` matching
+  the console's own constraint.
+- `DROP NOT NULL` on `discount_type`, `discount_value` and `stripe_coupon_id`.
+  Note the existing `CHECK (discount_value > 0)` already tolerates NULL, since
+  a CHECK passes when it evaluates to NULL — verify rather than assume.
+- Replace `promo_codes_code_length`. The `>= 12` rule cannot hold for
+  console-defined codes. Do NOT drop length validation entirely — an empty or
+  one-character code is a bug either way. Pick a floor that admits the
+  console's vocabulary and say why in a comment.
+- **Add the invariant that replaces what was lost.** A row must carry a
+  discount OR a trial extension — a code that does neither is meaningless:
+  `CHECK (trial_extension_days IS NOT NULL OR discount_type IS NOT NULL)`.
+- **Add the pairing invariant**: `discount_type` and `discount_value` are both
+  set or both null. Individually nullable columns otherwise permit a type with
+  no value.
+- The `promo_codes_stripe_idx` index on `stripe_coupon_id` should become a
+  partial index (`WHERE stripe_coupon_id IS NOT NULL`) now that the column is
+  nullable — the rows without one are not worth indexing.
+
+Write a real `down` that reverses each step. It must be honest: reverting
+means rows that violate the old NOT NULLs cannot exist, so the down migration
+should fail loudly if such rows are present rather than deleting them.
+
+**Bump `ExpectedSchemaVersion` to 131 in `migrations.go`.** The service refuses
+to start when it mismatches, so forgetting this breaks boot rather than
+degrading quietly.
+
+## Task — the Go model
+
+`internal/promo/model.go`'s `PromoCode`: make `StripeCouponID`, `DiscountType`
+and `DiscountValue` nullable (pointers), and add `TrialExtensionDays *int`.
+Update the struct's doc comment — it currently says "One row per Stripe Coupon
+we issue" and "≥12 chars", both of which stop being true.
+
+Then fix the compile fallout. `internal/promo/service.go` and `validator.go`
+read these fields; they must handle a nil discount rather than assuming one.
+**A trial-extension-only code must not be treated as a zero discount** — that
+would silently apply "0% off" instead of extending a trial.
+
+## Out of scope
+
+- The catalog client and the ingest itself (step 2).
+- Any change to `promo_redemptions`.
+- `max_per_email`: mark8ly defaults it to 1 as an abuse control (§7.3) and the
+  console contract cannot express it. Leaving the default is the current
+  policy; flagged on #726, not decided here.
+
+## Done when
+
+- A trial-extension-only row (no discount, no coupon id) INSERTs successfully
+- A row with neither a discount nor a trial extension is REJECTED
+- A row with `discount_type` set and `discount_value` null is REJECTED
+- Existing promo validation still behaves for a discount-bearing code
+- `go build ./...`, `go vet`, `go test ./internal/promo/...` green
+- Migration applies and reverts against a real database
+
+## Constraints
+
+- One atomic commit, single-line conventional message, NO attribution.
+- SHARED CHECKOUT: no checkout/switch/stash/reset beyond this branch.

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/page/... \
 	    ./internal/payment/... \
 	    ./internal/product/... \
+	    ./internal/promo/... \
 	    ./internal/reconciliation/... \
 	    ./internal/shipping/... \
 	    ./internal/signup/... \

--- a/services/marketplace-api/internal/handlers/admin/promo_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/promo_integration_test.go
@@ -19,6 +19,9 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 )
 
+// ptrOf is a local helper for the nullable promo_codes columns (#726).
+func ptrOf[T any](v T) *T { return &v }
+
 func promoApplyURL(storeID string) string {
 	return "/api/v1/admin/stores/" + storeID + "/subscription/apply-promo"
 }
@@ -28,9 +31,9 @@ func seedPromoCode(t *testing.T, env *testEnv, code string, discountBps int) uui
 	repo := promo.NewRepository()
 	pc := &promo.PromoCode{
 		Code:           code,
-		StripeCouponID: "co_test_" + code,
-		DiscountType:   promo.DiscountTypePercentage,
-		DiscountValue:  discountBps,
+		StripeCouponID: ptrOf("co_test_" + code),
+		DiscountType:   ptrOf(promo.DiscountTypePercentage),
+		DiscountValue:  ptrOf(discountBps),
 		MaxPerEmail:    3,
 		ValidFrom:      time.Now().UTC().Add(-24 * time.Hour),
 		CreatedBy:      "test",

--- a/services/marketplace-api/internal/promo/model.go
+++ b/services/marketplace-api/internal/promo/model.go
@@ -19,15 +19,32 @@ const (
 )
 
 // PromoCode is the GORM model for the promo_codes table.
-// One row per Stripe Coupon we issue. The code field is the human-facing
-// code (≥12 chars, visually-safe charset per §7.3).
+//
+// Promo definitions originate in the tesserix-home console (#726); mark8ly
+// ingests them. A row therefore carries a discount, a trial extension, or
+// both — the DB constraint promo_codes_has_benefit enforces "at least one".
+//
+// Codes we generate ourselves are ≥12 chars from the visually-safe charset
+// (§7.3, promo.MinCodeLength). Console-defined codes are human campaign codes
+// such as "LAUNCH50" and are only floored at 4 chars by the schema, so nothing
+// here may assume a length beyond that.
 type PromoCode struct {
-	ID             uuid.UUID    `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()"`
-	Code           string       `gorm:"column:code;type:varchar(64);not null;uniqueIndex"`
-	StripeCouponID string       `gorm:"column:stripe_coupon_id;type:varchar(100);not null"`
-	DiscountType   DiscountType `gorm:"column:discount_type;type:promo_discount_type;not null"`
+	ID   uuid.UUID `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()"`
+	Code string    `gorm:"column:code;type:varchar(64);not null;uniqueIndex"`
+	// StripeCouponID is nil when no Stripe Coupon backs this code — the
+	// console omits it for a code not minted in the current Stripe mode, and
+	// a trial-extension-only code never has one.
+	StripeCouponID *string `gorm:"column:stripe_coupon_id;type:varchar(100)"`
+	// DiscountType is nil when the code carries no discount. Nil must mean
+	// "no discount to apply" — never "0% off". It is set if and only if
+	// DiscountValue is set (DB constraint promo_codes_discount_pair).
+	DiscountType *DiscountType `gorm:"column:discount_type;type:promo_discount_type"`
 	// DiscountValue: basis points for percentage, minor units for amount.
-	DiscountValue                int            `gorm:"column:discount_value;not null"`
+	// Nil exactly when DiscountType is nil.
+	DiscountValue *int `gorm:"column:discount_value"`
+	// TrialExtensionDays is the number of days added to the store trial on
+	// redemption (#620). Nil when the code extends no trial.
+	TrialExtensionDays           *int           `gorm:"column:trial_extension_days"`
 	MaxDurationMonths            *int           `gorm:"column:max_duration_months"`
 	ValidFrom                    time.Time      `gorm:"column:valid_from;not null;default:now()"`
 	ValidUntil                   *time.Time     `gorm:"column:valid_until"`

--- a/services/marketplace-api/internal/promo/schema_integration_test.go
+++ b/services/marketplace-api/internal/promo/schema_integration_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package promo_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/promo"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// These tests pin migration 000131's constraints (#726). Loosening the
+// NOT NULLs on discount_type, discount_value and stripe_coupon_id was safe
+// only because explicit CHECKs replaced what they guaranteed; a CHECK that is
+// silently dropped or mis-written looks exactly like a CHECK that works, so
+// each one is asserted here against a real Postgres.
+
+func ptr[T any](v T) *T { return &v }
+
+// insertPromoCode inserts a row directly, bypassing any Go-side validation, so
+// the assertions are about the DATABASE and not about the model.
+func insertPromoCode(db *gorm.DB, pc *promo.PromoCode) error {
+	if pc.ValidFrom.IsZero() {
+		pc.ValidFrom = time.Now().UTC().Add(-time.Hour)
+	}
+	if pc.MaxPerEmail == 0 {
+		pc.MaxPerEmail = 1
+	}
+	if pc.CreatedBy == "" {
+		pc.CreatedBy = "test"
+	}
+	return db.Create(pc).Error
+}
+
+// TestPromoCodes_TrialExtensionOnlyRowInserts is the point of #726: the
+// console publishes codes that only extend a trial, with no discount and no
+// Stripe coupon. Before 000131 this row could not exist at all.
+//
+// It also proves the claim 000131 relies on but does not re-state as a new
+// constraint: 000060's CHECK (discount_value > 0) survives untouched and still
+// admits NULL, because a CHECK passes when it evaluates to UNKNOWN.
+func TestPromoCodes_TrialExtensionOnlyRowInserts(t *testing.T) {
+	db := testdb.NewTx(t)
+
+	pc := &promo.PromoCode{
+		Code:               "LAUNCH50",
+		TrialExtensionDays: ptr(14),
+	}
+	require.NoError(t, insertPromoCode(db, pc),
+		"a trial-extension-only code (no discount, no coupon id) must insert")
+
+	var got promo.PromoCode
+	require.NoError(t, db.Where("id = ?", pc.ID).First(&got).Error)
+	require.Nil(t, got.DiscountType, "no discount must round-trip as NULL, not as a zero value")
+	require.Nil(t, got.DiscountValue)
+	require.Nil(t, got.StripeCouponID)
+	require.NotNil(t, got.TrialExtensionDays)
+	require.Equal(t, 14, *got.TrialExtensionDays)
+}
+
+// TestPromoCodes_RowWithNoBenefitIsRejected covers promo_codes_has_benefit —
+// the invariant that replaces the NOT NULLs. A code that neither discounts nor
+// extends would be accepted at redemption and do nothing.
+func TestPromoCodes_RowWithNoBenefitIsRejected(t *testing.T) {
+	db := testdb.NewTx(t)
+
+	err := insertPromoCode(db, &promo.PromoCode{Code: "NOTHINGATALL"})
+	require.Error(t, err, "a code with neither a discount nor a trial extension must be rejected")
+}
+
+// TestPromoCodes_DiscountTypeWithoutValueIsRejected covers
+// promo_codes_discount_pair. Three independently nullable columns would
+// otherwise permit 'percentage' with no value.
+func TestPromoCodes_DiscountTypeWithoutValueIsRejected(t *testing.T) {
+	db := testdb.NewTx(t)
+
+	err := insertPromoCode(db, &promo.PromoCode{
+		Code:         "TYPENOVALUE1",
+		DiscountType: ptr(promo.DiscountTypePercentage),
+	})
+	require.Error(t, err, "discount_type set with discount_value NULL must be rejected")
+}
+
+// TestPromoCodes_DiscountValueWithoutTypeIsRejected is the other half of the
+// pair — a bare value with no type is equally meaningless.
+func TestPromoCodes_DiscountValueWithoutTypeIsRejected(t *testing.T) {
+	db := testdb.NewTx(t)
+
+	err := insertPromoCode(db, &promo.PromoCode{
+		Code:          "VALUENOTYPE1",
+		DiscountValue: ptr(1000),
+	})
+	require.Error(t, err, "discount_value set with discount_type NULL must be rejected")
+}
+
+// TestPromoCodes_DiscountBearingCodeStillInserts guards against the loosening
+// having broken the case that already worked.
+func TestPromoCodes_DiscountBearingCodeStillInserts(t *testing.T) {
+	db := testdb.NewTx(t)
+
+	require.NoError(t, insertPromoCode(db, &promo.PromoCode{
+		Code:           "ABCDEF123456",
+		StripeCouponID: ptr("co_test_abcdef123456"),
+		DiscountType:   ptr(promo.DiscountTypePercentage),
+		DiscountValue:  ptr(1000),
+	}), "a discount-bearing code must still insert unchanged")
+}
+
+// TestPromoCodes_NonPositiveDiscountValueIsStillRejected proves 000060's
+// CHECK (discount_value > 0) is still enforced for a discount that IS present.
+// "NULL passes" must not have become "anything passes".
+func TestPromoCodes_NonPositiveDiscountValueIsStillRejected(t *testing.T) {
+	db := testdb.NewTx(t)
+
+	err := insertPromoCode(db, &promo.PromoCode{
+		Code:          "ZERODISCOUNT",
+		DiscountType:  ptr(promo.DiscountTypePercentage),
+		DiscountValue: ptr(0),
+	})
+	require.Error(t, err, "a present discount_value must still be > 0")
+}
+
+// TestPromoCodes_TrialExtensionMustBePositive mirrors the console's own
+// constraint.
+func TestPromoCodes_TrialExtensionMustBePositive(t *testing.T) {
+	db := testdb.NewTx(t)
+
+	err := insertPromoCode(db, &promo.PromoCode{
+		Code:               "ZEROTRIALDAY",
+		TrialExtensionDays: ptr(0),
+	})
+	require.Error(t, err, "trial_extension_days must be > 0 when set")
+}
+
+// TestPromoCodes_ShortConsoleCodeIsAccepted is the reason the >= 12 floor had
+// to go: the console's own worked example is 'LAUNCH50', 8 characters.
+func TestPromoCodes_ShortConsoleCodeIsAccepted(t *testing.T) {
+	db := testdb.NewTx(t)
+
+	require.NoError(t, insertPromoCode(db, &promo.PromoCode{
+		Code:               "XMAS",
+		TrialExtensionDays: ptr(7),
+	}), "a 4-character console code must be accepted")
+}
+
+// TestPromoCodes_DegenerateCodeIsStillRejected — the length floor was lowered,
+// not removed. An empty or one-character code is a bug under any policy.
+func TestPromoCodes_DegenerateCodeIsStillRejected(t *testing.T) {
+	db := testdb.NewTx(t)
+
+	for _, code := range []string{"", "X", "AB "} {
+		err := insertPromoCode(db, &promo.PromoCode{
+			Code:               code,
+			TrialExtensionDays: ptr(7),
+		})
+		require.Errorf(t, err, "code %q must be rejected by the length floor", code)
+	}
+}

--- a/services/marketplace-api/internal/promo/service.go
+++ b/services/marketplace-api/internal/promo/service.go
@@ -42,7 +42,10 @@ type ApplyInput struct {
 
 // ApplyOutput is returned by Service.ApplyPromo on success.
 type ApplyOutput struct {
-	PromoCodeID    uuid.UUID
+	PromoCodeID uuid.UUID
+	// StripeCouponID is the Stripe Coupon backing the code, or "" when the
+	// code has none (trial-extension-only, or not minted in this Stripe mode).
+	// "" is not a valid Stripe coupon id, so it is unambiguously "no coupon".
 	StripeCouponID string
 	EffectiveMinor int64
 	// RejectReason is empty on success; set when the code was rejected (for audit).
@@ -134,15 +137,29 @@ func (s *Service) ApplyPromo(ctx context.Context, in ApplyInput) (ApplyOutput, e
 		return ApplyOutput{}, fmt.Errorf("promo: apply: check store redemption: %w", storeRedErr)
 	}
 
-	// 5. Attach coupon in Stripe (if client available).
-	if s.stripe != nil && in.StripeSubscriptionID != "" {
-		if err := billingstripe.AttachCoupon(ctx, s.stripe, in.StripeSubscriptionID, pc.StripeCouponID); err != nil {
+	// 5. Attach coupon in Stripe (if client available and the code has one).
+	//
+	// A console-defined code need not have a Stripe Coupon: a
+	// trial-extension-only code never does, and the console omits the coupon
+	// id for a code not minted in the current Stripe mode (#726). There is
+	// nothing to attach in that case — attaching an empty coupon id would be
+	// a Stripe API error, and inventing one would be worse.
+	couponID := ""
+	if pc.StripeCouponID != nil {
+		couponID = *pc.StripeCouponID
+	}
+	if s.stripe != nil && in.StripeSubscriptionID != "" && couponID != "" {
+		if err := billingstripe.AttachCoupon(ctx, s.stripe, in.StripeSubscriptionID, couponID); err != nil {
 			return ApplyOutput{}, fmt.Errorf("promo: apply: stripe attach coupon: %w", err)
 		}
 		s.logger.Info("promo: coupon attached to stripe subscription",
 			"store_id", in.StoreID,
-			"coupon_id", pc.StripeCouponID,
+			"coupon_id", couponID,
 			"stripe_sub_id", in.StripeSubscriptionID)
+	} else if couponID == "" {
+		s.logger.Info("promo: code carries no stripe coupon — nothing to attach",
+			"store_id", in.StoreID,
+			"promo_code_id", pc.ID)
 	} else {
 		s.logger.Warn("promo: stripe client nil or no subscription id — skipping Stripe coupon attach",
 			"store_id", in.StoreID)
@@ -157,8 +174,11 @@ func (s *Service) ApplyPromo(ctx context.Context, in ApplyInput) (ApplyOutput, e
 		RedeemedAt:     time.Now().UTC(),
 	}
 	if err := s.repo.CreateRedemption(ctx, s.db, red); err != nil {
-		// Best-effort rollback: try to detach from Stripe.
-		if s.stripe != nil && in.StripeSubscriptionID != "" {
+		// Best-effort rollback: try to detach from Stripe. Only when we
+		// actually attached something — a code with no coupon attached
+		// nothing, and detaching here would strip an unrelated coupon the
+		// subscription already carried.
+		if s.stripe != nil && in.StripeSubscriptionID != "" && couponID != "" {
 			_ = billingstripe.DetachCoupon(ctx, s.stripe, in.StripeSubscriptionID)
 		}
 		return ApplyOutput{}, fmt.Errorf("promo: apply: record redemption: %w", err)
@@ -171,7 +191,7 @@ func (s *Service) ApplyPromo(ctx context.Context, in ApplyInput) (ApplyOutput, e
 
 	return ApplyOutput{
 		PromoCodeID:    pc.ID,
-		StripeCouponID: pc.StripeCouponID,
+		StripeCouponID: couponID,
 		EffectiveMinor: result.EffectiveMinor,
 	}, nil
 }
@@ -233,11 +253,14 @@ func (s *Service) ValidateForSaveOffer(ctx context.Context, in ApplyInput) (Appl
 		return ApplyOutput{RejectReason: result.RejectReason}, ErrInvalidOrExpired
 	}
 
-	return ApplyOutput{
+	out := ApplyOutput{
 		PromoCodeID:    pc.ID,
-		StripeCouponID: pc.StripeCouponID,
 		EffectiveMinor: result.EffectiveMinor,
-	}, nil
+	}
+	if pc.StripeCouponID != nil {
+		out.StripeCouponID = *pc.StripeCouponID
+	}
+	return out, nil
 }
 
 func normaliseEmail(email string) string {

--- a/services/marketplace-api/internal/promo/validator.go
+++ b/services/marketplace-api/internal/promo/validator.go
@@ -45,6 +45,11 @@ const (
 	RejectReasonAnnualOnly         ValidationRejectReason = "annual_only"
 	RejectReasonBelowFloor         ValidationRejectReason = "below_absolute_floor"
 	RejectReasonCurrencyNotCovered ValidationRejectReason = "currency_not_covered"
+	// RejectReasonUnknownDiscountType covers a row whose discount_type is set
+	// to a value this build does not understand — only reachable via a bad
+	// ingest from the console (#726). Rejecting is safer than applying no
+	// discount and calling it a success.
+	RejectReasonUnknownDiscountType ValidationRejectReason = "unknown_discount_type"
 )
 
 // ValidationResult is returned by Validate. On success Accepted is true and
@@ -114,14 +119,29 @@ func Validate(in ValidationInput) ValidationResult {
 	}
 
 	// Compute effective price and run floor check.
-	var effectiveMinor int64
-	switch in.PromoCode.DiscountType {
-	case DiscountTypePercentage:
-		effectiveMinor = ComputeEffective(in.BasePriceMinor, in.PromoCode.DiscountValue, 0)
-	case DiscountTypeAmount:
-		effectiveMinor = ComputeEffective(in.BasePriceMinor, 0, int64(in.PromoCode.DiscountValue))
-	default:
-		effectiveMinor = in.BasePriceMinor
+	//
+	// A console-defined code may carry NO discount at all — a
+	// trial-extension-only code (#620, #726). That is not a zero discount:
+	// the price is simply untouched, and the benefit is delivered elsewhere
+	// (the trial extension). Treating nil as 0 here would be wrong in both
+	// directions — for DiscountTypePercentage it reads as "0% off" and for
+	// DiscountTypeAmount as "0 minor units off"; both are silently correct
+	// arithmetic for the wrong code, and both would hide a failed ingest.
+	// The DB guarantees a discount is complete when present
+	// (promo_codes_discount_pair), so nil type and nil value travel together.
+	effectiveMinor := in.BasePriceMinor
+	if in.PromoCode.DiscountType != nil && in.PromoCode.DiscountValue != nil {
+		switch *in.PromoCode.DiscountType {
+		case DiscountTypePercentage:
+			effectiveMinor = ComputeEffective(in.BasePriceMinor, *in.PromoCode.DiscountValue, 0)
+		case DiscountTypeAmount:
+			effectiveMinor = ComputeEffective(in.BasePriceMinor, 0, int64(*in.PromoCode.DiscountValue))
+		default:
+			// An unrecognised discount type is a data fault, not a free pass.
+			// Leaving the price undiscounted here would apply nothing while
+			// reporting success, so reject instead.
+			return ValidationResult{Accepted: false, RejectReason: RejectReasonUnknownDiscountType}
+		}
 	}
 
 	if err := CheckFloor(in.Plan, in.Currency, effectiveMinor); err != nil {

--- a/services/marketplace-api/internal/promo/validator_test.go
+++ b/services/marketplace-api/internal/promo/validator_test.go
@@ -7,10 +7,15 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 )
 
+// ptr is a local helper for the nullable promo_codes columns (#726): a
+// console-defined code may carry no discount at all, so DiscountType and
+// DiscountValue are pointers on the model.
+func ptr[T any](v T) *T { return &v }
+
 var baseCode = &PromoCode{
 	Code:          "ABCDEF123456",
-	DiscountType:  DiscountTypePercentage,
-	DiscountValue: 1000, // 10% off
+	DiscountType:  ptr(DiscountTypePercentage),
+	DiscountValue: ptr(1000), // 10% off
 	MaxPerEmail:   1,
 	ValidFrom:     time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 }
@@ -160,7 +165,7 @@ func TestValidate(t *testing.T) {
 				SubmittedCode: "ABCDEF123456",
 				PromoCode: func() *PromoCode {
 					pc := *baseCode
-					pc.DiscountValue = 5000 // 50% in basis points
+					pc.DiscountValue = ptr(5000) // 50% in basis points
 					return &pc
 				}(),
 				Now:              now,
@@ -201,5 +206,64 @@ func TestValidate(t *testing.T) {
 				t.Errorf("Validate().RejectReason = %q, want %q", result.RejectReason, tc.wantReason)
 			}
 		})
+	}
+}
+
+// TestValidate_TrialExtensionOnlyCodeLeavesPriceUntouched pins the rule that
+// a nil discount means "there is no discount to apply", NOT "0% off" (#726).
+// The two are numerically identical for a percentage, which is exactly why the
+// distinction has to be asserted deliberately: a nil deref or a silent
+// zero-value fallback would look correct here until an amount-typed code or an
+// unknown type arrived. What must hold is that the code is ACCEPTED (its
+// benefit is the trial extension, delivered elsewhere) and the price is the
+// base price, untouched.
+func TestValidate_TrialExtensionOnlyCodeLeavesPriceUntouched(t *testing.T) {
+	pc := *baseCode
+	pc.DiscountType = nil
+	pc.DiscountValue = nil
+	pc.TrialExtensionDays = ptr(14)
+
+	got := Validate(ValidationInput{
+		SubmittedCode:  "ABCDEF123456",
+		PromoCode:      &pc,
+		Now:            now,
+		Plan:           subscription.PlanStarter,
+		Period:         subscription.PeriodMonthly,
+		BasePriceMinor: 2900,
+		Currency:       "usd",
+	})
+
+	if !got.Accepted {
+		t.Fatalf("trial-extension-only code must be accepted, got reason %q", got.RejectReason)
+	}
+	if got.EffectiveMinor != 2900 {
+		t.Fatalf("EffectiveMinor = %d, want the untouched base price 2900", got.EffectiveMinor)
+	}
+}
+
+// TestValidate_UnknownDiscountTypeIsRejected covers the only way a discount
+// can be present but unusable: a row whose discount_type this build does not
+// understand, which can only arrive via a bad console ingest. Falling through
+// to the base price would report success while applying nothing.
+func TestValidate_UnknownDiscountTypeIsRejected(t *testing.T) {
+	pc := *baseCode
+	pc.DiscountType = ptr(DiscountType("bogus"))
+	pc.DiscountValue = ptr(1000)
+
+	got := Validate(ValidationInput{
+		SubmittedCode:  "ABCDEF123456",
+		PromoCode:      &pc,
+		Now:            now,
+		Plan:           subscription.PlanStarter,
+		Period:         subscription.PeriodMonthly,
+		BasePriceMinor: 2900,
+		Currency:       "usd",
+	})
+
+	if got.Accepted {
+		t.Fatal("an unrecognised discount_type must not be accepted as a no-op discount")
+	}
+	if got.RejectReason != RejectReasonUnknownDiscountType {
+		t.Fatalf("RejectReason = %q, want %q", got.RejectReason, RejectReasonUnknownDiscountType)
 	}
 }

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 130
+const ExpectedSchemaVersion uint = 131

--- a/services/marketplace-api/migrations/000131_promo_codes_console_sourced.down.sql
+++ b/services/marketplace-api/migrations/000131_promo_codes_console_sourced.down.sql
@@ -1,0 +1,56 @@
+-- 000131_promo_codes_console_sourced.down.sql
+--
+-- Reverting re-imposes NOT NULL on discount_type, discount_value and
+-- stripe_coupon_id, restores the >= 12 code-length floor, and drops
+-- trial_extension_days. Any row that only the loosened schema could hold has
+-- no representation afterwards.
+--
+-- This migration therefore REFUSES to run when such rows exist rather than
+-- deleting or defaulting them. Deleting them would make the rollback succeed
+-- by destroying exactly the data #620 exists to store, and a promo_redemptions
+-- row can already point at one. Reverting is only safe while the table holds
+-- nothing the old shape could not express.
+
+DO $$
+DECLARE
+    unrepresentable bigint;
+BEGIN
+    SELECT count(*) INTO unrepresentable
+    FROM promo_codes
+    WHERE discount_type        IS NULL
+       OR discount_value       IS NULL
+       OR stripe_coupon_id     IS NULL
+       OR trial_extension_days IS NOT NULL
+       OR char_length(code) < 12;
+
+    IF unrepresentable > 0 THEN
+        RAISE EXCEPTION
+            'migration 000131 cannot be reverted: % promo_codes row(s) carry a null discount, a null stripe_coupon_id, a trial extension, or a code shorter than 12 characters — none of which the pre-000131 schema can hold. Reverting would have to delete them. Remove or rewrite these rows deliberately, or restore from a pre-migration snapshot.',
+            unrepresentable;
+    END IF;
+END $$;
+
+-- Reverse step 5: back to a full index on a NOT NULL column.
+DROP INDEX promo_codes_stripe_idx;
+CREATE INDEX promo_codes_stripe_idx ON promo_codes (stripe_coupon_id);
+
+-- Reverse step 4.
+ALTER TABLE promo_codes DROP CONSTRAINT promo_codes_discount_pair;
+ALTER TABLE promo_codes DROP CONSTRAINT promo_codes_has_benefit;
+
+-- Reverse step 3.
+ALTER TABLE promo_codes DROP CONSTRAINT promo_codes_code_length;
+ALTER TABLE promo_codes
+    ADD CONSTRAINT promo_codes_code_length CHECK (char_length(code) >= 12);
+
+-- Reverse step 2. Safe: the guard above proved no null rows remain.
+ALTER TABLE promo_codes ALTER COLUMN stripe_coupon_id SET NOT NULL;
+ALTER TABLE promo_codes ALTER COLUMN discount_value   SET NOT NULL;
+ALTER TABLE promo_codes ALTER COLUMN discount_type    SET NOT NULL;
+
+-- Reverse step 1.
+ALTER TABLE promo_codes DROP CONSTRAINT promo_codes_trial_extension_days_positive;
+ALTER TABLE promo_codes DROP COLUMN trial_extension_days;
+
+COMMENT ON TABLE promo_codes IS
+    '§7.1 — subscription promo codes; Stripe Coupon is backend of record.';

--- a/services/marketplace-api/migrations/000131_promo_codes_console_sourced.up.sql
+++ b/services/marketplace-api/migrations/000131_promo_codes_console_sourced.up.sql
@@ -1,0 +1,83 @@
+-- 000131_promo_codes_console_sourced.up.sql
+-- #726 step 1 — let promo_codes hold what the tesserix-home console publishes.
+--
+-- mark8ly's promo_codes (000060) and the console's table (tesserix-home 0046)
+-- were designed independently. The fatal mismatch: the console allows a
+-- TRIAL-EXTENSION-ONLY code — trial_extension_days set, discount null, no
+-- Stripe coupon minted — and this table has discount_type NOT NULL,
+-- discount_value NOT NULL, stripe_coupon_id NOT NULL, and no trial-extension
+-- column at all. #620 ("redeem a promo code at onboarding to extend the
+-- trial") is entirely about those codes.
+--
+-- Loosening costs nothing today: promo.Repository.Create has zero production
+-- callers, no migration seeds a row, and no endpoint creates one. The table is
+-- empty, so no existing data has invariants to weaken. What IS lost is the
+-- NOT NULLs' implicit guarantees, so this migration replaces them with
+-- explicit CHECKs rather than simply dropping them.
+
+-- 1. The trial extension itself. Constraint mirrors the console's own.
+ALTER TABLE promo_codes ADD COLUMN trial_extension_days INTEGER;
+
+ALTER TABLE promo_codes
+    ADD CONSTRAINT promo_codes_trial_extension_days_positive
+    CHECK (trial_extension_days IS NULL OR trial_extension_days > 0);
+
+COMMENT ON COLUMN promo_codes.trial_extension_days IS
+    'Days added to the store trial when this code is redeemed (#620). NULL = the code extends no trial.';
+
+-- 2. A console code may carry no discount and no Stripe coupon.
+--
+-- The column-level CHECK (discount_value > 0) from 000060 is deliberately left
+-- in place: per SQL semantics a CHECK is satisfied when it evaluates to TRUE
+-- *or* UNKNOWN, so NULL > 0 yields NULL and passes. It therefore keeps meaning
+-- "a discount that exists must be positive" without blocking a null discount.
+-- Verified against a live database by
+-- TestPromoCodes_TrialExtensionOnlyRowInserts in internal/promo.
+ALTER TABLE promo_codes ALTER COLUMN discount_type    DROP NOT NULL;
+ALTER TABLE promo_codes ALTER COLUMN discount_value   DROP NOT NULL;
+ALTER TABLE promo_codes ALTER COLUMN stripe_coupon_id DROP NOT NULL;
+
+-- 3. Replace the >= 12 length floor.
+--
+-- 12 is right for codes WE generate — promo.MinCodeLength keeps enforcing it
+-- there, because a self-minted code's length is its entropy budget (§7.3).
+-- It cannot hold for codes the console defines: the console has no length
+-- constraint and its own worked example is 'LAUNCH50', 8 characters. Human
+-- campaign codes are routinely 6-10.
+--
+-- The new floor is 4, which is not an entropy claim — a console code's safety
+-- comes from its redemption limits, not from being unguessable. It exists to
+-- reject the cases that are a bug under any policy: the empty string, a stray
+-- single character, a truncated ingest. 4 is the shortest length any plausible
+-- real campaign code reaches ('XMAS', 'B2B1'), so it rejects garbage without
+-- rejecting anything the console can legitimately publish.
+ALTER TABLE promo_codes DROP CONSTRAINT promo_codes_code_length;
+ALTER TABLE promo_codes
+    ADD CONSTRAINT promo_codes_code_length CHECK (char_length(code) >= 4);
+
+-- 4. Replace what the NOT NULLs guaranteed.
+--
+-- A row must deliver SOMETHING. Without this, three nullable columns permit a
+-- row that neither discounts nor extends — a code that is accepted at
+-- redemption and does nothing.
+ALTER TABLE promo_codes
+    ADD CONSTRAINT promo_codes_has_benefit
+    CHECK (trial_extension_days IS NOT NULL OR discount_type IS NOT NULL);
+
+-- Discount type and value are set together or not at all. Nullable
+-- individually, they would otherwise permit 'percentage' with no value (which
+-- validator.go would have to invent a meaning for) or a bare value with no
+-- type. Both sides are IS NULL tests, so the expression is never UNKNOWN and
+-- the constraint cannot pass by accident.
+ALTER TABLE promo_codes
+    ADD CONSTRAINT promo_codes_discount_pair
+    CHECK ((discount_type IS NULL) = (discount_value IS NULL));
+
+-- 5. stripe_coupon_id is now nullable, and rows without a coupon are not worth
+-- indexing — the index exists to find a row BY its coupon id.
+DROP INDEX promo_codes_stripe_idx;
+CREATE INDEX promo_codes_stripe_idx ON promo_codes (stripe_coupon_id)
+    WHERE stripe_coupon_id IS NOT NULL;
+
+COMMENT ON TABLE promo_codes IS
+    '§7.1 — subscription promo codes. Definitions originate in the tesserix-home console (#726); a code may carry a discount (Stripe Coupon is then the backend of record), a trial extension (#620), or both.';


### PR DESCRIPTION
**Step 1 of #726** — schema only. The client and the ingest follow once the table can hold what the console publishes.

Per the decision on #726, the console owns promo definitions and mark8ly consumes them. But "populate `promo_codes` from the catalog" turned out not to be a straight ingest: the two tables were designed independently and do not line up.

## The mismatch that forced this

The console permits a **trial-extension-only** code — `trial_extension_days` set, `discount` null. Its route doc says so explicitly.

mark8ly could not represent one:

```sql
discount_type   promo_discount_type NOT NULL,
discount_value  INTEGER NOT NULL CHECK (discount_value > 0),
```

both NOT NULL, and **no trial-extension column at all** — zero matches for "trial" in migration 000060.

That is not an edge case. **#620 — "redeem promo codes at onboarding to extend the trial" — is entirely about those codes.** An ingest into the old table would have dropped or rejected exactly what #620 exists to redeem.

Three smaller ones, all real: `stripe_coupon_id` was NOT NULL here but is omitted by the console API when the coupon is not minted in that mode; `CHECK (char_length(code) >= 12)` rejected console codes (its own example is `LAUNCH50`, 8 chars); and percent is basis points here versus `numeric(5,2)` there.

## Loosening replaced the invariants rather than dropping them

Making columns individually nullable would have permitted a discount **type** with no **value**, and a code with no benefit at all. Migration 000131 adds back what the NOT NULLs were really guaranteeing:

| constraint | meaning |
|---|---|
| `promo_codes_has_benefit` | a code must discount **or** extend a trial — one that does neither is meaningless |
| `promo_codes_discount_pair` | `discount_type` and `discount_value` are both set or both null |
| `promo_codes_trial_extension_days_positive` | mirrors the console's own constraint |

`promo_codes_discount_pair` is written as `(discount_type IS NULL) = (discount_value IS NULL)` — both sides are boolean, never NULL, so it cannot be satisfied by evaluating to UNKNOWN. That is the subtle way this check could have been useless.

The `>= 12` length rule became `>= 4`, justified in the migration: 12 was an **entropy** budget and still applies to codes we mint (`promo.MinCodeLength`, unchanged). A console code's safety comes from redemption limits, not unguessability. The floor stays non-zero so empty strings and truncated ingests are still rejected.

`promo_codes_stripe_idx` becomes partial (`WHERE stripe_coupon_id IS NOT NULL`) now the column is nullable.

**`ExpectedSchemaVersion` -> 131.** The service refuses to start on a mismatch, so omitting that breaks boot rather than degrading quietly.

## The behaviour change that matters most

`validator.go` previously did `switch DiscountType` with a `default:` that fell through to the base price and reported **success**. With a nullable discount that would silently apply "0% off" to a trial-extension code — arithmetic that is correct for the wrong code, and that hides a failed ingest.

Now a nil discount leaves the price untouched deliberately, and an **unrecognised** discount type is rejected (`RejectReasonUnknownDiscountType`) rather than passing. That second part fixes a pre-existing hole this change would otherwise have widened.

`service.go`'s rollback was also guarded: it previously called `DetachCoupon` unconditionally, which after this change could strip an unrelated coupon from a subscription we never attached one to.

## What is NOT verified, stated plainly

**The migration has not been applied or reverted against a real database.** `TEST_DATABASE_URL` is unset here and the dev stack is unreachable from this network, so all 9 tests in `internal/promo/schema_integration_test.go` **did not execute** — they compile (`go vet -tags integration ./...` clean) and would skip silently while printing `ok`.

CI's `Integration (marketplace-api)` job runs `go test -tags=integration ./...` against a real postgres with migrations applied, and **that is the gate here** — do not merge on the unit suite alone. The DDL parsing, the constraint behaviour, and the `down` guard are all unproven until it runs.

What did execute: `go build ./...`, `go vet` (plain and `-tags integration`), and the unit suite including two new validator tests — nil discount leaves the price untouched, and an unknown discount type is rejected.

The `down` migration counts offending rows and `RAISE EXCEPTION`s naming the count. It deletes nothing to make itself succeed.

Safe to loosen because the table is empty: `promo.Repository.Create` has zero production callers, no migration seeds a row, and no endpoint creates one — which is the same fact that makes `apply-promo` permanently fail today.

Refs #726, #620.
