### PR TITLE
ci(mobile): build the iOS release locally instead of on EAS

### DIFF
--- a/.github/workflows/mobile-admin-build.yml
+++ b/.github/workflows/mobile-admin-build.yml
@@ -1,4 +1,11 @@
-name: Mobile Admin - EAS Build
+# Cloud EAS builds, which consume the account's EAS build quota.
+#
+# iOS RELEASES DO NOT COME FROM HERE ANY MORE. `mobile-admin-ios-release.yml`
+# builds the IPA locally on a free macOS runner and submits it to TestFlight.
+# This workflow stays for Android (Play needs an .aab, and there is no free
+# Linux path to one that also handles signing) and for on-demand iOS builds
+# someone explicitly asks for via workflow_dispatch.
+name: Mobile Admin - EAS Build (cloud)
 
 on:
   push:
@@ -38,7 +45,11 @@ jobs:
       lockfile_path: package-lock.json
       node_version: "22"
       legacy_peer_dependencies: true
-      platform: ${{ inputs.platform || 'all' }}
+      # A tag push builds ANDROID only: mobile-admin-ios-release.yml answers
+      # the same tag with a local iOS build, and leaving this at 'all' would
+      # build and submit iOS twice — once here on EAS quota, once there for
+      # free — racing each other to TestFlight with the same build number.
+      platform: ${{ inputs.platform || 'android' }}
       profile: ${{ inputs.profile || 'production' }}
       no_wait: true
       auto_submit: ${{ github.event_name == 'push' || inputs.submit }}

--- a/.github/workflows/mobile-admin-ios-release.yml
+++ b/.github/workflows/mobile-admin-ios-release.yml
@@ -1,0 +1,66 @@
+# Builds the iOS app ON THIS RUNNER and ships the exact IPA to TestFlight.
+#
+# Why local rather than `expo-eas-build.yml`: that workflow queues a build on
+# EAS's servers and burns the account's build quota. This one runs
+# `eas build --local` on a GitHub-hosted macOS runner, so the only Expo service
+# it uses is credential storage (signing certs and the App Store Connect key),
+# which is free. mark8ly is a PUBLIC repo, so the macOS minutes are free too.
+#
+# The IPA that is submitted is the exact artifact this job built — it is never
+# re-built between build and submit.
+name: Mobile Admin - iOS Release (local build)
+
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: EAS build profile
+        type: choice
+        options: [production, preview]
+        default: production
+      submit:
+        description: Submit to TestFlight when the build succeeds
+        type: boolean
+        default: true
+  push:
+    tags: ["mobile-admin-v*"]
+
+# Serial, and never cancelled: a half-finished submit leaves an orphaned
+# TestFlight build, and `autoIncrement` has already consumed a build number.
+concurrency:
+  group: mobile-admin-ios-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    uses: tesserix/tesserix-workflows/.github/workflows/expo-ios-release.yml@v2.3.0
+    with:
+      working_directory: apps/mobile-admin
+      # Root, not apps/mobile-admin: this is an npm-workspaces monorepo with a
+      # single root lockfile, and the app resolves @repo/* through it.
+      install_directory: .
+      lockfile_path: package-lock.json
+      # Node 24 is REQUIRED and is not a style choice. On Node 22 the Expo
+      # config plugins die with `SyntaxError: Unexpected token 'typeof'`, and
+      # NativeWind's Tailwind fork can hang Metro forever at 0% CPU with no
+      # output (it resolves only on `message`, with no error/exit handler).
+      # The sibling cloud workflow passes "22" harmlessly because prebuild and
+      # Metro run on EAS's servers there; in a LOCAL build they run HERE.
+      # Root package.json pins `engines: { node: ">=24" }`.
+      node_version: "24"
+      # The committed lockfile needs legacy peer resolution, same as the cloud
+      # workflow — without it `npm ci` fails on peer conflicts.
+      legacy_peer_dependencies: true
+      profile: ${{ github.event_name == 'workflow_dispatch' && inputs.profile || 'production' }}
+      submit: ${{ github.event_name != 'workflow_dispatch' || inputs.submit }}
+    secrets:
+      expo_token: ${{ secrets.EXPO_TOKEN }}
+      # @tesserix/otto-widget is on GitHub Packages, so `npm ci` 401s without
+      # this. Not optional for this repo despite being optional in the callee.
+      package_read_token: ${{ secrets.GHCR_PAT }}
+      # asc_* are deliberately NOT passed. The callee requires all three or
+      # none, and none are set here — so `eas submit` uses the App Store
+      # Connect key stored with Expo, exactly as kora's release does.


