### PR TITLE
docs(auth): audit the remaining GIP surface before removing any of it (#708)

### DIFF
--- a/docs/auth/2026-09-07-gip-removal-audit.md
+++ b/docs/auth/2026-09-07-gip-removal-audit.md
@@ -1,0 +1,166 @@
+# GIP removal audit (#708)
+
+Audited 2026-09-07 against `main` @ 716c60a5, by reading all 91 code files that
+reference GIP/Firebase/Identity Platform. This is the "audit commit" #708 asks
+for, in document form.
+
+## Read this first: #708 is not a cleanup issue
+
+The issue is framed as removing dead scaffolding left behind by a finished
+migration. That framing is wrong in one decisive way, and planning against it
+will delete working product.
+
+**Five live, merchant- or customer-facing capabilities are implemented entirely
+on GIP and have no Zitadel replacement anywhere in the codebase.** Removing GIP
+removes the feature:
+
+| Capability | Where | Consequence of a naive removal |
+|---|---|---|
+| Storefront **customer** token verification | `marketplace-api/internal/handlers/storefront/gip_customer_verifier.go` + `main.go:1755-1765` | Mobile storefront customer support chat stops authenticating. The Zitadel migration covered the ADMIN path only. |
+| Custom-domain browser-key allowlist | `marketplace-api/internal/gipkey` + `main.go:545-579` | A merchant's storefront sign-in stops working from their verified custom domain. Self-service feature. |
+| Tenant SAML/OIDC SSO | `marketplace-api/internal/sso/gip_client.go` | Enterprise tenant SSO provisioning disappears. May already be dark — nothing in `main.go` constructs it — confirm before deciding. |
+| Merchant display-name seeding | `marketplace-api/internal/gipuser` + `handlers/admin/account.go` (`SetGIPNames`) | Every merchant profile seeds blank. Already a known gap for Zitadel-mode merchants; removal makes it universal. |
+| Invite tenant-claim write | `platform-api/internal/gipadmin` + `cmd/server/provider_wiring.go` | No Zitadel equivalent exists. `requireGIPForTenantClaim` **panics** by design rather than let this be removed silently. |
+
+None of these are in #708's inventory. Each needs a **replacement decision**,
+not a deletion.
+
+## Two whole apps were never migrated
+
+`apps/mobile-storefront/` and `apps/storefront-mobile/` contain **zero**
+references to Zitadel and are 100% GIP/Firebase, with `gipTenantId` a required
+build field. Verified:
+
+```
+apps/mobile-storefront : zitadel refs = 0
+apps/storefront-mobile : zitadel refs = 0
+apps/mobile-admin      : zitadel refs = 21
+```
+
+They need their own migration phase. #708 cannot touch them.
+
+## The environment is not ready either
+
+| Service | State (verified in prod, 2026-09-07) |
+|---|---|
+| `marketplace-api-admin` | `ZITADEL_ENABLED=true`, **`ZITADEL_DUAL_ISSUER=true`** |
+| `marketplace-api-storefront` | **no `ZITADEL_ENABLED`** — customer path still GIP |
+| `platform-api` | `ZITADEL_ENABLED=true`, still holds `GIP_PROJECT_ID` + `GIP_TENANT_ID` |
+
+Dual-issuer being ON means GIP-issued tokens are still accepted, so the
+`tenant_id` custom claim invite-accept writes through GIP is still load-bearing.
+`provider_wiring.go` states the unblock condition in its own error text:
+GIP config may only leave platform-api once Zitadel is enabled on
+marketplace-api — which is true for the admin engine and **false for the
+storefront engine**.
+
+## Corrected scope
+
+#708 says 255 files (a later note says 373). Excluding build artifacts,
+lockfiles and `go.sum`, and using word-boundary matching: **139 files, of which
+91 are code** and 48 are docs/planning prose. Docs include legal pages
+(cookies, DPA, security, sub-processors) that name "Google Identity Platform"
+and need a **content edit timed with the real cutover**, not a deletion.
+
+## The grep is a trap in both directions
+
+#708's suggested approach is a greppable marker sweep. A `grep -r gip` gets
+this wrong both ways, and that is the single most useful output of this audit.
+
+### It would DELETE things that must stay
+
+- **`marketplace-api/internal/auth/gip_bearer.go`** — despite the name, this is
+  the shared, **provider-agnostic** bearer middleware that **Zitadel already
+  uses today**. Deleting it breaks 100% of mobile-admin auth. Rename it; do not
+  remove it.
+- **`auth-bff/internal/autologin/service.go`** — saturated with "gip" strings,
+  but `completeLogin` is shared and Zitadel's `CompleteForProvider` calls it.
+  Only `AutoLogin` + the `gip` field go.
+- **`platform-api/internal/gipadmin`'s sentinel errors** (`ErrUserNotFound`, …)
+  are reused ~20× by `zitadeladmin` and `internal/auth/handler.go`. Relocate
+  them **before** deleting the package or the build breaks.
+- **All of `marketplace-api/internal/whitelabel/**`** plus
+  `subscription/app_lifecycle.go` and migrations `000048`/`000076`. This is a
+  *third* meaning of "firebase": GCP **project lifecycle** teardown for a
+  merchant's own white-label app. Not auth, not push, not ours to remove.
+- **`GoogleService-Info.plist` / `google-services.json`** — consumed by
+  `app.config.js` at **prebuild**. PR #781 already proved that losing them
+  breaks the iOS build outright.
+- **`handlers/admin/validation.go`'s `isValidUUID` guard** — the comment
+  mentions Firebase UIDs, but a Zitadel `sub` is also non-UUID. Fix the
+  comment, keep the code.
+
+### It would MISS things that must go
+
+- **`auth-bff` `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET`** — GIP-era OIDC
+  redirect flow, **zero readers**, still `required:"true"`. No "gip" in the
+  name, so no grep finds them. Verified by direct search.
+- **`auth-bff` `GIP_PROJECT_NUMBER`** — `required:"true"`, **zero readers**.
+- **`packages/mobile-shared`'s `LinkAccountPrompt.tsx` and the 7 GIP-only
+  `AuthBackend` methods** (`completeLinkWith*`, `existingSignInMethods`,
+  `linkedProviderIds`, `linkGoogleToCurrentUser`, `linkAppleToCurrentUser`,
+  `unlinkProvider`) contain **no string "gip" at all** — the largest GIP-only
+  surface in the mobile app is invisible to the sweep.
+- **`ZitadelEnabled` / `ZitadelDualIssuer`** in `mobile_routes.go` and
+  `config.go` — no "gip" in the identifier, but entirely GIP-removal work.
+
+## Three hazards that fail silently
+
+1. **The outbox rots without erroring.** Unregistering
+   `platform-api/internal/onboarding/gip_claim_handler.go` makes any
+   already-queued `gip.set_tenant_claim` rows permanently unprocessable — the
+   drainer treats an unregistered kind as "still pending" and never alarms.
+   Drain and confirm empty first.
+2. **`gip.ts` is `require()`d lazily** inside `provider.tsx`'s
+   `createFirebaseBackend` (to keep Firebase out of Expo Go). Deleting it
+   without removing that call site fails **only at runtime on a device** —
+   `tsc` and `jest` stay green. This is the same class of failure as #781 and
+   as the sign-out bug in #780, both found only on hardware.
+3. **`NEXT_PUBLIC_GIP_*` are build-time inlined**, including into server
+   actions. Removing one is a rebuild and redeploy, and rollback is another
+   rebuild — never a config flip.
+
+## Ordering rules
+
+- **Removing a required config is code-first**: delete the reader, deploy, then
+  drop the chart value. (#774 did the opposite — *adding* one is k8s-first.
+  Same milestone, opposite directions.) Applies to auth-bff's
+  `GIP_PROJECT_ID`, `GIP_PROJECT_NUMBER`, `GIP_WEB_API_KEY`,
+  `GIP_INTERNAL_TENANT_ID`, `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`. Backwards
+  = CrashLoopBackOff on the auth gateway.
+- **Grep every reader**, not just `Validate()`. `GIPProjectID` in
+  marketplace-api alone gates three independent features.
+- `gip_bearer.go`'s collapse must land in the **same PR** as
+  `mobile_routes.go`'s flag removal and `main.go`'s call site — they share one
+  boolean contract. A partial edit leaves either zero tenant-id writers (mobile
+  404s) or two racing, which is exactly the bug #524 phase 4 fixed.
+- `ZitadelDualIssuer` collapse goes **last**, after every consumer has
+  collapsed.
+- **Do not delete the three GCP Identity Platform tenant pools.** Irreversible,
+  and explicitly gated on human approval. Deleting the *config that names them*
+  is not the same act as deleting the pools.
+
+## Recommended split of #708
+
+As written, #708 is not executable — it mixes dead-code deletion with feature
+migration. Suggested split:
+
+1. **Free wins** (no product decision, no replacement needed): auth-bff's three
+   unread required env vars; the unread `GIPCustomerTenantID` /
+   `GIPPlatformTenantID`; stale comments. Code-first ordering, small and safe.
+2. **Admin-path collapse**: `selectMobileTokenVerifier`, `gip_bearer.go`
+   rename + parameter drop, `mobile_routes.go` flags, mobile app's
+   `isZitadelProvider` branches, `gip.ts` and the Firebase backend. Gated on
+   turning **dual-issuer off**.
+3. **Feature replacements** (one issue each, each needs a decision): storefront
+   customer verification; custom-domain key allowlist; tenant SSO; display-name
+   seeding; invite tenant-claim.
+4. **Storefront/customer cutover**: `marketplace-api-storefront`'s
+   `ZITADEL_ENABLED`, plus `apps/mobile-storefront` and `apps/storefront-mobile`
+   migrations.
+5. **Schema and pools, last**: `customer_profiles.gip_uid` (+ migration 000084),
+   `tenant_sso_configs.gip_provider_id`, and finally the GCP tenant pools —
+   human-approved, irreversible.
+
+Steps 1 and 2 are the only ones that are cleanup. Steps 3 and 4 are migration
+work that has not been scoped anywhere yet.

--- a/services/auth-bff/internal/autologin/service.go
+++ b/services/auth-bff/internal/autologin/service.go
@@ -16,6 +16,11 @@
 // outbox drainer hasn't shipped the FGA write yet, the autologin call won't
 // hand back a session before the tuple is visible. The user will see a
 // 1-2 second delay at worst, never a "tenant not found" error.
+// GIP-708 SPLIT: this file is full of the string "gip" but must NOT be deleted
+// wholesale. completeLogin is SHARED — Zitadel's CompleteForProvider calls it,
+// so removing the file takes out the live Zitadel login gauntlet. Only
+// AutoLogin and the gip field are GIP-only.
+// See docs/auth/2026-09-07-gip-removal-audit.md.
 package autologin
 
 import (

--- a/services/marketplace-api/internal/auth/gip_bearer.go
+++ b/services/marketplace-api/internal/auth/gip_bearer.go
@@ -1,3 +1,11 @@
+// GIP-708 KEEP: despite the file name, NOTHING here is GIP-specific.
+// GIPBearerAuth is the provider-agnostic bearer middleware that the ZITADEL
+// path already uses today — it verifies whatever TokenVerifier it is handed.
+// Deleting this file during the GIP removal (#708) breaks 100% of
+// mobile-admin authentication, Zitadel included. Rename it; do not remove it.
+// The only GIP-shaped thing here is the setTenantFromClaim parameter, which
+// becomes permanently false once GIP is gone. See
+// docs/auth/2026-09-07-gip-removal-audit.md.
 package auth
 
 import (

--- a/services/marketplace-api/internal/handlers/storefront/gip_customer_verifier.go
+++ b/services/marketplace-api/internal/handlers/storefront/gip_customer_verifier.go
@@ -1,3 +1,11 @@
+// GIP-708 KEEP: this is LIVE storefront CUSTOMER authentication and it has no
+// Zitadel replacement anywhere in the codebase — the Zitadel migration (#524)
+// covered the merchant ADMIN path only, and marketplace-api-storefront does not
+// even set ZITADEL_ENABLED. Removing this during #708 removes a working
+// feature (mobile storefront customer support chat), it does not clean up dead
+// code. Needs a replacement decision first.
+// See docs/auth/2026-09-07-gip-removal-audit.md.
+//
 // Package storefront — gip_customer_verifier.go: production CustomerVerifier
 // backed by the Firebase Admin Auth client. Mirrors auth.GIPVerifier (used
 // by the admin mobile group) but projects the claims the storefront needs —

--- a/services/platform-api/internal/gipadmin/client.go
+++ b/services/platform-api/internal/gipadmin/client.go
@@ -1,3 +1,9 @@
+// GIP-708 ORDER: this package is DELETE, but its sentinel errors
+// (ErrUserNotFound and friends) are reused ~20x by internal/zitadeladmin and
+// internal/auth/handler.go. Relocate the sentinels to a shared home FIRST or
+// deleting this package breaks the build in two other packages.
+// See docs/auth/2026-09-07-gip-removal-audit.md.
+//
 // Package gipadmin is a thin wrapper over the Google Identity Toolkit
 // admin REST API. It is used by platform-api to drive password reset
 // flows without exposing the default Firebase action handler UI to end

--- a/services/platform-api/internal/onboarding/gip_claim_handler.go
+++ b/services/platform-api/internal/onboarding/gip_claim_handler.go
@@ -1,3 +1,10 @@
+// GIP-708 KEEP (data hazard, not dead code): the ENQUEUE side is already
+// skipped on the Zitadel path, so this handler looks unused — but
+// unregistering it makes any ALREADY-QUEUED gip.set_tenant_claim outbox rows
+// permanently unprocessable. The drainer treats an unregistered kind as
+// "still pending" and never errors, so the failure is silent and the rows rot.
+// Confirm the outbox is drained of this kind BEFORE removing (#708).
+// See docs/auth/2026-09-07-gip-removal-audit.md.
 package onboarding
 
 import (


### PR DESCRIPTION
The audit commit #708 asks for, as a document plus five targeted in-code markers. **No behaviour changes** — one new doc, five comment-only edits. All three Go services build clean and `gofmt` reports nothing.

Every one of the 91 code files that reference GIP/Firebase/Identity Platform was read and classified DELETE / COLLAPSE / KEEP / SCHEMA, with a removal hazard recorded per site.

## The headline: #708 is not a cleanup issue

It is framed as removing scaffolding left behind by a finished migration. That framing will delete working product. **Five live capabilities are implemented entirely on GIP with no Zitadel replacement anywhere in the codebase:**

- storefront **customer** token verification (mobile storefront support chat)
- the custom-domain browser-key allowlist (`internal/gipkey`)
- tenant SAML/OIDC SSO (`internal/sso/gip_client.go`)
- merchant display-name seeding (`SetGIPNames`)
- the invite tenant-claim write (`platform-api`, whose `requireGIPForTenantClaim` **panics** rather than let this go silently)

None appear in #708's inventory. Each needs a replacement decision, not a deletion.

## Two apps were never migrated

`apps/mobile-storefront/` and `apps/storefront-mobile/` have **zero** Zitadel references and are 100% GIP/Firebase. They need their own migration phase.

## The environment is not ready

`marketplace-api-admin` still runs `ZITADEL_DUAL_ISSUER=true`, so GIP tokens are still accepted and the GIP-written `tenant_id` claim is still load-bearing. `marketplace-api-storefront` has **no `ZITADEL_ENABLED` at all**. `provider_wiring.go` states the unblock condition in its own error text, and it is not met.

## The grep this issue is built on fails both ways

**Would wrongly delete:** `internal/auth/gip_bearer.go` is provider-**agnostic** and is what Zitadel uses today — deleting it breaks 100% of mobile-admin auth. Also `autologin/service.go` (its `completeLogin` is shared with Zitadel), `gipadmin`'s sentinel errors (reused ~20× by `zitadeladmin`), all of `internal/whitelabel/**` (a *third* meaning of "firebase": GCP project teardown for a merchant's white-label app), and `GoogleService-Info.plist` (PR #781 already proved that breaks the iOS build).

**Would wrongly miss:** `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET` — GIP-era, **zero readers**, still `required:"true"`, and no "gip" in the name. Same for `GIP_PROJECT_NUMBER` (also unread). Also `LinkAccountPrompt.tsx` and 7 GIP-only `AuthBackend` methods, which contain no "gip" string at all yet are the largest GIP-only surface in the mobile app.

I verified the zero-reader claims directly rather than taking them from the audit.

## Three failures that would be silent

1. Unregistering `gip_claim_handler.go` makes already-queued outbox rows permanently unprocessable — the drainer treats an unknown kind as "still pending" and never alarms.
2. `gip.ts` is `require()`d **lazily**, so deleting it without its call site fails **only at runtime on a device**; `tsc` and `jest` stay green. Same class as #781 and #780, both found only on hardware.
3. `NEXT_PUBLIC_GIP_*` are build-time inlined — removal is a rebuild, and so is rollback.

## The markers

Five comments, placed only where they prevent a specific expensive mistake rather than sprinkled across 91 files:

- `gip_bearer.go` — KEEP, deleting it breaks all mobile auth
- `gip_customer_verifier.go` — KEEP, live customer auth with no replacement
- `gip_claim_handler.go` — KEEP, silent outbox data hazard
- `gipadmin/client.go` — ORDER, relocate sentinels before deleting
- `autologin/service.go` — SPLIT, `completeLogin` is shared with Zitadel

**Why a document rather than the full marker sweep the issue suggests:** this repo has a dozen live worktrees and concurrent sessions, and a comment-only diff across 91 files would conflict constantly and go stale. Enumeration lives in the doc where it is reviewable; markers live in code only where a future remover could destroy something. Happy to do the full sweep instead if you'd rather.

## Also corrected

#708 says 255 files (a later note says 373). Excluding build artifacts, lockfiles and `go.sum` with word-boundary matching it is **139 — 91 code, 48 docs**. The docs include legal pages (DPA, sub-processors) naming "Google Identity Platform" that need a content edit timed with the cutover.

The doc closes with a suggested split of #708 into five issues, of which only the first two are actually cleanup.
