### PR TITLE
feat(branding): a merchant can set the support email customers reply to

### DIFF
--- a/apps/admin/components/settings/BrandingSettingsClient.tsx
+++ b/apps/admin/components/settings/BrandingSettingsClient.tsx
@@ -367,6 +367,56 @@ function IdentityTab({ form, patch, editable }: TabProps) {
           </p>
         </div>
       </div>
+
+      <div className="space-y-4 border-t border-border-subtle pt-6">
+        <SectionHeader
+          title="Contact"
+          description="Where customers reach you. Not shown as a link on your storefront pages — this is the address behind your store's email."
+        />
+        <SupportEmailField form={form} patch={patch} editable={editable} />
+      </div>
+    </div>
+  );
+}
+
+// ─── Support email ──────────────────────────────────────────────────
+
+// The server is the authority on what counts as a usable address: it
+// applies the same guard the mail sender applies before it will use the
+// value as Reply-To, so what saves is exactly what sends. This check is
+// deliberately looser — it catches a typo before a round trip and nothing
+// more. Restating the server rule here would give it a second spelling
+// free to drift.
+function looksLikeEmail(v: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
+}
+
+function SupportEmailField({ form, patch, editable }: TabProps) {
+  const value = form.support_email ?? "";
+  const trimmed = value.trim();
+  const malformed = trimmed !== "" && !looksLikeEmail(trimmed);
+
+  return (
+    <div className="space-y-1.5">
+      <FieldLabel htmlFor="support_email">Support email</FieldLabel>
+      <TextInput
+        id="support_email"
+        value={value}
+        onChange={(v) => patch({ support_email: v })}
+        placeholder="hello@yourstore.com"
+        disabled={!editable}
+        maxLength={255}
+      />
+      {malformed ? (
+        <p role="alert" className="text-xs text-[color:var(--signal)]">
+          That doesn&apos;t look like an email address.
+        </p>
+      ) : null}
+      <p className="text-xs text-foreground-tertiary">
+        {trimmed === ""
+          ? "Not set — when a customer replies to an order confirmation or shipping update, their reply goes to Mark8ly, not to you. Add an address to receive replies yourself."
+          : "Customer replies to your store's order confirmations and shipping updates go here. It's also the contact shown if your store is ever temporarily closed. Clear the field to send replies back to Mark8ly."}
+      </p>
     </div>
   );
 }

--- a/apps/admin/lib/api/marketplace-api.ts
+++ b/apps/admin/lib/api/marketplace-api.ts
@@ -2163,6 +2163,11 @@ export interface StoreBranding {
   seo_ai_policy: "allow" | "deny" | "training-only-denied";
   seo_llms_txt?: string | null;
   return_policy?: string | null;
+  // Customer-facing contact address. Reply-To on store mail and the
+  // mailto link on the closed-store page. Always a string, never null:
+  // the column is NOT NULL DEFAULT '' and "" means "not set", in which
+  // case replies go to the Mark8ly platform address instead.
+  support_email: string;
   created_at: string;
   updated_at: string;
 }

