### PR TITLE
fix(ci): refresh the pinned base image digests pruned by the weekly rebuild

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -8,7 +8,7 @@
 # differ.
 
 # ─── deps ──────────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-24@sha256:c5b173e90d748e60496f7b7be877e767226867c974cf322bec634f04beb45819 AS deps
+FROM ghcr.io/tesserix/base-node-builder-24@sha256:dc8e8205eab94ba9fbc4bea454f3998f0440135ed7e0f7300d0fef51d6e8b3a6 AS deps
 USER 0:0
 WORKDIR /src
 
@@ -29,7 +29,7 @@ COPY packages/ui/package.json ./packages/ui/
 RUN npm ci --no-audit --no-fund --legacy-peer-deps
 
 # ─── builder ───────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-24@sha256:c5b173e90d748e60496f7b7be877e767226867c974cf322bec634f04beb45819 AS builder
+FROM ghcr.io/tesserix/base-node-builder-24@sha256:dc8e8205eab94ba9fbc4bea454f3998f0440135ed7e0f7300d0fef51d6e8b3a6 AS builder
 USER 0:0
 WORKDIR /src
 COPY --from=deps /src/node_modules ./node_modules
@@ -114,7 +114,7 @@ RUN --mount=type=secret,id=APPLICATION_BUILD_SECRET \
 
 # ─── runtime ───────────────────────────────────────────────────────────
 # base-node-runtime-24: libc6-compat, tini PID 1, USER 10001 (nextjs).
-FROM ghcr.io/tesserix/base-node-runtime-24@sha256:6e503bc4b951eeb065b9ff8c4a0d53bfd240b9e974709c79b56f163b9d70b683 AS runtime
+FROM ghcr.io/tesserix/base-node-runtime-24@sha256:a76c207828d824d59e1c80957fe11d3ab5b561bbbe581962f23027d15e4eff7a AS runtime
 WORKDIR /app
 
 ENV PORT=4202

--- a/apps/onboarding/Dockerfile
+++ b/apps/onboarding/Dockerfile
@@ -11,7 +11,7 @@
 # the repo root.
 
 # ─── deps ──────────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-24@sha256:c5b173e90d748e60496f7b7be877e767226867c974cf322bec634f04beb45819 AS deps
+FROM ghcr.io/tesserix/base-node-builder-24@sha256:dc8e8205eab94ba9fbc4bea454f3998f0440135ed7e0f7300d0fef51d6e8b3a6 AS deps
 USER 0:0
 WORKDIR /src
 
@@ -32,7 +32,7 @@ COPY packages/ui/package.json ./packages/ui/
 RUN npm ci --no-audit --no-fund --legacy-peer-deps
 
 # ─── builder ───────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-24@sha256:c5b173e90d748e60496f7b7be877e767226867c974cf322bec634f04beb45819 AS builder
+FROM ghcr.io/tesserix/base-node-builder-24@sha256:dc8e8205eab94ba9fbc4bea454f3998f0440135ed7e0f7300d0fef51d6e8b3a6 AS builder
 USER 0:0
 WORKDIR /src
 COPY --from=deps /src/node_modules ./node_modules
@@ -102,7 +102,7 @@ RUN --mount=type=secret,id=APPLICATION_BUILD_SECRET \
 # Next.js standalone output for a workspace ends up at
 # apps/onboarding/.next/standalone/ with the monorepo directory layout
 # preserved, so the entrypoint is apps/onboarding/server.js.
-FROM ghcr.io/tesserix/base-node-runtime-24@sha256:6e503bc4b951eeb065b9ff8c4a0d53bfd240b9e974709c79b56f163b9d70b683 AS runtime
+FROM ghcr.io/tesserix/base-node-runtime-24@sha256:a76c207828d824d59e1c80957fe11d3ab5b561bbbe581962f23027d15e4eff7a AS runtime
 WORKDIR /app
 
 ENV PORT=4201

