### PR TITLE
refactor(auth-bff): read /auth/me/providers from Zitadel instead of GIP (#708)

### DIFF
--- a/services/auth-bff/cmd/server/main.go
+++ b/services/auth-bff/cmd/server/main.go
@@ -373,12 +373,35 @@ func main() {
 		}
 	}
 
+	// ─── Linked sign-in methods ────────────────────────────────────────
+	// One resolver, two surfaces: the merchant's own
+	// GET /auth/me/providers and marketplace-api's service-to-service
+	// GET /internal/users/:id/providers. The Google/Apple IDP ids are
+	// bound here because they are deployment config: they are what turns
+	// a Zitadel IDP link into the "google.com" name the panel keys on.
+	// Nil when no Zitadel client exists, which makes both endpoints
+	// answer 503 rather than an empty (and so actively wrong) list.
+	var linkedProviders session.LinkedProvidersResolver
+	if zitadelClient != nil {
+		linkedProviders = session.LinkedProvidersFunc(func(ctx context.Context, userID string) ([]session.LinkedProvider, error) {
+			found, err := zitadelClient.UserLinkedProviders(ctx, userID, cfg.ZitadelGoogleIDPID, cfg.ZitadelAppleIDPID)
+			if err != nil {
+				return nil, err
+			}
+			out := make([]session.LinkedProvider, 0, len(found))
+			for _, p := range found {
+				out = append(out, session.LinkedProvider{ProviderID: p.ProviderID, Email: p.Email})
+			}
+			return out, nil
+		})
+	}
+
 	// ─── Session introspection + logout ────────────────────────────────
 	sessionHandler := session.NewHandler(sessions, fgaClient).
 		WithRegistry(sessionRegistry, log).
 		WithMFA(mfaSvc).
 		WithAudit(auditClient).
-		WithGIPLookup(cfg.GIPWebAPIKey, cfg.GIPInternalTenantID)
+		WithLinkedProviders(linkedProviders)
 
 	// ─── Cross-TLD admin handoff ───────────────────────────────────────
 	// Mints a session cookie scoped to a custom admin domain
