### PR TITLE
Stop the proration doc implying a recurring co-terminated charge

### DIFF
--- a/services/marketplace-api/internal/billing/appaddon/proration.go
+++ b/services/marketplace-api/internal/billing/appaddon/proration.go
@@ -1,5 +1,18 @@
-// Package appaddon computes the co-termination proration for the white-label
-// mobile app add-on (spec §3.4) and exposes the Pro-gated purchase endpoint.
+// Package appaddon computes the up-front charge for the white-label mobile
+// app add-on (spec §3.4) and exposes the Pro-gated purchase endpoint.
+//
+// THE ADD-ON DOES NOT RECUR (#650). It is a one-time purchase: a single
+// Stripe invoice, after which the webhook flips has_white_label_app_add_on
+// and no billing code reads that flag again. There is no Stripe Price
+// object for it in either account, no subscription item, and no renewal
+// path anywhere in the tree.
+//
+// That matters here because the arithmetic below looks like it is setting
+// up a recurring co-terminated item, and it is not. The proration exists
+// only to make a mid-year purchase cost a fair fraction of the anchor year
+// it is bought into — it aligns the AMOUNT with the Pro anchor date, not a
+// future billing date. Nothing co-terminates, because there is no second
+// charge to co-terminate with.
 //
 // This file is pure math — no I/O, no database, no Stripe calls.
 package appaddon
@@ -8,8 +21,9 @@ import "time"
 
 // Pricing constants, per spec §3.4:
 //
-//   - App subscription : $199 / month × 12 months = $2388 / year
-//   - Setup fee        : $2000 one-time, payable at add-on purchase regardless
+//   - App fee   : $199 / month × 12 months = $2388, quoted as an annual
+//     figure and charged ONCE, prorated — not billed monthly or yearly
+//   - Setup fee : $2000 one-time, payable at add-on purchase regardless
 //     of proration
 //
 // Amounts are in USD cents (int64) to avoid floating-point rounding drift.
@@ -37,8 +51,10 @@ const (
 //   - If remaining > 365 (e.g. a just-renewed anchor), it's clamped to 365
 //     so we never charge for more than one anchor year.
 //   - If remaining == 0 (buying on the exact renewal day), the caller pays
-//     only the setup fee and the add-on co-terminates on the same day as
-//     the upcoming renewal, bundling into the next invoice.
+//     only the setup fee: there is no anchor year left to buy into, so the
+//     prorated component is zero. Nothing is deferred to a later invoice —
+//     this sentence previously said the add-on "bundles into the next
+//     invoice", which describes a charge that does not exist (#650).
 //
 // Rounding: half-to-nearest-even on the prorated component before the setup
 // fee is added. The setup fee is added as-is.
@@ -56,8 +72,8 @@ func ProrationCents(now, renewalAt time.Time) int64 {
 }
 
 // roundHalfEven rounds a float64 to the nearest int64 using banker's
-// rounding (round-half-to-even). Used by ProrationCents so cumulative
-// error is bounded across many co-terminated renewals.
+// rounding (round-half-to-even). Used by ProrationCents so rounding error
+// does not bias one way across many purchases.
 func roundHalfEven(x float64) int64 {
 	floor := int64(x)
 	frac := x - float64(floor)

--- a/services/marketplace-api/internal/billing/pricing/display_extras.go
+++ b/services/marketplace-api/internal/billing/pricing/display_extras.go
@@ -79,7 +79,15 @@ var FallbackComment = map[Plan]map[string]string{}
 // ProAppMonthly and ProAppAnnual are the Pro+App add-on's single global
 // price, per spec §4.1.2: billed in USD only, everywhere. There is no
 // Stripe Price object for it — no PlanProApp constant exists in catalog.go —
-// so it cannot be derived from the catalog. The TS table nonetheless
+// so it cannot be derived from the catalog.
+//
+// That absence is INTENDED, not a gap (#650): the add-on is a one-time
+// purchase billed through a single invoice, and a one-off charge needs no
+// Price object. These two constants are display and proration inputs, not
+// a subscription's price. See internal/billing/appaddon for the decision
+// and what the proration is actually for.
+//
+// The TS table nonetheless
 // repeats this same figure across every display currency (DisplayCurrencyOrder)
 // for a consistent card layout; the display layer annotates "billed in USD"
 // for non-USD viewers. The $2,000 setup fee is a separate one-off charge,


### PR DESCRIPTION
Closes #650.

The last item on that issue. #738 fixed the merchant-facing half — the purchase page no longer promises a "Next full-year charge" — and added tests pinning that no recurring charge is claimed. What it did not reach was the Go side, and that is where #650 predicted the next reader would go wrong:

> *"`ProrationCents`' own doc says buying on the renewal day means the add-on 'co-terminates on the same day as the upcoming renewal, **bundling into the next invoice**'. That sentence only makes sense if something recurs — and nothing does."*

Still true on main until this. Three places in `internal/billing/appaddon/proration.go` described a recurring co-terminated item:

- the package doc opened with *"computes the co-termination proration"*
- the pricing constants were labelled *"App subscription: $199 / month × 12 months"*
- `roundHalfEven` justified banker's rounding as bounding error *"across many co-terminated renewals"* — plural renewals, of which there are none

## What changed

Comments only. No behaviour, no constants, no arithmetic — `go test ./...` is unchanged and green.

The package doc now states the decision up front: the add-on is a one-time purchase, a single invoice, no Stripe Price object, no subscription item, no renewal path. It then says the thing that actually stops the rediscovery — **why the maths still looks recurring**: the proration aligns the *amount* with the Pro anchor date, not a future billing date, and nothing co-terminates because there is no second charge to co-terminate with.

The `remaining == 0` branch keeps its explanation but drops the deferred-invoice claim, and says explicitly that the old sentence described a charge that does not exist, so a reader comparing against git history sees why it went.

`display_extras.go` gains a short note for the same reason: its comment correctly records that no Stripe Price object exists, which reads as a gap. It is the intended state for a one-off charge, and now says so with a pointer to `appaddon` for the decision.

The remaining mentions of "renewal" in that package are deliberate and correct — they refer to the *Pro subscription's* anchor date, which really does renew and really is what the add-on is priced against.

## Verification

`gofmt`, `go build`, `go vet` and the full unit suite clean. Integration tests not run locally — another session is active in this workspace and the test DB is shared — though this change touches no code paths.
