### PR TITLE
feat(email): send customer-facing mail as the store, not as noreply@

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/journal/... \
 	    ./internal/notification/... \
 	    ./internal/order/... \
+	    ./internal/orderdoc/... \
 	    ./internal/orderrefund/... \
 	    ./internal/outbox/... \
 	    ./internal/page/... \

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/shipping/... \
 	    ./internal/signup/... \
 	    ./internal/stockhold/... \
+	    ./internal/storeidentity/... \
 	    ./internal/stores/... \
 	    ./internal/subscription \
 	    ./internal/subscription/cancel/... \

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -114,6 +114,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/shipping"
 	"github.com/mark8ly/marketplace-api/internal/signup"
 	"github.com/mark8ly/marketplace-api/internal/stockhold"
+	"github.com/mark8ly/marketplace-api/internal/storeidentity"
 	"github.com/mark8ly/marketplace-api/internal/stores"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 	"github.com/mark8ly/marketplace-api/internal/subscription/cancel"
@@ -732,7 +733,7 @@ func main() {
 	// sufficient as we only have one storefront brand per cluster.
 	ticketNotifier := ticket.NewEmailNotifier(
 		emailSender, cfg.EmailFrom, cfg.PublicStorefrontHost, log,
-	)
+	).WithStoreIdentity(storeidentity.NewDBLoader(conn))
 	// ticketRepo is hoisted so the platformadmin.Register call sites below
 	// (mode.Both and mode.Admin) can both wire the same #329 cross-store
 	// ticket read without constructing a second, redundant repository.

--- a/services/marketplace-api/internal/campaign/dispatcher.go
+++ b/services/marketplace-api/internal/campaign/dispatcher.go
@@ -2,6 +2,8 @@ package campaign
 
 import (
 	"context"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
 )
 
 // Dispatcher delivers fully-rendered campaign emails. The send worker
@@ -33,4 +35,10 @@ type OutboundEmail struct {
 	// originating campaign so future per-campaign metrics can be derived
 	// without re-keying recipient strings against the database.
 	CampaignID string
+	// Sender is the store's customer-facing identity (#718). A campaign
+	// is marketing mail FROM the merchant's store, so it wears the store
+	// name and the store's Reply-To. The send worker fills it from the
+	// campaign theme it already loads; a zero value degrades to the
+	// platform identity.
+	Sender email.StoreSender
 }

--- a/services/marketplace-api/internal/campaign/email_dispatcher.go
+++ b/services/marketplace-api/internal/campaign/email_dispatcher.go
@@ -55,12 +55,16 @@ func (d *EmailDispatcher) Send(ctx context.Context, msg OutboundEmail) error {
 		customArgs["campaign_id"] = msg.CampaignID
 	}
 
-	return d.sender.Send(ctx, email.Message{
-		From:       d.from,
+	out := email.Message{
 		To:         msg.Recipient,
 		Subject:    msg.Subject,
 		HTMLBody:   msg.HTMLBody,
 		TextBody:   msg.TextBody,
 		CustomArgs: customArgs,
-	})
+	}
+	// Customer-facing marketing sent BY the store, so it carries the
+	// store identity — never the platform's.
+	email.StoreIdentity(d.from, msg.Sender).Apply(&out)
+
+	return d.sender.Send(ctx, out)
 }

--- a/services/marketplace-api/internal/campaign/send_worker.go
+++ b/services/marketplace-api/internal/campaign/send_worker.go
@@ -11,6 +11,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/campaignbudget"
+	"github.com/mark8ly/marketplace-api/internal/email"
 )
 
 // BudgetReserver is the narrow interface SendWorker needs from the
