### PR TITLE
fix(mobile): build with the Zitadel provider, and stop offering Apple where it cannot work (#686)

### DIFF
--- a/apps/mobile-admin/__tests__/login.test.tsx
+++ b/apps/mobile-admin/__tests__/login.test.tsx
@@ -347,3 +347,35 @@ describe('involuntary sign-out notice', () => {
     expect(queryByText(/session ended|doesn't have access/i)).toBeNull();
   });
 });
+
+// Apple must not be offered on a Zitadel build until it has a Zitadel path.
+//
+// handleAppleSignIn does not branch on the provider: it authenticates against
+// Firebase and sets the provider's `user`, which AuthGate ignores under
+// Zitadel (it reads zitadelSignedIn) and api-client ignores too (it reads
+// zitadelSession). The result is a silent bounce back to /login — #493's
+// shape. A button that cannot work must not be shown.
+//
+// This is a submission blocker, not a preference: Apple guideline 4.8 requires
+// Sign in with Apple wherever another social provider is offered, and Google
+// is offered on this screen. Apple has to be migrated before an App Store
+// release, and this test should be deleted then, not weakened.
+describe('Apple button visibility by provider', () => {
+  afterEach(() => {
+    delete process.env.EXPO_PUBLIC_AUTH_PROVIDER;
+  });
+
+  it('is hidden on a Zitadel build', () => {
+    process.env.EXPO_PUBLIC_AUTH_PROVIDER = 'zitadel';
+    const { queryByTestId } = render(<LoginScreen />);
+    expect(queryByTestId('provider-apple')).toBeNull();
+    // Google still is offered — it has a Zitadel path (#686 item 1).
+    expect(queryByTestId('provider-google')).not.toBeNull();
+  });
+
+  it('is still shown on a GIP build, where it works', () => {
+    delete process.env.EXPO_PUBLIC_AUTH_PROVIDER;
+    const { queryByTestId } = render(<LoginScreen />);
+    expect(queryByTestId('provider-apple')).not.toBeNull();
+  });
+});

--- a/apps/mobile-admin/app/login.tsx
+++ b/apps/mobile-admin/app/login.tsx
@@ -413,7 +413,20 @@ export default function LoginScreen() {
           <GoogleMark />
         </IconButton>
 
-        {Platform.OS === 'ios' ? (
+        {/* Hidden under Zitadel, and NOT cosmetic: handleAppleSignIn has no
+            Zitadel branch, so it authenticates against Firebase and sets the
+            provider's `user` — which AuthGate ignores under Zitadel (it reads
+            zitadelSignedIn) and which api-client ignores too (it reads
+            zitadelSession). The tester would land back on /login with no
+            error at all, the #493 failure shape exactly. Offering a control
+            that cannot work is worse than not offering it.
+
+            This MUST come back before any App Store submission: Apple's
+            guideline 4.8 requires Sign in with Apple wherever another social
+            provider is offered, and Google IS offered here (#686 item 1). So
+            migrating Apple to Zitadel is a submission blocker, not a polish
+            item — see #686. */}
+        {Platform.OS === 'ios' && !isZitadelProvider() ? (
           <IconButton
             accessibilityLabel="Sign in with Apple"
             disabled={submitting}

--- a/apps/mobile-admin/eas.json
+++ b/apps/mobile-admin/eas.json
@@ -12,6 +12,7 @@
         "simulator": true
       },
       "env": {
+        "EXPO_PUBLIC_AUTH_PROVIDER": "zitadel",
         "EXPO_PUBLIC_API_URL": "https://api.mark8ly.com",
         "GIP_TENANT_ID": "MP-Internal-e986p",
         "EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID": "849928263410-5djgu3n40c5tpr86votuptkitqveegor.apps.googleusercontent.com",
@@ -29,6 +30,7 @@
         "buildType": "apk"
       },
       "env": {
+        "EXPO_PUBLIC_AUTH_PROVIDER": "zitadel",
         "EXPO_PUBLIC_API_URL": "https://api.mark8ly.com",
         "GIP_TENANT_ID": "MP-Internal-e986p",
         "EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID": "849928263410-5djgu3n40c5tpr86votuptkitqveegor.apps.googleusercontent.com",
@@ -44,6 +46,7 @@
         "resourceClass": "m-medium"
       },
       "env": {
+        "EXPO_PUBLIC_AUTH_PROVIDER": "zitadel",
         "EXPO_PUBLIC_API_URL": "https://api.mark8ly.com",
         "GIP_TENANT_ID": "MP-Internal-e986p",
         "EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID": "849928263410-5djgu3n40c5tpr86votuptkitqveegor.apps.googleusercontent.com",
@@ -62,6 +65,7 @@
         "buildType": "app-bundle"
       },
       "env": {
+        "EXPO_PUBLIC_AUTH_PROVIDER": "zitadel",
         "EXPO_PUBLIC_API_URL": "https://api.mark8ly.com",
         "GIP_TENANT_ID": "MP-Internal-e986p",
         "EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID": "849928263410-5djgu3n40c5tpr86votuptkitqveegor.apps.googleusercontent.com",


### PR DESCRIPTION
Every merged Zitadel change is inert in a built app. `EXPO_PUBLIC_AUTH_PROVIDER` is set in **no** `eas.json` profile:

```
local-sim   -> <unset>
development -> <unset>
preview     -> <unset>
production  -> <unset>
```

`EXPO_PUBLIC_*` flags are inlined at build time and `isZitadelProvider()` defaults to GIP when unset, so any EAS build — including the existing `mobile-admin-build.yml` cloud build — ships the **Firebase/GIP path** and ignores #750, #756, #759 and #761 entirely. It only works on a simulator because `.env.local` sets it, and that file is gitignored.

All four profiles now set `zitadel`.

## The part that isn't a one-liner

Flipping the flag makes a latent dead end **live**, so it is fixed here rather than shipped:

`handleAppleSignIn` has no Zitadel branch and the button was not provider-gated. Under Zitadel it authenticates against Firebase and sets the provider's `user` — which `AuthGate` ignores (it reads `zitadelSignedIn`) and `api-client` ignores (it reads `zitadelSession`). The result is a silent bounce back to `/login` **with no error at all**: the #493 failure shape this codebase already documents.

So Apple is hidden on a Zitadel build. Google stays — it has a Zitadel path as of #756.

## This is a submission blocker, and the comment says so

Apple's guideline 4.8 requires Sign in with Apple wherever another social provider is offered, and Google is offered on this screen. **Migrating Apple to Zitadel is therefore a prerequisite for any App Store release, not a polish item.** The hiding here is correct for internal/TestFlight builds and must be removed — by migrating Apple, not by weakening the test — before submission.

That also means the parked local-build/TestFlight CI work is blocked by the same thing, which is worth knowing before it is picked back up.

## Test plan

- [x] All four `eas.json` profiles resolve `EXPO_PUBLIC_AUTH_PROVIDER=zitadel`; file still parses
- [x] New tests: the Apple button is hidden on a Zitadel build while Google remains, and still shown on a GIP build where it works
- [x] `npx jest` — **1765 tests pass**
- [x] `npx tsc --noEmit` — no new errors
- [x] `packages/mobile-shared` `tsc --noEmit` — exit 0 (the stricter gate that broke main earlier today)

## Note

Formatting is preserved by inserting the key rather than reserialising `eas.json`, so the diff is four lines rather than a whole-file rewrite.

Not device-verified: the simulator build already had the flag via `.env.local`, so this changes what a **CI/EAS** build produces, which is exactly the path no device run covers.
