### PR TITLE
fix(mobile): three sign-in defects found on device, and a six-cell code entry (#686)

### DIFF
--- a/apps/mobile-admin/__tests__/otp-screen.test.tsx
+++ b/apps/mobile-admin/__tests__/otp-screen.test.tsx
@@ -1,0 +1,96 @@
+// The emailed-code screen (#686).
+//
+// The auto-submit path is the one worth pinning: CodeInput reports the full
+// code the instant its last cell fills, and reading component state there
+// instead of that argument would send a FIVE-digit code — a wrong-code error
+// on a code the merchant typed correctly, inside a challenge that expires in
+// five minutes.
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import OtpScreen from "../app/otp";
+
+const mockVerifyOtp = jest.fn();
+const mockReplace = jest.fn();
+let mockParams: Record<string, string> = {};
+
+jest.mock("expo-router", () => ({
+  router: { replace: (...args: unknown[]) => mockReplace(...args) },
+  useLocalSearchParams: () => mockParams,
+}));
+
+jest.mock("@repo/mobile-shared/auth/zitadel-signin", () => ({
+  createZitadelSignIn: () => ({ verifyOtp: mockVerifyOtp }),
+}));
+
+jest.mock("@repo/mobile-shared/config/env", () => ({
+  useEnvironment: () => ({ apiBaseUrl: "https://api.mark8ly.test" }),
+}));
+
+jest.mock("@repo/mobile-shared/stores/tenant-store", () => ({
+  useTenantStore: (selector: (s: unknown) => unknown) =>
+    selector({ setTenantId: jest.fn() }),
+}));
+
+beforeEach(() => {
+  mockVerifyOtp.mockReset().mockResolvedValue(undefined);
+  mockReplace.mockReset();
+  mockParams = { pendingToken: "pending-1", email: "demo@mark8ly.test" };
+});
+
+/** The library keeps one hidden TextInput behind the cells; type into that. */
+function enterCode(code: string) {
+  fireEvent.changeText(screen.getByLabelText("Email code"), code);
+}
+
+it("verifies with the whole code the moment the last cell fills", async () => {
+  render(<OtpScreen />);
+
+  enterCode("224365");
+
+  await waitFor(() =>
+    expect(mockVerifyOtp).toHaveBeenCalledWith(
+      "pending-1",
+      "224365",
+      expect.anything(),
+    ),
+  );
+  await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/(tabs)"));
+});
+
+it("does not submit a partial code", async () => {
+  render(<OtpScreen />);
+
+  enterCode("2243");
+
+  await waitFor(() => expect(mockVerifyOtp).not.toHaveBeenCalled());
+});
+
+// Pressable hands its press event to the first argument, so a bare
+// `onPress={handleVerify}` would submit a GestureResponderEvent as the code.
+it("sends the typed code, not the press event, when Verify is tapped", async () => {
+  render(<OtpScreen />);
+
+  enterCode("2243");
+  fireEvent.press(screen.getByLabelText("Verify code"));
+
+  await waitFor(() =>
+    expect(mockVerifyOtp).toHaveBeenCalledWith(
+      "pending-1",
+      "2243",
+      expect.anything(),
+    ),
+  );
+});
+
+it("refuses to submit when the sign-in attempt carries no pending token", async () => {
+  mockParams = { email: "demo@mark8ly.test" };
+  render(<OtpScreen />);
+
+  enterCode("224365");
+
+  await waitFor(() =>
+    expect(
+      screen.getByText(/sign-in attempt has expired/i),
+    ).toBeTruthy(),
+  );
+  expect(mockVerifyOtp).not.toHaveBeenCalled();
+});

--- a/apps/mobile-admin/__tests__/session-ended-notice.test.tsx
+++ b/apps/mobile-admin/__tests__/session-ended-notice.test.tsx
@@ -1,0 +1,128 @@
+// "Your session ended. Sign in again." must only ever be shown to someone who
+// HAD a session.
+//
+// On a first launch the auth gate has not routed to /login yet, so the mounted
+// dashboard fires its queries and every one of them 401s with no token at all.
+// That drove onUnauthorized("no-session") → setNotice, and a merchant opening
+// the app for the very first time was told their session had ended. Device
+// repro: reset the simulator keychain, launch, and the login form comes up
+// carrying the notice.
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useApiClient } from "@/lib/api-client";
+import { useAuthNoticeStore } from "@repo/mobile-shared/stores/auth-notice";
+import { zitadelSession } from "@repo/mobile-shared/auth/zitadel-session";
+
+jest.mock("expo-secure-store", () => {
+  const mem: Record<string, string> = {};
+  return {
+    __mem: mem,
+    getItemAsync: jest.fn(async (k: string) => mem[k] ?? null),
+    setItemAsync: jest.fn(async (k: string, v: string) => {
+      mem[k] = v;
+    }),
+    deleteItemAsync: jest.fn(async (k: string) => {
+      delete mem[k];
+    }),
+  };
+});
+
+const mockSignOut = jest.fn(async () => {});
+let mockUser: { uid: string; email: string | null; displayName: string | null } | null = null;
+let mockRefreshed: string | null = null;
+
+jest.mock("@repo/mobile-shared/auth/provider", () => ({
+  useAuth: () => ({
+    user: mockUser,
+    // GIP getter: null whenever Firebase holds no user, which is exactly the
+    // fresh-install case on a GIP build.
+    getToken: async () => (mockUser ? "gip-token" : null),
+    refreshToken: async () => mockRefreshed,
+    signOut: mockSignOut,
+  }),
+}));
+
+jest.mock("@repo/mobile-shared/config/env", () => ({
+  useEnvironment: () => ({ apiBaseUrl: "https://api.mark8ly.test" }),
+}));
+
+const mem = (jest.requireMock("expo-secure-store") as { __mem: Record<string, string> }).__mem;
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+async function requestAndSettle() {
+  const { result } = renderHook(() => useApiClient(), { wrapper });
+  await result.current.getTenant("/stores").catch(() => undefined);
+  await waitFor(() => expect(mockSignOut).toHaveBeenCalled());
+}
+
+beforeEach(() => {
+  for (const k of Object.keys(mem)) delete mem[k];
+  mockSignOut.mockClear();
+  mockUser = null;
+  mockRefreshed = null;
+  useAuthNoticeStore.getState().clearNotice();
+  globalThis.fetch = jest.fn() as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  delete process.env.EXPO_PUBLIC_AUTH_PROVIDER;
+});
+
+describe("Zitadel build", () => {
+  beforeEach(() => {
+    process.env.EXPO_PUBLIC_AUTH_PROVIDER = "zitadel";
+  });
+
+  it("shows no notice on a first launch, when no session was ever stored", async () => {
+    await requestAndSettle();
+
+    expect(useAuthNoticeStore.getState().notice).toBeNull();
+  });
+
+  it("still shows the notice when a stored session has expired", async () => {
+    // The record survives expiry, which is what makes "your session ended"
+    // true here and false above.
+    await zitadelSession.save("AT", "RT", -10);
+
+    await requestAndSettle();
+
+    expect(useAuthNoticeStore.getState().notice).toBe("no-session");
+  });
+
+  it("always shows access-denied, which is only reachable with a live token", async () => {
+    await zitadelSession.save("AT", "RT", 3600);
+    mockRefreshed = "fresh";
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValue({ status: 401, ok: false, json: async () => ({}) }) as unknown as typeof fetch;
+
+    await requestAndSettle();
+
+    expect(useAuthNoticeStore.getState().notice).toBe("access-denied");
+  });
+});
+
+describe("GIP build", () => {
+  it("shows no notice when Firebase holds no user", async () => {
+    await requestAndSettle();
+
+    expect(useAuthNoticeStore.getState().notice).toBeNull();
+  });
+
+  it("shows the notice when Firebase still holds the signed-in user", async () => {
+    mockUser = { uid: "u1", email: "a@b.test", displayName: null };
+    mockRefreshed = null;
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValue({ status: 401, ok: false, json: async () => ({}) }) as unknown as typeof fetch;
+
+    await requestAndSettle();
+
+    expect(useAuthNoticeStore.getState().notice).toBe("no-session");
+  });
+});

