### PR TITLE
feat(platform-api): serve the auth email-template registry on the console contract surface (#720)

### DIFF
--- a/services/platform-api/cmd/server/main.go
+++ b/services/platform-api/cmd/server/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/mark8ly/platform-api/internal/audit"
 	"github.com/mark8ly/platform-api/internal/auth"
 	"github.com/mark8ly/platform-api/internal/authz"
+	"github.com/mark8ly/platform-api/internal/emailtemplates"
 	"github.com/mark8ly/platform-api/internal/estate"
 	"github.com/mark8ly/platform-api/internal/estateuser"
 	"github.com/mark8ly/platform-api/internal/invitation"
@@ -352,6 +353,15 @@ func main() {
 		Logger:  log,
 		Secret:  cfg.PlatformAdminSecret,
 		Emitter: auditClient,
+		// mark8ly#720 Task 5: the auth/onboarding half of the email
+		// template registry. EmailTemplateRegistry wraps the SAME
+		// templateLoader the real send path (notification.NewHandler,
+		// below) reads, so an operator's edit is visible to actual sends
+		// immediately, not just to this surface's own preview — see
+		// emailtemplates.Registry's doc comment.
+		EmailTemplates:          emailtemplates.NewStore(conn),
+		EmailTemplateRegistry:   emailtemplates.NewRegistry(templateLoader),
+		EmailTemplateTestSender: emailtemplates.NewNotificationTestSender(sender, cfg.EmailFrom),
 	})
 
 	v1 := r.Group("/api/v1")

--- a/services/platform-api/internal/emailtemplates/registry.go
+++ b/services/platform-api/internal/emailtemplates/registry.go
@@ -1,0 +1,111 @@
+package emailtemplates
+
+// registry.go — the RegisteredKeys/Fallback/Invalidate/Render surface the
+// platform admin handler needs (mirroring marketplace-api's
+// emailtemplates.Loader interface field for field), backed by
+// internal/notification.Loader rather than a second cache.
+//
+// This is a deliberate divergence from marketplace-api's shape: there,
+// ONE emailtemplates.Loader IS both the send-path cache and the admin
+// registry, in the same package. Here, internal/notification.Loader is
+// already that send-path cache — built once in cmd/server/main.go and
+// handed to every real send call site (onboarding, verification, auth) —
+// and duplicating it as a second Loader in this package would mean an
+// admin write's Invalidate call evicts a cache nothing sends through,
+// leaving the real send path serving stale copy for up to CacheTTL.
+// Wrapping the SAME *notification.Loader instance instead means
+// Invalidate here is Invalidate there: an operator's edit takes effect on
+// the next real send, not just the next admin preview.
+
+import (
+	"context"
+	"errors"
+
+	"github.com/mark8ly/platform-api/internal/notification"
+)
+
+// EmbeddedFallback is what a key falls back to when no DB row exists.
+// Mirrors marketplace-api's emailtemplates.EmbeddedFallback: no declared
+// variable schema is carried here even though platform-api's embedded
+// templates DO have one (notification.EmbeddedDefault returns it) — see
+// Fallback below for why it is dropped at this boundary.
+type EmbeddedFallback struct {
+	Subject  string
+	HTMLBody string
+	TextBody string
+}
+
+// Rendered is a rendered subject/html/text triple, ready for a test send
+// or a preview.
+type Rendered struct {
+	Subject  string
+	HTMLBody string
+	TextBody string
+}
+
+// Registry adapts *notification.Loader to the shape
+// platformadmin.EmailTemplateRegistry expects.
+type Registry struct {
+	loader *notification.Loader
+}
+
+// NewRegistry wraps loader — the SAME instance cmd/server/main.go builds
+// for the real send path. loader may be nil; every method then degrades
+// (RegisteredKeys/Fallback still work off the fixed embedded set, which
+// needs no Loader; Invalidate is a no-op; Render errors).
+func NewRegistry(loader *notification.Loader) *Registry {
+	return &Registry{loader: loader}
+}
+
+// RegisteredKeys returns platform-api's six embedded template keys,
+// sorted. Needs no Loader — see notification.RegisteredKeys.
+func (r *Registry) RegisteredKeys() []string {
+	return notification.RegisteredKeys()
+}
+
+// Fallback returns the embedded default for key. The bool reports whether
+// key is one of the six embedded templates at all.
+//
+// The declared variable schema notification.EmbeddedDefault also returns
+// is deliberately dropped here, matching marketplace-api's
+// EmailTemplatesHandler.Get: for an UNAUTHORED key it always answers with
+// an EMPTY variables array regardless of what the embedded default might
+// otherwise declare (marketplace-api's own EmbeddedFallback type has no
+// Variables field at all), because "an embedded default declares no
+// variable schema — the registry holds three template strings and
+// nothing else" per that handler's doc comment. Keeping this type
+// variable-schema-free, rather than adding the field and then discarding
+// it at the call site, is what keeps that behaviour from silently
+// reappearing later.
+func (r *Registry) Fallback(key string) (EmbeddedFallback, bool) {
+	subject, html, text, _, ok := notification.EmbeddedDefault(key)
+	if !ok {
+		return EmbeddedFallback{}, false
+	}
+	return EmbeddedFallback{Subject: subject, HTMLBody: html, TextBody: text}, true
+}
+
+// Invalidate clears the SEND PATH's cache for key — see the package doc
+// comment for why this must reach the real *notification.Loader and not a
+// second, admin-only cache.
+func (r *Registry) Invalidate(key string) {
+	if r == nil || r.loader == nil {
+		return
+	}
+	r.loader.Invalidate(key)
+}
+
+// Render renders key against vars (typically a map[string]any decoded
+// from the console's JSON body) through the SAME loader the send path
+// uses — a published DB row if there is one, the embedded default
+// otherwise — so a test send exercises exactly what is live for the key.
+func (r *Registry) Render(ctx context.Context, key string, vars any) (Rendered, error) {
+	if r == nil || r.loader == nil {
+		return Rendered{}, errors.New("emailtemplates: registry has no template loader configured")
+	}
+	subject, html, text, err := r.loader.RenderPreview(ctx, key, vars)
+	if err != nil {
+		return Rendered{}, err
+	}
+	return Rendered{Subject: subject, HTMLBody: html, TextBody: text}, nil
+}

--- a/services/platform-api/internal/emailtemplates/sender.go
+++ b/services/platform-api/internal/emailtemplates/sender.go
@@ -1,0 +1,61 @@
+package emailtemplates
+
+// sender.go — the test-send dispatcher for the platform admin authoring
+// surface.
+//
+// marketplace-api's equivalent (sendgrid_test_sender.go) is a bespoke,
+// minimum-viable SendGrid v3 HTTP client, because marketplace-api's
+// package had no existing Sender abstraction to reuse. platform-api
+// already has one — internal/notification.Sender, with SendGrid, Resend
+// and a fallback chain wired in cmd/server/main.go (notification.NewFromConfig)
+// — so this file is an adapter onto that, not a second HTTP client.
+//
+// One consequence of reusing it: notification.NewFromConfig NEVER returns
+// nil — with no provider key configured it returns a LogSender that prints
+// to stdout, matching how every other platform-api email (password reset,
+// login OTP, ...) already degrades in dev. A test-send through this
+// adapter therefore does not answer 503 not_configured in that
+// configuration the way marketplace-api's does; it "succeeds" by logging
+// instead of emailing. That is an intentional, existing platform-api
+// behaviour this adapter inherits rather than papers over — see
+// TestSender's construction site in cmd/server/main.go.
+
+import (
+	"context"
+	"errors"
+
+	"github.com/mark8ly/platform-api/internal/notification"
+)
+
+// TestSender dispatches a rendered template to a single recipient for the
+// admin authoring surface's test-send route.
+type TestSender interface {
+	SendTest(ctx context.Context, to string, r Rendered) error
+}
+
+// notificationTestSender adapts a notification.Sender + From address into
+// a TestSender.
+type notificationTestSender struct {
+	sender notification.Sender
+	from   string
+}
+
+// NewNotificationTestSender builds a TestSender backed by sender (the same
+// notification.Sender instance cmd/server/main.go builds for real sends)
+// and the service's configured From address.
+func NewNotificationTestSender(sender notification.Sender, from string) TestSender {
+	return &notificationTestSender{sender: sender, from: from}
+}
+
+func (s *notificationTestSender) SendTest(ctx context.Context, to string, r Rendered) error {
+	if s == nil || s.sender == nil {
+		return errors.New("emailtemplates: no notification sender configured")
+	}
+	return s.sender.Send(ctx, notification.Email{
+		To:       to,
+		From:     s.from,
+		Subject:  r.Subject,
+		HTMLBody: r.HTMLBody,
+		TextBody: r.TextBody,
+	})
+}

