### PR TITLE
chore: delete a dead coupon path, stop discarding the Tax ID, retire the billing setup CTA

### DIFF
--- a/apps/admin/app/(admin)/settings/billing/BillingClient.tsx
+++ b/apps/admin/app/(admin)/settings/billing/BillingClient.tsx
@@ -5,7 +5,6 @@ import { Skeleton } from '@tesserix/web'
 import { useToast } from '@/components/feedback/Toaster'
 import { ApiError, SubscriptionInactiveError } from '@/lib/api/client'
 import {
-  useBootstrapSubscription,
   useCurrentPlan,
 } from '@/lib/api/subscription/hooks/useBilling'
 import { subscriptionCopy } from '@/lib/copy/subscription'
@@ -35,52 +34,6 @@ function PanelSkeleton() {
       <Skeleton className="h-4 w-52 rounded-md" />
       <Skeleton className="h-10 w-32 rounded-md" />
     </div>
-  )
-}
-
-// ─── Setup panel ──────────────────────────────────────────────────────────────
-
-interface SetupPanelProps {
-  onSetup: () => void
-  isPending: boolean
-  errorMessage: string | null
-}
-
-// Shown when GET subscription returns 404 — the store predates the v2.3
-// signup pipeline so no row exists yet. Single primary CTA creates the
-// Stripe customer + row on demand.
-function SetupPanel({ onSetup, isPending, errorMessage }: SetupPanelProps) {
-  return (
-    <section
-      aria-labelledby="billing-setup-heading"
-      className="border-b border-[var(--hairline,var(--ink-100))] pb-10"
-    >
-      <h2
-        id="billing-setup-heading"
-        className="font-serif text-2xl font-medium tracking-tight text-[var(--ink-900)]"
-      >
-        {copy.setupHeading}
-      </h2>
-      <p className="mt-3 max-w-xl text-sm leading-6 text-[var(--ink-700)]">
-        {copy.setupDescription}
-      </p>
-      <div className="mt-6">
-        <button
-          type="button"
-          onClick={onSetup}
-          disabled={isPending}
-          aria-busy={isPending}
-          className="inline-flex h-10 items-center rounded-md bg-[var(--ink-900)] px-5 text-sm font-medium text-white transition-colors hover:bg-[var(--ink-900)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {isPending ? copy.setupInProgress : copy.setupCta}
-        </button>
-      </div>
-      {errorMessage && (
-        <p role="alert" className="mt-4 text-sm text-[var(--danger,#7a1a1a)]">
-          {errorMessage}
-        </p>
-      )}
-    </section>
   )
 }
 
