### PR TITLE
feat(promo): honour the promo scope the console publishes (#795)

### DIFF
--- a/.planning/quick/260908-ps2-promo-scope-ingest/PLAN.md
+++ b/.planning/quick/260908-ps2-promo-scope-ingest/PLAN.md
@@ -1,0 +1,87 @@
+---
+id: 260908-ps2
+slug: promo-scope-ingest
+date: 2026-09-08
+issue: 795
+kind: quick
+branch: feat/795-ingest-promo-scoping
+---
+
+# mark8ly honours the promo scope the console publishes (#795)
+
+tesserix-home#593 shipped the authoring half: the console publishes
+`allowed_plans` and `annual_only` on `/api/v1/promo-catalog`, and an operator can
+scope a code to Pro-only or annual-only today. **mark8ly reads neither.** An
+operator narrowing a code gets silence, and the code goes on applying to every
+plan and both periods.
+
+## Two things are wrong, not one — and the first is a proven bug
+
+**1. `AllowedPlans` cannot be written at all.** `internal/promo/model.go:54`
+declares `[]string` with `gorm:"type:text[];serializer:json"`. Verified against a
+real Postgres 15 with the real model and the real table on 2026-09-08:
+
+```
+ERROR: malformed array literal: "["pro","studio"]" (SQLSTATE 22P02)
+INSERT … "allowed_plans" … VALUES (…,'["pro","studio"]',…)
+```
+
+GORM marshals the slice to a JSON document and sends it as a text literal;
+Postgres wants `{pro,studio}`. **The write fails outright.** It has never
+surfaced because the column has only ever held NULL. `pq.StringArray` — what the
+other five array columns in this service use — round-trips correctly, verified
+the same way.
+
+**2. The ingest deliberately preserves both columns.** `consolepromo/store.go`'s
+`upsertColumns` omits them, and because it upserts assigning only listed
+columns, a re-sync **preserves** whatever an existing row already holds. Its
+comment says all four omitted columns are "mark8ly policy the console cannot
+express (#726)". That was true when written and is now wrong for two of them.
+
+## Decisions, settled — do not re-open these
+
+1. **`allowed_plans` and `annual_only` become console-owned and JOIN
+   `upsertColumns`.** A console publication is the last word, consistent with the
+   reasoning already written for `valid_until` directly below it. Otherwise
+   re-scoping an existing code silently never lands.
+2. **`max_per_email` and `min_effective_price_per_currency` stay preserved.**
+   They are abuse controls (§7.3, §7.4) the console deliberately cannot express —
+   see tesserix-home#593 and `0051`'s header. The comment must be rewritten to
+   describe TWO rules rather than one, or it will justify the wrong behaviour to
+   whoever reads it next.
+3. **An unknown plan is a `skipped` row with a reason, never a stored value.**
+   The sync already reports `skipped_reasons`; use it. Storing an unrecognised
+   plan would scope a code to nothing while reading as scoped.
+4. **`null` means every plan; `{}` must never be written.** The redeemer guards
+   on `len(AllowedPlans) > 0` (`internal/promo/validator.go:107`), so `{}` and
+   `NULL` are the same fact to it — and the console refuses `{}` outright for
+   that reason. One spelling crosses the boundary.
+
+## THE LESSON THIS TASK EXISTS UNDER
+
+The regression test for the model fix must assert **the stored representation**,
+not that a write succeeded. `require.NoError` after the fix passes equally against
+a future change that reintroduces a serializer; only asserting `{pro,studio}` in
+the column pins the behaviour that was actually broken.
+
+The same applies to the ingest: covering first-ingest alone would pass against
+the current broken preservation. **The re-scope path is the test that matters** —
+publish, ingest, re-scope, re-ingest, assert the row changed.
+
+## Tasks
+
+- **T1 — fix the model, with a regression test.** `pq.StringArray`, matching the
+  other five array columns. An integration test that writes a scoped code, reads
+  the raw column, and asserts `{pro,studio}` — plus the read-back through GORM.
+- **T2 — ingest the two fields.** DTO in `consolepromo/catalog.go`, mapping in
+  `mapper.go` with plan-vocabulary validation, both columns into `upsertColumns`,
+  and that comment rewritten per decision 2. Cover the re-scope path.
+
+## Done means
+
+- [ ] A scoped code written through the model stores `{pro,studio}`, asserted on the column
+- [ ] The console's `allowed_plans` / `annual_only` reach `promo_codes`
+- [ ] Re-scoping a code the ingest has already seen CHANGES the stored row
+- [ ] An unknown plan is skipped with a reason, not stored
+- [ ] `max_per_email` and `min_effective_price_per_currency` are still preserved
+- [ ] `upsertColumns`' comment describes two rules, not one

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	    ./internal/authz/... \
 	    ./internal/billing/appaddon/... \
 	    ./internal/billing/attestations/... \
+	    ./internal/billing/consolepromo/... \
 	    ./internal/billing/dispatch/... \
 	    ./internal/billing/migration/... \
 	    ./internal/billing/tax/... \

--- a/services/marketplace-api/internal/billing/consolepromo/catalog.go
+++ b/services/marketplace-api/internal/billing/consolepromo/catalog.go
@@ -57,6 +57,23 @@ type Code struct {
 	ValidUntil *time.Time `json:"valid_until"`
 	// MaxRedemptions is nil for unlimited global redemptions.
 	MaxRedemptions *int `json:"max_redemptions"`
+	// AllowedPlans scopes the code to a set of plan ids. NIL MEANS EVERY
+	// PLAN — not "no plan" — which is also what promo_codes.allowed_plans
+	// NULL means and what the redeemer reads (validator.go guards on
+	// len() > 0).
+	//
+	// A plain slice and not a pointer, because here the two absent readings
+	// coincide: the console refuses to publish an empty array precisely
+	// because `[]` and absent would be the same fact to the redeemer, so
+	// there is no `[]` for a nil to be distinguished from.
+	AllowedPlans []string `json:"allowed_plans"`
+	// AnnualOnly restricts the code to annual subscriptions.
+	//
+	// The only plain non-pointer optional on this struct, and deliberately
+	// so: false and absent both mean "applies to both billing periods", so
+	// unlike max_redemptions or trial_extension_days there is no zero-value
+	// reading to confuse with absence.
+	AnnualOnly bool `json:"annual_only"`
 }
 
 // Discount is the money part of a promo definition.

--- a/services/marketplace-api/internal/billing/consolepromo/mapper.go
+++ b/services/marketplace-api/internal/billing/consolepromo/mapper.go
@@ -6,10 +6,14 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/lib/pq"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/pricing"
 	"github.com/mark8ly/marketplace-api/internal/promo"
 )
 
@@ -61,6 +65,7 @@ const (
 	ReasonDuration          Reason = "bad_duration"
 	ReasonDurationInMonths  Reason = "bad_duration_in_months"
 	ReasonEmptyStripeCoupon Reason = "empty_stripe_coupon_id"
+	ReasonUnknownPlan       Reason = "unknown_plan"
 	ReasonUnknown           Reason = "unknown"
 )
 
@@ -116,6 +121,11 @@ func MapCode(in Code, now time.Time) (promo.PromoCode, error) {
 			code, n, minConsoleCodeLength, maxConsoleCodeLength)
 	}
 
