### PR TITLE
feat(trial): the trials list can see tenants stuck at signup (#285)

### DIFF
--- a/.planning/quick/260907-sg-trials-include-signup/PLAN.md
+++ b/.planning/quick/260907-sg-trials-include-signup/PLAN.md
@@ -1,0 +1,121 @@
+# The trials list can see tenants stuck at signup
+
+An operator with **three tenants** in mark8ly opened the console's trials
+surface and saw nothing — at a 7-day window, at a year, and with
+Stripe-managed rows opted in. The list was answering correctly. None of those
+tenants is `trialing`.
+
+## What the code says
+
+`subscription.Service.Bootstrap` (`internal/subscription/service.go:120-126`)
+creates every new subscription as:
+
+```go
+Plan:   PlanTrial,      // on a trial by plan
+Status: StatusSignup,   // and NOT `trialing` by status
+```
+
+`trialingInWindowScope` (`internal/billing/trial/expiring.go:78`) requires
+`status = 'trialing'`. So a tenant on a trial plan is invisible to this list
+under **every** window and every existing option.
+
+**`signup → trialing` has exactly one writer in the service:** a Stripe
+`checkout.session.completed` webhook (`internal/billing/dispatch/handlers.go:213-222`,
+actor `system:webhook:stripe`). A tenant that signs up and never completes
+checkout never leaves `signup`.
+
+## And nothing else is watching them either
+
+`expiry_cron` selects `status = 'trialing'` (`expiry_cron.go:90`). A `signup`
+row is therefore **never aged out**: not trialing, not expired, not on the
+queue. It sits there indefinitely with nothing observing it.
+
+That is the real finding. The console surfacing it is the smaller half.
+
+## The shape: an explicit option, list-only
+
+`ListOptions`'s own comment states the rule this must respect:
+
+> *The zero value is the contract #285 already ships, so an omitted option can
+> never widen a live result set by accident.*
+
+So this is **not** a default change. Add `IncludeSignup`, mirroring
+`IncludeStripeManaged` exactly — same file, same shape, same discipline.
+
+**`CountExpiring` must not move.** It keeps the narrower "will expire" meaning
+for #282's KPI, which `/admin/kpis` shares with the console *"so the two cannot
+report different numbers for the same word."* `IncludeStripeManaged` is already
+excluded from it "entirely"; `IncludeSignup` follows.
+
+### The window still means something for a signup row
+
+`EndsAt` falls back to `created_at + TrialDays` when `trial_ends_at` is null
+(`endsat.go:22-26`), and `EndsBetweenScope`'s two-branch predicate already
+covers the null case. So a `signup` row has a well-defined effective end and
+sorts correctly against `trialing` rows. Nothing new is needed for the window.
+
+**But say plainly what that date is:** for a `signup` row it is a *notional*
+end — nothing will act on it, because `expiry_cron` will not touch the row.
+A comment must not let a reader think this list's presence implies the expiry
+machinery is watching.
+
+## Tasks
+
+Each is one atomic commit. Tests first.
+
+### T1 — `ListOptions.IncludeSignup`
+
+`internal/billing/trial/expiring.go`.
+
+- Add the field with a doc comment in `IncludeStripeManaged`'s register: what it
+  admits, why it is off by default, and that `CountExpiring` ignores it.
+- Widen `trialingInWindowScope` to `status IN (trialing, signup)` **only** when
+  set. Keep the existing scope byte-identical when it is not.
+- The two options are independent and compose: `IncludeSignup` alone must not
+  drag in card-backed rows, and vice versa. Four combinations, all meaningful.
+- **Do not touch `expiringScope`'s use by `CountExpiring`.**
+
+### T2 — the handler accepts it
+
+`internal/handlers/platformadmin/billing_trials.go`. Mirror how
+`include_stripe_managed` is read and validated. Update the route doc comment,
+which enumerates accepted params.
+
+### T3 — the row says which population it is from
+
+An operator cannot act on a `signup` row the way they act on a `trialing` one —
+the first needs chasing to complete checkout, the second is about to lose
+access. The response already carries `Status` on `ExpiringRow`; confirm it
+reaches the wire shape, and add it if not. Without it the two are
+indistinguishable in the console, which would trade one invisible scope for
+another.
+
+### T4 — tests
+
+Follow the package's conventions. Cover: the default excludes `signup`
+(the shipped contract, unchanged); `IncludeSignup` admits it; the two options
+compose in all four combinations; a `signup` row sorts by
+`created_at + TrialDays` against a `trialing` row's explicit `trial_ends_at`;
+and **`CountExpiring` is unmoved by the flag**.
+
+That last one is the assertion that matters most — it is what stops a view
+change quietly redefining a KPI.
+
+Integration tests here now actually run — they were dead until today
+(mark8ly#776), so a new one is worth writing rather than assuming coverage.
+
+## Out of scope, and worth its own issue
+
+**Nothing ages out a `signup` row.** Whether a tenant that never completes
+checkout should eventually be expired, chased, or left alone is a product
+decision with billing consequences, and it is not a console filter's job to
+decide. This plan makes the population *visible*; deciding what happens to it
+comes after someone can see it.
+
+## Global constraints
+
+- **Comment accuracy** — this estate's documented recurring defect. Run the
+  command before writing the sentence; count anything you assert a count about.
+- Do not weaken an existing assertion.
+- `go build ./...`, `go vet ./...`, `gofmt -l`, `go test ./...`, and the
+  integration suite with `-p 1`, all clean.

--- a/services/marketplace-api/internal/billing/trial/expiring.go
+++ b/services/marketplace-api/internal/billing/trial/expiring.go
@@ -50,6 +50,23 @@ type ListOptions struct {
 	// them extendable, and an endpoint the console cannot discover a store
 	// id for is unreachable in practice.
 	IncludeStripeManaged bool
+
+	// IncludeSignup adds trials whose status is still `signup`: a tenant on
+	// a trial plan that never completed Stripe checkout. subscription
+	// Service.Bootstrap creates every subscription that way, and the only
+	// writer of signup -> trialing in this service is the
+	// checkout.session.completed webhook handler (internal/billing/dispatch),
+	// so a tenant that never checks out stays at `signup` indefinitely and
+	// is invisible to this list under every window.
+	//
+	// Off by default, and — like IncludeStripeManaged — not reachable from
+	// CountExpiring at all, because a `signup` row's trial end is NOTIONAL.
+	// ExpiryCron selects status = 'trialing', so nothing will act on that
+	// date: the row is not queued to expire, and this list showing it must
+	// not be read as the expiry machinery watching it. It is listed so an
+	// operator can chase the tenant to complete checkout, which is a
+	// different action from an expiring trial's.
+	IncludeSignup bool
 }
 
 // expiringScope narrows to trials that will actually EXPIRE, in the window
@@ -67,27 +84,50 @@ type ListOptions struct {
 // The window's brackets and the index-preserving two-branch predicate both
 // live in EndsBetweenScope — see endsat.go.
 func expiringScope(db *gorm.DB, asOf time.Time, window time.Duration) *gorm.DB {
-	return trialingInWindowScope(db, asOf, window).Where("stripe_subscription_id IS NULL")
+	return trialingInWindowScope(db, asOf, window, false).Where("stripe_subscription_id IS NULL")
 }
 
-// trialingInWindowScope is expiringScope without the card filter: status is
-// trialing and the effective end lies in the window.
-func trialingInWindowScope(db *gorm.DB, asOf time.Time, window time.Duration) *gorm.DB {
-	return EndsBetweenScope(
-		db.Model(&subscription.StoreSubscription{}).
-			Where("status = ?", subscription.StatusTrialing),
-		asOf, asOf.Add(window),
-	)
-}
-
-// listScope is the scope ListExpiring queries against: expiringScope by
-// default (#285's shipped contract), or trialingInWindowScope when the
-// caller opts into seeing Stripe-managed (card-backed) trials too (#358).
-func listScope(db *gorm.DB, asOf time.Time, window time.Duration, opts ListOptions) *gorm.DB {
-	if opts.IncludeStripeManaged {
-		return trialingInWindowScope(db, asOf, window)
+// trialingInWindowScope is expiringScope without the card filter: the status
+// matches and the effective end lies in the window.
+//
+// includeSignup widens the status set from `trialing` alone to `trialing` or
+// `signup`. Only ListExpiring ever passes true — expiringScope, and so
+// CountExpiring, always passes false — see ListOptions.IncludeSignup for why
+// a signup row must not reach the KPI. The false branch builds the same
+// single-status predicate it always has, unchanged.
+func trialingInWindowScope(db *gorm.DB, asOf time.Time, window time.Duration, includeSignup bool) *gorm.DB {
+	scoped := db.Model(&subscription.StoreSubscription{})
+	if includeSignup {
+		scoped = scoped.Where("status IN ?", []subscription.SubscriptionStatus{
+			subscription.StatusTrialing, subscription.StatusSignup,
+		})
+	} else {
+		scoped = scoped.Where("status = ?", subscription.StatusTrialing)
 	}
-	return expiringScope(db, asOf, window)
+	return EndsBetweenScope(scoped, asOf, asOf.Add(window))
+}
+
+// listScope is the scope ListExpiring queries against. The two options widen
+// two independent dimensions — which statuses, and whether card-backed rows
+// count — so all four combinations are reachable and each means something:
+//
+//   - zero value: expiringScope, #285's shipped contract. Trialing, card-less.
+//   - IncludeStripeManaged: drops the card filter only (#358). Still trialing.
+//   - IncludeSignup: adds `signup` only. A card-backed signup row stays out.
+//   - both: trialing or signup, card-backed or not.
+//
+// The zero value delegates to expiringScope rather than rebuilding the same
+// predicate, so the default this list serves and the scope CountExpiring
+// counts cannot drift apart.
+func listScope(db *gorm.DB, asOf time.Time, window time.Duration, opts ListOptions) *gorm.DB {
+	if !opts.IncludeSignup && !opts.IncludeStripeManaged {
+		return expiringScope(db, asOf, window)
+	}
+	scoped := trialingInWindowScope(db, asOf, window, opts.IncludeSignup)
+	if !opts.IncludeStripeManaged {
+		scoped = scoped.Where("stripe_subscription_id IS NULL")
+	}
+	return scoped
 }
 
 // CountExpiring counts trials that will expire in the window (asOf,

--- a/services/marketplace-api/internal/billing/trial/expiring_integration_test.go
+++ b/services/marketplace-api/internal/billing/trial/expiring_integration_test.go
@@ -346,3 +346,189 @@ func TestCountExpiring_UnaffectedByStripeManagedRows(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(1), n, "trials_expiring counts trials that EXPIRE; a card-backed trial converts")
 }
+
+// seedSignupRow inserts a `signup` subscription whose trial has never been
+// extended, so its effective end comes from the null-trial_ends_at branch:
+// created_at + TrialDays. That is the population Bootstrap creates and the
+// checkout webhook never moved on — see trial.ListOptions.IncludeSignup.
+func seedSignupRow(t *testing.T, db *gorm.DB, trialEndsAt time.Time, opts func(*subscription.StoreSubscription)) subscription.StoreSubscription {
+	t.Helper()
+
+	return seedExpiringRow(t, db, trialEndsAt, func(r *subscription.StoreSubscription) {
+		r.Status = subscription.StatusSignup
+		if opts != nil {
+			opts(r)
+		}
+	})
+}
+
+// The default must be unchanged: a tenant still at `signup` is not
+// "expiring". This is the contract #285 already ships, and the zero
+// ListOptions value must keep it byte-for-byte.
+func TestListExpiring_DefaultExcludesSignup(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+
+	seedSignupRow(t, db, expiringAsOf.Add(3*24*time.Hour), nil)
+	trialing := seedExpiringRow(t, db, expiringAsOf.Add(4*24*time.Hour), nil)
+
+	rows, total, err := trial.ListExpiring(context.Background(), db,
+		expiringAsOf, trial.DefaultExpiryWindow, 1, 10, trial.ListOptions{})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total, "the signup row must not appear by default")
+	require.Len(t, rows, 1)
+	require.Equal(t, trialing.StoreID.String(), rows[0].StoreID)
+	require.Equal(t, string(subscription.StatusTrialing), rows[0].Status)
+}
+
+// With the flag, BOTH appear and Status is what tells them apart — an
+// operator chases a `signup` tenant to complete checkout, but a `trialing`
+// one is about to lose access. Two rows of different kinds in one fixture:
+// one kind cannot prove a filter.
+func TestListExpiring_IncludeSignup_ReturnsBothLabelledByStatus(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+
+	signup := seedSignupRow(t, db, expiringAsOf.Add(3*24*time.Hour), nil)
+	trialing := seedExpiringRow(t, db, expiringAsOf.Add(4*24*time.Hour), nil)
+
+	rows, total, err := trial.ListExpiring(context.Background(), db,
+		expiringAsOf, trial.DefaultExpiryWindow, 1, 10, trial.ListOptions{IncludeSignup: true})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), total)
+	require.Len(t, rows, 2)
+
+	byStore := map[string]trial.ExpiringRow{}
+	for _, r := range rows {
+		byStore[r.StoreID] = r
+	}
+	require.Equal(t, string(subscription.StatusSignup), byStore[signup.StoreID.String()].Status)
+	require.Equal(t, string(subscription.StatusTrialing), byStore[trialing.StoreID.String()].Status)
+}
+
+// The two options are independent, and all four combinations are
+// meaningful. One fixture holds a row of each kind — trialing/signup ×
+// card-less/card-backed — so a combination that admits one axis by
+// accident when widening the other is caught.
+//
+// IncludeSignup alone must not drag a card-backed row in, and
+// IncludeStripeManaged alone must not drag a signup row in.
+func TestListExpiring_SignupAndStripeManagedCompose(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+
+	cardSub := "sub_compose_trialing"
+	signupCardSub := "sub_compose_signup"
+
+	trialingCardless := seedExpiringRow(t, db, expiringAsOf.Add(1*24*time.Hour), nil)
+	trialingCarded := seedExpiringRow(t, db, expiringAsOf.Add(2*24*time.Hour),
+		func(r *subscription.StoreSubscription) { r.StripeSubscriptionID = &cardSub })
+	signupCardless := seedSignupRow(t, db, expiringAsOf.Add(3*24*time.Hour), nil)
+	signupCarded := seedSignupRow(t, db, expiringAsOf.Add(4*24*time.Hour),
+		func(r *subscription.StoreSubscription) { r.StripeSubscriptionID = &signupCardSub })
+
+	cases := []struct {
+		name string
+		opts trial.ListOptions
+		want []string
+	}{
+		{
+			name: "zero value: trialing and card-less only",
+			opts: trial.ListOptions{},
+			want: []string{trialingCardless.StoreID.String()},
+		},
+		{
+			name: "IncludeStripeManaged alone drops the card filter only",
+			opts: trial.ListOptions{IncludeStripeManaged: true},
+			want: []string{trialingCardless.StoreID.String(), trialingCarded.StoreID.String()},
+		},
+		{
+			name: "IncludeSignup alone widens the status set only",
+			opts: trial.ListOptions{IncludeSignup: true},
+			want: []string{trialingCardless.StoreID.String(), signupCardless.StoreID.String()},
+		},
+		{
+			name: "both widen both axes",
+			opts: trial.ListOptions{IncludeSignup: true, IncludeStripeManaged: true},
+			want: []string{
+				trialingCardless.StoreID.String(), trialingCarded.StoreID.String(),
+				signupCardless.StoreID.String(), signupCarded.StoreID.String(),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, total, err := trial.ListExpiring(context.Background(), db,
+				expiringAsOf, trial.DefaultExpiryWindow, 1, 10, tc.opts)
+			require.NoError(t, err)
+			require.Equal(t, int64(len(tc.want)), total)
+
+			got := make([]string, 0, len(rows))
+			for _, r := range rows {
+				got = append(got, r.StoreID)
+			}
+			require.ElementsMatch(t, tc.want, got)
+		})
+	}
+}
+
+// A signup row has no trial_ends_at, so its effective end comes from
+// created_at + TrialDays — the same fallback EndsAt applies. It must sort
+// against a trialing row's EXPLICIT trial_ends_at on that effective date,
+// not on created_at and not after every extended row.
+//
+// The extended trialing row is seeded with a created_at far outside the
+// window on purpose: if the ordering (or the window predicate) read
+// created_at rather than the effective end, this row would sort first, or
+// vanish from the page entirely.
+func TestListExpiring_SignupRowSortsOnItsDerivedEnd(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+
+	extendedEnd := expiringAsOf.Add(2 * 24 * time.Hour)
+	extended := seedExpiringRow(t, db, expiringAsOf.Add(300*24*time.Hour),
+		func(r *subscription.StoreSubscription) {
+			r.CreatedAt = expiringAsOf.Add(-200 * 24 * time.Hour)
+			r.TrialEndsAt = &extendedEnd
+		})
+	signupEarly := seedSignupRow(t, db, expiringAsOf.Add(1*24*time.Hour), nil)
+	signupLate := seedSignupRow(t, db, expiringAsOf.Add(5*24*time.Hour), nil)
+
+	rows, total, err := trial.ListExpiring(context.Background(), db,
+		expiringAsOf, trial.DefaultExpiryWindow, 1, 10, trial.ListOptions{IncludeSignup: true})
+	require.NoError(t, err)
+	require.Equal(t, int64(3), total)
+	require.Len(t, rows, 3)
+
+	require.Equal(t, signupEarly.StoreID.String(), rows[0].StoreID, "day 1, derived from created_at + TrialDays")
+	require.Equal(t, extended.StoreID.String(), rows[1].StoreID, "day 2, from an explicit trial_ends_at")
+	require.Equal(t, signupLate.StoreID.String(), rows[2].StoreID, "day 5, derived")
+
+	// The derived end is also what the row REPORTS, not created_at.
+	require.True(t, expiringAsOf.Add(1*24*time.Hour).Equal(rows[0].TrialEndsAt),
+		"want %s, got %s", expiringAsOf.Add(1*24*time.Hour), rows[0].TrialEndsAt)
+}
+
+// THE assertion that matters most. CountExpiring backs /admin/kpis's
+// trials_expiring, which the console shares with this list "so the two
+// cannot report different numbers for the same word". A `signup` row will
+// NOT expire — expiry_cron selects status = 'trialing' only — so widening
+// the list must leave the counter exactly where it was. CountExpiring takes
+// no ListOptions at all, and this proves the flag cannot reach it by any
+// other route either.
+func TestCountExpiring_UnmovedByIncludeSignup(t *testing.T) {
+	db := testdb.NewDB(t, "store_subscriptions", "stores")
+
+	seedSignupRow(t, db, expiringAsOf.Add(3*24*time.Hour), nil)
+	seedExpiringRow(t, db, expiringAsOf.Add(4*24*time.Hour), nil)
+
+	n, err := trial.CountExpiring(context.Background(), db, expiringAsOf, trial.DefaultExpiryWindow)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n,
+		"trials_expiring counts trials that EXPIRE; a signup row never reaches the expiry cron")
+
+	// The same fixture, listed with the flag, returns two. The counter and
+	// the list are ALLOWED to differ here — that is the point — but only
+	// because the list was asked an explicitly different question.
+	_, total, err := trial.ListExpiring(context.Background(), db,
+		expiringAsOf, trial.DefaultExpiryWindow, 1, 10, trial.ListOptions{IncludeSignup: true})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), total)
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_trials.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_trials.go
@@ -145,10 +145,20 @@ func (h *BillingTrialsHandler) list(c *gin.Context) {
 	// different question and an explicit one.
 	includeStripeManaged := c.Query("include_stripe_managed") == "true"
 
+	// Default false for the same reason, and a separate question again:
+	// a `signup` tenant is on a trial plan but never completed checkout, so
+	// it will never expire and never convert. It is listed only when asked
+	// for — see trial.ListOptions.IncludeSignup, which also explains why the
+	// trial_ends_at such a row reports is notional.
+	includeSignup := c.Query("include_signup") == "true"
+
 	ctx := c.Request.Context()
 	asOf := h.now()
 
-	rows, total, err := h.trials.ListExpiring(ctx, h.db, asOf, window, page, limit, trial.ListOptions{IncludeStripeManaged: includeStripeManaged})
+	rows, total, err := h.trials.ListExpiring(ctx, h.db, asOf, window, page, limit, trial.ListOptions{
+		IncludeStripeManaged: includeStripeManaged,
+		IncludeSignup:        includeSignup,
+	})
 	if err != nil {
 		h.respondErr(c, err)
 		return

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_trials_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_trials_test.go
@@ -828,3 +828,70 @@ func TestBillingTrials_IncludeStripeManagedReachesTheLister(t *testing.T) {
 			"every row states its kind; an omitted false is indistinguishable from an older server")
 	})
 }
