### PR TITLE
feat(sso): wire per-tenant SSO onto a real identity source, and mount it (#820)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -111,6 +111,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/shipmentcancel"
 	"github.com/mark8ly/marketplace-api/internal/shipping"
 	"github.com/mark8ly/marketplace-api/internal/signup"
+	"github.com/mark8ly/marketplace-api/internal/sso"
 	"github.com/mark8ly/marketplace-api/internal/stockhold"
 	"github.com/mark8ly/marketplace-api/internal/storeidentity"
 	"github.com/mark8ly/marketplace-api/internal/stores"
@@ -574,6 +575,12 @@ func main() {
 	// process never mounts the admin group so these dependencies would go
 	// unused there.
 	var adminDeps admin.Deps
+	// ssoLoginHandler is declared at this outer scope for the same reason
+	// breakGlassLoginHandler below is: it is BUILT in the admin-mode block,
+	// where its dependencies live, and MOUNTED further down on the public
+	// group. Building it beside its deps and mounting it beside the other
+	// public routes is what keeps both halves readable (#820).
+	var ssoLoginHandler *public.SSOLoginHandler
 	// breakGlassLoginHandler and breakGlassRateLimiter are declared at this
 	// outer scope (not inside the admin-mode block below) because
 	// breakGlassRateLimiter must ALSO reach platformadmin.Deps.BreakGlassRateLimiter
@@ -1432,8 +1439,25 @@ func main() {
 			})
 		}
 
+		// P13 §12 — per-tenant SSO (#820). Both surfaces are constructed
+		// here or neither is: a merchant able to SAVE an IdP config that
+		// nobody can then sign in with is the "looks delivered, does
+		// nothing" state #820 was opened about.
+		ssoRepo := sso.NewRepository(conn)
+		ssoConfigHandler, ssoLogin := buildSSO(ssoDeps{
+			cfg:      cfg,
+			repo:     ssoRepo,
+			stores:   storesRepo,
+			platform: platformClient,
+			bao:      breakGlassBaoClient,
+			audit:    auditEmitter,
+			log:      log,
+		})
+		ssoLoginHandler = ssoLogin
+
 		adminDeps = admin.Deps{
 			BreakGlassLoginHandler:   breakGlassLoginHandler,
+			SSOConfigHandler:         ssoConfigHandler,
 			TenantGate:               adminTenantGateHandler,
 			ProductHandler:           productHandler,
 			CategoryHandler:          categoryHandler,
@@ -2559,6 +2583,7 @@ func main() {
 		})
 		storefront.RegisterStorefront(r.Group("/api/v1"), storefrontDeps)
 		public.RegisterPublic(r.Group("/api/v1"), public.PublicDeps{
+			SSOLoginHandler:           ssoLoginHandler,
 			DelhiveryWebhookHandler:   delhiveryWebhookHandler,
 			JournalSubscribeHandler:   journalSubscribeHandler,
 			JournalUnsubscribeHandler: journalUnsubscribeHandler,

--- a/services/marketplace-api/cmd/marketplace-api/wiring_sso.go
+++ b/services/marketplace-api/cmd/marketplace-api/wiring_sso.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"log/slog"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/authbffclient"
+	"github.com/mark8ly/marketplace-api/internal/bao"
+	"github.com/mark8ly/marketplace-api/internal/handlers/admin"
+	"github.com/mark8ly/marketplace-api/internal/handlers/public"
+	"github.com/mark8ly/marketplace-api/internal/sso"
+	"github.com/mark8ly/marketplace-api/internal/ssousers"
+	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/pkg/config"
+)
+
+// wiring_sso.go — per-tenant SSO (#820).
+//
+// Both surfaces are built here, together, or neither is. Letting a merchant
+// SAVE an IdP configuration that nobody can then sign in with is the
+// "looks delivered, does nothing" state #820 exists to remove, and mounting
+// the login route without an identity source is worse: it would take the
+// merchant through their IdP and fail at the last step.
+
+// ssoDeps is what building the SSO surfaces needs from main.
+type ssoDeps struct {
+	cfg      *config.Config
+	repo     *sso.Repository
+	stores   stores.Repository
+	platform stores.Client
+	bao      *bao.Client
+	audit    *audit.Emitter
+	log      *slog.Logger
+}
+
+// buildSSO returns the config handler and the login handler, or (nil, nil)
+// when this deployment cannot serve SSO.
+//
+// Nil rather than handlers that fail: the route registrations are guarded on
+// nil, so an unconfigured deployment simply has no SSO routes — which is the
+// honest answer, and distinguishable from a broken one.
+//
+// The preconditions are the ones without which a login CANNOT complete:
+//
+//   - platform-api, which is the only thing that can say who an email is
+//     (marketplace-api has no user identity store at all — see
+//     internal/ssousers);
+//   - OpenBao, which holds every tenant's OIDC client secret;
+//   - auth-bff, which mints the session at the end of a successful callback.
+//
+// A missing one is logged at Error, not silently skipped: an operator who
+// configured SSO and finds no routes deserves to be told which piece is
+// absent.
+func buildSSO(d ssoDeps) (*admin.SSOConfigHandler, *public.SSOLoginHandler) {
+	switch {
+	case d.cfg.PlatformAPIURL == "":
+		d.log.Error("sso: MARKETPLACE_PLATFORM_API_URL is unset — SSO routes stay unmounted; " +
+			"identity resolution needs platform-api")
+		return nil, nil
+	case d.bao == nil:
+		d.log.Error("sso: no OpenBao client — SSO routes stay unmounted; " +
+			"tenant OIDC client secrets live there")
+		return nil, nil
+	case d.cfg.AuthBFFURL == "":
+		d.log.Error("sso: AUTH_BFF_URL is unset — SSO routes stay unmounted; " +
+			"a successful callback has nowhere to mint a session")
+		return nil, nil
+	}
+
+	// The relying-party cache reads client secrets straight from OpenBao at
+	// the path each tenant's config names. It builds per tenant on first use,
+	// so one customer's unreachable IdP cannot delay startup or affect
+	// another tenant (see sso/rp_cache.go).
+	rps := sso.NewRelyingPartyCache(d.bao, 0)
+
+	users := ssousers.NewClient(d.cfg.PlatformAPIURL, d.cfg.PlatformAPISecret, nil)
+	jit := sso.NewJITProvisioner(users, d.repo)
+
+	// The tenant resolver shares the slug cache's shape but not its instance:
+	// StoreMiddleware's cache is built for the admin request path, and an
+	// unauthenticated login route should not be able to evict entries that
+	// signed-in traffic depends on.
+	slugs := stores.NewSlugCache(d.stores, d.platform, &singleflight.Group{}, 5*time.Minute)
+
+	login := public.NewSSOLoginHandler(
+		d.repo,
+		jit,
+		authbffclient.NewSessionIssuer(d.cfg.AuthBFFURL, d.cfg.InternalAuthSecret, nil),
+		rps,
+		public.NewMemStateCache(),
+		d.audit,
+		public.NewStoreSlugTenantResolver(slugs),
+		d.log,
+	)
+
+	return admin.NewSSOConfigHandler(d.repo, d.audit, d.log), login
+}

--- a/services/marketplace-api/internal/handlers/public/sso_mount_test.go
+++ b/services/marketplace-api/internal/handlers/public/sso_mount_test.go
@@ -1,0 +1,57 @@
+package public_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/handlers/public"
+)
+
+// The mount test #820 asked for.
+//
+// Deliberately NOT the 404-vs-405 probe the issue text suggests:
+// HandleMethodNotAllowed is never set in any service in this estate, so gin
+// answers 404 whether or not a route is mounted and that probe distinguishes
+// nothing. Instead it compares a router built WITHOUT the handler against one
+// built WITH it, through the real RegisterPublic — an unmounted route 404s, a
+// mounted one answers its own error.
+func TestRegisterPublic_SSORoutesExistOnlyWhenTheHandlerIsSupplied(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	bare := gin.New()
+	public.RegisterPublic(bare.Group("/"), public.PublicDeps{})
+
+	// A handler with no dependencies at all still MOUNTS; it answers 503 from
+	// its own nil checks. That difference is the whole point: "the route is
+	// not there" and "the route is there and cannot serve" are different
+	// failures with different fixes, and #820 exists because they were
+	// indistinguishable.
+	mounted := gin.New()
+	public.RegisterPublic(mounted.Group("/"), public.PublicDeps{
+		SSOLoginHandler: public.NewSSOLoginHandler(nil, nil, nil, nil, nil, nil, nil, nil),
+	})
+
+	for _, route := range []struct {
+		method, path string
+	}{
+		{http.MethodGet, "/sso/acme/login"},
+		{http.MethodPost, "/sso/acme/callback"},
+		{http.MethodPost, "/sso/acme/logout"},
+	} {
+		t.Run(route.method+" "+route.path, func(t *testing.T) {
+			bareRec := httptest.NewRecorder()
+			bare.ServeHTTP(bareRec, httptest.NewRequest(route.method, route.path, nil))
+			require.Equal(t, http.StatusNotFound, bareRec.Code,
+				"the route exists without an SSO handler")
+
+			rec := httptest.NewRecorder()
+			mounted.ServeHTTP(rec, httptest.NewRequest(route.method, route.path, nil))
+			require.NotEqual(t, http.StatusNotFound, rec.Code,
+				"the route is missing even though a handler was supplied")
+		})
+	}
+}