--- a/services/marketplace-api/internal/branding/models.go
+++ b/services/marketplace-api/internal/branding/models.go
@@ -54,6 +54,20 @@ type StoreBranding struct {
 	SeoJsonLd             *string `gorm:"column:seo_json_ld"`
 	SeoAiPolicy           string  `gorm:"column:seo_ai_policy;type:varchar(30);not null;default:'allow'"`
 	SeoLlmsTxt            *string `gorm:"column:seo_llms_txt"`
+	// SupportEmail is the merchant's customer-facing contact address:
+	// the Reply-To on store mail (#748) and the mailto link on the
+	// closed-store page. Empty means "not set" and both consumers fall
+	// back — Reply-To to the platform address, the closed-store link to
+	// nothing.
+	//
+	// A `string`, not a `*string`, unlike the optional text fields above.
+	// Pointer-ness on this model tracks column NULLability, not
+	// optionality: support_email is NOT NULL DEFAULT '' (migration
+	// 000069), and Upsert's Select("*") writes every mapped column, so a
+	// nil *string here would send an explicit NULL into a NOT NULL column
+	// and fail the whole branding save. "" is both the zero value and a
+	// legal one.
+	SupportEmail string `gorm:"column:support_email;type:varchar(255);not null"`
 	// Policies
 	ReturnPolicy *string   `gorm:"column:return_policy"`
 	CreatedAt    time.Time `gorm:"column:created_at;not null;default:now()"`

--- a/services/marketplace-api/internal/branding/service.go
+++ b/services/marketplace-api/internal/branding/service.go
@@ -100,6 +100,9 @@ type UpdateInput struct {
 	SeoAiPolicy           *string
 	SeoLlmsTxt            *string
 	ReturnPolicy          *string
+	// SupportEmail: nil = leave unchanged; non-nil = write this value,
+	// where "" (or whitespace) clears it.
+	SupportEmail *string
 }
 
 // Update validates and persists branding changes.
@@ -289,6 +292,17 @@ func (s *Service) Update(ctx context.Context, in UpdateInput) (*StoreBranding, e
 	}
 	if in.SeoLlmsTxt != nil {
 		b.SeoLlmsTxt = in.SeoLlmsTxt
+	}
+
+	// Contact. Guarded on nil, like every other optional field: a PUT that
+	// omits support_email must leave the merchant's address alone. The
+	// admin form sends only the keys it changed, so most saves omit it.
+	if in.SupportEmail != nil {
+		normalised, err := normaliseSupportEmail(*in.SupportEmail)
+		if err != nil {
+			return nil, err
+		}
+		b.SupportEmail = normalised
 	}
 
 	// Policies.

--- a/services/marketplace-api/internal/branding/support_email.go
+++ b/services/marketplace-api/internal/branding/support_email.go
@@ -1,0 +1,59 @@
+package branding
+
+// support_email.go — validation for the merchant's customer-facing
+// contact address.
+//
+// This value is not merely stored. It is published in a Reply-To header
+// on mail sent to that store's customers (#748) and interpolated into a
+// mailto: link on the closed-store page. So it is validated at the write
+// boundary rather than at each send site.
+
+import (
+	"net/mail"
+	"strings"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+)
+
+// supportEmailMaxLen matches the column width (VARCHAR(255), migration
+// 000069). Rejecting here turns a driver-level truncation error into a
+// field-scoped validation message.
+const supportEmailMaxLen = 255
+
+// normaliseSupportEmail validates a candidate support address and returns
+// the value to persist. An empty or whitespace-only input is the merchant
+// clearing the field and is returned as "" — see the package doc on the
+// empty case.
+//
+// Three checks, each for a distinct reason:
+//
+//  1. mail.ParseAddress with an exact round-trip. This rejects the
+//     display-name form ("Nadia <n@x.com>") and anything carrying CR/LF,
+//     because the value lands in a mail header verbatim and a header is
+//     not a place to accept a caller-supplied structure.
+//  2. email.ValidateRecipient — the SAME guard email.StoreIdentity applies
+//     before it will use the address as Reply-To. Using a different (looser)
+//     spelling here would let a merchant save an address that the sender
+//     then silently discards, falling back to the platform with no
+//     explanation. What can be saved is exactly what will be used.
+//  3. Length, against the column width.
+func normaliseSupportEmail(raw string) (string, error) {
+	v := strings.TrimSpace(raw)
+	if v == "" {
+		return "", nil
+	}
+	if len(v) > supportEmailMaxLen {
+		return "", apperrors.ValidationFailed("support_email", "must be 255 characters or fewer")
+	}
+	addr, err := mail.ParseAddress(v)
+	if err != nil || addr.Name != "" || addr.Address != v {
+		return "", apperrors.ValidationFailed("support_email",
+			"must be a plain email address, e.g. hello@yourstore.com")
+	}
+	if err := email.ValidateRecipient(v); err != nil {
+		return "", apperrors.ValidationFailed("support_email",
+			"must be an address that can receive mail")
+	}
+	return v, nil
+}

--- a/services/marketplace-api/internal/branding/support_email_integration_test.go
+++ b/services/marketplace-api/internal/branding/support_email_integration_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+
+package branding
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/storeidentity"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// TestSupportEmail_SurvivesAnUnrelatedBrandingSave is the #749 hazard
+// against real SQL. Upsert's UPDATE path is Select("*"), which writes
+// every mapped column — including, now, support_email. The fake-repo unit
+// test proves Update merges correctly; only this one proves the row that
+// lands in Postgres still holds the address.
+func TestSupportEmail_SurvivesAnUnrelatedBrandingSave(t *testing.T) {
+	tx := testdb.NewTx(t)
+	ctx := context.Background()
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, tx, tenantID, storeID)
+
+	svc := NewService(ServiceConfig{DB: tx, Repo: NewRepository()})
+
+	addr := "hello@nadiasceramics.com"
+	_, err := svc.Update(ctx, UpdateInput{
+		TenantID: tenantID, StoreID: storeID, SupportEmail: &addr,
+	})
+	require.NoError(t, err)
+
+	// A second save that never mentions support_email — the shape of
+	// almost every real branding edit.
+	accent := "#2D4A2B"
+	_, err = svc.Update(ctx, UpdateInput{
+		TenantID: tenantID, StoreID: storeID, ColorAccent: &accent,
+	})
+	require.NoError(t, err)
+
+	var stored string
+	require.NoError(t, tx.Raw(
+		`SELECT support_email FROM store_branding WHERE store_id = ?`, storeID,
+	).Row().Scan(&stored))
+	require.Equal(t, addr, stored,
+		"Select(\"*\") must write back the address it read, not blank it")
+}
+
+// TestSupportEmail_ReachesReplyTo walks the whole path #749 exists to
+// close: the merchant saves an address through the branding service, and
+// the mail sender picks it up as Reply-To. Before this change nothing
+// wrote the column, so storeidentity always read "" and every store's
+// customer mail replied to the platform.
+func TestSupportEmail_ReachesReplyTo(t *testing.T) {
+	tx := testdb.NewTx(t)
+	ctx := context.Background()
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, tx, tenantID, storeID)
+
+	svc := NewService(ServiceConfig{DB: tx, Repo: NewRepository()})
+	addr := "hello@nadiasceramics.com"
+	_, err := svc.Update(ctx, UpdateInput{
+		TenantID: tenantID, StoreID: storeID, SupportEmail: &addr,
+	})
+	require.NoError(t, err)
+
+	store, err := storeidentity.NewDBLoader(tx).Load(ctx, storeID)
+	require.NoError(t, err)
+	require.Equal(t, addr, store.ContactEmail)
+
+	id := email.StoreIdentity("noreply@mark8ly.com", email.StoreSender{
+		Name: store.Name, Slug: store.Slug, ContactEmail: store.ContactEmail,
+	})
+	require.Equal(t, addr, id.ReplyTo)
+}
+
+// TestSupportEmail_UnsetFallsBackToPlatform records the decision behind
+// the empty case: blank is not an error, it means "replies reach the
+// platform". The admin UI says so in as many words.
+func TestSupportEmail_UnsetFallsBackToPlatform(t *testing.T) {
+	tx := testdb.NewTx(t)
+	ctx := context.Background()
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, tx, tenantID, storeID)
+
+	svc := NewService(ServiceConfig{DB: tx, Repo: NewRepository()})
+	tagline := "Wheel-thrown in Margate"
+	_, err := svc.Update(ctx, UpdateInput{
+		TenantID: tenantID, StoreID: storeID, Tagline: &tagline,
+	})
+	require.NoError(t, err)
+
+	store, err := storeidentity.NewDBLoader(tx).Load(ctx, storeID)
+	require.NoError(t, err)
+	require.Empty(t, store.ContactEmail)
+
+	id := email.StoreIdentity("noreply@mark8ly.com", email.StoreSender{
+		Name: store.Name, Slug: store.Slug, ContactEmail: store.ContactEmail,
+	})
+	require.Equal(t, "noreply@mark8ly.com", id.ReplyTo)
+}