### PR DESCRIPTION
Builds the iOS app **on the GitHub runner** and ships that exact IPA to TestFlight, instead of queueing a build on EAS's servers.

The reusable workflow for this already existed — `tesserix/tesserix-workflows/.github/workflows/expo-ios-release.yml`, which kora has been releasing through since August. This just wires mark8ly's `mobile-admin` to it. No new build infrastructure.

## What changes about cost

- `mobile-admin-build.yml` calls `expo-eas-build.yml`, which queues on EAS and **consumes the account's build quota**.
- The new `mobile-admin-ios-release.yml` calls `expo-ios-release.yml`, which runs `eas build --local` on a `macos-26` runner. The only Expo service left in the path is credential storage (signing certs + the App Store Connect key), which is free.
- **mark8ly is a public repo, so GitHub-hosted macOS minutes are free too.** On a private repo this would be a trade (macOS bills at a 10× multiplier); here it is not a trade.

## Preventing a double build

`mobile-admin-build.yml` already fired on `mobile-admin-v*` tags with `platform: all` and auto-submit. Left alone, a tag would now build and submit iOS **twice** — once on EAS quota, once locally — racing each other to TestFlight with the same `autoIncrement` build number.

So its tag-push default moves to `platform: android`. It keeps Android (Play needs a signed `.aab`) and stays available for on-demand iOS via `workflow_dispatch`.

## Node 24 is load-bearing, not a style choice

The new workflow passes `node_version: "24"`. The sibling cloud workflow passes `"22"` and is fine, because there prebuild and Metro run on **EAS's** servers — the runner only drives the CLI. In a local build they run **here**, and on Node 22:

- the Expo config plugins fail with `SyntaxError: Unexpected token 'typeof'`, and
- NativeWind's Tailwind fork can hang Metro **forever at 0% CPU with no output** — it resolves only on `message`, with no `error` or `exit` handler, so a child failure is never reported.

Root `package.json` already pins `engines: { node: ">=24" }`. Copying `"22"` across from the cloud workflow would have produced a silent hang to the 90-minute timeout.

## Credentials

Both required secrets already exist on this repo: `EXPO_TOKEN` and `GHCR_PAT` (needed because `@tesserix/otto-widget` is on GitHub Packages, so `npm ci` 401s without it).

The optional `asc_key_id` / `asc_issuer_id` / `asc_api_key_p8_base64` are deliberately **not** passed. The callee requires all three or none, and kora releases to TestFlight with none of them set — `eas submit` uses the App Store Connect key stored with Expo. mark8ly's `eas.json` submit block is the same shape as kora's, same Apple team `2CRHRRYBPL`.

## Testing

The workflow contract is validated: every input passed is declared by `expo-ios-release.yml@v2.3.0`, and its one required secret (`expo_token`) is supplied. Both files parse as valid YAML.

It has **not been executed** — `workflow_dispatch` only appears once the workflow is on the default branch. After merge, the safe first run is `workflow_dispatch` with **`submit: false`**, which exercises checkout → install → prebuild → local IPA build without shipping anything to TestFlight.

Worth knowing before the first submitting run: that will also be the **first real exercise of the Apple `.p8`** (see #771). Zitadel stores that key without validating it, and Apple only rejects a derived client secret when a real sign-in is attempted — so an Apple sign-in failure on the first TestFlight build is a plausible outcome and would not be a fault of this pipeline.
