### PR TITLE
fix(sso): drop the GIP provider id column from tenant_sso_configs (#793)

### DIFF
--- a/services/marketplace-api/internal/sso/models.go
+++ b/services/marketplace-api/internal/sso/models.go
@@ -35,14 +35,13 @@ func (p Provider) Valid() bool { return p == ProviderSAML || p == ProviderOIDC }
 // Plaintext secrets NEVER live in metadata — client_secret_ref points
 // at a Secret Manager path.
 type Config struct {
-	TenantID      uuid.UUID         `gorm:"column:tenant_id;type:uuid;primaryKey"`
-	Provider      Provider          `gorm:"column:provider;type:sso_provider_kind;not null"`
-	Metadata      datatypes.JSONMap `gorm:"column:metadata;type:jsonb;not null"`
-	AttrMapping   datatypes.JSONMap `gorm:"column:attr_mapping;type:jsonb;not null;default:'{}'::jsonb"`
-	GIPProviderID *string           `gorm:"column:gip_provider_id"`
-	Enabled       bool              `gorm:"column:enabled;not null;default:false"`
-	CreatedAt     time.Time         `gorm:"column:created_at;not null;autoCreateTime"`
-	UpdatedAt     time.Time         `gorm:"column:updated_at;not null;autoUpdateTime"`
+	TenantID    uuid.UUID         `gorm:"column:tenant_id;type:uuid;primaryKey"`
+	Provider    Provider          `gorm:"column:provider;type:sso_provider_kind;not null"`
+	Metadata    datatypes.JSONMap `gorm:"column:metadata;type:jsonb;not null"`
+	AttrMapping datatypes.JSONMap `gorm:"column:attr_mapping;type:jsonb;not null;default:'{}'::jsonb"`
+	Enabled     bool              `gorm:"column:enabled;not null;default:false"`
+	CreatedAt   time.Time         `gorm:"column:created_at;not null;autoCreateTime"`
+	UpdatedAt   time.Time         `gorm:"column:updated_at;not null;autoUpdateTime"`
 }
 
 // TableName pins the Postgres table name.

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 132
+const ExpectedSchemaVersion uint = 133

--- a/services/marketplace-api/migrations/000133_drop_sso_gip_provider_id.down.sql
+++ b/services/marketplace-api/migrations/000133_drop_sso_gip_provider_id.down.sql
@@ -1,0 +1,3 @@
+-- Restores the column. Values are NOT recoverable — the table was empty when
+-- 000133 ran, and the GIP provisioning client that populated it is gone.
+ALTER TABLE tenant_sso_configs ADD COLUMN IF NOT EXISTS gip_provider_id TEXT;

--- a/services/marketplace-api/migrations/000133_drop_sso_gip_provider_id.up.sql
+++ b/services/marketplace-api/migrations/000133_drop_sso_gip_provider_id.up.sql
@@ -1,0 +1,16 @@
+-- Drops tenant_sso_configs.gip_provider_id (#793).
+--
+-- The column recorded the GIP-side SAML/OIDC provider id, used as an
+-- idempotency key when the GIP provisioning client uploaded a tenant's SSO
+-- config. That client was deleted in #789 after it was shown to be
+-- unreachable: nothing constructed it, and both the admin and public SSO
+-- route groups were gated on handlers main.go never populated.
+--
+-- Safe to drop rather than migrate: tenant_sso_configs held ZERO rows in
+-- production when this was written, so no identifier is being discarded.
+--
+-- The TABLE deliberately stays. internal/sso's provider-agnostic half
+-- (SAML/OIDC parsing, attribute mapping, JIT provisioning) was kept in #789
+-- precisely so tenant SSO can be rebuilt on Zitadel without starting over,
+-- and internal/tenantpurge still covers the table for tenant deletion.
+ALTER TABLE tenant_sso_configs DROP COLUMN IF EXISTS gip_provider_id;


### PR DESCRIPTION
Part of #793 — the **reversible** half. The GCP tenant pools are deliberately not touched; they need explicit approval and are the one irreversible step in this milestone.

## What this drops

`tenant_sso_configs.gip_provider_id`, plus its single reader — a GORM field in `internal/sso/models.go`.

The column recorded the GIP-side SAML/OIDC provider id, used as an idempotency key when the GIP provisioning client uploaded a tenant's SSO config. That client was deleted in #789 once it was shown to be unreachable: nothing constructed it, and both the admin and public SSO route groups were gated on handlers `main.go` never populated.

**No data is discarded** — `tenant_sso_configs` holds **zero rows** in production, confirmed by direct query before writing the migration. The column is confirmed present in the live schema, so the migration has something to drop.

## The table deliberately STAYS

Only the GIP-specific column goes. `internal/sso`'s provider-agnostic half — SAML/OIDC parsing, attribute mapping, JIT provisioning — was kept in #789 precisely so tenant SSO can be rebuilt on Zitadel without starting from scratch, and `internal/tenantpurge` still covers the table for tenant deletion. Dropping the table would discard that work to save an empty table.

## Correction: I called the rest of #793 "trivial". It is not.

I described the schema half as trivial in an earlier update. That was wrong, and checking before acting is what caught it.

**`customer_profiles.gip_uid` is NOT a simple drop.** It still has live readers woven through the storefront session claims:

- `CustomerGipUIDKey` set in `mobile_auth.go` (×2) and read in `support.go`
- the `GipUID` field on the session claims struct (`middleware.go:132`)
- `UIDOrGipUID()` (`middleware.go:215`), which prefers the Zitadel uid and **falls back** to `gip_uid`
- writers in `customer_join.go` and `mobile_stubs.go`

Removing the column means changing the session-claim shape, which touches customers holding existing cookies. Production has 5 customer profiles and exactly **1** with a `gip_uid`, so the data at stake is one row — but the code change is real and deserves its own PR with its own tests, not a migration bolted onto this one.

Same code-first rule as every other step in #708: the readers go, it deploys, then the column drops.

## Verification

`gofmt` clean; `go build ./...` OK; `go vet ./...` OK; `internal/sso` and `internal/tenantpurge` suites pass. Live schema queried to confirm the column exists and the table is empty.

Migration `000133`, with a `down` that restores the column and states plainly that its values are not recoverable — which is honest rather than reassuring, since the table was empty and the client that populated it is gone.