@@ -436,25 +459,13 @@ func main() {
 	// for that user should say.
 	if zitadelClient != nil {
 		internalUsers = internalUsers.WithDisplayNames(zitadelClient)
-		// GET /internal/users/:id/providers backs the storefront's
-		// "Linked sign-in methods" panel (#787), which previously read
-		// Identity Toolkit from the storefront pod. The Google/Apple IDP
-		// ids are bound here because they are deployment config: they
-		// are what turns a Zitadel IDP link into the "google.com" name
-		// the panel keys on.
-		internalUsers = internalUsers.WithLinkedProviders(
-			session.LinkedProvidersFunc(func(ctx context.Context, userID string) ([]session.LinkedProvider, error) {
-				found, err := zitadelClient.UserLinkedProviders(ctx, userID, cfg.ZitadelGoogleIDPID, cfg.ZitadelAppleIDPID)
-				if err != nil {
-					return nil, err
-				}
-				out := make([]session.LinkedProvider, 0, len(found))
-				for _, p := range found {
-					out = append(out, session.LinkedProvider{ProviderID: p.ProviderID, Email: p.Email})
-				}
-				return out, nil
-			}),
-		)
+	}
+	// GET /internal/users/:id/providers backs the storefront's "Linked
+	// sign-in methods" panel (#787), which previously read Identity
+	// Toolkit from the storefront pod. Shares the resolver built above
+	// with the merchant surface so both answer in one vocabulary.
+	if linkedProviders != nil {
+		internalUsers = internalUsers.WithLinkedProviders(linkedProviders)
 	}
 	internalUsers.Register(internalGroup)
 

--- a/services/auth-bff/internal/session/handler.go
+++ b/services/auth-bff/internal/session/handler.go
@@ -38,9 +38,9 @@ type Handler struct {
 	audit    *audit.Client // optional — emits user.signed_out / user.mfa_completed
 	logger   *slog.Logger
 
-	// GIP REST credentials for /auth/me/providers (Phase 3).
-	gipAPIKey           string
-	gipInternalTenantID string
+	// Sign-in-method lookup behind /auth/me/providers. Provider-agnostic
+	// by design: the handler never learns which identity provider answers.
+	providers LinkedProvidersResolver
 }
 
 // NewHandler constructs a Handler over the given Manager.
@@ -76,11 +76,16 @@ func (h *Handler) WithAudit(c *audit.Client) *Handler {
 	return h
 }
 
-// WithGIPLookup wires GIP REST credentials for the providers endpoint.
-// Optional — when unset, /auth/me/providers returns 503.
-func (h *Handler) WithGIPLookup(apiKey, internalTenantID string) *Handler {
-	h.gipAPIKey = apiKey
-	h.gipInternalTenantID = internalTenantID
+// WithLinkedProviders wires the sign-in-method lookup behind
+// GET /auth/me/providers, the merchant admin's security page.
+//
+// Optional, and unset means that endpoint answers 503 rather than an
+// empty list — for the reason InternalUsersHandler.WithLinkedProviders
+// spells out: an empty "Linked sign-in methods" list reads to the
+// merchant as "my Google link was removed", so a deployment that cannot
+// answer must say so instead of answering wrongly.
+func (h *Handler) WithLinkedProviders(r LinkedProvidersResolver) *Handler {
+	h.providers = r
 	return h
 }
 

--- a/services/auth-bff/internal/session/providers_handler.go
+++ b/services/auth-bff/internal/session/providers_handler.go
@@ -1,43 +1,38 @@
 package session
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
-	"net/url"
-	"time"
 
 	"github.com/gin-gonic/gin"
 )
 
-// LinkedProvider is a single auth method bound to a GIP user.
+// LinkedProvider is a single sign-in method bound to a user.
+//
+// ProviderID is the vocabulary the linked-providers panel keys on —
+// "password", "google.com", "apple.com" — not a Zitadel enum and not a
+// raw IDP id, except when the deployment has not named that IDP (see
+// zitadellogin.providerIDForIDP: an unrecognised provider still renders
+// under its raw id rather than vanishing from a list the merchant uses
+// to audit account access).
 type LinkedProvider struct {
-	ProviderID string `json:"provider_id"`     // "password" or "google.com" or "facebook.com" etc.
-	Email      string `json:"email,omitempty"` // empty for password (mirrored to top-level email anyway)
+	ProviderID string `json:"provider_id"`     // "password" or "google.com" or "apple.com"
+	Email      string `json:"email,omitempty"` // empty when the provider asserted none
 }
 
 type providersResponse struct {
 	Providers []LinkedProvider `json:"providers"`
 }
 
-// gipLookupResponse mirrors the Identity Toolkit accounts:lookup response.
-type gipLookupResponse struct {
-	Users []struct {
-		Email            string `json:"email"`
-		PasswordHash     string `json:"passwordHash"`
-		ProviderUserInfo []struct {
-			ProviderID string `json:"providerId"`
-			Email      string `json:"email"`
-		} `json:"providerUserInfo"`
-	} `json:"users"`
-}
-
-// getMyProviders returns the linked providers for the current admin user.
-// Reads the m8_session cookie, extracts the GIP UID, calls Identity
-// Toolkit accounts:lookup against MP-Internal pool. Used by the
-// /settings/security page in the admin app.
+// getMyProviders returns the linked sign-in methods for the current
+// admin user, for the /settings/security page in the admin app.
+//
+// Reads the m8_session cookie for the user id and asks the configured
+// resolver — zitadellogin.Client.UserLinkedProviders in every real
+// deployment, bound in cmd/server/main.go. This handler holds no
+// identity-provider knowledge of its own, which is what let the GIP
+// Identity Toolkit accounts:lookup it used to make be swapped out
+// without the admin app changing: the response shape
+// ({"data":{"providers":[{"provider_id","email"}]}}) is unchanged.
 func (h *Handler) getMyProviders(c *gin.Context) {
 	s, err := h.mgr.Read(c.Request)
 	if err != nil || s == nil {
@@ -47,98 +42,35 @@ func (h *Handler) getMyProviders(c *gin.Context) {
 		})
 		return
 	}
-	if h.gipAPIKey == "" || h.gipInternalTenantID == "" {
+
+	// 503, never an empty list: "we cannot answer" and "you have no
+	// sign-in methods" must not look the same to the security page.
+	if h.providers == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{
-			"error":   "gip_not_configured",
+			"error":   "not_configured",
 			"message": "providers lookup is not configured",
 		})
 		return
 	}
 
