### PR TITLE
fix(auth-bff): drop five GIP-era env vars nothing reads (#784)

### DIFF
--- a/services/auth-bff/pkg/config/config.go
+++ b/services/auth-bff/pkg/config/config.go
@@ -22,15 +22,8 @@ type Config struct {
 
 	// Google Identity Platform
 	GIPProjectID        string `envconfig:"GIP_PROJECT_ID" required:"true"`
-	GIPProjectNumber    string `envconfig:"GIP_PROJECT_NUMBER" required:"true"`
 	GIPWebAPIKey        string `envconfig:"GIP_WEB_API_KEY" required:"true"`
 	GIPInternalTenantID string `envconfig:"GIP_INTERNAL_TENANT_ID" required:"true"` // staff/admin pool (e.g. MP-Internal-e986p)
-	GIPCustomerTenantID string `envconfig:"GIP_CUSTOMER_TENANT_ID"`                 // storefront end-user pool (later)
-	GIPPlatformTenantID string `envconfig:"GIP_PLATFORM_TENANT_ID"`                 // tesserix-home pool (later)
-
-	// OAuth client (for the OIDC redirect flow auth-bff orchestrates)
-	OAuthClientID     string `envconfig:"OAUTH_CLIENT_ID" required:"true"`
-	OAuthClientSecret string `envconfig:"OAUTH_CLIENT_SECRET" required:"true"`
 
 	// Cookie session
 	SessionCookieName   string `envconfig:"SESSION_COOKIE_NAME" default:"m8_session"`

--- a/services/auth-bff/pkg/config/config_test.go
+++ b/services/auth-bff/pkg/config/config_test.go
@@ -12,9 +12,8 @@ func clearAll(t *testing.T) {
 	t.Helper()
 	for _, k := range []string{
 		"ENV", "HTTP_PORT", "DATABASE_URL",
-		"GIP_PROJECT_ID", "GIP_PROJECT_NUMBER", "GIP_WEB_API_KEY",
-		"GIP_INTERNAL_TENANT_ID", "GIP_CUSTOMER_TENANT_ID", "GIP_PLATFORM_TENANT_ID",
-		"OAUTH_CLIENT_ID", "OAUTH_CLIENT_SECRET",
+		"GIP_PROJECT_ID", "GIP_WEB_API_KEY",
+		"GIP_INTERNAL_TENANT_ID",
 		"SESSION_COOKIE_NAME", "SESSION_COOKIE_DOMAIN", "SESSION_ENCRYPT_KEY",
 		"FGA_API_URL", "FGA_STORE_ID",
 		"ZITADEL_ENABLED", "ZITADEL_ISSUER", "ZITADEL_LOGIN_CLIENT_TOKEN",
@@ -30,11 +29,8 @@ func setRequiredEnv(t *testing.T) {
 	clearAll(t)
 	t.Setenv("DATABASE_URL", "postgres://test/test")
 	t.Setenv("GIP_PROJECT_ID", "test-project")
-	t.Setenv("GIP_PROJECT_NUMBER", "12345")
 	t.Setenv("GIP_WEB_API_KEY", "test-key")
 	t.Setenv("GIP_INTERNAL_TENANT_ID", "MP-Internal-test")
-	t.Setenv("OAUTH_CLIENT_ID", "test-client-id")
-	t.Setenv("OAUTH_CLIENT_SECRET", "test-client-secret")
 	t.Setenv("SESSION_ENCRYPT_KEY", "thirtytwo-bytes-for-testing-only")
 }
 
@@ -46,9 +42,6 @@ func TestLoad_ReadsRequiredFieldsFromEnv(t *testing.T) {
 	}
 	if cfg.GIPProjectID != "test-project" {
 		t.Errorf("GIPProjectID = %q, want %q", cfg.GIPProjectID, "test-project")
-	}
-	if cfg.OAuthClientSecret != "test-client-secret" {
-		t.Errorf("OAuthClientSecret = %q, want %q", cfg.OAuthClientSecret, "test-client-secret")
 	}
 }
 
@@ -98,11 +91,8 @@ func TestZitadelIsDisabledAndUnrequiredByDefault(t *testing.T) {
 	// Only the pre-existing required vars are set.
 	t.Setenv("DATABASE_URL", "postgres://x")
 	t.Setenv("GIP_PROJECT_ID", "p")
-	t.Setenv("GIP_PROJECT_NUMBER", "1")
 	t.Setenv("GIP_WEB_API_KEY", "k")
 	t.Setenv("GIP_INTERNAL_TENANT_ID", "t")
-	t.Setenv("OAUTH_CLIENT_ID", "c")
-	t.Setenv("OAUTH_CLIENT_SECRET", "s")
 	t.Setenv("SESSION_ENCRYPT_KEY", "thirtytwo-bytes-for-testing-only")
 
 	cfg, err := Load()


### PR DESCRIPTION
Closes #784. **Step 1 of 2** — this is the code half; the chart half follows after this deploys.

Removes five GIP-era fields from `auth-bff`'s config that **nothing reads**:

| Var | Was | Readers outside `config.go` |
|---|---|---|
| `GIP_PROJECT_NUMBER` | `required:"true"` | 0 |
| `OAUTH_CLIENT_ID` | `required:"true"` | 0 |
| `OAUTH_CLIENT_SECRET` | `required:"true"` | 0 (only a config test asserting it parsed) |
| `GIP_CUSTOMER_TENANT_ID` | optional, "(later)" | 0 |
| `GIP_PLATFORM_TENANT_ID` | optional, "(later)" | 0 |

Three were `required:"true"`, so every deployment has been forced to supply values that no code path consumes — and auth-bff, the auth gateway, refused to boot without them.

Verified per-symbol rather than by a single grep:

```
GIPProjectNumber    -> 0 references outside config.go
GIPCustomerTenantID -> 0
GIPPlatformTenantID -> 0
OAuthClientID       -> 0
OAuthClientSecret   -> 2  (both in pkg/config/config_test.go)
```

And, as a control that this does not over-remove, the three GIP vars that **stay** each have exactly one real reader: `GIPProjectID` (feeds `gip.New`), `GIPWebAPIKey` and `GIPInternalTenantID` (both feed `session.Handler.WithGIPLookup`, which serves `/auth/me/providers`). Those go with the admin-path work, not here.

## Why these were invisible

`OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET` contain no "gip" in the name — the greppable-marker sweep #708 originally proposed would never have found them, despite their doc comment saying outright they exist "for the OIDC redirect flow auth-bff orchestrates", i.e. the GIP-era flow that no longer exists.

## Ordering — this is the half that can break production

**Removing required config is code-first**, the exact opposite of #774, which *added* `ZITADEL_APPLE_IDP_ID` k8s-first:

1. **this PR** — delete the readers, merge, let it deploy;
2. **then** a tesserix-k8s PR removes the five from `charts/apps/mark8ly-auth-bff/templates/deployment.yaml`.

Doing it the other way round CrashLoopBackOffs auth-bff and takes sign-in down everywhere. Leaving the chart supplying them in the meantime is harmless — unread env vars are ignored.

There is one extra thing for that follow-up: `OAUTH_CLIENT_SECRET` is a `secretKeyRef`, so a **dead credential** is sitting in a Kubernetes Secret. It should be removed there too, and treated as retired rather than merely unreferenced.

## Testing

`go build ./... && go vet ./... && go test ./...` clean in `services/auth-bff` — 12 packages, all ok. `gofmt` reports nothing.

See `docs/auth/2026-09-07-gip-removal-audit.md`.
