### PR TITLE
fix(auth-bff): resolve login_name from Zitadel so a returning Google user gets a complete response (#686)

### DIFF
--- a/services/auth-bff/internal/zitadellogin/handler.go
+++ b/services/auth-bff/internal/zitadellogin/handler.go
@@ -808,11 +808,49 @@ func (h *Handler) idpFinishMode(w http.ResponseWriter, r *http.Request, issueTok
 	// before completion. login_name is identity.Email — the email from the
 	// retrieved identity — never anything the caller supplied.
 	if req.WorkspaceTenant == "" {
+		// `identity.Email` is
+		// readRawEmail's output, which FAILS SOFT to "" on any payload shape
+		// it does not recognise (see idpintent.go) — and the already-linked
+		// path never checks it, because the email-verified gate only guards
+		// creating a link. So a returning Google user could reach here with
+		// an empty login_name, and the admin app rejected the whole
+		// otherwise-successful response as `unrecognised_response_shape`
+		// (observed in production 2026-09-06, immediately after the
+		// COMMAND-Sfw3r fix let the flow get this far for the first time).
+		//
+		// This also matches the rule finishComplete already states for the
+		// same value: resolve the subject's email from Zitadel rather than
+		// trusting anything the caller or the provider supplied.
+		loginName := identity.Email
+		if loginName == "" {
+			// Only when the provider claim is absent: this path deliberately
+			// makes no further Zitadel calls once it has decided to defer
+			// tenant selection, and two tests pin that. Reading the subject's
+			// email is the one exception worth making, because the
+			// alternative is answering with an empty login_name.
+			resolved, err := h.c.UserEmail(ctx, sessionUserID)
+			if err != nil {
+				slog.ErrorContext(ctx, "zitadellogin: idp finish: no provider email and could not resolve the subject email from zitadel",
+					"err", err, "user_id", sessionUserID)
+			} else {
+				loginName = resolved
+			}
+		}
+		if sess.ID == "" || sess.Token == "" || loginName == "" {
+			// Refuse loudly rather than answer a shape the caller can only
+			// reject as unrecognisable. Naming the empty field is the whole
+			// point: the previous failure was diagnosable only by reading
+			// the client's parser.
+			slog.ErrorContext(ctx, "zitadellogin: idp finish: incomplete tenant_required response, refusing",
+				"has_session_id", sess.ID != "", "has_session_token", sess.Token != "", "has_login_name", loginName != "")
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+			return
+		}
 		writeJSON(w, http.StatusOK, map[string]any{
 			"tenant_required": true,
 			"session_id":      sess.ID,
 			"session_token":   sess.Token,
-			"login_name":      identity.Email,
+			"login_name":      loginName,
 		})
 		return
 	}

--- a/services/auth-bff/internal/zitadellogin/handler_test.go
+++ b/services/auth-bff/internal/zitadellogin/handler_test.go
@@ -1247,3 +1247,55 @@ func TestIDPFinishSendsTheLinkedUserWhenTheIdentityIsAlreadyLinked(t *testing.T)
 		t.Fatalf("session must be created for the linked user, body = %s", sessionBody)
 	}
 }
