### PR TITLE
Ingest promo code definitions from the console catalog

### DIFF
--- a/.planning/quick/260906-pi-promo-catalog-ingest/PLAN.md
+++ b/.planning/quick/260906-pi-promo-catalog-ingest/PLAN.md
@@ -1,0 +1,109 @@
+# Ingest the console's promo catalog
+
+Step 2 of #726. Step 1 (#742) made `promo_codes` able to hold what the console
+publishes. This fetches it and populates the table.
+
+Decision already taken (#726): the console owns promo definitions; mark8ly
+consumes them and never mints. Do not add a local create path.
+
+## Why rows, not just a cache
+
+`promo_redemptions.promo_code_id` is `NOT NULL REFERENCES promo_codes(id)`
+(migration 000061). A redemption must point at a real row, so an in-memory
+cache of the catalog is not sufficient — the codes have to land in the table.
+
+## Reuse, do not reinvent
+
+`internal/billing/consolecatalog` already does exactly this shape for the plan
+catalog: OAuth client-credentials token, fetch, cache with TTL, fail-open to
+last-known, compiled fallback. Mirror it. Read `client.go` and `cache.go`
+before writing anything.
+
+**Credentials are shared, only the URL differs.** The console gates the route
+on the `read-promo-catalog` capability, which rides in the token's roles claim
+— the same machine identity can hold both capabilities. So reuse
+`CONSOLE_CATALOG_TOKEN_URL` / `CLIENT_ID` / `CLIENT_SECRET` / `SCOPE` / `MODE`
+and add only a URL, e.g. `CONSOLE_PROMO_CATALOG_URL`. Do NOT provision a
+second OAuth client.
+
+Follow `Config.Configured()`'s precedent: unconfigured is a SUPPORTED state,
+not an error. With no URL set, the ingest is skipped and the service starts
+normally.
+
+## The contract (from the console route's own doc)
+
+    { source, mode, revision_id, codes: [ {
+        code, trial_extension_days,          // null when it extends no trial
+        discount: {                          // null for trial-extension-only
+          kind: "percent_off" | "amount_off",
+          percent_off, amount_off_minor, currency,
+          duration: "once"|"repeating"|"forever",
+          duration_in_months,                // null unless repeating
+          stripe_coupon_id                   // KEY ABSENT when not minted in mode
+        },
+        valid_from, valid_until, max_redemptions } ] }
+
+## Mapping — put this in a PURE function and test it directly
+
+| console | promo_codes |
+|---|---|
+| `code` | `code` |
+| `trial_extension_days` | `trial_extension_days` |
+| `discount.percent_off` (numeric, e.g. 50.00) | `discount_type='percentage'`, `discount_value` in **basis points** (50.00 -> 5000) |
+| `discount.amount_off_minor` | `discount_type='amount'`, `discount_value` = minor units |
+| `discount.duration` / `duration_in_months` | `max_duration_months`: `forever` -> NULL, `once` -> 1, `repeating` -> `duration_in_months` |
+| `discount.stripe_coupon_id` | `stripe_coupon_id`, NULL when the key is absent |
+| `valid_from` / `valid_until` / `max_redemptions` | same |
+| — | `created_by` = a system marker naming the console as source |
+
+Percent conversion is the easiest thing to get wrong: `numeric(5,2)` -> basis
+points is x100, and 33.33 must become 3333 without float drift. Parse as a
+decimal string, not a float64.
+
+Leave `max_per_email` (default 1), `min_effective_price_per_currency`,
+`allowed_plans` and `annual_only` alone — the console cannot express them and
+mark8ly's defaults are the current policy (flagged on #726, not decided).
+
+## Sync semantics
+
+- **Upsert on `code`** (it has a unique index). A re-sync updates in place.
+- **A code withdrawn from the catalog is EXPIRED, never deleted.** Set
+  `valid_until = now()` where it is currently null or later. `Validate` already
+  honours `valid_until` (`validator.go:88`), and `promo_redemptions` FKs to
+  these rows, so deleting would break an audit trail and could fail on the FK.
+- **A code that fails mapping must not abort the batch.** Log it, count it,
+  continue. One malformed row must not block every other code.
+- Reject anything the DB would reject anyway (no benefit at all, a partial
+  discount) at the mapping step, with a clear reason — a constraint violation
+  surfacing as a raw pg error is a worse diagnostic.
+
+## Running it
+
+At boot and on an interval, mirroring how the plan catalog is refreshed. Nil
+and unconfigured must both be safe. Failure to reach the console must never
+fail startup — the previously-ingested rows remain valid.
+
+Add a metric for codes ingested / skipped / expired, labelled by reason.
+
+## Out of scope
+
+- Redemption itself and the onboarding field (#620).
+- Attaching the coupon at redeem time — needs `Coupons: Read` on the Stripe
+  key, which is not yet granted.
+- Any local promo-code creation.
+
+## Done when
+
+- The mapper is a pure function with tests covering: percent, amount,
+  trial-only, absent coupon id, each duration, and each rejection
+- A withdrawn code is expired, not deleted
+- Unconfigured is a no-op and the service still starts
+- `go build ./...`, `go vet` (plain and `-tags integration`), `go test` green
+
+## Constraints
+
+- One atomic commit, single-line conventional message, NO attribution.
+- SHARED CHECKOUT: no checkout/switch/stash/reset beyond this branch.
+- `TEST_DATABASE_URL` is unset here; integration tests skip silently while
+  printing `ok`. Make the mapper unit-testable without a DB and report
+  honestly what ran.

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1058,6 +1058,17 @@ func main() {
 		// See catalog_admin_resolve.go.
 		startAdminCatalogResolve(m, cfg, log)
 
+		// #726 step 2 — ingest the console's promo-code definitions.
+		//
+		// Unlike the plan catalog above, this one WRITES: a redemption's
+		// promo_code_id is a foreign key into promo_codes, so the
+		// definitions have to exist as rows. Boot plus a ticker, entirely on
+		// its own goroutine — unconfigured or unreachable, the service
+		// starts identically and promo_codes is left alone. It carries its
+		// own m.RunsAdmin() gate for the same reason the resolve above does.
+		// See promo_ingest.go.
+		startPromoCatalogIngest(m, cfg, conn, log)
+
 		subscriptionSvc := subscription.NewService(subscription.ServiceConfig{
 			DB:     conn,
 			Repo:   subscriptionRepo,

--- a/services/marketplace-api/cmd/marketplace-api/promo_ingest.go
+++ b/services/marketplace-api/cmd/marketplace-api/promo_ingest.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/consolepromo"
+	"github.com/mark8ly/marketplace-api/internal/mode"
+	"github.com/mark8ly/marketplace-api/pkg/config"
+)
+
+// promoIngestTimeout bounds one sync's work. Same reasoning as checkTimeout
+// in catalog_parity.go: nothing waits on the outcome, so it can be generous,
+// but it must be bounded or a hung console pins this goroutine forever.
+const promoIngestTimeout = 30 * time.Second
+
+// promoIngestLogMsg is the greppable marker for one completed ingest.
+const promoIngestLogMsg = "consolepromo: promo catalog ingest"
+
+// promoMetricsOnce guards the process-global metric registration below.
+var promoMetricsOnce sync.Once
+
+// startPromoCatalogIngest pulls the console's promo-code definitions into
+// promo_codes at boot and on a ticker (#726 step 2). It returns whether it
+// started a goroutine, which is what the wiring tests assert.
+//
+// # Why rows in a table rather than a cache
+//
+// promo_redemptions.promo_code_id is NOT NULL REFERENCES promo_codes(id), so
+// a redemption must point at a real row. Unlike the plan catalog, this one
+// cannot live in memory. See the consolepromo package doc.
+//
+// # Why the admin pod
+//
+// The promo surfaces are admin-side (internal/handlers/admin/promo.go), and
+// #620's redemption lands there too. Running the ingest on the storefront
+// would double the console's read load and double the writers to one table
+// for a path that pod never takes. Asked through RunsAdmin rather than by
+// comparing mode constants, so it cannot drift from what is actually wired.
+//
+// # Unconfigured is a supported state, not a degraded one
+//
+// No URL means one log line, no goroutine, no metrics registered, and
+// behaviour identical to before this existed. Nor can a configured-but-
+// unreachable console fail startup: the first sync happens inside the
+// goroutine, its failure is logged and counted, and any rows a previous
+// ingest wrote stay exactly as they are. Nothing on a startup path waits on
+// the console.
+func startPromoCatalogIngest(m mode.Mode, cfg *config.Config, db *gorm.DB, log *slog.Logger) bool {
+	if !m.RunsAdmin() || db == nil {
+		return false
+	}
+
+	cc := consolepromo.Config{
+		CatalogURL:   cfg.ConsolePromoCatalogURL,
+		TokenURL:     cfg.ConsoleCatalogTokenURL,
+		ClientID:     cfg.ConsoleCatalogClientID,
+		ClientSecret: cfg.ConsoleCatalogClientSecret,
+		Scope:        cfg.ConsoleCatalogScope,
+		Mode:         cfg.ConsoleCatalogMode,
+	}
+	if !cc.Configured() {
+		log.Info("consolepromo: promo catalog ingest disabled (no CONSOLE_PROMO_CATALOG_URL " +
+			"or console credentials); promo_codes is left exactly as it is")
+		return false
+	}
+
+	interval := cfg.ConsoleCatalogInterval
+	if interval <= 0 {
+		interval = 15 * time.Minute
+	}
+
+	// After the gate, for the reason given on MustRegisterMetrics: a
+	// LastSuccessTimestamp published at zero on a pod that deliberately does
+	// not ingest would read as "last ingested in 1970" forever.
+	//
+	// Through a Once because registration is a process-global side effect
+	// while this function is otherwise pure wiring: production calls it once,
+	// but the mode-matrix test calls it several times and a duplicate
+	// registration panics. The Once removes that coupling without weakening
+	// the rule above — the first call still happens only after the gate.
+	promoMetricsOnce.Do(func() {
+		consolepromo.MustRegisterMetrics(prometheus.DefaultRegisterer)
+	})
+
+	syncer := consolepromo.NewSyncer(
+		consolepromo.NewClient(cc, log), consolepromo.NewStore(db), log)
+
+	log.Info("consolepromo: promo catalog ingest enabled",
+		"mode", cc.Mode, "interval", interval.String())
+
+	go func() {
+		syncOnceAndLog(syncer, log)
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for range t.C {
+			syncOnceAndLog(syncer, log)
+		}
+	}()
+	return true
+}
+
+// syncOnceAndLog performs one ingest and reports it. It never returns an
+// error: a failed ingest is a logged, counted event, not something any
+// caller here can act on — the correct response to an unreadable catalog is
+// to change nothing and try again on the next tick.
+func syncOnceAndLog(s *consolepromo.Syncer, log *slog.Logger) consolepromo.Result {
+	return syncWithin(promoIngestTimeout, s, log)
+}
+
+// syncWithin is syncOnceAndLog with the deadline as a parameter, so a test
+// can prove the deadline reaches the fetcher without waiting out the
+// production one.
+func syncWithin(timeout time.Duration, s *consolepromo.Syncer, log *slog.Logger) consolepromo.Result {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	res, err := s.Sync(ctx)
+	if err != nil {
+		consolepromo.SyncFailuresTotal.Inc()
+		if log != nil {
+			log.Warn(promoIngestLogMsg+" failed; promo_codes is unchanged", "error", err)
+		}
+		return res
+	}
+	if log != nil {
+		log.Info(promoIngestLogMsg,
+			"revision_id", res.RevisionID,
+			"ingested", res.Ingested,
+			"skipped", res.Skipped,
+			"expired", res.Expired)
+	}
+	return res
+}

--- a/services/marketplace-api/cmd/marketplace-api/promo_ingest_test.go
+++ b/services/marketplace-api/cmd/marketplace-api/promo_ingest_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/consolepromo"
+	"github.com/mark8ly/marketplace-api/internal/mode"
+	"github.com/mark8ly/marketplace-api/internal/promo"
+	"github.com/mark8ly/marketplace-api/pkg/config"
+)
+
+// promoConfiguredCfg is configuredCfg plus the one new setting the promo
+// ingest needs. 127.0.0.1:1 is refused immediately, so the goroutine this
+// starts cannot sit on a real network call for the length of the test.
+func promoConfiguredCfg() *config.Config {
+	cfg := configuredCfg()
+	cfg.ConsolePromoCatalogURL = "http://127.0.0.1:1/api/v1/billing/promo-catalog"
+	return cfg
+}
+
+// TestPromoIngestUnconfigured pins the contract the plan required: with no
+// URL set the ingest is skipped, no goroutine runs, promo_codes is untouched,
+// and the service starts exactly as it did before this existed.
+func TestPromoIngestUnconfigured(t *testing.T) {
+	log, h := captureLogger()
+
+	started := startPromoCatalogIngest(mode.Admin, &config.Config{}, &gorm.DB{}, log)
+
+	require.False(t, started, "no CONSOLE_PROMO_CATALOG_URL must mean no goroutine")
+	_, ok := h.find("promo catalog ingest disabled")
+	require.True(t, ok, "unconfigured must say so exactly once, clearly: %v", h.all())
+}
+
+// TestPromoIngestCredentialsAloneAreNotEnough — the credentials are shared
+// with the plan catalog, so a pod configured for that one must NOT start
+// ingesting promos as a side effect. The promo URL is the switch.
+func TestPromoIngestCredentialsAloneAreNotEnough(t *testing.T) {
+	log, _ := captureLogger()
+
+	cfg := configuredCfg() // plan-catalog credentials, no promo URL
+	require.False(t, startPromoCatalogIngest(mode.Admin, cfg, &gorm.DB{}, log))
+}
+
+// TestPromoIngestNeedsADatabase — this ingest writes rows, so without a
+// connection there is nothing it can usefully do. Skipping is silent because
+// a nil db means the process is not in a state where the ingest is even
+// applicable.
+func TestPromoIngestNeedsADatabase(t *testing.T) {
+	log, h := captureLogger()
+
+	require.False(t, startPromoCatalogIngest(mode.Admin, promoConfiguredCfg(), nil, log))
+	require.Empty(t, h.all())
+}
+
+// TestPromoIngestModeMatrix states the matrix implemented:
+//
+//	admin      -> started (the promo surfaces and #620's redemption are here)
+//	storefront -> not started
+//	both       -> started (local dev runs everything)
+//
+// The storefront case asserts SILENCE rather than a "disabled" line: there
+// the ingest is not disabled, it is not applicable, and a line claiming
+// otherwise would send someone hunting for credentials that pod is right not
+// to use.
+func TestPromoIngestModeMatrix(t *testing.T) {
+	for _, tc := range []struct {
+		m    mode.Mode
+		want bool
+	}{
+		{mode.Admin, true},
+		{mode.Storefront, false},
+		{mode.Both, true},
+	} {
+		t.Run(string(tc.m), func(t *testing.T) {
+			log, h := captureLogger()
+
+			got := startPromoCatalogIngest(tc.m, promoConfiguredCfg(), &gorm.DB{}, log)
+
+			require.Equal(t, tc.want, got)
+			if tc.want {
+				_, ok := h.find("promo catalog ingest enabled")
+				require.True(t, ok, "an enabled ingest must announce itself: %v", h.all())
+			} else {
+				require.Empty(t, h.all(), "a mode that does not ingest must log nothing")
+			}
+		})
+	}
+}
+
+// stubPromoFetcher is a consolepromo.Fetcher the test controls.
+type stubPromoFetcher struct {
+	cat consolepromo.Catalog
+	err error
+}
+
+func (f *stubPromoFetcher) Fetch(context.Context) (consolepromo.Catalog, error) {
+	return f.cat, f.err
+}
+
+// stubPromoStore accepts everything and records nothing; these tests are
+// about what gets LOGGED, which is the whole product of this file.
+type stubPromoStore struct{}
+
+func (stubPromoStore) UpsertCodes(context.Context, []promo.PromoCode) error { return nil }
+func (stubPromoStore) ExpireCodesNotIn(context.Context, []string, time.Time) (int, error) {
+	return 2, nil
+}
+
+func TestSyncOnceLogsTheOutcome(t *testing.T) {
+	log, h := captureLogger()
+	f := &stubPromoFetcher{cat: consolepromo.Catalog{
+		RevisionID: "rev-9",
+		Codes: []consolepromo.Code{
+			{Code: "EXTRA14DAYS", TrialExtensionDays: intPtr(14)},
+			{Code: "BAD"}, // too short and no benefit — skipped, not fatal
+		},
+	}}
+
+	res := syncOnceAndLog(consolepromo.NewSyncer(f, stubPromoStore{}, log), log)
+
+	require.Equal(t, 1, res.Ingested)
+	require.Equal(t, 1, res.Skipped)
+	require.Equal(t, 2, res.Expired)
+
+	rec, ok := h.find(promoIngestLogMsg)
+	require.True(t, ok, "a completed ingest must log: %v", h.all())
+	attrs := attrsOf(rec)
+	require.Equal(t, "rev-9", attrs["revision_id"])
+	require.Equal(t, int64(1), attrs["ingested"])
+	require.Equal(t, int64(1), attrs["skipped"])
+}
+
+// TestSyncOnceLogsAFailureAndSaysNothingChanged — the failure line has to
+// state the consequence, because "ingest failed" alone reads as data loss to
+// whoever finds it at 3am. Nothing changed is the whole point.
+func TestSyncOnceLogsAFailureAndSaysNothingChanged(t *testing.T) {
+	log, h := captureLogger()
+	f := &stubPromoFetcher{err: errors.New("console down")}
+
+	res := syncOnceAndLog(consolepromo.NewSyncer(f, stubPromoStore{}, log), log)
+
+	require.Zero(t, res.Ingested)
+	rec, ok := h.find("promo_codes is unchanged")
+	require.True(t, ok, "a failed ingest must say what it did NOT do: %v", h.all())
+	logged, ok := attrsOf(rec)["error"].(error)
+	require.True(t, ok, "the failure line must carry the error itself")
+	require.Contains(t, logged.Error(), "console down")
+}
+
+func intPtr(v int) *int { return &v }

--- a/services/marketplace-api/internal/billing/consolepromo/catalog.go
+++ b/services/marketplace-api/internal/billing/consolepromo/catalog.go
@@ -1,0 +1,107 @@
+// Package consolepromo ingests promo-code DEFINITIONS from the tesserix-home
+// console into this service's promo_codes table (#726 step 2).
+//
+// # Why rows and not a cache
+//
+// The obvious shape for "read a catalog from the console" is the one
+// internal/billing/consolecatalog uses: fetch, cache, serve from memory,
+// fall open to something older. That is not sufficient here.
+// promo_redemptions.promo_code_id is NOT NULL REFERENCES promo_codes(id)
+// (migration 000061), so a redemption must point at a real row. The codes
+// have to land in the table; an in-memory catalog could never be redeemed
+// against.
+//
+// So this package is deliberately consolecatalog's shape for the transport
+// (the same OAuth client-credentials token, the same fetch-with-ETag, the
+// same "unconfigured is a supported state") with a database write where
+// consolecatalog has a cache.
+//
+// # Direction of ownership
+//
+// The console owns promo definitions; mark8ly consumes them and never mints
+// one (#726). There is intentionally no local create path here.
+package consolepromo
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Catalog is the console's published promo catalog. The shape is a contract
+// owned by the console: additive changes only.
+type Catalog struct {
+	Source     string `json:"source"`
+	Mode       string `json:"mode"`
+	RevisionID string `json:"revision_id"`
+	Codes      []Code `json:"codes"`
+}
+
+// Code is one published promo definition.
+//
+// Every optional field is a pointer or a json.Number rather than a plain
+// value, because for each of them the zero value is a legitimate reading
+// that must not be confused with absence: max_redemptions 0 would mean "no
+// redemptions permitted" while absent means "unlimited", and
+// trial_extension_days 0 would mean "extends the trial by nothing" while
+// absent means "extends no trial".
+type Code struct {
+	Code string `json:"code"`
+	// TrialExtensionDays is nil when the code extends no trial.
+	TrialExtensionDays *int `json:"trial_extension_days"`
+	// Discount is nil for a trial-extension-only code.
+	Discount *Discount `json:"discount"`
+	// ValidFrom is nil when the console did not bound the start; the mapper
+	// then uses the ingest time, matching the column's own DEFAULT now().
+	ValidFrom *time.Time `json:"valid_from"`
+	// ValidUntil is nil for a code with no end date.
+	ValidUntil *time.Time `json:"valid_until"`
+	// MaxRedemptions is nil for unlimited global redemptions.
+	MaxRedemptions *int `json:"max_redemptions"`
+}
+
+// Discount is the money part of a promo definition.
+type Discount struct {
+	// Kind is DiscountKindPercentOff or DiscountKindAmountOff.
+	Kind string `json:"kind"`
+	// PercentOff arrives as the console's numeric(5,2) — "50.00", "33.33".
+	//
+	// It is a json.Number, NOT a float64, and that is load-bearing.
+	// promo_codes.discount_value holds basis points, so this has to be
+	// multiplied by 100; doing that through a binary float eventually lands
+	// on 3332 or 3334 for 33.33. json.Number keeps the literal digits so the
+	// conversion can be done exactly, as decimal string arithmetic. Empty
+	// means the key was absent or null.
+	PercentOff json.Number `json:"percent_off"`
+	// AmountOffMinor is minor units of Currency. Nil when the discount is
+	// not an amount-off.
+	AmountOffMinor *int64 `json:"amount_off_minor"`
+	// Currency names AmountOffMinor's currency. promo_codes has no currency
+	// column — discount_value for an amount code is read in the store's
+	// billing currency (000060) — so this is carried for diagnostics and
+	// deliberately not mapped. Widening the table to hold it is #726's open
+	// question, not this ingest's.
+	Currency string `json:"currency"`
+	// Duration is DurationOnce, DurationRepeating or DurationForever.
+	Duration string `json:"duration"`
+	// DurationInMonths is set only when Duration is DurationRepeating.
+	DurationInMonths *int `json:"duration_in_months"`
+	// StripeCouponID is nil when the KEY IS ABSENT, which is how the console
+	// reports "no coupon minted in this Stripe mode" — distinct from a
+	// present-but-empty string, which is malformed and rejected by the
+	// mapper. Absent maps to a NULL column (migration 000131 made it
+	// nullable precisely for this).
+	StripeCouponID *string `json:"stripe_coupon_id"`
+}
+
+// Discount kinds the console publishes.
+const (
+	DiscountKindPercentOff = "percent_off"
+	DiscountKindAmountOff  = "amount_off"
+)
+
+// Discount durations the console publishes.
+const (
+	DurationOnce      = "once"
+	DurationRepeating = "repeating"
+	DurationForever   = "forever"
+)

--- a/services/marketplace-api/internal/billing/consolepromo/client.go
+++ b/services/marketplace-api/internal/billing/consolepromo/client.go
@@ -1,0 +1,216 @@
+package consolepromo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ErrUnavailable signals the console could not be reached or answered 5xx.
+//
+// It must never be treated as an empty catalog: "we could not ask" and
+// "there are no promo codes" are different answers, and conflating them here
+// would expire every console-sourced code in the table on the first network
+// blip.
+var ErrUnavailable = errors.New("consolepromo: console unavailable")
+
+// ErrNotPublished signals the mode has never been published (404). Like
+// ErrUnavailable it is not an empty catalog, and for the same reason.
+var ErrNotPublished = errors.New("consolepromo: mode has never been published")
+
+// maxBody caps what we will read from the console.
+const maxBody = 4 << 20
+
+// tokenSkew renews a token this long before it actually expires, so a fetch
+// cannot lose a race with expiry mid-flight.
+const tokenSkew = 60 * time.Second
+
+// Config is everything needed to read one mode's promo catalog.
+//
+// # Only the URL is new
+//
+// Every credential here is the one internal/billing/consolecatalog already
+// uses. The console gates the promo route on the `read-promo-catalog`
+// capability, which rides in the token's roles claim, and one machine
+// identity can hold that capability alongside the plan catalog's — so a
+// second OAuth client would be a second thing to rotate, expire and get
+// wrong for no gain. main.go builds this from the same CONSOLE_CATALOG_*
+// settings plus CONSOLE_PROMO_CATALOG_URL.
+type Config struct {
+	CatalogURL   string
+	TokenURL     string
+	ClientID     string
+	ClientSecret string
+	// Scope must include both the project-audience scope and the roles
+	// scope; see consolecatalog.Config.Scope for why both are load-bearing.
+	Scope string
+	Mode  string
+}
+
+// Configured reports whether enough is set to attempt a read.
+//
+// An unconfigured client is a SUPPORTED state, not an error: no URL means no
+// ingest, the service starts exactly as it did before this existed, and any
+// rows a previous ingest wrote stay valid. This mirrors
+// consolecatalog.Config.Configured deliberately — enabling and disabling the
+// ingest is a config change with no second code path.
+func (c Config) Configured() bool {
+	return c.CatalogURL != "" && c.TokenURL != "" && c.ClientID != "" && c.ClientSecret != ""
+}
+
+// Fetcher is the console read the Syncer needs. Narrow on purpose: it is
+// what lets the sync logic be tested without a network.
+type Fetcher interface {
+	Fetch(ctx context.Context) (Catalog, error)
+}
+
+// Client reads one mode's promo catalog from the console.
+//
+// It retains the last successful body and its ETag so a 304 can be answered
+// from memory. That retention is not an optimisation: a 304 carries no body,
+// and answering one with an empty catalog would expire every code.
+type Client struct {
+	cfg    Config
+	http   *http.Client
+	logger *slog.Logger
+
+	mu       sync.Mutex
+	token    string
+	tokenExp time.Time
+	etag     string
+	lastGood Catalog
+	haveCat  bool
+}
+
+// NewClient builds a Client. It performs no I/O.
+func NewClient(cfg Config, logger *slog.Logger) *Client {
+	return &Client{
+		cfg:    cfg,
+		http:   &http.Client{Timeout: 10 * time.Second},
+		logger: logger,
+	}
+}
+
+// Fetch returns the console's current promo catalog for the configured mode.
+//
+// It returns an error rather than degrading; how to degrade is the caller's
+// decision, and here the caller's degradation is simply "change nothing",
+// which is the safest possible response to an unreadable catalog.
+//
+// # One deliberate difference from consolecatalog.Client
+//
+// A 200 carrying zero codes is ACCEPTED here, where consolecatalog treats it
+// as a contract violation. The reasoning differs because the data differs: a
+// mode with no prices cannot sell anything, so an empty price list is
+// necessarily a bug; a mode with no promo codes is an ordinary state that
+// every deployment starts in and returns to whenever the last campaign ends.
+// Refusing it would make "no campaigns running" indistinguishable from an
+// outage.
+func (c *Client) Fetch(ctx context.Context) (Catalog, error) {
+	tok, err := c.accessToken(ctx)
+	if err != nil {
+		return Catalog{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		c.cfg.CatalogURL+"?mode="+url.QueryEscape(c.cfg.Mode), nil)
+	if err != nil {
+		return Catalog{}, fmt.Errorf("consolepromo: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	c.mu.Lock()
+	etag, lastGood, have := c.etag, c.lastGood, c.haveCat
+	c.mu.Unlock()
+	if etag != "" && have {
+		req.Header.Set("If-None-Match", etag)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return Catalog{}, fmt.Errorf("%w: %v", ErrUnavailable, err)
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	switch {
+	case resp.StatusCode == http.StatusNotModified:
+		if !have {
+			// Impossible by construction — If-None-Match is only sent when a
+			// body is held — but answering with an empty catalog would
+			// expire every code, so refuse instead.
+			return Catalog{}, fmt.Errorf("%w: 304 with no retained catalog", ErrUnavailable)
+		}
+		return lastGood, nil
+	case resp.StatusCode == http.StatusNotFound:
+		return Catalog{}, ErrNotPublished
+	case resp.StatusCode != http.StatusOK:
+		return Catalog{}, fmt.Errorf("%w: status %d", ErrUnavailable, resp.StatusCode)
+	}
+
+	var out Catalog
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxBody)).Decode(&out); err != nil {
+		return Catalog{}, fmt.Errorf("consolepromo: decode: %w", err)
+	}
+
+	c.mu.Lock()
+	c.etag = resp.Header.Get("ETag")
+	c.lastGood, c.haveCat = out, true
+	c.mu.Unlock()
+	return out, nil
+}
+
+func (c *Client) accessToken(ctx context.Context) (string, error) {
+	c.mu.Lock()
+	if c.token != "" && time.Now().Before(c.tokenExp.Add(-tokenSkew)) {
+		tok := c.token
+		c.mu.Unlock()
+		return tok, nil
+	}
+	c.mu.Unlock()
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_id", c.cfg.ClientID)
+	form.Set("client_secret", c.cfg.ClientSecret)
+	form.Set("scope", c.cfg.Scope)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("consolepromo: build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("%w: token: %v", ErrUnavailable, err)
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%w: token status %d", ErrUnavailable, resp.StatusCode)
+	}
+
+	var body struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxBody)).Decode(&body); err != nil {
+		return "", fmt.Errorf("consolepromo: decode token: %w", err)
+	}
+	if body.AccessToken == "" {
+		return "", fmt.Errorf("%w: token response carried no access_token", ErrUnavailable)
+	}
+
+	c.mu.Lock()
+	c.token = body.AccessToken
+	c.tokenExp = time.Now().Add(time.Duration(body.ExpiresIn) * time.Second)
+	c.mu.Unlock()
+	return body.AccessToken, nil
+}

--- a/services/marketplace-api/internal/billing/consolepromo/mapper.go
+++ b/services/marketplace-api/internal/billing/consolepromo/mapper.go
@@ -1,0 +1,322 @@
+package consolepromo
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/promo"
+)
+
+// CreatedBy is written to promo_codes.created_by for every row this ingest
+// writes. It is the marker that says a row's definition lives in the console
+// and will be overwritten from there on the next sync.
+//
+// It is also the scope of the expiry sweep: only rows carrying this marker
+// are ever expired for being absent from the catalog, so a code created by
+// any other path is untouched by this package.
+const CreatedBy = "console:promo-catalog"
+
+// DefaultMaxPerEmail is written explicitly rather than left to the column
+// default.
+//
+// The console cannot express a per-email limit, so mark8ly's own policy
+// applies (§7.3; flagged on #726, not changed here). Writing it explicitly
+// rather than relying on promo_codes.max_per_email DEFAULT 1 is deliberate:
+// the field is a plain int on the model, and an int zero handed to the
+// database would mean "this code may never be redeemed by anyone" — a
+// silently dead code rather than a visible error.
+const DefaultMaxPerEmail = 1
+
+// Code length bounds enforced by the schema: char_length(code) >= 4 from
+// migration 000131 (a console code is a human campaign code such as
+// "LAUNCH50", so promo.MinCodeLength's 12 cannot apply to it) and
+// varchar(64) from 000060.
+//
+// Both are checked here so a bad definition is rejected with a named reason
+// rather than surfacing as a raw Postgres constraint violation that takes
+// the whole batch's write with it.
+const (
+	minConsoleCodeLength = 4
+	maxConsoleCodeLength = 64
+)
+
+// Reason names why a code was rejected. It is a closed set because it is a
+// Prometheus label value; an unbounded reason string would make the metric a
+// cardinality bomb.
+type Reason string
+
+const (
+	ReasonCodeLength        Reason = "code_length"
+	ReasonNoBenefit         Reason = "no_benefit"
+	ReasonTrialExtension    Reason = "bad_trial_extension"
+	ReasonDiscountKind      Reason = "bad_discount_kind"
+	ReasonPercentOff        Reason = "bad_percent_off"
+	ReasonAmountOff         Reason = "bad_amount_off"
+	ReasonDuration          Reason = "bad_duration"
+	ReasonDurationInMonths  Reason = "bad_duration_in_months"
+	ReasonEmptyStripeCoupon Reason = "empty_stripe_coupon_id"
+	ReasonUnknown           Reason = "unknown"
+)
+
+// RejectedError is a mapping failure carrying the reason it happened.
+//
+// One malformed definition must never abort an ingest — the other codes in
+// the batch are fine and a merchant is waiting on them — so this is returned
+// per code and counted, never propagated as a batch failure.
+type RejectedError struct {
+	Reason Reason
+	Detail string
+}
+
+func (e *RejectedError) Error() string {
+	return fmt.Sprintf("consolepromo: rejected (%s): %s", e.Reason, e.Detail)
+}
+
+func reject(r Reason, format string, args ...any) error {
+	return &RejectedError{Reason: r, Detail: fmt.Sprintf(format, args...)}
+}
+
+// ReasonOf returns the Reason carried by err, or ReasonUnknown when err is
+// not a RejectedError. Metrics label on this, so it must always answer.
+func ReasonOf(err error) Reason {
+	if err == nil {
+		return ""
+	}
+	var re *RejectedError
+	if errors.As(err, &re) {
+		return re.Reason
+	}
+	return ReasonUnknown
+}
+
+// MapCode converts one published definition into the row this service
+// stores. It is a PURE function of (in, now): no database, no clock, no
+// network, no logging — which is what lets every branch below, including
+// every rejection, be tested directly.
+//
+// now supplies valid_from when the console did not bound the start, matching
+// the column's own DEFAULT now().
+//
+// It rejects, with a named reason, everything the database would reject
+// anyway — a code with no benefit at all, a half-specified discount, a code
+// outside the length bounds — because a mapper's error naming the offending
+// code is a far better diagnostic than a raw SQLSTATE 23514 arriving from a
+// batch insert with no indication of which row caused it.
+func MapCode(in Code, now time.Time) (promo.PromoCode, error) {
+	code := strings.TrimSpace(in.Code)
+	if n := len([]rune(code)); n < minConsoleCodeLength || n > maxConsoleCodeLength {
+		return promo.PromoCode{}, reject(ReasonCodeLength,
+			"code %q is %d characters; the schema allows %d..%d",
+			code, n, minConsoleCodeLength, maxConsoleCodeLength)
+	}
+
+	out := promo.PromoCode{
+		Code:        code,
+		MaxPerEmail: DefaultMaxPerEmail,
+		CreatedBy:   CreatedBy,
+		ValidUntil:  in.ValidUntil,
+		// MaxRedemptions nil means unlimited on both sides, so it passes
+		// through untouched.
+		MaxRedemptions: in.MaxRedemptions,
+	}
+
+	if in.ValidFrom != nil {
+		out.ValidFrom = *in.ValidFrom
+	} else {
+		out.ValidFrom = now
+	}
+
+	if in.TrialExtensionDays != nil {
+		days := *in.TrialExtensionDays
+		if days <= 0 {
+			// The console's own constraint is > 0, and so is
+			// promo_codes_trial_extension_days_positive. A zero here is a
+			// code that claims to extend a trial by nothing.
+			return promo.PromoCode{}, reject(ReasonTrialExtension,
+				"code %q: trial_extension_days is %d, which must be positive", code, days)
+		}
+		out.TrialExtensionDays = &days
+	}
+
+	if in.Discount != nil {
+		if err := applyDiscount(&out, code, *in.Discount); err != nil {
+			return promo.PromoCode{}, err
+		}
+	}
+
+	// promo_codes_has_benefit: a row must deliver SOMETHING. Without this a
+	// code would be accepted at redemption and do nothing at all.
+	if out.TrialExtensionDays == nil && out.DiscountType == nil {
+		return promo.PromoCode{}, reject(ReasonNoBenefit,
+			"code %q carries neither a discount nor a trial extension", code)
+	}
+
+	out.CreatedAt, out.UpdatedAt = now, now
+	return out, nil
+}
+
+// applyDiscount fills the discount half of the row. It writes DiscountType
+// and DiscountValue together or not at all, which is what
+// promo_codes_discount_pair requires.
+func applyDiscount(out *promo.PromoCode, code string, d Discount) error {
+	switch d.Kind {
+	case DiscountKindPercentOff:
+		bp, err := percentToBasisPoints(d.PercentOff)
+		if err != nil {
+			return reject(ReasonPercentOff, "code %q: %v", code, err)
+		}
+		t := promo.DiscountTypePercentage
+		out.DiscountType, out.DiscountValue = &t, &bp
+	case DiscountKindAmountOff:
+		if d.AmountOffMinor == nil {
+			return reject(ReasonAmountOff,
+				"code %q: kind is %q but amount_off_minor is absent", code, d.Kind)
+		}
+		if *d.AmountOffMinor <= 0 {
+			// promo_codes.discount_value CHECK (discount_value > 0).
+			return reject(ReasonAmountOff,
+				"code %q: amount_off_minor is %d, which must be positive", code, *d.AmountOffMinor)
+		}
+		if *d.AmountOffMinor > math.MaxInt32 {
+			// discount_value is a Postgres INTEGER, i.e. 32-bit, while the
+			// console publishes an unbounded JSON number. Checked against
+			// MaxInt32 rather than against Go's int, which is 64-bit here and
+			// would let the value through to fail as a raw 22003 at insert
+			// time — taking the batch's write with it.
+			return reject(ReasonAmountOff,
+				"code %q: amount_off_minor %d does not fit the discount_value integer column",
+				code, *d.AmountOffMinor)
+		}
+		v := int(*d.AmountOffMinor)
+		t := promo.DiscountTypeAmount
+		out.DiscountType, out.DiscountValue = &t, &v
+	default:
+		return reject(ReasonDiscountKind,
+			"code %q: discount kind %q is neither %q nor %q",
+			code, d.Kind, DiscountKindPercentOff, DiscountKindAmountOff)
+	}
+
+	months, err := durationToMonths(d)
+	if err != nil {
+		return reject(reasonForDuration(d), "code %q: %v", code, err)
+	}
+	out.MaxDurationMonths = months
+
+	coupon, err := couponID(d)
+	if err != nil {
+		return reject(ReasonEmptyStripeCoupon, "code %q: %v", code, err)
+	}
+	out.StripeCouponID = coupon
+	return nil
+}
+
+// couponID resolves stripe_coupon_id, distinguishing the three states the
+// key can be in.
+//
+// Absent (nil) is the documented "not minted in this Stripe mode" and maps
+// to a NULL column. Present-but-empty is neither of the console's two
+// legitimate answers, so it is rejected rather than quietly treated as
+// absent: an empty coupon id reaching the redemption path would be handed to
+// Stripe as a coupon named "".
+func couponID(d Discount) (*string, error) {
+	if d.StripeCouponID == nil {
+		return nil, nil
+	}
+	id := strings.TrimSpace(*d.StripeCouponID)
+	if id == "" {
+		return nil, fmt.Errorf("stripe_coupon_id is present but empty; " +
+			"omit the key entirely to mean \"no coupon minted in this mode\"")
+	}
+	return &id, nil
+}
+
+// durationToMonths maps the console's discount duration onto
+// promo_codes.max_duration_months: forever -> NULL (the column's own meaning
+// for unbounded), once -> 1, repeating -> duration_in_months.
+func durationToMonths(d Discount) (*int, error) {
+	switch d.Duration {
+	case DurationForever:
+		return nil, nil
+	case DurationOnce:
+		one := 1
+		return &one, nil
+	case DurationRepeating:
+		if d.DurationInMonths == nil {
+			return nil, fmt.Errorf("duration is %q but duration_in_months is absent", DurationRepeating)
+		}
+		if *d.DurationInMonths <= 0 {
+			return nil, fmt.Errorf("duration_in_months is %d, which must be positive", *d.DurationInMonths)
+		}
+		months := *d.DurationInMonths
+		return &months, nil
+	default:
+		return nil, fmt.Errorf("duration %q is not one of %q, %q, %q",
+			d.Duration, DurationOnce, DurationRepeating, DurationForever)
+	}
+}
+
+// reasonForDuration separates "the duration word itself is wrong" from "the
+// month count that goes with it is wrong", so the skip metric can tell a
+// console contract change apart from one badly-filled campaign.
+func reasonForDuration(d Discount) Reason {
+	if d.Duration == DurationRepeating {
+		return ReasonDurationInMonths
+	}
+	return ReasonDuration
+}
+
+// decimalPercent matches what numeric(5,2) can serialise: an unsigned
+// decimal with at most two fractional digits. Anything else — a sign, an
+// exponent, a third decimal place — is a contract violation, and guessing at
+// its intent is how a wrong discount reaches a customer.
+var decimalPercent = regexp.MustCompile(`^([0-9]{1,3})(?:\.([0-9]{1,2}))?$`)
+
+// percentToBasisPoints converts the console's numeric(5,2) percentage into
+// the basis points promo_codes.discount_value holds: 50.00 -> 5000,
+// 33.33 -> 3333, 7.5 -> 750.
+//
+// The conversion is done on the DECIMAL DIGITS, never through a float64.
+// 33.33 is not representable in binary floating point, so `int(f*100)` and
+// even `math.Round(f*100)` are one library change away from 3332 or 3334 —
+// a discount silently a hundredth of a percent off, on every redemption,
+// with nothing to notice it by. String arithmetic has no such failure mode.
+func percentToBasisPoints(n json.Number) (int, error) {
+	s := strings.TrimSpace(n.String())
+	if s == "" {
+		return 0, fmt.Errorf("kind is %q but percent_off is absent", DiscountKindPercentOff)
+	}
+	m := decimalPercent.FindStringSubmatch(s)
+	if m == nil {
+		return 0, fmt.Errorf("percent_off %q is not a plain decimal with at most "+
+			"two fractional digits, which is all numeric(5,2) can hold", s)
+	}
+	whole, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, fmt.Errorf("percent_off %q: %w", s, err)
+	}
+	// Pad rather than parse: ".5" is five tenths, i.e. 50 basis points, and
+	// parsing "5" as the fractional part would make it 5.
+	frac := 0
+	if m[2] != "" {
+		padded := (m[2] + "00")[:2]
+		if frac, err = strconv.Atoi(padded); err != nil {
+			return 0, fmt.Errorf("percent_off %q: %w", s, err)
+		}
+	}
+	bp := whole*100 + frac
+	if bp <= 0 {
+		// discount_value CHECK (discount_value > 0), and a zero-percent
+		// discount is a code that does nothing.
+		return 0, fmt.Errorf("percent_off %q is not positive", s)
+	}
+	if bp > 10000 {
+		return 0, fmt.Errorf("percent_off %q is more than 100%%", s)
+	}
+	return bp, nil
+}

--- a/services/marketplace-api/internal/billing/consolepromo/mapper_test.go
+++ b/services/marketplace-api/internal/billing/consolepromo/mapper_test.go
@@ -1,0 +1,499 @@
+package consolepromo
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/promo"
+)
+
+// now is a fixed instant. MapCode is pure in (in, now), so every assertion
+// below is exact rather than approximate.
+var now = time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+
+func ptr[T any](v T) *T { return &v }
+
+// mustMap fails the test when a definition that should map does not.
+func mustMap(t *testing.T, in Code) promo.PromoCode {
+	t.Helper()
+	got, err := MapCode(in, now)
+	if err != nil {
+		t.Fatalf("MapCode(%q): unexpected error: %v", in.Code, err)
+	}
+	return got
+}
+
+// TestMapCode_PercentOffToBasisPoints is the test this package exists for.
+//
+// promo_codes.discount_value is basis points and the console publishes
+// numeric(5,2), so every value here is a x100 conversion that MUST be exact.
+// 33.33 is the case that matters: it has no exact binary representation, so
+// a float64 round-trip is one optimisation away from 3332 or 3334 — a
+// discount silently wrong on every redemption, with nothing to notice it by.
+func TestMapCode_PercentOffToBasisPoints(t *testing.T) {
+	cases := []struct {
+		percent string
+		wantBP  int
+	}{
+		{"50.00", 5000},
+		{"33.33", 3333}, // the float-drift case
+		{"66.67", 6667},
+		{"0.01", 1}, // the smallest expressible discount
+		{"100.00", 10000},
+		{"7.5", 750},  // one decimal place: five tenths is 50bp, not 5
+		{"7.50", 750}, // and it means the same written out
+		{"10", 1000},  // no decimal point at all
+		{"99.99", 9999},
+		{"1.23", 123},
+	}
+	for _, tc := range cases {
+		t.Run(tc.percent, func(t *testing.T) {
+			got := mustMap(t, Code{
+				Code: "LAUNCH50",
+				Discount: &Discount{
+					Kind:           DiscountKindPercentOff,
+					PercentOff:     json.Number(tc.percent),
+					Duration:       DurationForever,
+					StripeCouponID: ptr("cpn_live_1"),
+				},
+			})
+			if got.DiscountType == nil || *got.DiscountType != promo.DiscountTypePercentage {
+				t.Fatalf("discount_type = %v, want percentage", got.DiscountType)
+			}
+			if got.DiscountValue == nil || *got.DiscountValue != tc.wantBP {
+				t.Fatalf("discount_value = %v, want %d basis points", got.DiscountValue, tc.wantBP)
+			}
+		})
+	}
+}
+
+// TestMapCode_PercentOffNeverGoesThroughAFloat pins the property rather than
+// the values: for every hundredth of a percent, the basis points must be the
+// digits with the point removed. A float64 implementation fails somewhere in
+// this range; string arithmetic cannot.
+func TestMapCode_PercentOffNeverGoesThroughAFloat(t *testing.T) {
+	for whole := 0; whole <= 100; whole++ {
+		for frac := 0; frac < 100; frac++ {
+			want := whole*100 + frac
+			if want <= 0 || want > 10000 {
+				continue
+			}
+			s := json.Number(itoa(whole) + "." + pad2(frac))
+			got, err := percentToBasisPoints(s)
+			if err != nil {
+				t.Fatalf("percentToBasisPoints(%q): %v", s, err)
+			}
+			if got != want {
+				t.Fatalf("percentToBasisPoints(%q) = %d, want %d", s, got, want)
+			}
+		}
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func pad2(n int) string {
+	s := itoa(n)
+	if len(s) == 1 {
+		return "0" + s
+	}
+	return s
+}
+
+func TestMapCode_AmountOff(t *testing.T) {
+	got := mustMap(t, Code{
+		Code: "B2B1",
+		Discount: &Discount{
+			Kind:           DiscountKindAmountOff,
+			AmountOffMinor: ptr(int64(2500)),
+			Currency:       "usd",
+			Duration:       DurationOnce,
+			StripeCouponID: ptr("cpn_amt"),
+		},
+	})
+	if got.DiscountType == nil || *got.DiscountType != promo.DiscountTypeAmount {
+		t.Fatalf("discount_type = %v, want amount", got.DiscountType)
+	}
+	// Minor units pass through unchanged; unlike percent there is no scaling.
+	if got.DiscountValue == nil || *got.DiscountValue != 2500 {
+		t.Fatalf("discount_value = %v, want 2500 minor units", got.DiscountValue)
+	}
+}
+
+// TestMapCode_TrialExtensionOnly is the shape migration 000131 exists for: a
+// code with no discount, no coupon, and a trial extension.
+func TestMapCode_TrialExtensionOnly(t *testing.T) {
+	got := mustMap(t, Code{
+		Code:               "EXTRA14DAYS",
+		TrialExtensionDays: ptr(14),
+	})
+	if got.TrialExtensionDays == nil || *got.TrialExtensionDays != 14 {
+		t.Fatalf("trial_extension_days = %v, want 14", got.TrialExtensionDays)
+	}
+	if got.DiscountType != nil || got.DiscountValue != nil {
+		t.Fatalf("expected no discount, got type=%v value=%v", got.DiscountType, got.DiscountValue)
+	}
+	if got.StripeCouponID != nil {
+		t.Fatalf("stripe_coupon_id = %v, want nil for a trial-extension-only code", *got.StripeCouponID)
+	}
+	if got.MaxDurationMonths != nil {
+		t.Fatalf("max_duration_months = %v, want nil when there is no discount", *got.MaxDurationMonths)
+	}
+}
+
+// TestMapCode_AbsentStripeCouponIDBecomesNull covers the console's "not
+// minted in this Stripe mode" signal, which is an ABSENT KEY. It must reach
+// the database as NULL, never as the empty string.
+func TestMapCode_AbsentStripeCouponIDBecomesNull(t *testing.T) {
+	// Decoded from JSON rather than constructed, so the test proves the
+	// absent key really does arrive as nil through the wire type.
+	var in Code
+	raw := `{"code":"NOCOUPON50","discount":{"kind":"percent_off","percent_off":50.00,"duration":"forever"}}`
+	if err := json.Unmarshal([]byte(raw), &in); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if in.Discount.StripeCouponID != nil {
+		t.Fatalf("an absent stripe_coupon_id key decoded to %q, want nil", *in.Discount.StripeCouponID)
+	}
+
+	got := mustMap(t, in)
+	if got.StripeCouponID != nil {
+		t.Fatalf("stripe_coupon_id = %q, want nil (a NULL column)", *got.StripeCouponID)
+	}
+	if got.DiscountValue == nil || *got.DiscountValue != 5000 {
+		t.Fatalf("discount_value = %v, want 5000", got.DiscountValue)
+	}
+}
+
+// TestMapCode_PresentStripeCouponIDIsKept is the other half: a minted coupon
+// must survive, so redemption can attach it.
+func TestMapCode_PresentStripeCouponIDIsKept(t *testing.T) {
+	got := mustMap(t, Code{
+		Code: "LAUNCH50",
+		Discount: &Discount{
+			Kind:           DiscountKindPercentOff,
+			PercentOff:     json.Number("50.00"),
+			Duration:       DurationForever,
+			StripeCouponID: ptr("  cpn_abc123  "),
+		},
+	})
+	if got.StripeCouponID == nil || *got.StripeCouponID != "cpn_abc123" {
+		t.Fatalf("stripe_coupon_id = %v, want the trimmed \"cpn_abc123\"", got.StripeCouponID)
+	}
+}
+
+func TestMapCode_Durations(t *testing.T) {
+	cases := []struct {
+		name     string
+		duration string
+		months   *int
+		want     *int
+	}{
+		// forever -> NULL, which is what max_duration_months already means
+		// for an unbounded discount (000060).
+		{"forever", DurationForever, nil, nil},
+		{"once", DurationOnce, nil, ptr(1)},
+		{"repeating", DurationRepeating, ptr(3), ptr(3)},
+		{"repeating ignores a longer run", DurationRepeating, ptr(12), ptr(12)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mustMap(t, Code{
+				Code: "DURATION1",
+				Discount: &Discount{
+					Kind:             DiscountKindPercentOff,
+					PercentOff:       json.Number("10.00"),
+					Duration:         tc.duration,
+					DurationInMonths: tc.months,
+				},
+			})
+			switch {
+			case tc.want == nil && got.MaxDurationMonths != nil:
+				t.Fatalf("max_duration_months = %d, want NULL", *got.MaxDurationMonths)
+			case tc.want != nil && got.MaxDurationMonths == nil:
+				t.Fatalf("max_duration_months = NULL, want %d", *tc.want)
+			case tc.want != nil && *got.MaxDurationMonths != *tc.want:
+				t.Fatalf("max_duration_months = %d, want %d", *got.MaxDurationMonths, *tc.want)
+			}
+		})
+	}
+}
+
+func TestMapCode_PassesThroughWindowAndLimits(t *testing.T) {
+	from := now.Add(-24 * time.Hour)
+	until := now.Add(24 * time.Hour)
+	got := mustMap(t, Code{
+		Code:               "WINDOWED1",
+		TrialExtensionDays: ptr(7),
+		ValidFrom:          &from,
+		ValidUntil:         &until,
+		MaxRedemptions:     ptr(100),
+	})
+	if !got.ValidFrom.Equal(from) {
+		t.Fatalf("valid_from = %v, want %v", got.ValidFrom, from)
+	}
+	if got.ValidUntil == nil || !got.ValidUntil.Equal(until) {
+		t.Fatalf("valid_until = %v, want %v", got.ValidUntil, until)
+	}
+	if got.MaxRedemptions == nil || *got.MaxRedemptions != 100 {
+		t.Fatalf("max_redemptions = %v, want 100", got.MaxRedemptions)
+	}
+	if got.CreatedBy != CreatedBy {
+		t.Fatalf("created_by = %q, want %q", got.CreatedBy, CreatedBy)
+	}
+	// max_per_email must be written explicitly. A zero would mean "nobody may
+	// ever redeem this" — a dead code that looks alive.
+	if got.MaxPerEmail != DefaultMaxPerEmail {
+		t.Fatalf("max_per_email = %d, want %d", got.MaxPerEmail, DefaultMaxPerEmail)
+	}
+}
+
+// TestMapCode_DefaultsValidFromToNow covers the console omitting the start
+// bound; the column is NOT NULL DEFAULT now(), so the mapper supplies it.
+func TestMapCode_DefaultsValidFromToNow(t *testing.T) {
+	got := mustMap(t, Code{Code: "NOWINDOW1", TrialExtensionDays: ptr(7)})
+	if !got.ValidFrom.Equal(now) {
+		t.Fatalf("valid_from = %v, want the ingest time %v", got.ValidFrom, now)
+	}
+	if got.ValidUntil != nil {
+		t.Fatalf("valid_until = %v, want NULL", *got.ValidUntil)
+	}
+}
+
+// TestMapCode_UnlimitedRedemptionsStaysNil pins that an absent
+// max_redemptions is unlimited, not zero. A zero would be a code nobody can
+// redeem.
+func TestMapCode_UnlimitedRedemptionsStaysNil(t *testing.T) {
+	got := mustMap(t, Code{Code: "UNLIMITED1", TrialExtensionDays: ptr(30)})
+	if got.MaxRedemptions != nil {
+		t.Fatalf("max_redemptions = %d, want NULL (unlimited)", *got.MaxRedemptions)
+	}
+}
+
+// TestMapCode_Rejections walks every rejection path. Each asserts the REASON
+// as well as the failure, because the reason is a Prometheus label and the
+// whole diagnostic value of rejecting here rather than at the database.
+func TestMapCode_Rejections(t *testing.T) {
+	cases := []struct {
+		name string
+		in   Code
+		want Reason
+	}{
+		{
+			"empty code",
+			Code{Code: "", TrialExtensionDays: ptr(7)},
+			ReasonCodeLength,
+		},
+		{
+			"code below the schema floor of 4",
+			Code{Code: "AB", TrialExtensionDays: ptr(7)},
+			ReasonCodeLength,
+		},
+		{
+			"code beyond varchar(64)",
+			Code{Code: longCode(65), TrialExtensionDays: ptr(7)},
+			ReasonCodeLength,
+		},
+		{
+			"no benefit at all",
+			Code{Code: "USELESS1"},
+			ReasonNoBenefit,
+		},
+		{
+			"zero trial extension",
+			Code{Code: "ZERODAYS", TrialExtensionDays: ptr(0)},
+			ReasonTrialExtension,
+		},
+		{
+			"negative trial extension",
+			Code{Code: "NEGDAYS1", TrialExtensionDays: ptr(-3)},
+			ReasonTrialExtension,
+		},
+		{
+			"unknown discount kind",
+			Code{Code: "WEIRDKIND", Discount: &Discount{
+				Kind: "buy_one_get_one", Duration: DurationOnce,
+			}},
+			ReasonDiscountKind,
+		},
+		{
+			"percent kind with no percent_off",
+			Code{Code: "NOPERCENT", Discount: &Discount{
+				Kind: DiscountKindPercentOff, Duration: DurationOnce,
+			}},
+			ReasonPercentOff,
+		},
+		{
+			"zero percent",
+			Code{Code: "ZEROPCT1", Discount: &Discount{
+				Kind: DiscountKindPercentOff, PercentOff: json.Number("0.00"), Duration: DurationOnce,
+			}},
+			ReasonPercentOff,
+		},
+		{
+			"more than 100 percent",
+			Code{Code: "OVER100P", Discount: &Discount{
+				Kind: DiscountKindPercentOff, PercentOff: json.Number("100.01"), Duration: DurationOnce,
+			}},
+			ReasonPercentOff,
+		},
+		{
+			"negative percent",
+			Code{Code: "NEGPCT12", Discount: &Discount{
+				Kind: DiscountKindPercentOff, PercentOff: json.Number("-10.00"), Duration: DurationOnce,
+			}},
+			ReasonPercentOff,
+		},
+		{
+			"three decimal places is beyond numeric(5,2)",
+			Code{Code: "TOOPRECISE", Discount: &Discount{
+				Kind: DiscountKindPercentOff, PercentOff: json.Number("33.333"), Duration: DurationOnce,
+			}},
+			ReasonPercentOff,
+		},
+		{
+			"exponent notation is not a numeric(5,2) literal",
+			Code{Code: "EXPONENT1", Discount: &Discount{
+				Kind: DiscountKindPercentOff, PercentOff: json.Number("5e1"), Duration: DurationOnce,
+			}},
+			ReasonPercentOff,
+		},
+		{
+			"amount kind with no amount",
+			Code{Code: "NOAMOUNT1", Discount: &Discount{
+				Kind: DiscountKindAmountOff, Duration: DurationOnce,
+			}},
+			ReasonAmountOff,
+		},
+		{
+			"zero amount",
+			Code{Code: "ZEROAMT12", Discount: &Discount{
+				Kind: DiscountKindAmountOff, AmountOffMinor: ptr(int64(0)), Duration: DurationOnce,
+			}},
+			ReasonAmountOff,
+		},
+		{
+			"negative amount",
+			Code{Code: "NEGAMT123", Discount: &Discount{
+				Kind: DiscountKindAmountOff, AmountOffMinor: ptr(int64(-500)), Duration: DurationOnce,
+			}},
+			ReasonAmountOff,
+		},
+		{
+			"amount beyond the integer column",
+			Code{Code: "HUGEAMT12", Discount: &Discount{
+				Kind: DiscountKindAmountOff, AmountOffMinor: ptr(int64(1) << 40), Duration: DurationOnce,
+			}},
+			ReasonAmountOff,
+		},
+		{
+			"unknown duration",
+			Code{Code: "BADDUR123", Discount: &Discount{
+				Kind: DiscountKindPercentOff, PercentOff: json.Number("10.00"), Duration: "annually",
+			}},
+			ReasonDuration,
+		},
+		{
+			"repeating with no month count",
+			Code{Code: "REPEATNO1", Discount: &Discount{
+				Kind: DiscountKindPercentOff, PercentOff: json.Number("10.00"), Duration: DurationRepeating,
+			}},
+			ReasonDurationInMonths,
+		},
+		{
+			"repeating for zero months",
+			Code{Code: "REPEAT0MO", Discount: &Discount{
+				Kind: DiscountKindPercentOff, PercentOff: json.Number("10.00"),
+				Duration: DurationRepeating, DurationInMonths: ptr(0),
+			}},
+			ReasonDurationInMonths,
+		},
+		{
+			"stripe_coupon_id present but empty",
+			Code{Code: "EMPTYCPN1", Discount: &Discount{
+				Kind: DiscountKindPercentOff, PercentOff: json.Number("10.00"),
+				Duration: DurationOnce, StripeCouponID: ptr(""),
+			}},
+			ReasonEmptyStripeCoupon,
+		},
+		{
+			"stripe_coupon_id present but only whitespace",
+			Code{Code: "BLANKCPN1", Discount: &Discount{
+				Kind: DiscountKindPercentOff, PercentOff: json.Number("10.00"),
+				Duration: DurationOnce, StripeCouponID: ptr("   "),
+			}},
+			ReasonEmptyStripeCoupon,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := MapCode(tc.in, now)
+			if err == nil {
+				t.Fatal("expected a rejection, got none")
+			}
+			if got := ReasonOf(err); got != tc.want {
+				t.Fatalf("reason = %q, want %q (error: %v)", got, tc.want, err)
+			}
+		})
+	}
+}
+
+// TestMapCode_TrialExtensionAndDiscountTogether — the console can publish
+// both, and the row must carry both.
+func TestMapCode_TrialExtensionAndDiscountTogether(t *testing.T) {
+	got := mustMap(t, Code{
+		Code:               "BOTHBENEFITS",
+		TrialExtensionDays: ptr(30),
+		Discount: &Discount{
+			Kind:             DiscountKindPercentOff,
+			PercentOff:       json.Number("25.00"),
+			Duration:         DurationRepeating,
+			DurationInMonths: ptr(6),
+			StripeCouponID:   ptr("cpn_both"),
+		},
+	})
+	if got.TrialExtensionDays == nil || *got.TrialExtensionDays != 30 {
+		t.Fatalf("trial_extension_days = %v, want 30", got.TrialExtensionDays)
+	}
+	if got.DiscountValue == nil || *got.DiscountValue != 2500 {
+		t.Fatalf("discount_value = %v, want 2500", got.DiscountValue)
+	}
+	if got.MaxDurationMonths == nil || *got.MaxDurationMonths != 6 {
+		t.Fatalf("max_duration_months = %v, want 6", got.MaxDurationMonths)
+	}
+}
+
+// TestReasonOf_NonRejection keeps the metric label total: an error that is
+// not a RejectedError must still produce a usable label.
+func TestReasonOf_NonRejection(t *testing.T) {
+	if got := ReasonOf(nil); got != "" {
+		t.Fatalf("ReasonOf(nil) = %q, want the empty reason", got)
+	}
+	if got := ReasonOf(errString("something else")); got != ReasonUnknown {
+		t.Fatalf("ReasonOf(other) = %q, want %q", got, ReasonUnknown)
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+func longCode(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = 'A'
+	}
+	return string(b)
+}

--- a/services/marketplace-api/internal/billing/consolepromo/metrics.go
+++ b/services/marketplace-api/internal/billing/consolepromo/metrics.go
@@ -1,0 +1,89 @@
+package consolepromo
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Prometheus metrics for the promo catalog ingest (#726).
+//
+// # Why these four and not one
+//
+// The four answer questions that cannot substitute for each other, and the
+// distinction is the same one internal/billing/consolecatalog's metrics
+// preserve: a sync that has STOPPED RUNNING must not look like a sync that
+// KEEPS FINDING NOTHING TO DO.
+//
+//   - CodesIngested       → how many codes the table currently holds from the
+//     console. Legitimately zero when no campaign is running, so on its own
+//     it can never distinguish healthy from broken.
+//   - LastSuccessTimestamp stale → nothing has been ingested lately, so
+//     CodesIngested describes the past. This is the half that keeps a dead
+//     ingest from reading as an idle one.
+//   - SyncFailuresTotal rising → the ingest IS running and its reads or
+//     writes are failing, which the stale timestamp alone cannot tell apart
+//     from not running at all.
+//   - CodesSkippedTotal by reason → the console published something this
+//     service could not map. Labelled by reason because the reason is the
+//     whole diagnostic: "bad_percent_off" is a malformed campaign, while
+//     "bad_discount_kind" is the console contract having moved underneath us.
+//
+// CodesExpiredTotal is a counter, not a gauge, because withdrawal is an
+// event: the interesting question is "did a sweep expire anything", and a
+// gauge would read zero again on the very next sync that expired nothing.
+var (
+	// CodesIngested is how many codes the LAST SUCCESSFUL sync wrote. Not
+	// touched by a failed sync, so its value always describes a real one.
+	CodesIngested = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "mark8ly_promo_catalog_codes_ingested",
+			Help: "Promo codes written by the last successful console ingest. Only meaningful alongside mark8ly_promo_catalog_last_success_timestamp_seconds — a failed sync leaves this at its previous value.",
+		},
+	)
+	// CodesSkippedTotal counts definitions the mapper rejected, by reason.
+	// The reason set is closed (see Reason) so this cannot become a
+	// cardinality bomb.
+	CodesSkippedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mark8ly_promo_catalog_codes_skipped_total",
+			Help: "Published promo definitions the mapper rejected, by reason. A rejected definition is skipped and counted; it never aborts the batch.",
+		},
+		[]string{"reason"},
+	)
+	// CodesExpiredTotal counts rows expired for having been withdrawn from
+	// the catalog. Withdrawn codes are expired (valid_until = now), never
+	// deleted — see Syncer.Sync.
+	CodesExpiredTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "mark8ly_promo_catalog_codes_expired_total",
+			Help: "Console-sourced promo codes expired because they are no longer published. Expired, never deleted — promo_redemptions references these rows.",
+		},
+	)
+	// LastSuccessTimestamp is when a sync last COMPLETED. A failed sync must
+	// never advance it; that is what makes silence detectable.
+	LastSuccessTimestamp = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "mark8ly_promo_catalog_last_success_timestamp_seconds",
+			Help: "Unix time of the last COMPLETED promo catalog ingest. Never advanced by a failure, so staleness means the ingest is dead or cannot reach the console.",
+		},
+	)
+	// SyncFailuresTotal counts syncs abandoned because the console could not
+	// be read or the write failed.
+	SyncFailuresTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "mark8ly_promo_catalog_sync_failures_total",
+			Help: "Promo catalog ingests abandoned because the console read or the database write failed. Distinct from codes skipped — an outage is not a malformed definition.",
+		},
+	)
+)
+
+// MustRegisterMetrics registers the ingest's metrics with reg. Panics on
+// duplicate registration — call once at startup.
+//
+// Call it AFTER the credentials gate, never unconditionally. Registering a
+// gauge publishes it at zero immediately, and a LastSuccessTimestamp of zero
+// reads as "last ingested in 1970" — so registering on a pod where the
+// ingest is switched off would make a staleness alert fire forever on a
+// deployment behaving exactly as configured. Absent series mean "not enabled
+// here"; present-but-stale means "enabled and not working".
+func MustRegisterMetrics(reg prometheus.Registerer) {
+	reg.MustRegister(CodesIngested, CodesSkippedTotal, CodesExpiredTotal,
+		LastSuccessTimestamp, SyncFailuresTotal)
+}

