### PR TITLE
feat(mobile): sign in through the Zitadel front door and handle the email-OTP challenge (#686)

### DIFF
--- a/apps/mobile-admin/__tests__/zitadel-auth-client.test.ts
+++ b/apps/mobile-admin/__tests__/zitadel-auth-client.test.ts
@@ -1,0 +1,128 @@
+import { createZitadelAuthClient } from "@repo/mobile-shared/auth/zitadel-client";
+
+function jsonResponse(status: number, body: unknown) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response);
+}
+
+function clientWith(fetchImpl: jest.Mock) {
+  global.fetch = fetchImpl as unknown as typeof fetch;
+  return createZitadelAuthClient({ baseUrl: "https://api.mark8ly.com" });
+}
+
+it("signs in and reports the tokens", async () => {
+  const f = jest.fn(() =>
+    jsonResponse(200, {
+      data: {
+        uid: "u1", email: "a@b.test", tenant_id: "t-1",
+        tenants: [{ tenant_id: "t-1", name: "Mumbai Spice Co", role: "owner" }],
+        access_token: "AT", refresh_token: "RT", token_type: "Bearer", expires_in: 3599,
+        email_otp_required: false, mfa_required: false, totp_required: false,
+      },
+    }),
+  );
+  const res = await clientWith(f).signIn("a@b.test", "pw");
+
+  expect(res.status).toBe("complete");
+  if (res.status !== "complete") throw new Error("unreachable");
+  expect(res.tokens.accessToken).toBe("AT");
+  expect(res.tenantId).toBe("t-1");
+  expect(res.tenants).toHaveLength(1);
+
+  const [url, init] = f.mock.calls[0];
+  expect(url).toBe("https://api.mark8ly.com/api/v1/mobile/admin/auth/login");
+  expect((init as RequestInit).method).toBe("POST");
+  // No bearer: this call is how one is obtained.
+  expect((init as RequestInit).headers).not.toHaveProperty("Authorization");
+});
+
+// THE common first-login path: a fresh install is always a new device.
+it("reports an OTP challenge with the token needed to resume it", async () => {
+  const f = jest.fn(() =>
+    jsonResponse(200, {
+      data: {
+        uid: "u1", email: "a@b.test", tenant_id: "t-1",
+        email_otp_required: true, mfa_required: false, totp_required: false,
+        pending_token: "sealed-value",
+      },
+    }),
+  );
+  const res = await clientWith(f).signIn("a@b.test", "pw");
+
+  expect(res.status).toBe("otp_required");
+  if (res.status !== "otp_required") throw new Error("unreachable");
+  expect(res.pendingToken).toBe("sealed-value");
+  expect(res.email).toBe("a@b.test");
+});
+
+// A challenge with no pending_token cannot be completed. Treating it as a
+// normal OTP prompt would strand the user on a screen whose submit can
+// never succeed, so it fails loudly instead.
+it("rejects an OTP challenge that carries no pending token", async () => {
+  const f = jest.fn(() =>
+    jsonResponse(200, { data: { email_otp_required: true, email: "a@b.test" } }),
+  );
+  // Asserted on the stable code, not the copy: screens map from the code,
+  // and pinning wording makes the test fail on a copy edit.
+  await expect(clientWith(f).signIn("a@b.test", "pw")).rejects.toMatchObject({
+    code: "challenge_unresumable",
+  });
+});
+
+it("maps 401 to invalid credentials", async () => {
+  const f = jest.fn(() => jsonResponse(401, { error: "invalid_credentials" }));
+  await expect(clientWith(f).signIn("a@b.test", "bad")).rejects.toMatchObject({
+    code: "invalid_credentials",
+  });
+});
+
+// 404 no_store is a distinct, actionable state — the account exists but has
+// no store — and must not be flattened into "wrong password".
+it("maps 404 no_store distinctly", async () => {
+  const f = jest.fn(() => jsonResponse(404, { error: "no_store" }));
+  await expect(clientWith(f).signIn("a@b.test", "pw")).rejects.toMatchObject({
+    code: "no_store",
+  });
+});
+
+// A 502 means the credential may have been correct. Reporting it as a bad
+// password makes a merchant retype a correct one indefinitely.
+it("maps 502 to an availability error, not a credential error", async () => {
+  const f = jest.fn(() => jsonResponse(502, { error: "auth_unavailable" }));
+  await expect(clientWith(f).signIn("a@b.test", "pw")).rejects.toMatchObject({
+    code: "auth_unavailable",
+  });
+});
+
+it("completes the OTP challenge and returns tokens", async () => {
+  const f = jest.fn(() =>
+    jsonResponse(200, {
+      data: {
+        uid: "u1", email: "a@b.test", tenant_id: "t-1",
+        access_token: "AT2", refresh_token: "RT2", token_type: "Bearer", expires_in: 3599,
+      },
+    }),
+  );
+  const res = await clientWith(f).verifyOtp("sealed-value", "123456");
+
+  expect(res.tokens.accessToken).toBe("AT2");
+  expect(res.tenantId).toBe("t-1");
+
+  const [url, init] = f.mock.calls[0];
+  expect(url).toBe("https://api.mark8ly.com/api/v1/mobile/admin/auth/otp/verify");
+  expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+    pending_token: "sealed-value",
+    code: "123456",
+  });
+});
+
+it("maps a rejected OTP code to invalid_code", async () => {
+  const f = jest.fn(() => jsonResponse(401, { error: "invalid_code" }));
+  await expect(clientWith(f).verifyOtp("sealed", "000000")).rejects.toMatchObject({
+    code: "invalid_code",
+  });
+});

