### PR TITLE
feat(auth-bff,marketplace-api): session groundwork for break-glass, and a re-plan against the real code (#642)

### DIFF
--- a/docs/superpowers/artifacts/2026-09-07-break-glass-session-consumer-audit.md
+++ b/docs/superpowers/artifacts/2026-09-07-break-glass-session-consumer-audit.md
@@ -1,0 +1,245 @@
+# Break-glass session consumer audit (Task 0, #642)
+
+Gates Tasks 1–8 of `docs/superpowers/plans/2026-09-07-break-glass-activation-v2.md`.
+
+Two things under audit:
+
+- **D1** — adding `AuthContext string \`json:"auth_context,omitempty"\`` to
+  `services/auth-bff/internal/session/cookie.go:41-53`.
+- **D3** — a `Session.UID` of `BreakGlassUserID(tenantID)`
+  (`services/marketplace-api/internal/handlers/admin/break_glass_login.go:251-258`)
+  that resolves to no user row anywhere.
+
+## Headline
+
+**D1 is safe. D3 is not.** Adding the field breaks nothing — no decoder in the
+estate rejects unknown fields, and `/auth/session` hands out a hand-written
+allow-list that the new field cannot leak into. But a non-resolving UID is
+refused by the two authorization gates every admin request passes through, so a
+break-glass login that mints a cookie today produces a session that **cannot
+render a single admin page and cannot call a single admin API route**. This is
+not a corner case; it is the main path.
+
+## Scope of the search
+
+- The cookie is AES-GCM sealed by a key only auth-bff holds
+  (`cookie.go:106-114`, `pkg/config/config.go:38`). `SESSION_ENCRYPT_KEY` does
+  appear in `apps/admin` and `apps/storefront`, but only to HMAC handoff /
+  exchange codes (`apps/admin/app/auth/handoff/route.ts:28`,
+  `apps/storefront/lib/auth/join-grant.ts:63`) — **nothing outside auth-bff
+  decodes the session cookie**. Every other consumer sees either the
+  `/auth/session` JSON or the `X-User-Id` / `X-Tenant-Id` / `X-User-Email`
+  headers derived from it.
+- Grepped `-e m8_session -e SESSION_COOKIE_NAME -e session.Manager -e /auth/session`
+  across `services/{auth-bff,marketplace-api,otto,platform-api}` and
+  `apps/{admin,storefront,onboarding,mobile-admin,mobile-storefront,storefront-mobile}`
+  plus `packages/`.
+- Grepped `-e X-User-Id -e X-User-ID -e X-Tenant-Id -e X-Tenant-ID -e X-User-Email`
+  across the same tree.
+
+## Verdict table
+
+Legend: **OK** = unaffected · **DEGRADES** = works, loses fidelity · **BREAKS** = refuses the request.
+
+| # | Consumer | A: assumes UID resolves | B: assumes real mailbox | C: unknown JSON field | D: reads IdP token |
+|---|---|---|---|---|---|
+| 1 | `auth-bff` `Manager.encode/decode` — `internal/session/cookie.go:222,240` | OK | OK | **OK** — `json.Unmarshal`, no `DisallowUnknownFields` | OK — struct has no token field |
+| 2 | `auth-bff` `GET /auth/session` — `internal/session/handler.go:126-158` | OK | OK | OK — emits `sessionResponse` (`:113-118`), a 4-field allow-list | OK |
+| 3 | `auth-bff` `POST /auth/logout` — `internal/session/handler.go:271-306` | OK — `RevokeAllForUser` on a TEXT column, no FK (`migrations/0002_user_sessions.up.sql:10`) | OK — email is an audit label only | OK | OK |
+| 4 | `auth-bff` `POST /auth/switch-tenant` — `internal/session/handler.go:437-501` | **BREAKS** — `CheckMembership` at `:460` | OK | OK | OK |
+| 5 | `auth-bff` `POST /auth/switch-store` — `internal/session/handler.go:518-552` | OK — no FGA check by design | OK | **DEGRADES** — silently drops `AuthContext` on re-mint | OK |
+| 6 | `auth-bff` `GET/DELETE /api/v1/sessions` — `internal/session/handler.go:322-410` | OK — returns an empty list | OK | OK | OK |
+| 7 | `auth-bff` `GET /auth/me/providers` — `internal/session/providers_handler.go:126-132` | **BREAKS** — explicit `user_not_found` 404 | OK | OK | OK |
+| 8 | `auth-bff` admin cross-TLD handoff — `internal/adminhandoff/handler.go:112-142` | **BREAKS** — `CheckMembership` at `:113` | OK | **DEGRADES** — rebuilds `Session` at `:135` without `AuthContext` | OK |
+| 9 | `auth-bff` user MFA — `internal/usermfa/handler.go:41-52` | OK — `user_mfa` keyed on an opaque id | OK — email only labels the TOTP QR | OK | OK |
+| 10 | `apps/admin` `middleware.ts` role gate — `middleware.ts:407-435` | **BREAKS** — `/internal/tenants/{t}/me?uid=` → no role → `redirectToLogin` | OK | OK — plain `as SessionResponse` cast (`:70-77`), no runtime validator | OK |
+| 11 | `apps/admin` `lib/auth/session.ts:44-67` | OK | OK | OK — same untyped cast | OK |
+| 12 | `apps/admin` `lib/auth/serverSession.ts:63-101` | DEGRADES — `listMemberTenants(userId)` returns `[]`, switcher hides | OK | OK | OK |
+| 13 | `apps/admin` header forwarders (`lib/api/marketplace-api.ts:304-310`, `settings-tier2-api.ts:34-55`, `webhooks.ts:95`, `warehouses-api.ts:81`, `shipping-api.ts:114`, `campaigns-api.ts:17`, `settings-api.ts:162`, `app/api/admin/otto/_proxy.ts:168`, `app/api/otto-platform/[...path]/route.ts:58-68`) | OK — pass-through | OK — omits the header when blank | OK | OK |
+| 14 | `marketplace-api` `auth.HeaderTrustAuth` — `internal/auth/middleware.go:24-46` | OK — non-empty check only | OK — `:41` treats email as optional | OK | OK |
+| 15 | `marketplace-api` `authz.Middleware.RequireTenantRelation` — `internal/authz/middleware.go:34-56` | **BREAKS** — FGA `Check` → 404 on every admin route | OK | OK | OK |
+| 16 | `marketplace-api` audit + actor strings (`internal/audit/emitter.go:367`, `handlers/admin/promo.go:121`, `orders.go:453`, `returns.go:341`, `refund.go:86`, `team.go:101`, …) | OK — opaque actor string | DEGRADES — NULL `actor_email` | OK | OK |
+| 17 | `marketplace-api` account → auth-bff proxy — `internal/handlers/admin/account.go:478-496,535-537` | OK | DEGRADES — MFA QR labels with the opaque id | OK | OK |
+| 18 | `marketplace-api` uuid-parsing handlers — `apikeys_handler.go:245`, `push_tokens.go:34,57`, `billing/migration/handler.go:228` | OK — a UUIDv5 parses fine | OK | OK | OK |
+| 19 | `otto` `StaffAuth` / `CustomerContext` — `internal/auth/middleware.go:29-56,85-110` | OK — header trust, no lookup; `user_id` is only a message author id (`internal/conversation/admin_handler.go:48,561`) | OK — `:43` optional | OK | OK |
+| 20 | `platform-api` `getMe` / `listMyTenants` — `internal/tenant/handler.go:162-188,213-221` | **BREAKS** — `GetRole` returns `""` → 404 `no_role` | OK | OK | OK |
+| 21 | `apps/storefront`, `apps/onboarding`, `apps/mobile-admin`, `apps/mobile-storefront`, `apps/storefront-mobile` | n/a — **non-consumers**, see below | n/a | n/a | n/a |
+
+## The negatives, and how they were established
+
+- **C — no strict decoder anywhere.** `grep -rn --include='*.go' 'DisallowUnknownFields' .`
+  over the whole repo returns **zero** hits. `grep -rn -e '\.strict()' -e 'strictObject'`
+  over `apps/`, `packages/`, `services/` (node_modules excluded) returns **zero**.
+  `grep -e additionalProperties -e valibot -e superstruct -e 'io-ts'` returns zero;
+  `-e ErrorUnused -e UnmarshalStrict` over `services/` returns zero. Zod is present
+  (`apps/admin/lib/api/subscription/schemas/*.ts`, `components/auth/*.tsx`) but no
+  schema is applied to the session shape and none is `.strict()`. Both TS session
+  decoders are unvalidated casts (`middleware.ts:70-77`, `lib/auth/session.ts:59`).
+- **D — there is no IdP token on the session to read.** The `Session` struct
+  (`cookie.go:41-53`) has no access/ID/refresh field. The estate's only token
+  exchange lives in `services/auth-bff/internal/zitadellogin/token_exchange.go:34-58`
+  and returns tokens **in the login response body** for the mobile bearer path — it
+  never writes them to the cookie. The design spec's §7 risk ("a caller assumes
+  `session-exchange` returns a non-empty access_token") names a symbol that does not
+  exist; `grep -rn 'session-exchange'` finds no such route. **The risk is void**, and
+  no fix is required for D on any consumer.
+- **No DB will reject a synthetic id.** `grep -rn 'REFERENCES' --include='*.sql'`
+  in `services/marketplace-api/migrations` and `services/otto` yields no foreign key
+  to any user/staff table; `user_sessions.user_id` is `TEXT NOT NULL` with no FK
+  (`services/auth-bff/migrations/0002_user_sessions.up.sql:10`). Breakage is
+  authorization-layer, not storage-layer.
+- **No mail is sent to the session email.** `grep -rn -e SendEmail -e sendMail`
+  over `services/marketplace-api/internal` and `services/auth-bff/internal` finds
+  one unrelated webhook `notify`. `grep -e GetByEmail -e FindByEmail -e 'WHERE email'`
+  finds only `internal/campaign/segment_engine.go:98` (customer segments, not staff).
+  Every session-email read found is an attribution label with an explicit fallback
+  (`tickets.go:216-228`, `loyalty.go:179-182`, `middleware.go:38-42`).
+- **Only `apps/admin` consumes the cookie.** `grep -e m8_session -e SESSION_COOKIE_NAME`
+  over `apps/storefront`, `apps/onboarding`, `apps/mobile-admin`,
+  `apps/mobile-storefront`, `apps/storefront-mobile`: **zero non-test hits**.
+  `grep -e '/auth/session'` over the same: zero. Storefront has its own
+  `mp_customer_session`; the mobile apps authenticate with Zitadel bearer tokens
+  verified in `marketplace-api/internal/auth/zitadel_verifier.go`, a path a cookie
+  never enters.
+
+## Consumers that break
+
+### 10 + 20 — the admin role gate (BLOCKING)
+
+`apps/admin/middleware.ts:407-435` calls
+`GET {PLATFORM_API_URL}/internal/tenants/{session.tenant_id}/me?uid={session.user_id}`
+on every authenticated request. `platform-api`'s `getMe`
+(`services/platform-api/internal/tenant/handler.go:162-188`) answers from OpenFGA:
+
+```go
+role, err := h.fga.GetRole(c.Request.Context(), uid, tenantID)
+...
+if role == "" { c.JSON(http.StatusNotFound, gin.H{"error": "no_role", ...}) }
+```
+
+A break-glass UID has no FGA tuple, so `role` is `""` → 404 → `role` stays `null`
+in middleware → `middleware.ts:431` `return redirectToLogin(req)`. The merchant
+completes a correct dual-factor break-glass login, receives a valid cookie, and is
+bounced straight back to `/login` — a loop, with no error that names the cause.
+
+Note `handler.go:171-174`: with `fga == nil` (dev) it returns `role: owner`
+unconditionally. So this **passes in local dev and fails only in production** —
+exactly the shape that survives to deploy.
+
+**Fix.** Write the FGA tuple. At break-glass provisioning (or at successful login,
+before `Sessions.Issue`), write `user:{BreakGlassUserID(tenant)}` → `owner` (or a
+dedicated `break_glass` role) on `tenant:{tenantID}`. One additive tuple, matching
+the estate's existing "tenant ownership is a tuple" pattern, and it fixes #10, #15,
+#20, #4 and #8 in one move. The alternative — special-casing `auth_context` in the
+role gate — requires `/auth/session` to expose `auth_context` (see below) and adds
+an authorization bypass branch to the hottest path in the admin app. Prefer the tuple.
+
+### 15 — every admin API route (BLOCKING)
+
+`services/marketplace-api/internal/authz/middleware.go:41`:
+
+```go
+ok, err := m.client.Check(c.Request.Context(), userID, string(role), tenantID)
+```
+
+`RequireTenantRelation` is attached per-route across the whole admin surface —
+`internal/handlers/admin/routes.go:234-239` (products), `:258-270` (CSV imports),
+`:165-180` (SSO config), `:184-187` (stores), `:196-219` (account), and the rest of
+the `/admin/stores/:storeId` tree at `:230`. A break-glass UID fails `Check` and
+gets **404 not_found** on all of them (deliberately 404, not 403, per §13.1.1) — so
+even if the UI rendered, every panel would report "not found".
+
+**Fix.** Same tuple as above. No code change needed here.
+
+### 4 — `/auth/switch-tenant` (blocking in practice)
+
+`internal/session/handler.go:460` runs `CheckMembership(existing.UID, req.TenantID)`
+and 403s a non-member. `apps/admin/middleware.ts:376-400` calls this endpoint
+whenever the host slug's tenant differs from the session tenant, and on failure
+redirects to `/pick-tenant` — which is itself powered by `listMyTenants(uid)`
+(`platform-api/internal/tenant/handler.go:213-221`), empty for break-glass. So the
+recovery surface is empty too. The tuple fixes this as well.
+
+Separately: **`switch-tenant` on a break-glass session should be refused outright**,
+not merely fail. Once the tuple exists it would otherwise *succeed*, letting an
+emergency credential scoped to one tenant walk to another. Gate it on
+`AuthContext == "break_glass"` → 403.
+
+### 5 + 8 — `AuthContext` is silently dropped on re-mint (BLOCKING for D1's purpose)
+
+`switchStore` (`internal/session/handler.go:538-546`) and `switchTenant` (`:483-489`)
+both build a fresh `Session` literal copying `UID`, `Email`, `TenantID`, `StoreID`,
+`IssuedAt`, `ExpiresAt` — and nothing else. `adminhandoff` (`internal/adminhandoff/handler.go:135-142`)
+does the same from its code claims, which carry no `auth_context`.
+
+Adding `AuthContext` without touching these three sites gives a field that any
+merchant can strip by calling `POST /auth/switch-store` once. Since D1's stated
+purpose is "the spec's central safety control", a control that launders itself away
+on a routine UI action is worse than none: it will be trusted and it will be wrong.
+
+**Fix (must land in the same commit as D1).** Copy `AuthContext` in both
+`switchTenant` and `switchStore`; add an `auth_context` claim to the admin-handoff
+code (`internal/adminhandoff/code.go`) and carry it into the minted session, or
+refuse handoff for a break-glass session. Add a test per site that a
+`break_glass` session survives the round trip — three one-line struct fields is
+exactly the kind of change nobody writes a test for and everybody regresses.
+
+### 7 — `/auth/me/providers` (cosmetic)
+
+`internal/session/providers_handler.go:126-132` returns 404 `user_not_found` when
+GIP's `accounts:lookup` finds no record for `s.UID`, which is guaranteed for a
+synthetic id. Only feeds `/settings/security`. **Fix:** none required; optionally
+short-circuit to an empty provider list when `AuthContext == "break_glass"` so the
+page renders instead of erroring.
+
+## Two things the plan should record
+
+1. **`SessionIssuer` carries no email.** `internal/authbffclient/session_issuer.go:34`
+   is `Issue(ctx, tenantID, userID uuid.UUID, ttl)`. A break-glass session therefore
+   has `Email == ""`. Every email consumer audited (rows 14, 16, 17, 19) treats it as
+   optional with a fallback, so **empty is safe** — the only cost is NULL
+   `actor_email` on audit rows, where `actor_user_id` already carries the stable
+   synthetic id. Task 3's open question resolves in favour of **widening the
+   interface** anyway, because `auth_context` (unlike email) is load-bearing and must
+   not be defaulted by the callee.
+2. **`/auth/session` does not expose `auth_context`.** `sessionResponse`
+   (`internal/session/handler.go:113-118`) is a 4-field allow-list. This is why C is
+   safe — but it also means **no TypeScript consumer can see that a session is
+   break-glass**. If any UI must show an emergency-mode banner, or if the role gate
+   is fixed by special-casing rather than by a tuple, `sessionResponse` and
+   `apps/admin`'s three copies of the interface (`middleware.ts:70-77`,
+   `lib/auth/session.ts:20-26`, and the `x-session-*` header set at
+   `middleware.ts:487-491`) must be extended. That is additive and safe — no
+   validator would reject it — but it is not free, and it is not in the plan.
+
+## Overall verdict
+
+**Adding `AuthContext`: SAFE to land**, provided it lands together with the field
+copies in `switchTenant`, `switchStore`, and the admin-handoff mint. Go ignores
+unknown fields; no Go decoder in the repo sets `DisallowUnknownFields`; no
+TypeScript consumer validates the session shape at all; and the field cannot reach
+a TS consumer regardless because `/auth/session` emits a hand-written allow-list.
+Old cookies decode with an empty value, as D1 intends.
+
+**A non-resolving `UID`: NOT SAFE. This blocks Tasks 2–8.** Three gates refuse it —
+`platform-api getMe` (`internal/tenant/handler.go:176-182`),
+`marketplace-api RequireTenantRelation` (`internal/authz/middleware.go:41-53`), and
+`auth-bff switchTenant` / `adminhandoff` `CheckMembership`. The admin app bounces
+the session to `/login`; the API 404s every route. The plan's Task 8 ("provision +
+verify end to end") would fail at first render, and the dev-mode `fga == nil`
+fallback at `handler.go:171-174` means it would pass locally first.
+
+**Required before Task 2:**
+
+1. Add a task — before Task 6's mount — that writes an FGA tuple for
+   `BreakGlassUserID(tenantID)` on `tenant:{tenantID}`, at provisioning or at
+   successful login. Without it break-glass does not work, however correct the
+   cookie is.
+2. In Task 1, copy `AuthContext` through `switchTenant` (`handler.go:483`) and
+   `switchStore` (`handler.go:538`), and decide handoff (`adminhandoff/handler.go:135`)
+   — carry it or refuse it. With a test each.
+3. In Task 3, widen `SessionIssuer` to carry `auth_context` explicitly rather than
+   letting `HTTPIssuer` default it. Empty email is fine and needs no widening on its
+   own account; `auth_context` is the reason to widen.
+4. Delete the design spec's §7 access_token risk. There is no token on the session
+   and no `session-exchange` route; the risk describes a system that does not exist.

