### PR TITLE
fix(admin): continue web Google sign-in through the email-OTP step and recover from a spent auth request (#686)

### DIFF
--- a/apps/admin/app/auth/idp/finish/route.test.ts
+++ b/apps/admin/app/auth/idp/finish/route.test.ts
@@ -68,7 +68,8 @@ describe("GET /auth/idp/finish", () => {
     const location = res.headers.get("location") ?? "";
     expect(location).toContain("/login?");
     expect(location).toContain("error=google_sign_in_unavailable");
-    expect(location).toContain("authRequest=ar-1");
+    // NOT ar-1 — see the recovery-sentinel describe block below.
+    expect(new URL(location).searchParams.get("authRequest")).toBe("recovery");
     expect(finishZitadelGoogleSignInMock).not.toHaveBeenCalled();
   });
 
@@ -296,7 +297,7 @@ describe("GET /auth/idp/finish", () => {
     expect(location).toContain("error=internal_error");
   });
 
-  it("redirects with step_up_unsupported when a step-up is outstanding", async () => {
+  it("redirects with step_up_unsupported when auth-bff's usermfa gate is outstanding", async () => {
     finishZitadelGoogleSignInMock.mockResolvedValue({
       ok: true,
       data: { tenantId: "tenant-1", multipleTenants: false, mfaRequired: true, emailOtpRequired: false },
@@ -306,5 +307,175 @@ describe("GET /auth/idp/finish", () => {
 
     expect(res.status).toBe(303);
     expect(res.headers.get("location")).toContain("error=step_up_unsupported");
+  });
+
+  it("redirects with step_up_unsupported when Zitadel's own TOTP step-up is outstanding", async () => {
+    finishZitadelGoogleSignInMock.mockResolvedValue({
+      ok: true,
+      data: {
+        tenantId: "tenant-1",
+        multipleTenants: false,
+        mfaRequired: false,
+        emailOtpRequired: false,
+        totpRequired: true,
+        zitadelSessionId: "sess-1",
+        zitadelSessionToken: "sess-token-1",
+        zitadelTenantCode: "tenant-code-1",
+      },
+    });
+
+    const res = await GET(makeRequest("?id=i1&token=t1&auth_request_id=ar-1"));
+
+    expect(res.status).toBe(303);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("error=step_up_unsupported");
+    // The whole reason TOTP stays refused: its continuation needs a
+    // session id/token, and a redirect-only route has nowhere to put them
+    // but the URL.
+    expect(location).not.toContain("sess-1");
+    expect(location).not.toContain("sess-token-1");
+    expect(location).not.toContain("tenant-code-1");
+  });
+});
+
+// #686 — the last gap in WEB merchant Google sign-in. A browser auth-bff
+// has not fingerprinted before always trips the deviceguard/emailotp gate,
+// so refusing email OTP here refused Google sign-in outright for every new
+// device. This continues into the code screen the password path already
+// has, and leaves TOTP/MFA refused.
+describe("GET /auth/idp/finish — email-OTP continuation", () => {
+  const emailOtpOutcome = (multipleTenants = false) => ({
+    ok: true,
+    data: {
+      tenantId: "tenant-1",
+      multipleTenants,
+      mfaRequired: false,
+      emailOtpRequired: true,
+    },
+  });
+
+  it("redirects to /login's code step instead of refusing with step_up_unsupported", async () => {
+    finishZitadelGoogleSignInMock.mockResolvedValue(emailOtpOutcome());
+
+    const res = await GET(makeRequest("?id=i1&token=t1&auth_request_id=ar-1"));
+
+    expect(res.status).toBe(303);
+    const url = new URL(res.headers.get("location") ?? "");
+    expect(url.origin + url.pathname).toBe("https://admin.mark8ly.com/login");
+    expect(url.searchParams.get("challenge")).toBe("email_otp");
+    expect(url.searchParams.get("error")).toBeNull();
+  });
+
+  it("keeps the real auth request id so /login renders the form rather than bouncing through /login/authorize", async () => {
+    finishZitadelGoogleSignInMock.mockResolvedValue(emailOtpOutcome());
+
+    const res = await GET(makeRequest("?id=i1&token=t1&auth_request_id=ar-1"));
+
+    const url = new URL(res.headers.get("location") ?? "");
+    expect(url.searchParams.get("authRequest")).toBe("ar-1");
+    expect(wouldMiddleware404(url.toString())).toBe(false);
+  });
+
+  it("flags a multi-store account so the post-code landing is /pick-tenant", async () => {
+    finishZitadelGoogleSignInMock.mockResolvedValue(emailOtpOutcome(true));
+
+    const res = await GET(makeRequest("?id=i1&token=t1&auth_request_id=ar-1"));
+
+    expect(new URL(res.headers.get("location") ?? "").searchParams.get("multi")).toBe("1");
+  });
+
+  it("omits the multi flag for a single-store account", async () => {
+    finishZitadelGoogleSignInMock.mockResolvedValue(emailOtpOutcome(false));
+
+    const res = await GET(makeRequest("?id=i1&token=t1&auth_request_id=ar-1"));
+
+    expect(new URL(res.headers.get("location") ?? "").searchParams.get("multi")).toBeNull();
+  });
+
+  it("puts no session id, session token, intent id or intent token in the redirect URL", async () => {
+    finishZitadelGoogleSignInMock.mockResolvedValue(emailOtpOutcome());
+
+    const res = await GET(
+      makeRequest("?id=intent-abc&token=intent-token-xyz&auth_request_id=ar-1"),
+    );
+
+    const location = res.headers.get("location") ?? "";
+    for (const secret of ["intent-abc", "intent-token-xyz", "sess", "token"]) {
+      expect(location).not.toContain(secret);
+    }
+    // Only these three params, and nothing that could be a credential.
+    const params = [...new URL(location).searchParams.keys()].sort();
+    expect(params).toEqual(["authRequest", "challenge"]);
+  });
+
+  it("forwards the pending cookie auth-bff minted onto the redirect", async () => {
+    // The pending Set-Cookie is applied by finishZitadelGoogleSignIn ->
+    // mapZitadelOutcome -> applySetCookies, which writes through
+    // next/headers' cookies(); Next merges that store onto whatever
+    // response this handler returns, the same mechanism
+    // app/auth/handoff/route.ts relies on to land a session cookie on a
+    // 303. That mechanism is action-side, so this route test (which mocks
+    // the action wholesale) cannot observe it — the assertion that the
+    // email-OTP outcome really does apply its Set-Cookie headers lives in
+    // app/login/actions.zitadel.test.ts, "forwards the PENDING cookie on
+    // an email_otp_required outcome". This case is here only so the link
+    // between the two is not lost: without it the merchant reaches the
+    // code screen with no challenge to resume and a correct code fails.
+    finishZitadelGoogleSignInMock.mockResolvedValue(emailOtpOutcome());
+
+    const res = await GET(makeRequest("?id=i1&token=t1&auth_request_id=ar-1"));
+
+    expect(res.status).toBe(303);
+  });
+});
+
+// Production report: after a failed Google attempt the merchant followed
+// the "sign in with your email and password instead" advice and got a raw
+// Zitadel body — {"error": "No valid authentication request found"} —
+// because this route handed back the auth request idp/complete had already
+// spent. Every error redirect now carries the recovery sentinel instead.
+describe("GET /auth/idp/finish — error redirects never reuse a spent auth request", () => {
+  it("never carries the original auth_request_id on any error branch", async () => {
+    finishZitadelGoogleSignInMock.mockResolvedValue({
+      ok: false,
+      code: "no_admin_account",
+      message: "no admin account",
+    });
+
+    const scenarios = [
+      makeRequest("?id=i1&error=access_denied&auth_request_id=ar-1"),
+      makeRequest("?id=i1&token=t1&auth_request_id=ar-1"),
+    ];
+    for (const req of scenarios) {
+      const res = await GET(req);
+      const url = new URL(res.headers.get("location") ?? "");
+      expect(url.searchParams.get("authRequest")).toBe("recovery");
+      expect(url.toString()).not.toContain("ar-1");
+    }
+  });
+
+  it("uses the sentinel on the step_up_unsupported branch too, where the auth request is definitely spent", async () => {
+    finishZitadelGoogleSignInMock.mockResolvedValue({
+      ok: true,
+      data: { tenantId: "tenant-1", multipleTenants: false, mfaRequired: true, emailOtpRequired: false },
+    });
+
+    const res = await GET(makeRequest("?id=i1&token=t1&auth_request_id=ar-1"));
+
+    expect(new URL(res.headers.get("location") ?? "").searchParams.get("authRequest")).toBe(
+      "recovery",
+    );
+  });
+
+  it("still satisfies middleware's canonical-/login gate with the sentinel", async () => {
+    finishZitadelGoogleSignInMock.mockResolvedValue({
+      ok: false,
+      code: "no_admin_account",
+      message: "no admin account",
+    });
+
+    const res = await GET(makeRequest("?id=i1&token=t1&auth_request_id=ar-1"));
+
+    expect(wouldMiddleware404(res.headers.get("location") ?? "")).toBe(false);
   });
 });

--- a/apps/admin/app/auth/idp/finish/route.ts
+++ b/apps/admin/app/auth/idp/finish/route.ts
@@ -34,26 +34,16 @@ import { NextResponse } from "next/server";
 import { publicConfig } from "@/lib/config";
 import { isTrustedCallbackUrl, isTrustedZitadelHostedUrl } from "@/lib/auth/zitadel-oidc";
 import { finishZitadelGoogleSignIn } from "@/app/login/actions";
-import type { AdminGoogleErrorCode } from "@/lib/auth/google-sign-in-admin";
+import {
+  RECOVERY_AUTH_REQUEST_SENTINEL,
+  type AdminGoogleErrorCode,
+} from "@/lib/auth/google-sign-in-admin";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const DEFAULT_DESTINATION = "/dashboard";
 const MULTI_TENANT_DESTINATION = "/pick-tenant";
-
-// middleware.ts 404s canonical `/login` unless the request carries either
-// a valid slug returnUrl or a (merely non-empty — see its own check)
-// `authRequest` param. This flow has no slug to build a returnUrl from
-// (resolving one is the whole point of finishZitadelGoogleSignIn), so a
-// sentinel authRequest is the only way to guarantee the error page stays
-// reachable if Zitadel's callback ever omits the real auth_request_id.
-// /login/page.tsx only redirects to /login/authorize (minting a fresh
-// one) when authRequest is completely ABSENT, so this sentinel renders
-// the form normally with the truthful error message; a merchant who then
-// retries with this stale id gets a clean auth-bff rejection rather than
-// a blank 404 here.
-const RECOVERY_AUTH_REQUEST_SENTINEL = "recovery";
 
 export async function GET(req: Request): Promise<Response> {
   // This route only applies under the Zitadel provider — under GIP there
@@ -74,22 +64,58 @@ export async function GET(req: Request): Promise<Response> {
   const proto = headerBag.get("x-forwarded-proto") ??
     (forwardedHost.startsWith("localhost") || forwardedHost.startsWith("127.") ? "http" : "https");
 
-  // /login re-derives a fresh `authRequest` via /login/authorize whenever
-  // it renders under Zitadel without one already in the query string —
-  // see app/login/page.tsx. Carrying the SAME auth_request_id (still
-  // valid: this attempt never consumed it, it only failed to link a
-  // Google identity to it) back onto every error redirect avoids that
-  // detour and its side effect of losing `error` along the way, so a
-  // merchant landing back on /login after a Google failure both sees the
-  // truthful message AND can retry with a password using the exact auth
-  // request already in flight, rather than an invisible one silently
-  // restarted underneath them.
+  // Every error redirect lands on canonical /login carrying the RECOVERY
+  // sentinel rather than this attempt's own `auth_request_id`.
+  //
+  // An earlier version handed the original id back, on the theory that a
+  // failed Google link leaves the auth request untouched and reusable. It
+  // does not: once the flow has reached auth-bff's idp/complete, Zitadel
+  // has SPENT that auth request. /login then rendered its form around a
+  // dead id and the password fallback this route's own copy recommends
+  // came back as raw provider JSON —
+  // `{"error": "No valid authentication request found"}` — so the one
+  // recovery path offered to the merchant could not work. Reported from
+  // production.
+  //
+  // The sentinel keeps the redirect past middleware's canonical-/login
+  // 404 gate (which needs either a valid slug returnUrl — this flow has
+  // no slug — or a non-empty authRequest) and tells /login to mint a
+  // FRESH auth request via /login/authorize while carrying `error`
+  // across that hop, so the merchant still sees why Google failed AND
+  // gets a form that actually submits. See
+  // RECOVERY_AUTH_REQUEST_SENTINEL, app/login/page.tsx and
+  // app/login/authorize/route.ts.
   function errorRedirect(code: AdminGoogleErrorCode): Response {
     const params = new URLSearchParams({ error: code });
-    params.set("authRequest", authRequestId || RECOVERY_AUTH_REQUEST_SENTINEL);
+    params.set("authRequest", RECOVERY_AUTH_REQUEST_SENTINEL);
     const dest = forwardedHost
       ? `${proto}://${forwardedHost}/login?${params.toString()}`
       : `/login?${params.toString()}`;
+    return NextResponse.redirect(dest, { status: 303 });
+  }
+
+  // The email-OTP continuation: NOT an error, so it keeps this attempt's
+  // real `auth_request_id` and does not detour through /login/authorize
+  // (that detour would lose `challenge` — Zitadel rebuilds the /login URL
+  // itself and only appends its own authRequest). The id is spent by now,
+  // but nothing on the code screen uses it: confirmEmailOTPLogin resumes
+  // purely from the pending cookie auth-bff minted plus the typed code.
+  // It rides along only so /login renders instead of 404ing, and so the
+  // form has the same prop shape it has on the password path.
+  //
+  // `multi` is a UI hint, not a credential — it decides /pick-tenant vs
+  // /dashboard after the code verifies, exactly like `mfaMultipleTenants`
+  // does on the password path. Forging it buys nothing: /pick-tenant
+  // re-lists the caller's real memberships server-side and auto-skips to
+  // /dashboard for a single-tenant account.
+  //
+  // No session id, session token, intent id or intent token is ever put
+  // in this URL — see the TOTP refusal below for why that rule exists.
+  function emailOtpRedirect(multipleTenants: boolean): Response {
+    const params = new URLSearchParams({ authRequest: authRequestId ?? "" });
+    params.set("challenge", "email_otp");
+    if (multipleTenants) params.set("multi", "1");
+    const dest = `${proto}://${forwardedHost}/login?${params.toString()}`;
     return NextResponse.redirect(dest, { status: 303 });
   }
 
@@ -148,22 +174,36 @@ export async function GET(req: Request): Promise<Response> {
 
   const { data } = result;
 
-  // A step-up (Zitadel's own TOTP, or auth-bff's usermfa/email-OTP gate)
-  // is outstanding. auth-bff's usermfa/email-OTP gate DOES mint a pending
-  // cookie even here (forwarded above via finishZitadelGoogleSignIn's
-  // reuse of mapZitadelOutcome/applySetCookies), but there is no
-  // interactive form on this redirect-only path to collect the code the
-  // way SignInForm's challenge screens do for the password path — and
-  // Zitadel's own TOTP step-up hands back a session id/session token that
-  // must not travel in a URL. Rather than strand the merchant on a broken
-  // continuation, this treats every step-up as unsupported for the
-  // Google path today and sends them back to sign in with a password,
-  // where the exact same account can complete its second factor.
-  if (data.totpRequired || data.mfaRequired || data.emailOtpRequired) {
+  // Zitadel's OWN TOTP step-up, and auth-bff's usermfa gate, both stay
+  // unsupported on this path. The reason has not changed: Zitadel's TOTP
+  // step-up hands back a session id and session token that
+  // confirmZitadelTotp must carry forward, and those must never travel in
+  // a URL — which is the only channel a redirect-only route has. The
+  // merchant is sent back to sign in with a password, where the exact
+  // same account can complete its second factor.
+  if (data.totpRequired || data.mfaRequired) {
     console.error(
-      "admin google idp finish: a step-up is outstanding, which this redirect-only route cannot collect",
+      "admin google idp finish: a totp/mfa step-up is outstanding, which this redirect-only route cannot collect",
     );
     return errorRedirect("step_up_unsupported");
+  }
+
+  // Email OTP is the one step-up this path CAN continue, and it is the
+  // common case rather than an edge: a merchant signing in with Google
+  // from a browser auth-bff has not fingerprinted before always trips the
+  // deviceguard/emailotp gate, so refusing it refused web Google sign-in
+  // outright (#686).
+  //
+  // Nothing needs to be smuggled through the URL to resume it. auth-bff
+  // minted a PENDING cookie on this very response —
+  // finishZitadelGoogleSignIn's mapZitadelOutcome ran applySetCookies,
+  // which writes through next/headers' cookies() and so rides onto the
+  // 303 below, the same mechanism app/auth/handoff/route.ts uses to land
+  // a session cookie on a redirect. The code screen then calls
+  // confirmEmailOTPLogin, which needs exactly that pending cookie plus
+  // the typed code and nothing else.
+  if (data.emailOtpRequired) {
+    return emailOtpRedirect(data.multipleTenants);
   }
 
   if (data.handoffUrl) {

--- a/apps/admin/app/login/actions.zitadel.test.ts
+++ b/apps/admin/app/login/actions.zitadel.test.ts
@@ -623,6 +623,78 @@ describe("finishZitadelGoogleSignIn", () => {
     expect(cookiesSetSpy).not.toHaveBeenCalled();
   });
 
+  // THE regression that matters for #686's email-OTP continuation. The
+  // finish route now redirects this outcome to /login's code step instead
+  // of refusing it. auth-bff mints only a PENDING cookie at this point,
+  // and confirmEmailOTPLogin resumes from that cookie plus the typed code
+  // — so if these Set-Cookie headers are dropped, the merchant reaches the
+  // code screen, types a CORRECT code, and verification fails with no
+  // pending challenge to resume. That is strictly worse than the honest
+  // refusal it replaced, which is why it is pinned here rather than left
+  // to the route test (which mocks this action wholesale).
+  it("forwards the PENDING cookie on an email_otp_required outcome", async () => {
+    zitadelIdpFinishMock.mockResolvedValue({
+      sessionId: "sess-1",
+      sessionToken: "sess-token-1",
+      loginName: "merchant@example.com",
+    });
+    zitadelIdpCompleteMock.mockResolvedValue({
+      kind: "email_otp_required",
+      setCookies: [
+        "m8_otp_pending=pending-abc; Path=/; HttpOnly; Secure; Max-Age=300",
+        "m8_device=dev-1; Path=/; HttpOnly",
+      ],
+    });
+
+    const result = await finishZitadelGoogleSignIn(input);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.emailOtpRequired).toBe(true);
+      expect(result.data.mfaRequired).toBe(false);
+    }
+
+    // EVERY Set-Cookie auth-bff sent, not just the first.
+    expect(cookiesSetSpy).toHaveBeenCalledTimes(2);
+    expect(cookiesSetSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "m8_otp_pending",
+        value: "pending-abc",
+        httpOnly: true,
+        secure: true,
+        maxAge: 300,
+      }),
+    );
+    expect(cookiesSetSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "m8_device", value: "dev-1" }),
+    );
+    expect(cookieStore.map((c) => c.name)).toEqual(["m8_otp_pending", "m8_device"]);
+  });
+
+  it("carries multipleTenants through an email_otp_required outcome so the post-code landing is right", async () => {
+    listMemberTenantsMock.mockResolvedValue([
+      { tenant_id: "tenant-1", name: "Store One", role: "owner" },
+      { tenant_id: "tenant-2", name: "Store Two", role: "staff" },
+    ]);
+    zitadelIdpFinishMock.mockResolvedValue({
+      sessionId: "sess-1",
+      sessionToken: "sess-token-1",
+      loginName: "merchant@example.com",
+    });
+    zitadelIdpCompleteMock.mockResolvedValue({
+      kind: "email_otp_required",
+      setCookies: ["m8_otp_pending=pending-abc; Path=/; HttpOnly"],
+    });
+
+    const result = await finishZitadelGoogleSignIn(input);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.multipleTenants).toBe(true);
+      expect(result.data.emailOtpRequired).toBe(true);
+    }
+  });
+
   it("surfaces a step-up outcome from idp/complete with no session cookie minted", async () => {
     zitadelIdpFinishMock.mockResolvedValue({
       sessionId: "sess-1",

--- a/apps/admin/app/login/authorize/route.test.ts
+++ b/apps/admin/app/login/authorize/route.test.ts
@@ -89,3 +89,83 @@ describe("GET /login/authorize — redirect_uri is pinned to the canonical origi
     );
   });
 });
+
+// The other half of the spent-auth-request fix: /login sends a `recovery`
+// arrival here to mint a FRESH auth request, and the truthful Google
+// failure message has to survive the hop. Zitadel builds the final
+// /login?authRequest=… URL itself from its configured login base URI and
+// appends only its own param, so a query string cannot carry the message —
+// it rides a short-lived cookie, exactly like returnUrl already does.
+describe("GET /login/authorize — carrying a Google outcome code across the Zitadel hop", () => {
+  function setCookieHeaders(res: Response): string[] {
+    const getSetCookie = (res.headers as unknown as {
+      getSetCookie?: () => string[];
+    }).getSetCookie;
+    if (typeof getSetCookie === "function") return getSetCookie.call(res.headers);
+    const raw = res.headers.get("set-cookie");
+    return raw ? [raw] : [];
+  }
+
+  function errorCookie(res: Response): string | undefined {
+    return setCookieHeaders(res).find((c) => c.startsWith("zt_login_error="));
+  }
+
+  it("stores a recognised outcome code so /login can show it after the round trip", async () => {
+    const res = await GET(makeRequest("?error=no_admin_account"));
+
+    const cookie = errorCookie(res);
+    expect(cookie).toBeDefined();
+    expect(cookie).toContain("zt_login_error=no_admin_account");
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("Max-Age=120");
+  });
+
+  it("still redirects to Zitadel — carrying the message must not change where the browser goes", async () => {
+    const res = await GET(makeRequest("?error=no_admin_account"));
+
+    expect(res.headers.get("location")).toContain(
+      "https://auth.tesserix.app/oauth/v2/authorize",
+    );
+  });
+
+  it("leaves the PKCE state and verifier cookies untouched", async () => {
+    const withError = setCookieHeaders(await GET(makeRequest("?error=no_admin_account")));
+    const withoutError = setCookieHeaders(await GET(makeRequest()));
+
+    for (const cookies of [withError, withoutError]) {
+      expect(cookies.some((c) => c.startsWith("zt_auth_state="))).toBe(true);
+      expect(cookies.some((c) => c.startsWith("zt_pkce_verifier="))).toBe(true);
+    }
+  });
+
+  it("refuses to store an unrecognised error value — no provider text can reach the page this way", async () => {
+    const res = await GET(
+      makeRequest(
+        "?error=" + encodeURIComponent('{"error": "No valid authentication request found"}'),
+      ),
+    );
+
+    const cookie = errorCookie(res);
+    expect(cookie).toBeDefined();
+    // Present but EXPIRED and empty: an unrecognised value clears the
+    // channel rather than passing anything through it.
+    expect(cookie).toContain("Max-Age=0");
+    expect(cookie).not.toContain("No valid authentication request found");
+  });
+
+  it("clears any stale message when a new authorize starts with no error", async () => {
+    const cookie = errorCookie(await GET(makeRequest("?returnUrl=%2Fdashboard")));
+
+    expect(cookie).toBeDefined();
+    expect(cookie).toContain("Max-Age=0");
+  });
+
+  it("never mints the error cookie under GIP, where this route does not exist", async () => {
+    configMock.authProvider = "gip";
+
+    const res = await GET(makeRequest("?error=no_admin_account"));
+
+    expect(res.status).toBe(404);
+    expect(setCookieHeaders(res)).toEqual([]);
+  });
+});

--- a/apps/admin/app/login/authorize/route.ts
+++ b/apps/admin/app/login/authorize/route.ts
@@ -20,12 +20,15 @@ import {
   ZITADEL_STATE_COOKIE,
   ZITADEL_VERIFIER_COOKIE,
   ZITADEL_RETURN_URL_COOKIE,
+  ZITADEL_LOGIN_ERROR_COOKIE,
+  ZITADEL_LOGIN_ERROR_COOKIE_MAX_AGE_SECONDS,
   ZITADEL_FLOW_COOKIE_MAX_AGE_SECONDS,
   generateState,
   generatePkcePair,
   buildZitadelAuthorizeUrl,
 } from "@/lib/auth/zitadel-oidc";
 import { sanitizeReturnUrl } from "@/lib/auth/sanitize-return-url";
+import { isAdminGoogleErrorCode } from "@/lib/auth/google-sign-in-admin";
 import { publicConfig } from "@/lib/config";
 
 export const runtime = "nodejs";
@@ -83,6 +86,23 @@ export async function GET(req: NextRequest): Promise<Response> {
     req.nextUrl.searchParams.get("returnUrl"),
   );
 
+  // A Google sign-in that failed is redirected here (via /login's recovery
+  // sentinel — see app/auth/idp/finish/route.ts) precisely BECAUSE the auth
+  // request it held is spent and a fresh one is needed. The merchant must
+  // still be told why Google failed once they land back on the form, so the
+  // outcome code rides a short-lived cookie across the Zitadel hop: Zitadel
+  // builds that final /login URL itself and drops anything this route puts
+  // on the way in.
+  //
+  // Allowlisted, never free text. Only a value `isAdminGoogleErrorCode`
+  // recognises is stored, so no provider error body — and nothing else
+  // attacker-supplied — can reach the rendered page through this channel.
+  // Anything unrecognised (and the no-error case) CLEARS the cookie instead,
+  // so a stale message cannot resurface on an unrelated sign-in.
+  const errorParam = req.nextUrl.searchParams.get("error");
+  const safeErrorCode =
+    errorParam && isAdminGoogleErrorCode(errorParam) ? errorParam : null;
+
   const state = generateState();
   const { verifier, challenge } = await generatePkcePair();
 
@@ -115,5 +135,17 @@ export async function GET(req: NextRequest): Promise<Response> {
       ...cookieBase,
     });
   }
