### PR TITLE
feat(billing): merchants can redeem a promo code, and a refusal says which rule it hit

### DIFF
--- a/apps/admin/app/(admin)/settings/billing/BillingClient.tsx
+++ b/apps/admin/app/(admin)/settings/billing/BillingClient.tsx
@@ -12,6 +12,7 @@ import { subscriptionCopy } from '@/lib/copy/subscription'
 import { PlanCard } from './PlanCard'
 import { InvoicesList } from './InvoicesList'
 import { PaymentMethodCard } from './PaymentMethodCard'
+import { PromoCodeCard } from './PromoCodeCard'
 import { WhiteLabelAppCard } from './WhiteLabelAppCard'
 
 interface BillingClientProps {
@@ -214,6 +215,10 @@ export function BillingClient({ storeId }: BillingClientProps) {
     <div className="space-y-10">
       <PlanCard plan={plan} storeId={storeId} />
       <PaymentMethodCard plan={plan} storeId={storeId} />
+      {/* Above the invoice history: a merchant arriving from the day-30
+          win-back email (#727) came here to redeem a code, and the panel
+          they came for should not be below a table. */}
+      <PromoCodeCard plan={plan} storeId={storeId} />
       <InvoicesList storeId={storeId} />
       <WhiteLabelAppCard plan={plan} storeId={storeId} />
     </div>

--- a/apps/admin/app/(admin)/settings/billing/InvoicesList.tsx
+++ b/apps/admin/app/(admin)/settings/billing/InvoicesList.tsx
@@ -9,6 +9,7 @@ import {
 import type { Invoice } from '@/lib/api/subscription/schemas/billing'
 import { subscriptionCopy } from '@/lib/copy/subscription'
 import { formatBillingDate } from '@/lib/format/date'
+import { formatMinorUnits } from '@/lib/format/minorUnits'
 
 interface InvoicesListProps {
   storeId: string
@@ -16,25 +17,6 @@ interface InvoicesListProps {
 
 const copy = subscriptionCopy.billing
 
-const ZERO_DECIMAL = new Set([
-  'bif', 'clp', 'djf', 'gnf', 'jpy', 'kmf', 'krw', 'mga', 'pyg',
-  'rwf', 'ugx', 'vnd', 'vuv', 'xaf', 'xof', 'xpf',
-])
-
-function formatAmount(minor: number, currency: string): string {
-  const code = currency.toUpperCase()
-  const lower = currency.toLowerCase()
-  const major = ZERO_DECIMAL.has(lower) ? minor : minor / 100
-  try {
-    return new Intl.NumberFormat(undefined, {
-      style: 'currency',
-      currency: code,
-      minimumFractionDigits: ZERO_DECIMAL.has(lower) ? 0 : 2,
-    }).format(major)
-  } catch {
-    return `${code} ${major.toFixed(ZERO_DECIMAL.has(lower) ? 0 : 2)}`
-  }
-}
 
 function statusLabel(status: string): { label: string; tone: string } {
   switch (status) {
@@ -67,7 +49,7 @@ function InvoiceRow({ invoice }: { invoice: Invoice }) {
         {invoice.number || '—'}
       </td>
       <td className="py-4 text-sm text-[var(--ink-900)]">
-        {formatAmount(amount, invoice.currency)}
+        {formatMinorUnits(amount, invoice.currency)}
       </td>
       <td className="py-4 text-sm" style={{ color: tone }}>
         {label}

--- a/apps/admin/app/(admin)/settings/billing/PromoCodeCard.tsx
+++ b/apps/admin/app/(admin)/settings/billing/PromoCodeCard.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import type { CurrentPlan } from '@/lib/api/subscription/schemas/billing'
+import { PromoRejectedError } from '@/lib/api/subscription/promo'
+import { useApplyPromo } from '@/lib/api/subscription/hooks/usePromo'
+import type { ApplyPromoResponse } from '@/lib/api/subscription/schemas/promo'
+import {
+  promoRejectionMessage,
+  promoRejectionSuggestsPlanChange,
+} from '@/lib/copy/promoRejection'
+import { promoAppliedMessage } from '@/lib/copy/promoApplied'
+import { subscriptionCopy } from '@/lib/copy/subscription'
+
+interface PromoCodeCardProps {
+  plan: CurrentPlan
+  storeId: string
+}
+
+const copy = subscriptionCopy.promo
+
+/**
+ * Outcome of the last submission. Held locally rather than read off the
+ * mutation so a refusal and a transport failure stay distinguishable: React
+ * Query reports both as `isError`, and showing "that code is invalid" for a
+ * dropped connection would tell the merchant their working code is broken.
+ */
+type Outcome =
+  | { kind: 'applied'; response: ApplyPromoResponse }
+  | { kind: 'rejected'; message: string; suggestsPlanChange: boolean }
+  | { kind: 'failed'; message: string }
+
+/**
+ * PromoCodeCard — the merchant-facing redemption field.
+ *
+ * Lives on billing settings rather than in the cancel flow. The cancel
+ * flow's save offer redeems its code for the merchant automatically (see
+ * cancel.applySaveOfferDiscount) and never asks them to type one, so a field
+ * there would have nothing to do. Billing settings is also the surface a
+ * merchant arriving cold from the day-30 win-back email can reach: their
+ * subscription is expired by then, and readonly.DefaultAllowlist lets
+ * POST /subscription/* through in every read-only state precisely so they
+ * can recover.
+ *
+ * Design: hairline-only section, matching PlanCard and InvoicesList.
+ */
+export function PromoCodeCard({ plan, storeId }: PromoCodeCardProps) {
+  const [code, setCode] = useState('')
+  const [outcome, setOutcome] = useState<Outcome | null>(null)
+  const applyPromo = useApplyPromo(storeId)
+
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+
+    const trimmed = code.trim()
+    if (trimmed.length === 0) {
+      setOutcome({ kind: 'failed', message: copy.emptyCode })
+      return
+    }
+
+    setOutcome(null)
+    applyPromo.mutate(trimmed, {
+      onSuccess: (response) => {
+        setCode('')
+        setOutcome({ kind: 'applied', response })
+      },
+      onError: (error) => {
+        if (error instanceof PromoRejectedError) {
+          setOutcome({
+            kind: 'rejected',
+            message: promoRejectionMessage(error.reason, { plan: plan.plan }),
+            suggestsPlanChange: promoRejectionSuggestsPlanChange(error.reason),
+          })
+          return
+        }
+        // Not a refusal: a 401, a read-only 402, a dropped connection. The
+        // code was never judged, so say so instead of blaming it.
+        setOutcome({ kind: 'failed', message: copy.networkError })
+      },
+    })
+  }
+
+  const isPending = applyPromo.isPending
+
+  return (
+    <section
+      aria-labelledby="promo-card-heading"
+      className="border-b border-[var(--hairline,var(--ink-100))] pb-10"
+    >
+      <h2
+        id="promo-card-heading"
+        className="font-serif text-2xl font-medium tracking-tight text-[var(--ink-900)]"
+      >
+        {copy.heading}
+      </h2>
+
+      <p className="mt-1 max-w-xl text-sm leading-6 text-[var(--ink-700)]">
+        {copy.description}
+      </p>
+
+      <form onSubmit={handleSubmit} className="mt-5 flex flex-wrap items-end gap-3">
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="promo-code-input"
+            className="text-sm font-medium text-[var(--ink-900)]"
+          >
+            {copy.inputLabel}
+          </label>
+          <input
+            id="promo-code-input"
+            name="promo_code"
+            type="text"
+            autoComplete="off"
+            spellCheck={false}
+            value={code}
+            onChange={(event) => setCode(event.target.value)}
+            disabled={isPending}
+            placeholder={copy.inputPlaceholder}
+            // The outcome region is the accessible description so a screen
+            // reader reaching the field again after a refusal hears WHY,
+            // not just the label.
+            aria-describedby={outcome ? 'promo-code-outcome' : undefined}
+            aria-invalid={outcome?.kind === 'rejected' ? true : undefined}
+            className="h-10 w-64 rounded-md border border-[var(--hairline,var(--ink-100))] bg-[var(--background-elevated)] px-3 text-sm text-[var(--ink-900)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-60"
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={isPending}
+          aria-busy={isPending}
+          className="inline-flex h-10 items-center rounded-md bg-[var(--ink-900)] px-5 text-sm font-medium text-white transition-colors hover:bg-[var(--ink-900)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isPending ? copy.submitInProgress : copy.submitCta}
+        </button>
+      </form>
+
+      {/* One live region for every outcome, so a screen reader hears the
+          result whichever way it went. role="status" rather than "alert" for
+          the success case; a refusal adds role="alert" below. */}
+      <div id="promo-code-outcome" aria-live="polite" className="mt-4">
+        {outcome?.kind === 'applied' && (
+          <p role="status" className="text-sm text-[var(--moss-700)]">
+            {promoAppliedMessage(outcome.response)}
+          </p>
+        )}
+
+        {outcome?.kind === 'rejected' && (
+          <div role="alert" className="space-y-2">
+            <p className="max-w-xl text-sm leading-6 text-[var(--ink-700)]">
+              {outcome.message}
+            </p>
+            {outcome.suggestsPlanChange && (
+              <Link
+                href="/settings/billing/plan-change"
+                className="inline-flex text-sm font-medium text-[var(--moss-700)] underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--moss-700)]"
+              >
+                {subscriptionCopy.billing.changePlan}
+              </Link>
+            )}
+          </div>
+        )}
+
+        {outcome?.kind === 'failed' && (
+          <p role="alert" className="text-sm text-[var(--danger,#7a1a1a)]">
+            {outcome.message}
+          </p>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/apps/admin/app/api/admin/stores/[storeId]/subscription/apply-promo/route.ts
+++ b/apps/admin/app/api/admin/stores/[storeId]/subscription/apply-promo/route.ts
@@ -1,0 +1,9 @@
+import { proxyAdminApi } from "@/lib/api/server/proxyAdminApi";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ storeId: string }> },
+): Promise<Response> {
+  const { storeId } = await params;
+  return proxyAdminApi(request, `stores/${storeId}/subscription/apply-promo`);
+}

--- a/apps/admin/lib/api/client.ts
+++ b/apps/admin/lib/api/client.ts
@@ -24,6 +24,21 @@ export class ApiError extends Error {
     public readonly code: string,
     public readonly status: number,
     message?: string,
+    /**
+     * Machine-readable sub-reason from the error body's `reason` field,
+     * when the endpoint sends one.
+     *
+     * `code` is coarse and stable — it names the class of failure and UI
+     * branches on it. `reason` is the detail within that class, so an
+     * endpoint can add a case without every existing caller having to learn
+     * a new `code`. apply-promo is the first user: one `code`
+     * (`promo_invalid_or_expired`), eight reasons, each a different sentence
+     * the merchant can act on (#770).
+     *
+     * Undefined for every endpoint that does not send one, which is most of
+     * them — always fall back to `message` rather than assuming it is here.
+     */
+    public readonly reason?: string,
   ) {
     super(message ?? code)
     this.name = 'ApiError'
@@ -58,6 +73,7 @@ interface ErrorBody {
   error?: string
   message?: string
   status?: string
+  reason?: string
 }
 
 async function parseErrorBody(res: Response): Promise<ErrorBody> {
@@ -98,6 +114,7 @@ async function handleResponse<T>(
     body.error ?? 'network_error',
     res.status,
     body.message,
+    body.reason,
   )
 }
 

--- a/apps/admin/lib/api/subscription/hooks/usePromo.ts
+++ b/apps/admin/lib/api/subscription/hooks/usePromo.ts
@@ -1,0 +1,35 @@
+/**
+ * React Query hook for promo-code redemption.
+ *
+ * Invalidates ['subscription', storeId] on success so the plan card reflects
+ * the new price without a reload.
+ */
+'use client'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { UseMutationResult } from '@tanstack/react-query'
+import { applyPromo } from '../promo'
+import type { ApplyPromoResponse } from '../schemas/promo'
+
+/**
+ * Redeems a promo code against the store's subscription.
+ *
+ * The error is deliberately left as `Error` rather than narrowed here: the
+ * mutation rejects with PromoRejectedError for a refused code and ApiError
+ * for everything else, and the component has to tell those apart to pick the
+ * right sentence. Narrowing to one of them here would hide the other.
+ *
+ * @param storeId - The store UUID. Required.
+ */
+export function useApplyPromo(
+  storeId: string,
+): UseMutationResult<ApplyPromoResponse, Error, string> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (code: string) => applyPromo(storeId, code),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['subscription', storeId] })
+    },
+  })
+}

--- a/apps/admin/lib/api/subscription/promo.ts
+++ b/apps/admin/lib/api/subscription/promo.ts
@@ -1,0 +1,70 @@
+/**
+ * Promo-code redemption API client.
+ *
+ * Wraps:
+ *   POST /api/admin/stores/:storeId/subscription/apply-promo
+ *
+ * See services/marketplace-api/internal/handlers/admin/promo.go for backend
+ * behaviour and §7.3 of the subscription model spec for the validation rules.
+ */
+import { apiClient, ApiError } from '@/lib/api/client'
+import {
+  applyPromoRequestSchema,
+  applyPromoResponseSchema,
+  toPromoRejectReason,
+  type ApplyPromoResponse,
+  type PromoRejectReason,
+} from './schemas/promo'
+
+const applyPromoPath = (storeId: string) =>
+  `/api/admin/stores/${storeId}/subscription/apply-promo`
+
+/**
+ * A refused promo code.
+ *
+ * Thrown instead of a bare ApiError so a call site cannot render a refusal
+ * without deciding which sentence it shows. `reason` is always one of the
+ * eight public reasons — `toPromoRejectReason` narrows anything else to
+ * `invalid_or_expired`, so there is no "unknown reason" branch to forget.
+ */
+export class PromoRejectedError extends Error {
+  constructor(
+    public readonly reason: PromoRejectReason,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'PromoRejectedError'
+  }
+}
+
+/**
+ * Redeem a promo code against this store's subscription.
+ *
+ * The request carries only the code. The per-email redemption cap is counted
+ * server-side against the subscription's billing address — passing an email
+ * from here would let a merchant aim that cap at someone else.
+ *
+ * Throws PromoRejectedError for a 422 refusal (a valid request the rules
+ * declined), and ApiError for everything else — a 401, a 402 read-only
+ * subscription, a network failure. Those are not refusals of the code and
+ * must not be shown as if the code were the problem.
+ */
+export async function applyPromo(
+  storeId: string,
+  code: string,
+): Promise<ApplyPromoResponse> {
+  const validated = applyPromoRequestSchema.parse({ code })
+
+  try {
+    const raw = await apiClient.post<unknown>(
+      applyPromoPath(storeId),
+      validated,
+    )
+    return applyPromoResponseSchema.parse(raw)
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 422) {
+      throw new PromoRejectedError(toPromoRejectReason(err.reason), err.message)
+    }
+    throw err
+  }
+}

--- a/apps/admin/lib/api/subscription/schemas/promo.ts
+++ b/apps/admin/lib/api/subscription/schemas/promo.ts
@@ -1,0 +1,97 @@
+/**
+ * Zod schemas for the promo-code redemption wire types.
+ *
+ * Source of truth:
+ *   services/marketplace-api/internal/handlers/admin/promo.go
+ *   services/marketplace-api/internal/promo/public_reason.go
+ *
+ * Request:  POST /api/admin/stores/:storeId/subscription/apply-promo
+ *   Body:   { code: string }
+ *
+ * The body carries no email. The Go handler counts the per-email redemption
+ * cap against the subscription's own billing address; a client-supplied
+ * address would let one merchant spend another's cap.
+ *
+ * Response 200: { stripe_coupon_id, effective_minor, currency,
+ *                 percent_off_bps, max_duration_months }
+ * Response 422: { error: "promo_invalid_or_expired", message, reason }
+ */
+import { z } from 'zod'
+
+// ---------------------------------------------------------------------------
+// Request
+// ---------------------------------------------------------------------------
+
+export const applyPromoRequestSchema = z.object({
+  /**
+   * The code the merchant typed. Sent as-is: the server upper-cases and
+   * trims before its constant-time comparison, so normalising here would
+   * only risk drifting from that.
+   */
+  code: z.string().min(1),
+})
+
+export type ApplyPromoRequest = z.infer<typeof applyPromoRequestSchema>
+
+// ---------------------------------------------------------------------------
+// Response
+// ---------------------------------------------------------------------------
+
+export const applyPromoResponseSchema = z.object({
+  /** Stripe Coupon backing the code, or "" when the code has none. */
+  stripe_coupon_id: z.string().default(''),
+  /** Recurring price after the discount, in minor units. */
+  effective_minor: z.number().int(),
+  /**
+   * Lower-case ISO 4217 for `effective_minor`. Comes from the server because
+   * the GET subscription DTO does not populate billing_currency — the admin
+   * schema defaults that missing field to USD, which would print an INR
+   * price with a dollar sign.
+   */
+  currency: z.string().default(''),
+  /** Percentage discount in basis points (2000 = 20%). 0 = not a percentage code. */
+  percent_off_bps: z.number().int().default(0),
+  /** Months the discount runs for. 0 means the row states no bound — never "zero months". */
+  max_duration_months: z.number().int().default(0),
+})
+
+export type ApplyPromoResponse = z.infer<typeof applyPromoResponseSchema>
+
+// ---------------------------------------------------------------------------
+// Rejection reasons
+// ---------------------------------------------------------------------------
+
+/**
+ * The machine-readable reasons the server will return on a 422.
+ *
+ * This is the PUBLIC set, and it is one smaller than the validator's internal
+ * set: `not_found` and `expired` both arrive as `invalid_or_expired`. That
+ * merge is deliberate on the server — telling the two apart would confirm
+ * which code strings are real to anyone typing them — so there is no client
+ * copy for either, and asking for one is asking to undo it.
+ */
+export const PROMO_REJECT_REASONS = [
+  'invalid_or_expired',
+  'max_redemptions_reached',
+  'max_per_email_reached',
+  'wrong_plan',
+  'annual_only',
+  'below_absolute_floor',
+  'currency_not_covered',
+  'unknown_discount_type',
+] as const
+
+export type PromoRejectReason = (typeof PROMO_REJECT_REASONS)[number]
+
+/**
+ * Narrows an unknown `reason` string from an error body.
+ *
+ * An unrecognised reason — an older server, or a reason added after this
+ * build — falls back to `invalid_or_expired`, whose copy is the one sentence
+ * that is safe to show without knowing anything.
+ */
+export function toPromoRejectReason(reason: unknown): PromoRejectReason {
+  return (PROMO_REJECT_REASONS as readonly string[]).includes(reason as string)
+    ? (reason as PromoRejectReason)
+    : 'invalid_or_expired'
+}

--- a/apps/admin/lib/copy/promoApplied.ts
+++ b/apps/admin/lib/copy/promoApplied.ts
@@ -1,0 +1,61 @@
+/**
+ * Builds the confirmation sentence for a redeemed promo code (#770).
+ *
+ * Kept beside the rejection mapping and out of the component so what we
+ * CLAIM about an applied discount is testable on its own. The rule it
+ * enforces: state only what the response actually contains.
+ */
+import { subscriptionCopy } from '@/lib/copy/subscription'
+import { formatMinorUnits } from '@/lib/format/minorUnits'
+import type { ApplyPromoResponse } from '@/lib/api/subscription/schemas/promo'
+
+const copy = subscriptionCopy.promo
+
+/**
+ * Renders basis points as a display percentage: 2000 → "20", 1250 → "12.5".
+ * Returns null outside (0, 100), which the caller reads as "not a percentage
+ * discount we can describe".
+ *
+ * Mirrors formatPercentBps in the Go win-back cron deliberately: the same
+ * number reaches a merchant through two channels and must read the same in
+ * both.
+ */
+function formatPercentBps(bps: number): string | null {
+  if (!Number.isFinite(bps) || bps <= 0 || bps >= 10000) return null
+  return String(Number((bps / 100).toFixed(2)))
+}
+
+/**
+ * The confirmation sentence for `res`.
+ *
+ * Three shapes, in decreasing order of what the response lets us say:
+ *
+ *  1. A whole percentage AND a month bound — state the discount, how long it
+ *     runs, and the new price.
+ *  2. A price but no describable terms (a flat-amount code, or one with no
+ *     bound on its duration) — state the new price only. Naming a duration
+ *     here would be inventing one; `max_duration_months: 0` means the row
+ *     sets no bound, not that the discount lasts zero months.
+ *  3. No currency — quote no price at all rather than guessing one. The GET
+ *     subscription DTO does not carry billing_currency and its schema
+ *     defaults the gap to USD, so falling back to that would print an INR
+ *     price with a dollar sign.
+ *
+ * Every shape says the discount starts on the NEXT invoice, because that is
+ * what happens: applying a code attaches a Stripe coupon to the
+ * subscription's discounts and nothing re-bills the current period.
+ */
+export function promoAppliedMessage(res: ApplyPromoResponse): string {
+  if (!res.currency) {
+    return copy.appliedNoPrice
+  }
+
+  const price = formatMinorUnits(res.effective_minor, res.currency)
+  const percentOff = formatPercentBps(res.percent_off_bps)
+
+  if (percentOff !== null && res.max_duration_months > 0) {
+    return copy.appliedForMonths(percentOff, res.max_duration_months, price)
+  }
+
+  return copy.applied(price)
+}

--- a/apps/admin/lib/copy/promoRejection.ts
+++ b/apps/admin/lib/copy/promoRejection.ts
@@ -1,0 +1,66 @@
+/**
+ * Maps a machine-readable promo rejection reason onto the sentence the
+ * merchant reads (#770).
+ *
+ * A separate module from the component so the mapping can be tested without
+ * rendering anything — the sentences ARE the feature, and a test that only
+ * checks the happy path would miss all of it.
+ *
+ * The switch is exhaustive over PromoRejectReason with no default arm, so
+ * adding a ninth public reason to the schema fails the type-check here
+ * rather than silently falling back to the one sentence that says the least.
+ */
+import { subscriptionCopy } from '@/lib/copy/subscription'
+import type { PromoRejectReason } from '@/lib/api/subscription/schemas/promo'
+
+const copy = subscriptionCopy.promo.rejected
+
+/** Context two of the reasons need in order to name the merchant's own plan. */
+export interface PromoRejectionContext {
+  /** Plan slug, e.g. "starter". Rendered into the wrong_plan and floor sentences. */
+  plan: string
+}
+
+/**
+ * The sentence for `reason`.
+ *
+ * `wrong_plan` and `below_absolute_floor` name the plan because that is the
+ * fact that makes them actionable: without it, "does not apply to your plan"
+ * gives the merchant nothing to change.
+ */
+export function promoRejectionMessage(
+  reason: PromoRejectReason,
+  ctx: PromoRejectionContext,
+): string {
+  switch (reason) {
+    case 'invalid_or_expired':
+      return copy.invalidOrExpired
+    case 'max_redemptions_reached':
+      return copy.maxRedemptionsReached
+    case 'max_per_email_reached':
+      return copy.maxPerEmailReached
+    case 'wrong_plan':
+      return copy.wrongPlan(ctx.plan)
+    case 'annual_only':
+      return copy.annualOnly
+    case 'below_absolute_floor':
+      return copy.belowAbsoluteFloor(ctx.plan)
+    case 'currency_not_covered':
+      return copy.currencyNotCovered
+    case 'unknown_discount_type':
+      return copy.unknownDiscountType
+  }
+}
+
+/**
+ * Whether the refusal means the merchant should change plan or billing
+ * period, which the panel turns into a link to the plan-change screen.
+ *
+ * These two are the only reasons a merchant can resolve themselves without
+ * talking to us. Every other reason either needs support or needs nothing.
+ */
+export function promoRejectionSuggestsPlanChange(
+  reason: PromoRejectReason,
+): boolean {
+  return reason === 'wrong_plan' || reason === 'annual_only'
+}

--- a/apps/admin/lib/copy/subscription.ts
+++ b/apps/admin/lib/copy/subscription.ts
@@ -174,6 +174,91 @@ export const subscriptionCopy = {
   },
 
   /**
+   * Promo-code redemption panel — /settings/billing (#770).
+   *
+   * Voice: calm, editorial, factual. The refusal sentences carry the whole
+   * feature. Five of the eight reasons mean the code is FINE — it has been
+   * fully claimed, already used, or cannot combine with this plan, period or
+   * price floor — and saying "invalid or expired" for those sends a merchant
+   * to support holding a code that works. Two of them (wrong_plan,
+   * annual_only) name the change that would make the code work; one
+   * (unknown_discount_type) is our own data fault and must never read as the
+   * merchant's mistake.
+   *
+   * `invalid_or_expired` is the only reason that covers two server-side
+   * cases, and its sentence says so rather than picking one. The server
+   * merges "no such code" with "past its end date" on purpose — telling them
+   * apart would confirm which codes are real to anyone typing strings — so
+   * the copy must not imply we know which of the two it was.
+   */
+  promo: {
+    heading: 'Promo code',
+    description:
+      'If you have a code from us, redeem it here. The discount shows on your next invoice.',
+    inputLabel: 'Promo code',
+    inputPlaceholder: 'Enter your code',
+    submitCta: 'Redeem code',
+    submitInProgress: 'Checking\u2026',
+
+    /** Shown when the field is submitted empty. Never reaches the server. */
+    emptyCode: 'Enter the code from your email to redeem it.',
+
+    /**
+     * Merchant-facing sentence for each machine-readable rejection reason.
+     *
+     * Keyed by PromoRejectReason. Every value is a distinct sentence: two
+     * reasons sharing one string would put the merchant back where this
+     * issue found them, told nothing they can act on.
+     */
+    rejected: {
+      invalidOrExpired:
+        'We don\u2019t recognise that code, or it has passed its end date. Check the spelling and try again \u2014 codes are not case-sensitive.',
+      maxRedemptionsReached:
+        'This offer has been fully claimed. Your code was genuine \u2014 it has simply reached the number of redemptions it was issued for, so there is nothing to fix on your side.',
+      maxPerEmailReached:
+        'You have already redeemed this code. Each code can be used once per account, and the discount from your first redemption still stands.',
+      wrongPlan: (plan: string) =>
+        `This code does not apply to the ${plan} plan. It is a valid code \u2014 change plan and it will work.`,
+      annualOnly:
+        'This code applies to annual billing only. It is a valid code \u2014 switch to annual billing and it will work.',
+      belowAbsoluteFloor: (plan: string) =>
+        `This code is valid, but the discount would take your ${plan} plan below the lowest price we can bill it at in your currency. Changing plan may let you use it; otherwise contact us and we will find something that works.`,
+      currencyNotCovered:
+        'We cannot apply this code to a subscription billed in your currency yet. Contact us with the code and we will apply the discount by hand.',
+      unknownDiscountType:
+        'Something is wrong with this code on our side \u2014 it is not set up correctly. Contact us with the code and we will fix it.',
+    },
+
+    /**
+     * Confirmation sentences.
+     *
+     * Both state the new price and that it starts on the NEXT invoice. That
+     * is what actually happens: applying a code attaches a Stripe coupon to
+     * the subscription's discounts (AddSubscriptionDiscount) and nothing
+     * re-bills the current period, so "applied immediately" would be untrue
+     * and "you have been charged less today" doubly so.
+     *
+     * `appliedForMonths` is used only when the response carries BOTH a
+     * whole-percentage discount and a month bound. A code with a flat amount
+     * off, or no bound on how long it runs, cannot be described by that
+     * sentence \u2014 so it gets `applied`, which claims only the number the
+     * response actually contains. Same rule the win-back email follows
+     * (#727): never invent the part of an offer the data does not state.
+     */
+    appliedForMonths: (percentOff: string, months: number, price: string) =>
+      `Code applied. ${percentOff}% off for your next ${months === 1 ? 'month' : `${months} months`} \u2014 your plan is ${price} until then, starting with your next invoice.`,
+    applied: (price: string) =>
+      `Code applied. Your plan is ${price}, starting with your next invoice.`,
+    /** Used when the server returned no currency, so no price can be quoted. */
+    appliedNoPrice:
+      'Code applied. The discount shows on your next invoice.',
+
+    /** Non-refusal failures \u2014 the code was never judged. */
+    networkError:
+      'We could not reach billing just now. Your code has not been used \u2014 try again in a moment.',
+  },
+
+  /**
    * Trial banners + email ramp visualizer (§5, §5.3).
    *
    * Voice: calm, editorial. Trials are a positive state — never urgency.

--- a/apps/admin/lib/format/minorUnits.ts
+++ b/apps/admin/lib/format/minorUnits.ts
@@ -1,0 +1,39 @@
+/**
+ * Minor-unit money formatting for billing surfaces.
+ *
+ * Extracted from the invoices list so the promo confirmation quotes a price
+ * the same way the invoice for it will (#770). Distinct from
+ * `formatMoney` in lib/format.ts, which takes a MAJOR-unit amount — passing
+ * minor units to that prints 1520 as "$1,520.00".
+ */
+
+/**
+ * Currencies Stripe treats as zero-decimal: the amount is already in base
+ * units, so 1520 JPY is ¥1,520 and not ¥15.20.
+ */
+const ZERO_DECIMAL = new Set([
+  'bif', 'clp', 'djf', 'gnf', 'jpy', 'kmf', 'krw', 'mga', 'pyg',
+  'rwf', 'ugx', 'vnd', 'vuv', 'xaf', 'xof', 'xpf',
+])
+
+/**
+ * Formats a minor-unit amount in the given ISO 4217 currency.
+ *
+ * Falls back to "CODE 12.34" when Intl rejects the currency code, so an
+ * unexpected code degrades to a readable number rather than throwing.
+ */
+export function formatMinorUnits(minor: number, currency: string): string {
+  const code = currency.toUpperCase()
+  const lower = currency.toLowerCase()
+  const zeroDecimal = ZERO_DECIMAL.has(lower)
+  const major = zeroDecimal ? minor : minor / 100
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: code,
+      minimumFractionDigits: zeroDecimal ? 0 : 2,
+    }).format(major)
+  } catch {
+    return `${code} ${major.toFixed(zeroDecimal ? 0 : 2)}`
+  }
+}

