### PR TITLE
fix(platformadmin): remove a tenant discount by POST, not a DELETE carrying a signed body (#660)

### DIFF
--- a/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount.go
@@ -52,8 +52,11 @@ func (f *TenantDiscounterFuncs) Remove(ctx context.Context, in tenantdiscount.In
 	return f.RemoveFunc(ctx, in)
 }
 
-// BillingTenantDiscountHandler serves POST and DELETE
-// /admin/billing/tenants/:tenantID/discount (#660).
+// BillingTenantDiscountHandler serves the two tenant-discount writes (#660):
+// POST /admin/billing/tenants/:tenantID/discount to apply one and POST
+// /admin/billing/tenants/:tenantID/discount/remove to revoke it. Both are
+// POSTs carrying a JSON body — see Register for why the revoke is not a
+// DELETE.
 //
 // The path parameter is a BARE tenant uuid, like every other handler in this
 // package (tenant_lifecycle.go). The console addresses tenants with a
@@ -77,16 +80,38 @@ func NewBillingTenantDiscountHandler(db *gorm.DB, svc TenantDiscounter, logger *
 }
 
 // Register mounts both routes on the supplied group.
+//
+// The revoke is POST .../discount/remove and NOT DELETE .../discount. Do not
+// "restore REST correctness" by turning it back into a DELETE — the verb was
+// chosen against three specific facts, not by taste:
+//
+//  1. Both routes need a request body: the coupon id (a subscription may
+//     carry several discounts and a merchant's own promo must survive) and a
+//     mandatory reason. A DELETE body has no defined semantics in HTTP and
+//     intermediaries are permitted to drop it.
+//  2. The caller is tesserix-home's platform-api, whose federated requests
+//     are HMAC-signed over a sha256 OF THE BODY, and the path traverses an
+//     Istio waypoint. A hop that stripped the body would break the signature,
+//     and the failure would surface as a 401 — reading as an authentication
+//     problem rather than a stripped payload, and extremely hard to diagnose.
+//  3. platform-api's federation.Client has no DELETE helper at all, and Put's
+//     docstring there argues against a free-form method parameter precisely
+//     so a DELETE cannot be smuggled through a write helper.
+//
+// Changed while the endpoint was deployed but unreachable — nothing called it
+// yet, so it cost one PR. Once the console calls it, it costs three.
 func (h *BillingTenantDiscountHandler) Register(g *gin.RouterGroup) {
 	g.POST("/admin/billing/tenants/:tenantID/discount", h.apply)
-	g.DELETE("/admin/billing/tenants/:tenantID/discount", h.remove)
+	g.POST("/admin/billing/tenants/:tenantID/discount/remove", h.remove)
 }
 
-// tenantDiscountRequest is the body of BOTH routes. The DELETE carries one
+// tenantDiscountRequest is the body of BOTH routes. The revoke carries one
 // too: it needs the coupon id to know which discount to take off (the
 // subscription may carry several, and a merchant's own promo must survive),
-// and it needs a reason for the same rule that makes the POST need one —
-// tesserix-home#331's "removal is as audited as application".
+// and it needs a reason for the same rule that makes the apply need one —
+// tesserix-home#331's "removal is as audited as application". That both
+// routes must carry a body is also why the revoke is a POST rather than a
+// DELETE; see Register.
 type tenantDiscountRequest struct {
 	CouponID string `json:"coupon_id"`
 	Reason   string `json:"reason"`
@@ -154,8 +179,8 @@ func (h *BillingTenantDiscountHandler) handle(
 	idemKey := strings.TrimSpace(c.GetHeader("Idempotency-Key"))
 	if idemKey == "" {
 		// A write that cannot be retried safely is worse than one that
-		// refuses to start. The DELETE is held to the same rule as the
-		// POST: revoking a discount is as much a billing change as
+		// refuses to start. The revoke is held to the same rule as the
+		// apply: revoking a discount is as much a billing change as
 		// granting one.
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "idempotency_key_required", "message": "the Idempotency-Key header is required for this endpoint",

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount_integration_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount_integration_test.go
@@ -30,9 +30,14 @@ func discountRouter(db *gorm.DB, svc platformadmin.TenantDiscounter) *gin.Engine
 	return r
 }
 
-func sendDiscount(r *gin.Engine, method, tenantID, key, body string) *httptest.ResponseRecorder {
+// sendDiscount drives one operation. It takes an OPERATION, not a method:
+// apply and remove are two distinct routes (POST .../discount and POST
+// .../discount/remove), and discountRoute is the single place that pairs a
+// method with its path — see its doc comment.
+func sendDiscount(r *gin.Engine, op, tenantID, key, body string) *httptest.ResponseRecorder {
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(method, discountPath(tenantID), bytes.NewBufferString(body))
+	method, path := discountRoute(op, tenantID)
+	req := httptest.NewRequest(method, path, bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Idempotency-Key", key)
 	r.ServeHTTP(rec, req)
@@ -47,15 +52,15 @@ func TestTenantDiscountIsIdempotentPerKey(t *testing.T) {
 	svc := &stubDiscounter{applyResult: twoStoreApplyResult()}
 	r := discountRouter(db, svc)
 
-	first := sendDiscount(r, http.MethodPost, discountTenantID.String(), "key-alpha", discountBody)
+	first := sendDiscount(r, opApply, discountTenantID.String(), "key-alpha", discountBody)
 	require.Equal(t, http.StatusOK, first.Code, first.Body.String())
 
-	second := sendDiscount(r, http.MethodPost, discountTenantID.String(), "key-alpha", discountBody)
+	second := sendDiscount(r, opApply, discountTenantID.String(), "key-alpha", discountBody)
 	require.Equal(t, http.StatusOK, second.Code, second.Body.String())
 	require.JSONEq(t, first.Body.String(), second.Body.String(), "same key must replay the same body")
 	require.Equal(t, 1, svc.applyCalls, "same key must NOT apply the discount a second time")
 
-	third := sendDiscount(r, http.MethodPost, discountTenantID.String(), "key-beta", discountBody)
+	third := sendDiscount(r, opApply, discountTenantID.String(), "key-beta", discountBody)
 	require.Equal(t, http.StatusOK, third.Code, third.Body.String())
 	require.Equal(t, 2, svc.applyCalls, "a DIFFERENT key is a new request")
 }
@@ -85,9 +90,9 @@ func TestTenantDiscountKeyDoesNotReplayAcrossTenants(t *testing.T) {
 	}
 	r := discountRouter(db, svc)
 
-	first := sendDiscount(r, http.MethodPost, tenantA.String(), "shared-key", discountBody)
+	first := sendDiscount(r, opApply, tenantA.String(), "shared-key", discountBody)
 	require.Equal(t, http.StatusOK, first.Code, first.Body.String())
-	second := sendDiscount(r, http.MethodPost, tenantB.String(), "shared-key", discountBody)
+	second := sendDiscount(r, opApply, tenantB.String(), "shared-key", discountBody)
 	require.Equal(t, http.StatusOK, second.Code, second.Body.String())
 
 	require.Equal(t, []uuid.UUID{tenantA, tenantB},
@@ -106,6 +111,11 @@ func TestTenantDiscountKeyDoesNotReplayAcrossTenants(t *testing.T) {
 // idempotency namespace: an operator reusing a key to REVOKE a discount they
 // just applied would otherwise get the apply's stored report back and the
 // discount would silently stay on.
+//
+// The separate routes do NOT provide this on their own, so this assertion
+// still bites: the scoped key is "tenant_discount:<op>:<tenant>:<key>" and
+// the request PATH never enters it. Drop the operation from that scope and
+// the two calls below collide again, whatever paths they arrived on.
 func TestTenantDiscountApplyAndRemoveDoNotShareAnIdempotencyScope(t *testing.T) {
 	db := testdb.NewDB(t, "idempotency_keys")
 	removed := twoStoreApplyResult()
@@ -113,13 +123,13 @@ func TestTenantDiscountApplyAndRemoveDoNotShareAnIdempotencyScope(t *testing.T) 
 	svc := &stubDiscounter{applyResult: twoStoreApplyResult(), removeResult: removed}
 	r := discountRouter(db, svc)
 
-	applied := sendDiscount(r, http.MethodPost, discountTenantID.String(), "same-key", discountBody)
+	applied := sendDiscount(r, opApply, discountTenantID.String(), "same-key", discountBody)
 	require.Equal(t, http.StatusOK, applied.Code, applied.Body.String())
 
-	revoked := sendDiscount(r, http.MethodDelete, discountTenantID.String(), "same-key", discountBody)
+	revoked := sendDiscount(r, opRemove, discountTenantID.String(), "same-key", discountBody)
 	require.Equal(t, http.StatusOK, revoked.Code, revoked.Body.String())
 
-	require.Equal(t, 1, svc.removeCalls, "the DELETE must run, not replay the POST's stored report")
+	require.Equal(t, 1, svc.removeCalls, "the remove call must run, not replay the apply's stored report")
 	body := map[string]any{}
 	require.NoError(t, json.Unmarshal(revoked.Body.Bytes(), &body))
 	require.Equal(t, "remove", body["operation"])
@@ -132,13 +142,13 @@ func TestTenantDiscountCorrectedRetryAfterDomainFailureProceeds(t *testing.T) {
 	svc := &stubDiscounter{applyErr: tenantdiscount.ErrNoStores}
 	r := discountRouter(db, svc)
 
-	refused := sendDiscount(r, http.MethodPost, discountTenantID.String(), "key-retry", discountBody)
+	refused := sendDiscount(r, opApply, discountTenantID.String(), "key-retry", discountBody)
 	require.Equal(t, http.StatusNotFound, refused.Code, refused.Body.String())
 
 	// The operator fixes whatever was wrong and retries the same request.
 	svc.applyErr = nil
 	svc.applyResult = twoStoreApplyResult()
-	retried := sendDiscount(r, http.MethodPost, discountTenantID.String(), "key-retry", discountBody)
+	retried := sendDiscount(r, opApply, discountTenantID.String(), "key-retry", discountBody)
 	require.Equal(t, http.StatusOK, retried.Code, retried.Body.String())
 	require.Equal(t, 2, svc.applyCalls, "the corrected retry must reach the domain")
 }
@@ -156,10 +166,10 @@ func TestTenantDiscountPartialResultCompletesTheKey(t *testing.T) {
 	svc := &stubDiscounter{applyResult: res}
 	r := discountRouter(db, svc)
 
-	first := sendDiscount(r, http.MethodPost, discountTenantID.String(), "key-partial", discountBody)
+	first := sendDiscount(r, opApply, discountTenantID.String(), "key-partial", discountBody)
 	require.Equal(t, http.StatusOK, first.Code, first.Body.String())
 
-	second := sendDiscount(r, http.MethodPost, discountTenantID.String(), "key-partial", discountBody)
+	second := sendDiscount(r, opApply, discountTenantID.String(), "key-partial", discountBody)
 	require.Equal(t, http.StatusOK, second.Code, second.Body.String())
 	require.JSONEq(t, first.Body.String(), second.Body.String())
 	require.Equal(t, 1, svc.applyCalls, "a partial result is a completed request, not a retryable one")

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_tenant_discount_test.go
@@ -84,21 +84,50 @@ func twoStoreApplyResult() tenantdiscount.Result {
 
 const discountBody = `{"coupon_id":"cpn_test","reason":"negotiated renewal discount"}`
 
-func discountPath(tenantID string) string {
-	return "/admin/billing/tenants/" + tenantID + "/discount"
+// The two operations this handler serves. Named constants rather than bare
+// strings because they now select a ROUTE as well as labelling a report:
+// see discountRoute.
+const (
+	opApply  = "apply"
+	opRemove = "remove"
+)
+
+// bothDiscountOps is the pair every "both routes" table below iterates.
+var bothDiscountOps = []string{opApply, opRemove}
+
+// discountRoute returns the method AND path for one operation, so no test
+// can vary one without the other.
+//
+// The two routes are not one path distinguished by verb: apply is POST
+// .../discount and remove is POST .../discount/remove. Remove was a DELETE
+// carrying a body until it was found to be unreachable-and-fragile — see
+// Register in billing_tenant_discount.go for the body-hash HMAC and Istio
+// waypoint reasoning. A table that varied only the method would address a
+// route that does not exist and would get gin's 404, not the handler.
+func discountRoute(op, tenantID string) (method, path string) {
+	base := "/admin/billing/tenants/" + tenantID + "/discount"
+	switch op {
+	case opApply:
+		return http.MethodPost, base
+	case opRemove:
+		return http.MethodPost, base + "/remove"
+	default:
+		panic("unknown tenant discount operation: " + op)
+	}
 }
 
 // doDiscount drives the handler with a nil DB, which is how the trial
 // extend unit tests skip the idempotency store: the missing-header check
 // still fires, but nothing touches Postgres. Integration coverage of the
 // idempotency dance lives in billing_tenant_discount_integration_test.go.
-func doDiscount(t *testing.T, svc platformadmin.TenantDiscounter, method, tenantID, body string, withKey bool) *httptest.ResponseRecorder {
+func doDiscount(t *testing.T, svc platformadmin.TenantDiscounter, op, tenantID, body string, withKey bool) *httptest.ResponseRecorder {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	platformadmin.NewBillingTenantDiscountHandler(nil, svc, nil).Register(r.Group(""))
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(method, discountPath(tenantID), bytes.NewBufferString(body))
+	method, path := discountRoute(op, tenantID)
+	req := httptest.NewRequest(method, path, bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
 	if withKey {
 		req.Header.Set("Idempotency-Key", "test-key-"+tenantID)
@@ -115,13 +144,13 @@ func decodeDiscount(t *testing.T, rec *httptest.ResponseRecorder) map[string]any
 }
 
 // Both routes refuse without an Idempotency-Key: a write that cannot be
-// retried safely is worse than one that refuses to start, and the DELETE
-// is as much a billing change as the POST.
+// retried safely is worse than one that refuses to start, and revoking a
+// discount is as much a billing change as granting one.
 func TestTenantDiscountRequiresIdempotencyKey(t *testing.T) {
-	for _, method := range []string{http.MethodPost, http.MethodDelete} {
-		t.Run(method, func(t *testing.T) {
+	for _, op := range bothDiscountOps {
+		t.Run(op, func(t *testing.T) {
 			svc := &stubDiscounter{applyResult: twoStoreApplyResult(), removeResult: twoStoreApplyResult()}
-			rec := doDiscount(t, svc, method, discountTenantID.String(), discountBody, false)
+			rec := doDiscount(t, svc, op, discountTenantID.String(), discountBody, false)
 			require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
 			require.Equal(t, "idempotency_key_required", decodeDiscount(t, rec)["error"])
 			require.Zero(t, svc.applyCalls+svc.removeCalls, "the domain must not be called at all")
@@ -137,8 +166,8 @@ func TestTenantDiscountRejectsBlankIdempotencyKey(t *testing.T) {
 	r := gin.New()
 	platformadmin.NewBillingTenantDiscountHandler(nil, svc, nil).Register(r.Group(""))
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, discountPath(discountTenantID.String()),
-		bytes.NewBufferString(discountBody))
+	method, path := discountRoute(opApply, discountTenantID.String())
+	req := httptest.NewRequest(method, path, bytes.NewBufferString(discountBody))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Idempotency-Key", "   ")
 	r.ServeHTTP(rec, req)
@@ -152,10 +181,10 @@ func TestTenantDiscountRejectsBlankIdempotencyKey(t *testing.T) {
 // tenant_lifecycle.go already returns so the console handles every write on
 // this surface the same way.
 func TestTenantDiscountRejectsInvalidTenantID(t *testing.T) {
-	for _, method := range []string{http.MethodPost, http.MethodDelete} {
-		t.Run(method, func(t *testing.T) {
+	for _, op := range bothDiscountOps {
+		t.Run(op, func(t *testing.T) {
 			svc := &stubDiscounter{}
-			rec := doDiscount(t, svc, method, "not-a-uuid", discountBody, true)
+			rec := doDiscount(t, svc, op, "not-a-uuid", discountBody, true)
 			require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
 			body := decodeDiscount(t, rec)
 			require.Equal(t, "invalid_tenant_id", body["error"])
@@ -170,17 +199,17 @@ func TestTenantDiscountRejectsInvalidTenantID(t *testing.T) {
 // clean 400, never a tenant id that half-parses.
 func TestTenantDiscountRejectsNamespacedTenantID(t *testing.T) {
 	svc := &stubDiscounter{}
-	rec := doDiscount(t, svc, http.MethodPost, "mark8ly:"+discountTenantID.String(), discountBody, true)
+	rec := doDiscount(t, svc, opApply, "mark8ly:"+discountTenantID.String(), discountBody, true)
 	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
 	require.Equal(t, "invalid_tenant_id", decodeDiscount(t, rec)["error"])
 	require.Zero(t, svc.applyCalls)
 }
 
 func TestTenantDiscountRequiresCouponID(t *testing.T) {
-	for _, method := range []string{http.MethodPost, http.MethodDelete} {
-		t.Run(method, func(t *testing.T) {
+	for _, op := range bothDiscountOps {
+		t.Run(op, func(t *testing.T) {
 			svc := &stubDiscounter{}
-			rec := doDiscount(t, svc, method, discountTenantID.String(),
+			rec := doDiscount(t, svc, op, discountTenantID.String(),
 				`{"coupon_id":"  ","reason":"why"}`, true)
 			require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
 			body := decodeDiscount(t, rec)
@@ -195,10 +224,10 @@ func TestTenantDiscountRequiresCouponID(t *testing.T) {
 // removal is as audited as application, and an audit row saying what
 // happened without why is the gap this series exists to close.
 func TestTenantDiscountRequiresReason(t *testing.T) {
-	for _, method := range []string{http.MethodPost, http.MethodDelete} {
-		t.Run(method, func(t *testing.T) {
+	for _, op := range bothDiscountOps {
+		t.Run(op, func(t *testing.T) {
 			svc := &stubDiscounter{}
-			rec := doDiscount(t, svc, method, discountTenantID.String(),
+			rec := doDiscount(t, svc, op, discountTenantID.String(),
 				`{"coupon_id":"cpn_test","reason":"   "}`, true)
 			require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
 			body := decodeDiscount(t, rec)
@@ -213,7 +242,7 @@ func TestTenantDiscountRequiresReason(t *testing.T) {
 // the field checks above ever run.
 func TestTenantDiscountRejectsUnparseableBody(t *testing.T) {
 	svc := &stubDiscounter{}
-	rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), ``, true)
+	rec := doDiscount(t, svc, opApply, discountTenantID.String(), ``, true)
 	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
 	require.Equal(t, "invalid_request", decodeDiscount(t, rec)["error"])
 	require.Zero(t, svc.applyCalls)
@@ -233,7 +262,7 @@ func TestTenantDiscountTruncatesReasonOnARuneBoundary(t *testing.T) {
 	require.NoError(t, err)
 
 	svc := &stubDiscounter{applyResult: twoStoreApplyResult()}
-	rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), string(body), true)
+	rec := doDiscount(t, svc, opApply, discountTenantID.String(), string(body), true)
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 
 	require.Equal(t, 1, svc.applyCalls)
@@ -247,7 +276,7 @@ func TestTenantDiscountTruncatesReasonOnARuneBoundary(t *testing.T) {
 // response carries one line per store rather than a single status.
 func TestTenantDiscountApplyReportsPerStore(t *testing.T) {
 	svc := &stubDiscounter{applyResult: twoStoreApplyResult()}
-	rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), discountBody, true)
+	rec := doDiscount(t, svc, opApply, discountTenantID.String(), discountBody, true)
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 
 	body := decodeDiscount(t, rec)
@@ -279,14 +308,15 @@ func TestTenantDiscountApplyReportsPerStore(t *testing.T) {
 	require.NotNil(t, svc.gotIn.C, "the gin context must be forwarded so the audit row names the operator")
 }
 
-// DELETE reaches Remove, not Apply, and reports the same per-store shape.
+// The remove route reaches Remove, not Apply, and reports the same
+// per-store shape.
 func TestTenantDiscountRemoveReportsPerStore(t *testing.T) {
 	res := twoStoreApplyResult()
 	res.Stores[0].Outcome = tenantdiscount.OutcomeRemoved
 	res.Stores[1].Outcome = tenantdiscount.OutcomeNotApplied
 	svc := &stubDiscounter{removeResult: res}
 
-	rec := doDiscount(t, svc, http.MethodDelete, discountTenantID.String(), discountBody, true)
+	rec := doDiscount(t, svc, opRemove, discountTenantID.String(), discountBody, true)
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 
 	body := decodeDiscount(t, rec)
@@ -296,7 +326,7 @@ func TestTenantDiscountRemoveReportsPerStore(t *testing.T) {
 	require.Equal(t, "not_applied", stores[1].(map[string]any)["outcome"])
 
 	require.Equal(t, 1, svc.removeCalls)
-	require.Zero(t, svc.applyCalls, "DELETE must never apply a discount")
+	require.Zero(t, svc.applyCalls, "the remove route must never apply a discount")
 }
 
 // Every outcome the domain declares survives the trip to JSON under its own
@@ -321,7 +351,7 @@ func TestTenantDiscountSurfacesEveryOutcomeVerbatim(t *testing.T) {
 	}
 
 	svc := &stubDiscounter{applyResult: res}
-	rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), discountBody, true)
+	rec := doDiscount(t, svc, opApply, discountTenantID.String(), discountBody, true)
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 
 	stores := decodeDiscount(t, rec)["stores"].([]any)
@@ -340,7 +370,7 @@ func TestTenantDiscountFailedStoreNeverEchoesDriverText(t *testing.T) {
 	res.Stores[1].Err = errors.New(`pq: relation "store_subscriptions" does not exist`)
 
 	svc := &stubDiscounter{applyResult: res}
-	rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), discountBody, true)
+	rec := doDiscount(t, svc, opApply, discountTenantID.String(), discountBody, true)
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 	require.NotContains(t, rec.Body.String(), "does not exist", "driver text must never be echoed")
 
@@ -378,7 +408,7 @@ func TestTenantDiscountPerStoreDivergenceGetsItsOwnCode(t *testing.T) {
 			}
 
 			svc := &stubDiscounter{applyResult: res}
-			rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), discountBody, true)
+			rec := doDiscount(t, svc, opApply, discountTenantID.String(), discountBody, true)
 			require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 			require.NotContains(t, rec.Body.String(), "deadlock detected")
 
@@ -402,7 +432,7 @@ func TestTenantDiscountPerStoreStripeFailureIsNotTheDivergence(t *testing.T) {
 	res.Stores[0].Err = tenantdiscount.ErrStripeCall
 
 	svc := &stubDiscounter{applyResult: res}
-	rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), discountBody, true)
+	rec := doDiscount(t, svc, opApply, discountTenantID.String(), discountBody, true)
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 
 	body := decodeDiscount(t, rec)
@@ -421,7 +451,7 @@ func TestTenantDiscountAllStoresFailedIsStatusFailed(t *testing.T) {
 		res.Stores[i].Err = tenantdiscount.ErrStripeCall
 	}
 	svc := &stubDiscounter{applyResult: res}
-	rec := doDiscount(t, svc, http.MethodPost, discountTenantID.String(), discountBody, true)
+	rec := doDiscount(t, svc, opApply, discountTenantID.String(), discountBody, true)
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 	require.Equal(t, "failed", decodeDiscount(t, rec)["status"])
 }
@@ -455,8 +485,8 @@ func TestTenantDiscountDomainSentinelsMapToDistinctCodes(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			svc := &stubDiscounter{applyErr: tc.err, removeErr: tc.err}
-			for _, method := range []string{http.MethodPost, http.MethodDelete} {
-				rec := doDiscount(t, svc, method, discountTenantID.String(), discountBody, true)
+			for _, op := range bothDiscountOps {
+				rec := doDiscount(t, svc, op, discountTenantID.String(), discountBody, true)
 				require.Equal(t, tc.status, rec.Code, rec.Body.String())
 				body := decodeDiscount(t, rec)
 				require.Equal(t, tc.code, body["error"])

--- a/services/marketplace-api/internal/handlers/platformadmin/middleware.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/middleware.go
@@ -118,9 +118,11 @@ var RequiredWriteCapabilities = map[string]string{
 	CapabilityKey(http.MethodPost, "/api/v1/platform/admin/email-templates/:key/test-send"): "",
 	// #660: apply and revoke a console-minted tenant discount. BOTH
 	// directions are declared — a revoke is as much a billing change as a
-	// grant, and DELETE is a write by isWrite's rule.
-	CapabilityKey(http.MethodPost, "/api/v1/platform/admin/billing/tenants/:tenantID/discount"):   "",
-	CapabilityKey(http.MethodDelete, "/api/v1/platform/admin/billing/tenants/:tenantID/discount"): "",
+	// grant. The revoke is a POST on its own path, not a DELETE on the
+	// apply's path; see the Register doc comment in
+	// billing_tenant_discount.go.
+	CapabilityKey(http.MethodPost, "/api/v1/platform/admin/billing/tenants/:tenantID/discount"):        "",
+	CapabilityKey(http.MethodPost, "/api/v1/platform/admin/billing/tenants/:tenantID/discount/remove"): "",
 }
 
 // RequiredReadCapabilities declares reads that require a specific

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -128,10 +128,11 @@ type Deps struct {
 	// used for the read routes in this struct.
 	TrialExtender TrialExtender
 
-	// TenantDiscount serves POST and DELETE
-	// /admin/billing/tenants/:tenantID/discount (#660) — applying and
-	// revoking a console-minted Stripe coupon across every store the tenant
-	// owns. Like TrialExtender it needs DB and Emitter as well, and mounting
+	// TenantDiscount serves POST /admin/billing/tenants/:tenantID/discount
+	// and POST /admin/billing/tenants/:tenantID/discount/remove (#660) —
+	// applying and revoking a console-minted Stripe coupon across every store
+	// the tenant owns. Both are POSTs; see the Register doc comment in
+	// billing_tenant_discount.go for why the revoke is not a DELETE. Like TrialExtender it needs DB and Emitter as well, and mounting
 	// is hard-gated on both; see the guard below for what each one is
 	// actually doing there, since this handler — unlike every other write on
 	// this surface — does not emit the audit row itself.

--- a/services/marketplace-api/internal/handlers/platformadmin/routes_capability_coverage_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes_capability_coverage_test.go
@@ -19,8 +19,9 @@ import (
 // (#405) POST /admin/outbox/:id/requeue, POST /admin/outbox/requeue, POST
 // /admin/outbox/:id/dead-letter, (tesserix-home#588) PUT
 // /admin/email-templates/:key plus POST
-// /admin/email-templates/:key/test-send, and (#660) POST plus DELETE
-// /admin/billing/tenants/:tenantID/discount.
+// /admin/email-templates/:key/test-send, and (#660) POST
+// /admin/billing/tenants/:tenantID/discount plus POST
+// /admin/billing/tenants/:tenantID/discount/remove.
 //
 // Register's switch statements (routes.go) mount each write route group
 // only when THAT group's own dependency set is fully non-nil —


### PR DESCRIPTION
Follow-up to #766, before anything calls these endpoints.

| | old | new |
|---|---|---|
| apply | `POST /admin/billing/tenants/:tenantID/discount` | unchanged |
| remove | `DELETE /admin/billing/tenants/:tenantID/discount` | `POST /admin/billing/tenants/:tenantID/discount/remove` |

## Why

The remove endpoint **requires a JSON body** — it carries the coupon id and a mandatory `reason`, bound by the same `ShouldBindJSON` the apply route uses. A DELETE with a body is the problem:

- A DELETE body has **no defined semantics in HTTP**, and intermediaries are permitted to drop it.
- The caller is tesserix-home's platform-api, whose federated requests are **HMAC-signed over a sha256 of the body**, and the path traverses an Istio waypoint.
- So if any hop strips the body, the signature no longer matches and the request fails as a **401** — which reads as an authentication problem, not a stripped payload. That is a genuinely nasty thing to debug in production.

Independently, platform-api's `federation.Client` has **no DELETE helper at all** (`Get`, `Post`, `Put` only), and `Put`'s docstring there argues explicitly against a free-form method parameter so that a DELETE cannot be smuggled through a helper whose docstring is about writes.

**The timing is the point.** These endpoints are deployed but **unreachable** — platform-api has no billing write path yet and nothing in the console calls them. Changing the verb now costs one PR. After the transport and the console call land, it costs three across two repos.

The reasoning is recorded at the route registration, including an explicit note not to "restore REST correctness" by changing it back.

## What changed

- `billing_tenant_discount.go` — the registration, plus three doc comments that named DELETE (the handler type, `tenantDiscountRequest`'s "the DELETE carries one too", and the idempotency-key refusal).
- `middleware.go` — `RequiredWriteCapabilities`: the DELETE entry replaced by the new POST path. **Map size and write-route count both stay 11**, so `routes_capability_coverage_test.go`'s pinned count is untouched and still passes.
- `routes.go` — the `TenantDiscount` field doc.
- Tests — `discountPath` became `discountRoute(op, tenantID) (method, path)`, so a table cannot vary the verb independently of the path (a verb-only table would now hit gin's 404). Five method-tables converted. No assertion weakened or removed.

One comment worth calling out, added to the integration test: the two routes now have **different paths**, but that is *not* what isolates their idempotency keys — the scoped key is `tenant_discount:<op>:<tenant>:<key>` and the path never enters it. Without that note, a future reader could reasonably delete the `<op>` segment as redundant now that the paths differ, and silently let a reused key replay an apply's report in response to a remove.

## Test plan

- [x] RED first — with tests updated and the route unchanged, the remove subtests failed `404 page not found`
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test -count=1 ./...` — **105 packages ok, 0 fail**
- [x] `go test -count=1 -tags=integration -p 1` over `handlers/platformadmin`, `tenantpurge`, `billing/tenantdiscount` — all ok
- [x] Integration tests confirmed **not silently skipping**: the same run without `TEST_DATABASE_URL` reports `--- SKIP`, with it reports `--- PASS`
- [x] Mutation check: dropping `<op>` from `scopedKey` still fails `TestTenantDiscountApplyAndRemoveDoNotShareAnIdempotencyScope`
- [x] No `MethodDelete` or `g.DELETE` remains anywhere in the discount handler

## Not changed

`.planning/quick/260906-td-tenant-discount/PLAN.md` still describes the DELETE. It is a dated, already-executed plan artifact — a record of what #660 set out to build, not a live contract — and rewriting it would falsify the history. There is no OpenAPI spec for this surface, `admin-conformance.json` has no discount entry, and no caller exists in any repo.
