### PR TITLE
feat(admin): a screen to configure SSO, and two backend defects it exposed (#820)

### DIFF
--- a/apps/admin/app/(admin)/settings/sso/SSOClient.tsx
+++ b/apps/admin/app/(admin)/settings/sso/SSOClient.tsx
@@ -1,0 +1,399 @@
+"use client";
+
+/**
+ * Single sign-on configuration (#820).
+ *
+ * The screen the feature was missing: marketplace-api has had the config API
+ * and the login flow for some time, and no merchant could reach either,
+ * because there was nothing to click.
+ *
+ * Two behaviours here are deliberate and easy to get wrong:
+ *
+ *   1. The saved client-secret reference comes back REDACTED. Submitting the
+ *      placeholder would store the literal string "[redacted]" and leave a
+ *      configuration that looks right and cannot resolve a secret, so an
+ *      untouched field is omitted rather than sent.
+ *   2. "Test connection" reports what the server actually checked. A pass
+ *      that only validated the shape says so, because a merchant who reads
+ *      "connected" and then cannot sign in was told the wrong thing at the
+ *      one moment they were paying attention.
+ */
+
+import { useEffect, useState } from "react";
+import { Input, Label } from "@tesserix/web";
+
+import { ApiError } from "@/lib/api/client";
+import { ssoCopy } from "@/lib/copy/sso";
+import { REDACTED, type SSOTestResult } from "@/lib/api/sso/schemas";
+import {
+  deleteSSOConfig,
+  getSSOConfig,
+  saveSSOConfig,
+  testSSOConnection,
+} from "@/lib/api/sso/sso";
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "busy"; label: string }
+  | { kind: "ok"; message: string }
+  | { kind: "error"; message: string };
+
+interface FormState {
+  issuer: string;
+  clientId: string;
+  secretRef: string;
+  redirectUri: string;
+  scopes: string;
+  enabled: boolean;
+}
+
+const EMPTY: FormState = {
+  issuer: "",
+  clientId: "",
+  secretRef: "",
+  redirectUri: "",
+  scopes: "",
+  enabled: false,
+};
+
+export function SSOClient() {
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [hasSavedSecret, setHasSavedSecret] = useState(false);
+  const [configured, setConfigured] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [planGated, setPlanGated] = useState(false);
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const cfg = await getSSOConfig();
+        if (cancelled) return;
+        if (cfg) {
+          const saved = cfg.metadata.client_secret_ref === REDACTED;
+          setHasSavedSecret(saved);
+          setConfigured(true);
+          setForm({
+            issuer: cfg.metadata.issuer,
+            clientId: cfg.metadata.client_id,
+            // Never prefill the placeholder into an editable field: it would
+            // be submitted verbatim on the next save.
+            secretRef: saved ? "" : cfg.metadata.client_secret_ref,
+            redirectUri: cfg.metadata.redirect_uri,
+            scopes: cfg.metadata.scopes,
+            enabled: cfg.enabled,
+          });
+        }
+      } catch (err) {
+        if (cancelled) return;
+        // 403 is the plan gate, not a failure — it deserves its own sentence
+        // naming the plan rather than a generic error.
+        if (err instanceof ApiError && err.status === 403) setPlanGated(true);
+        else setStatus({ kind: "error", message: ssoCopy.loadError });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  function set<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((f) => ({ ...f, [key]: value }));
+    setStatus({ kind: "idle" });
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setStatus({ kind: "busy", label: ssoCopy.saving });
+    try {
+      await saveSSOConfig({
+        provider: "oidc",
+        metadata: {
+          issuer: form.issuer,
+          client_id: form.clientId,
+          client_secret_ref: form.secretRef,
+          redirect_uri: form.redirectUri,
+          scopes: form.scopes,
+        },
+        enabled: form.enabled,
+      });
+      setConfigured(true);
+      if (form.secretRef.trim()) setHasSavedSecret(true);
+      setStatus({ kind: "ok", message: ssoCopy.saved });
+    } catch {
+      setStatus({ kind: "error", message: ssoCopy.saveError });
+    }
+  }
+
+  async function handleTest() {
+    setStatus({ kind: "busy", label: ssoCopy.testing });
+    try {
+      const result: SSOTestResult = await testSSOConnection();
+      if (!result.ok) {
+        setStatus({
+          kind: "error",
+          message: ssoCopy.testFailed(result.error ?? ""),
+        });
+        return;
+      }
+      setStatus({
+        kind: "ok",
+        message:
+          result.checked === "idp"
+            ? ssoCopy.testReachedIdP
+            : ssoCopy.testConfigOnly,
+      });
+    } catch {
+      setStatus({ kind: "error", message: ssoCopy.testError });
+    }
+  }
+
+  async function handleRemove() {
+    setConfirmingRemove(false);
+    setStatus({ kind: "busy", label: ssoCopy.removing });
+    try {
+      await deleteSSOConfig();
+      setForm(EMPTY);
+      setHasSavedSecret(false);
+      setConfigured(false);
+      setStatus({ kind: "ok", message: ssoCopy.removed });
+    } catch {
+      setStatus({ kind: "error", message: ssoCopy.saveError });
+    }
+  }
+
+  if (loading) {
+    return <p className="text-sm text-foreground-tertiary">Loading…</p>;
+  }
+
+  if (planGated) {
+    return (
+      <p className="max-w-xl text-sm leading-6 text-[var(--ink-700)]">
+        {ssoCopy.planGated}
+      </p>
+    );
+  }
+
+  const busy = status.kind === "busy";
+
+  return (
+    <form onSubmit={handleSave} className="max-w-xl space-y-6" noValidate>
+      <Field
+        id="sso-issuer"
+        label={ssoCopy.fields.issuerLabel}
+        hint={ssoCopy.fields.issuerHint}
+      >
+        <Input
+          id="sso-issuer"
+          type="url"
+          inputMode="url"
+          autoComplete="off"
+          spellCheck={false}
+          required
+          value={form.issuer}
+          onChange={(e) => set("issuer", e.target.value)}
+          placeholder="https://accounts.example.com"
+        />
+      </Field>
+
+      <Field
+        id="sso-client-id"
+        label={ssoCopy.fields.clientIdLabel}
+        hint={ssoCopy.fields.clientIdHint}
+      >
+        <Input
+          id="sso-client-id"
+          autoComplete="off"
+          spellCheck={false}
+          required
+          value={form.clientId}
+          onChange={(e) => set("clientId", e.target.value)}
+        />
+      </Field>
+
+      <Field
+        id="sso-secret-ref"
+        label={ssoCopy.fields.secretRefLabel}
+        hint={
+          hasSavedSecret
+            ? ssoCopy.fields.secretRefKept
+            : ssoCopy.fields.secretRefHint
+        }
+      >
+        <Input
+          id="sso-secret-ref"
+          autoComplete="off"
+          spellCheck={false}
+          required={!hasSavedSecret}
+          value={form.secretRef}
+          onChange={(e) => set("secretRef", e.target.value)}
+          placeholder={hasSavedSecret ? "••••••••" : "kv/your-org/idp"}
+        />
+      </Field>
+
+      <Field
+        id="sso-redirect"
+        label={ssoCopy.fields.redirectLabel}
+        hint={ssoCopy.fields.redirectHint}
+      >
+        <Input
+          id="sso-redirect"
+          type="url"
+          inputMode="url"
+          autoComplete="off"
+          spellCheck={false}
+          value={form.redirectUri}
+          onChange={(e) => set("redirectUri", e.target.value)}
+        />
+      </Field>
+
+      <Field
+        id="sso-scopes"
+        label={ssoCopy.fields.scopesLabel}
+        hint={ssoCopy.fields.scopesHint}
+      >
+        <Input
+          id="sso-scopes"
+          autoComplete="off"
+          spellCheck={false}
+          value={form.scopes}
+          onChange={(e) => set("scopes", e.target.value)}
+          placeholder="openid email profile"
+        />
+      </Field>
+
+      <div className="border-t border-[var(--hairline,var(--ink-100))] pt-6">
+        <label className="flex cursor-pointer items-start gap-3">
+          <input
+            type="checkbox"
+            className="mt-0.5 h-4 w-4 shrink-0 accent-[var(--moss-700)]"
+            checked={form.enabled}
+            onChange={(e) => set("enabled", e.target.checked)}
+          />
+          <span>
+            <span className="block text-sm text-foreground">
+              {ssoCopy.fields.enabledLabel}
+            </span>
+            <span className="mt-1 block text-xs text-foreground-tertiary">
+              {ssoCopy.fields.enabledHint}
+            </span>
+          </span>
+        </label>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="submit"
+          disabled={busy}
+          aria-busy={busy}
+          className="inline-flex h-10 items-center rounded-md bg-[var(--ink-900)] px-5 text-sm font-medium text-white transition-colors hover:bg-[var(--ink-900)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {status.kind === "busy" && status.label === ssoCopy.saving
+            ? ssoCopy.saving
+            : ssoCopy.save}
+        </button>
+
+        {configured && (
+          <button
+            type="button"
+            onClick={handleTest}
+            disabled={busy}
+            className="inline-flex h-10 items-center rounded-md border border-[var(--ink-900)] px-5 text-sm font-medium text-[var(--ink-900)] transition-colors hover:bg-[var(--paper-200)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--moss-700)] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {status.kind === "busy" && status.label === ssoCopy.testing
+              ? ssoCopy.testing
+              : ssoCopy.test}
+          </button>
+        )}
+
+        {configured && (
+          <button
+            type="button"
+            onClick={() => setConfirmingRemove(true)}
+            disabled={busy}
+            className="text-sm text-[var(--danger,#7a1a1a)] underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--moss-700)] disabled:opacity-60"
+          >
+            {ssoCopy.remove}
+          </button>
+        )}
+      </div>
+
+      <div className="min-h-[1.25rem]" aria-live="polite">
+        {status.kind === "ok" && (
+          <p className="text-sm text-[var(--moss-700)]">{status.message}</p>
+        )}
+        {status.kind === "error" && (
+          <p role="alert" className="text-sm text-[var(--danger,#7a1a1a)]">
+            {status.message}
+          </p>
+        )}
+      </div>
+
+      <p className="text-xs text-foreground-tertiary">{ssoCopy.samlNote}</p>
+
+      {confirmingRemove && (
+        <div
+          role="alertdialog"
+          aria-labelledby="sso-remove-title"
+          aria-describedby="sso-remove-body"
+          className="rounded-md border border-[var(--hairline,var(--ink-100))] bg-[var(--background-elevated,#fff)] p-5"
+        >
+          <h3
+            id="sso-remove-title"
+            className="font-serif text-lg text-[var(--ink-900)]"
+          >
+            {ssoCopy.removeConfirmTitle}
+          </h3>
+          <p id="sso-remove-body" className="mt-2 text-sm leading-6 text-[var(--ink-700)]">
+            {ssoCopy.removeConfirmBody}
+          </p>
+          <div className="mt-4 flex gap-3">
+            <button
+              type="button"
+              onClick={handleRemove}
+              className="inline-flex h-9 items-center rounded-md bg-[var(--danger,#7a1a1a)] px-4 text-sm font-medium text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--moss-700)]"
+            >
+              {ssoCopy.removeConfirmCta}
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmingRemove(false)}
+              className="inline-flex h-9 items-center rounded-md px-4 text-sm text-[var(--ink-700)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--moss-700)]"
+            >
+              {ssoCopy.cancel}
+            </button>
+          </div>
+        </div>
+      )}
+    </form>
+  );
+}
+
+/** Label + control + a reserved hint row, matching the onboarding form's shape. */
+function Field({
+  id,
+  label,
+  hint,
+  children,
+}: {
+  id: string;
+  label: string;
+  hint: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id} className="text-foreground">
+        {label}
+      </Label>
+      {children}
+      <p id={`${id}-hint`} className="text-xs leading-5 text-foreground-tertiary">
+        {hint}
+      </p>
+    </div>
+  );
+}