+
+// The include_signup query parameter must reach the lister, and a signup
+// row's status must be legible on the wire. Both directions matter: a
+// handler that always passed true would widen a live contract, and one that
+// never passed it would leave the stuck-at-signup population invisible —
+// which is the defect this parameter exists to fix.
+func TestBillingTrials_IncludeSignupReachesTheLister(t *testing.T) {
+	dir := &stubBillingDirectory{names: map[string]string{}}
+
+	t.Run("with the flag", func(t *testing.T) {
+		rows := billingTrialsFixtureRows(billingTrialsFixtureAsOf)
+		rows[0].Status = "signup"
+		trials := &stubTrialLister{rows: rows, total: int64(len(rows))}
+
+		rec := httptest.NewRecorder()
+		billingTrialsRouter(t, trials, dir).ServeHTTP(rec, httptest.NewRequest(
+			http.MethodGet, "/admin/billing/trials?include_signup=true", nil))
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+		require.True(t, trials.gotOpts.IncludeSignup)
+		// Raw bytes: an operator acts on a signup row differently from a
+		// trialing one (chase checkout vs. about to lose access), so the
+		// status has to survive to the response, not just to the query.
+		require.Contains(t, rec.Body.String(), `"status":"signup"`)
+		require.Contains(t, rec.Body.String(), `"status":"trialing"`)
+	})
+
+	t.Run("without the flag the default is unchanged", func(t *testing.T) {
+		trials := &stubTrialLister{rows: nil, total: 0}
+		rec := httptest.NewRecorder()
+		billingTrialsRouter(t, trials, dir).ServeHTTP(rec, httptest.NewRequest(
+			http.MethodGet, "/admin/billing/trials", nil))
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.False(t, trials.gotOpts.IncludeSignup,
+			"the default must stay #285's shipped contract")
+	})
+
+	t.Run("anything other than true is false", func(t *testing.T) {
+		trials := &stubTrialLister{rows: nil, total: 0}
+		rec := httptest.NewRecorder()
+		billingTrialsRouter(t, trials, dir).ServeHTTP(rec, httptest.NewRequest(
+			http.MethodGet, "/admin/billing/trials?include_signup=1", nil))
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.False(t, trials.gotOpts.IncludeSignup,
+			"a widening flag must require the exact value, never a truthy-looking one")
+	})
+
+	t.Run("the two flags are read independently", func(t *testing.T) {
+		trials := &stubTrialLister{rows: nil, total: 0}
+		rec := httptest.NewRecorder()
+		billingTrialsRouter(t, trials, dir).ServeHTTP(rec, httptest.NewRequest(
+			http.MethodGet, "/admin/billing/trials?include_signup=true", nil))
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.True(t, trials.gotOpts.IncludeSignup)
+		require.False(t, trials.gotOpts.IncludeStripeManaged,
+			"asking for signup rows must not also opt into card-backed ones")
+
+		trials2 := &stubTrialLister{rows: nil, total: 0}
+		rec2 := httptest.NewRecorder()
+		billingTrialsRouter(t, trials2, dir).ServeHTTP(rec2, httptest.NewRequest(
+			http.MethodGet, "/admin/billing/trials?include_stripe_managed=true", nil))
+		require.Equal(t, http.StatusOK, rec2.Code)
+		require.True(t, trials2.gotOpts.IncludeStripeManaged)
+		require.False(t, trials2.gotOpts.IncludeSignup,
+			"asking for card-backed rows must not also opt into signup ones")
+	})
+}


