### PR TITLE
fix(tenantpurge): purge a tenant's applied discount records (#660)

### DIFF
--- a/services/marketplace-api/internal/tenantpurge/purge.go
+++ b/services/marketplace-api/internal/tenantpurge/purge.go
@@ -374,6 +374,19 @@ func purgePlan(tenantID string, storeIDs []string) []deleteStep {
 		tenantScoped("break_glass_accounts", tenantID),  // 000072: tenant_id (PK)
 		tenantScoped("enterprise_api_keys", tenantID),   // 000068: tenant_id, store_id
 		tenantScoped("webhook_subscriptions", tenantID), // 000126: tenant_id, store_id
+		// PURGED, not excluded. The row is operational state — the coupon this
+		// service applies to subscriptions the tenant creates later — so once
+		// the tenant is gone there is nothing left for it to act on, and a
+		// surviving row would be a live instruction aimed at a tenant that no
+		// longer exists.
+		//
+		// It is NOT the record of the grant, which is what makes purging it
+		// safe: who granted the discount and why lives in the console's
+		// `tenant_pricing_override_coupons` (tesserix-home 0047), and the
+		// operator's act of applying it is an `actor_type = 'operator'` row in
+		// audit_logs, which the predicate above deliberately spares. Both
+		// survive this purge, so nothing accountable is destroyed by it.
+		tenantScoped("tenant_applied_discounts", tenantID), // 000132: tenant_id
 		// audit_logs is tenant-scoped EXCEPT for operator rows. A platform
 		// operator's action against a tenant (suspend, trial extend, purge)
 		// is a governance record about the OPERATOR, not tenant data, and it


### PR DESCRIPTION
Fixes `main`, which is red after #766.

## What broke

`TestPurgePlan_CoversEveryTenantScopedTable` (`internal/tenantpurge/schema_coverage_integration_test.go:29`):

```
Should be empty, but was [tenant_applied_discounts]
tenant-scoped tables neither purged, nor cascaded, nor declared an exclusion.
A tenant purge would leave these rows behind.
```

`tenant_applied_discounts` (migration `000132`, added by #766) carries a `tenant_id` and was neither purged nor excluded, so a tenant purge would have left its rows behind. The guard reads the **live schema and FK graph**, which is why a new table trips it without anyone having to remember.

**No image was built and nothing deployed** — the CI gate refused, so production never saw #766.

## The fix, and why purge rather than exclude

One line, plus the reasoning at the call site. The row is **operational state** — the coupon this service applies to subscriptions the tenant creates later — so once the tenant is gone there is nothing for it to act on, and a surviving row would be a live instruction aimed at a tenant that no longer exists.

Purging it destroys nothing accountable, which is what makes it the right call rather than an exclusion:

- **The grant** lives in the console's `tenant_pricing_override_coupons` (tesserix-home `0047`) — a different database, untouched by this purge.
- **The operator's act** of applying it is an `actor_type = 'operator'` row in `audit_logs`, which `purgePlan`'s predicate deliberately spares for exactly this reason.

Both survive. Only the instruction goes.

## Test plan

- [x] Reproduced CI's exact failure locally — removed the new line, ran the guard, got the identical `was [tenant_applied_discounts]`
- [x] Restored and re-ran: green (`shasum` verified identical to the committed file)
- [x] `go test -tags=integration -p 1` over `tenantpurge`, `billing/tenantdiscount`, `handlers/platformadmin`, `subscription/planchange` — all ok
- [x] `go test ./...` — 104 packages ok, 0 fail
- [x] `go build ./...`, `go vet`, `gofmt` clean

## How this got through

#766's verification ran the integration suite over the packages it changed, not the whole thing — and `tenantpurge` is neither a package it touched nor one that imports it. The coupling is the **schema**, not the code, which is precisely the kind of dependency a per-package run cannot see. Worth remembering for any future PR that adds a tenant-scoped table: the guard lives somewhere you did not edit.