--- a/apps/admin/tests/unit/api/subscription/promo.test.ts
+++ b/apps/admin/tests/unit/api/subscription/promo.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Promo-code redemption tests (#770).
+ *
+ * Two halves, and the second is the point of the issue:
+ *
+ *   1. MSW-backed transport — applyPromo's request shape, the parsed 200,
+ *      and the 422 → PromoRejectedError translation carrying the reason.
+ *   2. The copy mapping — every rejection reason renders a DISTINCT sentence
+ *      a merchant can act on. A test that only checked the happy path would
+ *      pass while all eight said "invalid or expired".
+ */
+
+import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+
+import { applyPromo, PromoRejectedError } from '@/lib/api/subscription/promo'
+import {
+  PROMO_REJECT_REASONS,
+  toPromoRejectReason,
+  type PromoRejectReason,
+} from '@/lib/api/subscription/schemas/promo'
+import { promoRejectionMessage } from '@/lib/copy/promoRejection'
+import { promoAppliedMessage } from '@/lib/copy/promoApplied'
+import { ApiError } from '@/lib/api/client'
+
+// ---------------------------------------------------------------------------
+// MSW server
+// ---------------------------------------------------------------------------
+
+const server = setupServer()
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+const STORE_ID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+const APPLY_PATH = `/api/admin/stores/${STORE_ID}/subscription/apply-promo`
+
+const APPLIED_FIXTURE = {
+  stripe_coupon_id: 'co_test_winback',
+  effective_minor: 1520,
+  currency: 'usd',
+  percent_off_bps: 2000,
+  max_duration_months: 6,
+}
+
+function rejection(reason: string) {
+  return HttpResponse.json(
+    {
+      error: 'promo_invalid_or_expired',
+      message: 'the promo code is invalid or has expired',
+      reason,
+    },
+    { status: 422 },
+  )
+}
+
+// ---------------------------------------------------------------------------
+// applyPromo — transport
+// ---------------------------------------------------------------------------
+
+describe('applyPromo', () => {
+  it('200 — parses the applied response', async () => {
+    server.use(http.post(APPLY_PATH, () => HttpResponse.json(APPLIED_FIXTURE)))
+
+    const result = await applyPromo(STORE_ID, 'WINBACK20OFF6MONTHS')
+
+    expect(result.effective_minor).toBe(1520)
+    expect(result.currency).toBe('usd')
+    expect(result.percent_off_bps).toBe(2000)
+    expect(result.max_duration_months).toBe(6)
+  })
+
+  // The per-email redemption cap is counted server-side against the
+  // subscription's billing address. A body carrying an email would let a
+  // merchant aim that cap at somebody else's account, so the request must
+  // not have one — asserted against the wire, not against the module's own
+  // types, because a type cannot stop an extra field being sent.
+  it('sends only the code — never an email', async () => {
+    let sent: unknown = null
+    server.use(
+      http.post(APPLY_PATH, async ({ request }) => {
+        sent = await request.json()
+        return HttpResponse.json(APPLIED_FIXTURE)
+      }),
+    )
+
+    await applyPromo(STORE_ID, 'WINBACK20OFF6MONTHS')
+
+    expect(sent).toEqual({ code: 'WINBACK20OFF6MONTHS' })
+  })
+
+  it('422 — throws PromoRejectedError carrying the reason', async () => {
+    server.use(http.post(APPLY_PATH, () => rejection('below_absolute_floor')))
+
+    await expect(applyPromo(STORE_ID, 'HALFOFF')).rejects.toBeInstanceOf(
+      PromoRejectedError,
+    )
+
+    const err = await applyPromo(STORE_ID, 'HALFOFF').catch((e) => e)
+    expect(err.reason).toBe('below_absolute_floor')
+  })
+
+  it('422 with an unrecognised reason — falls back to invalid_or_expired', async () => {
+    server.use(http.post(APPLY_PATH, () => rejection('reason_from_the_future')))
+
+    const err = await applyPromo(STORE_ID, 'ANYCODE').catch((e) => e)
+    expect(err).toBeInstanceOf(PromoRejectedError)
+    expect(err.reason).toBe('invalid_or_expired')
+  })
+
+  // A 402 is the read-only-subscription gate, not a judgement on the code.
+  // It must stay an ApiError so the panel says "we could not reach billing"
+  // rather than telling the merchant their working code is invalid.
+  it('non-422 failures stay ApiError, not PromoRejectedError', async () => {
+    server.use(
+      http.post(APPLY_PATH, () =>
+        HttpResponse.json(
+          { error: 'internal_error', message: 'boom' },
+          { status: 500 },
+        ),
+      ),
+    )
+
+    const err = await applyPromo(STORE_ID, 'ANYCODE').catch((e) => e)
+    expect(err).toBeInstanceOf(ApiError)
+    expect(err).not.toBeInstanceOf(PromoRejectedError)
+  })
+})
+
+describe('toPromoRejectReason', () => {
+  it('narrows anything unrecognised to invalid_or_expired', () => {
+    expect(toPromoRejectReason(undefined)).toBe('invalid_or_expired')
+    expect(toPromoRejectReason('')).toBe('invalid_or_expired')
+    expect(toPromoRejectReason(42)).toBe('invalid_or_expired')
+    expect(toPromoRejectReason('wrong_plan')).toBe('wrong_plan')
+  })
+
+  // not_found and expired are merged SERVER-side and must never appear as
+  // client reasons. A client that knew them would be one copy change away
+  // from telling a code-guesser which strings are real.
+  it('does not recognise the server-internal not_found / expired reasons', () => {
+    expect(toPromoRejectReason('not_found')).toBe('invalid_or_expired')
+    expect(toPromoRejectReason('expired')).toBe('invalid_or_expired')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The copy mapping — this is the feature
+// ---------------------------------------------------------------------------
+
+const CTX = { plan: 'starter' }
+
+describe('promoRejectionMessage', () => {
+  it.each(PROMO_REJECT_REASONS)('%s renders a non-empty sentence', (reason) => {
+    const message = promoRejectionMessage(reason, CTX)
+    expect(message.length).toBeGreaterThan(0)
+  })
+
+  // The mutation guard. Getting these sentences right IS the issue: two
+  // reasons sharing one string puts the merchant back where #770 found
+  // them, told something that does not describe their situation.
+  it('renders a DISTINCT sentence for every reason', () => {
+    const seen = new Map<string, PromoRejectReason>()
+    for (const reason of PROMO_REJECT_REASONS) {
+      const message = promoRejectionMessage(reason, CTX)
+      const previous = seen.get(message)
+      expect(
+        previous,
+        `${previous} and ${reason} render the same sentence — a merchant cannot tell what happened`,
+      ).toBeUndefined()
+      seen.set(message, reason)
+    }
+    expect(seen.size).toBe(PROMO_REJECT_REASONS.length)
+  })
+
+  // The five reasons where the code is FINE. Telling a merchant their code
+  // is "invalid or expired" for any of these sends them to support holding
+  // a code that works — the exact failure #770 was filed for.
+  it.each([
+    'max_redemptions_reached',
+    'max_per_email_reached',
+    'wrong_plan',
+    'annual_only',
+    'below_absolute_floor',
+  ] as const)('%s never claims the code is invalid or expired', (reason) => {
+    const message = promoRejectionMessage(reason, CTX).toLowerCase()
+    expect(message).not.toContain('invalid')
+    expect(message).not.toContain('expired')
+  })
+
+  // The two actionable ones must name the change that would work, or the
+  // merchant is told what failed and not what to do about it.
+  it('wrong_plan names the merchant plan and points at changing it', () => {
+    const message = promoRejectionMessage('wrong_plan', { plan: 'starter' })
+    expect(message).toContain('starter')
+    expect(message.toLowerCase()).toContain('change plan')
+  })
+
+  it('annual_only names annual billing as the fix', () => {
+    const message = promoRejectionMessage('annual_only', CTX).toLowerCase()
+    expect(message).toContain('annual')
+  })
+
+  // below_absolute_floor is our pricing rule biting, not the merchant's
+  // mistake, and unknown_discount_type is our own bad data. Neither may
+  // read as something they did wrong.
+  it('below_absolute_floor says the code is valid', () => {
+    const message = promoRejectionMessage('below_absolute_floor', CTX)
+    // "is valid", not "valid" — the latter is satisfied by the word
+    // "invalid", which is the sentence this reason must never render.
+    expect(message.toLowerCase()).toContain('is valid')
+    expect(message).toContain('starter')
+  })
+
+  it('unknown_discount_type blames our side, not the merchant', () => {
+    const message = promoRejectionMessage('unknown_discount_type', CTX).toLowerCase()
+    expect(message).toContain('our side')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The confirmation sentence
+// ---------------------------------------------------------------------------
+
+describe('promoAppliedMessage', () => {
+  it('states the discount, its duration and the new price when the response carries all three', () => {
+    const message = promoAppliedMessage(APPLIED_FIXTURE)
+    expect(message).toContain('20%')
+    expect(message).toContain('6 months')
+    // The amount, not the symbol: Intl renders USD as "$15.20" or
+    // "USD 15.20" depending on the ambient locale, and jsdom has none.
+    expect(message).toContain('15.20')
+    expect(message).toContain('next invoice')
+  })
+
+  // max_duration_months: 0 means the row states no bound. Rendering it as a
+  // duration would tell the merchant the discount lasts zero months.
+  it('states no duration when the response gives no month bound', () => {
+    const message = promoAppliedMessage({
+      ...APPLIED_FIXTURE,
+      max_duration_months: 0,
+    })
+    expect(message).toContain('15.20')
+    expect(message).not.toContain('month')
+  })
+
+  // A flat-amount code has no percentage to quote.
+  it('states no percentage for a flat-amount code', () => {
+    const message = promoAppliedMessage({
+      ...APPLIED_FIXTURE,
+      percent_off_bps: 0,
+    })
+    expect(message).toContain('15.20')
+    expect(message).not.toContain('%')
+  })
+
+  // Without a currency the amount cannot be formatted. Defaulting to USD is
+  // exactly the bug this avoids: an INR price printed with a dollar sign.
+  it('quotes no price at all when the response carries no currency', () => {
+    const message = promoAppliedMessage({ ...APPLIED_FIXTURE, currency: '' })
+    expect(message).not.toContain('15.20')
+    expect(message).not.toContain('USD')
+    expect(message).toContain('next invoice')
+  })
+
+  it('formats a zero-decimal currency without inventing cents', () => {
+    const message = promoAppliedMessage({
+      ...APPLIED_FIXTURE,
+      effective_minor: 1520,
+      currency: 'jpy',
+    })
+    expect(message).toContain('1,520')
+    expect(message).not.toContain('15.20')
+  })
+
+  it('never claims the discount applies today', () => {
+    const message = promoAppliedMessage(APPLIED_FIXTURE).toLowerCase()
+    expect(message).not.toContain('immediately')
+    expect(message).not.toContain('today')
+    expect(message).toContain('next invoice')
+  })
+})

--- a/services/marketplace-api/internal/email/templates_content.go
+++ b/services/marketplace-api/internal/email/templates_content.go
@@ -116,15 +116,21 @@ var billingHTMLFragments = map[TemplateID]string{
 	// row too, so a console edit to the discount cannot leave the email
 	// quoting a stale one.
 	//
-	// It deliberately does NOT tell the merchant where to enter the code.
-	// POST /admin/stores/:storeId/subscription/apply-promo has no caller in
-	// apps/ — there is no field in the merchant admin that redeems a promo
-	// code — so naming a screen would be the same class of untrue statement
-	// this template was fixed to stop making. Whoever authors the code in
-	// the console owns closing that gap first.
+	// It now names where the code goes. It deliberately did not until #770,
+	// because POST /admin/stores/:storeId/subscription/apply-promo had no
+	// caller in apps/ — there was no field in the merchant admin that
+	// redeemed a promo code, so naming a screen would have been the same
+	// class of untrue statement this template was fixed to stop making.
+	// apps/admin/app/(admin)/settings/billing/PromoCodeCard.tsx is that
+	// field. If it is ever removed, this sentence goes with it.
+	//
+	// Billing settings is reachable in the state this email finds the
+	// merchant in: they are a month past expiry, and readonly.DefaultAllowlist
+	// lets POST /subscription/* through in every read-only state.
 	TemplateWinBack: `<h1 ` + h1 + `>Your store is still here</h1>
 <p><strong>{{.store_name}}</strong> has been closed for a month. Everything — products, orders, settings — is exactly as you left it.</p>
-<p>If you want to pick it back up, use the code <strong>{{.promo_code}}</strong> when you reopen your store and we will take <strong>{{.percent_off}}% off your first {{.duration_months}} months</strong>.</p>`,
+<p>If you want to pick it back up, use the code <strong>{{.promo_code}}</strong> when you reopen your store and we will take <strong>{{.percent_off}}% off your first {{.duration_months}} months</strong>.</p>
+<p>Enter it under Promo code in your Mark8ly billing settings.</p>`,
 
 	// The offer-less variant. It carries no number and names no code,
 	// because when this key is chosen there is nothing to name. What is
@@ -250,6 +256,8 @@ Mark8ly`,
 {{.store_name}} has been closed for a month. Everything — products, orders, settings — is exactly as you left it.
 
 If you want to pick it back up, use the code {{.promo_code}} when you reopen your store and we will take {{.percent_off}}% off your first {{.duration_months}} months.
+
+Enter it under Promo code in your Mark8ly billing settings.
 
 Mark8ly`,
 

--- a/services/marketplace-api/internal/handlers/admin/promo.go
+++ b/services/marketplace-api/internal/handlers/admin/promo.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -47,13 +48,37 @@ func (h *PromoHandler) WithAudit(e *audit.Emitter) *PromoHandler {
 
 type applyPromoRequest struct {
 	Code string `json:"code" binding:"required"`
-	// Email is the merchant email for per-email rate-limit and redemption tracking.
-	Email string `json:"email" binding:"required"`
 }
 
 type applyPromoResponse struct {
 	StripeCouponID string `json:"stripe_coupon_id"`
 	EffectiveMinor int64  `json:"effective_minor"`
+	// Currency is the store's billing currency, echoed so a client can format
+	// EffectiveMinor. It is not derivable client-side: the GET subscription
+	// DTO does not carry billing_currency, and the admin schema defaults the
+	// missing field to USD — which would render an INR price as dollars.
+	Currency string `json:"currency"`
+	// PercentOffBps and MaxDurationMonths describe the offer that was just
+	// applied, so the confirmation can state its size and how long it runs
+	// instead of only the new price. Both are 0 when the row does not say:
+	// 0 months is "no bound stated", never "zero months". A client that
+	// cannot describe the terms must say nothing about them rather than
+	// guess — the same rule the win-back email follows (#727).
+	PercentOffBps     int `json:"percent_off_bps"`
+	MaxDurationMonths int `json:"max_duration_months"`
+}
+
+// applyPromoErrorResponse is the 422 body for a refused code.
+//
+// Error stays the coarse, unchanging code. Reason is the machine-readable
+// rejection reason, already collapsed by promo.PublicReasonFor so that
+// not_found and expired are indistinguishable here — see public_reason.go for
+// why that pair alone is merged. Message remains the safe fallback sentence
+// for a client that does not recognise the reason.
+type applyPromoErrorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
+	Reason  string `json:"reason"`
 }
 
 // ApplyPromo handles POST /admin/stores/:storeId/subscription/apply-promo.
@@ -81,19 +106,26 @@ func (h *PromoHandler) ApplyPromo(c *gin.Context) {
 		RespondErr(c, err, h.logger)
 		return
 	}
+	if sub == nil {
+		RespondErr(c, apperrors.NotFound("subscription"), h.logger)
+		return
+	}
+
+	merchantEmail, ok := h.merchantEmail(c, sub)
+	if !ok {
+		RespondErr(c, apperrors.ValidationFailed("email",
+			"this store has no billing email, so per-email redemption limits cannot be checked"), h.logger)
+		return
+	}
 
 	actor := "user:" + c.GetString("user_id")
-	var subID uuid.UUID
-	if sub != nil {
-		subID = sub.ID
-	}
 
 	out, applyErr := h.svc.ApplyPromo(c.Request.Context(), promo.ApplyInput{
 		TenantID:       tenantID,
 		StoreID:        storeID,
-		SubscriptionID: subID,
+		SubscriptionID: sub.ID,
 		Code:           req.Code,
-		MerchantEmail:  req.Email,
+		MerchantEmail:  merchantEmail,
 		Plan:           sub.Plan,
 		Period:         sub.SubscriptionPeriod,
 		BasePriceMinor: promo.BasePriceMinorFor(
@@ -121,9 +153,10 @@ func (h *PromoHandler) ApplyPromo(c *gin.Context) {
 
 	if applyErr != nil {
 		if errors.Is(applyErr, promo.ErrInvalidOrExpired) {
-			c.AbortWithStatusJSON(http.StatusUnprocessableEntity, gin.H{
-				"error":   "promo_invalid_or_expired",
-				"message": "the promo code is invalid or has expired",
+			c.AbortWithStatusJSON(http.StatusUnprocessableEntity, applyPromoErrorResponse{
+				Error:   "promo_invalid_or_expired",
+				Message: "the promo code is invalid or has expired",
+				Reason:  string(promo.PublicReasonFor(out.RejectReason)),
 			})
 			return
 		}
@@ -132,9 +165,46 @@ func (h *PromoHandler) ApplyPromo(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, applyPromoResponse{
-		StripeCouponID: out.StripeCouponID,
-		EffectiveMinor: out.EffectiveMinor,
+		StripeCouponID:    out.StripeCouponID,
+		EffectiveMinor:    out.EffectiveMinor,
+		Currency:          stringVal(sub.BillingCurrency),
+		PercentOffBps:     out.PercentOffBps,
+		MaxDurationMonths: out.MaxDurationMonths,
 	})
+}
+
+// merchantEmail returns the address the per-email redemption cap is counted
+// against, and whether one was found.
+//
+// It is deliberately NOT taken from the request body, which is where this
+// handler used to read it. A client that chooses the address chooses whose
+// cap it spends: submitting someone else's address writes a redemption row
+// under it, and max_per_email being 1 for the campaign codes, that merchant's
+// own attempt is then refused max_per_email_reached. A merchant supplying
+// throwaway addresses would also clear their own cap at will.
+//
+// The subscription's billing email comes first because the other two callers
+// of promo.ApplyPromo already use it — cancel.applySaveOfferDiscount and the
+// day-30 win-back's offerFor both pass sub.Email. The cap only means anything
+// if all three agree on which address they mean, and disagreement here would
+// be worse than a wrong number: the win-back email validates against
+// sub.Email before it states the offer, so a redemption booked against the
+// session address would let the email promise a code this endpoint then
+// refuses.
+//
+// The session address is the fallback for a row whose email column is unset
+// — a store that never reached Stripe customer creation. It cannot fall back
+// further to the empty string: "" is a single shared bucket that every
+// address-less store would count redemptions in, so one store's redemption
+// would exhaust the cap for all of them.
+func (h *PromoHandler) merchantEmail(c *gin.Context, sub *subscription.StoreSubscription) (string, bool) {
+	if email := strings.TrimSpace(stringVal(sub.Email)); email != "" {
+		return email, true
+	}
+	if email := strings.TrimSpace(c.GetString("user_email")); email != "" {
+		return email, true
+	}
+	return "", false
 }
 
 type cancelPromoRequest struct {

--- a/services/marketplace-api/internal/handlers/admin/promo_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/promo_integration_test.go
@@ -51,6 +51,10 @@ func seedSubscriptionForPromoTest(t *testing.T, db *gorm.DB, storeID, tenantID s
 	sid, _ := uuid.Parse(storeID)
 	tid, _ := uuid.Parse(tenantID)
 	inr := currency
+	// The billing email is what the per-email redemption cap is counted
+	// against. The handler reads it from this row, not from the request body
+	// — see PromoHandler.merchantEmail.
+	email := "merchant@example.com"
 	sub := &subscription.StoreSubscription{
 		TenantID:         tid,
 		StoreID:          sid,
@@ -58,6 +62,7 @@ func seedSubscriptionForPromoTest(t *testing.T, db *gorm.DB, storeID, tenantID s
 		Plan:             subscription.SubscriptionPlan(plan),
 		Status:           subscription.StatusActive,
 		BillingCurrency:  &inr,
+		Email:            &email,
 	}
 	if err := db.Create(sub).Error; err != nil {
 		t.Fatalf("seed subscription: %v", err)
@@ -80,10 +85,7 @@ func TestPromoApply_BelowAbsoluteFloor_INR(t *testing.T) {
 	// Seed a subscription row for the store with INR currency and Starter plan.
 	seedSubscriptionForPromoTest(t, env.db, storeID, tenantID, "starter", "inr")
 
-	body := map[string]any{
-		"code":  "HALFOFF123456",
-		"email": "merchant@example.com",
-	}
+	body := map[string]any{"code": "HALFOFF123456"}
 	w := request(t, env.router, http.MethodPost, promoApplyURL(storeID), body, authHeaders(userID, tenantID))
 
 	if w.Code != http.StatusUnprocessableEntity {
@@ -96,6 +98,74 @@ func TestPromoApply_BelowAbsoluteFloor_INR(t *testing.T) {
 	}
 	if resp["error"] != "promo_invalid_or_expired" {
 		t.Errorf("spec criterion #40: expected error=promo_invalid_or_expired, got %v", resp["error"])
+	}
+	// #770: the reason must reach the merchant. "invalid or has expired" is
+	// the wrong sentence here — the code is real and the merchant did nothing
+	// wrong; the discount simply cannot go below the plan's floor.
+	if resp["reason"] != "below_absolute_floor" {
+		t.Errorf("reason = %v, want below_absolute_floor", resp["reason"])
+	}
+}
+
+// TestPromoApply_NotFoundCollapsesToInvalidOrExpired is the enumeration-oracle
+// guard at the HTTP layer. A code that does not exist must be answered
+// identically to one that has expired.
+func TestPromoApply_NotFoundCollapsesToInvalidOrExpired(t *testing.T) {
+	env := setupTestRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+
+	seedSubscriptionForPromoTest(t, env.db, storeID, tenantID, "starter", "usd")
+
+	body := map[string]any{"code": "NOSUCHCODEATALL"}
+	w := request(t, env.router, http.MethodPost, promoApplyURL(storeID), body, authHeaders(userID, tenantID))
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp["reason"] != "invalid_or_expired" {
+		t.Errorf("reason = %v, want invalid_or_expired — a distinct reason for a "+
+			"non-existent code tells a caller which strings are real", resp["reason"])
+	}
+}
+
+// TestPromoApply_IgnoresBodySuppliedEmail proves the per-email redemption cap
+// cannot be aimed at another merchant.
+//
+// The body carries victim@example.com. If the handler still read it, the
+// redemption row would be written under that address and the real owner's
+// own attempt would later be refused max_per_email_reached. The row must be
+// booked against the subscription's billing email instead.
+func TestPromoApply_IgnoresBodySuppliedEmail(t *testing.T) {
+	env := setupTestRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+
+	promoID := seedPromoCode(t, env, "WINBACK20OFF6MONTHS", 2000)
+	seedSubscriptionForPromoTest(t, env.db, storeID, tenantID, "starter", "usd")
+
+	body := map[string]any{"code": "WINBACK20OFF6MONTHS", "email": "victim@example.com"}
+	w := request(t, env.router, http.MethodPost, promoApplyURL(storeID), body, authHeaders(userID, tenantID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+
+	var email string
+	if err := env.db.Raw(
+		`SELECT email FROM promo_redemptions WHERE promo_code_id = ? AND store_id = ?`,
+		promoID, storeID,
+	).Scan(&email).Error; err != nil {
+		t.Fatalf("read redemption: %v", err)
+	}
+	if email != "merchant@example.com" {
+		t.Errorf("redemption booked against %q, want the subscription billing email "+
+			"merchant@example.com — a client-chosen address spends someone else's cap", email)
 	}
 }
 
@@ -118,7 +188,7 @@ func TestPromoApply_AbovePriceFloor_USD(t *testing.T) {
 	seedPromoCode(t, env, "WINBACK20OFF6MONTHS", 2000)
 	seedSubscriptionForPromoTest(t, env.db, storeID, tenantID, "starter", "usd")
 
-	body := map[string]any{"code": "WINBACK20OFF6MONTHS", "email": "merchant@example.com"}
+	body := map[string]any{"code": "WINBACK20OFF6MONTHS"}
 	w := request(t, env.router, http.MethodPost, promoApplyURL(storeID), body, authHeaders(userID, tenantID))
 
 	if w.Code != http.StatusOK {
@@ -131,5 +201,13 @@ func TestPromoApply_AbovePriceFloor_USD(t *testing.T) {
 	}
 	if got := resp["effective_minor"]; got != float64(1520) {
 		t.Errorf("effective_minor = %v, want 1520 ($19.00 less 20%%)", got)
+	}
+	// #770: the confirmation formats effective_minor, so the currency has to
+	// come back with it — the GET subscription DTO does not carry one.
+	if got := resp["currency"]; got != "usd" {
+		t.Errorf("currency = %v, want usd", got)
+	}
+	if got := resp["percent_off_bps"]; got != float64(2000) {
+		t.Errorf("percent_off_bps = %v, want 2000", got)
 	}
 }

--- a/services/marketplace-api/internal/promo/errors.go
+++ b/services/marketplace-api/internal/promo/errors.go
@@ -2,9 +2,15 @@ package promo
 
 import "errors"
 
-// ErrInvalidOrExpired is the uniform external error returned for every
-// promo validation failure (§7.3 pattern A). The true reason is recorded
-// in the audit event but never exposed to the HTTP client.
+// ErrInvalidOrExpired is the single Go error returned for every promo
+// validation failure (§7.3 pattern A), so no caller can branch on the failure
+// mode by comparing errors. The reason travels beside it on
+// ApplyOutput.RejectReason.
+//
+// It is no longer the whole story at the HTTP layer: the handler returns
+// PublicReasonFor(out.RejectReason) alongside the message, which keeps
+// not_found and expired indistinguishable while letting the seven reasons
+// that describe the caller's own subscription through. See public_reason.go.
 var ErrInvalidOrExpired = errors.New("promo: invalid or expired")
 
 // ErrAlreadyApplied is returned when the store already has an active

--- a/services/marketplace-api/internal/promo/public_reason.go
+++ b/services/marketplace-api/internal/promo/public_reason.go
@@ -1,0 +1,72 @@
+package promo
+
+// public_reason.go — which rejection reasons may leave the server.
+//
+// ValidationRejectReason is an internal record. This file decides what a
+// merchant's browser is told, which is a narrower question with a different
+// threat model: the audit trail is read by us, the HTTP response is read by
+// whoever is holding the keyboard.
+
+// PublicRejectReason is the machine-readable rejection reason returned on the
+// apply-promo response, for a client to map onto merchant-facing copy.
+//
+// It is a distinct type from ValidationRejectReason on purpose. The two sets
+// are deliberately NOT the same size, and giving them one type would make the
+// collapse below invisible at every call site.
+type PublicRejectReason string
+
+const (
+	// PublicReasonInvalidOrExpired is the collapsed reason covering BOTH
+	// RejectReasonNotFound and RejectReasonExpired.
+	//
+	// They stay merged because separating them is an enumeration oracle: a
+	// caller trying strings could tell "this code does not exist" from "this
+	// code exists but has expired", and the second answer confirms a real
+	// code for free. Nothing a merchant can act on is lost — either way the
+	// code they hold will not work and retyping it will not help.
+	//
+	// Every other reason below is safe to return because it is a fact about
+	// the caller's OWN subscription (plan, billing period, currency, price
+	// floor) or their own prior use of the code. None of them confirms
+	// anything about a code the caller has not already been given.
+	PublicReasonInvalidOrExpired PublicRejectReason = "invalid_or_expired"
+
+	PublicReasonMaxRedemptions     PublicRejectReason = "max_redemptions_reached"
+	PublicReasonMaxPerEmail        PublicRejectReason = "max_per_email_reached"
+	PublicReasonWrongPlan          PublicRejectReason = "wrong_plan"
+	PublicReasonAnnualOnly         PublicRejectReason = "annual_only"
+	PublicReasonBelowFloor         PublicRejectReason = "below_absolute_floor"
+	PublicReasonCurrencyNotCovered PublicRejectReason = "currency_not_covered"
+	PublicReasonUnknownDiscount    PublicRejectReason = "unknown_discount_type"
+)
+
+// PublicReasonFor maps an internal reason onto the one the client is told.
+//
+// The switch is written out in full rather than as a passthrough with two
+// special cases, so that adding a tenth ValidationRejectReason forces an
+// explicit decision here about whether it is safe to disclose. The default
+// arm is the safe answer, not the common one: an unrecognised reason — and
+// the empty reason, which means the failure was not a validation failure at
+// all — discloses nothing.
+func PublicReasonFor(r ValidationRejectReason) PublicRejectReason {
+	switch r {
+	case RejectReasonNotFound, RejectReasonExpired:
+		return PublicReasonInvalidOrExpired
+	case RejectReasonMaxRedemptions:
+		return PublicReasonMaxRedemptions
+	case RejectReasonMaxPerEmail:
+		return PublicReasonMaxPerEmail
+	case RejectReasonWrongPlan:
+		return PublicReasonWrongPlan
+	case RejectReasonAnnualOnly:
+		return PublicReasonAnnualOnly
+	case RejectReasonBelowFloor:
+		return PublicReasonBelowFloor
+	case RejectReasonCurrencyNotCovered:
+		return PublicReasonCurrencyNotCovered
+	case RejectReasonUnknownDiscountType:
+		return PublicReasonUnknownDiscount
+	default:
+		return PublicReasonInvalidOrExpired
+	}
+}

--- a/services/marketplace-api/internal/promo/public_reason_test.go
+++ b/services/marketplace-api/internal/promo/public_reason_test.go
@@ -1,0 +1,101 @@
+package promo_test
+
+import (
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/promo"
+)
+
+// allInternalReasons is every ValidationRejectReason the validator can
+// produce. Listed by hand: a new constant added to validator.go without a
+// line here is caught by TestPublicReasonFor_CoversEveryInternalReason below,
+// which counts them.
+var allInternalReasons = []promo.ValidationRejectReason{
+	promo.RejectReasonNotFound,
+	promo.RejectReasonExpired,
+	promo.RejectReasonMaxRedemptions,
+	promo.RejectReasonMaxPerEmail,
+	promo.RejectReasonWrongPlan,
+	promo.RejectReasonAnnualOnly,
+	promo.RejectReasonBelowFloor,
+	promo.RejectReasonCurrencyNotCovered,
+	promo.RejectReasonUnknownDiscountType,
+}
+
+// TestPublicReasonFor_NotFoundAndExpiredCollapse is the enumeration-oracle
+// guard. If these two ever return different public reasons, a caller trying
+// strings can tell a real code from a made-up one.
+func TestPublicReasonFor_NotFoundAndExpiredCollapse(t *testing.T) {
+	notFound := promo.PublicReasonFor(promo.RejectReasonNotFound)
+	expired := promo.PublicReasonFor(promo.RejectReasonExpired)
+
+	if notFound != expired {
+		t.Fatalf("not_found → %q and expired → %q must be indistinguishable to a client",
+			notFound, expired)
+	}
+	if notFound != promo.PublicReasonInvalidOrExpired {
+		t.Errorf("collapsed reason = %q, want %q", notFound, promo.PublicReasonInvalidOrExpired)
+	}
+}
+
+// TestPublicReasonFor_SevenReasonsStayDistinct is the other half. Collapsing
+// is a security decision made for exactly one pair; every other reason must
+// survive the trip to the client, because each one is a different sentence a
+// merchant can act on. A regression that widened the collapse — say, mapping
+// below_absolute_floor back onto invalid_or_expired — would restore the
+// support ticket this endpoint's response was changed to prevent.
+func TestPublicReasonFor_SevenReasonsStayDistinct(t *testing.T) {
+	distinct := []promo.ValidationRejectReason{
+		promo.RejectReasonMaxRedemptions,
+		promo.RejectReasonMaxPerEmail,
+		promo.RejectReasonWrongPlan,
+		promo.RejectReasonAnnualOnly,
+		promo.RejectReasonBelowFloor,
+		promo.RejectReasonCurrencyNotCovered,
+		promo.RejectReasonUnknownDiscountType,
+	}
+
+	seen := map[promo.PublicRejectReason]promo.ValidationRejectReason{}
+	for _, internal := range distinct {
+		public := promo.PublicReasonFor(internal)
+		if public == promo.PublicReasonInvalidOrExpired {
+			t.Errorf("%s collapsed into %q — it is a fact about the caller's own subscription and must reach them",
+				internal, public)
+			continue
+		}
+		if prev, dup := seen[public]; dup {
+			t.Errorf("%s and %s both map to %q — the client cannot tell them apart",
+				prev, internal, public)
+			continue
+		}
+		seen[public] = internal
+	}
+}
+
+// TestPublicReasonFor_UnknownReasonDisclosesNothing pins the default arm.
+// An empty reason means the refusal was not a validation refusal at all.
+func TestPublicReasonFor_UnknownReasonDisclosesNothing(t *testing.T) {
+	for _, r := range []promo.ValidationRejectReason{"", "something_new"} {
+		if got := promo.PublicReasonFor(r); got != promo.PublicReasonInvalidOrExpired {
+			t.Errorf("PublicReasonFor(%q) = %q, want %q", r, got, promo.PublicReasonInvalidOrExpired)
+		}
+	}
+}
+
+// TestPublicReasonFor_CoversEveryInternalReason fails when a tenth internal
+// reason is added without deciding whether it is safe to disclose. It cannot
+// see the new constant directly, so it asserts the count it was written
+// against — the failure message says what to do.
+func TestPublicReasonFor_CoversEveryInternalReason(t *testing.T) {
+	const knownReasonCount = 9
+	if len(allInternalReasons) != knownReasonCount {
+		t.Fatalf("allInternalReasons has %d entries, want %d — a reason was added or removed in validator.go; "+
+			"add it here AND to the switch in PublicReasonFor, deciding whether it is safe to disclose",
+			len(allInternalReasons), knownReasonCount)
+	}
+	for _, r := range allInternalReasons {
+		if promo.PublicReasonFor(r) == "" {
+			t.Errorf("PublicReasonFor(%q) returned the empty reason", r)
+		}
+	}
+}

--- a/services/marketplace-api/internal/promo/validator.go
+++ b/services/marketplace-api/internal/promo/validator.go
@@ -32,8 +32,12 @@ type ValidationInput struct {
 	Currency string
 }
 
-// ValidationRejectReason records the internal reason for audit events.
-// Never sent to the HTTP client — the external response is always ErrInvalidOrExpired.
+// ValidationRejectReason records the precise reason for audit events. It is
+// the internal record and stays complete: not_found and expired remain
+// separate here even though a client is told the same thing for both.
+//
+// It is never returned to a client as-is. PublicReasonFor (public_reason.go)
+// decides what leaves the server; go through it rather than casting.
 type ValidationRejectReason string
 
 const (


### PR DESCRIPTION
Closes #770. `apply-promo` was implemented, validated, audited and tested — with no caller in `apps/`. A merchant given a code had nowhere to type it.

Three parts: the server can now say **why** a code was refused, merchants have a field, and the win-back email can finally name where to use it.

## 1. The reason leaves the server

Nine internal rejection reasons existed; the handler passed them to **audit only** and collapsed every refusal to `promo_invalid_or_expired`. No UI could render useful copy, however well written.

`internal/promo/public_reason.go` adds `PublicRejectReason` as a **distinct type** from `ValidationRejectReason`, mapped by `PublicReasonFor` — a full switch with no passthrough, so a tenth internal reason forces an explicit disclose/don't-disclose decision rather than leaking by default. The default arm is the safe answer, not the common one.

**`not_found` and `expired` stay collapsed** into `invalid_or_expired`. Distinguishing them hands anyone typing codes a free enumeration oracle. The other seven are facts about the caller's own subscription or their own prior use, and reach them. **The audit emit is unchanged** and still records the precise internal reason — different threat model, and the comment says so, because a collapse looks like sloppiness otherwise.

Two comments that had become false are corrected: `ValidationRejectReason`'s "never sent to the HTTP client", and `ErrInvalidOrExpired`'s doc.

## 2. The per-email cap now counts against the store's own address

**The `email` body field is removed.** It was `binding:"required"`, so this is a breaking request change — safe only because the endpoint has no callers, which is the issue.

The attack it closes is not cap evasion, it is denial: `Redemption` has a unique index on `(promo_code_id, email)`, so submitting `victim@example.com` writes a row under their address, and with `max_per_email = 1` on both campaign codes **their own redemption is then permanently refused**.

The decisive argument is consistency rather than the attack: both other callers already use the subscription's address — `cancel.applySaveOfferDiscount` and the win-back's `offerFor`. The win-back *validates against `sub.Email` before it states the offer*, so booking a redemption against a session address would let the email promise a code this endpoint then refuses.

Resolution order is `sub.Email` → session `user_email` → 422. It deliberately cannot fall back to `""`, which would be one shared bucket every address-less store counted redemptions in.

## 3. Copy that says what actually happened

Five of the nine reasons mean **the code is fine**: `below_absolute_floor` (valid, but breaches the floor for this plan and currency), `max_redemptions_reached` (real offer, now fully claimed), `max_per_email_reached`, and `wrong_plan` / `annual_only` — the last two actionable, and the copy says which change would work.

Transport failures are kept separate: `applyPromo` throws `PromoRejectedError` only for a 422. A 402, 500 or network failure stays `ApiError` and renders "we could not reach billing — your code has not been used", not "your code is invalid".

Success states duration and price, and never says "today": `AddSubscriptionDiscount` only attaches a coupon to `subscription.discounts` — nothing re-bills the current period — so the copy says **next invoice**. A test asserts it contains neither "today" nor "immediately".

## A correction to the brief that changed the design

I was told the response could not carry duration. It can: `promo.ApplyOutput` has had `PercentOffBps` and `MaxDurationMonths` since #769's `terms()` helper, and the handler was simply discarding them. Both are now surfaced, degrading honestly — no bound or a flat amount shows price only, and `max_duration_months: 0` reads as "no bound stated", never "zero months".

`currency` was added to the response too, unasked and load-bearing: `billing_currency` is not populated by the Go subscription DTO and `toCurrentPlan` defaults the gap to `USD`, so formatting client-side would print an INR price with a dollar sign.

## Placement

Billing settings only, above the invoice table. Not the cancel flow — the save offer redeems *for* the merchant automatically and never asks them to type anything.

Reachability from a cold win-back email is proven rather than assumed: `readonly.DefaultAllowlist` allowlists `POST /admin/stores/:storeId/subscription/*path` in every read-only state, so an expired recipient can load billing and POST.

Commit `6d33fdcd` restores the sentence naming the field. Its previous comment said it deliberately would not name a screen "because apply-promo has no caller in apps/ — whoever authors the code owns closing that gap first". That is this PR.

## Mutation testing

Copy mapping — collapsing `below_absolute_floor` into `invalidOrExpired`, and `annual_only` into `maxRedemptionsReached` — each failed 2 tests naming the exact confusion.

Go mapping — collapsing `below_absolute_floor`, merging `annual_only` into `wrong_plan`, and splitting `not_found` from `expired` — each failed with the reason spelled out, including *"not_found and expired must be indistinguishable to a client"*.

## Test plan

- [x] `gofmt -l`, `go build ./...`, `go vet ./...` and `-tags integration`, `go test ./...`, `-race` on promo / handlers/admin / email / subscription
- [x] `PublicReasonFor` tests named in `-v`, including `CoversEveryInternalReason`
- [x] `tsc --noEmit` clean; `next build` compiles and lists the new proxy route
- [x] 31 promo frontend tests, all named
- [x] The 2 failures in `appCredentials.test.ts` confirmed **pre-existing** by stashing and re-running at HEAD — checked because this PR modifies `lib/api/client.ts`, which that test constructs `ApiError` from
- [ ] **The 4 Go integration tests have never executed** — Docker was unavailable, so they skipped on `TEST_DATABASE_URL`. CI's `Integration (marketplace-api)` job is the gate. `IgnoresBodySuppliedEmail` is the one proving the security fix.

## Found, not fixed

`internal/ratelimit/promo.go` is **dead code**: `PromoPerIP` (5/hr) and `PromoPerEmail` (10/24h) exist, are documented as §7.3 abuse prevention, and are wired into no route. This PR ships the first real UI for guessing codes at, so that gate probably wants turning on — left out as a behaviour change beyond this scope. Note `PromoPerEmail`'s doc claims it reads a JSON body `email`; it reads only a header or query param, and after this change there is no body email to read.

Also fixed in passing: the handler dereferenced `sub.Plan` immediately after an `if sub != nil` guard. Unreachable today, but it now has an explicit nil check since the code reads `sub.Email`.
