### PR TITLE
fix(platform-api): tear down FGA tuples for every tenant member, and stop deleting identities that are still in use (#361)

### DIFF
--- a/services/platform-api/internal/account/purge.go
+++ b/services/platform-api/internal/account/purge.go
@@ -8,7 +8,6 @@ import (
 
 	"gorm.io/gorm"
 
-	"github.com/mark8ly/platform-api/internal/authz"
 	"github.com/mark8ly/platform-api/internal/tenant"
 )
 
@@ -109,11 +108,11 @@ const PurgeBackstopDelay = 30 * time.Second
 // nil pointer; cleanupAfterTeardown's `!= nil` guards would pass, and the
 // nil receiver would panic AFTER this transaction has already committed.
 //
-// KNOWN GAP, inherited from deleteOwnerAccount rather than introduced
-// here: authz.Client has no method enumerating a tenant's members
-// (DeleteTuple requires a userID), so staff/admin/viewer tuples and their
-// GIP identities survive, pointing at a tenant object that no longer
-// exists. Filed separately.
+// #361 FIXED: cleanupAfterTeardown now enumerates every member via
+// authz.Client.ListTenantMembers (not just snap.OwnerUserID), so
+// staff/admin/viewer tuples no longer survive pointing at a tenant object
+// that no longer exists. See cleanupAfterTeardown and
+// Service.cleanupTenantMembers in service.go.
 func (s *Service) PurgeTenant(ctx context.Context, tenantID string, suppliedSlugs []string) (*PurgeResult, error) {
 	var snap *tenant.TeardownSnapshot
 
@@ -159,16 +158,20 @@ func (s *Service) PurgeTenant(ctx context.Context, tenantID string, suppliedSlug
 	}, nil
 }
 
-// cleanupAfterTeardown removes the owner's FGA role tuple, the store
-// parent tuples and the owner's GIP identity. Every failure is logged and
-// swallowed: the transaction has already committed and the outbox event is
-// the durable retry channel. Nil-tolerant on both clients.
+// cleanupAfterTeardown removes every member's FGA role tuple(s), the store
+// parent tuples, and (conditionally) member identities — via the same
+// cleanupTenantMembers helper deleteOwnerAccount uses, so the merchant and
+// operator teardown paths can't drift on which users get cleaned up (#361:
+// before this, only snap.OwnerUserID was unwound, leaving staff/admin/
+// viewer tuples pointing at a tenant object that no longer exists). Every
+// failure is logged and swallowed: the transaction has already committed
+// and the outbox event is the durable retry channel. Nil-tolerant on both
+// clients — cleanupTenantMembers no-ops when s.fga is nil, and
+// deleteIdentityIfNoTenantsRemain (called from within it) no-ops when
+// s.gip is nil.
 func (s *Service) cleanupAfterTeardown(ctx context.Context, snap *tenant.TeardownSnapshot) {
 	if s.fga != nil {
-		if err := s.fga.DeleteTuple(ctx, snap.OwnerUserID, string(authz.RoleOwner), snap.TenantID); err != nil {
-			s.warn("account: post-purge owner tuple delete failed",
-				"tenant_id", snap.TenantID, "owner_uid", snap.OwnerUserID, "err", err)
-		}
+		s.cleanupTenantMembers(ctx, snap.TenantID)
 		for _, st := range snap.Stores {
 			if err := s.fga.DeleteStoreParent(ctx, st.ID, snap.TenantID); err != nil {
 				s.warn("account: post-purge store parent delete failed",
@@ -180,12 +183,7 @@ func (s *Service) cleanupAfterTeardown(ctx context.Context, snap *tenant.Teardow
 			"tenant_id", snap.TenantID)
 	}
 
-	if s.gip != nil {
-		if err := s.gip.DeleteAccount(ctx, snap.OwnerUserID); err != nil {
-			s.warn("account: post-purge gip delete failed",
-				"tenant_id", snap.TenantID, "owner_uid", snap.OwnerUserID, "err", err)
-		}
-	} else {
+	if s.gip == nil {
 		s.warn("account: post-purge GIP cleanup skipped, no client configured",
 			"tenant_id", snap.TenantID)
 	}

--- a/services/platform-api/internal/account/service.go
+++ b/services/platform-api/internal/account/service.go
@@ -251,6 +251,20 @@ func (s *Service) deleteStaffAccount(ctx context.Context, tenantID, actorUID str
 	if err := s.fga.DeleteTuple(ctx, actorUID, string(role), tenantID); err != nil {
 		return fmt.Errorf("account: delete role tuple: %w", err)
 	}
+	// Same rule as the teardown paths (#361), and the case most likely to
+	// occur: a staff member who belongs to two tenants leaves ONE of them.
+	// Deleting their identity here would take their access to the other
+	// tenant with it. Unlike cleanupTenantMembers this runs inside the
+	// caller's request rather than post-commit, so failures are returned
+	// rather than logged — including a failed membership lookup, because
+	// an inconclusive answer must not fall through to a delete.
+	remaining, err := s.fga.ListMemberTenants(ctx, actorUID)
+	if err != nil {
+		return fmt.Errorf("account: list member tenants: %w", err)
+	}
+	if len(remaining) > 0 {
+		return nil
+	}
 	if err := s.gip.DeleteAccount(ctx, actorUID); err != nil {
 		return fmt.Errorf("account: delete gip account: %w", err)
 	}

--- a/services/platform-api/internal/account/service.go
+++ b/services/platform-api/internal/account/service.go
@@ -123,9 +123,12 @@ func (s *Service) DeleteAccount(ctx context.Context, tenantID, actorUID string) 
 	return s.deleteStaffAccount(ctx, tenantID, actorUID, role)
 }
 
-// deleteOwnerAccount runs the atomic DB teardown, then best-effort
-// cleans up FGA tuples and the GIP identity. See the package doc for why
-// the second half is best-effort.
+// deleteOwnerAccount runs the atomic DB teardown, then best-effort cleans
+// up FGA tuples and GIP identities for every member of the tenant — not
+// just the owner (actorUID). A tenant can have staff/admin/viewer
+// invitees with their own role tuples, and those tuples must not survive
+// pointing at a tenant object that no longer exists (#361). See the
+// package doc for why this second half is best-effort.
 func (s *Service) deleteOwnerAccount(ctx context.Context, tenantID, actorUID string) error {
 	storeIDs, err := s.repo.ListStoreIDs(ctx, nil, tenantID)
 	if err != nil {
@@ -136,18 +139,85 @@ func (s *Service) deleteOwnerAccount(ctx context.Context, tenantID, actorUID str
 		return fmt.Errorf("account: teardown tenant: %w", err)
 	}
 
-	if err := s.fga.DeleteTuple(ctx, actorUID, string(authz.RoleOwner), tenantID); err != nil {
-		s.warn("account: post-commit owner tuple delete failed", "tenant_id", tenantID, "actor_uid", actorUID, "err", err)
-	}
+	s.cleanupTenantMembers(ctx, tenantID)
 	for _, storeID := range storeIDs {
 		if err := s.fga.DeleteStoreParent(ctx, storeID, tenantID); err != nil {
 			s.warn("account: post-commit store parent delete failed", "tenant_id", tenantID, "store_id", storeID, "err", err)
 		}
 	}
-	if err := s.gip.DeleteAccount(ctx, actorUID); err != nil {
-		s.warn("account: post-commit gip delete failed", "tenant_id", tenantID, "actor_uid", actorUID, "err", err)
-	}
 	return nil
+}
+
+// cleanupTenantMembers enumerates every user holding a direct FGA role
+// tuple on tenantID — the owner included — and unwinds their role
+// tuple(s) and (conditionally) their identity. Called only after the
+// tenant's DB row is already gone in the same transaction that enqueued
+// the tenant.deleted outbox event, so every step here is best-effort:
+// a failure is logged via s.warn and cleanup moves on, never aborting or
+// returning an error.
+//
+// Nil-tolerant on s.fga: PurgeTenant's route is mounted unconditionally
+// and may be wired with fga == nil (see purge.go's cleanupAfterTeardown
+// doc). deleteOwnerAccount's caller always wires a real client, so this
+// nil check is a no-op there in practice — it exists so the same helper
+// serves both call sites without each having to remember to guard.
+func (s *Service) cleanupTenantMembers(ctx context.Context, tenantID string) {
+	if s.fga == nil {
+		return
+	}
+	members, err := s.fga.ListTenantMembers(ctx, tenantID)
+	if err != nil {
+		s.warn("account: post-commit list tenant members failed", "tenant_id", tenantID, "err", err)
+		return
+	}
+
+	// A user can hold more than one direct role tuple on the same
+	// tenant (e.g. a staff→admin promotion intentionally leaves the old
+	// tuple in place for audit trail — see authz.rolePriority's doc
+	// comment). Remove every tuple for a user before deciding whether
+	// to delete their identity, so that decision is made once per user
+	// against a tenant that's already fully unwound for them.
+	touchedUsers := map[string]bool{}
+	for _, m := range members {
+		if err := s.fga.DeleteTuple(ctx, m.UserID, m.Relation, tenantID); err != nil {
+			s.warn("account: post-commit member tuple delete failed",
+				"tenant_id", tenantID, "user_id", m.UserID, "relation", m.Relation, "err", err)
+		}
+		touchedUsers[m.UserID] = true
+	}
+	for userID := range touchedUsers {
+		s.deleteIdentityIfNoTenantsRemain(ctx, userID, tenantID)
+	}
+}
+
+// deleteIdentityIfNoTenantsRemain deletes userID's GIP/Zitadel identity
+// ONLY if authz.ListMemberTenants shows no remaining tenant membership
+// anywhere. A user can hold roles on multiple tenants — that's exactly
+// why ListMemberTenants exists — so deleting their identity because ONE
+// of their tenants was torn down would destroy their access to every
+// other tenant they belong to.
+//
+// If the ListMemberTenants lookup itself fails, the answer is
+// inconclusive and this deliberately does NOT delete: an inconclusive
+// answer must never be treated as "safe to delete". The failure is
+// logged and the identity deletion is skipped.
+func (s *Service) deleteIdentityIfNoTenantsRemain(ctx context.Context, userID, justRemovedTenantID string) {
+	if s.gip == nil {
+		return
+	}
+	remaining, err := s.fga.ListMemberTenants(ctx, userID)
+	if err != nil {
+		s.warn("account: post-commit list member tenants failed, skipping identity delete",
+			"user_id", userID, "tenant_id", justRemovedTenantID, "err", err)
+		return
+	}
+	if len(remaining) > 0 {
+		return
+	}
+	if err := s.gip.DeleteAccount(ctx, userID); err != nil {
+		s.warn("account: post-commit identity delete failed",
+			"user_id", userID, "tenant_id", justRemovedTenantID, "err", err)
+	}
 }
 
 // teardownTenantTx deletes the tenant row and enqueues the tenant.deleted

--- a/services/platform-api/internal/account/teardown_members_test.go
+++ b/services/platform-api/internal/account/teardown_members_test.go
@@ -1,0 +1,233 @@
+package account
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/platform-api/internal/authz"
+	"github.com/mark8ly/platform-api/internal/tenant"
+)
+
+// failingListMembersFGA wraps a real authz.Client (normally a
+// *authz.FakeClient) and forces ListTenantMembers to fail, leaving every
+// other method to the embedded client. Used to prove that an enumeration
+// failure is logged and cleanup continues rather than propagating an
+// error or aborting the teardown — authz.FakeClient's blanket
+// FailNextChecks counter can't target ListTenantMembers alone once
+// DeleteAccount's own GetRole call is in the mix.
+type failingListMembersFGA struct {
+	authz.Client
+	err error
+}
+
+func (f *failingListMembersFGA) ListTenantMembers(_ context.Context, _ string) ([]authz.Member, error) {
+	return nil, f.err
+}
+
+// TestDeleteAccount_Owner_TearsDownAllMembersNotJustOwner is the #361
+// regression test for the merchant self-serve path: before the fix, only
+// the owner's role tuple was removed on teardown, leaving staff/admin/
+// viewer tuples pointing at a tenant that no longer exists.
+func TestDeleteAccount_Owner_TearsDownAllMembersNotJustOwner(t *testing.T) {
+	ctx := context.Background()
+	fga := authz.NewFake()
+	require.NoError(t, fga.WriteOwnership(ctx, "owner-1", "t1"))
+	require.NoError(t, fga.WriteRole(ctx, "admin-1", authz.RoleAdmin, "t1"))
+	require.NoError(t, fga.WriteRole(ctx, "staff-1", authz.RoleStaff, "t1"))
+	require.NoError(t, fga.WriteRole(ctx, "viewer-1", authz.RoleViewer, "t1"))
+	gip := &fakeGIP{}
+	repo := &fakeTenantRepo{stores: map[string][]string{"t1": {}}}
+	ob := &fakeOutbox{}
+
+	svc := NewService(nil, repo, fga, gip, ob.Enqueue, testLogger())
+
+	require.NoError(t, svc.DeleteAccount(ctx, "t1", "owner-1"))
+
+	require.False(t, fga.HasRole("owner-1", authz.RoleOwner, "t1"), "owner tuple should be deleted")
+	require.False(t, fga.HasRole("admin-1", authz.RoleAdmin, "t1"), "admin tuple should be deleted")
+	require.False(t, fga.HasRole("staff-1", authz.RoleStaff, "t1"), "staff tuple should be deleted")
+	require.False(t, fga.HasRole("viewer-1", authz.RoleViewer, "t1"), "viewer tuple should be deleted")
+
+	// None of them belong to any other tenant, so all four identities
+	// should be gone.
+	require.True(t, gip.deleted["owner-1"])
+	require.True(t, gip.deleted["admin-1"])
+	require.True(t, gip.deleted["staff-1"])
+	require.True(t, gip.deleted["viewer-1"])
+}
+
+// TestDeleteAccount_Owner_MemberOnAnotherTenantKeepsIdentity pins the
+// CRITICAL safety rule from #361: a user with a role on more than one
+// tenant must keep their identity when only one of those tenants is torn
+// down. Deleting it unconditionally (the issue's own "suggested fix
+// direction") would sever their access to every other tenant they belong
+// to. Applies the rule to the owner too, since an owner can (in
+// principle) own more than one tenant.
+func TestDeleteAccount_Owner_MemberOnAnotherTenantKeepsIdentity(t *testing.T) {
+	ctx := context.Background()
+	fga := authz.NewFake()
+	// owner-1 owns t1 only.
+	require.NoError(t, fga.WriteOwnership(ctx, "owner-1", "t1"))
+	// staff-1 is staff on t1 AND owns a second, unrelated tenant t2.
+	require.NoError(t, fga.WriteRole(ctx, "staff-1", authz.RoleStaff, "t1"))
+	require.NoError(t, fga.WriteOwnership(ctx, "staff-1", "t2"))
+	gip := &fakeGIP{}
+	repo := &fakeTenantRepo{stores: map[string][]string{"t1": {}}}
+	ob := &fakeOutbox{}
+
+	svc := NewService(nil, repo, fga, gip, ob.Enqueue, testLogger())
+
+	require.NoError(t, svc.DeleteAccount(ctx, "t1", "owner-1"))
+
+	// t1's tuples are gone for both users.
+	require.False(t, fga.HasRole("owner-1", authz.RoleOwner, "t1"))
+	require.False(t, fga.HasRole("staff-1", authz.RoleStaff, "t1"))
+	// staff-1's membership on t2 is untouched.
+	require.True(t, fga.HasOwnership("staff-1", "t2"), "unrelated tenant membership must survive")
+
+	// owner-1 has no remaining tenant → identity deleted.
+	require.True(t, gip.deleted["owner-1"])
+	// staff-1 still belongs to t2 → identity must be KEPT.
+	require.False(t, gip.deleted["staff-1"], "identity must survive while the user still belongs to another tenant")
+}
+
+// TestDeleteAccount_Owner_ListTenantMembersFailure_LogsAndContinues
+// verifies an enumeration failure doesn't fail DeleteAccount or block the
+// store-parent cleanup that follows it — everything here is best-effort
+// post-commit cleanup, per the package doc.
+func TestDeleteAccount_Owner_ListTenantMembersFailure_LogsAndContinues(t *testing.T) {
+	ctx := context.Background()
+	fga := authz.NewFake()
+	require.NoError(t, fga.WriteOwnership(ctx, "owner-1", "t1"))
+	require.NoError(t, fga.WriteStoreParent(ctx, "s1", "t1"))
+	failing := &failingListMembersFGA{Client: fga, err: errors.New("fga read unavailable")}
+	gip := &fakeGIP{}
+	repo := &fakeTenantRepo{stores: map[string][]string{"t1": {"s1"}}}
+	ob := &fakeOutbox{}
+
+	svc := NewService(nil, repo, failing, gip, ob.Enqueue, testLogger())
+
+	require.NoError(t, svc.DeleteAccount(ctx, "t1", "owner-1"), "an enumeration failure must not fail the call")
+
+	// The tenant row is still gone (that part already committed).
+	require.True(t, repo.deleted["t1"])
+	// Store-parent cleanup, which doesn't depend on member enumeration,
+	// still ran.
+	require.False(t, fga.HasStoreParent("s1", "t1"))
+	// No identity was deleted: enumeration never returned any members.
+	require.False(t, gip.deleted["owner-1"])
+}
+
+// TestDeleteAccount_Owner_IdentityDeleteFailure_LogsAndContinues verifies
+// a GIP failure for one member doesn't stop the others from being
+// processed, and doesn't fail the call.
+func TestDeleteAccount_Owner_IdentityDeleteFailure_LogsAndContinues(t *testing.T) {
+	ctx := context.Background()
+	fga := authz.NewFake()
+	require.NoError(t, fga.WriteOwnership(ctx, "owner-1", "t1"))
+	require.NoError(t, fga.WriteRole(ctx, "staff-1", authz.RoleStaff, "t1"))
+	gip := &fakeGIP{err: errors.New("gip unavailable")}
+	repo := &fakeTenantRepo{stores: map[string][]string{"t1": {}}}
+	ob := &fakeOutbox{}
+
+	svc := NewService(nil, repo, fga, gip, ob.Enqueue, testLogger())
+
+	require.NoError(t, svc.DeleteAccount(ctx, "t1", "owner-1"), "identity delete failures are best-effort")
+
+	// FGA tuples are still cleaned up regardless of the GIP failure.
+	require.False(t, fga.HasRole("owner-1", authz.RoleOwner, "t1"))
+	require.False(t, fga.HasRole("staff-1", authz.RoleStaff, "t1"))
+}
+
+// TestPurgeTenant_CleansUpAllMembersNotJustOwner is the #361 regression
+// test for the operator-initiated purge path: cleanupAfterTeardown used
+// to only remove snap.OwnerUserID's tuple.
+func TestPurgeTenant_CleansUpAllMembersNotJustOwner(t *testing.T) {
+	ctx := t.Context()
+	fga := authz.NewFake()
+	require.NoError(t, fga.WriteOwnership(ctx, "uid-1", "t-1"))
+	require.NoError(t, fga.WriteRole(ctx, "admin-1", authz.RoleAdmin, "t-1"))
+	require.NoError(t, fga.WriteStoreParent(ctx, "store-a", "t-1"))
+	gip := &fakeGIP{}
+	repo := &fakePurgeTenantRepo{snap: snapshotWith("the-bondi-store")}
+	ob := &recordingOutbox{}
+
+	svc := NewService(nil, repo, fga, gip, ob.enqueue, testLogger())
+
+	_, err := svc.PurgeTenant(ctx, "t-1", []string{"the-bondi-store"})
+	require.NoError(t, err)
+
+	require.False(t, fga.HasOwnership("uid-1", "t-1"))
+	require.False(t, fga.HasRole("admin-1", authz.RoleAdmin, "t-1"))
+	require.False(t, fga.HasStoreParent("store-a", "t-1"))
+	require.True(t, gip.deleted["uid-1"])
+	require.True(t, gip.deleted["admin-1"])
+}
+
+// TestPurgeTenant_MemberOnAnotherTenantKeepsIdentity applies the same
+// CRITICAL multi-tenant-membership safety rule to the operator purge
+// path: snap.OwnerUserID's identity used to be deleted unconditionally,
+// which would be a latent instance of the #361 bug for any owner who
+// owns a second tenant.
+func TestPurgeTenant_MemberOnAnotherTenantKeepsIdentity(t *testing.T) {
+	ctx := t.Context()
+	fga := authz.NewFake()
+	// uid-1 owns t-1 AND a second tenant t-2.
+	require.NoError(t, fga.WriteOwnership(ctx, "uid-1", "t-1"))
+	require.NoError(t, fga.WriteOwnership(ctx, "uid-1", "t-2"))
+	gip := &fakeGIP{}
+	repo := &fakePurgeTenantRepo{snap: snapshotWith("the-bondi-store")}
+	ob := &recordingOutbox{}
+
+	svc := NewService(nil, repo, fga, gip, ob.enqueue, testLogger())
+
+	_, err := svc.PurgeTenant(ctx, "t-1", []string{"the-bondi-store"})
+	require.NoError(t, err)
+
+	require.False(t, fga.HasOwnership("uid-1", "t-1"), "t-1's tuple must be gone")
+	require.True(t, fga.HasOwnership("uid-1", "t-2"), "t-2's tuple is unrelated and must survive")
+	require.False(t, gip.deleted["uid-1"], "identity must survive while the user still owns t-2")
+}
+
+// TestPurgeTenant_NilFGAAndGIPSkipsCleanupWithoutPanicking pins the
+// documented nil-tolerance: PurgeTenant's route is mounted unconditionally
+// and fga/gip may be true nil interfaces (see purge.go's doc comment).
+func TestPurgeTenant_NilFGAAndGIPSkipsCleanupWithoutPanicking(t *testing.T) {
+	repo := &fakePurgeTenantRepo{snap: snapshotWith("the-bondi-store")}
+	svc := newTestService(repo, (&recordingOutbox{}).enqueue)
+
+	res, err := svc.PurgeTenant(t.Context(), "t-1", []string{"the-bondi-store"})
+
+	require.NoError(t, err)
+	require.Equal(t, "t-1", res.TenantID)
+}
+
+// TestPurgeTenant_ListTenantMembersFailure_LogsAndContinues mirrors the
+// owner-path enumeration-failure test for the operator purge: an FGA read
+// failure must not fail PurgeTenant, which has already committed the DB
+// teardown by the time cleanup runs.
+func TestPurgeTenant_ListTenantMembersFailure_LogsAndContinues(t *testing.T) {
+	ctx := t.Context()
+	fga := authz.NewFake()
+	require.NoError(t, fga.WriteOwnership(ctx, "uid-1", "t-1"))
+	require.NoError(t, fga.WriteStoreParent(ctx, "store-a", "t-1"))
+	failing := &failingListMembersFGA{Client: fga, err: errors.New("fga read unavailable")}
+	gip := &fakeGIP{}
+	repo := &fakePurgeTenantRepo{snap: &tenant.TeardownSnapshot{
+		TenantID: "t-1", Name: "The Bondi Store", OwnerUserID: "uid-1",
+		Stores: []tenant.StoreRef{{ID: "store-a", Slug: "the-bondi-store"}},
+	}}
+	ob := &recordingOutbox{}
+
+	svc := NewService(nil, repo, failing, gip, ob.enqueue, testLogger())
+
+	_, err := svc.PurgeTenant(ctx, "t-1", []string{"the-bondi-store"})
+	require.NoError(t, err, "an enumeration failure must not fail the call")
+
+	// Store-parent cleanup, independent of member enumeration, still ran.
+	require.False(t, fga.HasStoreParent("store-a", "t-1"))
+	require.False(t, gip.deleted["uid-1"])
+}

--- a/services/platform-api/internal/account/teardown_members_test.go
+++ b/services/platform-api/internal/account/teardown_members_test.go
@@ -231,3 +231,42 @@ func TestPurgeTenant_ListTenantMembersFailure_LogsAndContinues(t *testing.T) {
 	require.False(t, fga.HasStoreParent("store-a", "t-1"))
 	require.False(t, gip.deleted["uid-1"])
 }
+
+// A staff member leaving ONE of their tenants must keep their identity —
+// this is the likeliest instance of #361's bug to occur in practice, since
+// self-serve "delete my account" is a user-facing action and multi-tenant
+// staff are ordinary. Deleting the identity here would silently revoke their
+// access to every other tenant they belong to.
+func TestDeleteAccount_Staff_MemberOnAnotherTenantKeepsIdentity(t *testing.T) {
+	ctx := context.Background()
+	fga := authz.NewFake()
+	require.NoError(t, fga.WriteRole(ctx, "staff-1", authz.RoleStaff, "t1"))
+	require.NoError(t, fga.WriteRole(ctx, "staff-1", authz.RoleStaff, "t2"))
+	gip := &fakeGIP{}
+	repo := &fakeTenantRepo{stores: map[string][]string{"t1": {"s1"}}}
+	ob := &fakeOutbox{}
+
+	svc := NewService(nil, repo, fga, gip, ob.Enqueue, testLogger())
+
+	require.NoError(t, svc.DeleteAccount(ctx, "t1", "staff-1"))
+
+	require.False(t, fga.HasRole("staff-1", authz.RoleStaff, "t1"), "t1 tuple should be deleted")
+	require.True(t, fga.HasRole("staff-1", authz.RoleStaff, "t2"), "t2 tuple must survive")
+	require.False(t, gip.deleted["staff-1"], "identity must survive: still a member of t2")
+}
+
+// The counterpart: their last membership, so the identity does go.
+func TestDeleteAccount_Staff_LastMembershipDeletesIdentity(t *testing.T) {
+	ctx := context.Background()
+	fga := authz.NewFake()
+	require.NoError(t, fga.WriteRole(ctx, "staff-1", authz.RoleStaff, "t1"))
+	gip := &fakeGIP{}
+	repo := &fakeTenantRepo{stores: map[string][]string{"t1": {"s1"}}}
+	ob := &fakeOutbox{}
+
+	svc := NewService(nil, repo, fga, gip, ob.Enqueue, testLogger())
+
+	require.NoError(t, svc.DeleteAccount(ctx, "t1", "staff-1"))
+
+	require.True(t, gip.deleted["staff-1"], "identity should be deleted: no memberships remain")
+}

--- a/services/platform-api/internal/authz/authz.go
+++ b/services/platform-api/internal/authz/authz.go
@@ -128,6 +128,21 @@ type Client interface {
 	DeleteTuple(ctx context.Context, userID, relation, tenantID string) error
 	// DeleteStoreParent removes tenant:<tenantID> parent store:<storeID>. Idempotent.
 	DeleteStoreParent(ctx context.Context, storeID, tenantID string) error
+
+	// ListTenantMembers returns every user holding a direct role tuple
+	// on the tenant, along with which relation each holds. Used by
+	// tenant teardown (#361) to enumerate everyone whose FGA state
+	// needs cleaning up, not just the owner. Unlike ListMemberTenants
+	// (which asks "which tenants does this user belong to"), this asks
+	// the reverse: "which users belong to this tenant".
+	ListTenantMembers(ctx context.Context, tenantID string) ([]Member, error)
+}
+
+// Member is one user's direct role tuple on a tenant, as returned by
+// ListTenantMembers.
+type Member struct {
+	UserID   string
+	Relation string
 }
 
 // fgaClient is the OpenFGA-backed implementation of Client.
@@ -308,6 +323,47 @@ func (c *fgaClient) ListMemberTenants(ctx context.Context, userID string) ([]str
 		}
 	}
 	return out, nil
+}
+
+// ListTenantMembers returns every user holding a direct role tuple on
+// tenant:<tenantID>, via OpenFGA's Read (a tuple query by object),
+// not ListObjects — ListObjects answers "which objects does this user
+// relate to", the opposite of what teardown needs here. Read is
+// paginated; this loops on the continuation token until OpenFGA
+// reports none left, so a tenant with more members than fit in one
+// page is still enumerated completely.
+func (c *fgaClient) ListTenantMembers(ctx context.Context, tenantID string) ([]Member, error) {
+	object := "tenant:" + tenantID
+	var out []Member
+	var continuationToken *string
+	for {
+		body := client.ClientReadRequest{Object: &object}
+		req := c.api.Read(ctx).Body(body)
+		if continuationToken != nil && *continuationToken != "" {
+			req = req.Options(client.ClientReadOptions{ContinuationToken: continuationToken})
+		}
+		resp, err := req.Execute()
+		if err != nil {
+			return nil, fmt.Errorf("authz: list tenant members: %w", err)
+		}
+		if resp == nil {
+			return out, nil
+		}
+		for _, tuple := range resp.GetTuples() {
+			key := tuple.GetKey()
+			user := key.GetUser()
+			// Tuples are stored as "user:<id>" — strip the prefix the
+			// same way ListMemberTenants strips "tenant:".
+			if len(user) > len("user:") && user[:len("user:")] == "user:" {
+				out = append(out, Member{UserID: user[len("user:"):], Relation: key.GetRelation()})
+			}
+		}
+		if resp.ContinuationToken == "" {
+			return out, nil
+		}
+		token := resp.ContinuationToken
+		continuationToken = &token
+	}
 }
 
 // GetRole iterates the direct role relations in priority order and

--- a/services/platform-api/internal/authz/fake.go
+++ b/services/platform-api/internal/authz/fake.go
@@ -307,6 +307,31 @@ func (f *FakeClient) ListMemberTenants(ctx context.Context, userID string) ([]st
 	return out, nil
 }
 
+// ListTenantMembers returns every user holding a direct role tuple on
+// the tenant, mirroring the real client's Read-based enumeration. No
+// pagination to simulate here — the fake holds everything in memory.
+func (f *FakeClient) ListTenantMembers(ctx context.Context, tenantID string) ([]Member, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.checkCallCount++
+	if f.failNextChecks > 0 {
+		f.failNextChecks--
+		return nil, fakeError("simulated FGA check failure")
+	}
+	var out []Member
+	suffix := "|" + tenantID
+	for _, r := range allRoles {
+		for key := range f.roles[r] {
+			if len(key) <= len(suffix) || key[len(key)-len(suffix):] != suffix {
+				continue
+			}
+			userID := key[:len(key)-len(suffix)]
+			out = append(out, Member{UserID: userID, Relation: string(r)})
+		}
+	}
+	return out, nil
+}
+
 // DeleteTuple removes the user:<userID> <relation> tenant:<tenantID>
 // tuple if present. Idempotent: deleting an already-absent tuple (or
 // an unrecognized relation) is a no-op that returns nil, mirroring

--- a/services/platform-api/internal/authz/list_tenant_members_test.go
+++ b/services/platform-api/internal/authz/list_tenant_members_test.go
@@ -1,0 +1,129 @@
+package authz
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestFGAClient builds a real (non-fake) Client wired to an httptest
+// server running handler, the way the production authz.New would be wired
+// to a real OpenFGA instance. The server is closed automatically via
+// t.Cleanup.
+func newTestFGAClient(t *testing.T, handler http.HandlerFunc) Client {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	c, err := New(Config{APIURL: srv.URL, StoreID: "01H8XGJVBWQAK1SDS1KWQZKZ8J"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+// readTuple builds one JSON tuple in the shape OpenFGA's Read response
+// returns.
+func readTuple(user, relation, object string) map[string]any {
+	return map[string]any{
+		"key": map[string]any{
+			"user":     user,
+			"relation": relation,
+			"object":   object,
+		},
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+// TestListTenantMembers_PagesThroughAllResults pins the pagination
+// contract: OpenFGA's Read endpoint returns results one page at a time
+// with a continuation_token, and ListTenantMembers MUST keep calling
+// Read with that token until the server reports none left. A version
+// that only reads the first page would silently drop every member past
+// page 1 — exactly the bug #361 warns is easy to introduce.
+func TestListTenantMembers_PagesThroughAllResults(t *testing.T) {
+	pages := [][]map[string]any{
+		{
+			readTuple("user:owner-1", "owner", "tenant:t1"),
+			readTuple("user:admin-1", "admin", "tenant:t1"),
+		},
+		{
+			readTuple("user:staff-1", "staff", "tenant:t1"),
+		},
+		{
+			readTuple("user:viewer-1", "viewer", "tenant:t1"),
+		},
+	}
+	tokens := []string{"page-2-token", "page-3-token", ""}
+
+	var callCount int
+	client := newTestFGAClient(t, func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			ContinuationToken string `json:"continuation_token"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		// Figure out which page was requested from the continuation
+		// token the client sent (empty string means "first page").
+		pageIdx := 0
+		for i := 1; i < len(tokens); i++ {
+			if tokens[i-1] == body.ContinuationToken {
+				pageIdx = i
+				break
+			}
+		}
+		callCount++
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tuples":             pages[pageIdx],
+			"continuation_token": tokens[pageIdx],
+		})
+	})
+
+	members, err := client.ListTenantMembers(context.Background(), "t1")
+	require.NoError(t, err)
+	require.Equal(t, 3, callCount, "must follow the continuation token across all 3 pages")
+
+	require.ElementsMatch(t, []Member{
+		{UserID: "owner-1", Relation: "owner"},
+		{UserID: "admin-1", Relation: "admin"},
+		{UserID: "staff-1", Relation: "staff"},
+		{UserID: "viewer-1", Relation: "viewer"},
+	}, members)
+}
+
+// TestListTenantMembers_EmptyResult verifies a tenant with no direct role
+// tuples (e.g. already torn down) returns an empty slice and no error,
+// rather than panicking on a nil response.
+func TestListTenantMembers_EmptyResult(t *testing.T) {
+	client := newTestFGAClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tuples":             []map[string]any{},
+			"continuation_token": "",
+		})
+	})
+
+	members, err := client.ListTenantMembers(context.Background(), "t1")
+	require.NoError(t, err)
+	require.Empty(t, members)
+}
+
+// TestListTenantMembers_ServerError verifies a transport/API failure is
+// wrapped and returned rather than swallowed.
+func TestListTenantMembers_ServerError(t *testing.T) {
+	client := newTestFGAClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"code":"internal_error","message":"boom"}`))
+	})
+
+	_, err := client.ListTenantMembers(context.Background(), "t1")
+	require.Error(t, err)
+}


### PR DESCRIPTION
Closes #361.

`authz.Client` had no way to ask "which users hold a role on this tenant" — `DeleteTuple` requires a `userID` as input, and `ListMemberTenants` goes the other direction. So every tenant-teardown path cleaned up FGA state for exactly one user, the owner, and staff/admin/viewer tuples survived pointing at a `tenant:<id>` that no longer existed.

## Changes

**`ListTenantMembers(ctx, tenantID) ([]Member, error)`** on `authz.Client`, backed by OpenFGA's `Read` (tuple query by object) rather than `ListObjects`, which answers the opposite question. `Read` is paginated and the implementation loops on the continuation token until exhausted — a tenant with more members than fit one page would otherwise be cleaned up only as far as the first page, silently. Non-`user:` subjects are skipped.

**Both teardown paths** (`deleteOwnerAccount` and `PurgeTenant`'s `cleanupAfterTeardown`) now enumerate members and delete every `(user, relation)` tuple. Both keep the existing best-effort post-commit convention exactly: every failure is logged via `s.warn` and cleanup continues, never aborting the teardown. The nil guards on `s.fga`/`s.gip` in the purge path are preserved.

## Identity deletion is now conditional — this is the important part

The issue's own suggested fix says to "delete every role tuple and disable every associated GIP identity". Doing that literally would be worse than the bug: a user can hold roles on **multiple** tenants — which is exactly why `ListMemberTenants` exists — so deleting a staff member's identity because one of their tenants was torn down would destroy their access to every other tenant they belong to.

So an identity is deleted only when `ListMemberTenants` confirms no membership remains anywhere. If that lookup itself fails the answer is inconclusive and nothing is deleted — an inconclusive answer must never fall through to a delete.

## Two latent instances of the same bug, found and fixed

Both deleted an identity unconditionally:

- **`PurgeTenant` and `deleteOwnerAccount`** — an owner who owns two tenants lost their identity the moment either was purged.
- **`deleteStaffAccount`** — and this is the one most likely to fire in practice, since self-serve "delete my account" is a user-facing action and multi-tenant staff are ordinary. A staff member leaving one tenant silently lost access to the others. This path returns errors rather than logging (it runs inside the caller's request, not post-commit), so the fix preserves that: a failed membership lookup returns an error rather than falling through.

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test -count=1 ./internal/authz/... ./internal/account/...` — all pass, cache disabled
- [x] `ListTenantMembers` pages through a multi-page `Read` response (against an `httptest` stand-in, matching the existing `zitadeladmin`/`gipadmin` test pattern)
- [x] Teardown deletes tuples for all members, not just the owner — both paths
- [x] A member belonging to another tenant keeps their identity; one with no other membership loses it — owner, purge and staff paths
- [x] Enumeration failure and identity-delete failure log and continue rather than aborting the teardown
- [x] The staff-path fix RED-verified: reverting it fails `TestDeleteAccount_Staff_MemberOnAnotherTenantKeepsIdentity` with "identity must survive: still a member of t2"

## Not verified

No exercise against a live OpenFGA instance — pagination is covered against an `httptest` server, not a real container. `purge_integration_test.go` is behind `-tags integration` and needs a real Postgres; it was not run, though by inspection it contains no FGA/identity references and would not exercise this either way.

One behavioural note: if OpenFGA's read-after-write is not immediately consistent, `ListMemberTenants` may still report the just-removed tenant and the identity is then kept. That is the safe direction — an orphaned identity rather than a wrongly deleted one.

`s.gip` is a legacy field *name*, not a legacy path: `selectAccountProviders` returns the `zitadeladmin` client when `ZitadelEnabled`, so this already deletes from Zitadel where enabled. Renaming it is out of scope here.
