### PR TITLE
fix(billing): turn on the promo abuse limits, keyed on the tenant now the email no longer arrives

### DIFF
--- a/services/marketplace-api/internal/handlers/admin/promo_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/promo_integration_test.go
@@ -211,3 +211,39 @@ func TestPromoApply_AbovePriceFloor_USD(t *testing.T) {
 		t.Errorf("percent_off_bps = %v, want 2000", got)
 	}
 }
+
+// TestPromoApply_RateLimiterIsActuallyWired proves the §7.3 limiters reach the
+// route, not merely that they work in isolation.
+//
+// The unit tests in internal/ratelimit exercise the middleware directly and
+// would pass with it wired to nothing — which is exactly the state it sat in
+// from the day it was written until mark8ly#773 gave merchants a field to type
+// codes into. A limiter that is never mounted reads as protection and provides
+// none, and nothing in the package could tell you.
+//
+// PromoPerIP is the tighter of the two (burst 5, vs 10 per tenant), so it trips
+// first. httptest gives every request the same RemoteAddr, so all six share a
+// bucket. The status codes before the 6th are deliberately not asserted: what
+// the handler makes of an unseeded code is another test's business, and pinning
+// it here would couple this to promo validation.
+func TestPromoApply_RateLimiterIsActuallyWired(t *testing.T) {
+	env := setupTestRouter(t)
+	storeID, tenantID := seedStoreRow(t, env.db, "")
+	userID := uuid.NewString()
+	env.fga.Grant(userID, authz.RoleOwner, tenantID)
+	seedSubscriptionForPromoTest(t, env.db, storeID, tenantID, "starter", "usd")
+
+	body := map[string]any{"code": "NOPE"}
+	for i := 0; i < 5; i++ {
+		w := request(t, env.router, http.MethodPost, promoApplyURL(storeID), body, authHeaders(userID, tenantID))
+		if w.Code == http.StatusTooManyRequests {
+			t.Fatalf("request %d was throttled inside the burst of 5", i)
+		}
+	}
+
+	w := request(t, env.router, http.MethodPost, promoApplyURL(storeID), body, authHeaders(userID, tenantID))
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("6th request: expected 429 from PromoPerIP, got %d — the limiter is not on the route; body: %s",
+			w.Code, w.Body.String())
+	}
+}

--- a/services/marketplace-api/internal/handlers/admin/routes.go
+++ b/services/marketplace-api/internal/handlers/admin/routes.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/billing/migration"
 	"github.com/mark8ly/marketplace-api/internal/handlers/internalsvc"
 	"github.com/mark8ly/marketplace-api/internal/plangate"
+	"github.com/mark8ly/marketplace-api/internal/ratelimit"
 	"github.com/mark8ly/marketplace-api/internal/subscription/cancel"
 )
 
