### PR TITLE
docs(email): the provider chain is Resend alone, not Resend behind SendGrid

### DIFF
--- a/services/marketplace-api/internal/email/resend.go
+++ b/services/marketplace-api/internal/email/resend.go
@@ -16,9 +16,21 @@ import (
 //
 // Same thin-HTTP-client philosophy as SendGridSender: the whole integration
 // is one POST request, so the official SDK is not worth the dependency.
-// Resend is wired as the FALLBACK provider behind SendGrid — see
-// FallbackSender — so transactional mail keeps flowing when SendGrid is
-// down, rate-limiting, or rejecting the account.
+//
+// RESEND IS THE ONLY PROVIDER. This comment used to say the opposite — that
+// Resend was "the FALLBACK provider behind SendGrid ... so transactional mail
+// keeps flowing when SendGrid is down" — and that is now backwards in both
+// halves. The SendGrid account was closed, and its key was removed from every
+// workload (tesserix/tesserix-k8s#1014), so `NewFromConfig` builds a
+// single-provider chain and logs "single provider configured — no fallback"
+// at boot.
+//
+// The uncomfortable half, stated because a reader will otherwise assume the
+// old shape: NOTHING CATCHES A RESEND FAILURE. FallbackSender is still here
+// and still correct, but with one provider in the chain it has nothing to
+// fall back to. That is a deliberate position (tesserix/tesserix-k8s#1011),
+// not an oversight — and it is the reason this comment is worth keeping
+// accurate rather than deleting.
 type ResendSender struct {
 	apiKey string
 	client *http.Client

--- a/services/marketplace-api/internal/email/sender.go
+++ b/services/marketplace-api/internal/email/sender.go
@@ -3,11 +3,18 @@
 // Every product mailer (campaign, ticket, giftcard, orderdoc, shipping
 // label) renders its own envelope and hands the result to a Sender; the
 // adapters in this package translate the provider-agnostic Message into
-// each provider's wire format. Production wiring is SendGrid (primary)
-// → Resend (fallback) via FallbackSender so a SendGrid outage degrades
-// to a provider switch instead of dropped transactional mail. Mirrors
-// platform-api/internal/notification so both services fail over the
-// same way.
+// each provider's wire format.
+//
+// Production wiring is RESEND ALONE. This used to read "SendGrid (primary)
+// → Resend (fallback) ... so a SendGrid outage degrades to a provider switch
+// instead of dropped transactional mail", which is now wrong in a way that
+// matters: the SendGrid account was closed and its key removed from every
+// workload (tesserix/tesserix-k8s#1014), so there is no switch to degrade to.
+// A Resend failure drops the mail.
+//
+// The provider-agnostic shape is still worth having — adding a second
+// provider is a factory plus a defaultOrder entry (see providers.go) — but
+// nothing should read this package as currently redundant.
 package email
 
 import (


### PR DESCRIPTION
Two package comments describe the email provider chain backwards. Both were accurate when written; the SendGrid account has since been closed and its key removed from every workload (tesserix/tesserix-k8s#1014), so they now tell a reader the opposite of what the code does.

`internal/email/resend.go:18-20`:

> *"Resend is wired as the FALLBACK provider behind SendGrid — see FallbackSender — so transactional mail keeps flowing when SendGrid is down, rate-limiting, or rejecting the account."*

`internal/email/sender.go:6-10`:

> *"Production wiring is SendGrid (primary) → Resend (fallback) via FallbackSender so a SendGrid outage degrades to a provider switch instead of dropped transactional mail."*

Neither half survives: Resend is not the fallback, it is the only provider, and there is no switch to degrade to.

## Why this is worth a commit on its own

A comment that is merely stale gets ignored. One that is **inverted** actively misleads: someone reading `resend.go` today would conclude a Resend outage is survivable, and might reasonably deprioritise exactly the work that would make that true.

`NewFromConfig` builds a single-provider chain and logs `"single provider configured — no fallback"` at boot. The replacement comments say that plainly, including the uncomfortable half — **nothing catches a Resend failure** — and note it is a deliberate position (tesserix/tesserix-k8s#1011) rather than an oversight.

`FallbackSender` itself stays. It is still correct and still the right shape; it simply has one provider in the chain. The comment now says so rather than implying the package is redundant.

## Test plan

- [x] `gofmt -l` clean, `go build ./...`, `go vet ./internal/email/`
- [x] `go test ./internal/email/` passes
- [x] Grepped the sibling packages (`otto/internal/mailer`, `sendgrid.go`) for the same claim — the remaining "fallback-chain logs" mentions are accurate, since that is what the chain logging is called regardless of length

Comments only; no behaviour change.
