### PR TITLE
fix(auth-bff): send the user check when creating a session from a Google intent (#686)

### DIFF
--- a/services/auth-bff/internal/zitadellogin/client.go
+++ b/services/auth-bff/internal/zitadellogin/client.go
@@ -364,9 +364,26 @@ func (c *Client) CreatePasswordSession(ctx context.Context, loginName, password 
 // The intent must already be linked to an existing Zitadel user (see
 // IDPIdentity.ZitadelUserID's doc); callers are expected to have checked
 // that via RetrieveIDPIntent before calling this.
-func (c *Client) CreateIDPIntentSession(ctx context.Context, intentID, intentToken string) (Session, error) {
+func (c *Client) CreateIDPIntentSession(ctx context.Context, userID, intentID, intentToken string) (Session, error) {
 	body := map[string]any{
 		"checks": map[string]any{
+			// The user check is REQUIRED alongside the intent check, not
+			// belt-and-braces. Zitadel's CheckIntent
+			// (internal/command/session.go) opens with:
+			//
+			//     if cmd.sessionWriteModel.UserID == "" {
+			//         return nil, zerrors.ThrowPreconditionFailed(nil,
+			//             "COMMAND-Sfw3r", "Errors.User.UserIDMissing")
+			//     }
+			//
+			// and only CheckUser sets that field. An intent check alone can
+			// therefore NEVER create a session — it validates that an
+			// already-identified user is linked to the external identity,
+			// it does not resolve who that user is. Sending only the intent
+			// produced COMMAND-Sfw3r on every merchant Google sign-in.
+			"user": map[string]any{
+				"userId": userID,
+			},
 			"idpIntent": map[string]any{
 				"idpIntentId":    intentID,
 				"idpIntentToken": intentToken,

--- a/services/auth-bff/internal/zitadellogin/client_test.go
+++ b/services/auth-bff/internal/zitadellogin/client_test.go
@@ -754,3 +754,52 @@ func TestUserEmailVerifiedReadsIsVerified(t *testing.T) {
 		t.Fatal("verified = true, want false")
 	}
 }
+
+// CreateIDPIntentSession MUST send a user check alongside the intent check.
+//
+// Zitadel's CheckIntent (internal/command/session.go) begins:
+//
+//	if cmd.sessionWriteModel.UserID == "" {
+//	    return nil, zerrors.ThrowPreconditionFailed(nil,
+//	        "COMMAND-Sfw3r", "Errors.User.UserIDMissing")
+//	}
+//
+// and only CheckUser sets that field. An intent check alone therefore can
+// never create a session: it validates that an ALREADY-IDENTIFIED user is
+// linked to the external identity, it does not resolve who the user is.
+//
+// Sending only the intent is what made every merchant Google sign-in fail
+// in production with `COMMAND-Sfw3r`, surfaced to the merchant as "that
+// sign-in link expired" and to operators, before #755, as "bad credentials"
+// on a flow where no credential is presented. There was no test on this
+// call at all, which is why it shipped.
+func TestCreateIDPIntentSessionSendsTheUserCheck(t *testing.T) {
+	var body string
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v2/sessions" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		b, _ := io.ReadAll(r.Body)
+		body = string(b)
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"sessionId":"s1","sessionToken":"tok-1"}`))
+	})
+
+	sess, err := c.CreateIDPIntentSession(context.Background(), "user-1", "intent-1", "intent-tok")
+	if err != nil {
+		t.Fatalf("CreateIDPIntentSession() error = %v", err)
+	}
+	if sess.ID != "s1" || sess.Token != "tok-1" {
+		t.Fatalf("session = %+v", sess)
+	}
+
+	// The user check, without which Zitadel answers COMMAND-Sfw3r.
+	if !strings.Contains(body, `"user"`) || !strings.Contains(body, `"userId":"user-1"`) {
+		t.Errorf("request body must carry the user check, got %s", body)
+	}
+	// And the intent check is still what proves the external identity.
+	if !strings.Contains(body, `"idpIntentId":"intent-1"`) ||
+		!strings.Contains(body, `"idpIntentToken":"intent-tok"`) {
+		t.Errorf("request body must still carry the intent check, got %s", body)
+	}
+}

--- a/services/auth-bff/internal/zitadellogin/handler.go
+++ b/services/auth-bff/internal/zitadellogin/handler.go
@@ -719,6 +719,12 @@ func (h *Handler) idpFinishMode(w http.ResponseWriter, r *http.Request, issueTok
 	// raw claims (see IDPIdentity's doc) and defaults to false when the
 	// claim is absent — so an absent claim refuses here exactly like an
 	// explicit false, never like "probably fine".
+	// The user this session will belong to. Zitadel cannot derive it from
+	// the intent alone (see CreateIDPIntentSession), so it has to be
+	// resolved here — from the intent when the identity is already linked,
+	// otherwise from the account the link is about to be attached to.
+	sessionUserID := identity.ZitadelUserID
+
 	if identity.ZitadelUserID == "" {
 		if identity.Email == "" || !identity.EmailVerified {
 			slog.WarnContext(ctx, "zitadellogin: idp finish rejected: unlinked identity with no verified email")
@@ -761,9 +767,19 @@ func (h *Handler) idpFinishMode(w http.ResponseWriter, r *http.Request, issueTok
 			return
 		}
 		slog.InfoContext(ctx, "zitadellogin: idp finish linked a first-time Google identity to an existing account", "user_id", existingUserID)
+		sessionUserID = existingUserID
 	}
 
-	sess, err := h.c.CreateIDPIntentSession(ctx, req.IntentID, req.IntentToken)
+	if sessionUserID == "" {
+		// Unreachable: the branch above either sets it or has already
+		// answered. Refuse rather than call Zitadel with an empty user and
+		// take COMMAND-Sfw3r back as an opaque "bad credentials".
+		slog.ErrorContext(ctx, "zitadellogin: idp finish: no user resolved for the session, refusing")
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+		return
+	}
+
+	sess, err := h.c.CreateIDPIntentSession(ctx, sessionUserID, req.IntentID, req.IntentToken)
 	if err != nil {
 		h.respondIDPSessionCreateError(ctx, w, err)
 		return

--- a/services/auth-bff/internal/zitadellogin/handler_test.go
+++ b/services/auth-bff/internal/zitadellogin/handler_test.go
@@ -3,6 +3,7 @@ package zitadellogin
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1202,5 +1203,47 @@ func TestIDPFinishReportsARefusedIntentExchangeAsInvalidIntent(t *testing.T) {
 	}
 	if !strings.Contains(body, "invalid_intent") {
 		t.Fatalf("error = %s, want invalid_intent", body)
+	}
+}
+
+// The ALREADY-LINKED path must still resolve a user for the session.
+//
+// This is the case that failed in production: a merchant accepted an invite,
+// set a password, and signed in with Google. Their Google identity was
+// already linked, so `identity.ZitadelUserID` was set, the link block was
+// skipped entirely — and the session was then created with no user check at
+// all, which Zitadel refuses with COMMAND-Sfw3r (Errors.User.UserIDMissing).
+//
+// The link-creating path had a test; this one did not, and it is the one
+// every returning Google user takes.
+func TestIDPFinishSendsTheLinkedUserWhenTheIdentityIsAlreadyLinked(t *testing.T) {
+	var sessionBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v2/idp_intents/"):
+			// userId present => Zitadel already knows this identity.
+			w.Write([]byte(`{"idpInformation":{"idpId":"` + testGoogleIDPID + `","userId":"ext-1","userName":"person@gmail.com","rawInformation":{"email":"person@gmail.com","email_verified":true}},"userId":"linked-user-1"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/users":
+			t.Error("must not search by email: the identity is already linked")
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sessions":
+			b, _ := io.ReadAll(r.Body)
+			sessionBody = string(b)
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"sessionId":"s1","sessionToken":"tok-1"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	h := NewHandler(New(srv.URL, "pat", srv.Client()), nil).
+		WithGoogleIDPID(testGoogleIDPID).WithOrgID("org-1")
+	rec := httptest.NewRecorder()
+	h.idpFinish(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/idp/finish",
+		strings.NewReader(`{"auth_request_id":"V2_1","intent_id":"i1","intent_token":"tok"}`)))
+
+	if !strings.Contains(sessionBody, `"userId":"linked-user-1"`) {
+		t.Fatalf("session must be created for the linked user, body = %s", sessionBody)
 	}
 }


### PR DESCRIPTION
**Merchant Google sign-in cannot succeed.** This is the root cause behind the failure #755 made visible, found by reading the error id #755 started logging.

## Evidence

Production, 09:57:25 UTC, after #755 deployed:

```
WARN zitadellogin: idp finish rejected: could not create a session from the intent
  err="zitadellogin: POST /v2/sessions: COMMAND-Sfw3r: zitadellogin: bad credentials"
POST /auth/zitadel/idp/finish 401
```

`idp/start` was 8 seconds earlier, so the intent was fresh — not expired, which was the leading hypothesis.

`COMMAND-Sfw3r` is Zitadel's own id. From `zitadel/zitadel@v4.15.3 internal/command/session.go`:

```go
func CheckIntent(intentID, token string) SessionCommand {
	return func(ctx context.Context, cmd *SessionCommands) ([]eventstore.Command, error) {
		if cmd.sessionWriteModel.UserID == "" {
			return nil, zerrors.ThrowPreconditionFailed(nil, "COMMAND-Sfw3r", "Errors.User.UserIDMissing")
		}
```

`sessionWriteModel.UserID` is set only by `CheckUser`. **An intent check alone can never create a session** — it validates that an already-identified user is linked to the external identity; it does not resolve who that user is.

And `CreateIDPIntentSession` sent only the intent:

```json
{"checks":{"idpIntent":{"idpIntentId":"…","idpIntentToken":"…"}}}
```

So every merchant Google sign-in fails at the last step, on both paths:

- **already-linked identity** — `identity.ZitadelUserID` is set, the link block is skipped, and the session is created with no user at all. This is the path every *returning* Google user takes, and the one the reporting merchant hit (accept invite -> set password -> Continue with Google).
- **first-time identity** — links successfully, then calls the same function.

That also explains the three accounts in production holding Google IDP links: `LinkIDPToUser` runs *before* the failing call, so the link is proof the link step ran, not that anyone ever completed a sign-in.

## Fix

`CreateIDPIntentSession` now takes a `userID` and sends `checks.user` alongside `checks.idpIntent`. The caller resolves it from the intent when the identity is already linked, otherwise from the account the link was just attached to, and refuses rather than calling Zitadel with an empty user.

This is one shared code path, so it fixes **web** merchant Google sign-in and the **mobile** Google flow (#756) together. The storefront/customer handler does not use this call and is unaffected.

## Why it shipped

`CreateIDPIntentSession` had **no test at all**, and the only handler test covering `idp/finish`'s success path exercised the *link-creating* branch — not the already-linked one that every returning user takes. Both gaps are closed here:

- `TestCreateIDPIntentSessionSendsTheUserCheck` asserts the request body carries `checks.user.userId` and still carries the intent check.
- `TestIDPFinishSendsTheLinkedUserWhenTheIdentityIsAlreadyLinked` drives the already-linked path and asserts the session is created for the linked user — and that the email search is *not* performed.

## Test plan

- [x] `go build ./... && go vet ./... && go test -count=1 ./...` across auth-bff — all pass
- [x] RED-verified: removing the user check fails the new test with the exact production body, `{"checks":{"idpIntent":{…}}}`
- [x] The already-linked test fails without the fix (no `userId` in the session body) and passes with it

## Not verified

Not yet exercised against live Zitadel — that needs a real Google round trip, which is the next thing to do once this deploys. The reporting merchant can retry then; if `COMMAND-Sfw3r` is gone from the logs and a session is minted, this is confirmed end to end.

Worth noting the failure was invisible for as long as it was because the old mapping reported it as `invalid_credentials` — this PR only exists because #755 made the error id readable.