--- a/services/platform-api/internal/emailtemplates/store.go
+++ b/services/platform-api/internal/emailtemplates/store.go
@@ -1,0 +1,246 @@
+// Package emailtemplates is platform-api's half of the runtime email
+// template registry, serving mark8ly#720 Task 5. It reads and writes the
+// SAME email_templates table (migration 0013) that internal/notification's
+// Loader already reads on the real send path, and mirrors marketplace-api's
+// internal/emailtemplates package (services/marketplace-api/internal/
+// emailtemplates) field for field — the console's platform admin surface
+// treats both services' endpoints identically, so the two packages must
+// agree on shape even though they live in different services with
+// different production loaders behind them.
+//
+// Where the two tables diverge, this package follows platform-api's ACTUAL
+// schema, not marketplace-api's:
+//   - migration 0013 has no updated_at trigger and no per-column
+//     constraint beyond `status`; both tables otherwise agree, column for
+//     column (key, subject, html_body, text_body, variables jsonb, status,
+//     version, updated_at, updated_by).
+//   - There is no cross-DB grant here to preserve compatibility with
+//     (mark8ly has never had an admin database user for platform-api's
+//     database — that was always marketplace-api's cross-DB path, which
+//     mark8ly#720 is replacing, not extending). Nothing in this package
+//     depends on one.
+package emailtemplates
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// Status values the table's CHECK constraint allows (migration 0013).
+const (
+	StatusPublished = "published"
+	StatusDraft     = "draft"
+)
+
+// ErrNoDB is returned by every Store method when the store was built with
+// a nil *gorm.DB. Returned rather than panicking so a mis-wired process
+// surfaces a 500 with a logged cause instead of a crashed request.
+var ErrNoDB = errors.New("emailtemplates: no database connection")
+
+// Variable is one entry of a template's declared variable schema.
+type Variable struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Required bool   `json:"required"`
+}
+
+// Row is a stored template.
+type Row struct {
+	Key       string
+	Subject   string
+	HTMLBody  string
+	TextBody  string
+	Variables []Variable
+	Status    string
+	Version   int
+	UpdatedAt time.Time
+	UpdatedBy string
+}
+
+// UpsertInput is one authored save. UpdatedBy and Capability come from the
+// signed platform-admin request (platformauth.CtxOperatorID / CtxCapability),
+// never from the body.
+type UpsertInput struct {
+	Key        string
+	Subject    string
+	HTMLBody   string
+	TextBody   string
+	Variables  []Variable
+	Status     string
+	UpdatedBy  string
+	Capability string
+}
+
+// Store reads and writes email_templates.
+type Store struct {
+	db *gorm.DB
+}
+
+// NewStore binds a Store to a GORM connection. db may be nil; every method
+// then returns ErrNoDB.
+func NewStore(db *gorm.DB) *Store { return &Store{db: db} }
+
+type scanRow struct {
+	Key       string
+	Subject   string
+	HTMLBody  string
+	TextBody  string
+	Variables []byte
+	Status    string
+	Version   int
+	UpdatedAt time.Time
+	UpdatedBy *string
+}
+
+const selectColumns = `key, subject, html_body, text_body, variables, status, version, updated_at, updated_by`
+
+func toRow(r scanRow) Row {
+	row := Row{
+		Key:       r.Key,
+		Subject:   r.Subject,
+		HTMLBody:  r.HTMLBody,
+		TextBody:  r.TextBody,
+		Variables: decodeVariables(r.Variables),
+		Status:    r.Status,
+		Version:   r.Version,
+		UpdatedAt: r.UpdatedAt,
+	}
+	if r.UpdatedBy != nil {
+		row.UpdatedBy = *r.UpdatedBy
+	}
+	return row
+}
+
+// decodeVariables never returns nil: a nil slice marshals to null, and a
+// console reading `variables.map(...)` would crash on exactly the
+// templates that declare none.
+func decodeVariables(raw []byte) []Variable {
+	out := make([]Variable, 0)
+	if len(raw) == 0 {
+		return out
+	}
+	var decoded []Variable
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return out
+	}
+	for _, v := range decoded {
+		if strings.TrimSpace(v.Name) == "" {
+			continue
+		}
+		if v.Type == "" {
+			v.Type = "string"
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// List returns every stored template, published and draft alike, ordered
+// by key.
+func (s *Store) List(ctx context.Context) ([]Row, error) {
+	if s == nil || s.db == nil {
+		return nil, ErrNoDB
+	}
+	var scanned []scanRow
+	err := s.db.WithContext(ctx).
+		Raw(`SELECT ` + selectColumns + ` FROM email_templates ORDER BY key ASC`).
+		Scan(&scanned).Error
+	if err != nil {
+		return nil, fmt.Errorf("emailtemplates: list: %w", err)
+	}
+	rows := make([]Row, 0, len(scanned))
+	for _, r := range scanned {
+		rows = append(rows, toRow(r))
+	}
+	return rows, nil
+}
+
+// Get returns one stored template. The bool reports existence; a missing
+// row is not an error, because "no row" is a legitimate state for a
+// registered key (the embedded default is what sends).
+func (s *Store) Get(ctx context.Context, key string) (Row, bool, error) {
+	if s == nil || s.db == nil {
+		return Row{}, false, ErrNoDB
+	}
+	var scanned scanRow
+	err := s.db.WithContext(ctx).
+		Raw(`SELECT `+selectColumns+` FROM email_templates WHERE key = ?`, key).
+		Scan(&scanned).Error
+	if err != nil {
+		return Row{}, false, fmt.Errorf("emailtemplates: get %q: %w", key, err)
+	}
+	if scanned.Key == "" {
+		return Row{}, false, nil
+	}
+	return toRow(scanned), true, nil
+}
+
+// Upsert saves an authored template and records the change, both on ONE
+// transaction — see the package doc comment and migration 0018 for why
+// the revision insert is not optional decoration.
+func (s *Store) Upsert(ctx context.Context, in UpsertInput) (Row, error) {
+	if s == nil || s.db == nil {
+		return Row{}, ErrNoDB
+	}
+	status := in.Status
+	if status != StatusDraft {
+		status = StatusPublished
+	}
+	vars := in.Variables
+	if vars == nil {
+		vars = []Variable{}
+	}
+	encoded, err := json.Marshal(vars)
+	if err != nil {
+		return Row{}, fmt.Errorf("emailtemplates: encode variables: %w", err)
+	}
+
+	var saved Row
+	txErr := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var scanned scanRow
+		if err := tx.Raw(`
+			INSERT INTO email_templates
+				(key, subject, html_body, text_body, variables, status, version, updated_at, updated_by)
+			VALUES (?, ?, ?, ?, ?::jsonb, ?, 1, now(), ?)
+			ON CONFLICT (key) DO UPDATE SET
+				subject    = EXCLUDED.subject,
+				html_body  = EXCLUDED.html_body,
+				text_body  = EXCLUDED.text_body,
+				variables  = EXCLUDED.variables,
+				status     = EXCLUDED.status,
+				version    = email_templates.version + 1,
+				updated_at = now(),
+				updated_by = EXCLUDED.updated_by
+			RETURNING `+selectColumns,
+			in.Key, in.Subject, in.HTMLBody, in.TextBody, string(encoded), status, in.UpdatedBy,
+		).Scan(&scanned).Error; err != nil {
+			return fmt.Errorf("emailtemplates: upsert %q: %w", in.Key, err)
+		}
+		if scanned.Key == "" {
+			return fmt.Errorf("emailtemplates: upsert %q returned no row", in.Key)
+		}
+		saved = toRow(scanned)
+
+		var capability *string
+		if c := strings.TrimSpace(in.Capability); c != "" {
+			capability = &c
+		}
+		if err := tx.Exec(`
+			INSERT INTO email_template_revisions (key, version, status, changed_by, capability)
+			VALUES (?, ?, ?, ?, ?)
+		`, saved.Key, saved.Version, saved.Status, in.UpdatedBy, capability).Error; err != nil {
+			return fmt.Errorf("emailtemplates: record revision %q: %w", in.Key, err)
+		}
+		return nil
+	})
+	if txErr != nil {
+		return Row{}, txErr
+	}
+	return saved, nil
+}

--- a/services/platform-api/internal/idempotency/models.go
+++ b/services/platform-api/internal/idempotency/models.go
@@ -1,0 +1,35 @@
+// Package idempotency holds the IdempotencyKey model and its store.
+//
+// Ported from marketplace-api's internal/idempotency (mark8ly#720 Task 5)
+// against the identical idempotency_keys shape (migration 0017 here mirrors
+// marketplace-api's migration 000001 table verbatim), so this is the same
+// code against the same schema, not a reinterpretation. Unlike
+// marketplace-api, nothing here is wired to a cron sweep yet — this
+// service's first (and so far only) consumer is the email-template PUT's
+// Idempotency-Key replay, which needs Reserve/Lookup/Complete/Release, not
+// the sweep. SweepExpired is still included so a future cron wiring is a
+// one-line addition, not a second copy of this file.
+package idempotency
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// IdempotencyKey stores a previously-seen request key plus its response,
+// keyed by an Idempotency-Key header value.
+//
+// Response is json.RawMessage ([]byte underneath) rather than
+// marketplace-api's gorm.io/datatypes.JSON, deliberately: pulling in that
+// module for one column tagged jsonb would be a new dependency for a type
+// GORM already round-trips correctly via the postgres driver's []byte
+// handling plus the explicit column type tag below.
+type IdempotencyKey struct {
+	Key       string          `gorm:"primaryKey;column:key;type:varchar(255)" json:"key"`
+	TenantID  string          `gorm:"column:tenant_id;type:uuid;not null"     json:"tenant_id"`
+	Response  json.RawMessage `gorm:"column:response;type:jsonb"              json:"response,omitempty"`
+	CreatedAt time.Time       `gorm:"column:created_at;not null;default:now()" json:"created_at"`
+	ExpiresAt time.Time       `gorm:"column:expires_at;not null"              json:"expires_at"`
+}
+
+func (IdempotencyKey) TableName() string { return "idempotency_keys" }

--- a/services/platform-api/internal/idempotency/store.go
+++ b/services/platform-api/internal/idempotency/store.go
@@ -1,0 +1,120 @@
+package idempotency
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// DefaultTTL is how long a stored response stays replayable. Long enough to
+// cover a client's retry budget, short enough that the table stays small.
+const DefaultTTL = 24 * time.Hour
+
+// Lookup returns a previously stored response for key.
+//
+// An EXPIRED row is a miss: expiry is a property of the row, not of
+// whether a sweep happened to run recently, and replaying a response past
+// its TTL would make the guarantee depend on cron timing.
+//
+// A row with no Response is ALSO a miss, not an error: Reserve creates
+// such a row to claim a key before the work behind it has finished, and
+// its caller has not completed yet. Treating it as a hit would replay an
+// empty body to a second caller instead of telling them the truth — that
+// a request with this key is still in flight.
+//
+// Expiry is judged against the DATABASE clock (`now()` in the query
+// below), deliberately — every pod hitting this query agrees on what "now"
+// means regardless of its own clock. SweepExpired, below, takes an
+// app-clock `now` instead; the two are not guaranteed to agree.
+func Lookup(ctx context.Context, db *gorm.DB, key string) (json.RawMessage, bool, error) {
+	var row IdempotencyKey
+	err := db.WithContext(ctx).
+		Where("key = ? AND expires_at > now()", key).
+		First(&row).Error
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return nil, false, nil
+	case err != nil:
+		return nil, false, fmt.Errorf("idempotency: lookup: %w", err)
+	}
+	if len(row.Response) == 0 {
+		return nil, false, nil
+	}
+	return row.Response, true, nil
+}
+
+// Reserve claims key for the caller. It returns claimed=true when this
+// caller won the race and should do the work, false when another caller
+// already holds it — in which case the winner's response is the one that
+// will be replayed, and this caller must not execute.
+//
+// This is what makes the guarantee hold across pods: Lookup-then-Save is
+// check-then-act, and two pods can both miss before either saves. Reserve
+// closes that gap with an ON CONFLICT DO NOTHING insert of a row with no
+// Response — the row's mere existence is the claim, and Complete fills in
+// the body once the work is done.
+func Reserve(ctx context.Context, db *gorm.DB, key, tenantID string, now time.Time, ttl time.Duration) (bool, error) {
+	row := IdempotencyKey{
+		Key:       key,
+		TenantID:  tenantID,
+		CreatedAt: now.UTC(),
+		ExpiresAt: now.UTC().Add(ttl),
+	}
+	res := db.WithContext(ctx).
+		Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "key"}}, DoNothing: true}).
+		Create(&row)
+	if res.Error != nil {
+		return false, fmt.Errorf("idempotency: reserve: %w", res.Error)
+	}
+	return res.RowsAffected == 1, nil
+}
+
+// Complete stores the response body against an already-reserved key,
+// turning a claimed-but-empty row into a replayable one.
+func Complete(ctx context.Context, db *gorm.DB, key string, body json.RawMessage) error {
+	err := db.WithContext(ctx).Model(&IdempotencyKey{}).
+		Where("key = ?", key).
+		Update("response", []byte(body)).Error
+	if err != nil {
+		return fmt.Errorf("idempotency: complete: %w", err)
+	}
+	return nil
+}
+
+// Release drops a reservation whose work did not complete, so a corrected
+// retry with the same key is not blocked until the TTL expires.
+//
+// Only ever call this for a key THIS caller reserved and did not Complete.
+// A reservation that outlives its failed attempt turns a mistyped request
+// into a key that answers 409 in_progress for a day.
+//
+// Scoped to key AND an empty Response, so this can never delete a
+// completed row that some other caller is entitled to replay.
+func Release(ctx context.Context, db *gorm.DB, key string) error {
+	err := db.WithContext(ctx).
+		Where("key = ? AND response IS NULL", key).
+		Delete(&IdempotencyKey{}).Error
+	if err != nil {
+		return fmt.Errorf("idempotency: release: %w", err)
+	}
+	return nil
+}
+
+// SweepExpired deletes rows past their expires_at, inclusive of the
+// instant itself. Not wired to a cron in this service yet — see the
+// package doc comment — but kept alongside Reserve/Lookup/Complete/Release
+// so wiring one later is not a second copy of this file.
+func SweepExpired(ctx context.Context, db *gorm.DB, now time.Time) (int64, error) {
+	res := db.WithContext(ctx).
+		Where("expires_at <= ?", now.UTC()).
+		Delete(&IdempotencyKey{})
+	if res.Error != nil {
+		return 0, fmt.Errorf("idempotency: sweep expired: %w", res.Error)
+	}
+	return res.RowsAffected, nil
+}

