### PR TITLE
fix(customer): drop the gip_uid column and its dead unique index (#793)

### DIFF
--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 133
+const ExpectedSchemaVersion uint = 134

--- a/services/marketplace-api/migrations/000134_drop_customer_profiles_gip_uid.down.sql
+++ b/services/marketplace-api/migrations/000134_drop_customer_profiles_gip_uid.down.sql
@@ -1,0 +1,9 @@
+-- Restores the column and its partial unique index.
+--
+-- Values are NOT recoverable: the GIP identities they held are gone with the
+-- Identity Platform tenant pools, and nothing has written this column since
+-- #814. A rollback gives back the shape, not the data.
+ALTER TABLE customer_profiles ADD COLUMN IF NOT EXISTS gip_uid TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS customer_profiles_store_gip_uid_uq
+    ON customer_profiles (store_id, gip_uid)
+    WHERE gip_uid IS NOT NULL;

--- a/services/marketplace-api/migrations/000134_drop_customer_profiles_gip_uid.up.sql
+++ b/services/marketplace-api/migrations/000134_drop_customer_profiles_gip_uid.up.sql
@@ -1,0 +1,20 @@
+-- Drops customer_profiles.gip_uid and its partial unique index (#793).
+--
+-- The column was the customer identity key under GIP. Every reader and writer
+-- was removed in #814 (deployed before this migration, per the code-first rule
+-- the whole GIP removal followed): sessionClaims.UIDOrGipUID became
+-- IdentityUID and returns the Zitadel uid only, GetProfileByGipUID had no
+-- callers, and the upsert no longer writes the column.
+--
+-- Data: 1 of 5 production rows carried a non-null gip_uid when this was
+-- written. That customer's session already fails closed after #814 (a cookie
+-- carrying only a gip_uid is rejected rather than admitted with an empty
+-- identity), so they re-authenticate and are matched on their verified email
+-- like everyone else. Nothing is silently rebound.
+--
+-- The index goes with the column. 000084 created it to close a Phase 2/3 race
+-- on (store_id, gip_uid); with the column always NULL since #814 it constrains
+-- nothing, and Postgres would drop it with the column regardless -- naming it
+-- here keeps the intent explicit rather than incidental.
+DROP INDEX IF EXISTS customer_profiles_store_gip_uid_uq;
+ALTER TABLE customer_profiles DROP COLUMN IF EXISTS gip_uid;


### PR DESCRIPTION
Completes the **schema** half of #793. The three GCP tenant pools are deliberately untouched — those need explicit approval and are the only irreversible step left in this milestone.

## Code-first, and the gate was checked

`#814` removed every reader and writer of `customer_profiles.gip_uid`, and I confirmed it is **live in production** before writing this migration:

```
mark8ly-marketplace-api-storefront  ->  main-01fbae8   (contains #814)
```

A grep for `gip_uid` / `GipUID` across non-test Go now returns **only comments**.

## What drops

`customer_profiles.gip_uid`, plus `customer_profiles_store_gip_uid_uq` — the partial unique index `000084` created to close a Phase 2/3 race on `(store_id, gip_uid)`. With the column always NULL since #814 it constrains nothing. Postgres would drop it with the column anyway; naming it makes the intent explicit rather than incidental.

## The one row

Production has **1 of 5** `customer_profiles` rows with a non-null `gip_uid`.

That customer's session already fails closed after #814 — a cookie carrying only a `gip_uid` is rejected rather than admitted with an empty identity — so they re-authenticate and are matched on their verified email like everyone else. **Nothing is silently rebound to another account**, which was the failure mode worth designing against.

## The `down` migration is honest

It restores the column and the index, and says plainly that **the values are not recoverable**: the GIP identities they held go with the Identity Platform tenant pools, and nothing has written the column since #814. A rollback returns the shape, not the data. That seemed better than a reassuring comment that would mislead whoever runs it.

## Verification

`go build ./...` OK; `go vet ./...` OK; `go test ./...` → **105 packages ok, 0 FAIL**. `ExpectedSchemaVersion` bumped to **134** — the guard that caught me on #812, where I added a migration and forgot the constant.

## After this

#793 is down to the tenant pools alone. `tenants.owner_user_id` **stays** — it holds a Zitadel user id; only its meaning changed, and #791 corrected the doc comment that still claimed otherwise.
