### PR TITLE
fix(pricing): the SAML claim that survived #839 (#838)

### DIFF
--- a/.planning/quick/260908-sr-sso-copy-remnant/PLAN.md
+++ b/.planning/quick/260908-sr-sso-copy-remnant/PLAN.md
@@ -1,0 +1,66 @@
+# The SAML claim that survived #839 (#838)
+
+#838 reports two things and **both are already fixed** on `main` as of #839
+(`7c560461`):
+
+- `apps/onboarding/components/marketing/Pricing.tsx:103` and
+  `apps/admin/lib/copy/pricing.ts:126` both now read `'SSO (OpenID Connect)'`.
+- A self-serve SSO config screen exists at
+  `apps/admin/app/(admin)/settings/sso/{page,SSOClient}.tsx`, and
+  `lib/copy/sso.ts:85` states plainly that SAML is unsupported.
+
+#838 was split out of #820 and filed from notes taken before #839 landed, so it
+describes the pre-#839 state. One surface was genuinely missed:
+
+```
+apps/onboarding/public/llms-full.txt:43
+  ... 100 webhook endpoints, SSO (SAML/OIDC), priority support ...
+```
+
+Served at `mark8ly.com/llms-full.txt` — the machine-readable pricing surface.
+So the corrected claim reaches humans reading the pricing page while the stale
+one still reaches every agent and crawler that reads `llms-full.txt`, which is
+the audience least able to notice the contradiction.
+
+## Why the guard is the actual fix
+
+`apps/onboarding/tests/unit/pricing-surfaces-truth.spec.ts` exists for exactly
+this failure: it was written for #564 after plan copy drifted across the same
+three surfaces, and it already reads all three, `llms-full.txt` included. It had
+no SAML assertion, so #839 could correct two surfaces and leave the third
+without anything going red.
+
+Editing line 43 alone fixes today's drift and leaves the mechanism that allowed
+it. The assertion is what stops the next one.
+
+## Tasks
+
+### 1. Guard the SAML claim across all three surfaces (RED first)
+- [ ] Add a test to `pricing-surfaces-truth.spec.ts` asserting no pricing
+      surface advertises SAML, and that each surface naming SSO names
+      **OpenID Connect** — the positive half catches the opposite drift, where
+      the bullet is deleted outright and Pro silently stops advertising the SSO
+      it really does have.
+- [ ] Use the existing `copyOnly()` helper on the two TypeScript surfaces. Both
+      carry a comment naming SAML in order to explain its removal; scanning raw
+      source would make documenting the fix trip the guard enforcing it.
+- **Done when** the new test fails on `llms-full.txt` and only on
+  `llms-full.txt`, naming the file and the line's claim.
+
+### 2. Correct llms-full.txt
+- [ ] `SSO (SAML/OIDC)` -> `SSO (OpenID Connect)`, matching the wording the
+      other two surfaces settled on in #839.
+- **Done when** `npm test -w @mark8ly/onboarding` is green.
+
+### 3. Fix the indentation #839 left in pricing.ts
+- [ ] The comment block at `apps/admin/lib/copy/pricing.ts:126-129` and the
+      bullet after it sit at the wrong indent inside the `features` array.
+      Cosmetic, same hunk, no behaviour.
+
+## Not in scope
+
+Whether to implement SAML at all. #838's second half asks that as a product
+question and the honest `501` plus the "contact us" note make the current state
+safe either way. Narrowing the last surface does not pre-empt the answer — if
+SAML is later built, all three surfaces and this guard change together, which is
+the point of having the guard.

--- a/apps/admin/lib/copy/pricing.ts
+++ b/apps/admin/lib/copy/pricing.ts
@@ -124,10 +124,10 @@ export const pricingCopy = {
         'Full read/write API',
         '100 webhook endpoints',
         // SAML is not implemented — both SSO routes answer 501 for it and
-      // there is no SP (mark8ly#820). Advertising it sold something
-      // that cannot be delivered; OIDC is real and configurable at
-      // Settings -> Single sign-on.
-      'SSO (OpenID Connect)',
+        // there is no SP (mark8ly#820). Advertising it sold something
+        // that cannot be delivered; OIDC is real and configurable at
+        // Settings -> Single sign-on.
+        'SSO (OpenID Connect)',
         'Priority support (4h response)',
         'Forever audit retention',
       ],

--- a/apps/onboarding/public/llms-full.txt
+++ b/apps/onboarding/public/llms-full.txt
@@ -40,7 +40,7 @@ Ninety days free to start. After that, three clear plans — no hidden fees, no 
 
 - **Starter — $15/month billed yearly, or $19/month billed monthly.** For merchants opening their first store. Up to 2 stores, unlimited products and orders, 15,000 campaign emails/month, full colour palette and announcement bar, your own domain, read-only API, 10 webhook endpoints.
 - **Studio — $39/month billed yearly, or $49/month billed monthly.** For stores finding their rhythm. Up to 5 stores, 50 images per product, 50,000 campaign emails/month, custom CSS and fonts, read-only API, 25 webhook endpoints, 12-month audit log.
-- **Pro — $99/month billed yearly, or $119/month billed monthly.** For mid-market brands at scale. Up to 10 stores, unlimited images, full read/write API, 100 webhook endpoints, SSO (SAML/OIDC), priority support with 4-hour response, forever audit retention.
+- **Pro — $99/month billed yearly, or $119/month billed monthly.** For mid-market brands at scale. Up to 10 stores, unlimited images, full read/write API, 100 webhook endpoints, SSO (OpenID Connect), priority support with 4-hour response, forever audit retention.
 
 **White-label App add-on** (Pro only): publish a branded iOS and Android app for your storefront. Billed annually and co-terminated with your Pro renewal.
 