+	plans, err := allowedPlans(code, in.AllowedPlans)
+	if err != nil {
+		return promo.PromoCode{}, err
+	}
+
 	out := promo.PromoCode{
 		Code:        code,
 		MaxPerEmail: DefaultMaxPerEmail,
@@ -124,6 +134,8 @@ func MapCode(in Code, now time.Time) (promo.PromoCode, error) {
 		// MaxRedemptions nil means unlimited on both sides, so it passes
 		// through untouched.
 		MaxRedemptions: in.MaxRedemptions,
+		AllowedPlans:   plans,
+		AnnualOnly:     in.AnnualOnly,
 	}
 
 	if in.ValidFrom != nil {
@@ -159,6 +171,75 @@ func MapCode(in Code, now time.Time) (promo.PromoCode, error) {
 
 	out.CreatedAt, out.UpdatedAt = now, now
 	return out, nil
+}
+
+// knownPlans is the vocabulary allowed_plans may name: starter, studio, pro.
+//
+// It is DERIVED from the price catalog rather than restated as three literals,
+// so a plan added to or renamed in pricing cannot leave a stale list here
+// rejecting a scope the console legitimately publishes.
+//
+// That derivation also fixes the boundary of the set. plangate's "trial" is a
+// plan in that other sense but has no Price object, so it is absent here — and
+// correctly: it is not something a subscription is billed on, and the console
+// does not offer it as a scope either.
+var knownPlans = func() map[string]struct{} {
+	m := map[string]struct{}{}
+	for _, d := range pricing.AllDescriptors() {
+		m[string(d.Plan)] = struct{}{}
+	}
+	return m
+}()
+
+// allowedPlans maps the console's plan scope onto promo_codes.allowed_plans.
+//
+// Three things this does and one it must never do:
+//
+//   - An empty or absent scope becomes nil, which stores as NULL. The column's
+//     NULL and '{}' are the same fact to the redeemer (validator.go guards on
+//     len() > 0), so only ONE of the two spellings may ever cross this
+//     boundary; '{}' would additionally read as "scoped" to anything
+//     inspecting the column by eye.
+//   - An unrecognised plan REJECTS the whole definition, so the sync counts it
+//     as skipped with a reason. Storing it instead would scope the code to a
+//     plan nothing can ever be on — a code that is dead at redemption while
+//     reading as perfectly configured.
+//   - Names are trimmed and lower-cased. The redeemer already compares with
+//     strings.EqualFold, so this changes no redemption outcome; it only keeps
+//     the stored column in one spelling.
+func allowedPlans(code string, in []string) (pq.StringArray, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	out := make(pq.StringArray, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, raw := range in {
+		plan := strings.ToLower(strings.TrimSpace(raw))
+		if _, ok := knownPlans[plan]; !ok {
+			return nil, reject(ReasonUnknownPlan,
+				"code %q: allowed_plans names %q, which is not one of %s",
+				code, raw, knownPlanList())
+		}
+		// A repeat says nothing the first mention did not; dropping it keeps
+		// the column comparable between two publications of the same scope.
+		if _, dup := seen[plan]; dup {
+			continue
+		}
+		seen[plan] = struct{}{}
+		out = append(out, plan)
+	}
+	return out, nil
+}
+
+// knownPlanList renders the vocabulary in a stable order for error messages,
+// so two rejections of the same mistake are the same text.
+func knownPlanList() string {
+	names := make([]string, 0, len(knownPlans))
+	for p := range knownPlans {
+		names = append(names, strconv.Quote(p))
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
 }
 
 // applyDiscount fills the discount half of the row. It writes DiscountType

--- a/services/marketplace-api/internal/billing/consolepromo/scope_test.go
+++ b/services/marketplace-api/internal/billing/consolepromo/scope_test.go
@@ -1,0 +1,181 @@
+package consolepromo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lib/pq"
+)
+
+// These cover the scope half of a published definition — allowed_plans and
+// annual_only (#795). now, ptr and mustMap come from mapper_test.go.
+
+// scoped is a minimal definition carrying a benefit, so promo_codes_has_benefit
+// is satisfied and every assertion below is about the scope alone.
+func scoped(plans []string, annualOnly bool) Code {
+	return Code{
+		Code:               "LAUNCH50",
+		TrialExtensionDays: ptr(14),
+		AllowedPlans:       plans,
+		AnnualOnly:         annualOnly,
+	}
+}
+
+// TestMapCode_AllowedPlansReachTheRow is the point of the ingest half: before
+// #795 the console could publish a scope and nothing carried it into the row.
+func TestMapCode_AllowedPlansReachTheRow(t *testing.T) {
+	got := mustMap(t, scoped([]string{"pro"}, false))
+
+	want := pq.StringArray{"pro"}
+	if len(got.AllowedPlans) != len(want) || got.AllowedPlans[0] != want[0] {
+		t.Fatalf("AllowedPlans = %v, want %v", got.AllowedPlans, want)
+	}
+	if got.AnnualOnly {
+		t.Fatalf("AnnualOnly = true, want false")
+	}
+}
+
+// TestMapCode_AnnualOnlyReachesTheRow pins the other published field. It is a
+// plain bool on both sides, so the risk is not a bad conversion but the field
+// simply never being read — which is exactly what #795 was.
+func TestMapCode_AnnualOnlyReachesTheRow(t *testing.T) {
+	if got := mustMap(t, scoped(nil, true)); !got.AnnualOnly {
+		t.Fatalf("AnnualOnly = false, want true")
+	}
+}
+
+// TestMapCode_MultiplePlansKeepPublishedOrder guards the whole scope, not just
+// its first element.
+func TestMapCode_MultiplePlansKeepPublishedOrder(t *testing.T) {
+	got := mustMap(t, scoped([]string{"pro", "studio"}, false))
+
+	if len(got.AllowedPlans) != 2 || got.AllowedPlans[0] != "pro" || got.AllowedPlans[1] != "studio" {
+		t.Fatalf("AllowedPlans = %v, want [pro studio]", got.AllowedPlans)
+	}
+}
+
+// TestMapCode_UnscopedCodeMapsToNilNotEmpty is decision 4 of the plan, and the
+// reason it is a test rather than a comment: NULL and '{}' are the SAME fact to
+// the redeemer (validator.go guards on len() > 0), so only one of the two
+// spellings may ever be written. An empty pq.StringArray stores as '{}', which
+// reads as "scoped" to anything inspecting the column, and require.Empty would
+// accept it just as happily as nil.
+func TestMapCode_UnscopedCodeMapsToNilNotEmpty(t *testing.T) {
+	for name, in := range map[string][]string{
+		"absent": nil,
+		// The console refuses to publish this, so it should never arrive —
+		// but if it ever does it means "every plan", exactly as nil does.
+		"empty": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := mustMap(t, scoped(in, false))
+			if got.AllowedPlans != nil {
+				t.Fatalf("AllowedPlans = %#v, want nil so the column stores NULL and never '{}'", got.AllowedPlans)
+			}
+		})
+	}
+}
+
+// TestMapCode_UnknownPlanIsRejected is decision 3. Storing an unrecognised
+// plan would scope the code to something nothing can ever be on: dead at
+// redemption, and reading as correctly configured to anyone looking.
+func TestMapCode_UnknownPlanIsRejected(t *testing.T) {
+	cases := map[string][]string{
+		// plangate's plan, priced nowhere; the console does not offer it.
+		"trial":                {"trial"},
+		"never existed":        {"platinum"},
+		"one bad among good":   {"pro", "platinum"},
+		"empty string element": {""},
+	}
+	for name, plans := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := MapCode(scoped(plans, false), now)
+			if err == nil {
+				t.Fatalf("MapCode(%v): expected a rejection, got none", plans)
+			}
+			if r := ReasonOf(err); r != ReasonUnknownPlan {
+				t.Fatalf("reason = %q, want %q", r, ReasonUnknownPlan)
+			}
+		})
+	}
+}
+
+// TestMapCode_UnknownPlanRejectsRatherThanDropping is the failure mode a
+// per-plan filter would have: dropping "platinum" from {pro, platinum} still
+// leaves a plausible row, so only checking that SOMETHING was rejected would
+// pass against it. Nothing may be written for this code at all.
+func TestMapCode_UnknownPlanRejectsRatherThanDropping(t *testing.T) {
+	got, err := MapCode(scoped([]string{"pro", "platinum"}, false), now)
+	if err == nil {
+		t.Fatalf("expected a rejection")
+	}
+	if got.Code != "" || got.AllowedPlans != nil {
+		t.Fatalf("a rejected definition must yield the zero row, got %+v", got)
+	}
+}
+
+// TestMapCode_PlanNamesAreNormalised keeps one spelling in the column. The
+// redeemer compares with strings.EqualFold, so this changes no redemption
+// outcome — it only stops two publications of the same scope storing
+// differently.
+func TestMapCode_PlanNamesAreNormalised(t *testing.T) {
+	got := mustMap(t, scoped([]string{" PRO ", "Studio", "pro"}, false))
+
+	if len(got.AllowedPlans) != 2 || got.AllowedPlans[0] != "pro" || got.AllowedPlans[1] != "studio" {
+		t.Fatalf("AllowedPlans = %v, want [pro studio] (trimmed, lower-cased, deduplicated)", got.AllowedPlans)
+	}
+}
+
+// TestKnownPlans_IsTheConsoleVocabulary pins the derived set itself. It is
+// built from the price catalog, so this fails if a plan is added to pricing
+// without the console contract being reconsidered — which is the moment to
+// look, not later when a scope is silently rejected in production.
+func TestKnownPlans_IsTheConsoleVocabulary(t *testing.T) {
+	want := []string{"starter", "studio", "pro"}
+	if len(knownPlans) != len(want) {
+		t.Fatalf("knownPlans = %v, want exactly %v", knownPlans, want)
+	}
+	for _, p := range want {
+		if _, ok := knownPlans[p]; !ok {
+			t.Fatalf("knownPlans is missing %q; it holds %v", p, knownPlans)
+		}
+	}
+	if _, ok := knownPlans["trial"]; ok {
+		t.Fatalf("trial is a plangate plan with no price and must not be a promo scope")
+	}
+}
+
+// TestSync_UnknownPlanIsSkippedWithAReasonAndCostsOnlyItsOwnCode is decision 3
+// at the sync level: the rejection has to arrive as a COUNTED skip with a
+// named reason, not as a silent drop and not as a failed batch. The sibling
+// code in the same publication must still be written.
+func TestSync_UnknownPlanIsSkippedWithAReasonAndCostsOnlyItsOwnCode(t *testing.T) {
+	f := &fakeFetcher{cat: Catalog{RevisionID: "rev-scope", Codes: []Code{
+		scoped([]string{"platinum"}, false),
+		{Code: "EXTRA14DAYS", TrialExtensionDays: ptr(14)},
+	}}}
+	s := &fakeStore{}
+
+	res, err := newSyncer(f, s).Sync(context.Background())
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	if res.Ingested != 1 || res.Skipped != 1 {
+		t.Fatalf("ingested=%d skipped=%d, want 1 and 1", res.Ingested, res.Skipped)
+	}
+	if got := res.SkippedByReason[ReasonUnknownPlan]; got != 1 {
+		t.Fatalf("SkippedByReason[%s] = %d, want 1 (breakdown: %v)",
+			ReasonUnknownPlan, got, res.SkippedByReason)
+	}
+	if len(s.upserted) != 1 || len(s.upserted[0]) != 1 || s.upserted[0][0].Code != "EXTRA14DAYS" {
+		t.Fatalf("upserted = %+v, want only EXTRA14DAYS", s.upserted)
+	}
+
+	// The rejected code is still KEPT, not expired. It is present in the
+	// catalog and merely unreadable by us; expiring it would turn a scope we
+	// could not parse into a withdrawn campaign for a merchant.
+	if len(s.keptCalls) != 1 || len(s.keptCalls[0]) != 2 {
+		t.Fatalf("kept = %v, want both published codes", s.keptCalls)
+	}
+}