--- a/apps/storefront/Dockerfile
+++ b/apps/storefront/Dockerfile
@@ -7,7 +7,7 @@
 # apps/admin and apps/onboarding — only workspace name + port differ.
 
 # ─── deps ──────────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-24@sha256:c5b173e90d748e60496f7b7be877e767226867c974cf322bec634f04beb45819 AS deps
+FROM ghcr.io/tesserix/base-node-builder-24@sha256:dc8e8205eab94ba9fbc4bea454f3998f0440135ed7e0f7300d0fef51d6e8b3a6 AS deps
 USER 0:0
 WORKDIR /src
 
@@ -28,7 +28,7 @@ COPY packages/ui/package.json ./packages/ui/
 RUN npm ci --no-audit --no-fund --legacy-peer-deps
 
 # ─── builder ───────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-node-builder-24@sha256:c5b173e90d748e60496f7b7be877e767226867c974cf322bec634f04beb45819 AS builder
+FROM ghcr.io/tesserix/base-node-builder-24@sha256:dc8e8205eab94ba9fbc4bea454f3998f0440135ed7e0f7300d0fef51d6e8b3a6 AS builder
 USER 0:0
 WORKDIR /src
 COPY --from=deps /src/node_modules ./node_modules
@@ -84,7 +84,7 @@ RUN --mount=type=secret,id=APPLICATION_BUILD_SECRET \
 
 # ─── runtime ───────────────────────────────────────────────────────────
 # base-node-runtime-24: libc6-compat, tini PID 1, USER 10001 (nextjs).
-FROM ghcr.io/tesserix/base-node-runtime-24@sha256:6e503bc4b951eeb065b9ff8c4a0d53bfd240b9e974709c79b56f163b9d70b683 AS runtime
+FROM ghcr.io/tesserix/base-node-runtime-24@sha256:a76c207828d824d59e1c80957fe11d3ab5b561bbbe581962f23027d15e4eff7a AS runtime
 WORKDIR /app
 
 ENV PORT=4203

--- a/services/auth-bff/Dockerfile
+++ b/services/auth-bff/Dockerfile
@@ -10,7 +10,7 @@
 # unnecessary. K8s securityContext overrides the image's USER, so the
 # binaries are world-executable (mode 0755 from `go build`).
 
-FROM ghcr.io/tesserix/base-go-builder@sha256:1d52f1321953c29971c261ccc7cd212f2ab84008321b88113ccff88330dd7d1f AS build
+FROM ghcr.io/tesserix/base-go-builder@sha256:196c74ed0c05329dbe72c4277b7c983ab32c31279769e09bee9c9539e89e2b4a AS build
 USER 0:0
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -21,7 +21,7 @@ RUN go build -trimpath -ldflags="-s -w" -o /out/server ./cmd/server \
 
 # Single runtime stage carries both binaries so the K8s init pattern
 # can override ENTRYPOINT to /migrate without pulling a second image.
-FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS server
+FROM ghcr.io/tesserix/base-distroless-static@sha256:2fea7cf18950a0c9e6a08d0260643003d05eb43e66e09ec4d06562e3b71024e8 AS server
 COPY --from=build --chown=10001:10001 /out/server /server
 COPY --from=build --chown=10001:10001 /out/migrate /migrate
 EXPOSE 8080
@@ -29,6 +29,6 @@ CMD ["/server"]
 
 # Legacy single-purpose stage retained for local docker-compose flows
 # that build with --target migrate.
-FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS migrate
+FROM ghcr.io/tesserix/base-distroless-static@sha256:2fea7cf18950a0c9e6a08d0260643003d05eb43e66e09ec4d06562e3b71024e8 AS migrate
 COPY --from=build --chown=10001:10001 /out/migrate /migrate
 CMD ["/migrate"]