--- a/services/marketplace-api/internal/billing/consolepromo/store.go
+++ b/services/marketplace-api/internal/billing/consolepromo/store.go
@@ -1,0 +1,107 @@
+package consolepromo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/mark8ly/marketplace-api/internal/promo"
+)
+
+// upsertBatchSize bounds one INSERT. The catalog is small (campaign codes,
+// not a product catalog), so this is a guard against a pathological
+// publication rather than a tuning knob.
+const upsertBatchSize = 200
+
+// gormStore is the production Store.
+type gormStore struct{ db *gorm.DB }
+
+// NewStore builds the GORM-backed Store.
+func NewStore(db *gorm.DB) Store { return &gormStore{db: db} }
+
+// upsertColumns are the columns a re-sync overwrites from the console.
+//
+// Everything absent from this list is deliberately preserved on an existing
+// row: max_per_email, min_effective_price_per_currency, allowed_plans and
+// annual_only are mark8ly policy the console cannot express (#726), and id
+// and created_at belong to the row, not to the definition.
+var upsertColumns = []string{
+	"stripe_coupon_id",
+	"discount_type",
+	"discount_value",
+	"trial_extension_days",
+	"max_duration_months",
+	"valid_from",
+	"valid_until",
+	"max_redemptions",
+	"created_by",
+	"updated_at",
+}
+
+// UpsertCodes writes the mapped rows, keyed on the unique index on code.
+//
+// valid_until is among the overwritten columns, so a code that was expired
+// by a previous sweep and then republished is un-expired by the same
+// mechanism that expired it. That is what makes the expiry policy
+// recoverable: a console publication is always the last word.
+func (s *gormStore) UpsertCodes(ctx context.Context, codes []promo.PromoCode) error {
+	if len(codes) == 0 {
+		return nil
+	}
+
+	// Copy rather than mutate the caller's slice, and assign ids here rather
+	// than in the mapper: an id is a storage concern, and generating one in
+	// the mapper would make that pure function non-deterministic and its
+	// tests unable to compare whole rows. Assigning explicitly also avoids
+	// depending on GORM's zero-value handling of the column's
+	// DEFAULT gen_random_uuid().
+	rows := make([]promo.PromoCode, len(codes))
+	copy(rows, codes)
+	for i := range rows {
+		if rows[i].ID == uuid.Nil {
+			rows[i].ID = uuid.New()
+		}
+	}
+
+	if err := s.db.WithContext(ctx).
+		Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "code"}},
+			DoUpdates: clause.AssignmentColumns(upsertColumns),
+		}).
+		CreateInBatches(&rows, upsertBatchSize).Error; err != nil {
+		return fmt.Errorf("consolepromo: upsert promo codes: %w", err)
+	}
+	return nil
+}
+
+// ExpireCodesNotIn expires console-sourced codes absent from keep.
+//
+// Three parts of the WHERE clause each carry a decision:
+//
+//   - created_by = CreatedBy scopes the sweep to rows THIS ingest wrote. A
+//     code created by any other path is none of this package's business, and
+//     without this an empty catalog would expire the lot.
+//   - the valid_until predicate skips rows that are already expired, so a
+//     re-run is idempotent and does not keep pushing their expiry forward.
+//   - keep is applied only when non-empty. An empty catalog legitimately
+//     expires every console-sourced code (no campaigns are running), and
+//     `NOT IN ()` is not valid SQL.
+func (s *gormStore) ExpireCodesNotIn(ctx context.Context, keep []string, at time.Time) (int, error) {
+	q := s.db.WithContext(ctx).
+		Model(&promo.PromoCode{}).
+		Where("created_by = ?", CreatedBy).
+		Where("valid_until IS NULL OR valid_until > ?", at)
+	if len(keep) > 0 {
+		q = q.Where("code NOT IN ?", keep)
+	}
+
+	res := q.Updates(map[string]any{"valid_until": at, "updated_at": at})
+	if res.Error != nil {
+		return 0, fmt.Errorf("consolepromo: expire withdrawn promo codes: %w", res.Error)
+	}
+	return int(res.RowsAffected), nil
+}