+
+// A returning Google user whose intent carries no usable raw email must
+// still get a complete tenant_required response.
+//
+// `identity.Email` is readRawEmail's soft-fail output: any rawInformation
+// shape it does not recognise yields "". The already-linked path never
+// checks it — the email-verified gate only guards CREATING a link — so an
+// empty provider email reached the response as an empty `login_name`, and
+// the admin app rejected the whole 200 as `unrecognised_response_shape`.
+// Observed in production the moment the COMMAND-Sfw3r fix let the flow get
+// this far. login_name must come from Zitadel's record of the subject.
+func TestIDPFinishResolvesLoginNameFromZitadelWhenTheProviderEmailIsAbsent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v2/idp_intents/"):
+			// Already linked, and rawInformation carries NO email — exactly
+			// what readRawEmail fails soft on.
+			w.Write([]byte(`{"idpInformation":{"idpId":"` + testGoogleIDPID + `","userId":"ext-1","userName":"person@gmail.com","rawInformation":{}},"userId":"linked-user-1"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sessions":
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"sessionId":"s1","sessionToken":"tok-1"}`))
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v2/users/"):
+			w.Write([]byte(`{"user":{"human":{"email":{"email":"person@gmail.com"}}}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	h := NewHandler(New(srv.URL, "pat", srv.Client()), nil).
+		WithGoogleIDPID(testGoogleIDPID).WithOrgID("org-1")
+	rec := httptest.NewRecorder()
+	h.idpFinish(rec, httptest.NewRequest(http.MethodPost, "/auth/zitadel/idp/finish",
+		strings.NewReader(`{"auth_request_id":"V2_1","intent_id":"i1","intent_token":"tok"}`)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body = %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// The admin app rejects the response unless ALL FOUR are present.
+	for _, k := range []string{"tenant_required", "session_id", "session_token", "login_name"} {
+		if v, ok := body[k]; !ok || v == "" || v == nil {
+			t.Errorf("%s missing or empty in %v", k, body)
+		}
+	}
+	if body["login_name"] != "person@gmail.com" {
+		t.Errorf("login_name = %v, want the email from Zitadel's record", body["login_name"])
+	}
+}


### PR DESCRIPTION
#760 got merchant Google sign-in past `COMMAND-Sfw3r` — `/auth/zitadel/idp/finish` now returns **200** and a Zitadel session is created. It then failed at the very next step, on a bug that had been unreachable until now.

## Evidence

auth-bff, 10:21:05 UTC, on `main-b7c38ab`:

```
POST /auth/zitadel/idp/start   200
POST /auth/zitadel/idp/finish  200      <- was 401 COMMAND-Sfw3r
```

No `/idp/complete` follows. The admin app logged:

```
admin google idp finish: sign-in failed unrecognised_response_shape
```

`apps/admin/lib/auth/auth-bff.ts` requires all four of `tenant_required`, `session_id`, `session_token`, `login_name`. `login_name` was `identity.Email`, which is `readRawEmail`'s output — and that **fails soft to `""`** on any `rawInformation` shape it does not recognise (idpintent.go says so explicitly).

Crucially, the already-linked path never notices: the email-verified gate only guards *creating* a link (`if identity.ZitadelUserID == ""`), so a **returning** Google user sails past it and reaches the response with an empty `login_name`. That is every merchant who has signed in with Google before.

## Fix

Fall back to Zitadel's own record of the subject (`UserEmail`) when the provider claim is absent, and refuse loudly — naming the empty field — rather than emitting a response the caller can only reject as unrecognisable.

The refusal log is the point as much as the fix:

```
ERROR idp finish: incomplete tenant_required response, refusing
      has_session_id=true has_session_token=true has_login_name=false
```

Previously this was diagnosable only by reading the *client's* parser and inferring which of four fields was empty.

## A narrower fix than my first attempt

My first version resolved `login_name` from Zitadel unconditionally. That broke two existing tests — `TestIDPFinishWithoutTenantReturnsTenantRequiredAndDoesNotComplete` and `TestIDPFinishWithoutTenantIgnoresACallerSuppliedLoginName` — which assert this path makes **no further Zitadel calls** once it has decided to defer tenant selection. The fallback worked, so the behaviour was fine, but the invariant is deliberate and worth keeping.

So Zitadel is consulted **only** when the provider claim is empty. Common path: unchanged, no extra round trip, both tests still pass as written.

## Test plan

- [x] `go build ./... && go vet ./... && go test -count=1 ./...` across auth-bff — all packages pass
- [x] New `TestIDPFinishResolvesLoginNameFromZitadelWhenTheProviderEmailIsAbsent`: an already-linked identity whose `rawInformation` carries no email still yields all four fields, with `login_name` from Zitadel's record
- [x] RED-verified: with the fallback removed the test fails, and the new refusal log pinpoints it — `has_session_id=true has_session_token=true has_login_name=false`
- [x] The two invariant tests above still pass unmodified

## Still to confirm

This is the second failure in a chain that was invisible until #755 made the errors readable, so I will not claim Google sign-in works until a real attempt gets past `/idp/complete` and lands a session. The next step after this deploys is exactly that.