### PR DESCRIPTION
An operator with **three tenants** opened the console's trials surface and saw nothing — at 7 days, at a year, and with Stripe-managed rows opted in. The list was answering correctly. **None of those tenants is `trialing`.**

## What the code says

`subscription.Service.Bootstrap` (`internal/subscription/service.go:125`) creates every new subscription as:

```go
Plan:   PlanTrial,      // on a trial by plan
Status: StatusSignup,   // and NOT `trialing` by status
```

`trialingInWindowScope` requires `status = 'trialing'`, so a tenant on a trial plan is invisible to this list under **every** window and every existing option.

**`signup → trialing` has exactly one non-test writer in the service:** a Stripe `checkout.session.completed` webhook (`internal/billing/dispatch/handlers.go:219`, actor `system:webhook:stripe`). A tenant that signs up and never completes checkout never leaves `signup`.

## And nothing else is watching them

`expiry_cron` also selects `status = 'trialing'` (`expiry_cron.go:90`). So a `signup` row is **never aged out** — not trialing, not expired, not on any queue, and not seen by the machinery that exists to watch trials. It sits there indefinitely.

That is the real finding. The console not showing them is the smaller half.

## The shape: opt-in, list-only

`ListOptions`'s own doc states the rule this respects — *"The zero value is the contract #285 already ships, so an omitted option can never widen a live result set by accident."*

