### PR TITLE
refactor(marketplace-api): drop the gip_uid customer-identity fallback (#793)

### DIFF
--- a/services/marketplace-api/internal/customer/models.go
+++ b/services/marketplace-api/internal/customer/models.go
@@ -25,7 +25,6 @@ type CustomerProfile struct {
 	ID             uuid.UUID      `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()"`
 	TenantID       uuid.UUID      `gorm:"column:tenant_id;type:uuid;not null"`
 	StoreID        uuid.UUID      `gorm:"column:store_id;type:uuid;not null"`
-	GipUID         *string        `gorm:"column:gip_uid;type:varchar(200)"`
 	Email          string         `gorm:"column:email;type:varchar(300);not null"`
 	FirstName      *string        `gorm:"column:first_name;type:varchar(200)"`
 	LastName       *string        `gorm:"column:last_name;type:varchar(200)"`

--- a/services/marketplace-api/internal/customer/repository.go
+++ b/services/marketplace-api/internal/customer/repository.go
@@ -18,7 +18,7 @@ var ErrNotFound = errors.New("customer: not found")
 
 // Repository is the data-access interface for customer profiles and addresses.
 type Repository interface {
-	// UpsertProfile inserts a profile or updates gip_uid+updated_at on conflict(store_id, email).
+	// UpsertProfile inserts a profile or bumps updated_at on conflict(store_id, email).
 	UpsertProfile(ctx context.Context, p *CustomerProfile) (*CustomerProfile, error)
 
 	// GetProfileByEmail returns the membership row for (store_id, email),
@@ -26,9 +26,6 @@ type Repository interface {
 	// the read half of the membership model: every session-path caller
 	// uses it, and none of them may fall back to creating a row.
 	GetProfileByEmail(ctx context.Context, storeID uuid.UUID, email string) (*CustomerProfile, error)
-
-	// GetProfileByGipUID returns the profile for (store_id, gip_uid). ErrNotFound on miss.
-	GetProfileByGipUID(ctx context.Context, storeID uuid.UUID, gipUID string) (*CustomerProfile, error)
 
 	// GetProfileByID returns a profile by primary key. ErrNotFound on miss.
 	GetProfileByID(ctx context.Context, profileID uuid.UUID) (*CustomerProfile, error)
@@ -89,8 +86,8 @@ type gormRepo struct {
 func NewRepository(db *gorm.DB) Repository { return &gormRepo{db: db} }
 
 func (r *gormRepo) UpsertProfile(ctx context.Context, p *CustomerProfile) (*CustomerProfile, error) {
-	// On conflict we only refresh gip_uid (in case the IdP rotated it)
-	// and updated_at. We deliberately do NOT touch first_name / last_name
+	// On conflict we only bump updated_at. We deliberately do NOT touch
+	// first_name / last_name
 	// here — those are owned by the customer via the storefront /account
 	// PATCH. Including them in DoUpdates caused every subsequent login
 	// to clobber saved edits with whatever (usually empty) values the
@@ -98,7 +95,7 @@ func (r *gormRepo) UpsertProfile(ctx context.Context, p *CustomerProfile) (*Cust
 	err := r.db.WithContext(ctx).
 		Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "store_id"}, {Name: "email"}},
-			DoUpdates: clause.AssignmentColumns([]string{"gip_uid", "updated_at"}),
+			DoUpdates: clause.AssignmentColumns([]string{"updated_at"}),
 		}).
 		Create(p).Error
 	if err != nil {
@@ -130,20 +127,6 @@ func (r *gormRepo) GetProfileByEmail(ctx context.Context, storeID uuid.UUID, ema
 	}
 	if err != nil {
 		return nil, fmt.Errorf("customer: get by email: %w", err)
-	}
-	return &p, nil
-}
-
-func (r *gormRepo) GetProfileByGipUID(ctx context.Context, storeID uuid.UUID, gipUID string) (*CustomerProfile, error) {
-	var p CustomerProfile
-	err := r.db.WithContext(ctx).
-		Where("store_id = ? AND gip_uid = ?", storeID, gipUID).
-		First(&p).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, ErrNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("customer: get by gip_uid: %w", err)
 	}
 	return &p, nil
 }

--- a/services/marketplace-api/internal/customer/service.go
+++ b/services/marketplace-api/internal/customer/service.go
@@ -19,7 +19,6 @@ import (
 type JoinStoreInput struct {
 	StoreID   uuid.UUID
 	TenantID  uuid.UUID
-	GipUID    string
 	Email     string
 	FirstName string
 	LastName  string
@@ -80,9 +79,9 @@ func (s *Service) LookupProfile(ctx context.Context, storeID uuid.UUID, email st
 // explicit join (the storefront /account/join endpoint and the mobile
 // /account/register endpoint), never from a session or browsing path.
 //
-// Uses INSERT ON CONFLICT (store_id, email) DO UPDATE SET gip_uid = EXCLUDED.gip_uid
+// Uses INSERT ON CONFLICT (store_id, email) DO UPDATE SET updated_at
 // so a double-submitted join is safe. The conflict branch deliberately
-// touches only gip_uid/updated_at, so re-joining can never reset status,
+// touches only updated_at, so re-joining can never reset status,
 // block_reason, tags, or notes; a blocked membership is additionally
 // refused up front with ErrBlocked rather than relying on that.
 //
@@ -108,7 +107,6 @@ func (s *Service) JoinStore(ctx context.Context, input JoinStoreInput, c *gin.Co
 	profile := &CustomerProfile{
 		TenantID:  input.TenantID,
 		StoreID:   input.StoreID,
-		GipUID:    nilIfEmpty(input.GipUID),
 		Email:     email,
 		FirstName: nilIfEmpty(input.FirstName),
 		LastName:  nilIfEmpty(input.LastName),

--- a/services/marketplace-api/internal/handlers/storefront/customer_join.go
+++ b/services/marketplace-api/internal/handlers/storefront/customer_join.go
@@ -25,7 +25,7 @@ import (
 )
 
 // joinRequest carries the optional display name the customer supplied on
-// the join screen. The identity (email + uid) is NEVER taken from the
+// the join screen. The identity (email) is NEVER taken from the
 // body — it comes from the verified session/bearer credential on the
 // context, so a caller cannot join a store on someone else's behalf.
 type joinRequest struct {
@@ -75,7 +75,6 @@ func (h *CustomerAccountHandler) Membership(c *gin.Context) {
 // who is already a member gets 200 and their existing profile back.
 func (h *CustomerAccountHandler) Join(c *gin.Context) {
 	email := c.GetString(CustomerIdentityEmailKey)
-	uid := c.GetString(CustomerIdentityUIDKey)
 	if email == "" {
 		c.JSON(http.StatusUnauthorized, gin.H{
 			"error":   "unauthorized",
@@ -96,7 +95,6 @@ func (h *CustomerAccountHandler) Join(c *gin.Context) {
 	profile, err := h.customerSvc.JoinStore(c.Request.Context(), customer.JoinStoreInput{
 		StoreID:   storeID,
 		TenantID:  tenantID,
-		GipUID:    uid,
 		Email:     email,
 		FirstName: derefString(req.FirstName),
 		LastName:  derefString(req.LastName),

--- a/services/marketplace-api/internal/handlers/storefront/customer_membership_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/customer_membership_test.go
@@ -339,7 +339,7 @@ func TestMobileSessionPathNeverCreatesMembership(t *testing.T) {
 	r.Use(func(c *gin.Context) {
 		c.Set("store", store)
 		// What a verified Bearer token leaves behind.
-		c.Set(CustomerGipUIDKey, "gip-uid-1")
+		c.Set(CustomerUIDKey, "gip-uid-1")
 		c.Set(CustomerEmailKey, "shopper@example.com")
 		c.Next()
 	})

--- a/services/marketplace-api/internal/handlers/storefront/identity_uid_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/identity_uid_test.go
@@ -1,0 +1,125 @@
+package storefront
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/marketplace-api/internal/stores"
+)
+
+// signClaims builds a correctly signed mp_customer_session cookie from an
+// arbitrary claim map, so a test can omit "uid" — something signedCookie
+// cannot express.
+func signClaims(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	b64 := base64.StdEncoding.EncodeToString(payload)
+	mac := hmac.New(sha256.New, []byte(testSessionSecret))
+	mac.Write([]byte(b64))
+	return b64 + "." + hex.EncodeToString(mac.Sum(nil))
+}
+
+func storeScopedClaims(store *stores.Store, email string) map[string]any {
+	return map[string]any{
+		"email":      email,
+		"store_slug": store.Slug,
+		"store_id":   store.ID,
+		"tenant_id":  store.TenantID,
+		"exp":        time.Now().Add(time.Hour).Unix(),
+	}
+}
+
+func TestIdentityUIDReturnsZitadelUID(t *testing.T) {
+	claims := sessionClaims{UID: "zitadel-uid-1"}
+	if got := claims.IdentityUID(); got != "zitadel-uid-1" {
+		t.Fatalf("IdentityUID() = %q, want %q", got, "zitadel-uid-1")
+	}
+}
+
+// A cookie carrying no uid has no identity at all. It must never resolve
+// to the empty string, which would compare equal to every other
+// identity-less request (#793).
+func TestIdentityUIDHasNoGipUIDFallback(t *testing.T) {
+	store := membershipTestStore()
+	claims := storeScopedClaims(store, "legacy@example.com")
+	claims["gip_uid"] = "legacy-gip-uid"
+
+	if _, err := validateSessionCookie(signClaims(t, claims), testSessionSecret); err == nil {
+		t.Fatal("expected a gip_uid-only cookie to be rejected as missing identity")
+	}
+}
+
+// The happy path still works: a Zitadel uid resolves normally, all the
+// way through the session middleware.
+func TestSessionWithZitadelUIDResolvesIdentity(t *testing.T) {
+	store := membershipTestStore()
+	claims := storeScopedClaims(store, "shopper@example.com")
+	claims["uid"] = "zitadel-uid-1"
+
+	got, err := validateSessionCookie(signClaims(t, claims), testSessionSecret)
+	if err != nil {
+		t.Fatalf("validateSessionCookie: %v", err)
+	}
+	if got.IdentityUID() != "zitadel-uid-1" {
+		t.Fatalf("IdentityUID() = %q, want %q", got.IdentityUID(), "zitadel-uid-1")
+	}
+
+	r := identityRouter(t)
+	w := doIdentityGet(t, r, signClaims(t, claims))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); body != `{"uid":"zitadel-uid-1"}` {
+		t.Fatalf("body = %s, want the zitadel uid", body)
+	}
+}
+
+// A legacy cookie carrying only gip_uid is treated as UNAUTHENTICATED —
+// 401, sign in again — rather than as an authenticated request with an
+// empty identity.
+func TestSessionWithOnlyGipUIDIsUnauthenticated(t *testing.T) {
+	store := membershipTestStore()
+	claims := storeScopedClaims(store, "legacy@example.com")
+	claims["gip_uid"] = "legacy-gip-uid"
+
+	r := identityRouter(t)
+	w := doIdentityGet(t, r, signClaims(t, claims))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (body %s)", w.Code, w.Body.String())
+	}
+}
+
+func identityRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	store := membershipTestStore()
+	r.Use(func(c *gin.Context) { c.Set("store", store); c.Next() })
+	r.Use(OptionalCustomerAuth(testSessionSecret, &tripwireService{t: t}, membershipTestLogger()))
+	r.Use(RequireCustomerIdentity())
+	r.GET("/whoami", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"uid": c.GetString(CustomerIdentityUIDKey)})
+	})
+	return r
+}
+
+func doIdentityGet(t *testing.T, r *gin.Engine, cookie string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/whoami", nil)
+	req.AddCookie(&http.Cookie{Name: "mp_customer_session", Value: cookie})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}

--- a/services/marketplace-api/internal/handlers/storefront/middleware.go
+++ b/services/marketplace-api/internal/handlers/storefront/middleware.go
@@ -98,7 +98,7 @@ func respondNotFound(c *gin.Context) {
 const (
 	CustomerProfileIDKey = "customer_profile_id"
 	CustomerEmailKey     = "customer_email"
-	CustomerGipUIDKey    = "customer_gip_uid"
+	CustomerUIDKey       = "customer_uid"
 	CustomerProfileKey   = "customer_profile"
 
 	// CustomerIdentityEmailKey / CustomerIdentityUIDKey carry the
@@ -129,7 +129,6 @@ type CustomerProfileService interface {
 // sessionClaims represents the decoded auth-bff session cookie payload.
 type sessionClaims struct {
 	UID       string `json:"uid"`
-	GipUID    string `json:"gip_uid"`
 	Email     string `json:"email"`
 	FirstName string `json:"first_name"`
 	LastName  string `json:"last_name"`
@@ -212,7 +211,7 @@ func OptionalCustomerAuth(secret string, customerSvc CustomerProfileService, log
 		// identity is trustworthy from here on — independently of whether
 		// it has a membership.
 		c.Set(CustomerIdentityEmailKey, claims.Email)
-		c.Set(CustomerIdentityUIDKey, claims.UIDOrGipUID())
+		c.Set(CustomerIdentityUIDKey, claims.IdentityUID())
 
 		profile, err := customerSvc.LookupProfile(c.Request.Context(), storeID, claims.Email)
 		if err != nil {
@@ -231,7 +230,7 @@ func OptionalCustomerAuth(secret string, customerSvc CustomerProfileService, log
 
 		c.Set(CustomerProfileIDKey, profile.ID.String())
 		c.Set(CustomerEmailKey, profile.Email)
-		c.Set(CustomerGipUIDKey, claims.GipUID)
+		c.Set(CustomerUIDKey, claims.IdentityUID())
 		c.Set(CustomerProfileKey, profile)
 
 		c.Next()
@@ -242,9 +241,15 @@ func OptionalCustomerAuth(secret string, customerSvc CustomerProfileService, log
 // verified customer identity. It deliberately does NOT require a
 // membership — it is the guard for the join endpoint, which exists
 // precisely for authenticated customers who have not joined yet.
+//
+// BOTH the email and the uid must be present. Since the gip_uid fallback
+// was removed (#793) a legacy cookie carrying only a gip_uid resolves to
+// an empty uid, and an empty identity must never be treated as
+// authenticated — it would otherwise be indistinguishable from any other
+// identity-less request. Such a customer is asked to sign in again.
 func RequireCustomerIdentity() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if c.GetString(CustomerIdentityEmailKey) == "" {
+		if c.GetString(CustomerIdentityEmailKey) == "" || c.GetString(CustomerIdentityUIDKey) == "" {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, map[string]any{
 				"error":   "unauthorized",
 				"message": "Authentication required. Please sign in.",
@@ -298,18 +303,21 @@ func validateSessionCookie(cookie, secret string) (*sessionClaims, error) {
 		return nil, fmt.Errorf("malformed cookie: %w", err)
 	}
 
-	if claims.Email == "" || claims.UIDOrGipUID() == "" {
+	if claims.Email == "" || claims.IdentityUID() == "" {
 		return nil, errors.New("malformed cookie: missing identity")
 	}
 
 	return &claims, nil
 }
 
-func (s sessionClaims) UIDOrGipUID() string {
-	if s.UID != "" {
-		return s.UID
-	}
-	return s.GipUID
+// IdentityUID is the verified identity subject carried by the session
+// cookie: the Zitadel uid, and nothing else. There is deliberately no
+// fallback to a legacy gip_uid claim (#793) — a cookie that carries no
+// uid has no identity, and validateSessionCookie rejects it so the
+// customer re-authenticates. Falling back would risk resolving an empty
+// identity, which must never be allowed to match a stored row.
+func (s sessionClaims) IdentityUID() string {
+	return s.UID
 }
 
 func (s sessionClaims) MatchesStore(store *stores.Store) bool {

--- a/services/marketplace-api/internal/handlers/storefront/mobile_auth.go
+++ b/services/marketplace-api/internal/handlers/storefront/mobile_auth.go
@@ -35,7 +35,7 @@ func GIPBearerAuth(_ bool) gin.HandlerFunc {
 		// MUST be chained after this one. If it's not, reaching a handler
 		// without a verified identity is a misconfiguration we refuse to
 		// silently paper over — reject so the broken wiring is visible.
-		if _, exists := c.Get(CustomerGipUIDKey); !exists {
+		if _, exists := c.Get(CustomerUIDKey); !exists {
 			// No upstream verifier has set identity; fail closed.
 			// (The verifier middleware wires itself after this one and sets
 			// the key before the handler runs.)
@@ -68,9 +68,9 @@ func OptionalGIPBearerAuth(_ bool) gin.HandlerFunc {
 // to validate tokens AND resolve customer profiles. It bridges the GIP token
 // to the same customer context keys used by the cookie-based web storefront.
 type CustomerVerifier interface {
-	// VerifyCustomerToken validates a GIP ID token and returns the customer's
-	// GIP UID and email. Returns an error if the token is invalid.
-	VerifyCustomerToken(idToken string) (gipUID, email string, err error)
+	// VerifyCustomerToken validates an ID token and returns the customer's
+	// identity UID and email. Returns an error if the token is invalid.
+	VerifyCustomerToken(idToken string) (uid, email string, err error)
 }
 
 // MobileCustomerAuth validates Bearer tokens via a CustomerVerifier and sets
@@ -89,13 +89,13 @@ func MobileCustomerAuth(verifier CustomerVerifier) gin.HandlerFunc {
 			return
 		}
 
-		gipUID, email, err := verifier.VerifyCustomerToken(idToken)
+		uid, email, err := verifier.VerifyCustomerToken(idToken)
 		if err != nil {
 			abortUnauthorized(c, "invalid or expired token")
 			return
 		}
 
-		c.Set(CustomerGipUIDKey, gipUID)
+		c.Set(CustomerUIDKey, uid)
 		c.Set(CustomerEmailKey, email)
 		c.Next()
 	}
@@ -117,14 +117,14 @@ func OptionalMobileCustomerAuth(verifier CustomerVerifier) gin.HandlerFunc {
 			return
 		}
 
-		gipUID, email, err := verifier.VerifyCustomerToken(idToken)
+		uid, email, err := verifier.VerifyCustomerToken(idToken)
 		if err != nil {
 			// Invalid token on optional auth — continue as guest.
 			c.Next()
 			return
 		}
 
-		c.Set(CustomerGipUIDKey, gipUID)
+		c.Set(CustomerUIDKey, uid)
 		c.Set(CustomerEmailKey, email)
 		c.Next()
 	}

--- a/services/marketplace-api/internal/handlers/storefront/mobile_auth_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/mobile_auth_test.go
@@ -58,7 +58,7 @@ func TestGIPBearerAuth_DevMode_DoesNotSetIdentityWithoutVerifier(t *testing.T) {
 	r.Use(storefront.GIPBearerAuth(true)) // devMode param now ignored
 	r.GET("/test", func(c *gin.Context) {
 		c.JSON(200, gin.H{
-			"gip_uid": c.GetString("customer_gip_uid"),
+			"gip_uid": c.GetString("customer_uid"),
 			"email":   c.GetString("customer_email"),
 		})
 	})
@@ -96,7 +96,7 @@ func TestOptionalGIPBearerAuth_MissingToken_ContinuesAsGuest(t *testing.T) {
 	r := gin.New()
 	r.Use(storefront.OptionalGIPBearerAuth(true))
 	r.GET("/test", func(c *gin.Context) {
-		gipUID := c.GetString("customer_gip_uid")
+		gipUID := c.GetString("customer_uid")
 		c.JSON(200, gin.H{"has_auth": gipUID != ""})
 	})
 
@@ -116,7 +116,7 @@ func TestOptionalGIPBearerAuth_DevMode_DoesNotSetIdentityWithoutVerifier(t *test
 	r.Use(storefront.OptionalGIPBearerAuth(true)) // devMode param now ignored
 	r.GET("/test", func(c *gin.Context) {
 		c.JSON(200, gin.H{
-			"gip_uid": c.GetString("customer_gip_uid"),
+			"gip_uid": c.GetString("customer_uid"),
 		})
 	})
 
@@ -166,7 +166,7 @@ func TestMobileCustomerAuth_ValidToken_SetsContext(t *testing.T) {
 	}))
 	r.GET("/test", func(c *gin.Context) {
 		c.JSON(200, gin.H{
-			"gip_uid": c.GetString("customer_gip_uid"),
+			"gip_uid": c.GetString("customer_uid"),
 			"email":   c.GetString("customer_email"),
 		})
 	})

--- a/services/marketplace-api/internal/handlers/storefront/mobile_routes.go
+++ b/services/marketplace-api/internal/handlers/storefront/mobile_routes.go
@@ -58,7 +58,7 @@ type MobileDeps struct {
 // So there is no customer bearer verifier in this service at all today.
 // This function's "Authenticated routes" group chains requireAuth :=
 // GIPBearerAuth(deps.DevMode) — the scaffold guard in mobile_auth.go that
-// never sets CustomerGipUIDKey itself — with no MobileCustomerAuth in the
+// never sets CustomerUIDKey itself — with no MobileCustomerAuth in the
 // chain to set it. mobileCustomerProfileMW then finds no identity and
 // treats the caller as a guest, so RequireCustomerAuth has nothing to
 // authorize and 401s every request in the authed group. Wiring this
@@ -251,9 +251,9 @@ func RegisterMobileStorefront(router *gin.RouterGroup, deps MobileDeps) {
 // docs/superpowers/specs/2026-09-05-customer-store-membership-design.md.
 func mobileCustomerProfileMW(customerSvc CustomerProfileService, logger *slog.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		gipUID := c.GetString(CustomerGipUIDKey)
+		uid := c.GetString(CustomerUIDKey)
 		email := c.GetString(CustomerEmailKey)
-		if gipUID == "" || email == "" {
+		if uid == "" || email == "" {
 			// No auth context — continue as guest.
 			c.Next()
 			return
@@ -277,7 +277,7 @@ func mobileCustomerProfileMW(customerSvc CustomerProfileService, logger *slog.Lo
 		}
 
 		c.Set(CustomerIdentityEmailKey, email)
-		c.Set(CustomerIdentityUIDKey, gipUID)
+		c.Set(CustomerIdentityUIDKey, uid)
 
 		profile, err := customerSvc.LookupProfile(c.Request.Context(), storeID, email)
 		if err != nil {
@@ -294,7 +294,7 @@ func mobileCustomerProfileMW(customerSvc CustomerProfileService, logger *slog.Lo
 
 		c.Set(CustomerProfileIDKey, profile.ID.String())
 		c.Set(CustomerEmailKey, profile.Email)
-		c.Set(CustomerGipUIDKey, gipUID)
+		c.Set(CustomerUIDKey, uid)
 		c.Set(CustomerProfileKey, profile)
 		c.Next()
 	}

--- a/services/marketplace-api/internal/handlers/storefront/mobile_stubs.go
+++ b/services/marketplace-api/internal/handlers/storefront/mobile_stubs.go
@@ -162,9 +162,9 @@ type registerRequest struct {
 // the context, never from the body. See customer_join.go's header for why
 // nothing else on this surface may create a membership.
 func (h *CustomerAccountHandler) Register(c *gin.Context) {
-	gipUID := c.GetString(CustomerIdentityUIDKey)
+	uid := c.GetString(CustomerIdentityUIDKey)
 	email := c.GetString(CustomerIdentityEmailKey)
-	if gipUID == "" || email == "" {
+	if uid == "" || email == "" {
 		c.JSON(http.StatusUnauthorized, gin.H{
 			"error":   "unauthorized",
 			"message": "Authentication required",
@@ -207,7 +207,6 @@ func (h *CustomerAccountHandler) Register(c *gin.Context) {
 	profile, err := h.customerSvc.JoinStore(c.Request.Context(), customer.JoinStoreInput{
 		StoreID:   storeID,
 		TenantID:  tenantID,
-		GipUID:    gipUID,
 		Email:     email,
 		FirstName: firstName,
 		LastName:  lastName,

--- a/services/marketplace-api/internal/handlers/storefront/support.go
+++ b/services/marketplace-api/internal/handlers/storefront/support.go
@@ -47,7 +47,7 @@ func storefrontResolver(c *gin.Context) (ottoclient.ForwardScope, ottoclient.For
 	}
 	return ottoclient.ForwardScope{TenantID: s.TenantID, StoreID: s.ID},
 		ottoclient.ForwardIdentity{
-			UserID:    c.GetString(CustomerGipUIDKey),
+			UserID:    c.GetString(CustomerUIDKey),
 			UserEmail: c.GetString(CustomerEmailKey),
 		},
 		true

--- a/services/marketplace-api/internal/handlers/storefront/support_test.go
+++ b/services/marketplace-api/internal/handlers/storefront/support_test.go
@@ -28,7 +28,7 @@ func newSupportTestRig(t *testing.T, otto http.HandlerFunc) (*gin.Engine, func()
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
 		c.Set("store", &stores.Store{ID: "store-1", TenantID: "tenant-1", Status: stores.StatusActive})
-		c.Set(CustomerGipUIDKey, "gip-abc")
+		c.Set(CustomerUIDKey, "gip-abc")
 		c.Set(CustomerEmailKey, "buyer@example.com")
 		c.Next()
 	})

--- a/services/marketplace-api/internal/notification/models.go
+++ b/services/marketplace-api/internal/notification/models.go
@@ -39,9 +39,10 @@ type Notification struct {
 	// PROFILE ID (customer_profiles.id) for the customer notification bell.
 	// NULL = store/staff notification.
 	//
-	// NOT customer_profiles.gip_uid. Both are opaque strings in the same
-	// conceptual role, so the distinction is easy to lose: a GIP UID pasted
-	// into the /admin/notifications recipient_user_id filter matches nothing
+	// NOT an IdP subject (Zitadel uid, or the legacy customer_profiles.gip_uid
+	// this service no longer reads or writes — #793). Both are opaque strings
+	// in the same conceptual role, so the distinction is easy to lose: an IdP
+	// uid pasted into the /admin/notifications recipient_user_id filter matches nothing
 	// and returns an empty 200, which on a governance surface is
 	// indistinguishable from "this customer was never notified" (#350).
 	RecipientUserID *string          `gorm:"column:recipient_user_id;type:varchar(255)"`


### PR DESCRIPTION
Part of #793. Removes the `gip_uid` customer-identity fallback. **Code only — the column stays**; dropping it is a separate PR after this deploys, the same code-first ordering every step of #708 followed.

## It also fixes a latent bug

`middleware.go` on `main` sets two different keys from two different sources:

```go
c.Set(CustomerIdentityUIDKey, claims.UIDOrGipUID())   // correct — falls back
c.Set(CustomerGipUIDKey,      claims.GipUID)          // raw, no fallback
```

Under Zitadel, `claims.GipUID` is **always empty** — sessions carry `uid`. And `support.go:50` reads `CustomerGipUIDKey` as its otto `UserID`.

So **every Zitadel customer's support chat has been recording a blank user id.** Verified against `main` before changing anything. The key is now `CustomerUIDKey` (`"customer_uid"`), fed the Zitadel uid, so it carries a real subject.

That was not the goal of this change — it surfaced because removing a fallback forces you to look at everything the value fed.

## The identity change

- `sessionClaims.UIDOrGipUID()` → **`IdentityUID()`**, returning `s.UID` only; the `GipUID` claims field is gone.
- A cookie carrying **only** a `gip_uid` is now **rejected**: `validateSessionCookie` fails on `claims.Email == "" || claims.IdentityUID() == ""`, so the cookie never decodes and the request is an unauthenticated guest.
- `RequireCustomerIdentity` additionally requires **both** the email and uid keys to be non-empty.

That second guard is the point. The failure mode to avoid was an empty identity being admitted and matching a row; it now fails closed with a 401 "Please sign in", so the affected customer simply signs in again.

**Blast radius, measured:** production has **5** `customer_profiles`, exactly **1** with a non-null `gip_uid`. At most one person re-authenticates. No backfill machinery for one row.

## Also removed

`GetProfileByGipUID` (no callers anywhere — interface and gorm impl only), the `GipUID` field on `CustomerProfile` and `JoinStoreInput`, and the upsert's `DO UPDATE SET gip_uid` (now `updated_at` only).

## Verification

`gofmt` clean; `go build ./...` OK; `go vet ./...` OK; `go test ./...` → **105 packages ok, 0 FAIL**.

New `identity_uid_test.go`, 7 assertions passing, covering exactly the risk: a uid-only session resolves end-to-end through the middleware (200, correct uid), and a **gip_uid-only session 401s** rather than being admitted with an empty identity.

## Two follow-ups this exposes

1. **Migration `000084`'s partial unique index** on `(store_id, gip_uid) WHERE gip_uid IS NOT NULL` is now dead weight — new rows are always NULL. Fold its drop into the column-drop PR.
2. `mobile_auth.go`'s `MobileCustomerAuth` / `OptionalMobileCustomerAuth` have **no production caller**: the GIP customer verifier went in #787 and was deliberately not replaced, and the standalone support mount went with it. Left in place rather than widening this change — it belongs with #792, when the storefront app that would use those routes is migrated.
