### PR TITLE
fix(auth-bff): an IDP link is an identity source, not an uncollectible factor (#686)

### DIFF
--- a/services/auth-bff/internal/zitadellogin/sufficiency.go
+++ b/services/auth-bff/internal/zitadellogin/sufficiency.go
@@ -38,6 +38,19 @@ type sufficient struct{}
 const (
 	methodPassword = "AUTHENTICATION_METHOD_TYPE_PASSWORD" // not a second factor
 	methodTOTP     = "AUTHENTICATION_METHOD_TYPE_TOTP"     // the one we can collect
+	// An identity SOURCE, not a factor to collect. Zitadel reports this the
+	// moment a user holds any IDP link — and the Google flow CREATES that
+	// link — so classifying it uncollectible meant a completed Google
+	// sign-in permanently prevented the next one. Verified in production
+	// 2026-09-06: enrolled methods were exactly [PASSWORD, IDP], sufficiency
+	// handed off, and Zitadel's hosted login answered the handoff with
+	// {"error":"no valid authentication request found"}. A Google-only
+	// account would carry [IDP] alone and fail identically.
+	//
+	// This does NOT weaken MFA. Enforcement still runs through the login
+	// policy and totpEnrolled below, and a genuinely uncollectible factor —
+	// a passkey, U2F — still falls to `default` and still hands off.
+	methodIDP = "AUTHENTICATION_METHOD_TYPE_IDP"
 )
 
 // finalize exchanges a session for an authorization code. Unexported and
@@ -73,6 +86,7 @@ func (c *Client) classifyEnrolledMethods(ctx context.Context, userID string) (to
 	for _, t := range types {
 		switch t {
 		case methodPassword:
+		case methodIDP:
 		case methodTOTP:
 			totpEnrolled = true
 		default:

--- a/services/auth-bff/internal/zitadellogin/sufficiency_test.go
+++ b/services/auth-bff/internal/zitadellogin/sufficiency_test.go
@@ -275,3 +275,52 @@ func TestDecideAfterFactorFailsClosedWhenTOTPIsNotConfirmed(t *testing.T) {
 		t.Fatalf("outcome = %v, want OutcomeHandoff", res.Outcome)
 	}
 }
+
+// An IDP link must not make a session uncollectible.
+//
+// Zitadel reports AUTHENTICATION_METHOD_TYPE_IDP the moment a user holds any
+// IDP link — and the Google sign-in flow is what CREATES that link. Treating
+// it as uncollectible therefore made a completed Google sign-in permanently
+// prevent the next one: sufficiency handed off, the browser followed the
+// handoff to Zitadel's hosted login, and Zitadel answered
+// {"error":"no valid authentication request found"}.
+//
+// Verified in production 2026-09-06: the reporting account's enrolled methods
+// were exactly [PASSWORD, IDP]. A Google-only account carries [IDP] alone and
+// failed identically, so no choice of address avoided it.
+func TestDecideSufficiencyTreatsAnIDPLinkAsCollectible(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		methodsJSON string
+	}{
+		{"password and idp", `["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_IDP"]`},
+		{"idp only", `["AUTHENTICATION_METHOD_TYPE_IDP"]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fakeZitadelNoFinalize(t, policyNoMFA, tc.methodsJSON, factorsPasswordOnly)
+			res, err := c.DecideSufficiency(context.Background(), Session{ID: "s1", Token: "t"}, true)
+			if err != nil {
+				t.Fatalf("err = %v", err)
+			}
+			if res.Outcome == OutcomeHandoff {
+				t.Fatalf("outcome = OutcomeHandoff — an IDP link is an identity source, not an uncollectible factor")
+			}
+		})
+	}
+}
+
+// The guard that keeps the fix honest: a REAL uncollectible factor alongside
+// an IDP link must still hand off. Ignoring IDP must not become "ignore
+// everything that is not password or TOTP".
+func TestDecideSufficiencyStillHandsOffForAPasskeyBesideAnIDPLink(t *testing.T) {
+	c := fakeZitadelNoFinalize(t, policyForceMFA,
+		`["AUTHENTICATION_METHOD_TYPE_PASSWORD","AUTHENTICATION_METHOD_TYPE_IDP","AUTHENTICATION_METHOD_TYPE_PASSKEY"]`,
+		factorsPasswordOnly)
+	res, err := c.DecideSufficiency(context.Background(), Session{ID: "s1", Token: "t"}, true)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Outcome != OutcomeHandoff {
+		t.Fatalf("outcome = %v, want OutcomeHandoff — a passkey is still uncollectible", res.Outcome)
+	}
+}


### PR DESCRIPTION
A completed Google sign-in permanently prevented the next one. Linking a Google identity is what creates the condition that blocks it.

## The catch-22

Zitadel reports `AUTHENTICATION_METHOD_TYPE_IDP` in a user's enrolled methods as soon as they hold **any** IDP link — and the Google flow's own `LinkIDPToUser` is what creates that link.

`classifyEnrolledMethods` classified anything that is not PASSWORD or TOTP as an uncollectible factor:

```go
case methodPassword:
case methodTOTP:
        totpEnrolled = true
default:
        uncollectible = true   // <- IDP landed here
```

`uncollectible` fails closed to `OutcomeHandoff`, so `idp/complete` returned a `handoff_url`, the browser followed it to Zitadel's hosted login, and Zitadel answered:

```
{"error": "no valid authentication request found"}
```

which is what the merchant saw.

## Evidence

Production, 10:47-10:48 UTC on `main-d14e365`:

```
POST /auth/zitadel/idp/start     200
POST /auth/zitadel/idp/finish    200
POST /auth/zitadel/idp/complete  200
INFO handoff (uncollectible factor or unreadable policy/session)
     auth_request_id=V2_389556424713175555
```

Note there is **no preceding WARN**. Three of the four handoff paths log one; the `uncollectible` branch is the only silent one, which is what identified it.

The account's enrolled methods, read from production:

```
AUTHENTICATION_METHOD_TYPE_PASSWORD
AUTHENTICATION_METHOD_TYPE_IDP
```

A Google-only account carries `[IDP]` alone and fails identically — so this was never about a particular address, a reused email, or a pre-existing account. Both cases are tested.

## Fix

`AUTHENTICATION_METHOD_TYPE_IDP` is an identity **source**, not a factor a login UI collects, so it no longer marks a session uncollectible.

**This does not weaken MFA.** Enforcement runs through the login policy plus `totpEnrolled`, both untouched. A genuinely uncollectible factor still falls to `default` and still hands off — pinned by `TestDecideSufficiencyStillHandsOffForAPasskeyBesideAnIDPLink`, which puts a passkey *beside* an IDP link and asserts the handoff survives. That guard exists so this fix cannot later be widened into "ignore anything that is not password or TOTP".

## Test plan

- [x] `go build ./... && go vet ./... && go test -count=1 ./...` — all auth-bff packages pass
- [x] `TestDecideSufficiencyTreatsAnIDPLinkAsCollectible` — both `[PASSWORD, IDP]` and `[IDP]` alone
- [x] `TestDecideSufficiencyStillHandsOffForAPasskeyBesideAnIDPLink` — the anti-over-reach guard
- [x] RED-verified: reverting the one `case` fails both sub-cases with "an IDP link is an identity source, not an uncollectible factor"
- [x] The existing `TestDecideSufficiencyFailsClosedOnEveryUncertainInput` still passes unmodified, including its PASSKEY case

## Where this sits

Fourth and hopefully last in the chain that #755 made visible: `COMMAND-Sfw3r` (#760) -> `unrecognised_response_shape` (#762) -> this. Each was hidden behind the previous one. I will not call Google sign-in working until an attempt actually lands a session and a dashboard — that has not happened yet.