--- a/docs/superpowers/plans/2026-09-04-break-glass-activation.md
+++ b/docs/superpowers/plans/2026-09-04-break-glass-activation.md
@@ -722,3 +722,81 @@ Zero break-glass accounts exist today, so the feature is not real until this run
 - [ ] **Step 3: End-to-end** — a correct password+TOTP returns 200 with `Set-Cookie`; the cookie is accepted by marketplace-api-admin (this is the §4 claim, proven against the live Istio policy rather than the manifest).
 - [ ] **Step 4: Negative** — wrong factor returns the uniform `invalid_credentials`; the lockout path still trips; the Slack alert and `severity=critical` audit event both fire.
 - [ ] **Step 5: Audit `session-exchange` callers** for any that assume a non-empty `access_token`, since break-glass sessions return empty strings there.
+
+---
+
+## Errata — verified against the code, 2026-09-07
+
+Before executing Task 1, every symbol this plan names was checked against
+`services/auth-bff` and `services/marketplace-api`. **Five of the plan's and
+the merged design spec's load-bearing claims are wrong.** They are recorded
+here rather than quietly worked around, because each one would have been
+discovered mid-implementation and patched by guesswork.
+
+### E1 — `CookieStore` does not exist
+
+The type is `session.Manager`, constructed by `NewManager(cfg Config)`, not
+`NewCookieStore(keyHex, ttl, secure)`. `services/auth-bff/internal/session/cookie.go:91`.
+
+### E2 — `Encode` already exists, unexported
+
+`func (m *Manager) encode(s Session) (string, error)` is at `cookie.go:222`,
+already factored out and already used by `MintWithDomain` (`:156`). Task 1 is
+therefore **export or wrap**, not extract. The plan's Step 3 body — which
+re-derives an extraction out of `Save` — describes work that was already done.
+
+`Save` does not exist either; the writers are `Mint` / `MintWithDomain`, and
+they take an `http.ResponseWriter`, not a `*gin.Context`.
+
+### E3 — `LoadFromValue` does not exist
+
+The readers are `Read(r *http.Request)` and the unexported `decode(encoded string)`.
+The round-trip test in Task 1 Step 1 cannot compile as written.
+
+### E4 — `Session` has no `AuthContext` field
+
+`Session` is `{UID, Email, TenantID, StoreID, IssuedAt, ExpiresAt}`
+(`cookie.go:41-53`). `IssuedAt`/`ExpiresAt` are `time.Time`, not the int64 the
+plan's test assumes (`if in.IssuedAt == 0`).
+
+This matters well beyond a compile error: **the allow-list is the spec's
+central safety control** — "it must never default to `staff`, a typo would
+silently mint a full staff session" — and there is no field for it to guard.
+Adding one is a change to the session cookie payload shared by every
+consumer, which is a design decision, not a task step.
+
+### E5 — the cited precedent does not exist
+
+The design spec justifies the allow-list as working "exactly as
+`IsKnownSessionCookie` guards `session-exchange` today". Neither
+`IsKnownSessionCookie` nor `session-exchange` appears anywhere in this
+repository, in Go or TypeScript.
+
+Relatedly, the spec "corrects" `session_issuer.go`'s own comment — which says
+the endpoint is mTLS-gated — toward "the `/internal` group's actual, working
+pattern is a Bearer service key plus rate limiting". That is also wrong. The
+real pattern is a shared **`X-Internal-Auth` header**, compared in constant
+time by `internalauth.Equal` (`internal/internalauth/internalauth.go:29`),
+applied **per route inside the handler**, not as group middleware, and there
+is no rate limiting on it. `cmd/server/main.go:425-431`.
+
+### E6 — the issuer interface cannot carry the design
+
+`SessionIssuer.Issue(ctx, tenantID, userID uuid.UUID, ttl)` passes no email,
+no tenant slug and no auth context, yet auth-bff's `Session` needs `UID` (a
+string identity key) and `Email`. A break-glass principal is synthetic, so
+what goes in `UID` is an open question with real consequences — this estate
+already has three identity keys in play, and login reads email while the API
+reads uid. Minting a session whose `UID` is a freshly-invented UUID needs to
+be checked against every consumer before it is written, not after.
+
+## Consequence
+
+Tasks 1–3 must be re-planned against the real API. Tasks 4–8 (OpenBao port,
+GCP client deletion, mounting, config, provisioning) were **not** re-verified
+in this pass and must be assumed to carry the same class of error until they
+are.
+
+The design's *intent* survives all six findings: mint a session in auth-bff
+for an already-authenticated principal, keep cookie crypto in auth-bff, port
+the secret store to OpenBao. Only its account of the code is unreliable.