--- a/services/marketplace-api/internal/billing/consolepromo/sync.go
+++ b/services/marketplace-api/internal/billing/consolepromo/sync.go
@@ -1,0 +1,171 @@
+package consolepromo
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/promo"
+)
+
+// Store is the write half of the ingest. It is an interface so the sync
+// decisions above it — which codes are kept, which are expired, what happens
+// when one code is malformed — are testable without a database.
+type Store interface {
+	// UpsertCodes inserts or updates rows keyed on code (promo_codes has a
+	// unique index on it), so a re-sync is an update in place rather than a
+	// duplicate.
+	UpsertCodes(ctx context.Context, codes []promo.PromoCode) error
+
+	// ExpireCodesNotIn expires every console-sourced code whose code string
+	// is not in keep, by setting valid_until = at. It returns how many rows
+	// it changed. Rows already expired at or before at are left alone so a
+	// re-run does not keep rewriting them.
+	ExpireCodesNotIn(ctx context.Context, keep []string, at time.Time) (int, error)
+}
+
+// Result is one sync's outcome.
+type Result struct {
+	// Ingested is how many definitions were mapped and written.
+	Ingested int
+	// Skipped is how many were rejected by the mapper.
+	Skipped int
+	// SkippedByReason breaks Skipped down. Sums to Skipped.
+	SkippedByReason map[Reason]int
+	// Expired is how many previously-ingested rows were expired for being
+	// absent from the catalog.
+	Expired int
+	// RevisionID is the catalog revision this result describes.
+	RevisionID string
+}
+
+// Syncer pulls the console's promo catalog into promo_codes.
+type Syncer struct {
+	fetcher Fetcher
+	store   Store
+	logger  *slog.Logger
+	// now is injectable so expiry timestamps are assertable in tests without
+	// reaching for the wall clock.
+	now func() time.Time
+}
+
+// NewSyncer builds a Syncer. It performs no I/O.
+func NewSyncer(f Fetcher, s Store, logger *slog.Logger) *Syncer {
+	return &Syncer{fetcher: f, store: s, logger: logger, now: time.Now}
+}
+
+// Sync reads the catalog once and reconciles promo_codes against it.
+//
+// # A malformed code must not cost the batch
+//
+// Each definition is mapped independently. A rejection is logged, counted by
+// reason and skipped; the rest of the batch is written. The alternative —
+// failing the sync on the first bad row — would let one badly-filled console
+// campaign withhold every other code from every merchant, which is a far
+// worse outcome than one code being missing.
+//
+// # A withdrawn code is EXPIRED, never deleted
+//
+// promo_redemptions.promo_code_id is NOT NULL REFERENCES promo_codes(id), so
+// a delete could fail outright on the foreign key — and where it succeeded
+// it would erase the audit trail of who redeemed what. Expiry achieves the
+// same thing for every caller that matters: promo.Validate already refuses a
+// code past valid_until (validator.go), and the row survives for the
+// redemptions that point at it.
+//
+// # Which codes count as "still in the catalog"
+//
+// Every code the console published, INCLUDING the ones this sync could not
+// map. A definition we failed to parse is present in the catalog and merely
+// unreadable by us; expiring it would turn a mapping bug in this service
+// into a withdrawn campaign for a merchant. Only genuine absence expires a
+// code.
+func (s *Syncer) Sync(ctx context.Context) (Result, error) {
+	cat, err := s.fetcher.Fetch(ctx)
+	if err != nil {
+		// Nothing is written. An unreadable catalog changes nothing at all:
+		// previously ingested rows stay exactly as they are.
+		return Result{}, fmt.Errorf("consolepromo: fetch: %w", err)
+	}
+
+	now := s.now()
+	res := Result{RevisionID: cat.RevisionID, SkippedByReason: map[Reason]int{}}
+
+	rows := make([]promo.PromoCode, 0, len(cat.Codes))
+	keep := make([]string, 0, len(cat.Codes))
+	for _, in := range cat.Codes {
+		if in.Code != "" {
+			keep = append(keep, in.Code)
+		}
+		row, err := MapCode(in, now)
+		if err != nil {
+			reason := ReasonOf(err)
+			res.Skipped++
+			res.SkippedByReason[reason]++
+			CodesSkippedTotal.WithLabelValues(string(reason)).Inc()
+			s.warn("consolepromo: skipping a published promo code the mapper rejected",
+				"code", in.Code, "reason", string(reason), "error", err)
+			continue
+		}
+		rows = append(rows, row)
+	}
+
+	if len(rows) > 0 {
+		if err := s.store.UpsertCodes(ctx, rows); err != nil {
+			return res, fmt.Errorf("consolepromo: upsert: %w", err)
+		}
+	}
+	res.Ingested = len(rows)
+
+	// Expire AFTER the upsert. In this order a code that is both republished
+	// and briefly absent from an intermediate state can never end up
+	// expired; in the other order an upsert failure would leave codes
+	// expired with nothing written back.
+	expired, err := s.store.ExpireCodesNotIn(ctx, keep, now)
+	if err != nil {
+		return res, fmt.Errorf("consolepromo: expire withdrawn codes: %w", err)
+	}
+	res.Expired = expired
+
+	CodesIngested.Set(float64(res.Ingested))
+	CodesExpiredTotal.Add(float64(res.Expired))
+	LastSuccessTimestamp.Set(float64(now.Unix()))
+
+	s.info("consolepromo: promo catalog ingested",
+		"revision_id", res.RevisionID, "mode", cat.Mode,
+		"ingested", res.Ingested, "skipped", res.Skipped, "expired", res.Expired,
+		"skipped_reasons", reasonSummary(res.SkippedByReason))
+	return res, nil
+}
+
+// reasonSummary renders the skip breakdown in a stable order, so two log
+// lines describing the same outcome are the same text and can be diffed.
+func reasonSummary(byReason map[Reason]int) string {
+	if len(byReason) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(byReason))
+	for r, n := range byReason {
+		parts = append(parts, fmt.Sprintf("%s=%d", r, n))
+	}
+	sort.Strings(parts)
+	out := parts[0]
+	for _, p := range parts[1:] {
+		out += "," + p
+	}
+	return out
+}
+
+func (s *Syncer) info(msg string, args ...any) {
+	if s.logger != nil {
+		s.logger.Info(msg, args...)
+	}
+}
+
+func (s *Syncer) warn(msg string, args ...any) {
+	if s.logger != nil {
+		s.logger.Warn(msg, args...)
+	}
+}

