### PR TITLE
docs(subscription): signup is a resting state, and nothing ages it out (#803)

### DIFF
--- a/services/marketplace-api/internal/billing/trial/expiry_cron.go
+++ b/services/marketplace-api/internal/billing/trial/expiry_cron.go
@@ -24,6 +24,20 @@ const ExpirySpec = "15 0 * * *"
 // TrialDays, extended if an operator has set trial_ends_at) to the "expired"
 // status via the state machine. It is idempotent: stores already in "expired"
 // are never selected.
+//
+// `trialing` ONLY, AND A `signup` ROW IS THEREFORE NEVER AGED OUT. That is a
+// recorded decision, not an oversight — mark8ly#803, 2026-09-07. A tenant who
+// signed up and never completed Stripe Checkout stays at `signup` forever:
+// this cron does not select them, the dunning ladder does not, and nothing
+// bills them. `EndsAt` will happily compute `created_at + TrialDays` for such
+// a row, but that date is NOTIONAL, because this is the code that would have
+// acted on it and does not.
+//
+// Nothing was built because there is nothing to act on yet: `store_subscriptions`
+// held zero rows when this was measured, and Stripe is deliberately still on
+// the test key (mark8ly#371). Widening the predicate here is the obvious
+// change and would be writer code against zero rows. See
+// subscription.StatusSignup for what reopens the decision.
 type ExpiryCron struct {
 	db      *gorm.DB
 	emitter *audit.Emitter

--- a/services/marketplace-api/internal/subscription/models.go
+++ b/services/marketplace-api/internal/subscription/models.go
@@ -62,6 +62,29 @@ func AllStatuses() []SubscriptionStatus {
 type SubscriptionStatus string
 
 const (
+	// StatusSignup is where `Bootstrap` puts every new row, and it is a
+	// RESTING STATE, not a transient one. Documented rather than fixed, on
+	// purpose — tesserix-home#582's reasoning applied to this enum
+	// (mark8ly#803, decided 2026-09-07).
+	//
+	// Exactly one thing promotes it: the Stripe
+	// `checkout.session.completed` webhook (`internal/billing/dispatch/handlers.go`).
+	// A tenant who signs up and abandons checkout therefore stays here
+	// indefinitely — and nothing else observes them, because `ExpiryCron`
+	// selects `trialing` and the dunning ladder selects live statuses. Not
+	// trialing, so no trial machinery; not expired, so no retention path;
+	// not converted, so nothing bills them.
+	//
+	// WHY NOTHING WAS BUILT. Measured on 2026-09-07: `store_subscriptions`
+	// held ZERO rows, and Stripe is deliberately still on the test key
+	// (mark8ly#371, "not yet"), so no tenant can be stuck here yet. An
+	// expiry path or a chase path would be writer code exercised against
+	// zero rows — the failure this milestone already paid for once.
+	//
+	// WHAT REOPENS IT: real subscribers existing (following the live-key
+	// swap), or an abandonment rate worth chasing. The chase option
+	// additionally needs mark8ly#703, since no billing lifecycle email is
+	// sent today.
 	StatusSignup                SubscriptionStatus = "signup"
 	StatusTrialing              SubscriptionStatus = "trialing"
 	StatusActive                SubscriptionStatus = "active"


### PR DESCRIPTION
Closes #803. Doc-only — no behaviour change, deliberately.

## The decision

`signup` is a **resting state, not a transient one**, and that is now recorded where someone tracing it will look: on `StatusSignup` itself, and on `ExpiryCron`, which is the code that would have acted on it and does not.

Exactly one thing promotes it: the Stripe `checkout.session.completed` webhook. A tenant who signs up and abandons checkout stays there indefinitely — not trialing so no trial machinery, not expired so no retention path, not converted so nothing bills them.

## Why nothing was built

Measured on 2026-09-07: `store_subscriptions` held **zero rows**, and Stripe is deliberately still on the test key (mark8ly#371, decided "not yet"). **No tenant can be stuck here yet.**

An expiry path or a chase path would be writer code exercised against zero rows. This milestone has already paid for that once — a missing `transfer_lookup_key` survived a green suite because nothing exercised it. Same reasoning tesserix-home#582 used to decline building a subscriber price-distribution view, and for the same measured reason.

Widening `ExpiryCron`'s predicate is the obvious change and the wrong one today, so the comment says so at the point where someone would make it.

## What reopens it

- Real subscribers existing, following the live-key swap (mark8ly#371); or
- an abandonment rate worth chasing — which additionally needs mark8ly#703, since no billing lifecycle email is sent at all today.

## Claims verified, not assumed

- `checkout.session.completed` is the **only** non-test writer of `signup → trialing`
- `ExpiryCron` selects `status = 'trialing'`
- **the dunning ladder handles only `past_due`, `expired` and `store_closed`** — `signup` appears nowhere in it, checked before writing the sentence that says so
- `EndsAt` does compute `created_at + TrialDays` for a signup row, which is why the comment calls that date *notional* rather than pretending it does not exist

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `go test` across `internal/subscription/...` and `internal/billing/trial/...` — all ok

Comment-only; nothing executable changed.

Found while tracing an operator's empty Trials tab, which turned out to have a different cause entirely (four hand-seeded demo stores, zero subscriptions). This gap was real but latent, and worth recording before it stops being latent.