### PR TITLE
fix(backfill): the trial backfill read a column the stores projection never had (#827)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ test-int: ## Run integration tests against the running `make dev` stack
 	  go test -tags=integration -p 1 \
 	    . \
 	    ./cmd/backfill-email/... \
+	    ./cmd/backfill-trial-start/... \
 	    ./cmd/carrier-secrets-backfill/... \
 	    ./internal/apikeys/... \
 	    ./internal/arbitrage/... \

--- a/services/marketplace-api/cmd/backfill-trial-start/main.go
+++ b/services/marketplace-api/cmd/backfill-trial-start/main.go
@@ -92,15 +92,22 @@ func main() {
 // importing the stores model so the backfill cannot start depending on
 // unrelated columns.
 type storeRow struct {
-	ID        string
-	TenantID  string
-	Currency  string
-	CreatedAt time.Time
+	ID       string
+	TenantID string
+	Currency string
+	// CreatedAt is NULL for a store mirrored before migration 136, which
+	// added the column. Such a row cannot be dated and is SKIPPED rather
+	// than guessed at — see run().
+	CreatedAt *time.Time
 }
 
 type runStats struct {
 	Scanned int
 	Created int
+	// Undated counts stores whose projection has no created_at — mirrored
+	// before migration 136 and not re-synced since. They are skipped, not
+	// guessed at, and reported so the operator knows the run was partial.
+	Undated int
 	// AlreadyExpired counts rows whose backfilled trial end is in the PAST,
 	// because the store is older than the trial length. Reported separately
 	// because it is the number a human needs before running with -apply: it
@@ -136,7 +143,21 @@ func run(ctx context.Context, conn *gorm.DB, batchSize int, apply bool, now time
 			lastID = r.ID
 			stats.Scanned++
 
-			trialEnd, expired := backfilledTrialEnd(r.CreatedAt, now)
+			// No creation date, no trial date. Using synced_at instead would
+			// date the trial from the last time this projection copied the
+			// row — i.e. from a store-settings edit — and using now() would
+			// hand a year-old store a fresh 90 days. Both are worse than
+			// saying so and moving on; platform-api re-sends created_at on
+			// its next upsert, and a later run picks the row up.
+			if r.CreatedAt == nil {
+				stats.Undated++
+				log.Warn("backfill-trial-start: store has no created_at — skipping",
+					"store_id", r.ID, "tenant_id", r.TenantID,
+					"hint", "re-sync the store from platform-api, then re-run")
+				continue
+			}
+
+			trialEnd, expired := backfilledTrialEnd(*r.CreatedAt, now)
 			if expired {
 				stats.AlreadyExpired++
 			}

--- a/services/marketplace-api/cmd/backfill-trial-start/query_integration_test.go
+++ b/services/marketplace-api/cmd/backfill-trial-start/query_integration_test.go
@@ -1,0 +1,129 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// This test exists because the first version of this command could not run.
+//
+// Its scan selected s.created_at from the stores projection, which had no such
+// column — the projection carried only synced_at. Every unit test passed, the
+// build was green, and the command would have failed on its first real
+// invocation with `column s.created_at does not exist`. Nothing in the suite
+// executed the query against a real schema, so nothing could have known.
+//
+// The dry-run default made it worse rather than safer: the failure was waiting
+// behind an operator flag, so even a cautious first run would have hit it.
+//
+// What this pins is narrow and deliberate: that the SQL this command actually
+// issues matches the migrated schema. It is the assertion whose absence let a
+// broken command merge.
+func TestRun_QueryMatchesTheMigratedSchema(t *testing.T) {
+	db := testdb.NewTx(t)
+	log := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+
+	// Dry run: proves the scan executes and reads its columns without writing
+	// anything. A schema mismatch fails here, which is the whole point.
+	stats, err := run(context.Background(), db, 100, false, time.Now().UTC(), log)
+	require.NoError(t, err, "the backfill query does not match the schema")
+	require.Zero(t, stats.Created, "a dry run wrote rows")
+}
+
+// A store with a known creation date is picked up and dated from it — not from
+// the moment of the backfill, which would hand a year-old store a fresh trial.
+func TestRun_DatesTheTrialFromTheStore(t *testing.T) {
+	db := testdb.NewTx(t)
+	log := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+
+	storeID := uuid.New()
+	tenantID := uuid.New()
+	created := time.Now().UTC().AddDate(0, 0, -200)
+	seedStore(t, db, storeID, tenantID, &created)
+
+	now := time.Now().UTC()
+	stats, err := run(context.Background(), db, 100, true, now, log)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, stats.Created, 1)
+
+	var trialEndsAt time.Time
+	require.NoError(t, db.Raw(
+		`SELECT trial_ends_at FROM store_subscriptions WHERE store_id = ?`, storeID,
+	).Scan(&trialEndsAt).Error)
+
+	want, expired := backfilledTrialEnd(created, now)
+	require.True(t, expired, "a 200-day-old store should backfill as already expired")
+	require.WithinDuration(t, want, trialEndsAt, time.Second,
+		"the trial was not dated from the store's own creation")
+}
+
+// A row mirrored before migration 136 has no created_at. It must be skipped
+// and COUNTED, not guessed at: synced_at would date the trial from the last
+// settings edit, and now() would grant a fresh 90 days to an old store.
+func TestRun_SkipsAndCountsAnUndatedStore(t *testing.T) {
+	db := testdb.NewTx(t)
+	log := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+
+	storeID := uuid.New()
+	seedStore(t, db, storeID, uuid.New(), nil)
+
+	stats, err := run(context.Background(), db, 100, true, time.Now().UTC(), log)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, stats.Undated, 1, "an undated store was not reported")
+
+	var n int64
+	require.NoError(t, db.Raw(
+		`SELECT count(*) FROM store_subscriptions WHERE store_id = ?`, storeID,
+	).Scan(&n).Error)
+	require.Zero(t, n, "a store with no creation date was given a trial anyway")
+}
+
+// Re-running must not double-insert. The command is an operator tool and will
+// be run twice by someone who is unsure whether the first run took.
+func TestRun_IsIdempotent(t *testing.T) {
+	db := testdb.NewTx(t)
+	log := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+
+	storeID := uuid.New()
+	created := time.Now().UTC().AddDate(0, 0, -10)
+	seedStore(t, db, storeID, uuid.New(), &created)
+
+	now := time.Now().UTC()
+	_, err := run(context.Background(), db, 100, true, now, log)
+	require.NoError(t, err)
+	second, err := run(context.Background(), db, 100, true, now, log)
+	require.NoError(t, err)
+	require.Zero(t, second.Created, "a second run inserted again")
+
+	var n int64
+	require.NoError(t, db.Raw(
+		`SELECT count(*) FROM store_subscriptions WHERE store_id = ?`, storeID,
+	).Scan(&n).Error)
+	require.EqualValues(t, 1, n)
+}
+
+func seedStore(t *testing.T, db interface {
+	Exec(string, ...any) *gorm.DB
+}, storeID, tenantID uuid.UUID, createdAt *time.Time) {
+	t.Helper()
+	require.NoError(t, db.Exec(`
+		INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, created_at, synced_at)
+		VALUES (?, ?, ?, ?, 'AU', 'AUD', 'Australia/Sydney', 'active', ?, now())`,
+		storeID, tenantID, "s-"+storeID.String()[:8], "Test Store", createdAt,
+	).Error)
+}
+
+type testWriter struct{ t *testing.T }
+
+func (w testWriter) Write(p []byte) (int, error) { w.t.Log(string(p)); return len(p), nil }

--- a/services/marketplace-api/cmd/backfill-trial-start/query_integration_test.go
+++ b/services/marketplace-api/cmd/backfill-trial-start/query_integration_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -117,10 +118,16 @@ func seedStore(t *testing.T, db interface {
 	Exec(string, ...any) *gorm.DB
 }, storeID, tenantID uuid.UUID, createdAt *time.Time) {
 	t.Helper()
+	// storefront_customer_portal_secret is NOT NULL and generated server-side
+	// by the upsert handler, so a hand-rolled INSERT has to supply one. Any
+	// 64 hex characters satisfy the column; nothing here reads it back.
 	require.NoError(t, db.Exec(`
-		INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code, timezone, status, created_at, synced_at)
-		VALUES (?, ?, ?, ?, 'AU', 'AUD', 'Australia/Sydney', 'active', ?, now())`,
-		storeID, tenantID, "s-"+storeID.String()[:8], "Test Store", createdAt,
+		INSERT INTO stores (id, tenant_id, slug, name, country_code, currency_code,
+		                    timezone, status, storefront_customer_portal_secret,
+		                    created_at, synced_at)
+		VALUES (?, ?, ?, ?, 'AU', 'AUD', 'Australia/Sydney', 'active', ?, ?, now())`,
+		storeID, tenantID, "s-"+storeID.String()[:8], "Test Store",
+		strings.Repeat("0", 64), createdAt,
 	).Error)
 }
 

--- a/services/marketplace-api/internal/stores/internal_handler.go
+++ b/services/marketplace-api/internal/stores/internal_handler.go
@@ -45,6 +45,11 @@ type upsertStoreRequest struct {
 	CurrencyCode string `json:"currency_code" binding:"required"`
 	Timezone     string `json:"timezone"      binding:"required"`
 	Status       string `json:"status"`
+	// CreatedAt is when platform_api created the store. Optional, because a
+	// caller running an older build does not send it — and an absent value
+	// must leave the column alone rather than overwrite a known date with a
+	// zero one (#827).
+	CreatedAt *time.Time `json:"created_at"`
 }
 
 func (h *InternalHandler) upsert(c *gin.Context) {
@@ -80,6 +85,7 @@ func (h *InternalHandler) upsert(c *gin.Context) {
 		CurrencyCode:                   req.CurrencyCode,
 		Timezone:                       req.Timezone,
 		Status:                         status,
+		CreatedAt:                      req.CreatedAt,
 		SyncedAt:                       time.Now().UTC(),
 		StorefrontCustomerPortalSecret: secret,
 	}

--- a/services/marketplace-api/internal/stores/models.go
+++ b/services/marketplace-api/internal/stores/models.go
@@ -10,15 +10,24 @@ import "time"
 // exists so StoreMiddleware can look up store metadata without an HTTP
 // round-trip on every admin request (db-f1-micro 5-conn pool).
 type Store struct {
-	ID           string    `gorm:"primaryKey;column:id;type:uuid"                          json:"id"`
-	TenantID     string    `gorm:"column:tenant_id;type:uuid;not null"                     json:"tenant_id"`
-	Slug         string    `gorm:"column:slug;type:varchar(63);not null;uniqueIndex"       json:"slug"`
-	Name         string    `gorm:"column:name;type:varchar(200);not null"                  json:"name"`
-	CountryCode  string    `gorm:"column:country_code;type:char(2);not null"               json:"country_code"`
-	CurrencyCode string    `gorm:"column:currency_code;type:char(3);not null"              json:"currency_code"`
-	Timezone     string    `gorm:"column:timezone;type:varchar(64);not null"               json:"timezone"`
-	Status       string    `gorm:"column:status;type:varchar(20);not null"                 json:"status"`
-	SyncedAt     time.Time `gorm:"column:synced_at;not null;default:now()"                 json:"synced_at"`
+	ID           string `gorm:"primaryKey;column:id;type:uuid"                          json:"id"`
+	TenantID     string `gorm:"column:tenant_id;type:uuid;not null"                     json:"tenant_id"`
+	Slug         string `gorm:"column:slug;type:varchar(63);not null;uniqueIndex"       json:"slug"`
+	Name         string `gorm:"column:name;type:varchar(200);not null"                  json:"name"`
+	CountryCode  string `gorm:"column:country_code;type:char(2);not null"               json:"country_code"`
+	CurrencyCode string `gorm:"column:currency_code;type:char(3);not null"              json:"currency_code"`
+	Timezone     string `gorm:"column:timezone;type:varchar(64);not null"               json:"timezone"`
+	Status       string `gorm:"column:status;type:varchar(20);not null"                 json:"status"`
+	// CreatedAt is when the store was created in platform_api, mirrored so
+	// this service can date things from it — a backfilled trial, above all
+	// (#827). NULL for rows mirrored before migration 136, which is the
+	// honest answer: those rows never carried it.
+	//
+	// NOT SyncedAt. That is when this projection last copied the row and
+	// moves on every upsert, so using it would date a trial from the last
+	// time a merchant edited their store settings.
+	CreatedAt *time.Time `gorm:"column:created_at"                                       json:"created_at,omitempty"`
+	SyncedAt  time.Time  `gorm:"column:synced_at;not null;default:now()"                 json:"synced_at"`
 	// StorefrontCustomerPortalSecret is the per-store HMAC key for customer
 	// portal tokens (§15.4, migration 058). Generated at migration time;
 	// lazily regenerated if empty via customerportal.GenerateSecret().

--- a/services/marketplace-api/internal/stores/repository.go
+++ b/services/marketplace-api/internal/stores/repository.go
@@ -162,14 +162,37 @@ func (r *gormRepository) GetProductsWatermark(ctx context.Context, storeID strin
 // Upsert writes the row keyed on primary key id. On conflict it replaces
 // every non-pk column and bumps synced_at. Caller is responsible for
 // setting SyncedAt to time.Now() before calling.
+// storeUpsertAssignments is the ON CONFLICT SET list for the projection.
+//
+// Every column is taken from the incoming row EXCEPT created_at, which is
+// COALESCEd against the existing value. That asymmetry is deliberate (#827):
+//
+//   - A caller running a build older than migration 136 sends no created_at.
+//     A plain assignment would overwrite a date this projection already knew
+//     with NULL, and the trial backfill would then have nothing to date from.
+//   - A row mirrored BEFORE 136 holds NULL and must be able to learn its real
+//     creation time from the next upsert.
+//
+// COALESCE(excluded, existing) is the only rule that satisfies both: it fills
+// a gap and never creates one. platform_api is the source of truth and a
+// store's creation time does not change, so preferring the incoming value
+// when present loses nothing.
+func storeUpsertAssignments() clause.Set {
+	sets := clause.AssignmentColumns([]string{
+		"tenant_id", "slug", "name", "country_code",
+		"currency_code", "timezone", "status", "synced_at",
+	})
+	return append(sets, clause.Assignment{
+		Column: clause.Column{Name: "created_at"},
+		Value:  gorm.Expr("COALESCE(EXCLUDED.created_at, stores.created_at)"),
+	})
+}
+
 func (r *gormRepository) Upsert(ctx context.Context, s *Store) error {
 	if err := r.db.WithContext(ctx).
 		Clauses(clause.OnConflict{
-			Columns: []clause.Column{{Name: "id"}},
-			DoUpdates: clause.AssignmentColumns([]string{
-				"tenant_id", "slug", "name", "country_code",
-				"currency_code", "timezone", "status", "synced_at",
-			}),
+			Columns:   []clause.Column{{Name: "id"}},
+			DoUpdates: storeUpsertAssignments(),
 		}).
 		Create(s).Error; err != nil {
 		return fmt.Errorf("stores: upsert: %w", err)

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 135
+const ExpectedSchemaVersion uint = 136

--- a/services/marketplace-api/migrations/000136_stores_created_at.down.sql
+++ b/services/marketplace-api/migrations/000136_stores_created_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE stores DROP COLUMN IF EXISTS created_at;

--- a/services/marketplace-api/migrations/000136_stores_created_at.up.sql
+++ b/services/marketplace-api/migrations/000136_stores_created_at.up.sql
@@ -1,0 +1,18 @@
+-- 000136_stores_created_at.up.sql
+--
+-- The stores projection mirrors platform_api.stores but never carried WHEN a
+-- store was created, only synced_at — the time this service last copied the
+-- row, which moves on every upsert.
+--
+-- That gap is not cosmetic. #827 dates a backfilled trial from the store's
+-- creation, and cmd/backfill-trial-start selected s.created_at from a table
+-- that has no such column: it would have failed on its first real run.
+--
+-- Nullable on purpose. Rows mirrored before this column existed genuinely do
+-- not know their creation time, and NULL says so. A DEFAULT now() would have
+-- stamped every existing row with the migration's own timestamp — which reads
+-- as a fact and would date those merchants' trials from a schema change.
+ALTER TABLE stores ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN stores.created_at IS
+  'When the store was created in platform_api. NULL for rows mirrored before migration 136. Distinct from synced_at, which is when this projection last copied the row.';

--- a/services/platform-api/internal/marketplaceapi/vendor_client.go
+++ b/services/platform-api/internal/marketplaceapi/vendor_client.go
@@ -139,6 +139,11 @@ type Store struct {
 	CurrencyCode string `json:"currency_code"`
 	Timezone     string `json:"timezone"`
 	Status       string `json:"status"`
+	// CreatedAt is when this store row was created here. Mirrored because
+	// marketplace-api dates a backfilled trial from it and had no way to know
+	// it (mark8ly#827) — its projection carried only synced_at, which moves
+	// on every upsert.
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 }
 
 // EnsureSubscription gives a newly created store its subscription row, and

--- a/services/platform-api/internal/onboarding/service.go
+++ b/services/platform-api/internal/onboarding/service.go
@@ -477,6 +477,7 @@ func (s *Service) Complete(ctx context.Context, req CompleteRequest) (*CompleteR
 			CurrencyCode: st.CurrencyCode,
 			Timezone:     st.Timezone,
 			Status:       string(store.StatusActive),
+			CreatedAt:    &st.CreatedAt,
 		}); sErr != nil {
 			log.Printf("onboarding.Complete: ensure self-store for tenant %s store %s: %v", t.ID, st.ID, sErr)
 		}


### PR DESCRIPTION
`cmd/backfill-trial-start`, shipped in #828, **could not run**.

Its scan selected `s.created_at` from the `stores` projection, and that column does not exist. The projection mirrors slug, name, country, currency, timezone, status and `synced_at` — never when the store was created. The command would have failed on its first real invocation with `column s.created_at does not exist`.

Found by measuring production before running it, not by a test. Every unit test passed and the build was green, because nothing in the suite ever executed the query against a real schema. The dry-run default made it worse rather than safer: the failure sat behind an operator flag, so even a cautious first run would have hit it.

## Why the column has to exist

`synced_at` is not a substitute. It is when this projection last copied the row and moves on every upsert, so dating a trial from it would date it from the last time a merchant edited their store settings. `now()` is worse — it hands a year-old store a fresh 90 days, the exact outcome the backfill was written to avoid.

The creation time lives in `platform_api.stores`, a different database this service cannot join to. So it has to travel: platform-api now sends `created_at` with the store mirror, and migration 136 gives the projection somewhere to put it.

**Nullable, with no default.** Rows mirrored before 136 genuinely do not know their creation time, and NULL says so. `DEFAULT now()` would have stamped every existing row with the migration's own timestamp — which reads as a fact, and would date those merchants' trials from a schema change.

**The upsert COALESCEs it**, and that asymmetry is the point: a caller on an older build sends nothing, and a plain assignment would overwrite a date the projection already knew with NULL. `COALESCE(EXCLUDED.created_at, stores.created_at)` fills a gap and never creates one.

**An undated store is skipped and counted**, not guessed at. The run reports `Undated` so an operator knows it was partial and can re-sync those stores rather than believing the backfill covered everything.

## The test that was missing

`TestRun_QueryMatchesTheMigratedSchema` executes the command's real query against a migrated Postgres. It is the assertion whose absence let a broken command merge, and it fails loudly on any future column drift.

Three more integration tests cover the behaviour that matters: the trial is dated from the store and not from the backfill, an undated store gets no trial, and a second run does not insert again.

## Production state, measured

4 stores, 0 subscriptions — so all four currently see the error panel #832 introduced when it retired the "Set up billing" CTA.

| store | created | age | trial would end | |
|---|---|---|---|---|
| the-bondi-store | 2026-04-29 | 132d | 2026-07-28 | already expired |
| thefacadefactory | 2026-05-29 | 102d | 2026-08-27 | already expired |
| demo-store | 2026-07-31 | 39d | 2026-10-29 | still running |
| mumbai-spice-co | 2026-09-05 | 3d | 2026-12-04 | still running |

That settles the decision #827 deferred: two stores backfill as already-expired, and both are team/test stores from before there were any merchants. Nobody is billed and nothing is taken away — an expired trial is the truthful state for a store created 132 days ago.

**After this deploys, those four rows still hold `created_at = NULL`**, because platform-api only re-sends a store on onboarding completion or a settings edit. They need one re-sync (or a small direct update from `platform_api.stores`, which sits in the same cluster) before the backfill has anything to date from. That is an operator step, not a code change, and it is the last thing standing between #827 and done.

## Test plan

- [x] `gofmt`, `go build`, `go vet ./...` **and** `go vet -tags integration ./...` clean in both services
- [x] Full marketplace-api and platform-api suites green
- [x] `ExpectedSchemaVersion` bumped to 136 — its guard test caught the omission
- [x] The new package added to `make test-int` — `TestEveryIntegrationPackageIsInTheTestIntTarget` caught that too, which is precisely the guard that exists because four defects once survived in unlisted packages
- [x] `gitleaks` clean over the branch
- [ ] **The integration tests have not been run locally.** The LAN Postgres at the documented DSN is unreachable from this machine right now (`dial tcp 192.168.1.110:5432: operation timed out`), so they will execute for the first time in CI. Given the whole point of this PR is a query that was never run against a real schema, that is worth stating plainly rather than leaving to be assumed.