So `IncludeSignup` mirrors `IncludeStripeManaged` exactly: same file, same shape, off by default. `trialingInWindowScope`'s false branch builds the **identical** predicate it always had; only the true branch widens to `status IN (trialing, signup)`.

**`CountExpiring` cannot move, structurally.** `expiringScope` passes `false` unconditionally, so the KPI is unreachable from the new flag rather than merely not-currently-passed. `/admin/kpis`'s `trials_expiring` and the console share a definition deliberately *"so the two cannot report different numbers for the same word"*, and a **view** change must not redefine it. `TestCountExpiring_UnmovedByIncludeSignup` is the test that pins it; mutating `expiringScope` to pass `true` turns it red.

The two options **compose independently** — signup alone admits no card-backed rows, and vice versa. All four combinations are tested against one fixture.

### The window already worked; the comment now says what it means

`EndsAt` falls back to `created_at + TrialDays` for a null `trial_ends_at`, and `EndsBetweenScope` covers the null branch — verified by a sorting test rather than assumed, with a signup row at day 1 and day 5 straddling an *extended* trialing row whose `created_at` is 200 days back, so a predicate that read `created_at` instead of the derived end would fail.

But the doc now says plainly that for a `signup` row that date is **notional**: `expiry_cron` will not act on it. A reader must not infer from this list that the expiry machinery is watching.

