### PR TITLE
feat(platformadmin): mount the break-glass write endpoints (#404)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -590,6 +590,11 @@ func main() {
 	// never two. See the construction site (admin-mode block) for why.
 	var breakGlassLoginHandler *admin.BreakGlassLoginHandler
 	var breakGlassRateLimiter *breakglass.LoginRateLimiter
+	// #404's write deps. Declared at this scope for the same reason the
+	// limiter is: platformadmin.Register is called far below, and both
+	// must reach it from inside the OpenBao-guarded block that builds them.
+	var breakGlassRotator *breakglass.Rotator
+	var breakGlassWriter platformadmin.BreakGlassWriter
 	// delhiveryWebhookHandler is constructed in the admin wiring branch
 	// (where shipmentsHandler, apiKeyEncryptor and carrierSecretStore
 	// are built) but mounted below inside the engine switch, so declare
@@ -1437,6 +1442,26 @@ func main() {
 				Sessions:    authbffclient.NewSessionIssuer(cfg.AuthBFFURL, cfg.InternalAuthSecret, nil),
 				Logger:      log,
 			})
+
+			// #404's write endpoints: rotate / disable / enable /
+			// clear-lockout. Both must be non-nil or platformadmin leaves
+			// all four unmounted while List (#333) keeps working.
+			//
+			// Held back until now on purpose: #404 argued that controls
+			// over a feature nobody could reach "look delivered and cannot
+			// work". That was right while the login route was unmounted
+			// (#642) and while per-tenant SSO did not exist. Both shipped —
+			// the route mounts, and #836 wired SSO onto a real identity
+			// source — so break-glass now guards a failure mode that can
+			// occur, and its controls should exist alongside it.
+			//
+			// The Rotator reuses the SAME repo, secret manager, audit
+			// emitter and Slack client the login handler was built with, so
+			// a rotation and a login cannot disagree about where the
+			// credential lives.
+			breakGlassRotator = breakglass.NewRotator(
+				breakGlassRepo, breakGlassSecrets, breakGlassAudit, breakGlassSlack)
+			breakGlassWriter = breakGlassRepo
 		}
 
 		// P13 §12 — per-tenant SSO (#820). Both surfaces are constructed
@@ -2573,6 +2598,8 @@ func main() {
 			EstateUsers:             estateUsersClient,
 			EmailSends:              platformadmin.EmailSendListerFunc(emaillog.ListPlatform),
 			BreakGlass:              platformadmin.BreakGlassListerFunc(breakglass.ListPlatform),
+			BreakGlassRotator:       breakGlassRotator,
+			BreakGlassWriter:        breakGlassWriter,
 			BreakGlassRateLimiter:   breakGlassRateLimiter,
 			BreakGlassIPHMACKey:     breakglass.HMACKey(cfg.BreakGlassIPHMACKey),
 			EmailTemplates:          templateStore,
@@ -2748,6 +2775,8 @@ func main() {
 				EstateUsers:             estateUsersClient,
 				EmailSends:              platformadmin.EmailSendListerFunc(emaillog.ListPlatform),
 				BreakGlass:              platformadmin.BreakGlassListerFunc(breakglass.ListPlatform),
+				BreakGlassRotator:       breakGlassRotator,
+				BreakGlassWriter:        breakGlassWriter,
 				BreakGlassRateLimiter:   breakGlassRateLimiter,
 				BreakGlassIPHMACKey:     breakglass.HMACKey(cfg.BreakGlassIPHMACKey),
 				EmailTemplates:          templateStore,


### PR DESCRIPTION
Closes #404. Mounts `rotate` / `disable` / `enable` / `clear-lockout` by filling the two deps that were deliberately left nil.

## Why now, when #404 argued for holding back

The issue's author refused to mount these, and was right at the time:

> controls over an empty, unusable feature would be a surface that looks delivered and cannot work

Two things have since changed:

- **#642 mounted the login route** (#819). It was previously constructed only in tests, so `POST /admin/break-glass/login` did not exist at all.
- **Per-tenant SSO is implemented and mounted** (#833, #836). Break-glass exists to rescue a tenant whose own IdP breaks; until SSO shipped, that failure mode could not occur. Now it can.

So break-glass guards something real, and controls over it belong next to it. What remains — no provisioned accounts yet — is a subscription question, not a missing-feature question: the route is gated on `PlanPro` and `store_subscriptions` has 0 rows because Stripe is still in test mode (#366/#371).

## The change

`BreakGlassRotator` and `BreakGlassWriter` are constructed inside the same OpenBao-guarded block that already builds the login handler, and passed at both `platformadmin.Register` call sites.

The Rotator reuses the **same** repository, secret manager, audit emitter and Slack client the login handler was built with — so a rotation and a login cannot disagree about where the credential lives. `BreakGlassWriter` is that same `*breakglass.Repository`.

`BreakGlassRateLimiter` and `BreakGlassIPHMACKey` were **already threaded** at both call sites by #819, specifically so this change could not reintroduce the two-instance bug the issue warns about:

> two instances means clear-lockout resets a map nobody reads

One `*breakglass.LoginRateLimiter` still serves both the login path and clear-lockout. #819 also replaced the two duplicated key functions with a single shared `breakglass.LoginRateLimitKey`, so the subtler version of that failure — the two paths agreeing on the instance but disagreeing on the key — is impossible by construction rather than policed by a comment.

## Guards that stay in force

`platformadmin`'s existing discipline is unchanged: the four write routes mount only when `BreakGlassRotator`, `BreakGlassWriter`, `DB` **and** `Emitter` are all non-nil. A write that cannot be attributed to an operator still does not exist rather than running silently unaudited (#287, F1). If the OpenBao client fails to initialise, all four stay unmounted along with the login route, and `List` (#333) keeps working.

## Verified

`go build`, `go vet`, `go vet -tags=integration`, `go test ./...`, `gofmt -l` all clean.

Worth noting `gofmt` earned its place here: my first edit matched a three-tab pattern inside a four-tab block and left mixed indentation at the second call site. It compiled and vetted fine; `gofmt -l` was what flagged it.

## What this does not do

It does not provision an account, and no end-to-end login has been exercised in production — the plan gate refuses every tenant while `store_subscriptions` is empty. The break-glass integration tests (`break_glass_login_integration_test.go`, `break_glass_shared_limiter_integration_test.go`) do cover the disabled-account paths and the shared limiter against a real database, and run in CI's `Integration (marketplace-api)` job.