--- a/services/marketplace-api/internal/branding/support_email_test.go
+++ b/services/marketplace-api/internal/branding/support_email_test.go
@@ -1,0 +1,168 @@
+package branding
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+)
+
+// fakeRepo stands in for Postgres so these tests can pin Service.Update's
+// field-merge behaviour without a database. It records the row Update
+// handed to Upsert, which is what would have been written.
+type fakeRepo struct {
+	existing *StoreBranding
+	upserted *StoreBranding
+}
+
+func (f *fakeRepo) GetByStoreID(context.Context, *gorm.DB, uuid.UUID) (*StoreBranding, error) {
+	if f.existing == nil {
+		return nil, apperrors.NotFound("branding")
+	}
+	clone := *f.existing
+	return &clone, nil
+}
+
+func (f *fakeRepo) Upsert(_ context.Context, _ *gorm.DB, b *StoreBranding) error {
+	clone := *b
+	f.upserted = &clone
+	return nil
+}
+
+func ptr(s string) *string { return &s }
+
+func newTestService(existing *StoreBranding) (*Service, *fakeRepo) {
+	repo := &fakeRepo{existing: existing}
+	return NewService(ServiceConfig{Repo: repo}), repo
+}
+
+func TestUpdate_SetsSupportEmail(t *testing.T) {
+	storeID := uuid.New()
+	svc, repo := newTestService(nil)
+
+	got, err := svc.Update(context.Background(), UpdateInput{
+		StoreID:      storeID,
+		SupportEmail: ptr("hello@nadiasceramics.com"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "hello@nadiasceramics.com", got.SupportEmail)
+	require.Equal(t, "hello@nadiasceramics.com", repo.upserted.SupportEmail,
+		"the value must reach the row that is written, not just the response")
+}
+
+func TestUpdate_TrimsSupportEmail(t *testing.T) {
+	svc, repo := newTestService(nil)
+	_, err := svc.Update(context.Background(), UpdateInput{
+		StoreID:      uuid.New(),
+		SupportEmail: ptr("  hello@nadiasceramics.com  "),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "hello@nadiasceramics.com", repo.upserted.SupportEmail)
+}
+
+func TestUpdate_ClearsSupportEmail(t *testing.T) {
+	storeID := uuid.New()
+	existing := defaultBranding(storeID)
+	existing.SupportEmail = "hello@nadiasceramics.com"
+	svc, repo := newTestService(existing)
+
+	got, err := svc.Update(context.Background(), UpdateInput{
+		StoreID:      storeID,
+		SupportEmail: ptr(""),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "", got.SupportEmail)
+	require.Equal(t, "", repo.upserted.SupportEmail,
+		"an explicit empty string is the merchant clearing the field")
+}
+
+// TestUpdate_OmittedSupportEmailIsPreserved is the acceptance criterion
+// from #749: a branding save that does not mention support_email must not
+// destroy it. Upsert writes every mapped column via Select("*"), so the
+// only thing standing between a colour change and a wiped contact address
+// is that Update merges onto the row it just read and guards this field
+// on nil.
+func TestUpdate_OmittedSupportEmailIsPreserved(t *testing.T) {
+	storeID := uuid.New()
+	existing := defaultBranding(storeID)
+	existing.SupportEmail = "hello@nadiasceramics.com"
+	svc, repo := newTestService(existing)
+
+	got, err := svc.Update(context.Background(), UpdateInput{
+		StoreID:     storeID,
+		ColorAccent: ptr("#2D4A2B"),
+		// SupportEmail deliberately omitted.
+	})
+	require.NoError(t, err)
+	require.Equal(t, "hello@nadiasceramics.com", got.SupportEmail)
+	require.Equal(t, "hello@nadiasceramics.com", repo.upserted.SupportEmail,
+		"an unrelated branding save must not blank the support email")
+}
+
+func TestUpdate_RejectsUnusableSupportEmail(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"no at sign", "not-an-email"},
+		{"no domain dot", "nadia@localhost"},
+		{"display name form", "Nadia <nadia@nadiasceramics.com>"},
+		{"angle brackets", "<nadia@nadiasceramics.com>"},
+		{"header injection", "nadia@nadiasceramics.com\nBcc: attacker@evil.com"},
+		{"trailing comment", "nadia@nadiasceramics.com (Nadia)"},
+		{"address list", "a@nadiasceramics.com, b@nadiasceramics.com"},
+		{"unroutable placeholder tld", "nadia@nadiasceramics.local"},
+		{"reserved example tld", "nadia@nadiasceramics.example"},
+		{"over column width", strings.Repeat("a", 250) + "@nadiasceramics.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, repo := newTestService(nil)
+			_, err := svc.Update(context.Background(), UpdateInput{
+				StoreID:      uuid.New(),
+				SupportEmail: ptr(tc.input),
+			})
+			require.Error(t, err)
+			require.True(t, errors.Is(err, apperrors.ErrValidationFailed),
+				"want a field validation error, got %v", err)
+			require.Nil(t, repo.upserted,
+				"a rejected address must not reach the database")
+		})
+	}
+}
+
+// TestSupportEmail_SaveAndSendAgree: every address the admin API accepts
+// must be one email.StoreIdentity will actually put in Reply-To. If the
+// two guards ever diverge, a merchant saves an address, sees it echoed
+// back, and their customers still reply to the platform.
+func TestSupportEmail_SaveAndSendAgree(t *testing.T) {
+	accepted := []string{
+		"hello@nadiasceramics.com",
+		"support+orders@nadias-ceramics.co.uk",
+		"a@b.io",
+	}
+	for _, addr := range accepted {
+		t.Run(addr, func(t *testing.T) {
+			svc, _ := newTestService(nil)
+			got, err := svc.Update(context.Background(), UpdateInput{
+				StoreID:      uuid.New(),
+				SupportEmail: ptr(addr),
+			})
+			require.NoError(t, err)
+			require.Equal(t, addr, got.SupportEmail)
+			id := email.StoreIdentity("noreply@mark8ly.com", email.StoreSender{
+				Name: "Nadia's Ceramics", Slug: "nadias-ceramics",
+				ContactEmail: got.SupportEmail,
+			})
+			require.Equal(t, addr, id.ReplyTo,
+				"saved address must survive the sender's own recipient guard")
+		})
+	}
+}

--- a/services/marketplace-api/internal/handlers/admin/branding.go
+++ b/services/marketplace-api/internal/handlers/admin/branding.go
@@ -92,6 +92,7 @@ type BrandingResponse struct {
 	SeoAiPolicy           string          `json:"seo_ai_policy"`
 	SeoLlmsTxt            *string         `json:"seo_llms_txt,omitempty"`
 	ReturnPolicy          *string         `json:"return_policy,omitempty"`
+	SupportEmail          string          `json:"support_email"`
 	HomepageContent       json.RawMessage `json:"homepage_content"`
 	CreatedAt             string          `json:"created_at"`
 	UpdatedAt             string          `json:"updated_at"`
@@ -136,6 +137,7 @@ func toBrandingResponse(b branding.StoreBranding) BrandingResponse {
 		SeoAiPolicy:           b.SeoAiPolicy,
 		SeoLlmsTxt:            b.SeoLlmsTxt,
 		ReturnPolicy:          b.ReturnPolicy,
+		SupportEmail:          b.SupportEmail,
 		CreatedAt:             b.CreatedAt.Format("2006-01-02T15:04:05Z"),
 		UpdatedAt:             b.UpdatedAt.Format("2006-01-02T15:04:05Z"),
 	}
@@ -205,6 +207,7 @@ type UpdateBrandingRequest struct {
 	SeoAiPolicy           *string                   `json:"seo_ai_policy"`
 	SeoLlmsTxt            *string                   `json:"seo_llms_txt"`
 	ReturnPolicy          *string                   `json:"return_policy"`
+	SupportEmail          *string                   `json:"support_email"`
 	HomepageContent       *json.RawMessage          `json:"homepage_content"`
 }
 
@@ -288,6 +291,7 @@ func (h *BrandingHandler) Update(c *gin.Context) {
 		SeoAiPolicy:           req.SeoAiPolicy,
 		SeoLlmsTxt:            req.SeoLlmsTxt,
 		ReturnPolicy:          req.ReturnPolicy,
+		SupportEmail:          req.SupportEmail,
 	})
 	if err != nil {
 		RespondErr(c, err, h.logger)

--- a/services/marketplace-api/internal/handlers/admin/branding_support_email_test.go
+++ b/services/marketplace-api/internal/handlers/admin/branding_support_email_test.go
@@ -1,0 +1,131 @@
+package admin_test
+
+// branding_support_email_test.go — pins the request → UpdateInput wiring
+// for support_email (#749).
+//
+// The service-layer tests in internal/branding prove the field is merged
+// and validated correctly once it arrives. They cannot prove it arrives:
+// drop `SupportEmail: req.SupportEmail` from the UpdateInput literal in
+// Update and every one of them still passes, because in.SupportEmail is
+// simply always nil and the nil guard preserves whatever was there. What
+// the merchant then sees is a form that saves without error and changes
+// nothing. These tests drive the real HTTP handler so that line is load-
+// bearing.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/branding"
+	"github.com/mark8ly/marketplace-api/internal/handlers/admin"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+)
+
+// recordingBrandingRepo implements branding.Repository over memory.
+type recordingBrandingRepo struct {
+	existing *branding.StoreBranding
+	upserted *branding.StoreBranding
+}
+
+func (r *recordingBrandingRepo) GetByStoreID(context.Context, *gorm.DB, uuid.UUID) (*branding.StoreBranding, error) {
+	if r.existing == nil {
+		return nil, apperrors.NotFound("branding")
+	}
+	clone := *r.existing
+	return &clone, nil
+}
+
+func (r *recordingBrandingRepo) Upsert(_ context.Context, _ *gorm.DB, b *branding.StoreBranding) error {
+	clone := *b
+	r.upserted = &clone
+	return nil
+}
+
+func brandingPUT(t *testing.T, repo *recordingBrandingRepo, storeID uuid.UUID, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	svc := branding.NewService(branding.ServiceConfig{Repo: repo})
+	h := admin.NewBrandingHandler(svc, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	r := gin.New()
+	r.PUT("/admin/stores/:storeId/branding", func(c *gin.Context) {
+		c.Set("tenant_id", uuid.New().String())
+		h.Update(c)
+	})
+
+	req := httptest.NewRequest(http.MethodPut,
+		"/admin/stores/"+storeID.String()+"/branding", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestBrandingUpdate_SupportEmailReachesTheService(t *testing.T) {
+	storeID := uuid.New()
+	repo := &recordingBrandingRepo{}
+
+	rec := brandingPUT(t, repo, storeID, `{"support_email":"hello@nadiasceramics.com"}`)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	require.NotNil(t, repo.upserted)
+	require.Equal(t, "hello@nadiasceramics.com", repo.upserted.SupportEmail,
+		"the address in the request body must reach the row that gets written")
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, "hello@nadiasceramics.com", resp["support_email"],
+		"and must be echoed back, or the admin form reloads showing it blank")
+}
+
+func TestBrandingUpdate_SupportEmailCanBeCleared(t *testing.T) {
+	storeID := uuid.New()
+	existing := &branding.StoreBranding{
+		StoreID: storeID, SupportEmail: "hello@nadiasceramics.com",
+		ColorBackground: "#F7F6F2", ColorText: "#0E0E0C", ColorAccent: "#2D4A2B",
+		ColorButtonBg: "#0E0E0C", ColorButtonText: "#F7F6F2",
+	}
+	repo := &recordingBrandingRepo{existing: existing}
+
+	rec := brandingPUT(t, repo, storeID, `{"support_email":""}`)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.Equal(t, "", repo.upserted.SupportEmail)
+}
+
+// The admin form PUTs only the keys the merchant changed, so this is the
+// shape of almost every real save.
+func TestBrandingUpdate_UnrelatedSaveKeepsSupportEmail(t *testing.T) {
+	storeID := uuid.New()
+	existing := &branding.StoreBranding{
+		StoreID: storeID, SupportEmail: "hello@nadiasceramics.com",
+		ColorBackground: "#F7F6F2", ColorText: "#0E0E0C", ColorAccent: "#2D4A2B",
+		ColorButtonBg: "#0E0E0C", ColorButtonText: "#F7F6F2",
+	}
+	repo := &recordingBrandingRepo{existing: existing}
+
+	rec := brandingPUT(t, repo, storeID, `{"tagline":"Wheel-thrown in Margate"}`)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.Equal(t, "hello@nadiasceramics.com", repo.upserted.SupportEmail,
+		"a save that never mentions support_email must not blank it")
+}
+
+func TestBrandingUpdate_RejectsUnusableSupportEmail(t *testing.T) {
+	storeID := uuid.New()
+	repo := &recordingBrandingRepo{}
+
+	rec := brandingPUT(t, repo, storeID, `{"support_email":"Nadia <nadia@nadiasceramics.com>"}`)
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	require.Nil(t, repo.upserted, "nothing may be written when validation fails")
+}

--- a/services/marketplace-api/internal/handlers/storefront/branding.go
+++ b/services/marketplace-api/internal/handlers/storefront/branding.go
@@ -41,9 +41,18 @@ type ActivePromotionResponse struct {
 // PublicBrandingResponse is the public wire DTO for the storefront.
 //
 // Relative to branding.StoreBranding it withholds the row's identifiers
-// and timestamps (ID, TenantID, StoreID, CreatedAt, UpdatedAt) and
+// and timestamps (ID, TenantID, StoreID, CreatedAt, UpdatedAt),
 // ReturnPolicy, which only the admin DTO carries
-// (handlers/admin/branding.go).
+// (handlers/admin/branding.go), and SupportEmail.
+//
+// SupportEmail is withheld because nothing on the storefront renders it
+// and this endpoint is unauthenticated — carrying it would make every
+// merchant's contact address harvestable from one public GET for no
+// gain. Its two real consumers reach it another way: Reply-To is set
+// server-side from internal/storeidentity, and the closed-store page is
+// rendered by the storefront-gate Worker from
+// GET /internal/storefront-status/:host. Publishing it here would be a
+// deliberate new decision, not a consequence of #749.
 //
 // It DOES carry custom_css. That is deliberate: the field is
 // merchant-authored styling for the merchant's own storefront, so the

--- a/services/marketplace-api/internal/handlers/storefront/branding_exposure_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/branding_exposure_test.go
@@ -32,6 +32,9 @@ func TestPublicBrandingExposureIsExactlyWhatTheCommentClaims(t *testing.T) {
 		"UpdatedAt": {},
 
 		"ReturnPolicy": {},
+		// #749: merchant contact address. Withheld from this
+		// unauthenticated endpoint — see the PublicBrandingResponse doc.
+		"SupportEmail": {},
 	}
 
 	public := map[string]struct{}{}

--- a/services/marketplace-api/internal/storeidentity/storeidentity.go
+++ b/services/marketplace-api/internal/storeidentity/storeidentity.go
@@ -7,11 +7,16 @@
 // while missing the fourth column. One joined query, one definition of
 // "who this store is to a customer".
 //
-// The contact address lives in store_branding.support_email. That column
-// is deliberately NOT mapped onto branding.StoreBranding: the branding
-// Upsert writes with Select("*"), and no admin surface populates the
-// column today, so a mapped field would be blanked on the merchant's
-// next branding save. Reading it here keeps that hazard off the model.
+// The contact address lives in store_branding.support_email. This package
+// reads it with an explicit LEFT JOIN rather than through the branding
+// model, so a store with no branding row at all still resolves an
+// identity — an INNER JOIN would strip the sender identity from every
+// merchant who never opened the branding editor.
+//
+// The column was unmapped on branding.StoreBranding until #749, when the
+// admin branding form gained a field that writes it; it is mapped now.
+// The join stays because of the missing-row case above, not because the
+// model cannot see the column.
 package storeidentity
 
 import (

--- a/services/marketplace-api/internal/storeidentity/storeidentity_integration_test.go
+++ b/services/marketplace-api/internal/storeidentity/storeidentity_integration_test.go
@@ -12,9 +12,8 @@ import (
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
-// TestLoad_JoinsBrandingSupportEmail is the reason this package issues a
-// LEFT JOIN rather than reading the branding model: support_email is not
-// a field on branding.StoreBranding, so only SQL can see it.
+// TestLoad_JoinsBrandingSupportEmail pins the join that carries the
+// merchant's contact address onto the resolved identity.
 func TestLoad_JoinsBrandingSupportEmail(t *testing.T) {
 	tx := testdb.NewTx(t)
 	ctx := context.Background()
@@ -49,8 +48,8 @@ func TestLoad_NoBrandingRow(t *testing.T) {
 }
 
 // TestLoad_BrandingRowWithoutSupportEmail — the column is NOT NULL
-// DEFAULT ”, so this is the common case today: no admin surface writes
-// it, and Reply-To falls back to the platform address.
+// DEFAULT ”, so this is every store that has not filled the field in
+// yet: Reply-To falls back to the platform address.
 func TestLoad_BrandingRowWithoutSupportEmail(t *testing.T) {
 	tx := testdb.NewTx(t)
 


### PR DESCRIPTION
Closes #749.

A merchant can now set the address customers reach when they reply to store mail. The column has existed since `000069`; **nothing has ever written it**, so it has been empty for every store since.

## One missing write has been disabling two features

**Reply-To on customer mail** (#748) falls back to the platform address for every store, so replies to order confirmations reach Mark8ly rather than the merchant.

**The closed-store page's contact link** — what `000069` was actually added for — has never rendered. And confirming that turned up a second defect: the consumer is not in this repo. `storefront_status` feeds the `storefront-gate` Cloudflare Worker in **tesserix-k8s**, whose `src/closed.html:60` is `<a href="mailto:{{SUPPORT_EMAIL}}">{{SUPPORT_EMAIL}}</a>` with `interpolate.ts` rendering a missing key as `""` and no conditional. So every closed store has been showing an **empty, broken `mailto:` anchor**, not an absent link. Writing the column fixes the content; the empty case still needs a conditional in that template. Different repo, filed separately.

## Correcting the issue's stated mechanism

#749 says mapping the column without wiring the request would blank it on the next save, because `Upsert` uses `Select("*")`. **That is not what this code does**, and the next person should not inherit the wrong model.

`branding.Service.Update` is read-modify-write: `GetByStoreID` loads the full row (which now hydrates `SupportEmail`), non-nil input is merged onto it, and the whole row goes to `Upsert`. `Select("*")` then writes back the value it just read.

Mutation-tested both shapes against the committed baseline:

- **Delete `SupportEmail: req.SupportEmail`** (the issue's feared shape): the four service tests still pass; three handler tests fail. `TestBrandingUpdate_UnrelatedSaveKeepsSupportEmail` **passes under this mutation** — preservation genuinely survives it. Which is why the wiring pin lives at the HTTP handler, where a service-layer test cannot see that line.
- **Apply the field unconditionally**, dropping the nil guard — the real bug shape: `TestUpdate_OmittedSupportEmailIsPreserved` and `TestBrandingUpdate_UnrelatedSaveKeepsSupportEmail` both fail.

The issue reaches the right conclusion (these must land together) by the wrong route.

## Validation

`normaliseSupportEmail`: trim, `""` clears, ≤255 (column width), `mail.ParseAddress` with an **exact round-trip** check (`Name == "" && Address == input`), then `email.ValidateRecipient`.

The round-trip is what rejects `Nadia <n@x.com>`, `<n@x.com>`, address lists, trailing comments, and CR/LF header injection. `ValidateRecipient` alone accepts `Nadia <n@x.com>` — it does `strings.Cut` on `@`, so it sees `local="Nadia <n"`, `domain="x.com>"` and passes.

Reusing `ValidateRecipient` is not just convenience: `email.StoreIdentity` (`identity.go:110`) applies **that same function** before it will use an address as Reply-To. A looser rule at the write boundary would let a merchant save an address the sender then silently discards. `TestSupportEmail_SaveAndSendAgree` pins that agreement.

(The `plausibleEmail` helper named in the brief for this work does not exist in mark8ly — that symbol is in tesserix-home's platform-api tickets module.)

## Judgement calls

**`string`, not `*string`.** Pointer-ness on this model tracks column **nullability**, not optionality: every `*string` maps a NULL-able column, every `NOT NULL` column (`ColorBackground`, `SeoAiPolicy`, `ShowPoweredBy`) is a value type. With `*string`, `Select("*")` + `Updates` on a nil pointer sends an explicit `NULL` into a `NOT NULL` column and fails the *entire* branding save. No `default:` gorm tag either — that tag is what caused #394's create-path bug.

**Withheld from the public storefront branding DTO.** The existing guard `TestPublicBrandingExposureIsExactlyWhatTheCommentClaims` (#694) went red and forced an explicit decision. That endpoint is unauthenticated, nothing on the storefront renders a contact address, and both real consumers reach the value another way — Reply-To server-side via `storeidentity`, the closed-store page via the internal endpoint. Publishing it there would make every merchant's address harvestable from one public GET.

**No backfill.** There is no source of truth to backfill from. The nearest candidate is the tenant owner's account email, and silently promoting a private account address into a `Reply-To` header on customer mail is a disclosure the merchant makes, not one we make for them. `TestSupportEmail_UnsetFallsBackToPlatform` records it.

The admin UI states the empty case rather than leaving it implicit: *"Not set — when a customer replies to an order confirmation or shipping update, their reply goes to Mark8ly, not to you."*

## Test plan

- [x] `gofmt -l .`, `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` no failures; `-race` green on branding, handlers/admin, handlers/storefront, email
- [x] Integration tests against real Postgres, confirmed named in `-v`: `SurvivesAnUnrelatedBrandingSave`, `ReachesReplyTo`, `UnsetFallsBackToPlatform`
- [x] `TestSupportEmail_ReachesReplyTo` is the end-to-end criterion: `Service.Update` → Postgres → `storeidentity.Load` → `email.StoreIdentity` → `ReplyTo`
- [x] Mutation-tested both failure shapes (above)
- [x] Admin: `tsc --noEmit` clean; `vitest` 1170 pass, 2 pre-existing failures in `appCredentials.test.ts` — verified pre-existing by stashing and re-running on a clean tree
- [ ] Post-merge: set a support email on a store and confirm an order confirmation carries it in `Reply-To`
