### PR TITLE
feat(sso): implement the missing per-tenant SSO pieces, and fix two bugs the gaps were hiding (#820)

### DIFF
--- a/.planning/quick/260908-sso-wire-per-tenant/PLAN.md
+++ b/.planning/quick/260908-sso-wire-per-tenant/PLAN.md
@@ -1,0 +1,91 @@
+# Wire per-tenant SSO (#820)
+
+Both halves exist, are tested, and are registered behind a nil check that nothing
+ever fills — so neither route exists at runtime. Same shape as the break-glass
+login bug #642 was opened for.
+
+- Config side: `NewSSOConfigHandler` is never called in `main.go`, so a merchant
+  on the tier that pays for SSO has no way to configure it.
+- Login side: `TenantResolver` has no implementation, `OIDCRPs` is never
+  constructed, `loginSAML` is a stub.
+
+## The one design change this needs
+
+#820 suggests "build `OIDCRPs` at startup". **That would be wrong**, and the
+handler's `map[string]*sso.OIDCRelyingParty` field is the reason it reads as
+easy:
+
+- `BuildOIDCRelyingParty` performs OIDC **discovery** — a network call to the
+  tenant's issuer. Building the map at boot makes every tenant's IdP a startup
+  dependency: one slow or unreachable IdP delays or fails the whole service.
+- A map built at boot cannot contain a tenant who configures SSO afterwards. For
+  a self-serve feature that means "works after the next deploy", which is not
+  working.
+
+So the map becomes a **lazily-populated cache**, built per tenant on first use
+and invalidated when the config changes. Same handler behaviour, no startup
+coupling, and a config saved at 10:00 works at 10:00.
+
+## Tasks
+
+### 1. TenantResolver over the store-slug projection
+- [ ] Implement against `stores.SlugCache`, which already does exactly this
+      lookup for admin/storefront routing, with a TTL and singleflight.
+- [ ] Return `ErrTenantNotFound` on a miss so the handler answers 404 rather
+      than 500.
+- **Done when** `/sso/{slug}/login` resolves a real tenant and an unknown slug
+  is a 404.
+
+### 2. Lazy relying-party cache
+- [ ] `sso.RelyingPartyCache` — build on demand, cache per tenant, TTL.
+- [ ] Resolve `client_secret_ref` through OpenBao (`internal/bao`). The metadata
+      comment still says "Secret Manager path"; that backend was retired in
+      #813 and the comment is stale.
+- [ ] Invalidate on config upsert/delete, so a corrected client secret takes
+      effect without a restart.
+- **Done when** a tenant configured after boot can log in, and a broken issuer
+  fails that tenant's login rather than the service.
+
+### 3. Mount both surfaces
+- [ ] Construct `SSOConfigHandler` and fill `SSOLoginHandler`'s deps in
+      `main.go`, on **both** engines.
+- [ ] Mount tests driven through the real router. NOT a 404-vs-405 probe:
+      `HandleMethodNotAllowed` is never set in this estate, so gin answers 404
+      either way and that probe distinguishes nothing (#642, #820).
+
+### 4. Stop `loginSAML` reporting success
+- [ ] It currently returns **nothing** — a SAML tenant gets `200` with an empty
+      body, which reads as success. The callback already answers `501` for the
+      same reason. Make the two agree.
+- **Done when** no SAML path can be mistaken for a working one.
+
+## Open, and asked rather than assumed
+
+Whether SAML should be implemented or removed outright. A full crewjam SP with
+per-tenant middleware is its own project; a permanent `501` is honest but leaves
+`sso_provider_kind` carrying a value nothing serves. Task 4 makes the current
+state safe either way, and does not pre-empt the answer.
+
+## Discovered mid-task: a fourth missing implementation
+
+`sso.UsersRepo` has no implementation either — #820 lists three gaps and there
+are four. JIT provisioning needs it for steps 3 and 4 of its binding algorithm:
+"find the existing Mark8ly user with this email in this tenant", and "create
+one".
+
+Steps 1 and 2 run entirely off `tenant_sso_user_mappings`, so an SSO user who
+has logged in before needs nothing new. The gap is the FIRST login.
+
+And it cannot be satisfied locally. marketplace-api has no user identity store:
+`user_profiles` is keyed on a provider subject string, is not tenant-scoped,
+and holds display preferences. Membership is FGA tuples; identity is Zitadel.
+Neither can answer "which user id has this email in this tenant" —
+FGA checks a relation for a KNOWN id, and platform-api exposes no
+lookup-by-email (`/users/me/tenants` and `/tenants/:id/me` both start from a
+uid).
+
+That makes step 3 an architectural decision rather than a wiring task, and the
+wrong answer is silently wrong: a merchant admin who already signs in with a
+password would, on their first SSO login, be minted a NEW internal id — a
+second identity for one human, with the first one's role. Recorded on the
+issue rather than guessed at here.

--- a/services/marketplace-api/internal/handlers/public/sso_login.go
+++ b/services/marketplace-api/internal/handlers/public/sso_login.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"reflect"
 	"sync"
 	"time"
 
@@ -32,12 +33,35 @@ const adminHomeRedirect = "/admin"
 // ---------------------------------------------------------------------------
 
 // TenantResolver looks up a tenant UUID from its URL slug.
-// The production implementation queries the tenants table; tests supply a stub.
 //
-// TODO(wiring): wire against internal/tenants or the tenant-service HTTP
-// client once the canonical tenant-lookup path is settled.
+// The production implementation is StoreSlugTenantResolver
+// (sso_tenant_resolver.go), which goes through the stores projection — this
+// service has no tenants table, and a store slug identifies its tenant.
 type TenantResolver interface {
 	ByTenantSlug(ctx context.Context, slug string) (uuid.UUID, error)
+}
+
+// SSOConfigLoader reads a tenant's SSO configuration. *sso.Repository
+// satisfies it.
+//
+// An interface rather than the concrete repository so the branches that depend
+// on a LOADED config can be tested without a database. Before #820 this field
+// was a *sso.Repository, so every test could only reach the paths that fail
+// BEFORE the config is read — which is why the SAML branch could return an
+// empty 200 with a full test suite passing.
+type SSOConfigLoader interface {
+	GetByTenant(ctx context.Context, tenantID uuid.UUID) (*sso.Config, error)
+}
+
+// OIDCRelyingParties supplies the relying party for a tenant's config.
+// *sso.RelyingPartyCache satisfies it.
+//
+// Replaces the `map[string]*sso.OIDCRelyingParty` this handler used to hold.
+// A map has to be built somewhere, and the only somewhere was startup — which
+// makes every customer's IdP a boot dependency of this service and excludes
+// any tenant who configures SSO afterwards. See sso/rp_cache.go.
+type OIDCRelyingParties interface {
+	For(ctx context.Context, cfg *sso.Config) (*sso.OIDCRelyingParty, error)
 }
 
 // StateCache stores (state, nonce, tenantID) triples for the OIDC
@@ -103,10 +127,10 @@ func (c *MemStateCache) Get(state string) (string, uuid.UUID, error) {
 //	POST /sso/:tenantSlug/callback  — handle IdP response
 //	POST /sso/:tenantSlug/logout    — clear session + optional SLO
 type SSOLoginHandler struct {
-	Repo           *sso.Repository
+	Repo           SSOConfigLoader
 	JIT            JITProvisioner
 	Sessions       authbffclient.SessionIssuer
-	OIDCRPs        map[string]*sso.OIDCRelyingParty // keyed by tenantID.String()
+	OIDCRPs        OIDCRelyingParties
 	StateCache     StateCache
 	Audit          *audit.Emitter
 	TenantResolver TenantResolver
@@ -123,10 +147,10 @@ type JITProvisioner interface {
 // OIDCRPs and Sessions must be set before serving requests; nil values
 // cause the affected provider path to return 503.
 func NewSSOLoginHandler(
-	repo *sso.Repository,
+	repo SSOConfigLoader,
 	jit JITProvisioner,
 	sessions authbffclient.SessionIssuer,
-	oidcRPs map[string]*sso.OIDCRelyingParty,
+	oidcRPs OIDCRelyingParties,
 	stateCache StateCache,
 	auditEmitter *audit.Emitter,
 	tenantResolver TenantResolver,
@@ -137,6 +161,17 @@ func NewSSOLoginHandler(
 	}
 	if stateCache == nil {
 		stateCache = NewMemStateCache()
+	}
+	// A TYPED nil — a nil *sso.Repository assigned into the interface — is
+	// normalised to a true nil rather than left to panic at first use. Both
+	// read as "no repository configured" to a human, but only one of them
+	// does to Go: an interface holding a nil pointer is itself non-nil, so
+	// the `h.Repo == nil` guard below would pass and the first method call
+	// would panic inside an unauthenticated route (the #288 shape).
+	if repo != nil {
+		if v := reflect.ValueOf(repo); v.Kind() == reflect.Ptr && v.IsNil() {
+			repo = nil
+		}
 	}
 	return &SSOLoginHandler{
 		Repo:           repo,
@@ -176,12 +211,17 @@ func (h *SSOLoginHandler) Login(c *gin.Context) {
 }
 
 func (h *SSOLoginHandler) loginOIDC(c *gin.Context, tenantID uuid.UUID, cfg *sso.Config) {
-	rp := h.oidcRP(tenantID)
-	if rp == nil {
-		h.Logger.Error("sso_login: OIDC RP not configured", "tenant_id", tenantID)
+	rp, err := h.oidcRP(c.Request.Context(), cfg)
+	if err != nil {
+		// 503, not 500: the tenant's configuration or their IdP is the
+		// problem, and both are recoverable without a code change. The
+		// message stays generic — the cause is in the log, because it can
+		// name the customer's issuer URL and their secret path.
+		h.Logger.Error("sso_login: could not build the OIDC relying party",
+			"tenant_id", tenantID, "err", err)
 		c.JSON(http.StatusServiceUnavailable, gin.H{
 			"error":   "provider_not_ready",
-			"message": "OIDC provider is not yet initialised for this tenant",
+			"message": "single sign-on is not available for this tenant right now",
 		})
 		return
 	}
@@ -207,16 +247,24 @@ func (h *SSOLoginHandler) loginOIDC(c *gin.Context, tenantID uuid.UUID, cfg *sso
 	c.Redirect(http.StatusFound, authURL)
 }
 
-func (h *SSOLoginHandler) loginSAML(_ *gin.Context, _ uuid.UUID, _ *sso.Config) {
-	// SAML login initiation via crewjam samlsp.Middleware.HandleStartAuthFlow
-	// requires the SP middleware to be registered as an http.Handler.
-	// The full SAML SP wiring (loading the per-tenant middleware at startup and
-	// routing through it) is deferred — this stub returns a redirect placeholder
-	// so the test for "SAML login → 302 with SAMLRequest param" can be satisfied
-	// once the SP map is populated.
-	//
-	// TODO(wiring): look up h.SAMLSPs[tenantID.String()].HandleStartAuthFlow(w, r)
-	// once per-tenant SAML SP middleware initialisation is implemented.
+// loginSAML refuses, explicitly.
+//
+// SAML login initiation needs crewjam's samlsp.Middleware registered as an
+// http.Handler per tenant, and that SP wiring does not exist. Until it does,
+// there is nothing to send the browser to.
+//
+// It answers 501, matching what Callback already answers for the SAML branch.
+// Before #820 this function had an empty body, so a SAML tenant got 200 with
+// no content — which a browser renders as a blank page and a monitor records
+// as a successful login. An unimplemented path must fail like one; the two
+// SAML branches now agree, and neither can be mistaken for working.
+func (h *SSOLoginHandler) loginSAML(c *gin.Context, tenantID uuid.UUID, _ *sso.Config) {
+	h.Logger.Warn("sso_login: SAML login attempted but the SP is not implemented",
+		"tenant_id", tenantID)
+	c.JSON(http.StatusNotImplemented, gin.H{
+		"error":   "saml_not_implemented",
+		"message": "SAML sign-in is not available; this tenant should be configured for OIDC",
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -242,7 +290,7 @@ func (h *SSOLoginHandler) Callback(c *gin.Context) {
 	switch cfg.Provider {
 	case sso.ProviderOIDC:
 		var err error
-		claims, externalUserID, err = h.exchangeOIDC(c, tenantID)
+		claims, externalUserID, err = h.exchangeOIDC(c, tenantID, cfg)
 		if err != nil {
 			h.Logger.Warn("sso_callback: OIDC exchange failed", "tenant_id", tenantID, "err", err)
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "auth_failed", "message": err.Error()})
@@ -329,7 +377,7 @@ func (h *SSOLoginHandler) Callback(c *gin.Context) {
 	c.Redirect(http.StatusFound, adminHomeRedirect)
 }
 
-func (h *SSOLoginHandler) exchangeOIDC(c *gin.Context, tenantID uuid.UUID) (claims map[string]any, sub string, err error) {
+func (h *SSOLoginHandler) exchangeOIDC(c *gin.Context, tenantID uuid.UUID, cfg *sso.Config) (claims map[string]any, sub string, err error) {
 	state := c.PostForm("state")
 	code := c.PostForm("code")
 
@@ -345,9 +393,9 @@ func (h *SSOLoginHandler) exchangeOIDC(c *gin.Context, tenantID uuid.UUID) (clai
 		return nil, "", fmt.Errorf("state tenant mismatch")
 	}
 
-	rp := h.oidcRP(tenantID)
-	if rp == nil {
-		return nil, "", fmt.Errorf("OIDC RP not configured for tenant")
+	rp, err := h.oidcRP(c.Request.Context(), cfg)
+	if err != nil {
+		return nil, "", fmt.Errorf("OIDC relying party unavailable: %w", err)
 	}
 
 	claimsMap, err := rp.Exchange(c.Request.Context(), code, expectedNonce)
@@ -414,6 +462,21 @@ func (h *SSOLoginHandler) Logout(c *gin.Context) {
 // loadConfig resolves tenantID from slug and loads its SSO config.
 // Returns (tenantID, config, true) on success; writes HTTP error and
 // returns (Nil, nil, false) on failure.
+// ssoNotFound is the ONE answer this route gives for every "you cannot sign in
+// here" case: unknown slug, no config, and config present but disabled.
+//
+// One function rather than three identical literals, because the property
+// being protected is that they are indistinguishable, and three copies of a
+// string is how they stop being. The route is unauthenticated, so any
+// difference between them enumerates tenants — and SSO being a Pro-tier
+// feature, enumerates paying customers.
+func ssoNotFound(c *gin.Context) {
+	c.JSON(http.StatusNotFound, gin.H{
+		"error":   "not_found",
+		"message": "no SSO configuration for this tenant",
+	})
+}
+
 func (h *SSOLoginHandler) loadConfig(c *gin.Context, slug string) (uuid.UUID, *sso.Config, bool) {
 	if h.TenantResolver == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "not_configured"})
@@ -423,10 +486,7 @@ func (h *SSOLoginHandler) loadConfig(c *gin.Context, slug string) (uuid.UUID, *s
 	tenantID, err := h.TenantResolver.ByTenantSlug(c.Request.Context(), slug)
 	if err != nil {
 		if errors.Is(err, ErrTenantNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "not_found",
-				"message": "no SSO configuration for this tenant",
-			})
+			ssoNotFound(c)
 		} else {
 			h.Logger.Error("sso_login: tenant lookup failed", "slug", slug, "err", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
@@ -442,10 +502,7 @@ func (h *SSOLoginHandler) loadConfig(c *gin.Context, slug string) (uuid.UUID, *s
 	cfg, err := h.Repo.GetByTenant(c.Request.Context(), tenantID)
 	if err != nil {
 		if errors.Is(err, sso.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "not_found",
-				"message": "no SSO configuration for this tenant",
-			})
+			ssoNotFound(c)
 		} else {
 			h.Logger.Error("sso_login: config load failed", "tenant_id", tenantID, "err", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
@@ -454,10 +511,16 @@ func (h *SSOLoginHandler) loadConfig(c *gin.Context, slug string) (uuid.UUID, *s
 	}
 
 	if !cfg.Enabled {
-		c.JSON(http.StatusNotFound, gin.H{
-			"error":   "not_found",
-			"message": "SSO is not enabled for this tenant",
-		})
+		// The SAME body as an unknown tenant and a missing config, not a
+		// more specific one.
+		//
+		// This route is unauthenticated. A distinguishable "SSO is not enabled
+		// for this tenant" tells anyone who asks that the tenant exists AND
+		// has an IdP configured — and since SSO is gated on the Pro tier, that
+		// also reports which customers are on Pro. The two neighbouring
+		// branches were already careful to say the same thing as each other;
+		// this one was not folded in with them.
+		ssoNotFound(c)
 		return uuid.Nil, nil, false
 	}
 
@@ -465,11 +528,14 @@ func (h *SSOLoginHandler) loadConfig(c *gin.Context, slug string) (uuid.UUID, *s
 }
 
 // oidcRP fetches the OIDC relying party for a tenant, or nil if absent.
-func (h *SSOLoginHandler) oidcRP(tenantID uuid.UUID) *sso.OIDCRelyingParty {
+// oidcRP returns the relying party for cfg's tenant, or an error explaining
+// why there is none. The error is for the LOG, never for the response: it can
+// name a customer's issuer and the shape of their secret store.
+func (h *SSOLoginHandler) oidcRP(ctx context.Context, cfg *sso.Config) (*sso.OIDCRelyingParty, error) {
 	if h.OIDCRPs == nil {
-		return nil
+		return nil, fmt.Errorf("sso: no relying-party source configured")
 	}
-	return h.OIDCRPs[tenantID.String()]
+	return h.OIDCRPs.For(ctx, cfg)
 }
 
 // clearSessionCookie instructs the browser to expire the Mark8ly session

--- a/services/marketplace-api/internal/handlers/public/sso_login_test.go
+++ b/services/marketplace-api/internal/handlers/public/sso_login_test.go
@@ -2,6 +2,7 @@ package public_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -131,28 +132,72 @@ func TestSSOLogin_OIDC_NilRP_Returns503(t *testing.T) {
 // OIDC callback — wrong state → 401
 // ---------------------------------------------------------------------------
 
+// Rewritten by #820. It used to assert 503, with a comment explaining that a
+// config could not be loaded without a database — so a test named
+// "wrong state → 401" proved only that a nil repository short-circuits. Now
+// that Repo is an interface it asserts the state check it was written for.
 func TestSSOCallback_OIDC_WrongState_Returns401(t *testing.T) {
 	tenantID := uuid.New()
 	resolver := &fakeTenantResolver{slugToID: map[string]uuid.UUID{"acme": tenantID}}
-	cache := public.NewMemStateCache()
+	loader := &fakeConfigLoader{cfg: &sso.Config{
+		TenantID: tenantID, Provider: sso.ProviderOIDC, Enabled: true,
+	}}
 
-	// Nil repo → 503 from loadConfig before we ever reach the state check.
-	// To reach the state-check we need a working repo. Since we can't mock
-	// sso.Repository without a DB, we test via the public-facing inline router.
-	// Use the tenantResolver-nil-repo path and verify the 503 pre-gate:
-	h := public.NewSSOLoginHandler(nil, &fakeJIT{},
-		authbffclient.NoopIssuer{},
-		map[string]*sso.OIDCRelyingParty{},
-		cache, nil, resolver, nil)
+	h := public.NewSSOLoginHandler(loader, &fakeJIT{}, authbffclient.NoopIssuer{}, nil,
+		public.NewMemStateCache(), nil, resolver, nil)
 
-	r := buildTestRouter(h)
-
-	// With nil repo the handler returns 503 before reaching state lookup.
-	w := doTestForm(r, "/sso/acme/callback", url.Values{
+	w := doTestForm(buildTestRouter(h), "/sso/acme/callback", url.Values{
 		"state": {"never-stored"},
 		"code":  {"some-code"},
 	})
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	require.Contains(t, w.Body.String(), "auth_failed")
+}
+
+// A relying party that cannot be built is the tenant's configuration or their
+// IdP being unreachable — recoverable without a code change, so 503 rather
+// than 500. The response must not carry the reason: it names the customer's
+// issuer and the path of their client secret.
+func TestSSOLogin_OIDC_UnbuildableRelyingParty_Returns503WithoutDetail(t *testing.T) {
+	tenantID := uuid.New()
+	resolver := &fakeTenantResolver{slugToID: map[string]uuid.UUID{"acme": tenantID}}
+	loader := &fakeConfigLoader{cfg: &sso.Config{
+		TenantID: tenantID, Provider: sso.ProviderOIDC, Enabled: true,
+	}}
+	rps := &fakeRelyingParties{err: errors.New("discover https://idp.acme.example: dial tcp: refused")}
+
+	h := public.NewSSOLoginHandler(loader, &fakeJIT{}, authbffclient.NoopIssuer{}, rps,
+		public.NewMemStateCache(), nil, resolver, nil)
+
+	w := doTestGet(buildTestRouter(h), "/sso/acme/login")
+
 	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	require.NotContains(t, w.Body.String(), "idp.acme.example",
+		"the response leaked the tenant's issuer URL")
+	require.NotContains(t, w.Body.String(), "dial tcp")
+}
+
+// The relying party is fetched per request from the source, not held in a map
+// built at boot — which is what lets a tenant who configures SSO after startup
+// actually sign in.
+func TestSSOLogin_OIDC_AsksForTheRelyingPartyPerRequest(t *testing.T) {
+	tenantID := uuid.New()
+	resolver := &fakeTenantResolver{slugToID: map[string]uuid.UUID{"acme": tenantID}}
+	loader := &fakeConfigLoader{cfg: &sso.Config{
+		TenantID: tenantID, Provider: sso.ProviderOIDC, Enabled: true,
+	}}
+	rps := &fakeRelyingParties{err: errors.New("not ready")}
+
+	h := public.NewSSOLoginHandler(loader, &fakeJIT{}, authbffclient.NoopIssuer{}, rps,
+		public.NewMemStateCache(), nil, resolver, nil)
+	r := buildTestRouter(h)
+
+	doTestGet(r, "/sso/acme/login")
+	doTestGet(r, "/sso/acme/login")
+
+	require.Equal(t, 2, rps.calls, "the handler cached a relying party itself")
+	require.Equal(t, tenantID, rps.lastCfg.TenantID)
 }
 
 // ---------------------------------------------------------------------------
@@ -216,4 +261,114 @@ func TestMemStateCache_EmptyStateOrNonce_ReturnsError(t *testing.T) {
 
 	require.Error(t, cache.Put("", "nonce", tid), "empty state must fail")
 	require.Error(t, cache.Put("state", "", tid), "empty nonce must fail")
+}
+
+// ---------------------------------------------------------------------------
+// Config-dependent branches (#820)
+//
+// These could not be written before: SSOLoginHandler.Repo was a concrete
+// *sso.Repository, so every test could only reach the paths that fail BEFORE
+// the config is read. That is how loginSAML shipped with an empty body — a
+// green suite that never once loaded a config.
+// ---------------------------------------------------------------------------
+
+type fakeRelyingParties struct {
+	rp      *sso.OIDCRelyingParty
+	err     error
+	calls   int
+	lastCfg *sso.Config
+}
+
+func (f *fakeRelyingParties) For(_ context.Context, cfg *sso.Config) (*sso.OIDCRelyingParty, error) {
+	f.calls++
+	f.lastCfg = cfg
+	return f.rp, f.err
+}
+
+type fakeConfigLoader struct {
+	cfg *sso.Config
+	err error
+}
+
+func (f *fakeConfigLoader) GetByTenant(_ context.Context, _ uuid.UUID) (*sso.Config, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.cfg, nil
+}
+
+func samlHandler(t *testing.T, tenantID uuid.UUID) *gin.Engine {
+	t.Helper()
+	resolver := &fakeTenantResolver{slugToID: map[string]uuid.UUID{"acme": tenantID}}
+	loader := &fakeConfigLoader{cfg: &sso.Config{
+		TenantID: tenantID,
+		Provider: sso.ProviderSAML,
+		Enabled:  true,
+	}}
+	h := public.NewSSOLoginHandler(loader, &fakeJIT{}, authbffclient.NoopIssuer{}, nil,
+		public.NewMemStateCache(), nil, resolver, nil)
+	return buildTestRouter(h)
+}
+
+// A SAML tenant used to get 200 with an empty body from the login route: a
+// blank page to the merchant, a successful login to any monitor counting
+// statuses. An unimplemented path has to fail like one.
+func TestSSOLogin_SAML_IsRefusedNotSilentlyEmpty(t *testing.T) {
+	w := doTestGet(samlHandler(t, uuid.New()), "/sso/acme/login")
+
+	require.Equal(t, http.StatusNotImplemented, w.Code)
+	require.Contains(t, w.Body.String(), "saml_not_implemented")
+}
+
+// The two SAML branches must agree. They did not: callback answered 501 while
+// login answered an empty 200, so which one a merchant hit decided whether SSO
+// looked broken or looked fine.
+func TestSSOLogin_SAML_LoginAndCallbackAgree(t *testing.T) {
+	tenantID := uuid.New()
+
+	login := doTestGet(samlHandler(t, tenantID), "/sso/acme/login")
+	callback := doTestForm(samlHandler(t, tenantID), "/sso/acme/callback", url.Values{
+		"SAMLResponse": {"whatever"},
+	})
+
+	require.Equal(t, callback.Code, login.Code,
+		"login and callback disagree about whether SAML works")
+	require.Equal(t, http.StatusNotImplemented, login.Code)
+}
+
+// A disabled config is a 404, and must not be distinguishable from "no such
+// tenant" — otherwise the route enumerates which tenants have bought SSO.
+func TestSSOLogin_DisabledConfigIsIndistinguishableFromAMissingTenant(t *testing.T) {
+	tenantID := uuid.New()
+	resolver := &fakeTenantResolver{slugToID: map[string]uuid.UUID{"acme": tenantID}}
+	loader := &fakeConfigLoader{cfg: &sso.Config{
+		TenantID: tenantID, Provider: sso.ProviderOIDC, Enabled: false,
+	}}
+	h := public.NewSSOLoginHandler(loader, &fakeJIT{}, authbffclient.NoopIssuer{}, nil,
+		public.NewMemStateCache(), nil, resolver, nil)
+
+	disabled := doTestGet(buildTestRouter(h), "/sso/acme/login")
+
+	unknownResolver := &fakeTenantResolver{slugToID: map[string]uuid.UUID{}}
+	unknown := doTestGet(buildTestRouter(public.NewSSOLoginHandler(loader, &fakeJIT{},
+		authbffclient.NoopIssuer{}, nil, public.NewMemStateCache(), nil, unknownResolver, nil)),
+		"/sso/nobody/login")
+
+	require.Equal(t, http.StatusNotFound, disabled.Code)
+	require.Equal(t, unknown.Code, disabled.Code)
+	require.Equal(t, unknown.Body.String(), disabled.Body.String(),
+		"a disabled tenant answers differently from an unknown one — that enumerates customers")
+}
+
+// A typed nil repository must not panic. An interface holding a nil pointer is
+// itself non-nil, so the handler's `Repo == nil` guard would pass and the
+// first call would panic inside an unauthenticated route (#288's shape).
+func TestNewSSOLoginHandler_TypedNilRepoDoesNotPanic(t *testing.T) {
+	var typedNil *sso.Repository
+	resolver := &fakeTenantResolver{slugToID: map[string]uuid.UUID{"acme": uuid.New()}}
+	h := public.NewSSOLoginHandler(typedNil, &fakeJIT{}, authbffclient.NoopIssuer{}, nil,
+		public.NewMemStateCache(), nil, resolver, nil)
+
+	w := doTestGet(buildTestRouter(h), "/sso/acme/login")
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
 }

--- a/services/marketplace-api/internal/handlers/public/sso_tenant_resolver.go
+++ b/services/marketplace-api/internal/handlers/public/sso_tenant_resolver.go
@@ -1,0 +1,87 @@
+package public
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/stores"
+)
+
+// sso_tenant_resolver.go — the production TenantResolver (#820).
+//
+// The interface has carried a `TODO(wiring)` since it was written, with no
+// implementing type anywhere, which is why /sso/:tenantSlug/login could not be
+// mounted: the handler answers 503 when TenantResolver is nil.
+
+// StoreSlugLookup is the part of *stores.SlugCache this resolver needs.
+// Declared narrowly so the resolver can be tested without a database or a
+// platform-api client.
+type StoreSlugLookup interface {
+	Get(ctx context.Context, slug string) (*stores.Store, error)
+}
+
+// StoreSlugTenantResolver resolves the `:tenantSlug` route parameter to a
+// tenant id through the stores projection.
+//
+// The parameter is named tenantSlug, but in this estate the slug in a URL is
+// always a STORE slug — it is what `{slug}-admin.mark8ly.com` is built from
+// and what platform-api's by-slug endpoint takes. A store belongs to exactly
+// one tenant, so the store row is the canonical way to get from a slug to a
+// tenant, and this service has no tenants table of its own to consult instead.
+//
+// It goes through stores.SlugCache rather than the repository directly because
+// that cache already solves this exact lookup for admin and storefront
+// routing: TTL, singleflight coalescing, a platform-api refresh on miss, and a
+// stale-but-cached fallback when platform-api is down. An SSO login failing
+// because platform-api is briefly unreachable — when the answer was sitting in
+// the projection table — would be a worse outage than the one it reported.
+type StoreSlugTenantResolver struct {
+	lookup StoreSlugLookup
+}
+
+// NewStoreSlugTenantResolver constructs a resolver over the slug cache.
+func NewStoreSlugTenantResolver(lookup StoreSlugLookup) *StoreSlugTenantResolver {
+	return &StoreSlugTenantResolver{lookup: lookup}
+}
+
+// ByTenantSlug returns the tenant that owns the store with this slug.
+//
+// An unknown slug returns ErrTenantNotFound, which the handler renders as a
+// 404 carrying the same body as "this tenant has no SSO config". That merge is
+// deliberate: distinguishing "no such tenant" from "that tenant has not set up
+// SSO" would let an anonymous caller enumerate which stores exist.
+func (r *StoreSlugTenantResolver) ByTenantSlug(ctx context.Context, slug string) (uuid.UUID, error) {
+	if r == nil || r.lookup == nil {
+		return uuid.Nil, fmt.Errorf("sso: tenant resolver has no store lookup")
+	}
+	if slug == "" {
+		return uuid.Nil, ErrTenantNotFound
+	}
+
+	store, err := r.lookup.Get(ctx, slug)
+	if err != nil {
+		if errors.Is(err, stores.ErrNotFound) {
+			return uuid.Nil, ErrTenantNotFound
+		}
+		return uuid.Nil, fmt.Errorf("sso: resolve tenant for slug %q: %w", slug, err)
+	}
+	if store == nil {
+		// A nil store with a nil error is not a shape the cache produces
+		// today, but the alternative here is a nil dereference inside an
+		// auth path, so it is checked rather than assumed.
+		return uuid.Nil, ErrTenantNotFound
+	}
+
+	tenantID, err := uuid.Parse(store.TenantID)
+	if err != nil {
+		// The projection holds a tenant id that is not a UUID. That is a data
+		// fault, not a missing tenant, and must not be reported as one: a 404
+		// would send an operator looking for a store that is right there.
+		return uuid.Nil, fmt.Errorf("sso: store %q has an unparseable tenant id %q: %w",
+			slug, store.TenantID, err)
+	}
+	return tenantID, nil
+}

--- a/services/marketplace-api/internal/handlers/public/sso_tenant_resolver_test.go
+++ b/services/marketplace-api/internal/handlers/public/sso_tenant_resolver_test.go
@@ -1,0 +1,93 @@
+package public_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/public"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+)
+
+type stubSlugLookup struct {
+	store *stores.Store
+	err   error
+	slugs []string
+}
+
+func (s *stubSlugLookup) Get(_ context.Context, slug string) (*stores.Store, error) {
+	s.slugs = append(s.slugs, slug)
+	return s.store, s.err
+}
+
+func TestByTenantSlug_ResolvesTheTenantThatOwnsTheStore(t *testing.T) {
+	tenantID := uuid.New()
+	lookup := &stubSlugLookup{store: &stores.Store{TenantID: tenantID.String(), Slug: "bondi-surf"}}
+	r := public.NewStoreSlugTenantResolver(lookup)
+
+	got, err := r.ByTenantSlug(context.Background(), "bondi-surf")
+	if err != nil {
+		t.Fatalf("ByTenantSlug: %v", err)
+	}
+	if got != tenantID {
+		t.Errorf("tenant = %s, want %s", got, tenantID)
+	}
+	if len(lookup.slugs) != 1 || lookup.slugs[0] != "bondi-surf" {
+		t.Errorf("looked up %v", lookup.slugs)
+	}
+}
+
+// The handler renders ErrTenantNotFound as a 404 with the same body it uses
+// for "this tenant has no SSO config". Distinguishing the two would let an
+// anonymous caller enumerate which stores exist.
+func TestByTenantSlug_UnknownSlugIsNotFound(t *testing.T) {
+	r := public.NewStoreSlugTenantResolver(&stubSlugLookup{err: stores.ErrNotFound})
+
+	_, err := r.ByTenantSlug(context.Background(), "no-such-store")
+	if !errors.Is(err, public.ErrTenantNotFound) {
+		t.Fatalf("err = %v, want ErrTenantNotFound", err)
+	}
+}
+
+func TestByTenantSlug_EmptySlugIsNotFoundWithoutALookup(t *testing.T) {
+	lookup := &stubSlugLookup{}
+	r := public.NewStoreSlugTenantResolver(lookup)
+
+	if _, err := r.ByTenantSlug(context.Background(), ""); !errors.Is(err, public.ErrTenantNotFound) {
+		t.Fatalf("err = %v, want ErrTenantNotFound", err)
+	}
+	if len(lookup.slugs) != 0 {
+		t.Error("an empty slug still hit the store lookup")
+	}
+}
+
+// A lookup that fails for any other reason must NOT collapse into "no such
+// tenant": the handler answers 404 for that, and a merchant whose SSO is down
+// because the store service is unreachable would be told their tenant does not
+// exist.
+func TestByTenantSlug_ALookupFailureIsNotAMissingTenant(t *testing.T) {
+	r := public.NewStoreSlugTenantResolver(&stubSlugLookup{err: errors.New("platform-api down")})
+
+	_, err := r.ByTenantSlug(context.Background(), "bondi-surf")
+	if err == nil {
+		t.Fatal("a lookup failure was reported as success")
+	}
+	if errors.Is(err, public.ErrTenantNotFound) {
+		t.Fatal("a lookup failure was reported as a missing tenant — that renders as 404")
+	}
+}
+
+// Same reasoning for a corrupt projection row: a 404 would send an operator
+// looking for a store that is sitting right there.
+func TestByTenantSlug_AnUnparseableTenantIDIsAnError(t *testing.T) {
+	r := public.NewStoreSlugTenantResolver(&stubSlugLookup{
+		store: &stores.Store{TenantID: "not-a-uuid", Slug: "bondi-surf"},
+	})
+
+	_, err := r.ByTenantSlug(context.Background(), "bondi-surf")
+	if err == nil || errors.Is(err, public.ErrTenantNotFound) {
+		t.Fatalf("err = %v, want a real error", err)
+	}
+}

--- a/services/marketplace-api/internal/sso/rp_cache.go
+++ b/services/marketplace-api/internal/sso/rp_cache.go
@@ -1,0 +1,187 @@
+package sso
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/sync/singleflight"
+)
+
+// rp_cache.go — per-tenant OIDC relying parties, built on demand (#820).
+//
+// # Why this is not a map built at startup
+//
+// SSOLoginHandler used to take `map[string]*OIDCRelyingParty`, and #820's own
+// suggested scope was to "build OIDCRPs at startup". Both are wrong, for two
+// reasons that only show up in production:
+//
+//  1. BuildOIDCRelyingParty performs OIDC DISCOVERY — an HTTP call to the
+//     tenant's issuer. Building every tenant's party at boot makes every
+//     customer's IdP a startup dependency of this service. One slow or
+//     unreachable issuer delays the rollout; one that fails outright takes the
+//     whole service down, for every tenant, over one tenant's misconfiguration.
+//  2. A map built at boot cannot contain a tenant who configures SSO
+//     afterwards. For a self-serve feature that means "works after the next
+//     deploy", which is another way of saying it does not work.
+//
+// Building lazily inverts both: a broken issuer fails that tenant's login and
+// nobody else's, and a config saved at 10:00 works at 10:00.
+
+// OIDCSecretField is the key this cache reads out of the KV secret named by
+// a config's client_secret_ref.
+//
+// "client_secret" rather than carriersecrets' "value" because these secrets
+// are written by an operator against a documented contract, and a named field
+// says what the blob is. A ref pointing at a secret without this field is a
+// configuration error and is reported as one.
+const OIDCSecretField = "client_secret"
+
+// DefaultRelyingPartyTTL bounds how long a built relying party is reused.
+//
+// It is not about the client secret going stale — Invalidate covers a config
+// change. It bounds the DISCOVERY document, which carries the IdP's signing
+// keys and endpoints. An IdP that rotates keys or moves an endpoint is picked
+// up within this window without an operator having to do anything.
+const DefaultRelyingPartyTTL = 30 * time.Minute
+
+// ErrNoClientSecret is returned when a config's client_secret_ref names a
+// secret that does not exist, or one with no OIDCSecretField in it. Separate
+// from a build failure so an operator is told which of the two happened —
+// "your IdP is unreachable" and "your secret is missing" need different fixes.
+var ErrNoClientSecret = errors.New("sso: client secret not found for config")
+
+// SecretReader is the part of *bao.Client this cache needs.
+type SecretReader interface {
+	ReadSecret(ctx context.Context, path string) (map[string]string, int, error)
+}
+
+type rpEntry struct {
+	rp      *OIDCRelyingParty
+	builtAt time.Time
+}
+
+// RelyingPartyCache builds and reuses per-tenant OIDC relying parties.
+//
+// Safe for concurrent use. Concurrent misses for the SAME tenant are coalesced
+// through singleflight, so a burst of logins after a config change performs one
+// discovery call rather than one per request — which matters because the thing
+// being coalesced is an outbound HTTP call to a customer's IdP.
+type RelyingPartyCache struct {
+	secrets SecretReader
+	ttl     time.Duration
+	now     func() time.Time
+
+	mu      sync.Mutex
+	entries map[uuid.UUID]rpEntry
+	flight  singleflight.Group
+}
+
+// NewRelyingPartyCache constructs a cache. A zero ttl means
+// DefaultRelyingPartyTTL; a nil secrets reader is allowed and makes every
+// build fail with ErrNoClientSecret rather than panic.
+func NewRelyingPartyCache(secrets SecretReader, ttl time.Duration) *RelyingPartyCache {
+	if ttl <= 0 {
+		ttl = DefaultRelyingPartyTTL
+	}
+	return &RelyingPartyCache{
+		secrets: secrets,
+		ttl:     ttl,
+		now:     time.Now,
+		entries: map[uuid.UUID]rpEntry{},
+	}
+}
+
+// For returns the relying party for cfg's tenant, building it if there is no
+// fresh one cached.
+func (c *RelyingPartyCache) For(ctx context.Context, cfg *Config) (*OIDCRelyingParty, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("%w: cfg is nil", ErrInvalidMetadata)
+	}
+	if rp, ok := c.cached(cfg.TenantID); ok {
+		return rp, nil
+	}
+
+	built, err, _ := c.flight.Do(cfg.TenantID.String(), func() (any, error) {
+		// Re-check inside the flight: the winner of a race has already
+		// stored a party by the time the losers run, and rebuilding would
+		// spend a second discovery call for nothing.
+		if rp, ok := c.cached(cfg.TenantID); ok {
+			return rp, nil
+		}
+		rp, err := c.build(ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
+		c.store(cfg.TenantID, rp)
+		return rp, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return built.(*OIDCRelyingParty), nil
+}
+
+// Invalidate drops any cached party for a tenant.
+//
+// Called when a config is written or deleted. Without it, a merchant
+// correcting a wrong client secret would keep failing to log in for up to the
+// TTL, with the console showing the corrected value — the kind of bug that
+// gets diagnosed as "SSO is broken" rather than "the cache is warm".
+func (c *RelyingPartyCache) Invalidate(tenantID uuid.UUID) {
+	c.mu.Lock()
+	delete(c.entries, tenantID)
+	c.mu.Unlock()
+}
+
+func (c *RelyingPartyCache) cached(tenantID uuid.UUID) (*OIDCRelyingParty, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[tenantID]
+	if !ok || c.now().Sub(e.builtAt) > c.ttl {
+		return nil, false
+	}
+	return e.rp, true
+}
+
+func (c *RelyingPartyCache) store(tenantID uuid.UUID, rp *OIDCRelyingParty) {
+	c.mu.Lock()
+	c.entries[tenantID] = rpEntry{rp: rp, builtAt: c.now()}
+	c.mu.Unlock()
+}
+
+func (c *RelyingPartyCache) build(ctx context.Context, cfg *Config) (*OIDCRelyingParty, error) {
+	secret, err := c.clientSecret(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return BuildOIDCRelyingParty(ctx, cfg, secret)
+}
+
+// clientSecret resolves cfg's client_secret_ref through the secret store.
+//
+// The plaintext never touches the database — metadata holds only the ref. The
+// value is not cached separately either: it lives only inside the built
+// relying party's oauth2.Config, for as long as that party is cached.
+func (c *RelyingPartyCache) clientSecret(ctx context.Context, cfg *Config) (string, error) {
+	ref, ok := nonEmpty(cfg.Metadata, OIDCKeyClientSecretRef)
+	if !ok {
+		return "", fmt.Errorf("%w: %s required", ErrInvalidMetadata, OIDCKeyClientSecretRef)
+	}
+	if c.secrets == nil {
+		return "", fmt.Errorf("%w: no secret store configured", ErrNoClientSecret)
+	}
+
+	data, _, err := c.secrets.ReadSecret(ctx, ref)
+	if err != nil {
+		return "", fmt.Errorf("%w: read %s: %w", ErrNoClientSecret, ref, err)
+	}
+	secret := data[OIDCSecretField]
+	if secret == "" {
+		return "", fmt.Errorf("%w: %s has no %q field", ErrNoClientSecret, ref, OIDCSecretField)
+	}
+	return secret, nil
+}

--- a/services/marketplace-api/internal/sso/rp_cache_test.go
+++ b/services/marketplace-api/internal/sso/rp_cache_test.go
@@ -1,0 +1,258 @@
+package sso
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+)
+
+// discoveryServer stands in for a tenant's IdP, counting how many times its
+// discovery document is fetched — which is the cost this cache exists to
+// avoid paying per request.
+type discoveryServer struct {
+	*httptest.Server
+	hits atomic.Int32
+}
+
+func newDiscoveryServer(t *testing.T) *discoveryServer {
+	t.Helper()
+	ds := &discoveryServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		ds.hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"issuer": "` + ds.URL + `",
+			"authorization_endpoint": "` + ds.URL + `/auth",
+			"token_endpoint": "` + ds.URL + `/token",
+			"jwks_uri": "` + ds.URL + `/jwks"
+		}`))
+	})
+	ds.Server = httptest.NewServer(mux)
+	t.Cleanup(ds.Close)
+	return ds
+}
+
+type stubSecrets struct {
+	data map[string]string
+	err  error
+	// reads counts secret fetches, so a test can prove the plaintext is not
+	// re-read on every login.
+	reads atomic.Int32
+}
+
+func (s *stubSecrets) ReadSecret(_ context.Context, _ string) (map[string]string, int, error) {
+	s.reads.Add(1)
+	if s.err != nil {
+		return nil, 0, s.err
+	}
+	return s.data, 1, nil
+}
+
+// testVaultPath is the KV PATH a config points at, not a secret — the value
+// behind it comes from the stub secret store below.
+//
+// Deliberately named without "secret" in it and kept low-entropy: gitleaks'
+// generic-api-key rule fires on a secret-ish identifier sitting next to a
+// slashy string, and it does not care that this one is a lookup key rather
+// than a credential. Naming it plainly is cheaper than an ignore entry, which
+// would also suppress a real finding on this line later.
+const testVaultPath = "kv/test/sso"
+
+func testConfig(issuer string) *Config {
+	return &Config{
+		TenantID: uuid.New(),
+		Provider: ProviderOIDC,
+		Enabled:  true,
+		Metadata: datatypes.JSONMap{
+			OIDCKeyIssuer:          issuer,
+			OIDCKeyClientID:        "client-abc",
+			OIDCKeyClientSecretRef: testVaultPath,
+			OIDCKeyRedirectURI:     "https://acme-admin.mark8ly.com/sso/acme/callback",
+		},
+	}
+}
+
+func goodSecrets() *stubSecrets {
+	return &stubSecrets{data: map[string]string{OIDCSecretField: "s3cr3t"}}
+}
+
+func TestRelyingPartyCache_BuildsOnFirstUse(t *testing.T) {
+	ds := newDiscoveryServer(t)
+	secrets := goodSecrets()
+	c := NewRelyingPartyCache(secrets, 0)
+
+	rp, err := c.For(context.Background(), testConfig(ds.URL))
+	if err != nil {
+		t.Fatalf("For: %v", err)
+	}
+	if rp == nil || rp.ClientID != "client-abc" {
+		t.Fatalf("rp = %+v", rp)
+	}
+	if rp.OAuth.ClientSecret != "s3cr3t" {
+		t.Errorf("client secret not resolved from the secret store")
+	}
+	if got := ds.hits.Load(); got != 1 {
+		t.Errorf("discovery hits = %d, want 1", got)
+	}
+}
+
+// The point of caching: discovery is an outbound call to a CUSTOMER's IdP, and
+// paying it per login would put their uptime in our request path.
+func TestRelyingPartyCache_ReusesAcrossCalls(t *testing.T) {
+	ds := newDiscoveryServer(t)
+	secrets := goodSecrets()
+	c := NewRelyingPartyCache(secrets, 0)
+	cfg := testConfig(ds.URL)
+
+	for i := 0; i < 5; i++ {
+		if _, err := c.For(context.Background(), cfg); err != nil {
+			t.Fatalf("For #%d: %v", i, err)
+		}
+	}
+	if got := ds.hits.Load(); got != 1 {
+		t.Errorf("discovery hits = %d, want 1 — the cache is not being used", got)
+	}
+	if got := secrets.reads.Load(); got != 1 {
+		t.Errorf("secret reads = %d, want 1", got)
+	}
+}
+
+// A merchant who corrects a wrong client secret must not keep failing to log
+// in until the TTL expires, while the console shows the corrected value.
+func TestRelyingPartyCache_InvalidateForcesARebuild(t *testing.T) {
+	ds := newDiscoveryServer(t)
+	c := NewRelyingPartyCache(goodSecrets(), 0)
+	cfg := testConfig(ds.URL)
+
+	if _, err := c.For(context.Background(), cfg); err != nil {
+		t.Fatalf("For: %v", err)
+	}
+	c.Invalidate(cfg.TenantID)
+	if _, err := c.For(context.Background(), cfg); err != nil {
+		t.Fatalf("For after invalidate: %v", err)
+	}
+	if got := ds.hits.Load(); got != 2 {
+		t.Errorf("discovery hits = %d, want 2 — invalidate did not force a rebuild", got)
+	}
+}
+
+// The TTL bounds the DISCOVERY document, not the secret: an IdP that rotates
+// signing keys is picked up without an operator doing anything.
+func TestRelyingPartyCache_RebuildsAfterTheTTL(t *testing.T) {
+	ds := newDiscoveryServer(t)
+	c := NewRelyingPartyCache(goodSecrets(), time.Minute)
+	cfg := testConfig(ds.URL)
+
+	now := time.Now()
+	c.now = func() time.Time { return now }
+
+	if _, err := c.For(context.Background(), cfg); err != nil {
+		t.Fatalf("For: %v", err)
+	}
+	now = now.Add(2 * time.Minute)
+	if _, err := c.For(context.Background(), cfg); err != nil {
+		t.Fatalf("For after ttl: %v", err)
+	}
+	if got := ds.hits.Load(); got != 2 {
+		t.Errorf("discovery hits = %d, want 2 — the entry never expired", got)
+	}
+}
+
+// A burst of logins after a config change must not fan out into one discovery
+// call per request against the customer's IdP.
+func TestRelyingPartyCache_ConcurrentMissesCoalesce(t *testing.T) {
+	ds := newDiscoveryServer(t)
+	c := NewRelyingPartyCache(goodSecrets(), 0)
+	cfg := testConfig(ds.URL)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := c.For(context.Background(), cfg); err != nil {
+				t.Errorf("For: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := ds.hits.Load(); got != 1 {
+		t.Errorf("discovery hits = %d, want 1 — 20 concurrent logins each hit the IdP", got)
+	}
+}
+
+// "Your IdP is unreachable" and "your secret is missing" need different fixes,
+// so they must not arrive as the same error.
+func TestRelyingPartyCache_MissingSecretIsItsOwnError(t *testing.T) {
+	ds := newDiscoveryServer(t)
+
+	for _, tc := range []struct {
+		name    string
+		secrets *stubSecrets
+	}{
+		{"secret store unreachable", &stubSecrets{err: errors.New("bao down")}},
+		{"secret has no client_secret field", &stubSecrets{data: map[string]string{"other": "x"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewRelyingPartyCache(tc.secrets, 0)
+			_, err := c.For(context.Background(), testConfig(ds.URL))
+			if !errors.Is(err, ErrNoClientSecret) {
+				t.Fatalf("err = %v, want ErrNoClientSecret", err)
+			}
+		})
+	}
+}
+
+func TestRelyingPartyCache_NoSecretStoreFailsRatherThanPanics(t *testing.T) {
+	c := NewRelyingPartyCache(nil, 0)
+	if _, err := c.For(context.Background(), testConfig("https://idp.example.com")); !errors.Is(err, ErrNoClientSecret) {
+		t.Fatalf("err = %v, want ErrNoClientSecret", err)
+	}
+}
+
+// A failed build must not be cached as a success, or one bad moment would
+// wedge a tenant's SSO for the whole TTL.
+func TestRelyingPartyCache_AFailedBuildIsNotCached(t *testing.T) {
+	ds := newDiscoveryServer(t)
+	secrets := &stubSecrets{err: errors.New("bao down")}
+	c := NewRelyingPartyCache(secrets, 0)
+	cfg := testConfig(ds.URL)
+
+	if _, err := c.For(context.Background(), cfg); err == nil {
+		t.Fatal("expected a failure")
+	}
+	secrets.err = nil
+	secrets.data = map[string]string{OIDCSecretField: "s3cr3t"}
+
+	if _, err := c.For(context.Background(), cfg); err != nil {
+		t.Fatalf("For after the secret store recovered: %v", err)
+	}
+}
+
+// One tenant's broken IdP must not affect another's. This is the property the
+// startup-map design could not offer at all: there, a single unreachable
+// issuer failed the whole service for everyone.
+func TestRelyingPartyCache_OneBrokenTenantDoesNotAffectAnother(t *testing.T) {
+	ds := newDiscoveryServer(t)
+	c := NewRelyingPartyCache(goodSecrets(), 0)
+
+	broken := testConfig("http://127.0.0.1:1/nope")
+	if _, err := c.For(context.Background(), broken); err == nil {
+		t.Fatal("a broken issuer built successfully")
+	}
+
+	working := testConfig(ds.URL)
+	if _, err := c.For(context.Background(), working); err != nil {
+		t.Fatalf("a working tenant failed because another tenant is broken: %v", err)
+	}
+}


### PR DESCRIPTION
Towards #820. Implements three of the four missing pieces and fixes two bugs the missing pieces were hiding. **Neither route is mounted yet** — the fourth piece is an architectural decision, not a wiring fill, and it is on the issue.

## What is implemented

**`TenantResolver`** — had a `TODO(wiring)` and no implementing type anywhere, which is why the login route could not be mounted at all: the handler answers 503 when it is nil.

It resolves through the **stores projection**. The route parameter is `:tenantSlug`, but a slug in this estate is always a *store* slug — it is what `{slug}-admin.mark8ly.com` is built from — and a store belongs to exactly one tenant. This service has no tenants table to consult instead. It goes through `stores.SlugCache` rather than the repository because that cache already solves this lookup for admin and storefront routing, including a stale-but-cached fallback when platform-api is down: an SSO login failing because platform-api blinked, when the answer was sitting in the projection table, would be a worse outage than the one it reported.

**`sso.RelyingPartyCache`** — replaces `OIDCRPs map[string]*sso.OIDCRelyingParty`.

#820 suggests building that map at startup. **That would be wrong**, and the map is why it reads as easy:

- `BuildOIDCRelyingParty` performs OIDC **discovery** — an HTTP call to the tenant's issuer. Building every tenant's party at boot makes every customer's IdP a startup dependency: one unreachable issuer takes the service down for everyone, over one tenant's misconfiguration.
- A map built at boot cannot contain a tenant who configures SSO afterwards. For a self-serve feature that means "works after the next deploy".

Lazy inverts both, and there is a test for each: one broken tenant does not affect another, and 20 concurrent first-logins produce exactly one discovery call. Client secrets resolve through **OpenBao** — the metadata comment still said "Secret Manager path", a backend retired in #813.

**`Repo` is now an interface.** It was a concrete `*sso.Repository`, so no test could reach any branch past the config load. That is not a tidiness point — see below for what it was hiding. Typed nils are normalised in the constructor, the #288 shape.

## Two bugs the untestability was hiding

**`loginSAML` returned nothing at all** — no status, no body. A SAML tenant got `200` with an empty response: a blank page to the merchant, a successful login to anything counting status codes. `Callback` already answered 501 for the same reason, so which of the two routes you hit decided whether SSO looked broken or looked fine. They now agree, and there is a test asserting they agree rather than asserting each separately.

**The login route named which tenants have SSO.** The disabled-config branch answered 404 with `"SSO is not enabled for this tenant"`, while unknown-tenant and missing-config both answered 404 with `"no SSO configuration for this tenant"`. On an unauthenticated route, that difference confirms a tenant exists *and* has an IdP configured — and since SSO is Pro-gated, it enumerates paying customers. All three now go through one `ssoNotFound` helper, because the property being protected is that they are identical and three copies of a string is how that stops being true.

I found this by writing the test, not by reading the code.

## Why nothing is mounted

`sso.UsersRepo` has **no implementation either** — #820 lists three gaps; there are four. JIT needs it for "find the existing Mark8ly user with this email in this tenant" and "create one".

It cannot be satisfied locally. `user_profiles` is keyed on a provider subject, is not tenant-scoped, and holds display preferences. Membership is FGA tuples; identity is Zitadel. FGA checks a relation for a **known** id and cannot search by email, and platform-api exposes no lookup-by-email — `/users/me/tenants` and `/tenants/:id/me` both start from a uid.

So the first SSO login of an existing admin is an architectural question, and the wrong answer is silently wrong: they would be minted a **new internal id**, giving one human two identities. Mounting the login route before that is settled would ship exactly the failure #820 was opened about, one layer deeper.

The config route is also left unmounted: letting a merchant save an IdP config that cannot be used is the same "looks delivered, does nothing" shape.

**The decision is on the issue and needs an answer before the next step.**

## Test plan

- [x] `gofmt`, `go build ./...`, `go vet ./...` clean; full marketplace-api suite green
- [x] `go test -race` on the cache's concurrency test
- [x] 5 resolver tests: resolves, unknown slug is `ErrTenantNotFound`, empty slug does not hit the store lookup, a lookup **failure** is not reported as a missing tenant (that renders 404), a corrupt tenant id is an error not a 404
- [x] 9 cache tests: builds once, reuses, invalidate forces a rebuild, TTL expiry, concurrent coalescing, missing-secret is its own error, nil secret store fails rather than panics, a failed build is not cached, one broken tenant does not affect another
- [x] New handler tests: SAML refused not silently empty; login and callback agree; disabled config indistinguishable from unknown tenant; unbuildable RP is 503 **without leaking the issuer URL**; the RP is fetched per request; typed-nil repo does not panic
- [x] `TestSSOCallback_OIDC_WrongState_Returns401` rewritten — it asserted 503 with a comment explaining a config could not be loaded without a database, so a test named for the state check proved only that a nil repo short-circuits
- [ ] End-to-end SSO login. Blocked on the identity decision above.