--- a/apps/admin/app/(admin)/settings/sso/page.tsx
+++ b/apps/admin/app/(admin)/settings/sso/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+
+import { AdminPage, PageSection } from "@/components/layout";
+import { ssoCopy } from "@/lib/copy/sso";
+
+import { SSOClient } from "./SSOClient";
+
+export const metadata: Metadata = { title: "Single sign-on" };
+
+export default function SSOSettingsPage() {
+  return (
+    <AdminPage
+      eyebrow={ssoCopy.eyebrow}
+      title={ssoCopy.title}
+      description={ssoCopy.description}
+    >
+      <PageSection
+        title={ssoCopy.sectionTitle}
+        description={ssoCopy.sectionDescription}
+      >
+        <SSOClient />
+      </PageSection>
+    </AdminPage>
+  );
+}

--- a/apps/admin/app/api/admin/sso/config/route.ts
+++ b/apps/admin/app/api/admin/sso/config/route.ts
@@ -1,0 +1,35 @@
+// Proxy for the tenant SSO configuration (#820).
+//
+// The tenant id comes from the SESSION, never from the client. marketplace-api
+// re-checks that the path tenant matches the authenticated one and refuses a
+// mismatch, but building the path from the session means a client cannot even
+// ask about another tenant's IdP configuration.
+import { resolveAuth } from "@/lib/auth/serverSession";
+import { proxyAdminApi } from "@/lib/api/server/proxyAdminApi";
+
+async function backendPath(): Promise<string | null> {
+  const auth = await resolveAuth();
+  return auth ? `tenants/${auth.tenantId}/sso/config` : null;
+}
+
+function unauthorized(): Response {
+  return Response.json(
+    { error: "unauthorized", message: "session headers missing" },
+    { status: 401 },
+  );
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const path = await backendPath();
+  return path ? proxyAdminApi(request, path) : unauthorized();
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const path = await backendPath();
+  return path ? proxyAdminApi(request, path) : unauthorized();
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  const path = await backendPath();
+  return path ? proxyAdminApi(request, path) : unauthorized();
+}