-	body := map[string]any{
-		"localId":  []string{s.UID},
-		"tenantId": h.gipInternalTenantID,
-	}
-	raw, err := json.Marshal(body)
+	found, err := h.providers.LinkedProviders(c.Request.Context(), s.UID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "internal_error",
-			"message": "failed to build lookup request",
-		})
-		return
-	}
-
-	apiURL := fmt.Sprintf(
-		"https://identitytoolkit.googleapis.com/v1/accounts:lookup?key=%s",
-		url.QueryEscape(h.gipAPIKey),
-	)
-	req, err := http.NewRequestWithContext(c.Request.Context(), "POST", apiURL, bytes.NewReader(raw))
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "internal_error",
-			"message": "failed to build lookup request",
-		})
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	client := &http.Client{Timeout: 5 * time.Second}
-	res, err := client.Do(req)
-	if err != nil {
+		// The uid and the error only — a provider list is personal data
+		// and must not reach the log stream.
 		if h.logger != nil {
-			h.logger.Warn("providers lookup: gip unreachable", "err", err)
-		}
-		c.JSON(http.StatusServiceUnavailable, gin.H{
-			"error":   "gip_unreachable",
-			"message": "could not reach identity provider",
-		})
-		return
-	}
-	defer res.Body.Close()
-	respBody, err := io.ReadAll(res.Body)
-	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{
-			"error":   "gip_read_failed",
-			"message": "could not read identity provider response",
-		})
-		return
-	}
-	if res.StatusCode != http.StatusOK {
-		if h.logger != nil {
-			h.logger.Warn("providers lookup: gip returned non-200",
-				"status", res.StatusCode, "body", string(respBody))
+			h.logger.Info("providers lookup unavailable", "err", err, "user_id", s.UID)
 		}
 		c.JSON(http.StatusBadGateway, gin.H{
-			"error":   "gip_error",
-			"message": "identity provider returned an error",
+			"error":   "upstream_unavailable",
+			"message": "could not resolve linked providers",
 		})
 		return
 	}
 
-	var lookup gipLookupResponse
-	if err := json.Unmarshal(respBody, &lookup); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "parse_failed",
-			"message": "could not parse identity provider response",
-		})
-		return
+	// Non-nil so an account with no methods marshals as [] and not null
+	// — the consumer maps over it unconditionally.
+	if found == nil {
+		found = []LinkedProvider{}
 	}
-	if len(lookup.Users) == 0 {
-		c.JSON(http.StatusNotFound, gin.H{
-			"error":   "user_not_found",
-			"message": "no provider records for the current user",
-		})
-		return
-	}
-
-	user := lookup.Users[0]
-	providers := []LinkedProvider{}
-	if user.PasswordHash != "" {
-		providers = append(providers, LinkedProvider{ProviderID: "password", Email: user.Email})
-	}
-	for _, p := range user.ProviderUserInfo {
-		providers = append(providers, LinkedProvider{ProviderID: p.ProviderID, Email: p.Email})
-	}
-
-	c.JSON(http.StatusOK, gin.H{"data": providersResponse{Providers: providers}})
+	c.JSON(http.StatusOK, gin.H{"data": providersResponse{Providers: found}})
 }