--- a/apps/mobile-admin/__tests__/signout-clears-zitadel-session.test.tsx
+++ b/apps/mobile-admin/__tests__/signout-clears-zitadel-session.test.tsx
@@ -1,0 +1,75 @@
+// Signing out must actually sign the user out on a Zitadel build.
+//
+// The Zitadel bearer tokens live in SecureStore, owned by this app rather than
+// by the Firebase SDK, so `backend.signOut()` cannot reach them. Without an
+// explicit clear, "Sign Out" wiped the tenant/store ids and left the tokens
+// behind: AuthGate re-read a still-fresh access token, concluded the user was
+// signed in, and replaced /login with the dashboard. The 401 sign-out path
+// (api-client's onUnauthorized) landed in the same place.
+import React from "react";
+import { Text } from "react-native";
+import { render, screen, waitFor } from "@testing-library/react-native";
+import { AuthProvider, useAuth } from "@repo/mobile-shared/auth/provider";
+import { zitadelSession } from "@repo/mobile-shared/auth/zitadel-session";
+import { tokenStorage } from "@repo/mobile-shared/auth/token-storage";
+
+// expo-constants pulls in `expo/virtual/env`, which does not resolve under
+// jest. Reporting Expo Go also selects the demo backend, keeping Firebase out
+// of a test that is only about the provider's own sign-out.
+jest.mock("expo-constants", () => ({
+  __esModule: true,
+  default: { executionEnvironment: "storeClient", expoConfig: { extra: {} } },
+  ExecutionEnvironment: { StoreClient: "storeClient", Standalone: "standalone", Bare: "bare" },
+}));
+
+jest.mock("expo-secure-store", () => {
+  const mem: Record<string, string> = {};
+  return {
+    __mem: mem,
+    getItemAsync: jest.fn(async (k: string) => mem[k] ?? null),
+    setItemAsync: jest.fn(async (k: string, v: string) => {
+      mem[k] = v;
+    }),
+    deleteItemAsync: jest.fn(async (k: string) => {
+      delete mem[k];
+    }),
+  };
+});
+
+const mem = (jest.requireMock("expo-secure-store") as { __mem: Record<string, string> }).__mem;
+
+// The demo backend keeps Firebase out of this test entirely; the clear under
+// test lives in the provider, above whichever backend is in use.
+beforeEach(() => {
+  process.env.EXPO_PUBLIC_AUTH_BACKEND = "demo";
+  for (const k of Object.keys(mem)) delete mem[k];
+});
+afterEach(() => {
+  delete process.env.EXPO_PUBLIC_AUTH_BACKEND;
+});
+
+function SignOutOnMount() {
+  const { signOut } = useAuth();
+  React.useEffect(() => {
+    void signOut();
+  }, [signOut]);
+  return <Text>ready</Text>;
+}
+
+it("clears the persisted Zitadel tokens, not just the tenant ids", async () => {
+  await zitadelSession.save("AT", "RT", 3600);
+  await tokenStorage.setTenantId("t-1");
+
+  render(
+    <AuthProvider tenantId="MP-Internal-test">
+      <SignOutOnMount />
+    </AuthProvider>,
+  );
+  await screen.findByText("ready");
+
+  await waitFor(async () => {
+    expect(await zitadelSession.read()).toBeNull();
+  });
+  // The pre-existing behaviour still holds.
+  expect(await tokenStorage.getTenantId()).toBeNull();
+});