--- a/apps/admin/app/api/admin/sso/test/route.ts
+++ b/apps/admin/app/api/admin/sso/test/route.ts
@@ -1,0 +1,15 @@
+// Proxy for "Test connection" (#820). See ../config/route.ts for why the
+// tenant comes from the session.
+import { resolveAuth } from "@/lib/auth/serverSession";
+import { proxyAdminApi } from "@/lib/api/server/proxyAdminApi";
+
+export async function POST(request: Request): Promise<Response> {
+  const auth = await resolveAuth();
+  if (!auth) {
+    return Response.json(
+      { error: "unauthorized", message: "session headers missing" },
+      { status: 401 },
+    );
+  }
+  return proxyAdminApi(request, `tenants/${auth.tenantId}/sso/test`);
+}

--- a/apps/admin/components/shell/AdminShell.tsx
+++ b/apps/admin/components/shell/AdminShell.tsx
@@ -151,6 +151,7 @@ const navigation: NavSection[] = [
       { group: "Selling", label: "Payments", href: "/settings/payments" },
       { group: "Selling", label: "Shipping", href: "/settings/shipping" },
       { group: "Team & access", label: "Team", href: "/settings/team" },
+      { group: "Team & access", label: "Single sign-on", href: "/settings/sso" },
       { group: "Team & access", label: "Audit Logs", href: "/settings/audit-logs" },
       { group: "Account", label: "Account", href: "/settings/account" },
       { group: "Account", label: "Security", href: "/settings/security" },

--- a/apps/admin/lib/api/sso/schemas.ts
+++ b/apps/admin/lib/api/sso/schemas.ts
@@ -1,0 +1,79 @@
+/**
+ * Wire types for the tenant SSO configuration (#820).
+ *
+ * Source of truth:
+ *   services/marketplace-api/internal/handlers/admin/sso_config.go
+ *   services/marketplace-api/internal/sso/repository.go  (Validate)
+ */
+import { z } from 'zod'
+
+/**
+ * The three metadata fields an OIDC login actually needs.
+ *
+ * Not a guess: `sso.Validate` requires exactly these, and
+ * `BuildOIDCRelyingParty` reads issuer and client_id while the relying-party
+ * cache reads client_secret_ref. `discovery_url` used to be required and is
+ * read by nothing — discovery comes from the issuer — so it is not collected
+ * here (#820).
+ */
+export const ssoMetadataSchema = z.object({
+  issuer: z.string().default(''),
+  client_id: z.string().default(''),
+  /**
+   * A PATH into the secret store, never the secret itself. The server
+   * redacts it on read, so what comes back is "[redacted]" once saved —
+   * see redactConfig.
+   */
+  client_secret_ref: z.string().default(''),
+  redirect_uri: z.string().default(''),
+  scopes: z.string().default(''),
+})
+
+export const ssoConfigSchema = z.object({
+  tenant_id: z.string(),
+  provider: z.string(),
+  metadata: ssoMetadataSchema,
+  attr_mapping: z.record(z.string(), z.string()).default({}),
+  enabled: z.boolean(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+})
+
+export type SSOConfig = z.infer<typeof ssoConfigSchema>
+
+/**
+ * The server's answer to "Test connection".
+ *
+ * `checked` says HOW far the test got: "idp" means the identity provider was
+ * reached and the client secret read; "configuration" means only the shape was
+ * validated, because that build has no way to reach an IdP. Reporting a pass
+ * without saying which would let a shape check read as a working login.
+ */
+export const ssoTestResultSchema = z.object({
+  ok: z.boolean(),
+  provider: z.string().default(''),
+  checked: z.enum(['idp', 'configuration']).optional(),
+  error: z.string().optional(),
+})
+
+export type SSOTestResult = z.infer<typeof ssoTestResultSchema>
+
+/** The value the form submits. */
+export interface SSOConfigInput {
+  provider: 'oidc'
+  metadata: {
+    issuer: string
+    client_id: string
+    client_secret_ref: string
+    redirect_uri?: string
+    scopes?: string
+  }
+  enabled: boolean
+}
+
+/**
+ * The placeholder the server returns in place of a saved secret reference.
+ * Submitting it back would store the literal string, so the form treats it as
+ * "unchanged" and omits the field.
+ */
+export const REDACTED = '[redacted]'

--- a/apps/admin/lib/api/sso/sso.ts
+++ b/apps/admin/lib/api/sso/sso.ts
@@ -1,0 +1,92 @@
+/**
+ * Tenant SSO configuration client (#820).
+ *
+ * Wraps the proxy routes under /api/admin/sso, which build the tenant-scoped
+ * backend path from the SESSION — a client never names a tenant.
+ */
+import { apiClient, ApiError } from '@/lib/api/client'
+import {
+  REDACTED,
+  ssoConfigSchema,
+  ssoTestResultSchema,
+  type SSOConfig,
+  type SSOConfigInput,
+  type SSOTestResult,
+} from './schemas'
+
+const CONFIG_PATH = '/api/admin/sso/config'
+const TEST_PATH = '/api/admin/sso/test'
+
+/**
+ * The tenant's SSO configuration, or null when none is set up.
+ *
+ * A 404 is not an error here — "no SSO configured" is the normal state for
+ * every tenant that has not set it up, and the screen renders an empty form
+ * for it. Every other status still throws.
+ */
+export async function getSSOConfig(): Promise<SSOConfig | null> {
+  try {
+    return ssoConfigSchema.parse(await apiClient.get<unknown>(CONFIG_PATH))
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return null
+    throw err
+  }
+}
+
+/**
+ * Saves the configuration.
+ *
+ * `client_secret_ref` is omitted when it still holds the server's redaction
+ * placeholder: the server returns `[redacted]` in place of a saved reference,
+ * and sending that back would overwrite the real path with the literal string
+ * — leaving a config that looks correct on screen and cannot resolve a secret.
+ */
+export async function saveSSOConfig(input: SSOConfigInput): Promise<void> {
+  const metadata: Record<string, string> = {
+    issuer: input.metadata.issuer.trim(),
+    client_id: input.metadata.client_id.trim(),
+  }
+  const ref = input.metadata.client_secret_ref.trim()
+  if (ref && ref !== REDACTED) metadata.client_secret_ref = ref
+
+  const redirect = input.metadata.redirect_uri?.trim()
+  if (redirect) metadata.redirect_uri = redirect
+  const scopes = input.metadata.scopes?.trim()
+  if (scopes) metadata.scopes = scopes
+
+  await apiClient.post<unknown>(CONFIG_PATH, {
+    provider: input.provider,
+    metadata,
+    enabled: input.enabled,
+  })
+}
+
+/** Removes the configuration and every JIT user mapping under it. */
+export async function deleteSSOConfig(): Promise<void> {
+  await apiClient.del<unknown>(CONFIG_PATH)
+}
+
+/**
+ * Asks the server to reach the identity provider.
+ *
+ * Uses fetch directly rather than apiClient, for one reason: a FAILED test is
+ * a 422 whose BODY is the answer — `ok: false` plus a reason the merchant
+ * needs to read. apiClient turns any non-2xx into an ApiError that does not
+ * carry the parsed body, so the interesting half of this endpoint's contract
+ * would be thrown away. "Your IdP could not be reached" is a successful
+ * answer to the question the merchant asked.
+ *
+ * Only a request that could not be made at all throws.
+ */
+export async function testSSOConnection(): Promise<SSOTestResult> {
+  const res = await fetch(TEST_PATH, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'same-origin',
+  })
+
+  if (res.status !== 200 && res.status !== 422) {
+    throw new ApiError('sso_test_failed', res.status, 'could not run the connection test')
+  }
+  return ssoTestResultSchema.parse(await res.json())
+}

--- a/apps/admin/lib/copy/pricing.ts
+++ b/apps/admin/lib/copy/pricing.ts
@@ -123,7 +123,11 @@ export const pricingCopy = {
         'Unlimited images',
         'Full read/write API',
         '100 webhook endpoints',
-        'SSO (SAML / OIDC)',
+        // SAML is not implemented — both SSO routes answer 501 for it and
+      // there is no SP (mark8ly#820). Advertising it sold something
+      // that cannot be delivered; OIDC is real and configurable at
+      // Settings -> Single sign-on.
+      'SSO (OpenID Connect)',
         'Priority support (4h response)',
         'Forever audit retention',
       ],

--- a/apps/admin/lib/copy/sso.ts
+++ b/apps/admin/lib/copy/sso.ts
@@ -1,0 +1,86 @@
+/**
+ * Single sign-on settings copy (#820).
+ *
+ * Voice per the design context: calm, editorial, precise. This screen asks a
+ * merchant for values they must copy out of another system, so every field
+ * says where the value comes from rather than restating its own name.
+ *
+ * The one rule the sentences follow: never claim more than the server checked.
+ * "Test connection" reports whether the identity provider was actually
+ * reached, and the copy distinguishes that from a shape check — because a
+ * merchant who reads "looks good" and cannot sign in has been told the wrong
+ * thing at the only moment they were listening.
+ */
+export const ssoCopy = {
+  eyebrow: 'Settings',
+  title: 'Single sign-on',
+  description:
+    'Let your team sign in to this dashboard with your own identity provider.',
+
+  sectionTitle: 'OpenID Connect',
+  sectionDescription:
+    'Mark8ly supports OpenID Connect. Create an application in your identity provider, then paste its details here.',
+
+  fields: {
+    issuerLabel: 'Issuer URL',
+    issuerHint:
+      'The base URL your provider publishes its configuration under — Mark8ly reads the rest from there.',
+    clientIdLabel: 'Client ID',
+    clientIdHint: 'The application identifier your provider issued.',
+    secretRefLabel: 'Client secret reference',
+    secretRefHint:
+      'The path where your client secret is stored. The secret itself never reaches Mark8ly’s database — contact us to have it stored.',
+    secretRefKept: 'A secret reference is already saved. Leave this blank to keep it.',
+    redirectLabel: 'Redirect URI (optional)',
+    redirectHint: 'Add this to your provider’s allowed redirect list.',
+    scopesLabel: 'Scopes (optional)',
+    scopesHint: 'Space-separated. Defaults to openid email profile.',
+    enabledLabel: 'Allow your team to sign in with this provider',
+    enabledHint:
+      'Turn this on once the connection test passes. Until then, everyone signs in as usual.',
+  },
+
+  save: 'Save configuration',
+  saving: 'Saving…',
+  saved: 'Configuration saved.',
+  test: 'Test connection',
+  testing: 'Testing…',
+  remove: 'Remove configuration',
+  removing: 'Removing…',
+  removed: 'Configuration removed.',
+
+  /** Shown when the test genuinely reached the identity provider. */
+  testReachedIdP: 'Connected. Your identity provider answered and the client secret was read.',
+  /**
+   * Shown when only the shape was checked, which is not the same claim.
+   * Saying "connected" here would be a promise this build cannot make.
+   */
+  testConfigOnly:
+    'The configuration looks complete. This environment cannot reach your provider to confirm it.',
+  testFailed: (reason: string) => `Not connected. ${reason}`,
+  testError:
+    'We couldn’t run the test just now. Your configuration has not been changed.',
+
+  removeConfirmTitle: 'Remove single sign-on?',
+  removeConfirmBody:
+    'Your team will go back to signing in with their Mark8ly passwords. Anyone who has only ever signed in through your provider will need a password reset.',
+  removeConfirmCta: 'Remove',
+  cancel: 'Cancel',
+
+  /**
+   * The plan gate. The API answers 403 for a tenant whose plan lacks the
+   * feature, and this says which plan it needs rather than "forbidden".
+   */
+  planGated:
+    'Single sign-on is part of the Pro plan. Upgrade to connect your identity provider.',
+  loadError: 'We couldn’t load your single sign-on settings.',
+  saveError: 'We couldn’t save that. Check the values and try again.',
+
+  /**
+   * SAML. Stated once, plainly, rather than offered as an option that
+   * answers 501 — the pricing page's claim was corrected alongside this
+   * screen for the same reason.
+   */
+  samlNote:
+    'SAML is not supported. If your provider only speaks SAML, contact us.',
+} as const

--- a/apps/admin/tests/unit/api/sso/sso.test.ts
+++ b/apps/admin/tests/unit/api/sso/sso.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tenant SSO configuration client (#820).
+ *
+ * Two behaviours carry real consequences and neither is visible from the
+ * types, so they are pinned here:
+ *
+ *   1. The redaction placeholder must never be submitted. The server returns
+ *      "[redacted]" in place of a saved secret reference; sending it back
+ *      stores that literal string and leaves a configuration that looks
+ *      correct on screen and cannot resolve a secret.
+ *   2. A failed connection test is an ANSWER (422 with a body), not a
+ *      transport failure. Throwing it away would leave the merchant with a
+ *      generic error instead of the reason.
+ */
+import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest'
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+
+import {
+  getSSOConfig,
+  saveSSOConfig,
+  testSSOConnection,
+} from '@/lib/api/sso/sso'
+import { REDACTED } from '@/lib/api/sso/schemas'
+
+const server = setupServer()
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+const CONFIG = '/api/admin/sso/config'
+const TEST = '/api/admin/sso/test'
+
+function savedConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    tenant_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+    provider: 'oidc',
+    metadata: {
+      issuer: 'https://accounts.example.com',
+      client_id: 'client-abc',
+      client_secret_ref: REDACTED,
+      redirect_uri: '',
+      scopes: '',
+    },
+    attr_mapping: {},
+    enabled: true,
+    ...overrides,
+  }
+}
+
+describe('getSSOConfig', () => {
+  it('parses a saved configuration', async () => {
+    server.use(http.get(CONFIG, () => HttpResponse.json(savedConfig())))
+
+    const cfg = await getSSOConfig()
+    expect(cfg?.metadata.issuer).toBe('https://accounts.example.com')
+    expect(cfg?.enabled).toBe(true)
+  })
+
+  // Not an error: no SSO configured is the normal state for every tenant that
+  // has not set it up, and the screen renders an empty form for it.
+  it('returns null when no configuration exists', async () => {
+    server.use(
+      http.get(CONFIG, () =>
+        HttpResponse.json({ error: 'not_found' }, { status: 404 }),
+      ),
+    )
+    await expect(getSSOConfig()).resolves.toBeNull()
+  })
+
+  it('still throws on a real failure', async () => {
+    server.use(
+      http.get(CONFIG, () =>
+        HttpResponse.json({ error: 'internal_error' }, { status: 500 }),
+      ),
+    )
+    await expect(getSSOConfig()).rejects.toBeTruthy()
+  })
+})
+
+describe('saveSSOConfig', () => {
+  // The bug this prevents: storing the literal string "[redacted]" as the
+  // secret path, producing a config that reads correctly and can never
+  // resolve a secret.
+  it('omits the secret reference when it is still the redaction placeholder', async () => {
+    const seen = vi.fn()
+    server.use(
+      http.post(CONFIG, async ({ request }) => {
+        seen(await request.json())
+        return HttpResponse.json({}, { status: 201 })
+      }),
+    )
+
+    await saveSSOConfig({
+      provider: 'oidc',
+      metadata: {
+        issuer: 'https://accounts.example.com',
+        client_id: 'client-abc',
+        client_secret_ref: REDACTED,
+      },
+      enabled: true,
+    })
+
+    const body = seen.mock.calls[0][0] as { metadata: Record<string, string> }
+    expect(body.metadata).not.toHaveProperty('client_secret_ref')
+    expect(body.metadata.issuer).toBe('https://accounts.example.com')
+  })
+
+  it('omits it when left blank, so an untouched field keeps the saved value', async () => {
+    const seen = vi.fn()
+    server.use(
+      http.post(CONFIG, async ({ request }) => {
+        seen(await request.json())
+        return HttpResponse.json({}, { status: 201 })
+      }),
+    )
+
+    await saveSSOConfig({
+      provider: 'oidc',
+      metadata: { issuer: 'https://x.example', client_id: 'c', client_secret_ref: '   ' },
+      enabled: false,
+    })
+
+    const body = seen.mock.calls[0][0] as { metadata: Record<string, string> }
+    expect(body.metadata).not.toHaveProperty('client_secret_ref')
+  })
+
+  it('sends a genuinely new reference', async () => {
+    const seen = vi.fn()
+    server.use(
+      http.post(CONFIG, async ({ request }) => {
+        seen(await request.json())
+        return HttpResponse.json({}, { status: 201 })
+      }),
+    )
+
+    await saveSSOConfig({
+      provider: 'oidc',
+      metadata: {
+        issuer: 'https://x.example',
+        client_id: 'c',
+        client_secret_ref: 'kv/acme/idp',
+      },
+      enabled: true,
+    })
+
+    const body = seen.mock.calls[0][0] as { metadata: Record<string, string> }
+    expect(body.metadata.client_secret_ref).toBe('kv/acme/idp')
+  })
+
+  it('omits the optional fields rather than sending empty strings', async () => {
+    const seen = vi.fn()
+    server.use(
+      http.post(CONFIG, async ({ request }) => {
+        seen(await request.json())
+        return HttpResponse.json({}, { status: 201 })
+      }),
+    )
+
+    await saveSSOConfig({
+      provider: 'oidc',
+      metadata: {
+        issuer: 'https://x.example',
+        client_id: 'c',
+        client_secret_ref: 'kv/a',
+        redirect_uri: '',
+        scopes: '',
+      },
+      enabled: true,
+    })
+
+    const body = seen.mock.calls[0][0] as { metadata: Record<string, string> }
+    expect(body.metadata).not.toHaveProperty('redirect_uri')
+    expect(body.metadata).not.toHaveProperty('scopes')
+  })
+})
+
+describe('testSSOConnection', () => {
+  // The distinction the copy depends on: "we reached your IdP" and "the shape
+  // looks right" are different claims, and only one of them means a merchant
+  // can sign in.
+  it('reports that the identity provider was reached', async () => {
+    server.use(
+      http.post(TEST, () =>
+        HttpResponse.json({ ok: true, provider: 'oidc', checked: 'idp' }),
+      ),
+    )
+    const res = await testSSOConnection()
+    expect(res.ok).toBe(true)
+    expect(res.checked).toBe('idp')
+  })
+
+  it('reports a shape-only pass distinctly', async () => {
+    server.use(
+      http.post(TEST, () =>
+        HttpResponse.json({ ok: true, provider: 'oidc', checked: 'configuration' }),
+      ),
+    )
+    expect((await testSSOConnection()).checked).toBe('configuration')
+  })
+
+  // A refusal is an answer. Throwing it would replace the reason the merchant
+  // needs with a generic failure.
+  it('returns the reason from a 422 instead of throwing', async () => {
+    server.use(
+      http.post(TEST, () =>
+        HttpResponse.json(
+          { ok: false, provider: 'oidc', error: 'we could not read the client secret' },
+          { status: 422 },
+        ),
+      ),
+    )
+
+    const res = await testSSOConnection()
+    expect(res.ok).toBe(false)
+    expect(res.error).toContain('client secret')
+  })
+
+  it('throws when the test could not be run at all', async () => {
+    server.use(
+      http.post(TEST, () => HttpResponse.json({ error: 'boom' }, { status: 500 })),
+    )
+    await expect(testSSOConnection()).rejects.toBeTruthy()
+  })
+})