--- a/docs/superpowers/plans/2026-09-04-break-glass-activation.md
+++ b/docs/superpowers/plans/2026-09-04-break-glass-activation.md
@@ -1,0 +1,724 @@
+# Break-Glass Activation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `SessionIssuer` so the break-glass login and per-tenant SSO routes become reachable, and move break-glass credentials off the decommissioned GCP Secret Manager onto OpenBao.
+
+**Architecture:** auth-bff gains one internal endpoint that mints a session cookie for an already-authenticated principal, on the existing `/internal` group (Bearer service key + rate limit). marketplace-api implements `SessionIssuer` as an HTTP client to it, swaps the break-glass `SecretClient` to an OpenBao adapter, and mounts the two route groups that were written but never registered. No downstream service changes — verified: marketplace-api authenticates on `X-User-Id`/`X-Tenant-Id`, and its Istio policy is mTLS workload-identity with no JWT requirement.
+
+**Tech Stack:** Go 1.26, Gin, `openbao/openbao/api`, AES-256-GCM cookie sessions, bcrypt, TOTP (`pquerna/otp`).
+
+**Spec:** [`docs/superpowers/specs/2026-09-04-break-glass-activation-design.md`](../specs/2026-09-04-break-glass-activation-design.md)
+
+## Global Constraints
+
+- **marketplace-api MUST NEVER sign or encrypt a session cookie.** Cookie cryptography stays in auth-bff. marketplace-api only passes a `Set-Cookie` string through.
+- **`auth_context` is an explicit allow-list**: `staff`, `customer`, `break_glass`. Reject anything else with 400. It must never default to `staff` — a typo would silently mint a full staff session.
+- **No secret value in any log line** — not the password, TOTP secret, session cookie, or service key. Log lengths and outcomes, never contents.
+- **Break-glass login responses stay uniform.** `{"error":"invalid_credentials"}` regardless of which factor failed; forensics goes to the audit log.
+- **bcrypt cost stays 12** (§12.4). **Secret-store write precedes the DB write** in `Bootstrapper`, so a store failure never leaves a `password_hash` referencing a non-existent blob.
+- Repo conventions: single-line commit messages, no signatures, conventional-commit prefixes.
+
+---
+
+### Task 1: `CookieStore.Encode` in auth-bff
+
+Extract the encrypt step from `Save` so a non-HTTP caller can produce a cookie value. `Save` must keep behaving identically.
+
+**Files:**
+- Modify: `auth-bff/internal/session/cookie.go:62-79`
+- Test: `auth-bff/internal/session/cookie_test.go`
+
+**Interfaces:**
+- Produces: `func (cs *CookieStore) Encode(sess *Session) (string, error)` — sets `IssuedAt`, marshals, AES-GCM encrypts, returns the raw cookie value.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestCookieStore_Encode_RoundTrips(t *testing.T) {
+	cs := NewCookieStore(testKeyHex, time.Hour, false)
+	in := &Session{UserID: "u1", TenantID: "t1", AuthContext: "break_glass"}
+
+	value, err := cs.Encode(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if value == "" {
+		t.Fatal("Encode returned an empty cookie value")
+	}
+
+	out, err := cs.LoadFromValue(value)
+	if err != nil {
+		t.Fatalf("LoadFromValue: %v", err)
+	}
+	if out.UserID != "u1" || out.AuthContext != "break_glass" {
+		t.Fatalf("round-trip mismatch: %+v", out)
+	}
+	if in.IssuedAt == 0 {
+		t.Fatal("Encode must stamp IssuedAt, as Save does")
+	}
+}
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: `cd auth-bff && go test ./internal/session/ -run TestCookieStore_Encode -v`
+Expected: FAIL — `cs.Encode undefined`
+
+- [ ] **Step 3: Implement, and make `Save` use it**
+
+```go
+// Encode stamps IssuedAt, marshals and encrypts the session, returning
+// the raw cookie value. Save writes this into an HTTP cookie; internal
+// endpoints that mint a session for another service use it directly.
+func (cs *CookieStore) Encode(sess *Session) (string, error) {
+	sess.IssuedAt = time.Now().Unix()
+
+	data, err := json.Marshal(sess)
+	if err != nil {
+		return "", fmt.Errorf("session: marshal: %w", err)
+	}
+	encrypted, err := crypto.EncryptAESGCM(data, cs.encryptionKey)
+	if err != nil {
+		return "", fmt.Errorf("session: encrypt: %w", err)
+	}
+	return encrypted, nil
+}
+
+func (cs *CookieStore) Save(c *gin.Context, cookieName, cookieDomain string, sess *Session) error {
+	encrypted, err := cs.Encode(sess)
+	if err != nil {
+		return err
+	}
+	maxAgeSeconds := int(cs.maxAge.Seconds())
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie(cookieName, encrypted, maxAgeSeconds, "/", cookieDomain, cs.secure, true)
+	return nil
+}
+```
+
+- [ ] **Step 4: Run the whole session package**
+
+Run: `cd auth-bff && go test ./internal/session/ -v`
+Expected: PASS, including the pre-existing `Save`/`Load` tests — this is a refactor, not a behaviour change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/session/cookie.go internal/session/cookie_test.go
+git commit -m "refactor(session): extract Encode from Save so internal callers can mint a cookie value"
+```
+
+---
+
+### Task 2: `POST /internal/mint-session` in auth-bff
+
+**Files:**
+- Modify: `auth-bff/internal/handlers/internal.go` (register route + handler)
+- Test: `auth-bff/internal/handlers/internal_mint_session_test.go`
+
+**Interfaces:**
+- Consumes: `CookieStore.Encode` from Task 1.
+- Produces: `POST /internal/mint-session` — body `{tenant_id, tenant_slug, user_id, email, auth_context, app_name, cookie_name, ttl_seconds}`, response `{"set_cookie": "<header value>"}`.
+
+**Note:** `cookie_name` is validated with the existing `cfg.IsKnownSessionCookie`, exactly as `SessionExchange` does — that guard already exists and prevents the endpoint being used to mint a cookie under an arbitrary name.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestMintSession_RejectsUnknownAuthContext(t *testing.T) {
+	h, r := newTestInternalHandler(t)
+	_ = h
+	body := `{"tenant_id":"t1","user_id":"u1","auth_context":"root","cookie_name":"mark8ly_session","ttl_seconds":7200}`
+	w := postJSON(r, "/internal/mint-session", body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 for an unknown auth_context, got %d", w.Code)
+	}
+}
+
+func TestMintSession_AcceptsBreakGlassAndSetsNoIdPTokens(t *testing.T) {
+	h, r := newTestInternalHandler(t)
+	body := `{"tenant_id":"t1","tenant_slug":"bondi","user_id":"u1","email":"bg@example.test","auth_context":"break_glass","app_name":"marketplace-admin","cookie_name":"mark8ly_session","ttl_seconds":7200}`
+	w := postJSON(r, "/internal/mint-session", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		SetCookie string `json:"set_cookie"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if !strings.HasPrefix(resp.SetCookie, "mark8ly_session=") {
+		t.Fatalf("set_cookie not a cookie header: %q", resp.SetCookie)
+	}
+
+	value := strings.TrimPrefix(strings.Split(resp.SetCookie, ";")[0], "mark8ly_session=")
+	sess, err := h.sessions.LoadFromValue(value)
+	if err != nil {
+		t.Fatalf("minted cookie does not decrypt: %v", err)
+	}
+	if sess.AuthContext != "break_glass" {
+		t.Fatalf("auth_context = %q, want break_glass", sess.AuthContext)
+	}
+	// The whole point: a break-glass principal has no IdP identity.
+	if sess.AccessToken != "" || sess.IDToken != "" || sess.RefreshToken != "" {
+		t.Fatalf("break-glass session must carry no IdP tokens: %+v", sess)
+	}
+	if sess.ExpiresAt <= time.Now().Unix() {
+		t.Fatal("ExpiresAt must be in the future")
+	}
+}
+
+func TestMintSession_RejectsUnknownCookieName(t *testing.T) {
+	_, r := newTestInternalHandler(t)
+	body := `{"tenant_id":"t1","user_id":"u1","auth_context":"break_glass","cookie_name":"evil_cookie","ttl_seconds":7200}`
+	w := postJSON(r, "/internal/mint-session", body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 for an unknown cookie_name, got %d", w.Code)
+	}
+}
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `cd auth-bff && go test ./internal/handlers/ -run TestMintSession -v`
+Expected: FAIL — route returns 404.
+
+- [ ] **Step 3: Implement**
+
+Register alongside the existing internal routes:
+
+```go
+	internal.POST("/mint-session", h.MintSession)
+```
+
+```go
+// allowedAuthContexts is an explicit allow-list. It must never fall
+// back to "staff": a typo in a caller would otherwise silently mint a
+// full staff session.
+var allowedAuthContexts = map[string]bool{
+	"staff":       true,
+	"customer":    true,
+	"break_glass": true,
+}
+
+// MintSession issues a Mark8ly session cookie for a principal that the
+// CALLER has already authenticated. auth-bff performs no credential
+// check here — the Bearer service key on this route group is what makes
+// that safe.
+//
+// Used by marketplace-api's break-glass login and SSO callback, whose
+// principals have no IdP identity: AccessToken/IDToken/RefreshToken are
+// deliberately left empty, so nothing downstream can mistake this for a
+// federated session.
+func (h *InternalHandler) MintSession(c *gin.Context) {
+	var req struct {
+		TenantID    string `json:"tenant_id" binding:"required"`
+		TenantSlug  string `json:"tenant_slug"`
+		UserID      string `json:"user_id" binding:"required"`
+		Email       string `json:"email"`
+		AuthContext string `json:"auth_context" binding:"required"`
+		AppName     string `json:"app_name"`
+		CookieName  string `json:"cookie_name" binding:"required"`
+		TTLSeconds  int    `json:"ttl_seconds" binding:"required,min=60,max=86400"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "INVALID_REQUEST"})
+		return
+	}
+	if !allowedAuthContexts[req.AuthContext] {
+		slog.Warn("mint-session: rejected auth_context", "auth_context", req.AuthContext)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "INVALID_AUTH_CONTEXT"})
+		return
+	}
+	if !h.cfg.IsKnownSessionCookie(req.CookieName) {
+		slog.Warn("mint-session: unknown cookie name", "cookie_name", req.CookieName)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "INVALID_COOKIE_NAME"})
+		return
+	}
+
+	ttl := time.Duration(req.TTLSeconds) * time.Second
+	csrf, err := crypto.RandomToken(32)
+	if err != nil {
+		slog.Error("mint-session: csrf generation failed", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "MINT_FAILED"})
+		return
+	}
+
+	sess := &session.Session{
+		UserID:      req.UserID,
+		Email:       req.Email,
+		TenantID:    req.TenantID,
+		TenantSlug:  req.TenantSlug,
+		AuthContext: req.AuthContext,
+		AppName:     req.AppName,
+		CSRFToken:   csrf,
+		ExpiresAt:   time.Now().Add(ttl).Unix(),
+		// AccessToken / IDToken / RefreshToken intentionally empty.
+	}
+
+	value, err := h.sessions.Encode(sess)
+	if err != nil {
+		slog.Error("mint-session: encode failed", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "MINT_FAILED"})
+		return
+	}
+
+	ck := &http.Cookie{
+		Name:     req.CookieName,
+		Value:    value,
+		Path:     "/",
+		Domain:   h.cfg.SessionCookieDomain,
+		MaxAge:   int(ttl.Seconds()),
+		Secure:   h.cfg.SecureCookies(),
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
+	slog.Info("mint-session: issued",
+		"auth_context", req.AuthContext, "tenant_id", req.TenantID,
+		"user_id", req.UserID, "ttl_seconds", req.TTLSeconds)
+	c.JSON(http.StatusOK, gin.H{"set_cookie": ck.String()})
+}
+```
+
+> If `crypto.RandomToken` / `cfg.SecureCookies()` / `cfg.SessionCookieDomain` differ in name, use the equivalents already used by `DirectAuthHandler` when it builds a session — match that call site rather than inventing helpers.
+
+- [ ] **Step 4: Run**
+
+Run: `cd auth-bff && go test ./internal/handlers/ -run TestMintSession -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/handlers/internal.go internal/handlers/internal_mint_session_test.go
+git commit -m "feat(internal): mint a session cookie for an already-authenticated principal"
+```
+
+---
+
+### Task 3: `HTTPIssuer` in marketplace-api
+
+**Files:**
+- Create: `services/marketplace-api/internal/authbffclient/http_issuer.go`
+- Test: `services/marketplace-api/internal/authbffclient/http_issuer_test.go`
+
+**Interfaces:**
+- Consumes: `POST /internal/mint-session` from Task 2.
+- Produces: `authbffclient.NewHTTPIssuer(baseURL, serviceKey, cookieName string, slug TenantSlugFunc) *HTTPIssuer`, satisfying `SessionIssuer`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestHTTPIssuer_Issue_SendsBreakGlassContextAndReturnsCookie(t *testing.T) {
+	var gotAuth, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"set_cookie":"mark8ly_session=abc; Path=/; HttpOnly"}`))
+	}))
+	defer srv.Close()
+
+	iss := NewHTTPIssuer(srv.URL, "svc-key", "mark8ly_session",
+		func(context.Context, uuid.UUID) (string, error) { return "bondi", nil })
+
+	tid, uid := uuid.New(), uuid.New()
+	cookie, err := iss.Issue(context.Background(), tid, uid, 2*time.Hour)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if cookie != "mark8ly_session=abc; Path=/; HttpOnly" {
+		t.Fatalf("cookie = %q", cookie)
+	}
+	if gotAuth != "Bearer svc-key" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if !strings.Contains(gotBody, `"auth_context":"break_glass"`) {
+		t.Fatalf("body missing break_glass context: %s", gotBody)
+	}
+	if !strings.Contains(gotBody, `"ttl_seconds":7200`) {
+		t.Fatalf("body missing ttl: %s", gotBody)
+	}
+}
+
+func TestHTTPIssuer_Issue_NonOKIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	iss := NewHTTPIssuer(srv.URL, "wrong", "mark8ly_session",
+		func(context.Context, uuid.UUID) (string, error) { return "bondi", nil })
+
+	if _, err := iss.Issue(context.Background(), uuid.New(), uuid.New(), time.Hour); err == nil {
+		t.Fatal("want an error on 401, got nil")
+	}
+}
+
+func TestHTTPIssuer_SatisfiesSessionIssuer(t *testing.T) {
+	var _ SessionIssuer = (*HTTPIssuer)(nil)
+}
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `cd services/marketplace-api && go test ./internal/authbffclient/ -run TestHTTPIssuer -v`
+Expected: FAIL — `NewHTTPIssuer` undefined.
+
+- [ ] **Step 3: Implement**
+
+```go
+package authbffclient
+
+// TenantSlugFunc resolves a tenant's slug. The minted session carries it
+// so the admin app can render tenant context without a second lookup.
+type TenantSlugFunc func(context.Context, uuid.UUID) (string, error)
+
+// HTTPIssuer mints sessions by calling auth-bff's internal endpoint.
+// It authenticates with the same Bearer service key the rest of the
+// /internal group uses.
+type HTTPIssuer struct {
+	baseURL    string
+	serviceKey string
+	cookieName string
+	slug       TenantSlugFunc
+	client     *http.Client
+}
+
+func NewHTTPIssuer(baseURL, serviceKey, cookieName string, slug TenantSlugFunc) *HTTPIssuer {
+	return &HTTPIssuer{
+		baseURL:    strings.TrimSuffix(baseURL, "/"),
+		serviceKey: serviceKey,
+		cookieName: cookieName,
+		slug:       slug,
+		client:     &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func (h *HTTPIssuer) Issue(ctx context.Context, tenantID, userID uuid.UUID, ttl time.Duration) (string, error) {
+	slug := ""
+	if h.slug != nil {
+		if s, err := h.slug(ctx, tenantID); err == nil {
+			slug = s
+		}
+	}
+
+	payload := map[string]any{
+		"tenant_id":    tenantID.String(),
+		"tenant_slug":  slug,
+		"user_id":      userID.String(),
+		"auth_context": "break_glass",
+		"app_name":     "marketplace-admin",
+		"cookie_name":  h.cookieName,
+		"ttl_seconds":  int(ttl.Seconds()),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("authbffclient: marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.baseURL+"/internal/mint-session", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("authbffclient: new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+h.serviceKey)
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("authbffclient: mint-session: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Never echo the response body — it is auth-bff's and may name
+		// internals. The status is enough to act on.
+		return "", fmt.Errorf("authbffclient: mint-session: status %d", resp.StatusCode)
+	}
+
+	var out struct {
+		SetCookie string `json:"set_cookie"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("authbffclient: decode: %w", err)
+	}
+	if out.SetCookie == "" {
+		return "", errors.New("authbffclient: mint-session returned an empty cookie")
+	}
+	return out.SetCookie, nil
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd services/marketplace-api && go test ./internal/authbffclient/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/authbffclient/http_issuer.go internal/authbffclient/http_issuer_test.go
+git commit -m "feat(authbffclient): implement SessionIssuer against auth-bff mint-session"
+```
+
+---
+
+### Task 4: OpenBao adapter for break-glass secrets
+
+`breakglass.SecretClient` needs two methods; `carriersecrets.BaoClient` already provides both under different names.
+
+**Files:**
+- Create: `services/marketplace-api/internal/breakglass/bao_secret_client.go`
+- Test: `services/marketplace-api/internal/breakglass/bao_secret_client_test.go`
+
+**Interfaces:**
+- Consumes: `carriersecrets.BaoClient.CreateOrAddVersion(ctx, name, payload)` and `.AccessLatest(ctx, name)`.
+- Produces: `breakglass.NewBaoSecretClient(*carriersecrets.BaoClient) SecretClient`, and `BreakGlassSecretName(tenantID uuid.UUID) string` returning `break-glass/<tenant_id>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+type fakeBao struct {
+	saved map[string][]byte
+	err   error
+}
+
+func (f *fakeBao) CreateOrAddVersion(_ context.Context, name string, payload []byte) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.saved == nil {
+		f.saved = map[string][]byte{}
+	}
+	f.saved[name] = payload
+	return nil
+}
+func (f *fakeBao) AccessLatest(_ context.Context, name string) ([]byte, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	b, ok := f.saved[name]
+	if !ok {
+		return nil, fmt.Errorf("not found: %s", name)
+	}
+	return b, nil
+}
+
+func TestBaoSecretClient_RoundTripsABlob(t *testing.T) {
+	f := &fakeBao{}
+	c := NewBaoSecretClientFrom(f)
+	sm := NewSecretManager(c)
+
+	tenant := uuid.New()
+	path := BreakGlassSecretName(tenant)
+	if !strings.HasPrefix(path, "break-glass/") {
+		t.Fatalf("path = %q, want break-glass/<tenant>", path)
+	}
+
+	in := Blob{Password: "pw", TOTPSecret: "totp", GeneratedAt: time.Now().UTC()}
+	if err := sm.Write(context.Background(), path, in); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	out, err := sm.Read(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if out.Password != "pw" || out.TOTPSecret != "totp" {
+		t.Fatalf("round-trip mismatch: %+v", out)
+	}
+}
+
+func TestBaoSecretClient_PropagatesWriteFailure(t *testing.T) {
+	c := NewBaoSecretClientFrom(&fakeBao{err: errors.New("bao down")})
+	if err := NewSecretManager(c).Write(context.Background(), "break-glass/x", Blob{}); err == nil {
+		t.Fatal("a store failure must propagate — Bootstrapper relies on it to skip the DB write")
+	}
+}
+```
+
+> Match `SecretManager`'s real method names when writing this test — read `secret_manager.go` first and use whatever it calls read/write.
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `cd services/marketplace-api && go test ./internal/breakglass/ -run TestBaoSecretClient -v`
+Expected: FAIL — undefined.
+
+- [ ] **Step 3: Implement**
+
+```go
+package breakglass
+
+// baoWriter is the slice of carriersecrets.BaoClient this package needs.
+// Declared as an interface so tests need no live OpenBao.
+type baoWriter interface {
+	CreateOrAddVersion(ctx context.Context, name string, payload []byte) error
+	AccessLatest(ctx context.Context, name string) ([]byte, error)
+}
+
+// BaoSecretClient adapts an OpenBao client to SecretClient.
+//
+// Break-glass credentials used to live in GCP Secret Manager. That
+// backend was decommissioned (milestone 10: secrets deleted, IAM
+// revoked), so this is now the only store — not an alternative to one.
+type BaoSecretClient struct{ bao baoWriter }
+
+func NewBaoSecretClientFrom(b baoWriter) *BaoSecretClient { return &BaoSecretClient{bao: b} }
+
+func (c *BaoSecretClient) AddVersion(ctx context.Context, path string, payload []byte) error {
+	return c.bao.CreateOrAddVersion(ctx, path, payload)
+}
+
+func (c *BaoSecretClient) AccessLatest(ctx context.Context, path string) ([]byte, error) {
+	return c.bao.AccessLatest(ctx, path)
+}
+
+// BreakGlassSecretName is the OpenBao path for a tenant's break-glass
+// blob, mirroring the carrier-secrets convention.
+func BreakGlassSecretName(tenantID uuid.UUID) string {
+	return "break-glass/" + tenantID.String()
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd services/marketplace-api && go test ./internal/breakglass/ -v`
+Expected: PASS, existing break-glass tests included.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/breakglass/bao_secret_client.go internal/breakglass/bao_secret_client_test.go
+git commit -m "feat(breakglass): store credentials in OpenBao instead of the retired GCP Secret Manager"
+```
+
+---
+
+### Task 5: Delete the GCP Secret Manager client
+
+**Files:**
+- Delete: `services/marketplace-api/internal/breakglass/gcp_secret_manager.go`
+- Delete: `services/marketplace-api/internal/breakglass/secret_manager_test.go` cases that construct `GCPSecretClient` (keep the `FakeSecretClient` ones)
+- Modify: `services/marketplace-api/go.mod` if `cloud.google.com/go/secretmanager` becomes unused
+
+- [ ] **Step 1: Confirm nothing else imports it**
+
+Run: `cd services/marketplace-api && grep -rn "GCPSecretClient\|secretmanager" --include=*.go . | grep -v _test.go`
+Expected: only `gcp_secret_manager.go` itself. **If anything else appears, stop and report** — another caller means this is not a clean delete.
+
+- [ ] **Step 2: Delete and tidy**
+
+```bash
+git rm internal/breakglass/gcp_secret_manager.go
+go mod tidy
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `cd services/marketplace-api && go build ./... && go test ./internal/breakglass/ -v`
+Expected: builds clean, tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "chore(breakglass): delete the GCP Secret Manager client for a decommissioned backend"
+```
+
+---
+
+### Task 6: Wire and mount in `main.go`
+
+**Files:**
+- Modify: `services/marketplace-api/cmd/marketplace-api/main.go`
+- Modify: `services/marketplace-api/internal/handlers/admin/routes.go` (if the login route registers there)
+
+- [ ] **Step 1: Build the issuer and the Bao-backed secret manager**
+
+Construct `HTTPIssuer` from config, falling back to `NoopIssuer` when unset so a misconfigured deploy fails loudly at first use rather than serving an unauthenticated route:
+
+```go
+	var bgIssuer authbffclient.SessionIssuer = authbffclient.NoopIssuer{}
+	if cfg.AuthBFFInternalURL != "" && cfg.AuthBFFInternalServiceKey != "" {
+		bgIssuer = authbffclient.NewHTTPIssuer(
+			cfg.AuthBFFInternalURL,
+			cfg.AuthBFFInternalServiceKey,
+			cfg.SessionCookieName,
+			tenantSlugLookup,
+		)
+	} else {
+		log.Warn("break-glass: no auth-bff internal config; login will return 500 until set")
+	}
+```
+
+- [ ] **Step 2: Mount the login route OUTSIDE the store-scoped group**
+
+The handler's own comment is explicit: it must survive `read_only` / `store_closed` subscription states (§12.4). Gate it with `plangate.RequireFeature(FeatureSSO)` — break-glass exists for SSO tenants.
+
+```go
+	bgHandler := admin.NewBreakGlassLoginHandler(admin.BreakGlassDeps{
+		Repo: bgRepo, Secrets: bgSecrets, Audit: bgAudit, Slack: bgSlack,
+		RateLimiter: bgLimiter, IPHMACKey: bgHMACKey,
+		Sessions: bgIssuer, Logger: appLogger,
+	})
+	adminRoot.POST("/break-glass/login",
+		plangate.RequireFeature(plangate.FeatureSSO),
+		bgHandler.Login)
+```
+
+- [ ] **Step 3: Mount the SSO routes**
+
+Same issuer. Register `SSOLoginHandler`'s `Login`, `Callback`, `Logout` on the public group.
+
+- [ ] **Step 4: Prove the routes exist**
+
+Add a route-registration test — an unmounted route is this codebase's recurring silent failure, so assert presence directly:
+
+```go
+func TestBreakGlassLoginRouteIsMounted(t *testing.T) {
+	r := buildTestRouter(t)
+	found := false
+	for _, ri := range r.Routes() {
+		if ri.Method == http.MethodPost && strings.HasSuffix(ri.Path, "/break-glass/login") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("POST /break-glass/login is not registered — the handler exists but is unreachable")
+	}
+}
+```
+
+- [ ] **Step 5: Build, test, commit**
+
+```bash
+cd services/marketplace-api && go build ./... && go test ./... 
+git add -A
+git commit -m "feat(marketplace-api): mount the break-glass login and SSO routes"
+```
+
+---
+
+### Task 7: Config and deployment
+
+**Ordering matters and is the opposite of intuition** for the two directions:
+
+- `AUTH_BFF_INTERNAL_URL` / `AUTH_BFF_INTERNAL_SERVICE_KEY` are **new required-ish config**, so the **cluster change goes first**: add the env vars and the ExternalSecret, then ship the code that reads them. Shipping code first would crashloop on validate.
+- The OpenBao grant needs a `break-glass/*` path policy for the marketplace-api roles. CronJobs inherit the deployment ServiceAccount, so the existing grant machinery applies — what a new path needs is the policy line, not new IAM.
+
+- [ ] **Step 1: tesserix-k8s — add the env vars + secret, chart version bump, merge, confirm synced**
+- [ ] **Step 2: Extend the OpenBao policy to `kv/data/mark8ly/break-glass/*`**
+- [ ] **Step 3: Only then merge the marketplace-api change**
+
+---
+
+### Task 8: Provision accounts and verify end to end
+
+Zero break-glass accounts exist today, so the feature is not real until this runs.
+
+- [ ] **Step 1: Run `Bootstrapper` for each Pro+SSO tenant** — verify the OpenBao blob exists and the DB row references it, and that a store failure leaves **no** DB row.
+- [ ] **Step 2: Confirm the credentials are delivered to their owner out-of-band.** Never paste a password or TOTP secret into a PR, issue, log, or chat.
+- [ ] **Step 3: End-to-end** — a correct password+TOTP returns 200 with `Set-Cookie`; the cookie is accepted by marketplace-api-admin (this is the §4 claim, proven against the live Istio policy rather than the manifest).
+- [ ] **Step 4: Negative** — wrong factor returns the uniform `invalid_credentials`; the lockout path still trips; the Slack alert and `severity=critical` audit event both fire.
+- [ ] **Step 5: Audit `session-exchange` callers** for any that assume a non-empty `access_token`, since break-glass sessions return empty strings there.

--- a/docs/superpowers/plans/2026-09-07-break-glass-activation-v2.md
+++ b/docs/superpowers/plans/2026-09-07-break-glass-activation-v2.md
@@ -29,7 +29,17 @@ Every symbol below was read in the tree before being written down.
 spec's central safety control ("must never default to `staff`") and there is
 nothing for it to guard today. Added as
 `AuthContext string \`json:"auth_context,omitempty"\`` so existing cookies stay
-valid and decode with an empty value. Task 0 audits consumers before it lands.
+valid and decode with an empty value.
+
+> **Amended after the Task 0 audit.** Three call sites rebuild `Session` as a
+> fresh struct literal, copying named fields: `switchTenant`
+> (`auth-bff/internal/session/handler.go:483`), `switchStore` (`:538`) and
+> `adminhandoff` (`handler.go:135`). Adding the field without patching all
+> three ships a safety control that **any merchant strips by calling
+> `POST /auth/switch-store` once** — a control that would be trusted and be
+> wrong. All four changes land in one commit, with a test per site asserting
+> the value survives. This is the same shape as the mobile IDP provider being
+> pinned in three services where two hops dropped it invisibly.
 
 **D2 — the internal endpoint follows `X-Internal-Auth`.** Not Bearer, not
 mTLS. Both the code comment in `session_issuer.go` and the design spec's
@@ -39,12 +49,51 @@ for one endpoint would be a new thing to get wrong.
 
 **D3 — the synthetic principal keeps the id the code already derives.**
 `Session.UID` = `BreakGlassUserID(tenantID).String()`. It is stable per
-tenant, so audit trails join, and no new identity scheme is invented. Task 0
-checks what breaks when that UID has no user row.
+tenant, so audit trails join, and no new identity scheme is invented.
+
+> **Amended after the Task 0 audit: this is not safe on its own.** A UID with
+> no FGA tuple is refused by three authorization gates, and every admin
+> request passes at least one:
+>
+> - `apps/admin/middleware.ts:407-435` → platform-api `getMe`
+>   (`internal/tenant/handler.go:176-182`) answers 404 `no_role`, and the
+>   middleware redirects to login. **A correct break-glass login bounces back
+>   to `/login` in a loop, with nothing naming the cause.**
+> - `marketplace-api/internal/authz/middleware.go:41` `RequireTenantRelation`
+>   → 404 on every admin API route.
+> - auth-bff `switchTenant` (`handler.go:460`) and `adminhandoff` (`:113`)
+>   `CheckMembership` → 403. The `/pick-tenant` recovery surface is empty too,
+>   since it is driven by `listMyTenants(uid)`.
+>
+> **It passes in local dev and fails only in production**: `handler.go:171-174`
+> returns `role: owner` unconditionally when `fga == nil`. A green local login
+> is not evidence.
+>
+> One fix covers all three — an FGA tuple for `BreakGlassUserID(tenant)` on
+> that tenant. Tenant membership in this estate is a tuple, never a DB column,
+> so this is one additive write. It becomes **Task 5a**, and it gates Task 6.
 
 ---
 
-### Task 0 — consumer audit (NEW, and it gates everything)
+### Task 0 — consumer audit — **DONE**
+
+Report: `docs/superpowers/artifacts/2026-09-07-break-glass-session-consumer-audit.md`.
+21 consumers examined. Verdict: `AuthContext` safe to add (subject to D1's
+amendment); a non-resolving `UID` **not** safe (see D3's amendment, now Task 5a).
+
+It also voided one of the design spec's risks: §7's "a caller assumes
+`session-exchange` returns a non-empty access_token" describes a system that
+does not exist — `Session` has no token field at all (`cookie.go:41-53`), and
+the estate's only token exchange is the mobile bearer path in
+`zitadellogin/token_exchange.go`, which never touches the cookie. Delete that
+risk row rather than mitigating it.
+
+And it settled a Task 3 question: `SessionIssuer` passing no email is fine —
+every consumer treats `Email` as an optional attribution label with a fallback,
+and nothing looks a user up by it. `auth_context` is the only reason to widen
+the interface, because unlike email it must never be defaulted by the callee.
+
+<details><summary>Original brief</summary>
 
 Neither D1 nor D3 is safe until we know who reads a session and what they
 assume. This task writes no feature code.
@@ -66,6 +115,8 @@ a symbol that does not exist — this task is what that risk actually needed.
 **Do not proceed to Task 2 until this is done.** It is the one step that can
 turn "break-glass works" into "break-glass mints a session that half the
 estate rejects".
+
+</details>
 
 ### Task 1 — export the encoder in auth-bff
 
@@ -106,6 +157,22 @@ auth context. Either widen it or have `HTTPIssuer` supply
 `auth_context: "break_glass"` and a synthetic email itself. Widening is
 cleaner but touches the SSO caller too; decide with Task 0's findings in hand
 and record which was chosen and why.
+
+### Task 5a — grant the break-glass principal its tenant relation (NEW)
+
+Gates Task 6. Write an FGA tuple for `BreakGlassUserID(tenant)` on its tenant,
+so the three gates in D3 admit it. Decide and record **where**: at provisioning
+(`Bootstrapper`, alongside the secret and the row) or at login.
+
+Provisioning is the better default — it keeps the emergency path free of a new
+dependency, which is the whole point of break-glass and the constraint #404
+insists on. Doing it at login would mean an FGA write on the path that must
+work when everything else is broken.
+
+**Done when:** a provisioned break-glass principal gets past
+`apps/admin/middleware.ts` and `RequireTenantRelation` **against real FGA**.
+Not against a `nil` client — that returns `role: owner` unconditionally and
+proves nothing.
 
 ### Tasks 4–8 — carried over, spot-checked
 

--- a/docs/superpowers/plans/2026-09-07-break-glass-activation-v2.md
+++ b/docs/superpowers/plans/2026-09-07-break-glass-activation-v2.md
@@ -1,0 +1,143 @@
+# Break-glass activation — implementation plan (v2)
+
+**Supersedes:** `2026-09-04-break-glass-activation.md`, whose errata section
+lists the six wrong claims that made it unexecutable.
+**Issue:** #642. **Unblocks:** #404.
+**Corrects:** the merged design spec `2026-09-04-break-glass-activation-design.md`
+(§5.1 and its "correction" footnote), which is wrong about the same things.
+
+Every symbol below was read in the tree before being written down.
+
+## Verified state — what is actually there
+
+| Thing | Reality | Where |
+|---|---|---|
+| Session cookie type | `session.Manager`, `NewManager(cfg Config)` | `auth-bff/internal/session/cookie.go:91` |
+| Encode | **`m.encode(s Session)` already exists**, already used by `MintWithDomain` | `cookie.go:222`, `:156` |
+| Writers / readers | `Mint`, `MintWithDomain`, `Read`, `decode` — take `http.ResponseWriter` / `*http.Request` | `cookie.go:128,143,182,240` |
+| `Session` fields | `UID, Email, TenantID, StoreID, IssuedAt, ExpiresAt` — `time.Time`, **no auth context** | `cookie.go:41-53` |
+| `/internal` auth | shared **`X-Internal-Auth`** header, `internalauth.Equal` (sha256 + constant time), applied **per route inside the handler** | `internalauth/internalauth.go:29`, `cmd/server/main.go:425` |
+| Break-glass principal id | **already deterministic** — `BreakGlassUserID(tenantID)` = UUIDv5 in a fixed namespace | `marketplace-api/internal/handlers/admin/break_glass_login.go:251-258` |
+| Session TTL | `BreakGlassSessionTTL = 2h`, already const | `break_glass_login.go:21` |
+| `SecretClient` | `AddVersion` / `AccessLatest` — matches `carriersecrets.BaoClient`'s `CreateOrAddVersion` / `AccessLatest` | `breakglass/secret_manager.go:25`, `carriersecrets/bao.go:61,88` |
+| `FeatureSSO` | exists, `Disabled` on the low tier | `plangate/matrix.go:57,158` |
+| Break-glass config | **absent** from `pkg/config` | — |
+
+## Decisions taken before planning
+
+**D1 — `AuthContext` becomes a `Session` field.** `auth_context` is the
+spec's central safety control ("must never default to `staff`") and there is
+nothing for it to guard today. Added as
+`AuthContext string \`json:"auth_context,omitempty"\`` so existing cookies stay
+valid and decode with an empty value. Task 0 audits consumers before it lands.
+
+**D2 — the internal endpoint follows `X-Internal-Auth`.** Not Bearer, not
+mTLS. Both the code comment in `session_issuer.go` and the design spec's
+"correction" of it are wrong; the pattern that exists and works is the header
+compared by `internalauth.Equal`. Introducing a second inbound auth mechanism
+for one endpoint would be a new thing to get wrong.
+
+**D3 — the synthetic principal keeps the id the code already derives.**
+`Session.UID` = `BreakGlassUserID(tenantID).String()`. It is stable per
+tenant, so audit trails join, and no new identity scheme is invented. Task 0
+checks what breaks when that UID has no user row.
+
+---
+
+### Task 0 — consumer audit (NEW, and it gates everything)
+
+Neither D1 nor D3 is safe until we know who reads a session and what they
+assume. This task writes no feature code.
+
+Enumerate every reader of the session cookie and of the `X-User-Id` header
+derived from it — `apps/admin`, `apps/storefront`, `marketplace-api`'s
+`auth.HeaderTrustAuth` path — and answer, per consumer:
+
+- does it assume `UID` resolves to a real user row? A break-glass UID does not.
+- does it assume `Email` is a real mailbox?
+- does adding an unknown JSON field break its decode? (Go: no. TypeScript
+  with a strict schema validator: possibly.)
+
+**Done when:** a written list of consumers with a verdict each, and any that
+break have a fix named. The design spec's §7 already flags "a caller assumes
+`session-exchange` returns a non-empty access_token" as a risk and then names
+a symbol that does not exist — this task is what that risk actually needed.
+
+**Do not proceed to Task 2 until this is done.** It is the one step that can
+turn "break-glass works" into "break-glass mints a session that half the
+estate rejects".
+
+### Task 1 — export the encoder in auth-bff
+
+`encode` already exists. Add an exported wrapper that stamps `IssuedAt` /
+`ExpiresAt` the way `MintWithDomain` does (`cookie.go:147-153`) and returns
+the value, so `MintWithDomain` and the new endpoint share one path.
+
+Add the `AuthContext` field from D1 in the same commit, with a round-trip
+test through `encode`/`decode` (**not** `LoadFromValue` — it does not exist)
+asserting an empty `AuthContext` on an old-shaped cookie.
+
+**Done when:** `go test ./internal/session/` passes including the pre-existing
+`Mint`/`Read` tests. This is a refactor plus one additive field; any existing
+test changing behaviour means something was got wrong.
+
+### Task 2 — `POST /internal/mint-session` in auth-bff
+
+Mount on the existing `/internal` group (`cmd/server/main.go:425`), guarded
+**inside the handler** by `internalauth.Equal(c.GetHeader(internalauth.Header), secret)`,
+failing closed when the secret is unset — copying `InternalUsersHandler`
+(`internal/session/internal_users.go:69`) rather than inventing a shape.
+
+Request carries tenant id, user id, email, `auth_context`, ttl. Response is
+`{"set_cookie": "..."}`.
+
+`auth_context` is an explicit allow-list — `staff`, `customer`, `break_glass`
+— rejecting anything else with 400 and **never defaulting**. One unit test per
+accepted value plus one for a rejected typo.
+
+### Task 3 — `HTTPIssuer` in marketplace-api
+
+Implement `authbffclient.SessionIssuer` over that endpoint. `NoopIssuer`
+stays the default when config is absent, so a misconfigured deploy fails
+loudly rather than serving an unauthenticated route.
+
+Note the interface passes only `(tenantID, userID, ttl)` — no email, no
+auth context. Either widen it or have `HTTPIssuer` supply
+`auth_context: "break_glass"` and a synthetic email itself. Widening is
+cleaner but touches the SSO caller too; decide with Task 0's findings in hand
+and record which was chosen and why.
+
+### Tasks 4–8 — carried over, spot-checked
+
+`SecretClient` and `carriersecrets.BaoClient` line up exactly as the spec
+says, and `gcp_secret_manager.go` and `FeatureSSO` exist, so §5.3–5.5 of the
+design are sound. Detail:
+
+4. **OpenBao adapter** — `breakglass/bao_secret_client.go`, thin, path
+   `break-glass/{tenant_id}`. Preserve `Bootstrapper`'s secret-write-before-DB
+   ordering so a Bao failure leaves no orphan row.
+5. **Delete `gcp_secret_manager.go`** and the dead Terraform IAM. An unused
+   client whose IAM was revoked is a trap for the next reader.
+6. **Mount** `POST /admin/break-glass/login` outside the `RequireActive`
+   group (it must survive `read_only` / `store_closed`), gated by
+   `plangate.RequireFeature(FeatureSSO)`. Mount the SSO routes too — they
+   share the issuer. **`BreakGlassWriteHandler` and `BreakGlassLoginHandler`
+   must share ONE `*LoginRateLimiter`**; two instances means clear-lockout
+   resets a map nobody reads and reports success while clearing nothing.
+7. **Config** — `pkg/config` has no break-glass fields at all. Adding
+   required config is a **k8s-first** change: env lands before the code that
+   reads it, or the service crash-loops. Grep every reader, not just `Validate()`.
+8. **Provision + verify end to end.** Zero accounts exist. Prove the route is
+   **absent before and present after** — a GET on a POST-only route answers
+   405 when mounted and 404 when not, which distinguishes the two without
+   attempting a login.
+
+These five were not re-verified symbol by symbol the way Tasks 0–3 were.
+Treat their detail as probable, not established, and check before executing
+each.
+
+## Then #404
+
+Its code is merged (#641) and deliberately unmounted. Once the above is real,
+mounting it is the one-line dependency fill the issue describes — plus the
+shared-rate-limiter wiring in Task 6, which is the part that silently breaks.

--- a/docs/superpowers/plans/2026-09-07-break-glass-activation-v2.md
+++ b/docs/superpowers/plans/2026-09-07-break-glass-activation-v2.md
@@ -195,9 +195,25 @@ design are sound. Detail:
    required config is a **k8s-first** change: env lands before the code that
    reads it, or the service crash-loops. Grep every reader, not just `Validate()`.
 8. **Provision + verify end to end.** Zero accounts exist. Prove the route is
-   **absent before and present after** — a GET on a POST-only route answers
-   405 when mounted and 404 when not, which distinguishes the two without
-   attempting a login.
+   **absent before and present after**.
+
+   > **Do NOT use the 405-vs-404 probe.** #642's evidence block and this
+   > plan's earlier draft both claim "a GET on a POST-only route returns 405
+   > when mounted and 404 when not". That is false in this estate:
+   > `HandleMethodNotAllowed` is never set in **any** service, so gin's
+   > default of `false` applies and a GET on a *mounted* POST-only route also
+   > returns 404. The probe cannot distinguish the two states.
+   >
+   > #642's conclusion was right for an unrelated reason —
+   > `NewBreakGlassLoginHandler` is constructed only in tests — but anyone
+   > re-running that probe after mounting will see 404, conclude the mount
+   > failed, and go hunting a bug that is not there.
+   >
+   > Prove mounting instead by comparing a bare router against one with
+   > `Register()` called, both driven through `router.ServeHTTP` — the shape
+   > Task 2 used (`TestMintSession_RouteIsMountedOnInternalGroup`). Against a
+   > running pod, POST with a deliberately invalid body: an unmounted route
+   > 404s, a mounted one answers its own validation or auth error.
 
 These five were not re-verified symbol by symbol the way Tasks 0–3 were.
 Treat their detail as probable, not established, and check before executing

--- a/docs/superpowers/specs/2026-09-04-break-glass-activation-design.md
+++ b/docs/superpowers/specs/2026-09-04-break-glass-activation-design.md
@@ -1,11 +1,38 @@
 # Break-glass activation — design
 
-**Status:** proposed
+**Status:** accepted, with §5.1 corrected — see the correction block below
 **Issues:** closes #642 (turn it on), unblocks #404 (write operations)
 **Supersedes the unfinished parts of:** `docs/superpowers/plans/2026-04-18-p13-sso-break-glass.md`
 
 **Goal:** make the break-glass emergency admin login reachable, and mount the
 per-tenant SSO login routes that share its one missing dependency.
+
+
+> ## Correction (2026-09-07)
+>
+> §5.1's account of auth-bff is wrong, and so is the footnote in which it
+> "corrects" `session_issuer.go`'s own comment. Verified in the tree:
+>
+> - There is no `CookieStore`, no `Save`, no `LoadFromValue`. The type is
+>   `session.Manager`; the writers are `Mint` / `MintWithDomain`; the readers
+>   are `Read` / `decode`. An **`encode` method already exists**
+>   (`cookie.go:222`), so §5.1's "extract the encrypt step" describes work
+>   already done.
+> - The `/internal` group is **not** "a Bearer service key plus rate
+>   limiting". It is a shared **`X-Internal-Auth`** header compared by
+>   `internalauth.Equal` (sha256, constant time), applied per route inside the
+>   handler, with no rate limiting. `cmd/server/main.go:425`,
+>   `internal/session/internal_users.go:69`.
+> - `IsKnownSessionCookie` and `session-exchange`, cited as the precedent the
+>   `auth_context` allow-list follows, **do not exist anywhere in this
+>   repository** — Go or TypeScript. The allow-list is still right; it simply
+>   has no precedent, and `Session` has no `auth_context` field for it to
+>   guard. Adding one is a change to the shared cookie payload.
+>
+> The design's intent is unaffected: mint the session in auth-bff, keep cookie
+> cryptography there, port the secret store to OpenBao. Only its account of
+> the existing code was unreliable. The executable version is
+> `plans/2026-09-07-break-glass-activation-v2.md`.
 
 ---
 

--- a/services/auth-bff/cmd/server/main.go
+++ b/services/auth-bff/cmd/server/main.go
@@ -431,6 +431,17 @@ func main() {
 	)
 	internalUsers.Register(internalGroup)
 
+	// POST /internal/mint-session lets marketplace-api ask auth-bff to
+	// mint a session cookie for a principal it has already authenticated
+	// (break-glass login today, SSO callback later). Cookie cryptography
+	// stays here — marketplace-api never signs a session cookie itself.
+	mintSession := session.NewMintSessionHandler(
+		sessions,
+		cfg.MarketplaceInternalAuthSecret,
+		log,
+	)
+	mintSession.Register(internalGroup)
+
 	if err := httpserver.Run(ctx, cfg.HTTPPort, r, log); err != nil {
 		log.Error("http server", "err", err)
 		panic(err)

--- a/services/auth-bff/internal/adminhandoff/code.go
+++ b/services/auth-bff/internal/adminhandoff/code.go
@@ -44,6 +44,11 @@ type Claims struct {
 	StoreID    string `json:"store_id,omitempty"`
 	TargetHost string `json:"target_host"`
 	Exp        int64  `json:"exp"` // Unix epoch seconds
+	// AuthContext mirrors session.Session.AuthContext — carried across
+	// the cross-TLD handoff so a break-glass (or any non-default)
+	// session doesn't lose its marker mid-hop. Empty on codes minted
+	// before this field existed; omitempty keeps those decoding.
+	AuthContext string `json:"auth_context,omitempty"`
 }
 
 // Errors returned by Verify. Callers map these to HTTP status codes.

--- a/services/auth-bff/internal/adminhandoff/handler.go
+++ b/services/auth-bff/internal/adminhandoff/handler.go
@@ -133,11 +133,12 @@ func (h *Handler) mint(c *gin.Context) {
 
 	now := time.Now()
 	s := session.Session{
-		UID:      claims.UID,
-		Email:    claims.Email,
-		TenantID: claims.TenantID,
-		StoreID:  claims.StoreID,
-		IssuedAt: now,
+		UID:         claims.UID,
+		Email:       claims.Email,
+		TenantID:    claims.TenantID,
+		StoreID:     claims.StoreID,
+		IssuedAt:    now,
+		AuthContext: claims.AuthContext,
 		// Empty ExpiresAt → Manager applies its configured maxAge.
 	}
 	if err := h.cfg.Sessions.MintWithDomain(c.Writer, s, claims.TargetHost); err != nil {

--- a/services/auth-bff/internal/adminhandoff/handler_test.go
+++ b/services/auth-bff/internal/adminhandoff/handler_test.go
@@ -184,6 +184,31 @@ func TestMint_RejectsCanonicalTargetHost(t *testing.T) {
 	}
 }
 
+// TestMint_PreservesAuthContext is the regression test for the third
+// rebuild site D1's amendment names: the cross-TLD handoff must not
+// silently drop AuthContext off the Session it mints.
+func TestMint_PreservesAuthContext(t *testing.T) {
+	minter := &fakeMinter{}
+	h := adminhandoff.NewHandler(adminhandoff.Config{
+		HMACKey:  testKey,
+		FGA:      &fakeFGA{allow: true},
+		Sessions: minter,
+	})
+
+	c := handlerClaims()
+	c.AuthContext = "break_glass"
+	w := postCode(t, makeRouter(h), mintCode(t, c, testKey))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200, body=%s", w.Code, w.Body.String())
+	}
+	if !minter.called {
+		t.Fatal("minter was not called")
+	}
+	if minter.gotS.AuthContext != "break_glass" {
+		t.Errorf("AuthContext = %q, want %q — adminhandoff dropped it", minter.gotS.AuthContext, "break_glass")
+	}
+}
+
 func TestMint_RejectsFGAError(t *testing.T) {
 	fga := &fakeFGA{err: errors.New("boom")}
 	h := adminhandoff.NewHandler(adminhandoff.Config{

--- a/services/auth-bff/internal/session/cookie.go
+++ b/services/auth-bff/internal/session/cookie.go
@@ -176,22 +176,40 @@ func (m *Manager) MintWithDomain(w http.ResponseWriter, s Session, domainOverrid
 		return err
 	}
 
+	http.SetCookie(w, m.buildCookie(encoded, domainOverride))
+	return nil
+}
+
+// buildCookie constructs the *http.Cookie with the attributes every minted
+// session cookie shares (path, domain, max-age, HttpOnly, Secure,
+// SameSite=Lax). MintWithDomain and BuildSetCookieHeader both go through
+// this so the attribute list can't drift between the two callers.
+func (m *Manager) buildCookie(value, domainOverride string) *http.Cookie {
 	domain := m.domain
 	if domainOverride != "" {
 		domain = domainOverride
 	}
-
-	http.SetCookie(w, &http.Cookie{
+	return &http.Cookie{
 		Name:     m.cookieName,
-		Value:    encoded,
+		Value:    value,
 		Path:     "/",
 		Domain:   domain,
 		MaxAge:   int(m.maxAge.Seconds()),
 		HttpOnly: true,
 		Secure:   m.secure,
 		SameSite: http.SameSiteLaxMode, // auth-bug #4 fix: Lax not Strict
-	})
-	return nil
+	}
+}
+
+// BuildSetCookieHeader returns the full Set-Cookie header VALUE (not the
+// header name) for an already-encoded session value, using the same
+// attributes MintWithDomain writes. Used by callers that hand the cookie
+// back in a JSON response instead of writing it directly onto a
+// http.ResponseWriter — e.g. POST /internal/mint-session, whose caller
+// (marketplace-api) does `c.Writer.Header().Add("Set-Cookie", setCookie)`
+// with the string verbatim.
+func (m *Manager) BuildSetCookieHeader(value, domainOverride string) string {
+	return m.buildCookie(value, domainOverride).String()
 }
 
 // Read parses and validates the session cookie from a request. Returns

--- a/services/auth-bff/internal/session/cookie.go
+++ b/services/auth-bff/internal/session/cookie.go
@@ -50,6 +50,13 @@ type Session struct {
 	StoreID   string    `json:"store_id,omitempty"`
 	IssuedAt  time.Time `json:"iat"`
 	ExpiresAt time.Time `json:"exp"`
+	// AuthContext discriminates how this session was established —
+	// e.g. "staff", "customer", "break_glass". Empty on cookies minted
+	// before this field existed (`omitempty` keeps those decoding), and
+	// must never be defaulted by a reader: an unset AuthContext must
+	// stay unset, not silently become "staff". See docs/superpowers/plans/
+	// 2026-09-07-break-glass-activation-v2.md decision D1.
+	AuthContext string `json:"auth_context,omitempty"`
 }
 
 // IsExpired returns true if the session is past its exp.
@@ -138,11 +145,18 @@ func (m *Manager) Mint(w http.ResponseWriter, s Session) error {
 // hop. domainOverride must be a host the caller has authority for —
 // validation lives in the calling handler, not here.
 //
-// Empty domainOverride falls through to the manager's configured domain
-// (the canonical .mark8ly.com path).
-func (m *Manager) MintWithDomain(w http.ResponseWriter, s Session, domainOverride string) error {
+// EncodeSession stamps IssuedAt/ExpiresAt exactly the way MintWithDomain
+// does (only when zero, using one `now`), validates that UID is
+// non-empty, and returns the encrypted cookie value — without writing
+// it anywhere. MintWithDomain is built on top of this so there is a
+// single path that stamps and encodes a Session.
+//
+// This exists for callers that need a cookie VALUE without an
+// http.ResponseWriter — e.g. an internal endpoint that hands the value
+// back in a JSON response for another service to Set-Cookie.
+func (m *Manager) EncodeSession(s Session) (string, error) {
 	if s.UID == "" {
-		return errors.New("session: UID is required")
+		return "", errors.New("session: UID is required")
 	}
 	now := time.Now()
 	if s.IssuedAt.IsZero() {
@@ -151,8 +165,13 @@ func (m *Manager) MintWithDomain(w http.ResponseWriter, s Session, domainOverrid
 	if s.ExpiresAt.IsZero() {
 		s.ExpiresAt = now.Add(m.maxAge)
 	}
+	return m.encode(s)
+}
 
-	encoded, err := m.encode(s)
+// Empty domainOverride falls through to the manager's configured domain
+// (the canonical .mark8ly.com path).
+func (m *Manager) MintWithDomain(w http.ResponseWriter, s Session, domainOverride string) error {
+	encoded, err := m.EncodeSession(s)
 	if err != nil {
 		return err
 	}

--- a/services/auth-bff/internal/session/cookie_test.go
+++ b/services/auth-bff/internal/session/cookie_test.go
@@ -1,6 +1,9 @@
 package session
 
 import (
+	"crypto/rand"
+	"encoding/base64"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -70,6 +73,20 @@ func TestNewManager_AcceptsAES128_192_256(t *testing.T) {
 	}
 }
 
+// encryptForTest AES-GCM encrypts arbitrary raw JSON the same way encode
+// does, without going through json.Marshal(Session{...}) — used to
+// simulate a cookie shaped by an older version of Session that never
+// had an auth_context field at all.
+func encryptForTest(t *testing.T, m *Manager, plaintextJSON string) string {
+	t.Helper()
+	nonce := make([]byte, m.gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		t.Fatalf("nonce: %v", err)
+	}
+	ciphertext := m.gcm.Seal(nonce, nonce, []byte(plaintextJSON), nil)
+	return base64.RawURLEncoding.EncodeToString(ciphertext)
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // Round-trip
 // ─────────────────────────────────────────────────────────────────────────
@@ -108,6 +125,55 @@ func TestMintAndRead_RoundTrip(t *testing.T) {
 	}
 	if got.TenantID != original.TenantID {
 		t.Errorf("TenantID = %q, want %q", got.TenantID, original.TenantID)
+	}
+}
+
+// TestEncodeSession_RoundTripsAuthContext exercises the exported
+// EncodeSession -> decode path directly (not LoadFromValue — it does
+// not exist) and asserts AuthContext survives the round trip.
+func TestEncodeSession_RoundTripsAuthContext(t *testing.T) {
+	m := newTestManager(t)
+
+	original := Session{
+		UID:         "user-123",
+		TenantID:    "tenant-1",
+		AuthContext: "break_glass",
+	}
+	encoded, err := m.EncodeSession(original)
+	if err != nil {
+		t.Fatalf("EncodeSession: %v", err)
+	}
+
+	got, err := m.decode(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.AuthContext != "break_glass" {
+		t.Errorf("AuthContext = %q, want %q", got.AuthContext, "break_glass")
+	}
+}
+
+// TestDecode_OldShapedCookieDefaultsAuthContextEmpty proves backward
+// compatibility: a cookie encoded before AuthContext existed (plain
+// JSON with no auth_context key) still decodes, with AuthContext =="".
+func TestDecode_OldShapedCookieDefaultsAuthContextEmpty(t *testing.T) {
+	m := newTestManager(t)
+
+	// Simulate a pre-AuthContext cookie by encrypting JSON with the
+	// field entirely absent, the way json.Marshal(Session{...}) would
+	// have produced before this field existed.
+	oldShaped := `{"uid":"user-123","email":"u@example.com","tenant_id":"tenant-1","iat":"2026-01-01T00:00:00Z","exp":"2099-01-01T00:00:00Z"}`
+	encoded := encryptForTest(t, m, oldShaped)
+
+	got, err := m.decode(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.AuthContext != "" {
+		t.Errorf("AuthContext = %q, want empty on old-shaped cookie", got.AuthContext)
+	}
+	if got.UID != "user-123" {
+		t.Errorf("UID = %q, want user-123", got.UID)
 	}
 }
 

--- a/services/auth-bff/internal/session/handler.go
+++ b/services/auth-bff/internal/session/handler.go
@@ -481,11 +481,12 @@ func (h *Handler) switchTenant(c *gin.Context) {
 	// store" and the admin resolves a new default on next render.
 	now := time.Now()
 	next := Session{
-		UID:       existing.UID,
-		Email:     existing.Email,
-		TenantID:  req.TenantID,
-		IssuedAt:  now,
-		ExpiresAt: existing.ExpiresAt,
+		UID:         existing.UID,
+		Email:       existing.Email,
+		TenantID:    req.TenantID,
+		IssuedAt:    now,
+		ExpiresAt:   existing.ExpiresAt,
+		AuthContext: existing.AuthContext,
 	}
 	if err := h.mgr.Mint(c.Writer, next); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -536,12 +537,13 @@ func (h *Handler) switchStore(c *gin.Context) {
 
 	now := time.Now()
 	next := Session{
-		UID:       existing.UID,
-		Email:     existing.Email,
-		TenantID:  existing.TenantID,
-		StoreID:   req.StoreID,
-		IssuedAt:  now,
-		ExpiresAt: existing.ExpiresAt,
+		UID:         existing.UID,
+		Email:       existing.Email,
+		TenantID:    existing.TenantID,
+		StoreID:     req.StoreID,
+		IssuedAt:    now,
+		ExpiresAt:   existing.ExpiresAt,
+		AuthContext: existing.AuthContext,
 	}
 	if err := h.mgr.Mint(c.Writer, next); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{

--- a/services/auth-bff/internal/session/mint_session.go
+++ b/services/auth-bff/internal/session/mint_session.go
@@ -1,0 +1,148 @@
+package session
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/auth-bff/internal/internalauth"
+)
+
+// allowedAuthContexts is the explicit allow-list for the auth_context
+// field on POST /internal/mint-session. This is the safety control the
+// endpoint exists to enforce: an unrecognized or absent value must be
+// rejected, never silently defaulted to "staff" — a typo minting a full
+// staff session is exactly the failure this guards against. See
+// docs/superpowers/plans/2026-09-07-break-glass-activation-v2.md, D1 and
+// Task 2.
+var allowedAuthContexts = map[string]bool{
+	"staff":       true,
+	"customer":    true,
+	"break_glass": true,
+}
+
+// MintSessionRequest is the payload marketplace-api sends to mint a
+// session cookie for a principal it has already authenticated (e.g. a
+// break-glass login, and later an SSO callback). auth-bff never trusts
+// the caller's authentication decision — it only turns an already-made
+// decision into a signed cookie, and enforces the auth_context
+// allow-list regardless of what the caller asserts.
+type MintSessionRequest struct {
+	TenantID    string `json:"tenant_id" binding:"required"`
+	TenantSlug  string `json:"tenant_slug"`
+	UserID      string `json:"user_id" binding:"required"`
+	Email       string `json:"email"`
+	AuthContext string `json:"auth_context"`
+	TTLSeconds  int    `json:"ttl_seconds"`
+}
+
+// MintSessionResponse carries the full Set-Cookie header VALUE (not the
+// header name). marketplace-api forwards it verbatim via
+// c.Writer.Header().Add("Set-Cookie", setCookie) — see
+// marketplace-api/internal/handlers/admin/break_glass_login.go.
+type MintSessionResponse struct {
+	SetCookie string `json:"set_cookie"`
+}
+
+// MintSessionHandler implements POST /internal/mint-session. Cookie
+// cryptography stays in auth-bff: marketplace-api must never sign a
+// session cookie itself, it only asks auth-bff to mint one for a
+// principal it has already authenticated.
+type MintSessionHandler struct {
+	sessions *Manager
+	secret   string
+	logger   *slog.Logger
+}
+
+// NewMintSessionHandler constructs the handler. secret is the expected
+// value of the X-Internal-Auth header; an empty secret disables the
+// endpoint entirely (every request returns 503) so a misconfigured
+// deploy fails closed instead of serving an unauthenticated route.
+func NewMintSessionHandler(sessions *Manager, secret string, logger *slog.Logger) *MintSessionHandler {
+	return &MintSessionHandler{
+		sessions: sessions,
+		secret:   secret,
+		logger:   logger,
+	}
+}
+
+// Register mounts POST /internal/mint-session onto the given router group.
+func (h *MintSessionHandler) Register(r *gin.RouterGroup) {
+	r.POST("/mint-session", h.mintSession)
+}
+
+func (h *MintSessionHandler) mintSession(c *gin.Context) {
+	if h.secret == "" {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error":   "not_configured",
+			"message": "internal auth secret is not configured",
+		})
+		return
+	}
+	if !internalauth.Equal(c.GetHeader(internalauth.Header), h.secret) {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error":   "unauthorized",
+			"message": "missing or invalid internal auth",
+		})
+		return
+	}
+
+	var req MintSessionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "invalid_request",
+			"message": "request body is invalid",
+		})
+		return
+	}
+
+	if !allowedAuthContexts[req.AuthContext] {
+		if h.logger != nil {
+			h.logger.Warn("mint-session: rejected auth_context",
+				"tenant_id", req.TenantID,
+			)
+		}
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "invalid_auth_context",
+			"message": "auth_context must be one of: staff, customer, break_glass",
+		})
+		return
+	}
+
+	s := Session{
+		UID:         req.UserID,
+		Email:       req.Email,
+		TenantID:    req.TenantID,
+		AuthContext: req.AuthContext,
+	}
+	if req.TTLSeconds > 0 {
+		now := time.Now()
+		s.IssuedAt = now
+		s.ExpiresAt = now.Add(time.Duration(req.TTLSeconds) * time.Second)
+	}
+
+	encoded, err := h.sessions.EncodeSession(s)
+	if err != nil {
+		if h.logger != nil {
+			h.logger.Error("mint-session: encode", "err", err, "tenant_id", req.TenantID)
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "internal_error",
+			"message": "failed to mint session",
+		})
+		return
+	}
+
+	setCookie := h.sessions.BuildSetCookieHeader(encoded, "")
+
+	if h.logger != nil {
+		h.logger.Info("mint-session: minted",
+			"tenant_id", req.TenantID,
+			"auth_context", req.AuthContext,
+		)
+	}
+
+	c.JSON(http.StatusOK, MintSessionResponse{SetCookie: setCookie})
+}

--- a/services/auth-bff/internal/session/mint_session_test.go
+++ b/services/auth-bff/internal/session/mint_session_test.go
@@ -1,0 +1,243 @@
+package session
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+const mintSessionSecret = "test-internal-secret"
+
+func mintSessionRouter(t *testing.T, mgr *Manager, secret string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	h := NewMintSessionHandler(mgr, secret, nil)
+	r := gin.New()
+	g := r.Group("/internal")
+	h.Register(g)
+	return r
+}
+
+func doMintSession(t *testing.T, router *gin.Engine, header string, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/internal/mint-session", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if header != "" {
+		req.Header.Set("X-Internal-Auth", header)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Allow-list acceptance — one per allowed value
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestMintSession_AcceptsAllowedAuthContexts(t *testing.T) {
+	for _, ac := range []string{"staff", "customer", "break_glass"} {
+		t.Run(ac, func(t *testing.T) {
+			mgr := newTestManager(t)
+			router := mintSessionRouter(t, mgr, mintSessionSecret)
+
+			body := `{"tenant_id":"tenant-a","user_id":"user-1","email":"user@example.com","auth_context":"` + ac + `"}`
+			w := doMintSession(t, router, mintSessionSecret, body)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status: got %d want 200, body=%s", w.Code, w.Body.String())
+			}
+
+			var resp MintSessionResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("unmarshal response: %v", err)
+			}
+			if resp.SetCookie == "" {
+				t.Fatal("expected non-empty set_cookie")
+			}
+			if !strings.Contains(resp.SetCookie, mgr.cookieName+"=") {
+				t.Errorf("set_cookie missing cookie name: %s", resp.SetCookie)
+			}
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Allow-list rejection — this is the point of the endpoint
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestMintSession_RejectsUnknownAuthContext(t *testing.T) {
+	mgr := newTestManager(t)
+	router := mintSessionRouter(t, mgr, mintSessionSecret)
+
+	body := `{"tenant_id":"tenant-a","user_id":"user-1","auth_context":"stff"}`
+	w := doMintSession(t, router, mintSessionSecret, body)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestMintSession_RejectsAbsentAuthContext(t *testing.T) {
+	mgr := newTestManager(t)
+	router := mintSessionRouter(t, mgr, mintSessionSecret)
+
+	body := `{"tenant_id":"tenant-a","user_id":"user-1"}`
+	w := doMintSession(t, router, mintSessionSecret, body)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestMintSession_RejectsEmptyAuthContext(t *testing.T) {
+	mgr := newTestManager(t)
+	router := mintSessionRouter(t, mgr, mintSessionSecret)
+
+	body := `{"tenant_id":"tenant-a","user_id":"user-1","auth_context":""}`
+	w := doMintSession(t, router, mintSessionSecret, body)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400, body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// X-Internal-Auth guard
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestMintSession_RejectsWrongInternalAuth(t *testing.T) {
+	mgr := newTestManager(t)
+	router := mintSessionRouter(t, mgr, mintSessionSecret)
+
+	body := `{"tenant_id":"tenant-a","user_id":"user-1","auth_context":"staff"}`
+	w := doMintSession(t, router, "wrong-secret", body)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status: got %d want 401, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestMintSession_RejectsMissingInternalAuth(t *testing.T) {
+	mgr := newTestManager(t)
+	router := mintSessionRouter(t, mgr, mintSessionSecret)
+
+	body := `{"tenant_id":"tenant-a","user_id":"user-1","auth_context":"staff"}`
+	w := doMintSession(t, router, "", body)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status: got %d want 401, body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestMintSession_FailsClosedWhenSecretEmpty is the config-absent case:
+// no caller can authenticate against an unconfigured secret, matching
+// InternalUsersHandler's fail-closed behaviour.
+func TestMintSession_FailsClosedWhenSecretEmpty(t *testing.T) {
+	mgr := newTestManager(t)
+	router := mintSessionRouter(t, mgr, "")
+
+	body := `{"tenant_id":"tenant-a","user_id":"user-1","auth_context":"staff"}`
+	w := doMintSession(t, router, "anything", body)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d want 503, body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Round trip through the real Manager
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestMintSession_CookieRoundTripsWithAuthContext(t *testing.T) {
+	mgr := newTestManager(t)
+	router := mintSessionRouter(t, mgr, mintSessionSecret)
+
+	body := `{"tenant_id":"tenant-a","user_id":"user-1","email":"user@example.com","auth_context":"break_glass","ttl_seconds":7200}`
+	w := doMintSession(t, router, mintSessionSecret, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200, body=%s", w.Code, w.Body.String())
+	}
+
+	var resp MintSessionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	// Parse the Set-Cookie header value the way net/http would, then feed
+	// it through the same Manager's Read to prove it decodes with
+	// AuthContext intact — this is the whole point: cryptography stays
+	// in auth-bff, and what marketplace-api forwards is exactly what
+	// auth-bff can read back.
+	header := http.Header{}
+	header.Add("Set-Cookie", resp.SetCookie)
+	respRec := http.Response{Header: header}
+	cookies := respRec.Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 cookie parsed from set_cookie, got %d", len(cookies))
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(cookies[0])
+
+	got, err := mgr.Read(req)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil session")
+	}
+	if got.UID != "user-1" {
+		t.Errorf("UID: got %q want %q", got.UID, "user-1")
+	}
+	if got.TenantID != "tenant-a" {
+		t.Errorf("TenantID: got %q want %q", got.TenantID, "tenant-a")
+	}
+	if got.AuthContext != "break_glass" {
+		t.Errorf("AuthContext: got %q want %q", got.AuthContext, "break_glass")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Route mounting — through the real router, not a direct handler call.
+// Proves the endpoint is actually wired the same way main.go wires it
+// onto the /internal group, guarding against the #642 failure mode where
+// a handler was constructed only in tests and never mounted.
+//
+// gin's default engine (as constructed by pkg/httpserver.New, which
+// main.go uses) does not enable HandleMethodNotAllowed, so a wrong
+// method and an absent route both answer 404 — a GET can't distinguish
+// them here. Instead this proves mounting the way that actually
+// discriminates on this engine: registering the handler on a router
+// group makes POST /internal/mint-session reachable (any response other
+// than 404), and a router with nothing registered on that path answers
+// 404 for the identical request.
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestMintSession_RouteIsMountedOnInternalGroup(t *testing.T) {
+	mgr := newTestManager(t)
+	body := `{"tenant_id":"tenant-a","user_id":"user-1","auth_context":"staff"}`
+
+	t.Run("unmounted router 404s", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		bare := gin.New()
+		w := doMintSession(t, bare, mintSessionSecret, body)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("bare router: got %d want 404, body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("mounted router reaches the handler", func(t *testing.T) {
+		router := mintSessionRouter(t, mgr, mintSessionSecret)
+		w := doMintSession(t, router, mintSessionSecret, body)
+		if w.Code == http.StatusNotFound {
+			t.Fatalf("route not mounted: POST /internal/mint-session returned 404")
+		}
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: got %d want 200, body=%s", w.Code, w.Body.String())
+		}
+	})
+}

--- a/services/auth-bff/internal/session/switch_test.go
+++ b/services/auth-bff/internal/session/switch_test.go
@@ -1,0 +1,110 @@
+package session
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// switchRouter mounts a bare Handler (no FGA — nil FGA degrades the
+// membership check to "allow any target id", which is fine for these
+// tests: they exercise the Session rebuild, not authorization).
+func switchRouter(mgr *Manager) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	h := NewHandler(mgr, nil)
+	r := gin.New()
+	g := r.Group("/auth")
+	h.Register(g)
+	return r
+}
+
+// requestWithSession mints a session cookie carrying the given
+// AuthContext and attaches it to a fresh request against the given path.
+func requestWithSession(t *testing.T, mgr *Manager, method, path, body string) *http.Request {
+	t.Helper()
+	w := httptest.NewRecorder()
+	if err := mgr.Mint(w, Session{
+		UID:         "user-1",
+		Email:       "user@example.com",
+		TenantID:    "tenant-a",
+		AuthContext: "break_glass",
+	}); err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	for _, c := range w.Result().Cookies() {
+		req.AddCookie(c)
+	}
+	return req
+}
+
+// TestSwitchTenant_PreservesAuthContext is the regression test for the
+// hole D1's amendment describes: a merchant calling POST
+// /auth/switch-tenant must not be able to silently strip AuthContext
+// off their own session by re-minting it.
+func TestSwitchTenant_PreservesAuthContext(t *testing.T) {
+	mgr := newTestManager(t)
+	router := switchRouter(mgr)
+
+	req := requestWithSession(t, mgr, http.MethodPost, "/auth/switch-tenant", `{"tenant_id":"tenant-b"}`)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200, body=%s", w.Code, w.Body.String())
+	}
+
+	nextReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	for _, c := range w.Result().Cookies() {
+		nextReq.AddCookie(c)
+	}
+	got, err := mgr.Read(nextReq)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Read returned nil session after switch-tenant")
+	}
+	if got.AuthContext != "break_glass" {
+		t.Errorf("AuthContext = %q, want %q — switch-tenant dropped it", got.AuthContext, "break_glass")
+	}
+	if got.TenantID != "tenant-b" {
+		t.Errorf("TenantID = %q, want tenant-b", got.TenantID)
+	}
+}
+
+// TestSwitchStore_PreservesAuthContext mirrors the switch-tenant
+// regression test for POST /auth/switch-store — the other rebuild site
+// D1's amendment names.
+func TestSwitchStore_PreservesAuthContext(t *testing.T) {
+	mgr := newTestManager(t)
+	router := switchRouter(mgr)
+
+	req := requestWithSession(t, mgr, http.MethodPost, "/auth/switch-store", `{"store_id":"store-b"}`)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200, body=%s", w.Code, w.Body.String())
+	}
+
+	nextReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	for _, c := range w.Result().Cookies() {
+		nextReq.AddCookie(c)
+	}
+	got, err := mgr.Read(nextReq)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Read returned nil session after switch-store")
+	}
+	if got.AuthContext != "break_glass" {
+		t.Errorf("AuthContext = %q, want %q — switch-store dropped it", got.AuthContext, "break_glass")
+	}
+	if got.StoreID != "store-b" {
+		t.Errorf("StoreID = %q, want store-b", got.StoreID)
+	}
+}

--- a/services/marketplace-api/internal/authbffclient/http_issuer.go
+++ b/services/marketplace-api/internal/authbffclient/http_issuer.go
@@ -1,0 +1,139 @@
+package authbffclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// internalAuthHeader carries the shared internal secret auth-bff
+// validates via internalauth.Equal on its side (auth-bff/internal/internalauth).
+// marketplace-api has no equivalent package to import — mobile_login.go
+// uses the same literal header name for the same reason.
+const internalAuthHeader = "X-Internal-Auth"
+
+// defaultHTTPIssuerTimeout bounds a single mint-session call. Issuance
+// happens synchronously inside a request handler (break-glass login,
+// SSO callback) — a hung auth-bff must not hang the caller's request
+// forever.
+const defaultHTTPIssuerTimeout = 5 * time.Second
+
+// HTTPIssuer is the production SessionIssuer. It POSTs to auth-bff's
+// POST /internal/mint-session (internal/session/mint_session.go),
+// authenticated with the shared X-Internal-Auth header — see D2 in
+// docs/superpowers/plans/2026-09-07-break-glass-activation-v2.md. Not
+// mTLS, not a Bearer token: both were wrong guesses recorded as errata.
+type HTTPIssuer struct {
+	baseURL string
+	secret  string
+	http    *http.Client
+}
+
+// NewHTTPIssuer builds an HTTPIssuer with a sane default timeout. Pass
+// a non-nil client via NewHTTPIssuerWithClient to override it (tests
+// that need a tighter timeout).
+func NewHTTPIssuer(baseURL, secret string, httpClient *http.Client) *HTTPIssuer {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultHTTPIssuerTimeout}
+	}
+	return &HTTPIssuer{baseURL: baseURL, secret: secret, http: httpClient}
+}
+
+// NewHTTPIssuerWithClient builds an HTTPIssuer with an explicit,
+// required http.Client — used by tests that need a tight timeout to
+// exercise the timeout path without waiting 5s.
+func NewHTTPIssuerWithClient(baseURL, secret string, httpClient *http.Client) *HTTPIssuer {
+	return &HTTPIssuer{baseURL: baseURL, secret: secret, http: httpClient}
+}
+
+// NewSessionIssuer decides which SessionIssuer to wire up from config,
+// so a service's main.go never has to construct a "half-configured"
+// HTTPIssuer itself. baseURL and secret come from cfg.AuthBFFURL and
+// cfg.InternalAuthSecret (pkg/config) — the same two settings
+// MobileLoginClient already relies on, so this needs no new config
+// field.
+//
+// If either is empty, NoopIssuer is returned: every Issue call then
+// fails loudly with ErrIssuerUnavailable instead of a misconfigured
+// deploy silently serving an unauthenticated route. InternalAuthSecret
+// is already required outside dev (pkg/config Validate), and AuthBFFURL
+// is optional there — so a break-glass/SSO deploy without AuthBFFURL
+// set is a valid, if degraded, state: those routes 500 instead of
+// crash-looping the whole service.
+func NewSessionIssuer(baseURL, secret string, httpClient *http.Client) SessionIssuer {
+	if baseURL == "" || secret == "" {
+		return NoopIssuer{}
+	}
+	return NewHTTPIssuer(baseURL, secret, httpClient)
+}
+
+type mintSessionRequestWire struct {
+	TenantID    string `json:"tenant_id"`
+	UserID      string `json:"user_id"`
+	AuthContext string `json:"auth_context"`
+	TTLSeconds  int    `json:"ttl_seconds"`
+}
+
+type mintSessionResponseWire struct {
+	SetCookie string `json:"set_cookie"`
+}
+
+// Issue implements SessionIssuer. Any non-200 response, a malformed
+// body, or a transport failure (timeout, connection refused) returns
+// an error and an empty cookie string — never a partially-trusted
+// cookie value.
+//
+// Never logged here: the service key (never attached to any log
+// call), the returned cookie, or an email (this issuer never sends
+// one — see the SessionIssuer doc comment on why that's safe).
+func (i *HTTPIssuer) Issue(ctx context.Context, tenantID, userID uuid.UUID, authContext string, ttl time.Duration) (string, error) {
+	reqBody := mintSessionRequestWire{
+		TenantID:    tenantID.String(),
+		UserID:      userID.String(),
+		AuthContext: authContext,
+		TTLSeconds:  int(ttl.Seconds()),
+	}
+	b, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("authbffclient: marshal mint-session request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, i.baseURL+"/internal/mint-session", bytes.NewReader(b))
+	if err != nil {
+		return "", fmt.Errorf("authbffclient: build mint-session request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(internalAuthHeader, i.secret)
+
+	resp, err := i.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("authbffclient: mint-session request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+
+	if resp.StatusCode != http.StatusOK {
+		// Deliberately no response body in the error: it may echo back
+		// caller-controlled fields, and the handler above maps any error
+		// here to a generic 500 without leaking why — keep that true from
+		// this layer up.
+		return "", fmt.Errorf("authbffclient: mint-session returned status %d", resp.StatusCode)
+	}
+
+	var out mintSessionResponseWire
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return "", fmt.Errorf("authbffclient: decode mint-session response: %w", err)
+	}
+	if out.SetCookie == "" {
+		return "", fmt.Errorf("authbffclient: mint-session response missing set_cookie")
+	}
+
+	return out.SetCookie, nil
+}

--- a/services/marketplace-api/internal/authbffclient/http_issuer_test.go
+++ b/services/marketplace-api/internal/authbffclient/http_issuer_test.go
@@ -1,0 +1,159 @@
+package authbffclient_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/authbffclient"
+)
+
+func TestHTTPIssuer_Success(t *testing.T) {
+	var gotHeader string
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("X-Internal-Auth")
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"set_cookie": "mk8_session=abc123; HttpOnly; Secure; SameSite=Lax; Path=/",
+		})
+	}))
+	defer srv.Close()
+
+	issuer := authbffclient.NewHTTPIssuer(srv.URL, "test-secret", nil)
+
+	tenantID := uuid.New()
+	userID := uuid.New()
+	cookie, err := issuer.Issue(t.Context(), tenantID, userID, "break_glass", 2*time.Hour)
+
+	require.NoError(t, err)
+	assert.Equal(t, "mk8_session=abc123; HttpOnly; Secure; SameSite=Lax; Path=/", cookie)
+
+	// The request actually carried the shared secret header.
+	assert.Equal(t, "test-secret", gotHeader)
+
+	// The body carries auth_context: "break_glass", not just a 200.
+	assert.Equal(t, "break_glass", gotBody["auth_context"])
+	assert.Equal(t, tenantID.String(), gotBody["tenant_id"])
+	assert.Equal(t, userID.String(), gotBody["user_id"])
+	assert.EqualValues(t, 7200, gotBody["ttl_seconds"])
+}
+
+func TestHTTPIssuer_Non200_ReturnsErrorAndEmptyCookie(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"unauthorized", http.StatusUnauthorized, `{"error":"unauthorized"}`},
+		{"server_error", http.StatusInternalServerError, `{"error":"internal_error"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			issuer := authbffclient.NewHTTPIssuer(srv.URL, "test-secret", nil)
+			cookie, err := issuer.Issue(t.Context(), uuid.New(), uuid.New(), "break_glass", time.Hour)
+
+			require.Error(t, err)
+			assert.Empty(t, cookie)
+		})
+	}
+}
+
+func TestHTTPIssuer_MalformedBody_ReturnsErrorAndEmptyCookie(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{not valid json`))
+	}))
+	defer srv.Close()
+
+	issuer := authbffclient.NewHTTPIssuer(srv.URL, "test-secret", nil)
+	cookie, err := issuer.Issue(t.Context(), uuid.New(), uuid.New(), "break_glass", time.Hour)
+
+	require.Error(t, err)
+	assert.Empty(t, cookie)
+}
+
+func TestHTTPIssuer_ConnectionFailure_ReturnsErrorRatherThanHanging(t *testing.T) {
+	// A closed server: connection refused, not a hang.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close()
+
+	issuer := authbffclient.NewHTTPIssuer(srv.URL, "test-secret", nil)
+
+	done := make(chan struct{})
+	var cookie string
+	var err error
+	go func() {
+		cookie, err = issuer.Issue(t.Context(), uuid.New(), uuid.New(), "break_glass", time.Hour)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		require.Error(t, err)
+		assert.Empty(t, cookie)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Issue did not return within 10s — appears to hang")
+	}
+}
+
+func TestNewSessionIssuer_AbsentConfig_YieldsNoopIssuer(t *testing.T) {
+	cases := []struct {
+		name    string
+		baseURL string
+		secret  string
+	}{
+		{"both empty", "", ""},
+		{"missing base URL", "", "secret"},
+		{"missing secret", "http://auth-bff.internal", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issuer := authbffclient.NewSessionIssuer(tc.baseURL, tc.secret, nil)
+			_, ok := issuer.(authbffclient.NoopIssuer)
+			require.True(t, ok, "expected NoopIssuer, got %T", issuer)
+
+			cookie, err := issuer.Issue(t.Context(), uuid.New(), uuid.New(), "break_glass", time.Hour)
+			require.ErrorIs(t, err, authbffclient.ErrIssuerUnavailable)
+			assert.Empty(t, cookie)
+		})
+	}
+}
+
+func TestNewSessionIssuer_FullConfig_YieldsHTTPIssuer(t *testing.T) {
+	issuer := authbffclient.NewSessionIssuer("http://auth-bff.internal", "secret", nil)
+	_, ok := issuer.(*authbffclient.HTTPIssuer)
+	require.True(t, ok, "expected *HTTPIssuer, got %T", issuer)
+}
+
+func TestHTTPIssuer_Timeout_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"set_cookie":"nope"}`))
+	}))
+	defer srv.Close()
+
+	issuer := authbffclient.NewHTTPIssuerWithClient(srv.URL, "test-secret", &http.Client{Timeout: 50 * time.Millisecond})
+	cookie, err := issuer.Issue(t.Context(), uuid.New(), uuid.New(), "break_glass", time.Hour)
+
+	require.Error(t, err)
+	assert.Empty(t, cookie)
+}

--- a/services/marketplace-api/internal/authbffclient/session_issuer.go
+++ b/services/marketplace-api/internal/authbffclient/session_issuer.go
@@ -3,11 +3,15 @@
 // contract by which break-glass login + SSO callback routes ask
 // auth-bff to mint the standard Mark8ly session cookie.
 //
-// The production implementation is expected to POST to an
-// internal-only auth-bff endpoint (mTLS-gated) and return the raw
-// Set-Cookie header value for marketplace-api to pass through to the
-// caller. Cookie cryptography stays owned by auth-bff — marketplace-api
-// must NEVER sign session cookies itself.
+// The production implementation POSTs to auth-bff's internal-only
+// POST /internal/mint-session endpoint, authenticated with the shared
+// X-Internal-Auth header (internalauth.Equal on the auth-bff side) —
+// NOT mTLS. See docs/superpowers/plans/2026-09-07-break-glass-activation-v2.md,
+// D2: mTLS was never real for this endpoint; the header is the pattern
+// that already exists and works for every other /internal route.
+// It returns the raw Set-Cookie header value for marketplace-api to
+// pass through to the caller. Cookie cryptography stays owned by
+// auth-bff — marketplace-api must NEVER sign session cookies itself.
 package authbffclient
 
 import (
@@ -28,11 +32,25 @@ var ErrIssuerUnavailable = errors.New("authbffclient: session issuer not configu
 // with a TTL and returns the full Set-Cookie header value, ready to
 // hand to c.Writer.Header().Add("Set-Cookie", ...).
 //
+// authContext is one of auth-bff's allow-listed values ("staff",
+// "customer", "break_glass") and is passed by the CALLER, never
+// defaulted here. This is the interface-widening decision recorded in
+// the v2 plan (Task 3): the Task 0 consumer audit found a missing
+// email is safe (every consumer treats it as an optional attribution
+// label with a fallback), but auth_context is not — it is the one
+// safety control the mint-session endpoint exists to enforce, and a
+// callee-supplied default would silently defeat it for whichever
+// caller forgot to think about it. Widening also means the SSO
+// callback (internal/handlers/public/sso_login.go) and break-glass
+// login (internal/handlers/admin/break_glass_login.go) both say what
+// they are minting explicitly, in one interface, rather than one of
+// them being hidden inside HTTPIssuer's implementation.
+//
 // Implementations MUST be safe for concurrent use from request
 // goroutines — marketplace-api treats issuance as a synchronous,
 // request-scoped call.
 type SessionIssuer interface {
-	Issue(ctx context.Context, tenantID, userID uuid.UUID, ttl time.Duration) (setCookie string, err error)
+	Issue(ctx context.Context, tenantID, userID uuid.UUID, authContext string, ttl time.Duration) (setCookie string, err error)
 }
 
 // NoopIssuer is a safe-by-default stub returned when no real issuer
@@ -42,7 +60,7 @@ type SessionIssuer interface {
 type NoopIssuer struct{}
 
 // Issue always returns ErrIssuerUnavailable — by design.
-func (NoopIssuer) Issue(_ context.Context, _, _ uuid.UUID, _ time.Duration) (string, error) {
+func (NoopIssuer) Issue(_ context.Context, _, _ uuid.UUID, _ string, _ time.Duration) (string, error) {
 	return "", ErrIssuerUnavailable
 }
 
@@ -55,7 +73,7 @@ type StaticIssuer struct {
 }
 
 // Issue returns the pre-configured Cookie / Err.
-func (s StaticIssuer) Issue(_ context.Context, tenantID, userID uuid.UUID, ttl time.Duration) (string, error) {
+func (s StaticIssuer) Issue(_ context.Context, tenantID, userID uuid.UUID, _ string, ttl time.Duration) (string, error) {
 	if s.Err != nil {
 		return "", s.Err
 	}

--- a/services/marketplace-api/internal/handlers/admin/break_glass_login.go
+++ b/services/marketplace-api/internal/handlers/admin/break_glass_login.go
@@ -163,7 +163,7 @@ func (h *BreakGlassLoginHandler) Login(c *gin.Context) {
 	// sessions so ops audit logs consistently tie the same actor to
 	// every break-glass login for a tenant.
 	userID := BreakGlassUserID(tenantID)
-	setCookie, err := h.deps.Sessions.Issue(ctx, tenantID, userID, BreakGlassSessionTTL)
+	setCookie, err := h.deps.Sessions.Issue(ctx, tenantID, userID, "break_glass", BreakGlassSessionTTL)
 	if err != nil {
 		h.logger().Error("break-glass: session issue failed", "err", err, "tenant", tenantID)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "session_mint_failed"})

--- a/services/marketplace-api/internal/handlers/public/sso_login.go
+++ b/services/marketplace-api/internal/handlers/public/sso_login.go
@@ -299,8 +299,10 @@ func (h *SSOLoginHandler) Callback(c *gin.Context) {
 		return
 	}
 
-	// Mint session cookie via auth-bff.
-	setCookie, err := h.Sessions.Issue(c.Request.Context(), tenantID, out.InternalUserID, SSOSessionTTL)
+	// Mint session cookie via auth-bff. auth_context is "staff" —
+	// matches the DefaultRole passed to JIT.Provision above; SSO login
+	// is always a staff/admin session, never a break-glass one.
+	setCookie, err := h.Sessions.Issue(c.Request.Context(), tenantID, out.InternalUserID, "staff", SSOSessionTTL)
 	if err != nil {
 		h.Logger.Error("sso_callback: session issue failed", "tenant_id", tenantID, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "session_failed"})


### PR DESCRIPTION
Supersedes #657. Documentation only — no behaviour change.

I went to execute #657's plan and checked every symbol it names against the tree first. **Six of its load-bearing claims are wrong, and so is the design spec already merged in #652.**

| | Claim | Reality |
|---|---|---|
| E1 | `CookieStore` / `NewCookieStore` | `session.Manager` / `NewManager(cfg Config)` |
| E2 | "extract `Encode` from `Save`" | `encode()` already exists (`cookie.go:222`); `Save` does not — writers are `Mint`/`MintWithDomain` |
| E3 | `LoadFromValue` | Does not exist. The plan's Task 1 test cannot compile |
| E4 | `Session.AuthContext` | No such field — the allow-list had nothing to guard |
| E5 | "works exactly as `IsKnownSessionCookie` guards `session-exchange`" | Neither symbol exists anywhere in the repo. Real `/internal` auth is an `X-Internal-Auth` header via `internalauth.Equal`, per route — the spec "corrected" the code's own comment toward something less accurate than the comment |
| E6 | `SessionIssuer` can carry the design | Passes no email, slug or auth context |

The design's **intent** survives all six, and tasks 4–8 spot-check clean: `SecretClient` lines up exactly with `carriersecrets.BaoClient`, and `FeatureSSO` exists. Only its account of auth-bff was unreliable.

## What is here

- **Errata** appended to the old plan, and a **correction block on the merged spec** so the next reader does not hit the same wall.
- **A v2 plan** written against verified symbols, with three decisions recorded: `AuthContext` as a `Session` field, `X-Internal-Auth` (not Bearer, not mTLS), and `UID` = the deterministic UUIDv5 `BreakGlassUserID` already derives.
- **A consumer audit** (new Task 0, 21 consumers) — added because nothing had checked what actually reads a session. It found two blockers:

### Blocker 1 — a break-glass login would loop back to `/login`

A UID with no FGA tuple is refused by three gates, and every admin request hits at least one: `apps/admin/middleware.ts:407-435` → platform-api `getMe` 404 `no_role` → redirect to login; `RequireTenantRelation` (`authz/middleware.go:41`); `CheckMembership` in `switchTenant`/`adminhandoff`. The `/pick-tenant` recovery surface is empty too.

**It passes in local dev and fails only in production** — `tenant/handler.go:171-174` returns `role: owner` unconditionally when `fga == nil`. Now Task 5a: one additive FGA tuple at provisioning, gating the mount.

### Blocker 2 — the safety control any merchant could strip

`switchTenant` (`handler.go:483`), `switchStore` (`:538`) and `adminhandoff` (`:135`) each rebuild `Session` as a fresh literal copying named fields. Adding `AuthContext` without patching all three ships a control that one `POST /auth/switch-store` removes. Same shape as the mobile IDP provider pinned in three services where two hops dropped it invisibly.

The audit also **voids a spec risk**: §7's "a caller assumes `session-exchange` returns a non-empty access_token" describes a system that does not exist — `Session` has no token field. Delete rather than mitigate.

Negatives were tested, not assumed: zero `DisallowUnknownFields`, zero strict zod/valibot/superstruct schemas, no FK to any user table, and only `apps/admin` consumes the cookie (storefront, onboarding and all three mobile apps: zero non-test hits).