--- a/apps/mobile-admin/app/login.tsx
+++ b/apps/mobile-admin/app/login.tsx
@@ -1,15 +1,12 @@
 import { useEffect, useState } from 'react';
 import {
-  KeyboardAvoidingView,
   Linking,
   Platform,
   Pressable,
-  ScrollView,
   StyleSheet,
   TextInput,
   View,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import Svg, { Path } from 'react-native-svg';
 import { useAuth } from '@repo/mobile-shared/auth/provider';
 import { authErrorMessage } from '@repo/mobile-shared/auth/errors';
@@ -17,6 +14,7 @@ import type { SocialSignInOutcome } from '@repo/mobile-shared/auth/social-creden
 import { useAuthNoticeStore, type AuthNotice } from '@repo/mobile-shared/stores/auth-notice';
 import { configureGoogleSignin, signInWithAppleNative, signInWithGoogleNative } from '@/lib/social-auth';
 import { theme } from '@/lib/theme';
+import { AuthScreen } from '@/components/ui/AuthScreen';
 import { IconButton } from '@/components/ui/IconButton';
 import { LinkAccountPrompt } from '../components/auth/LinkAccountPrompt';
 import { Text } from '../components/ui/Text';
@@ -241,153 +239,147 @@ export default function LoginScreen() {
   }
 
   return (
-    <SafeAreaView className="flex-1 bg-paper">
-      <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
-        <ScrollView contentContainerStyle={{ flexGrow: 1 }} keyboardShouldPersistTaps="handled">
-          <View className="flex-1 px-6 pt-16">
-            <Text preset="eyebrow" className="text-moss">
-              Merchant admin
-            </Text>
-            <Text preset="display" className="mt-2">
-              Mark8ly
-            </Text>
-            <Text preset="body" className="mt-2 text-ink-muted">
-              Sign in to manage your store.
-            </Text>
+    <AuthScreen>
+      <Text preset="eyebrow" className="text-moss">
+        Merchant admin
+      </Text>
+      <Text preset="display" className="mt-2">
+        Mark8ly
+      </Text>
+      <Text preset="body" className="mt-2 text-ink-muted">
+        Sign in to manage your store.
+      </Text>
 
-            <View className="mt-8 gap-3">
-              <TextInput
-                accessibilityLabel="Email"
-                className="min-h-touch rounded border border-border bg-paper-elevated px-4 font-sans text-body text-ink"
-                placeholder="Email"
-                placeholderTextColor={theme.colors.textTertiary}
-                autoCapitalize="none"
-                keyboardType="email-address"
-                textContentType="emailAddress"
-                autoComplete="email"
-                value={email}
-                onChangeText={setEmail}
-              />
-              <TextInput
-                accessibilityLabel="Password"
-                className="min-h-touch rounded border border-border bg-paper-elevated px-4 font-sans text-body text-ink"
-                placeholder="Password"
-                placeholderTextColor={theme.colors.textTertiary}
-                secureTextEntry
-                textContentType="password"
-                autoComplete="password"
-                value={password}
-                onChangeText={setPassword}
-              />
-            </View>
+      <View className="mt-8 gap-3">
+        <TextInput
+          accessibilityLabel="Email"
+          className="min-h-touch rounded border border-border bg-paper-elevated px-4 font-sans text-body text-ink"
+          placeholder="Email"
+          placeholderTextColor={theme.colors.textTertiary}
+          autoCapitalize="none"
+          keyboardType="email-address"
+          textContentType="emailAddress"
+          autoComplete="email"
+          value={email}
+          onChangeText={setEmail}
+        />
+        <TextInput
+          accessibilityLabel="Password"
+          className="min-h-touch rounded border border-border bg-paper-elevated px-4 font-sans text-body text-ink"
+          placeholder="Password"
+          placeholderTextColor={theme.colors.textTertiary}
+          secureTextEntry
+          textContentType="password"
+          autoComplete="password"
+          value={password}
+          onChangeText={setPassword}
+        />
+      </View>
 
-            {error ? (
-              <Text
-                preset="caption"
-                className="mt-3 text-danger"
-                accessibilityRole="alert"
-                accessibilityLiveRegion="polite"
-              >
-                {error}
-              </Text>
-            ) : null}
+      {error ? (
+        <Text
+          preset="caption"
+          className="mt-3 text-danger"
+          accessibilityRole="alert"
+          accessibilityLiveRegion="polite"
+        >
+          {error}
+        </Text>
+      ) : null}
 
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Sign in"
-              disabled={submitting}
-              onPress={handleSignIn}
-              className="mt-6 min-h-touch items-center justify-center rounded bg-ink active:opacity-90"
-            >
-              <Text preset="bodyEmphasis" className="text-paper">
-                {submitting ? 'Signing in…' : 'Sign in'}
-              </Text>
-            </Pressable>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Sign in"
+        disabled={submitting}
+        onPress={handleSignIn}
+        className="mt-6 min-h-touch items-center justify-center rounded bg-ink active:opacity-90"
+      >
+        <Text preset="bodyEmphasis" className="text-paper">
+          {submitting ? 'Signing in…' : 'Sign in'}
+        </Text>
+      </Pressable>
 
-            <View className="mt-6 flex-row items-center gap-3">
-              <View className="h-px flex-1 bg-border" />
-              <Text preset="caption">or</Text>
-              <View className="h-px flex-1 bg-border" />
-            </View>
+      <View className="mt-6 flex-row items-center gap-3">
+        <View className="h-px flex-1 bg-border" />
+        <Text preset="caption">or</Text>
+        <View className="h-px flex-1 bg-border" />
+      </View>
 
-            {/*
-              Deliberately CENTRED — the one local exception to the page's
-              left-aligned, asymmetric rhythm. A provider row is a pair of
-              equal-weight alternatives with no reading order, not a hero;
-              everything around it stays left-aligned. Collapsing both
-              providers to icons leaves the full-width ink "Sign in" bar as
-              the only solid on screen, which is the whole point of the
-              change.
-            */}
-            <View style={styles.providerRow} testID="provider-row">
-              <IconButton
-                accessibilityLabel="Continue with Google"
-                disabled={submitting}
-                onPress={handleGoogleSignIn}
-                testID="provider-google"
-                // "ink" tone: the Google box is an outline/white surface, so
-                // it takes the dark ripple and the standard iOS press dim.
-                tone="ink"
-                style={[styles.providerBox, styles.providerBoxOutline]}
-              >
-                <GoogleMark />
-              </IconButton>
+      {/*
+        Deliberately CENTRED — the one local exception to the page's
+        left-aligned, asymmetric rhythm. A provider row is a pair of
+        equal-weight alternatives with no reading order, not a hero;
+        everything around it stays left-aligned. Collapsing both
+        providers to icons leaves the full-width ink "Sign in" bar as
+        the only solid on screen, which is the whole point of the
+        change.
+      */}
+      <View style={styles.providerRow} testID="provider-row">
+        <IconButton
+          accessibilityLabel="Continue with Google"
+          disabled={submitting}
+          onPress={handleGoogleSignIn}
+          testID="provider-google"
+          // "ink" tone: the Google box is an outline/white surface, so
+          // it takes the dark ripple and the standard iOS press dim.
+          tone="ink"
+          style={[styles.providerBox, styles.providerBoxOutline]}
+        >
+          <GoogleMark />
+        </IconButton>
 
-              {Platform.OS === 'ios' ? (
-                <IconButton
-                  accessibilityLabel="Sign in with Apple"
-                  disabled={submitting}
-                  onPress={handleAppleSignIn}
-                  testID="provider-apple"
-                  // "ink" tone, matching Google: both targets are now the same
-                  // outline/Paper surface, so both take the dark ripple and the
-                  // standard iOS press dim. (The "onDark" tone exists for solid
-                  // fills, where a 45% fade reads as broken rather than pressed
-                  // — see lib/theme.ts. Nothing on this row is solid any more.)
-                  tone="ink"
-                  style={[styles.providerBox, styles.providerBoxOutline]}
-                >
-                  <AppleMark />
-                </IconButton>
-              ) : null}
-            </View>
+        {Platform.OS === 'ios' ? (
+          <IconButton
+            accessibilityLabel="Sign in with Apple"
+            disabled={submitting}
+            onPress={handleAppleSignIn}
+            testID="provider-apple"
+            // "ink" tone, matching Google: both targets are now the same
+            // outline/Paper surface, so both take the dark ripple and the
+            // standard iOS press dim. (The "onDark" tone exists for solid
+            // fills, where a 45% fade reads as broken rather than pressed
+            // — see lib/theme.ts. Nothing on this row is solid any more.)
+            tone="ink"
+            style={[styles.providerBox, styles.providerBoxOutline]}
+          >
+            <AppleMark />
+          </IconButton>
+        ) : null}
+      </View>
 
-            {linkTarget ? (
-              <LinkAccountPrompt
-                visible
-                email={linkTarget.email}
-                provider={linkTarget.provider}
-                pendingCredential={linkTarget.pendingCredential}
-                onCancel={() => setLinkTarget(null)}
-                onLinked={() => setLinkTarget(null)}
-              />
-            ) : null}
+      {linkTarget ? (
+        <LinkAccountPrompt
+          visible
+          email={linkTarget.email}
+          provider={linkTarget.provider}
+          pendingCredential={linkTarget.pendingCredential}
+          onCancel={() => setLinkTarget(null)}
+          onLinked={() => setLinkTarget(null)}
+        />
+      ) : null}
 
-            <View className="mt-8 flex-row items-center justify-center gap-3">
-              <Pressable
-                accessibilityRole="link"
-                accessibilityLabel="Privacy Policy"
-                onPress={() => Linking.openURL(PRIVACY_URL)}
-              >
-                <Text preset="caption" className="underline">
-                  Privacy Policy
-                </Text>
-              </Pressable>
-              <Text preset="caption">·</Text>
-              <Pressable
-                accessibilityRole="link"
-                accessibilityLabel="Terms of Service"
-                onPress={() => Linking.openURL(TERMS_URL)}
-              >
-                <Text preset="caption" className="underline">
-                  Terms of Service
-                </Text>
-              </Pressable>
-            </View>
-          </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+      <View className="mt-8 flex-row items-center justify-center gap-3">
+        <Pressable
+          accessibilityRole="link"
+          accessibilityLabel="Privacy Policy"
+          onPress={() => Linking.openURL(PRIVACY_URL)}
+        >
+          <Text preset="caption" className="underline">
+            Privacy Policy
+          </Text>
+        </Pressable>
+        <Text preset="caption">·</Text>
+        <Pressable
+          accessibilityRole="link"
+          accessibilityLabel="Terms of Service"
+          onPress={() => Linking.openURL(TERMS_URL)}
+        >
+          <Text preset="caption" className="underline">
+            Terms of Service
+          </Text>
+        </Pressable>
+      </View>
+    </AuthScreen>
   );
 }
 