--- a/apps/onboarding/tests/unit/pricing-surfaces-truth.spec.ts
+++ b/apps/onboarding/tests/unit/pricing-surfaces-truth.spec.ts
@@ -150,3 +150,46 @@ test("no pricing surface still sells custom code injection (#544)", () => {
     }
   }
 });
+
+/**
+ * #838. Pro was sold as `SSO (SAML / OIDC)` on all three surfaces. OIDC is
+ * real and self-serve since #839; SAML is not, and does not merely lack an
+ * implementation — `loginSAML` and its callback both answer **501**
+ * deliberately (`internal/handlers/public/sso_login.go:265,303`).
+ *
+ * #839 narrowed the two TypeScript surfaces to OpenID Connect and left
+ * `llms-full.txt` still advertising SAML. That is the worst surface to miss
+ * it on: it is the machine-readable pricing document, so the corrected claim
+ * reached humans while the stale one kept reaching every agent and crawler,
+ * the audience least placed to notice the contradiction.
+ *
+ * The positive half of this test matters as much as the negative one. Deleting
+ * the bullet outright would also pass a SAML check while quietly dropping a
+ * capability Pro genuinely has — understating is drift too, just in the
+ * direction nobody complains about.
+ */
+test("pricing surfaces sell the SSO protocol that works, and only that one (#838)", () => {
+  const surfaces: ReadonlyArray<[string, string]> = [
+    ["onboarding Pricing.tsx", copyOnly(read("apps/onboarding/components/marketing/Pricing.tsx"))],
+    ["admin lib/copy/pricing.ts", copyOnly(read("apps/admin/lib/copy/pricing.ts"))],
+    ["llms-full.txt", read("apps/onboarding/public/llms-full.txt")],
+  ];
+
+  for (const [name, src] of surfaces) {
+    expect(
+      src,
+      `${name} advertises SAML. Both SSO routes answer 501 for it by design ` +
+        `(#820, #838) and there is no SP, so this sells a protocol the product ` +
+        `refuses. Narrow it to OpenID Connect, which is real and configurable ` +
+        `at Settings -> Single sign-on.`,
+    ).not.toMatch(/SAML/i);
+
+    expect(
+      src,
+      `${name} mentions SSO without naming OpenID Connect. Pro really does ` +
+        `include self-serve OIDC (#839) — a bullet that says only "SSO", or no ` +
+        `bullet at all, understates the plan and leaves the next editor guessing ` +
+        `which protocols are meant. Name the one that works.`,
+    ).toMatch(/OpenID Connect/i);
+  }
+});


### PR DESCRIPTION
Closes part 1 of #838.

## What #838 actually reports

Both halves of #838 were **already fixed on `main`** by #839 (`7c560461`), which
landed after the issue's notes were taken:

- `apps/onboarding/components/marketing/Pricing.tsx:103` and
  `apps/admin/lib/copy/pricing.ts:126` both already read `'SSO (OpenID Connect)'`.
- A self-serve SSO config screen exists at `apps/admin/app/(admin)/settings/sso/`,
  and `lib/copy/sso.ts:85` states plainly that SAML is unsupported.

One surface was genuinely missed:

```
apps/onboarding/public/llms-full.txt:43
  ... 100 webhook endpoints, SSO (SAML/OIDC), priority support ...
```

That is served at `mark8ly.com/llms-full.txt` — the machine-readable pricing
document. So the corrected claim reached humans reading the pricing page while
the stale one kept reaching every agent and crawler, the audience least placed
to notice the contradiction.

## The guard is the actual fix

`apps/onboarding/tests/unit/pricing-surfaces-truth.spec.ts` exists for exactly
this failure — written for #564 after plan copy drifted across the same three
surfaces, and it already reads all three including `llms-full.txt`. It had no
SAML assertion, so #839 could correct two surfaces and leave the third with
nothing going red.

Editing line 43 alone would fix today's drift and leave the mechanism that
allowed it, so this adds the assertion first.

The test has a **positive** half as well as a negative one: each surface must
also *name* OpenID Connect. Deleting the bullet outright would pass a SAML check
while quietly dropping a capability Pro genuinely has — understating is drift
too, just in the direction nobody complains about.

## Verification

- New test fails on `llms-full.txt` **and only** on `llms-full.txt` before the
  fix, confirming the other two surfaces already pass both halves.
- Mutation-tested both halves, each mutation confirmed applied before running:
  - reintroducing `'SSO (SAML / OIDC)'` in `apps/admin/lib/copy/pricing.ts` →
    caught by the negative half
  - replacing the bullet with `'Priority onboarding'` in `Pricing.tsx` →
    caught by the positive half
- `npm test -w @mark8ly/onboarding` — 105 passed.
- `tsc --noEmit` clean in `apps/admin`.
- The `apps/admin` change is whitespace-only (`git diff -w` is empty): it
  reindents the comment block and bullet #839 left at the wrong depth inside the
  `features` array. `apps/admin` pricing unit tests pass 24/24.

## Not in scope

Whether to implement SAML at all — #838's second half asks that as a product
question, and the honest `501` plus the "contact us" note make the current state
safe either way. Narrowing the last surface does not pre-empt the answer: if
SAML is later built, all three surfaces and this guard change together, which is
the point of having the guard.

I've left #838 open for that decision and commented there with what remains.