--- a/services/marketplace-api/internal/billing/consolepromo/store.go
+++ b/services/marketplace-api/internal/billing/consolepromo/store.go
@@ -25,10 +25,20 @@ func NewStore(db *gorm.DB) Store { return &gormStore{db: db} }
 
 // upsertColumns are the columns a re-sync overwrites from the console.
 //
-// Everything absent from this list is deliberately preserved on an existing
-// row: max_per_email, min_effective_price_per_currency, allowed_plans and
-// annual_only are mark8ly policy the console cannot express (#726), and id
-// and created_at belong to the row, not to the definition.
+// Everything absent from this list is preserved on an existing row, and there
+// are TWO separate reasons for an absence — this is not one rule:
+//
+//  1. id and created_at belong to the ROW, not to the definition. Rewriting
+//     either would re-identify a code that promo_redemptions already points at.
+//  2. max_per_email and min_effective_price_per_currency are mark8ly's own
+//     abuse controls (§7.3, §7.4) that the console deliberately cannot express
+//     (#726). A publication says nothing about them, so it must not clear them.
+//
+// allowed_plans and annual_only used to sit in group 2 and no longer do
+// (#795). The console publishes both, so they are console-owned like every
+// other column listed here. Preserving them instead made re-scoping a code the
+// ingest had already seen silently never land: the operator narrowed the code
+// and the row went on applying to every plan and both periods.
 var upsertColumns = []string{
 	"stripe_coupon_id",
 	"discount_type",
@@ -38,6 +48,8 @@ var upsertColumns = []string{
 	"valid_from",
 	"valid_until",
 	"max_redemptions",
+	"allowed_plans",
+	"annual_only",
 	"created_by",
 	"updated_at",
 }

--- a/services/marketplace-api/internal/billing/consolepromo/store_scope_integration_test.go
+++ b/services/marketplace-api/internal/billing/consolepromo/store_scope_integration_test.go
@@ -1,0 +1,150 @@
+//go:build integration
+
+package consolepromo_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/consolepromo"
+	"github.com/mark8ly/marketplace-api/internal/promo"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// These tests are about the RE-SCOPE path, and that is deliberate.
+//
+// Covering first ingest alone would have passed against the bug (#795): the
+// upsert assigns only the columns in upsertColumns, and allowed_plans and
+// annual_only were absent from it, so a NEW row got the console's scope from
+// the INSERT while an EXISTING row kept whatever it already held. An operator
+// narrowing a live code got silence. Only publish -> ingest -> re-scope ->
+// re-ingest -> assert the stored row CHANGED can tell the two apart.
+
+var ingestedAt = time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+
+// publish builds one console definition carrying a benefit, so
+// promo_codes_has_benefit is satisfied and every assertion is about the scope.
+func publish(code string, plans []string, annualOnly bool) consolepromo.Code {
+	days := 14
+	return consolepromo.Code{
+		Code:               code,
+		TrialExtensionDays: &days,
+		AllowedPlans:       plans,
+		AnnualOnly:         annualOnly,
+	}
+}
+
+// ingest maps one definition and upserts it, i.e. does what one sync does to
+// one code.
+func ingest(t *testing.T, store consolepromo.Store, in consolepromo.Code) {
+	t.Helper()
+	row, err := consolepromo.MapCode(in, ingestedAt)
+	require.NoError(t, err, "the definition must map")
+	require.NoError(t, store.UpsertCodes(context.Background(),
+		[]promo.PromoCode{row}), "the upsert must succeed")
+}
+
+// storedScope reads the two columns back as the DATABASE holds them.
+// allowed_plans is read as ::text rather than through the model so an accidental
+// '{}' cannot be mistaken for NULL — both read as an empty scope in Go.
+func storedScope(t *testing.T, db *gorm.DB, code string) (plans *string, annualOnly bool) {
+	t.Helper()
+	var got struct {
+		AllowedPlans *string
+		AnnualOnly   bool
+	}
+	require.NoError(t, db.Raw(
+		`SELECT allowed_plans::text AS allowed_plans, annual_only FROM promo_codes WHERE code = ?`,
+		code,
+	).Scan(&got).Error)
+	return got.AllowedPlans, got.AnnualOnly
+}
+
+// TestUpsertCodes_RescopingAnIngestedCodeChangesTheRow is THE test for #795.
+func TestUpsertCodes_RescopingAnIngestedCodeChangesTheRow(t *testing.T) {
+	db := testdb.NewTx(t)
+	store := consolepromo.NewStore(db)
+
+	ingest(t, store, publish("RESCOPE50", []string{"pro"}, true))
+	plans, annualOnly := storedScope(t, db, "RESCOPE50")
+	require.NotNil(t, plans)
+	require.Equal(t, "{pro}", *plans, "the first publication's scope must land")
+	require.True(t, annualOnly)
+
+	// The operator re-scopes the same code in the console and it publishes
+	// again. The row already exists, so this is the upsert's UPDATE branch —
+	// the branch that used to preserve both columns.
+	ingest(t, store, publish("RESCOPE50", []string{"starter", "studio"}, false))
+
+	plans, annualOnly = storedScope(t, db, "RESCOPE50")
+	require.NotNil(t, plans)
+	require.Equal(t, "{starter,studio}", *plans,
+		"re-scoping an already-ingested code must overwrite allowed_plans, not preserve it")
+	require.False(t, annualOnly,
+		"clearing annual_only must land too; preserving it leaves the code annual-only forever")
+
+	var n int64
+	require.NoError(t, db.Raw(`SELECT count(*) FROM promo_codes WHERE code = ?`, "RESCOPE50").Scan(&n).Error)
+	require.EqualValues(t, 1, n, "a re-sync must update in place, not duplicate the code")
+}
+
+// TestUpsertCodes_WideningAScopeBackToEveryPlanStoresNull is the other
+// direction, and the one an "is it non-empty?" assertion would miss entirely:
+// an operator who removes the restriction must get NULL back, not the old scope
+// and not '{}'.
+func TestUpsertCodes_WideningAScopeBackToEveryPlanStoresNull(t *testing.T) {
+	db := testdb.NewTx(t)
+	store := consolepromo.NewStore(db)
+
+	ingest(t, store, publish("WIDENME50", []string{"pro"}, false))
+	ingest(t, store, publish("WIDENME50", nil, false))
+
+	plans, _ := storedScope(t, db, "WIDENME50")
+	require.Nil(t, plans,
+		"an unscoped publication must store NULL — '{}' means the same to the redeemer but reads as scoped")
+}
+
+// TestUpsertCodes_PreservesMark8lyOnlyPolicyColumns is decision 2 of the plan,
+// and the guard on the change made for decision 1. max_per_email and
+// min_effective_price_per_currency are abuse controls the console cannot
+// express (#726); adding two console-owned columns to upsertColumns must not
+// have quietly turned these into console-owned columns too.
+func TestUpsertCodes_PreservesMark8lyOnlyPolicyColumns(t *testing.T) {
+	db := testdb.NewTx(t)
+	store := consolepromo.NewStore(db)
+
+	ingest(t, store, publish("POLICY5050", []string{"pro"}, false))
+
+	// mark8ly tightens its own controls on the ingested row.
+	require.NoError(t, db.Exec(
+		`UPDATE promo_codes
+		    SET max_per_email = 5,
+		        min_effective_price_per_currency = '{"usd": 1000}'::jsonb
+		  WHERE code = ?`, "POLICY5050").Error)
+
+	ingest(t, store, publish("POLICY5050", []string{"starter"}, true))
+
+	var got struct {
+		MaxPerEmail int
+		MinPrice    string
+	}
+	require.NoError(t, db.Raw(
+		`SELECT max_per_email, min_effective_price_per_currency::text AS min_price
+		   FROM promo_codes WHERE code = ?`, "POLICY5050",
+	).Scan(&got).Error)
+	require.Equal(t, 5, got.MaxPerEmail,
+		"max_per_email is mark8ly policy; a console publication must not reset it")
+	require.JSONEq(t, `{"usd": 1000}`, got.MinPrice,
+		"min_effective_price_per_currency is mark8ly policy; a console publication must not clear it")
+
+	// …while the scope on the same row did move, so this test is not passing
+	// merely because the second upsert did nothing at all.
+	plans, annualOnly := storedScope(t, db, "POLICY5050")
+	require.NotNil(t, plans)
+	require.Equal(t, "{starter}", *plans)
+	require.True(t, annualOnly)
+}

--- a/services/marketplace-api/internal/promo/allowed_plans_integration_test.go
+++ b/services/marketplace-api/internal/promo/allowed_plans_integration_test.go
@@ -1,0 +1,78 @@
+//go:build integration
+
+package promo_test
+
+import (
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/promo"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// These tests pin how allowed_plans crosses the Go/Postgres boundary (#795).
+//
+// The column is text[]. Declaring the field with GORM's `serializer:json`
+// made every write of a non-empty scope fail outright:
+//
+//	ERROR: malformed array literal: "["pro","studio"]" (SQLSTATE 22P02)
+//
+// GORM marshalled the slice to a JSON document and handed Postgres a text
+// literal, which is not array syntax. It never surfaced because nothing had
+// ever written a scope — the column has only held NULL.
+//
+// The assertion that matters is the STORED REPRESENTATION, not that the write
+// returned no error: a future change that reintroduces a serializer would pass
+// a bare require.NoError just as happily. Only reading allowed_plans::text back
+// and demanding `{pro,studio}` pins the behaviour that was broken.
+
+// TestPromoCodes_AllowedPlansStoresAsPostgresArray is the regression guard.
+func TestPromoCodes_AllowedPlansStoresAsPostgresArray(t *testing.T) {
+	db := testdb.NewTx(t)
+
+	// promo_codes_has_benefit refuses a row that neither discounts nor
+	// extends, so the fixture must carry a benefit to reach the column
+	// under test at all.
+	pc := &promo.PromoCode{
+		Code:               "SCOPEDPLANS1",
+		TrialExtensionDays: ptr(14),
+		AllowedPlans:       pq.StringArray{"pro", "studio"},
+	}
+	require.NoError(t, insertPromoCode(db, pc),
+		"a plan-scoped code must insert; a JSON serializer makes this fail with 22P02")
+
+	var stored string
+	require.NoError(t, db.Raw(
+		`SELECT allowed_plans::text FROM promo_codes WHERE id = ?`, pc.ID,
+	).Scan(&stored).Error)
+	require.Equal(t, "{pro,studio}", stored,
+		"the column must hold a Postgres array literal, not a JSON document")
+
+	var got promo.PromoCode
+	require.NoError(t, db.Where("id = ?", pc.ID).First(&got).Error)
+	require.Equal(t, pq.StringArray{"pro", "studio"}, got.AllowedPlans,
+		"the scope must round-trip through GORM in order")
+}
+
+// TestPromoCodes_UnscopedCodeStoresNull pins the other half of the contract the
+// redeemer depends on. validator.go guards on len(AllowedPlans) > 0, so NULL
+// and '{}' are the same fact to it — but only one of them is written, and an
+// accidental '{}' would read as "scoped" to anything inspecting the column.
+func TestPromoCodes_UnscopedCodeStoresNull(t *testing.T) {
+	db := testdb.NewTx(t)
+
+	pc := &promo.PromoCode{Code: "UNSCOPEDCODE", TrialExtensionDays: ptr(7)}
+	require.NoError(t, insertPromoCode(db, pc))
+
+	var isNull bool
+	require.NoError(t, db.Raw(
+		`SELECT allowed_plans IS NULL FROM promo_codes WHERE id = ?`, pc.ID,
+	).Scan(&isNull).Error)
+	require.True(t, isNull, "an unscoped code must store NULL, never '{}'")
+
+	var got promo.PromoCode
+	require.NoError(t, db.Where("id = ?", pc.ID).First(&got).Error)
+	require.Empty(t, got.AllowedPlans, "NULL must read back as an empty scope")
+}

--- a/services/marketplace-api/internal/promo/model.go
+++ b/services/marketplace-api/internal/promo/model.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"gorm.io/datatypes"
 )
 
@@ -51,11 +52,16 @@ type PromoCode struct {
 	MaxRedemptions               *int           `gorm:"column:max_redemptions"`
 	MaxPerEmail                  int            `gorm:"column:max_per_email;not null;default:1"`
 	MinEffectivePricePerCurrency datatypes.JSON `gorm:"column:min_effective_price_per_currency;type:jsonb"`
-	AllowedPlans                 []string       `gorm:"column:allowed_plans;type:text[];serializer:json"`
-	AnnualOnly                   bool           `gorm:"column:annual_only;not null;default:false"`
-	CreatedBy                    string         `gorm:"column:created_by;not null"`
-	CreatedAt                    time.Time      `gorm:"column:created_at;not null;default:now()"`
-	UpdatedAt                    time.Time      `gorm:"column:updated_at;not null;default:now()"`
+	// AllowedPlans scopes the code to a set of plan ids; NULL/empty means
+	// every plan (validator.go guards on len() > 0). It must be
+	// pq.StringArray, not []string with a JSON serializer: the column is
+	// text[], and a serializer sends the JSON document as a text literal,
+	// which Postgres rejects with "malformed array literal" (#795).
+	AllowedPlans pq.StringArray `gorm:"column:allowed_plans;type:text[]"`
+	AnnualOnly   bool           `gorm:"column:annual_only;not null;default:false"`
+	CreatedBy    string         `gorm:"column:created_by;not null"`
+	CreatedAt    time.Time      `gorm:"column:created_at;not null;default:now()"`
+	UpdatedAt    time.Time      `gorm:"column:updated_at;not null;default:now()"`
 }
 
 // TableName returns the database table name for GORM.


### PR DESCRIPTION
Closes #795.

tesserix-home#593 shipped the authoring half: the console publishes `allowed_plans` and `annual_only` on `/api/v1/promo-catalog`, and an operator can scope a code to Pro-only or annual-only today. mark8ly read neither. Two separate things were wrong.

## 1. `allowed_plans` could not be written at all

`internal/promo/model.go` declared the field as `[]string` with `gorm:"type:text[];serializer:json"`. GORM marshalled the slice to a JSON document and handed Postgres a text literal, which is not array syntax:

```
ERROR: malformed array literal: "["pro","studio"]" (SQLSTATE 22P02)
```

Every write of a non-empty scope failed outright. It never surfaced because nothing had ever written one — the column has only ever held NULL. It is now `pq.StringArray`, matching the other five array columns in this service.

The regression test asserts the **stored representation**, not that the write succeeded. `require.NoError` after the fix would pass just as happily against a future change that reintroduces a serializer; only reading `allowed_plans::text` back and demanding `{pro,studio}` pins the behaviour that was broken.

## 2. The ingest deliberately preserved both columns

`consolepromo/store.go`'s `upsertColumns` omitted `allowed_plans` and `annual_only`, and the upsert assigns only listed columns — so an existing row kept whatever it already held. A **new** code got the console's scope from the INSERT, which is why first-ingest coverage would have looked fine. An operator narrowing an already-ingested code got silence, and the code went on applying to every plan and both periods.

Both columns are now console-owned and join `upsertColumns`, consistent with the reasoning already written for `valid_until` directly below them: a console publication is the last word.

### What did NOT change

`max_per_email` and `min_effective_price_per_currency` stay preserved. They are mark8ly's own abuse controls (§7.3, §7.4) that the console deliberately cannot express (#726), so a publication says nothing about them and must not clear them. `upsertColumns`' comment previously described all four omitted columns as one rule; it now describes the two distinct rules that actually apply, so it cannot justify the wrong change to whoever reads it next.

### Plan vocabulary

`knownPlans` is derived from `pricing.AllDescriptors()` rather than restated as three literals, so a plan added to or renamed in the price catalog cannot leave a stale list here rejecting a legitimate scope. plangate's `trial` is correctly absent — it has no Price object and the console does not offer it as a scope.

An unrecognised plan **rejects the whole definition**, arriving as a counted `skipped` row with reason `unknown_plan`. Storing it would scope the code to something nothing can ever be on: dead at redemption, and reading as correctly configured to anyone looking. The rest of the batch is still written, and the rejected code is still kept rather than expired.

`null` means every plan; `{}` is never written. The redeemer guards on `len(AllowedPlans) > 0`, so `{}` and NULL are the same fact to it — but only one spelling may cross the boundary, since `{}` reads as "scoped" to anything inspecting the column by eye.

## Test plan

- [x] `go build ./...` and `go build -tags=integration ./...`
- [x] `go vet ./...` and `go vet -tags=integration ./...`
- [x] `go test ./internal/billing/consolepromo/ ./internal/promo/` — 142 pass
- [x] Same two packages with `-tags=integration` and `TEST_DATABASE_URL` set against Postgres 15 — 156 pass, 0 skipped, 0 failed. Integration tests **ran**; with the variable unset they skip, and a green run then means nothing.
- [x] Mutation-checked the re-scope test both ways: removing `allowed_plans` from `upsertColumns` fails it on `{pro} != {starter,studio}`; removing `annual_only` fails it on the annual-only assertion. Restored, green again.