--- a/apps/mobile-admin/app/otp.tsx
+++ b/apps/mobile-admin/app/otp.tsx
@@ -1,19 +1,12 @@
 import { useState } from "react";
-import {
-  KeyboardAvoidingView,
-  Platform,
-  Pressable,
-  ScrollView,
-  TextInput,
-  View,
-} from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { Pressable, View } from "react-native";
 import { router, useLocalSearchParams } from "expo-router";
 import { useTenantStore } from "@repo/mobile-shared/stores/tenant-store";
 import { createZitadelSignIn } from "@repo/mobile-shared/auth/zitadel-signin";
 import { ZitadelAuthError } from "@repo/mobile-shared/auth/zitadel-client";
 import { useEnvironment } from "@repo/mobile-shared/config/env";
-import { theme } from "@/lib/theme";
+import { AuthScreen } from "../components/ui/AuthScreen";
+import { CodeInput } from "../components/ui/CodeInput";
 import { Text } from "../components/ui/Text";
 
 /**
@@ -39,9 +32,15 @@ export default function OtpScreen() {
 
   const pendingToken = params.pendingToken ?? "";
 
-  async function handleVerify() {
+  /**
+   * `submitted` is the value CodeInput reports the moment its last cell
+   * fills. Reading `code` there would read the previous render's state and
+   * verify a five-digit code.
+   */
+  async function handleVerify(submitted?: string) {
     if (submitting) return;
-    if (code.trim().length === 0) {
+    const entered = (submitted ?? code).trim();
+    if (entered.length === 0) {
       setError("Enter the code we emailed you.");
       return;
     }
@@ -57,7 +56,7 @@ export default function OtpScreen() {
     try {
       await createZitadelSignIn(env.apiBaseUrl).verifyOtp(
         pendingToken,
-        code.trim(),
+        entered,
         setTenantId,
       );
       router.replace("/(tabs)");
@@ -87,83 +86,66 @@ export default function OtpScreen() {
   }
 
   return (
-    <SafeAreaView className="flex-1 bg-paper">
-      {/* style={{flex:1}}, NOT className="flex-1". NativeWind's interop does
-          not reliably apply a className to KeyboardAvoidingView, so the
-          container never fills its parent and the content collapses upward
-          with no top margin. login.tsx uses the inline style for the same
-          reason; this screen must match it exactly, not approximately. */}
-      <KeyboardAvoidingView
-        style={{ flex: 1 }}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
-      >
-        <ScrollView
-          contentContainerStyle={{ flexGrow: 1 }}
-          keyboardShouldPersistTaps="handled"
+    <AuthScreen>
+      <Text preset="eyebrow" className="text-moss">
+        CHECK YOUR EMAIL
+      </Text>
+      <Text preset="display" className="mt-2 text-ink">
+        Enter code
+      </Text>
+      <Text preset="body" className="mt-3 text-ink-secondary">
+        {params.email
+          ? `We sent a sign-in code to ${params.email}.`
+          : "We sent a sign-in code to your email."}
+      </Text>
+
+      <CodeInput
+        accessibilityLabel="Email code"
+        onChangeText={(next) => {
+          setCode(next);
+          // Clear a stale "that code isn't right" the moment they start
+          // correcting it, rather than leaving the old verdict under a new
+          // code.
+          if (error) setError(null);
+        }}
+        onFilled={(next) => void handleVerify(next)}
+        disabled={submitting}
+      />
+
+      {error ? (
+        <Text
+          preset="caption"
+          className="mt-3 text-danger"
+          accessibilityRole="alert"
+          accessibilityLiveRegion="polite"
         >
-          <View className="flex-1 px-6 pt-16">
-          <Text preset="eyebrow" className="text-moss">
-              CHECK YOUR EMAIL
-            </Text>
-            <Text preset="display" className="mt-2 text-ink">
-              Enter code
-            </Text>
-            <Text preset="body" className="mt-3 text-ink-secondary">
-              {params.email
-                ? `We sent a sign-in code to ${params.email}.`
-                : "We sent a sign-in code to your email."}
-            </Text>
+          {error}
+        </Text>
+      ) : null}
 
-            <TextInput
-              accessibilityLabel="Email code"
-              className="mt-8 min-h-touch rounded border border-border bg-paper-elevated px-4 text-center font-sans text-display text-ink"
-              placeholder="000000"
-              placeholderTextColor={theme.colors.textTertiary}
-              keyboardType="number-pad"
-              textContentType="oneTimeCode"
-              autoComplete="one-time-code"
-              maxLength={8}
-              value={code}
-              onChangeText={setCode}
-            />
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Verify code"
+        disabled={submitting}
+        onPress={() => void handleVerify()}
+        className="mt-6 min-h-touch items-center justify-center rounded bg-ink active:opacity-90"
+      >
+        <Text preset="bodyEmphasis" className="text-paper">
+          {submitting ? "Verifying…" : "Verify"}
+        </Text>
+      </Pressable>
 
-            {error ? (
-              <Text
-                preset="caption"
-                className="mt-3 text-danger"
-                accessibilityRole="alert"
-                accessibilityLiveRegion="polite"
-              >
-                {error}
-              </Text>
-            ) : null}
-
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Verify code"
-              disabled={submitting}
-              onPress={handleVerify}
-              className="mt-6 min-h-touch items-center justify-center rounded bg-ink active:opacity-90"
-            >
-              <Text preset="bodyEmphasis" className="text-paper">
-                {submitting ? "Verifying…" : "Verify"}
-              </Text>
-            </Pressable>
-
-            <View className="mt-6 items-center">
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Back to sign in"
-                onPress={() => router.replace("/login")}
-              >
-                <Text preset="caption" className="text-moss underline">
-                  Back to sign in
-                </Text>
-              </Pressable>
-            </View>
-          </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+      <View className="mt-6 items-center">
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Back to sign in"
+          onPress={() => router.replace("/login")}
+        >
+          <Text preset="caption" className="text-moss underline">
+            Back to sign in
+          </Text>
+        </Pressable>
+      </View>
+    </AuthScreen>
   );
 }

--- a/apps/mobile-admin/components/ui/AuthScreen.tsx
+++ b/apps/mobile-admin/components/ui/AuthScreen.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+import { KeyboardAvoidingView, Platform, ScrollView, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+/**
+ * The shell every signed-out screen sits in: /login and /otp.
+ *
+ * Extracted because those two had each hand-rolled the same four nested
+ * containers, and the pair drifted twice in a single day — #751 top-aligned
+ * the OTP screen, then #752 had to restore its top margin after NativeWind
+ * silently dropped `className="flex-1"` on KeyboardAvoidingView. Two copies of
+ * a layout that must be identical is the actual defect; one component is the
+ * fix, and a future keyboard-avoidance change now lands on both screens or
+ * neither.
+ *
+ * This is a pure extraction: the tree below is byte-for-byte what login.tsx
+ * rendered, including the deliberate inline `style={{ flex: 1 }}`.
+ */
+export function AuthScreen({ children }: { children: ReactNode }) {
+  return (
+    <SafeAreaView className="flex-1 bg-paper">
+      {/* style={{flex:1}}, NOT className="flex-1". NativeWind's interop does
+          not reliably apply a className to KeyboardAvoidingView, so the
+          container never fills its parent and the content collapses upward
+          with no top margin. */}
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      >
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View className="flex-1 px-6 pt-16">{children}</View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}

--- a/apps/mobile-admin/components/ui/CodeInput.tsx
+++ b/apps/mobile-admin/components/ui/CodeInput.tsx
@@ -1,0 +1,117 @@
+import { StyleSheet, View } from "react-native";
+import { OtpInput } from "react-native-otp-entry";
+import { theme } from "@/lib/theme";
+import { BODY_FONT_FAMILY } from "@/lib/fonts";
+
+/**
+ * Digits in an emailed sign-in code.
+ *
+ * Not a display choice — auth-bff's `emailotp.codeDigits` is 6, and its
+ * verifier REJECTS any input that is not exactly six digits before it even
+ * looks at the value. The field this replaced allowed eight, so a merchant
+ * could type a code the server would refuse on length alone and be told the
+ * code was wrong.
+ */
+export const CODE_LENGTH = 6;
+
+interface CodeInputProps {
+  /**
+   * Uncontrolled: the cells own what has been typed and report it upward.
+   * Nothing in this flow needs to push a value back down — an expired attempt
+   * sends the merchant to /login, not back to a cleared field — so there is no
+   * `value` prop to keep in sync with a control that would ignore it.
+   */
+  onChangeText: (code: string) => void;
+  /** Fired once the last cell is filled — wire this to submit. */
+  onFilled?: (code: string) => void;
+  disabled?: boolean;
+  accessibilityLabel: string;
+}
+
+/**
+ * One cell per digit, the convention every merchant has already met in every
+ * other app that emails a code.
+ *
+ * It replaced a single centred TextInput whose caret sat mid-field with the
+ * placeholder pushed off to one side, and which gave no feedback on how many
+ * digits were expected or entered.
+ *
+ * Built on `react-native-otp-entry` rather than hand-rolled: six separate
+ * inputs break iOS one-time-code AutoFill, which is the whole point on a
+ * screen reached from an email. The library keeps ONE hidden TextInput behind
+ * the cells, so AutoFill, paste and the keyboard all behave normally — and it
+ * is MIT, dependency-free and pure JS, so it needs no config plugin and no
+ * prebuild.
+ *
+ * Styling is passed through `theme` rather than className: NativeWind cannot
+ * reach inside the library's own views, and these are real token values, not
+ * approximations of them.
+ */
+export function CodeInput({
+  onChangeText,
+  onFilled,
+  disabled,
+  accessibilityLabel,
+}: CodeInputProps) {
+  return (
+    <View style={styles.wrap}>
+      <OtpInput
+        numberOfDigits={CODE_LENGTH}
+        type="numeric"
+        onTextChange={onChangeText}
+        onFilled={onFilled}
+        blurOnFilled
+        disabled={disabled}
+        // Off: the code arrives by email, so the merchant leaves the app to
+        // read it. Grabbing focus on mount raises the keyboard over the
+        // heading for a screen they are about to background anyway.
+        autoFocus={false}
+        focusColor={theme.colors.accent}
+        textInputProps={{
+          accessibilityLabel,
+          // Both halves of iOS AutoFill. Without them the code banner never
+          // offers itself above the keyboard.
+          textContentType: "oneTimeCode",
+          autoComplete: "one-time-code",
+        }}
+        theme={{
+          containerStyle: styles.container,
+          pinCodeContainerStyle: styles.cell,
+          focusedPinCodeContainerStyle: styles.cellFocused,
+          filledPinCodeContainerStyle: styles.cellFilled,
+          pinCodeTextStyle: styles.cellText,
+        }}
+      />
+    </View>
+  );
+}
+
+const CELL_HEIGHT = 56;
+
+const styles = StyleSheet.create({
+  wrap: { marginTop: theme.spacing.xxl },
+  container: { gap: theme.spacing.sm },
+  cell: {
+    height: CELL_HEIGHT,
+    // 1, not `theme.hairline` (0.5). The half-pixel value is for hairline
+    // RULES between sections; every FIELD in this app — including the email
+    // and password inputs one screen back — draws a 1px border, and at 0.5 on
+    // white-on-Paper the empty cells read as six floating white blobs with no
+    // edge. Measured on device before changing it.
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radii.md,
+    backgroundColor: theme.colors.elevated,
+  },
+  // Moss, the one accent — the same colour the focus ring uses everywhere
+  // else in this app.
+  cellFocused: { borderColor: theme.colors.accent },
+  // A filled cell reads as settled: ink hairline, no accent competing with
+  // the cell the caret is actually in.
+  cellFilled: { borderColor: theme.colors.text },
+  cellText: {
+    fontFamily: BODY_FONT_FAMILY,
+    fontSize: 24,
+    color: theme.colors.text,
+  },
+});

--- a/apps/mobile-admin/components/ui/index.ts
+++ b/apps/mobile-admin/components/ui/index.ts
@@ -1,4 +1,6 @@
 export { Screen } from "./Screen";
+export { AuthScreen } from "./AuthScreen";
+export { CodeInput, CODE_LENGTH } from "./CodeInput";
 export { Card } from "./Card";
 export { Text, MAX_FONT_SCALE } from "./Text";
 export { Eyebrow } from "./Eyebrow";

--- a/apps/mobile-admin/jest.config.js
+++ b/apps/mobile-admin/jest.config.js
@@ -72,6 +72,15 @@ module.exports = {
     // write lands nowhere, with no error to explain it.
     '^expo-secure-store$': '<rootDir>/node_modules/expo-secure-store',
     '^expo-secure-store/(.*)$': '<rootDir>/node_modules/expo-secure-store/$1',
+    // Seventh instance of the hoisting bug. babel-preset-expo injects a
+    // `require('expo/virtual/env')` into the modules it transforms, resolved
+    // relative to the FILE — so anything under packages/mobile-shared (which
+    // has no node_modules of its own) walks up to the hoisted ROOT `expo`,
+    // which ships no `virtual/` directory at all: "Cannot find module
+    // 'expo/virtual/env'". A test's own jest.mock cannot help, because the
+    // require is injected rather than written. Pin the virtual modules to this
+    // app's install, which does have them.
+    '^expo/virtual/(.*)$': '<rootDir>/node_modules/expo/virtual/$1',
     '^@gorhom/bottom-sheet$': '<rootDir>/lib/test-support/gorhom-bottom-sheet-mock',
   },
 };

--- a/apps/mobile-admin/lib/api-client.ts
+++ b/apps/mobile-admin/lib/api-client.ts
@@ -1,7 +1,7 @@
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { createApiClient } from "@repo/mobile-shared/api/client";
-import { useAuth } from "@repo/mobile-shared/auth/provider";
+import { useAuth, type AuthUser } from "@repo/mobile-shared/auth/provider";
 import { useAuthNoticeStore } from "@repo/mobile-shared/stores/auth-notice";
 import { zitadelSession } from "@repo/mobile-shared/auth/zitadel-session";
 import { isZitadelProvider } from "@/lib/auth-provider";
@@ -13,6 +13,20 @@ import { createDemoApiClient } from "./demo-api-client";
 // and bounce the user back to /login. Serve canned data instead.
 const DEMO_MODE = process.env.EXPO_PUBLIC_AUTH_BACKEND === "demo";
 const demoClient = DEMO_MODE ? createDemoApiClient() : null;
+
+/**
+ * Did a session ever exist on this device?
+ *
+ * Under Zitadel that is the persisted token record — present even once
+ * EXPIRED, which is exactly the case where "your session ended" is both true
+ * and useful. Under GIP the Firebase SDK owns persistence, so the provider's
+ * user is the signal (it is always null under Zitadel, which is why this
+ * cannot be one shared check).
+ */
+async function hadSession(gipUser: AuthUser | null): Promise<boolean> {
+  if (!isZitadelProvider()) return gipUser !== null;
+  return (await zitadelSession.read()) !== null;
+}
 
 /**
  * Shared API client hook used by every admin data hook.
@@ -27,7 +41,11 @@ const demoClient = DEMO_MODE ? createDemoApiClient() : null;
  *     redirects a member-revoked user back to /pick-tenant.
  */
 export function useApiClient() {
-  const { getToken, refreshToken, signOut } = useAuth();
+  const { user, getToken, refreshToken, signOut } = useAuth();
+  // Read at 401 time rather than captured into the memo below, so an
+  // auth-state change does not rebuild the whole client.
+  const userRef = useRef<AuthUser | null>(user);
+  userRef.current = user;
   const activeStore = useTenantStore((s) => s.activeStore);
   const tenantId = useTenantStore((s) => s.tenantId);
   const clearActiveStore = useTenantStore((s) => s.clearActiveStore);
@@ -53,7 +71,19 @@ export function useApiClient() {
         onUnauthorized: async (reason) => {
           // Record WHY before tearing the session down — /login reads this and
           // explains itself instead of bouncing the user with no message.
-          useAuthNoticeStore.getState().setNotice(reason);
+          //
+          // But only when a session actually existed. On a FIRST launch the
+          // gate has not routed to /login yet, so the mounted dashboard fires
+          // its queries and every one of them 401s with no token at all —
+          // which is how someone who has never signed in was greeted with
+          // "Your session ended. Sign in again." That copy asserts a past the
+          // user does not have.
+          //
+          // `access-denied` is exempt: it is only reachable with a freshly
+          // minted token in hand, so a session provably existed.
+          if (reason === "access-denied" || (await hadSession(userRef.current))) {
+            useAuthNoticeStore.getState().setNotice(reason);
+          }
           await signOut();
         },
         onTenantInvalid: async () => {

--- a/apps/mobile-admin/package.json
+++ b/apps/mobile-admin/package.json
@@ -7,7 +7,7 @@
     "dev": "expo start",
     "ios": "expo run:ios",
     "build": "echo 'use eas build'",
-    "lint": "echo 'lint stub \u2014 needs ESLint flat config (eslint.config.js); this app has no eslint config or eslint dep, so `eslint .` was an unconditional fatal error'",
+    "lint": "echo 'lint stub — needs ESLint flat config (eslint.config.js); this app has no eslint config or eslint dep, so `eslint .` was an unconditional fatal error'",
     "check-types": "tsc --noEmit",
     "test": "jest",
     "postinstall": "node scripts/link-nativewind-tailwind.js"
@@ -46,6 +46,7 @@
     "react-dom": "19.2.3",
     "react-native": "0.85.3",
     "react-native-gesture-handler": "~3.1.0",
+    "react-native-otp-entry": "^1.8.6",
     "react-native-reanimated": "4.3.1",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.25.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -377,6 +377,7 @@
         "react-dom": "19.2.3",
         "react-native": "0.85.3",
         "react-native-gesture-handler": "~3.1.0",
+        "react-native-otp-entry": "^1.8.6",
         "react-native-reanimated": "4.3.1",
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "4.25.2",
@@ -390,7 +391,6 @@
         "@react-native/jest-preset": "^0.85.3",
         "@testing-library/react-native": "^13.0.0",
         "@types/react": "~19.2.14",
-        "@xmldom/xmldom": "0.8.15",
         "jest": "~29.7.0",
         "jest-expo": "~56.0.0",
         "typescript": "~6.0.3"
@@ -32224,6 +32224,16 @@
         "react": "*",
         "react-native": "*",
         "react-native-nitro-modules": "*"
+      }
+    },
+    "node_modules/react-native-otp-entry": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/react-native-otp-entry/-/react-native-otp-entry-1.8.6.tgz",
+      "integrity": "sha512-es9ppHi5ybaGsNwtolq0cVL/I3f0O5EvopXwN0SW+Y0hYoXw0kHSYAFuW7u0nfo4fevSnQ5Co88979d+Tu3fAA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-razorpay": {

--- a/packages/mobile-shared/auth/provider.tsx
+++ b/packages/mobile-shared/auth/provider.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
 import Constants, { ExecutionEnvironment } from "expo-constants";
 import { tokenStorage } from "./token-storage";
+import { zitadelSession } from "./zitadel-session";
 import { getEnv } from "../config/env";
 import type { AppleFullName, SocialSignInOutcome } from "./social-credentials";
 import type { FirebaseAuthTypes } from "@react-native-firebase/auth";
@@ -246,6 +247,14 @@ export function AuthProvider({ tenantId, children }: AuthProviderProps) {
 
   const signOut = async () => {
     await tokenStorage.clearAll();
+    // The Zitadel bearer tokens live in SecureStore, owned by this app rather
+    // than by a Firebase SDK, so `backend.signOut()` below cannot reach them.
+    // Without this, signing out of a Zitadel build left the tokens in place:
+    // AuthGate re-read a still-fresh token, decided the user was signed in and
+    // sent them straight back to the dashboard. Unconditional on purpose — on
+    // a GIP build the keys were never written and deleting them is a no-op, so
+    // there is no provider branch to keep in sync here.
+    await zitadelSession.clear();
     await backend.signOut();
   };
 


### PR DESCRIPTION
Three defects found by running the app on a device, plus the OTP screen rework. None of the three was caught by the 1722-test suite.

## Fixes

**"Your session ended. Sign in again." on a fresh install.** `api/client.ts` calls `onUnauthorized("no-session")` whenever `getToken()` returns null. On a first launch the auth gate has not routed to `/login` yet, so the mounted dashboard fires its queries and every one 401s with no token at all — and someone who had never signed in was told their session had ended. The notice is now gated on whether a session ever existed: the persisted token record under Zitadel (present even once **expired**, which is exactly when the copy is true), the Firebase user under GIP. `access-denied` is exempt — it is only reachable with a freshly minted token in hand.

**Sign-out did not sign you out under Zitadel.** `provider.tsx`'s `signOut` cleared `tokenStorage` and called `backend.signOut()` (Firebase), but never touched `zitadelSession` — `zitadelSession.clear()` had exactly one call site in the repo, in a failed-sign-in path. So the bearer tokens survived "Sign Out", `AuthGate` re-read a still-fresh one and returned the user to the dashboard. Now cleared in the provider, unconditionally: on a GIP build the keys were never written, so there is no provider branch to keep in sync.

**The code field accepted eight characters.** `auth-bff/internal/emailotp` generates exactly six (`codeDigits = 6`) and its verifier rejects any other length *before* looking at the value. A stray seventh digit produced "that code isn't right" for a length error, inside a five-minute window. Six cells makes it correct by construction.

## Rework

`/login` and `/otp` had each hand-rolled the same four nested containers. That duplication is the actual defect behind #751 and #752 — the same fix had to be applied twice and landed "approximately" the second time. Both now share one `AuthScreen`; the extraction is behaviour-neutral and `/login` renders pixel-identical on device.

The single centred code field is replaced by six cells built on `react-native-otp-entry` (MIT, no runtime dependencies, pure JS, so no config plugin and no prebuild). Six separate `TextInput`s would have broken iOS one-time-code AutoFill, which is the whole point on a screen you reach from an email; the library keeps one hidden input behind the cells. Filling the last cell submits, and `handleVerify` takes that value as an argument — reading component state there would have verified a five-digit code.

## Test plan

Device run on an iPhone 17 Pro Max simulator against **production**:

- [x] Clean keychain -> launch -> login form shows **no** notice (was: "Your session ended")
- [x] `/login` renders identically after the `AuthScreen` extraction
- [x] Six cells render; 1px borders match the email/password fields (0.5 was invisible — caught on device, fixed)
- [x] iOS one-time-code AutoFill populates the cells
- [x] Filling the last cell auto-submits, reaches marketplace-api, and maps the server's `invalid_code` to the right copy — confirmed in auth-bff production logs (`mobile otp verify rejected an unusable pending token` -> 401)
- [x] `npx tsc --noEmit` adds no new errors; 1726 tests pass across 133 suites
- [ ] **Not device-verified: the sign-out fix.** Covered by a unit test that mounts `AuthProvider` and asserts the persisted tokens are cleared, but proving it on device needs a live sign-in, which the owner chose to skip. The change is a single unconditional `zitadelSession.clear()`.

## Notes

`jest.config.js` gains an `expo/virtual/*` mapping — the seventh instance of the hoisting bug already documented there. `babel-preset-expo` injects `require('expo/virtual/env')` resolved relative to the file, so anything under `packages/mobile-shared` (no `node_modules` of its own) walks up to the hoisted root `expo`, which ships no `virtual/`. It blocks any test that mounts `AuthProvider`, and a test's own `jest.mock` cannot help because the require is injected rather than written.

Does **not** close #686: Google/Apple on mobile still go through the Firebase SDK, MFA/TOTP has no screen, and there is no OTP resend. Detail in the issue.