--- a/apps/onboarding/components/marketing/Pricing.tsx
+++ b/apps/onboarding/components/marketing/Pricing.tsx
@@ -100,7 +100,11 @@ const PLAN_META: readonly PlanMeta[] = [
       'Unlimited images',
       'Full read/write API',
       '100 webhook endpoints',
-      'SSO (SAML / OIDC)',
+      // SAML is not implemented — both SSO routes answer 501 for it and
+      // there is no SP (mark8ly#820). Advertising it sold something
+      // that cannot be delivered; OIDC is real and configurable at
+      // Settings -> Single sign-on.
+      'SSO (OpenID Connect)',
       'Priority support (4h response)',
       'Forever audit retention',
     ],

--- a/services/marketplace-api/cmd/marketplace-api/wiring_sso.go
+++ b/services/marketplace-api/cmd/marketplace-api/wiring_sso.go
@@ -96,5 +96,12 @@ func buildSSO(d ssoDeps) (*admin.SSOConfigHandler, *public.SSOLoginHandler) {
 		d.log,
 	)
 
-	return admin.NewSSOConfigHandler(d.repo, d.audit, d.log), login
+	// The config handler gets the SAME cache the login path uses, so
+	// "Test connection" exercises the exact object a login would build —
+	// discovery against the tenant's issuer and the client secret out of
+	// OpenBao — rather than re-running the validation that just accepted the
+	// save. It invalidates before testing, so it tests the config as edited.
+	config := admin.NewSSOConfigHandler(d.repo, d.audit, d.log).WithRelyingParties(rps)
+
+	return config, login
 }