@@ -772,8 +773,20 @@ func RegisterAdmin(router *gin.RouterGroup, deps Deps) {
 
 				// P10 — promo-code engine (§7).
 				if deps.PromoHandler != nil {
+					// §7.3 abuse prevention. These were written with the engine
+					// and wired to nothing until mark8ly#773 gave merchants a
+					// field to type codes into — which is also the first thing
+					// that makes guessing codes worth doing.
+					//
+					// IP first, so an unauthenticated flood is shed before the
+					// authz round-trip. Tenant second, because it keys on
+					// `tenant_id`, which tenantMW sets upstream in storeMW.
+					// Both are per-pod and in-memory; see the package docs for
+					// why that is accepted here.
 					sub.POST("/apply-promo",
+						ratelimit.PromoPerIP(),
 						deps.AuthzMiddleware.RequireTenantRelation(authz.SubscriptionEditRole),
+						ratelimit.PromoPerTenant(),
 						deps.PromoHandler.ApplyPromo)
 					sub.DELETE("/promo",
 						deps.AuthzMiddleware.RequireTenantRelation(authz.SubscriptionEditRole),

--- a/services/marketplace-api/internal/ratelimit/promo.go
+++ b/services/marketplace-api/internal/ratelimit/promo.go
@@ -13,6 +13,11 @@ import (
 // PromoPerIP returns a Gin middleware that limits promo-apply requests per
 // client IP: 5 requests per hour with a burst of 5 (§7.3 abuse prevention,
 // pattern H). Uses the same in-memory token bucket as PerIP; no Redis.
+//
+// In-memory means PER POD. With N replicas the effective ceiling is N times
+// this, and a rollout resets every bucket. That is accepted: this is a brake
+// on code-guessing, not an accounting control, and the codes it protects are
+// additionally bounded by max_redemptions on the row itself.
 func PromoPerIP() gin.HandlerFunc {
 	// 5/hour = 5/(3600s) ≈ 0.00139 rps, burst=5
 	const rps = 5.0 / 3600.0
@@ -22,21 +27,37 @@ func PromoPerIP() gin.HandlerFunc {
 	})
 }
 
-// PromoPerEmail returns a Gin middleware that limits promo-apply requests per
-// merchant email address: 10 requests per 24 hours with a burst of 10
-// (§7.3 abuse prevention, pattern H). The email is read from the "email"
-// query param or the JSON body field "email"; callers may also set the
-// "X-Merchant-Email" header as a fallback.
-func PromoPerEmail() gin.HandlerFunc {
+// PromoPerTenant returns a Gin middleware that limits promo-apply requests per
+// tenant: 10 requests per 24 hours with a burst of 10 (§7.3 abuse prevention,
+// pattern H).
+//
+// # It was PromoPerEmail, and keyed on an address that no longer arrives
+//
+// The previous version read the caller's email from an "X-Merchant-Email"
+// header or an "email" query param — while its own doc claimed it also read a
+// JSON body field of that name, which it never did. mark8ly#773 then removed
+// the request body's `email` entirely, so the merchant's address stops at the
+// handler, which resolves it from the subscription row.
+//
+// That left nothing for this limiter to key on. buildKeyedLimiter SKIPS a
+// request whose key is empty, so wiring the old version would not have
+// throttled anything — it would have been a middleware that reads as
+// protection and enforces none. That failure is silent by construction, which
+// is why this is a rename rather than a tweak: the name now matches what it
+// can actually see.
+//
+// `tenant_id` is set by tenantMW, which is part of storeMW on
+// /admin/stores/:storeId — so it is present for every route this can guard.
+// A request that somehow lacks it is skipped rather than lumped into one
+// shared bucket, which is the same fail-open choice buildKeyedLimiter makes
+// and the right one: an unkeyed request is unattributable, and throttling all
+// of them together would let one caller starve everyone else.
+func PromoPerTenant() gin.HandlerFunc {
 	// 10/24h = 10/86400s ≈ 0.0001157 rps, burst=10
 	const rps = 10.0 / 86400.0
 	const burst = 10
-	return buildKeyedLimiter("promo:email:", rps, burst, func(c *gin.Context) string {
-		email := strings.ToLower(strings.TrimSpace(c.GetHeader("X-Merchant-Email")))
-		if email == "" {
-			email = strings.ToLower(strings.TrimSpace(c.Query("email")))
-		}
-		return email
+	return buildKeyedLimiter("promo:tenant:", rps, burst, func(c *gin.Context) string {
+		return strings.ToLower(strings.TrimSpace(c.GetString("tenant_id")))
 	})
 }
 

--- a/services/marketplace-api/internal/ratelimit/promo_test.go
+++ b/services/marketplace-api/internal/ratelimit/promo_test.go
@@ -1,0 +1,89 @@
+package ratelimit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// routerWithTenant builds a router that stamps tenantID into the context the
+// way tenantMW does upstream, then applies PromoPerTenant.
+func routerWithTenant(tenantID string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if tenantID != "" {
+			c.Set("tenant_id", tenantID)
+		}
+		c.Next()
+	})
+	r.Use(PromoPerTenant())
+	r.POST("/apply-promo", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+	return r
+}
+
+func postN(t *testing.T, r *gin.Engine, n int) []int {
+	t.Helper()
+	codes := make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/apply-promo", nil)
+		req.RemoteAddr = "1.2.3.4:12345"
+		r.ServeHTTP(w, req)
+		codes = append(codes, w.Code)
+	}
+	return codes
+}
+
+func TestPromoPerTenant_BlocksOverTheBurst(t *testing.T) {
+	r := routerWithTenant("tenant-a")
+	codes := postN(t, r, 11)
+
+	for i, c := range codes[:10] {
+		if c != http.StatusOK {
+			t.Fatalf("request %d within burst: expected 200, got %d", i, c)
+		}
+	}
+	if codes[10] != http.StatusTooManyRequests {
+		t.Fatalf("11th request: expected 429, got %d", codes[10])
+	}
+}
+
+func TestPromoPerTenant_OneTenantCannotExhaustAnother(t *testing.T) {
+	// THE ROW THIS EXISTS FOR. The limiter it replaced keyed on an email
+	// address that mark8ly#773 stopped sending, so every request would have
+	// carried the same empty key. Had buildKeyedLimiter bucketed those
+	// together rather than skipping them, one merchant's retries would lock
+	// out every other merchant.
+	shared := PromoPerTenant()
+	build := func(tenantID string) *gin.Engine {
+		gin.SetMode(gin.TestMode)
+		r := gin.New()
+		r.Use(func(c *gin.Context) { c.Set("tenant_id", tenantID); c.Next() })
+		r.Use(shared)
+		r.POST("/apply-promo", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+		return r
+	}
+
+	if got := postN(t, build("tenant-a"), 11); got[10] != http.StatusTooManyRequests {
+		t.Fatalf("tenant-a should be exhausted: got %d", got[10])
+	}
+	// Same middleware instance, different tenant: unaffected.
+	if got := postN(t, build("tenant-b"), 1); got[0] != http.StatusOK {
+		t.Fatalf("tenant-b must not inherit tenant-a's bucket: got %d", got[0])
+	}
+}
+
+func TestPromoPerTenant_NoTenantIsSkippedNotShared(t *testing.T) {
+	// An unattributable request is let through rather than counted into one
+	// global bucket. Bucketing them together would let a single unkeyed caller
+	// starve every other unkeyed caller, which is worse than not limiting.
+	r := routerWithTenant("")
+	for i, c := range postN(t, r, 15) {
+		if c != http.StatusOK {
+			t.Fatalf("request %d with no tenant_id: expected 200 (skipped), got %d", i, c)
+		}
+	}
+}


### PR DESCRIPTION
`internal/ratelimit/promo.go` defined §7.3 abuse limits for the promo endpoint and was **wired to no route**. Found while shipping #773, which gave merchants the first real UI to type codes into — and therefore the first reason for anyone to guess them.

## The email limiter could not have worked

`PromoPerEmail` keyed on an address read from an `X-Merchant-Email` header or an `?email=` query param. Its own doc also claimed it read a JSON body field `email` — **it never did**.

#773 then removed the request body's `email` entirely, because a client-chosen address could book a redemption under someone else's name and burn their `max_per_email`. So no email reaches this middleware by any route.

`buildKeyedLimiter` **skips** a request whose key is empty. So wiring it as written would not have throttled anything — a middleware that reads as protection and enforces none, failing silently by construction.

Renamed to `PromoPerTenant` and keyed on `tenant_id`, which `tenantMW` sets upstream in `storeMW`, so it is present for every route this can guard. The rename is the point: the name now matches what it can actually see.

## Wiring

```go
sub.POST("/apply-promo",
    ratelimit.PromoPerIP(),
    deps.AuthzMiddleware.RequireTenantRelation(authz.SubscriptionEditRole),
    ratelimit.PromoPerTenant(),
    deps.PromoHandler.ApplyPromo)
```

IP first, so an unauthenticated flood is shed before the authz round-trip. Tenant second, because it needs the context the auth chain populates.

`DELETE /promo` is left alone — it cancels a discount the merchant already holds, and is not a guessing surface.

## Two properties worth stating

**Unkeyed requests are skipped, not pooled.** An unattributable request is let through rather than counted into one shared bucket. Bucketing them would let a single unkeyed caller starve every other one, which is worse than not limiting. `TestPromoPerTenant_NoTenantIsSkippedNotShared` pins it.

**These are per-pod and in-memory.** With N replicas the real ceiling is N times the stated one, and a rollout resets every bucket. Accepted and now written in the package doc: this is a brake on code-guessing, not an accounting control, and the codes it protects are additionally bounded by `max_redemptions` on the row.

## Tests

Three unit tests on the limiter, and — the one that matters — `TestPromoApply_RateLimiterIsActuallyWired`, an integration test that fires six requests at the real router built by `admin.RegisterAdmin` and expects the sixth to be 429.

The unit tests would pass with the middleware wired to nothing, which is precisely the state this package sat in since it was written. That is the supply-vs-apply gap, and only a route-level test closes it.

**Mutation-verified.** Keying on a constant instead of the tenant fails `OneTenantCannotExhaustAnother` and `NoTenantIsSkippedNotShared`, and leaves `BlocksOverTheBurst` passing — the burst test alone cannot see the bug. (A first attempt returning `""` only broke the build by orphaning an import; a mutation that reddens everything is a syntax error, not a coverage signal.)

## Test plan

- [x] `gofmt -l` clean, `go build ./...`, `go vet ./...` and `-tags=integration`
- [x] `go test ./internal/ratelimit/ ./internal/handlers/admin/` pass
- [x] Mutation check kills exactly the two tests that should die
- [ ] **`TestPromoApply_RateLimiterIsActuallyWired` has not run locally** — it needs a real Postgres and Docker was unavailable. CI's `Integration (marketplace-api)` job is the gate, as it was for #773.

## Note for whoever tunes these

5/hour per IP and 10/24h per tenant come from §7.3 as originally written, and have never been exercised against real traffic. A merchant legitimately retrying a code they mistyped could plausibly hit five in an hour. Worth watching the 429 rate once `WINBACK20OFF6MONTHS` is authored and merchants actually arrive with codes.
