### PR TITLE
fix(mobile): stop ignoring the committed Firebase config so local iOS builds work

### DIFF
--- a/apps/mobile-admin/.gitignore
+++ b/apps/mobile-admin/.gitignore
@@ -14,9 +14,23 @@ web-build/
 # metro FileStore cache
 .metro-cache/
 
-# Firebase config (gitignored - injected via GOOGLE_SERVICES_PLIST or provided locally)
-GoogleService-Info.plist
-google-services.json
+# Firebase client config is COMMITTED, deliberately, and must stay that way.
+#
+# Both files were already tracked while these ignore rules matched them, which
+# git allows silently (an ignore rule does not evict an already-tracked file,
+# and `git check-ignore` will not even report one unless you pass --no-index).
+# That mismatch was invisible on EAS CLOUD builds, which package the committed
+# git tree, and fatal for `eas build --local`, which copies the working tree
+# HONOURING these rules: prebuild died with
+#   [ios.xcodeproj]: withIosXcodeprojBaseMod: ENOENT ... GoogleService-Info.plist
+#
+# Keeping them committed is also what lets app.config.js read REVERSED_CLIENT_ID
+# out of the plist at CONFIG time, before any EXPO_PUBLIC_* env exists.
+#
+# These are not secrets: a GoogleService-Info.plist / google-services.json holds
+# client identifiers that ship inside every copy of the app binary, and this
+# repository is public, so they are already world-readable. The env overrides
+# (GOOGLE_SERVICES_PLIST / GOOGLE_SERVICES_JSON) still win when set.
 
 # Google Play submit service-account key (real secret — never commit; provide via EAS secret)
 play-service-account.json


### PR DESCRIPTION
Without this, the local iOS build added in #777 fails every time. **Verified both ways**: the build failed on `main`, and passed on this branch — [run 34067702247](https://github.com/tesserix/mark8ly/actions/runs/34067702247), `Local iOS release: success`.

## The failure

```
[PREBUILD] Error: [ios.xcodeproj]: withIosXcodeprojBaseMod: ENOENT:
  no such file or directory, copyfile '.../apps/mobile-admin/GoogleService-Info.plist'
    -> '.../apps/mobile-admin/ios/Mark8lyAdmin/GoogleService-Info.plist'
```

## The cause: tracked *and* ignored

`GoogleService-Info.plist` and `google-services.json` are **committed**, while `apps/mobile-admin/.gitignore` also matched them. Git permits that silently — an ignore rule never evicts an already-tracked file — and `git check-ignore` will not even report one unless you pass `--no-index`, which is what made this hard to see:

```
$ git check-ignore -v apps/mobile-admin/GoogleService-Info.plist       # (nothing, exit 1)
$ git check-ignore -v --no-index apps/mobile-admin/GoogleService-Info.plist
apps/mobile-admin/.gitignore:18:GoogleService-Info.plist   apps/mobile-admin/GoogleService-Info.plist
```

The mismatch was invisible until now because the two build paths package the project differently:

- **EAS cloud** packages the committed git tree → the tracked plist is included → cloud builds have always worked.
- **`eas build --local`** copies the working tree *honouring ignore rules* → the plist is excluded → prebuild cannot find it.

So this bug has been latent in the repo, and only a local build could ever have surfaced it.

## The fix

Drop the two stale rules and replace them with a comment recording why these files must stay committed.

**This changes no exposure.** Both files were already committed to a repository that is public, and a `GoogleService-Info.plist` / `google-services.json` holds client identifiers that ship inside every copy of the app binary — not server secrets. Keeping the plist committed is also what lets `app.config.js` read `REVERSED_CLIENT_ID` out of it at config time, before any `EXPO_PUBLIC_*` env exists.

`play-service-account.json` stays ignored — that one genuinely is a secret.

## Checked for others

Swept the whole repo for anything else tracked-but-ignored that would fail a local build the same way:

```
git ls-files -z | git check-ignore --no-index --stdin -z -v
```

Only unrelated cruft from an old session came back. Nothing else in the build path.
