### PR TITLE
fix(auth-bff): stop reporting a refused Google intent exchange as bad credentials (#686)

### DIFF
--- a/services/auth-bff/internal/zitadellogin/handler.go
+++ b/services/auth-bff/internal/zitadellogin/handler.go
@@ -633,7 +633,7 @@ func (h *Handler) idpFinish(w http.ResponseWriter, r *http.Request) {
 
 	sess, err := h.c.CreateIDPIntentSession(ctx, req.IntentID, req.IntentToken)
 	if err != nil {
-		h.respondSessionCreateError(ctx, w, err)
+		h.respondIDPSessionCreateError(ctx, w, err)
 		return
 	}
 
@@ -753,6 +753,43 @@ func (h *Handler) respondIDPIntentError(ctx context.Context, w http.ResponseWrit
 		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "zitadel_unavailable"})
 	default:
 		slog.ErrorContext(ctx, "zitadellogin: unexpected error retrieving idp intent", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+	}
+}
+
+// respondIDPSessionCreateError maps CreateIDPIntentSession's errors.
+//
+// This exists because respondSessionCreateError — which this call site used
+// to share — maps CreatePasswordSession's errors, and do() turns ANY Zitadel
+// 400 into ErrBadCredentials (see client.go's requestOptions default). On the
+// Google path that produced two lies at once: the operator saw
+// "login rejected: bad credentials" for a flow in which no credential was
+// ever presented, and the merchant got `invalid_credentials`, which
+// google-sign-in-admin.ts states as a hard rule must never happen here —
+// "no outcome may imply the Google credential itself was wrong (it never is:
+// every failure here is either a platform-side account/authorization
+// decision or an availability problem, never a bad password)". Observed in
+// production 2026-09-06: a merchant with a correctly linked Google identity
+// was told to check their details.
+//
+// Unlike the password path, every branch logs `err`. The wrapped error
+// carries Zitadel's own error id (do() formats it in, e.g. "COMMAND-3M0fs")
+// and nothing else — no credential, no token. On the password path a bare
+// "bad credentials" is a complete explanation; here it is the only clue
+// there is, and discarding it is what made this cost an afternoon to find.
+func (h *Handler) respondIDPSessionCreateError(ctx context.Context, w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrBadCredentials), errors.Is(err, ErrUserNotFound):
+		// Zitadel refused the intent -> session exchange: consumed,
+		// expired, or not linked to a user. Same answer as a bad intent
+		// on retrieve, because to the caller it is the same situation.
+		slog.WarnContext(ctx, "zitadellogin: idp finish rejected: could not create a session from the intent", "err", err)
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "invalid_intent"})
+	case errors.Is(err, ErrUnavailable):
+		slog.ErrorContext(ctx, "zitadellogin: zitadel unavailable creating a session from the idp intent", "err", err)
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "zitadel_unavailable"})
+	default:
+		slog.ErrorContext(ctx, "zitadellogin: unexpected error creating a session from the idp intent", "err", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
 	}
 }

--- a/services/auth-bff/internal/zitadellogin/handler_test.go
+++ b/services/auth-bff/internal/zitadellogin/handler_test.go
@@ -1154,3 +1154,53 @@ func TestIDPFinishWithoutTenantStillRefusesNoAdminAccountAndReturnsNoSession(t *
 		t.Fatalf("body = %v, must not carry any session/tenant_required fields", respBody)
 	}
 }
