### PR TITLE
fix(mobile): stop the auth gate bouncing Zitadel sessions, and top-align the OTP screen (#686)

### DIFF
--- a/apps/mobile-admin/app/_layout.tsx
+++ b/apps/mobile-admin/app/_layout.tsx
@@ -1,6 +1,6 @@
 import '../global.css';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { View } from 'react-native';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
@@ -15,6 +15,8 @@ import {
 import * as SplashScreen from 'expo-splash-screen';
 import { useFonts } from 'expo-font';
 import { AuthProvider, useAuth } from '@repo/mobile-shared/auth/provider';
+import { zitadelSession } from '@repo/mobile-shared/auth/zitadel-session';
+import { isZitadelProvider } from '@/lib/auth-provider';
 import { useTenantStore } from '@repo/mobile-shared/stores/tenant-store';
 import { ApiError } from '@repo/mobile-shared/api/client';
 import { ErrorBoundary } from '../components/ErrorBoundary';
@@ -37,6 +39,33 @@ function AuthGate() {
   const { user, loading } = useAuth();
   const segments = useSegments();
   const router = useRouter();
+  // Re-read the token whenever the route changes, so completing the OTP
+  // screen is noticed without waiting for a remount.
+  const segmentsKey = segments.join('/');
+  // Under Zitadel `user` is ALWAYS null — that field belongs to the Firebase
+  // SDK and this provider never populates it. Signed-in-ness comes from the
+  // token this app persisted at sign-in instead. Without this the gate below
+  // bounces every Zitadel session straight back to /login: the navigation
+  // succeeds, the guard undoes it, and the user sees a blank login form with
+  // no error anywhere — the #493 failure, reproduced exactly.
+  const [zitadelSignedIn, setZitadelSignedIn] = useState<boolean | null>(
+    isZitadelProvider() ? null : false,
+  );
+  useEffect(() => {
+    if (!isZitadelProvider()) return;
+    let cancelled = false;
+    zitadelSession
+      .accessTokenIfFresh()
+      .then((t) => {
+        if (!cancelled) setZitadelSignedIn(Boolean(t));
+      })
+      .catch(() => {
+        if (!cancelled) setZitadelSignedIn(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [segmentsKey]);
   const qc = useQueryClient();
   const hydrate = useTenantStore((s) => s.hydrate);
   const clearTenant = useTenantStore((s) => s.clear);
@@ -48,7 +77,14 @@ function AuthGate() {
 
   useEffect(() => {
     if (loading) return;
-    const inAuthGroup = segments[0] === 'login';
+    // null means the token read has not resolved yet. Redirecting on an
+    // unknown answer would race the check and bounce a signed-in user.
+    if (zitadelSignedIn === null) return;
+    // /otp is part of the sign-in flow: the caller is legitimately not
+    // authenticated there yet, so it must not be treated as a protected
+    // route.
+    const inAuthGroup = segments[0] === 'login' || segments[0] === 'otp';
+    const signedIn = isZitadelProvider() ? zitadelSignedIn : Boolean(user);
 
     // Identity changed → wipe cached queries + tenant so user A's data can't
     // leak into user B's session.
@@ -59,13 +95,13 @@ function AuthGate() {
     }
     previousUid.current = currentUid;
 
-    if (!user && !inAuthGroup) {
+    if (!signedIn && !inAuthGroup) {
       router.replace('/login');
-    } else if (user && inAuthGroup) {
+    } else if (signedIn && inAuthGroup) {
       router.replace('/');
     }
     SplashScreen.hideAsync();
-  }, [user, loading, segments, router, clearTenant, qc]);
+  }, [user, loading, segments, router, clearTenant, qc, zitadelSignedIn]);
 
   // Root stack (not Slot) so screens outside the tab group — like the
   // notifications inbox — push as cards ABOVE the tabs. Launching the inbox

--- a/apps/mobile-admin/app/otp.tsx
+++ b/apps/mobile-admin/app/otp.tsx
@@ -1,13 +1,20 @@
-import { useState } from 'react';
-import { KeyboardAvoidingView, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { router, useLocalSearchParams } from 'expo-router';
-import { useTenantStore } from '@repo/mobile-shared/stores/tenant-store';
-import { createZitadelSignIn } from '@repo/mobile-shared/auth/zitadel-signin';
-import { ZitadelAuthError } from '@repo/mobile-shared/auth/zitadel-client';
-import { useEnvironment } from '@repo/mobile-shared/config/env';
-import { theme } from '@/lib/theme';
-import { Text } from '../components/ui/Text';
+import { useState } from "react";
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  TextInput,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { router, useLocalSearchParams } from "expo-router";
+import { useTenantStore } from "@repo/mobile-shared/stores/tenant-store";
+import { createZitadelSignIn } from "@repo/mobile-shared/auth/zitadel-signin";
+import { ZitadelAuthError } from "@repo/mobile-shared/auth/zitadel-client";
+import { useEnvironment } from "@repo/mobile-shared/config/env";
+import { theme } from "@/lib/theme";
+import { Text } from "../components/ui/Text";
 
 /**
  * Email one-time code screen (#686).
@@ -19,46 +26,60 @@ import { Text } from '../components/ui/Text';
  * success and the code screen simply did not exist.
  */
 export default function OtpScreen() {
-  const params = useLocalSearchParams<{ pendingToken?: string; email?: string }>();
+  const params = useLocalSearchParams<{
+    pendingToken?: string;
+    email?: string;
+  }>();
   const env = useEnvironment();
   const setTenantId = useTenantStore((s) => s.setTenantId);
 
-  const [code, setCode] = useState('');
+  const [code, setCode] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
-  const pendingToken = params.pendingToken ?? '';
+  const pendingToken = params.pendingToken ?? "";
 
   async function handleVerify() {
     if (submitting) return;
     if (code.trim().length === 0) {
-      setError('Enter the code we emailed you.');
+      setError("Enter the code we emailed you.");
       return;
     }
     // Without this there is nothing to resume, and submitting would fail
     // with copy that blames the code the user typed correctly.
     if (!pendingToken) {
-      setError('This sign-in attempt has expired. Go back and sign in again.');
+      setError("This sign-in attempt has expired. Go back and sign in again.");
       return;
     }
 
     setSubmitting(true);
     setError(null);
     try {
-      await createZitadelSignIn(env.apiBaseUrl).verifyOtp(pendingToken, code.trim(), setTenantId);
-      router.replace('/(tabs)');
+      await createZitadelSignIn(env.apiBaseUrl).verifyOtp(
+        pendingToken,
+        code.trim(),
+        setTenantId,
+      );
+      router.replace("/(tabs)");
     } catch (e: unknown) {
       // Mapped from the server's stable code, never the status: 401 covers
       // both a wrong code and an expired challenge, and "sign-in
       // unavailable" must never read as "wrong code" or a merchant will
       // retype a correct one indefinitely.
-      const code = e instanceof ZitadelAuthError ? e.code : '';
+      const code = e instanceof ZitadelAuthError ? e.code : "";
       setError(
-        code === 'invalid_code'
-          ? "That code isn't right, or it has expired. Request a new one."
-          : code === 'auth_unavailable' || code === 'network'
-            ? 'Sign-in is temporarily unavailable. Try again shortly.'
-            : 'Something went wrong. Please try again.',
+        code === "invalid_code"
+          ? // "Request a new one" was the first wording and it was a dead
+            // end: this screen has no resend, so the only way to get a fresh
+            // code is to sign in again. Advice the UI cannot honour is worse
+            // than none. A real resend needs a mobile equivalent of
+            // auth-bff's cookie-based /auth/otp/resend — worth adding, since
+            // the challenge expires after 5 minutes and reading an email can
+            // easily take longer.
+            "That code isn't right, or it has expired. Sign in again to get a new code."
+          : code === "auth_unavailable" || code === "network"
+            ? "Sign-in is temporarily unavailable. Try again shortly."
+            : "Something went wrong. Please try again.",
       );
     } finally {
       setSubmitting(false);
@@ -69,67 +90,77 @@ export default function OtpScreen() {
     <SafeAreaView className="flex-1 bg-paper">
       <KeyboardAvoidingView
         className="flex-1"
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
       >
-        <ScrollView contentContainerClassName="grow justify-center px-6" keyboardShouldPersistTaps="handled">
-          <Text preset="eyebrow" className="text-moss">
-            CHECK YOUR EMAIL
-          </Text>
-          <Text preset="display" className="mt-2 text-ink">
-            Enter code
-          </Text>
-          <Text preset="body" className="mt-3 text-ink-secondary">
-            {params.email
-              ? `We sent a sign-in code to ${params.email}.`
-              : 'We sent a sign-in code to your email.'}
-          </Text>
-
-          <TextInput
-            accessibilityLabel="Email code"
-            className="mt-8 min-h-touch rounded border border-border bg-paper-elevated px-4 text-center font-sans text-display text-ink"
-            placeholder="000000"
-            placeholderTextColor={theme.colors.textTertiary}
-            keyboardType="number-pad"
-            textContentType="oneTimeCode"
-            autoComplete="one-time-code"
-            maxLength={8}
-            value={code}
-            onChangeText={setCode}
-          />
-
-          {error ? (
-            <Text
-              preset="caption"
-              className="mt-3 text-danger"
-              accessibilityRole="alert"
-              accessibilityLiveRegion="polite"
-            >
-              {error}
+        {/* Mirrors login.tsx exactly — contentContainerStyle flexGrow + an
+            inner flex-1 px-6 pt-16 — so the two screens share a top edge and
+            a left margin. Centring the content (the first attempt) pushed
+            the heading into the middle of a tall device and read as though
+            the top of the screen had been cut off. */}
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View className="flex-1 px-6 pt-16">
+            <Text preset="eyebrow" className="text-moss">
+              CHECK YOUR EMAIL
             </Text>
-          ) : null}
-
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Verify code"
-            disabled={submitting}
-            onPress={handleVerify}
-            className="mt-6 min-h-touch items-center justify-center rounded bg-ink active:opacity-90"
-          >
-            <Text preset="bodyEmphasis" className="text-paper">
-              {submitting ? 'Verifying…' : 'Verify'}
+            <Text preset="display" className="mt-2 text-ink">
+              Enter code
             </Text>
-          </Pressable>
+            <Text preset="body" className="mt-3 text-ink-secondary">
+              {params.email
+                ? `We sent a sign-in code to ${params.email}.`
+                : "We sent a sign-in code to your email."}
+            </Text>
 
-          <View className="mt-6 items-center">
+            <TextInput
+              accessibilityLabel="Email code"
+              className="mt-8 min-h-touch rounded border border-border bg-paper-elevated px-4 text-center font-sans text-display text-ink"
+              placeholder="000000"
+              placeholderTextColor={theme.colors.textTertiary}
+              keyboardType="number-pad"
+              textContentType="oneTimeCode"
+              autoComplete="one-time-code"
+              maxLength={8}
+              value={code}
+              onChangeText={setCode}
+            />
+
+            {error ? (
+              <Text
+                preset="caption"
+                className="mt-3 text-danger"
+                accessibilityRole="alert"
+                accessibilityLiveRegion="polite"
+              >
+                {error}
+              </Text>
+            ) : null}
+
             <Pressable
               accessibilityRole="button"
-              accessibilityLabel="Back to sign in"
-              onPress={() => router.replace('/login')}
+              accessibilityLabel="Verify code"
+              disabled={submitting}
+              onPress={handleVerify}
+              className="mt-6 min-h-touch items-center justify-center rounded bg-ink active:opacity-90"
             >
-              <Text preset="caption" className="text-moss underline">
-                Back to sign in
+              <Text preset="bodyEmphasis" className="text-paper">
+                {submitting ? "Verifying…" : "Verify"}
               </Text>
             </Pressable>
+
+            <View className="mt-6 items-center">
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Back to sign in"
+                onPress={() => router.replace("/login")}
+              >
+                <Text preset="caption" className="text-moss underline">
+                  Back to sign in
+                </Text>
+              </Pressable>
+            </View>
           </View>
         </ScrollView>
       </KeyboardAvoidingView>


### PR DESCRIPTION
Two fixes from driving the real sign-in on a simulator against production. Both found by using the app, neither catchable by the existing tests.

## 1. The auth gate bounced every Zitadel session back to login

`_layout.tsx` gated on `user` from `useAuth()` — a field belonging to the **Firebase SDK**, which the Zitadel provider never populates. So `user` is always null, and navigating to `/otp` succeeded and was instantly undone by `router.replace('/login')`.

The symptom was a blank login form, **no error anywhere**, and `200`s in the server log. That is #493 reproduced exactly: every layer reports success and the user is silently returned to where they started.

Fixed by deriving signed-in-ness from the token the app persisted, and treating `/otp` as part of the sign-in flow rather than a protected route. Two details that matter:

- The token read is async, so the gate **waits** on `null` rather than redirecting on an unknown answer — redirecting there would race the check and bounce a genuinely signed-in user.
- It re-reads on every route change, so completing the OTP screen is noticed without a remount.

No unit test would have caught this. It needs a real navigation stack, a real provider and a real token.

## 2. The OTP screen looked cut off at the top

It used `grow justify-center`, which on a tall device pushes the heading into the middle and reads as though the top of the screen is missing. It now mirrors `login.tsx` exactly — `contentContainerStyle={{ flexGrow: 1 }}` with an inner `flex-1 px-6 pt-16` — so the two screens share a top edge and a left margin and read as one flow.

## Verified on device

After these, the full chain completes against production:

```
POST /mobile/admin/auth/login      → 200   email_otp_required + pending_token
POST /mobile/admin/auth/otp/verify → 200   bearer tokens issued
```

A merchant who exists **only in Zitadel** — the account #686 is about — signs in on mobile through mark8ly's own form with an emailed code.

## What is still blocked, and it is config not code

The app then shows "No access", because `marketplace-api-admin` has no `ZITADEL_ENABLED` and still verifies GIP tokens only. tesserix-k8s#1019 sets it (with `ZITADEL_DUAL_ISSUER`, so installed GIP apps keep working). Until that deploys, a successful mobile sign-in cannot reach the API.

130 suites, 1716 tests, type-clean.