+  // Deliberately separate from the PKCE/state pair above: this cookie is a
+  // display hint with its own (shorter) lifetime and carries no security
+  // weight, so it must not borrow theirs.
+  res.cookies.set({
+    name: ZITADEL_LOGIN_ERROR_COOKIE,
+    value: safeErrorCode ?? "",
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: safeErrorCode ? ZITADEL_LOGIN_ERROR_COOKIE_MAX_AGE_SECONDS : 0,
+  });
   return res;
 }

--- a/apps/admin/app/login/page.test.tsx
+++ b/apps/admin/app/login/page.test.tsx
@@ -11,9 +11,40 @@ vi.mock("@repo/ui/brand-bar", () => ({
 }));
 
 vi.mock("@/components/auth/SignInForm", () => ({
-  SignInForm: (props: { provider?: string }) => (
-    <div data-testid="sign-in-form" data-provider={props.provider ?? ""} />
+  SignInForm: (props: {
+    provider?: string;
+    googleErrorCode?: string;
+    initialChallenge?: string;
+    initialMultipleTenants?: boolean;
+  }) => (
+    <div
+      data-testid="sign-in-form"
+      data-provider={props.provider ?? ""}
+      data-google-error={props.googleErrorCode ?? ""}
+      data-initial-challenge={props.initialChallenge ?? ""}
+      data-initial-multi={props.initialMultipleTenants ? "1" : "0"}
+    />
   ),
+}));
+
+const redirectMock = vi.fn((dest: string) => {
+  // Stand-in for next/navigation's redirect, which throws to unwind the
+  // render. Throwing here keeps the control flow honest: anything after
+  // the redirect call must not run.
+  throw new Error(`REDIRECT:${dest}`);
+});
+vi.mock("next/navigation", () => ({
+  redirect: (dest: string) => redirectMock(dest),
+}));
+
+const loginErrorCookie: { value?: string } = {};
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) =>
+      name === "zt_login_error" && loginErrorCookie.value !== undefined
+        ? { name, value: loginErrorCookie.value }
+        : undefined,
+  }),
 }));
 
 vi.mock("@/lib/auth/sanitize-return-url", () => ({
@@ -24,6 +55,22 @@ const configMock = vi.hoisted(() => ({ authProvider: "gip" as "gip" | "zitadel" 
 vi.mock("@/lib/config", () => ({ publicConfig: configMock }));
 
 import LoginPage from "./page";
+import { beforeEach } from "vitest";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete loginErrorCookie.value;
+});
+
+/** Runs the page and returns the destination its redirect threw with. */
+async function redirectDestination(
+  searchParams: Record<string, string>,
+): Promise<string> {
+  await expect(
+    LoginPage({ searchParams: Promise.resolve(searchParams) }),
+  ).rejects.toThrow(/^REDIRECT:/);
+  return redirectMock.mock.calls[0]![0];
+}
 
 describe("LoginPage — provider wiring", () => {
   it("passes provider=\"gip\" to SignInForm when the flag is unset", async () => {
@@ -44,5 +91,140 @@ describe("LoginPage — provider wiring", () => {
     render(element);
 
     expect(screen.getByTestId("sign-in-form").dataset.provider).toBe("zitadel");
+  });
+});
+
+// Production report: a failed Google attempt sent the merchant back to
+// /login carrying the auth request idp/complete had already SPENT, so the
+// "sign in with your email and password instead" advice ended in a raw
+// Zitadel body — {"error": "No valid authentication request found"}. The
+// finish route now sends the `recovery` sentinel instead, and this page
+// has to give it its documented meaning.
+describe("LoginPage — recovery sentinel", () => {
+  it("bounces a recovery arrival to /login/authorize for a FRESH auth request instead of rendering a dead one", async () => {
+    configMock.authProvider = "zitadel";
+
+    const dest = await redirectDestination({
+      authRequest: "recovery",
+      error: "no_admin_account",
+    });
+
+    expect(dest.startsWith("/login/authorize")).toBe(true);
+  });
+
+  it("preserves the error code across that bounce so the merchant still learns why Google failed", async () => {
+    configMock.authProvider = "zitadel";
+
+    const dest = await redirectDestination({
+      authRequest: "recovery",
+      error: "no_admin_account",
+    });
+
+    expect(new URLSearchParams(dest.split("?")[1]).get("error")).toBe("no_admin_account");
+  });
+
+  it("preserves returnUrl alongside the error", async () => {
+    configMock.authProvider = "zitadel";
+
+    const dest = await redirectDestination({
+      authRequest: "recovery",
+      error: "step_up_unsupported",
+      returnUrl: "/orders",
+    });
+
+    const params = new URLSearchParams(dest.split("?")[1]);
+    expect(params.get("returnUrl")).toBe("/orders");
+    expect(params.get("error")).toBe("step_up_unsupported");
+  });
+
+  it("also carries the error when there is no authRequest at all", async () => {
+    configMock.authProvider = "zitadel";
+
+    const dest = await redirectDestination({ error: "email_ambiguous" });
+
+    expect(new URLSearchParams(dest.split("?")[1]).get("error")).toBe("email_ambiguous");
+  });
+
+  it("renders the form (no bounce) once a real auth request has been minted", async () => {
+    configMock.authProvider = "zitadel";
+
+    const element = await LoginPage({
+      searchParams: Promise.resolve({ authRequest: "V2_fresh" }),
+    });
+    render(element);
+
+    expect(redirectMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("sign-in-form")).toBeTruthy();
+  });
+
+  it("reads the error back off the cookie that survived the Zitadel hop", async () => {
+    configMock.authProvider = "zitadel";
+    loginErrorCookie.value = "no_admin_account";
+
+    const element = await LoginPage({
+      searchParams: Promise.resolve({ authRequest: "V2_fresh" }),
+    });
+    render(element);
+
+    expect(screen.getByTestId("sign-in-form").dataset.googleError).toBe("no_admin_account");
+  });
+
+  it("hands an unrecognised code to SignInForm as a code, never as rendered text — messageForAdminGoogleError maps it to the generic message", async () => {
+    configMock.authProvider = "zitadel";
+
+    const element = await LoginPage({
+      searchParams: Promise.resolve({
+        authRequest: "V2_fresh",
+        error: "No valid authentication request found",
+      }),
+    });
+    render(element);
+
+    // The value reaches the form only as an opaque code; the form maps
+    // anything unrecognised onto a generic message (pinned in
+    // lib/auth/google-sign-in-admin.test.ts), so no provider text is
+    // rendered. Nothing about the raw string is echoed into the page.
+    expect(document.body.textContent).not.toContain("No valid authentication request found");
+  });
+});
+
+describe("LoginPage — email-OTP challenge arrival (#686)", () => {
+  it("passes challenge=email_otp down to the form so it opens on the code step", async () => {
+    configMock.authProvider = "zitadel";
+
+    const element = await LoginPage({
+      searchParams: Promise.resolve({ authRequest: "ar-1", challenge: "email_otp" }),
+    });
+    render(element);
+
+    expect(screen.getByTestId("sign-in-form").dataset.initialChallenge).toBe("email_otp");
+  });
+
+  it("ignores any other challenge value — mfa/totp must never be openable from a query string", async () => {
+    configMock.authProvider = "zitadel";
+
+    for (const challenge of ["mfa", "totp", "email_otp_but_not"]) {
+      const element = await LoginPage({
+        searchParams: Promise.resolve({ authRequest: "ar-1", challenge }),
+      });
+      const { unmount } = render(element);
+      expect(screen.getByTestId("sign-in-form").dataset.initialChallenge).toBe("");
+      unmount();
+    }
+  });
+
+  it("passes multi=1 through as initialMultipleTenants", async () => {
+    configMock.authProvider = "zitadel";
+
+    const element = await LoginPage({
+      searchParams: Promise.resolve({
+        authRequest: "ar-1",
+        challenge: "email_otp",
+        multi: "1",
+      }),
+    });
+    render(element);
+
+    expect(screen.getByTestId("sign-in-form").dataset.initialMulti).toBe("1");
   });
 });

--- a/apps/admin/app/login/page.tsx
+++ b/apps/admin/app/login/page.tsx
@@ -1,15 +1,33 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { BrandBar } from "@repo/ui/brand-bar";
 
 import { SignInForm } from "@/components/auth/SignInForm";
 import { sanitizeReturnUrl } from "@/lib/auth/sanitize-return-url";
+import { RECOVERY_AUTH_REQUEST_SENTINEL } from "@/lib/auth/google-sign-in-admin";
+import { ZITADEL_LOGIN_ERROR_COOKIE } from "@/lib/auth/zitadel-oidc";
 import { publicConfig } from "@/lib/config";
 
 export const metadata: Metadata = { title: "Sign in" };
 
 interface PageProps {
-  searchParams: Promise<{ returnUrl?: string; authRequest?: string; error?: string }>;
+  searchParams: Promise<{
+    returnUrl?: string;
+    authRequest?: string;
+    error?: string;
+    // Set only by app/auth/idp/finish/route.ts when a Google sign-in
+    // reached auth-bff's email-OTP gate. The single recognised value is
+    // "email_otp" — Zitadel's own TOTP and auth-bff's usermfa gate are
+    // still refused on that path (they need a session id/token this page
+    // must never receive in a URL), so nothing else may open the code
+    // screen from a query string.
+    challenge?: string;
+    // "1" when the resolved account belongs to more than one store, so
+    // the post-code redirect goes to /pick-tenant instead of /dashboard.
+    // A display hint only — /pick-tenant re-resolves memberships itself.
+    multi?: string;
+  }>;
 }
 
 /**
@@ -29,12 +47,20 @@ interface PageProps {
  * .mark8ly.com so it carries across the bounce.
  */
 export default async function LoginPage({ searchParams }: PageProps) {
-  const { returnUrl, authRequest, error } = await searchParams;
+  const { returnUrl, authRequest, error, challenge, multi } = await searchParams;
   const safeReturnUrl = sanitizeReturnUrl(returnUrl);
 
   const isZitadel = publicConfig.authProvider === "zitadel";
 
-  if (isZitadel && !authRequest) {
+  // The recovery sentinel is not an auth request — it is the marker
+  // app/auth/idp/finish/route.ts sets to say "the one I had is spent,
+  // mint a fresh one but keep my message". Treating it as a real id is
+  // what put a dead auth request behind the form and turned the password
+  // fallback into raw provider JSON.
+  const needsFreshAuthRequest =
+    !authRequest || authRequest === RECOVERY_AUTH_REQUEST_SENTINEL;
+
+  if (isZitadel && needsFreshAuthRequest) {
     // Zitadel's login-client model needs an auth_request_id, which
     // only exists after Zitadel's /authorize bounces the browser back
     // here with ?authRequest=. /login/authorize is a Route Handler
@@ -42,11 +68,26 @@ export default async function LoginPage({ searchParams }: PageProps) {
     // cookies requires cookie writes, and Next.js only allows those
     // from a Server Action or Route Handler — never a Server
     // Component's render.
+    //
+    // `error` is forwarded so the truthful Google-failure message
+    // survives the detour; /login/authorize re-validates it against the
+    // outcome-code allowlist and parks it in a short-lived cookie,
+    // because Zitadel rebuilds this page's URL itself and would drop a
+    // query param.
     const params = new URLSearchParams();
     if (safeReturnUrl) params.set("returnUrl", safeReturnUrl);
+    if (error) params.set("error", error);
     const suffix = params.toString();
     redirect(`/login/authorize${suffix ? `?${suffix}` : ""}`);
   }
+
+  // Query param first (the direct, same-hop case — e.g. /auth/callback's
+  // own state_mismatch), then the cookie that survived a Zitadel detour.
+  // Either way the value only ever reaches the browser through
+  // messageForAdminGoogleError, which maps an unrecognised code onto a
+  // generic message rather than echoing it.
+  const googleErrorCode =
+    error ?? (await cookies()).get(ZITADEL_LOGIN_ERROR_COOKIE)?.value ?? undefined;
 
   return (
     <>
@@ -57,7 +98,9 @@ export default async function LoginPage({ searchParams }: PageProps) {
             returnUrl={safeReturnUrl}
             authRequestId={authRequest}
             provider={publicConfig.authProvider}
-            googleErrorCode={error}
+            googleErrorCode={googleErrorCode || undefined}
+            initialChallenge={challenge === "email_otp" ? "email_otp" : undefined}
+            initialMultipleTenants={multi === "1"}
           />
           {/* Operator disclosure on the sign-in screen: this is where a
               merchant decides to trust the platform, and the entity on their

--- a/apps/admin/components/auth/SignInForm.test.tsx
+++ b/apps/admin/components/auth/SignInForm.test.tsx
@@ -15,6 +15,8 @@ const signInWithPassword = vi.fn();
 const signIn = vi.fn();
 const signInWithZitadel = vi.fn();
 const confirmZitadelTotp = vi.fn();
+const confirmEmailOTPLogin = vi.fn();
+const resendEmailOTPCode = vi.fn();
 const push = vi.fn();
 
 vi.mock("@/lib/gip/signup", () => ({
@@ -47,8 +49,8 @@ vi.mock("@/app/login/actions", () => ({
   signInWithZitadel: (...args: unknown[]) => signInWithZitadel(...args),
   confirmZitadelTotp: (...args: unknown[]) => confirmZitadelTotp(...args),
   confirmMFALogin: vi.fn(),
-  confirmEmailOTPLogin: vi.fn(),
-  resendEmailOTPCode: vi.fn(),
+  confirmEmailOTPLogin: (...args: unknown[]) => confirmEmailOTPLogin(...args),
+  resendEmailOTPCode: (...args: unknown[]) => resendEmailOTPCode(...args),
 }));
 
 const startAdminGoogleSignIn = vi.fn();
@@ -334,5 +336,90 @@ describe("SignInForm — handoffUrl validation (Minor)", () => {
 
     await waitFor(() => expect(signInWithZitadel).toHaveBeenCalledTimes(1));
     expect(assign).not.toHaveBeenCalled();
+  });
+});
+
+// #686 — a Google sign-in that hits auth-bff's email-OTP gate is redirected
+// back to /login with ?challenge=email_otp instead of being refused. The
+// form has to OPEN on the code step: the pending cookie rode in on that
+// redirect, and there is no password submit to reach the step through.
+describe("SignInForm — email-OTP challenge arriving by redirect", () => {
+  it("renders the code step on first paint, not the password form", () => {
+    render(<SignInForm provider="zitadel" authRequestId="ar-1" initialChallenge="email_otp" />);
+
+    expect(screen.getByLabelText(/sign-in code/i)).toBeTruthy();
+    expect(screen.queryByLabelText(/^password$/i)).toBeNull();
+    // The email-OTP copy, not the authenticator-app copy.
+    expect(screen.getByRole("heading", { name: /check your email/i })).toBeTruthy();
+  });
+
+  it("keeps the password form when no initial challenge is supplied — the untouched default", () => {
+    render(<SignInForm provider="zitadel" authRequestId="ar-1" />);
+
+    expect(screen.getByLabelText(/^password$/i)).toBeTruthy();
+    expect(screen.queryByLabelText(/sign-in code/i)).toBeNull();
+  });
+
+  it("verifies through confirmEmailOTPLogin — the same resume path the password flow uses", async () => {
+    confirmEmailOTPLogin.mockResolvedValue({ ok: true, data: { tenantId: "tenant-1" } });
+    render(<SignInForm provider="zitadel" authRequestId="ar-1" initialChallenge="email_otp" />);
+
+    await userEvent.type(screen.getByLabelText(/sign-in code/i), "123456");
+    await userEvent.click(screen.getByRole("button", { name: /verify and continue/i }));
+
+    await waitFor(() => expect(confirmEmailOTPLogin).toHaveBeenCalledWith("123456"));
+    // Nothing but the code: the pending cookie carries the rest.
+    expect(confirmEmailOTPLogin.mock.calls[0]).toHaveLength(1);
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/dashboard"));
+  });
+
+  it("lands on /pick-tenant when the redirect flagged a multi-store account", async () => {
+    confirmEmailOTPLogin.mockResolvedValue({ ok: true, data: { tenantId: "tenant-1" } });
+    render(
+      <SignInForm
+        provider="zitadel"
+        authRequestId="ar-1"
+        initialChallenge="email_otp"
+        initialMultipleTenants
+      />,
+    );
+
+    await userEvent.type(screen.getByLabelText(/sign-in code/i), "123456");
+    await userEvent.click(screen.getByRole("button", { name: /verify and continue/i }));
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/pick-tenant"));
+  });
+
+  it("offers the resend affordance the password email-OTP step has", async () => {
+    resendEmailOTPCode.mockResolvedValue({ ok: true, data: null });
+    render(<SignInForm provider="zitadel" authRequestId="ar-1" initialChallenge="email_otp" />);
+
+    await userEvent.click(screen.getByRole("button", { name: /send a new code/i }));
+
+    await waitFor(() => expect(resendEmailOTPCode).toHaveBeenCalled());
+  });
+
+  it("re-enters through /login/authorize on cancel, because this page's auth request is already spent", async () => {
+    render(<SignInForm provider="zitadel" authRequestId="ar-1" initialChallenge="email_otp" />);
+
+    await userEvent.click(screen.getByRole("button", { name: /use a different account/i }));
+
+    expect(assign).toHaveBeenCalledWith("/login/authorize");
+  });
+
+  it("cancel on the PASSWORD email-OTP step still just reveals the form — no navigation", async () => {
+    signInWithZitadel.mockResolvedValue({
+      ok: true,
+      data: { multipleTenants: false, mfaRequired: false, emailOtpRequired: true },
+    });
+    render(<SignInForm provider="zitadel" authRequestId="ar-1" />);
+
+    await fillAndSubmit();
+    await waitFor(() => expect(screen.getByLabelText(/sign-in code/i)).toBeTruthy());
+
+    await userEvent.click(screen.getByRole("button", { name: /use a different account/i }));
+
+    expect(assign).not.toHaveBeenCalled();
+    expect(screen.getByLabelText(/^password$/i)).toBeTruthy();
   });
 });

--- a/apps/admin/components/auth/SignInForm.tsx
+++ b/apps/admin/components/auth/SignInForm.tsx
@@ -85,6 +85,27 @@ interface SignInFormProps {
    * internal error string.
    */
   googleErrorCode?: string;
+  /**
+   * Set only when app/auth/idp/finish/route.ts redirected here because a
+   * Google-through-Zitadel sign-in hit auth-bff's email-OTP gate. The form
+   * then OPENS on the code step instead of the password fields: the
+   * pending cookie auth-bff minted rode in on that redirect, and
+   * `confirmEmailOTPLogin` resumes from that cookie plus the typed code
+   * alone — nothing else has to survive the navigation.
+   *
+   * Deliberately narrower than the internal `challenge` state: "mfa" is
+   * not accepted, because auth-bff's usermfa gate and Zitadel's own TOTP
+   * step-up are still refused on the redirect path (they need a session
+   * id/token that must never travel in a URL).
+   */
+  initialChallenge?: "email_otp";
+  /**
+   * Whether the account resolved to more than one store, carried across
+   * the same redirect so the post-code landing is /pick-tenant rather
+   * than /dashboard — the job `mfaMultipleTenants` does on the password
+   * path, where it is remembered in state instead.
+   */
+  initialMultipleTenants?: boolean;
 }
 
 export function SignInForm({
@@ -92,6 +113,8 @@ export function SignInForm({
   authRequestId,
   provider,
   googleErrorCode,
+  initialChallenge,
+  initialMultipleTenants,
 }: SignInFormProps = {}) {
   const router = useRouter();
   const isZitadel = provider === "zitadel";
@@ -138,12 +161,20 @@ export function SignInForm({
   // Which challenge the server asked for. "mfa" is an authenticator
   // app; "email_otp" is the new-device code auth-bff emails. Both leave
   // only a PENDING cookie, so neither may skip to goToDestination.
-  const [challenge, setChallenge] = useState<"mfa" | "email_otp" | null>(null);
+  //
+  // `initialChallenge` seeds all three from a redirect arrival (the Google
+  // email-OTP path) instead of from a server-action result, so the code
+  // screen renders on first paint with no flash of the password form.
+  const [challenge, setChallenge] = useState<"mfa" | "email_otp" | null>(
+    initialChallenge ?? null,
+  );
   const [resendNotice, setResendNotice] = useState<string | null>(null);
-  const [mfaStep, setMfaStep] = useState(false);
+  const [mfaStep, setMfaStep] = useState(initialChallenge !== undefined);
   const [mfaCode, setMfaCode] = useState("");
   const [mfaPending, setMfaPending] = useState(false);
-  const [mfaMultipleTenants, setMfaMultipleTenants] = useState(false);
+  const [mfaMultipleTenants, setMfaMultipleTenants] = useState(
+    initialMultipleTenants ?? false,
+  );
 
   // Zitadel's own TOTP step-up — a different mechanism from auth-bff's
   // `usermfa` gate above. Zitadel itself demands a verified
@@ -491,6 +522,17 @@ export function SignInForm({
   }
 
   function cancelMFA() {
+    // Arrived here by redirect from the Google flow: the auth_request_id
+    // on this page was already spent by idp/complete, so simply revealing
+    // the password fields would hand the merchant a form Zitadel rejects
+    // ("No valid authentication request found"). Re-enter through
+    // /login/authorize for a fresh one instead. The password path never
+    // takes this branch — initialChallenge is undefined there — so its
+    // behaviour is unchanged.
+    if (initialChallenge && typeof window !== "undefined") {
+      window.location.assign("/login/authorize");
+      return;
+    }
     setMfaStep(false);
     setChallenge(null);
     setMfaCode("");

--- a/apps/admin/lib/auth/google-sign-in-admin.ts
+++ b/apps/admin/lib/auth/google-sign-in-admin.ts
@@ -38,6 +38,29 @@ export function buildAdminGoogleReturnUrl(
 }
 
 /**
+ * RECOVERY_AUTH_REQUEST_SENTINEL is the value app/auth/idp/finish/route.ts
+ * puts in `?authRequest=` on EVERY error redirect back to /login.
+ *
+ * It is deliberately NOT the auth_request_id the attempt started with. By
+ * the time a Google attempt has reached auth-bff's idp/complete, Zitadel
+ * has spent that auth request — handing it back rendered the login form
+ * around a dead id, and the password submit the error copy recommends came
+ * back as raw provider JSON:
+ *
+ *   {"error": "No valid authentication request found"}
+ *
+ * The sentinel exists purely so the redirect still satisfies middleware's
+ * canonical-/login gate (which 404s a /login with neither a valid slug
+ * returnUrl nor a non-empty authRequest). app/login/page.tsx recognises it
+ * and bounces through /login/authorize to mint a FRESH auth request,
+ * carrying the error code across that hop so the merchant still sees why
+ * Google failed — see that file and app/login/authorize/route.ts.
+ *
+ * It must never be sent to auth-bff or Zitadel as an auth_request_id.
+ */
+export const RECOVERY_AUTH_REQUEST_SENTINEL = "recovery";
+
+/**
  * AdminGoogleErrorCode enumerates every distinct code the merchant Google
  * flow can redirect back to /login with. Kept as a type (not just `string`)
  * so `messageForAdminGoogleError`'s exhaustiveness is checkable, and so a

--- a/apps/admin/lib/auth/zitadel-oidc.ts
+++ b/apps/admin/lib/auth/zitadel-oidc.ts
@@ -18,6 +18,26 @@ export const ZITADEL_RETURN_URL_COOKIE = "zt_return_url";
 // tab open overnight.
 export const ZITADEL_FLOW_COOKIE_MAX_AGE_SECONDS = 600;
 
+// Carries a merchant-facing Google sign-in outcome code across the
+// /login/authorize -> Zitadel /authorize -> /login?authRequest=… hop.
+//
+// A query param cannot do this job: Zitadel builds that final /login URL
+// itself from the app's configured login base URI and appends only its own
+// `authRequest`, so anything this app puts on the way in is dropped. The
+// returnUrl already rides a cookie for the same reason
+// (ZITADEL_RETURN_URL_COOKIE) — this is that pattern, not a new one.
+//
+// Only a value that passes `isAdminGoogleErrorCode` is ever written here
+// (see app/login/authorize/route.ts), so nothing free-text — least of all
+// a provider's own error body — can reach the page through it.
+export const ZITADEL_LOGIN_ERROR_COOKIE = "zt_login_error";
+
+// Two minutes: the hop it survives is three redirects long. A Server
+// Component render cannot clear a cookie, so this TTL is the only thing
+// bounding how long a stale message could reappear on a /login reload —
+// short enough that it cannot outlive the attempt it describes.
+export const ZITADEL_LOGIN_ERROR_COOKIE_MAX_AGE_SECONDS = 120;
+
 function base64url(bytes: Uint8Array): string {
   return Buffer.from(bytes).toString("base64url");
 }


### PR DESCRIPTION
Closes the last two gaps in merchant Google sign-in on web. Google already works on a **recognised** device — verified in production at 11:30 UTC today, `start`/`finish`/`complete` all 200 with no handoff. These two are what remain for a **new** device.

## 1. A new device can now finish with the emailed code

Every new device trips the `deviceguard`/`emailotp` gate, and the redirect-only finish route refused outright:

```ts
if (data.totpRequired || data.mfaRequired || data.emailOtpRequired) {
    return errorRedirect("step_up_unsupported");
}
```

`emailOtpRequired` now continues into the code step that already exists for the password path. **TOTP and MFA keep the refusal** — that comment's reason still holds: Zitadel's TOTP step-up hands back a session id/token that must never travel in a URL. A test asserts no session id, session token, intent id or intent token appears in the redirect, by pinning the exact param set to `["authRequest","challenge"]`.

`SignInForm`'s new `initialChallenge` is typed **narrower** than its internal `"mfa" | "email_otp"` state, so MFA and TOTP can never be opened from a query string.

## 2. The password fallback works after a failed Google attempt

A merchant hit this in production today: told *"sign in with your email and password instead"*, they did, and got

```
{"error": "No valid authentication request found"}
```

`errorRedirect` handed back the **original** `authRequestId`, which Zitadel had already spent — captured in the logs as `COMMAND-Sx208nt` on `POST /v2/oidc/auth_requests/{id}`, a positive decision whose exchange failed. `page.tsx` only mints a fresh request when `authRequest` is completely absent, so it rendered a form around a dead id. **The recommended fallback could not work.**

Error redirects now always use the recovery sentinel; the login page bounces through `/login/authorize` for a fresh request and carries the message in an httpOnly cookie. The cookie is necessary, not stylistic: in Zitadel's login-client model *Zitadel* builds the final `/login?authRequest=…` URL and drops anything we append — the same reason `returnUrl` already rides `ZITADEL_RETURN_URL_COOKIE`.

Confirmed by the reporting merchant: loading a fresh tab and signing in with a password worked, which is exactly what this makes automatic.

## Two review notes

**My brief was wrong about `Set-Cookie`.** I asserted the finish route discarded auth-bff's cookies. It does not — `finishZitadelGoogleSignIn` -> `mapZitadelOutcome` -> `applySetCookies` writes them through `next/headers` (`actions.ts:427`), the same mechanism `app/auth/handoff/route.ts` uses in production. No second mechanism was added. Returning `setCookies` from that `"use server"` export was considered and rejected, because it would put httpOnly cookie values into a client-callable action's return.

**Unrecognised error codes are not filtered, deliberately.** I asked for filtering; that would have been wrong. `/auth/callback` legitimately redirects `?error=state_mismatch`, which is not an `AdminGoogleErrorCode`, and `messageForAdminGoogleError` already maps unknowns to a generic message — filtering would make that failure render nothing at all. What is pinned instead is that no raw provider string is ever echoed.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **1212 tests / 138 files pass**
- [x] `npm run build` — **compiled successfully** (run because `next build` is the only gate that catches `"use server"` export violations, and this touches a server component and a `"use server"` consumer)
- [x] email-OTP redirects to the code step, keeps a usable auth request, sets `multi` correctly, and leaks no session/intent identifier
- [x] TOTP and MFA still refuse, with no `sess-1`/`sess-token-1`/`tenant-code-1` anywhere in the Location
- [x] Pending cookie forwarding pinned at the actions level, where it is observable
- [x] Recovery: error redirects never carry the original id; the sentinel bounce mints a fresh request and preserves the message; PKCE `state`/verifier untouched
- [x] Password path unchanged — cancel still reveals the form with no navigation

## Not verified

- **No live run.** That `zt_login_error` (SameSite=Lax) survives the return navigation from Zitadel's origin is reasoned from the `ZITADEL_RETURN_URL_COOKIE` precedent, not observed. If it does not, the form still works and only the message is lost — a degradation, not a break.
- A `/login` reload within 120s can re-show a stale Google message; a Server Component cannot clear a cookie. Bounded by the TTL.
- The recovery bounce costs one extra redirect on every error branch, including ones where the auth request was still live. Chosen to remove the class of bug rather than one instance of it.
- One existing test changed on purpose: the `google_sign_in_unavailable` case asserted `authRequest=ar-1` and now asserts `recovery`.