+
+// A Zitadel 400 on the intent -> session exchange must NEVER surface as
+// `invalid_credentials`.
+//
+// Observed in production 2026-09-06: a merchant whose Google identity was
+// correctly linked (one Zitadel user, verified email, one Google IDP link)
+// was told to check their details, and the log said "login rejected: bad
+// credentials" — on a flow where no credential is presented at all. The
+// cause was this call site sharing respondSessionCreateError, which maps
+// CreatePasswordSession's errors, combined with do() turning any Zitadel 400
+// into ErrBadCredentials.
+//
+// google-sign-in-admin.ts states the rule this broke: no outcome of this
+// flow may imply the Google credential itself was wrong, because it never
+// is. `invalid_intent` is the honest answer — the intent was refused.
+func TestIDPFinishReportsARefusedIntentExchangeAsInvalidIntent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v2/idp_intents/"):
+			w.Write([]byte(`{"idpInformation":{"idpId":"` + testGoogleIDPID + `","userId":"ext-1","userName":"person@gmail.com","rawInformation":{"email":"person@gmail.com","email_verified":true}}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/users":
+			w.Write([]byte(`{"result":[{"userId":"existing-1","human":{"email":{"email":"person@gmail.com","isVerified":true}}}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/users/existing-1/links":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sessions":
+			// Zitadel refusing the exchange — a consumed or expired intent.
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"code":3,"message":"invalid intent","details":[{"id":"COMMAND-3M0fs"}]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	h := NewHandler(New(srv.URL, "pat", srv.Client()), nil).WithGoogleIDPID(testGoogleIDPID).WithOrgID("org-1")
+	rec := httptest.NewRecorder()
+	h.idpFinish(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/idp/finish",
+		strings.NewReader(`{"auth_request_id":"V2_1","intent_id":"i1","intent_token":"tok","workspace_tenant":"t1"}`)))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401, body = %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "invalid_credentials") {
+		t.Fatalf("a Google sign-in must never be reported as a credential failure, got %s", body)
+	}
+	if !strings.Contains(body, "invalid_intent") {
+		t.Fatalf("error = %s, want invalid_intent", body)
+	}
+}


### PR DESCRIPTION
Found while diagnosing a real failure: a merchant with a correctly linked Google identity was told to check their details, and the log blamed a credential that was never presented.

## What happened in production, 2026-09-06 09:09:33 UTC

```
POST /auth/zitadel/idp/start   200
WARN zitadellogin: login rejected: bad credentials
POST /auth/zitadel/idp/finish  401   -> {"error":"invalid_credentials"}
```

The account was fine, and I checked it directly against production Zitadel: exactly one user for that address, `USER_STATE_ACTIVE`, email verified, and exactly one Google IDP link carrying the right Google `sub`. Nothing about the identity, the linking, or any "account merge" was wrong.

## Cause

`idpFinish` calls `CreateIDPIntentSession` and handed its error to **`respondSessionCreateError`** — which its own doc comment (`handler.go:1102`) says maps *`CreatePasswordSession`*'s errors. Combined with `do()`'s default of turning **any Zitadel 400** into `ErrBadCredentials` (`client.go:236`), a refused intent→session exchange came out as a credential rejection.

That produced two false statements at once:

- **To the merchant:** `invalid_credentials`, on a flow where they typed nothing. `apps/admin/lib/auth/google-sign-in-admin.ts` states this as a hard rule — *"no outcome may imply the Google credential itself was wrong (it never is: every failure here is either a platform-side account/authorization decision or an availability problem, never a bad password)"*. This was a direct violation of a documented invariant.
- **To the operator:** `login rejected: bad credentials`, which sends whoever is debugging after a password problem that does not exist.

## Fix

A dedicated `respondIDPSessionCreateError`, mirroring the existing `respondIDPIntentError`:

- A refused exchange (Zitadel 400, or 404) now answers **`invalid_intent`** — already a known code in `AdminGoogleErrorCode` with its own merchant copy, and the honest description: the intent was refused, whether consumed, expired, or unlinked. Previously it fell through the web route's mapping to a generic `internal_error`.
- Unavailability and anything unexpected keep their existing distinct answers.

**Every branch now logs `err`.** The wrapped error carries Zitadel's own error id (`do()` formats it in, e.g. `COMMAND-3M0fs`) and nothing else — no credential, no token. On the password path a bare "bad credentials" is a complete explanation, so that call site is deliberately left alone; on the IDP path it was the only clue there was, and discarding it is why the actual cause is still unknown from the logs we have.

## What this does and does not fix

It does **not** fix the underlying sign-in failure — Zitadel still returned 400 to `POST /v2/sessions`, and I will not guess at why. What it does is make the next occurrence diagnosable: the log will carry Zitadel's error id, and the merchant will see truthful copy instead of being told to check a password.

The storefront/customer handler has a same-named helper but does not route its IDP path through it — checked, and unaffected.

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test -count=1 ./...` across auth-bff — all pass
- [x] New `TestIDPFinishReportsARefusedIntentExchangeAsInvalidIntent`: a Zitadel 400 on `/v2/sessions` must answer `invalid_intent` and must never contain `invalid_credentials`
- [x] RED-verified: restoring the old call reproduces the production symptom exactly — `{"error":"invalid_credentials"}`
