### PR TITLE
fix(metrics): compute MRR from the price catalog instead of a nonexistent column

### DIFF
--- a/services/marketplace-api/internal/metrics/mrr_rollup.go
+++ b/services/marketplace-api/internal/metrics/mrr_rollup.go
@@ -2,20 +2,66 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/shopspring/decimal"
 	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
 )
 
-// mrrRow is the result of the MRR aggregation query — one row per (plan, currency).
-type mrrRow struct {
-	Plan     string
-	Currency string
-	// TotalMinor is the sum of plan_amount_minor for active subscriptions in this bucket.
-	TotalMinor int64
+// mrrGroup is one row of the active-subscription aggregation: a count of
+// active subscriptions sharing a (plan, subscription_period, billing_currency).
+//
+// store_subscriptions does NOT store a price — there is no amount column on
+// the table at all. The amount therefore has to come from the compiled price
+// catalog (internal/billing/pricing), keyed by exactly these three fields,
+// which is why the SQL side only counts.
+type mrrGroup struct {
+	Plan          string
+	Period        string
+	Currency      string
+	Subscriptions int64
+}
+
+// mrrGroupReader reads active-subscription counts grouped by
+// (plan, period, currency). The gorm-backed implementation is the only
+// production one; tests substitute a stub.
+type mrrGroupReader interface {
+	activeSubscriptionGroups(ctx context.Context) ([]mrrGroup, error)
+}
+
+// gormMRRGroupReader is the production mrrGroupReader, backed by Postgres.
+type gormMRRGroupReader struct {
+	db *gorm.DB
+}
+
+func (r gormMRRGroupReader) activeSubscriptionGroups(ctx context.Context) ([]mrrGroup, error) {
+	if r.db == nil {
+		return nil, fmt.Errorf("mrr_rollup: no db connection")
+	}
+	var rows []mrrGroup
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT
+			plan                                        AS plan,
+			COALESCE(subscription_period, 'monthly')    AS period,
+			COALESCE(billing_currency, 'USD')           AS currency,
+			COUNT(*)                                    AS subscriptions
+		FROM store_subscriptions
+		WHERE status = 'active'
+		GROUP BY plan,
+		         COALESCE(subscription_period, 'monthly'),
+		         COALESCE(billing_currency, 'USD')
+	`).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 // mrrFXReader is the minimal interface MRRRollup needs from the FX repository.
@@ -24,16 +70,21 @@ type mrrFXReader interface {
 	GetAll(ctx context.Context) (map[string]decimal.Decimal, error)
 }
 
-// MRRRollup is a prometheus.Collector that computes the Monthly Recurring
-// Revenue (MRR) in USD at scrape time by joining the store_subscriptions table
-// with fx_rates. It emits a single GaugeVec metric:
+// MRRRollup is a prometheus.Collector that computes Monthly Recurring Revenue
+// (MRR) in USD at scrape time. It counts active subscriptions per
+// (plan, period, currency) in SQL, resolves the per-subscription price from
+// the compiled price catalog in Go, normalises annual prices to a monthly
+// figure, and converts to USD with fx_rates. It emits a single GaugeVec:
 //
 //	mark8ly_subscription_mrr_usd{plan, currency}
 //
+// Currency buckets are never summed together: each (plan, currency) is its own
+// series, matching the metric's label set.
+//
 // If the underlying query fails the collector emits a zero value and logs the
-// error — it never breaks the scrape.
+// error — it never breaks the scrape, and it never panics.
 type MRRRollup struct {
-	db     *gorm.DB
+	reader mrrGroupReader
 	fx     mrrFXReader
 	logger *slog.Logger
 	desc   *prometheus.Desc
@@ -43,11 +94,17 @@ type MRRRollup struct {
 // prometheus.MustRegister (or a test registry) to activate scrape-time
 // collection.
 func NewMRRRollup(db *gorm.DB, fx mrrFXReader, logger *slog.Logger) *MRRRollup {
+	return newMRRRollupWithReader(gormMRRGroupReader{db: db}, fx, logger)
+}
+
+// newMRRRollupWithReader is the seam the tests use to supply canned rows
+// without a database.
+func newMRRRollupWithReader(reader mrrGroupReader, fx mrrFXReader, logger *slog.Logger) *MRRRollup {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &MRRRollup{
-		db:     db,
+		reader: reader,
 		fx:     fx,
 		logger: logger,
 		desc: prometheus.NewDesc(
@@ -64,10 +121,65 @@ func (m *MRRRollup) Describe(ch chan<- *prometheus.Desc) {
 	ch <- m.desc
 }
 
+// minorPerMajor converts minor units (cents, paise, sen…) to major units.
+// The price catalog stores every currency at ×100, including the zero-decimal
+// ones, so this divisor is uniform — see the zero-decimal note in
+// internal/billing/pricing/catalog.go.
+var minorPerMajor = decimal.NewFromInt(100)
+
+var monthsPerYear = decimal.NewFromInt(12)
+
+// monthlyMinorFor resolves the per-subscription price for one group from the
+// compiled catalog and normalises it to a MONTHLY figure.
+//
+// MRR means monthly: an annual price is divided by 12, otherwise a yearly
+// subscription would be counted at twelve times its monthly contribution and
+// every dashboard built on this metric would be wrong.
+//
+// The division is deliberately performed in decimal and NOT rounded to whole
+// minor units. Several annual prices do not divide evenly by 12 (e.g. USD
+// $182/yr → $15.1666…/mo), and rounding each group to whole cents before
+// multiplying by the subscription count would push a systematic bias into the
+// total that grows with the number of subscribers. decimal.Div keeps 16
+// decimal places; the only rounding left is the final float64 conversion at
+// the gauge boundary, which is far below one cent.
+//
+// It never panics: pricing.MustGet is deliberately not used here because a
+// missing catalog entry inside a Prometheus scrape must degrade, not crash.
+func monthlyMinorFor(plan, period, currency string) (decimal.Decimal, bool) {
+	p := pricing.Plan(strings.ToLower(strings.TrimSpace(plan)))
+	per := pricing.Period(strings.ToLower(strings.TrimSpace(period)))
+	// The catalog keys currencies in lowercase ISO 4217; the column is CHAR(3)
+	// with no enforced case.
+	cur := strings.ToLower(strings.TrimSpace(currency))
+
+	amt, ok := pricing.DevelopedAmount(p, per, cur)
+	if !ok {
+		amt, ok = pricing.PPPAmount(p, per, cur)
+	}
+	if !ok {
+		return decimal.Zero, false
+	}
+
+	minor := decimal.NewFromInt(amt.UnitAmountMinor)
+	if per == pricing.PeriodAnnual {
+		minor = minor.Div(monthsPerYear)
+	}
+	return minor, true
+}
+
+// bucket is the emitted label pair. Several period groups (monthly + annual)
+// collapse into one series, so they must be summed before emission or
+// Prometheus rejects the scrape with duplicate label values.
+type bucket struct {
+	plan     string
+	currency string
+}
+
 // Collect implements prometheus.Collector. It runs a single aggregate query
-// with a 5-second timeout. On failure it emits a zero gauge for each
-// (plan, currency) pair rather than omitting the metric entirely, so
-// dashboards show "0" rather than a gap.
+// with a 5-second timeout. On failure, on an empty table, or when nothing at
+// all could be priced, it emits a zero gauge rather than omitting the metric
+// entirely, so dashboards show "0" rather than a gap.
 func (m *MRRRollup) Collect(ch chan<- prometheus.Metric) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -79,66 +191,105 @@ func (m *MRRRollup) Collect(ch chan<- prometheus.Metric) {
 			"err", err)
 		rates = map[string]decimal.Decimal{}
 	}
-	// Ensure USD identity rate is always present.
-	if _, ok := rates["USD"]; !ok {
-		rates["USD"] = decimal.NewFromInt(1)
+	// Ensure USD identity rate is always present. Copy first: the map may be
+	// owned by the FX repository or by a caller.
+	normalisedRates := make(map[string]decimal.Decimal, len(rates)+1)
+	for k, v := range rates {
+		normalisedRates[strings.ToUpper(strings.TrimSpace(k))] = v
+	}
+	if _, ok := normalisedRates["USD"]; !ok {
+		normalisedRates["USD"] = decimal.NewFromInt(1)
 	}
 
-	// Guard: nil DB means no DB connection available (e.g. unit tests without
-	// a real Postgres). Emit a zero and return cleanly.
-	if m.db == nil {
-		m.logger.Warn("mrr_rollup: no db connection, emitting 0")
+	groups, err := m.reader.activeSubscriptionGroups(ctx)
+	if err != nil {
+		m.logger.Error("mrr_rollup: aggregate query failed", "err", err)
+		// Emit a zero so the series does not gap on a transient DB failure.
 		ch <- prometheus.MustNewConstMetric(m.desc, prometheus.GaugeValue, 0, "unknown", "USD")
 		return
 	}
 
-	// Aggregate active subscriptions by plan + billing_currency.
-	var rows []mrrRow
-	queryErr := m.db.WithContext(ctx).Raw(`
-		SELECT
-			plan,
-			COALESCE(billing_currency, 'USD') AS currency,
-			COALESCE(SUM(plan_amount_minor), 0) AS total_minor
-		FROM store_subscriptions
-		WHERE status = 'active'
-		  AND plan_amount_minor IS NOT NULL
-		GROUP BY plan, COALESCE(billing_currency, 'USD')
-	`).Scan(&rows).Error
-
-	if queryErr != nil {
-		m.logger.Error("mrr_rollup: aggregate query failed", "err", queryErr)
-		// Emit a zero so the scrape doesn't time out waiting for a metric that
-		// never arrives.
-		ch <- prometheus.MustNewConstMetric(m.desc, prometheus.GaugeValue, 0, "unknown", "USD")
-		return
-	}
-
-	if len(rows) == 0 {
-		// No active paying subscriptions — emit zero so dashboards don't gap.
+	if len(groups) == 0 {
+		// No active subscriptions — emit zero so dashboards don't gap.
 		ch <- prometheus.MustNewConstMetric(m.desc, prometheus.GaugeValue, 0, "all", "USD")
 		return
 	}
 
-	for _, row := range rows {
-		usdRate, ok := rates[row.Currency]
+	totals := make(map[bucket]decimal.Decimal, len(groups))
+	// unpriceable collects every (plan, period, currency) the catalog could not
+	// price. These are EXCLUDED from the gauge rather than emitted as zero: a
+	// zero-valued series is indistinguishable from a plan that genuinely earns
+	// nothing, which is exactly how a revenue metric under-reports without
+	// anyone noticing. An absent series plus this log is visible.
+	var unpriceable []string
+	var unpricedSubscriptions int64
+
+	for _, g := range groups {
+		currency := strings.ToUpper(strings.TrimSpace(g.Currency))
+		if currency == "" {
+			currency = "USD"
+		}
+		plan := strings.TrimSpace(g.Plan)
+
+		monthlyMinor, ok := monthlyMinorFor(plan, g.Period, currency)
 		if !ok {
-			// No FX rate for this currency — emit zero for this bucket.
-			m.logger.Warn("mrr_rollup: no fx rate for currency, emitting 0",
-				"currency", row.Currency)
-			ch <- prometheus.MustNewConstMetric(m.desc, prometheus.GaugeValue, 0, row.Plan, row.Currency)
+			unpriceable = append(unpriceable,
+				fmt.Sprintf("%s/%s/%s(n=%d)", plan, strings.TrimSpace(g.Period), currency, g.Subscriptions))
+			unpricedSubscriptions += g.Subscriptions
 			continue
 		}
 
-		// Convert minor units (cents) to major, then to USD.
-		major := decimal.NewFromInt(row.TotalMinor).Div(decimal.NewFromInt(100))
-		mrrUSD, _ := major.Mul(usdRate).Float64()
+		key := bucket{plan: plan, currency: currency}
+		rate, ok := normalisedRates[currency]
+		if !ok {
+			// No FX rate for this currency — this bucket contributes 0 USD, but
+			// the series is still emitted so its absence is not mistaken for a
+			// missing plan.
+			m.logger.Warn("mrr_rollup: no fx rate for currency, contributing 0",
+				"currency", currency, "plan", plan)
+			if _, seen := totals[key]; !seen {
+				totals[key] = decimal.Zero
+			}
+			continue
+		}
 
-		ch <- prometheus.MustNewConstMetric(
-			m.desc,
-			prometheus.GaugeValue,
-			mrrUSD,
-			row.Plan,
-			row.Currency,
-		)
+		contribution := monthlyMinor.
+			Mul(decimal.NewFromInt(g.Subscriptions)).
+			Div(minorPerMajor).
+			Mul(rate)
+		totals[key] = totals[key].Add(contribution)
+	}
+
+	if len(unpriceable) > 0 {
+		// One log line per scrape, naming every offending key.
+		sort.Strings(unpriceable)
+		m.logger.Warn("mrr_rollup: active subscriptions the price catalog cannot price, excluded from the gauge",
+			"groups", strings.Join(unpriceable, ","),
+			"group_count", len(unpriceable),
+			"subscription_count", unpricedSubscriptions)
+	}
+
+	if len(totals) == 0 {
+		// Every group was unpriceable — still emit a zero so the scrape has a
+		// sample and the dashboard does not hole.
+		ch <- prometheus.MustNewConstMetric(m.desc, prometheus.GaugeValue, 0, "all", "USD")
+		return
+	}
+
+	// Deterministic emission order keeps test output and logs stable.
+	keys := make([]bucket, 0, len(totals))
+	for k := range totals {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].plan != keys[j].plan {
+			return keys[i].plan < keys[j].plan
+		}
+		return keys[i].currency < keys[j].currency
+	})
+
+	for _, k := range keys {
+		usd, _ := totals[k].Float64()
+		ch <- prometheus.MustNewConstMetric(m.desc, prometheus.GaugeValue, usd, k.plan, k.currency)
 	}
 }

--- a/services/marketplace-api/internal/metrics/mrr_rollup_catalog_test.go
+++ b/services/marketplace-api/internal/metrics/mrr_rollup_catalog_test.go
@@ -1,0 +1,220 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubGroupReader returns canned aggregation rows, standing in for Postgres.
+type stubGroupReader struct {
+	groups []mrrGroup
+	err    error
+}
+
+func (s stubGroupReader) activeSubscriptionGroups(context.Context) ([]mrrGroup, error) {
+	return s.groups, s.err
+}
+
+type stubRates struct {
+	rates map[string]decimal.Decimal
+	err   error
+}
+
+func (s stubRates) GetAll(context.Context) (map[string]decimal.Decimal, error) {
+	return s.rates, s.err
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// gather collects the emitted samples as plan/currency -> value.
+func gather(t *testing.T, groups []mrrGroup, readErr error, rates map[string]decimal.Decimal) map[[2]string]float64 {
+	t.Helper()
+	c := newMRRRollupWithReader(
+		stubGroupReader{groups: groups, err: readErr},
+		stubRates{rates: rates},
+		quietLogger(),
+	)
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(c))
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err, "gather must not error (duplicate label sets would surface here)")
+	require.Len(t, mfs, 1)
+	require.Equal(t, "mark8ly_subscription_mrr_usd", mfs[0].GetName())
+
+	out := make(map[[2]string]float64)
+	for _, mtr := range mfs[0].GetMetric() {
+		var plan, currency string
+		for _, l := range mtr.GetLabel() {
+			switch l.GetName() {
+			case "plan":
+				plan = l.GetValue()
+			case "currency":
+				currency = l.GetValue()
+			}
+		}
+		require.NotNil(t, mtr.GetGauge(), "expected a gauge sample")
+		out[[2]string{plan, currency}] = mtr.GetGauge().GetValue()
+	}
+	return out
+}
+
+var usdOnly = map[string]decimal.Decimal{"USD": decimal.NewFromInt(1)}
+
+// A monthly plan bills its catalog price once per subscription.
+// starter/monthly/usd = 1900 minor = $19.00 × 3 = $57.00.
+func TestMRRRollup_MonthlyPlan(t *testing.T) {
+	got := gather(t, []mrrGroup{
+		{Plan: "starter", Period: "monthly", Currency: "USD", Subscriptions: 3},
+	}, nil, usdOnly)
+
+	require.Len(t, got, 1)
+	assert.InDelta(t, 57.0, got[[2]string{"starter", "USD"}], 1e-9)
+}
+
+// An annual plan must be normalised to a monthly figure: starter/annual/usd
+// = 18200 minor = $182.00/yr → $15.1666…/mo × 2 = $30.3333….
+// Asserting the un-normalised $364.00 would be the bug this guards.
+func TestMRRRollup_AnnualPlanNormalisedToMonthly(t *testing.T) {
+	got := gather(t, []mrrGroup{
+		{Plan: "starter", Period: "annual", Currency: "USD", Subscriptions: 2},
+	}, nil, usdOnly)
+
+	require.Len(t, got, 1)
+	assert.InDelta(t, 182.0*2/12, got[[2]string{"starter", "USD"}], 1e-9)
+	assert.Less(t, got[[2]string{"starter", "USD"}], 40.0, "must not be the un-normalised $364 annual total")
+}
+
+// Monthly and annual rows for the same plan+currency collapse into one series
+// (the metric has no period label) and must be summed, not emitted twice.
+// $19.00 × 1 + $182.00/12 × 1 = 19 + 15.1666… = 34.1666….
+func TestMRRRollup_MonthlyAndAnnualShareOneSeries(t *testing.T) {
+	got := gather(t, []mrrGroup{
+		{Plan: "starter", Period: "monthly", Currency: "USD", Subscriptions: 1},
+		{Plan: "starter", Period: "annual", Currency: "USD", Subscriptions: 1},
+	}, nil, usdOnly)
+
+	require.Len(t, got, 1)
+	assert.InDelta(t, 19.0+182.0/12, got[[2]string{"starter", "USD"}], 1e-9)
+}
+
+// Two currencies stay in separate buckets and are never added together.
+// USD: $19.00 × 1 = 19.00. INR: ₹999.00 × 1 × 0.012 = 11.988 USD.
+func TestMRRRollup_CurrenciesStayInSeparateBuckets(t *testing.T) {
+	rates := map[string]decimal.Decimal{
+		"USD": decimal.NewFromInt(1),
+		"INR": decimal.NewFromFloat(0.012),
+	}
+	got := gather(t, []mrrGroup{
+		{Plan: "starter", Period: "monthly", Currency: "USD", Subscriptions: 1},
+		{Plan: "starter", Period: "monthly", Currency: "INR", Subscriptions: 1},
+	}, nil, rates)
+
+	require.Len(t, got, 2, "one series per currency")
+	assert.InDelta(t, 19.0, got[[2]string{"starter", "USD"}], 1e-9)
+	assert.InDelta(t, 11.988, got[[2]string{"starter", "INR"}], 1e-9)
+}
+
+// A plan the catalog cannot price is excluded from the gauge (not emitted as a
+// misleading zero) while priceable groups in the same scrape are unaffected.
+func TestMRRRollup_UnpriceablePlanExcluded(t *testing.T) {
+	got := gather(t, []mrrGroup{
+		{Plan: "starter", Period: "monthly", Currency: "USD", Subscriptions: 1},
+		{Plan: "marketplace", Period: "monthly", Currency: "USD", Subscriptions: 5},
+		{Plan: "starter", Period: "quarterly", Currency: "USD", Subscriptions: 7},
+	}, nil, usdOnly)
+
+	require.Len(t, got, 1, "only the priceable group is emitted")
+	assert.InDelta(t, 19.0, got[[2]string{"starter", "USD"}], 1e-9)
+	_, ok := got[[2]string{"marketplace", "USD"}]
+	assert.False(t, ok, "unpriceable plan must not appear as a zero series")
+}
+
+// If nothing at all can be priced the collector still emits the placeholder
+// zero so the series does not gap.
+func TestMRRRollup_AllGroupsUnpriceableEmitsZero(t *testing.T) {
+	got := gather(t, []mrrGroup{
+		{Plan: "marketplace", Period: "monthly", Currency: "USD", Subscriptions: 5},
+	}, nil, usdOnly)
+
+	assert.Equal(t, map[[2]string]float64{{"all", "USD"}: 0}, got)
+}
+
+// Zero active subscriptions — the production state today — emits a zero.
+func TestMRRRollup_NoActiveSubscriptions(t *testing.T) {
+	got := gather(t, []mrrGroup{}, nil, usdOnly)
+	assert.Equal(t, map[[2]string]float64{{"all", "USD"}: 0}, got)
+}
+
+// A DB error emits the fallback zero rather than gapping or panicking.
+func TestMRRRollup_DBErrorEmitsZero(t *testing.T) {
+	got := gather(t, nil, errors.New("boom"), usdOnly)
+	assert.Equal(t, map[[2]string]float64{{"unknown", "USD"}: 0}, got)
+}
+
+// An FX outage must not lose the USD bucket, and a currency with no rate
+// contributes 0 while keeping its series visible.
+func TestMRRRollup_FXErrorKeepsUSDAndZeroesOthers(t *testing.T) {
+	c := newMRRRollupWithReader(
+		stubGroupReader{groups: []mrrGroup{
+			{Plan: "starter", Period: "monthly", Currency: "USD", Subscriptions: 1},
+			{Plan: "starter", Period: "monthly", Currency: "INR", Subscriptions: 4},
+		}},
+		stubRates{err: errors.New("fx down")},
+		quietLogger(),
+	)
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(c))
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	require.Len(t, mfs, 1)
+
+	values := map[string]float64{}
+	for _, mtr := range mfs[0].GetMetric() {
+		for _, l := range mtr.GetLabel() {
+			if l.GetName() == "currency" {
+				values[l.GetValue()] = mtr.GetGauge().GetValue()
+			}
+		}
+	}
+	assert.InDelta(t, 19.0, values["USD"], 1e-9)
+	assert.InDelta(t, 0.0, values["INR"], 1e-9)
+}
+
+// The collector must never panic, whatever the input.
+func TestMRRRollup_NeverPanics(t *testing.T) {
+	c := newMRRRollupWithReader(
+		stubGroupReader{groups: []mrrGroup{
+			{Plan: "", Period: "", Currency: "", Subscriptions: 0},
+			{Plan: "STARTER", Period: "ANNUAL", Currency: "usd", Subscriptions: 1},
+		}},
+		stubRates{rates: nil},
+		quietLogger(),
+	)
+	ch := make(chan prometheus.Metric, 8)
+	require.NotPanics(t, func() { c.Collect(ch) })
+	close(ch)
+
+	// Case-insensitive plan/period/currency still resolve.
+	var found bool
+	for mtr := range ch {
+		var pb dto.Metric
+		require.NoError(t, mtr.Write(&pb))
+		if pb.GetGauge().GetValue() > 0 {
+			found = true
+			assert.InDelta(t, 182.0/12, pb.GetGauge().GetValue(), 1e-9)
+		}
+	}
+	assert.True(t, found, "expected the case-varied row to be priced")
+}


### PR DESCRIPTION
Fixes the only recurring error in mark8ly production. Surveying all six services over 30 minutes, this was the **sole** repeating ERROR — 12× on each marketplace-api engine, nothing at all from auth-bff, platform-api, storefront or otto.

```
ERROR: column "plan_amount_minor" does not exist (SQLSTATE 42703)
mrr_rollup: aggregate query failed
```

## It never worked — this is not a regression

The query did `SUM(plan_amount_minor)` against `store_subscriptions`. I dumped the live schema: that column has **never existed**, and there is **no amount column at all** — price is not stored on the subscription. Postgres rejects the statement at parse time, so the collector has taken its error path and emitted a zero on every scrape since it was written.

A metric that reports 0 while erroring is worse than one that is absent: the dashboard looks answered.

## How MRR is computed now

SQL does only `COUNT(*)`, grouped by `(plan, subscription_period, billing_currency)` where `status='active'`. The amount is resolved **in Go** from `internal/billing/pricing` — `DevelopedAmount`, falling back to `PPPAmount`, both returning `(Amount, bool)`. **No `Must*`, no unchecked map indexing**: this runs inside a Prometheus scrape and must never panic. Keys are trimmed and case-normalised, because catalog keys are lowercase and `billing_currency` is a `CHAR(3)` with no enforced case.

**Annual is normalised to monthly** — otherwise the number is not MRR and every dashboard built on it is wrong. The division happens in `decimal` and is *not* rounded to whole minor units per group: rounding to cents before multiplying by the subscriber count biases the total in proportion to how many subscribers there are. The only rounding left is the float64 at the gauge boundary.

## A trap worth calling out

Monthly and annual rows for the same `(plan, currency)` are summed **before** emission. The metric has no period label, so emitting both would produce a duplicate label set and make Prometheus `Gather()` fail — turning a wrong number into a broken scrape. There is a test pinning this.

## Unpriceable groups are excluded, not zeroed

A plan the catalog cannot price is omitted from the gauge and logged once per scrape, naming every offending `plan/period/currency(n=…)` and the total unpriced subscription count.

Emitting zero would be the wrong call: a zero series is indistinguishable from a plan genuinely earning nothing. An absent series plus a loud log is visible. If *every* group is unpriceable the `{plan="all",currency="USD"} 0` fallback still fires, so dashboards never gap.

## Testing

`gofmt` clean; `go build ./...` OK; `go vet ./...` OK; `go test ./...` → **106 packages ok, 0 FAIL**.

14 tests in `internal/metrics`, asserting **gauge values**, not merely that it does not crash:

| case | assertion |
|---|---|
| monthly | `$19 × 3 = 57.00` |
| annual normalised | `$182 × 2 / 12 = 30.3333` — and `< 40`, which fails loudly on the un-normalised 364 |
| mixed periods, one series | `19 + 15.1666 = 34.1666` |
| two currencies | USD `19.00` and INR separate, not summed |
| unpriceable plan | absent, while `starter=19.00` survives |
| zero subscriptions | `{all,USD} 0` |
| DB error | `{unknown,USD} 0` |
| FX outage | USD intact, others 0 |
| never panics | explicit |

## Risk, stated plainly

`store_subscriptions` currently holds **zero rows**, so there is no live revenue to validate against and the tests are the only real check — which is why they assert values rather than absence of panic.

That also means nothing yet confirms stored `plan` strings match catalog plan names. `trial` and `marketplace` have no catalog price *by design* and will log as unpriceable if they ever go active — **that log line is the early warning**, and it is worth watching the first time a real subscription lands.

## Pre-existing, not introduced here

The gauge is named `_usd` and converts through `fx_rates`, so a currency with no FX row reports 0 for a real revenue bucket. Carried over from the old code; it under-reports rather than erroring, and deserves its own fix.
