### PR TITLE
fix(audit): name the write timeout, and derive every drain budget from it (#804)

### DIFF
--- a/services/marketplace-api/cmd/break-glass-rotation/main.go
+++ b/services/marketplace-api/cmd/break-glass-rotation/main.go
@@ -105,7 +105,13 @@ func main() {
 }
 
 func drain(e *audit.Emitter) {
-	drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// audit.WriteTimeout PLUS head-room, not a bare 5s. `Stop` is
+	// best-effort and returns on this deadline logging "in-flight events
+	// may be lost"; a budget EQUAL to the write timeout leaves no margin,
+	// because Stop's clock starts here while the write began earlier. This
+	// process exits straight after, so a dropped row is dropped for good.
+	// mark8ly#804.
+	drainCtx, cancel := context.WithTimeout(context.Background(), audit.WriteTimeout+time.Second)
 	defer cancel()
 	e.Stop(drainCtx)
 }

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -2843,7 +2843,15 @@ func main() {
 		}
 	}
 	if auditEmitter != nil {
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// audit.WriteTimeout PLUS head-room, not a bare 5s that happens to
+		// match it. `Stop` is best-effort: it waits for the workers or this
+		// deadline, whichever comes first, and on the deadline it logs
+		// "in-flight events may be lost" and returns. A budget EQUAL to the
+		// write timeout leaves no margin — Stop's clock starts here, while the
+		// write it is waiting on began earlier and may legitimately consume
+		// its full budget — so a healthy write can still be in flight when
+		// this expires and the row is dropped on shutdown. mark8ly#804.
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), audit.WriteTimeout+time.Second)
 		auditEmitter.Stop(stopCtx)
 		stopCancel()
 		log.Info("audit emitter stopped")

--- a/services/marketplace-api/cmd/reconciliation-cron/main.go
+++ b/services/marketplace-api/cmd/reconciliation-cron/main.go
@@ -70,7 +70,13 @@ func main() {
 	if err != nil {
 		log.Error("reconciliation-cron: run failed", "err", err)
 		// Drain audit queue before exit.
-		drainCtx, drainCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// audit.WriteTimeout PLUS head-room, not a bare 5s. `Stop` is
+		// best-effort and returns on this deadline logging "in-flight events
+		// may be lost"; a budget EQUAL to the write timeout leaves no margin,
+		// because Stop's clock starts here while the write began earlier. This
+		// process exits straight after, so a dropped row is dropped for good.
+		// mark8ly#804.
+		drainCtx, drainCancel := context.WithTimeout(context.Background(), audit.WriteTimeout+time.Second)
 		defer drainCancel()
 		auditEmitter.Stop(drainCtx)
 		os.Exit(1)
@@ -79,7 +85,13 @@ func main() {
 	log.Info("reconciliation-cron: done", "drift_count", driftCount)
 
 	// Drain the async audit queue before the process exits.
-	drainCtx, drainCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// audit.WriteTimeout PLUS head-room, not a bare 5s. `Stop` is
+	// best-effort and returns on this deadline logging "in-flight events
+	// may be lost"; a budget EQUAL to the write timeout leaves no margin,
+	// because Stop's clock starts here while the write began earlier. This
+	// process exits straight after, so a dropped row is dropped for good.
+	// mark8ly#804.
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), audit.WriteTimeout+time.Second)
 	defer drainCancel()
 	auditEmitter.Stop(drainCtx)
 }