--- a/services/marketplace-api/internal/handlers/admin/sso_config.go
+++ b/services/marketplace-api/internal/handlers/admin/sso_config.go
@@ -1,6 +1,8 @@
 package admin
 
 import (
+	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"time"
@@ -26,17 +28,52 @@ import (
 //  2. The route group must be wrapped in plangate.RequireFeatureByTenant so
 //     only Pro+ tenants reach these handlers.
 type SSOConfigHandler struct {
-	Repo   *sso.Repository
-	Audit  *audit.Emitter
-	Logger *slog.Logger
+	// RelyingParties is optional; nil makes Test a shape check only.
+	RelyingParties SSORelyingParties
+	Repo           SSOConfigStore
+	Audit          *audit.Emitter
+	Logger         *slog.Logger
 }
 
 // NewSSOConfigHandler constructs the handler. Audit may be nil (tests).
-func NewSSOConfigHandler(repo *sso.Repository, auditEmitter *audit.Emitter, logger *slog.Logger) *SSOConfigHandler {
+func NewSSOConfigHandler(repo SSOConfigStore, auditEmitter *audit.Emitter, logger *slog.Logger) *SSOConfigHandler {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &SSOConfigHandler{Repo: repo, Audit: auditEmitter, Logger: logger}
+}
+
+// WithRelyingParties gives Test something real to test.
+//
+// Without it Test re-runs sso.Validate — the same check Upsert already ran to
+// accept the config — so it answers "ok" for a config that has never been
+// tried against the IdP at all. With it, Test builds the relying party: it
+// fetches the issuer's discovery document and reads the client secret out of
+// OpenBao, which are the two things that actually fail in practice and the two
+// a merchant pressing "Test connection" is asking about.
+func (h *SSOConfigHandler) WithRelyingParties(rps SSORelyingParties) *SSOConfigHandler {
+	h.RelyingParties = rps
+	return h
+}
+
+// SSOConfigStore is the persistence this handler needs. *sso.Repository
+// satisfies it.
+//
+// An interface rather than the concrete repository, for the reason #833 found
+// on the login side: with a *sso.Repository here, no test could reach any
+// branch that depends on a LOADED config, and the Test endpoint's entire
+// behaviour is one of those branches.
+type SSOConfigStore interface {
+	GetByTenant(ctx context.Context, tenantID uuid.UUID) (*sso.Config, error)
+	Upsert(ctx context.Context, cfg *sso.Config) error
+	Delete(ctx context.Context, tenantID uuid.UUID) error
+}
+
+// SSORelyingParties builds (and caches) a tenant's OIDC relying party.
+// *sso.RelyingPartyCache satisfies it.
+type SSORelyingParties interface {
+	For(ctx context.Context, cfg *sso.Config) (*sso.OIDCRelyingParty, error)
+	Invalidate(tenantID uuid.UUID)
 }
 
 // ssoUpsertRequest is the JSON body accepted by Upsert.
@@ -212,9 +249,52 @@ func (h *SSOConfigHandler) Test(c *gin.Context) {
 		return
 	}
 
+	// SAML has no SP, so there is nothing to reach. Say so rather than
+	// reporting a pass for a provider that cannot serve a login.
+	if cfg.Provider == sso.ProviderSAML {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{
+			"ok":       false,
+			"provider": string(cfg.Provider),
+			"error":    "SAML sign-in is not available; configure this tenant for OIDC",
+		})
+		return
+	}
+
+	if h.RelyingParties == nil {
+		// Shape-checked only. Reported honestly rather than as a pass: this
+		// build cannot reach the IdP, and a merchant told "ok" would learn
+		// otherwise at their first login attempt.
+		c.JSON(http.StatusOK, gin.H{
+			"ok":       true,
+			"provider": string(cfg.Provider),
+			"checked":  "configuration",
+		})
+		return
+	}
+
+	// Drop any cached party first, so this tests the config as it is NOW
+	// rather than one built before the merchant's last edit — which is the
+	// whole reason someone presses Test after changing something.
+	h.RelyingParties.Invalidate(tenantID)
+
+	if _, err := h.RelyingParties.For(c.Request.Context(), cfg); err != nil {
+		h.Logger.Warn("sso_config: test failed to build the relying party",
+			"tenant_id", tenantID, "err", err)
+		// The cause is deliberately summarised, not echoed: it can carry the
+		// issuer URL and the secret path, and this response is rendered in a
+		// merchant's browser.
+		c.JSON(http.StatusUnprocessableEntity, gin.H{
+			"ok":       false,
+			"provider": string(cfg.Provider),
+			"error":    testFailureReason(err),
+		})
+		return
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"ok":       true,
 		"provider": string(cfg.Provider),
+		"checked":  "idp",
 	})
 }
 