--- a/services/marketplace-api/internal/ssousers/client.go
+++ b/services/marketplace-api/internal/ssousers/client.go
@@ -1,0 +1,178 @@
+// Package ssousers implements sso.UsersRepo against platform-api (#820).
+//
+// It exists because marketplace-api cannot answer "who is this email in this
+// tenant" for itself. `user_profiles` is keyed on a provider subject, is not
+// tenant-scoped, and holds display preferences; membership is FGA tuples and
+// identity is Zitadel. FGA can check a relation for a KNOWN id but cannot
+// search by email.
+//
+// Getting that answer wrong is silently wrong. A merchant admin who already
+// signs in with a password would, on their first SSO login, be minted a SECOND
+// identity — their role would not follow them, their audit trail would split,
+// and they would most likely land with no access at all.
+package ssousers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DefaultRole is the tenant role granted to a user provisioned by an SSO
+// login. Staff, deliberately: an IdP assertion is a statement about WHO
+// someone is, not about how much they should be trusted, and the tenant's
+// owner can raise it afterwards.
+const DefaultRole = "staff"
+
+// Client calls platform-api's SSO identity routes.
+type Client struct {
+	baseURL string
+	secret  string
+	http    *http.Client
+}
+
+// NewClient constructs a Client. httpClient may be nil.
+//
+// The timeout is longer than the stores client's 3s because these calls reach
+// Zitadel and OpenFGA behind platform-api, and they sit on an interactive
+// login path where a retry means starting the IdP round-trip again.
+func NewClient(baseURL, secret string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &Client{baseURL: baseURL, secret: secret, http: httpClient}
+}
+
+// FindByTenantAndEmail satisfies sso.UsersRepo.
+//
+// found is true ONLY when the email already belongs to a member of the
+// tenant — someone with a role, whose identity is reused as-is. An account
+// that exists but holds no role here answers false, which sends JIT to
+// CreateForTenant; that resolves the same account rather than duplicating it
+// and grants the role. Both paths land on one identity, which is why the JIT
+// algorithm itself needed no change.
+func (c *Client) FindByTenantAndEmail(ctx context.Context, tenantID uuid.UUID, email string) (uuid.UUID, bool, error) {
+	var out struct {
+		UserID string `json:"user_id"`
+		Found  bool   `json:"found"`
+	}
+	err := c.post(ctx,
+		fmt.Sprintf("/internal/tenants/%s/sso-users/lookup", tenantID),
+		map[string]string{"email": email}, &out)
+	if err != nil {
+		return uuid.Nil, false, err
+	}
+	if !out.Found {
+		return uuid.Nil, false, nil
+	}
+	id, err := parseUserID(out.UserID)
+	if err != nil {
+		return uuid.Nil, false, err
+	}
+	return id, true, nil
+}
+
+// CreateForTenant satisfies sso.UsersRepo: ensure the account exists and give
+// it a role on the tenant.
+//
+// attrs carries whatever the IdP asserted; only the name is used, and only to
+// satisfy Zitadel's requirement for a non-empty given/family name. The role
+// argument from JIT is ignored in favour of DefaultRole for the reason given
+// there: an IdP says who someone is, not how much to trust them.
+func (c *Client) CreateForTenant(ctx context.Context, tenantID uuid.UUID, email string,
+	attrs map[string]any, _ string) (uuid.UUID, error) {
+
+	first, last := namesFrom(attrs)
+
+	var out struct {
+		UserID string `json:"user_id"`
+	}
+	err := c.post(ctx,
+		fmt.Sprintf("/internal/tenants/%s/sso-users", tenantID),
+		map[string]string{
+			"email":      email,
+			"first_name": first,
+			"last_name":  last,
+			"role":       DefaultRole,
+		}, &out)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	return parseUserID(out.UserID)
+}
+
+// namesFrom pulls a display name out of the resolved IdP attributes.
+//
+// Both halves are best-effort: platform-api derives them from the email local
+// part when they arrive empty, because Zitadel rejects an empty givenName or
+// familyName outright and a nameless assertion would otherwise fail the login
+// rather than provision.
+func namesFrom(attrs map[string]any) (first, last string) {
+	get := func(keys ...string) string {
+		for _, k := range keys {
+			if v, ok := attrs[k].(string); ok && v != "" {
+				return v
+			}
+		}
+		return ""
+	}
+	return get("firstName", "given_name", "givenName"),
+		get("lastName", "family_name", "familyName", "surname")
+}
+
+func parseUserID(raw string) (uuid.UUID, error) {
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		// Zitadel ids are not UUIDs in every deployment shape, and
+		// sso.UsersRepo's contract is a uuid.UUID. Saying so plainly beats
+		// returning uuid.Nil, which would read as a valid user and bind an
+		// SSO login to the zero identity.
+		return uuid.Nil, fmt.Errorf("ssousers: platform-api returned a non-UUID user id %q: %w", raw, err)
+	}
+	return id, nil
+}
+
+func (c *Client) post(ctx context.Context, path string, body any, out any) error {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("ssousers: encode: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("ssousers: new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if c.secret != "" {
+		req.Header.Set("X-Internal-Auth", c.secret)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("ssousers: %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// The body is not surfaced to the merchant — it can name another
+		// account holding the same address — but it is worth carrying into
+		// the log, where the SSO handler already sends its causes.
+		return fmt.Errorf("ssousers: %s: unexpected status %d", path, resp.StatusCode)
+	}
+
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return fmt.Errorf("ssousers: %s: decode: %w", path, err)
+	}
+	if err := json.Unmarshal(envelope.Data, out); err != nil {
+		return fmt.Errorf("ssousers: %s: decode data: %w", path, err)
+	}
+	return nil
+}

--- a/services/marketplace-api/internal/ssousers/client_test.go
+++ b/services/marketplace-api/internal/ssousers/client_test.go
@@ -1,0 +1,189 @@
+package ssousers_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/sso"
+	"github.com/mark8ly/marketplace-api/internal/ssousers"
+)
+
+// The client must satisfy the interface JIT provisioning consumes. Asserted
+// here because that interface had NO implementation at all until #820, which
+// is why the SSO login route could not be mounted.
+var _ sso.UsersRepo = (*ssousers.Client)(nil)
+
+const testSecret = "internal-auth-for-tests"
+
+type capture struct {
+	path   string
+	auth   string
+	body   map[string]any
+	status int
+	reply  string
+}
+
+func serve(t *testing.T, c *capture) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.path = r.URL.Path
+		c.auth = r.Header.Get("X-Internal-Auth")
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &c.body)
+
+		status := c.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(c.reply))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestFindByTenantAndEmail_ReturnsTheMemberIdentity(t *testing.T) {
+	userID := uuid.New()
+	tenantID := uuid.New()
+	c := &capture{reply: `{"data":{"user_id":"` + userID.String() + `","found":true}}`}
+	srv := serve(t, c)
+
+	got, found, err := ssousers.NewClient(srv.URL, testSecret, nil).
+		FindByTenantAndEmail(context.Background(), tenantID, "someone@example.com")
+
+	if err != nil {
+		t.Fatalf("FindByTenantAndEmail: %v", err)
+	}
+	if !found || got != userID {
+		t.Fatalf("got %s found=%v, want %s true", got, found, userID)
+	}
+	if c.path != "/internal/tenants/"+tenantID.String()+"/sso-users/lookup" {
+		t.Errorf("path = %q", c.path)
+	}
+	if c.auth != testSecret {
+		t.Errorf("internal auth header = %q — the route refuses without it", c.auth)
+	}
+	if c.body["email"] != "someone@example.com" {
+		t.Errorf("body = %v", c.body)
+	}
+}
+
+func TestFindByTenantAndEmail_NotFoundIsNotAnError(t *testing.T) {
+	c := &capture{reply: `{"data":{"user_id":"","found":false}}`}
+	srv := serve(t, c)
+
+	got, found, err := ssousers.NewClient(srv.URL, testSecret, nil).
+		FindByTenantAndEmail(context.Background(), uuid.New(), "nobody@example.com")
+
+	if err != nil {
+		t.Fatalf("FindByTenantAndEmail: %v", err)
+	}
+	if found || got != uuid.Nil {
+		t.Fatalf("got %s found=%v, want the zero identity and false", got, found)
+	}
+}
+
+// A failed lookup must NOT read as "no such user": JIT's next step on false is
+// to provision, so an outage would create a duplicate account per login.
+func TestFindByTenantAndEmail_AFailureIsNotANegativeAnswer(t *testing.T) {
+	c := &capture{status: http.StatusInternalServerError, reply: `{"error":"boom"}`}
+	srv := serve(t, c)
+
+	_, found, err := ssousers.NewClient(srv.URL, testSecret, nil).
+		FindByTenantAndEmail(context.Background(), uuid.New(), "someone@example.com")
+
+	if err == nil {
+		t.Fatal("a 500 was reported as a successful lookup")
+	}
+	if found {
+		t.Fatal("a failure reported found=true")
+	}
+}
+
+func TestCreateForTenant_SendsTheAssertedNameAndTheDefaultRole(t *testing.T) {
+	userID := uuid.New()
+	tenantID := uuid.New()
+	c := &capture{reply: `{"data":{"user_id":"` + userID.String() + `"}}`}
+	srv := serve(t, c)
+
+	got, err := ssousers.NewClient(srv.URL, testSecret, nil).CreateForTenant(
+		context.Background(), tenantID, "new.person@example.com",
+		map[string]any{"firstName": "New", "lastName": "Person"}, "ignored")
+
+	if err != nil {
+		t.Fatalf("CreateForTenant: %v", err)
+	}
+	if got != userID {
+		t.Errorf("got %s, want %s", got, userID)
+	}
+	if c.path != "/internal/tenants/"+tenantID.String()+"/sso-users" {
+		t.Errorf("path = %q", c.path)
+	}
+	if c.body["first_name"] != "New" || c.body["last_name"] != "Person" {
+		t.Errorf("names = %v", c.body)
+	}
+	// The role JIT passes is deliberately ignored: an IdP assertion says who
+	// someone is, not how much to trust them.
+	if c.body["role"] != ssousers.DefaultRole {
+		t.Errorf("role = %v, want %q", c.body["role"], ssousers.DefaultRole)
+	}
+}
+
+// Zitadel's own attribute names differ per IdP. Missing names are fine —
+// platform-api derives them from the email — but a name that WAS asserted must
+// not be dropped.
+func TestCreateForTenant_ReadsTheCommonAttributeSpellings(t *testing.T) {
+	for _, attrs := range []map[string]any{
+		{"given_name": "Jo", "family_name": "Lee"},
+		{"givenName": "Jo", "familyName": "Lee"},
+		{"firstName": "Jo", "surname": "Lee"},
+	} {
+		c := &capture{reply: `{"data":{"user_id":"` + uuid.New().String() + `"}}`}
+		srv := serve(t, c)
+
+		if _, err := ssousers.NewClient(srv.URL, testSecret, nil).CreateForTenant(
+			context.Background(), uuid.New(), "jo@example.com", attrs, ""); err != nil {
+			t.Fatalf("CreateForTenant: %v", err)
+		}
+		if c.body["first_name"] != "Jo" || c.body["last_name"] != "Lee" {
+			t.Errorf("attrs %v produced names %v", attrs, c.body)
+		}
+	}
+}
+
+func TestCreateForTenant_MissingNamesAreLeftToPlatformAPI(t *testing.T) {
+	c := &capture{reply: `{"data":{"user_id":"` + uuid.New().String() + `"}}`}
+	srv := serve(t, c)
+
+	if _, err := ssousers.NewClient(srv.URL, testSecret, nil).CreateForTenant(
+		context.Background(), uuid.New(), "jo@example.com", nil, ""); err != nil {
+		t.Fatalf("CreateForTenant: %v", err)
+	}
+	if c.body["first_name"] != nil && c.body["first_name"] != "" {
+		t.Errorf("first_name = %v, want empty so platform-api derives it", c.body["first_name"])
+	}
+}
+
+// uuid.Nil would read as a valid identity and bind the SSO login to the zero
+// user, so a non-UUID id has to be an error rather than a fallback.
+func TestParseFailure_IsAnErrorNotTheZeroIdentity(t *testing.T) {
+	c := &capture{reply: `{"data":{"user_id":"not-a-uuid","found":true}}`}
+	srv := serve(t, c)
+
+	_, found, err := ssousers.NewClient(srv.URL, testSecret, nil).
+		FindByTenantAndEmail(context.Background(), uuid.New(), "someone@example.com")
+
+	if err == nil {
+		t.Fatal("a non-UUID user id was accepted")
+	}
+	if found {
+		t.Fatal("a malformed id reported found=true")
+	}
+}