## Test plan

- [x] `gofmt -l` clean, `go build ./...`, `go vet ./...`
- [x] `go test ./...` — **3066 pass, 0 fail**
- [x] Integration (`-tags=integration -p 1`, both packages) — **686 pass, 0 fail, 0 skip**
- [x] Mutation-checked, restored and re-verified by `shasum`:
  - `expiringScope` widened to include signup → `TestCountExpiring_UnmovedByIncludeSignup` red
  - default branch forced true → the default-excludes and compose tests red
- [x] `status` asserted on the raw response body (`"status":"signup"` / `"trialing"`) — nothing pinned it before

These integration tests **actually run**, which is new: this package's integration suite was dead until earlier today (#776), so coverage here was written rather than assumed.

## Two notes

- **`Status` was already on the wire** — `trialRow.Status` with no `omitempty`, already set by `toTrialRow`. Nothing needed adding; a raw-body assertion was added because none existed. That matters for the console half: a `signup` tenant needs chasing to complete checkout, a `trialing` one is about to lose access, and they must be distinguishable rather than merged into one list.
- **The plan asked me to update a route doc block listing accepted params — there isn't one.** `billing_trials.go` documents each param at its read site instead. I followed that convention rather than inventing an enumeration that would immediately risk going stale.

## Follow-up, deliberately not here

**Nothing ages out a `signup` row.** Whether a tenant that never completes checkout should eventually be expired, chased, or left alone is a product decision with billing consequences, and a filter change should not settle it. This makes the population visible; deciding what happens to it comes after someone can see it.

The console half — forwarding `include_signup` and showing the status — follows in tesserix-home.