--- a/services/marketplace-api/Dockerfile
+++ b/services/marketplace-api/Dockerfile
@@ -15,7 +15,7 @@
 # the same pattern for the same reason.
 
 # ─── builder ────────────────────────────────────────────────────────────
-FROM ghcr.io/tesserix/base-go-builder@sha256:1d52f1321953c29971c261ccc7cd212f2ab84008321b88113ccff88330dd7d1f AS builder
+FROM ghcr.io/tesserix/base-go-builder@sha256:196c74ed0c05329dbe72c4277b7c983ab32c31279769e09bee9c9539e89e2b4a AS builder
 USER 0:0
 WORKDIR /src
 
@@ -47,7 +47,7 @@ RUN go build -trimpath -ldflags="-s -w" \
 
 # ─── migrate ────────────────────────────────────────────────────────────
 # Standalone image used by the K8s Job pattern.
-FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS migrate
+FROM ghcr.io/tesserix/base-distroless-static@sha256:2fea7cf18950a0c9e6a08d0260643003d05eb43e66e09ec4d06562e3b71024e8 AS migrate
 COPY --from=builder --chown=10001:10001 /out/migrate /usr/local/bin/migrate
 CMD ["/usr/local/bin/migrate"]
 
@@ -62,7 +62,7 @@ CMD ["/usr/local/bin/migrate"]
 # webhook-delivery-prune-cron prunes webhook_deliveries (OUTBOUND merchant
 # webhooks). It is NOT internal/webhookprune, which prunes webhook_events
 # (the inbound provider log) in-process inside marketplace-api.
-FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS runtime
+FROM ghcr.io/tesserix/base-distroless-static@sha256:2fea7cf18950a0c9e6a08d0260643003d05eb43e66e09ec4d06562e3b71024e8 AS runtime
 COPY --from=builder --chown=10001:10001 /out/marketplace-api /usr/local/bin/marketplace-api
 COPY --from=builder --chown=10001:10001 /out/migrate /usr/local/bin/migrate
 COPY --from=builder --chown=10001:10001 /out/refund-sweep-cron /usr/local/bin/refund-sweep-cron

--- a/services/otto/Dockerfile
+++ b/services/otto/Dockerfile
@@ -6,7 +6,7 @@
 # Go's runtime handles SIGTERM directly so tini is unnecessary; K8s
 # securityContext overrides USER, mode 0755 lets any uid execute.
 
-FROM ghcr.io/tesserix/base-go-builder@sha256:1d52f1321953c29971c261ccc7cd212f2ab84008321b88113ccff88330dd7d1f AS build
+FROM ghcr.io/tesserix/base-go-builder@sha256:196c74ed0c05329dbe72c4277b7c983ab32c31279769e09bee9c9539e89e2b4a AS build
 USER 0:0
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -14,7 +14,7 @@ RUN go mod download
 COPY . .
 RUN go build -trimpath -ldflags="-s -w" -o /out/server ./cmd/server
 
-FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS server
+FROM ghcr.io/tesserix/base-distroless-static@sha256:2fea7cf18950a0c9e6a08d0260643003d05eb43e66e09ec4d06562e3b71024e8 AS server
 COPY --from=build --chown=10001:10001 /out/server /server
 EXPOSE 8089
 CMD ["/server"]

--- a/services/platform-api/Dockerfile
+++ b/services/platform-api/Dockerfile
@@ -13,7 +13,7 @@
 # `replace github.com/mark8ly/platformauth => ../../packages/platformauth`,
 # a sibling module a services/platform-api-scoped context can't reach.
 
-FROM ghcr.io/tesserix/base-go-builder@sha256:1d52f1321953c29971c261ccc7cd212f2ab84008321b88113ccff88330dd7d1f AS build
+FROM ghcr.io/tesserix/base-go-builder@sha256:196c74ed0c05329dbe72c4277b7c983ab32c31279769e09bee9c9539e89e2b4a AS build
 USER 0:0
 WORKDIR /src
 