--- a/services/auth-bff/internal/session/providers_handler_test.go
+++ b/services/auth-bff/internal/session/providers_handler_test.go
@@ -1,0 +1,160 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// meProvidersRouter mounts a Handler with the given resolver (nil is a
+// deployment that cannot answer) and no FGA — /auth/me/providers reads
+// the cookie and nothing else.
+func meProvidersRouter(mgr *Manager, r LinkedProvidersResolver) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	h := NewHandler(mgr, nil).WithLinkedProviders(r)
+	e := gin.New()
+	h.Register(e.Group("/auth"))
+	return e
+}
+
+func getMyProvidersResp(t *testing.T, r LinkedProvidersResolver, withCookie bool) *httptest.ResponseRecorder {
+	t.Helper()
+	mgr := newTestManager(t)
+	router := meProvidersRouter(mgr, r)
+
+	var req *http.Request
+	if withCookie {
+		req = requestWithSession(t, mgr, http.MethodGet, "/auth/me/providers", "")
+	} else {
+		req = httptest.NewRequest(http.MethodGet, "/auth/me/providers", nil)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// decodeMyProviders asserts the wire shape the admin app's
+// getMyProviders() parses: {"data":{"providers":[{"provider_id",…}]}}.
+func decodeMyProviders(t *testing.T, w *httptest.ResponseRecorder) []LinkedProvider {
+	t.Helper()
+	var body struct {
+		Data providersResponse `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, w.Body.String())
+	}
+	return body.Data.Providers
+}
+
+func TestGetMyProviders_PasswordOnly(t *testing.T) {
+	f := &fakeProviders{out: []LinkedProvider{{ProviderID: "password", Email: "user@example.com"}}}
+	w := getMyProvidersResp(t, f, true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200, body=%s", w.Code, w.Body.String())
+	}
+	got := decodeMyProviders(t, w)
+	if len(got) != 1 || got[0].ProviderID != "password" || got[0].Email != "user@example.com" {
+		t.Fatalf("providers = %+v", got)
+	}
+	if f.calls != 1 {
+		t.Fatalf("resolver calls = %d, want 1", f.calls)
+	}
+}
+
+// The exact bytes apps/admin/lib/auth/auth-bff.ts reads: a "data"
+// envelope wrapping "providers", each entry keyed provider_id/email.
+// This is the contract the GIP port must not have moved.
+func TestGetMyProviders_WireShapeUnchanged(t *testing.T) {
+	f := &fakeProviders{out: []LinkedProvider{
+		{ProviderID: "password", Email: "user@example.com"},
+		{ProviderID: "google.com", Email: "user@gmail.com"},
+	}}
+	w := getMyProvidersResp(t, f, true)
+	want := `{"data":{"providers":[{"provider_id":"password","email":"user@example.com"},{"provider_id":"google.com","email":"user@gmail.com"}]}}`
+	if w.Body.String() != want {
+		t.Fatalf("body:\n got %s\nwant %s", w.Body.String(), want)
+	}
+}
+
+// email is omitempty, so a provider that asserted no address must not
+// emit a null the consumer would render as the string "null".
+func TestGetMyProviders_OmitsEmptyEmail(t *testing.T) {
+	f := &fakeProviders{out: []LinkedProvider{{ProviderID: "password"}}}
+	w := getMyProvidersResp(t, f, true)
+	if got, want := w.Body.String(), `{"data":{"providers":[{"provider_id":"password"}]}}`; got != want {
+		t.Fatalf("body: got %s want %s", got, want)
+	}
+}
+
+// An IDP the deployment has not named renders under its raw Zitadel id
+// rather than vanishing from a list the merchant uses to audit access.
+func TestGetMyProviders_UnrecognisedIDPKeepsRawID(t *testing.T) {
+	f := &fakeProviders{out: []LinkedProvider{
+		{ProviderID: "password", Email: "user@example.com"},
+		{ProviderID: "idp-338290", Email: "user@corp.example"},
+	}}
+	w := getMyProvidersResp(t, f, true)
+	got := decodeMyProviders(t, w)
+	if len(got) != 2 || got[1].ProviderID != "idp-338290" {
+		t.Fatalf("providers = %+v", got)
+	}
+}
+
+// No resolver must be 503, never 200 with an empty list: a merchant
+// reading an empty "Linked sign-in methods" panel would conclude their
+// Google link had been removed.
+func TestGetMyProviders_UnconfiguredIs503(t *testing.T) {
+	w := getMyProvidersResp(t, nil, true)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d want 503, body=%s", w.Code, w.Body.String())
+	}
+	if got := decodeMyProviders(t, w); len(got) != 0 {
+		t.Fatalf("503 must carry no providers, got %+v", got)
+	}
+}
+
+func TestGetMyProviders_UpstreamFailureIs502(t *testing.T) {
+	f := &fakeProviders{err: errors.New("zitadel unreachable")}
+	w := getMyProvidersResp(t, f, true)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status: got %d want 502, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetMyProviders_NoSessionIs401(t *testing.T) {
+	f := &fakeProviders{}
+	w := getMyProvidersResp(t, f, false)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status: got %d want 401, body=%s", w.Code, w.Body.String())
+	}
+	if f.calls != 0 {
+		t.Fatalf("resolver must not be called without a session, calls = %d", f.calls)
+	}
+}
+
+// The resolver is asked about the cookie's own uid — never an id the
+// caller supplied, which is what keeps this endpoint reading only the
+// current merchant's methods.
+func TestGetMyProviders_UsesSessionUID(t *testing.T) {
+	var seen string
+	r := LinkedProvidersFunc(func(_ context.Context, userID string) ([]LinkedProvider, error) {
+		seen = userID
+		return nil, nil
+	})
+	w := getMyProvidersResp(t, r, true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", w.Code)
+	}
+	if seen != "user-1" {
+		t.Fatalf("resolver got user id %q, want %q", seen, "user-1")
+	}
+	// A nil slice must marshal as [] — the consumer maps over it.
+	if got, want := w.Body.String(), `{"data":{"providers":[]}}`; got != want {
+		t.Fatalf("body: got %s want %s", got, want)
+	}
+}

--- a/services/auth-bff/pkg/config/config.go
+++ b/services/auth-bff/pkg/config/config.go
@@ -20,10 +20,13 @@ type Config struct {
 	HTTPPort    int    `envconfig:"HTTP_PORT" default:"8080"`
 	DatabaseURL string `envconfig:"DATABASE_URL" required:"true"`
 
-	// Google Identity Platform
-	GIPProjectID        string `envconfig:"GIP_PROJECT_ID" required:"true"`
-	GIPWebAPIKey        string `envconfig:"GIP_WEB_API_KEY" required:"true"`
-	GIPInternalTenantID string `envconfig:"GIP_INTERNAL_TENANT_ID" required:"true"` // staff/admin pool (e.g. MP-Internal-e986p)
+	// Google Identity Platform. Only the project id survives: it scopes
+	// the ID-token verifier the /auth/autologin path still uses. The web
+	// API key and internal tenant pool went with the Identity Toolkit
+	// accounts:lookup behind /auth/me/providers, which now reads Zitadel
+	// (#708). GIP_WEB_API_KEY / GIP_INTERNAL_TENANT_ID are droppable
+	// from the chart once this deploys.
+	GIPProjectID string `envconfig:"GIP_PROJECT_ID" required:"true"`
 
 	// Cookie session
 	SessionCookieName   string `envconfig:"SESSION_COOKIE_NAME" default:"m8_session"`

--- a/services/auth-bff/pkg/config/config_test.go
+++ b/services/auth-bff/pkg/config/config_test.go
@@ -12,8 +12,7 @@ func clearAll(t *testing.T) {
 	t.Helper()
 	for _, k := range []string{
 		"ENV", "HTTP_PORT", "DATABASE_URL",
-		"GIP_PROJECT_ID", "GIP_WEB_API_KEY",
-		"GIP_INTERNAL_TENANT_ID",
+		"GIP_PROJECT_ID",
 		"SESSION_COOKIE_NAME", "SESSION_COOKIE_DOMAIN", "SESSION_ENCRYPT_KEY",
 		"FGA_API_URL", "FGA_STORE_ID",
 		"ZITADEL_ENABLED", "ZITADEL_ISSUER", "ZITADEL_LOGIN_CLIENT_TOKEN",
@@ -29,8 +28,6 @@ func setRequiredEnv(t *testing.T) {
 	clearAll(t)
 	t.Setenv("DATABASE_URL", "postgres://test/test")
 	t.Setenv("GIP_PROJECT_ID", "test-project")
-	t.Setenv("GIP_WEB_API_KEY", "test-key")
-	t.Setenv("GIP_INTERNAL_TENANT_ID", "MP-Internal-test")
 	t.Setenv("SESSION_ENCRYPT_KEY", "thirtytwo-bytes-for-testing-only")
 }
 
@@ -91,8 +88,6 @@ func TestZitadelIsDisabledAndUnrequiredByDefault(t *testing.T) {
 	// Only the pre-existing required vars are set.
 	t.Setenv("DATABASE_URL", "postgres://x")
 	t.Setenv("GIP_PROJECT_ID", "p")
-	t.Setenv("GIP_WEB_API_KEY", "k")
-	t.Setenv("GIP_INTERNAL_TENANT_ID", "t")
 	t.Setenv("SESSION_ENCRYPT_KEY", "thirtytwo-bytes-for-testing-only")
 
 	cfg, err := Load()


### PR DESCRIPTION
Part of #708. Ports auth-bff's `/auth/me/providers` — which serves the **merchant admin** security page — off the GIP Identity Toolkit and onto Zitadel.

This is the same feature #807 just ported on the *customer* surface, so it **reuses `zitadellogin.Client.UserLinkedProviders` and that PR's mapping rather than writing a second lookup**. The resolver is now constructed once in `main.go` and shared by `/auth/me/providers` and `/internal/users/:id/providers`, so both surfaces answer in one vocabulary.

## The response shape is unchanged, and that is tested

`apps/admin` is **not** being changed, so the wire format had to stay exactly as it was. Confirmed by reading the only consumer — `apps/admin/lib/auth/auth-bff.ts:299-330`, which parses `wrapper.data.providers[].provider_id/email` — and pinning it with a byte-exact golden test (`TestGetMyProviders_WireShapeUnchanged`) plus an `omitempty`-email case.

Error *codes* were renamed (`gip_not_configured` → `not_configured`, `gip_unreachable`/`gip_error` → `upstream_unavailable`). That is safe here specifically because nothing in `apps/admin` branches on the code — it renders `body.message` only.

## I was wrong that this is the last GIP reader — it is the last GIP *REST* reader

I said in #807 that this endpoint was the final one. It is not, and the difference matters for when #708 can close.

`internal/gip/` **cannot** be deleted yet: `gip.New` is still constructed at `cmd/server/main.go:210`, and `gip.Verifier` / `gip.ErrTenantMismatch` are load-bearing in `internal/autologin/service.go` — the `/auth/auto-login` **ID-token** path is still wired.

Evidence that path is nonetheless dead in practice: no caller anywhere in the repo (`grep "auth/autologin"` across `*.go`, `*.ts`, `*.tsx`, `*.yaml` finds only a doc comment), and **zero** `autologin` log lines in 12h of production auth-bff logs. Its removal is a separate, well-bounded change — and it is a **split, not a deletion**: `autologinSvc.CompleteForProvider` is passed into `newZitadelHandlers` (`main.go:369`), so `completeLogin` is shared with the live Zitadel path. Only `AutoLogin` and the `gip` field go. That is the last item before #708 can close.

## Config

Droppable from `mark8ly-auth-bff` **after this deploys** (code-first): `GIP_WEB_API_KEY`, `GIP_INTERNAL_TENANT_ID`.

**`GIP_PROJECT_ID` must stay** — still `required:"true"` and read by the autologin verifier above. It goes with that change, not this one.

No Helm chart touched. No GCP tenant pool referenced.

## One behavioural change

Where GIP returned `404 user_not_found` for a uid with no Identity Toolkit record, the Zitadel path returns `502 upstream_unavailable`. That case is a session cookie whose uid no longer exists. Authentication is unchanged — still the `m8_session` cookie, read before anything else, and a missing session still 401s without the resolver ever being called.

## Verification

`gofmt -l` clean; `go build ./...` OK; `go vet ./...` OK; `go test ./...` → **16 packages ok, 0 FAIL**.

8 new handler tests, all passing: password-only, password+google (golden wire shape), unrecognised IDP keeps its raw id, resolver unconfigured → 503, upstream failure → 502, no session → 401 with the resolver never called, session-uid-only, and email omitted when empty. The IDP → `google.com`/`apple.com` mapping itself is already covered by #807's `user_linked_providers_test.go`.
