### PR TITLE
fix(mobile-shared): satisfy noUncheckedIndexedAccess in the IDP callback parser (#686)

### DIFF
--- a/packages/mobile-shared/auth/zitadel-idp-callback.ts
+++ b/packages/mobile-shared/auth/zitadel-idp-callback.ts
@@ -35,7 +35,12 @@ export function parseIdpCallback(url: string): IdpCallback {
   const start = url.indexOf("?");
   if (start === -1) return {};
   // Drop any fragment: a value after '#' was never a query parameter.
-  const query = url.slice(start + 1).split("#")[0];
+  // `?? ""` is required, not defensive: this package compiles under the root
+  // tsconfig's `noUncheckedIndexedAccess`, so `split()[0]` is
+  // `string | undefined` here even though it can never actually be absent.
+  // apps/mobile-admin does NOT enable that flag, so a check there passes
+  // while `@repo/mobile-shared#check-types` fails the whole Next.js gate.
+  const query = url.slice(start + 1).split("#")[0] ?? "";
 
   const out: IdpCallback = {};
   for (const pair of query.split("&")) {


### PR DESCRIPTION
**`main` is red and nothing is deploying.** This unblocks it.

`37c14c6` (the tip carrying #753, #754, #755 and #756) failed CI on `Next.js / Next.js quality`:

```
auth/zitadel-idp-callback.ts(41,22): error TS18048: 'query' is possibly 'undefined'.
ERROR  @repo/mobile-shared#check-types: exited (2)
Failed: @repo/mobile-shared#check-types
```

`url.slice(start + 1).split("#")[0]` is `string | undefined` under `noUncheckedIndexedAccess`. One `?? ""`.

## Why this got through review and a local check

The root `tsconfig.json` sets `noUncheckedIndexedAccess: true` and `packages/mobile-shared/tsconfig.json` extends it. **`apps/mobile-admin` does not enable that flag.** The file lives in `mobile-shared` but every test that exercises it lives in `mobile-admin`, so:

- `cd apps/mobile-admin && npx tsc --noEmit` — clean, which is what I ran and reported on #756
- `npx jest` — 1738 tests pass, including 12 for this parser
- `@repo/mobile-shared#check-types` — **fails**, and it is the one CI actually gates on

Adding a file to `packages/mobile-shared` means running that package's own `check-types`, not the consuming app's. I did not, and #756 merged red. The comment added here says so at the call site so the next person does not repeat it.

## Blast radius while this is red

Four merged PRs are stuck behind it, because CI publishes the images Kargo forms Freight from:

- #755's Google sign-in diagnostics — the reason a merchant's failure is still unexplained
- #753 mobile sign-in defects, #754 tenant teardown, #756 mobile Google

Note the three commits underneath (`1194cab`, `1cfdc50`, `c913cd8`) all had their CI runs **cancelled** by the next merge landing on top, which is expected and harmless — the tip build covers all of them. But it does mean this one run is the only thing that can produce deployable images.

## Test plan

- [x] `packages/mobile-shared` `tsc --noEmit` no longer reports `TS18048`, and reports nothing at all for `zitadel-idp-callback.ts`
- [x] RED-verified: reverting the `?? ""` reproduces CI's exact error, `auth/zitadel-idp-callback.ts(41,22): error TS18048`
- [x] Behaviour unchanged — `split()` always yields at least one element, so the coalesce is unreachable at runtime; it exists to satisfy the compiler

Verified in a clean worktree without `node_modules`, so the run also emits `TS2307 Cannot find module 'zod'/'vitest'` noise. Those are the known worktree module-resolution artefacts, not real, and are absent in CI where the install has run.
