### PR TITLE
refactor(mobile-storefront): drop GIP/Firebase auth remnants and make sign-in state honest (#792)

### DIFF
--- a/apps/mobile-storefront/app.config.js
+++ b/apps/mobile-storefront/app.config.js
@@ -59,7 +59,6 @@ if (!fs.existsSync(configPath)) {
  * @property {string} colors.accent
  * @property {string} colors.background
  * @property {string} colors.text
- * @property {string} gipTenantId       Customer GIP/Identity Platform tenant pool id.
  */
 
 /** @type {MerchantConfig} */
@@ -74,7 +73,6 @@ const REQUIRED = [
   "associatedDomain",
   "defaultStoreSlug",
   "colors",
-  "gipTenantId",
 ];
 for (const key of REQUIRED) {
   if (!merchant[key]) {
@@ -133,18 +131,16 @@ module.exports = {
       "expo-router",
       "expo-secure-store",
       "expo-notifications",
-      "@react-native-firebase/app",
     ],
     // `extra` is the runtime side of the merchant config — every value
     // here lands in Constants.expoConfig.extra at runtime so the app can
-    // bind to the right merchant slug, API base, palette, and identity
-    // pool without rebuilding.
+    // bind to the right merchant slug, API base, and palette without
+    // rebuilding.
     extra: {
       eas: { projectId: merchant.easProjectId || "" },
       apiBaseUrl: "https://api.mark8ly.com",
       merchantSlug: merchant.merchantSlug,
       defaultStoreSlug: merchant.defaultStoreSlug,
-      gipTenantId: merchant.gipTenantId,
       shortName: merchant.shortName || merchant.name,
       colors: merchant.colors,
     },

--- a/apps/mobile-storefront/app/sign-in.tsx
+++ b/apps/mobile-storefront/app/sign-in.tsx
@@ -1,200 +1,46 @@
-import { useState } from "react";
-import {
-  KeyboardAvoidingView,
-  Platform,
-  StyleSheet,
-  TextInput,
-  TouchableOpacity,
-  View,
-} from "react-native";
-import { useRouter, Stack } from "expo-router";
-import { ChevronLeft } from "lucide-react-native";
-import { useAuth } from "@repo/mobile-shared/auth/provider";
-import { Button, Screen, Text } from "@/components/ui";
+import { View, StyleSheet } from "react-native";
+import { Stack, useRouter } from "expo-router";
+import { Button, EmptyState, Screen } from "@/components/ui";
 import { theme } from "@/lib/theme";
-import { getMerchant } from "@/lib/merchant";
 
+/**
+ * Customer sign-in is not available in this build.
+ *
+ * The hosted identity pool this screen used to authenticate
+ * against was removed (#787, #792), and no customer auth endpoint has been
+ * built on its replacement yet. Rather than render a login form whose submit
+ * throws an opaque error, this screen says so plainly and keeps the rest of
+ * the app — browse, cart, checkout as a guest — reachable.
+ *
+ * When a customer auth flow exists, this screen becomes the form again.
+ */
 export default function SignInScreen() {
   const router = useRouter();
-  const merchant = getMerchant();
-  const { signIn } = useAuth();
-
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const handleSignIn = async () => {
-    if (!email.trim() || !password) {
-      setError("Email and password are required");
-      return;
-    }
-    setLoading(true);
-    setError(null);
-    try {
-      await signIn(email.trim(), password);
-      router.replace("/(tabs)/account");
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Sign-in failed";
-      if (message.includes("wrong-password") || message.includes("user-not-found")) {
-        setError("Invalid email or password");
-      } else if (message.includes("network")) {
-        setError("Network error — check your connection");
-      } else {
-        setError("Sign-in failed — please try again");
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
 
   return (
     <Screen>
       <Stack.Screen options={{ headerShown: false }} />
-      <KeyboardAvoidingView
-        style={{ flex: 1 }}
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-      >
-        <View style={styles.headerBar}>
-          <TouchableOpacity
-            onPress={() => router.back()}
-            hitSlop={12}
-            accessibilityRole="button"
-            accessibilityLabel="Back"
-            style={styles.backBtn}
-          >
-            <ChevronLeft size={22} color={theme.colors.text} strokeWidth={1.75} />
-          </TouchableOpacity>
-        </View>
-
-        <View style={styles.body}>
-          <View style={styles.brand}>
-            <Text preset="eyebrow" color="textTertiary">
-              {merchant.shortName.toUpperCase()}
-            </Text>
-            <Text preset="display" color="text" style={styles.wordmark}>
-              Welcome back
-            </Text>
-            <Text preset="bodyLg" color="textSecondary">
-              Sign in to your account.
-            </Text>
-          </View>
-
-          {error ? (
-            <View style={styles.errorBox}>
-              <Text preset="caption" color="danger">
-                {error}
-              </Text>
-            </View>
-          ) : null}
-
-          <View style={styles.form}>
-            <Field label="Email">
-              <TextInput
-                placeholder="you@example.com"
-                value={email}
-                onChangeText={setEmail}
-                autoCapitalize="none"
-                keyboardType="email-address"
-                autoComplete="email"
-                style={styles.input}
-                placeholderTextColor={theme.colors.textTertiary}
-              />
-            </Field>
-            <Field label="Password">
-              <TextInput
-                placeholder="••••••••"
-                value={password}
-                onChangeText={setPassword}
-                secureTextEntry
-                autoComplete="password"
-                style={styles.input}
-                placeholderTextColor={theme.colors.textTertiary}
-              />
-            </Field>
-
+      <View style={styles.center}>
+        <EmptyState
+          title="Sign-in unavailable"
+          message="Accounts aren't available in this version of the app yet. You can still browse and check out as a guest."
+          action={
             <Button
-              label="Sign in"
-              onPress={handleSignIn}
-              loading={loading}
+              label="Continue browsing"
+              onPress={() => router.replace("/(tabs)")}
               fullWidth
-              style={{ marginTop: theme.spacing.lg }}
             />
-
-            <TouchableOpacity
-              onPress={() => router.push("/sign-up")}
-              style={styles.linkBtn}
-              accessibilityRole="link"
-              accessibilityLabel="Create an account"
-            >
-              <Text preset="caption" color="textSecondary">
-                New here? <Text preset="caption" color="text">Create an account</Text>
-              </Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-      </KeyboardAvoidingView>
+          }
+        />
+      </View>
     </Screen>
   );
 }
 
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <View style={{ gap: theme.spacing.xs }}>
-      <Text preset="caption" color="textSecondary" style={{ letterSpacing: 0.4 }}>
-        {label}
-      </Text>
-      {children}
-    </View>
-  );
-}
-
 const styles = StyleSheet.create({
-  headerBar: {
-    paddingHorizontal: theme.spacing.lg,
-    paddingTop: theme.spacing.sm,
-  },
-  backBtn: {
-    width: 36,
-    height: 36,
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: theme.radii.pill,
-  },
-  body: {
+  center: {
     flex: 1,
-    paddingHorizontal: theme.spacing.xl,
-    paddingTop: theme.spacing.xxxl,
-    paddingBottom: theme.spacing.xxl,
-  },
-  brand: {
-    gap: theme.spacing.xs,
-    marginBottom: theme.spacing.xxxl,
-  },
-  wordmark: { marginTop: theme.spacing.sm },
-  errorBox: {
-    paddingVertical: theme.spacing.sm,
-    paddingHorizontal: theme.spacing.md,
-    borderLeftWidth: 2,
-    borderLeftColor: theme.colors.danger,
-    marginBottom: theme.spacing.lg,
-    backgroundColor: theme.colors.surfaceAlt,
-  },
-  form: { gap: theme.spacing.lg },
-  input: {
-    height: 48,
-    fontFamily: theme.fonts.sans,
-    fontSize: 16,
-    color: theme.colors.text,
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.border,
-    paddingHorizontal: 0,
-  },
-  linkBtn: {
-    alignSelf: "center",
-    marginTop: theme.spacing.md,
-    minHeight: 44,
     justifyContent: "center",
-    paddingHorizontal: theme.spacing.md,
+    paddingHorizontal: theme.spacing.lg,
   },
 });

--- a/apps/mobile-storefront/branding/example/config.json
+++ b/apps/mobile-storefront/branding/example/config.json
@@ -8,7 +8,6 @@
   "associatedDomain": "example.mark8ly.com",
   "defaultStoreSlug": "example",
   "easProjectId": "",
-  "gipTenantId": "",
   "colors": {
     "primary": "#0E0E0C",
     "accent": "#2D4A2B",

--- a/apps/mobile-storefront/lib/api-client.ts
+++ b/apps/mobile-storefront/lib/api-client.ts
@@ -5,13 +5,21 @@ import { getMerchant } from "@/lib/merchant";
 
 /**
  * Storefront API client hook. Pre-binds every call to the merchant's
- * store slug (baked in at build time) and forwards the customer's GIP
- * id_token when they're signed in. Anonymous browse works without a
- * token — only account/cart-on-server endpoints require auth.
+ * store slug (baked in at build time) and forwards the customer's bearer
+ * token when they're signed in. Anonymous browse works without a token —
+ * only account/cart-on-server endpoints require auth.
  *
  * Self-correction:
- *   - 401 → force a fresh GIP id_token via refreshToken, retry. Still
- *     401? signOut so the AuthGate routes back to /sign-in.
+ *   - 401 → `refreshToken` re-reads the persisted session token and the
+ *     call is retried. There is no force-refresh on this path: the stored
+ *     token is the only one there is, so a lapsed token yields null and the
+ *     retry 401s again. Still 401? signOut, and the AuthGate routes back to
+ *     /sign-in.
+ *
+ * Note: customer sign-in is not available in this build (see app/sign-in.tsx),
+ * so in practice every call here is currently anonymous. The token plumbing is
+ * kept intact rather than ripped out — it is provider-agnostic and is what a
+ * future customer auth flow will feed.
  */
 export function useStorefrontApi() {
   const { getToken, refreshToken, signOut } = useAuth();

--- a/apps/mobile-storefront/lib/merchant.ts
+++ b/apps/mobile-storefront/lib/merchant.ts
@@ -14,8 +14,6 @@ export interface MerchantConfig {
   defaultStoreSlug: string;
   /** Mark8ly storefront API base URL — always prod for white-label apps. */
   apiBaseUrl: string;
-  /** Customer GIP/Identity Platform tenant pool id. */
-  gipTenantId: string;
   /** Short brand label for UI strings ("Welcome to Acme"). */
   shortName: string;
   /** Build-time palette. Runtime branding from /storefront/branding can override. */
@@ -45,7 +43,6 @@ function readMerchantFromExpoConfig(): MerchantConfig {
     merchantSlug: extra.merchantSlug,
     defaultStoreSlug: extra.defaultStoreSlug,
     apiBaseUrl: extra.apiBaseUrl ?? "https://api.mark8ly.com",
-    gipTenantId: extra.gipTenantId ?? "",
     shortName: extra.shortName ?? "Shop",
     colors: extra.colors ?? {
       primary: "#0E0E0C",

--- a/apps/mobile-storefront/package.json
+++ b/apps/mobile-storefront/package.json
@@ -11,8 +11,6 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "1.23.1",
-    "@react-native-firebase/app": "^21.0.0",
-    "@react-native-firebase/auth": "^21.0.0",
     "@repo/mobile-shared": "*",
     "@tanstack/react-query": "^5.83.0",
     "expo": "~52.0.0",

--- a/apps/mobile-storefront/scripts/build-merchant.sh
+++ b/apps/mobile-storefront/scripts/build-merchant.sh
@@ -21,7 +21,7 @@
 # To onboard a new merchant:
 #   1. cp -r branding/example branding/<slug>
 #   2. Edit branding/<slug>/config.json (name, bundle id, colors,
-#      defaultStoreSlug, gipTenantId, easProjectId).
+#      defaultStoreSlug, easProjectId).
 #   3. Drop merchant assets into branding/<slug>/assets/
 #      (icon.png, adaptive-icon.png, splash.png).
 #   4. Run this script.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4423,8 +4423,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "1.23.1",
-        "@react-native-firebase/app": "^21.0.0",
-        "@react-native-firebase/auth": "^21.0.0",
         "@repo/mobile-shared": "*",
         "@tanstack/react-query": "^5.83.0",
         "expo": "~52.0.0",
@@ -9185,6 +9183,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.11.tgz",
       "integrity": "sha512-zwuPiRE0+hgcS95JZbJ6DFQN4xYFO8IyGxpeePTV51YJMwCf3lkBa6FnZ/iXIqDKcBPMgMuuEZozI0BJWaLEYg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/installations": "0.6.12",
@@ -9201,6 +9200,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.17.tgz",
       "integrity": "sha512-SJNVOeTvzdqZQvXFzj7yAirXnYcLDxh57wBFROfeowq/kRN1AqOw1tG6U4OiFOEhqi7s3xLze/LMkZatk2IEww==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/analytics": "0.10.11",
         "@firebase/analytics-types": "0.8.3",
@@ -9216,13 +9216,15 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
       "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/app": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.11.1.tgz",
       "integrity": "sha512-Vz4DrNLPfDx3RwQf+4klXtu7OUYDO6xz2hlRyFawWskS7YqdtNzkDDxrqH20KDfjCF1lib46/NgchIj1+8h4wQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/logger": "0.4.4",
@@ -9239,6 +9241,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.11.tgz",
       "integrity": "sha512-42zIfRI08/7bQqczAy7sY2JqZYEv3a1eNa4fLFdtJ54vNevbBIRSEA3fZgRqWFNHalh5ohsBXdrYgFqaRIuCcQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/logger": "0.4.4",
@@ -9257,6 +9260,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.18.tgz",
       "integrity": "sha512-qjozwnwYmAIdrsVGrJk+hnF1WBois54IhZR6gO0wtZQoTvWL/GtiA2F31TIgAhF0ayUiZhztOv1RfC7YyrZGDQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app-check": "0.8.11",
         "@firebase/app-check-types": "0.5.3",
@@ -9276,19 +9280,22 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
       "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/app-check-types": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
       "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/app-compat": {
       "version": "0.2.50",
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.50.tgz",
       "integrity": "sha512-7yD362icKgjoNvFxwth420TNZgqCfuTJ28yQCdpyjC2fXyaZHhAbxVKnHEXGTAaUKSHWxsIy46lBKGi/x/Mflw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.11.1",
         "@firebase/component": "0.6.12",
@@ -9304,13 +9311,15 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.9.0.tgz",
       "integrity": "sha512-Xz2mbEYauF689qXG/4HppS2+/yGo9R7B6eNUBh3H2+XpAZTGdx8d8TFsW/BMTAK9Q95NB0pb1Bbvfx0lwofq8Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/logger": "0.4.4",
@@ -9335,6 +9344,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.18.tgz",
       "integrity": "sha512-dFBev8AMNb2AgIt9afwf/Ku4/0Wq9R9OFSeBB/xjyJt+RfQ9PnNWqU2oFphews23byLg6jle8twRA7iOYfRGRw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/auth": "1.9.0",
         "@firebase/auth-types": "0.13.0",
@@ -9353,13 +9363,15 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
       "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth-types": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
       "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@firebase/app-types": "0.x",
         "@firebase/util": "1.x"
@@ -9370,6 +9382,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.12.tgz",
       "integrity": "sha512-YnxqjtohLbnb7raXt2YuA44cC1wA9GiehM/cmxrsoxKlFxBLy2V0OkRSj9gpngAE0UoJ421Wlav9ycO7lTPAUw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/util": "1.10.3",
         "tslib": "^2.1.0"
@@ -9383,6 +9396,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.0.tgz",
       "integrity": "sha512-inbLq0JyQD/d02Al3Lso0Hc8z1BVpB3dYSMFcQkeKhYyjn5bspLczLdasPbCOEUp8MOkLblLZhJuRs7Q/spFnw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/auth-interop-types": "0.2.4",
         "@firebase/component": "0.6.12",
@@ -9399,6 +9413,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.12.tgz",
       "integrity": "sha512-psFl5t6rSFHq3i3fnU1QQlc4BB9Hnhh8TgEqvQlPPm8kDLw8gYxvjqYw3c5CZW0+zKR837nwT6im/wtJUivMKw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
         "@firebase/auth-interop-types": "0.2.4",
@@ -9417,6 +9432,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.0.3.tgz",
       "integrity": "sha512-uHGQrSUeJvsDfA+IyHW5O4vdRPsCksEzv4T4Jins+bmQgYy20ZESU4x01xrQCn/nzqKHuQMEW99CoCO7D+5NiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/database": "1.0.12",
@@ -9434,6 +9450,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.8.tgz",
       "integrity": "sha512-6lPWIGeufhUq1heofZULyVvWFhD01TUrkkB9vyhmksjZ4XF7NaivQp9rICMk7QNhqwa+uDCaj4j+Q8qqcSVZ9g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app-types": "0.9.3",
         "@firebase/util": "1.10.3"
@@ -9444,6 +9461,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.8.tgz",
       "integrity": "sha512-eDvVJ/I5vSmIdGmLHJAK1OcviigIxjjia6i5/AkMFq6vZMt7CBXA0B5Xz9pGRCZ7WewFcsCbK1ZUQoYJ91+Cew==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/logger": "0.4.4",
@@ -9465,6 +9483,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.43.tgz",
       "integrity": "sha512-zxg7YS07XQnTetGs3GADM/eA6HB4vWUp+Av4iugmTbft0fQxuTSnGm7ifctaYuR7VMTPckU9CW+oFC9QUNSYvg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/firestore": "4.7.8",
@@ -9484,6 +9503,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
       "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@firebase/app-types": "0.x",
         "@firebase/util": "1.x"
@@ -9494,6 +9514,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.12.2.tgz",
       "integrity": "sha512-iKpFDoCYk/Qm+Qwv5ynRb9/yq64QOt0A0+t9NuekyAZnSoV56kSNq/PmsVmBauar5SlmEjhHk6QKdMBP9S0gXA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
         "@firebase/auth-interop-types": "0.2.4",
@@ -9514,6 +9535,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.19.tgz",
       "integrity": "sha512-uw4tR8NcJCDu86UD63Za8A8SgFgmAVFb1XsGlkuBY7gpLyZWEFavWnwRkZ/8cUwpqUhp/SptXFZ1WFJSnOokLw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/functions": "0.12.2",
@@ -9532,13 +9554,15 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
       "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/installations": {
       "version": "0.6.12",
       "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.12.tgz",
       "integrity": "sha512-ES/WpuAV2k2YtBTvdaknEo7IY8vaGjIjS3zhnHSAIvY9KwTR8XZFXOJoZ3nSkjN1A5R4MtEh+07drnzPDg9vaw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/util": "1.10.3",
@@ -9554,6 +9578,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.12.tgz",
       "integrity": "sha512-RhcGknkxmFu92F6Jb3rXxv6a4sytPjJGifRZj8MSURPuv2Xu+/AispCXEfY1ZraobhEHTG5HLGsP6R4l9qB5aA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/installations": "0.6.12",
@@ -9570,6 +9595,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
       "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@firebase/app-types": "0.x"
       }
@@ -9579,6 +9605,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
       "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -9591,6 +9618,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.16.tgz",
       "integrity": "sha512-VJ8sCEIeP3+XkfbJA7410WhYGHdloYFZXoHe/vt+vNVDGw8JQPTQSVTRvjrUprEf5I4Tbcnpr2H34lS6zhCHSA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/installations": "0.6.12",
@@ -9608,6 +9636,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.16.tgz",
       "integrity": "sha512-9HZZ88Ig3zQ0ok/Pwt4gQcNsOhoEy8hDHoGsV1am6ulgMuGuDVD2gl11Lere2ksL+msM12Lddi2x/7TCqmODZw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/messaging": "0.12.16",
@@ -9622,13 +9651,15 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
       "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/performance": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.0.tgz",
       "integrity": "sha512-L91PwYuiJdKXKSRqsWNicvTppAJVzKjye03UlegeD6TkpKjb93T8AmJ9B0Mt0bcWHCNtnnRBCdSCvD2U9GZDjw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/installations": "0.6.12",
@@ -9646,6 +9677,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.13.tgz",
       "integrity": "sha512-pB0SMQj2TLQ6roDcX0YQDWvUnVgsVOl0VnUvyT/VBdCUuQYDHobZsPEuQsoEqmPA44KS/Gl0oyKqf+I8UPtRgw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/logger": "0.4.4",
@@ -9662,13 +9694,15 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
       "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/remote-config": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.5.0.tgz",
       "integrity": "sha512-weiEbpBp5PBJTHUWR4GwI7ZacaAg68BKha5QnZ8Go65W4oQjEWqCW/rfskABI/OkrGijlL3CUmCB/SA6mVo0qA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/installations": "0.6.12",
@@ -9685,6 +9719,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.12.tgz",
       "integrity": "sha512-91jLWPtubIuPBngg9SzwvNCWzhMLcyBccmt7TNZP+y1cuYFNOWWHKUXQ3IrxCLB7WwLqQaEu7fTDAjHsTyBsSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/logger": "0.4.4",
@@ -9701,13 +9736,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.4.0.tgz",
       "integrity": "sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/storage": {
       "version": "0.13.6",
       "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.6.tgz",
       "integrity": "sha512-BEJLYQzVgAoglRl5VRIRZ91RRBZgS/O37/PSGQJBYNuoLmFZUrtwrlLTOAwG776NlO9VQR+K2j15/36Lr2EqHA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/util": "1.10.3",
@@ -9725,6 +9762,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.16.tgz",
       "integrity": "sha512-EeMuok/s0r938lEomia8XILEqSYULm7HcYZ/GTZLDWur0kMf2ktuPVZiTdRiwEV3Iki7FtQO5txrQ/0pLRVLAw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.12",
         "@firebase/storage": "0.13.6",
@@ -9744,6 +9782,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
       "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@firebase/app-types": "0.x",
         "@firebase/util": "1.x"
@@ -9754,6 +9793,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.3.tgz",
       "integrity": "sha512-wfoF5LTy0m2ufUapV0ZnpcGQvuavTbJ5Qr1Ze9OJGL70cSMvhDyjS4w2121XdA3lGZSTOsDOyGhpoDtYwck85A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -9766,6 +9806,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/vertexai/-/vertexai-1.0.4.tgz",
       "integrity": "sha512-Nkf/r4u166b4Id6zrrW0Qtg1KyZpQvvYchtkebamnHtIfY+Qnt51I/sx4Saos/WrmO8SnrSU850LfmJ7pehYXg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
         "@firebase/component": "0.6.12",
@@ -9785,7 +9826,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.3.tgz",
       "integrity": "sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
@@ -13996,6 +14038,7 @@
       "resolved": "https://registry.npmjs.org/@react-native-firebase/app/-/app-21.14.0.tgz",
       "integrity": "sha512-vBNfn7PoQrZfANLJnJiWZSHVu7WG6hjM5w3MDfmG8DLdr8VsAVBUgsn8lGpqobSuno1vTgwDIhR8PYZjMGsuvg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "firebase": "11.3.1"
       },
@@ -14015,6 +14058,7 @@
       "resolved": "https://registry.npmjs.org/@react-native-firebase/auth/-/auth-21.14.0.tgz",
       "integrity": "sha512-m4BFrq/pC4OlPPLZJjDu0n/3QHM+pE5KlYc7dvnE8zavtlqKclvZ6cchcfm4DsPVqmuQOJ1QQqrYdOfRm3hsHA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "plist": "^3.1.0"
       },
@@ -22798,6 +22842,7 @@
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.3.1.tgz",
       "integrity": "sha512-P4YVFM0Bm2d8aO61SCEMF8E1pYgieGLrmr/LFw7vs6sAMebwuwHt+Wug+1qL2fhAHWPwpWbCLsdJH8NQ+4Sw8Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/analytics": "0.10.11",
         "@firebase/analytics-compat": "0.2.17",


### PR DESCRIPTION
Part of #792. Makes `apps/mobile-storefront` **0% GIP**. It does **not** make its sign-in work — see below, that is deliberate.

## Firebase could go here — the opposite call from #781, and for a concrete reason

`apps/mobile-admin` genuinely needs `@react-native-firebase/app`: it ships `GoogleService-Info.plist` and `google-services.json`, `app.config.js` reads `REVERSED_CLIENT_ID` at prebuild, and #781 proved removing them breaks the iOS build.

**`mobile-storefront` is not that app.** It has never contained either service file — `git log --all` over both paths returns nothing — and it imports `@react-native-firebase/*` nowhere. Its push notifications run on `expo-notifications` + `@repo/mobile-shared/push/registration`, which never touches RNFirebase.

So the RNFirebase expo plugin existed solely for the GIP auth SDK, and **without the service files its prebuild step could never have succeeded anyway**. Removing it takes nothing working away.

## Removed

`gipTenantId` from `app.config.js` (doc comment, REQUIRED list and `extra`), `branding/example/config.json`, `lib/merchant.ts` and `scripts/build-merchant.sh`; `@react-native-firebase/app` and `/auth` from `package.json`; the RNFirebase expo plugin.

`lib/api-client.ts`'s comments claimed a "GIP id_token" and a force-refresh on 401. They now describe what the code actually does — `refreshToken` re-reads the persisted session token; there is no force-refresh. **Runtime behaviour is unchanged**; the retry is not dead, just weaker than the comment claimed.

## Sign-in is now honest rather than broken

`useAuth().signIn` reaches the shared `createZitadelBackend`, which throws by design since #799. There is **no customer mobile auth endpoint on Zitadel**: #787 removed the GIP customer verifier and deliberately did not build a speculative replacement for an app that has never shipped.

So sign-in now renders an `EmptyState` — *"Accounts aren't available in this version of the app yet. You can still browse and check out as a guest"* — mirroring the existing `sign-up.tsx` pattern. No form, no throw, no provider toggle, no placeholder API call.

Same judgement as #810's dead "Link Google" controls: a visibly unavailable feature beats one that throws, and beats one that silently vanishes.

**Building customer mobile auth on Zitadel is product work, not GIP removal.** Doing it here would mean shipping untested auth code with no caller — exactly what #787 argued against.

## Verification

- `apps/mobile-storefront && npx tsc --noEmit` → **clean, exit 0**, no pre-existing errors.
- Confirmed unaffected: `packages/mobile-shared` tsc clean, `apps/mobile-admin` still at its **4** known pre-existing `TS2304` errors — no new ones.
- Grep for `gip` / `firebase` / `identitytoolkit` across the app → **zero matches**.

**Dependency change, so read this before merging:** `package-lock.json` was regenerated with `npm install --package-lock-only --ignore-scripts` (+57/−12: the two removals plus `"peer": true` markers on the RNFirebase tree, now reachable only through `mobile-shared`'s peerDep, which is untouched and still resolves for mobile-admin). No version changed. **`npm ci` could not be run here — CI is the real gate. Do not merge on a red lockfile check.**

## Worth knowing

- **This app has effectively no CI.** No `mobile-storefront` workflow exists, nothing runs turbo `check-types`/`lint` over it, and `ci.yml`'s `audit_workspaces` deliberately excludes `apps/mobile-*`. The only coverage is the root `npm ci`. It also has no test suite.
- The Expo Go demo backend previously accepted any email at sign-in; that dev convenience is gone with the unavailable screen.
- `packages/mobile-shared` still declares `@react-native-firebase/auth` as a peerDependency because **mobile-admin needs it** — so the monorepo is not 0% Firebase, only this app is.
