### PR TITLE
feat(promo): actually grant the trial extension a promo code promises (#620)

### DIFF
--- a/.planning/quick/260908-tx-promo-trial-extension/PLAN.md
+++ b/.planning/quick/260908-tx-promo-trial-extension/PLAN.md
@@ -1,0 +1,85 @@
+# Deliver the trial extension a promo code promises (#620)
+
+`promo_codes.trial_extension_days` is ingested from the console (#745), stored,
+and documented on the model as *"the number of days added to the store trial on
+redemption (#620)"*. `promo.Service.ApplyPromo` never reads it.
+
+So a merchant who redeems a trial-extension code today gets a `200`, a ledger
+row, and **no extra days**. Nothing errors and nothing logs, because the
+validator already handles a discount-less row correctly — it leaves the price
+untouched and accepts, on the stated understanding that "the benefit is
+delivered elsewhere". Elsewhere does not exist.
+
+`validator.go` warns about exactly this failure mode one layer down:
+
+> both are silently correct arithmetic for the wrong code, and both would hide
+> a failed ingest.
+
+## Tasks
+
+### 1. One definition of "can this trial move"
+
+`trial.Extend` refuses a converted, non-trialing or already-lapsed trial inside
+its row lock. A caller that wants to refuse *before* writing anything needs the
+same rule, and a second copy of it would drift.
+
+- [ ] Extract `trial.Extendable(sub, now) error` from `Extend`'s refusal
+      switch, returning the same sentinels. `Extend` calls it under the lock;
+      nothing else changes about `Extend`.
+- **Done when** `Extend`'s behaviour is byte-identical and the switch exists once.
+
+### 2. Apply the extension on redemption
+
+- [ ] `promo.TrialExtender` — the narrow interface satisfied by `*trial.Extender`.
+- [ ] `ApplyInput.Sub *subscription.StoreSubscription` — the row the extension
+      is computed from. All three callers already hold it.
+- [ ] Pre-flight, before any write: a trial-extension code on a subscription
+      that fails `trial.Extendable` is rejected with a new reason, so the
+      merchant gets a 422 and **their redemption is not burned**.
+- [ ] Extend AFTER the ledger row is written, with
+      `callerIdemKey = "promo_redeem:<redemption id>"`, per #620.
+- [ ] Base date is `trial.EndsAt(sub) + N days` — never `created_at + TrialDays`.
+      #620 names this specifically: `Extend` takes an absolute end, so computing
+      from the signup date silently overwrites an operator-granted extension.
+- **Done when** a 14-day code on a trial ending in 10 days sets the end 24 days
+  out, and a code applied to an operator-extended trial adds to the stored end.
+
+### 3. Fail honestly, in both directions
+
+- [ ] Extension fails → roll back the ledger row and the Stripe coupon, so a
+      retry works rather than reporting the code spent.
+- [ ] **Except** `trial.ErrStripeAppliedLocalWriteFailed`: Stripe has already
+      moved the merchant's billing date. Rolling back would hide it. Keep the
+      row and surface the error.
+- [ ] A trial-extension code with no extender wired, or no subscription passed,
+      is a **server** fault and must 500 — never a 422 telling the merchant a
+      valid code is invalid.
+- **Done when** each path has a test that fails if the branch is removed.
+
+### 4. Say what was granted
+
+- [ ] `ApplyOutput.TrialExtensionDays` / `TrialEndsAt`, set through `terms()` so
+      `ValidateCode` describes the same row identically — the rule
+      `PercentOffBps` already follows for the win-back email (#727).
+- [ ] Surface both on the apply-promo response.
+- **Done when** the confirmation can state "+14 days, now ending 3 Nov" from
+  the response alone.
+
+### 5. Wire it
+
+- [ ] `promo.NewService` gains the extender at both `main.go` construction
+      sites, sharing the `trial.NewExtender(trialStripe)` already built there.
+
+## Out of scope
+
+The onboarding field (#620's last checkbox) — it needs the validate endpoint to
+be reachable unauthenticated, which is a separate surface with its own
+rate-limiting question. This task makes the benefit real for the redemption
+paths that already exist.
+
+## Decision recorded: a lapsed trial cannot be extended
+
+#620 open question 1. `extend.go` already settled it — *"Reinstating an
+already-expired trial is out of scope"* — and this change adopts that answer
+rather than inventing a second one: the code is refused with
+`trial_not_extendable`, and the merchant keeps their redemption.

--- a/apps/admin/lib/api/subscription/schemas/promo.ts
+++ b/apps/admin/lib/api/subscription/schemas/promo.ts
@@ -13,7 +13,8 @@
  * address would let one merchant spend another's cap.
  *
  * Response 200: { stripe_coupon_id, effective_minor, currency,
- *                 percent_off_bps, max_duration_months }
+ *                 percent_off_bps, max_duration_months,
+ *                 trial_extension_days?, trial_ends_at? }
  * Response 422: { error: "promo_invalid_or_expired", message, reason }
  */
 import { z } from 'zod'
@@ -53,6 +54,20 @@ export const applyPromoResponseSchema = z.object({
   percent_off_bps: z.number().int().default(0),
   /** Months the discount runs for. 0 means the row states no bound — never "zero months". */
   max_duration_months: z.number().int().default(0),
+  /**
+   * Trial days this code granted (#620). Absent for a discount-only code,
+   * which is most of them.
+   */
+  trial_extension_days: z.number().int().default(0),
+  /**
+   * The trial end that was actually written, RFC 3339. Absent when the code
+   * granted no trial days.
+   *
+   * Never re-derive it as "today + trial_extension_days": the extension is
+   * applied to the subscription's EFFECTIVE trial end, which may already
+   * carry an extension an operator granted and this client cannot see.
+   */
+  trial_ends_at: z.string().optional(),
 })
 
 export type ApplyPromoResponse = z.infer<typeof applyPromoResponseSchema>
@@ -79,6 +94,7 @@ export const PROMO_REJECT_REASONS = [
   'below_absolute_floor',
   'currency_not_covered',
   'unknown_discount_type',
+  'trial_not_extendable',
 ] as const
 
 export type PromoRejectReason = (typeof PROMO_REJECT_REASONS)[number]

--- a/apps/admin/lib/copy/promoApplied.ts
+++ b/apps/admin/lib/copy/promoApplied.ts
@@ -6,6 +6,7 @@
  * enforces: state only what the response actually contains.
  */
 import { subscriptionCopy } from '@/lib/copy/subscription'
+import { formatBillingDate } from '@/lib/format/date'
 import { formatMinorUnits } from '@/lib/format/minorUnits'
 import type { ApplyPromoResponse } from '@/lib/api/subscription/schemas/promo'
 
@@ -46,16 +47,43 @@ function formatPercentBps(bps: number): string | null {
  * subscription's discounts and nothing re-bills the current period.
  */
 export function promoAppliedMessage(res: ApplyPromoResponse): string {
+  const trial = trialExtensionPhrase(res)
+
+  // A trial-extension-ONLY code carries no discount and no coupon (#620), so
+  // there is no price to quote and the discount sentences would all be
+  // false. The days ARE the whole offer.
+  if (trial !== null && res.percent_off_bps === 0 && !res.stripe_coupon_id) {
+    return copy.appliedTrialDaysOnly(res.trial_extension_days, trial)
+  }
+
+  const suffix =
+    trial === null ? '' : copy.appliedTrialDaysSuffix(res.trial_extension_days, trial)
+
   if (!res.currency) {
-    return copy.appliedNoPrice
+    return copy.appliedNoPrice + suffix
   }
 
   const price = formatMinorUnits(res.effective_minor, res.currency)
   const percentOff = formatPercentBps(res.percent_off_bps)
 
   if (percentOff !== null && res.max_duration_months > 0) {
-    return copy.appliedForMonths(percentOff, res.max_duration_months, price)
+    return copy.appliedForMonths(percentOff, res.max_duration_months, price) + suffix
   }
 
-  return copy.applied(price)
+  return copy.applied(price) + suffix
+}
+
+/**
+ * The formatted new trial end, or null when this response grants no trial
+ * days — or grants days without a date we can show.
+ *
+ * Both halves are required before anything is said. Days with no date would
+ * leave the merchant to guess when their trial now ends, and the one date
+ * they would guess (today + days) is the wrong one whenever an operator has
+ * already extended them. Silence beats a date we did not write.
+ */
+function trialExtensionPhrase(res: ApplyPromoResponse): string | null {
+  if (res.trial_extension_days <= 0) return null
+  const endsOn = formatBillingDate(res.trial_ends_at)
+  return endsOn === '' ? null : endsOn
 }

--- a/apps/admin/lib/copy/promoRejection.ts
+++ b/apps/admin/lib/copy/promoRejection.ts
@@ -49,6 +49,8 @@ export function promoRejectionMessage(
       return copy.currencyNotCovered
     case 'unknown_discount_type':
       return copy.unknownDiscountType
+    case 'trial_not_extendable':
+      return copy.trialNotExtendable
   }
 }
 

--- a/apps/admin/lib/copy/subscription.ts
+++ b/apps/admin/lib/copy/subscription.ts
@@ -227,6 +227,8 @@ export const subscriptionCopy = {
         'We cannot apply this code to a subscription billed in your currency yet. Contact us with the code and we will apply the discount by hand.',
       unknownDiscountType:
         'Something is wrong with this code on our side \u2014 it is not set up correctly. Contact us with the code and we will fix it.',
+      trialNotExtendable:
+        'This code adds days to a free trial, and yours has already ended or converted to a paid plan. The code itself is fine \u2014 contact us and we will see what we can do.',
     },
 
     /**
@@ -252,6 +254,24 @@ export const subscriptionCopy = {
     /** Used when the server returned no currency, so no price can be quoted. */
     appliedNoPrice:
       'Code applied. The discount shows on your next invoice.',
+
+    /**
+     * Trial-extension confirmations (#620).
+     *
+     * The DATE comes from the response and is never recomputed here: the
+     * extension is applied to the subscription's effective trial end, which
+     * may already carry an operator's extension this client cannot see, so
+     * "today + N days" would show the merchant a date we did not write.
+     *
+     * `appliedTrialDaysOnly` is the whole sentence for a code that grants
+     * days and no discount \u2014 a shape the console mints deliberately, and
+     * one that needs no Stripe coupon at all.
+     */
+    appliedTrialDaysOnly: (days: number, endsOn: string) =>
+      `Code applied. Your trial is extended by ${days === 1 ? 'a day' : `${days} days`} and now ends on ${endsOn}.`,
+    /** Appended when a code grants days AND a discount. */
+    appliedTrialDaysSuffix: (days: number, endsOn: string) =>
+      ` Your trial is also extended by ${days === 1 ? 'a day' : `${days} days`}, to ${endsOn}.`,
 
     /** Non-refusal failures \u2014 the code was never judged. */
     networkError:

--- a/apps/admin/tests/unit/api/subscription/promo.test.ts
+++ b/apps/admin/tests/unit/api/subscription/promo.test.ts
@@ -43,6 +43,22 @@ const APPLIED_FIXTURE = {
   currency: 'usd',
   percent_off_bps: 2000,
   max_duration_months: 6,
+  trial_extension_days: 0,
+}
+
+/**
+ * A trial-extension-ONLY code (#620): no discount, no Stripe coupon, no
+ * price to quote. That shape is normal — the console mints no Coupon for a
+ * code that touches no Stripe object.
+ */
+const TRIAL_ONLY_FIXTURE = {
+  stripe_coupon_id: '',
+  effective_minor: 2900,
+  currency: 'usd',
+  percent_off_bps: 0,
+  max_duration_months: 0,
+  trial_extension_days: 14,
+  trial_ends_at: '2026-11-03T00:00:00Z',
 }
 
 function rejection(reason: string) {
@@ -184,6 +200,7 @@ describe('promoRejectionMessage', () => {
     'wrong_plan',
     'annual_only',
     'below_absolute_floor',
+    'trial_not_extendable',
   ] as const)('%s never claims the code is invalid or expired', (reason) => {
     const message = promoRejectionMessage(reason, CTX).toLowerCase()
     expect(message).not.toContain('invalid')
@@ -273,6 +290,49 @@ describe('promoAppliedMessage', () => {
     })
     expect(message).toContain('1,520')
     expect(message).not.toContain('15.20')
+  })
+
+  // #620. A trial-extension-only code has no discount and no price, so every
+  // discount sentence would be false. The days are the whole offer.
+  it('states the trial days and the new end date for an extension-only code', () => {
+    const message = promoAppliedMessage(TRIAL_ONLY_FIXTURE)
+    expect(message).toContain('14 days')
+    expect(message).toContain('3 November 2026')
+    expect(message).not.toContain('%')
+    expect(message).not.toContain('29.00')
+  })
+
+  it('states both when a code grants a discount AND trial days', () => {
+    const message = promoAppliedMessage({
+      ...APPLIED_FIXTURE,
+      trial_extension_days: 14,
+      trial_ends_at: '2026-11-03T00:00:00Z',
+    })
+    expect(message).toContain('20%')
+    expect(message).toContain('15.20')
+    expect(message).toContain('14 days')
+    expect(message).toContain('3 November 2026')
+  })
+
+  // The date is the server's, never re-derived. Without one there is nothing
+  // honest to say: "today + 14 days" is the wrong date for any merchant whose
+  // trial an operator has already extended.
+  it('says nothing about the trial when the response carries days but no date', () => {
+    const message = promoAppliedMessage({
+      ...TRIAL_ONLY_FIXTURE,
+      trial_ends_at: undefined,
+    })
+    expect(message).not.toContain('14 days')
+    expect(message).not.toContain('trial')
+  })
+
+  it('says a day, not 1 days', () => {
+    const message = promoAppliedMessage({
+      ...TRIAL_ONLY_FIXTURE,
+      trial_extension_days: 1,
+    })
+    expect(message).toContain('a day')
+    expect(message).not.toContain('1 days')
   })
 
   it('never claims the discount applies today', () => {

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -210,6 +210,17 @@ func (a *trialStripeAdapter) GetSubscription(ctx context.Context, id string) (*b
 	return billingstripe.GetSubscription(ctx, a.c, id)
 }
 
+// promoTrialStripe returns the trial updater for a billing client, keeping the
+// interface a TRUE nil when there is no client. Written once because both
+// promo.Service constructions need it and a copy that forgot the nil check
+// would panic inside an open transaction — see trial.NewExtender.
+func promoTrialStripe(c *billingstripe.Client) trial.StripeTrialUpdater {
+	if c == nil {
+		return nil
+	}
+	return &trialStripeAdapter{c: c}
+}
+
 func (a *trialStripeAdapter) UpdateTrialEnd(ctx context.Context, in billingstripe.UpdateTrialEndParams) (*billingstripe.Subscription, error) {
 	return billingstripe.UpdateTrialEnd(ctx, a.c, in)
 }
@@ -1219,7 +1230,16 @@ func main() {
 
 		// P10 — Promo-code engine (§7).
 		promoRepo := promo.NewRepository()
-		promoSvc := promo.NewService(conn, promoRepo, billingStripeClient, log)
+		promoSvc := promo.NewService(conn, promoRepo, billingStripeClient, log).
+			// A console-defined code may grant trial days as well as, or
+			// instead of, a discount (#620). Without this the extension is
+			// silently skipped and the merchant is told the code applied —
+			// so ApplyPromo refuses rather than degrades when it is absent.
+			//
+			// A TRUE nil interface when Stripe is unconfigured, for the
+			// reason trialStripe below documents at length: a typed nil
+			// makes `e.Stripe != nil` true and panics on first use.
+			WithTrialExtender(trial.NewExtender(promoTrialStripe(billingStripeClient)))
 		promoHandler := admin.NewPromoHandler(conn, promoSvc, subscriptionRepo, log).WithAudit(auditEmitter)
 
 		// P10 — 14-day cooling-off refund (§8).
@@ -2329,7 +2349,13 @@ func main() {
 	// so this service is constructed with a nil Stripe client on purpose.
 	// promo.Service.ValidateCode makes no Stripe call, and handing the cron a
 	// client it must not use would be an invitation to start using it.
-	winBackPromo := promo.NewService(conn, promo.NewRepository(), nil, log)
+	//
+	// It DOES get a trial extender, which is a different thing: ValidateCode
+	// never calls Extend, but it does refuse a trial-extension code that has
+	// no way to be delivered. Without one here, the win-back's validate
+	// would disagree with the redeem path about a code that carries days.
+	winBackPromo := promo.NewService(conn, promo.NewRepository(), nil, log).
+		WithTrialExtender(trial.NewExtender(promoTrialStripe(billingStripeClient)))
 
 	winBackCron := lifecycle.NewWinBackCron(conn, winBackEmailClient, log, nil).
 		WithSkipCounter(lifecycleSkipCounter{metrics.BillingEmailsSkippedTotal}).

--- a/services/marketplace-api/internal/audit/promo_events.go
+++ b/services/marketplace-api/internal/audit/promo_events.go
@@ -1,6 +1,8 @@
 package audit
 
 import (
+	"time"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
@@ -15,6 +17,17 @@ type PromoApplied struct {
 	RejectReason string
 	// Accepted indicates whether the promo was successfully applied.
 	Accepted bool
+	// TrialExtensionDays and TrialEndsAt record a trial extension this code
+	// granted (#620), and are omitted from the metadata when it granted
+	// none.
+	//
+	// Recorded because the code alone does not say what changed: a promo can
+	// move a merchant's billing date, which is the same consequential write
+	// an operator extension emits its own audit row for. Without these, the
+	// only trace of a moved trial end is a code string whose definition
+	// lives in another system and can be edited after the fact.
+	TrialExtensionDays int
+	TrialEndsAt        time.Time
 }
 
 // EmitPromoApplied emits a subscription.promo_applied audit event.
@@ -28,6 +41,12 @@ func (e *Emitter) EmitPromoApplied(c *gin.Context, p PromoApplied) {
 	}
 	if p.RejectReason != "" {
 		md["reject_reason"] = p.RejectReason
+	}
+	if p.TrialExtensionDays > 0 {
+		md["trial_extension_days"] = p.TrialExtensionDays
+	}
+	if !p.TrialEndsAt.IsZero() {
+		md["trial_ends_at"] = p.TrialEndsAt.UTC().Format(time.RFC3339)
 	}
 
 	severity := SeverityInfo

--- a/services/marketplace-api/internal/audit/promo_events_test.go
+++ b/services/marketplace-api/internal/audit/promo_events_test.go
@@ -1,0 +1,90 @@
+package audit_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+)
+
+// emitPromoAndDrain emits one promo_applied event and returns the row that
+// was written. Stop drains the queue, so this is deterministic rather than an
+// "eventually" assertion against a background writer.
+func emitPromoAndDrain(t *testing.T, p audit.PromoApplied) *audit.Entry {
+	t.Helper()
+	repo := &recordingRepo{}
+	e, err := audit.NewEmitter(audit.EmitterConfig{DB: nil, Repo: repo, Logger: slog.Default()})
+	require.NoError(t, err)
+
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	e.EmitPromoApplied(c, p)
+	e.Stop(context.Background())
+
+	require.Len(t, repo.created, 1)
+	return repo.created[0]
+}
+
+// A promo can move a merchant's billing date, which is the same consequential
+// write an operator extension emits its own audit row for. The code string
+// alone does not record it: the definition behind it lives in the console and
+// can be edited afterwards (#620).
+func TestEmitPromoApplied_RecordsTheTrialExtensionItGranted(t *testing.T) {
+	end := time.Date(2026, 11, 3, 0, 0, 0, 0, time.UTC)
+	entry := emitPromoAndDrain(t, audit.PromoApplied{
+		TenantID:           uuid.New(),
+		StoreID:            uuid.New(),
+		Code:               "STAYLONGER",
+		Actor:              "user:" + uuid.New().String(),
+		Accepted:           true,
+		TrialExtensionDays: 14,
+		TrialEndsAt:        end,
+	})
+
+	require.Equal(t, float64(14), toNumber(t, entry.Metadata["trial_extension_days"]))
+	require.Equal(t, "2026-11-03T00:00:00Z", entry.Metadata["trial_ends_at"])
+}
+
+// A discount-only code granted no days, and the row must not imply it did.
+// A zero would read as "extended by nothing" rather than "not that kind of
+// code", and a zero-valued date would render as the year 1.
+func TestEmitPromoApplied_OmitsTheTrialFieldsWhenNoDaysWereGranted(t *testing.T) {
+	entry := emitPromoAndDrain(t, audit.PromoApplied{
+		TenantID: uuid.New(),
+		StoreID:  uuid.New(),
+		Code:     "WINBACK20OFF6MONTHS",
+		Actor:    "system:winback",
+		Accepted: true,
+	})
+
+	require.NotContains(t, entry.Metadata, "trial_extension_days")
+	require.NotContains(t, entry.Metadata, "trial_ends_at")
+}
+
+// toNumber tolerates the int/float64 ambiguity a metadata map picks up when
+// it round-trips through JSON, so the assertion is about the VALUE rather
+// than about which side of a serialiser the test happens to sit on.
+func toNumber(t *testing.T, v any) float64 {
+	t.Helper()
+	switch n := v.(type) {
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case float64:
+		return n
+	default:
+		t.Fatalf("metadata value %v (%T) is not a number", v, v)
+		return 0
+	}
+}

--- a/services/marketplace-api/internal/billing/trial/extend.go
+++ b/services/marketplace-api/internal/billing/trial/extend.go
@@ -204,6 +204,45 @@ func NewExtender(su StripeTrialUpdater) *Extender {
 	return &Extender{Stripe: su}
 }
 
+// Extendable reports whether sub's trial may be moved at now, returning the
+// same sentinel Extend refuses with, or nil when it may.
+//
+// THIS IS THE ONLY DEFINITION OF "can this trial move". Extend calls it
+// inside its row lock, where the answer is authoritative. A caller that must
+// refuse BEFORE writing anything of its own calls it on a row it has already
+// loaded — promo redemption does, so that a merchant whose trial cannot move
+// is refused without spending their one redemption (#620).
+//
+// A pre-flight answer is necessarily advisory: the row can convert between
+// the check and Extend's lock. That is why Extend re-checks rather than
+// trusting the caller. What this shares is the RULE, not the guarantee — a
+// second copy of the rule would drift, and the drift would show up as a
+// promo code accepted at the door and refused at the till.
+func Extendable(sub subscription.StoreSubscription, now time.Time) error {
+	// Order matters: `active` gets its own error even though it would
+	// also fail the trial-state check, because "already converted" is
+	// the acceptance criterion's own words and the console shows a
+	// different message for it.
+	switch {
+	case sub.Status == subscription.StatusActive:
+		return ErrAlreadyConverted
+	case sub.Status != subscription.StatusTrialing && sub.Status != subscription.StatusSignup:
+		return ErrNotTrialing
+	}
+
+	// A trial whose EFFECTIVE end has already passed but whose status is
+	// still `trialing` — the window between the end passing and the 00:15
+	// expiry cron sweeping it to `not_trialing` — must refuse the same way
+	// the post-cron state does. Using the SAME sentinel, ErrNotTrialing, is
+	// the point: the operator's answer must not depend on whether the cron
+	// happened to run yet. Reinstating an already-expired trial is out of
+	// scope (see the spec).
+	if !EndsAt(sub).After(now) {
+		return ErrNotTrialing
+	}
+	return nil
+}
+
 // Extend moves a trial's end date, refusing the states where doing so
 // would be wrong or would disagree with Stripe.
 //
@@ -239,26 +278,8 @@ func (e *Extender) Extend(ctx context.Context, db *gorm.DB, storeID uuid.UUID, n
 			return fmt.Errorf("trial: load subscription: %w", err)
 		}
 
-		// Order matters: `active` gets its own error even though it would
-		// also fail the trial-state check, because "already converted" is
-		// the acceptance criterion's own words and the console shows a
-		// different message for it.
-		switch {
-		case sub.Status == subscription.StatusActive:
-			return ErrAlreadyConverted
-		case sub.Status != subscription.StatusTrialing && sub.Status != subscription.StatusSignup:
-			return ErrNotTrialing
-		}
-
-		// A trial whose EFFECTIVE end has already passed but whose status
-		// is still `trialing` — the window between the end passing and the
-		// 00:15 expiry cron sweeping it to `not_trialing` — must refuse the
-		// same way the post-cron state does. Using the SAME sentinel,
-		// ErrNotTrialing, is the point: the operator's answer must not
-		// depend on whether the cron happened to run yet. Reinstating an
-		// already-expired trial is out of scope (see the spec).
-		if !EndsAt(sub).After(now) {
-			return ErrNotTrialing
+		if err := Extendable(sub, now); err != nil {
+			return err
 		}
 
 		// The EFFECTIVE end before the write — the derived date when the

--- a/services/marketplace-api/internal/handlers/admin/promo.go
+++ b/services/marketplace-api/internal/handlers/admin/promo.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -66,6 +67,14 @@ type applyPromoResponse struct {
 	// guess — the same rule the win-back email follows (#727).
 	PercentOffBps     int `json:"percent_off_bps"`
 	MaxDurationMonths int `json:"max_duration_months"`
+	// TrialExtensionDays and TrialEndsAt describe the trial days this code
+	// granted (#620). Both are omitted when it granted none — a
+	// discount-only code, which is most of them. TrialEndsAt is the date
+	// that was actually written, not one the client should re-derive: it is
+	// computed from the subscription's EFFECTIVE trial end, which may
+	// already carry an operator's extension the client cannot see.
+	TrialExtensionDays int        `json:"trial_extension_days,omitempty"`
+	TrialEndsAt        *time.Time `json:"trial_ends_at,omitempty"`
 }
 
 // applyPromoErrorResponse is the 422 body for a refused code.
@@ -133,6 +142,7 @@ func (h *PromoHandler) ApplyPromo(c *gin.Context) {
 		Currency:             stringVal(sub.BillingCurrency),
 		StripeSubscriptionID: stringVal(sub.StripeSubscriptionID),
 		Actor:                actor,
+		Sub:                  sub,
 	})
 
 	// Emit audit regardless of success/failure (§23.1).
@@ -170,6 +180,9 @@ func (h *PromoHandler) ApplyPromo(c *gin.Context) {
 		Currency:          stringVal(sub.BillingCurrency),
 		PercentOffBps:     out.PercentOffBps,
 		MaxDurationMonths: out.MaxDurationMonths,
+
+		TrialExtensionDays: out.TrialExtensionDays,
+		TrialEndsAt:        trialEndOrNil(out.TrialEndsAt),
 	})
 }
 
@@ -265,6 +278,16 @@ func (h *PromoHandler) CancelPromo(c *gin.Context) {
 	}
 
 	c.Status(http.StatusNoContent)
+}
+
+// trialEndOrNil keeps a zero time out of the response. Serialising it would
+// send "0001-01-01T00:00:00Z", which a client renders as a real date and a
+// merchant reads as a trial that ended two millennia ago.
+func trialEndOrNil(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
 }
 
 func stringVal(s *string) string {

--- a/services/marketplace-api/internal/handlers/admin/promo.go
+++ b/services/marketplace-api/internal/handlers/admin/promo.go
@@ -158,6 +158,9 @@ func (h *PromoHandler) ApplyPromo(c *gin.Context) {
 			Actor:        actor,
 			RejectReason: rejectReason,
 			Accepted:     applyErr == nil,
+
+			TrialExtensionDays: out.TrialExtensionDays,
+			TrialEndsAt:        out.TrialEndsAt,
 		})
 	}
 

--- a/services/marketplace-api/internal/promo/errors.go
+++ b/services/marketplace-api/internal/promo/errors.go
@@ -28,3 +28,13 @@ var ErrCurrencyNotCovered = errors.New("promo: currency not covered by floor tab
 // ErrProAppRefund indicates a Pro+App setup fee refund was requested, which
 // is never refundable per §8.
 var ErrProAppRefund = errors.New("refund: Pro+App setup fee is not refundable")
+
+// ErrTrialExtensionUnavailable is returned when a code that grants a trial
+// extension cannot be honoured for a reason that is OURS, not the merchant's:
+// no trial extender wired, or a caller that passed no subscription.
+//
+// Deliberately NOT ErrInvalidOrExpired. That error tells a merchant their code
+// is no good, which would be a lie here and would also bury a wiring
+// regression behind a routine 422 — the same "looks delivered, does nothing"
+// shape #620 exists to remove.
+var ErrTrialExtensionUnavailable = errors.New("promo: trial extension cannot be delivered")

--- a/services/marketplace-api/internal/promo/public_reason.go
+++ b/services/marketplace-api/internal/promo/public_reason.go
@@ -38,6 +38,13 @@ const (
 	PublicReasonBelowFloor         PublicRejectReason = "below_absolute_floor"
 	PublicReasonCurrencyNotCovered PublicRejectReason = "currency_not_covered"
 	PublicReasonUnknownDiscount    PublicRejectReason = "unknown_discount_type"
+
+	// PublicReasonTrialNotExtendable is safe to disclose for the reason
+	// given above: it is a fact about the caller's OWN subscription — their
+	// trial has ended, or they are already a paying customer — and it
+	// confirms nothing about a code they were not already holding. It is
+	// also the one refusal a merchant can act on, by asking an operator.
+	PublicReasonTrialNotExtendable PublicRejectReason = "trial_not_extendable"
 )
 
 // PublicReasonFor maps an internal reason onto the one the client is told.
@@ -66,6 +73,8 @@ func PublicReasonFor(r ValidationRejectReason) PublicRejectReason {
 		return PublicReasonCurrencyNotCovered
 	case RejectReasonUnknownDiscountType:
 		return PublicReasonUnknownDiscount
+	case RejectReasonTrialNotExtendable:
+		return PublicReasonTrialNotExtendable
 	default:
 		return PublicReasonInvalidOrExpired
 	}

--- a/services/marketplace-api/internal/promo/service.go
+++ b/services/marketplace-api/internal/promo/service.go
@@ -12,6 +12,7 @@ import (
 	"gorm.io/gorm"
 
 	billingstripe "github.com/mark8ly/marketplace-api/internal/billing/stripe"
+	"github.com/mark8ly/marketplace-api/internal/billing/trial"
 	"github.com/mark8ly/marketplace-api/internal/metrics"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
 	"github.com/mark8ly/marketplace-api/pkg/apperrors"
@@ -38,6 +39,17 @@ type ApplyInput struct {
 	StripeSubscriptionID string
 	// Actor is the audit actor string ("user:<uuid>" or "system:…").
 	Actor string
+	// Sub is the store subscription this code is being applied to.
+	//
+	// Needed ONLY by a code that carries a trial extension, and needed in
+	// full rather than as a copied-out date: both "may this trial move" and
+	// "what does it move from" are properties of the row, and each has
+	// exactly one definition (trial.Extendable, trial.EndsAt). Passing
+	// scalars would put a second copy of each here.
+	//
+	// Nil is correct for a discount-only code. Nil with a trial-extension
+	// code is a call-site bug and fails closed — see ApplyPromo.
+	Sub *subscription.StoreSubscription
 }
 
 // ApplyOutput is returned by Service.ApplyPromo on success.
@@ -59,6 +71,17 @@ type ApplyOutput struct {
 	// MaxDurationMonths is how many months the discount runs for, or 0 when
 	// the row sets no bound. 0 is "unbounded", never "zero months".
 	MaxDurationMonths int
+	// TrialExtensionDays is the number of days this code adds to the trial,
+	// or 0 when it extends none. Set by terms(), so ValidateCode reports the
+	// same number ApplyPromo would grant — a client can state "+14 days"
+	// before the merchant commits.
+	TrialExtensionDays int
+	// TrialEndsAt is the trial end AFTER the extension was applied. Set by
+	// ApplyPromo alone and zero everywhere else, including ValidateCode:
+	// asking whether a code would be accepted grants no date, and reporting
+	// one would invite a client to display a trial end that was never
+	// written.
+	TrialEndsAt time.Time
 }
 
 // terms copies the describable parts of a promo row into an output. Kept in
@@ -77,6 +100,9 @@ func terms(out ApplyOutput, pc *PromoCode) ApplyOutput {
 	if pc.MaxDurationMonths != nil {
 		out.MaxDurationMonths = *pc.MaxDurationMonths
 	}
+	if pc.TrialExtensionDays != nil {
+		out.TrialExtensionDays = *pc.TrialExtensionDays
+	}
 	return out
 }
 
@@ -89,11 +115,20 @@ type CancelInput struct {
 	Actor                string
 }
 
+// TrialExtender is the subset of *trial.Extender this package needs. Declared
+// here rather than imported as a concrete type so a redemption can be tested
+// without a database, and so the dependency points inward.
+type TrialExtender interface {
+	Extend(ctx context.Context, db *gorm.DB, storeID uuid.UUID,
+		newEnd, now time.Time, callerIdemKey string) (trial.ExtendResult, error)
+}
+
 // Service is the promo-code application service.
 type Service struct {
 	db     *gorm.DB
 	repo   Repository
 	stripe *billingstripe.Client
+	trial  TrialExtender
 	logger *slog.Logger
 }
 
@@ -104,6 +139,20 @@ func NewService(db *gorm.DB, repo Repository, stripe *billingstripe.Client, logg
 		logger = slog.Default()
 	}
 	return &Service{db: db, repo: repo, stripe: stripe, logger: logger}
+}
+
+// WithTrialExtender wires the trial extender a trial-extension code needs
+// (#620) and returns s, so it can be chained onto NewService.
+//
+// Deliberately NOT a NewService parameter. A nil Stripe client is a supported
+// configuration — a code with no coupon simply attaches none — but a nil
+// extender is not: a code that promises days and silently grants none is the
+// exact defect #620 was opened for. Keeping it off the constructor means the
+// four existing call sites that pass no extender keep compiling, while
+// ApplyPromo refuses rather than degrades. See the trial branch there.
+func (s *Service) WithTrialExtender(e TrialExtender) *Service {
+	s.trial = e
+	return s
 }
 
 // ApplyPromo applies a promo code to a store subscription. Returns
@@ -165,6 +214,25 @@ func (s *Service) ApplyPromo(ctx context.Context, in ApplyInput) (ApplyOutput, e
 		return ApplyOutput{}, fmt.Errorf("promo: apply: check store redemption: %w", storeRedErr)
 	}
 
+	// 4b. Pre-flight the trial extension, BEFORE anything is written.
+	//
+	// The refusal has to happen here rather than at the Extend call below,
+	// because by then the ledger row exists and max_per_email is 1: a
+	// merchant refused after the row is written has spent their one
+	// redemption on nothing. Extend re-checks under its row lock, so this is
+	// the merchant's answer, not the guarantee.
+	extendDays, newTrialEnd, err := s.planTrialExtension(pc, in)
+	if err != nil {
+		if errors.Is(err, ErrInvalidOrExpired) {
+			if metrics.Subscription != nil {
+				metrics.Subscription.PromoAppliedTotal.
+					WithLabelValues(string(in.Plan), in.Currency, string(RejectReasonTrialNotExtendable)).Inc()
+			}
+			return ApplyOutput{RejectReason: RejectReasonTrialNotExtendable}, err
+		}
+		return ApplyOutput{}, err
+	}
+
 	// 5. Attach coupon in Stripe (if client available and the code has one).
 	//
 	// A console-defined code need not have a Stripe Coupon: a
@@ -195,6 +263,11 @@ func (s *Service) ApplyPromo(ctx context.Context, in ApplyInput) (ApplyOutput, e
 
 	// 6. Record redemption row.
 	red := &Redemption{
+		// Generated here rather than left to the column default, because
+		// the trial extension's idempotency key is derived from it (#620)
+		// and a key cannot be built from an id the database has not
+		// returned yet.
+		ID:             uuid.New(),
 		PromoCodeID:    pc.ID,
 		StoreID:        in.StoreID,
 		SubscriptionID: in.SubscriptionID,
@@ -212,6 +285,45 @@ func (s *Service) ApplyPromo(ctx context.Context, in ApplyInput) (ApplyOutput, e
 		return ApplyOutput{}, fmt.Errorf("promo: apply: record redemption: %w", err)
 	}
 
+	// 7. Extend the trial, keyed on the ledger row just written (#620).
+	//
+	// After the row, not before, so the key exists and a retry converges on
+	// the same Stripe idempotency key rather than extending twice.
+	appliedEnd := time.Time{}
+	if extendDays > 0 {
+		if _, err := s.trial.Extend(ctx, s.db, in.StoreID, newTrialEnd, time.Now().UTC(),
+			"promo_redeem:"+red.ID.String()); err != nil {
+
+			// The ONE failure that must not be undone. Stripe has already
+			// moved the merchant's billing date and only the local write
+			// failed; deleting the ledger row would erase the only local
+			// record that the redemption happened, and the retry it invites
+			// is refused by Extend anyway (ErrTrialEndNotAfterStripe). A
+			// human reconciles this — see trial.ErrStripeAppliedLocalWriteFailed.
+			if errors.Is(err, trial.ErrStripeAppliedLocalWriteFailed) {
+				s.logger.Error("promo: trial extension moved stripe but not the local row — redemption kept for reconciliation",
+					"store_id", in.StoreID, "promo_code_id", pc.ID,
+					"redemption_id", red.ID, "err", err)
+				return ApplyOutput{}, fmt.Errorf("promo: apply: extend trial: %w", err)
+			}
+
+			// Everything else: put the merchant back where they started, so
+			// the code is not spent on an extension that never happened.
+			if delErr := s.repo.DeleteRedemptionByStore(ctx, s.db, pc.ID, in.StoreID); delErr != nil {
+				s.logger.Error("promo: could not roll back redemption after a failed trial extension — the code is now spent",
+					"store_id", in.StoreID, "promo_code_id", pc.ID, "err", delErr)
+			}
+			if s.stripe != nil && in.StripeSubscriptionID != "" && couponID != "" {
+				_ = billingstripe.RemoveSubscriptionDiscount(ctx, s.stripe, in.StripeSubscriptionID, couponID)
+			}
+			return ApplyOutput{}, fmt.Errorf("promo: apply: extend trial: %w", err)
+		}
+		appliedEnd = newTrialEnd
+		s.logger.Info("promo: trial extended",
+			"store_id", in.StoreID, "promo_code_id", pc.ID,
+			"days", extendDays, "trial_ends_at", newTrialEnd)
+	}
+
 	if metrics.Subscription != nil {
 		metrics.Subscription.PromoAppliedTotal.
 			WithLabelValues(string(in.Plan), in.Currency, "applied").Inc()
@@ -221,7 +333,54 @@ func (s *Service) ApplyPromo(ctx context.Context, in ApplyInput) (ApplyOutput, e
 		PromoCodeID:    pc.ID,
 		StripeCouponID: couponID,
 		EffectiveMinor: result.EffectiveMinor,
+		TrialEndsAt:    appliedEnd,
 	}, pc), nil
+}
+
+// planTrialExtension answers "how many days does this code add, and to what
+// date", or explains why it cannot.
+//
+// It returns (0, zero, nil) for a code that extends no trial — the common
+// case, and the one every existing call site is in.
+//
+// The two failure kinds are deliberately different errors, because they are
+// different people's problems:
+//
+//   - ErrInvalidOrExpired: the merchant's subscription cannot take an
+//     extension (converted, not trialing, or already lapsed). A 422 with a
+//     reason, and their redemption is not spent.
+//   - anything else: WE are misconfigured — no extender wired, or a caller
+//     that did not pass the subscription. Reporting that as "invalid or
+//     expired" would tell a merchant holding a perfectly good code to stop
+//     trying, and would hide a wiring regression behind a merchant-facing
+//     refusal. It fails closed and loudly instead.
+func (s *Service) planTrialExtension(pc *PromoCode, in ApplyInput) (int, time.Time, error) {
+	if pc.TrialExtensionDays == nil || *pc.TrialExtensionDays <= 0 {
+		return 0, time.Time{}, nil
+	}
+	days := *pc.TrialExtensionDays
+
+	if s.trial == nil {
+		return 0, time.Time{}, fmt.Errorf(
+			"promo: code %s grants a %d-day trial extension but no trial extender is wired: %w",
+			pc.Code, days, ErrTrialExtensionUnavailable)
+	}
+	if in.Sub == nil {
+		return 0, time.Time{}, fmt.Errorf(
+			"promo: code %s grants a %d-day trial extension but the caller passed no subscription: %w",
+			pc.Code, days, ErrTrialExtensionUnavailable)
+	}
+
+	if err := trial.Extendable(*in.Sub, time.Now().UTC()); err != nil {
+		s.logger.Info("promo: trial-extension code refused — this trial cannot move",
+			"store_id", in.StoreID, "promo_code_id", pc.ID, "reason", err)
+		return 0, time.Time{}, ErrInvalidOrExpired
+	}
+
+	// The base is the EFFECTIVE end, never created_at + TrialDays. Extend
+	// takes an absolute date, so deriving it from the signup date would
+	// silently discard an extension an operator already granted (#620).
+	return days, trial.EndsAt(*in.Sub).AddDate(0, 0, days), nil
 }
 
 // CancelPromo removes this code's coupon from the Stripe subscription's
@@ -315,6 +474,17 @@ func (s *Service) ValidateCode(ctx context.Context, in ApplyInput) (ApplyOutput,
 	})
 	if !result.Accepted {
 		return ApplyOutput{RejectReason: result.RejectReason}, ErrInvalidOrExpired
+	}
+
+	// The same trial pre-flight ApplyPromo runs, for the same reason it is a
+	// pre-flight there: "would this be accepted" and "apply it" must give the
+	// same answer, or a caller states an offer the redeem path then refuses.
+	// It writes nothing here — planTrialExtension only reads.
+	if _, _, err := s.planTrialExtension(pc, in); err != nil {
+		if errors.Is(err, ErrInvalidOrExpired) {
+			return ApplyOutput{RejectReason: RejectReasonTrialNotExtendable}, err
+		}
+		return ApplyOutput{}, err
 	}
 
 	return terms(ApplyOutput{

--- a/services/marketplace-api/internal/promo/trial_extension_test.go
+++ b/services/marketplace-api/internal/promo/trial_extension_test.go
@@ -1,0 +1,366 @@
+package promo_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/trial"
+	"github.com/mark8ly/marketplace-api/internal/promo"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+)
+
+// extendCall records one invocation of the trial extender, so a test can
+// assert the DATE that was asked for. The date is the whole point: #620's
+// hazard is an extension computed from the signup date, which silently
+// discards an extension an operator already granted.
+type extendCall struct {
+	storeID uuid.UUID
+	newEnd  time.Time
+	idemKey string
+}
+
+type stubExtender struct {
+	calls []extendCall
+	err   error
+}
+
+func (e *stubExtender) Extend(_ context.Context, _ *gorm.DB, storeID uuid.UUID,
+	newEnd, _ time.Time, callerIdemKey string) (trial.ExtendResult, error) {
+	e.calls = append(e.calls, extendCall{storeID: storeID, newEnd: newEnd, idemKey: callerIdemKey})
+	if e.err != nil {
+		return trial.ExtendResult{}, e.err
+	}
+	return trial.ExtendResult{StoreID: storeID, NewEndsAt: newEnd}, nil
+}
+
+// trialRepo is stubRepo plus the redemption bookkeeping ApplyPromo performs,
+// so a test can tell a redemption that was written from one that was rolled
+// back — the difference between "try again" and "your code is spent".
+type trialRepo struct {
+	code           *promo.PromoCode
+	created        []promo.Redemption
+	deletes        int
+	createErr      error
+	alreadyRedeems bool
+}
+
+func (r *trialRepo) GetByCode(context.Context, *gorm.DB, string) (*promo.PromoCode, error) {
+	return r.code, nil
+}
+func (r *trialRepo) GetByID(context.Context, *gorm.DB, uuid.UUID) (*promo.PromoCode, error) {
+	return r.code, nil
+}
+func (r *trialRepo) Create(context.Context, *gorm.DB, *promo.PromoCode) error { return nil }
+func (r *trialRepo) CountRedemptions(context.Context, *gorm.DB, uuid.UUID) (int, error) {
+	return 0, nil
+}
+func (r *trialRepo) CountRedemptionsByEmail(context.Context, *gorm.DB, uuid.UUID, string) (int, error) {
+	return 0, nil
+}
+func (r *trialRepo) GetRedemptionByStore(context.Context, *gorm.DB, uuid.UUID, uuid.UUID) (*promo.Redemption, error) {
+	if r.alreadyRedeems {
+		return &promo.Redemption{}, nil
+	}
+	return nil, apperrors.NotFound("redemption")
+}
+func (r *trialRepo) CreateRedemption(_ context.Context, _ *gorm.DB, red *promo.Redemption) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	r.created = append(r.created, *red)
+	return nil
+}
+func (r *trialRepo) DeleteRedemptionByStore(context.Context, *gorm.DB, uuid.UUID, uuid.UUID) error {
+	r.deletes++
+	return nil
+}
+
+// extensionRow is a trial-extension-ONLY code: no discount, no Stripe coupon.
+// That shape is normal, not degenerate — the console mints no Coupon for a
+// code that touches no Stripe object (#726).
+func extensionRow(days int) *promo.PromoCode {
+	return &promo.PromoCode{
+		ID:                 uuid.New(),
+		Code:               "STAYLONGER",
+		TrialExtensionDays: &days,
+		MaxPerEmail:        1,
+		ValidFrom:          time.Now().UTC().Add(-time.Hour),
+	}
+}
+
+// trialingSub is a store still on trial, ending `in` from now. storedEnd is
+// written to TrialEndsAt so a test can pin the EFFECTIVE end rather than the
+// derived one.
+func trialingSub(storedEnd time.Time) *subscription.StoreSubscription {
+	return &subscription.StoreSubscription{
+		ID:          uuid.New(),
+		StoreID:     uuid.New(),
+		TenantID:    uuid.New(),
+		Status:      subscription.StatusTrialing,
+		Plan:        subscription.PlanStarter,
+		CreatedAt:   time.Now().UTC().Add(-30 * 24 * time.Hour),
+		TrialEndsAt: &storedEnd,
+	}
+}
+
+func extensionInput(sub *subscription.StoreSubscription) promo.ApplyInput {
+	in := validateInput()
+	in.Code = "STAYLONGER"
+	in.Sub = sub
+	if sub != nil {
+		in.StoreID = sub.StoreID
+		in.TenantID = sub.TenantID
+		in.SubscriptionID = sub.ID
+	}
+	return in
+}
+
+// The core of #620: redeeming a trial-extension code must actually move the
+// trial end. Before this, ApplyPromo returned 200, wrote a ledger row, and
+// granted nothing.
+func TestApplyPromo_TrialExtensionCodeMovesTheTrialEnd(t *testing.T) {
+	end := time.Now().UTC().Add(10 * 24 * time.Hour)
+	sub := trialingSub(end)
+	repo := &trialRepo{code: extensionRow(14)}
+	ext := &stubExtender{}
+	svc := promo.NewService(nil, repo, nil, nil).WithTrialExtender(ext)
+
+	out, err := svc.ApplyPromo(context.Background(), extensionInput(sub))
+	if err != nil {
+		t.Fatalf("ApplyPromo: %v", err)
+	}
+	if len(ext.calls) != 1 {
+		t.Fatalf("extender called %d times, want 1", len(ext.calls))
+	}
+	want := end.AddDate(0, 0, 14)
+	if !ext.calls[0].newEnd.Equal(want) {
+		t.Errorf("newEnd = %s, want %s", ext.calls[0].newEnd, want)
+	}
+	if ext.calls[0].storeID != sub.StoreID {
+		t.Errorf("storeID = %s, want %s", ext.calls[0].storeID, sub.StoreID)
+	}
+	if out.TrialExtensionDays != 14 {
+		t.Errorf("TrialExtensionDays = %d, want 14", out.TrialExtensionDays)
+	}
+	if !out.TrialEndsAt.Equal(want) {
+		t.Errorf("TrialEndsAt = %s, want %s", out.TrialEndsAt, want)
+	}
+}
+
+// #620 names this hazard outright: Extend takes an ABSOLUTE end, so an
+// extension computed from created_at + TrialDays silently overwrites an
+// extension an operator already granted. The base must be trial.EndsAt.
+func TestApplyPromo_ExtendsFromTheStoredEndNotTheSignupDate(t *testing.T) {
+	// Operator already pushed this trial far past created_at + 90d.
+	operatorEnd := time.Now().UTC().Add(200 * 24 * time.Hour)
+	sub := trialingSub(operatorEnd)
+	repo := &trialRepo{code: extensionRow(14)}
+	ext := &stubExtender{}
+	svc := promo.NewService(nil, repo, nil, nil).WithTrialExtender(ext)
+
+	if _, err := svc.ApplyPromo(context.Background(), extensionInput(sub)); err != nil {
+		t.Fatalf("ApplyPromo: %v", err)
+	}
+	want := operatorEnd.AddDate(0, 0, 14)
+	if !ext.calls[0].newEnd.Equal(want) {
+		t.Fatalf("newEnd = %s, want %s — the promo overwrote the operator's extension",
+			ext.calls[0].newEnd, want)
+	}
+	derived := sub.CreatedAt.AddDate(0, 0, trial.TrialDays+14)
+	if ext.calls[0].newEnd.Equal(derived) {
+		t.Fatal("newEnd was computed from created_at + TrialDays")
+	}
+}
+
+// The extension is keyed on the ledger row, per #620: "using the redemption id
+// as the callerIdemKey so a retry after a partial failure re-applies cleanly
+// rather than double-extending".
+func TestApplyPromo_ExtensionIsKeyedOnTheRedemptionRow(t *testing.T) {
+	sub := trialingSub(time.Now().UTC().Add(10 * 24 * time.Hour))
+	repo := &trialRepo{code: extensionRow(7)}
+	ext := &stubExtender{}
+	svc := promo.NewService(nil, repo, nil, nil).WithTrialExtender(ext)
+
+	if _, err := svc.ApplyPromo(context.Background(), extensionInput(sub)); err != nil {
+		t.Fatalf("ApplyPromo: %v", err)
+	}
+	if len(repo.created) != 1 {
+		t.Fatalf("wrote %d redemption rows, want 1", len(repo.created))
+	}
+	id := repo.created[0].ID
+	if id == uuid.Nil {
+		t.Fatal("redemption row has no id, so the idempotency key cannot be derived from it")
+	}
+	if want := "promo_redeem:" + id.String(); ext.calls[0].idemKey != want {
+		t.Errorf("idemKey = %q, want %q", ext.calls[0].idemKey, want)
+	}
+}
+
+// A lapsed or converted subscription is refused BEFORE anything is written, so
+// the merchant keeps their one redemption. #620 open question 1, answered the
+// way extend.go already answers it: reinstating an expired trial is out of
+// scope.
+func TestApplyPromo_TrialThatCannotMoveIsRefusedWithoutBurningTheCode(t *testing.T) {
+	cases := []struct {
+		name string
+		sub  *subscription.StoreSubscription
+	}{
+		{"already lapsed", trialingSub(time.Now().UTC().Add(-24 * time.Hour))},
+		{"already converted", func() *subscription.StoreSubscription {
+			s := trialingSub(time.Now().UTC().Add(10 * 24 * time.Hour))
+			s.Status = subscription.StatusActive
+			return s
+		}()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &trialRepo{code: extensionRow(14)}
+			ext := &stubExtender{}
+			svc := promo.NewService(nil, repo, nil, nil).WithTrialExtender(ext)
+
+			out, err := svc.ApplyPromo(context.Background(), extensionInput(tc.sub))
+			if !errors.Is(err, promo.ErrInvalidOrExpired) {
+				t.Fatalf("err = %v, want ErrInvalidOrExpired", err)
+			}
+			if out.RejectReason != promo.RejectReasonTrialNotExtendable {
+				t.Errorf("reject reason = %q, want trial_not_extendable", out.RejectReason)
+			}
+			if len(repo.created) != 0 {
+				t.Error("a refused redemption still wrote a ledger row — the code is now spent")
+			}
+			if len(ext.calls) != 0 {
+				t.Error("extender was called for a trial that cannot move")
+			}
+		})
+	}
+}
+
+// The merchant is told a fact about their own subscription, which is safe to
+// disclose — it confirms nothing about a code they were not already given.
+func TestPublicReasonFor_TrialNotExtendableIsDisclosed(t *testing.T) {
+	if got := promo.PublicReasonFor(promo.RejectReasonTrialNotExtendable); got != promo.PublicReasonTrialNotExtendable {
+		t.Errorf("PublicReasonFor(trial_not_extendable) = %q, want trial_not_extendable", got)
+	}
+}
+
+// A missing extender is OUR fault, not the merchant's. Reporting it as
+// "invalid or expired" would tell a merchant holding a perfectly good code to
+// stop trying, and would hide a wiring regression behind a 422.
+func TestApplyPromo_MissingExtenderIsAServerFaultNotARejection(t *testing.T) {
+	sub := trialingSub(time.Now().UTC().Add(10 * 24 * time.Hour))
+	repo := &trialRepo{code: extensionRow(14)}
+	svc := promo.NewService(nil, repo, nil, nil) // no extender wired
+
+	_, err := svc.ApplyPromo(context.Background(), extensionInput(sub))
+	if err == nil {
+		t.Fatal("ApplyPromo succeeded with no extender — the extension was silently skipped")
+	}
+	if errors.Is(err, promo.ErrInvalidOrExpired) {
+		t.Fatalf("err = %v, want a server error rather than a merchant-facing rejection", err)
+	}
+	if len(repo.created) != 0 {
+		t.Error("wrote a ledger row for an extension that could not be delivered")
+	}
+}
+
+// Same reasoning for a caller that forgot the subscription: it is a call-site
+// bug, and failing closed keeps it from reading as a bad code.
+func TestApplyPromo_MissingSubscriptionIsAServerFault(t *testing.T) {
+	repo := &trialRepo{code: extensionRow(14)}
+	ext := &stubExtender{}
+	svc := promo.NewService(nil, repo, nil, nil).WithTrialExtender(ext)
+
+	in := extensionInput(nil)
+	in.StoreID = uuid.New()
+	_, err := svc.ApplyPromo(context.Background(), in)
+	if err == nil || errors.Is(err, promo.ErrInvalidOrExpired) {
+		t.Fatalf("err = %v, want a server error", err)
+	}
+	if len(repo.created) != 0 {
+		t.Error("wrote a ledger row without a subscription to extend")
+	}
+}
+
+// A failed extension must not leave the code spent: roll the ledger row back so
+// the merchant can retry.
+func TestApplyPromo_FailedExtensionRollsBackTheRedemption(t *testing.T) {
+	sub := trialingSub(time.Now().UTC().Add(10 * 24 * time.Hour))
+	repo := &trialRepo{code: extensionRow(14)}
+	ext := &stubExtender{err: errors.New("boom")}
+	svc := promo.NewService(nil, repo, nil, nil).WithTrialExtender(ext)
+
+	if _, err := svc.ApplyPromo(context.Background(), extensionInput(sub)); err == nil {
+		t.Fatal("ApplyPromo succeeded despite the extension failing")
+	}
+	if repo.deletes != 1 {
+		t.Fatalf("redemption deletes = %d, want 1 — the merchant's code is spent on nothing", repo.deletes)
+	}
+}
+
+// The one failure that must NOT roll back. Stripe has already moved the
+// merchant's billing date; deleting the ledger row would erase the only local
+// record that it happened and invite a retry that Stripe then refuses.
+func TestApplyPromo_StripeAlreadyMovedIsNotRolledBack(t *testing.T) {
+	sub := trialingSub(time.Now().UTC().Add(10 * 24 * time.Hour))
+	repo := &trialRepo{code: extensionRow(14)}
+	ext := &stubExtender{err: fmt.Errorf("%w: sub_123", trial.ErrStripeAppliedLocalWriteFailed)}
+	svc := promo.NewService(nil, repo, nil, nil).WithTrialExtender(ext)
+
+	_, err := svc.ApplyPromo(context.Background(), extensionInput(sub))
+	if !errors.Is(err, trial.ErrStripeAppliedLocalWriteFailed) {
+		t.Fatalf("err = %v, want the divergence surfaced to the caller", err)
+	}
+	if repo.deletes != 0 {
+		t.Fatalf("redemption deletes = %d, want 0 — rolling back hides that stripe already moved", repo.deletes)
+	}
+}
+
+// A discount-only code must not touch the trial, and must still work with no
+// extender wired at all — which is every existing call site.
+func TestApplyPromo_DiscountOnlyCodeNeverTouchesTheTrial(t *testing.T) {
+	sub := trialingSub(time.Now().UTC().Add(10 * 24 * time.Hour))
+	repo := &trialRepo{code: winBackRow()}
+	ext := &stubExtender{}
+	svc := promo.NewService(nil, repo, nil, nil).WithTrialExtender(ext)
+
+	in := extensionInput(sub)
+	in.Code = "WINBACK20OFF6MONTHS"
+	out, err := svc.ApplyPromo(context.Background(), in)
+	if err != nil {
+		t.Fatalf("ApplyPromo: %v", err)
+	}
+	if len(ext.calls) != 0 {
+		t.Errorf("extender called %d times for a discount-only code", len(ext.calls))
+	}
+	if out.TrialExtensionDays != 0 || !out.TrialEndsAt.IsZero() {
+		t.Errorf("output claims a trial extension: days=%d end=%s", out.TrialExtensionDays, out.TrialEndsAt)
+	}
+}
+
+// ValidateCode answers "would this be accepted" and must describe the SAME
+// terms ApplyPromo would grant, without granting them — the rule the win-back
+// email already relies on for PercentOffBps (#727).
+func TestValidateCode_DescribesTheTrialExtensionAndGrantsNothing(t *testing.T) {
+	sub := trialingSub(time.Now().UTC().Add(10 * 24 * time.Hour))
+	repo := &trialRepo{code: extensionRow(30)}
+	ext := &stubExtender{}
+	svc := promo.NewService(nil, repo, nil, nil).WithTrialExtender(ext)
+
+	out, err := svc.ValidateCode(context.Background(), extensionInput(sub))
+	if err != nil {
+		t.Fatalf("ValidateCode: %v", err)
+	}
+	if out.TrialExtensionDays != 30 {
+		t.Errorf("TrialExtensionDays = %d, want 30", out.TrialExtensionDays)
+	}
+	if len(ext.calls) != 0 || len(repo.created) != 0 {
+		t.Error("ValidateCode granted the extension it was only asked about")
+	}
+}

--- a/services/marketplace-api/internal/promo/validator.go
+++ b/services/marketplace-api/internal/promo/validator.go
@@ -54,6 +54,16 @@ const (
 	// ingest from the console (#726). Rejecting is safer than applying no
 	// discount and calling it a success.
 	RejectReasonUnknownDiscountType ValidationRejectReason = "unknown_discount_type"
+	// RejectReasonTrialNotExtendable covers a code that grants a trial
+	// extension applied to a subscription whose trial cannot move — already
+	// converted, not trialing, or already lapsed. The rule is
+	// trial.Extendable's; this is only the name the promo audit trail gives
+	// its refusal (#620).
+	//
+	// It is NOT produced by Validate: it is a fact about the subscription
+	// rather than about the code, and Validate is given no subscription.
+	// Service.planTrialExtension sets it.
+	RejectReasonTrialNotExtendable ValidationRejectReason = "trial_not_extendable"
 )
 
 // ValidationResult is returned by Validate. On success Accepted is true and

--- a/services/marketplace-api/internal/subscription/cancel/save_offer.go
+++ b/services/marketplace-api/internal/subscription/cancel/save_offer.go
@@ -104,6 +104,11 @@ func (s *Service) applySaveOfferDiscount(ctx context.Context, in Input, sub *sub
 		Currency:             derefString(sub.BillingCurrency),
 		StripeSubscriptionID: derefString(sub.StripeSubscriptionID),
 		Actor:                in.Actor,
+		// The save-offer code carries a discount, not trial days, so this
+		// changes nothing today. It is passed because promo decides that,
+		// not this call site: a code that grew a trial extension would
+		// otherwise fail closed here rather than be applied (#620).
+		Sub: sub,
 	}
 
 	if _, err := s.promo.ValidateForSaveOffer(ctx, applyIn); err != nil {

--- a/services/marketplace-api/internal/subscription/lifecycle/winback_offer.go
+++ b/services/marketplace-api/internal/subscription/lifecycle/winback_offer.go
@@ -103,6 +103,9 @@ func (c *WinBackCron) offerFor(ctx context.Context, row *subscription.StoreSubsc
 			row.Plan, row.SubscriptionPeriod, row.PriceTier, derefString(row.BillingCurrency)),
 		Currency: derefString(row.BillingCurrency),
 		Actor:    "system:winback",
+		// Passed so validate answers what redeem would. The win-back code
+		// is discount-only, so this is inert today (#620).
+		Sub: row,
 	})
 	if err != nil {
 		c.logger.Info("lifecycle: win-back offer not available — sending without one",


### PR DESCRIPTION
Closes part of #620 — the redemption half's core promise.

## The defect

`promo_codes.trial_extension_days` has been ingested from the console since #745, stored, and documented on the model as *"the number of days added to the store trial on redemption (#620)"*.

`promo.Service.ApplyPromo` never read it.

So a merchant redeeming a trial-extension code got a `200`, a ledger row, a confirmation sentence — and **no extra days**. Nothing errored and nothing logged, because the validator already handles a discount-less row correctly: it leaves the price untouched and accepts, on the stated understanding that *"the benefit is delivered elsewhere"*. Elsewhere did not exist.

`validator.go` warns about this exact shape one layer down:

> both are silently correct arithmetic for the wrong code, and both would hide a failed ingest.

## What changed

**`trial.Extendable(sub, now)`** — extracted from `Extend`'s refusal switch, returning the same sentinels. `Extend` calls it under its row lock; the promo path calls it as a pre-flight. One definition, so the two cannot drift into "accepted at the door, refused at the till".

**The extension is applied**, from `trial.EndsAt(sub) + N days`. #620 names this hazard specifically: `Extend` takes an *absolute* end, so computing from `created_at + TrialDays` would silently discard an extension an operator had already granted. There is a test that fails on exactly that mutation.

**Ordering, per #620:** ledger row first, then the extension, keyed `promo_redeem:<redemption id>`. The row's id is now generated in Go rather than left to the column default, because a key cannot be derived from an id the database has not returned yet.

**Failure paths, both directions:**

| situation | behaviour |
|---|---|
| trial converted / not trialing / already lapsed | 422 `trial_not_extendable`, **refused before any write** — the merchant keeps their one redemption |
| extension fails | ledger row and Stripe coupon rolled back, so the code is not spent on nothing |
| `trial.ErrStripeAppliedLocalWriteFailed` | **not** rolled back — Stripe already moved the billing date, and deleting the row would erase the only local record of it |
| no extender wired / no subscription passed | **500, not 422.** Ours to fix, not the merchant's; a 422 would tell someone holding a good code to stop trying and would bury a wiring regression |

**`ValidateCode` runs the same pre-flight** and grants nothing, so the win-back email and cancel save-offer cannot state an offer the redeem path then refuses.

**The response and the audit row say what was granted** — `trial_extension_days` and the `trial_ends_at` that was actually written. The date is never re-derived client-side: `today + N` is the wrong date for any merchant an operator has already extended.

## Decision recorded: a lapsed trial cannot be redeemed against

#620's open question 1. `extend.go` had already settled it — *"Reinstating an already-expired trial is out of scope"* — and this adopts that answer rather than inventing a second one.

Question 2 (per-tenant vs per-store) was already settled in the shipped code: `promo_redemptions` is unique per store, with a per-email cap on top. Question 3 (surviving a plan change) is untouched — `planchange.go` reads `trial.EndsAt`, so a promo extension is picked up the same way an operator's is.

## Still open on #620

The onboarding field. It needs the validate endpoint reachable unauthenticated, which is a separate surface with its own rate-limiting question — #620 calls that field "an oracle for guessing valid codes". Left for its own change; this one makes the benefit real for the redemption paths that already exist.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt` clean
- [x] Full Go suite green (integration tests skip without `TEST_DATABASE_URL`; nothing here touches migrations)
- [x] **Mutation-checked** — neutering each of the three branches fails a named test:
  - extension never applied → 4 failures
  - base computed from the signup date → `TestApplyPromo_ExtendsFromTheStoredEndNotTheSignupDate`
  - rollback on the Stripe divergence → `TestApplyPromo_StripeAlreadyMovedIsNotRolledBack`
- [x] `apps/admin` — `tsc --noEmit` clean, `npm run build` green, 37 promo unit tests pass
- [ ] Verify against a real console-authored trial-extension code. #620 notes none has been authored yet — every code so far is discount-only — and that a trial-extension code needs no Stripe coupon, so it can be authored without minting.