--- a/services/platform-api/internal/notification/admin_registry.go
+++ b/services/platform-api/internal/notification/admin_registry.go
@@ -1,0 +1,115 @@
+package notification
+
+// admin_registry.go — the read-only surface internal/emailtemplates (the
+// platform admin authoring package, mark8ly#720 Task 5) needs from this
+// package's Loader, without that package importing anything about HTTP,
+// gin, or the console's wire shapes.
+//
+// Everything here is DERIVED from what Render/renderEmbedded already use
+// (embeddedSeed's rows, the Loader's own DB cache) — it adds no new state
+// and no new source of truth for what "the embedded default" is.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// TemplateVariable is one entry of a template's declared variable schema,
+// decoded from the JSON embedded in embeddedSeed. Mirrors marketplace-api's
+// emailtemplates.Variable field for field.
+type TemplateVariable struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Required bool   `json:"required"`
+}
+
+// RegisteredKeys returns every key this service embeds a fallback for,
+// sorted. Unlike marketplace-api's Loader.RegisteredKeys (which reflects a
+// dynamic Register() call from each sending package), this list is FIXED:
+// platform-api's six auth/onboarding templates are all defined in this one
+// package and never grow at runtime, so the embedded seed list IS the
+// registered-keys list — there is nothing else that could register one.
+func RegisteredKeys() []string {
+	seed := embeddedSeed()
+	keys := make([]string, 0, len(seed))
+	for _, s := range seed {
+		keys = append(keys, s.key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// EmbeddedDefault returns the raw (unrendered) subject/html/text and
+// declared variable schema for key, as compiled into the binary. The bool
+// reports whether key is one of the six embedded templates at all — a
+// caller must not treat the zero value as "an empty template".
+func EmbeddedDefault(key string) (subject, html, text string, variables []TemplateVariable, ok bool) {
+	s, found := embeddedTemplate(key)
+	if !found {
+		return "", "", "", nil, false
+	}
+	return s.subject, s.html, s.text, decodeSeedVariables(s.varsJSON), true
+}
+
+func embeddedTemplate(key string) (seedRow, bool) {
+	for _, s := range embeddedSeed() {
+		if s.key == key {
+			return s, true
+		}
+	}
+	return seedRow{}, false
+}
+
+func decodeSeedVariables(raw string) []TemplateVariable {
+	if raw == "" {
+		return []TemplateVariable{}
+	}
+	var out []TemplateVariable
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return []TemplateVariable{}
+	}
+	return out
+}
+
+// RenderPreview renders a template GENERICALLY for the platform admin
+// authoring surface: unlike Render (used by every real send call site),
+// it takes untyped vars — a map[string]any built from a signed console
+// request body — rather than one of this package's typed Vars structs,
+// and it produces a subject/html/text triple rather than a dispatch-ready
+// Email (there is no recipient or tenant to attach yet; the caller is
+// building a preview or a test-send payload, not sending mail through
+// this Loader).
+//
+// It follows the SAME db-then-embedded precedence Render uses — a
+// published DB row wins, the embedded default otherwise — through the
+// SAME cache (l.load), so a preview reflects exactly what a real send
+// would use and an admin edit that calls Invalidate is visible here too.
+func (l *Loader) RenderPreview(ctx context.Context, key string, vars any) (subject, html, text string, err error) {
+	if row, ok, lerr := l.load(ctx, key); lerr == nil && ok {
+		return renderPreviewTriple(key, row.Subject, row.HTMLBody, row.TextBody, vars)
+	}
+
+	seed, found := embeddedTemplate(key)
+	if !found {
+		return "", "", "", fmt.Errorf("notification: no embedded template for key %q", key)
+	}
+	return renderPreviewTriple(key, seed.subject, seed.html, seed.text, vars)
+}
+
+func renderPreviewTriple(key, subjectTpl, htmlTpl, textTpl string, vars any) (subject, html, text string, err error) {
+	subject, err = renderInline("subject:"+key, subjectTpl, vars)
+	if err != nil {
+		return "", "", "", fmt.Errorf("notification: preview render %q: %w", key, err)
+	}
+	html, err = renderInline("html:"+key, htmlTpl, vars)
+	if err != nil {
+		return "", "", "", fmt.Errorf("notification: preview render %q: %w", key, err)
+	}
+	text, err = renderInline("text:"+key, textTpl, vars)
+	if err != nil {
+		return "", "", "", fmt.Errorf("notification: preview render %q: %w", key, err)
+	}
+	return subject, html, text, nil
+}

--- a/services/platform-api/internal/platformadmin/email_templates.go
+++ b/services/platform-api/internal/platformadmin/email_templates.go
@@ -1,0 +1,662 @@
+package platformadmin
+
+// email_templates.go — the auth/onboarding half of the transactional
+// email template registry on the platform admin contract surface
+// (mark8ly#720 Task 5).
+//
+// marketplace-api already serves its half of this registry
+// (services/marketplace-api/internal/handlers/platformadmin/
+// email_templates.go, tesserix-home#588) — orderdoc_*, giftcard_delivery
+// and the twelve billing keys. This file serves the other half: welcome,
+// email_verification, invitation, password_reset, login_otp,
+// new_device_login — migration 0013's table, which marketplace-api's
+// doc comment names as the gap this closes. Routes, request/response
+// shapes and the error envelope are copied from that file field for
+// field so the console can call both services' endpoints identically; see
+// this file's doc comments only where platform-api's actual
+// infrastructure differs from what that file could assume.
+//
+// mark8ly#730 fixed a bug where this endpoint's PUT ignored its
+// Idempotency-Key header entirely. This file is written directly against
+// the FIXED behaviour (reserve-then-complete via internal/idempotency,
+// requiring the header, replaying a stored response) — there was never a
+// version of this handler here with the bug to inherit.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	htmltpl "html/template"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	texttpl "text/template"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/platform-api/internal/emailtemplates"
+	"github.com/mark8ly/platform-api/internal/idempotency"
+	"github.com/mark8ly/platformauth"
+)
+
+// EmailTemplateStore is the subset of *emailtemplates.Store this handler
+// needs. Narrowed and declared locally, matching marketplace-api's
+// pattern, so the handler is stubbable in tests without a database.
+type EmailTemplateStore interface {
+	List(ctx context.Context) ([]emailtemplates.Row, error)
+	Get(ctx context.Context, key string) (emailtemplates.Row, bool, error)
+	Upsert(ctx context.Context, in emailtemplates.UpsertInput) (emailtemplates.Row, error)
+}
+
+// EmailTemplateRegistry is the subset of *emailtemplates.Registry this
+// handler needs: the fixed embedded-key list, the cache eviction (which
+// reaches the real *notification.Loader — see registry.go's doc comment),
+// and a render for the test send.
+type EmailTemplateRegistry interface {
+	RegisteredKeys() []string
+	Fallback(key string) (emailtemplates.EmbeddedFallback, bool)
+	Invalidate(key string)
+	Render(ctx context.Context, key string, vars any) (emailtemplates.Rendered, error)
+}
+
+// Template row states, as seen by an operator. Identical vocabulary to
+// marketplace-api's surface — see that file's doc comments for the full
+// rationale, which is unchanged here.
+const (
+	stateUnauthored = "unauthored"
+	stateDraft      = "draft"
+	statePublished  = "published"
+)
+
+const (
+	sendsFromRow      = "row"
+	sendsFromEmbedded = "embedded"
+	sendsFromNothing  = "nothing"
+)
+
+// EmailTemplatesHandler serves /admin/email-templates.
+type EmailTemplatesHandler struct {
+	store    EmailTemplateStore
+	registry EmailTemplateRegistry
+	sender   emailtemplates.TestSender
+	writable bool
+	db       *gorm.DB
+	logger   *slog.Logger
+}
+
+// NewEmailTemplatesHandler constructs the handler.
+//
+// logger and sender may be nil — a nil sender leaves the test-send route
+// mounted and answering 503 not_configured, matching how an unset
+// PLATFORM_API_PLATFORM_ADMIN_SECRET leaves this whole surface mounted but
+// inert. writable gates the PUT; see Register in routes.go for what that
+// requires.
+//
+// db backs Idempotency-Key replay on the PUT. It is a separate parameter
+// from writable even though production derives both from the same
+// deps.DB, matching marketplace-api's BillingTrialExtendHandler /
+// EmailTemplatesHandler pattern: the unit tests below exercise a writable
+// handler with no database, where a nil db means the write happens but is
+// not replayable.
+func NewEmailTemplatesHandler(
+	store EmailTemplateStore,
+	registry EmailTemplateRegistry,
+	sender emailtemplates.TestSender,
+	writable bool,
+	db *gorm.DB,
+	logger *slog.Logger,
+) *EmailTemplatesHandler {
+	return &EmailTemplatesHandler{
+		store: store, registry: registry, sender: sender,
+		writable: writable, db: db, logger: logger,
+	}
+}
+
+// Register mounts the routes. The PUT mounts only when the handler was
+// built writable — see routes.go.
+func (h *EmailTemplatesHandler) Register(g *gin.RouterGroup) {
+	g.GET("/admin/email-templates", h.List)
+	g.GET("/admin/email-templates/:key", h.Get)
+	g.POST("/admin/email-templates/:key/test-send", h.TestSend)
+	if h.writable {
+		g.PUT("/admin/email-templates/:key", h.Upsert)
+	}
+}
+
+// emailTemplateRow is the pinned list shape — identical to
+// marketplace-api's, field for field, so the console's list rendering
+// needs no per-service branch.
+type emailTemplateRow struct {
+	Key                string  `json:"key"`
+	State              string  `json:"state"`
+	SendsFrom          string  `json:"sends_from"`
+	HasEmbeddedDefault bool    `json:"has_embedded_default"`
+	Subject            string  `json:"subject"`
+	Version            *int    `json:"version,omitempty"`
+	UpdatedAt          *string `json:"updated_at,omitempty"`
+	UpdatedBy          *string `json:"updated_by,omitempty"`
+}
+
+// emailTemplateDetail is the single-key shape: the list row plus the
+// bodies and the declared variable schema.
+type emailTemplateDetail struct {
+	emailTemplateRow
+	HTMLBody  string                    `json:"html_body"`
+	TextBody  string                    `json:"text_body"`
+	Variables []emailtemplates.Variable `json:"variables"`
+}
+
+// List serves GET /admin/email-templates.
+//
+// No pagination envelope — matching marketplace-api's surface, for the
+// same reason: platform-api's key set is CLOSED at six entries, all owned
+// by internal/notification's embedded templates, and cannot grow at
+// runtime.
+func (h *EmailTemplatesHandler) List(c *gin.Context) {
+	stored, err := h.store.List(c.Request.Context())
+	if err != nil {
+		h.logError("platform email templates list failed", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "internal_error", "message": "could not read the template registry",
+		})
+		return
+	}
+
+	byKey := make(map[string]emailtemplates.Row, len(stored))
+	keys := make([]string, 0, len(stored))
+	for _, r := range stored {
+		byKey[r.Key] = r
+		keys = append(keys, r.Key)
+	}
+	for _, k := range h.registeredKeys() {
+		if _, ok := byKey[k]; !ok {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	rows := make([]emailTemplateRow, 0, len(keys))
+	for _, k := range keys {
+		row, ok := byKey[k]
+		if !ok {
+			rows = append(rows, h.unauthoredRow(k))
+			continue
+		}
+		rows = append(rows, h.storedRow(row))
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": rows})
+}
+
+// Get serves GET /admin/email-templates/:key.
+func (h *EmailTemplatesHandler) Get(c *gin.Context) {
+	key := strings.TrimSpace(c.Param("key"))
+	if key == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_key", "message": "key is required", "field": "key",
+		})
+		return
+	}
+
+	row, found, err := h.store.Get(c.Request.Context(), key)
+	if err != nil {
+		h.logError("platform email template read failed", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "internal_error", "message": "could not read the template",
+		})
+		return
+	}
+	if found {
+		c.JSON(http.StatusOK, gin.H{"data": emailTemplateDetail{
+			emailTemplateRow: h.storedRow(row),
+			HTMLBody:         row.HTMLBody,
+			TextBody:         row.TextBody,
+			Variables:        variablesOrEmpty(row.Variables),
+		}})
+		return
+	}
+
+	fb, registered := h.fallback(key)
+	if !registered {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error":   "unknown_key",
+			"message": "no template is stored or registered under this key",
+		})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": emailTemplateDetail{
+		emailTemplateRow: h.unauthoredRow(key),
+		HTMLBody:         fb.HTMLBody,
+		TextBody:         fb.TextBody,
+		Variables:        []emailtemplates.Variable{},
+	}})
+}
+
+// upsertRequest is the PUT wire shape — snake_case, matching
+// marketplace-api's surface.
+type upsertRequest struct {
+	Subject   string                    `json:"subject"`
+	HTMLBody  string                    `json:"html_body"`
+	TextBody  string                    `json:"text_body"`
+	Variables []emailtemplates.Variable `json:"variables"`
+	Status    string                    `json:"status"`
+}
+
+// Upsert serves PUT /admin/email-templates/:key.
+func (h *EmailTemplatesHandler) Upsert(c *gin.Context) {
+	// Checked FIRST, before the key or the body — matching
+	// marketplace-api's ordering (mark8ly#730): the console's
+	// federation.Client refuses to make a write without this header, so
+	// every real caller already sends one.
+	idemKey := strings.TrimSpace(c.GetHeader("Idempotency-Key"))
+	if idemKey == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "idempotency_key_required",
+			"message": "the Idempotency-Key header is required for this endpoint",
+		})
+		return
+	}
+
+	key := strings.TrimSpace(c.Param("key"))
+	if key == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_key", "message": "key is required", "field": "key",
+		})
+		return
+	}
+
+	var req upsertRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_request", "message": "request body could not be parsed",
+		})
+		return
+	}
+
+	status, ok := normaliseStatus(req.Status)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "invalid_status",
+			"message": "status must be draft or published",
+			"field":   "status",
+			"allowed": []string{emailtemplates.StatusDraft, emailtemplates.StatusPublished},
+		})
+		return
+	}
+
+	// The key must already be known: either a row exists, or it is one of
+	// the six embedded keys. Keys are owned by code (internal/notification's
+	// embedded templates), not by the console, so creating a new one out of
+	// thin air is out of scope — matching marketplace-api's rule.
+	_, exists, err := h.store.Get(c.Request.Context(), key)
+	if err != nil {
+		h.logError("platform email template read failed", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "internal_error", "message": "could not read the template",
+		})
+		return
+	}
+	if _, registered := h.fallback(key); !exists && !registered {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error":   "unknown_key",
+			"message": "no template is stored or registered under this key",
+		})
+		return
+	}
+
+	if problems := validateTemplateBody(req); len(problems) > 0 {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":    "invalid_template",
+			"message":  strings.Join(problems, "; "),
+			"problems": problems,
+		})
+		return
+	}
+
+	operator := strings.TrimSpace(c.GetString(platformauth.CtxOperatorID))
+	if operator == "" {
+		// RequirePlatformAuth requires a signed operator on every write, so
+		// this is unreachable through the mounted surface. Checked anyway
+		// because it is the field the whole attribution rests on.
+		h.logError("platform email template write without an operator id", errors.New("missing operator"))
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "internal_error", "message": "could not attribute the change",
+		})
+		return
+	}
+
+	// Namespaced so a key can never replay across template keys or across
+	// endpoints — idempotency_keys.key is a bare primary key shared by the
+	// whole service.
+	scopedKey := "email_template_upsert:" + key + ":" + idemKey
+
+	// Reserved AFTER every validation above and immediately before the
+	// write, matching marketplace-api's ordering: validation is
+	// deterministic, so two callers with the same key either both pass it
+	// or both fail it, and only then race.
+	if h.db != nil {
+		claimed, err := idempotency.Reserve(c.Request.Context(), h.db, scopedKey,
+			estateWideTenant, time.Now().UTC(), idempotency.DefaultTTL)
+		if err != nil {
+			// Fail CLOSED — a caller that cannot be told whether this key
+			// was already used must not be let through to a second UPSERT.
+			h.logError("platform email template idempotency reserve failed", err)
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"error": "unavailable", "message": "could not verify idempotency key",
+			})
+			return
+		}
+		if !claimed {
+			stored, ok, err := idempotency.Lookup(c.Request.Context(), h.db, scopedKey)
+			if err != nil {
+				h.logError("platform email template idempotency lookup failed", err)
+				c.JSON(http.StatusServiceUnavailable, gin.H{
+					"error": "unavailable", "message": "could not verify idempotency key",
+				})
+				return
+			}
+			if ok {
+				// A replay: the stored bytes verbatim, no second UPSERT, no
+				// version bump, no extra revision row.
+				c.Data(http.StatusOK, "application/json; charset=utf-8", stored)
+				return
+			}
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "in_progress", "message": "a request with this Idempotency-Key is already in flight",
+			})
+			return
+		}
+	}
+
+	saved, err := h.store.Upsert(c.Request.Context(), emailtemplates.UpsertInput{
+		Key:        key,
+		Subject:    req.Subject,
+		HTMLBody:   req.HTMLBody,
+		TextBody:   req.TextBody,
+		Variables:  variablesOrEmpty(req.Variables),
+		Status:     status,
+		UpdatedBy:  operator,
+		Capability: strings.TrimSpace(c.GetString(platformauth.CtxCapability)),
+	})
+	if err != nil {
+		h.releaseReservation(c, scopedKey)
+		h.logError("platform email template write failed", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "internal_error", "message": "could not save the template",
+		})
+		return
+	}
+
+	// Cache eviction, in-process, on the SAME *notification.Loader the
+	// send path reads — see emailtemplates.Registry's doc comment. No HTTP
+	// round trip to another process is needed; there never was one for
+	// platform-api's own templates the way tesserix-home's old cross-DB
+	// path needed for marketplace-api's.
+	if h.registry != nil {
+		h.registry.Invalidate(key)
+	}
+
+	body, err := json.Marshal(gin.H{"data": emailTemplateDetail{
+		emailTemplateRow: h.storedRow(saved),
+		HTMLBody:         saved.HTMLBody,
+		TextBody:         saved.TextBody,
+		Variables:        variablesOrEmpty(saved.Variables),
+	}})
+	if err != nil {
+		// The write SUCCEEDED — this is not a failed request, but the
+		// caller cannot be given a body and the key must not be left
+		// claimed with an empty response.
+		h.releaseReservation(c, scopedKey)
+		h.logError("platform email template response encode failed", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "internal_error", "message": "the template was saved but the response could not be encoded",
+		})
+		return
+	}
+
+	if h.db != nil {
+		if err := idempotency.Complete(c.Request.Context(), h.db, scopedKey, body); err != nil {
+			h.logError("platform email template idempotency complete failed", err)
+		}
+	}
+
+	c.Data(http.StatusOK, "application/json; charset=utf-8", body)
+}
+
+// estateWideTenant is the tenant_id recorded against an email-template
+// reservation. idempotency_keys.tenant_id is NOT NULL (migration 0017)
+// and this registry is estate-wide, so the nil uuid is the honest value —
+// matching marketplace-api's identical constant.
+var estateWideTenant = uuid.Nil.String()
+
+func (h *EmailTemplatesHandler) releaseReservation(c *gin.Context, scopedKey string) {
+	if h.db == nil {
+		return
+	}
+	if err := idempotency.Release(c.Request.Context(), h.db, scopedKey); err != nil {
+		h.logError("platform email template idempotency release failed", err)
+	}
+}
+
+// testSendRequest is the test-send wire shape.
+type testSendRequest struct {
+	To   string         `json:"to"`
+	Vars map[string]any `json:"vars"`
+}
+
+// TestSend serves POST /admin/email-templates/:key/test-send.
+//
+// It renders through registry.Render, which — via emailtemplates.Registry
+// — reaches into the SAME *notification.Loader the real send path uses,
+// so it exercises exactly what is live for the key.
+func (h *EmailTemplatesHandler) TestSend(c *gin.Context) {
+	key := strings.TrimSpace(c.Param("key"))
+	if key == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_key", "message": "key is required", "field": "key",
+		})
+		return
+	}
+
+	var req testSendRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_request", "message": "request body could not be parsed",
+		})
+		return
+	}
+	if strings.TrimSpace(req.To) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_recipient", "message": "to is required", "field": "to",
+		})
+		return
+	}
+
+	if h.registry == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "not_configured", "message": "the template registry is not wired",
+		})
+		return
+	}
+
+	vars := req.Vars
+	if vars == nil {
+		vars = map[string]any{}
+	}
+	rendered, err := h.registry.Render(c.Request.Context(), key, vars)
+	if err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{
+			"error": "render_failed", "message": err.Error(),
+		})
+		return
+	}
+
+	if h.sender == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error":   "not_configured",
+			"message": "no test sender is configured",
+		})
+		return
+	}
+	if err := h.sender.SendTest(c.Request.Context(), req.To, rendered); err != nil {
+		h.logError("platform email template test send failed", err)
+		c.JSON(http.StatusBadGateway, gin.H{
+			"error": "send_failed", "message": "the provider rejected the test send",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{
+		"key": key, "to": req.To, "sent": true,
+	}})
+}
+
+// storedRow projects a stored row FIELD BY FIELD, so a column added to
+// email_templates tomorrow cannot leak through this endpoint.
+func (h *EmailTemplatesHandler) storedRow(r emailtemplates.Row) emailTemplateRow {
+	_, registered := h.fallback(r.Key)
+
+	state := statePublished
+	sendsFrom := sendsFromRow
+	if r.Status != emailtemplates.StatusPublished {
+		state = stateDraft
+		sendsFrom = sendsFromEmbedded
+		if !registered {
+			sendsFrom = sendsFromNothing
+		}
+	}
+
+	version := r.Version
+	updatedAt := r.UpdatedAt.UTC().Format(time.RFC3339)
+	row := emailTemplateRow{
+		Key:                r.Key,
+		State:              state,
+		SendsFrom:          sendsFrom,
+		HasEmbeddedDefault: registered,
+		Subject:            r.Subject,
+		Version:            &version,
+		UpdatedAt:          &updatedAt,
+	}
+	if r.UpdatedBy != "" {
+		by := r.UpdatedBy
+		row.UpdatedBy = &by
+	}
+	return row
+}
+
+func (h *EmailTemplatesHandler) unauthoredRow(key string) emailTemplateRow {
+	fb, registered := h.fallback(key)
+	sendsFrom := sendsFromEmbedded
+	if !registered {
+		sendsFrom = sendsFromNothing
+	}
+	return emailTemplateRow{
+		Key:                key,
+		State:              stateUnauthored,
+		SendsFrom:          sendsFrom,
+		HasEmbeddedDefault: registered,
+		Subject:            fb.Subject,
+	}
+}
+
+func (h *EmailTemplatesHandler) registeredKeys() []string {
+	if h.registry == nil {
+		return nil
+	}
+	return h.registry.RegisteredKeys()
+}
+
+func (h *EmailTemplatesHandler) fallback(key string) (emailtemplates.EmbeddedFallback, bool) {
+	if h.registry == nil {
+		return emailtemplates.EmbeddedFallback{}, false
+	}
+	return h.registry.Fallback(key)
+}
+
+func (h *EmailTemplatesHandler) logError(msg string, err error) {
+	if h.logger != nil {
+		h.logger.Error(msg, "err", err)
+	}
+}
+
+// normaliseStatus accepts an absent status as `published`. An
+// unrecognised value is REJECTED rather than coerced.
+func normaliseStatus(raw string) (string, bool) {
+	switch strings.TrimSpace(raw) {
+	case "":
+		return emailtemplates.StatusPublished, true
+	case emailtemplates.StatusPublished:
+		return emailtemplates.StatusPublished, true
+	case emailtemplates.StatusDraft:
+		return emailtemplates.StatusDraft, true
+	default:
+		return "", false
+	}
+}
+
+// validateTemplateBody checks all three template fields SERVER-SIDE,
+// matching marketplace-api's rules exactly, including the brace-count
+// check kept alongside the parse for the same reason: it produces the
+// message an operator can act on.
+func validateTemplateBody(req upsertRequest) []string {
+	var problems []string
+
+	fields := []struct {
+		name  string
+		value string
+		html  bool
+	}{
+		{"subject", req.Subject, false},
+		{"html_body", req.HTMLBody, true},
+		{"text_body", req.TextBody, false},
+	}
+
+	for _, f := range fields {
+		if strings.TrimSpace(f.value) == "" {
+			problems = append(problems, f.name+": must not be empty")
+			continue
+		}
+		if opens, closes := strings.Count(f.value, "{{"), strings.Count(f.value, "}}"); opens != closes {
+			problems = append(problems,
+				f.name+": mismatched template braces ("+
+					strconv.Itoa(opens)+" {{, "+strconv.Itoa(closes)+" }})")
+			continue
+		}
+		if err := parseTemplate(f.name, f.value, f.html); err != nil {
+			problems = append(problems, f.name+": "+err.Error())
+		}
+	}
+
+	for i, v := range req.Variables {
+		if strings.TrimSpace(v.Name) == "" {
+			problems = append(problems, "variables["+strconv.Itoa(i)+"]: name must not be empty")
+		}
+	}
+
+	return problems
+}
+
+// parseTemplate compiles the field with the SAME engine the send path
+// uses for it — html/template for the HTML body, text/template for the
+// subject and the plain-text body.
+func parseTemplate(name, body string, html bool) error {
+	if html {
+		_, err := htmltpl.New(name).Parse(body)
+		return err
+	}
+	_, err := texttpl.New(name).Parse(body)
+	return err
+}
+
+// variablesOrEmpty never returns nil.
+func variablesOrEmpty(in []emailtemplates.Variable) []emailtemplates.Variable {
+	if in == nil {
+		return []emailtemplates.Variable{}
+	}
+	return in
+}

