### PR TITLE
feat(billing): apply and remove a console-minted tenant discount, stacked so it cannot delete a merchant's promo (#660)

### DIFF
--- a/.planning/quick/260906-td-tenant-discount/PLAN.md
+++ b/.planning/quick/260906-td-tenant-discount/PLAN.md
@@ -1,0 +1,226 @@
+# Apply and remove a console-minted discount on a tenant's subscriptions
+
+mark8ly#660, counterpart to tesserix-home#331. The console **mints** a Stripe
+Coupon and records it (`0047`); it cannot apply it, because the Stripe customer
+lives here. This builds the endpoints that apply and remove it.
+
+PR 1 of 3. The transport (tesserix-home platform-api billing write path) and the
+console call are separate PRs; this one ships unreachable, exactly as the
+console's own half did.
+
+## Two premises in #660 are wrong. Read this before the issue.
+
+**1. There is no customer-scoped apply call.** The SDK pins
+`APIVersion = "2025-08-27.basil"` (`stripe-go/v82@v82.5.1/api_version.go`), and
+Basil **removed** coupon attachment from the Customer API — `CustomerUpdateParams`,
+`CustomerCreateParams` and `CustomerParams` carry no `Coupon`, `PromotionCode`
+or `Discounts` field. (v76 still has `Coupon *string`; the v82 CHANGELOG records
+the removal.) Only read (`Customer.Discount`) and delete
+(`V1Customers.DeleteDiscount`) survive.
+
+**2. A customer discount would not have stacked anyway.** Stripe: *"When a
+subscription has no discounts, the customer-level discount, if any, applies to
+invoices."* Customer-level is a **fallback, masked by** any subscription
+discount. A tenant whose store had redeemed a merchant promo would have received
+**no platform discount at all, silently** — worse than the collision it was
+meant to avoid.
+
+## The design: read-modify-write the subscription's `discounts` array
+
+Basil's replacement is a stackable array (up to 20), whose entries are a
+discriminated choice (`SubscriptionUpdateDiscountParams`):
+
+```go
+Coupon        *string // create a new discount from this coupon
+Discount      *string // REUSE an existing discount already on the object
+PromotionCode *string
+```
+
+The `Discount` arm is what makes this non-destructive:
+
+- **Apply** — read current `discounts`, write back
+  `[existing ids as Discount…] + [our coupon as Coupon]`.
+- **Remove** — read current, write back the array **minus ours**, preserving the
+  rest.
+
+### This fixes a live bug, it does not work around one
+
+`AttachCoupon` (`internal/billing/stripe/coupon.go:93`) sets the coupon as the
+**sole** discount — its own comment says so — and `DetachCoupon` (`:107`) sends
+an empty slice, clearing **all** discounts. `internal/promo/service.go:152`
+attaches merchants' promo codes through those same helpers, and already knows
+the hazard (`:180`: *"detaching here would strip an unrelated coupon the
+subscription already carried"*).
+
+So today an operator override would delete a merchant's promo, and a revoke
+would delete whatever discount happened to be there. The read-modify-write pair
+replaces them. **Migrate `internal/promo`'s call sites in this PR** — leaving two
+mechanisms against one Stripe field is how the collision comes back.
+
+## Scope: all current AND future stores (decided)
+
+`store_subscriptions` is `UNIQUE (store_id)` with a separate `tenant_id`
+(`migrations/000015_subscriptions.up.sql`), so a tenant with several stores has
+several subscriptions and several customers. #660 says "the tenant's
+subscription customer", singular; it is not.
+
+Decided: the grant is a standing property of the tenant.
+
+- Apply fans out over every store subscription the tenant owns, and reports
+  **per store** — a store with no subscription yet is an explicit outcome, not a
+  silent skip (`internal/billing/appaddon/handler.go:133` is the precedent for
+  the guard).
+- **`StripeSubscriptionID` is nullable** (`internal/subscription/models.go:116`).
+  A trialing, card-less tenant has nothing to attach to — and is exactly the
+  population an operator discounts. Those stores report `pending`, and the
+  override is applied when the subscription is created (T6).
+- Remove fans out the same way and is as audited as the apply
+  (tesserix-home#331: "removal is as audited as application").
+
+## One transaction per store, not one across the tenant
+
+`internal/billing/trial/extend.go:232-357` puts the Stripe call **inside** the
+transaction, holding `SELECT … FOR UPDATE` on the subscription row across the
+network call, bounded by `stripeCallTimeout = 10s` (`:139`). Its reasoning
+(`:270-280`) is that Stripe must move first and be the source of truth: a Stripe
+failure rolls back and writes nothing locally; a failed commit afterwards leaves
+Stripe **ahead**, which bills the merchant *later* than we show — the safe
+direction.
+
+Follow that, but **per store**. One transaction spanning N stores would hold N
+row locks across N Stripe round-trips. Each store gets its own
+transaction-with-Stripe-call, so one store's failure neither rolls back nor
+blocks the others, and the per-store report is the honest unit.
+
+## Tasks
+
+Each is one atomic commit. Tests first.
+
+### T1 — `EmitTx` on the audit emitter
+
+`internal/audit/emitter.go`. tesserix-home#331 requires the audit row be written
+**inside** the transaction that applies the change.
+
+Cheaper than it looks: `Repository.Create(ctx, db *gorm.DB, e *Entry)`
+(`repository.go:43`) **already takes the handle as a parameter** and
+`gormRepository` is stateless (`:55`). `EmitTx` is `EmitSync` with the handle
+passed in. Nothing touches the queue, worker or `stop`.
+
+- Must live on `*Emitter` in package `audit`: `buildEntry` is unexported by
+  design (`export_test_helpers.go:6`) and owns all actor/operator/capability/IP
+  derivation. Do not re-derive it in `platformadmin`.
+- **Takes the caller's `ctx`**, contradicting both neighbours. `Emit`'s worker
+  and `EmitSync` deliberately use a fresh `context.Background()` with a 5s
+  timeout so a disconnecting client cannot cancel the record (`:184-187`,
+  `:236-240`). That is correct for them and **wrong here** — the insert must
+  share the transaction's cancellation. Say so in the doc comment.
+- Nil-receiver: returns an **error**, never a silent no-op —
+  `nil_repo_test.go`'s `TestNilEmitter_AllExportedMethodsAreSafe` gains a
+  twelfth method, and a transactional audit that quietly does nothing is the
+  exact failure #331 exists to prevent.
+- Do **not** use the `emailtemplates` revision-row pattern (migration 000130).
+  That exists only because an email template key is estate-wide and
+  `audit_logs.tenant_id` is `NOT NULL` (`routes.go:371-401`). A tenant discount
+  has a real tenant id, so that blocker never fires and a second governance
+  store would fragment the trail.
+
+### T2 — non-destructive Stripe discount helpers
+
+`internal/billing/stripe/coupon.go`.
+
+- `AddSubscriptionDiscount(ctx, c, subID, couponID)` — retrieve, map existing
+  discounts to `{Discount: id}`, append `{Coupon: couponID}`, update.
+- `RemoveSubscriptionDiscount(ctx, c, subID, couponID)` — retrieve, write back
+  without that one.
+- **Already present is a no-op, absent is a no-op.** Both must be safe to retry;
+  the endpoint's idempotency layer is a separate guarantee and must not be the
+  only one.
+- Stripe caps the array at 20 — refuse with a named error rather than letting
+  the API reject it, so the message says which subscription.
+- Then **replace `AttachCoupon`/`DetachCoupon` and migrate `internal/promo`**
+  (`service.go:152`, `:182`, `:204`). Delete the old pair; leaving it is leaving
+  the foot-gun loaded.
+
+### T3 — the domain service
+
+`internal/billing/tenantdiscount/` (new package).
+
+`Apply(ctx, in) (Result, error)` and `Remove(ctx, in) (Result, error)`. Per
+store: open a transaction, `SELECT … FOR UPDATE` the subscription row, call
+Stripe inside it (bounded, per `stripeCallTimeout`), write local state if any,
+then `EmitTx` the audit row **last, inside the same transaction**.
+
+**Name the residual divergence.** If the audit insert fails, the transaction
+rolls back but the Stripe discount **stays applied**. That is the same class as
+`ErrStripeAppliedLocalWriteFailed` (`trial/extend.go:83-90`) and needs its own
+sentinel, its own log line carrying coupon + subscription + customer ids, and a
+stated decision: an unattributable discount is rolled back locally rather than
+kept silently. Do not let this fall out of ordering by accident.
+
+Per-store outcomes, each explicit: `applied`, `already_applied`, `pending`
+(no `stripe_subscription_id` yet), `failed` with a reason.
+
+### T4 — the platform-admin endpoints
+
+`internal/handlers/platformadmin/billing_tenant_discount.go`. Model on
+`billing_trial_extend.go` — it is a complete precedent.
+
+- `POST /admin/billing/tenants/:tenantID/discount` and `DELETE` the same path.
+  **Bare UUID** tenant id, like every handler here (`tenant_lifecycle.go:200`);
+  the console's namespaced `<source>:<id>` is split by platform-api (PR 2).
+- Mandatory scoped `Idempotency-Key`, reserved **after** validation and
+  immediately before the work (`billing_trial_extend.go:189-206`), scoped
+  `"tenant_discount:" + tenantID + ":" + key` because the table's PK is
+  service-wide. Release on domain failure so a corrected retry proceeds.
+- Mandatory `reason`, `truncateUTF8`'d before it reaches metadata
+  (`:349-362`) — under `EmitTx` an unmarshalable reason no longer means
+  "succeeded unaudited", it means "the discount silently failed".
+- Distinct error codes per domain sentinel; driver text logged, never echoed.
+- **Add both routes to `RequiredWriteCapabilities`**
+  (`middleware.go:104-119`), value `""` — the vocabulary is the console's
+  (#275/#333). `TestAllWriteRoutesDeclareACapability` fails the build otherwise,
+  and once `CapabilityValueChecked` flips an undeclared write route 403s.
+- Mount conditionally in `routes.go`, refusing to mount without the emitter —
+  "a write endpoint that cannot be attributed should not exist."
+
+### T5 — tests
+
+Both layers, per the package convention: unit with hand-rolled stubs
+(`billing_trial_extend_test.go`) and `//go:build integration` against a real DB
+(`billing_trial_extend_integration_test.go`, `testdb.NewDB(t, "idempotency_keys")`).
+`./internal/handlers/platformadmin/...` is already in `make test-int`'s list.
+
+Must cover: the fan-out reporting per store; a `pending` store; same
+idempotency key replaying without a second Stripe call or a second audit row;
+the audit row written in-transaction (assert it is absent after a forced
+rollback); and that applying an override **preserves an existing merchant promo
+discount** — the regression the whole design exists for.
+
+### T6 — apply on subscription creation
+
+The "future stores" half. Where a subscription is created for a store whose
+tenant holds a live override, apply it. Find the creation path and hook it
+there; without this the discount silently stops covering the tenant as they
+grow, which surfaces in a renewal negotiation.
+
+## Out of scope, stated so it is not smuggled in
+
+- **The transport.** tesserix-home's platform-api billing module is read-only —
+  no `fed.Post`, no `splitTenantID`. PR 2.
+- **The console call and its copy.** `tenant-pricing-override-controls.tsx:62,84,94`
+  flag `overrideMintedMessage` as MUST-REWRITE when attach lands. PR 3.
+- **"At most one active override per tenant", enforced here.** #660 asserts it,
+  but there is no local table to enforce against — the grant record lives in the
+  console's `0047`. This PR enforces *idempotent application*, not global
+  uniqueness. Say so rather than implying the stronger guarantee.
+- **Customer-level discounts.** Not creatable at this API version. `DeleteDiscount`
+  stays useful only for cleaning up pre-Basil legacy discounts; not this endpoint.
+
+## Global constraints
+
+- **Comment accuracy.** Run the command before writing the sentence that
+  describes it; count anything you assert a count about. Do not state a rule
+  more broadly than the code implements it.
+- Do not weaken an existing assertion. Do not touch `apps/`.
+- `go build ./...`, `go vet ./...` and `go test ./...` from
+  `services/marketplace-api`, all clean, before each commit.

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/billing/dispatch/... \
 	    ./internal/billing/migration/... \
 	    ./internal/billing/tax/... \
+	    ./internal/billing/tenantdiscount/... \
 	    ./internal/billing/trial/... \
 	    ./internal/branding/... \
 	    ./internal/breakglass/... \

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -639,6 +639,13 @@ func main() {
 	// hard-delete runner's Stripe customer deletion step.
 	var billingStripeClient *billingstripe.Client
 
+	// tenantDiscountSvc is hoisted for the same reason and one more: it is
+	// used in THREE places at two different depths — the two
+	// subscription-creation paths inside the admin-mode block (#660 T6) and
+	// the platform-admin route wiring far below it — and constructing it
+	// twice would give the fan-out and the creation hook different services.
+	var tenantDiscountSvc *tenantdiscount.Service
+
 	// wlAppCredsSvc is hoisted so both admin route registration (constructs
 	// AppCredentialsHandler + AppAddOnHandler) and the white-label lifecycle
 	// cron (constructs Advancer) share a single appcreds.Service instance.
@@ -1031,6 +1038,28 @@ func main() {
 		if cfg.StripeBillingSecretKey != "" {
 			billingStripeClient = billingstripe.New(cfg.StripeBillingSecretKey)
 			stripeAdapter = &stripeClientAdapter{c: billingStripeClient}
+
+			// #660 — the tenant-wide platform discount. Constructed HERE,
+			// before the plan-change orchestrator and the trial subscriber
+			// below, because both take it as their T6 creation hook; the
+			// platform-admin routes far below reuse this same instance.
+			//
+			// A construction failure is logged and leaves the service nil,
+			// which is a supported state everywhere it is used: the two
+			// creation paths skip the hook and the two operator routes stay
+			// unmounted. It cannot fail on the audit writer here — the
+			// emitter is unconditional — so in practice this only fires if a
+			// future dependency is added and not wired.
+			if svc, tdErr := tenantdiscount.NewService(tenantdiscount.Config{
+				DB:     conn,
+				Stripe: &tenantdiscount.StripeAdapter{C: billingStripeClient},
+				Audit:  auditEmitter,
+				Logger: log,
+			}); tdErr != nil {
+				log.Warn("tenant discount service not available", "err", tdErr)
+			} else {
+				tenantDiscountSvc = svc
+			}
 		} else {
 			log.Warn("STRIPE_BILLING_SECRET_KEY not set — subscription checkout/portal will fail")
 		}
@@ -1089,6 +1118,7 @@ func main() {
 				Emitter:          auditEmitter,
 				SubscriptionRepo: subscriptionRepo,
 				StoreRepo:        storesRepo,
+				TenantDiscount:   tenantDiscountApplier(tenantDiscountSvc),
 			})
 			changePlanHandler = admin.NewChangePlanHandler(planChangeOrch, log)
 
@@ -1188,6 +1218,9 @@ func main() {
 		var trialBillingHandler *admin.TrialBillingHandler
 		if billingStripeClient != nil {
 			trialSubscriber := trial.NewSubscriber(conn, &trial.StripeAdapter{C: billingStripeClient}, nil)
+			if tenantDiscountSvc != nil {
+				trialSubscriber = trialSubscriber.WithTenantDiscount(tenantDiscountSvc)
+			}
 			trialBillingHandler = admin.NewTrialBillingHandler(trialSubscriber, log)
 		}
 
@@ -2419,32 +2452,26 @@ func main() {
 		log.Warn("STRIPE_BILLING_SECRET_KEY not set — card-backed trials cannot be extended (409 stripe_managed)")
 	}
 
-	// tenantDiscountSvc stays a TRUE nil interface unless the service was
+	// tenantDiscounter stays a TRUE nil interface unless the service was
 	// really constructed, for the same reason trialStripe above does: a
 	// typed nil assigned into platformadmin.Deps.TenantDiscount is a
 	// non-nil interface value and would defeat Register's mount guard.
 	//
-	// Unlike trials there is no degraded mode to fall back to. Every
+	// The service itself is built up in the admin-mode block, beside the
+	// Stripe client and the two subscription-creation paths that share it
+	// (#660 T6). It is nil here when Stripe billing is unconfigured, when
+	// MODE=storefront so that block never ran, or when construction failed —
+	// and unlike trials there is no degraded mode to fall back to. Every
 	// operation this service performs IS a Stripe operation
 	// (tenantdiscount.ErrNoStripeClient), and it refuses construction
 	// without an audit writer as well (ErrNoAuditWriter), so a missing
 	// dependency leaves the two discount routes unmounted rather than
 	// mounted and answering an error.
-	var tenantDiscountSvc platformadmin.TenantDiscounter
-	if billingStripeClient != nil {
-		svc, err := tenantdiscount.NewService(tenantdiscount.Config{
-			DB:     conn,
-			Stripe: &tenantdiscount.StripeAdapter{C: billingStripeClient},
-			Audit:  auditEmitter,
-			Logger: log,
-		})
-		if err != nil {
-			log.Warn("tenant discount routes not available", "err", err)
-		} else {
-			tenantDiscountSvc = svc
-		}
+	var tenantDiscounter platformadmin.TenantDiscounter
+	if tenantDiscountSvc != nil {
+		tenantDiscounter = tenantDiscountSvc
 	} else {
-		log.Warn("STRIPE_BILLING_SECRET_KEY not set — tenant discounts cannot be applied or removed (routes unmounted)")
+		log.Warn("tenant discount service not available — tenant discounts cannot be applied or removed (routes unmounted)")
 	}
 
 	// Construct Gin engine(s) per MODE.
@@ -2512,7 +2539,7 @@ func main() {
 			Outbox:                  platformadmin.OutboxListerFunc(outbox.ListPlatform),
 			OutboxWriter:            outbox.WriterFuncs{},
 			TrialExtender:           trial.NewExtender(trialStripe),
-			TenantDiscount:          tenantDiscountSvc,
+			TenantDiscount:          tenantDiscounter,
 			TenantTeardown:          tenantTeardownClient,
 			Purger:                  tenantpurge.NewGormPurger(conn),
 			Inbox:                   inboxDep(newInboxAggregator(conn, onboardingFunnelClient, 0)),
@@ -2665,7 +2692,7 @@ func main() {
 				Outbox:                  platformadmin.OutboxListerFunc(outbox.ListPlatform),
 				OutboxWriter:            outbox.WriterFuncs{},
 				TrialExtender:           trial.NewExtender(trialStripe),
-				TenantDiscount:          tenantDiscountSvc,
+				TenantDiscount:          tenantDiscounter,
 				TenantTeardown:          tenantTeardownClient,
 				Purger:                  tenantpurge.NewGormPurger(conn),
 				Inbox:                   inboxDep(newInboxAggregator(conn, onboardingFunnelClient, 0)),
@@ -2970,4 +2997,21 @@ func (c *arbitragePrometheusCounter) IncArbitrageFalsePositiveCleared() {
 		metrics.Subscription.SubscriptionArbitrageFlaggedTotal.
 			WithLabelValues("false_positive_cleared").Inc()
 	}
+}
+
+// tenantDiscountApplier converts a possibly-nil *tenantdiscount.Service into a
+// planchange.TenantDiscountApplier that is TRULY nil when no service was
+// constructed.
+//
+// Assigning the typed nil straight into the struct field would make
+// Deps.TenantDiscount != nil true, and every initial subscription would call a
+// method on a nil receiver. That is survivable — ApplyToNewSubscription
+// returns ErrNilService and the hook swallows it — but it would log an error
+// on every subscription created without Stripe billing configured, which is
+// noise that reads like a fault.
+func tenantDiscountApplier(s *tenantdiscount.Service) planchange.TenantDiscountApplier {
+	if s == nil {
+		return nil
+	}
+	return s
 }

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -50,6 +50,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/billing/tax/revalidation"
 	"github.com/mark8ly/marketplace-api/internal/billing/tax/seaqueue"
 	"github.com/mark8ly/marketplace-api/internal/billing/tax/taxreg"
+	"github.com/mark8ly/marketplace-api/internal/billing/tenantdiscount"
 	"github.com/mark8ly/marketplace-api/internal/billing/trial"
 	"github.com/mark8ly/marketplace-api/internal/billingarchive"
 	"github.com/mark8ly/marketplace-api/internal/branding"
@@ -2418,6 +2419,34 @@ func main() {
 		log.Warn("STRIPE_BILLING_SECRET_KEY not set — card-backed trials cannot be extended (409 stripe_managed)")
 	}
 
+	// tenantDiscountSvc stays a TRUE nil interface unless the service was
+	// really constructed, for the same reason trialStripe above does: a
+	// typed nil assigned into platformadmin.Deps.TenantDiscount is a
+	// non-nil interface value and would defeat Register's mount guard.
+	//
+	// Unlike trials there is no degraded mode to fall back to. Every
+	// operation this service performs IS a Stripe operation
+	// (tenantdiscount.ErrNoStripeClient), and it refuses construction
+	// without an audit writer as well (ErrNoAuditWriter), so a missing
+	// dependency leaves the two discount routes unmounted rather than
+	// mounted and answering an error.
+	var tenantDiscountSvc platformadmin.TenantDiscounter
+	if billingStripeClient != nil {
+		svc, err := tenantdiscount.NewService(tenantdiscount.Config{
+			DB:     conn,
+			Stripe: &tenantdiscount.StripeAdapter{C: billingStripeClient},
+			Audit:  auditEmitter,
+			Logger: log,
+		})
+		if err != nil {
+			log.Warn("tenant discount routes not available", "err", err)
+		} else {
+			tenantDiscountSvc = svc
+		}
+	} else {
+		log.Warn("STRIPE_BILLING_SECRET_KEY not set — tenant discounts cannot be applied or removed (routes unmounted)")
+	}
+
 	// Construct Gin engine(s) per MODE.
 	healthHandler := health.New(conn)
 
@@ -2483,6 +2512,7 @@ func main() {
 			Outbox:                  platformadmin.OutboxListerFunc(outbox.ListPlatform),
 			OutboxWriter:            outbox.WriterFuncs{},
 			TrialExtender:           trial.NewExtender(trialStripe),
+			TenantDiscount:          tenantDiscountSvc,
 			TenantTeardown:          tenantTeardownClient,
 			Purger:                  tenantpurge.NewGormPurger(conn),
 			Inbox:                   inboxDep(newInboxAggregator(conn, onboardingFunnelClient, 0)),
@@ -2635,6 +2665,7 @@ func main() {
 				Outbox:                  platformadmin.OutboxListerFunc(outbox.ListPlatform),
 				OutboxWriter:            outbox.WriterFuncs{},
 				TrialExtender:           trial.NewExtender(trialStripe),
+				TenantDiscount:          tenantDiscountSvc,
 				TenantTeardown:          tenantTeardownClient,
 				Purger:                  tenantpurge.NewGormPurger(conn),
 				Inbox:                   inboxDep(newInboxAggregator(conn, onboardingFunnelClient, 0)),

--- a/services/marketplace-api/internal/audit/emit_tx_integration_test.go
+++ b/services/marketplace-api/internal/audit/emit_tx_integration_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+package audit_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// newRealEmitter wires the shipped gormRepository against a real handle.
+// The unit tests in emit_tx_test.go use a double, which can prove which
+// handle EmitTx passed but not what Postgres does with it — and
+// transactional visibility is the only thing these tests are about.
+func newRealEmitter(t *testing.T, db *gorm.DB) *audit.Emitter {
+	t.Helper()
+	e, err := audit.NewEmitter(audit.EmitterConfig{
+		DB:     db,
+		Repo:   audit.NewRepository(),
+		Logger: slog.Default(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { e.Stop(context.Background()) })
+	return e
+}
+
+// countAuditRowsForTenant counts audit_logs rows for one tenant through the given handle.
+// Reading through `tx` sees uncommitted work; reading through `db` does not —
+// that difference is the assertion in both tests below.
+func countAuditRowsForTenant(t *testing.T, h *gorm.DB, tenantID uuid.UUID) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, h.Model(&audit.Entry{}).Where("tenant_id = ?", tenantID).Count(&n).Error)
+	return n
+}
+
+// TestEmitTx_RowIsAbsentAfterTheCallersTransactionRollsBack is the reason
+// EmitTx exists. Emit and EmitSync both write on the Emitter's own handle, so
+// their row commits independently of whatever the caller was doing: roll the
+// business change back and the audit row claiming it happened survives.
+//
+// The in-transaction count is not decoration — without it an EmitTx that
+// wrote nothing at all would satisfy the post-rollback assertion perfectly.
+// The pair together says: the row was really written, on this transaction,
+// and died with it.
+//
+// NewDB rather than NewTx: this test manages its own transaction, and NewTx
+// hands back a handle that is already inside one.
+func TestEmitTx_RowIsAbsentAfterTheCallersTransactionRollsBack(t *testing.T) {
+	db := testdb.NewDB(t, "audit_logs")
+	e := newRealEmitter(t, db)
+	tenantID := uuid.New()
+
+	tx := db.Begin()
+	require.NoError(t, tx.Error)
+
+	require.NoError(t, e.EmitTx(context.Background(), tx, nil, audit.Event{
+		Action: "tenant.discount_applied", ResourceType: "subscription",
+		TenantID: tenantID, Metadata: map[string]any{"coupon_id": "co_123"},
+	}))
+
+	require.EqualValues(t, 1, countAuditRowsForTenant(t, tx, tenantID),
+		"the row must be visible inside the caller's transaction")
+
+	require.NoError(t, tx.Rollback().Error)
+
+	require.EqualValues(t, 0, countAuditRowsForTenant(t, db, tenantID),
+		"the audit row must roll back with the change it describes")
+}
+
+// TestEmitTx_RowSurvivesTheCallersCommit is the positive control for the
+// test above: rolling back is only meaningful if committing keeps the row.
+func TestEmitTx_RowSurvivesTheCallersCommit(t *testing.T) {
+	db := testdb.NewDB(t, "audit_logs")
+	e := newRealEmitter(t, db)
+	tenantID := uuid.New()
+
+	tx := db.Begin()
+	require.NoError(t, tx.Error)
+
+	require.NoError(t, e.EmitTx(context.Background(), tx, nil, audit.Event{
+		Action: "tenant.discount_applied", ResourceType: "subscription", TenantID: tenantID,
+	}))
+	require.NoError(t, tx.Commit().Error)
+
+	require.EqualValues(t, 1, countAuditRowsForTenant(t, db, tenantID),
+		"a committed transaction must leave its audit row behind")
+}

--- a/services/marketplace-api/internal/audit/emit_tx_test.go
+++ b/services/marketplace-api/internal/audit/emit_tx_test.go
@@ -1,0 +1,204 @@
+package audit_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+)
+
+// txRecordingRepo records the two arguments EmitTx is responsible for
+// forwarding — the *gorm.DB handle and the context.Context — alongside the
+// Entry. recordingRepo (emitter_test.go) deliberately discards both, which is
+// right for the tests that use it and useless here: every assertion below is
+// about WHICH handle and WHICH context reached the repository.
+//
+// ctxErr captures ctx.Err() at call time rather than retaining ctx, because a
+// context is only meaningfully inspectable while the call is in flight.
+type txRecordingRepo struct {
+	calls     int
+	gotDB     *gorm.DB
+	gotCtxErr error
+	created   []*audit.Entry
+	createErr error
+	// ctxErrAsCreateErr makes Create fail when the caller's context is
+	// already cancelled, the way a real driver does. Without it a
+	// forwarded-but-cancelled context is indistinguishable from a fresh one
+	// at the call site.
+	ctxErrAsCreateErr bool
+}
+
+func (r *txRecordingRepo) Create(ctx context.Context, db *gorm.DB, e *audit.Entry) error {
+	r.calls++
+	r.gotDB = db
+	r.gotCtxErr = ctx.Err()
+	if r.ctxErrAsCreateErr && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if r.createErr != nil {
+		return r.createErr
+	}
+	r.created = append(r.created, e)
+	return nil
+}
+
+func (r *txRecordingRepo) List(_ context.Context, _ *gorm.DB, _ audit.ListFilter) (audit.ListResult, error) {
+	return audit.ListResult{}, nil
+}
+
+func (r *txRecordingRepo) Stream(_ context.Context, _ *gorm.DB, _ audit.ListFilter, _ func(*audit.Entry) error) error {
+	return nil
+}
+
+func (r *txRecordingRepo) ListPlatform(_ context.Context, _ *gorm.DB, _ audit.PlatformListFilter) (audit.ListResult, error) {
+	return audit.ListResult{}, nil
+}
+
+// newTxEmitter builds an Emitter whose cfg.DB is a distinct, non-nil sentinel
+// so a test can tell "wrote on the handle I passed" apart from "fell back to
+// the emitter's own handle". The sentinel is never dereferenced:
+// txRecordingRepo only compares the pointer, and NewEmitter's doc comment
+// states the Emitter treats cfg.DB as opaque data it forwards to Repo.Create.
+func newTxEmitter(t *testing.T, repo audit.Repository) (*audit.Emitter, *gorm.DB) {
+	t.Helper()
+	emitterDB := &gorm.DB{}
+	e, err := audit.NewEmitter(audit.EmitterConfig{DB: emitterDB, Repo: repo, Logger: slog.Default()})
+	require.NoError(t, err)
+	t.Cleanup(func() { e.Stop(context.Background()) })
+	return e, emitterDB
+}
+
+// TestEmitTx_WritesOnTheSuppliedHandleNotTheEmittersOwn is the whole point of
+// EmitTx: the insert must go through the caller's transaction, so the audit
+// row and the state change it describes share a fate. Passing e.db instead
+// would produce a row that commits independently — the exact failure
+// tesserix-home#331 asks this function to prevent — and would still pass a
+// test that only asserted "a row was created".
+//
+// It also asserts the operator attribution, which is not incidental: it is
+// the evidence that EmitTx reuses buildEntry rather than assembling an Entry
+// of its own. Actor type, operator id and capability all come from there.
+func TestEmitTx_WritesOnTheSuppliedHandleNotTheEmittersOwn(t *testing.T) {
+	repo := &txRecordingRepo{}
+	e, emitterDB := newTxEmitter(t, repo)
+
+	tx := &gorm.DB{}
+	tenantID := uuid.New()
+
+	err := e.EmitTx(context.Background(), tx, ginContextWithOperator(t, "op-7", "billing.discount"), audit.Event{
+		Action: "tenant.discount_applied", ResourceType: "subscription",
+		TenantID: tenantID, Metadata: map[string]any{"coupon_id": "co_123"},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, repo.created, 1)
+	require.Same(t, tx, repo.gotDB, "EmitTx must insert on the caller's transaction handle")
+	require.NotSame(t, emitterDB, repo.gotDB, "EmitTx must not fall back to the Emitter's own handle")
+
+	require.Equal(t, tenantID, repo.created[0].TenantID)
+	require.Equal(t, audit.ActorOperator, repo.created[0].ActorType)
+	require.Equal(t, "op-7", *repo.created[0].ActorOperatorID)
+	require.Equal(t, "billing.discount", *repo.created[0].Capability)
+}
+
+// TestEmitTx_UsesTheCallersContext pins the deliberate divergence from
+// EmitSync and write(), both of which substitute a fresh
+// context.Background() with a timeout. An insert on someone else's
+// transaction must share that transaction's cancellation; substituting a
+// background context here would leave the insert running against a handle
+// whose transaction is already being torn down.
+//
+// The assertion is on ctx.Err() observed INSIDE Create: a test that merely
+// passed a live context would pass unchanged if EmitTx swapped in a
+// background one.
+func TestEmitTx_UsesTheCallersContext(t *testing.T) {
+	repo := &txRecordingRepo{ctxErrAsCreateErr: true}
+	e, _ := newTxEmitter(t, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := e.EmitTx(ctx, &gorm.DB{}, ginContextWithOperator(t, "op-7", "billing.discount"), audit.Event{
+		Action: "tenant.discount_applied", ResourceType: "subscription", TenantID: uuid.New(),
+	})
+
+	require.Equal(t, 1, repo.calls, "EmitTx must still reach the repository; the context is the caller's to cancel")
+	require.ErrorIs(t, repo.gotCtxErr, context.Canceled,
+		"the caller's cancelled context must reach Create, not a fresh context.Background()")
+	require.ErrorIs(t, err, context.Canceled, "the cancellation must be surfaced to the caller")
+}
+
+// TestEmitTx_NilTxIsRefusedWithoutFallingBackToTheEmittersDB guards the
+// quietest way to get this wrong: a caller who forgets the transaction gets a
+// non-transactional audit row that looks entirely correct in the table. An
+// error is the only outcome that surfaces the mistake.
+func TestEmitTx_NilTxIsRefusedWithoutFallingBackToTheEmittersDB(t *testing.T) {
+	repo := &txRecordingRepo{}
+	e, _ := newTxEmitter(t, repo)
+
+	err := e.EmitTx(context.Background(), nil, ginContextWithOperator(t, "op-7", "billing.discount"), audit.Event{
+		Action: "tenant.discount_applied", ResourceType: "subscription", TenantID: uuid.New(),
+	})
+
+	require.Error(t, err)
+	require.Zero(t, repo.calls, "a nil transaction must not be silently replaced by the Emitter's own handle")
+	require.Empty(t, repo.created)
+}
+
+// TestEmitTx_NilReceiverIsAnError mirrors EmitSync: the documented opt-out
+// (a nil *Emitter) must stay safe to call, but a TRANSACTIONAL audit that
+// quietly does nothing is the precise failure this function exists to
+// prevent, so the nil receiver reports rather than returns silently.
+func TestEmitTx_NilReceiverIsAnError(t *testing.T) {
+	var e *audit.Emitter
+	require.Error(t, e.EmitTx(context.Background(), &gorm.DB{}, nil,
+		audit.Event{Action: "a", ResourceType: "b", TenantID: uuid.New()}))
+}
+
+// TestEmitTx_PropagatesTheRepositoryError: the caller decides what a failed
+// audit insert means for its transaction, so the error has to reach it
+// intact. Swallowing it would commit the state change unattributed.
+func TestEmitTx_PropagatesTheRepositoryError(t *testing.T) {
+	repo := &txRecordingRepo{createErr: errors.New("boom")}
+	e, _ := newTxEmitter(t, repo)
+
+	err := e.EmitTx(context.Background(), &gorm.DB{}, ginContextWithOperator(t, "op-7", "billing.discount"),
+		audit.Event{Action: "tenant.discount_applied", ResourceType: "subscription", TenantID: uuid.New()})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "boom")
+}
+
+// TestEmitTx_MissingTenantIsAnError: buildEntry returns nil rather than write
+// a tenant-unscoped row. EmitSync turns that into an error and so must this,
+// or the caller commits its change believing it was audited.
+func TestEmitTx_MissingTenantIsAnError(t *testing.T) {
+	repo := &txRecordingRepo{}
+	e, _ := newTxEmitter(t, repo)
+
+	err := e.EmitTx(context.Background(), &gorm.DB{}, ginContextWithOperator(t, "op-7", "billing.discount"),
+		audit.Event{Action: "tenant.discount_applied", ResourceType: "subscription"}) // no TenantID
+
+	require.Error(t, err)
+	require.Empty(t, repo.created, "a tenant-less row must never be written")
+}
+
+// TestEmitTx_MissingActionOrResourceTypeIsAnError keeps the validation floor
+// level with EmitSync's; these two columns are NOT NULL and a row missing
+// either is not a usable trail entry.
+func TestEmitTx_MissingActionOrResourceTypeIsAnError(t *testing.T) {
+	repo := &txRecordingRepo{}
+	e, _ := newTxEmitter(t, repo)
+
+	require.Error(t, e.EmitTx(context.Background(), &gorm.DB{}, nil,
+		audit.Event{ResourceType: "subscription", TenantID: uuid.New()}), "missing action")
+	require.Error(t, e.EmitTx(context.Background(), &gorm.DB{}, nil,
+		audit.Event{Action: "tenant.discount_applied", TenantID: uuid.New()}), "missing resource type")
+	require.Empty(t, repo.created)
+}

--- a/services/marketplace-api/internal/audit/emitter.go
+++ b/services/marketplace-api/internal/audit/emitter.go
@@ -74,17 +74,18 @@ type EmitterConfig struct {
 // NewEmitter constructs an Emitter and starts its worker goroutines.
 // Call Stop() at process shutdown to drain the queue.
 //
-// cfg.Repo is required: it is dereferenced on every write (Emit's worker
-// and EmitSync both call repo.Create). A nil Repo returns an error instead
+// cfg.Repo is required: it is dereferenced on every write (Emit's worker,
+// EmitSync and EmitTx all call repo.Create). A nil Repo returns an error instead
 // of a broken Emitter. If auditing is intentionally disabled — e.g. in a
 // unit test — do not pass a nil Repo here; use a nil *Emitter instead
-// (var em *audit.Emitter). Every exported method (all eleven — see
+// (var em *audit.Emitter). Every exported method (all twelve — see
 // nil_repo_test.go's TestNilEmitter_AllExportedMethodsAreSafe) is
 // nil-receiver-safe, so that is the supported opt-out, not a nil Repo.
 //
 // cfg.DB may legitimately be nil: the Emitter never dereferences it
-// itself — it is opaque data forwarded to Repo.Create on each write, so
-// whether nil is safe depends on the Repository implementation (a test
+// itself — it is opaque data forwarded to Repo.Create on each write
+// except EmitTx's, which forwards the caller's transaction handle in its
+// place — so whether nil is safe depends on the Repository implementation (a test
 // double may not need it at all). Note that the shipped Repository —
 // audit.NewRepository()'s gormRepository — DOES dereference it
 // (db.WithContext(ctx).Create(e)); pairing a real Repo from
@@ -188,6 +189,63 @@ func (e *Emitter) EmitSync(c *gin.Context, ev Event) error {
 	defer cancel()
 	if err := e.repo.Create(ctx, e.db, entry); err != nil {
 		return fmt.Errorf("audit.EmitSync: insert: %w", err)
+	}
+	return nil
+}
+
+// EmitTx writes an audit row on the CALLER's transaction, so the row and
+// the state change it describes commit or roll back together. Required by
+// tesserix-home#331 for federated writes: an operator-driven change that
+// commits without its audit row is an unattributable change, and an audit
+// row that commits without its change is a false record.
+//
+// Emit and EmitSync both write on the Emitter's own handle (e.db), which
+// is a separate connection from the caller's transaction — their row
+// commits whatever the caller's transaction goes on to do. That is the
+// property EmitTx exists to remove; use it only when there is a
+// transaction to join, and Emit everywhere else.
+//
+// ctx is the CALLER's, and this deliberately contradicts both neighbours.
+// write() and EmitSync each substitute a fresh context.Background() with a
+// 5s timeout so a disconnecting client cannot cancel the record. That is
+// right for them — their write outlives the request by design — and wrong
+// here: this insert runs inside someone else's transaction and must share
+// that transaction's cancellation. Do not "fix" it back to
+// context.Background(); TestEmitTx_UsesTheCallersContext pins it.
+//
+// tx must not be nil. Falling back to e.db would hand a caller who forgot
+// their transaction a non-transactional row that looks entirely correct in
+// the table, which is the failure this function exists to prevent, so a
+// nil tx is an error instead.
+//
+// A nil *Emitter returns an error rather than the silent no-op Emit gives
+// it, for the same reason as EmitSync: a transactional audit that quietly
+// does nothing is worse than none at all.
+//
+// buildEntry is REUSED, as in EmitSync: a second derivation of actor type,
+// operator id, capability and IP would drift the moment either path gained
+// a field.
+//
+// The queue, the worker, e.wg and e.stop are untouched — EmitTx runs
+// entirely on the caller's goroutine.
+func (e *Emitter) EmitTx(ctx context.Context, tx *gorm.DB, c *gin.Context, ev Event) error {
+	if e == nil {
+		return errors.New("audit.EmitTx: nil emitter")
+	}
+	if tx == nil {
+		return errors.New("audit.EmitTx: nil tx; EmitTx must be given the caller's transaction — use EmitSync if there is no transaction to join")
+	}
+	if ev.Action == "" || ev.ResourceType == "" {
+		return errors.New("audit.EmitTx: action and resource_type are required")
+	}
+
+	entry := buildEntry(c, ev)
+	if entry == nil {
+		return errors.New("audit.EmitTx: no tenant in scope, refusing to write a tenant-unscoped row")
+	}
+
+	if err := e.repo.Create(ctx, tx, entry); err != nil {
+		return fmt.Errorf("audit.EmitTx: insert: %w", err)
 	}
 	return nil
 }

--- a/services/marketplace-api/internal/audit/nil_repo_test.go
+++ b/services/marketplace-api/internal/audit/nil_repo_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/audit"
 )
@@ -61,7 +62,7 @@ func TestNewEmitter_NilRepo_ReturnsErrorAndStartsNoWorkers(t *testing.T) {
 
 // TestNilEmitter_AllExportedMethodsAreSafe pins the documented opt-out
 // contract: a nil *Emitter is safe to call every exported method on —
-// all eleven, enumerated by grepping the PACKAGE (every "func (e
+// all twelve, enumerated by grepping the PACKAGE (every "func (e
 // *Emitter)" across every file in internal/audit), not just emitter.go.
 // A narrower enumeration is exactly how #318's follow-up review found
 // EmitCredentialAccess, EmitPromoApplied, EmitPromoCancelled,
@@ -69,7 +70,7 @@ func TestNewEmitter_NilRepo_ReturnsErrorAndStartsNoWorkers(t *testing.T) {
 // though they live outside emitter.go and share the same delegation
 // pattern.
 //
-// Emit, EmitSync and Stop guard the receiver explicitly; the other eight
+// Emit, EmitSync, EmitTx and Stop guard the receiver explicitly; the other eight
 // are safe only because they delegate to Emit without dereferencing e
 // themselves — an implementation detail nothing else currently pins. If
 // a future refactor made any of them touch e directly before calling
@@ -85,6 +86,12 @@ func TestNilEmitter_AllExportedMethodsAreSafe(t *testing.T) {
 		err := e.EmitSync(nil, audit.Event{Action: "a", ResourceType: "b", TenantID: uuid.New()})
 		require.Error(t, err, "EmitSync on a nil *Emitter must return an error, not silently succeed")
 	}, "EmitSync on a nil *Emitter must not panic")
+
+	require.NotPanics(t, func() {
+		err := e.EmitTx(context.Background(), &gorm.DB{}, nil,
+			audit.Event{Action: "a", ResourceType: "b", TenantID: uuid.New()})
+		require.Error(t, err, "EmitTx on a nil *Emitter must return an error, not silently succeed")
+	}, "EmitTx on a nil *Emitter must not panic")
 
 	require.NotPanics(t, func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/services/marketplace-api/internal/billing/stripe/coupon.go
+++ b/services/marketplace-api/internal/billing/stripe/coupon.go
@@ -125,6 +125,44 @@ func subscriptionDiscounts(ctx context.Context, c *Client, subID string) ([]*sdk
 	return s.Discounts, nil
 }
 
+// discountFromCoupon reports whether d is a discount created from couponID.
+// One definition for the three callers below, so "is our coupon on this
+// subscription" cannot come to mean different things in the add, the remove
+// and the read.
+func discountFromCoupon(d *sdk.Discount, couponID string) bool {
+	return d != nil && d.Coupon != nil && d.Coupon.ID == couponID
+}
+
+// SubscriptionHasDiscount reports whether the subscription already carries a
+// discount created from couponID.
+//
+// AddSubscriptionDiscount treats an already-attached coupon as a no-op, but it
+// reports that no-op and a real attachment identically — both return nil. A
+// caller that must tell "we applied it" from "it was already there", which the
+// tenant-discount fan-out's per-store report is, needs the question asked
+// separately. Asking it here rather than widening AddSubscriptionDiscount's
+// return leaves that helper and its three call sites in internal/promo alone.
+//
+// The answer is a snapshot: nothing stops the array changing between this read
+// and a following add, and it is not meant to. AddSubscriptionDiscount stays
+// idempotent on its own, so the worst outcome of a lost race is an outcome
+// label that reads "applied" for a coupon a concurrent call had just attached.
+func SubscriptionHasDiscount(ctx context.Context, c *Client, subID, couponID string) (bool, error) {
+	if subID == "" || couponID == "" {
+		return false, errors.New("stripe: SubscriptionHasDiscount: subscription and coupon ids are required")
+	}
+	existing, err := subscriptionDiscounts(ctx, c, subID)
+	if err != nil {
+		return false, err
+	}
+	for _, d := range existing {
+		if discountFromCoupon(d, couponID) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // reuseParams maps existing discounts to update params that reuse them.
 // The Discount arm carries a discount id already on the object; the Coupon
 // arm would mint a second discount from the same coupon instead.
@@ -181,7 +219,7 @@ func AddSubscriptionDiscount(ctx context.Context, c *Client, subID, couponID str
 		return err
 	}
 	for _, d := range existing {
-		if d != nil && d.Coupon != nil && d.Coupon.ID == couponID {
+		if discountFromCoupon(d, couponID) {
 			return nil
 		}
 	}
@@ -216,7 +254,7 @@ func RemoveSubscriptionDiscount(ctx context.Context, c *Client, subID, couponID 
 	keep := make([]*sdk.Discount, 0, len(existing))
 	found := false
 	for _, d := range existing {
-		if d != nil && d.Coupon != nil && d.Coupon.ID == couponID {
+		if discountFromCoupon(d, couponID) {
 			found = true
 			continue
 		}

--- a/services/marketplace-api/internal/billing/stripe/coupon.go
+++ b/services/marketplace-api/internal/billing/stripe/coupon.go
@@ -3,6 +3,7 @@ package stripe
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 
 	sdk "github.com/stripe/stripe-go/v82"
@@ -87,31 +88,149 @@ func GetCoupon(ctx context.Context, c *Client, id string) (*Coupon, error) {
 	return mapCoupon(cu), nil
 }
 
-// AttachCoupon attaches a Stripe Coupon to an existing Subscription by setting
-// it as the sole discount via the Discounts slice (SDK v82 pattern).
-// Idempotent: re-attaching the same coupon is a no-op on Stripe's side.
-func AttachCoupon(ctx context.Context, c *Client, subID, couponID string) error {
-	params := &sdk.SubscriptionUpdateParams{
-		Discounts: []*sdk.SubscriptionUpdateDiscountParams{
-			{Coupon: sdk.String(couponID)},
-		},
+// maxSubscriptionDiscounts is Stripe's cap on the size of a subscription's
+// discounts array. Enforced here so a full subscription is reported with its
+// id rather than as an opaque API rejection.
+const maxSubscriptionDiscounts = 20
+
+// ErrTooManyDiscounts is what a TooManyDiscountsError unwraps to, so callers
+// can branch on the condition without depending on the concrete type.
+var ErrTooManyDiscounts = errors.New("stripe: subscription discount limit reached")
+
+// TooManyDiscountsError reports a subscription that already carries Stripe's
+// maximum number of discounts, naming the subscription and the count found.
+type TooManyDiscountsError struct {
+	SubscriptionID string
+	Count          int
+}
+
+func (e *TooManyDiscountsError) Error() string {
+	return fmt.Sprintf("stripe: subscription %s already carries %d discounts (Stripe's maximum is %d)",
+		e.SubscriptionID, e.Count, maxSubscriptionDiscounts)
+}
+
+func (e *TooManyDiscountsError) Unwrap() error { return ErrTooManyDiscounts }
+
+// subscriptionDiscounts retrieves the subscription's current discounts with
+// the array expanded. Expansion is required, not an optimisation: unexpanded,
+// Stripe returns bare discount ids and the coupon behind each one — the only
+// thing our callers can match on — is not present.
+func subscriptionDiscounts(ctx context.Context, c *Client, subID string) ([]*sdk.Discount, error) {
+	params := &sdk.SubscriptionRetrieveParams{}
+	params.AddExpand("discounts")
+	s, err := c.sdk.V1Subscriptions.Retrieve(ctx, subID, params)
+	if err != nil {
+		return nil, toAPIError(err)
 	}
+	return s.Discounts, nil
+}
+
+// reuseParams maps existing discounts to update params that reuse them.
+// The Discount arm carries a discount id already on the object; the Coupon
+// arm would mint a second discount from the same coupon instead.
+func reuseParams(subID string, discounts []*sdk.Discount) ([]*sdk.SubscriptionUpdateDiscountParams, error) {
+	// Non-nil even when empty: stripe-go encodes a nil slice as nothing at
+	// all (leaving the array untouched) and a non-nil empty one as
+	// "discounts=", which is what clears it.
+	out := make([]*sdk.SubscriptionUpdateDiscountParams, 0, len(discounts)+1)
+	for _, d := range discounts {
+		if d == nil {
+			continue
+		}
+		if d.ID == "" {
+			// Writing the array back without an id we cannot name would
+			// silently drop that discount — the bug this pair replaces.
+			return nil, fmt.Errorf("stripe: subscription %s carries a discount with no id; refusing to rewrite its discounts", subID)
+		}
+		out = append(out, &sdk.SubscriptionUpdateDiscountParams{Discount: sdk.String(d.ID)})
+	}
+	return out, nil
+}
+
+// putSubscriptionDiscounts writes discounts back as the subscription's whole
+// array.
+//
+// No Idempotency-Key is set, unlike the object-creating POSTs whose key
+// generators live in client.go. A retried create must not make a second
+// object; this update is a read-modify-write whose result depends on the
+// state it just read. A key stable across calls ("this coupon on this
+// subscription") would, within Stripe's 24-hour key window, replay the
+// cached response for a re-add that follows a removal — skipping the update
+// while reporting success. Idempotency comes from the membership check
+// instead, which re-reads state on every attempt.
+func putSubscriptionDiscounts(ctx context.Context, c *Client, subID string, discounts []*sdk.SubscriptionUpdateDiscountParams) error {
+	params := &sdk.SubscriptionUpdateParams{Discounts: discounts}
 	if _, err := c.sdk.V1Subscriptions.Update(ctx, subID, params); err != nil {
 		return toAPIError(err)
 	}
 	return nil
 }
 
-// DetachCoupon removes any active coupon from a Stripe Subscription by
-// supplying an empty Discounts slice, which clears all discounts.
-func DetachCoupon(ctx context.Context, c *Client, subID string) error {
-	params := &sdk.SubscriptionUpdateParams{
-		Discounts: []*sdk.SubscriptionUpdateDiscountParams{},
+// AddSubscriptionDiscount adds couponID to a subscription's discounts,
+// preserving every discount already there — including a merchant's own promo.
+//
+// A coupon already on the subscription is a no-op, so the call is safe to
+// retry on its own.
+func AddSubscriptionDiscount(ctx context.Context, c *Client, subID, couponID string) error {
+	if subID == "" || couponID == "" {
+		return errors.New("stripe: AddSubscriptionDiscount: subscription and coupon ids are required")
 	}
-	if _, err := c.sdk.V1Subscriptions.Update(ctx, subID, params); err != nil {
-		return toAPIError(err)
+
+	existing, err := subscriptionDiscounts(ctx, c, subID)
+	if err != nil {
+		return err
 	}
-	return nil
+	for _, d := range existing {
+		if d != nil && d.Coupon != nil && d.Coupon.ID == couponID {
+			return nil
+		}
+	}
+	if len(existing) >= maxSubscriptionDiscounts {
+		return &TooManyDiscountsError{SubscriptionID: subID, Count: len(existing)}
+	}
+
+	discounts, err := reuseParams(subID, existing)
+	if err != nil {
+		return err
+	}
+	discounts = append(discounts, &sdk.SubscriptionUpdateDiscountParams{Coupon: sdk.String(couponID)})
+	return putSubscriptionDiscounts(ctx, c, subID, discounts)
+}
+
+// RemoveSubscriptionDiscount removes the discount created from couponID and
+// writes the rest of the array back untouched.
+//
+// A coupon that is not attached is a no-op — no update is sent at all — so
+// the call is safe to retry on its own. Should the same coupon somehow back
+// two of the subscription's discounts, both go.
+func RemoveSubscriptionDiscount(ctx context.Context, c *Client, subID, couponID string) error {
+	if subID == "" || couponID == "" {
+		return errors.New("stripe: RemoveSubscriptionDiscount: subscription and coupon ids are required")
+	}
+
+	existing, err := subscriptionDiscounts(ctx, c, subID)
+	if err != nil {
+		return err
+	}
+
+	keep := make([]*sdk.Discount, 0, len(existing))
+	found := false
+	for _, d := range existing {
+		if d != nil && d.Coupon != nil && d.Coupon.ID == couponID {
+			found = true
+			continue
+		}
+		keep = append(keep, d)
+	}
+	if !found {
+		return nil
+	}
+
+	discounts, err := reuseParams(subID, keep)
+	if err != nil {
+		return err
+	}
+	return putSubscriptionDiscounts(ctx, c, subID, discounts)
 }
 
 func mapCoupon(cu *sdk.Coupon) *Coupon {
@@ -143,10 +262,4 @@ func mapCoupon(cu *sdk.Coupon) *Coupon {
 // CouponIdempotencyKey returns a stable idempotency key for coupon creation.
 func CouponIdempotencyKey(promoCodeID string) string {
 	return "coupon:" + promoCodeID
-}
-
-// SubscriptionDiscountIdempotencyKey returns a stable idempotency key for
-// attaching a coupon to a subscription (§7.3 pattern B).
-func SubscriptionDiscountIdempotencyKey(subID, couponID string) string {
-	return "sub-discount:" + subID + ":" + couponID
 }

--- a/services/marketplace-api/internal/billing/stripe/coupon_test.go
+++ b/services/marketplace-api/internal/billing/stripe/coupon_test.go
@@ -1,0 +1,198 @@
+package stripe_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
+)
+
+// discountStub is one entry of an expanded `discounts` array as Stripe
+// returns it: a discount object carrying its own id and the coupon it was
+// created from.
+type discountStub struct {
+	discountID string
+	couponID   string
+}
+
+func discountsJSON(ds ...discountStub) string {
+	parts := make([]string, 0, len(ds))
+	for _, d := range ds {
+		parts = append(parts, fmt.Sprintf(
+			`{"object":"discount","id":%q,"coupon":{"id":%q,"object":"coupon","valid":true}}`,
+			d.discountID, d.couponID))
+	}
+	return "[" + strings.Join(parts, ",") + "]"
+}
+
+// subDiscountStub serves a subscription whose expanded discounts array is ds,
+// records every POST body, and returns the recorded bodies via the closure.
+// The POST response is deliberately minimal: these helpers return only an
+// error, so nothing reads the updated subscription back.
+func subDiscountStub(t *testing.T, subID string, ds ...discountStub) (*billingstripe.Client, *[]url.Values, *[]url.Values) {
+	t.Helper()
+
+	posts := &[]url.Values{}
+	gets := &[]url.Values{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/subscriptions/"+subID, r.URL.Path)
+		switch r.Method {
+		case http.MethodGet:
+			*gets = append(*gets, r.URL.Query())
+			_, _ = fmt.Fprintf(w, `{"id":%q,"status":"active","discounts":%s}`, subID, discountsJSON(ds...))
+		case http.MethodPost:
+			require.NoError(t, r.ParseForm())
+			*posts = append(*posts, r.PostForm)
+			_, _ = fmt.Fprintf(w, `{"id":%q,"status":"active"}`, subID)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := billingstripe.New("sk_test_x")
+	c.SetBaseURLForTesting(srv.URL)
+	return c, posts, gets
+}
+
+// The regression the whole read-modify-write design exists for: an operator
+// applying a platform coupon must not delete the merchant's own promo.
+func TestAddSubscriptionDiscount_PreservesAnExistingMerchantPromo(t *testing.T) {
+	c, posts, gets := subDiscountStub(t, "sub_1",
+		discountStub{discountID: "di_merchant", couponID: "coupon_merchant_promo"})
+
+	err := billingstripe.AddSubscriptionDiscount(context.Background(), c, "sub_1", "coupon_platform_override")
+	require.NoError(t, err)
+
+	require.Len(t, *gets, 1)
+	require.Equal(t, "discounts", (*gets)[0].Get("expand[0]"),
+		"the coupon behind each existing discount is only visible when discounts are expanded")
+
+	require.Len(t, *posts, 1)
+	body := (*posts)[0]
+	// The merchant's discount is preserved by its DISCOUNT id (reuse), and
+	// ours is added by its COUPON id (create). Both are present.
+	require.Equal(t, "di_merchant", body.Get("discounts[0][discount]"))
+	require.Equal(t, "coupon_platform_override", body.Get("discounts[1][coupon]"))
+	require.Empty(t, body.Get("discounts[0][coupon]"))
+	require.Empty(t, body.Get("discounts[2][coupon]"))
+}
+
+func TestAddSubscriptionDiscount_AlreadyPresentDoesNotDuplicate(t *testing.T) {
+	c, posts, _ := subDiscountStub(t, "sub_1",
+		discountStub{discountID: "di_merchant", couponID: "coupon_merchant_promo"},
+		discountStub{discountID: "di_ours", couponID: "coupon_platform_override"})
+
+	err := billingstripe.AddSubscriptionDiscount(context.Background(), c, "sub_1", "coupon_platform_override")
+	require.NoError(t, err)
+	require.Empty(t, *posts, "a coupon already on the subscription is a no-op, not a second update")
+}
+
+func TestAddSubscriptionDiscount_RefusesAtStripesTwentyDiscountCap(t *testing.T) {
+	full := make([]discountStub, 0, 20)
+	for i := range 20 {
+		full = append(full, discountStub{
+			discountID: fmt.Sprintf("di_%d", i),
+			couponID:   fmt.Sprintf("coupon_%d", i),
+		})
+	}
+	c, posts, _ := subDiscountStub(t, "sub_full", full...)
+
+	err := billingstripe.AddSubscriptionDiscount(context.Background(), c, "sub_full", "coupon_platform_override")
+	require.Error(t, err)
+	require.ErrorIs(t, err, billingstripe.ErrTooManyDiscounts)
+	require.Contains(t, err.Error(), "sub_full", "the message must say which subscription is full")
+	require.Empty(t, *posts, "the cap is refused locally, not by letting Stripe reject the update")
+}
+
+func TestRemoveSubscriptionDiscount_RemovesOnlyTheNamedCoupon(t *testing.T) {
+	c, posts, _ := subDiscountStub(t, "sub_1",
+		discountStub{discountID: "di_merchant", couponID: "coupon_merchant_promo"},
+		discountStub{discountID: "di_ours", couponID: "coupon_platform_override"},
+		discountStub{discountID: "di_other", couponID: "coupon_other"})
+
+	err := billingstripe.RemoveSubscriptionDiscount(context.Background(), c, "sub_1", "coupon_platform_override")
+	require.NoError(t, err)
+
+	require.Len(t, *posts, 1)
+	body := (*posts)[0]
+	require.Equal(t, "di_merchant", body.Get("discounts[0][discount]"))
+	require.Equal(t, "di_other", body.Get("discounts[1][discount]"))
+	require.Empty(t, body.Get("discounts[2][discount]"), "exactly the two survivors are written back")
+	require.Empty(t, body.Get("discounts[0][coupon]"))
+	require.Empty(t, body.Get("discounts[1][coupon]"))
+}
+
+func TestRemoveSubscriptionDiscount_AbsentIsNoOp(t *testing.T) {
+	c, posts, _ := subDiscountStub(t, "sub_1",
+		discountStub{discountID: "di_merchant", couponID: "coupon_merchant_promo"})
+
+	err := billingstripe.RemoveSubscriptionDiscount(context.Background(), c, "sub_1", "coupon_platform_override")
+	require.NoError(t, err)
+	require.Empty(t, *posts, "a coupon that is not attached must not provoke an update that rewrites the array")
+}
+
+func TestRemoveSubscriptionDiscount_LastDiscountClearsTheArray(t *testing.T) {
+	c, posts, _ := subDiscountStub(t, "sub_1",
+		discountStub{discountID: "di_ours", couponID: "coupon_platform_override"})
+
+	err := billingstripe.RemoveSubscriptionDiscount(context.Background(), c, "sub_1", "coupon_platform_override")
+	require.NoError(t, err)
+
+	require.Len(t, *posts, 1)
+	body := (*posts)[0]
+	// stripe-go encodes a non-nil empty slice as `discounts=`, which is how
+	// Stripe is told "no discounts" rather than "field omitted".
+	require.Equal(t, []string{""}, body["discounts"])
+}
+
+func TestSubscriptionDiscountHelpers_MapStripeErrorsThroughAPIError(t *testing.T) {
+	t.Run("retrieve failure", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Request-Id", "req_ret")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"type":"invalid_request_error","code":"resource_missing","message":"No such subscription: sub_gone"}}`))
+		}))
+		defer srv.Close()
+		c := billingstripe.New("sk_test_x")
+		c.SetBaseURLForTesting(srv.URL)
+
+		err := billingstripe.AddSubscriptionDiscount(context.Background(), c, "sub_gone", "coupon_x")
+		var apiErr *billingstripe.APIError
+		require.True(t, errors.As(err, &apiErr))
+		require.Equal(t, http.StatusNotFound, apiErr.HTTPStatus)
+		require.Equal(t, "resource_missing", apiErr.Code)
+		require.NotContains(t, err.Error(), "No such subscription")
+	})
+
+	t.Run("update failure", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				_, _ = fmt.Fprintf(w, `{"id":"sub_1","status":"active","discounts":%s}`,
+					discountsJSON(discountStub{discountID: "di_ours", couponID: "coupon_x"}))
+				return
+			}
+			w.Header().Set("Request-Id", "req_upd")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"type":"invalid_request_error","code":"coupon_expired","message":"secret detail"}}`))
+		}))
+		defer srv.Close()
+		c := billingstripe.New("sk_test_x")
+		c.SetBaseURLForTesting(srv.URL)
+
+		err := billingstripe.RemoveSubscriptionDiscount(context.Background(), c, "sub_1", "coupon_x")
+		var apiErr *billingstripe.APIError
+		require.True(t, errors.As(err, &apiErr))
+		require.Equal(t, "coupon_expired", apiErr.Code)
+		require.NotContains(t, err.Error(), "secret detail")
+	})
+}

--- a/services/marketplace-api/internal/billing/tenantdiscount/adapter.go
+++ b/services/marketplace-api/internal/billing/tenantdiscount/adapter.go
@@ -1,0 +1,28 @@
+package tenantdiscount
+
+import (
+	"context"
+
+	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
+)
+
+// StripeAdapter wraps *billingstripe.Client to satisfy StripeDiscounts.
+// Construct one per client in main.go and pass it to NewService, mirroring
+// trial.StripeAdapter (trial/subscribe.go:46).
+//
+// The three helpers it delegates to are package-level functions taking the
+// client, not methods on it, so an adapter is the only way to express them as
+// an interface — which is what keeps the fan-out testable without HTTP.
+type StripeAdapter struct{ C *billingstripe.Client }
+
+func (a *StripeAdapter) SubscriptionHasDiscount(ctx context.Context, subID, couponID string) (bool, error) {
+	return billingstripe.SubscriptionHasDiscount(ctx, a.C, subID, couponID)
+}
+
+func (a *StripeAdapter) AddSubscriptionDiscount(ctx context.Context, subID, couponID string) error {
+	return billingstripe.AddSubscriptionDiscount(ctx, a.C, subID, couponID)
+}
+
+func (a *StripeAdapter) RemoveSubscriptionDiscount(ctx context.Context, subID, couponID string) error {
+	return billingstripe.RemoveSubscriptionDiscount(ctx, a.C, subID, couponID)
+}

--- a/services/marketplace-api/internal/billing/tenantdiscount/applied_override_integration_test.go
+++ b/services/marketplace-api/internal/billing/tenantdiscount/applied_override_integration_test.go
@@ -1,0 +1,445 @@
+//go:build integration
+
+package tenantdiscount_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/billing/tenantdiscount"
+)
+
+// These tests cover migration 000132's table and the two things the service
+// does with it: record the tenant's override once before the fan-out, and read
+// it back when a subscription is created for a store that did not exist when
+// an operator pressed the button.
+
+// overrides returns every tenant_applied_discounts row for a tenant, oldest
+// first. Read through the shipped model so a column renamed in the migration
+// and not in the struct fails here rather than silently reading zero values.
+func overrides(t *testing.T, db *gorm.DB, tenantID uuid.UUID) []tenantdiscount.AppliedOverride {
+	t.Helper()
+	var rows []tenantdiscount.AppliedOverride
+	require.NoError(t, db.Where("tenant_id = ?", tenantID).Order("granted_at").Find(&rows).Error)
+	return rows
+}
+
+// liveOverride returns the tenant's single live row, failing when there is not
+// exactly one. Callers asserting "no live row" use overrides() directly.
+func liveOverride(t *testing.T, db *gorm.DB, tenantID uuid.UUID) tenantdiscount.AppliedOverride {
+	t.Helper()
+	var live []tenantdiscount.AppliedOverride
+	for _, r := range overrides(t, db, tenantID) {
+		if r.Live() {
+			live = append(live, r)
+		}
+	}
+	require.Len(t, live, 1, "expected exactly one live override for the tenant")
+	return live[0]
+}
+
+// ---------------------------------------------------------------------------
+// The record is written once, before the fan-out
+// ---------------------------------------------------------------------------
+
+// observingStripe wraps the fake and reads the override table THROUGH A
+// SEPARATE, COMMITTED HANDLE at the moment of the first Stripe call.
+//
+// This is what distinguishes "written before the fan-out" from "written after
+// it": a post-hoc count cannot tell the two apart, because both leave the same
+// row behind. The read has to happen while the fan-out is in flight.
+type observingStripe struct {
+	*fakeStripe
+	db *gorm.DB
+
+	// liveAtFirstCall is the number of live rows for the tenant observed
+	// during the first Stripe call of the fan-out.
+	liveAtFirstCall int64
+	tenantID        uuid.UUID
+	observed        bool
+}
+
+func (o *observingStripe) SubscriptionHasDiscount(ctx context.Context, subID, couponID string) (bool, error) {
+	if !o.observed {
+		o.observed = true
+		_ = o.db.Model(&tenantdiscount.AppliedOverride{}).
+			Where("tenant_id = ? AND removed_at IS NULL", o.tenantID).
+			Count(&o.liveAtFirstCall).Error
+	}
+	return o.fakeStripe.SubscriptionHasDiscount(ctx, subID, couponID)
+}
+
+func TestApply_RecordsTheOverrideBeforeTheFanOutTouchesStripe(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	seedStoreWithSubscription(t, db, tenantID, "sub_a")
+	seedStoreWithSubscription(t, db, tenantID, "sub_b")
+
+	obs := &observingStripe{fakeStripe: newFakeStripe(), db: db, tenantID: tenantID}
+	_, err := newService(t, db, obs, realEmitter(t, db)).
+		Apply(context.Background(), tenantdiscount.Input{
+			TenantID: tenantID, CouponID: couponID, Reason: "negotiated 2026 rate",
+			C: operatorContext("op_7"),
+		})
+	require.NoError(t, err)
+
+	require.True(t, obs.observed, "the fan-out must have reached Stripe at least once")
+	require.EqualValues(t, 1, obs.liveAtFirstCall,
+		"the tenant's override must already be recorded when the first store's Stripe call happens — a store created mid-fan-out has to be covered too")
+
+	live := liveOverride(t, db, tenantID)
+	require.Equal(t, couponID, live.StripeCouponID)
+	require.NotNil(t, live.GrantedBy)
+	require.Equal(t, "op_7", *live.GrantedBy)
+	require.Nil(t, live.RemovedBy)
+}
+
+// A fan-out where EVERY store fails must still leave the tenant marked as
+// holding the override: the operator retries those stores, but a store created
+// in the meantime is covered by the record regardless of how today's stores
+// fared.
+func TestApply_TheOverrideRecordSurvivesAFanOutThatFailedForEveryStore(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	a := seedStoreWithSubscription(t, db, tenantID, "sub_a")
+	b := seedStoreWithSubscription(t, db, tenantID, "sub_b")
+
+	fs := newFakeStripe()
+	fs.fail("sub_a", errStripeDown)
+	fs.fail("sub_b", errStripeDown)
+
+	res, err := newService(t, db, fs, realEmitter(t, db)).
+		Apply(context.Background(), tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})
+	require.NoError(t, err)
+
+	got := outcomes(res)
+	require.Equal(t, tenantdiscount.OutcomeFailed, got[a.StoreID].Outcome)
+	require.Equal(t, tenantdiscount.OutcomeFailed, got[b.StoreID].Outcome)
+
+	require.Equal(t, couponID, liveOverride(t, db, tenantID).StripeCouponID,
+		"the record is tenant-scoped and must not depend on the per-store outcomes")
+}
+
+// A partial failure — the ordinary case the plan is written around.
+func TestApply_TheOverrideRecordSurvivesAPartialFanOutFailure(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	ok := seedStoreWithSubscription(t, db, tenantID, "sub_a")
+	broken := seedStoreWithSubscription(t, db, tenantID, "sub_bad")
+
+	fs := newFakeStripe()
+	fs.fail("sub_bad", errStripeDown)
+
+	res, err := newService(t, db, fs, realEmitter(t, db)).
+		Apply(context.Background(), tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})
+	require.NoError(t, err)
+
+	got := outcomes(res)
+	require.Equal(t, tenantdiscount.OutcomeApplied, got[ok.StoreID].Outcome)
+	require.Equal(t, tenantdiscount.OutcomeFailed, got[broken.StoreID].Outcome)
+	require.Equal(t, couponID, liveOverride(t, db, tenantID).StripeCouponID)
+}
+
+// Re-applying the same coupon must not stack a second live row — the partial
+// unique index would refuse it, and a fan-out that a retry cannot re-run is a
+// fan-out an operator cannot correct.
+func TestApply_ReApplyingTheSameCouponKeepsOneLiveRecord(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	seedStoreWithSubscription(t, db, tenantID, "sub_a")
+
+	svc := newService(t, db, newFakeStripe(), realEmitter(t, db))
+	in := tenantdiscount.Input{TenantID: tenantID, CouponID: couponID}
+
+	_, err := svc.Apply(context.Background(), in)
+	require.NoError(t, err)
+	_, err = svc.Apply(context.Background(), in)
+	require.NoError(t, err)
+
+	require.Len(t, overrides(t, db, tenantID), 1, "the second apply must reuse the recorded row, not add one")
+}
+
+// A SECOND, different coupon is refused before anything reaches Stripe.
+// Superseding the recorded row would claim a retirement that never happened in
+// Stripe — the first coupon would stay on every subscription.
+func TestApply_RefusesASecondDifferentCouponWhileOneIsRecorded(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	seedStoreWithSubscription(t, db, tenantID, "sub_a")
+
+	fs := newFakeStripe()
+	svc := newService(t, db, fs, realEmitter(t, db))
+
+	_, err := svc.Apply(context.Background(), tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})
+	require.NoError(t, err)
+
+	_, err = svc.Apply(context.Background(), tenantdiscount.Input{TenantID: tenantID, CouponID: "co_second"})
+	require.ErrorIs(t, err, tenantdiscount.ErrOverrideAlreadyRecorded)
+	require.Contains(t, err.Error(), couponID, "the refusal must name the coupon already held")
+
+	require.Equal(t, []string{"sub_a/" + couponID}, fs.adds,
+		"the refusal must happen before any Stripe call, so nothing is half-applied")
+	require.Len(t, overrides(t, db, tenantID), 1)
+}
+
+// ---------------------------------------------------------------------------
+// Remove clears it
+// ---------------------------------------------------------------------------
+
+func TestRemove_RetiresTheRecordedOverride(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	seedStoreWithSubscription(t, db, tenantID, "sub_a")
+
+	svc := newService(t, db, newFakeStripe(), realEmitter(t, db))
+	_, err := svc.Apply(context.Background(), tenantdiscount.Input{
+		TenantID: tenantID, CouponID: couponID, C: operatorContext("op_grant")})
+	require.NoError(t, err)
+
+	_, err = svc.Remove(context.Background(), tenantdiscount.Input{
+		TenantID: tenantID, CouponID: couponID, C: operatorContext("op_revoke")})
+	require.NoError(t, err)
+
+	rows := overrides(t, db, tenantID)
+	require.Len(t, rows, 1)
+	require.False(t, rows[0].Live())
+	require.NotNil(t, rows[0].RemovedBy)
+	require.Equal(t, "op_revoke", *rows[0].RemovedBy)
+	require.NotNil(t, rows[0].RemovedAt)
+	require.False(t, rows[0].RemovedAt.Before(rows[0].GrantedAt),
+		"tenant_applied_discounts_removal_follows_grant: a removal cannot precede its grant")
+}
+
+// Retiring the row is what lets the tenant be granted a DIFFERENT override
+// later — the reason the uniqueness rule is a partial index over the live rows
+// rather than a plain UNIQUE (tenant_id).
+func TestRemove_ThenApplyingADifferentCouponIsAccepted(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	seedStoreWithSubscription(t, db, tenantID, "sub_a")
+
+	svc := newService(t, db, newFakeStripe(), realEmitter(t, db))
+	ctx := context.Background()
+
+	require.NoError(t, firstErr(svc.Apply(ctx, tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})))
+	require.NoError(t, firstErr(svc.Remove(ctx, tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})))
+	require.NoError(t, firstErr(svc.Apply(ctx, tenantdiscount.Input{TenantID: tenantID, CouponID: "co_second"})))
+
+	require.Len(t, overrides(t, db, tenantID), 2)
+	require.Equal(t, "co_second", liveOverride(t, db, tenantID).StripeCouponID)
+}
+
+// Removing an override this service never recorded is not an error: an
+// override applied before migration 000132 existed still has to be removable
+// from Stripe, and refusing here would strand those merchants discounted.
+func TestRemove_WithNoRecordedOverrideStillFansOut(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	store := seedStoreWithSubscription(t, db, tenantID, "sub_a")
+
+	fs := newFakeStripe()
+	fs.attach("sub_a", couponID)
+
+	res, err := newService(t, db, fs, realEmitter(t, db)).
+		Remove(context.Background(), tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})
+	require.NoError(t, err)
+
+	require.Equal(t, tenantdiscount.OutcomeRemoved, outcomes(res)[store.StoreID].Outcome)
+	require.Empty(t, overrides(t, db, tenantID))
+}
+
+// firstErr discards a two-value (Result, error) return down to its error, so
+// the sequences above read as the steps they are.
+func firstErr(_ tenantdiscount.Result, err error) error { return err }
+
+// ---------------------------------------------------------------------------
+// The schema's own guarantees
+// ---------------------------------------------------------------------------
+
+// The ceiling. Asserted against the database rather than the service, because
+// the service is not the only thing that could ever write here and the index
+// is what makes "which coupon does this tenant hold" have one answer.
+func TestSchema_PartialUniqueIndexRefusesASecondLiveRow(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+
+	require.NoError(t, db.Create(&tenantdiscount.AppliedOverride{
+		TenantID: tenantID, StripeCouponID: couponID}).Error)
+
+	err := db.Create(&tenantdiscount.AppliedOverride{
+		TenantID: tenantID, StripeCouponID: "co_second"}).Error
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tenant_applied_discounts_one_live_per_tenant")
+}
+
+// And the floor it is not: a retired row does not occupy the slot.
+func TestSchema_ARetiredRowDoesNotBlockANewLiveOne(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+
+	require.NoError(t, db.Create(&tenantdiscount.AppliedOverride{
+		TenantID: tenantID, StripeCouponID: couponID}).Error)
+	require.NoError(t, db.Model(&tenantdiscount.AppliedOverride{}).
+		Where("tenant_id = ?", tenantID).
+		Updates(map[string]any{"removed_by": "op_x", "removed_at": gorm.Expr("now()")}).Error)
+
+	require.NoError(t, db.Create(&tenantdiscount.AppliedOverride{
+		TenantID: tenantID, StripeCouponID: "co_second"}).Error)
+}
+
+// The removal pair is whole in BOTH directions. A removed_at with no
+// removed_by is a removal nobody is accountable for; a removed_by with no
+// removed_at is a row the partial index still counts as live, which would keep
+// handing the coupon to new stores after it was removed.
+func TestSchema_TheRemovalPairMustBeWholeInBothDirections(t *testing.T) {
+	db := newDB(t)
+
+	err := db.Exec(`INSERT INTO tenant_applied_discounts (tenant_id, stripe_coupon_id, removed_at)
+	                VALUES (?, ?, now())`, uuid.New(), couponID).Error
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tenant_applied_discounts_removal_is_whole")
+
+	err = db.Exec(`INSERT INTO tenant_applied_discounts (tenant_id, stripe_coupon_id, removed_by)
+	               VALUES (?, ?, 'op_x')`, uuid.New(), couponID).Error
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tenant_applied_discounts_removal_is_whole")
+}
+
+func TestSchema_ABlankCouponIdIsRefused(t *testing.T) {
+	db := newDB(t)
+	err := db.Create(&tenantdiscount.AppliedOverride{TenantID: uuid.New(), StripeCouponID: "   "}).Error
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tenant_applied_discounts_coupon_id_is_not_blank")
+}
+
+// ---------------------------------------------------------------------------
+// ApplyToNewSubscription — the "future stores" half
+// ---------------------------------------------------------------------------
+
+func TestApplyToNewSubscription_AppliesTheTenantsLiveOverride(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	pending := seedStoreWithSubscription(t, db, tenantID, "")
+
+	fs := newFakeStripe()
+	svc := newService(t, db, fs, realEmitter(t, db))
+
+	// The operator applies while the store is still card-less: reported
+	// pending, and the record is what carries it forward.
+	res, err := svc.Apply(context.Background(), tenantdiscount.Input{
+		TenantID: tenantID, CouponID: couponID, C: operatorContext("op_1")})
+	require.NoError(t, err)
+	require.Equal(t, tenantdiscount.OutcomePending, outcomes(res)[pending.StoreID].Outcome)
+
+	// Later, the store gets a Stripe subscription.
+	outcome, err := svc.ApplyToNewSubscription(context.Background(), tenantdiscount.NewSubscriptionInput{
+		TenantID: tenantID, StoreID: pending.StoreID, StripeSubscriptionID: "sub_new"})
+	require.NoError(t, err)
+	require.Equal(t, tenantdiscount.OutcomeApplied, outcome)
+	require.True(t, fs.has("sub_new", couponID))
+
+	require.EqualValues(t, 2, auditRowsForStore(t, db, pending.StoreID, tenantdiscount.ActionApply),
+		"the operator's pending outcome and this application are both audited")
+}
+
+// A newly created subscription for a tenant with NO override is untouched —
+// the control that stops the assertion above passing for every tenant.
+func TestApplyToNewSubscription_ATenantWithNoOverrideIsUntouched(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	storeID := seedStoreWithoutSubscription(t, db, tenantID)
+
+	fs := newFakeStripe()
+	outcome, err := newService(t, db, fs, realEmitter(t, db)).
+		ApplyToNewSubscription(context.Background(), tenantdiscount.NewSubscriptionInput{
+			TenantID: tenantID, StoreID: storeID, StripeSubscriptionID: "sub_new"})
+	require.NoError(t, err)
+	require.Equal(t, tenantdiscount.OutcomeNoOverride, outcome)
+
+	require.Empty(t, fs.reads, "no override means no Stripe call at all")
+	require.Empty(t, fs.adds)
+	require.EqualValues(t, 0, auditRowsForStore(t, db, storeID, tenantdiscount.ActionApply))
+}
+
+// A RETIRED override must not be re-applied to a new store. Without this, the
+// removal would only hold until the tenant opened another shop.
+func TestApplyToNewSubscription_ARemovedOverrideIsNotApplied(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	store := seedStoreWithSubscription(t, db, tenantID, "sub_a")
+
+	fs := newFakeStripe()
+	svc := newService(t, db, fs, realEmitter(t, db))
+	ctx := context.Background()
+	require.NoError(t, firstErr(svc.Apply(ctx, tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})))
+	require.NoError(t, firstErr(svc.Remove(ctx, tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})))
+
+	outcome, err := svc.ApplyToNewSubscription(ctx, tenantdiscount.NewSubscriptionInput{
+		TenantID: tenantID, StoreID: store.StoreID, StripeSubscriptionID: "sub_new"})
+	require.NoError(t, err)
+	require.Equal(t, tenantdiscount.OutcomeNoOverride, outcome)
+	require.False(t, fs.has("sub_new", couponID))
+}
+
+// Creation paths retry, so this has to be safe to run twice.
+func TestApplyToNewSubscription_IsIdempotent(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	store := seedStoreWithSubscription(t, db, tenantID, "sub_a")
+
+	fs := newFakeStripe()
+	svc := newService(t, db, fs, realEmitter(t, db))
+	require.NoError(t, firstErr(svc.Apply(context.Background(),
+		tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})))
+
+	in := tenantdiscount.NewSubscriptionInput{
+		TenantID: tenantID, StoreID: store.StoreID, StripeSubscriptionID: "sub_new"}
+
+	first, err := svc.ApplyToNewSubscription(context.Background(), in)
+	require.NoError(t, err)
+	require.Equal(t, tenantdiscount.OutcomeApplied, first)
+
+	second, err := svc.ApplyToNewSubscription(context.Background(), in)
+	require.NoError(t, err)
+	require.Equal(t, tenantdiscount.OutcomeAlreadyApplied, second)
+
+	require.Equal(t, []string{"sub_a/" + couponID, "sub_new/" + couponID}, fs.adds,
+		"the replay must not send a second attach")
+}
+
+// The audit row this path writes has no operator behind it, and says so.
+func TestApplyToNewSubscription_TheAuditRowRecordsASystemActorAndTheCause(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	store := seedStoreWithSubscription(t, db, tenantID, "sub_a")
+
+	svc := newService(t, db, newFakeStripe(), realEmitter(t, db))
+	require.NoError(t, firstErr(svc.Apply(context.Background(),
+		tenantdiscount.Input{TenantID: tenantID, CouponID: couponID, C: operatorContext("op_1")})))
+
+	_, err := svc.ApplyToNewSubscription(context.Background(), tenantdiscount.NewSubscriptionInput{
+		TenantID: tenantID, StoreID: store.StoreID, StripeSubscriptionID: "sub_new"})
+	require.NoError(t, err)
+
+	var row audit.Entry
+	require.NoError(t, db.Where("store_id = ? AND action = ? AND metadata->>'stripe_subscription_id' = ?",
+		store.StoreID, tenantdiscount.ActionApply, "sub_new").First(&row).Error)
+
+	require.Nil(t, row.ActorOperatorID, "no operator is behind the creation hook")
+	require.Equal(t, couponID, row.Metadata["coupon_id"])
+	require.Equal(t, string(tenantdiscount.OutcomeApplied), row.Metadata["outcome"])
+	require.Contains(t, row.Metadata["reason"], "standing platform override")
+}
+
+func TestApplyToNewSubscription_RefusesABlankSubscriptionID(t *testing.T) {
+	db := newDB(t)
+	_, err := newService(t, db, newFakeStripe(), realEmitter(t, db)).
+		ApplyToNewSubscription(context.Background(), tenantdiscount.NewSubscriptionInput{
+			TenantID: uuid.New(), StoreID: uuid.New()})
+	require.ErrorIs(t, err, tenantdiscount.ErrNoStripeSubscription)
+}

--- a/services/marketplace-api/internal/billing/tenantdiscount/doubles_test.go
+++ b/services/marketplace-api/internal/billing/tenantdiscount/doubles_test.go
@@ -1,0 +1,143 @@
+package tenantdiscount_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+)
+
+// fakeStripe is a hand-rolled stand-in for the StripeDiscounts port, matching
+// this repository's convention of stubs written per package rather than a
+// generated-mock framework (internal/billing/trial's *_test.go files do the
+// same).
+//
+// It models what Stripe actually stores — a SET of coupons per subscription —
+// rather than a call log, because "already attached" is a property of that
+// state and every test that asserts an already_applied outcome depends on the
+// double behaving idempotently the way the real helpers do.
+type fakeStripe struct {
+	mu sync.Mutex
+
+	// attached[subID] is the set of coupon ids on that subscription.
+	attached map[string]map[string]bool
+
+	// failFor[subID] makes every call for that subscription fail. One
+	// subscription failing while its siblings succeed is the per-store
+	// isolation these tests exist to pin.
+	failFor map[string]error
+
+	adds    []string // "<subID>/<couponID>", in call order
+	removes []string
+	reads   []string
+}
+
+func newFakeStripe() *fakeStripe {
+	return &fakeStripe{
+		attached: map[string]map[string]bool{},
+		failFor:  map[string]error{},
+	}
+}
+
+// attach seeds a coupon as already present, standing in for a discount the
+// subscription carried before this service ever ran — a merchant's own promo,
+// or an earlier apply that this one is retrying.
+func (f *fakeStripe) attach(subID, couponID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.set(subID)[couponID] = true
+}
+
+func (f *fakeStripe) fail(subID string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failFor[subID] = err
+}
+
+func (f *fakeStripe) has(subID, couponID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.set(subID)[couponID]
+}
+
+func (f *fakeStripe) coupons(subID string) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.set(subID)))
+	for id := range f.set(subID) {
+		out = append(out, id)
+	}
+	return out
+}
+
+// set returns the coupon set for subID, creating it on first use. Callers
+// must already hold f.mu.
+func (f *fakeStripe) set(subID string) map[string]bool {
+	if f.attached[subID] == nil {
+		f.attached[subID] = map[string]bool{}
+	}
+	return f.attached[subID]
+}
+
+func (f *fakeStripe) SubscriptionHasDiscount(_ context.Context, subID, couponID string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reads = append(f.reads, subID+"/"+couponID)
+	if err := f.failFor[subID]; err != nil {
+		return false, err
+	}
+	return f.set(subID)[couponID], nil
+}
+
+func (f *fakeStripe) AddSubscriptionDiscount(_ context.Context, subID, couponID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.adds = append(f.adds, subID+"/"+couponID)
+	if err := f.failFor[subID]; err != nil {
+		return err
+	}
+	f.set(subID)[couponID] = true
+	return nil
+}
+
+func (f *fakeStripe) RemoveSubscriptionDiscount(_ context.Context, subID, couponID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.removes = append(f.removes, subID+"/"+couponID)
+	if err := f.failFor[subID]; err != nil {
+		return err
+	}
+	delete(f.set(subID), couponID)
+	return nil
+}
+
+// errStripeDown is the failure the fake injects. It carries no meaning to the
+// service beyond "the Stripe call did not succeed".
+var errStripeDown = errors.New("stripe is down")
+
+// recordingAudit satisfies AuditWriter without a database. It is used by the
+// unit tests, which never reach a transaction.
+type recordingAudit struct {
+	mu     sync.Mutex
+	events []audit.Event
+}
+
+func (r *recordingAudit) EmitTx(_ context.Context, _ *gorm.DB, _ *gin.Context, ev audit.Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, ev)
+	return nil
+}
+
+// nilAuditWriter exists only so a TYPED nil can be assigned into the
+// AuditWriter interface. Its method is never called — the constructor must
+// refuse the value before anything can call it.
+type nilAuditWriter struct{}
+
+func (*nilAuditWriter) EmitTx(context.Context, *gorm.DB, *gin.Context, audit.Event) error {
+	panic("nilAuditWriter.EmitTx must never be called")
+}

--- a/services/marketplace-api/internal/billing/tenantdiscount/errors.go
+++ b/services/marketplace-api/internal/billing/tenantdiscount/errors.go
@@ -27,6 +27,36 @@ var (
 	ErrNoTenant = errors.New("tenantdiscount: a tenant id is required")
 	ErrNoCoupon = errors.New("tenantdiscount: a coupon id is required")
 
+	// ErrNilService: a method was called on a nil *Service. Named rather than
+	// left as an inline errors.New so ApplyToNewSubscription's caller — whose
+	// contract is to discard the error — can still be tested for it.
+	ErrNilService = errors.New("tenantdiscount: nil service")
+
+	// ErrNoStripeSubscription: ApplyToNewSubscription was handed a blank
+	// Stripe subscription id. Refused rather than treated as "nothing to do":
+	// its two callers are the paths that have just CREATED a subscription, so
+	// a blank id there is a bug in the caller and a silent no-op would hide
+	// the very gap this hook exists to close.
+	ErrNoStripeSubscription = errors.New("tenantdiscount: a stripe subscription id is required")
+
+	// ErrOverrideAlreadyRecorded: Apply was asked to put a SECOND, different
+	// coupon on a tenant that already holds a live recorded override. Refused
+	// before any Stripe call, so nothing is half-applied.
+	//
+	// The alternative — retiring the recorded row and applying the new coupon
+	// — was rejected: that retirement never happens in Stripe, so the old
+	// coupon would stay on every existing subscription while this service's
+	// record claimed it was gone. Removing the first override is a real
+	// operation with its own Stripe calls and its own audit rows, and it has
+	// to be asked for.
+	//
+	// This refusal is NOT the "at most one active override per tenant"
+	// guarantee #660 asserts. It bounds what THIS SERVICE has recorded and
+	// will act on; a coupon attached out of band — in the Stripe dashboard,
+	// or by this service before migration 000132 existed — is invisible to
+	// it, and a tenant can still be carrying one.
+	ErrOverrideAlreadyRecorded = errors.New("tenantdiscount: the tenant already holds a recorded override")
+
 	// ErrNoStores: the tenant owns no stores, so there is nothing to apply
 	// the override to. Refused rather than returned as an empty success,
 	// which would read to an operator as "done".

--- a/services/marketplace-api/internal/billing/tenantdiscount/errors.go
+++ b/services/marketplace-api/internal/billing/tenantdiscount/errors.go
@@ -1,0 +1,96 @@
+package tenantdiscount
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// Errors returned by Apply and Remove themselves — the ones that refuse the
+// whole fan-out before any store is touched. A per-store failure is NOT one of
+// these: it lives in StoreResult.Err, because one store's failure must neither
+// roll back nor block the others.
+var (
+	// ErrNoAuditWriter: constructed without an audit writer. tesserix-home#331
+	// requires the audit row be written inside the transaction that applies
+	// the change, so a Service that cannot write one has no legal behaviour —
+	// "a write endpoint that cannot be attributed should not exist".
+	ErrNoAuditWriter = errors.New("tenantdiscount: an audit writer is required")
+
+	// ErrNoStripeClient: constructed without a Stripe client. Unlike
+	// trial.Extender, where a nil Stripe field is a supported configuration
+	// that refuses card-backed trials, every operation here IS a Stripe
+	// operation; there is no local-only half to fall back to.
+	ErrNoStripeClient = errors.New("tenantdiscount: a stripe client is required")
+
+	ErrNoTenant = errors.New("tenantdiscount: a tenant id is required")
+	ErrNoCoupon = errors.New("tenantdiscount: a coupon id is required")
+
+	// ErrNoStores: the tenant owns no stores, so there is nothing to apply
+	// the override to. Refused rather than returned as an empty success,
+	// which would read to an operator as "done".
+	ErrNoStores = errors.New("tenantdiscount: tenant owns no stores")
+
+	// ErrStripeCall: Stripe was reached for and did not succeed, for ONE
+	// store. That store's transaction rolled back and nothing was written for
+	// it; its siblings are unaffected and the caller may retry.
+	ErrStripeCall = errors.New("tenantdiscount: stripe call failed")
+
+	// ErrStripeChangedAuditWriteFailed is the ONE divergence this design
+	// accepts, and it is named here rather than left to fall out of ordering.
+	//
+	// The audit row is written LAST inside the store's transaction, so if
+	// that insert (or the commit after it) fails, the transaction rolls back
+	// — and rolling back cannot undo Stripe. The subscription keeps the
+	// discount while no audit row records who applied it or why: a live
+	// billing change with no attribution, which is precisely what
+	// tesserix-home#331 exists to prevent.
+	//
+	// THE DECISION, STATED: an unattributable discount is rolled back
+	// LOCALLY — the store is reported failed, not applied — rather than kept
+	// silently by reporting success and letting the missing audit row go
+	// unnoticed. We deliberately do NOT attempt to undo the Stripe side: a
+	// compensating call is itself an unaudited billing change, it can fail
+	// too, and it would delete a discount that a concurrent, correctly
+	// audited apply may have just placed. Reconciliation is a human's, and
+	// the log line and this error carry the three ids they need — the coupon,
+	// the Stripe subscription and the Stripe customer.
+	//
+	// This is the same class as trial.ErrStripeAppliedLocalWriteFailed
+	// (trial/extend.go:83-90) and must never be reported as a routine
+	// database error.
+	ErrStripeChangedAuditWriteFailed = errors.New("tenantdiscount: the stripe discount was changed but the audit row was not written")
+)
+
+// AuditDivergenceError carries the ids a human needs to reconcile a discount
+// Stripe holds and no audit row explains. It exists for the same reason
+// trial.TrialEndNotAfterStripeError does: the sentinel says WHICH failure this
+// is, and the struct says which objects to go and look at.
+type AuditDivergenceError struct {
+	// Op is "apply" or "remove" — which direction Stripe moved in.
+	Op string
+
+	StoreID              uuid.UUID
+	CouponID             string
+	StripeSubscriptionID string
+	StripeCustomerID     string
+
+	// Cause is the audit insert's or the commit's own error.
+	Cause error
+}
+
+func (e *AuditDivergenceError) Error() string {
+	return fmt.Sprintf(
+		"%s: %s coupon %s on stripe subscription %s (customer %s, store %s): %v",
+		ErrStripeChangedAuditWriteFailed, e.Op, e.CouponID,
+		e.StripeSubscriptionID, e.StripeCustomerID, e.StoreID, e.Cause)
+}
+
+// Unwrap returns both the sentinel and the cause so errors.Is finds either.
+// A caller branching on ErrStripeChangedAuditWriteFailed gets its distinct
+// status; a caller (or a test) looking for the underlying insert failure can
+// still reach it.
+func (e *AuditDivergenceError) Unwrap() []error {
+	return []error{ErrStripeChangedAuditWriteFailed, e.Cause}
+}

--- a/services/marketplace-api/internal/billing/tenantdiscount/newsubscription.go
+++ b/services/marketplace-api/internal/billing/tenantdiscount/newsubscription.go
@@ -1,0 +1,144 @@
+package tenantdiscount
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// NewSubscriptionInput identifies a subscription that has just been created in
+// Stripe and not yet been offered the tenant's standing override.
+type NewSubscriptionInput struct {
+	TenantID uuid.UUID
+	StoreID  uuid.UUID
+
+	// StripeSubscriptionID is the subscription Stripe just created. Blank is
+	// refused: there is nothing to attach a discount to, and the caller
+	// reaching here with one has a bug worth seeing rather than a no-op.
+	StripeSubscriptionID string
+}
+
+// ApplyToNewSubscription attaches the tenant's live recorded override to a
+// subscription that has just been created, and is the half of #660 that makes
+// the grant cover FUTURE stores rather than only the ones that existed when an
+// operator pressed the button.
+//
+// # The caller must treat every error as non-fatal
+//
+// This is called from the two subscription-creation paths
+// (trial.Subscriber.subscribeInTx and
+// planchange.Orchestrator.executeInitialSubscription). A discount that cannot
+// be applied must never stop a merchant subscribing: the failure costs the
+// tenant a discount they can be given again by hand, while a refusal costs
+// them the subscription itself. Both callers log and continue, and nothing
+// here returns an error the caller is expected to act on synchronously.
+//
+// # It touches no transaction of the caller's
+//
+// Every read and write below goes through the Service's own handle, never a
+// transaction the caller passed in — deliberately, and not for tidiness. A
+// failed statement poisons a Postgres transaction: every subsequent statement
+// on it fails with "current transaction is aborted". Writing the audit row on
+// the caller's transaction would therefore turn an audit failure into a failed
+// subscription creation, which is exactly the outcome "non-fatal" forbids.
+//
+// The cost is stated plainly: the audit row here is NOT bound to the
+// transaction that created the subscription, unlike the one Apply writes. If
+// the caller's transaction rolls back after this returns, a row records a
+// discount applied to a subscription whose local row never landed. The Stripe
+// subscription itself is in the same position — CreateSubscription is not
+// rolled back either — so the audit row describes the state Stripe is really
+// in, which is the more useful of the two.
+//
+// # Idempotency
+//
+// Creation paths retry. A coupon already on the subscription reports
+// OutcomeAlreadyApplied and sends nothing, exactly as Apply does.
+func (s *Service) ApplyToNewSubscription(ctx context.Context, in NewSubscriptionInput) (Outcome, error) {
+	if s == nil {
+		return "", ErrNilService
+	}
+	if in.TenantID == uuid.Nil {
+		return "", ErrNoTenant
+	}
+	if in.StripeSubscriptionID == "" {
+		return "", ErrNoStripeSubscription
+	}
+
+	live, err := loadLiveOverride(ctx, s.db, in.TenantID)
+	if err != nil {
+		return "", err
+	}
+	if live == nil {
+		// The common case by a wide margin: most tenants hold no override.
+		// Reported under its own name rather than as "already applied" so a
+		// caller's log can tell "nothing to do" from "already done".
+		return OutcomeNoOverride, nil
+	}
+
+	sctx, cancel := context.WithTimeout(ctx, stripeCallTimeout)
+	defer cancel()
+
+	outcome, err := applyOp.run(sctx, s.stripe, in.StripeSubscriptionID, live.StripeCouponID)
+	if err != nil {
+		return "", fmt.Errorf("%w: apply coupon %s on subscription %s: %w",
+			ErrStripeCall, live.StripeCouponID, in.StripeSubscriptionID, err)
+	}
+
+	res := StoreResult{
+		StoreID:              in.StoreID,
+		StripeSubscriptionID: in.StripeSubscriptionID,
+		Outcome:              outcome,
+	}
+	auditErr := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return s.writeAudit(ctx, tx, Input{
+			TenantID: in.TenantID,
+			CouponID: live.StripeCouponID,
+			Reason:   reasonSubscriptionCreated,
+		}, applyOp, res)
+	})
+	if auditErr == nil {
+		return outcome, nil
+	}
+
+	if !res.Changed() {
+		// Nothing was sent to Stripe, so this is an ordinary write failure,
+		// not the divergence. The outcome is still returned: the coupon is on
+		// the subscription, which is what the caller asked about.
+		return outcome, fmt.Errorf("tenantdiscount: write audit row for new subscription %s: %w",
+			in.StripeSubscriptionID, auditErr)
+	}
+
+	// Stripe was changed and no audit row records it — the same divergence
+	// ErrStripeChangedAuditWriteFailed names on the operator path, reached
+	// here without an operator to report it to. Logged with the ids a human
+	// needs, because the returned error goes to a caller whose contract is to
+	// discard it.
+	//
+	// StripeCustomerID is absent from both the error and the log line: this
+	// path is handed a subscription id by its caller and never reads the
+	// local subscription row, so it does not know the customer. The
+	// subscription id resolves to it in Stripe.
+	div := &AuditDivergenceError{
+		Op:                   applyOp.name,
+		StoreID:              in.StoreID,
+		CouponID:             live.StripeCouponID,
+		StripeSubscriptionID: in.StripeSubscriptionID,
+		Cause:                auditErr,
+	}
+	s.logger.Error("tenantdiscount: standing override applied to a new subscription but the audit row was not written",
+		"coupon_id", live.StripeCouponID,
+		"stripe_subscription_id", in.StripeSubscriptionID,
+		"store_id", in.StoreID.String(),
+		"tenant_id", in.TenantID.String(),
+		"err", auditErr)
+	return outcome, div
+}
+
+// reasonSubscriptionCreated is the reason recorded on an audit row this path
+// writes. The operator endpoint makes a reason mandatory and passes the
+// operator's own words; there is no operator here, so the row states what
+// caused the application instead of leaving the field empty.
+const reasonSubscriptionCreated = "the tenant's standing platform override, applied when this subscription was created"

--- a/services/marketplace-api/internal/billing/tenantdiscount/outcome.go
+++ b/services/marketplace-api/internal/billing/tenantdiscount/outcome.go
@@ -30,9 +30,22 @@ const (
 	// OutcomePending — the store's subscription row exists but its
 	// stripe_subscription_id is NULL, so there is no Stripe subscription to
 	// carry a discount. That is the card-less trialing tenant, which is
-	// exactly the population an operator discounts. For Apply the override
-	// is recorded and will be applied when the subscription is created
-	// (T6); for Remove there is nothing attached to take off.
+	// exactly the population an operator discounts. For Remove there is
+	// nothing attached to take off.
+	//
+	// NOTHING PICKS THIS UP LATER, AND THAT IS THE HONEST STATE TODAY.
+	// "Pending" names what did not happen; it is not a queue. This service
+	// holds NO record of a tenant's override — the grant lives in the
+	// console's `tenant_pricing_override_coupons` (tesserix-home 0047), which
+	// this service cannot read — so when the subscription is later created
+	// there is nothing here to consult and the discount is not applied. The
+	// operator has to apply it again once the tenant has a subscription.
+	//
+	// Closing that gap needs a decision recorded on mark8ly#660: a local
+	// applied-override table, the console re-driving the apply, or a
+	// tenant-scoped console read. Until one lands, do not write code that
+	// assumes this outcome is durable, and do not soften this comment — a
+	// caller told the override is "recorded" would stop re-applying it.
 	OutcomePending Outcome = "pending"
 
 	// OutcomeNoSubscription — the store has no store_subscriptions row at

--- a/services/marketplace-api/internal/billing/tenantdiscount/outcome.go
+++ b/services/marketplace-api/internal/billing/tenantdiscount/outcome.go
@@ -14,9 +14,12 @@ const (
 	OutcomeApplied Outcome = "applied"
 
 	// OutcomeAlreadyApplied — the coupon was already on the subscription, so
-	// nothing was sent. This is idempotent APPLICATION, and it is not the
-	// "at most one active override per tenant" guarantee #660 asserts: there
-	// is no local grant table here to enforce that against.
+	// nothing was sent. This is idempotent APPLICATION, and it is still not
+	// the "at most one active override per tenant" guarantee #660 asserts.
+	// Migration 000132 added a local record of what THIS SERVICE applied, and
+	// ErrOverrideAlreadyRecorded refuses a second recorded override — but
+	// neither can see a coupon attached out of band, so neither can answer
+	// what a Stripe customer is really carrying.
 	OutcomeAlreadyApplied Outcome = "already_applied"
 
 	// OutcomeRemoved — the coupon was on the subscription and this call took
@@ -33,20 +36,49 @@ const (
 	// exactly the population an operator discounts. For Remove there is
 	// nothing attached to take off.
 	//
-	// NOTHING PICKS THIS UP LATER, AND THAT IS THE HONEST STATE TODAY.
-	// "Pending" names what did not happen; it is not a queue. This service
-	// holds NO record of a tenant's override — the grant lives in the
-	// console's `tenant_pricing_override_coupons` (tesserix-home 0047), which
-	// this service cannot read — so when the subscription is later created
-	// there is nothing here to consult and the discount is not applied. The
-	// operator has to apply it again once the tenant has a subscription.
+	// "Pending" still names what did not happen in THIS call — it is not a
+	// queue, and nothing retries it. What changed with migration 000132 is
+	// that the store no longer has to be re-applied by hand: the SAME Apply
+	// that reported this outcome first wrote the tenant's override to
+	// tenant_applied_discounts, and the two places this service creates a
+	// Stripe subscription (trial.Subscriber.subscribeInTx and
+	// planchange.Orchestrator.executeInitialSubscription) read that record
+	// and attach the coupon to the subscription they create. A store reported
+	// pending is picked up when one of those two creates its subscription,
+	// not before — and NOT when the subscription is created by hosted Stripe
+	// Checkout, which this service only learns about from a webhook. See the
+	// migration 000132 header.
 	//
-	// Closing that gap needs a decision recorded on mark8ly#660: a local
-	// applied-override table, the console re-driving the apply, or a
-	// tenant-scoped console read. Until one lands, do not write code that
-	// assumes this outcome is durable, and do not soften this comment — a
-	// caller told the override is "recorded" would stop re-applying it.
+	// BE EXACT ABOUT WHAT IS DURABLE. What is durable is THIS SERVICE'S
+	// RECORD OF WHAT IT APPLIED, and only for a tenant an Apply reached. What
+	// is NOT:
+	//
+	//   - the grant itself, which lives in the console's
+	//     `tenant_pricing_override_coupons` (tesserix-home 0047) and is still
+	//     unreadable from here. A grant the console minted and never
+	//     successfully sent to this service leaves nothing behind, and a
+	//     store created afterwards gets no discount;
+	//
+	//   - the reverse: a console-side retirement that never reaches this
+	//     service leaves our record live, and new stores keep receiving a
+	//     coupon the console believes it withdrew;
+	//
+	//   - anything about a coupon attached out of band. Only what this
+	//     service applied through Apply — or through the creation hook — is
+	//     recorded.
+	//
+	// The application to the new subscription is also NON-FATAL by design: it
+	// is never allowed to block a subscription being created, so it can fail
+	// and be logged, leaving the store undiscounted with the tenant's record
+	// still live.
 	OutcomePending Outcome = "pending"
+
+	// OutcomeNoOverride — the tenant holds no live recorded override, so
+	// there was nothing to apply. Produced ONLY by ApplyToNewSubscription,
+	// never by the Apply/Remove fan-out, which is always called with an
+	// explicit coupon. It is the ordinary case on the subscription-creation
+	// path: most tenants have no override at all.
+	OutcomeNoOverride Outcome = "no_override"
 
 	// OutcomeNoSubscription — the store has no store_subscriptions row at
 	// all. Nothing to lock and nothing to bill; reported rather than skipped.

--- a/services/marketplace-api/internal/billing/tenantdiscount/outcome.go
+++ b/services/marketplace-api/internal/billing/tenantdiscount/outcome.go
@@ -1,0 +1,116 @@
+package tenantdiscount
+
+import "github.com/google/uuid"
+
+// Outcome is what happened to ONE store. Every store the tenant owns gets
+// one, including the stores where nothing happened: the plan's rule is that a
+// store with no subscription is an explicit outcome, never a silent skip, and
+// an outcome set that only names successes cannot express that.
+type Outcome string
+
+const (
+	// OutcomeApplied — the coupon was not on the subscription and this call
+	// attached it. This is the only Apply outcome that changed Stripe.
+	OutcomeApplied Outcome = "applied"
+
+	// OutcomeAlreadyApplied — the coupon was already on the subscription, so
+	// nothing was sent. This is idempotent APPLICATION, and it is not the
+	// "at most one active override per tenant" guarantee #660 asserts: there
+	// is no local grant table here to enforce that against.
+	OutcomeAlreadyApplied Outcome = "already_applied"
+
+	// OutcomeRemoved — the coupon was on the subscription and this call took
+	// it off. The only Remove outcome that changed Stripe.
+	OutcomeRemoved Outcome = "removed"
+
+	// OutcomeNotApplied — Remove found the coupon was not attached, so no
+	// update was sent.
+	OutcomeNotApplied Outcome = "not_applied"
+
+	// OutcomePending — the store's subscription row exists but its
+	// stripe_subscription_id is NULL, so there is no Stripe subscription to
+	// carry a discount. That is the card-less trialing tenant, which is
+	// exactly the population an operator discounts. For Apply the override
+	// is recorded and will be applied when the subscription is created
+	// (T6); for Remove there is nothing attached to take off.
+	OutcomePending Outcome = "pending"
+
+	// OutcomeNoSubscription — the store has no store_subscriptions row at
+	// all. Nothing to lock and nothing to bill; reported rather than skipped.
+	OutcomeNoSubscription Outcome = "no_subscription"
+
+	// OutcomeNoStripeCustomer — the subscription row exists but its
+	// stripe_customer_id is empty, which is an incompletely provisioned row
+	// rather than a normal state. Guarded like
+	// internal/billing/appaddon/handler.go:133 guards it, and checked BEFORE
+	// the pending check: a card-less trial does have a customer, so a row
+	// missing one is an anomaly worth surfacing under its own name rather
+	// than filing under "pending" where it would look routine.
+	OutcomeNoStripeCustomer Outcome = "no_stripe_customer"
+
+	// OutcomeFailed — this store's transaction rolled back. StoreResult.Err
+	// and StoreResult.FailureCode say why.
+	OutcomeFailed Outcome = "failed"
+)
+
+// FailureCode names the stage a failed store failed at, so a caller can build
+// a distinct error code per stage without matching on driver text.
+type FailureCode string
+
+const (
+	// FailureLoadSubscription — the locking read of store_subscriptions
+	// failed for a reason other than "no row".
+	FailureLoadSubscription FailureCode = "load_subscription_failed"
+
+	// FailureStripeCall — Stripe was reached for and did not succeed.
+	// Nothing was written for this store; the caller may retry.
+	FailureStripeCall FailureCode = "stripe_call_failed"
+
+	// FailureAuditWrite — the EmitTx insert failed. When Stripe had already
+	// been changed, this is the divergence: see
+	// ErrStripeChangedAuditWriteFailed.
+	FailureAuditWrite FailureCode = "audit_write_failed"
+
+	// FailureCommit — the closure succeeded and the COMMIT did not. Treated
+	// as the same class as FailureAuditWrite when Stripe had been changed,
+	// because the audit row is the only thing the transaction carried.
+	FailureCommit FailureCode = "commit_failed"
+)
+
+// StoreResult is one store's line in the report.
+type StoreResult struct {
+	StoreID uuid.UUID
+
+	// SubscriptionID is the local store_subscriptions row id, or uuid.Nil
+	// when the store has none (OutcomeNoSubscription).
+	SubscriptionID uuid.UUID
+
+	// StripeCustomerID and StripeSubscriptionID are read from the local row.
+	// StripeSubscriptionID is "" for a card-less trial (OutcomePending), and
+	// both are "" when there is no row at all.
+	StripeCustomerID     string
+	StripeSubscriptionID string
+
+	Outcome Outcome
+
+	// Err and FailureCode are populated only when Outcome is OutcomeFailed.
+	// Err carries the wrapped cause and the sentinel, if any, that names it.
+	Err         error
+	FailureCode FailureCode
+}
+
+// Changed reports whether this store's Stripe subscription was actually
+// modified by the call. Used to decide whether a later failure is the
+// unattributable-discount divergence or an ordinary one.
+func (r StoreResult) Changed() bool {
+	return r.Outcome == OutcomeApplied || r.Outcome == OutcomeRemoved
+}
+
+// Result is the whole fan-out: one line per store the tenant owns, in a
+// deterministic order (stores.id ascending) so two runs of the same request
+// read the same way.
+type Result struct {
+	TenantID uuid.UUID
+	CouponID string
+	Stores   []StoreResult
+}

--- a/services/marketplace-api/internal/billing/tenantdiscount/record.go
+++ b/services/marketplace-api/internal/billing/tenantdiscount/record.go
@@ -1,0 +1,182 @@
+package tenantdiscount
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// AppliedOverride is the GORM model for tenant_applied_discounts
+// (migration 000132): the record of what THIS SERVICE applied for a tenant.
+//
+// It is not the grant. The console's tenant_pricing_override_coupons
+// (tesserix-home 0047) records who granted what and why, and this service
+// cannot read it. What a live row here says, and all it says, is: this service
+// attached this coupon for this tenant, and has not since been told to stop.
+// A console-side retirement that never reaches mark8ly leaves this row live —
+// a known, accepted limitation of duplicating a fact another service owns,
+// stated at length in the migration header.
+type AppliedOverride struct {
+	ID       uuid.UUID `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()"`
+	TenantID uuid.UUID `gorm:"column:tenant_id;type:uuid;not null"`
+
+	// StripeCouponID is the `co_…` this service applied. Never blank — the
+	// service trims and refuses a blank coupon id, and
+	// tenant_applied_discounts_coupon_id_is_not_blank is the second line.
+	StripeCouponID string `gorm:"column:stripe_coupon_id;type:text;not null"`
+
+	// GrantedBy is the platform operator who applied it, or nil when no
+	// operator was behind the write — which is the subscription-creation
+	// hook, running with no request. nil means "this service, on its own
+	// behalf"; it never means "unknown operator".
+	GrantedBy *string   `gorm:"column:granted_by;type:text"`
+	GrantedAt time.Time `gorm:"column:granted_at;not null;default:now()"`
+
+	// RemovedBy and RemovedAt are the retirement pair. Both nil is a live
+	// row; both set is a retired one, and the database's
+	// tenant_applied_discounts_removal_is_whole rejects any other
+	// combination — so a retired row always names someone, even when that
+	// someone is systemActor.
+	RemovedBy *string    `gorm:"column:removed_by;type:text"`
+	RemovedAt *time.Time `gorm:"column:removed_at"`
+}
+
+// TableName returns the database table name for GORM.
+func (AppliedOverride) TableName() string { return "tenant_applied_discounts" }
+
+// Live reports whether this row records an override that is still in force as
+// far as this service knows.
+func (o AppliedOverride) Live() bool { return o.RemovedAt == nil }
+
+// systemActor is written to removed_by when a removal has no operator behind
+// it. granted_by is left NULL in the same situation, and the asymmetry is the
+// database's doing rather than a choice: the removal pair must be whole, so a
+// retired row cannot leave removed_by NULL, while a live row's granted_by has
+// no such constraint to satisfy.
+//
+// Production removals always have an operator — Remove is reached only through
+// the platform-admin endpoint, whose middleware sets platform_operator_id — so
+// this value is a fallback, not the normal case.
+const systemActor = "system"
+
+// loadLiveOverride returns the tenant's live override row, or nil when the
+// tenant holds none.
+//
+// It can return at most one row without choosing between candidates, and that
+// is the database's guarantee rather than this query's: the partial unique
+// index tenant_applied_discounts_one_live_per_tenant permits exactly one row
+// per tenant with removed_at IS NULL.
+func loadLiveOverride(ctx context.Context, db *gorm.DB, tenantID uuid.UUID) (*AppliedOverride, error) {
+	var row AppliedOverride
+	err := db.WithContext(ctx).
+		Where("tenant_id = ? AND removed_at IS NULL", tenantID).
+		First(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("tenantdiscount: load live override for tenant %s: %w", tenantID, err)
+	}
+	return &row, nil
+}
+
+// recordApplied writes the tenant's override row, and is called ONCE per
+// Apply, BEFORE the per-store fan-out.
+//
+// Before, and not after, because the record is what makes a store created
+// LATER receive the discount. A fan-out that failed for every store still
+// leaves the tenant correctly marked as holding an override — those stores are
+// reported failed and the operator retries, but a store provisioned in the
+// meantime is covered either way. Writing it afterwards, or only on success,
+// would make "the tenant holds an override" depend on how many of today's
+// stores Stripe happened to accept.
+//
+// Re-applying the SAME coupon is a no-op: this is the ceiling on double
+// application. Applying a DIFFERENT coupon while one is live is refused with
+// ErrOverrideAlreadyRecorded rather than superseded, because superseding would
+// write a removal that never happened in Stripe — the old coupon would stay on
+// every subscription while this table claimed it was retired.
+func (s *Service) recordApplied(ctx context.Context, in Input) error {
+	live, err := loadLiveOverride(ctx, s.db, in.TenantID)
+	if err != nil {
+		return err
+	}
+	if live != nil {
+		if live.StripeCouponID == in.CouponID {
+			return nil
+		}
+		return fmt.Errorf("%w: tenant %s already holds coupon %s (recorded %s); remove it before applying %s",
+			ErrOverrideAlreadyRecorded, in.TenantID, live.StripeCouponID,
+			live.GrantedAt.UTC().Format(time.RFC3339), in.CouponID)
+	}
+
+	row := AppliedOverride{
+		TenantID:       in.TenantID,
+		StripeCouponID: in.CouponID,
+		GrantedBy:      operatorID(in.C),
+	}
+	// A concurrent Apply for the same tenant loses this insert to the partial
+	// unique index rather than producing a second live row. The loser's whole
+	// fan-out is refused, which is the safe direction: no Stripe call has been
+	// made yet at this point.
+	if err := s.db.WithContext(ctx).Create(&row).Error; err != nil {
+		return fmt.Errorf("tenantdiscount: record applied override for tenant %s: %w", in.TenantID, err)
+	}
+	return nil
+}
+
+// recordRemoved retires the tenant's live row for this coupon, and is called
+// ONCE per Remove, BEFORE the per-store fan-out — the mirror of
+// recordApplied's ordering and for the mirror reason: once the operator has
+// said "stop", a store created while the fan-out is still running must not be
+// given the coupon.
+//
+// A tenant with no live row for this coupon is not an error. An override
+// applied before this table existed, or one whose record was never written,
+// still has to be removable from Stripe; refusing here would leave those
+// merchants discounted with no way to stop it.
+func (s *Service) recordRemoved(ctx context.Context, in Input) error {
+	by := systemActor
+	if op := operatorID(in.C); op != nil {
+		by = *op
+	}
+
+	// now() and not a Go timestamp: granted_at defaults to the DATABASE
+	// clock, and tenant_applied_discounts_removal_follows_grant compares the
+	// two. Sending the application server's clock would let ordinary skew
+	// reject a legitimate removal.
+	err := s.db.WithContext(ctx).Model(&AppliedOverride{}).
+		Where("tenant_id = ? AND stripe_coupon_id = ? AND removed_at IS NULL", in.TenantID, in.CouponID).
+		Updates(map[string]any{
+			"removed_by": by,
+			"removed_at": gorm.Expr("now()"),
+		}).Error
+	if err != nil {
+		return fmt.Errorf("tenantdiscount: retire applied override for tenant %s: %w", in.TenantID, err)
+	}
+	return nil
+}
+
+// operatorID pulls the platform operator id off the request context, or
+// returns nil when there is no request or no operator on it.
+//
+// The literal "platform_operator_id" is the same key audit's buildEntry reads
+// (internal/audit/emitter.go), duplicated here for the same reason audit
+// duplicates it rather than importing platformadmin: that package is an HTTP
+// handler package. Keep both sides greppable if it changes.
+func operatorID(c *gin.Context) *string {
+	if c == nil {
+		return nil
+	}
+	id := strings.TrimSpace(c.GetString("platform_operator_id"))
+	if id == "" {
+		return nil
+	}
+	return &id
+}

--- a/services/marketplace-api/internal/billing/tenantdiscount/service.go
+++ b/services/marketplace-api/internal/billing/tenantdiscount/service.go
@@ -1,0 +1,441 @@
+// Package tenantdiscount applies and removes a console-minted Stripe coupon
+// across every store a tenant owns.
+//
+// The console mints the coupon and records the grant (tesserix-home#331,
+// migration 0047); it cannot apply it, because the Stripe customer lives here.
+// This package is the domain half of that: given a tenant and a coupon id, put
+// the coupon on — or take it off — each of that tenant's store subscriptions,
+// and report what happened to each one.
+//
+// # Why the fan-out is per store and not per tenant
+//
+// store_subscriptions is UNIQUE (store_id) with a separate tenant_id
+// (migration 000015), so a tenant with several stores has several
+// subscriptions and several Stripe customers. #660 says "the tenant's
+// subscription customer", singular; it is not. The grant is a standing
+// property of the TENANT, so it fans out over all of the tenant's stores.
+//
+// # Why each store gets its own transaction
+//
+// trial/extend.go puts the Stripe call INSIDE the transaction, holding
+// SELECT ... FOR UPDATE on the subscription row across the network call and
+// bounding it with a timeout. Its reasoning (extend.go:270-280) is that Stripe
+// must move first and be the source of truth: a Stripe failure rolls back and
+// writes nothing locally, while a failure AFTER Stripe leaves Stripe ahead,
+// which is the safe direction.
+//
+// This package follows that, but PER STORE. One transaction spanning N stores
+// would hold N row locks across N Stripe round-trips, and one store's failure
+// would roll back the rest. trial/extend.go never faced this because it is
+// single-store. Each store here gets its own transaction, so one store's
+// failure neither rolls back nor blocks the others, and the per-store report
+// is the honest unit.
+package tenantdiscount
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// Audit actions this package writes. Exported because the handler's tests and
+// the console's audit filters both name them, and a literal duplicated in
+// three places drifts.
+//
+// Present tense, deliberately, against the past-tense convention of
+// "order.cancelled" and "subscription.plan_changed": those rows are only ever
+// written when the thing happened. A row here is written for every store
+// including the ones where nothing was applied — pending, no_subscription —
+// so "applied" would be a false record. What happened is in
+// metadata.outcome.
+const (
+	ActionApply  = "billing.tenant_discount.apply"
+	ActionRemove = "billing.tenant_discount.remove"
+)
+
+// resourceType is the audit row's resource_type. The resource is the store's
+// subscription; the row's resource_id is the store id, matching how the
+// subscription events in internal/audit already identify one.
+const resourceType = "subscription"
+
+// stripeCallTimeout bounds how long a store_subscriptions row lock is held
+// across the external call. Mirrors trial/extend.go:139 — the lock is
+// deliberate (it removes the window in which the row could change while
+// Stripe is in flight) and this ceiling keeps "deliberate" from becoming
+// "indefinite". Per store: the locks are never held concurrently, so the
+// ceiling is per round-trip, not per fan-out.
+const stripeCallTimeout = 10 * time.Second
+
+// StripeDiscounts is the subset of Stripe this package needs, declared here
+// rather than imported as a concrete type so the fan-out can be tested without
+// a live Stripe and so the dependency points inward. StripeAdapter implements
+// it over *billingstripe.Client.
+type StripeDiscounts interface {
+	// SubscriptionHasDiscount reports whether the coupon is already on the
+	// subscription. Asked separately because Add reports "attached it" and
+	// "it was already there" identically, and those are different outcomes
+	// in the report.
+	SubscriptionHasDiscount(ctx context.Context, subID, couponID string) (bool, error)
+
+	// AddSubscriptionDiscount attaches the coupon, preserving every discount
+	// already on the subscription — including a merchant's own promo.
+	AddSubscriptionDiscount(ctx context.Context, subID, couponID string) error
+
+	// RemoveSubscriptionDiscount removes the discount created from the coupon
+	// and leaves the rest of the array untouched.
+	RemoveSubscriptionDiscount(ctx context.Context, subID, couponID string) error
+}
+
+// AuditWriter is the audit surface this package needs: an insert that joins
+// the CALLER's transaction. *audit.Emitter satisfies it. Nothing here may use
+// Emit or EmitSync — both write on the emitter's own handle, so their row
+// commits whatever this transaction goes on to do, which is the property
+// EmitTx exists to remove.
+type AuditWriter interface {
+	EmitTx(ctx context.Context, tx *gorm.DB, c *gin.Context, ev audit.Event) error
+}
+
+// Config groups Service construction params.
+type Config struct {
+	DB     *gorm.DB
+	Stripe StripeDiscounts
+	Audit  AuditWriter
+	Logger *slog.Logger
+}
+
+// Service applies and removes a tenant-wide discount.
+type Service struct {
+	db     *gorm.DB
+	stripe StripeDiscounts
+	audit  AuditWriter
+	logger *slog.Logger
+}
+
+// NewService constructs a Service, refusing a build that could not do its job.
+//
+// A TYPED nil — a nil *audit.Emitter or a nil *StripeAdapter assigned into the
+// interface — is a non-nil interface value, so a plain `!= nil` check would
+// pass it and the first method call would run inside an open transaction
+// holding a row lock. trial.NewExtender guards the same shape
+// (trial/extend.go:198) by normalising it to nil, because there a nil Stripe
+// client is a supported configuration. Here neither dependency is optional, so
+// the typed nil is normalised and then REFUSED.
+func NewService(cfg Config) (*Service, error) {
+	if isNilValue(cfg.Audit) {
+		return nil, ErrNoAuditWriter
+	}
+	if isNilValue(cfg.Stripe) {
+		return nil, ErrNoStripeClient
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	return &Service{db: cfg.DB, stripe: cfg.Stripe, audit: cfg.Audit, logger: cfg.Logger}, nil
+}
+
+// isNilValue reports whether v is nil, including a nil pointer wrapped in a
+// non-nil interface.
+func isNilValue(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	return rv.Kind() == reflect.Ptr && rv.IsNil()
+}
+
+// Input is one operator request. The same shape serves Apply and Remove.
+type Input struct {
+	TenantID uuid.UUID
+	CouponID string
+
+	// Reason is the operator's stated reason, recorded in every audit row
+	// this call writes. The handler is responsible for making it mandatory
+	// and for truncating it before it reaches here.
+	Reason string
+
+	// C is the operator's request context, forwarded to audit.EmitTx so
+	// buildEntry can derive the operator id, capability and IP. It may be
+	// nil — a background caller (T6's subscription-creation hook) has no
+	// request — in which case the row records a system actor.
+	C *gin.Context
+}
+
+// Apply puts the coupon on every store subscription the tenant owns.
+//
+// The returned error refuses the WHOLE request: bad input, or the tenant
+// lookup itself failing. A single store failing is not an error here — it is a
+// StoreResult with OutcomeFailed, because the point of a per-store transaction
+// is that its siblings still committed.
+func (s *Service) Apply(ctx context.Context, in Input) (Result, error) {
+	return s.fanOut(ctx, in, applyOp)
+}
+
+// Remove takes the coupon off every store subscription the tenant owns,
+// leaving every other discount — a merchant's own promo above all — in place.
+// It is as audited as the apply (tesserix-home#331).
+func (s *Service) Remove(ctx context.Context, in Input) (Result, error) {
+	return s.fanOut(ctx, in, removeOp)
+}
+
+// operation is the difference between Apply and Remove, which is only the
+// audit action and the Stripe call. Everything else — the store enumeration,
+// the per-store transaction, the locking read, the guards, the audit write and
+// the divergence handling — is shared, so it is written once.
+type operation struct {
+	name   string // "apply" | "remove", for the divergence error and logs
+	action string // audit action
+
+	// run performs the Stripe side and returns the outcome. It is only
+	// reached for a store that has a Stripe subscription id.
+	run func(ctx context.Context, sd StripeDiscounts, subID, couponID string) (Outcome, error)
+}
+
+var applyOp = operation{
+	name:   "apply",
+	action: ActionApply,
+	run: func(ctx context.Context, sd StripeDiscounts, subID, couponID string) (Outcome, error) {
+		// Read before write so "we attached it" and "it was already there"
+		// are told apart. AddSubscriptionDiscount is idempotent on its own
+		// and returns nil for both, which is the right contract for it and
+		// not enough information for this report.
+		has, err := sd.SubscriptionHasDiscount(ctx, subID, couponID)
+		if err != nil {
+			return "", err
+		}
+		if has {
+			return OutcomeAlreadyApplied, nil
+		}
+		if err := sd.AddSubscriptionDiscount(ctx, subID, couponID); err != nil {
+			return "", err
+		}
+		return OutcomeApplied, nil
+	},
+}
+
+var removeOp = operation{
+	name:   "remove",
+	action: ActionRemove,
+	run: func(ctx context.Context, sd StripeDiscounts, subID, couponID string) (Outcome, error) {
+		has, err := sd.SubscriptionHasDiscount(ctx, subID, couponID)
+		if err != nil {
+			return "", err
+		}
+		if !has {
+			return OutcomeNotApplied, nil
+		}
+		if err := sd.RemoveSubscriptionDiscount(ctx, subID, couponID); err != nil {
+			return "", err
+		}
+		return OutcomeRemoved, nil
+	},
+}
+
+func (s *Service) fanOut(ctx context.Context, in Input, op operation) (Result, error) {
+	if s == nil {
+		return Result{}, errors.New("tenantdiscount: nil service")
+	}
+
+	// Validated before the fan-out query, not inside the per-store loop: a
+	// blank coupon id would otherwise be reported once per store as a Stripe
+	// failure, after N transactions had been opened for it.
+	in.CouponID = strings.TrimSpace(in.CouponID)
+	if in.TenantID == uuid.Nil {
+		return Result{}, ErrNoTenant
+	}
+	if in.CouponID == "" {
+		return Result{}, ErrNoCoupon
+	}
+
+	storeIDs, err := s.tenantStores(ctx, in.TenantID)
+	if err != nil {
+		return Result{}, fmt.Errorf("tenantdiscount: list tenant stores: %w", err)
+	}
+	if len(storeIDs) == 0 {
+		return Result{}, ErrNoStores
+	}
+
+	out := Result{TenantID: in.TenantID, CouponID: in.CouponID, Stores: make([]StoreResult, 0, len(storeIDs))}
+	for _, storeID := range storeIDs {
+		out.Stores = append(out.Stores, s.oneStore(ctx, in, op, storeID))
+	}
+	return out, nil
+}
+
+// tenantStores lists the tenant's stores, ordered so two runs of the same
+// request report in the same order.
+//
+// Enumerating STORES rather than store_subscriptions rows is what makes "a
+// store with no subscription" reportable at all: a fan-out over subscription
+// rows cannot name a store that has none, and would skip it silently.
+//
+// No status filter. stores.status is one of active/suspended/archived
+// (migration 000001), and a suspended store's subscription can still carry a
+// discount; filtering here would silently drop stores from a report whose
+// whole purpose is to be exhaustive.
+func (s *Service) tenantStores(ctx context.Context, tenantID uuid.UUID) ([]uuid.UUID, error) {
+	var ids []uuid.UUID
+	err := s.db.WithContext(ctx).
+		Raw(`SELECT id FROM stores WHERE tenant_id = ? ORDER BY id`, tenantID).
+		Scan(&ids).Error
+	return ids, err
+}
+
+// oneStore runs the whole operation for a single store inside a single
+// transaction, and never returns an error: a store's failure belongs in its
+// own line of the report.
+func (s *Service) oneStore(ctx context.Context, in Input, op operation, storeID uuid.UUID) StoreResult {
+	res := StoreResult{StoreID: storeID}
+
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var sub subscription.StoreSubscription
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("store_id = ?", storeID).First(&sub).Error; err != nil {
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				res.FailureCode = FailureLoadSubscription
+				return fmt.Errorf("tenantdiscount: load subscription for store %s: %w", storeID, err)
+			}
+			// No subscription row: nothing to lock and nothing to bill. The
+			// audit row below is still written, so the operator's action
+			// leaves a trail for this store rather than none.
+			res.Outcome = OutcomeNoSubscription
+			return s.writeAudit(ctx, tx, in, op, res)
+		}
+
+		res.SubscriptionID = sub.ID
+		res.StripeCustomerID = sub.StripeCustomerID
+		res.StripeSubscriptionID = stripeSubscriptionID(sub)
+
+		switch {
+		case res.StripeCustomerID == "":
+			res.Outcome = OutcomeNoStripeCustomer
+		case res.StripeSubscriptionID == "":
+			res.Outcome = OutcomePending
+		default:
+			// The row lock taken above is held across this call, so the
+			// subscription cannot change underneath it; stripeCallTimeout
+			// bounds how long that lock can live. Stripe moves FIRST and is
+			// the source of truth, per trial/extend.go:270-280: a Stripe
+			// failure rolls this store back and writes nothing, while a
+			// failure after it leaves Stripe ahead — which is what
+			// ErrStripeChangedAuditWriteFailed is for.
+			sctx, cancel := context.WithTimeout(ctx, stripeCallTimeout)
+			defer cancel()
+
+			outcome, err := op.run(sctx, s.stripe, res.StripeSubscriptionID, in.CouponID)
+			if err != nil {
+				res.FailureCode = FailureStripeCall
+				return fmt.Errorf("%w: %s coupon %s on subscription %s: %w",
+					ErrStripeCall, op.name, in.CouponID, res.StripeSubscriptionID, err)
+			}
+			res.Outcome = outcome
+		}
+
+		// LAST, and inside this store's transaction: the row and the change
+		// it describes commit or roll back together.
+		if err := s.writeAudit(ctx, tx, in, op, res); err != nil {
+			res.FailureCode = FailureAuditWrite
+			return err
+		}
+		return nil
+	})
+	if err == nil {
+		return res
+	}
+
+	// The closure wrote into res before the rollback, so res still records
+	// whether Stripe was actually changed. A rolled-back transaction undoes
+	// our audit row; it cannot undo Stripe.
+	//
+	// This catches the COMMIT failing as well as the audit insert failing:
+	// the audit row is the only thing this transaction carried, so a lost
+	// commit loses exactly the same record, and both leave Stripe ahead.
+	if res.Changed() {
+		if res.FailureCode == "" {
+			res.FailureCode = FailureCommit
+		}
+		div := &AuditDivergenceError{
+			Op:                   op.name,
+			StoreID:              storeID,
+			CouponID:             in.CouponID,
+			StripeSubscriptionID: res.StripeSubscriptionID,
+			StripeCustomerID:     res.StripeCustomerID,
+			Cause:                err,
+		}
+		// Logged as well as returned: the returned error travels to one
+		// operator, and reconciling this needs whoever reads the logs to
+		// have the three ids without that operator forwarding them.
+		s.logger.Error("tenantdiscount: stripe discount changed but the audit row was not written",
+			"op", op.name,
+			"coupon_id", in.CouponID,
+			"stripe_subscription_id", res.StripeSubscriptionID,
+			"stripe_customer_id", res.StripeCustomerID,
+			"store_id", storeID.String(),
+			"tenant_id", in.TenantID.String(),
+			"err", err)
+		err = div
+	}
+
+	res.Outcome = OutcomeFailed
+	res.Err = err
+	return res
+}
+
+// writeAudit emits the store's audit row on the caller's transaction.
+func (s *Service) writeAudit(ctx context.Context, tx *gorm.DB, in Input, op operation, res StoreResult) error {
+	md := map[string]any{
+		"coupon_id": in.CouponID,
+		"outcome":   string(res.Outcome),
+	}
+	if in.Reason != "" {
+		md["reason"] = in.Reason
+	}
+	if res.StripeSubscriptionID != "" {
+		md["stripe_subscription_id"] = res.StripeSubscriptionID
+	}
+	if res.StripeCustomerID != "" {
+		md["stripe_customer_id"] = res.StripeCustomerID
+	}
+
+	// Warning for the outcomes where the operator asked for a billing change
+	// and did not get one, so those stand out in the console's audit filter
+	// from the ones that did what was asked.
+	severity := audit.SeverityInfo
+	switch res.Outcome {
+	case OutcomePending, OutcomeNoSubscription, OutcomeNoStripeCustomer:
+		severity = audit.SeverityWarning
+	}
+
+	return s.audit.EmitTx(ctx, tx, in.C, audit.Event{
+		Action:       op.action,
+		ResourceType: resourceType,
+		ResourceID:   res.StoreID.String(),
+		Severity:     severity,
+		Metadata:     md,
+		TenantID:     in.TenantID,
+		StoreID:      res.StoreID,
+	})
+}
+
+// stripeSubscriptionID returns the subscription's Stripe id, or "" when it has
+// none. A nil pointer and a pointer to "" mean the same thing — the store has
+// no Stripe subscription — and collapsing them at one site keeps every caller
+// from having to remember that. Same helper, same reasoning, as
+// trial/extend.go:484.
+func stripeSubscriptionID(sub subscription.StoreSubscription) string {
+	if sub.StripeSubscriptionID == nil {
+		return ""
+	}
+	return *sub.StripeSubscriptionID
+}

--- a/services/marketplace-api/internal/billing/tenantdiscount/service.go
+++ b/services/marketplace-api/internal/billing/tenantdiscount/service.go
@@ -200,11 +200,21 @@ type operation struct {
 	// run performs the Stripe side and returns the outcome. It is only
 	// reached for a store that has a Stripe subscription id.
 	run func(ctx context.Context, sd StripeDiscounts, subID, couponID string) (Outcome, error)
+
+	// record writes the tenant-scoped applied-override row: Apply creates it,
+	// Remove retires it. Called ONCE per request, before the fan-out.
+	record func(s *Service, ctx context.Context, in Input) error
+}
+
+// recordFanOut applies the operation's tenant-scoped record write.
+func (s *Service) recordFanOut(ctx context.Context, in Input, op operation) error {
+	return op.record(s, ctx, in)
 }
 
 var applyOp = operation{
 	name:   "apply",
 	action: ActionApply,
+	record: (*Service).recordApplied,
 	run: func(ctx context.Context, sd StripeDiscounts, subID, couponID string) (Outcome, error) {
 		// Read before write so "we attached it" and "it was already there"
 		// are told apart. AddSubscriptionDiscount is idempotent on its own
@@ -227,6 +237,7 @@ var applyOp = operation{
 var removeOp = operation{
 	name:   "remove",
 	action: ActionRemove,
+	record: (*Service).recordRemoved,
 	run: func(ctx context.Context, sd StripeDiscounts, subID, couponID string) (Outcome, error) {
 		has, err := sd.SubscriptionHasDiscount(ctx, subID, couponID)
 		if err != nil {
@@ -244,7 +255,7 @@ var removeOp = operation{
 
 func (s *Service) fanOut(ctx context.Context, in Input, op operation) (Result, error) {
 	if s == nil {
-		return Result{}, errors.New("tenantdiscount: nil service")
+		return Result{}, ErrNilService
 	}
 
 	// Validated before the fan-out query, not inside the per-store loop: a
@@ -264,6 +275,23 @@ func (s *Service) fanOut(ctx context.Context, in Input, op operation) (Result, e
 	}
 	if len(storeIDs) == 0 {
 		return Result{}, ErrNoStores
+	}
+
+	// The tenant-scoped record, written ONCE and BEFORE the per-store loop.
+	//
+	// It is tenant-scoped because the grant is: a store created tomorrow is
+	// covered by an override granted today, and the creation paths read this
+	// row to do it. Before the loop, because a fan-out that fails for some or
+	// all of today's stores must still leave the tenant marked as holding the
+	// override — those stores are reported failed and the operator retries,
+	// while a store provisioned in the meantime is covered either way.
+	//
+	// A failure here refuses the WHOLE request rather than being reported per
+	// store. Nothing has been sent to Stripe yet, so refusing costs nothing;
+	// continuing would apply the discount to today's stores while silently
+	// dropping every future one, which is the exact gap this record closes.
+	if err := s.recordFanOut(ctx, in, op); err != nil {
+		return Result{}, err
 	}
 
 	out := Result{TenantID: in.TenantID, CouponID: in.CouponID, Stores: make([]StoreResult, 0, len(storeIDs))}

--- a/services/marketplace-api/internal/billing/tenantdiscount/tenantdiscount_integration_test.go
+++ b/services/marketplace-api/internal/billing/tenantdiscount/tenantdiscount_integration_test.go
@@ -36,7 +36,7 @@ const merchantPromo = "co_merchant_promo"
 // into a savepoint, which is precisely the behaviour under test.
 func newDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	return testdb.NewDB(t, "audit_logs", "store_subscriptions", "stores")
+	return testdb.NewDB(t, "audit_logs", "tenant_applied_discounts", "store_subscriptions", "stores")
 }
 
 // seededStore is one store plus (optionally) its subscription row.
@@ -385,8 +385,9 @@ func TestApply_AnAuditFailureWithoutAStripeChangeIsNotTheDivergence(t *testing.T
 
 // Applying twice must not report the second run as a fresh application, and
 // must not send a second attach. This is idempotent APPLICATION, which is not
-// the "at most one active override per tenant" guarantee #660 asserts — there
-// is no local table here to enforce that against.
+// the "at most one active override per tenant" guarantee #660 asserts — the
+// local record migration 000132 added bounds what this service applied, not
+// what the Stripe customer carries.
 func TestApply_ReAppliedCouponReportsAlreadyApplied(t *testing.T) {
 	db := newDB(t)
 	tenantID := uuid.New()

--- a/services/marketplace-api/internal/billing/tenantdiscount/tenantdiscount_integration_test.go
+++ b/services/marketplace-api/internal/billing/tenantdiscount/tenantdiscount_integration_test.go
@@ -1,0 +1,502 @@
+//go:build integration
+
+package tenantdiscount_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/billing/tenantdiscount"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// couponID is the platform override every test in this file applies. It is a
+// single constant so an assertion can never pass by matching the wrong coupon.
+const couponID = "co_platform_override"
+
+// merchantPromo stands in for a discount the merchant already redeemed. The
+// fan-out must never disturb it — that regression is what T2's
+// read-modify-write pair exists for, and this package is its first caller.
+const merchantPromo = "co_merchant_promo"
+
+// newDB opens a real, committing handle and truncates everything these tests
+// write. NewDB rather than NewTx: the service opens ONE TRANSACTION PER STORE,
+// and a handle that is already inside a transaction would turn each of those
+// into a savepoint, which is precisely the behaviour under test.
+func newDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	return testdb.NewDB(t, "audit_logs", "store_subscriptions", "stores")
+}
+
+// seededStore is one store plus (optionally) its subscription row.
+type seededStore struct {
+	StoreID              uuid.UUID
+	SubscriptionID       uuid.UUID
+	StripeSubscriptionID string
+}
+
+// seedStoreWithSubscription creates a store and a store_subscriptions row for
+// it. A blank stripeSubID leaves stripe_subscription_id NULL — the card-less
+// trialing tenant the plan calls out as exactly the population an operator
+// discounts.
+func seedStoreWithSubscription(t *testing.T, db *gorm.DB, tenantID uuid.UUID, stripeSubID string) seededStore {
+	t.Helper()
+
+	storeID := uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
+
+	row := subscription.StoreSubscription{
+		TenantID:           tenantID,
+		StoreID:            storeID,
+		StripeCustomerID:   "cus_" + storeID.String()[:8],
+		Status:             subscription.StatusTrialing,
+		Plan:               subscription.PlanTrial,
+		SubscriptionPeriod: subscription.PeriodMonthly,
+		PriceTier:          subscription.PriceTierDeveloped,
+	}
+	if stripeSubID != "" {
+		row.StripeSubscriptionID = &stripeSubID
+	}
+	require.NoError(t, db.Create(&row).Error)
+
+	return seededStore{StoreID: storeID, SubscriptionID: row.ID, StripeSubscriptionID: stripeSubID}
+}
+
+// seedStoreWithoutSubscription creates a store that has no store_subscriptions
+// row at all. The fan-out must report it, not skip it.
+func seedStoreWithoutSubscription(t *testing.T, db *gorm.DB, tenantID uuid.UUID) uuid.UUID {
+	t.Helper()
+	storeID := uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
+	return storeID
+}
+
+// realEmitter wires the shipped gormRepository so EmitTx's insert really goes
+// through Postgres. A double could prove which handle was passed but not what
+// the database does with it, and transactional visibility is the whole point.
+func realEmitter(t *testing.T, db *gorm.DB) *audit.Emitter {
+	t.Helper()
+	e, err := audit.NewEmitter(audit.EmitterConfig{DB: db, Repo: audit.NewRepository(), Logger: slog.Default()})
+	require.NoError(t, err)
+	t.Cleanup(func() { e.Stop(context.Background()) })
+	return e
+}
+
+func newService(t *testing.T, db *gorm.DB, st tenantdiscount.StripeDiscounts, aw tenantdiscount.AuditWriter) *tenantdiscount.Service {
+	t.Helper()
+	svc, err := tenantdiscount.NewService(tenantdiscount.Config{
+		DB: db, Stripe: st, Audit: aw, Logger: slog.Default(),
+	})
+	require.NoError(t, err)
+	return svc
+}
+
+// outcomes indexes a Result by store id so assertions name the store rather
+// than a slice position.
+func outcomes(r tenantdiscount.Result) map[uuid.UUID]tenantdiscount.StoreResult {
+	out := make(map[uuid.UUID]tenantdiscount.StoreResult, len(r.Stores))
+	for _, s := range r.Stores {
+		out[s.StoreID] = s
+	}
+	return out
+}
+
+// auditRowsForStore counts committed audit rows this package wrote for a store.
+func auditRowsForStore(t *testing.T, h *gorm.DB, storeID uuid.UUID, action string) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, h.Model(&audit.Entry{}).
+		Where("store_id = ? AND action = ?", storeID, action).Count(&n).Error)
+	return n
+}
+
+// operatorContext is a gin context carrying the platform_operator_id key the
+// audit emitter derives ActorOperator from. Passed through Input so the audit
+// row names the operator rather than the system.
+func operatorContext(operatorID string) *gin.Context {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	// A Request is mandatory, not decoration: audit's buildEntry reads
+	// c.ClientIP() and c.Request.UserAgent(), both of which dereference it.
+	c.Request = httptest.NewRequest(http.MethodPost, "/admin/billing/tenants/discount", nil)
+	c.Set("platform_operator_id", operatorID)
+	return c
+}
+
+// ---------------------------------------------------------------------------
+// The fan-out
+// ---------------------------------------------------------------------------
+
+// A tenant with several stores has several subscriptions and several Stripe
+// customers. #660 says "the tenant's subscription customer", singular; it is
+// not, and this is the test that says so.
+func TestApply_FansOutOverEveryStoreTheTenantOwns(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	a := seedStoreWithSubscription(t, db, tenantID, "sub_a")
+	b := seedStoreWithSubscription(t, db, tenantID, "sub_b")
+	c := seedStoreWithSubscription(t, db, tenantID, "sub_c")
+
+	// A second tenant's store, to prove the fan-out is tenant-scoped and not
+	// simply "every subscription in the table".
+	other := seedStoreWithSubscription(t, db, uuid.New(), "sub_other")
+
+	fs := newFakeStripe()
+	fs.attach("sub_b", merchantPromo)
+
+	res, err := newService(t, db, fs, realEmitter(t, db)).
+		Apply(context.Background(), tenantdiscount.Input{
+			TenantID: tenantID, CouponID: couponID, Reason: "negotiated 2026 rate",
+			C: operatorContext("op_1"),
+		})
+	require.NoError(t, err)
+
+	require.Len(t, res.Stores, 3, "every one of the tenant's stores must be reported")
+	got := outcomes(res)
+	for _, s := range []seededStore{a, b, c} {
+		require.Equal(t, tenantdiscount.OutcomeApplied, got[s.StoreID].Outcome)
+		require.True(t, fs.has(s.StripeSubscriptionID, couponID))
+		require.EqualValues(t, 1, auditRowsForStore(t, db, s.StoreID, tenantdiscount.ActionApply))
+	}
+
+	require.NotContains(t, got, other.StoreID, "another tenant's store must not be touched")
+	require.False(t, fs.has("sub_other", couponID))
+
+	require.ElementsMatch(t, []string{merchantPromo, couponID}, fs.coupons("sub_b"),
+		"the merchant's own promo must survive the platform override")
+}
+
+// The card-less trialing tenant. stripe_subscription_id is NULL, so there is
+// nothing to attach the coupon to — and that is a reported outcome with its
+// own name, not a failure and not a silent skip.
+func TestApply_AStoreWithNoStripeSubscriptionIsReportedPending(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	withSub := seedStoreWithSubscription(t, db, tenantID, "sub_a")
+	cardless := seedStoreWithSubscription(t, db, tenantID, "")
+
+	fs := newFakeStripe()
+	res, err := newService(t, db, fs, realEmitter(t, db)).
+		Apply(context.Background(), tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})
+	require.NoError(t, err)
+
+	got := outcomes(res)
+	require.Equal(t, tenantdiscount.OutcomePending, got[cardless.StoreID].Outcome)
+	require.Equal(t, tenantdiscount.OutcomeApplied, got[withSub.StoreID].Outcome,
+		"a pending sibling must not hold the rest of the fan-out back")
+
+	require.Equal(t, []string{"sub_a/" + couponID}, fs.adds,
+		"the pending store has no stripe subscription id, so it must produce no Stripe call")
+
+	require.EqualValues(t, 1, auditRowsForStore(t, db, cardless.StoreID, tenantdiscount.ActionApply),
+		"a pending store is still an audited outcome")
+}
+
+// A store with no store_subscriptions row at all. The plan is explicit that
+// this must be an outcome rather than a store the loop never visits.
+func TestApply_AStoreWithNoSubscriptionRowIsAnExplicitOutcome(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	withSub := seedStoreWithSubscription(t, db, tenantID, "sub_a")
+	bare := seedStoreWithoutSubscription(t, db, tenantID)
+
+	res, err := newService(t, db, newFakeStripe(), realEmitter(t, db)).
+		Apply(context.Background(), tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})
+	require.NoError(t, err)
+
+	got := outcomes(res)
+	require.Len(t, res.Stores, 2)
+	require.Equal(t, tenantdiscount.OutcomeNoSubscription, got[bare].Outcome)
+	require.Equal(t, tenantdiscount.OutcomeApplied, got[withSub.StoreID].Outcome)
+	require.EqualValues(t, 1, auditRowsForStore(t, db, bare, tenantdiscount.ActionApply))
+}
+
+// An operator applying an override to a tenant with no stores achieves
+// nothing, and reporting an empty success would read as "done".
+func TestApply_RefusesATenantWithNoStores(t *testing.T) {
+	db := newDB(t)
+
+	_, err := newService(t, db, newFakeStripe(), realEmitter(t, db)).
+		Apply(context.Background(), tenantdiscount.Input{TenantID: uuid.New(), CouponID: couponID})
+	require.ErrorIs(t, err, tenantdiscount.ErrNoStores)
+}
+
+// ---------------------------------------------------------------------------
+// One transaction PER STORE
+// ---------------------------------------------------------------------------
+
+// The load-bearing isolation assertion. One transaction across N stores would
+// let one store's Stripe failure roll the others back; this pins that it does
+// not — the siblings keep both their Stripe discount and their committed audit
+// row, and only the failing store is reported failed.
+func TestApply_OneStoreFailingLeavesTheOthersAppliedAndAudited(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	first := seedStoreWithSubscription(t, db, tenantID, "sub_a")
+	broken := seedStoreWithSubscription(t, db, tenantID, "sub_bad")
+	last := seedStoreWithSubscription(t, db, tenantID, "sub_c")
+
+	fs := newFakeStripe()
+	fs.fail("sub_bad", errStripeDown)
+
+	res, err := newService(t, db, fs, realEmitter(t, db)).
+		Apply(context.Background(), tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})
+	require.NoError(t, err, "a per-store failure is reported in the Result, not as a fan-out error")
+
+	got := outcomes(res)
+	require.Equal(t, tenantdiscount.OutcomeFailed, got[broken.StoreID].Outcome)
+	require.ErrorIs(t, got[broken.StoreID].Err, tenantdiscount.ErrStripeCall)
+	require.EqualValues(t, 0, auditRowsForStore(t, db, broken.StoreID, tenantdiscount.ActionApply),
+		"the failing store's transaction must roll its audit row back")
+
+	for _, s := range []seededStore{first, last} {
+		require.Equal(t, tenantdiscount.OutcomeApplied, got[s.StoreID].Outcome,
+			"a sibling's failure must neither roll back nor block this store")
+		require.True(t, fs.has(s.StripeSubscriptionID, couponID))
+		require.EqualValues(t, 1, auditRowsForStore(t, db, s.StoreID, tenantdiscount.ActionApply))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The audit row is written LAST, inside the store's transaction
+// ---------------------------------------------------------------------------
+
+// rollbackAfterAudit writes the real audit row through the caller's
+// transaction and THEN fails. Nothing follows EmitTx inside the transaction,
+// so this is the only way to force a rollback after a successful audit insert
+// — and forcing exactly that is what separates "written on the transaction"
+// from "written on the emitter's own handle", which no post-hoc count can
+// tell apart on the happy path.
+type rollbackAfterAudit struct {
+	inner  *audit.Emitter
+	forSub string // the stripe subscription id whose store must roll back
+
+	// seenInTx records the row count observed THROUGH the caller's
+	// transaction immediately after the insert. Without it, an EmitTx that
+	// wrote nothing at all would satisfy the post-rollback assertion.
+	seenInTx int64
+}
+
+func (r *rollbackAfterAudit) EmitTx(ctx context.Context, tx *gorm.DB, c *gin.Context, ev audit.Event) error {
+	if err := r.inner.EmitTx(ctx, tx, c, ev); err != nil {
+		return err
+	}
+	if sub, _ := ev.Metadata["stripe_subscription_id"].(string); sub != r.forSub {
+		return nil
+	}
+	if err := tx.Model(&audit.Entry{}).
+		Where("store_id = ?", ev.StoreID).Count(&r.seenInTx).Error; err != nil {
+		return err
+	}
+	return errAuditWriteRejected
+}
+
+var errAuditWriteRejected = errors.New("audit write rejected")
+
+func TestApply_TheAuditRowRollsBackWithItsStoresTransaction(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	doomed := seedStoreWithSubscription(t, db, tenantID, "sub_doomed")
+	survivor := seedStoreWithSubscription(t, db, tenantID, "sub_ok")
+
+	fs := newFakeStripe()
+	aw := &rollbackAfterAudit{inner: realEmitter(t, db), forSub: "sub_doomed"}
+
+	res, err := newService(t, db, fs, aw).
+		Apply(context.Background(), tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})
+	require.NoError(t, err)
+
+	require.EqualValues(t, 1, aw.seenInTx,
+		"the row must be visible inside the store's own transaction — otherwise EmitTx wrote nothing and the assertion below is vacuous")
+	require.EqualValues(t, 0, auditRowsForStore(t, db, doomed.StoreID, tenantdiscount.ActionApply),
+		"the audit row must die with the transaction that carried it")
+	require.EqualValues(t, 1, auditRowsForStore(t, db, survivor.StoreID, tenantdiscount.ActionApply),
+		"the sibling store's own transaction committed independently")
+
+	got := outcomes(res)
+	require.Equal(t, tenantdiscount.OutcomeFailed, got[doomed.StoreID].Outcome)
+	require.Equal(t, tenantdiscount.OutcomeApplied, got[survivor.StoreID].Outcome)
+}
+
+// The residual divergence, named. The transaction rolled back but Stripe still
+// holds the discount, so the operator gets a distinct sentinel rather than a
+// routine database error — the same treatment trial's
+// ErrStripeAppliedLocalWriteFailed gets.
+func TestApply_AnUnattributableDiscountIsNamedNotSwallowed(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	doomed := seedStoreWithSubscription(t, db, tenantID, "sub_doomed")
+
+	fs := newFakeStripe()
+	aw := &rollbackAfterAudit{inner: realEmitter(t, db), forSub: "sub_doomed"}
+
+	res, err := newService(t, db, fs, aw).
+		Apply(context.Background(), tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})
+	require.NoError(t, err)
+
+	got := outcomes(res)[doomed.StoreID]
+	require.Equal(t, tenantdiscount.OutcomeFailed, got.Outcome)
+	require.ErrorIs(t, got.Err, tenantdiscount.ErrStripeChangedAuditWriteFailed)
+	require.ErrorIs(t, got.Err, errAuditWriteRejected, "the underlying cause must stay reachable")
+	require.Equal(t, tenantdiscount.FailureAuditWrite, got.FailureCode)
+
+	require.True(t, fs.has("sub_doomed", couponID),
+		"the local rollback cannot and does not undo Stripe — that is the divergence being named")
+	require.Contains(t, got.Err.Error(), couponID)
+	require.Contains(t, got.Err.Error(), "sub_doomed")
+	require.Contains(t, got.Err.Error(), got.StripeCustomerID)
+}
+
+// An audit failure on a store where Stripe was NOT changed is an ordinary
+// failure, not the divergence. Without this control the sentinel above could
+// be returned for every audit failure and still look correct.
+func TestApply_AnAuditFailureWithoutAStripeChangeIsNotTheDivergence(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	already := seedStoreWithSubscription(t, db, tenantID, "sub_already")
+
+	fs := newFakeStripe()
+	fs.attach("sub_already", couponID) // already there; this apply changes nothing
+	aw := &rollbackAfterAudit{inner: realEmitter(t, db), forSub: "sub_already"}
+
+	res, err := newService(t, db, fs, aw).
+		Apply(context.Background(), tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})
+	require.NoError(t, err)
+
+	got := outcomes(res)[already.StoreID]
+	require.Equal(t, tenantdiscount.OutcomeFailed, got.Outcome)
+	require.NotErrorIs(t, got.Err, tenantdiscount.ErrStripeChangedAuditWriteFailed)
+	require.ErrorIs(t, got.Err, errAuditWriteRejected)
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency
+// ---------------------------------------------------------------------------
+
+// Applying twice must not report the second run as a fresh application, and
+// must not send a second attach. This is idempotent APPLICATION, which is not
+// the "at most one active override per tenant" guarantee #660 asserts — there
+// is no local table here to enforce that against.
+func TestApply_ReAppliedCouponReportsAlreadyApplied(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	store := seedStoreWithSubscription(t, db, tenantID, "sub_a")
+
+	fs := newFakeStripe()
+	svc := newService(t, db, fs, realEmitter(t, db))
+	in := tenantdiscount.Input{TenantID: tenantID, CouponID: couponID}
+
+	first, err := svc.Apply(context.Background(), in)
+	require.NoError(t, err)
+	require.Equal(t, tenantdiscount.OutcomeApplied, outcomes(first)[store.StoreID].Outcome)
+
+	second, err := svc.Apply(context.Background(), in)
+	require.NoError(t, err)
+	require.Equal(t, tenantdiscount.OutcomeAlreadyApplied, outcomes(second)[store.StoreID].Outcome)
+
+	require.Equal(t, []string{"sub_a/" + couponID}, fs.adds,
+		"the second apply must not send a second attach")
+	require.EqualValues(t, 2, auditRowsForStore(t, db, store.StoreID, tenantdiscount.ActionApply),
+		"both operator actions are audited; only one of them changed Stripe")
+}
+
+// ---------------------------------------------------------------------------
+// Remove
+// ---------------------------------------------------------------------------
+
+// Removal fans out the same way and is as audited as the application
+// (tesserix-home#331), and it takes out only the platform coupon.
+func TestRemove_FansOutAndLeavesTheMerchantPromoAlone(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	a := seedStoreWithSubscription(t, db, tenantID, "sub_a")
+	b := seedStoreWithSubscription(t, db, tenantID, "sub_b")
+	cardless := seedStoreWithSubscription(t, db, tenantID, "")
+
+	fs := newFakeStripe()
+	fs.attach("sub_a", couponID)
+	fs.attach("sub_b", couponID)
+	fs.attach("sub_b", merchantPromo)
+
+	res, err := newService(t, db, fs, realEmitter(t, db)).
+		Remove(context.Background(), tenantdiscount.Input{
+			TenantID: tenantID, CouponID: couponID, Reason: "override expired",
+		})
+	require.NoError(t, err)
+
+	got := outcomes(res)
+	require.Equal(t, tenantdiscount.OutcomeRemoved, got[a.StoreID].Outcome)
+	require.Equal(t, tenantdiscount.OutcomeRemoved, got[b.StoreID].Outcome)
+	require.Equal(t, tenantdiscount.OutcomePending, got[cardless.StoreID].Outcome)
+
+	require.False(t, fs.has("sub_a", couponID))
+	require.Equal(t, []string{merchantPromo}, fs.coupons("sub_b"),
+		"removal must take out the platform coupon and nothing else")
+
+	for _, id := range []uuid.UUID{a.StoreID, b.StoreID, cardless.StoreID} {
+		require.EqualValues(t, 1, auditRowsForStore(t, db, id, tenantdiscount.ActionRemove))
+	}
+}
+
+// A coupon that is not attached is reported as such rather than as a removal
+// that happened, so a replayed removal cannot read as a fresh one.
+func TestRemove_ACouponThatIsNotAttachedReportsNotApplied(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	store := seedStoreWithSubscription(t, db, tenantID, "sub_a")
+
+	fs := newFakeStripe()
+	fs.attach("sub_a", merchantPromo)
+
+	res, err := newService(t, db, fs, realEmitter(t, db)).
+		Remove(context.Background(), tenantdiscount.Input{TenantID: tenantID, CouponID: couponID})
+	require.NoError(t, err)
+
+	require.Equal(t, tenantdiscount.OutcomeNotApplied, outcomes(res)[store.StoreID].Outcome)
+	require.Empty(t, fs.removes, "nothing to remove means no update is sent")
+	require.Equal(t, []string{merchantPromo}, fs.coupons("sub_a"))
+}
+
+// ---------------------------------------------------------------------------
+// Attribution
+// ---------------------------------------------------------------------------
+
+// The audit row must carry the operator and the facts a human needs to
+// reconcile: which coupon, which Stripe subscription, which customer, and the
+// operator's stated reason.
+func TestApply_TheAuditRowCarriesTheOperatorAndTheStripeFacts(t *testing.T) {
+	db := newDB(t)
+	tenantID := uuid.New()
+	store := seedStoreWithSubscription(t, db, tenantID, "sub_a")
+
+	_, err := newService(t, db, newFakeStripe(), realEmitter(t, db)).
+		Apply(context.Background(), tenantdiscount.Input{
+			TenantID: tenantID, CouponID: couponID, Reason: "negotiated 2026 rate",
+			C: operatorContext("op_42"),
+		})
+	require.NoError(t, err)
+
+	var row audit.Entry
+	require.NoError(t, db.Where("store_id = ? AND action = ?", store.StoreID, tenantdiscount.ActionApply).
+		First(&row).Error)
+
+	require.Equal(t, audit.ActorOperator, row.ActorType)
+	require.NotNil(t, row.ActorOperatorID)
+	require.Equal(t, "op_42", *row.ActorOperatorID)
+	require.Equal(t, tenantID, row.TenantID)
+	require.Equal(t, couponID, row.Metadata["coupon_id"])
+	require.Equal(t, string(tenantdiscount.OutcomeApplied), row.Metadata["outcome"])
+	require.Equal(t, "sub_a", row.Metadata["stripe_subscription_id"])
+	require.Equal(t, "negotiated 2026 rate", row.Metadata["reason"])
+	require.NotEmpty(t, row.Metadata["stripe_customer_id"])
+}

--- a/services/marketplace-api/internal/billing/tenantdiscount/tenantdiscount_test.go
+++ b/services/marketplace-api/internal/billing/tenantdiscount/tenantdiscount_test.go
@@ -1,0 +1,90 @@
+package tenantdiscount_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
+	"github.com/mark8ly/marketplace-api/internal/billing/tenantdiscount"
+)
+
+// The checks in this file run before any database handle is touched, so they
+// are ordinary unit tests: they are the reason the validation happens BEFORE
+// the fan-out query rather than inside the per-store loop, where a missing
+// coupon id would be reported once per store as a Stripe failure.
+
+func TestNewService_RefusesANilAuditWriter(t *testing.T) {
+	_, err := tenantdiscount.NewService(tenantdiscount.Config{
+		DB:     nil,
+		Stripe: newFakeStripe(),
+		Audit:  nil,
+	})
+	require.ErrorIs(t, err, tenantdiscount.ErrNoAuditWriter)
+}
+
+// A nil *audit.Emitter assigned into the AuditWriter interface is a NON-nil
+// interface, so `s.audit != nil` would be true and every store would fail at
+// its EmitTx call — inside an open transaction holding a row lock. The
+// Extender's NewExtender guards the same shape (trial/extend.go:198); this
+// mirrors it, and refuses rather than normalising because an audit writer is
+// mandatory here where a Stripe client is optional there.
+func TestNewService_RefusesATypedNilAuditWriter(t *testing.T) {
+	var emitter *nilAuditWriter
+	_, err := tenantdiscount.NewService(tenantdiscount.Config{
+		Stripe: newFakeStripe(),
+		Audit:  emitter,
+	})
+	require.ErrorIs(t, err, tenantdiscount.ErrNoAuditWriter)
+}
+
+func TestNewService_RefusesANilStripeClient(t *testing.T) {
+	_, err := tenantdiscount.NewService(tenantdiscount.Config{
+		Stripe: nil,
+		Audit:  &recordingAudit{},
+	})
+	require.ErrorIs(t, err, tenantdiscount.ErrNoStripeClient)
+}
+
+func TestApplyAndRemove_RefuseAMissingTenantOrCoupon(t *testing.T) {
+	svc := newServiceForValidation(t)
+
+	for _, tc := range []struct {
+		name string
+		in   tenantdiscount.Input
+		want error
+	}{
+		{"no tenant", tenantdiscount.Input{CouponID: "co_x"}, tenantdiscount.ErrNoTenant},
+		{"no coupon", tenantdiscount.Input{TenantID: uuid.New()}, tenantdiscount.ErrNoCoupon},
+		{"blank coupon", tenantdiscount.Input{TenantID: uuid.New(), CouponID: "   "}, tenantdiscount.ErrNoCoupon},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.Apply(context.Background(), tc.in)
+			require.ErrorIs(t, err, tc.want)
+			_, err = svc.Remove(context.Background(), tc.in)
+			require.ErrorIs(t, err, tc.want)
+		})
+	}
+}
+
+// The adapter is what makes the port reachable from a real Stripe client, and
+// a port nothing can implement is a port that never ships. This only asserts
+// the three methods exist with the signatures the interface names — the
+// delegation itself is exercised against a stub server in the stripe package's
+// own tests.
+func TestStripeAdapter_SatisfiesThePort(t *testing.T) {
+	var _ tenantdiscount.StripeDiscounts = &tenantdiscount.StripeAdapter{C: billingstripe.New("sk_test_x")}
+}
+
+func newServiceForValidation(t *testing.T) *tenantdiscount.Service {
+	t.Helper()
+	svc, err := tenantdiscount.NewService(tenantdiscount.Config{
+		DB:     nil, // never reached: validation refuses before the fan-out query
+		Stripe: newFakeStripe(),
+		Audit:  &recordingAudit{},
+	})
+	require.NoError(t, err)
+	return svc
+}

--- a/services/marketplace-api/internal/billing/trial/subscribe.go
+++ b/services/marketplace-api/internal/billing/trial/subscribe.go
@@ -9,12 +9,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
 	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
+	"github.com/mark8ly/marketplace-api/internal/billing/tenantdiscount"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 )
 
@@ -55,11 +57,29 @@ func (a *StripeAdapter) PriceIDFor(ctx context.Context, plan subscription.Subscr
 	return billingstripe.PriceIDFor(ctx, a.C, plan, period, currency, tier)
 }
 
+// TenantDiscountApplier offers a newly created subscription to the tenant's
+// standing platform override (mark8ly#660). *tenantdiscount.Service satisfies
+// it.
+//
+// Declared here rather than imported as a concrete type for the reason
+// StripeAPI above is: it keeps the dependency pointing inward and lets the
+// tests substitute a stub. There is no import cycle to avoid — tenantdiscount
+// does not import this package — so the input and outcome types are the
+// domain's own rather than re-spelled as strings.
+type TenantDiscountApplier interface {
+	ApplyToNewSubscription(ctx context.Context, in tenantdiscount.NewSubscriptionInput) (tenantdiscount.Outcome, error)
+}
+
 // Subscriber orchestrates the deferred-charge trial flow.
 type Subscriber struct {
 	db     *gorm.DB
 	stripe StripeAPI
 	clock  func() time.Time
+
+	// discounts may be nil: without Stripe billing configured there is no
+	// tenantdiscount.Service to wire, and a nil one means Subscribe behaves
+	// exactly as it did before #660 T6.
+	discounts TenantDiscountApplier
 }
 
 // NewSubscriber constructs a Subscriber. If clock is nil, time.Now().UTC() is used.
@@ -68,6 +88,19 @@ func NewSubscriber(db *gorm.DB, s StripeAPI, clock func() time.Time) *Subscriber
 		clock = func() time.Time { return time.Now().UTC() }
 	}
 	return &Subscriber{db: db, stripe: s, clock: clock}
+}
+
+// WithTenantDiscount wires the tenant-override hook and returns the receiver
+// so it can be chained onto NewSubscriber.
+//
+// A setter rather than a fourth NewSubscriber parameter: the discounter is
+// optional (see Subscriber.discounts) and every existing caller and test
+// constructs a Subscriber without one. It follows the same shape as
+// brandingHandler.SetPlanResolver in main.go, where a dependency built later
+// in the wiring is attached after construction.
+func (s *Subscriber) WithTenantDiscount(d TenantDiscountApplier) *Subscriber {
+	s.discounts = d
+	return s
 }
 
 // SubscribeInput carries the caller-supplied parameters for a trial subscription.
@@ -156,8 +189,51 @@ func (s *Subscriber) subscribeInTx(ctx context.Context, tx *gorm.DB, in Subscrib
 		return nil, fmt.Errorf("trial: persist subscription id: %w", err)
 	}
 
+	// #660 T6 — the tenant may hold a standing platform override granted
+	// before this store had a Stripe subscription to carry it. Applying it
+	// here is what makes the grant cover stores created after the operator
+	// pressed the button.
+	s.applyTenantDiscount(ctx, in, sub.ID)
+
 	return &SubscribeResult{
 		StripeSubscriptionID: sub.ID,
 		TrialEndUnix:         trialEnd,
 	}, nil
+}
+
+// applyTenantDiscount offers the new subscription to the tenant's standing
+// override, and RETURNS NOTHING.
+//
+// That is the contract, not an oversight. A discount that cannot be applied
+// costs the tenant a discount an operator can re-apply by hand; a discount
+// that blocks this call costs the merchant their subscription. The first is
+// recoverable and the second is not, so the failure is logged and dropped.
+//
+// It also touches no transaction: ApplyToNewSubscription works entirely on the
+// tenantdiscount service's own handle. A failed statement poisons a Postgres
+// transaction, so writing on the caller's tx would turn exactly the failure
+// this function is built to swallow back into a failed subscription.
+func (s *Subscriber) applyTenantDiscount(ctx context.Context, in SubscribeInput, stripeSubID string) {
+	if s.discounts == nil {
+		return
+	}
+	outcome, err := s.discounts.ApplyToNewSubscription(ctx, tenantdiscount.NewSubscriptionInput{
+		TenantID:             in.TenantID,
+		StoreID:              in.StoreID,
+		StripeSubscriptionID: stripeSubID,
+	})
+	if err != nil {
+		slog.Error("trial: could not apply the tenant's standing platform override to a new subscription",
+			"tenant_id", in.TenantID.String(),
+			"store_id", in.StoreID.String(),
+			"stripe_subscription_id", stripeSubID,
+			"err", err)
+		return
+	}
+	if outcome == tenantdiscount.OutcomeApplied {
+		slog.Info("trial: applied the tenant's standing platform override to a new subscription",
+			"tenant_id", in.TenantID.String(),
+			"store_id", in.StoreID.String(),
+			"stripe_subscription_id", stripeSubID)
+	}
 }

--- a/services/marketplace-api/internal/billing/trial/subscribe_tenantdiscount_integration_test.go
+++ b/services/marketplace-api/internal/billing/trial/subscribe_tenantdiscount_integration_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+
+package trial_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/tenantdiscount"
+	"github.com/mark8ly/marketplace-api/internal/billing/trial"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// mark8ly#660 T6, the "future stores" half. A tenant granted a platform
+// override before this store had a Stripe subscription must have it applied
+// when the subscription is finally created — otherwise the discount silently
+// stops covering the tenant as they grow.
+//
+// These use testdb (TEST_DATABASE_URL) rather than this file's neighbours'
+// openIntegrationDB (TEST_DB_DSN). `make test-int` exports only the former, so
+// a test written against the latter never runs there.
+
+// stubDiscounter stands in for tenantdiscount.Service at the port trial
+// declares. Hand-rolled per this repository's convention.
+type stubDiscounter struct {
+	calls   []tenantdiscount.NewSubscriptionInput
+	outcome tenantdiscount.Outcome
+	err     error
+}
+
+func (s *stubDiscounter) ApplyToNewSubscription(_ context.Context, in tenantdiscount.NewSubscriptionInput) (tenantdiscount.Outcome, error) {
+	s.calls = append(s.calls, in)
+	return s.outcome, s.err
+}
+
+func TestSubscribe_OffersTheNewSubscriptionToTheTenantsStandingOverride(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
+	seedSubscription(t, db, subscription.StoreSubscription{
+		TenantID:         tenantID,
+		StoreID:          storeID,
+		StripeCustomerID: "cus_test",
+		Status:           subscription.StatusSignup,
+	})
+
+	disc := &stubDiscounter{outcome: tenantdiscount.OutcomeApplied}
+	sub := trial.NewSubscriber(db, defaultFakeStripe(), nil).WithTenantDiscount(disc)
+
+	res, err := sub.Subscribe(context.Background(), buildInput(tenantID, storeID))
+	require.NoError(t, err)
+	require.Equal(t, "sub_test_123", res.StripeSubscriptionID)
+
+	require.Len(t, disc.calls, 1, "the newly created subscription must be offered to the override hook")
+	require.Equal(t, tenantdiscount.NewSubscriptionInput{
+		TenantID: tenantID, StoreID: storeID, StripeSubscriptionID: "sub_test_123",
+	}, disc.calls[0])
+}
+
+// THE LOAD-BEARING ONE. A discount that cannot be applied costs the tenant a
+// discount an operator can re-apply by hand; a discount that BLOCKS the call
+// costs the merchant their subscription. The first is recoverable and the
+// second is not, so this failure must never propagate.
+func TestSubscribe_ADiscountFailureDoesNotBlockTheSubscription(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
+	seedSubscription(t, db, subscription.StoreSubscription{
+		TenantID:         tenantID,
+		StoreID:          storeID,
+		StripeCustomerID: "cus_test",
+		Status:           subscription.StatusSignup,
+	})
+
+	disc := &stubDiscounter{err: errors.New("stripe is down")}
+	sub := trial.NewSubscriber(db, defaultFakeStripe(), nil).WithTenantDiscount(disc)
+
+	res, err := sub.Subscribe(context.Background(), buildInput(tenantID, storeID))
+	require.NoError(t, err, "a discount failure must never fail the subscription")
+	require.Equal(t, "sub_test_123", res.StripeSubscriptionID)
+
+	// And the subscription really landed, rather than being reported and
+	// rolled back: without this the assertion above would pass for a
+	// transaction that discarded everything.
+	var got subscription.StoreSubscription
+	require.NoError(t, db.Where("tenant_id = ? AND store_id = ?", tenantID, storeID).First(&got).Error)
+	require.NotNil(t, got.StripeSubscriptionID)
+	require.Equal(t, "sub_test_123", *got.StripeSubscriptionID)
+}
+
+// The hook is optional wiring: without Stripe billing configured there is no
+// tenantdiscount.Service to pass, and Subscribe must behave exactly as it did
+// before T6.
+func TestSubscribe_WithNoDiscounterWiredSubscribesUnchanged(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
+	seedSubscription(t, db, subscription.StoreSubscription{
+		TenantID:         tenantID,
+		StoreID:          storeID,
+		StripeCustomerID: "cus_test",
+		Status:           subscription.StatusSignup,
+	})
+
+	res, err := trial.NewSubscriber(db, defaultFakeStripe(), nil).
+		Subscribe(context.Background(), buildInput(tenantID, storeID))
+	require.NoError(t, err)
+	require.Equal(t, "sub_test_123", res.StripeSubscriptionID)
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount.go
@@ -449,9 +449,10 @@ func (h *BillingTenantDiscountHandler) releaseReservation(c *gin.Context, op, sc
 // tenant owns no stores" from "the store lookup broke" rather than getting
 // one opaque refusal.
 //
-// Apply and Remove return ErrNoTenant, ErrNoCoupon, ErrNoStores or a wrapped
-// store-lookup error, and nothing else — a single store's failure is a
-// StoreResult, not an error, because its siblings still committed. The two
+// Apply and Remove return ErrNoTenant, ErrNoCoupon, ErrNoStores,
+// ErrOverrideAlreadyRecorded, or a wrapped store-lookup or override-record
+// error, and nothing else — a single store's failure is a StoreResult, not an
+// error, because its siblings still committed. The two
 // per-store sentinels are matched here anyway, divergence first, so that a
 // future change which does surface one of them at the request level cannot
 // land it in the default branch and report a live billing divergence as a
@@ -470,6 +471,19 @@ func (h *BillingTenantDiscountHandler) respondDiscountErr(c *gin.Context, op str
 	case errors.Is(err, tenantdiscount.ErrNoCoupon):
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "invalid_coupon_id", "message": "coupon_id is required", "field": "coupon_id",
+		})
+	case errors.Is(err, tenantdiscount.ErrOverrideAlreadyRecorded):
+		// 409 and not 400: the request is well formed and would have been
+		// accepted a moment earlier or after a removal. Nothing was sent to
+		// Stripe, so a corrected retry is safe.
+		//
+		// The message says what to do rather than restating the refusal,
+		// because the operator's next move is not obvious: replacing an
+		// override is a removal and then an application, two audited acts,
+		// and this service will not fold them into one.
+		c.JSON(http.StatusConflict, gin.H{
+			"error":   "override_already_recorded",
+			"message": "this tenant already holds a platform discount applied by this service; remove it before applying a different coupon",
 		})
 	case errors.Is(err, tenantdiscount.ErrStripeChangedAuditWriteFailed):
 		// Checked BEFORE ErrStripeCall, and 500 rather than the 502 below:

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount.go
@@ -1,0 +1,500 @@
+package platformadmin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/tenantdiscount"
+	"github.com/mark8ly/marketplace-api/internal/idempotency"
+)
+
+// TenantDiscounter is the subset of internal/billing/tenantdiscount this
+// handler needs, declared locally so the handler is stubbable — the same
+// reason TrialExtender and TenantLifecycle are declared here rather than
+// imported. *tenantdiscount.Service satisfies it.
+//
+// Unlike TrialExtender there is no audit function parameter beside it: the
+// domain writes its own audit row with EmitTx, INSIDE each store's
+// transaction, which is the property tesserix-home#331 asks for and the one
+// an emit made out here could not have. See the mount guard in routes.go for
+// why this handler is still gated on the Emitter being wired.
+type TenantDiscounter interface {
+	Apply(ctx context.Context, in tenantdiscount.Input) (tenantdiscount.Result, error)
+	Remove(ctx context.Context, in tenantdiscount.Input) (tenantdiscount.Result, error)
+}
+
+// TenantDiscounterFuncs adapts a pair of free functions to TenantDiscounter.
+//
+// A struct of fields rather than a single func type like TrialExtenderFunc:
+// that pattern works only for a ONE-method interface, and this one has two.
+// A nil field panics on call, which is the same failure a nil TenantDiscounter
+// would produce and is not a case production wiring can reach — main.go
+// passes *tenantdiscount.Service, never this.
+type TenantDiscounterFuncs struct {
+	ApplyFunc  func(ctx context.Context, in tenantdiscount.Input) (tenantdiscount.Result, error)
+	RemoveFunc func(ctx context.Context, in tenantdiscount.Input) (tenantdiscount.Result, error)
+}
+
+func (f *TenantDiscounterFuncs) Apply(ctx context.Context, in tenantdiscount.Input) (tenantdiscount.Result, error) {
+	return f.ApplyFunc(ctx, in)
+}
+
+func (f *TenantDiscounterFuncs) Remove(ctx context.Context, in tenantdiscount.Input) (tenantdiscount.Result, error) {
+	return f.RemoveFunc(ctx, in)
+}
+
+// BillingTenantDiscountHandler serves POST and DELETE
+// /admin/billing/tenants/:tenantID/discount (#660).
+//
+// The path parameter is a BARE tenant uuid, like every other handler in this
+// package (tenant_lifecycle.go). The console addresses tenants with a
+// namespaced "<source>:<id>"; platform-api splits that before the request
+// reaches this service, so a namespaced value arriving here is a 400 and not
+// something to parse leniently.
+type BillingTenantDiscountHandler struct {
+	db     *gorm.DB
+	svc    TenantDiscounter
+	logger *slog.Logger
+}
+
+// NewBillingTenantDiscountHandler constructs the handler. logger may be nil —
+// slog.Default() is substituted, matching NewBillingTrialExtendHandler, so a
+// nil logger can never silence the divergence log below.
+func NewBillingTenantDiscountHandler(db *gorm.DB, svc TenantDiscounter, logger *slog.Logger) *BillingTenantDiscountHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &BillingTenantDiscountHandler{db: db, svc: svc, logger: logger}
+}
+
+// Register mounts both routes on the supplied group.
+func (h *BillingTenantDiscountHandler) Register(g *gin.RouterGroup) {
+	g.POST("/admin/billing/tenants/:tenantID/discount", h.apply)
+	g.DELETE("/admin/billing/tenants/:tenantID/discount", h.remove)
+}
+
+// tenantDiscountRequest is the body of BOTH routes. The DELETE carries one
+// too: it needs the coupon id to know which discount to take off (the
+// subscription may carry several, and a merchant's own promo must survive),
+// and it needs a reason for the same rule that makes the POST need one —
+// tesserix-home#331's "removal is as audited as application".
+type tenantDiscountRequest struct {
+	CouponID string `json:"coupon_id"`
+	Reason   string `json:"reason"`
+}
+
+// tenantDiscountStoreResponse is one store's line in the report. The
+// omitempty fields are genuinely absent rather than empty for the outcomes
+// that have no such id — a card-less trialing store has no Stripe
+// subscription, and a store with no subscription row has neither.
+type tenantDiscountStoreResponse struct {
+	StoreID              string `json:"store_id"`
+	SubscriptionID       string `json:"subscription_id,omitempty"`
+	StripeCustomerID     string `json:"stripe_customer_id,omitempty"`
+	StripeSubscriptionID string `json:"stripe_subscription_id,omitempty"`
+	Outcome              string `json:"outcome"`
+
+	// FailureCode and FailureReason are set only for OutcomeFailed.
+	// FailureReason is a FIXED message chosen from the code — the domain's
+	// error text can carry driver output and is logged server-side instead.
+	FailureCode   string `json:"failure_code,omitempty"`
+	FailureReason string `json:"failure_reason,omitempty"`
+}
+
+// tenantDiscountResponse is the fan-out report. Stores is the point of it:
+// outcomes differ per store, and flattening them to one status would discard
+// exactly what the console renders.
+type tenantDiscountResponse struct {
+	TenantID  string `json:"tenant_id"`
+	CouponID  string `json:"coupon_id"`
+	Operation string `json:"operation"` // "apply" | "remove"
+	Reason    string `json:"reason"`
+	// PerformedAt is the instant the fan-out started, not per store.
+	PerformedAt string `json:"performed_at"`
+
+	// Status is "ok" (no store failed), "partial" (some did) or "failed"
+	// (all did). A summary line, never a substitute for reading Stores.
+	Status string `json:"status"`
+
+	// RequiresReconciliation is set only when at least one store hit the
+	// ErrStripeChangedAuditWriteFailed divergence: Stripe holds — or no
+	// longer holds — the discount and no audit row explains it. Omitted
+	// rather than false so its presence is the signal.
+	RequiresReconciliation bool `json:"requires_reconciliation,omitempty"`
+
+	Stores []tenantDiscountStoreResponse `json:"stores"`
+}
+
+func (h *BillingTenantDiscountHandler) apply(c *gin.Context) {
+	h.handle(c, "apply", h.svc.Apply)
+}
+
+func (h *BillingTenantDiscountHandler) remove(c *gin.Context) {
+	h.handle(c, "remove", h.svc.Remove)
+}
+
+// handle is the whole endpoint. Apply and Remove differ only in which domain
+// call they make and in the operation name that scopes their idempotency key
+// and labels their report, so the validation, the idempotency dance and the
+// error mapping are written once.
+func (h *BillingTenantDiscountHandler) handle(
+	c *gin.Context,
+	op string,
+	call func(ctx context.Context, in tenantdiscount.Input) (tenantdiscount.Result, error),
+) {
+	idemKey := strings.TrimSpace(c.GetHeader("Idempotency-Key"))
+	if idemKey == "" {
+		// A write that cannot be retried safely is worse than one that
+		// refuses to start. The DELETE is held to the same rule as the
+		// POST: revoking a discount is as much a billing change as
+		// granting one.
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "idempotency_key_required", "message": "the Idempotency-Key header is required for this endpoint",
+		})
+		return
+	}
+
+	tenantID, err := uuid.Parse(strings.TrimSpace(c.Param("tenantID")))
+	if err != nil {
+		// 400, not 500: a malformed id is the caller's error. Same shape as
+		// tenant_lifecycle.go's invalid_tenant_id so the console handles
+		// every write on this surface the same way. A namespaced
+		// "<source>:<id>" from the console lands here too — platform-api
+		// splits it upstream, and guessing at one here would silently
+		// address a tenant nobody named.
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_tenant_id", "message": "tenant id is not a valid uuid", "field": "tenant_id",
+		})
+		return
+	}
+
+	var req tenantDiscountRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		// gin returns io.EOF for a completely empty body, so an omitted
+		// body is rejected HERE. `{}` binds to the zero value and is what
+		// the two field checks below exist to catch.
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_request", "message": "request body could not be parsed",
+		})
+		return
+	}
+
+	couponID := strings.TrimSpace(req.CouponID)
+	if couponID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_coupon_id", "message": "coupon_id is required", "field": "coupon_id",
+		})
+		return
+	}
+
+	reason := strings.TrimSpace(req.Reason)
+	if reason == "" {
+		// Mandatory, both directions. An audit row that says what happened
+		// without saying why is the gap this series exists to close, and
+		// there is no reason_code vocabulary for a discount to fall back on
+		// the way ExtendReasonCodes serves trial extension.
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_reason", "message": "reason is required", "field": "reason",
+		})
+		return
+	}
+	if len(reason) > maxReasonLen {
+		// truncateUTF8, never reason[:maxReasonLen]: the domain puts this
+		// string straight into the audit row's jsonb metadata, and a
+		// half-rune left by a raw byte slice fails that marshal. Under
+		// EmitTx that failure is no longer "the write succeeded
+		// unaudited" — the audit insert is inside the store's
+		// transaction, so it rolls the store back and the discount
+		// SILENTLY DOES NOT APPLY. See truncateUTF8's own doc comment for
+		// the pre-EmitTx version of this hazard.
+		reason = truncateUTF8(reason, maxReasonLen)
+	}
+
+	// Namespaced by OPERATION as well as by tenant. idempotency_keys.key is
+	// a bare primary key shared by the whole service and the caller's raw
+	// header is theirs to choose, so without the tenant an operator's key
+	// would replay one tenant's report onto another. The operation is in
+	// there for the same reason and one step further: apply and remove are
+	// opposite changes on the same path, so a key reused to REVOKE a
+	// discount the operator just granted would otherwise replay the grant's
+	// stored report and leave the discount on.
+	scopedKey := "tenant_discount:" + op + ":" + tenantID.String() + ":" + idemKey
+
+	// Reserve immediately before the work, AFTER every validation step
+	// above: validation is deterministic, so two concurrent callers with
+	// the same key either both pass it or both fail it identically, and
+	// only then race on Reserve. Reserving any earlier would let a failed
+	// attempt (a malformed body, a blank coupon id, a missing reason, or a
+	// domain refusal below) leave the key claimed with an empty Response
+	// for the full TTL — turning a mistyped request into a key that answers
+	// 409 in_progress for a day.
+	if h.db != nil {
+		// Reserve BEFORE doing the work, not Lookup-then-Save after: two
+		// pods handling the same retry can both miss a plain Lookup before
+		// either writes. Reserve claims the key itself first.
+		claimed, err := idempotency.Reserve(c.Request.Context(), h.db, scopedKey, tenantID.String(), time.Now().UTC(), idempotency.DefaultTTL)
+		if err != nil {
+			// Fail CLOSED: a caller that cannot be told whether this key
+			// was already used must not be allowed through to a second
+			// fan-out and a second set of audit rows.
+			h.logger.Error("tenant discount: idempotency reserve failed",
+				"op", op, "tenant_id", tenantID.String(), "err", err)
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"error": "unavailable", "message": "could not verify idempotency key",
+			})
+			return
+		}
+		if !claimed {
+			stored, ok, err := idempotency.Lookup(c.Request.Context(), h.db, scopedKey)
+			if err != nil {
+				h.logger.Error("tenant discount: idempotency lookup failed",
+					"op", op, "tenant_id", tenantID.String(), "err", err)
+				c.JSON(http.StatusServiceUnavailable, gin.H{
+					"error": "unavailable", "message": "could not verify idempotency key",
+				})
+				return
+			}
+			if ok {
+				// A replay: return the stored bytes verbatim, without a
+				// second fan-out and so without a second Stripe call or a
+				// second audit row.
+				c.Data(http.StatusOK, "application/json; charset=utf-8", stored)
+				return
+			}
+			// Reserved but not yet completed: another caller (or another
+			// pod handling the SAME retry) is still doing the work.
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "in_progress", "message": "a request with this Idempotency-Key is already in flight",
+			})
+			return
+		}
+	}
+
+	performedAt := time.Now().UTC()
+	res, err := call(c.Request.Context(), tenantdiscount.Input{
+		TenantID: tenantID,
+		CouponID: couponID,
+		Reason:   reason,
+		// The gin context is what lets audit.buildEntry derive the
+		// operator, capability and IP for every row the fan-out writes.
+		C: c,
+	})
+	if err != nil {
+		h.releaseReservation(c, op, scopedKey)
+		h.respondDiscountErr(c, op, err)
+		return
+	}
+
+	resp := h.buildResponse(op, reason, performedAt, res)
+
+	// The key is COMPLETED even for a partial result. The stores that
+	// committed must not be re-applied by a retry of the same key; retrying
+	// the stores that failed is a new operator decision and takes a new
+	// key, which the domain answers idempotently anyway (a store that
+	// already carries the coupon reports already_applied).
+	if h.db != nil {
+		if body, err := json.Marshal(resp); err != nil {
+			h.logger.Error("tenant discount: could not marshal response for idempotency save", "op", op, "err", err)
+		} else if err := idempotency.Complete(c.Request.Context(), h.db, scopedKey, body); err != nil {
+			// Logged, not surfaced: the fan-out already happened, and
+			// failing the response would make the caller retry work that
+			// succeeded.
+			h.logger.Error("tenant discount: idempotency complete failed",
+				"op", op, "tenant_id", tenantID.String(), "err", err)
+		}
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+// buildResponse turns the domain's report into the wire shape, and logs the
+// per-store failures whose detail must not travel in the response.
+//
+// Deliberately NO failure audit row is written here. See the package-level
+// note in routes.go's mount guard for the decision; in short: the domain
+// already writes an EmitTx row for every store whose transaction COMMITS,
+// including the ones where nothing was applied, so the only unrecorded cases
+// are stores that rolled back — and for the divergence, a handler-written
+// row saying "failed" would be actively false, because Stripe did change.
+func (h *BillingTenantDiscountHandler) buildResponse(
+	op, reason string, performedAt time.Time, res tenantdiscount.Result,
+) tenantDiscountResponse {
+	resp := tenantDiscountResponse{
+		TenantID:    res.TenantID.String(),
+		CouponID:    res.CouponID,
+		Operation:   op,
+		Reason:      reason,
+		PerformedAt: performedAt.Format(time.RFC3339),
+		Stores:      make([]tenantDiscountStoreResponse, 0, len(res.Stores)),
+	}
+
+	failed := 0
+	for _, s := range res.Stores {
+		line := tenantDiscountStoreResponse{
+			StoreID:              s.StoreID.String(),
+			StripeCustomerID:     s.StripeCustomerID,
+			StripeSubscriptionID: s.StripeSubscriptionID,
+			Outcome:              string(s.Outcome),
+		}
+		if s.SubscriptionID != uuid.Nil {
+			line.SubscriptionID = s.SubscriptionID.String()
+		}
+		if s.Outcome == tenantdiscount.OutcomeFailed {
+			failed++
+			line.FailureCode, line.FailureReason = storeFailure(s)
+			if line.FailureCode == codeStripeChangedAuditWriteFailed {
+				resp.RequiresReconciliation = true
+			}
+			// The domain already logs the divergence with the three ids a
+			// human needs. This line adds the ones only the handler knows —
+			// which operator request this store belonged to — and is the
+			// only record of an ordinary per-store failure, whose driver
+			// text never travels in the response.
+			h.logger.Error("tenant discount: store failed",
+				"op", op,
+				"tenant_id", res.TenantID.String(),
+				"store_id", s.StoreID.String(),
+				"coupon_id", res.CouponID,
+				"failure_code", line.FailureCode,
+				"err", s.Err)
+		}
+		resp.Stores = append(resp.Stores, line)
+	}
+
+	switch {
+	case failed == 0:
+		resp.Status = "ok"
+	case failed == len(res.Stores):
+		resp.Status = "failed"
+	default:
+		resp.Status = "partial"
+	}
+	return resp
+}
+
+// codeStripeChangedAuditWriteFailed names the one divergence this design
+// accepts: Stripe's subscription changed and the audit row that would have
+// explained it did not commit. It is its own code — never the routine
+// audit_write_failed or commit_failed the domain also records on the same
+// StoreResult, and never a plain database error — for the same reason
+// trial's stripe_applied_local_write_failed is: something very much happened,
+// to a real billing arrangement, and it needs manual reconciliation.
+const codeStripeChangedAuditWriteFailed = "stripe_changed_audit_write_failed"
+
+// storeFailure maps a failed store to a stable code and a fixed message.
+//
+// The divergence is checked FIRST, before the Stripe branch. Today the two
+// can never both match a real error value — ErrStripeChangedAuditWriteFailed
+// wraps the audit insert's or the commit's own error, on a path where the
+// Stripe call already succeeded — but the ordering still puts the more
+// specific, higher-stakes sentinel first so a future wrapping change cannot
+// silently demote it to the ordinary Stripe failure.
+//
+// The message is composed here, never taken from err.Error(): the domain
+// wraps driver output, which is logged server-side and not echoed.
+func storeFailure(s tenantdiscount.StoreResult) (code, message string) {
+	switch {
+	case errors.Is(s.Err, tenantdiscount.ErrStripeChangedAuditWriteFailed):
+		return codeStripeChangedAuditWriteFailed,
+			"stripe accepted the discount change but the audit row was not written, so the change was rolled back locally and stripe and this service now disagree; this store requires manual reconciliation"
+	case errors.Is(s.Err, tenantdiscount.ErrStripeCall):
+		return string(tenantdiscount.FailureStripeCall),
+			"the stripe call failed and nothing was changed for this store; it can be retried"
+	case s.FailureCode == tenantdiscount.FailureLoadSubscription:
+		return string(tenantdiscount.FailureLoadSubscription),
+			"this store's subscription could not be read, so nothing was changed for it"
+	case s.FailureCode == tenantdiscount.FailureAuditWrite, s.FailureCode == tenantdiscount.FailureCommit:
+		// Reached only when Stripe was NOT changed — a store whose outcome
+		// needed no Stripe call (pending, no_subscription, no_stripe_customer)
+		// and whose audit row or commit then failed. The transaction rolled
+		// back and nothing diverged.
+		return string(s.FailureCode),
+			"this store's audit row could not be committed, so nothing was changed for it"
+	default:
+		return "internal_error", "this store failed for an unexpected reason; see the service logs"
+	}
+}
+
+// releaseReservation drops a Reserve claim that will never be Completed,
+// because the domain refused or failed the WHOLE request. Without it the
+// reservation would sit on the key with an empty Response for the full TTL,
+// answering 409 in_progress to a corrected retry for a day.
+//
+// A per-store failure does NOT come through here: those requests completed,
+// and their report is stored — see the Complete call in handle.
+//
+// The Release failure is logged, not surfaced: the caller already has the
+// real error from respondDiscountErr, and a failed Release just means the
+// reservation lives out its TTL instead of being cleared early.
+func (h *BillingTenantDiscountHandler) releaseReservation(c *gin.Context, op, scopedKey string) {
+	if h.db == nil {
+		return
+	}
+	if err := idempotency.Release(c.Request.Context(), h.db, scopedKey); err != nil {
+		h.logger.Error("tenant discount: idempotency release failed", "op", op, "err", err)
+	}
+}
+
+// respondDiscountErr maps the errors Apply and Remove return for the WHOLE
+// request to distinct statuses and codes, so the console can tell "this
+// tenant owns no stores" from "the store lookup broke" rather than getting
+// one opaque refusal.
+//
+// Apply and Remove return ErrNoTenant, ErrNoCoupon, ErrNoStores or a wrapped
+// store-lookup error, and nothing else — a single store's failure is a
+// StoreResult, not an error, because its siblings still committed. The two
+// per-store sentinels are matched here anyway, divergence first, so that a
+// future change which does surface one of them at the request level cannot
+// land it in the default branch and report a live billing divergence as a
+// generic internal error.
+func (h *BillingTenantDiscountHandler) respondDiscountErr(c *gin.Context, op string, err error) {
+	switch {
+	case errors.Is(err, tenantdiscount.ErrNoStores):
+		c.JSON(http.StatusNotFound, gin.H{
+			"error":   "no_stores",
+			"message": "this tenant owns no stores, so there is no subscription to carry the discount",
+		})
+	case errors.Is(err, tenantdiscount.ErrNoTenant):
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_tenant_id", "message": "tenant id is required", "field": "tenant_id",
+		})
+	case errors.Is(err, tenantdiscount.ErrNoCoupon):
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_coupon_id", "message": "coupon_id is required", "field": "coupon_id",
+		})
+	case errors.Is(err, tenantdiscount.ErrStripeChangedAuditWriteFailed):
+		// Checked BEFORE ErrStripeCall, and 500 rather than the 502 below:
+		// a 502 tells the caller nothing happened, and here something very
+		// much happened to a real billing arrangement. The wrapped
+		// AuditDivergenceError carries the coupon, subscription and
+		// customer ids; they go to the log, not to the response.
+		h.logger.Error("tenant discount: stripe changed but the audit row was not written; manual reconciliation required",
+			"op", op, "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   codeStripeChangedAuditWriteFailed,
+			"message": "stripe accepted the discount change but the audit row was not written; stripe and this service now disagree and require manual reconciliation",
+		})
+	case errors.Is(err, tenantdiscount.ErrStripeCall):
+		// 502, not the 503 above: 503 means OUR idempotency store is
+		// unreachable, 502 means the dependency failed.
+		h.logger.Error("tenant discount: stripe call failed", "op", op, "err", err)
+		c.JSON(http.StatusBadGateway, gin.H{
+			"error": "stripe_unavailable", "message": "could not change the discount in stripe; nothing was changed",
+		})
+	default:
+		h.logger.Error("tenant discount failed", "op", op, "err", err)
+		// The driver's error text is logged server-side, never echoed.
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "internal_error", "message": "could not change the tenant discount",
+		})
+	}
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount_integration_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount_integration_test.go
@@ -1,0 +1,166 @@
+//go:build integration
+
+package platformadmin_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/tenantdiscount"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// discountRouter mounts the handler against a real database, which is what
+// makes the Reserve/Lookup/Complete/Release dance in the handler reachable
+// at all — the unit tests pass a nil DB and skip it entirely.
+func discountRouter(db *gorm.DB, svc platformadmin.TenantDiscounter) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	platformadmin.NewBillingTenantDiscountHandler(db, svc, nil).Register(r.Group(""))
+	return r
+}
+
+func sendDiscount(r *gin.Engine, method, tenantID, key, body string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, discountPath(tenantID), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", key)
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// The same key replays the stored body without calling the domain a second
+// time — no second Stripe round-trip and no second audit row, since both
+// live inside Apply. A different key is a new request.
+func TestTenantDiscountIsIdempotentPerKey(t *testing.T) {
+	db := testdb.NewDB(t, "idempotency_keys")
+	svc := &stubDiscounter{applyResult: twoStoreApplyResult()}
+	r := discountRouter(db, svc)
+
+	first := sendDiscount(r, http.MethodPost, discountTenantID.String(), "key-alpha", discountBody)
+	require.Equal(t, http.StatusOK, first.Code, first.Body.String())
+
+	second := sendDiscount(r, http.MethodPost, discountTenantID.String(), "key-alpha", discountBody)
+	require.Equal(t, http.StatusOK, second.Code, second.Body.String())
+	require.JSONEq(t, first.Body.String(), second.Body.String(), "same key must replay the same body")
+	require.Equal(t, 1, svc.applyCalls, "same key must NOT apply the discount a second time")
+
+	third := sendDiscount(r, http.MethodPost, discountTenantID.String(), "key-beta", discountBody)
+	require.Equal(t, http.StatusOK, third.Code, third.Body.String())
+	require.Equal(t, 2, svc.applyCalls, "a DIFFERENT key is a new request")
+}
+
+// idempotency_keys.key is a bare primary key shared by the whole service, so
+// the handler scopes it. Reusing one key against two tenants must perform
+// TWO fan-outs and return each tenant's own report, not replay the first
+// tenant's body onto the second.
+func TestTenantDiscountKeyDoesNotReplayAcrossTenants(t *testing.T) {
+	db := testdb.NewDB(t, "idempotency_keys")
+
+	tenantA := uuid.New()
+	tenantB := uuid.New()
+
+	var seen []uuid.UUID
+	svc := &platformadmin.TenantDiscounterFuncs{
+		ApplyFunc: func(_ context.Context, in tenantdiscount.Input) (tenantdiscount.Result, error) {
+			seen = append(seen, in.TenantID)
+			return tenantdiscount.Result{
+				TenantID: in.TenantID,
+				CouponID: in.CouponID,
+				Stores: []tenantdiscount.StoreResult{
+					{StoreID: uuid.New(), Outcome: tenantdiscount.OutcomeApplied, StripeSubscriptionID: "sub_x"},
+				},
+			}, nil
+		},
+	}
+	r := discountRouter(db, svc)
+
+	first := sendDiscount(r, http.MethodPost, tenantA.String(), "shared-key", discountBody)
+	require.Equal(t, http.StatusOK, first.Code, first.Body.String())
+	second := sendDiscount(r, http.MethodPost, tenantB.String(), "shared-key", discountBody)
+	require.Equal(t, http.StatusOK, second.Code, second.Body.String())
+
+	require.Equal(t, []uuid.UUID{tenantA, tenantB},
+		seen, "the same key against two tenants must perform TWO fan-outs")
+
+	var firstResp, secondResp struct {
+		TenantID string `json:"tenant_id"`
+	}
+	require.NoError(t, json.Unmarshal(first.Body.Bytes(), &firstResp))
+	require.NoError(t, json.Unmarshal(second.Body.Bytes(), &secondResp))
+	require.Equal(t, tenantA.String(), firstResp.TenantID)
+	require.Equal(t, tenantB.String(), secondResp.TenantID)
+}
+
+// Apply and Remove are opposite billing changes, so they must not share one
+// idempotency namespace: an operator reusing a key to REVOKE a discount they
+// just applied would otherwise get the apply's stored report back and the
+// discount would silently stay on.
+func TestTenantDiscountApplyAndRemoveDoNotShareAnIdempotencyScope(t *testing.T) {
+	db := testdb.NewDB(t, "idempotency_keys")
+	removed := twoStoreApplyResult()
+	removed.Stores[0].Outcome = tenantdiscount.OutcomeRemoved
+	svc := &stubDiscounter{applyResult: twoStoreApplyResult(), removeResult: removed}
+	r := discountRouter(db, svc)
+
+	applied := sendDiscount(r, http.MethodPost, discountTenantID.String(), "same-key", discountBody)
+	require.Equal(t, http.StatusOK, applied.Code, applied.Body.String())
+
+	revoked := sendDiscount(r, http.MethodDelete, discountTenantID.String(), "same-key", discountBody)
+	require.Equal(t, http.StatusOK, revoked.Code, revoked.Body.String())
+
+	require.Equal(t, 1, svc.removeCalls, "the DELETE must run, not replay the POST's stored report")
+	body := map[string]any{}
+	require.NoError(t, json.Unmarshal(revoked.Body.Bytes(), &body))
+	require.Equal(t, "remove", body["operation"])
+}
+
+// A domain refusal releases the reservation, so a corrected retry with the
+// SAME key proceeds instead of answering 409 in_progress for the full TTL.
+func TestTenantDiscountCorrectedRetryAfterDomainFailureProceeds(t *testing.T) {
+	db := testdb.NewDB(t, "idempotency_keys")
+	svc := &stubDiscounter{applyErr: tenantdiscount.ErrNoStores}
+	r := discountRouter(db, svc)
+
+	refused := sendDiscount(r, http.MethodPost, discountTenantID.String(), "key-retry", discountBody)
+	require.Equal(t, http.StatusNotFound, refused.Code, refused.Body.String())
+
+	// The operator fixes whatever was wrong and retries the same request.
+	svc.applyErr = nil
+	svc.applyResult = twoStoreApplyResult()
+	retried := sendDiscount(r, http.MethodPost, discountTenantID.String(), "key-retry", discountBody)
+	require.Equal(t, http.StatusOK, retried.Code, retried.Body.String())
+	require.Equal(t, 2, svc.applyCalls, "the corrected retry must reach the domain")
+}
+
+// A partial result — one store applied, one failed — still COMPLETES the
+// key. The stores that committed must not be re-applied by a retry of the
+// same key; a retry aimed at the failed store is a new operator decision and
+// takes a new key.
+func TestTenantDiscountPartialResultCompletesTheKey(t *testing.T) {
+	db := testdb.NewDB(t, "idempotency_keys")
+	res := twoStoreApplyResult()
+	res.Stores[1].Outcome = tenantdiscount.OutcomeFailed
+	res.Stores[1].FailureCode = tenantdiscount.FailureStripeCall
+	res.Stores[1].Err = tenantdiscount.ErrStripeCall
+	svc := &stubDiscounter{applyResult: res}
+	r := discountRouter(db, svc)
+
+	first := sendDiscount(r, http.MethodPost, discountTenantID.String(), "key-partial", discountBody)
+	require.Equal(t, http.StatusOK, first.Code, first.Body.String())
+
+	second := sendDiscount(r, http.MethodPost, discountTenantID.String(), "key-partial", discountBody)
+	require.Equal(t, http.StatusOK, second.Code, second.Body.String())
+	require.JSONEq(t, first.Body.String(), second.Body.String())
+	require.Equal(t, 1, svc.applyCalls, "a partial result is a completed request, not a retryable one")
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount_test.go
@@ -1,0 +1,463 @@
+package platformadmin_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/tenantdiscount"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+)
+
+var discountTenantID = uuid.MustParse("dddddddd-1111-1111-1111-111111111111")
+var discountStoreA = uuid.MustParse("dddddddd-2222-2222-2222-222222222222")
+var discountStoreB = uuid.MustParse("dddddddd-3333-3333-3333-333333333333")
+
+// stubDiscounter records what the handler asked for and returns a canned
+// report. Hand-rolled rather than generated: the package has no mocking
+// framework and stubExtender (billing_trial_extend_test.go) is the shape
+// every double on this surface follows.
+type stubDiscounter struct {
+	applyResult  tenantdiscount.Result
+	removeResult tenantdiscount.Result
+	applyErr     error
+	removeErr    error
+
+	applyCalls  int
+	removeCalls int
+	gotIn       tenantdiscount.Input
+}
+
+func (s *stubDiscounter) Apply(_ context.Context, in tenantdiscount.Input) (tenantdiscount.Result, error) {
+	s.applyCalls++
+	s.gotIn = in
+	if s.applyErr != nil {
+		return tenantdiscount.Result{}, s.applyErr
+	}
+	return s.applyResult, nil
+}
+
+func (s *stubDiscounter) Remove(_ context.Context, in tenantdiscount.Input) (tenantdiscount.Result, error) {
+	s.removeCalls++
+	s.gotIn = in
+	if s.removeErr != nil {
+		return tenantdiscount.Result{}, s.removeErr
+	}
+	return s.removeResult, nil
+}
+
+// twoStoreApplyResult is the fan-out this endpoint exists to report: one
+// store where the coupon went on, one card-less trialing store that could
+// not carry it. A response that flattened these to a single status would
+// throw away exactly the thing the console renders.
+func twoStoreApplyResult() tenantdiscount.Result {
+	return tenantdiscount.Result{
+		TenantID: discountTenantID,
+		CouponID: "cpn_test",
+		Stores: []tenantdiscount.StoreResult{
+			{
+				StoreID:              discountStoreA,
+				SubscriptionID:       uuid.MustParse("dddddddd-4444-4444-4444-444444444444"),
+				StripeCustomerID:     "cus_a",
+				StripeSubscriptionID: "sub_a",
+				Outcome:              tenantdiscount.OutcomeApplied,
+			},
+			{
+				StoreID:          discountStoreB,
+				SubscriptionID:   uuid.MustParse("dddddddd-5555-5555-5555-555555555555"),
+				StripeCustomerID: "cus_b",
+				Outcome:          tenantdiscount.OutcomePending,
+			},
+		},
+	}
+}
+
+const discountBody = `{"coupon_id":"cpn_test","reason":"negotiated renewal discount"}`
+
+func discountPath(tenantID string) string {
+	return "/admin/billing/tenants/" + tenantID + "/discount"
+}
+
+// doDiscount drives the handler with a nil DB, which is how the trial
+// extend unit tests skip the idempotency store: the missing-header check
+// still fires, but nothing touches Postgres. Integration coverage of the
+// idempotency dance lives in billing_tenant_discount_integration_test.go.
+func doDiscount(t *testing.T, svc platformadmin.TenantDiscounter, method, tenantID, body string, withKey bool) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	platformadmin.NewBillingTenantDiscountHandler(nil, svc, nil).Register(r.Group(""))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, discountPath(tenantID), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	if withKey {
+		req.Header.Set("Idempotency-Key", "test-key-"+tenantID)
+	}
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeDiscount(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got), rec.Body.String())
+	return got
+}
+
+// Both routes refuse without an Idempotency-Key: a write that cannot be
+// retried safely is worse than one that refuses to start, and the DELETE
+// is as much a billing change as the POST.
+func TestTenantDiscountRequiresIdempotencyKey(t *testing.T) {
+	for _, method := range []string{http.MethodPost, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			svc := &stubDiscounter{applyResult: twoStoreApplyResult(), removeResult: twoStoreApplyResult()}
+			rec := doDiscount(t, svc, method, discountTenantID.String(), discountBody, false)
+			require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+			require.Equal(t, "idempotency_key_required", decodeDiscount(t, rec)["error"])
+			require.Zero(t, svc.applyCalls+svc.removeCalls, "the domain must not be called at all")
+		})
+	}
+}
+
+// A blank Idempotency-Key is the same refusal as a missing one — the
+// header is trimmed before it is judged.
+func TestTenantDiscountRejectsBlankIdempotencyKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &stubDiscounter{applyResult: twoStoreApplyResult()}
+	r := gin.New()
+	platformadmin.NewBillingTenantDiscountHandler(nil, svc, nil).Register(r.Group(""))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, discountPath(discountTenantID.String()),
+		bytes.NewBufferString(discountBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", "   ")
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	require.Equal(t, "idempotency_key_required", decodeDiscount(t, rec)["error"])
+	require.Zero(t, svc.applyCalls)
+}
+
+// A malformed tenant id is 400, not 500 — the caller's error, in the shape
+// tenant_lifecycle.go already returns so the console handles every write on
+// this surface the same way.
+func TestTenantDiscountRejectsInvalidTenantID(t *testing.T) {
+	for _, method := range []string{http.MethodPost, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			svc := &stubDiscounter{}
+			rec := doDiscount(t, svc, method, "not-a-uuid", discountBody, true)
+			require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+			body := decodeDiscount(t, rec)
+			require.Equal(t, "invalid_tenant_id", body["error"])
+			require.Equal(t, "tenant_id", body["field"])
+			require.Zero(t, svc.applyCalls+svc.removeCalls)
+		})
+	}
+}
+
+// The console's namespaced "<source>:<id>" is NOT accepted here: platform-api
+// splits it before it reaches this service (PR 2). Sending one must be a
+// clean 400, never a tenant id that half-parses.
+func TestTenantDiscountRejectsNamespacedTenantID(t *testing.T) {
+	svc := &stubDiscounter{}
+	rec := doDiscount(t, svc, http.MethodPost, "mark8ly:"+discountTenantID.String(), discountBody, true)
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	require.Equal(t, "invalid_tenant_id", decodeDiscount(t, rec)["error"])
+	require.Zero(t, svc.applyCalls)
+}
+
+func TestTenantDiscountRequiresCouponID(t *testing.T) {
+	for _, method := range []string{http.MethodPost, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			svc := &stubDiscounter{}
+			rec := doDiscount(t, svc, method, discountTenantID.String(),
+				`{"coupon_id":"  ","reason":"why"}`, true)
+			require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+			body := decodeDiscount(t, rec)
+			require.Equal(t, "invalid_coupon_id", body["error"])
+			require.Equal(t, "coupon_id", body["field"])
+			require.Zero(t, svc.applyCalls+svc.removeCalls)
+		})
+	}
+}
+
+// The reason is mandatory on BOTH routes: tesserix-home#331's rule is that
+// removal is as audited as application, and an audit row saying what
+// happened without why is the gap this series exists to close.
+func TestTenantDiscountRequiresReason(t *testing.T) {
+	for _, method := range []string{http.MethodPost, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			svc := &stubDiscounter{}
+			rec := doDiscount(t, svc, method, discountTenantID.String(),
+				`{"coupon_id":"cpn_test","reason":"   "}`, true)
+			require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+			body := decodeDiscount(t, rec)
+			require.Equal(t, "invalid_reason", body["error"])
+			require.Equal(t, "reason", body["field"])
+			require.Zero(t, svc.applyCalls+svc.removeCalls)
+		})
+	}
+}
+
+// An omitted body is rejected by the binder (gin returns io.EOF), before
+// the field checks above ever run.
+func TestTenantDiscountRejectsUnparseableBody(t *testing.T) {
+	svc := &stubDiscounter{}
+	rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), ``, true)
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	require.Equal(t, "invalid_request", decodeDiscount(t, rec)["error"])
+	require.Zero(t, svc.applyCalls)
+}
+
+// The reason is truncated on a RUNE boundary before it reaches the domain,
+// which puts it straight into the audit row's jsonb metadata. Invalid UTF-8
+// there fails the marshal, and under EmitTx that failure rolls the store's
+// transaction back — so a mis-truncated reason does not mean "succeeded
+// unaudited", it means the discount silently did not apply.
+func TestTenantDiscountTruncatesReasonOnARuneBoundary(t *testing.T) {
+	// "€" is THREE bytes, so a 500-byte cap lands mid-rune (500 = 166*3 + 2)
+	// and the truncation has real work to do. A 2-byte rune would divide the
+	// cap exactly and the test would pass without exercising anything.
+	long := strings.Repeat("€", 300)
+	body, err := json.Marshal(map[string]string{"coupon_id": "cpn_test", "reason": long})
+	require.NoError(t, err)
+
+	svc := &stubDiscounter{applyResult: twoStoreApplyResult()}
+	rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), string(body), true)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	require.Equal(t, 1, svc.applyCalls)
+	got := svc.gotIn.Reason
+	require.LessOrEqual(t, len(got), 500, "reason must be capped before it reaches the domain")
+	require.True(t, utf8.ValidString(got), "a truncated reason must still be valid UTF-8")
+	require.Equal(t, 498, len(got), "the two bytes of the half rune at the 500-byte cap must be dropped, not kept")
+}
+
+// The fan-out's whole point is that outcomes differ per store, so the
+// response carries one line per store rather than a single status.
+func TestTenantDiscountApplyReportsPerStore(t *testing.T) {
+	svc := &stubDiscounter{applyResult: twoStoreApplyResult()}
+	rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), discountBody, true)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	body := decodeDiscount(t, rec)
+	require.Equal(t, discountTenantID.String(), body["tenant_id"])
+	require.Equal(t, "cpn_test", body["coupon_id"])
+	require.Equal(t, "apply", body["operation"])
+	require.Equal(t, "ok", body["status"])
+
+	stores, ok := body["stores"].([]any)
+	require.True(t, ok, "stores must be an array: %s", rec.Body.String())
+	require.Len(t, stores, 2)
+
+	first := stores[0].(map[string]any)
+	require.Equal(t, discountStoreA.String(), first["store_id"])
+	require.Equal(t, "applied", first["outcome"])
+	require.Equal(t, "sub_a", first["stripe_subscription_id"])
+
+	second := stores[1].(map[string]any)
+	require.Equal(t, discountStoreB.String(), second["store_id"])
+	require.Equal(t, "pending", second["outcome"])
+	require.NotContains(t, second, "stripe_subscription_id",
+		"a card-less store has no stripe subscription id to report")
+
+	require.Equal(t, 1, svc.applyCalls)
+	require.Zero(t, svc.removeCalls)
+	require.Equal(t, discountTenantID, svc.gotIn.TenantID)
+	require.Equal(t, "cpn_test", svc.gotIn.CouponID)
+	require.Equal(t, "negotiated renewal discount", svc.gotIn.Reason)
+	require.NotNil(t, svc.gotIn.C, "the gin context must be forwarded so the audit row names the operator")
+}
+
+// DELETE reaches Remove, not Apply, and reports the same per-store shape.
+func TestTenantDiscountRemoveReportsPerStore(t *testing.T) {
+	res := twoStoreApplyResult()
+	res.Stores[0].Outcome = tenantdiscount.OutcomeRemoved
+	res.Stores[1].Outcome = tenantdiscount.OutcomeNotApplied
+	svc := &stubDiscounter{removeResult: res}
+
+	rec := doDiscount(t, svc, http.MethodDelete, discountTenantID.String(), discountBody, true)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	body := decodeDiscount(t, rec)
+	require.Equal(t, "remove", body["operation"])
+	stores := body["stores"].([]any)
+	require.Equal(t, "removed", stores[0].(map[string]any)["outcome"])
+	require.Equal(t, "not_applied", stores[1].(map[string]any)["outcome"])
+
+	require.Equal(t, 1, svc.removeCalls)
+	require.Zero(t, svc.applyCalls, "DELETE must never apply a discount")
+}
+
+// Every outcome the domain declares survives the trip to JSON under its own
+// name. A response that collapsed two of them would make the console show
+// "nothing happened" for a store where something did.
+func TestTenantDiscountSurfacesEveryOutcomeVerbatim(t *testing.T) {
+	all := []tenantdiscount.Outcome{
+		tenantdiscount.OutcomeApplied,
+		tenantdiscount.OutcomeAlreadyApplied,
+		tenantdiscount.OutcomeRemoved,
+		tenantdiscount.OutcomeNotApplied,
+		tenantdiscount.OutcomePending,
+		tenantdiscount.OutcomeNoSubscription,
+		tenantdiscount.OutcomeNoStripeCustomer,
+	}
+	res := tenantdiscount.Result{TenantID: discountTenantID, CouponID: "cpn_test"}
+	for range all {
+		res.Stores = append(res.Stores, tenantdiscount.StoreResult{StoreID: uuid.New()})
+	}
+	for i, o := range all {
+		res.Stores[i].Outcome = o
+	}
+
+	svc := &stubDiscounter{applyResult: res}
+	rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), discountBody, true)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	stores := decodeDiscount(t, rec)["stores"].([]any)
+	require.Len(t, stores, len(all))
+	for i, o := range all {
+		require.Equal(t, string(o), stores[i].(map[string]any)["outcome"])
+	}
+}
+
+// A failed store carries a stage-named failure code and a fixed message —
+// never the driver's own error text, which is logged server-side instead.
+func TestTenantDiscountFailedStoreNeverEchoesDriverText(t *testing.T) {
+	res := twoStoreApplyResult()
+	res.Stores[1].Outcome = tenantdiscount.OutcomeFailed
+	res.Stores[1].FailureCode = tenantdiscount.FailureLoadSubscription
+	res.Stores[1].Err = errors.New(`pq: relation "store_subscriptions" does not exist`)
+
+	svc := &stubDiscounter{applyResult: res}
+	rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), discountBody, true)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.NotContains(t, rec.Body.String(), "does not exist", "driver text must never be echoed")
+
+	body := decodeDiscount(t, rec)
+	require.Equal(t, "partial", body["status"], "one applied store and one failed store is a partial result")
+	failed := body["stores"].([]any)[1].(map[string]any)
+	require.Equal(t, "failed", failed["outcome"])
+	require.Equal(t, "load_subscription_failed", failed["failure_code"])
+	require.NotEmpty(t, failed["failure_reason"])
+}
+
+// The divergence, per store: Stripe holds the discount and no audit row
+// explains it. It must get its OWN failure code, not the routine
+// audit_write_failed / commit_failed the domain also sets, and the response
+// must say reconciliation is required.
+func TestTenantDiscountPerStoreDivergenceGetsItsOwnCode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code tenantdiscount.FailureCode
+	}{
+		{"audit_insert_failed", tenantdiscount.FailureAuditWrite},
+		{"commit_failed", tenantdiscount.FailureCommit},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := twoStoreApplyResult()
+			res.Stores[0].Outcome = tenantdiscount.OutcomeFailed
+			res.Stores[0].FailureCode = tc.code
+			res.Stores[0].Err = &tenantdiscount.AuditDivergenceError{
+				Op:                   "apply",
+				StoreID:              discountStoreA,
+				CouponID:             "cpn_test",
+				StripeSubscriptionID: "sub_a",
+				StripeCustomerID:     "cus_a",
+				Cause:                errors.New("pq: deadlock detected"),
+			}
+
+			svc := &stubDiscounter{applyResult: res}
+			rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), discountBody, true)
+			require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+			require.NotContains(t, rec.Body.String(), "deadlock detected")
+
+			body := decodeDiscount(t, rec)
+			require.Equal(t, true, body["requires_reconciliation"],
+				"a discount stripe holds and no audit row explains must be flagged at the top level")
+
+			failed := body["stores"].([]any)[0].(map[string]any)
+			require.Equal(t, "stripe_changed_audit_write_failed", failed["failure_code"],
+				"the divergence must not be reported as a routine %s", tc.code)
+		})
+	}
+}
+
+// A per-store Stripe failure is NOT the divergence: nothing was changed and
+// the caller may retry. Distinct code, and requires_reconciliation absent.
+func TestTenantDiscountPerStoreStripeFailureIsNotTheDivergence(t *testing.T) {
+	res := twoStoreApplyResult()
+	res.Stores[0].Outcome = tenantdiscount.OutcomeFailed
+	res.Stores[0].FailureCode = tenantdiscount.FailureStripeCall
+	res.Stores[0].Err = tenantdiscount.ErrStripeCall
+
+	svc := &stubDiscounter{applyResult: res}
+	rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), discountBody, true)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	body := decodeDiscount(t, rec)
+	require.NotContains(t, body, "requires_reconciliation")
+	require.Equal(t, "stripe_call_failed",
+		body["stores"].([]any)[0].(map[string]any)["failure_code"])
+}
+
+// Every store failing is reported as `failed`, not `partial` — an operator
+// reading the top-level status must not be told part of it worked.
+func TestTenantDiscountAllStoresFailedIsStatusFailed(t *testing.T) {
+	res := twoStoreApplyResult()
+	for i := range res.Stores {
+		res.Stores[i].Outcome = tenantdiscount.OutcomeFailed
+		res.Stores[i].FailureCode = tenantdiscount.FailureStripeCall
+		res.Stores[i].Err = tenantdiscount.ErrStripeCall
+	}
+	svc := &stubDiscounter{applyResult: res}
+	rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), discountBody, true)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.Equal(t, "failed", decodeDiscount(t, rec)["status"])
+}
+
+// Each whole-request sentinel gets its own status and code, so the console
+// can tell "this tenant has no stores" from "the lookup broke" rather than
+// getting one opaque refusal.
+func TestTenantDiscountDomainSentinelsMapToDistinctCodes(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    error
+		status int
+		code   string
+	}{
+		{"no_stores", tenantdiscount.ErrNoStores, http.StatusNotFound, "no_stores"},
+		{"no_tenant", tenantdiscount.ErrNoTenant, http.StatusBadRequest, "invalid_tenant_id"},
+		{"no_coupon", tenantdiscount.ErrNoCoupon, http.StatusBadRequest, "invalid_coupon_id"},
+		{"stripe_call", tenantdiscount.ErrStripeCall, http.StatusBadGateway, "stripe_unavailable"},
+		{
+			"divergence",
+			&tenantdiscount.AuditDivergenceError{Op: "apply", Cause: errors.New("pq: deadlock detected")},
+			http.StatusInternalServerError, "stripe_changed_audit_write_failed",
+		},
+		{"unknown", errors.New("pq: connection refused"), http.StatusInternalServerError, "internal_error"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &stubDiscounter{applyErr: tc.err, removeErr: tc.err}
+			for _, method := range []string{http.MethodPost, http.MethodDelete} {
+				rec := doDiscount(t, svc, method, discountTenantID.String(), discountBody, true)
+				require.Equal(t, tc.status, rec.Code, rec.Body.String())
+				body := decodeDiscount(t, rec)
+				require.Equal(t, tc.code, body["error"])
+				require.NotContains(t, rec.Body.String(), "connection refused")
+				require.NotContains(t, rec.Body.String(), "deadlock detected")
+			}
+		})
+	}
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount_test.go
@@ -439,6 +439,11 @@ func TestTenantDiscountDomainSentinelsMapToDistinctCodes(t *testing.T) {
 		{"no_stores", tenantdiscount.ErrNoStores, http.StatusNotFound, "no_stores"},
 		{"no_tenant", tenantdiscount.ErrNoTenant, http.StatusBadRequest, "invalid_tenant_id"},
 		{"no_coupon", tenantdiscount.ErrNoCoupon, http.StatusBadRequest, "invalid_coupon_id"},
+		{
+			"override_already_recorded",
+			tenantdiscount.ErrOverrideAlreadyRecorded,
+			http.StatusConflict, "override_already_recorded",
+		},
 		{"stripe_call", tenantdiscount.ErrStripeCall, http.StatusBadGateway, "stripe_unavailable"},
 		{
 			"divergence",

--- a/services/marketplace-api/internal/handlers/platformadmin/middleware.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/middleware.go
@@ -116,6 +116,11 @@ var RequiredWriteCapabilities = map[string]string{
 	// writes by isWrite's rule and both need a declaration here.
 	CapabilityKey(http.MethodPut, "/api/v1/platform/admin/email-templates/:key"):            "",
 	CapabilityKey(http.MethodPost, "/api/v1/platform/admin/email-templates/:key/test-send"): "",
+	// #660: apply and revoke a console-minted tenant discount. BOTH
+	// directions are declared — a revoke is as much a billing change as a
+	// grant, and DELETE is a write by isWrite's rule.
+	CapabilityKey(http.MethodPost, "/api/v1/platform/admin/billing/tenants/:tenantID/discount"):   "",
+	CapabilityKey(http.MethodDelete, "/api/v1/platform/admin/billing/tenants/:tenantID/discount"): "",
 }
 
 // RequiredReadCapabilities declares reads that require a specific

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -128,6 +128,15 @@ type Deps struct {
 	// used for the read routes in this struct.
 	TrialExtender TrialExtender
 
+	// TenantDiscount serves POST and DELETE
+	// /admin/billing/tenants/:tenantID/discount (#660) — applying and
+	// revoking a console-minted Stripe coupon across every store the tenant
+	// owns. Like TrialExtender it needs DB and Emitter as well, and mounting
+	// is hard-gated on both; see the guard below for what each one is
+	// actually doing there, since this handler — unlike every other write on
+	// this surface — does not emit the audit row itself.
+	TenantDiscount TenantDiscounter
+
 	// TenantTeardown and Purger together serve POST /admin/tenants/:id/purge
 	// and GET /admin/tenants/:id/purge/preview (#288) — the surface's
 	// IRREVERSIBLE endpoint. Both must be non-nil, along with DB, Emitter
@@ -454,6 +463,35 @@ func Register(g *gin.RouterGroup, deps Deps) {
 		// reachable.
 		if deps.Logger != nil {
 			deps.Logger.Warn("platformadmin: trial extend route not mounted — DB and Emitter are both required",
+				"db_nil", deps.DB == nil, "emitter_nil", deps.Emitter == nil)
+		}
+	}
+
+	switch {
+	case deps.TenantDiscount != nil && deps.DB != nil && deps.Emitter != nil:
+		NewBillingTenantDiscountHandler(deps.DB, deps.TenantDiscount, deps.Logger).Register(group)
+	case deps.TenantDiscount != nil:
+		// TenantDiscount is wired but DB or Emitter isn't. Both gates are
+		// real, and they are not the same gate:
+		//
+		// DB is the idempotency store. Without it the handler still
+		// REQUIRES an Idempotency-Key but has nowhere to reserve, replay or
+		// release it, so the retry safety the header promises is decorative
+		// — a retried apply would fan out a second time.
+		//
+		// Emitter is this surface's standing rule, kept uniform: a write
+		// endpoint that cannot be attributed to an operator should not
+		// exist rather than run silently unaudited (#287, F1). Unlike the
+		// TrialExtender case below, the Emitter is NOT handed to this
+		// handler — internal/billing/tenantdiscount writes its own audit
+		// row with EmitTx, inside each store's transaction, and refuses
+		// construction without an audit writer (ErrNoAuditWriter). main.go
+		// builds that service from the SAME auditEmitter this field holds,
+		// so a nil here means the wiring that would have attributed these
+		// writes is absent, and the gate says so at the mount rather than
+		// leaving it to a constructor two packages away.
+		if deps.Logger != nil {
+			deps.Logger.Warn("platformadmin: tenant discount routes not mounted — DB and Emitter are both required",
 				"db_nil", deps.DB == nil, "emitter_nil", deps.Emitter == nil)
 		}
 	}

--- a/services/marketplace-api/internal/handlers/platformadmin/routes_capability_coverage_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes_capability_coverage_test.go
@@ -13,17 +13,19 @@ import (
 )
 
 // allWriteRoutesDeps wires every dependency Register (routes.go) needs to
-// mount ALL NINE of this surface's write routes at once: POST
+// mount ALL ELEVEN of this surface's write routes at once: POST
 // /admin/billing/trials/:storeID/extend, POST /admin/tenants/:id/suspend,
 // POST /admin/tenants/:id/unsuspend, POST /admin/tenants/:id/purge,
 // (#405) POST /admin/outbox/:id/requeue, POST /admin/outbox/requeue, POST
-// /admin/outbox/:id/dead-letter, and (tesserix-home#588) PUT
+// /admin/outbox/:id/dead-letter, (tesserix-home#588) PUT
 // /admin/email-templates/:key plus POST
-// /admin/email-templates/:key/test-send.
+// /admin/email-templates/:key/test-send, and (#660) POST plus DELETE
+// /admin/billing/tenants/:tenantID/discount.
 //
 // Register's switch statements (routes.go) mount each write route group
 // only when THAT group's own dependency set is fully non-nil —
-// TrialExtender needs DB+Emitter, TenantLifecycle needs DB+Emitter, the
+// TrialExtender needs DB+Emitter, TenantLifecycle needs DB+Emitter,
+// TenantDiscount needs DB+Emitter, the
 // purge pair needs DB+Emitter+TenantDirectory+TenantTeardown+Purger, and
 // OutboxWriter needs Outbox+DB+Emitter, and the email template writes
 // need EmailTemplates+EmailTemplateRegistry+DB (NOT Emitter — see
@@ -32,7 +34,7 @@ import (
 // mount only some write routes, and TestAllWriteRoutesDeclareACapability
 // below would pass VACUOUSLY on the ones it never saw. That is why this
 // helper wires every dependency, and why the test separately asserts the
-// mounted write-route count is exactly 7 rather than trusting an empty
+// mounted write-route count is exactly 11 rather than trusting an empty
 // failure list alone.
 func allWriteRoutesDeps(t *testing.T) platformadmin.Deps {
 	return platformadmin.Deps{
@@ -44,6 +46,7 @@ func allWriteRoutesDeps(t *testing.T) platformadmin.Deps {
 		Emitter:         mustEmitter(t, &recordingRepo{}),
 		TenantLifecycle: &stubLifecycle{},
 		TrialExtender:   &stubExtender{},
+		TenantDiscount:  &stubDiscounter{},
 		TenantTeardown:  &fakeTeardown{seq: &seq{}},
 		Purger:          &fakePurger{seq: &seq{}},
 		Outbox:          &stubOutboxLister{},
@@ -114,8 +117,8 @@ func TestAllWriteRoutesDeclareACapability(t *testing.T) {
 	// loop above would just see fewer routes and pass on the ones it never
 	// saw, exactly the vacuous-pass hazard this file's doc comments warn
 	// about.
-	require.Equal(t, 9, writeRouteCount,
-		"expected exactly the 9 known write routes to be mounted; got %d — "+
+	require.Equal(t, 11, writeRouteCount,
+		"expected exactly the 11 known write routes to be mounted; got %d — "+
 			"either allWriteRoutesDeps is missing a dependency, or a new "+
 			"write route was added and this test's expected count needs "+
 			"updating alongside its capability declaration in "+

--- a/services/marketplace-api/internal/promo/service.go
+++ b/services/marketplace-api/internal/promo/service.go
@@ -149,10 +149,10 @@ func (s *Service) ApplyPromo(ctx context.Context, in ApplyInput) (ApplyOutput, e
 		couponID = *pc.StripeCouponID
 	}
 	if s.stripe != nil && in.StripeSubscriptionID != "" && couponID != "" {
-		if err := billingstripe.AttachCoupon(ctx, s.stripe, in.StripeSubscriptionID, couponID); err != nil {
-			return ApplyOutput{}, fmt.Errorf("promo: apply: stripe attach coupon: %w", err)
+		if err := billingstripe.AddSubscriptionDiscount(ctx, s.stripe, in.StripeSubscriptionID, couponID); err != nil {
+			return ApplyOutput{}, fmt.Errorf("promo: apply: stripe add subscription discount: %w", err)
 		}
-		s.logger.Info("promo: coupon attached to stripe subscription",
+		s.logger.Info("promo: coupon added to stripe subscription discounts",
 			"store_id", in.StoreID,
 			"coupon_id", couponID,
 			"stripe_sub_id", in.StripeSubscriptionID)
@@ -174,12 +174,12 @@ func (s *Service) ApplyPromo(ctx context.Context, in ApplyInput) (ApplyOutput, e
 		RedeemedAt:     time.Now().UTC(),
 	}
 	if err := s.repo.CreateRedemption(ctx, s.db, red); err != nil {
-		// Best-effort rollback: try to detach from Stripe. Only when we
-		// actually attached something — a code with no coupon attached
-		// nothing, and detaching here would strip an unrelated coupon the
-		// subscription already carried.
+		// Best-effort rollback: remove what we just added, and only when we
+		// actually added something — a code with no coupon added nothing.
+		// RemoveSubscriptionDiscount takes out that coupon's discount alone,
+		// so an unrelated coupon the subscription already carried survives.
 		if s.stripe != nil && in.StripeSubscriptionID != "" && couponID != "" {
-			_ = billingstripe.DetachCoupon(ctx, s.stripe, in.StripeSubscriptionID)
+			_ = billingstripe.RemoveSubscriptionDiscount(ctx, s.stripe, in.StripeSubscriptionID, couponID)
 		}
 		return ApplyOutput{}, fmt.Errorf("promo: apply: record redemption: %w", err)
 	}
@@ -196,17 +196,26 @@ func (s *Service) ApplyPromo(ctx context.Context, in ApplyInput) (ApplyOutput, e
 	}, nil
 }
 
-// CancelPromo detaches the coupon from the Stripe subscription and removes
-// the local redemption record. Idempotent — if no redemption exists, returns nil.
+// CancelPromo removes this code's coupon from the Stripe subscription's
+// discounts and removes the local redemption record. Idempotent — if no
+// redemption exists, returns nil.
 func (s *Service) CancelPromo(ctx context.Context, in CancelInput) error {
-	// Detach from Stripe first (idempotent on 404).
+	// Remove from Stripe first. Only this code's coupon goes: any other
+	// discount on the subscription is written back untouched.
 	if s.stripe != nil && in.StripeSubscriptionID != "" {
-		if err := billingstripe.DetachCoupon(ctx, s.stripe, in.StripeSubscriptionID); err != nil {
-			return fmt.Errorf("promo: cancel: stripe detach coupon: %w", err)
+		couponID, err := s.cancelCouponID(ctx, in.PromoCodeID)
+		if err != nil {
+			return err
 		}
-		s.logger.Info("promo: coupon detached from stripe subscription",
-			"store_id", in.StoreID,
-			"stripe_sub_id", in.StripeSubscriptionID)
+		if couponID != "" {
+			if err := billingstripe.RemoveSubscriptionDiscount(ctx, s.stripe, in.StripeSubscriptionID, couponID); err != nil {
+				return fmt.Errorf("promo: cancel: stripe remove subscription discount: %w", err)
+			}
+			s.logger.Info("promo: coupon removed from stripe subscription discounts",
+				"store_id", in.StoreID,
+				"coupon_id", couponID,
+				"stripe_sub_id", in.StripeSubscriptionID)
+		}
 	}
 
 	// Remove local redemption record.
@@ -214,6 +223,26 @@ func (s *Service) CancelPromo(ctx context.Context, in CancelInput) error {
 		return fmt.Errorf("promo: cancel: delete redemption: %w", err)
 	}
 	return nil
+}
+
+// cancelCouponID returns the Stripe coupon backing promoCodeID, or "" when
+// there is nothing to remove from Stripe: the code carries no coupon (a
+// trial-extension-only code never does, and the console omits the id for a
+// code not minted in the current Stripe mode, #726), or the promo code row
+// is gone — in which case the local redemption delete still runs, keeping
+// CancelPromo idempotent.
+func (s *Service) cancelCouponID(ctx context.Context, promoCodeID uuid.UUID) (string, error) {
+	pc, err := s.repo.GetByID(ctx, s.db, promoCodeID)
+	if err != nil {
+		if errors.As(err, new(*apperrors.Error)) {
+			return "", nil
+		}
+		return "", fmt.Errorf("promo: cancel: lookup promo code: %w", err)
+	}
+	if pc.StripeCouponID == nil {
+		return "", nil
+	}
+	return *pc.StripeCouponID, nil
 }
 
 // ValidateForSaveOffer is called by P11's cancel flow to assert that a promo

--- a/services/marketplace-api/internal/subscription/planchange/initial_tenantdiscount_integration_test.go
+++ b/services/marketplace-api/internal/subscription/planchange/initial_tenantdiscount_integration_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+
+package planchange_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
+	"github.com/mark8ly/marketplace-api/internal/billing/tenantdiscount"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/internal/subscription/planchange"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// mark8ly#660 T6. executeInitialSubscription is the SECOND place a Stripe
+// subscription is created for a store that had none — the lazily bootstrapped
+// row, stripe_customer_id set and stripe_subscription_id still NULL, which is
+// precisely the store the fan-out reported `pending`.
+
+// stubDiscounter stands in for tenantdiscount.Service at the port planchange
+// declares.
+type stubDiscounter struct {
+	calls   []tenantdiscount.NewSubscriptionInput
+	outcome tenantdiscount.Outcome
+	err     error
+}
+
+func (s *stubDiscounter) ApplyToNewSubscription(_ context.Context, in tenantdiscount.NewSubscriptionInput) (tenantdiscount.Outcome, error) {
+	s.calls = append(s.calls, in)
+	return s.outcome, s.err
+}
+
+// newInitialSubscriptionOrchestrator seeds the store and the
+// store_subscriptions row executeInitialSubscription is written for — a
+// customer but no Stripe subscription yet — and returns an orchestrator over
+// them.
+func newInitialSubscriptionOrchestrator(t *testing.T, disc planchange.TenantDiscountApplier) (*planchange.Orchestrator, uuid.UUID, uuid.UUID) {
+	t.Helper()
+
+	db := testdb.NewDB(t, "subscription_plan_change_audit", "store_subscriptions", "stores")
+	tenantID, storeID := uuid.New(), uuid.New()
+	testdb.SeedStore(t, db, tenantID, storeID)
+
+	require.NoError(t, db.Create(&subscription.StoreSubscription{
+		TenantID:           tenantID,
+		StoreID:            storeID,
+		StripeCustomerID:   "cus_test",
+		Plan:               subscription.PlanTrial,
+		Status:             subscription.StatusSignup,
+		SubscriptionPeriod: subscription.PeriodMonthly,
+		PriceTier:          subscription.PriceTierDeveloped,
+		BillingCurrency:    strPtr("USD"),
+	}).Error)
+
+	fs := &fakeStripe{
+		priceID:   "price_test_starter_monthly",
+		updateSub: &billingstripe.Subscription{ID: "sub_initial_test", Status: "trialing"},
+	}
+	o := planchange.NewOrchestrator(planchange.Deps{
+		DB:               db,
+		Stripe:           fs,
+		SubscriptionRepo: subscription.NewRepository(),
+		Clock:            fixedClock{t: time.Now()},
+		TenantDiscount:   disc,
+	})
+	return o, tenantID, storeID
+}
+
+func initialSubscriptionInput(tenantID, storeID uuid.UUID) planchange.Input {
+	return planchange.Input{
+		TenantID:          tenantID,
+		StoreID:           storeID,
+		TargetPlan:        subscription.PlanStarter,
+		TargetPeriod:      subscription.PeriodMonthly,
+		RequestedCurrency: "USD",
+		Actor:             "user:" + uuid.NewString(),
+		Reason:            "integration_test",
+	}
+}
+
+func TestExecute_InitialSubscriptionOffersItToTheTenantsStandingOverride(t *testing.T) {
+	disc := &stubDiscounter{outcome: tenantdiscount.OutcomeApplied}
+	o, tenantID, storeID := newInitialSubscriptionOrchestrator(t, disc)
+
+	out, err := o.Execute(context.Background(), initialSubscriptionInput(tenantID, storeID))
+	require.NoError(t, err)
+	require.Equal(t, planchange.ResultUpgradeCommitted, out.Result)
+
+	require.Len(t, disc.calls, 1)
+	require.Equal(t, tenantdiscount.NewSubscriptionInput{
+		TenantID: tenantID, StoreID: storeID, StripeSubscriptionID: "sub_initial_test",
+	}, disc.calls[0])
+}
+
+// THE LOAD-BEARING ONE, mirroring trial's. The discount must never be able to
+// fail a plan change.
+func TestExecute_ADiscountFailureDoesNotBlockTheInitialSubscription(t *testing.T) {
+	disc := &stubDiscounter{err: errors.New("stripe is down")}
+	o, tenantID, storeID := newInitialSubscriptionOrchestrator(t, disc)
+
+	out, err := o.Execute(context.Background(), initialSubscriptionInput(tenantID, storeID))
+	require.NoError(t, err, "a discount failure must never fail the plan change")
+	require.Equal(t, planchange.ResultUpgradeCommitted, out.Result)
+}
+
+// Without a discounter wired — the no-Stripe-billing configuration — Execute
+// behaves exactly as it did before T6.
+func TestExecute_InitialSubscriptionWithNoDiscounterIsUnchanged(t *testing.T) {
+	o, tenantID, storeID := newInitialSubscriptionOrchestrator(t, nil)
+
+	out, err := o.Execute(context.Background(), initialSubscriptionInput(tenantID, storeID))
+	require.NoError(t, err)
+	require.Equal(t, planchange.ResultUpgradeCommitted, out.Result)
+}

--- a/services/marketplace-api/internal/subscription/planchange/planchange.go
+++ b/services/marketplace-api/internal/subscription/planchange/planchange.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/audit"
 	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
+	"github.com/mark8ly/marketplace-api/internal/billing/tenantdiscount"
 	"github.com/mark8ly/marketplace-api/internal/billing/trial"
 	"github.com/mark8ly/marketplace-api/internal/stores"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
@@ -117,6 +119,25 @@ type Deps struct {
 	// is called inside the upgrade/downgrade-commit transaction so that plan
 	// and budget rows always commit atomically.
 	BudgetRecomputer BudgetRecomputer
+
+	// TenantDiscount is optional (#660 T6). When non-nil,
+	// executeInitialSubscription offers the subscription it has just created
+	// to the tenant's standing platform override. Nil is the configuration
+	// with no Stripe billing key, where no tenantdiscount.Service exists to
+	// wire — and with it Execute behaves exactly as it did before T6.
+	TenantDiscount TenantDiscountApplier
+}
+
+// TenantDiscountApplier offers a newly created subscription to the tenant's
+// standing platform override (mark8ly#660). *tenantdiscount.Service satisfies
+// it.
+//
+// Declared here as an interface for the reason StripeClient above is —
+// substitutable in tests — and NOT for the reason BudgetRecomputer is.
+// BudgetRecomputer exists to avoid a circular import; there is no cycle here,
+// because tenantdiscount imports neither this package nor internal/billing/trial.
+type TenantDiscountApplier interface {
+	ApplyToNewSubscription(ctx context.Context, in tenantdiscount.NewSubscriptionInput) (tenantdiscount.Outcome, error)
 }
 
 // Orchestrator runs the plan-change workflow under an advisory lock.
@@ -291,11 +312,55 @@ func (o *Orchestrator) executeInitialSubscription(ctx context.Context, tx *gorm.
 		})
 	}
 
+	// #660 T6 — this store had no Stripe subscription until a moment ago, so
+	// a platform override granted to its tenant could not be attached to it.
+	// It can be now, and this is the second of the two places where that is
+	// true (the other is trial.Subscriber.subscribeInTx).
+	o.applyTenantDiscount(ctx, in, stripeSub.ID)
+
 	return Output{
 		Result:        ResultUpgradeCommitted,
 		EffectiveAt:   in.Now,
 		StripeUpdated: true,
 	}, nil
+}
+
+// applyTenantDiscount offers the new subscription to the tenant's standing
+// override, and RETURNS NOTHING.
+//
+// That is the contract, not an oversight. A discount that cannot be applied
+// costs the tenant a discount an operator can re-apply by hand; a discount
+// that blocks this call costs the merchant their plan change. The first is
+// recoverable and the second is not, so the failure is logged and dropped.
+//
+// It is also handed no transaction: ApplyToNewSubscription works entirely on
+// the tenantdiscount service's own handle. A failed statement poisons a
+// Postgres transaction, so writing on the transaction this runs inside would
+// turn exactly the failure this function exists to swallow into a failed plan
+// change.
+func (o *Orchestrator) applyTenantDiscount(ctx context.Context, in Input, stripeSubID string) {
+	if o.deps.TenantDiscount == nil {
+		return
+	}
+	outcome, err := o.deps.TenantDiscount.ApplyToNewSubscription(ctx, tenantdiscount.NewSubscriptionInput{
+		TenantID:             in.TenantID,
+		StoreID:              in.StoreID,
+		StripeSubscriptionID: stripeSubID,
+	})
+	if err != nil {
+		slog.Error("planchange: could not apply the tenant's standing platform override to a new subscription",
+			"tenant_id", in.TenantID.String(),
+			"store_id", in.StoreID.String(),
+			"stripe_subscription_id", stripeSubID,
+			"err", err)
+		return
+	}
+	if outcome == tenantdiscount.OutcomeApplied {
+		slog.Info("planchange: applied the tenant's standing platform override to a new subscription",
+			"tenant_id", in.TenantID.String(),
+			"store_id", in.StoreID.String(),
+			"stripe_subscription_id", stripeSubID)
+	}
 }
 
 // executeUpgrade handles immediate plan upgrades and period upgrades

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 131
+const ExpectedSchemaVersion uint = 132

--- a/services/marketplace-api/migrations/000132_tenant_applied_discounts.down.sql
+++ b/services/marketplace-api/migrations/000132_tenant_applied_discounts.down.sql
@@ -1,0 +1,21 @@
+-- 000132_tenant_applied_discounts.down.sql
+--
+-- Dropping this table does not undo anything in Stripe. Every discount it
+-- records is still attached to a real subscription and still reducing real
+-- invoices; what is lost is this service's ability to say WHICH tenants hold
+-- one, and therefore its ability to cover a store created afterwards.
+--
+-- That is a data loss with no local reconstruction: the applications are
+-- audited (audit_logs, action billing.tenant_discount.apply) and the console
+-- holds the grants (tesserix-home 0047), but neither is queried by the
+-- subscription-creation hook, and the audit trail records attempts per store
+-- rather than the tenant's current standing.
+--
+-- It is NOT guarded the way 000131's revert is. That guard exists because
+-- reverting would have had to DELETE rows to succeed, and the choice of
+-- deleting versus refusing belonged to a human. Here there is no such choice —
+-- the whole table is the new thing, and refusing to drop it would leave a
+-- migration that cannot be reverted at all. Take a snapshot first if the rows
+-- matter; reverting past 000132 is a decision about a live billing account.
+
+DROP TABLE IF EXISTS tenant_applied_discounts;

--- a/services/marketplace-api/migrations/000132_tenant_applied_discounts.up.sql
+++ b/services/marketplace-api/migrations/000132_tenant_applied_discounts.up.sql
@@ -1,0 +1,162 @@
+-- 000132_tenant_applied_discounts.up.sql
+-- mark8ly#660 T6 — what THIS service applied for a tenant, so a store created
+-- later can be covered by an override granted before it existed.
+--
+-- ══ THE GAP THIS CLOSES ══
+--
+-- internal/billing/tenantdiscount fans an operator's apply out over every
+-- store the tenant owns today. A store whose subscription has no
+-- stripe_subscription_id yet — the card-less trialing tenant, which is exactly
+-- the population an operator discounts — is reported `pending`, and until this
+-- migration NOTHING picked that store up afterwards: the service held no
+-- record that the tenant had an override at all, so when the subscription was
+-- finally created there was nothing here to consult. The discount silently
+-- stopped covering the tenant as they grew, which surfaces in a renewal
+-- negotiation rather than in a log.
+--
+-- One row per (tenant, coupon) makes the override a durable, readable fact
+-- inside this service. The two places this service ITSELF creates a Stripe
+-- subscription — internal/billing/trial.Subscriber.subscribeInTx and
+-- internal/subscription/planchange.Orchestrator.executeInitialSubscription,
+-- the only two callers of billingstripe.CreateSubscription — read it and
+-- attach the coupon to the subscription they just created.
+--
+-- A THIRD ROUTE IS NOT COVERED, and saying so here is cheaper than finding it
+-- in a renewal. internal/billing/stripe.CreateCheckoutSession opens a hosted
+-- Checkout with mode=subscription: Stripe creates the subscription, and this
+-- service only learns of it from a webhook. Nothing on that path consults this
+-- table, so a store subscribed through hosted Checkout does not get the
+-- tenant's override applied. Closing that would mean hooking the webhook that
+-- records the new stripe_subscription_id, which is a separate change against a
+-- path that is currently unreachable anyway — its PriceID is a documented
+-- placeholder (cmd/marketplace-api/main.go, stripeClientAdapter).
+--
+-- ══ WHAT THIS TABLE IS NOT ══
+--
+-- IT IS NOT THE GRANT, AND IT IS NOT AUTHORITATIVE ABOUT ONE.
+--
+-- The console's `tenant_pricing_override_coupons` (tesserix-home 0047) remains
+-- the record of WHO was granted WHAT and WHY. It is minted there, in the same
+-- act that creates the Stripe Coupon, and this service cannot read it. What is
+-- recorded here is narrower and is the only thing this service can honestly
+-- claim: THIS SERVICE APPLIED THIS COUPON FOR THIS TENANT, and has not since
+-- been told to stop.
+--
+-- The difference is not academic. A console-side retirement that never reaches
+-- mark8ly — the DELETE call fails, the transport is down, the operator retires
+-- the grant in a window where these two products disagree — leaves the row
+-- below LIVE, and a store created afterwards is given a discount the console
+-- believes it withdrew. THAT IS A KNOWN, ACCEPTED LIMITATION, and it is the
+-- unavoidable cost of duplicating a fact another service owns: the alternative
+-- is a synchronous read across a product boundary on the subscription-creation
+-- hot path, which would make a console outage stop merchants subscribing.
+-- Reconciliation is a human's, and both sides carry the coupon id.
+--
+-- IT IS ALSO NOT "AT MOST ONE ACTIVE OVERRIDE PER TENANT" AS #660 STATES IT.
+-- #660 asserts that guarantee; no local table can deliver it, because the
+-- discounts a Stripe customer actually carries are held in Stripe, and a
+-- coupon attached out of band — by an operator in the Stripe dashboard, or by
+-- this service before this table existed — is invisible here. The partial
+-- unique index below is a CEILING on what THIS SERVICE will record and act on,
+-- in the same sense 0047's own index is a ceiling on what the console will
+-- mint. Neither is a floor, and neither can answer "is this tenant really
+-- being charged less".
+--
+-- ══ SHAPE ══
+--
+-- Deliberately 0047's shape, because it is the same fact viewed from the other
+-- side of the boundary and two spellings of one fact is two things to
+-- reconcile: a surrogate key, a `granted_by`/`granted_at` pair, a
+-- `removed_by`/`removed_at` retirement pair kept whole by a biconditional, and
+-- the at-most-one rule as a PARTIAL UNIQUE INDEX over the live rows rather
+-- than a bare unique constraint on tenant_id.
+--
+-- The partial index is what makes re-granting possible. A tenant whose
+-- override was removed in March must be able to receive a different one in
+-- June; under a plain UNIQUE (tenant_id) that second grant is refused forever
+-- by a row describing a coupon nobody is using, and the only ways out are
+-- deleting the row (erasing the record of a discount that was really applied
+-- to real invoices) or a later migration rewriting the uniqueness rule under
+-- live data.
+--
+-- Two differences from 0047, both deliberate:
+--
+--   * `tenant_id` is a bare uuid, not the console's namespaced
+--     `<source>:<id>` text. Every tenant id in this database is a uuid and
+--     every other table spells it that way; platform-api splits the namespace
+--     before a request reaches this service.
+--
+--   * there is no `mode` column. 0047 needs one because the console mints into
+--     a Stripe account it chooses per request. This service talks to exactly
+--     one Stripe account — the one STRIPE_BILLING_SECRET_KEY names — so every
+--     row here is already reachable from one mode and a column recording it
+--     would record the same value forever.
+--
+-- `granted_by` is NULLABLE, where 0047's is NOT NULL, and that is not an
+-- oversight. 0047 is only ever written by an operator pressing a button. This
+-- table is also written by the subscription-creation hook, which runs with no
+-- request and no operator behind it; NULL there says "this service, on its own
+-- behalf" rather than inventing a fake identity. There is no FK either way —
+-- operator identity lives in Zitadel, not in this database.
+
+CREATE TABLE IF NOT EXISTS tenant_applied_discounts (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    tenant_id uuid NOT NULL,
+
+    -- `co_…`. The blank CHECK is not decoration: '' is NOT NULL, so without it
+    -- an empty string records an application that named no coupon, in the one
+    -- spelling NOT NULL cannot see. tenantdiscount.Service trims and refuses a
+    -- blank coupon id before it gets here; this is the second line.
+    stripe_coupon_id text NOT NULL
+                     CONSTRAINT tenant_applied_discounts_coupon_id_is_not_blank
+                     CHECK (btrim(stripe_coupon_id) <> ''),
+
+    -- The operator who applied it, as an opaque identity. NULL means no
+    -- operator was behind the write — see the header.
+    granted_by text
+               CONSTRAINT tenant_applied_discounts_granted_by_is_not_blank
+               CHECK (granted_by IS NULL OR btrim(granted_by) <> ''),
+    granted_at timestamptz NOT NULL DEFAULT now(),
+
+    -- The retirement half. Both NULL is a live override; both set is a
+    -- retired one.
+    removed_by text,
+    removed_at timestamptz,
+
+    -- One biconditional rather than two NULL checks, 0047's rule for the same
+    -- reason: the two halves are the same rule, and splitting them lets a
+    -- future edit satisfy one and drop the other. A `removed_at` with no
+    -- `removed_by` is a removal nobody is accountable for; a `removed_by` with
+    -- no `removed_at` is a row the partial index below still counts as live,
+    -- which would keep handing the coupon to new stores after it was removed.
+    --
+    -- Both sides are IS NULL tests, so the expression is never UNKNOWN and the
+    -- constraint cannot pass by accident.
+    CONSTRAINT tenant_applied_discounts_removal_is_whole
+    CHECK ((removed_by IS NULL) = (removed_at IS NULL)),
+
+    -- A removal cannot precede the application it removes. `>=` and not `>`:
+    -- an override applied and removed in the same transaction is odd but
+    -- coherent, whereas a removal timestamped before its grant can only be a
+    -- clock or an input error, and it reads as a live row on any surface
+    -- ordering by date.
+    CONSTRAINT tenant_applied_discounts_removal_follows_grant
+    CHECK (removed_at IS NULL OR removed_at >= granted_at)
+);
+
+-- AT MOST ONE LIVE ROW PER TENANT, with the retired ones not counted.
+--
+-- This is what makes the read on the subscription-creation path unambiguous:
+-- "which coupon does this tenant hold" has one answer or none, and the code
+-- that reads it never has to choose between two.
+--
+-- A partial unique index rather than a table constraint, because a table
+-- constraint cannot carry a WHERE — and CREATE UNIQUE INDEX IF NOT EXISTS is
+-- idempotent on its own, so this file needs no DROP/ADD dance.
+CREATE UNIQUE INDEX IF NOT EXISTS tenant_applied_discounts_one_live_per_tenant
+    ON tenant_applied_discounts (tenant_id)
+    WHERE removed_at IS NULL;
+
+COMMENT ON TABLE tenant_applied_discounts IS
+    'mark8ly#660 — the platform override THIS SERVICE applied for a tenant, read by the subscription-creation paths so a store created later is covered too. Not the grant: tesserix-home 0047 records who granted what and why, and a console-side retirement that never reaches mark8ly leaves a row here stale.';


### PR DESCRIPTION
PR 1 of 3 for #660. The console **mints** a Stripe Coupon and records it (tesserix-home `0047`); it cannot apply it, because the Stripe customer lives here. This builds the endpoints that apply and remove it.

**Ships unreachable, deliberately.** The transport (tesserix-home platform-api billing write path) is PR 2 and the console call is PR 3 — exactly as the console's own half shipped built-and-unmounted.

## ⚠️ Migration `000132` must be applied to production BEFORE this merges

Migrations here do not ride the deploy. Kargo promotes the image on merge; `db:migrate` does not come with it. `ExpectedSchemaVersion` is bumped to 132, so merging first means running code that expects a table that does not exist.

## Two premises in #660 are wrong, and the design changed because of them

**1. There is no customer-scoped apply call.** `stripe-go/v82 v82.5.1` pins `APIVersion = "2025-08-27.basil"`, and Basil **removed** coupon attachment from the Customer API — `CustomerUpdateParams`, `CustomerCreateParams` and `CustomerParams` carry no `Coupon`, `PromotionCode` or `Discounts` field. Only read (`Customer.Discount`) and delete (`V1Customers.DeleteDiscount`) survive.

**2. A customer discount would not have stacked anyway.** Stripe: *"When a subscription has no discounts, the customer-level discount, if any, applies to invoices."* Customer-level is a **fallback, masked by** any subscription discount — so a tenant whose store had redeemed a merchant promo would have received **no platform discount at all, silently**.

So the design is **read-modify-write of the subscription's `discounts` array**, which Basil made stackable (up to 20). Each entry is a discriminated choice, and the `Discount` arm ("reuse an existing discount on the object") is what makes it non-destructive.

## This fixes a live bug rather than routing around it

`AttachCoupon` set the coupon as the **sole** discount — its own comment said so — and `DetachCoupon` cleared **all** discounts. `internal/promo` attaches merchants' promo codes through the same field, and `service.go:180` already carried a comment acknowledging the hazard.

So today an operator override would silently delete a merchant's promo, and a revoke would delete whatever was there. Both functions had **zero test coverage**, which is part of why it survived. They are deleted; `internal/promo`'s three call sites are migrated.

## What is in each commit

| | |
|---|---|
| `4eae86b4` | `EmitTx` — audit row on the **caller's** transaction. #331 requires the record bound to the change |
| `74f7f7db` | Stack subscription discounts instead of replacing them |
| `398f5363` | `tenantdiscount` domain service — per-store fan-out |
| `81a1d78f` | Comment correction: `pending` is not a queue |
| `eadfeb1b` | The two platform-admin endpoints |
| `a8344099` | `000132` applied-override table + both creation hooks |

## Design notes worth reviewing

**One transaction per store, not one across the tenant.** `store_subscriptions` is `UNIQUE (store_id)` with a separate `tenant_id`, so a tenant has several subscriptions and several customers — #660's "the tenant's subscription customer" is not singular. Following `trial/extend.go`, the Stripe call runs **inside** the transaction under `SELECT … FOR UPDATE`; but per store, because one transaction across N stores would hold N row locks across N Stripe round-trips.

**The residual divergence is named, not accidental.** If the audit insert fails, the transaction rolls back but the Stripe discount stays applied. `ErrStripeChangedAuditWriteFailed` + `AuditDivergenceError` carry coupon, subscription and customer ids. The decision is stated: an unattributable discount is rolled back **locally** and reported failed, and we deliberately do **not** attempt a compensating Stripe call — it would itself be an unaudited billing change, it can fail, and it could delete a discount a concurrent correctly-audited apply just placed.

**Idempotency scope includes the operation.** `tenant_discount:<op>:<tenant>:<key>`. Sharing one namespace between POST and DELETE would let an operator reusing a key to revoke get the apply's stored report replayed — the discount silently staying on.

**No failure audit for rolled-back stores, deliberately.** Every store whose transaction commits already gets a row, including `pending`. For the divergence a handler-written "failed" row would be *actively false* — Stripe did change — and a misleading row is worse than none during reconciliation.

## What this does NOT claim

- **Not** #660's "at most one active override per tenant". No local table can deliver it: the discounts a customer actually carries live in Stripe, and a coupon attached out of band is invisible here. `000132`'s partial unique index is a **ceiling on what this service records and acts on**. The migration header says so.
- **A console-side retirement that never reaches mark8ly leaves the row stale**, and a store created afterwards gets a discount the console believes it withdrew. Known, accepted, documented — the alternative is a synchronous cross-product read on the subscription-creation hot path, which would make a console outage stop merchants subscribing.
- **A third creation route is uncovered.** `CreateCheckoutSession` opens hosted Checkout with `mode=subscription`; Stripe creates the subscription and we learn by webhook. Named in the migration header rather than glossed. Currently unreachable anyway — its `PriceID` is a documented placeholder.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` — clean
- [x] `go test ./...` — **104 packages ok, 0 fail**
- [x] Integration (`-p 1`) tenantdiscount + planchange + platformadmin — **539 pass, 0 fail, 0 skip**
- [x] `000132` applied to a real Postgres, down/up round-trip exercised
- [x] Mutation-checked, each restored and re-verified green:
  - move `deleteCoupon`-equivalent audit write off `tx` → red
  - collapse per-store transactions into one fan-out transaction → red
  - drop the divergence branch → red
  - remove `op` from the idempotency scope → red
  - move the override record to *after* the fan-out → red
  - make the creation hooks fatal → red
  - revert `AddSubscriptionDiscount` to the sole-discount write → red
- [ ] **`000132` applied to production before merge** — the one blocking gate

## Found, not fixed (pre-existing, out of scope)

- `internal/billing/trial` has **19 integration tests gated on `TEST_DB_DSN`**, which `make test-int` never exports — so they have never run. Run with it set, **all 19 fail**: `seedSubscription` inserts `store_subscriptions` with no `stores` row and violates `store_subscriptions_store_id_fkey`. That includes the whole of `subscribe_integration_test.go`.
- `internal/audit`'s `TestEmitStateTransition_TerminalStatesGetWarning` flaked once under DB contention (12.37s against its own 2s timeout). Passes 5/5 isolated; nothing here touches that path.