@@ -232,6 +233,11 @@ func (w *SendWorker) dispatchCampaign(ctx context.Context, c Campaign) error {
 				TextBody:   textBody,
 				TenantID:   c.TenantID.String(),
 				CampaignID: c.ID.String(),
+				Sender: email.StoreSender{
+					Name:         theme.StoreName,
+					Slug:         theme.StoreSlug,
+					ContactEmail: theme.StoreContactEmail,
+				},
 			}
 			if err := w.dispatcher.Send(ctx, outbound); err != nil {
 				w.logger.Error("campaign: dispatch failed",

--- a/services/marketplace-api/internal/campaign/send_worker_identity_integration_test.go
+++ b/services/marketplace-api/internal/campaign/send_worker_identity_integration_test.go
@@ -1,0 +1,71 @@
+//go:build integration
+
+package campaign
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// capturingDispatcher records the OutboundEmail the worker built.
+type capturingDispatcher struct {
+	mu   sync.Mutex
+	msgs []OutboundEmail
+}
+
+func (d *capturingDispatcher) Send(_ context.Context, msg OutboundEmail) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.msgs = append(d.msgs, msg)
+	return nil
+}
+
+// storeThemeStub supplies the store identity the loader reads from the
+// database in production.
+type storeThemeStub struct{}
+
+func (storeThemeStub) LoadTheme(context.Context, uuid.UUID) (CampaignTheme, error) {
+	return CampaignTheme{
+		StoreName:         "Nadia's Ceramics",
+		StoreSlug:         "nadias-ceramics",
+		StoreContactEmail: "hello@nadiasceramics.com",
+	}, nil
+}
+
+// TestIntegration_SendWorker_CarriesStoreSenderIdentity pins the hop the
+// dispatcher-level test in internal/email cannot see (#718).
+//
+// That test hands EmailDispatcher a Sender it built itself, so it proves
+// the dispatcher APPLIES an identity — not that the worker SUPPLIES one.
+// Emptying the worker's Sender literal left every other test in this
+// service green, which is precisely the gap this closes: the assertion
+// is on what the worker produces from a loaded theme, not on a value the
+// test handed it.
+func TestIntegration_SendWorker_CarriesStoreSenderIdentity(t *testing.T) {
+	db := testdb.NewTx(t)
+	c := seedCampaignWithRecipients(t, db, 2)
+	disp := &capturingDispatcher{}
+
+	w := NewSendWorker(SendWorkerConfig{
+		DB: db, Repo: NewRepository(db), Dispatcher: disp,
+		ThemeLoader: storeThemeStub{},
+		Logger:      slog.New(slog.NewTextHandler(nopWriter{}, nil)),
+	})
+
+	require.NoError(t, w.dispatchCampaign(context.Background(), c))
+	require.Len(t, disp.msgs, 2)
+
+	for _, msg := range disp.msgs {
+		require.Equal(t, "Nadia's Ceramics", msg.Sender.Name,
+			"the worker must carry the loaded store name into the envelope")
+		require.Equal(t, "nadias-ceramics", msg.Sender.Slug)
+		require.Equal(t, "hello@nadiasceramics.com", msg.Sender.ContactEmail)
+	}
+}

--- a/services/marketplace-api/internal/campaign/templates.go
+++ b/services/marketplace-api/internal/campaign/templates.go
@@ -18,19 +18,24 @@ var templateFS embed.FS
 // Paper/Ink/Moss defaults so a merchant who never visited Branding still
 // gets a polished email.
 type CampaignTheme struct {
-	StoreName       string // merchant-facing name, used for masthead wordmark + "from"
-	LogoURL         string // optional — rendered as <img> when non-empty
-	Tagline         string // short store tagline, shown under wordmark
-	ColorBackground string // page background (paper)
-	ColorText       string // body copy color
-	ColorAccent     string // links + masthead wordmark accent
-	ColorButtonBg   string // reserved for future CTA buttons
-	ColorButtonText string // reserved for future CTA buttons
-	HeadingFont     string // serif cascade for h1/h2/h3 (CSS font-family)
-	BodyFont        string // sans cascade for body (CSS font-family)
-	FooterTagline   string // editorial sign-off line
-	FooterCopyright string // copyright footer (e.g. "© 2026 Acme Store")
-	Unsubscribe     string // unsubscribe link (future)
+	StoreName string // merchant-facing name, used for masthead wordmark + "from"
+	// StoreSlug and StoreContactEmail feed the ENVELOPE (#718) — the From
+	// local part and the Reply-To — not the rendered body. The loader
+	// already reads the store row, so carrying them costs no extra query.
+	StoreSlug         string
+	StoreContactEmail string
+	LogoURL           string // optional — rendered as <img> when non-empty
+	Tagline           string // short store tagline, shown under wordmark
+	ColorBackground   string // page background (paper)
+	ColorText         string // body copy color
+	ColorAccent       string // links + masthead wordmark accent
+	ColorButtonBg     string // reserved for future CTA buttons
+	ColorButtonText   string // reserved for future CTA buttons
+	HeadingFont       string // serif cascade for h1/h2/h3 (CSS font-family)
+	BodyFont          string // sans cascade for body (CSS font-family)
+	FooterTagline     string // editorial sign-off line
+	FooterCopyright   string // copyright footer (e.g. "© 2026 Acme Store")
+	Unsubscribe       string // unsubscribe link (future)
 }
 
 // Default palette — matches packages/ui/src/styles/mark8ly-tokens.css and

--- a/services/marketplace-api/internal/campaign/theme_loader.go
+++ b/services/marketplace-api/internal/campaign/theme_loader.go
@@ -9,7 +9,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/branding"
-	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/internal/storeidentity"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 )
 
@@ -24,11 +24,16 @@ import (
 type StoreThemeLoader struct {
 	db          *gorm.DB
 	brandingSvc *branding.Service
+	identity    storeidentity.Loader
 }
 
 // NewStoreThemeLoader constructs a theme loader.
 func NewStoreThemeLoader(db *gorm.DB, brandingSvc *branding.Service) *StoreThemeLoader {
-	return &StoreThemeLoader{db: db, brandingSvc: brandingSvc}
+	return &StoreThemeLoader{
+		db:          db,
+		brandingSvc: brandingSvc,
+		identity:    storeidentity.NewDBLoader(db),
+	}
 }
 
 // LoadTheme resolves a store + its branding into a CampaignTheme. Any
@@ -41,14 +46,13 @@ func (l *StoreThemeLoader) LoadTheme(ctx context.Context, storeID uuid.UUID) (Ca
 	// worker calls us with a campaign's StoreID and an orphaned campaign
 	// should still attempt dispatch with neutral defaults (which will
 	// almost certainly fail downstream, surfacing the issue explicitly).
-	var store stores.Store
-	err := l.db.WithContext(ctx).
-		Where("id = ?", storeID).
-		First(&store).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+	store, err := l.identity.Load(ctx, storeID)
+	if err != nil {
 		return CampaignTheme{}, fmt.Errorf("campaign: load store: %w", err)
 	}
 	theme.StoreName = store.Name
+	theme.StoreSlug = store.Slug
+	theme.StoreContactEmail = store.ContactEmail
 
 	// Branding is optional — service returns defaults when none exists,
 	// and ErrNotFound is surfaced for truly missing rows. Keep going with

--- a/services/marketplace-api/internal/campaign/theme_loader_identity_integration_test.go
+++ b/services/marketplace-api/internal/campaign/theme_loader_identity_integration_test.go
@@ -1,0 +1,36 @@
+//go:build integration
+
+package campaign
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/branding"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// TestIntegration_LoadTheme_CarriesStoreSenderIdentity — see the twin in
+// internal/giftcard. The campaign send worker reads these two fields
+// straight into the outbound envelope (#718), so a loader that stops
+// populating them silently reverts campaigns to the platform sender.
+func TestIntegration_LoadTheme_CarriesStoreSenderIdentity(t *testing.T) {
+	tx := testdb.NewTx(t)
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, tx, tenantID, storeID)
+	require.NoError(t, tx.Exec(`
+		INSERT INTO store_branding (tenant_id, store_id, support_email)
+		VALUES (?, ?, ?)`, tenantID, storeID, "hello@nadiasceramics.com").Error)
+
+	loader := NewStoreThemeLoader(tx, branding.NewService(branding.ServiceConfig{DB: tx, Repo: branding.NewRepository()}))
+	theme, err := loader.LoadTheme(context.Background(), storeID)
+	require.NoError(t, err)
+
+	require.Equal(t, "Test Store", theme.StoreName)
+	require.NotEmpty(t, theme.StoreSlug)
+	require.Equal(t, "hello@nadiasceramics.com", theme.StoreContactEmail)
+}

--- a/services/marketplace-api/internal/email/identity.go
+++ b/services/marketplace-api/internal/email/identity.go
@@ -1,0 +1,267 @@
+// identity.go — who a Message says it is from.
+//
+// Two identities exist and they are never interchangeable:
+//
+//   - StoreIdentity — customer-facing mail sent BY a merchant's store.
+//     The customer bought from Nadia's Ceramics; the inbox line should
+//     say so. Display name = the store name, local part = the store
+//     slug, Reply-To = the merchant's contact address.
+//
+//   - PlatformIdentity — mail mark8ly sends TO a merchant as their
+//     provider: dunning, trial reminders, payment-action, win-back,
+//     auth. Dressing a failed-payment notice in the merchant's own
+//     brand is misleading, so these keep the platform address and the
+//     platform's own display name.
+//
+// There is deliberately NO default. Neither identity is applied by the
+// transport or by any shared middleware — every mailer picks one at its
+// send site, so switching billing mail to a store identity requires
+// editing that mailer and tripping TestIdentitySplit_ByMailer.
+//
+// The sending DOMAIN is never chosen here: it is taken from whatever
+// address EMAIL_FROM is configured with, so this works unchanged
+// whether that is noreply@tesserix.app today or a mark8ly domain after
+// tesserix/tesserix-k8s#1011.
+package email
+
+import (
+	"strings"
+	"unicode"
+)
+
+// PlatformDisplayName is the fallback inbox name. It matches the
+// "Mark8ly" fallback the order-document and gift-card bodies already
+// use for a store with no name set (orderdoc.Theme.withDefaults), so
+// the envelope and the body copy agree.
+const PlatformDisplayName = "Mark8ly"
+
+// maxDisplayNameRunes keeps the display name well inside the 78-octet
+// RFC 5322 line limit once a provider RFC 2047-encodes a non-ASCII name
+// (worst case ~4 octets per rune plus the encoded-word wrapper).
+const maxDisplayNameRunes = 64
+
+// maxLocalPartLen is the RFC 5321 local-part maximum.
+const maxLocalPartLen = 64
+
+// Identity is the resolved sender identity for one Message.
+type Identity struct {
+	From     string
+	FromName string
+	ReplyTo  string
+}
+
+// Apply writes the identity onto a Message. Mailers build their envelope
+// and then apply an identity, so the choice is one visible line at the
+// send site rather than a field spread across a struct literal.
+func (id Identity) Apply(msg *Message) {
+	msg.From = id.From
+	msg.FromName = id.FromName
+	msg.ReplyTo = id.ReplyTo
+}
+
+// StoreSender is the merchant-controlled input to StoreIdentity. Every
+// field is untrusted text from the stores / store_branding rows.
+type StoreSender struct {
+	// Name is stores.name — rendered in the recipient's inbox list.
+	Name string
+	// Slug is stores.slug — globally unique (uniqueIndex on the column),
+	// which is what makes a slug-derived local part collision-free
+	// between stores without a lookup.
+	Slug string
+	// ContactEmail is store_branding.support_email, or "" when the
+	// merchant has set none.
+	ContactEmail string
+}
+
+// PlatformIdentity returns the identity for mark8ly-to-merchant mail.
+// displayName is the sending surface's own name ("Mark8ly Billing");
+// pass "" to send with no display name at all.
+//
+// ReplyTo is deliberately empty. The platform From is an unattended
+// noreply box, and pointing Reply-To back at it would promise a reply
+// path that does not exist.
+func PlatformIdentity(from, displayName string) Identity {
+	return Identity{From: from, FromName: displayName}
+}
+
+// StoreIdentity derives a store's customer-facing sender identity,
+// hosted on the domain of platformFrom.
+//
+// Every part degrades rather than fails: an underivable slug keeps the
+// platform local part, a hostile or empty name becomes "Mark8ly", and a
+// missing or unroutable contact address falls back to platformFrom, so
+// Reply-To is always a real mailbox and never an empty header.
+func StoreIdentity(platformFrom string, s StoreSender) Identity {
+	id := Identity{
+		From:     platformFrom,
+		FromName: SafeDisplayName(s.Name),
+		ReplyTo:  platformFrom,
+	}
+
+	if local := DeriveLocalPart(s.Slug); local != "" {
+		if domain := addressDomain(platformFrom); domain != "" {
+			id.From = local + "@" + domain
+		}
+	}
+
+	if contact := strings.TrimSpace(s.ContactEmail); contact != "" {
+		if err := ValidateRecipient(contact); err == nil {
+			id.ReplyTo = contact
+		}
+	}
+	return id
+}
+
+// reservedLocalParts are local parts a store must never be able to claim.
+// A store slug is merchant-chosen, so without this a merchant could take
+// `billing@` or `support@` on the platform's own verified domain and send
+// mail that reads as coming from mark8ly itself.
+var reservedLocalParts = map[string]bool{
+	"abuse": true, "accounts": true, "admin": true, "administrator": true,
+	"alerts": true, "billing": true, "dmarc": true, "help": true,
+	"hostmaster": true, "info": true, "mail": true, "mark8ly": true,
+	"no-reply": true, "noreply": true, "notifications": true,
+	"payments": true, "postmaster": true, "root": true, "sales": true,
+	"security": true, "store": true, "support": true, "tesserix": true,
+	"webmaster": true,
+}
+
+// escapePrefix disambiguates a reserved slug from an ordinary one.
+const escapePrefix = "store-"
+
+// DeriveLocalPart normalises a store slug into an RFC-safe local part,
+// returning "" when nothing usable survives (the caller then keeps the
+// platform address).
+//
+// The mapping is injective, so two stores can never share an address:
+// slugs are globally unique, an unreserved slug maps to itself, and a
+// reserved one is prefixed with "store-" — a prefix also applied to any
+// slug that already starts with it, so the escaped and unescaped spaces
+// stay disjoint.
+func DeriveLocalPart(slug string) string {
+	normalised := normaliseSlug(slug)
+	if normalised == "" {
+		return ""
+	}
+	if reservedLocalParts[normalised] || strings.HasPrefix(normalised, escapePrefix) {
+		normalised = escapePrefix + normalised
+	}
+	if len(normalised) > maxLocalPartLen {
+		normalised = strings.Trim(normalised[:maxLocalPartLen], "-")
+	}
+	return normalised
+}
+
+// normaliseSlug lowercases and reduces to [a-z0-9-], collapsing runs of
+// separators and trimming them from both ends. Anything outside the set
+// — including a non-ASCII slug that would otherwise need SMTPUTF8 —
+// becomes a separator rather than being passed through.
+func normaliseSlug(slug string) string {
+	var b strings.Builder
+	lastDash := true // suppresses a leading dash
+	for _, r := range strings.ToLower(strings.TrimSpace(slug)) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastDash = false
+		default:
+			if !lastDash {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// Display-name characters split into two tiers, because neutralising
+// everything produces worse results than rejecting some outright:
+// `"Support" <a@b.com>` stripped down to "Support ab.com" still reads as
+// a support sender in an inbox.
+//
+// fatalNameChars mean the name was shaped like an address or a quoted
+// phrase. There is no honest store name that needs them, so the whole
+// name is discarded rather than salvaged.
+const fatalNameChars = `<>@"\`
+
+// strippableNameChars are punctuation that only misbehaves inside an
+// unquoted display name — Resend takes the name inline as
+// `Name <addr>`, where a comma splits the address list. They are removed
+// and the rest of the name kept, so "Acme, Inc." survives as "Acme Inc.".
+const strippableNameChars = `,;:()[]`
+
+// platformTokens are names no store may wear. A store called
+// "Mark8ly Support" in the inbox line is a phishing sender regardless of
+// what address it sends from, so the name is dropped entirely rather
+// than trimmed — a partial match ("Mark8ly Threads") is indistinguishable
+// from a deliberate one at the point we can check.
+var platformTokens = []string{"mark8ly", "tesserix"}
+
+// SafeDisplayName neutralises a merchant-controlled store name for use
+// as an inbox display name, falling back to PlatformDisplayName when
+// nothing safe survives.
+//
+// Known limit: this catches literal and spaced-out platform names, not
+// homoglyphs or leetspeak ("M4rk8ly"). Those need a confusables table;
+// the fallback here is the floor, not the ceiling.
+func SafeDisplayName(name string) string {
+	// Control characters go first and are dropped, not replaced — CR/LF/
+	// NUL are the header-injection vector and must not survive as
+	// whitespace either. Dropping them before the fatal-character scan
+	// also means "Nadia\r\nBcc: victim@example.com" is judged on the
+	// address it smuggles, not on the line break.
+	var b strings.Builder
+	for _, r := range name {
+		if !unicode.IsControl(r) {
+			b.WriteRune(r)
+		}
+	}
+
+	if strings.ContainsAny(b.String(), fatalNameChars) {
+		return PlatformDisplayName
+	}
+
+	cleaned := strings.Map(func(r rune) rune {
+		if strings.ContainsRune(strippableNameChars, r) {
+			return -1
+		}
+		return r
+	}, b.String())
+
+	cleaned = strings.Join(strings.Fields(cleaned), " ")
+	if cleaned == "" || impersonatesPlatform(cleaned) {
+		return PlatformDisplayName
+	}
+	if runes := []rune(cleaned); len(runes) > maxDisplayNameRunes {
+		cleaned = strings.TrimSpace(string(runes[:maxDisplayNameRunes]))
+	}
+	return cleaned
+}
+
+// impersonatesPlatform reports whether name contains a platform token
+// once punctuation and spacing are stripped, so "M a r k 8 l y" and
+// "Mark-8-ly" are caught alongside the literal string.
+func impersonatesPlatform(name string) bool {
+	var b strings.Builder
+	for _, r := range strings.ToLower(name) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+		}
+	}
+	flattened := b.String()
+	for _, token := range platformTokens {
+		if strings.Contains(flattened, token) {
+			return true
+		}
+	}
+	return false
+}
+
+// addressDomain returns the domain of an address, or "" if it has none.
+func addressDomain(addr string) string {
+	_, domain, found := strings.Cut(strings.TrimSpace(addr), "@")
+	if !found || domain == "" || strings.Contains(domain, "@") {
+		return ""
+	}
+	return domain
+}

--- a/services/marketplace-api/internal/email/identity_split_test.go
+++ b/services/marketplace-api/internal/email/identity_split_test.go
@@ -1,0 +1,290 @@
+package email_test
+
+// identity_split_test.go — the guard on #718's central rule.
+//
+// Two kinds of mail leave this service and they must never converge:
+//
+//   - Store identity     — customer-facing mail sent BY a merchant's
+//     store. The customer bought from Nadia's Ceramics and should see
+//     Nadia's Ceramics.
+//   - Platform identity  — mail mark8ly sends TO a merchant as their
+//     provider: dunning, trial reminders, payment-action, win-back.
+//     A failed-payment notice wearing the merchant's own brand is
+//     actively misleading, so these keep the platform sender.
+//
+// Nothing in the transport enforces this; each mailer opts in at its
+// send site. That is deliberate — a global default is exactly the thing
+// that would silently drag billing mail into the store identity — and it
+// is also why this test exists. It drives the REAL mailers, not a
+// reimplementation of them, so deleting an Apply call or adding one to a
+// billing path goes red here.
+//
+// Adding a mailer? Add it to one of the two tables below. A new
+// customer-facing mailer that forgets its identity fails
+// TestIdentitySplit_StoreMail; a billing path that acquires one fails
+// TestIdentitySplit_PlatformMail.
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/mark8ly/marketplace-api/internal/campaign"
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/giftcard"
+	"github.com/mark8ly/marketplace-api/internal/orderdoc"
+	"github.com/mark8ly/marketplace-api/internal/shipping"
+	"github.com/mark8ly/marketplace-api/internal/storeidentity"
+	"github.com/mark8ly/marketplace-api/internal/ticket"
+)
+
+const (
+	splitFrom      = "noreply@tesserix.app"
+	splitStore     = "Nadia's Ceramics"
+	splitSlug      = "nadias-ceramics"
+	splitContact   = "hello@nadiasceramics.com"
+	splitExpFrom   = "nadias-ceramics@tesserix.app"
+	splitRecipient = "buyer@example.com"
+)
+
+// storeSender is the identity every customer-facing mailer must produce.
+func storeSender() email.StoreSender {
+	return email.StoreSender{Name: splitStore, Slug: splitSlug, ContactEmail: splitContact}
+}
+
+// TestIdentitySplit_StoreMail — every customer-facing mailer must name
+// the merchant in the inbox line and offer the merchant's reply path.
+func TestIdentitySplit_StoreMail(t *testing.T) {
+	cases := []struct {
+		name string
+		send func(t *testing.T, sender email.Sender)
+	}{
+		{
+			name: "orderdoc invoice",
+			send: func(t *testing.T, sender email.Sender) {
+				m := orderdoc.NewDocumentMailer(sender, splitFrom, slog.Default())
+				if err := m.SendInvoice(context.Background(), orderdoc.DocumentInput{
+					Recipient:         splitRecipient,
+					TenantID:          "tenant-1",
+					DocumentNumber:    "INV-1",
+					OrderID:           uuid.NewString(),
+					StoreSlug:         splitSlug,
+					StoreContactEmail: splitContact,
+					OrderNumber:       "ORD-1",
+					PlacedAt:          time.Now(),
+					GrandTotal:        decimal.NewFromInt(42),
+					CurrencyCode:      "EUR",
+					ItemCount:         1,
+					Theme:             orderdoc.Theme{StoreName: splitStore},
+				}); err != nil {
+					t.Fatalf("SendInvoice: %v", err)
+				}
+			},
+		},
+		{
+			name: "giftcard delivery",
+			send: func(t *testing.T, sender email.Sender) {
+				m := giftcard.NewDeliveryMailer(sender, splitFrom, slog.Default())
+				if err := m.SendDelivery(context.Background(), giftcard.DeliveryInput{
+					Recipient: splitRecipient,
+					TenantID:  "tenant-1",
+					Card: &giftcard.GiftCard{
+						Code:           "GC-TEST-0001",
+						CurrentBalance: decimal.NewFromInt(50),
+						CurrencyCode:   "EUR",
+					},
+					Theme: giftcard.GiftCardEmailTheme{
+						StoreName:         splitStore,
+						StoreSlug:         splitSlug,
+						StoreContactEmail: splitContact,
+					},
+				}); err != nil {
+					t.Fatalf("SendDelivery: %v", err)
+				}
+			},
+		},
+		{
+			name: "shipping label",
+			send: func(t *testing.T, sender email.Sender) {
+				m := shipping.NewEmailLabelMailer(sender, splitFrom, slog.Default())
+				if err := m.SendLabel(context.Background(), shipping.LabelEmailPayload{
+					Recipient:         splitRecipient,
+					TenantID:          "tenant-1",
+					StoreName:         splitStore,
+					StoreSlug:         splitSlug,
+					StoreContactEmail: splitContact,
+					OrderNumber:       "ORD-1",
+					Carrier:           "DHL",
+					TrackingNumber:    "TRACK-1",
+					PDF:               []byte("%PDF-1.4 fake"),
+				}); err != nil {
+					t.Fatalf("SendLabel: %v", err)
+				}
+			},
+		},
+		{
+			name: "campaign",
+			send: func(t *testing.T, sender email.Sender) {
+				d := campaign.NewEmailDispatcher(sender, splitFrom, slog.Default())
+				if err := d.Send(context.Background(), campaign.OutboundEmail{
+					Recipient:  splitRecipient,
+					Subject:    "Spring collection",
+					HTMLBody:   "<p>hi</p>",
+					TextBody:   "hi",
+					TenantID:   "tenant-1",
+					CampaignID: uuid.NewString(),
+					Sender:     storeSender(),
+				}); err != nil {
+					t.Fatalf("campaign Send: %v", err)
+				}
+			},
+		},
+		{
+			name: "ticket created",
+			send: func(t *testing.T, sender email.Sender) {
+				n := ticket.NewEmailNotifier(sender, splitFrom, "https://x.example", slog.Default()).
+					WithStoreIdentity(storeidentity.StaticLoader{Store: storeidentity.Store{
+						TenantID:     "tenant-1",
+						Name:         splitStore,
+						Slug:         splitSlug,
+						ContactEmail: splitContact,
+					}})
+				n.NotifyTicketCreated(context.Background(), &ticket.Ticket{
+					TenantID:         uuid.New(),
+					StoreID:          uuid.New(),
+					TicketNumber:     "CASE-1",
+					Subject:          "Where is my order?",
+					SubmittedByEmail: splitRecipient,
+					SubmittedByName:  "A Buyer",
+				})
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sender := &captureSender{}
+			c.send(t, sender)
+			msg := sender.last(t)
+
+			if msg.FromName != splitStore {
+				t.Errorf("FromName = %q, want %q — the customer must see the store, not the platform",
+					msg.FromName, splitStore)
+			}
+			if msg.From != splitExpFrom {
+				t.Errorf("From = %q, want %q", msg.From, splitExpFrom)
+			}
+			if msg.ReplyTo != splitContact {
+				t.Errorf("ReplyTo = %q, want %q — a reply must reach the merchant",
+					msg.ReplyTo, splitContact)
+			}
+			if msg.CustomArgs["product"] != "mark8ly" {
+				t.Errorf("product attribution lost: %v", msg.CustomArgs)
+			}
+			if msg.CustomArgs["tenant_id"] == "" {
+				t.Errorf("tenant_id attribution lost: %v", msg.CustomArgs)
+			}
+		})
+	}
+}
+
+// TestIdentitySplit_PlatformMail — mark8ly-to-merchant mail must stay on
+// the platform address and must never acquire a store's display name or
+// a merchant Reply-To. Every billing template is exercised, so switching
+// any single one to a store identity goes red.
+func TestIdentitySplit_PlatformMail(t *testing.T) {
+	// EVERY template the billing client can send — dunning, trial
+	// lifecycle, payment-action, migration decisions, win-back. Listed in
+	// full rather than sampled, so flipping any one of them to a store
+	// identity has nowhere to hide.
+	billing := []email.TemplateID{
+		email.TemplateDunningDay5,
+		email.TemplateDunningDay7,
+		email.TemplatePaymentActionReminder,
+		email.TemplateTrialNoPMT15,
+		email.TemplateTrialNoPMT10,
+		email.TemplateTrialNoPMT7,
+		email.TemplateTrialNoPMT3,
+		email.TemplateTrialNoPMT1,
+		email.TemplateTrialHasPMT1,
+		email.TemplateTrialStartedBilled,
+		email.TemplateTrialExpired,
+		email.TemplateMigrationFastPathApproved,
+		email.TemplateMigrationFastPathRejected,
+		email.TemplateWinBack,
+	}
+
+	for _, tmpl := range billing {
+		t.Run(string(tmpl), func(t *testing.T) {
+			sender := &captureSender{}
+			loader := loaderWith(string(tmpl), "Subject for {{.store_name}}",
+				"<p>{{.store_name}}</p>", "{{.store_name}}")
+			c := email.NewTemplateClient(loader, sender, splitFrom, slog.Default())
+
+			// The merchant's store name reaches this mail as template
+			// DATA. That is the trap: it is right there in the payload,
+			// one line away from being used as the sender.
+			err := c.Send(context.Background(), tmpl, "merchant@example.com", map[string]any{
+				"store_name": splitStore,
+				"tenant_id":  "tenant-1",
+				"day":        5,
+			})
+			if err != nil {
+				t.Fatalf("Send: %v", err)
+			}
+
+			msg := sender.last(t)
+			if msg.From != splitFrom {
+				t.Errorf("From = %q, want the platform address %q", msg.From, splitFrom)
+			}
+			if msg.FromName != "Mark8ly Billing" {
+				t.Errorf("FromName = %q, want the platform display name", msg.FromName)
+			}
+			if strings.Contains(msg.FromName, splitStore) {
+				t.Errorf("billing mail is wearing the merchant's brand: FromName = %q", msg.FromName)
+			}
+			if msg.ReplyTo != "" {
+				t.Errorf("ReplyTo = %q, want empty — billing mail must not route replies to the merchant",
+					msg.ReplyTo)
+			}
+			// The body still names the store; only the ENVELOPE is the
+			// platform's. This distinguishes a correct implementation
+			// from one that simply never saw the store name. Asserted on
+			// the text body: the HTML one is escaped by html/template,
+			// so the apostrophe in the store name would not match.
+			if !strings.Contains(msg.TextBody, splitStore) {
+				t.Errorf("body lost the store name: %q", msg.TextBody)
+			}
+		})
+	}
+}
+
+// TestIdentitySplit_NoGlobalDefault is the structural half of the rule:
+// a bare Message must come out of the transport with no identity at all.
+// If someone ever adds a default From/FromName inside the email package
+// — the change that would silently apply a store identity everywhere —
+// this fails.
+func TestIdentitySplit_NoGlobalDefault(t *testing.T) {
+	msg := email.Message{}
+	if msg.From != "" || msg.FromName != "" || msg.ReplyTo != "" {
+		t.Fatalf("zero Message carries an identity: %+v", msg)
+	}
+
+	// And the two constructors must not be interchangeable.
+	store := email.StoreIdentity(splitFrom, storeSender())
+	platform := email.PlatformIdentity(splitFrom, "Mark8ly Billing")
+	if store.From == platform.From {
+		t.Errorf("store and platform identities share a From (%q)", store.From)
+	}
+	if store.FromName == platform.FromName {
+		t.Errorf("store and platform identities share a FromName (%q)", store.FromName)
+	}
+	if platform.ReplyTo != "" {
+		t.Errorf("platform identity acquired a ReplyTo: %q", platform.ReplyTo)
+	}
+}

--- a/services/marketplace-api/internal/email/identity_test.go
+++ b/services/marketplace-api/internal/email/identity_test.go
@@ -1,0 +1,288 @@
+package email
+
+import (
+	"strings"
+	"testing"
+)
+
+const platformFrom = "noreply@tesserix.app"
+
+func TestDeriveLocalPart(t *testing.T) {
+	cases := []struct{ slug, want string }{
+		{"nadias-ceramics", "nadias-ceramics"},
+		{"Nadias-Ceramics", "nadias-ceramics"},
+		{"acme", "acme"},
+		{"store123", "store123"},
+
+		// Normalisation: anything outside [a-z0-9-] collapses to one dash
+		// and never leaks to the edges.
+		{"Nadia's Ceramics", "nadia-s-ceramics"},
+		{"  spaced  out  ", "spaced-out"},
+		{"--leading--and--trailing--", "leading-and-trailing"},
+		{"dots.and_underscores", "dots-and-underscores"},
+
+		// Nothing usable survives — caller keeps the platform address.
+		{"", ""},
+		{"   ", ""},
+		{"---", ""},
+		{"日本語", ""},
+		{"!!!", ""},
+
+		// A non-ASCII slug must not reach the wire as-is; SMTPUTF8 is not
+		// something either provider is configured for.
+		{"café", "caf"},
+
+		// Reserved local parts are escaped, so no merchant can claim an
+		// address that reads as the platform speaking.
+		{"support", "store-support"},
+		{"billing", "store-billing"},
+		{"noreply", "store-noreply"},
+		{"security", "store-security"},
+		{"mark8ly", "store-mark8ly"},
+		{"Support", "store-support"},
+
+		// ...and the escape space is itself escaped, so the mapping stays
+		// injective: "support" and "store-support" cannot collide.
+		{"store-support", "store-store-support"},
+		{"store-anything", "store-store-anything"},
+	}
+	for _, c := range cases {
+		if got := DeriveLocalPart(c.slug); got != c.want {
+			t.Errorf("DeriveLocalPart(%q) = %q, want %q", c.slug, got, c.want)
+		}
+	}
+}
+
+// TestDeriveLocalPart_Injective is the collision rule stated as a
+// property: distinct slugs must never produce the same local part, or
+// two stores would share one sender address.
+func TestDeriveLocalPart_Injective(t *testing.T) {
+	slugs := []string{
+		"support", "store-support", "store-store-support",
+		"billing", "store-billing", "nadias-ceramics", "store", "store-store",
+	}
+	seen := map[string]string{}
+	for _, slug := range slugs {
+		got := DeriveLocalPart(slug)
+		if prev, dup := seen[got]; dup {
+			t.Errorf("collision: %q and %q both derive %q", prev, slug, got)
+		}
+		seen[got] = slug
+	}
+}
+
+func TestDeriveLocalPart_RespectsRFCLength(t *testing.T) {
+	got := DeriveLocalPart(strings.Repeat("a", 200))
+	if len(got) > maxLocalPartLen {
+		t.Errorf("local part %d chars, want <= %d", len(got), maxLocalPartLen)
+	}
+	if strings.HasSuffix(got, "-") || strings.HasPrefix(got, "-") {
+		t.Errorf("truncation left a dangling separator: %q", got)
+	}
+}
+
+// TestSafeDisplayName_Hostile is the phishing surface. The store name is
+// merchant-controlled text rendered in a stranger's inbox.
+func TestSafeDisplayName_Hostile(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"honest name passes through", "Nadia's Ceramics", "Nadia's Ceramics"},
+		{"unicode name survives", "Café Noir", "Café Noir"},
+
+		// The #718 headline case.
+		{"platform support impersonation", "Mark8ly Support", PlatformDisplayName},
+		{"platform billing impersonation", "Mark8ly Billing", PlatformDisplayName},
+		{"platform name alone", "mark8ly", PlatformDisplayName},
+		{"platform name spaced out", "M a r k 8 l y  S e c u r i t y", PlatformDisplayName},
+		{"platform name punctuated", "Mark-8-ly Support", PlatformDisplayName},
+		{"sibling brand", "Tesserix Ops", PlatformDisplayName},
+
+		// Address-shaped names: a client rendering these can show a
+		// second, forged address next to the real one.
+		{"embedded address", "Nadia <security@mark8ly.com>", PlatformDisplayName},
+		{"bare address", "security@example.com", PlatformDisplayName},
+		{"quoted spoof", `"Support" <a@b.com>`, PlatformDisplayName},
+		{"comment syntax", "Nadia (via mark8ly)", PlatformDisplayName},
+
+		// Header injection at the name layer.
+		{"crlf injection", "Nadia\r\nBcc: victim@example.com", PlatformDisplayName},
+		{"newline only", "Nadia\nX-Spoof: 1", "NadiaX-Spoof 1"},
+		{"comma survives", "Acme, Inc.", "Acme Inc."},
+		{"nul byte", "Nadia\x00", "Nadia"},
+
+		// The #718 acceptance criterion: an unnamed store keeps the
+		// "Mark8ly" body-copy fallback.
+		{"empty name", "", PlatformDisplayName},
+		{"whitespace only", "   \t  ", PlatformDisplayName},
+		{"specials only", "<>@,;", PlatformDisplayName},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := SafeDisplayName(c.input)
+			if got != c.want {
+				t.Fatalf("SafeDisplayName(%q) = %q, want %q", c.input, got, c.want)
+			}
+			// Whatever survives must be transport-safe, unconditionally.
+			if strings.ContainsAny(got, "\r\n\x00") {
+				t.Errorf("result carries a control character: %q", got)
+			}
+			if strings.ContainsAny(got, fatalNameChars+strippableNameChars) {
+				t.Errorf("result carries an RFC 5322 special: %q", got)
+			}
+		})
+	}
+}
+
+func TestSafeDisplayName_Truncates(t *testing.T) {
+	got := SafeDisplayName(strings.Repeat("ü", 200))
+	if n := len([]rune(got)); n > maxDisplayNameRunes {
+		t.Errorf("display name %d runes, want <= %d", n, maxDisplayNameRunes)
+	}
+}
+
+func TestStoreIdentity(t *testing.T) {
+	got := StoreIdentity(platformFrom, StoreSender{
+		Name:         "Nadia's Ceramics",
+		Slug:         "nadias-ceramics",
+		ContactEmail: "hello@nadiasceramics.com",
+	})
+
+	// The local part is derived; the DOMAIN comes from the configured
+	// platform address and is never hardcoded, so this keeps working
+	// after tesserix/tesserix-k8s#1011 moves the sending domain.
+	if got.From != "nadias-ceramics@tesserix.app" {
+		t.Errorf("From = %q", got.From)
+	}
+	if got.FromName != "Nadia's Ceramics" {
+		t.Errorf("FromName = %q", got.FromName)
+	}
+	if got.ReplyTo != "hello@nadiasceramics.com" {
+		t.Errorf("ReplyTo = %q", got.ReplyTo)
+	}
+}
+
+func TestStoreIdentity_FollowsConfiguredDomain(t *testing.T) {
+	got := StoreIdentity("noreply@mail.mark8ly.com", StoreSender{
+		Name: "Nadia's Ceramics", Slug: "nadias-ceramics",
+	})
+	if got.From != "nadias-ceramics@mail.mark8ly.com" {
+		t.Errorf("From = %q; the domain must follow EMAIL_FROM", got.From)
+	}
+}
+
+// TestStoreIdentity_Degrades pins that no input can produce a broken
+// envelope: an empty Reply-To, a bare "@domain", or an empty From name.
+func TestStoreIdentity_Degrades(t *testing.T) {
+	cases := []struct {
+		name         string
+		in           StoreSender
+		wantFrom     string
+		wantFromName string
+		wantReplyTo  string
+	}{
+		{
+			name:         "no slug keeps the platform local part",
+			in:           StoreSender{Name: "Nadia's Ceramics"},
+			wantFrom:     platformFrom,
+			wantFromName: "Nadia's Ceramics",
+			wantReplyTo:  platformFrom,
+		},
+		{
+			name:         "underivable slug keeps the platform local part",
+			in:           StoreSender{Name: "Nadia's Ceramics", Slug: "日本語"},
+			wantFrom:     platformFrom,
+			wantFromName: "Nadia's Ceramics",
+			wantReplyTo:  platformFrom,
+		},
+		{
+			name:         "unnamed store falls back to Mark8ly",
+			in:           StoreSender{Slug: "acme"},
+			wantFrom:     "acme@tesserix.app",
+			wantFromName: PlatformDisplayName,
+			wantReplyTo:  platformFrom,
+		},
+		{
+			name:         "hostile name falls back to Mark8ly",
+			in:           StoreSender{Name: "Mark8ly Support", Slug: "acme"},
+			wantFrom:     "acme@tesserix.app",
+			wantFromName: PlatformDisplayName,
+			wantReplyTo:  platformFrom,
+		},
+		{
+			name:         "unroutable contact falls back to the platform address",
+			in:           StoreSender{Name: "Acme", Slug: "acme", ContactEmail: "owner@acme.local"},
+			wantFrom:     "acme@tesserix.app",
+			wantFromName: "Acme",
+			wantReplyTo:  platformFrom,
+		},
+		{
+			name:         "malformed contact falls back to the platform address",
+			in:           StoreSender{Name: "Acme", Slug: "acme", ContactEmail: "not-an-address"},
+			wantFrom:     "acme@tesserix.app",
+			wantFromName: "Acme",
+			wantReplyTo:  platformFrom,
+		},
+		{
+			name:         "reserved slug is escaped",
+			in:           StoreSender{Name: "Support Co", Slug: "support"},
+			wantFrom:     "store-support@tesserix.app",
+			wantFromName: "Support Co",
+			wantReplyTo:  platformFrom,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := StoreIdentity(platformFrom, c.in)
+			if got.From != c.wantFrom {
+				t.Errorf("From = %q, want %q", got.From, c.wantFrom)
+			}
+			if got.FromName != c.wantFromName {
+				t.Errorf("FromName = %q, want %q", got.FromName, c.wantFromName)
+			}
+			if got.ReplyTo != c.wantReplyTo {
+				t.Errorf("ReplyTo = %q, want %q", got.ReplyTo, c.wantReplyTo)
+			}
+			if got.ReplyTo == "" {
+				t.Error("ReplyTo is empty; a store identity must always offer a reply path")
+			}
+		})
+	}
+}
+
+// TestStoreIdentity_AlwaysPassesTransportValidation is the belt-and-
+// braces check: no merchant input may produce a Message the transport
+// then refuses, which would drop a real order confirmation.
+func TestStoreIdentity_AlwaysPassesTransportValidation(t *testing.T) {
+	hostile := []StoreSender{
+		{Name: "Mark8ly Support", Slug: "support", ContactEmail: "a@b.local"},
+		{Name: "Nadia\r\nBcc: victim@example.com", Slug: "nadia\r\nx"},
+		{Name: "<script>alert(1)</script>", Slug: strings.Repeat("z", 300)},
+		{Name: "", Slug: "", ContactEmail: ""},
+		{Name: "N", Slug: "-", ContactEmail: "a@b.com\r\nBcc: v@e.com"},
+	}
+	for _, s := range hostile {
+		msg := Message{To: "buyer@example.com", Subject: "s", TextBody: "b"}
+		StoreIdentity(platformFrom, s).Apply(&msg)
+		if err := validate(msg); err != nil {
+			t.Errorf("StoreIdentity(%+v) produced an unsendable message: %v", s, err)
+		}
+	}
+}
+
+// TestPlatformIdentity keeps mark8ly-to-merchant mail on the platform
+// address and offers no reply path into an unattended noreply box.
+func TestPlatformIdentity(t *testing.T) {
+	got := PlatformIdentity(platformFrom, "Mark8ly Billing")
+	if got.From != platformFrom {
+		t.Errorf("From = %q", got.From)
+	}
+	if got.FromName != "Mark8ly Billing" {
+		t.Errorf("FromName = %q", got.FromName)
+	}
+	if got.ReplyTo != "" {
+		t.Errorf("ReplyTo = %q, want empty", got.ReplyTo)
+	}
+}

--- a/services/marketplace-api/internal/email/resend.go
+++ b/services/marketplace-api/internal/email/resend.go
@@ -42,6 +42,37 @@ func (s *ResendSender) Send(ctx context.Context, msg Message) error {
 		return fmt.Errorf("email: Resend API key is not configured")
 	}
 
+	raw, err := json.Marshal(buildResendRequest(msg))
+	if err != nil {
+		return fmt.Errorf("email: marshal resend request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		"https://api.resend.com/emails", bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("email: build resend request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("email: resend POST: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("email: resend returned %d: %s", resp.StatusCode, string(respBody))
+}
+
+// buildResendRequest renders a Message into Resend's wire shape. Split
+// out of Send so the envelope — the inline "Name <addr>" From, reply_to
+// and the tags that mirror SendGrid's custom_args attribution — can be
+// asserted without an HTTP round trip.
+func buildResendRequest(msg Message) resendRequest {
 	// Resend has no per-send tracking toggle (click/open tracking is off
 	// unless enabled on the domain), so magic-link tokens are safe by
 	// default. Attribution mirrors the SendGrid custom_args via tags —
@@ -87,33 +118,11 @@ func (s *ResendSender) Send(ctx context.Context, msg Message) error {
 		Subject:     msg.Subject,
 		HTML:        msg.HTMLBody,
 		Text:        msg.TextBody,
+		ReplyTo:     msg.ReplyTo,
 		Tags:        tags,
 		Attachments: attachments,
 	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return fmt.Errorf("email: marshal resend request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		"https://api.resend.com/emails", bytes.NewReader(raw))
-	if err != nil {
-		return fmt.Errorf("email: build resend request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+s.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := s.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("email: resend POST: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		return nil
-	}
-	respBody, _ := io.ReadAll(resp.Body)
-	return fmt.Errorf("email: resend returned %d: %s", resp.StatusCode, string(respBody))
+	return body
 }
 
 // resendTagSafe reports whether s is a valid Resend tag name or value:
@@ -138,11 +147,14 @@ func resendTagSafe(s string) bool {
 
 // Resend API request shape — minimum viable subset.
 type resendRequest struct {
-	From        string             `json:"from"`
-	To          []string           `json:"to"`
-	Subject     string             `json:"subject"`
-	HTML        string             `json:"html,omitempty"`
-	Text        string             `json:"text,omitempty"`
+	From    string   `json:"from"`
+	To      []string `json:"to"`
+	Subject string   `json:"subject"`
+	HTML    string   `json:"html,omitempty"`
+	Text    string   `json:"text,omitempty"`
+	// Resend accepts reply_to as either a string or an array; the string
+	// form is used, and omitempty keeps it off the wire when unset.
+	ReplyTo     string             `json:"reply_to,omitempty"`
 	Tags        []resendTag        `json:"tags,omitempty"`
 	Attachments []resendAttachment `json:"attachments,omitempty"`
 }

--- a/services/marketplace-api/internal/email/sender.go
+++ b/services/marketplace-api/internal/email/sender.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 )
 
 // Message is one outbound email, provider-agnostic. The product mailers
@@ -24,6 +25,15 @@ type Message struct {
 	FromName string // optional display name (e.g. "Mark8ly Support")
 	To       string // recipient address — required
 	ToName   string // optional recipient display name
+
+	// ReplyTo, when set, is emitted as the RFC 5322 Reply-To header so a
+	// recipient's reply reaches a mailbox someone actually reads instead
+	// of the unattended From address. Store-branded mail carries the
+	// merchant's contact address (see StoreIdentity); platform mail
+	// leaves this empty rather than inviting replies to a noreply box.
+	// validate rejects a malformed value — a broken Reply-To silently
+	// strands every reply, so it fails the send instead.
+	ReplyTo string
 
 	Subject  string
 	HTMLBody string // either body may be empty, but not both
@@ -76,6 +86,30 @@ func validate(msg Message) error {
 	}
 	if msg.HTMLBody == "" && msg.TextBody == "" {
 		return fmt.Errorf("email: missing body")
+	}
+	// Header-injection backstop. Every one of these lands in an RFC 5322
+	// header, and FromName is merchant-controlled text (the store name).
+	// SafeDisplayName already neutralises it upstream, but this is the
+	// boundary no call site can bypass — and Resend's From is an inline
+	// "Name <addr>" string the provider re-parses, so a bare newline
+	// there is a real injection point rather than a JSON-escaped one.
+	for label, value := range map[string]string{
+		"from": msg.From, "from name": msg.FromName,
+		"to": msg.To, "to name": msg.ToName,
+		"reply-to": msg.ReplyTo, "subject": msg.Subject,
+	} {
+		if strings.ContainsAny(value, "\r\n\x00") {
+			return fmt.Errorf("email: %s contains a line break or NUL", label)
+		}
+	}
+	// An unset Reply-To is fine (platform mail); a set-but-unroutable one
+	// is not. Emitting it would strand every reply, and neither provider
+	// rejects it for us — SendGrid accepts any syntactically-plausible
+	// address and Resend accepts the string verbatim.
+	if msg.ReplyTo != "" {
+		if err := ValidateRecipient(msg.ReplyTo); err != nil {
+			return fmt.Errorf("email: invalid reply-to %q: %w", msg.ReplyTo, err)
+		}
 	}
 	return nil
 }

--- a/services/marketplace-api/internal/email/sendgrid.go
+++ b/services/marketplace-api/internal/email/sendgrid.go
@@ -39,6 +39,37 @@ func (s *SendGridSender) Send(ctx context.Context, msg Message) error {
 		return fmt.Errorf("email: SendGrid API key is not configured")
 	}
 
+	raw, err := json.Marshal(buildSendGridRequest(msg))
+	if err != nil {
+		return fmt.Errorf("email: marshal sendgrid request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		"https://api.sendgrid.com/v3/mail/send", bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("email: build sendgrid request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("email: sendgrid POST: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("email: sendgrid returned %d: %s", resp.StatusCode, string(respBody))
+}
+
+// buildSendGridRequest renders a Message into SendGrid's wire shape.
+// Split out of Send so the envelope — sender identity, reply-to and the
+// custom_args attribution the notification-service webhook receiver
+// joins on — can be asserted without an HTTP round trip.
+func buildSendGridRequest(msg Message) sgRequest {
 	// SendGrid rejects content entries with empty values and requires
 	// text/plain to precede text/html, so only the parts a mailer
 	// actually rendered are included (the ticket notifier is HTML-only).
@@ -73,7 +104,11 @@ func (s *SendGridSender) Send(ctx context.Context, msg Message) error {
 		Personalizations: []sgPersonalization{{
 			To: []sgAddress{{Email: msg.To, Name: msg.ToName}},
 		}},
-		From:        sgAddress{Email: msg.From, Name: msg.FromName},
+		From: sgAddress{Email: msg.From, Name: msg.FromName},
+		// Reply-To is a pointer so an unset one is omitted entirely;
+		// SendGrid rejects `"reply_to": {}` with a 400 rather than
+		// ignoring it.
+		ReplyTo:     replyToAddress(msg),
 		Subject:     msg.Subject,
 		Content:     content,
 		Attachments: attachments,
@@ -95,36 +130,25 @@ func (s *SendGridSender) Send(ctx context.Context, msg Message) error {
 			},
 		},
 	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return fmt.Errorf("email: marshal sendgrid request: %w", err)
-	}
+	return body
+}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		"https://api.sendgrid.com/v3/mail/send", bytes.NewReader(raw))
-	if err != nil {
-		return fmt.Errorf("email: build sendgrid request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+s.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := s.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("email: sendgrid POST: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+// replyToAddress renders Message.ReplyTo as SendGrid's reply_to object,
+// or nil when unset. The display name is deliberately NOT repeated here:
+// the merchant's contact address is their own mailbox, and labelling it
+// with the store name would let a store name reach a second header.
+func replyToAddress(msg Message) *sgAddress {
+	if msg.ReplyTo == "" {
 		return nil
 	}
-	respBody, _ := io.ReadAll(resp.Body)
-	return fmt.Errorf("email: sendgrid returned %d: %s", resp.StatusCode, string(respBody))
+	return &sgAddress{Email: msg.ReplyTo}
 }
 
 // SendGrid v3 API request shapes — minimum viable subset.
 type sgRequest struct {
 	Personalizations []sgPersonalization `json:"personalizations"`
 	From             sgAddress           `json:"from"`
+	ReplyTo          *sgAddress          `json:"reply_to,omitempty"`
 	Subject          string              `json:"subject"`
 	Content          []sgContent         `json:"content"`
 	Attachments      []sgAttachment      `json:"attachments,omitempty"`

--- a/services/marketplace-api/internal/email/wire_test.go
+++ b/services/marketplace-api/internal/email/wire_test.go
@@ -1,0 +1,193 @@
+package email
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// storeMsg is a customer-facing envelope with a full store sender
+// identity — the shape #718 introduces.
+func storeMsg() Message {
+	return Message{
+		From:     "nadias-ceramics@mail.mark8ly.com",
+		FromName: "Nadia's Ceramics",
+		ReplyTo:  "hello@nadiasceramics.com",
+		To:       "buyer@example.com",
+		ToName:   "A Buyer",
+		Subject:  "Your order is confirmed",
+		HTMLBody: "<p>hi</p>",
+		TextBody: "hi",
+		CustomArgs: map[string]string{
+			"product":   "mark8ly",
+			"kind":      "invoice",
+			"tenant_id": "d3b07384-d9a0-4f1e-9b1a-000000000001",
+		},
+	}
+}
+
+// TestSendGridRequest_SenderIdentity pins every field of the From /
+// Reply-To pair onto SendGrid's wire shape. FromName had two callers
+// before #718 and no test proving it reached the provider at all.
+func TestSendGridRequest_SenderIdentity(t *testing.T) {
+	got := buildSendGridRequest(storeMsg())
+
+	if got.From.Email != "nadias-ceramics@mail.mark8ly.com" {
+		t.Errorf("from email = %q", got.From.Email)
+	}
+	if got.From.Name != "Nadia's Ceramics" {
+		t.Errorf("from name = %q; FromName must reach the provider", got.From.Name)
+	}
+	if got.ReplyTo == nil {
+		t.Fatal("reply_to omitted; a set ReplyTo must be emitted")
+	}
+	if got.ReplyTo.Email != "hello@nadiasceramics.com" {
+		t.Errorf("reply_to = %q", got.ReplyTo.Email)
+	}
+}
+
+// TestSendGridRequest_NoReplyTo_OmitsField guards the 400 SendGrid
+// returns for an empty reply_to object: platform mail sets no ReplyTo,
+// so the key must be absent from the JSON, not present-and-empty.
+func TestSendGridRequest_NoReplyTo_OmitsField(t *testing.T) {
+	msg := storeMsg()
+	msg.ReplyTo = ""
+
+	if got := buildSendGridRequest(msg); got.ReplyTo != nil {
+		t.Fatalf("reply_to = %+v, want nil", got.ReplyTo)
+	}
+	raw, err := json.Marshal(buildSendGridRequest(msg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "reply_to") {
+		t.Errorf("reply_to present in payload: %s", raw)
+	}
+}
+
+// TestSendGridRequest_CustomArgsSurvive is the #718 acceptance check
+// that bounce/complaint attribution still reaches provider webhooks
+// after the sender identity change.
+func TestSendGridRequest_CustomArgsSurvive(t *testing.T) {
+	got := buildSendGridRequest(storeMsg())
+
+	for k, want := range map[string]string{
+		"product":   "mark8ly",
+		"kind":      "invoice",
+		"tenant_id": "d3b07384-d9a0-4f1e-9b1a-000000000001",
+	} {
+		if got.CustomArgs[k] != want {
+			t.Errorf("custom_args[%q] = %q, want %q", k, got.CustomArgs[k], want)
+		}
+	}
+}
+
+// TestResendRequest_SenderIdentity pins Resend's inline RFC-5322 From
+// and its string-form reply_to.
+func TestResendRequest_SenderIdentity(t *testing.T) {
+	got := buildResendRequest(storeMsg())
+
+	const wantFrom = "Nadia's Ceramics <nadias-ceramics@mail.mark8ly.com>"
+	if got.From != wantFrom {
+		t.Errorf("from = %q, want %q", got.From, wantFrom)
+	}
+	if got.ReplyTo != "hello@nadiasceramics.com" {
+		t.Errorf("reply_to = %q", got.ReplyTo)
+	}
+}
+
+// TestResendRequest_NoFromName_BareAddress keeps the pre-#718 behaviour
+// for mail that sets no display name.
+func TestResendRequest_NoFromName_BareAddress(t *testing.T) {
+	msg := storeMsg()
+	msg.FromName = ""
+	msg.ReplyTo = ""
+
+	got := buildResendRequest(msg)
+	if got.From != "nadias-ceramics@mail.mark8ly.com" {
+		t.Errorf("from = %q, want the bare address", got.From)
+	}
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "reply_to") {
+		t.Errorf("reply_to present in payload: %s", raw)
+	}
+}
+
+// TestResendRequest_TagsCarryAttribution mirrors the SendGrid
+// custom_args check — Resend echoes tags back on webhook events.
+func TestResendRequest_TagsCarryAttribution(t *testing.T) {
+	got := buildResendRequest(storeMsg())
+
+	seen := map[string]string{}
+	for _, tag := range got.Tags {
+		seen[tag.Name] = tag.Value
+	}
+	if seen["product"] != "mark8ly" || seen["kind"] != "invoice" {
+		t.Errorf("tags = %+v", got.Tags)
+	}
+	if seen["tenant_id"] != "d3b07384-d9a0-4f1e-9b1a-000000000001" {
+		t.Errorf("tenant_id tag = %q", seen["tenant_id"])
+	}
+}
+
+// TestValidate_ReplyTo refuses a Reply-To that would strand every reply.
+// A broken value must fail the send rather than ship a dead header.
+func TestValidate_ReplyTo(t *testing.T) {
+	cases := []struct {
+		name    string
+		replyTo string
+		wantErr bool
+	}{
+		{"unset is fine", "", false},
+		{"real address", "hello@nadiasceramics.com", false},
+		{"no at sign", "hello.nadiasceramics.com", true},
+		{"no domain", "hello@", true},
+		{"unroutable .local", "billing@mark8ly.local", true},
+		{"bare hostname", "hello@localhost", true},
+		{"header injection", "a@b.com\r\nBcc: victim@example.com", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			msg := storeMsg()
+			msg.ReplyTo = c.replyTo
+			err := validate(msg)
+			if c.wantErr && err == nil {
+				t.Fatalf("validate(reply-to %q) = nil, want error", c.replyTo)
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("validate(reply-to %q) = %v, want nil", c.replyTo, err)
+			}
+		})
+	}
+}
+
+// TestValidate_RejectsHeaderInjection covers the boundary no call site
+// can bypass. The single-@ Reply-To case matters most: ValidateRecipient
+// alone lets it through, because it only rejects a SECOND "@" in the
+// domain — so "a@b.com\r\nBcc: x" is caught here and nowhere else.
+func TestValidate_RejectsHeaderInjection(t *testing.T) {
+	cases := []struct {
+		field  string
+		mutate func(*Message)
+	}{
+		{"FromName", func(m *Message) { m.FromName = "Nadia's\r\nBcc: victim@example.com" }},
+		{"From", func(m *Message) { m.From = "a@b.com\nX-Spoof: 1" }},
+		{"To", func(m *Message) { m.To = "a@b.com\r\nCc: victim@example.com" }},
+		{"ToName", func(m *Message) { m.ToName = "Buyer\r\nSubject: spoofed" }},
+		{"ReplyTo", func(m *Message) { m.ReplyTo = "a@b.com\r\nBcc: victim@example.com" }},
+		{"Subject", func(m *Message) { m.Subject = "Hi\r\nBcc: victim@example.com" }},
+		{"NUL in FromName", func(m *Message) { m.FromName = "Nadia\x00" }},
+	}
+	for _, c := range cases {
+		t.Run(c.field, func(t *testing.T) {
+			msg := storeMsg()
+			c.mutate(&msg)
+			if err := validate(msg); err == nil {
+				t.Fatalf("validate accepted an injected %s", c.field)
+			}
+		})
+	}
+}

--- a/services/marketplace-api/internal/giftcard/mailer.go
+++ b/services/marketplace-api/internal/giftcard/mailer.go
@@ -40,7 +40,14 @@ type DeliveryInput struct {
 // gift-card email. Kept as a plain struct (not a branding type) so the
 // giftcard package doesn't depend on the branding package internals.
 type GiftCardEmailTheme struct {
-	StoreName       string
+	StoreName string
+	// StoreSlug and StoreContactEmail feed the ENVELOPE (#718) — the
+	// From local part and the Reply-To — not the rendered body. They
+	// live here because the theme loader already reads the store row, so
+	// carrying them costs no extra query.
+	StoreSlug         string
+	StoreContactEmail string
+
 	LogoURL         string
 	Tagline         string
 	ColorBackground string
@@ -267,14 +274,21 @@ func (m *DeliveryMailer) SendDelivery(ctx context.Context, in DeliveryInput) err
 		customArgs["tenant_id"] = in.TenantID
 	}
 
-	if err := m.sender.Send(ctx, email.Message{
-		From:       m.from,
+	msg := email.Message{
 		To:         in.Recipient,
 		Subject:    subject,
 		HTMLBody:   htmlBody,
 		TextBody:   textBody,
 		CustomArgs: customArgs,
-	}); err != nil {
+	}
+	// Customer-facing: a gift card arrives from the store that issued it.
+	email.StoreIdentity(m.from, email.StoreSender{
+		Name:         in.Theme.StoreName,
+		Slug:         in.Theme.StoreSlug,
+		ContactEmail: in.Theme.StoreContactEmail,
+	}).Apply(&msg)
+
+	if err := m.sender.Send(ctx, msg); err != nil {
 		return fmt.Errorf("giftcard: send delivery email: %w", err)
 	}
 	return nil

--- a/services/marketplace-api/internal/giftcard/theme_loader.go
+++ b/services/marketplace-api/internal/giftcard/theme_loader.go
@@ -9,7 +9,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/branding"
-	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/internal/storeidentity"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 )
 
@@ -20,6 +20,7 @@ import (
 // never customized their branding still gets a polished email.
 type StoreThemeLoader struct {
 	db                *gorm.DB
+	identity          storeidentity.Loader
 	brandingSvc       *branding.Service
 	storefrontURLBase string // e.g. "https://{slug}.mark8ly.com" — {slug} is substituted
 }
@@ -31,6 +32,7 @@ type StoreThemeLoader struct {
 func NewStoreThemeLoader(db *gorm.DB, brandingSvc *branding.Service, storefrontURLBase string) *StoreThemeLoader {
 	return &StoreThemeLoader{
 		db:                db,
+		identity:          storeidentity.NewDBLoader(db),
 		brandingSvc:       brandingSvc,
 		storefrontURLBase: storefrontURLBase,
 	}
@@ -43,14 +45,13 @@ func (l *StoreThemeLoader) LoadTheme(ctx context.Context, storeID uuid.UUID) (Gi
 	theme := GiftCardEmailTheme{}
 	storefrontURL := ""
 
-	var store stores.Store
-	err := l.db.WithContext(ctx).
-		Where("id = ?", storeID).
-		First(&store).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+	store, err := l.identity.Load(ctx, storeID)
+	if err != nil {
 		return GiftCardEmailTheme{}, "", fmt.Errorf("giftcard: load store: %w", err)
 	}
 	theme.StoreName = store.Name
+	theme.StoreSlug = store.Slug
+	theme.StoreContactEmail = store.ContactEmail
 
 	// Build storefront URL from template if we have a slug + template.
 	if store.Slug != "" && l.storefrontURLBase != "" {

--- a/services/marketplace-api/internal/giftcard/theme_loader_identity_integration_test.go
+++ b/services/marketplace-api/internal/giftcard/theme_loader_identity_integration_test.go
@@ -1,0 +1,39 @@
+//go:build integration
+
+package giftcard
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/branding"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// TestIntegration_LoadTheme_CarriesStoreSenderIdentity pins the hop the
+// mailer-level test in internal/email cannot see (#718): that test hands
+// the mailer a theme it built itself, so it proves the mailer APPLIES an
+// identity, not that the loader SUPPLIES one. Emptying the two
+// assignments in LoadTheme left every other test green.
+func TestIntegration_LoadTheme_CarriesStoreSenderIdentity(t *testing.T) {
+	tx := testdb.NewTx(t)
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, tx, tenantID, storeID)
+	require.NoError(t, tx.Exec(`
+		INSERT INTO store_branding (tenant_id, store_id, support_email)
+		VALUES (?, ?, ?)`, tenantID, storeID, "hello@nadiasceramics.com").Error)
+
+	loader := NewStoreThemeLoader(tx, branding.NewService(branding.ServiceConfig{DB: tx, Repo: branding.NewRepository()}), "")
+	theme, _, err := loader.LoadTheme(context.Background(), storeID)
+	require.NoError(t, err)
+
+	require.Equal(t, "Test Store", theme.StoreName)
+	require.NotEmpty(t, theme.StoreSlug,
+		"the envelope's From local part is derived from this")
+	require.Equal(t, "hello@nadiasceramics.com", theme.StoreContactEmail,
+		"the envelope's Reply-To comes from this")
+}

--- a/services/marketplace-api/internal/handlers/admin/shipments.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments.go
@@ -2296,24 +2296,33 @@ func (h *ShipmentsHandler) EmailLabel(c *gin.Context) {
 	var meta struct {
 		OrderNumber string `gorm:"column:order_number"`
 		StoreName   string `gorm:"column:name"`
+		StoreSlug   string `gorm:"column:slug"`
 		TenantID    string `gorm:"column:tenant_id"`
+		// support_email is LEFT JOINed: a store that never opened the
+		// branding editor has no row, and an INNER JOIN would drop the
+		// whole envelope rather than just the Reply-To (#718).
+		ContactEmail string `gorm:"column:contact_email"`
 	}
 	_ = h.db.WithContext(ctx).Raw(`
-		SELECT o.order_number, s.name, s.tenant_id
+		SELECT o.order_number, s.name, s.slug, s.tenant_id,
+		       COALESCE(sb.support_email, '') AS contact_email
 		FROM orders o
 		JOIN stores s ON s.id = o.store_id
+		LEFT JOIN store_branding sb ON sb.store_id = s.id
 		WHERE o.id = ? LIMIT 1`, orderID).Scan(&meta).Error
 
 	if err := h.labelMailer.SendLabel(ctx, shipping.LabelEmailPayload{
-		Recipient:      strings.TrimSpace(req.Recipient),
-		TenantID:       meta.TenantID,
-		StoreName:      meta.StoreName,
-		OrderNumber:    meta.OrderNumber,
-		Carrier:        rec.Carrier,
-		TrackingNumber: rec.TrackingNumber,
-		PDF:            pdf,
-		ContentType:    ct,
-		Filename:       fmt.Sprintf("shipping-label-%s.pdf", rec.TrackingNumber),
+		Recipient:         strings.TrimSpace(req.Recipient),
+		TenantID:          meta.TenantID,
+		StoreName:         meta.StoreName,
+		StoreSlug:         meta.StoreSlug,
+		StoreContactEmail: meta.ContactEmail,
+		OrderNumber:       meta.OrderNumber,
+		Carrier:           rec.Carrier,
+		TrackingNumber:    rec.TrackingNumber,
+		PDF:               pdf,
+		ContentType:       ct,
+		Filename:          fmt.Sprintf("shipping-label-%s.pdf", rec.TrackingNumber),
 	}); err != nil {
 		if h.logger != nil {
 			h.logger.Error("shipments: label email dispatch failed",

--- a/services/marketplace-api/internal/handlers/admin/shipments.go
+++ b/services/marketplace-api/internal/handlers/admin/shipments.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/orderdoc"
 	"github.com/mark8ly/marketplace-api/internal/shipmentcancel"
 	"github.com/mark8ly/marketplace-api/internal/shipping"
+	"github.com/mark8ly/marketplace-api/internal/storeidentity"
 	"github.com/mark8ly/marketplace-api/internal/warehouse"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 )
@@ -2292,31 +2293,36 @@ func (h *ShipmentsHandler) EmailLabel(c *gin.Context) {
 		return
 	}
 
-	// Resolve order_number and store display name for the email envelope.
+	// Resolve the order number, then the store's public sender identity
+	// through the shared loader (#718) rather than a fourth hand-written
+	// copy of the stores/store_branding join — that duplication was how
+	// three of these call sites ended up missing the contact address.
 	var meta struct {
 		OrderNumber string `gorm:"column:order_number"`
-		StoreName   string `gorm:"column:name"`
-		StoreSlug   string `gorm:"column:slug"`
-		TenantID    string `gorm:"column:tenant_id"`
-		// support_email is LEFT JOINed: a store that never opened the
-		// branding editor has no row, and an INNER JOIN would drop the
-		// whole envelope rather than just the Reply-To (#718).
-		ContactEmail string `gorm:"column:contact_email"`
+		StoreID     string `gorm:"column:store_id"`
 	}
 	_ = h.db.WithContext(ctx).Raw(`
-		SELECT o.order_number, s.name, s.slug, s.tenant_id,
-		       COALESCE(sb.support_email, '') AS contact_email
-		FROM orders o
-		JOIN stores s ON s.id = o.store_id
-		LEFT JOIN store_branding sb ON sb.store_id = s.id
-		WHERE o.id = ? LIMIT 1`, orderID).Scan(&meta).Error
+		SELECT o.order_number, o.store_id
+		FROM orders o WHERE o.id = ? LIMIT 1`, orderID).Scan(&meta).Error
+
+	var store storeidentity.Store
+	if sid, err := uuid.Parse(meta.StoreID); err == nil {
+		// Best-effort, like the lookup it replaced: a failure here costs
+		// the store branding on the envelope, not the label email.
+		if loaded, lerr := storeidentity.NewDBLoader(h.db).Load(ctx, sid); lerr == nil {
+			store = loaded
+		} else if h.logger != nil {
+			h.logger.Warn("shipments: store identity lookup failed",
+				"order_id", orderID, "err", lerr)
+		}
+	}
 
 	if err := h.labelMailer.SendLabel(ctx, shipping.LabelEmailPayload{
 		Recipient:         strings.TrimSpace(req.Recipient),
-		TenantID:          meta.TenantID,
-		StoreName:         meta.StoreName,
-		StoreSlug:         meta.StoreSlug,
-		StoreContactEmail: meta.ContactEmail,
+		TenantID:          store.TenantID,
+		StoreName:         store.Name,
+		StoreSlug:         store.Slug,
+		StoreContactEmail: store.ContactEmail,
 		OrderNumber:       meta.OrderNumber,
 		Carrier:           rec.Carrier,
 		TrackingNumber:    rec.TrackingNumber,

--- a/services/marketplace-api/internal/orderdoc/mailer.go
+++ b/services/marketplace-api/internal/orderdoc/mailer.go
@@ -117,6 +117,12 @@ type DocumentInput struct {
 	// — empty string suppresses the block entirely.
 	AdminNote string
 
+	// StoreContactEmail is store_branding.support_email — the merchant's
+	// own address, used as the customer-facing Reply-To so a reply to an
+	// order confirmation reaches the merchant instead of the platform's
+	// unattended noreply box. Empty falls back to the platform address.
+	StoreContactEmail string
+
 	// Brand surface
 	Theme Theme
 }
@@ -548,15 +554,24 @@ func (m *DocumentMailer) send(ctx context.Context, kind Kind, in DocumentInput) 
 		customArgs["tenant_id"] = in.TenantID
 	}
 
-	if err := m.sender.Send(ctx, email.Message{
-		From:        m.from,
+	msg := email.Message{
 		To:          in.Recipient,
 		Subject:     subject,
 		HTMLBody:    htmlBody,
 		TextBody:    textBody,
 		CustomArgs:  customArgs,
 		Attachments: attachments,
-	}); err != nil {
+	}
+	// Customer-facing: the buyer bought from this store, so the store is
+	// who the inbox line names (#718). Deliberately explicit here rather
+	// than defaulted in the transport — see email/identity.go.
+	email.StoreIdentity(m.from, email.StoreSender{
+		Name:         in.Theme.StoreName,
+		Slug:         in.StoreSlug,
+		ContactEmail: in.StoreContactEmail,
+	}).Apply(&msg)
+
+	if err := m.sender.Send(ctx, msg); err != nil {
 		return fmt.Errorf("orderdoc: send %s email: %w", string(kind), err)
 	}
 	return nil

--- a/services/marketplace-api/internal/orderdoc/service.go
+++ b/services/marketplace-api/internal/orderdoc/service.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/branding"
 	"github.com/mark8ly/marketplace-api/internal/order"
-	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/internal/storeidentity"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
 )
 
@@ -28,7 +28,11 @@ type Service struct {
 	orderRepo         order.Repository
 	brandingSvc       *branding.Service
 	storefrontURLBase string // template with {slug}
-	logger            *slog.Logger
+	// identity resolves the store's public sender identity (#718). It
+	// replaces the bare `stores` lookup this service used to do — same
+	// one query, plus the branding contact address the envelope needs.
+	identity storeidentity.Loader
+	logger   *slog.Logger
 }
 
 // NewService constructs a Service. Pass empty storefrontURLBase to
@@ -40,6 +44,7 @@ func NewService(db *gorm.DB, mailer Mailer, orderRepo order.Repository, branding
 		orderRepo:         orderRepo,
 		brandingSvc:       brandingSvc,
 		storefrontURLBase: storefrontURLBase,
+		identity:          storeidentity.NewDBLoader(db),
 	}
 }
 
@@ -185,9 +190,17 @@ func (s *Service) buildInput(ctx context.Context, orderID uuid.UUID, asReceipt b
 		return DocumentInput{}, fmt.Errorf("%w (order_id=%s)", errMissingCustomerEmail, orderID)
 	}
 
-	var store stores.Store
-	if err := s.db.WithContext(ctx).Where("id = ?", o.StoreID).First(&store).Error; err != nil {
+	store, err := s.identity.Load(ctx, o.StoreID)
+	if err != nil {
 		return DocumentInput{}, fmt.Errorf("orderdoc: load store: %w", err)
+	}
+	// The loader returns a zero Store for a missing row rather than an
+	// error, because its other callers are best-effort. Here the store is
+	// load-bearing — it supplies the tenant id every downstream document
+	// is scoped by — so the hard failure the previous First() produced is
+	// kept. tenant_id is NOT NULL, so an empty one means no row.
+	if store.TenantID == "" {
+		return DocumentInput{}, fmt.Errorf("orderdoc: store %s not found", o.StoreID)
 	}
 
 	theme := Theme{StoreName: store.Name}
@@ -241,14 +254,17 @@ func (s *Service) buildInput(ctx context.Context, orderID uuid.UUID, asReceipt b
 		DocumentNumber: documentNumber(asReceipt, o.OrderNumber),
 		OrderID:        orderID.String(),
 		StoreSlug:      store.Slug,
-		OrderNumber:    o.OrderNumber,
-		OrderURL:       orderURL,
-		DocumentURL:    documentURL,
-		PlacedAt:       o.PlacedAt,
-		GrandTotal:     o.GrandTotal,
-		CurrencyCode:   o.CurrencyCode,
-		ItemCount:      len(items),
-		Theme:          theme,
+		// Feeds the customer-facing Reply-To (#718); empty is fine and
+		// falls back to the platform address.
+		StoreContactEmail: store.ContactEmail,
+		OrderNumber:       o.OrderNumber,
+		OrderURL:          orderURL,
+		DocumentURL:       documentURL,
+		PlacedAt:          o.PlacedAt,
+		GrandTotal:        o.GrandTotal,
+		CurrencyCode:      o.CurrencyCode,
+		ItemCount:         len(items),
+		Theme:             theme,
 	}
 	if asReceipt {
 		in.DeliveredAt = s.lookupDeliveredAt(ctx, orderID, o.UpdatedAt)

--- a/services/marketplace-api/internal/orderdoc/service_identity_integration_test.go
+++ b/services/marketplace-api/internal/orderdoc/service_identity_integration_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+
+package orderdoc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/branding"
+	"github.com/mark8ly/marketplace-api/internal/order"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// captureMailer records the DocumentInput the service built.
+type captureMailer struct{ last DocumentInput }
+
+func (m *captureMailer) SendInvoice(_ context.Context, in DocumentInput) error {
+	m.last = in
+	return nil
+}
+func (m *captureMailer) SendReceipt(context.Context, DocumentInput) error      { return nil }
+func (m *captureMailer) SendCancellation(context.Context, DocumentInput) error { return nil }
+func (m *captureMailer) SendRefund(context.Context, DocumentInput) error       { return nil }
+func (m *captureMailer) SendShipmentDispatched(context.Context, DocumentInput) error {
+	return nil
+}
+
+// TestIntegration_BuildInput_CarriesStoreSenderIdentity pins the hop the
+// mailer-level test in internal/email cannot see (#718): that test hands
+// the mailer a DocumentInput it built itself, so it proves the mailer
+// APPLIES an identity, not that the service SUPPLIES one. Blanking
+// StoreContactEmail here left every other test in this service green.
+func TestIntegration_BuildInput_CarriesStoreSenderIdentity(t *testing.T) {
+	tx := testdb.NewTx(t)
+	ctx := context.Background()
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, tx, tenantID, storeID)
+	require.NoError(t, tx.Exec(`
+		INSERT INTO store_branding (tenant_id, store_id, support_email)
+		VALUES (?, ?, ?)`, tenantID, storeID, "hello@nadiasceramics.com").Error)
+
+	orderID := uuid.New()
+	require.NoError(t, tx.Exec(`
+		INSERT INTO orders (id, tenant_id, store_id, order_number, idempotency_key,
+		                    customer_email, subtotal, grand_total, currency_code)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		orderID, tenantID, storeID, "ORD-718-1", uuid.NewString(),
+		"buyer@example.com", "42.00", "42.00", "EUR").Error)
+
+	mailer := &captureMailer{}
+	svc := NewService(tx, mailer, order.NewRepository(),
+		branding.NewService(branding.ServiceConfig{DB: tx, Repo: branding.NewRepository()}),
+		"https://{slug}.mark8ly.com")
+
+	require.NoError(t, svc.SendInvoice(ctx, orderID))
+
+	require.Equal(t, "Test Store", mailer.last.Theme.StoreName,
+		"the envelope's From display name comes from this")
+	require.NotEmpty(t, mailer.last.StoreSlug,
+		"the envelope's From local part is derived from this")
+	require.Equal(t, "hello@nadiasceramics.com", mailer.last.StoreContactEmail,
+		"the envelope's Reply-To comes from this")
+	require.Equal(t, tenantID.String(), mailer.last.TenantID)
+}

--- a/services/marketplace-api/internal/shipping/labelmailer.go
+++ b/services/marketplace-api/internal/shipping/labelmailer.go
@@ -25,14 +25,21 @@ type LabelEmailPayload struct {
 	// TenantID, when non-empty, is forwarded to the email provider as a
 	// custom_arg so notification-service can attribute open/click/bounce
 	// events back to the right tenant in tesserix-home dashboards.
-	TenantID       string
-	StoreName      string
-	OrderNumber    string
-	Carrier        string
-	TrackingNumber string
-	PDF            []byte
-	ContentType    string
-	Filename       string
+	TenantID  string
+	StoreName string
+	// StoreSlug and StoreContactEmail carry the store's sender identity
+	// (#718). This mail goes to an address the MERCHANT nominates (a
+	// fulfiller, a warehouse), not to a shopper — but it is still the
+	// store's own mail, not the platform speaking to the merchant, so it
+	// wears the store identity.
+	StoreSlug         string
+	StoreContactEmail string
+	OrderNumber       string
+	Carrier           string
+	TrackingNumber    string
+	PDF               []byte
+	ContentType       string
+	Filename          string
 }
 
 // EmailLabelMailer sends the label email + PDF attachment through the
@@ -92,8 +99,7 @@ func (m *EmailLabelMailer) SendLabel(ctx context.Context, in LabelEmailPayload) 
 		customArgs["tenant_id"] = in.TenantID
 	}
 
-	if err := m.sender.Send(ctx, email.Message{
-		From:       m.from,
+	msg := email.Message{
 		To:         in.Recipient,
 		Subject:    subject,
 		HTMLBody:   htmlBody,
@@ -104,7 +110,14 @@ func (m *EmailLabelMailer) SendLabel(ctx context.Context, in LabelEmailPayload) 
 			ContentType: ct,
 			Content:     in.PDF,
 		}},
-	}); err != nil {
+	}
+	email.StoreIdentity(m.from, email.StoreSender{
+		Name:         in.StoreName,
+		Slug:         in.StoreSlug,
+		ContactEmail: in.StoreContactEmail,
+	}).Apply(&msg)
+
+	if err := m.sender.Send(ctx, msg); err != nil {
 		return fmt.Errorf("shipping: send label email: %w", err)
 	}
 	return nil

--- a/services/marketplace-api/internal/storeidentity/storeidentity.go
+++ b/services/marketplace-api/internal/storeidentity/storeidentity.go
@@ -1,0 +1,78 @@
+// Package storeidentity resolves the public identity of a store — the
+// name, slug and contact address that customer-facing email puts in the
+// From and Reply-To headers (#718).
+//
+// It exists because four mailers needed the same three columns and three
+// of them were already issuing their own near-identical `stores` lookup
+// while missing the fourth column. One joined query, one definition of
+// "who this store is to a customer".
+//
+// The contact address lives in store_branding.support_email. That column
+// is deliberately NOT mapped onto branding.StoreBranding: the branding
+// Upsert writes with Select("*"), and no admin surface populates the
+// column today, so a mapped field would be blanked on the merchant's
+// next branding save. Reading it here keeps that hazard off the model.
+package storeidentity
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// Store is a store's public identity. Every string field is
+// merchant-controlled and untrusted; email.StoreIdentity sanitises them
+// before any of it reaches a header.
+type Store struct {
+	TenantID string
+	Name     string
+	Slug     string
+	// ContactEmail is store_branding.support_email, empty when the
+	// merchant has set none or has no branding row at all.
+	ContactEmail string
+}
+
+// Loader resolves a store id to its public identity. An interface so
+// mailers can be unit-tested without a database.
+type Loader interface {
+	Load(ctx context.Context, storeID uuid.UUID) (Store, error)
+}
+
+// DBLoader is the production Loader, backed by one LEFT JOIN.
+type DBLoader struct{ db *gorm.DB }
+
+// NewDBLoader constructs a Loader over the given connection.
+func NewDBLoader(db *gorm.DB) *DBLoader { return &DBLoader{db: db} }
+
+// Load returns the store's public identity.
+//
+// A store id with no row is NOT an error: it returns the zero Store, and
+// email.StoreIdentity degrades that to the platform identity. Every
+// caller is a best-effort mailer, and failing an order confirmation
+// because a store row is missing would trade a cosmetic problem for a
+// lost transactional email.
+func (l *DBLoader) Load(ctx context.Context, storeID uuid.UUID) (Store, error) {
+	var s Store
+	err := l.db.WithContext(ctx).Raw(`
+		SELECT s.tenant_id      AS tenant_id,
+		       s.name           AS name,
+		       s.slug           AS slug,
+		       COALESCE(sb.support_email, '') AS contact_email
+		FROM stores s
+		LEFT JOIN store_branding sb ON sb.store_id = s.id
+		WHERE s.id = ?
+		LIMIT 1`, storeID).Scan(&s).Error
+	if err != nil {
+		return Store{}, fmt.Errorf("storeidentity: load store %s: %w", storeID, err)
+	}
+	return s, nil
+}
+
+// StaticLoader returns a fixed identity. For tests and for call sites
+// that already hold the store row.
+type StaticLoader struct{ Store Store }
+
+// Load returns the configured Store.
+func (l StaticLoader) Load(context.Context, uuid.UUID) (Store, error) { return l.Store, nil }

--- a/services/marketplace-api/internal/storeidentity/storeidentity_integration_test.go
+++ b/services/marketplace-api/internal/storeidentity/storeidentity_integration_test.go
@@ -1,0 +1,75 @@
+//go:build integration
+
+package storeidentity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// TestLoad_JoinsBrandingSupportEmail is the reason this package issues a
+// LEFT JOIN rather than reading the branding model: support_email is not
+// a field on branding.StoreBranding, so only SQL can see it.
+func TestLoad_JoinsBrandingSupportEmail(t *testing.T) {
+	tx := testdb.NewTx(t)
+	ctx := context.Background()
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, tx, tenantID, storeID)
+	require.NoError(t, tx.Exec(`
+		INSERT INTO store_branding (tenant_id, store_id, support_email)
+		VALUES (?, ?, ?)`, tenantID, storeID, "hello@nadiasceramics.com").Error)
+
+	got, err := NewDBLoader(tx).Load(ctx, storeID)
+	require.NoError(t, err)
+	require.Equal(t, tenantID.String(), got.TenantID)
+	require.Equal(t, "Test Store", got.Name)
+	require.NotEmpty(t, got.Slug)
+	require.Equal(t, "hello@nadiasceramics.com", got.ContactEmail)
+}
+
+// TestLoad_NoBrandingRow — the LEFT JOIN must still return the store.
+// An INNER JOIN here would silently strip the sender identity from every
+// merchant who never opened the branding editor.
+func TestLoad_NoBrandingRow(t *testing.T) {
+	tx := testdb.NewTx(t)
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, tx, tenantID, storeID)
+
+	got, err := NewDBLoader(tx).Load(context.Background(), storeID)
+	require.NoError(t, err)
+	require.Equal(t, "Test Store", got.Name)
+	require.Empty(t, got.ContactEmail)
+}
+
+// TestLoad_BrandingRowWithoutSupportEmail — the column is NOT NULL
+// DEFAULT ”, so this is the common case today: no admin surface writes
+// it, and Reply-To falls back to the platform address.
+func TestLoad_BrandingRowWithoutSupportEmail(t *testing.T) {
+	tx := testdb.NewTx(t)
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, tx, tenantID, storeID)
+	require.NoError(t, tx.Exec(`
+		INSERT INTO store_branding (tenant_id, store_id) VALUES (?, ?)`,
+		tenantID, storeID).Error)
+
+	got, err := NewDBLoader(tx).Load(context.Background(), storeID)
+	require.NoError(t, err)
+	require.Empty(t, got.ContactEmail)
+}
+
+// TestLoad_MissingStore must not error — see the Load doc comment.
+func TestLoad_MissingStore(t *testing.T) {
+	tx := testdb.NewTx(t)
+
+	got, err := NewDBLoader(tx).Load(context.Background(), uuid.New())
+	require.NoError(t, err, "a missing store must degrade, not fail the send")
+	require.Equal(t, Store{}, got)
+}

--- a/services/marketplace-api/internal/ticket/mailer.go
+++ b/services/marketplace-api/internal/ticket/mailer.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/storeidentity"
 )
 
 // EmailNotifier implements TicketNotifier on top of the shared
@@ -33,7 +34,13 @@ type EmailNotifier struct {
 	sender     email.Sender
 	from       string
 	publicHost string // e.g. "https://mystore.mark8ly.com" for deep links
-	logger     *slog.Logger
+	// identity resolves the store behind a ticket so the customer sees
+	// the merchant they contacted in their inbox (#718). Optional: nil
+	// keeps the platform identity, which is what an unwired notifier had
+	// before — see the send() comment for why that fallback is a
+	// downgrade rather than a neutral default.
+	identity storeidentity.Loader
+	logger   *slog.Logger
 }
 
 // NewEmailNotifier constructs a notifier. publicHost is used to
@@ -49,6 +56,14 @@ func NewEmailNotifier(sender email.Sender, from, publicHost string, logger *slog
 	}
 }
 
+// WithStoreIdentity wires the store-identity loader so support mail is
+// sent as the merchant's store rather than as the platform. Chainable,
+// matching the loader wiring on the orderdoc and giftcard mailers.
+func (m *EmailNotifier) WithStoreIdentity(l storeidentity.Loader) *EmailNotifier {
+	m.identity = l
+	return m
+}
+
 // NotifyTicketCreated emails the customer that a support case has
 // been logged with a case ID they can quote.
 func (m *EmailNotifier) NotifyTicketCreated(ctx context.Context, t *Ticket) {
@@ -56,8 +71,7 @@ func (m *EmailNotifier) NotifyTicketCreated(ctx context.Context, t *Ticket) {
 		return
 	}
 	subject := fmt.Sprintf("Your support request is logged — case %s", t.TicketNumber)
-	body := m.renderCreated(t)
-	m.send(ctx, t.SubmittedByEmail, t.SubmittedByName, subject, body, "ticket_created")
+	m.send(ctx, t, subject, m.renderCreated(t), "ticket_created")
 }
 
 // NotifyTicketResolved emails the customer that the merchant marked
@@ -67,8 +81,7 @@ func (m *EmailNotifier) NotifyTicketResolved(ctx context.Context, t *Ticket) {
 		return
 	}
 	subject := fmt.Sprintf("Your support case %s is resolved", t.TicketNumber)
-	body := m.renderResolved(t)
-	m.send(ctx, t.SubmittedByEmail, t.SubmittedByName, subject, body, "ticket_resolved")
+	m.send(ctx, t, subject, m.renderResolved(t), "ticket_resolved")
 }
 
 // ---------------------------------------------------------------------------
@@ -116,24 +129,51 @@ func (m *EmailNotifier) caseLink(t *Ticket) string {
 // logged, never returned — ticket emails are best-effort by contract
 // (see the package comment). In dev the transport is a LogSender, so
 // the dispatch path still runs end-to-end without a provider account.
-func (m *EmailNotifier) send(ctx context.Context, toEmail, toName, subject, body, kind string) {
-	err := m.sender.Send(ctx, email.Message{
-		From:     m.from,
-		FromName: "Mark8ly Support",
-		To:       toEmail,
-		ToName:   toName,
+func (m *EmailNotifier) send(ctx context.Context, t *Ticket, subject, body, kind string) {
+	msg := email.Message{
+		To:       t.SubmittedByEmail,
+		ToName:   t.SubmittedByName,
 		Subject:  subject,
 		HTMLBody: body,
 		// Wave 1.5 attribution — product/kind let notification-service
-		// group engagement events without parsing subjects.
-		CustomArgs: map[string]string{"product": "mark8ly", "kind": kind},
-	})
-	if err != nil {
+		// group engagement events without parsing subjects. tenant_id
+		// joins them to a merchant; every other customer-facing mailer
+		// already emitted it and this one did not.
+		CustomArgs: map[string]string{
+			"product":   "mark8ly",
+			"kind":      kind,
+			"tenant_id": t.TenantID.String(),
+		},
+	}
+
+	// Customer-facing: the shopper opened a case with a MERCHANT, so the
+	// merchant is who replies. This mail used to go out as
+	// "Mark8ly Support" — a platform identity on a conversation the
+	// platform is not part of, and the exact display name #718's guard
+	// now refuses a store for using. With no loader wired we fall back
+	// to the plain platform identity and no display name, which is
+	// honest rather than actively wrong.
+	identity := email.PlatformIdentity(m.from, "")
+	if m.identity != nil {
+		store, err := m.identity.Load(ctx, t.StoreID)
+		if err != nil {
+			m.log("ticket store identity lookup failed", kind, err)
+		} else {
+			identity = email.StoreIdentity(m.from, email.StoreSender{
+				Name:         store.Name,
+				Slug:         store.Slug,
+				ContactEmail: store.ContactEmail,
+			})
+		}
+	}
+	identity.Apply(&msg)
+
+	if err := m.sender.Send(ctx, msg); err != nil {
 		m.log("ticket email send failed", kind, err)
 		return
 	}
 	if m.logger != nil {
-		m.logger.Info("ticket email sent", "kind", kind, "to", toEmail)
+		m.logger.Info("ticket email sent", "kind", kind, "to", t.SubmittedByEmail)
 	}
 }
 


### PR DESCRIPTION
Closes #718.

A customer buying from Nadia's Ceramics gets an order confirmation from `noreply@tesserix.app`, with nothing in the sender identifying the store. The body knows the store's name; the envelope did not.

```
From:      Nadia's Ceramics <nadias-ceramics@tesserix.app>
Reply-To:  hello@nadiasceramics.com        (platform address until the admin field exists — see below)
```

No new domain and no new Resend domain slot: the identity is the display name, the derived local part, and Reply-To, all on whichever domain `EMAIL_FROM` already serves.

## The issue's premise was wrong

#718 says `FromName` has "no non-test caller anywhere in the service; verify, don't assume". It has two on main: `ticket/mailer.go:122` sends as `"Mark8ly Support"`, `email/template_client.go:138` as `"Mark8ly Billing"`.

That makes **ticket the worst case rather than a deferral candidate**. A storefront ticket reply is a conversation between a customer and a merchant, and it was going out under a platform support identity — `"Mark8ly Support"` being precisely the string the new guard refuses a *store* for using. It is wired here, not deferred.

## What changed

**Transport** — `Message.ReplyTo`, emitted by both adapters (SendGrid a `reply_to` object, pointer so an unset one is omitted since SendGrid 400s on `{}`; Resend a `reply_to` string). `validate()` rejects an unroutable Reply-To and adds a header-injection backstop across From/FromName/To/ToName/ReplyTo/Subject.

`buildSendGridRequest` / `buildResendRequest` are extracted from the two `Send` methods because **the adapters had no wire-shape tests at all** — nothing proved `FromName` reached a provider or that `CustomArgs` survived the trip.

**Derivation** (`internal/email/identity.go`) — `StoreIdentity` and `PlatformIdentity`, with **no default anywhere**: every call site chooses. Local part normalised from `stores.slug`; display name sanitised in two tiers, where address-shaped input like `"Support" <a@b.com>` is **rejected rather than salvaged** (defanging it to `Support ab.com` still reads as a support sender), while ordinary punctuation is stripped so "Acme, Inc." survives.

**`internal/storeidentity`** — one LEFT JOIN replacing four near-duplicate store lookups, three of which were missing the contact column.

**Wired**: orderdoc, giftcard, shipping, campaign, ticket. Platform-to-merchant mail — trials, dunning, payment-action, win-back, and everything in mark8ly's platform-api — keeps the platform identity, pinned by a test so a later change cannot quietly flip billing mail to a store's brand.

## Reply-To does not bite yet, and that is deliberate

`store_branding.support_email` exists (migration `000069`) but is **not on the GORM model, and must not be**: branding `Upsert` uses `Select("*")` and no admin surface writes the column, so mapping it would blank the merchant's value on their next save.

So **Reply-To falls back to the platform address for every store today**. The plumbing is right and tested; it needs an admin field to populate. Follow-up filed.

## Judgement calls

**Domain** — never chosen in code, taken from `addressDomain(EMAIL_FROM)`. Works on `tesserix.app` now and after tesserix/tesserix-k8s#1011 moves it, pinned by `TestStoreIdentity_FollowsConfiguredDomain`.

**Per-store local part: yes.** `stores.slug` is a `uniqueIndex`, so slug-derived local parts are collision-free between stores with no lookup; reserved names are escaped with a provably injective `store-` prefix (`TestDeriveLocalPart_Injective`). **Caveat worth knowing:** the derived mailbox does not exist, so mail *to* it hard-bounces — mitigated only because Reply-To is always populated. The argument against is real (the local part is invisible in most inbox lists, and `tenant_id` already carries attribution); traceability and the issue's acceptance criteria carried it.

**platform-api: no change.** All six of its templates are platform→merchant — `welcome.txt` says "your storefront… your customers". Adding `FromName`/`ReplyTo` there would create fields with no caller, which is exactly the state that made this issue's premise wrong in the first place.

## Test plan

- [x] `gofmt -l .`, `go build ./...`, `go vet ./...` clean across all four services
- [x] `go test ./...` clean; `-race` green on all 8 touched packages
- [x] 8 new integration tests against a real Postgres, each confirmed **named and PASS in `-v` output, zero SKIP**
- [x] Hostile display names: address-shaped, newline, platform-impersonating — all refused
- [x] Store/platform split pinned per mailer **and** at the supplying layer
- [x] `CustomArgs` attribution (`product`, `kind`, `tenant_id`) proven to survive to the wire
- [x] **Mutation-tested: 7 mutations, 4 initially survived.** The split test drove the mailers, proving they *apply* an identity but not that the services *supply* one — emptying a theme loader or the campaign worker's sender left everything green. Four tests added at the supplying layer; the shipments handler now uses the shared loader instead of a fourth copy of the SQL. All 7 now die.
- [ ] Not covered: the shipments label-email HTTP path has no test harness. Risk reduced by routing it through the integration-tested loader rather than building one.

Note `TestReplay_ResetsAFailedDeliveryToPendingAndDueNow` failed 1 run in 7. Diagnosed, not dismissed: it compares Postgres `now()` to Go's `time.Now()` with a strict `.After()` — a clock-skew flake in a file this branch never touches. Base and branch both reproduce it.
