### PR TITLE
feat(billing): the day-30 win-back offers a real code, and claims one only when it validates

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -2341,9 +2341,17 @@ func main() {
 	}
 
 	winBackEmailClient := billingEmailClient
+
+	// The win-back only ever VALIDATES a promo code — it never redeems one —
+	// so this service is constructed with a nil Stripe client on purpose.
+	// promo.Service.ValidateCode makes no Stripe call, and handing the cron a
+	// client it must not use would be an invitation to start using it.
+	winBackPromo := promo.NewService(conn, promo.NewRepository(), nil, log)
+
 	winBackCron := lifecycle.NewWinBackCron(conn, winBackEmailClient, log, nil).
 		WithSkipCounter(lifecycleSkipCounter{metrics.BillingEmailsSkippedTotal}).
-		WithSentCounter(lifecycleSentCounter{metrics.BillingEmailsSentTotal})
+		WithSentCounter(lifecycleSentCounter{metrics.BillingEmailsSentTotal}).
+		WithPromo(winBackPromo)
 	if _, err := trialScheduler.AddFunc(lifecycle.WinBackSpec, func() {
 		if err := winBackCron.Run(workerCtx); err != nil {
 			log.Error("lifecycle win-back cron failed", "err", err)

--- a/services/marketplace-api/internal/email/client.go
+++ b/services/marketplace-api/internal/email/client.go
@@ -42,11 +42,25 @@ const (
 	TemplateMigrationFastPathApproved TemplateID = "migration_fast_path_approved"
 	TemplateMigrationFastPathRejected TemplateID = "migration_fast_path_rejected"
 
-	// Day-30 post-expiry win-back promo. Lived in the lifecycle package
-	// until #381; moved here so the billing catalog is complete in one
-	// place and the email package can register its fallback without
-	// importing lifecycle (which imports email).
-	TemplateWinBack TemplateID = "win_back_day30"
+	// Day-30 post-expiry win-back. Lived in the lifecycle package until
+	// #381; moved here so the billing catalog is complete in one place and
+	// the email package can register its fallback without importing
+	// lifecycle (which imports email).
+	//
+	// TWO keys, one campaign. TemplateWinBack states a discount and is sent
+	// only when the cron has confirmed a redeemable promo code; the copy
+	// interpolates that code and its terms. TemplateWinBackNoOffer states no
+	// discount at all and is what goes out when there is none to state.
+	//
+	// The choice is made in Go (lifecycle.WinBackTemplate) rather than by a
+	// {{if}} inside one template, because these keys are overridable from
+	// the operator console: a single template would put the guard on the
+	// discount claim into a text box an operator can edit, and deleting it
+	// would restore #727's unconditional promise with no code change and no
+	// review. Two keys make the offer-less copy a separate row, which cannot
+	// grow a discount claim by accident.
+	TemplateWinBack        TemplateID = "win_back_day30"
+	TemplateWinBackNoOffer TemplateID = "win_back_day30_no_offer"
 )
 
 // Client is the narrow interface every caller uses.

--- a/services/marketplace-api/internal/email/identity_split_test.go
+++ b/services/marketplace-api/internal/email/identity_split_test.go
@@ -217,6 +217,7 @@ func TestIdentitySplit_PlatformMail(t *testing.T) {
 		email.TemplateMigrationFastPathApproved,
 		email.TemplateMigrationFastPathRejected,
 		email.TemplateWinBack,
+		email.TemplateWinBackNoOffer,
 	}
 
 	for _, tmpl := range billing {

--- a/services/marketplace-api/internal/email/templates.go
+++ b/services/marketplace-api/internal/email/templates.go
@@ -31,6 +31,7 @@ var billingTemplateKeys = []TemplateID{
 	TemplateDunningDay5,
 	TemplateDunningDay7,
 	TemplateWinBack,
+	TemplateWinBackNoOffer,
 	TemplateMigrationFastPathApproved,
 	TemplateMigrationFastPathRejected,
 }

--- a/services/marketplace-api/internal/email/templates_content.go
+++ b/services/marketplace-api/internal/email/templates_content.go
@@ -115,9 +115,16 @@ var billingHTMLFragments = map[TemplateID]string{
 	// when it holds a code that validated. Its numbers come from the promo
 	// row too, so a console edit to the discount cannot leave the email
 	// quoting a stale one.
+	//
+	// It deliberately does NOT tell the merchant where to enter the code.
+	// POST /admin/stores/:storeId/subscription/apply-promo has no caller in
+	// apps/ — there is no field in the merchant admin that redeems a promo
+	// code — so naming a screen would be the same class of untrue statement
+	// this template was fixed to stop making. Whoever authors the code in
+	// the console owns closing that gap first.
 	TemplateWinBack: `<h1 ` + h1 + `>Your store is still here</h1>
 <p><strong>{{.store_name}}</strong> has been closed for a month. Everything — products, orders, settings — is exactly as you left it.</p>
-<p>If you want to pick it back up, use the code <strong>{{.promo_code}}</strong> in your billing settings and we will take <strong>{{.percent_off}}% off your first {{.duration_months}} months</strong>.</p>`,
+<p>If you want to pick it back up, use the code <strong>{{.promo_code}}</strong> when you reopen your store and we will take <strong>{{.percent_off}}% off your first {{.duration_months}} months</strong>.</p>`,
 
 	// The offer-less variant. It carries no number and names no code,
 	// because when this key is chosen there is nothing to name. What is
@@ -242,7 +249,7 @@ Mark8ly`,
 
 {{.store_name}} has been closed for a month. Everything — products, orders, settings — is exactly as you left it.
 
-If you want to pick it back up, use the code {{.promo_code}} in your billing settings and we will take {{.percent_off}}% off your first {{.duration_months}} months.
+If you want to pick it back up, use the code {{.promo_code}} when you reopen your store and we will take {{.percent_off}}% off your first {{.duration_months}} months.
 
 Mark8ly`,
 

--- a/services/marketplace-api/internal/email/templates_content.go
+++ b/services/marketplace-api/internal/email/templates_content.go
@@ -54,7 +54,8 @@ var billingSubjects = map[TemplateID]string{
 	TemplateTrialHasPMT1:          `Your {{.plan}} plan for {{.store_name}} starts tomorrow`,
 	TemplateTrialStartedBilled:    `Your {{.plan}} plan for {{.store_name}} is active`,
 	TemplateTrialExpired:          `Your {{.store_name}} trial has ended`,
-	TemplateWinBack:               `Come back to Mark8ly — 20% off six months`,
+	TemplateWinBack:               `Come back to Mark8ly — {{.percent_off}}% off for {{.duration_months}} months`,
+	TemplateWinBackNoOffer:        `Your {{.store_name}} store is still here`,
 
 	TemplateMigrationFastPathApproved: `Your migration request for {{.store_name}} is approved`,
 	TemplateMigrationFastPathRejected: `We could not approve the migration request for {{.store_name}}`,
@@ -109,9 +110,22 @@ var billingHTMLFragments = map[TemplateID]string{
 <p>Nothing has been deleted. Your products, orders and settings are exactly as you left them.</p>
 <p>To reopen the store, add a payment method and choose a plan in your Mark8ly billing settings — it comes back straight away.</p>`,
 
+	// The discount sentence names {{.promo_code}}, so this fragment cannot
+	// render a credible offer without one — the cron only reaches this key
+	// when it holds a code that validated. Its numbers come from the promo
+	// row too, so a console edit to the discount cannot leave the email
+	// quoting a stale one.
 	TemplateWinBack: `<h1 ` + h1 + `>Your store is still here</h1>
 <p><strong>{{.store_name}}</strong> has been closed for a month. Everything — products, orders, settings — is exactly as you left it.</p>
-<p>If you want to pick it back up, we will take <strong>20% off your first six months</strong>.</p>`,
+<p>If you want to pick it back up, use the code <strong>{{.promo_code}}</strong> in your billing settings and we will take <strong>{{.percent_off}}% off your first {{.duration_months}} months</strong>.</p>`,
+
+	// The offer-less variant. It carries no number and names no code,
+	// because when this key is chosen there is nothing to name. What is
+	// left is still worth sending: a merchant a month past expiry does not
+	// know their catalogue survived.
+	TemplateWinBackNoOffer: `<h1 ` + h1 + `>Your store is still here</h1>
+<p><strong>{{.store_name}}</strong> has been closed for a month. Everything — products, orders, settings — is exactly as you left it.</p>
+<p>Nothing has been deleted. Whenever you want to reopen it, add a payment method and choose a plan in your Mark8ly billing settings — the storefront comes back straight away.</p>`,
 
 	TemplateMigrationFastPathApproved: `<h1 ` + h1 + `>Your migration request is approved</h1>
 <p>We reviewed the evidence you sent for <strong>{{.store_name}}</strong> and approved your migration request. Nothing further is needed from you.</p>
@@ -228,7 +242,15 @@ Mark8ly`,
 
 {{.store_name}} has been closed for a month. Everything — products, orders, settings — is exactly as you left it.
 
-If you want to pick it back up, we will take 20% off your first six months.
+If you want to pick it back up, use the code {{.promo_code}} in your billing settings and we will take {{.percent_off}}% off your first {{.duration_months}} months.
+
+Mark8ly`,
+
+	TemplateWinBackNoOffer: `Your store is still here
+
+{{.store_name}} has been closed for a month. Everything — products, orders, settings — is exactly as you left it.
+
+Nothing has been deleted. Whenever you want to reopen it, add a payment method and choose a plan in your Mark8ly billing settings — the storefront comes back straight away.
 
 Mark8ly`,
 

--- a/services/marketplace-api/internal/email/templates_lint_test.go
+++ b/services/marketplace-api/internal/email/templates_lint_test.go
@@ -25,7 +25,9 @@ func TestBillingTemplates_NoMissingVariables(t *testing.T) {
 		"has_payment_method": false,
 		"plan":               "growth",
 		"period":             "monthly",
-		"promo":              "20%-off-6-months",
+		"promo_code":         "WINBACK20OFF6MONTHS",
+		"percent_off":        "20",
+		"duration_months":    6,
 		"hosted_invoice_url": "https://invoice.stripe.com/i/test",
 	}
 

--- a/services/marketplace-api/internal/email/templates_test.go
+++ b/services/marketplace-api/internal/email/templates_test.go
@@ -22,7 +22,9 @@ func sampleVars() map[string]any {
 		"has_payment_method": false,
 		"plan":               "growth",
 		"period":             "monthly",
-		"promo":              "20%-off-6-months",
+		"promo_code":         "WINBACK20OFF6MONTHS",
+		"percent_off":        "20",
+		"duration_months":    6,
 		"hosted_invoice_url": "https://invoice.stripe.com/i/test",
 	}
 }
@@ -32,8 +34,8 @@ func TestRegisterFallbacks_EveryKeyRenders(t *testing.T) {
 	email.RegisterFallbacks(loader)
 
 	keys := email.BillingTemplateKeys()
-	if len(keys) != 14 {
-		t.Fatalf("BillingTemplateKeys() has %d keys, want 14", len(keys))
+	if len(keys) != 15 {
+		t.Fatalf("BillingTemplateKeys() has %d keys, want 15", len(keys))
 	}
 
 	for _, key := range keys {

--- a/services/marketplace-api/internal/email/winback_copy_test.go
+++ b/services/marketplace-api/internal/email/winback_copy_test.go
@@ -1,0 +1,96 @@
+package email_test
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+)
+
+// discountClaims are the shapes a reader would take as a promise of money
+// off. The offer-less win-back must contain none of them in any of its three
+// parts — that is the whole of #727: the day-30 mail quantified an offer
+// nothing could honour.
+var discountClaims = []string{"%", "discount", "off your", "off for", "promo", "code"}
+
+// htmlTag strips markup so the claim scan reads what a MERCHANT reads. The
+// shared chrome is full of layout attributes — width="100%" among them — and
+// scanning raw HTML would fail on those while telling you nothing about the
+// copy.
+var htmlTag = regexp.MustCompile(`<[^>]*>`)
+
+func visibleText(html string) string { return htmlTag.ReplaceAllString(html, " ") }
+
+func renderWinBack(t *testing.T, key email.TemplateID, vars map[string]any) emailtemplates.Rendered {
+	t.Helper()
+	loader := emailtemplates.NewLoader(nil)
+	email.RegisterFallbacks(loader)
+	r, err := loader.Render(context.Background(), string(key), vars)
+	if err != nil {
+		t.Fatalf("Render(%s): %v", key, err)
+	}
+	return r
+}
+
+func TestWinBackNoOffer_MakesNoDiscountClaim(t *testing.T) {
+	r := renderWinBack(t, email.TemplateWinBackNoOffer, map[string]any{
+		"store_name": "Acme Supply Co",
+	})
+
+	for _, part := range []struct{ name, body string }{
+		{"subject", r.Subject},
+		{"html", visibleText(r.HTMLBody)},
+		{"text", r.TextBody},
+	} {
+		lower := strings.ToLower(part.body)
+		for _, claim := range discountClaims {
+			if strings.Contains(lower, claim) {
+				t.Errorf("%s contains %q — the offer-less win-back must promise nothing: %s",
+					part.name, claim, part.body)
+			}
+		}
+	}
+}
+
+// The offer-less variant is still a useful email, not an empty one: it has to
+// tell a merchant a month past expiry that their catalogue is intact.
+func TestWinBackNoOffer_StillSaysTheStoreIsIntact(t *testing.T) {
+	r := renderWinBack(t, email.TemplateWinBackNoOffer, map[string]any{
+		"store_name": "Acme Supply Co",
+	})
+	for _, want := range []string{"Acme Supply Co", "Nothing has been deleted"} {
+		if !strings.Contains(r.TextBody, want) {
+			t.Errorf("text body does not mention %q: %s", want, r.TextBody)
+		}
+	}
+}
+
+// The offer variant's numbers come from template DATA, not from prose. A
+// console row that says 15% for 3 months must produce an email that says 15%
+// for 3 months — the #727 defect was a hardcoded "20% off your first six
+// months" that no data could contradict.
+func TestWinBackOffer_QuotesTheDataNotAHardcodedNumber(t *testing.T) {
+	r := renderWinBack(t, email.TemplateWinBack, map[string]any{
+		"store_name":      "Acme Supply Co",
+		"promo_code":      "COMEBACK15OFF3MONTHS",
+		"percent_off":     "15",
+		"duration_months": 3,
+	})
+
+	for _, part := range []string{r.Subject, r.HTMLBody, r.TextBody} {
+		if strings.Contains(part, "20%") || strings.Contains(strings.ToLower(part), "six months") {
+			t.Errorf("a hardcoded 20%%/six-months claim survived the data: %s", part)
+		}
+	}
+	for _, want := range []string{"COMEBACK15OFF3MONTHS", "15%", "3 months"} {
+		if !strings.Contains(r.TextBody, want) {
+			t.Errorf("text body does not carry %q: %s", want, r.TextBody)
+		}
+	}
+	if !strings.Contains(r.Subject, "15%") {
+		t.Errorf("subject does not carry the discount from data: %s", r.Subject)
+	}
+}

--- a/services/marketplace-api/internal/handlers/admin/promo.go
+++ b/services/marketplace-api/internal/handlers/admin/promo.go
@@ -89,14 +89,15 @@ func (h *PromoHandler) ApplyPromo(c *gin.Context) {
 	}
 
 	out, applyErr := h.svc.ApplyPromo(c.Request.Context(), promo.ApplyInput{
-		TenantID:             tenantID,
-		StoreID:              storeID,
-		SubscriptionID:       subID,
-		Code:                 req.Code,
-		MerchantEmail:        req.Email,
-		Plan:                 sub.Plan,
-		Period:               sub.SubscriptionPeriod,
-		BasePriceMinor:       0, // populated from billing_currency/plan lookup in future; floor uses plan+currency
+		TenantID:       tenantID,
+		StoreID:        storeID,
+		SubscriptionID: subID,
+		Code:           req.Code,
+		MerchantEmail:  req.Email,
+		Plan:           sub.Plan,
+		Period:         sub.SubscriptionPeriod,
+		BasePriceMinor: promo.BasePriceMinorFor(
+			sub.Plan, sub.SubscriptionPeriod, sub.PriceTier, stringVal(sub.BillingCurrency)),
 		Currency:             stringVal(sub.BillingCurrency),
 		StripeSubscriptionID: stringVal(sub.StripeSubscriptionID),
 		Actor:                actor,

--- a/services/marketplace-api/internal/handlers/admin/promo_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/promo_integration_test.go
@@ -98,3 +98,38 @@ func TestPromoApply_BelowAbsoluteFloor_INR(t *testing.T) {
 		t.Errorf("spec criterion #40: expected error=promo_invalid_or_expired, got %v", resp["error"])
 	}
 }
+
+// TestPromoApply_AbovePriceFloor_USD is the negative control the floor test
+// above never had: proof that a code CAN be applied at all.
+//
+// Before the BasePriceMinor fix, the handler passed a literal 0 and
+// promo.Validate derived the floor comparison from it, so the effective price
+// was always 0 and every priced plan was rejected below_absolute_floor. The
+// INR test passed either way — it expects a rejection — which is precisely
+// why it could not detect that no application ever succeeded.
+//
+// $19.00 Starter monthly less 20% is $15.20, above the $12.00 floor.
+func TestPromoApply_AbovePriceFloor_USD(t *testing.T) {
+	env := setupTestRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+
+	seedPromoCode(t, env, "WINBACK20OFF6MONTHS", 2000)
+	seedSubscriptionForPromoTest(t, env.db, storeID, tenantID, "starter", "usd")
+
+	body := map[string]any{"code": "WINBACK20OFF6MONTHS", "email": "merchant@example.com"}
+	w := request(t, env.router, http.MethodPost, promoApplyURL(storeID), body, authHeaders(userID, tenantID))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if got := resp["effective_minor"]; got != float64(1520) {
+		t.Errorf("effective_minor = %v, want 1520 ($19.00 less 20%%)", got)
+	}
+}

--- a/services/marketplace-api/internal/promo/baseprice.go
+++ b/services/marketplace-api/internal/promo/baseprice.go
@@ -1,0 +1,82 @@
+package promo
+
+import (
+	"strings"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// BasePriceMinorFor returns the undiscounted recurring price, in minor units,
+// that ApplyInput.BasePriceMinor must carry for the §7.4 absolute-floor check
+// to mean anything.
+//
+// Every caller used to pass a literal 0 with a comment saying the floor "keys
+// off plan + currency". It does not. Validate computes the discounted price
+// from BasePriceMinor and compares THAT against the floor, so a zero base
+// yields a zero effective price, which is below every floor in
+// PlanAbsoluteFloorMinor. The result was that no store on starter, studio or
+// pro could redeem any promo code at all — the request came back
+// below_absolute_floor whatever the code said — while a store still on the
+// trial plan was accepted, because trial has no floor entry. The floor was
+// therefore rejecting exactly the merchants it was written to price-protect
+// and waving through the ones it does not cover.
+//
+// A miss returns 0. That is the previous behaviour, and it is the safe
+// direction: for a plan with a floor it rejects, and for trial/marketplace —
+// the plans with no Stripe Price and no floor — the value is not consulted.
+func BasePriceMinorFor(
+	plan subscription.SubscriptionPlan,
+	period subscription.SubscriptionPeriod,
+	tier subscription.PriceTier,
+	currency string,
+) int64 {
+	p, ok := pricingPlan(plan)
+	if !ok {
+		return 0
+	}
+	cur := strings.ToLower(strings.TrimSpace(currency))
+	if cur == "" {
+		return 0
+	}
+	per := pricing.PeriodMonthly
+	if period == subscription.PeriodAnnual {
+		per = pricing.PeriodAnnual
+	}
+
+	// Both tables are consulted regardless of the row's price_tier, in the
+	// tier's own order. price_tier records which catalog the merchant was
+	// SOLD from, and a currency can be reached from either table (a PPP-tier
+	// row billed in usd, say). Trusting the column alone would return 0 —
+	// "no price" — for a subscription that plainly has one.
+	if tier == subscription.PriceTierPPP {
+		if amt, found := pricing.LookupPPPOption(p, per, cur); found {
+			return amt.UnitAmountMinor
+		}
+	}
+	if opts, found := pricing.DevelopedCurrencyOptions(p, per); found {
+		if amt, present := opts[cur]; present {
+			return amt.UnitAmountMinor
+		}
+	}
+	if amt, found := pricing.LookupPPPOption(p, per, cur); found {
+		return amt.UnitAmountMinor
+	}
+	return 0
+}
+
+// pricingPlan maps a subscription plan onto the pricing catalog's plan.
+// trial and marketplace have no Stripe Price object and no floor entry, so
+// they map to nothing rather than to a zero price.
+func pricingPlan(plan subscription.SubscriptionPlan) (pricing.Plan, bool) {
+	switch plan {
+	case subscription.PlanStarter:
+		return pricing.PlanStarter, true
+	case subscription.PlanStudio:
+		return pricing.PlanStudio, true
+	case subscription.PlanPro:
+		return pricing.PlanPro, true
+	default:
+		return "", false
+	}
+}

--- a/services/marketplace-api/internal/promo/baseprice_test.go
+++ b/services/marketplace-api/internal/promo/baseprice_test.go
@@ -1,0 +1,153 @@
+package promo_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/promo"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+func TestBasePriceMinorFor_DevelopedTier(t *testing.T) {
+	got := promo.BasePriceMinorFor(subscription.PlanStarter, subscription.PeriodMonthly,
+		subscription.PriceTierDeveloped, "usd")
+	if got != 1900 {
+		t.Fatalf("starter monthly usd = %d, want 1900", got)
+	}
+}
+
+func TestBasePriceMinorFor_CurrencyCaseAndPaddingFolded(t *testing.T) {
+	// billing_currency is a char(3) column of unspecified case, so the
+	// value arriving here can be "USD" or "usd " and must find the same row.
+	for _, cur := range []string{"USD", " usd", "Usd "} {
+		if got := promo.BasePriceMinorFor(subscription.PlanStudio, subscription.PeriodAnnual,
+			subscription.PriceTierDeveloped, cur); got != 47000 {
+			t.Errorf("studio annual %q = %d, want 47000", cur, got)
+		}
+	}
+}
+
+func TestBasePriceMinorFor_PPPTier(t *testing.T) {
+	got := promo.BasePriceMinorFor(subscription.PlanStarter, subscription.PeriodMonthly,
+		subscription.PriceTierPPP, "inr")
+	if got != 99900 {
+		t.Fatalf("starter monthly inr = %d, want 99900", got)
+	}
+}
+
+// A PPP-tier row billed in a developed currency still has a price. Reading
+// only the tier's own table would report "no price" for a real subscription.
+func TestBasePriceMinorFor_PPPTierBilledInDevelopedCurrency(t *testing.T) {
+	got := promo.BasePriceMinorFor(subscription.PlanPro, subscription.PeriodMonthly,
+		subscription.PriceTierPPP, "usd")
+	if got == 0 {
+		t.Fatal("pro monthly usd on a ppp-tier row returned 0; the developed table was not consulted")
+	}
+}
+
+func TestBasePriceMinorFor_UnpricedPlansAndMissingCurrency(t *testing.T) {
+	cases := []struct {
+		name     string
+		plan     subscription.SubscriptionPlan
+		currency string
+	}{
+		{"trial has no stripe price", subscription.PlanTrial, "usd"},
+		{"marketplace has no stripe price", subscription.PlanMarketplace, "usd"},
+		{"null billing_currency", subscription.PlanStarter, ""},
+		{"currency not in the catalog", subscription.PlanStarter, "zar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := promo.BasePriceMinorFor(tc.plan, subscription.PeriodMonthly,
+				subscription.PriceTierDeveloped, tc.currency); got != 0 {
+				t.Fatalf("got %d, want 0", got)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The defect this helper exists to close.
+// ---------------------------------------------------------------------------
+
+func percentCode(t *testing.T, bps int) *promo.PromoCode {
+	t.Helper()
+	typ := promo.DiscountTypePercentage
+	val := bps
+	return &promo.PromoCode{
+		Code:          "SAVEOFFER20OFF6MONTHS",
+		DiscountType:  &typ,
+		DiscountValue: &val,
+		MaxPerEmail:   1,
+		ValidFrom:     time.Now().Add(-time.Hour),
+	}
+}
+
+func validateAt(t *testing.T, plan subscription.SubscriptionPlan, currency string, base int64) promo.ValidationResult {
+	t.Helper()
+	return promo.Validate(promo.ValidationInput{
+		SubmittedCode:  "SAVEOFFER20OFF6MONTHS",
+		PromoCode:      percentCode(t, 2000),
+		Now:            time.Now().UTC(),
+		Plan:           plan,
+		Period:         subscription.PeriodMonthly,
+		BasePriceMinor: base,
+		Currency:       currency,
+	})
+}
+
+// The bug, pinned: a zero base price makes the discounted price zero, which
+// is below every floor. Every priced plan was rejected for a reason that had
+// nothing to do with the code submitted.
+func TestValidate_ZeroBasePriceRejectsEveryPricedPlan(t *testing.T) {
+	for _, plan := range []subscription.SubscriptionPlan{
+		subscription.PlanStarter, subscription.PlanStudio, subscription.PlanPro,
+	} {
+		got := validateAt(t, plan, "usd", 0)
+		if got.Accepted {
+			t.Errorf("%s: accepted with a zero base price", plan)
+		}
+		if got.RejectReason != promo.RejectReasonBelowFloor {
+			t.Errorf("%s: reject reason = %q, want below_absolute_floor", plan, got.RejectReason)
+		}
+	}
+}
+
+// And the same zero waved through the one plan the floor does not cover, so
+// the old constant was not merely conservative — it was wrong in both
+// directions.
+func TestValidate_ZeroBasePriceAcceptsTrialPlan(t *testing.T) {
+	if got := validateAt(t, subscription.PlanTrial, "usd", 0); !got.Accepted {
+		t.Fatalf("trial rejected: %q", got.RejectReason)
+	}
+}
+
+func TestValidate_CatalogBasePriceAcceptsStarterUSD(t *testing.T) {
+	base := promo.BasePriceMinorFor(subscription.PlanStarter, subscription.PeriodMonthly,
+		subscription.PriceTierDeveloped, "usd")
+	got := validateAt(t, subscription.PlanStarter, "usd", base)
+	if !got.Accepted {
+		t.Fatalf("rejected with the real base price: %q", got.RejectReason)
+	}
+	if got.EffectiveMinor != 1520 {
+		t.Fatalf("effective = %d, want 1520 ($19.00 less 20%%)", got.EffectiveMinor)
+	}
+}
+
+// The floor still bites where the policy says it should. Starter monthly INR
+// is ₹999; 20% off is ₹799.20, eighty paise under the ₹800 floor. A real
+// base price does not disable the check, it makes it mean what it says.
+func TestValidate_CatalogBasePriceStillEnforcesTheFloor(t *testing.T) {
+	base := promo.BasePriceMinorFor(subscription.PlanStarter, subscription.PeriodMonthly,
+		subscription.PriceTierPPP, "inr")
+	if base != 99900 {
+		t.Fatalf("base = %d, want 99900", base)
+	}
+	got := validateAt(t, subscription.PlanStarter, "inr", base)
+	if got.Accepted {
+		t.Fatal("accepted below the ₹800 absolute floor")
+	}
+	if got.RejectReason != promo.RejectReasonBelowFloor {
+		t.Fatalf("reject reason = %q, want below_absolute_floor", got.RejectReason)
+	}
+}

--- a/services/marketplace-api/internal/promo/service.go
+++ b/services/marketplace-api/internal/promo/service.go
@@ -50,6 +50,34 @@ type ApplyOutput struct {
 	EffectiveMinor int64
 	// RejectReason is empty on success; set when the code was rejected (for audit).
 	RejectReason ValidationRejectReason
+	// PercentOffBps is the code's percentage discount in basis points (2000
+	// = 20%), or 0 when the code carries no percentage discount — it may
+	// carry a flat amount instead, or none at all. Exposed so a caller that
+	// has to DESCRIBE the offer (the day-30 win-back email, #727) states the
+	// row's own number rather than one written into prose.
+	PercentOffBps int
+	// MaxDurationMonths is how many months the discount runs for, or 0 when
+	// the row sets no bound. 0 is "unbounded", never "zero months".
+	MaxDurationMonths int
+}
+
+// terms copies the describable parts of a promo row into an output. Kept in
+// one place so ApplyPromo and ValidateCode cannot describe the same row
+// differently.
+func terms(out ApplyOutput, pc *PromoCode) ApplyOutput {
+	if pc == nil {
+		return out
+	}
+	if pc.StripeCouponID != nil {
+		out.StripeCouponID = *pc.StripeCouponID
+	}
+	if pc.DiscountType != nil && *pc.DiscountType == DiscountTypePercentage && pc.DiscountValue != nil {
+		out.PercentOffBps = *pc.DiscountValue
+	}
+	if pc.MaxDurationMonths != nil {
+		out.MaxDurationMonths = *pc.MaxDurationMonths
+	}
+	return out
 }
 
 // CancelInput is the input to Service.CancelPromo.
@@ -189,11 +217,11 @@ func (s *Service) ApplyPromo(ctx context.Context, in ApplyInput) (ApplyOutput, e
 			WithLabelValues(string(in.Plan), in.Currency, "applied").Inc()
 	}
 
-	return ApplyOutput{
+	return terms(ApplyOutput{
 		PromoCodeID:    pc.ID,
 		StripeCouponID: couponID,
 		EffectiveMinor: result.EffectiveMinor,
-	}, nil
+	}, pc), nil
 }
 
 // CancelPromo removes this code's coupon from the Stripe subscription's
@@ -245,26 +273,33 @@ func (s *Service) cancelCouponID(ctx context.Context, promoCodeID uuid.UUID) (st
 	return *pc.StripeCouponID, nil
 }
 
-// ValidateForSaveOffer is called by P11's cancel flow to assert that a promo
-// code is valid for the save-offer flow before accepting the cancellation
-// rescind. It runs all §7.3 checks but does NOT record a redemption — that
-// happens only if the merchant confirms the save-offer.
-func (s *Service) ValidateForSaveOffer(ctx context.Context, in ApplyInput) (ApplyOutput, error) {
+// ValidateCode runs every §7.3 check for `in` and records NOTHING: no
+// redemption row, no Stripe call, no metric. It answers "would this code be
+// accepted for this store right now", which is a different question from
+// "apply it".
+//
+// Two callers want that question, for different reasons. The cancel save
+// offer asks before accepting the rescind, and applies straight after. The
+// day-30 win-back email (#727) asks so it can decide whether to STATE the
+// offer, and must not redeem: the merchant has not asked for anything yet,
+// and burning the redemption here would leave them unable to use the code
+// when they return — max_per_email is 1.
+func (s *Service) ValidateCode(ctx context.Context, in ApplyInput) (ApplyOutput, error) {
 	pc, err := s.repo.GetByCode(ctx, s.db, in.Code)
 	if err != nil {
 		if errors.As(err, new(*apperrors.Error)) {
 			return ApplyOutput{RejectReason: RejectReasonNotFound}, ErrInvalidOrExpired
 		}
-		return ApplyOutput{}, fmt.Errorf("promo: validate for save offer: lookup: %w", err)
+		return ApplyOutput{}, fmt.Errorf("promo: validate code: lookup: %w", err)
 	}
 
 	totalRed, err := s.repo.CountRedemptions(ctx, s.db, pc.ID)
 	if err != nil {
-		return ApplyOutput{}, fmt.Errorf("promo: validate for save offer: count: %w", err)
+		return ApplyOutput{}, fmt.Errorf("promo: validate code: count: %w", err)
 	}
 	emailRed, err := s.repo.CountRedemptionsByEmail(ctx, s.db, pc.ID, normaliseEmail(in.MerchantEmail))
 	if err != nil {
-		return ApplyOutput{}, fmt.Errorf("promo: validate for save offer: count email: %w", err)
+		return ApplyOutput{}, fmt.Errorf("promo: validate code: count email: %w", err)
 	}
 
 	result := Validate(ValidationInput{
@@ -282,14 +317,17 @@ func (s *Service) ValidateForSaveOffer(ctx context.Context, in ApplyInput) (Appl
 		return ApplyOutput{RejectReason: result.RejectReason}, ErrInvalidOrExpired
 	}
 
-	out := ApplyOutput{
+	return terms(ApplyOutput{
 		PromoCodeID:    pc.ID,
 		EffectiveMinor: result.EffectiveMinor,
-	}
-	if pc.StripeCouponID != nil {
-		out.StripeCouponID = *pc.StripeCouponID
-	}
-	return out, nil
+	}, pc), nil
+}
+
+// ValidateForSaveOffer is the cancel flow's name for ValidateCode. Kept as
+// its own method because the save offer's call site and its tests read for
+// the flow, not the mechanism; it adds no behaviour of its own.
+func (s *Service) ValidateForSaveOffer(ctx context.Context, in ApplyInput) (ApplyOutput, error) {
+	return s.ValidateCode(ctx, in)
 }
 
 func normaliseEmail(email string) string {

--- a/services/marketplace-api/internal/promo/validate_code_test.go
+++ b/services/marketplace-api/internal/promo/validate_code_test.go
@@ -1,0 +1,163 @@
+package promo_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/promo"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+)
+
+// stubRepo implements promo.Repository over in-memory values. Only the three
+// reads ValidateCode performs are meaningful; the write methods exist to
+// satisfy the interface and fail loudly if ValidateCode ever calls one —
+// which would mean it had started redeeming.
+type stubRepo struct {
+	code       *promo.PromoCode
+	getErr     error
+	total      int
+	perEmail   int
+	writeCalls int
+}
+
+func (r *stubRepo) GetByCode(context.Context, *gorm.DB, string) (*promo.PromoCode, error) {
+	if r.getErr != nil {
+		return nil, r.getErr
+	}
+	return r.code, nil
+}
+func (r *stubRepo) GetByID(context.Context, *gorm.DB, uuid.UUID) (*promo.PromoCode, error) {
+	return r.code, nil
+}
+func (r *stubRepo) Create(context.Context, *gorm.DB, *promo.PromoCode) error {
+	r.writeCalls++
+	return nil
+}
+func (r *stubRepo) CountRedemptions(context.Context, *gorm.DB, uuid.UUID) (int, error) {
+	return r.total, nil
+}
+func (r *stubRepo) CountRedemptionsByEmail(context.Context, *gorm.DB, uuid.UUID, string) (int, error) {
+	return r.perEmail, nil
+}
+func (r *stubRepo) GetRedemptionByStore(context.Context, *gorm.DB, uuid.UUID, uuid.UUID) (*promo.Redemption, error) {
+	return nil, apperrors.NotFound("redemption")
+}
+func (r *stubRepo) CreateRedemption(context.Context, *gorm.DB, *promo.Redemption) error {
+	r.writeCalls++
+	return nil
+}
+func (r *stubRepo) DeleteRedemptionByStore(context.Context, *gorm.DB, uuid.UUID, uuid.UUID) error {
+	r.writeCalls++
+	return nil
+}
+
+func winBackRow() *promo.PromoCode {
+	typ := promo.DiscountTypePercentage
+	val := 2000
+	months := 6
+	coupon := "co_test"
+	return &promo.PromoCode{
+		ID:                uuid.New(),
+		Code:              "WINBACK20OFF6MONTHS",
+		StripeCouponID:    &coupon,
+		DiscountType:      &typ,
+		DiscountValue:     &val,
+		MaxDurationMonths: &months,
+		MaxPerEmail:       1,
+		ValidFrom:         time.Now().UTC().Add(-time.Hour),
+	}
+}
+
+func validateInput() promo.ApplyInput {
+	return promo.ApplyInput{
+		Code:           "WINBACK20OFF6MONTHS",
+		MerchantEmail:  "merchant@example.com",
+		Plan:           subscription.PlanStarter,
+		Period:         subscription.PeriodMonthly,
+		Currency:       "usd",
+		BasePriceMinor: promo.BasePriceMinorFor(subscription.PlanStarter, subscription.PeriodMonthly, subscription.PriceTierDeveloped, "usd"),
+	}
+}
+
+func TestValidateCode_ReportsTheRowsOwnTerms(t *testing.T) {
+	repo := &stubRepo{code: winBackRow()}
+	svc := promo.NewService(nil, repo, nil, nil)
+
+	out, err := svc.ValidateCode(context.Background(), validateInput())
+	if err != nil {
+		t.Fatalf("ValidateCode: %v", err)
+	}
+	if out.PercentOffBps != 2000 {
+		t.Errorf("PercentOffBps = %d, want 2000", out.PercentOffBps)
+	}
+	if out.MaxDurationMonths != 6 {
+		t.Errorf("MaxDurationMonths = %d, want 6", out.MaxDurationMonths)
+	}
+	if out.StripeCouponID != "co_test" {
+		t.Errorf("StripeCouponID = %q", out.StripeCouponID)
+	}
+}
+
+// The property the win-back depends on: asking whether a code would be
+// accepted must not consume it. max_per_email is 1, so a redemption recorded
+// at email time is a code the merchant can never use.
+func TestValidateCode_RecordsNothing(t *testing.T) {
+	repo := &stubRepo{code: winBackRow()}
+	svc := promo.NewService(nil, repo, nil, nil)
+
+	if _, err := svc.ValidateCode(context.Background(), validateInput()); err != nil {
+		t.Fatalf("ValidateCode: %v", err)
+	}
+	if repo.writeCalls != 0 {
+		t.Fatalf("ValidateCode performed %d writes; it must record nothing", repo.writeCalls)
+	}
+}
+
+func TestValidateCode_MissingRowIsInvalidOrExpired(t *testing.T) {
+	repo := &stubRepo{getErr: apperrors.NotFound("promo code")}
+	svc := promo.NewService(nil, repo, nil, nil)
+
+	out, err := svc.ValidateCode(context.Background(), validateInput())
+	if !errors.Is(err, promo.ErrInvalidOrExpired) {
+		t.Fatalf("err = %v, want ErrInvalidOrExpired", err)
+	}
+	if out.RejectReason != promo.RejectReasonNotFound {
+		t.Errorf("reject reason = %q", out.RejectReason)
+	}
+}
+
+func TestValidateCode_ExhaustedGlobalCapIsRejected(t *testing.T) {
+	row := winBackRow()
+	max := 100
+	row.MaxRedemptions = &max
+	repo := &stubRepo{code: row, total: 100}
+	svc := promo.NewService(nil, repo, nil, nil)
+
+	out, err := svc.ValidateCode(context.Background(), validateInput())
+	if !errors.Is(err, promo.ErrInvalidOrExpired) {
+		t.Fatalf("err = %v, want ErrInvalidOrExpired", err)
+	}
+	if out.RejectReason != promo.RejectReasonMaxRedemptions {
+		t.Errorf("reject reason = %q, want max_redemptions_reached", out.RejectReason)
+	}
+}
+
+func TestValidateForSaveOffer_IsValidateCode(t *testing.T) {
+	repo := &stubRepo{code: winBackRow()}
+	svc := promo.NewService(nil, repo, nil, nil)
+
+	a, errA := svc.ValidateForSaveOffer(context.Background(), validateInput())
+	b, errB := svc.ValidateCode(context.Background(), validateInput())
+	if errA != nil || errB != nil {
+		t.Fatalf("errs: %v %v", errA, errB)
+	}
+	if a != b {
+		t.Fatalf("ValidateForSaveOffer = %+v, ValidateCode = %+v", a, b)
+	}
+}

--- a/services/marketplace-api/internal/subscription/cancel/save_offer.go
+++ b/services/marketplace-api/internal/subscription/cancel/save_offer.go
@@ -9,16 +9,16 @@ import (
 
 // SaveOfferPromoCode is the promo code the cancellation save offer redeems.
 //
-// Provisioning a promo_codes row whose code is exactly this string is what
-// switches the save-offer discount on. Nothing in the product creates promo
-// codes today (promo.Repository.Create has no production caller and no
-// migration seeds a row), so until such a row exists this path is a deliberate
-// no-op: the reversal still happens and the merchant is simply not told about a
-// discount that was not applied (#701).
+// A promo_codes row whose code is exactly this string is what switches the
+// save-offer discount on. mark8ly does not mint codes: rows arrive from the
+// tesserix-home promo catalog through internal/billing/consolepromo (#726),
+// so authoring this code is a console action. Until the row exists this path
+// is a deliberate no-op — the reversal still happens and the merchant is not
+// told about a discount that was not applied (#701).
 //
-// The promo_codes table carries CHECK (char_length(code) >= 12), so any
-// replacement for this constant must be at least 12 characters or it could
-// never be provisioned.
+// promo_codes now floors code length at 4 characters (migration 000131,
+// relaxed from 12 for console campaign codes such as "LAUNCH50"), so this
+// constant is comfortably provisionable at either bound.
 const SaveOfferPromoCode = "SAVEOFFER20OFF6MONTHS"
 
 const (
@@ -88,14 +88,19 @@ func (s *Service) applySaveOfferDiscount(ctx context.Context, in Input, sub *sub
 	}
 
 	applyIn := promo.ApplyInput{
-		TenantID:             in.TenantID,
-		StoreID:              in.StoreID,
-		SubscriptionID:       sub.ID,
-		Code:                 SaveOfferPromoCode,
-		MerchantEmail:        derefString(sub.Email),
-		Plan:                 sub.Plan,
-		Period:               sub.SubscriptionPeriod,
-		BasePriceMinor:       0, // floor validation keys off plan + currency; mirrors admin.PromoHandler.
+		TenantID:       in.TenantID,
+		StoreID:        in.StoreID,
+		SubscriptionID: sub.ID,
+		Code:           SaveOfferPromoCode,
+		MerchantEmail:  derefString(sub.Email),
+		Plan:           sub.Plan,
+		Period:         sub.SubscriptionPeriod,
+		// The §7.4 absolute floor is computed FROM this price, so a zero
+		// here rejected every priced plan out of hand — the save-offer
+		// discount could never apply to a paying merchant. See
+		// promo.BasePriceMinorFor.
+		BasePriceMinor: promo.BasePriceMinorFor(
+			sub.Plan, sub.SubscriptionPeriod, sub.PriceTier, derefString(sub.BillingCurrency)),
 		Currency:             derefString(sub.BillingCurrency),
 		StripeSubscriptionID: derefString(sub.StripeSubscriptionID),
 		Actor:                in.Actor,

--- a/services/marketplace-api/internal/subscription/cancel/save_offer_test.go
+++ b/services/marketplace-api/internal/subscription/cancel/save_offer_test.go
@@ -152,3 +152,27 @@ func TestApplySaveOfferDiscount_NilSubscriptionIsSafe(t *testing.T) {
 	})
 	require.Empty(t, stub.validateCalls)
 }
+
+// TestApplySaveOfferDiscount_SendsTheRealBasePrice guards the defect the
+// save offer inherited from admin.PromoHandler: BasePriceMinor was a literal
+// 0, and promo.Validate computes the §7.4 floor comparison FROM it, so every
+// priced plan came back below_absolute_floor. The save-offer discount could
+// not have applied to a single paying merchant, whatever code existed.
+func TestApplySaveOfferDiscount_SendsTheRealBasePrice(t *testing.T) {
+	sub := testSub()
+	sub.Plan = subscription.PlanStudio
+	sub.SubscriptionPeriod = subscription.PeriodMonthly
+	sub.PriceTier = subscription.PriceTierDeveloped
+	aud := "aud"
+	sub.BillingCurrency = &aud
+
+	stub := &stubPromo{}
+	svc := testService(stub)
+	require.True(t, svc.applySaveOfferDiscount(context.Background(), testInput(sub), sub))
+
+	require.Len(t, stub.validateCalls, 1)
+	want := promo.BasePriceMinorFor(sub.Plan, sub.SubscriptionPeriod, sub.PriceTier, aud)
+	require.NotZero(t, want, "the pricing catalog must know studio monthly AUD")
+	require.Equal(t, want, stub.validateCalls[0].BasePriceMinor)
+	require.Equal(t, want, stub.applyCalls[0].BasePriceMinor)
+}

--- a/services/marketplace-api/internal/subscription/lifecycle/winback.go
+++ b/services/marketplace-api/internal/subscription/lifecycle/winback.go
@@ -18,15 +18,16 @@ const WinBackSpec = "0 10 * * *"
 // winBack30Days is the post-expiry window after which the win-back promo is sent.
 const winBack30Days = 30 * 24 * time.Hour
 
-// WinBackCron sends a 20%-off-6-months promo email to expired stores at day 30
-// post-expiry (§15.3).
+// WinBackCron emails expired stores at day 30 post-expiry (§15.3).
 //
 // Idempotence comes from the billing_email_sends claim, NOT from the window
 // query. The window selects the same rows on every run within the same day —
 // before #381 the comment here claimed that was idempotent, which it was only
 // because the client was a no-op that never sent anything.
 //
-// NOTE: The actual promo code attachment (P10 promo service) is deferred.
+// The mail is sent whether or not a discount is available; which of the two
+// win-back templates goes out is decided per recipient by offerFor. See
+// winback_offer.go for why the campaign is not gated on the offer.
 type WinBackCron struct {
 	db     *gorm.DB
 	mailer email.Client
@@ -34,6 +35,7 @@ type WinBackCron struct {
 	clock  func() time.Time
 	skip   SkipCounter
 	sent   SentCounter
+	promo  WinBackPromoChecker
 }
 
 // CounterIncrementer is a one-method counter so tests can stub it.
@@ -127,12 +129,19 @@ func (c *WinBackCron) sendOne(ctx context.Context, row *subscription.StoreSubscr
 		to = *row.Email
 	}
 
-	err = c.mailer.Send(ctx, email.TemplateWinBack, to, map[string]any{
+	offer, offered := c.offerFor(ctx, row, to)
+	data := map[string]any{
 		"store_id":   row.StoreID.String(),
 		"tenant_id":  row.TenantID.String(),
 		"store_name": subscription.StoreNameFor(ctx, c.db, row.StoreID),
-		"promo":      "20%-off-6-months",
-	})
+	}
+	if offered {
+		data["promo_code"] = offer.Code
+		data["percent_off"] = offer.PercentOff
+		data["duration_months"] = offer.DurationMonths
+	}
+
+	err = c.mailer.Send(ctx, WinBackTemplate(offered), to, data)
 	if err != nil {
 		c.logger.Warn("lifecycle: win-back email not sent",
 			"store_id", row.StoreID, "tenant_id", row.TenantID,
@@ -154,9 +163,17 @@ func (c *WinBackCron) sendOne(ctx context.Context, row *subscription.StoreSubscr
 		}
 		return
 	}
+	// The claim key and both counters stay on email.TemplateWinBack even
+	// when the offer-less variant was rendered. They identify the CAMPAIGN —
+	// one day-30 send per store — and splitting them by variant would break
+	// the sent+skipped identity documented on
+	// metrics.BillingEmailsSkippedTotal, since a claim taken under one label
+	// could be skipped under the other. Which variant went out is on the log
+	// line below and in the message's `kind` attribution arg.
 	if c.sent != nil {
 		c.sent.WithTemplate(string(email.TemplateWinBack)).Inc()
 	}
 	c.logger.Info("lifecycle: win-back email sent",
-		"store_id", row.StoreID, "tenant_id", row.TenantID)
+		"store_id", row.StoreID, "tenant_id", row.TenantID,
+		"template", string(WinBackTemplate(offered)), "offer", offered)
 }

--- a/services/marketplace-api/internal/subscription/lifecycle/winback_integration_test.go
+++ b/services/marketplace-api/internal/subscription/lifecycle/winback_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/email"
 	"github.com/mark8ly/marketplace-api/internal/emailtemplates"
+	"github.com/mark8ly/marketplace-api/internal/promo"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 	"github.com/mark8ly/marketplace-api/internal/subscription/lifecycle"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
@@ -257,4 +259,190 @@ func TestWinBack_TransportFailureKeepsClaimBurned(t *testing.T) {
 	var claims int64
 	require.NoError(t, db.Raw(`SELECT count(*) FROM billing_email_sends`).Scan(&claims).Error)
 	require.EqualValues(t, 1, claims, "transport failure released the claim; a retry could duplicate")
+}
+
+// ---------------------------------------------------------------------------
+// #727 — the offer the email states must be one that exists.
+// ---------------------------------------------------------------------------
+
+// winBackTables is the cleanup set for the promo-aware tests. promo_codes and
+// promo_redemptions are added because the offer check reads both.
+var winBackTables = []string{
+	"promo_redemptions", "promo_codes", "store_subscriptions", "stores", "billing_email_sends",
+}
+
+// seedWinBackCode inserts the console-authored row the win-back offers. The
+// shape mirrors what internal/billing/consolepromo writes: a percentage
+// discount in basis points, bounded by max_duration_months.
+func seedWinBackCode(t *testing.T, db *gorm.DB, mutate func(*promo.PromoCode)) {
+	t.Helper()
+	typ := promo.DiscountTypePercentage
+	val := 2000
+	months := 6
+	coupon := "co_test_winback"
+	pc := &promo.PromoCode{
+		Code:              lifecycle.WinBackPromoCode,
+		StripeCouponID:    &coupon,
+		DiscountType:      &typ,
+		DiscountValue:     &val,
+		MaxDurationMonths: &months,
+		MaxPerEmail:       1,
+		ValidFrom:         time.Now().UTC().Add(-24 * time.Hour),
+		CreatedBy:         "console:promo-catalog",
+	}
+	if mutate != nil {
+		mutate(pc)
+	}
+	require.NoError(t, promo.NewRepository().Create(context.Background(), db, pc))
+}
+
+// onStarterUSD moves a seeded row onto a real paid plan and currency, which
+// is what a lapsed paying merchant looks like. Uses a raw UPDATE so GORM does
+// not restamp updated_at and push the row out of the 30-day window.
+func onStarterUSD(t *testing.T, db *gorm.DB, id uuid.UUID) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`UPDATE store_subscriptions
+		    SET plan = 'starter', billing_currency = 'usd',
+		        subscription_period = 'monthly', price_tier = 'developed'
+		  WHERE id = ?`, id).Error)
+}
+
+// winBackMessage runs the cron with the REAL email client and promo service
+// and returns the single message that reached the transport.
+func winBackMessage(t *testing.T, db *gorm.DB, now time.Time) email.Message {
+	t.Helper()
+	loader := emailtemplates.NewLoader(nil)
+	email.RegisterFallbacks(loader)
+	sender := &captureSender{}
+	client := email.NewTemplateClient(loader, sender, "noreply@mark8ly.com", nil)
+
+	cron := lifecycle.NewWinBackCron(db, client, slog.Default(), func() time.Time { return now }).
+		WithPromo(promo.NewService(db, promo.NewRepository(), nil, slog.Default()))
+
+	require.NoError(t, cron.Run(context.Background()))
+	require.Len(t, sender.msgs, 1, "expected exactly one win-back message")
+	return sender.msgs[0]
+}
+
+// requireNoDiscountClaim asserts the rendered message promises nothing. This
+// is the property #727 is about: the day-30 mail quantified an offer that
+// nothing could honour.
+func requireNoDiscountClaim(t *testing.T, msg email.Message) {
+	t.Helper()
+	tag := regexp.MustCompile(`<[^>]*>`)
+	parts := map[string]string{
+		"subject": msg.Subject,
+		"text":    msg.TextBody,
+		"html":    tag.ReplaceAllString(msg.HTMLBody, " "),
+	}
+	for name, body := range parts {
+		lower := strings.ToLower(body)
+		for _, claim := range []string{"%", "discount", "off your", "promo", lifecycle.WinBackPromoCode} {
+			require.NotContainsf(t, lower, strings.ToLower(claim),
+				"%s promises %q with no code behind it: %s", name, claim, body)
+		}
+	}
+	require.Contains(t, msg.TextBody, "Nothing has been deleted",
+		"the offer-less win-back must still be worth sending")
+}
+
+// The state production is in today: the catalog holds no win-back code. The
+// email goes out — a merchant a month past expiry does not know their
+// catalogue survived — and states no discount.
+func TestWinBack_NoCodeSendsWithoutAnOffer(t *testing.T) {
+	db := testdb.NewDB(t, winBackTables...)
+	now := time.Now().UTC()
+
+	addr := "merchant@example.com"
+	sub := seedExpired(t, db, now, &addr)
+	onStarterUSD(t, db, sub.ID)
+
+	msg := winBackMessage(t, db, now)
+	require.Equal(t, string(email.TemplateWinBackNoOffer), msg.CustomArgs["kind"])
+	requireNoDiscountClaim(t, msg)
+}
+
+// The mutation the honesty property is worth testing under: the code EXISTS,
+// so a happy-path-only test would be green, but it is no longer redeemable.
+// The email must fall back to stating nothing rather than naming a code that
+// would be refused.
+func TestWinBack_ExpiredCodeSendsWithoutAnOffer(t *testing.T) {
+	db := testdb.NewDB(t, winBackTables...)
+	now := time.Now().UTC()
+
+	past := time.Now().UTC().Add(-time.Hour)
+	seedWinBackCode(t, db, func(pc *promo.PromoCode) { pc.ValidUntil = &past })
+
+	addr := "merchant@example.com"
+	sub := seedExpired(t, db, now, &addr)
+	onStarterUSD(t, db, sub.ID)
+
+	msg := winBackMessage(t, db, now)
+	require.Equal(t, string(email.TemplateWinBackNoOffer), msg.CustomArgs["kind"])
+	requireNoDiscountClaim(t, msg)
+}
+
+// The same mutation from the other direction: the code is live, but this
+// merchant's address has already used its one permitted redemption.
+func TestWinBack_AlreadyRedeemedSendsWithoutAnOffer(t *testing.T) {
+	db := testdb.NewDB(t, winBackTables...)
+	now := time.Now().UTC()
+
+	seedWinBackCode(t, db, nil)
+	addr := "merchant@example.com"
+	sub := seedExpired(t, db, now, &addr)
+	onStarterUSD(t, db, sub.ID)
+
+	repo := promo.NewRepository()
+	pc, err := repo.GetByCode(context.Background(), db, lifecycle.WinBackPromoCode)
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateRedemption(context.Background(), db, &promo.Redemption{
+		PromoCodeID:    pc.ID,
+		StoreID:        uuid.New(),
+		SubscriptionID: uuid.New(),
+		Email:          addr,
+		RedeemedAt:     time.Now().UTC(),
+	}))
+
+	msg := winBackMessage(t, db, now)
+	require.Equal(t, string(email.TemplateWinBackNoOffer), msg.CustomArgs["kind"])
+	requireNoDiscountClaim(t, msg)
+}
+
+// And the offer itself: a redeemable code produces an email that names it and
+// quotes the row's own terms.
+func TestWinBack_RedeemableCodeIsNamedInTheEmail(t *testing.T) {
+	db := testdb.NewDB(t, winBackTables...)
+	now := time.Now().UTC()
+
+	seedWinBackCode(t, db, nil)
+	addr := "merchant@example.com"
+	sub := seedExpired(t, db, now, &addr)
+	onStarterUSD(t, db, sub.ID)
+
+	msg := winBackMessage(t, db, now)
+	require.Equal(t, string(email.TemplateWinBack), msg.CustomArgs["kind"])
+	require.Contains(t, msg.TextBody, lifecycle.WinBackPromoCode)
+	require.Contains(t, msg.TextBody, "20% off your first 6 months")
+	require.Contains(t, msg.Subject, "20% off for 6 months")
+}
+
+// Asking whether a code is offerable must not consume it. max_per_email is 1,
+// so a redemption recorded at email time would leave the merchant holding a
+// code the apply-promo endpoint refuses.
+func TestWinBack_OfferCheckRecordsNoRedemption(t *testing.T) {
+	db := testdb.NewDB(t, winBackTables...)
+	now := time.Now().UTC()
+
+	seedWinBackCode(t, db, nil)
+	addr := "merchant@example.com"
+	sub := seedExpired(t, db, now, &addr)
+	onStarterUSD(t, db, sub.ID)
+
+	winBackMessage(t, db, now)
+
+	var n int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM promo_redemptions`).Scan(&n).Error)
+	require.EqualValues(t, 0, n, "the win-back redeemed the code on the merchant's behalf")
 }

--- a/services/marketplace-api/internal/subscription/lifecycle/winback_offer.go
+++ b/services/marketplace-api/internal/subscription/lifecycle/winback_offer.go
@@ -1,0 +1,151 @@
+package lifecycle
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/promo"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// WinBackPromoCode is the promo code the day-30 win-back email offers.
+//
+// A promo_codes row whose code is exactly this string is what switches the
+// win-back offer on. mark8ly does not mint codes — rows arrive from the
+// tesserix-home promo catalog through internal/billing/consolepromo (#726) —
+// so authoring it is a console action. Until it exists, and on every run
+// where it does not currently validate, the cron sends
+// email.TemplateWinBackNoOffer instead and states nothing (#727).
+//
+// It is deliberately NOT cancel.SaveOfferPromoCode. The two are separate
+// campaigns with separate caps and separate redemption histories, and
+// max_per_email is 1: sharing one code would mean a merchant who took the
+// save offer could never take the win-back, and neither campaign's redemption
+// count would mean anything on its own.
+const WinBackPromoCode = "WINBACK20OFF6MONTHS"
+
+// WinBackPromoChecker is the narrow slice of promo.Service the win-back needs.
+//
+// ValidateCode and not ApplyPromo, because the merchant has not asked for
+// anything yet. Redeeming on their behalf at email time would attach a coupon
+// to a subscription they have already lost and — max_per_email being 1 —
+// consume the only redemption their address gets, so the code in the email
+// would be rejected the moment they tried to use it.
+type WinBackPromoChecker interface {
+	ValidateCode(ctx context.Context, in promo.ApplyInput) (promo.ApplyOutput, error)
+}
+
+// winBackOffer is a discount the email is entitled to state. The zero value
+// is "no offer", and every field is populated from the promo row rather than
+// from prose.
+type winBackOffer struct {
+	Code string
+	// PercentOff is the discount as a display string without the sign:
+	// "20", or "12.5" for a rate that is not a whole percentage.
+	PercentOff     string
+	DurationMonths int
+}
+
+// WithPromo returns the cron with p attached. A cron without one never states
+// an offer; passing nil leaves it unchanged. Mirrors cancel.Service.WithPromo.
+func (c *WinBackCron) WithPromo(p WinBackPromoChecker) *WinBackCron {
+	if c == nil || p == nil {
+		return c
+	}
+	c.promo = p
+	return c
+}
+
+// WinBackTemplate maps "is there an offer to state" onto the template key.
+//
+// This decision lives in Go on purpose. Both keys are overridable from the
+// operator console, so expressing it as a {{if}} inside a single template
+// would put the guard on the discount claim into an editable text box —
+// deleting the guard would restore #727's unconditional promise with no code
+// change, no review and no test able to see it.
+func WinBackTemplate(offered bool) email.TemplateID {
+	if offered {
+		return email.TemplateWinBack
+	}
+	return email.TemplateWinBackNoOffer
+}
+
+// offerFor reports the discount this row's email may state, if any.
+//
+// Like cancel.applySaveOfferDiscount it returns no error: the win-back is
+// worth sending either way — a merchant a month past expiry does not know
+// their products, orders and settings survived — so a promo problem must
+// degrade the copy, never suppress the mail. Every failure path logs and
+// returns "no offer", and the copy then follows honestly.
+func (c *WinBackCron) offerFor(ctx context.Context, row *subscription.StoreSubscription, to string) (winBackOffer, bool) {
+	if c.promo == nil {
+		c.logger.Info("lifecycle: win-back has no promo service — sending without an offer",
+			"store_id", row.StoreID)
+		return winBackOffer{}, false
+	}
+	if to == "" {
+		// Per-email redemption caps cannot be evaluated without an address,
+		// and this send is about to be refused as undeliverable anyway.
+		return winBackOffer{}, false
+	}
+
+	out, err := c.promo.ValidateCode(ctx, promo.ApplyInput{
+		TenantID:       row.TenantID,
+		StoreID:        row.StoreID,
+		SubscriptionID: row.ID,
+		Code:           WinBackPromoCode,
+		MerchantEmail:  to,
+		Plan:           row.Plan,
+		Period:         row.SubscriptionPeriod,
+		BasePriceMinor: promo.BasePriceMinorFor(
+			row.Plan, row.SubscriptionPeriod, row.PriceTier, derefString(row.BillingCurrency)),
+		Currency: derefString(row.BillingCurrency),
+		Actor:    "system:winback",
+	})
+	if err != nil {
+		c.logger.Info("lifecycle: win-back offer not available — sending without one",
+			"store_id", row.StoreID, "code", WinBackPromoCode,
+			"reason", string(out.RejectReason), "err", err.Error())
+		return winBackOffer{}, false
+	}
+
+	pct, ok := formatPercentBps(out.PercentOffBps)
+	if !ok || out.MaxDurationMonths <= 0 {
+		// The copy says "N% off your first M months". A code that carries a
+		// flat amount, or no bound on how long the discount runs, cannot be
+		// described by that sentence — and inventing a sentence for it is
+		// how the hardcoded promise got there in the first place.
+		c.logger.Warn("lifecycle: win-back code is valid but not describable as a bounded percentage — sending without an offer",
+			"store_id", row.StoreID, "code", WinBackPromoCode,
+			"percent_off_bps", out.PercentOffBps, "max_duration_months", out.MaxDurationMonths)
+		return winBackOffer{}, false
+	}
+
+	return winBackOffer{
+		Code:           WinBackPromoCode,
+		PercentOff:     pct,
+		DurationMonths: out.MaxDurationMonths,
+	}, true
+}
+
+// formatPercentBps renders basis points as a display percentage: 2000 → "20",
+// 1250 → "12.5". It reports false for anything outside (0, 100), which the
+// caller treats as "not describable" rather than rounding it into a number
+// the merchant would be quoted.
+func formatPercentBps(bps int) (string, bool) {
+	if bps <= 0 || bps >= 10000 {
+		return "", false
+	}
+	s := strconv.FormatFloat(float64(bps)/100, 'f', 2, 64)
+	s = strings.TrimRight(s, "0")
+	return strings.TrimRight(s, "."), true
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/services/marketplace-api/internal/subscription/lifecycle/winback_offer_test.go
+++ b/services/marketplace-api/internal/subscription/lifecycle/winback_offer_test.go
@@ -1,0 +1,203 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/email"
+	"github.com/mark8ly/marketplace-api/internal/promo"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+type stubChecker struct {
+	out   promo.ApplyOutput
+	err   error
+	calls []promo.ApplyInput
+}
+
+func (s *stubChecker) ValidateCode(_ context.Context, in promo.ApplyInput) (promo.ApplyOutput, error) {
+	s.calls = append(s.calls, in)
+	return s.out, s.err
+}
+
+func offerCron(p WinBackPromoChecker) *WinBackCron {
+	c := NewWinBackCron(nil, nil, slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	return c.WithPromo(p)
+}
+
+func expiredRow() *subscription.StoreSubscription {
+	cur := "usd"
+	return &subscription.StoreSubscription{
+		ID:                 uuid.New(),
+		TenantID:           uuid.New(),
+		StoreID:            uuid.New(),
+		Plan:               subscription.PlanStarter,
+		SubscriptionPeriod: subscription.PeriodMonthly,
+		PriceTier:          subscription.PriceTierDeveloped,
+		BillingCurrency:    &cur,
+		Status:             subscription.StatusExpired,
+	}
+}
+
+func goodOutput() promo.ApplyOutput {
+	return promo.ApplyOutput{PercentOffBps: 2000, MaxDurationMonths: 6, EffectiveMinor: 1520}
+}
+
+// ---------------------------------------------------------------------------
+// The code exists, is named by a constant, and is provisionable.
+// ---------------------------------------------------------------------------
+
+func TestWinBackPromoCode_IsProvisionable(t *testing.T) {
+	if len(WinBackPromoCode) < 4 {
+		t.Fatalf("promo_codes CHECK (char_length(code) >= 4) — %q cannot be provisioned", WinBackPromoCode)
+	}
+	if WinBackPromoCode == "" {
+		t.Fatal("empty code")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// offerFor
+// ---------------------------------------------------------------------------
+
+func TestOfferFor_ValidCodeIsOffered(t *testing.T) {
+	stub := &stubChecker{out: goodOutput()}
+	offer, ok := offerCron(stub).offerFor(context.Background(), expiredRow(), "merchant@example.com")
+
+	if !ok {
+		t.Fatal("a valid code was not offered")
+	}
+	if offer.Code != WinBackPromoCode {
+		t.Errorf("Code = %q", offer.Code)
+	}
+	if offer.PercentOff != "20" || offer.DurationMonths != 6 {
+		t.Errorf("terms = %s%% for %d months, want 20%% for 6", offer.PercentOff, offer.DurationMonths)
+	}
+}
+
+// The offer check must ask the same question the merchant's redemption will
+// ask. A zero base price would make the §7.4 floor comparison meaningless and
+// let the email promise a discount the apply-promo endpoint then refuses.
+func TestOfferFor_AsksWithTheRealBasePrice(t *testing.T) {
+	stub := &stubChecker{out: goodOutput()}
+	row := expiredRow()
+	offerCron(stub).offerFor(context.Background(), row, "merchant@example.com")
+
+	if len(stub.calls) != 1 {
+		t.Fatalf("%d validate calls, want 1", len(stub.calls))
+	}
+	got := stub.calls[0]
+	want := promo.BasePriceMinorFor(row.Plan, row.SubscriptionPeriod, row.PriceTier, "usd")
+	if want == 0 {
+		t.Fatal("the pricing catalog must know starter monthly USD")
+	}
+	if got.BasePriceMinor != want {
+		t.Errorf("BasePriceMinor = %d, want %d", got.BasePriceMinor, want)
+	}
+	if got.Code != WinBackPromoCode {
+		t.Errorf("Code = %q", got.Code)
+	}
+	if got.MerchantEmail != "merchant@example.com" {
+		t.Errorf("MerchantEmail = %q — per-email caps cannot be evaluated without it", got.MerchantEmail)
+	}
+}
+
+func TestOfferFor_NoOfferWhenCodeIsRejected(t *testing.T) {
+	stub := &stubChecker{
+		out: promo.ApplyOutput{RejectReason: promo.RejectReasonNotFound},
+		err: promo.ErrInvalidOrExpired,
+	}
+	if _, ok := offerCron(stub).offerFor(context.Background(), expiredRow(), "merchant@example.com"); ok {
+		t.Fatal("a rejected code was offered")
+	}
+}
+
+func TestOfferFor_NoOfferWhenTheLookupFails(t *testing.T) {
+	stub := &stubChecker{err: errors.New("promo: validate code: lookup: connection refused")}
+	if _, ok := offerCron(stub).offerFor(context.Background(), expiredRow(), "merchant@example.com"); ok {
+		t.Fatal("an infrastructure failure was reported as an offer")
+	}
+}
+
+func TestOfferFor_NoOfferWithoutAPromoService(t *testing.T) {
+	c := NewWinBackCron(nil, nil, slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	if _, ok := c.offerFor(context.Background(), expiredRow(), "merchant@example.com"); ok {
+		t.Fatal("offered a discount with no promo service attached")
+	}
+}
+
+// A code that validates but cannot be described by the sentence the template
+// carries must not be described by it anyway.
+func TestOfferFor_NoOfferForIndescribableTerms(t *testing.T) {
+	cases := []struct {
+		name string
+		out  promo.ApplyOutput
+	}{
+		{"flat amount, no percentage", promo.ApplyOutput{PercentOffBps: 0, MaxDurationMonths: 6}},
+		{"no duration bound", promo.ApplyOutput{PercentOffBps: 2000, MaxDurationMonths: 0}},
+		{"negative basis points", promo.ApplyOutput{PercentOffBps: -100, MaxDurationMonths: 6}},
+		{"100% or more off", promo.ApplyOutput{PercentOffBps: 10000, MaxDurationMonths: 6}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &stubChecker{out: tc.out}
+			if _, ok := offerCron(stub).offerFor(context.Background(), expiredRow(), "m@example.com"); ok {
+				t.Fatal("offered")
+			}
+		})
+	}
+}
+
+// The email states the row's number, so a console edit to the discount must
+// reach the merchant rather than being contradicted by prose.
+func TestOfferFor_QuotesTheRowsOwnTerms(t *testing.T) {
+	stub := &stubChecker{out: promo.ApplyOutput{PercentOffBps: 1250, MaxDurationMonths: 3}}
+	offer, ok := offerCron(stub).offerFor(context.Background(), expiredRow(), "m@example.com")
+	if !ok {
+		t.Fatal("not offered")
+	}
+	if offer.PercentOff != "12.5" || offer.DurationMonths != 3 {
+		t.Fatalf("terms = %s%% for %d months, want 12.5%% for 3", offer.PercentOff, offer.DurationMonths)
+	}
+}
+
+func TestFormatPercentBps(t *testing.T) {
+	cases := []struct {
+		bps  int
+		want string
+		ok   bool
+	}{
+		{2000, "20", true},
+		{1250, "12.5", true},
+		{1, "0.01", true},
+		{9999, "99.99", true},
+		{0, "", false},
+		{-1, "", false},
+		{10000, "", false},
+		{20000, "", false},
+	}
+	for _, tc := range cases {
+		got, ok := formatPercentBps(tc.bps)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("formatPercentBps(%d) = %q,%v; want %q,%v", tc.bps, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Template selection
+// ---------------------------------------------------------------------------
+
+func TestWinBackTemplate_FollowsTheOffer(t *testing.T) {
+	if got := WinBackTemplate(true); got != email.TemplateWinBack {
+		t.Errorf("offered → %q", got)
+	}
+	if got := WinBackTemplate(false); got != email.TemplateWinBackNoOffer {
+		t.Errorf("not offered → %q", got)
+	}
+}


### PR DESCRIPTION
Closes #727. The day-30 win-back promised "20% off your first six months" in prose, with no code behind it and nothing that could honour it.

It now offers a real promo code — and says so **only when that code validates**.

## A precondition this uncovered: the floor check compared against zero

Not scope creep. Validating the win-back against the same input would have named a code the redeem path is guaranteed to refuse — the exact defect this issue is about.

`cancel/save_offer.go:98` and `admin/promo.go` both passed `BasePriceMinor: 0`, with a comment claiming *"floor validation keys off plan + currency"*. It does not: `promo/validator.go:132` starts from that value and `CheckFloor` compares the result against `PlanAbsoluteFloorMinor`. Zero base → zero effective price → below every floor.

Measured before any change:

```
plan=starter cur=usd base=0    -> accepted=false  below_absolute_floor
plan=studio  cur=usd base=0    -> accepted=false  below_absolute_floor
plan=trial   cur=usd base=0    -> accepted=true            (no floor entry)
plan=starter cur=usd base=1900 -> accepted=true   effective=1520
```

So the save offer could never apply to a paying merchant, and `POST /admin/stores/:storeId/subscription/apply-promo` has never succeeded for a priced plan. `SAVEOFFER20OFF6MONTHS` existing in production did not change that. Commit `d7b8f19c` adds `promo.BasePriceMinorFor(plan, period, tier, currency)` reading `internal/billing/pricing`, and wires both call sites. `TestPromoApply_AbovePriceFloor_USD` could not have been written before it.

## Validate without recording

The win-back cannot *attach*: the recipient's subscription is expired, so there is nothing to attach a coupon to. Worse, `max_per_email` is forced to 1 for every ingested code, so recording a redemption at email time would consume the merchant's only redemption and the code in their email would be refused the moment they used it.

`promo.Service.ValidateCode` (commit `94e8bd15`) runs the full §7.3 rule set and records nothing; `ValidateForSaveOffer` now delegates to it. `ApplyOutput` gains `PercentOffBps` and `MaxDurationMonths` so the email can quote the row's own terms rather than repeat a number from prose.

`offerFor` returns no error, mirroring `applySaveOfferDiscount`: every failure logs and yields "no offer", and the copy follows. `promo_code`, `percent_off` and `duration_months` enter the template data only when an offer exists.

## Judgement calls

**Shared code, capped.** Per-recipient is unavailable by construction — mark8ly does not mint (#726 settled the console as the source of truth). Given a shared code, `max_per_email` is not the bound (it is forced to 1 and a new address defeats it); `max_redemptions` and `valid_until` are, and both flow through `consolepromo/mapper.go`. Nothing in the promo engine checks the redeemer is a lapsed store, so a leaked code is redeemable by any new signup — the cap is the only thing between a forum post and unbounded 20%-off. One good property falls out: when the cap is exhausted, `ValidateCode` returns `max_redemptions_reached` and the email stops promising the discount by itself, with no operator action (`TestValidateCode_ExhaustedGlobalCapIsRejected`).

**Send anyway, without a number.** The offer-less content is true and useful on its own — a merchant a month past expiry does not know their products, orders and settings survived, and "Nothing has been deleted" is the part they need. Suppressing the send would also be a silent failure: a mistyped or lapsed code would turn off the whole day-30 touchpoint with no signal.

**The conditional lives in Go, across two templates.** Both keys are editable from the console's `email_templates` surface. A `{{if .promo_code}}` inside one template would put the guard on the discount claim into a text box an operator can edit — deleting it restores this issue's unconditional promise with no code change and no test able to see it. Two keys make the offer-less copy a row that cannot grow a discount claim by accident. The claim key and both metric counters stay on `win_back_day30`: they identify the campaign, and splitting them would break the sent+skipped identity documented on `BillingEmailsSkippedTotal`.

## Mutation testing

Committed first, then mutated.

1. `WinBackTemplate` always returns the offer template → 4 failures, including all three no-offer integration tests.
2. `offerFor` ignores the validation error and forces good terms — the "reported as success when it failed" shape → **7 failures**.
3. Re-inserted "We will take 20% off your first six months" into the no-offer template → `TestWinBackNoOffer_MakesNoDiscountClaim` and `TestWinBack_NoCodeSendsWithoutAnOffer` fail.

The integration mutations drive the **real** `email.templateClient` through the real cron and assert on the message that reached the transport, not on a double.

## Two things NOT fixed, which gate switching this on

**Nothing redeems a promo code in the merchant UI.** `subscription/apply-promo` has zero callers in `apps/` — only the handler and its own test. So the email can name a valid code and the merchant has nowhere to enter it. Commit `6eeb02b1` removes the copy's claim that it goes "in your billing settings" rather than assert a screen that does not exist. **Authoring the console row switches on an offer nobody can currently redeem without an operator calling the API for them** — a redemption field should be treated as a hard precondition. Worth its own issue.

**A residual honesty gap.** The check uses the *expired* row's plan and currency. A trial-plan expired store has no floor entry, validates, and gets the offer — but if that merchant returns on Starter monthly INR, redemption is refused: ₹999 less 20% is ₹799.20, eighty paise under the ₹800 floor (`TestValidate_CatalogBasePriceStillEnforcesTheFloor`). The plan they return to is unknowable at day 30, so no code fixes it; either the floor table wants revisiting against the PPP prices, or the offer wants restricting to plans it can clear.

## Test plan

- [x] `gofmt -l .`, `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`
- [x] `go test ./...` no failures, including `TestEveryIntegrationPackageIsInTheTestIntTarget`
- [x] Integration tests confirmed **named** in `-v`, not skipped
- [x] `-race` green on promo, email, subscription/*, billing/*, handlers/admin
- [x] Three mutations, each killing a specific named set
- [ ] Post-merge: author `WINBACK20OFF6MONTHS` in the console (parameters in the issue), confirm ingest, confirm the email names it
