### PR TITLE
feat(billing): expose the compiled plan-feature matrix for console parity (tesserix-home#146)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -2484,6 +2484,7 @@ func main() {
 			EmailTemplateRegistry:   templateLoader,
 			EmailTemplateTestSender: templateTestSender,
 			PriceCatalog:            newServingCatalogResolver(cfg, log),
+			CatalogMode:             cfg.ConsoleCatalogMode,
 		})
 		storefront.RegisterStorefront(r.Group("/api/v1"), storefrontDeps)
 		public.RegisterPublic(r.Group("/api/v1"), public.PublicDeps{
@@ -2636,6 +2637,7 @@ func main() {
 				EmailTemplateRegistry:   templateLoader,
 				EmailTemplateTestSender: templateTestSender,
 				PriceCatalog:            newServingCatalogResolver(cfg, log),
+				CatalogMode:             cfg.ConsoleCatalogMode,
 			})
 			// Public Delhivery webhook receiver. Mounted on the admin
 			// engine because the merchant-configured URL points at the

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_entitlements.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_entitlements.go
@@ -1,0 +1,124 @@
+// services/marketplace-api/internal/handlers/platformadmin/billing_entitlements.go
+package platformadmin
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/marketplace-api/internal/plangate"
+)
+
+// entitlementsSource names the product this matrix belongs to. It matches the
+// `source` vocabulary the console's plan_catalog_entitlements table CHECKs
+// (tesserix-home#146), which is closed at 'mark8ly' today: the column is the
+// seam for a second product, not a live multi-source surface.
+const entitlementsSource = "mark8ly"
+
+// EntitlementsResponse is the wire shape of GET /admin/billing/entitlements.
+//
+// Deliberately NOT wrapped in a `data` envelope, matching
+// LifecycleReasonCodesResponse's sibling reads on this surface only in
+// spirit: the four fields are all top-level because a consumer parity-checking
+// this payload compares whole documents, and an envelope adds a level with
+// nothing in it.
+//
+// Plans is map[plan]map[feature]int rather than a list of rows so the shape
+// mirrors plangate's own two-lookup model exactly — one integer per
+// (plan, feature), read as an entitlement by IsAllowed and as a limit by
+// Limit. Splitting it into "enabled" and "limit" here would invent a
+// distinction the enforcement point does not make, and give the console two
+// things to keep agreeing instead of one.
+type EntitlementsResponse struct {
+	// Source is the product this matrix is enforced by.
+	Source string `json:"source"`
+
+	// CatalogMode is CONSOLE_CATALOG_MODE as this process actually read it —
+	// `test` today, moving at the Stripe live-key swap (mark8ly#371). The
+	// console cannot see that variable and the value is not derivable from
+	// anything it can see, which is the whole reason it is reported here
+	// rather than assumed on the other side. It is passed through verbatim,
+	// including empty: an unset mode must read as unset, never as `test`.
+	CatalogMode string `json:"catalog_mode"`
+
+	// Features is plangate's canonical ordered feature list. Order is part of
+	// the contract, not incidental — a consumer diffing this positionally must
+	// see churn only when the gate changes.
+	Features []string `json:"features"`
+
+	// Plans carries every plan the matrix keys on. A plan absent from the
+	// matrix is absent here rather than published as all-Disabled; see
+	// plangate.AllPlans for why that distinction matters for
+	// subscription.PlanMarketplace.
+	Plans map[string]map[string]int `json:"plans"`
+}
+
+// BillingEntitlementsHandler serves GET /admin/billing/entitlements — the
+// compiled plan-feature matrix, exactly as this binary enforces it.
+//
+// The endpoint exists so the platform console can parity-check the
+// entitlements it stores and displays against what is actually enforced
+// (tesserix-home#146). That purpose is the constraint on the implementation:
+// **every value and every key in the response is DERIVED from plangate at
+// request time and none is restated here.** A hand-typed feature name, plan
+// name or limit would make this file a third copy of the matrix, free to
+// disagree with the gate it claims to describe — and a parity check between
+// two copies of the same mistake reports agreement, which is worse than no
+// check at all.
+//
+// It holds no repository and touches no database. The matrix is compiled into
+// the binary, so this read cannot fail and needs nothing wired.
+type BillingEntitlementsHandler struct {
+	catalogMode string
+	logger      *slog.Logger
+}
+
+// NewBillingEntitlementsHandler builds the handler. catalogMode comes from the
+// same configuration value CONSOLE_CATALOG_MODE feeds (cfg.ConsoleCatalogMode),
+// injected rather than read from the environment here so the response describes
+// the mode THIS process runs with and a test can state one without setting a
+// variable.
+func NewBillingEntitlementsHandler(catalogMode string, logger *slog.Logger) *BillingEntitlementsHandler {
+	return &BillingEntitlementsHandler{catalogMode: catalogMode, logger: logger}
+}
+
+// Register mounts the route unconditionally, for the same reason
+// LifecycleReasonCodesHandler does: it reads a compile-time constant, depends
+// on nothing and can fail in no way. Gating it on any of this surface's
+// optional dependencies would answer 404 in exactly the deployment where the
+// console most needs to see what is enforced.
+//
+// It needs no packages/platformauth entry. RequiredWriteCapabilities covers
+// writes only, and RequiredReadCapabilities is opt-in — every read this
+// surface already serves in production (/admin/audit-logs,
+// /admin/billing/subscriptions, /admin/billing/trials, /admin/health) is
+// absent from it and must stay absent. This is a read of the same kind, so it
+// declares nothing and behaves exactly as its siblings do: signature only.
+func (h *BillingEntitlementsHandler) Register(g *gin.RouterGroup) {
+	g.GET("/admin/billing/entitlements", h.list)
+}
+
+func (h *BillingEntitlementsHandler) list(c *gin.Context) {
+	features := plangate.AllFeatures()
+	names := make([]string, 0, len(features))
+	for _, f := range features {
+		names = append(names, string(f))
+	}
+
+	plans := make(map[string]map[string]int, len(plangate.AllPlans()))
+	for _, p := range plangate.AllPlans() {
+		// AllFeatureLimits is the canonical accessor: it returns EVERY
+		// feature for the plan, defaulting an unset cell to Disabled (0), so
+		// the response can never carry a hole a consumer might read as
+		// permissive.
+		plans[string(p)] = plangate.AllFeatureLimits(p)
+	}
+
+	c.JSON(http.StatusOK, EntitlementsResponse{
+		Source:      entitlementsSource,
+		CatalogMode: h.catalogMode,
+		Features:    names,
+		Plans:       plans,
+	})
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_entitlements_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_entitlements_test.go
@@ -1,0 +1,123 @@
+package platformadmin
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/plangate"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// entitlementsBody is the wire shape as a CONSUMER sees it — decoded from
+// JSON rather than read off the handler's own struct, so a field renamed in
+// the response type fails here instead of passing against itself.
+type entitlementsBody struct {
+	Source      string                    `json:"source"`
+	CatalogMode string                    `json:"catalog_mode"`
+	Features    []string                  `json:"features"`
+	Plans       map[string]map[string]int `json:"plans"`
+}
+
+func decodeEntitlements(t *testing.T, catalogMode string) (int, entitlementsBody) {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	h := NewBillingEntitlementsHandler(catalogMode, slog.Default())
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/billing/entitlements", nil)
+
+	h.list(c)
+
+	var body entitlementsBody
+	if w.Code == http.StatusOK {
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	}
+	return w.Code, body
+}
+
+func TestEntitlementsHandlerReportsTheCompiledMatrix(t *testing.T) {
+	code, body := decodeEntitlements(t, "test")
+
+	require.Equal(t, http.StatusOK, code)
+	require.Equal(t, "mark8ly", body.Source)
+	require.Equal(t, "test", body.CatalogMode)
+	require.Len(t, body.Features, len(plangate.AllFeatures()))
+	require.Len(t, body.Plans, 4)
+
+	// DERIVED, never restated: assert against plangate itself, so a matrix
+	// change moves this test rather than leaving it asserting a stale copy.
+	for _, p := range []subscription.SubscriptionPlan{"trial", "starter", "studio", "pro"} {
+		require.Equal(t, plangate.AllFeatureLimits(p), body.Plans[string(p)])
+	}
+}
+
+// TestEntitlementsHandlerPublishesExactlyTheMatrixPlans is the guard against
+// the plan list becoming a fourth hand-written copy. It compares the keys of
+// `plans` against plangate.AllPlans() — which is itself the matrix's own key
+// set — rather than against the four names spelled out above, so a plan added
+// to or removed from the matrix moves this assertion automatically.
+func TestEntitlementsHandlerPublishesExactlyTheMatrixPlans(t *testing.T) {
+	_, body := decodeEntitlements(t, "test")
+
+	want := make(map[string]bool, len(plangate.AllPlans()))
+	for _, p := range plangate.AllPlans() {
+		want[string(p)] = true
+	}
+	got := make(map[string]bool, len(body.Plans))
+	for name := range body.Plans {
+		got[name] = true
+	}
+	require.Equal(t, want, got)
+
+	// PlanMarketplace exists as a subscription plan but is deliberately
+	// absent from the matrix (hidden platform tier; platform routes bypass
+	// plangate). Publishing it would report "a plan on which nothing is
+	// enabled", which is a different and wrong claim.
+	require.NotContains(t, got, string(subscription.PlanMarketplace))
+}
+
+// TestEntitlementsHandlerFeaturesAreTheCanonicalList pins the feature array to
+// plangate.AllFeatures() including its ORDER — the response is a parity
+// target, and a consumer diffing it positionally must not see churn that the
+// gate did not produce.
+func TestEntitlementsHandlerFeaturesAreTheCanonicalList(t *testing.T) {
+	_, body := decodeEntitlements(t, "test")
+
+	want := make([]string, 0, len(plangate.AllFeatures()))
+	for _, f := range plangate.AllFeatures() {
+		want = append(want, string(f))
+	}
+	require.Equal(t, want, body.Features)
+}
+
+// TestEntitlementsHandlerReportsTheConfiguredCatalogMode covers the reason the
+// field exists at all: the console cannot see CONSOLE_CATALOG_MODE, and the
+// value moves at the Stripe live-key swap. Reporting a constant would go
+// silently wrong on that day.
+func TestEntitlementsHandlerReportsTheConfiguredCatalogMode(t *testing.T) {
+	for _, mode := range []string{"test", "live", ""} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			_, body := decodeEntitlements(t, mode)
+			require.Equal(t, mode, body.CatalogMode)
+		})
+	}
+}
+
+// TestEntitlementsRouteMounts proves Register puts the handler on the path the
+// console federates, not merely that list() works when called directly.
+func TestEntitlementsRouteMounts(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	NewBillingEntitlementsHandler("test", slog.Default()).Register(r.Group(""))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/admin/billing/entitlements", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+}

--- a/services/marketplace-api/internal/handlers/platformadmin/routes.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/routes.go
@@ -244,6 +244,19 @@ type Deps struct {
 	// unsetting CONSOLE_CATALOG_* in the chart reverts this surface to the
 	// compiled amounts without a code change. See compiledPriceCatalog.
 	PriceCatalog CatalogResolver
+
+	// CatalogMode is CONSOLE_CATALOG_MODE (cfg.ConsoleCatalogMode), reported
+	// verbatim by GET /admin/billing/entitlements so the console knows which
+	// catalog mode this process reads — `test` today, moving at the Stripe
+	// live-key swap. It is a plain string, not a dependency: an empty value
+	// unmounts nothing and is published as empty rather than defaulted to
+	// `test`, because a console told `test` by a service that was never
+	// configured would parity-check the wrong mode and report agreement.
+	//
+	// Both main.go call sites must set it. A site that forgets leaves that
+	// binary path reporting an empty mode while every other field looks
+	// right, which reads as a configuration problem rather than a wiring one.
+	CatalogMode string
 }
 
 // TenantGateInvalidator drops a tenant's cached admin-gate status. Declared
@@ -333,6 +346,13 @@ func Register(g *gin.RouterGroup, deps Deps) {
 	if deps.AllSubscriptions != nil && deps.TenantDirectory != nil {
 		NewBillingSubscriptionsHandler(deps.AllSubscriptions, deps.TenantDirectory, deps.DB, deps.PriceCatalog, deps.Logger).Register(group)
 	}
+
+	// The compiled plan-feature matrix (tesserix-home#146). Mounted
+	// unconditionally, beside health and the lifecycle reason codes and for
+	// the same reason: it reads a compile-time constant and depends on
+	// nothing. Gating it on the billing dependencies above would hide what is
+	// enforced in exactly the deployment where the console needs to see it.
+	NewBillingEntitlementsHandler(deps.CatalogMode, deps.Logger).Register(group)
 
 	if deps.Tickets != nil {
 		NewTicketsHandler(deps.DB, deps.Tickets, deps.Logger).Register(group)

--- a/services/marketplace-api/internal/plangate/matrix.go
+++ b/services/marketplace-api/internal/plangate/matrix.go
@@ -4,6 +4,7 @@
 package plangate
 
 import (
+	"slices"
 	"time"
 
 	"github.com/mark8ly/marketplace-api/internal/subscription"
@@ -111,6 +112,44 @@ func AllFeatures() []Feature {
 	out := make([]Feature, len(allFeatures))
 	copy(out, allFeatures)
 	return out
+}
+
+// AllPlans returns the plans featureMatrix actually keys on, public tier
+// order first.
+//
+// DERIVED from the matrix, never restated. A caller that publishes "the
+// plans" from a hand-written list is describing a matrix that may no
+// longer exist: a plan added to or removed from featureMatrix would leave
+// that list silently wrong while every one of its own tests still passed.
+// The public-plan order is used only for ORDERING; membership comes from
+// the matrix alone, and any matrix plan the public list does not know
+// about is appended (sorted, so the output is deterministic) rather than
+// dropped.
+//
+// subscription.PlanMarketplace is deliberately absent from the matrix —
+// it is a hidden platform tier and platform routes bypass plangate — so
+// it is absent here too. That is not an omission to fix: AllFeatureLimits
+// would answer all-Disabled for it, which would publish "marketplace is a
+// plan on which nothing is enabled" rather than "marketplace is not gated
+// by this matrix".
+func AllPlans() []subscription.SubscriptionPlan {
+	out := make([]subscription.SubscriptionPlan, 0, len(featureMatrix))
+	seen := make(map[subscription.SubscriptionPlan]bool, len(featureMatrix))
+	for _, p := range subscription.AllPublicPlans() {
+		if _, ok := featureMatrix[p]; ok {
+			out = append(out, p)
+			seen[p] = true
+		}
+	}
+
+	rest := make([]subscription.SubscriptionPlan, 0)
+	for p := range featureMatrix {
+		if !seen[p] {
+			rest = append(rest, p)
+		}
+	}
+	slices.Sort(rest)
+	return append(out, rest...)
 }
 
 type planLimits map[Feature]int

--- a/services/marketplace-api/internal/plangate/matrix_test.go
+++ b/services/marketplace-api/internal/plangate/matrix_test.go
@@ -239,3 +239,34 @@ func TestImagesAllowed_Trial_NoGrandfathering(t *testing.T) {
 	require.Equal(t, 50,
 		plangate.ImagesAllowed(subscription.PlanTrial, old, &changedAt))
 }
+
+// TestAllPlans_IsExactlyTheMatrixKeySet pins AllPlans to the matrix rather
+// than to a list of names. Publishing "the plans" from a hand-written list is
+// how a consumer ends up describing a matrix that no longer exists, so the
+// assertion checks membership against featureMatrix's own behaviour: every
+// plan AllPlans reports must have at least one non-Disabled cell (i.e. it is
+// really in the matrix), and PlanMarketplace — absent from the matrix by
+// design — must not appear.
+func TestAllPlans_IsExactlyTheMatrixKeySet(t *testing.T) {
+	plans := plangate.AllPlans()
+	require.Equal(t, []subscription.SubscriptionPlan{
+		subscription.PlanTrial,
+		subscription.PlanStarter,
+		subscription.PlanStudio,
+		subscription.PlanPro,
+	}, plans, "the matrix keys on four plans; update this when the matrix changes, not before")
+
+	for _, p := range plans {
+		anyEnabled := false
+		for _, f := range plangate.AllFeatures() {
+			if plangate.IsAllowed(p, f) {
+				anyEnabled = true
+				break
+			}
+		}
+		require.Truef(t, anyEnabled, "plan %s is reported by AllPlans but enables nothing — it is not really in the matrix", p)
+	}
+
+	require.NotContains(t, plans, subscription.PlanMarketplace,
+		"PlanMarketplace bypasses plangate; publishing it would report a plan on which nothing is enabled")
+}


### PR DESCRIPTION
## What

Adds `GET /admin/billing/entitlements` to the platform-admin surface: a thin,
read-only report of the plan-feature matrix this binary actually enforces.

```json
{"source":"mark8ly","catalog_mode":"test",
 "features":["stores", ...],
 "plans":{"trial":{...},"starter":{...},"studio":{...},"pro":{...}}}
```

## Why

tesserix-home#146 gives the platform console a versioned record of what each
plan entitles a tenant to. That record is a second copy of something already
compiled into this service, and two copies drift. This endpoint is the
comparison target that makes the drift visible: the console parity-checks its
stored entitlements against what is enforced here, using the same runner the
plan-catalog prices already use.

## It derives, it does not restate

Every value and every key in the response comes from `plangate` at request
time:

- feature names and their order — `plangate.AllFeatures()`
- every plan's cells — `plangate.AllFeatureLimits(plan)`, which returns every
  feature and defaults an unset cell to `Disabled` (0), so the payload can
  never carry a hole a consumer might read as permissive
- the plan list — a new `plangate.AllPlans()`, derived from `featureMatrix`'s
  own key set

Nothing is typed by hand. A hand-written copy here would be a third copy of
the matrix, free to disagree with the gate it claims to describe — and a
parity check between two copies of the same mistake reports agreement, which
is worse than no check at all. `AllPlans()` exists for exactly that reason:
hard-coding the four plan names would have half-broken the rule at the level
where it is easiest to miss. `subscription.PlanMarketplace` is deliberately
absent from the matrix (hidden platform tier; platform routes bypass plangate)
and so is absent from the response — publishing it would report "a plan on
which nothing is enabled", a different and wrong claim.

## catalog_mode

`CONSOLE_CATALOG_MODE` as this process read it, passed through verbatim,
including empty. The console cannot see that variable and cannot derive it;
hard-coding `test` on the console side would go silently wrong at the Stripe
live-key swap, when parity would then run against the mode nobody reads.

## Wiring

`Deps.CatalogMode` is set at **both** `platformadmin.Register` call sites in
`cmd/marketplace-api/main.go` — the merged `mode.Both` engine and the
`mode.Admin` engine. Wiring one would leave a binary path reporting an empty
mode while everything else looked correct.

No `packages/platformauth` entry: `RequiredWriteCapabilities` covers writes
only, and `RequiredReadCapabilities` is opt-in — every read this surface
already serves in production (`/admin/audit-logs`,
`/admin/billing/subscriptions`, `/admin/billing/trials`, `/admin/health`) is
absent from it and must stay absent. This read behaves exactly as its
siblings do: signature only.

The route mounts unconditionally, beside `/admin/health` and
`/admin/lifecycle/reason-codes`, because it reads a compile-time constant and
depends on nothing. Gating it on the billing dependencies would hide what is
enforced in exactly the deployment where the console needs to see it.

## Tests

`go build ./...`, `go vet ./...` clean. `go test ./internal/handlers/platformadmin/`
— 395 passing, 1 pre-existing skip (`TestConformanceDeclarationMatchesChartCopy`,
which needs a sibling `tesserix-k8s` checkout). `go test ./internal/plangate/`
green.

The handler tests assert against `plangate` itself rather than against
expected literals, so a matrix change moves the test instead of leaving it
asserting a stale copy. Mutation-checked: renaming a plan key inside
`featureMatrix` fails both the handler test and the new `AllPlans` test.

## Consumed by

tesserix-home#146 — platform-api federates this as `/v1/billing/entitlements`,
and the console seeds and parity-checks from it. That work cannot be verified
end to end until this is merged **and deployed**.
