### PR TITLE
fix(mobile): sign-out on a Zitadel build errors on the absent Firebase user

### DIFF
--- a/apps/mobile-admin/__tests__/gip.test.tsx
+++ b/apps/mobile-admin/__tests__/gip.test.tsx
@@ -58,6 +58,7 @@ interface MockedAuthInstance {
   setTenantId: jest.Mock;
   signInWithEmailAndPassword: jest.Mock;
   signOut: jest.Mock;
+  currentUser: unknown;
 }
 
 const instance = (getAuth as unknown as () => MockedAuthInstance)();
@@ -127,5 +128,59 @@ describe("createGIPAuth tenant scoping", () => {
       "pw",
       pending,
     );
+  });
+});
+
+// Signing out when nobody is signed in must be a NO-OP, not a rejection.
+//
+// On a Zitadel build the Firebase SDK never has a current user, so
+// `firebaseAuth.signOut()` rejects with `auth/no-current-user`. The provider
+// clears the tokens that actually hold the session BEFORE calling this, so the
+// person really is signed out — the rejection was pure noise: a red-box console
+// error on the device in dev, an unhandled promise rejection in production, and
+// worst of all it made every single sign-out look broken, which would mask a
+// real one. Observed on an iPhone 17 Pro Max simulator, 2026-09-07.
+describe("createGIPAuth sign-out is idempotent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    instance.setTenantId.mockResolvedValue(undefined);
+  });
+
+  it("resolves without calling Firebase when no user is signed in", async () => {
+    instance.currentUser = null;
+    const gip = createGIPAuth({ tenantId: "T6" });
+    await expect(gip.signOut()).resolves.toBeUndefined();
+    expect(instance.signOut).not.toHaveBeenCalled();
+  });
+
+  it("swallows auth/no-current-user when the user disappears mid-call", async () => {
+    instance.currentUser = { uid: "u1" };
+    instance.signOut.mockRejectedValueOnce(
+      Object.assign(new Error("No user currently signed in."), {
+        code: "auth/no-current-user",
+      }),
+    );
+    const gip = createGIPAuth({ tenantId: "T7" });
+    await expect(gip.signOut()).resolves.toBeUndefined();
+    expect(instance.signOut).toHaveBeenCalled();
+  });
+
+  it("still signs out normally when a user IS signed in", async () => {
+    instance.currentUser = { uid: "u1" };
+    instance.signOut.mockResolvedValueOnce(undefined);
+    const gip = createGIPAuth({ tenantId: "T8" });
+    await gip.signOut();
+    expect(instance.signOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates a genuine sign-out failure", async () => {
+    instance.currentUser = { uid: "u1" };
+    instance.signOut.mockRejectedValueOnce(
+      Object.assign(new Error("network request failed"), {
+        code: "auth/network-request-failed",
+      }),
+    );
+    const gip = createGIPAuth({ tenantId: "T9" });
+    await expect(gip.signOut()).rejects.toThrow("network request failed");
   });
 });

--- a/packages/mobile-shared/auth/gip.ts
+++ b/packages/mobile-shared/auth/gip.ts
@@ -96,7 +96,27 @@ export function createGIPAuth(config: GIPAuthConfig) {
       await tenantReady;
       return unlinkProvider(providerId);
     },
-    signOut: () => firebaseAuth.signOut(),
+    // Sign-out is IDEMPOTENT: signing out when nobody is signed in is a
+    // no-op, not a failure.
+    //
+    // On a Zitadel build no Firebase user is ever created, so calling
+    // firebaseAuth.signOut() rejects with `auth/no-current-user`. The
+    // provider's signOut has already cleared the tokens that actually hold
+    // the session by the time it gets here, so the person IS signed out --
+    // the rejection is pure noise that surfaces as a red-box console error in
+    // dev and an unhandled promise rejection in production, and it masks real
+    // sign-out failures by making every sign-out look broken.
+    signOut: async () => {
+      if (!firebaseAuth.currentUser) return;
+      try {
+        await firebaseAuth.signOut();
+      } catch (e) {
+        // Re-check rather than trusting the guard above: currentUser can be
+        // torn down between the check and the call. Any OTHER failure is a
+        // real one and must still propagate.
+        if ((e as { code?: string } | null)?.code !== 'auth/no-current-user') throw e;
+      }
+    },
     getIdToken: async (): Promise<string | null> => {
       const user = firebaseAuth.currentUser;
       if (!user) return null;


### PR DESCRIPTION
Found on an iPhone 17 Pro Max simulator while device-verifying the Zitadel mobile flows (#771). Tapping **Sign Out** on a Zitadel build throws:

```
Uncaught (in promise) Error: [auth/no-current-user] No user currently signed in.
  signOut  gip.ts:99          -> signOut: () => firebaseAuth.signOut()
  signOut  provider.tsx:188
  signOut  provider.tsx:258
```

## Why it happens

`AuthProvider.signOut` ends with `await backend.signOut()`, which on a Firebase backend is `firebaseAuth.signOut()`. On a **Zitadel** build no Firebase user is ever created, so that call rejects with `auth/no-current-user`.

This is the same family as #493 and the `AuthGate` bug in #686: a GIP code path still load-bearing on a build that never touches GIP.

## The person really was signed out

`tokenStorage.clearAll()` and `zitadelSession.clear()` both run **before** the failing call, so the session is genuinely gone — confirmed on device: after dismissing the red box, sign-out had worked.

That is exactly what makes it worth fixing rather than shrugging at. The rejection is pure noise, and it is noise that **makes every sign-out look broken**:

- a red-box console error on the device in development, which is what blocked testing;
- an unhandled promise rejection in production (neither `account.tsx` nor `support.tsx` catches it);
- and it would mask a *real* sign-out failure, because a genuine one now looks identical to the routine one.

## The fix

Make sign-out idempotent — signing out when nobody is signed in is a no-op, not a failure:

- skip the Firebase call when there is no `currentUser`;
- still catch `auth/no-current-user` if the user is torn down between the check and the call;
- **re-throw anything else**, so a genuine failure (e.g. `auth/network-request-failed`) still propagates.

Deliberately no provider branch. `packages/mobile-shared` has no `isZitadelProvider` helper, and it does not need one: "sign out when not signed in" should be a no-op on *every* backend. The same reasoning is already recorded a few lines above in `provider.tsx`, where `zitadelSession.clear()` is unconditional for the mirror-image reason.

## Testing

Four new cases in `apps/mobile-admin/__tests__/gip.test.tsx`, covering both directions so this cannot regress into swallowing real errors:

- no current user → resolves, and Firebase is never called
- `auth/no-current-user` mid-call → swallowed
- a real signed-in user → signs out normally, exactly once
- `auth/network-request-failed` → still propagates

Gates run locally:

- `packages/mobile-shared && npx tsc --noEmit` → exit 0 (the stricter gate that has broken `main` before)
- `apps/mobile-admin && npx jest` → 138 suites / **1787 tests** pass (was 1783; +4)

`next build` was not run — no Next.js code is touched.