@@ -39,7 +39,7 @@ RUN go build -trimpath -ldflags="-s -w" -o /out/server           ./cmd/server \
 # overrides can pick the right entrypoint without pulling a second image.
 # /backfill-vendors is the CLI surfaced by the marketplace-api error
 # "tenant has no self-vendor; run platform-api's backfill-vendors CLI".
-FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS server
+FROM ghcr.io/tesserix/base-distroless-static@sha256:2fea7cf18950a0c9e6a08d0260643003d05eb43e66e09ec4d06562e3b71024e8 AS server
 COPY --from=build --chown=10001:10001 /out/server           /server
 COPY --from=build --chown=10001:10001 /out/migrate          /migrate
 COPY --from=build --chown=10001:10001 /out/seed             /seed
@@ -48,10 +48,10 @@ EXPOSE 8086
 CMD ["/server"]
 
 # Legacy single-purpose stages retained for local docker-compose flows.
-FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS migrate
+FROM ghcr.io/tesserix/base-distroless-static@sha256:2fea7cf18950a0c9e6a08d0260643003d05eb43e66e09ec4d06562e3b71024e8 AS migrate
 COPY --from=build --chown=10001:10001 /out/migrate /migrate
 CMD ["/migrate"]
 
-FROM ghcr.io/tesserix/base-distroless-static@sha256:db09c7f5c9fde6eb1217a323d6e0158ba6339123859cb8ffc113320352a99598 AS seed
+FROM ghcr.io/tesserix/base-distroless-static@sha256:2fea7cf18950a0c9e6a08d0260643003d05eb43e66e09ec4d06562e3b71024e8 AS seed
 COPY --from=build --chown=10001:10001 /out/seed /seed
 CMD ["/seed"]


### PR DESCRIPTION
**Every container build in this repo is currently failing.** This unpins nothing and changes no behaviour — it just refreshes four base-image digests that GHCR has pruned.

## Symptom

Every `Containers / Container — *` job fails in **14–21 seconds**, including services untouched by whatever PR is running:

```
#4 [internal] load metadata for ghcr.io/tesserix/base-go-builder@sha256:1d52f13…
#4 ERROR: ghcr.io/tesserix/base-go-builder@sha256:1d52f13…: not found
ERROR: failed to build: failed to solve: … failed to resolve source metadata
```

It never reaches the diff. A fast, uniform failure across *all* container jobs is the signature — if only your own service failed, it would be your change.

## Cause and timing

The weekly base rebuild publishes new images and prunes the old digests. The Dockerfiles pin by digest, so once a pin is pruned the build cannot resolve it.

This one landed today between **06:47** (last green `main` CI) and **09:39** (first failure). It is not branch-specific; `main` will fail on its next run too.

## The refresh

Resolved from GHCR via the packages API, taking the version currently tagged `latest` for each image:

| image | new digest | published |
|---|---|---|
| `base-go-builder` | `sha256:196c74ed…` | 2026-09-05 |
| `base-distroless-static` | `sha256:2fea7cf1…` | 2026-09-05 |
| `base-node-builder-24` | `sha256:dc8e8205…` | 2026-09-05 |
| `base-node-runtime-24` | `sha256:a76c2078…` | 2026-09-05 |

Applied across all **7** Dockerfiles that pin a company base image: `apps/{admin,storefront,onboarding}` and `services/{auth-bff,platform-api,marketplace-api,otto}`. Verified afterwards that no stale digest remains.

Digest pinning itself is kept — that is the point of the contract test (`test_base_image_pins_are_tracked_by_a_dependency_updater`), which still passes, along with the other five.

## Worth noting

This recurs by design: pinning is deliberate, and the weekly rebuild prunes what it replaces, so pins go stale on a schedule. Whatever is supposed to refresh them has not, and the failure mode is maximally confusing — it blocks every PR simultaneously with an error that points at infrastructure, not at the change under test.