--- a/services/platform-api/internal/platformadmin/email_templates_integration_test.go
+++ b/services/platform-api/internal/platformadmin/email_templates_integration_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+package platformadmin_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/platform-api/internal/emailtemplates"
+	"github.com/mark8ly/platform-api/pkg/testdb"
+)
+
+// TestUpsertReplaysIdempotentRetryFromDB proves the PUT actually honours
+// its Idempotency-Key against a real database — the bug mark8ly#730 fixed
+// on marketplace-api's identical route was that this header was accepted
+// and then silently ignored, so a client retry re-ran the UPSERT and
+// bumped the version a second time. This is written directly against the
+// FIXED behaviour and exercises the real internal/idempotency package
+// through pkg/testdb, not a stub: a stub store's own Reserve/Lookup could
+// not have caught that class of bug in the first place, since the bug was
+// in whether the handler called the real reservation machinery at all.
+//
+// Build-tagged `integration` and excluded from the default `go test ./...`
+// run, matching every other DB-backed test in this service — the shared
+// test database is not safe for concurrent or ad-hoc runs.
+func TestUpsertReplaysIdempotentRetryFromDB(t *testing.T) {
+	db := testdb.NewTx(t)
+	store := newStubTemplateStore(fixtureRow("login_otp", emailtemplates.StatusPublished))
+	r := templateRouter(store, newStubRegistry(nil), nil, true, db)
+
+	first := do(t, r, http.MethodPut, "/admin/email-templates/login_otp", validBody)
+	require.Equal(t, http.StatusOK, first.Code, first.Body.String())
+	firstData := decodeData(t, first)
+	require.Equal(t, float64(4), firstData["version"])
+
+	// Same Idempotency-Key (do() derives it from method+path, which is
+	// identical on this retry) must replay the FIRST response verbatim —
+	// no second UPSERT, no second version bump.
+	second := do(t, r, http.MethodPut, "/admin/email-templates/login_otp", validBody)
+	require.Equal(t, http.StatusOK, second.Code, second.Body.String())
+	require.JSONEq(t, first.Body.String(), second.Body.String(),
+		"a retried PUT with the same Idempotency-Key must replay the stored response, not re-run the write")
+}