--- a/services/marketplace-api/internal/audit/drain_budget_test.go
+++ b/services/marketplace-api/internal/audit/drain_budget_test.go
@@ -1,0 +1,51 @@
+package audit_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+)
+
+// drainBudget is the deadline every test in this package hands to
+// Emitter.Stop before reading back the row it just emitted.
+//
+// It is DERIVED from audit.WriteTimeout rather than being a number of its
+// own, because the two are not independent choices. Stop's drain is
+// best-effort and bounded by the caller's context, while the worker's
+// insert runs on its own WriteTimeout-bounded context; a budget shorter
+// than WriteTimeout lets Stop return on its deadline while a healthy
+// insert is still in flight, and the read that follows finds nothing.
+// That is mark8ly#804: the tests used a flat 2s against a 5s write and
+// passed only because the database was usually fast enough. Writing it
+// as a derivation means the budget cannot silently fall below the write
+// again if WriteTimeout is ever changed.
+//
+// The extra second is head-room, not superstition: Stop's clock starts
+// when Stop is called, whereas the write it is waiting on may only have
+// begun a moment earlier and may legitimately consume its full
+// WriteTimeout. Exactly WriteTimeout would leave zero margin for that
+// offset plus the queue handoff.
+const drainBudget = audit.WriteTimeout + time.Second
+
+// Compile-time floor. Constant expressions are evaluated by the compiler,
+// and converting a negative constant to uint is a compile error, so this
+// line stops the package building at all if drainBudget is ever edited
+// below audit.WriteTimeout — including via a change to WriteTimeout
+// itself. A failing build is a louder signal than a flaky test, which is
+// the failure mode this whole file exists to remove.
+const _ = uint(drainBudget - audit.WriteTimeout)
+
+// TestDrainBudgetCoversTheWriteTimeout states the same invariant in a
+// form a reader will actually see when it is violated. The compile-time
+// guard above is the real enforcement — it fires before this test can
+// run — but a bare `const _ = uint(...)` explains nothing on its own, and
+// this failure message does.
+func TestDrainBudgetCoversTheWriteTimeout(t *testing.T) {
+	require.GreaterOrEqual(t, drainBudget, audit.WriteTimeout,
+		"a Stop deadline shorter than audit.WriteTimeout can expire while a healthy "+
+			"insert is still in flight, so any test that Stops and then reads the row "+
+			"back would be racing the write rather than testing it (mark8ly#804)")
+}

--- a/services/marketplace-api/internal/audit/emitter.go
+++ b/services/marketplace-api/internal/audit/emitter.go
@@ -15,6 +15,24 @@ import (
 	"gorm.io/gorm"
 )
 
+// WriteTimeout bounds every audit insert this package performs on its own
+// connection — the background worker's write() and the synchronous
+// EmitSync. Both deliberately substitute a fresh context.Background() for
+// the caller's, so that a client disconnecting mid-request cannot cancel
+// the record of what it did; something then has to stop a slow database
+// pinning the worker forever, and this is that bound. EmitTx is the one
+// insert NOT bounded by it: that one runs inside the caller's transaction
+// and must share the caller's cancellation, by design.
+//
+// It is a named constant rather than a literal at each site because the
+// two sites are one fact, not two: an insert's budget. Two literals drift.
+//
+// It is EXPORTED for callers, not merely for tests. Choosing a deadline
+// for Stop requires knowing how long an in-flight write may still be
+// running, because Stop's budget is measured against exactly this number
+// — see Stop, and pass it at least this much.
+const WriteTimeout = 5 * time.Second
+
 // Event is the input to Emitter.Emit. Required fields are validated by
 // the emitter; a missing tenant causes the event to be dropped with a
 // warning rather than written as a tenant-unscoped row. Store is optional
