### PR TITLE
feat(onboarding): redeem a promo code while signing up (#620)

### DIFF
--- a/apps/onboarding/app/onboarding/actions.ts
+++ b/apps/onboarding/app/onboarding/actions.ts
@@ -22,8 +22,12 @@
 //                                 user, the admin project grant and both
 //                                 FGA owner tuples.
 
+import { headers } from "next/headers";
+
 import { onboarding, tenants, PlatformApiError } from "@/lib/api/platform-api";
 import { config } from "@/lib/config";
+import { allowPromoCheck } from "@/lib/promo/rateLimit";
+import type { PromoCheck } from "@/lib/promo/message";
 
 type Result<T> =
   | { ok: true; data: T }
@@ -48,6 +52,49 @@ export async function checkSlug(
   }
 }
 
+// ─── checkPromoCode: live check as the merchant types ──────────────────
+//
+// Answers what a code WOULD grant, and redeems nothing. Redeeming here would
+// be fatal: max_per_email is 1, so a redemption written while someone is still
+// typing is a code they can never actually use.
+//
+// Rate limited on the visitor's address, which only this layer can see — the
+// call to platform-api comes from this app's pod, so its own limiter counts
+// every visitor in one bucket. See lib/promo/rateLimit.ts.
+//
+// Returns null for "we could not ask", which the field renders as its own
+// message. It must never collapse into "invalid": telling a merchant their
+// working code is bad because a service was down is the one outcome here that
+// silently costs a signup.
+export async function checkPromoCode(
+  code: string,
+  email: string,
+  currencyCode: string,
+): Promise<Result<PromoCheck | null>> {
+  const trimmed = code.trim();
+  if (!trimmed) {
+    return { ok: true, data: null };
+  }
+
+  const h = await headers();
+  // x-forwarded-for is a list; the first entry is the client as seen by the
+  // edge. Falling back to a single shared bucket is deliberate — an absent
+  // header must not mean "unlimited".
+  const visitor = (h.get("x-forwarded-for") ?? "unknown").split(",")[0]!.trim();
+  if (!allowPromoCheck(visitor)) {
+    return { ok: false, code: "rate_limited", message: "too many attempts" };
+  }
+
+  try {
+    const res = await onboarding.validatePromo(trimmed, email, currencyCode);
+    return { ok: true, data: res };
+  } catch {
+    // Deliberately not `fail(err)`: the caller distinguishes "could not ask"
+    // from "answered no", and an ok:false here would be read as the latter.
+    return { ok: true, data: null };
+  }
+}
+
 // ─── submitOnboarding: form submit → create session + send magic link ──
 interface SubmitInput {
   email: string;
@@ -59,6 +106,9 @@ interface SubmitInput {
   // §5.1.1 — optional; persisted to draft so completeOnboarding can
   // forward them to the backend tax-ID endpoint once the store exists.
   taxId?: string;
+  // §620 — optional; persisted to the draft so completeOnboarding can hand it
+  // to marketplace-api, which redeems it once the subscription row exists.
+  promoCode?: string;
   migrationType?: "new" | "migrating";
   whoisUrl?: string;
   // screenshot_url is the GCS URL returned by the upload helper; the
@@ -87,6 +137,7 @@ export async function submitOnboarding(
       timezone: input.timezone,
     };
     if (input.taxId) draft.tax_id = input.taxId;
+    if (input.promoCode) draft.promo_code = input.promoCode;
     if (input.migrationType) draft.migration_type = input.migrationType;
     if (input.whoisUrl) draft.whois_url = input.whoisUrl;
     if (input.screenshotUrl) draft.screenshot_url = input.screenshotUrl;
@@ -214,6 +265,11 @@ export async function completeOnboardingWithZitadel(
     const countryCode = draft.country_code ?? "";
     const currencyCode = draft.currency_code ?? "";
     const timezone = draft.timezone ?? "UTC";
+    // Carried from the form rather than re-asked. It is redeemed by
+    // marketplace-api immediately after the subscription row is created —
+    // the earliest moment redemption is possible, since the ledger row needs
+    // a subscription id and the trial extension needs a row to move (#620).
+    const promoCode = draft.promo_code ?? "";
 
     if (!businessName || !slug || !countryCode || !currencyCode) {
       return {
@@ -241,6 +297,7 @@ export async function completeOnboardingWithZitadel(
       password: input.password,
       first_name: firstName,
       last_name: lastName,
+      ...(promoCode ? { promo_code: promoCode } : {}),
     });
 
     return {

--- a/apps/onboarding/components/onboarding/OnboardingForm.tsx
+++ b/apps/onboarding/components/onboarding/OnboardingForm.tsx
@@ -17,7 +17,12 @@ import {
 
 import type { Country, Currency, Timezone } from "@/lib/types";
 import { useOnboardingStore } from "@/lib/store/onboarding-store";
-import { checkSlug, submitOnboarding } from "@/app/onboarding/actions";
+import {
+  checkPromoCode,
+  checkSlug,
+  submitOnboarding,
+} from "@/app/onboarding/actions";
+import { promoMessage, type PromoMessage } from "@/lib/promo/message";
 import { signupCopy } from "@/lib/copy/signup";
 
 interface Props {
@@ -58,6 +63,7 @@ const schema = z
     countryCode: z.string().min(1, "Please select a country"),
     currencyCode: z.string().min(1, "Please select a currency"),
     taxId: z.string().optional(),
+    promoCode: z.string().optional(),
     migrationType: z.enum(["new", "migrating"]),
     whoisUrl: z.string().optional(),
     // screenshotFile is handled outside RHF via a ref; its upload
@@ -123,6 +129,8 @@ export function OnboardingForm({ countries, currencies, timezones }: Props) {
     state: "idle",
   });
   const [slugTouched, setSlugTouched] = useState(false);
+  const [promoStatus, setPromoStatus] = useState<PromoMessage | null>(null);
+  const [promoChecking, setPromoChecking] = useState(false);
   const [screenshotUploading, setScreenshotUploading] = useState(false);
   const [screenshotFileName, setScreenshotFileName] = useState<string | null>(
     null,
@@ -148,6 +156,7 @@ export function OnboardingForm({ countries, currencies, timezones }: Props) {
       countryCode: "",
       currencyCode: "",
       taxId: "",
+      promoCode: "",
       migrationType: "new",
       whoisUrl: "",
       screenshotUrl: "",
@@ -157,6 +166,12 @@ export function OnboardingForm({ countries, currencies, timezones }: Props) {
   const watchedBusinessName = watch("businessName");
   const watchedSlug = watch("slug");
   const watchedCountry = watch("countryCode");
+  const watchedPromoCode = watch("promoCode");
+  // The email and currency travel with the promo check: the per-email
+  // redemption cap is the only abuse control available before a store
+  // exists, and the currency decides which prices a code could apply to.
+  const watchedEmail = watch("email");
+  const watchedCurrency = watch("currencyCode");
   const watchedMigrationType = watch("migrationType");
   const isMigrating = watchedMigrationType === "migrating";
 
@@ -223,6 +238,33 @@ export function OnboardingForm({ countries, currencies, timezones }: Props) {
     return () => clearTimeout(handle);
   }, [watchedSlug]);
 
+  // Debounced promo-code check.
+  //
+  // Longer debounce than the slug check: a promo code is typed once and read
+  // back from an email, not explored, and every keystroke here is an attempt
+  // against a rate limit shared with the merchant's real submission.
+  useEffect(() => {
+    const code = (watchedPromoCode ?? "").trim();
+    if (code.length < 3) {
+      setPromoStatus(null);
+      setPromoChecking(false);
+      return;
+    }
+    setPromoChecking(true);
+    const handle = setTimeout(async () => {
+      const r = await checkPromoCode(code, watchedEmail ?? "", watchedCurrency ?? "");
+      setPromoChecking(false);
+      if (!r.ok) {
+        // Rate limited. Say nothing rather than imply the code is bad —
+        // the merchant still submits it and it is still redeemed.
+        setPromoStatus(null);
+        return;
+      }
+      setPromoStatus(promoMessage(r.data));
+    }, 600);
+    return () => clearTimeout(handle);
+  }, [watchedPromoCode, watchedEmail, watchedCurrency]);
+
   // Clear migration evidence when switching back to "new store".
   useEffect(() => {
     if (!isMigrating) {
@@ -270,6 +312,7 @@ export function OnboardingForm({ countries, currencies, timezones }: Props) {
       currencyCode: values.currencyCode,
       timezone: resolvedTimezone,
       taxId: values.taxId?.trim() || undefined,
+      promoCode: values.promoCode?.trim() || undefined,
       migrationType: values.migrationType,
       whoisUrl:
         values.migrationType === "migrating"
@@ -472,6 +515,35 @@ export function OnboardingForm({ countries, currencies, timezones }: Props) {
                 errors.taxId ? "taxId-error" : "taxId-hint"
               }
               {...register("taxId")}
+            />
+          </Field>
+        </div>
+
+        {/* ── Promo code (#620) ─────────────────────────────── */}
+        <div className="border-t border-border-subtle pt-5">
+          <Field
+            id="promoCode"
+            label={signupCopy.promoLabel}
+            hint={promoChecking ? signupCopy.promoChecking : promoStatus?.text}
+            hintState={
+              promoStatus?.tone === "accepted"
+                ? "success"
+                : promoStatus?.tone === "refused"
+                  ? "error"
+                  : // "unknown" stays neutral on purpose: we could not check,
+                    // which is not the merchant's problem and not a refusal.
+                    "default"
+            }
+          >
+            <Input
+              id="promoCode"
+              type="text"
+              placeholder={signupCopy.promoPlaceholder}
+              autoComplete="off"
+              autoCapitalize="characters"
+              spellCheck={false}
+              aria-describedby="promoCode-hint"
+              {...register("promoCode")}
             />
           </Field>
         </div>

--- a/apps/onboarding/lib/api/platform-api.ts
+++ b/apps/onboarding/lib/api/platform-api.ts
@@ -90,6 +90,23 @@ export const onboarding = {
       },
     ),
 
+  /** Asks what a promo code would grant, WITHOUT redeeming it (#620).
+   *
+   *  Goes through platform-api rather than straight to marketplace-api:
+   *  marketplace-api's validate route is guarded by the shared internal
+   *  secret, which platform-api holds and this app does not. That is the
+   *  point — #620 calls an open validate endpoint "an oracle for guessing
+   *  valid codes", and routing it this way means no such endpoint exists. */
+  validatePromo: (code: string, email: string, currency: string) =>
+    request<{
+      valid: boolean;
+      trial_extension_days: number;
+      reject_reason: string;
+    }>("/api/v1/onboarding/promo/validate", {
+      method: "POST",
+      body: JSON.stringify({ code, email, currency }),
+    }),
+
   verifyCode: (sessionId: string, code: string) =>
     request<{ verified: boolean }>(
       `/api/v1/onboarding/sessions/${sessionId}/verification/verify`,
@@ -115,6 +132,11 @@ export const onboarding = {
       password?: string;
       first_name?: string;
       last_name?: string;
+      /** What the merchant typed in the promo field, if anything (#620).
+       *  Redeemed by marketplace-api immediately after it creates the
+       *  subscription row — the earliest moment redemption is possible,
+       *  since the ledger row needs a subscription id. */
+      promo_code?: string;
     },
   ) =>
     request<CompleteResult>(

--- a/apps/onboarding/lib/copy/signup.ts
+++ b/apps/onboarding/lib/copy/signup.ts
@@ -7,6 +7,39 @@
 export const signupCopy = {
   taxIdLabel: "Tax ID (optional)",
 
+  // ─── Promo code (#620) ──────────────────────────────────────────────
+  //
+  // The field is optional and stays quiet until it has something true to
+  // say. Every message below states only what the server actually
+  // returned: the number of days comes from the promo definition, never
+  // from copy, so a code's terms can change in the console without a
+  // deploy here.
+  promoLabel: "Promo code (optional)",
+  promoPlaceholder: "If you have one",
+  promoChecking: "Checking\u2026",
+  /** The offer, stated in the code's own numbers. */
+  promoAccepted: (days: number) =>
+    days === 1
+      ? "Adds a day to your free trial."
+      : `Adds ${days} days to your free trial.`,
+  /** Accepted, but grants nothing we can describe — say nothing rather
+   *  than invent a benefit. The code is still carried and still redeemed. */
+  promoAcceptedNoTerms: "That code is valid.",
+  promoInvalid:
+    "We don\u2019t recognise that code, or it has passed its end date. You can carry on without it.",
+  /** The code works, just not here. Saying "invalid" would send a merchant
+   *  holding a good code away from the page that would have taken it. */
+  promoRedeemInBilling:
+    "That code applies to a paid plan. Finish signing up and redeem it in Billing.",
+  promoMaxRedemptions:
+    "That offer has been fully claimed. Your code was genuine \u2014 it has simply run out.",
+  promoAlreadyUsed:
+    "That code has already been used with this email address.",
+  /** We could not ASK. Never rendered as "invalid": a merchant holding a
+   *  good code must not be told it is bad because a service was down. */
+  promoCheckFailed:
+    "We couldn\u2019t check that code just now. You can carry on \u2014 we\u2019ll try again when you finish.",
+
   // Country-aware help text shown below the tax ID field.
   // Keyed by ISO 3166-1 alpha-2 country code.
   taxIdHelpByCountry: {

--- a/apps/onboarding/lib/promo/message.ts
+++ b/apps/onboarding/lib/promo/message.ts
@@ -1,0 +1,66 @@
+/**
+ * What the promo field says, for every answer the server can give (#620).
+ *
+ * Its own module, and pure, so the sentences can be tested without rendering
+ * anything. The sentences ARE the feature here: a merchant holding a working
+ * code who is told it is invalid abandons a code that would have worked, and
+ * that failure is invisible to any test that only checks the happy path.
+ *
+ * The rule every branch follows: state only what the server actually returned.
+ * The number of days comes from the promo definition, so a code's terms can
+ * change in the console without a deploy here.
+ */
+import { signupCopy } from "../copy/signup";
+
+/** The server's answer to "what would this code grant?" */
+export interface PromoCheck {
+  valid: boolean;
+  trial_extension_days: number;
+  reject_reason: string;
+}
+
+/** What the field should show, and whether it reads as good news. */
+export interface PromoMessage {
+  text: string;
+  tone: "accepted" | "refused" | "unknown";
+}
+
+/**
+ * The message for `check`.
+ *
+ * `unknown` is deliberately distinct from `refused`: it means we could not
+ * ASK, and it must never render as "invalid". A merchant holding a good code
+ * being told it is bad because a service was down is the one outcome here that
+ * costs a signup, and it is also the one that would never be noticed.
+ */
+export function promoMessage(check: PromoCheck | null): PromoMessage | null {
+  if (check === null) {
+    return { text: signupCopy.promoCheckFailed, tone: "unknown" };
+  }
+
+  if (check.valid) {
+    return {
+      text:
+        check.trial_extension_days > 0
+          ? signupCopy.promoAccepted(check.trial_extension_days)
+          : // Accepted but grants nothing we can describe. Saying so beats
+            // inventing a benefit the response does not contain.
+            signupCopy.promoAcceptedNoTerms,
+      tone: "accepted",
+    };
+  }
+
+  switch (check.reject_reason) {
+    case "redeem_in_billing":
+      return { text: signupCopy.promoRedeemInBilling, tone: "refused" };
+    case "max_redemptions_reached":
+      return { text: signupCopy.promoMaxRedemptions, tone: "refused" };
+    case "max_per_email_reached":
+      return { text: signupCopy.promoAlreadyUsed, tone: "refused" };
+    default:
+      // Everything else — including invalid_or_expired, which deliberately
+      // merges "no such code" with "expired" so the field cannot be used to
+      // confirm which codes are real.
+      return { text: signupCopy.promoInvalid, tone: "refused" };
+  }
+}

--- a/apps/onboarding/lib/promo/rateLimit.ts
+++ b/apps/onboarding/lib/promo/rateLimit.ts
@@ -1,0 +1,50 @@
+/**
+ * Per-visitor cap on promo-code checks (#620).
+ *
+ * # Why this exists HERE and not only in the API
+ *
+ * The field calls a server action, so by the time the request reaches
+ * platform-api the client IP is this app's pod — every visitor shares one
+ * bucket there. platform-api's limiter is therefore a coarse service-wide cap,
+ * and this is the layer that can actually see a visitor.
+ *
+ * Two layers, each doing what only it can: this one bounds a single visitor,
+ * that one bounds the blast radius if this one is bypassed.
+ *
+ * In-memory and per-pod, like every other limiter in this estate. A visitor
+ * spread across pods gets a multiple of the cap; that is acceptable for a
+ * guessing surface whose codes are already capped per email address on
+ * redemption.
+ */
+
+/** Window and cap. Loose enough to retype a code several times, tight enough
+ *  that enumeration is pointless. */
+export const PROMO_WINDOW_MS = 10 * 60 * 1000;
+export const PROMO_MAX_ATTEMPTS = 12;
+
+const attempts = new Map<string, number[]>();
+
+/**
+ * Records an attempt for `key` and reports whether it is within the cap.
+ *
+ * `now` is a parameter so the window can be tested without sleeping.
+ */
+export function allowPromoCheck(key: string, now: number = Date.now()): boolean {
+  const cutoff = now - PROMO_WINDOW_MS;
+  const fresh = (attempts.get(key) ?? []).filter((t) => t > cutoff);
+
+  if (fresh.length >= PROMO_MAX_ATTEMPTS) {
+    // Write the pruned list back even on refusal, so a key that stops being
+    // used stops holding its timestamps.
+    attempts.set(key, fresh);
+    return false;
+  }
+  fresh.push(now);
+  attempts.set(key, fresh);
+  return true;
+}
+
+/** Clears all buckets. Tests only — nothing in the app calls it. */
+export function resetPromoRateLimit(): void {
+  attempts.clear();
+}

--- a/apps/onboarding/lib/types/index.ts
+++ b/apps/onboarding/lib/types/index.ts
@@ -46,6 +46,10 @@ export interface OnboardingDraft {
   timezone?: string;
   // §5.1.1 — optional tax-ID and migration fast-path evidence
   tax_id?: string;
+  // #620 — the promo code typed on the form. Held in the draft rather than
+  // redeemed at typing time because redemption needs a subscription row, and
+  // that row is not created until onboarding completes (#827).
+  promo_code?: string;
   migration_type?: MigrationEvidenceType;
   // Only present when migration_type === "migrating"
   whois_url?: string;

--- a/apps/onboarding/tests/unit/promo-code-field.spec.ts
+++ b/apps/onboarding/tests/unit/promo-code-field.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test } from "@playwright/test";
+
+import { promoMessage } from "../../lib/promo/message";
+import {
+  allowPromoCheck,
+  resetPromoRateLimit,
+  PROMO_MAX_ATTEMPTS,
+  PROMO_WINDOW_MS,
+} from "../../lib/promo/rateLimit";
+
+/**
+ * The onboarding promo field (#620).
+ *
+ * These cover the two pieces with a merchant-visible consequence that no
+ * rendering test would catch: which sentence each server answer produces, and
+ * the per-visitor cap on a surface that is, by nature, a guessing target.
+ */
+
+test.describe("promoMessage", () => {
+  test("states the offer in the code's own numbers", () => {
+    const msg = promoMessage({
+      valid: true,
+      trial_extension_days: 30,
+      reject_reason: "",
+    });
+    expect(msg?.tone).toBe("accepted");
+    expect(msg?.text).toContain("30 days");
+  });
+
+  test("says a day, not 1 days", () => {
+    const msg = promoMessage({
+      valid: true,
+      trial_extension_days: 1,
+      reject_reason: "",
+    });
+    expect(msg?.text).toContain("a day");
+    expect(msg?.text).not.toContain("1 days");
+  });
+
+  test("claims no benefit when the response describes none", () => {
+    const msg = promoMessage({
+      valid: true,
+      trial_extension_days: 0,
+      reject_reason: "",
+    });
+    expect(msg?.tone).toBe("accepted");
+    expect(msg?.text).not.toMatch(/\d/);
+  });
+
+  // The failure that costs a signup: a merchant holding a code that works is
+  // told it does not, and goes away instead of finishing in Billing.
+  test("redeem_in_billing never says the code is invalid", () => {
+    const msg = promoMessage({
+      valid: false,
+      trial_extension_days: 0,
+      reject_reason: "redeem_in_billing",
+    });
+    expect(msg?.text.toLowerCase()).not.toContain("recognise");
+    expect(msg?.text.toLowerCase()).toContain("billing");
+  });
+
+  test("renders a distinct sentence for every refusal it knows", () => {
+    const reasons = [
+      "invalid_or_expired",
+      "redeem_in_billing",
+      "max_redemptions_reached",
+      "max_per_email_reached",
+    ];
+    const seen = new Set<string>();
+    for (const reject_reason of reasons) {
+      const msg = promoMessage({
+        valid: false,
+        trial_extension_days: 0,
+        reject_reason,
+      });
+      expect(msg, reject_reason).not.toBeNull();
+      expect(seen.has(msg!.text), `${reject_reason} repeats another sentence`).toBe(false);
+      seen.add(msg!.text);
+    }
+  });
+
+  // A reason this build has never heard of must fall back to the safest
+  // sentence rather than crash or say nothing.
+  test("an unrecognised reason falls back rather than failing", () => {
+    const msg = promoMessage({
+      valid: false,
+      trial_extension_days: 0,
+      reject_reason: "some_reason_added_after_this_build",
+    });
+    expect(msg?.tone).toBe("refused");
+    expect(msg?.text.length).toBeGreaterThan(0);
+  });
+
+  // "We could not ask" is NOT "your code is bad". Distinct tone and distinct
+  // sentence, because the merchant should keep going, not retype.
+  test("an unreachable check is not reported as an invalid code", () => {
+    const msg = promoMessage(null);
+    expect(msg?.tone).toBe("unknown");
+    const invalid = promoMessage({
+      valid: false,
+      trial_extension_days: 0,
+      reject_reason: "invalid_or_expired",
+    });
+    expect(msg?.text).not.toBe(invalid?.text);
+  });
+});
+
+test.describe("allowPromoCheck", () => {
+  test.beforeEach(() => resetPromoRateLimit());
+
+  test("allows up to the cap, then refuses", () => {
+    for (let i = 0; i < PROMO_MAX_ATTEMPTS; i++) {
+      expect(allowPromoCheck("1.2.3.4"), `attempt ${i + 1}`).toBe(true);
+    }
+    expect(allowPromoCheck("1.2.3.4")).toBe(false);
+  });
+
+  // Buckets share one map. A keying mistake would show up only under real
+  // traffic, as "promo codes stopped working for everyone".
+  test("one visitor cannot exhaust another's budget", () => {
+    for (let i = 0; i < PROMO_MAX_ATTEMPTS; i++) allowPromoCheck("1.2.3.4");
+    expect(allowPromoCheck("5.6.7.8")).toBe(true);
+  });
+
+  test("the window expires", () => {
+    const t0 = 1_000_000;
+    for (let i = 0; i < PROMO_MAX_ATTEMPTS; i++) allowPromoCheck("1.2.3.4", t0);
+    expect(allowPromoCheck("1.2.3.4", t0)).toBe(false);
+    expect(allowPromoCheck("1.2.3.4", t0 + PROMO_WINDOW_MS + 1)).toBe(true);
+  });
+});

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -2596,6 +2596,11 @@ func main() {
 			subscription.NewService(subscription.ServiceConfig{
 				DB: conn, Repo: subscription.NewRepository(), Logger: log,
 			})).
+			// Promo redemption at signup (#620). Its promo.Service DOES need
+			// the trial extender — a code that grants days and cannot deliver
+			// them is refused, not silently ignored (#825).
+			WithPromo(signupPromoAdapter{svc: promo.NewService(conn, promo.NewRepository(), nil, log).
+				WithTrialExtender(trial.NewExtender(promoTrialStripe(billingStripeClient)))}).
 			RegisterRoutes(r.Group("/internal"), cfg.InternalAuthSecret)
 		// Otto escalation hook — slm-router POSTs
 		// /internal/v1/tickets/from-conversation when an AI chat is
@@ -2770,6 +2775,9 @@ func main() {
 				subscription.NewService(subscription.ServiceConfig{
 					DB: conn, Repo: subscription.NewRepository(), Logger: log,
 				})).
+				// See the mode-Both mount above.
+				WithPromo(signupPromoAdapter{svc: promo.NewService(conn, promo.NewRepository(), nil, log).
+					WithTrialExtender(trial.NewExtender(promoTrialStripe(billingStripeClient)))}).
 				RegisterRoutes(engine.Group("/internal"), cfg.InternalAuthSecret)
 			// slm-router escalation hook + the mark8ly-mcp
 			// create_support_ticket tool both POST /internal/v1/tickets/

--- a/services/marketplace-api/cmd/marketplace-api/wiring_signup_promo.go
+++ b/services/marketplace-api/cmd/marketplace-api/wiring_signup_promo.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+
+	"github.com/mark8ly/marketplace-api/internal/promo"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// signupPromoAdapter joins internal/promo to internal/subscription's
+// SignupPromoRedeemer.
+//
+// It exists because the dependency can only point one way: internal/promo
+// already imports internal/subscription for its plan and status constants, so
+// subscription cannot import promo back. main.go imports both, which makes it
+// the only place the two shapes can meet.
+//
+// The adapter is also where the INTERNAL reject reason becomes the PUBLIC one.
+// That conversion has to happen exactly once, at the boundary the value
+// crosses on its way to platform-api and then to a merchant — promo's own
+// reasons distinguish not_found from expired, and PublicReasonFor merges them
+// so a caller cannot tell a real code from a guessed one (#620).
+type signupPromoAdapter struct{ svc *promo.Service }
+
+func (a signupPromoAdapter) RedeemAtSignup(ctx context.Context,
+	in subscription.SignupPromoInput) (subscription.SignupPromoOffer, error) {
+	offer, err := a.svc.RedeemAtSignup(ctx, promo.SignupInput{
+		Code:          in.Code,
+		MerchantEmail: in.MerchantEmail,
+		Currency:      in.Currency,
+		Sub:           in.Sub,
+	})
+	return out(offer), err
+}
+
+func (a signupPromoAdapter) ValidateForSignup(ctx context.Context,
+	in subscription.SignupPromoInput) (subscription.SignupPromoOffer, error) {
+	offer, err := a.svc.ValidateForSignup(ctx, promo.SignupInput{
+		Code:          in.Code,
+		MerchantEmail: in.MerchantEmail,
+		Currency:      in.Currency,
+		Sub:           in.Sub,
+	})
+	return out(offer), err
+}
+
+// out converts a promo offer for the wire, collapsing the reject reason to the
+// public set. An empty internal reason stays empty rather than becoming
+// PublicReasonFor's default — "" means "not a validation failure at all", and
+// mapping it to invalid_or_expired would report a refusal on a success.
+func out(offer promo.SignupOffer) subscription.SignupPromoOffer {
+	reason := ""
+	if offer.RejectReason != "" {
+		reason = string(promo.PublicReasonFor(offer.RejectReason))
+	}
+	return subscription.SignupPromoOffer{
+		TrialExtensionDays: offer.TrialExtensionDays,
+		RejectReason:       reason,
+	}
+}

--- a/services/marketplace-api/internal/promo/public_reason.go
+++ b/services/marketplace-api/internal/promo/public_reason.go
@@ -45,6 +45,12 @@ const (
 	// confirms nothing about a code they were not already holding. It is
 	// also the one refusal a merchant can act on, by asking an operator.
 	PublicReasonTrialNotExtendable PublicRejectReason = "trial_not_extendable"
+
+	// PublicReasonRedeemInBilling must reach the merchant: it is the one
+	// refusal that means "your code works, just not here". Collapsing it into
+	// invalid_or_expired would send someone holding a good code away from the
+	// field that would have taken it.
+	PublicReasonRedeemInBilling PublicRejectReason = "redeem_in_billing"
 )
 
 // PublicReasonFor maps an internal reason onto the one the client is told.
@@ -75,6 +81,8 @@ func PublicReasonFor(r ValidationRejectReason) PublicRejectReason {
 		return PublicReasonUnknownDiscount
 	case RejectReasonTrialNotExtendable:
 		return PublicReasonTrialNotExtendable
+	case RejectReasonRedeemInBilling:
+		return PublicReasonRedeemInBilling
 	default:
 		return PublicReasonInvalidOrExpired
 	}

--- a/services/marketplace-api/internal/promo/signup.go
+++ b/services/marketplace-api/internal/promo/signup.go
@@ -1,0 +1,164 @@
+package promo
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// signup.go — redeeming a promo code at onboarding (#620).
+//
+// The merchant types a code before they have a plan, a price or a card. That
+// makes signup a NARROWER surface than the billing page, not merely an earlier
+// one, and the narrowing is what this file exists to state.
+
+// SignupInput asks about, or redeems, a code for a merchant who has just
+// signed up.
+//
+// No plan, period or base price: at signup the plan is always trial, which has
+// no Stripe Price and no floor entry, so those are derived here rather than
+// asked of a caller that could get them wrong.
+type SignupInput struct {
+	// Code is what the merchant typed. Empty is normal and means "no code".
+	Code string
+	// MerchantEmail is the address the per-email cap counts against. It is
+	// the one abuse control available at signup, and it is available because
+	// onboarding has already verified the address.
+	MerchantEmail string
+	// Currency is the store's ISO 4217 billing currency.
+	Currency string
+	// Sub is the subscription row to extend. Nil for validation, required for
+	// redemption — RedeemAtSignup fails closed without it.
+	Sub *subscription.StoreSubscription
+}
+
+// SignupOffer is what a code grants a merchant at signup.
+type SignupOffer struct {
+	// TrialExtensionDays is the number of days added to the trial, or 0 when
+	// no code was supplied or none was granted.
+	TrialExtensionDays int
+	// RejectReason is empty on success. It is the INTERNAL reason; run it
+	// through PublicReasonFor before it leaves the server.
+	RejectReason ValidationRejectReason
+}
+
+// applyInput builds the ApplyInput a signup redemption uses.
+//
+// Plan is trial and Period is monthly because that is what a store_subscriptions
+// row looks like the moment onboarding creates it (#827): plan=trial,
+// status=signup, no period chosen. BasePriceMinor is 0 for the same reason —
+// trial has no catalog price — and CheckFloor passes for a plan with no floor
+// entry, so a zero here is not a discount that undercuts anything.
+func (in SignupInput) applyInput() ApplyInput {
+	out := ApplyInput{
+		Code:           strings.TrimSpace(in.Code),
+		MerchantEmail:  in.MerchantEmail,
+		Plan:           subscription.PlanTrial,
+		Period:         subscription.PeriodMonthly,
+		BasePriceMinor: 0,
+		Currency:       strings.ToLower(strings.TrimSpace(in.Currency)),
+		Actor:          "system:onboarding",
+		Sub:            in.Sub,
+	}
+	if in.Sub != nil {
+		out.TenantID = in.Sub.TenantID
+		out.StoreID = in.Sub.StoreID
+		out.SubscriptionID = in.Sub.ID
+		return out
+	}
+
+	// No subscription yet — this is the validating caller, asking before the
+	// row exists. Answer against the row onboarding is ABOUT to create (#827):
+	// plan=trial, status=signup, created now, never extended.
+	//
+	// Not a fudge to satisfy a nil check. "Would this code work?" asked at
+	// signup means "would it work against the subscription I am about to
+	// get", and that row's shape is known exactly. Passing nil instead would
+	// fail closed as a caller bug, and inventing a different shape here would
+	// let validate and redeem answer differently.
+	out.Sub = &subscription.StoreSubscription{
+		Plan:      subscription.PlanTrial,
+		Status:    subscription.StatusSignup,
+		CreatedAt: time.Now().UTC(),
+	}
+	return out
+}
+
+// deliverableAtSignup reports whether the WHOLE of a code's benefit can be
+// delivered to a merchant who has just signed up.
+//
+// A discount cannot be. There is no Stripe subscription yet for a coupon to
+// attach to, so ApplyPromo would log "no subscription id — skipping Stripe
+// coupon attach", write the ledger row, and report success: the merchant's one
+// redemption spent on the half we could not honour, with nothing to show for
+// it and no way to claim it later.
+//
+// So a code carrying any discount is refused here and pointed at the billing
+// page, where it works. Refusing is the conservative direction: the merchant
+// still holds a usable code.
+//
+// ONE definition, called by both ValidateForSignup and RedeemAtSignup. If the
+// two could disagree, the onboarding field would accept a code that signup
+// then silently ate — which is the exact failure this rule prevents.
+func deliverableAtSignup(pc *PromoCode) bool {
+	return pc.DiscountType == nil && pc.DiscountValue == nil
+}
+
+// ValidateForSignup answers "would this code be accepted at signup, and what
+// would it grant", and records NOTHING — no redemption row, no Stripe call.
+//
+// It is what the onboarding field calls as the merchant types, so the offer
+// can be shown before they commit. Spending the code here would be fatal:
+// max_per_email is 1, so a redemption written at typing time is a code the
+// merchant can never actually use.
+func (s *Service) ValidateForSignup(ctx context.Context, in SignupInput) (SignupOffer, error) {
+	code := strings.TrimSpace(in.Code)
+	if code == "" {
+		return SignupOffer{}, nil
+	}
+
+	pc, err := s.repo.GetByCode(ctx, s.db, code)
+	if err != nil {
+		return SignupOffer{RejectReason: RejectReasonNotFound}, ErrInvalidOrExpired
+	}
+	if !deliverableAtSignup(pc) {
+		return SignupOffer{RejectReason: RejectReasonRedeemInBilling}, ErrInvalidOrExpired
+	}
+
+	out, err := s.ValidateCode(ctx, in.applyInput())
+	if err != nil {
+		return SignupOffer{RejectReason: out.RejectReason}, err
+	}
+	return SignupOffer{TrialExtensionDays: out.TrialExtensionDays}, nil
+}
+
+// RedeemAtSignup redeems a code against a subscription that has just been
+// created, and returns what it granted.
+//
+// An empty code is a no-op returning the zero offer, because most merchants
+// type nothing and that is not a failure. Called from the onboarding
+// subscription callback, immediately after the row exists — which is the
+// earliest moment redemption is possible at all, since the ledger row needs a
+// subscription id and trial.Extend needs a row to move.
+func (s *Service) RedeemAtSignup(ctx context.Context, in SignupInput) (SignupOffer, error) {
+	code := strings.TrimSpace(in.Code)
+	if code == "" {
+		return SignupOffer{}, nil
+	}
+
+	pc, err := s.repo.GetByCode(ctx, s.db, code)
+	if err != nil {
+		return SignupOffer{RejectReason: RejectReasonNotFound}, ErrInvalidOrExpired
+	}
+	if !deliverableAtSignup(pc) {
+		return SignupOffer{RejectReason: RejectReasonRedeemInBilling}, ErrInvalidOrExpired
+	}
+
+	out, err := s.ApplyPromo(ctx, in.applyInput())
+	if err != nil {
+		return SignupOffer{RejectReason: out.RejectReason}, err
+	}
+	return SignupOffer{TrialExtensionDays: out.TrialExtensionDays}, nil
+}

--- a/services/marketplace-api/internal/promo/signup_test.go
+++ b/services/marketplace-api/internal/promo/signup_test.go
@@ -1,0 +1,187 @@
+package promo_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/promo"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+func signupInput() promo.SignupInput {
+	return promo.SignupInput{
+		Code:          "STAYLONGER",
+		MerchantEmail: "founder@example.com",
+		Currency:      "aud",
+	}
+}
+
+// The whole point of the onboarding field (#620): tell the merchant what the
+// code grants BEFORE they commit, without spending it.
+func TestValidateForSignup_ReportsTheDaysAndRecordsNothing(t *testing.T) {
+	repo := &trialRepo{code: extensionRow(30)}
+	ext := &stubExtender{}
+	svc := promo.NewService(nil, repo, nil, nil).WithTrialExtender(ext)
+
+	offer, err := svc.ValidateForSignup(context.Background(), signupInput())
+	if err != nil {
+		t.Fatalf("ValidateForSignup: %v", err)
+	}
+	if offer.TrialExtensionDays != 30 {
+		t.Errorf("TrialExtensionDays = %d, want 30", offer.TrialExtensionDays)
+	}
+	// Both halves of "records nothing". max_per_email is 1, so a redemption
+	// written while the merchant is still typing is a code they can never use.
+	if len(repo.created) != 0 {
+		t.Fatal("validating a code at signup consumed it")
+	}
+	if len(ext.calls) != 0 {
+		t.Fatal("validating a code extended a trial that does not exist yet")
+	}
+}
+
+// A code carrying a discount cannot be delivered at signup: there is no
+// subscription for Stripe to attach a coupon to, and redeeming would write the
+// ledger row anyway — spending the merchant's one redemption on the half we
+// cannot honour. Refuse it, and say where it DOES work.
+func TestValidateForSignup_RefusesACodeCarryingADiscount(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		row  *promo.PromoCode
+	}{
+		{"discount only", winBackRow()},
+		{"discount AND trial days", func() *promo.PromoCode {
+			r := winBackRow()
+			days := 14
+			r.TrialExtensionDays = &days
+			return r
+		}()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &trialRepo{code: tc.row}
+			svc := promo.NewService(nil, repo, nil, nil).WithTrialExtender(&stubExtender{})
+
+			in := signupInput()
+			in.Code = tc.row.Code
+			offer, err := svc.ValidateForSignup(context.Background(), in)
+			if !errors.Is(err, promo.ErrInvalidOrExpired) {
+				t.Fatalf("err = %v, want ErrInvalidOrExpired", err)
+			}
+			if offer.RejectReason != promo.RejectReasonRedeemInBilling {
+				t.Errorf("reject reason = %q, want redeem_in_billing", offer.RejectReason)
+			}
+			if len(repo.created) != 0 {
+				t.Error("a refused code still wrote a redemption row")
+			}
+		})
+	}
+}
+
+// The public reason has to reach the merchant: "invalid or expired" would send
+// someone holding a working code away from the field that would have taken it.
+func TestPublicReasonFor_RedeemInBillingIsDisclosed(t *testing.T) {
+	if got := promo.PublicReasonFor(promo.RejectReasonRedeemInBilling); got != promo.PublicReasonRedeemInBilling {
+		t.Errorf("PublicReasonFor(redeem_in_billing) = %q", got)
+	}
+}
+
+// Ordinary validation still applies — the per-email cap in particular, which is
+// the one check that can be made at signup because the address is known.
+func TestValidateForSignup_AppliesThePerEmailCap(t *testing.T) {
+	repo := &trialRepo{code: extensionRow(14)}
+	repo.perEmail = 1
+	svc := promo.NewService(nil, repo, nil, nil).WithTrialExtender(&stubExtender{})
+
+	offer, err := svc.ValidateForSignup(context.Background(), signupInput())
+	if !errors.Is(err, promo.ErrInvalidOrExpired) {
+		t.Fatalf("err = %v, want ErrInvalidOrExpired", err)
+	}
+	if offer.RejectReason != promo.RejectReasonMaxPerEmail {
+		t.Errorf("reject reason = %q, want max_per_email_reached", offer.RejectReason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RedeemAtSignup
+// ---------------------------------------------------------------------------
+
+func TestRedeemAtSignup_ExtendsTheBrandNewTrial(t *testing.T) {
+	repo := &trialRepo{code: extensionRow(14)}
+	ext := &stubExtender{}
+	svc := promo.NewService(nil, repo, nil, nil).WithTrialExtender(ext)
+
+	// A subscription created moments ago: no stored end, so the effective end
+	// is created_at + TrialDays. This is the shape #827 now produces.
+	sub := &subscription.StoreSubscription{
+		ID: uuid.New(), StoreID: uuid.New(), TenantID: uuid.New(),
+		Status: subscription.StatusSignup, Plan: subscription.PlanTrial,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	in := signupInput()
+	in.Sub = sub
+	offer, err := svc.RedeemAtSignup(context.Background(), in)
+	if err != nil {
+		t.Fatalf("RedeemAtSignup: %v", err)
+	}
+	if offer.TrialExtensionDays != 14 {
+		t.Errorf("TrialExtensionDays = %d, want 14", offer.TrialExtensionDays)
+	}
+	if len(ext.calls) != 1 {
+		t.Fatalf("extender called %d times, want 1", len(ext.calls))
+	}
+	if len(repo.created) != 1 {
+		t.Errorf("wrote %d ledger rows, want 1", len(repo.created))
+	}
+}
+
+// The same refusal as validate, at the moment it actually matters. If these
+// two disagreed, the field would accept a code that signup then silently ate.
+func TestRedeemAtSignup_RefusesACodeCarryingADiscount(t *testing.T) {
+	repo := &trialRepo{code: winBackRow()}
+	ext := &stubExtender{}
+	svc := promo.NewService(nil, repo, nil, nil).WithTrialExtender(ext)
+
+	sub := &subscription.StoreSubscription{
+		ID: uuid.New(), StoreID: uuid.New(), TenantID: uuid.New(),
+		Status: subscription.StatusSignup, Plan: subscription.PlanTrial,
+		CreatedAt: time.Now().UTC(),
+	}
+	in := signupInput()
+	in.Code = winBackRow().Code
+	in.Sub = sub
+
+	if _, err := svc.RedeemAtSignup(context.Background(), in); !errors.Is(err, promo.ErrInvalidOrExpired) {
+		t.Fatalf("err = %v, want ErrInvalidOrExpired", err)
+	}
+	if len(repo.created) != 0 {
+		t.Fatal("burned the merchant's redemption on a code signup cannot honour")
+	}
+	if len(ext.calls) != 0 {
+		t.Error("extended a trial for a code that was refused")
+	}
+}
+
+// An empty code is not a failure — most merchants type nothing. It must not
+// look up a row, and must not read as a rejected code.
+func TestRedeemAtSignup_AnEmptyCodeIsANoOp(t *testing.T) {
+	repo := &trialRepo{code: extensionRow(14)}
+	svc := promo.NewService(nil, repo, nil, nil).WithTrialExtender(&stubExtender{})
+
+	in := signupInput()
+	in.Code = "   "
+	offer, err := svc.RedeemAtSignup(context.Background(), in)
+	if err != nil {
+		t.Fatalf("RedeemAtSignup: %v", err)
+	}
+	if offer.TrialExtensionDays != 0 || offer.RejectReason != "" {
+		t.Errorf("offer = %+v, want the zero offer", offer)
+	}
+	if len(repo.created) != 0 {
+		t.Error("an empty code wrote a redemption row")
+	}
+}

--- a/services/marketplace-api/internal/promo/trial_extension_test.go
+++ b/services/marketplace-api/internal/promo/trial_extension_test.go
@@ -45,6 +45,7 @@ func (e *stubExtender) Extend(_ context.Context, _ *gorm.DB, storeID uuid.UUID,
 // back — the difference between "try again" and "your code is spent".
 type trialRepo struct {
 	code           *promo.PromoCode
+	perEmail       int
 	created        []promo.Redemption
 	deletes        int
 	createErr      error
@@ -62,7 +63,7 @@ func (r *trialRepo) CountRedemptions(context.Context, *gorm.DB, uuid.UUID) (int,
 	return 0, nil
 }
 func (r *trialRepo) CountRedemptionsByEmail(context.Context, *gorm.DB, uuid.UUID, string) (int, error) {
-	return 0, nil
+	return r.perEmail, nil
 }
 func (r *trialRepo) GetRedemptionByStore(context.Context, *gorm.DB, uuid.UUID, uuid.UUID) (*promo.Redemption, error) {
 	if r.alreadyRedeems {

--- a/services/marketplace-api/internal/promo/validator.go
+++ b/services/marketplace-api/internal/promo/validator.go
@@ -64,6 +64,11 @@ const (
 	// rather than about the code, and Validate is given no subscription.
 	// Service.planTrialExtension sets it.
 	RejectReasonTrialNotExtendable ValidationRejectReason = "trial_not_extendable"
+	// RejectReasonRedeemInBilling covers a code whose benefit cannot be
+	// delivered at signup — one carrying a discount, which needs a Stripe
+	// subscription that does not exist yet (#620). The code is fine; only
+	// the moment is wrong. Set by the signup path, never by Validate.
+	RejectReasonRedeemInBilling ValidationRejectReason = "redeem_in_billing"
 )
 
 // ValidationResult is returned by Validate. On success Accepted is true and

--- a/services/marketplace-api/internal/subscription/internal_handler.go
+++ b/services/marketplace-api/internal/subscription/internal_handler.go
@@ -18,6 +18,7 @@ package subscription
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -31,14 +32,54 @@ type Bootstrapper interface {
 	Bootstrap(ctx context.Context, in BootstrapInput) (*StoreSubscription, error)
 }
 
+// SignupPromoRedeemer redeems a promo code against a subscription that has
+// just been created. *promo.Service satisfies it through a small adapter.
+//
+// An interface rather than the concrete type because internal/promo already
+// imports this package for its plan and status constants; depending on it back
+// would be an import cycle.
+type SignupPromoRedeemer interface {
+	RedeemAtSignup(ctx context.Context, in SignupPromoInput) (SignupPromoOffer, error)
+	// ValidateForSignup answers the same question without spending the code,
+	// for the onboarding field to call as the merchant types.
+	ValidateForSignup(ctx context.Context, in SignupPromoInput) (SignupPromoOffer, error)
+}
+
+// SignupPromoInput and SignupPromoOffer mirror promo.SignupInput /
+// promo.SignupOffer across that same boundary. The adapter that converts
+// between them lives in main.go, which imports both.
+type SignupPromoInput struct {
+	Code          string
+	MerchantEmail string
+	Currency      string
+	Sub           *StoreSubscription
+}
+
+// SignupPromoOffer is what the code granted. RejectReason is already the
+// PUBLIC reason — the adapter runs promo.PublicReasonFor — because this value
+// crosses to platform-api and on to a merchant.
+type SignupPromoOffer struct {
+	TrialExtensionDays int
+	RejectReason       string
+}
+
 // InternalHandler serves the platform-api subscription callback.
 type InternalHandler struct {
-	svc Bootstrapper
+	svc   Bootstrapper
+	promo SignupPromoRedeemer
 }
 
 // NewInternalHandler constructs an InternalHandler.
 func NewInternalHandler(svc Bootstrapper) *InternalHandler {
 	return &InternalHandler{svc: svc}
+}
+
+// WithPromo wires promo redemption at signup (#620). Nil-safe: without it a
+// code sent by the caller is REFUSED rather than ignored, so a merchant is
+// never told their code applied when nothing could have applied it.
+func (h *InternalHandler) WithPromo(p SignupPromoRedeemer) *InternalHandler {
+	h.promo = p
+	return h
 }
 
 // RegisterRoutes mounts the callback behind the shared internal secret.
@@ -51,6 +92,60 @@ func NewInternalHandler(svc Bootstrapper) *InternalHandler {
 func (h *InternalHandler) RegisterRoutes(g *gin.RouterGroup, internalSecret string) {
 	g.POST("/stores/:storeID/ensure-subscription",
 		auth.InternalSecretAuth(internalSecret), h.ensureSubscription)
+	// Promo validation for the onboarding field (#620). Deliberately on
+	// /internal rather than the public group: #620 calls an open validate
+	// endpoint "an oracle for guessing valid codes", and platform-api — which
+	// owns the onboarding session and already holds this secret — is the only
+	// caller that needs it. Keeping it internal removes the oracle instead of
+	// rate-limiting one into existence.
+	g.POST("/promo/validate-for-signup",
+		auth.InternalSecretAuth(internalSecret), h.validatePromoForSignup)
+}
+
+type validatePromoRequest struct {
+	Code string `json:"code" binding:"required"`
+	// Email is the address the per-email cap counts against — the one abuse
+	// control available at signup, and available because onboarding has
+	// already verified the address.
+	Email    string `json:"email"`
+	Currency string `json:"currency"`
+}
+
+// validatePromoForSignup reports what a code would grant a merchant who is
+// signing up, and records nothing.
+//
+// The response deliberately carries only the days and a reason. No code
+// echo, no terms, no indication of whether an unknown code exists: the
+// reject reason is already collapsed by promo.PublicReasonFor, which merges
+// not_found and expired precisely so a caller cannot tell a real code from a
+// guessed one.
+func (h *InternalHandler) validatePromoForSignup(c *gin.Context) {
+	var req validatePromoRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"error": "invalid_request", "detail": err.Error(),
+		})
+		return
+	}
+	if h.promo == nil {
+		c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": "promo_unavailable"})
+		return
+	}
+
+	offer, err := h.promo.ValidateForSignup(c.Request.Context(), SignupPromoInput{
+		Code:          req.Code,
+		MerchantEmail: req.Email,
+		Currency:      req.Currency,
+	})
+	// A refused code is a 200 with valid:false, not a 4xx. The merchant asked
+	// a question and got an answer; "your code will not work" is a successful
+	// answer, and giving it its own status invites a caller to treat it as a
+	// transport failure and retry.
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{
+		"valid":                err == nil,
+		"trial_extension_days": offer.TrialExtensionDays,
+		"reject_reason":        offer.RejectReason,
+	}})
 }
 
 type ensureSubscriptionRequest struct {
@@ -62,6 +157,9 @@ type ensureSubscriptionRequest struct {
 	// Currency is the store's ISO 4217 billing currency. Known at signup and
 	// supplied by nothing else afterwards.
 	Currency string `json:"currency"`
+	// PromoCode is what the merchant typed at onboarding, if anything (#620).
+	// Empty is the normal case.
+	PromoCode string `json:"promo_code"`
 }
 
 func (h *InternalHandler) ensureSubscription(c *gin.Context) {
@@ -98,10 +196,42 @@ func (h *InternalHandler) ensureSubscription(c *gin.Context) {
 		return
 	}
 
+	// Redeem the promo code, if one was typed. AFTER Bootstrap, because the
+	// ledger row needs a subscription id and the trial extension needs a row
+	// to move — this is the earliest moment redemption is possible at all.
+	//
+	// A refusal does NOT fail the call. The store exists and the trial has
+	// started; onboarding must complete either way. The outcome travels in
+	// the response so the caller can tell the merchant what happened.
+	offer := SignupPromoOffer{}
+	if code := strings.TrimSpace(req.PromoCode); code != "" {
+		if h.promo == nil {
+			// Refuse rather than ignore. Silently dropping the code would
+			// tell a merchant it applied while nothing could have applied
+			// it — the shape of #620's original defect.
+			offer.RejectReason = "promo_unavailable"
+		} else {
+			granted, promoErr := h.promo.RedeemAtSignup(c.Request.Context(), SignupPromoInput{
+				Code:          code,
+				MerchantEmail: req.Email,
+				Currency:      req.Currency,
+				Sub:           sub,
+			})
+			offer = granted
+			if promoErr != nil && offer.RejectReason == "" {
+				offer.RejectReason = "promo_failed"
+			}
+		}
+	}
+
 	c.JSON(http.StatusOK, gin.H{"data": gin.H{
 		"id":         sub.ID.String(),
 		"plan":       string(sub.Plan),
 		"status":     string(sub.Status),
 		"created_at": sub.CreatedAt,
+		"promo": gin.H{
+			"trial_extension_days": offer.TrialExtensionDays,
+			"reject_reason":        offer.RejectReason,
+		},
 	}})
 }

--- a/services/marketplace-api/internal/subscription/internal_handler_test.go
+++ b/services/marketplace-api/internal/subscription/internal_handler_test.go
@@ -183,3 +183,204 @@ func TestEnsureSubscription_IsOpenWhenNoSecretIsConfigured(t *testing.T) {
 		t.Fatalf("status = %d, want 200 — parity with the rest of /internal", rec.Code)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Promo at signup (#620)
+// ---------------------------------------------------------------------------
+
+type stubPromo struct {
+	redeems   []subscription.SignupPromoInput
+	validates []subscription.SignupPromoInput
+	offer     subscription.SignupPromoOffer
+	err       error
+}
+
+func (p *stubPromo) RedeemAtSignup(_ context.Context, in subscription.SignupPromoInput) (subscription.SignupPromoOffer, error) {
+	p.redeems = append(p.redeems, in)
+	return p.offer, p.err
+}
+
+func (p *stubPromo) ValidateForSignup(_ context.Context, in subscription.SignupPromoInput) (subscription.SignupPromoOffer, error) {
+	p.validates = append(p.validates, in)
+	return p.offer, p.err
+}
+
+func promoRouter(t *testing.T, svc subscription.Bootstrapper, p subscription.SignupPromoRedeemer) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	e := gin.New()
+	h := subscription.NewInternalHandler(svc)
+	if p != nil {
+		h = h.WithPromo(p)
+	}
+	h.RegisterRoutes(e.Group("/internal"), testInternalSecret)
+	return e
+}
+
+func decode(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var out struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode %s: %v", body, err)
+	}
+	return out.Data
+}
+
+func TestEnsureSubscription_RedeemsThePromoCodeAgainstTheNewRow(t *testing.T) {
+	svc := &stubBootstrapper{}
+	p := &stubPromo{offer: subscription.SignupPromoOffer{TrialExtensionDays: 14}}
+	storeID := uuid.New()
+
+	rec := httptest.NewRecorder()
+	promoRouter(t, svc, p).ServeHTTP(rec, ensureReq(t, storeID, map[string]any{
+		"tenant_id":  uuid.New().String(),
+		"email":      "founder@example.com",
+		"currency":   "aud",
+		"promo_code": "STAYLONGER",
+	}, testInternalSecret))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if len(p.redeems) != 1 {
+		t.Fatalf("redeemed %d times, want 1", len(p.redeems))
+	}
+	// Redemption must run against the row Bootstrap just created — the ledger
+	// row needs its id and the extension needs a row to move.
+	if p.redeems[0].Sub == nil || p.redeems[0].Sub.StoreID != storeID {
+		t.Errorf("redeemed against %+v, want the freshly bootstrapped row", p.redeems[0].Sub)
+	}
+	if got := decode(t, rec.Body.Bytes())["promo"].(map[string]any)["trial_extension_days"]; got != float64(14) {
+		t.Errorf("trial_extension_days = %v, want 14", got)
+	}
+}
+
+// Most merchants type nothing, and that must not look like a refused code.
+func TestEnsureSubscription_NoPromoCodeIsNotARefusal(t *testing.T) {
+	p := &stubPromo{}
+	rec := httptest.NewRecorder()
+	promoRouter(t, &stubBootstrapper{}, p).ServeHTTP(rec, ensureReq(t, uuid.New(), map[string]any{
+		"tenant_id": uuid.New().String(),
+	}, testInternalSecret))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if len(p.redeems) != 0 {
+		t.Error("looked up a promo code that was never supplied")
+	}
+	if got := decode(t, rec.Body.Bytes())["promo"].(map[string]any)["reject_reason"]; got != "" {
+		t.Errorf("reject_reason = %v, want empty", got)
+	}
+}
+
+// A refused code must not fail onboarding: the store exists and the trial has
+// started. It must also not be reported as applied.
+func TestEnsureSubscription_ARefusedCodeStillCompletesOnboarding(t *testing.T) {
+	p := &stubPromo{
+		offer: subscription.SignupPromoOffer{RejectReason: "redeem_in_billing"},
+		err:   errors.New("refused"),
+	}
+	rec := httptest.NewRecorder()
+	promoRouter(t, &stubBootstrapper{}, p).ServeHTTP(rec, ensureReq(t, uuid.New(), map[string]any{
+		"tenant_id":  uuid.New().String(),
+		"promo_code": "WINBACK20OFF6MONTHS",
+	}, testInternalSecret))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d — a refused promo code failed onboarding", rec.Code)
+	}
+	got := decode(t, rec.Body.Bytes())["promo"].(map[string]any)
+	if got["reject_reason"] != "redeem_in_billing" {
+		t.Errorf("reject_reason = %v", got["reject_reason"])
+	}
+	if got["trial_extension_days"] != float64(0) {
+		t.Errorf("trial_extension_days = %v, want 0", got["trial_extension_days"])
+	}
+}
+
+// With no promo service wired, a code must be REFUSED rather than dropped.
+// Silently ignoring it would tell a merchant it applied when nothing could
+// have applied it — the shape of #620's original defect.
+func TestEnsureSubscription_ACodeWithNoPromoServiceIsRefusedNotIgnored(t *testing.T) {
+	rec := httptest.NewRecorder()
+	promoRouter(t, &stubBootstrapper{}, nil).ServeHTTP(rec, ensureReq(t, uuid.New(), map[string]any{
+		"tenant_id":  uuid.New().String(),
+		"promo_code": "STAYLONGER",
+	}, testInternalSecret))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := decode(t, rec.Body.Bytes())["promo"].(map[string]any)["reject_reason"]; got != "promo_unavailable" {
+		t.Errorf("reject_reason = %v, want promo_unavailable", got)
+	}
+}
+
+func TestValidatePromoForSignup_ReportsTheOfferWithoutRedeeming(t *testing.T) {
+	p := &stubPromo{offer: subscription.SignupPromoOffer{TrialExtensionDays: 30}}
+
+	body, _ := json.Marshal(map[string]any{"code": "STAYLONGER", "email": "f@example.com", "currency": "aud"})
+	req := httptest.NewRequest(http.MethodPost, "/internal/promo/validate-for-signup", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Internal-Auth", testInternalSecret)
+
+	rec := httptest.NewRecorder()
+	promoRouter(t, &stubBootstrapper{}, p).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	got := decode(t, rec.Body.Bytes())
+	if got["valid"] != true || got["trial_extension_days"] != float64(30) {
+		t.Errorf("data = %+v", got)
+	}
+	if len(p.redeems) != 0 {
+		t.Fatal("validating consumed the code")
+	}
+}
+
+// A refused code is a 200 with valid:false. Giving it a 4xx invites the caller
+// to treat a successful answer as a transport failure and retry it.
+func TestValidatePromoForSignup_ARefusalIsStillA200(t *testing.T) {
+	p := &stubPromo{
+		offer: subscription.SignupPromoOffer{RejectReason: "invalid_or_expired"},
+		err:   errors.New("refused"),
+	}
+	body, _ := json.Marshal(map[string]any{"code": "NOPE"})
+	req := httptest.NewRequest(http.MethodPost, "/internal/promo/validate-for-signup", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Internal-Auth", testInternalSecret)
+
+	rec := httptest.NewRecorder()
+	promoRouter(t, &stubBootstrapper{}, p).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	got := decode(t, rec.Body.Bytes())
+	if got["valid"] != false || got["reject_reason"] != "invalid_or_expired" {
+		t.Errorf("data = %+v", got)
+	}
+}
+
+// #620 calls an open validate endpoint "an oracle for guessing valid codes".
+// It is on /internal for that reason, and the guard is what makes that true.
+func TestValidatePromoForSignup_RefusesWithoutTheInternalSecret(t *testing.T) {
+	p := &stubPromo{}
+	body, _ := json.Marshal(map[string]any{"code": "STAYLONGER"})
+	req := httptest.NewRequest(http.MethodPost, "/internal/promo/validate-for-signup", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	promoRouter(t, &stubBootstrapper{}, p).ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusOK {
+		t.Fatalf("status = %d — the code oracle is open", rec.Code)
+	}
+	if len(p.validates) != 0 {
+		t.Fatal("validated a code for a request that failed the guard")
+	}
+}

--- a/services/platform-api/internal/marketplaceapi/vendor_client.go
+++ b/services/platform-api/internal/marketplaceapi/vendor_client.go
@@ -191,6 +191,64 @@ type EnsureSubscription struct {
 	// nothing supplies it to marketplace-api afterwards, and a subscription
 	// row without one cannot have its price resolved.
 	Currency string `json:"currency,omitempty"`
+	// PromoCode is what the merchant typed at onboarding, if anything
+	// (mark8ly#620). Redeemed on the far side, immediately after the row is
+	// created — the earliest moment redemption is possible at all.
+	PromoCode string `json:"promo_code,omitempty"`
+}
+
+// SignupPromoOffer is what a promo code granted, or why it was refused.
+// RejectReason is already the public reason; it is safe to show a merchant.
+type SignupPromoOffer struct {
+	TrialExtensionDays int    `json:"trial_extension_days"`
+	RejectReason       string `json:"reject_reason"`
+}
+
+// ValidatePromoForSignup asks what a code would grant a merchant who is
+// signing up, WITHOUT redeeming it.
+//
+// This is why marketplace-api's validate route is on /internal rather than
+// exposed publicly: mark8ly#620 calls an open validate endpoint "an oracle for
+// guessing valid codes", and routing it through platform-api — which already
+// holds the shared secret — means no such endpoint has to exist.
+func (c *VendorClient) ValidatePromoForSignup(ctx context.Context, code, email, currency string) (SignupPromoOffer, bool, error) {
+	var out SignupPromoOffer
+
+	body, err := json.Marshal(map[string]string{
+		"code": code, "email": email, "currency": currency,
+	})
+	if err != nil {
+		return out, false, err
+	}
+	url := fmt.Sprintf("%s/internal/promo/validate-for-signup", c.baseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return out, false, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.addInternalAuth(req)
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return out, false, fmt.Errorf("marketplace-api validate-promo: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 300 {
+		raw, _ := io.ReadAll(res.Body)
+		return out, false, fmt.Errorf("marketplace-api validate-promo %d: %s", res.StatusCode, string(raw))
+	}
+
+	var envelope struct {
+		Data struct {
+			Valid bool `json:"valid"`
+			SignupPromoOffer
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&envelope); err != nil {
+		return out, false, fmt.Errorf("marketplace-api validate-promo: decode: %w", err)
+	}
+	return envelope.Data.SignupPromoOffer, envelope.Data.Valid, nil
 }
 
 // EnsureSelfStore upserts the authoritative store row from platform_api

--- a/services/platform-api/internal/onboarding/completion_integration_test.go
+++ b/services/platform-api/internal/onboarding/completion_integration_test.go
@@ -318,10 +318,11 @@ func TestIntegration_Complete_DuplicateSlugRollsBackEverything(t *testing.T) {
 // ─── fakeVendorClient ────────────────────────────────────────────────────────
 
 type fakeVendorClient struct {
-	calls      []struct{ tenantID, name, slug string }
-	storeCalls []marketplaceapi.Store
-	subCalls   []marketplaceapi.EnsureSubscription
-	err        error
+	calls       []struct{ tenantID, name, slug string }
+	storeCalls  []marketplaceapi.Store
+	subCalls    []marketplaceapi.EnsureSubscription
+	promoChecks []string
+	err         error
 }
 
 // EnsureSubscription starts the store's trial (mark8ly#827). Recorded so a
@@ -330,6 +331,14 @@ type fakeVendorClient struct {
 func (f *fakeVendorClient) EnsureSubscription(_ context.Context, in marketplaceapi.EnsureSubscription) error {
 	f.subCalls = append(f.subCalls, in)
 	return f.err
+}
+
+// ValidatePromoForSignup is never reached from Complete — the code is redeemed
+// on the far side of EnsureSubscription, not validated again here — so this
+// exists to satisfy the interface and records the call in case that changes.
+func (f *fakeVendorClient) ValidatePromoForSignup(_ context.Context, code, email, currency string) (marketplaceapi.SignupPromoOffer, bool, error) {
+	f.promoChecks = append(f.promoChecks, code)
+	return marketplaceapi.SignupPromoOffer{}, false, nil
 }
 
 // EnsureSelfStore mirrors the platform-api store row into marketplace-api.
@@ -556,5 +565,119 @@ func TestIntegration_Complete_StartsTheTrial(t *testing.T) {
 	if fake.storeCalls[0].ID != got.StoreID {
 		t.Errorf("store mirrored = %q but subscription attached to %q",
 			fake.storeCalls[0].ID, got.StoreID)
+	}
+}
+
+// The promo code has to reach marketplace-api, because that is where it can be
+// redeemed: the ledger row needs a subscription id and the trial extension
+// needs a row to move, and both come into existence inside EnsureSubscription
+// (mark8ly#620, mark8ly#827).
+func TestIntegration_Complete_CarriesThePromoCode(t *testing.T) {
+	db := testdb.NewDB(t,
+		"outbox_events",
+		"verification_tokens",
+		"onboarding_sessions",
+		"tenants",
+	)
+
+	onboardingRepo := NewRepository(db)
+	fake := &fakeVendorClient{}
+	svc := NewService(Config{
+		DB:           db,
+		Repo:         onboardingRepo,
+		TenantRepo:   tenant.NewRepository(db),
+		Sender:       notification.NoopSender{},
+		EmailFrom:    "noreply@test.local",
+		SupportEmail: "help@test.local",
+		VendorClient: fake,
+	})
+
+	ctx := context.Background()
+	now := time.Now()
+	sess := &Session{
+		Email:           "promo-carry@test.local",
+		Draft:           json.RawMessage(`{}`),
+		Status:          StatusInProgress,
+		EmailVerifiedAt: &now,
+	}
+	if err := onboardingRepo.Create(ctx, sess); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	if _, err := svc.Complete(ctx, CompleteRequest{
+		SessionID:    sess.ID,
+		BusinessName: "Promo Carry Co",
+		Slug:         "promo-carry-co",
+		OwnerUserID:  "gip-uid-promo-carry",
+		OwnerEmail:   "promo-carry@test.local",
+		PromoCode:    "STAYLONGER",
+		CountryCode:  "AU",
+		CurrencyCode: "AUD",
+		Timezone:     "Australia/Sydney",
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	if len(fake.subCalls) != 1 {
+		t.Fatalf("EnsureSubscription called %d times, want 1", len(fake.subCalls))
+	}
+	if got := fake.subCalls[0].PromoCode; got != "STAYLONGER" {
+		t.Errorf("PromoCode = %q, want STAYLONGER — the merchant typed a code and it was dropped", got)
+	}
+	// The email travels too: it is what the per-email redemption cap counts
+	// against, and it is the only abuse control available at signup.
+	if fake.subCalls[0].Email != "promo-carry@test.local" {
+		t.Errorf("Email = %q — the per-email cap cannot be enforced without it", fake.subCalls[0].Email)
+	}
+}
+
+// A merchant who types nothing must not have an empty code forwarded as though
+// they had — the far side treats "" as "no code", but only if it arrives empty.
+func TestIntegration_Complete_NoPromoCodeStaysEmpty(t *testing.T) {
+	db := testdb.NewDB(t,
+		"outbox_events",
+		"verification_tokens",
+		"onboarding_sessions",
+		"tenants",
+	)
+
+	onboardingRepo := NewRepository(db)
+	fake := &fakeVendorClient{}
+	svc := NewService(Config{
+		DB: db, Repo: onboardingRepo, TenantRepo: tenant.NewRepository(db),
+		Sender: notification.NoopSender{}, EmailFrom: "noreply@test.local",
+		SupportEmail: "help@test.local", VendorClient: fake,
+	})
+
+	ctx := context.Background()
+	now := time.Now()
+	sess := &Session{
+		Email:           "no-promo@test.local",
+		Draft:           json.RawMessage(`{}`),
+		Status:          StatusInProgress,
+		EmailVerifiedAt: &now,
+	}
+	if err := onboardingRepo.Create(ctx, sess); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	if _, err := svc.Complete(ctx, CompleteRequest{
+		SessionID:    sess.ID,
+		BusinessName: "No Promo Co",
+		Slug:         "no-promo-co",
+		OwnerUserID:  "gip-uid-no-promo",
+		OwnerEmail:   "no-promo@test.local",
+		CountryCode:  "US",
+		CurrencyCode: "USD",
+		Timezone:     "America/New_York",
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	if len(fake.subCalls) != 1 {
+		t.Fatalf("EnsureSubscription called %d times, want 1", len(fake.subCalls))
+	}
+	if got := fake.subCalls[0].PromoCode; got != "" {
+		t.Errorf("PromoCode = %q, want empty", got)
 	}
 }

--- a/services/platform-api/internal/onboarding/handler.go
+++ b/services/platform-api/internal/onboarding/handler.go
@@ -22,11 +22,15 @@ import (
 type Handler struct {
 	svc      *Service
 	verifSvc *verification.Service
+	// promoLimiter caps promo-code attempts per client IP. The promo route is
+	// unauthenticated like the rest of this group, and a code checker is a
+	// guessing surface by nature (mark8ly#620).
+	promoLimiter *PromoRateLimiter
 }
 
 // NewHandler constructs a Handler.
 func NewHandler(svc *Service, verifSvc *verification.Service) *Handler {
-	return &Handler{svc: svc, verifSvc: verifSvc}
+	return &Handler{svc: svc, verifSvc: verifSvc, promoLimiter: NewPromoRateLimiter()}
 }
 
 // Register mounts onboarding routes onto the given gin.RouterGroup.
@@ -42,7 +46,64 @@ func (h *Handler) Register(r *gin.RouterGroup) {
 		// from the token's session_id.
 		o.POST("/verify-token", h.verifyAndMarkSession)
 		o.POST("/sessions/:id/complete", h.completeSession)
+		// Promo-code check for the onboarding field (mark8ly#620). Sits
+		// here, on the public wizard group, because the merchant typing the
+		// code has no credential of any kind yet — the same reason
+		// /sessions and /verify-token do.
+		o.POST("/promo/validate", h.validatePromo)
 	}
+}
+
+// promoValidateRequest is what the onboarding app sends as the merchant types.
+type promoValidateRequest struct {
+	Code string `json:"code" binding:"required"`
+	// Email is the address the per-email redemption cap counts against. It is
+	// the only abuse control available before a store exists.
+	Email    string `json:"email"`
+	Currency string `json:"currency"`
+}
+
+// validatePromo serves POST /api/v1/onboarding/promo/validate.
+//
+// It is a thin proxy onto marketplace-api's internal validate route. The hop
+// is the point: mark8ly#620 calls an open validate endpoint "an oracle for
+// guessing valid codes", and marketplace-api's route is guarded by the shared
+// internal secret, which this service holds and the onboarding app does not.
+// So there is no unauthenticated promo endpoint anywhere.
+//
+// This surface is itself unauthenticated, like every other route in this
+// group, and is rate limited by client IP for that reason.
+//
+// A refused code answers 200 with valid:false. It is a successful answer to a
+// question, and giving it a 4xx invites a caller to retry a settled result.
+func (h *Handler) validatePromo(c *gin.Context) {
+	if h.promoLimiter != nil && !h.promoLimiter.Allow(c.ClientIP()) {
+		respondError(c, apperrors.TooManyRequests("rate_limited",
+			"too many promo code attempts, please try again shortly"))
+		return
+	}
+
+	var req promoValidateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondError(c, apperrors.BadRequest("invalid_request", err.Error()))
+		return
+	}
+
+	offer, valid, err := h.svc.ValidatePromo(c.Request.Context(), req.Code, req.Email, req.Currency)
+	if err != nil {
+		// marketplace-api unreachable. Answering "invalid" would tell a
+		// merchant their good code is bad; say nothing about the code and
+		// let the field stay quiet.
+		respondError(c, apperrors.Internal("promo_check_failed",
+			"we could not check that code just now"))
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{
+		"valid":                valid,
+		"trial_extension_days": offer.TrialExtensionDays,
+		"reject_reason":        offer.RejectReason,
+	}})
 }
 
 func (h *Handler) createSession(c *gin.Context) {

--- a/services/platform-api/internal/onboarding/promo_ratelimit.go
+++ b/services/platform-api/internal/onboarding/promo_ratelimit.go
@@ -1,0 +1,66 @@
+package onboarding
+
+import (
+	"sync"
+	"time"
+)
+
+// PromoRateWindow and PromoRateMax bound how often one client may test promo
+// codes. A code checker is a guessing surface by nature, and this route is
+// unauthenticated like the rest of the onboarding wizard (mark8ly#620).
+//
+// Set deliberately loose. A merchant retyping a code they hold gets several
+// attempts; someone enumerating a namespace gets nowhere near enough. The
+// codes themselves are the real defence — the console mints human campaign
+// codes, and the per-email cap means a guessed code is still only redeemable
+// once per address.
+const (
+	PromoRateWindow = 10 * time.Minute
+	PromoRateMax    = 20
+)
+
+// PromoRateLimiter is an in-memory sliding-window counter keyed by client IP,
+// the same shape marketplace-api's journal.RateLimiter uses.
+//
+// # What this limiter can and cannot see
+//
+// The onboarding app calls this route from a SERVER action, so the IP gin
+// reports is that app's pod, not the visitor's. This limiter is therefore a
+// coarse, service-wide cap rather than a per-visitor one, and it is the second
+// of two layers: the onboarding app applies its own per-visitor limit, keyed
+// on the address it can actually see, before it ever calls here.
+//
+// Stated because the distinction is invisible from this file, and a reader who
+// assumed "per IP" meant "per visitor" would over-trust it — and might tighten
+// PromoRateMax to a number that locks out every merchant at once.
+type PromoRateLimiter struct {
+	mu       sync.Mutex
+	attempts map[string][]time.Time
+}
+
+// NewPromoRateLimiter returns an empty PromoRateLimiter.
+func NewPromoRateLimiter() *PromoRateLimiter {
+	return &PromoRateLimiter{attempts: map[string][]time.Time{}}
+}
+
+// Allow records an attempt for key and reports whether it is within
+// PromoRateMax for the current window.
+func (l *PromoRateLimiter) Allow(key string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	cutoff := time.Now().Add(-PromoRateWindow)
+	bucket := l.attempts[key]
+	fresh := bucket[:0]
+	for _, t := range bucket {
+		if t.After(cutoff) {
+			fresh = append(fresh, t)
+		}
+	}
+	if len(fresh) >= PromoRateMax {
+		l.attempts[key] = fresh
+		return false
+	}
+	l.attempts[key] = append(fresh, time.Now())
+	return true
+}

--- a/services/platform-api/internal/onboarding/promo_ratelimit_test.go
+++ b/services/platform-api/internal/onboarding/promo_ratelimit_test.go
@@ -1,0 +1,32 @@
+package onboarding
+
+import (
+	"testing"
+)
+
+func TestPromoRateLimiter_AllowsUpToTheCapThenRefuses(t *testing.T) {
+	l := NewPromoRateLimiter()
+
+	for i := 0; i < PromoRateMax; i++ {
+		if !l.Allow("1.2.3.4") {
+			t.Fatalf("attempt %d refused, want allowed up to %d", i+1, PromoRateMax)
+		}
+	}
+	if l.Allow("1.2.3.4") {
+		t.Fatal("attempt past the cap was allowed")
+	}
+}
+
+// One caller exhausting its bucket must not lock out another. Worth asserting
+// because the buckets share a map, and a keying mistake would present as
+// "promo codes stopped working for everyone" only under load.
+func TestPromoRateLimiter_BucketsArePerKey(t *testing.T) {
+	l := NewPromoRateLimiter()
+
+	for i := 0; i < PromoRateMax; i++ {
+		l.Allow("1.2.3.4")
+	}
+	if !l.Allow("5.6.7.8") {
+		t.Fatal("a second caller was refused because the first exhausted its bucket")
+	}
+}

--- a/services/platform-api/internal/onboarding/service.go
+++ b/services/platform-api/internal/onboarding/service.go
@@ -33,6 +33,9 @@ type VendorEnsurer interface {
 	// opens the admin Billing page, and never at all for one who does not
 	// (mark8ly#827).
 	EnsureSubscription(ctx context.Context, in marketplaceapi.EnsureSubscription) error
+	// ValidatePromoForSignup asks what a promo code would grant, without
+	// redeeming it (mark8ly#620).
+	ValidatePromoForSignup(ctx context.Context, code, email, currency string) (marketplaceapi.SignupPromoOffer, bool, error)
 }
 
 // Service is the business logic for the onboarding flow.
@@ -251,8 +254,13 @@ type CompleteRequest struct {
 	// FirstName / LastName populate the Zitadel profile. Optional —
 	// derived from the email local part when absent (Zitadel rejects an
 	// empty givenName/familyName).
-	FirstName    string `json:"first_name"`
-	LastName     string `json:"last_name"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	// PromoCode is what the merchant typed at onboarding, if anything. It
+	// travels with completion rather than being redeemed earlier because
+	// redemption needs a subscription row, and that row is created as part of
+	// this call (mark8ly#620, mark8ly#827).
+	PromoCode    string `json:"promo_code"`
 	CountryCode  string `json:"country_code"`
 	CurrencyCode string `json:"currency_code"`
 	Timezone     string `json:"timezone"`
@@ -484,6 +492,10 @@ func (s *Service) Complete(ctx context.Context, req CompleteRequest) (*CompleteR
 			Email:    req.OwnerEmail,
 			Name:     st.Name,
 			Currency: st.CurrencyCode,
+			// Redeemed on the far side, right after the row exists
+			// (mark8ly#620). A refused code does not fail this call: the
+			// outcome comes back in the response and is logged.
+			PromoCode: req.PromoCode,
 		}); subErr != nil {
 			log.Printf("onboarding.Complete: ensure subscription for tenant %s store %s: %v — THIS STORE HAS NO TRIAL CLOCK",
 				t.ID, st.ID, subErr)
@@ -495,6 +507,21 @@ func (s *Service) Complete(ctx context.Context, req CompleteRequest) (*CompleteR
 	}
 
 	return &CompleteResult{TenantID: t.ID, Slug: st.Slug}, nil
+}
+
+// ValidatePromo asks marketplace-api what a promo code would grant a merchant
+// who is signing up, without redeeming it (mark8ly#620).
+//
+// Returns (offer, valid, err). A refused code is (reason, false, nil) — not an
+// error: "your code will not work" is a successful answer. Only a failure to
+// ASK is an error, and the handler turns that into "we could not check that
+// code" rather than into "invalid", so a merchant holding a good code is never
+// told it is bad because a service was down.
+func (s *Service) ValidatePromo(ctx context.Context, code, email, currency string) (marketplaceapi.SignupPromoOffer, bool, error) {
+	if s.vendorClient == nil {
+		return marketplaceapi.SignupPromoOffer{}, false, fmt.Errorf("onboarding: no marketplace client configured")
+	}
+	return s.vendorClient.ValidatePromoForSignup(ctx, code, email, currency)
 }
 
 func (s *Service) sendWelcome(ctx context.Context, t *tenant.Tenant, st *store.Store, req CompleteRequest) error {

--- a/services/platform-api/pkg/errors/errors.go
+++ b/services/platform-api/pkg/errors/errors.go
@@ -42,6 +42,9 @@ func Unauthorized(code, msg string) *AppError {
 	return New(http.StatusUnauthorized, code, msg)
 }
 func Forbidden(code, msg string) *AppError { return New(http.StatusForbidden, code, msg) }
+func TooManyRequests(code, msg string) *AppError {
+	return New(http.StatusTooManyRequests, code, msg)
+}
 
 // As is a convenience to extract an *AppError from any error.
 func As(err error) (*AppError, bool) {


### PR DESCRIPTION
Closes #620 — the last unchecked box, the onboarding field.

A merchant types a promo code while signing up, sees what it grants before committing, and gets the days the moment their store exists.

Only buildable now that #828 makes a subscription row exist at signup: redemption needs a `subscription_id` for the ledger row and a row for `trial.Extend` to move, and before #828 neither existed until someone opened the Billing page.

## No public promo endpoint

#620 flags an open validate endpoint as **"an oracle for guessing valid codes"**. So there isn't one.

```
onboarding app  ──▶  platform-api  ──▶  marketplace-api
   server action      /api/v1/onboarding    /internal/promo/
   (per-visitor        /promo/validate      validate-for-signup
    rate limit)        (per-IP limit)       (internal secret)
```

The extra hop is the design: marketplace-api's route is guarded by the shared internal secret, which platform-api holds and the onboarding app does not. **No new configuration anywhere** — platform-api's `VendorClient` already sends `X-Internal-Auth`.

**Two rate-limit layers, because only one of them can see a visitor.** The onboarding app calls from a *server action*, so by the time the request reaches platform-api the client IP is the app's own pod — every visitor shares one bucket there. platform-api's limiter is a coarse service-wide cap; the per-visitor cap lives in the app, keyed on the address it can actually see. Both are documented as such, since a reader who assumed "per IP" meant "per visitor" would over-trust one and might tighten it to a number that locks out every merchant at once.

## Signup refuses what signup cannot deliver

**A code carrying a discount is refused at onboarding, and the merchant is told where it works.**

There is no Stripe subscription yet for a coupon to attach to. `ApplyPromo` would log "no subscription id — skipping Stripe coupon attach", write the ledger row, and report success — spending the merchant's one redemption (`max_per_email` is 1) on the half we could not honour, with no way to claim it later.

So: `deliverableAtSignup` is one predicate called by **both** validate and redeem. If those could disagree, the field would accept a code that signup then silently ate — which is the failure this rule exists to prevent, and it has its own test.

The refusal reason `redeem_in_billing` is deliberately **not** collapsed into `invalid_or_expired`: it is the one refusal meaning "your code works, just not here", and telling someone holding a good code that it is invalid sends them away from the page that would have taken it.

## Validating against a subscription that does not exist yet

`ValidateCode` pre-flights the trial extension against a subscription (#825), and at signup there is none. Rather than weaken that check, `SignupInput.applyInput()` builds the row onboarding is **about** to create — `plan=trial`, `status=signup`, created now, never extended.

Not a fudge to satisfy a nil check: "would this code work?" asked at signup means "would it work against the subscription I am about to get", and that row's shape is known exactly. It also keeps validate and redeem answering identically.

## What the field says

Every branch states only what the server returned; the day count comes from the promo definition, so a code's terms can change in the console with no deploy here.

The branch that matters most is **"we could not check"** — rendered as its own neutral message, never as "invalid". A merchant holding a working code being told it is bad because a service was down is the one outcome that silently costs a signup, and the one no happy-path test would catch. It has a test asserting its sentence differs from the invalid one.

## Test plan

- [x] `gofmt`, `go build`, `go vet`, full suites green in **both** Go services
- [x] `go vet -tags integration ./...` on platform-api — the `VendorEnsurer` fakes live only in tagged files, so an untagged run is green while CI is not
- [x] `apps/onboarding`: `tsc --noEmit` clean, **`next build` green** (the only gate that catches a bad `"use server"` export), 104 unit tests pass including 10 new
- [x] Promo service: validate reports days and touches neither the ledger nor the extender; discount-carrying codes refused by both paths; per-email cap applies; empty code is a no-op, not a refusal
- [x] Route tests through the real router: redemption runs against the freshly bootstrapped row; a refused code still completes onboarding; a code with no promo service wired is **refused, not ignored**; the validate route refuses without the secret
- [x] platform-api: the code and the email both reach `EnsureSubscription`, and an absent code stays empty
- [ ] End-to-end against a real console-authored trial-extension code. Still blocked on the same thing #825 was: none has been authored yet. Such a code needs **no Stripe coupon**, so it can be created in the console's Promo codes tab without minting anything.

## Follow-on

`OnboardingDraft` gained `promo_code`. Worth noting that `tax_id` has been written to that draft since §5.1.1 and **nothing reads it** — platform-api has no `tax_id` anywhere. Not touched here, but the comment promising it is "forwarded once the store exists" is not true today.