@@ -279,4 +359,20 @@ func stringMetaVal(m datatypes.JSONMap, k string) string {
 		}
 	}
 	return ""
+}
+
+// testFailureReason turns a build failure into something a merchant can act on
+// without leaking their issuer URL or secret path into a browser.
+//
+// Two causes, two different fixes: the secret store could not produce a client
+// secret at the path the config names, or the IdP itself could not be reached
+// or did not answer with a usable discovery document.
+func testFailureReason(err error) string {
+	if errors.Is(err, sso.ErrNoClientSecret) {
+		return "we could not read the client secret at the path this configuration names"
+	}
+	if errors.Is(err, sso.ErrInvalidMetadata) {
+		return "this configuration is missing something the provider needs"
+	}
+	return "we could not reach the identity provider, or it did not answer with a valid OpenID configuration"
 }

--- a/services/marketplace-api/internal/handlers/admin/sso_config_test.go
+++ b/services/marketplace-api/internal/handlers/admin/sso_config_test.go
@@ -2,7 +2,10 @@ package admin
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -50,6 +53,51 @@ func doJSON(r *gin.Engine, method, path string, body interface{}) *httptest.Resp
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	return w
+}
+
+// stubSSOStore stands in for *sso.Repository so the branches that depend on a
+// LOADED config can be tested without a database (#820).
+type stubSSOStore struct {
+	cfg *sso.Config
+	err error
+}
+
+func (s *stubSSOStore) GetByTenant(context.Context, uuid.UUID) (*sso.Config, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.cfg, nil
+}
+func (s *stubSSOStore) Upsert(context.Context, *sso.Config) error { return nil }
+func (s *stubSSOStore) Delete(context.Context, uuid.UUID) error   { return nil }
+
+// oidcConfig is a configuration that passes sso.Validate — the three fields a
+// login actually needs.
+func oidcConfig() *sso.Config {
+	return &sso.Config{
+		Provider: sso.ProviderOIDC,
+		Enabled:  true,
+		Metadata: datatypes.JSONMap{
+			sso.OIDCKeyIssuer:          "https://idp.acme.example",
+			sso.OIDCKeyClientID:        "client-abc",
+			sso.OIDCKeyClientSecretRef: "kv/acme/idp",
+		},
+	}
+}
+
+// runSSOTest drives POST /sso/test through the real router and returns the
+// response plus the tenant it was called for.
+func runSSOTest(t *testing.T, cfg *sso.Config, rps SSORelyingParties) (*httptest.ResponseRecorder, uuid.UUID) {
+	t.Helper()
+	tenantID := uuid.New()
+	cfg.TenantID = tenantID
+
+	h := NewSSOConfigHandler(&stubSSOStore{cfg: cfg}, nil, nil)
+	if rps != nil {
+		h = h.WithRelyingParties(rps)
+	}
+	r := newSSOTestRouter(h, tenantID)
+	return doJSON(r, http.MethodPost, "/admin/tenants/"+tenantID.String()+"/sso/test", nil), tenantID
 }
 
 // ---------------------------------------------------------------------------