@@ -185,7 +203,7 @@ func (e *Emitter) EmitSync(c *gin.Context, ev Event) error {
 	// Use a fresh background context with a timeout rather than the
 	// request's — matching write(). A client disconnecting mid-purge must
 	// not cancel the record of what was destroyed.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), WriteTimeout)
 	defer cancel()
 	if err := e.repo.Create(ctx, e.db, entry); err != nil {
 		return fmt.Errorf("audit.EmitSync: insert: %w", err)
@@ -206,10 +224,11 @@ func (e *Emitter) EmitSync(c *gin.Context, ev Event) error {
 // transaction to join, and Emit everywhere else.
 //
 // ctx is the CALLER's, and this deliberately contradicts both neighbours.
-// write() and EmitSync each substitute a fresh context.Background() with a
-// 5s timeout so a disconnecting client cannot cancel the record. That is
-// right for them — their write outlives the request by design — and wrong
-// here: this insert runs inside someone else's transaction and must share
+// write() and EmitSync each substitute a fresh context.Background()
+// bounded by WriteTimeout so a disconnecting client cannot cancel the
+// record. That is right for them — their write outlives the request by
+// design — and wrong here: this insert runs inside someone else's
+// transaction and must share
 // that transaction's cancellation. Do not "fix" it back to
 // context.Background(); TestEmitTx_UsesTheCallersContext pins it.
 //
@@ -253,6 +272,24 @@ func (e *Emitter) EmitTx(ctx context.Context, tx *gorm.DB, c *gin.Context, ev Ev
 // Stop signals workers to drain the queue and exit. Safe to call once;
 // further Emit calls after Stop will block briefly until workers exit
 // then drop. Intended to be called from main on shutdown signal.
+//
+// The drain is BEST-EFFORT, bounded by ctx and not by the queue emptying.
+// Stop returns when every worker has exited OR when ctx expires, whichever
+// happens first; on expiry it logs a warning and returns with events still
+// unwritten. It does not promise the queue is drained, and never has.
+//
+// THE TRAP, because it is not the obvious one: a worker's insert runs on
+// its own context bounded by WriteTimeout, which is entirely independent
+// of ctx. So a caller whose deadline is SHORTER than WriteTimeout can have
+// ctx expire while a perfectly healthy insert is still in flight — nothing
+// is failing, the row simply has not landed yet. Stop returns, the warning
+// says events "may be lost", and the caller cannot tell that case apart
+// from a real failure. (The insert itself is not cancelled — the worker
+// goroutine carries on — but a process that exits, or a caller that reads
+// the row back straight away, sees the event as lost either way.)
+//
+// So: give ctx at least WriteTimeout. mark8ly#804 was a test that gave 2s
+// and then read the row back, and lost that race under a loaded database.
 func (e *Emitter) Stop(ctx context.Context) {
 	if e == nil {
 		return
@@ -291,10 +328,12 @@ func (e *Emitter) worker() {
 }
 
 func (e *Emitter) write(entry Entry) {
-	// Use a fresh background context with a short timeout so a slow DB
+	// Use a fresh background context bounded by WriteTimeout so a slow DB
 	// can't pin the worker indefinitely. Audit writes are ephemeral —
-	// dropping one on timeout is preferable to backing up the queue.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// dropping one on timeout is preferable to backing up the queue. This
+	// context is independent of any ctx passed to Stop, which is why Stop
+	// documents WriteTimeout as the floor for its own deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), WriteTimeout)
 	defer cancel()
 	if err := e.repo.Create(ctx, e.db, &entry); err != nil {
 		e.logger.Error("audit.Emitter: insert failed",

--- a/services/marketplace-api/internal/audit/state_transition_test.go
+++ b/services/marketplace-api/internal/audit/state_transition_test.go
@@ -37,7 +37,7 @@ func TestEmitStateTransition_WritesCanonicalEvent(t *testing.T) {
 	})
 
 	// Drain queue.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), drainBudget)
 	defer cancel()
 	em.Stop(ctx)
 
@@ -79,7 +79,7 @@ func TestEmitStateTransition_TerminalStatesGetWarning(t *testing.T) {
 		Actor:    "system:cron:retention",
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), drainBudget)
 	defer cancel()
 	em.Stop(ctx)
 
@@ -114,7 +114,7 @@ func TestEmitPlanChange_WritesCanonicalEvent(t *testing.T) {
 		EffectiveAt: time.Now(),
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), drainBudget)
 	defer cancel()
 	em.Stop(ctx)
 
@@ -154,7 +154,7 @@ func TestEmitPlanChange_BlockedOverQuota_SeverityWarning(t *testing.T) {
 		Reason:     "store_count=3 > starter_limit=2",
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), drainBudget)
 	defer cancel()
 	em.Stop(ctx)
 

--- a/services/marketplace-api/internal/subscription/statemachine/machine_test.go
+++ b/services/marketplace-api/internal/subscription/statemachine/machine_test.go
@@ -143,7 +143,16 @@ func TestTransition_EmitsAuditEvent(t *testing.T) {
 	}))
 
 	// Drain the async queue before asserting.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	//
+	// The budget DERIVES from the write it is waiting on, and must not be a
+	// bare number again (mark8ly#804). `Stop` is best-effort: it waits for the
+	// workers or the caller's deadline, whichever comes first, and on the
+	// deadline it logs "in-flight events may be lost" and returns. A budget
+	// shorter than `audit.WriteTimeout` therefore lets a perfectly healthy
+	// write still be in flight when `Stop` gives up, and the read below finds
+	// nothing — a flake with no bug behind it. The spare second is head-room:
+	// `Stop`'s clock starts here, while the write it waits on began earlier.
+	ctx, cancel := context.WithTimeout(context.Background(), audit.WriteTimeout+time.Second)
 	defer cancel()
 	em.Stop(ctx)
 


### PR DESCRIPTION
Closes #804.

## The mechanism, demonstrated rather than assumed

`Stop` is **best-effort by design**: it waits for the workers or the caller's deadline, whichever comes first, and on the deadline logs *"in-flight events may be lost"* and returns. It never promised the queue was drained.

The worker's write has its own **5-second** context. A caller giving `Stop` less than that can have the deadline expire while a perfectly healthy write is still in flight. The flaky test gave it **2 seconds**.

Reproduced before fixing: shrinking the budget to 1ns failed **3 runs in 5**, with the issue's exact signature —

```
WARN msg="audit.Emitter: shutdown timed out, in-flight events may be lost"
state_transition_test.go:88: Received unexpected error: record not found
```

The 2-of-5 that passed confirm a race, not a deterministic break. **The production code was honest; the test relied on a guarantee it never made.**

## The actual defect: two numbers that must relate, and nothing relating them

`5 * time.Second` appeared as **two independent literals** inside the emitter, and the test's 2s could derive from neither. So:

- `audit.WriteTimeout` now backs both write sites. **Exported** — the test package is `audit_test` (external), and the doc says it exists for callers choosing a `Stop` deadline, not merely for tests.
- `EmitTx` is deliberately **not** bounded by it (it shares the caller's transaction context), and the comment says so, so nobody "unifies" the third site.
- Budgets are `WriteTimeout + 1s`, not equal to it: **`Stop`'s clock starts when `Stop` is called, while the write it waits on began earlier**, so equality leaves zero margin.

## Scope grew, in both directions

**The issue named one test; four had the defect** — `state_transition_test.go` has four `Stop`-then-read tests, all on a flat 2s. Fixing only the reported one would have left three identical flakes. A fifth lived in `internal/subscription/statemachine/machine_test.go`.

**And four PRODUCTION drain sites sat at exactly 5s** — `cmd/marketplace-api` shutdown, both `reconciliation-cron` paths, and `break-glass-rotation`'s `drain()`. Not shorter, so not a bug — but with **no margin**, for the offset reason above. The two crons exit immediately after draining, so a dropped row there is dropped for good. All four now derive from the constant.

I did **not** blanket-replace: `main.go` holds five instances of that literal and only one is the audit drain. Each site was edited individually.

## Guards, both still biting

- `drainBudget = audit.WriteTimeout - time.Second` → **build fails** (`constant -1000000000 overflows uint`), a compile-time floor.
- Bypassing the constant with an inline 1ns → **FAIL**, `record not found`. The row assertion is still load-bearing, not decorative.

## Test plan

- [x] `gofmt -l` clean, `go build ./...`, `go vet ./...`, `go vet -tags=integration`
- [x] `go test -count=1 ./...` — **106 packages ok, 0 fail**
- [x] Integration `-p 1` over `internal/audit` and `internal/subscription/statemachine` — ok, and audit reports **44 RUN / 44 PASS / 0 SKIP**, verified by counting rather than reading the `ok` line

## One thing worth a follow-up

The three cron/shutdown sites now import `internal/audit` purely for the constant, which is correct but couples them. If that ever grates, the alternative is a `DrainBudget()` helper on the emitter — I did not add one, because a second name for the same fact is what caused this issue.