--- a/services/marketplace-api/internal/billing/consolepromo/sync_test.go
+++ b/services/marketplace-api/internal/billing/consolepromo/sync_test.go
@@ -1,0 +1,295 @@
+package consolepromo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/promo"
+)
+
+// fakeFetcher answers with a fixed catalog or a fixed error.
+type fakeFetcher struct {
+	cat   Catalog
+	err   error
+	calls int
+}
+
+func (f *fakeFetcher) Fetch(context.Context) (Catalog, error) {
+	f.calls++
+	if f.err != nil {
+		return Catalog{}, f.err
+	}
+	return f.cat, nil
+}
+
+// fakeStore records what the Syncer asked it to do. A fake rather than a
+// database because every decision under test — which codes are written,
+// which are kept, what a malformed one costs the batch — is made above the
+// storage layer, and TEST_DATABASE_URL is not always set.
+type fakeStore struct {
+	upserted   [][]promo.PromoCode
+	keptCalls  [][]string
+	expireAt   []time.Time
+	expireN    int
+	upsertErr  error
+	expireErr  error
+	upsertHits int
+}
+
+func (s *fakeStore) UpsertCodes(_ context.Context, codes []promo.PromoCode) error {
+	s.upsertHits++
+	if s.upsertErr != nil {
+		return s.upsertErr
+	}
+	cp := make([]promo.PromoCode, len(codes))
+	copy(cp, codes)
+	s.upserted = append(s.upserted, cp)
+	return nil
+}
+
+func (s *fakeStore) ExpireCodesNotIn(_ context.Context, keep []string, at time.Time) (int, error) {
+	if s.expireErr != nil {
+		return 0, s.expireErr
+	}
+	cp := make([]string, len(keep))
+	copy(cp, keep)
+	s.keptCalls = append(s.keptCalls, cp)
+	s.expireAt = append(s.expireAt, at)
+	return s.expireN, nil
+}
+
+func newSyncer(f Fetcher, s Store) *Syncer {
+	sy := NewSyncer(f, s, nil)
+	sy.now = func() time.Time { return now }
+	return sy
+}
+
+func percentCode(code, percent string) Code {
+	return Code{Code: code, Discount: &Discount{
+		Kind: DiscountKindPercentOff, PercentOff: json.Number(percent), Duration: DurationForever,
+	}}
+}
+
+func TestSync_WritesMappedCodes(t *testing.T) {
+	f := &fakeFetcher{cat: Catalog{RevisionID: "rev-1", Codes: []Code{
+		percentCode("LAUNCH50", "50.00"),
+		{Code: "EXTRA14DAYS", TrialExtensionDays: ptr(14)},
+	}}}
+	store := &fakeStore{}
+
+	res, err := newSyncer(f, store).Sync(context.Background())
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.Ingested != 2 || res.Skipped != 0 {
+		t.Fatalf("ingested=%d skipped=%d, want 2 and 0", res.Ingested, res.Skipped)
+	}
+	if res.RevisionID != "rev-1" {
+		t.Fatalf("revision_id = %q, want rev-1", res.RevisionID)
+	}
+	if len(store.upserted) != 1 || len(store.upserted[0]) != 2 {
+		t.Fatalf("upserted %v, want one batch of two", store.upserted)
+	}
+}
+
+// TestSync_OneBadCodeDoesNotAbortTheBatch is the property that keeps one
+// badly-filled console campaign from withholding every other code from every
+// merchant.
+func TestSync_OneBadCodeDoesNotAbortTheBatch(t *testing.T) {
+	f := &fakeFetcher{cat: Catalog{RevisionID: "rev-2", Codes: []Code{
+		percentCode("GOODCODE1", "10.00"),
+		percentCode("BADPCT123", "not-a-number"),
+		{Code: "NOBENEFIT1"},
+		percentCode("GOODCODE2", "20.00"),
+	}}}
+	store := &fakeStore{}
+
+	res, err := newSyncer(f, store).Sync(context.Background())
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.Ingested != 2 {
+		t.Fatalf("ingested = %d, want the 2 good codes", res.Ingested)
+	}
+	if res.Skipped != 2 {
+		t.Fatalf("skipped = %d, want 2", res.Skipped)
+	}
+	if res.SkippedByReason[ReasonPercentOff] != 1 || res.SkippedByReason[ReasonNoBenefit] != 1 {
+		t.Fatalf("skipped by reason = %v, want one each of %q and %q",
+			res.SkippedByReason, ReasonPercentOff, ReasonNoBenefit)
+	}
+
+	got := map[string]bool{}
+	for _, row := range store.upserted[0] {
+		got[row.Code] = true
+	}
+	if !got["GOODCODE1"] || !got["GOODCODE2"] {
+		t.Fatalf("written codes = %v, want both good codes", got)
+	}
+}
+
+// TestSync_AnUnmappableCodeIsStillKept — a definition this service could not
+// parse is PRESENT in the catalog, merely unreadable. Expiring it would turn
+// a mapping bug here into a withdrawn campaign for a merchant.
+func TestSync_AnUnmappableCodeIsStillKept(t *testing.T) {
+	f := &fakeFetcher{cat: Catalog{Codes: []Code{
+		percentCode("GOODCODE1", "10.00"),
+		percentCode("BADPCT123", "wat"),
+	}}}
+	store := &fakeStore{}
+
+	if _, err := newSyncer(f, store).Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(store.keptCalls) != 1 {
+		t.Fatalf("expire called %d times, want once", len(store.keptCalls))
+	}
+	keep := store.keptCalls[0]
+	if len(keep) != 2 || keep[0] != "GOODCODE1" || keep[1] != "BADPCT123" {
+		t.Fatalf("keep = %v, want both published codes including the unmappable one", keep)
+	}
+}
+
+// TestSync_WithdrawnCodesAreExpiredAtTheSyncInstant — expiry, never deletion
+// (promo_redemptions references these rows), stamped with the sync's own
+// clock so the timestamp is assertable.
+func TestSync_WithdrawnCodesAreExpiredAtTheSyncInstant(t *testing.T) {
+	f := &fakeFetcher{cat: Catalog{Codes: []Code{percentCode("STILLHERE1", "10.00")}}}
+	store := &fakeStore{expireN: 3}
+
+	res, err := newSyncer(f, store).Sync(context.Background())
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.Expired != 3 {
+		t.Fatalf("expired = %d, want 3", res.Expired)
+	}
+	if len(store.expireAt) != 1 || !store.expireAt[0].Equal(now) {
+		t.Fatalf("expired at %v, want the sync instant %v", store.expireAt, now)
+	}
+}
+
+// TestSync_EmptyCatalogExpiresEverythingAndWritesNothing — no published
+// codes is a legitimate state (no campaign is running), distinct from a
+// failed read, which is covered below.
+func TestSync_EmptyCatalogExpiresEverythingAndWritesNothing(t *testing.T) {
+	f := &fakeFetcher{cat: Catalog{RevisionID: "rev-empty"}}
+	store := &fakeStore{expireN: 5}
+
+	res, err := newSyncer(f, store).Sync(context.Background())
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.Ingested != 0 || res.Expired != 5 {
+		t.Fatalf("ingested=%d expired=%d, want 0 and 5", res.Ingested, res.Expired)
+	}
+	if store.upsertHits != 0 {
+		t.Fatalf("upsert called %d times for an empty catalog, want none", store.upsertHits)
+	}
+	if len(store.keptCalls) != 1 || len(store.keptCalls[0]) != 0 {
+		t.Fatalf("keep = %v, want one call with an empty list", store.keptCalls)
+	}
+}
+
+// TestSync_AFailedReadChangesNothing is the distinction the ErrUnavailable
+// doc insists on: "we could not ask" must never be read as "there are no
+// codes", which would expire the lot.
+func TestSync_AFailedReadChangesNothing(t *testing.T) {
+	f := &fakeFetcher{err: ErrUnavailable}
+	store := &fakeStore{expireN: 99}
+
+	_, err := newSyncer(f, store).Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected an error from a failed fetch")
+	}
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("error = %v, want it to wrap ErrUnavailable", err)
+	}
+	if store.upsertHits != 0 || len(store.keptCalls) != 0 {
+		t.Fatalf("a failed read wrote to the store: upserts=%d expires=%d",
+			store.upsertHits, len(store.keptCalls))
+	}
+}
+
+// TestSync_NotPublishedChangesNothing — 404 is likewise not an empty
+// catalog.
+func TestSync_NotPublishedChangesNothing(t *testing.T) {
+	f := &fakeFetcher{err: ErrNotPublished}
+	store := &fakeStore{}
+
+	if _, err := newSyncer(f, store).Sync(context.Background()); !errors.Is(err, ErrNotPublished) {
+		t.Fatalf("error = %v, want ErrNotPublished", err)
+	}
+	if store.upsertHits != 0 || len(store.keptCalls) != 0 {
+		t.Fatal("a 404 wrote to the store")
+	}
+}
+
+// TestSync_UpsertFailureSkipsTheExpirySweep — expiring codes when nothing
+// was written back would leave the table strictly worse than before.
+func TestSync_UpsertFailureSkipsTheExpirySweep(t *testing.T) {
+	f := &fakeFetcher{cat: Catalog{Codes: []Code{percentCode("LAUNCH50", "50.00")}}}
+	store := &fakeStore{upsertErr: errors.New("boom")}
+
+	if _, err := newSyncer(f, store).Sync(context.Background()); err == nil {
+		t.Fatal("expected the upsert failure to surface")
+	}
+	if len(store.keptCalls) != 0 {
+		t.Fatal("the expiry sweep ran after a failed upsert")
+	}
+}
+
+func TestSync_ExpireFailureSurfaces(t *testing.T) {
+	f := &fakeFetcher{cat: Catalog{Codes: []Code{percentCode("LAUNCH50", "50.00")}}}
+	store := &fakeStore{expireErr: errors.New("boom")}
+
+	res, err := newSyncer(f, store).Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected the expiry failure to surface")
+	}
+	// The upsert did happen, and the result says so — a partial sync must be
+	// reported as what it was, not erased.
+	if res.Ingested != 1 {
+		t.Fatalf("ingested = %d, want the 1 code that was written before the sweep failed", res.Ingested)
+	}
+}
+
+func TestReasonSummary_IsStable(t *testing.T) {
+	if got := reasonSummary(nil); got != "none" {
+		t.Fatalf("reasonSummary(nil) = %q, want \"none\"", got)
+	}
+	got := reasonSummary(map[Reason]int{ReasonPercentOff: 2, ReasonNoBenefit: 1})
+	want := "bad_percent_off=2,no_benefit=1"
+	if got != want {
+		t.Fatalf("reasonSummary = %q, want %q", got, want)
+	}
+}
+
+func TestConfig_Configured(t *testing.T) {
+	full := Config{
+		CatalogURL: "https://console/promo", TokenURL: "https://idp/token",
+		ClientID: "id", ClientSecret: "secret",
+	}
+	if !full.Configured() {
+		t.Fatal("a fully populated config reported unconfigured")
+	}
+	// Each credential is individually load-bearing, and an empty URL is the
+	// switch that turns the whole ingest off.
+	for name, mutate := range map[string]func(*Config){
+		"no url":    func(c *Config) { c.CatalogURL = "" },
+		"no token":  func(c *Config) { c.TokenURL = "" },
+		"no id":     func(c *Config) { c.ClientID = "" },
+		"no secret": func(c *Config) { c.ClientSecret = "" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := full
+			mutate(&c)
+			if c.Configured() {
+				t.Fatal("reported configured with a missing setting")
+			}
+		})
+	}
+}