@@ -225,4 +273,91 @@ func (s *ssoTestConfig) toConfig() *sso.Config {
 		Provider: s.provider,
 		Metadata: m,
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Test endpoint (#820)
+//
+// Before this, Test re-ran sso.Validate — the same check Upsert had already
+// run to accept the config — so it answered "ok" for a configuration that had
+// never been tried against the IdP at all. A merchant pressing "Test
+// connection" is asking about the two things that actually fail: can we reach
+// your IdP, and can we read your client secret.
+// ---------------------------------------------------------------------------
+
+type stubRelyingParties struct {
+	err         error
+	invalidated []uuid.UUID
+	built       int
+}
+
+func (s *stubRelyingParties) For(context.Context, *sso.Config) (*sso.OIDCRelyingParty, error) {
+	s.built++
+	return nil, s.err
+}
+
+func (s *stubRelyingParties) Invalidate(tenantID uuid.UUID) {
+	s.invalidated = append(s.invalidated, tenantID)
+}
+
+func TestSSOConfigTest_BuildsTheRelyingPartyAndReportsWhatItChecked(t *testing.T) {
+	rps := &stubRelyingParties{}
+	w, tenantID := runSSOTest(t, oidcConfig(), rps)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Contains(t, w.Body.String(), `"checked":"idp"`,
+		"a pass must say the IdP was reached, not just that the shape was valid")
+	require.Equal(t, 1, rps.built)
+	// Invalidated FIRST, or Test reports on a party built before the
+	// merchant's last edit — which is precisely when someone presses Test.
+	require.Equal(t, []uuid.UUID{tenantID}, rps.invalidated)
+}
+
+func TestSSOConfigTest_AnUnreachableIdPFails(t *testing.T) {
+	rps := &stubRelyingParties{err: errors.New("discover https://idp.acme.example: dial tcp: refused")}
+	w, _ := runSSOTest(t, oidcConfig(), rps)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	require.Contains(t, w.Body.String(), "could not reach the identity provider")
+	// The cause names the tenant's issuer; it belongs in the log, not in a
+	// browser.
+	require.NotContains(t, w.Body.String(), "idp.acme.example")
+	require.NotContains(t, w.Body.String(), "dial tcp")
+}
+
+// The two failures need different fixes, so they must not read the same.
+func TestSSOConfigTest_AMissingClientSecretSaysSo(t *testing.T) {
+	rps := &stubRelyingParties{err: fmt.Errorf("read kv/acme/idp: %w", sso.ErrNoClientSecret)}
+	w, _ := runSSOTest(t, oidcConfig(), rps)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	require.Contains(t, w.Body.String(), "client secret")
+	require.NotContains(t, w.Body.String(), "kv/acme/idp", "the secret path leaked to the browser")
+}
+
+// SAML has no SP. Reporting a pass for it would tell a merchant their
+// configuration works when no login can ever complete.
+func TestSSOConfigTest_SAMLIsNeverAPass(t *testing.T) {
+	cfg := oidcConfig()
+	cfg.Provider = sso.ProviderSAML
+	cfg.Metadata = datatypes.JSONMap{
+		sso.SAMLKeyIDPEntityID: "urn:acme",
+		sso.SAMLKeyIDPACSURL:   "https://idp.example.com/acs",
+		sso.SAMLKeyIDPCertPEM:  "-----BEGIN CERTIFICATE-----",
+	}
+
+	w, _ := runSSOTest(t, cfg, &stubRelyingParties{})
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	require.Contains(t, w.Body.String(), "not available")
+}
+
+// A build with no relying-party source can still shape-check, but it must say
+// that is all it did rather than claiming the IdP was reached.
+func TestSSOConfigTest_WithoutARelyingPartySourceSaysWhatItChecked(t *testing.T) {
+	w, _ := runSSOTest(t, oidcConfig(), nil)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), `"checked":"configuration"`)
+	require.NotContains(t, w.Body.String(), `"checked":"idp"`)
 }

--- a/services/marketplace-api/internal/sso/repository.go
+++ b/services/marketplace-api/internal/sso/repository.go
@@ -52,7 +52,22 @@ func Validate(cfg *Config) error {
 			}
 		}
 	case ProviderOIDC:
-		for _, k := range []string{OIDCKeyIssuer, OIDCKeyClientID, OIDCKeyDiscoveryURL} {
+		// These three are what a login actually needs, which is not what this
+		// list used to hold (mark8ly#820).
+		//
+		// It required discovery_url, which NOTHING reads: BuildOIDCRelyingParty
+		// discovers from the issuer, per the OIDC spec's well-known path. And
+		// it did not require client_secret_ref, without which no relying party
+		// can be built at all.
+		//
+		// So a config could save cleanly, pass the Test endpoint, and then fail
+		// every login with "provider_not_ready" — while the one field the
+		// merchant was forced to supply was ignored. Corrected while there are
+		// zero configs in existence and it costs nothing.
+		//
+		// discovery_url is still ACCEPTED and still stored; it is simply no
+		// longer demanded for a config that does not need it.
+		for _, k := range []string{OIDCKeyIssuer, OIDCKeyClientID, OIDCKeyClientSecretRef} {
 			if _, ok := nonEmpty(cfg.Metadata, k); !ok {
 				return fmt.Errorf("%w: oidc.%s required", ErrInvalidMetadata, k)
 			}

--- a/services/marketplace-api/internal/sso/repository_test.go
+++ b/services/marketplace-api/internal/sso/repository_test.go
@@ -49,16 +49,44 @@ func TestValidate_SAML_RequiresCoreKeys(t *testing.T) {
 	require.NoError(t, Validate(base))
 }
 
-func TestValidate_OIDC_RequiresIssuerClientDiscovery(t *testing.T) {
+// Renamed and corrected by mark8ly#820. It used to require discovery_url,
+// which nothing reads — BuildOIDCRelyingParty discovers from the issuer — and
+// did not require client_secret_ref, without which no relying party can be
+// built. A config could therefore save cleanly and then fail every login.
+func TestValidate_OIDC_RequiresWhatALoginActuallyNeeds(t *testing.T) {
 	base := &Config{TenantID: uuid.New(), Provider: ProviderOIDC, Metadata: map[string]any{}}
 	require.Error(t, Validate(base))
 
 	base.Metadata = map[string]any{
+		OIDCKeyIssuer:          "https://accounts.example.com",
+		OIDCKeyClientID:        "client-abc",
+		OIDCKeyClientSecretRef: "kv/test/idp",
+	}
+	require.NoError(t, Validate(base), "the three fields a login needs were rejected")
+}
+
+// The field the old rule demanded is now optional — accepted and stored for a
+// caller that wants to record it, never required for a config that works
+// without it.
+func TestValidate_OIDC_DiscoveryURLIsOptional(t *testing.T) {
+	cfg := &Config{TenantID: uuid.New(), Provider: ProviderOIDC, Metadata: map[string]any{
+		OIDCKeyIssuer:          "https://accounts.example.com",
+		OIDCKeyClientID:        "client-abc",
+		OIDCKeyClientSecretRef: "kv/test/idp",
+		OIDCKeyDiscoveryURL:    "https://accounts.example.com/.well-known/openid-configuration",
+	}}
+	require.NoError(t, Validate(cfg))
+}
+
+// The specific regression: a config missing the client secret reference must
+// NOT validate. It saved cleanly before, and then no one could sign in.
+func TestValidate_OIDC_RefusesAConfigThatCannotBuildARelyingParty(t *testing.T) {
+	cfg := &Config{TenantID: uuid.New(), Provider: ProviderOIDC, Metadata: map[string]any{
 		OIDCKeyIssuer:       "https://accounts.example.com",
 		OIDCKeyClientID:     "client-abc",
 		OIDCKeyDiscoveryURL: "https://accounts.example.com/.well-known/openid-configuration",
-	}
-	require.NoError(t, Validate(base))
+	}}
+	require.Error(t, Validate(cfg), "a config with no client_secret_ref validated; every login would fail")
 }
 
 func TestValidate_OIDC_EmptyStringsFail(t *testing.T) {


### PR DESCRIPTION
Finishes per-tenant SSO by giving it the thing it never had: a screen. Follows #836, which mounted the config API and the login flow but built no UI — so configuring SSO meant calling `POST /admin/tenants/:id/sso/config` by hand.

This also lands the one point #835 was right about, now that PR is closed.

## Two backend defects found before writing any UI

Building the form meant asking what to collect, and the answer did not match what a login needs.

**`sso.Validate` was backwards on both counts.** It required `discovery_url` — which **nothing reads**; `BuildOIDCRelyingParty` discovers from the issuer — and did **not** require `client_secret_ref`, without which no relying party can be built at all. So a config could save cleanly, pass the Test endpoint, and fail every login with `provider_not_ready`, while the one field the merchant was forced to supply was ignored. Corrected while there are zero configs and it costs nothing; `discovery_url` is still accepted and stored, just no longer demanded.

**"Test connection" tested nothing.** It re-ran `sso.Validate` — the same check `Upsert` had just run to accept the config — so it answered `ok` for a configuration never tried against the IdP. It now builds the relying party through the same cache the login path uses: discovery against the tenant's issuer, and the client secret out of OpenBao. Those are the two things that actually fail, and the two a merchant pressing the button is asking about.

It **invalidates the cache first**, so it tests the config as edited rather than one built before the last change — which is exactly when someone presses Test. A build with no relying-party source still shape-checks, but reports `checked: "configuration"` rather than claiming the IdP was reached. And SAML is never a pass: there is no SP, so reporting one would tell a merchant their setup works when no login can complete.

`SSOConfigHandler.Repo` became an interface to test any of this — the same change that surfaced two bugs on the login side in #833, and for the same reason: nothing could reach a branch that depends on a loaded config.

## The screen

`Settings → Team & access → Single sign-on`. Follows the Security settings page's shape (`AdminPage` / `PageSection`, `@tesserix/web` primitives, paper/ink/moss tokens, hairline rules) rather than inventing a look.

Two behaviours are deliberate and easy to get wrong, both pinned by tests:

- **The redaction placeholder is never submitted.** The server returns `[redacted]` in place of a saved secret reference; sending it back would store that literal string, leaving a config that reads correctly on screen and cannot resolve a secret. An untouched field is omitted, and the placeholder is never prefilled into an editable input.
- **The result says what was checked.** "Connected — your provider answered and the client secret was read" and "the configuration looks complete, this environment cannot reach your provider" are different claims, and only one means a merchant can sign in.

A 403 renders the plan gate naming Pro, not a generic error. Destructive removal is behind an `alertdialog` that states the consequence: anyone who has only ever signed in through the provider will need a password reset.

## The pricing claim

Both surfaces advertised **`SSO (SAML / OIDC)`** on Pro. SAML is not implemented — both routes answer 501 and there is no SP — so half that claim was simply false. Now `SSO (OpenID Connect)`, with a comment at each site saying why.

## Test plan

- [x] `gofmt`, `go build`, `go vet`, full marketplace-api suite green
- [x] `apps/admin`: `tsc --noEmit` clean, **`next build` green**, 11 new tests
- [x] `apps/onboarding`: `tsc --noEmit` clean, **`next build` green**, 104 tests pass
- [x] `gitleaks` clean over the branch before pushing
- [x] Backend: Validate accepts the three fields a login needs, rejects a config with no `client_secret_ref`, treats `discovery_url` as optional
- [x] Test endpoint: builds the relying party and reports `checked: "idp"`; **invalidates before testing**; an unreachable IdP and a missing secret give *different* messages; neither leaks the issuer URL or the secret path into the browser; SAML is never a pass; no relying-party source reports `checked: "configuration"`
- [x] Client: the redaction placeholder is omitted on save, a blank field is omitted, a genuinely new reference is sent, optional fields are omitted rather than sent empty; 404 is null not an error; a 422 test result is returned rather than thrown
- [ ] `apps/admin` vitest: the same **2 pre-existing failures** in `appCredentials.test.ts`, verified earlier as failing on clean `main`. Unrelated; 1,200 other tests pass.
- [ ] A real IdP. Still no SSO tenants, so the full round trip is unexercised.

## What is still not true

A merchant can now configure OIDC, test it, and enable it. Nobody has done it against a live provider, and the client secret still has to be placed in OpenBao by us — the form collects the *path*, not the secret, and the copy says so.
