### PR TITLE
test(billing): run the 22 integration tests that never ran

### DIFF
--- a/services/marketplace-api/internal/billing/trial/activation_cron_integration_test.go
+++ b/services/marketplace-api/internal/billing/trial/activation_cron_integration_test.go
@@ -4,6 +4,7 @@ package trial_test
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/billing/trial"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
 // newActivationCounter creates an unregistered prometheus counter safe for test use.
@@ -33,11 +35,11 @@ func activationCounterValue(c prometheus.Counter) float64 {
 // at exactly day 30 with one product and asserts the counter increments and the
 // row is stamped.
 func TestActivationCron_IncrementsForStoreWithProductAtDay30(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "products", "vendors", "store_subscriptions", "stores")
 	now := time.Date(2026, 9, 1, 0, 30, 0, 0, time.UTC)
 	day30 := now.AddDate(0, 0, -30)
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_act_day30",
 		Status:             subscription.StatusTrialing,
 		Plan:               subscription.PlanTrial,
@@ -48,9 +50,10 @@ func TestActivationCron_IncrementsForStoreWithProductAtDay30(t *testing.T) {
 
 	productID := uuid.New()
 	require.NoError(t, db.Exec(`
-		INSERT INTO products (id, tenant_id, store_id, handle, title, status, tags, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, '{}', now(), now())`,
-		productID, row.TenantID, row.StoreID, "act-product-day30", "Test Product", "active",
+		INSERT INTO products (id, tenant_id, store_id, vendor_id, handle, title, status, published_at, tags, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, now(), '{}', now(), now())`,
+		productID, row.TenantID, row.StoreID, testdb.SeedVendor(t, db, row.TenantID),
+		"act-product-day30", "Test Product", "active",
 	).Error)
 	t.Cleanup(func() { db.Exec("DELETE FROM products WHERE id = ?", productID) })
 
@@ -60,21 +63,25 @@ func TestActivationCron_IncrementsForStoreWithProductAtDay30(t *testing.T) {
 
 	assert.Equal(t, float64(1), activationCounterValue(counter), "counter must increment once")
 
-	var markedAt *time.Time
+	// sql.NullTime, not *time.Time: GORM's Raw().Scan() into a bare *time.Time
+	// errors ("unsupported Scan ... storing driver.Value type <nil>") the
+	// moment the column is NULL — the same trap documented at
+	// internal/billing/migration/repository_integration_test.go:177.
+	var markedAt sql.NullTime
 	require.NoError(t, db.Raw(
 		"SELECT trial_activation_marked_at FROM store_subscriptions WHERE id = ?", row.ID,
 	).Scan(&markedAt).Error)
-	assert.NotNil(t, markedAt, "trial_activation_marked_at must be stamped")
+	assert.True(t, markedAt.Valid, "trial_activation_marked_at must be stamped")
 }
 
 // TestActivationCron_SkipsStoreWithoutProducts seeds a day-30 trialing store with
 // no products and asserts the counter stays 0 and no mark is set.
 func TestActivationCron_SkipsStoreWithoutProducts(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "products", "vendors", "store_subscriptions", "stores")
 	now := time.Date(2026, 9, 2, 0, 30, 0, 0, time.UTC)
 	day30 := now.AddDate(0, 0, -30)
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_act_noproduct",
 		Status:             subscription.StatusTrialing,
 		Plan:               subscription.PlanTrial,
@@ -89,22 +96,24 @@ func TestActivationCron_SkipsStoreWithoutProducts(t *testing.T) {
 
 	assert.Equal(t, float64(0), activationCounterValue(counter), "counter must not increment for store with no products")
 
-	var markedAt *time.Time
+	// sql.NullTime for the same reason as above; this is the NULL branch that
+	// makes a *time.Time destination fail outright rather than assert.
+	var markedAt sql.NullTime
 	require.NoError(t, db.Raw(
 		"SELECT trial_activation_marked_at FROM store_subscriptions WHERE id = ?", row.ID,
 	).Scan(&markedAt).Error)
-	assert.Nil(t, markedAt, "trial_activation_marked_at must not be set for store with no products")
+	assert.False(t, markedAt.Valid, "trial_activation_marked_at must not be set for store with no products")
 }
 
 // TestActivationCron_SkipsAlreadyMarkedStore seeds a day-30 trialing store that
 // already has trial_activation_marked_at stamped and asserts the counter stays 0.
 func TestActivationCron_SkipsAlreadyMarkedStore(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "products", "vendors", "store_subscriptions", "stores")
 	now := time.Date(2026, 9, 3, 0, 30, 0, 0, time.UTC)
 	day30 := now.AddDate(0, 0, -30)
 	alreadyMarked := now.Add(-time.Hour)
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:        "cus_act_marked",
 		Status:                  subscription.StatusTrialing,
 		Plan:                    subscription.PlanTrial,
@@ -116,9 +125,10 @@ func TestActivationCron_SkipsAlreadyMarkedStore(t *testing.T) {
 
 	productID := uuid.New()
 	require.NoError(t, db.Exec(`
-		INSERT INTO products (id, tenant_id, store_id, handle, title, status, tags, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, '{}', now(), now())`,
-		productID, row.TenantID, row.StoreID, "act-product-marked", "Test Product", "active",
+		INSERT INTO products (id, tenant_id, store_id, vendor_id, handle, title, status, published_at, tags, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, now(), '{}', now(), now())`,
+		productID, row.TenantID, row.StoreID, testdb.SeedVendor(t, db, row.TenantID),
+		"act-product-marked", "Test Product", "active",
 	).Error)
 	t.Cleanup(func() { db.Exec("DELETE FROM products WHERE id = ?", productID) })
 
@@ -132,11 +142,11 @@ func TestActivationCron_SkipsAlreadyMarkedStore(t *testing.T) {
 // TestActivationCron_SkipsNonTrialingStore seeds a day-30 store in "active"
 // status with a product and asserts the counter stays 0.
 func TestActivationCron_SkipsNonTrialingStore(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "products", "vendors", "store_subscriptions", "stores")
 	now := time.Date(2026, 9, 4, 0, 30, 0, 0, time.UTC)
 	day30 := now.AddDate(0, 0, -30)
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_act_active",
 		Status:             subscription.StatusActive,
 		Plan:               subscription.PlanStarter,
@@ -147,9 +157,10 @@ func TestActivationCron_SkipsNonTrialingStore(t *testing.T) {
 
 	productID := uuid.New()
 	require.NoError(t, db.Exec(`
-		INSERT INTO products (id, tenant_id, store_id, handle, title, status, tags, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, '{}', now(), now())`,
-		productID, row.TenantID, row.StoreID, "act-product-active", "Test Product", "active",
+		INSERT INTO products (id, tenant_id, store_id, vendor_id, handle, title, status, published_at, tags, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, now(), '{}', now(), now())`,
+		productID, row.TenantID, row.StoreID, testdb.SeedVendor(t, db, row.TenantID),
+		"act-product-active", "Test Product", "active",
 	).Error)
 	t.Cleanup(func() { db.Exec("DELETE FROM products WHERE id = ?", productID) })
 
@@ -163,11 +174,11 @@ func TestActivationCron_SkipsNonTrialingStore(t *testing.T) {
 // TestActivationCron_Idempotent_SecondRunNoop runs the cron twice for the same
 // qualifying store and asserts the counter increments exactly once total.
 func TestActivationCron_Idempotent_SecondRunNoop(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "products", "vendors", "store_subscriptions", "stores")
 	now := time.Date(2026, 9, 5, 0, 30, 0, 0, time.UTC)
 	day30 := now.AddDate(0, 0, -30)
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_act_idem",
 		Status:             subscription.StatusTrialing,
 		Plan:               subscription.PlanTrial,
@@ -178,9 +189,10 @@ func TestActivationCron_Idempotent_SecondRunNoop(t *testing.T) {
 
 	productID := uuid.New()
 	require.NoError(t, db.Exec(`
-		INSERT INTO products (id, tenant_id, store_id, handle, title, status, tags, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, '{}', now(), now())`,
-		productID, row.TenantID, row.StoreID, "act-product-idem", "Test Product", "active",
+		INSERT INTO products (id, tenant_id, store_id, vendor_id, handle, title, status, published_at, tags, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, now(), '{}', now(), now())`,
+		productID, row.TenantID, row.StoreID, testdb.SeedVendor(t, db, row.TenantID),
+		"act-product-idem", "Test Product", "active",
 	).Error)
 	t.Cleanup(func() { db.Exec("DELETE FROM products WHERE id = ?", productID) })
 

--- a/services/marketplace-api/internal/billing/trial/banner_cron_integration_test.go
+++ b/services/marketplace-api/internal/billing/trial/banner_cron_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/billing/trial"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
 // fixedClock returns a clock func that always returns t.
@@ -21,14 +22,14 @@ func fixedClock(t time.Time) func() time.Time { return func() time.Time { return
 // 59, 60, and 61 relative to "now", runs the cron, and asserts only the
 // day-60 row advances to "day_60".
 func TestBannerCron_SetsDay60State_SkipsOtherDays(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
 	now := time.Date(2026, 3, 1, 9, 0, 0, 0, time.UTC)
 
 	day60 := now.AddDate(0, 0, -60)
 	day59 := now.AddDate(0, 0, -59)
 	day61 := now.AddDate(0, 0, -61)
 
-	rowAt60 := seedSubscription(t, db, subscription.StoreSubscription{
+	rowAt60 := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_banner_60",
 		Status:             subscription.StatusTrialing,
 		Plan:               subscription.PlanTrial,
@@ -36,7 +37,7 @@ func TestBannerCron_SetsDay60State_SkipsOtherDays(t *testing.T) {
 		PriceTier:          subscription.PriceTierDeveloped,
 		CreatedAt:          day60,
 	})
-	rowAt59 := seedSubscription(t, db, subscription.StoreSubscription{
+	rowAt59 := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_banner_59",
 		Status:             subscription.StatusTrialing,
 		Plan:               subscription.PlanTrial,
@@ -44,7 +45,7 @@ func TestBannerCron_SetsDay60State_SkipsOtherDays(t *testing.T) {
 		PriceTier:          subscription.PriceTierDeveloped,
 		CreatedAt:          day59,
 	})
-	rowAt61 := seedSubscription(t, db, subscription.StoreSubscription{
+	rowAt61 := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_banner_61",
 		Status:             subscription.StatusTrialing,
 		Plan:               subscription.PlanTrial,
@@ -83,11 +84,11 @@ func TestBannerCron_SetsDay60State_SkipsOtherDays(t *testing.T) {
 // TestBannerCron_Idempotent_SameDay runs the cron twice at the same simulated
 // day and asserts the second run is a no-op (state stays "day_60", not promoted).
 func TestBannerCron_Idempotent_SameDay(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
 	now := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
 	createdAt := now.AddDate(0, 0, -60)
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_idem_60",
 		Status:             subscription.StatusTrialing,
 		Plan:               subscription.PlanTrial,
@@ -115,12 +116,12 @@ func TestBannerCron_Idempotent_SameDay(t *testing.T) {
 // store that already has a Stripe subscription (card added late) is not touched
 // by the banner cron.
 func TestBannerCron_SkipsStoresWithStripeSubscriptionID(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
 	now := time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC)
 	createdAt := now.AddDate(0, 0, -60)
 
 	subID := "sub_already_carded"
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:     "cus_carded",
 		StripeSubscriptionID: &subID,
 		Status:               subscription.StatusTrialing,
@@ -144,11 +145,11 @@ func TestBannerCron_SkipsStoresWithStripeSubscriptionID(t *testing.T) {
 // gets state "day_75" directly, skipping "day_60" entirely, because each query
 // selects only stores whose created_at matches the specific day window.
 func TestBannerCron_AdvancesStateAcrossThresholds(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
 	now := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
 	createdAt := now.AddDate(0, 0, -75)
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_day75",
 		Status:             subscription.StatusTrialing,
 		Plan:               subscription.PlanTrial,

--- a/services/marketplace-api/internal/billing/trial/e2e_deferred_charge_test.go
+++ b/services/marketplace-api/internal/billing/trial/e2e_deferred_charge_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/billing/trial"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
 // TestE2E_Criterion46_CardDay45_ChargeDay90 asserts the spec §28 criterion #46
@@ -25,12 +26,12 @@ import (
 // trial_end against the arithmetic anchor (signup_date + 90d), which must
 // equal (card_add_day + 45d) when the card is added on day 45.
 func TestE2E_Criterion46_CardDay45_ChargeDay90(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
 
 	// Day 0: merchant signs up. CreatedAt stands in for signup_date.
 	day0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_criterion_46",
 		Status:             subscription.StatusSignup,
 		Plan:               subscription.PlanTrial,

--- a/services/marketplace-api/internal/billing/trial/expiry_cron_integration_test.go
+++ b/services/marketplace-api/internal/billing/trial/expiry_cron_integration_test.go
@@ -12,18 +12,19 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/billing/trial"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
 // TestExpiryCron_TransitionsDay90StoresWithoutCard seeds a trialing store
 // whose created_at is 91 days ago (past the 90-day cutoff) and verifies Run
 // transitions it to "expired".
 func TestExpiryCron_TransitionsDay90StoresWithoutCard(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
 	now := time.Date(2026, 7, 1, 0, 15, 0, 0, time.UTC)
 	// 91 days ago — clearly past the cutoff.
 	createdAt := now.AddDate(0, 0, -(trial.TrialDays + 1))
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_expiry_91",
 		Status:             subscription.StatusTrialing,
 		Plan:               subscription.PlanTrial,
@@ -45,12 +46,12 @@ func TestExpiryCron_TransitionsDay90StoresWithoutCard(t *testing.T) {
 // store that already has a Stripe subscription ID (card was added) is not
 // expired by the cron — it will convert to active when Stripe fires invoice.paid.
 func TestExpiryCron_SkipsStoresWithStripeSubscription(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
 	now := time.Date(2026, 7, 2, 0, 15, 0, 0, time.UTC)
 	createdAt := now.AddDate(0, 0, -(trial.TrialDays + 1))
 
 	subID := "sub_has_card"
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:     "cus_expiry_carded",
 		StripeSubscriptionID: &subID,
 		Status:               subscription.StatusTrialing,
@@ -73,11 +74,11 @@ func TestExpiryCron_SkipsStoresWithStripeSubscription(t *testing.T) {
 // twice for the same store produces no error and does not change the status a
 // second time (the state machine guards the trialing → expired transition).
 func TestExpiryCron_Idempotent_SecondRunNoop(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
 	now := time.Date(2026, 7, 3, 0, 15, 0, 0, time.UTC)
 	createdAt := now.AddDate(0, 0, -(trial.TrialDays + 1))
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_expiry_idem",
 		Status:             subscription.StatusTrialing,
 		Plan:               subscription.PlanTrial,

--- a/services/marketplace-api/internal/billing/trial/subscribe_integration_test.go
+++ b/services/marketplace-api/internal/billing/trial/subscribe_integration_test.go
@@ -4,19 +4,18 @@ package trial_test
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
 	"github.com/mark8ly/marketplace-api/internal/billing/trial"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
 // fakeStripe is a test double for trial.StripeAPI that records calls and
@@ -43,18 +42,28 @@ func (f *fakeStripe) PriceIDFor(_ context.Context, _ subscription.SubscriptionPl
 	return f.priceIDResult, f.priceIDErr
 }
 
-// openIntegrationDB connects to the database specified by TEST_DB_DSN.
-// Tests that call this are skipped when the env var is absent.
-func openIntegrationDB(t *testing.T) *gorm.DB {
+// seedStoreAndSubscription seeds the stores row that
+// store_subscriptions_store_id_fkey requires, then the subscription itself.
+//
+// seedSubscription alone cannot be used by a caller that does not seed a
+// store: it invents a store_id when the caller leaves the field zero, and
+// store_subscriptions.store_id has referenced stores(id) since migration
+// 000015, so the INSERT is rejected outright. UNIQUE (store_id) on the same
+// table means each subscription needs its own store, never a shared one.
+//
+// Callers that mint their own ids and seed the store themselves — see
+// subscribe_tenantdiscount_integration_test.go — call seedSubscription
+// directly instead.
+func seedStoreAndSubscription(t *testing.T, db *gorm.DB, row subscription.StoreSubscription) subscription.StoreSubscription {
 	t.Helper()
-	dsn, ok := os.LookupEnv("TEST_DB_DSN")
-	if !ok || dsn == "" {
-		t.Skip("TEST_DB_DSN not set; skipping integration test")
+	if row.TenantID == uuid.Nil {
+		row.TenantID = uuid.New()
 	}
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	require.NoError(t, err, "open integration DB")
-	t.Cleanup(func() { sqlDB, _ := db.DB(); _ = sqlDB.Close() })
-	return db
+	if row.StoreID == uuid.Nil {
+		row.StoreID = uuid.New()
+	}
+	testdb.SeedStore(t, db, row.TenantID, row.StoreID)
+	return seedSubscription(t, db, row)
 }
 
 // seedSubscription inserts a StoreSubscription row and registers cleanup.
@@ -96,10 +105,10 @@ func buildInput(tenantID, storeID uuid.UUID) trial.SubscribeInput {
 // TestSubscribe_TrialEndIsSignupPlus90Days verifies that trial_end equals
 // row.CreatedAt + 90d (the signup_date proxy).
 func TestSubscribe_TrialEndIsSignupPlus90Days(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
 	day0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_abc",
 		Status:             subscription.StatusSignup,
 		Plan:               subscription.PlanTrial,
@@ -122,9 +131,9 @@ func TestSubscribe_TrialEndIsSignupPlus90Days(t *testing.T) {
 // TestSubscribe_PersistsStripeSubscriptionID verifies the DB row is updated
 // with the Stripe subscription ID returned from the API.
 func TestSubscribe_PersistsStripeSubscriptionID(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_abc",
 		Status:             subscription.StatusSignup,
 		Plan:               subscription.PlanTrial,
@@ -151,9 +160,9 @@ func TestSubscribe_PersistsStripeSubscriptionID(t *testing.T) {
 // TestSubscribe_NoImmediateStatusMutation verifies Subscribe does NOT flip
 // subscription.status — the webhook owns that transition.
 func TestSubscribe_NoImmediateStatusMutation(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_abc",
 		Status:             subscription.StatusSignup,
 		Plan:               subscription.PlanTrial,
@@ -174,9 +183,9 @@ func TestSubscribe_NoImmediateStatusMutation(t *testing.T) {
 // TestSubscribe_BlockedWhenAlreadyActive verifies ErrSubscriptionAlreadyActive
 // for stores whose status is already active.
 func TestSubscribe_BlockedWhenAlreadyActive(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_abc",
 		Status:             subscription.StatusActive,
 		Plan:               subscription.PlanStarter,
@@ -192,9 +201,9 @@ func TestSubscribe_BlockedWhenAlreadyActive(t *testing.T) {
 // TestSubscribe_MissingStripeCustomer verifies ErrMissingStripeCustomer when
 // StripeCustomerID is empty.
 func TestSubscribe_MissingStripeCustomer(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "",
 		Status:             subscription.StatusSignup,
 		Plan:               subscription.PlanTrial,
@@ -211,9 +220,9 @@ func TestSubscribe_MissingStripeCustomer(t *testing.T) {
 // the same inputs (and a fake that returns the same sub ID on both calls)
 // produces the same result. This mirrors Stripe's idempotency-key behaviour.
 func TestSubscribe_IdempotentOnReplay(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
 
-	row := seedSubscription(t, db, subscription.StoreSubscription{
+	row := seedStoreAndSubscription(t, db, subscription.StoreSubscription{
 		StripeCustomerID:   "cus_abc",
 		Status:             subscription.StatusSignup,
 		Plan:               subscription.PlanTrial,

--- a/services/marketplace-api/internal/billing/trial/subscribe_tenantdiscount_integration_test.go
+++ b/services/marketplace-api/internal/billing/trial/subscribe_tenantdiscount_integration_test.go
@@ -21,9 +21,11 @@ import (
 // when the subscription is finally created — otherwise the discount silently
 // stops covering the tenant as they grow.
 //
-// These use testdb (TEST_DATABASE_URL) rather than this file's neighbours'
-// openIntegrationDB (TEST_DB_DSN). `make test-int` exports only the former, so
-// a test written against the latter never runs there.
+// These use testdb (TEST_DATABASE_URL), which is what `make test-int` exports.
+// They once stood alone in doing so: the rest of this package opened its own
+// connection from TEST_DB_DSN, a variable no Makefile has ever exported, so
+// nineteen of its tests silently skipped in CI. That harness is now gone and
+// every file here uses testdb.
 
 // stubDiscounter stands in for tenantdiscount.Service at the port trial
 // declares. Hand-rolled per this repository's convention.

--- a/services/marketplace-api/internal/signup/anomaly_cron_integration_test.go
+++ b/services/marketplace-api/internal/signup/anomaly_cron_integration_test.go
@@ -5,19 +5,19 @@ package signup_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/signup"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
 // newTestCounter creates an unregistered prometheus counter safe for test use.
@@ -32,20 +32,6 @@ func testCounterValue(c prometheus.Counter) float64 {
 	return m.GetCounter().GetValue()
 }
 
-// openIntegrationDB connects to the database specified by TEST_DB_DSN.
-// Tests that call this are skipped when the env var is absent.
-func openIntegrationDB(t *testing.T) *gorm.DB {
-	t.Helper()
-	dsn, ok := os.LookupEnv("TEST_DB_DSN")
-	if !ok || dsn == "" {
-		t.Skip("TEST_DB_DSN not set; skipping integration test")
-	}
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	require.NoError(t, err, "open integration DB")
-	t.Cleanup(func() { sqlDB, _ := db.DB(); _ = sqlDB.Close() })
-	return db
-}
-
 // fakeSlack records calls to Send.
 type fakeSlack struct {
 	calls atomic.Int32
@@ -56,25 +42,33 @@ func (f *fakeSlack) Send(_ context.Context, _ string) error {
 	return nil
 }
 
-// seedSignups inserts n store_subscriptions rows with created_at = ts and
-// registers cleanup to delete them. Returns a unique marker stripe_customer_id
-// prefix for isolation.
+// seedSignups inserts n store_subscriptions rows with created_at = ts, each
+// with its own stores parent row.
+//
+// The parent is not optional and cannot be shared. store_subscriptions.store_id
+// has referenced stores(id) since migration 000015, so a synthetic
+// gen_random_uuid() store_id is rejected by store_subscriptions_store_id_fkey;
+// and UNIQUE (store_id) on the same table means n subscriptions need n stores.
+//
+// prefix distinguishes one test's rows from another's in stripe_customer_id.
+// No cleanup is registered here: the caller's testdb.NewDB truncates
+// store_subscriptions, stores and signup_anomaly_log on test completion, and
+// testdb.SeedStore registers its own per-store row and sequence cleanup.
 func seedSignups(t *testing.T, db *gorm.DB, n int, ts time.Time, prefix string) {
 	t.Helper()
 	for i := 0; i < n; i++ {
+		tenantID, storeID := uuid.New(), uuid.New()
+		testdb.SeedStore(t, db, tenantID, storeID)
+
 		err := db.Exec(`
 			INSERT INTO store_subscriptions
 				(id, tenant_id, store_id, stripe_customer_id, plan, status, subscription_period, price_tier, created_at, updated_at)
 			VALUES
-				(gen_random_uuid(), gen_random_uuid(), gen_random_uuid(), ?, 'trial', 'trialing', 'monthly', 'developed', ?, now())`,
-			fmt.Sprintf("%s_%d", prefix, i), ts,
+				(gen_random_uuid(), ?, ?, ?, 'trial', 'trialing', 'monthly', 'developed', ?, now())`,
+			tenantID, storeID, fmt.Sprintf("%s_%d", prefix, i), ts,
 		).Error
 		require.NoError(t, err)
 	}
-	t.Cleanup(func() {
-		db.Exec("DELETE FROM store_subscriptions WHERE stripe_customer_id LIKE ?", prefix+"%")
-		db.Exec("DELETE FROM signup_anomaly_log WHERE alert_date >= ?", ts.Format("2006-01-02"))
-	})
 }
 
 // fixedClock returns a clock func that always returns t.
@@ -83,7 +77,7 @@ func fixedClock(t time.Time) func() time.Time { return func() time.Time { return
 // TestAnomalyCron_QuietUnder50_NoSlack_NoCounter seeds 49 rows created
 // yesterday and asserts: no Slack send, no log row, counter stays at 0.
 func TestAnomalyCron_QuietUnder50_NoSlack_NoCounter(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores", "signup_anomaly_log")
 	now := time.Date(2026, 8, 1, 5, 0, 0, 0, time.UTC)
 	yesterday := now.AddDate(0, 0, -1)
 
@@ -108,7 +102,7 @@ func TestAnomalyCron_QuietUnder50_NoSlack_NoCounter(t *testing.T) {
 // TestAnomalyCron_AlertsOver50 seeds 75 rows yesterday, runs the cron, and
 // asserts exactly one Slack send, counter incremented once, and a log row present.
 func TestAnomalyCron_AlertsOver50(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores", "signup_anomaly_log")
 	now := time.Date(2026, 8, 2, 5, 0, 0, 0, time.UTC)
 	yesterday := now.AddDate(0, 0, -1)
 
@@ -133,7 +127,7 @@ func TestAnomalyCron_AlertsOver50(t *testing.T) {
 // TestAnomalyCron_IdempotentSameDay_SecondRunNoOp seeds 75 rows, runs the cron
 // twice with the same clock, and asserts only one Slack send total.
 func TestAnomalyCron_IdempotentSameDay_SecondRunNoOp(t *testing.T) {
-	db := openIntegrationDB(t)
+	db := testdb.NewDB(t, "store_subscriptions", "stores", "signup_anomaly_log")
 	now := time.Date(2026, 8, 3, 5, 0, 0, 0, time.UTC)
 	yesterday := now.AddDate(0, 0, -1)
 


### PR DESCRIPTION
22 integration tests across two packages have **never run — not once**. This makes them run, and they pass.

Found while wrapping up #660: `internal/billing/trial` covers the trial subscription path, which is one of the two chokepoints migration `000132` hooks. I built that hook believing the area had integration coverage. It had none.

## Why they never ran

They gated on a `TEST_DB_DSN` env var through a hand-rolled `openIntegrationDB(t)` that calls `t.Skip` when it is absent.

```
$ git log -S "TEST_DB_DSN" -- Makefile
(nothing)
```

**No Makefile in this repo's history has ever exported that variable.** `make test-int` exports `TEST_DATABASE_URL`, which is what `pkg/testdb` reads. So the skip fired on every run, forever, and a green CI reported nothing about these paths.

And when you do set it, all 22 fail identically: the seed inserts `store_subscriptions` with an invented `store_id` and **no parent `stores` row**, violating `store_subscriptions_store_id_fkey` — a constraint that has existed since migration `000015` created the table. They were not tests that rotted. They were never executed.

## Measured, under CI's real conditions

`TEST_DATABASE_URL` set, `TEST_DB_DSN` unset (via `env -u`), `-p 1`:

| | before | after |
|---|---|---|
| PASS | 67 | **89** |
| SKIP | **22** (19 trial + 3 signup) | **0** |
| FAIL | 0 | **0** |

## The fix

Move the six files onto the harness **221 other files already use**: `testdb.NewDB` (reads `TEST_DATABASE_URL`, truncates named tables) plus `testdb.SeedStore`, which inserts the parent `stores` row — the missing piece. Both packages were already in `make test-int`; no Makefile change.

`openIntegrationDB` is deleted from both packages so it cannot be copied into a seventh file.

## Three defects the tests themselves contained

All surfaced only once the tests executed, all in `activation_cron_integration_test.go`, none a product bug:

1. **`products.vendor_id` is NOT NULL** (000028) and the raw INSERT omitted it — fixed with `testdb.SeedVendor`, which exists for this.
2. **`products_published_requires_active`**, a CHECK from migration **000001**: `status='active'` requires a non-NULL `published_at`. The fixture inserted `'active'` with NULL. **That fixture was wrong the day it was written** and nothing ever told anyone. Fixed by supplying `published_at`; the cron's predicate is `EXISTS (SELECT 1 FROM products p WHERE p.store_id = ss.store_id LIMIT 1)`, which filters on **neither** column, so what the test proves is unchanged — verified in `activation_cron.go:71`, not assumed.
3. **`Raw().Scan()` into `*time.Time` errors outright on NULL.** Switched to `sql.NullTime`, the idiom already documented at `internal/billing/migration/repository_integration_test.go:177`. `assert.NotNil(markedAt, …)` → `assert.True(markedAt.Valid, …)` with the identical message: the read mechanism changed, the claim did not.

**No assertion was weakened, skipped or deleted.** The diff removes four `assert`/`require` lines: two lived inside the deleted helper, and two are the NullTime pair, replaced one-for-one with the same messages.

## Test plan

- [x] Baseline reproduced exactly: 67 pass / 22 skip
- [x] After: **89 pass, 0 skip, 0 fail**, `env -u TEST_DB_DSN` so the old gate cannot be what makes them green
- [x] `go build ./...`, `go vet ./...` (including `-tags=integration` on both packages), `gofmt -l` clean
- [x] `go test ./...` — 105 packages ok, including `TestEveryIntegrationPackageIsInTheTestIntTarget`
- [x] `TEST_DB_DSN` now appears in no Go file except two historical comments

## Worth knowing

`openIntegrationDB` still exists in three other packages — `internal/arbitrage`, `cmd/carrier-secrets-backfill`, `internal/billing/migration`. **All three read `TEST_DATABASE_URL`, so they run**; no test is dark. Duplication worth consolidating, not a correctness problem, and out of scope here.