--- a/services/platform-api/cmd/server/main.go
+++ b/services/platform-api/cmd/server/main.go
@@ -287,6 +287,18 @@ func main() {
 		panic(provisionerErr)
 	}
 
+	// The same provisioner, kept at its CONCRETE type for the SSO identity
+	// routes (mark8ly#820). staffProvisioner above is an interface, so a
+	// "not configured" value there is a typed nil that no == nil check can
+	// see — the trap buildZitadelProvisioner's doc exists to keep out of the
+	// wiring. Built through that function for the same reason the two
+	// provisioners above are.
+	ssoUsersProvisioner, ssoProvErr := buildZitadelProvisioner(cfg)
+	if ssoProvErr != nil {
+		log.Error("sso users provisioner wiring", "err", ssoProvErr)
+		panic(ssoProvErr)
+	}
+
 	invitationSvc := invitation.NewService(invitation.Config{
 		Repo:        invitation.NewRepository(conn),
 		TenantRepo:  tenantRepo,
@@ -382,6 +394,7 @@ func main() {
 		EstateCounts:        estate.NewHandler(estate.NewRepository(conn)).Register,
 		EstateUsers:         estateuser.NewHandler(estateuser.NewRepository(conn)).Register,
 		AccountOperator:     accountHandler.RegisterOperator,
+		SSOUsers:            ssoUsersRegistrar(ssoUsersProvisioner, fga),
 
 		Tenant:          func(g *gin.RouterGroup) { tenantHandler.Register(v1, g) },
 		Store:           func(g *gin.RouterGroup) { storeHandler.Register(v1, g) },

--- a/services/platform-api/cmd/server/sso_users_wiring.go
+++ b/services/platform-api/cmd/server/sso_users_wiring.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/platform-api/internal/authz"
+	"github.com/mark8ly/platform-api/internal/routes"
+	"github.com/mark8ly/platform-api/internal/ssousers"
+	"github.com/mark8ly/platform-api/internal/zitadeladmin"
+)
+
+// ssoUsersRegistrar wires the SSO identity routes marketplace-api's JIT
+// provisioning calls (mark8ly#820), or returns nil when this deployment cannot
+// serve them.
+//
+// Nil rather than a handler that 503s, because MountInternal skips a nil
+// registrar and the route is then genuinely absent — which is the honest
+// answer for a deployment with no Zitadel configured. A mounted route that
+// always fails would look like an outage instead of a configuration.
+//
+// Both dependencies are required and both can legitimately be absent:
+// staffProvisioner is nil unless ZITADEL_ENABLED, and fga is nil when OpenFGA
+// is unconfigured. Provisioning needs both — an account nobody can grant a
+// role to is not a provisioned user — so either being nil means no route.
+func ssoUsersRegistrar(provisioner *zitadeladmin.StaffProvisioner, fga authz.Client) routes.Registrar {
+	// A typed nil would satisfy the interface and panic on first use, the
+	// #288 shape; compared against the concrete type before it is widened.
+	if provisioner == nil || fga == nil {
+		return nil
+	}
+	h := ssousers.NewHandler(ssousers.NewService(provisioner, fga))
+	return func(g *gin.RouterGroup) { h.Register(g) }
+}

--- a/services/platform-api/internal/routes/internal.go
+++ b/services/platform-api/internal/routes/internal.go
@@ -26,6 +26,7 @@ type InternalHandlers struct {
 	EstateCounts        Registrar
 	EstateUsers         Registrar
 	AccountOperator     Registrar
+	SSOUsers            Registrar
 
 	Tenant          Registrar
 	Store           Registrar
@@ -40,7 +41,7 @@ type InternalHandlers struct {
 func StrictSlots() []string {
 	return []string{
 		"TenantDirectory", "TenantLifecycle", "OnboardingAnalytics",
-		"EstateCounts", "EstateUsers", "AccountOperator",
+		"EstateCounts", "EstateUsers", "AccountOperator", "SSOUsers",
 	}
 }
 
@@ -58,7 +59,10 @@ func PermissiveSlots() []string {
 // to know — you need a tenant id to ask for its members.
 //
 // The strict group refuses with 503 on an empty secret instead. Its
-// routes return ESTATE-WIDE data — every tenant (#277), every staff
+// routes either return ESTATE-WIDE data or perform a privileged WRITE —
+// SSOUsers creates an account and grants it a role on a tenant
+// (mark8ly#820), which an unconfigured deploy must refuse rather than offer
+// to anything that reaches the pod. Its other routes return ESTATE-WIDE data — every tenant (#277), every staff
 // identity (#278), platform-wide counts (#282), the onboarding funnel
 // (#283) — so an unconfigured deploy must refuse rather than serve the
 // lot to anything that reaches the pod.
@@ -69,7 +73,7 @@ func MountInternal(r gin.IRouter, secret string, h InternalHandlers) {
 	strict := r.Group("/internal", middleware.RequireInternalAuthStrict(secret))
 	mount(strict,
 		h.TenantDirectory, h.TenantLifecycle, h.OnboardingAnalytics,
-		h.EstateCounts, h.EstateUsers, h.AccountOperator,
+		h.EstateCounts, h.EstateUsers, h.AccountOperator, h.SSOUsers,
 	)
 
 	permissive := r.Group("/internal", middleware.RequireInternalAuth(secret))

--- a/services/platform-api/internal/routes/internal_test.go
+++ b/services/platform-api/internal/routes/internal_test.go
@@ -34,6 +34,12 @@ var (
 	wantStrict = []string{
 		"TenantDirectory", "TenantLifecycle", "OnboardingAnalytics",
 		"EstateCounts", "EstateUsers", "AccountOperator",
+		// SSOUsers is strict for a different reason from the rest: it is
+		// not estate-wide data, it is a privileged WRITE — it creates an
+		// account and grants it a role on a tenant (mark8ly#820). The
+		// permissive guard no-ops on an empty secret, so an unconfigured
+		// deploy would offer that to anything that reaches the pod.
+		"SSOUsers",
 	}
 	wantPermissive = []string{
 		"Tenant", "Store", "Invitation", "Auth", "MerchantAccount", "Notification",

--- a/services/platform-api/internal/ssousers/handler.go
+++ b/services/platform-api/internal/ssousers/handler.go
@@ -1,0 +1,117 @@
+package ssousers
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mark8ly/platform-api/internal/zitadeladmin"
+	apperrors "github.com/mark8ly/platform-api/pkg/errors"
+)
+
+// Handler exposes the two internal routes marketplace-api's SSO JIT needs.
+type Handler struct{ svc *Service }
+
+// NewHandler constructs a Handler.
+func NewHandler(svc *Service) *Handler { return &Handler{svc: svc} }
+
+// Register mounts both routes on an /internal group.
+//
+// They belong behind the STRICT guard, not the permissive one that the other
+// tenant-scoped routes use. The permissive guard no-ops on an empty secret,
+// which is right for a read you had to know a tenant id to ask for — but
+// Provision CREATES an account and GRANTS it a role on a tenant. An
+// unconfigured deploy must refuse that rather than serve it to anything that
+// reaches the pod.
+func (h *Handler) Register(g *gin.RouterGroup) {
+	t := g.Group("/tenants/:id/sso-users")
+	{
+		t.POST("/lookup", h.lookup)
+		t.POST("", h.provision)
+	}
+}
+
+type lookupRequest struct {
+	Email string `json:"email" binding:"required"`
+}
+
+// lookup answers "is this email already a member of this tenant".
+//
+// found=false is a successful answer, not a 404: the caller's next step is to
+// provision, and a 404 would read as "this route is wrong".
+func (h *Handler) lookup(c *gin.Context) {
+	var req lookupRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondError(c, apperrors.BadRequest("invalid_request", err.Error()))
+		return
+	}
+
+	res, err := h.svc.Lookup(c.Request.Context(), c.Param("id"), req.Email)
+	if err != nil {
+		respondError(c, mapErr(err))
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{
+		"user_id": res.UserID,
+		"found":   res.Found,
+	}})
+}
+
+type provisionRequest struct {
+	Email     string `json:"email" binding:"required"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Role      string `json:"role" binding:"required"`
+}
+
+func (h *Handler) provision(c *gin.Context) {
+	var req provisionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondError(c, apperrors.BadRequest("invalid_request", err.Error()))
+		return
+	}
+
+	userID, err := h.svc.Provision(c.Request.Context(), ProvisionInput{
+		TenantID:  c.Param("id"),
+		Email:     req.Email,
+		FirstName: req.FirstName,
+		LastName:  req.LastName,
+		Role:      req.Role,
+	})
+	if err != nil {
+		respondError(c, mapErr(err))
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{"user_id": userID}})
+}
+
+// mapErr turns a service error into a status.
+//
+// ErrAmbiguousEmail is a 409 and deliberately not a 500: two accounts share
+// the address, and which one an IdP assertion refers to is not a question this
+// service may answer by picking. It needs a human.
+func mapErr(err error) error {
+	switch {
+	case errors.Is(err, zitadeladmin.ErrAmbiguousEmail):
+		return apperrors.Conflict("ambiguous_email",
+			"more than one account uses this email address")
+	case strings.Contains(err.Error(), "owner cannot be granted"),
+		strings.Contains(err.Error(), "unknown role"):
+		return apperrors.BadRequest("invalid_role", err.Error())
+	default:
+		return apperrors.Internal("sso_user_failed", err.Error())
+	}
+}
+
+func respondError(c *gin.Context, err error) {
+	if ae, ok := apperrors.As(err); ok {
+		c.AbortWithStatusJSON(ae.Status, gin.H{
+			"error":   ae.Code,
+			"message": ae.Message,
+		})
+		return
+	}
+	c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+}

--- a/services/platform-api/internal/ssousers/service.go
+++ b/services/platform-api/internal/ssousers/service.go
@@ -1,0 +1,212 @@
+// Package ssousers answers, for marketplace-api's SSO just-in-time
+// provisioning, the two questions it cannot answer for itself
+// (mark8ly#820):
+//
+//	"is there already a Mark8ly user with this email in this tenant?"
+//	"there is not — make one, with a role."
+//
+// marketplace-api has no user identity store. `user_profiles` is keyed on a
+// provider subject, is not tenant-scoped, and holds display preferences;
+// membership is FGA tuples and identity is Zitadel. FGA can check a relation
+// for a KNOWN id but cannot search by email, so the lookup has to happen
+// where Zitadel is — here.
+//
+// # Why this matters more than it looks
+//
+// Getting the answer wrong is silently wrong. A merchant admin who already
+// signs in with a password would, on their first SSO login, be minted a
+// SECOND identity: their existing role would not follow them, their audit
+// trail would split in two, and they would most likely land with no access at
+// all. Resolving through Zitadel is what keeps one human as one user.
+package ssousers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mark8ly/platform-api/internal/authz"
+	"github.com/mark8ly/platform-api/internal/idperr"
+)
+
+// EmailResolver maps an email to a Zitadel user id. *zitadeladmin.Client
+// satisfies it.
+type EmailResolver interface {
+	ResolveUserIDByEmail(ctx context.Context, email string) (string, error)
+}
+
+// StaffProvisioner makes an email a sign-in-capable identity on the admin
+// project WITHOUT giving it a password. *zitadeladmin.StaffProvisioner
+// satisfies it.
+type StaffProvisioner interface {
+	ProvisionSSOStaff(ctx context.Context, email, firstName, lastName string) (string, error)
+}
+
+// Directory is both halves. *zitadeladmin.StaffProvisioner satisfies it, so
+// the wiring passes one dependency rather than the client and the provisioner
+// separately — which also means the lookup and the create can never be
+// pointed at different Zitadel orgs.
+type Directory interface {
+	EmailResolver
+	StaffProvisioner
+}
+
+// Service resolves and provisions SSO identities.
+type Service struct {
+	dir Directory
+	fga authz.Client
+}
+
+// NewService constructs a Service.
+func NewService(dir Directory, fga authz.Client) *Service {
+	return &Service{dir: dir, fga: fga}
+}
+
+// LookupResult is the answer to "who is this email in this tenant".
+type LookupResult struct {
+	UserID string
+	// Found reports whether this email already belongs to a MEMBER of the
+	// tenant — someone with a role, whose identity should simply be reused.
+	//
+	// It is deliberately NOT "a Zitadel account with this email exists".
+	// An account that exists but holds no role in this tenant still needs a
+	// grant, and reporting it as found would bind the SSO login to an
+	// identity that cannot do anything. Answering false sends the caller to
+	// Provision, which resolves that same account rather than duplicating it
+	// and then grants the role. Both paths therefore end on ONE identity,
+	// with no change to marketplace-api's JIT algorithm.
+	Found bool
+}
+
+// Lookup resolves email within tenantID.
+//
+// A resolution failure is not "not found": the two are different answers and
+// only one of them means "go and create this person". An unreachable Zitadel
+// reported as not-found would provision duplicates for every login during an
+// outage.
+func (s *Service) Lookup(ctx context.Context, tenantID, email string) (LookupResult, error) {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return LookupResult{}, fmt.Errorf("ssousers: email is required")
+	}
+	if strings.TrimSpace(tenantID) == "" {
+		return LookupResult{}, fmt.Errorf("ssousers: tenant id is required")
+	}
+
+	userID, err := s.dir.ResolveUserIDByEmail(ctx, email)
+	if err != nil {
+		if errors.Is(err, idperr.ErrUserNotFound) {
+			return LookupResult{}, nil
+		}
+		return LookupResult{}, fmt.Errorf("ssousers: resolve %s: %w", email, err)
+	}
+
+	member, err := s.fga.CheckMembership(ctx, userID, tenantID)
+	if err != nil {
+		return LookupResult{}, fmt.Errorf("ssousers: membership check: %w", err)
+	}
+	if !member {
+		// The account exists but holds nothing here. Report the id anyway —
+		// the caller may want it for logging — but not as Found, so the
+		// grant still happens.
+		return LookupResult{UserID: userID, Found: false}, nil
+	}
+	return LookupResult{UserID: userID, Found: true}, nil
+}
+
+// ProvisionInput describes the account to ensure.
+type ProvisionInput struct {
+	TenantID  string
+	Email     string
+	FirstName string
+	LastName  string
+	// Role is the tenant role to grant. Restricted to the non-owner roles:
+	// an IdP assertion must never be able to mint an owner, which is the one
+	// role that can remove the actual owner.
+	Role string
+}
+
+// Provision ensures a Zitadel account for the email and grants it Role on the
+// tenant. Idempotent: an existing account is resolved rather than duplicated,
+// and an existing role write is a no-op.
+//
+// The account is created WITHOUT a password (see zitadeladmin.HumanUser's
+// WithoutPassword). An SSO-provisioned account with a password would be
+// signable-into through Zitadel directly, and a password could be set later
+// through password reset — either one bypassing the tenant's IdP and
+// everything it enforces. A tenant buys SSO to centralise that; the second
+// credential path is never created.
+func (s *Service) Provision(ctx context.Context, in ProvisionInput) (string, error) {
+	email := strings.TrimSpace(in.Email)
+	if email == "" {
+		return "", fmt.Errorf("ssousers: email is required")
+	}
+	if strings.TrimSpace(in.TenantID) == "" {
+		return "", fmt.Errorf("ssousers: tenant id is required")
+	}
+	role, err := tenantRole(in.Role)
+	if err != nil {
+		return "", err
+	}
+
+	first, last := names(in.FirstName, in.LastName, email)
+
+	// Resolve-or-create plus the admin-project grant, in one call that
+	// marketplace-api's invitation path already uses. The grant is what makes
+	// the admin app reachable at all (mark8ly-admin sets projectRoleCheck),
+	// and it happens before the tenant role so a partial failure leaves a
+	// user who cannot reach anything rather than one holding a role they
+	// cannot exercise.
+	userID, err := s.dir.ProvisionSSOStaff(ctx, email, first, last)
+	if err != nil {
+		return "", fmt.Errorf("ssousers: ensure user %s: %w", email, err)
+	}
+
+	if err := s.fga.WriteRole(ctx, userID, role, in.TenantID); err != nil {
+		return "", fmt.Errorf("ssousers: grant %s on %s: %w", role, in.TenantID, err)
+	}
+	return userID, nil
+}
+
+// tenantRole validates the requested role.
+//
+// Owner is refused outright. Every other role is additive, but owner is the
+// one that can remove the real owner — and the assertion driving this call
+// comes from a customer-controlled IdP, so it must not be able to reach it.
+func tenantRole(raw string) (authz.Role, error) {
+	switch authz.Role(strings.ToLower(strings.TrimSpace(raw))) {
+	case authz.RoleAdmin:
+		return authz.RoleAdmin, nil
+	case authz.RoleStaff:
+		return authz.RoleStaff, nil
+	case authz.RoleViewer:
+		return authz.RoleViewer, nil
+	case authz.RoleOwner:
+		return "", fmt.Errorf("ssousers: owner cannot be granted by SSO provisioning")
+	default:
+		return "", fmt.Errorf("ssousers: unknown role %q", raw)
+	}
+}
+
+// names fills the givenName/familyName Zitadel requires, deriving from the
+// email local part when the IdP sent nothing. Empty strings are rejected by
+// Zitadel outright, so a nameless assertion would otherwise fail the login.
+func names(first, last, email string) (string, string) {
+	first = strings.TrimSpace(first)
+	last = strings.TrimSpace(last)
+	if first != "" && last != "" {
+		return first, last
+	}
+	local := email
+	if at := strings.Index(email, "@"); at > 0 {
+		local = email[:at]
+	}
+	if first == "" {
+		first = local
+	}
+	if last == "" {
+		last = local
+	}
+	return first, last
+}

--- a/services/platform-api/internal/ssousers/service_test.go
+++ b/services/platform-api/internal/ssousers/service_test.go
@@ -1,0 +1,194 @@
+package ssousers_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/platform-api/internal/authz"
+	"github.com/mark8ly/platform-api/internal/idperr"
+	"github.com/mark8ly/platform-api/internal/ssousers"
+	"github.com/mark8ly/platform-api/internal/zitadeladmin"
+)
+
+const testTenant = "11111111-1111-1111-1111-111111111111"
+
+// stubDirectory stands in for *zitadeladmin.StaffProvisioner, which supplies
+// both the lookup and the create.
+type stubDirectory struct {
+	resolveID  string
+	resolveErr error
+
+	provisionID  string
+	provisionErr error
+	calls        []struct{ email, first, last string }
+}
+
+func (s *stubDirectory) ResolveUserIDByEmail(context.Context, string) (string, error) {
+	return s.resolveID, s.resolveErr
+}
+
+func (s *stubDirectory) ProvisionSSOStaff(_ context.Context, email, first, last string) (string, error) {
+	s.calls = append(s.calls, struct{ email, first, last string }{email, first, last})
+	return s.provisionID, s.provisionErr
+}
+
+type stubFGA struct {
+	authz.Client
+	member    bool
+	memberErr error
+	writes    []struct {
+		userID, tenantID string
+		role             authz.Role
+	}
+	writeErr error
+}
+
+func (s *stubFGA) CheckMembership(_ context.Context, _, _ string) (bool, error) {
+	return s.member, s.memberErr
+}
+
+func (s *stubFGA) WriteRole(_ context.Context, userID string, role authz.Role, tenantID string) error {
+	s.writes = append(s.writes, struct {
+		userID, tenantID string
+		role             authz.Role
+	}{userID, tenantID, role})
+	return s.writeErr
+}
+
+// ---------------------------------------------------------------------------
+// Lookup
+// ---------------------------------------------------------------------------
+
+func TestLookup_AMemberIsFound(t *testing.T) {
+	svc := ssousers.NewService(&stubDirectory{resolveID: "zid-1"}, &stubFGA{member: true})
+
+	res, err := svc.Lookup(context.Background(), testTenant, "someone@example.com")
+	require.NoError(t, err)
+	require.True(t, res.Found)
+	require.Equal(t, "zid-1", res.UserID)
+}
+
+// The subtle one. An account that exists but holds no role here must NOT be
+// reported as found: the caller would bind the SSO login to an identity with
+// no access. Answering false sends it to Provision, which resolves that same
+// account and grants the role — one identity, with access.
+func TestLookup_AnAccountWithNoRoleHereIsNotFound(t *testing.T) {
+	svc := ssousers.NewService(&stubDirectory{resolveID: "zid-1"}, &stubFGA{member: false})
+
+	res, err := svc.Lookup(context.Background(), testTenant, "someone@example.com")
+	require.NoError(t, err)
+	require.False(t, res.Found)
+	require.Equal(t, "zid-1", res.UserID, "the id is still reported, for logging")
+}
+
+func TestLookup_AnUnknownEmailIsNotFound(t *testing.T) {
+	svc := ssousers.NewService(&stubDirectory{resolveErr: idperr.ErrUserNotFound}, &stubFGA{})
+
+	res, err := svc.Lookup(context.Background(), testTenant, "nobody@example.com")
+	require.NoError(t, err)
+	require.False(t, res.Found)
+	require.Empty(t, res.UserID)
+}
+
+// "Zitadel is unreachable" reported as "not found" would provision a
+// duplicate account for every login for the duration of the outage.
+func TestLookup_AResolutionFailureIsNotANegativeAnswer(t *testing.T) {
+	svc := ssousers.NewService(&stubDirectory{resolveErr: errors.New("zitadel down")}, &stubFGA{})
+
+	_, err := svc.Lookup(context.Background(), testTenant, "someone@example.com")
+	require.Error(t, err)
+}
+
+// Two accounts sharing an address is not a question this service may settle
+// by picking one — it decides whose identity an IdP assertion binds to.
+func TestLookup_AnAmbiguousEmailIsAnError(t *testing.T) {
+	svc := ssousers.NewService(&stubDirectory{resolveErr: zitadeladmin.ErrAmbiguousEmail}, &stubFGA{})
+
+	_, err := svc.Lookup(context.Background(), testTenant, "shared@example.com")
+	require.ErrorIs(t, err, zitadeladmin.ErrAmbiguousEmail)
+}
+
+func TestLookup_AMembershipFailureIsNotANegativeAnswer(t *testing.T) {
+	svc := ssousers.NewService(&stubDirectory{resolveID: "zid-1"},
+		&stubFGA{memberErr: errors.New("openfga down")})
+
+	_, err := svc.Lookup(context.Background(), testTenant, "someone@example.com")
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Provision
+// ---------------------------------------------------------------------------
+
+func TestProvision_EnsuresTheAccountThenGrantsTheRole(t *testing.T) {
+	prov := &stubDirectory{provisionID: "zid-new"}
+	fga := &stubFGA{}
+	svc := ssousers.NewService(prov, fga)
+
+	id, err := svc.Provision(context.Background(), ssousers.ProvisionInput{
+		TenantID: testTenant, Email: "New.Person@example.com",
+		FirstName: "New", LastName: "Person", Role: "staff",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "zid-new", id)
+	require.Len(t, prov.calls, 1)
+	require.Len(t, fga.writes, 1)
+	require.Equal(t, authz.RoleStaff, fga.writes[0].role)
+	require.Equal(t, "zid-new", fga.writes[0].userID)
+	require.Equal(t, testTenant, fga.writes[0].tenantID)
+}
+
+// Owner is the one role that can remove the real owner, and the assertion
+// driving this call comes from a CUSTOMER-controlled IdP.
+func TestProvision_RefusesToGrantOwner(t *testing.T) {
+	prov := &stubDirectory{provisionID: "zid-new"}
+	fga := &stubFGA{}
+	svc := ssousers.NewService(prov, fga)
+
+	_, err := svc.Provision(context.Background(), ssousers.ProvisionInput{
+		TenantID: testTenant, Email: "attacker@example.com", Role: "owner",
+	})
+	require.Error(t, err)
+	require.Empty(t, prov.calls, "an account was created for a refused role")
+	require.Empty(t, fga.writes)
+}
+
+func TestProvision_RefusesAnUnknownRole(t *testing.T) {
+	svc := ssousers.NewService(&stubDirectory{}, &stubFGA{})
+
+	_, err := svc.Provision(context.Background(), ssousers.ProvisionInput{
+		TenantID: testTenant, Email: "someone@example.com", Role: "superuser",
+	})
+	require.Error(t, err)
+}
+
+// Zitadel rejects an empty givenName/familyName outright, so an assertion
+// carrying no name would otherwise fail the login rather than provision.
+func TestProvision_DerivesNamesFromTheEmailWhenTheIdPSendsNone(t *testing.T) {
+	prov := &stubDirectory{provisionID: "zid-new"}
+	svc := ssousers.NewService(prov, &stubFGA{})
+
+	_, err := svc.Provision(context.Background(), ssousers.ProvisionInput{
+		TenantID: testTenant, Email: "jordan@example.com", Role: "viewer",
+	})
+	require.NoError(t, err)
+	require.Len(t, prov.calls, 1)
+	require.Equal(t, "jordan", prov.calls[0].first)
+	require.Equal(t, "jordan", prov.calls[0].last)
+}
+
+// A role that could not be written means the user has an account and no
+// access. Reporting success would hand the caller a user id it would then
+// bind an SSO identity to, silently.
+func TestProvision_AFailedRoleWriteIsAFailure(t *testing.T) {
+	svc := ssousers.NewService(&stubDirectory{provisionID: "zid-new"},
+		&stubFGA{writeErr: errors.New("openfga down")})
+
+	_, err := svc.Provision(context.Background(), ssousers.ProvisionInput{
+		TenantID: testTenant, Email: "someone@example.com", Role: "staff",
+	})
+	require.Error(t, err)
+}

--- a/services/platform-api/internal/zitadeladmin/provision.go
+++ b/services/platform-api/internal/zitadeladmin/provision.go
@@ -71,6 +71,21 @@ type HumanUser struct {
 	// empty givenName/familyName.
 	FirstName string
 	LastName  string
+	// WithoutPassword creates the account with NO password credential.
+	//
+	// For SSO just-in-time provisioning (mark8ly#820), where there is no
+	// password to set — the IdP is what authenticates. It is deliberately an
+	// explicit flag rather than "Password == \"\" means passwordless",
+	// because a caller that simply forgot to pass one would then silently
+	// create an account with a credential path it did not intend.
+	//
+	// The point is what it withholds. An SSO-provisioned account WITH a
+	// password can be signed into through Zitadel's own password flow, and a
+	// password can be set later through password reset — both bypassing the
+	// tenant's IdP and everything it enforces (MFA, device posture,
+	// offboarding). A tenant buys SSO to centralise exactly that, so the
+	// second credential path must never be created in the first place.
+	WithoutPassword bool
 	// Password is set with changeRequired=false so the invitee can
 	// sign in immediately with what they just typed. Required when the
 	// user does not already exist.
@@ -116,8 +131,11 @@ func (c *Client) EnsureHumanUser(ctx context.Context, in HumanUser) (string, err
 	if first == "" || last == "" {
 		return "", fmt.Errorf("zitadeladmin: first and last name are required to create a human user")
 	}
-	if in.Password == "" {
+	if in.Password == "" && !in.WithoutPassword {
 		return "", fmt.Errorf("zitadeladmin: password is required to create a human user")
+	}
+	if in.Password != "" && in.WithoutPassword {
+		return "", fmt.Errorf("zitadeladmin: WithoutPassword and a password are contradictory")
 	}
 
 	body := map[string]any{
@@ -130,10 +148,15 @@ func (c *Client) EnsureHumanUser(ctx context.Context, in HumanUser) (string, err
 			"email":      email,
 			"isVerified": true,
 		},
-		"password": map[string]any{
+	}
+	// Omitted entirely rather than sent empty: Zitadel treats an absent
+	// password block as "no password credential", while a present one with
+	// an empty string is a policy violation.
+	if !in.WithoutPassword {
+		body["password"] = map[string]any{
 			"password":       in.Password,
 			"changeRequired": false,
-		},
+		}
 	}
 	var wire struct {
 		UserID string `json:"userId"`
@@ -277,16 +300,56 @@ func NewStaffProvisioner(client *Client, projectID string, roleKeys []string) (*
 // earlier GIP-era migration) has no grant on the admin project, and
 // without one it cannot complete the OIDC flow.
 func (p *StaffProvisioner) ProvisionStaff(ctx context.Context, email, firstName, lastName, password string) (string, error) {
+	return p.provision(ctx, email, firstName, lastName, password, false)
+}
+
+// ProvisionSSOStaff is ProvisionStaff for an identity that authenticates
+// through a tenant's own IdP (mark8ly#820), and differs in exactly one way:
+// when the account has to be created, it is created with NO password.
+//
+// That difference is the whole point. An SSO-provisioned account holding a
+// password can be signed into through Zitadel directly, and a password can be
+// set later through password reset — both bypassing the tenant's IdP and the
+// MFA, device posture and offboarding it enforces. A tenant buys SSO to
+// centralise exactly that.
+//
+// It shares provision() with ProvisionStaff rather than copying it, because
+// the resolve-first behaviour and the always-ensure-the-grant rule are
+// properties of "make an identity on the admin project" and must not drift
+// between the two callers.
+//
+// An account that ALREADY exists keeps whatever credentials it already had:
+// this path withholds a password, it does not remove one. A merchant who
+// already signs in with a password and then arrives via SSO is the same
+// person with the same account, which is the point of resolving rather than
+// creating — see internal/ssousers.
+func (p *StaffProvisioner) ProvisionSSOStaff(ctx context.Context, email, firstName, lastName string) (string, error) {
+	return p.provision(ctx, email, firstName, lastName, "", true)
+}
+
+// ResolveUserIDByEmail exposes the lookup provision() already performs, so a
+// caller that only needs to ASK ("is this address a known identity?") does not
+// have to be handed the whole client to do it.
+//
+// Same guarantees as the client's: scoped to the configured org, requires a
+// VERIFIED email, refuses an ambiguous match rather than picking one, and
+// returns idperr.ErrUserNotFound on zero matches.
+func (p *StaffProvisioner) ResolveUserIDByEmail(ctx context.Context, email string) (string, error) {
+	return p.client.ResolveUserIDByEmail(ctx, email)
+}
+
+func (p *StaffProvisioner) provision(ctx context.Context, email, firstName, lastName, password string, withoutPassword bool) (string, error) {
 	userID, err := p.client.ResolveUserIDByEmail(ctx, email)
 	switch {
 	case err == nil:
 		// Existing account — password intentionally unused.
 	case errors.Is(err, idperr.ErrUserNotFound):
 		userID, err = p.client.EnsureHumanUser(ctx, HumanUser{
-			Email:     email,
-			FirstName: firstName,
-			LastName:  lastName,
-			Password:  password,
+			Email:           email,
+			FirstName:       firstName,
+			LastName:        lastName,
+			Password:        password,
+			WithoutPassword: withoutPassword,
 		})
 		if err != nil {
 			return "", err

--- a/services/platform-api/internal/zitadeladmin/provision_test.go
+++ b/services/platform-api/internal/zitadeladmin/provision_test.go
@@ -360,3 +360,78 @@ func TestNewStaffProvisioner_RefusesEmptyConfig(t *testing.T) {
 		t.Error("NewStaffProvisioner with no roles = nil error, want a refusal")
 	}
 }
+
+// An SSO-provisioned account must carry NO password credential
+// (mark8ly#820). A password on such an account is a second way in that
+// bypasses the tenant's IdP — through Zitadel's own password flow, or through
+// password reset — which defeats the MFA, device posture and offboarding the
+// tenant bought SSO to centralise.
+//
+// The block must be ABSENT, not empty: Zitadel reads an absent password block
+// as "no credential", while a present one carrying an empty string is a policy
+// violation.
+func TestEnsureHumanUser_WithoutPasswordOmitsTheBlockEntirely(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		body := decodeBody(t, r)
+
+		if _, present := body["password"]; present {
+			t.Errorf("body carries a password block for a passwordless account: %v", body["password"])
+		}
+		// Everything else must still be the verified shape — in particular
+		// the explicit isVerified, without which the account is invisible to
+		// resolveUserIDByEmail and can never be found again.
+		email, _ := body["email"].(map[string]any)
+		if email == nil || email["isVerified"] != true {
+			t.Errorf("email = %v, want isVerified sent explicitly", body["email"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"userId":"zid-sso","details":{}}`))
+	})
+
+	in := newUser()
+	in.Password = ""
+	in.WithoutPassword = true
+
+	id, err := c.EnsureHumanUser(context.Background(), in)
+	if err != nil {
+		t.Fatalf("EnsureHumanUser: %v", err)
+	}
+	if id != "zid-sso" {
+		t.Errorf("id = %q, want zid-sso", id)
+	}
+}
+
+// Passwordless has to be asked for. A caller that merely forgot the password
+// must still be refused, or a missing argument silently becomes an account
+// with a different credential model than the caller intended.
+func TestEnsureHumanUser_AnAbsentPasswordIsStillRefusedWithoutTheFlag(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("a request was sent for an input that should have been refused locally")
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	in := newUser()
+	in.Password = ""
+
+	if _, err := c.EnsureHumanUser(context.Background(), in); err == nil {
+		t.Fatal("an empty password created an account without the flag")
+	}
+}
+
+// The two are contradictory: one of them is wrong, and guessing which would
+// either create a credential the caller meant to withhold or drop one they
+// meant to set.
+func TestEnsureHumanUser_APasswordWithTheFlagIsRefused(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("a contradictory input reached Zitadel")
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	in := newUser()
+	in.WithoutPassword = true
+
+	if _, err := c.EnsureHumanUser(context.Background(), in); err == nil {
+		t.Fatal("WithoutPassword alongside a password was accepted")
+	}
+}


### PR DESCRIPTION
Closes #820. Per-tenant SSO is wired end to end and both routes are mounted.

Follows #833, which implemented the resolver and the relying-party cache and left both surfaces unmounted because the identity question was unanswered. This answers it.

## One human, one identity

marketplace-api cannot say who an email is. `user_profiles` is keyed on a provider subject, is not tenant-scoped, and holds display preferences; membership is FGA tuples, identity is Zitadel, and FGA can check a relation for a **known** id but cannot search by email.

So `sso.UsersRepo` is implemented against platform-api, which has Zitadel. The alternative — minting a local id per tenant+email — is much smaller and silently wrong: a merchant admin who already signs in with a password would, on their first SSO login, become a **second person**, with their role left behind on the first.

**The mapping onto the existing JIT algorithm needed no change to it.** `FindByTenantAndEmail` returns found **only when the resolved user is already a member** — they have a role, so their identity is reused as-is. An account that exists but holds no role here answers false, which sends JIT to `CreateForTenant`; that resolves the same Zitadel account rather than duplicating it, then grants the role. Both paths land on one identity.

## SSO-provisioned accounts get no password

`EnsureHumanUser` required one. An SSO account holding a password can be signed into through Zitadel directly, and a password can be **set later through password reset** — either one bypassing the tenant's IdP and the MFA, device posture and offboarding it enforces. A tenant buys SSO to centralise exactly that.

So `HumanUser.WithoutPassword` omits the password block entirely (absent means "no credential"; present-but-empty is a policy violation), and `ProvisionSSOStaff` shares `provision()` with `ProvisionStaff` so the resolve-first and always-ensure-the-grant rules cannot drift between them.

It **withholds** a password rather than removing one: an existing account keeps whatever it had, which is the point of resolving rather than creating. There are no SSO tenants today, so this is settled at the moment it costs nothing.

Owner is refused outright — it is the one role that can remove the real owner, and the assertion driving the call comes from a customer-controlled IdP. The role JIT passes is ignored in favour of `staff`: an IdP says who someone is, not how much to trust them.

## Guard placement

`SSOUsers` goes behind platform-api's **strict** internal guard, not the permissive one the other tenant-scoped routes use. The permissive guard no-ops on an empty secret — right for a read you needed a tenant id to ask for, wrong for a route that creates an account and grants it a role. `routes.StrictSlots()` is asserted by a test, so adding the field forced the decision rather than defaulting to neither; the test now records why this one is strict for a different reason from its neighbours.

## Mounting

`buildSSO` returns both handlers or neither. Letting a merchant save an IdP config nobody can sign in with is the state #820 was opened about; mounting login without an identity source is worse — it would walk the merchant through their IdP and fail at the last step.

Its three preconditions are the ones without which a login cannot complete — platform-api, OpenBao, auth-bff — and a missing one is logged at Error rather than skipped silently, so an operator who configured SSO and finds no routes is told which piece is absent.

## Test plan

- [x] `gofmt`, `go build`, `go vet` clean in both services; **both full suites green**
- [x] `go vet -tags integration ./...` on platform-api
- [x] `gitleaks` clean over the branch before pushing (#833 tripped it on a KV path)
- [x] zitadeladmin: the password block is **absent** for passwordless while the verified shape is otherwise unchanged; an absent password without the flag is still refused; flag + password is refused
- [x] ssousers service: a member is found; **an account with no role here is not found** (the subtle one); unknown email is not found; a resolution failure and a membership failure are **not** negative answers; ambiguous email surfaces; owner refused with no account created; names derived from the email; a failed role write is a failure
- [x] ssousers client: compile-time assertion that it satisfies `sso.UsersRepo`; member identity returned with the internal-auth header; not-found is not an error; a 500 is **not** a negative answer; the default role is sent; three IdP attribute spellings read; a non-UUID id is an error rather than the zero identity
- [x] Mount test through the real `RegisterPublic` — comparing a bare router against one with the handler, **not** the 404-vs-405 probe #820 suggests, which distinguishes nothing here
- [ ] A real IdP. There are no SSO tenants yet, so the end-to-end path is unexercised against live Zitadel and a real OIDC provider.

## Deployment note

The routes appear only where `MARKETPLACE_PLATFORM_API_URL`, OpenBao and `AUTH_BFF_URL` are all configured, and platform-api's `SSOUsers` routes only when Zitadel and OpenFGA are. No new configuration is introduced — every value is one both services already hold.