--- a/services/platform-api/internal/platformadmin/email_templates_test.go
+++ b/services/platform-api/internal/platformadmin/email_templates_test.go
@@ -1,0 +1,518 @@
+package platformadmin_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/platform-api/internal/emailtemplates"
+	"github.com/mark8ly/platform-api/internal/platformadmin"
+	"github.com/mark8ly/platformauth"
+)
+
+// ─── doubles ────────────────────────────────────────────────────────────
+
+type stubTemplateStore struct {
+	rows      map[string]emailtemplates.Row
+	listErr   error
+	getErr    error
+	upsertErr error
+	gotUpsert *emailtemplates.UpsertInput
+}
+
+func newStubTemplateStore(rows ...emailtemplates.Row) *stubTemplateStore {
+	s := &stubTemplateStore{rows: map[string]emailtemplates.Row{}}
+	for _, r := range rows {
+		s.rows[r.Key] = r
+	}
+	return s
+}
+
+func (s *stubTemplateStore) List(context.Context) ([]emailtemplates.Row, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	out := make([]emailtemplates.Row, 0, len(s.rows))
+	for _, r := range s.rows {
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+func (s *stubTemplateStore) Get(_ context.Context, key string) (emailtemplates.Row, bool, error) {
+	if s.getErr != nil {
+		return emailtemplates.Row{}, false, s.getErr
+	}
+	r, ok := s.rows[key]
+	return r, ok, nil
+}
+
+func (s *stubTemplateStore) Upsert(_ context.Context, in emailtemplates.UpsertInput) (emailtemplates.Row, error) {
+	s.gotUpsert = &in
+	if s.upsertErr != nil {
+		return emailtemplates.Row{}, s.upsertErr
+	}
+	prev := s.rows[in.Key]
+	saved := emailtemplates.Row{
+		Key:       in.Key,
+		Subject:   in.Subject,
+		HTMLBody:  in.HTMLBody,
+		TextBody:  in.TextBody,
+		Variables: in.Variables,
+		Status:    in.Status,
+		Version:   prev.Version + 1,
+		UpdatedAt: time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC),
+		UpdatedBy: in.UpdatedBy,
+	}
+	s.rows[in.Key] = saved
+	return saved, nil
+}
+
+// stubTemplateRegistry is a hand-rolled EmailTemplateRegistry double.
+//
+// marketplace-api's equivalent test double wraps a real
+// *emailtemplates.Loader, because that package's Loader supports
+// registering an arbitrary fallback key at test time (Loader.Register).
+// platform-api's emailtemplates.Registry instead wraps
+// *notification.Loader, whose embedded fallback set is the FIXED six
+// auth/onboarding keys compiled into the binary — there is no
+// Register(key, fallback) to inject a synthetic key into. So this double
+// implements platformadmin.EmailTemplateRegistry directly against a
+// caller-supplied map, the smallest thing that stands in for it.
+type stubTemplateRegistry struct {
+	fallbacks   map[string]emailtemplates.EmbeddedFallback
+	invalidated []string
+	renderErr   error
+	renderFn    func(ctx context.Context, key string, vars any) (emailtemplates.Rendered, error)
+}
+
+func newStubRegistry(fallbacks map[string]emailtemplates.EmbeddedFallback) *stubTemplateRegistry {
+	return &stubTemplateRegistry{fallbacks: fallbacks}
+}
+
+func (s *stubTemplateRegistry) RegisteredKeys() []string {
+	keys := make([]string, 0, len(s.fallbacks))
+	for k := range s.fallbacks {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (s *stubTemplateRegistry) Fallback(key string) (emailtemplates.EmbeddedFallback, bool) {
+	fb, ok := s.fallbacks[key]
+	return fb, ok
+}
+
+func (s *stubTemplateRegistry) Invalidate(key string) {
+	s.invalidated = append(s.invalidated, key)
+}
+
+func (s *stubTemplateRegistry) Render(ctx context.Context, key string, vars any) (emailtemplates.Rendered, error) {
+	if s.renderErr != nil {
+		return emailtemplates.Rendered{}, s.renderErr
+	}
+	if s.renderFn != nil {
+		return s.renderFn(ctx, key, vars)
+	}
+	fb, ok := s.fallbacks[key]
+	if !ok {
+		return emailtemplates.Rendered{}, errors.New("emailtemplates: unknown key")
+	}
+	return emailtemplates.Rendered{Subject: fb.Subject, HTMLBody: fb.HTMLBody, TextBody: fb.TextBody}, nil
+}
+
+type stubTestSender struct {
+	gotTo       string
+	gotRendered emailtemplates.Rendered
+	err         error
+}
+
+func (s *stubTestSender) SendTest(_ context.Context, to string, r emailtemplates.Rendered) error {
+	s.gotTo, s.gotRendered = to, r
+	return s.err
+}
+
+// ─── harness ────────────────────────────────────────────────────────────
+
+const testOperatorID = "op_11111111"
+
+// templateRouter mounts the handler behind a middleware that sets the same
+// context keys RequirePlatformAuth sets. The operator id is what
+// updated_by is stamped from, so a harness that omitted it would let a
+// bug that reads the body instead pass unnoticed.
+func templateRouter(
+	store platformadmin.EmailTemplateStore,
+	registry platformadmin.EmailTemplateRegistry,
+	sender emailtemplates.TestSender,
+	writable bool,
+	db *gorm.DB,
+) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	g := r.Group("", func(c *gin.Context) {
+		c.Set(platformauth.CtxOperatorID, testOperatorID)
+		c.Set(platformauth.CtxCapability, "platform.email_templates.write")
+	})
+	platformadmin.NewEmailTemplatesHandler(store, registry, sender, writable, db, nil).Register(g)
+	return r
+}
+
+// emailTemplatesTestRouter builds a full platformadmin.Register router —
+// signature-checked, like the rest of routes_test.go — with the
+// email-templates handler wired via a stub store/registry. Used by
+// TestNegativeControl's email-templates subtest, which needs the route
+// actually mounted so an unsigned 401 is distinguishable from an
+// unmounted 404.
+func emailTemplatesTestRouter(t *testing.T, secret string, nonces platformauth.NonceStore) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	platformadmin.Register(r.Group(platformadmin.MountPrefix), platformadmin.Deps{
+		Secret:                secret,
+		NonceStore:            nonces,
+		EmailTemplates:        newStubTemplateStore(),
+		EmailTemplateRegistry: newStubRegistry(nil),
+	})
+	return r
+}
+
+// do sends an Idempotency-Key by default, because the PUT requires one
+// (mirroring marketplace-api's mark8ly#730 fix) and every other assertion
+// in this file is about something else. Use doWithoutIdempotencyKey for
+// the case that tests the requirement.
+func do(t *testing.T, r *gin.Engine, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	return doHeaders(t, r, method, path, body, true)
+}
+
+func doWithoutIdempotencyKey(t *testing.T, r *gin.Engine, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	return doHeaders(t, r, method, path, body, false)
+}
+
+func doHeaders(t *testing.T, r *gin.Engine, method, path, body string, withIdempotencyKey bool) *httptest.ResponseRecorder {
+	t.Helper()
+	var req *http.Request
+	if body == "" {
+		req = httptest.NewRequest(method, path, nil)
+	} else {
+		req = httptest.NewRequest(method, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if withIdempotencyKey {
+		req.Header.Set("Idempotency-Key", "test-key-"+method+"-"+path)
+	}
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeData(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var body struct {
+		Data map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	return body.Data
+}
+
+func decodeRows(t *testing.T, rec *httptest.ResponseRecorder) []map[string]any {
+	t.Helper()
+	var body struct {
+		Data []map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	return body.Data
+}
+
+func fixtureRow(key, status string) emailtemplates.Row {
+	return emailtemplates.Row{
+		Key:       key,
+		Subject:   "{{.Code}} is your Mark8ly sign-in code",
+		HTMLBody:  "<p>{{.Code}}</p>",
+		TextBody:  "{{.Code}}",
+		Variables: []emailtemplates.Variable{{Name: "Code", Type: "string", Required: true}},
+		Status:    status,
+		Version:   3,
+		UpdatedAt: time.Date(2026, 8, 1, 9, 30, 0, 0, time.UTC),
+		UpdatedBy: "op_previous",
+	}
+}
+
+func welcomeFallback() map[string]emailtemplates.EmbeddedFallback {
+	return map[string]emailtemplates.EmbeddedFallback{
+		"welcome": {
+			Subject:  "Welcome to Mark8ly, {{.BusinessName}}",
+			HTMLBody: "<p>embedded html</p>",
+			TextBody: "embedded text",
+		},
+		"login_otp": {
+			Subject:  "{{.Code}} is your Mark8ly sign-in code",
+			HTMLBody: "<p>embedded html</p>",
+			TextBody: "embedded text",
+		},
+	}
+}
+
+// ─── list ───────────────────────────────────────────────────────────────
+
+// TestListMergesRegisteredButUnseededKeys mirrors marketplace-api's own
+// test of the same name (mark8ly#717's bug): a registered key with no
+// database row must still be listed as unauthored/sends-from-embedded,
+// not silently dropped.
+func TestListMergesRegisteredButUnseededKeys(t *testing.T) {
+	store := newStubTemplateStore(fixtureRow("login_otp", emailtemplates.StatusPublished))
+	reg := newStubRegistry(welcomeFallback())
+
+	rows := decodeRows(t, do(t, templateRouter(store, reg, nil, true, nil), http.MethodGet, "/admin/email-templates", ""))
+
+	byKey := map[string]map[string]any{}
+	for _, r := range rows {
+		byKey[r["key"].(string)] = r
+	}
+	require.Len(t, rows, 2)
+
+	unseeded := byKey["welcome"]
+	require.NotNil(t, unseeded, "a registered key with no row must still be listed")
+	require.Equal(t, "unauthored", unseeded["state"])
+	require.Equal(t, "embedded", unseeded["sends_from"])
+	require.Equal(t, true, unseeded["has_embedded_default"])
+	require.Equal(t, "Welcome to Mark8ly, {{.BusinessName}}", unseeded["subject"])
+	require.NotContains(t, unseeded, "version")
+	require.NotContains(t, unseeded, "updated_at")
+
+	published := byKey["login_otp"]
+	require.Equal(t, "published", published["state"])
+	require.Equal(t, "row", published["sends_from"])
+	require.Equal(t, float64(3), published["version"])
+	require.Equal(t, "2026-08-01T09:30:00Z", published["updated_at"])
+	require.Equal(t, "op_previous", published["updated_by"])
+}
+
+func TestListReturnsEmptyArrayNotNull(t *testing.T) {
+	rec := do(t, templateRouter(newStubTemplateStore(), newStubRegistry(nil), nil, true, nil),
+		http.MethodGet, "/admin/email-templates", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"data":[]}`, rec.Body.String())
+}
+
+func TestListReportsStoreFailure(t *testing.T) {
+	store := newStubTemplateStore()
+	store.listErr = errors.New("boom")
+	rec := do(t, templateRouter(store, newStubRegistry(nil), nil, true, nil),
+		http.MethodGet, "/admin/email-templates", "")
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// ─── get ────────────────────────────────────────────────────────────────
+
+func TestGetReturnsStoredBodies(t *testing.T) {
+	store := newStubTemplateStore(fixtureRow("login_otp", emailtemplates.StatusPublished))
+	data := decodeData(t, do(t, templateRouter(store, newStubRegistry(nil), nil, true, nil),
+		http.MethodGet, "/admin/email-templates/login_otp", ""))
+
+	require.Equal(t, "{{.Code}}", data["text_body"])
+	require.Equal(t, "<p>{{.Code}}</p>", data["html_body"])
+}
+
+func TestGetReturnsEmbeddedBodiesForUnauthoredKey(t *testing.T) {
+	reg := newStubRegistry(welcomeFallback())
+	data := decodeData(t, do(t, templateRouter(newStubTemplateStore(), reg, nil, true, nil),
+		http.MethodGet, "/admin/email-templates/welcome", ""))
+
+	require.Equal(t, "unauthored", data["state"])
+	require.Equal(t, "embedded text", data["text_body"])
+	require.Equal(t, []any{}, data["variables"],
+		"an embedded default declares no variable schema on this endpoint, matching marketplace-api")
+}
+
+func TestGetRejectsUnknownKey(t *testing.T) {
+	rec := do(t, templateRouter(newStubTemplateStore(), newStubRegistry(nil), nil, true, nil),
+		http.MethodGet, "/admin/email-templates/not_a_real_key", "")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// ─── upsert ─────────────────────────────────────────────────────────────
+
+const validBody = `{"subject":"Hi {{.Name}}","html_body":"<p>{{.Name}}</p>","text_body":"{{.Name}}","status":"published"}`
+
+func TestUpsertStampsSignedOperatorAndBumpsVersion(t *testing.T) {
+	store := newStubTemplateStore(fixtureRow("login_otp", emailtemplates.StatusPublished))
+	reg := newStubRegistry(welcomeFallback())
+	r := templateRouter(store, reg, nil, true, nil)
+
+	rec := do(t, r, http.MethodPut, "/admin/email-templates/login_otp", validBody)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	require.Equal(t, testOperatorID, store.gotUpsert.UpdatedBy)
+	data := decodeData(t, rec)
+	require.Equal(t, float64(4), data["version"])
+}
+
+func TestUpsertRequiresIdempotencyKey(t *testing.T) {
+	store := newStubTemplateStore(fixtureRow("login_otp", emailtemplates.StatusPublished))
+	r := templateRouter(store, newStubRegistry(nil), nil, true, nil)
+
+	rec := doWithoutIdempotencyKey(t, r, http.MethodPut, "/admin/email-templates/login_otp", validBody)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "idempotency_key_required")
+}
+
+func TestUpsertInvalidatesTheRegistry(t *testing.T) {
+	store := newStubTemplateStore(fixtureRow("login_otp", emailtemplates.StatusPublished))
+	reg := newStubRegistry(nil)
+	r := templateRouter(store, reg, nil, true, nil)
+
+	rec := do(t, r, http.MethodPut, "/admin/email-templates/login_otp", validBody)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.Equal(t, []string{"login_otp"}, reg.invalidated)
+}
+
+func TestUpsertRejectsUnbalancedBraces(t *testing.T) {
+	store := newStubTemplateStore(fixtureRow("login_otp", emailtemplates.StatusPublished))
+	r := templateRouter(store, newStubRegistry(nil), nil, true, nil)
+
+	body := `{"subject":"Hi {{.Name}","html_body":"<p>ok</p>","text_body":"ok","status":"published"}`
+	rec := do(t, r, http.MethodPut, "/admin/email-templates/login_otp", body)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "mismatched template braces")
+}
+
+func TestUpsertRejectsUnknownStatus(t *testing.T) {
+	store := newStubTemplateStore(fixtureRow("login_otp", emailtemplates.StatusPublished))
+	r := templateRouter(store, newStubRegistry(nil), nil, true, nil)
+
+	body := `{"subject":"ok","html_body":"ok","text_body":"ok","status":"live"}`
+	rec := do(t, r, http.MethodPut, "/admin/email-templates/login_otp", body)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "invalid_status")
+}
+
+func TestUpsertCreatesTheOverrideForAnUnseededKey(t *testing.T) {
+	store := newStubTemplateStore()
+	reg := newStubRegistry(welcomeFallback())
+	r := templateRouter(store, reg, nil, true, nil)
+
+	rec := do(t, r, http.MethodPut, "/admin/email-templates/welcome", validBody)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+}
+
+func TestUpsertRefusesAnUnknownKey(t *testing.T) {
+	store := newStubTemplateStore()
+	r := templateRouter(store, newStubRegistry(nil), nil, true, nil)
+
+	rec := do(t, r, http.MethodPut, "/admin/email-templates/not_a_real_key", validBody)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestWriteRouteRequiresDBThroughRegister proves the mount guard in
+// routes.go's Register — not just NewEmailTemplatesHandler's writable
+// flag directly, which TestPutIsUnmountedWhenNotWritable below covers.
+// EmailTemplates and EmailTemplateRegistry are both non-nil (a real
+// deployment would have them) but DB is nil, so the write route must not
+// exist: routes.go computes `writable` as `deps.DB != nil`, and this is
+// the test that would fail if that expression were ever weakened (e.g.
+// hardcoded to true) — see the mutation check recorded for this task.
+func TestWriteRouteRequiresDBThroughRegister(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	platformadmin.Register(r.Group(platformadmin.MountPrefix), platformadmin.Deps{
+		Secret:                testSecret,
+		NonceStore:            newMemNonces(),
+		EmailTemplates:        newStubTemplateStore(fixtureRow("login_otp", emailtemplates.StatusPublished)),
+		EmailTemplateRegistry: newStubRegistry(nil),
+		DB:                    nil,
+	})
+
+	req := signedRequest(t, testSecret, http.MethodPut, platformadmin.MountPrefix+"/admin/email-templates/login_otp")
+	req.Body = http.NoBody
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code,
+		"the write route must not mount without a database — it is what records the change against an operator")
+}
+
+func TestPutIsUnmountedWhenNotWritable(t *testing.T) {
+	store := newStubTemplateStore(fixtureRow("login_otp", emailtemplates.StatusPublished))
+	r := templateRouter(store, newStubRegistry(nil), nil, false, nil)
+
+	rec := do(t, r, http.MethodPut, "/admin/email-templates/login_otp", validBody)
+	require.Equal(t, http.StatusNotFound, rec.Code,
+		"the PUT route must not exist at all when the handler was built non-writable")
+}
+
+func TestReadsStayMountedWhenNotWritable(t *testing.T) {
+	store := newStubTemplateStore(fixtureRow("login_otp", emailtemplates.StatusPublished))
+	r := templateRouter(store, newStubRegistry(nil), nil, false, nil)
+
+	rec := do(t, r, http.MethodGet, "/admin/email-templates", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+// Idempotency replay against a real database (mirroring marketplace-api's
+// mark8ly#730 fix) is covered by TestUpsertReplaysIdempotentRetryFromDB in
+// email_templates_integration_test.go (//go:build integration) — it needs
+// pkg/testdb, and this file's unit tests must not touch a database at all
+// (the shared test DB is not safe for concurrent/ad-hoc runs). What THIS
+// file proves without a database is TestUpsertRequiresIdempotencyKey
+// above: the header is required before the handler ever reaches the
+// reservation machinery.
+
+// ─── test-send ──────────────────────────────────────────────────────────
+
+func TestTestSendRendersThroughTheRegistry(t *testing.T) {
+	reg := newStubRegistry(welcomeFallback())
+	sender := &stubTestSender{}
+	r := templateRouter(newStubTemplateStore(), reg, sender, true, nil)
+
+	body := `{"to":"operator@example.com","vars":{"BusinessName":"Acme"}}`
+	rec := do(t, r, http.MethodPost, "/admin/email-templates/welcome/test-send", body)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.Equal(t, "operator@example.com", sender.gotTo)
+	require.Equal(t, "Welcome to Mark8ly, {{.BusinessName}}", sender.gotRendered.Subject)
+}
+
+func TestTestSendRequiresARecipient(t *testing.T) {
+	r := templateRouter(newStubTemplateStore(), newStubRegistry(welcomeFallback()), &stubTestSender{}, true, nil)
+
+	rec := do(t, r, http.MethodPost, "/admin/email-templates/welcome/test-send", `{"vars":{}}`)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestTestSendMapsUpstreamFailures(t *testing.T) {
+	sender := &stubTestSender{err: errors.New("provider rejected")}
+	r := templateRouter(newStubTemplateStore(), newStubRegistry(welcomeFallback()), sender, true, nil)
+
+	rec := do(t, r, http.MethodPost, "/admin/email-templates/welcome/test-send", `{"to":"op@example.com"}`)
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Contains(t, rec.Body.String(), "send_failed")
+}
+
+func TestTestSendOnUnknownKeyReportsRenderFailure(t *testing.T) {
+	r := templateRouter(newStubTemplateStore(), newStubRegistry(nil), &stubTestSender{}, true, nil)
+
+	rec := do(t, r, http.MethodPost, "/admin/email-templates/not_a_real_key/test-send", `{"to":"op@example.com"}`)
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	require.Contains(t, rec.Body.String(), "render_failed")
+}
+
+func TestTestSendWithNoSenderAnswers503(t *testing.T) {
+	r := templateRouter(newStubTemplateStore(), newStubRegistry(welcomeFallback()), nil, true, nil)
+
+	rec := do(t, r, http.MethodPost, "/admin/email-templates/welcome/test-send", `{"to":"op@example.com"}`)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Contains(t, rec.Body.String(), "not_configured")
+}

--- a/services/platform-api/internal/platformadmin/routes.go
+++ b/services/platform-api/internal/platformadmin/routes.go
@@ -6,10 +6,12 @@
 // platformadmin) is built on — rather than reimplementing any of the
 // signing scheme here.
 //
-// This package intentionally starts small: a single conformance/health
-// read route proving the auth chain works end to end. Task 5 adds the
-// email-template routes; this file's Register and Deps are shaped so that
-// task only has to add fields and a mount guard, not restructure this one.
+// This package started small: a single conformance/health read route
+// proving the auth chain works end to end. Task 5 (mark8ly#720) adds the
+// email-template routes — welcome, email_verification, invitation,
+// password_reset, login_otp, new_device_login — mirroring the shape
+// marketplace-api's own platformadmin surface already serves for its half
+// of the same registry (orderdoc_*, giftcard_delivery, the billing keys).
 package platformadmin
 
 import (
@@ -19,6 +21,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/platform-api/internal/audit"
+	"github.com/mark8ly/platform-api/internal/emailtemplates"
 	"github.com/mark8ly/platformauth"
 )
 
@@ -46,15 +49,38 @@ type Deps struct {
 
 	// Emitter is platform-api's existing fire-and-forget audit client
 	// (internal/audit.Client), which posts events to marketplace-api's
-	// /internal/audit-events ingest. It is not read by Register today —
-	// no write route exists on this surface yet — but it is plumbed
-	// through here so a future write route (Task 5) has an audit path to
-	// gate on immediately, matching marketplace-api's discipline: a write
-	// endpoint that cannot be attributed to an operator must not mount
-	// (see Deps.Emitter's doc comment in marketplace-api's routes.go). A
-	// nil Emitter must gate any future write route's mounting the same
-	// way; it does not gate the read route this task adds.
+	// /internal/audit-events ingest. It does NOT gate the email-template
+	// write below, even though the surface's general rule is "a write
+	// that cannot be attributed to an operator must not mount" — see the
+	// EmailTemplates/EmailTemplateRegistry doc comment below for why
+	// Emitter specifically cannot carry that attribution for this route,
+	// which is the same reason marketplace-api's own routes.go declines
+	// to require an Emitter for its email-templates PUT. It remains
+	// plumbed through here for whatever future write route on this
+	// surface deals in tenant-scoped changes, where it DOES apply.
 	Emitter *audit.Client
+
+	// EmailTemplates, EmailTemplateRegistry and EmailTemplateTestSender
+	// together serve /admin/email-templates (mark8ly#720 Task 5) — the
+	// auth/onboarding half of the registry (welcome, email_verification,
+	// invitation, password_reset, login_otp, new_device_login).
+	//
+	// Both EmailTemplates and EmailTemplateRegistry must be non-nil for any
+	// route to mount, matching marketplace-api's pairing: the registry is
+	// the only source for the fixed six-key list this handler treats as
+	// "registered" (see emailtemplates.Registry.RegisteredKeys), so
+	// mounting the read without it would report an incomplete list without
+	// looking incomplete.
+	//
+	// EmailTemplateTestSender may be nil: the test-send route still mounts
+	// and answers 503 not_configured. In production it never actually is
+	// nil, because internal/notification.NewFromConfig never returns a nil
+	// Sender (it falls back to a LogSender in dev) — see
+	// emailtemplates.NewNotificationTestSender's doc comment for what that
+	// means for a test-send in an environment with no provider key.
+	EmailTemplates          EmailTemplateStore
+	EmailTemplateRegistry   EmailTemplateRegistry
+	EmailTemplateTestSender emailtemplates.TestSender
 }
 
 // Register mounts the platform console's surface behind
@@ -89,4 +115,32 @@ func Register(g *gin.RouterGroup, deps Deps) {
 	// and a nil DB degrades its answer rather than failing to mount — see
 	// health.go.
 	NewHealthHandler(deps.DB, deps.Logger).Register(group)
+
+	if deps.EmailTemplates != nil && deps.EmailTemplateRegistry != nil {
+		// The PUT mounts only with a DB, exactly matching
+		// marketplace-api's EmailTemplates gate (services/marketplace-api/
+		// internal/handlers/platformadmin/routes.go) and for the SAME
+		// reason, not the surface's general Emitter rule:
+		//
+		// audit.Client.Emit requires a non-empty TenantID and no-ops with a
+		// logged warning otherwise (internal/audit/client.go) — the same
+		// constraint marketplace-api's audit_logs table enforces with a
+		// NOT NULL column. An email template key is estate-wide, so there
+		// is no tenant to supply either way. Requiring Emitter here would
+		// gate this route on a dependency that, once past the gate, could
+		// never actually attribute the write — a guard that guards
+		// nothing, which is worse than an honest one.
+		//
+		// What actually attributes the write is the revision row
+		// emailtemplates.Store.Upsert inserts on the SAME transaction as
+		// the change (migration 0018): a failed insert rolls the change
+		// back. That needs a database, so the database is the gate.
+		NewEmailTemplatesHandler(
+			deps.EmailTemplates, deps.EmailTemplateRegistry,
+			deps.EmailTemplateTestSender, deps.DB != nil, deps.DB, deps.Logger,
+		).Register(group)
+		if deps.DB == nil && deps.Logger != nil {
+			deps.Logger.Warn("platformadmin: email template write route not mounted — DB is required to record the change against an operator")
+		}
+	}
 }

--- a/services/platform-api/internal/platformadmin/routes_test.go
+++ b/services/platform-api/internal/platformadmin/routes_test.go
@@ -93,6 +93,23 @@ func TestNegativeControl(t *testing.T) {
 			"the real, mounted route must reject an unsigned request with 401")
 	})
 
+	// mark8ly#720 Task 5: the same proof, extended to the email-template
+	// GET this task adds. This subtest uses its own router — built with
+	// EmailTemplates/EmailTemplateRegistry wired via
+	// emailTemplatesTestRouter (email_templates_test.go) — because plain
+	// r above has neither, so the route wouldn't mount at all and this
+	// would 404 for the wrong reason (unmounted, not unauthenticated),
+	// which is exactly the ambiguity this whole test exists to rule out.
+	t.Run("email templates route unsigned answers 401, not 404", func(t *testing.T) {
+		er := emailTemplatesTestRouter(t, testSecret, newMemNonces())
+		req := httptest.NewRequest(http.MethodGet, platformadmin.MountPrefix+"/admin/email-templates", nil)
+		w := httptest.NewRecorder()
+		er.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusUnauthorized, w.Code,
+			"the email-templates route must reject an unsigned request with 401")
+	})
+
 	t.Run("made-up path under the same prefix answers 404", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, platformadmin.MountPrefix+"/admin/this-route-does-not-exist", nil)
 		w := httptest.NewRecorder()

--- a/services/platform-api/migrations.go
+++ b/services/platform-api/migrations.go
@@ -11,4 +11,4 @@ var MigrationsFS embed.FS
 // ExpectedSchemaVersion is the version cmd/server requires on startup.
 // Bump this when you add a new migration. cmd/server refuses to start if the
 // DB is at any other version.
-const ExpectedSchemaVersion uint = 16
+const ExpectedSchemaVersion uint = 18

--- a/services/platform-api/migrations/0017_create_idempotency_keys.down.sql
+++ b/services/platform-api/migrations/0017_create_idempotency_keys.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS idempotency_keys;

--- a/services/platform-api/migrations/0017_create_idempotency_keys.up.sql
+++ b/services/platform-api/migrations/0017_create_idempotency_keys.up.sql
@@ -1,0 +1,27 @@
+-- idempotency_keys — replay protection for platform-api's HMAC-signed
+-- console writes (mark8ly#720 Task 5).
+--
+-- marketplace-api's platformadmin surface already has this table
+-- (its migration 000001) and internal/idempotency.Reserve/Lookup/Complete/
+-- Release built on it; platform-api never needed the pattern until now,
+-- because its first platformadmin write route is the email-template PUT
+-- this migration exists for. Schema and index are copied verbatim from
+-- marketplace-api's so internal/idempotency here (services/platform-api/
+-- internal/idempotency) is the same code against the same shape, not a
+-- reinterpretation.
+--
+-- tenant_id is NOT NULL for the same reason marketplace-api's copy is: it
+-- lets one table serve both tenant-scoped writes (a real tenant/store id)
+-- and estate-wide ones. The email-template PUT is estate-wide, so its
+-- reservations record uuid.Nil — see emailtemplates.Store's
+-- estateWideTenant for why that is the honest value rather than a
+-- borrowed one.
+CREATE TABLE idempotency_keys (
+    key        varchar(255) PRIMARY KEY,
+    tenant_id  uuid         NOT NULL,
+    response   jsonb,
+    created_at timestamptz  NOT NULL DEFAULT now(),
+    expires_at timestamptz  NOT NULL
+);
+
+CREATE INDEX idempotency_expires_idx ON idempotency_keys (expires_at);

--- a/services/platform-api/migrations/0018_email_template_revisions.down.sql
+++ b/services/platform-api/migrations/0018_email_template_revisions.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS email_template_revisions;

--- a/services/platform-api/migrations/0018_email_template_revisions.up.sql
+++ b/services/platform-api/migrations/0018_email_template_revisions.up.sql
@@ -1,0 +1,29 @@
+-- email_template_revisions — operator attribution for authored templates
+-- served on the platform admin contract surface (mark8ly#720 Task 5).
+--
+-- Mirrors marketplace-api's migration 000130 field for field, for the same
+-- reason: this service has no tenant-scoped audit table to record an
+-- email-template edit against. platform-api's audit trail is
+-- internal/audit.Client, which posts to marketplace-api's
+-- /internal/audit-events ingest and REQUIRES a non-empty tenant_id
+-- (Client.Emit no-ops with a warning otherwise) — and an email template
+-- key is estate-wide, so there is no tenant to supply. Inventing one would
+-- put a fiction in a governance table, so the record lives here instead,
+-- written on the SAME transaction as the change it accounts for
+-- (internal/emailtemplates.Store.Upsert): a failed insert here rolls the
+-- change back rather than leaving an edit unattributed.
+--
+-- Structural facts only, never the authored copy — see marketplace-api's
+-- 000130 for the fuller rationale, which applies unchanged here.
+CREATE TABLE IF NOT EXISTS email_template_revisions (
+    id         bigserial   PRIMARY KEY,
+    key        text        NOT NULL,
+    version    integer     NOT NULL,
+    status     text        NOT NULL CHECK (status IN ('draft','published')),
+    changed_by text        NOT NULL,
+    capability text,
+    changed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_template_revisions_key_changed_at
+    ON email_template_revisions (key, changed_at DESC);


### PR DESCRIPTION
Last code task of #720. mark8ly's platform-api now serves the **auth half** of the email-template registry on its console contract surface, so the console can reach both halves of a registry that is split across two services.

Until now the console could only reach marketplace-api's half (`orderdoc_*`, `giftcard_delivery`, 12 billing keys). platform-api owns `welcome`, `email_verification`, `invitation`, `password_reset`, `login_otp`, `new_device_login` — the mail an operator is most likely to need to correct — and they were editable only in the old admin.

## Routes

Mounted at `/api/v1/platform` (never `/api/v1/admin`, for the Istio reason recorded in the surface):

- `GET /admin/email-templates`
- `GET /admin/email-templates/:key`
- `POST /admin/email-templates/:key/test-send`
- `PUT /admin/email-templates/:key`

Paths, payloads, error envelope, list-merge of registered-but-unseeded keys, state vocabulary, brace validation and idempotent PUT are copied field-for-field from marketplace-api's surface, so the console can treat the two identically. It inherits #730's fixed `Idempotency-Key` handling rather than the bug.

`RequiredWriteCapabilities` in the shared `packages/platformauth` module already declared these exact route templates from marketplace-api's #588 work, so the console's capability declaration covers both services with no change.

## One deliberate divergence from the task brief

I asked for writes to refuse to mount without an audit **Emitter**, "matching marketplace-api's discipline". Reading marketplace-api rather than trusting my description, it does the opposite for this route, and says why:

> `audit_logs` is tenant partitioned (`tenant_id NOT NULL`) and an email template key is estate-wide. `EmitOperatorAction` rejects `uuid.Nil` for exactly this reason, so requiring an Emitter here would gate the route on a dependency that is then never called — a guard that guards nothing.

It gates on **DB** instead, because `Store.Upsert` writes the attribution row in the same transaction. This PR follows that actual discipline: the write route mounts only when `deps.DB != nil`, with migration `0018_email_template_revisions` mirroring marketplace-api's `000130`. `Deps.Emitter` stays plumbed but unused here.

## Supporting work platform-api did not have

- `internal/idempotency/` ported against a new `idempotency_keys` table (migration `0017`), using `json.RawMessage` rather than adding a `gorm.io/datatypes` dependency.
- `internal/emailtemplates/` — Store, Registry, TestSender. The Registry wraps the **same** `*notification.Loader` the real send path uses, so an admin edit's `Invalidate` affects live onboarding and auth mail immediately instead of a second, divergent cache.
- `internal/notification/admin_registry.go` — exported `RegisteredKeys` / `EmbeddedDefault` / `RenderPreview`, so previews render with generic map vars without disturbing the typed production `Render` path.

`ExpectedSchemaVersion` 16 → 18, caught by the existing guard test. Migrations apply via the `migrate` initContainer from the same image tag, so schema and binary move together.

## Verified

24 tests in `internal/platformadmin`. The negative control is extended rather than replaced — the real `/admin/email-templates` route unsigned answers **401** while a made-up path under the same prefix answers **404**, driven through `router.ServeHTTP`. No GET-on-POST 405 probe: `HandleMethodNotAllowed` is never set in any service here, so that probe returns 404 either way and distinguishes nothing.

Mutation-checked the DB gate: forcing it open made `TestWriteRouteRequiresDBThroughRegister` fail (404 expected, 401 got — the route mounted when it should not have). Restored, green.

`go build`, `go vet`, `go test ./...`, `gofmt -l` all clean. The one DB-backed idempotency-replay test is `//go:build integration` and was compile-checked only.

## Remaining to close #720

1. Add `email-templates` to platform-api's (deliberately empty) `endpoints` list in tesserix-k8s — an over-declared endpoint 404s and reads to an operator as "mark8ly could not be read".
2. Wire `FanOutServices` into the console's `emailtemplates` module so it queries both services and merges. Until then the shared endpoint fails closed rather than silently returning one owner's half.

## Deploy note

This deployment is `replicas=1` with `maxSurge=0`, so its rollout has a downtime gap like any other. tesserix-k8s#1043 removes the separate failure mode where a missing secret made that gap unbounded.
