### PR TITLE
fix(mobile): keep the OTP screen's top margin (NativeWind interop on KeyboardAvoidingView) (#686)

### DIFF
--- a/apps/mobile-admin/app/otp.tsx
+++ b/apps/mobile-admin/app/otp.tsx
@@ -88,29 +88,21 @@ export default function OtpScreen() {
 
   return (
     <SafeAreaView className="flex-1 bg-paper">
+      {/* style={{flex:1}}, NOT className="flex-1". NativeWind's interop does
+          not reliably apply a className to KeyboardAvoidingView, so the
+          container never fills its parent and the content collapses upward
+          with no top margin. login.tsx uses the inline style for the same
+          reason; this screen must match it exactly, not approximately. */}
       <KeyboardAvoidingView
-        className="flex-1"
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        style={{ flex: 1 }}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
       >
-        {/* Mirrors login.tsx exactly — contentContainerStyle flexGrow + an
-            inner flex-1 px-6 pt-16 — so the two screens share a top edge and
-            a left margin. Centring the content (the first attempt) pushed
-            the heading into the middle of a tall device and read as though
-            the top of the screen had been cut off. */}
         <ScrollView
           contentContainerStyle={{ flexGrow: 1 }}
           keyboardShouldPersistTaps="handled"
-          keyboardDismissMode="interactive"
         >
-          {/* NO flex-1 here, deliberately. With it the inner View is forced to
-              the container's height, so when the keyboard opens and
-              KeyboardAvoidingView shrinks that container the content is
-              SQUEEZED rather than made scrollable — the heading slides off the
-              top edge with no way to scroll back to it. Sized by its content,
-              with flexGrow on the container, a short screen still sits
-              top-aligned and a keyboard simply makes the view scrollable. */}
-          <View className="px-6 pb-12 pt-16">
-            <Text preset="eyebrow" className="text-moss">
+          <View className="flex-1 px-6 pt-16">
+          <Text preset="eyebrow" className="text-moss">
               CHECK YOUR EMAIL
             </Text>
             <Text preset="display" className="mt-2 text-ink">

--- a/apps/mobile-admin/app/otp.tsx
+++ b/apps/mobile-admin/app/otp.tsx
@@ -100,8 +100,16 @@ export default function OtpScreen() {
         <ScrollView
           contentContainerStyle={{ flexGrow: 1 }}
           keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="interactive"
         >
-          <View className="flex-1 px-6 pt-16">
+          {/* NO flex-1 here, deliberately. With it the inner View is forced to
+              the container's height, so when the keyboard opens and
+              KeyboardAvoidingView shrinks that container the content is
+              SQUEEZED rather than made scrollable — the heading slides off the
+              top edge with no way to scroll back to it. Sized by its content,
+              with flexGrow on the container, a short screen still sits
+              top-aligned and a keyboard simply makes the view scrollable. */}
+          <View className="px-6 pb-12 pt-16">
             <Text preset="eyebrow" className="text-moss">
               CHECK YOUR EMAIL
             </Text>


### PR DESCRIPTION
Fixes the OTP screen rendering with no top margin, its heading pushed off the visible area.

## Root cause: a NativeWind interop trap, not padding

`KeyboardAvoidingView` had `className="flex-1"`. **NativeWind's interop does not reliably apply a className to that component**, so the container never filled its parent and the content collapsed upward. `login.tsx` uses `style={{ flex: 1 }}` for exactly this reason; this screen now matches it rather than approximating it.

This codebase already records the same class of trap in `TenantGate.tsx` — *"NativeWind's JSX interop doesn't resolve a function `style` prop the way it resolves a plain array"*. I should have read that before my first attempt.

**My two earlier attempts changed the wrong layer.** I adjusted `justify-center` → top-align, then `flex-1` → content-sized on the *inner* View. Both were reasonable-looking edits to the child of a parent that had no height, so neither could work. Worth stating plainly: the screen "still wasn't fixed" twice because I was tuning padding instead of asking why the container had collapsed.

Also carried: `behavior` now matches login's (`'height'` on Android rather than `undefined`), so the two screens behave identically when the keyboard opens.

## Verification

1716 tests pass, type-clean. Verified on an iPhone 17 Pro Max simulator: "CHECK YOUR EMAIL / Enter code" sits at the top on the same left edge as the login screen, and the full sign-in reaches this screen with a real emailed code.

## Note

This is presentation only. The functional blocker after a successful OTP is tesserix-k8s#1021 — the ingress gateway rejects the Zitadel token's audience before marketplace-api sees it.