--- a/apps/mobile-admin/__tests__/zitadel-auth-client.test.ts
+++ b/apps/mobile-admin/__tests__/zitadel-auth-client.test.ts
@@ -9,13 +9,15 @@ function jsonResponse(status: number, body: unknown) {
   } as unknown as Response);
 }
 
-function clientWith(fetchImpl: jest.Mock) {
+type FetchMock = jest.Mock<Promise<Response>, [string, RequestInit]>;
+
+function clientWith(fetchImpl: FetchMock) {
   global.fetch = fetchImpl as unknown as typeof fetch;
   return createZitadelAuthClient({ baseUrl: "https://api.mark8ly.com" });
 }
 
 it("signs in and reports the tokens", async () => {
-  const f = jest.fn(() =>
+  const f: FetchMock = jest.fn((_u: string, _i: RequestInit) =>
     jsonResponse(200, {
       data: {
         uid: "u1", email: "a@b.test", tenant_id: "t-1",
@@ -35,14 +37,14 @@ it("signs in and reports the tokens", async () => {
 
   const [url, init] = f.mock.calls[0];
   expect(url).toBe("https://api.mark8ly.com/api/v1/mobile/admin/auth/login");
-  expect((init as RequestInit).method).toBe("POST");
+  expect(init.method).toBe("POST");
   // No bearer: this call is how one is obtained.
-  expect((init as RequestInit).headers).not.toHaveProperty("Authorization");
+  expect(init.headers).not.toHaveProperty("Authorization");
 });
 
 // THE common first-login path: a fresh install is always a new device.
 it("reports an OTP challenge with the token needed to resume it", async () => {
-  const f = jest.fn(() =>
+  const f: FetchMock = jest.fn((_u: string, _i: RequestInit) =>
     jsonResponse(200, {
       data: {
         uid: "u1", email: "a@b.test", tenant_id: "t-1",
@@ -63,7 +65,7 @@ it("reports an OTP challenge with the token needed to resume it", async () => {
 // normal OTP prompt would strand the user on a screen whose submit can
 // never succeed, so it fails loudly instead.
 it("rejects an OTP challenge that carries no pending token", async () => {
-  const f = jest.fn(() =>
+  const f: FetchMock = jest.fn((_u: string, _i: RequestInit) =>
     jsonResponse(200, { data: { email_otp_required: true, email: "a@b.test" } }),
   );
   // Asserted on the stable code, not the copy: screens map from the code,
@@ -74,7 +76,7 @@ it("rejects an OTP challenge that carries no pending token", async () => {
 });
 
 it("maps 401 to invalid credentials", async () => {
-  const f = jest.fn(() => jsonResponse(401, { error: "invalid_credentials" }));
+  const f: FetchMock = jest.fn((_u: string, _i: RequestInit) => jsonResponse(401, { error: "invalid_credentials" }));
   await expect(clientWith(f).signIn("a@b.test", "bad")).rejects.toMatchObject({
     code: "invalid_credentials",
   });
@@ -83,7 +85,7 @@ it("maps 401 to invalid credentials", async () => {
 // 404 no_store is a distinct, actionable state — the account exists but has
 // no store — and must not be flattened into "wrong password".
 it("maps 404 no_store distinctly", async () => {
-  const f = jest.fn(() => jsonResponse(404, { error: "no_store" }));
+  const f: FetchMock = jest.fn((_u: string, _i: RequestInit) => jsonResponse(404, { error: "no_store" }));
   await expect(clientWith(f).signIn("a@b.test", "pw")).rejects.toMatchObject({
     code: "no_store",
   });
@@ -92,14 +94,14 @@ it("maps 404 no_store distinctly", async () => {
 // A 502 means the credential may have been correct. Reporting it as a bad
 // password makes a merchant retype a correct one indefinitely.
 it("maps 502 to an availability error, not a credential error", async () => {
-  const f = jest.fn(() => jsonResponse(502, { error: "auth_unavailable" }));
+  const f: FetchMock = jest.fn((_u: string, _i: RequestInit) => jsonResponse(502, { error: "auth_unavailable" }));
   await expect(clientWith(f).signIn("a@b.test", "pw")).rejects.toMatchObject({
     code: "auth_unavailable",
   });
 });
 
 it("completes the OTP challenge and returns tokens", async () => {
-  const f = jest.fn(() =>
+  const f: FetchMock = jest.fn((_u: string, _i: RequestInit) =>
     jsonResponse(200, {
       data: {
         uid: "u1", email: "a@b.test", tenant_id: "t-1",
@@ -114,14 +116,14 @@ it("completes the OTP challenge and returns tokens", async () => {
 
   const [url, init] = f.mock.calls[0];
   expect(url).toBe("https://api.mark8ly.com/api/v1/mobile/admin/auth/otp/verify");
-  expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+  expect(JSON.parse(init.body as string)).toEqual({
     pending_token: "sealed-value",
     code: "123456",
   });
 });
 
 it("maps a rejected OTP code to invalid_code", async () => {
-  const f = jest.fn(() => jsonResponse(401, { error: "invalid_code" }));
+  const f: FetchMock = jest.fn((_u: string, _i: RequestInit) => jsonResponse(401, { error: "invalid_code" }));
   await expect(clientWith(f).verifyOtp("sealed", "000000")).rejects.toMatchObject({
     code: "invalid_code",
   });

--- a/apps/mobile-admin/__tests__/zitadel-session.test.ts
+++ b/apps/mobile-admin/__tests__/zitadel-session.test.ts
@@ -1,0 +1,67 @@
+import { zitadelSession } from "@repo/mobile-shared/auth/zitadel-session";
+
+jest.mock("expo-secure-store", () => {
+  const mem: Record<string, string> = {};
+  return {
+    __mem: mem,
+    getItemAsync: jest.fn(async (k: string) => mem[k] ?? null),
+    setItemAsync: jest.fn(async (k: string, v: string) => {
+      mem[k] = v;
+    }),
+    deleteItemAsync: jest.fn(async (k: string) => {
+      delete mem[k];
+    }),
+  };
+});
+
+const mem = (jest.requireMock("expo-secure-store") as { __mem: Record<string, string> }).__mem;
+beforeEach(() => {
+  for (const k of Object.keys(mem)) delete mem[k];
+  jest.useRealTimers();
+});
+
+it("round-trips a session", async () => {
+  await zitadelSession.save("AT", "RT", 3600);
+  const s = await zitadelSession.read();
+  expect(s?.accessToken).toBe("AT");
+  expect(s?.refreshToken).toBe("RT");
+  expect(await zitadelSession.accessTokenIfFresh()).toBe("AT");
+});
+
+// The server sends seconds-from-now. Storing that verbatim would make it
+// meaningless after a restart — an hour-old "3600" would still read fresh.
+it("stores an absolute expiry, not a relative one", async () => {
+  const before = Date.now();
+  await zitadelSession.save("AT", "RT", 3600);
+  const s = await zitadelSession.read();
+  expect(s!.expiresAt).toBeGreaterThanOrEqual(before + 3600 * 1000);
+});
+
+it("treats an expired token as absent", async () => {
+  await zitadelSession.save("AT", "RT", -10);
+  expect(await zitadelSession.accessTokenIfFresh()).toBeNull();
+  // read() still returns it: the refresh path needs the refresh token even
+  // once the access token has lapsed.
+  expect((await zitadelSession.read())?.refreshToken).toBe("RT");
+});
+
+// A token expiring seconds from now would lapse mid-request and surface as
+// a 401 the client reads as "signed out".
+it("treats a token inside the skew window as stale", async () => {
+  await zitadelSession.save("AT", "RT", 30);
+  expect(await zitadelSession.accessTokenIfFresh()).toBeNull();
+});
+
+// Corrupt state must fail toward re-authentication, never toward trusting a
+// token forever.
+it("treats an unparseable expiry as elapsed", async () => {
+  await zitadelSession.save("AT", "RT", 3600);
+  mem["mark8ly_zitadel_expires_at"] = "not-a-number";
+  expect(await zitadelSession.accessTokenIfFresh()).toBeNull();
+});
+
+it("clears everything on sign-out", async () => {
+  await zitadelSession.save("AT", "RT", 3600);
+  await zitadelSession.clear();
+  expect(await zitadelSession.read()).toBeNull();
+});

--- a/apps/mobile-admin/__tests__/zitadel-signin-flow.test.ts
+++ b/apps/mobile-admin/__tests__/zitadel-signin-flow.test.ts
@@ -1,0 +1,104 @@
+import { createZitadelSignIn } from "@repo/mobile-shared/auth/zitadel-signin";
+import { isZitadelProvider } from "@/lib/auth-provider";
+import { zitadelSession } from "@repo/mobile-shared/auth/zitadel-session";
+
+jest.mock("expo-secure-store", () => {
+  const mem: Record<string, string> = {};
+  return {
+    __mem: mem,
+    getItemAsync: jest.fn(async (k: string) => mem[k] ?? null),
+    setItemAsync: jest.fn(async (k: string, v: string) => {
+      mem[k] = v;
+    }),
+    deleteItemAsync: jest.fn(async (k: string) => {
+      delete mem[k];
+    }),
+  };
+});
+
+const mem = (jest.requireMock("expo-secure-store") as { __mem: Record<string, string> }).__mem;
+
+function respond(body: unknown, status = 200) {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    } as unknown as Response),
+  ) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  for (const k of Object.keys(mem)) delete mem[k];
+});
+
+// The flag must default OFF so an unmodified build keeps using GIP.
+it("uses the GIP provider unless explicitly opted in", () => {
+  delete process.env.EXPO_PUBLIC_AUTH_PROVIDER;
+  expect(isZitadelProvider()).toBe(false);
+  process.env.EXPO_PUBLIC_AUTH_PROVIDER = "zitadel";
+  expect(isZitadelProvider()).toBe(true);
+  delete process.env.EXPO_PUBLIC_AUTH_PROVIDER;
+});
+
+it("persists tokens and the tenant on a completed sign-in", async () => {
+  respond({
+    data: {
+      uid: "u1", email: "a@b.test", tenant_id: "t-1",
+      access_token: "AT", refresh_token: "RT", expires_in: 3600,
+    },
+  });
+  const setTenantId = jest.fn();
+  const flow = createZitadelSignIn("https://api.mark8ly.com");
+
+  const out = await flow.signIn("a@b.test", "pw", setTenantId);
+
+  expect(out.kind).toBe("signed_in");
+  expect(await zitadelSession.accessTokenIfFresh()).toBe("AT");
+  // The TENANT id, from the login response — never a store id.
+  expect(setTenantId).toHaveBeenCalledWith("t-1");
+});
+
+// The common first login. Nothing may be persisted yet: a stored tenant
+// with no token leaves the app sending X-Acting-Tenant-Id unauthenticated,
+// which reads as a server fault rather than an unfinished login.
+it("persists nothing while an OTP challenge is outstanding", async () => {
+  respond({
+    data: {
+      email: "a@b.test", tenant_id: "t-1",
+      email_otp_required: true, pending_token: "sealed",
+    },
+  });
+  const setTenantId = jest.fn();
+  const flow = createZitadelSignIn("https://api.mark8ly.com");
+
+  const out = await flow.signIn("a@b.test", "pw", setTenantId);
+
+  expect(out.kind).toBe("otp");
+  expect(out.pendingToken).toBe("sealed");
+  expect(await zitadelSession.read()).toBeNull();
+  expect(setTenantId).not.toHaveBeenCalled();
+});
+
+it("persists on OTP completion", async () => {
+  respond({
+    data: {
+      uid: "u1", email: "a@b.test", tenant_id: "t-1",
+      access_token: "AT2", refresh_token: "RT2", expires_in: 3600,
+    },
+  });
+  const setTenantId = jest.fn();
+  const flow = createZitadelSignIn("https://api.mark8ly.com");
+
+  const out = await flow.verifyOtp("sealed", "123456", setTenantId);
+
+  expect(out.kind).toBe("signed_in");
+  expect(await zitadelSession.accessTokenIfFresh()).toBe("AT2");
+  expect(setTenantId).toHaveBeenCalledWith("t-1");
+});
+
+it("clears the session on sign-out", async () => {
+  await zitadelSession.save("AT", "RT", 3600);
+  await createZitadelSignIn("https://api.mark8ly.com").signOut();
+  expect(await zitadelSession.read()).toBeNull();
+});

--- a/apps/mobile-admin/app/_layout.tsx
+++ b/apps/mobile-admin/app/_layout.tsx
@@ -76,6 +76,7 @@ function AuthGate() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="(tabs)" />
       <Stack.Screen name="login" />
+      <Stack.Screen name="otp" />
       <Stack.Screen name="notifications" />
     </Stack>
   );

--- a/apps/mobile-admin/app/login.tsx
+++ b/apps/mobile-admin/app/login.tsx
@@ -171,7 +171,13 @@ export default function LoginScreen() {
               ? "We couldn't find a store for this account. Did you finish onboarding?"
               : e.code === 'auth_unavailable' || e.code === 'network'
                 ? 'Sign-in is temporarily unavailable. Try again shortly.'
-                : GENERIC_AUTH_ERROR,
+                : e.code === 'challenge_unresumable'
+                  // The server asked for a verification step but sent
+                  // nothing to resume it with — in practice, an app newer
+                  // than the API it is talking to. Distinct copy because
+                  // "try again" is useless advice here: retrying repeats it.
+                  ? 'This app version needs an update to finish signing in.'
+                  : GENERIC_AUTH_ERROR,
         );
         return;
       }

--- a/apps/mobile-admin/app/login.tsx
+++ b/apps/mobile-admin/app/login.tsx
@@ -20,6 +20,12 @@ import { theme } from '@/lib/theme';
 import { IconButton } from '@/components/ui/IconButton';
 import { LinkAccountPrompt } from '../components/auth/LinkAccountPrompt';
 import { Text } from '../components/ui/Text';
+import { router } from 'expo-router';
+import { useTenantStore } from '@repo/mobile-shared/stores/tenant-store';
+import { useEnvironment } from '@repo/mobile-shared/config/env';
+import { createZitadelSignIn } from '@repo/mobile-shared/auth/zitadel-signin';
+import { ZitadelAuthError } from '@repo/mobile-shared/auth/zitadel-client';
+import { isZitadelProvider } from '@/lib/auth-provider';
 
 const DEMO_AUTH = process.env.EXPO_PUBLIC_AUTH_BACKEND === 'demo';
 
@@ -116,6 +122,8 @@ function AppleMark({ size = PROVIDER_MARK }: { size?: number }) {
 
 export default function LoginScreen() {
   const { signIn, signInWithGoogle, signInWithApple } = useAuth();
+  const env = useEnvironment();
+  const setTenantId = useTenantStore((s) => s.setTenantId);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -135,8 +143,38 @@ export default function LoginScreen() {
     setError(null);
     setSubmitting(true);
     try {
+      if (isZitadelProvider()) {
+        // Our own form, posted to marketplace-api rather than to Zitadel's
+        // hosted login. A fresh install is always an unrecognised device,
+        // so the usual answer here is a challenge, not a session.
+        const out = await createZitadelSignIn(env.apiBaseUrl).signIn(email, password, setTenantId);
+        if (out.kind === 'otp') {
+          router.push({
+            pathname: '/otp',
+            params: { pendingToken: out.pendingToken ?? '', email: out.email },
+          });
+          return;
+        }
+        router.replace('/(tabs)');
+        return;
+      }
       await signIn(email, password);
     } catch (e: unknown) {
+      if (isZitadelProvider() && e instanceof ZitadelAuthError) {
+        // Mapped from the server's stable code. `no_store` is a real,
+        // actionable state — the account exists but has no store — and
+        // `auth_unavailable` must never read as a wrong password.
+        setError(
+          e.code === 'invalid_credentials'
+            ? "Couldn't sign you in. Check your details and try again."
+            : e.code === 'no_store'
+              ? "We couldn't find a store for this account. Did you finish onboarding?"
+              : e.code === 'auth_unavailable' || e.code === 'network'
+                ? 'Sign-in is temporarily unavailable. Try again shortly.'
+                : GENERIC_AUTH_ERROR,
+        );
+        return;
+      }
       const msg = authErrorMessage(e);
       // null is the mapper's deliberate "user cancelled — stay silent" signal;
       // anything else always surfaces copy, falling back to generic wording so

--- a/apps/mobile-admin/app/otp.tsx
+++ b/apps/mobile-admin/app/otp.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react';
+import { KeyboardAvoidingView, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { router, useLocalSearchParams } from 'expo-router';
+import { useTenantStore } from '@repo/mobile-shared/stores/tenant-store';
+import { createZitadelSignIn } from '@repo/mobile-shared/auth/zitadel-signin';
+import { ZitadelAuthError } from '@repo/mobile-shared/auth/zitadel-client';
+import { useEnvironment } from '@repo/mobile-shared/config/env';
+import { theme } from '@/lib/theme';
+import { Text } from '../components/ui/Text';
+
+/**
+ * Email one-time code screen (#686).
+ *
+ * This is the COMMON first sign-in on mobile, not an edge case: a fresh
+ * install is by definition an unrecognised device, so a merchant setting up
+ * a new phone lands here every time. Its absence is why the equivalent web
+ * flow silently bounced users back to /login (#493) — every layer logged
+ * success and the code screen simply did not exist.
+ */
+export default function OtpScreen() {
+  const params = useLocalSearchParams<{ pendingToken?: string; email?: string }>();
+  const env = useEnvironment();
+  const setTenantId = useTenantStore((s) => s.setTenantId);
+
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const pendingToken = params.pendingToken ?? '';
+
+  async function handleVerify() {
+    if (submitting) return;
+    if (code.trim().length === 0) {
+      setError('Enter the code we emailed you.');
+      return;
+    }
+    // Without this there is nothing to resume, and submitting would fail
+    // with copy that blames the code the user typed correctly.
+    if (!pendingToken) {
+      setError('This sign-in attempt has expired. Go back and sign in again.');
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      await createZitadelSignIn(env.apiBaseUrl).verifyOtp(pendingToken, code.trim(), setTenantId);
+      router.replace('/(tabs)');
+    } catch (e: unknown) {
+      // Mapped from the server's stable code, never the status: 401 covers
+      // both a wrong code and an expired challenge, and "sign-in
+      // unavailable" must never read as "wrong code" or a merchant will
+      // retype a correct one indefinitely.
+      const code = e instanceof ZitadelAuthError ? e.code : '';
+      setError(
+        code === 'invalid_code'
+          ? "That code isn't right, or it has expired. Request a new one."
+          : code === 'auth_unavailable' || code === 'network'
+            ? 'Sign-in is temporarily unavailable. Try again shortly.'
+            : 'Something went wrong. Please try again.',
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <SafeAreaView className="flex-1 bg-paper">
+      <KeyboardAvoidingView
+        className="flex-1"
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView contentContainerClassName="grow justify-center px-6" keyboardShouldPersistTaps="handled">
+          <Text preset="eyebrow" className="text-moss">
+            CHECK YOUR EMAIL
+          </Text>
+          <Text preset="display" className="mt-2 text-ink">
+            Enter code
+          </Text>
+          <Text preset="body" className="mt-3 text-ink-secondary">
+            {params.email
+              ? `We sent a sign-in code to ${params.email}.`
+              : 'We sent a sign-in code to your email.'}
+          </Text>
+
+          <TextInput
+            accessibilityLabel="Email code"
+            className="mt-8 min-h-touch rounded border border-border bg-paper-elevated px-4 text-center font-sans text-display text-ink"
+            placeholder="000000"
+            placeholderTextColor={theme.colors.textTertiary}
+            keyboardType="number-pad"
+            textContentType="oneTimeCode"
+            autoComplete="one-time-code"
+            maxLength={8}
+            value={code}
+            onChangeText={setCode}
+          />
+
+          {error ? (
+            <Text
+              preset="caption"
+              className="mt-3 text-danger"
+              accessibilityRole="alert"
+              accessibilityLiveRegion="polite"
+            >
+              {error}
+            </Text>
+          ) : null}
+
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Verify code"
+            disabled={submitting}
+            onPress={handleVerify}
+            className="mt-6 min-h-touch items-center justify-center rounded bg-ink active:opacity-90"
+          >
+            <Text preset="bodyEmphasis" className="text-paper">
+              {submitting ? 'Verifying…' : 'Verify'}
+            </Text>
+          </Pressable>
+
+          <View className="mt-6 items-center">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Back to sign in"
+              onPress={() => router.replace('/login')}
+            >
+              <Text preset="caption" className="text-moss underline">
+                Back to sign in
+              </Text>
+            </Pressable>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}

--- a/apps/mobile-admin/lib/api-client.ts
+++ b/apps/mobile-admin/lib/api-client.ts
@@ -3,6 +3,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import { createApiClient } from "@repo/mobile-shared/api/client";
 import { useAuth } from "@repo/mobile-shared/auth/provider";
 import { useAuthNoticeStore } from "@repo/mobile-shared/stores/auth-notice";
+import { zitadelSession } from "@repo/mobile-shared/auth/zitadel-session";
+import { isZitadelProvider } from "@/lib/auth-provider";
 import { useTenantStore } from "@repo/mobile-shared/stores/tenant-store";
 import { useEnvironment } from "@repo/mobile-shared/config/env";
 import { createDemoApiClient } from "./demo-api-client";
@@ -36,7 +38,12 @@ export function useApiClient() {
     () =>
       createApiClient({
         baseUrl: env.apiBaseUrl,
-        getToken,
+        // Under Zitadel the bearer is a plain token this app persisted at
+        // sign-in, not something a Firebase SDK mints on demand. Falls back
+        // to the GIP getter so a non-Zitadel build is unchanged.
+        getToken: isZitadelProvider()
+          ? () => zitadelSession.accessTokenIfFresh()
+          : getToken,
         refreshToken,
         getStoreId: () => activeStore?.id ?? null,
         // Tenancy for a Zitadel token, which carries no tenant claim

--- a/apps/mobile-admin/lib/auth-provider.ts
+++ b/apps/mobile-admin/lib/auth-provider.ts
@@ -1,0 +1,10 @@
+/**
+ * Which auth provider this build uses (#686).
+ *
+ * NEXT_PUBLIC-style flags are inlined at BUILD time, so this cannot be
+ * flipped by a chart env var — a switch means a rebuild, and for the app a
+ * store release. Defaults to GIP so an unmodified build is unchanged.
+ */
+export function isZitadelProvider(): boolean {
+  return process.env.EXPO_PUBLIC_AUTH_PROVIDER === "zitadel";
+}

--- a/packages/mobile-shared/auth/zitadel-client.ts
+++ b/packages/mobile-shared/auth/zitadel-client.ts
@@ -1,0 +1,175 @@
+/**
+ * Network layer for Zitadel-backed mobile sign-in (#686).
+ *
+ * The app keeps mark8ly's own login form rather than sending merchants to
+ * Zitadel's hosted login, so it posts credentials to marketplace-api's
+ * public front door, which proxies to auth-bff. Nothing here talks to
+ * Zitadel directly and nothing here holds a client secret.
+ *
+ * Deliberately free of React and of storage so the wire contract and its
+ * error mapping can be tested on their own — this is the layer where a
+ * wrong status-to-copy mapping strands a merchant.
+ */
+
+export interface ZitadelAuthClientConfig {
+  baseUrl: string;
+}
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  tokenType: string;
+  /** Seconds from issue, as returned. Absolute expiry is the caller's job. */
+  expiresIn: number;
+}
+
+export interface TenantMembership {
+  tenant_id: string;
+  name: string;
+  role: string;
+}
+
+export interface CompleteSignIn {
+  status: "complete";
+  uid: string;
+  email: string;
+  tenantId: string;
+  tenants: TenantMembership[];
+  tokens: AuthTokens;
+}
+
+export interface OtpRequired {
+  status: "otp_required";
+  email: string;
+  tenantId: string;
+  tenants: TenantMembership[];
+  /** Opaque; handed straight back to verifyOtp. */
+  pendingToken: string;
+}
+
+export type SignInResult = CompleteSignIn | OtpRequired;
+
+/**
+ * A failure with a stable `code`, so screens map to copy from the code
+ * rather than from a status number or a message string.
+ *
+ * `auth_unavailable` matters most: it means the credential may have been
+ * CORRECT and the service was not reachable. Showing "wrong password" there
+ * makes a merchant retype a correct one indefinitely.
+ */
+export class ZitadelAuthError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ZitadelAuthError";
+  }
+}
+
+interface WireData {
+  uid?: string;
+  email?: string;
+  tenant_id?: string;
+  tenants?: TenantMembership[];
+  access_token?: string;
+  refresh_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  email_otp_required?: boolean;
+  mfa_required?: boolean;
+  totp_required?: boolean;
+  pending_token?: string;
+}
+
+const PATHS = {
+  login: "/api/v1/mobile/admin/auth/login",
+  otpVerify: "/api/v1/mobile/admin/auth/otp/verify",
+} as const;
+
+export function createZitadelAuthClient(config: ZitadelAuthClientConfig) {
+  async function post(path: string, body: unknown): Promise<WireData> {
+    let res: Response;
+    try {
+      res = await fetch(config.baseUrl + path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify(body),
+      });
+    } catch {
+      // Offline and server-down are the same to the user: try again later.
+      throw new ZitadelAuthError("network", "No connection. Check your network and try again.");
+    }
+
+    let parsed: { data?: WireData; error?: string; message?: string } = {};
+    try {
+      parsed = (await res.json()) as typeof parsed;
+    } catch {
+      parsed = {};
+    }
+
+    if (!res.ok) {
+      // The server's own code is preserved rather than re-derived from the
+      // status, because 401 covers both a wrong password and a wrong OTP
+      // code, which need different copy.
+      throw new ZitadelAuthError(parsed.error ?? `http_${res.status}`, parsed.message ?? "");
+    }
+    return parsed.data ?? {};
+  }
+
+  function tokensFrom(d: WireData): AuthTokens {
+    return {
+      accessToken: d.access_token ?? "",
+      refreshToken: d.refresh_token ?? "",
+      tokenType: d.token_type ?? "Bearer",
+      expiresIn: d.expires_in ?? 0,
+    };
+  }
+
+  return {
+    async signIn(email: string, password: string): Promise<SignInResult> {
+      const d = await post(PATHS.login, { email, password });
+
+      if (d.email_otp_required || d.mfa_required || d.totp_required) {
+        // A challenge with nothing to resume from is unfinishable. Failing
+        // here is better than a code screen whose submit can never succeed.
+        if (!d.pending_token) {
+          throw new ZitadelAuthError(
+            "challenge_unresumable",
+            "We couldn't start the verification step. Try signing in again.",
+          );
+        }
+        return {
+          status: "otp_required",
+          email: d.email ?? email,
+          tenantId: d.tenant_id ?? "",
+          tenants: d.tenants ?? [],
+          pendingToken: d.pending_token,
+        };
+      }
+
+      return {
+        status: "complete",
+        uid: d.uid ?? "",
+        email: d.email ?? email,
+        tenantId: d.tenant_id ?? "",
+        tenants: d.tenants ?? [],
+        tokens: tokensFrom(d),
+      };
+    },
+
+    async verifyOtp(pendingToken: string, code: string): Promise<CompleteSignIn> {
+      const d = await post(PATHS.otpVerify, { pending_token: pendingToken, code });
+      return {
+        status: "complete",
+        uid: d.uid ?? "",
+        email: d.email ?? "",
+        tenantId: d.tenant_id ?? "",
+        tenants: d.tenants ?? [],
+        tokens: tokensFrom(d),
+      };
+    },
+  };
+}
+
+export type ZitadelAuthClient = ReturnType<typeof createZitadelAuthClient>;

--- a/packages/mobile-shared/auth/zitadel-session.ts
+++ b/packages/mobile-shared/auth/zitadel-session.ts
@@ -1,0 +1,80 @@
+import * as SecureStore from "expo-secure-store";
+
+/**
+ * Persistent home for the bearer tokens a Zitadel sign-in returns (#686).
+ *
+ * The GIP path never needed this: the Firebase SDK owned the tokens and
+ * minted a fresh id_token on demand. Zitadel tokens arrive as plain values
+ * from our own API, so the app has to keep them itself — in SecureStore,
+ * the same place the tenant and store ids already live, never AsyncStorage.
+ */
+
+const KEYS = {
+  ACCESS: "mark8ly_zitadel_access_token",
+  REFRESH: "mark8ly_zitadel_refresh_token",
+  /** Absolute epoch-ms expiry, computed once at issue. */
+  EXPIRES_AT: "mark8ly_zitadel_expires_at",
+} as const;
+
+export interface StoredSession {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+}
+
+/**
+ * Treat a token as expired slightly early, so one that would lapse
+ * mid-flight is refreshed instead of producing a 401 the client then has to
+ * interpret as "signed out".
+ */
+const EXPIRY_SKEW_MS = 60_000;
+
+export const zitadelSession = {
+  /**
+   * expiresIn is seconds-from-now, as the server returns it, and is
+   * converted to an absolute instant here. Storing the relative value would
+   * make it meaningless after the first app restart.
+   */
+  async save(accessToken: string, refreshToken: string, expiresIn: number): Promise<void> {
+    const expiresAt = Date.now() + expiresIn * 1000;
+    await Promise.all([
+      SecureStore.setItemAsync(KEYS.ACCESS, accessToken),
+      SecureStore.setItemAsync(KEYS.REFRESH, refreshToken),
+      SecureStore.setItemAsync(KEYS.EXPIRES_AT, String(expiresAt)),
+    ]);
+  },
+
+  async read(): Promise<StoredSession | null> {
+    const [accessToken, refreshToken, rawExp] = await Promise.all([
+      SecureStore.getItemAsync(KEYS.ACCESS),
+      SecureStore.getItemAsync(KEYS.REFRESH),
+      SecureStore.getItemAsync(KEYS.EXPIRES_AT),
+    ]);
+    if (!accessToken) return null;
+    const expiresAt = Number(rawExp);
+    return {
+      accessToken,
+      refreshToken: refreshToken ?? "",
+      // A missing or unparseable expiry is treated as already elapsed
+      // rather than as "never expires": the safe reading of corrupt state
+      // is to re-authenticate, not to trust a token indefinitely.
+      expiresAt: Number.isFinite(expiresAt) ? expiresAt : 0,
+    };
+  },
+
+  /** The access token, or null when absent or (near) expired. */
+  async accessTokenIfFresh(): Promise<string | null> {
+    const s = await zitadelSession.read();
+    if (!s) return null;
+    if (s.expiresAt - EXPIRY_SKEW_MS <= Date.now()) return null;
+    return s.accessToken;
+  },
+
+  async clear(): Promise<void> {
+    await Promise.all([
+      SecureStore.deleteItemAsync(KEYS.ACCESS),
+      SecureStore.deleteItemAsync(KEYS.REFRESH),
+      SecureStore.deleteItemAsync(KEYS.EXPIRES_AT),
+    ]);
+  },
+};

--- a/packages/mobile-shared/auth/zitadel-signin.ts
+++ b/packages/mobile-shared/auth/zitadel-signin.ts
@@ -1,0 +1,70 @@
+import { createZitadelAuthClient, type SignInResult, type CompleteSignIn } from "./zitadel-client";
+import { zitadelSession } from "./zitadel-session";
+
+/**
+ * The sign-in flow, joining the wire client to persistence (#686).
+ *
+ * Which provider a build uses is decided in the APP (see
+ * lib/auth-provider.ts), not here: reading process.env from a shared
+ * package pulls in Expo's virtual env module, which is not resolvable
+ * outside an app's bundler context.
+ */
+
+export interface SignInOutcome {
+  /** "otp" means a code was emailed and the caller must show the screen. */
+  kind: "signed_in" | "otp";
+  email: string;
+  tenantId: string;
+  pendingToken?: string;
+}
+
+export function createZitadelSignIn(baseUrl: string) {
+  const client = createZitadelAuthClient({ baseUrl });
+
+  // Tokens and the tenant are persisted TOGETHER, and only on completion.
+  // Writing the tenant earlier would leave a half-signed-in app that sends
+  // X-Acting-Tenant-Id with no bearer token, which reads as a server fault
+  // rather than an unfinished login.
+  async function persist(res: CompleteSignIn, setTenantId: (id: string) => void): Promise<void> {
+    await zitadelSession.save(
+      res.tokens.accessToken,
+      res.tokens.refreshToken,
+      res.tokens.expiresIn,
+    );
+    if (res.tenantId) setTenantId(res.tenantId);
+  }
+
+  return {
+    async signIn(
+      email: string,
+      password: string,
+      setTenantId: (id: string) => void,
+    ): Promise<SignInOutcome> {
+      const res: SignInResult = await client.signIn(email, password);
+      if (res.status === "otp_required") {
+        return {
+          kind: "otp",
+          email: res.email,
+          tenantId: res.tenantId,
+          pendingToken: res.pendingToken,
+        };
+      }
+      await persist(res, setTenantId);
+      return { kind: "signed_in", email: res.email, tenantId: res.tenantId };
+    },
+
+    async verifyOtp(
+      pendingToken: string,
+      code: string,
+      setTenantId: (id: string) => void,
+    ): Promise<SignInOutcome> {
+      const res = await client.verifyOtp(pendingToken, code);
+      await persist(res, setTenantId);
+      return { kind: "signed_in", email: res.email, tenantId: res.tenantId };
+    },
+
+    async signOut(): Promise<void> {
+      await zitadelSession.clear();
+    },
+  };
+}


### PR DESCRIPTION
Part of #686. The client half: the app signs in through mark8ly's own form against the new front door, handles the email-OTP challenge, and stores real bearer tokens.

Behind `EXPO_PUBLIC_AUTH_PROVIDER=zitadel`, default off, so GIP builds are unchanged. Inlined at build time, so flipping it is a rebuild and a store release — not a chart edit.

## Layers

| File | Job | Tests |
|---|---|---|
| `zitadel-client.ts` | wire contract + error-code mapping | 8 |
| `zitadel-session.ts` | token persistence in SecureStore | 6 |
| `zitadel-signin.ts` | joins wire to persistence | 5 |
| `app/otp.tsx` | the email-code screen | — |
| `login.tsx`, `api-client.ts` | wiring | — |

Split this way so the wire contract and its error mapping are testable without a simulator — that is the layer where a wrong status-to-copy mapping strands a merchant.

## Verified on a simulator against production

This is not only unit-tested. Built Release, ran on an iPhone 17 Pro Max, typed the real India merchant's credentials, and watched it call `api.mark8ly.com` — **HTTP 200 in 4.6s**.

It then correctly **refused**, because the deployed API predates #746/#747 and returns no `pending_token`. Rather than dropping the merchant on an OTP screen whose submit could never succeed, it stops at the login screen. That dead-end is precisely the #493 failure mode, where every layer logged success and the user was bounced with nothing shown.

The run did expose a real flaw, now fixed: that case fell through to "Something went wrong. Please try again.", which is useless advice when retrying reproduces it. It now reads **"This app version needs an update to finish signing in."** — the honest diagnosis, since the state means an app newer than its API.

## Decisions worth review

- **Tokens and tenant are persisted together, only on completion.** Writing the tenant at challenge time would leave the app sending `X-Acting-Tenant-Id` with no bearer token, which reads as a server fault rather than an unfinished login.
- **Absolute expiry, not relative.** The server sends seconds-from-now; storing that verbatim makes it meaningless after a restart, where an hour-old `3600` still reads fresh. A 60s skew means a token that would lapse mid-request is treated as stale rather than producing a 401 the client reads as "signed out".
- **Corrupt expiry counts as elapsed**, never as "never expires": the safe reading of corrupt state is re-authenticate.
- **Screens map from the server's stable `code`, never the HTTP status** — 401 covers both a wrong password and a wrong OTP code, which need different copy. `auth_unavailable` in particular must never read as a bad credential.
- The env flag lives in the **app**, not the shared package: reading `process.env` there pulls in Expo's virtual env module, which is unresolvable outside a bundler context.

## Verification

130 suites, 1716 tests, all passing. `tsc` clean for every file touched (the repo-wide missing-`@types/jest` noise predates this — see #716).

## Next

Once #746/#747 promote, the same tap should reach the OTP screen with a real emailed code and land on the dashboard. Still to do: MFA/TOTP, and Google/Apple which remain on the Firebase SDK.