--- a/services/marketplace-api/pkg/config/config.go
+++ b/services/marketplace-api/pkg/config/config.go
@@ -127,6 +127,23 @@ type Config struct {
 	// outage. Zero or negative takes consolecatalog.DefaultTTL.
 	ConsoleCatalogCacheTTL time.Duration `envconfig:"CONSOLE_CATALOG_CACHE_TTL" default:"6h"`
 
+	// Console PROMO-catalog ingest (#726). The console owns promo-code
+	// definitions and mark8ly consumes them; this is the route they are read
+	// from.
+	//
+	// ONLY THE URL IS NEW. The credentials above are reused: the console
+	// gates this route on the `read-promo-catalog` capability, which rides in
+	// the token's roles claim, and one machine identity can hold it alongside
+	// the plan catalog's. A second OAuth client would be a second secret to
+	// rotate and expire for no gain. CONSOLE_CATALOG_MODE and
+	// CONSOLE_CATALOG_INTERVAL likewise apply to both reads.
+	//
+	// OPTIONAL BY DESIGN, like every setting above it. Unset, no ingest runs
+	// and the service starts exactly as it did before — an unreachable
+	// console must never be able to fail startup, and any rows a previous
+	// ingest wrote remain valid.
+	ConsolePromoCatalogURL string `envconfig:"CONSOLE_PROMO_CATALOG_URL" default:""`
+
 	// RESEND_WEBHOOK_SECRET verifies inbound provider delivery events
 	// (#348B). Empty leaves the endpoint mounted but inert: it answers 503
 	// not_configured rather than 404, so a missing secret is diagnosable


### PR DESCRIPTION
**Step 2 of #726** — the client and ingest. #742 made `promo_codes` able to hold what the console publishes; this fetches it and populates the table.

Per the decision on #726: the console owns promo definitions and mark8ly consumes them. No local create path is added.

## Why rows rather than a cache

`promo_redemptions.promo_code_id` is `NOT NULL REFERENCES promo_codes(id)`, so a redemption must point at a real row. An in-memory catalog would not have worked — which is what made #742's migration necessary rather than optional.

## Reuses the existing console client shape

New `internal/billing/consolepromo` mirrors `consolecatalog`: OAuth client-credentials token, fetch with ETag retention, fail-open, and `Configured()` treating unconfigured as a **supported state** rather than an error.

**No second OAuth client.** The console gates this route on the `read-promo-catalog` capability, which rides in the token's roles claim, so the same machine identity can hold both. Every credential is the existing `CONSOLE_CATALOG_*` one; the only new setting is `CONSOLE_PROMO_CATALOG_URL`.

One deliberate divergence from `consolecatalog`, documented in the code: **a 200 with zero codes is accepted.** No campaigns running is an ordinary state, whereas an empty *price* list is a contract violation.

## The mapper is pure, and that is where the risk lives

`MapCode(in Code, now time.Time) (promo.PromoCode, error)` — no DB, no clock, fully unit-testable.

**Percent conversion never touches a float.** The console publishes `numeric(5,2)`; `discount_value` is basis points. Parsed as a decimal string via `json.Number`, because a float64 round-trip eventually turns 33.33 into 3332 or 3334. There is an explicit 33.33 test and an exhaustive sweep of all 10,000 hundredths.

It also handles a detail I would have missed: `.5` is five tenths — 50 basis points — so the fractional part is **padded**, not parsed directly, which would have made it 5.

**`stripe_coupon_id` absent vs empty are distinguished.** Absent (the key omitted when the coupon is not minted in that mode) maps to NULL. Present-but-empty is *rejected* rather than folded into absent — an empty id reaching redemption would be handed to Stripe as a coupon named `""`. That is stricter than the plan asked for; easy to relax if you would rather.

Rejections happen at the mapper with named reasons, so a bad definition surfaces as `code X skipped: discount_type without discount_value` rather than a raw Postgres constraint error.

## Withdrawal expires, never deletes

`ExpireCodesNotIn(keep, at)` sets `valid_until = at`, scoped to rows this ingest created, skipping already-expired ones. `Validate` already honours `valid_until` (`validator.go:88`), and deleting would risk the redemptions FK and erase an audit trail.

Two details worth a reviewer's eye:

- **`keep` includes codes the mapper REJECTED.** An unparseable definition is *present*, not withdrawn — so a mapping bug cannot silently read as a withdrawn campaign and expire live codes.
- **Expiry runs after the upsert**, so a failed upsert never expires anything.

Also: `max_per_email` is written explicitly as `1` rather than relying on the column default, because the model field is a plain `int` and a zero reaching the DB would mean *nobody may ever redeem this*.

## Safety

The ingest runs at boot and on `CONSOLE_CATALOG_INTERVAL`, entirely inside a goroutine — **reaching the console can never fail startup**. Unconfigured, credentials-without-URL, and nil-db are each a clean no-op with a test.

## Testing

**All tests genuinely execute** — no integration-tagged files were added, so nothing skips silently here and the `TestEveryIntegrationPackageIsInTheTestIntTarget` guard stays green.

- `consolepromo`: **24 top-level (64 with subtests)** — percent, amount, trial-extension-only, both benefits, absent coupon id decoded from real JSON to prove the absent key arrives as nil, each of once/repeating/forever, and 22 rejection cases each asserting its reason
- wiring: **6** — the unconfigured/no-URL/nil-db no-ops and the admin/storefront mode matrix

The DB write path is covered through a fake `Store`, not against Postgres. `go build`, `go vet` (plain and `-tags integration`), `gofmt -l` and the full `go test ./...` are clean; re-verified after rebasing onto current `main`.

## Still needed before this does anything in production

1. **The `read-promo-catalog` capability** on mark8ly's existing machine identity — a grant, not new credentials.
2. **`CONSOLE_PROMO_CATALOG_URL`** set in the deployment.

Until both land the ingest is a no-op, which is the intended unconfigured behaviour.

`Coupons: Read` on the Stripe key is **not** needed by this PR — that is redemption (#620), which attaches the coupon.

Refs #726, #620.