@@ -121,16 +74,14 @@ function ErrorPanel({ message, onRetry }: ErrorPanelProps) {
  */
 export function BillingClient({ storeId }: BillingClientProps) {
   const { data: plan, isLoading, error, refetch } = useCurrentPlan(storeId)
-  const bootstrap = useBootstrapSubscription(storeId)
   const { toast } = useToast()
 
   const isNotFound = error instanceof ApiError && error.status === 404
 
   // Fire the ApiError toast as a side-effect, not during render. Calling
   // toast.error() inline on every render triggered an infinite re-render loop
-  // because the toast store update re-rendered this component. 404 is an
-  // expected state (pre-v2.3 store needs bootstrap) — don't surface it as a
-  // scary toast.
+  // because the toast store update re-rendered this component. 404 gets its
+  // own panel below rather than a toast.
   useEffect(() => {
     if (error instanceof ApiError && error.status !== 404) {
       toast.error(error.message ?? copy.loadingError)
@@ -161,25 +112,18 @@ export function BillingClient({ storeId }: BillingClientProps) {
       )
     }
 
-    // 404: the store predates the v2.3 signup pipeline — show the bootstrap CTA.
+    // 404: no subscription row for this store.
+    //
+    // This used to be an expected state with a "Set up billing" button, back
+    // when nothing created the row at signup and the merchant had to press it
+    // themselves — which is also what made the 90-day trial start on that
+    // press (#827). Onboarding now creates the row, so a 404 here is OUR bug,
+    // not a step the merchant has left undone, and asking them to run our
+    // data migration would misreport whose problem it is.
     if (isNotFound) {
       return (
         <div className="space-y-10">
-          <SetupPanel
-            onSetup={() =>
-              bootstrap.mutate(undefined, {
-                onSuccess: () => {
-                  void refetch()
-                },
-              })
-            }
-            isPending={bootstrap.isPending}
-            errorMessage={
-              bootstrap.error instanceof Error
-                ? bootstrap.error.message
-                : null
-            }
-          />
+          <ErrorPanel message={copy.missingSubscription} onRetry={() => void refetch()} />
         </div>
       )
     }

--- a/apps/admin/app/api/admin/stores/[storeId]/subscription/bootstrap/route.ts
+++ b/apps/admin/app/api/admin/stores/[storeId]/subscription/bootstrap/route.ts
@@ -1,9 +1,0 @@
-import { proxyAdminApi } from "@/lib/api/server/proxyAdminApi";
-
-export async function POST(
-  request: Request,
-  { params }: { params: Promise<{ storeId: string }> },
-): Promise<Response> {
-  const { storeId } = await params;
-  return proxyAdminApi(request, `stores/${storeId}/subscription/bootstrap`);
-}

--- a/apps/admin/lib/api/subscription/billing.ts
+++ b/apps/admin/lib/api/subscription/billing.ts
@@ -22,9 +22,10 @@ import {
  * The response is validated with Zod. Throws on network or API errors —
  * callers should handle via React Query's error state.
  *
- * A 404 on this endpoint is not an error: it means the store predates
- * the v2.3 signup pipeline and has no store_subscriptions row yet. The
- * billing page has its own bootstrap flow to remediate. Every OTHER
+ * A 404 on this endpoint means the store has no store_subscriptions row.
+ * Since #827 onboarding creates that row at signup, so a 404 is a data
+ * problem rather than a state the merchant can resolve — the billing page
+ * says so, and no longer offers a button to create one. Every OTHER
  * admin page — Shipping, Payments, Products, etc. — mounts the shell
  * BannerStack which calls this via useCurrentPlan, so we must NOT
  * pollute the console with a 404 on every navigation. Returning null
@@ -58,25 +59,9 @@ export async function getSubscription(
  * Note: the Go handler returns `{ url: string }` (not `portal_url`).
  */
 /**
- * Idempotently initialise the store_subscriptions row for a store that
- * predates the v2.3 signup pipeline. The admin billing page calls this
- * when getSubscription() 404s so the merchant can proceed without
- * platform intervention.
- */
-export async function bootstrapSubscription(
-  storeId: string,
-): Promise<CurrentPlan> {
-  const raw = await apiClient.post<unknown>(
-    `/api/admin/stores/${storeId}/subscription/bootstrap`,
-    null,
-  )
-  const parsed = subscriptionResponseSchema.parse(raw)
-  return toCurrentPlan(parsed)
-}
-
-/**
  * Fetch up to 25 most-recent invoices for the store's Stripe customer.
- * Pre-bootstrap stores return an empty list (no Stripe customer yet).
+ * A store with no Stripe customer yet returns an empty list — since #827 a
+ * subscription row deliberately starts without one.
  */
 export async function listInvoices(storeId: string): Promise<Invoice[]> {
   const raw = await apiClient.get<unknown>(

--- a/apps/admin/lib/api/subscription/hooks/useBilling.ts
+++ b/apps/admin/lib/api/subscription/hooks/useBilling.ts
@@ -11,7 +11,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { UseQueryResult, UseMutationResult } from '@tanstack/react-query'
 import {
-  bootstrapSubscription,
   getSubscription,
   listInvoices,
   openPortal,
@@ -40,28 +39,11 @@ export function useCurrentPlan(
   })
 }
 
-/**
- * Initialises the subscription row for a store that predates the v2.3
- * signup pipeline. On success seeds the ['subscription', storeId] cache
- * with the new row so the UI immediately swaps from the "not found" CTA
- * to the normal billing view.
- */
-export function useBootstrapSubscription(
-  storeId: string,
-): UseMutationResult<CurrentPlan, Error, void> {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    mutationFn: () => bootstrapSubscription(storeId),
-    onSuccess: (data) => {
-      queryClient.setQueryData<CurrentPlan>(['subscription', storeId], data)
-    },
-  })
-}
 
 /**
  * Fetches up to 25 most-recent invoices for the store's Stripe customer.
- * Pre-bootstrap stores resolve to an empty array (no Stripe customer yet).
+ * A store with no Stripe customer yet resolves to an empty array — since
+ * #827 a subscription row deliberately starts without one.
  */
 export function useInvoices(storeId: string): UseQueryResult<Invoice[], Error> {
   return useQuery({

--- a/apps/admin/lib/copy/subscription.ts
+++ b/apps/admin/lib/copy/subscription.ts
@@ -154,12 +154,16 @@ export const subscriptionCopy = {
       'Add the white-label app to publish iOS and Android builds of your storefront.',
     whiteLabelAppAddCta: 'Add white-label app',
 
-    // ─── Setup / first-run ──────────────────────────────────────────────
-    setupHeading: 'Set up billing',
-    setupDescription:
-      'Finish setting up your billing account to see your plan, payment method, and invoices.',
-    setupCta: 'Set up billing',
-    setupInProgress: 'Setting up\u2026',
+    // ─── Missing subscription row ───────────────────────────────────────
+    //
+    // Replaced the old "Set up billing" CTA (#827). That button existed
+    // because nothing created a subscription row at signup, so every store
+    // arrived here needing one — and pressing it was what started the 90-day
+    // trial. Onboarding creates the row now, so a store without one is our
+    // data problem, and the copy says so rather than handing the merchant a
+    // button to run our migration.
+    missingSubscription:
+      'We can\u2019t find your billing details. This is on our side \u2014 contact us and we\u2019ll put it right.',
 
     // ─── Error / loading states ─────────────────────────────────────────
     loadingError: 'Something went wrong loading your plan.',

--- a/apps/onboarding/app/onboarding/actions.ts
+++ b/apps/onboarding/app/onboarding/actions.ts
@@ -103,8 +103,9 @@ interface SubmitInput {
   countryCode: string;
   currencyCode: string;
   timezone: string;
-  // §5.1.1 — optional; persisted to draft so completeOnboarding can
-  // forward them to the backend tax-ID endpoint once the store exists.
+  // §5.1.1 — optional; persisted to the draft and forwarded by
+  // completeOnboarding, which is where it reaches marketplace-api and is
+  // stored against the subscription row (unvalidated).
   taxId?: string;
   // §620 — optional; persisted to the draft so completeOnboarding can hand it
   // to marketplace-api, which redeems it once the subscription row exists.
@@ -125,10 +126,14 @@ export async function submitOnboarding(
     // Persist the business fields into the session draft so the
     // /onboarding/set-password page (reached after the magic link click)
     // can read them server-side without depending on per-tab state.
-    // §5.1.1: include migration fast-path evidence in the draft so
-    // completeOnboarding can forward them to the tax-ID endpoint once
-    // the store row has been created.  Fields absent when "new store"
-    // is selected are simply omitted — the backend ignores them.
+    // §5.1.1: include the tax ID and the migration fast-path evidence.
+    // completeOnboarding forwards the tax ID to marketplace-api, which
+    // stores it against the subscription row once that row exists.
+    // Fields absent when "new store" is selected are simply omitted —
+    // the backend ignores them.
+    //
+    // The migration evidence is still draft-only: nothing reads whois_url
+    // or screenshot_url after this point.
     const draft: Record<string, unknown> = {
       business_name: input.businessName,
       slug: input.slug,
@@ -270,6 +275,10 @@ export async function completeOnboardingWithZitadel(
     // the earliest moment redemption is possible, since the ledger row needs
     // a subscription id and the trial extension needs a row to move (#620).
     const promoCode = draft.promo_code ?? "";
+    // Held in the draft since §5.1.1 and, until now, read by nothing.
+    // marketplace-api stores it against the subscription row with
+    // tax_id_validated left false; the tax service validates it later.
+    const taxId = draft.tax_id ?? "";
 
     if (!businessName || !slug || !countryCode || !currencyCode) {
       return {
@@ -298,6 +307,7 @@ export async function completeOnboardingWithZitadel(
       first_name: firstName,
       last_name: lastName,
       ...(promoCode ? { promo_code: promoCode } : {}),
+      ...(taxId ? { tax_id: taxId } : {}),
     });
 
     return {

--- a/apps/onboarding/lib/api/platform-api.ts
+++ b/apps/onboarding/lib/api/platform-api.ts
@@ -137,6 +137,14 @@ export const onboarding = {
        *  subscription row — the earliest moment redemption is possible,
        *  since the ledger row needs a subscription id. */
       promo_code?: string;
+      /** The Tax ID the merchant typed on the form, unvalidated.
+       *
+       *  Sent because signup is the only point it is known. It was written
+       *  to the session draft from §5.1.1 onward and read by nobody:
+       *  platform-api had no `tax_id` at all, and marketplace-api's
+       *  reverse_charge_tax_id column had no writer anywhere in the tree
+       *  while two consumers read it. */
+      tax_id?: string;
     },
   ) =>
     request<CompleteResult>(

--- a/services/marketplace-api/internal/billing/stripe/coupon.go
+++ b/services/marketplace-api/internal/billing/stripe/coupon.go
@@ -4,89 +4,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 
 	sdk "github.com/stripe/stripe-go/v82"
 )
 
-// Coupon is our sanitised representation of a Stripe Coupon object.
-type Coupon struct {
-	ID               string   `json:"id"`
-	PercentOff       *float64 `json:"percent_off,omitempty"`
-	AmountOff        *int64   `json:"amount_off,omitempty"`
-	Currency         string   `json:"currency,omitempty"`
-	DurationInMonths *int64   `json:"duration_in_months,omitempty"`
-	Duration         string   `json:"duration"`
-	MaxRedemptions   *int64   `json:"max_redemptions,omitempty"`
-	Valid            bool     `json:"valid"`
-}
-
-// CreateCouponInput holds the parameters for creating a Stripe Coupon.
-type CreateCouponInput struct {
-	// ID is the Stripe coupon ID to create (must be unique in Stripe).
-	// If empty, Stripe auto-generates one.
-	ID               string
-	PercentOff       *float64 // 0–100; mutually exclusive with AmountOff
-	AmountOff        *int64   // minor units; mutually exclusive with PercentOff
-	Currency         string   // required when AmountOff is set
-	Duration         string   // "once" | "repeating" | "forever"
-	DurationInMonths *int64   // required when Duration == "repeating"
-	MaxRedemptions   *int64
-	Name             string
-	IdempotencyKey   string
-}
-
-// CreateCoupon creates a new Stripe Coupon.
-func CreateCoupon(ctx context.Context, c *Client, in CreateCouponInput) (*Coupon, error) {
-	params := &sdk.CouponCreateParams{}
-	if in.ID != "" {
-		params.ID = sdk.String(in.ID)
-	}
-	if in.PercentOff != nil {
-		params.PercentOff = in.PercentOff
-	}
-	if in.AmountOff != nil {
-		params.AmountOff = in.AmountOff
-		if in.Currency != "" {
-			params.Currency = sdk.String(in.Currency)
-		}
-	}
-	if in.Duration != "" {
-		params.Duration = sdk.String(in.Duration)
-	}
-	if in.DurationInMonths != nil {
-		params.DurationInMonths = in.DurationInMonths
-	}
-	if in.MaxRedemptions != nil {
-		params.MaxRedemptions = in.MaxRedemptions
-	}
-	if in.Name != "" {
-		params.Name = sdk.String(in.Name)
-	}
-	if in.IdempotencyKey != "" {
-		params.SetIdempotencyKey(in.IdempotencyKey)
-	}
-
-	cu, err := c.sdk.V1Coupons.Create(ctx, params)
-	if err != nil {
-		return nil, toAPIError(err)
-	}
-	return mapCoupon(cu), nil
-}
-
-// GetCoupon retrieves a Stripe Coupon by ID.
-// Returns ErrNotFound when the Stripe API returns HTTP 404.
-func GetCoupon(ctx context.Context, c *Client, id string) (*Coupon, error) {
-	cu, err := c.sdk.V1Coupons.Retrieve(ctx, id, nil)
-	if err != nil {
-		var se *sdk.Error
-		if errors.As(err, &se) && se.HTTPStatusCode == http.StatusNotFound {
-			return nil, ErrNotFound
-		}
-		return nil, toAPIError(err)
-	}
-	return mapCoupon(cu), nil
-}
+// This file holds the SUBSCRIPTION-DISCOUNT half of Stripe coupon handling.
+//
+// Coupon CREATION used to live here too — CreateCoupon, GetCoupon, the Coupon
+// DTO and a CouponIdempotencyKey helper — and none of it was ever called.
+// mark8ly#620 settled why: the tesserix-home console mints coupons and records
+// the id against the promo definition, and mark8ly only ever ATTACHES an
+// existing coupon to a subscription. Deleted rather than left in place,
+// because a second minting path that looks usable is how two systems end up
+// creating coupons for the same code.
+//
+// If mark8ly ever needs to mint one, that is a decision to make deliberately
+// and not by finding a dormant function.
 
 // maxSubscriptionDiscounts is Stripe's cap on the size of a subscription's
 // discounts array. Enforced here so a full subscription is reported with its
@@ -269,35 +202,4 @@ func RemoveSubscriptionDiscount(ctx context.Context, c *Client, subID, couponID 
 		return err
 	}
 	return putSubscriptionDiscounts(ctx, c, subID, discounts)
-}
-
-func mapCoupon(cu *sdk.Coupon) *Coupon {
-	out := &Coupon{
-		ID:       cu.ID,
-		Duration: string(cu.Duration),
-		Valid:    cu.Valid,
-	}
-	if cu.PercentOff != 0 {
-		v := cu.PercentOff
-		out.PercentOff = &v
-	}
-	if cu.AmountOff != 0 {
-		v := cu.AmountOff
-		out.AmountOff = &v
-		out.Currency = string(cu.Currency)
-	}
-	if cu.DurationInMonths != 0 {
-		v := cu.DurationInMonths
-		out.DurationInMonths = &v
-	}
-	if cu.MaxRedemptions != 0 {
-		v := cu.MaxRedemptions
-		out.MaxRedemptions = &v
-	}
-	return out
-}
-
-// CouponIdempotencyKey returns a stable idempotency key for coupon creation.
-func CouponIdempotencyKey(promoCodeID string) string {
-	return "coupon:" + promoCodeID
 }

--- a/services/marketplace-api/internal/subscription/bootstrap_test.go
+++ b/services/marketplace-api/internal/subscription/bootstrap_test.go
@@ -270,3 +270,60 @@ func TestEnsureStripeCustomer_RefusesWithNoStripeConfigured(t *testing.T) {
 		t.Fatal("EnsureStripeCustomer succeeded with no Stripe client")
 	}
 }
+
+// The Tax ID has been collected on the onboarding form since §5.1.1 and
+// stored nowhere: reverse_charge_tax_id had no writer anywhere in the tree,
+// while the revalidation cron and the reverse-charge invoice annotation both
+// read it. Signup is the only point the value is known.
+func TestBootstrap_StoresTheTaxIDTheMerchantSupplied(t *testing.T) {
+	repo := &bootstrapRepo{}
+	svc := newSvc(repo, nil)
+
+	in := bootstrapInput()
+	in.TaxID = "GB123456789"
+	in.TaxIDCountry = "gb"
+
+	sub, err := svc.Bootstrap(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if sub.ReverseChargeTaxID == nil || *sub.ReverseChargeTaxID != "GB123456789" {
+		t.Fatalf("ReverseChargeTaxID = %v, want GB123456789", sub.ReverseChargeTaxID)
+	}
+	if sub.TaxIDCountry == nil || *sub.TaxIDCountry != "GB" {
+		t.Fatalf("TaxIDCountry = %v, want GB (upper-case, CHAR(2))", sub.TaxIDCountry)
+	}
+	// The claim is unchecked, and must be recorded as unchecked. Both
+	// downstream consumers gate on this flag, so a true here would put an
+	// unverified id onto a reverse-charge invoice.
+	if sub.TaxIDValidated {
+		t.Error("an unvalidated tax id was recorded as validated")
+	}
+}
+
+// Half a tax id is worse than none: the validator dispatches on country and
+// the invoice annotation prints the pair, so a value with no country reads as
+// present and can never be used.
+func TestBootstrap_StoresNeitherHalfOfAnIncompleteTaxID(t *testing.T) {
+	for _, tc := range []struct{ name, id, country string }{
+		{"id with no country", "GB123456789", ""},
+		{"country with no id", "", "GB"},
+		{"malformed country", "GB123456789", "GBR"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newSvc(&bootstrapRepo{}, nil)
+			in := bootstrapInput()
+			in.TaxID = tc.id
+			in.TaxIDCountry = tc.country
+
+			sub, err := svc.Bootstrap(context.Background(), in)
+			if err != nil {
+				t.Fatalf("Bootstrap: %v", err)
+			}
+			if sub.ReverseChargeTaxID != nil || sub.TaxIDCountry != nil {
+				t.Errorf("stored a partial tax id: id=%v country=%v",
+					sub.ReverseChargeTaxID, sub.TaxIDCountry)
+			}
+		})
+	}
+}

--- a/services/marketplace-api/internal/subscription/internal_handler.go
+++ b/services/marketplace-api/internal/subscription/internal_handler.go
@@ -160,6 +160,14 @@ type ensureSubscriptionRequest struct {
 	// PromoCode is what the merchant typed at onboarding, if anything (#620).
 	// Empty is the normal case.
 	PromoCode string `json:"promo_code"`
+	// TaxID is what the merchant typed in onboarding's Tax ID field,
+	// unvalidated. Its country comes from the store, so the caller sends only
+	// the id.
+	TaxID string `json:"tax_id"`
+	// CountryCode is the store's ISO 3166-1 alpha-2 country, used as the tax
+	// id's jurisdiction. Distinct from Currency: a store can bill in a
+	// currency other than its own country's.
+	CountryCode string `json:"country_code"`
 }
 
 func (h *InternalHandler) ensureSubscription(c *gin.Context) {
@@ -188,6 +196,8 @@ func (h *InternalHandler) ensureSubscription(c *gin.Context) {
 		Email:           req.Email,
 		Name:            req.Name,
 		BillingCurrency: req.Currency,
+		TaxID:           req.TaxID,
+		TaxIDCountry:    req.CountryCode,
 	})
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{

--- a/services/marketplace-api/internal/subscription/internal_handler_test.go
+++ b/services/marketplace-api/internal/subscription/internal_handler_test.go
@@ -384,3 +384,26 @@ func TestValidatePromoForSignup_RefusesWithoutTheInternalSecret(t *testing.T) {
 		t.Fatal("validated a code for a request that failed the guard")
 	}
 }
+
+// The Tax ID has to survive the hop, with the store's country as its
+// jurisdiction. Before this it was collected on the form and read by nobody.
+func TestEnsureSubscription_CarriesTheTaxIDAndItsCountry(t *testing.T) {
+	svc := &stubBootstrapper{}
+	rec := httptest.NewRecorder()
+	promoRouter(t, svc, nil).ServeHTTP(rec, ensureReq(t, uuid.New(), map[string]any{
+		"tenant_id":    uuid.New().String(),
+		"currency":     "gbp",
+		"country_code": "GB",
+		"tax_id":       "GB123456789",
+	}, testInternalSecret))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if len(svc.calls) != 1 {
+		t.Fatalf("Bootstrap called %d times, want 1", len(svc.calls))
+	}
+	if got := svc.calls[0]; got.TaxID != "GB123456789" || got.TaxIDCountry != "GB" {
+		t.Errorf("tax id = %q/%q, want GB123456789/GB", got.TaxID, got.TaxIDCountry)
+	}
+}

--- a/services/marketplace-api/internal/subscription/service.go
+++ b/services/marketplace-api/internal/subscription/service.go
@@ -73,6 +73,22 @@ type BootstrapInput struct {
 	// what every reader already treats as "not known yet"; "" would be a
 	// third meaning nothing tests for.
 	BillingCurrency string
+	// TaxID and TaxIDCountry are what the merchant typed in onboarding's Tax
+	// ID field, unvalidated.
+	//
+	// Stored here because nothing else ever stored them. The field has been
+	// on the form since §5.1.1 and was written to the onboarding draft and
+	// read by nobody; reverse_charge_tax_id had no writer anywhere in the
+	// tree, while the revalidation cron and the reverse-charge invoice
+	// annotation both READ it. This closes that gap at the only point the
+	// value is known.
+	//
+	// tax_id_validated stays false — its default. Both downstream consumers
+	// gate on it (invoice_finalized.go, revalidation/cron.go), so an
+	// unvalidated id changes no behaviour until the tax service validates it.
+	// Recording an unchecked claim as checked is the one thing that would.
+	TaxID        string
+	TaxIDCountry string
 }
 
 // Bootstrap idempotently initialises a store_subscriptions row: plan=trial,
@@ -122,6 +138,16 @@ func (s *Service) Bootstrap(ctx context.Context, in BootstrapInput) (*StoreSubsc
 	}
 	if cur := strings.ToLower(strings.TrimSpace(in.BillingCurrency)); cur != "" {
 		row.BillingCurrency = &cur
+	}
+	// Both or neither: a tax id without its country cannot be validated (the
+	// validator dispatches on country) and cannot be rendered on a
+	// reverse-charge invoice, which prints the pair. Storing half of it would
+	// leave a value that reads as present and can never be used.
+	taxID := strings.TrimSpace(in.TaxID)
+	taxCountry := strings.ToUpper(strings.TrimSpace(in.TaxIDCountry))
+	if taxID != "" && len(taxCountry) == 2 {
+		row.ReverseChargeTaxID = &taxID
+		row.TaxIDCountry = &taxCountry
 	}
 	if err := s.repo.Create(ctx, s.db, row); err != nil {
 		return nil, fmt.Errorf("bootstrap: create subscription row: %w", err)

--- a/services/platform-api/internal/marketplaceapi/vendor_client.go
+++ b/services/platform-api/internal/marketplaceapi/vendor_client.go
@@ -195,6 +195,14 @@ type EnsureSubscription struct {
 	// (mark8ly#620). Redeemed on the far side, immediately after the row is
 	// created — the earliest moment redemption is possible at all.
 	PromoCode string `json:"promo_code,omitempty"`
+	// TaxID is what the merchant typed in onboarding's Tax ID field,
+	// unvalidated. Sent because signup is the only point it is known:
+	// marketplace-api's reverse_charge_tax_id column had no writer anywhere,
+	// while its revalidation cron and reverse-charge invoice annotation both
+	// read it (mark8ly#620 follow-up).
+	TaxID string `json:"tax_id,omitempty"`
+	// CountryCode is the store's country, the tax id's jurisdiction.
+	CountryCode string `json:"country_code,omitempty"`
 }
 
 // SignupPromoOffer is what a promo code granted, or why it was refused.

--- a/services/platform-api/internal/onboarding/completion_integration_test.go
+++ b/services/platform-api/internal/onboarding/completion_integration_test.go
@@ -681,3 +681,64 @@ func TestIntegration_Complete_NoPromoCodeStaysEmpty(t *testing.T) {
 		t.Errorf("PromoCode = %q, want empty", got)
 	}
 }
+
+// The Tax ID reaches marketplace-api, with the store's country as its
+// jurisdiction. Before this it was written to the onboarding draft and read by
+// nobody: platform-api had no tax_id anywhere, and marketplace-api's
+// reverse_charge_tax_id column had no writer at all.
+func TestIntegration_Complete_CarriesTheTaxID(t *testing.T) {
+	db := testdb.NewDB(t,
+		"outbox_events",
+		"verification_tokens",
+		"onboarding_sessions",
+		"tenants",
+	)
+
+	onboardingRepo := NewRepository(db)
+	fake := &fakeVendorClient{}
+	svc := NewService(Config{
+		DB: db, Repo: onboardingRepo, TenantRepo: tenant.NewRepository(db),
+		Sender: notification.NoopSender{}, EmailFrom: "noreply@test.local",
+		SupportEmail: "help@test.local", VendorClient: fake,
+	})
+
+	ctx := context.Background()
+	now := time.Now()
+	sess := &Session{
+		Email:           "tax-id@test.local",
+		Draft:           json.RawMessage(`{}`),
+		Status:          StatusInProgress,
+		EmailVerifiedAt: &now,
+	}
+	if err := onboardingRepo.Create(ctx, sess); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	if _, err := svc.Complete(ctx, CompleteRequest{
+		SessionID:    sess.ID,
+		BusinessName: "Tax ID Co",
+		Slug:         "tax-id-co",
+		OwnerUserID:  "gip-uid-tax-id",
+		OwnerEmail:   "tax-id@test.local",
+		TaxID:        "GB123456789",
+		CountryCode:  "GB",
+		CurrencyCode: "GBP",
+		Timezone:     "Europe/London",
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	if len(fake.subCalls) != 1 {
+		t.Fatalf("EnsureSubscription called %d times, want 1", len(fake.subCalls))
+	}
+	got := fake.subCalls[0]
+	if got.TaxID != "GB123456789" {
+		t.Errorf("TaxID = %q — the merchant filled the field and it was dropped", got.TaxID)
+	}
+	// The country is the tax id's jurisdiction and comes from the STORE, not
+	// from the currency: a store can bill in a currency other than its own
+	// country's, and the validator dispatches on country.
+	if got.CountryCode != "GB" {
+		t.Errorf("CountryCode = %q, want GB", got.CountryCode)
+	}
+}

--- a/services/platform-api/internal/onboarding/service.go
+++ b/services/platform-api/internal/onboarding/service.go
@@ -260,7 +260,11 @@ type CompleteRequest struct {
 	// travels with completion rather than being redeemed earlier because
 	// redemption needs a subscription row, and that row is created as part of
 	// this call (mark8ly#620, mark8ly#827).
-	PromoCode    string `json:"promo_code"`
+	PromoCode string `json:"promo_code"`
+	// TaxID is what the merchant typed in onboarding's Tax ID field. Carried
+	// to marketplace-api, which stores it against the subscription row with
+	// tax_id_validated left false.
+	TaxID        string `json:"tax_id"`
 	CountryCode  string `json:"country_code"`
 	CurrencyCode string `json:"currency_code"`
 	Timezone     string `json:"timezone"`
@@ -496,6 +500,11 @@ func (s *Service) Complete(ctx context.Context, req CompleteRequest) (*CompleteR
 			// (mark8ly#620). A refused code does not fail this call: the
 			// outcome comes back in the response and is logged.
 			PromoCode: req.PromoCode,
+			// Unvalidated, and recorded as such on the far side. The tax
+			// service validates it later; this only stops the merchant's
+			// answer being thrown away.
+			TaxID:       req.TaxID,
+			CountryCode: st.CountryCode,
 		}); subErr != nil {
 			log.Printf("onboarding.Complete: ensure subscription for tenant %s store %s: %v — THIS STORE HAS NO TRIAL CLOCK",
 				t.ID, st.ID, subErr)


### PR DESCRIPTION
Three dead or half-connected paths, found while working #620 and #827.

## 1. The coupon-minting path mark8ly never uses

`internal/billing/stripe/coupon.go` carried `CreateCoupon`, `GetCoupon`, a `Coupon` DTO, `mapCoupon` and `CouponIdempotencyKey`. **None had a single caller** — not in the tree, not in tests. The only other `CreateCoupon` hits are `internal/handlers/admin`'s storefront coupons, an unrelated concept and exactly the naming hazard #620 warned about.

#620 settled the question: the tesserix-home console mints coupons and records the id against the promo definition; mark8ly only ever *attaches* an existing coupon to a subscription. So this is deleted rather than left in place — a second minting path that looks usable is how two systems end up creating coupons for the same code. The subscription-discount helpers beside it are live and untouched.

## 2. The Tax ID was collected and thrown away

A merchant fills in the Tax ID field at onboarding. It was written to the session draft and **read by nobody**: platform-api has no `tax_id` anywhere, and the Next action's comment claiming completion "forwards them to the backend tax-ID endpoint" was simply untrue.

It is worse than a dropped field. `store_subscriptions.reverse_charge_tax_id` **had no writer anywhere in the tree** — while two consumers read it:

```
internal/billing/dispatch/invoice_finalized.go:64   reverse-charge invoice annotation
internal/billing/tax/revalidation/cron.go:138       COALESCE(reverse_charge_tax_id, '')
```

The tax Submit endpoint validates an ID against a registry and flips `tax_id_validated`, but never stores the ID it validated. So the reverse-charge chain has always been reading a column nothing fills.

Now the value travels signup → platform-api → marketplace-api and lands on the row, alongside `tax_id_country` taken from the **store** (not the currency — a store can bill in another country's currency, and the validator dispatches on country).

**`tax_id_validated` stays false**, its default. Both consumers gate on it, so an unvalidated claim changes no behaviour until the tax service validates it — and recording an unchecked claim as checked is the one thing that would. Stored as both-or-neither: an id without its country cannot be validated or rendered, so half of it would read as present and never be usable.

## 3. The "Set up billing" CTA

The admin Billing page answered a 404 with a button that created the subscription row on demand, described in its own comment as being for stores that "predate the v2.3 signup pipeline".

#827 established that the pipeline did not exist and #828 built it. Pressing that button was also **what started the 90-day trial**. Now that onboarding creates the row, a 404 here is our data problem, not a step the merchant left undone — so the button is gone and the panel says so instead of handing the merchant our migration to run.

Removed: the CTA and its panel, the React Query hook, the client function, the Next proxy route, and the setup copy.

### ⚠️ Ordering requirement

**This part must not ship before `cmd/backfill-trial-start` has run.** Every store created before #828 still has no subscription row, and this CTA is currently their only remedy — after this change they would see an error panel instead. The backfill is written and deliberately unrun pending your decision on the expired-trial rows (#827); that decision now gates this merge.

I have **kept the Go endpoint** (`POST /admin/stores/:storeId/subscription/bootstrap`) rather than deleting it in the same breath. It has no caller after this and should follow — but removing the last remediation path while row-less stores exist is a different risk from removing a button, and it deserves to be a deliberate second step.

## Test plan

- [x] `gofmt`, `go build`, `go vet` clean in both services; marketplace-api and platform-api suites green
- [x] `go vet -tags integration ./...` on platform-api
- [x] `apps/admin` and `apps/onboarding`: `tsc --noEmit` clean, **both `next build` green**
- [x] `apps/onboarding` 104 unit tests pass
- [x] New tests: Bootstrap stores the tax id upper-cased with `tax_id_validated` false; stores **neither** half of an incomplete pair (three cases); the internal callback carries id + country; `Complete` forwards both
- [x] Confirmed by grep that nothing referenced the deleted coupon symbols, and that no test pinned the removed setup copy
- [ ] `apps/admin` vitest: **2 pre-existing failures** in `tests/unit/api/subscription/appCredentials.test.ts` (multipart upload assertions). Verified they fail identically on clean `origin/main` with this branch stashed — unrelated to these changes, and they look environment-dependent rather than a real regression.

## Also noticed, not changed

`whois_url` and `screenshot_url` are written to the onboarding draft and read by nothing, the same shape the Tax ID had. The migration UI is behind `MIGRATION_UI_ENABLED`, so that may be deliberate parking rather than a gap — I have made the comment say what is actually true rather than guessing.
