### PR TITLE
fix(billing): start the 90-day trial at signup instead of when a merchant opens the Billing page (#827)

### DIFF
--- a/.planning/quick/260908-ts-trial-starts-at-signup/PLAN.md
+++ b/.planning/quick/260908-ts-trial-starts-at-signup/PLAN.md
@@ -1,0 +1,78 @@
+# Start the trial at signup (#827)
+
+`store_subscriptions` rows are created in exactly one place — `Service.Bootstrap`
+— reached from exactly one place: a CTA on the admin Billing page. `trial.EndsAt`
+derives the trial end from that row's `created_at`, so the 90-day clock starts on
+the button press. A merchant who never opens Billing has no row, no trial, and is
+invisible to every billing cron.
+
+Bootstrap's own doc calls itself a back-fill for "stores created before the v2.3
+signup pipeline". That pipeline does not exist.
+
+Full evidence on #827. This plan is the fix.
+
+## The shape of it
+
+A free trial must not depend on a payment provider being reachable. That
+dependency is what turns a Stripe outage — or a mis-scoped key, which #696 says
+we currently have — into a merchant with no trial at all.
+
+An empty `stripe_customer_id` is already a state this codebase expects and
+handles: five call sites guard it, and the paid path (`planchange.go:257`)
+refuses a customer-less row outright with "run bootstrap first". `NOT NULL` is
+satisfied by `''`, so no migration is needed.
+
+## Tasks
+
+### 1. Separate "the row exists" from "Stripe knows about it"
+
+- [ ] `Bootstrap` no longer calls Stripe. It ensures the row: plan=trial,
+      status=signup, and now `billing_currency` when the caller knows it.
+- [ ] New `EnsureStripeCustomer(ctx, tenantID, storeID)` — idempotent, attaches
+      a customer to a row that has none.
+- **Not** best-effort-with-a-warning inside Bootstrap. Swallowing a Stripe error
+  would hide exactly the broken-key failure #696 describes, and #827 exists
+  because a billing precondition failed silently for months.
+- **Done when** Bootstrap succeeds with a nil Stripe client, and the two
+  responsibilities fail independently.
+
+### 2. Keep the existing paths whole
+
+- [ ] Admin's bootstrap CTA calls both, surfacing the Stripe error — but the row
+      is created first, so a retry is cheap and the trial has started either way.
+- [ ] The card-add path ensures a customer before `trial.Subscribe`, which
+      otherwise refuses with `ErrMissingStripeCustomer` for every merchant whose
+      row was created at signup.
+- **Done when** no path that worked before now fails, and the CTA still reports
+  a Stripe problem rather than hiding it.
+
+### 3. Create the row at onboarding completion
+
+- [ ] `POST /internal/stores/:storeID/ensure-subscription` on marketplace-api,
+      guarded by `InternalAuthSecret` — the migration handler's precedent, not
+      the unguarded one next to it. This is a write with a billing consequence.
+- [ ] platform-api calls it from `onboarding.Complete`, after `EnsureSelfStore`
+      (the store row must exist — `store_subscriptions.store_id` is an FK) and
+      under the same best-effort policy: a failure is logged and does not fail
+      onboarding.
+- **Done when** completing onboarding leaves a `trialing`-eligible row whose
+  `created_at` is the signup moment.
+
+### 4. Backfill, written but NOT run
+
+- [ ] `cmd/subscription-backfill` — one row per store that has none, with
+      `trial_ends_at` set explicitly from the STORE's `created_at + 90d` rather
+      than from the moment of the backfill.
+- [ ] `--dry-run` default. Running it is a data decision with a merchant-visible
+      outcome; for a store older than 90 days it writes an already-expired
+      trial, which is truthful but should be seen before it is written.
+- **Done when** a dry run prints what it would write and changes nothing.
+
+## Out of scope
+
+The onboarding promo field (#620). It is what surfaced this, and it becomes
+buildable once a row exists at signup — but it is a separate change.
+
+Whether `stripe_customer_id` should become nullable rather than `''`. The empty
+string is what every existing guard already tests for; a migration would be a
+second representation of the same state.

--- a/services/marketplace-api/cmd/backfill-trial-start/main.go
+++ b/services/marketplace-api/cmd/backfill-trial-start/main.go
@@ -1,0 +1,203 @@
+// Command backfill-trial-start gives every store that has no subscription row
+// one, dating its trial from the STORE's own created_at rather than from the
+// moment of the backfill.
+//
+// Why any store lacks one: until #827 the only code that created a
+// store_subscriptions row was reachable from a single CTA on the admin Billing
+// page. A merchant who never opened that page has no row — no trial clock, no
+// expiry, and no presence in any billing cron. #827 makes onboarding create
+// the row going forward; this covers everyone who signed up before it.
+//
+// # The date is the whole point
+//
+// trial.EndsAt derives the trial end from the subscription row's created_at
+// when trial_ends_at is NULL. A naive backfill would therefore hand every
+// existing merchant a brand-new 90 days starting today, including merchants
+// who signed up a year ago.
+//
+// So this writes trial_ends_at EXPLICITLY, as store.created_at + 90 days, and
+// EndsAt treats a non-NULL value as authoritative. For a store older than 90
+// days that writes a trial end in the past — an already-expired trial. That is
+// the truthful answer and it is deliberate: the alternative is granting a free
+// trial to every dormant account in the estate.
+//
+// It is also why --dry-run is the DEFAULT. The expired-trial rows are
+// merchant-visible and feed the expiry cron the next time it runs; whoever
+// runs this should read the summary first and decide, rather than discover it.
+//
+// # What it does not do
+//
+// No Stripe call, and no stripe_customer_id. A trial row does not need one
+// (#827) and minting a customer for a dormant store would be both wasteful and
+// a way for a bad billing key to fail the whole backfill. The customer is
+// attached lazily when the merchant first adds a card.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/trial"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/db"
+)
+
+func main() {
+	var (
+		batchSize int
+		apply     bool
+	)
+	flag.IntVar(&batchSize, "batch", 200, "rows fetched per DB scan")
+	// Inverted deliberately: --dry-run defaulting to true would let
+	// `-dry-run=false` write by accident from a shell that mangles the value.
+	// Writing requires naming the intent.
+	flag.BoolVar(&apply, "apply", false, "actually write rows (default: report only)")
+	flag.Parse()
+
+	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		log.Error("backfill-trial-start: DATABASE_URL not set")
+		os.Exit(1)
+	}
+	conn, err := db.Open(databaseURL)
+	if err != nil {
+		log.Error("backfill-trial-start: db open failed", "err", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	stats, err := run(ctx, conn, batchSize, apply, time.Now().UTC(), log)
+	if err != nil {
+		log.Error("backfill-trial-start: run failed", "err", err, "stats", stats)
+		os.Exit(1)
+	}
+	if !apply {
+		log.Info("backfill-trial-start: DRY RUN — nothing was written; re-run with -apply", "stats", stats)
+		return
+	}
+	log.Info("backfill-trial-start: done", "stats", stats)
+}
+
+// storeRow is the projection this command reads. Declared here rather than
+// importing the stores model so the backfill cannot start depending on
+// unrelated columns.
+type storeRow struct {
+	ID        string
+	TenantID  string
+	Currency  string
+	CreatedAt time.Time
+}
+
+type runStats struct {
+	Scanned int
+	Created int
+	// AlreadyExpired counts rows whose backfilled trial end is in the PAST,
+	// because the store is older than the trial length. Reported separately
+	// because it is the number a human needs before running with -apply: it
+	// is how many merchants become "trial expired" the moment this lands.
+	AlreadyExpired int
+	Failed         int
+}
+
+func run(ctx context.Context, conn *gorm.DB, batchSize int, apply bool, now time.Time, log *slog.Logger) (runStats, error) {
+	var stats runStats
+	lastID := ""
+
+	for {
+		var rows []storeRow
+		q := conn.WithContext(ctx).
+			Table("stores s").
+			Select("s.id AS id, s.tenant_id AS tenant_id, s.currency_code AS currency, s.created_at AS created_at").
+			Joins("LEFT JOIN store_subscriptions ss ON ss.store_id = s.id").
+			Where("ss.id IS NULL").
+			Order("s.id ASC").
+			Limit(batchSize)
+		if lastID != "" {
+			q = q.Where("s.id > ?", lastID)
+		}
+		if err := q.Scan(&rows).Error; err != nil {
+			return stats, fmt.Errorf("scan stores without a subscription: %w", err)
+		}
+		if len(rows) == 0 {
+			return stats, nil
+		}
+
+		for _, r := range rows {
+			lastID = r.ID
+			stats.Scanned++
+
+			trialEnd, expired := backfilledTrialEnd(r.CreatedAt, now)
+			if expired {
+				stats.AlreadyExpired++
+			}
+
+			log.Info("backfill-trial-start: store has no subscription",
+				"store_id", r.ID, "tenant_id", r.TenantID,
+				"store_created_at", r.CreatedAt.UTC(),
+				"trial_ends_at", trialEnd, "already_expired", expired,
+				"will_write", apply)
+
+			if !apply {
+				continue
+			}
+
+			// Raw INSERT rather than the repository: the repository's Create
+			// takes the full model and would carry defaults this command is
+			// deliberately not setting (no Stripe customer, no period). The
+			// ON CONFLICT makes a re-run converge rather than fail, and makes
+			// this safe to run alongside live onboarding traffic that may be
+			// creating the same row concurrently.
+			res := conn.WithContext(ctx).Exec(`
+				INSERT INTO store_subscriptions
+					(tenant_id, store_id, stripe_customer_id, plan, status, billing_currency, trial_ends_at, created_at)
+				VALUES (?, ?, '', 'trial', 'signup', NULLIF(LOWER(?), ''), ?, ?)
+				ON CONFLICT (store_id) DO NOTHING`,
+				r.TenantID, r.ID, r.Currency, trialEnd, r.CreatedAt.UTC())
+			if res.Error != nil {
+				stats.Failed++
+				log.Error("backfill-trial-start: insert failed",
+					"store_id", r.ID, "err", res.Error)
+				continue
+			}
+			if res.RowsAffected > 0 {
+				stats.Created++
+			}
+		}
+	}
+}
+
+// backfilledTrialEnd is the rule this command exists to apply: a trial dated
+// from the STORE's creation, not from the moment of the backfill. It also
+// reports whether that end has already passed.
+//
+// Its own function so the rule can be tested without a database, because it is
+// the part with a merchant-visible consequence: get it wrong in one direction
+// and every dormant account in the estate receives a fresh 90-day trial; get
+// it wrong in the other and an active merchant's trial ends early.
+//
+// Uses trial.TrialDays rather than a local 90 so it cannot drift from the
+// trial length the rest of the service enforces.
+func backfilledTrialEnd(storeCreatedAt, now time.Time) (end time.Time, alreadyExpired bool) {
+	// trial.EndsAt, not arithmetic. It is the ONLY definition of a trial end
+	// (#353), and TestTrialEndIsDerivedInExactlyOnePlace fails the build for
+	// any file that recomputes one — which this did, on its first draft.
+	//
+	// The subscription passed in is the row this command is about to write,
+	// as it would look once written: created at the store's signup, never
+	// extended. So the date asked for here is exactly the date stored below.
+	end = trial.EndsAt(subscription.StoreSubscription{CreatedAt: storeCreatedAt})
+	// Not After, not Before: an end exactly at `now` has passed. Same
+	// boundary trial.Extendable uses, and the two must agree or a backfilled
+	// row could be reported here as live and refused there.
+	return end, !end.After(now)
+}

--- a/services/marketplace-api/cmd/backfill-trial-start/main_test.go
+++ b/services/marketplace-api/cmd/backfill-trial-start/main_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/trial"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+func TestBackfilledTrialEnd_DatesFromTheStoreNotTheBackfill(t *testing.T) {
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	signedUp := now.AddDate(0, 0, -30)
+
+	end, expired := backfilledTrialEnd(signedUp, now)
+
+	want := trial.EndsAt(subscription.StoreSubscription{CreatedAt: signedUp})
+	if !end.Equal(want) {
+		t.Fatalf("end = %s, want %s", end, want)
+	}
+	if expired {
+		t.Error("a store 30 days old was reported as already expired")
+	}
+	// The failure this guards: a fresh 90 days handed to an account that
+	// signed up a month ago.
+	if end.Equal(trial.EndsAt(subscription.StoreSubscription{CreatedAt: now})) {
+		t.Fatal("trial was dated from the backfill instead of from the store")
+	}
+}
+
+// The expensive direction to get wrong silently: an estate full of dormant
+// accounts each granted a brand-new free trial.
+func TestBackfilledTrialEnd_ReportsAnOldStoreAsExpired(t *testing.T) {
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	signedUp := now.AddDate(-1, 0, 0)
+
+	end, expired := backfilledTrialEnd(signedUp, now)
+
+	if !expired {
+		t.Fatal("a store a year old was not reported as expired")
+	}
+	if !end.Before(now) {
+		t.Errorf("end = %s, want a date in the past", end)
+	}
+}
+
+// The boundary has to match trial.Extendable's, which uses !After(now) — an
+// end exactly at now has passed. If these disagree, a backfilled row reads as
+// live here and is refused there.
+func TestBackfilledTrialEnd_AnEndExactlyNowHasPassed(t *testing.T) {
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	signedUp := now.Add(-trial.TrialDays * 24 * time.Hour) // exactly one trial length ago
+
+	end, expired := backfilledTrialEnd(signedUp, now)
+
+	if !end.Equal(now) {
+		t.Fatalf("end = %s, want exactly now", end)
+	}
+	if !expired {
+		t.Error("an end exactly at now was reported as still running")
+	}
+}

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -2583,6 +2583,20 @@ func main() {
 		// EnsureSelfVendor). See internal_handler.go for idempotency.
 		stores.NewInternalHandler(domainStoresRepo).
 			RegisterRoutes(r.Group("/internal"))
+		// Onboarding's subscription callback — what makes the 90-day trial
+		// start at signup rather than when a merchant happens to open the
+		// Billing page (#827). Mounted on BOTH engines via the same method,
+		// so MODE=admin (production) and local mode.Both cannot drift the
+		// way #323 found they had.
+		//
+		// Its Service needs no Stripe client, which is the point of #827's
+		// split: starting a trial is a database write, not a payment-provider
+		// call, so this route cannot be taken down by a billing key.
+		subscription.NewInternalHandler(
+			subscription.NewService(subscription.ServiceConfig{
+				DB: conn, Repo: subscription.NewRepository(), Logger: log,
+			})).
+			RegisterRoutes(r.Group("/internal"), cfg.InternalAuthSecret)
 		// Otto escalation hook — slm-router POSTs
 		// /internal/v1/tickets/from-conversation when an AI chat is
 		// handed off to a human. Same /internal namespace + same shared
@@ -2745,6 +2759,18 @@ func main() {
 			// writes stores.
 			stores.NewInternalHandler(domainStoresRepo).
 				RegisterRoutes(engine.Group("/internal"))
+			// Onboarding's subscription callback — what makes the 90-day trial
+			// start at signup rather than when a merchant happens to open the
+			// Billing page (#827). Mounted on BOTH engines via the same method,
+			// so MODE=admin (production) and local mode.Both cannot drift the
+			// way #323 found they had.
+			//
+			// No Stripe client — see the mode-Both mount above.
+			subscription.NewInternalHandler(
+				subscription.NewService(subscription.ServiceConfig{
+					DB: conn, Repo: subscription.NewRepository(), Logger: log,
+				})).
+				RegisterRoutes(engine.Group("/internal"), cfg.InternalAuthSecret)
 			// slm-router escalation hook + the mark8ly-mcp
 			// create_support_ticket tool both POST /internal/v1/tickets/
 			// from-conversation to open a support ticket from an AI chat

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -1214,7 +1214,12 @@ func main() {
 			if tenantDiscountSvc != nil {
 				trialSubscriber = trialSubscriber.WithTenantDiscount(tenantDiscountSvc)
 			}
-			trialBillingHandler = admin.NewTrialBillingHandler(trialSubscriber, log)
+			// The customer ensurer is what lets a merchant whose row was
+			// created at signup (#827) actually add a card: that row
+			// deliberately carries no Stripe customer, and trial.Subscribe
+			// refuses without one.
+			trialBillingHandler = admin.NewTrialBillingHandler(trialSubscriber, log).
+				WithCustomerEnsurer(subscriptionSvc)
 		}
 
 		// P10 — Promo-code engine (§7).

--- a/services/marketplace-api/internal/auth/middleware.go
+++ b/services/marketplace-api/internal/auth/middleware.go
@@ -21,6 +21,32 @@ import (
 // HeaderTrustAuth returns a gin middleware that reads the user/tenant
 // claim headers populated upstream by Istio. internalSecret, when
 // non-empty, requires X-Internal-Auth to match.
+// InternalSecretAuth guards a service-to-service route with the shared
+// internal secret ALONE — no X-User-Id / X-Tenant-Id, which HeaderTrustAuth
+// additionally requires.
+//
+// That distinction is the reason this exists. HeaderTrustAuth is for internal
+// calls made ON BEHALF OF a user (the CSM review route). A platform-api
+// callback fired during onboarding has no user: the merchant has not signed in
+// anywhere yet. Reusing HeaderTrustAuth there would 401 every legitimate call
+// and read as a broken secret.
+//
+// An EMPTY secret disables the check, matching HeaderTrustAuth and every other
+// /internal route in this service. That is deliberate rather than lax: a route
+// that fails closed while the ones beside it stay open turns a missing
+// deployment variable into a partial outage that looks like a bug in whichever
+// feature happens to use the strict route. The /internal namespace's real
+// boundary is the network policy; this header is defence in depth.
+func InternalSecretAuth(internalSecret string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if internalSecret != "" && !constantTimeEqual(c.GetHeader("X-Internal-Auth"), internalSecret) {
+			respondUnauthorized(c)
+			return
+		}
+		c.Next()
+	}
+}
+
 func HeaderTrustAuth(internalSecret string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if internalSecret != "" && !constantTimeEqual(c.GetHeader("X-Internal-Auth"), internalSecret) {

--- a/services/marketplace-api/internal/handlers/admin/subscription.go
+++ b/services/marketplace-api/internal/handlers/admin/subscription.go
@@ -357,6 +357,19 @@ func (h *SubscriptionHandler) Bootstrap(c *gin.Context) {
 		return
 	}
 
+	// The row exists now, so the trial has started (#827) — that half is
+	// committed whatever happens next. Attaching the Stripe customer is the
+	// other half, and its error is surfaced rather than logged away: an
+	// unusable billing key is precisely the failure #827 found had been
+	// invisible for months. A retry of this endpoint is cheap, because
+	// both halves are idempotent.
+	withCustomer, err := h.svc.EnsureStripeCustomer(c.Request.Context(), tenantID, storeID, email, name)
+	if err != nil {
+		RespondErr(c, err, h.logger)
+		return
+	}
+	sub = withCustomer
+
 	if h.audit != nil {
 		h.audit.Emit(c, audit.Event{
 			Action:       "subscription.bootstrap",

--- a/services/marketplace-api/internal/handlers/admin/subscription_trial.go
+++ b/services/marketplace-api/internal/handlers/admin/subscription_trial.go
@@ -24,10 +24,32 @@ type TrialSubscriber interface {
 	Subscribe(ctx context.Context, in trial.SubscribeInput) (*trial.SubscribeResult, error)
 }
 
+// StripeCustomerEnsurer attaches a Stripe customer to a subscription row that
+// has none. *subscription.Service satisfies it.
+//
+// Needed since #827: a row created at signup deliberately carries no Stripe
+// customer, and trial.Subscribe refuses without one. Without this the card-add
+// step would answer 412 for every merchant who signed up after that change —
+// which is exactly the shape of bug #827 was opened for, moved one step later.
+type StripeCustomerEnsurer interface {
+	EnsureStripeCustomer(ctx context.Context, tenantID, storeID uuid.UUID,
+		email, name string) (*subscription.StoreSubscription, error)
+}
+
 // TrialBillingHandler exposes the deferred-charge trial subscription endpoint.
 type TrialBillingHandler struct {
 	subscriber TrialSubscriber
+	customers  StripeCustomerEnsurer
 	logger     *slog.Logger
+}
+
+// WithCustomerEnsurer wires the Stripe-customer step that must run before a
+// card-backed subscription can be created. Nil-safe: without it the handler
+// behaves exactly as it did before #827, answering 412 missing_stripe_customer
+// for a row that has none.
+func (h *TrialBillingHandler) WithCustomerEnsurer(e StripeCustomerEnsurer) *TrialBillingHandler {
+	h.customers = e
+	return h
 }
 
 // NewTrialBillingHandler constructs a TrialBillingHandler.
@@ -63,6 +85,21 @@ func (h *TrialBillingHandler) Subscribe(c *gin.Context) {
 	if err := c.ShouldBindJSON(&req); err != nil {
 		RespondErr(c, apperrors.ValidationFailed("body", err.Error()), h.logger)
 		return
+	}
+
+	// A row created at signup carries no Stripe customer by design (#827);
+	// mint one now that the merchant is actually adding a card.
+	//
+	// A failure here is logged and NOT returned: Subscribe below produces the
+	// merchant-facing answer for a row with no customer — 412
+	// missing_stripe_customer — and that is the honest thing to tell someone
+	// whose card we cannot take yet. The log line carries why.
+	if h.customers != nil {
+		if _, err := h.customers.EnsureStripeCustomer(c.Request.Context(),
+			tenantID, storeID, c.GetString("user_email"), ""); err != nil && h.logger != nil {
+			h.logger.Error("trial subscribe: could not attach a stripe customer",
+				"store_id", storeID, "tenant_id", tenantID, "err", err)
+		}
 	}
 
 	res, err := h.subscriber.Subscribe(c.Request.Context(), trial.SubscribeInput{

--- a/services/marketplace-api/internal/subscription/bootstrap_test.go
+++ b/services/marketplace-api/internal/subscription/bootstrap_test.go
@@ -1,0 +1,272 @@
+package subscription_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/pkg/apperrors"
+)
+
+// bootstrapRepo is the subset of subscription.Repository Bootstrap touches,
+// with the rest present only to satisfy the interface.
+type bootstrapRepo struct {
+	existing  *subscription.StoreSubscription
+	created   []subscription.StoreSubscription
+	updated   []subscription.StoreSubscription
+	createErr error
+}
+
+func (r *bootstrapRepo) GetByStoreID(_ context.Context, _ *gorm.DB, _, _ uuid.UUID) (*subscription.StoreSubscription, error) {
+	if r.existing == nil {
+		return nil, apperrors.NotFound("subscription")
+	}
+	return r.existing, nil
+}
+
+func (r *bootstrapRepo) Create(_ context.Context, _ *gorm.DB, s *subscription.StoreSubscription) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	r.created = append(r.created, *s)
+	r.existing = s
+	return nil
+}
+
+func (r *bootstrapRepo) Update(_ context.Context, _ *gorm.DB, s *subscription.StoreSubscription) error {
+	r.updated = append(r.updated, *s)
+	return nil
+}
+
+func (r *bootstrapRepo) GetByStripeCustomerID(context.Context, *gorm.DB, string) (*subscription.StoreSubscription, error) {
+	return nil, apperrors.NotFound("subscription")
+}
+func (r *bootstrapRepo) SetPendingDowngrade(context.Context, *gorm.DB, uuid.UUID, uuid.UUID,
+	subscription.SubscriptionPlan, subscription.SubscriptionPeriod, time.Time, string) error {
+	return nil
+}
+func (r *bootstrapRepo) ClearPendingDowngrade(context.Context, *gorm.DB, uuid.UUID, uuid.UUID) error {
+	return nil
+}
+func (r *bootstrapRepo) CommitDowngrade(context.Context, *gorm.DB, uuid.UUID, uuid.UUID,
+	subscription.SubscriptionPlan, subscription.SubscriptionPeriod) error {
+	return nil
+}
+func (r *bootstrapRepo) CommitUpgrade(context.Context, *gorm.DB, uuid.UUID, uuid.UUID,
+	subscription.SubscriptionPlan, subscription.SubscriptionPeriod, string) error {
+	return nil
+}
+func (r *bootstrapRepo) FindPendingDowngradesReady(context.Context, *gorm.DB, time.Time) ([]subscription.StoreSubscription, error) {
+	return nil, nil
+}
+func (r *bootstrapRepo) CountStoresForPlanSlot(context.Context, *gorm.DB, uuid.UUID) (int, error) {
+	return 0, nil
+}
+func (r *bootstrapRepo) ListAllSubscriptions(context.Context, *gorm.DB, subscription.CrossTenantFilter) ([]subscription.StoreSubscription, int64, error) {
+	return nil, 0, nil
+}
+
+// recordingStripe counts customer creations so a test can prove Bootstrap
+// makes none.
+type recordingStripe struct {
+	created int
+	err     error
+}
+
+func (s *recordingStripe) CreateCustomer(context.Context, string, string) (string, error) {
+	s.created++
+	if s.err != nil {
+		return "", s.err
+	}
+	return "cus_test", nil
+}
+func (s *recordingStripe) CreateCheckoutSession(context.Context, string, subscription.SubscriptionPlan, string, string) (string, error) {
+	return "", nil
+}
+func (s *recordingStripe) CreatePortalSession(context.Context, string, string) (string, error) {
+	return "", nil
+}
+
+func newSvc(repo subscription.Repository, stripe subscription.StripeClient) *subscription.Service {
+	return subscription.NewService(subscription.ServiceConfig{DB: nil, Repo: repo, Stripe: stripe})
+}
+
+func bootstrapInput() subscription.BootstrapInput {
+	return subscription.BootstrapInput{
+		TenantID: uuid.New(),
+		StoreID:  uuid.New(),
+		Email:    "founder@example.com",
+		Name:     "Bondi Surf Co",
+	}
+}
+
+// The point of #827. A free trial must not depend on a payment provider being
+// reachable: that dependency is what turns a mis-scoped Stripe key into a
+// merchant with no trial at all.
+func TestBootstrap_CreatesTheRowWithNoStripeClientAtAll(t *testing.T) {
+	repo := &bootstrapRepo{}
+	svc := newSvc(repo, nil)
+
+	sub, err := svc.Bootstrap(context.Background(), bootstrapInput())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if len(repo.created) != 1 {
+		t.Fatalf("created %d rows, want 1", len(repo.created))
+	}
+	if sub.Plan != subscription.PlanTrial {
+		t.Errorf("plan = %q, want trial", sub.Plan)
+	}
+	if sub.Status != subscription.StatusSignup {
+		t.Errorf("status = %q, want signup", sub.Status)
+	}
+	if sub.StripeCustomerID != "" {
+		t.Errorf("StripeCustomerID = %q, want empty — Bootstrap must not mint one", sub.StripeCustomerID)
+	}
+}
+
+// Even WITH a client. Attaching a customer is a separate responsibility with a
+// separate failure mode; folding it in is what let a Stripe problem present as
+// "no trial" instead of as a Stripe problem.
+func TestBootstrap_MakesNoStripeCallEvenWhenAClientIsWired(t *testing.T) {
+	stripe := &recordingStripe{}
+	svc := newSvc(&bootstrapRepo{}, stripe)
+
+	if _, err := svc.Bootstrap(context.Background(), bootstrapInput()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if stripe.created != 0 {
+		t.Fatalf("Bootstrap made %d Stripe customer calls, want 0", stripe.created)
+	}
+}
+
+// The billing currency is known at signup and nothing else supplies it later.
+// A row without one cannot have its price resolved.
+func TestBootstrap_RecordsTheBillingCurrencyWhenTheCallerKnowsIt(t *testing.T) {
+	repo := &bootstrapRepo{}
+	svc := newSvc(repo, nil)
+
+	in := bootstrapInput()
+	in.BillingCurrency = "aud"
+	sub, err := svc.Bootstrap(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if sub.BillingCurrency == nil || *sub.BillingCurrency != "aud" {
+		t.Fatalf("BillingCurrency = %v, want aud", sub.BillingCurrency)
+	}
+}
+
+// An unknown currency must stay NULL rather than becoming "". The column is
+// CHAR(3) and every reader treats nil as "not known yet"; "" would be a third
+// meaning nothing tests for.
+func TestBootstrap_LeavesTheCurrencyNullWhenNotSupplied(t *testing.T) {
+	svc := newSvc(&bootstrapRepo{}, nil)
+
+	sub, err := svc.Bootstrap(context.Background(), bootstrapInput())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if sub.BillingCurrency != nil {
+		t.Fatalf("BillingCurrency = %q, want nil", *sub.BillingCurrency)
+	}
+}
+
+// Unchanged from before #827, and load-bearing: onboarding retries, and the
+// admin CTA can still be pressed on a row that already exists.
+func TestBootstrap_IsIdempotent(t *testing.T) {
+	existing := &subscription.StoreSubscription{
+		ID: uuid.New(), Plan: subscription.PlanStarter, Status: subscription.StatusActive,
+	}
+	repo := &bootstrapRepo{existing: existing}
+	svc := newSvc(repo, nil)
+
+	sub, err := svc.Bootstrap(context.Background(), bootstrapInput())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if len(repo.created) != 0 {
+		t.Fatal("Bootstrap inserted a second row for a store that already had one")
+	}
+	if sub.Plan != subscription.PlanStarter {
+		t.Errorf("returned plan = %q — the existing row was overwritten", sub.Plan)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EnsureStripeCustomer — the other half, failing on its own terms
+// ---------------------------------------------------------------------------
+
+func TestEnsureStripeCustomer_AttachesToARowThatHasNone(t *testing.T) {
+	in := bootstrapInput()
+	repo := &bootstrapRepo{existing: &subscription.StoreSubscription{
+		TenantID: in.TenantID, StoreID: in.StoreID, StripeCustomerID: "",
+	}}
+	stripe := &recordingStripe{}
+	svc := newSvc(repo, stripe)
+
+	sub, err := svc.EnsureStripeCustomer(context.Background(), in.TenantID, in.StoreID, in.Email, in.Name)
+	if err != nil {
+		t.Fatalf("EnsureStripeCustomer: %v", err)
+	}
+	if sub.StripeCustomerID != "cus_test" {
+		t.Errorf("StripeCustomerID = %q, want cus_test", sub.StripeCustomerID)
+	}
+	if len(repo.updated) != 1 {
+		t.Errorf("persisted %d updates, want 1", len(repo.updated))
+	}
+}
+
+func TestEnsureStripeCustomer_IsIdempotent(t *testing.T) {
+	in := bootstrapInput()
+	repo := &bootstrapRepo{existing: &subscription.StoreSubscription{
+		TenantID: in.TenantID, StoreID: in.StoreID, StripeCustomerID: "cus_already",
+	}}
+	stripe := &recordingStripe{}
+	svc := newSvc(repo, stripe)
+
+	sub, err := svc.EnsureStripeCustomer(context.Background(), in.TenantID, in.StoreID, in.Email, in.Name)
+	if err != nil {
+		t.Fatalf("EnsureStripeCustomer: %v", err)
+	}
+	if stripe.created != 0 {
+		t.Errorf("minted a second customer for a row that already had one")
+	}
+	if sub.StripeCustomerID != "cus_already" {
+		t.Errorf("StripeCustomerID = %q", sub.StripeCustomerID)
+	}
+}
+
+// The failure #827 exists to stop being invisible. A broken Stripe key must
+// surface here, loudly, rather than being folded into "the trial did not start".
+func TestEnsureStripeCustomer_SurfacesTheStripeError(t *testing.T) {
+	in := bootstrapInput()
+	repo := &bootstrapRepo{existing: &subscription.StoreSubscription{
+		TenantID: in.TenantID, StoreID: in.StoreID,
+	}}
+	svc := newSvc(repo, &recordingStripe{err: errors.New("more_permissions_required")})
+
+	if _, err := svc.EnsureStripeCustomer(context.Background(), in.TenantID, in.StoreID, in.Email, in.Name); err == nil {
+		t.Fatal("EnsureStripeCustomer swallowed a Stripe failure")
+	}
+	if len(repo.updated) != 0 {
+		t.Error("persisted an update despite the Stripe call failing")
+	}
+}
+
+func TestEnsureStripeCustomer_RefusesWithNoStripeConfigured(t *testing.T) {
+	in := bootstrapInput()
+	repo := &bootstrapRepo{existing: &subscription.StoreSubscription{
+		TenantID: in.TenantID, StoreID: in.StoreID,
+	}}
+	svc := newSvc(repo, nil)
+
+	if _, err := svc.EnsureStripeCustomer(context.Background(), in.TenantID, in.StoreID, in.Email, in.Name); err == nil {
+		t.Fatal("EnsureStripeCustomer succeeded with no Stripe client")
+	}
+}

--- a/services/marketplace-api/internal/subscription/internal_handler.go
+++ b/services/marketplace-api/internal/subscription/internal_handler.go
@@ -1,0 +1,107 @@
+// Package subscription — internal_handler.go
+//
+// POST /internal/stores/:storeID/ensure-subscription is the platform-api
+// callback that gives a brand-new store its subscription row, and with it its
+// trial clock.
+//
+// It exists because that clock had no other start (#827). Bootstrap was
+// reachable from exactly one place — a CTA on the admin Billing page — so the
+// 90-day trial began when a merchant happened to open Billing, and a merchant
+// who never opened it had no row at all: no trial, no expiry, and invisible to
+// every billing cron.
+//
+// Called from onboarding.Complete AFTER EnsureSelfStore, because
+// store_subscriptions.store_id is a foreign key onto stores(id) — the
+// projection has to land first. Idempotent, so a retry of onboarding is safe.
+package subscription
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/auth"
+)
+
+// Bootstrapper is the one method this handler needs. *Service satisfies it;
+// the interface keeps the handler testable without a database.
+type Bootstrapper interface {
+	Bootstrap(ctx context.Context, in BootstrapInput) (*StoreSubscription, error)
+}
+
+// InternalHandler serves the platform-api subscription callback.
+type InternalHandler struct {
+	svc Bootstrapper
+}
+
+// NewInternalHandler constructs an InternalHandler.
+func NewInternalHandler(svc Bootstrapper) *InternalHandler {
+	return &InternalHandler{svc: svc}
+}
+
+// RegisterRoutes mounts the callback behind the shared internal secret.
+//
+// InternalSecretAuth, not HeaderTrustAuth: this call is made during
+// onboarding, when the merchant has not signed in anywhere, so there is no
+// X-User-Id or X-Tenant-Id to present and HeaderTrustAuth would refuse every
+// legitimate call. platform-api's VendorClient already sends X-Internal-Auth,
+// so no new configuration is needed on the calling side.
+func (h *InternalHandler) RegisterRoutes(g *gin.RouterGroup, internalSecret string) {
+	g.POST("/stores/:storeID/ensure-subscription",
+		auth.InternalSecretAuth(internalSecret), h.ensureSubscription)
+}
+
+type ensureSubscriptionRequest struct {
+	TenantID string `json:"tenant_id" binding:"required"`
+	// Email and Name are used only if a Stripe customer is minted later; they
+	// are carried now so the caller does not have to be asked again.
+	Email string `json:"email"`
+	Name  string `json:"name"`
+	// Currency is the store's ISO 4217 billing currency. Known at signup and
+	// supplied by nothing else afterwards.
+	Currency string `json:"currency"`
+}
+
+func (h *InternalHandler) ensureSubscription(c *gin.Context) {
+	storeID, err := uuid.Parse(c.Param("storeID"))
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_store_id"})
+		return
+	}
+
+	var req ensureSubscriptionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_request", "detail": err.Error(),
+		})
+		return
+	}
+	tenantID, err := uuid.Parse(req.TenantID)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_tenant_id"})
+		return
+	}
+
+	sub, err := h.svc.Bootstrap(c.Request.Context(), BootstrapInput{
+		TenantID:        tenantID,
+		StoreID:         storeID,
+		Email:           req.Email,
+		Name:            req.Name,
+		BillingCurrency: req.Currency,
+	})
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+			"error": "ensure_subscription_failed", "detail": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{
+		"id":         sub.ID.String(),
+		"plan":       string(sub.Plan),
+		"status":     string(sub.Status),
+		"created_at": sub.CreatedAt,
+	}})
+}

--- a/services/marketplace-api/internal/subscription/internal_handler_test.go
+++ b/services/marketplace-api/internal/subscription/internal_handler_test.go
@@ -1,0 +1,185 @@
+package subscription_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+const testInternalSecret = "internal-secret-for-tests"
+
+type stubBootstrapper struct {
+	calls []subscription.BootstrapInput
+	err   error
+}
+
+func (b *stubBootstrapper) Bootstrap(_ context.Context, in subscription.BootstrapInput) (*subscription.StoreSubscription, error) {
+	b.calls = append(b.calls, in)
+	if b.err != nil {
+		return nil, b.err
+	}
+	return &subscription.StoreSubscription{
+		ID: uuid.New(), TenantID: in.TenantID, StoreID: in.StoreID,
+		Plan: subscription.PlanTrial, Status: subscription.StatusSignup,
+	}, nil
+}
+
+// router builds the real thing, through Register, and drives it with
+// ServeHTTP. Deliberately not a 404-vs-405 probe: HandleMethodNotAllowed is
+// never set in this estate, so gin answers 404 whether or not a route is
+// mounted and that probe distinguishes nothing (#642).
+func router(t *testing.T, svc subscription.Bootstrapper) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	e := gin.New()
+	subscription.NewInternalHandler(svc).RegisterRoutes(e.Group("/internal"), testInternalSecret)
+	return e
+}
+
+func ensureReq(t *testing.T, storeID uuid.UUID, body map[string]any, secret string) *http.Request {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost,
+		"/internal/stores/"+storeID.String()+"/ensure-subscription", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	if secret != "" {
+		req.Header.Set("X-Internal-Auth", secret)
+	}
+	return req
+}
+
+// The point of #827: completing onboarding leaves a row, and that row's
+// existence is what starts the trial.
+func TestEnsureSubscription_BootstrapsTheStore(t *testing.T) {
+	svc := &stubBootstrapper{}
+	storeID, tenantID := uuid.New(), uuid.New()
+
+	rec := httptest.NewRecorder()
+	router(t, svc).ServeHTTP(rec, ensureReq(t, storeID, map[string]any{
+		"tenant_id": tenantID.String(),
+		"email":     "founder@example.com",
+		"name":      "Bondi Surf Co",
+		"currency":  "aud",
+	}, testInternalSecret))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if len(svc.calls) != 1 {
+		t.Fatalf("Bootstrap called %d times, want 1", len(svc.calls))
+	}
+	got := svc.calls[0]
+	if got.StoreID != storeID || got.TenantID != tenantID {
+		t.Errorf("ids = %s/%s, want %s/%s", got.TenantID, got.StoreID, tenantID, storeID)
+	}
+	if got.BillingCurrency != "aud" {
+		t.Errorf("BillingCurrency = %q, want aud — nothing else supplies it later", got.BillingCurrency)
+	}
+}
+
+// The route writes a row that starts a billing clock. Unlike
+// /internal/stores/upsert beside it, it is guarded — and the guard is only
+// worth having if it actually refuses.
+func TestEnsureSubscription_RefusesWithoutTheInternalSecret(t *testing.T) {
+	svc := &stubBootstrapper{}
+
+	for _, tc := range []struct{ name, secret string }{
+		{"no header", ""},
+		{"wrong secret", "not-the-secret"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			router(t, svc).ServeHTTP(rec, ensureReq(t, uuid.New(),
+				map[string]any{"tenant_id": uuid.New().String()}, tc.secret))
+
+			if rec.Code == http.StatusOK {
+				t.Fatalf("status = %d — an unauthenticated caller started a trial", rec.Code)
+			}
+			if len(svc.calls) != 0 {
+				t.Fatal("Bootstrap ran for a request that failed the guard")
+			}
+		})
+	}
+}
+
+func TestEnsureSubscription_RejectsAMalformedStoreID(t *testing.T) {
+	svc := &stubBootstrapper{}
+	req := httptest.NewRequest(http.MethodPost,
+		"/internal/stores/not-a-uuid/ensure-subscription", bytes.NewReader([]byte(`{"tenant_id":"x"}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Internal-Auth", testInternalSecret)
+
+	rec := httptest.NewRecorder()
+	router(t, svc).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if len(svc.calls) != 0 {
+		t.Fatal("Bootstrap ran with an unparseable store id")
+	}
+}
+
+// A missing tenant must be a 400, not a row created against the zero UUID —
+// which the repository would accept as a real tenant and no query would ever
+// find again.
+func TestEnsureSubscription_RejectsAMissingTenant(t *testing.T) {
+	svc := &stubBootstrapper{}
+	rec := httptest.NewRecorder()
+	router(t, svc).ServeHTTP(rec, ensureReq(t, uuid.New(), map[string]any{}, testInternalSecret))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if len(svc.calls) != 0 {
+		t.Fatal("Bootstrap ran with no tenant")
+	}
+}
+
+// Onboarding treats this call as best-effort, so the failure has to be
+// legible on the wire rather than swallowed into a 200 the caller cannot
+// distinguish from success.
+func TestEnsureSubscription_ReportsABootstrapFailure(t *testing.T) {
+	svc := &stubBootstrapper{err: errors.New("db down")}
+	rec := httptest.NewRecorder()
+	router(t, svc).ServeHTTP(rec, ensureReq(t, uuid.New(),
+		map[string]any{"tenant_id": uuid.New().String()}, testInternalSecret))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+// Documents a security-relevant choice rather than asserting a nice property:
+// with NO secret configured the route is open, exactly like every other
+// /internal route in this service. Made deliberately — a route that fails
+// closed while the ones beside it stay open turns a missing deployment
+// variable into a partial outage that presents as a bug in whichever feature
+// uses the strict route. If the /internal namespace ever starts failing
+// closed, this test should change WITH the others, not before them.
+func TestEnsureSubscription_IsOpenWhenNoSecretIsConfigured(t *testing.T) {
+	svc := &stubBootstrapper{}
+	gin.SetMode(gin.TestMode)
+	e := gin.New()
+	subscription.NewInternalHandler(svc).RegisterRoutes(e.Group("/internal"), "")
+
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, ensureReq(t, uuid.New(),
+		map[string]any{"tenant_id": uuid.New().String()}, ""))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 — parity with the rest of /internal", rec.Code)
+	}
+}

--- a/services/marketplace-api/internal/subscription/service.go
+++ b/services/marketplace-api/internal/subscription/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -67,19 +68,36 @@ type BootstrapInput struct {
 	StoreID  uuid.UUID
 	Email    string
 	Name     string
+	// BillingCurrency is the store's ISO 4217 currency, lower-case, when the
+	// caller knows it — onboarding does. Left empty it stays NULL, which is
+	// what every reader already treats as "not known yet"; "" would be a
+	// third meaning nothing tests for.
+	BillingCurrency string
 }
 
-// Bootstrap idempotently initialises a store_subscriptions row.
+// Bootstrap idempotently initialises a store_subscriptions row: plan=trial,
+// status=signup. The status machine (P2) owns the signup → trialing
+// transition once the merchant confirms a plan.
 //
-// If a row already exists for the (tenant, store) pair it is returned as-is
-// (idempotent — safe to call from a retry). Otherwise a Stripe customer is
-// created and a new row is inserted with plan=trial, status=signup. The
-// status machine (P2) owns the signup → trialing transition once the
-// merchant confirms a plan.
+// IT MAKES NO STRIPE CALL. That is the fix for #827, and it is deliberate in
+// both directions:
 //
-// This exists because stores created before the subscription-v2 refactor
-// shipped have no row and GetSubscription returns 404. The admin UI calls
-// Bootstrap on that 404 to create the row on demand.
+//   - The row's created_at IS the trial clock (trial.EndsAt derives from it
+//     when trial_ends_at is NULL). Making a free trial depend on a payment
+//     provider being reachable is what turns a Stripe outage — or the
+//     mis-scoped key #696 describes — into a merchant with no trial at all.
+//   - Attaching a customer has its own failure mode, and folding it in here
+//     is what let a Stripe problem present as "the trial did not start"
+//     rather than as a Stripe problem. See EnsureStripeCustomer.
+//
+// A row with an empty stripe_customer_id is a state this codebase already
+// expects: the reconciler, hard-delete, the billing archive and the admin
+// payment-method lookup all guard it and degrade, and the PAID path refuses
+// it outright (planchange.go, "run bootstrap first"). That refusal is what
+// makes a customer-less trial row safe to create.
+//
+// Called at onboarding completion, which is what makes the trial start at
+// signup, and still by the admin billing page for a store that predates it.
 func (s *Service) Bootstrap(ctx context.Context, in BootstrapInput) (*StoreSubscription, error) {
 	if in.TenantID == uuid.Nil {
 		return nil, apperrors.ValidationFailed("tenant_id", "tenant_id is required")
@@ -87,10 +105,6 @@ func (s *Service) Bootstrap(ctx context.Context, in BootstrapInput) (*StoreSubsc
 	if in.StoreID == uuid.Nil {
 		return nil, apperrors.ValidationFailed("store_id", "store_id is required")
 	}
-	if s.stripe == nil {
-		return nil, fmt.Errorf("stripe client not configured")
-	}
-
 	// Idempotency — return the existing row if one is already in place.
 	existing, err := s.repo.GetByStoreID(ctx, s.db, in.TenantID, in.StoreID)
 	if err == nil {
@@ -100,34 +114,72 @@ func (s *Service) Bootstrap(ctx context.Context, in BootstrapInput) (*StoreSubsc
 		return nil, err
 	}
 
-	email := in.Email
-	if email == "" {
-		// Stripe requires non-empty customer email for reliable dedup;
-		// fall back to a deterministic tenant-scoped placeholder so the
-		// customer record is still unique per tenant/store.
-		email = fmt.Sprintf("billing+%s@mark8ly.local", in.StoreID.String())
-	}
-	name := in.Name
-	if name == "" {
-		name = in.StoreID.String()
-	}
-
-	customerID, err := s.stripe.CreateCustomer(ctx, email, name)
-	if err != nil {
-		return nil, fmt.Errorf("bootstrap: create stripe customer: %w", err)
-	}
-
 	row := &StoreSubscription{
-		TenantID:         in.TenantID,
-		StoreID:          in.StoreID,
-		StripeCustomerID: customerID,
-		Plan:             PlanTrial,
-		Status:           StatusSignup,
+		TenantID: in.TenantID,
+		StoreID:  in.StoreID,
+		Plan:     PlanTrial,
+		Status:   StatusSignup,
+	}
+	if cur := strings.ToLower(strings.TrimSpace(in.BillingCurrency)); cur != "" {
+		row.BillingCurrency = &cur
 	}
 	if err := s.repo.Create(ctx, s.db, row); err != nil {
 		return nil, fmt.Errorf("bootstrap: create subscription row: %w", err)
 	}
 	return row, nil
+}
+
+// EnsureStripeCustomer attaches a Stripe customer to a subscription row that
+// has none, and returns the row either way. Idempotent: a row that already
+// carries a customer id is returned untouched and no customer is minted.
+//
+// Split out of Bootstrap by #827 so the two can fail independently. A Stripe
+// failure here is returned, never logged-and-swallowed: an unusable billing
+// key is the thing that must be visible, and #827 exists because a billing
+// precondition failed quietly for months.
+//
+// Callers: the admin bootstrap CTA (after Bootstrap, so the trial has started
+// even when this half fails) and the card-add path, which cannot create a
+// Stripe subscription without one.
+func (s *Service) EnsureStripeCustomer(ctx context.Context, tenantID, storeID uuid.UUID,
+	email, name string) (*StoreSubscription, error) {
+
+	sub, err := s.repo.GetByStoreID(ctx, s.db, tenantID, storeID)
+	if err != nil {
+		return nil, err
+	}
+	if sub.StripeCustomerID != "" {
+		return sub, nil
+	}
+	if s.stripe == nil {
+		return nil, fmt.Errorf("ensure stripe customer: stripe client not configured")
+	}
+
+	if email == "" {
+		// Stripe requires non-empty customer email for reliable dedup;
+		// fall back to a deterministic tenant-scoped placeholder so the
+		// customer record is still unique per tenant/store.
+		email = fmt.Sprintf("billing+%s@mark8ly.local", storeID.String())
+	}
+	if name == "" {
+		name = storeID.String()
+	}
+
+	customerID, err := s.stripe.CreateCustomer(ctx, email, name)
+	if err != nil {
+		return nil, fmt.Errorf("ensure stripe customer: create stripe customer: %w", err)
+	}
+
+	sub.StripeCustomerID = customerID
+	if err := s.repo.Update(ctx, s.db, sub); err != nil {
+		// The customer exists at Stripe but we did not record it. Saying so
+		// is the point: a retry mints a SECOND customer for this store, and
+		// whoever reads this line is the only one who can tell that the
+		// duplicate came from here.
+		return nil, fmt.Errorf("ensure stripe customer: stripe customer %s created but not recorded: %w",
+			customerID, err)
+	}
+	return sub, nil
 }
 
 // CheckoutInput holds the parameters for creating a checkout session.

--- a/services/platform-api/internal/marketplaceapi/vendor_client.go
+++ b/services/platform-api/internal/marketplaceapi/vendor_client.go
@@ -141,6 +141,58 @@ type Store struct {
 	Status       string `json:"status"`
 }
 
+// EnsureSubscription gives a newly created store its subscription row, and
+// with it the start of its 90-day trial.
+//
+// Called from onboarding.Complete AFTER EnsureSelfStore, and the order is a
+// requirement rather than a preference: marketplace_api's
+// store_subscriptions.store_id is a foreign key onto its stores projection,
+// so the row this mirrors has to land first.
+//
+// Idempotent on store id. Best-effort like the two calls beside it — a
+// failure is logged and does not fail onboarding — but the consequence is
+// worth naming: a store with no subscription row has no trial clock at all
+// and is invisible to every billing cron until something else creates one
+// (mark8ly#827).
+func (c *VendorClient) EnsureSubscription(ctx context.Context, in EnsureSubscription) error {
+	body, err := json.Marshal(in)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/internal/stores/%s/ensure-subscription", c.baseURL, in.StoreID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.addInternalAuth(req)
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("marketplace-api ensure-subscription: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 300 {
+		raw, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("marketplace-api ensure-subscription %d: %s", res.StatusCode, string(raw))
+	}
+	return nil
+}
+
+// EnsureSubscription is the request body for the call of the same name.
+// StoreID travels in the path and is not serialised.
+type EnsureSubscription struct {
+	StoreID  string `json:"-"`
+	TenantID string `json:"tenant_id"`
+	Email    string `json:"email,omitempty"`
+	Name     string `json:"name,omitempty"`
+	// Currency is the store's ISO 4217 billing currency. Sent because
+	// nothing supplies it to marketplace-api afterwards, and a subscription
+	// row without one cannot have its price resolved.
+	Currency string `json:"currency,omitempty"`
+}
+
 // EnsureSelfStore upserts the authoritative store row from platform_api
 // into marketplace_api's local stores projection. Idempotent and keyed
 // on store id — re-runs are safe and preserve any server-side fields

--- a/services/platform-api/internal/onboarding/completion_integration_test.go
+++ b/services/platform-api/internal/onboarding/completion_integration_test.go
@@ -320,7 +320,16 @@ func TestIntegration_Complete_DuplicateSlugRollsBackEverything(t *testing.T) {
 type fakeVendorClient struct {
 	calls      []struct{ tenantID, name, slug string }
 	storeCalls []marketplaceapi.Store
+	subCalls   []marketplaceapi.EnsureSubscription
 	err        error
+}
+
+// EnsureSubscription starts the store's trial (mark8ly#827). Recorded so a
+// test can assert both that it happens and that it happens AFTER the store
+// mirror — marketplace-api's FK depends on that order.
+func (f *fakeVendorClient) EnsureSubscription(_ context.Context, in marketplaceapi.EnsureSubscription) error {
+	f.subCalls = append(f.subCalls, in)
+	return f.err
 }
 
 // EnsureSelfStore mirrors the platform-api store row into marketplace-api.
@@ -470,5 +479,82 @@ func TestIntegration_Complete_SwallowsVendorError(t *testing.T) {
 	// Tenant row must exist despite vendor error.
 	if _, err := tenantRepo.GetByID(ctx, res.TenantID); err != nil {
 		t.Errorf("tenant row missing after swallowed vendor error: %v", err)
+	}
+}
+
+// The trial has to start at signup. Before mark8ly#827 nothing here created a
+// subscription row, so the 90-day clock began whenever the merchant first
+// opened the admin Billing page — and never, for one who did not.
+func TestIntegration_Complete_StartsTheTrial(t *testing.T) {
+	db := testdb.NewDB(t,
+		"outbox_events",
+		"verification_tokens",
+		"onboarding_sessions",
+		"tenants",
+	)
+
+	onboardingRepo := NewRepository(db)
+	fake := &fakeVendorClient{}
+	svc := NewService(Config{
+		DB:           db,
+		Repo:         onboardingRepo,
+		TenantRepo:   tenant.NewRepository(db),
+		Sender:       notification.NoopSender{},
+		EmailFrom:    "noreply@test.local",
+		SupportEmail: "help@test.local",
+		VendorClient: fake,
+	})
+
+	ctx := context.Background()
+	now := time.Now()
+	sess := &Session{
+		Email:           "trial-start@test.local",
+		Draft:           json.RawMessage(`{}`),
+		Status:          StatusInProgress,
+		EmailVerifiedAt: &now,
+	}
+	if err := onboardingRepo.Create(ctx, sess); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	res, err := svc.Complete(ctx, CompleteRequest{
+		SessionID:    sess.ID,
+		BusinessName: "Trial Start Co",
+		Slug:         "trial-start-co",
+		OwnerUserID:  "gip-uid-trial-start",
+		OwnerEmail:   "trial-start@test.local",
+		CountryCode:  "AU",
+		CurrencyCode: "AUD",
+		Timezone:     "Australia/Sydney",
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	if len(fake.subCalls) != 1 {
+		t.Fatalf("EnsureSubscription called %d times, want 1 — onboarding completed without starting a trial",
+			len(fake.subCalls))
+	}
+	got := fake.subCalls[0]
+	if got.TenantID != res.TenantID {
+		t.Errorf("tenant = %q, want %q", got.TenantID, res.TenantID)
+	}
+	if got.StoreID == "" {
+		t.Error("no store id — the callback cannot find the row it must attach to")
+	}
+	if got.Currency != "AUD" {
+		t.Errorf("currency = %q, want AUD — nothing supplies it to marketplace-api afterwards", got.Currency)
+	}
+
+	// store_subscriptions.store_id is an FK onto the stores projection
+	// EnsureSelfStore creates, so this ordering is a requirement rather than
+	// a preference. Asserted here because a reordering would still pass
+	// every other test in this file and fail only against a real database.
+	if len(fake.storeCalls) != 1 {
+		t.Fatalf("EnsureSelfStore called %d times, want 1", len(fake.storeCalls))
+	}
+	if fake.storeCalls[0].ID != got.StoreID {
+		t.Errorf("store mirrored = %q but subscription attached to %q",
+			fake.storeCalls[0].ID, got.StoreID)
 	}
 }

--- a/services/platform-api/internal/onboarding/service.go
+++ b/services/platform-api/internal/onboarding/service.go
@@ -28,6 +28,11 @@ import (
 type VendorEnsurer interface {
 	EnsureSelfVendor(ctx context.Context, tenantID, name, slug string) (*marketplaceapi.Vendor, error)
 	EnsureSelfStore(ctx context.Context, s marketplaceapi.Store) (*marketplaceapi.Store, error)
+	// EnsureSubscription starts the store's trial. Without it the 90-day
+	// clock does not begin at signup — it begins whenever a merchant first
+	// opens the admin Billing page, and never at all for one who does not
+	// (mark8ly#827).
+	EnsureSubscription(ctx context.Context, in marketplaceapi.EnsureSubscription) error
 }
 
 // Service is the business logic for the onboarding flow.
@@ -462,6 +467,26 @@ func (s *Service) Complete(ctx context.Context, req CompleteRequest) (*CompleteR
 			Status:       string(store.StatusActive),
 		}); sErr != nil {
 			log.Printf("onboarding.Complete: ensure self-store for tenant %s store %s: %v", t.ID, st.ID, sErr)
+		}
+
+		// Start the trial. AFTER EnsureSelfStore, because marketplace-api's
+		// store_subscriptions.store_id is an FK onto the projection that
+		// call creates.
+		//
+		// Same best-effort policy, and the same caveat as the store mirror:
+		// onboarding must not fail over it. But this one is worth a louder
+		// log line — a store with no subscription row has no trial, no
+		// expiry and no presence in any billing cron, which is the state
+		// mark8ly#827 found every store had been in.
+		if subErr := s.vendorClient.EnsureSubscription(ctx, marketplaceapi.EnsureSubscription{
+			StoreID:  st.ID,
+			TenantID: t.ID,
+			Email:    req.OwnerEmail,
+			Name:     st.Name,
+			Currency: st.CurrencyCode,
+		}); subErr != nil {
+			log.Printf("onboarding.Complete: ensure subscription for tenant %s store %s: %v — THIS STORE HAS NO TRIAL CLOCK",
+				t.ID, st.ID, subErr)
 		}
 	}
 


### PR DESCRIPTION
Closes #827.

The 90-day trial did not start at signup. It started when a merchant clicked a CTA on the admin Billing page — and for a merchant who never clicked it, there was no subscription row at all: no trial, no expiry, and no presence in any billing cron.

`Service.Bootstrap` was the only code in the tree that created a `store_subscriptions` row, and its only caller was that CTA. Its own doc calls it a back-fill for "stores created before the v2.3 signup pipeline". **That pipeline did not exist.** Full evidence on #827.

Found while scoping the onboarding promo field (#620), which cannot be built until a row exists at signup — a promo code typed at onboarding has nothing to redeem against.

## The shape of the fix

**A free trial must not depend on a payment provider being reachable.** That dependency is what turns a Stripe outage — or the mis-scoped key #696 describes — into a merchant with no trial. So:

- **`Bootstrap` no longer calls Stripe.** It creates the row: `plan=trial`, `status=signup`, plus `billing_currency`, which is known at signup and supplied by nothing afterwards.
- **`EnsureStripeCustomer` is the other half**, and it fails on its own terms. Not best-effort-with-a-warning inside Bootstrap: swallowing a Stripe error is exactly how a billing precondition stayed invisible for months.

**No migration.** An empty `stripe_customer_id` is already a state this codebase expects — the reconciler, hard-delete, the billing archive and the admin payment-method lookup all guard it and degrade, and `planchange.go:257` refuses a customer-less row outright with *"run bootstrap first"*. That refusal is what makes a customer-less trial row safe. `NOT NULL` is satisfied by `''`.

## What changed

| | |
|---|---|
| `POST /internal/stores/:storeID/ensure-subscription` | new; mounted on **both** engines through one method, so `MODE=admin` and local `mode.Both` cannot drift the way #323 found they had |
| `auth.InternalSecretAuth` | new; secret-only guard. `HeaderTrustAuth` also demands `X-User-Id`/`X-Tenant-Id`, and an onboarding callback has no user — reusing it would 401 every legitimate call and read as a broken secret |
| platform-api `onboarding.Complete` | calls it after `EnsureSelfStore`, because `store_subscriptions.store_id` is an FK onto the projection that call creates. Same best-effort policy as its two neighbours |
| admin bootstrap CTA | Bootstrap **then** EnsureStripeCustomer — the row is committed first, so the trial has started even when the Stripe half fails, and the Stripe error is still surfaced |
| card-add path | ensures a customer before `trial.Subscribe`, which otherwise answers 412 for every merchant whose row was created at signup |
| `cmd/backfill-trial-start` | new; **not run** |

The internal handler's `Service` is constructed with **no Stripe client at all**. That is the point of the split: starting a trial is a database write, so this route cannot be taken down by a billing key.

## The backfill is deliberately not run

It dates each trial from the **store's** `created_at`, not from the moment of the backfill — otherwise every dormant account in the estate receives a fresh 90 days. For a store older than 90 days that writes an already-expired trial, which is truthful and merchant-visible.

So `-apply` is opt-in (inverted from the usual `-dry-run` so writing requires naming the intent), and the summary reports `already_expired` separately: that is the number to read before running it. **This is a data decision and should be made against the real store count.**

## A note on the repo's own guard

The first draft of the backfill computed `created_at + 90d` itself, and `TestTrialEndIsDerivedInExactlyOnePlace` failed the build — the guard #353 added after that arithmetic had been duplicated across seven sites. It was right, and the backfill now calls `trial.EndsAt` on the row it is about to write. Worth mentioning because the guard did its job on a file that did not exist when it was written.

## Test plan

- [x] `gofmt`, `go build ./...`, `go vet ./...` clean in **both** services
- [x] Full marketplace-api suite green; platform-api green including `-tags integration` vet (the fake `VendorEnsurer` would otherwise not compile — CI builds that tag)
- [x] New tests: Bootstrap creates a row with no Stripe client and makes no Stripe call even when one is wired; currency recorded and left NULL when absent; idempotency; EnsureStripeCustomer attaches, is idempotent, surfaces the Stripe error and persists nothing when it fails
- [x] Route tests drive the **real router** through `ServeHTTP` — deliberately not a 404-vs-405 probe, which distinguishes nothing in this estate since `HandleMethodNotAllowed` is never set (#642)
- [x] The unconfigured-secret case has its own test, because "open when no secret is set" is a security-relevant choice and should be visible rather than incidental
- [x] `Complete` asserts the trial starts **and** that it happens after the store mirror — a reordering would pass every other test in that file and fail only against a real database
- [ ] Run the backfill. Needs a decision on the expired-trial rows first.

## Follow-on

- The onboarding promo field (#620) becomes buildable once this lands.
- `/internal/stores/upsert` has **no** app-layer guard, despite a comment on the ticket handler describing the `/internal` group as protected by a shared-secret middleware. There is no such middleware. Not changed here — platform-api already sends the header, so guarding it is a small follow-up, but it is a behaviour change on a live path and deserves its own PR.
