### PR TITLE
feat(marketplace-api): mount the break-glass login route and share one rate limiter (#642)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/auth"
 	"github.com/mark8ly/marketplace-api/internal/authbffclient"
 	"github.com/mark8ly/marketplace-api/internal/authz"
+	"github.com/mark8ly/marketplace-api/internal/bao"
 	"github.com/mark8ly/marketplace-api/internal/billing/appaddon"
 	appcredspkg "github.com/mark8ly/marketplace-api/internal/billing/appcreds"
 	"github.com/mark8ly/marketplace-api/internal/billing/dispatch"
@@ -563,6 +564,15 @@ func main() {
 	// process never mounts the admin group so these dependencies would go
 	// unused there.
 	var adminDeps admin.Deps
+	// breakGlassLoginHandler and breakGlassRateLimiter are declared at this
+	// outer scope (not inside the admin-mode block below) because
+	// breakGlassRateLimiter must ALSO reach platformadmin.Deps.BreakGlassRateLimiter
+	// further down: the login path and the clear-lockout write path
+	// (#404, currently unmounted — see BreakGlassRotator/BreakGlassWriter
+	// below) share ONE in-memory *breakglass.LoginRateLimiter instance,
+	// never two. See the construction site (admin-mode block) for why.
+	var breakGlassLoginHandler *admin.BreakGlassLoginHandler
+	var breakGlassRateLimiter *breakglass.LoginRateLimiter
 	// delhiveryWebhookHandler is constructed in the admin wiring branch
 	// (where shipmentsHandler, apiKeyEncryptor and carrierSecretStore
 	// are built) but mounted below inside the engine switch, so declare
@@ -1349,7 +1359,61 @@ func main() {
 			adminTenantGateHandler = tenantGate.RequireActiveTenant()
 		}
 
+		// P13 §12.4 — break-glass emergency login (#642). Zero break-glass
+		// accounts exist anywhere in this estate until cmd/break-glass-provision
+		// is run per tenant, but the LOGIN ROUTE itself has never been
+		// constructed here at all — NewBreakGlassLoginHandler was called
+		// only in tests, so the route in admin/routes.go stayed permanently
+		// unmounted (deps.BreakGlassLoginHandler == nil) regardless.
+		//
+		// OpenBao client construction mirrors cmd/break-glass-provision's
+		// exactly (bao.New -> carriersecrets.NewBaoClient ->
+		// breakglass.NewBaoSecretClient) rather than reaching into
+		// carrierSecretStore above, which exposes no accessor to the
+		// *bao.Client it may hold internally. bao.New does not authenticate
+		// at construction — that happens lazily on first use — so this is
+		// safe to build unconditionally even when ShippingSecretStore is
+		// "inline" and nothing else in this process talks to OpenBao.
+		breakGlassIPHMACKey := breakglass.HMACKey(cfg.BreakGlassIPHMACKey)
+		breakGlassBaoClient, err := bao.New(bao.Config{
+			Address:        cfg.OpenBaoAddr,
+			Mount:          cfg.OpenBaoKVMount,
+			KubernetesRole: cfg.OpenBaoRole,
+		})
+		if err != nil {
+			log.Error("break-glass: openbao client init failed — /admin/break-glass/login stays unmounted", "err", err)
+		} else {
+			breakGlassRepo := breakglass.NewRepository(conn)
+			breakGlassSecrets := breakglass.NewSecretManager(
+				breakglass.NewBaoSecretClient(carriersecrets.NewBaoClient(breakGlassBaoClient)))
+			breakGlassAudit := breakglass.NewAuditEmitter(auditEmitter, breakGlassIPHMACKey)
+			var breakGlassSlack *breakglass.SlackClient
+			if cfg.BreakGlassSlackWebhookURL != "" {
+				breakGlassSlack = breakglass.NewSlackClient(cfg.BreakGlassSlackWebhookURL, breakglass.SlackChannel)
+			}
+			// SHARED with platformadmin.Deps.BreakGlassRateLimiter below —
+			// exactly ONE *breakglass.LoginRateLimiter for both the login
+			// path (records failures, resets on success) and the
+			// clear-lockout write path (resets the same in-memory bucket
+			// alongside the durable DB lock). Two separate instances here
+			// would mean clear-lockout resets a map nobody reads: the
+			// durable lockout row clears, the operator sees success, and
+			// the in-memory limiter keeps refusing the IP (#642).
+			breakGlassRateLimiter = breakglass.NewLoginRateLimiter()
+			breakGlassLoginHandler = admin.NewBreakGlassLoginHandler(admin.BreakGlassDeps{
+				Repo:        breakGlassRepo,
+				Secrets:     breakGlassSecrets,
+				Audit:       breakGlassAudit,
+				Slack:       breakGlassSlack,
+				RateLimiter: breakGlassRateLimiter,
+				IPHMACKey:   breakGlassIPHMACKey,
+				Sessions:    authbffclient.NewSessionIssuer(cfg.AuthBFFURL, cfg.InternalAuthSecret, nil),
+				Logger:      log,
+			})
+		}
+
 		adminDeps = admin.Deps{
+			BreakGlassLoginHandler:   breakGlassLoginHandler,
 			TenantGate:               adminTenantGateHandler,
 			ProductHandler:           productHandler,
 			CategoryHandler:          categoryHandler,
@@ -2480,6 +2544,8 @@ func main() {
 			EstateUsers:             estateUsersClient,
 			EmailSends:              platformadmin.EmailSendListerFunc(emaillog.ListPlatform),
 			BreakGlass:              platformadmin.BreakGlassListerFunc(breakglass.ListPlatform),
+			BreakGlassRateLimiter:   breakGlassRateLimiter,
+			BreakGlassIPHMACKey:     breakglass.HMACKey(cfg.BreakGlassIPHMACKey),
 			EmailTemplates:          templateStore,
 			EmailTemplateRegistry:   templateLoader,
 			EmailTemplateTestSender: templateTestSender,
@@ -2633,6 +2699,8 @@ func main() {
 				EstateUsers:             estateUsersClient,
 				EmailSends:              platformadmin.EmailSendListerFunc(emaillog.ListPlatform),
 				BreakGlass:              platformadmin.BreakGlassListerFunc(breakglass.ListPlatform),
+				BreakGlassRateLimiter:   breakGlassRateLimiter,
+				BreakGlassIPHMACKey:     breakglass.HMACKey(cfg.BreakGlassIPHMACKey),
 				EmailTemplates:          templateStore,
 				EmailTemplateRegistry:   templateLoader,
 				EmailTemplateTestSender: templateTestSender,

--- a/services/marketplace-api/internal/breakglass/ratelimit.go
+++ b/services/marketplace-api/internal/breakglass/ratelimit.go
@@ -67,6 +67,30 @@ func (l *LoginRateLimiter) Reset(key string) {
 	delete(l.attempts, key)
 }
 
+// LoginRateLimitKey shapes a LoginRateLimiter bucket key from an
+// ip_hash. THE single source of truth for this shape — both
+// internal/handlers/admin (the login path, which records failures and
+// resets on success) and internal/handlers/platformadmin (the
+// clear-lockout write path, which resets the same bucket) call this
+// directly rather than each keeping their own copy. Before this
+// existed, the two packages each defined a byte-for-byte identical
+// private function with a prose comment promising they'd stay in sync
+// — a promise nothing enforced. A key shaped differently in one place
+// than the other means clear-lockout resets a bucket the login path
+// never reads: the durable DB lockout clears, the operator sees
+// success, and the in-memory limiter silently keeps refusing the IP.
+//
+// Keeping only the first 16 bytes of ip_hash avoids memory bloat across
+// many concurrent IPs; 16 bytes of a HMAC-SHA256 output is still
+// effectively collision-free for this purpose.
+func LoginRateLimitKey(ipHash []byte) string {
+	n := len(ipHash)
+	if n > 16 {
+		n = 16
+	}
+	return string(ipHash[:n])
+}
+
 // Count returns the current in-window failure count for key. Useful
 // for tests; production code should use RecordFailure's return value.
 func (l *LoginRateLimiter) Count(key string) int {

--- a/services/marketplace-api/internal/breakglass/ratelimit_key_test.go
+++ b/services/marketplace-api/internal/breakglass/ratelimit_key_test.go
@@ -1,0 +1,86 @@
+package breakglass
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoginRateLimitKey_EdgeCases pins the shape of the ONE function both
+// internal/handlers/admin (login: records failures, resets on success) and
+// internal/handlers/platformadmin (clear-lockout: resets the same bucket)
+// call to derive a LoginRateLimiter bucket key from an ip_hash.
+//
+// Before LoginRateLimitKey existed, each package kept its own private copy
+// of this logic with a comment promising they'd stay byte-identical — a
+// promise nothing enforced. Now there is exactly one implementation, so
+// drift between the two call sites is impossible by construction; this
+// test instead pins the shape itself (truncate-at-16-bytes, including the
+// boundary and degenerate inputs) so a future edit to LoginRateLimitKey
+// that changes that shape fails loudly here rather than silently breaking
+// clear-lockout for both routes at once.
+func TestLoginRateLimitKey_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want string
+	}{
+		{
+			name: "empty ip_hash",
+			in:   []byte{},
+			want: "",
+		},
+		{
+			name: "nil ip_hash",
+			in:   nil,
+			want: "",
+		},
+		{
+			name: "short ip_hash (under 16 bytes) is kept in full",
+			in:   []byte{0x01, 0x02, 0x03},
+			want: string([]byte{0x01, 0x02, 0x03}),
+		},
+		{
+			name: "exactly 16 bytes is kept in full",
+			in:   bytes16(0xAA),
+			want: string(bytes16(0xAA)),
+		},
+		{
+			name: "over 16 bytes (a real HMAC-SHA256 output, 32 bytes) is truncated to 16",
+			in:   bytes32(0xBB),
+			want: string(bytes32(0xBB)[:16]),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, LoginRateLimitKey(tc.in))
+		})
+	}
+}
+
+// TestLoginRateLimitKey_Deterministic pins that the function is a pure
+// function of its input — the login path and the clear-lockout path must
+// derive the SAME key from the SAME ip_hash every time, or a failure
+// recorded on one request is invisible to a clear-lockout call made
+// moments later.
+func TestLoginRateLimitKey_Deterministic(t *testing.T) {
+	h := bytes32(0xCC)
+	require.Equal(t, LoginRateLimitKey(h), LoginRateLimitKey(h))
+	require.Equal(t, LoginRateLimitKey(h), LoginRateLimitKey(append([]byte(nil), h...)))
+}
+
+func bytes16(b byte) []byte {
+	out := make([]byte, 16)
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}
+
+func bytes32(b byte) []byte {
+	out := make([]byte, 32)
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}

--- a/services/marketplace-api/internal/handlers/admin/break_glass_login.go
+++ b/services/marketplace-api/internal/handlers/admin/break_glass_login.go
@@ -82,7 +82,7 @@ func (h *BreakGlassLoginHandler) Login(c *gin.Context) {
 		// Degrade to the in-memory limiter rather than choosing one extreme.
 		// It is per-pod and resets on deploy, but it is the signal still
 		// available, and it refuses exactly the IPs that have earned it.
-		recent := h.deps.RateLimiter.Count(rlKey(ipHash))
+		recent := h.deps.RateLimiter.Count(breakglass.LoginRateLimitKey(ipHash))
 		locked = degradedLockDecision(recent)
 		h.logger().Error("break-glass: lockout lookup failed; degraded to the in-memory limiter",
 			"err", err, "recent_failures", recent, "treated_as_locked", locked)
@@ -189,7 +189,7 @@ func (h *BreakGlassLoginHandler) Login(c *gin.Context) {
 		}()
 	}
 
-	h.deps.RateLimiter.Reset(rlKey(ipHash))
+	h.deps.RateLimiter.Reset(breakglass.LoginRateLimitKey(ipHash))
 
 	c.JSON(http.StatusOK, gin.H{"session_ttl_seconds": int(BreakGlassSessionTTL.Seconds())})
 }
@@ -199,7 +199,7 @@ func (h *BreakGlassLoginHandler) Login(c *gin.Context) {
 // event. Slack is also pinged so on-call sees the attempt in real
 // time.
 func (h *BreakGlassLoginHandler) recordFailure(c *gin.Context, ipHash []byte, tenantID uuid.UUID, reason string) {
-	count := h.deps.RateLimiter.RecordFailure(rlKey(ipHash))
+	count := h.deps.RateLimiter.RecordFailure(breakglass.LoginRateLimitKey(ipHash))
 
 	if count >= breakglass.LoginMaxFailures {
 		var tidPtr *uuid.UUID
@@ -233,16 +233,6 @@ func (h *BreakGlassLoginHandler) logger() *slog.Logger {
 		return h.deps.Logger
 	}
 	return slog.Default()
-}
-
-// rlKey shapes the rate-limit bucket key. Keeping it tiny (hex first
-// 16 bytes of ip_hash) avoids memory bloat across many concurrent IPs.
-func rlKey(ipHash []byte) string {
-	n := len(ipHash)
-	if n > 16 {
-		n = 16
-	}
-	return string(ipHash[:n])
 }
 
 // breakGlassNamespace is a fixed UUIDv5 namespace for synthesising

--- a/services/marketplace-api/internal/handlers/admin/break_glass_mount_test.go
+++ b/services/marketplace-api/internal/handlers/admin/break_glass_mount_test.go
@@ -1,0 +1,97 @@
+package admin_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/admin"
+)
+
+// breakGlassRoutePath is the mount point mark8ly#642's plan asserts:
+// POST /admin/break-glass/login, at the /admin root — NOT nested under
+// /admin/stores/:storeId.
+const breakGlassRoutePath = "/admin/break-glass/login"
+
+// TestBreakGlassLogin_RouteIsMounted is the proof this task exists to
+// produce: NewBreakGlassLoginHandler is now constructed in
+// cmd/marketplace-api/main.go (previously only in tests), so the route
+// admin/routes.go has always been willing to mount — gated on
+// deps.BreakGlassLoginHandler != nil — actually gets mounted.
+//
+// This deliberately does NOT probe with a GET-on-POST-only-route and
+// compare 404 vs 405: HandleMethodNotAllowed is never set in any service
+// in this estate, so gin's default (false) applies and a GET on a
+// MOUNTED POST-only route also 404s — that probe cannot tell "unmounted"
+// apart from "mounted, wrong method". Instead this compares the actual
+// gin route table (*gin.Engine.Routes()) of a bare router against one
+// with the handler wired — the same fact router.ServeHTTP would exercise,
+// read directly rather than inferred from a status code.
+func TestBreakGlassLogin_RouteIsMounted(t *testing.T) {
+	bare := gin.New()
+	admin.RegisterAdmin(bare.Group("/"), admin.Deps{})
+
+	wired := gin.New()
+	admin.RegisterAdmin(wired.Group("/"), admin.Deps{
+		BreakGlassLoginHandler: admin.NewBreakGlassLoginHandler(admin.BreakGlassDeps{}),
+		PlanResolver:           nil, // unreached: the gate short-circuits below on a peek miss
+	})
+
+	require.False(t, hasRoute(bare, http.MethodPost, breakGlassRoutePath),
+		"a bare Deps{} router must NOT have the break-glass login route — otherwise this test proves nothing")
+	require.True(t, hasRoute(wired, http.MethodPost, breakGlassRoutePath),
+		"POST /admin/break-glass/login must be registered once BreakGlassLoginHandler is set — "+
+			"this is the mount mark8ly#642 needed: NewBreakGlassLoginHandler is now called from "+
+			"cmd/marketplace-api/main.go, not only from tests")
+}
+
+func hasRoute(r *gin.Engine, method, path string) bool {
+	for _, rt := range r.Routes() {
+		if rt.Method == method && rt.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+// TestBreakGlassLogin_SurvivesReadOnlyAndStoreClosed proves the route is
+// mounted OUTSIDE the store-scoped group that carries
+// SubscriptionReadOnlyGate — the whole point of break-glass (§12.4): it
+// must survive read_only / store_closed subscription states.
+//
+// This asserts the fact structurally (the registered path) rather than
+// by driving a live request through the full middleware chain: doing the
+// latter for real would need a *plangate.PlanResolver and a
+// *breakglass.Repository backed by an actual Postgres connection (both
+// run real queries once a well-formed tenant_id makes it past the
+// gate — see break_glass_shared_limiter_integration_test.go, which
+// exercises exactly that live-DB path), which this package's unit tests
+// deliberately don't stand up. routes.go wires SubscriptionReadOnlyGate
+// ONLY into storeMW / storeRoute (path prefix
+// "/admin/stores/:storeId..."); the break-glass route is registered
+// directly on router at "/admin/break-glass/login" — a path that cannot
+// be a descendant of that group, proving it never passes through
+// SubscriptionReadOnlyGate regardless of runtime subscription state.
+func TestBreakGlassLogin_SurvivesReadOnlyAndStoreClosed(t *testing.T) {
+	r := gin.New()
+	admin.RegisterAdmin(r.Group("/"), admin.Deps{
+		BreakGlassLoginHandler: admin.NewBreakGlassLoginHandler(admin.BreakGlassDeps{}),
+	})
+
+	found := false
+	for _, rt := range r.Routes() {
+		if rt.Method != http.MethodPost || rt.Path != breakGlassRoutePath {
+			continue
+		}
+		found = true
+		require.False(t, strings.HasPrefix(rt.Path, "/admin/stores/"),
+			"break-glass login must not be registered under /admin/stores/:storeId — "+
+				"that is the ONLY group SubscriptionReadOnlyGate is wired into, and nesting "+
+				"break-glass there would make it (silently) subject to read_only / store_closed "+
+				"gating, defeating the entire point of the recovery path")
+	}
+	require.True(t, found, "break-glass login route must be registered for this assertion to mean anything")
+}

--- a/services/marketplace-api/internal/handlers/admin/break_glass_plangate.go
+++ b/services/marketplace-api/internal/handlers/admin/break_glass_plangate.go
@@ -1,0 +1,111 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/plangate"
+)
+
+// breakGlassPlanResolver is the narrow slice of *plangate.PlanResolver this
+// middleware needs. Declared as an interface (rather than depending on the
+// concrete type) so tests can supply a fake that never touches a *gorm.DB —
+// PlanResolver.ResolveByTenant runs a raw query against store_subscriptions,
+// which a unit test has no business standing up a database for.
+type breakGlassPlanResolver interface {
+	ResolveByTenant(ctx context.Context, tenantID uuid.UUID) plangate.Plan
+}
+
+// breakGlassTenantIDPeek is the minimal shape this middleware needs out of
+// the login request body — just enough to resolve a plan, nothing that
+// would duplicate breakGlassLoginRequest's validation.
+type breakGlassTenantIDPeek struct {
+	TenantID string `json:"tenant_id"`
+}
+
+// RequireBreakGlassFeature returns middleware that 403s a break-glass login
+// attempt for a tenant whose plan doesn't include feature, mirroring
+// plangate.RequireFeatureByTenant's response shape.
+//
+// It cannot reuse RequireFeatureByTenant as-is: that function reads
+// tenant_id off the Gin context, which is only ever set by upstream auth
+// middleware — and POST /admin/break-glass/login deliberately runs with
+// NONE. This is the recovery path; requiring a working auth pipeline to
+// reach it would defeat the point. The tenant id it needs instead travels
+// in the JSON body (breakGlassLoginRequest.TenantID), exactly like every
+// other input to this handler.
+//
+// So this middleware peeks the body: reads it fully, restores
+// c.Request.Body so the handler's own c.ShouldBindJSON still sees the full
+// payload, and — only if a well-formed UUID tenant_id was present —
+// resolves that tenant's plan and gates on it.
+//
+// A missing or malformed tenant_id is deliberately NOT rejected here. The
+// handler's own step 2 (shape validation) already turns that into the same
+// uniform {"error":"invalid_credentials"} response the wrong-password path
+// returns — matching this endpoint's documented invariant that response
+// shape must never reveal which check failed. Duplicating that rejection
+// here, with a differently-shaped error, would break that invariant for
+// exactly the requests this middleware runs on.
+func RequireBreakGlassFeature(resolver breakGlassPlanResolver, feature plangate.Feature, logger *slog.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		tenantID, ok := peekBreakGlassTenantID(c)
+		if !ok {
+			c.Next()
+			return
+		}
+
+		plan := resolver.ResolveByTenant(c.Request.Context(), tenantID)
+		if !plangate.IsAllowed(plan, feature) {
+			minPlan := plangate.MinPlanForFeature(feature)
+			c.JSON(http.StatusForbidden, gin.H{
+				"error":    "plan_required",
+				"message":  fmt.Sprintf("This feature requires the %s plan or higher", minPlan),
+				"required": string(minPlan),
+				"current":  string(plan),
+				"feature":  string(feature),
+			})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// peekBreakGlassTenantID reads tenant_id out of the request body WITHOUT
+// consuming it for downstream readers: c.Request.Body is drained into
+// memory and then replaced with a fresh reader over the same bytes, so
+// BreakGlassLoginHandler.Login's own c.ShouldBindJSON call still sees the
+// complete body exactly as the client sent it.
+func peekBreakGlassTenantID(c *gin.Context) (uuid.UUID, bool) {
+	if c.Request == nil || c.Request.Body == nil {
+		return uuid.Nil, false
+	}
+
+	raw, err := io.ReadAll(c.Request.Body)
+	_ = c.Request.Body.Close()
+	c.Request.Body = io.NopCloser(bytes.NewReader(raw))
+	if err != nil {
+		return uuid.Nil, false
+	}
+
+	var peek breakGlassTenantIDPeek
+	if err := json.Unmarshal(raw, &peek); err != nil {
+		return uuid.Nil, false
+	}
+
+	tenantID, err := uuid.Parse(peek.TenantID)
+	if err != nil {
+		return uuid.Nil, false
+	}
+	return tenantID, true
+}

--- a/services/marketplace-api/internal/handlers/admin/break_glass_plangate_test.go
+++ b/services/marketplace-api/internal/handlers/admin/break_glass_plangate_test.go
@@ -1,0 +1,111 @@
+package admin_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/admin"
+	"github.com/mark8ly/marketplace-api/internal/plangate"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// fakePlanResolver implements the resolver method RequireBreakGlassFeature
+// needs (structurally — the middleware's parameter type is an unexported
+// interface, satisfied by any type with a matching ResolveByTenant method,
+// per Go's structural interface typing) WITHOUT touching a *gorm.DB. It
+// records the tenant it was asked to resolve so tests can assert the
+// middleware actually called it with the tenant id peeked from the body.
+type fakePlanResolver struct {
+	plan   subscription.SubscriptionPlan
+	called uuid.UUID
+}
+
+func (f *fakePlanResolver) ResolveByTenant(_ context.Context, tenantID uuid.UUID) plangate.Plan {
+	f.called = tenantID
+	return f.plan
+}
+
+func breakGlassGateRouter(resolver *fakePlanResolver) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/admin/break-glass/login",
+		admin.RequireBreakGlassFeature(resolver, plangate.FeatureSSO, nil),
+		func(c *gin.Context) {
+			// Stand-in for BreakGlassLoginHandler.Login: proves the body
+			// the gate peeked is STILL fully readable downstream.
+			body, _ := readAll(c)
+			c.JSON(http.StatusOK, gin.H{"received_body_len": len(body)})
+		})
+	return r
+}
+
+func readAll(c *gin.Context) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	_, err := buf.ReadFrom(c.Request.Body)
+	return buf.Bytes(), err
+}
+
+// TestRequireBreakGlassFeature_RefusesTenantWithoutFeature pins the plan
+// brief's Task 6 gate: a tenant on a plan below FeatureSSO's minimum gets
+// the SAME 403 the SSO config endpoints give, even though break-glass
+// login runs with no upstream auth middleware to have set tenant_id on
+// the Gin context — the tenant id here comes from the request body.
+func TestRequireBreakGlassFeature_RefusesTenantWithoutFeature(t *testing.T) {
+	tenantID := uuid.New()
+	resolver := &fakePlanResolver{plan: subscription.PlanStudio} // below Pro
+	r := breakGlassGateRouter(resolver)
+
+	body := []byte(`{"tenant_id":"` + tenantID.String() + `","password":"x","totp_code":"000000"}`)
+	req := httptest.NewRequest(http.MethodPost, "/admin/break-glass/login", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Contains(t, rec.Body.String(), "plan_required")
+	require.Equal(t, tenantID, resolver.called, "gate must resolve the plan for the tenant_id in the body")
+}
+
+// TestRequireBreakGlassFeature_AllowsTenantWithFeature is the mirror case:
+// a Pro-plan tenant passes through to the handler, and the body it sent
+// is still intact for the handler to bind (the gate's body-peek must not
+// consume the stream).
+func TestRequireBreakGlassFeature_AllowsTenantWithFeature(t *testing.T) {
+	tenantID := uuid.New()
+	resolver := &fakePlanResolver{plan: subscription.PlanPro}
+	r := breakGlassGateRouter(resolver)
+
+	body := []byte(`{"tenant_id":"` + tenantID.String() + `","password":"x","totp_code":"000000"}`)
+	req := httptest.NewRequest(http.MethodPost, "/admin/break-glass/login", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"received_body_len": `+strconv.Itoa(len(body))+`}`, rec.Body.String())
+}
+
+// TestRequireBreakGlassFeature_MalformedBodyPassesThrough documents the
+// deliberate choice in RequireBreakGlassFeature's doc comment: a missing
+// or malformed tenant_id is NOT rejected by the gate. It falls through so
+// BreakGlassLoginHandler.Login's own shape validation produces the SAME
+// uniform {"error":"invalid_credentials"} a wrong password gets — the
+// endpoint's documented invariant that its response must never reveal
+// which check failed.
+func TestRequireBreakGlassFeature_MalformedBodyPassesThrough(t *testing.T) {
+	resolver := &fakePlanResolver{plan: subscription.PlanStudio} // would be refused if resolved
+	r := breakGlassGateRouter(resolver)
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/break-glass/login", bytes.NewReader([]byte(`not json`)))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "malformed body must fall through to the handler, not be blocked by the gate")
+	require.Equal(t, uuid.Nil, resolver.called, "resolver must never be called when no tenant_id could be peeked")
+}

--- a/services/marketplace-api/internal/handlers/admin/break_glass_shared_limiter_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/break_glass_shared_limiter_integration_test.go
@@ -1,0 +1,121 @@
+//go:build integration
+
+package admin_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+	"github.com/mark8ly/marketplace-api/internal/handlers/admin"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// sharedLimiterTestWriter and sharedLimiterTestRotator are declared in
+// break_glass_shared_limiter_test.go (not integration-tagged) so both
+// that file's DB-free test and this one can use them.
+
+// TestSharedRateLimiter_LoginFailureVisibleToClearLockout is THE test
+// that catches mark8ly#642's two-rate-limiter bug. It wires
+// admin.BreakGlassLoginHandler and platformadmin.BreakGlassWriteHandler
+// with the SAME *breakglass.LoginRateLimiter — exactly as
+// cmd/marketplace-api/main.go now does — and drives BOTH through their
+// real production HTTP handlers (not stand-ins for the rate-limit logic):
+// a failed login records a failure on the shared limiter, and the write
+// handler's clear-lockout must be able to see and reset that same bucket.
+//
+// If main.go ever regresses to constructing two separate
+// *breakglass.LoginRateLimiter instances — one for BreakGlassDeps.RateLimiter,
+// another for platformadmin.Deps.BreakGlassRateLimiter — this exact
+// scenario reproduces mark8ly#642's failure mode in production: an
+// operator runs clear-lockout, the durable break_glass_lockouts row is
+// deleted, the API reports success, and the in-memory limiter (a
+// DIFFERENT map nobody ever resets) keeps refusing the IP as if nothing
+// happened. That is a miserable thing to debug because every signal says
+// it worked.
+//
+// Requires the login side to run its real IsIPLocked query, which needs
+// a live DB — see the package's other break_glass_login_integration_test.go
+// for the same constraint. Do NOT run this against the shared
+// TEST_DATABASE_URL concurrently with other integration suites.
+func TestSharedRateLimiter_LoginFailureVisibleToClearLockout(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := breakglass.NewRepository(db)
+	secrets := breakglass.NewSecretManager(breakglass.NewFakeSecretClient())
+	ipHMACKey := breakglass.HMACKey("shared-limiter-test-key")
+
+	// ONE instance, threaded to both handlers — the fix under test.
+	sharedLimiter := breakglass.NewLoginRateLimiter()
+
+	loginHandler := admin.NewBreakGlassLoginHandler(admin.BreakGlassDeps{
+		Repo:        repo,
+		Secrets:     secrets,
+		RateLimiter: sharedLimiter,
+		IPHMACKey:   ipHMACKey,
+	})
+	writeHandler := platformadmin.NewBreakGlassWriteHandler(
+		db,
+		&sharedLimiterTestWriter{clearN: 1},
+		sharedLimiterTestRotator{},
+		sharedLimiter,
+		ipHMACKey,
+		nil, // emit — no-op default
+		nil, // logger — slog.Default()
+	)
+
+	gin.SetMode(gin.TestMode)
+	loginRouter := gin.New()
+	loginRouter.POST("/admin/break-glass/login", loginHandler.Login)
+	writeRouter := gin.New()
+	writeHandler.Register(writeRouter.Group("/"))
+
+	const callerIP = "203.0.113.55"
+
+	// 1. A failed login (nonexistent tenant — no account needs
+	// provisioning) from callerIP. Login()'s recordFailure path calls
+	// h.deps.RateLimiter.RecordFailure(breakglass.LoginRateLimitKey(ipHash))
+	// on sharedLimiter.
+	body, err := json.Marshal(map[string]string{
+		"tenant_id": uuid.New().String(),
+		"password":  "wrong-password",
+		"totp_code": "000000",
+	})
+	require.NoError(t, err)
+	loginReq := httptest.NewRequest(http.MethodPost, "/admin/break-glass/login", bytes.NewReader(body))
+	loginReq.Header.Set("Content-Type", "application/json")
+	loginReq.Header.Set("X-Forwarded-For", callerIP)
+	loginRec := httptest.NewRecorder()
+	loginRouter.ServeHTTP(loginRec, loginReq)
+	require.Equal(t, http.StatusUnauthorized, loginRec.Code, "expected the uniform invalid_credentials failure")
+
+	ipHash := breakglass.HMACIPHash(ipHMACKey, callerIP)
+	key := breakglass.LoginRateLimitKey(ipHash)
+	require.Equal(t, 1, sharedLimiter.Count(key),
+		"the login path must have recorded its failure on sharedLimiter — if this is 0, "+
+			"the login handler is not touching the instance the test wired it with")
+
+	// 2. clear-lockout for the SAME ip, via the write handler's real HTTP
+	// route. It must reach the SAME bucket the login path just wrote to.
+	clearBody, err := json.Marshal(map[string]string{"ip": callerIP})
+	require.NoError(t, err)
+	clearReq := httptest.NewRequest(http.MethodPost, "/admin/break-glass/clear-lockout", bytes.NewReader(clearBody))
+	clearReq.Header.Set("Content-Type", "application/json")
+	clearRec := httptest.NewRecorder()
+	writeRouter.ServeHTTP(clearRec, clearReq)
+	require.Equal(t, http.StatusOK, clearRec.Code)
+
+	require.Equal(t, 0, sharedLimiter.Count(key),
+		"clear-lockout did NOT reset the same in-memory bucket the login path recorded the "+
+			"failure on. In production this is mark8ly#642's failure mode: the durable DB "+
+			"lockout clears, the API reports success, and the in-memory limiter silently keeps "+
+			"refusing the IP — because the login and write handlers were wired with two "+
+			"separate *breakglass.LoginRateLimiter instances instead of one shared instance.")
+}

--- a/services/marketplace-api/internal/handlers/admin/break_glass_shared_limiter_test.go
+++ b/services/marketplace-api/internal/handlers/admin/break_glass_shared_limiter_test.go
@@ -1,0 +1,101 @@
+package admin_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+	"github.com/mark8ly/marketplace-api/internal/handlers/platformadmin"
+)
+
+// sharedLimiterTestWriter and sharedLimiterTestRotator satisfy
+// platformadmin's BreakGlassWriter and BreakGlassRotator interfaces
+// without touching the DB — clear-lockout's only DB-shaped dependency is
+// h.writer.ClearIPLock, which this stub answers directly. Rotate/disable/
+// enable are never exercised by either test that uses these. Declared
+// here (not integration-tagged) so both this file and
+// break_glass_shared_limiter_integration_test.go can use them.
+type sharedLimiterTestWriter struct{ clearN int64 }
+
+func (w *sharedLimiterTestWriter) Disable(context.Context, uuid.UUID, string) error { return nil }
+func (w *sharedLimiterTestWriter) Enable(context.Context, uuid.UUID) error          { return nil }
+func (w *sharedLimiterTestWriter) ClearIPLock(context.Context, []byte) (int64, error) {
+	return w.clearN, nil
+}
+
+type sharedLimiterTestRotator struct{}
+
+func (sharedLimiterTestRotator) RotateOne(context.Context, uuid.UUID) error { return nil }
+
+// TestSharedRateLimiter_ClearLockoutResetsALoginPathFailure is the
+// unit-test-safe half of the shared-limiter proof (mark8ly#642): it does
+// NOT stand up a database, so it runs in the normal `go test ./...` pass
+// rather than requiring the integration tag — see
+// break_glass_shared_limiter_integration_test.go for the full end-to-end
+// version that drives admin.BreakGlassLoginHandler.Login itself (which
+// needs a live DB for its IsIPLocked check before recordFailure ever
+// runs).
+//
+// It records a failure the EXACT way BreakGlassLoginHandler.recordFailure
+// does — h.deps.RateLimiter.RecordFailure(breakglass.LoginRateLimitKey(ipHash))
+// — using the identical package-level helpers the login handler calls
+// (not a re-implementation), then drives platformadmin.BreakGlassWriteHandler's
+// REAL /admin/break-glass/clear-lockout HTTP handler and asserts the
+// SAME shared *breakglass.LoginRateLimiter instance was reset.
+//
+// If mark8ly#642 regresses — the login side and the write side wired
+// with two SEPARATE *breakglass.LoginRateLimiter instances instead of
+// one shared instance — this test fails: the assertion checks the
+// instance the "login path" (the RecordFailure call above) wrote to,
+// and the write handler's Reset would land on a different map entirely.
+func TestSharedRateLimiter_ClearLockoutResetsALoginPathFailure(t *testing.T) {
+	ipHMACKey := breakglass.HMACKey("shared-limiter-unit-test-key")
+	const callerIP = "198.51.100.23"
+	ipHash := breakglass.HMACIPHash(ipHMACKey, callerIP)
+	key := breakglass.LoginRateLimitKey(ipHash)
+
+	sharedLimiter := breakglass.NewLoginRateLimiter()
+
+	// --- "login path": the exact two calls break_glass_login.go's
+	// recordFailure makes on a failed attempt. ---
+	sharedLimiter.RecordFailure(key)
+	require.Equal(t, 1, sharedLimiter.Count(key), "test setup: the simulated login failure must be recorded")
+
+	// --- write path: the REAL clear-lockout HTTP handler. ---
+	writeHandler := platformadmin.NewBreakGlassWriteHandler(
+		nil, // db — unused by clearLockout beyond what's passed to writer/rateLimiter
+		&sharedLimiterTestWriter{clearN: 1},
+		sharedLimiterTestRotator{},
+		sharedLimiter, // the SAME instance — this is the fix under test
+		ipHMACKey,
+		nil,
+		nil,
+	)
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	writeHandler.Register(r.Group("/"))
+
+	body, err := json.Marshal(map[string]string{"ip": callerIP})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/admin/break-glass/clear-lockout", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.Equal(t, 0, sharedLimiter.Count(key),
+		"clear-lockout did not reset the bucket the login path recorded a failure on — in "+
+			"production this is mark8ly#642's failure mode: the durable DB lockout row clears, "+
+			"the API reports success, and the in-memory limiter silently keeps refusing the IP, "+
+			"because the login and write handlers were wired with two separate "+
+			"*breakglass.LoginRateLimiter instances instead of one shared instance")
+}

--- a/services/marketplace-api/internal/handlers/admin/routes.go
+++ b/services/marketplace-api/internal/handlers/admin/routes.go
@@ -151,8 +151,17 @@ func RegisterAdmin(router *gin.RouterGroup, deps Deps) {
 	// the recovery path, it MUST work when the subscription is
 	// expired / store_closed / pending_hard_delete. Rate-limit + dual-
 	// factor verification live inside the handler itself.
+	//
+	// Gated on FeatureSSO (Pro+ only) — break-glass exists to recover
+	// admin access when a tenant's SSO config is broken, so a tenant that
+	// never had SSO gets the same 403 the SSO config endpoints give.
+	// RequireBreakGlassFeature (not plangate.RequireFeatureByTenant) runs
+	// here because there is deliberately no auth middleware upstream to
+	// have set tenant_id on the context — see that function's doc.
 	if deps.BreakGlassLoginHandler != nil {
-		router.POST("/admin/break-glass/login", deps.BreakGlassLoginHandler.Login)
+		router.POST("/admin/break-glass/login",
+			RequireBreakGlassFeature(deps.PlanResolver, plangate.FeatureSSO, deps.APIKeysLogger),
+			deps.BreakGlassLoginHandler.Login)
 	}
 
 	// P13 §12 — SSO config. Tenant-wide, Pro-gated, outside /stores/:storeId.

--- a/services/marketplace-api/internal/handlers/platformadmin/break_glass_write.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/break_glass_write.go
@@ -110,21 +110,6 @@ func (h *BreakGlassWriteHandler) Register(g *gin.RouterGroup) {
 	g.POST("/admin/break-glass/clear-lockout", h.clearLockout)
 }
 
-// breakGlassRLKey MUST stay byte-identical to rlKey in
-// internal/handlers/admin/break_glass_login.go: both shape the same
-// LoginRateLimiter bucket key from an ip_hash, and the login path resets
-// that bucket on a successful login. A key that shapes the hash
-// differently here would mean clear-lockout resets a bucket the login
-// path never reads, leaving the in-memory limiter stuck even though the
-// durable DB lock was cleared.
-func breakGlassRLKey(ipHash []byte) string {
-	n := len(ipHash)
-	if n > 16 {
-		n = 16
-	}
-	return string(ipHash[:n])
-}
-
 func (h *BreakGlassWriteHandler) parseTenantID(c *gin.Context) (uuid.UUID, bool) {
 	id, err := uuid.Parse(strings.TrimSpace(c.Param("tenantId")))
 	if err != nil {
@@ -341,7 +326,7 @@ func (h *BreakGlassWriteHandler) clearLockout(c *gin.Context) {
 	// counter would be untouched by this call. That is current luck, not
 	// design (#404).
 	if h.rateLimiter != nil {
-		h.rateLimiter.Reset(breakGlassRLKey(ipHash))
+		h.rateLimiter.Reset(breakglass.LoginRateLimitKey(ipHash))
 	} else {
 		h.logger.Warn("break-glass: clear-lockout has no rate limiter wired; only the durable DB lock was cleared")
 	}

--- a/services/marketplace-api/internal/handlers/platformadmin/break_glass_write_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/break_glass_write_test.go
@@ -246,7 +246,7 @@ func TestBreakGlassWrite_ClearLockout_ResetsTheRateLimiterWithTheLoginPathKeySha
 	ipHash := breakglass.HMACIPHash(key, "198.51.100.9")
 	wantKey := string(ipHash[:16])
 	require.Equal(t, []string{wantKey}, limiter.resetOn,
-		"the rate limiter must be Reset with the same key shape the login handler's rlKey computes")
+		"the rate limiter must be Reset with the same key shape breakglass.LoginRateLimitKey computes")
 }
 
 func TestBreakGlassWrite_ClearLockout_NilRateLimiterDoesNotPanic(t *testing.T) {

--- a/services/marketplace-api/pkg/config/config.go
+++ b/services/marketplace-api/pkg/config/config.go
@@ -306,6 +306,22 @@ type Config struct {
 	// on the first merchant credential save. Unused otherwise.
 	OpenBaoKVMount string `envconfig:"OPENBAO_KV_MOUNT" default:"kv"`
 
+	// BreakGlassIPHMACKey fingerprints caller IPs before they hit the
+	// break-glass audit log or the break_glass_lockouts table (§12.4) —
+	// raw IPs must never be persisted. Empty is a safe (if weaker)
+	// default: breakglass.HMACIPHash still runs with an empty key rather
+	// than panicking, so an unset value degrades to a deterministic but
+	// guessable hash instead of crash-looping the service. Set via
+	// ExternalSecret in production, same pattern as InternalAuthSecret.
+	BreakGlassIPHMACKey string `envconfig:"BREAK_GLASS_IP_HMAC_KEY" default:""`
+	// BreakGlassSlackWebhookURL posts a #security-alerts notice on every
+	// break-glass login attempt (success and failure). Empty leaves
+	// Slack unwired — the login/audit/lockout path works exactly the
+	// same without it, since breakglass.SlackClient is a best-effort
+	// post-use hook (BreakGlassLoginHandler nil-checks it), not a
+	// dependency the login itself needs.
+	BreakGlassSlackWebhookURL string `envconfig:"BREAK_GLASS_SLACK_WEBHOOK_URL" default:""`
+
 	// Zitadel bearer verifier for mobile admin routes (#524 phase 4).
 	// Mirrors auth-bff's ZITADEL_ENABLED shape: an explicit boolean,
 	// defaulting to false. Since #786 removed the GIP verifier it is a


### PR DESCRIPTION
Task 6 of #642 — the reason break-glass has never worked. `internal/handlers/admin/routes.go` mounts `POST /admin/break-glass/login` only when `deps.BreakGlassLoginHandler != nil`, and `NewBreakGlassLoginHandler` was called **only in tests**. `main.go` never constructed it, so the route did not exist.

It is now constructed and wired to the OpenBao secret client, the repository, the audit emitter, an optional Slack hook, and the `HTTPIssuer`. Two new config fields, both optional with empty defaults, so this needs no k8s-first sequencing.

## The two silent failures this had to prevent

**One rate limiter, not two.** `LoginRateLimiter` is an in-memory per-pod map. If the login handler and the clear-lockout write handler hold separate instances, clear-lockout resets a map nobody reads: the durable `break_glass_lockouts` row clears, the API reports success, and the limiter keeps refusing the IP. #642 calls it "a miserable thing to debug." **Nothing in production constructed a limiter at all**, so this wiring is where that bug would have been born. One instance is now created and threaded to both — including pre-wired into the `platformadmin` deps so the later PR that mounts #404's writes cannot reintroduce it.

**The two key functions could drift.** `rlKey` and `breakGlassRLKey` were byte-for-byte duplicates in different packages, with the invariant stated only in a comment promising they would stay in sync — a promise nothing enforced. Different keys produce exactly the same silent failure by a different route. Both are deleted in favour of one exported `breakglass.LoginRateLimitKey` that both packages call, so drift is now **impossible by construction** rather than policed by prose.

Both were mutation-checked, and I re-verified both independently:

- separate limiter instances → the shared-limiter test fails with its full consequence message
- key truncation changed 16 → 8 bytes → `TestLoginRateLimitKey_EdgeCases` fails

## Plan gate

`plangate.RequireFeature` could not be used as the plan said: it requires `:storeId` in the URL and `tenant_id` already on the Gin context, and this route deliberately runs before any auth middleware with the tenant in the body. A purpose-built middleware reads `tenant_id` from the body and restores `c.Request.Body` so the handler's own binding still works, and lets a missing or malformed `tenant_id` fall through untouched — otherwise a differently-shaped 400 from the gate would break the endpoint's documented invariant that it never reveals which check failed.

## SSO routes: NOT mounted, and the plan was wrong about why

The plan said to mount SSO login/callback/logout "now that their issuer exists". The issuer was **not** the only blocker:

- `TenantResolver` has no production implementation anywhere — its own doc comment is a literal `TODO(wiring)`
- `OIDCRPs`, the per-tenant relying-party map, is never constructed at startup
- `loginSAML` is a no-op stub

Mounting them would have wired a permanently-broken endpoint rather than delivering functionality. Left unmounted deliberately.

Worth knowing: `SSOConfigHandler` — the admin-side SSO config CRUD, already registered in `admin/routes.go` — is **also** never constructed in `main.go`. So SSO is unwired on both the config and login sides, not just login. That is a larger gap than #642 describes and probably deserves its own issue.

## #404

Its write routes stay unmounted: `BreakGlassRotator` / `BreakGlassWriter` remain nil. The shared limiter is already threaded to those deps, so mounting them later is the one-line dependency fill its author described, with the two-instance bug already designed out.

## Verified

`go build`, `go vet`, `go vet -tags=integration`, `go test ./...`, `gofmt -l` all clean. New unit tests cover the mount (driven through the real router, not a 405-vs-404 probe, which cannot work here since `HandleMethodNotAllowed` is never set), the plan gate, the shared limiter, and the key edge cases.

## What remains in #642

Task 7's config for a real deployment, then provisioning an account with `cmd/break-glass-provision` and an end-to-end login. Until an account exists, this route is mounted and correct but has nothing to authenticate.
